### PR TITLE
fix(sentinel)+feat(freshness): ARCH-9 heartbeat preference + UUID ingestion canary

### DIFF
--- a/apps/evaluator/nlm_deep_research/freshness_monitor.py
+++ b/apps/evaluator/nlm_deep_research/freshness_monitor.py
@@ -397,7 +397,177 @@ def get_status() -> dict[str, Any]:
         "scan_count": state.get("scan_count", 0),
         "remediations_triggered": state.get("remediations_triggered", 0),
         "changes_detected": state.get("changes_detected", {}),
+        "ingestion_verifications": state.get("ingestion_verifications", {}),
     }
+
+
+# ── Ingestion verification (Sprint 1 — UUID injection test) ──────────────────
+#
+# Purpose: prove that a notebook is alive end-to-end (upload + index + query).
+# Gateway mtime lies; source count can grow without query working; NLM chat
+# can be silently 5xx. The only honest signal is: upload a string with an
+# unambiguous UUID, wait for indexing, then query for that UUID. If the
+# answer contains the UUID, ingestion path is green. If not, the notebook is
+# STALE and the oracle gate must refuse to serve it (see S1.3 in plan v2).
+
+
+def verify_ingestion_uuid(
+    notebook_id: str,
+    *,
+    poll_seconds: float = 40.0,
+    query_timeout_s: int = 90,
+    cleanup: bool = True,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Inject a UUID-tagged text source, query for it, report whether found.
+
+    Args:
+        notebook_id: NotebookLM UUID.
+        poll_seconds: How long to wait after upload before querying (NLM
+            indexing typically completes within 20-60s).
+        query_timeout_s: CLI timeout passed to ``nlm notebook query``.
+        cleanup: Delete the test source after the check. False is useful
+            when the caller wants to retain audit trail.
+        dry_run: Skip actual CLI calls. Return a stub payload.
+
+    Returns:
+        Dict with keys: ``status`` (ok|stale|error), ``uuid``,
+        ``source_id`` (if upload succeeded), ``query_answer_excerpt``,
+        ``age_seconds``, ``error`` (if any).
+
+    The returned payload is also persisted to ``freshness_monitor_state.json``
+    under ``ingestion_verifications[notebook_id]`` so operators can inspect
+    historical results across runs.
+    """
+    import uuid as _uuid
+
+    marker = _uuid.uuid4().hex[:12]
+    canary = (
+        f"INGESTION-CANARY-{marker}\n\n"
+        f"Injected by freshness_monitor.verify_ingestion_uuid at "
+        f"{_now_iso()} to verify end-to-end ingestion of notebook "
+        f"{notebook_id}. Query marker: {marker}."
+    )
+    result: dict[str, Any] = {
+        "notebook_id": notebook_id,
+        "uuid": marker,
+        "started_at": _now_iso(),
+        "status": "error",
+        "source_id": None,
+        "query_answer_excerpt": None,
+        "age_seconds": None,
+        "error": None,
+    }
+
+    if dry_run:
+        result["status"] = "ok"
+        result["error"] = "dry_run"
+        return result
+
+    started = time.monotonic()
+
+    # Step 1: upload canary source via `nlm source add --text`.
+    try:
+        add_proc = subprocess.run(
+            ["nlm", "source", "add", notebook_id,
+             "--text", canary,
+             "--title", f"ingestion-canary-{marker}",
+             "--wait"],
+            capture_output=True, text=True, timeout=180,
+        )
+        if add_proc.returncode != 0:
+            result["error"] = f"source add failed: {add_proc.stderr.strip()[:200]}"
+            _persist_verification(notebook_id, result)
+            return result
+
+        # Extract source_id from output. CLI prints "Source ID: <id>".
+        stdout = add_proc.stdout
+        source_id = None
+        for line in stdout.splitlines():
+            if "source" in line.lower() and "id" in line.lower() and ":" in line:
+                source_id = line.split(":", 1)[1].strip()
+                break
+        result["source_id"] = source_id
+    except subprocess.TimeoutExpired:
+        result["error"] = "source add timed out after 180s"
+        _persist_verification(notebook_id, result)
+        return result
+    except Exception as exc:
+        result["error"] = f"source add exception: {exc}"
+        _persist_verification(notebook_id, result)
+        return result
+
+    # Step 2: wait for indexing. `--wait` should already handle this, but
+    # NLM sometimes reports "ready" before full retrieval index is built.
+    time.sleep(poll_seconds)
+
+    # Step 3: query and look for the marker in the answer.
+    try:
+        query_proc = subprocess.run(
+            ["nlm", "notebook", "query", notebook_id,
+             f"Inside the canary source is a 12-character hex marker. "
+             f"Repeat that marker back to me exactly as it appears after "
+             f"'Query marker:'.",
+             "--timeout", str(query_timeout_s)],
+            capture_output=True, text=True, timeout=query_timeout_s + 20,
+        )
+        stdout = query_proc.stdout or ""
+        if query_proc.returncode != 0:
+            result["error"] = f"query failed: {query_proc.stderr.strip()[:200]}"
+            _persist_verification(notebook_id, result)
+            return result
+
+        result["query_answer_excerpt"] = stdout[:800]
+        if marker in stdout:
+            result["status"] = "ok"
+        else:
+            result["status"] = "stale"
+            result["error"] = "marker not found in answer (indexing incomplete or retrieval broken)"
+    except subprocess.TimeoutExpired:
+        result["error"] = f"query timed out after {query_timeout_s}s"
+        _persist_verification(notebook_id, result)
+        return result
+    except Exception as exc:
+        result["error"] = f"query exception: {exc}"
+        _persist_verification(notebook_id, result)
+        return result
+    finally:
+        result["age_seconds"] = round(time.monotonic() - started, 1)
+
+    # Step 4: cleanup (best-effort, do not fail the test if delete fails).
+    if cleanup and result.get("source_id"):
+        try:
+            subprocess.run(
+                ["nlm", "source", "delete", notebook_id, result["source_id"]],
+                capture_output=True, text=True, timeout=60,
+            )
+        except Exception as exc:
+            logger.warning("canary cleanup failed for %s: %s", result["source_id"], exc)
+
+    _persist_verification(notebook_id, result)
+    return result
+
+
+def _persist_verification(notebook_id: str, result: dict[str, Any]) -> None:
+    """Store verification result in freshness_monitor_state.json.
+
+    Keeps the most recent result per notebook_id and appends to a rolling
+    history (max 20 entries per notebook) for trend analysis.
+    """
+    state = _load_state()
+    verifications = state.setdefault("ingestion_verifications", {})
+    entry = verifications.setdefault(notebook_id, {"last": None, "history": []})
+    entry["last"] = result
+    history = entry["history"]
+    history.append({
+        "ts": result.get("started_at"),
+        "status": result.get("status"),
+        "uuid": result.get("uuid"),
+        "age_seconds": result.get("age_seconds"),
+        "error": result.get("error"),
+    })
+    entry["history"] = history[-20:]  # trim rolling window
+    _save_state(state)
 
 
 # ── CLI ───────────────────────────────────────────────────────────────────────
@@ -417,8 +587,14 @@ def main() -> None:
                        help="Trigger NLM research for STALE/GAP topics from coverage matrix")
     group.add_argument("--status", action="store_true",
                        help="Show freshness monitor state")
+    group.add_argument(
+        "--verify-ingestion", metavar="NOTEBOOK_ID",
+        help="Inject UUID canary, query, check ingestion alive (Sprint 1 S1.2)",
+    )
     parser.add_argument("--dry-run", action="store_true",
                         help="Preview only, do not query Gemini or trigger NLM research")
+    parser.add_argument("--no-cleanup", action="store_true",
+                        help="(with --verify-ingestion) keep canary source on NB after check")
 
     args = parser.parse_args()
 
@@ -453,6 +629,26 @@ def main() -> None:
         if result["errors"]:
             print(f"  Errors: {result['errors']}")
         sys.exit(0 if result["status"] in ("ok", "partial", "skipped") else 1)
+
+    elif args.verify_ingestion:
+        result = verify_ingestion_uuid(
+            args.verify_ingestion,
+            dry_run=args.dry_run,
+            cleanup=not args.no_cleanup,
+        )
+        status = result.get("status", "error")
+        print(f"\nIngestion verification: {status.upper()}")
+        print(f"  Notebook:  {result['notebook_id']}")
+        print(f"  UUID:      {result['uuid']}")
+        print(f"  Age:       {result.get('age_seconds')}s")
+        if result.get("source_id"):
+            print(f"  Source ID: {result['source_id']}")
+        if result.get("error"):
+            print(f"  Error:     {result['error']}")
+        if result.get("query_answer_excerpt"):
+            excerpt = result["query_answer_excerpt"].replace("\n", " ")
+            print(f"  Answer:    {excerpt[:200]}...")
+        sys.exit(0 if status == "ok" else 1)
 
 
 if __name__ == "__main__":

--- a/apps/evaluator/nlm_deep_research/scripts/run_nb10_pipeline.sh
+++ b/apps/evaluator/nlm_deep_research/scripts/run_nb10_pipeline.sh
@@ -47,6 +47,10 @@ EXIT_CODE=${PIPESTATUS[0]}
 
 if [ $EXIT_CODE -eq 0 ]; then
     echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [DONE] NB-10 pipeline completed successfully" >> "$LOG_FILE"
+    # ARCH-9 heartbeat — writes heartbeat_nb10_pipeline.json so sentinel reads
+    # truthful success signal (not stale gateway projection). See T16 fix.
+    PYTHONPATH=. "$PYTHON" -m apps.evaluator.nlm_deep_research.heartbeat_monitor \
+        --record "nb10_pipeline" 2>/dev/null || true
 else
     echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [FAIL] NB-10 pipeline failed (exit $EXIT_CODE)" >> "$LOG_FILE"
     if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_OWNER_CHAT_ID:-}" ]; then

--- a/apps/evaluator/nlm_deep_research/scripts/run_nb3_pipeline.sh
+++ b/apps/evaluator/nlm_deep_research/scripts/run_nb3_pipeline.sh
@@ -47,6 +47,10 @@ EXIT_CODE=${PIPESTATUS[0]}
 
 if [ $EXIT_CODE -eq 0 ]; then
     echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [DONE] NB-3 pipeline completed successfully" >>"$LOG_FILE"
+    # ARCH-9 heartbeat — writes heartbeat_nb3_pipeline.json so sentinel reads
+    # truthful success signal (not stale gateway projection). See T16 fix.
+    PYTHONPATH=. "$PYTHON" -m apps.evaluator.nlm_deep_research.heartbeat_monitor \
+        --record "nb3_pipeline" 2>/dev/null || true
 else
     echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [FAIL] NB-3 pipeline failed (exit $EXIT_CODE)" >>"$LOG_FILE"
     if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_OWNER_CHAT_ID:-}" ]; then

--- a/apps/evaluator/nlm_deep_research/scripts/run_nb4_pipeline.sh
+++ b/apps/evaluator/nlm_deep_research/scripts/run_nb4_pipeline.sh
@@ -47,6 +47,10 @@ EXIT_CODE=${PIPESTATUS[0]}
 
 if [ $EXIT_CODE -eq 0 ]; then
     echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [DONE] NB-4 pipeline completed successfully" >> "$LOG_FILE"
+    # ARCH-9 heartbeat — writes heartbeat_nb4_pipeline.json so sentinel reads
+    # truthful success signal (not stale gateway projection). See T16 fix.
+    PYTHONPATH=. "$PYTHON" -m apps.evaluator.nlm_deep_research.heartbeat_monitor \
+        --record "nb4_pipeline" 2>/dev/null || true
 else
     echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [FAIL] NB-4 pipeline failed (exit $EXIT_CODE)" >> "$LOG_FILE"
     # Telegram alert on failure

--- a/apps/evaluator/nlm_deep_research/scripts/run_nb5_pipeline.sh
+++ b/apps/evaluator/nlm_deep_research/scripts/run_nb5_pipeline.sh
@@ -47,6 +47,10 @@ EXIT_CODE=${PIPESTATUS[0]}
 
 if [ $EXIT_CODE -eq 0 ]; then
     echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [DONE] NB-5 pipeline completed successfully" >> "$LOG_FILE"
+    # ARCH-9 heartbeat — writes heartbeat_nb5_pipeline.json so sentinel reads
+    # truthful success signal (not stale gateway projection). See T16 fix.
+    PYTHONPATH=. "$PYTHON" -m apps.evaluator.nlm_deep_research.heartbeat_monitor \
+        --record "nb5_pipeline" 2>/dev/null || true
 else
     echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [FAIL] NB-5 pipeline failed (exit $EXIT_CODE)" >> "$LOG_FILE"
     if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_OWNER_CHAT_ID:-}" ]; then

--- a/apps/evaluator/nlm_deep_research/scripts/run_nb6_pipeline.sh
+++ b/apps/evaluator/nlm_deep_research/scripts/run_nb6_pipeline.sh
@@ -47,6 +47,10 @@ EXIT_CODE=${PIPESTATUS[0]}
 
 if [ $EXIT_CODE -eq 0 ]; then
     echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [DONE] NB-6 pipeline completed successfully" >> "$LOG_FILE"
+    # ARCH-9 heartbeat — writes heartbeat_nb6_pipeline.json so sentinel reads
+    # truthful success signal (not stale gateway projection). See T16 fix.
+    PYTHONPATH=. "$PYTHON" -m apps.evaluator.nlm_deep_research.heartbeat_monitor \
+        --record "nb6_pipeline" 2>/dev/null || true
 else
     echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [FAIL] NB-6 pipeline failed (exit $EXIT_CODE)" >> "$LOG_FILE"
     # Telegram alert on failure

--- a/apps/evaluator/nlm_deep_research/scripts/run_nb7_pipeline.sh
+++ b/apps/evaluator/nlm_deep_research/scripts/run_nb7_pipeline.sh
@@ -47,6 +47,10 @@ EXIT_CODE=${PIPESTATUS[0]}
 
 if [ $EXIT_CODE -eq 0 ]; then
     echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [DONE] NB-7 pipeline completed successfully" >> "$LOG_FILE"
+    # ARCH-9 heartbeat — writes heartbeat_nb7_pipeline.json so sentinel reads
+    # truthful success signal (not stale gateway projection). See T16 fix.
+    PYTHONPATH=. "$PYTHON" -m apps.evaluator.nlm_deep_research.heartbeat_monitor \
+        --record "nb7_pipeline" 2>/dev/null || true
 else
     echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [FAIL] NB-7 pipeline failed (exit $EXIT_CODE)" >> "$LOG_FILE"
     if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_OWNER_CHAT_ID:-}" ]; then

--- a/apps/evaluator/nlm_deep_research/scripts/run_nb8_pipeline.sh
+++ b/apps/evaluator/nlm_deep_research/scripts/run_nb8_pipeline.sh
@@ -47,6 +47,10 @@ EXIT_CODE=${PIPESTATUS[0]}
 
 if [ $EXIT_CODE -eq 0 ]; then
     echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [DONE] NB-8 pipeline completed successfully" >> "$LOG_FILE"
+    # ARCH-9 heartbeat — writes heartbeat_nb8_pipeline.json so sentinel reads
+    # truthful success signal (not stale gateway projection). See T16 fix.
+    PYTHONPATH=. "$PYTHON" -m apps.evaluator.nlm_deep_research.heartbeat_monitor \
+        --record "nb8_pipeline" 2>/dev/null || true
 else
     echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [FAIL] NB-8 pipeline failed (exit $EXIT_CODE)" >> "$LOG_FILE"
     if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_OWNER_CHAT_ID:-}" ]; then

--- a/apps/evaluator/nlm_deep_research/tests/test_verify_ingestion.py
+++ b/apps/evaluator/nlm_deep_research/tests/test_verify_ingestion.py
@@ -1,0 +1,171 @@
+"""Regression tests for verify_ingestion_uuid (Sprint 1 S1.2).
+
+Covers the happy path (marker returned by NLM), the STALE path (marker
+missing in answer → notebook ingestion is broken), and the failure paths
+(upload error, query timeout). Uses monkeypatch on subprocess.run to
+avoid touching real NotebookLM cloud.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from apps.evaluator.nlm_deep_research import freshness_monitor as fm
+
+
+def _fake_completed(stdout: str = "", stderr: str = "", returncode: int = 0):
+    """Build a CompletedProcess-like object for mocking."""
+    return SimpleNamespace(stdout=stdout, stderr=stderr, returncode=returncode)
+
+
+def test_verify_ingestion_dry_run_skips_cli():
+    """--dry-run returns ok without touching NLM."""
+    result = fm.verify_ingestion_uuid("dummy-nb-id", dry_run=True)
+    assert result["status"] == "ok"
+    assert result["error"] == "dry_run"
+
+
+def test_verify_ingestion_happy_path(tmp_path, monkeypatch):
+    """Upload succeeds, query returns the injected marker → status=ok."""
+    # Redirect state file into tmp_path
+    monkeypatch.setattr(
+        fm, "FRESHNESS_STATE_FILE", tmp_path / "freshness_monitor_state.json"
+    )
+
+    captured_marker: dict[str, str] = {}
+
+    def fake_run(cmd, **kwargs):
+        if cmd[1] == "source" and cmd[2] == "add":
+            # Extract marker from the --text payload
+            text_idx = cmd.index("--text") + 1
+            text = cmd[text_idx]
+            # marker is the 12-char hex after "Query marker:"
+            marker_line = [l for l in text.splitlines() if "Query marker:" in l][0]
+            captured_marker["m"] = marker_line.split("Query marker:")[1].strip().rstrip(".")
+            return _fake_completed(stdout=f"Source ID: fake-src-id\n✓ Added")
+        if cmd[1] == "notebook" and cmd[2] == "query":
+            # Echo the marker back as if NLM found it
+            m = captured_marker.get("m", "")
+            return _fake_completed(stdout=f"Found the marker: {m}")
+        if cmd[1] == "source" and cmd[2] == "delete":
+            return _fake_completed(stdout="deleted")
+        pytest.fail(f"unexpected subprocess command: {cmd}")
+
+    with patch.object(fm, "time", SimpleNamespace(sleep=lambda s: None, monotonic=lambda: 0.0)):
+        with patch.object(fm.subprocess, "run", side_effect=fake_run):
+            result = fm.verify_ingestion_uuid("nb-id", poll_seconds=0)
+
+    assert result["status"] == "ok"
+    assert result["error"] is None
+    assert result["source_id"] == "fake-src-id"
+    # State persisted
+    saved = json.loads((tmp_path / "freshness_monitor_state.json").read_text())
+    assert "ingestion_verifications" in saved
+    assert saved["ingestion_verifications"]["nb-id"]["last"]["status"] == "ok"
+
+
+def test_verify_ingestion_stale_when_marker_missing(tmp_path, monkeypatch):
+    """Upload ok, query returns answer without marker → status=stale."""
+    monkeypatch.setattr(
+        fm, "FRESHNESS_STATE_FILE", tmp_path / "freshness_monitor_state.json"
+    )
+
+    def fake_run(cmd, **kwargs):
+        if cmd[1] == "source" and cmd[2] == "add":
+            return _fake_completed(stdout="Source ID: fake-src-id")
+        if cmd[1] == "notebook" and cmd[2] == "query":
+            # Answer that does NOT contain the marker
+            return _fake_completed(stdout="Sorry, I could not find that in the sources.")
+        if cmd[1] == "source" and cmd[2] == "delete":
+            return _fake_completed(stdout="")
+        pytest.fail(f"unexpected command: {cmd}")
+
+    with patch.object(fm, "time", SimpleNamespace(sleep=lambda s: None, monotonic=lambda: 0.0)):
+        with patch.object(fm.subprocess, "run", side_effect=fake_run):
+            result = fm.verify_ingestion_uuid("nb-stale", poll_seconds=0)
+
+    assert result["status"] == "stale"
+    assert "marker not found" in (result["error"] or "")
+
+
+def test_verify_ingestion_upload_failure(tmp_path, monkeypatch):
+    """`nlm source add` nonzero exit → status=error, query skipped."""
+    monkeypatch.setattr(
+        fm, "FRESHNESS_STATE_FILE", tmp_path / "freshness_monitor_state.json"
+    )
+
+    def fake_run(cmd, **kwargs):
+        if cmd[1] == "source" and cmd[2] == "add":
+            return _fake_completed(
+                stdout="", stderr="upload rejected: quota exceeded", returncode=1
+            )
+        pytest.fail(f"query should not be called after upload failure, got: {cmd}")
+
+    with patch.object(fm, "time", SimpleNamespace(sleep=lambda s: None, monotonic=lambda: 0.0)):
+        with patch.object(fm.subprocess, "run", side_effect=fake_run):
+            result = fm.verify_ingestion_uuid("nb-upfail", poll_seconds=0)
+
+    assert result["status"] == "error"
+    assert "source add failed" in (result["error"] or "")
+    assert result["source_id"] is None
+
+
+def test_verify_ingestion_query_timeout(tmp_path, monkeypatch):
+    """Query subprocess raises TimeoutExpired → status=error."""
+    monkeypatch.setattr(
+        fm, "FRESHNESS_STATE_FILE", tmp_path / "freshness_monitor_state.json"
+    )
+
+    def fake_run(cmd, **kwargs):
+        if cmd[1] == "source" and cmd[2] == "add":
+            return _fake_completed(stdout="Source ID: fake-id")
+        if cmd[1] == "notebook" and cmd[2] == "query":
+            raise subprocess.TimeoutExpired(cmd, 60)
+        pytest.fail(f"unexpected: {cmd}")
+
+    with patch.object(fm, "time", SimpleNamespace(sleep=lambda s: None, monotonic=lambda: 0.0)):
+        with patch.object(fm.subprocess, "run", side_effect=fake_run):
+            result = fm.verify_ingestion_uuid("nb-qtimeout", poll_seconds=0)
+
+    assert result["status"] == "error"
+    assert "timed out" in (result["error"] or "")
+
+
+def test_verify_ingestion_persists_rolling_history(tmp_path, monkeypatch):
+    """Multiple runs accumulate in history (max 20)."""
+    state_file = tmp_path / "freshness_monitor_state.json"
+    monkeypatch.setattr(fm, "FRESHNESS_STATE_FILE", state_file)
+
+    # Seed state with 19 prior history entries
+    prior = {
+        "ingestion_verifications": {
+            "nb-x": {
+                "last": None,
+                "history": [{"ts": "prior", "status": "ok", "uuid": "zzz", "age_seconds": 1, "error": None}] * 19,
+            }
+        }
+    }
+    state_file.write_text(json.dumps(prior))
+
+    def fake_run(cmd, **kwargs):
+        if cmd[1] == "source" and cmd[2] == "add":
+            return _fake_completed(stdout="Source ID: s1")
+        if cmd[1] == "notebook" and cmd[2] == "query":
+            # No marker echo — so status=stale. Good for this test.
+            return _fake_completed(stdout="empty")
+        return _fake_completed(stdout="")
+
+    with patch.object(fm, "time", SimpleNamespace(sleep=lambda s: None, monotonic=lambda: 0.0)):
+        with patch.object(fm.subprocess, "run", side_effect=fake_run):
+            fm.verify_ingestion_uuid("nb-x", poll_seconds=0)
+
+    saved = json.loads(state_file.read_text())
+    entry = saved["ingestion_verifications"]["nb-x"]
+    # After append, history should be max 20 (prior 19 + new 1)
+    assert len(entry["history"]) == 20
+    assert entry["last"]["status"] == "stale"

--- a/scripts/nuzantara-sentinel.py
+++ b/scripts/nuzantara-sentinel.py
@@ -200,7 +200,22 @@ def _collect_openclaw_states(registry: dict) -> dict:
 
 
 def collect_state_files(registry: Optional[dict] = None) -> dict:
-    """Read local + Pro state files + OpenClaw bridge. Returns {job_id: state_dict}."""
+    """Read local + Pro state files + OpenClaw bridge. Returns {job_id: state_dict}.
+
+    Read precedence (lowest to highest — later writes override earlier):
+      1. OpenClaw gateway projection (jobs.json → synthesised state).
+      2. Local {job}.last.json files.
+      3. **ARCH-9 native heartbeat** ``heartbeat_{name}.json`` written by
+         ``apps.evaluator.nlm_deep_research.heartbeat_monitor.record_success``.
+         When present, it is the only source that reflects a real successful
+         run of an NLM pipeline — the gateway projection may lie (see
+         research/nlm-elevation/08-s02-dispatcher-diagnosis.md).
+
+    Rationale: gateway rewrites .last.json every 5min with lastRunAtMs from
+    jobs.json, which stays frozen when run_nbN_pipeline.sh doesn't notify
+    openclaw. ARCH-9 is only written on actual success, so it is the truth
+    source for any NLM pipeline that has a matching registry entry.
+    """
     if registry is None:
         registry = load_registry()
     states = {}
@@ -215,6 +230,52 @@ def collect_state_files(registry: Optional[dict] = None) -> dict:
             states[job_id] = json.loads(open(path).read())
         except Exception:
             pass
+
+    # ARCH-9 heartbeat — highest precedence for NLM pipelines.
+    # Map heartbeat_{name}.json → registry job_id based on pipeline naming.
+    for path in glob.glob(os.path.join(STATE_DIR, "heartbeat_*.json")):
+        try:
+            pipeline_name = os.path.basename(path).replace("heartbeat_", "").replace(".json", "")
+            hb = json.loads(open(path).read())
+            last_success = hb.get("last_success")
+            if not last_success:
+                continue
+            # Convert ISO timestamp to epoch seconds for Sentinel state format
+            try:
+                from datetime import datetime as _dt
+                ts = _dt.fromisoformat(last_success).timestamp()
+            except (ValueError, TypeError):
+                continue
+            # Match pipeline_name to registry job_id. Try direct and variants.
+            candidates = [
+                pipeline_name,                             # nb2_pipeline
+                f"nlm_{pipeline_name}",                    # nlm_nb2_pipeline
+                pipeline_name.replace("_pipeline", ""),    # nb2
+                f"nlm_{pipeline_name.replace('_pipeline', '')}",  # nlm_nb2
+            ]
+            # Fuzzy: find registry keys starting with nlm_{nbN}_ if pipeline is nbN_pipeline
+            short = pipeline_name.split("_")[0]
+            if short.startswith("nb"):
+                fuzzy = [k for k in registry if k.startswith(f"nlm_{short}_") or k.startswith(f"{short}_")]
+                candidates.extend(fuzzy)
+            matched = next((c for c in candidates if c in registry), None)
+            if not matched:
+                continue
+            # Only override if ARCH-9 heartbeat is newer than whatever we have
+            existing_ts = (states.get(matched) or {}).get("ts", 0) or 0
+            if ts >= existing_ts:
+                states[matched] = {
+                    "job": matched,
+                    "ts": ts,
+                    "status": "ok",
+                    "last_error": "",
+                    "retry_attempt": 0,
+                    "_source": "arch9_heartbeat",
+                    "_heartbeat_file": os.path.basename(path),
+                    "duration_seconds": hb.get("duration_seconds"),
+                }
+        except Exception as exc:
+            logger.debug("Failed to read ARCH-9 heartbeat %s: %s", path, exc)
 
     # Pro state files via SSH (skip if we are Pro)
     import socket

--- a/scripts/tests/test_sentinel_arch9_heartbeat.py
+++ b/scripts/tests/test_sentinel_arch9_heartbeat.py
@@ -1,0 +1,180 @@
+"""
+Regression tests for T16 fix — nuzantara-sentinel.py ARCH-9 heartbeat preference.
+
+Covers the case where the openclaw-gateway writes a stale .last.json with
+fresh mtime (self-repair cieco pattern) and the sentinel must prefer the
+ARCH-9 native heartbeat_{name}.json as source of truth.
+
+Root cause: research/nlm-elevation/08-s02-dispatcher-diagnosis.md.
+Fix commit: T16 (2026-04-25).
+"""
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+
+def _load_sentinel_module():
+    """Load nuzantara-sentinel.py as module (hyphen in filename blocks direct import)."""
+    repo_root = Path(__file__).resolve().parents[2]
+    sentinel_path = repo_root / "scripts" / "nuzantara-sentinel.py"
+    spec = importlib.util.spec_from_file_location("sentinel_under_test", sentinel_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["sentinel_under_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def isolated_state_dir(tmp_path, monkeypatch):
+    """Run sentinel with isolated STATE_DIR so tests do not touch real files."""
+    sentinel = _load_sentinel_module()
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    # Patch module-level STATE_DIR
+    monkeypatch.setattr(sentinel, "STATE_DIR", str(state_dir))
+    # Prevent SSH fan-out in tests (we are not Pro-host by default)
+    monkeypatch.setattr(sentinel, "PRO_HOST", os.uname().nodename)
+    # Bypass the openclaw-bridge collector: we test heartbeat override
+    # in isolation.
+    monkeypatch.setattr(sentinel, "_collect_openclaw_states", lambda registry: {})
+    return sentinel, state_dir
+
+
+def test_arch9_heartbeat_overrides_stale_gateway(isolated_state_dir):
+    """ARCH-9 heartbeat is newer than gateway projection → ARCH-9 wins."""
+    sentinel, sdir = isolated_state_dir
+
+    # Gateway projection with stale ts (Apr 14)
+    stale_ts = datetime(2026, 4, 14, 0, 0, tzinfo=timezone.utc).timestamp()
+    (sdir / "nlm_nb2_pipeline.last.json").write_text(json.dumps({
+        "job": "nlm_nb2_pipeline",
+        "ts": stale_ts,
+        "status": "failed",
+        "source": "openclaw-bridge",
+        "last_error": "OpenClaw consecutiveErrors=0, lastStatus=pending",
+    }))
+
+    # ARCH-9 heartbeat with fresh ts (today)
+    fresh_iso = datetime.now(tz=timezone.utc).isoformat()
+    (sdir / "heartbeat_nb2_pipeline.json").write_text(json.dumps({
+        "pipeline": "nb2_pipeline",
+        "last_success": fresh_iso,
+        "duration_seconds": 56.0,
+    }))
+
+    registry = {"nlm_nb2_pipeline": {"type": "openclaw"}}
+    states = sentinel.collect_state_files(registry=registry)
+
+    assert "nlm_nb2_pipeline" in states
+    s = states["nlm_nb2_pipeline"]
+    assert s["_source"] == "arch9_heartbeat"
+    assert s["status"] == "ok"
+    assert s["duration_seconds"] == 56.0
+    # ts must be close to now, NOT Apr 14
+    now_ts = datetime.now(tz=timezone.utc).timestamp()
+    assert abs(s["ts"] - now_ts) < 5  # within 5s
+
+
+def test_arch9_heartbeat_missing_falls_back_to_gateway(isolated_state_dir):
+    """No ARCH-9 heartbeat → gateway projection wins (legacy behavior)."""
+    sentinel, sdir = isolated_state_dir
+
+    ts = datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc).timestamp()
+    (sdir / "nlm_nb5_pipeline.last.json").write_text(json.dumps({
+        "job": "nlm_nb5_pipeline",
+        "ts": ts,
+        "status": "ok",
+        "source": "openclaw-bridge",
+    }))
+    # No heartbeat_nb5_pipeline.json
+
+    registry = {"nlm_nb5_pipeline": {"type": "openclaw"}}
+    states = sentinel.collect_state_files(registry=registry)
+
+    s = states["nlm_nb5_pipeline"]
+    # Not arch9_heartbeat — gateway projection preserved
+    assert s.get("_source") != "arch9_heartbeat"
+    assert s["ts"] == ts
+
+
+def test_arch9_older_than_existing_does_not_override(isolated_state_dir):
+    """If an existing state has a newer ts than ARCH-9, do not override.
+
+    Prevents regressing to an older timestamp when the pipeline just ran
+    successfully via a different codepath that already wrote .last.json.
+    """
+    sentinel, sdir = isolated_state_dir
+
+    # Gateway projection already has fresh ts (e.g. just ran via cron-agent)
+    newer_ts = datetime.now(tz=timezone.utc).timestamp()
+    (sdir / "nlm_nb3_pipeline.last.json").write_text(json.dumps({
+        "job": "nlm_nb3_pipeline",
+        "ts": newer_ts,
+        "status": "ok",
+        "source": "openclaw-bridge",
+    }))
+
+    # ARCH-9 heartbeat with older ts
+    older_iso = (datetime.now(tz=timezone.utc) - timedelta(hours=12)).isoformat()
+    (sdir / "heartbeat_nb3_pipeline.json").write_text(json.dumps({
+        "pipeline": "nb3_pipeline",
+        "last_success": older_iso,
+    }))
+
+    registry = {"nlm_nb3_pipeline": {"type": "openclaw"}}
+    states = sentinel.collect_state_files(registry=registry)
+
+    s = states["nlm_nb3_pipeline"]
+    # Newer gateway ts preserved
+    assert s["ts"] == newer_ts
+
+
+def test_fuzzy_match_nb_prefix(isolated_state_dir):
+    """heartbeat_nb2_pipeline matches registry key nlm_nb2_immigration via nbN prefix."""
+    sentinel, sdir = isolated_state_dir
+
+    fresh_iso = datetime.now(tz=timezone.utc).isoformat()
+    (sdir / "heartbeat_nb2_pipeline.json").write_text(json.dumps({
+        "pipeline": "nb2_pipeline",
+        "last_success": fresh_iso,
+    }))
+
+    # Registry uses different naming than the heartbeat file
+    registry = {"nlm_nb2_immigration": {"type": "openclaw"}}
+    states = sentinel.collect_state_files(registry=registry)
+
+    assert "nlm_nb2_immigration" in states
+    assert states["nlm_nb2_immigration"]["_source"] == "arch9_heartbeat"
+
+
+def test_heartbeat_without_last_success_is_ignored(isolated_state_dir):
+    """Malformed ARCH-9 heartbeat (missing last_success) is silently skipped."""
+    sentinel, sdir = isolated_state_dir
+
+    (sdir / "heartbeat_nb4_pipeline.json").write_text(json.dumps({
+        "pipeline": "nb4_pipeline",
+        "duration_seconds": 30.0,
+        # no last_success field
+    }))
+
+    # Also write a valid gateway projection so we can verify fallback
+    ts = datetime(2026, 4, 20, tzinfo=timezone.utc).timestamp()
+    (sdir / "nlm_nb4_pipeline.last.json").write_text(json.dumps({
+        "job": "nlm_nb4_pipeline",
+        "ts": ts,
+        "status": "ok",
+    }))
+
+    registry = {"nlm_nb4_pipeline": {"type": "openclaw"}}
+    states = sentinel.collect_state_files(registry=registry)
+
+    s = states["nlm_nb4_pipeline"]
+    # Not overridden — gateway projection stays
+    assert s.get("_source") != "arch9_heartbeat"
+    assert s["ts"] == ts


### PR DESCRIPTION
## Summary

Terza PR della serie Sprint 0/1 NLM elevation (complementare a #243 e #244). Due commit atomici.

### 🔧 T16 — fix(sentinel): ARCH-9 heartbeat preference over stale gateway

Fix del bug diagnosticato in PR #244 (`research/nlm-elevation/08-s02-dispatcher-diagnosis.md`):

- `scripts/nuzantara-sentinel.py::collect_state_files()` ora legge
  `heartbeat_{name}.json` (ARCH-9 scritto da `record_success()` solo a
  vero successo pipeline) come override del gateway projection stale.
- Match registry key via direct name, `nlm_` prefix, o fuzzy `nbN_` prefix.
- Solo override se ARCH-9 timestamp è **più recente** del gateway (safety).
- 7 wrapper `run_nb{3..8,10}_pipeline.sh` estesi per chiamare
  `heartbeat_monitor --record nbN_pipeline` su exit 0 (nb2 lo aveva già).
  Ora l'intera flotta NB-2..NB-10 scrive il segnale che il sentinel preferisce.

**Regression tests (5/5 PASS)**: arch9 overrides stale gateway · fallback to gateway when arch9 missing · older arch9 does NOT override newer gateway · fuzzy match nbN prefix · malformed heartbeat ignored.

### ✨ S1.2 — feat(freshness): verify_ingestion_uuid canary

Sprint 1 dell'elevation plan v2. Aggiunge a `freshness_monitor.py` una funzione che prova end-to-end l'ingestion di un notebook:

1. Inject source di testo con UUID marker (12 hex)
2. Wait 40s per indexing
3. Query NLM chiedendo di echo del marker
4. `status=ok` se il marker è nell'answer, `stale` altrimenti
5. Cleanup source canary (best-effort, can disable with `--no-cleanup`)

Risultato persistito in `freshness_monitor_state.json` sotto `ingestion_verifications[notebook_id]` con rolling history (max 20 entries).

**CLI**: `python -m apps.evaluator.nlm_deep_research.freshness_monitor --verify-ingestion <NOTEBOOK_UUID>`

**Live test 2026-04-25 su NB-0 Meta-NLM** (`9a70162a-db99...`):
- Upload 53s total, marker `350fcb0bfbdf` echoed correttamente
- `status=ok`, source deleted, state persisted

**Regression tests (6/6 PASS)**: dry_run · happy path (marker echoed) · stale (marker missing) · upload failure · query timeout · rolling history trim.

## Test plan
- [x] `pytest test_sentinel_arch9_heartbeat.py` → 5/5
- [x] `pytest test_verify_ingestion.py` → 6/6
- [x] Live `--verify-ingestion` su NB-0 → ok in 53s
- [ ] Dopo merge: il prossimo tick sentinel (5min) DEVE mostrare `_source=arch9_heartbeat` per i job con `heartbeat_{name}.json` recente — previene la falsa vita dei `.last.json` stale.
- [ ] Sprint 1 follow-up S1.3: estendere `nlm_notebook_registry.py::resolve_notebook()` a rifiutare query quando `ingestion_verifications[nb].last.status != ok` entro `max_staleness_hours`.

## Relazione con altre PR
- PR #243 (fix/nlm-elevation-sprint0) — Sprint 0 core fix
- PR #244 (fix/nlm-s05-truth-dashboard) — truth_dashboard + diagnosis
- PR qui — consuma la diagnosi #244 e inizia Sprint 1 freshness contract

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)