### PR TITLE
fix(p0-7): resolve duplicate migration numbers + CI guardrail

### DIFF
--- a/.github/workflows/lint-migration-numbers.yml
+++ b/.github/workflows/lint-migration-numbers.yml
@@ -1,0 +1,44 @@
+name: Migration number uniqueness lint
+
+# P0-7 (zero-crash audit 2026-04-29): PR-time guardrail against duplicate
+# migration prefixes in apps/backend-rag/backend/db/migrations_v2/. Two
+# files sharing the same NNN_ prefix make `discover_migrations` order
+# undefined (filesystem glob), so the runner applies whichever comes
+# first alphabetically and silently skips the second on the next deploy.
+# Complementary to migration-lint.yml (Squawk DDL safety) and the
+# runtime assert in migration_manager.discover_migrations.
+
+on:
+  pull_request:
+    paths:
+      - 'apps/backend-rag/backend/db/migrations_v2/**'
+
+jobs:
+  lint:
+    name: Detect duplicate prefixes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect duplicate migration numbers
+        run: |
+          set -eu
+          DIR=apps/backend-rag/backend/db/migrations_v2
+          DUPS=$(ls "$DIR" \
+            | grep -E '^[0-9]+_.*\.sql$' \
+            | awk -F_ '{print $1}' \
+            | sort \
+            | uniq -d)
+          if [ -n "$DUPS" ]; then
+            echo "::error::Duplicate migration numbers detected: $(echo $DUPS | tr '\n' ' ')"
+            for n in $DUPS; do
+              echo "  Number $n found in:"
+              ls "$DIR" | grep -E "^${n}_" | sed 's/^/    /'
+            done
+            echo ""
+            echo "Resolution: rename the file that is NOT yet in"
+            echo "_schema_versions to the next-available number."
+            echo "Reference: cicatrix STRUCTURAL 2026-04-29 P0-7."
+            exit 1
+          fi
+          echo "All migration numbers are unique."

--- a/apps/backend-rag/backend/db/migration_manager.py
+++ b/apps/backend-rag/backend/db/migration_manager.py
@@ -23,7 +23,45 @@ logger = logging.getLogger(__name__)
 # `__all__` advertises the re-export so static analyzers don't flag it
 # as dead code (CodeQL: py/unused-global-variable).
 _ROLLBACK_MARKER_RE = ROLLBACK_MARKER_RE
-__all__ = ["MigrationManager", "_ROLLBACK_MARKER_RE", "_extract_rollback_sql"]
+__all__ = [
+    "MigrationManager",
+    "_ROLLBACK_MARKER_RE",
+    "_assert_unique_migration_numbers",
+    "_extract_rollback_sql",
+]
+
+
+def _assert_unique_migration_numbers(sql_files: list[Path]) -> None:
+    """Raise MigrationError if any two paths in `sql_files` share a numeric
+    prefix (e.g. `129_a.sql` + `129_b.sql`).
+
+    Pulled out of `MigrationManager.discover_migrations` so unit tests can
+    exercise the rule without instantiating the manager (which requires
+    DATABASE_URL). Files that don't start with `NNN_` are ignored — the
+    parser falls back to logging a warning later.
+    """
+    seen: dict[int, str] = {}
+    duplicates: dict[int, list[str]] = {}
+    for sql_file in sql_files:
+        try:
+            num = int(sql_file.stem.split("_")[0])
+        except (ValueError, IndexError):
+            continue
+        if num in seen:
+            duplicates.setdefault(num, [seen[num]]).append(sql_file.name)
+        else:
+            seen[num] = sql_file.name
+    if duplicates:
+        details = ", ".join(
+            f"{num}: [{', '.join(files)}]" for num, files in sorted(duplicates.items())
+        )
+        raise MigrationError(
+            "Duplicate migration numbers in migrations_v2/: "
+            f"{details}. Two files cannot share a prefix — the runner "
+            "applies one and silently skips the other. Resolution: "
+            "rename the not-yet-applied file to the next free number. "
+            "See cicatrix STRUCTURAL 2026-04-29 P0-7."
+        )
 
 
 def _extract_rollback_sql(sql_text: str) -> str | None:
@@ -235,6 +273,13 @@ class MigrationManager:
         migrations_dir.mkdir(exist_ok=True)
 
         sql_files = sorted(migrations_dir.glob("*.sql"))
+
+        # P0-7 (zero-crash audit 2026-04-29): reject duplicate migration
+        # numbers. Two files sharing the same prefix make
+        # `discover_migrations` order undefined — the runner applies one
+        # alphabetically and silently skips the other on the next deploy.
+        # See cicatrix STRUCTURAL 2026-04-29 P0-7 (PRs #254 + #258).
+        _assert_unique_migration_numbers(sql_files)
 
         migrations = []
         for sql_file in sql_files:

--- a/apps/backend-rag/backend/db/migrations_v2/142_legacy_user_profiles.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/142_legacy_user_profiles.sql
@@ -1,4 +1,11 @@
--- 129_legacy_user_profiles.sql
+-- 142_legacy_user_profiles.sql
+--
+-- (Renumbered from 129_legacy_user_profiles.sql by P0-7 audit fix
+-- 2026-04-29 — original 129 was duplicated by 129_crm_guardian.sql,
+-- which the runner picked up first; 129_legacy_user_profiles never
+-- landed in _schema_versions. The DDL below is idempotent — no-op
+-- on prod where user_profiles already exists.)
+--
 --
 -- Promote `user_profiles` from a CI-bootstrap-only table to a
 -- migrations_v2 entry. Mirrors the DDL that

--- a/apps/backend-rag/backend/db/migrations_v2/143_legacy_conversations.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/143_legacy_conversations.sql
@@ -1,4 +1,10 @@
--- 130_legacy_conversations.sql
+-- 143_legacy_conversations.sql
+--
+-- (Renumbered from 130_legacy_conversations.sql by P0-7 audit fix
+-- 2026-04-29 — original 130 was duplicated by
+-- 130_crm_guardian_summary_queue.sql. The DDL below is idempotent —
+-- no-op on prod where conversations already exists.)
+--
 --
 -- Promote `conversations` from a CI-bootstrap-only table to a
 -- migrations_v2 entry. Mirrors `ci_bootstrap_schema.py` exactly.

--- a/apps/backend-rag/backend/db/migrations_v2/LEGACY_PROMOTION_README.md
+++ b/apps/backend-rag/backend/db/migrations_v2/LEGACY_PROMOTION_README.md
@@ -34,8 +34,8 @@ so they can land in `migrations_v2/` without breaking either:
 
 | Bootstrap (`ci_bootstrap_schema.py`) | Migration |
 |--------------------------------------|-----------|
-| `CREATE TABLE IF NOT EXISTS user_profiles ...`  | `129_legacy_user_profiles.sql` |
-| `CREATE TABLE IF NOT EXISTS conversations ...`  | `130_legacy_conversations.sql` |
+| `CREATE TABLE IF NOT EXISTS user_profiles ...`  | `142_legacy_user_profiles.sql` (was `129_*` until P0-7 renumber on 2026-04-29) |
+| `CREATE TABLE IF NOT EXISTS conversations ...`  | `143_legacy_conversations.sql` (was `130_*` until P0-7 renumber on 2026-04-29) |
 | `CREATE TABLE IF NOT EXISTS lkpm_reports ...` + 18 ALTER + company_id | `132_legacy_lkpm_reports.sql` |
 | `CREATE TABLE IF NOT EXISTS system_settings ...` | `133_legacy_system_settings.sql` |
 | `CREATE TABLE IF NOT EXISTS notification_log ...` + index | `134_legacy_notification_log.sql` |

--- a/apps/backend-rag/backend/tests/db/test_legacy_promotion_migrations.py
+++ b/apps/backend-rag/backend/tests/db/test_legacy_promotion_migrations.py
@@ -38,11 +38,14 @@ MIG_DIR = (
 )
 
 
-# Files this batch ships. Numbered with one intentional gap (131) for
-# Strategy 01 Step 3 (`131_unify_migration_tracking.sql`).
+# Files this batch ships. Originally numbered 129–137 with one
+# intentional gap (131) for Strategy 01 Step 3
+# (`131_unify_migration_tracking.sql`). 129 and 130 collided with the
+# crm_guardian batch (PR #258) and were renumbered to 142 and 143 by
+# the P0-7 audit fix on 2026-04-29 — see cicatrix STRUCTURAL P0-7.
 LEGACY_PROMOTION_FILES = (
-    "129_legacy_user_profiles.sql",
-    "130_legacy_conversations.sql",
+    "142_legacy_user_profiles.sql",
+    "143_legacy_conversations.sql",
     "132_legacy_lkpm_reports.sql",
     "133_legacy_system_settings.sql",
     "134_legacy_notification_log.sql",
@@ -51,7 +54,7 @@ LEGACY_PROMOTION_FILES = (
     "137_team_members_legacy_columns_and_defaults.sql",
 )
 
-# Files that landed in the 129-137 number range but are NOT part of the
+# Files that landed in the 129/130 number range and are NOT part of the
 # legacy-promotion batch. They have their own forward/rollback contracts
 # tested elsewhere (or none, if pre-dating the convention). Listed here
 # so test_files_match_directory_listing accepts them as expected.
@@ -196,7 +199,12 @@ def test_files_match_directory_listing() -> None:
         and 129 <= int(f.name[:3]) <= 137
     )
     # 131 is intentionally reserved for unify_migration_tracking
-    expected = sorted(LEGACY_PROMOTION_FILES + NON_LEGACY_FILES_IN_RANGE)
+    # 142, 143 used to live in this range as 129_legacy_user_profiles and
+    # 130_legacy_conversations; renumbered out by P0-7 (2026-04-29).
+    in_range_legacy = tuple(
+        f for f in LEGACY_PROMOTION_FILES if 129 <= int(f[:3]) <= 137
+    )
+    expected = sorted(in_range_legacy + NON_LEGACY_FILES_IN_RANGE)
     assert actual == expected, (
         f"unexpected files in 129–137 range\n"
         f"  expected: {expected}\n"

--- a/apps/backend-rag/backend/tests/db/test_migration_uniqueness.py
+++ b/apps/backend-rag/backend/tests/db/test_migration_uniqueness.py
@@ -1,0 +1,90 @@
+"""P0-7 (zero-crash audit 2026-04-29) — duplicate migration prefix guard.
+
+Two files sharing the same NNN_ prefix in `migrations_v2/` produce
+undefined apply order: the runner picks one alphabetically and silently
+skips the other. `_assert_unique_migration_numbers` turns that silent
+skip into a `MigrationError`, both at deploy time and at runtime if a
+future PR slips one in.
+
+These tests don't touch the database — they exercise the disk-walking
+helper in isolation, plus a smoke test against the real
+`migrations_v2/` directory to catch regressions.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.db.migration_base import MigrationError
+from backend.db.migration_manager import _assert_unique_migration_numbers
+
+
+def _touch(dir_path: Path, name: str) -> Path:
+    """Create an empty `.sql` file (assert helper only inspects filenames)."""
+    p = dir_path / name
+    p.touch()
+    return p
+
+
+def test_duplicate_prefix_raises(tmp_path):
+    """Two files sharing the `001_` prefix → MigrationError with details."""
+    files = [
+        _touch(tmp_path, "001_first.sql"),
+        _touch(tmp_path, "001_second.sql"),
+        _touch(tmp_path, "002_unique.sql"),
+    ]
+
+    with pytest.raises(MigrationError) as excinfo:
+        _assert_unique_migration_numbers(sorted(files))
+
+    msg = str(excinfo.value)
+    assert "Duplicate migration numbers" in msg
+    assert "1:" in msg
+    assert "001_first.sql" in msg
+    assert "001_second.sql" in msg
+    assert "P0-7" in msg
+
+
+def test_unique_prefixes_pass(tmp_path):
+    """Three files with distinct prefixes → no error."""
+    files = [
+        _touch(tmp_path, "001_a.sql"),
+        _touch(tmp_path, "002_b.sql"),
+        _touch(tmp_path, "003_c.sql"),
+    ]
+
+    # Should not raise.
+    _assert_unique_migration_numbers(sorted(files))
+
+
+def test_non_numeric_prefix_ignored(tmp_path):
+    """Files without an `NNN_` prefix are not counted as duplicates."""
+    files = [
+        _touch(tmp_path, "001_real.sql"),
+        _touch(tmp_path, "README.sql"),
+        _touch(tmp_path, "stray.sql"),
+    ]
+
+    # Two non-numeric stems exist alongside one numeric — no collision.
+    _assert_unique_migration_numbers(sorted(files))
+
+
+def test_real_migrations_v2_has_no_duplicates():
+    """Smoke test: the actual migrations_v2/ directory must stay clean.
+
+    Canary that fails fast if a future PR ever lands a duplicate prefix
+    without going through the CI guardrail (e.g. a direct push, or a
+    force-push past branch protection).
+    """
+    real_dir = (
+        Path(__file__).resolve().parents[2]
+        / "db"
+        / "migrations_v2"
+    )
+    if not real_dir.is_dir():
+        pytest.skip(f"migrations_v2 dir not found at {real_dir}")
+
+    sql_files = sorted(real_dir.glob("*.sql"))
+    # Should not raise on the real directory after P0-7 cleanup.
+    _assert_unique_migration_numbers(sql_files)


### PR DESCRIPTION
Resolves cicatrix STRUCTURAL 2026-04-29 P0-7 from zero-crash audit.

## Summary
- Renamed non-applied duplicate migrations:
  - \`129_legacy_user_profiles.sql\` → \`142_legacy_user_profiles.sql\`
  - \`130_legacy_conversations.sql\` → \`143_legacy_conversations.sql\`
  (141 was already taken by canary in PR #336)
- Runtime assert in \`migration_manager.py\` via \`_assert_unique_migration_numbers\` (testable without DB)
- CI guardrail \`.github/workflows/lint-migration-numbers.yml\` prevents future duplicates
- 4 new tests in \`test_migration_uniqueness.py\` (4/4 pass), updated \`test_legacy_promotion_migrations.py\` (6/6 pass)

## Diagnosis findings
- Production \`_schema_versions\` only had \`129_crm_guardian.sql\`. Number 130 was absent.
- Legacy tracker \`schema_migrations\` had 3 entries for 130.
- All 6 DDL tables (crm_guardian + legacy) exist in prod (idempotent CREATE IF NOT EXISTS masked the bug).
- The renamed files will apply on next deploy via the new \`run-sql-v2-migrations-post-deploy\` job (PR #336).

## Test plan
- [x] 4/4 unit tests in \`test_migration_uniqueness.py\` pass
- [x] 6/6 tests in \`test_legacy_promotion_migrations.py\` (updated) pass
- [x] Production \`_schema_versions\` queried via \`fly ssh\` to confirm rename targets
- [ ] Post-deploy: 142 and 143 in \`_schema_versions\` after merge

## Cicatrix
STRUCTURAL 2026-04-29 P0-7 \"Duplicate SQL v2 migration numbers 129_* and 130_*\" → resolved.

🤖 Generated by S3 (Air) + Pro auth fallback for PR creation. See pattern memory \"Antonello NON è dev\".