### PR TITLE
feat(oracle): S1.3 stale-ingestion gate in resolve_notebook()

### DIFF
--- a/apps/backend-rag/backend/services/oracle/nlm_notebook_registry.py
+++ b/apps/backend-rag/backend/services/oracle/nlm_notebook_registry.py
@@ -4,9 +4,24 @@ Each domain has:
 - notebook_id: operational notebook (NB-Xb) — T2+T3 verified guides
 - primary_notebook_id: oracle notebook (NB-Xa) — T0+T1 law only (None until created)
 - keywords: used by resolve_notebook() to route queries
+
+Stale-ingestion gate (S1.3, 2026-04-25): resolve_notebook() can refuse to
+return a notebook_id when its most recent ingestion canary verification
+(written by apps.evaluator.nlm_deep_research.freshness_monitor.verify_ingestion_uuid)
+is failing or missing within the configured staleness window. The caller
+in nlm_orchestrator falls back to Qdrant-only when this happens.
 """
 
 from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 NLM_NOTEBOOKS: dict[str, dict] = {
     "immigration": {
@@ -120,6 +135,141 @@ _PRIMARY_LAW_KEYWORDS = frozenset(
 )
 
 
+# ── Stale-ingestion gate (S1.3) ──────────────────────────────────────────────
+
+_DEFAULT_FRESHNESS_STATE_PATH = (
+    Path(__file__).resolve().parents[5]
+    / "apps" / "evaluator" / "nlm_deep_research" / "freshness_monitor_state.json"
+)
+_DEFAULT_MAX_STALE_HOURS = 24
+
+
+def _resolve_state_path() -> Path:
+    """State file path is resolvable from env var or repo default.
+
+    The freshness_monitor lives under ``apps/evaluator``; the backend-rag
+    process either runs from the same monorepo (Pro Mac local) or from a
+    Docker image that mounts/copies the state file. Allow override via
+    ``NLM_FRESHNESS_STATE_FILE`` env var so tests and Fly.io deploys can
+    pin a path explicitly.
+    """
+    env = os.environ.get("NLM_FRESHNESS_STATE_FILE")
+    if env:
+        return Path(env)
+    return _DEFAULT_FRESHNESS_STATE_PATH
+
+
+def _max_stale_hours() -> int:
+    raw = os.environ.get("NLM_MAX_STALE_HOURS")
+    if not raw:
+        return _DEFAULT_MAX_STALE_HOURS
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return _DEFAULT_MAX_STALE_HOURS
+
+
+def check_ingestion_freshness(
+    notebook_id: str,
+    *,
+    max_stale_hours: Optional[int] = None,
+    state_path: Optional[Path] = None,
+) -> dict[str, object]:
+    """Inspect the most recent ingestion canary for a notebook.
+
+    Reads ``freshness_monitor_state.json`` and returns a verdict suitable
+    for gating oracle queries.
+
+    Args:
+        notebook_id: NLM notebook UUID.
+        max_stale_hours: Override threshold (default 24, env override
+            ``NLM_MAX_STALE_HOURS``).
+        state_path: Override state file path (test injection).
+
+    Returns:
+        Dict with keys:
+          - ``status`` — "fresh", "stale", "never_verified"
+          - ``last_status`` — "ok", "stale", "error", or None
+          - ``age_hours`` — float or None
+          - ``last_uuid`` — last canary UUID or None
+          - ``reason`` — short string, present when not fresh
+
+    The function never raises on disk errors — a missing/corrupt state
+    file is treated as ``never_verified`` so oracle behavior degrades
+    gracefully (caller may decide whether to fail-open or fail-closed).
+    """
+    threshold = max_stale_hours if max_stale_hours is not None else _max_stale_hours()
+    path = state_path or _resolve_state_path()
+
+    verdict: dict[str, object] = {
+        "status": "never_verified",
+        "last_status": None,
+        "age_hours": None,
+        "last_uuid": None,
+    }
+
+    try:
+        raw = path.read_text()
+    except FileNotFoundError:
+        verdict["reason"] = f"freshness state file not found: {path}"
+        return verdict
+    except OSError as exc:
+        logger.warning("freshness state unreadable (%s): %s", path, exc)
+        verdict["reason"] = f"state file unreadable: {exc}"
+        return verdict
+
+    try:
+        state = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.warning("freshness state malformed: %s", exc)
+        verdict["reason"] = "state file malformed"
+        return verdict
+
+    verifications = state.get("ingestion_verifications") or {}
+    entry = verifications.get(notebook_id)
+    if not entry:
+        verdict["reason"] = "no canary verification on record"
+        return verdict
+
+    last = entry.get("last") or {}
+    started_at = last.get("started_at")
+    last_status = last.get("status")
+    verdict["last_status"] = last_status
+    verdict["last_uuid"] = last.get("uuid")
+
+    if not started_at:
+        verdict["reason"] = "last verification has no timestamp"
+        return verdict
+
+    try:
+        ts = datetime.fromisoformat(started_at)
+    except (TypeError, ValueError):
+        verdict["reason"] = f"timestamp not parseable: {started_at}"
+        return verdict
+
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+
+    age = datetime.now(tz=timezone.utc) - ts
+    age_hours = age.total_seconds() / 3600
+    verdict["age_hours"] = round(age_hours, 2)
+
+    if last_status != "ok":
+        verdict["status"] = "stale"
+        verdict["reason"] = f"last canary status={last_status}"
+        return verdict
+
+    if age_hours > threshold:
+        verdict["status"] = "stale"
+        verdict["reason"] = (
+            f"last canary {age_hours:.1f}h ago > threshold {threshold}h"
+        )
+        return verdict
+
+    verdict["status"] = "fresh"
+    return verdict
+
+
 def resolve_multi_notebook(
     query: str,
     threshold: int = 1,
@@ -167,7 +317,12 @@ def resolve_multi_notebook(
     ]
 
 
-def resolve_notebook(query: str) -> dict[str, object] | None:
+def resolve_notebook(
+    query: str,
+    *,
+    enforce_freshness: bool | None = None,
+    max_stale_hours: Optional[int] = None,
+) -> dict[str, object] | None:
     """Resolve a user query to the best-matching NLM notebook.
 
     When a primary notebook exists for the domain, returns it for
@@ -176,10 +331,21 @@ def resolve_notebook(query: str) -> dict[str, object] | None:
 
     Args:
         query: Free-text user query.
+        enforce_freshness: If True, gate the result on ingestion canary
+            freshness (S1.3). When the chosen notebook has no recent
+            successful canary, return ``None`` (the caller falls back to
+            Qdrant-only retrieval). Defaults to the env var
+            ``NLM_ENFORCE_FRESHNESS`` (any truthy value enables it),
+            else False — backward compatible no-op.
+        max_stale_hours: Override the freshness threshold (default 24h,
+            env ``NLM_MAX_STALE_HOURS``).
 
     Returns:
-        A dict with keys ``domain``, ``notebook_id``, ``label``, ``keywords``
-        for the best match, or ``None`` if nothing matches.
+        A dict with keys ``domain``, ``notebook_id``, ``label``,
+        ``keywords``, ``primary_notebook_id``, plus ``freshness`` (the
+        verdict from check_ingestion_freshness) when that check is
+        actually performed. Returns ``None`` if no domain matches OR
+        when enforce_freshness is on and the chosen notebook is stale.
     """
     if not query:
         return None
@@ -203,10 +369,33 @@ def resolve_notebook(query: str) -> dict[str, object] | None:
     primary = data.get("primary_notebook_id")
     active_id = primary if (wants_primary and primary) else data["notebook_id"]
 
-    return {
+    # Resolve enforce_freshness: explicit arg > env var > False (legacy default)
+    if enforce_freshness is None:
+        enforce_freshness = os.environ.get("NLM_ENFORCE_FRESHNESS", "").lower() in (
+            "1", "true", "yes", "on",
+        )
+
+    result: dict[str, object] = {
         "domain": best_domain,
         "notebook_id": active_id,
         "primary_notebook_id": data.get("primary_notebook_id"),
         "label": data["label"],
         "keywords": frozenset(data["keywords"]),
     }
+
+    if enforce_freshness:
+        verdict = check_ingestion_freshness(
+            active_id,  # type: ignore[arg-type]
+            max_stale_hours=max_stale_hours,
+        )
+        result["freshness"] = verdict
+        if verdict["status"] != "fresh":
+            logger.info(
+                "NLM oracle gate: refusing notebook %s (%s) — %s",
+                active_id,
+                best_domain,
+                verdict.get("reason"),
+            )
+            return None
+
+    return result

--- a/apps/backend-rag/backend/tests/services/oracle/test_nlm_notebook_registry_freshness.py
+++ b/apps/backend-rag/backend/tests/services/oracle/test_nlm_notebook_registry_freshness.py
@@ -1,0 +1,162 @@
+"""Regression tests for S1.3 — NLM oracle gate on stale ingestion.
+
+Covers:
+  - check_ingestion_freshness against various state file shapes
+  - resolve_notebook backward-compatible default (no gate, returns NB)
+  - resolve_notebook with enforce_freshness=True (returns None when stale)
+  - env var NLM_ENFORCE_FRESHNESS toggles default
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from backend.services.oracle import nlm_notebook_registry as reg
+
+
+def _write_state(path: Path, ingestion_verifications: dict) -> None:
+    path.write_text(json.dumps({"ingestion_verifications": ingestion_verifications}))
+
+
+# ── check_ingestion_freshness ────────────────────────────────────────────────
+
+def test_freshness_fresh_when_recent_ok(tmp_path):
+    state = tmp_path / "fresh_state.json"
+    now_iso = datetime.now(tz=timezone.utc).isoformat()
+    _write_state(state, {
+        "nb-1": {
+            "last": {"started_at": now_iso, "status": "ok", "uuid": "abc123"},
+            "history": [],
+        }
+    })
+    verdict = reg.check_ingestion_freshness("nb-1", state_path=state)
+    assert verdict["status"] == "fresh"
+    assert verdict["last_status"] == "ok"
+    assert verdict["age_hours"] is not None
+    assert verdict["age_hours"] < 1  # just written
+    assert verdict["last_uuid"] == "abc123"
+
+
+def test_freshness_stale_when_canary_status_not_ok(tmp_path):
+    state = tmp_path / "state.json"
+    now_iso = datetime.now(tz=timezone.utc).isoformat()
+    _write_state(state, {
+        "nb-1": {
+            "last": {"started_at": now_iso, "status": "stale", "uuid": "x"},
+        }
+    })
+    verdict = reg.check_ingestion_freshness("nb-1", state_path=state)
+    assert verdict["status"] == "stale"
+    assert "status=stale" in verdict["reason"]
+
+
+def test_freshness_stale_when_too_old(tmp_path):
+    state = tmp_path / "state.json"
+    old = (datetime.now(tz=timezone.utc) - timedelta(hours=48)).isoformat()
+    _write_state(state, {
+        "nb-1": {
+            "last": {"started_at": old, "status": "ok", "uuid": "x"},
+        }
+    })
+    # Default threshold = 24h
+    verdict = reg.check_ingestion_freshness("nb-1", state_path=state, max_stale_hours=24)
+    assert verdict["status"] == "stale"
+    assert verdict["age_hours"] > 24
+    assert "threshold" in verdict["reason"]
+
+
+def test_freshness_never_verified_when_no_entry(tmp_path):
+    state = tmp_path / "state.json"
+    _write_state(state, {})  # empty verifications dict
+    verdict = reg.check_ingestion_freshness("never-seen-nb", state_path=state)
+    assert verdict["status"] == "never_verified"
+    assert "no canary verification" in verdict["reason"]
+
+
+def test_freshness_handles_missing_state_file(tmp_path):
+    state = tmp_path / "does_not_exist.json"
+    verdict = reg.check_ingestion_freshness("any-nb", state_path=state)
+    assert verdict["status"] == "never_verified"
+    assert "not found" in verdict["reason"]
+
+
+def test_freshness_handles_corrupt_json(tmp_path):
+    state = tmp_path / "broken.json"
+    state.write_text("{ not json")
+    verdict = reg.check_ingestion_freshness("nb", state_path=state)
+    assert verdict["status"] == "never_verified"
+    assert "malformed" in verdict["reason"]
+
+
+# ── resolve_notebook with enforce_freshness ──────────────────────────────────
+
+def test_resolve_notebook_default_does_not_gate(tmp_path, monkeypatch):
+    """Backward compatibility: default behavior is NO gating."""
+    monkeypatch.delenv("NLM_ENFORCE_FRESHNESS", raising=False)
+    result = reg.resolve_notebook("KITAS visa requirements")
+    assert result is not None
+    assert result["domain"] == "immigration"
+    assert "freshness" not in result  # gate not invoked
+
+
+def test_resolve_notebook_returns_none_when_stale_and_gated(tmp_path, monkeypatch):
+    """enforce_freshness=True + stale state → None (caller falls back)."""
+    state = tmp_path / "state.json"
+    old = (datetime.now(tz=timezone.utc) - timedelta(hours=48)).isoformat()
+    _write_state(state, {
+        # Use the actual NB-2 UUID from registry
+        "cff93ab0-813a-42f2-a8de-36987e724271": {
+            "last": {"started_at": old, "status": "ok", "uuid": "x"},
+        }
+    })
+    monkeypatch.setenv("NLM_FRESHNESS_STATE_FILE", str(state))
+    result = reg.resolve_notebook(
+        "KITAS visa requirements",
+        enforce_freshness=True,
+        max_stale_hours=24,
+    )
+    assert result is None
+
+
+def test_resolve_notebook_returns_nb_when_fresh_and_gated(tmp_path, monkeypatch):
+    """enforce_freshness=True + fresh state → NB returned with freshness verdict."""
+    state = tmp_path / "state.json"
+    now = datetime.now(tz=timezone.utc).isoformat()
+    _write_state(state, {
+        "cff93ab0-813a-42f2-a8de-36987e724271": {
+            "last": {"started_at": now, "status": "ok", "uuid": "fresh"},
+        }
+    })
+    monkeypatch.setenv("NLM_FRESHNESS_STATE_FILE", str(state))
+    result = reg.resolve_notebook("KITAS visa", enforce_freshness=True)
+    assert result is not None
+    assert result["domain"] == "immigration"
+    assert result["freshness"]["status"] == "fresh"
+
+
+def test_resolve_notebook_env_var_enables_gate(tmp_path, monkeypatch):
+    """NLM_ENFORCE_FRESHNESS=1 enables gating without explicit arg."""
+    state = tmp_path / "state.json"
+    _write_state(state, {})  # empty → never_verified
+    monkeypatch.setenv("NLM_FRESHNESS_STATE_FILE", str(state))
+    monkeypatch.setenv("NLM_ENFORCE_FRESHNESS", "1")
+    result = reg.resolve_notebook("KITAS visa")
+    assert result is None  # blocked by missing canary
+
+
+def test_resolve_notebook_env_var_off_disables_gate(tmp_path, monkeypatch):
+    """NLM_ENFORCE_FRESHNESS=0 keeps the gate disabled."""
+    monkeypatch.setenv("NLM_ENFORCE_FRESHNESS", "0")
+    result = reg.resolve_notebook("KITAS visa")
+    assert result is not None
+    assert "freshness" not in result
+
+
+def test_resolve_notebook_explicit_false_overrides_env(tmp_path, monkeypatch):
+    """Explicit enforce_freshness=False wins over env=1."""
+    monkeypatch.setenv("NLM_ENFORCE_FRESHNESS", "1")
+    result = reg.resolve_notebook("KITAS visa", enforce_freshness=False)
+    assert result is not None
+    assert "freshness" not in result


### PR DESCRIPTION
## Summary

Quarta PR della serie Sprint 0/1 NLM elevation. Chiude il loop tra il canary ingestion (PR #245) e l'oracle: quando il canary di un notebook è failing/stale, `resolve_notebook()` ritorna `None` e il caller cade su Qdrant pure.

## Changes

**Nuova funzione**: `check_ingestion_freshness(notebook_id, max_stale_hours=24)`
- Legge `apps/evaluator/nlm_deep_research/freshness_monitor_state.json`
- Verdetto: `fresh` / `stale` / `never_verified`
- Disk errors degradano gracefully (file missing/corrotto → never_verified, mai raise)
- Env override `NLM_FRESHNESS_STATE_FILE` per Fly.io che monta path differente
- Env override `NLM_MAX_STALE_HOURS` per regolare threshold

**`resolve_notebook()` extension**:
- Nuovo kwarg `enforce_freshness` (default reads `NLM_ENFORCE_FRESHNESS`, legacy=False)
- Quando attivo e canary != fresh → ritorna `None`
- Quando attivo e canary fresh → ritorna NB con `freshness` verdict allegato

## Backward compatibility

Zero breaking changes:
- Default è disabled (gate non attivo)
- 30 test esistenti in `test_nlm_orchestrator.py` PASS senza modifiche
- Activation opt-in: `fly secrets set NLM_ENFORCE_FRESHNESS=1 -a nuzantara-rag`

## Test plan
- [x] `pytest test_nlm_notebook_registry_freshness.py` → 12/12 PASS
- [x] `pytest test_nlm_orchestrator.py` → 30/30 PASS (no regression)
- [ ] Dopo merge: rollout in 2 step
  1. Deploy senza env var (no-op, prove non rompe nulla)
  2. `fly secrets set NLM_ENFORCE_FRESHNESS=1` quando il cron `verify-ingestion` ha popolato lo state per ≥24h su tutti i NB-2..NB-10

## Catena Sprint 0/1 completa

- PR #243 — fix claim_extractor + bridge/CLI timeout + docs Fed A2A + research artifacts + registry MASTER_DIGEST
- PR #244 — `truth_dashboard` CLI + S0.2 dispatcher diagnosis + doc hygiene
- PR #245 — T16 sentinel ARCH-9 preference + 7 wrapper record + S1.2 verify_ingestion_uuid
- PR (qui) — S1.3 oracle gate on stale ingestion

Sprint 1 chiude qui per la parte freshness contract. Prossimo: Sprint 2 Shadow Graphing.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)