### PR TITLE
feat(p1-8): mirror escalations into local SQLite + cron prune/archive

### DIFF
--- a/infra/launchd/README.md
+++ b/infra/launchd/README.md
@@ -1,0 +1,49 @@
+# infra/launchd — versioned LaunchAgent plists
+
+This directory holds **versioned, repo-tracked** copies of the LaunchAgent
+plist files that run on Pro (and selectively on Air). The actual plists that
+`launchd` loads live in `~/Library/LaunchAgents/` — these files are the
+canonical source the agents copy from.
+
+VADEMECUM §11 conventions enforced for every plist here:
+
+- `EnvironmentVariables` MUST include `HOME` and `PATH`.
+- `StandardOutPath` / `StandardErrorPath` MUST point under `~/logs/` (not
+  `/tmp/` — that is wiped on reboot and breaks Sentinel forensics).
+- `RunAtLoad` MUST be set explicitly (`false` for cron-style jobs,
+  `true` for daemon-on-boot).
+- `StartCalendarInterval` schedules use the user's **LOCAL time zone**
+  (Bali Zero = `Asia/Makassar` = WITA = UTC+8).
+
+## Current plists
+
+| File | Purpose | Schedule |
+| ---- | ------- | -------- |
+| `com.nuzantara.escalations-prune.plist` | P1-8 — prune resolved escalations >30d, archive unresolved >90d from `~/.agent/decisions/escalations.sqlite` | Daily 03:00 WITA |
+
+## Install
+
+After merging a new/updated plist here, install on the target machine:
+
+```bash
+# Pro (or Air, if applicable)
+cp infra/launchd/com.nuzantara.escalations-prune.plist ~/Library/LaunchAgents/
+plutil -lint ~/Library/LaunchAgents/com.nuzantara.escalations-prune.plist  # must print "OK"
+launchctl unload -w ~/Library/LaunchAgents/com.nuzantara.escalations-prune.plist 2>/dev/null || true
+launchctl load   -w ~/Library/LaunchAgents/com.nuzantara.escalations-prune.plist
+launchctl list | grep com.nuzantara.escalations-prune
+```
+
+## P1-8 first-run on Pro
+
+After installing the plist for the first time, also run the one-shot import
+to backfill the SQLite mirror from the existing JSONL:
+
+```bash
+mkdir -p ~/.agent/decisions ~/logs/cron-agent
+python3 ~/Desktop/nuzantara/scripts/migrate_escalations_to_sqlite.py import
+sqlite3 ~/.agent/decisions/escalations.sqlite \
+    "SELECT COUNT(*) AS total, SUM(resolved_at IS NULL) AS active FROM escalations"
+```
+
+The cron then keeps the DB bounded automatically.

--- a/infra/launchd/com.nuzantara.escalations-prune.plist
+++ b/infra/launchd/com.nuzantara.escalations-prune.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.nuzantara.escalations-prune</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <key>PATH</key>
+        <string>/Users/nuzantara/.openclaw/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/Users/nuzantara/.pyenv/versions/3.11.11/bin</string>
+    </dict>
+    <key>Program</key>
+    <string>/bin/bash</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/nuzantara/Desktop/nuzantara/scripts/escalations_prune_cron.sh</string>
+    </array>
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/cron-agent/escalations-prune.out</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/cron-agent/escalations-prune.err</string>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/scripts/escalations_prune_cron.sh
+++ b/scripts/escalations_prune_cron.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# P1-8: daily cron wrapper for escalations SQLite mirror.
+# Runs prune (deletes resolved >30d) then archive (gzip-archives unresolved >90d).
+#
+# Loaded via infra/launchd/com.nuzantara.escalations-prune.plist at 03:00 WITA.
+set -u  # do NOT use -e: we want both subcommands to attempt even if one fails.
+
+PYTHON="${PYTHON:-/usr/bin/env python3}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MIGRATE="${SCRIPT_DIR}/migrate_escalations_to_sqlite.py"
+
+if [ ! -f "$MIGRATE" ]; then
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ERROR: migrate script not found: $MIGRATE" >&2
+    exit 2
+fi
+
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) escalations-prune: starting"
+
+PRUNE_RC=0
+$PYTHON "$MIGRATE" prune --older-than-days 30 || PRUNE_RC=$?
+if [ "$PRUNE_RC" -ne 0 ]; then
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) WARN: prune exited $PRUNE_RC" >&2
+fi
+
+ARCHIVE_RC=0
+$PYTHON "$MIGRATE" archive --older-than-days 90 || ARCHIVE_RC=$?
+if [ "$ARCHIVE_RC" -ne 0 ]; then
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) WARN: archive exited $ARCHIVE_RC" >&2
+fi
+
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) escalations-prune: done (prune_rc=$PRUNE_RC archive_rc=$ARCHIVE_RC)"
+# Exit non-zero only if BOTH failed — partial success keeps the LaunchAgent green.
+if [ "$PRUNE_RC" -ne 0 ] && [ "$ARCHIVE_RC" -ne 0 ]; then
+    exit 1
+fi
+exit 0

--- a/scripts/migrate_escalations_to_sqlite.py
+++ b/scripts/migrate_escalations_to_sqlite.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""P1-8 — Migrate per-machine escalations JSONL into a local SQLite index.
+
+Architecture (per ADR-3 v3.3 in NB-1, kept INTACT):
+- ``shared/escalations_pro.jsonl`` and ``shared/escalations_air.jsonl`` remain
+  the **federation bus** (cross-machine eventual consistency via git).
+- This SQLite database lives at ``~/.agent/decisions/escalations.sqlite`` —
+  **outside** the git tree, on each machine's local filesystem only. It is a
+  per-machine **local index/replica** of the JSONL, used to:
+    1. Prune disk growth (``shared/escalations_pro.jsonl`` is 4041+ lines).
+    2. Provide indexed active-query for consumers (e.g. metabolic collector).
+    3. Support deduplication (audit_id where present, else canonical-JSON
+       hash).
+
+Subcommands
+-----------
+- ``import``  : read JSONL → INSERT OR IGNORE (idempotent, dedup_key UNIQUE).
+- ``prune``   : DELETE rows where ``resolved_at`` is set and older than N days.
+- ``archive`` : export unresolved rows older than N days to a gzip JSONL,
+                then DELETE them from the main DB.
+
+The cron LaunchAgent (``infra/launchd/com.nuzantara.escalations-prune.plist``)
+runs ``prune`` and ``archive`` daily at 03:00 WITA via
+``scripts/escalations_prune_cron.sh``.
+
+This script never touches the canonical JSONL files.
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import json
+import logging
+import os
+import sqlite3
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Optional
+
+logger = logging.getLogger("migrate_escalations_to_sqlite")
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+DEFAULT_DB_PATH = Path.home() / ".agent" / "decisions" / "escalations.sqlite"
+DEFAULT_ARCHIVE_DIR = Path.home() / ".agent" / "decisions"
+
+# Project default JSONL sources. Can be overridden via --source-jsonl.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_SOURCES = [
+    _PROJECT_ROOT / "shared" / "escalations_pro.jsonl",
+    _PROJECT_ROOT / "shared" / "escalations_air.jsonl",
+]
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS escalations (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    dedup_key     TEXT NOT NULL UNIQUE,
+    audit_id      TEXT,
+    job           TEXT,
+    type          TEXT,
+    severity      TEXT,
+    machine       TEXT,
+    error_summary TEXT,
+    task_file     TEXT,
+    ts            REAL NOT NULL,
+    status        TEXT NOT NULL DEFAULT 'pending',
+    resolved_at   REAL,
+    raw_json      TEXT NOT NULL,
+    imported_at   REAL NOT NULL DEFAULT (unixepoch())
+);
+CREATE INDEX IF NOT EXISTS idx_escalations_active
+    ON escalations(resolved_at) WHERE resolved_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_escalations_machine
+    ON escalations(machine);
+CREATE INDEX IF NOT EXISTS idx_escalations_ts
+    ON escalations(ts);
+CREATE INDEX IF NOT EXISTS idx_escalations_job_ts
+    ON escalations(job, ts);
+"""
+
+
+# ---------------------------------------------------------------------------
+# Connection helpers
+# ---------------------------------------------------------------------------
+def _connect(db_path: Path) -> sqlite3.Connection:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    # WAL: many concurrent cron writers (DLQ autopilot, sentinel, manual).
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    conn.execute("PRAGMA busy_timeout=5000")  # 5s — handles cron-burst overlap
+    return conn
+
+
+def ensure_schema(db_path: Path) -> None:
+    """Create the table + indexes if they don't exist. Idempotent."""
+    conn = _connect(db_path)
+    try:
+        conn.executescript(SCHEMA_SQL)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Dedup
+# ---------------------------------------------------------------------------
+def dedup_key_for(row: dict) -> str:
+    """Return a stable dedup key for an escalation row.
+
+    Strategy:
+    - If ``audit_id`` is set (rare today), use ``audit:<audit_id>|<machine>``.
+    - Otherwise, hash the canonical JSON (sort_keys=True, no whitespace) of
+      the row. The hash is stable across re-serialization but changes if any
+      field changes — which is the desired semantics for "same row".
+
+    This solves the original plan's UNIQUE(audit_id, machine) bug: SQLite's
+    UNIQUE treats two NULLs as distinct, so rows with NULL audit_id would
+    duplicate freely.
+    """
+    audit_id = row.get("audit_id")
+    if audit_id:
+        machine = row.get("machine") or "?"
+        return f"audit:{audit_id}|{machine}"
+    canonical = json.dumps(row, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:32]
+    return f"sha:{digest}"
+
+
+# ---------------------------------------------------------------------------
+# Insert
+# ---------------------------------------------------------------------------
+_INSERT_SQL = """
+INSERT OR IGNORE INTO escalations (
+    dedup_key, audit_id, job, type, severity, machine,
+    error_summary, task_file, ts, status, resolved_at, raw_json
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+"""
+
+
+def _insert_row(
+    conn: sqlite3.Connection, row: dict, raw_json_str: Optional[str] = None
+) -> bool:
+    """Insert one row. Returns True if a new row was inserted, False if dedup'd.
+
+    ``raw_json_str`` lets callers pass the original line verbatim; if omitted,
+    we re-serialize the dict (canonical form).
+    """
+    raw = raw_json_str if raw_json_str is not None else json.dumps(
+        row, sort_keys=True, separators=(",", ":")
+    )
+    severity = row.get("severity") or row.get("priority")
+    ts = row.get("ts")
+    if ts is None:
+        ts = time.time()
+    try:
+        ts = float(ts)
+    except (TypeError, ValueError):
+        ts = time.time()
+
+    resolved_at = row.get("resolved_at")
+    if resolved_at is not None:
+        try:
+            resolved_at = float(resolved_at)
+        except (TypeError, ValueError):
+            resolved_at = None
+
+    cur = conn.execute(
+        _INSERT_SQL,
+        (
+            dedup_key_for(row),
+            row.get("audit_id"),
+            row.get("job"),
+            row.get("type"),
+            severity,
+            row.get("machine"),
+            row.get("error_summary"),
+            row.get("task_file"),
+            ts,
+            row.get("status") or "pending",
+            resolved_at,
+            raw,
+        ),
+    )
+    return cur.rowcount > 0
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: import
+# ---------------------------------------------------------------------------
+def import_jsonl(
+    sources: Iterable[Path], db_path: Path, batch_size: int = 1000
+) -> int:
+    """Import every line of every source JSONL into SQLite. Idempotent.
+
+    Returns the number of NEW rows actually inserted (after dedup). The
+    canonical JSONL files are not modified.
+    """
+    ensure_schema(db_path)
+    inserted = 0
+    skipped_parse = 0
+    conn = _connect(db_path)
+    try:
+        n_in_batch = 0
+        for src in sources:
+            src = Path(src)
+            if not src.exists():
+                logger.info("source missing, skipping: %s", src)
+                continue
+            with src.open("r", encoding="utf-8") as f:
+                for line_no, raw in enumerate(f, start=1):
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    try:
+                        row = json.loads(raw)
+                        if not isinstance(row, dict):
+                            skipped_parse += 1
+                            continue
+                    except json.JSONDecodeError:
+                        skipped_parse += 1
+                        continue
+                    try:
+                        if _insert_row(conn, row, raw):
+                            inserted += 1
+                    except sqlite3.Error as exc:  # noqa: BLE001
+                        logger.warning(
+                            "INSERT failed for %s:%d — %s", src, line_no, exc
+                        )
+                        continue
+                    n_in_batch += 1
+                    if n_in_batch >= batch_size:
+                        conn.commit()
+                        n_in_batch = 0
+        conn.commit()
+    finally:
+        conn.close()
+    logger.info(
+        "import: inserted=%d skipped_parse=%d sources=%s",
+        inserted,
+        skipped_parse,
+        [str(s) for s in sources],
+    )
+    return inserted
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: prune
+# ---------------------------------------------------------------------------
+def prune(db_path: Path, older_than_days: int = 30) -> int:
+    """Delete rows that have been *explicitly* resolved more than N days ago.
+
+    Returns the number of rows deleted. Never auto-marks anything resolved —
+    that's an operator decision.
+    """
+    ensure_schema(db_path)
+    cutoff = time.time() - older_than_days * 86400
+    conn = _connect(db_path)
+    try:
+        cur = conn.execute(
+            "DELETE FROM escalations "
+            "WHERE resolved_at IS NOT NULL AND resolved_at < ?",
+            (cutoff,),
+        )
+        deleted = cur.rowcount
+        conn.commit()
+    finally:
+        conn.close()
+    logger.info("prune: deleted=%d (older than %dd)", deleted, older_than_days)
+    return deleted
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: archive
+# ---------------------------------------------------------------------------
+def archive(
+    db_path: Path,
+    older_than_days: int = 90,
+    archive_dir: Path = DEFAULT_ARCHIVE_DIR,
+) -> Optional[Path]:
+    """Export unresolved rows older than N days to gzip JSONL, then delete.
+
+    Returns the archive file path on success, or None if no rows qualified.
+    """
+    ensure_schema(db_path)
+    archive_dir = Path(archive_dir)
+    archive_dir.mkdir(parents=True, exist_ok=True)
+
+    cutoff = time.time() - older_than_days * 86400
+    conn = _connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT raw_json FROM escalations "
+            "WHERE resolved_at IS NULL AND ts < ?",
+            (cutoff,),
+        ).fetchall()
+        if not rows:
+            logger.info("archive: nothing to archive (cutoff=%s)", cutoff)
+            return None
+
+        date_tag = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+        out_path = archive_dir / f"escalations_archive_{date_tag}.jsonl.gz"
+        # If multiple cron runs happen on the same day (manual + scheduled),
+        # append a counter to keep the existing archive intact.
+        suffix = 1
+        while out_path.exists():
+            out_path = archive_dir / (
+                f"escalations_archive_{date_tag}_{suffix}.jsonl.gz"
+            )
+            suffix += 1
+
+        with gzip.open(out_path, "wt", encoding="utf-8") as gz:
+            for (raw_json,) in rows:
+                gz.write(raw_json.rstrip("\n") + "\n")
+
+        conn.execute(
+            "DELETE FROM escalations "
+            "WHERE resolved_at IS NULL AND ts < ?",
+            (cutoff,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "archive: wrote %d rows to %s (older than %dd)",
+        len(rows),
+        out_path,
+        older_than_days,
+    )
+    return out_path
+
+
+# ---------------------------------------------------------------------------
+# Public writer (used by sentinel_lib.escalations.write_escalation)
+# ---------------------------------------------------------------------------
+def write_escalation_to_sqlite(
+    row: dict, db_path: Optional[Path] = None
+) -> bool:
+    """Insert one escalation into SQLite. Idempotent. Used by the dual-writer.
+
+    Honors the env var ``ESCALATIONS_SQLITE_PATH`` if ``db_path`` is None.
+    Failures raise sqlite3.Error — caller is responsible for catch+log so
+    the JSONL append is never blocked by SQLite issues.
+    """
+    if db_path is None:
+        env_path = os.environ.get("ESCALATIONS_SQLITE_PATH")
+        db_path = Path(env_path) if env_path else DEFAULT_DB_PATH
+    ensure_schema(db_path)
+    conn = _connect(db_path)
+    try:
+        inserted = _insert_row(conn, row)
+        conn.commit()
+        return inserted
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def _main(argv: Optional[list[str]] = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument(
+        "--db-path", type=Path, default=DEFAULT_DB_PATH,
+        help=f"SQLite path (default: {DEFAULT_DB_PATH})",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp_import = sub.add_parser("import", help="Import JSONL files into SQLite")
+    sp_import.add_argument(
+        "--source-jsonl", type=Path, action="append", default=None,
+        help="Path to a JSONL file (repeatable). Default: shared/escalations_*.jsonl"
+    )
+    sp_import.add_argument(
+        "--batch-size", type=int, default=1000,
+        help="Commit every N rows (default 1000)",
+    )
+
+    sp_prune = sub.add_parser("prune", help="Delete resolved rows older than N days")
+    sp_prune.add_argument(
+        "--older-than-days", type=int, default=30,
+        help="Delete rows resolved more than N days ago (default 30)",
+    )
+
+    sp_archive = sub.add_parser(
+        "archive", help="Archive unresolved rows older than N days"
+    )
+    sp_archive.add_argument(
+        "--older-than-days", type=int, default=90,
+        help="Archive unresolved rows older than N days (default 90)",
+    )
+    sp_archive.add_argument(
+        "--archive-dir", type=Path, default=DEFAULT_ARCHIVE_DIR,
+        help=f"Archive directory (default: {DEFAULT_ARCHIVE_DIR})",
+    )
+
+    args = p.parse_args(argv)
+
+    if args.cmd == "import":
+        sources = args.source_jsonl or DEFAULT_SOURCES
+        n = import_jsonl(sources=sources, db_path=args.db_path, batch_size=args.batch_size)
+        print(f"inserted {n} new rows into {args.db_path}")
+        return 0
+
+    if args.cmd == "prune":
+        n = prune(db_path=args.db_path, older_than_days=args.older_than_days)
+        print(f"deleted {n} rows from {args.db_path}")
+        return 0
+
+    if args.cmd == "archive":
+        out = archive(
+            db_path=args.db_path,
+            older_than_days=args.older_than_days,
+            archive_dir=args.archive_dir,
+        )
+        if out is None:
+            print("nothing to archive")
+        else:
+            print(f"archived to {out}")
+        return 0
+
+    p.error(f"unknown subcommand: {args.cmd}")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/scripts/sentinel_lib/escalations.py
+++ b/scripts/sentinel_lib/escalations.py
@@ -8,13 +8,23 @@ Each file is append-only. O_APPEND provides local atomicity (writes < PIPE_BUF =
 Merge conflicts are structurally impossible because each file has a single writer.
 
 Readers: read both files, parse each line as JSON, merge in-memory.
+
+P1-8: in addition to the canonical JSONL (federation bus), every write is
+mirrored into a per-machine local SQLite index at
+``~/.agent/decisions/escalations.sqlite`` for indexed active-query and
+bounded-retention pruning. The SQLite mirror lives OUTSIDE the git tree
+(per ADR-3 v3.3 — no shared SQLite, no split-brain). Toggle off with
+``ESCALATIONS_USE_SQLITE=false``.
 """
 import json
+import logging
 import os
 import socket
 import time
 from pathlib import Path
 from typing import Iterator
+
+_logger = logging.getLogger("sentinel_lib.escalations")
 
 _NUZANTARA_ROOT = Path(__file__).parent.parent.parent  # scripts/sentinel_lib → project root
 _SHARED_DIR = _NUZANTARA_ROOT / "shared"
@@ -59,6 +69,33 @@ def write_escalation(entry: dict) -> None:
         os.write(fd, line)
     finally:
         os.close(fd)
+
+    # P1-8: dual-write to local SQLite index (best-effort; never blocks JSONL).
+    if os.environ.get("ESCALATIONS_USE_SQLITE", "true").lower() not in (
+        "0", "false", "no", "off",
+    ):
+        try:
+            _mirror_to_sqlite(record)
+        except Exception as exc:  # noqa: BLE001 — mirror failures must NEVER break JSONL
+            _logger.warning("SQLite mirror failed (record kept in JSONL): %s", exc)
+
+
+def _mirror_to_sqlite(record: dict) -> None:
+    """Insert one record into the SQLite mirror via the migration module.
+
+    Imported lazily so test environments without the migration module on
+    sys.path still get the JSONL behavior.
+    """
+    import sys as _sys
+
+    scripts_dir = str(Path(__file__).resolve().parent.parent)
+    if scripts_dir not in _sys.path:
+        _sys.path.insert(0, scripts_dir)
+    try:
+        import migrate_escalations_to_sqlite as _mig
+    except ImportError:
+        return  # mirror module not available — skip silently
+    _mig.write_escalation_to_sqlite(record)
 
 
 def read_all_escalations(include_resolved: bool = False) -> list[dict]:

--- a/tests/scripts/test_migrate_escalations_to_sqlite.py
+++ b/tests/scripts/test_migrate_escalations_to_sqlite.py
@@ -1,0 +1,339 @@
+"""Tests for scripts/migrate_escalations_to_sqlite.py (P1-8).
+
+Covers:
+1. Import creates table + indexes.
+2. Idempotent import (rerun = no duplicate rows).
+3. Zero data loss (line count == row count for unique rows).
+4. Prune deletes only resolved rows older than threshold.
+5. Archive exports unresolved rows older than threshold to gzip JSONL.
+6. Writer dual-writes to SQLite when env toggle is on.
+
+All tests use tmp_path. No real ~/.agent/ writes.
+"""
+from __future__ import annotations
+
+import gzip
+import importlib.util
+import json
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Module loader (script lives at scripts/migrate_escalations_to_sqlite.py and
+# is not on sys.path by default).
+# ---------------------------------------------------------------------------
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "migrate_escalations_to_sqlite.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "migrate_escalations_to_sqlite", str(SCRIPT_PATH)
+    )
+    assert spec and spec.loader, f"could not load {SCRIPT_PATH}"
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def migrate():
+    return _load_module()
+
+
+@pytest.fixture
+def sample_jsonl(tmp_path: Path) -> Path:
+    """Three rows mirroring real shapes from shared/escalations_pro.jsonl."""
+    rows = [
+        {
+            "job": "compliance_ops",
+            "type": "dlq_autopilot_escalation",
+            "error_summary": "OpenClaw consecutiveErrors=8",
+            "priority": "HIGH",
+            "task_file": "compliance_ops_1.json",
+            "machine": "pro",
+            "ts": 1775757354.478498,
+            "status": "pending",
+            "_writer": "pro",
+        },
+        {
+            "job": "biz_orchestrator",
+            "type": "dlq_autopilot_escalation",
+            "error_summary": "",
+            "priority": "NORMAL",
+            "task_file": "biz_orchestrator_2.json",
+            "machine": "pro",
+            "ts": 1775757355.7944782,
+            "status": "pending",
+            "_writer": "pro",
+        },
+        {
+            # Air row with audit_id
+            "job": "air-a1-auth-surface",
+            "type": "zero_decision",
+            "priority": "HIGH",
+            "ts": 1776457007,
+            "machine": "air",
+            "status": "pending",
+            "_writer": "air",
+            "audit_id": "2026-04-18-HIGH-5",
+        },
+    ]
+    p = tmp_path / "escalations_pro.jsonl"
+    with p.open("w") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — schema + indexes
+# ---------------------------------------------------------------------------
+def test_import_creates_table_and_indexes(migrate, sample_jsonl, tmp_path):
+    db = tmp_path / "escalations.sqlite"
+    n = migrate.import_jsonl(sources=[sample_jsonl], db_path=db)
+    assert n == 3
+
+    conn = sqlite3.connect(str(db))
+    try:
+        # Table exists
+        names = {row[0] for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()}
+        assert "escalations" in names
+
+        # Required columns
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(escalations)").fetchall()}
+        for required in (
+            "id", "dedup_key", "audit_id", "job", "type", "severity",
+            "machine", "error_summary", "task_file", "ts", "status",
+            "resolved_at", "raw_json", "imported_at",
+        ):
+            assert required in cols, f"missing column: {required}"
+
+        # Indexes (4 expected — including the active-only partial index)
+        idx_names = {row[0] for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='escalations' AND name NOT LIKE 'sqlite_autoindex%'"
+        ).fetchall()}
+        for required in (
+            "idx_escalations_active",
+            "idx_escalations_machine",
+            "idx_escalations_ts",
+            "idx_escalations_job_ts",
+        ):
+            assert required in idx_names, f"missing index: {required}"
+
+        # WAL mode
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        assert mode.lower() == "wal"
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — idempotent rerun
+# ---------------------------------------------------------------------------
+def test_import_no_duplicates_on_rerun(migrate, sample_jsonl, tmp_path):
+    db = tmp_path / "escalations.sqlite"
+    first = migrate.import_jsonl(sources=[sample_jsonl], db_path=db)
+    second = migrate.import_jsonl(sources=[sample_jsonl], db_path=db)
+    assert first == 3
+    # Second run inserts 0 new rows (all dedup_keys already present).
+    assert second == 0
+
+    conn = sqlite3.connect(str(db))
+    try:
+        total = conn.execute("SELECT COUNT(*) FROM escalations").fetchone()[0]
+        assert total == 3
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — zero data loss
+# ---------------------------------------------------------------------------
+def test_import_preserves_all_jsonl_rows(migrate, tmp_path):
+    src = tmp_path / "many.jsonl"
+    n_rows = 100
+    with src.open("w") as f:
+        for i in range(n_rows):
+            f.write(json.dumps({
+                "job": f"job_{i}",
+                "type": "dlq_autopilot_escalation",
+                "priority": "NORMAL",
+                "machine": "pro",
+                "ts": 1700000000 + i,
+                "status": "pending",
+                "_writer": "pro",
+            }) + "\n")
+
+    db = tmp_path / "escalations.sqlite"
+    inserted = migrate.import_jsonl(sources=[src], db_path=db)
+    assert inserted == n_rows
+
+    # Line count == row count
+    line_count = sum(1 for _ in src.open())
+    conn = sqlite3.connect(str(db))
+    try:
+        row_count = conn.execute("SELECT COUNT(*) FROM escalations").fetchone()[0]
+    finally:
+        conn.close()
+    assert row_count == line_count == n_rows
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — prune
+# ---------------------------------------------------------------------------
+def test_prune_resolved_older_than_30d(migrate, tmp_path):
+    db = tmp_path / "escalations.sqlite"
+    migrate.ensure_schema(db)
+    now = time.time()
+
+    rows = [
+        # 3 resolved >30d → should be pruned
+        {"job": "j1", "machine": "pro", "ts": now - 100 * 86400,
+         "status": "resolved", "resolved_at": now - 40 * 86400, "audit_id": "a1"},
+        {"job": "j2", "machine": "pro", "ts": now - 100 * 86400,
+         "status": "resolved", "resolved_at": now - 35 * 86400, "audit_id": "a2"},
+        {"job": "j3", "machine": "pro", "ts": now - 100 * 86400,
+         "status": "resolved", "resolved_at": now - 31 * 86400, "audit_id": "a3"},
+        # 1 resolved <30d → keep
+        {"job": "j4", "machine": "pro", "ts": now - 100 * 86400,
+         "status": "resolved", "resolved_at": now - 5 * 86400, "audit_id": "a4"},
+        # 1 unresolved → keep
+        {"job": "j5", "machine": "pro", "ts": now - 100 * 86400,
+         "status": "pending", "audit_id": "a5"},
+    ]
+    conn = sqlite3.connect(str(db))
+    try:
+        for r in rows:
+            migrate._insert_row(conn, r, json.dumps(r))
+        conn.commit()
+    finally:
+        conn.close()
+
+    deleted = migrate.prune(db_path=db, older_than_days=30)
+    assert deleted == 3
+
+    conn = sqlite3.connect(str(db))
+    try:
+        remaining = conn.execute("SELECT job FROM escalations ORDER BY job").fetchall()
+        assert [r[0] for r in remaining] == ["j4", "j5"]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — archive
+# ---------------------------------------------------------------------------
+def test_archive_unresolved_older_than_90d(migrate, tmp_path):
+    db = tmp_path / "escalations.sqlite"
+    archive_dir = tmp_path / "archives"
+    archive_dir.mkdir()
+    migrate.ensure_schema(db)
+    now = time.time()
+
+    rows = [
+        # 2 unresolved >90d → archive + delete
+        {"job": "old1", "machine": "pro", "ts": now - 100 * 86400,
+         "status": "pending", "audit_id": "old1"},
+        {"job": "old2", "machine": "air", "ts": now - 91 * 86400,
+         "status": "pending", "audit_id": "old2"},
+        # 1 fresh → keep
+        {"job": "fresh", "machine": "pro", "ts": now - 1 * 86400,
+         "status": "pending", "audit_id": "fresh"},
+    ]
+    conn = sqlite3.connect(str(db))
+    try:
+        for r in rows:
+            migrate._insert_row(conn, r, json.dumps(r))
+        conn.commit()
+    finally:
+        conn.close()
+
+    archived_path = migrate.archive(
+        db_path=db, older_than_days=90, archive_dir=archive_dir
+    )
+    assert archived_path is not None
+    assert archived_path.exists()
+    assert archived_path.suffixes[-2:] == [".jsonl", ".gz"]
+
+    # 2 rows in gzip file
+    with gzip.open(archived_path, "rt") as f:
+        lines = [json.loads(line) for line in f if line.strip()]
+    assert len(lines) == 2
+    assert {r["job"] for r in lines} == {"old1", "old2"}
+
+    # DB now has only the fresh row
+    conn = sqlite3.connect(str(db))
+    try:
+        remaining = conn.execute("SELECT job FROM escalations").fetchall()
+        assert [r[0] for r in remaining] == ["fresh"]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — writer dual-writes
+# ---------------------------------------------------------------------------
+def test_writer_dual_writes_to_sqlite(migrate, tmp_path, monkeypatch):
+    """When ESCALATIONS_USE_SQLITE=true, the JSONL writer also INSERTs into SQLite.
+
+    We import scripts/sentinel_lib/escalations.py from the project (NOT through
+    the migrate module — we exercise the real writer with patched paths).
+    """
+    # Make sentinel_lib importable.
+    scripts_dir = PROJECT_ROOT / "scripts"
+    monkeypatch.syspath_prepend(str(scripts_dir))
+
+    # Point JSONL output at tmp_path (per-machine writer picks file by hostname).
+    import sentinel_lib.escalations as escalations_mod
+    importlib_reload = __import__("importlib").reload
+    # Keep a fresh module load so we can patch the constants.
+    escalations_mod = importlib_reload(escalations_mod)
+
+    fake_jsonl = tmp_path / "escalations_pro.jsonl"
+    fake_db = tmp_path / "escalations.sqlite"
+
+    # Patch the per-machine map and DB resolver. (current_machine returns 'pro'
+    # on the dev workstation; if not, force it.)
+    monkeypatch.setattr(
+        escalations_mod, "_MACHINE_FILES", {"pro": fake_jsonl, "air": fake_jsonl}
+    )
+    monkeypatch.setattr(escalations_mod, "_current_machine", lambda: "pro")
+    monkeypatch.setenv("ESCALATIONS_USE_SQLITE", "true")
+    monkeypatch.setenv("ESCALATIONS_SQLITE_PATH", str(fake_db))
+
+    escalations_mod.write_escalation({
+        "job": "writer_dual_test",
+        "type": "dlq_autopilot_escalation",
+        "audit_id": "writer-1",
+        "priority": "HIGH",
+    })
+
+    # JSONL got the line.
+    assert fake_jsonl.exists()
+    lines = [json.loads(line) for line in fake_jsonl.read_text().splitlines() if line.strip()]
+    assert len(lines) == 1
+    assert lines[0]["job"] == "writer_dual_test"
+    assert lines[0]["audit_id"] == "writer-1"
+
+    # SQLite got the row with matching dedup_key.
+    assert fake_db.exists()
+    conn = sqlite3.connect(str(fake_db))
+    try:
+        rows = conn.execute(
+            "SELECT job, audit_id, dedup_key FROM escalations"
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == "writer_dual_test"
+        assert rows[0][1] == "writer-1"
+        assert rows[0][2] == "audit:writer-1|pro"
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

P1-8 from the 2026-04-29 zero-crash audit (`docs/audits/2026-04-29-zero-crash-audit/09_intervention_plan.md`).

`shared/escalations_pro.jsonl` had **4088 lines** today (≈1 MB) — append-only, no rotation, no dedup, no consumer process. The metabolic collector parses it end-to-end every cycle. This PR adds:

- **`scripts/migrate_escalations_to_sqlite.py`** — `import` / `prune` / `archive` subcommands. SQLite at `~/.agent/decisions/escalations.sqlite` (per-machine, **outside** the git tree — see "Architectural fit" below). WAL mode, parameterized SQL throughout.
- **`scripts/escalations_prune_cron.sh`** — wrapper that runs `prune --older-than-days 30` then `archive --older-than-days 90`. Both attempt; partial success keeps the LaunchAgent green.
- **`infra/launchd/com.nuzantara.escalations-prune.plist`** — versioned plist. Daily 03:00 WITA. Includes `EnvironmentVariables` (PATH+HOME) per VADEMECUM §11. Logs under `~/logs/cron-agent/`. **Not loaded** by this PR — Antonello loads on Pro after merge per `infra/launchd/README.md`.
- **`scripts/sentinel_lib/escalations.py`** — `write_escalation` now dual-writes (JSONL → SQLite). Failures swallowed: SQLite mirror NEVER blocks the JSONL append. Toggle off with `ESCALATIONS_USE_SQLITE=false`.
- **6 unit tests** covering: schema/indexes, idempotent rerun, zero data loss, prune semantics, archive→gzip JSONL, writer dual-write.

## Architectural fit (NB-1 ground-truth check)

Before writing any code I queried NB-1 about ADR-3 v3.3, which deliberately rejected SQLite for the federation bus because Pro and Air sync escalations via **git** (not a shared FS) — a shared SQLite would split-brain at the first git-sync.

**This PR honors that ADR.** The JSONL files at `shared/escalations_{pro,air}.jsonl` remain the canonical federation bus, untouched. The new SQLite lives at `~/.agent/decisions/escalations.sqlite` — **per-machine, outside the git tree** — purely as a local index/replica for prune/archive and indexed active-query. The `metabolic_collector` (the existing JSONL reader) is intentionally NOT switched over in this PR.

Brainstorm artifacts: `/tmp/kakuro-SY-brainstorms/` (Codex hit usage limit, Gemini 3.1 Pro 429-capacity, DeepSeek delivered, NotebookLM NB-1 delivered the architectural veto-check). Synthesis at `/tmp/kakuro-SY-brainstorms/00_SYNTHESIS.md`.

## Test plan

- [x] All 6 unit tests pass locally (`pytest tests/scripts/test_migrate_escalations_to_sqlite.py -v`).
- [x] Smoke import on a copy of `shared/escalations_pro.jsonl` (4088 lines) + `shared/escalations_air.jsonl` (2 lines) → 4090 SQLite rows. Zero data loss.
- [x] Idempotent rerun on the same JSONL → 0 new rows, total still 4090.
- [x] Synthetic prune (3 resolved >30d) → -3. Synthetic archive (2 unresolved >90d) → -2 + gzip JSONL with 2 lines. Final 4085.
- [x] `plutil -lint infra/launchd/com.nuzantara.escalations-prune.plist` → OK.
- [x] `bash -n scripts/escalations_prune_cron.sh` → OK; smoke run executes prune+archive cleanly.
- [ ] Post-merge on Pro: `cp infra/launchd/com.nuzantara.escalations-prune.plist ~/Library/LaunchAgents/ && launchctl load -w ~/Library/LaunchAgents/com.nuzantara.escalations-prune.plist` (Antonello).
- [ ] Post-merge on Pro: one-shot `python3 ~/Desktop/nuzantara/scripts/migrate_escalations_to_sqlite.py import` to backfill — see `infra/launchd/README.md`.

## Backward compatibility

- Existing JSONL files **untouched**. They remain the federation bus.
- Writer keeps appending JSONL exactly as before; SQLite mirror is additive.
- `ESCALATIONS_USE_SQLITE=false` disables the mirror entirely with no other changes.
- Future PR can switch the metabolic collector to read SQLite for performance, and (much later) drop the JSONL writer — neither is in scope here.

## Out of scope (deliberate)

- No auto-resolution heuristic ("if circuit-breaker CLOSED >24h mark resolved"). Operator decides; `prune` only honors explicit `resolved_at`.
- No cross-machine SQLite sync (would re-introduce the split-brain ADR-3 was designed to prevent).
- Air gets the same code via git, but the cron plist is Pro-only in this PR. Air has only 2 lines — defer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)