### PR TITLE
fix(ops): renaissance PR-A1 — machine-aware paths + DLQ PATH

### DIFF
--- a/scripts/curiosity_loop.sh
+++ b/scripts/curiosity_loop.sh
@@ -10,7 +10,17 @@
 
 set -euo pipefail
 
-REPO="/Users/antonellosiano/Projects/nuzantara"
+# Machine-aware repo + python (Pro vs Air). Dirname fallback so a future
+# user rename doesn't silently fail.
+case "$(whoami)" in
+    nuzantara)      REPO="$HOME/Desktop/nuzantara" ;;
+    antonellosiano) REPO="$HOME/Projects/nuzantara" ;;
+    *)
+        SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+        ;;
+esac
+
 LOG_DIR="$HOME/logs/cron"
 mkdir -p "$LOG_DIR"
 
@@ -21,7 +31,7 @@ if [ -f "$HOME/.nuzantara-secrets.env" ]; then
     set +a
 fi
 
-PY="/Users/antonellosiano/.pyenv/shims/python3"
+PY="$HOME/.pyenv/shims/python3"
 if [ ! -x "$PY" ]; then
     PY="/usr/bin/python3"
 fi

--- a/scripts/dlq_autopilot.py
+++ b/scripts/dlq_autopilot.py
@@ -226,7 +226,14 @@ Rules:
             logger.info(f"{job}: skip {label} (exhausted: {_EXHAUSTED_TOKENS[label]})")
             continue
 
-        env = {**os.environ, "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"}
+        env = {
+            **os.environ,
+            "PATH": (
+                f"{os.path.expanduser('~/.local/bin')}:"
+                f"{os.path.expanduser('~/.claude/local')}:"
+                "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+            ),
+        }
         if token:
             env["CLAUDE_CODE_OAUTH_TOKEN"] = token
         else:

--- a/scripts/genome_decay.sh
+++ b/scripts/genome_decay.sh
@@ -9,7 +9,17 @@
 
 set -euo pipefail
 
-REPO="/Users/antonellosiano/Projects/nuzantara"
+# Machine-aware repo + python (Pro vs Air). Dirname fallback so a future
+# user rename doesn't silently fail.
+case "$(whoami)" in
+    nuzantara)      REPO="$HOME/Desktop/nuzantara" ;;
+    antonellosiano) REPO="$HOME/Projects/nuzantara" ;;
+    *)
+        SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+        ;;
+esac
+
 CELLCORE="$REPO/packages/cell-core"
 LOG_DIR="$HOME/logs/cron"
 mkdir -p "$LOG_DIR"
@@ -21,7 +31,7 @@ if [ -f "$HOME/.nuzantara-secrets.env" ]; then
     set +a
 fi
 
-PY="/Users/antonellosiano/.pyenv/shims/python3"
+PY="$HOME/.pyenv/shims/python3"
 if [ ! -x "$PY" ]; then
     PY="/usr/bin/python3"
 fi


### PR DESCRIPTION
## Summary

PR-A1 of the automation renaissance plan. Two atomic fixes that unblock
infra-level cascades on Pro:

1. **`scripts/curiosity_loop.sh` + `scripts/genome_decay.sh`** — replace
   hardcoded Air paths (`/Users/antonellosiano/...`) with `whoami`-based
   dispatch + dirname fallback. Symbiosis Pillars 5 (Sogno/genome decay) and
   6 (Curiosity Loop) cron jobs were silently failing every night on Pro.
2. **`scripts/dlq_autopilot.py`** — preserve `~/.local/bin` in subprocess
   PATH so `claude --print` resolves. 100% of DLQ entries (54/run) were
   bypassing the claude-reasoning step due to `FileNotFoundError`.

## Evidence (live tested on Pro)

- **A1.2:** `bash -x curiosity_loop.sh` now uses
  `/Users/nuzantara/.pyenv/versions/3.11.11/bin/python3` and `cd`s into
  `/Users/nuzantara/Desktop/nuzantara`. (Downstream `asyncpg "role postgres
  does not exist"` is a separate DB-config issue tracked in MOS — not a
  regression of this PR.)
- **A1.4:** `seo_guardian_observe: reasoning → confidence=0.20
  needs_code=False type=unknown` after the PATH fix — confirms claude CLI
  is now reachable from the launchd-spawned Python subprocess.

## Out of scope for this PR (in-flight)

- A1.1 (FDA grant for `/usr/sbin/cron`): manual user action, completed.
- A1.3 missing scripts (`wr2_fact_checker.py`, `wr2_fact_extractor.py`):
  not in git history, not recoverable. LaunchAgents disabled and parked
  in `~/Library/LaunchAgents/.disabled/` on Pro pending design decision.
- A1.5 fly-pg-backup: confirmed working on Pro post-sync; produced 98MB
  backup `nuzantara-fly-20260429-2034.sql.gz`.

## Test plan

- [x] Bash syntax check on both .sh files (`bash -n`)
- [x] `bash -x` exec on Pro produces expected paths
- [x] DLQ live run on Pro shows reasoning succeed (confidence > 0)
- [x] Pre-commit hooks pass (lint, typecheck, no secrets, off-limits clean)

Reference: `research/ops/2026-04-29-pro-automations-audit/README.md`
(automation renaissance plan, Phase A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)