### PR TITLE
feat(innervation/W1.1): enroll 8 Tier-1 Critical Pro infra organi

### DIFF
--- a/apps/cell/cell/main.py
+++ b/apps/cell/cell/main.py
@@ -28,6 +28,7 @@ from cell.sensors.backup_sensor import BackupSensor
 from cell.sensors.cron_sensor import CronSensor
 from cell.sensors.database_sensor import DatabaseSensor
 from cell.sensors.error_rate_sensor import ErrorRateSensor
+from cell.utils.organ_emitter import emit_organ_last_seen
 from cell.sensors.health_sensor import HealthSensor
 from cell.sensors.ollama_sensor import OllamaSensor
 from cell.sensors.qdrant_sensor import QdrantSensor
@@ -297,6 +298,24 @@ async def main() -> None:
                 logger.info(f"Pulse #{pulse_count} complete. Health: {status_str}{action_str}{tier_str}")
                 _last_status = status_str
 
+                # Innervation W1.1: emit liveness sidecar each pulse so the
+                # genome aggregator sees we're alive. Map health to sidecar
+                # status: green→ok, yellow→degraded, red→fail.
+                _organ_status = {
+                    "green": "ok",
+                    "yellow": "degraded",
+                    "red": "fail",
+                }.get(status_str, "degraded")
+                emit_organ_last_seen(
+                    "cell.organism",
+                    _organ_status,
+                    {
+                        "pulse_count": pulse_count,
+                        "tier": result.thought_tier,
+                        "action": result.action_taken,
+                    },
+                )
+
                 # Episodic forgetting — every 1000 pulses (~17h at 60s intervals)
                 if pulse_count % 1000 == 0 and pulse_count > 0:
                     try:
@@ -308,6 +327,15 @@ async def main() -> None:
 
             except Exception as e:
                 logger.error(f"Pulse #{pulse_count} error: {e}", exc_info=True)
+                # Innervation W1.1: pulse threw — surface as fail in the
+                # sidecar so the aggregator does not treat us as silently
+                # alive. Stays best-effort (emit_organ_last_seen swallows
+                # its own exceptions).
+                emit_organ_last_seen(
+                    "cell.organism",
+                    "fail",
+                    {"pulse_count": pulse_count, "error": type(e).__name__},
+                )
 
             # Adaptive interval: homeostatic controller decides (circadian + stress-aware)
             interval = homeostatic.recommended_pulse_interval()

--- a/apps/cell/cell/utils/__init__.py
+++ b/apps/cell/cell/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers for the Cell daemon (Innervation W1.1+)."""

--- a/apps/cell/cell/utils/organ_emitter.py
+++ b/apps/cell/cell/utils/organ_emitter.py
@@ -1,0 +1,70 @@
+"""Emit a sidecar liveness file for the Innervation Genoma aggregator.
+
+Convention (W1.1, 2026-04-30):
+
+    ~/.organism/last_seen/<organ_id>.json
+
+    {
+        "ts": <unix_epoch_float>,
+        "status": "ok" | "degraded" | "fail",
+        "organ_id": "<full.id>",
+        "metadata": {<dict>}
+    }
+
+The Cell `genome_aggregator_sensor` reads this sidecar via
+`bridge_source: state_file` declared in `apps/organism/organism/genome.yaml`.
+A missing / stale file → BridgeReading.error → organ classified `dead`.
+
+This helper is intentionally tiny and dependency-free: it is called from
+hot paths (every Pulse cycle for cell.organism, every cron tick for shell
+organi) and MUST never raise back to the producer.
+
+Spec ref: docs/innervation-2026-04-29/07_innervation_protocol.md §1.1.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any, Mapping
+
+logger = logging.getLogger("cell.utils.organ_emitter")
+
+# Module-level constants — easy to override in tests.
+DEFAULT_LAST_SEEN_DIR = Path("~/.organism/last_seen").expanduser()
+
+
+def emit_organ_last_seen(
+    organ_id: str,
+    status: str,
+    metadata: Mapping[str, Any] | None = None,
+    *,
+    out_dir: Path | str | None = None,
+) -> bool:
+    """Write the sidecar JSON. Returns True on success, False otherwise.
+
+    Best-effort: any I/O / serialization failure is logged at WARNING and
+    swallowed — the producer's primary path must NOT depend on the sidecar
+    landing on disk. The Genoma aggregator already treats absent sidecar as
+    `dead`, so a write failure naturally surfaces as silence on the next
+    Cell pulse.
+    """
+    target_dir = Path(out_dir) if out_dir else DEFAULT_LAST_SEEN_DIR
+    try:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        payload: dict[str, Any] = {
+            "ts": time.time(),
+            "status": str(status),
+            "organ_id": str(organ_id),
+            "metadata": dict(metadata) if metadata else {},
+        }
+        out_file = target_dir / f"{organ_id}.json"
+        out_file.write_text(json.dumps(payload), encoding="utf-8")
+        return True
+    except Exception as exc:  # noqa: BLE001 — keep emitter robust
+        logger.warning(f"organ_last_seen emit failed for {organ_id}: {exc}")
+        return False
+
+
+__all__ = ["emit_organ_last_seen", "DEFAULT_LAST_SEEN_DIR"]

--- a/apps/cell/tests/test_genome_aggregator_sensor.py
+++ b/apps/cell/tests/test_genome_aggregator_sensor.py
@@ -391,3 +391,56 @@ def test_w1_pro_zombie_hunter_enrolled(tmp_path):
     assert happy.metadata["alive"] == 1
     assert dead.status == "red"
     assert dead.metadata["dead_organs"] == ["pro.zombie_hunter"]
+
+
+def test_w1_pro_dlq_autopilot_enrolled(tmp_path):
+    happy, dead = _w1_happy_dead_pair(
+        tmp_path,
+        "pro.dlq_autopilot",
+        expected_hb_seconds=2700,
+    )
+    assert happy.status == "green"
+    assert happy.metadata["alive"] == 1
+    assert dead.status == "red"
+    assert dead.metadata["dead_organs"] == ["pro.dlq_autopilot"]
+
+
+def test_w1_pro_sentinel_enrolled(tmp_path):
+    happy, dead = _w1_happy_dead_pair(
+        tmp_path,
+        "pro.sentinel",
+        expected_hb_seconds=90000,
+        severity="critical",
+    )
+    assert happy.status == "green"
+    assert happy.metadata["alive"] == 1
+    assert dead.status == "red"
+    assert dead.metadata["dead_organs"] == ["pro.sentinel"]
+
+
+def test_w1_cell_organism_enrolled(tmp_path):
+    """cell.organism daemon: recovery_action=human_only but sidecar still
+    feeds the aggregator so the Supervisor can see liveness/status without
+    being able to act on silence (operator wakes it up by hand)."""
+    happy, dead = _w1_happy_dead_pair(
+        tmp_path,
+        "cell.organism",
+        expected_hb_seconds=90,
+        severity="critical",
+    )
+    assert happy.status == "green"
+    assert happy.metadata["alive"] == 1
+    assert dead.status == "red"
+    assert dead.metadata["dead_organs"] == ["cell.organism"]
+
+
+def test_w1_pro_metabolic_rollup_enrolled(tmp_path):
+    happy, dead = _w1_happy_dead_pair(
+        tmp_path,
+        "pro.metabolic_rollup",
+        expected_hb_seconds=5400,
+    )
+    assert happy.status == "green"
+    assert happy.metadata["alive"] == 1
+    assert dead.status == "red"
+    assert dead.metadata["dead_organs"] == ["pro.metabolic_rollup"]

--- a/apps/cell/tests/test_genome_aggregator_sensor.py
+++ b/apps/cell/tests/test_genome_aggregator_sensor.py
@@ -267,3 +267,127 @@ def test_bridge_source_override_wins_over_last_seen_db(tmp_path):
     assert reading.status == "green"
     assert reading.metadata["alive"] == 1
     assert reading.metadata["dead"] == 0
+
+
+# ---------- W1.1 enrollment tests -------------------------------------------
+#
+# Every Tier-1 Critical Pro infra organ enrolled in genome.yaml during W1.1
+# emits a sidecar at ~/.organism/last_seen/<organ_id>.json with the standard
+# schema (ts, status, organ_id, metadata). The aggregator already supports
+# this via bridge_source: state_file. The tests here use tmp_path bridge
+# files (not the real ~/.organism/) and assert two cases per organ:
+#
+#   - happy path: sidecar present + ts recent → state alive (aggregate green)
+#   - dead path:  sidecar missing            → state dead (aggregate red),
+#                 with bridge error surfaced via the aggregator's classification
+#                 (BridgeReading.error populated by BridgeStateReader._read_one).
+#
+# Spec ref: ScratchPad: docs/innervation-2026-04-29/07_innervation_protocol.md §1.1.
+
+
+def _w1_organ(
+    organ_id: str,
+    bridge_path: Path,
+    expected_hb_seconds: int,
+    *,
+    severity: str = "warning",
+) -> dict:
+    """Build a genoma entry mirroring the W1.1 enrollment shape."""
+    out = _organ(
+        organ_id,
+        expected_hb_seconds=expected_hb_seconds,
+        bridge_path=bridge_path,
+    )
+    out["severity_on_silence"] = severity
+    return out
+
+
+def _write_w1_sidecar(path: Path, *, status: str, age_s: float, organ_id: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "ts": time.time() - age_s,
+                "status": status,
+                "organ_id": organ_id,
+                "metadata": {},
+            }
+        )
+    )
+
+
+def _w1_happy_dead_pair(
+    tmp_path: Path,
+    organ_id: str,
+    expected_hb_seconds: int,
+    *,
+    severity: str = "warning",
+) -> tuple[SensorReading, SensorReading]:
+    """Run the aggregator twice for one organ: once happy, once dead."""
+    genome = tmp_path / f"{organ_id}_genome.yaml"
+    db = tmp_path / f"{organ_id}_last_seen.db"
+    bridge = tmp_path / f"{organ_id}.json"
+
+    _write_genome(genome, [_w1_organ(organ_id, bridge, expected_hb_seconds, severity=severity)])
+
+    # Happy: sidecar fresh (age ≪ 1.5x expected)
+    _write_w1_sidecar(bridge, status="ok", age_s=max(1.0, expected_hb_seconds * 0.1), organ_id=organ_id)
+    sensor = GenomeAggregatorSensor(genome_path=genome, last_seen_db_path=db)
+    happy = _run(sensor)
+
+    # Dead: sidecar absent. (Use a fresh sensor instance to be explicit, even
+    # though read() reloads I/O each call.)
+    bridge.unlink()
+    sensor = GenomeAggregatorSensor(genome_path=genome, last_seen_db_path=db)
+    dead = _run(sensor)
+
+    return happy, dead
+
+
+def test_w1_pro_fly_restart_loop_detector_enrolled(tmp_path):
+    happy, dead = _w1_happy_dead_pair(
+        tmp_path,
+        "pro.fly_restart_loop_detector",
+        expected_hb_seconds=1350,
+        severity="critical",
+    )
+    assert happy.status == "green"
+    assert happy.metadata["alive"] == 1
+    assert dead.status == "red"
+    assert dead.metadata["dead_organs"] == ["pro.fly_restart_loop_detector"]
+
+
+def test_w1_pro_cpu_monitor_enrolled(tmp_path):
+    happy, dead = _w1_happy_dead_pair(
+        tmp_path,
+        "pro.cpu_monitor",
+        expected_hb_seconds=1350,
+    )
+    assert happy.status == "green"
+    assert happy.metadata["alive"] == 1
+    assert dead.status == "red"
+    assert dead.metadata["dead_organs"] == ["pro.cpu_monitor"]
+
+
+def test_w1_pro_disk_monitor_enrolled(tmp_path):
+    happy, dead = _w1_happy_dead_pair(
+        tmp_path,
+        "pro.disk_monitor",
+        expected_hb_seconds=1350,
+    )
+    assert happy.status == "green"
+    assert happy.metadata["alive"] == 1
+    assert dead.status == "red"
+    assert dead.metadata["dead_organs"] == ["pro.disk_monitor"]
+
+
+def test_w1_pro_zombie_hunter_enrolled(tmp_path):
+    happy, dead = _w1_happy_dead_pair(
+        tmp_path,
+        "pro.zombie_hunter",
+        expected_hb_seconds=90,
+    )
+    assert happy.status == "green"
+    assert happy.metadata["alive"] == 1
+    assert dead.status == "red"
+    assert dead.metadata["dead_organs"] == ["pro.zombie_hunter"]

--- a/apps/organism/organism/genome.yaml
+++ b/apps/organism/organism/genome.yaml
@@ -28,7 +28,7 @@
 
 version: 1
 checksum_algo: sha256
-checksum: d2b8db9f2f236250290a4e0d449c2ddf3f7c93c4806ff54076b1610f5dd7efdd
+checksum: 825ed3052ebc5bf7c60eef9c7f9cc47a3c302ca636172e11d9561a3779f3caa7
 organs:
 - id: infra.postgres
   runtime: fly_machine
@@ -197,5 +197,71 @@ organs:
   bridge_source:
     type: state_file
     path: ~/.organism/last_seen/pro.zombie_hunter.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.dlq_autopilot
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 2700
+  owner_module: scripts/dlq_autopilot.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.dlq-autopilot
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.dlq_autopilot.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.sentinel
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/nuzantara-sentinel.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.sentinel
+  severity_on_silence: critical
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.sentinel.json
+    timestamp_field: ts
+    status_field: status
+- id: cell.organism
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 90
+  owner_module: apps/cell/cell/main.py
+  dependencies:
+  - infra.postgres
+  - infra.redis
+  recovery_action: human_only
+  recovery_params:
+    label: com.cell.organism
+  severity_on_silence: critical
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/cell.organism.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.metabolic_rollup
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 5400
+  owner_module: scripts/metabolic_rollup_pro.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.cell.metabolic-rollup
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.metabolic_rollup.json
     timestamp_field: ts
     status_field: status

--- a/apps/organism/organism/genome.yaml
+++ b/apps/organism/organism/genome.yaml
@@ -133,3 +133,69 @@ organs:
     path: ~/.agent/decisions/state/login_healthcheck.last.json
     timestamp_field: ts
     status_field: status
+- id: pro.fly_restart_loop_detector
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 1350
+  owner_module: scripts/fly-restart-loop-detector.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.fly-restart-loop-detector
+  severity_on_silence: critical
+  cicatrix_refs:
+  - 2026-04-29-drive-poll-attribute-error
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.fly_restart_loop_detector.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.cpu_monitor
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 1350
+  owner_module: scripts/cpu-monitor.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.cpu-monitor
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.cpu_monitor.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.disk_monitor
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 1350
+  owner_module: scripts/disk-monitor.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.disk-monitor
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.disk_monitor.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.zombie_hunter
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90
+  owner_module: .claude/scripts/zombie-hunter.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.zombie-hunter
+  severity_on_silence: warning
+  cicatrix_refs:
+  - 2026-04-29-untracked-files-lost
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.zombie_hunter.json
+    timestamp_field: ts
+    status_field: status

--- a/scripts/metabolic_rollup_pro.sh
+++ b/scripts/metabolic_rollup_pro.sh
@@ -48,9 +48,32 @@ export METABOLIC_DB_PATH="${METABOLIC_DB_PATH:-$HOME/.agent/decisions/organism_m
 
 # mode=pro: no PG_DSN, writes 1 row with scope='host', collector='pro'.
 # TTR+DO will be NULL with metadata.error='not_applicable_by_design'.
-exec "$PY" scripts/metabolic_rollup.py \
+"$PY" scripts/metabolic_rollup.py \
     --db-path "$METABOLIC_DB_PATH" \
     --mode pro \
     --collector-host pro \
     --notify \
     >> "$LOG_DIR/metabolic-rollup-pro.log" 2>&1
+rc=$?
+
+# Innervation W1.1: emit liveness sidecar regardless of rc — the aggregator
+# only cares that we ran, the status field tells it how the run went.
+ORGAN_LAST_SEEN_DIR="$HOME/.organism/last_seen"
+mkdir -p "$ORGAN_LAST_SEEN_DIR"
+if [ "$rc" -eq 0 ]; then
+    organ_status=ok
+else
+    organ_status=fail
+fi
+"$PY" -c "
+import json, time
+out = '$ORGAN_LAST_SEEN_DIR/pro.metabolic_rollup.json'
+open(out, 'w').write(json.dumps({
+    'ts': time.time(),
+    'status': '$organ_status',
+    'organ_id': 'pro.metabolic_rollup',
+    'metadata': {'rc': $rc, 'mode': 'pro'},
+}))
+" 2>>"$LOG_DIR/metabolic-rollup-pro.log" || true
+
+exit "$rc"


### PR DESCRIPTION
## Summary

Enrolls 8 Tier-1 Critical Pro infra organi in the Innervation Genoma:
fly_restart_loop_detector, cpu_monitor, disk_monitor, zombie_hunter,
dlq_autopilot, sentinel, cell.organism, metabolic_rollup. Each emits a
sidecar `~/.organism/last_seen/<organ_id>.json` with the standard schema
(ts, status, organ_id, metadata) so the Cell `genome_aggregator_sensor`
can compute liveness and the Supervisor can route `recovery_action`
when silence exceeds `expected_hb_seconds`.

Genoma post-merge: 7 (W0) + 8 (W1.1) = **15 organi enrolled**.
Checksum re-stamp: `d2b8db9f… → 825ed305…`.

## Per-organ summary

| organ_id | runtime | hb_seconds | recovery_action | severity |
|---|---|---|---|---|
| pro.fly_restart_loop_detector | cron | 1350 | launchctl_kickstart | critical |
| pro.cpu_monitor | cron | 1350 | launchctl_kickstart | warning |
| pro.disk_monitor | cron | 1350 | launchctl_kickstart | warning |
| pro.zombie_hunter | cron | 90 | launchctl_kickstart | warning |
| pro.dlq_autopilot | cron | 2700 | launchctl_kickstart | warning |
| pro.sentinel | cron | 90000 | launchctl_kickstart | critical |
| cell.organism | daemon | 90 | **human_only** | critical |
| pro.metabolic_rollup | cron | 5400 | launchctl_kickstart | warning |

`recovery_action=human_only` for cell.organism: qwen3:8b reload costs
~30s VRAM; operator restart preferred over auto-thundering-herd.

## Excluded from W1.1

- `pro.cert_monitor` — runs from user crontab (`0 7 * * *
  /Users/nuzantara/scripts/cert-monitor.sh`), NOT LaunchAgent.
  Different recovery pattern (`crontab_kickstart` not
  `launchctl_kickstart`). Tracked as **W1-bug-2** follow-up:
  crontab-based organ enrollment.

## Files modified outside repo (with `.pre-w1.1` backups)

- `~/scripts/fly-restart-loop-detector.sh` (FASE 1)
- `~/scripts/cpu-monitor.sh` (FASE 1)
- `~/scripts/disk-monitor.sh` (FASE 1)
- `~/.claude/scripts/zombie-hunter.sh` (FASE 1)
- `~/scripts/dlq_autopilot.py` (FASE 2)
- `~/scripts/nuzantara-sentinel.py` (FASE 2)
- `~/scripts/_organism_lib.sh` (helper, no backup — new file)

In-repo file modified: `scripts/metabolic_rollup_pro.sh` (FASE 2 — the
only in-repo organ script in W1.1).

## Helper introduced

- `apps/cell/cell/utils/organ_emitter.py` — `emit_organ_last_seen(organ_id,
  status, metadata)`. Best-effort; never raises back to producer. Used by
  `cell.organism` daemon. Shell organi outside the repo use the bash
  analog at `~/scripts/_organism_lib.sh`.

## Discoveries (flagged for follow-up)

- **cell.organism PID 12016 had `last exit code = 1` at pre-flight.**
  KeepAlive=true masked the crash. NOT a blocker for enrollment
  (`recovery_action=human_only`), but flagged for cicatrix update
  + investigation. Bootstrap sidecar pre-seeded as `degraded` with
  the failing PID + last_exit code in the metadata until next operator
  restart.
- **Plist files post-P0-3 recovery (2026-04-29) have `StartInterval` /
  `StartCalendarInterval` directives stripped from disk.** `launchctl
  print` in-memory still shows `run interval = N seconds`. Authoritative
  source for `expected_hb_seconds` is `launchctl print`, not the on-disk
  plist. (Saved as discovery memory 2026-04-30.)

## Test plan

- [x] 14/14 tests in `apps/cell/tests/test_genome_aggregator_sensor.py`
      PASS — 6 baseline + 8 W1.1 organ enrollments (1 test per organ:
      happy path → green + dead path → red).
- [x] 8/8 W1.bug regression tests in
      `apps/organism/tests/scripts/test_deploy_w0.py` stay PASS.
- [x] Genoma `validate_genome` exit 0 with new checksum.
- [x] Live sidecar verify at PR-time: 8/8 organi sidecar files exist
      and parse to valid JSON; 4 status=ok recently fired by their cron
      schedule, 2 status=degraded reflecting the last actual run
      (dlq_autopilot, sentinel — both surfaced their escalation/queue
      stats), 2 status=degraded bootstrap snapshots (cell.organism,
      metabolic_rollup) that flip to live emission at the next producer
      event.
- [x] Bash syntax check on `scripts/metabolic_rollup_pro.sh`: clean.
- [x] Python AST parse on `apps/cell/cell/main.py`: clean.

## Cicatrix references

- STRUCTURAL "53 LaunchAgents Pro, only 7 (13%) KeepAlive=true"
  (2026-04-29) — this PR enrolls 8 of those non-KeepAlive cron organi
  so silence detection + `recovery_action` is now in scope of the
  Supervisor.
- STRUCTURAL "Untracked files lost when sibling automation switches
  branches" (2026-04-29) — mitigated by pre-flight session count = 1
  and FASE 1 WIP-commit + push pattern.
- New (proposed): cell.organism `KeepAlive=true` masks daemon crashes
  (`last_exit=1` yet `state = running`) — to be added if recurrence
  confirms structural class.

## Co-deployed context

Branch was rebased on `origin/main` after `#377` (cron_sensor
fly_health_check + core_guardian removal — applied independently)
and `#378` (heartbeat parse_mode HTML) merged. No conflict.