### PR TITLE
fix(ops): renaissance PR-D1 — gap_scanner Layer B resilience

### DIFF
--- a/apps/evaluator/nlm_deep_research/gap_scanner.py
+++ b/apps/evaluator/nlm_deep_research/gap_scanner.py
@@ -44,6 +44,7 @@ _BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN", "")
 _CHAT_ID = os.environ.get("TELEGRAM_OWNER_CHAT_ID", "")
 
 NLM_QUERY_TIMEOUT = 120
+LAYER_B_QUERY_TIMEOUT = 180  # PR-D1 (2026-04-30): NLM bridge slow under load — was 90s
 GAP_QUERY_DELAY = 5  # seconds between queries — NLM rate limiting
 
 # Freshness thresholds (days)
@@ -446,13 +447,13 @@ def run_layer_b(dry_run: bool = False) -> dict[str, Any]:
 
         domain_results: dict[str, str] = {}
 
-        for topic in topics:
+        for topic_idx, topic in enumerate(topics, 1):
             result["total_topics"] += 1
 
             if not dry_run:
                 total_queries_attempted += 1
                 query = FRESHNESS_QUERY_TEMPLATE.format(topic=topic)
-                response = _query_notebook(nb_id, query, timeout=90)
+                response = _query_notebook(nb_id, query, timeout=LAYER_B_QUERY_TIMEOUT)
                 if response is None:
                     total_queries_failed += 1
                 classification = _classify_freshness(response)
@@ -461,7 +462,12 @@ def run_layer_b(dry_run: bool = False) -> dict[str, Any]:
 
             domain_results[topic] = classification
             result[classification.lower()] += 1
-            logger.debug("  [%s] %s: %s", domain, topic[:50], classification)
+            # PR-D1 (2026-04-30): per-topic progress so a kill mid-domain
+            # leaves a breadcrumb in the log instead of silent gap.
+            logger.info(
+                "  [%s %d/%d] %s — %s",
+                domain, topic_idx, len(topics), topic[:60], classification,
+            )
 
             if not dry_run:
                 time.sleep(GAP_QUERY_DELAY)

--- a/apps/evaluator/nlm_deep_research/multimodal_pipeline.py
+++ b/apps/evaluator/nlm_deep_research/multimodal_pipeline.py
@@ -299,12 +299,15 @@ def _run_nlm_create(
 
     Returns (success, message).
     """
+    # PR-E1 (2026-04-30): nlm CLI promoted infographic/mindmap to top-level
+    # commands (out of the deprecated `studio create` namespace). `studio`
+    # now only has status/delete/rename. New shape: `nlm <type> create NOTEBOOK_ID`.
     if artifact_type == "audio":
         cmd = [NLM_CLI, "audio", "create", notebook_id, "--format", "deep_dive", "--confirm"]
     elif artifact_type == "infographic":
-        cmd = [NLM_CLI, "studio", "create", "infographic", notebook_id, "--confirm"]
+        cmd = [NLM_CLI, "infographic", "create", notebook_id, "--confirm"]
     elif artifact_type == "mind-map":
-        cmd = [NLM_CLI, "studio", "create", "mind-map", notebook_id, "--confirm"]
+        cmd = [NLM_CLI, "mindmap", "create", notebook_id, "--confirm"]
     elif artifact_type == "report":
         cmd = [NLM_CLI, "report", "create", notebook_id, "--confirm"]
     else:

--- a/apps/evaluator/nlm_deep_research/scripts/run_gap_scanner.sh
+++ b/apps/evaluator/nlm_deep_research/scripts/run_gap_scanner.sh
@@ -35,6 +35,15 @@ if [ -f "$HOME/.zshrc.secrets" ]; then
     source "$HOME/.zshrc.secrets" 2>/dev/null || true
     set -u
 fi
+# PR-D1 (2026-04-30): also source canonical secrets file (PR-C3 introduced
+# this path; .zshrc.secrets above is the legacy fallback). Either is fine —
+# the if-fi guards mean dev environments without the file still work.
+if [ -f "$HOME/.nuzantara-secrets.env" ]; then
+    # shellcheck disable=SC1091
+    set -a
+    source "$HOME/.nuzantara-secrets.env"
+    set +a
+fi
 
 VENV="$PROJECT_ROOT/apps/backend-rag/.venv"
 if [ ! -f "$VENV/bin/activate" ]; then

--- a/apps/evaluator/nlm_deep_research/yt_monitor.py
+++ b/apps/evaluator/nlm_deep_research/yt_monitor.py
@@ -210,8 +210,10 @@ def ingest_video(notebook_id: str, video_url: str, dry_run: bool = False) -> boo
         return True
 
     try:
+        # PR-E1 (2026-04-30): nlm CLI dropped --notebook flag — NOTEBOOK_ID
+        # is now a positional, --youtube replaces --url for YT video ingestion.
         result = subprocess.run(
-            ["nlm", "source", "add", "--notebook", notebook_id, "--url", video_url],
+            ["nlm", "source", "add", notebook_id, "--youtube", video_url],
             capture_output=True,
             text=True,
             timeout=120,

--- a/docs/ops/2026-04-30-pr-d1-gap-scanner-resilience.md
+++ b/docs/ops/2026-04-30-pr-d1-gap-scanner-resilience.md
@@ -1,0 +1,139 @@
+# PR-D1 — Gap scanner Layer B resilience (2026-04-30)
+
+Phase D (self-learning chains) of the Pro automations renaissance.
+First PR of the D-series — sblocca self-learning chain #1
+(Layer A → Layer B → Remediate).
+
+## Audit reformulation
+
+The 2026-04-29 audit said:
+
+> BROKEN. Cron-runner.sh now exports correct PATH (fixed 2026-04-19
+> 21:40 per file mtime), so future runs MAY work. But Sunday 04-26
+> produced no log file at all — chain did not close last week. Layer
+> B last successfully classified 2026-04-19 (and it claimed every
+> topic was 100% gap because nlm CLI was not in PATH).
+
+**Live verification on 2026-04-30 02:30 WITA contradicts that:**
+
+A manual `--layer-b` run kicked off at 02:30 WITA showed:
+
+```
+02:30:45 [GapScanner] Starting --layer-b
+02:30:45 [GapScanner] Layer B — coverage matrix for immigration (8 topics)
+02:36:12 [GapScanner] Query timeout for notebook cff93ab0-...
+02:39:21 [GapScanner]   immigration: 62% fresh, 12% gap
+02:39:21 [GapScanner] Layer B — coverage matrix for company (8 topics)
+02:48:09 [GapScanner]   company: 100% fresh, 0% gap
+02:48:09 [GapScanner] Layer B — coverage matrix for tax (8 topics)
+02:56:05 [GapScanner] Query timeout for notebook d4b2eedb-...
+02:57:06 [GapScanner]   tax: 75% fresh, 12% gap
+03:03:31 [GapScanner]   property: 75% fresh, 0% gap
+03:13:19 [GapScanner]   operations: 38% fresh, 25% gap
+...
+```
+
+So the actual root causes are **different**:
+
+1. **NLM bridge is slow under load.** Query timeouts (~90s) fire on the
+   largest notebooks. 8 queries × 7 domains × ~30s avg = ~28 min for the
+   full Layer B run, but the slowest notebooks push individual queries past
+   the 90s ceiling.
+2. **Per-topic logging is missing.** The current code only logs once
+   per domain (`X% fresh, Y% gap`). If the cron run gets killed mid-domain
+   (sleep, system crash, OOM, etc.), the log shows nothing about what was
+   in flight — making post-mortem impossible.
+3. **Crontab comment lies about timezone.** The cron line
+   `0 19 * * 0 ...layer-b` uses a comment that says "Sun 19:00 UTC =
+   Mon 03:00 WITA", but cron uses the system local timezone (WITA), so
+   `0 19 * * 0` actually fires at **19:00 WITA Sunday = 11:00 UTC Sunday**.
+   This is purely cosmetic but caused confusion when reading the audit.
+4. **`run_gap_scanner.sh` only sources `~/.zshrc.secrets`** (legacy path),
+   not `~/.nuzantara-secrets.env` (canonical, introduced in PR-C3). So
+   Telegram alerts depend on the legacy file being present and current.
+
+## Fixes
+
+### 1. Per-query timeout 90s → 180s (`gap_scanner.py:46-47`)
+
+```python
+NLM_QUERY_TIMEOUT = 120
+LAYER_B_QUERY_TIMEOUT = 180  # PR-D1: NLM bridge slow under load — was 90s
+```
+
+The `--layer-b` flow now uses `LAYER_B_QUERY_TIMEOUT` instead of the
+hardcoded `90`. Larger notebooks (immigration, tax, operations,
+editorial) routinely hit 90s+ on freshness queries; 180s gives 2× safety
+margin without making individual failures take much longer.
+
+### 2. Per-topic progress logging (`gap_scanner.py:450-470`)
+
+```python
+for topic_idx, topic in enumerate(topics, 1):
+    ...
+    logger.info(
+        "  [%s %d/%d] %s — %s",
+        domain, topic_idx, len(topics), topic[:60], classification,
+    )
+```
+
+Promoted from `logger.debug` to `logger.info` and added topic position
+(`3/8`) + truncated topic title + classification. A killed run now leaves
+a breadcrumb at the exact topic where it died.
+
+### 3. Source canonical secrets (`run_gap_scanner.sh:33-42`)
+
+Added a second secrets-source block that reads
+`~/.nuzantara-secrets.env` (canonical, PR-C3 baseline) on top of the
+existing legacy `.zshrc.secrets`. Both are guarded with `if [ -f ]` so
+dev environments without either file still work. Also makes the cron
+firing `_send_telegram` succeed even if `.zshrc.secrets` is removed
+later.
+
+## Out of scope (deliberately deferred)
+
+- **Crontab comment fix** (cosmetic). The comment says "Sun 19:00 UTC"
+  but cron uses WITA. Fixable on Pro via `crontab -e`, but not in
+  repo. Tracked as TODO.
+- **Sunday 26/04 missing run forensic.** The 26/04 log file has only
+  Layer A; Layer B/Remediate left no trace. Possible causes: cron
+  daemon sleep, PID lock orphan, stdout silently lost. Not actionable
+  without more data.
+- **Remediate bug** (`No such file or directory: 'nlm'`). The audit
+  observed this on 2026-04-19 but the fix to cron-runner.sh on the same
+  day's 21:40 should have fixed it. Will re-validate next Sunday after
+  Layer B completes — if Remediate still errors, it's a separate bug
+  (possibly a different subprocess shell context).
+- **Eliminate timeouts via batching** (proper architectural fix). The
+  bottleneck is one NLM query per topic. A batched API would cut the
+  full run from ~30 min to ~3 min. Out of scope here — needs an
+  upstream NLM bridge change.
+
+## Verification
+
+Live `--layer-b` test launched 2026-04-30 02:30 WITA — runs ~25-30 min,
+Telegram digest expected at end. Per-topic logging will show in the
+next firing (Sunday 19:00 WITA = next 2026-05-04, or via manual
+`run_gap_scanner.sh --layer-b`).
+
+## Test plan
+
+- [x] py_compile gap_scanner.py
+- [x] bash -n run_gap_scanner.sh
+- [x] Live `--layer-b` running (started 02:30 WITA on 2026-04-30) —
+      confirms the audit's "100% gap because nlm not in PATH" narrative
+      is **stale** — Layer B is producing real classifications
+- [ ] (Post-merge, next Sunday firing) Logs in `~/logs/cron-tmp/gap-scanner.log`
+      should show `[domain X/8] topic — CLASSIFICATION` lines per query
+- [ ] (Post-merge, next Sunday firing) Telegram digest delivered at
+      end of `--layer-b` (already happens via `_send_telegram` line 520
+      — this PR ensures it works regardless of `.zshrc.secrets`
+      presence)
+
+## Related
+
+- Plan: `~/.claude/plans/RESUME-renaissance-2026-04-29.md` (PR-D1 row)
+- Audit SSOT: `research/ops/2026-04-29-pro-automations-audit/automations-audit-2026-04-29.csv`
+- Predecessors: PR #367 (C5), #368 (C3), #369 (C4), #371 (E1)
+- Same secrets pattern: `scripts/genome_decay.sh`,
+  `apps/evaluator/nlm_deep_research/scripts/run_heartbeat_check.sh` (PR-C3)

--- a/docs/ops/2026-04-30-pr-e1-cleanup.md
+++ b/docs/ops/2026-04-30-pr-e1-cleanup.md
@@ -1,0 +1,149 @@
+# PR-E1 — Cleanup: /tmp logs → ~/logs/cron-tmp/, NLM CLI arg drift (2026-04-30)
+
+Phase E (cleanup) of the Pro automations renaissance. Two unrelated
+classes of fix, bundled because both fall under "things-that-rot-on-Pro":
+
+1. **/tmp/cron-\*.log persistence** — 29 cron lines on Pro logged to
+   `/tmp/`, which is volatile across reboots and macOS sweeps. Audit
+   trails and Sentinel both depend on log persistence.
+2. **NLM CLI arg drift** — the `nlm` CLI shipped a breaking change:
+   `nlm source add` dropped `--notebook` (NOTEBOOK_ID is now positional),
+   and `nlm studio create infographic|mind-map` was promoted to top-level
+   `nlm infographic create` / `nlm mindmap create`. Two repo scripts still
+   used the old syntax and were silently failing every cron firing.
+
+## Targets
+
+### Part 1 — log path rewrite (29 cron lines)
+
+| Old destination            | New destination                       |
+| -------------------------- | ------------------------------------- |
+| `/tmp/cron-<NAME>.log`     | `~/logs/cron-tmp/<NAME>.log`          |
+| `/tmp/legal_radar.log`     | `~/logs/cron-tmp/legal_radar.log`     |
+| `/tmp/openclaw-bridge.log` | `~/logs/cron-tmp/openclaw-bridge.log` |
+
+Applied via `scripts/ops/pr-e1-cleanup-tmp-logs.sh`: idempotent
+crontab rewrite via awk (in-place pattern match, never delete/add
+lines, only rewrite paths). Sanity gates: line count must be
+unchanged after the rewrite, and zero `/tmp/cron-` /
+`/tmp/legal_radar.log` / `/tmp/openclaw-bridge.log` references must
+remain.
+
+The script also `mkdir -p ~/logs/cron-tmp/` before installing the
+new crontab, so the next cron firing doesn't fail with "no such
+directory".
+
+### Part 2 — NLM CLI arg drift fixes (2 repo files)
+
+#### `yt_monitor.py:214` — source add
+
+**Before:**
+
+```python
+["nlm", "source", "add", "--notebook", notebook_id, "--url", video_url]
+```
+
+`nlm source add` errored with `No such option: --notebook` for every
+YT video found, blocking ingestion entirely. The cron run still
+"succeeded" because the outer wrapper logs `complete: 180 polled,
+9 relevant, 0 ingested` — but the `0 ingested` was a silent failure.
+
+**After:**
+
+```python
+["nlm", "source", "add", notebook_id, "--youtube", video_url]
+```
+
+`NOTEBOOK_ID` is now positional. `--youtube` is the YT-specific URL
+option (more semantically accurate than the old `--url`).
+
+#### `multimodal_pipeline.py:_run_nlm_create` — studio create rename
+
+**Before:**
+
+```python
+elif artifact_type == "infographic":
+    cmd = [NLM_CLI, "studio", "create", "infographic", notebook_id, "--confirm"]
+elif artifact_type == "mind-map":
+    cmd = [NLM_CLI, "studio", "create", "mind-map", notebook_id, "--confirm"]
+```
+
+`nlm studio` no longer has a `create` subcommand — only
+`status/delete/rename`. Every multimodal cron run errored with
+`No such command 'create'. Did you mean 'rename'?`
+
+**After:**
+
+```python
+elif artifact_type == "infographic":
+    cmd = [NLM_CLI, "infographic", "create", notebook_id, "--confirm"]
+elif artifact_type == "mind-map":
+    cmd = [NLM_CLI, "mindmap", "create", notebook_id, "--confirm"]
+```
+
+`infographic` and `mindmap` are now top-level `nlm` subcommands with
+their own `create NOTEBOOK_ID --confirm` shape. `audio create` and
+`report create` did NOT change shape — left untouched.
+
+## Live operation on Pro (2026-04-29 18:15 UTC = 2026-04-30 02:15 WITA)
+
+```
+[2026-04-29T18:15:51Z] line count unchanged: 243
+[2026-04-29T18:15:51Z] no /tmp/ residual paths after rewrite.
+[2026-04-29T18:15:51Z] crontab installed.
+[2026-04-29T18:15:51Z] post-install verified.
+[2026-04-29T18:15:51Z] PR-E1 applied. Backup: /Users/nuzantara/.crontab.backups/20260429T181551Z.cron
+[2026-04-29T18:15:51Z] New log dir: /Users/nuzantara/logs/cron-tmp (created).
+```
+
+Re-run reported `no-op: crontab already matches PR-E1 target state`.
+
+The Python edits (`yt_monitor.py`, `multimodal_pipeline.py`) will
+land on Pro through the standard post-commit sync hook
+(Air → Pro → GitHub). py_compile validated locally before commit.
+
+## Rollback
+
+```bash
+# Crontab rewrite
+ssh pro 'crontab "$HOME/.crontab.backups/20260429T181551Z.cron"'
+
+# Python edits
+git revert <commit-sha>
+```
+
+## Test plan
+
+- [x] Pre-flight: dry-run awk on snapshot of Pro crontab — 29 entries
+      rewritten, 0 residuals
+- [x] Live apply on Pro
+- [x] Idempotence verified
+- [x] `~/logs/cron-tmp/` directory created
+- [x] py_compile both Python edits
+- [ ] (Post-merge, next cron firings):
+  - `~/logs/cron-tmp/yt-monitor.log` should fill with new
+    `Ingested <url> into <notebook>` lines instead of
+    `No such option: --notebook`
+  - `~/logs/cron-tmp/multimodal.log` should fill with successful
+    `infographic`/`mindmap` creates instead of
+    `No such command 'create'. Did you mean 'rename'?`
+- [ ] (Reboot test, eventual) Logs in `~/logs/cron-tmp/` survive
+      reboot whereas `/tmp/` would have been wiped
+
+## Out of scope (deliberately deferred)
+
+- 2 cron lines still log to `/tmp/openclaw-bridge.log` and
+  `/tmp/legal_radar.log` were rewritten in this PR. Other 4 stragglers
+  (`/tmp/cron-drive-poll.log` is in a `# DISABLED` line, so ignored;
+  the cache-cleanup chained 4 redirects to the same /tmp file — all 4
+  rewritten correctly thanks to awk `while (match)`).
+- Whether `nlm source add --youtube` produces the same Drive folder
+  outcome as the old `--url` for YT videos — to be verified next 6h
+  cycle.
+
+## Related
+
+- Plan: `~/.claude/plans/RESUME-renaissance-2026-04-29.md` (PR-E1 row)
+- Audit SSOT:
+  `research/ops/2026-04-29-pro-automations-audit/automations-audit-2026-04-29.csv`
+- Predecessors: PR #367 (PR-C5), #368 (PR-C3), #369 (PR-C4)

--- a/scripts/ops/pr-e1-cleanup-tmp-logs.sh
+++ b/scripts/ops/pr-e1-cleanup-tmp-logs.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# PR-E1 — Move /tmp/cron-*.log + 2 outliers (/tmp/legal_radar.log,
+# /tmp/openclaw-bridge.log) to ~/logs/cron-tmp/<name>.log on Pro crontab.
+#
+# RUN ON PRO ONLY. Idempotent: re-run after success is a no-op.
+#
+# Reason: /tmp/ is volatile across reboots (and macOS aggressive cleanup).
+# Logs there are routinely lost — Sentinel and audit trails depend on log
+# persistence. Other cron-agent-python jobs already log to ~/logs/cron-agent-python/
+# (canonical), so we mirror that pattern under ~/logs/cron-tmp/ to avoid
+# colliding with Python jobs while still being persistent.
+#
+# Strategy:
+#   1. Snapshot current crontab to ~/.crontab.backups/<utc-ts>.cron
+#   2. Awk pipeline rewrites every "/tmp/cron-NAME.log" reference to
+#      "/Users/nuzantara/logs/cron-tmp/NAME.log" (preserves the rest of
+#      the cron line).
+#   3. Same for the 2 non-cron-prefixed outliers (legal_radar, openclaw-bridge).
+#   4. mkdir -p ~/logs/cron-tmp/ before installing the new crontab so the
+#      first cron firing doesn't fail with "no such directory".
+#   5. Validate: line count must be unchanged (we never delete/add lines,
+#      only rewrite paths in place).
+#   6. Install + verify by re-reading the live crontab.
+#
+# Reference: PR-E1 in plan
+#   ~/.claude/plans/RESUME-renaissance-2026-04-29.md
+#   research/ops/2026-04-29-pro-automations-audit/automations-audit-2026-04-29.csv
+
+set -euo pipefail
+
+if [[ "$(whoami)" != "nuzantara" ]]; then
+  echo "[pr-e1] ERROR: must run on Pro (whoami=nuzantara). got: $(whoami)" >&2
+  exit 1
+fi
+
+BACKUP_DIR="$HOME/.crontab.backups"
+LOG_DIR="$HOME/logs/ops"
+LOG_FILE="$LOG_DIR/pr-e1-cleanup-tmp-logs.log"
+TARGET_LOG_DIR="$HOME/logs/cron-tmp"
+TS_UTC="$(date -u +%Y%m%dT%H%M%SZ)"
+
+mkdir -p "$BACKUP_DIR" "$LOG_DIR" "$TARGET_LOG_DIR"
+
+log() {
+  printf '[%s] %s\n' "$(date -u +%FT%TZ)" "$*" | tee -a "$LOG_FILE"
+}
+
+TMP_BEFORE="$(mktemp -t pr-e1-before.XXXXXX)"
+TMP_AFTER="$(mktemp -t pr-e1-after.XXXXXX)"
+trap 'rm -f "$TMP_BEFORE" "$TMP_AFTER"' EXIT
+
+crontab -l > "$TMP_BEFORE"
+cp "$TMP_BEFORE" "$BACKUP_DIR/$TS_UTC.cron"
+log "snapshot saved: $BACKUP_DIR/$TS_UTC.cron ($(wc -l < "$TMP_BEFORE" | tr -d ' ') lines)"
+
+# Awk: rewrite /tmp/cron-*.log + 2 outliers, in-place.
+awk '
+  {
+    # Pass 1: /tmp/cron-NAME.log → ~/logs/cron-tmp/NAME.log
+    while (match($0, /\/tmp\/cron-[A-Za-z0-9_-]+\.log/)) {
+      matched = substr($0, RSTART, RLENGTH)
+      name = substr(matched, length("/tmp/cron-") + 1, length(matched) - length("/tmp/cron-") - 4)
+      replacement = "/Users/nuzantara/logs/cron-tmp/" name ".log"
+      $0 = substr($0, 1, RSTART - 1) replacement substr($0, RSTART + RLENGTH)
+    }
+    # Pass 2: /tmp/{legal_radar,openclaw-bridge}.log → ~/logs/cron-tmp/<NAME>.log
+    while (match($0, /\/tmp\/(legal_radar|openclaw-bridge)\.log/)) {
+      matched = substr($0, RSTART, RLENGTH)
+      name = substr(matched, length("/tmp/") + 1, length(matched) - length("/tmp/") - 4)
+      replacement = "/Users/nuzantara/logs/cron-tmp/" name ".log"
+      $0 = substr($0, 1, RSTART - 1) replacement substr($0, RSTART + RLENGTH)
+    }
+    print
+  }
+' "$TMP_BEFORE" > "$TMP_AFTER"
+
+# Diff summary for audit log.
+DIFF_OUT="$(diff -u "$TMP_BEFORE" "$TMP_AFTER" || true)"
+if [[ -z "$DIFF_OUT" ]]; then
+  log "no-op: crontab already matches PR-E1 target state"
+  exit 0
+fi
+log "diff (rewrites only):"
+printf '%s\n' "$DIFF_OUT" | tee -a "$LOG_FILE"
+
+# Sanity: line count must be unchanged (rewrite-only, no add/delete).
+LINES_BEFORE=$(wc -l < "$TMP_BEFORE" | tr -d ' ')
+LINES_AFTER=$(wc -l < "$TMP_AFTER" | tr -d ' ')
+if (( LINES_BEFORE != LINES_AFTER )); then
+  log "ERROR: line count changed ($LINES_BEFORE → $LINES_AFTER). aborting (rewrite-only contract violated)."
+  exit 2
+fi
+log "line count unchanged: $LINES_BEFORE"
+
+# Sanity: no /tmp/cron- or /tmp/legal_radar.log or /tmp/openclaw-bridge.log left.
+RESIDUALS=$(grep -cE "/tmp/cron-|/tmp/legal_radar\.log|/tmp/openclaw-bridge\.log" "$TMP_AFTER" || true)
+if (( RESIDUALS > 0 )); then
+  log "ERROR: $RESIDUALS residual /tmp/ paths after rewrite. aborting."
+  exit 3
+fi
+log "no /tmp/ residual paths after rewrite."
+
+# Install + verify.
+crontab "$TMP_AFTER"
+log "crontab installed."
+
+crontab -l > "$TMP_BEFORE"
+if ! diff -q "$TMP_BEFORE" "$TMP_AFTER" >/dev/null; then
+  log "WARNING: post-install crontab differs from intended. Investigate manually."
+  exit 4
+fi
+log "post-install verified."
+
+log "PR-E1 applied. Backup: $BACKUP_DIR/$TS_UTC.cron"
+log "Rollback: crontab '$BACKUP_DIR/$TS_UTC.cron'"
+log "New log dir: $TARGET_LOG_DIR (created)."


### PR DESCRIPTION
## Summary

PR-D1 of Phase D (self-learning chains). Reformulated against live evidence: the 2026-04-29 audit narrative ("Layer B broken — 100% gap because nlm CLI not in PATH") is **stale**. A 2026-04-30 02:30 WITA manual run produced real classifications (immigration 62% fresh, company 100% fresh, tax 75% fresh, property 75% fresh, operations 38% fresh). cron-runner.sh PATH was fixed 2026-04-19 21:40 — that issue is gone.

**Real issues are slowness + observability:**

| Fix | Why |
|---|---|
| `LAYER_B_QUERY_TIMEOUT 90s → 180s` | NLM bridge slow under load; large notebooks hit 90s ceiling |
| Per-topic progress log (`logger.info` with `[domain X/8] topic — CLASSIFICATION`) | Killed run leaves a breadcrumb where it died (silent gap previously) |
| Source `~/.nuzantara-secrets.env` in addition to legacy `~/.zshrc.secrets` | Telegram digest survives even if .zshrc.secrets is removed |

## Live evidence

```
02:30:45 [GapScanner] Starting --layer-b
02:39:21   immigration: 62% fresh, 12% gap
02:48:09   company: 100% fresh, 0% gap
02:57:06   tax: 75% fresh, 12% gap
03:03:31   property: 75% fresh, 0% gap
03:13:19   operations: 38% fresh, 25% gap
...
```

This contradicts the audit. Layer B is producing real classifications, just slowly (~30 min for 56 topics across 7 domains).

## Out of scope

- Crontab comment cosmetic fix (Pro-side, not in repo): comment claims "Sun 19:00 UTC = Mon 03:00 WITA" but cron uses local WITA so the line fires at 19:00 WITA = 11:00 UTC.
- Sunday 26/04 missing run forensic (no log file at all)
- Remediate "no such file 'nlm'" — believed fixed by cron-runner.sh PATH export same day, re-validate next Sunday

## Test plan

- [x] py_compile gap_scanner.py
- [x] bash -n run_gap_scanner.sh
- [x] Live `--layer-b` running (started 02:30 WITA on 2026-04-30) — confirms audit's "100% gap" narrative is stale
- [ ] (Post-merge, next Sunday) Logs show `[domain X/8] topic — CLASSIFICATION` per query
- [ ] (Post-merge, next Sunday) Telegram digest delivered at end of `--layer-b`

## Reference

- Plan: \`~/.claude/plans/RESUME-renaissance-2026-04-29.md\` (PR-D1 row)
- Audit SSOT: \`research/ops/2026-04-29-pro-automations-audit/automations-audit-2026-04-29.csv\`
- Predecessors: PR #367 (C5), #368 (C3), #369 (C4), #371 (E1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)