### PR TITLE
fix(crm): correct passport OCR given/family name attribution

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_clients_documents.py
+++ b/apps/backend-rag/backend/app/routers/crm_clients_documents.py
@@ -140,6 +140,8 @@ class PassportPreviewResponse(BaseModel):
     success: bool
     confidence: float = 0.0
     full_name: str | None = None
+    surname: str | None = None
+    given_names: str | None = None
     nationality: str | None = None
     date_of_birth: str | None = None
     gender: str | None = None
@@ -212,7 +214,7 @@ async def extract_passport_enhanced(
 {
   "passport_number": "XX123456",
   "expiry_date": "YYYY-MM-DD",
-  "full_name": "SURNAME GIVEN_NAMES",
+  "full_name": "GIVEN_NAMES SURNAME",
   "surname": "SURNAME",
   "given_names": "GIVEN NAMES",
   "gender": "M or F",
@@ -221,6 +223,10 @@ async def extract_passport_enhanced(
   "nationality": "country code",
   "confidence": 0.95
 }
+
+The "surname" field MUST contain ONLY the family name (Surname/Apellidos/Nom),
+and "given_names" MUST contain ONLY the first/middle names (Given names/Prenoms/Nombres).
+"full_name" MUST be given names FIRST, then surname (Western reading order).
 
 Use null for unclear fields. Return ONLY JSON."""
 
@@ -304,6 +310,8 @@ Use null for unclear fields. Return ONLY JSON."""
 
         # Normalize extracted fields
         extracted["full_name"] = title_case_name(extracted.get("full_name"))
+        extracted["surname"] = title_case_name(extracted.get("surname"))
+        extracted["given_names"] = title_case_name(extracted.get("given_names"))
         extracted["nationality"] = normalize_nationality(extracted.get("nationality"))
         extracted["date_of_birth"] = normalize_date(extracted.get("date_of_birth"))
         extracted["expiry_date"] = normalize_date(extracted.get("expiry_date"))
@@ -343,6 +351,8 @@ Use null for unclear fields. Return ONLY JSON."""
                 success=bool(extracted),
                 confidence=extracted.get("confidence", 0.0) if extracted else 0.0,
                 full_name=extracted.get("full_name") if extracted else None,
+                surname=extracted.get("surname") if extracted else None,
+                given_names=extracted.get("given_names") if extracted else None,
                 nationality=extracted.get("nationality") if extracted else None,
                 date_of_birth=extracted.get("date_of_birth") if extracted else None,
                 gender=extracted.get("gender") if extracted else None,
@@ -358,17 +368,14 @@ Use null for unclear fields. Return ONLY JSON."""
 
         # --- Persist mode (client_id is not None) ---
 
-        # Verify name match
+        # Verify name match (order-insensitive: "Rewis Bishop" must match "Bishop Rewis")
         name_match = None
         ratio = None
         extracted_name = extracted.get("full_name")
         if extracted_name and existing_name:
-            # Fuzzy match with 80% threshold
-            ratio = SequenceMatcher(
-                None,
-                existing_name.upper().replace(",", " ").split(),
-                extracted_name.upper().replace(",", " ").split(),
-            ).ratio()
+            existing_tokens = sorted(existing_name.upper().replace(",", " ").split())
+            extracted_tokens = sorted(extracted_name.upper().replace(",", " ").split())
+            ratio = SequenceMatcher(None, existing_tokens, extracted_tokens).ratio()
             name_match = ratio >= 0.8
 
         # Prepare OCR data for storage
@@ -437,6 +444,8 @@ Use null for unclear fields. Return ONLY JSON."""
             success=True,
             confidence=extracted.get("confidence", 0.0),
             full_name=extracted.get("full_name"),
+            surname=extracted.get("surname"),
+            given_names=extracted.get("given_names"),
             nationality=extracted.get("nationality"),
             date_of_birth=extracted.get("date_of_birth"),
             gender=extracted.get("gender"),

--- a/apps/mouth/src/app/(workspace)/clients/new/components/PassportScanSection.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/new/components/PassportScanSection.tsx
@@ -30,7 +30,7 @@ interface PassportScanSectionProps {
 // State Machine Types
 // ============================================
 
-/** OCR-extractable field keys */
+/** OCR-extractable field keys (applied to the form on confirm) */
 const OCR_FIELDS = [
   'full_name',
   'nationality',
@@ -42,9 +42,15 @@ const OCR_FIELDS = [
 
 type OcrFieldKey = (typeof OCR_FIELDS)[number];
 
+/** Read-only name component fields shown for verification (not applied to form) */
+const NAME_COMPONENT_FIELDS = ['given_names', 'surname'] as const;
+type NameComponentKey = (typeof NAME_COMPONENT_FIELDS)[number];
+
 /** Human-readable labels for each OCR field */
-const FIELD_LABELS: Record<OcrFieldKey, string> = {
+const FIELD_LABELS: Record<OcrFieldKey | NameComponentKey, string> = {
   full_name: 'Full Name',
+  given_names: 'Given Names',
+  surname: 'Surname',
   nationality: 'Nationality',
   date_of_birth: 'Date of Birth',
   gender: 'Gender',
@@ -389,6 +395,27 @@ export function PassportScanSection({ onFieldsConfirmed, onDiscarded }: Passport
           <CheckCircle className="w-5 h-5 text-green-400" />
           <p className="text-sm font-medium text-[var(--foreground)]">Passport Data Extracted</p>
         </div>
+
+        {/* Name components (read-only verify) — shown when OCR returned them */}
+        {(result.given_names || result.surname) && (
+          <div className="rounded-md border border-[var(--border)] bg-[var(--background-elevated)]/50 p-3 space-y-1">
+            <p className="text-xs text-[var(--foreground-muted)] mb-1">
+              Verify name attribution from passport
+            </p>
+            {NAME_COMPONENT_FIELDS.map((key) =>
+              result[key] ? (
+                <div key={key} className="flex items-center gap-3 px-1">
+                  <span className="text-xs text-[var(--foreground-muted)] w-28 flex-shrink-0">
+                    {FIELD_LABELS[key]}
+                  </span>
+                  <span className="text-sm text-[var(--foreground)] font-medium">
+                    {result[key]}
+                  </span>
+                </div>
+              ) : null,
+            )}
+          </div>
+        )}
 
         {/* Fields */}
         <div className="space-y-2">

--- a/apps/mouth/src/lib/api/crm/crm.types.ts
+++ b/apps/mouth/src/lib/api/crm/crm.types.ts
@@ -348,6 +348,8 @@ export interface PassportOcrResult {
   success: boolean;
   confidence: number;
   full_name: string | null;
+  surname: string | null;
+  given_names: string | null;
   nationality: string | null;
   date_of_birth: string | null;
   gender: "M" | "F" | null;


### PR DESCRIPTION
## Summary

- Inverts passport OCR prompt to request `full_name` as `GIVEN_NAMES SURNAME` (Western reading order). Adds explicit attribution rules and exposes separated `surname` + `given_names` fields in the response.
- Adds a read-only "Verify name attribution" panel in the New Client passport-scan UI so the operator can confirm given/family parse before applying.
- Makes the persist-mode name-match order-insensitive, eliminating false negatives on clients whose stored `full_name` predates this fix.

## Bug observed

Passport for **Bishop Rewis** (Surname/Apellidos=REWIS, Given names=BISHOP) was parsed and shown as `Full Name: Rewis Bishop`, which a Western reader takes as `FirstName=Rewis, FamilyName=Bishop` — inverted. Visible at `kita.balizero.com/clients/new`.

Root cause: the LLM prompt at `crm_clients_documents.py:215` literally said `"full_name": "SURNAME GIVEN_NAMES"` (MRZ order). The model obeyed; the UI then displayed the result as if it were Western order.

## Changes

**Backend** — `apps/backend-rag/backend/app/routers/crm_clients_documents.py`
- Prompt now requests `GIVEN_NAMES SURNAME` and explicitly defines what `surname` and `given_names` must contain.
- `PassportPreviewResponse` exposes `surname` and `given_names`.
- `title_case_name` normalization applied to both new fields.
- Both preview and persist response builders return the new fields.
- Persist-mode name-match uses sorted-token comparison (order-insensitive), so a re-scan of a legacy client (`full_name="Rewis Bishop"`) against a fresh OCR (`"Bishop Rewis"`) no longer trips the < 0.8 threshold spuriously.

**Frontend**
- `crm.types.ts` — `PassportOcrResult` carries `surname` + `given_names`.
- `PassportScanSection.tsx` — new read-only "Verify name attribution from passport" panel renders Given Names + Surname above the existing field checklist. Purely informational; nothing applied to the form, so `CreateClientInput` shape is unchanged.

## Out of scope

Schema-level split of `clients.full_name` into separate `given_name`/`family_name` columns. The current fix resolves the visible bug without a migration. Tracked for a future PR.

## Test plan

- [x] `pytest backend/tests/unit/routers/test_crm_clients_documents_coverage.py backend/tests/unit/utils/test_passport_normalize.py -q` → 55 passed
- [ ] Manual QA on `kita.balizero.com/clients/new` after deploy: rescan Rewis Bishop passport, confirm UI shows `Given Names: Bishop` / `Surname: Rewis`, and `Full Name` applied to form is `Bishop Rewis`
- [ ] Manual QA: scan a passport for an existing client whose stored `full_name` is in legacy `Surname Given` order, confirm `name_match=true` in persist mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)