### PR TITLE
feat(notifications): NB-E Resend fallback + team alerts Indonesian

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ See [`INDEX.md`](INDEX.md) for the full atlas including packages, tessuti dati, 
 ### Tech Stack
 
 <!-- DOCSYNC:BACKEND_STATS_START -->
-- **Backend:** Python 3.11+, FastAPI, 253 routers, 513 services, 869 test files
+- **Backend:** Python 3.11+, FastAPI, 253 routers, 516 services, 880 test files
 <!-- DOCSYNC:BACKEND_STATS_END -->
 - **Frontend:** Next.js, TypeScript, Tailwind CSS
 - **Databases:** PostgreSQL (relational), Qdrant (vector), Redis (cache)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 253 routers · 513 services
+- Backend: FastAPI · 253 routers · 516 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 21 · Packages: 5

--- a/apps/backend-rag/backend/app/modules/notifications/router.py
+++ b/apps/backend-rag/backend/app/modules/notifications/router.py
@@ -313,28 +313,44 @@ async def send_direct_email(
     bcc_list = [b.strip() for b in request.bcc.split(",")] if request.bcc else None
     attachments = [a.model_dump() for a in request.attachments] if request.attachments else None
 
-    # Route: intra-domain (@balizero.com) → Zoho SMTP, external → Brevo
+    # Provider chain (NB-E 2026-04-29):
+    #   intra-domain (@balizero.com): Zoho SMTP → Brevo
+    #   external:                     Brevo → Resend → Zoho SMTP
+    # Resend uses zantara@send.balizero.com (separate DKIM) so a Brevo
+    # account suspension / apex DNS issue cannot also kill the fallback.
     if request.to.endswith("@balizero.com"):
-        result = await _send_via_zoho_smtp(request.to, request.subject, request.body, cc_list, bcc_list, attachments)
+        chain: list[tuple[str, callable]] = [  # type: ignore[type-arg]
+            ("zoho", _send_via_zoho_smtp),
+            ("brevo", _send_via_brevo),
+        ]
     else:
-        result = await _send_via_brevo(request.to, request.subject, request.body, cc_list, bcc_list, attachments)
+        chain = [
+            ("brevo", _send_via_brevo),
+            ("resend", _send_via_resend),
+            ("zoho", _send_via_zoho_smtp),
+        ]
 
-    if result:
-        logger.info(f"Direct email sent to {request.to} — {request.subject!r}")
-        return SendEmailResponse(success=True, message=f"Email sent to {request.to}")
+    for idx, (name, sender) in enumerate(chain):
+        result = await sender(
+            request.to, request.subject, request.body, cc_list, bcc_list, attachments,
+        )
+        if result:
+            tag = "primary" if idx == 0 else f"fallback={name}"
+            logger.info(
+                f"Direct email sent to {request.to} via {name} ({tag}) — {request.subject!r}"
+            )
+            return SendEmailResponse(
+                success=True,
+                message=f"Email sent to {request.to} via {name}",
+            )
+        logger.warning(
+            f"Provider {name} failed for {request.to}, trying next in chain"
+        )
 
-    # Fallback: if primary fails, try the other channel
-    logger.warning(f"Primary channel failed for {request.to}, trying fallback")
-    if request.to.endswith("@balizero.com"):
-        fallback = await _send_via_brevo(request.to, request.subject, request.body, cc_list, bcc_list, attachments)
-    else:
-        fallback = await _send_via_zoho_smtp(request.to, request.subject, request.body, cc_list, bcc_list, attachments)
-
-    if fallback:
-        logger.info(f"Email sent to {request.to} via fallback — {request.subject!r}")
-        return SendEmailResponse(success=True, message=f"Email sent to {request.to} (fallback)")
-
-    return SendEmailResponse(success=False, message="Both Zoho SMTP and Brevo failed")
+    return SendEmailResponse(
+        success=False,
+        message=f"All providers failed: {', '.join(n for n, _ in chain)}",
+    )
 
 
 async def _send_via_zoho_smtp(
@@ -428,6 +444,32 @@ async def _send_via_brevo(
     except Exception as e:
         logger.error(f"Brevo failed for {to_email}: {e}")
         return False
+
+
+async def _send_via_resend(
+    to_email: str,
+    subject: str,
+    body: str,
+    cc_list: list[str] | None,
+    bcc_list: list[str] | None = None,
+    attachments: list[dict] | None = None,
+) -> bool:
+    """Send via Resend HTTPS API (fallback for external delivery, NB-E 2026-04-29).
+
+    Uses ``zantara@send.balizero.com`` (separate DKIM/MX subdomain) so a
+    Brevo suspension or apex ``balizero.com`` DNS misconfiguration does
+    not also break the fallback path. Returns False on any failure.
+    """
+    from backend.services.notifications.resend_http import send_via_resend
+
+    return await send_via_resend(
+        to_email=to_email,
+        subject=subject,
+        body=body,
+        cc=cc_list,
+        bcc=bcc_list,
+        attachments=attachments,
+    )
 
 
 # Include test endpoints only in non-production environments

--- a/apps/backend-rag/backend/services/crm/notifiers.py
+++ b/apps/backend-rag/backend/services/crm/notifiers.py
@@ -483,7 +483,10 @@ class StalePracticeNotifier:
         logger.info("Admin summary sent", extra={"context": {"to": ADMIN_EMAIL, "stale_count": len(stale)}})
 
     async def _send_team_leader_alert(self, email: str, practices: list[dict[str, Any]]) -> None:
-        subject = "[TEAM] ⏰ Pratiche in attesa — aggiornamento richiesto"
+        # Language policy 2026-04-29: messages directed exclusively at team
+        # members default to Indonesian (Bali Zero team is mostly Indonesian).
+        # Client-facing flows still use NATIONALITY_LANGUAGE_MAP elsewhere.
+        subject = "[TEAM] ⏰ Praktik tertunda — perlu pembaruan"
 
         rows_html = ""
         for p in practices:
@@ -494,7 +497,7 @@ class StalePracticeNotifier:
                 f'<td style="{_TD}">{_esc(p["client_name"])}</td>'
                 f'<td style="{_TD}">{_esc(p["practice_type_name"])}</td>'
                 f'<td style="{_TD}">{_esc(p["status"])}</td>'
-                f'<td style="{_TD};color:#f87171;font-weight:600;">{p["days_stale"]} giorni</td>'
+                f'<td style="{_TD};color:#f87171;font-weight:600;">{p["days_stale"]} hari</td>'
                 f"</tr>\n"
             )
 
@@ -503,24 +506,24 @@ class StalePracticeNotifier:
         <body style="font-family:Arial,sans-serif;background:#0f172a;color:#e2e8f0;padding:24px;">
           <div style="max-width:700px;margin:0 auto;">
             <h2 style="color:#f1f5f9;margin-bottom:4px;">
-              Ciao! \ud83d\udc4b Alcune pratiche hanno bisogno della tua attenzione.
+              Halo! \ud83d\udc4b Beberapa praktik membutuhkan perhatian Anda.
             </h2>
             <p style="color:#cbd5e1;line-height:1.6;">
-              Alcune tue pratiche non hanno aggiornamenti da <strong>{STALE_DAYS}+ giorni</strong>.
-              Puoi controllare lo stato e aggiungere una nota nel CRM?
+              Beberapa praktik Anda belum diperbarui selama <strong>{STALE_DAYS}+ hari</strong>.
+              Bisakah Anda memeriksa statusnya dan menambahkan catatan di CRM?
             </p>
             <table style="width:100%;border-collapse:collapse;margin-top:16px;">
               <thead>
                 <tr style="background:#1e3a5f;">
-                  <th style="{_TH}">ID</th><th style="{_TH}">Cliente</th>
-                  <th style="{_TH}">Tipo pratica</th><th style="{_TH}">Status</th>
-                  <th style="{_TH}">Giorni senza agg.</th>
+                  <th style="{_TH}">ID</th><th style="{_TH}">Klien</th>
+                  <th style="{_TH}">Jenis praktik</th><th style="{_TH}">Status</th>
+                  <th style="{_TH}">Hari tanpa pembaruan</th>
                 </tr>
               </thead>
               <tbody>{rows_html}</tbody>
             </table>
             <p style="margin-top:24px;font-size:13px;color:#64748b;">
-              Grazie mille! \u2014 Zantara CRM
+              Terima kasih banyak! \u2014 Zantara CRM
             </p>
           </div>
         </body>

--- a/apps/backend-rag/backend/services/notifications/resend_http.py
+++ b/apps/backend-rag/backend/services/notifications/resend_http.py
@@ -1,0 +1,106 @@
+"""Resend HTTPS API client used as fallback when Brevo fails.
+
+NB-E (2026-04-29): Brevo remains primary for external recipients; Resend
+is the secondary path. The two providers use different verified domains
+on purpose so a Brevo account suspension or DNS misconfiguration on the
+apex ``balizero.com`` cannot also take down the fallback:
+
+- Brevo  → ``zantara@balizero.com``        (alias of damar@balizero.com)
+- Resend → ``zantara@send.balizero.com``    (subdomain, separate DKIM/MX)
+
+The fallback exists for *delivery* failures (Brevo HTTP 5xx, account
+freeze, network), not for *content* failures (bad recipient address,
+malformed payload). The Resend call uses the same payload semantics so
+a payload that fails Brevo will also fail Resend; degrade-gracefully —
+the goal is to keep the channel diversified, not to retry past a
+genuine bad request.
+
+Configuration:
+- ``RESEND_API_KEY``       — Resend API key, format ``re_...``
+- ``RESEND_FROM_EMAIL``    — sender override, default ``zantara@send.balizero.com``
+- ``RESEND_FROM_NAME``     — sender display name, default ``Zantara``
+
+Failure mode contract: returns ``False`` on any non-2xx, missing key, or
+exception. NEVER raises. The caller decides whether to alert.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+from backend.services.notifications.email_http import get_email_client
+
+logger = logging.getLogger(__name__)
+
+_RESEND_API_URL = "https://api.resend.com/emails"
+
+
+async def send_via_resend(
+    *,
+    to_email: str,
+    subject: str,
+    body: str,
+    cc: list[str] | None = None,
+    bcc: list[str] | None = None,
+    attachments: list[dict] | None = None,
+) -> bool:
+    """Send an HTML email via Resend.
+
+    Returns True on 2xx, False on any other outcome. Never raises.
+
+    The ``from`` address defaults to the verified ``send.balizero.com``
+    subdomain so a DKIM/MX failure on the apex ``balizero.com`` (Brevo's
+    domain) does not also kill the fallback path.
+    """
+    api_key = os.getenv("RESEND_API_KEY", "")
+    if not api_key:
+        logger.debug("resend_http: RESEND_API_KEY not set — skipping fallback")
+        return False
+
+    from_email = os.getenv("RESEND_FROM_EMAIL", "zantara@send.balizero.com")
+    from_name = os.getenv("RESEND_FROM_NAME", "Zantara")
+
+    payload: dict = {
+        "from": f"{from_name} <{from_email}>",
+        "to": [to_email],
+        "subject": subject,
+        "html": body,
+    }
+    if cc:
+        payload["cc"] = list(cc)
+    if bcc:
+        payload["bcc"] = list(bcc)
+    if attachments:
+        payload["attachments"] = [
+            {"filename": a.get("name", "attachment"), "content": a.get("content", "")}
+            for a in attachments
+        ]
+
+    try:
+        client = await get_email_client()
+        resp = await client.post(
+            _RESEND_API_URL,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+        )
+        if resp.status_code in (200, 201, 202):
+            logger.info(
+                "Resend fallback sent: to=%s subject=%r from=%s",
+                to_email,
+                subject,
+                from_email,
+            )
+            return True
+        logger.error(
+            "Resend API error %d for %s: %s",
+            resp.status_code,
+            to_email,
+            resp.text[:300],
+        )
+        return False
+    except Exception as e:
+        logger.error("Resend fallback failed for %s: %s", to_email, e)
+        return False

--- a/apps/backend-rag/backend/tests/unit/app/modules/notifications/test_send_email_chain.py
+++ b/apps/backend-rag/backend/tests/unit/app/modules/notifications/test_send_email_chain.py
@@ -1,0 +1,157 @@
+"""Provider-chain tests for ``POST /api/notifications/send-email``.
+
+NB-E (2026-04-29) extends the chain to:
+
+    intra-domain:  Zoho SMTP  → Brevo
+    external:      Brevo → Resend → Zoho SMTP
+
+These tests exercise the chain order without going to the network.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.app.modules.notifications.router import (
+    SendEmailRequest,
+    send_direct_email,
+)
+
+
+@pytest.fixture
+def req_external():
+    return SendEmailRequest(
+        to="alice@example.com", subject="hi", body="<p>x</p>",
+    )
+
+
+@pytest.fixture
+def req_intra():
+    return SendEmailRequest(
+        to="bob@balizero.com", subject="hi", body="<p>x</p>",
+    )
+
+
+@pytest.mark.asyncio
+async def test_external_brevo_succeeds_no_fallback(req_external):
+    """When Brevo (primary for externals) succeeds, Resend and Zoho must NOT be called."""
+    with (
+        patch(
+            "backend.app.modules.notifications.router._send_via_brevo",
+            new=AsyncMock(return_value=True),
+        ) as brevo,
+        patch(
+            "backend.app.modules.notifications.router._send_via_resend",
+            new=AsyncMock(return_value=True),
+        ) as resend,
+        patch(
+            "backend.app.modules.notifications.router._send_via_zoho_smtp",
+            new=AsyncMock(return_value=True),
+        ) as zoho,
+    ):
+        resp = await send_direct_email(req_external, _auth={})
+    assert resp.success is True
+    assert "brevo" in resp.message
+    brevo.assert_called_once()
+    resend.assert_not_called()
+    zoho.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_external_brevo_fail_resend_succeeds(req_external):
+    """Brevo failure must fall through to Resend (the new NB-E layer) before Zoho."""
+    with (
+        patch(
+            "backend.app.modules.notifications.router._send_via_brevo",
+            new=AsyncMock(return_value=False),
+        ) as brevo,
+        patch(
+            "backend.app.modules.notifications.router._send_via_resend",
+            new=AsyncMock(return_value=True),
+        ) as resend,
+        patch(
+            "backend.app.modules.notifications.router._send_via_zoho_smtp",
+            new=AsyncMock(return_value=True),
+        ) as zoho,
+    ):
+        resp = await send_direct_email(req_external, _auth={})
+    assert resp.success is True
+    assert "resend" in resp.message
+    brevo.assert_called_once()
+    resend.assert_called_once()
+    zoho.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_external_brevo_and_resend_fail_zoho_last_resort(req_external):
+    """If both Brevo and Resend fail, Zoho SMTP is the last resort."""
+    with (
+        patch(
+            "backend.app.modules.notifications.router._send_via_brevo",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "backend.app.modules.notifications.router._send_via_resend",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "backend.app.modules.notifications.router._send_via_zoho_smtp",
+            new=AsyncMock(return_value=True),
+        ) as zoho,
+    ):
+        resp = await send_direct_email(req_external, _auth={})
+    assert resp.success is True
+    assert "zoho" in resp.message
+    zoho.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_external_all_three_fail(req_external):
+    with (
+        patch(
+            "backend.app.modules.notifications.router._send_via_brevo",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "backend.app.modules.notifications.router._send_via_resend",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "backend.app.modules.notifications.router._send_via_zoho_smtp",
+            new=AsyncMock(return_value=False),
+        ),
+    ):
+        resp = await send_direct_email(req_external, _auth={})
+    assert resp.success is False
+    # All three providers should be named in the failure message.
+    assert "brevo" in resp.message
+    assert "resend" in resp.message
+    assert "zoho" in resp.message
+
+
+@pytest.mark.asyncio
+async def test_intra_domain_does_not_use_resend(req_intra):
+    """Resend must NOT appear in the intra-domain chain — Zoho is primary,
+    Brevo is the only fallback. Adding Resend on @balizero.com would
+    cross domains needlessly."""
+    with (
+        patch(
+            "backend.app.modules.notifications.router._send_via_zoho_smtp",
+            new=AsyncMock(return_value=False),
+        ) as zoho,
+        patch(
+            "backend.app.modules.notifications.router._send_via_brevo",
+            new=AsyncMock(return_value=True),
+        ) as brevo,
+        patch(
+            "backend.app.modules.notifications.router._send_via_resend",
+            new=AsyncMock(return_value=True),
+        ) as resend,
+    ):
+        resp = await send_direct_email(req_intra, _auth={})
+    assert resp.success is True
+    zoho.assert_called_once()
+    brevo.assert_called_once()
+    resend.assert_not_called()

--- a/apps/backend-rag/backend/tests/unit/services/crm/test_notifiers_team_lang.py
+++ b/apps/backend-rag/backend/tests/unit/services/crm/test_notifiers_team_lang.py
@@ -1,0 +1,85 @@
+"""Pin the team-leader alert language to Indonesian (NB-E 2026-04-29).
+
+Policy: messages directed *exclusively* at team members default to
+Indonesian — the Bali Zero team is mostly Indonesian. Client-facing
+flows continue to use ``NATIONALITY_LANGUAGE_MAP`` and default to
+English when nationality is missing.
+
+This test guards against accidental reverts to the old hardcoded
+Italian template (which leaked Italian text to Indonesian recipients
+and was the immediate trigger for this language audit).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.services.crm.notifiers import StalePracticeNotifier
+
+
+@pytest.fixture
+def practices() -> list[dict]:
+    return [
+        {
+            "id": 42,
+            "client_name": "PT Example",
+            "practice_type_name": "KITAS",
+            "status": "in_review",
+            "days_stale": 9,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_team_leader_alert_uses_indonesian_subject(practices):
+    pool = MagicMock()
+    notifier = StalePracticeNotifier(pool)
+    sent = {}
+
+    async def _capture(**kwargs):
+        sent.update(kwargs)
+
+    with patch(
+        "backend.services.crm.notifiers.send_internal_email",
+        new=AsyncMock(side_effect=_capture),
+    ):
+        await notifier._send_team_leader_alert(  # noqa: SLF001 — pinning private contract
+            "team@balizero.com", practices,
+        )
+
+    # Subject pinned to Indonesian.
+    assert sent["subject"] == "[TEAM] ⏰ Praktik tertunda — perlu pembaruan"
+
+
+@pytest.mark.asyncio
+async def test_team_leader_alert_body_has_no_italian_strings(practices):
+    """Regression guard: verify the body contains the new Indonesian
+    strings and none of the old Italian phrasing."""
+    pool = MagicMock()
+    notifier = StalePracticeNotifier(pool)
+    sent = {}
+
+    async def _capture(**kwargs):
+        sent.update(kwargs)
+
+    with patch(
+        "backend.services.crm.notifiers.send_internal_email",
+        new=AsyncMock(side_effect=_capture),
+    ):
+        await notifier._send_team_leader_alert(  # noqa: SLF001
+            "team@balizero.com", practices,
+        )
+
+    body = sent["body"]
+    # Indonesian strings present.
+    assert "Halo!" in body
+    assert "Beberapa praktik" in body
+    assert "Terima kasih" in body
+    assert "9 hari" in body
+    # Italian strings absent (regression guard).
+    assert "Ciao!" not in body
+    assert "Alcune pratiche" not in body
+    assert "Grazie mille" not in body
+    assert "9 giorni" not in body

--- a/apps/backend-rag/backend/tests/unit/services/notifications/test_resend_http.py
+++ b/apps/backend-rag/backend/tests/unit/services/notifications/test_resend_http.py
@@ -1,0 +1,155 @@
+"""Unit tests for ``services.notifications.resend_http``.
+
+Resend is the secondary delivery path when Brevo fails (NB-E 2026-04-29).
+Contract under test:
+
+- Returns ``True`` only on HTTP 200/201/202.
+- Returns ``False`` on missing ``RESEND_API_KEY`` (no exception, no log spam).
+- Returns ``False`` on non-2xx response (logs the body excerpt).
+- Returns ``False`` on httpx exception (degrade-gracefully, no raise).
+- Default ``from`` is the ``send.balizero.com`` subdomain so Brevo apex DNS
+  issues do not cascade into the fallback path.
+- ``cc`` / ``bcc`` / attachments are forwarded to the Resend payload shape.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from backend.services.notifications.resend_http import send_via_resend
+
+
+def _mk_response(status: int = 202, body: str = '{"id":"resend_xxx"}') -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status
+    resp.text = body
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_returns_false_when_api_key_missing(monkeypatch):
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+    with patch(
+        "backend.services.notifications.resend_http.get_email_client",
+        new=AsyncMock(),
+    ) as mocked:
+        result = await send_via_resend(
+            to_email="alice@example.com",
+            subject="hello",
+            body="<p>hi</p>",
+        )
+    assert result is False
+    mocked.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_returns_true_on_2xx(monkeypatch):
+    monkeypatch.setenv("RESEND_API_KEY", "re_test_key_xxxxxx")
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=_mk_response(202))
+    with patch(
+        "backend.services.notifications.resend_http.get_email_client",
+        new=AsyncMock(return_value=fake_client),
+    ):
+        result = await send_via_resend(
+            to_email="alice@example.com",
+            subject="hello",
+            body="<p>hi</p>",
+        )
+    assert result is True
+    fake_client.post.assert_called_once()
+    args, kwargs = fake_client.post.call_args
+    assert args[0] == "https://api.resend.com/emails"
+    assert kwargs["headers"]["Authorization"].startswith("Bearer re_")
+    payload = kwargs["json"]
+    # Default from is send.balizero.com — the verified subdomain.
+    assert "send.balizero.com" in payload["from"]
+    assert payload["to"] == ["alice@example.com"]
+    assert payload["subject"] == "hello"
+    assert payload["html"] == "<p>hi</p>"
+
+
+@pytest.mark.asyncio
+async def test_default_from_uses_send_subdomain(monkeypatch):
+    """Apex balizero.com is Brevo's domain. Resend MUST default to the
+    separate subdomain so a Brevo apex DKIM/MX failure does not also
+    take down the fallback. This test pins the default."""
+    monkeypatch.setenv("RESEND_API_KEY", "re_key")
+    monkeypatch.delenv("RESEND_FROM_EMAIL", raising=False)
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=_mk_response(200))
+    with patch(
+        "backend.services.notifications.resend_http.get_email_client",
+        new=AsyncMock(return_value=fake_client),
+    ):
+        await send_via_resend(to_email="x@y.com", subject="s", body="b")
+    payload = fake_client.post.call_args.kwargs["json"]
+    assert payload["from"] == "Zantara <zantara@send.balizero.com>"
+
+
+@pytest.mark.asyncio
+async def test_returns_false_on_4xx(monkeypatch):
+    monkeypatch.setenv("RESEND_API_KEY", "re_key")
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=_mk_response(422, '{"error":"bad"}'))
+    with patch(
+        "backend.services.notifications.resend_http.get_email_client",
+        new=AsyncMock(return_value=fake_client),
+    ):
+        result = await send_via_resend(to_email="x@y.com", subject="s", body="b")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_returns_false_on_exception(monkeypatch):
+    monkeypatch.setenv("RESEND_API_KEY", "re_key")
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(side_effect=httpx.ConnectError("boom"))
+    with patch(
+        "backend.services.notifications.resend_http.get_email_client",
+        new=AsyncMock(return_value=fake_client),
+    ):
+        result = await send_via_resend(to_email="x@y.com", subject="s", body="b")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_cc_bcc_attachments_forwarded(monkeypatch):
+    monkeypatch.setenv("RESEND_API_KEY", "re_key")
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=_mk_response(202))
+    with patch(
+        "backend.services.notifications.resend_http.get_email_client",
+        new=AsyncMock(return_value=fake_client),
+    ):
+        await send_via_resend(
+            to_email="x@y.com",
+            subject="s",
+            body="b",
+            cc=["c@x.com"],
+            bcc=["b@x.com"],
+            attachments=[{"name": "doc.pdf", "content": "BASE64=="}],
+        )
+    payload = fake_client.post.call_args.kwargs["json"]
+    assert payload["cc"] == ["c@x.com"]
+    assert payload["bcc"] == ["b@x.com"]
+    assert payload["attachments"] == [{"filename": "doc.pdf", "content": "BASE64=="}]
+
+
+@pytest.mark.asyncio
+async def test_from_override_via_env(monkeypatch):
+    monkeypatch.setenv("RESEND_API_KEY", "re_key")
+    monkeypatch.setenv("RESEND_FROM_EMAIL", "ops@send.balizero.com")
+    monkeypatch.setenv("RESEND_FROM_NAME", "Ops")
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=_mk_response(202))
+    with patch(
+        "backend.services.notifications.resend_http.get_email_client",
+        new=AsyncMock(return_value=fake_client),
+    ):
+        await send_via_resend(to_email="x@y.com", subject="s", body="b")
+    payload = fake_client.post.call_args.kwargs["json"]
+    assert payload["from"] == "Ops <ops@send.balizero.com>"

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`253 routers · 513 services · 869 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`253 routers · 516 services · 880 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary

Two related fixes shipped together because they share the email policy
boundary surfaced by today's audit:

- **NB-E** — `POST /api/notifications/send-email` gains a Resend fallback between Brevo and Zoho SMTP for external recipients. Resend uses the new verified subdomain `send.balizero.com` (Cloudflare DNS records DKIM/SPF/MX added 2026-04-29) so a Brevo apex DKIM/MX failure cannot also kill the fallback.
- **Team alerts language** — `_send_team_leader_alert` in `services/crm/notifiers.py` had subject + body hardcoded in Italian. Bali Zero team members are mostly Indonesian; the message that goes *exclusively* to the team now defaults to Indonesian. Owner-only messages (`_send_zero_summary`) stay Italian.

## Provider chain after this PR

| Recipient class | Chain |
|---|---|
| External (`@gmail`, `@outlook`, …) | Brevo → **Resend** → Zoho SMTP |
| Intra-domain (`@balizero.com`) | Zoho SMTP → Brevo (unchanged) |

`RESEND_API_KEY` activation is opt-in: missing key skips the Resend layer silently and the chain falls through to Zoho.

## Email-language policy (codified)

| Audience | Language |
|---|---|
| Client (`nationality` set) | `NATIONALITY_LANGUAGE_MAP` |
| Client (`nationality` empty) | English (existing default) |
| Team member (message directed *exclusively* to the team) | **Indonesian** (new default) |
| Owner (Zero-only summary) | Italian (unchanged) |

## Tests

- `backend/tests/unit/services/notifications/test_resend_http.py` — 7 tests pin: 2xx success path, missing-key silent skip, 4xx fallthrough, httpx exception fallthrough, default sender = `send.balizero.com` (regression guard), env override, cc/bcc/attachment forwarding.
- `backend/tests/unit/app/modules/notifications/test_send_email_chain.py` — 5 tests pin provider order: brevo-first wins skips resend+zoho; brevo-fail uses resend; both-fail uses zoho last-resort; all-three-fail returns failure list with all provider names; intra-domain never touches Resend.
- `backend/tests/unit/services/crm/test_notifiers_team_lang.py` — 2 tests pin the new Indonesian subject + body strings and assert the absence of the old Italian phrasing (regression guard against accidental reverts).

Local run: 14 new + 106 existing = **120/120 PASS** in the affected suites.

## Test plan

- [x] `PYTHONPATH=. pytest backend/tests/unit/services/notifications/test_resend_http.py -q` → 7 PASS
- [x] `PYTHONPATH=. pytest backend/tests/unit/app/modules/notifications/test_send_email_chain.py -q` → 5 PASS
- [x] `PYTHONPATH=. pytest backend/tests/unit/services/crm/test_notifiers_team_lang.py -q` → 2 PASS
- [x] Notifications + crm-notifier wider sweep → 120/120 PASS, no regressions
- [x] Import chain validates with stub secrets
- [ ] Post-deploy: trigger a fake Brevo failure (e.g. invalid recipient) and confirm Resend log line appears in Fly logs
- [ ] Post-deploy: send a stale-practice alert (or wait for next cron) — confirm subject = `[TEAM] ⏰ Praktik tertunda — perlu pembaruan`

## Pre-deploy / activation steps

`RESEND_API_KEY` must be set on Fly for the fallback to engage:

```bash
fly secrets set -a nuzantara-rag \
  RESEND_API_KEY=re_CeKxy34c_MJt18zZ4TYpe1j8jhDdQGoqP
```

(The key is already in `~/.nuzantara-secrets.env` on Pro/Air.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)