### PR TITLE
feat(p1-11): Drive OAuth tiered warnings + Cell sensor

### DIFF
--- a/apps/backend-rag/backend/tests/unit/scripts/test_drive_watchdog_tiers.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_drive_watchdog_tiers.py
@@ -1,0 +1,225 @@
+"""Tests for the tiered alert system in scripts/drive_token_watchdog.py.
+
+Covers:
+    - classify_tier() at each boundary (60, 30, 14, 7, 1, 0, -1 days)
+    - should_alert() idempotency (no spam, escalation, de-escalation)
+    - render_alert_text() formatting
+    - parse_expires_at() / compute_days_left() roundtrip
+
+The watchdog itself is not invoked here — only the pure functions. The
+fly-ssh + Telegram I/O paths are integration-tested elsewhere (manual
+QA on Air during deploy).
+
+P1-11 reference: docs/audits/2026-04-29-zero-crash-audit/02_opus_analysis.md
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from scripts.drive_token_watchdog import (
+    TIER_14_DAYS,
+    TIER_1_DAY,
+    TIER_30_DAYS,
+    TIER_7_DAYS,
+    TIER_EXPIRED,
+    TIER_OK,
+    TIER_SEVERITY,
+    classify_tier,
+    compute_days_left,
+    parse_expires_at,
+    render_alert_text,
+    should_alert,
+)
+
+
+# ---------------------------------------------------------------------------
+# classify_tier — tier-by-tier
+# ---------------------------------------------------------------------------
+
+class TestClassifyTier:
+    """Each tier fires at the documented boundary."""
+
+    def test_60_days_returns_ok(self) -> None:
+        alert = classify_tier(60)
+        assert alert.tier == TIER_OK
+        assert alert.severity_label == "OK"
+        assert alert.message_template == ""  # no message when OK
+
+    def test_31_days_returns_ok(self) -> None:
+        # Just above 30-day threshold — still OK
+        assert classify_tier(31).tier == TIER_OK
+
+    def test_30_days_returns_info(self) -> None:
+        alert = classify_tier(30)
+        assert alert.tier == TIER_30_DAYS
+        assert alert.severity_label == "INFO"
+        assert "🔵" in alert.emoji or alert.emoji == "🔵"
+
+    def test_15_days_returns_info(self) -> None:
+        # Within 30-day window, above 14-day → still info
+        assert classify_tier(15).tier == TIER_30_DAYS
+
+    def test_14_days_returns_warning(self) -> None:
+        alert = classify_tier(14)
+        assert alert.tier == TIER_14_DAYS
+        assert alert.severity_label == "WARNING"
+
+    def test_8_days_returns_warning(self) -> None:
+        # Above 7-day threshold, within 14 → still warning
+        assert classify_tier(8).tier == TIER_14_DAYS
+
+    def test_7_days_returns_urgent(self) -> None:
+        alert = classify_tier(7)
+        assert alert.tier == TIER_7_DAYS
+        assert alert.severity_label == "URGENT"
+
+    def test_2_days_returns_urgent(self) -> None:
+        # Above 1-day, within 7 → still urgent
+        assert classify_tier(2).tier == TIER_7_DAYS
+
+    def test_1_day_returns_critical(self) -> None:
+        alert = classify_tier(1)
+        assert alert.tier == TIER_1_DAY
+        assert alert.severity_label == "CRITICAL"
+
+    def test_0_days_returns_critical_1d(self) -> None:
+        # Edge: 0 days = expires today. Treated as critical_1d (still positive).
+        assert classify_tier(0).tier == TIER_1_DAY
+
+    def test_negative_1_returns_expired(self) -> None:
+        alert = classify_tier(-1)
+        assert alert.tier == TIER_EXPIRED
+        assert "EXPIRED" in alert.severity_label
+
+    def test_negative_30_returns_expired(self) -> None:
+        # Long-expired token still classified as expired (no separate tier).
+        assert classify_tier(-30).tier == TIER_EXPIRED
+
+
+# ---------------------------------------------------------------------------
+# render_alert_text — formatting
+# ---------------------------------------------------------------------------
+
+class TestRenderAlertText:
+    def test_render_30_day_message_includes_days(self) -> None:
+        text = render_alert_text(classify_tier(25))
+        assert "25" in text
+        assert "Drive OAuth" in text
+
+    def test_render_expired_message_uses_abs_days(self) -> None:
+        # -3 days → message says "3 giorni fa"
+        text = render_alert_text(classify_tier(-3))
+        assert "3 giorni fa" in text
+        assert "SCADUTO" in text
+
+    def test_render_1_day_message_says_domani(self) -> None:
+        text = render_alert_text(classify_tier(1))
+        assert "DOMANI" in text
+
+
+# ---------------------------------------------------------------------------
+# should_alert — idempotency
+# ---------------------------------------------------------------------------
+
+class TestShouldAlert:
+    """The state-file logic that prevents Telegram spam."""
+
+    def test_first_time_30_day_alerts(self) -> None:
+        # Cron runs first time, token at 28 days → alert.
+        assert should_alert(TIER_30_DAYS, last_tier=None) is True
+
+    def test_first_time_after_ok_alerts(self) -> None:
+        # Last run was OK, now crossed into 30d window → alert.
+        assert should_alert(TIER_30_DAYS, last_tier=TIER_OK) is True
+
+    def test_same_tier_does_not_re_alert(self) -> None:
+        # Cron runs again, still in 30-day window → silent.
+        assert should_alert(TIER_30_DAYS, last_tier=TIER_30_DAYS) is False
+
+    def test_escalation_30_to_14_alerts(self) -> None:
+        # Token aged: was in info window, now in warning → alert.
+        assert should_alert(TIER_14_DAYS, last_tier=TIER_30_DAYS) is True
+
+    def test_escalation_14_to_7_alerts(self) -> None:
+        assert should_alert(TIER_7_DAYS, last_tier=TIER_14_DAYS) is True
+
+    def test_escalation_7_to_1_alerts(self) -> None:
+        assert should_alert(TIER_1_DAY, last_tier=TIER_7_DAYS) is True
+
+    def test_escalation_1_to_expired_alerts(self) -> None:
+        assert should_alert(TIER_EXPIRED, last_tier=TIER_1_DAY) is True
+
+    def test_de_escalation_after_reauth_silent(self) -> None:
+        # User re-authed: was at urgent_7d, now back to OK → no alert.
+        assert should_alert(TIER_OK, last_tier=TIER_7_DAYS) is False
+
+    def test_de_escalation_to_lower_tier_silent(self) -> None:
+        # Was warning (14d), but token got refreshed and now we're at info (30d).
+        # Don't alert — the user already saw the warning, and this is improvement.
+        assert should_alert(TIER_30_DAYS, last_tier=TIER_14_DAYS) is False
+
+    def test_ok_to_ok_silent(self) -> None:
+        assert should_alert(TIER_OK, last_tier=TIER_OK) is False
+
+    def test_severity_table_is_strictly_monotonic(self) -> None:
+        """Sanity: tiers ordered correctly from least to most urgent."""
+        order = [TIER_OK, TIER_30_DAYS, TIER_14_DAYS, TIER_7_DAYS, TIER_1_DAY, TIER_EXPIRED]
+        sev = [TIER_SEVERITY[t] for t in order]
+        assert sev == sorted(sev), "TIER_SEVERITY must be monotonic"
+        assert len(set(sev)) == len(sev), "TIER_SEVERITY must be unique"
+
+
+# ---------------------------------------------------------------------------
+# parse_expires_at + compute_days_left — date math
+# ---------------------------------------------------------------------------
+
+class TestDateMath:
+    def test_parse_iso_with_tz(self) -> None:
+        dt = parse_expires_at("2026-08-01T12:00:00+00:00")
+        assert dt.tzinfo is not None
+        assert dt.year == 2026 and dt.month == 8
+
+    def test_parse_iso_with_z_suffix(self) -> None:
+        dt = parse_expires_at("2026-08-01T12:00:00Z")
+        assert dt.tzinfo is not None
+
+    def test_parse_naive_assumed_utc(self) -> None:
+        dt = parse_expires_at("2026-08-01 12:00:00")
+        assert dt.tzinfo is timezone.utc
+
+    def test_compute_days_left_future(self) -> None:
+        now = datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc)
+        # 30 days later
+        expires = now + timedelta(days=30)
+        assert compute_days_left(expires, now) == 30
+
+    def test_compute_days_left_past(self) -> None:
+        now = datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc)
+        # 5 days ago
+        expires = now - timedelta(days=5)
+        assert compute_days_left(expires, now) == -5
+
+
+# ---------------------------------------------------------------------------
+# End-to-end tier-driven alert simulation (mocked timestamps)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "days,expected_tier",
+    [
+        (60, TIER_OK),
+        (30, TIER_30_DAYS),
+        (14, TIER_14_DAYS),
+        (7, TIER_7_DAYS),
+        (1, TIER_1_DAY),
+        (0, TIER_1_DAY),
+        (-1, TIER_EXPIRED),
+    ],
+    ids=["60d_ok", "30d_info", "14d_warn", "7d_urgent", "1d_crit", "0d_crit", "expired"],
+)
+def test_tier_table_at_thresholds(days: int, expected_tier: str) -> None:
+    """Each documented threshold maps to the documented tier."""
+    assert classify_tier(days).tier == expected_tier

--- a/apps/cell/cell/sensors/oauth_health_sensor.py
+++ b/apps/cell/cell/sensors/oauth_health_sensor.py
@@ -1,0 +1,155 @@
+"""OAuthHealthSensor — Cell sensor for Google Drive OAuth token expiry.
+
+Reads the watchdog state file written by `scripts/drive_token_watchdog.py`
+(no extra DB / fly ssh round-trip from the Cell pulse loop). Maps the
+last-classified tier to green/yellow/red per the P1-11 (zero-crash audit
+2026-04-29) tier table:
+
+    TIER                  days_left      Cell color
+    --------------------  -------------  ------------
+    TIER_OK               > 30           green
+    TIER_30_DAYS          15..30         green   (heads-up only)
+    TIER_14_DAYS          8..14          yellow  (warning)
+    TIER_7_DAYS           2..7           red     (urgent — visible to organism)
+    TIER_1_DAY            0..1           red
+    TIER_EXPIRED          < 0            red
+
+State file: ``~/.agent/decisions/state/drive_oauth_watchdog.state.json``
+(written every ``drive_token_watchdog.py`` run on Air, every 6h).
+
+If the state file is missing OR stale (no successful watchdog run within the
+last 18h = 3× the cron interval), the sensor returns ``yellow`` with reason
+``stale`` — the Cell can then surface "OAuth visibility lost" as distinct
+from "OAuth definitely fine".
+
+The sensor never makes network calls — it only inspects a local JSON file.
+This keeps the Cell pulse loop fast and decoupled from Fly.io connectivity.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger("cell.sensors.oauth_health")
+
+# Default state-file path; matches scripts/drive_token_watchdog.py.
+_DEFAULT_STATE_PATH = os.path.expanduser(
+    "~/.agent/decisions/state/drive_oauth_watchdog.state.json"
+)
+
+# Watchdog cron runs every 6h; treat last_check older than 18h as stale.
+_DEFAULT_STALE_AFTER_HOURS = 18.0
+
+# Tier → (cell_color, reason_label). Mirrors the watchdog tier names so the
+# Cell pulse and the Telegram alerts agree on terminology.
+_TIER_TO_COLOR: dict[str, tuple[str, str]] = {
+    "ok": ("green", "token healthy (>30 days remaining)"),
+    "info_30d": ("green", "30d heads-up window"),
+    "warning_14d": ("yellow", "14d warning — re-auth this week"),
+    "urgent_7d": ("red", "7d urgent — re-auth NOW"),
+    "critical_1d": ("red", "1d critical — re-auth immediately"),
+    "critical_expired": ("red", "OAuth EXPIRED — Drive polling broken"),
+}
+
+
+@dataclass
+class OAuthHealthReading:
+    """One sensor reading. ``status`` is green/yellow/red per Cell convention."""
+
+    status: str  # "green", "yellow", "red", "unknown"
+    tier: str = ""  # watchdog tier string (e.g. "warning_14d") or empty
+    days_left: int | None = None  # extracted from state if present
+    last_check_iso: str = ""  # last watchdog run ISO timestamp
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class OAuthHealthSensor:
+    """Reads the drive_token_watchdog state file and classifies it.
+
+    No network I/O. The watchdog is the sole owner of the actual check; this
+    sensor is purely a *consumer* of the watchdog's classification.
+    """
+
+    def __init__(
+        self,
+        state_path: str = _DEFAULT_STATE_PATH,
+        stale_after_hours: float = _DEFAULT_STALE_AFTER_HOURS,
+    ) -> None:
+        self._state_path = state_path
+        self._stale_after_hours = stale_after_hours
+
+    def read(self, now: datetime | None = None) -> OAuthHealthReading:
+        """Read & classify. ``now`` is injectable for tests."""
+        now = now or datetime.now(timezone.utc)
+
+        if not os.path.exists(self._state_path):
+            return OAuthHealthReading(
+                status="unknown",
+                metadata={
+                    "reason": "watchdog state file not found",
+                    "path": self._state_path,
+                },
+            )
+
+        try:
+            with open(self._state_path) as f:
+                state = json.load(f)
+        except Exception as e:
+            logger.debug(f"OAuthHealthSensor: failed to read {self._state_path}: {e}")
+            return OAuthHealthReading(
+                status="unknown",
+                metadata={"reason": f"state read error: {e}", "path": self._state_path},
+            )
+
+        tier = state.get("last_oauth_tier", "") or ""
+        last_check_iso = state.get("last_oauth_check_iso", "") or ""
+        days_left = state.get("last_oauth_days_left")  # optional
+
+        # Staleness check — if the watchdog hasn't successfully run recently,
+        # we don't trust the cached tier. Yellow ("visibility lost"), not red.
+        if last_check_iso:
+            try:
+                last_check_dt = datetime.fromisoformat(last_check_iso)
+                if last_check_dt.tzinfo is None:
+                    last_check_dt = last_check_dt.replace(tzinfo=timezone.utc)
+                age_hours = (now - last_check_dt).total_seconds() / 3600.0
+                if age_hours > self._stale_after_hours:
+                    return OAuthHealthReading(
+                        status="yellow",
+                        tier=tier,
+                        days_left=days_left,
+                        last_check_iso=last_check_iso,
+                        metadata={
+                            "reason": f"watchdog state stale ({age_hours:.1f}h old)",
+                            "stale_after_hours": self._stale_after_hours,
+                        },
+                    )
+            except Exception as e:
+                logger.debug(
+                    f"OAuthHealthSensor: failed to parse last_check_iso "
+                    f"{last_check_iso!r}: {e}"
+                )
+                # Fall through to tier-based classification.
+
+        if not tier:
+            return OAuthHealthReading(
+                status="unknown",
+                last_check_iso=last_check_iso,
+                metadata={"reason": "state file has no last_oauth_tier yet"},
+            )
+
+        color, reason = _TIER_TO_COLOR.get(
+            tier, ("unknown", f"unknown tier: {tier}")
+        )
+        return OAuthHealthReading(
+            status=color,
+            tier=tier,
+            days_left=days_left,
+            last_check_iso=last_check_iso,
+            metadata={"reason": reason},
+        )

--- a/apps/cell/tests/test_oauth_health_sensor.py
+++ b/apps/cell/tests/test_oauth_health_sensor.py
@@ -1,0 +1,173 @@
+"""Tests for OAuthHealthSensor (P1-11, zero-crash audit 2026-04-29).
+
+The sensor consumes the JSON state file written by
+`scripts/drive_token_watchdog.py`. We don't run the watchdog here; we
+write fixture state files and assert the sensor classifies them correctly.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from cell.sensors.oauth_health_sensor import OAuthHealthSensor
+
+
+def _write_state(tmp_path: Path, **kwargs) -> str:
+    """Write a watchdog-style state file and return its path."""
+    p = tmp_path / "drive_oauth_watchdog.state.json"
+    p.write_text(json.dumps(kwargs))
+    return str(p)
+
+
+class TestOAuthHealthSensor:
+    def test_missing_state_file_is_unknown(self, tmp_path: Path) -> None:
+        sensor = OAuthHealthSensor(state_path=str(tmp_path / "does_not_exist.json"))
+        reading = sensor.read()
+        assert reading.status == "unknown"
+        assert "not found" in reading.metadata["reason"]
+
+    def test_corrupt_state_file_is_unknown(self, tmp_path: Path) -> None:
+        p = tmp_path / "corrupt.json"
+        p.write_text("not valid json {{{")
+        sensor = OAuthHealthSensor(state_path=str(p))
+        reading = sensor.read()
+        assert reading.status == "unknown"
+
+    def test_tier_ok_classifies_green(self, tmp_path: Path) -> None:
+        now = datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc)
+        path = _write_state(
+            tmp_path,
+            last_oauth_tier="ok",
+            last_oauth_check_iso=now.isoformat(),
+            last_oauth_days_left=60,
+        )
+        sensor = OAuthHealthSensor(state_path=path)
+        reading = sensor.read(now=now)
+        assert reading.status == "green"
+        assert reading.tier == "ok"
+        assert reading.days_left == 60
+
+    def test_tier_info_30d_classifies_green(self, tmp_path: Path) -> None:
+        now = datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc)
+        path = _write_state(
+            tmp_path,
+            last_oauth_tier="info_30d",
+            last_oauth_check_iso=now.isoformat(),
+            last_oauth_days_left=25,
+        )
+        sensor = OAuthHealthSensor(state_path=path)
+        reading = sensor.read(now=now)
+        # 30d window is still "green" in Cell terms — heads-up only,
+        # nothing actionable. Yellow/red kicks in at 14d/7d.
+        assert reading.status == "green"
+        assert reading.tier == "info_30d"
+
+    def test_tier_warning_14d_classifies_yellow(self, tmp_path: Path) -> None:
+        now = datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc)
+        path = _write_state(
+            tmp_path,
+            last_oauth_tier="warning_14d",
+            last_oauth_check_iso=now.isoformat(),
+            last_oauth_days_left=10,
+        )
+        sensor = OAuthHealthSensor(state_path=path)
+        reading = sensor.read(now=now)
+        assert reading.status == "yellow"
+        assert reading.tier == "warning_14d"
+
+    def test_tier_urgent_7d_classifies_red(self, tmp_path: Path) -> None:
+        now = datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc)
+        path = _write_state(
+            tmp_path,
+            last_oauth_tier="urgent_7d",
+            last_oauth_check_iso=now.isoformat(),
+            last_oauth_days_left=5,
+        )
+        sensor = OAuthHealthSensor(state_path=path)
+        reading = sensor.read(now=now)
+        assert reading.status == "red"
+        assert reading.tier == "urgent_7d"
+        assert reading.days_left == 5
+
+    def test_tier_critical_1d_classifies_red(self, tmp_path: Path) -> None:
+        now = datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc)
+        path = _write_state(
+            tmp_path,
+            last_oauth_tier="critical_1d",
+            last_oauth_check_iso=now.isoformat(),
+            last_oauth_days_left=0,
+        )
+        sensor = OAuthHealthSensor(state_path=path)
+        reading = sensor.read(now=now)
+        assert reading.status == "red"
+
+    def test_tier_expired_classifies_red(self, tmp_path: Path) -> None:
+        now = datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc)
+        path = _write_state(
+            tmp_path,
+            last_oauth_tier="critical_expired",
+            last_oauth_check_iso=now.isoformat(),
+            last_oauth_days_left=-3,
+        )
+        sensor = OAuthHealthSensor(state_path=path)
+        reading = sensor.read(now=now)
+        assert reading.status == "red"
+        assert reading.tier == "critical_expired"
+
+    def test_stale_state_classifies_yellow(self, tmp_path: Path) -> None:
+        # Watchdog last ran 25h ago — stale (>18h threshold).
+        now = datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc)
+        old = now - timedelta(hours=25)
+        path = _write_state(
+            tmp_path,
+            last_oauth_tier="ok",  # would be green if fresh
+            last_oauth_check_iso=old.isoformat(),
+            last_oauth_days_left=60,
+        )
+        sensor = OAuthHealthSensor(state_path=path)
+        reading = sensor.read(now=now)
+        # Even though tier=ok, staleness pushes it to yellow.
+        assert reading.status == "yellow"
+        assert "stale" in reading.metadata["reason"]
+
+    def test_fresh_state_within_threshold_uses_tier(self, tmp_path: Path) -> None:
+        # Watchdog ran 6h ago — fresh.
+        now = datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc)
+        recent = now - timedelta(hours=6)
+        path = _write_state(
+            tmp_path,
+            last_oauth_tier="ok",
+            last_oauth_check_iso=recent.isoformat(),
+            last_oauth_days_left=60,
+        )
+        sensor = OAuthHealthSensor(state_path=path)
+        reading = sensor.read(now=now)
+        assert reading.status == "green"
+
+    def test_state_with_no_tier_is_unknown(self, tmp_path: Path) -> None:
+        # State file exists but watchdog hasn't classified yet
+        # (e.g. backend was unreachable last run).
+        now = datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc)
+        path = _write_state(
+            tmp_path,
+            last_oauth_check_iso=now.isoformat(),
+            # NO last_oauth_tier
+        )
+        sensor = OAuthHealthSensor(state_path=path)
+        reading = sensor.read(now=now)
+        assert reading.status == "unknown"
+
+    def test_unknown_tier_value_returns_unknown(self, tmp_path: Path) -> None:
+        now = datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc)
+        path = _write_state(
+            tmp_path,
+            last_oauth_tier="some_future_tier_we_dont_know",
+            last_oauth_check_iso=now.isoformat(),
+        )
+        sensor = OAuthHealthSensor(state_path=path)
+        reading = sensor.read(now=now)
+        assert reading.status == "unknown"

--- a/scripts/drive_token_watchdog.py
+++ b/scripts/drive_token_watchdog.py
@@ -1,7 +1,17 @@
 #!/usr/bin/env python3
 """
 Drive Token Watchdog — Controlla scadenza OAuth token Google Drive e SA key.
-Invia alert Telegram 7 giorni prima della scadenza (o se già scaduto).
+
+Tiered alert system (P1-11, zero-crash audit 2026-04-29):
+    - 30 days  → INFO    (heads-up, plan re-auth)
+    - 14 days  → WARNING (schedule re-auth this week)
+    -  7 days  → URGENT  (re-auth NOW)
+    -  1 day   → CRITICAL (immediate action — Drive will break tomorrow)
+    -  expired → CRITICAL (Drive polling already broken)
+
+Idempotent: alerts only escalate when the tier *changes*. State persisted in
+`~/.agent/decisions/state/drive_oauth_watchdog.state.json` so cron can fire
+every 6h without spamming Telegram.
 
 Cron OpenClaw Air: 0 */6 * * *
 
@@ -19,8 +29,10 @@ import subprocess
 import sys
 import urllib.parse
 import urllib.request
+from dataclasses import dataclass
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
+from typing import Optional
 
 WITA = timezone(timedelta(hours=8))
 PROJECT_ROOT = Path(__file__).parent.parent
@@ -29,9 +41,33 @@ BACKEND_ENV = PROJECT_ROOT / "apps" / "backend-rag" / ".env"
 # Telegram — stessa config di expiry_alerter.py
 TELEGRAM_OWNER_CHAT_ID = "1125336968"  # Zero (archangelsamyaza) — corretto 2026-03-31
 
-# Soglie di alert
-WARN_DAYS = 7    # ⚠️ alert se scade entro 7 giorni
-SA_KEY_MAX_AGE_DAYS = 30  # ⚠️ alert se SA key > 30 giorni
+# State file for idempotency (avoid Telegram spam on every cron run)
+STATE_DIR = Path(os.path.expanduser("~/.agent/decisions/state"))
+STATE_FILE = STATE_DIR / "drive_oauth_watchdog.state.json"
+
+# Tier names (most-urgent first). Use string constants so state files written
+# by previous runs are forward-compatible.
+TIER_EXPIRED = "critical_expired"
+TIER_1_DAY = "critical_1d"
+TIER_7_DAYS = "urgent_7d"
+TIER_14_DAYS = "warning_14d"
+TIER_30_DAYS = "info_30d"
+TIER_OK = "ok"
+
+# Numerical severity for "is this a more urgent tier than last time?".
+# Higher number = more urgent. TIER_OK is the baseline (no alert).
+TIER_SEVERITY: dict[str, int] = {
+    TIER_OK: 0,
+    TIER_30_DAYS: 1,
+    TIER_14_DAYS: 2,
+    TIER_7_DAYS: 3,
+    TIER_1_DAY: 4,
+    TIER_EXPIRED: 5,
+}
+
+# SA key threshold (separate from OAuth — SA keys never expire by default,
+# but rotation policy = 30 days)
+SA_KEY_MAX_AGE_DAYS = 30
 
 # SA email (service account Drive bot)
 SA_EMAIL = "nuzantara-drive-bot@nuzantara.iam.gserviceaccount.com"
@@ -39,6 +75,153 @@ SA_EMAIL = "nuzantara-drive-bot@nuzantara.iam.gserviceaccount.com"
 VERBOSE = False
 DRY_RUN = False
 
+
+# ---------------------------------------------------------------------------
+# Tier classification — pure function, no I/O. Easy to unit-test.
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TierAlert:
+    """Result of classify_tier()."""
+    tier: str  # one of TIER_* constants
+    emoji: str
+    severity_label: str
+    message_template: str
+    days_left: int  # negative if already expired
+
+
+def classify_tier(days_left: int) -> TierAlert:
+    """
+    Map days remaining to a tier. Pure function.
+
+    days_left < 0     → TIER_EXPIRED (already expired)
+    days_left <= 1    → TIER_1_DAY    (critical, last day)
+    days_left <= 7    → TIER_7_DAYS   (urgent)
+    days_left <= 14   → TIER_14_DAYS  (warning)
+    days_left <= 30   → TIER_30_DAYS  (info heads-up)
+    days_left > 30    → TIER_OK       (no alert)
+    """
+    if days_left < 0:
+        return TierAlert(
+            tier=TIER_EXPIRED,
+            emoji="🔴",
+            severity_label="CRITICAL — EXPIRED",
+            message_template=(
+                "🔴 <b>Drive OAuth SCADUTO</b> ({abs_days} giorni fa!)\n"
+                "Drive polling NON funziona. Re-auth IMMEDIATA:\n"
+                "<code>https://kita.balizero.com/settings/integrations</code>"
+            ),
+            days_left=days_left,
+        )
+    if days_left <= 1:
+        return TierAlert(
+            tier=TIER_1_DAY,
+            emoji="🚨",
+            severity_label="CRITICAL",
+            message_template=(
+                "🚨 <b>Drive OAuth scade DOMANI</b> ({days} giorni rimasti)\n"
+                "Re-auth ORA per evitare interruzione Drive polling:\n"
+                "<code>https://kita.balizero.com/settings/integrations</code>"
+            ),
+            days_left=days_left,
+        )
+    if days_left <= 7:
+        return TierAlert(
+            tier=TIER_7_DAYS,
+            emoji="⚠️",
+            severity_label="URGENT",
+            message_template=(
+                "⚠️ <b>Drive OAuth</b> scade in <b>{days} giorni</b> (URGENT)\n"
+                "Pianifica re-auth questa settimana:\n"
+                "<code>https://kita.balizero.com/settings/integrations</code>"
+            ),
+            days_left=days_left,
+        )
+    if days_left <= 14:
+        return TierAlert(
+            tier=TIER_14_DAYS,
+            emoji="🟡",
+            severity_label="WARNING",
+            message_template=(
+                "🟡 <b>Drive OAuth</b>: <b>{days} giorni</b> alla scadenza\n"
+                "Pianifica re-auth nei prossimi giorni:\n"
+                "<code>https://kita.balizero.com/settings/integrations</code>"
+            ),
+            days_left=days_left,
+        )
+    if days_left <= 30:
+        return TierAlert(
+            tier=TIER_30_DAYS,
+            emoji="🔵",
+            severity_label="INFO",
+            message_template=(
+                "🔵 <b>Drive OAuth</b>: heads-up — {days} giorni alla scadenza\n"
+                "Re-auth diventa urgente sotto i 14 giorni."
+            ),
+            days_left=days_left,
+        )
+    return TierAlert(
+        tier=TIER_OK,
+        emoji="✅",
+        severity_label="OK",
+        message_template="",
+        days_left=days_left,
+    )
+
+
+def render_alert_text(alert: TierAlert) -> str:
+    """Format alert.message_template with days_left / abs_days."""
+    return alert.message_template.format(
+        days=alert.days_left,
+        abs_days=abs(alert.days_left),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — load/save last-alerted tier so we don't spam every 6h.
+# ---------------------------------------------------------------------------
+
+def load_state() -> dict:
+    """Load watchdog state. Returns empty dict if missing/corrupt."""
+    if not STATE_FILE.exists():
+        return {}
+    try:
+        return json.loads(STATE_FILE.read_text())
+    except Exception:
+        return {}
+
+
+def save_state(state: dict) -> None:
+    """Persist watchdog state. Best-effort (errors logged, not raised)."""
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        STATE_FILE.write_text(json.dumps(state, indent=2))
+    except Exception as e:
+        log(f"Failed to save state: {e}")
+
+
+def should_alert(current_tier: str, last_tier: Optional[str]) -> bool:
+    """
+    Return True iff current_tier is *strictly more severe* than last_tier.
+
+    Examples:
+        should_alert(TIER_30_DAYS, None)           → True   (first time ever)
+        should_alert(TIER_30_DAYS, TIER_OK)        → True   (just crossed 30d threshold)
+        should_alert(TIER_14_DAYS, TIER_30_DAYS)   → True   (escalation)
+        should_alert(TIER_14_DAYS, TIER_14_DAYS)   → False  (same tier — silent)
+        should_alert(TIER_14_DAYS, TIER_7_DAYS)    → False  (de-escalation, e.g. after re-auth)
+        should_alert(TIER_OK, TIER_7_DAYS)         → False  (recovered — no alert needed)
+    """
+    if current_tier == TIER_OK:
+        return False  # never alert on recovery
+    current_sev = TIER_SEVERITY.get(current_tier, 0)
+    last_sev = TIER_SEVERITY.get(last_tier or TIER_OK, 0)
+    return current_sev > last_sev
+
+
+# ---------------------------------------------------------------------------
+# I/O helpers (unchanged from previous version)
+# ---------------------------------------------------------------------------
 
 def log(msg: str) -> None:
     if VERBOSE:
@@ -170,6 +353,25 @@ def _check_sa_key_age() -> int | None:
         return None
 
 
+def parse_expires_at(expires_str: str) -> datetime:
+    """Parse asyncpg/SSH-stringified timestamp → tz-aware datetime."""
+    if "+" in expires_str or expires_str.endswith("Z"):
+        return datetime.fromisoformat(expires_str.replace("Z", "+00:00"))
+    # Naive datetime — assume UTC
+    return datetime.fromisoformat(expires_str).replace(tzinfo=timezone.utc)
+
+
+def compute_days_left(expires_at: datetime, now_utc: datetime | None = None) -> int:
+    """Days remaining until expiry. Negative if already expired."""
+    if now_utc is None:
+        now_utc = datetime.now(timezone.utc)
+    return (expires_at - now_utc).days
+
+
+# ---------------------------------------------------------------------------
+# Main flow
+# ---------------------------------------------------------------------------
+
 def main() -> int:
     env = _load_env()
     bot_token = os.environ.get("TELEGRAM_BOT_TOKEN") or env.get("TELEGRAM_BOT_TOKEN", "")
@@ -179,60 +381,86 @@ def main() -> int:
     now_wita = now_utc.astimezone(WITA)
     timestamp = now_wita.strftime("%Y-%m-%d %H:%M WITA")
 
-    # --- Check 1: Drive OAuth token ---
+    state = load_state()
+    last_oauth_tier: Optional[str] = state.get("last_oauth_tier")
+    last_sa_alert_age: Optional[int] = state.get("last_sa_alert_age")
+
+    # --- Check 1: Drive OAuth token with tier system ---
     log("Controllo Drive OAuth token...")
     token_data = _check_drive_token_via_fly()
 
+    new_oauth_tier: Optional[str] = None  # set if classification succeeds
+    new_oauth_days_left: Optional[int] = None  # last computed days_left (sensor input)
+
     if token_data is None:
+        # Connection failure — separate from tier system; always alert.
         alerts.append(
             "⚠️ <b>Drive Watchdog</b>: impossibile connettersi al backend Fly.io\n"
             "Verifica che <code>fly ssh</code> funzioni."
         )
     elif token_data.get("expires_at") is None:
-        alerts.append(
-            "🔴 <b>Drive OAuth</b>: NESSUN TOKEN in DB\n"
-            "Drive polling disabilitato. Esegui re-auth:\n"
-            "<code>https://kita.balizero.com/settings/integrations</code>"
-        )
+        # Same effect as expired — fold into TIER_EXPIRED with synthetic message.
+        new_oauth_tier = TIER_EXPIRED
+        if should_alert(new_oauth_tier, last_oauth_tier):
+            alerts.append(
+                "🔴 <b>Drive OAuth</b>: NESSUN TOKEN in DB\n"
+                "Drive polling disabilitato. Esegui re-auth:\n"
+                "<code>https://kita.balizero.com/settings/integrations</code>"
+            )
     else:
         expires_str = token_data["expires_at"]
         log(f"expires_at raw: {expires_str}")
         try:
-            # asyncpg restituisce datetime — ma via ssh diventa stringa
-            if "+" in expires_str or expires_str.endswith("Z"):
-                expires_dt = datetime.fromisoformat(expires_str.replace("Z", "+00:00"))
-            else:
-                # Naive datetime — assume UTC
-                expires_dt = datetime.fromisoformat(expires_str).replace(tzinfo=timezone.utc)
-            days_left = (expires_dt - now_utc).days
+            expires_dt = parse_expires_at(expires_str)
+            days_left = compute_days_left(expires_dt, now_utc)
             log(f"Token scade in {days_left} giorni")
-            if days_left < 0:
-                alerts.append(
-                    f"🔴 <b>Drive OAuth SCADUTO</b> ({abs(days_left)} giorni fa!)\n"
-                    "Drive polling non funziona. Re-auth immediata:\n"
-                    "<code>https://kita.balizero.com/settings/integrations</code>"
-                )
-            elif days_left < WARN_DAYS:
-                alerts.append(
-                    f"⚠️ <b>Drive OAuth</b> scade in <b>{days_left} giorni</b>\n"
-                    "Pianifica re-auth prima che scada:\n"
-                    "<code>https://kita.balizero.com/settings/integrations</code>"
+
+            tier_alert = classify_tier(days_left)
+            new_oauth_tier = tier_alert.tier
+            new_oauth_days_left = days_left
+
+            if should_alert(new_oauth_tier, last_oauth_tier):
+                alerts.append(render_alert_text(tier_alert))
+                log(
+                    f"Tier transition: {last_oauth_tier or 'OK'} → {new_oauth_tier} "
+                    f"({tier_alert.severity_label})"
                 )
             else:
-                log(f"Token OK — scade in {days_left} giorni")
+                log(
+                    f"Tier {new_oauth_tier} (last: {last_oauth_tier or 'OK'}) — "
+                    f"no alert (idempotent)"
+                )
         except Exception as e:
             log(f"Parse expires_at fallito: {e}")
             alerts.append(f"⚠️ <b>Drive Watchdog</b>: errore parsing expires_at: {e}")
 
-    # --- Check 2: SA key age ---
+    # --- Check 2: SA key age (kept simple — no tier system, single threshold) ---
     log("Controllo SA key age...")
     sa_age = _check_sa_key_age()
+    new_sa_alert_age: Optional[int] = None
     if sa_age is not None and sa_age > SA_KEY_MAX_AGE_DAYS:
-        alerts.append(
-            f"⚠️ <b>SA Key</b> age: {sa_age} giorni (soglia: {SA_KEY_MAX_AGE_DAYS})\n"
-            "Rotazione consigliata: Google Cloud Console → IAM → Service Accounts\n"
-            f"<code>{SA_EMAIL}</code>"
-        )
+        # Idempotent: only alert if age went UP since last alert (or no prev alert).
+        if last_sa_alert_age is None or sa_age > last_sa_alert_age:
+            alerts.append(
+                f"⚠️ <b>SA Key</b> age: {sa_age} giorni (soglia: {SA_KEY_MAX_AGE_DAYS})\n"
+                "Rotazione consigliata: Google Cloud Console → IAM → Service Accounts\n"
+                f"<code>{SA_EMAIL}</code>"
+            )
+            new_sa_alert_age = sa_age
+        else:
+            new_sa_alert_age = last_sa_alert_age
+
+    # --- Persist state (best-effort) ---
+    if not DRY_RUN:
+        new_state = dict(state)
+        if new_oauth_tier is not None:
+            new_state["last_oauth_tier"] = new_oauth_tier
+            new_state["last_oauth_check_iso"] = now_utc.isoformat()
+            if new_oauth_days_left is not None:
+                new_state["last_oauth_days_left"] = new_oauth_days_left
+        if new_sa_alert_age is not None:
+            new_state["last_sa_alert_age"] = new_sa_alert_age
+        save_state(new_state)
 
     # --- Invia alerts ---
     if alerts:


### PR DESCRIPTION
Track B independent — agent-C wave2-mio. P1-11 from zero-crash audit 2026-04-29.

## Summary
- Replace single 7-day OAuth-expiry threshold with **4 tiers**: 30 (info) / 14 (warning) / 7 (urgent) / 1 (critical) / expired (critical).
- Idempotent: each tier alerts only on tier *transition* (escalation), not every 6h cron run. State persisted in `~/.agent/decisions/state/drive_oauth_watchdog.state.json`.
- New **Cell `OAuthHealthSensor`** consumes the same state file and exposes green/yellow/red to the Cell pulse loop without an extra DB / fly-ssh round-trip.

## Tier table

| `days_left`   | Tier               | Telegram severity | Cell color |
|---------------|--------------------|-------------------|------------|
| > 30          | `ok`               | (silent)          | green      |
| 16..30        | `info_30d`         | INFO 🔵           | green      |
| 8..14         | `warning_14d`      | WARNING 🟡        | yellow     |
| 2..7          | `urgent_7d`        | URGENT ⚠️         | red        |
| 0..1          | `critical_1d`      | CRITICAL 🚨       | red        |
| < 0           | `critical_expired` | CRITICAL 🔴       | red        |

## Files
- `scripts/drive_token_watchdog.py` — tier classification (`classify_tier`), idempotency (`should_alert`), state load/save. Original `_check_drive_token_via_fly`, `_check_sa_key_age`, `_send_telegram` paths unchanged.
- `apps/cell/cell/sensors/oauth_health_sensor.py` (NEW) — `OAuthHealthSensor.read() → OAuthHealthReading(status, tier, days_left, last_check_iso, metadata)`. Stale-state (>18h) returns yellow with reason="stale" so visibility loss is distinguishable from "definitely fine".
- `apps/backend-rag/backend/tests/unit/scripts/test_drive_watchdog_tiers.py` (NEW) — 38 unit tests.
- `apps/cell/tests/test_oauth_health_sensor.py` (NEW) — 12 unit tests.

## Sensor location decision
Cell sensor lives under `apps/cell/cell/sensors/` (where every other sensor lives — `database_sensor.py`, `cron_sensor.py`, `vercel_sensor.py`, etc.). The `packages/cell-core/cell_core/` package has no `sensors/` directory; the briefing's failure-mode guidance ("Cell sensor structure mismatch: document in PR") applies. Wiring into `apps/cell/cell/main.py`'s `PulseLoop` is intentionally **deferred to a follow-up PR** — the sensor is a self-contained, fully-tested primitive; coupling it to the pulse loop needs its own QA window.

## Test plan
- [x] 38 watchdog-tier tests pass (`pytest apps/backend-rag/backend/tests/unit/scripts/test_drive_watchdog_tiers.py -v`)
- [x] 12 Cell-sensor tests pass (`pytest apps/cell/tests/test_oauth_health_sensor.py -v`)
- [x] Manual mock simulation: each tier (60/30/14/7/1/0/-1 days) renders the expected Telegram message; idempotency (no spam at same tier, no spam after re-auth) verified.
- [ ] Real Drive simulation deferred — drive-poll cron Pro DISABLED per memory `unresolved_2026_04_29` (broken-pipe, separate fix). Watchdog runs from Air, unaffected; tier system activates on next 6h cron firing.

## Off-limits respected
No changes to `prompts/zantara_core.py`, `fly.toml`, `.env*`, or OAuth refresh logic. Pure monitoring layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)