### PR TITLE
fix(ops): renaissance PR-E1 — /tmp logs cleanup + NLM CLI arg drift

### DIFF
--- a/apps/evaluator/nlm_deep_research/multimodal_pipeline.py
+++ b/apps/evaluator/nlm_deep_research/multimodal_pipeline.py
@@ -299,12 +299,15 @@ def _run_nlm_create(
 
     Returns (success, message).
     """
+    # PR-E1 (2026-04-30): nlm CLI promoted infographic/mindmap to top-level
+    # commands (out of the deprecated `studio create` namespace). `studio`
+    # now only has status/delete/rename. New shape: `nlm <type> create NOTEBOOK_ID`.
     if artifact_type == "audio":
         cmd = [NLM_CLI, "audio", "create", notebook_id, "--format", "deep_dive", "--confirm"]
     elif artifact_type == "infographic":
-        cmd = [NLM_CLI, "studio", "create", "infographic", notebook_id, "--confirm"]
+        cmd = [NLM_CLI, "infographic", "create", notebook_id, "--confirm"]
     elif artifact_type == "mind-map":
-        cmd = [NLM_CLI, "studio", "create", "mind-map", notebook_id, "--confirm"]
+        cmd = [NLM_CLI, "mindmap", "create", notebook_id, "--confirm"]
     elif artifact_type == "report":
         cmd = [NLM_CLI, "report", "create", notebook_id, "--confirm"]
     else:

--- a/apps/evaluator/nlm_deep_research/yt_monitor.py
+++ b/apps/evaluator/nlm_deep_research/yt_monitor.py
@@ -210,8 +210,10 @@ def ingest_video(notebook_id: str, video_url: str, dry_run: bool = False) -> boo
         return True
 
     try:
+        # PR-E1 (2026-04-30): nlm CLI dropped --notebook flag — NOTEBOOK_ID
+        # is now a positional, --youtube replaces --url for YT video ingestion.
         result = subprocess.run(
-            ["nlm", "source", "add", "--notebook", notebook_id, "--url", video_url],
+            ["nlm", "source", "add", notebook_id, "--youtube", video_url],
             capture_output=True,
             text=True,
             timeout=120,

--- a/docs/ops/2026-04-30-pr-e1-cleanup.md
+++ b/docs/ops/2026-04-30-pr-e1-cleanup.md
@@ -1,0 +1,149 @@
+# PR-E1 — Cleanup: /tmp logs → ~/logs/cron-tmp/, NLM CLI arg drift (2026-04-30)
+
+Phase E (cleanup) of the Pro automations renaissance. Two unrelated
+classes of fix, bundled because both fall under "things-that-rot-on-Pro":
+
+1. **/tmp/cron-\*.log persistence** — 29 cron lines on Pro logged to
+   `/tmp/`, which is volatile across reboots and macOS sweeps. Audit
+   trails and Sentinel both depend on log persistence.
+2. **NLM CLI arg drift** — the `nlm` CLI shipped a breaking change:
+   `nlm source add` dropped `--notebook` (NOTEBOOK_ID is now positional),
+   and `nlm studio create infographic|mind-map` was promoted to top-level
+   `nlm infographic create` / `nlm mindmap create`. Two repo scripts still
+   used the old syntax and were silently failing every cron firing.
+
+## Targets
+
+### Part 1 — log path rewrite (29 cron lines)
+
+| Old destination            | New destination                       |
+| -------------------------- | ------------------------------------- |
+| `/tmp/cron-<NAME>.log`     | `~/logs/cron-tmp/<NAME>.log`          |
+| `/tmp/legal_radar.log`     | `~/logs/cron-tmp/legal_radar.log`     |
+| `/tmp/openclaw-bridge.log` | `~/logs/cron-tmp/openclaw-bridge.log` |
+
+Applied via `scripts/ops/pr-e1-cleanup-tmp-logs.sh`: idempotent
+crontab rewrite via awk (in-place pattern match, never delete/add
+lines, only rewrite paths). Sanity gates: line count must be
+unchanged after the rewrite, and zero `/tmp/cron-` /
+`/tmp/legal_radar.log` / `/tmp/openclaw-bridge.log` references must
+remain.
+
+The script also `mkdir -p ~/logs/cron-tmp/` before installing the
+new crontab, so the next cron firing doesn't fail with "no such
+directory".
+
+### Part 2 — NLM CLI arg drift fixes (2 repo files)
+
+#### `yt_monitor.py:214` — source add
+
+**Before:**
+
+```python
+["nlm", "source", "add", "--notebook", notebook_id, "--url", video_url]
+```
+
+`nlm source add` errored with `No such option: --notebook` for every
+YT video found, blocking ingestion entirely. The cron run still
+"succeeded" because the outer wrapper logs `complete: 180 polled,
+9 relevant, 0 ingested` — but the `0 ingested` was a silent failure.
+
+**After:**
+
+```python
+["nlm", "source", "add", notebook_id, "--youtube", video_url]
+```
+
+`NOTEBOOK_ID` is now positional. `--youtube` is the YT-specific URL
+option (more semantically accurate than the old `--url`).
+
+#### `multimodal_pipeline.py:_run_nlm_create` — studio create rename
+
+**Before:**
+
+```python
+elif artifact_type == "infographic":
+    cmd = [NLM_CLI, "studio", "create", "infographic", notebook_id, "--confirm"]
+elif artifact_type == "mind-map":
+    cmd = [NLM_CLI, "studio", "create", "mind-map", notebook_id, "--confirm"]
+```
+
+`nlm studio` no longer has a `create` subcommand — only
+`status/delete/rename`. Every multimodal cron run errored with
+`No such command 'create'. Did you mean 'rename'?`
+
+**After:**
+
+```python
+elif artifact_type == "infographic":
+    cmd = [NLM_CLI, "infographic", "create", notebook_id, "--confirm"]
+elif artifact_type == "mind-map":
+    cmd = [NLM_CLI, "mindmap", "create", notebook_id, "--confirm"]
+```
+
+`infographic` and `mindmap` are now top-level `nlm` subcommands with
+their own `create NOTEBOOK_ID --confirm` shape. `audio create` and
+`report create` did NOT change shape — left untouched.
+
+## Live operation on Pro (2026-04-29 18:15 UTC = 2026-04-30 02:15 WITA)
+
+```
+[2026-04-29T18:15:51Z] line count unchanged: 243
+[2026-04-29T18:15:51Z] no /tmp/ residual paths after rewrite.
+[2026-04-29T18:15:51Z] crontab installed.
+[2026-04-29T18:15:51Z] post-install verified.
+[2026-04-29T18:15:51Z] PR-E1 applied. Backup: /Users/nuzantara/.crontab.backups/20260429T181551Z.cron
+[2026-04-29T18:15:51Z] New log dir: /Users/nuzantara/logs/cron-tmp (created).
+```
+
+Re-run reported `no-op: crontab already matches PR-E1 target state`.
+
+The Python edits (`yt_monitor.py`, `multimodal_pipeline.py`) will
+land on Pro through the standard post-commit sync hook
+(Air → Pro → GitHub). py_compile validated locally before commit.
+
+## Rollback
+
+```bash
+# Crontab rewrite
+ssh pro 'crontab "$HOME/.crontab.backups/20260429T181551Z.cron"'
+
+# Python edits
+git revert <commit-sha>
+```
+
+## Test plan
+
+- [x] Pre-flight: dry-run awk on snapshot of Pro crontab — 29 entries
+      rewritten, 0 residuals
+- [x] Live apply on Pro
+- [x] Idempotence verified
+- [x] `~/logs/cron-tmp/` directory created
+- [x] py_compile both Python edits
+- [ ] (Post-merge, next cron firings):
+  - `~/logs/cron-tmp/yt-monitor.log` should fill with new
+    `Ingested <url> into <notebook>` lines instead of
+    `No such option: --notebook`
+  - `~/logs/cron-tmp/multimodal.log` should fill with successful
+    `infographic`/`mindmap` creates instead of
+    `No such command 'create'. Did you mean 'rename'?`
+- [ ] (Reboot test, eventual) Logs in `~/logs/cron-tmp/` survive
+      reboot whereas `/tmp/` would have been wiped
+
+## Out of scope (deliberately deferred)
+
+- 2 cron lines still log to `/tmp/openclaw-bridge.log` and
+  `/tmp/legal_radar.log` were rewritten in this PR. Other 4 stragglers
+  (`/tmp/cron-drive-poll.log` is in a `# DISABLED` line, so ignored;
+  the cache-cleanup chained 4 redirects to the same /tmp file — all 4
+  rewritten correctly thanks to awk `while (match)`).
+- Whether `nlm source add --youtube` produces the same Drive folder
+  outcome as the old `--url` for YT videos — to be verified next 6h
+  cycle.
+
+## Related
+
+- Plan: `~/.claude/plans/RESUME-renaissance-2026-04-29.md` (PR-E1 row)
+- Audit SSOT:
+  `research/ops/2026-04-29-pro-automations-audit/automations-audit-2026-04-29.csv`
+- Predecessors: PR #367 (PR-C5), #368 (PR-C3), #369 (PR-C4)

--- a/scripts/ops/pr-e1-cleanup-tmp-logs.sh
+++ b/scripts/ops/pr-e1-cleanup-tmp-logs.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# PR-E1 — Move /tmp/cron-*.log + 2 outliers (/tmp/legal_radar.log,
+# /tmp/openclaw-bridge.log) to ~/logs/cron-tmp/<name>.log on Pro crontab.
+#
+# RUN ON PRO ONLY. Idempotent: re-run after success is a no-op.
+#
+# Reason: /tmp/ is volatile across reboots (and macOS aggressive cleanup).
+# Logs there are routinely lost — Sentinel and audit trails depend on log
+# persistence. Other cron-agent-python jobs already log to ~/logs/cron-agent-python/
+# (canonical), so we mirror that pattern under ~/logs/cron-tmp/ to avoid
+# colliding with Python jobs while still being persistent.
+#
+# Strategy:
+#   1. Snapshot current crontab to ~/.crontab.backups/<utc-ts>.cron
+#   2. Awk pipeline rewrites every "/tmp/cron-NAME.log" reference to
+#      "/Users/nuzantara/logs/cron-tmp/NAME.log" (preserves the rest of
+#      the cron line).
+#   3. Same for the 2 non-cron-prefixed outliers (legal_radar, openclaw-bridge).
+#   4. mkdir -p ~/logs/cron-tmp/ before installing the new crontab so the
+#      first cron firing doesn't fail with "no such directory".
+#   5. Validate: line count must be unchanged (we never delete/add lines,
+#      only rewrite paths in place).
+#   6. Install + verify by re-reading the live crontab.
+#
+# Reference: PR-E1 in plan
+#   ~/.claude/plans/RESUME-renaissance-2026-04-29.md
+#   research/ops/2026-04-29-pro-automations-audit/automations-audit-2026-04-29.csv
+
+set -euo pipefail
+
+if [[ "$(whoami)" != "nuzantara" ]]; then
+  echo "[pr-e1] ERROR: must run on Pro (whoami=nuzantara). got: $(whoami)" >&2
+  exit 1
+fi
+
+BACKUP_DIR="$HOME/.crontab.backups"
+LOG_DIR="$HOME/logs/ops"
+LOG_FILE="$LOG_DIR/pr-e1-cleanup-tmp-logs.log"
+TARGET_LOG_DIR="$HOME/logs/cron-tmp"
+TS_UTC="$(date -u +%Y%m%dT%H%M%SZ)"
+
+mkdir -p "$BACKUP_DIR" "$LOG_DIR" "$TARGET_LOG_DIR"
+
+log() {
+  printf '[%s] %s\n' "$(date -u +%FT%TZ)" "$*" | tee -a "$LOG_FILE"
+}
+
+TMP_BEFORE="$(mktemp -t pr-e1-before.XXXXXX)"
+TMP_AFTER="$(mktemp -t pr-e1-after.XXXXXX)"
+trap 'rm -f "$TMP_BEFORE" "$TMP_AFTER"' EXIT
+
+crontab -l > "$TMP_BEFORE"
+cp "$TMP_BEFORE" "$BACKUP_DIR/$TS_UTC.cron"
+log "snapshot saved: $BACKUP_DIR/$TS_UTC.cron ($(wc -l < "$TMP_BEFORE" | tr -d ' ') lines)"
+
+# Awk: rewrite /tmp/cron-*.log + 2 outliers, in-place.
+awk '
+  {
+    # Pass 1: /tmp/cron-NAME.log → ~/logs/cron-tmp/NAME.log
+    while (match($0, /\/tmp\/cron-[A-Za-z0-9_-]+\.log/)) {
+      matched = substr($0, RSTART, RLENGTH)
+      name = substr(matched, length("/tmp/cron-") + 1, length(matched) - length("/tmp/cron-") - 4)
+      replacement = "/Users/nuzantara/logs/cron-tmp/" name ".log"
+      $0 = substr($0, 1, RSTART - 1) replacement substr($0, RSTART + RLENGTH)
+    }
+    # Pass 2: /tmp/{legal_radar,openclaw-bridge}.log → ~/logs/cron-tmp/<NAME>.log
+    while (match($0, /\/tmp\/(legal_radar|openclaw-bridge)\.log/)) {
+      matched = substr($0, RSTART, RLENGTH)
+      name = substr(matched, length("/tmp/") + 1, length(matched) - length("/tmp/") - 4)
+      replacement = "/Users/nuzantara/logs/cron-tmp/" name ".log"
+      $0 = substr($0, 1, RSTART - 1) replacement substr($0, RSTART + RLENGTH)
+    }
+    print
+  }
+' "$TMP_BEFORE" > "$TMP_AFTER"
+
+# Diff summary for audit log.
+DIFF_OUT="$(diff -u "$TMP_BEFORE" "$TMP_AFTER" || true)"
+if [[ -z "$DIFF_OUT" ]]; then
+  log "no-op: crontab already matches PR-E1 target state"
+  exit 0
+fi
+log "diff (rewrites only):"
+printf '%s\n' "$DIFF_OUT" | tee -a "$LOG_FILE"
+
+# Sanity: line count must be unchanged (rewrite-only, no add/delete).
+LINES_BEFORE=$(wc -l < "$TMP_BEFORE" | tr -d ' ')
+LINES_AFTER=$(wc -l < "$TMP_AFTER" | tr -d ' ')
+if (( LINES_BEFORE != LINES_AFTER )); then
+  log "ERROR: line count changed ($LINES_BEFORE → $LINES_AFTER). aborting (rewrite-only contract violated)."
+  exit 2
+fi
+log "line count unchanged: $LINES_BEFORE"
+
+# Sanity: no /tmp/cron- or /tmp/legal_radar.log or /tmp/openclaw-bridge.log left.
+RESIDUALS=$(grep -cE "/tmp/cron-|/tmp/legal_radar\.log|/tmp/openclaw-bridge\.log" "$TMP_AFTER" || true)
+if (( RESIDUALS > 0 )); then
+  log "ERROR: $RESIDUALS residual /tmp/ paths after rewrite. aborting."
+  exit 3
+fi
+log "no /tmp/ residual paths after rewrite."
+
+# Install + verify.
+crontab "$TMP_AFTER"
+log "crontab installed."
+
+crontab -l > "$TMP_BEFORE"
+if ! diff -q "$TMP_BEFORE" "$TMP_AFTER" >/dev/null; then
+  log "WARNING: post-install crontab differs from intended. Investigate manually."
+  exit 4
+fi
+log "post-install verified."
+
+log "PR-E1 applied. Backup: $BACKUP_DIR/$TS_UTC.cron"
+log "Rollback: crontab '$BACKUP_DIR/$TS_UTC.cron'"
+log "New log dir: $TARGET_LOG_DIR (created)."


### PR DESCRIPTION
## Summary

PR-E1 of the Pro automations renaissance. Two cleanup classes bundled because both fall under "things-that-rot-on-Pro":

### Part 1 — log path persistence (29 cron lines)

29 cron lines on Pro logged to `/tmp/`, which is volatile across reboots and macOS sweeps. Audit trails and Sentinel depend on log persistence.

| Old | New |
|---|---|
| `/tmp/cron-<NAME>.log` (29 lines) | `~/logs/cron-tmp/<NAME>.log` |
| `/tmp/legal_radar.log` | `~/logs/cron-tmp/legal_radar.log` |
| `/tmp/openclaw-bridge.log` | `~/logs/cron-tmp/openclaw-bridge.log` |

Applied via `scripts/ops/pr-e1-cleanup-tmp-logs.sh` (idempotent awk rewrite, line-count-invariant, sanity gates on residuals).

### Part 2 — NLM CLI breaking changes

The `nlm` CLI shipped a breaking change. 2 repo files were silently failing every cron firing:

| File | Old | New |
|---|---|---|
| `yt_monitor.py:214` | `nlm source add --notebook ID --url URL` | `nlm source add ID --youtube URL` |
| `multimodal_pipeline.py` | `nlm studio create infographic\|mind-map ID` | `nlm infographic\|mindmap create ID` |

`nlm source add` dropped `--notebook` (NOTEBOOK_ID is positional now). `nlm studio` lost `create` subcommand (only status/delete/rename remain) — `infographic` and `mindmap` were promoted to top-level.

## Live verification

Crontab rewrite applied on Pro at `2026-04-29T18:15:51Z UTC` = `2026-04-30T02:15 WITA`:

```
[2026-04-29T18:15:51Z] line count unchanged: 243
[2026-04-29T18:15:51Z] no /tmp/ residual paths after rewrite.
[2026-04-29T18:15:51Z] crontab installed.
[2026-04-29T18:15:51Z] post-install verified.
[2026-04-29T18:15:51Z] New log dir: /Users/nuzantara/logs/cron-tmp (created).
```

Re-run = no-op (idempotent). Backup at `~/.crontab.backups/20260429T181551Z.cron`.

Python edits (`yt_monitor.py`, `multimodal_pipeline.py`) are in git and will land on Pro via the standard post-commit Air→Pro sync hook. py_compile validated locally.

## Test plan

- [x] Pre-flight: dry-run awk on Pro crontab snapshot — 29 entries rewritten, 0 residuals
- [x] Live apply on Pro crontab
- [x] Idempotence verified (re-run = no-op)
- [x] `~/logs/cron-tmp/` directory created
- [x] py_compile both Python edits
- [ ] (Post-merge, next cron firings):
  - `~/logs/cron-tmp/yt-monitor.log` shows `Ingested <url> into <notebook>` instead of `No such option: --notebook`
  - `~/logs/cron-tmp/multimodal.log` shows successful `infographic`/`mindmap` creates instead of `No such command 'create'`

## Reference

- Plan: \`~/.claude/plans/RESUME-renaissance-2026-04-29.md\` (PR-E1 row)
- Audit SSOT: \`research/ops/2026-04-29-pro-automations-audit/automations-audit-2026-04-29.csv\`
- Predecessors: PR #367 (C5 dead code), #368 (C3 missing-env), #369 (C4 API degraded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)