### PR TITLE
fix(ops): renaissance PR-C4 — API degraded fixes

### DIFF
--- a/docs/ops/2026-04-30-pr-c4-api-degraded.md
+++ b/docs/ops/2026-04-30-pr-c4-api-degraded.md
@@ -1,0 +1,153 @@
+# PR-C4 — API degraded fixes (2026-04-30)
+
+Phase C of the Pro automations renaissance. Four `cron-agent-python`
+scripts that the 2026-04-29 audit flagged as degraded by external API
+failures or by dead/unused LLM calls. Applied via reproducible script
+`scripts/ops/pr-c4-api-degraded-patch.sh` (idempotent, per-file backup,
+in-place Python rewrite, `py_compile` validation).
+
+Audit reference:
+`research/ops/2026-04-29-pro-automations-audit/automations-audit-2026-04-29.csv`
+
+## ⚠️ Architectural note
+
+`/Users/nuzantara/scripts/cron-agent-python/` on Pro is **NOT in
+git**. It is "shadow infrastructure" — 31 Python files, ~10k lines,
+running production cron jobs since at least 2026-04-14, never
+versioned. PR-C4 does not solve this; it documents the patches so
+they can be re-applied if Pro is rebuilt, and so the next maintainer
+can audit what was changed.
+
+A proper fix is a separate future PR: promote
+`cron-agent-python/` into the repo under `scripts/cron-agent-python/`,
+with a CI guardrail that fails when Pro's working tree drifts from
+HEAD. Out of scope here.
+
+## Targets
+
+### 1. `imigrasi_monitor.py` — drop `peraturan.go.id` source
+
+**Before:** Source 3 (`peraturan.go.id/search?q=imigrasi`) returned
+HTTP 500 every run for 10+ days. Sources 1
+(`imigrasi.go.id/berita`) and 2
+(`imigrasi.go.id/produk-hukum/peraturan-pemerintah`) cover the same
+domain (immigration regulations) and work fine.
+
+**Patch:** Remove the 7-line block that calls `_fetch_peraturan` and
+the `random_delay` before it. The method definition stays in the file
+(harmless dead code; can be deleted in a future cleanup), only the
+call site is removed.
+
+**Net:** one less hung HTTP roundtrip per daily run, no functional
+loss.
+
+### 2. `bi_exchange_rate.py` — drop BI native API tier
+
+**Before:** 3-tier cascade: `_try_bi_api` (BI's `wskursbi.asmx`
+JSON endpoint) → `_try_html_scrape` (HTML table parse) →
+`_try_fallback_api` (`exchangerate-api.com`). The BI native API has
+been broken since 2026-04-22 (every run logs
+`bi_api_failed_fallback_html`). The HTML scrape via Playwright works
+reliably.
+
+**Patch:** Remove the BI-API-first cascade. HTML scrape is now
+primary; `exchangerate-api.com` stays as last-resort fallback.
+
+**Net:** ~10s saved per run (BI API timeout) + cleaner logs.
+
+### 3. `compliance_ops.py` — drop unused `session_id`
+
+**Before:** `get_or_create_session("compliance-ops", scope="daily")`
+spawns `claude --print "Session start for compliance-ops daily ..."`
+with `timeout=30` to obtain a session ID. The session ID is then
+captured and saved via `save_session(...)` at end of run, but **never
+used** anywhere in the code path — no `fork_from_session`, no
+`claude --resume`. Pure dead code that costs ~30s per run.
+
+CLAUDE.md §10 explicitly says _"compliance-ops: no LLM in main path
+(deterministic per fedeltà) — touches money/clients/legal, sensitive
+zone."_ So even the _intent_ of session-resume here is questionable.
+
+**Patch:** Remove the `get_or_create_session` import, the
+`session_id = get_or_create_session(...)` block at top of `run()`,
+and the `save_session(...)` block at end of `run()`. Keep
+`today = datetime.now(WITA).strftime("%Y-%m-%d")` because it's still
+used for log scoping.
+
+**Live verification (2026-04-30 02:01 WITA):** Manual `run.sh
+compliance-ops` finished in ~2s (vs 30+s before patch). Telegram
+delivery succeeded (`side_effect=compliance_summary`). No
+`session_error` warning in log.
+
+### 4. `daily_ops.py` — fix log false-positive
+
+**Before:** `error=None if renewals else "failed"` flagged a legit
+empty list `[]` as `error="failed"`. The endpoint
+`/api/crm/practices/renewals/upcoming` actually works (HTTP 200 +
+`X-API-Key` auth verified), it just returns `[]` most days.
+
+**Patch:** Change to `error=None if renewals is not None else
+"failed"`. Only an actual httpx error or non-200 response
+(`backend_api` returns `None`) triggers the error path now.
+
+Also: change `params={"days_ahead": 30}` → `params={"days": 30}`
+to match the endpoint's actual query-param name (router signature is
+`days: int = Query(...)`). FastAPI silently ignored the wrong name
+before; this just makes the call honest.
+
+**Net:** clean logs, correct param name, no behavior change (the
+endpoint accepted both names due to FastAPI tolerating extra params).
+
+## Live operation on Pro (2026-04-29 18:01 UTC = 2026-04-30 02:01 WITA)
+
+```
+[2026-04-29T18:01:26Z] === PATCH 1: imigrasi_monitor.py — drop peraturan.go.id source ===
+[imigrasi_monitor.py] patched (11717 -> 11439 bytes)
+py_compile OK
+[2026-04-29T18:01:26Z] === PATCH 2: bi_exchange_rate.py — drop BI API tier ===
+[bi_exchange_rate.py] patched (9871 -> 9778 bytes)
+py_compile OK
+[2026-04-29T18:01:26Z] === PATCH 3: compliance_ops.py — drop unused session_id ===
+[compliance_ops.py] patched (10250 -> 9990 bytes)
+py_compile OK
+[2026-04-29T18:01:26Z] === PATCH 4: daily_ops.py — log false-positive ===
+[daily_ops.py] patched (7262 -> 7268 bytes)
+py_compile OK
+```
+
+Re-run: all 4 files reported `no-op (already patched)`.
+
+Backups: `/Users/nuzantara/.cron-agent-python.backups/20260429T180126Z/`
+
+## Rollback
+
+```bash
+ssh pro 'cp ~/.cron-agent-python.backups/20260429T180126Z/imigrasi_monitor.py.bak ~/scripts/cron-agent-python/imigrasi_monitor.py'
+ssh pro 'cp ~/.cron-agent-python.backups/20260429T180126Z/bi_exchange_rate.py.bak ~/scripts/cron-agent-python/bi_exchange_rate.py'
+ssh pro 'cp ~/.cron-agent-python.backups/20260429T180126Z/compliance_ops.py.bak ~/scripts/cron-agent-python/compliance_ops.py'
+ssh pro 'cp ~/.cron-agent-python.backups/20260429T180126Z/daily_ops.py.bak ~/scripts/cron-agent-python/daily_ops.py'
+```
+
+Backups persist indefinitely (no shared state between patched files
+and other crons).
+
+## Test plan
+
+- [x] Pre-flight: dry-run on local copies of all 4 files
+- [x] py_compile all 4 patched files
+- [x] Live apply on Pro
+- [x] Verify idempotence (re-run = 4× no-op)
+- [x] Live runtime test: `compliance-ops` finished in ~2s (vs 30s)
+      with no session_error
+- [ ] (Post-merge, next 24h) Watch logs: - `bi-exchange-rate.log` 07:00 WITA → no
+      `bi_api_failed_fallback_html` - `imigrasi-monitor.log` 06:00 WITA → no `peraturan_fetch_error` - `compliance-ops.cron.log` 00:00/06:00/12:00/18:00 WITA → no
+      session_error - `daily-ops.cron.log` 08:00 WITA → `fetch_renewals error=None`
+      even when result is `[]`
+
+## Related
+
+- Plan: `~/.claude/plans/RESUME-renaissance-2026-04-29.md` (PR-C4 row)
+- Audit SSOT:
+  `research/ops/2026-04-29-pro-automations-audit/automations-audit-2026-04-29.csv`
+- Predecessors: PR #367 (PR-C5), PR #368 (PR-C3)
+- Future: promote `~/scripts/cron-agent-python/` to repo (separate PR)

--- a/scripts/ops/pr-c4-api-degraded-patch.sh
+++ b/scripts/ops/pr-c4-api-degraded-patch.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# PR-C4 — Patch 4 cron-agent-python scripts on Pro that the 2026-04-29 audit
+# flagged as degraded by external API failures or unused/dead LLM calls.
+#
+# RUN ON PRO ONLY. Idempotent: safe to re-run after success.
+#
+# IMPORTANT CONTEXT: ~/scripts/cron-agent-python/ on Pro is NOT in git.
+# It's "shadow infrastructure" that ought to be promoted into the repo as
+# its own future PR. This script applies 4 surgical patches via in-place
+# Python rewriting (NOT sed — Python source is too sensitive to regex line
+# noise) so the transformation is reproducible without committing the full
+# script tree.
+#
+# Targets:
+#   1. imigrasi_monitor.py    — drop _fetch_peraturan() call (peraturan.go.id
+#                                returns HTTP 500 for 10+ days; sources
+#                                imigrasi.go.id/berita and /produk-hukum
+#                                still work and cover the same domain).
+#   2. bi_exchange_rate.py    — drop _try_bi_api() tier (bi_api_failed_fallback_html
+#                                logged every run since 2026-04-22). HTML
+#                                scrape becomes primary, exchangerate-api.com
+#                                stays as last-resort fallback.
+#   3. compliance_ops.py      — drop get_or_create_session/save_session calls
+#                                (claude --print 30s timeout every run, but
+#                                session_id is captured and never used for
+#                                fork/resume — purely dead code that costs
+#                                latency. CLAUDE.md §10 says "no LLM in
+#                                compliance — deterministic per fedeltà").
+#   4. daily_ops.py           — fix logging false-positive (`error=None if
+#                                renewals else "failed"` flagged success
+#                                results returning [] as "failed"). The
+#                                renewals endpoint actually works, just
+#                                returns empty most days.
+#
+# Backups: each .py saved to ~/.cron-agent-python.backups/<utc-ts>/<file>.py.bak
+# Audit log: appended to ~/logs/ops/pr-c4-api-degraded-patch.log
+#
+# Reference:
+#   ~/.claude/plans/RESUME-renaissance-2026-04-29.md (PR-C4 row)
+#   research/ops/2026-04-29-pro-automations-audit/automations-audit-2026-04-29.csv
+
+set -euo pipefail
+
+if [[ "$(whoami)" != "nuzantara" ]]; then
+  echo "[pr-c4] ERROR: must run on Pro (whoami=nuzantara). got: $(whoami)" >&2
+  exit 1
+fi
+
+CRON_DIR="$HOME/scripts/cron-agent-python"
+BACKUP_ROOT="$HOME/.cron-agent-python.backups"
+LOG_DIR="$HOME/logs/ops"
+LOG_FILE="$LOG_DIR/pr-c4-api-degraded-patch.log"
+TS_UTC="$(date -u +%Y%m%dT%H%M%SZ)"
+BACKUP_DIR="$BACKUP_ROOT/$TS_UTC"
+
+mkdir -p "$BACKUP_DIR" "$LOG_DIR"
+
+log() {
+  printf '[%s] %s\n' "$(date -u +%FT%TZ)" "$*" | tee -a "$LOG_FILE"
+}
+
+# Patch helper: backs up a file then runs an in-place python rewrite via
+# `python3 -c "..."`. The python snippet is responsible for being
+# idempotent (i.e. tolerate the patch having already been applied).
+patch_file() {
+  local file="$1"
+  local label="$2"
+  local pyscript="$3"
+
+  if [[ ! -f "$CRON_DIR/$file" ]]; then
+    log "[$label] SKIP: $CRON_DIR/$file does not exist"
+    return 0
+  fi
+
+  cp "$CRON_DIR/$file" "$BACKUP_DIR/${file}.bak"
+  log "[$label] backup -> $BACKUP_DIR/${file}.bak"
+
+  python3 - "$CRON_DIR/$file" <<PY
+import sys
+from pathlib import Path
+
+target = Path(sys.argv[1])
+src = target.read_text()
+
+$pyscript
+
+if new_src == src:
+    print(f"[{target.name}] no-op (already patched)", flush=True)
+else:
+    target.write_text(new_src)
+    print(f"[{target.name}] patched ({len(src)} -> {len(new_src)} bytes)", flush=True)
+PY
+
+  # Lint the result.
+  if ! python3 -m py_compile "$CRON_DIR/$file"; then
+    log "[$label] ERROR: py_compile failed on $file. Restoring backup."
+    cp "$BACKUP_DIR/${file}.bak" "$CRON_DIR/$file"
+    return 2
+  fi
+  log "[$label] py_compile OK"
+}
+
+# ─── Patch 1: imigrasi_monitor.py — drop _fetch_peraturan() ─────────────────
+log "=== PATCH 1: imigrasi_monitor.py — drop peraturan.go.id source ==="
+patch_file imigrasi_monitor.py imigrasi '
+import re
+
+# Drop the peraturan.go.id call block (3 lines: random_delay + fetch_peraturan
+# + extend + log_step). Idempotent: if block is gone, this is a no-op.
+PATTERN = re.compile(
+    r"\n\n        await self\.random_delay\(3\.0, 6\.0\)\n"
+    r"\n        # Source 3: peraturan\.go\.id \(imigrasi filter\)\n"
+    r"        items_peraturan = await self\._fetch_peraturan\(\)\n"
+    r"        all_items\.extend\(items_peraturan\)\n"
+    r"        self\.log_step\(\"fetch_peraturan\", outputs=\{\"count\": len\(items_peraturan\)\}\)\n"
+)
+new_src = PATTERN.sub("\n", src)
+'
+
+# ─── Patch 2: bi_exchange_rate.py — drop _try_bi_api() tier ────────────────
+log "=== PATCH 2: bi_exchange_rate.py — drop BI API tier ==="
+patch_file bi_exchange_rate.py bi-exchange '
+import re
+
+# Inside async def run(self), the cascade is:
+#   data = await self._try_bi_api()
+#   if not data:
+#       self.logger.info("bi_api_failed_fallback_html")
+#       data = await self._try_html_scrape()
+# Replace the BI-API-first cascade with HTML-first.
+PATTERN = re.compile(
+    r"        # Try JSON API \(much cleaner than HTML scrape\)\n"
+    r"        data = await self\._try_bi_api\(\)\n"
+    r"        if not data:\n"
+    r"            self\.logger\.info\(\"bi_api_failed_fallback_html\"\)\n"
+    r"            data = await self\._try_html_scrape\(\)\n"
+)
+REPLACEMENT = (
+    "        # PR-C4 (2026-04-30): BI native API broken since 2026-04-22; HTML primary now.\n"
+    "        data = await self._try_html_scrape()\n"
+)
+new_src = PATTERN.sub(REPLACEMENT, src)
+'
+
+# ─── Patch 3: compliance_ops.py — drop session_id dead code ────────────────
+log "=== PATCH 3: compliance_ops.py — drop unused session_id (claude --print timeout) ==="
+patch_file compliance_ops.py compliance-ops '
+import re
+
+# 3a. Drop the import for get_or_create_session / save_session.
+PATTERN_IMPORT = re.compile(
+    r"from agent_job import AgentJob, RunResult, WITA, main, get_or_create_session, save_session\n"
+)
+REPLACEMENT_IMPORT = "from agent_job import AgentJob, RunResult, WITA, main\n"
+src1 = PATTERN_IMPORT.sub(REPLACEMENT_IMPORT, src)
+
+# 3b. Drop the get_or_create_session block at top of run().
+PATTERN_GET = re.compile(
+    r"        # ── Session resume \(daily scope\) ─────────────────────────────────\n"
+    r"        # Accumulates context from prior runs in the same day\.\n"
+    r"        today = datetime\.now\(WITA\)\.strftime\(\"%Y-%m-%d\"\)\n"
+    r"        session_id = get_or_create_session\(\"compliance-ops\", scope=f\"daily:\{today\}\"\)\n"
+    r"        if session_id:\n"
+    r"            self\.logger\.debug\(\"session_resume\", session_id=session_id\)\n"
+    r"\n"
+)
+REPLACEMENT_GET = (
+    "        # PR-C4 (2026-04-30): session_id was captured but never used for fork/resume.\n"
+    "        # Removed get_or_create_session — it spawns claude --print which times out\n"
+    "        # every run (30s) and CLAUDE.md says \"no LLM in compliance — deterministic\".\n"
+    "        today = datetime.now(WITA).strftime(\"%Y-%m-%d\")\n"
+    "\n"
+)
+src2 = PATTERN_GET.sub(REPLACEMENT_GET, src1)
+
+# 3c. Drop the save_session block near end of run().
+PATTERN_SAVE = re.compile(
+    r"\n        # Save session context for next run in same day\n"
+    r"        if session_id:\n"
+    r"            save_session\(\"compliance-ops\", session_id, scope=f\"daily:\{today\}\"\)\n"
+)
+REPLACEMENT_SAVE = ""
+new_src = PATTERN_SAVE.sub(REPLACEMENT_SAVE, src2)
+'
+
+# ─── Patch 4: daily_ops.py — fix log false-positive on empty list ──────────
+log "=== PATCH 4: daily_ops.py — log false-positive on empty renewals list ==="
+patch_file daily_ops.py daily-ops '
+import re
+
+# `error=None if renewals else "failed"` flags `[]` (legitimate empty list)
+# as "failed". Use `is None` so only a true None response (httpx error or
+# 401/500) triggers the error path.
+PATTERN = re.compile(
+    r"        renewals = await self\.backend_api\(\"/api/crm/practices/renewals/upcoming\", params=\{\"days_ahead\": 30\}\)\n"
+    r"        self\.log_step\(\"fetch_renewals\", outputs=renewals, error=None if renewals else \"failed\"\)\n"
+)
+REPLACEMENT = (
+    "        renewals = await self.backend_api(\"/api/crm/practices/renewals/upcoming\", params={\"days\": 30})\n"
+    "        self.log_step(\"fetch_renewals\", outputs=renewals, error=None if renewals is not None else \"failed\")\n"
+)
+new_src = PATTERN.sub(REPLACEMENT, src)
+'
+
+# ─── Final summary ─────────────────────────────────────────────────────────
+log "PR-C4 applied. Backups in: $BACKUP_DIR"
+log "Rollback: cp $BACKUP_DIR/*.bak $CRON_DIR/<corresponding file>"
+log ""
+log "Verify next runs:"
+log "  bi-exchange-rate (07:00 WITA)        — should NOT log bi_api_failed_fallback_html"
+log "  imigrasi-monitor (06:00 WITA)        — should NOT log peraturan_fetch_error"
+log "  compliance-ops   (every 6h)          — should NOT log session_error / claude --print timeout"
+log "  daily-ops        (08:00 WITA)        — should log fetch_renewals error=None even on []"


### PR DESCRIPTION
## Summary

PR-C4 of the Pro automations renaissance. Four cron-agent-python scripts patched via reproducible script. Each patch idempotent, backed up, py_compile-validated.

| Script | Issue | Fix | Net effect |
|---|---|---|---|
| `imigrasi_monitor.py` | `peraturan.go.id` HTTP 500 every run for 10+ days | Drop `_fetch_peraturan()` call | -1 hung HTTP roundtrip per daily run |
| `bi_exchange_rate.py` | `bi_api_failed_fallback_html` every run since 2026-04-22 | Drop BI native API tier; HTML primary now | ~10s saved per run |
| `compliance_ops.py` | `claude --print` 30s timeout per run for unused session_id | Drop `get_or_create_session`/`save_session` (session_id captured but never used for fork/resume) | **Live verified: 30s → 2s per run** |
| `daily_ops.py` | `error=None if renewals else "failed"` flagged `[]` as failed | Use `renewals is not None`; also fix param name `days_ahead` → `days` | Cleaner logs, correct param |

## ⚠️ Architectural caveat

`~/scripts/cron-agent-python/` on Pro is **NOT in git** — shadow infrastructure (31 .py files, ~10k lines). PR-C4 patches via reproducible shell script (in-place Python rewrite) so the changes survive Pro rebuilds, but doesn't solve the underlying versioning gap. Promoting the full directory to repo is a separate future PR.

## Live verification

Already applied on Pro at `2026-04-29T18:01:26Z UTC` = `2026-04-30T02:01 WITA`. All 4 files patched + py_compile OK + idempotence test (re-run = 4× no-op).

Manual `run.sh compliance-ops` post-patch:

```
2026-04-30 02:01:35 [info] fetch_expiry_summary  duration_s=0.0 error=None
2026-04-30 02:01:36 [info] fetch_expiry_detail   duration_s=0.0 error=None
2026-04-30 02:01:36 [info] fetch_practices_stats duration_s=0.0 error=None
2026-04-30 02:01:36 [info] fetch_active_practices duration_s=0.0 error=None
2026-04-30 02:01:37 [info] telegram_send  side_effect=compliance_summary
2026-04-30 02:01:37 [info] redis_event_published stream=cron:compliance-ops
```

Total: ~2 seconds, no `session_error`, no `claude --print` timeout. Compare to pre-patch logs which always opened with `WARNING session_error` (claude --print 30s timeout).

Backups: `/Users/nuzantara/.cron-agent-python.backups/20260429T180126Z/`

## Test plan

- [x] Pre-flight: dry-run on local copies of all 4 files
- [x] py_compile all 4 patched files
- [x] Live apply on Pro
- [x] Verify idempotence (re-run = 4× no-op)
- [x] Live runtime test: compliance-ops 30s → 2s
- [ ] (Post-merge, next 24h):
  - `bi-exchange-rate.log` 07:00 WITA → no `bi_api_failed_fallback_html`
  - `imigrasi-monitor.log` 06:00 WITA → no `peraturan_fetch_error`
  - `compliance-ops.cron.log` every 6h → no `session_error`
  - `daily-ops.cron.log` 08:00 WITA → `fetch_renewals error=None` even on `[]`

## Reference

- Plan: \`~/.claude/plans/RESUME-renaissance-2026-04-29.md\` (PR-C4 row)
- Audit SSOT: \`research/ops/2026-04-29-pro-automations-audit/automations-audit-2026-04-29.csv\`
- Predecessors: PR #367 (PR-C5 dead code), PR #368 (PR-C3 missing-env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)