### PR TITLE
chore(api/dashboard): remove deprecated pratiche_assegnate field

### DIFF
--- a/apps/backend-rag/backend/app/routers/dashboard_summary.py
+++ b/apps/backend-rag/backend/app/routers/dashboard_summary.py
@@ -608,11 +608,7 @@ async def get_role_metrics(
                     user_id,
                 )
             metrics = {
-                # New EN field — preferred. Frontend will switch to this in PR-11b.
                 "assigned_cases": int(user_practices),
-                # Legacy IT field — kept for backwards-compat during rolling deploy.
-                # Will be removed in PR-11c after the frontend is fully migrated.
-                "pratiche_assegnate": int(user_practices),
                 "prossima_scadenza": next_deadline,
                 "doc_mancanti": 0,
                 "clienti_assegnati": int(user_practices),
@@ -691,7 +687,6 @@ async def get_role_metrics(
             },
             "team": {
                 "assigned_cases": 0,
-                "pratiche_assegnate": 0,  # legacy IT alias — see PR-11
                 "prossima_scadenza": None,
                 "doc_mancanti": 0,
                 "clienti_assegnati": 0,


### PR DESCRIPTION
## Summary

Final step of the cross-API rename `pratiche_assegnate` → `assigned_cases`:

- **PR #276** (PR-11a): added `assigned_cases` alongside `pratiche_assegnate`
- **PR #277** (PR-11b): switched frontend to read `assigned_cases`
- **This PR** (PR-11c): removes the deprecated Italian field

## Verified safe to remove

```
$ grep -rn "pratiche_assegnate" --include="*.py" --include="*.ts" \
    --include="*.tsx" --include="*.js" --include="*.json"
apps/backend-rag/backend/app/routers/dashboard_summary.py:615 (this file)
apps/backend-rag/backend/app/routers/dashboard_summary.py:694 (this file)
```

**No external consumers remain.** The frontend (`apps/mouth`) reads `assigned_cases` via the `TeamMetrics` interface, and PR #277 has been merged to main since 2026-04-25.

## Files

- `apps/backend-rag/backend/app/routers/dashboard_summary.py`:
  - team metrics dict: drop `pratiche_assegnate` (was line 615)
  - default empty payload: drop `pratiche_assegnate` (was line 694)

## Test plan

- [ ] CI: pytest backend
- [ ] Manual after deploy: `GET /api/dashboard/summary` for team-role user, verify response contains `assigned_cases` but NOT `pratiche_assegnate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)