### PR TITLE
fix(ops): renaissance PR-C1 — auto_judgement_day machine-aware

### DIFF
--- a/scripts/auto_judgement_day.sh
+++ b/scripts/auto_judgement_day.sh
@@ -1,8 +1,25 @@
 #!/bin/bash
 
-# Configuration
-PROJECT_DIR="/Users/antonellosiano/Projects/nuzantara"
-PYTHON_EXEC="$PROJECT_DIR/apps/backend-rag/venv/bin/python3"
+# Configuration — machine-aware (Pro vs Air). Same pattern as
+# curiosity_loop.sh and genome_decay.sh after the renaissance PR-A1 fix.
+case "$(whoami)" in
+    nuzantara)
+        PROJECT_DIR="$HOME/Desktop/nuzantara"
+        # Pro uses .venv (CLAUDE.md §14)
+        PYTHON_EXEC="$PROJECT_DIR/apps/backend-rag/.venv/bin/python3"
+        ;;
+    antonellosiano)
+        PROJECT_DIR="$HOME/Projects/nuzantara"
+        # Air uses venv (CLAUDE.md §14)
+        PYTHON_EXEC="$PROJECT_DIR/apps/backend-rag/venv/bin/python3"
+        ;;
+    *)
+        SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+        PYTHON_EXEC="$PROJECT_DIR/apps/backend-rag/.venv/bin/python3"
+        [ -x "$PYTHON_EXEC" ] || PYTHON_EXEC="$PROJECT_DIR/apps/backend-rag/venv/bin/python3"
+        ;;
+esac
 EVAL_DIR="$PROJECT_DIR/apps/evaluator"
 LOG_FILE="$PROJECT_DIR/logs/judgement_day.log"
 DATE=$(date "+%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
## Summary

PR-C1 of the renaissance plan. Single fix: `scripts/auto_judgement_day.sh`
hardcoded the Air `PROJECT_DIR=/Users/antonellosiano/Projects/nuzantara`
on line 4, plus picked the Air-only `venv/` location (Pro uses `.venv/`
per CLAUDE.md §14).

Same Air-path-on-Pro pattern that PR-A1 fixed for `curiosity_loop.sh` and
`genome_decay.sh` — applied here with the same `whoami` dispatch + venv
selection.

## Why

Audit chunk3 P0 flagged this in the original report. On Pro the script
would write log lines to a non-existent Air path
(`/Users/antonellosiano/Projects/nuzantara/logs/judgement_day.log` →
"No such file or directory" 3×/run) and try `mkdir /Users/antonellosiano/...`
→ "Permission denied". The shell-redirect failures didn't propagate, so
the wrapper exited 0 and the cron looked healthy from outside. Sunday's
RAGAS evaluation was therefore silently broken for weeks.

## What changed

- Lines 3-8 — replaced hardcoded Air paths with a `case "$(whoami)"` block
  selecting `$HOME/Desktop/nuzantara` (Pro) or `$HOME/Projects/nuzantara`
  (Air), and the matching venv (`.venv` vs `venv`). Dirname fallback for
  third-machine safety.

## What stayed the same

- ragas/langchain dependency check at lines ~14-19 (now relative to the
  resolved `$PYTHON_EXEC`)
- Telegram failure alert wiring
- Crontab entry (`0 8 * * 0 ... auto_judgement_day.sh`) — no change needed

## Live test on Pro

- ✓ Script writes to the right path: `/Users/nuzantara/Desktop/nuzantara/logs/judgement_day.log`
- ✓ Resolves `.venv` Python correctly: `/Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python3`
- ⚠️ Now exposes a downstream issue: `ModuleNotFoundError: No module named
  'langchain_google_genai'`. Out of scope for this PR; tracked in MOS as
  unresolved (the venv on Pro lacks that dep + ragas may be incomplete).

## Other PR-C1 items (no commit needed)

The 11 other ex-TCC-blocked cron jobs are healthy after PR-A1.1 (the
manual FDA grant). Live-verified on Pro post-grant:
- `auto_test.sh` — runs (test failures inside are pre-existing, not
  TCC-related)
- `auto_sentinel.sh` — runs
- `rag-canary.py` — produces `passed: true, score: 0.4566` JSON output
- `db-nlm-sync` — runs (logs to `~/logs/cron/db-nlm-sync.log`)

So PR-C1 boils down to this 1-file machine-aware fix.

## Test plan

- [x] `bash -n scripts/auto_judgement_day.sh` — syntax OK
- [x] Live exec on Pro — writes to `~/Desktop/nuzantara/logs/...` (correct)
- [x] Pre-commit hooks pass

Reference: `research/ops/2026-04-29-pro-automations-audit/README.md`
(automation renaissance plan, Phase C-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)