### PR TITLE
fix(admin_pii): remove unused HTTPException import (unblocks deploy)

### DIFF
--- a/apps/backend-rag/backend/app/routers/admin_pii.py
+++ b/apps/backend-rag/backend/app/routers/admin_pii.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import asyncpg
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 
 from backend.app.deps.database import get_database_pool
 from backend.app.routers.debug import verify_debug_access


### PR DESCRIPTION
Pre-deploy ruff F401 was blocking fly-deploy.yml on every commit since #258. `admin_pii` router doesn't use HTTPException directly — drop the dead import.

Unblocks deploy of all backend commits since 2026-04-25T15:00 (#108, #276, #278, #279, #280, #281, #282, #283, #284).