### PR TITLE
chore(prompts): add ZANTARA_PROMPT_VERSION feature flag (default v1, no-op)

### DIFF
--- a/apps/backend-rag/backend/llm/prompt_manager.py
+++ b/apps/backend-rag/backend/llm/prompt_manager.py
@@ -10,11 +10,35 @@ No more reading .md files at runtime.
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING, Any
 
-from backend.prompts.zantara_core import ZANTARA_MASTER_TEMPLATE
+from backend.prompts.zantara_core import ZANTARA_MASTER_TEMPLATE as _TEMPLATE_V1
 
 logger = logging.getLogger(__name__)
+
+# Feature flag: ZANTARA_PROMPT_VERSION selects between v1 (current SSOT,
+# Italian-heavy examples) and v2 (multi-language refactor, populated by
+# PR-16b/17). Default is v1 — v2 is currently a transparent re-export of
+# v1 (see backend/prompts/zantara_core_v2.py), so flipping the flag is a
+# no-op until those PRs land.
+_PROMPT_VERSION = os.environ.get("ZANTARA_PROMPT_VERSION", "v1").lower()
+
+if _PROMPT_VERSION == "v2":
+    try:
+        from backend.prompts.zantara_core_v2 import (
+            ZANTARA_MASTER_TEMPLATE,
+        )
+        logger.info("PromptManager: using zantara_core_v2 (ZANTARA_PROMPT_VERSION=v2)")
+    except ImportError as exc:  # pragma: no cover — defensive fallback
+        logger.warning(
+            "PromptManager: ZANTARA_PROMPT_VERSION=v2 requested but "
+            "zantara_core_v2 import failed (%s) — falling back to v1.",
+            exc,
+        )
+        ZANTARA_MASTER_TEMPLATE = _TEMPLATE_V1
+else:
+    ZANTARA_MASTER_TEMPLATE = _TEMPLATE_V1
 
 # ToneStyle is imported at runtime to avoid circular import
 # The TONE_PROMPTS dict uses string keys at module level, mapped to ToneStyle at runtime

--- a/apps/backend-rag/backend/prompts/zantara_core_v2.py
+++ b/apps/backend-rag/backend/prompts/zantara_core_v2.py
@@ -1,0 +1,35 @@
+"""
+Zantara Core Prompt — v2 placeholder.
+
+This module is the future home of the multi-language overhaul of
+zantara_core.py. For now (PR-16a) it is a transparent re-export so the
+ZANTARA_PROMPT_VERSION feature flag can be flipped between v1 and v2
+without producing a behaviour change.
+
+PR-16b will populate sections 1-7 (security, tool usage, system instructions,
+knowledge governance, language protocol, greeting rules, citation rules)
+using the multi-language pattern in backend.prompts.business_rules_i18n.
+
+PR-17 will populate sections 8-14 (internal monologue, escalation, crash,
+closing, creator persona, team persona, master template assembly).
+
+Until those PRs land this file delegates to v1 — flipping the env var
+ZANTARA_PROMPT_VERSION=v2 today is therefore a no-op.
+"""
+
+from backend.prompts.zantara_core import (  # noqa: F401 — re-exported for v1==v2 fallback
+    CITATION_RULES,
+    CLOSING_PHRASES,
+    CRASH_PROTOCOL,
+    CREATOR_PERSONA,
+    ESCALATION_PROTOCOL,
+    GREETING_RULES,
+    INTERNAL_MONOLOGUE,
+    KNOWLEDGE_GOVERNANCE,
+    LANGUAGE_PROTOCOL,
+    SECURITY_BOUNDARY,
+    SYSTEM_INSTRUCTIONS,
+    TEAM_PERSONA,
+    TOOL_USAGE_POLICY,
+    ZANTARA_MASTER_TEMPLATE,
+)


### PR DESCRIPTION
## Summary

Sets up the safety harness for the upcoming multi-language overhaul of `zantara_core.py`. **No behaviour change today** — the flag is a no-op until PR-16b/17 land.

## Changes

### NEW: `backend/prompts/zantara_core_v2.py`

Currently a transparent re-export of all symbols from `zantara_core` (`SECURITY_BOUNDARY`, `TOOL_USAGE_POLICY`, `SYSTEM_INSTRUCTIONS`, …, `ZANTARA_MASTER_TEMPLATE`).

- **PR-16b** will populate sections 1-7 with multi-language phrases via `backend.prompts.business_rules_i18n` (added in #279)
- **PR-17** will populate sections 8-14 (persona, escalation, etc)

### MODIFIED: `backend/llm/prompt_manager.py`

- New env-var `ZANTARA_PROMPT_VERSION` (default `"v1"`) selects which module supplies `ZANTARA_MASTER_TEMPLATE`
- `"v2"` → import from `zantara_core_v2` (transparent re-export today, real refactor in PR-16b/17)
- Anything else (including unset) → import from `zantara_core` (current production behaviour, unchanged)
- `ImportError` on v2 → defensive fallback to v1 with a logged warning

## Behaviour today

`ZANTARA_PROMPT_VERSION` unset or `"v1"` or `"v2"` all yield **identical prompts** because v2 re-exports v1. Flipping the env var in prod is a safe no-op — that is the point.

## Rollout strategy

| Step | Action | Effect |
|---|---|---|
| Now | Deploy this PR | No behaviour change |
| After PR-16b ships | `fly secrets set ZANTARA_PROMPT_VERSION=v2 -a nuzantara-rag` (canary) | Multi-language sections 1-7 active |
| After PR-17 ships, ≥1 week canary stable | Promote v2 to default | Full multi-language prompt |
| Future PR-18 | Remove v1, delete env-var | Cleanup |

## Test plan

- [ ] CI: pytest backend
- [ ] Module import smoke: `python -c "from backend.llm.prompt_manager import ZANTARA_MASTER_TEMPLATE; import backend.prompts.zantara_core as v1; assert ZANTARA_MASTER_TEMPLATE == v1.ZANTARA_MASTER_TEMPLATE"`
- [ ] With `ZANTARA_PROMPT_VERSION=v2` set: same equality holds (transparent re-export)
- [ ] Manual: set `ZANTARA_PROMPT_VERSION=v2` in a local env, verify "PromptManager: using zantara_core_v2" log line appears at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)