### PR TITLE
ops: migrate 3 fly sentinel cron jobs to GitHub Actions (week 2 sub-A)

### DIFF
--- a/.github/workflows/cron-cert-monitor.yml
+++ b/.github/workflows/cron-cert-monitor.yml
@@ -1,0 +1,82 @@
+name: cron - cert monitor (daily 07:00 WITA)
+
+# Migrated from Pro crontab `0 7 * * * cert-monitor.sh` (2026-04-26).
+# Checks SSL cert expiry on 7 balizero.com subdomains + nuzantara-rag.fly.dev.
+# Alerts Telegram when any cert is < 30 days from expiry, or unreachable.
+
+on:
+  schedule:
+    - cron: '0 23 * * *' # 23:00 UTC = 07:00 WITA next day
+  workflow_dispatch: {}
+
+concurrency:
+  group: cron-cert-monitor
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      THRESHOLD_DAYS: '30'
+    steps:
+      - name: Check certs
+        id: check
+        run: |
+          set -uo pipefail
+          DOMAINS=(
+            "balizero.com:443"
+            "kita.balizero.com:443"
+            "mail.balizero.com:443"
+            "calendar.balizero.com:443"
+            "drive.balizero.com:443"
+            "knowledge.balizero.com:443"
+            "nuzantara-rag.fly.dev:443"
+          )
+          ALERTS=""
+          for dp in "${DOMAINS[@]}"; do
+            host="${dp%%:*}"
+            end_date=$(echo | openssl s_client -servername "$host" -connect "$dp" 2>/dev/null \
+              | openssl x509 -noout -enddate 2>/dev/null | sed 's/notAfter=//') || end_date=""
+            if [ -z "$end_date" ]; then
+              echo "[$host] cert check failed"
+              ALERTS="${ALERTS}⚠️ <b>${host}</b>: cert check failed"$'\n'
+              continue
+            fi
+            # GNU date (Ubuntu runner): -d parses arbitrary formats
+            end_epoch=$(date -d "$end_date" "+%s" 2>/dev/null) || end_epoch=""
+            if [ -z "$end_epoch" ]; then
+              echo "[$host] cert date unparseable: $end_date"
+              ALERTS="${ALERTS}⚠️ <b>${host}</b>: cert date unparseable"$'\n'
+              continue
+            fi
+            now_epoch=$(date "+%s")
+            days=$(( (end_epoch - now_epoch) / 86400 ))
+            echo "[$host] $days days left"
+            if [ "$days" -lt "$THRESHOLD_DAYS" ]; then
+              ALERTS="${ALERTS}🔴 <b>${host}</b>: expires in ${days} days"$'\n'
+            fi
+          done
+          {
+            echo "alerts<<EOF"
+            echo "$ALERTS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Telegram alert
+        if: steps.check.outputs.alerts != ''
+        env:
+          BOT: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          CHAT: ${{ secrets.TELEGRAM_OWNER_CHAT_ID }}
+          ALERTS: ${{ steps.check.outputs.alerts }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          [ -z "$BOT" ] || [ -z "$CHAT" ] && { echo "Telegram secrets missing"; exit 0; }
+          TEXT="🔒 <b>SSL Cert Monitor</b>
+          ${ALERTS}
+          Run: ${RUN_URL}"
+          curl -sS -m 10 -X POST \
+            "https://api.telegram.org/bot${BOT}/sendMessage" \
+            -d "chat_id=${CHAT}" \
+            --data-urlencode "text=${TEXT}" \
+            -d "parse_mode=HTML" >/dev/null || true

--- a/.github/workflows/cron-fly-cost-alert.yml
+++ b/.github/workflows/cron-fly-cost-alert.yml
@@ -1,0 +1,77 @@
+name: cron - fly cost alert (weekly Mon 09:00 WITA)
+
+# Migrated from Pro crontab `0 9 * * 1 fly-cost-alert.sh` (2026-04-26).
+# Weekly check of Fly.io billing; Telegram alert if monthly projection exceeds threshold.
+
+on:
+  schedule:
+    - cron: '0 1 * * 1' # 01:00 UTC Mon = 09:00 WITA Mon
+  workflow_dispatch: {}
+
+concurrency:
+  group: cron-fly-cost-alert
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      THRESHOLD_CENTS: '6000' # $60.00 monthly cap
+    steps:
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Check Fly.io billing
+        id: check
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          set -uo pipefail
+          INVOICE=$(flyctl bills view --json 2>/dev/null || echo '{}')
+          if [ "$INVOICE" = '{}' ]; then
+            echo "WARNING: could not fetch billing; falling back to machine count"
+            TOTAL=0
+            for app in nuzantara-rag nuzantara-postgres; do
+              COUNT=$(flyctl status --app "$app" 2>/dev/null | grep -c "started" || echo "0")
+              TOTAL=$((TOTAL + COUNT))
+            done
+            echo "Active machines: $TOTAL (manual cost check recommended)"
+            echo "alert=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          TOTAL_CENTS=$(echo "$INVOICE" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('total_cents', d.get('amount', 0)))" 2>/dev/null || echo "0")
+          TOTAL_DOLLARS=$(python3 -c "print(f'{${TOTAL_CENTS}/100:.2f}')")
+          THRESHOLD_DOLLARS=$(python3 -c "print(f'{${THRESHOLD_CENTS}/100:.2f}')")
+          echo "Current month cost: \$$TOTAL_DOLLARS (threshold: \$$THRESHOLD_DOLLARS)"
+          if [ "$TOTAL_CENTS" -gt "$THRESHOLD_CENTS" ]; then
+            ALERT="💰 <b>Fly.io Cost Alert</b>
+          Current: \$${TOTAL_DOLLARS}
+          Threshold: \$${THRESHOLD_DOLLARS}
+          Check: flyctl bills view"
+            {
+              echo "alert<<EOF"
+              echo "$ALERT"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "::warning::Fly.io cost \$$TOTAL_DOLLARS exceeds threshold \$$THRESHOLD_DOLLARS"
+          else
+            echo "Cost within budget ✅"
+            echo "alert=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Telegram alert
+        if: steps.check.outputs.alert != ''
+        env:
+          BOT: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          CHAT: ${{ secrets.TELEGRAM_OWNER_CHAT_ID }}
+          ALERT: ${{ steps.check.outputs.alert }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          [ -z "$BOT" ] || [ -z "$CHAT" ] && { echo "Telegram secrets missing"; exit 0; }
+          TEXT="${ALERT}
+          Run: ${RUN_URL}"
+          curl -sS -m 10 -X POST \
+            "https://api.telegram.org/bot${BOT}/sendMessage" \
+            -d "chat_id=${CHAT}" \
+            --data-urlencode "text=${TEXT}" \
+            -d "parse_mode=HTML" >/dev/null || true

--- a/.github/workflows/cron-sentry-quota-check.yml
+++ b/.github/workflows/cron-sentry-quota-check.yml
@@ -1,0 +1,123 @@
+name: cron - sentry quota check (daily 09:00 WITA)
+
+# Migrated from Pro LaunchAgent / sentry-quota-check.sh (2026-04-26).
+# Reads Sentry config from nuzantara-rag runtime env via `flyctl ssh console`,
+# alerts Telegram if SENTRY_TRACES_SAMPLE_RATE > 0.02 in production
+# or if SENTRY_SEND_DEFAULT_PII is truthy.
+
+on:
+  schedule:
+    - cron: '0 1 * * *' # 01:00 UTC = 09:00 WITA
+  workflow_dispatch: {}
+
+concurrency:
+  group: cron-sentry-quota-check
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      APP: nuzantara-rag
+      MAX_TRACES: '0.02'
+    steps:
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Read runtime env from Fly machine
+        id: read
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          set -uo pipefail
+          # Read runtime env via fly ssh console with a python one-liner.
+          # Banner lines from ssh console come before the JSON; we grep the marker.
+          RUNTIME_RAW=$(flyctl ssh console --app "$APP" --quiet --command \
+            'python -c "import os,json; keys=[\"ENVIRONMENT\",\"SENTRY_TRACES_SAMPLE_RATE\",\"SENTRY_PROFILES_SAMPLE_RATE\",\"SENTRY_SEND_DEFAULT_PII\",\"SKIP_SENTRY_INIT\",\"SENTRY_DSN\"]; print(\"SQC_JSON:\"+json.dumps({k:os.getenv(k,\"\") for k in keys}))"' \
+            2>/dev/null || true)
+          RUNTIME_ENV=$(echo "$RUNTIME_RAW" | grep -o 'SQC_JSON:{.*}' | head -1 | sed 's/^SQC_JSON://')
+          if [ -z "$RUNTIME_ENV" ]; then
+            echo "::warning::unable to read runtime env from $APP"
+            echo "alert=⚠️ <b>sentry-quota-check</b>: unable to read runtime env from ${APP} (no machine running?)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo "runtime_env<<EOF"
+            echo "$RUNTIME_ENV"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Audit Sentry config
+        id: audit
+        if: steps.read.outputs.runtime_env != ''
+        env:
+          RUNTIME_ENV: ${{ steps.read.outputs.runtime_env }}
+        run: |
+          set -uo pipefail
+          eval "$(RUNTIME_ENV="$RUNTIME_ENV" python3 - <<'PY'
+          import json, os
+          d = json.loads(os.environ["RUNTIME_ENV"])
+          for k, v in d.items():
+              # shell-quote-safe: escape single quotes and wrap
+              esc = v.replace("'", "'\\''")
+              print(f"export {k}='{esc}'")
+          PY
+          )"
+          echo "app=$APP env=${ENVIRONMENT:-?} dsn=$([ -n "$SENTRY_DSN" ] && echo yes || echo no) traces=${SENTRY_TRACES_SAMPLE_RATE:-<default>} profiles=${SENTRY_PROFILES_SAMPLE_RATE:-<default>} send_pii=${SENTRY_SEND_DEFAULT_PII:-false} skip=${SKIP_SENTRY_INIT:-false}"
+
+          ALERT=""
+          if [ -n "${SKIP_SENTRY_INIT:-}" ]; then
+            echo "SKIP_SENTRY_INIT set — Sentry disabled, nothing to audit"
+            echo "alert=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -z "${SENTRY_DSN:-}" ]; then
+            echo "no SENTRY_DSN — Sentry not active"
+            echo "alert=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # PII bypass check
+          SEND_PII_LC=$(printf '%s' "${SENTRY_SEND_DEFAULT_PII:-}" | tr '[:upper:]' '[:lower:]')
+          case "$SEND_PII_LC" in
+            1|true|yes)
+              ALERT="⚠️ <b>sentry-quota-check (${APP})</b>: SENTRY_SEND_DEFAULT_PII is truthy — PII scrubbing bypassed. Unset immediately."
+              ;;
+          esac
+          # Quota check (only in production)
+          if [ -z "$ALERT" ] && [ "${ENVIRONMENT:-}" = "production" ]; then
+            TRACES_VAL="${SENTRY_TRACES_SAMPLE_RATE:-0.0}"
+            OVER=$(python3 -c "print(1 if float('$TRACES_VAL') > float('$MAX_TRACES') else 0)" 2>/dev/null || echo 0)
+            if [ "$OVER" = "1" ]; then
+              ALERT="⚠️ <b>sentry-quota-check (${APP})</b>: SENTRY_TRACES_SAMPLE_RATE=${TRACES_VAL} exceeds safe ceiling ${MAX_TRACES} in production. Quota will burn."
+            fi
+          fi
+          if [ -n "$ALERT" ]; then
+            {
+              echo "alert<<EOF"
+              echo "$ALERT"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "::warning::$ALERT"
+          else
+            echo "OK"
+            echo "alert=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Telegram alert
+        if: steps.audit.outputs.alert != '' || steps.read.outputs.alert != ''
+        env:
+          BOT: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          CHAT: ${{ secrets.TELEGRAM_OWNER_CHAT_ID }}
+          ALERT_AUDIT: ${{ steps.audit.outputs.alert }}
+          ALERT_READ: ${{ steps.read.outputs.alert }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          [ -z "$BOT" ] || [ -z "$CHAT" ] && { echo "Telegram secrets missing"; exit 0; }
+          ALERT="${ALERT_AUDIT:-$ALERT_READ}"
+          TEXT="${ALERT}
+          Run: ${RUN_URL}"
+          curl -sS -m 10 -X POST \
+            "https://api.telegram.org/bot${BOT}/sendMessage" \
+            -d "chat_id=${CHAT}" \
+            --data-urlencode "text=${TEXT}" \
+            -d "parse_mode=HTML" >/dev/null || true


### PR DESCRIPTION
## Summary
Sub-batch A of week-2 plan. Three low-effort cron jobs that need no new repo secrets.

- **cron-cert-monitor.yml** (`0 23 * * *` = 07:00 WITA): SSL expiry check across 7 domains, Telegram alert if any cert < 30 days from expiry or unreachable
- **cron-fly-cost-alert.yml** (`0 1 * * 1` = Mon 09:00 WITA): `flyctl bills view`, alert if monthly cost > \$60 threshold
- **cron-sentry-quota-check.yml** (`0 1 * * *` = 09:00 WITA): reads Sentry runtime config from `nuzantara-rag` via `flyctl ssh console`, alerts if `SENTRY_TRACES_SAMPLE_RATE > 0.02` in production or `SENTRY_SEND_DEFAULT_PII` truthy

## Sub-batches deferred
- **Sub-batch B (separate PR)**: `fly-backup` requires adding `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` secrets and merits a careful review since pg_dump is critical for DR
- **Out of scope**: `expiry_alerter.py` stays on Pro — 465 LOC Python with subprocess `fly ssh console` for DB access, SMTP via Zoho. Reconsidered as future Cloud Run Job. Also fixed a duplicate-execution bug today: removed the `0 8 * * *` cron entry on Pro (LaunchAgent `com.balizero.renewal-alerts` was running the same job concurrently)

## Notes
- Branched off `ops/migrate-cron-to-github-actions-week1` (PR #301) so the mouth typecheck unblock fix carries through. Will rebase cleanly onto main once #301 merges
- Cert monitor uses GNU date (`-d`); BSD date on macOS rejects the OpenSSL cert format — local dry-run on darwin will fail, Ubuntu runner will succeed (validated `gdate` parses the format correctly)
- Pro keeps running these in parallel for ~7 days; manual prune of local crontab/LaunchAgents after validation

## Test plan
- [ ] Trigger `cron-cert-monitor` via `workflow_dispatch`, verify it parses real cert dates and reports days-left for all 7 domains
- [ ] Trigger `cron-fly-cost-alert` via `workflow_dispatch`, verify it queries `flyctl bills view` (not a fallback)
- [ ] Trigger `cron-sentry-quota-check` via `workflow_dispatch`, verify `flyctl ssh console` reaches `nuzantara-rag` and returns runtime env
- [ ] After 24h, compare Pro `~/logs/cert-monitor.log` and Actions log for parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)