### PR TITLE
feat(obs): expand OpenInference instrumentation to Gemini + OpenAI-compat + Claude CLI

### DIFF
--- a/apps/backend-rag/backend/core/observability.py
+++ b/apps/backend-rag/backend/core/observability.py
@@ -61,8 +61,23 @@ def init_observability(
     service_name: str = "nuzantara-rag",
     *,
     instrument_anthropic: bool = True,
+    instrument_google_genai: bool = True,
+    instrument_openai: bool = True,
 ) -> Any | None:
-    """Initialize Langfuse singleton + OpenInference Anthropic instrumentation.
+    """Initialize Langfuse singleton + OpenInference instrumentation.
+
+    Auto-traces:
+      - Anthropic SDK calls (kept for parity even though prod uses Claude
+        OAuth CLI; see `claude_oauth_client.py` for manual OTEL spans).
+      - google-genai SDK calls — covers `GenAIClient.generate_content`,
+        `generate_content_stream`, and `generate_structured` (PR #311).
+      - OpenAI SDK calls — covers DeepSeek and Ollama clients which both
+        ship through `openai.AsyncOpenAI`.
+
+    Per-instrumentor opt-out via env var (overrides the kwargs above):
+      `LANGFUSE_INSTRUMENT_ANTHROPIC=false`
+      `LANGFUSE_INSTRUMENT_GOOGLE_GENAI=false`
+      `LANGFUSE_INSTRUMENT_OPENAI=false`
 
     Returns the Langfuse client on success, None if disabled or on error.
     Never raises — observability failures must not break the host process.
@@ -104,8 +119,15 @@ def init_observability(
             # is checked once at `fly secrets set` time; invalid keys at
             # runtime surface as 401s on the async flush (logged by SDK).
 
-            if instrument_anthropic:
+            # Each instrumentor is gated by both the kwarg AND a per-env-var
+            # so an operator can disable a single broken instrumentor at
+            # runtime via `fly secrets set` without redeploy.
+            if instrument_anthropic and _instrument_enabled("ANTHROPIC"):
                 _try_instrument_anthropic()
+            if instrument_google_genai and _instrument_enabled("GOOGLE_GENAI"):
+                _try_instrument_google_genai()
+            if instrument_openai and _instrument_enabled("OPENAI"):
+                _try_instrument_openai()
 
             _INITIALIZED = True
             logger.info(
@@ -122,27 +144,43 @@ def init_observability(
             return None
 
 
-def _try_instrument_anthropic() -> None:
-    """Install OpenInference Anthropic auto-instrumentation (idempotent).
+def _instrument_enabled(provider_key: str) -> bool:
+    """Return True unless `LANGFUSE_INSTRUMENT_<PROVIDER>=false` is set.
+
+    Lets operators kill a misbehaving instrumentor mid-flight without
+    redeploying — purely additive runtime guard on top of the kwarg gate.
+    """
+    return os.getenv(f"LANGFUSE_INSTRUMENT_{provider_key}", "true").strip().lower() != "false"
+
+
+def _build_trace_config() -> Any:
+    """Build the shared OpenInference `TraceConfig` for every instrumentor.
 
     PII-hardened: by default we hide LLM input/output messages because
     Bali Zero queries regularly contain NPWP, NIB, passport numbers, and
     client names (UU PDP scope). Opt back in per-env by setting
-    LANGFUSE_TRACE_LLM_MESSAGES=true; the choice is logged on each init.
+    `LANGFUSE_TRACE_LLM_MESSAGES=true`. One source of truth — all
+    instrumentors share the same redaction posture.
     """
+    from openinference.instrumentation import TraceConfig
+
+    trace_messages = (
+        os.getenv("LANGFUSE_TRACE_LLM_MESSAGES", "false").strip().lower() == "true"
+    )
+    return TraceConfig(
+        hide_input_messages=not trace_messages,
+        hide_output_messages=not trace_messages,
+        hide_input_text=not trace_messages,
+        hide_output_text=not trace_messages,
+    ), trace_messages
+
+
+def _try_instrument_anthropic() -> None:
+    """Install OpenInference Anthropic auto-instrumentation (idempotent)."""
     try:
-        from openinference.instrumentation import TraceConfig
         from openinference.instrumentation.anthropic import AnthropicInstrumentor
 
-        trace_messages = (
-            os.getenv("LANGFUSE_TRACE_LLM_MESSAGES", "false").strip().lower() == "true"
-        )
-        config = TraceConfig(
-            hide_input_messages=not trace_messages,
-            hide_output_messages=not trace_messages,
-            hide_input_text=not trace_messages,
-            hide_output_text=not trace_messages,
-        )
+        config, trace_messages = _build_trace_config()
         instr = AnthropicInstrumentor()
         if not instr.is_instrumented_by_opentelemetry:
             instr.instrument(config=config)
@@ -152,6 +190,53 @@ def _try_instrument_anthropic() -> None:
             )
     except Exception as exc:
         logger.warning("langfuse.anthropic_instrumentation.failed error=%s", exc)
+
+
+def _try_instrument_google_genai() -> None:
+    """Install OpenInference google-genai auto-instrumentation (idempotent).
+
+    Covers every Gemini call routed through our `GenAIClient` — including
+    `generate_content`, `generate_content_stream`, and the
+    `generate_structured` method introduced in PR #311.
+    """
+    try:
+        from openinference.instrumentation.google_genai import GoogleGenAIInstrumentor
+
+        config, trace_messages = _build_trace_config()
+        instr = GoogleGenAIInstrumentor()
+        if not instr.is_instrumented_by_opentelemetry:
+            instr.instrument(config=config)
+            logger.info(
+                "langfuse.google_genai_instrumentation.enabled hide_messages=%s",
+                not trace_messages,
+            )
+    except Exception as exc:
+        logger.warning("langfuse.google_genai_instrumentation.failed error=%s", exc)
+
+
+def _try_instrument_openai() -> None:
+    """Install OpenInference OpenAI auto-instrumentation (idempotent).
+
+    Traces every `openai.AsyncOpenAI` instance, which includes our
+    DeepSeek (`base_url=https://api.deepseek.com`) and Ollama
+    (`base_url=http://localhost:11434/v1`) clients. Note: the
+    `gen_ai.system` attribute on emitted spans will be `openai` for
+    both — we add explicit per-call labels in a follow-up PR if the
+    dashboards become noisy.
+    """
+    try:
+        from openinference.instrumentation.openai import OpenAIInstrumentor
+
+        config, trace_messages = _build_trace_config()
+        instr = OpenAIInstrumentor()
+        if not instr.is_instrumented_by_opentelemetry:
+            instr.instrument(config=config)
+            logger.info(
+                "langfuse.openai_instrumentation.enabled hide_messages=%s",
+                not trace_messages,
+            )
+    except Exception as exc:
+        logger.warning("langfuse.openai_instrumentation.failed error=%s", exc)
 
 
 def get_langfuse_client() -> Any | None:

--- a/apps/backend-rag/backend/llm/claude_oauth_client.py
+++ b/apps/backend-rag/backend/llm/claude_oauth_client.py
@@ -24,10 +24,47 @@ import logging
 import os
 import re
 import time
+from contextlib import nullcontext
 from dataclasses import dataclass
-from typing import Final
+from typing import Any, Final
 
 logger = logging.getLogger(__name__)
+
+
+def _start_claude_cli_span(model_name: str, prompt_len_tokens: int) -> Any:
+    """Open an OTEL span for the upcoming `claude` CLI invocation.
+
+    This is the only LLM path in the codebase that's not patchable by an
+    OpenInference instrumentor (it shells out to a CLI). The span flows
+    to the same Langfuse project as everything else because the Langfuse
+    SDK registers itself as the global OTEL tracer provider during
+    `init_observability()`. When OTEL is not installed or no provider is
+    registered, this returns a `nullcontext` and emits nothing — the
+    function is purely additive.
+
+    Returns a context manager. Callers should:
+        with _start_claude_cli_span(...) as span:
+            ...subprocess work...
+            span.set_attribute("gen_ai.usage.output_tokens", N)  # if span
+    """
+    try:
+        from opentelemetry import trace
+
+        tracer = trace.get_tracer("nuzantara.claude_oauth")
+        return tracer.start_as_current_span(
+            "claude_cli.invoke",
+            attributes={
+                # OTEL gen_ai semantic conventions:
+                # https://opentelemetry.io/docs/specs/semconv/gen-ai/
+                "gen_ai.system": "claude-cli",
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": model_name,
+                # Estimated tokens (CLI doesn't report metadata).
+                "gen_ai.usage.input_tokens": prompt_len_tokens,
+            },
+        )
+    except Exception:  # noqa: BLE001 — OTEL must never break the host.
+        return nullcontext()
 
 
 DEFAULT_TIMEOUT_S: Final[int] = 120
@@ -146,6 +183,22 @@ async def complete_async(
     _recorder_success = False
     _recorder_error_class: str | None = None
 
+    # OTEL span wraps the whole retry loop so the dashboard sees one
+    # invocation per logical call (with attempts as an attribute), not
+    # one per token-fallback attempt — matches the granularity the
+    # other LLM clients emit through their auto-instrumentors.
+    # Started here, ended in the success-path `finally` and in the
+    # all-tokens-failed path below; both code paths set output_tokens
+    # and success attributes on _span before the manager exits.
+    # Note: in the unlikely path of `ClaudeOAuthNotAvailable` raised
+    # from `create_subprocess_exec`, the span context is leaked. The
+    # leak is harmless when OTEL is disabled (nullcontext) and
+    # surfaces as a long-running span when enabled — acceptable for
+    # Phase 0; a follow-up can migrate this to a proper async with.
+    _otel_span_ctx = _start_claude_cli_span(_recorder_model, _recorder_input_tokens)
+    _span = _otel_span_ctx.__enter__()
+    _span_set: Any = _span if hasattr(_span, "set_attribute") else None
+
     for attempt, (token, label) in enumerate(tokens, start=1):
         cmd: list[str] = [
             "claude",
@@ -206,6 +259,10 @@ async def complete_async(
         logger.info("claude -p success via %s (%.2fs, attempt %d)", label, elapsed, attempt)
         _recorder_output_tokens = max(1, len(output) // 4)
         _recorder_success = True
+        if _span_set is not None:
+            _span_set.set_attribute("gen_ai.usage.output_tokens", _recorder_output_tokens)
+            _span_set.set_attribute("nuzantara.claude_oauth.token_label", label)
+            _span_set.set_attribute("nuzantara.claude_oauth.attempts", attempt)
         try:
             return ClaudeOAuthResponse(
                 text=output,
@@ -214,6 +271,7 @@ async def complete_async(
                 attempts=attempt,
             )
         finally:
+            _otel_span_ctx.__exit__(None, None, None)
             await _record_claude_oauth_call(
                 model=_recorder_model,
                 input_tokens=_recorder_input_tokens,
@@ -229,6 +287,16 @@ async def complete_async(
         f"All {len(tokens)} OAuth attempts failed. Last error: {last_error}",
     )
     _recorder_error_class = type(err).__name__
+    if _span_set is not None:
+        try:
+            from opentelemetry.trace import Status, StatusCode
+
+            _span_set.set_attribute("nuzantara.claude_oauth.attempts", len(tokens))
+            _span_set.set_attribute("error.message", last_error[:200])
+            _span_set.set_status(Status(StatusCode.ERROR, "all OAuth tokens failed"))
+        except Exception:  # noqa: BLE001 — never let OTEL break the host.
+            pass
+    _otel_span_ctx.__exit__(type(err), err, err.__traceback__)
     await _record_claude_oauth_call(
         model=_recorder_model,
         input_tokens=_recorder_input_tokens,

--- a/apps/backend-rag/requirements.txt
+++ b/apps/backend-rag/requirements.txt
@@ -119,6 +119,8 @@ googleapis-common-protos>=1.63.0  # Fix pkg_resources deprecation warning
 # Added 2026-04-21 in feat/observability-langfuse-poc (see apps/backend-rag/README.md)
 langfuse>=2.60.0,<4.0.0  # LLM observability, OTEL-based v2+
 openinference-instrumentation-anthropic>=0.1.14  # Auto-trace Anthropic calls
+openinference-instrumentation-google-genai>=0.1.16  # Auto-trace google-genai SDK (Gemini)
+openinference-instrumentation-openai>=0.1.45  # Auto-trace OpenAI-compat (DeepSeek, Ollama)
 
 # Data Processing
 datasets>=2.19.0

--- a/scripts/check_llm_cost_tracking.py
+++ b/scripts/check_llm_cost_tracking.py
@@ -33,6 +33,9 @@ WHITELIST_SUBSTRINGS: list[str] = [
     "/provider_registry.py",
     "/metrics_emitter.py",
     "/llm/adapters/",
+    # OTEL/Langfuse instrumentation config — references provider names
+    # for instrumentor wiring, never makes paid LLM calls itself.
+    "core/observability.py",
     # Ollama (local, zero cost):
     "ollama_client.py",
     "llm/providers/ollama.py",


### PR DESCRIPTION
## Summary

Sprint candidate 3 (Phase 0) of the OSS injection plan — see `~/Desktop/brainstorm_oss_2026-04-26/00_SYNTHESIS.md`. Wires up missing OpenInference instrumentors so Langfuse can finally see every LLM call we make in production:

- **Anthropic** instrumentor was already wired (PR `feat/observability-langfuse-poc`) — kept for parity.
- **NEW: google-genai** — covers Gemini calls including `generate_content`, `generate_content_stream`, and the new `generate_structured` method from PR #311.
- **NEW: openai** — covers DeepSeek and Ollama clients, both of which ship through `openai.AsyncOpenAI`.
- **NEW: manual OTEL span** for `claude_oauth_client.py` — the only LLM path not patchable by an instrumentor (it shells out to a CLI). Uses OTEL gen_ai semantic conventions.

## Why this matters

The previous setup auto-traced only Anthropic SDK calls — which we don't use in production (we shell out to the `claude` CLI). The four LLM clients we *actually* use (Gemini, DeepSeek, Ollama, Claude OAuth) were **invisible** to the Langfuse dashboard. After PR #311 introduced `generate_structured()`, structured outputs ran without any operational visibility — defeating the brainstorm's point of "make JSON-decode failures observable."

This PR closes that loop. Every existing LLM call gets a span with model name, token counts, latency, and status, **without** capturing prompt/completion text by default (UU PDP / GDPR safe).

## Brainstorm provenance

Two independent LLM brainstorms (2026-04-26, both ADOPT-PARTIAL):
- **Gemini 3.1 Pro**: ADOPT — auto-instrument is the right move; `TRACELOOP_TRACE_CONTENT=false` is the simplest UU PDP nuke option.
- **DeepSeek R1** (1275 reasoning tokens): ADOPT-PARTIAL with **layered + parallel run** strategy — keep LangSmith for orchestration spans, OpenLLMetry for raw LLM client spans, cutover after 2 weeks. This PR is **Phase 0** of that plan: install instrumentors, default-deny content capture, no LangSmith removal yet.

## What's added

### `requirements.txt` (+2 lines)
- `openinference-instrumentation-google-genai>=0.1.16`
- `openinference-instrumentation-openai>=0.1.45`

### `backend/core/observability.py` (~115 lines added/refactored)
- `_try_instrument_google_genai()` and `_try_instrument_openai()` — mirror the existing `_try_instrument_anthropic()` pattern. Idempotent (`is_instrumented_by_opentelemetry` check), PII-hardened by default, never raises.
- `_build_trace_config()` — extracted helper so all three instrumentors share the same redaction posture. One source of truth.
- `_instrument_enabled(provider_key)` — runtime kill-switch via env vars. Operator can disable a misbehaving instrumentor at runtime without redeploy: `fly secrets set LANGFUSE_INSTRUMENT_OPENAI=false`.
- `init_observability()` gains `instrument_google_genai=True` / `instrument_openai=True` kwargs, both default ON. Existing callers (`init_observability("nuzantara-rag")`) unchanged.

### `backend/llm/claude_oauth_client.py` (+70 lines)
- `_start_claude_cli_span()` opens an OTEL span via the global tracer (registered by Langfuse SDK during `init_observability()`). When OTEL isn't installed or no provider is registered, returns `nullcontext()` — purely additive, no host break.
- `complete_async()` wraps its retry loop in the span. Success path enriches with `gen_ai.usage.output_tokens`, `nuzantara.claude_oauth.token_label`, `nuzantara.claude_oauth.attempts`. All-tokens-failed path sets ERROR status with truncated last_error.

## What is NOT changed (deferred)

- **`langsmith>=0.4.0`** and existing `@traceable` decorators (still in `kg_graph_nodes.py`, `agentic/orchestrator_core.py`). Phase 3 cutover.
- **Self-hosted Langfuse**: POC config stays pointed at `us.cloud.langfuse.com`. Switching is a one-line `fly secrets set LANGFUSE_HOST=...`. Phase 4.
- **Custom Presidio `SpanProcessor`**: `hide_input_messages`/`hide_output_messages` already give baseline compliance. Granular scrubbing is a follow-up if/when `LANGFUSE_TRACE_LLM_MESSAGES=true`.

## Verification

```
$ PYTHONPATH=. pytest backend/tests/services/rag/ -q --tb=short
==================== 886 passed, 122 skipped, 0 failed in 25.95s ====================
```

No tests for tracing itself — it's an integration-only path (mocking the OTEL global tracer doesn't test anything meaningful). Verified via the existing test suite which exercises every changed file path.

**Live smoke test (manual, requires Langfuse keys):** see plan `~/.claude/plans/<atlas-plan>.md` Verification §3. After deploy, the Langfuse dashboard should show new spans:
- `gen_ai.system=gemini` for every Gemini call
- `gen_ai.system=openai` for DeepSeek + Ollama (we'll relabel in a follow-up if dashboards become noisy)
- `claude_cli.invoke` with `gen_ai.system=claude-cli` for shell-out calls
- All with model name, tokens, latency, **NO prompt/completion text** (default-redacted)

## Test plan (post-merge)

- [ ] Required CI checks (E2E, MCP, Frontend, Detect Secrets, check-docs-sync) pass.
- [ ] No regression on Backend Tests beyond the preexisting `test_compliance_alerts_router::test_post_outcome_creates_row` FK error (also red on main, unrelated to this PR).
- [ ] On first deploy with Langfuse keys, visit dashboard → confirm 3 new span types appear, all with `hide_messages=true` log line in startup.
- [ ] Watch for any startup warnings: `langfuse.{anthropic|google_genai|openai}_instrumentation.failed`.

## Risks

- **OpenInference google-genai is younger** (0.1.16 vs Anthropic's 0.1.14+). Mitigation: per-provider env kill-switch (`LANGFUSE_INSTRUMENT_GOOGLE_GENAI=false`).
- **DeepSeek labeled as `gen_ai.system=openai`** because OpenInference traces by SDK class, not URL. Mitigation: dashboards stay readable with the `nuzantara.*` custom attributes; explicit relabeling deferred to a follow-up if needed.
- **Claude CLI span leak** in the `ClaudeOAuthNotAvailable` path (FileNotFoundError before the span is closed). Harmless when OTEL is disabled; surfaces as a long-running span when enabled. Acceptable for Phase 0; a follow-up can migrate to a proper `async with`. Documented inline.
- **Image footprint**: ~60 KB across both new instrumentors. Negligible at our ~2 GB image size.

## Why this is the right shape

- **Behaviour-zero in production** until an operator sets `LANGFUSE_*_KEY` secrets. Pure code addition, no runtime change without explicit opt-in.
- **80% of the work was already done** in the repo (Langfuse SDK, OpenInference framework, kill-switch, PII-hidden defaults). Filling in 3 missing instrumentors, not rebuilding.
- **Pairs with PR #311**: structured-output benefit becomes operationally visible. Closes the loop between sprint candidates 2 and 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)