### PR TITLE
feat(prompts): centralize business phrases as multi-lang dict (en/it/id)

### DIFF
--- a/apps/backend-rag/backend/prompts/business_rules_i18n.py
+++ b/apps/backend-rag/backend/prompts/business_rules_i18n.py
@@ -1,0 +1,111 @@
+"""
+Business rules — multi-language phrases.
+
+Centralised dict of business-critical phrases that Zantara uses verbatim in
+its responses to clients. Each phrase is provided in en/it/id; when the LLM
+needs to surface one of these phrases it MUST pick the variant that matches
+the user's query language (LANGUAGE_PROTOCOL in zantara_core.py).
+
+Why a centralised dict instead of inlining variants in each prompt:
+- Single source of truth — when Bali Zero updates a phrase, one edit covers
+  every prompt that references it.
+- Tests can assert presence/absence of these phrases in golden-set responses
+  without hard-coding strings in five places.
+
+Adding a new phrase:
+- Pick a stable, semantic key (snake_case, ASCII).
+- Provide all three variants (en/it/id) at once. If a variant cannot be
+  written immediately, fall back to the en string in id/it slots so the
+  helper still returns something usable.
+"""
+
+from __future__ import annotations
+
+# Stable semantic keys → per-language variants.
+BUSINESS_PHRASES_I18N: dict[str, dict[str, str]] = {
+    # Pricing — used when get_pricing returns no result for a specific service.
+    "verify_with_team": {
+        "en": "This specific cost must be verified with the team.",
+        "it": "Questo costo specifico è da verificare con il team.",
+        "id": "Biaya spesifik ini perlu diverifikasi dengan tim.",
+    },
+    # Identity Lock — used when redirecting prompt-injection attempts.
+    "redirect_to_indonesia": {
+        "en": "I can help you with Indonesia.",
+        "it": "Posso aiutarti con l'Indonesia.",
+        "id": "Saya bisa membantu Anda dengan Indonesia.",
+    },
+    # Identity Lock long form — surfaces our scope after a redirect.
+    "redirect_to_indonesia_long": {
+        "en": "I can help with Indonesia visas, PT PMA, or tax consulting.",
+        "it": "Posso aiutarti con visti Indonesia, PT PMA, o consulenza fiscale.",
+        "id": "Saya bisa membantu dengan visa Indonesia, PT PMA, atau konsultasi pajak.",
+    },
+    # Escalation — handing off to the human team.
+    "check_with_team": {
+        "en": "Let me check with the team and get back to you.",
+        "it": "Verifico col team e ti faccio sapere.",
+        "id": "Saya cek dengan tim dan akan kabari Anda.",
+    },
+    "connect_with_team": {
+        "en": "Let me connect you with the team for this.",
+        "it": "Ti metto in contatto col team per questo.",
+        "id": "Saya hubungkan Anda dengan tim untuk ini.",
+    },
+    # Crash protocol — used when a tool errors out.
+    "temporary_system_issue": {
+        "en": (
+            "There is a temporary technical issue with our systems. "
+            "Let me connect you with the team to answer your question."
+        ),
+        "it": (
+            "C'è un problema tecnico temporaneo sui nostri sistemi. "
+            "Ti metto in contatto col team per rispondere alla tua domanda."
+        ),
+        "id": (
+            "Ada masalah teknis sementara di sistem kami. "
+            "Saya hubungkan Anda dengan tim untuk menjawab pertanyaan Anda."
+        ),
+    },
+    # KBLI — used when vector_search(collection="kbli_2025_final") returns empty.
+    "verify_kbli_with_team": {
+        "en": "This KBLI code must be verified with the team.",
+        "it": "Questo codice KBLI è da verificare con il team.",
+        "id": "Kode KBLI ini perlu diverifikasi dengan tim.",
+    },
+    # KBLI — proactive Navigator pointer.
+    "kbli_navigator_pointer": {
+        "en": "You can explore all KBLI 2025 codes interactively at https://balizero.com/kbli",
+        "it": "Puoi esplorare tutti i codici KBLI 2025 in modo interattivo su https://balizero.com/kbli",
+        "id": "Anda bisa menjelajahi semua kode KBLI 2025 secara interaktif di https://balizero.com/kbli",
+    },
+    # Self-correction acknowledgement (Creator persona / strong recovery).
+    "user_correction_ack": {
+        "en": "You're absolutely right. I rechecked the official Bali Zero 2025 data in our database and confirm the correct value.",
+        "it": "Hai perfettamente ragione. Ho ricontrollato i dati ufficiali di Bali Zero 2025 nel nostro database e confermo il valore corretto.",
+        "id": "Anda benar. Saya memeriksa ulang data resmi Bali Zero 2025 di database kami dan mengonfirmasi nilai yang benar.",
+    },
+}
+
+
+def get_phrase(key: str, lang: str = "en") -> str:
+    """
+    Return a business phrase localized to the requested language.
+
+    Fallback chain: lang → "en" → key (so missing translations degrade
+    gracefully and the key surfaces clearly during development).
+    """
+    entry = BUSINESS_PHRASES_I18N.get(key)
+    if entry is None:
+        return key
+    return entry.get(lang) or entry.get("en") or key
+
+
+def all_languages_for(key: str) -> dict[str, str]:
+    """
+    Return every variant of a phrase as a {lang: text} dict.
+
+    Useful when injecting the multi-language menu directly into a prompt
+    so the model picks the right variant via LANGUAGE_PROTOCOL.
+    """
+    return dict(BUSINESS_PHRASES_I18N.get(key, {}))

--- a/apps/backend-rag/backend/tests/unit/test_business_rules_i18n.py
+++ b/apps/backend-rag/backend/tests/unit/test_business_rules_i18n.py
@@ -1,0 +1,61 @@
+"""Unit tests for backend.prompts.business_rules_i18n."""
+
+import pytest
+
+from backend.prompts.business_rules_i18n import (
+    BUSINESS_PHRASES_I18N,
+    all_languages_for,
+    get_phrase,
+)
+
+
+class TestSchemaCompleteness:
+    """Every phrase must have all three language variants populated."""
+
+    @pytest.mark.parametrize("key", sorted(BUSINESS_PHRASES_I18N.keys()))
+    def test_every_phrase_has_en_it_id(self, key: str) -> None:
+        entry = BUSINESS_PHRASES_I18N[key]
+        for lang in ("en", "it", "id"):
+            assert lang in entry, f"{key} missing {lang}"
+            assert isinstance(entry[lang], str)
+            assert entry[lang].strip(), f"{key}.{lang} is empty"
+
+
+class TestGetPhrase:
+    """Localized retrieval with graceful fallbacks."""
+
+    def test_returns_requested_language(self) -> None:
+        assert "verificare con il team" in get_phrase("verify_with_team", "it")
+        assert "verified with the team" in get_phrase("verify_with_team", "en")
+        assert "diverifikasi dengan tim" in get_phrase("verify_with_team", "id")
+
+    def test_unknown_language_falls_back_to_english(self) -> None:
+        # Russian is not registered — we should still get the English variant.
+        assert get_phrase("verify_with_team", "ru") == get_phrase(
+            "verify_with_team", "en",
+        )
+
+    def test_unknown_key_returns_key_for_debug(self) -> None:
+        assert get_phrase("not_a_real_key", "en") == "not_a_real_key"
+        assert get_phrase("not_a_real_key", "it") == "not_a_real_key"
+
+    def test_default_language_is_english(self) -> None:
+        assert get_phrase("verify_with_team") == get_phrase(
+            "verify_with_team", "en",
+        )
+
+
+class TestAllLanguagesFor:
+    """Bulk retrieval used when injecting all variants into a prompt."""
+
+    def test_returns_full_variant_map(self) -> None:
+        variants = all_languages_for("redirect_to_indonesia")
+        assert set(variants) == {"en", "it", "id"}
+
+    def test_unknown_key_returns_empty_dict(self) -> None:
+        assert all_languages_for("not_a_real_key") == {}
+
+    def test_returns_a_copy_not_a_reference(self) -> None:
+        variants = all_languages_for("verify_with_team")
+        variants["en"] = "MUTATED"
+        assert get_phrase("verify_with_team", "en") != "MUTATED"


### PR DESCRIPTION
## Summary

New module `backend/prompts/business_rules_i18n.py` with a curated dict of business-critical phrases that Zantara uses verbatim in client responses. Each phrase is provided in `en/it/id`; consumers retrieve the variant matching the user's query language (`LANGUAGE_PROTOCOL` from `zantara_core.py`).

## Phrases registered (8 keys × 3 languages)

- `verify_with_team` — *"Questo costo specifico è da verificare con il team"* (used by pricing rule when `get_pricing` returns no match)
- `redirect_to_indonesia` / `redirect_to_indonesia_long` — Identity Lock redirect under prompt-injection attempts
- `check_with_team` / `connect_with_team` — escalation handoff
- `temporary_system_issue` — crash protocol fallback
- `verify_kbli_with_team` — KBLI lookup miss
- `kbli_navigator_pointer` — proactive Navigator URL
- `user_correction_ack` — self-correction acknowledgement template

## Public API

```python
from backend.prompts.business_rules_i18n import get_phrase, all_languages_for

get_phrase("verify_with_team", "it")
# → "Questo costo specifico è da verificare con il team."

all_languages_for("redirect_to_indonesia")
# → {"en": "...", "it": "...", "id": "..."}
```

Fallback chain: `lang → en → key` (so missing translations surface clearly during development).

## Tests

`apps/backend-rag/backend/tests/unit/test_business_rules_i18n.py`:
- Schema completeness: every key has en/it/id, all non-empty
- `get_phrase`: returns requested language, falls back to `en` for unknown languages, returns the key for unknown keys, defaults to `en`
- `all_languages_for`: returns full map, empty dict for unknown key, returns a copy (mutation safety)

## Scope

**Infrastructure only** — no existing prompt text is modified. The module will be wired into `council/prompts.py`, `prompt_builder.py`, and the future `zantara_core_v2.py` in subsequent PRs (PR-16a/b/17), each gated behind the `ZANTARA_PROMPT_VERSION` feature flag.

## Test plan

- [ ] CI: pytest backend
- [ ] Module import: `python -c "from backend.prompts.business_rules_i18n import get_phrase; print(get_phrase('verify_with_team', 'it'))"`
- [ ] Unit tests: `PYTHONPATH=. pytest backend/tests/unit/test_business_rules_i18n.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)