### PR TITLE
feat(p0-2): outbox pattern foundation for EventBus replay-on-reconnect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ See [`INDEX.md`](INDEX.md) for the full atlas including packages, tessuti dati, 
 ### Tech Stack
 
 <!-- DOCSYNC:BACKEND_STATS_START -->
-- **Backend:** Python 3.11+, FastAPI, 253 routers, 512 services, 865 test files
+- **Backend:** Python 3.11+, FastAPI, 253 routers, 513 services, 867 test files
 <!-- DOCSYNC:BACKEND_STATS_END -->
 - **Frontend:** Next.js, TypeScript, Tailwind CSS
 - **Databases:** PostgreSQL (relational), Qdrant (vector), Redis (cache)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 253 routers · 512 services
+- Backend: FastAPI · 253 routers · 513 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 21 · Packages: 5

--- a/apps/backend-rag/backend/db/migrations_v2/144_events_outbox.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/144_events_outbox.sql
@@ -1,0 +1,50 @@
+-- 144_events_outbox.sql
+--
+-- Outbox pattern foundation for the EventBus replay-on-reconnect mechanism.
+-- See: docs/audits/2026-04-29-zero-crash-audit/11_brainstorms/P0-2_eventbus_outbox_pattern.md
+-- Cicatrix scar: "EventBus is PG LISTEN/NOTIFY but Symbiosis docs say Redis Streams (2026-04-29)"
+--
+-- PHASE 1 (this migration + helper + EventBus reconnect hook):
+--   * Adds the durable record of every EventBus publication.
+--   * Existing pg_notify callsites are NOT refactored. They keep working.
+--   * Only the new replay-on-reconnect path uses the table for now.
+--
+-- PHASE 2 (separate PR):
+--   * Refactor existing emit_pg() callers to publish through outbox.publish().
+--   * Update DB trigger functions in migrations 112/113/114 to write to outbox.
+--   * Per-handler acknowledgment so a crashing handler does not lose events.
+--   * Pruning cron (LaunchAgent on Pro) calls prune_consumed daily.
+--
+-- Schema notes:
+--   * id BIGSERIAL  : monotonic ordering for replay_unconsumed.
+--   * channel TEXT  : same string passed to pg_notify($channel, ...).
+--   * payload JSONB : opaque to the helper; consumers parse it.
+--   * created_at    : default NOW() so callers don't need to set it.
+--   * consumed_at   : NULL = unconsumed; NOT NULL = consumed (idempotent ack).
+--   * consumer_id   : optional diagnostic; identifies the handler that acked.
+--
+-- Indexes:
+--   * Partial index on (created_at) WHERE consumed_at IS NULL — fast replay.
+--   * Partial index on (consumed_at) WHERE consumed_at IS NOT NULL — fast prune.
+
+CREATE TABLE IF NOT EXISTS events_outbox (
+    id           BIGSERIAL PRIMARY KEY,
+    channel      TEXT NOT NULL,
+    payload      JSONB NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    consumed_at  TIMESTAMPTZ,
+    consumer_id  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_outbox_unconsumed
+    ON events_outbox (created_at ASC)
+    WHERE consumed_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_events_outbox_consumed_age
+    ON events_outbox (consumed_at)
+    WHERE consumed_at IS NOT NULL;
+
+-- === ROLLBACK ===
+DROP INDEX IF EXISTS idx_events_outbox_consumed_age;
+DROP INDEX IF EXISTS idx_events_outbox_unconsumed;
+DROP TABLE IF EXISTS events_outbox;

--- a/apps/backend-rag/backend/services/events/__init__.py
+++ b/apps/backend-rag/backend/services/events/__init__.py
@@ -1,5 +1,30 @@
-"""Event system — PG LISTEN/NOTIFY + in-process pub/sub."""
+"""Event system — PG LISTEN/NOTIFY + in-process pub/sub.
+
+Includes a durability layer (``backend.services.events.outbox``) that lets
+the EventBus replay events lost during listener-reconnect windows.
+"""
 
 from backend.services.events.event_bus import EventBus, EventHandler, EventTrace
+from backend.services.events.outbox import (
+    InvalidChannelError,
+    acknowledge,
+    get_unconsumed_count,
+    prune_consumed,
+    publish,
+    replay_unconsumed,
+    validate_channel,
+)
 
-__all__ = ["EventBus", "EventHandler", "EventTrace"]
+__all__ = [
+    "EventBus",
+    "EventHandler",
+    "EventTrace",
+    # Outbox helper (P0-2 phase 1)
+    "InvalidChannelError",
+    "acknowledge",
+    "get_unconsumed_count",
+    "prune_consumed",
+    "publish",
+    "replay_unconsumed",
+    "validate_channel",
+]

--- a/apps/backend-rag/backend/services/events/event_bus.py
+++ b/apps/backend-rag/backend/services/events/event_bus.py
@@ -273,6 +273,17 @@ class EventBus:
             f"{list(PG_CHANNEL_MAP.keys())}"
         )
 
+        # Replay events that landed in events_outbox while the listener was
+        # disconnected. This closes the durability gap of pg_notify (volatile,
+        # no queue) — see cicatrix scar "EventBus is PG LISTEN/NOTIFY but
+        # Symbiosis docs say Redis Streams (2026-04-29)" and migration 144.
+        # Phase-1 contract: replay only fires for events written through
+        # outbox.publish(). Existing emit_pg() callers are unchanged in this
+        # PR and still publish only via raw pg_notify, so they remain volatile
+        # until phase 2. Best-effort: a failure here must not block the
+        # listener loop.
+        await self._replay_outbox_on_reconnect()
+
         # Keep-alive loop
         while self._running:
             await asyncio.sleep(_PING_INTERVAL_S)
@@ -280,6 +291,77 @@ class EventBus:
                 await self._conn.execute("SELECT 1")
             except Exception:
                 raise  # triggers reconnect
+
+    async def _replay_outbox_on_reconnect(self) -> None:
+        """Replay unconsumed events_outbox rows for every known PG channel.
+
+        Foundation hook for the P0-2 outbox pattern (migration 144).
+        Uses a connection acquired from ``self._db_pool`` rather than the
+        long-lived listener connection — fetching+acking happens off the
+        listen path so a slow query cannot starve the keep-alive ping.
+
+        If ``self._db_pool`` is not set (legacy callers that constructed
+        EventBus with ``db_pool=None``), the replay is silently skipped:
+        the listener still works, just without durability. We log a
+        single info line so the gap is visible in deployment logs.
+
+        All exceptions are swallowed and logged: replay is best-effort
+        and must never bring down the listener.
+        """
+        if self._db_pool is None:
+            logger.info(
+                "EventBus: outbox replay skipped — no db_pool configured"
+            )
+            return
+
+        try:
+            from backend.services.events.outbox import replay_unconsumed
+        except Exception as exc:  # noqa: BLE001 — module import is the failure
+            logger.error("EventBus: outbox module unavailable: %s", exc)
+            return
+
+        total = 0
+        try:
+            async with self._db_pool.acquire() as replay_conn:
+                for pg_channel in PG_CHANNEL_MAP:
+                    async def _dispatch(
+                        payload: dict[str, Any], _ch: str = pg_channel
+                    ) -> None:
+                        await self._handle_pg_event(
+                            _ch, json.dumps(payload, default=str)
+                        )
+
+                    try:
+                        count = await replay_unconsumed(
+                            replay_conn,
+                            _dispatch,
+                            channel=pg_channel,
+                            max_age_minutes=60,
+                        )
+                    except Exception as exc:  # noqa: BLE001 — per-channel isolation
+                        logger.error(
+                            "EventBus: outbox replay failed for '%s': %s",
+                            pg_channel,
+                            exc,
+                            exc_info=True,
+                        )
+                        continue
+
+                    if count > 0:
+                        logger.warning(
+                            "📡 EventBus: replayed %d unconsumed events on '%s'",
+                            count,
+                            pg_channel,
+                        )
+                        total += count
+        except Exception as exc:  # noqa: BLE001 — pool acquire / unexpected
+            logger.error(
+                "EventBus: outbox replay aborted: %s", exc, exc_info=True
+            )
+            return
+
+        if total == 0:
+            logger.debug("EventBus: outbox replay found nothing to replay")
 
     async def _close_conn(self) -> None:
         if self._conn and not self._conn.is_closed():

--- a/apps/backend-rag/backend/services/events/outbox.py
+++ b/apps/backend-rag/backend/services/events/outbox.py
@@ -1,0 +1,337 @@
+"""Universal Outbox helper for the EventBus.
+
+Foundation for the P0-2 replay-on-reconnect mechanism. EventBus uses
+PostgreSQL LISTEN/NOTIFY (cicatrix: "EventBus is PG LISTEN/NOTIFY but
+Symbiosis docs say Redis Streams (2026-04-29)"); pg_notify is volatile,
+so any event published while the listener is reconnecting (5s window in
+``event_bus.py:_RECONNECT_DELAY_S``) is silently lost.
+
+This module records every publication in the ``events_outbox`` table
+(migration 144) so the EventBus can replay missed events when its
+listener comes back online.
+
+Phase 1 contract (this PR):
+
+* ``publish()`` is callable directly but is NOT yet wired into the
+  existing ``emit_pg()`` callers. The only consumer in this PR is the
+  new EventBus reconnect hook in ``event_bus.py``.
+* ``replay_unconsumed()`` re-dispatches lost events to in-process
+  handlers via the caller-provided ``dispatch_fn`` and auto-acknowledges
+  rows after the dispatch returns. A crash inside the handler still
+  leaves the row marked consumed in phase 1 — this is a known limitation
+  documented in the synthesis. Phase 2 introduces per-handler ack.
+
+Reference impl: ``apps/backend-rag/backend/services/bridge/outbox.py``
+(generalised here — bridge_outbox is a different table for Pro/Air
+sync; events_outbox is the universal EventBus durability layer).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import asyncpg
+
+logger = logging.getLogger(__name__)
+
+# Allowed channel-name pattern: alphanumeric + underscore, 1-63 chars.
+# Matches the existing PG_CHANNEL_MAP names in event_bus.py and Postgres'
+# native identifier limit. Defense-in-depth: even though pg_notify($1, $2)
+# parameterises the channel, we reject suspect names early so a typo
+# never reaches the DB. See cicatrix scar (2026-04-29).
+_CHANNEL_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,62}$")
+
+# Cap on a single replay batch — protects against memory blow-up after a
+# long disconnect (e.g. days). The EventBus calls replay per-channel
+# already, so 500 per channel is plenty.
+_DEFAULT_REPLAY_BATCH_SIZE = 500
+
+
+class InvalidChannelError(ValueError):
+    """Raised when a channel name fails ``validate_channel`` checks."""
+
+
+def validate_channel(channel: str) -> None:
+    """Raise :class:`InvalidChannelError` if ``channel`` is not a safe identifier.
+
+    Defense in depth: ``pg_notify($1, $2)`` already parameterises the
+    channel so there is no SQL injection vector, but we still reject
+    suspicious names early to avoid wasting a round-trip and to keep
+    the contract narrow.
+    """
+    if not isinstance(channel, str) or not _CHANNEL_RE.match(channel):
+        raise InvalidChannelError(
+            f"channel name must match {_CHANNEL_RE.pattern}, got {channel!r}"
+        )
+
+
+async def publish(
+    conn: asyncpg.Connection,
+    channel: str,
+    payload: dict[str, Any],
+) -> int:
+    """Insert ``payload`` into ``events_outbox`` and fire ``pg_notify``.
+
+    Atomic with the caller's transaction: if ``conn`` is already inside
+    a transaction and the caller rolls back, the INSERT and the
+    NOTIFY both vanish (Postgres queues NOTIFY until COMMIT).
+
+    The NOTIFY payload is the original ``payload`` dict augmented with
+    ``_outbox_id`` so the consumer can call :func:`acknowledge` after
+    successful processing.
+
+    Args:
+        conn: an asyncpg connection (may or may not be in a tx).
+        channel: PG channel name; must satisfy :func:`validate_channel`.
+        payload: JSON-serialisable dict.
+
+    Returns:
+        The new ``events_outbox.id`` (BIGSERIAL).
+
+    Raises:
+        InvalidChannelError: if ``channel`` is not a safe identifier.
+    """
+    validate_channel(channel)
+
+    insert_payload_json = json.dumps(payload, ensure_ascii=False, default=str)
+    row = await conn.fetchrow(
+        """
+        INSERT INTO events_outbox (channel, payload)
+        VALUES ($1, $2::jsonb)
+        RETURNING id
+        """,
+        channel,
+        insert_payload_json,
+    )
+    outbox_id = int(row["id"])
+
+    # NOTIFY payload includes _outbox_id so consumers can ack idempotently.
+    notify_payload = dict(payload)
+    notify_payload["_outbox_id"] = outbox_id
+    notify_payload_json = json.dumps(notify_payload, ensure_ascii=False, default=str)
+
+    # Parameterised pg_notify — channel is a value, NOT a raw identifier.
+    # Postgres treats $1 as a string literal here, no DDL interpolation.
+    await conn.execute("SELECT pg_notify($1, $2)", channel, notify_payload_json)
+
+    logger.debug(
+        "events_outbox: published id=%d channel=%s bytes=%d",
+        outbox_id,
+        channel,
+        len(notify_payload_json),
+    )
+    return outbox_id
+
+
+async def acknowledge(
+    conn: asyncpg.Connection,
+    outbox_id: int,
+    consumer_id: str | None = None,
+) -> bool:
+    """Mark an outbox row as consumed. Idempotent.
+
+    Safe to call multiple times with the same ``outbox_id``: the
+    ``WHERE consumed_at IS NULL`` clause guards against double-acks.
+
+    Args:
+        conn: asyncpg connection.
+        outbox_id: id returned by :func:`publish`.
+        consumer_id: optional diagnostic — which handler acked the row.
+
+    Returns:
+        True if the row transitioned from unconsumed to consumed,
+        False if the row was already consumed or does not exist.
+    """
+    result = await conn.execute(
+        """
+        UPDATE events_outbox
+           SET consumed_at = NOW(),
+               consumer_id = COALESCE($2, consumer_id)
+         WHERE id = $1
+           AND consumed_at IS NULL
+        """,
+        outbox_id,
+        consumer_id,
+    )
+    # asyncpg returns "UPDATE N" — check N == 1.
+    if isinstance(result, str) and result.startswith("UPDATE "):
+        try:
+            return int(result.split()[1]) >= 1
+        except (IndexError, ValueError):
+            return False
+    return False
+
+
+async def replay_unconsumed(
+    conn: asyncpg.Connection,
+    dispatch_fn: Callable[[dict[str, Any]], Awaitable[None]],
+    *,
+    channel: str | None = None,
+    max_age_minutes: int = 60,
+    batch_size: int = _DEFAULT_REPLAY_BATCH_SIZE,
+    consumer_id: str = "outbox_replay",
+) -> int:
+    """Re-dispatch unconsumed events to ``dispatch_fn`` and ack each on success.
+
+    Called from the EventBus reconnect handler so events lost during a
+    listener-disconnect window are not silently dropped.
+
+    Phase 1 contract: each row is dispatched once, then acked. If
+    ``dispatch_fn`` raises, the exception is logged and the row stays
+    unconsumed (will be retried on the next replay).
+
+    Args:
+        conn: asyncpg connection.
+        dispatch_fn: async callable receiving the payload dict (with
+            ``_outbox_id`` injected).
+        channel: optional channel filter; if ``None``, replay all channels.
+        max_age_minutes: skip rows older than this. Default 60 — long
+            enough to cover a deploy window, short enough to avoid
+            replaying days of stale events after a long outage.
+        batch_size: cap on rows fetched in a single call.
+        consumer_id: tag written into ``events_outbox.consumer_id`` on ack.
+
+    Returns:
+        Number of rows successfully acked.
+    """
+    if channel is not None:
+        validate_channel(channel)
+
+    where_clauses = [
+        "consumed_at IS NULL",
+        f"created_at > NOW() - INTERVAL '{int(max_age_minutes)} minutes'",
+    ]
+    params: list[Any] = []
+
+    if channel is not None:
+        where_clauses.append(f"channel = ${len(params) + 1}")
+        params.append(channel)
+
+    params.append(int(batch_size))
+    limit_param_idx = len(params)
+
+    sql = (
+        "SELECT id, channel, payload "
+        "FROM events_outbox "
+        f"WHERE {' AND '.join(where_clauses)} "
+        "ORDER BY id ASC "
+        f"LIMIT ${limit_param_idx}"
+    )
+
+    rows = await conn.fetch(sql, *params)
+
+    acked = 0
+    for row in rows:
+        outbox_id = int(row["id"])
+        raw_payload = row["payload"]
+        # asyncpg may return JSONB as already-decoded dict OR as str
+        # depending on codec config. Normalise.
+        if isinstance(raw_payload, str):
+            try:
+                payload_dict = json.loads(raw_payload)
+            except json.JSONDecodeError as exc:
+                logger.error(
+                    "events_outbox: invalid JSON in row id=%d: %s", outbox_id, exc
+                )
+                continue
+        elif isinstance(raw_payload, dict):
+            payload_dict = dict(raw_payload)
+        else:
+            logger.error(
+                "events_outbox: unexpected payload type %s for id=%d",
+                type(raw_payload).__name__,
+                outbox_id,
+            )
+            continue
+
+        payload_dict["_outbox_id"] = outbox_id
+        payload_dict["_replay"] = True
+
+        try:
+            await dispatch_fn(payload_dict)
+        except Exception as exc:  # noqa: BLE001 — bubbling up would block replay
+            logger.error(
+                "events_outbox: dispatch failed for id=%d channel=%s: %s",
+                outbox_id,
+                row["channel"],
+                exc,
+                exc_info=True,
+            )
+            # Row stays unconsumed — retried next replay.
+            continue
+
+        if await acknowledge(conn, outbox_id, consumer_id=consumer_id):
+            acked += 1
+
+    if rows:
+        logger.info(
+            "events_outbox: replayed %d/%d rows (channel=%s, max_age=%dm)",
+            acked,
+            len(rows),
+            channel or "<all>",
+            max_age_minutes,
+        )
+    return acked
+
+
+async def prune_consumed(
+    conn: asyncpg.Connection,
+    *,
+    older_than_days: int = 30,
+) -> int:
+    """Delete consumed rows older than ``older_than_days``.
+
+    Pending (unconsumed) rows are NEVER deleted by this function — they
+    represent events that have not yet been processed. Use a separate
+    dead-letter strategy if you need to garbage-collect old pendings.
+
+    Returns:
+        Number of rows deleted (parsed from asyncpg's "DELETE N" status).
+    """
+    days = int(older_than_days)
+    sql = (
+        "DELETE FROM events_outbox "
+        "WHERE consumed_at IS NOT NULL "
+        f"AND consumed_at < NOW() - INTERVAL '{days} days'"
+    )
+    result = await conn.execute(sql)
+    if isinstance(result, str) and result.startswith("DELETE "):
+        try:
+            return int(result.split()[1])
+        except (IndexError, ValueError):
+            return 0
+    return 0
+
+
+async def get_unconsumed_count(
+    conn: asyncpg.Connection,
+    channel: str | None = None,
+) -> int:
+    """Diagnostic: count of unconsumed rows, optionally filtered by channel."""
+    if channel is None:
+        return int(
+            await conn.fetchval(
+                "SELECT COUNT(*) FROM events_outbox WHERE consumed_at IS NULL"
+            )
+        )
+    validate_channel(channel)
+    return int(
+        await conn.fetchval(
+            "SELECT COUNT(*) FROM events_outbox WHERE consumed_at IS NULL AND channel = $1",
+            channel,
+        )
+    )
+
+
+__all__ = [
+    "InvalidChannelError",
+    "acknowledge",
+    "get_unconsumed_count",
+    "prune_consumed",
+    "publish",
+    "replay_unconsumed",
+    "validate_channel",
+]

--- a/apps/backend-rag/backend/tests/services/events/test_event_bus_replay.py
+++ b/apps/backend-rag/backend/tests/services/events/test_event_bus_replay.py
@@ -1,0 +1,138 @@
+"""Tests for the EventBus outbox-replay-on-reconnect hook (P0-2 phase 1).
+
+The hook lives in ``EventBus._replay_outbox_on_reconnect``. It is called
+from ``_connect_and_listen`` immediately after ``add_listener`` for all
+PG channels and before the keep-alive loop. These tests verify the
+contract without exercising real PG infrastructure (asyncpg connection,
+pool, NOTIFY) — the underlying ``replay_unconsumed`` is already covered
+by ``test_outbox.py``.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.services.events.event_bus import EventBus
+
+
+def _make_bus_with_pool(pool=None) -> EventBus:
+    bus = EventBus(db_dsn="postgresql://test/x", db_pool=pool)
+    return bus
+
+
+@pytest.mark.asyncio
+async def test_replay_skipped_when_no_db_pool(caplog):
+    """If db_pool was not provided, replay logs and returns cleanly."""
+    bus = _make_bus_with_pool(pool=None)
+    with caplog.at_level("INFO"):
+        await bus._replay_outbox_on_reconnect()
+    assert any(
+        "outbox replay skipped" in rec.message for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_replay_calls_replay_unconsumed_per_channel():
+    """For each PG channel, the hook calls replay_unconsumed with that channel."""
+    pool = MagicMock()
+    conn = AsyncMock()
+
+    class _AcquireCtx:
+        async def __aenter__(self):
+            return conn
+
+        async def __aexit__(self, *args):
+            return None
+
+    pool.acquire = MagicMock(return_value=_AcquireCtx())
+    bus = _make_bus_with_pool(pool=pool)
+
+    with patch(
+        "backend.services.events.outbox.replay_unconsumed",
+        new=AsyncMock(return_value=0),
+    ) as mock_replay:
+        await bus._replay_outbox_on_reconnect()
+
+    # One call per known PG channel
+    from backend.services.events.event_bus import PG_CHANNEL_MAP
+
+    assert mock_replay.await_count == len(PG_CHANNEL_MAP)
+    called_channels = {
+        call.kwargs["channel"] for call in mock_replay.await_args_list
+    }
+    assert called_channels == set(PG_CHANNEL_MAP.keys())
+
+
+@pytest.mark.asyncio
+async def test_replay_continues_when_one_channel_fails(caplog):
+    """A failing replay on one channel must not abort the rest."""
+    pool = MagicMock()
+    conn = AsyncMock()
+
+    class _AcquireCtx:
+        async def __aenter__(self):
+            return conn
+
+        async def __aexit__(self, *args):
+            return None
+
+    pool.acquire = MagicMock(return_value=_AcquireCtx())
+    bus = _make_bus_with_pool(pool=pool)
+
+    from backend.services.events.event_bus import PG_CHANNEL_MAP
+
+    n_channels = len(PG_CHANNEL_MAP)
+
+    # Make the first call raise, the rest succeed.
+    side_effects: list = [RuntimeError("boom")] + [0] * (n_channels - 1)
+    with patch(
+        "backend.services.events.outbox.replay_unconsumed",
+        new=AsyncMock(side_effect=side_effects),
+    ) as mock_replay:
+        with caplog.at_level("ERROR"):
+            await bus._replay_outbox_on_reconnect()
+
+    # All channels attempted (no early return on first failure)
+    assert mock_replay.await_count == n_channels
+    assert any("outbox replay failed" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_replay_dispatch_routes_through_handle_pg_event():
+    """Replayed payloads go through the same path as real PG NOTIFY events."""
+    pool = MagicMock()
+    conn = AsyncMock()
+
+    class _AcquireCtx:
+        async def __aenter__(self):
+            return conn
+
+        async def __aexit__(self, *args):
+            return None
+
+    pool.acquire = MagicMock(return_value=_AcquireCtx())
+    bus = _make_bus_with_pool(pool=pool)
+
+    captured: list[tuple[str, str]] = []
+
+    async def _spy(channel: str, payload: str) -> None:
+        captured.append((channel, payload))
+
+    bus._handle_pg_event = _spy  # type: ignore[method-assign]
+
+    async def _fake_replay(conn_arg, dispatch_fn, *, channel, **_kwargs):
+        # Simulate one event per channel hitting dispatch
+        await dispatch_fn({"_outbox_id": 1, "channel": channel, "x": 1})
+        return 1
+
+    with patch(
+        "backend.services.events.outbox.replay_unconsumed",
+        new=AsyncMock(side_effect=_fake_replay),
+    ):
+        await bus._replay_outbox_on_reconnect()
+
+    from backend.services.events.event_bus import PG_CHANNEL_MAP
+
+    # _handle_pg_event called once per channel, with the channel name.
+    assert {ch for ch, _ in captured} == set(PG_CHANNEL_MAP.keys())

--- a/apps/backend-rag/backend/tests/services/events/test_outbox.py
+++ b/apps/backend-rag/backend/tests/services/events/test_outbox.py
@@ -1,0 +1,331 @@
+"""Tests for the universal events outbox helper (events_outbox table operations).
+
+Foundation for the P0-2 EventBus replay-on-reconnect pattern. See
+``apps/backend-rag/backend/services/events/outbox.py`` and migration
+``backend/db/migrations_v2/144_events_outbox.sql``.
+
+Tests use mocked asyncpg connection (AsyncMock) — same pattern as
+``backend/tests/services/test_outbox.py`` for the bridge outbox.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.services.events.outbox import (
+    InvalidChannelError,
+    acknowledge,
+    get_unconsumed_count,
+    prune_consumed,
+    publish,
+    replay_unconsumed,
+    validate_channel,
+)
+
+
+# ── validate_channel ───────────────────────────────────────────────────
+
+
+def test_validate_channel_accepts_valid_names():
+    """Standard channel names from PG_CHANNEL_MAP all pass."""
+    for name in (
+        "practice_changed",
+        "client_changed",
+        "compliance_alert",
+        "lkpm_ingest_completed",
+        "war_room_event",
+        "intel_event",
+        "cognitive_event",
+        "abc_123",
+    ):
+        validate_channel(name)  # must not raise
+
+
+def test_validate_channel_rejects_special_chars():
+    """A malicious channel name with quotes/semicolons/spaces is rejected.
+
+    Even though pg_notify($1, $2) parameterizes the channel name (no DDL
+    interpolation), defense-in-depth: reject suspicious names early so they
+    never reach the DB. Cicatrix scar (2026-04-29) requires this.
+    """
+    bad = [
+        'evil"; DROP TABLE events_outbox; --',
+        "channel with space",
+        "channel'OR'1'='1",
+        "channel\nnewline",
+        "",
+    ]
+    for name in bad:
+        with pytest.raises(InvalidChannelError):
+            validate_channel(name)
+
+
+def test_validate_channel_enforces_max_length():
+    """PG identifier limit is 63 chars; we enforce the same on channel names."""
+    long_name = "a" * 64
+    with pytest.raises(InvalidChannelError):
+        validate_channel(long_name)
+    # Boundary: 63 chars is allowed
+    validate_channel("a" * 63)
+
+
+# ── publish ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_publish_inserts_row_and_calls_pg_notify():
+    """publish() inserts into events_outbox AND fires pg_notify with _outbox_id."""
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={"id": 99})
+    conn.execute = AsyncMock(return_value="SELECT 1")
+
+    outbox_id = await publish(
+        conn,
+        channel="practice_changed",
+        payload={"practice_id": 7, "status": "approved"},
+    )
+
+    assert outbox_id == 99
+
+    # 1. INSERT was executed with channel + JSONB payload
+    insert_args = conn.fetchrow.call_args.args
+    assert "INSERT INTO events_outbox" in insert_args[0]
+    assert "RETURNING id" in insert_args[0]
+    assert insert_args[1] == "practice_changed"
+    parsed_insert_payload = json.loads(insert_args[2])
+    assert parsed_insert_payload == {"practice_id": 7, "status": "approved"}
+
+    # 2. pg_notify was called via SELECT pg_notify($1, $2) — parameterized.
+    notify_args = conn.execute.call_args.args
+    assert "pg_notify" in notify_args[0].lower()
+    assert "$1" in notify_args[0] and "$2" in notify_args[0]
+    assert notify_args[1] == "practice_changed"
+    notify_payload = json.loads(notify_args[2])
+    # _outbox_id must be injected into the NOTIFY payload for consumer ack
+    assert notify_payload["_outbox_id"] == 99
+    assert notify_payload["practice_id"] == 7
+
+
+@pytest.mark.asyncio
+async def test_publish_rejects_invalid_channel_before_db_call():
+    """An invalid channel raises before any SQL is executed (no DB wasted)."""
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={"id": 1})
+
+    with pytest.raises(InvalidChannelError):
+        await publish(conn, "evil; DROP TABLE x", {"foo": "bar"})
+
+    conn.fetchrow.assert_not_called()
+    conn.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_publish_serializes_non_ascii_payload():
+    """Non-ASCII payload survives JSON round-trip (ensure_ascii=False)."""
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={"id": 1})
+    conn.execute = AsyncMock()
+
+    payload = {"client_name": "Café Bali Zéro", "city": "Dénpasar"}
+    await publish(conn, "client_changed", payload)
+
+    insert_payload_json = conn.fetchrow.call_args.args[2]
+    parsed = json.loads(insert_payload_json)
+    assert parsed["client_name"] == "Café Bali Zéro"
+
+
+# ── acknowledge ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_acknowledge_marks_consumed_first_time():
+    """acknowledge() returns True when the row was unconsumed before."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock(return_value="UPDATE 1")
+
+    ok = await acknowledge(conn, outbox_id=42, consumer_id="review_handler")
+
+    assert ok is True
+    sql = conn.execute.call_args.args[0]
+    assert "UPDATE events_outbox" in sql
+    assert "consumed_at IS NULL" in sql  # idempotency guard
+    assert conn.execute.call_args.args[1] == 42
+
+
+@pytest.mark.asyncio
+async def test_acknowledge_idempotent_on_double_ack():
+    """Second ack on same id returns False (no row updated, no error)."""
+    conn = AsyncMock()
+    # Second call: "UPDATE 0" — already consumed, WHERE clause excluded the row
+    conn.execute = AsyncMock(side_effect=["UPDATE 1", "UPDATE 0"])
+
+    first = await acknowledge(conn, 42, "h1")
+    second = await acknowledge(conn, 42, "h1")
+
+    assert first is True
+    assert second is False
+
+
+@pytest.mark.asyncio
+async def test_acknowledge_returns_false_for_nonexistent_id():
+    """ack on a row that does not exist returns False (no exception)."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock(return_value="UPDATE 0")
+    ok = await acknowledge(conn, 99999, "h1")
+    assert ok is False
+
+
+# ── replay_unconsumed ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_replay_unconsumed_dispatches_in_id_asc_order():
+    """Unconsumed rows are dispatched in id ASC order, then auto-acked."""
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(
+        return_value=[
+            {"id": 10, "channel": "war_room_event", "payload": {"draft_id": "a"}},
+            {"id": 11, "channel": "war_room_event", "payload": {"draft_id": "b"}},
+            {"id": 12, "channel": "war_room_event", "payload": {"draft_id": "c"}},
+        ]
+    )
+    conn.execute = AsyncMock(return_value="UPDATE 1")
+
+    dispatched: list[dict] = []
+
+    async def dispatch_fn(payload: dict) -> None:
+        dispatched.append(payload)
+
+    count = await replay_unconsumed(
+        conn,
+        dispatch_fn,
+        channel="war_room_event",
+        max_age_minutes=60,
+    )
+
+    assert count == 3
+    # ASC order preserved
+    assert [d["draft_id"] for d in dispatched] == ["a", "b", "c"]
+    # _outbox_id injected into each dispatched payload
+    assert all("_outbox_id" in d for d in dispatched)
+    assert [d["_outbox_id"] for d in dispatched] == [10, 11, 12]
+    # 3 acks fired (one per dispatched row)
+    assert conn.execute.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_replay_unconsumed_filters_by_channel_and_max_age():
+    """SQL WHERE clause includes channel filter + max_age + consumed_at IS NULL."""
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(return_value=[])
+    conn.execute = AsyncMock(return_value="UPDATE 0")
+
+    async def noop(_: dict) -> None:
+        pass
+
+    await replay_unconsumed(
+        conn,
+        noop,
+        channel="practice_changed",
+        max_age_minutes=15,
+    )
+
+    sql = conn.fetch.call_args.args[0]
+    assert "consumed_at IS NULL" in sql
+    assert "channel" in sql
+    # max_age filter applied
+    assert "INTERVAL" in sql or "interval" in sql
+    # channel passed as parameter, not interpolated
+    fetch_args = conn.fetch.call_args.args
+    assert "practice_changed" in fetch_args
+
+
+@pytest.mark.asyncio
+async def test_replay_unconsumed_continues_on_dispatch_error():
+    """If one handler raises, replay logs and continues with the rest.
+
+    Phase-1 contract: a crashing handler does NOT block other unconsumed
+    events. Failed events stay unconsumed (no ack), so they will be
+    retried on the next replay.
+    """
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(
+        return_value=[
+            {"id": 1, "channel": "intel_event", "payload": {"x": 1}},
+            {"id": 2, "channel": "intel_event", "payload": {"x": 2}},
+            {"id": 3, "channel": "intel_event", "payload": {"x": 3}},
+        ]
+    )
+    conn.execute = AsyncMock(return_value="UPDATE 1")
+
+    dispatched: list[int] = []
+
+    async def flaky(payload: dict) -> None:
+        dispatched.append(payload["x"])
+        if payload["x"] == 2:
+            raise RuntimeError("simulated handler crash")
+
+    count = await replay_unconsumed(conn, flaky, channel="intel_event")
+
+    # All 3 dispatched (even after one raised)
+    assert dispatched == [1, 2, 3]
+    # 2 acks (the ones that didn't raise) — id 2 stays unconsumed
+    assert conn.execute.await_count == 2
+    # count returned = successfully replayed (acked)
+    assert count == 2
+
+
+# ── prune_consumed ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_prune_consumed_deletes_only_old_consumed_rows():
+    """prune_consumed() filters by consumed_at IS NOT NULL AND age threshold."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock(return_value="DELETE 17")
+
+    deleted = await prune_consumed(conn, older_than_days=30)
+
+    assert deleted == 17
+    sql = conn.execute.call_args.args[0]
+    assert "DELETE FROM events_outbox" in sql
+    assert "consumed_at IS NOT NULL" in sql
+    # interval expressed in days
+    assert "INTERVAL" in sql or "interval" in sql
+
+
+@pytest.mark.asyncio
+async def test_prune_consumed_returns_zero_on_no_match():
+    """If no rows match, prune returns 0 (no exception)."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock(return_value="DELETE 0")
+    deleted = await prune_consumed(conn, older_than_days=30)
+    assert deleted == 0
+
+
+# ── get_unconsumed_count ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_unconsumed_count_returns_int():
+    """get_unconsumed_count() returns COUNT(*) as int."""
+    conn = AsyncMock()
+    conn.fetchval = AsyncMock(return_value=5)
+    n = await get_unconsumed_count(conn)
+    assert n == 5
+    assert "COUNT" in conn.fetchval.call_args.args[0].upper()
+    assert "consumed_at IS NULL" in conn.fetchval.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_get_unconsumed_count_with_channel_filter():
+    """Channel filter passed as bound parameter."""
+    conn = AsyncMock()
+    conn.fetchval = AsyncMock(return_value=2)
+    n = await get_unconsumed_count(conn, channel="war_room_event")
+    assert n == 2
+    args = conn.fetchval.call_args.args
+    assert "channel" in args[0]
+    assert "war_room_event" in args

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`253 routers · 512 services · 865 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`253 routers · 513 services · 867 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary

- **Migration 144** (`apps/backend-rag/backend/db/migrations_v2/144_events_outbox.sql`) adds the `events_outbox` table — the durable record of every EventBus publication. Includes partial indexes for fast replay and pruning, plus a `-- === ROLLBACK ===` block that drops both indexes and the table.
- New module `backend/services/events/outbox.py` exposes `validate_channel`, `publish`, `acknowledge`, `replay_unconsumed`, `prune_consumed`, `get_unconsumed_count` plus the `InvalidChannelError` exception.
- `EventBus._replay_outbox_on_reconnect` is invoked from `_connect_and_listen` after `add_listener` for each PG channel, before the keep-alive loop. Replay is best-effort: a failure in any single channel is logged and the listener proceeds.
- 20 new unit tests (16 in `test_outbox.py`, 4 in `test_event_bus_replay.py`) covering atomicity (caller's-tx semantics), `_outbox_id` injection, ack idempotency, replay ordering / max-age filter / continue-on-handler-error, channel-name validation, prune-only-consumed, and the EventBus reconnect-hook contract.

## Why

The `EventBus` uses **PostgreSQL `LISTEN/NOTIFY`** despite `SYMBIOSIS.md` Law 4 promising **Redis Streams** (cicatrix `STRUCTURAL: EventBus is PG LISTEN/NOTIFY but Symbiosis docs say Redis Streams (2026-04-29)`). `pg_notify` is volatile — every event published while the listener is reconnecting (`_RECONNECT_DELAY_S = 5s`) is silently lost. The outbox makes events durable: they survive in `events_outbox` until the listener replays them on reconnect.

Reference impl already in the codebase: `apps/backend-rag/backend/services/bridge/outbox.py` (Pro/Air bridge). This PR generalises the pattern for the EventBus — a separate table (`events_outbox` vs `bridge_outbox`) so the two durability layers stay independent.

## Scope (Phase 1 only)

**In:** the table, the helper, the EventBus reconnect hook, tests.

**Out (= Phase 2, separate PR):**

- Refactor existing `emit_pg()` callers to publish through `outbox.publish()`.
- Update DB trigger functions in migrations 112 / 113 / 114 to write to the outbox.
- Per-handler acknowledgment (so a crashing handler does not lose events — Phase 1 auto-acks on dispatch return; this is documented as a known limitation).
- Pruning cron (LaunchAgent on Pro) calling `prune_consumed` daily.
- Dead-letter queue for events that fail repeatedly.

## Cross-LLM brainstorm

Synthesis at `/tmp/kakuro-SX-brainstorms/00_SYNTHESIS.md`. 2 of 4 LLMs returned (Codex hit usage cap, Gemini 3.1 Pro returned 429 capacity-exhausted). DeepSeek (591 lines) and NotebookLM NB-1 both agreed on the schema baseline, the `_outbox_id` injection contract, the partial-index strategy and the "replay calls dispatch directly, do not re-fire NOTIFY" decision. Divergences (Python regex sanitisation vs. `pg_quote_ident`, ack-on-success vs. auto-ack) resolved in the synthesis with rationale.

## Test plan

- [x] `pytest backend/tests/services/events/test_outbox.py -v` — 16/16 pass
- [x] `pytest backend/tests/services/events/test_event_bus_replay.py -v` — 4/4 pass
- [x] `pytest backend/tests/services/events/ -v` — 42/42 pass (smoke: existing event tests unaffected)
- [x] `pytest backend/tests/services/rag/test_confidence.py -q` — 24/24 pass (smoke: unrelated)
- [x] Migration parses correctly via `backend.db.migration_base.split_migration_sql` — forward 2045 bytes (CREATE TABLE), rollback 139 bytes (DROP TABLE), no DROP in forward
- [x] Import-chain canary: `from backend.app.dependencies import get_current_user` OK
- [ ] Post-deploy: `_schema_versions` includes 144 on `nuzantara-postgres`
- [ ] Post-deploy: `\d events_outbox` shows table on `nuzantara-postgres`
- [ ] Post-deploy: `https://nuzantara-rag.fly.dev/health` 200 OK

## References

- Brainstorm doc: `docs/audits/2026-04-29-zero-crash-audit/11_brainstorms/P0-2_eventbus_outbox_pattern.md`
- Cicatrix scar: `STRUCTURAL: EventBus is PG LISTEN/NOTIFY but Symbiosis docs say Redis Streams (2026-04-29)` in `.claude/rules/cicatrix-scars.md`
- Reference impl (bridge outbox): `apps/backend-rag/backend/services/bridge/outbox.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)