### PR TITLE
feat(innervation/W1.5): enroll organism control-panel daemon in Genoma

### DIFF
--- a/apps/cell/tests/test_genome_aggregator_sensor.py
+++ b/apps/cell/tests/test_genome_aggregator_sensor.py
@@ -677,3 +677,69 @@ def test_w1_pro_renewal_alerts_enrolled(tmp_path):
     assert happy.metadata["alive"] == 1
     assert dead.status == "red"
     assert dead.metadata["dead_organs"] == ["pro.renewal_alerts"]
+
+
+# ---------- W1.5 organism control-panel daemon (http bridge) ---------------
+# pro.organism_control_panel hits http://127.0.0.1:1819/health (the daemon
+# already KeepAlive=true on Pro). The /health body is FLAT (`{status, paused, ts}`),
+# not nested like the channels endpoint, so we mock a separate response shape.
+
+
+def _mock_control_panel_response(status_value: str, *, age_s: float = 1.0):
+    """Build an httpx-Client mock returning the control-panel /health body."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.text = ""
+    resp.json = MagicMock(return_value={
+        "status": status_value,
+        "paused": False,
+        "ts": time.time() - age_s,
+    })
+    client = MagicMock()
+    client.__enter__ = MagicMock(return_value=client)
+    client.__exit__ = MagicMock(return_value=False)
+    client.get = MagicMock(return_value=resp)
+    return MagicMock(return_value=client)
+
+
+def _w1_organ_control_panel(*, severity: str = "critical") -> dict:
+    return {
+        "id": "pro.organism_control_panel",
+        "runtime": "pro_launchd",
+        "type": "daemon",
+        "expected_hb_seconds": 120,
+        "owner_module": "apps/organism/organism/control_panel.py",
+        "dependencies": [],
+        "recovery_action": "launchctl_kickstart",
+        "recovery_params": {"label": "com.nuzantara.organism.control-panel"},
+        "severity_on_silence": severity,
+        "cicatrix_refs": [],
+        "bridge_source": {
+            "type": "http",
+            "path": "http://127.0.0.1:1819/health",
+            "timestamp_field": "ts",
+            "json_path": "status",
+        },
+    }
+
+
+def test_w1_pro_organism_control_panel_enrolled(tmp_path):
+    """Happy: /health 200 + status=ok + fresh ts → green.
+    Dead:  /health 503 → BridgeReading.error → red."""
+    genome = tmp_path / "control_panel_genome.yaml"
+    db = tmp_path / "control_panel_last_seen.db"
+    _write_genome(genome, [_w1_organ_control_panel()])
+
+    with _patch("cell.sensors.bridge_state_reader.httpx.Client",
+                _mock_control_panel_response("ok", age_s=1.0)):
+        sensor = GenomeAggregatorSensor(genome_path=genome, last_seen_db_path=db)
+        happy = _run(sensor)
+    assert happy.status == "green"
+    assert happy.metadata["alive"] == 1
+
+    with _patch("cell.sensors.bridge_state_reader.httpx.Client",
+                _mock_http_5xx()):
+        sensor = GenomeAggregatorSensor(genome_path=genome, last_seen_db_path=db)
+        dead = _run(sensor)
+    assert dead.status == "red"
+    assert dead.metadata["dead_organs"] == ["pro.organism_control_panel"]

--- a/apps/organism/organism/control_panel.py
+++ b/apps/organism/organism/control_panel.py
@@ -5,13 +5,15 @@ filesystem-readable file (ORGANISM_TOKEN_PATH env). No user database,
 no session — one shared operator token.
 
 Endpoints:
-  GET  /health    — status + paused flag (no auth)
+  GET  /health    — status + paused flag + ts (no auth, used as W1.5
+                    organism heartbeat bridge for the Cell aggregator)
   POST /pause     — set blackout for N min (auth required)
   POST /resume    — clear blackout (auth required)
   GET  /stats     — organism metrics (W2 will populate)
 """
 import logging
 import os
+import time
 from pathlib import Path
 from fastapi import FastAPI, Header, HTTPException
 from organism.blackout import BlackoutManager
@@ -40,7 +42,11 @@ def create_app(*, blackout: BlackoutManager) -> FastAPI:
     async def health():
         paused = blackout.is_paused()
         logger.debug("Health check: paused=%s", paused)
-        return {"status": "ok", "paused": paused}
+        # `ts` (unix epoch) is the heartbeat field consumed by the Cell
+        # GenomeAggregatorSensor for the pro.organism_control_panel organ
+        # (W1.5). Don't remove or rename without updating the bridge_source
+        # entry in genome.yaml.
+        return {"status": "ok", "paused": paused, "ts": time.time()}
 
     @app.post("/pause")
     async def pause(minutes: int = 30, x_organism_token: str | None = Header(None)):

--- a/apps/organism/organism/genome.yaml
+++ b/apps/organism/organism/genome.yaml
@@ -28,7 +28,7 @@
 
 version: 1
 checksum_algo: sha256
-checksum: d3d17a36b0319d3b43dd8dca9c870913bfb7213d65df0bf99e256af9a26363ed
+checksum: 968ef15c9d75538ef578319e193c57189b39feb12a03802197da080835faf598
 organs:
 - id: infra.postgres
   runtime: fly_machine
@@ -438,3 +438,19 @@ organs:
     path: ~/.organism/last_seen/wr2.newsletter.json
     timestamp_field: ts
     status_field: status
+- id: pro.organism_control_panel
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 120
+  owner_module: apps/organism/organism/control_panel.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.organism.control-panel
+  severity_on_silence: critical
+  cicatrix_refs: []
+  bridge_source:
+    type: http
+    path: http://127.0.0.1:1819/health
+    timestamp_field: ts
+    json_path: status

--- a/apps/organism/tests/test_control_panel.py
+++ b/apps/organism/tests/test_control_panel.py
@@ -6,12 +6,20 @@ from organism.blackout import BlackoutManager
 
 
 def test_health_endpoint_returns_ok(tmp_path):
+    import time as _time
+    before = _time.time()
     app = create_app(blackout=BlackoutManager(flag_path=tmp_path / "pause.flag"))
     client = TestClient(app)
     resp = client.get("/health")
+    after = _time.time()
     assert resp.status_code == 200
-    assert resp.json()["status"] == "ok"
-    assert resp.json()["paused"] is False
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["paused"] is False
+    # `ts` field powers the W1.5 organism heartbeat bridge — must be
+    # present, numeric, and within the request window.
+    assert isinstance(body["ts"], (int, float))
+    assert before <= body["ts"] <= after
 
 
 def test_pause_requires_token(tmp_path):

--- a/apps/organism/tests/tools/test_validate_genome.py
+++ b/apps/organism/tests/tools/test_validate_genome.py
@@ -224,3 +224,26 @@ def test_w1_4_wr2_core_organi_enrolled(organ_id):
         f"{organ_id}: until the wrapper emits sidecars (W2), severity must be "
         f"'warning' — 'critical' here would page on every Cell pulse"
     )
+
+
+def test_w1_5_organism_control_panel_enrolled():
+    """W1.5 enrolls the organism control-panel HTTP daemon (already
+    KeepAlive=true on Pro :1819) with an http bridge that hits its own
+    /health endpoint. Severity=critical: if the control panel itself
+    is down, /pause and /resume are unreachable — Zero loses the
+    blackout escape hatch.
+    """
+    doc = yaml.safe_load(_LIVE_GENOME.read_text())
+    by_id = {o["id"]: o for o in doc["organs"]}
+    assert "pro.organism_control_panel" in by_id, (
+        "pro.organism_control_panel not enrolled in live genome"
+    )
+    organ = by_id["pro.organism_control_panel"]
+    assert organ["type"] == "daemon"
+    assert organ["recovery_action"] == "launchctl_kickstart"
+    assert organ["recovery_params"]["label"] == "com.nuzantara.organism.control-panel"
+    assert organ["severity_on_silence"] == "critical"
+    bridge = organ["bridge_source"]
+    assert bridge["type"] == "http"
+    assert bridge["path"] == "http://127.0.0.1:1819/health"
+    assert bridge["timestamp_field"] == "ts"


### PR DESCRIPTION
## Summary
- Enrolls 1 organ in \`apps/organism/organism/genome.yaml\`: \`pro.organism_control_panel\` (daemon, hb 120s, severity=critical, bridge http on \`127.0.0.1:1819/health\`).
- \`/health\` endpoint gains a \`ts\` (unix epoch) field — the heartbeat the Cell aggregator needs. Backwards compatible: existing \`{status, paused}\` fields preserved.
- Severity=critical because if the control-panel is down, Zero loses \`/pause\` and \`/resume\` (the manual blackout escape hatch).
- Genome SHA256: \`d3d17a36b031…\` → \`968ef15c9d75538ef578319e193c57189b39feb12a03802197da080835faf598\`.
- 3 test deltas (1 new live-genome guard, 1 new sensor happy/dead pair, 1 updated control_panel \`/health\` test). All green locally.

## Out of scope (NOT deferred — intentional)
- **MCP servers** (\`nuzantara-mcp\`, \`nuzantara-mcp-advanced\`): stdio processes spawned on-demand by clients (Claude Desktop, Codex). No always-on daemon semantics, no liveness signal that maps to Genoma.
- **admin-dashboard**: it's a CONSUMER of organism state (Next.js app on Fly), not an organ. The "admin view of organism state" is a separate frontend feature wiring \`/stats\` etc., not Genoma enrollment.

## Post-merge manual action (Zero, on Pro)
The live daemon was started before this PR and still serves the pre-W1.5 \`/health\` (no \`ts\`). Reload to pick up the new code:
\`\`\`bash
launchctl kickstart -k gui/\$(id -u)/com.nuzantara.organism.control-panel
\`\`\`
Until then, the bridge classifies the organ as silent (warning) — no false page since severity-critical only fires after \`expected_hb_seconds × 3 = 360s\` of silence on a daemon (here: with \`expected_hb_seconds=0\` semantics infra would be \"bridge presence only\"; for our hb=120 daemon: dead at 360s).

## Test plan
- [x] \`pytest apps/organism/tests/tools/test_validate_genome.py -q\` → 15/15 pass
- [x] \`pytest apps/organism/tests/test_control_panel.py -q\` → 10/10 pass
- [x] \`pytest apps/cell/tests/test_genome_aggregator_sensor.py -k 'control_panel or w1' -q\` → 19/19 pass
- [x] \`python -m organism.tools.validate_genome\` → ✓ valid
- [x] \`python scripts/docs_sync.py --check\` → DOCSYNC OK
- [ ] CI green
- [ ] Post-merge: \`launchctl kickstart -k\` + \`curl :1819/health\` returns \`{status,paused,ts}\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)