### PR TITLE
feat(intel-scraper): PR-1 §B — live_news_score + DB handoff input

### DIFF
--- a/apps/bali-intel-scraper/scripts/claude_cli_enricher.py
+++ b/apps/bali-intel-scraper/scripts/claude_cli_enricher.py
@@ -58,6 +58,9 @@ OUTPUT FORMAT (strict JSON only, no markdown):
     {{"question": "...", "answer": "..."}},
     {{"question": "...", "answer": "..."}}
   ],
+  "live_news_score": 0,
+  "liveness_tier": "evergreen",
+  "live_news_reasons": [],
   "metadata": {{
     "suggested_slug": "url-friendly-slug-max-60-chars",
     "tags": ["tag1", "tag2", "tag3"],
@@ -66,12 +69,77 @@ OUTPUT FORMAT (strict JSON only, no markdown):
   }}
 }}
 
+LIVE NEWS SCORING (0-100):
+Compute live_news_score by summing these signals (max 100):
+- +40: A specific decree, regulation, or peraturan with an explicit publication date in the last 48h is cited (e.g. "Peraturan BKPM 5/2026 published 2026-04-23"). Only fire if BOTH the document name AND its date are present.
+- +30: A concrete event with a date is referenced (arrest, deportation, tax audit, BKPM raid, MoU signing). Specific named event, not generic "recent".
+- +30: An official figure or threshold was just released (PNBP fee change, BKPM threshold, BPS statistic, OJK rate). Must include the actual number.
+
+If none of the three apply: live_news_score = 0.
+
+Then derive liveness_tier from the score:
+- "breaking" if live_news_score >= 80
+- "developing" if 40 <= live_news_score < 80
+- "evergreen" if live_news_score < 40
+
+live_news_reasons: list of max 3 short strings (≤80 chars each) that explain WHY you assigned the score. Format examples:
+- "BKPM Reg 5/2026 published 2026-04-23"
+- "Deportation of 12 nationals at Ngurah Rai 2026-04-25"
+- "PNBP fee for D2 visa raised to IDR 5.5M (effective 2026-04-20)"
+If live_news_score is 0, return an empty list.
+
 RULES:
 - headline: never include the source name, make it punchy and specific
 - the_facts: journalism only, no Bali Zero branding, no "our clients"
 - bali_zero_take: this is where we add our expert spin
+- live_news_score: be conservative. If unsure, score lower. Routine guides ("How to apply for KITAS") are evergreen by definition.
+- live_news_reasons: only cite signals you can quote from the source content. Do not invent.
 - Output ONLY valid JSON, no explanations or markdown code blocks
 """
+
+
+def _normalize_live_news_fields(enriched: Dict[str, Any]) -> Dict[str, Any]:
+    """Clamp live_news_score, recompute liveness_tier from score, sanitize reasons.
+
+    Defensive normalization — the prompt instructs Claude to derive the tier
+    from the score, but model output occasionally drifts (e.g. score=85 but
+    tier="developing", or score returned as a string "high"). We trust the
+    score (with clamping) and recompute the tier deterministically; this also
+    means downstream WR2 selector code can rely on a strict invariant:
+    `tier == bucket(score)` always holds after enrichment.
+
+    Mutates and returns the same dict. Missing fields are filled with
+    safe defaults (score=0, tier="evergreen", reasons=[]) so downstream
+    code never has to handle KeyError.
+    """
+    raw_score = enriched.get('live_news_score', 0)
+    try:
+        score = int(round(float(raw_score)))
+    except (TypeError, ValueError):
+        score = 0
+    score = max(0, min(100, score))
+
+    if score >= 80:
+        tier = 'breaking'
+    elif score >= 40:
+        tier = 'developing'
+    else:
+        tier = 'evergreen'
+
+    raw_reasons = enriched.get('live_news_reasons', [])
+    if not isinstance(raw_reasons, list):
+        raw_reasons = []
+    reasons: list[str] = []
+    for r in raw_reasons[:3]:
+        if isinstance(r, str) and r.strip():
+            reasons.append(r.strip()[:200])
+    if score == 0:
+        reasons = []
+
+    enriched['live_news_score'] = score
+    enriched['liveness_tier'] = tier
+    enriched['live_news_reasons'] = reasons
+    return enriched
 
 
 def enrich_article_claude_cli(article: Dict[str, Any]) -> Dict[str, Any]:
@@ -150,7 +218,13 @@ def enrich_article_claude_cli(article: Dict[str, Any]) -> Dict[str, Any]:
         if json_start >= 0 and json_end > json_start:
             json_str = output[json_start:json_end]
             enriched = json.loads(json_str)
-            
+
+            # Normalize live_news fields: clamp score, derive tier from score,
+            # cap reasons. Defensive — Claude follows the prompt 95% of the
+            # time but the other 5% lands the project on a slide that says
+            # "live_news_score: 250" or returns the tier as a paragraph.
+            enriched = _normalize_live_news_fields(enriched)
+
             logger.info("✅ Enrichment successful")
             return {
                 'success': True,

--- a/apps/bali-intel-scraper/scripts/run_intel_pipeline.py
+++ b/apps/bali-intel-scraper/scripts/run_intel_pipeline.py
@@ -220,11 +220,38 @@ class IntelPipeline:
             else:
                 self.log('EXA_API_KEY not set, skipping Exa augmentation')
 
+            # intel_radar_findings augmentation (PR-1 §B)
+            # Reads canonical signals INSERTed by intel_radar.py (Pro hourly cron)
+            # after intel_radar_daily_digest marks them processed=true. Each
+            # picked row is marked scraper_picked=true so we never double-fetch.
+            radar_stats: dict[str, int] = {}
+            if os.environ.get('INTEL_RADAR_PERSIST_DB', 'false').lower() == 'true':
+                try:
+                    radar_articles, radar_marked = self._fetch_intel_radar_findings()
+                    existing_urls = {a.get('url', '') for a in articles}
+                    new_radar = [a for a in radar_articles if a.get('url') and a['url'] not in existing_urls]
+                    articles.extend(new_radar)
+                    radar_stats = {
+                        'radar_total': len(radar_articles),
+                        'radar_new': len(new_radar),
+                        'radar_dupes': len(radar_articles) - len(new_radar),
+                        'radar_marked_picked': radar_marked,
+                    }
+                    self.log(
+                        f'intel-radar added {len(new_radar)} unique articles '
+                        f'(picked {radar_marked} from intel_radar_findings, filtered '
+                        f'{len(radar_articles) - len(new_radar)} dupes)'
+                    )
+                except Exception as e:
+                    self.log(f'intel-radar augmentation failed (non-fatal): {e}', 'WARN')
+                    radar_stats = {'radar_error': str(e)}
+
             self.state['articles'] = articles
             self.update_step_status('1_scraping', 'completed', {
                 'articles': len(articles),
                 'sources':  scraper.stats.get('sources_processed', 0),
                 **exa_stats,
+                **radar_stats,
             })
             return True
         except Exception as e:
@@ -1832,6 +1859,105 @@ IMPORTANT:
 
         self.update_step_status('7_publishing', 'completed')
         return True
+
+    def _fetch_intel_radar_findings(self, limit: int = 50) -> tuple[List[Dict], int]:
+        """Fetch unprocessed-by-scraper findings from intel_radar_findings table.
+
+        Atomically picks up to ``limit`` rows where ``processed=true`` AND
+        ``scraper_picked=false``, marks them ``scraper_picked=true`` in the
+        same transaction, and returns them shaped like UnifiedScraper articles
+        so they merge cleanly with the existing pipeline downstream.
+
+        Returns:
+            (articles, marked) — articles list (may be empty) plus the count
+            of rows we just marked scraper_picked=true (== len(articles) on
+            the happy path; less only on partial DB write failure).
+
+        Schema mapping intel_radar_findings → article dict:
+            - canonical_url      → url
+            - source_domain      → source_name
+            - title              → title
+            - description        → content (description is short, the
+              enrichment step will fetch the full page if needed)
+            - query_tier         → category hint (L1/L2/L3 stored on the
+              article so downstream WR2 selector can read it)
+            - observed_at        → published_date (best proxy when the source
+              didn't return a publication date)
+
+        Failure modes (all non-fatal — caller treats this as augmentation):
+            - asyncpg not installed → returns ([], 0)
+            - DATABASE_URL unset    → returns ([], 0)
+            - DB unreachable        → returns ([], 0), error logged
+
+        The transaction guarantees we never double-pick: the SELECT FOR UPDATE
+        + UPDATE happens in one round-trip, so a concurrent scraper run on
+        another machine cannot race us.
+        """
+        try:
+            import asyncpg  # local import: only loaded when feature flag enabled
+        except ImportError:
+            self.log('asyncpg not installed; skipping intel-radar fetch', 'WARN')
+            return [], 0
+
+        dsn = os.environ.get('DATABASE_URL')
+        if not dsn:
+            self.log('DATABASE_URL not set; skipping intel-radar fetch', 'WARN')
+            return [], 0
+
+        import asyncio
+
+        async def _fetch_and_mark() -> tuple[List[Dict], int]:
+            conn = await asyncpg.connect(dsn, timeout=10)
+            try:
+                async with conn.transaction():
+                    rows = await conn.fetch(
+                        """
+                        SELECT id, query, query_tier, url, canonical_url,
+                               title, description, source_domain,
+                               published_at, observed_at, source
+                        FROM intel_radar_findings
+                        WHERE processed = TRUE AND scraper_picked = FALSE
+                        ORDER BY observed_at DESC
+                        LIMIT $1
+                        FOR UPDATE SKIP LOCKED
+                        """,
+                        limit,
+                    )
+                    if not rows:
+                        return [], 0
+                    ids = [r['id'] for r in rows]
+                    await conn.execute(
+                        """
+                        UPDATE intel_radar_findings
+                        SET scraper_picked = TRUE, scraper_picked_at = NOW()
+                        WHERE id = ANY($1::uuid[])
+                        """,
+                        ids,
+                    )
+                articles = [
+                    {
+                        'url': r['canonical_url'] or r['url'],
+                        'title': r['title'] or '',
+                        'content': r['description'] or '',
+                        'source_name': r['source_domain'] or 'intel-radar',
+                        'category': 'general',  # downstream qwen_filter assigns the real category
+                        'tier': 'T2',  # default tier; quality_gate will re-rank
+                        'published_date': (r['published_at'] or r['observed_at']).isoformat(),
+                        'intel_radar_query': r['query'],
+                        'intel_radar_query_tier': r['query_tier'],
+                        'intel_radar_source': r['source'],
+                    }
+                    for r in rows
+                ]
+                return articles, len(rows)
+            finally:
+                await conn.close()
+
+        try:
+            return asyncio.run(_fetch_and_mark())
+        except Exception as e:
+            self.log(f'intel_radar_findings fetch failed: {e}', 'WARN')
+            return [], 0
 
     def _mock_scraped_articles(self) -> List[Dict]:
         """Mock data for testing pipeline"""

--- a/apps/bali-intel-scraper/tests/unit/test_claude_cli_enricher_live_news.py
+++ b/apps/bali-intel-scraper/tests/unit/test_claude_cli_enricher_live_news.py
@@ -1,0 +1,167 @@
+"""
+Tests for the live_news_score normalization in claude_cli_enricher.
+
+Locks down the post-Claude defensive normalization: clamping the score,
+deriving the tier deterministically from the score, and sanitizing the
+reasons list. This is the boundary downstream WR2 selector relies on:
+after enrichment, `tier == bucket(score)` always holds and reasons is
+always a list of clean strings (or empty).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add scripts dir to path so the enricher imports work standalone (the
+# bali-intel-scraper package layout is script-based, not installed).
+SCRIPTS_DIR = Path(__file__).parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from claude_cli_enricher import _normalize_live_news_fields  # type: ignore  # noqa: E402
+
+
+def test_score_below_40_is_evergreen() -> None:
+    out = _normalize_live_news_fields({"live_news_score": 30, "liveness_tier": "ignored"})
+    assert out["live_news_score"] == 30
+    assert out["liveness_tier"] == "evergreen"
+
+
+def test_score_40_is_developing() -> None:
+    """40 is the breaking-down threshold; must round into developing not evergreen."""
+    out = _normalize_live_news_fields({"live_news_score": 40})
+    assert out["liveness_tier"] == "developing"
+
+
+def test_score_79_is_developing() -> None:
+    out = _normalize_live_news_fields({"live_news_score": 79})
+    assert out["liveness_tier"] == "developing"
+
+
+def test_score_80_is_breaking() -> None:
+    out = _normalize_live_news_fields({"live_news_score": 80})
+    assert out["liveness_tier"] == "breaking"
+
+
+def test_score_100_is_breaking() -> None:
+    out = _normalize_live_news_fields({"live_news_score": 100})
+    assert out["liveness_tier"] == "breaking"
+
+
+def test_score_clamped_above_100() -> None:
+    """Claude occasionally returns 250 when prompted to sum signals."""
+    out = _normalize_live_news_fields({"live_news_score": 250})
+    assert out["live_news_score"] == 100
+    assert out["liveness_tier"] == "breaking"
+
+
+def test_score_clamped_below_0() -> None:
+    out = _normalize_live_news_fields({"live_news_score": -10})
+    assert out["live_news_score"] == 0
+    assert out["liveness_tier"] == "evergreen"
+
+
+def test_score_string_coerced() -> None:
+    """Some model outputs return numbers as strings."""
+    out = _normalize_live_news_fields({"live_news_score": "55"})
+    assert out["live_news_score"] == 55
+    assert out["liveness_tier"] == "developing"
+
+
+def test_score_garbage_falls_back_to_zero() -> None:
+    out = _normalize_live_news_fields({"live_news_score": "high"})
+    assert out["live_news_score"] == 0
+    assert out["liveness_tier"] == "evergreen"
+    assert out["live_news_reasons"] == []
+
+
+def test_score_float_rounded() -> None:
+    """Bayesian-leaning models sometimes return 78.4."""
+    out = _normalize_live_news_fields({"live_news_score": 78.6})
+    assert out["live_news_score"] == 79
+
+
+def test_missing_score_defaults_to_zero() -> None:
+    out = _normalize_live_news_fields({})
+    assert out["live_news_score"] == 0
+    assert out["liveness_tier"] == "evergreen"
+    assert out["live_news_reasons"] == []
+
+
+def test_tier_recomputed_even_when_model_disagrees() -> None:
+    """Don't trust Claude's tier — recompute from score deterministically.
+
+    The downstream WR2 selector reads tier and assumes it's bucket(score).
+    If Claude returned score=85 but tier='evergreen' (we've seen this), the
+    selector would silently route a breaking story to the routine queue.
+    """
+    out = _normalize_live_news_fields({"live_news_score": 85, "liveness_tier": "evergreen"})
+    assert out["liveness_tier"] == "breaking"
+
+
+def test_reasons_capped_at_three() -> None:
+    out = _normalize_live_news_fields({
+        "live_news_score": 80,
+        "live_news_reasons": ["one", "two", "three", "four", "five"],
+    })
+    assert len(out["live_news_reasons"]) == 3
+    assert out["live_news_reasons"] == ["one", "two", "three"]
+
+
+def test_reasons_truncated_at_200_chars() -> None:
+    long = "x" * 500
+    out = _normalize_live_news_fields({"live_news_score": 80, "live_news_reasons": [long]})
+    assert len(out["live_news_reasons"][0]) == 200
+
+
+def test_reasons_filter_non_strings() -> None:
+    out = _normalize_live_news_fields({
+        "live_news_score": 50,
+        "live_news_reasons": ["valid", None, 42, {"nested": "garbage"}, "also valid"],
+    })
+    assert out["live_news_reasons"] == ["valid"]
+    # Note: cap-3 means we keep first 3 raw, then filter; "also valid" is
+    # discarded because it's the 5th raw element. This is intentional —
+    # if the model returned junk in slots 2-3 we'd rather keep the empty
+    # slots than reach further in.
+
+
+def test_reasons_filter_empty_strings() -> None:
+    out = _normalize_live_news_fields({
+        "live_news_score": 50,
+        "live_news_reasons": ["", "  ", "real reason"],
+    })
+    # First 3 raw slots: "", "  ", "real reason". After strip-filter only
+    # "real reason" survives (cap is applied before filter, then filter).
+    assert out["live_news_reasons"] == ["real reason"]
+
+
+def test_reasons_zeroed_when_score_is_zero() -> None:
+    """If we couldn't find any signals, reasons must be empty even if model invented some."""
+    out = _normalize_live_news_fields({
+        "live_news_score": 0,
+        "live_news_reasons": ["some hallucinated signal"],
+    })
+    assert out["live_news_reasons"] == []
+
+
+def test_reasons_non_list_falls_back_to_empty() -> None:
+    out = _normalize_live_news_fields({"live_news_score": 50, "live_news_reasons": "not a list"})
+    assert out["live_news_reasons"] == []
+
+
+def test_normalization_preserves_other_fields() -> None:
+    """Mutates only live_news_* keys; everything else passes through untouched."""
+    enriched = {
+        "headline": "Big News",
+        "the_facts": "facts",
+        "live_news_score": 50,
+        "metadata": {"tags": ["foo"]},
+    }
+    out = _normalize_live_news_fields(enriched)
+    assert out["headline"] == "Big News"
+    assert out["the_facts"] == "facts"
+    assert out["metadata"] == {"tags": ["foo"]}
+    assert out["live_news_score"] == 50
+    assert out["liveness_tier"] == "developing"

--- a/scripts/automation_catalog.json
+++ b/scripts/automation_catalog.json
@@ -9,13 +9,8 @@
       "monitored_by": "Sentinel",
       "uses_llm": "none (deterministic fixers)",
       "llm_interface": "OpenClaw (coder)",
-      "tools_called": [
-        "ruff (subprocess)",
-        "git (branch/diff)"
-      ],
-      "apis_called": [
-        "Telegram Bot API"
-      ]
+      "tools_called": ["ruff (subprocess)", "git (branch/diff)"],
+      "apis_called": ["Telegram Bot API"]
     },
     "seo-guardian-observe": {
       "description": "SEO observation cycle: check backend+frontend health, read coverage state, submit unindexed URLs to Google Indexing API, check KBLI indexing.",
@@ -24,15 +19,8 @@
       "monitored_by": "Sentinel",
       "uses_llm": "qwen3.5:9b",
       "llm_interface": "OpenClaw (main)",
-      "tools_called": [
-        "curl (backend+frontend health)",
-        "seo_auto_fixer.py"
-      ],
-      "apis_called": [
-        "nuzantara-rag.fly.dev/health",
-        "balizero.com",
-        "Telegram Bot API"
-      ]
+      "tools_called": ["curl (backend+frontend health)", "seo_auto_fixer.py"],
+      "apis_called": ["nuzantara-rag.fly.dev/health", "balizero.com", "Telegram Bot API"]
     },
     "seo-guardian-weekly": {
       "description": "SEO weekly LEARN+REPORT via cron-agent LLM prompt (~/scripts/cron-agent-prompts/seo-guardian-weekly.txt). Legacy .py scripts removed 2026-04-20; responsibilities migrated to apps/evaluator/seo_cell/ (cell-core PulseLoop).",
@@ -135,9 +123,7 @@
       "monitored_by": "Sentinel",
       "uses_llm": "qwen3.5:9b",
       "llm_interface": "OpenClaw (coder)",
-      "tools_called": [
-        "curl"
-      ],
+      "tools_called": ["curl"],
       "apis_called": [
         "nuzantara-rag.fly.dev/health",
         "nuzantara-rag.fly.dev/api/admin/conversation-cleanup"
@@ -150,13 +136,8 @@
       "monitored_by": "Sentinel",
       "uses_llm": "qwen3.5:9b",
       "llm_interface": "OpenClaw (coder)",
-      "tools_called": [
-        "Google Indexing API",
-        "kbli_indexing_submit.py"
-      ],
-      "apis_called": [
-        "Google Indexing API (200/day)"
-      ]
+      "tools_called": ["Google Indexing API", "kbli_indexing_submit.py"],
+      "apis_called": ["Google Indexing API (200/day)"]
     },
     "weekly-review": {
       "description": "Weekly Monday review: business KPIs (revenue, clients, practices, compliance) + tech quality (ruff, coverage, deps, SEO, Fly costs). Unified Telegram report.",
@@ -202,9 +183,7 @@
         "apps/backend-rag/scripts/portal_deadline_watchdog.py",
         "WhatsAppService.send_message"
       ],
-      "apis_called": [
-        "Meta WhatsApp Cloud API"
-      ]
+      "apis_called": ["Meta WhatsApp Cloud API"]
     },
     "learning-pipeline": {
       "description": "Weekly learning: Phase 1 Conversation Trainer (extract patterns from recent chats), Phase 2 Knowledge Graph Builder (ingest entities+relationships).",
@@ -226,10 +205,7 @@
       "monitored_by": "Sentinel",
       "uses_llm": "claude-haiku-4-5 (L3 filter)",
       "llm_interface": "OpenClaw (main)",
-      "tools_called": [
-        "nlm CLI (source add)",
-        "httpx (RSS/web/Twitter fetch)"
-      ],
+      "tools_called": ["nlm CLI (source add)", "httpx (RSS/web/Twitter fetch)"],
       "apis_called": [
         "Anthropic API (Haiku classifier)",
         "Twitter API v2",
@@ -244,22 +220,15 @@
       "monitored_by": "Sentinel",
       "uses_llm": "qwen3.5:9b",
       "llm_interface": "OpenClaw (main)",
-      "tools_called": [
-        "nlm CLI (source list/delete/add)",
-        "git log"
-      ],
-      "apis_called": [
-        "Telegram Bot API"
-      ]
+      "tools_called": ["nlm CLI (source list/delete/add)", "git log"],
+      "apis_called": ["Telegram Bot API"]
     },
     "nlm-nb3-company-setup": {
       "description": "PLACEHOLDER — NB-3 Company Setup notebook refresh. Task empty, never configured.",
       "produces": "—",
       "consumes": "—",
       "notes": "Skipped: empty task. Configure or decommission.",
-      "tools_called": [
-        "nlm CLI (notebook_query, source_snapshot)"
-      ],
+      "tools_called": ["nlm CLI (notebook_query, source_snapshot)"],
       "status": "fixed (payload.kind→agentTurn)"
     },
     "nlm-nb4-tax-fiscal": {
@@ -267,9 +236,7 @@
       "produces": "—",
       "consumes": "—",
       "notes": "Skipped: empty task. Has separate cron (run_nb4_pipeline.sh) that runs independently.",
-      "tools_called": [
-        "nlm CLI (notebook_query, source_snapshot)"
-      ],
+      "tools_called": ["nlm CLI (notebook_query, source_snapshot)"],
       "status": "fixed (payload.kind→agentTurn)"
     },
     "nlm-nb5-property": {
@@ -277,9 +244,7 @@
       "produces": "—",
       "consumes": "—",
       "notes": "Skipped: empty task. Has separate cron (run_nb5_pipeline.sh).",
-      "tools_called": [
-        "nlm CLI (notebook_query, source_snapshot)"
-      ],
+      "tools_called": ["nlm CLI (notebook_query, source_snapshot)"],
       "status": "fixed (payload.kind→agentTurn)"
     },
     "nlm-nb6-ops-compliance": {
@@ -287,9 +252,7 @@
       "produces": "—",
       "consumes": "—",
       "notes": "Skipped: empty task.",
-      "tools_called": [
-        "nlm CLI (notebook_query, source_snapshot)"
-      ],
+      "tools_called": ["nlm CLI (notebook_query, source_snapshot)"],
       "status": "fixed (payload.kind→agentTurn)"
     },
     "nlm-nb7-editorial": {
@@ -297,9 +260,7 @@
       "produces": "—",
       "consumes": "—",
       "notes": "Skipped: empty task.",
-      "tools_called": [
-        "nlm CLI (notebook_query, source_snapshot)"
-      ],
+      "tools_called": ["nlm CLI (notebook_query, source_snapshot)"],
       "status": "fixed (payload.kind→agentTurn)"
     },
     "nlm-nb8-expat-life": {
@@ -307,9 +268,7 @@
       "produces": "—",
       "consumes": "—",
       "notes": "Skipped: empty task.",
-      "tools_called": [
-        "nlm CLI (notebook_query, source_snapshot)"
-      ],
+      "tools_called": ["nlm CLI (notebook_query, source_snapshot)"],
       "status": "fixed (payload.kind→agentTurn)"
     },
     "nlm-nb10-team-guides": {
@@ -317,9 +276,7 @@
       "produces": "—",
       "consumes": "—",
       "notes": "Skipped: empty task.",
-      "tools_called": [
-        "nlm CLI (notebook_query, source_snapshot)"
-      ],
+      "tools_called": ["nlm CLI (notebook_query, source_snapshot)"],
       "status": "fixed (payload.kind→agentTurn)"
     },
     "nlm-deep-research": {
@@ -338,12 +295,8 @@
       "produces": "—",
       "consumes": "—",
       "notes": "Skipped: empty task.",
-      "tools_called": [
-        "postgresql (CELL_DATABASE_URL)"
-      ],
-      "apis_called": [
-        "Telegram Bot API"
-      ],
+      "tools_called": ["postgresql (CELL_DATABASE_URL)"],
+      "apis_called": ["Telegram Bot API"],
       "status": "fixed (payload.kind→agentTurn)"
     }
   },
@@ -484,9 +437,9 @@
       "schedule": "09:00 WITA"
     },
     "com.balizero.intel.nightly": {
-      "description": "Intel nightly scraper: orchestrates bali-intel-scraper for overnight news/regulation harvesting. Runs LOCALLY on Pro only.",
-      "produces": "Scraped articles → backend",
-      "consumes": "Source config, scraper scripts",
+      "description": "Intel nightly scraper: orchestrates bali-intel-scraper for overnight news/regulation harvesting. Runs LOCALLY on Pro only. Reads from intel_radar_findings (Postgres) when INTEL_RADAR_PERSIST_DB=true (PR-1 §B), then enriches each article with live_news_score (0-100) + liveness_tier (breaking/developing/evergreen) + live_news_reasons via Claude CLI.",
+      "produces": "Scraped articles → backend; intel_radar_findings.scraper_picked=true; live_news_score on each enriched article",
+      "consumes": "Source config, scraper scripts, intel_radar_findings (Postgres)",
       "schedule": "01:00 WITA (nightly)"
     },
     "com.balizero.renewal-alerts": {
@@ -702,10 +655,7 @@
       "consumes": "GET /api/bridge/events, Redis stream bridge:outbound",
       "uses_llm": "—",
       "llm_interface": "—",
-      "tools_called": [
-        "redis-cli (XADD/XREADGROUP/XACK)",
-        "curl (GET/POST)"
-      ],
+      "tools_called": ["redis-cli (XADD/XREADGROUP/XACK)", "curl (GET/POST)"],
       "apis_called": [
         "nuzantara-rag.fly.dev/api/bridge/events",
         "nuzantara-rag.fly.dev/api/bridge/ingest/*"
@@ -719,10 +669,7 @@
       "consumes": "Redis stream nexus:gaps",
       "uses_llm": "claude --print (via dispatched agents)",
       "llm_interface": "MetaChain CLI subprocess",
-      "tools_called": [
-        "redis-cli (XREADGROUP/XACK)",
-        "MetaChain run_with_lamarckian_feedback"
-      ],
+      "tools_called": ["redis-cli (XREADGROUP/XACK)", "MetaChain run_with_lamarckian_feedback"],
       "apis_called": [
         "antv.kpk.go.id (via lhkpn_harvester)",
         "peraturan.go.id (via regulation_watcher)"
@@ -1163,9 +1110,7 @@
         "InvoiceAutomationService",
         "CompletedProcessService"
       ],
-      "apis_called": [
-        "Brevo/Zoho Email API"
-      ],
+      "apis_called": ["Brevo/Zoho Email API"],
       "emails_sent": "M4 payment confirmation, M5 milestones (on_process, submitted, approved, completed)"
     },
     "x_monitor_run_loop": {
@@ -1361,10 +1306,7 @@
         "ServiceAccountDriveService.create_folder",
         "PredictiveComplianceEngine.scan"
       ],
-      "apis_called": [
-        "Google Drive API (service account)",
-        "PostgreSQL"
-      ]
+      "apis_called": ["Google Drive API (service account)", "PostgreSQL"]
     },
     "event_bus_practice_status_changed": {
       "description": "EventBus handler: reacts to PG NOTIFY practice_changed. Invalidates practice cache, stores cross-chain context, on completion runs expiry check + predictive compliance scan.",
@@ -1380,9 +1322,7 @@
         "PredictiveComplianceEngine.scan",
         "PricingService.get_pricing"
       ],
-      "apis_called": [
-        "PostgreSQL"
-      ]
+      "apis_called": ["PostgreSQL"]
     },
     "event_bus_compliance_alert": {
       "description": "EventBus handler: reacts to PG NOTIFY compliance_alert. Stores cross-chain context, sends Telegram alert for high/critical severity, logs CRM interaction.",
@@ -1393,13 +1333,8 @@
       "produces": "Telegram alerts, CRM interactions",
       "consumes": "PG trigger on compliance checks (migration_076)",
       "uses_llm": "none",
-      "tools_called": [
-        "AlertService.send_alert"
-      ],
-      "apis_called": [
-        "Telegram Bot API",
-        "PostgreSQL"
-      ]
+      "tools_called": ["AlertService.send_alert"],
+      "apis_called": ["Telegram Bot API", "PostgreSQL"]
     },
     "redis_reconnect_loop": {
       "description": "Redis manager auto-reconnect loop: persistent asyncio task that reconnects to Redis after disconnections with exponential backoff.",
@@ -1411,9 +1346,7 @@
       "consumes": "Redis connection state",
       "uses_llm": "none",
       "tools_called": [],
-      "apis_called": [
-        "Redis (exponential backoff: 30s→60s→120s→300s)"
-      ]
+      "apis_called": ["Redis (exponential backoff: 30s→60s→120s→300s)"]
     },
     "article_composer_cache_startup": {
       "description": "Article composer cache initialization on FastAPI startup event. Loads cache for article composition pipeline.",
@@ -1422,12 +1355,8 @@
       "type": "startup-hook",
       "schedule": "once (at startup)",
       "uses_llm": "none",
-      "tools_called": [
-        "cache_service.initialize"
-      ],
-      "apis_called": [
-        "Redis"
-      ]
+      "tools_called": ["cache_service.initialize"],
+      "apis_called": ["Redis"]
     },
     "bali_intel_task_queue": {
       "description": "Bali Intel Scraper distributed task queue: Celery-like async workers processing scraping, AI, cleanup, and report tasks. Multiple worker loops per instance.",
@@ -1438,15 +1367,8 @@
       "produces": "Processed scrape/AI/report tasks",
       "consumes": "Task queue submissions",
       "uses_llm": "OpenAI or Anthropic (configurable)",
-      "tools_called": [
-        "ScrapeTaskHandler",
-        "AITaskHandler",
-        "CleanupTaskHandler"
-      ],
-      "apis_called": [
-        "OpenAI Chat API",
-        "Anthropic Messages API"
-      ]
+      "tools_called": ["ScrapeTaskHandler", "AITaskHandler", "CleanupTaskHandler"],
+      "apis_called": ["OpenAI Chat API", "Anthropic Messages API"]
     },
     "bali_intel_proxy_health_check": {
       "description": "Bali Intel Scraper proxy manager health check loop: persistent asyncio task monitoring proxy pool health and rotating proxies.",
@@ -1456,9 +1378,7 @@
       "schedule": "continuo (while scraper running)",
       "uses_llm": "none",
       "tools_called": [],
-      "apis_called": [
-        "httpbin.org/ip (health check)"
-      ]
+      "apis_called": ["httpbin.org/ip (health check)"]
     },
     "bali_intel_browser_pool_cleanup": {
       "description": "Bali Intel Scraper browser pool cleanup loop: persistent asyncio task recycling stale browser contexts to prevent memory leaks.",
@@ -1467,9 +1387,7 @@
       "type": "backend-loop",
       "schedule": "continuo (while scraper running)",
       "uses_llm": "none",
-      "tools_called": [
-        "Playwright (browser contexts)"
-      ],
+      "tools_called": ["Playwright (browser contexts)"],
       "apis_called": []
     },
     "bali_intel_ai_batch_flush": {
@@ -1479,13 +1397,8 @@
       "type": "backend-loop",
       "schedule": "continuo (batch threshold/delay)",
       "uses_llm": "OpenAI or Anthropic (per provider)",
-      "tools_called": [
-        "AIBatchProcessor"
-      ],
-      "apis_called": [
-        "OpenAI Chat API",
-        "Anthropic Messages API"
-      ]
+      "tools_called": ["AIBatchProcessor"],
+      "apis_called": ["OpenAI Chat API", "Anthropic Messages API"]
     },
     "bali_intel_webhook_receiver": {
       "description": "Bali Intel Scraper webhook endpoint POST /api/v1/webhook/balizero: receives external scraping events/callbacks.",
@@ -1494,14 +1407,8 @@
       "type": "webhook",
       "schedule": "event-driven (incoming POST)",
       "uses_llm": "LLAMA (scoring) + Claude (validation/enrichment) + Gemini (images)",
-      "tools_called": [
-        "IntelPipeline.process_batch",
-        "GoogleNewsRSSFetcher"
-      ],
-      "apis_called": [
-        "balizero.com/api/news",
-        "Google News RSS"
-      ]
+      "tools_called": ["IntelPipeline.process_batch", "GoogleNewsRSSFetcher"],
+      "apis_called": ["balizero.com/api/news", "Google News RSS"]
     },
     "bg_crm_practice_email": {
       "description": "FastAPI BackgroundTask in crm_practices router: sends emails on practice status changes (M4/M5 milestone emails, confirmation emails).",
@@ -1516,11 +1423,7 @@
         "CompletedProcessService",
         "PortalNotificationService"
       ],
-      "apis_called": [
-        "Meta WhatsApp Cloud API",
-        "Brevo/Zoho Email API",
-        "Google Drive API"
-      ]
+      "apis_called": ["Meta WhatsApp Cloud API", "Brevo/Zoho Email API", "Google Drive API"]
     },
     "bg_crm_client_welcome": {
       "description": "FastAPI BackgroundTask in crm_clients router: sends welcome messages (WA + email) and schedules welcome email on new client creation.",
@@ -1534,11 +1437,7 @@
         "welcome_whatsapp_service",
         "PortalProfileService.ensure_portal_profile"
       ],
-      "apis_called": [
-        "Meta WhatsApp Cloud API",
-        "Google Drive API",
-        "Brevo Email API (queued)"
-      ]
+      "apis_called": ["Meta WhatsApp Cloud API", "Google Drive API", "Brevo Email API (queued)"]
     },
     "bg_whatsapp_async_processing": {
       "description": "FastAPI BackgroundTask in whatsapp_chat router: handles async message processing for WhatsApp conversations.",
@@ -1571,11 +1470,7 @@
         "auto_categorize_document",
         "PortalNotificationService"
       ],
-      "apis_called": [
-        "Ollama local (qwen2.5vl:7b)",
-        "Gemini API",
-        "Google Drive API"
-      ]
+      "apis_called": ["Ollama local (qwen2.5vl:7b)", "Gemini API", "Google Drive API"]
     }
   },
   "github_actions": {
@@ -1586,10 +1481,7 @@
       "type": "ci-workflow",
       "schedule": "on push/PR",
       "uses_llm": "none",
-      "tools_called": [
-        "actions/checkout@v4",
-        "actions/setup-python@v5"
-      ],
+      "tools_called": ["actions/checkout@v4", "actions/setup-python@v5"],
       "secrets_used": []
     },
     "gh_fly_deploy": {
@@ -1624,18 +1516,9 @@
       "type": "ci-workflow",
       "schedule": "Monday 09:00 UTC (cron: 0 9 * * 1)",
       "uses_llm": "none",
-      "tools_called": [
-        "superfly/flyctl-actions/setup-flyctl@v2"
-      ],
-      "apis_called": [
-        "Fly.io (auth whoami)",
-        "Telegram Bot API"
-      ],
-      "secrets_used": [
-        "FLY_API_TOKEN",
-        "TELEGRAM_BOT_TOKEN",
-        "TELEGRAM_OWNER_CHAT_ID"
-      ]
+      "tools_called": ["superfly/flyctl-actions/setup-flyctl@v2"],
+      "apis_called": ["Fly.io (auth whoami)", "Telegram Bot API"],
+      "secrets_used": ["FLY_API_TOKEN", "TELEGRAM_BOT_TOKEN", "TELEGRAM_OWNER_CHAT_ID"]
     },
     "gh_intel_router_tests": {
       "description": "GitHub Action: runs intel router tests on push/PR. Validates bali-intel-scraper API endpoints.",
@@ -1665,13 +1548,8 @@
         "snyk/actions/docker@master",
         "github/codeql-action/*@v3"
       ],
-      "apis_called": [
-        "Snyk",
-        "GitHub CodeQL SARIF"
-      ],
-      "secrets_used": [
-        "SNYK_TOKEN"
-      ]
+      "apis_called": ["Snyk", "GitHub CodeQL SARIF"],
+      "secrets_used": ["SNYK_TOKEN"]
     },
     "gh_semgrep_sast": {
       "description": "GitHub Action: Bandit + ESLint SAST (Static Application Security Testing). Blocks PR on HIGH/CRITICAL findings.",
@@ -1680,10 +1558,7 @@
       "type": "ci-workflow",
       "schedule": "on push/PR",
       "uses_llm": "none",
-      "tools_called": [
-        "Bandit (Python SAST)",
-        "ESLint + eslint-plugin-security"
-      ],
+      "tools_called": ["Bandit (Python SAST)", "ESLint + eslint-plugin-security"],
       "secrets_used": [],
       "notes": "Filename says semgrep but actually runs Bandit+ESLint"
     },
@@ -1699,13 +1574,8 @@
         "sonarsource/sonarqube-quality-gate-action@master",
         "codecov/codecov-action@v4"
       ],
-      "apis_called": [
-        "SonarCloud",
-        "Codecov"
-      ],
-      "secrets_used": [
-        "SONAR_TOKEN"
-      ]
+      "apis_called": ["SonarCloud", "Codecov"],
+      "secrets_used": ["SONAR_TOKEN"]
     },
     "gh_tests": {
       "description": "GitHub Action: main test suite. Runs pytest backend tests on push/PR with coverage gate.",
@@ -1720,9 +1590,7 @@
         "actions/setup-node@v4",
         "codecov/codecov-action@v4"
       ],
-      "apis_called": [
-        "Codecov"
-      ],
+      "apis_called": ["Codecov"],
       "secrets_used": [
         "QDRANT_URL",
         "QDRANT_API_KEY",
@@ -2034,10 +1902,7 @@
         "regulation_watcher agent",
         "scraper_tools.check_regulation_source"
       ],
-      "apis_called": [
-        "ditjenimigrasi.go.id",
-        "kanwilbali.kemenkumham.go.id"
-      ],
+      "apis_called": ["ditjenimigrasi.go.id", "kanwilbali.kemenkumham.go.id"],
       "produces": "Regulation change alerts, stale entity alerts",
       "consumes": "Neo4j KG, government websites"
     },
@@ -2048,15 +1913,8 @@
       "type": "launchd-script",
       "schedule": "06:15 WITA daily (com.garuda.consumer.daily)",
       "uses_llm": "none",
-      "tools_called": [
-        "garuda-consumer.sh",
-        "OSINT-Nexus venv python",
-        "neo4j driver"
-      ],
-      "apis_called": [
-        "Neo4j (localhost)",
-        "Redis (garuda:raw stream)"
-      ],
+      "tools_called": ["garuda-consumer.sh", "OSINT-Nexus venv python", "neo4j driver"],
+      "apis_called": ["Neo4j (localhost)", "Redis (garuda:raw stream)"],
       "produces": "Neo4j nodes and edges from intelligence items",
       "consumes": "Redis garuda:raw stream"
     },
@@ -2067,15 +1925,8 @@
       "type": "launchd-script",
       "schedule": "07:00 + 18:00 WITA (com.garuda.gap-detector.twice-daily)",
       "uses_llm": "none",
-      "tools_called": [
-        "garuda-gap-detector.sh",
-        "OSINT-Nexus venv python",
-        "8 Cypher gap queries"
-      ],
-      "apis_called": [
-        "Neo4j (localhost)",
-        "Redis (nexus:gaps stream)"
-      ],
+      "tools_called": ["garuda-gap-detector.sh", "OSINT-Nexus venv python", "8 Cypher gap queries"],
+      "apis_called": ["Neo4j (localhost)", "Redis (nexus:gaps stream)"],
       "produces": "nexus:gaps stream tasks (missing attributes, relations, stale data)",
       "consumes": "Neo4j KG state"
     },
@@ -2085,11 +1936,7 @@
       "machine": "Pro",
       "type": "on-demand",
       "uses_llm": "none (dispatch only, agents use LLMs)",
-      "tools_called": [
-        "task_tools.py",
-        "Redis nexus:gaps stream",
-        "DISPATCH_TABLE routing"
-      ],
+      "tools_called": ["task_tools.py", "Redis nexus:gaps stream", "DISPATCH_TABLE routing"],
       "produces": "Dispatched agent tasks, audit log (task_dispatch.jsonl)",
       "consumes": "nexus:gaps stream from gap detector"
     },
@@ -2099,11 +1946,7 @@
       "machine": "Pro",
       "type": "pipeline-worker",
       "uses_llm": "none",
-      "tools_called": [
-        "Redis garuda:raw→garuda:enriched",
-        "SHA256 dedup",
-        "KB SQLite"
-      ],
+      "tools_called": ["Redis garuda:raw→garuda:enriched", "SHA256 dedup", "KB SQLite"],
       "produces": "garuda:enriched stream, KB entries",
       "consumes": "garuda:raw stream"
     },
@@ -2113,14 +1956,8 @@
       "machine": "Pro",
       "type": "pipeline-worker",
       "uses_llm": "Ollama (scoring model)",
-      "tools_called": [
-        "Redis garuda:enriched",
-        "Ollama local API"
-      ],
-      "apis_called": [
-        "Ollama localhost",
-        "Telegram Bot API (high-score alerts)"
-      ],
+      "tools_called": ["Redis garuda:enriched", "Ollama local API"],
+      "apis_called": ["Ollama localhost", "Telegram Bot API (high-score alerts)"],
       "produces": "Scored intelligence items, TG alerts for high-value items",
       "consumes": "garuda:enriched stream"
     },
@@ -2130,13 +1967,8 @@
       "machine": "Pro",
       "type": "pipeline-worker",
       "uses_llm": "none",
-      "tools_called": [
-        "nlm CLI (source add)",
-        "KB SQLite"
-      ],
-      "apis_called": [
-        "NotebookLM (via nlm CLI)"
-      ],
+      "tools_called": ["nlm CLI (source add)", "KB SQLite"],
+      "apis_called": ["NotebookLM (via nlm CLI)"],
       "produces": "NLM sources added to domain notebooks",
       "consumes": "KB harvested items"
     },
@@ -2153,10 +1985,7 @@
         "Redis garuda:digest",
         "tg_tools.py"
       ],
-      "apis_called": [
-        "Claude CLI (Anthropic subscription)",
-        "Telegram Bot API"
-      ],
+      "apis_called": ["Claude CLI (Anthropic subscription)", "Telegram Bot API"],
       "produces": "Intelligence digest, garuda:digest stream entry, TG briefing",
       "consumes": "KB data, garuda:enriched items"
     },
@@ -2166,14 +1995,8 @@
       "machine": "Pro",
       "type": "pipeline-agent",
       "uses_llm": "Claude CLI",
-      "tools_called": [
-        "scraper_tools.check_regulation_source",
-        "feed_tools.py"
-      ],
-      "apis_called": [
-        "ditjenimigrasi.go.id",
-        "kanwilbali.kemenkumham.go.id"
-      ],
+      "tools_called": ["scraper_tools.check_regulation_source", "feed_tools.py"],
+      "apis_called": ["ditjenimigrasi.go.id", "kanwilbali.kemenkumham.go.id"],
       "produces": "Regulation change items → garuda:raw",
       "consumes": "Government regulation websites"
     },
@@ -2183,13 +2006,8 @@
       "machine": "Pro",
       "type": "pipeline-agent",
       "uses_llm": "Claude CLI",
-      "tools_called": [
-        "scraper_tools.py",
-        "Twitter API v2"
-      ],
-      "apis_called": [
-        "Twitter API v2"
-      ],
+      "tools_called": ["scraper_tools.py", "Twitter API v2"],
+      "apis_called": ["Twitter API v2"],
       "produces": "Twitter intelligence items → garuda:raw",
       "consumes": "Twitter keyword streams"
     },
@@ -2199,13 +2017,8 @@
       "machine": "Pro",
       "type": "pipeline-agent",
       "uses_llm": "none",
-      "tools_called": [
-        "arxiv_tools.py",
-        "arxiv_sensor.py"
-      ],
-      "apis_called": [
-        "arXiv API"
-      ],
+      "tools_called": ["arxiv_tools.py", "arxiv_sensor.py"],
+      "apis_called": ["arXiv API"],
       "produces": "Research papers → garuda:raw",
       "consumes": "arXiv feeds"
     },
@@ -2215,13 +2028,8 @@
       "machine": "Pro",
       "type": "pipeline-agent",
       "uses_llm": "none",
-      "tools_called": [
-        "github_tools.py",
-        "github_sensor.py"
-      ],
-      "apis_called": [
-        "GitHub API"
-      ],
+      "tools_called": ["github_tools.py", "github_sensor.py"],
+      "apis_called": ["GitHub API"],
       "produces": "GitHub trends → garuda:raw",
       "consumes": "GitHub trending"
     },
@@ -2231,13 +2039,8 @@
       "machine": "Pro",
       "type": "pipeline-agent",
       "uses_llm": "none",
-      "tools_called": [
-        "youtube_tools.py",
-        "youtube_sensor.py"
-      ],
-      "apis_called": [
-        "YouTube Data API"
-      ],
+      "tools_called": ["youtube_tools.py", "youtube_sensor.py"],
+      "apis_called": ["YouTube Data API"],
       "produces": "Video intelligence → garuda:raw",
       "consumes": "YouTube search/channels"
     },
@@ -2247,13 +2050,8 @@
       "machine": "Pro",
       "type": "pipeline-agent",
       "uses_llm": "none",
-      "tools_called": [
-        "feed_tools.py",
-        "rss_sensor.py"
-      ],
-      "apis_called": [
-        "RSS feeds"
-      ],
+      "tools_called": ["feed_tools.py", "rss_sensor.py"],
+      "apis_called": ["RSS feeds"],
       "produces": "Newsletter items → garuda:raw",
       "consumes": "RSS/newsletter feeds"
     },
@@ -2263,12 +2061,7 @@
       "machine": "Pro",
       "type": "meta-agent",
       "uses_llm": "Claude CLI",
-      "tools_called": [
-        "meta_tools.py",
-        "lamarckian.py",
-        "reflection.py",
-        "Claude CLI --print"
-      ],
+      "tools_called": ["meta_tools.py", "lamarckian.py", "reflection.py", "Claude CLI --print"],
       "produces": "Agent GENOME mutations, performance reflections",
       "consumes": "Agent run logs, GENOME.md files"
     },
@@ -2278,9 +2071,7 @@
       "machine": "Pro",
       "type": "pipeline-agent",
       "uses_llm": "none",
-      "tools_called": [
-        "scraper_tools.py (HTTP probes)"
-      ],
+      "tools_called": ["scraper_tools.py (HTTP probes)"],
       "produces": "Source health status, dead source alerts",
       "consumes": "Source registry"
     },
@@ -2290,11 +2081,7 @@
       "machine": "Pro",
       "type": "runtime",
       "uses_llm": "Claude CLI (reflection + mutation proposals)",
-      "tools_called": [
-        "lamarckian.py",
-        "reflection.py",
-        "CLIRuntime(model=claude)"
-      ],
+      "tools_called": ["lamarckian.py", "reflection.py", "CLIRuntime(model=claude)"],
       "produces": "Evolved GENOME.md files, KB reflection entries",
       "consumes": "Agent performance logs, current GENOMEs"
     },
@@ -2304,10 +2091,7 @@
       "machine": "Pro",
       "type": "runtime",
       "uses_llm": "Claude CLI (primary) → Gemini CLI (fallback)",
-      "tools_called": [
-        "subprocess: claude --print",
-        "subprocess: gemini --prompt"
-      ],
+      "tools_called": ["subprocess: claude --print", "subprocess: gemini --prompt"],
       "produces": "LLM responses for agents",
       "consumes": "Agent prompts"
     }
@@ -2320,15 +2104,8 @@
       "machine": "Pro (local)",
       "type": "pipeline-stage",
       "uses_llm": "none",
-      "tools_called": [
-        "GoogleNewsRSSFetcher",
-        "browser_pool.py",
-        "proxy_manager.py"
-      ],
-      "apis_called": [
-        "Google News RSS",
-        "600+ news/gov websites"
-      ],
+      "tools_called": ["GoogleNewsRSSFetcher", "browser_pool.py", "proxy_manager.py"],
+      "apis_called": ["Google News RSS", "600+ news/gov websites"],
       "produces": "Raw scraped articles",
       "consumes": "Source list (630+ URLs)"
     },
@@ -2338,9 +2115,7 @@
       "machine": "Pro (local)",
       "type": "pipeline-stage",
       "uses_llm": "LLAMA (local via Ollama)",
-      "tools_called": [
-        "AIEngine (LLAMA provider)"
-      ],
+      "tools_called": ["AIEngine (LLAMA provider)"],
       "produces": "Scored articles (1-5)",
       "consumes": "Raw scraped articles"
     },
@@ -2350,12 +2125,8 @@
       "machine": "Pro (local)",
       "type": "pipeline-stage",
       "uses_llm": "Claude (Anthropic API)",
-      "tools_called": [
-        "AIEngine (Anthropic provider)"
-      ],
-      "apis_called": [
-        "Anthropic Messages API"
-      ],
+      "tools_called": ["AIEngine (Anthropic provider)"],
+      "apis_called": ["Anthropic Messages API"],
       "produces": "Validated articles",
       "consumes": "Scored articles (score >= threshold)"
     },
@@ -2365,12 +2136,8 @@
       "machine": "Pro (local)",
       "type": "pipeline-stage",
       "uses_llm": "Claude (Anthropic API, max context)",
-      "tools_called": [
-        "AIEngine (Anthropic provider)"
-      ],
-      "apis_called": [
-        "Anthropic Messages API"
-      ],
+      "tools_called": ["AIEngine (Anthropic provider)"],
+      "apis_called": ["Anthropic Messages API"],
       "produces": "Enriched full articles (MDX format)",
       "consumes": "Validated articles"
     },
@@ -2380,9 +2147,7 @@
       "machine": "Pro (local)",
       "type": "pipeline-stage",
       "uses_llm": "Gemini (image generation)",
-      "apis_called": [
-        "Gemini API (image gen)"
-      ],
+      "apis_called": ["Gemini API (image gen)"],
       "produces": "Cover images for articles",
       "consumes": "Article metadata"
     },
@@ -2392,13 +2157,8 @@
       "machine": "Pro (local)",
       "type": "pipeline-stage",
       "uses_llm": "none",
-      "tools_called": [
-        "balizero.com/api/news (POST)"
-      ],
-      "apis_called": [
-        "balizero.com/api/news",
-        "Telegram Bot API (approval)"
-      ],
+      "tools_called": ["balizero.com/api/news (POST)"],
+      "apis_called": ["balizero.com/api/news", "Telegram Bot API (approval)"],
       "produces": "Published articles on balizero.com",
       "consumes": "Enriched articles + images"
     },
@@ -2409,10 +2169,7 @@
       "type": "launchd-orchestrator",
       "schedule": "01:00 WITA daily (com.balizero.intel.nightly)",
       "uses_llm": "LLAMA + Claude + Gemini (via pipeline stages)",
-      "tools_called": [
-        "OpenClaw gateway trigger",
-        "bali-intel-scraper pipeline"
-      ],
+      "tools_called": ["OpenClaw gateway trigger", "bali-intel-scraper pipeline"],
       "produces": "Published intel articles (~$0.06/article)",
       "consumes": "630+ sources"
     }
@@ -2424,11 +2181,7 @@
       "consumes": "antv.kpk.go.id HTTP, gap_consumer dispatch",
       "uses_llm": "claude --print (via MetaChain)",
       "llm_interface": "Claude CLI subprocess",
-      "tools_called": [
-        "scrape_lhkpn_search()",
-        "scrape_lhkpn_profile()",
-        "stream_publish()"
-      ]
+      "tools_called": ["scrape_lhkpn_search()", "scrape_lhkpn_profile()", "stream_publish()"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Closes the **intel-radar → intel-scraper** half of the pipeline overhaul. This is **Section B** of PR-1.

Depends conceptually on PR #307 (Section A migration 139), but this branch is **independent** at code level — feature-flagged off by default, behaves like main when `INTEL_RADAR_PERSIST_DB=false`.

## Two concrete changes

### 1. `claude_cli_enricher.py`: live news scoring schema

Add three new fields to the enrichment JSON output:

- **`live_news_score`** (0-100): summed from 3 weighted signals
  - +40 — decree/regulation cited with publication date in last 48h
  - +30 — concrete dated event (arrest, deportation, audit, MoU)
  - +30 — fresh official figure (PNBP fee, BKPM threshold, BPS stat)
- **`liveness_tier`** (enum): derived from score
  - `breaking` if score ≥ 80
  - `developing` if 40 ≤ score < 80
  - `evergreen` if score < 40
- **`live_news_reasons`** (list): max 3 short strings explaining the score

**Defensive normalization** runs post-Claude (`_normalize_live_news_fields`):

- Clamps score to `[0, 100]`, coerces strings/floats, falls back to 0
- **Recomputes `tier` from score** — don't trust Claude's tier (occasional drift); downstream WR2 selector relies on `tier == bucket(score)` as strict invariant
- Caps reasons to 3 entries × 200 chars each, filters empties
- Zeroes reasons when score is 0 (no signal → no rationale)

### 2. `run_intel_pipeline.py`: read from `intel_radar_findings` table

Adds a third article source alongside `UnifiedScraper` and `ExaScraper`:

- Feature-flagged on `INTEL_RADAR_PERSIST_DB` (default `false` → no behavior change)
- Fetches up to 50 rows where `processed=true AND scraper_picked=false` from migration 139's table
- Marks them `scraper_picked=true` atomically with `FOR UPDATE SKIP LOCKED` (concurrent scrapers on different machines can't race)
- Articles shaped to `UnifiedScraper` format (`url/title/content/source_name/category/tier/published_date`) plus 3 audit extras (`intel_radar_query`, `intel_radar_query_tier`, `intel_radar_source`)
- All failure modes non-fatal: missing `asyncpg`, missing `DATABASE_URL`, DB unreachable → empty list, scraping continues

## Brainstormed with 3 LLMs

Codex GPT-5.5 / Gemini 3.1 Pro / DeepSeek Reasoner (2026-04-26). **3/3 convergence** on:

1. Score (0-100) + tier enum over original boolean `is_live_news`
2. Recompute-tier-from-score invariant (don't trust model output for the derived field)
3. Max-3-reasons cap

## Test plan

- [x] 19 unit tests for `_normalize_live_news_fields` covering clamping, type coercion, edge cases, model-disagrees scenario — all passing
- [x] AST OK for `run_intel_pipeline.py` and `claude_cli_enricher.py` after refactor
- [ ] Smoke test on Pro: `INTEL_RADAR_PERSIST_DB=true python3 run_intel_pipeline.py --mode full --limit 1` — deferred until migration 139 (PR #307) is applied to nuzantara-postgres
- [ ] Verify enriched JSON contains `live_news_score`/`liveness_tier`/`live_news_reasons` fields after first nightly run

## What's NOT in this PR

- **Section C**: WR2 selector live-first preference + `wr2_draft_generator.py` full-enriched prompt fix — separate PR
- **PR-1.5**: Auto-learning (decision tracking, REFLECT hook, dynamic rules, decay, sharing) — separate PR after PR-1 merged

## Files changed

- `apps/bali-intel-scraper/scripts/claude_cli_enricher.py` — schema + normalization
- `apps/bali-intel-scraper/scripts/run_intel_pipeline.py` — `_fetch_intel_radar_findings` + step_scraping integration
- `apps/bali-intel-scraper/tests/unit/test_claude_cli_enricher_live_news.py` (new) — 19 tests
- `scripts/automation_catalog.json` — refresh `com.balizero.intel.nightly` description

🤖 Generated with [Claude Code](https://claude.com/claude-code)