### PR TITLE
feat(p1-7): NLM pipelines auto-recovery

### DIFF
--- a/scripts/system_doctor.py
+++ b/scripts/system_doctor.py
@@ -18,11 +18,13 @@ import re
 import subprocess
 import sys
 import time
+import urllib.parse
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
+from typing import Callable
 
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
@@ -106,6 +108,30 @@ STALENESS = {
 }
 
 VERBOSE = False
+
+# --- P1-7 NLM auto-recovery constants ---
+# State files written by NLM pipelines to ~/.agent/decisions/state/<job>.last.json
+# Format: {"job": "...", "ts": <unix_epoch>, "status": "ok"|"failed", "host": "..."}.
+# Mapping is explicit (not regex) because nb1_daily_refresh dispatches via
+# nlm_bridge, not nb1_pipeline (which doesn't exist). None = "known but no
+# rerun handle" (heartbeat / umbrella) — these are skipped silently.
+NLM_PIPELINE_MODULES: dict[str, str | None] = {
+    "nlm_nb1_daily_refresh":  "apps.evaluator.nlm_deep_research.nlm_bridge",
+    "nlm_nb3_company_setup":  "apps.evaluator.nlm_deep_research.nb3_pipeline",
+    "nlm_nb4_tax_fiscal":     "apps.evaluator.nlm_deep_research.nb4_pipeline",
+    "nlm_nb5_property":       "apps.evaluator.nlm_deep_research.nb5_pipeline",
+    "nlm_nb6_ops_compliance": "apps.evaluator.nlm_deep_research.nb6_pipeline",
+    "nlm_nb7_editorial":      "apps.evaluator.nlm_deep_research.nb7_pipeline",
+    "nlm_nb8_expat_life":     "apps.evaluator.nlm_deep_research.nb8_pipeline",
+    "nlm_nb10_team_guides":   "apps.evaluator.nlm_deep_research.nb10_pipeline",
+    "nlm_bridge":             None,
+    "nlm_deep_research":      None,
+    "weekly_report":          None,
+}
+NLM_STATE_DIR = Path.home() / ".agent" / "decisions" / "state"
+NLM_STALENESS_HOURS = 24
+NLM_RERUN_TIMEOUT_S = 300
+NLM_TELEGRAM_OWNER_CHAT_ID = "1125336968"
 
 
 def log(msg: str) -> None:
@@ -1308,6 +1334,170 @@ def fix_log_rotation(dry_run: bool) -> list[AutoFix]:
     return fixes
 
 
+# --- P1-7 NLM auto-recovery ---
+
+def _nlm_send_telegram_warning(message: str, *, chat_id: str = NLM_TELEGRAM_OWNER_CHAT_ID) -> bool:
+    """Telegram alert for NLM auto-recovery failures.
+
+    Reuses the urllib.request POST pattern from scripts/expiry_alerter.py
+    (_send_telegram). Plain text — no parse_mode — to avoid escaping issues
+    with subprocess stderr that may contain Markdown/HTML metacharacters.
+    Returns True on send, False on missing-token or HTTP error.
+    """
+    bot_token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+    if not bot_token:
+        secrets = Path.home() / ".nuzantara-secrets.env"
+        if secrets.exists():
+            for line in secrets.read_text().splitlines():
+                if line.startswith("TELEGRAM_BOT_TOKEN="):
+                    bot_token = line.split("=", 1)[1].strip().strip('"').strip("'")
+                    break
+    if not bot_token:
+        log("nlm_recovery: no TELEGRAM_BOT_TOKEN — alert skipped")
+        return False
+
+    try:
+        data = urllib.parse.urlencode({"chat_id": chat_id, "text": message}).encode()
+        urllib.request.urlopen(
+            f"https://api.telegram.org/bot{bot_token}/sendMessage",
+            data, timeout=10,
+        )
+        return True
+    except Exception as e:
+        log(f"nlm_recovery: telegram failed: {type(e).__name__}: {e}")
+        return False
+
+
+def _nlm_pipeline_name_from_state_file(path: Path) -> str:
+    """`nlm_nb6_ops_compliance.last.json` -> `nlm_nb6_ops_compliance`."""
+    name = path.name
+    if name.endswith(".last.json"):
+        return name[: -len(".last.json")]
+    return path.stem
+
+
+def check_nlm_pipelines_stuck(
+    state_dir: Path | None = None,
+    *,
+    now_fn: Callable[[], float] = time.time,
+    max_age_hours: int = NLM_STALENESS_HOURS,
+) -> dict:
+    """Detect NLM pipelines stuck >24h or with status=='failed' and attempt rerun.
+
+    Walks ``state_dir`` for ``nlm_*.last.json`` files. For each known pipeline:
+    - if ts<=0 (never run) OR status=='ok' AND age within max_age_hours: skip
+    - else: subprocess.run([sys.executable, '-m', <module>], timeout=300)
+        - returncode 0 -> recovered
+        - returncode != 0 OR TimeoutExpired -> failed + Telegram alert
+    Pipelines without a module mapping (heartbeat / umbrella) are skipped.
+
+    Idempotent (healthy short-circuits, no state writes here). Telegram alert
+    fires only on rerun failure to avoid spam. Returns dict with
+    ``stuck/recovered/failed/skipped/errors`` keys, used by ``--check-nlm``
+    CLI and as raw input for system_doctor's collector pipeline.
+
+    24h threshold: NB-1 daily refresh expects a beat every 24h; tighter
+    yields false positives during normal night-window OpenClaw runs, looser
+    lets a real failure linger an extra day.
+    """
+    if state_dir is None:
+        state_dir = NLM_STATE_DIR
+
+    result: dict = {
+        "stuck": [], "recovered": [], "failed": [],
+        "skipped": [], "errors": {},
+    }
+
+    if not state_dir.exists() or not state_dir.is_dir():
+        return result
+
+    now = now_fn()
+
+    for path in sorted(state_dir.glob("nlm_*.last.json")):
+        pipeline = _nlm_pipeline_name_from_state_file(path)
+
+        if pipeline not in NLM_PIPELINE_MODULES:
+            result["skipped"].append(pipeline)
+            continue
+
+        try:
+            state = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError) as e:
+            result["errors"][pipeline] = f"{type(e).__name__}: {e}"
+            continue
+
+        ts = state.get("ts", 0)
+        status = state.get("status", "")
+        try:
+            ts_num = float(ts)
+        except (TypeError, ValueError):
+            result["errors"][pipeline] = f"invalid ts: {ts!r}"
+            continue
+
+        if ts_num <= 0:
+            result["skipped"].append(pipeline)
+            continue
+
+        age_hours = (now - ts_num) / 3600.0
+        is_stuck = age_hours > max_age_hours
+        is_failed = status == "failed"
+
+        if not (is_stuck or is_failed):
+            result["skipped"].append(pipeline)
+            continue
+
+        module_path = NLM_PIPELINE_MODULES.get(pipeline)
+        if module_path is None:
+            result["skipped"].append(pipeline)
+            continue
+
+        result["stuck"].append(pipeline)
+
+        cmd = [sys.executable, "-m", module_path]
+        try:
+            proc = subprocess.run(
+                cmd, capture_output=True, text=True,
+                timeout=NLM_RERUN_TIMEOUT_S,
+                cwd=str(PROJECT_ROOT),
+            )
+        except subprocess.TimeoutExpired as exc:
+            result["failed"].append(pipeline)
+            stderr_tail = (exc.stderr or "")[-500:] if isinstance(exc.stderr, str) else ""
+            _nlm_send_telegram_warning(
+                f"[NLM auto-recovery FAILED] {pipeline}\n"
+                f"Age: {age_hours:.1f}h since last success\n"
+                f"Rerun: timeout after {NLM_RERUN_TIMEOUT_S}s\n"
+                f"Stderr: {stderr_tail}\n"
+                f"Run: python scripts/system_doctor.py --check-nlm"
+            )
+            continue
+        except Exception as e:
+            result["failed"].append(pipeline)
+            result["errors"][pipeline] = f"{type(e).__name__}: {e}"
+            _nlm_send_telegram_warning(
+                f"[NLM auto-recovery FAILED] {pipeline}\n"
+                f"Age: {age_hours:.1f}h since last success\n"
+                f"Rerun: subprocess error: {type(e).__name__}: {e}\n"
+                f"Run: python scripts/system_doctor.py --check-nlm"
+            )
+            continue
+
+        if proc.returncode == 0:
+            result["recovered"].append(pipeline)
+        else:
+            result["failed"].append(pipeline)
+            stderr = proc.stderr or proc.stdout or ""
+            _nlm_send_telegram_warning(
+                f"[NLM auto-recovery FAILED] {pipeline}\n"
+                f"Age: {age_hours:.1f}h since last success\n"
+                f"Rerun: returncode={proc.returncode}, timeout={NLM_RERUN_TIMEOUT_S}s\n"
+                f"Stderr: {stderr[-500:]}\n"
+                f"Run: python scripts/system_doctor.py --check-nlm"
+            )
+
+    return result
+
+
 # --- Report formatting ---
 
 def build_telegram_summary(report: DoctorReport) -> str:
@@ -1369,8 +1559,17 @@ def main() -> None:
     parser.add_argument("--dry-run", action="store_true", help="Read-only, no auto-fixes")
     parser.add_argument("--verbose", action="store_true", help="Debug output to stderr")
     parser.add_argument("--notify-telegram", action="store_true", help="Send Telegram alert on issues (used by cron)")
+    parser.add_argument("--check-nlm", action="store_true",
+                        help="Run only NLM pipeline auto-recovery (P1-7) and print result JSON")
     args = parser.parse_args()
     VERBOSE = args.verbose
+
+    if args.check_nlm:
+        state_dir_env = os.environ.get("NLM_STATE_DIR")
+        state_dir = Path(state_dir_env) if state_dir_env else NLM_STATE_DIR
+        nlm_result = check_nlm_pipelines_stuck(state_dir=state_dir, now_fn=time.time)
+        print(json.dumps(nlm_result, indent=2, default=str))
+        return
 
     log("Starting System Doctor...")
     now = datetime.now(WITA)

--- a/tests/scripts/test_system_doctor_nlm.py
+++ b/tests/scripts/test_system_doctor_nlm.py
@@ -1,0 +1,263 @@
+"""Tests for system_doctor.check_nlm_pipelines_stuck() — P1-7 NLM auto-recovery."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+import system_doctor as sd  # noqa: E402
+
+
+def _write_state(state_dir: Path, name: str, ts: int, status: str = "ok") -> Path:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    p = state_dir / f"{name}.last.json"
+    p.write_text(json.dumps({
+        "job": name.replace("_", "-"),
+        "ts": ts,
+        "status": status,
+        "host": "test-host",
+    }))
+    return p
+
+
+def _ok_run(stdout: str = "", stderr: str = "") -> SimpleNamespace:
+    return SimpleNamespace(returncode=0, stdout=stdout, stderr=stderr)
+
+
+def _fail_run(stderr: str = "boom", returncode: int = 1) -> SimpleNamespace:
+    return SimpleNamespace(returncode=returncode, stdout="", stderr=stderr)
+
+
+@pytest.fixture
+def now_ts() -> int:
+    return 1_800_000_000
+
+
+def test_healthy_pipeline_skipped(tmp_path, now_ts):
+    """ts within 24h AND status=ok → skipped, no rerun, no telegram."""
+    _write_state(tmp_path, "nlm_nb6_ops_compliance", now_ts - 3600, status="ok")
+
+    with patch.object(sd, "subprocess") as mock_sub, \
+         patch.object(sd, "_nlm_send_telegram_warning") as mock_tg:
+        result = sd.check_nlm_pipelines_stuck(
+            state_dir=tmp_path, now_fn=lambda: now_ts,
+        )
+
+    assert "nlm_nb6_ops_compliance" in result["skipped"]
+    assert result["stuck"] == []
+    assert result["recovered"] == []
+    assert result["failed"] == []
+    mock_sub.run.assert_not_called()
+    mock_tg.assert_not_called()
+
+
+def test_stuck_pipeline_rerun_succeeds(tmp_path, now_ts):
+    """age > 24h triggers rerun; returncode=0 → recovered, no telegram."""
+    _write_state(tmp_path, "nlm_nb6_ops_compliance", now_ts - 48 * 3600, status="ok")
+
+    with patch.object(sd.subprocess, "run", return_value=_ok_run()) as mock_run, \
+         patch.object(sd, "_nlm_send_telegram_warning") as mock_tg:
+        result = sd.check_nlm_pipelines_stuck(
+            state_dir=tmp_path, now_fn=lambda: now_ts,
+        )
+
+    assert "nlm_nb6_ops_compliance" in result["stuck"]
+    assert "nlm_nb6_ops_compliance" in result["recovered"]
+    assert result["failed"] == []
+    mock_run.assert_called_once()
+    cmd = mock_run.call_args.args[0]
+    assert cmd[0] == sys.executable
+    assert "-m" in cmd
+    assert "apps.evaluator.nlm_deep_research.nb6_pipeline" in cmd
+    mock_tg.assert_not_called()
+
+
+def test_failed_status_triggers_rerun(tmp_path, now_ts):
+    """status=='failed' triggers rerun even within 24h."""
+    _write_state(tmp_path, "nlm_nb7_editorial", now_ts - 600, status="failed")
+
+    with patch.object(sd.subprocess, "run", return_value=_ok_run()) as mock_run, \
+         patch.object(sd, "_nlm_send_telegram_warning") as mock_tg:
+        result = sd.check_nlm_pipelines_stuck(
+            state_dir=tmp_path, now_fn=lambda: now_ts,
+        )
+
+    assert "nlm_nb7_editorial" in result["stuck"]
+    assert "nlm_nb7_editorial" in result["recovered"]
+    mock_run.assert_called_once()
+    mock_tg.assert_not_called()
+
+
+def test_rerun_failure_triggers_telegram(tmp_path, now_ts):
+    """rerun returncode != 0 → counted as failed AND telegram alert sent."""
+    _write_state(tmp_path, "nlm_nb6_ops_compliance", now_ts - 48 * 3600, status="ok")
+
+    with patch.object(sd.subprocess, "run",
+                      return_value=_fail_run(stderr="ModuleNotFoundError", returncode=2)), \
+         patch.object(sd, "_nlm_send_telegram_warning") as mock_tg:
+        result = sd.check_nlm_pipelines_stuck(
+            state_dir=tmp_path, now_fn=lambda: now_ts,
+        )
+
+    assert "nlm_nb6_ops_compliance" in result["failed"]
+    assert "nlm_nb6_ops_compliance" not in result["recovered"]
+    mock_tg.assert_called_once()
+    args = mock_tg.call_args
+    msg_arg = args.kwargs.get("message") or args.args[0]
+    assert "nlm_nb6_ops_compliance" in msg_arg
+    assert "ModuleNotFoundError" in msg_arg
+
+
+def test_subprocess_timeout_treated_as_failure(tmp_path, now_ts):
+    """subprocess.TimeoutExpired → failed + telegram with timeout marker."""
+    _write_state(tmp_path, "nlm_nb6_ops_compliance", now_ts - 30 * 3600, status="ok")
+
+    def _raise_timeout(*args, **kwargs):
+        raise sd.subprocess.TimeoutExpired(cmd=args[0], timeout=300)
+
+    with patch.object(sd.subprocess, "run", side_effect=_raise_timeout), \
+         patch.object(sd, "_nlm_send_telegram_warning") as mock_tg:
+        result = sd.check_nlm_pipelines_stuck(
+            state_dir=tmp_path, now_fn=lambda: now_ts,
+        )
+
+    assert "nlm_nb6_ops_compliance" in result["failed"]
+    mock_tg.assert_called_once()
+    msg = mock_tg.call_args.args[0] if mock_tg.call_args.args else mock_tg.call_args.kwargs.get("message", "")
+    assert "timeout" in msg.lower()
+
+
+def test_missing_state_dir_returns_empty(tmp_path, now_ts):
+    """state_dir not present → empty result, no errors raised."""
+    missing = tmp_path / "does-not-exist"
+
+    with patch.object(sd.subprocess, "run") as mock_run, \
+         patch.object(sd, "_nlm_send_telegram_warning") as mock_tg:
+        result = sd.check_nlm_pipelines_stuck(
+            state_dir=missing, now_fn=lambda: now_ts,
+        )
+
+    assert result == {"stuck": [], "recovered": [], "failed": [], "skipped": [], "errors": {}}
+    mock_run.assert_not_called()
+    mock_tg.assert_not_called()
+
+
+def test_malformed_json_recorded_as_error(tmp_path, now_ts):
+    """Invalid JSON in state file → error entry, not crash."""
+    (tmp_path).mkdir(exist_ok=True)
+    (tmp_path / "nlm_nb6_ops_compliance.last.json").write_text("{ not json")
+
+    with patch.object(sd.subprocess, "run") as mock_run, \
+         patch.object(sd, "_nlm_send_telegram_warning") as mock_tg:
+        result = sd.check_nlm_pipelines_stuck(
+            state_dir=tmp_path, now_fn=lambda: now_ts,
+        )
+
+    assert "nlm_nb6_ops_compliance" in result["errors"]
+    assert "json" in result["errors"]["nlm_nb6_ops_compliance"].lower() or \
+           "decode" in result["errors"]["nlm_nb6_ops_compliance"].lower() or \
+           "expecting" in result["errors"]["nlm_nb6_ops_compliance"].lower()
+    mock_run.assert_not_called()
+    mock_tg.assert_not_called()
+
+
+def test_pipeline_with_no_module_mapping_skipped(tmp_path, now_ts):
+    """nlm_bridge has no rerun module (None in table) → skipped even if stuck."""
+    _write_state(tmp_path, "nlm_bridge", now_ts - 100 * 3600, status="ok")
+
+    with patch.object(sd.subprocess, "run") as mock_run, \
+         patch.object(sd, "_nlm_send_telegram_warning") as mock_tg:
+        result = sd.check_nlm_pipelines_stuck(
+            state_dir=tmp_path, now_fn=lambda: now_ts,
+        )
+
+    assert "nlm_bridge" in result["skipped"]
+    assert "nlm_bridge" not in result["stuck"]
+    mock_run.assert_not_called()
+    mock_tg.assert_not_called()
+
+
+def test_unknown_pipeline_in_state_dir_ignored(tmp_path, now_ts):
+    """nlm_*.last.json with unknown name → not in mapping → skipped silently."""
+    _write_state(tmp_path, "nlm_unknown_future_pipeline", now_ts - 100 * 3600, status="failed")
+
+    with patch.object(sd.subprocess, "run") as mock_run, \
+         patch.object(sd, "_nlm_send_telegram_warning") as mock_tg:
+        result = sd.check_nlm_pipelines_stuck(
+            state_dir=tmp_path, now_fn=lambda: now_ts,
+        )
+
+    assert "nlm_unknown_future_pipeline" in result["skipped"]
+    mock_run.assert_not_called()
+    mock_tg.assert_not_called()
+
+
+def test_ts_zero_treated_as_never_run_skipped(tmp_path, now_ts):
+    """ts <= 0 → no usable signal → skip."""
+    _write_state(tmp_path, "nlm_nb6_ops_compliance", 0, status="ok")
+
+    with patch.object(sd.subprocess, "run") as mock_run, \
+         patch.object(sd, "_nlm_send_telegram_warning") as mock_tg:
+        result = sd.check_nlm_pipelines_stuck(
+            state_dir=tmp_path, now_fn=lambda: now_ts,
+        )
+
+    assert "nlm_nb6_ops_compliance" in result["skipped"]
+    mock_run.assert_not_called()
+    mock_tg.assert_not_called()
+
+
+def test_multiple_pipelines_independent(tmp_path, now_ts):
+    """Mix of healthy/stuck/failed across multiple pipelines — partial outcomes."""
+    _write_state(tmp_path, "nlm_nb6_ops_compliance", now_ts - 1 * 3600, status="ok")  # healthy
+    _write_state(tmp_path, "nlm_nb7_editorial", now_ts - 48 * 3600, status="ok")     # stuck → recover
+    _write_state(tmp_path, "nlm_nb8_expat_life", now_ts - 30 * 3600, status="ok")    # stuck → fail
+
+    runs: list = []
+
+    def _alternate_run(cmd, **kwargs):
+        runs.append(cmd)
+        # nb7 succeeds, nb8 fails
+        module = next((c for c in cmd if "nlm_deep_research" in c), "")
+        if "nb8_pipeline" in module:
+            return _fail_run(stderr="boom", returncode=1)
+        return _ok_run()
+
+    with patch.object(sd.subprocess, "run", side_effect=_alternate_run), \
+         patch.object(sd, "_nlm_send_telegram_warning") as mock_tg:
+        result = sd.check_nlm_pipelines_stuck(
+            state_dir=tmp_path, now_fn=lambda: now_ts,
+        )
+
+    assert "nlm_nb6_ops_compliance" in result["skipped"]
+    assert "nlm_nb7_editorial" in result["recovered"]
+    assert "nlm_nb8_expat_life" in result["failed"]
+    assert mock_tg.call_count == 1
+    msg = mock_tg.call_args.args[0]
+    assert "nlm_nb8_expat_life" in msg
+
+
+def test_cli_check_nlm_short_circuits_main(tmp_path, now_ts, monkeypatch, capsys):
+    """`python system_doctor.py --check-nlm` runs ONLY this function and prints JSON."""
+    _write_state(tmp_path, "nlm_nb6_ops_compliance", now_ts - 1 * 3600, status="ok")
+
+    monkeypatch.setattr(sys, "argv", ["system_doctor.py", "--check-nlm"])
+    monkeypatch.setenv("NLM_STATE_DIR", str(tmp_path))
+
+    with patch.object(sd, "time") as mock_time, \
+         patch.object(sd.subprocess, "run") as mock_run, \
+         patch.object(sd, "_nlm_send_telegram_warning"):
+        mock_time.time.return_value = now_ts
+        sd.main()
+
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert "skipped" in payload
+    assert "nlm_nb6_ops_compliance" in payload["skipped"]
+    mock_run.assert_not_called()


### PR DESCRIPTION
## Summary

P1-7 from the 2026-04-29 zero-crash audit. Adds `check_nlm_pipelines_stuck()` to `scripts/system_doctor.py`:

- Walks `~/.agent/decisions/state/nlm_*.last.json`, detects pipelines with `age > 24h` OR `status == "failed"`.
- Attempts rerun via `subprocess.run([sys.executable, "-m", <module>], timeout=300, cwd=PROJECT_ROOT)`.
- Sends Telegram alert (plain text via `urllib.request`) ONLY on rerun failure — no spam on healthy or recovered.
- New `--check-nlm` CLI short-circuits the rest of system_doctor and prints just the result JSON.
- Pipeline-name → module-path mapping is explicit (`NLM_PIPELINE_MODULES` dict) — `nb1_daily_refresh` dispatches via `nlm_bridge`, not a non-existent `nb1_pipeline`. Heartbeats / umbrellas (`nlm_bridge`, `nlm_deep_research`, `weekly_report`) map to `None` and are skipped silently.

Idempotent. Telegram pattern matches `scripts/expiry_alerter.py:208-228`. No new dependencies. Cron call site: `system_doctor.py` 08:00 daily on Pro.

## Test plan

- [x] 12/12 tests green in `tests/scripts/test_system_doctor_nlm.py`
- [x] Real-world smoke: `python scripts/system_doctor.py --check-nlm` against the live state on Air detected `nlm_nb1_daily_refresh` (10d stale) and recovered it via subprocess rerun (returncode=0)
- [x] No mutation of unrelated tests (`scripts/tests/test_system_doctor_emit.py` still 2/2 green)
- [x] AST syntax valid; ruff: 7 pre-existing errors, 0 new errors from this PR
- [ ] Post-merge: cron 08:00 WITA next-day exercise (24h soak)

Brainstorm artifacts (codex CLI hit usage-limit, gemini hit GCP 429 — synthesized designs from constraints): `/tmp/wave2-air-brainstorms/p1-7-{codex,gemini,nlm}.md` on Air.

Refs: `docs/audits/2026-04-29-zero-crash-audit/09_intervention_plan.md` §P1-7

🤖 Generated with [Claude Code](https://claude.com/claude-code)