### PR TITLE
feat(nlm): Sprint 2 Shadow Graphing — collection + extractor

### DIFF
--- a/apps/backend-rag/backend/core/collection_registry.py
+++ b/apps/backend-rag/backend/core/collection_registry.py
@@ -13,6 +13,11 @@ CANONICAL_LOGICAL_COLLECTIONS: Final[tuple[str, ...]] = (
     "training_conversations_hybrid",
     "immigration_circulars",
     "balizero_news",
+    # Sprint 2 Shadow Graphing (2026-04-25): NLM-extracted claims projected
+    # offline into Qdrant for sub-second runtime retrieval. Schema is
+    # NLMShadowChunk (NOT HierarchicalChunk) — kept fully separate so
+    # legal_unified / visa_oracle / etc. payloads stay rigid.
+    "nlm_shadow_hybrid",
 )
 
 LOGICAL_TO_PHYSICAL_COLLECTIONS: Final[dict[str, str]] = {
@@ -31,6 +36,8 @@ LOGICAL_TO_PHYSICAL_COLLECTIONS: Final[dict[str, str]] = {
     "tax_knowledge": "tax_genius_hybrid",
     "legal_updates": "legal_unified_hybrid_hybrid",
     "legal_intelligence": "legal_unified_hybrid_hybrid",
+    # Sprint 2 Shadow Graphing
+    "nlm_shadow_hybrid": "nlm_shadow_hybrid",
 }
 
 CANONICAL_COLLECTION_ALIASES: Final[dict[str, str]] = {
@@ -52,6 +59,7 @@ CANONICAL_COLLECTION_ALIASES: Final[dict[str, str]] = {
     "immigration_circulars": "immigration_circulars",
     "balizero_news": "balizero_news",
     "intel_authoritative_sources": "balizero_news",
+    "nlm_shadow_hybrid": "nlm_shadow_hybrid",
 }
 
 

--- a/apps/backend-rag/backend/core/nlm_shadow_chunk.py
+++ b/apps/backend-rag/backend/core/nlm_shadow_chunk.py
@@ -1,0 +1,105 @@
+"""Pydantic schema for nlm_shadow_hybrid Qdrant collection (Sprint 2).
+
+The Shadow Graphing pattern projects claims extracted offline by NotebookLM
+into a Qdrant collection that the runtime RAG can query in sub-second time
+without ever waking the NLM CLI. Each row is one atomic claim, validated by
+DeepSeek before write, with full provenance back to the NB and the run.
+
+Why a separate model from HierarchicalChunk:
+  - HierarchicalChunk is rigid (parent_id chains, level integer, doc-level
+    metadata) and is consumed by `legal/hierarchical_indexer.py` retrieval
+    paths that would Pydantic-fail on extra/missing fields.
+  - Shadow chunks are not legal documents — they are derived statements with
+    different lifecycle (24h-72h TTL, not permanent), different retrieval
+    surface (always grounded in nb_id), and a deepseek-validated flag the
+    other collections don't carry.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class NLMShadowChunk(BaseModel):
+    """A single atomic claim extracted from a NotebookLM notebook.
+
+    Stored in the ``nlm_shadow_hybrid`` Qdrant collection. Payload is FLAT
+    per the Nuzantara golden rule (no nested dicts in Qdrant payloads).
+    """
+
+    chunk_id: str = Field(..., description="Stable id, e.g. nlm_shadow_NB-3_20260425_001")
+    claim_text: str = Field(..., min_length=10, description="The atomic claim itself")
+
+    # Provenance (all flat strings/ints to play nice with Qdrant filters)
+    nb_id: str = Field(..., description="Source notebook UUID")
+    nb_label: str = Field(..., description="Domain label: immigration|company|tax|...")
+    nlm_source_id: Optional[str] = Field(
+        default=None, description="Originating source within the NB, when known"
+    )
+    extraction_run_id: str = Field(..., description="UUID of the extractor cron run")
+    extracted_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
+
+    # DeepSeek validation outcome
+    deepseek_validated: bool = Field(
+        default=False, description="True iff DeepSeek confirmed the claim is well-formed"
+    )
+    deepseek_confidence: float = Field(
+        default=0.0, ge=0.0, le=1.0, description="Confidence reported by DeepSeek validator"
+    )
+    deepseek_notes: Optional[str] = Field(
+        default=None, description="Short DeepSeek note (rejection reason, caveat)"
+    )
+
+    # Lifecycle
+    source: str = Field(default="nlm_shadow", description="Always 'nlm_shadow' for this collection")
+    ttl_hours: int = Field(default=72, ge=1, description="Soft TTL — runtime should ignore beyond this")
+
+    @field_validator("claim_text")
+    @classmethod
+    def _strip_claim(cls, v: str) -> str:
+        cleaned = v.strip()
+        if not cleaned:
+            raise ValueError("claim_text must not be blank after strip")
+        return cleaned
+
+    def to_qdrant_payload(self) -> dict:
+        """Render flat payload for Qdrant upsert.
+
+        Datetimes are converted to ISO strings (Qdrant payload type-safe).
+        """
+        return {
+            "chunk_id": self.chunk_id,
+            "claim_text": self.claim_text,
+            "nb_id": self.nb_id,
+            "nb_label": self.nb_label,
+            "nlm_source_id": self.nlm_source_id or "",
+            "extraction_run_id": self.extraction_run_id,
+            "extracted_at": self.extracted_at.isoformat(),
+            "deepseek_validated": self.deepseek_validated,
+            "deepseek_confidence": self.deepseek_confidence,
+            "deepseek_notes": self.deepseek_notes or "",
+            "source": self.source,
+            "ttl_hours": self.ttl_hours,
+        }
+
+    @classmethod
+    def from_qdrant_payload(cls, payload: dict) -> "NLMShadowChunk":
+        """Re-hydrate a chunk from a Qdrant payload."""
+        # Datetime parsing — string back to datetime
+        ext = payload.get("extracted_at")
+        if isinstance(ext, str):
+            try:
+                payload = {**payload, "extracted_at": datetime.fromisoformat(ext)}
+            except ValueError:
+                payload = {**payload, "extracted_at": datetime.now(tz=timezone.utc)}
+        # Treat empty strings as None for the optional fields
+        for k in ("nlm_source_id", "deepseek_notes"):
+            if payload.get(k) == "":
+                payload[k] = None
+        return cls(**payload)
+
+
+__all__ = ["NLMShadowChunk"]

--- a/apps/backend-rag/backend/tests/core/test_nlm_shadow_chunk.py
+++ b/apps/backend-rag/backend/tests/core/test_nlm_shadow_chunk.py
@@ -1,0 +1,115 @@
+"""Tests for NLMShadowChunk Pydantic model (Sprint 2 Shadow Graphing)."""
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from backend.core.nlm_shadow_chunk import NLMShadowChunk
+
+
+def test_minimal_construction():
+    c = NLMShadowChunk(
+        chunk_id="nlm_shadow_NB-3_20260425_001",
+        claim_text="PT PMA minimum capital is IDR 10 billion under PP 28/2025.",
+        nb_id="933509f9-1561-403d-bd44-4a7a67a36df2",
+        nb_label="company",
+        extraction_run_id="run-001",
+    )
+    assert c.source == "nlm_shadow"
+    assert c.ttl_hours == 72
+    assert c.deepseek_validated is False
+    assert c.deepseek_confidence == 0.0
+
+
+def test_to_qdrant_payload_flat():
+    c = NLMShadowChunk(
+        chunk_id="x",
+        claim_text="A claim with enough length.",
+        nb_id="nb-uuid",
+        nb_label="tax",
+        extraction_run_id="r1",
+        deepseek_validated=True,
+        deepseek_confidence=0.85,
+        deepseek_notes="ok",
+    )
+    payload = c.to_qdrant_payload()
+    # Flat — no nested dicts
+    for v in payload.values():
+        assert not isinstance(v, dict)
+    assert payload["source"] == "nlm_shadow"
+    assert isinstance(payload["extracted_at"], str)
+    assert payload["deepseek_confidence"] == 0.85
+
+
+def test_round_trip_qdrant_payload():
+    original = NLMShadowChunk(
+        chunk_id="rt",
+        claim_text="A round-trip test claim.",
+        nb_id="nb-rt",
+        nb_label="immigration",
+        extraction_run_id="r-rt",
+        nlm_source_id="src-rt",
+        deepseek_validated=True,
+        deepseek_confidence=0.7,
+    )
+    payload = original.to_qdrant_payload()
+    rehydrated = NLMShadowChunk.from_qdrant_payload(payload)
+    assert rehydrated.chunk_id == original.chunk_id
+    assert rehydrated.claim_text == original.claim_text
+    assert rehydrated.nlm_source_id == "src-rt"
+    assert rehydrated.deepseek_validated is True
+
+
+def test_empty_claim_text_rejected():
+    with pytest.raises(ValidationError):
+        NLMShadowChunk(
+            chunk_id="x",
+            claim_text="   ",  # blank after strip
+            nb_id="nb",
+            nb_label="tax",
+            extraction_run_id="r",
+        )
+
+
+def test_short_claim_text_rejected():
+    with pytest.raises(ValidationError):
+        NLMShadowChunk(
+            chunk_id="x",
+            claim_text="short",  # < 10 chars
+            nb_id="nb",
+            nb_label="tax",
+            extraction_run_id="r",
+        )
+
+
+def test_confidence_out_of_range_rejected():
+    with pytest.raises(ValidationError):
+        NLMShadowChunk(
+            chunk_id="x",
+            claim_text="A valid claim text.",
+            nb_id="nb",
+            nb_label="tax",
+            extraction_run_id="r",
+            deepseek_confidence=1.5,  # > 1.0
+        )
+
+
+def test_empty_string_optionals_become_none_on_rehydrate():
+    payload = {
+        "chunk_id": "x",
+        "claim_text": "Round-trip empty optionals test.",
+        "nb_id": "nb",
+        "nb_label": "tax",
+        "extraction_run_id": "r",
+        "extracted_at": datetime.now(tz=timezone.utc).isoformat(),
+        "deepseek_validated": False,
+        "deepseek_confidence": 0.0,
+        "deepseek_notes": "",          # empty string in storage
+        "nlm_source_id": "",           # empty string in storage
+        "source": "nlm_shadow",
+        "ttl_hours": 72,
+    }
+    rehydrated = NLMShadowChunk.from_qdrant_payload(payload)
+    assert rehydrated.deepseek_notes is None
+    assert rehydrated.nlm_source_id is None

--- a/scripts/nlm_shadow_extractor.py
+++ b/scripts/nlm_shadow_extractor.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Sprint 2 Shadow Graphing — extract claims from NB into Qdrant nlm_shadow_hybrid.
+
+For each NB domain in the registry:
+  1. ask NLM (via nlm CLI) for atomic claims in JSON-strict format
+  2. validate each candidate with DeepSeek Reasoner
+  3. embed claim_text via OpenAI text-embedding-3-small (FROZEN model)
+  4. upsert into Qdrant collection nlm_shadow_hybrid as NLMShadowChunk
+
+Designed to run as nightly cron after NB-2..NB-10 pipelines complete.
+
+Usage:
+    python scripts/nlm_shadow_extractor.py --notebook NB-2 [--dry-run] [--limit 10]
+    python scripts/nlm_shadow_extractor.py --all-domains [--dry-run]
+
+Env required (when not --dry-run):
+    DEEPSEEK_API_KEY      — for claim validation
+    OPENAI_API_KEY        — for claim embedding
+    QDRANT_URL            — for upsert (default http://localhost:6333)
+    QDRANT_API_KEY        — for cloud Qdrant only
+
+Vincolo Anthropic OAuth-only (Golden Rule #13): NEVER calls Claude API
+directly. NLM CLI uses the user's Max OAuth subscription. DeepSeek and
+OpenAI are paid per-token but allowed (not banned by the rule).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger("nlm_shadow_extractor")
+
+# ── Domain → notebook mapping (canonical, mirrors backend nlm_notebook_registry) ──
+DOMAIN_TO_NB: dict[str, dict[str, str]] = {
+    "immigration": {
+        "id": "cff93ab0-813a-42f2-a8de-36987e724271",
+        "label": "immigration",
+        "extract_prompt_subject": "immigration & visa requirements (KITAS, KITAP, TKA)",
+    },
+    "company": {
+        "id": "933509f9-1561-403d-bd44-4a7a67a36df2",
+        "label": "company",
+        "extract_prompt_subject": "company setup, KBLI, PMA, OSS, NIB",
+    },
+    "tax": {
+        "id": "d4b2eedb-9863-4a1a-81ff-a11b0b45d853",
+        "label": "tax",
+        "extract_prompt_subject": "Indonesian tax obligations (PPh, PPN, NPWP, BPJS)",
+    },
+    "property": {
+        "id": "d9438180-5e63-4e2a-a473-6061101f6a8d",
+        "label": "property",
+        "extract_prompt_subject": "property, zoning, HGB, Hak Pakai, leasehold",
+    },
+    "operations": {
+        "id": "85207af3-352f-4554-8d2a-18f42cc541ba",
+        "label": "operations",
+        "extract_prompt_subject": "operations, manpower, HR, BPJS",
+    },
+}
+
+EXTRACTION_PROMPT = (
+    "Extract atomic claims from the sources of this notebook about "
+    "{subject}. Each claim must be:\n"
+    "  - one self-contained statement\n"
+    "  - factual, attributable to a source in this notebook\n"
+    "  - 50-300 characters\n"
+    "Return STRICT JSON: a list of objects with keys 'claim' and "
+    "'source_id'. No prose, no markdown, no explanation. "
+    "Maximum {limit} claims. Example:\n"
+    '[{{"claim": "...", "source_id": "..."}}, ...]\n'
+)
+
+DEEPSEEK_VALIDATE_PROMPT = (
+    "You are validating an atomic legal/regulatory claim about Indonesia. "
+    "The claim is: {claim}\n\n"
+    "Reply with strict JSON: {{\"valid\": true|false, \"confidence\": 0.0-1.0, "
+    "\"notes\": \"short reason\"}}. A claim is INVALID if it is vague, "
+    "self-contradictory, or makes a numeric assertion without a clear basis. "
+    "If you are unsure, prefer valid=true with confidence < 0.6 and a note."
+)
+
+
+def _run_nlm_extract(notebook_id: str, subject: str, limit: int, timeout: int = 180) -> list[dict]:
+    """Ask NLM for claims as JSON list. Returns [] on parse failure."""
+    prompt = EXTRACTION_PROMPT.format(subject=subject, limit=limit)
+    logger.info("Querying NLM for %d claims (NB=%s)", limit, notebook_id[:8])
+    try:
+        proc = subprocess.run(
+            ["nlm", "notebook", "query", notebook_id, prompt, "--timeout", str(timeout)],
+            capture_output=True, text=True, timeout=timeout + 20,
+        )
+        if proc.returncode != 0:
+            logger.error("nlm CLI exit %d: %s", proc.returncode, proc.stderr.strip()[:200])
+            return []
+        wrapper = json.loads(proc.stdout)
+        # nlm CLI wraps response in {"value": {...}}
+        if "value" in wrapper:
+            wrapper = wrapper["value"]
+        answer = wrapper.get("answer", "")
+        # Extract JSON list from answer (NLM sometimes wraps in markdown)
+        return _parse_json_list(answer)
+    except subprocess.TimeoutExpired:
+        logger.warning("NLM query timed out after %ds", timeout)
+        return []
+    except Exception as exc:
+        logger.exception("NLM extraction failed: %s", exc)
+        return []
+
+
+def _parse_json_list(text: str) -> list[dict]:
+    """Best-effort parse of a JSON list from a possibly-wrapped answer."""
+    text = text.strip()
+    # Strip markdown code fences
+    if text.startswith("```"):
+        lines = [ln for ln in text.splitlines() if not ln.strip().startswith("```")]
+        text = "\n".join(lines).strip()
+    # Find the first [ ... ] block
+    start = text.find("[")
+    end = text.rfind("]")
+    if start == -1 or end == -1 or end <= start:
+        logger.warning("no JSON list found in answer")
+        return []
+    try:
+        parsed = json.loads(text[start:end + 1])
+        if isinstance(parsed, list):
+            return [c for c in parsed if isinstance(c, dict) and "claim" in c]
+    except json.JSONDecodeError as exc:
+        logger.warning("JSON parse failed: %s", exc)
+    return []
+
+
+def _validate_with_deepseek(claim: str, api_key: str, timeout: int = 60) -> dict:
+    """Call DeepSeek Reasoner to validate a single claim."""
+    import urllib.request
+    body = {
+        "model": "deepseek-reasoner",
+        "messages": [
+            {"role": "system", "content": "You validate atomic claims and reply only with strict JSON."},
+            {"role": "user", "content": DEEPSEEK_VALIDATE_PROMPT.format(claim=claim)},
+        ],
+        "max_tokens": 256,
+        "temperature": 0.0,
+    }
+    req = urllib.request.Request(
+        "https://api.deepseek.com/v1/chat/completions",
+        data=json.dumps(body).encode(),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            payload = json.loads(resp.read())
+        msg = payload["choices"][0]["message"].get("content", "")
+        # Strip optional markdown fences
+        msg = msg.strip().strip("```json").strip("```").strip()
+        parsed = json.loads(msg)
+        return {
+            "valid": bool(parsed.get("valid", False)),
+            "confidence": float(parsed.get("confidence", 0.0)),
+            "notes": str(parsed.get("notes", ""))[:200],
+        }
+    except Exception as exc:
+        logger.warning("DeepSeek validation failed for claim: %s", exc)
+        return {"valid": False, "confidence": 0.0, "notes": f"validator_error: {exc}"}
+
+
+def _embed_openai(text: str, api_key: str, timeout: int = 30) -> Optional[list[float]]:
+    """Embed text via OpenAI text-embedding-3-small (FROZEN per Nuzantara golden rule)."""
+    import urllib.request
+    req = urllib.request.Request(
+        "https://api.openai.com/v1/embeddings",
+        data=json.dumps({"model": "text-embedding-3-small", "input": text}).encode(),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            payload = json.loads(resp.read())
+        return payload["data"][0]["embedding"]
+    except Exception as exc:
+        logger.error("OpenAI embed failed: %s", exc)
+        return None
+
+
+def extract_for_notebook(
+    domain: str,
+    *,
+    limit: int = 20,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Run the full pipeline for one domain. Returns summary dict."""
+    nb = DOMAIN_TO_NB.get(domain)
+    if nb is None:
+        return {"domain": domain, "status": "unknown_domain", "claims_emitted": 0}
+
+    run_id = uuid.uuid4().hex[:12]
+    started = datetime.now(tz=timezone.utc).isoformat()
+    summary: dict[str, Any] = {
+        "domain": domain,
+        "run_id": run_id,
+        "started_at": started,
+        "notebook_id": nb["id"],
+        "claims_extracted": 0,
+        "claims_validated": 0,
+        "claims_emitted": 0,
+        "errors": [],
+    }
+
+    if dry_run:
+        summary["status"] = "dry_run"
+        return summary
+
+    # 1. Extract claims via NLM
+    raw_claims = _run_nlm_extract(nb["id"], nb["extract_prompt_subject"], limit=limit)
+    summary["claims_extracted"] = len(raw_claims)
+    if not raw_claims:
+        summary["status"] = "no_claims_extracted"
+        return summary
+
+    # 2. Validate each via DeepSeek
+    deepseek_key = os.environ.get("DEEPSEEK_API_KEY", "").strip()
+    if not deepseek_key:
+        summary["status"] = "missing_DEEPSEEK_API_KEY"
+        summary["errors"].append("DEEPSEEK_API_KEY not set — claims emitted with deepseek_validated=False")
+
+    openai_key = os.environ.get("OPENAI_API_KEY", "").strip()
+    if not openai_key:
+        summary["status"] = "missing_OPENAI_API_KEY"
+        return summary
+
+    # Lazy-import Qdrant + the chunk model so the script is importable
+    # without those deps (e.g. for unit tests).
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "apps" / "backend-rag"))
+    from backend.core.nlm_shadow_chunk import NLMShadowChunk  # type: ignore
+    from qdrant_client import QdrantClient
+    from qdrant_client.http.models import PointStruct, VectorParams, Distance
+
+    qdrant_url = os.environ.get("QDRANT_URL", "http://localhost:6333")
+    qdrant_api_key = os.environ.get("QDRANT_API_KEY") or None
+    qclient = QdrantClient(url=qdrant_url, api_key=qdrant_api_key)
+
+    # Ensure the collection exists with 1536 OpenAI dim
+    collection_name = "nlm_shadow_hybrid"
+    try:
+        qclient.get_collection(collection_name)
+    except Exception:
+        logger.info("Creating Qdrant collection %s (vector_size=1536)", collection_name)
+        qclient.create_collection(
+            collection_name=collection_name,
+            vectors_config=VectorParams(size=1536, distance=Distance.COSINE),
+        )
+
+    points: list[PointStruct] = []
+    for idx, raw in enumerate(raw_claims, start=1):
+        claim_text = (raw.get("claim") or "").strip()
+        if len(claim_text) < 10:
+            continue
+
+        # 2. validate
+        validation = (
+            _validate_with_deepseek(claim_text, deepseek_key)
+            if deepseek_key else
+            {"valid": False, "confidence": 0.0, "notes": "no_validator_configured"}
+        )
+        if not validation["valid"] or validation["confidence"] < 0.5:
+            continue
+        summary["claims_validated"] += 1
+
+        # 3. embed
+        vec = _embed_openai(claim_text, openai_key)
+        if vec is None:
+            summary["errors"].append(f"embed_failed: {claim_text[:40]}")
+            continue
+
+        # 4. build chunk + upsert
+        chunk = NLMShadowChunk(
+            chunk_id=f"nlm_shadow_{nb['label']}_{run_id}_{idx:03d}",
+            claim_text=claim_text,
+            nb_id=nb["id"],
+            nb_label=nb["label"],
+            nlm_source_id=raw.get("source_id"),
+            extraction_run_id=run_id,
+            deepseek_validated=True,
+            deepseek_confidence=validation["confidence"],
+            deepseek_notes=validation["notes"] or None,
+        )
+        points.append(PointStruct(
+            id=str(uuid.uuid4()),
+            vector=vec,
+            payload=chunk.to_qdrant_payload(),
+        ))
+
+    if points:
+        qclient.upsert(collection_name=collection_name, points=points)
+        summary["claims_emitted"] = len(points)
+    summary["status"] = "ok" if points else "no_valid_claims"
+    summary["completed_at"] = datetime.now(tz=timezone.utc).isoformat()
+    return summary
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description="Sprint 2 NLM Shadow Graphing extractor")
+    g = parser.add_mutually_exclusive_group(required=True)
+    g.add_argument("--notebook", help="Single domain (e.g. immigration, company, tax)")
+    g.add_argument("--all-domains", action="store_true",
+                   help="Run extractor for all 5 domains sequentially")
+    parser.add_argument("--limit", type=int, default=20, help="Max claims per notebook")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Skip CLI calls; print plan only")
+    args = parser.parse_args()
+
+    if args.notebook:
+        domains = [args.notebook]
+    else:
+        domains = list(DOMAIN_TO_NB.keys())
+
+    overall: list[dict[str, Any]] = []
+    for domain in domains:
+        result = extract_for_notebook(domain, limit=args.limit, dry_run=args.dry_run)
+        overall.append(result)
+        print(json.dumps(result, indent=2, default=str))
+        # Throttle between NBs to avoid CLI rate limits
+        if not args.dry_run and len(domains) > 1:
+            time.sleep(5)
+
+    # Final summary line for cron logs
+    total_emitted = sum(r.get("claims_emitted", 0) for r in overall)
+    print(f"\n=== Shadow extraction complete: {total_emitted} claim(s) emitted across {len(domains)} domain(s) ===")
+    sys.exit(0 if total_emitted > 0 or all(r.get("status") == "dry_run" for r in overall) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_nlm_shadow_extractor.py
+++ b/scripts/tests/test_nlm_shadow_extractor.py
@@ -1,0 +1,99 @@
+"""Tests for nlm_shadow_extractor.py — Sprint 2 Shadow Graphing.
+
+Covers the parser/dispatch logic without touching NLM CLI, DeepSeek API,
+OpenAI API, or Qdrant.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_extractor():
+    """Load scripts/nlm_shadow_extractor.py as a module."""
+    p = Path(__file__).resolve().parents[2] / "scripts" / "nlm_shadow_extractor.py"
+    spec = importlib.util.spec_from_file_location("shadow_extractor", p)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["shadow_extractor"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ── _parse_json_list ─────────────────────────────────────────────────────────
+
+def test_parse_json_list_plain():
+    ext = _load_extractor()
+    answer = '[{"claim": "PT PMA needs IDR 10B", "source_id": "s1"}]'
+    out = ext._parse_json_list(answer)
+    assert len(out) == 1
+    assert out[0]["claim"].startswith("PT PMA")
+
+
+def test_parse_json_list_markdown_wrapped():
+    ext = _load_extractor()
+    answer = '```json\n[{"claim": "VOA tarif Rp500k", "source_id": "x"}]\n```'
+    out = ext._parse_json_list(answer)
+    assert len(out) == 1
+    assert "VOA" in out[0]["claim"]
+
+
+def test_parse_json_list_with_prose_around():
+    ext = _load_extractor()
+    answer = (
+        "Sure, here are the claims:\n"
+        '[{"claim": "KITAS valid 1y", "source_id": "a"},'
+        ' {"claim": "renew at +30 days", "source_id": "b"}]\n'
+        "Let me know if you need more."
+    )
+    out = ext._parse_json_list(answer)
+    assert len(out) == 2
+
+
+def test_parse_json_list_no_list_returns_empty():
+    ext = _load_extractor()
+    out = ext._parse_json_list("Sorry I cannot answer.")
+    assert out == []
+
+
+def test_parse_json_list_malformed_returns_empty():
+    ext = _load_extractor()
+    out = ext._parse_json_list('[{"claim": "broken json missing brace"')
+    assert out == []
+
+
+def test_parse_json_list_drops_items_without_claim_key():
+    ext = _load_extractor()
+    answer = '[{"claim": "good"}, {"source_id": "no_claim"}, {"claim": "also good"}]'
+    out = ext._parse_json_list(answer)
+    assert len(out) == 2
+    assert all("claim" in o for o in out)
+
+
+# ── extract_for_notebook unknown_domain path ─────────────────────────────────
+
+def test_extract_for_notebook_unknown_domain():
+    ext = _load_extractor()
+    res = ext.extract_for_notebook("not-a-domain", dry_run=True)
+    assert res["status"] == "unknown_domain"
+    assert res["claims_emitted"] == 0
+
+
+def test_extract_for_notebook_dry_run_known_domain():
+    ext = _load_extractor()
+    res = ext.extract_for_notebook("immigration", dry_run=True)
+    assert res["status"] == "dry_run"
+    assert res["domain"] == "immigration"
+    assert res["notebook_id"] == "cff93ab0-813a-42f2-a8de-36987e724271"
+    assert "run_id" in res
+
+
+# ── domain registry coverage ─────────────────────────────────────────────────
+
+def test_all_domains_have_required_fields():
+    ext = _load_extractor()
+    for domain, data in ext.DOMAIN_TO_NB.items():
+        assert "id" in data and len(data["id"]) > 30
+        assert "label" in data
+        assert "extract_prompt_subject" in data


### PR DESCRIPTION
## Summary

Sprint 2 dell'NLM elevation plan v2. Aggiunge i 3 pezzi minimi per il pattern Shadow Graphing — claims estratti offline da NotebookLM, validati da DeepSeek, embedded da OpenAI, persistiti in una nuova collection Qdrant. **Tutto opt-in**: zero impatto sul runtime RAG attuale finché non si attiva il cron e si wire-up il retrieval.

## Three pieces

### 1. `backend/core/collection_registry.py`
Nuova canonical logical collection: `nlm_shadow_hybrid`. Mapping fisico identità (no resolution surprises). Commento spiega perché serve uno schema dedicato (non riusare `HierarchicalChunk` che è rigido per consumer del retrieval legale).

### 2. `backend/core/nlm_shadow_chunk.py` (nuovo)
`NLMShadowChunk` Pydantic model:
- **Provenance**: `nb_id`, `nb_label`, `nlm_source_id`, `extraction_run_id`, `extracted_at`
- **DeepSeek validation**: `deepseek_validated`, `deepseek_confidence` (0..1), `deepseek_notes`
- **Lifecycle**: `source="nlm_shadow"`, `ttl_hours=72` soft default
- **Round-trip safe**: `to_qdrant_payload()` flatten datetime to ISO string, empty optional fields stored as empty string and rehydrated to None
- 7/7 test PASS

### 3. `scripts/nlm_shadow_extractor.py` (nuovo, executable)
CLI cron-runnable:
```bash
python scripts/nlm_shadow_extractor.py --notebook tax --limit 30
python scripts/nlm_shadow_extractor.py --all-domains [--dry-run]
```

Pipeline per notebook:
1. **Extract**: `nlm notebook query` con prompt JSON-strict, parser tollerante (markdown wrap, prose around)
2. **Validate**: ogni claim al DeepSeek Reasoner; salta se `confidence < 0.5`
3. **Embed**: OpenAI `text-embedding-3-small` (FROZEN)
4. **Upsert**: NLMShadowChunk in `nlm_shadow_hybrid` con UUID point id

Auto-crea la Qdrant collection alla prima run (1536 dim cosine). 9/9 test PASS sul parser/dispatch.

## Vincoli rispettati
- **Anthropic OAuth-only (Golden Rule #13)**: zero chiamate Anthropic API. NLM CLI usa la subscription Max OAuth dell'utente.
- **DeepSeek + OpenAI**: paid per-token allowed (regola Anthropic-specifica).
- **Embedding FROZEN** `text-embedding-3-small` 1536 dim.

## Test plan
- [x] `pytest test_nlm_shadow_chunk.py` → 7/7
- [x] `pytest test_nlm_shadow_extractor.py` → 9/9
- [x] Dry-run `--all-domains` → plan per 5 domini, exit 0
- [ ] Live run staging: serve `DEEPSEEK_API_KEY`, `OPENAI_API_KEY`, `QDRANT_URL`
- [ ] PR successiva: wire-up retrieval `nlm_shadow_hybrid` nel runtime orchestrator

## Catena Sprint 0/1/2 NLM elevation
- PR #243 — Sprint 0 fix
- PR #244 — truth_dashboard + S0.2 diagnosis
- PR #245 — T16 sentinel ARCH-9 + S1.2 verify_ingestion
- PR #246 — S1.3 oracle stale gate
- PR (qui) — Sprint 2 Shadow Graphing pezzi base

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)