### PR TITLE
fix(innervation/deploy_w0): accept cron-pattern in trigger 5 verify

### DIFF
--- a/apps/organism/scripts/deploy_w0.sh
+++ b/apps/organism/scripts/deploy_w0.sh
@@ -17,7 +17,11 @@
 #   4. presence of new .bak-* / .disabled / .backup-* files in
 #      ~/Library/LaunchAgents/com.{nuzantara,balizero,cell}.* not seen pre-cp
 #   5. launchctl print gui/$(id -u)/<label> doesn't show "state = running"
-#      within VERIFY_TIMEOUT_SECONDS
+#      within VERIFY_TIMEOUT_SECONDS (daemon plist) — OR — for cron plist
+#      (StartCalendarInterval/StartInterval, no KeepAlive=true), shows
+#      "state = not running" with a non-zero "last exit code". Cron pattern
+#      with state=not running and last exit code=0 (or absent: never run)
+#      is the launchd-correct steady-state and MUST NOT abort.
 #
 # Usage:
 #   ./deploy_w0.sh                    # full deploy
@@ -196,21 +200,62 @@ deploy_one() {
     abort "3_bootstrap" "$plist" "launchctl bootstrap failed: ${bootstrap_out:-no stderr}"
   fi
 
-  # 10. trigger 5 — verify "state = running" within timeout.
+  # 10. trigger 5 — verify launchd reached the expected steady state within
+  # timeout. "Expected steady state" depends on plist type:
+  #   - daemon  (KeepAlive=true): state = running
+  #   - cron    (StartCalendarInterval/StartInterval, no KeepAlive=true):
+  #             state = not running + last exit code = 0 (already ran OK)
+  #             OR no last-exit-code line yet (never fired since bootstrap)
+  # The cron-pattern branch is the launchd-correct steady-state and MUST
+  # NOT abort: a cron tick with KeepAlive=true would be a daemon, not a cron.
+  # `plutil -extract KeepAlive raw` returns "true" + rc=0 if KeepAlive=true,
+  # rc=1 if the key is absent (cron plist). NB: `-extract … json` rejects
+  # top-level scalars on macOS (`Invalid object in plist for JSON format`),
+  # so `raw` is the only reliable form for boolean keys.
+  local is_daemon=0
+  if [ "$(plutil -extract KeepAlive raw -o - "$dst" 2>/dev/null)" = "true" ]; then
+    is_daemon=1
+  fi
+
   local elapsed=0
-  local seen_running=0
+  local accepted=0
+  local last_print=""
   while [ "$elapsed" -lt "$VERIFY_TIMEOUT_SECONDS" ]; do
-    if launchctl print "gui/${UID_NUM}/${label}" 2>/dev/null \
-        | grep -qE 'state = running'; then
-      seen_running=1
-      break
+    last_print=$(launchctl print "gui/${UID_NUM}/${label}" 2>/dev/null || true)
+    if [ "$is_daemon" = "1" ]; then
+      if echo "$last_print" | grep -qE 'state = running'; then
+        accepted=1
+        break
+      fi
+    else
+      # Cron pattern: not running is the expected steady-state.
+      # Accept iff state=not running AND (no last exit code line yet OR last exit code = 0).
+      if echo "$last_print" | grep -qE 'state = not running'; then
+        if echo "$last_print" | grep -qE 'last exit code = '; then
+          if echo "$last_print" | grep -qE 'last exit code = 0\b'; then
+            accepted=1
+            break
+          fi
+          # Non-zero exit → keep waiting in case launchd is mid-cycle, but
+          # don't promote to accepted; loop exit will trigger abort.
+        else
+          # Never fired yet — bootstrap fresh. Accept.
+          accepted=1
+          break
+        fi
+      fi
     fi
     sleep 1
     elapsed=$((elapsed + 1))
   done
-  if [ "$seen_running" != "1" ]; then
-    abort "5_state_running" "$plist" \
-      "launchctl print did not show 'state = running' within ${VERIFY_TIMEOUT_SECONDS}s"
+  if [ "$accepted" != "1" ]; then
+    if [ "$is_daemon" = "1" ]; then
+      abort "5_state_running" "$plist" \
+        "launchctl print did not show 'state = running' within ${VERIFY_TIMEOUT_SECONDS}s"
+    else
+      abort "5_state_running" "$plist" \
+        "cron plist did not reach steady-state (state=not running + last exit=0) within ${VERIFY_TIMEOUT_SECONDS}s"
+    fi
   fi
 
   echo "  ✓ $plist deployed and running"

--- a/apps/organism/tests/scripts/test_deploy_w0.py
+++ b/apps/organism/tests/scripts/test_deploy_w0.py
@@ -86,8 +86,19 @@ def _make_env(
           bootout)   exit 0 ;;
           bootstrap) exit 0 ;;
           print)
-            # Print the canonical "state = running" line so trigger 5 passes.
-            echo "state = running"
+            # `launchctl print gui/<uid>/<label>` — $2 is the path. Emit a
+            # realistic steady-state line per plist type so trigger 5 passes:
+            #   - daemon (supervisor, control-panel): state = running
+            #   - cron   (scheduled-tick): state = not running + last exit = 0
+            case "$2" in
+              *scheduled-tick*)
+                echo "state = not running"
+                echo "last exit code = 0"
+                ;;
+              *)
+                echo "state = running"
+                ;;
+            esac
             exit 0
             ;;
         esac
@@ -260,7 +271,12 @@ def test_trigger_4_quarantine_artifact_aborts(tmp_path):
 
 @pytest.mark.allow_real_subprocess
 def test_trigger_5_state_running_timeout_aborts(tmp_path):
-    """Trigger 5: launchctl print never shows 'state = running' → abort."""
+    """Trigger 5: launchctl print never shows 'state = running' → abort.
+
+    Daemon-path failure: the first plist in PLISTS is supervisor (KeepAlive=true).
+    With set -euo pipefail, abort on supervisor exits before scheduled-tick is
+    even reached, so this test exercises only the daemon branch.
+    """
     launchctl_body = textwrap.dedent(
         f"""\
         #!/usr/bin/env bash
@@ -280,3 +296,80 @@ def test_trigger_5_state_running_timeout_aborts(tmp_path):
 
     assert result.returncode != 0
     assert "trigger=5_state_running" in result.stderr
+
+
+@pytest.mark.allow_real_subprocess
+def test_trigger_5_cron_never_fired_accepted(tmp_path):
+    """Trigger 5 cron-branch: scheduled-tick never ran yet → state=not running
+    with NO 'last exit code' line is the bootstrap-fresh steady-state and
+    must be accepted (no abort).
+
+    The default stub already emits "state = not running" + "last exit code = 0"
+    for scheduled-tick. To exercise the never-fired path we override print to
+    omit the last-exit line for that label only.
+    """
+    launchctl_body = textwrap.dedent(
+        f"""\
+        #!/usr/bin/env bash
+        echo "launchctl $@" >> {tmp_path}/calls.log
+        case "$1" in
+          bootout)   exit 0 ;;
+          bootstrap) exit 0 ;;
+          print)
+            case "$2" in
+              *scheduled-tick*)
+                # Bootstrap-fresh: never fired yet, no last-exit line.
+                echo "state = not running"
+                ;;
+              *)
+                echo "state = running"
+                ;;
+            esac
+            exit 0
+            ;;
+        esac
+        exit 0
+        """
+    )
+    _, env, log = _make_env(tmp_path, launchctl_body=launchctl_body)
+    result = _run(env)
+
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    assert "W0-B deploy complete (3 plist deployed)" in result.stdout
+
+
+@pytest.mark.allow_real_subprocess
+def test_trigger_5_cron_last_exit_nonzero_aborts(tmp_path):
+    """Trigger 5 cron-branch: scheduled-tick ran and crashed (last exit != 0)
+    → trigger 5 must fire. Cron-pattern accept is steady-state OK only when
+    last exit code is 0 or absent."""
+    launchctl_body = textwrap.dedent(
+        f"""\
+        #!/usr/bin/env bash
+        echo "launchctl $@" >> {tmp_path}/calls.log
+        case "$1" in
+          bootout)   exit 0 ;;
+          bootstrap) exit 0 ;;
+          print)
+            case "$2" in
+              *scheduled-tick*)
+                echo "state = not running"
+                echo "last exit code = 78"
+                ;;
+              *)
+                echo "state = running"
+                ;;
+            esac
+            exit 0
+            ;;
+        esac
+        exit 0
+        """
+    )
+    _, env, log = _make_env(tmp_path, launchctl_body=launchctl_body)
+    result = _run(env)
+
+    assert result.returncode != 0
+    assert "trigger=5_state_running" in result.stderr
+    # Error message must reference cron-specific phrasing so triage is fast.
+    assert "cron plist" in result.stderr


### PR DESCRIPTION
## Summary

- Splits trigger-5 verify in `apps/organism/scripts/deploy_w0.sh` into a daemon branch (`KeepAlive=true` → expects `state = running`) and a cron branch (cron plist → expects `state = not running` + `last exit code = 0`, or never-fired).
- Detects plist type via `plutil -extract KeepAlive raw` (one reliable form on macOS — `json` rejects top-level scalars with `Invalid object in plist for JSON format`).
- Cron-pattern with `state = not running + last exit code = 0` was previously a spurious trigger-5 abort, which had to be recovered manually after every W0-B run on `com.nuzantara.organism.scheduled-tick`.

## Why

W1 batches will enroll 8+ cron-pattern organs (W1.1 `pro.sentinel`, `pro.cpu_monitor`, `pro.disk_monitor`, …; W1.3 `pro.intel_*`, `pro.indexing_sweep`, `pro.translate_hourly`, …). Without this fix every cron plist redeploy aborts at trigger 5 even when launchd is correctly registering the schedule.

The Innervation orchestrator prompt explicitly calls this out as `W1.bug`: standalone fix, no Genoma touch, no organ enrollment, blocks future automation only as a false-positive nuisance.

## Approach

`plutil -extract KeepAlive raw -o - "$dst"` returns:
- `true` + rc=0 → daemon path (unchanged behavior)
- empty + rc=1 → cron path (new accept logic)

The cron-pattern accept logic:

| state | last exit code | result |
|---|---|---|
| `running` | * | not expected for cron — keep waiting (will abort) |
| `not running` | `0` | ✅ accept (idle between fires) |
| `not running` | absent (line missing) | ✅ accept (bootstrap-fresh, never fired) |
| `not running` | non-zero | ❌ keep waiting → abort with cron-specific phrasing |

The cron-specific abort message (`cron plist did not reach steady-state…`) gives faster triage than reusing the daemon phrasing.

## Test plan

- [x] 6 existing trigger tests stay green.
- [x] Default `_make_env` launchctl stub now emits realistic per-plist-type output (daemon → `state = running`, cron-named labels → `state = not running` + `last exit code = 0`) so the trigger-4 / dry-run tests continue to drive the cron branch correctly.
- [x] New `test_trigger_5_cron_never_fired_accepted` — bootstrap-fresh cron with no last-exit line accepted.
- [x] New `test_trigger_5_cron_last_exit_nonzero_aborts` — cron with `last exit code = 78` aborts with `cron plist` phrasing.
- [x] `DRY_RUN=1 bash apps/organism/scripts/deploy_w0.sh` smoke-tests clean on all 3 W0 plist (no behavior change for dry-run).
- [x] Live read-only verify on `com.nuzantara.organism.scheduled-tick` confirms the parser matches the actual launchd output (`state = not running` + `last exit code = 0`).
- [ ] Real W0-B deploy will be exercised at the start of the next W1.x batch — that is the live integration test by default.

## Cicatrix references

- STRUCTURAL "53 LaunchAgents Pro, only 7 (13%) KeepAlive=true" (2026-04-29) — confirms cron+daemon coexist and any verifier targeting all plist must distinguish them.
- No P0-3 plist-corruption-surface affected (lint/size/quarantine triggers and chmod 0400 hardening unchanged).