### PR TITLE
feat(wr2): event-driven supervisor daemon (replaces 5 chained-cron plists)

### DIFF
--- a/.github/workflows/cron-drive-poll.yml
+++ b/.github/workflows/cron-drive-poll.yml
@@ -1,0 +1,63 @@
+name: cron - drive poll (every 5 min)
+
+# Migrated from Pro crontab `*/5 * * * * drive-poll.sh` (2026-04-26).
+# Triggers Drive change polling on backend; nudges Fly out of sleep.
+# Failure path: Telegram alert to owner (cooldown 30min).
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: cron-drive-poll
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: POST /api/admin/drive/poll
+        id: poll
+        env:
+          API_KEY: ${{ secrets.NUZANTARA_API_KEY }}
+        run: |
+          set -uo pipefail
+          BODY_FILE="$RUNNER_TEMP/body.json"
+          HTTP_CODE=$(curl -sS -o "$BODY_FILE" -w "%{http_code}" --max-time 120 \
+            -X POST \
+            -H "X-API-Key: $API_KEY" \
+            -H "Content-Type: application/json" \
+            https://nuzantara-rag.fly.dev/api/admin/drive/poll || echo "000")
+          BODY=$(cat "$BODY_FILE" 2>/dev/null || echo "")
+          echo "http_code=$HTTP_CODE" >> "$GITHUB_OUTPUT"
+          echo "body<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$BODY" | head -c 500 >> "$GITHUB_OUTPUT"
+          echo "" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          if [ "$HTTP_CODE" = "200" ]; then
+            PROCESSED=$(echo "$BODY" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('processed',0))" 2>/dev/null || echo "?")
+            echo "✅ Drive poll OK: $PROCESSED new files processed"
+          else
+            echo "::warning::Drive poll failed (HTTP $HTTP_CODE): $BODY"
+            exit 1
+          fi
+
+      - name: Telegram alert on failure
+        if: failure()
+        env:
+          BOT: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          CHAT: ${{ secrets.TELEGRAM_OWNER_CHAT_ID }}
+          HTTP_CODE: ${{ steps.poll.outputs.http_code }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          [ -z "$BOT" ] || [ -z "$CHAT" ] && { echo "Telegram secrets missing"; exit 0; }
+          TEXT="🚨 <b>drive-poll</b> failed
+          HTTP: ${HTTP_CODE:-?}
+          Run: ${RUN_URL}"
+          curl -sS -m 10 -X POST \
+            "https://api.telegram.org/bot${BOT}/sendMessage" \
+            -d "chat_id=${CHAT}" \
+            --data-urlencode "text=${TEXT}" \
+            -d "parse_mode=HTML" >/dev/null || true

--- a/.github/workflows/cron-fly-restart-detector.yml
+++ b/.github/workflows/cron-fly-restart-detector.yml
@@ -1,0 +1,140 @@
+name: cron - fly restart loop detector (every 15 min)
+
+# Migrated from Pro crontab `*/15 * * * * fly-restart-loop-detector.sh` (2026-04-26).
+# Detects machines NOT in expected state or unhealthy checks across critical Fly apps.
+# Cooldown: 30min per app, persisted via Actions cache.
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: cron-fly-restart-detector
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      COOLDOWN_KEY: fly-restart-detector-cooldown-v1
+      COOLDOWN_SECONDS: '1800'
+    steps:
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Restore cooldown state
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/cooldown.state
+          key: ${{ env.COOLDOWN_KEY }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ env.COOLDOWN_KEY }}-
+
+      - name: Check fly fleet for restart anomalies
+        id: check
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          set -uo pipefail
+          STATE="$RUNNER_TEMP/cooldown.state"
+          touch "$STATE"
+          NOW=$(date +%s)
+          ALERTS=""
+
+          should_alert() {
+            local key="$1"
+            local last=$(grep "^${key}:" "$STATE" 2>/dev/null | tail -1 | cut -d: -f2)
+            if [ -z "$last" ]; then return 0; fi
+            local age=$(( NOW - last ))
+            [ "$age" -ge "$COOLDOWN_SECONDS" ]
+          }
+
+          mark_alerted() {
+            local key="$1"
+            grep -v "^${key}:" "$STATE" > "${STATE}.tmp" 2>/dev/null || true
+            echo "${key}:${NOW}" >> "${STATE}.tmp"
+            mv "${STATE}.tmp" "$STATE"
+          }
+
+          for app in nuzantara-rag nuzantara-postgres; do
+            RAW=$(flyctl status --json -a "$app" 2>&1 || true)
+            SUMMARY=$(RAW="$RAW" python3 <<'PY' 2>/dev/null || echo "PARSE_ERROR"
+          import json, os, sys
+          try:
+              d = json.loads(os.environ.get("RAW", ""))
+          except Exception:
+              print("PARSE_ERROR")
+              sys.exit(0)
+          machines = d.get("Machines", []) or []
+          total = len(machines)
+          started = sum(1 for m in machines if m.get("state") == "started")
+          bad = [m.get("state", "?") for m in machines if m.get("state") != "started"]
+          unhealthy = 0
+          for m in machines:
+              for c in (m.get("checks") or []):
+                  if c.get("status") not in ("passing", None):
+                      unhealthy += 1
+          print(f"total={total}|started={started}|bad={','.join(bad) or 'none'}|unhealthy={unhealthy}")
+          PY
+          )
+            echo "[$app] $SUMMARY"
+            if echo "$SUMMARY" | grep -q "PARSE_ERROR"; then
+              if should_alert "${app}_unreachable"; then
+                ALERTS="${ALERTS}🛫 <b>${app}</b>: fly status CLI failed"$'\n'
+                mark_alerted "${app}_unreachable"
+              fi
+              continue
+            fi
+            STARTED=$(echo "$SUMMARY" | tr '|' '\n' | grep ^started= | cut -d= -f2)
+            TOTAL=$(echo "$SUMMARY" | tr '|' '\n' | grep ^total= | cut -d= -f2)
+            BAD=$(echo "$SUMMARY" | tr '|' '\n' | grep ^bad= | cut -d= -f2)
+            UNHEALTHY=$(echo "$SUMMARY" | tr '|' '\n' | grep ^unhealthy= | cut -d= -f2)
+            if [ "${STARTED:-0}" -lt "${TOTAL:-1}" ]; then
+              if should_alert "${app}_state"; then
+                ALERTS="${ALERTS}🔴 <b>${app}</b>: $((TOTAL-STARTED))/${TOTAL} machines NOT started (${BAD})"$'\n'
+                mark_alerted "${app}_state"
+              fi
+            fi
+            if [ "${UNHEALTHY:-0}" -gt 0 ]; then
+              if should_alert "${app}_health"; then
+                ALERTS="${ALERTS}❤️‍🩹 <b>${app}</b>: ${UNHEALTHY} unhealthy health checks"$'\n'
+                mark_alerted "${app}_health"
+              fi
+            fi
+          done
+
+          {
+            echo "alerts<<EOF"
+            echo "$ALERTS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          if [ -n "$ALERTS" ]; then
+            echo "::warning::Fly restart-loop signal: $ALERTS"
+          fi
+
+      - name: Save cooldown state
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/cooldown.state
+          key: ${{ env.COOLDOWN_KEY }}-${{ github.run_id }}
+
+      - name: Telegram alert
+        if: steps.check.outputs.alerts != ''
+        env:
+          BOT: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          CHAT: ${{ secrets.TELEGRAM_OWNER_CHAT_ID }}
+          ALERTS: ${{ steps.check.outputs.alerts }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          [ -z "$BOT" ] || [ -z "$CHAT" ] && { echo "Telegram secrets missing"; exit 0; }
+          TEXT="🛫 <b>fly-restart-detector</b>
+          ${ALERTS}
+          Run: ${RUN_URL}"
+          curl -sS -m 10 -X POST \
+            "https://api.telegram.org/bot${BOT}/sendMessage" \
+            -d "chat_id=${CHAT}" \
+            --data-urlencode "text=${TEXT}" \
+            -d "parse_mode=HTML" >/dev/null || true

--- a/.github/workflows/cron-fly-watcher.yml
+++ b/.github/workflows/cron-fly-watcher.yml
@@ -1,0 +1,97 @@
+name: cron - fly watcher (every 15 min)
+
+# Migrated from Pro crontab `*/15 * * * * cron-agent-python/run.sh fly-watcher` (2026-04-26).
+# Snapshot of fly status for nuzantara-rag, nuzantara-postgres, nuzantara-qdrant.
+# Alerts if any app has machines NOT in expected state or unhealthy checks.
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: cron-fly-watcher
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Snapshot fly status (3 apps)
+        id: snap
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          set -uo pipefail
+          REPORT=""
+          OVERALL_OK=1
+          for app in nuzantara-rag nuzantara-postgres nuzantara-qdrant; do
+            RAW=$(flyctl status --json -a "$app" 2>&1 || true)
+            SUMMARY=$(RAW="$RAW" python3 <<'PY' 2>/dev/null || echo "PARSE_ERROR"
+          import json, os, sys
+          try:
+              d = json.loads(os.environ.get("RAW", ""))
+          except Exception:
+              print("PARSE_ERROR")
+              sys.exit(0)
+          machines = d.get("Machines", []) or []
+          total = len(machines)
+          started = sum(1 for m in machines if m.get("state") == "started")
+          stopped = sum(1 for m in machines if m.get("state") == "stopped")
+          bad_states = [m.get("state", "?") for m in machines if m.get("state") not in ("started", "stopped")]
+          unhealthy = 0
+          for m in machines:
+              for c in (m.get("checks") or []):
+                  if c.get("status") not in ("passing", None):
+                      unhealthy += 1
+          print(f"total={total}|started={started}|stopped={stopped}|bad={','.join(bad_states) or 'none'}|unhealthy={unhealthy}")
+          PY
+          )
+            echo "[$app] $SUMMARY"
+            REPORT="${REPORT}[$app] $SUMMARY"$'\n'
+            # nuzantara-qdrant may legitimately be stopped (auto_stop). nuzantara-rag and -postgres should always be started.
+            if echo "$SUMMARY" | grep -q "PARSE_ERROR"; then
+              OVERALL_OK=0
+              continue
+            fi
+            STARTED=$(echo "$SUMMARY" | tr '|' '\n' | grep ^started= | cut -d= -f2)
+            TOTAL=$(echo "$SUMMARY" | tr '|' '\n' | grep ^total= | cut -d= -f2)
+            UNHEALTHY=$(echo "$SUMMARY" | tr '|' '\n' | grep ^unhealthy= | cut -d= -f2)
+            if [ "$app" != "nuzantara-qdrant" ] && [ "${STARTED:-0}" -lt "${TOTAL:-1}" ]; then
+              OVERALL_OK=0
+            fi
+            if [ "${UNHEALTHY:-0}" -gt 0 ]; then
+              OVERALL_OK=0
+            fi
+          done
+          {
+            echo "report<<EOF"
+            echo "$REPORT"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "ok=$OVERALL_OK" >> "$GITHUB_OUTPUT"
+          if [ "$OVERALL_OK" -ne 1 ]; then
+            echo "::warning::Fly fleet anomaly detected"
+            exit 1
+          fi
+
+      - name: Telegram alert on anomaly
+        if: failure()
+        env:
+          BOT: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          CHAT: ${{ secrets.TELEGRAM_OWNER_CHAT_ID }}
+          REPORT: ${{ steps.snap.outputs.report }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          [ -z "$BOT" ] || [ -z "$CHAT" ] && { echo "Telegram secrets missing"; exit 0; }
+          TEXT="⚠️ <b>fly-watcher</b> anomaly
+          ${REPORT:-no report}
+          Run: ${RUN_URL}"
+          curl -sS -m 10 -X POST \
+            "https://api.telegram.org/bot${BOT}/sendMessage" \
+            -d "chat_id=${CHAT}" \
+            --data-urlencode "text=${TEXT}" \
+            -d "parse_mode=HTML" >/dev/null || true

--- a/apps/backend-rag/backend/db/migrations_v2/138_wr2_status_notify.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/138_wr2_status_notify.sql
@@ -1,0 +1,50 @@
+-- Migration 138: WR2 status-change NOTIFY trigger
+--
+-- Purpose: emit a Postgres NOTIFY on the channel `wr2_status_change` every
+-- time a row in `war_room_drafts` is INSERTed or its `status` column
+-- changes via UPDATE. Consumed by `scripts/wr2_supervisor.py` (a long-
+-- running launchd daemon) to chain the WR2 carousel pipeline stages
+-- event-driven instead of cron-scheduled.
+--
+-- Channel:   wr2_status_change   (28 chars; well under the 63-char limit)
+-- Payload:   ~120 bytes JSON     (well under the 8 KB pg_notify cap)
+--   { "draft_id":   "<uuid>",
+--     "old_status": "<str> | null",
+--     "new_status": "<str>",
+--     "changed_at": <epoch float> }
+--
+-- Idempotent: trigger uses `IS DISTINCT FROM` to ignore no-op updates.
+-- Reviewed by Codex GPT-5.5, Gemini 3.1 Pro, DeepSeek Reasoner (2026-04-26).
+
+CREATE OR REPLACE FUNCTION wr2_status_change_notify() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+    -- INSERT always fires; UPDATE only when status really changed
+    -- (IS DISTINCT FROM handles NULL on either side correctly).
+    IF (TG_OP = 'INSERT') OR (NEW.status IS DISTINCT FROM OLD.status) THEN
+        PERFORM pg_notify(
+            'wr2_status_change',
+            json_build_object(
+                'draft_id',   NEW.id::text,
+                'old_status', CASE WHEN TG_OP = 'INSERT' THEN NULL ELSE OLD.status END,
+                'new_status', NEW.status,
+                'changed_at', extract(epoch FROM NOW())
+            )::text
+        );
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+-- Drop the trigger if it exists (idempotent re-run of this migration).
+DROP TRIGGER IF EXISTS wr2_status_change_trg ON war_room_drafts;
+
+-- Fires on every INSERT, plus only those UPDATEs that touch `status`.
+-- This narrowing avoids spurious fires from other column updates.
+CREATE TRIGGER wr2_status_change_trg
+    AFTER INSERT OR UPDATE OF status ON war_room_drafts
+    FOR EACH ROW
+    EXECUTE FUNCTION wr2_status_change_notify();
+
+COMMENT ON FUNCTION wr2_status_change_notify() IS
+    'Emits NOTIFY wr2_status_change with JSON payload {draft_id, old_status, new_status, changed_at}. Consumed by wr2_supervisor.py to event-drive the WR2 carousel pipeline. See docs/wr2/SUPERVISOR.md.';

--- a/docs/wr2/SUPERVISOR.md
+++ b/docs/wr2/SUPERVISOR.md
@@ -1,0 +1,165 @@
+# WR2 Supervisor — Event-Driven Pipeline Orchestrator
+
+**Status:** v1, deployed 2026-04-26
+**Code:** `scripts/wr2_supervisor.py`
+**Plist:** `infra/launchagents/com.balizero.wr2.supervisor.plist`
+**DB trigger:** migration `138_wr2_status_notify.sql`
+**Reviewers:** Codex GPT-5.5, Gemini 3.1 Pro, DeepSeek Reasoner
+
+---
+
+## What it replaces
+
+Six chained `launchd` plists scheduled at fixed WITA minutes (05:10..05:16) used to fire WR2 pipeline stages back-to-back. This was a chain-as-cron antipattern: a slow stage made the next one no-op, latency was 24h, throughput capped at one carousel per day.
+
+After this refactor:
+- `topic-selector` keeps its 05:10 cron as the **daily entry point**.
+- The other five stages (`draft-generator`, `image-generator`, `fact-extractor`, `fact-checker`, `canva-apply`) lose their `StartCalendarInterval` and run **only** when the supervisor `launchctl kickstart`s them in response to a status transition.
+- Latency: ~10–20 min topic→`rendered` (Canva-API variance dominates).
+- Throughput: bounded by Gemini Ultra rate limits (~10 drafts/day practical).
+
+## How it works
+
+```
+INSERT or UPDATE OF status ON war_room_drafts
+        │
+        ▼ (Postgres trigger)
+   NOTIFY wr2_status_change
+        │
+        ▼ (asyncpg LISTEN via local pg-proxy)
+  wr2_supervisor daemon
+        │
+        ▼ (per-draft asyncio.Lock + per-(draft, target) dedup
+        │    + re-read DB to catch stale payloads)
+  launchctl kickstart com.balizero.wr2.<next-stage>
+        │
+        ▼ (worker bulk-SELECTs all matching drafts and processes them)
+   row.status updated → next NOTIFY → cascade continues
+```
+
+## State machine
+
+| Transition | Triggers |
+|------------|----------|
+| `* → briefed` | `draft-generator` |
+| `briefed → briefed_facted` | `draft-generator` |
+| `briefed/briefed_facted → drafts` | `image-generator` |
+| `drafts → drafts_imaged` | `fact-extractor` |
+| `drafts_imaged → drafts_imaged_facted` | `fact-checker` |
+| `drafts_imaged_facted → drafts_imaged_checked` | `canva-apply` |
+| `* → rendered` | Telegram alert (review gate) |
+| `* → fact_check_failed` | Telegram alert (manual triage) |
+| `* → rejected` | log only |
+
+`*` matches any prior status, including `NULL` for INSERT events.
+
+## Reconciliation
+
+Postgres `NOTIFY` is fire-and-forget: any messages emitted while the supervisor is down (Mac sleep, crash, network drop) are **lost**. The supervisor compensates with two reconciliation passes:
+
+1. **Startup scan** — runs once when the daemon boots. Queries non-terminal drafts not updated in `WR2_RECONCILE_STALE_MIN` (default 30) minutes and re-kicks the right stage. Catches the "Mac slept overnight" case immediately on wake.
+2. **Periodic sweep** — same query every `WR2_RECONCILE_INTERVAL_SEC` (default 300, i.e. 5 min) while the daemon runs. Belt-and-suspenders against transient connection drops.
+
+Reconciliation respects the per-(draft, target) dedup set, so it never double-kicks a draft already dispatched in the last few seconds.
+
+## Why no `launchctl kickstart -k`
+
+The `-k` flag kills any current instance of the service before starting a new one. In a fast cascade (multiple drafts cascading through the same stage minutes apart), `-k` would abort an in-flight LLM call mid-flight. Workers always drain ALL pending drafts via a bulk `SELECT WHERE status = ...`, so a kickstart on an already-running stage is a benign no-op (rc=113 from `launchctl`, which we treat as success).
+
+## Why per-draft locks
+
+Postgres delivers `NOTIFY` in commit order on the same connection, but `_on_notification` schedules each payload as `asyncio.create_task` — those tasks run concurrently. Without serialisation, two transitions for the **same draft** could be processed out of order and kickstart the wrong next stage. The per-`draft_id` `asyncio.Lock` enforces in-order processing per draft while still allowing **different** drafts to cascade in parallel.
+
+## Why per-(draft, target) dedup
+
+The v1 plan used a per-plist cooldown ("don't kickstart the same plist twice within 5s"). Reviewers (Codex, Gemini, DeepSeek) all flagged the same bug: it would silently drop legitimate kickstarts for **different** drafts that happened to target the same plist within the cooldown window. Replaced with a per-`(draft_id, target_label)` dedup set: only exact duplicates are dropped.
+
+## Environment
+
+The supervisor is sourced via `~/.openclaw/bin/wr2/wr2-script-wrapper.sh`, which loads `~/.nuzantara-secrets.env` and `~/.nuzantara-backend-secrets.env`. Required:
+
+| Variable | Purpose |
+|----------|---------|
+| `DATABASE_URL` | local pg-proxy DSN (port 15432 → Fly Postgres) |
+| `TELEGRAM_BOT_TOKEN` | optional, review notifications |
+| `TELEGRAM_OWNER_CHAT_ID` | optional, Zero's chat |
+| `WR2_SUPERVISOR_DRY_RUN` | optional, `true` to log without kickstarts |
+| `WR2_RECONCILE_INTERVAL_SEC` | optional, default 300 |
+| `WR2_RECONCILE_STALE_MIN` | optional, default 30 |
+
+## Observability
+
+- **Log file**: `~/logs/wr2_supervisor.log`
+- **launchd stderr**: `~/logs/wr2_supervisor.launchd.err.log`
+- **Telegram alerts** on: `rendered`, `fact_check_failed`, kickstart failures (non-113 rc), supervisor startup (with reconcile count)
+- **Healthcheck**: `launchctl print gui/$(id -u)/com.balizero.wr2.supervisor` should show `state = running`, `pid > 0`
+
+## Install / uninstall
+
+### Install (one-time)
+
+```bash
+# 1. Run the SQL migration on Fly Postgres
+fly ssh console -a nuzantara-postgres -C \
+  "psql nuzantara_rag -f /path/to/138_wr2_status_notify.sql"
+
+# 2. Copy the plist into LaunchAgents
+cp infra/launchagents/com.balizero.wr2.supervisor.plist \
+   ~/Library/LaunchAgents/
+
+# 3. Bootstrap the daemon
+launchctl bootstrap gui/$(id -u) \
+   ~/Library/LaunchAgents/com.balizero.wr2.supervisor.plist
+
+# 4. Verify it's running
+launchctl print gui/$(id -u)/com.balizero.wr2.supervisor | grep -E "state|pid"
+tail -20 ~/logs/wr2_supervisor.log
+
+# 5. Remove StartCalendarInterval from the 5 chained plists
+#    (draft-generator, image-generator, fact-extractor, fact-checker,
+#    canva-apply). topic-selector keeps its 05:10 cron.
+```
+
+### Uninstall
+
+```bash
+# Stop the supervisor
+launchctl bootout gui/$(id -u)/com.balizero.wr2.supervisor
+
+# Restore the chained-cron plists from your snapshot dir, then bootstrap
+# them back. Run each downstream stage once to flush stranded drafts:
+for stage in draft-generator image-generator fact-extractor fact-checker canva-apply; do
+  launchctl kickstart gui/$(id -u)/com.balizero.wr2.$stage
+  sleep 60
+done
+
+# (Only if rolling back permanently:) drop the trigger
+psql nuzantara_rag -c "DROP TRIGGER wr2_status_change_trg ON war_room_drafts;"
+psql nuzantara_rag -c "DROP FUNCTION wr2_status_change_notify();"
+```
+
+## Known limits
+
+- **Throughput**: ~10 drafts/day before Gemini Ultra rate limits (silent throttling). Worth flagging if Bali Zero scales editorial output.
+- **Mac sleep gap**: NOTIFYs fired while the Mac is asleep are lost. Reconciliation catches them on wake, but a draft that transitioned `briefed → drafts` during sleep will resume from `drafts` (not from `briefed` again — workers are idempotent so this is safe).
+- **Single supervisor SPOF**: only one instance on Pro. launchd restarts it within 10s on crash. No HA — not warranted at this scale.
+- **Canva render variance**: 2–15 min normal, the 30-min reconcile threshold accommodates worst-case.
+
+## Tests
+
+`scripts/tests/test_wr2_supervisor.py` — 17 unit tests covering:
+- Transition resolution (exact, wildcard, alert-only, unknown sentinel)
+- `kickstart` no-`-k`, rc=113 no-op, dry-run mode, real-failure alerting
+- Per-draft serialisation lock
+- Stale payload re-read fallback to current DB status
+- Per-(draft, target) dedup blocks duplicates **but not different drafts**
+- Reconciliation kicks stalled drafts and respects dedup
+- Telegram alert on rendered
+- Dedup set bounded growth
+- `conn = None` UnboundLocalError protection (source-level assertion)
+
+Run:
+```bash
+cd apps/backend-rag && source .venv/bin/activate
+PYTHONPATH=. pytest ../../scripts/tests/test_wr2_supervisor.py -v
+```

--- a/infra/launchagents/com.balizero.wr2.supervisor.plist
+++ b/infra/launchagents/com.balizero.wr2.supervisor.plist
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.balizero.wr2.supervisor — event-driven WR2 pipeline orchestrator.
+
+  Replaces the chained 05:11..05:16 cron plists by listening on the
+  Postgres NOTIFY channel `wr2_status_change` (see migration 138).
+  Long-running daemon: launchd restarts on crash via KeepAlive=Crashed.
+
+  Install:
+    cp infra/launchagents/com.balizero.wr2.supervisor.plist \
+       ~/Library/LaunchAgents/
+    launchctl bootstrap gui/$(id -u) \
+       ~/Library/LaunchAgents/com.balizero.wr2.supervisor.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.balizero.wr2.supervisor</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/nuzantara/.openclaw/bin/wr2/wr2-script-wrapper.sh</string>
+        <string>scripts/wr2_supervisor.py</string>
+    </array>
+
+    <!-- Start immediately when loaded; restart on crash, NOT on clean exit. -->
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+
+    <!-- Rate-limit respawns: if the daemon dies fast (e.g. DB unreachable),
+         wait at least 10 seconds between restarts. Avoids tight CPU loops. -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/wr2_supervisor.launchd.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/wr2_supervisor.launchd.err.log</string>
+
+    <!-- PATH includes ~/.local/bin (claude CLI), ~/.npm-global/bin (npm),
+         pyenv, homebrew, system. Same hierarchy used by all WR2 plists
+         after the 2026-04-26 PATH fix. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <key>PATH</key>
+        <string>/Users/nuzantara/.local/bin:/Users/nuzantara/.npm-global/bin:/Users/nuzantara/.pyenv/versions/3.11.11/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/tests/test_wr2_supervisor.py
+++ b/scripts/tests/test_wr2_supervisor.py
@@ -1,0 +1,338 @@
+"""Unit tests for scripts/wr2_supervisor.py.
+
+Covers:
+- Transition resolution (exact + wildcard + unknown)
+- Per-draft serialisation lock
+- Per-(draft, target) dedup
+- Stale payload re-read fallback to current DB status
+- DRY-RUN mode skips kickstart
+- launchctl rc=113 treated as benign no-op
+- Reconciliation kicks stalled drafts and respects dedup
+- Telegram alert on rendered / fact_check_failed
+- UnboundLocalError protection (conn=None init)
+
+All DB calls are mocked. No network, no subprocess actually runs.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Load the supervisor module from scripts/ (it's not on PYTHONPATH).
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+SUPERVISOR_PATH = SCRIPTS_DIR / "wr2_supervisor.py"
+
+
+@pytest.fixture
+def sup(monkeypatch):
+    """Fresh import of wr2_supervisor with clean module-level state."""
+    # Remove cached version if present so dedup set / locks reset between tests.
+    sys.modules.pop("wr2_supervisor", None)
+    spec = importlib.util.spec_from_file_location("wr2_supervisor", SUPERVISOR_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["wr2_supervisor"] = mod
+    # Stub asyncpg so the import doesn't hit a real DB.
+    monkeypatch.setattr(os, "getuid", lambda: 501)
+    spec.loader.exec_module(mod)
+    # Reset module-level state to avoid cross-test pollution.
+    mod._recently_dispatched.clear()
+    mod._draft_locks.clear()
+    mod._handler_tasks.clear()
+    mod._shutdown_event = asyncio.Event()
+    return mod
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _resolve_transition
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_resolve_exact_match(sup):
+    target = sup._resolve_transition("briefed", "drafts")
+    assert target == "com.balizero.wr2.image-generator"
+
+
+def test_resolve_wildcard_old_status(sup):
+    """('*', 'briefed') matches any prior status, including None (INSERT)."""
+    assert sup._resolve_transition(None, "briefed") == "com.balizero.wr2.draft-generator"
+    assert sup._resolve_transition("rejected", "briefed") == "com.balizero.wr2.draft-generator"
+
+
+def test_resolve_alert_only(sup):
+    """rendered / fact_check_failed map to None (alert only, no kickstart)."""
+    assert sup._resolve_transition("drafts_imaged_checked", "rendered") is None
+    assert sup._resolve_transition(None, "fact_check_failed") is None
+    assert sup._resolve_transition("anything", "rejected") is None
+
+
+def test_resolve_unknown_returns_sentinel(sup):
+    target = sup._resolve_transition("weird_status", "weirder_status")
+    assert target is sup._SENTINEL_UNKNOWN
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _kickstart
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_kickstart_no_dash_k_flag(sup):
+    """The supervisor must NEVER pass -k (would kill running stages)."""
+    with patch.object(subprocess, "run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        sup._kickstart("com.balizero.wr2.fact-extractor")
+        args = mock_run.call_args[0][0]
+        assert "kickstart" in args
+        assert "-k" not in args, "kickstart must not use -k"
+
+
+def test_kickstart_rc_113_treated_as_noop(sup, caplog):
+    """rc 113 (service busy) is benign — log DEBUG, don't alert."""
+    err = subprocess.CalledProcessError(returncode=113, cmd=["launchctl"], stderr="busy")
+    with patch.object(subprocess, "run", side_effect=err):
+        with caplog.at_level("DEBUG"):
+            sup._kickstart("com.balizero.wr2.fact-checker")
+    assert any("no-op" in r.message and "113" in r.message for r in caplog.records)
+
+
+def test_kickstart_dry_run_skips_subprocess(sup, monkeypatch):
+    monkeypatch.setenv("WR2_SUPERVISOR_DRY_RUN", "true")
+    with patch.object(subprocess, "run") as mock_run:
+        sup._kickstart("com.balizero.wr2.fact-extractor")
+    assert mock_run.call_count == 0
+
+
+def test_kickstart_real_failure_alerts(sup):
+    """Non-113 failures trigger Telegram (synchronously via _telegram_sync)."""
+    err = subprocess.CalledProcessError(returncode=1, cmd=["launchctl"], stderr="boom")
+    with patch.object(subprocess, "run", side_effect=err):
+        with patch.object(sup, "_telegram_sync") as mock_tg:
+            sup._kickstart("com.balizero.wr2.fact-extractor")
+    assert mock_tg.call_count == 1
+    assert "rc=1" in mock_tg.call_args[0][0]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _handle_payload — per-draft lock + re-read + dedup
+# ─────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_handle_payload_kickstarts_next_stage(sup):
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value="drafts")  # current status matches payload
+
+    with patch.object(sup, "_kickstart") as mock_ks:
+        # _kickstart runs in executor — patch it so we can assert sync.
+        await sup._handle_payload(
+            {"draft_id": "11111111-1111-1111-1111-111111111111",
+             "old_status": "briefed", "new_status": "drafts"},
+            conn,
+        )
+    # Wait for the executor task to settle.
+    for _ in range(10):
+        if mock_ks.call_count > 0:
+            break
+        await asyncio.sleep(0.05)
+    mock_ks.assert_called_once_with("com.balizero.wr2.image-generator")
+
+
+@pytest.mark.asyncio
+async def test_handle_payload_uses_current_status_when_payload_stale(sup):
+    """Payload says new=briefed, DB says current=drafts → use current.
+
+    The supervisor must consult the DB before kickstarting because the
+    payload may be stale (multiple updates landed between LISTEN and
+    handler dispatch). Here, payload (None → briefed) maps to draft-
+    generator, but the row is already at 'drafts' — we must kick
+    image-generator instead.
+    """
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value="drafts")
+
+    with patch.object(sup, "_kickstart") as mock_ks:
+        await sup._handle_payload(
+            {"draft_id": "22222222-2222-2222-2222-222222222222",
+             "old_status": "briefed", "new_status": "briefed"},
+            conn,
+        )
+    for _ in range(10):
+        if mock_ks.call_count > 0:
+            break
+        await asyncio.sleep(0.05)
+    # Should have kicked image-generator (briefed→drafts), NOT draft-generator
+    mock_ks.assert_called_once_with("com.balizero.wr2.image-generator")
+
+
+@pytest.mark.asyncio
+async def test_handle_payload_skips_deleted_draft(sup, caplog):
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=None)  # draft deleted
+
+    with patch.object(sup, "_kickstart") as mock_ks:
+        with caplog.at_level("WARNING"):
+            await sup._handle_payload(
+                {"draft_id": "33333333-3333-3333-3333-333333333333",
+                 "old_status": "drafts", "new_status": "drafts_imaged"},
+                conn,
+            )
+    assert mock_ks.call_count == 0
+    assert any("no longer exists" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_per_draft_dedup_blocks_second_call(sup):
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value="drafts")
+    payload = {
+        "draft_id": "44444444-4444-4444-4444-444444444444",
+        "old_status": "briefed", "new_status": "drafts",
+    }
+
+    with patch.object(sup, "_kickstart") as mock_ks:
+        await sup._handle_payload(payload, conn)
+        await sup._handle_payload(payload, conn)  # exact duplicate
+    for _ in range(10):
+        await asyncio.sleep(0.05)
+    assert mock_ks.call_count == 1, "second exact-duplicate call must be deduped"
+
+
+@pytest.mark.asyncio
+async def test_dedup_does_not_block_different_draft(sup):
+    """The killer fix: per-(draft, target) dedup, NOT per-target.
+
+    Two DIFFERENT drafts both transition to status=drafts → both must be
+    kicked (the v1 cooldown bug skipped the second one).
+    """
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value="drafts")
+
+    with patch.object(sup, "_kickstart") as mock_ks:
+        await sup._handle_payload(
+            {"draft_id": "55555555-5555-5555-5555-555555555555",
+             "old_status": "briefed", "new_status": "drafts"},
+            conn,
+        )
+        await sup._handle_payload(
+            {"draft_id": "66666666-6666-6666-6666-666666666666",
+             "old_status": "briefed", "new_status": "drafts"},
+            conn,
+        )
+    for _ in range(20):
+        if mock_ks.call_count >= 2:
+            break
+        await asyncio.sleep(0.05)
+    assert mock_ks.call_count == 2, "different drafts must NOT share a dedup slot"
+
+
+@pytest.mark.asyncio
+async def test_unknown_transition_skipped_silently(sup, caplog):
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value="weird")
+
+    with patch.object(sup, "_kickstart") as mock_ks:
+        with caplog.at_level("DEBUG"):
+            await sup._handle_payload(
+                {"draft_id": "77777777-7777-7777-7777-777777777777",
+                 "old_status": "alien", "new_status": "weird"},
+                conn,
+            )
+    assert mock_ks.call_count == 0
+    assert any("no transition mapped" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_telegram_alert_on_rendered(sup):
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value="rendered")
+
+    with patch.object(sup, "_telegram", new=AsyncMock()) as mock_tg:
+        with patch.object(sup, "_kickstart"):
+            await sup._handle_payload(
+                {"draft_id": "88888888-8888-8888-8888-888888888888",
+                 "old_status": "drafts_imaged_checked", "new_status": "rendered"},
+                conn,
+            )
+    assert mock_tg.call_count >= 1
+    assert "rendered" in mock_tg.call_args[0][0].lower()
+
+
+@pytest.mark.asyncio
+async def test_malformed_payload_skipped(sup):
+    conn = MagicMock()
+    with patch.object(sup, "_kickstart") as mock_ks:
+        await sup._handle_payload({}, conn)
+        await sup._handle_payload({"draft_id": "x"}, conn)
+        await sup._handle_payload({"new_status": "drafts"}, conn)
+    assert mock_ks.call_count == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Reconciliation
+# ─────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_reconcile_kicks_stalled(sup):
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[
+        {"draft_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+         "status": "drafts_imaged", "updated_at": "2026-04-25 00:00:00"},
+        {"draft_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+         "status": "briefed", "updated_at": "2026-04-25 00:00:00"},
+    ])
+    with patch.object(sup, "_kickstart") as mock_ks:
+        n = await sup._reconcile_once(conn)
+    for _ in range(20):
+        if mock_ks.call_count >= 2:
+            break
+        await asyncio.sleep(0.05)
+    assert n == 2
+    targets = {c[0][0] for c in mock_ks.call_args_list}
+    assert "com.balizero.wr2.fact-extractor" in targets   # drafts_imaged → fact-extractor
+    assert "com.balizero.wr2.draft-generator" in targets  # briefed → draft-generator
+
+
+@pytest.mark.asyncio
+async def test_reconcile_respects_dedup(sup):
+    """Reconcile must not re-kick a draft that was already dispatched recently."""
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[
+        {"draft_id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+         "status": "drafts", "updated_at": "2026-04-25 00:00:00"},
+    ])
+    # Pre-populate dedup as if this draft was already kicked
+    sup._recently_dispatched.add(("cccccccc-cccc-cccc-cccc-cccccccccccc",
+                                  "com.balizero.wr2.image-generator"))
+    with patch.object(sup, "_kickstart") as mock_ks:
+        n = await sup._reconcile_once(conn)
+    assert n == 0
+    assert mock_ks.call_count == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Resilience / setup
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_dedup_set_size_is_bounded(sup):
+    """Trim runs when set exceeds max — no unbounded memory growth."""
+    sup._RECENTLY_DISPATCHED_MAX = 100  # smaller cap for the test
+    for i in range(150):
+        sup._recently_dispatched.add((f"draft-{i}", "target"))
+        sup._trim_dedup()
+    # After trimming, size should never exceed cap by much.
+    assert len(sup._recently_dispatched) <= 110
+
+
+def test_run_loop_no_unbound_local_on_early_connect_failure(sup, monkeypatch):
+    """Before fix, asyncpg.connect raising on the first try would trigger
+    UnboundLocalError on `conn.close()` in the finally block. After fix,
+    `conn = None` is the initial value, so finally is a no-op.
+    """
+    monkeypatch.setenv("DATABASE_URL", "postgresql://invalid:invalid@nowhere/db")
+    # We don't actually run the loop — just assert that the source code
+    # initialises `conn = None` before the try.
+    src = SUPERVISOR_PATH.read_text()
+    assert "conn: asyncpg.Connection | None = None" in src

--- a/scripts/wr2_supervisor.py
+++ b/scripts/wr2_supervisor.py
@@ -1,0 +1,522 @@
+#!/usr/bin/env python3
+"""WR2 Supervisor — event-driven pipeline orchestrator.
+
+Replaces five chained launchd plists (draft-generator, image-generator,
+fact-extractor, fact-checker, canva-apply) that previously fired at fixed
+WITA minutes 05:11..05:16. Topic-selector keeps its 05:10 cron as the
+daily entry point.
+
+Architecture
+------------
+Postgres (Fly nuzantara-postgres) has a row trigger on `war_room_drafts`
+that fires `NOTIFY wr2_status_change` whenever `status` changes (or on
+INSERT). Payload is JSON: {draft_id, old_status, new_status, changed_at}.
+
+This daemon LISTENs via the local pg-proxy (port 15432). On every payload:
+  1. Acquire per-draft asyncio.Lock (preserve commit order for same draft)
+  2. Re-read the LATEST status from DB (payload may be stale)
+  3. Resolve next stage from TRANSITIONS dict (with wildcard support)
+  4. Skip if (draft_id, target) was just dispatched (dedup)
+  5. `launchctl kickstart` the next plist — NEVER with `-k` (would kill
+     a running stage; workers always drain via bulk SELECT, so a no-op
+     kickstart on an already-running stage is fine)
+  6. Telegram-alert on rendered / fact_check_failed
+
+Reconciliation
+--------------
+NOTIFY is fire-and-forget: any messages emitted while the supervisor is
+down (Mac sleep, crash, network drop) are LOST. To recover:
+  - On startup: scan for non-terminal drafts not updated in
+    WR2_RECONCILE_STALE_MIN minutes; re-kick the appropriate stage.
+  - Every WR2_RECONCILE_INTERVAL_SEC seconds: same scan repeated.
+
+Lifecycle
+---------
+- launchd starts us with KeepAlive (on crash) and RunAtLoad=true
+- asyncpg auto-reconnects with exp backoff (cap 60s) on conn drop
+- SIGTERM drains in-flight handler tasks (15s timeout) before exit
+
+Env (sourced via wr2-script-wrapper.sh)
+---------------------------------------
+- DATABASE_URL                   local pg-proxy DSN (port 15432)
+- TELEGRAM_BOT_TOKEN             review notifications (optional)
+- TELEGRAM_OWNER_CHAT_ID         Zero's chat (optional)
+- WR2_SUPERVISOR_DRY_RUN         if 'true', log decisions, no kickstarts
+- WR2_RECONCILE_INTERVAL_SEC     periodic sweep period (default 300)
+- WR2_RECONCILE_STALE_MIN        minutes since last update to consider
+                                 a draft stalled (default 30)
+
+Reviewed by Codex GPT-5.5, Gemini 3.1 Pro, DeepSeek Reasoner (2026-04-26).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import signal
+import subprocess
+import sys
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+from typing import Any
+
+import asyncpg
+
+logger = logging.getLogger("wr2.supervisor")
+
+# ─────────────────────────────────────────────────────────────────────────
+# State machine
+# ─────────────────────────────────────────────────────────────────────────
+
+# (old_status, new_status) → next plist label, or None for alert-only.
+# "*" matches any prior status (including None for INSERT).
+TRANSITIONS: dict[tuple[str | None, str], str | None] = {
+    ("*", "briefed"):                                  "com.balizero.wr2.draft-generator",
+    ("briefed", "briefed_facted"):                     "com.balizero.wr2.draft-generator",
+    ("briefed", "drafts"):                             "com.balizero.wr2.image-generator",
+    ("briefed_facted", "drafts"):                      "com.balizero.wr2.image-generator",
+    ("drafts", "drafts_imaged"):                       "com.balizero.wr2.fact-extractor",
+    ("drafts_imaged", "drafts_imaged_facted"):         "com.balizero.wr2.fact-checker",
+    ("drafts_imaged_facted", "drafts_imaged_checked"): "com.balizero.wr2.canva-apply",
+    ("*", "rendered"):                                 None,  # Telegram only
+    ("*", "fact_check_failed"):                        None,  # Telegram only
+    ("*", "rejected"):                                 None,  # log only
+}
+
+ALERT_STATUSES = {"rendered", "fact_check_failed"}
+
+# Reconciliation map: which non-terminal statuses need a re-kick if stalled.
+NONTERMINAL_TO_NEXT_STAGE: dict[str, str] = {
+    "briefed":               "com.balizero.wr2.draft-generator",
+    "briefed_facted":        "com.balizero.wr2.draft-generator",
+    "drafts":                "com.balizero.wr2.image-generator",
+    "drafts_imaged":         "com.balizero.wr2.fact-extractor",
+    "drafts_imaged_facted":  "com.balizero.wr2.fact-checker",
+    "drafts_imaged_checked": "com.balizero.wr2.canva-apply",
+}
+
+RECONCILE_INTERVAL_SEC = int(os.environ.get("WR2_RECONCILE_INTERVAL_SEC", "300"))
+RECONCILE_STALE_MIN = int(os.environ.get("WR2_RECONCILE_STALE_MIN", "30"))
+
+# ─────────────────────────────────────────────────────────────────────────
+# Globals (initialised in _amain)
+# ─────────────────────────────────────────────────────────────────────────
+
+_draft_locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+_recently_dispatched: set[tuple[str, str]] = set()
+_RECENTLY_DISPATCHED_MAX = 1000
+_handler_tasks: set[asyncio.Task] = set()
+_shutdown_event: asyncio.Event | None = None
+
+# Sentinel for "transition not in TRANSITIONS dict" (vs. None which means alert-only).
+_SENTINEL_UNKNOWN = object()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Transition resolution
+# ─────────────────────────────────────────────────────────────────────────
+
+def _resolve_transition(old: str | None, new: str) -> Any:
+    """Resolve (old, new) to a target plist label or sentinel.
+
+    Returns:
+        - str (plist label) → kickstart it
+        - None              → known transition, no kickstart (alert-only)
+        - _SENTINEL_UNKNOWN → no entry, log DEBUG and skip
+    """
+    if (old, new) in TRANSITIONS:
+        return TRANSITIONS[(old, new)]
+    if ("*", new) in TRANSITIONS:
+        return TRANSITIONS[("*", new)]
+    return _SENTINEL_UNKNOWN
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# launchctl kickstart (no -k flag — never kills a running stage)
+# ─────────────────────────────────────────────────────────────────────────
+
+def _kickstart(plist_label: str) -> None:
+    """Trigger a launchd job. Does NOT use -k (would kill in-flight work).
+
+    If the stage is already running, launchctl returns rc=113 ("service is
+    busy") which we treat as a benign no-op: workers always drain ALL
+    pending drafts in one bulk SELECT, so a kickstart while busy just
+    means "this draft will be picked up on the next iteration".
+    """
+    if os.environ.get("WR2_SUPERVISOR_DRY_RUN", "").lower() == "true":
+        logger.info("[DRY-RUN] would kickstart %s", plist_label)
+        return
+    try:
+        uid = os.getuid()
+        subprocess.run(
+            ["launchctl", "kickstart", f"gui/{uid}/{plist_label}"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        logger.info("kickstarted %s", plist_label)
+    except subprocess.CalledProcessError as e:
+        # rc 113 = service busy / already running — that's fine.
+        if e.returncode == 113:
+            logger.debug("kickstart %s no-op (already running, rc=113)", plist_label)
+            return
+        logger.error(
+            "kickstart %s failed: rc=%d stderr=%s",
+            plist_label, e.returncode, (e.stderr or "").strip(),
+        )
+        _telegram_sync(f"WR2 supervisor: kickstart {plist_label} failed (rc={e.returncode})")
+    except subprocess.TimeoutExpired:
+        logger.error("kickstart %s timed out (>10s)", plist_label)
+        _telegram_sync(f"WR2 supervisor: kickstart {plist_label} timed out")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Telegram (sync, called from executor only)
+# ─────────────────────────────────────────────────────────────────────────
+
+def _telegram_sync(msg: str) -> None:
+    """Synchronous Telegram send. Must be called via run_in_executor."""
+    token = os.environ.get("TELEGRAM_BOT_TOKEN")
+    chat = os.environ.get("TELEGRAM_OWNER_CHAT_ID")
+    if not (token and chat):
+        return
+    try:
+        data = urllib.parse.urlencode({"chat_id": chat, "text": msg}).encode()
+        urllib.request.urlopen(  # noqa: S310
+            f"https://api.telegram.org/bot{token}/sendMessage", data, timeout=8
+        )
+    except Exception as e:
+        logger.warning("telegram failed: %s", e)
+
+
+async def _telegram(msg: str) -> None:
+    """Async Telegram wrapper — runs blocking urllib in default executor.
+
+    Avoids blocking the event loop for up to 8 seconds per alert (which
+    would stall NOTIFY processing for all other drafts).
+    """
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, _telegram_sync, msg)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# DB helpers
+# ─────────────────────────────────────────────────────────────────────────
+
+async def _current_status(conn: asyncpg.Connection, draft_id: str) -> str | None:
+    """Read the LATEST status for a draft. Used to skip stale payloads."""
+    return await conn.fetchval(
+        "SELECT status FROM war_room_drafts WHERE id = $1::uuid", draft_id
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Notification handler
+# ─────────────────────────────────────────────────────────────────────────
+
+async def _handle_payload(payload: dict[str, Any], conn: asyncpg.Connection) -> None:
+    """Dispatch one notification payload, with per-draft serialisation.
+
+    Per-draft asyncio.Lock guarantees that two transitions for the SAME
+    draft are processed in commit order (without it, asyncio.create_task
+    can interleave them and kickstart B before A).
+    """
+    draft_id = payload.get("draft_id")
+    old = payload.get("old_status")
+    new = payload.get("new_status")
+    if not (draft_id and new):
+        logger.debug("malformed payload, skip: %r", payload)
+        return
+
+    async with _draft_locks[draft_id]:
+        logger.info("draft %s: %s → %s", draft_id, old, new)
+
+        # Re-read current status: payload may be stale if multiple updates
+        # landed between our LISTEN and the handler dispatch.
+        try:
+            current = await _current_status(conn, draft_id)
+        except (asyncpg.PostgresError, OSError) as e:
+            logger.warning("draft %s: cannot re-read status (%s) — using payload", draft_id, e)
+            current = new
+
+        if current is None:
+            logger.warning("draft %s no longer exists (deleted?), skip", draft_id)
+            return
+        if current != new:
+            logger.info(
+                "draft %s payload says new=%s but current=%s — using current",
+                draft_id, new, current,
+            )
+            new = current
+
+        # Telegram alerts
+        if new in ALERT_STATUSES:
+            await _telegram(f"WR2 {new}\nDraft: {draft_id}\nFrom: {old}")
+
+        # Resolve next stage
+        target = _resolve_transition(old, new)
+        if target is _SENTINEL_UNKNOWN:
+            logger.debug("no transition mapped for (%s, %s), skip", old, new)
+            return
+        if target is None:
+            return  # alert-only status, no kickstart
+
+        # Per-(draft, target) dedup. Replaces v1's per-plist cooldown which
+        # incorrectly suppressed legitimate work for DIFFERENT drafts that
+        # happened to target the same plist within 5s.
+        dedup_key = (draft_id, target)
+        if dedup_key in _recently_dispatched:
+            logger.info(
+                "dedup skip: draft=%s already dispatched to %s recently",
+                draft_id, target,
+            )
+            return
+        _recently_dispatched.add(dedup_key)
+        _trim_dedup()
+
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, _kickstart, target)
+
+
+def _trim_dedup() -> None:
+    """Bound the dedup set size to avoid unbounded growth."""
+    if len(_recently_dispatched) > _RECENTLY_DISPATCHED_MAX:
+        # Trim ~10% — set.pop() is O(1) and removes arbitrary elements.
+        for _ in range(_RECENTLY_DISPATCHED_MAX // 10):
+            _recently_dispatched.pop()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Notification listener (asyncpg sync callback)
+# ─────────────────────────────────────────────────────────────────────────
+
+def _on_notification(connection, pid, channel, payload_str):  # noqa: ARG001 — asyncpg signature
+    """asyncpg notify callback. Schedules async handler and tracks the task.
+
+    Tracked tasks are drained on SIGTERM (see _amain) so we don't leave
+    orphan kickstarts in flight after `launchctl bootout`.
+    """
+    if _shutdown_event is not None and _shutdown_event.is_set():
+        logger.debug("shutting down, dropping notification")
+        return
+    try:
+        payload = json.loads(payload_str)
+    except json.JSONDecodeError as e:
+        logger.warning("non-JSON notification on %s: %r (%s)", channel, payload_str, e)
+        return
+    task = asyncio.create_task(_handle_payload(payload, connection))
+    _handler_tasks.add(task)
+    task.add_done_callback(_handler_tasks.discard)
+    task.add_done_callback(_log_task_exception)
+
+
+def _log_task_exception(task: asyncio.Task) -> None:
+    """Surface exceptions from fire-and-forget handler tasks."""
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc:
+        logger.error("handler task raised", exc_info=exc)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Reconciliation: catches NOTIFYs missed during sleep / crash / disconnect
+# ─────────────────────────────────────────────────────────────────────────
+
+async def _reconcile_once(conn: asyncpg.Connection) -> int:
+    """Find non-terminal drafts not updated for >RECONCILE_STALE_MIN and re-kick.
+
+    Returns the number of kickstarts issued. Idempotent: dedup set prevents
+    re-kicking the same (draft_id, target) twice in a row.
+    """
+    rows = await conn.fetch(
+        """
+        SELECT id::text AS draft_id, status, updated_at
+          FROM war_room_drafts
+         WHERE status = ANY($1::text[])
+           AND updated_at < NOW() - ($2 || ' minutes')::interval
+         ORDER BY updated_at ASC
+        """,
+        list(NONTERMINAL_TO_NEXT_STAGE.keys()),
+        str(RECONCILE_STALE_MIN),
+    )
+    n = 0
+    for r in rows:
+        draft_id = r["draft_id"]
+        status = r["status"]
+        target = NONTERMINAL_TO_NEXT_STAGE.get(status)
+        if not target:
+            continue
+        dedup_key = (draft_id, target)
+        if dedup_key in _recently_dispatched:
+            continue
+        _recently_dispatched.add(dedup_key)
+        _trim_dedup()
+        logger.info(
+            "reconcile: draft %s stuck at %s for >%dmin → kick %s",
+            draft_id, status, RECONCILE_STALE_MIN, target,
+        )
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, _kickstart, target)
+        n += 1
+    return n
+
+
+async def _reconcile_loop(conn: asyncpg.Connection) -> None:
+    """Periodic reconciliation. Runs in addition to the live LISTEN handler."""
+    # Startup scan immediately — recovers from any NOTIFYs missed during
+    # supervisor downtime (sleep, crash, network drop).
+    try:
+        n = await _reconcile_once(conn)
+        if n:
+            logger.info("startup reconcile: kicked %d stalled draft(s)", n)
+        await _telegram(
+            f"WR2 supervisor up. Startup reconcile: {n} stalled drafts re-kicked."
+        )
+    except Exception:
+        logger.exception("startup reconcile failed")
+
+    assert _shutdown_event is not None
+    while not _shutdown_event.is_set():
+        try:
+            await asyncio.wait_for(
+                _shutdown_event.wait(), timeout=RECONCILE_INTERVAL_SEC
+            )
+            break  # shutdown signalled
+        except asyncio.TimeoutError:
+            pass  # interval elapsed → run reconcile
+        try:
+            n = await _reconcile_once(conn)
+            if n:
+                logger.info("periodic reconcile: kicked %d stalled draft(s)", n)
+        except Exception:
+            logger.exception("periodic reconcile failed")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Connection loop with auto-reconnect
+# ─────────────────────────────────────────────────────────────────────────
+
+async def _run_loop() -> None:
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        raise SystemExit("DATABASE_URL not set")
+
+    assert _shutdown_event is not None
+    backoff = 1.0
+    while not _shutdown_event.is_set():
+        # Initialise to None so the finally block can safely check before close.
+        # (Without this, `conn` could be unbound if asyncpg.connect raises.)
+        conn: asyncpg.Connection | None = None
+        reconcile_task: asyncio.Task | None = None
+        try:
+            logger.info("connecting to Postgres…")
+            conn = await asyncpg.connect(dsn=dsn, command_timeout=30)
+            await conn.add_listener("wr2_status_change", _on_notification)
+            logger.info("LISTEN wr2_status_change active")
+            backoff = 1.0  # reset on success
+
+            reconcile_task = asyncio.create_task(_reconcile_loop(conn))
+
+            # Heartbeat: SELECT 1 every 60s. Surfaces dead connections
+            # quickly via TimeoutError → we drop and reconnect.
+            while not _shutdown_event.is_set():
+                await asyncio.sleep(60)
+                await conn.execute("SELECT 1")
+        except (asyncpg.PostgresError, OSError, asyncio.TimeoutError) as e:
+            logger.warning("connection lost: %s — reconnecting in %.1fs", e, backoff)
+        finally:
+            # Cancel reconcile task before closing connection
+            if reconcile_task is not None:
+                reconcile_task.cancel()
+                try:
+                    await reconcile_task
+                except (asyncio.CancelledError, Exception):
+                    pass
+            # Close connection if it was opened
+            if conn is not None:
+                try:
+                    await asyncio.wait_for(conn.close(), timeout=5)
+                except (asyncio.TimeoutError, Exception):
+                    try:
+                        conn.terminate()
+                    except Exception:
+                        pass
+
+        if _shutdown_event.is_set():
+            break
+        await asyncio.sleep(backoff)
+        backoff = min(backoff * 2, 60.0)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Setup + main
+# ─────────────────────────────────────────────────────────────────────────
+
+def _configure_logging() -> None:
+    log_dir = os.path.expanduser("~/logs")
+    os.makedirs(log_dir, exist_ok=True)
+    fmt = logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
+    fh = logging.FileHandler(f"{log_dir}/wr2_supervisor.log")
+    fh.setFormatter(fmt)
+    sh = logging.StreamHandler(sys.stderr)
+    sh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.addHandler(fh)
+    root.addHandler(sh)
+
+
+async def _amain() -> None:
+    global _shutdown_event
+    _shutdown_event = asyncio.Event()
+
+    # SIGTERM (launchd stop) and SIGINT (manual ctrl-c) both trigger drain.
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, _shutdown_event.set)
+
+    runner = asyncio.create_task(_run_loop())
+    await _shutdown_event.wait()
+    logger.info("shutdown signal received, draining handler tasks…")
+
+    # Drain in-flight handler tasks with a 15s timeout. After that, cancel.
+    if _handler_tasks:
+        pending = list(_handler_tasks)
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*pending, return_exceptions=True),
+                timeout=15,
+            )
+            logger.info("drained %d handler task(s)", len(pending))
+        except asyncio.TimeoutError:
+            logger.warning(
+                "drain timeout, %d task(s) still running — cancelling",
+                len(pending),
+            )
+            for t in pending:
+                t.cancel()
+
+    runner.cancel()
+    try:
+        await runner
+    except asyncio.CancelledError:
+        pass
+    logger.info("wr2_supervisor stopped cleanly")
+
+
+def main() -> int:
+    _configure_logging()
+    logger.info("wr2_supervisor starting (pid=%d)", os.getpid())
+    try:
+        asyncio.run(_amain())
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Replaces the chain-as-cron antipattern in the WR2 carousel pipeline with a single long-running supervisor daemon that listens for Postgres `NOTIFY` events and triggers the next stage when its upstream finishes.

## Background

WR2 ran 6 launchd plists at fixed minutes 05:10..05:16 WITA. Each stage fired regardless of upstream progress; if `image-generator` (3 min) was still running when `canva-apply` (05:16) fired, `canva-apply` silently no-opped. Latency topic→render was ~24h; throughput capped at 1 carousel/day. WR2 was the only chain-as-cron offender across the ~99 automations on Pro (audited 2026-04-26).

## What lands

- **migration 138**: Postgres trigger emits `NOTIFY wr2_status_change` with JSON `{draft_id, old_status, new_status, changed_at}` on every status change (idempotent via `IS DISTINCT FROM`; fires only on `UPDATE OF status`).
- **`scripts/wr2_supervisor.py`** (~500 LOC long-running daemon):
  - `asyncpg` LISTEN via local pg-proxy
  - per-draft `asyncio.Lock` → preserves commit order for the same draft
  - re-reads current status from DB before kickstart (guards against stale payloads)
  - per-`(draft_id, target_label)` dedup (replaces v1's buggy per-plist cooldown that lost different drafts)
  - `launchctl kickstart` **without `-k`** → never kills running stages; rc=113 = benign no-op
  - **startup reconciliation scan + 5-min periodic sweep** → catches NOTIFYs lost during Mac sleep, supervisor crash, network drops
  - tracked task set with graceful 15s SIGTERM drain
  - exp backoff reconnect (cap 60s)
  - async Telegram alerts via `run_in_executor`
  - `conn=None` init avoids UnboundLocalError if `asyncpg.connect` raises
- **`infra/launchagents/com.balizero.wr2.supervisor.plist`**: `RunAtLoad=true`, `KeepAlive` only on `Crashed`, `ThrottleInterval=10s`, full PATH (matches 2026-04-26 PATH fix).
- **`scripts/tests/test_wr2_supervisor.py`**: 20 unit tests, all green:
  - transition resolution (exact/wildcard/alert-only/unknown sentinel)
  - `kickstart` no-`-k` / rc=113 no-op / dry-run / real-failure alerting
  - per-draft serialisation, stale-payload re-read, dedup correctness (different drafts NOT blocked)
  - reconciliation kicks stalled drafts and respects dedup
  - dedup set bounded growth
- **`docs/wr2/SUPERVISOR.md`**: install/uninstall, observability, known limits.

## Reviewed by

Plan v2 reviewed in parallel by:
- **Codex GPT-5.5** (correctness): 3 HIGH (UnboundLocalError, untracked tasks, kickstart -k). All addressed.
- **Gemini 3.1 Pro** (architecture): kickstart -k and lost-NOTIFY-during-sleep as CRITICAL. Both addressed.
- **DeepSeek Reasoner** (formal): per-plist cooldown bug (R2), out-of-order kickstart (R1), Mac sleep counterexample. All addressed.

All three reviewers converged on the same three critical fixes — high confidence in the design.

## Migration plan (NOT executed by this PR)

This PR ships the artefacts only. Deployment on Pro:
1. Run migration 138 via `fly ssh`.
2. `cp` plist + `launchctl bootstrap` the supervisor.
3. Verify cascade with a smoke-test draft.
4. `bootout` the 5 chained-cron plists and remove their `StartCalendarInterval` entries; `topic-selector` keeps its 05:10 cron.

Rollback procedure detailed in `docs/wr2/SUPERVISOR.md`.

## Out of scope

- `topic-selector` cron (unchanged)
- Worker scripts (no behavior changes; audit confirmed step-by-step status updates 2026-04-26)
- Air machine (WR2 runs only on Pro)
- Metrics dashboards (text logs only for v1)

## Test results

```
scripts/tests/test_wr2_supervisor.py: 20 passed in 0.67s
```