### PR TITLE
fix(backend/channels): /health threshold ordering — `down` was unreachable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ See [`INDEX.md`](INDEX.md) for the full atlas including packages, tessuti dati, 
 ### Tech Stack
 
 <!-- DOCSYNC:BACKEND_STATS_START -->
-- **Backend:** Python 3.11+, FastAPI, 253 routers, 516 services, 879 test files
+- **Backend:** Python 3.11+, FastAPI, 253 routers, 516 services, 880 test files
 <!-- DOCSYNC:BACKEND_STATS_END -->
 - **Frontend:** Next.js, TypeScript, Tailwind CSS
 - **Databases:** PostgreSQL (relational), Qdrant (vector), Redis (cache)
@@ -328,6 +328,28 @@ The user writes in **colloquial Italian**. Translate intent into precise technic
 ### CRM RBAC
 
 Admin (`zero@`, `antonellosiano@`, `asya@balizero.com`) → all. Team → only `assigned_to` matches.
+
+### Team Bali Zero (operational reference)
+
+| Member | Email | Role | Perimeter |
+|---|---|---|---|
+| Antonello (Zero) | `zero@balizero.com` / `antonellosiano@gmail.com` | Owner / Architect | All |
+| Asya | `asya@balizero.com` | Platform / Backend | All except prod secrets rotation |
+| Surya | `surya@balizero.com` | Tax operations | Tax practices, CoreTax |
+| Ari Firda | `ari.firda@balizero.com` | Visa/Immigration | Visa practices, KITAS |
+| Adit | `adit@balizero.com` | Operations / Welcome | Office, contracts, onboarding |
+| Sahira | `sahira@balizero.com` | Sales / WhatsApp | Lead handoff, client comms |
+| Krisna | `krisna@balizero.com` | LKPM / Reporting | LKPM allowlist (migration 110), Telegram @KrissTzy |
+| Damar | `damar@balizero.com` | Marketing / War Room | Canva, social, dispatch carousels |
+| Vino | `vino@balizero.com` | Marketing | Social, content support |
+| Veronika | `tax@balizero.com` | Tax team manager | Tax team coordination |
+| Rina | `rina@balizero.com` | Reception | Front desk, scheduling |
+| Ruslana | `ruslana@balizero.com` | Strategic / English content | Strategy, English copy. Telegram chat_id 3743891689 |
+| **Subhi Darajat** ⭐ NEW | `subhi@balizero.com` | **Growth Systems Owner** (probation 90gg 2026-04-30 → 2026-07-29) | `apps/mouth/(blog\|marketing\|kbli\|visa\|property\|tax-calendar)/**` + GA4/GSC + organic distribution. NO backend RAG, NO genome.yaml, NO secrets. See `~/.claude/projects/-Users-nuzantara/memory/subhi-{task-routing,rbac-permissions,contact}.md` |
+
+**Email language to team** (`feedback_email_language.md`): Bahasa Indonesia for all `@balizero.com` except `zero@`/`antonellosiano@`. Subhi: bahasa default, italiano OK as fallback.
+
+**Email sending** (REGOLA FISSA): always `from=zantara@balizero.com` (alias of `damar@balizero.com`) via Brevo `/api/notifications/send-email` + `X-API-Key: zantara-secret-2024`. Never `zero@`, `notifications@`, `subhi@` for automated/transactional sends.
 
 ## 10. Frontend Deploy — QA Automatico (OBBLIGATORIO)
 

--- a/apps/backend-rag/backend/app/routers/channels.py
+++ b/apps/backend-rag/backend/app/routers/channels.py
@@ -48,11 +48,13 @@ async def channel_health(
         errors = stats.get("errors", 0)
         error_rate = (errors / received * 100) if received > 0 else 0.0
 
-        # Determine status
-        if error_rate > 20:
-            status = "degraded"
-        elif error_rate > 50:
+        # Determine status. Order matters: check the stricter threshold first,
+        # otherwise `> 20` matches before `> 50` is ever reached and `down` is
+        # unreachable (latent bug pre-2026-04-30).
+        if error_rate > 50:
             status = "down"
+        elif error_rate > 20:
+            status = "degraded"
         else:
             status = "up"
 

--- a/apps/backend-rag/backend/tests/api/app/routers/test_channels.py
+++ b/apps/backend-rag/backend/tests/api/app/routers/test_channels.py
@@ -1,0 +1,106 @@
+"""Tests for apps/backend-rag/backend/app/routers/channels.py
+
+Pre-W1.2 scope: regression test for the threshold ordering bug in
+`/api/channels/health` — before this PR, the branch order was
+`if > 20: degraded; elif > 50: down`, which made `down` unreachable
+because anything `> 50` is also `> 20` and matched the first branch.
+
+Test strategy: mount the router in an isolated FastAPI app, stub
+`channel_router` (state) and `channel_metrics` (per-channel stats),
+override `get_current_user` to bypass auth, drive the endpoint with
+synthetic error_rate values across the three thresholds.
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from backend.app.dependencies import get_current_user
+from backend.app.routers.channels import router
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_app(channel_router_stub: Any) -> FastAPI:
+    """Build a minimal FastAPI app with channels router mounted and auth bypassed."""
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: {"email": "test@balizero.com"}
+    app.state.channel_router = channel_router_stub
+    app.state.db_pool = None  # /health gracefully handles None db_pool
+    return app
+
+
+def _stub_router(channels: list[str]) -> MagicMock:
+    """Mock ChannelRouter exposing get_available_channels()."""
+    cr = MagicMock()
+    cr.get_available_channels.return_value = channels
+    return cr
+
+
+async def _get_health(app: FastAPI) -> dict[str, Any]:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/channels/health")
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Threshold ordering regression tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_health_status_up_when_error_rate_below_20pct():
+    app = _build_app(_stub_router(["whatsapp"]))
+
+    metrics = MagicMock()
+    metrics.get_stats.return_value = {"messages_received": 100, "errors": 5}  # 5%
+    with patch(
+        "backend.channels.optimizations.channel_metrics",
+        metrics,
+    ):
+        body = await _get_health(app)
+
+    assert body["channels"]["whatsapp"]["status"] == "up"
+
+
+@pytest.mark.asyncio
+async def test_health_status_degraded_when_error_rate_between_20_and_50pct():
+    app = _build_app(_stub_router(["whatsapp"]))
+
+    metrics = MagicMock()
+    metrics.get_stats.return_value = {"messages_received": 100, "errors": 30}  # 30%
+    with patch(
+        "backend.channels.optimizations.channel_metrics",
+        metrics,
+    ):
+        body = await _get_health(app)
+
+    assert body["channels"]["whatsapp"]["status"] == "degraded"
+
+
+@pytest.mark.asyncio
+async def test_health_status_down_when_error_rate_above_50pct():
+    """Regression: pre-fix this would return 'degraded' because the `> 20`
+    branch matched before `> 50` was ever evaluated. With the fix, the
+    stricter threshold is checked first."""
+    app = _build_app(_stub_router(["whatsapp"]))
+
+    metrics = MagicMock()
+    metrics.get_stats.return_value = {"messages_received": 100, "errors": 60}  # 60%
+    with patch(
+        "backend.channels.optimizations.channel_metrics",
+        metrics,
+    ):
+        body = await _get_health(app)
+
+    assert body["channels"]["whatsapp"]["status"] == "down"

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`253 routers · 516 services · 879 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`253 routers · 516 services · 880 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary

`/api/channels/health` declared statuses with the threshold checks in the wrong order:

\`\`\`python
if error_rate > 20:
    status = "degraded"
elif error_rate > 50:
    status = "down"
\`\`\`

Any channel with an `error_rate > 50%` was also `> 20%`, so the first branch always matched first. **`down` was unreachable**. A 100% error_rate channel was reported as "degraded" in `/api/channels/health`. Downstream the overall-status aggregator (lines 84-89) computed "partial" where it should have computed "degraded".

## Fix

Invert the order: stricter threshold first.

\`\`\`python
if error_rate > 50:
    status = "down"
elif error_rate > 20:
    status = "degraded"
\`\`\`

3 LOC + reordered branches.

## Why now

Spotted while designing the public companion endpoint for the Innervation Genoma W1.2 channel enrollment. The new public endpoint reuses the same threshold logic, so the fix has to land first to avoid baking the bug into the new pattern. Doing it as a separate PR keeps git blame clean for the future W1.2 PR.

## Test plan

- [x] Adds the first regression test suite for `apps/backend-rag/backend/app/routers/channels.py` (none existed): three-bucket boundary tests at 5% / 30% / 60% error_rate.
- [x] Sanity check: pre-fix, the 60% test fails with `assert 'degraded' == 'down'`. Post-fix, all 3 PASS.
- [x] No regression of existing `/health` consumers (admin dashboard, Sentinel) — they receive a *more specific* status in the >50% bucket; downstream code already handled "down" alongside "degraded" (lines 84-89 already mapped "down" to "degraded" overall, so existing dashboards keep their behavior).
- [ ] Post-deploy: spot-check `curl https://kita.balizero.com/api/channels/health` (auth-walled, requires JWT) returns valid JSON shape — no field schema change.