### PR TITLE
fix(deploy): SQL v2 post-deploy job + canary migration verify (P0-4)

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -173,6 +173,108 @@ jobs:
             --dockerfile apps/backend-rag/Dockerfile \
             --config apps/backend-rag/fly.toml
 
+  # SQL v2 migrations must re-run AFTER the new image is live.
+  #
+  # The pre-deploy `run-migrations` job uses `flyctl ssh console` against the
+  # currently-running container — i.e. the PREVIOUS image. Any new SQL file
+  # in apps/backend-rag/backend/db/migrations_v2/NNN_*.sql added by the same
+  # PR is not yet visible to the migration runner. The new SQL only lands in
+  # the image at the `deploy` step. So a PR with new SQL would historically
+  # require a manual `gh workflow run "Deploy Backend to Fly.io" --ref main`
+  # to trigger a no-op redeploy that finally picks up the new file.
+  #
+  # This job re-runs `python -m backend.db.migrate apply-all` on the FRESH
+  # image. Idempotent: the runner skips already-applied via _schema_versions.
+  # On a deploy without new SQL it is a no-op (~5-10s round-trip). On a
+  # deploy with new SQL it applies them and fires a Telegram signal that the
+  # pre-deploy step had been masking.
+  #
+  # Cicatrix STRUCTURAL 2026-04-26 'SQL v2 migrations apply on OLD image'
+  # is resolved by this job (zero-crash audit P0-4).
+  run-sql-v2-migrations-post-deploy:
+    name: Re-run SQL v2 migrations on fresh image
+    needs: deploy
+    runs-on: ubuntu-latest
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      FLY_ACCESS_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+    steps:
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Pin migration to a fresh-image machine (sentinel)
+        id: sentinel
+        run: |
+          # Fly's `flyctl deploy --strategy rolling` waits until each machine
+          # has been swapped to the new image before exiting; if `deploy`
+          # succeeded, both machines should be on the same fresh image_ref.
+          # We still verify defensively: if any started machine still carries
+          # a different tag, the rollout is incomplete and we must not run
+          # migrations on the OLD image (the bug we are fixing).
+          for i in $(seq 1 18); do
+            JSON=$(flyctl machines list --app nuzantara-rag --json 2>/dev/null || echo '[]')
+            STARTED_TAGS=$(echo "$JSON" | jq -r '[.[] | select(.state=="started") | .image_ref.tag] | unique')
+            STARTED_COUNT=$(echo "$STARTED_TAGS" | jq 'length')
+            if [ "$STARTED_COUNT" = "1" ]; then
+              TAG=$(echo "$STARTED_TAGS" | jq -r '.[0]')
+              MACHINE=$(echo "$JSON" | jq -r --arg tag "$TAG" '[.[] | select(.state=="started" and .image_ref.tag==$tag)] | .[0].id')
+              echo "✅ Both started machines share image tag: $TAG"
+              echo "✅ Pinning migration to machine: $MACHINE"
+              echo "tag=$TAG" >> $GITHUB_OUTPUT
+              echo "machine=$MACHINE" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+            echo "Tentativo $i/18 — started_unique_tags=$STARTED_COUNT (rolling not yet converged)"
+            sleep 10
+          done
+          echo "❌ Could not converge on a single fresh image tag after 3 min"
+          echo "Started machines image tags: $STARTED_TAGS"
+          exit 1
+
+      - name: Re-run SQL v2 apply-all on fresh image
+        id: migrate
+        timeout-minutes: 5
+        run: |
+          set -o pipefail
+          MACHINE="${{ steps.sentinel.outputs.machine }}"
+          # tee preserves the live log AND captures output for the alert step.
+          flyctl ssh console \
+            --app nuzantara-rag \
+            --machine "$MACHINE" \
+            --command "/bin/sh -c 'cd /app && PYTHONPATH=. python -m backend.db.migrate apply-all'" \
+            2>&1 | tee migration_output.txt
+          # Migration runner (backend/db/migrate.py) prints
+          #   "✅ Applied: N migrations"
+          # Then one "   - Migration NNN" line per applied SQL. We count those
+          # via fixed-string grep — robust to ANSI color, log prefix variation,
+          # and the leading checkmark byte sequence.
+          APPLIED=$(grep -cF "   - Migration " migration_output.txt || true)
+          echo "applied_count=$APPLIED" >> $GITHUB_OUTPUT
+          echo "::notice::SQL v2 post-deploy: $APPLIED migrations applied on fresh image"
+
+      - name: Telegram — post-deploy migrations actually applied
+        if: success() && steps.migrate.outputs.applied_count != '0'
+        run: |
+          MESSAGE="🆕 *SQL v2 post-deploy applied*%0A%0A\`${{ steps.migrate.outputs.applied_count }}\` migrazioni sull'immagine fresca dopo deploy.%0A%0AImage tag: \`${{ steps.sentinel.outputs.tag }}\`%0AMachine: \`${{ steps.sentinel.outputs.machine }}\`%0ACommit: \`${{ github.sha }}\`%0AAutore: ${{ github.actor }}%0A%0ASegnale che il job pre-deploy stava mascherando nuovi SQL (cicatrix STRUCTURAL 2026-04-26 — fix verificato in produzione)."
+          curl -s "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d "chat_id=${{ secrets.TELEGRAM_OWNER_CHAT_ID }}" \
+            -d "text=${MESSAGE}" \
+            -d "parse_mode=Markdown" || true
+
+      - name: Fail loud on migration error
+        if: failure()
+        run: |
+          echo "::error::Post-deploy SQL v2 migration failed. Manual investigation required."
+          if [ -f migration_output.txt ]; then
+            echo "--- migration_output.txt (head 100) ---"
+            head -100 migration_output.txt || true
+          fi
+          MESSAGE="🔴 *SQL v2 post-deploy FAILED*%0A%0AMigration runner errored on fresh image after deploy.%0A%0ACommit: \`${{ github.sha }}\`%0AAutore: ${{ github.actor }}%0ARun: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}%0A%0A⚠️ Backend live ma schema potenzialmente disallineato. Investigare subito."
+          curl -s "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d "chat_id=${{ secrets.TELEGRAM_OWNER_CHAT_ID }}" \
+            -d "text=${MESSAGE}" \
+            -d "parse_mode=Markdown" || true
+
   # Python-idiom migrations must run AFTER the new image is live, because
   # the SQL v2 migration runner (in run-migrations above) doesn't discover
   # backend/migrations/migration_NNN_*.py files — those are wrapped by
@@ -183,7 +285,7 @@ jobs:
   # on subsequent deploys is a no-op.
   run-python-migrations:
     name: Run Python-idiom migrations (post-deploy, idempotent)
-    needs: deploy
+    needs: [deploy, run-sql-v2-migrations-post-deploy]
     runs-on: ubuntu-latest
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/apps/backend-rag/backend/db/migrations_v2/141_audit_canary_post_deploy.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/141_audit_canary_post_deploy.sql
@@ -1,0 +1,26 @@
+-- Migration 141: audit canary for P0-4 verification (zero-crash audit 2026-04-29).
+--
+-- Purpose: prove that the new run-sql-v2-migrations-post-deploy job actually
+-- applies new SQL files against the FRESHLY-DEPLOYED image. The pre-deploy
+-- run-migrations job runs against the OLD image and will NOT see this file
+-- (cicatrix STRUCTURAL 2026-04-26). Only the post-deploy job, on the fresh
+-- container, will pick up 141 — that's the test.
+--
+-- Telegram alert with applied_count >= 1 = fix verified working in prod.
+--
+-- A follow-up PR (chore/cleanup-p04-canary) will git-rm this file once the
+-- alert has fired. The forward DDL is harmless: a single-column placeholder
+-- table that is dropped immediately by the rollback section if anything
+-- needs to be unwound.
+--
+-- DO NOT BACKPORT this convention to real migrations. Canaries belong in
+-- migrations_v2/ only because the runner is the system under test.
+
+CREATE TABLE IF NOT EXISTS p04_canary_20260429 (
+    id BIGSERIAL PRIMARY KEY,
+    note TEXT NOT NULL DEFAULT 'P0-4 verification 2026-04-29 — cicatrix STRUCTURAL 2026-04-26 resolved'
+);
+
+-- === ROLLBACK ===
+
+DROP TABLE IF EXISTS p04_canary_20260429;


### PR DESCRIPTION
## Summary

Resolves cicatrix STRUCTURAL 2026-04-26 *"SQL v2 migrations apply on OLD image, not the freshly-built one"*. Implements **P0-4** from the zero-crash audit 2026-04-29.

The pre-deploy `run-migrations` job runs `flyctl ssh console` against the currently-running container (the previous image), so a PR introducing a new SQL v2 file is invisible to it. The new SQL only lands in the image at the `deploy` step, after which the existing workflow never re-applies. Operator workaround: manual `gh workflow run` after merge — 5-30 min window of production 500s ("column does not exist") on every migration PR.

## Changes

### `.github/workflows/fly-deploy.yml`
- **New job** `run-sql-v2-migrations-post-deploy` (`needs: deploy`):
  - Sentinel: `flyctl machines list --json` → verify all started machines share one image tag (rolling rollout converged), pin SSH to a specific fresh-image machine via `--machine <id>`. 18-attempt poll, 10s sleep = 3 min budget.
  - Run `python -m backend.db.migrate apply-all` against the fresh image. 5-min step timeout. `set -o pipefail`.
  - Count applied via `grep -cF "   - Migration "` on the runner's `print()` summary (stable across log prefix variation).
  - Telegram alert when `applied_count != 0` — signal that pre-deploy was masking. Includes image tag + machine ID + commit + author.
  - Fail-loud Telegram alert on migration error.
- **Modified** `run-python-migrations` `needs: deploy` → `needs: [deploy, run-sql-v2-migrations-post-deploy]`. SQL schema must be ready before Python wrapper migrations run. `post-deploy-health` chains transitively.
- Idempotent: on a no-op deploy (no new SQL files), `apply-all` skips everything via `_schema_versions` table — adds ~5-10s to deploy.

### `apps/backend-rag/backend/db/migrations_v2/141_audit_canary_post_deploy.sql`
- Synthetic canary: creates `p04_canary_20260429` (single-column placeholder) with `-- === ROLLBACK ===` marker. Forward DDL is harmless. Will be removed in a follow-up PR after the Telegram alert fires with `applied_count=1`, proving the fix works.

## Cross-LLM brainstorm

- **Codex** (xhigh): hit usage cap, no output.
- **Gemini 3.1 Pro**: proposed `flyctl releases list` → `flyctl machines list --json` → pin SSH via `--machine` flag. **Adopted.**
- **DeepSeek v4-pro**: proposed capturing release version as `deploy` job output + optional Dockerfile sentinel. Rejected — more invasive; the same-tag check on `flyctl machines list` is sufficient.
- **NotebookLM**: CLI signature mismatch on the wrapper, skipped.

## Test plan

- [x] `actionlint -shellcheck=` exit 0 on workflow
- [x] `yq` parses the new job
- [x] All 7 jobs present in correct order: `pre-deploy-gate → run-migrations → deploy → run-sql-v2-migrations-post-deploy → run-python-migrations → post-deploy-health`, sibling `deploy-failure-alert`
- [x] Migration runner regex (`migration_base.py::ROLLBACK_MARKER_RE`) parses 141 forward + rollback correctly
- [x] 141 number is unique (no duplicate; the existing 129/130 dups are tracked separately by P0-7)
- [ ] On merge: `run-sql-v2-migrations-post-deploy` actually runs (not skipped)
- [ ] Sentinel pins to a fresh machine (logs show single-tag convergence)
- [ ] Migration 141 applied in the post-deploy job, NOT in the pre-deploy `run-migrations`
- [ ] Telegram alert fires with `applied_count=1`, image tag + machine ID + commit
- [ ] Follow-up PR `chore/cleanup-p04-canary` removes 141 cleanly

## Rollback

`git revert` of this commit removes the new job and the canary file. Behavior reverts to the manual `gh workflow run` workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)