### PR TITLE
fix(whatsapp_persona): make pricing table + expert rule lang-aware

### DIFF
--- a/apps/backend-rag/backend/prompts/whatsapp_persona.py
+++ b/apps/backend-rag/backend/prompts/whatsapp_persona.py
@@ -18,8 +18,60 @@ from backend.prompts.zantara_core import ZANTARA_MASTER_TEMPLATE
 logger = logging.getLogger(__name__)
 
 
-def _load_full_pricing() -> str:
-    """Load ALL prices from JSON and format as plain text (no markdown, no bullets)."""
+# Localized labels for each pricing category in the JSON dataset.
+# Keys must match category keys in bali_zero_official_prices_2025.json.
+_CATEGORY_LABELS_BY_LANG: dict[str, dict[str, str]] = {
+    "en": {
+        "single_entry_visas": "SINGLE ENTRY VISAS",
+        "multiple_entry_visas": "MULTIPLE ENTRY VISAS",
+        "kitas_permits": "KITAS (residence permits)",
+        "kitap_permits": "KITAP (permanent permits)",
+        "company_services": "COMPANY SERVICES",
+        "other_process": "OTHER PROCESSES",
+        "urgent_services": "URGENT SERVICES (additional cost)",
+    },
+    "it": {
+        "single_entry_visas": "VISTI SINGLE ENTRY",
+        "multiple_entry_visas": "VISTI MULTIPLE ENTRY",
+        "kitas_permits": "KITAS (permessi di soggiorno)",
+        "kitap_permits": "KITAP (permessi permanenti)",
+        "company_services": "SERVIZI AZIENDALI",
+        "other_process": "ALTRI PROCESSI",
+        "urgent_services": "URGENZE (costo aggiuntivo)",
+    },
+    "id": {
+        "single_entry_visas": "VISA SINGLE ENTRY",
+        "multiple_entry_visas": "VISA MULTIPLE ENTRY",
+        "kitas_permits": "KITAS (izin tinggal terbatas)",
+        "kitap_permits": "KITAP (izin tinggal tetap)",
+        "company_services": "LAYANAN PERUSAHAAN",
+        "other_process": "PROSES LAINNYA",
+        "urgent_services": "LAYANAN URGENT (biaya tambahan)",
+    },
+}
+
+# "Exchange rate" intro line per language (kept short to mirror the original).
+_EXCHANGE_RATE_INTRO_BY_LANG: dict[str, str] = {
+    "en": "Exchange rate: approx. 15,385 IDR per 1 USD\n",
+    "it": "Tasso di cambio: circa 15.385 IDR per 1 USD\n",
+    "id": "Kurs: sekitar 15.385 IDR per 1 USD\n",
+}
+
+# Inline "approximately" word in the per-row USD price annotation.
+_APPROX_BY_LANG: dict[str, str] = {
+    "en": "approx.",
+    "it": "circa",
+    "id": "sekitar",
+}
+
+
+def _load_full_pricing(lang: str = "en") -> str:
+    """Load ALL prices from JSON and format as plain text (no markdown, no bullets).
+
+    Args:
+        lang: Language code for category labels and intro/approx wording.
+              Falls back to "en" if the requested lang is not registered.
+    """
     pricing_file = Path(__file__).parent.parent / "data" / "bali_zero_official_prices_2025.json"
     try:
         if not pricing_file.exists():
@@ -28,18 +80,15 @@ def _load_full_pricing() -> str:
             data = json.load(f)
         services = data.get("services", {})
 
-        sections = []
-        sections.append("Tasso di cambio: circa 15.385 IDR per 1 USD\n")
+        category_labels = _CATEGORY_LABELS_BY_LANG.get(
+            lang, _CATEGORY_LABELS_BY_LANG["en"],
+        )
+        intro = _EXCHANGE_RATE_INTRO_BY_LANG.get(
+            lang, _EXCHANGE_RATE_INTRO_BY_LANG["en"],
+        )
+        approx = _APPROX_BY_LANG.get(lang, _APPROX_BY_LANG["en"])
 
-        category_labels = {
-            "single_entry_visas": "VISTI SINGLE ENTRY",
-            "multiple_entry_visas": "VISTI MULTIPLE ENTRY",
-            "kitas_permits": "KITAS (permessi di soggiorno)",
-            "kitap_permits": "KITAP (permessi permanenti)",
-            "company_services": "SERVIZI AZIENDALI",
-            "other_process": "ALTRI PROCESSI",
-            "urgent_services": "URGENZE (costo aggiuntivo)",
-        }
+        sections = [intro]
 
         for cat_key, cat_label in category_labels.items():
             items = services.get(cat_key, [])
@@ -54,7 +103,7 @@ def _load_full_pricing() -> str:
                 notes = item.get("notes", "")
                 note_str = f" ({notes})" if notes else ""
                 lines.append(
-                    f"{code} = {name}: {price_idr:,} IDR (circa ${price_usd} USD){note_str}",
+                    f"{code} = {name}: {price_idr:,} IDR ({approx} ${price_usd} USD){note_str}",
                 )
             sections.append("\n".join(lines))
 
@@ -64,7 +113,15 @@ def _load_full_pricing() -> str:
         return ""
 
 
-_PRICING_TABLE = _load_full_pricing()
+# Cache pricing tables per language so we build each one only once at import.
+_PRICING_TABLES: dict[str, str] = {
+    lang: _load_full_pricing(lang) for lang in _CATEGORY_LABELS_BY_LANG
+}
+
+# Backwards-compat alias — defaults to English (was Italian; this is the bug
+# fix at the heart of this PR). Callers that did not pass a language used to
+# always get Italian labels even for English-speaking clients.
+_PRICING_TABLE = _PRICING_TABLES["en"]
 
 # Base prompt from single source of truth
 _BASE_PROMPT = ZANTARA_MASTER_TEMPLATE
@@ -152,24 +209,84 @@ def build_system_prompt(
 
     greeting_note = templates["greeting"] if is_first_message else templates["no_greeting"]
 
+    # Pick the localized pricing table (falls back to EN inside the dict).
+    pricing_table = _PRICING_TABLES.get(lang, _PRICING_TABLES["en"])
+
+    # Critical rule + price-list header — kept multilingual so an English-speaking
+    # client never sees Italian instructions in their system context.
+    expert_rules: dict[str, str] = {
+        "en": (
+            "CRITICAL RULE: NEVER tell the client \"I don't have access\", "
+            "\"I have no info in the system\", \"the data isn't loaded\", or "
+            "\"I can't search\". You are an expert consultant, not a piece of "
+            "software. If you don't know something, say \"let me check with "
+            "the team and get back to you\" or answer with what you know. "
+            "NEVER ask the client to give you information about regulations — "
+            "you are the expert."
+        ),
+        "it": (
+            "REGOLA CRITICA: Non dire MAI al cliente che \"non hai accesso\", "
+            "\"non hai info nel sistema\", \"non ti sono stati caricati i dati\", "
+            "\"non posso cercare\". Tu sei un consulente esperto, non un software. "
+            "Se non conosci qualcosa, dì \"verifico col team e ti faccio sapere\" "
+            "oppure rispondi con quello che sai sull'argomento. Non chiedere MAI "
+            "al cliente di darti informazioni su regolamenti — sei tu l'esperto."
+        ),
+        "id": (
+            "ATURAN KRITIS: JANGAN PERNAH bilang ke klien \"saya tidak punya "
+            "akses\", \"tidak ada info di sistem\", \"data belum dimuat\", atau "
+            "\"saya tidak bisa mencari\". Anda adalah konsultan ahli, bukan "
+            "perangkat lunak. Jika tidak tahu sesuatu, katakan \"saya cek dengan "
+            "tim dan akan kabari Anda\" atau jawab dengan yang Anda ketahui. "
+            "JANGAN PERNAH minta klien memberikan informasi tentang regulasi — "
+            "Anda yang ahlinya."
+        ),
+        "de": (
+            "KRITISCHE REGEL: Sagen Sie dem Kunden NIEMALS \"ich habe keinen "
+            "Zugriff\", \"ich habe keine Infos im System\", \"die Daten sind "
+            "nicht geladen\" oder \"ich kann nicht suchen\". Sie sind ein "
+            "Experte, keine Software. Wenn Sie etwas nicht wissen, sagen Sie "
+            "\"ich kläre das mit dem Team und melde mich\" oder antworten mit "
+            "dem, was Sie wissen."
+        ),
+    }
+    expert_rule = expert_rules.get(lang, expert_rules["en"])
+
+    pricing_headers: dict[str, str] = {
+        "en": "OFFICIAL BALI ZERO 2025 PRICE LIST (use ONLY these prices, never invent):",
+        "it": "LISTINO PREZZI UFFICIALE BALI ZERO 2025 (usa SOLO questi prezzi, mai inventare):",
+        "id": "DAFTAR HARGA RESMI BALI ZERO 2025 (gunakan HANYA harga ini, jangan dibuat-buat):",
+        "de": "OFFIZIELLE BALI ZERO 2025 PREISLISTE (verwenden Sie NUR diese Preise, niemals erfinden):",
+    }
+    pricing_header = pricing_headers.get(lang, pricing_headers["en"])
+
+    client_context_headers: dict[str, str] = {
+        "en": "CLIENT CONTEXT:",
+        "it": "CONTESTO CLIENTE:",
+        "id": "KONTEKS KLIEN:",
+        "de": "KUNDENKONTEXT:",
+    }
+    client_context_header = client_context_headers.get(lang, client_context_headers["en"])
+
     prompt = f"""{_BASE_PROMPT}
 
 {templates["response_instruction"]}
 
-REGOLA CRITICA: Non dire MAI al cliente che "non hai accesso", "non hai info nel sistema", "non ti sono stati caricati i dati", "non posso cercare". Tu sei un consulente esperto, non un software. Se non conosci qualcosa, dì "verifico col team e ti faccio sapere" oppure rispondi con quello che sai sull'argomento. Non chiedere MAI al cliente di darti informazioni su regolamenti — sei tu l'esperto.
+{expert_rule}
 
-CONTESTO CLIENTE:
+{client_context_header}
 {context_section}
 
 {greeting_note}
 
-LISTINO PREZZI UFFICIALE BALI ZERO 2025 (usa SOLO questi prezzi, mai inventare):
-{_PRICING_TABLE}"""
+{pricing_header}
+{pricing_table}"""
 
     return prompt
 
 
-# For backward compatibility
+# For backward compatibility — defaults to English (same default as
+# build_system_prompt). Callers that need IT/ID/DE must pass detected_language.
 SYSTEM_INSTRUCTION = build_system_prompt()
 
 


### PR DESCRIPTION
## Summary

**Bug fix**: WhatsApp clients in any language were receiving Italian-labelled pricing categories (`VISTI SINGLE ENTRY`, `KITAS (permessi di soggiorno)`, …) and an Italian critical-rule paragraph, **regardless of `detected_language`**.

## Root cause

- `_load_full_pricing()` had Italian category labels hardcoded.
- The single `_PRICING_TABLE` module-level constant was injected into every prompt without per-language switching.
- The "REGOLA CRITICA" paragraph in the prompt template was inlined as Italian-only.

## Fix

- `_CATEGORY_LABELS_BY_LANG` dict provides `en/it/id` labels for the 7 pricing categories
- `_EXCHANGE_RATE_INTRO_BY_LANG` and `_APPROX_BY_LANG` cover the intro line and per-row "approximately" wording
- `_load_full_pricing(lang)` accepts a language param and returns the correctly localized table (EN fallback for unknown langs)
- `_PRICING_TABLES` dict caches one table per registered language at import time (en/it/id pre-built)
- `_PRICING_TABLE` module alias keeps backwards-compat — but now defaults to **EN** (was IT)
- `build_system_prompt()` picks `_PRICING_TABLES[detected_language]` (EN fallback) and uses lang-aware versions of the "expert rule" and the section headers (covers `en/it/id/de`)

## Behaviour change

- ✅ EN/ID/DE clients now receive labels and headers in **their own language** (correction of latent bug)
- ✅ IT clients see **no change** (their existing IT labels are preserved)
- ⚠️ Default fallback (no `detected_language`) shifts from IT to EN — admin/support-bot WhatsApp invocations without language context now match the documented default in `build_system_prompt(detected_language=None)`

## Test plan

- [ ] CI: pytest backend
- [ ] Module import smoke: `python -c "from backend.prompts.whatsapp_persona import build_system_prompt, _PRICING_TABLES; print(list(_PRICING_TABLES))"`
- [ ] Manual: invoke `build_system_prompt(detected_language="en")` and verify the prompt contains `"SINGLE ENTRY VISAS"` not `"VISTI SINGLE ENTRY"`
- [ ] Manual: invoke `build_system_prompt(detected_language="it")` and verify the prompt still contains `"VISTI SINGLE ENTRY"` (no regression for IT users)

🤖 Generated with [Claude Code](https://claude.com/claude-code)