### PR TITLE
refactor(mouth): rename Pratica*/pratiche → Case*/cases (TS-only, no API change)

### DIFF
--- a/apps/mouth/src/app/(workspace)/dashboard/__tests__/page.test.tsx
+++ b/apps/mouth/src/app/(workspace)/dashboard/__tests__/page.test.tsx
@@ -69,15 +69,15 @@ vi.mock("@/components/dashboard", () => ({
       </a>
     </div>
   ),
-  PratichePreview: ({
-    pratiche,
+  CasesPreview: ({
+    cases,
     isLoading,
   }: {
-    pratiche: unknown[];
+    cases: unknown[];
     isLoading: boolean;
   }) => (
-    <div data-testid="pratiche-preview">
-      {isLoading ? "Loading..." : `${pratiche.length} practices`}
+    <div data-testid="cases-preview">
+      {isLoading ? "Loading..." : `${cases.length} cases`}
     </div>
   ),
   WhatsAppPreview: ({

--- a/apps/mouth/src/app/(workspace)/dashboard/page.tsx
+++ b/apps/mouth/src/app/(workspace)/dashboard/page.tsx
@@ -13,7 +13,7 @@ import {
 } from 'lucide-react';
 import { LiveActivityFeed, RoleWidget, ZantaraPortalCard } from '@/components/dashboard';
 import { HeroLiveWindow } from '@/components/workspace/HeroLiveWindow';
-import type { PraticaPreview } from '@/components/dashboard/PratichePreview';
+import type { CasePreview } from '@/components/dashboard/CasesPreview';
 import { DashboardErrorBoundary } from '@/components/ErrorBoundary';
 import { TeamActivityPanel } from '@/components/dashboard/TeamActivityPanel';
 import type { TeamMemberStats, TeamOverview } from '@/components/dashboard/TeamActivityPanel';
@@ -166,7 +166,7 @@ function MetricItem({
 }
 
 // ── Pipeline row ───────────────────────────────────────────
-function PipelineRow({ p }: { p: PraticaPreview }) {
+function PipelineRow({ p }: { p: CasePreview }) {
   const cfg = STATUS_CONFIG[p.status];
   const isUrgent =
     p.daysRemaining !== undefined && p.daysRemaining <= 3 && p.status !== 'completed';

--- a/apps/mouth/src/components/dashboard/CasesPreview.tsx
+++ b/apps/mouth/src/components/dashboard/CasesPreview.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { ChevronRight, Clock } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-export interface PraticaPreview {
+export interface CasePreview {
   id: number;
   title: string;
   client: string;
@@ -12,8 +12,8 @@ export interface PraticaPreview {
   completedAt?: string;
 }
 
-interface PratichePreviewProps {
-  pratiche: PraticaPreview[];
+interface CasesPreviewProps {
+  cases: CasePreview[];
   isLoading?: boolean;
 }
 
@@ -50,7 +50,7 @@ const statusConfig = {
   },
 };
 
-export function PratichePreview({ pratiche, isLoading }: PratichePreviewProps) {
+export function CasesPreview({ cases, isLoading }: CasesPreviewProps) {
   if (isLoading) {
     return (
       <div className="glass-card-warm p-5 rounded-xl">
@@ -86,28 +86,28 @@ export function PratichePreview({ pratiche, isLoading }: PratichePreviewProps) {
       </div>
 
       <div className="space-y-2">
-        {pratiche.length === 0 ? (
+        {cases.length === 0 ? (
           <div className="text-center py-8">
             <p className="text-sm text-[var(--foreground-muted)]">
               No process assigned
             </p>
           </div>
         ) : (
-          pratiche.map((pratica) => {
-            const config = statusConfig[pratica.status];
+          cases.map((caseItem) => {
+            const config = statusConfig[caseItem.status];
             return (
               <Link
-                key={pratica.id}
-                href={`/process/${pratica.id}`}
+                key={caseItem.id}
+                href={`/process/${caseItem.id}`}
                 className="block p-3 rounded-lg border border-[var(--border)] hover:border-[var(--border-hover)] hover:bg-[var(--background-elevated)]/30 transition-all"
               >
                 <div className="flex items-start justify-between gap-3">
                   <div className="flex-1 min-w-0">
                     <p className="text-sm font-medium text-[var(--foreground)] truncate">
-                      {pratica.title}
+                      {caseItem.title}
                     </p>
                     <p className="text-xs text-[var(--foreground-muted)] truncate">
-                      {pratica.client}
+                      {caseItem.client}
                     </p>
                   </div>
                   <div className="flex flex-col items-end gap-1">
@@ -123,29 +123,29 @@ export function PratichePreview({ pratiche, isLoading }: PratichePreviewProps) {
                       />
                       {config.label}
                     </span>
-                    {pratica.status !== "completed" &&
-                      pratica.daysRemaining !== undefined && (
+                    {caseItem.status !== "completed" &&
+                      caseItem.daysRemaining !== undefined && (
                         <span
                           className={cn(
                             "text-xs flex items-center gap-1",
-                            pratica.daysRemaining <= 0
+                            caseItem.daysRemaining <= 0
                               ? "text-[var(--error)]"
-                              : pratica.daysRemaining <= 3
+                              : caseItem.daysRemaining <= 3
                                 ? "text-[var(--error)]"
-                                : pratica.daysRemaining <= 7
+                                : caseItem.daysRemaining <= 7
                                   ? "text-[var(--warning)]"
                                   : "text-[var(--foreground-muted)]",
                           )}
                         >
                           <Clock className="w-3 h-3" />
-                          {pratica.daysRemaining <= 0
+                          {caseItem.daysRemaining <= 0
                             ? "Expired"
-                            : `${pratica.daysRemaining}d`}
+                            : `${caseItem.daysRemaining}d`}
                         </span>
                       )}
-                    {pratica.status === "completed" && pratica.completedAt && (
+                    {caseItem.status === "completed" && caseItem.completedAt && (
                       <span className="text-xs text-[var(--foreground-muted)]">
-                        {pratica.completedAt}
+                        {caseItem.completedAt}
                       </span>
                     )}
                   </div>

--- a/apps/mouth/src/components/dashboard/index.ts
+++ b/apps/mouth/src/components/dashboard/index.ts
@@ -1,6 +1,6 @@
 export { StatsCard } from "./StatsCard";
-export { PratichePreview } from "./PratichePreview";
-export type { PraticaPreview } from "./PratichePreview";
+export { CasesPreview } from "./CasesPreview";
+export type { CasePreview } from "./CasesPreview";
 export { WhatsAppPreview } from "./WhatsAppPreview";
 export type { WhatsAppMessage } from "./WhatsAppPreview";
 export { FinancialRealityWidget } from "./FinancialRealityWidget";

--- a/apps/mouth/src/components/dashboard/role-widgets/TeamRoleWidget.tsx
+++ b/apps/mouth/src/components/dashboard/role-widgets/TeamRoleWidget.tsx
@@ -9,26 +9,26 @@ export function TeamRoleWidget({ metrics }: Props) {
   return (
     <div className="flex flex-col gap-2.5">
       <span className="text-[9px] font-bold text-white/40 tracking-[.12em]">
-        LE MIE PRATICHE
+        MY CASES
       </span>
       <span className="text-2xl font-black text-accent-sage leading-none">
         {metrics.pratiche_assegnate}
       </span>
-      <span className="text-[10px] text-white/50">pratiche assegnate</span>
+      <span className="text-[10px] text-white/50">assigned cases</span>
       <div className="h-px bg-white/[0.06]" />
       {metrics.prossima_scadenza && (
         <div className="px-2 py-1.5 rounded-lg bg-[rgba(196,92,120,0.09)] border border-[rgba(196,92,120,0.22)] text-[9px] font-semibold text-accent-pink-editorial">
-          ⏰ Scadenza: {metrics.prossima_scadenza}
+          ⏰ Deadline: {metrics.prossima_scadenza}
         </div>
       )}
       {metrics.stalled_count > 0 && (
         <div className="px-2 py-1.5 rounded-lg bg-[rgba(184,154,64,0.09)] border border-[rgba(184,154,64,0.22)] text-[9px] font-semibold text-[#b89a40]">
-          ⚠️ {metrics.stalled_count} stalled &gt;14gg
+          ⚠️ {metrics.stalled_count} stalled &gt;14d
         </div>
       )}
       {metrics.doc_mancanti > 0 && (
         <div className="px-2 py-1.5 rounded-lg bg-[rgba(184,154,64,0.07)] border border-[rgba(184,154,64,0.18)] text-[9px] font-semibold text-[#b89a40]">
-          📄 {metrics.doc_mancanti} doc mancanti
+          📄 {metrics.doc_mancanti} missing documents
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

TypeScript identifier cleanup in `apps/mouth/`. Renames Italian symbols to their English standard equivalents. **No cross-API field changes** — see the upcoming PR-11 for the coordinated rename of `pratiche_assegnate` → `assigned_cases`.

## File renames (`git mv`)

- `apps/mouth/src/components/dashboard/PratichePreview.tsx` → `CasesPreview.tsx`

## Identifier renames

In `CasesPreview.tsx`:
- `interface PraticaPreview` → `interface CasePreview`
- `component PratichePreview` → `component CasesPreview`
- `pratiche: PraticaPreview[]` prop → `cases: CasePreview[]`
- loop variable `pratica` → `caseItem` (avoids the JS keyword `case`)

Consumer updates:
- `components/dashboard/index.ts`: re-export `Case*` names
- `app/(workspace)/dashboard/page.tsx`: import `CasePreview` type
- `app/(workspace)/dashboard/__tests__/page.test.tsx`: mock now exports `CasesPreview` with `cases` prop, `data-testid="cases-preview"`

## Bonus UI label updates in `TeamRoleWidget.tsx`

Visible labels (not field names):
- `"LE MIE PRATICHE"` → `"MY CASES"`
- `"pratiche assegnate"` → `"assigned cases"`
- `"Scadenza:"` → `"Deadline:"`
- `">14gg"` → `">14d"`
- `"doc mancanti"` → `"missing documents"`

The underlying `TeamMetrics` interface fields (`pratiche_assegnate`, `prossima_scadenza`, `doc_mancanti`) are **not touched** — they cross the API boundary and will be renamed in the upcoming PR-11 (coordinated FE+BE rolling deploy).

## Out of scope (explicit)

- Comments in hooks (`useCrmPractices.ts`, `useCrmSearch.ts`, `useCrmNotifications.ts`) — comments are not in the IT→EN translation scope per user instructions
- `pratiche_assegnate` field — see PR-11 for cross-API coordinated rename
- Other Italian `*Metrics` fields (`visti_scadenza`, `fatture_overdue`, `prossima_scadenza`, `clienti_compliant`, `articoli_pubblicati`, etc) — same cross-API constraint, will be addressed when DB schema updates land

## Test plan

- [ ] CI typecheck on apps/mouth
- [ ] CI build on apps/mouth
- [ ] Vitest: `apps/mouth/src/app/(workspace)/dashboard/__tests__/page.test.tsx`
- [ ] Manual: dashboard page renders CasesPreview correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)