### PR TITLE
fix(tests/oracle_universal): replace caplog with monkeypatch on logger.warning

### DIFF
--- a/apps/backend-rag/backend/tests/api/app/routers/test_oracle_universal.py
+++ b/apps/backend-rag/backend/tests/api/app/routers/test_oracle_universal.py
@@ -1109,16 +1109,29 @@ async def test_query_malformed_service_response_logs_validation_error(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_dropped_fields_use_dedicated_logger(caplog) -> None:
+async def test_dropped_fields_use_dedicated_logger(monkeypatch) -> None:
     """Wave 3: the Q1 drop WARN must emerge from the dedicated
     `oracle.query.dropped_fields` logger so the event can be routed, muted
     or aggregated independently of the rest of the router's chatty logs.
 
     Until wave 3 it came from `backend.app.routers.oracle_universal`.
-    """
-    import logging as _logging
 
-    caplog.set_level(_logging.WARNING, logger="oracle.query.dropped_fields")
+    Asserted via monkeypatch on the dedicated logger's `warning` method for
+    the same reason as `test_query_malformed_service_response_logs_validation_error`:
+    the full backend-test collection runs an upstream test that pollutes
+    the logger graph (caplog records arrive with ANSI-colored `levelname`
+    like `'\\x1b[33mWARNING\\x1b[0m'` instead of `'WARNING'`, breaking
+    direct equality and causing 5+ consecutive `Tests & Coverage`
+    failures on main). Bound-method capture is immune to that pollution.
+    """
+    captured: list[tuple[str, tuple]] = []
+
+    import backend.app.routers.oracle_universal as oracle_router
+
+    def _capture(msg: str, *args, **kwargs) -> None:  # noqa: ANN401
+        captured.append((msg, args))
+
+    monkeypatch.setattr(oracle_router._DROPPED_FIELDS_LOGGER, "warning", _capture)
 
     app = _build_app()
     process = AsyncMock(return_value=_happy_result(query="logger name drift"))
@@ -1133,10 +1146,15 @@ async def test_dropped_fields_use_dedicated_logger(caplog) -> None:
             )
 
     assert r.status_code == 200
-    named = [rec for rec in caplog.records if rec.name == "oracle.query.dropped_fields"]
-    assert len(named) == 1
-    assert named[0].levelname == "WARNING"
-    assert "domain_hint" in named[0].message
+    assert len(captured) == 1, (
+        f"expected exactly 1 dropped-fields WARN, got {len(captured)} "
+        f"(captured: {captured})"
+    )
+    msg, args = captured[0]
+    rendered = msg % args if args else msg
+    assert "domain_hint" in rendered, (
+        f"expected 'domain_hint' in dropped-fields message, got: {rendered!r}"
+    )
 
 
 @pytest.mark.asyncio

--- a/apps/backend-rag/backend/tests/api/app/routers/test_oracle_universal.py
+++ b/apps/backend-rag/backend/tests/api/app/routers/test_oracle_universal.py
@@ -1046,7 +1046,7 @@ async def test_query_default_response_format_does_not_log_drop_warning(caplog) -
 
 
 @pytest.mark.asyncio
-async def test_query_malformed_service_response_logs_validation_error(caplog) -> None:
+async def test_query_malformed_service_response_logs_validation_error(monkeypatch) -> None:
     """Q2: when oracle_service returns a dict that does not match
     OracleQueryResponse, the router must:
     - still answer 200 (contract unchanged, no breaking caller impact),
@@ -1054,10 +1054,25 @@ async def test_query_malformed_service_response_logs_validation_error(caplog) ->
     - but tag the error string with `response_validation_error:` and emit
       a WARN log — so Sentry can distinguish schema drift from a true
       runtime fault.
-    """
-    import logging as _logging
 
-    caplog.set_level(_logging.WARNING, logger="backend.app.routers.oracle_universal")
+    We assert the WARN log via monkeypatch on the router's `logger.warning`
+    (same pattern as `test_dropped_fields_emit_sentry_tag`) instead of caplog,
+    because caplog's record propagation is fragile across the full backend
+    test collection: some upstream test had already configured the
+    `backend.app.routers.oracle_universal` logger with `propagate=False` or a
+    higher level, making caplog blind to records emitted in this test even
+    though the WARN is produced (verified: the response body still carries
+    `error="response_validation_error: …"` in CI). monkeypatch on the bound
+    method is immune to that interference.
+    """
+    captured: list[tuple[str, tuple]] = []
+
+    import backend.app.routers.oracle_universal as oracle_router
+
+    def _capture(msg: str, *args, **kwargs) -> None:  # noqa: ANN401
+        captured.append((msg, args))
+
+    monkeypatch.setattr(oracle_router.logger, "warning", _capture)
 
     app = _build_app()
     # Missing required field execution_time_ms → ValidationError
@@ -1079,10 +1094,13 @@ async def test_query_malformed_service_response_logs_validation_error(caplog) ->
     assert body["success"] is False
     assert body["error"].startswith("response_validation_error:")
     validation_logs = [
-        rec for rec in caplog.records
-        if "validation failed" in rec.message and rec.levelname == "WARNING"
+        (msg, args) for msg, args in captured
+        if "validation failed" in msg
     ]
-    assert len(validation_logs) == 1
+    assert len(validation_logs) == 1, (
+        f"expected exactly 1 'validation failed' WARN, got {len(validation_logs)} "
+        f"(all captured: {captured})"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Test \`test_query_malformed_service_response_logs_validation_error\` was failing in CI on every run since 2026-04-30 (5+ consecutive \`Tests & Coverage\` failures on main: \`1fa890fb\`, \`64273205\`, \`7071847b\`, \`5c31d499\`, \`095ab145\`), but passing locally in isolation. Root cause is caplog fragility across the full backend test collection — some upstream test had already configured the \`backend.app.routers.oracle_universal\` logger (\`propagate=False\`, level filter, or \`dictConfig\`) before this test ran, and \`caplog.set_level(level, logger=...)\` couldn't re-attach in time. The WARN was being emitted (response body still carried \`error="response_validation_error: …"\`), caplog just couldn't see it.

## Fix
Monkeypatch \`oracle_router.logger.warning\` directly — same pattern already used by \`test_dropped_fields_emit_sentry_tag\` in the same file. Bound-method replacement is immune to upstream logger config drift.

## Why this is a real fix, not a workaround
- The router code under test is unchanged (it always emitted the WARN correctly).
- The contract being asserted is unchanged (\"the router emits exactly one WARN with 'validation failed' in the message\").
- Only the observation mechanism is hardened: instead of relying on Python's logging propagation graph (which can be poisoned by test-order side effects), we observe the bound method directly.
- Failure message now includes the full captured list, so any future regression is faster to triage than \"assert 0 == 1\".

## Test plan
- [x] \`pytest backend/tests/api/app/routers/test_oracle_universal.py::test_query_malformed_service_response_logs_validation_error\` → PASS in isolation
- [x] \`pytest backend/tests/api/app/routers/test_oracle_universal.py -q\` → 42/42 PASS
- [ ] CI \`Backend Tests (Python)\` finally goes green
- [ ] \`Tests & Coverage\` on main next run reports \`success\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)