### PR TITLE
fix(obs): add langfuse + openinference to requirements-prod

### DIFF
--- a/apps/backend-rag/requirements-prod.txt
+++ b/apps/backend-rag/requirements-prod.txt
@@ -108,6 +108,15 @@ apscheduler==3.10.4
 setuptools>=78.1.1
 langsmith>=0.4.0  # Observability: @traceable on RAG nodes + KG nodes
 
+# Langfuse + OpenInference instrumentation (PR #312, prod runtime — was
+# missing in requirements-prod.txt so observability silently no-op'd in
+# production even with LANGFUSE_*_KEY secrets set on Fly).
+# Phase 0 of OpenLLMetry expansion. See docs/oss-injections-2026-04-26.md.
+langfuse>=2.60.0,<4.0.0  # LLM observability, OTEL-based v2+
+openinference-instrumentation-anthropic>=0.1.14  # Anthropic SDK auto-trace
+openinference-instrumentation-google-genai>=0.1.16  # Auto-trace Gemini SDK
+openinference-instrumentation-openai>=0.1.45  # Auto-trace OpenAI-compat (DeepSeek, Ollama)
+
 # Monorepo workspace package: cell-core (DNA-recording — Genome, Experience,
 # Skill, Metabolic, HGT). Editable install; path is resolved relative to the
 # working directory where `pip install -r` runs. In the Dockerfile that is


### PR DESCRIPTION
## Summary

PR #312 added `langfuse` + `openinference-instrumentation-{anthropic,google-genai,openai}` only to `requirements.txt` (dev). Production image uses `requirements-prod.txt` — so Langfuse was **never installed in prod** and `init_observability()` silently failed with `No module named 'langfuse'` even when `LANGFUSE_PUBLIC_KEY` + `LANGFUSE_SECRET_KEY` secrets were set on Fly.

## How this was found

Tonight, after setting Langfuse keys on Fly via `fly secrets set`:
1. Container restarted successfully (both machines, version 3040)
2. 2 RAG queries fired live with `expansion_count=3` returned 200 OK
3. Langfuse dashboard query API returned **0 traces**
4. SSH'd into the prod machine: env vars present, but Python diagnostic showed:
   ```
   FAIL import: No module named 'langfuse'
   langfuse.import_failed error=No module named 'langfuse'
   ```

The kill-switch design we celebrated as 'behaviour-zero by default' worked too well: not having the package made init fail silently with a WARNING log line that got rotated out of the log buffer before we could see it.

## Fix

Add the same 4 lines to `requirements-prod.txt` that PR #312 added to `requirements.txt`. Total wheel weight ~60 KB. Pure additive — no other changes.

## Test plan

- [ ] CI green on this PR (only required: E2E, MCP, Frontend, Detect Secrets, check-docs-sync).
- [ ] After merge, `fly-deploy.yml` runs (paths filter matches `apps/backend-rag/**`).
- [ ] After deploy: SSH into prod, verify `from langfuse import Langfuse` succeeds.
- [ ] Fire 1 RAG query → expect a trace in Langfuse dashboard within 1–2 seconds (flush_interval=1.0s).
- [ ] Cleanup: this PR closes the loop on the OSS injection sprint observability (Sprint 3 was Phase 0; this is the Phase 0.5 deps fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)