### PR TITLE
feat(p1-10): lint useTranslation() without I18nProvider ancestor

### DIFF
--- a/.github/workflows/lint-i18n-providers.yml
+++ b/.github/workflows/lint-i18n-providers.yml
@@ -1,0 +1,31 @@
+name: Lint i18n providers
+
+# Catches the white-screen regression pattern from PR #273: a component
+# imports useTranslation() under apps/mouth/src/app/ without an ancestor
+# I18nProvider in its layout chain. Refs: P1-10 in
+# docs/audits/2026-04-29-zero-crash-audit/09_intervention_plan.md.
+
+on:
+  pull_request:
+    paths:
+      - 'apps/mouth/src/app/**'
+      - 'apps/mouth/src/i18n/**'
+      - 'scripts/lint_i18n_providers.sh'
+      - 'tests/lint/test_i18n_providers.sh'
+      - '.github/workflows/lint-i18n-providers.yml'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
+      - name: Run synthetic test suite
+        run: bash tests/lint/test_i18n_providers.sh
+
+      - name: Run lint on apps/mouth/src/app
+        run: bash scripts/lint_i18n_providers.sh

--- a/scripts/lint_i18n_providers.sh
+++ b/scripts/lint_i18n_providers.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# lint_i18n_providers.sh
+#
+# Catches the white-screen regression from PR #273: a component imports
+# `useTranslation()` from `@/i18n` (or relative path), but no ancestor
+# layout (or the file itself) wraps children in `<I18nProvider>`. At
+# runtime React throws and the page goes blank.
+#
+# For every .ts/.tsx file under the lint root that calls `useTranslation()`
+# (excluding type-only imports and commented-out lines), walk the layout
+# chain from the file's directory up to the lint root. If neither the
+# file itself nor any ancestor layout.tsx contains `<I18nProvider`, that
+# is a violation.
+#
+# Exit 1 on any violation, 0 otherwise. Designed to run in <5s on the
+# full apps/mouth/ tree.
+#
+# Known limitation: aliased imports such as
+#   `import { useTranslation as useT } from "@/i18n"` followed by `useT()`
+# are NOT detected — this lint matches the literal `useTranslation(`
+# token. There are zero such aliases in the codebase today. If the
+# pattern becomes common, swap to a TypeScript AST-based check.
+#
+# Refs: docs/audits/2026-04-29-zero-crash-audit/09_intervention_plan.md (P1-10)
+
+set -euo pipefail
+
+# --- args ---------------------------------------------------------------
+ROOT_DIR=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --root)
+      ROOT_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: lint_i18n_providers.sh [--root <dir>]
+
+Scans <dir> for .ts/.tsx files that call useTranslation() without an
+ancestor I18nProvider. Defaults to apps/mouth/src/app relative to the
+script's repository root.
+
+Options:
+  --root <dir>   Override the lint root (used by tests/CI).
+  -h, --help     Show this help.
+EOF
+      exit 0
+      ;;
+    *)
+      echo "lint_i18n_providers: unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$ROOT_DIR" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+  ROOT_DIR="$REPO_ROOT/apps/mouth/src/app"
+fi
+
+if [[ ! -d "$ROOT_DIR" ]]; then
+  echo "lint_i18n_providers: root not found: $ROOT_DIR" >&2
+  exit 2
+fi
+
+ROOT_DIR="$(cd "$ROOT_DIR" && pwd)"
+
+# --- dependencies -------------------------------------------------------
+if ! command -v rg >/dev/null 2>&1; then
+  echo "lint_i18n_providers: ripgrep (rg) is required" >&2
+  exit 2
+fi
+
+# --- helpers ------------------------------------------------------------
+
+# Pattern matches a real call site `useTranslation(` that is NOT
+# preceded only by whitespace + `//` (line comment). Also excludes
+# `import type { ... } from "@/i18n"` lines because they never resolve
+# to a runtime call. We do this in two stages: rg finds candidates,
+# then we filter out comments and type-only imports.
+USE_TRANSLATION_RE='useTranslation[[:space:]]*\('
+PROVIDER_RE='<I18nProvider'
+TYPE_IMPORT_RE='^[[:space:]]*import[[:space:]]+type[[:space:]]'
+LINE_COMMENT_RE='^[[:space:]]*//'
+
+# file_self_provides <file> -> 0 if file contains <I18nProvider, else 1
+file_self_provides() {
+  local file="$1"
+  rg --quiet --no-config --fixed-strings "$PROVIDER_RE" "$file"
+}
+
+# layout_chain_provides <dir> -> 0 if any ancestor layout.tsx contains
+# <I18nProvider, walking up from <dir> until ROOT_DIR's parent. We stop
+# at ROOT_DIR (inclusive) because anything outside the lint root is
+# irrelevant — Next.js doesn't read layouts above the app/ root.
+layout_chain_provides() {
+  local dir="$1"
+  while :; do
+    local layout="$dir/layout.tsx"
+    if [[ -f "$layout" ]]; then
+      if rg --quiet --no-config --fixed-strings "$PROVIDER_RE" "$layout"; then
+        return 0
+      fi
+    fi
+    if [[ "$dir" == "$ROOT_DIR" ]]; then
+      return 1
+    fi
+    local parent
+    parent="$(dirname "$dir")"
+    if [[ "$parent" == "$dir" ]]; then
+      return 1
+    fi
+    dir="$parent"
+  done
+}
+
+# is_real_call_site <line_text> -> 0 if the line is a real
+# `useTranslation(` call site (not a type-only import, not a comment).
+is_real_call_site() {
+  local text="$1"
+  [[ "$text" =~ $TYPE_IMPORT_RE ]] && return 1
+  [[ "$text" =~ $LINE_COMMENT_RE ]] && return 1
+  local trimmed
+  trimmed="${text#"${text%%[![:space:]]*}"}"
+  [[ "$trimmed" == \** || "$trimmed" == /\** ]] && return 1
+  return 0
+}
+
+# count_call_sites <file>: increments $total_checked for each real
+# call site found in <file>.
+count_call_sites() {
+  local f="$1"
+  while IFS= read -r match; do
+    [[ -z "$match" ]] && continue
+    if is_real_call_site "${match#*:}"; then
+      total_checked=$((total_checked + 1))
+    fi
+  done < <(rg --no-config --line-number --no-heading \
+    -e "$USE_TRANSLATION_RE" "$f" 2>/dev/null || true)
+}
+
+# --- scan ---------------------------------------------------------------
+
+# rg finds every line in a .ts/.tsx file (excluding typical build dirs
+# and node_modules) that contains `useTranslation(`. We then post-filter
+# to drop comment lines and type-only imports.
+violations=0
+total_checked=0
+
+# rg --files-with-matches gives one path per line. We disable globbing
+# in the for-loop and read line-by-line so paths with spaces survive.
+# (NUL-delimited mode would be cleaner but mapfile -d '' is bash 4+,
+# and macOS still ships bash 3.2 — keep the script portable so it runs
+# both in CI and on dev machines.)
+hit_files_tmp="$(mktemp)"
+trap 'rm -f "$hit_files_tmp"' EXIT
+rg \
+  --no-config \
+  --files-with-matches \
+  --glob '*.ts' \
+  --glob '*.tsx' \
+  --glob '!**/node_modules/**' \
+  --glob '!**/.next/**' \
+  --glob '!**/dist/**' \
+  --glob '!**/build/**' \
+  --glob '!api/**' \
+  -e "$USE_TRANSLATION_RE" \
+  "$ROOT_DIR" > "$hit_files_tmp" 2>/dev/null || true
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  # Skip the I18nProvider definition site — it exports the hook + provider,
+  # but is never itself rendered as a route component.
+  base="$(basename "$file")"
+  parent_dir="$(dirname "$file")"
+  if [[ "$base" == "index.tsx" || "$base" == "index.ts" ]]; then
+    if [[ "$parent_dir" == */i18n ]]; then
+      continue
+    fi
+  fi
+
+  # Provider in scope (self or ancestor)? Just tally call sites for the
+  # final stats and move on.
+  if file_self_provides "$file" || layout_chain_provides "$parent_dir"; then
+    count_call_sites "$file"
+    continue
+  fi
+
+  # No provider. Emit a violation per real call site.
+  while IFS= read -r match; do
+    [[ -z "$match" ]] && continue
+    line_no="${match%%:*}"
+    line_text="${match#*:}"
+    if ! is_real_call_site "$line_text"; then
+      continue
+    fi
+    total_checked=$((total_checked + 1))
+    printf '%s:%s: useTranslation() without <I18nProvider> ancestor\n' \
+      "$file" "$line_no"
+    violations=$((violations + 1))
+  done < <(rg --no-config --line-number --no-heading \
+    -e "$USE_TRANSLATION_RE" "$file" 2>/dev/null || true)
+done < "$hit_files_tmp"
+
+if [[ "$violations" -gt 0 ]]; then
+  printf '\nlint_i18n_providers: %d violation(s) found (checked %d call site(s) under %s)\n' \
+    "$violations" "$total_checked" "$ROOT_DIR" >&2
+  exit 1
+fi
+
+printf 'lint_i18n_providers: OK (%d call site(s) checked under %s)\n' \
+  "$total_checked" "$ROOT_DIR"
+exit 0

--- a/tests/lint/test_i18n_providers.sh
+++ b/tests/lint/test_i18n_providers.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# test_i18n_providers.sh — TDD harness for scripts/lint_i18n_providers.sh.
+#
+# Builds synthetic mini-trees that mimic apps/mouth/src/app/ shape,
+# runs the lint at them, and asserts the exit code + violation count.
+# All scratch state lives under a temp dir that is removed on exit.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LINT="$REPO_ROOT/scripts/lint_i18n_providers.sh"
+
+if [[ ! -x "$LINT" ]]; then
+  echo "FAIL: lint script not executable at $LINT" >&2
+  exit 2
+fi
+
+TMP="$(mktemp -d -t lint_i18n_test.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+
+assert_exit() {
+  local name="$1"
+  local expected="$2"
+  local root="$3"
+  local actual=0
+  local out
+  out="$(bash "$LINT" --root "$root" 2>&1)" || actual=$?
+  if [[ "$actual" -eq "$expected" ]]; then
+    pass=$((pass + 1))
+    printf 'PASS  %s (exit=%d)\n' "$name" "$actual"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL  %s: expected exit=%d, got exit=%d\n' "$name" "$expected" "$actual"
+    printf '      output:\n%s\n' "$out" | sed 's/^/      /'
+  fi
+}
+
+# --- case 1: provider in route group layout, descendant uses hook -- OK ---
+case1="$TMP/case1"
+mkdir -p "$case1/(blog)"
+cat > "$case1/(blog)/layout.tsx" <<'EOF'
+import { I18nProvider } from "@/i18n";
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <I18nProvider>{children}</I18nProvider>;
+}
+EOF
+cat > "$case1/(blog)/page.tsx" <<'EOF'
+"use client";
+import { useTranslation } from "@/i18n";
+export default function Page() {
+  const { t } = useTranslation();
+  return <div>{t("hello")}</div>;
+}
+EOF
+assert_exit "case1: ancestor layout has provider"  0  "$case1"
+
+# --- case 2: descendant uses hook, no provider in chain -- VIOLATION ------
+case2="$TMP/case2"
+mkdir -p "$case2/(broken)"
+cat > "$case2/(broken)/layout.tsx" <<'EOF'
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <div>{children}</div>;
+}
+EOF
+cat > "$case2/(broken)/page.tsx" <<'EOF'
+"use client";
+import { useTranslation } from "@/i18n";
+export default function Page() {
+  const { t } = useTranslation();
+  return <div>{t("hello")}</div>;
+}
+EOF
+assert_exit "case2: missing provider triggers VIOLATION"  1  "$case2"
+
+# --- case 3: page self-wraps in <I18nProvider> -- OK ----------------------
+case3="$TMP/case3"
+mkdir -p "$case3/portal/login"
+cat > "$case3/portal/login/page.tsx" <<'EOF'
+"use client";
+import { I18nProvider, useTranslation } from "@/i18n";
+function Inner() {
+  const { t } = useTranslation();
+  return <div>{t("hi")}</div>;
+}
+export default function Page() {
+  return <I18nProvider><Inner /></I18nProvider>;
+}
+EOF
+assert_exit "case3: self-provided page is OK"  0  "$case3"
+
+# --- case 4: type-only import is NOT a call -- OK -------------------------
+case4="$TMP/case4"
+mkdir -p "$case4/(group)"
+cat > "$case4/(group)/page.tsx" <<'EOF'
+import type { useTranslation } from "@/i18n";
+export default function Page() {
+  return <div>noop</div>;
+}
+EOF
+assert_exit "case4: type-only import is ignored"  0  "$case4"
+
+# --- case 5: commented-out useTranslation call -- OK ----------------------
+case5="$TMP/case5"
+mkdir -p "$case5/(group)"
+cat > "$case5/(group)/page.tsx" <<'EOF'
+export default function Page() {
+  // const { t } = useTranslation();
+  return <div>noop</div>;
+}
+EOF
+assert_exit "case5: commented-out call is ignored"  0  "$case5"
+
+# --- case 6: nested groups, ancestor (not direct parent) has provider -----
+case6="$TMP/case6"
+mkdir -p "$case6/portal/(authenticated)/dashboard"
+cat > "$case6/portal/layout.tsx" <<'EOF'
+import { I18nProvider } from "@/i18n";
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <I18nProvider>{children}</I18nProvider>;
+}
+EOF
+cat > "$case6/portal/(authenticated)/layout.tsx" <<'EOF'
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <section>{children}</section>;
+}
+EOF
+cat > "$case6/portal/(authenticated)/dashboard/page.tsx" <<'EOF'
+"use client";
+import { useTranslation } from "@/i18n";
+export default function Page() {
+  const { t } = useTranslation();
+  return <div>{t("hi")}</div>;
+}
+EOF
+assert_exit "case6: deep ancestor provides — chain walk reaches it"  0  "$case6"
+
+# --- case 7: deep descendant in route group with NO provider --- VIOLATION
+case7="$TMP/case7"
+mkdir -p "$case7/(marketing)/section/sub"
+cat > "$case7/(marketing)/layout.tsx" <<'EOF'
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <div>{children}</div>;
+}
+EOF
+cat > "$case7/(marketing)/section/sub/page.tsx" <<'EOF'
+"use client";
+import { useTranslation } from "@/i18n";
+export default function Page() {
+  const { t } = useTranslation();
+  return <div>{t("hi")}</div>;
+}
+EOF
+assert_exit "case7: deep descendant w/o provider — VIOLATION"  1  "$case7"
+
+# --- case 8: empty tree -- OK ---------------------------------------------
+case8="$TMP/case8"
+mkdir -p "$case8/(empty)"
+cat > "$case8/(empty)/layout.tsx" <<'EOF'
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <div>{children}</div>;
+}
+EOF
+assert_exit "case8: tree without any useTranslation is OK"  0  "$case8"
+
+# --- summary --------------------------------------------------------------
+total=$((pass + fail))
+printf '\n--------\n%d/%d passed\n' "$pass" "$total"
+if [[ "$fail" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- New `scripts/lint_i18n_providers.sh` + CI workflow `.github/workflows/lint-i18n-providers.yml` block any PR introducing `useTranslation()` under `apps/mouth/src/app/` when neither the file itself nor any ancestor `layout.tsx` wraps children in `<I18nProvider>`.
- Catches the white-screen regression pattern from PR #273 at PR-check time, ~3-5s in CI, ~67ms locally.
- Self-provided pattern (file wraps its own JSX in `<I18nProvider>`, as `portal/login-upgraded/page.tsx` does today) is treated as OK.

## What changed

- `scripts/lint_i18n_providers.sh` — bash 3.2 compatible (works on macOS dev machines too); `--root <dir>` override for tests/CI.
- `tests/lint/test_i18n_providers.sh` — 8 synthetic cases: provider in chain, missing provider, self-provided, type-only import, commented-out call, deep nesting (provider 2 levels up), deep descendant w/o provider, empty tree.
- `.github/workflows/lint-i18n-providers.yml` — runs on PRs touching `apps/mouth/src/app/`, `apps/mouth/src/i18n/`, the script, the test harness, or this workflow itself.

## Verification

- `bash tests/lint/test_i18n_providers.sh` → 8/8 PASS
- `bash scripts/lint_i18n_providers.sh` on current `main` → exit 0, 3 call sites checked under `apps/mouth/src/app`
- Plant 3 violation patterns (unwrapped `(marketing)/`, deep-nested `(assessment)/sub/`, `portal/(authenticated)/`) → all 3 caught, exit 1

## Known limitation

Aliased imports `import { useTranslation as useT } from "@/i18n"` followed by `useT()` are NOT detected (zero such aliases in the codebase today; if the pattern becomes common, swap to a TypeScript AST-based check). Documented in the script preamble.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, `bash scripts/lint_i18n_providers.sh` on `main` exits 0

## Refs

- `docs/audits/2026-04-29-zero-crash-audit/09_intervention_plan.md` (P1-10)
- White-screen regression pattern: PR #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)