### PR TITLE
[CANARY do-not-merge] nb-d lint canary

### DIFF
--- a/apps/mouth/package.json
+++ b/apps/mouth/package.json
@@ -94,5 +94,6 @@
     "tailwindcss": "^4",
     "typescript": "^5.9.3",
     "vitest": "^4.0.15"
-  }
+  },
+  "_nb_d_canary": "do-not-merge"
 }

--- a/apps/mouth/src/__nb_d_canary_test.tsx
+++ b/apps/mouth/src/__nb_d_canary_test.tsx
@@ -1,0 +1,4 @@
+// NB-D canary: synthetic undeclared import. Should fail lint-cross-import.
+// PR will be closed without merging.
+import type { Foo } from "@nuzantara/totally-fake-nb-d-canary-pkg";
+export const X: Foo | null = null;


### PR DESCRIPTION
Synthetic test for NB-D workflow (PR #346 just merged). Should fail `Cross-import integrity`. Will close without merge.

Plants:
- `apps/mouth/package.json`: adds `_nb_d_canary` marker (forces workflow trigger via the path filter `apps/*/package.json`)
- `apps/mouth/src/__nb_d_canary_test.tsx`: imports from `@nuzantara/totally-fake-nb-d-canary-pkg` which is NOT in any package.json deps and NOT in any tsconfig path alias

Expected: `Cross-import integrity` job fails on the `Detect undeclared workspace imports` step with an `::error file=apps/mouth/src/__nb_d_canary_test.tsx,line=3::undeclared workspace import` annotation.

Will be closed without merge regardless of result.