### PR TITLE
fix(ops): heartbeat_monitor Telegram parse_mode Markdown → HTML

### DIFF
--- a/apps/evaluator/nlm_deep_research/heartbeat_monitor.py
+++ b/apps/evaluator/nlm_deep_research/heartbeat_monitor.py
@@ -371,7 +371,7 @@ def _send_telegram(text: str, dry_run: bool = False) -> bool:
     """Send a message via Telegram Bot API.
 
     Args:
-        text: Message text (supports Markdown).
+        text: Message text (supports HTML — <b>, <i>, <code>).
         dry_run: If True, print instead of sending.
 
     Returns:
@@ -389,10 +389,15 @@ def _send_telegram(text: str, dry_run: bool = False) -> bool:
         return False
 
     url = f"{TELEGRAM_API_BASE}/bot{token}/sendMessage"
+    # Renaissance follow-up #2 (2026-04-30): switched parse_mode from
+    # "Markdown" (legacy v1) to "HTML" because pipeline names contain
+    # underscores ("nb1_daily_refresh", "t4_monitor") which Markdown v1
+    # interprets as italic delimiters. Unbalanced underscores → HTTP 400.
+    # gap_scanner.py uses HTML and works reliably; we copy that pattern.
     payload = json.dumps({
         "chat_id": chat_id,
         "text": text,
-        "parse_mode": "Markdown",
+        "parse_mode": "HTML",
         "disable_web_page_preview": True,
     }).encode("utf-8")
 
@@ -460,12 +465,12 @@ def send_alert(statuses: list[dict[str, Any]], dry_run: bool = False) -> None:
         logger.info("All pipelines healthy — no alert needed")
         return
 
-    lines = ["\U0001f6a8 *NLM Pipeline Alert*", ""]
+    lines = ["\U0001f6a8 <b>NLM Pipeline Alert</b>", ""]
 
     for s in alert_statuses:
         emoji = STATUS_EMOJI.get(s["status"], "?")
         last_run = _format_last_run(s.get("last_success"))
-        lines.append(f"{emoji} `{s['pipeline']}` — {s['status']} ({last_run})")
+        lines.append(f"{emoji} <code>{s['pipeline']}</code> — {s['status']} ({last_run})")
 
     ok_count = sum(1 for s in statuses if s["status"] == STATUS_OK)
     total = len(statuses)
@@ -490,7 +495,7 @@ def send_daily_digest(
     if memory is None:
         memory = check_memory_pressure()
 
-    lines = ["\U0001f3e5 *NLM Pipeline Health \u2014 Daily Digest*", ""]
+    lines = ["\U0001f3e5 <b>NLM Pipeline Health \u2014 Daily Digest</b>", ""]
 
     for s in statuses:
         emoji = STATUS_EMOJI.get(s["status"], "?")
@@ -498,7 +503,7 @@ def send_daily_digest(
         duration = ""
         if s.get("duration_seconds") is not None:
             duration = f" ({s['duration_seconds']}s)"
-        lines.append(f"{emoji} `{s['pipeline']}` \u2014 {last_run}{duration}")
+        lines.append(f"{emoji} <code>{s['pipeline']}</code> \u2014 {last_run}{duration}")
 
     # Summary counts
     ok_count = sum(1 for s in statuses if s["status"] == STATUS_OK)

--- a/docs/ops/2026-04-30-followup-heartbeat-telegram-html.md
+++ b/docs/ops/2026-04-30-followup-heartbeat-telegram-html.md
@@ -1,0 +1,103 @@
+# Renaissance Follow-up #2 — Heartbeat Telegram HTTP 400 (2026-04-30)
+
+Discovery during live test phase of the renaissance:
+`apps/evaluator/nlm_deep_research/heartbeat_monitor.py::_send_telegram`
+returned `HTTP Error 400: Bad Request` from the Telegram Bot API on
+every alert.
+
+The PR-C3 fix (sourcing `~/.nuzantara-secrets.env`) successfully made
+`TELEGRAM_BOT_TOKEN` reach the cron environment, so the API call
+itself fired — but Telegram rejected the payload.
+
+## Root cause
+
+`_send_telegram` used `parse_mode: "Markdown"` (legacy v1). Pipeline
+names contain underscores (`nb1_daily_refresh`, `t4_monitor`,
+`db_nlm_sync`), which Markdown v1 interprets as italic delimiters.
+Unbalanced underscores → "can't parse entities" → HTTP 400.
+
+## Fix
+
+Switch `parse_mode` from `"Markdown"` to `"HTML"`, and rewrite the
+two message builders (`send_alert`, `send_daily_digest`) to emit HTML
+tags instead of Markdown:
+
+```diff
+- "*NLM Pipeline Alert*"
++ "<b>NLM Pipeline Alert</b>"
+
+- f"`{s['pipeline']}` — {s['status']}"
++ f"<code>{s['pipeline']}</code> — {s['status']}"
+```
+
+This is the same pattern `gap_scanner.py::_send_telegram` (and
+`apps/cell` Telegram delivery) already use successfully. HTML mode
+treats `_` as a literal character, so pipeline names stop breaking
+the parser.
+
+The em-dash `—` (`—`) and emoji are unaffected by parse_mode
+changes — they're plain Unicode.
+
+## Live verification
+
+After deploying the patched file to Pro and running:
+
+```bash
+ssh pro 'cd ~/Desktop/nuzantara && source apps/backend-rag/.venv/bin/activate \
+  && set -a && source ~/.nuzantara-secrets.env && set +a \
+  && PYTHONPATH=. python -m apps.evaluator.nlm_deep_research.heartbeat_monitor --check'
+```
+
+The log emits:
+
+```
+2026-04-30 04:21:11,837 [INFO] __main__: Telegram alert sent successfully
+```
+
+(Previously: `Failed to send Telegram alert: HTTP Error 400: Bad Request`.)
+
+The alert message arrived in chat `1125336968` with proper formatting:
+**NLM Pipeline Alert** in bold, pipeline names in monospace `code`
+blocks, status emoji preserved.
+
+## Why not MarkdownV2
+
+MarkdownV2 (Telegram's escape-required successor) would also work,
+but requires escaping `_*[]()~`>#+-=|{}.!` in every dynamic string
+— easy to miss one and re-introduce HTTP 400. HTML has 3 escape
+chars (`<`, `>`, `&`) and the message content here has none of them
+by construction (pipeline names are `[a-z0-9_]+`, statuses are
+fixed strings).
+
+If a future pipeline name introduces `<` or `>` (unlikely — registry
+schema is `pipeline_id: lowercase_with_underscores`), `html.escape()`
+should be added in the builder. For now: zero escapes needed.
+
+## Test plan
+
+- [x] py_compile heartbeat_monitor.py
+- [x] Live deploy to Pro + manual run → "Telegram alert sent
+      successfully"
+- [x] Verified message arrives in chat 1125336968 with HTML
+      formatting intact
+- [ ] (Post-merge, next 6h heartbeat tick `30 */6 * * *`) Cron-driven
+      alert delivers without HTTP 400
+
+## Out of scope
+
+- **Wider Telegram delivery audit.** Other scripts on Pro
+  (`run_gap_scanner.sh` self-built bash, `heartbeat_monitor.py`,
+  `gap_scanner.py`, cell-organism, openclaw) use various
+  parse_modes. A standardization pass to HTML across the board would
+  reduce future surprises but is a separate cleanup PR.
+- **html.escape() in message builders.** Defensive but not needed
+  for current input alphabet (no special HTML chars in pipeline
+  ids or registry strings).
+
+## Related
+
+- Renaissance summary: `docs/ops/2026-04-30-renaissance-summary.md`
+- Predecessor PR-C3: `docs/ops/2026-04-30-pr-c3-missing-env.md`
+  (sourced secrets so token reached the API)
+- MOS unresolved id 1968 (this discovery)
+- Same pattern: `apps/evaluator/nlm_deep_research/gap_scanner.py::_send_telegram`


### PR DESCRIPTION
Renaissance follow-up #2.

Telegram API rejected every heartbeat alert with HTTP 400 because pipeline names contain underscores (`nb1_daily_refresh`, `t4_monitor`, `db_nlm_sync`) which Markdown v1 parses as italic delimiters. Unbalanced underscores → can't parse entities → 400.

## Fix

`parse_mode` "Markdown" → "HTML" in `_send_telegram`, plus rewrite the 2 message builders:
- `*NLM Pipeline Alert*` → `<b>NLM Pipeline Alert</b>`
- `\`{pipeline}\`` → `<code>{pipeline}</code>`

Same pattern `gap_scanner.py` and `apps/cell` Telegram delivery already use successfully.

## Live verification on Pro (2026-04-30 04:21 WITA)

Before patch:
```
ERROR Failed to send Telegram alert: HTTP Error 400: Bad Request
```

After patch:
```
INFO Telegram alert sent successfully
```

Alert delivered to chat 1125336968 with proper HTML formatting (bold title, monospace pipeline names).

PR-C3 (source secrets) made the token reachable; this PR fixes the actual payload. Both needed.

## Test plan

- [x] py_compile
- [x] Live deploy to Pro + manual run → 'Telegram alert sent successfully'
- [x] Alert arrived in chat 1125336968
- [ ] (Post-merge, next 6h heartbeat tick) Cron-driven alert delivers

## Reference

- Doc: `docs/ops/2026-04-30-followup-heartbeat-telegram-html.md`
- Renaissance summary: `docs/ops/2026-04-30-renaissance-summary.md`
- Predecessor PR-C3: `docs/ops/2026-04-30-pr-c3-missing-env.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)