### PR TITLE
fix(ops): renaissance PR-C2 — intel-radar-daily-digest Python 3.11.9→3.11.11

### DIFF
--- a/infra/launchagents/com.balizero.intel-radar-daily-digest.plist
+++ b/infra/launchagents/com.balizero.intel-radar-daily-digest.plist
@@ -8,7 +8,7 @@
     <array>
         <string>/bin/zsh</string>
         <string>-lc</string>
-        <string>set -a; [ -f /Users/nuzantara/.nuzantara-secrets.env ] &amp;&amp; source /Users/nuzantara/.nuzantara-secrets.env; set +a; /Users/nuzantara/.pyenv/versions/3.11.9/bin/python3 /Users/nuzantara/scripts/cron-agent-python/intel_radar_daily_digest.py &gt;&gt; /Users/nuzantara/logs/intel-radar-daily-digest.log 2&gt;&amp;1</string>
+        <string>set -a; [ -f /Users/nuzantara/.nuzantara-secrets.env ] &amp;&amp; source /Users/nuzantara/.nuzantara-secrets.env; set +a; /Users/nuzantara/.pyenv/versions/3.11.11/bin/python3 /Users/nuzantara/scripts/cron-agent-python/intel_radar_daily_digest.py &gt;&gt; /Users/nuzantara/logs/intel-radar-daily-digest.log 2&gt;&amp;1</string>
     </array>
     <key>StartCalendarInterval</key>
     <dict>
@@ -28,7 +28,7 @@
         <key>HOME</key>
         <string>/Users/nuzantara</string>
         <key>PATH</key>
-        <string>/Users/nuzantara/.pyenv/versions/3.11.9/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>/Users/nuzantara/.pyenv/versions/3.11.11/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     </dict>
     <key>KeepAlive</key>
     <false/>


### PR DESCRIPTION
## Summary

Updates the canonical
`infra/launchagents/com.balizero.intel-radar-daily-digest.plist` to use
Python 3.11.11 instead of 3.11.9. Pro only has 3.11.11 installed
(`pyenv versions --bare` confirms), so every fire wrote 3 lines of
"no such file or directory" and the daily intel digest never reached
Zero on Telegram. Audit chunk1 P0.

## What changed

- 2 occurrences of `3.11.9` → `3.11.11` in
  `infra/launchagents/com.balizero.intel-radar-daily-digest.plist`:
  - `EnvironmentVariables.PATH` (line 31)
  - inline `zsh -lc` command (line 11)

## Branch hygiene note

Verified before opening this PR: branch contains ONLY the plist change
(`git diff main..HEAD` = 1 file, 4 lines). The 3 Atlas-related untracked
files (`.github/workflows/atlas-migrate-lint.yml`, `atlas.hcl`,
`scripts/atlas_split_migrations.sh`) that were sitting in the working
tree from the 2026-04-26 brainstorm are NOT in this PR — they were
intentionally handled in a separate branch
`chore/disable-atlas-attempt-2026-04-29` (PR #363) which moves them to
`.disabled/` for audit. See cicatrix-scars.md entry "Atlas migrate-lint
paywalled in v0.38 — pivoted to Squawk".

## Live verification on Pro

Synced the live `~/Library/LaunchAgents/` copy and reloaded with
`launchctl bootout/bootstrap + kickstart -k`. Post-fix:

- `plutil -extract EnvironmentVariables.PATH` → `3.11.11` path active
- Fresh kickstart: `redis_event_published` log line written, no python3
  not-found errors
- Stream `cron:intel-radar-daily-digest` now publishing events to Redis

## Cross-check with PR-B1 linter

The new `lint_launchagents.sh` rule shipped in PR-B1 caught this exact
violation:

> [VIOLATION] com.balizero.intel-radar-daily-digest: pinned Python 3.11.9
> not installed (have: 3.11.11)

Confirms the linter is doing its job — it would have prevented the
regression had it been wired earlier.

## Out-of-band change (not in git)

The `0 9 * * * job_health.py --alert` crontab line on Pro now sources
`~/.nuzantara-secrets.env` before invocation, so the daily 1-of-11
healthy summary reaches Zero on Telegram. Crontab isn't git-tracked;
the change is logged in the audit pack
(`research/ops/2026-04-29-pro-automations-audit/README.md` PR-C2.2).

## Test plan

- [x] `plutil -lint` on patched plist — OK
- [x] Live kickstart on Pro — `redis_event_published` log line
- [x] PR-B1 linter no longer flags this plist's Python pin
- [x] Pre-commit hooks pass

Reference: `research/ops/2026-04-29-pro-automations-audit/README.md`
(automation renaissance plan, Phase C-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)