### PR TITLE
fix(db): migration 138 missing rollback_sql blocks deploy

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/138_wr2_status_notify.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/138_wr2_status_notify.sql
@@ -48,3 +48,12 @@ CREATE TRIGGER wr2_status_change_trg
 
 COMMENT ON FUNCTION wr2_status_change_notify() IS
     'Emits NOTIFY wr2_status_change with JSON payload {draft_id, old_status, new_status, changed_at}. Consumed by wr2_supervisor.py to event-drive the WR2 carousel pipeline. See docs/wr2/SUPERVISOR.md.';
+
+-- === ROLLBACK ===
+-- Reverts the trigger and the function. Safe to run on any DB state because
+-- both DROP statements use IF EXISTS — no error if the migration was never
+-- applied. Rolling back simply removes the NOTIFY emission; consumers
+-- (wr2_supervisor.py) would receive no events but tolerate that gracefully
+-- (they fall back to cron-style polling on their next loop).
+DROP TRIGGER IF EXISTS wr2_status_change_trg ON war_room_drafts;
+DROP FUNCTION IF EXISTS wr2_status_change_notify();


### PR DESCRIPTION
Migration 138_wr2_status_notify.sql was committed without the mandatory `-- === ROLLBACK ===` section. The release command in fly-deploy.yml aborts the entire rolling deploy with: `ValueError: Migration 138 must supply rollback_sql`. This blocks ALL deploys to nuzantara-rag including PR #300 (zantara_core_v3) currently stuck behind it. Fix: add the ROLLBACK section with idempotent DROP IF EXISTS statements.