### PR TITLE
refactor(mouth): switch to assigned_cases field (drops pratiche_assegnate)

### DIFF
--- a/apps/backend-rag/backend/app/routers/dashboard_summary.py
+++ b/apps/backend-rag/backend/app/routers/dashboard_summary.py
@@ -608,6 +608,10 @@ async def get_role_metrics(
                     user_id,
                 )
             metrics = {
+                # New EN field — preferred. Frontend will switch to this in PR-11b.
+                "assigned_cases": int(user_practices),
+                # Legacy IT field — kept for backwards-compat during rolling deploy.
+                # Will be removed in PR-11c after the frontend is fully migrated.
                 "pratiche_assegnate": int(user_practices),
                 "prossima_scadenza": next_deadline,
                 "doc_mancanti": 0,
@@ -686,7 +690,8 @@ async def get_role_metrics(
                 "fly_uptime": 0,
             },
             "team": {
-                "pratiche_assegnate": 0,
+                "assigned_cases": 0,
+                "pratiche_assegnate": 0,  # legacy IT alias — see PR-11
                 "prossima_scadenza": None,
                 "doc_mancanti": 0,
                 "clienti_assegnati": 0,

--- a/apps/mouth/src/components/dashboard/role-widgets/TeamRoleWidget.tsx
+++ b/apps/mouth/src/components/dashboard/role-widgets/TeamRoleWidget.tsx
@@ -12,7 +12,7 @@ export function TeamRoleWidget({ metrics }: Props) {
         LE MIE PRATICHE
       </span>
       <span className="text-2xl font-black text-accent-sage leading-none">
-        {metrics.pratiche_assegnate}
+        {metrics.assigned_cases}
       </span>
       <span className="text-[10px] text-white/50">pratiche assegnate</span>
       <div className="h-px bg-white/[0.06]" />

--- a/apps/mouth/src/components/dashboard/role-widgets/__tests__/role-widgets.test.tsx
+++ b/apps/mouth/src/components/dashboard/role-widgets/__tests__/role-widgets.test.tsx
@@ -44,7 +44,7 @@ describe("TeamRoleWidget", () => {
     render(
       <TeamRoleWidget
         metrics={{
-          pratiche_assegnate: 7,
+          assigned_cases: 7,
           prossima_scadenza: "2026-03-20",
           doc_mancanti: 2,
           clienti_assegnati: 4,
@@ -59,7 +59,7 @@ describe("TeamRoleWidget", () => {
     render(
       <TeamRoleWidget
         metrics={{
-          pratiche_assegnate: 0,
+          assigned_cases: 0,
           prossima_scadenza: "2026-03-20",
           doc_mancanti: 0,
           clienti_assegnati: 0,

--- a/apps/mouth/src/hooks/__tests__/useRoleMetrics.test.ts
+++ b/apps/mouth/src/hooks/__tests__/useRoleMetrics.test.ts
@@ -36,7 +36,7 @@ describe("useRoleMetrics", () => {
     const mockData = {
       role: "team",
       metrics: {
-        pratiche_assegnate: 5,
+        assigned_cases: 5,
         prossima_scadenza: null,
         doc_mancanti: 2,
         clienti_assegnati: 8,

--- a/apps/mouth/src/types/dashboard-role.types.ts
+++ b/apps/mouth/src/types/dashboard-role.types.ts
@@ -11,7 +11,7 @@ export interface ZeroMetrics {
 }
 
 export interface TeamMetrics {
-  pratiche_assegnate: number;
+  assigned_cases: number;
   prossima_scadenza: string | null;
   doc_mancanti: number;
   clienti_assegnati: number;


### PR DESCRIPTION
## Summary

Frontend follow-up to #276 (PR-11a) — switches all consumers to read the new English field name `assigned_cases`.

**Base**: #276. Will rebase to `main` once #276 is merged.

## Changes

- `apps/mouth/src/types/dashboard-role.types.ts`: `TeamMetrics.pratiche_assegnate` → `TeamMetrics.assigned_cases`
- `apps/mouth/src/components/dashboard/role-widgets/TeamRoleWidget.tsx`: read `metrics.assigned_cases`
- `apps/mouth/src/components/dashboard/role-widgets/__tests__/role-widgets.test.tsx`: fixture data uses `assigned_cases`
- `apps/mouth/src/hooks/__tests__/useRoleMetrics.test.ts`: fixture data uses `assigned_cases`

## Deploy gate

This PR should be merged **after** #276 is deployed and stable in prod. Backend will keep `pratiche_assegnate` exposed for ≥24h after this PR ships, then PR-11c removes the legacy field.

## Note on UI labels

No UI **label** change here — the visible text in `TeamRoleWidget` still reads `"LE MIE PRATICHE"` / `"pratiche assegnate"`. Those labels are translated in #275 (PR-10) which is a parallel branch.

After both #275 and this PR are merged, the widget will show English labels reading the English field.

## Test plan

- [ ] CI typecheck on apps/mouth
- [ ] Vitest: `role-widgets.test.tsx`, `useRoleMetrics.test.ts`
- [ ] Manual after deploy: dashboard team-role widget shows correct count

🤖 Generated with [Claude Code](https://claude.com/claude-code)