### PR TITLE
refactor(mouth): extract KitaCommandPalette strings to i18n

### DIFF
--- a/apps/mouth/src/components/workspace/KitaCommandPalette.tsx
+++ b/apps/mouth/src/components/workspace/KitaCommandPalette.tsx
@@ -3,13 +3,15 @@
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { CommandPalette, type CommandAction } from "@balizero/core";
+import { useTranslation } from "@/i18n";
 
 /**
  * Workspace-wide Cmd+K command palette for /kita.
- * Actions: navigation + practice-creation shortcuts + external (Prime).
+ * Actions: navigation + case-creation shortcuts + external (Prime).
  */
 export function KitaCommandPalette() {
   const router = useRouter();
+  const { t } = useTranslation();
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
@@ -29,54 +31,54 @@ export function KitaCommandPalette() {
     () => [
       {
         id: "go-inbox",
-        label: "Vai a Inbox",
-        group: "Navigazione",
+        label: t("commandPalette.actions.goInbox"),
+        group: t("commandPalette.groups.navigation"),
         run: () => router.push("/inbox"),
       },
       {
         id: "go-clients",
-        label: "Clienti",
-        group: "Navigazione",
+        label: t("commandPalette.actions.goClients"),
+        group: t("commandPalette.groups.navigation"),
         run: () => router.push("/clients"),
       },
       {
         id: "go-process",
-        label: "Pratiche",
-        group: "Navigazione",
+        label: t("commandPalette.actions.goProcess"),
+        group: t("commandPalette.groups.navigation"),
         run: () => router.push("/process"),
       },
       {
         id: "go-prime",
-        label: "Apri Prime 3D",
-        group: "Navigazione",
+        label: t("commandPalette.actions.goPrime"),
+        group: t("commandPalette.groups.navigation"),
         run: () => window.open("https://prime.balizero.com/", "_blank", "noopener"),
       },
       {
         id: "create-kitas",
-        label: "Crea pratica KITAS",
-        group: "Pratiche",
+        label: t("commandPalette.actions.createKitas"),
+        group: t("commandPalette.groups.cases"),
         run: () => router.push("/process/new?type=kitas"),
       },
       {
         id: "create-pt",
-        label: "Crea pratica PT Setup",
-        group: "Pratiche",
+        label: t("commandPalette.actions.createPtSetup"),
+        group: t("commandPalette.groups.cases"),
         run: () => router.push("/process/new?type=pt_setup"),
       },
       {
         id: "export-lkpm",
-        label: "Esporta LKPM Q1",
-        group: "Tax",
+        label: t("commandPalette.actions.exportLkpm"),
+        group: t("commandPalette.groups.tax"),
         run: () => router.push("/lkpm"),
       },
       {
         id: "open-analytics",
-        label: "Analytics funnel",
-        group: "Analytics",
+        label: t("commandPalette.actions.openAnalytics"),
+        group: t("commandPalette.groups.analytics"),
         run: () => router.push("/analytics/funnel"),
       },
     ],
-    [router],
+    [router, t],
   );
 
   return (

--- a/apps/mouth/src/i18n/locales/en.json
+++ b/apps/mouth/src/i18n/locales/en.json
@@ -273,5 +273,23 @@
       "title": "Recover access",
       "sent": "We received your request. Our team will contact you."
     }
+  },
+  "commandPalette": {
+    "groups": {
+      "navigation": "Navigation",
+      "cases": "Cases",
+      "tax": "Tax",
+      "analytics": "Analytics"
+    },
+    "actions": {
+      "goInbox": "Go to Inbox",
+      "goClients": "Clients",
+      "goProcess": "Cases",
+      "goPrime": "Open Prime 3D",
+      "createKitas": "Create KITAS case",
+      "createPtSetup": "Create PT Setup case",
+      "exportLkpm": "Export LKPM Q1",
+      "openAnalytics": "Analytics funnel"
+    }
   }
 }

--- a/apps/mouth/src/i18n/locales/fr.json
+++ b/apps/mouth/src/i18n/locales/fr.json
@@ -254,5 +254,23 @@
       "living": "Vivre à Bali, culture, communauté, permis de conduire, santé et vie quotidienne.",
       "trends": "Économie numérique, industrie tech, nouvelles réglementations et analyses de marché."
     }
+  },
+  "commandPalette": {
+    "groups": {
+      "navigation": "Navigation",
+      "cases": "Dossiers",
+      "tax": "Fiscalité",
+      "analytics": "Analytique"
+    },
+    "actions": {
+      "goInbox": "Aller à la boîte de réception",
+      "goClients": "Clients",
+      "goProcess": "Dossiers",
+      "goPrime": "Ouvrir Prime 3D",
+      "createKitas": "Créer un dossier KITAS",
+      "createPtSetup": "Créer un dossier PT Setup",
+      "exportLkpm": "Exporter LKPM Q1",
+      "openAnalytics": "Funnel analytique"
+    }
   }
 }

--- a/apps/mouth/src/i18n/locales/id.json
+++ b/apps/mouth/src/i18n/locales/id.json
@@ -273,5 +273,23 @@
       "title": "Pemulihan akses",
       "sent": "Kami telah menerima permintaan Anda. Tim akan menghubungi Anda."
     }
+  },
+  "commandPalette": {
+    "groups": {
+      "navigation": "Navigasi",
+      "cases": "Kasus",
+      "tax": "Pajak",
+      "analytics": "Analitik"
+    },
+    "actions": {
+      "goInbox": "Ke Kotak Masuk",
+      "goClients": "Klien",
+      "goProcess": "Kasus",
+      "goPrime": "Buka Prime 3D",
+      "createKitas": "Buat kasus KITAS",
+      "createPtSetup": "Buat kasus PT Setup",
+      "exportLkpm": "Ekspor LKPM Q1",
+      "openAnalytics": "Funnel analitik"
+    }
   }
 }

--- a/apps/mouth/src/i18n/locales/it.json
+++ b/apps/mouth/src/i18n/locales/it.json
@@ -273,5 +273,23 @@
       "title": "Recupera accesso",
       "sent": "Abbiamo ricevuto la tua richiesta. Il team ti contatterà."
     }
+  },
+  "commandPalette": {
+    "groups": {
+      "navigation": "Navigazione",
+      "cases": "Pratiche",
+      "tax": "Tax",
+      "analytics": "Analytics"
+    },
+    "actions": {
+      "goInbox": "Vai a Inbox",
+      "goClients": "Clienti",
+      "goProcess": "Pratiche",
+      "goPrime": "Apri Prime 3D",
+      "createKitas": "Crea pratica KITAS",
+      "createPtSetup": "Crea pratica PT Setup",
+      "exportLkpm": "Esporta LKPM Q1",
+      "openAnalytics": "Analytics funnel"
+    }
   }
 }

--- a/apps/mouth/src/i18n/locales/ru.json
+++ b/apps/mouth/src/i18n/locales/ru.json
@@ -254,5 +254,23 @@
       "living": "Жизнь на Бали, культура, сообщество, водительские права, здоровье.",
       "trends": "Цифровая экономика, технологии, новые правила и рыночная аналитика."
     }
+  },
+  "commandPalette": {
+    "groups": {
+      "navigation": "Навигация",
+      "cases": "Дела",
+      "tax": "Налоги",
+      "analytics": "Аналитика"
+    },
+    "actions": {
+      "goInbox": "Перейти во Входящие",
+      "goClients": "Клиенты",
+      "goProcess": "Дела",
+      "goPrime": "Открыть Prime 3D",
+      "createKitas": "Создать дело KITAS",
+      "createPtSetup": "Создать дело PT Setup",
+      "exportLkpm": "Экспорт LKPM Q1",
+      "openAnalytics": "Воронка аналитики"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Replace 12 hardcoded Italian labels and groups in `KitaCommandPalette.tsx` with `t()` lookups against the existing i18n stack.

## Translation keys added (`commandPalette.*` namespace)

**Groups**: navigation, cases, tax, analytics
**Actions**: goInbox, goClients, goProcess, goPrime, createKitas, createPtSetup, exportLkpm, openAnalytics

## Locale files populated

- **en.json** — English (default)
- **it.json** — Italian (preserves original copy: `"Vai a Inbox"`, `"Pratiche"`, etc)
- **fr.json** — French
- **id.json** — Indonesian
- **ru.json** — Russian

## Note on terminology

The action label for `/process` was previously `"Pratiche"` (Italian), with group also `"Pratiche"`. The English translation uses `"Cases"` — this aligns with the upcoming `Pratica → Case` rename (planned in a separate PR).

For Italian users, the label remains `"Pratiche"` (no behavior change).

## Test plan

- [ ] CI typecheck on apps/mouth
- [ ] CI build on apps/mouth
- [ ] Manual: open Cmd+K palette, switch language EN ↔ IT, verify labels update

🤖 Generated with [Claude Code](https://claude.com/claude-code)