### PR TITLE
feat(wr2): PR-1 §C — live-first selector + full-enriched draft prompt

### DIFF
--- a/scripts/tests/test_wr2_draft_generator_enriched_prompt.py
+++ b/scripts/tests/test_wr2_draft_generator_enriched_prompt.py
@@ -1,0 +1,314 @@
+"""
+Tests for the enriched-prompt bug fix in scripts/wr2_draft_generator.py.
+
+Locks down PR-1 §C bug fix: when an enrichment object is available and the
+WR2_USE_FULL_ENRICHED_PROMPT flag is on, the draft prompt is built from the
+structured 1400-2000-word enrichment fields instead of summary[:3500].
+
+The previous behavior shipped only 25% of the available material to Claude;
+this fix is the difference between "11 slides built on a paragraph" and
+"11 slides built on the_facts + bali_zero_take + in_practice + next_steps + faq".
+
+These tests don't call Claude — they verify the prompt construction
+deterministically, which is the unit boundary we control.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import sys
+
+import pytest
+
+# wr2_draft_generator imports asyncpg/httpx at module load. Both are in the
+# backend-rag venv → available when run via PYTHONPATH=. + venv python.
+SCRIPTS_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from wr2_draft_generator import _build_draft_prompt, _build_enriched_brief  # noqa: E402
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _build_enriched_brief
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_enriched_brief_renders_all_sections() -> None:
+    """Full enrichment object → all 6 section labels appear in output."""
+    enrichment = {
+        "thirty_second_brief": {
+            "what": "BKPM raided unlicensed PMAs",
+            "why_it_matters": "Compliance risk for foreign investors",
+            "who": "Foreign-owned PT PMA without OSS",
+            "risk_level": "high",
+        },
+        "the_facts": "Paragraph 1.\n\nParagraph 2.",
+        "bali_zero_take": "Editorial perspective.",
+        "in_practice": "What expats should do.",
+        "next_steps": "Action items.",
+        "faq": [
+            {"question": "Q1?", "answer": "A1."},
+            {"question": "Q2?", "answer": "A2."},
+        ],
+    }
+    brief = _build_enriched_brief(enrichment, live_reasons=None)
+    assert "30-second brief" in brief
+    assert "The facts" in brief
+    assert "Bali Zero editorial take" in brief
+    assert "In practice" in brief
+    assert "Next steps" in brief
+    assert "FAQ" in brief
+
+
+def test_enriched_brief_includes_field_content() -> None:
+    """Verbatim content from each field must appear in the rendered brief."""
+    enrichment = {
+        "the_facts": "BKPM published Reg 5/2026 on 2026-04-23.",
+        "bali_zero_take": "This shifts the compliance burden to consultants.",
+        "next_steps": "Audit OSS status within 30 days.",
+    }
+    brief = _build_enriched_brief(enrichment, live_reasons=None)
+    assert "Reg 5/2026 on 2026-04-23" in brief
+    assert "compliance burden to consultants" in brief
+    assert "Audit OSS status within 30 days" in brief
+
+
+def test_enriched_brief_handles_empty_enrichment() -> None:
+    """Empty dict → empty brief (caller falls back to summary path)."""
+    assert _build_enriched_brief({}, live_reasons=None) == ""
+    assert _build_enriched_brief({"unknown_field": "noise"}, live_reasons=None) == ""
+
+
+def test_enriched_brief_skips_missing_sections() -> None:
+    """Partial enrichment renders only the sections that exist."""
+    brief = _build_enriched_brief(
+        {"the_facts": "Only the facts here.", "in_practice": ""},
+        live_reasons=None,
+    )
+    assert "The facts" in brief
+    assert "Only the facts here." in brief
+    # No bali_zero_take / next_steps / faq → labels absent
+    assert "Bali Zero editorial take" not in brief
+    assert "Next steps" not in brief
+    assert "FAQ" not in brief
+
+
+def test_enriched_brief_thirty_second_partial_fields() -> None:
+    """Partial 30-second brief renders only present subfields."""
+    brief = _build_enriched_brief(
+        {"thirty_second_brief": {"what": "Decree published", "risk_level": "medium"}},
+        live_reasons=None,
+    )
+    assert "What: Decree published" in brief
+    assert "Risk level: medium" in brief
+    assert "Why it matters" not in brief
+    assert "Who is affected" not in brief
+
+
+def test_enriched_brief_appends_live_reasons() -> None:
+    enrichment = {"the_facts": "Facts."}
+    brief = _build_enriched_brief(
+        enrichment,
+        live_reasons=[
+            "BKPM Reg 5/2026 published 2026-04-23",
+            "Deportation of 12 nationals 2026-04-25",
+        ],
+    )
+    assert "Live news signals" in brief
+    assert "BKPM Reg 5/2026 published 2026-04-23" in brief
+    assert "Deportation of 12 nationals 2026-04-25" in brief
+
+
+def test_enriched_brief_caps_live_reasons_at_three() -> None:
+    brief = _build_enriched_brief(
+        {"the_facts": "Facts."},
+        live_reasons=["one", "two", "three", "four", "five"],
+    )
+    assert "one" in brief
+    assert "three" in brief
+    assert "four" not in brief
+    assert "five" not in brief
+
+
+def test_enriched_brief_empty_live_reasons_no_section() -> None:
+    """Empty list → no Live news signals section (avoid empty header)."""
+    brief = _build_enriched_brief({"the_facts": "Facts."}, live_reasons=[])
+    assert "Live news signals" not in brief
+
+
+def test_enriched_brief_caps_faq_at_six() -> None:
+    enrichment = {
+        "faq": [{"question": f"Q{i}?", "answer": f"A{i}."} for i in range(10)]
+    }
+    brief = _build_enriched_brief(enrichment, live_reasons=None)
+    assert "Q5?" in brief
+    assert "Q6?" not in brief
+
+
+def test_enriched_brief_skips_malformed_faq_entries() -> None:
+    enrichment = {
+        "faq": [
+            {"question": "Q1?", "answer": "A1."},
+            "not a dict",
+            {"question": "", "answer": "missing question"},
+            {"question": "Q4?", "answer": "A4."},
+        ],
+    }
+    brief = _build_enriched_brief(enrichment, live_reasons=None)
+    assert "Q1?" in brief
+    assert "Q4?" in brief
+    assert "missing question" not in brief
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _build_draft_prompt — flag gating
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_legacy_path_used_when_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default behavior: enriched ignored, summary[:3500] used. Preserves
+    pre-§C behavior for safe rollback."""
+    monkeypatch.setenv("WR2_USE_FULL_ENRICHED_PROMPT", "false")
+    enrichment = {
+        "the_facts": "ENRICHED FACT TEXT",
+        "bali_zero_take": "ENRICHED TAKE",
+    }
+    prompt = _build_draft_prompt(
+        topic="Test topic",
+        summary="LEGACY SUMMARY CONTENT",
+        source_url="https://example.com",
+        enrichment=enrichment,
+        live_reasons=["should not appear"],
+    )
+    assert "LEGACY SUMMARY CONTENT" in prompt
+    assert "ENRICHED FACT TEXT" not in prompt
+    assert "ENRICHED TAKE" not in prompt
+
+
+def test_enriched_path_used_when_flag_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Flag on + enrichment present → prompt is built from structured fields."""
+    monkeypatch.setenv("WR2_USE_FULL_ENRICHED_PROMPT", "true")
+    enrichment = {
+        "the_facts": "ENRICHED FACT TEXT",
+        "bali_zero_take": "ENRICHED TAKE",
+        "in_practice": "ENRICHED PRACTICE",
+    }
+    prompt = _build_draft_prompt(
+        topic="Test topic",
+        summary="LEGACY SUMMARY CONTENT",
+        source_url="https://example.com",
+        enrichment=enrichment,
+        live_reasons=None,
+    )
+    assert "ENRICHED FACT TEXT" in prompt
+    assert "ENRICHED TAKE" in prompt
+    assert "ENRICHED PRACTICE" in prompt
+    # Section labels present → confirms _build_enriched_brief path was taken
+    assert "The facts" in prompt
+    assert "Bali Zero editorial take" in prompt
+
+
+def test_falls_back_to_summary_when_flag_on_but_no_enrichment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Flag on but enrichment empty → graceful fallback to summary path.
+
+    Critical: items that pre-date §B (enrichment=None) must still produce a
+    valid prompt instead of crashing or sending Claude an empty body.
+    """
+    monkeypatch.setenv("WR2_USE_FULL_ENRICHED_PROMPT", "true")
+    prompt = _build_draft_prompt(
+        topic="Legacy topic",
+        summary="LEGACY SUMMARY CONTENT",
+        source_url="https://example.com",
+        enrichment=None,
+        live_reasons=None,
+    )
+    assert "LEGACY SUMMARY CONTENT" in prompt
+
+
+def test_falls_back_to_summary_when_enrichment_is_empty_dict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Flag on but enrichment={} → also falls back to summary path."""
+    monkeypatch.setenv("WR2_USE_FULL_ENRICHED_PROMPT", "true")
+    prompt = _build_draft_prompt(
+        topic="t",
+        summary="LEGACY SUMMARY CONTENT",
+        source_url="",
+        enrichment={},
+        live_reasons=None,
+    )
+    assert "LEGACY SUMMARY CONTENT" in prompt
+
+
+def test_summary_truncated_at_3500_in_legacy_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy invariant preserved: summary[:3500] cap stays in place to
+    avoid blowing the context budget on the back-compat path."""
+    monkeypatch.setenv("WR2_USE_FULL_ENRICHED_PROMPT", "false")
+    long_summary = "x" * 5000 + "TAIL_MARKER"
+    prompt = _build_draft_prompt(
+        topic="t", summary=long_summary, source_url="",
+        enrichment=None, live_reasons=None,
+    )
+    assert "TAIL_MARKER" not in prompt  # everything past 3500 is dropped
+
+
+def test_enriched_prompt_is_substantially_longer_than_legacy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The whole point of this bug fix: with the enriched object, the
+    prompt body Claude sees is materially larger than ~3500 chars. We
+    don't pin exact size (it's content-dependent), only that the
+    enriched-mode prompt is meaningfully bigger than the legacy one
+    on the same data — confirming we're shipping more material.
+    """
+    enrichment = {
+        "thirty_second_brief": {
+            "what": "What happened.",
+            "why_it_matters": "Why it matters.",
+            "who": "Who is affected.",
+            "risk_level": "medium",
+        },
+        "the_facts": "x" * 1500,
+        "bali_zero_take": "y" * 600,
+        "in_practice": "z" * 600,
+        "next_steps": "w" * 400,
+        "faq": [{"question": f"Q{i}?", "answer": "a" * 100} for i in range(4)],
+    }
+
+    monkeypatch.setenv("WR2_USE_FULL_ENRICHED_PROMPT", "false")
+    legacy = _build_draft_prompt(
+        topic="t", summary="short summary", source_url="",
+        enrichment=enrichment, live_reasons=None,
+    )
+
+    monkeypatch.setenv("WR2_USE_FULL_ENRICHED_PROMPT", "true")
+    enriched = _build_draft_prompt(
+        topic="t", summary="short summary", source_url="",
+        enrichment=enrichment, live_reasons=None,
+    )
+
+    # System prompt is fixed ~2000 chars; only the body section changes
+    # between modes. Enriched body must be substantially larger than the
+    # legacy "short summary" path. We assert delta >= 3000 chars — enough
+    # to confirm we're shipping the_facts + take + practice + steps + faq
+    # instead of the truncated paragraph.
+    assert len(enriched) - len(legacy) >= 3000
+    assert len(enriched) > 4000  # crosses the 3500 ceiling the bug imposed
+
+
+def test_topic_and_source_appear_in_both_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Common-prompt invariants: topic and source_url labels appear
+    regardless of which body path was taken."""
+    for flag in ("false", "true"):
+        monkeypatch.setenv("WR2_USE_FULL_ENRICHED_PROMPT", flag)
+        prompt = _build_draft_prompt(
+            topic="My Topic",
+            summary="summary",
+            source_url="https://example.com/article",
+            enrichment={"the_facts": "facts"},
+            live_reasons=None,
+        )
+        assert "My Topic" in prompt
+        assert "https://example.com/article" in prompt

--- a/scripts/tests/test_wr2_topic_selector_live_news.py
+++ b/scripts/tests/test_wr2_topic_selector_live_news.py
@@ -1,0 +1,211 @@
+"""
+Tests for the live-news scoring additions to scripts/wr2_topic_selector.py.
+
+Locks down PR-1 §C behaviors:
+  - score_item bonus = live_news_score / 2 (0..50 range)
+  - score_item penalty = -20 when title matches a routine/evergreen pattern
+  - liveness_tier passes through to detail rules (and falls back to
+    "evergreen" on missing/garbage values, matching the enricher's
+    normalization invariant from §B)
+  - the score_item caller path tolerates legacy items with no
+    live_news_score / liveness_tier fields (returns 0 bonus, no penalty
+    unless the title pattern fires)
+
+These are the rules a downstream operator needs to be able to reason
+about when triaging "why did the selector pick draft X over Y today?"
+from the scored top-5 log line, so we lock the specific point values.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+# Make scripts/ importable. wr2_topic_selector.py imports asyncpg/httpx at
+# module load — both are in the backend-rag venv so the test runner picks
+# them up via PYTHONPATH=. from repo root.
+SCRIPTS_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from wr2_topic_selector import (  # noqa: E402
+    LIVE_NEWS_BONUS_DIVISOR,
+    ROUTINE_TITLE_PENALTY,
+    score_item,
+)
+
+
+def _base_item(**overrides) -> dict:
+    """A minimal staging item that scores to ~5 base points (T3, no kw, stale).
+
+    Tests override only the fields they care about — keeping the base
+    constant means the asserted deltas come from §C bonuses/penalties only.
+    """
+    item = {
+        "title": "Generic news item from Indonesia",
+        "content": "lorem ipsum",
+        "tier": "T3",
+        # No detected_at / published_at → falls back to age=24h, fresh_score≈20
+    }
+    item.update(overrides)
+    return item
+
+
+def test_evergreen_item_gets_no_live_bonus() -> None:
+    score, detail = score_item(_base_item())
+    assert detail["rules"]["live_news_score"] == 0
+    assert detail["rules"]["live_news_bonus"] == 0
+    assert detail["rules"]["liveness_tier"] == "evergreen"
+
+
+def test_breaking_score_80_gets_40_point_bonus() -> None:
+    score, detail = score_item(_base_item(
+        live_news_score=80,
+        liveness_tier="breaking",
+    ))
+    assert detail["rules"]["live_news_score"] == 80
+    assert detail["rules"]["live_news_bonus"] == 80 / LIVE_NEWS_BONUS_DIVISOR  # 40
+    assert detail["rules"]["liveness_tier"] == "breaking"
+
+
+def test_developing_score_60_gets_30_point_bonus() -> None:
+    score, detail = score_item(_base_item(
+        live_news_score=60,
+        liveness_tier="developing",
+    ))
+    assert detail["rules"]["live_news_bonus"] == 60 / LIVE_NEWS_BONUS_DIVISOR  # 30
+
+
+def test_breaking_score_100_gets_50_point_bonus() -> None:
+    score, detail = score_item(_base_item(
+        live_news_score=100,
+        liveness_tier="breaking",
+    ))
+    assert detail["rules"]["live_news_bonus"] == 50.0
+
+
+def test_score_clamped_above_100() -> None:
+    """Defense-in-depth: even if upstream missed it, selector clamps to 100."""
+    _, detail = score_item(_base_item(live_news_score=250))
+    assert detail["rules"]["live_news_score"] == 100
+    assert detail["rules"]["live_news_bonus"] == 50.0
+
+
+def test_score_clamped_below_0() -> None:
+    _, detail = score_item(_base_item(live_news_score=-30))
+    assert detail["rules"]["live_news_score"] == 0
+    assert detail["rules"]["live_news_bonus"] == 0
+
+
+def test_score_string_coerced() -> None:
+    _, detail = score_item(_base_item(live_news_score="55"))
+    assert detail["rules"]["live_news_score"] == 55
+    assert detail["rules"]["live_news_bonus"] == 27.5
+
+
+def test_score_garbage_falls_back_to_zero() -> None:
+    _, detail = score_item(_base_item(live_news_score="not a number"))
+    assert detail["rules"]["live_news_score"] == 0
+    assert detail["rules"]["live_news_bonus"] == 0
+
+
+def test_invalid_liveness_tier_falls_back_to_evergreen() -> None:
+    _, detail = score_item(_base_item(
+        live_news_score=85,
+        liveness_tier="hot",  # not in {breaking,developing,evergreen}
+    ))
+    # Tier passes through normalized to evergreen, but the bonus from the
+    # numeric score is still applied — the selector trusts the score, not
+    # the (possibly drifted) tier label.
+    assert detail["rules"]["liveness_tier"] == "evergreen"
+    assert detail["rules"]["live_news_bonus"] == 42.5
+
+
+@pytest.mark.parametrize("title", [
+    "How to apply for KITAS in 2026",
+    "Guide to PT PMA company setup",
+    "The Complete Guide to Bali Property Investment",
+    "KITAS Renewal Explained",
+    "Indonesian Tax Code Decoded",
+    "Step-by-step KBLI 2026 navigator",
+    "Step by step KBLI 2026 navigator",
+    "Everything you need to know about NPWP",
+])
+def test_routine_title_pattern_triggers_penalty(title: str) -> None:
+    _, detail = score_item(_base_item(title=title))
+    assert detail["rules"]["routine_penalty"] == ROUTINE_TITLE_PENALTY
+
+
+@pytest.mark.parametrize("title", [
+    "BKPM tightens foreign investment rules",
+    "Indonesia deports 12 nationals over visa fraud",
+    "New PNBP fees announced for 2026",
+    "Bali property market: Q1 2026 numbers",
+])
+def test_news_title_no_penalty(title: str) -> None:
+    _, detail = score_item(_base_item(title=title))
+    assert detail["rules"]["routine_penalty"] == 0
+
+
+def test_routine_penalty_subtracted_from_total() -> None:
+    """Two items with identical keyword/tier/freshness — only the title
+    pattern differs. The routine title pays the -20 penalty, the news
+    title doesn't. This is the only place where the penalty contribution
+    can be measured cleanly.
+    """
+    # Identical keyword content — only the title prefix differs (routine vs
+    # news shape). Other scoring inputs (kw match, tier, freshness) match
+    # exactly, so the score delta isolates the penalty contribution.
+    base = {
+        "content": "kitas visa imigrasi",  # same kw matches both items
+        "tier": "T2",
+    }
+    score_routine, detail_routine = score_item({
+        "title": "How to renew status",  # routine pattern, no kw in title
+        **base,
+    })
+    score_news, detail_news = score_item({
+        "title": "Officials confirm policy change",  # news, no kw in title
+        **base,
+    })
+    assert detail_routine["rules"]["routine_penalty"] == ROUTINE_TITLE_PENALTY
+    assert detail_news["rules"]["routine_penalty"] == 0
+    assert detail_routine["rules"]["keywords_points"] == detail_news["rules"]["keywords_points"]
+    # Same base, different penalty → exactly ROUTINE_TITLE_PENALTY apart
+    assert score_routine == pytest.approx(score_news - ROUTINE_TITLE_PENALTY)
+
+
+def test_breaking_news_outscores_routine_guide_with_same_keywords() -> None:
+    """The end-to-end intent of §C: a breaking news item with score 85 must
+    beat a routine guide on the same topic."""
+    breaking_score, _ = score_item({
+        "title": "BKPM raids 5 unlicensed PT PMAs in Jakarta",
+        "content": "kitas visa investor pma kbli",
+        "tier": "T1",
+        "live_news_score": 85,
+        "liveness_tier": "breaking",
+    })
+    routine_score, _ = score_item({
+        "title": "The Complete Guide to PT PMA in 2026",
+        "content": "kitas visa investor pma kbli",
+        "tier": "T1",
+        # No live_news_score → 0
+    })
+    assert breaking_score > routine_score
+    # And by a wide margin: bonus +42.5 plus penalty +20 of separation
+    assert (breaking_score - routine_score) >= 60
+
+
+def test_legacy_item_without_live_news_fields_works() -> None:
+    """Items predating §B (no live_news_score in payload) must still score
+    cleanly with the bonus = 0 and the tier defaulting to evergreen."""
+    item = {
+        "title": "Indonesian rupiah hits 16,500 against dollar",
+        "content": "rupiah dollar exchange",
+        "tier": "T2",
+    }
+    score, detail = score_item(item)
+    assert detail["rules"]["live_news_score"] == 0
+    assert detail["rules"]["liveness_tier"] == "evergreen"
+    assert detail["rules"]["routine_penalty"] == 0
+    assert score > 0  # base scoring still gives points

--- a/scripts/wr2_draft_generator.py
+++ b/scripts/wr2_draft_generator.py
@@ -188,7 +188,120 @@ Structure:
 """
 
 
-def _build_draft_prompt(topic: str, summary: str, source_url: str) -> str:
+def _build_enriched_brief(enrichment: dict[str, Any], live_reasons: list[str] | None) -> str:
+    """Render the structured enrichment object as a labeled brief for Claude.
+
+    The intel-scraper produces 1400-2000 words across these fields:
+      - thirty_second_brief: {what, why_it_matters, who, risk_level}
+      - the_facts: 3-5 paragraphs of pure journalism, 400-500 words
+      - bali_zero_take: 2-3 paragraphs editorial perspective, 150-200 words
+      - in_practice: practical implications, 150-200 words
+      - next_steps: concrete action items, 100-150 words
+      - faq: list of {question, answer} pairs
+
+    The legacy prompt path passed only `summary[:3500]` (≈ 25% of the
+    available material) and ignored every Bali-Zero-specific framing the
+    enricher produced. This builder turns the structured object into a
+    section-tagged ground-truth brief Claude can quote from directly.
+
+    Returns an empty string if enrichment has no usable fields, so the
+    caller can fall back to the legacy summary path cleanly.
+    """
+    parts: list[str] = []
+
+    brief30 = enrichment.get("thirty_second_brief") or {}
+    if isinstance(brief30, dict) and brief30:
+        what = brief30.get("what") or ""
+        why = brief30.get("why_it_matters") or ""
+        who = brief30.get("who") or ""
+        risk = brief30.get("risk_level") or ""
+        if what or why or who:
+            parts.append("### 30-second brief")
+            if what:
+                parts.append(f"What: {what}")
+            if why:
+                parts.append(f"Why it matters: {why}")
+            if who:
+                parts.append(f"Who is affected: {who}")
+            if risk:
+                parts.append(f"Risk level: {risk}")
+            parts.append("")
+
+    facts = enrichment.get("the_facts") or ""
+    if isinstance(facts, str) and facts.strip():
+        parts.append("### The facts (use these as ground truth)")
+        parts.append(facts.strip())
+        parts.append("")
+
+    take = enrichment.get("bali_zero_take") or ""
+    if isinstance(take, str) and take.strip():
+        parts.append("### Bali Zero editorial take")
+        parts.append(take.strip())
+        parts.append("")
+
+    practice = enrichment.get("in_practice") or ""
+    if isinstance(practice, str) and practice.strip():
+        parts.append("### In practice (for expats/investors)")
+        parts.append(practice.strip())
+        parts.append("")
+
+    next_steps = enrichment.get("next_steps") or ""
+    if isinstance(next_steps, str) and next_steps.strip():
+        parts.append("### Next steps")
+        parts.append(next_steps.strip())
+        parts.append("")
+
+    faq = enrichment.get("faq") or []
+    if isinstance(faq, list) and faq:
+        parts.append("### FAQ")
+        for entry in faq[:6]:  # cap at 6, more is noise
+            if not isinstance(entry, dict):
+                continue
+            q = entry.get("question") or ""
+            a = entry.get("answer") or ""
+            if q and a:
+                parts.append(f"Q: {q}")
+                parts.append(f"A: {a}")
+                parts.append("")
+
+    if live_reasons:
+        parts.append("### Live news signals (why this is timely)")
+        for reason in live_reasons[:3]:
+            parts.append(f"- {reason}")
+        parts.append("")
+
+    return "\n".join(parts).strip()
+
+
+def _build_draft_prompt(
+    topic: str,
+    summary: str,
+    source_url: str,
+    enrichment: dict[str, Any] | None = None,
+    live_reasons: list[str] | None = None,
+) -> str:
+    """Build the slide-composition prompt.
+
+    PR-1 §C: when an enrichment object is available we hand Claude the full
+    structured brief (1400-2000 words across the_facts, bali_zero_take,
+    in_practice, next_steps, faq) instead of a truncated paragraph. This
+    is gated by WR2_USE_FULL_ENRICHED_PROMPT so the legacy path stays
+    available for back-compat / rollback.
+
+    Falls back to summary[:3500] when:
+      - WR2_USE_FULL_ENRICHED_PROMPT != "true" (legacy mode), OR
+      - enrichment dict is empty / missing all expected fields.
+    """
+    use_full_enriched = os.environ.get("WR2_USE_FULL_ENRICHED_PROMPT", "false").lower() == "true"
+
+    body = ""
+    if use_full_enriched and enrichment:
+        body = _build_enriched_brief(enrichment, live_reasons)
+
+    if not body:
+        # Legacy path: truncated summary. Always available as fallback.
+        body = summary[:3500]
+
     return f"""{SYSTEM_INSTRUCTIONS}
 
 ---
@@ -199,8 +312,8 @@ Title: {topic}
 
 Source: {source_url or "n/a"}
 
-Content (excerpt):
-{summary[:3500]}
+Content:
+{body}
 
 ---
 
@@ -223,8 +336,17 @@ def _extract_json(text: str) -> dict[str, Any]:
     return json.loads(text)
 
 
-async def claude_compose_slides(topic: str, summary: str, source_url: str) -> dict[str, Any]:
-    prompt = _build_draft_prompt(topic, summary, source_url)
+async def claude_compose_slides(
+    topic: str,
+    summary: str,
+    source_url: str,
+    enrichment: dict[str, Any] | None = None,
+    live_reasons: list[str] | None = None,
+) -> dict[str, Any]:
+    prompt = _build_draft_prompt(
+        topic, summary, source_url,
+        enrichment=enrichment, live_reasons=live_reasons,
+    )
     logger.info("Calling Claude OAuth for slide composition (prompt %d chars)", len(prompt))
     t0 = time.perf_counter()
     resp = await complete_async(
@@ -463,11 +585,22 @@ async def _process_one(conn: asyncpg.Connection, row: asyncpg.Record) -> bool:
     brief = json.loads(brief_raw) if isinstance(brief_raw, str) else (brief_raw or {})
     summary = brief.get("article_summary") or ""
     source_url = brief.get("source_url") or ""
+    enrichment = brief.get("enrichment") or None
+    live_reasons = brief.get("live_news_reasons") or []
+    if not isinstance(live_reasons, list):
+        live_reasons = []
 
-    logger.info("─── processing draft %s ─── topic=%r", draft_id, topic[:80])
+    logger.info(
+        "─── processing draft %s ─── topic=%r enrichment=%s live_score=%s",
+        draft_id, topic[:80],
+        bool(enrichment), brief.get("live_news_score"),
+    )
 
     try:
-        parsed = await claude_compose_slides(topic=topic, summary=summary, source_url=source_url)
+        parsed = await claude_compose_slides(
+            topic=topic, summary=summary, source_url=source_url,
+            enrichment=enrichment, live_reasons=live_reasons,
+        )
     except (ClaudeOAuthError, ClaudeOAuthNotAvailable) as e:
         logger.error("Claude OAuth failed: %s", e)
         await _mark_rejected(conn, draft_id, f"claude_failed: {e}")

--- a/scripts/wr2_topic_selector.py
+++ b/scripts/wr2_topic_selector.py
@@ -68,6 +68,29 @@ TIER_WEIGHT: dict[str, int] = {"T1": 30, "T2": 15, "T3": 5}
 SCORE_THRESHOLD: float = 40.0
 STAGING_FETCH_TIMEOUT: float = 30.0
 
+# PR-1 §C: live news preference. The intel-scraper enricher (Section B) tags
+# each staging item with live_news_score (0-100) and a derived liveness_tier
+# (breaking >= 80, developing 40-79, evergreen <40). The selector turns those
+# into a soft score adjustment so that — all else equal — a breaking-news
+# item beats an evergreen guide.
+#
+# Bonus: live_news_score / 2 → up to +50 points for breaking, +40 max for
+# upper-developing, 0 for evergreen. Defense-in-depth on top of the
+# live-first hard filter (when WR2_PREFER_LIVE_NEWS=true).
+#
+# Penalty: -20 if the headline matches a routine/evergreen pattern. Even
+# with a live_news_score from the enricher, a "How to apply for KITAS" or
+# "The Complete Guide to PT PMA" should never beat an actual breaking item.
+import re  # noqa: E402
+
+LIVE_NEWS_BONUS_DIVISOR: float = 2.0  # score / 2 → 0..50 points
+ROUTINE_TITLE_PENALTY: float = 20.0
+ROUTINE_TITLE_PATTERN: re.Pattern[str] = re.compile(
+    r"^\s*(?:how\s+to|guide\s+to|the\s+complete\s+guide|.+\s+explained|.+\s+decoded|step[-\s]by[-\s]step|everything\s+you\s+need)\b",
+    re.IGNORECASE,
+)
+LIVENESS_TIER_VALID = {"breaking", "developing", "evergreen"}
+
 
 def _parse_dt(value: Any) -> datetime | None:
     if not value:
@@ -111,7 +134,33 @@ def score_item(item: dict[str, Any]) -> tuple[float, dict[str, Any]]:
     detail["rules"]["tier"] = tier
     detail["rules"]["tier_points"] = tier_score
 
-    total = fresh_score + kw_score + tier_score
+    # Live news bonus (PR-1 §C). The intel-scraper enricher computes
+    # live_news_score (0-100); we use it as a soft additive signal here.
+    # Defaults to 0 when the field is missing (legacy items, evergreen).
+    raw_live = item.get("live_news_score")
+    try:
+        live_news_score = int(round(float(raw_live))) if raw_live is not None else 0
+    except (TypeError, ValueError):
+        live_news_score = 0
+    live_news_score = max(0, min(100, live_news_score))
+    live_bonus = round(live_news_score / LIVE_NEWS_BONUS_DIVISOR, 1)
+    detail["rules"]["live_news_score"] = live_news_score
+    detail["rules"]["live_news_bonus"] = live_bonus
+
+    liveness_tier = str(item.get("liveness_tier") or "").lower()
+    if liveness_tier not in LIVENESS_TIER_VALID:
+        liveness_tier = "evergreen"
+    detail["rules"]["liveness_tier"] = liveness_tier
+
+    # Routine/evergreen title penalty (PR-1 §C). Even when the enricher
+    # mistakenly stamps a live_news_score on a routine guide, the headline
+    # shape gives it away. Conservative: only fires on the title, not body.
+    routine_penalty = 0.0
+    if title and ROUTINE_TITLE_PATTERN.search(title):
+        routine_penalty = ROUTINE_TITLE_PENALTY
+    detail["rules"]["routine_penalty"] = routine_penalty
+
+    total = fresh_score + kw_score + tier_score + live_bonus - routine_penalty
     detail["score"] = round(total, 1)
     return total, detail
 
@@ -203,16 +252,49 @@ async def run(*, dry_run: bool = False, force: bool = False) -> int:
         logger.info("No pending items — nothing to do today")
         return 1
 
+    # Live-first hard preference (PR-1 §C). When WR2_PREFER_LIVE_NEWS=true,
+    # restrict the candidate pool to items the enricher tagged as breaking
+    # or developing AND whose live_news_score crosses LIVE_NEWS_FILTER_MIN.
+    # If that pool is empty, log explicitly and fall back to the full pool
+    # (evergreen queue) so the pipeline never goes idle just because no
+    # live news landed today. The score-bonus + routine-penalty in
+    # score_item() apply on top regardless of this flag.
+    prefer_live = os.environ.get("WR2_PREFER_LIVE_NEWS", "false").lower() == "true"
+    live_filter_min = int(os.environ.get("WR2_LIVE_NEWS_FILTER_MIN", "40"))
+    if prefer_live:
+        live_pool = [
+            i for i in items
+            if str(i.get("liveness_tier") or "").lower() in {"breaking", "developing"}
+            and (int(i.get("live_news_score") or 0) >= live_filter_min)
+        ]
+        if live_pool:
+            logger.info(
+                "WR2_PREFER_LIVE_NEWS=true: using live pool (%d items, score >= %d)",
+                len(live_pool), live_filter_min,
+            )
+            items = live_pool
+        else:
+            logger.info(
+                "WR2_PREFER_LIVE_NEWS=true: live pool empty (no items with "
+                "liveness_tier∈{breaking,developing} AND live_news_score >= %d); "
+                "falling back to evergreen pool (%d items)",
+                live_filter_min, len(items),
+            )
+
     scored = [(item, *score_item(item)) for item in items]
     scored.sort(key=lambda t: -t[1])
 
     for rank, (item, score, detail) in enumerate(scored[:5], start=1):
         logger.info(
-            "#%d score=%.1f [%s] kw=%d title=%r",
+            "#%d score=%.1f [%s/%s] kw=%d live=%d/%.1f routine=-%.0f title=%r",
             rank,
             score,
             detail["rules"]["tier"],
+            detail["rules"].get("liveness_tier", "evergreen"),
             detail["rules"]["keywords_points"],
+            detail["rules"].get("live_news_score", 0),
+            detail["rules"].get("live_news_bonus", 0.0),
+            detail["rules"].get("routine_penalty", 0.0),
             (item.get("title") or "")[:80],
         )
 
@@ -278,12 +360,24 @@ async def run(*, dry_run: bool = False, force: bool = False) -> int:
             logger.info("[DRY-RUN] brief_json preview: %s", json.dumps(top_detail, indent=2))
             return 0
 
+        # Enriched object pass-through (PR-1 §C bug fix). The intel-scraper
+        # produces a full structured enrichment (1400-2000 words across
+        # the_facts/bali_zero_take/in_practice/next_steps/faq) but the old
+        # draft generator only saw `summary[:3500]` — i.e. ~25% of the
+        # available material. We pass the entire enriched object through
+        # brief_json so the draft generator can use the structured ground
+        # truth instead of a truncated paragraph.
+        enrichment_obj = top_item.get("enrichment") or {}
         brief_json: dict[str, Any] = {
             "staging_id": staging_id,
             "staging_type": top_item.get("type"),
             "source_url": top_item.get("source"),
             "article_title": title,
             "article_summary": (top_item.get("content") or "")[:2000],
+            "enrichment": enrichment_obj,  # full structured object (PR-1 §C)
+            "live_news_score": top_item.get("live_news_score"),
+            "liveness_tier": top_item.get("liveness_tier"),
+            "live_news_reasons": top_item.get("live_news_reasons") or [],
             "detected_at": top_item.get("detected_at"),
             "picked_at": datetime.now(timezone.utc).isoformat(),
             "score_detail": top_detail,


### PR DESCRIPTION
## Summary

Closes the **WR2 half** of the intel pipeline overhaul (PR-1 final piece). Builds on PR #307 (Section A — migration 139, tier rotation) and PR #308 (Section B — live_news_score enrichment).

This PR contains the **bug fix critical** from the original brainstorm: the draft generator was feeding Claude only 25% of the available enriched material.

## Two changes

### 1. `wr2_topic_selector.py` — score live news ahead of routine guides

**Hard preference** (`WR2_PREFER_LIVE_NEWS=true`): restrict candidate pool to items where `liveness_tier ∈ {breaking, developing}` AND `live_news_score >= WR2_LIVE_NEWS_FILTER_MIN` (default 40). When live pool empty, falls back to full pool (pipeline never goes idle).

**Soft bonus**: `live_news_score / 2` → 0..50 points on top of existing freshness/keyword/tier score.

**Routine penalty**: `-20` when title matches `^(How to|Guide to|.+ Explained|.+ Decoded|The Complete|Step by step|Everything you need to know)`.

**Enriched-object pass-through**: the entire enrichment dict from §B is copied to `brief_json["enrichment"]` for the draft generator to consume.

### 2. `wr2_draft_generator.py` — bug fix critical: full enriched prompt

**Before**: `_build_draft_prompt` fed Claude only `summary[:3500]` (25% of available material). Enricher's 1400-2000 words of structured ground truth (`the_facts/bali_zero_take/in_practice/next_steps/faq`) was dropped on the floor. 11-slide carousels were built on a paragraph instead of an article.

**Fix**: new `_build_enriched_brief()` renders the structured object as a section-tagged ground-truth brief. Sections: 30-second brief, the_facts, bali_zero_take, in_practice, next_steps, faq (max 6), live_news_reasons (max 3).

Gated by `WR2_USE_FULL_ENRICHED_PROMPT` (default `false` → legacy path preserved). Falls back to `summary[:3500]` when flag is off OR enrichment dict is empty.

**Result**: enriched prompts ship ~3000 chars more material than legacy (typically 2-3x more content to Claude).

## Brainstormed with 3 LLMs

Codex GPT-5.5 / Gemini 3.1 Pro / DeepSeek Reasoner (2026-04-26). **3/3 convergence** on:
- Bonus formula `score / 2` (capped at 50)
- Hard penalty `-20` on routine title pattern
- Tier-from-score recompute invariant (don't trust model output)
- Gated rollout via env flag

## Test plan

- [x] **41 unit tests** across both files — all passing
  - 24 for topic_selector: clamping, type coercion, routine pattern matching (all 8 prefixes), news outscores routine same-keyword, legacy-item back-compat
  - 17 for draft_generator: each section renders, FAQ cap at 6, live_reasons cap at 3, falls-back-to-summary on missing enrichment, `summary[:3500]` truncation preserved in legacy, enriched prompt ≥ 3000 chars longer than legacy
- [x] AST OK on both files
- [ ] Smoke test on Pro: insert 2 mock staging items (one breaking score=85, one evergreen score=20) → run `wr2_topic_selector.py --dry-run` → verify breaking picked. Deferred until PR #307 + #308 merged + WR2 staging populated.
- [ ] First production run: `WR2_USE_FULL_ENRICHED_PROMPT=true` + verify draft slides cite specific facts from `the_facts` (deferred until merged on Pro).

## Feature flags (default off)

In `~/.nuzantara-secrets.env` on Pro:
- `WR2_PREFER_LIVE_NEWS` (default `false`)
- `WR2_LIVE_NEWS_FILTER_MIN` (default `40`)
- `WR2_USE_FULL_ENRICHED_PROMPT` (default `false`)

## What's NOT in this PR

- **PR-1.5**: Auto-learning E.1-E.7 (decision tracking, REFLECT hook, dynamic rules, decay, sharing) — separate PR after PR-1 merged
- **PR-2**: NotebookLM grounding before slide composition — separate PR
- **PR-2.5**: Thompson sampling Track B for weight auto-calibration — separate PR (after ≥200 decisions accumulate)

## Files changed

- `scripts/wr2_topic_selector.py` — live preference + bonus + penalty + enriched pass-through
- `scripts/wr2_draft_generator.py` — `_build_enriched_brief` + flag-gated `_build_draft_prompt` + caller wiring
- `scripts/tests/test_wr2_topic_selector_live_news.py` (new) — 24 tests
- `scripts/tests/test_wr2_draft_generator_enriched_prompt.py` (new) — 17 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)