### PR TITLE
🎨 Palette: Improve accessibility with ARIA attributes in Chat interface

### DIFF
--- a/apps/mouth/src/components/chat/ChatHeader.tsx
+++ b/apps/mouth/src/components/chat/ChatHeader.tsx
@@ -110,6 +110,7 @@ export function ChatHeader({
             variant={isClockIn ? 'default' : 'outline'}
             size="sm"
             disabled={isClockLoading}
+            aria-label={isClockIn ? 'Clock Out' : 'Clock In'}
             className={`gap-2 ${isClockIn ? 'bg-[var(--success)] hover:bg-[var(--success)]/90' : ''}`}
           >
             {isClockLoading ? (
@@ -175,6 +176,8 @@ export function ChatHeader({
               onClick={onToggleUserMenu}
               className="flex items-center gap-2 px-2 py-1 rounded-lg hover:bg-[var(--background-elevated)] transition-colors"
               aria-label="User menu"
+              aria-haspopup="true"
+              aria-expanded={showUserMenu}
             >
               <div className="w-8 h-8 rounded-full bg-[var(--accent)] flex items-center justify-center text-white font-medium overflow-hidden relative">
                 {userAvatar ? (

--- a/apps/mouth/src/components/chat/ChatInputBar.tsx
+++ b/apps/mouth/src/components/chat/ChatInputBar.tsx
@@ -142,6 +142,8 @@ export function ChatInputBar({
                 onClick={() => setShowAttachMenu(!showAttachMenu)}
                 className={`rounded-xl ${showAttachMenu ? 'text-[var(--accent)] bg-[var(--accent)]/10' : ''}`}
                 aria-label="Attach file"
+                aria-haspopup="true"
+                aria-expanded={showAttachMenu}
               >
                 <Plus className="w-5 h-5" />
               </Button>
@@ -184,6 +186,7 @@ export function ChatInputBar({
               onChange={(e) => setInput(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder={showImagePrompt ? 'Describe your image...' : 'Type your message...'}
+              aria-label={showImagePrompt ? 'Describe your image' : 'Type your message'}
               disabled={isLoading}
               rows={1}
               className="flex-1 border-0 bg-transparent focus:ring-0 focus:outline-none focus-visible:ring-0 focus-visible:outline-none focus-visible:ring-offset-0 resize-none min-h-[40px] max-h-[120px] py-2 px-3 text-sm text-[#D8D6D0] placeholder:text-zinc-500 font-medium outline-none ring-0"

--- a/apps/mouth/src/components/chat/MessageBubble.tsx
+++ b/apps/mouth/src/components/chat/MessageBubble.tsx
@@ -380,6 +380,7 @@ function MessageBubbleComponent({
                 <button
                   onClick={() => setIsThinkingExpanded(!isThinkingExpanded)}
                   className="flex items-center gap-2 text-xs font-medium text-[var(--foreground-muted)] hover:text-[var(--accent)] transition-colors mb-2"
+                  aria-expanded={isThinkingExpanded}
                 >
                   <Lightbulb className="w-3.5 h-3.5" />
                   <span>Thinking Process</span>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,5 +29,6 @@
     "./utils": "./utils/index.ts",
     "./auth": "./auth/index.ts",
     "./analytics": "./analytics/index.ts"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Improved accessibility in the `apps/mouth` chat interface by implementing semantic ARIA attributes for menus, toggles, and inputs.

### 🎯 Why: The user problem it solves
Screen reader users were unable to discern the expanded/collapsed state of menus and decorative-looking toggles, or the specific purpose of the primary chat input.

### ♿ Accessibility: Any a11y improvements made
- Added `aria-haspopup="true"` and dynamic `aria-expanded` to the User Menu and Attachment Toggle.
- Added `aria-expanded` to the Thinking Process (collapsed content) toggle.
- Added descriptive `aria-label` to the Clock In/Out button and the main message textarea.
- Verified that `aria-expanded` states update correctly in the DOM upon user interaction.

---
*PR created automatically by Jules for task [11157565597744056574](https://jules.google.com/task/11157565597744056574) started by @Balizero1987*