### PR TITLE
fix(ops): renaissance PR-C3 — missing-env / source ~/.nuzantara-secrets.env

### DIFF
--- a/apps/evaluator/nlm_deep_research/scripts/run_heartbeat_check.sh
+++ b/apps/evaluator/nlm_deep_research/scripts/run_heartbeat_check.sh
@@ -9,6 +9,15 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 
+# ── Load secrets (TELEGRAM_BOT_TOKEN / TELEGRAM_OWNER_CHAT_ID for
+#    CRITICAL/DEAD pipeline alerts) ───────────────────────────────────────────
+if [ -f "$HOME/.nuzantara-secrets.env" ]; then
+    # shellcheck disable=SC1091
+    set -a
+    source "$HOME/.nuzantara-secrets.env"
+    set +a
+fi
+
 # Detect venv (Pro uses .venv, Air uses venv)
 if [ -d "$PROJECT_ROOT/apps/backend-rag/.venv" ]; then
     PYTHON="$PROJECT_ROOT/apps/backend-rag/.venv/bin/python"

--- a/apps/evaluator/nlm_deep_research/scripts/run_peraturan_ingestion.sh
+++ b/apps/evaluator/nlm_deep_research/scripts/run_peraturan_ingestion.sh
@@ -17,6 +17,15 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 LOG_FILE="$PROJECT_ROOT/apps/evaluator/nlm_deep_research/peraturan_ingestion.log"
 LOCK_FILE="/tmp/peraturan_ingestion.lock"
 
+# ── Load secrets (GOOGLE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS,
+#    plus any optional Telegram tokens used by downstream notify hooks) ───────
+if [ -f "$HOME/.nuzantara-secrets.env" ]; then
+    # shellcheck disable=SC1091
+    set -a
+    source "$HOME/.nuzantara-secrets.env"
+    set +a
+fi
+
 cd "$PROJECT_ROOT"
 
 # ── PID lock (prevent overlapping runs) ──────────────────────────────────────

--- a/docs/ops/2026-04-30-pr-c3-missing-env.md
+++ b/docs/ops/2026-04-30-pr-c3-missing-env.md
@@ -1,0 +1,117 @@
+# PR-C3 — Missing-env / missing-secrets fixes (2026-04-30)
+
+Phase C of the Pro automations renaissance. Two cron-driven scripts
+were silently broken because they read env vars that the cron context
+never set. Fix is canonical: source `~/.nuzantara-secrets.env` at the
+top of each script, behind an `if [ -f ]` guard so dev machines
+without the file still work.
+
+Audit reference:
+`research/ops/2026-04-29-pro-automations-audit/automations-audit-2026-04-29.csv`
+
+## Targets
+
+### 1. `run_peraturan_ingestion.sh` (cron `30 21 * * 0`)
+
+**Before:** failed three consecutive Sunday runs (2026-04-12, 04-19,
+04-26) with `Google credentials error: GOOGLE_SERVICE_ACCOUNT_JSON env
+var missing`. Three lost ingestion windows for `peraturan` regulation
+sheet → Qdrant/KG/Drive/NLM NB-6 pipeline.
+
+**After:** sources `~/.nuzantara-secrets.env` so
+`GOOGLE_APPLICATION_CREDENTIALS` is set. The script's loader
+(`peraturan_ingestion_trigger.py:152`) accepts both
+`GOOGLE_SERVICE_ACCOUNT_JSON` (raw JSON, less secure) and
+`GOOGLE_APPLICATION_CREDENTIALS` (file path, more secure). We chose
+the file-path variant — Pro already has the SA at
+`/Users/nuzantara/Desktop/nuzantara/.secrets/service-account.json`
+(mode 0444, owner nuzantara) so no JSON has to leak into the env.
+
+### 2. `run_heartbeat_check.sh` (cron `30 */6 * * *` and `0 0 * * *`)
+
+**Before:** every run logged `[ERROR] TELEGRAM_BOT_TOKEN not set —
+cannot send alert`. The script computes pipeline freshness
+(NEVER_RAN, CRITICAL, DEAD, WARN, OK) but the alert side-effect was
+silently disabled. Result: 4 NEVER_RAN + 7 CRITICAL + 1 DEAD pipelines
+sat invisible.
+
+**After:** sources `~/.nuzantara-secrets.env` so `TELEGRAM_BOT_TOKEN`
+and `TELEGRAM_OWNER_CHAT_ID` reach the curl call at line 42.
+
+## Code change pattern (canonical)
+
+Same shell-source guard used elsewhere in the repo
+(`scripts/genome_decay.sh`, `scripts/metabolic_rollup.sh`,
+`scripts/wr2-cron-wrapper.sh`):
+
+```bash
+if [ -f "$HOME/.nuzantara-secrets.env" ]; then
+    # shellcheck disable=SC1091
+    set -a
+    source "$HOME/.nuzantara-secrets.env"
+    set +a
+fi
+```
+
+`set -a` auto-exports anything sourced (so child processes see the
+vars), `set +a` reverts. The `if [ -f ]` guard means the script still
+runs in dev environments / CI where the secrets file doesn't exist
+(env vars stay empty, the script's existing fallback path handles it).
+
+## Live operation on Pro
+
+`~/.nuzantara-secrets.env` was missing
+`GOOGLE_APPLICATION_CREDENTIALS`. Added on 2026-04-30 ~01:39 WITA
+(backup: `~/.nuzantara-secrets.env.bak.20260430-pre-c3`):
+
+```bash
+# PR-C3 (2026-04-30): GOOGLE_APPLICATION_CREDENTIALS for run_peraturan_ingestion.sh
+export GOOGLE_APPLICATION_CREDENTIALS=/Users/nuzantara/Desktop/nuzantara/.secrets/service-account.json
+```
+
+`TELEGRAM_BOT_TOKEN` and `TELEGRAM_OWNER_CHAT_ID` were already in the
+file — just unreachable from the cron context.
+
+File mode preserved at `0600` after edit.
+
+## Out of scope (deliberately deferred)
+
+- **`renewal-alerts` LaunchAgent** (audit row, "No expiries found"
+  for 17+ days). The fix is a Python query reconciliation against
+  `/api/crm/expiry-alerts` (which `compliance-ops` calls and works).
+  That's a backend logic fix, not env-vars — moved to a separate PR.
+- **WR2 fact-extractor / fact-checker plist**. Already quarantined in
+  `~/Library/LaunchAgents/.disabled/` by sessione 2026-04-29.
+  Restoring them needs PR-D2 (WR2 canva race + script restore), not
+  config touches.
+
+## Test plan (post-merge)
+
+- [ ] Next Sunday 2026-05-03 21:30 UTC: `run_peraturan_ingestion.sh`
+      should log `Google credentials loaded: <SA email>` instead of
+      "missing env var". Check `peraturan_ingestion.log`.
+- [ ] Next 6h tick (00:30 / 06:30 / 12:30 / 18:30 WITA):
+      `run_heartbeat_check.sh --check` should fire a Telegram alert
+      to chat `1125336968` if the 7 CRITICAL pipelines are still
+      stale. Check `heartbeat_monitor.log` for `telegram_sent` event.
+- [ ] If both pipelines silently improve over the next week, the
+      audit numbers move: - `peraturan_ingestion`: `NEVER_RAN` → `OK` after the next
+      Sunday 21:30 UTC fire - heartbeat: silent → audible (Telegram), so we'll learn whether
+      the 7 CRITICAL are real or stale data
+
+## Rollback
+
+Pure git revert — the 2 shell scripts are the only repo change. The
+Pro-side `GOOGLE_APPLICATION_CREDENTIALS` line in
+`~/.nuzantara-secrets.env` can stay (other consumers may want it) or
+be removed via:
+
+```bash
+ssh pro 'cp ~/.nuzantara-secrets.env.bak.20260430-pre-c3 ~/.nuzantara-secrets.env && chmod 600 ~/.nuzantara-secrets.env'
+```
+
+## Related
+
+- Plan: `~/.claude/plans/RESUME-renaissance-2026-04-29.md` (PR-C3 row)
+- Predecessor: PR #367 (PR-C5 dead code uninstall)
+- Same pattern: `scripts/genome_decay.sh`, `scripts/metabolic_rollup.sh`


### PR DESCRIPTION
## Summary

PR-C3 of the Pro automations renaissance. Two cron scripts silently broken because they read env vars the cron context never set. Canonical fix: source `~/.nuzantara-secrets.env` at top, behind `if [ -f ]` guard.

| Script | Cron | Was failing with | Now |
|---|---|---|---|
| `run_peraturan_ingestion.sh` | `30 21 * * 0` | `Google credentials error: GOOGLE_SERVICE_ACCOUNT_JSON env var missing` (3 consecutive Sundays) | Reads `GOOGLE_APPLICATION_CREDENTIALS` (file path) from secrets — no raw JSON in env |
| `run_heartbeat_check.sh` | `30 */6 * * *`, `0 0 * * *` | `[ERROR] TELEGRAM_BOT_TOKEN not set — cannot send alert` on every run | Reads `TELEGRAM_BOT_TOKEN` + `TELEGRAM_OWNER_CHAT_ID` from secrets |

Net effect: **4 NEVER_RAN + 7 CRITICAL + 1 DEAD pipelines** that were silently invisible should now produce Telegram alerts on next 6h tick (00:30/06:30/12:30/18:30 WITA), and the `peraturan_ingestion` Sunday job should fire successfully on 2026-05-03 21:30 UTC.

## Live operation on Pro (already done)

`~/.nuzantara-secrets.env` was missing `GOOGLE_APPLICATION_CREDENTIALS`. Added 2026-04-30 ~01:39 WITA (backup at `~/.nuzantara-secrets.env.bak.20260430-pre-c3`, mode 0600 preserved):

```
export GOOGLE_APPLICATION_CREDENTIALS=/Users/nuzantara/Desktop/nuzantara/.secrets/service-account.json
```

`TELEGRAM_BOT_TOKEN` and `TELEGRAM_OWNER_CHAT_ID` were already in the secrets file — just unreachable from cron.

## Code change pattern (canonical, used elsewhere in repo)

```bash
if [ -f "\$HOME/.nuzantara-secrets.env" ]; then
    # shellcheck disable=SC1091
    set -a
    source "\$HOME/.nuzantara-secrets.env"
    set +a
fi
```

Same pattern as `scripts/genome_decay.sh`, `scripts/metabolic_rollup.sh`, `scripts/wr2-cron-wrapper.sh`.

## Out of scope (deferred)

- `renewal-alerts` LaunchAgent — needs Python query reconcile against `/api/crm/expiry-alerts`, not env fix
- WR2 fact-extractor / fact-checker plist — already in `.disabled/` from sessione 2026-04-29

## Test plan

- [x] Pre-flight: confirm `~/.nuzantara-secrets.env` exists on Pro (mode 0600)
- [x] Add `GOOGLE_APPLICATION_CREDENTIALS` to secrets file with backup
- [x] Lint both shell scripts (`bash -n`)
- [ ] (Post-merge) Next 6h tick: `heartbeat_monitor.log` should show `telegram_sent` for the CRITICAL pipelines
- [ ] (Post-merge) Sunday 2026-05-03 21:30 UTC: `peraturan_ingestion.log` should show `Google credentials loaded` and successful sheet read

## Reference

- Plan: \`~/.claude/plans/RESUME-renaissance-2026-04-29.md\` (PR-C3 row)
- Audit SSOT: \`research/ops/2026-04-29-pro-automations-audit/automations-audit-2026-04-29.csv\`
- Predecessor: PR #367 (PR-C5 dead code uninstall)

🤖 Generated with [Claude Code](https://claude.com/claude-code)