### PR TITLE
ops: migrate 3 high-frequency cron jobs to GitHub Actions (week 1)

### DIFF
--- a/.github/workflows/cron-drive-poll.yml
+++ b/.github/workflows/cron-drive-poll.yml
@@ -1,0 +1,63 @@
+name: cron - drive poll (every 5 min)
+
+# Migrated from Pro crontab `*/5 * * * * drive-poll.sh` (2026-04-26).
+# Triggers Drive change polling on backend; nudges Fly out of sleep.
+# Failure path: Telegram alert to owner (cooldown 30min).
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: cron-drive-poll
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: POST /api/admin/drive/poll
+        id: poll
+        env:
+          API_KEY: ${{ secrets.NUZANTARA_API_KEY }}
+        run: |
+          set -uo pipefail
+          BODY_FILE="$RUNNER_TEMP/body.json"
+          HTTP_CODE=$(curl -sS -o "$BODY_FILE" -w "%{http_code}" --max-time 120 \
+            -X POST \
+            -H "X-API-Key: $API_KEY" \
+            -H "Content-Type: application/json" \
+            https://nuzantara-rag.fly.dev/api/admin/drive/poll || echo "000")
+          BODY=$(cat "$BODY_FILE" 2>/dev/null || echo "")
+          echo "http_code=$HTTP_CODE" >> "$GITHUB_OUTPUT"
+          echo "body<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$BODY" | head -c 500 >> "$GITHUB_OUTPUT"
+          echo "" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          if [ "$HTTP_CODE" = "200" ]; then
+            PROCESSED=$(echo "$BODY" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('processed',0))" 2>/dev/null || echo "?")
+            echo "✅ Drive poll OK: $PROCESSED new files processed"
+          else
+            echo "::warning::Drive poll failed (HTTP $HTTP_CODE): $BODY"
+            exit 1
+          fi
+
+      - name: Telegram alert on failure
+        if: failure()
+        env:
+          BOT: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          CHAT: ${{ secrets.TELEGRAM_OWNER_CHAT_ID }}
+          HTTP_CODE: ${{ steps.poll.outputs.http_code }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          [ -z "$BOT" ] || [ -z "$CHAT" ] && { echo "Telegram secrets missing"; exit 0; }
+          TEXT="🚨 <b>drive-poll</b> failed
+          HTTP: ${HTTP_CODE:-?}
+          Run: ${RUN_URL}"
+          curl -sS -m 10 -X POST \
+            "https://api.telegram.org/bot${BOT}/sendMessage" \
+            -d "chat_id=${CHAT}" \
+            --data-urlencode "text=${TEXT}" \
+            -d "parse_mode=HTML" >/dev/null || true

--- a/.github/workflows/cron-fly-restart-detector.yml
+++ b/.github/workflows/cron-fly-restart-detector.yml
@@ -1,0 +1,140 @@
+name: cron - fly restart loop detector (every 15 min)
+
+# Migrated from Pro crontab `*/15 * * * * fly-restart-loop-detector.sh` (2026-04-26).
+# Detects machines NOT in expected state or unhealthy checks across critical Fly apps.
+# Cooldown: 30min per app, persisted via Actions cache.
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: cron-fly-restart-detector
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      COOLDOWN_KEY: fly-restart-detector-cooldown-v1
+      COOLDOWN_SECONDS: '1800'
+    steps:
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Restore cooldown state
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/cooldown.state
+          key: ${{ env.COOLDOWN_KEY }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ env.COOLDOWN_KEY }}-
+
+      - name: Check fly fleet for restart anomalies
+        id: check
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          set -uo pipefail
+          STATE="$RUNNER_TEMP/cooldown.state"
+          touch "$STATE"
+          NOW=$(date +%s)
+          ALERTS=""
+
+          should_alert() {
+            local key="$1"
+            local last=$(grep "^${key}:" "$STATE" 2>/dev/null | tail -1 | cut -d: -f2)
+            if [ -z "$last" ]; then return 0; fi
+            local age=$(( NOW - last ))
+            [ "$age" -ge "$COOLDOWN_SECONDS" ]
+          }
+
+          mark_alerted() {
+            local key="$1"
+            grep -v "^${key}:" "$STATE" > "${STATE}.tmp" 2>/dev/null || true
+            echo "${key}:${NOW}" >> "${STATE}.tmp"
+            mv "${STATE}.tmp" "$STATE"
+          }
+
+          for app in nuzantara-rag nuzantara-postgres; do
+            RAW=$(flyctl status --json -a "$app" 2>&1 || true)
+            SUMMARY=$(RAW="$RAW" python3 <<'PY' 2>/dev/null || echo "PARSE_ERROR"
+          import json, os, sys
+          try:
+              d = json.loads(os.environ.get("RAW", ""))
+          except Exception:
+              print("PARSE_ERROR")
+              sys.exit(0)
+          machines = d.get("Machines", []) or []
+          total = len(machines)
+          started = sum(1 for m in machines if m.get("state") == "started")
+          bad = [m.get("state", "?") for m in machines if m.get("state") != "started"]
+          unhealthy = 0
+          for m in machines:
+              for c in (m.get("checks") or []):
+                  if c.get("status") not in ("passing", None):
+                      unhealthy += 1
+          print(f"total={total}|started={started}|bad={','.join(bad) or 'none'}|unhealthy={unhealthy}")
+          PY
+          )
+            echo "[$app] $SUMMARY"
+            if echo "$SUMMARY" | grep -q "PARSE_ERROR"; then
+              if should_alert "${app}_unreachable"; then
+                ALERTS="${ALERTS}🛫 <b>${app}</b>: fly status CLI failed"$'\n'
+                mark_alerted "${app}_unreachable"
+              fi
+              continue
+            fi
+            STARTED=$(echo "$SUMMARY" | tr '|' '\n' | grep ^started= | cut -d= -f2)
+            TOTAL=$(echo "$SUMMARY" | tr '|' '\n' | grep ^total= | cut -d= -f2)
+            BAD=$(echo "$SUMMARY" | tr '|' '\n' | grep ^bad= | cut -d= -f2)
+            UNHEALTHY=$(echo "$SUMMARY" | tr '|' '\n' | grep ^unhealthy= | cut -d= -f2)
+            if [ "${STARTED:-0}" -lt "${TOTAL:-1}" ]; then
+              if should_alert "${app}_state"; then
+                ALERTS="${ALERTS}🔴 <b>${app}</b>: $((TOTAL-STARTED))/${TOTAL} machines NOT started (${BAD})"$'\n'
+                mark_alerted "${app}_state"
+              fi
+            fi
+            if [ "${UNHEALTHY:-0}" -gt 0 ]; then
+              if should_alert "${app}_health"; then
+                ALERTS="${ALERTS}❤️‍🩹 <b>${app}</b>: ${UNHEALTHY} unhealthy health checks"$'\n'
+                mark_alerted "${app}_health"
+              fi
+            fi
+          done
+
+          {
+            echo "alerts<<EOF"
+            echo "$ALERTS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          if [ -n "$ALERTS" ]; then
+            echo "::warning::Fly restart-loop signal: $ALERTS"
+          fi
+
+      - name: Save cooldown state
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/cooldown.state
+          key: ${{ env.COOLDOWN_KEY }}-${{ github.run_id }}
+
+      - name: Telegram alert
+        if: steps.check.outputs.alerts != ''
+        env:
+          BOT: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          CHAT: ${{ secrets.TELEGRAM_OWNER_CHAT_ID }}
+          ALERTS: ${{ steps.check.outputs.alerts }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          [ -z "$BOT" ] || [ -z "$CHAT" ] && { echo "Telegram secrets missing"; exit 0; }
+          TEXT="🛫 <b>fly-restart-detector</b>
+          ${ALERTS}
+          Run: ${RUN_URL}"
+          curl -sS -m 10 -X POST \
+            "https://api.telegram.org/bot${BOT}/sendMessage" \
+            -d "chat_id=${CHAT}" \
+            --data-urlencode "text=${TEXT}" \
+            -d "parse_mode=HTML" >/dev/null || true

--- a/.github/workflows/cron-fly-watcher.yml
+++ b/.github/workflows/cron-fly-watcher.yml
@@ -1,0 +1,97 @@
+name: cron - fly watcher (every 15 min)
+
+# Migrated from Pro crontab `*/15 * * * * cron-agent-python/run.sh fly-watcher` (2026-04-26).
+# Snapshot of fly status for nuzantara-rag, nuzantara-postgres, nuzantara-qdrant.
+# Alerts if any app has machines NOT in expected state or unhealthy checks.
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: cron-fly-watcher
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Snapshot fly status (3 apps)
+        id: snap
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          set -uo pipefail
+          REPORT=""
+          OVERALL_OK=1
+          for app in nuzantara-rag nuzantara-postgres nuzantara-qdrant; do
+            RAW=$(flyctl status --json -a "$app" 2>&1 || true)
+            SUMMARY=$(RAW="$RAW" python3 <<'PY' 2>/dev/null || echo "PARSE_ERROR"
+          import json, os, sys
+          try:
+              d = json.loads(os.environ.get("RAW", ""))
+          except Exception:
+              print("PARSE_ERROR")
+              sys.exit(0)
+          machines = d.get("Machines", []) or []
+          total = len(machines)
+          started = sum(1 for m in machines if m.get("state") == "started")
+          stopped = sum(1 for m in machines if m.get("state") == "stopped")
+          bad_states = [m.get("state", "?") for m in machines if m.get("state") not in ("started", "stopped")]
+          unhealthy = 0
+          for m in machines:
+              for c in (m.get("checks") or []):
+                  if c.get("status") not in ("passing", None):
+                      unhealthy += 1
+          print(f"total={total}|started={started}|stopped={stopped}|bad={','.join(bad_states) or 'none'}|unhealthy={unhealthy}")
+          PY
+          )
+            echo "[$app] $SUMMARY"
+            REPORT="${REPORT}[$app] $SUMMARY"$'\n'
+            # nuzantara-qdrant may legitimately be stopped (auto_stop). nuzantara-rag and -postgres should always be started.
+            if echo "$SUMMARY" | grep -q "PARSE_ERROR"; then
+              OVERALL_OK=0
+              continue
+            fi
+            STARTED=$(echo "$SUMMARY" | tr '|' '\n' | grep ^started= | cut -d= -f2)
+            TOTAL=$(echo "$SUMMARY" | tr '|' '\n' | grep ^total= | cut -d= -f2)
+            UNHEALTHY=$(echo "$SUMMARY" | tr '|' '\n' | grep ^unhealthy= | cut -d= -f2)
+            if [ "$app" != "nuzantara-qdrant" ] && [ "${STARTED:-0}" -lt "${TOTAL:-1}" ]; then
+              OVERALL_OK=0
+            fi
+            if [ "${UNHEALTHY:-0}" -gt 0 ]; then
+              OVERALL_OK=0
+            fi
+          done
+          {
+            echo "report<<EOF"
+            echo "$REPORT"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "ok=$OVERALL_OK" >> "$GITHUB_OUTPUT"
+          if [ "$OVERALL_OK" -ne 1 ]; then
+            echo "::warning::Fly fleet anomaly detected"
+            exit 1
+          fi
+
+      - name: Telegram alert on anomaly
+        if: failure()
+        env:
+          BOT: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          CHAT: ${{ secrets.TELEGRAM_OWNER_CHAT_ID }}
+          REPORT: ${{ steps.snap.outputs.report }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          [ -z "$BOT" ] || [ -z "$CHAT" ] && { echo "Telegram secrets missing"; exit 0; }
+          TEXT="⚠️ <b>fly-watcher</b> anomaly
+          ${REPORT:-no report}
+          Run: ${RUN_URL}"
+          curl -sS -m 10 -X POST \
+            "https://api.telegram.org/bot${BOT}/sendMessage" \
+            -d "chat_id=${CHAT}" \
+            --data-urlencode "text=${TEXT}" \
+            -d "parse_mode=HTML" >/dev/null || true

--- a/apps/mouth/src/app/(marketing)/page.tsx
+++ b/apps/mouth/src/app/(marketing)/page.tsx
@@ -1,51 +1,56 @@
-import type { Metadata } from "next";
-import { NavShell } from "@balizero/core/components/NavShell";
-import { BZLogo } from "@balizero/core/components/BZLogo";
-import { MobileNav } from "../v2/_components/MobileNav";
-import { HomeSearchButton } from "../v2/_components/HomeSearchButton";
-import { HeroBlueprint } from "../v2/_components/HeroBlueprint";
-import { SocialProof } from "../v2/_components/SocialProof";
-import { FunnelFeature } from "../v2/_components/FunnelFeature";
-import { NewsHero } from "../v2/_components/NewsHero";
-import { TopicPills } from "../v2/_components/TopicPills";
-import { LatestNews } from "../v2/_components/LatestNews";
-import { Footer } from "../v2/_components/Footer";
-import { ZantaraFAB } from "../v2/_components/ZantaraFAB";
-import { getAllArticles } from "@/lib/blog/articles";
-import { buildWhatsAppLink } from "@/lib/whatsapp-utm";
-import { buildCombinedHomepageSchema } from "./_seo/funnel-schema";
-import homepageLayout from "@/content/homepage-layout.json";
+import type { Metadata } from 'next';
+import Script from 'next/script';
+import { NavShell } from '@balizero/core/components/NavShell';
+import { BZLogo } from '@balizero/core/components/BZLogo';
+import { MobileNav } from '../v2/_components/MobileNav';
+import { HomeSearchButton } from '../v2/_components/HomeSearchButton';
+import { HeroBlueprint } from '../v2/_components/HeroBlueprint';
+import { SocialProof } from '../v2/_components/SocialProof';
+import { FunnelFeature } from '../v2/_components/FunnelFeature';
+import { NewsHero } from '../v2/_components/NewsHero';
+import { TopicPills } from '../v2/_components/TopicPills';
+import { LatestNews } from '../v2/_components/LatestNews';
+import { Footer } from '../v2/_components/Footer';
+import { ZantaraFAB } from '../v2/_components/ZantaraFAB';
+import { ZantaraWidget } from '@/components/ZantaraWidget';
+import { HomepageStaticContent } from './HomepageStaticContent';
+import { KbliSearchBox } from './KbliSearchBox';
+import { LatestIntelligence } from './LatestIntelligence';
+import { getAllArticles } from '@/lib/blog/articles';
+import { buildWhatsAppLink } from '@/lib/whatsapp-utm';
+import { buildCombinedHomepageSchema } from './_seo/funnel-schema';
+import homepageLayout from '@/content/homepage-layout.json';
 
 // Force dynamic rendering so / always reflects the freshest MDX covers.
-export const dynamic = "force-dynamic";
+export const dynamic = 'force-dynamic';
 
 // How many cards to show in "Latest from Bali Zero". Auto-adapts grid.
 const LATEST_NEWS_COUNT = 5;
 
 export const metadata: Metadata = {
   title: {
-    absolute: "Bali Zero | #1 Visa & PT PMA Experts in Bali, Indonesia",
+    absolute: 'Bali Zero | #1 Visa & PT PMA Experts in Bali, Indonesia',
   },
   description:
     "Indonesia's AI-powered visa agency. KITAS, KITAP, Golden Visa, PT PMA company setup, tax compliance. 24/7 AI assistant. Trusted by 5000+ clients since 2020.",
   alternates: {
-    canonical: "https://balizero.com",
+    canonical: 'https://balizero.com',
   },
   openGraph: {
-    title: "Bali Zero | #1 Visa & PT PMA Experts in Bali, Indonesia",
+    title: 'Bali Zero | #1 Visa & PT PMA Experts in Bali, Indonesia',
     description:
       "Indonesia's AI-powered visa agency. KITAS, KITAP, Golden Visa, PT PMA company setup, tax compliance. 24/7 AI assistant. Trusted by 5000+ clients.",
-    url: "https://balizero.com",
+    url: 'https://balizero.com',
   },
 };
 
 const NAV_ITEMS = [
-  { label: "Home", href: "#top" },
-  { label: "Visa", href: "#visa" },
-  { label: "Business", href: "#kbli" },
-  { label: "Tax", href: "#tax" },
-  { label: "Property", href: "#property" },
-  { label: "News", href: "#news" },
+  { label: 'Home', href: '#top' },
+  { label: 'Visa', href: '#visa' },
+  { label: 'Business', href: '#kbli' },
+  { label: 'Tax', href: '#tax' },
+  { label: 'Property', href: '#property' },
+  { label: 'News', href: '#news' },
 ];
 
 export default async function HomePage() {
@@ -53,20 +58,19 @@ export default async function HomePage() {
   const layout = homepageLayout as Record<string, string>;
 
   const heroSlugs = new Set(
-    ["hero_main", "hero_2", "hero_3", "hero_4", "hero_5"]
-      .map((k) => layout[k])
-      .filter(Boolean),
+    ['hero_main', 'hero_2', 'hero_3', 'hero_4', 'hero_5'].map((k) => layout[k]).filter(Boolean)
   );
-  const heroArticles = ["hero_main", "hero_2", "hero_3", "hero_4", "hero_5"]
+  const heroArticles = ['hero_main', 'hero_2', 'hero_3', 'hero_4', 'hero_5']
     .map((k) => articles.find((a) => a.slug === layout[k]))
     .filter(Boolean) as typeof articles;
-  const preferred = ["latest_1", "latest_2", "latest_3", "latest_4", "latest_5"]
+  const preferred = ['latest_1', 'latest_2', 'latest_3', 'latest_4', 'latest_5']
     .map((k) => articles.find((a) => a.slug === layout[k]))
     .filter(Boolean) as typeof articles;
   const fallback = articles.filter((a) => !heroSlugs.has(a.slug));
-  const latest = (
-    preferred.length >= LATEST_NEWS_COUNT ? preferred : fallback
-  ).slice(0, LATEST_NEWS_COUNT);
+  const latest = (preferred.length >= LATEST_NEWS_COUNT ? preferred : fallback).slice(
+    0,
+    LATEST_NEWS_COUNT
+  );
 
   const homepageSchema = buildCombinedHomepageSchema();
 
@@ -74,9 +78,9 @@ export default async function HomePage() {
     <div
       id="top"
       style={{
-        background: "var(--surface-base)",
-        color: "var(--text-primary)",
-        minHeight: "100vh",
+        background: 'var(--surface-base)',
+        color: 'var(--text-primary)',
+        minHeight: '100vh',
       }}
     >
       <script
@@ -94,22 +98,22 @@ export default async function HomePage() {
               href="https://kita.balizero.com/"
               className="px-4 py-1.5 rounded-md text-[11px] font-semibold uppercase tracking-wide"
               style={{
-                background: "transparent",
-                color: "var(--text-secondary)",
-                textDecoration: "none",
+                background: 'transparent',
+                color: 'var(--text-secondary)',
+                textDecoration: 'none',
               }}
             >
               Login
             </a>
             <a
-              href={buildWhatsAppLink("home")}
+              href={buildWhatsAppLink('home')}
               target="_blank"
               rel="noopener noreferrer"
               className="px-4 py-1.5 rounded-md text-[11px] font-semibold uppercase tracking-wide"
               style={{
-                background: "var(--accent-funnel)",
-                color: "var(--text-on-accent)",
-                textDecoration: "none",
+                background: 'var(--accent-funnel)',
+                color: 'var(--text-on-accent)',
+                textDecoration: 'none',
               }}
             >
               Get Started
@@ -775,7 +779,8 @@ body::after {
 `,
         }}
       />
-      <HomepageStaticContent html={`
+      <HomepageStaticContent
+        html={`
 <!-- ════════ NAVBAR ════════ -->
 <nav>
   <a class="logo-wrap" href="/">
@@ -1138,7 +1143,8 @@ body::after {
     <a href="/news?category=visas&q=work+permit" class="topic-pill">Work Permits</a>
   </div>
 
-`} />
+`}
+      />
 
       {/* ── Latest Intelligence (client-side, always fresh) ── */}
       <LatestIntelligence />
@@ -1147,22 +1153,32 @@ body::after {
       <div className="kbli-section">
         <div className="kbli-left">
           <span className="kbli-badge">Featured Intelligence Tool</span>
-          <h2 className="kbli-title">KBLI 2025<br />Navigator</h2>
-          <p className="kbli-desc">Instant access to all 1,563 KBLI 2025 codes with intelligent search, 4-level risk assessment, PMA status tracking, and AI-powered guidance.</p>
+          <h2 className="kbli-title">
+            KBLI 2025
+            <br />
+            Navigator
+          </h2>
+          <p className="kbli-desc">
+            Instant access to all 1,563 KBLI 2025 codes with intelligent search, 4-level risk
+            assessment, PMA status tracking, and AI-powered guidance.
+          </p>
           <div className="kbli-features">
             <span className="kbli-feat">Smart bilingual search</span>
             <span className="kbli-feat">4-level risk system</span>
             <span className="kbli-feat">PMA status tracking</span>
             <span className="kbli-feat">AI assistant</span>
           </div>
-          <a href="/kbli" className="kbli-btn">▶ Explore Navigator</a>
+          <a href="/kbli" className="kbli-btn">
+            ▶ Explore Navigator
+          </a>
         </div>
         <div className="kbli-right">
           <KbliSearchBox />
         </div>
       </div>
 
-      <HomepageStaticContent html={`
+      <HomepageStaticContent
+        html={`
   <!-- Services -->
   <div class="services-section">
     <div class="services-top">
@@ -1249,7 +1265,8 @@ body::after {
   </footer>
 </div>
 
-`} />
+`}
+      />
       <ZantaraWidget />
       <Script id="balizero-homepage-js" strategy="afterInteractive">{`
 // ════════ CAROUSEL ENGINE ════════
@@ -1310,6 +1327,6 @@ document.addEventListener('mousemove', function(e) {
   document.body.style.setProperty('--mouse-y', e.clientY + 'px');
 });
 `}</Script>
-    </>
+    </div>
   );
 }

--- a/apps/mouth/src/components/workspace/AppSidebar.tsx
+++ b/apps/mouth/src/components/workspace/AppSidebar.tsx
@@ -1,9 +1,9 @@
-"use client";
+'use client';
 
-import React from "react";
-import Link from "next/link";
-import Image from "next/image";
-import { usePathname } from "next/navigation";
+import React from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import { usePathname } from 'next/navigation';
 import {
   Home,
   Inbox,
@@ -27,14 +27,10 @@ import {
   ClipboardCheck,
   Banknote,
   Terminal,
-} from "lucide-react";
-import {
-  navigation,
-  portalNavigation,
-  NavSection,
-  NavItem,
-} from "@/types/navigation";
-import { cn } from "@/lib/utils";
+  Handshake,
+} from 'lucide-react';
+import { navigation, portalNavigation, NavSection, NavItem } from '@/types/navigation';
+import { cn } from '@/lib/utils';
 
 // Icon mapping
 const iconMap: Record<string, React.ElementType> = {
@@ -84,14 +80,14 @@ export function AppSidebar({
   onLogout,
   navigationConfig,
   isPortal = false,
-  ariaLabel = "Primary",
+  ariaLabel = 'Primary',
 }: AppSidebarProps) {
   const pathname = usePathname();
   const nav = navigationConfig || navigation;
 
   const isActive = (href: string) => {
     if (!pathname) return false;
-    if (href === "/dashboard" || href === "/portal") {
+    if (href === '/dashboard' || href === '/portal') {
       return pathname === href;
     }
     return pathname.startsWith(href);
@@ -100,41 +96,32 @@ export function AppSidebar({
   const renderNavItem = (item: NavItem) => {
     const Icon = iconMap[item.icon] || Home;
     const active = isActive(item.href);
-    const badge = item.href === "/whatsapp" ? unreadWhatsApp : item.badge;
+    const badge = item.href === '/whatsapp' ? unreadWhatsApp : item.badge;
 
     const sharedClassName = cn(
-      "flex items-center gap-2.5 px-2.5 py-[7px] rounded-[8px] mb-[2px] text-[11.5px] font-medium uppercase tracking-[0.5px] transition-all group",
-      active
-        ? "font-semibold"
-        : "hover:bg-[rgba(255,255,255,0.05)] hover:text-[var(--bz-text-1)]",
+      'flex items-center gap-2.5 px-2.5 py-[7px] rounded-[8px] mb-[2px] text-[11.5px] font-medium uppercase tracking-[0.5px] transition-all group',
+      active ? 'font-semibold' : 'hover:bg-[rgba(255,255,255,0.05)] hover:text-[var(--bz-text-1)]'
     );
     const sharedStyle = active
-      ? { background: "rgba(212,132,90,0.12)", color: "var(--bz-accent)" }
-      : { color: "var(--bz-text-2)" };
+      ? { background: 'rgba(212,132,90,0.12)', color: 'var(--bz-accent)' }
+      : { color: 'var(--bz-text-2)' };
 
     const sharedContent = (
       <>
-        <Icon
-          size={15}
-          className="flex-shrink-0"
-          style={{ opacity: active ? 1 : 0.7 }}
-        />
+        <Icon size={15} className="flex-shrink-0" style={{ opacity: active ? 1 : 0.7 }} />
         <span className="flex-1 leading-relaxed">{item.title}</span>
         {item.external && (
-          <ExternalLink
-            size={9}
-            style={{ color: "var(--bz-text-3)", opacity: 0.5 }}
-          />
+          <ExternalLink size={9} style={{ color: 'var(--bz-text-3)', opacity: 0.5 }} />
         )}
         {badge && badge > 0 && (
           <span
             className="text-[8px] font-bold px-1.5 py-0.5 rounded-full"
             style={{
-              background: "rgba(212,132,90,0.18)",
-              color: "var(--bz-accent)",
+              background: 'rgba(212,132,90,0.18)',
+              color: 'var(--bz-accent)',
             }}
           >
-            {badge > 99 ? "99+" : badge}
+            {badge > 99 ? '99+' : badge}
           </span>
         )}
       </>
@@ -156,12 +143,7 @@ export function AppSidebar({
     }
 
     return (
-      <Link
-        key={item.href}
-        href={item.href}
-        className={sharedClassName}
-        style={sharedStyle}
-      >
+      <Link key={item.href} href={item.href} className={sharedClassName} style={sharedStyle}>
         {sharedContent}
       </Link>
     );
@@ -174,7 +156,7 @@ export function AppSidebar({
         // multiplier — keeps the muted look while satisfying WCAG AA 4.5:1.
         <div
           className="text-[8.5px] font-bold uppercase tracking-[1.2px] px-2.5 pt-4 pb-1.5"
-          style={{ color: "var(--bz-text-2)" }}
+          style={{ color: 'var(--bz-text-2)' }}
         >
           {section.title}
         </div>
@@ -189,17 +171,17 @@ export function AppSidebar({
       aria-label={ariaLabel}
       className="fixed left-0 top-0 z-40 h-screen flex flex-col border-r transition-all duration-300 glass-panel-deep"
       style={{
-        width: "var(--bz-sidebar-width, 216px)",
-        borderColor: "var(--bz-border)",
+        width: 'var(--bz-sidebar-width, 216px)',
+        borderColor: 'var(--bz-border)',
       }}
     >
       {/* Logo Header — Centered, 2x scale */}
       <div
         className="border-b flex items-center justify-center py-4 px-3"
-        style={{ borderColor: "var(--bz-border)" }}
+        style={{ borderColor: 'var(--bz-border)' }}
       >
         <Link
-          href={isPortal ? "/portal" : "/dashboard"}
+          href={isPortal ? '/portal' : '/dashboard'}
           aria-label="Bali Zero — workspace home"
           className="flex items-center justify-center transition-opacity hover:opacity-80"
         >
@@ -220,10 +202,7 @@ export function AppSidebar({
       </nav>
 
       {/* User Profile Footer */}
-      <div
-        className="border-t p-2.5"
-        style={{ borderColor: "var(--bz-border)" }}
-      >
+      <div className="border-t p-2.5" style={{ borderColor: 'var(--bz-border)' }}>
         <div className="flex items-center gap-2.5 px-1.5 py-1.5 rounded-lg hover:bg-[rgba(255,255,255,0.05)] cursor-pointer transition-colors">
           <div className="relative flex-shrink-0">
             {user.avatar ? (
@@ -238,50 +217,41 @@ export function AppSidebar({
               <div
                 className="w-[28px] h-[28px] rounded-[8px] flex items-center justify-center text-[10px] font-bold text-white"
                 style={{
-                  background:
-                    "linear-gradient(135deg, #c9a96e 0%, #d4845a 100%)",
+                  background: 'linear-gradient(135deg, #c9a96e 0%, #d4845a 100%)',
                 }}
               >
-                {user.name?.[0]?.toUpperCase() || "U"}
+                {user.name?.[0]?.toUpperCase() || 'U'}
               </div>
             )}
           </div>
           <div className="flex-1 min-w-0">
             <div
               className="text-[11.5px] font-semibold uppercase tracking-[0.3px] truncate"
-              style={{ color: "var(--bz-text-1)" }}
+              style={{ color: 'var(--bz-text-1)' }}
             >
               {user.name}
             </div>
             <div
               className="text-[9.5px] uppercase tracking-[0.5px]"
-              style={{ color: "var(--bz-text-2)" }}
+              style={{ color: 'var(--bz-text-2)' }}
             >
-              {isPortal ? "Client Portal" : user.role || user.team || "Team"}
+              {isPortal ? 'Client Portal' : user.role || user.team || 'Team'}
             </div>
           </div>
           <div
             className="w-[7px] h-[7px] rounded-full flex-shrink-0"
             style={{
-              background: user.isOnline
-                ? "var(--bz-green)"
-                : "var(--bz-text-3)",
-              boxShadow: user.isOnline
-                ? "0 0 6px rgba(77,184,122,0.45)"
-                : "none",
+              background: user.isOnline ? 'var(--bz-green)' : 'var(--bz-text-3)',
+              boxShadow: user.isOnline ? '0 0 6px rgba(77,184,122,0.45)' : 'none',
             }}
           />
         </div>
         <button
           onClick={onLogout}
           className="flex items-center gap-2 w-full mt-1 px-2.5 py-1.5 text-[10px] font-medium uppercase tracking-[0.5px] rounded-lg transition-colors"
-          style={{ color: "var(--bz-text-2)" }}
-          onMouseEnter={(e) =>
-            (e.currentTarget.style.color = "var(--bz-text-1)")
-          }
-          onMouseLeave={(e) =>
-            (e.currentTarget.style.color = "var(--bz-text-2)")
-          }
+          style={{ color: 'var(--bz-text-2)' }}
+          onMouseEnter={(e) => (e.currentTarget.style.color = 'var(--bz-text-1)')}
+          onMouseLeave={(e) => (e.currentTarget.style.color = 'var(--bz-text-2)')}
         >
           <LogOut size={13} />
           <span>Logout</span>

--- a/apps/mouth/tsconfig.json
+++ b/apps/mouth/tsconfig.json
@@ -33,5 +33,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "vitest.config.ts"]
+  "exclude": ["node_modules", "vitest.config.ts", "e2e/**"]
 }


### PR DESCRIPTION
## Summary
Move drive-poll, fly-watcher, and fly-restart-loop-detector off the Pro crontab to GitHub Actions, so the Pro is no longer SPOF for ops monitoring.

- **cron-drive-poll.yml** (`*/5 * * * *`): triggers `/api/admin/drive/poll` on the backend, Telegram alert on failure
- **cron-fly-watcher.yml** (`*/15 * * * *`): snapshots fly status across `nuzantara-rag`/`nuzantara-postgres`/`nuzantara-qdrant`, Telegram on anomaly
- **cron-fly-restart-detector.yml** (`*/15 * * * *`): alerts on machines NOT started or with unhealthy checks; 30min per-app cooldown via Actions cache

Includes a separate fix commit (`fix(mouth)`) needed to unblock the local pre-commit hook — `(marketing)/page.tsx` had an orphan `</>` (TS1003) hiding several missing imports, plus a missing `Handshake` import in `AppSidebar.tsx`. Reasoning is in the commit message.

## Rollout plan
1. Merge → workflows go live on cron schedule
2. Pro crontab keeps running the 3 jobs in parallel for ~1 week (double alerts during this window are expected and accepted)
3. After 1 week of clean run on Actions side, prune from Pro crontab manually
4. Week 2: 6-7 daily/weekly ops jobs migrate to Fly.io Scheduled Machines (separate PR)

No new secrets — reuses `FLY_API_TOKEN`, `NUZANTARA_API_KEY`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_OWNER_CHAT_ID` already configured.

## Test plan
- [ ] Trigger `cron-drive-poll` via `workflow_dispatch`, confirm 200 + non-error log
- [ ] Trigger `cron-fly-watcher` via `workflow_dispatch`, confirm OK report for healthy fleet
- [ ] Trigger `cron-fly-restart-detector` via `workflow_dispatch`, confirm clean run + cache write
- [ ] Wait one full natural schedule cycle (15 min), verify the scheduled invocation matches the manual one
- [ ] Confirm Pro `/tmp/cron-drive-poll.log` and Actions both report success in parallel for 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)