### PR TITLE
feat(nlm): activation wrapper scripts (committed but not scheduled)

### DIFF
--- a/scripts/nlm_activation/README.md
+++ b/scripts/nlm_activation/README.md
@@ -1,0 +1,76 @@
+# scripts/nlm_activation/
+
+Wrapper scripts for the NLM elevation activation runbook
+(`docs/operations/NLM_ELEVATION_ACTIVATION.md`).
+
+Each file is **committed but not scheduled**. To activate any one of them,
+add the corresponding crontab entry by hand — see the header comment of
+each script for the exact `crontab -e` line.
+
+| Script | Stage | Cron schedule (when activated) | Cost / risk |
+|---|---|---|---|
+| `truth_dashboard_digest.sh` | 1+ | `0 7 * * *` | Free, read-only |
+| `run_canary_all.sh` | 3 | `30 4 * * 1-6` | NLM CLI cost (OAuth) |
+| `run_cep_daily.sh` | 5 | `0 6 * * *` | DeepSeek ~$0.50/run |
+| `collect_cep_answers.py` | 5 | (called by run_cep_daily.sh) | Free |
+| `nlm_shadow_run_all.sh` | 6 | `30 3 * * 1-6` | DeepSeek + OpenAI ~$3/night |
+
+## Why not scheduled automatically
+
+The runbook prescribes a sequenced rollout (Stage 1 → 7) where each stage
+must be observed for hours/days before the next can begin. Pre-installing
+crontab entries would bypass that gating and risk:
+- Stage 6 shadow extractor running before CEP baseline is established →
+  no way to detect quality regression.
+- Stage 4 oracle gate firing before canary verifications populate the
+  freshness state → all queries get refused.
+- Cost spikes (DeepSeek $50+/month) if shadow extractor runs for weeks
+  before being needed.
+
+## Activation order
+
+Read `docs/operations/NLM_ELEVATION_ACTIVATION.md` first. The order is:
+
+1. Merge all 6 PRs (#243-#248 series).
+2. Stage 1: deploy. Wait 24h. No cron added yet.
+3. Stage 2: heartbeat truth automatic — no cron needed.
+4. Stage 2 day 2: enable `truth_dashboard_digest.sh`. Read for 48h to
+   build trust in the signal.
+5. Stage 3: enable `run_canary_all.sh`. Wait 7 days for canaries to
+   stabilize.
+6. Stage 4: `fly secrets set NLM_ENFORCE_FRESHNESS=1`.
+7. Stage 5: enable `run_cep_daily.sh`. Wait 7 days for CEP baseline.
+8. Stage 6: enable `nlm_shadow_run_all.sh`. Wait 7 days for collection
+   to fill.
+9. Stage 7: `fly secrets set NLM_SHADOW_RETRIEVAL_ENABLED=1`.
+
+Total time from Stage 1 to Stage 7: minimum ~25 days.
+
+## Rollback
+
+To disable any cron: `crontab -e`, comment out the line, save. The
+underlying scripts and code stay; only the schedule disappears. The two
+env-var-gated stages (4 and 7) roll back via `fly secrets unset`.
+
+## Bypass for testing
+
+Each script supports manual invocation outside cron:
+
+```bash
+# Test canary on one NB
+PYTHONPATH=. python -m apps.evaluator.nlm_deep_research.freshness_monitor \
+    --verify-ingestion <NOTEBOOK_UUID> --no-cleanup
+
+# Test CEP cycle without writing report
+PYTHONPATH=. python -m apps.evaluator.cep.run_cep --dry-run
+
+# Test shadow extractor on one domain
+PYTHONPATH=. python scripts/nlm_shadow_extractor.py --notebook tax --limit 5
+
+# Print truth dashboard
+PYTHONPATH=. python -m apps.evaluator.nlm_deep_research.heartbeat_monitor --truth
+```
+
+All four manual paths work at any stage and never modify production state
+in destructive ways (canary cleans up its source, dry-run skips writes,
+extractor only upserts to its dedicated collection).

--- a/scripts/nlm_activation/collect_cep_answers.py
+++ b/scripts/nlm_activation/collect_cep_answers.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Collect RAG answers for the CEP golden set — Stage 5 of activation runbook.
+
+Iterates the golden_v20260425.json query list, fires each against the prod
+RAG endpoint, and emits a JSON file mapping query_id -> answer_text suitable
+for run_cep.py --answers-file.
+
+Usage:
+    python scripts/nlm_activation/collect_cep_answers.py \\
+        --golden apps/evaluator/cep/golden_v20260425.json \\
+        --endpoint https://nuzantara-rag.fly.dev \\
+        --out /tmp/cep-answers-$(date +%F).json
+
+Auth: set NUZANTARA_RAG_TOKEN env var if the endpoint requires Bearer auth.
+
+Throttles 2s between requests to be polite to the prod endpoint. Tolerates
+per-query failures (logs + records empty answer; CEP grader treats empty as
+miss with notes='no answer').
+
+Vincoli rispettati:
+  - Anthropic OAuth-only (Golden Rule #13): no Anthropic API key.
+  - Pure HTTP client to YOUR own RAG endpoint — no third-party API.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("collect_cep_answers")
+
+
+def fetch_answer(
+    endpoint: str,
+    query: str,
+    *,
+    token: str | None = None,
+    timeout: int = 30,
+) -> str:
+    """POST a query to the RAG endpoint, return the answer text.
+
+    Endpoint is assumed to expose POST /api/rag/query with payload:
+      {"query": "..."}
+    and response shape (worst case, defensive parsing):
+      {"answer": "..."} OR {"value": {"answer": "..."}} OR {"text": "..."}
+    """
+    body = json.dumps({"query": query}).encode()
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    req = urllib.request.Request(
+        endpoint.rstrip("/") + "/api/rag/query",
+        data=body,
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            payload = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        logger.warning("HTTP %d on query %r: %s", exc.code, query[:50], exc.reason)
+        return ""
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        logger.warning("Fetch failed for %r: %s", query[:50], exc)
+        return ""
+
+    # Defensive: try common shapes
+    if isinstance(payload, dict):
+        for key in ("answer", "text", "response"):
+            v = payload.get(key)
+            if isinstance(v, str) and v:
+                return v
+        # Wrapped under "value"
+        inner = payload.get("value")
+        if isinstance(inner, dict):
+            for key in ("answer", "text", "response"):
+                v = inner.get(key)
+                if isinstance(v, str) and v:
+                    return v
+    return ""
+
+
+def collect(
+    golden_path: Path,
+    endpoint: str,
+    *,
+    token: str | None = None,
+    delay_seconds: float = 2.0,
+) -> dict[str, str]:
+    """Iterate the golden set and return {query_id: answer}."""
+    golden = json.loads(golden_path.read_text())
+    answers: dict[str, str] = {}
+    total = sum(len(qs) for qs in golden.get("domains", {}).values())
+    idx = 0
+    for domain, queries in golden.get("domains", {}).items():
+        for q in queries:
+            idx += 1
+            qid = q["id"]
+            text = q["query"]
+            logger.info("[%d/%d] %s/%s", idx, total, domain, qid)
+            answers[qid] = fetch_answer(endpoint, text, token=token)
+            time.sleep(delay_seconds)
+    return answers
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(
+        description="Collect RAG answers for CEP grading (Stage 5)"
+    )
+    parser.add_argument(
+        "--golden",
+        default="apps/evaluator/cep/golden_v20260425.json",
+        help="Path to versioned golden set",
+    )
+    parser.add_argument(
+        "--endpoint",
+        default=os.environ.get("NUZANTARA_RAG_ENDPOINT", "https://nuzantara-rag.fly.dev"),
+        help="RAG endpoint base URL (env NUZANTARA_RAG_ENDPOINT, default Fly prod)",
+    )
+    parser.add_argument(
+        "--out", required=True,
+        help="Output JSON file (query_id -> answer_text) for run_cep --answers-file",
+    )
+    parser.add_argument(
+        "--delay", type=float, default=2.0,
+        help="Seconds between queries (rate limiting, default 2.0)",
+    )
+    args = parser.parse_args()
+
+    token = os.environ.get("NUZANTARA_RAG_TOKEN") or None
+    answers = collect(
+        Path(args.golden),
+        args.endpoint,
+        token=token,
+        delay_seconds=args.delay,
+    )
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(answers, ensure_ascii=False, indent=2))
+
+    non_empty = sum(1 for v in answers.values() if v)
+    logger.info("Wrote %d answers (%d non-empty) to %s", len(answers), non_empty, out_path)
+    sys.exit(0 if non_empty > 0 else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/nlm_activation/nlm_shadow_run_all.sh
+++ b/scripts/nlm_activation/nlm_shadow_run_all.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# nlm_shadow_run_all.sh — Stage 6 of NLM_ELEVATION_ACTIVATION.md.
+#
+# Nightly Shadow Graphing extraction: ask NLM for atomic claims per domain,
+# validate each with DeepSeek, embed via OpenAI, upsert into Qdrant
+# collection nlm_shadow_hybrid. Runs after the NB-N domain pipelines have
+# completed at ~02:30-02:50 WITA.
+#
+# Schedule (manual install when ready for Stage 6):
+#   crontab -e
+#   30 3 * * 1-6 /bin/bash /Users/nuzantara/scripts/cron-runner.sh \
+#       /Users/nuzantara/Desktop/nuzantara/scripts/nlm_activation/nlm_shadow_run_all.sh \
+#       >> /tmp/cron-shadow-extractor.log 2>&1
+#
+# Env required:
+#   DEEPSEEK_API_KEY     — claim validation (~$0.01 × 50 claims × 5 NB = ~$2.50/night)
+#   OPENAI_API_KEY       — embedding (text-embedding-3-small, FROZEN)
+#   QDRANT_URL           — default http://localhost:6333
+#   QDRANT_API_KEY       — only for cloud Qdrant
+#
+# DO NOT enable until Stage 5 (CEP baseline) has 7+ days of measurements.
+# This populates the shadow collection but no caller reads from it until
+# Stage 7 (NLM_SHADOW_RETRIEVAL_ENABLED=1).
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$HOME/Desktop/nuzantara}"
+LOG_FILE="$HOME/.openclaw/logs/nlm_shadow_extractor.log"
+mkdir -p "$(dirname "$LOG_FILE")"
+
+cd "$REPO_ROOT"
+
+if [ -d apps/backend-rag/.venv ]; then
+    PYTHON="$REPO_ROOT/apps/backend-rag/.venv/bin/python"
+elif [ -d apps/backend-rag/venv ]; then
+    PYTHON="$REPO_ROOT/apps/backend-rag/venv/bin/python"
+else
+    echo "ERROR: no venv found in apps/backend-rag/" >&2
+    exit 1
+fi
+
+# Load secrets (DEEPSEEK_API_KEY, OPENAI_API_KEY, QDRANT_*)
+# These files are user-managed and may not exist on Air — that's fine,
+# the extractor itself will refuse to run without the keys.
+[ -f "$HOME/.ai_keys.env" ] && set -a && source "$HOME/.ai_keys.env" && set +a
+[ -f "$HOME/.nuzantara-secrets.env" ] && set -a && source "$HOME/.nuzantara-secrets.env" && set +a
+
+# Sanity check before paying for API calls
+if [ -z "${DEEPSEEK_API_KEY:-}" ]; then
+    echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [SKIP] DEEPSEEK_API_KEY not set — skipping" >> "$LOG_FILE"
+    exit 0
+fi
+if [ -z "${OPENAI_API_KEY:-}" ]; then
+    echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [SKIP] OPENAI_API_KEY not set — skipping" >> "$LOG_FILE"
+    exit 0
+fi
+
+echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [START] shadow extraction — all 5 domains" >> "$LOG_FILE"
+
+# Run the extractor across 5 domains. The script itself handles per-domain
+# isolation (one bad domain doesn't kill the others) and the 5s throttle
+# between NBs.
+PYTHONPATH=. "$PYTHON" scripts/nlm_shadow_extractor.py --all-domains --limit 25 >> "$LOG_FILE" 2>&1
+EXIT_CODE=$?
+
+echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [DONE] shadow extraction exit=$EXIT_CODE" >> "$LOG_FILE"
+
+# ARCH-9 heartbeat so truth_dashboard can verify the cron actually ran
+if [ "$EXIT_CODE" -eq 0 ]; then
+    PYTHONPATH=. "$PYTHON" -m apps.evaluator.nlm_deep_research.heartbeat_monitor \
+        --record "shadow_extractor" 2>/dev/null || true
+fi
+
+# Telegram alert only on failure (success is silent — daily extractor is
+# operational background)
+if [ "$EXIT_CODE" -ne 0 ] && [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_OWNER_CHAT_ID:-}" ]; then
+    MSG="🔴 NLM Shadow extractor FAILED (exit $EXIT_CODE) — see $LOG_FILE"
+    curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+        -d "chat_id=${TELEGRAM_OWNER_CHAT_ID}" \
+        -d "text=${MSG}" >/dev/null 2>&1 || true
+fi
+
+exit "$EXIT_CODE"

--- a/scripts/nlm_activation/run_canary_all.sh
+++ b/scripts/nlm_activation/run_canary_all.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# run_canary_all.sh — Stage 3 of NLM_ELEVATION_ACTIVATION.md.
+#
+# Iterates verify_ingestion_uuid over the 5 NB domain notebooks. Persists
+# results to apps/evaluator/nlm_deep_research/freshness_monitor_state.json
+# under ingestion_verifications[notebook_id]. Sentinel + oracle gate read
+# this state.
+#
+# Schedule (manual install when ready for Stage 3):
+#   crontab -e
+#   30 4 * * 1-6 /bin/bash /Users/nuzantara/scripts/cron-runner.sh \
+#       /Users/nuzantara/Desktop/nuzantara/scripts/nlm_activation/run_canary_all.sh \
+#       >> /tmp/cron-canary.log 2>&1
+#
+# Prerequisites:
+#   - Sprint 0/1 PRs merged (claim_extractor fix, bridge timeout, S1.2 verify_ingestion)
+#   - `nlm` CLI authenticated on Pro (user-level OAuth, not Anthropic)
+#   - 5min cooldown between NB queries to avoid NLM rate limit
+#
+# DO NOT enable this until Stage 2 (heartbeat truth) is stable for 48h.
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$HOME/Desktop/nuzantara}"
+LOG_FILE="$HOME/.openclaw/logs/nlm_canary.log"
+mkdir -p "$(dirname "$LOG_FILE")"
+
+cd "$REPO_ROOT"
+
+if [ -d apps/backend-rag/.venv ]; then
+    PYTHON="$REPO_ROOT/apps/backend-rag/.venv/bin/python"
+elif [ -d apps/backend-rag/venv ]; then
+    PYTHON="$REPO_ROOT/apps/backend-rag/venv/bin/python"
+else
+    echo "ERROR: no venv found in apps/backend-rag/" >&2
+    exit 1
+fi
+
+echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [START] NLM ingestion canary — 5 domains" >> "$LOG_FILE"
+
+# 5 NB domain UUIDs (canonical, mirrors backend nlm_notebook_registry).
+# Update here if registry changes.
+declare -a NBS=(
+    "cff93ab0-813a-42f2-a8de-36987e724271:NB-2 Immigration"
+    "933509f9-1561-403d-bd44-4a7a67a36df2:NB-3 Company"
+    "d4b2eedb-9863-4a1a-81ff-a11b0b45d853:NB-4 Tax"
+    "d9438180-5e63-4e2a-a473-6061101f6a8d:NB-5 Property"
+    "85207af3-352f-4554-8d2a-18f42cc541ba:NB-6 Operations"
+)
+
+OK_COUNT=0
+FAIL_COUNT=0
+
+for entry in "${NBS[@]}"; do
+    NB_ID="${entry%%:*}"
+    NB_LABEL="${entry##*:}"
+    echo "$(date -u '+%H:%M:%S') canary $NB_LABEL ($NB_ID)" >> "$LOG_FILE"
+
+    # The canary uploads a UUID-tagged source, queries for it, cleans up.
+    # Exit code 0 = status=ok, 1 = stale|error.
+    if PYTHONPATH=. "$PYTHON" -m apps.evaluator.nlm_deep_research.freshness_monitor \
+            --verify-ingestion "$NB_ID" >> "$LOG_FILE" 2>&1; then
+        OK_COUNT=$((OK_COUNT + 1))
+    else
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        # Per-NB Telegram alert if creds set
+        if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_OWNER_CHAT_ID:-}" ]; then
+            MSG="🔴 NLM canary FAIL $NB_LABEL — see $LOG_FILE"
+            curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+                -d "chat_id=${TELEGRAM_OWNER_CHAT_ID}" \
+                -d "text=${MSG}" >/dev/null 2>&1 || true
+        fi
+    fi
+
+    # Cooldown to avoid hitting NLM rate limit (the bridge has soft limits).
+    sleep 30
+done
+
+echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [DONE] canaries: ok=$OK_COUNT fail=$FAIL_COUNT" >> "$LOG_FILE"
+
+# Aggregate alert if 2+ failed
+if [ "$FAIL_COUNT" -ge 2 ] && [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_OWNER_CHAT_ID:-}" ]; then
+    MSG="🚨 NLM canary aggregate: $FAIL_COUNT/5 NB stale — oracle gate may refuse queries"
+    curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+        -d "chat_id=${TELEGRAM_OWNER_CHAT_ID}" \
+        -d "text=${MSG}" >/dev/null 2>&1 || true
+fi
+
+# Exit 0 even if individual NB failed — overall script succeeded by running
+# all 5. Failure tracking is in the state file + Telegram. This avoids the
+# sentinel marking the whole script as failing when only 1 NB had an issue.
+exit 0

--- a/scripts/nlm_activation/run_cep_daily.sh
+++ b/scripts/nlm_activation/run_cep_daily.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# run_cep_daily.sh — Stage 5 of NLM_ELEVATION_ACTIVATION.md.
+#
+# Daily CEP cycle: collect prod RAG answers for the 50 golden queries,
+# grade them with DeepSeek Reasoner against the rubric, write a CSV
+# report, and alert Telegram if hit rate <80%.
+#
+# Schedule (manual install when ready for Stage 5):
+#   crontab -e
+#   0 6 * * * /bin/bash /Users/nuzantara/scripts/cron-runner.sh \
+#       /Users/nuzantara/Desktop/nuzantara/scripts/nlm_activation/run_cep_daily.sh \
+#       >> /tmp/cron-cep.log 2>&1
+#
+# Env required:
+#   DEEPSEEK_API_KEY     — for grading (~$0.50/run, ~$15/month)
+#   NUZANTARA_RAG_ENDPOINT (optional, default https://nuzantara-rag.fly.dev)
+#   NUZANTARA_RAG_TOKEN  — only if endpoint requires auth
+#
+# DO NOT enable until Stage 4 (oracle gate) is stable for ≥7 days, OR
+# explicitly run in observe-only mode in parallel with Stage 4.
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$HOME/Desktop/nuzantara}"
+LOG_FILE="$HOME/.openclaw/logs/nlm_cep.log"
+mkdir -p "$(dirname "$LOG_FILE")"
+
+cd "$REPO_ROOT"
+
+if [ -d apps/backend-rag/.venv ]; then
+    PYTHON="$REPO_ROOT/apps/backend-rag/.venv/bin/python"
+elif [ -d apps/backend-rag/venv ]; then
+    PYTHON="$REPO_ROOT/apps/backend-rag/venv/bin/python"
+else
+    echo "ERROR: no venv found in apps/backend-rag/" >&2
+    exit 1
+fi
+
+DATE_STAMP=$(date +%Y-%m-%d)
+ANSWERS_FILE="/tmp/cep-answers-${DATE_STAMP}.json"
+REPORT_FILE="/tmp/cep-report-${DATE_STAMP}.csv"
+SUMMARY_FILE="/tmp/cep-summary-${DATE_STAMP}.json"
+
+echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [START] CEP daily $DATE_STAMP" >> "$LOG_FILE"
+
+# Step 1: collect answers from prod endpoint
+echo "$(date -u '+%H:%M:%S') Step 1/2: collecting answers from prod RAG..." >> "$LOG_FILE"
+if ! PYTHONPATH=. "$PYTHON" scripts/nlm_activation/collect_cep_answers.py \
+        --golden apps/evaluator/cep/golden_v20260425.json \
+        --out "$ANSWERS_FILE" >> "$LOG_FILE" 2>&1; then
+    echo "$(date -u '+%H:%M:%S') [FAIL] answer collection failed" >> "$LOG_FILE"
+    if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_OWNER_CHAT_ID:-}" ]; then
+        MSG="🔴 CEP daily FAILED at answer collection — see $LOG_FILE"
+        curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d "chat_id=${TELEGRAM_OWNER_CHAT_ID}" \
+            -d "text=${MSG}" >/dev/null 2>&1 || true
+    fi
+    exit 1
+fi
+
+# Step 2: grade with DeepSeek
+echo "$(date -u '+%H:%M:%S') Step 2/2: grading with DeepSeek..." >> "$LOG_FILE"
+SUMMARY_RAW=$(PYTHONPATH=. "$PYTHON" -m apps.evaluator.cep.run_cep \
+    --golden apps/evaluator/cep/golden_v20260425.json \
+    --answers-file "$ANSWERS_FILE" \
+    --report "$REPORT_FILE" 2>>"$LOG_FILE")
+EXIT_CODE=$?
+echo "$SUMMARY_RAW" > "$SUMMARY_FILE"
+echo "$SUMMARY_RAW" >> "$LOG_FILE"
+
+# Parse hit_rate using python (jq may not be available everywhere)
+HIT_RATE=$(echo "$SUMMARY_RAW" | "$PYTHON" -c "import json,sys; print(json.load(sys.stdin).get('hit_rate', 0))" 2>/dev/null || echo "0")
+
+echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [DONE] CEP daily — hit_rate=$HIT_RATE exit=$EXIT_CODE" >> "$LOG_FILE"
+
+# Telegram daily summary (always, not just on failure — operator wants trend)
+if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_OWNER_CHAT_ID:-}" ]; then
+    if [ "$EXIT_CODE" -eq 0 ]; then
+        EMOJI="🟢"
+    else
+        EMOJI="🔴"
+    fi
+    MSG="${EMOJI} CEP $DATE_STAMP — hit_rate=$HIT_RATE — report=$REPORT_FILE"
+    curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+        -d "chat_id=${TELEGRAM_OWNER_CHAT_ID}" \
+        -d "text=${MSG}" >/dev/null 2>&1 || true
+fi
+
+# Cleanup answers file (keep report + summary for trend analysis)
+rm -f "$ANSWERS_FILE"
+
+exit "$EXIT_CODE"

--- a/scripts/nlm_activation/truth_dashboard_digest.sh
+++ b/scripts/nlm_activation/truth_dashboard_digest.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# truth_dashboard_digest.sh — daily honest-monitoring summary to Telegram.
+#
+# Runs heartbeat_monitor --truth and sends the resulting table to Telegram
+# every morning. This is the operational counterpart to PR #244's
+# truth_dashboard CLI: instead of relying on Antonello to ssh in and run
+# the command, the digest is pushed daily so silent failures (GATEWAY_LIES,
+# DEAD pipelines) become visible without manual intervention.
+#
+# Schedule (manual install when ready):
+#   crontab -e
+#   0 7 * * * /bin/bash /Users/nuzantara/scripts/cron-runner.sh \
+#       /Users/nuzantara/Desktop/nuzantara/scripts/nlm_activation/truth_dashboard_digest.sh \
+#       >> /tmp/cron-truth-digest.log 2>&1
+#
+# Safe to enable from Stage 1 onwards — it only reads, never writes.
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$HOME/Desktop/nuzantara}"
+LOG_FILE="$HOME/.openclaw/logs/nlm_truth_digest.log"
+mkdir -p "$(dirname "$LOG_FILE")"
+
+cd "$REPO_ROOT"
+
+if [ -d apps/backend-rag/.venv ]; then
+    PYTHON="$REPO_ROOT/apps/backend-rag/.venv/bin/python"
+elif [ -d apps/backend-rag/venv ]; then
+    PYTHON="$REPO_ROOT/apps/backend-rag/venv/bin/python"
+else
+    echo "ERROR: no venv found in apps/backend-rag/" >&2
+    exit 1
+fi
+
+DATE_STAMP=$(date '+%Y-%m-%d %H:%M WITA')
+
+# Capture the dashboard output
+TABLE=$(PYTHONPATH=. "$PYTHON" -m apps.evaluator.nlm_deep_research.heartbeat_monitor --truth 2>&1 || true)
+
+echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') === Truth digest ===" >> "$LOG_FILE"
+echo "$TABLE" >> "$LOG_FILE"
+
+# Count the non-OK verdicts to highlight in the message header
+PROBLEM_COUNT=$(echo "$TABLE" | grep -cE "GATEWAY_LIES|LOG_NO_HEARTBEAT|DEAD|DEGRADED" || true)
+
+# Send to Telegram (only if creds set and there's something to report)
+if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_OWNER_CHAT_ID:-}" ]; then
+    if [ "$PROBLEM_COUNT" -gt 0 ]; then
+        HEADER="⚠️ NLM truth $DATE_STAMP — $PROBLEM_COUNT problem(s)"
+    else
+        HEADER="✅ NLM truth $DATE_STAMP — all OK"
+    fi
+
+    # Telegram message limit is 4096 chars; keep the table compact
+    BODY=$(echo "$TABLE" | head -25)
+    MSG="${HEADER}"$'\n'"\`\`\`"$'\n'"${BODY}"$'\n'"\`\`\`"
+
+    curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+        -d "chat_id=${TELEGRAM_OWNER_CHAT_ID}" \
+        -d "parse_mode=Markdown" \
+        --data-urlencode "text=${MSG}" >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/scripts/tests/test_collect_cep_answers.py
+++ b/scripts/tests/test_collect_cep_answers.py
@@ -1,0 +1,111 @@
+"""Tests for scripts/nlm_activation/collect_cep_answers.py — defensive
+parsing of the prod RAG endpoint response shapes.
+"""
+
+import importlib.util
+import json
+import sys
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _load_collector():
+    p = Path(__file__).resolve().parents[2] / "scripts" / "nlm_activation" / "collect_cep_answers.py"
+    spec = importlib.util.spec_from_file_location("collect_cep", p)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["collect_cep"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict):
+        self._buf = BytesIO(json.dumps(payload).encode())
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self):
+        return self._buf.read()
+
+
+def test_fetch_answer_top_level_answer_key():
+    cep = _load_collector()
+    with patch.object(cep.urllib.request, "urlopen", return_value=_FakeResponse({"answer": "OK!"})):
+        assert cep.fetch_answer("http://x", "q") == "OK!"
+
+
+def test_fetch_answer_nested_under_value():
+    """Some NLM CLI wrappers return {value: {answer: ...}} — accept it."""
+    cep = _load_collector()
+    payload = {"value": {"answer": "wrapped answer"}}
+    with patch.object(cep.urllib.request, "urlopen", return_value=_FakeResponse(payload)):
+        assert cep.fetch_answer("http://x", "q") == "wrapped answer"
+
+
+def test_fetch_answer_text_alias():
+    """Tolerates {'text': ...} shape if the endpoint changes."""
+    cep = _load_collector()
+    with patch.object(cep.urllib.request, "urlopen", return_value=_FakeResponse({"text": "alias"})):
+        assert cep.fetch_answer("http://x", "q") == "alias"
+
+
+def test_fetch_answer_unknown_shape_returns_empty():
+    cep = _load_collector()
+    with patch.object(cep.urllib.request, "urlopen", return_value=_FakeResponse({"weird": True})):
+        assert cep.fetch_answer("http://x", "q") == ""
+
+
+def test_fetch_answer_http_error_returns_empty():
+    cep = _load_collector()
+    err = cep.urllib.error.HTTPError("http://x", 500, "boom", {}, None)
+    with patch.object(cep.urllib.request, "urlopen", side_effect=err):
+        assert cep.fetch_answer("http://x", "q") == ""
+
+
+def test_fetch_answer_timeout_returns_empty():
+    cep = _load_collector()
+    with patch.object(cep.urllib.request, "urlopen", side_effect=TimeoutError("slow")):
+        assert cep.fetch_answer("http://x", "q") == ""
+
+
+def test_collect_iterates_synthetic_golden(tmp_path):
+    """collect() walks every (domain, query) tuple in the golden file.
+
+    Uses a synthetic golden file local to the test rather than depending
+    on the real apps/evaluator/cep/golden_v20260425.json, which lives in
+    a separate PR. This keeps the test self-contained.
+    """
+    cep = _load_collector()
+    golden_path = tmp_path / "synthetic_golden.json"
+    golden_path.write_text(json.dumps({
+        "version": "test",
+        "domains": {
+            "immigration": [
+                {"id": "imm-01", "query": "Q1", "required_facts": ["x"], "tier": 1},
+                {"id": "imm-02", "query": "Q2", "required_facts": ["y"], "tier": 1},
+            ],
+            "tax": [
+                {"id": "tax-01", "query": "Q3", "required_facts": ["z"], "tier": 1},
+            ],
+        },
+    }))
+
+    called = []
+
+    def fake_fetch(endpoint, query, *, token=None, timeout=30):
+        called.append(query)
+        return f"FAKE-ANSWER for {query}"
+
+    with patch.object(cep, "fetch_answer", side_effect=fake_fetch):
+        answers = cep.collect(golden_path, "http://x", token=None, delay_seconds=0)
+
+    assert len(answers) == 3
+    assert {"imm-01", "imm-02", "tax-01"} == set(answers.keys())
+    assert all(v.startswith("FAKE-ANSWER") for v in answers.values())


### PR DESCRIPTION
## Summary

Settima ed ultima PR della serie NLM elevation. Operationalizza il runbook
docs/operations/NLM_ELEVATION_ACTIVATION.md con 5 wrapper script versionati,
ciascuno con header documentato che spiega quando attivarlo (stage runbook)
e l'esatta `crontab -e` line da aggiungere.

**Nessuno è schedulato automaticamente** — i wrapper esistono nel repo per
review e versioning, l'attivazione è una decisione esplicita dell'operatore
seguendo le pre-condizioni del runbook.

## Files

| File | Stage | When to enable | Cost |
|---|---|---|---|
| `truth_dashboard_digest.sh` | 1+ | Day 1, safe | Free |
| `run_canary_all.sh` | 3 | After 48h heartbeat truth stable | NLM CLI (OAuth) |
| `run_cep_daily.sh` + `collect_cep_answers.py` | 5 | Parallel with Stage 4 | DeepSeek ~$15/mo |
| `nlm_shadow_run_all.sh` | 6 | After 7d CEP baseline | DeepSeek + OpenAI ~$90/mo |
| `README.md` | — | Always read first | Free |

## Why not pre-scheduled

Pre-installing crontab entries would bypass the stage gating and risk:
- Stage 6 shadow extractor running before CEP baseline → no quality regression detection
- Stage 4 oracle gate firing before canaries populate state → all queries refused
- Cost spikes ($50+/month DeepSeek) if shadow runs prematurely

Each wrapper's header documents the exact `crontab -e` line. Activation is one
copy-paste per stage when the runbook pre-conditions are met.

## Defensive parsing in `collect_cep_answers.py`

The prod RAG endpoint shape may evolve. The fetcher tolerates 4 shapes:
- `{"answer": "..."}` (canonical)
- `{"value": {"answer": "..."}}` (NLM CLI wrapper style)
- `{"text": "..."}` (alias)
- `{"weird": "..."}` → returns empty (CEP grader handles as miss)

HTTP errors and timeouts return empty answer instead of raising — so a
single endpoint hiccup doesn't abort the whole 50-query collection cycle.

## Test plan
- [x] `pytest scripts/tests/test_collect_cep_answers.py` → 7/7 PASS
- [x] All 4 shell wrappers `bash -n` syntax check OK
- [x] `--help` invocable on Python script
- [ ] Live activation: follow `NLM_ELEVATION_ACTIVATION.md` runbook stage-by-stage

## Catena Sprint 0/1/2 NLM elevation

| PR | Sprint | Subject |
|---|---|---|
| #243 | 0 | core fix |
| #244 | 0 | truth_dashboard + diagnosis |
| #245 | 0/1 | sentinel + canary |
| #246 | 1 | oracle stale gate |
| #247 | 2 | shadow extractor |
| #248 | 2 | retrieval + CEP + runbook + gating |
| (qui) | activation | wrapper scripts |

**Total**: 7 PR, 81 test PASS, zero breaking changes, tutto opt-in.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)