### PR TITLE
feat(api/dashboard): add assigned_cases field (deprecates pratiche_assegnate)

### DIFF
--- a/apps/backend-rag/backend/app/routers/dashboard_summary.py
+++ b/apps/backend-rag/backend/app/routers/dashboard_summary.py
@@ -608,6 +608,10 @@ async def get_role_metrics(
                     user_id,
                 )
             metrics = {
+                # New EN field — preferred. Frontend will switch to this in PR-11b.
+                "assigned_cases": int(user_practices),
+                # Legacy IT field — kept for backwards-compat during rolling deploy.
+                # Will be removed in PR-11c after the frontend is fully migrated.
                 "pratiche_assegnate": int(user_practices),
                 "prossima_scadenza": next_deadline,
                 "doc_mancanti": 0,
@@ -686,7 +690,8 @@ async def get_role_metrics(
                 "fly_uptime": 0,
             },
             "team": {
-                "pratiche_assegnate": 0,
+                "assigned_cases": 0,
+                "pratiche_assegnate": 0,  # legacy IT alias — see PR-11
                 "prossima_scadenza": None,
                 "doc_mancanti": 0,
                 "clienti_assegnati": 0,


### PR DESCRIPTION
## Summary

**Additive** change — both fields are now in the response. Sets up the rolling deploy for cross-API rename of the team metrics field:

`pratiche_assegnate` (Italian, legacy) → `assigned_cases` (English, canonical)

## Sequence

- **PR-11a (this PR)**: backend exposes BOTH fields with the same value
- **PR-11b** (next): frontend switches to read `assigned_cases`. Backend keeps both for ≥24h to allow safe rolling deploy
- **PR-11c**: backend removes deprecated `pratiche_assegnate` once no callers remain. Manual gate — merged only after PR-11b is stable in prod

## Files

- `apps/backend-rag/backend/app/routers/dashboard_summary.py`:
  - team metrics dict: add `assigned_cases` alongside existing `pratiche_assegnate`
  - default empty payload: same dual-field shape

## Behavior

No frontend or behavior change at this point. **Pure additive on response shape.**

## Test plan

- [ ] CI: pytest backend
- [ ] Manual: `GET /api/dashboard/summary` for team-role user, verify both `assigned_cases` and `pratiche_assegnate` present with same value

🤖 Generated with [Claude Code](https://claude.com/claude-code)