### PR TITLE
feat(innervation/W1.4): enroll WR2 core (supervisor, oracle, newsletter) in Genoma

### DIFF
--- a/apps/cell/tests/test_genome_aggregator_sensor.py
+++ b/apps/cell/tests/test_genome_aggregator_sensor.py
@@ -446,6 +446,51 @@ def test_w1_pro_metabolic_rollup_enrolled(tmp_path):
     assert dead.metadata["dead_organs"] == ["pro.metabolic_rollup"]
 
 
+# ---------- W1.4 wr2.* core organi (state_file bridge) ----------------------
+# WR2 supervisor + the two flagship cron (oracle weekly Sun 22:30, newsletter
+# Mon 09:00). Sidecar emission is deferred to W2 (requires touching
+# ~/.openclaw/bin/wr2/wr2-cron-wrapper.sh shared by 13+ cron, plus
+# wr2_supervisor.py heartbeat). Until then severity_on_silence='warning'
+# in the live genome — these tests still exercise the full happy/dead
+# pair via tmp_path bridges to lock the sensor contract.
+
+
+def test_w1_wr2_supervisor_enrolled(tmp_path):
+    happy, dead = _w1_happy_dead_pair(
+        tmp_path,
+        "wr2.supervisor",
+        expected_hb_seconds=300,
+    )
+    assert happy.status == "green"
+    assert happy.metadata["alive"] == 1
+    assert dead.status == "red"
+    assert dead.metadata["dead_organs"] == ["wr2.supervisor"]
+
+
+def test_w1_wr2_oracle_enrolled(tmp_path):
+    happy, dead = _w1_happy_dead_pair(
+        tmp_path,
+        "wr2.oracle",
+        expected_hb_seconds=1209600,  # 2 weeks (1.5x weekly cadence)
+    )
+    assert happy.status == "green"
+    assert happy.metadata["alive"] == 1
+    assert dead.status == "red"
+    assert dead.metadata["dead_organs"] == ["wr2.oracle"]
+
+
+def test_w1_wr2_newsletter_enrolled(tmp_path):
+    happy, dead = _w1_happy_dead_pair(
+        tmp_path,
+        "wr2.newsletter",
+        expected_hb_seconds=1209600,  # 2 weeks (1.5x weekly cadence)
+    )
+    assert happy.status == "green"
+    assert happy.metadata["alive"] == 1
+    assert dead.status == "red"
+    assert dead.metadata["dead_organs"] == ["wr2.newsletter"]
+
+
 # ---------- W1.2 channel.* organi (http bridge) -----------------------------
 # These reach liveness through `bridge_source.type=http` (the public
 # /api/channels/health-public endpoint) instead of a state_file. The

--- a/apps/organism/organism/genome.yaml
+++ b/apps/organism/organism/genome.yaml
@@ -28,7 +28,7 @@
 
 version: 1
 checksum_algo: sha256
-checksum: c153272ca126bd421a4601f87db8ee713ffab17d889187b7655112c86afa0124
+checksum: d3d17a36b0319d3b43dd8dca9c870913bfb7213d65df0bf99e256af9a26363ed
 organs:
 - id: infra.postgres
   runtime: fly_machine
@@ -383,5 +383,58 @@ organs:
   bridge_source:
     type: state_file
     path: ~/.agent/decisions/state/expiry_alerter.last.json
+    timestamp_field: ts
+    status_field: status
+- id: wr2.supervisor
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 300
+  owner_module: scripts/wr2_supervisor.py
+  dependencies:
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.balizero.wr2.supervisor
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/wr2.supervisor.json
+    timestamp_field: ts
+    status_field: status
+- id: wr2.oracle
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 1209600
+  owner_module: backend.services.cognitive.oracle_cli
+  dependencies:
+  - infra.postgres
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.balizero.wr2.oracle
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/wr2.oracle.json
+    timestamp_field: ts
+    status_field: status
+- id: wr2.newsletter
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 1209600
+  owner_module: backend.services.newsletter.newsletter_cli
+  dependencies:
+  - infra.postgres
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.balizero.wr2.newsletter
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/wr2.newsletter.json
     timestamp_field: ts
     status_field: status

--- a/apps/organism/tests/tools/test_validate_genome.py
+++ b/apps/organism/tests/tools/test_validate_genome.py
@@ -185,3 +185,42 @@ def test_compute_checksum_is_canonical_and_stable(tmp_path):
     h2 = vg.compute_checksum([reordered])
     assert h1 == h2
     assert len(h1) == 64  # sha256 hex length
+
+
+# ---------- live genome.yaml integration ------------------------------------
+
+
+_LIVE_GENOME = (
+    Path(__file__).resolve().parents[2] / "organism" / "genome.yaml"
+)
+
+
+def test_live_genome_is_valid():
+    """The repo's genome.yaml must always validate clean — guards against
+    accidental schema drift in PRs that touch the live registry."""
+    assert _LIVE_GENOME.exists(), f"missing {_LIVE_GENOME}"
+    errors = vg.validate_file(_LIVE_GENOME)
+    assert errors == [], f"live genome failed validation: {errors}"
+
+
+@pytest.mark.parametrize(
+    "organ_id",
+    ["wr2.supervisor", "wr2.oracle", "wr2.newsletter"],
+)
+def test_w1_4_wr2_core_organi_enrolled(organ_id):
+    """W1.4 enrolls the WR2 core trio. Each entry must:
+    - exist in the live genome
+    - declare bridge_source.type == state_file
+    - have severity_on_silence == 'warning' (sidecar emission deferred to W2 —
+      until then the sensor sees a missing file → silent → don't page Zero)
+    """
+    doc = yaml.safe_load(_LIVE_GENOME.read_text())
+    by_id = {o["id"]: o for o in doc["organs"]}
+    assert organ_id in by_id, f"{organ_id} not enrolled in live genome"
+    organ = by_id[organ_id]
+    assert "bridge_source" in organ, f"{organ_id} missing bridge_source"
+    assert organ["bridge_source"]["type"] == "state_file"
+    assert organ["severity_on_silence"] == "warning", (
+        f"{organ_id}: until the wrapper emits sidecars (W2), severity must be "
+        f"'warning' — 'critical' here would page on every Cell pulse"
+    )


### PR DESCRIPTION
## Summary
- Enrolls 3 WR2 organi in `apps/organism/organism/genome.yaml`: `wr2.supervisor` (daemon, hb 300s), `wr2.oracle` (cron Sun 22:30, hb 1209600s = 2-week 1.5x), `wr2.newsletter` (cron Mon 09:00, hb 1209600s).
- All use `bridge_source.type=state_file` at `~/.organism/last_seen/<organ_id>.json`. `severity_on_silence=warning` (NOT critical) until W2 wires sidecar emission — sensor sees missing file → silent → warning, no Telegram noise.
- Genome SHA256 recomputed: `c153272c…` → `d3d17a36b0319d3b43dd8dca9c870913bfb7213d65df0bf99e256af9a26363ed`.
- 7 new tests (3 cell sensor happy/dead + 4 organism validate_genome — incl. live-genome guard). 38/38 pass.

## Out of scope (W2 follow-up)
- Shared wrapper `~/.openclaw/bin/wr2/wr2-cron-wrapper.sh` emits sidecar post-exec (touches 13+ cron — too broad for atomic enrollment PR).
- `wr2_supervisor.py` in-process heartbeat to `~/.organism/last_seen/wr2.supervisor.json`.
- `infra/launchagents/com.balizero.wr2.{oracle,newsletter,supervisor}.plist` repo↔live divergence (repo points at non-existent `/Users/nuzantara/Desktop/nuzantara/scripts/wr2-cron-wrapper.sh`; live correctly points at `~/.openclaw/bin/wr2/...`).

## Test plan
- [x] `pytest apps/organism/tests/tools/test_validate_genome.py -q` → 14/14 pass
- [x] `pytest apps/cell/tests/test_genome_aggregator_sensor.py -q` → 24/24 pass
- [x] `python -m organism.tools.validate_genome` → ✓ valid
- [x] `python scripts/docs_sync.py --check` → DOCSYNC OK
- [ ] CI green
- [ ] Post-merge: validator pre-commit hook still passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)