### PR TITLE
fix(mouth): wrap (workspace) layout in I18nProvider

### DIFF
--- a/apps/mouth/src/app/(workspace)/layout.tsx
+++ b/apps/mouth/src/app/(workspace)/layout.tsx
@@ -12,6 +12,7 @@ import { ErrorBoundary } from "@/components/optimization";
 import { CellWidget } from "@/components/cell/CellWidget";
 import { WorkspaceAssistant } from "@/components/workspace/WorkspaceAssistant";
 import { KitaCommandPalette } from "@/components/workspace/KitaCommandPalette";
+import { I18nProvider } from "@/i18n";
 import { routeTitles } from "@/types/navigation";
 
 interface WorkspaceLayoutProps {
@@ -249,6 +250,7 @@ export default function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
   }
 
   return (
+    <I18nProvider>
     <ToastProvider>
       <a href="#main-content" className="bz-skip-link">
         Skip to main content
@@ -329,5 +331,6 @@ export default function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
       {!isTerminalPage && <WorkspaceAssistant />}
       <KitaCommandPalette />
     </ToastProvider>
+    </I18nProvider>
   );
 }


### PR DESCRIPTION
## Summary
- **Bug**: kita.balizero.com (every workspace page) crashes with `useTranslation must be used within I18nProvider`. React unmounts the tree → blank/broken UI.
- **Cause**: PR #273 (`69eafecd9`) added `useTranslation()` to `KitaCommandPalette`, mounted in `(workspace)/layout.tsx`. The workspace route group has no `I18nProvider` ancestor — only `(blog)`, `(book)` and a couple of portal pages provide it.
- **Fix**: Wrap `(workspace)/layout.tsx` main return in `<I18nProvider>`, mirroring `(blog)`/`(book)` convention. 3-line change, no behavior shift for users.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run src/app/(workspace)` → 136/136 pass
- [x] `next build` succeeds
- [ ] Post-merge: load https://kita.balizero.com/dashboard, confirm no `useTranslation` throw in console
- [ ] Cmd+K opens command palette with EN/IT labels per persisted `blog-language`

🤖 Generated with [Claude Code](https://claude.com/claude-code)