### PR TITLE
feat(seo_cell/sprint2): close A3 anomaly with lead_attribution sensor

### DIFF
--- a/apps/evaluator/seo_cell/cell.py
+++ b/apps/evaluator/seo_cell/cell.py
@@ -31,6 +31,7 @@ from apps.evaluator.seo_cell.sensors import (
     GA4Sensor,
     GSCSensor,
     KGSensor,
+    LeadAttributionSensor,
     WarRoomEventSensor,
 )
 from apps.evaluator.seo_cell.thinker import SEOThinker
@@ -69,6 +70,7 @@ def create_seo_cell() -> PulseLoop:
         KGSensor(),
         WarRoomEventSensor(),
         CannibalizationSensor(),
+        LeadAttributionSensor(),
     ]
 
     thinker = SEOThinker()

--- a/apps/evaluator/seo_cell/run_seo_cell.py
+++ b/apps/evaluator/seo_cell/run_seo_cell.py
@@ -1,0 +1,94 @@
+"""SEO Cell daily runner — single-pulse driver for cron / LaunchAgent.
+
+Sprint 2 entrypoint. Performs one `single_pulse()`, persists side-effects
+(SQLite memory, birth-date marker, sensor caches), and exits 0 on
+success / 1 on failure. The exit code is the only health signal — the
+LaunchAgent log captures stderr; the sentinel writes the success/fail
+state to `~/.agent/decisions/state/seo_cell.last.json` (handled by the
+shell wrapper, not here).
+
+Why a separate file instead of `python -c "from … import …; …"`:
+  - the cell's I/O surface (Postgres, Google APIs) means `KeyboardInterrupt`
+    handling, structured logging, and a graceful asyncpg cleanup on shutdown
+    deserve a dedicated module
+  - the sentinel and LaunchAgent ergonomics expect a stable import path
+    (`python -m apps.evaluator.seo_cell.run_seo_cell`) — keeping it inside
+    the package keeps the relative imports working under all PYTHONPATH
+    permutations, including the editable-install one used by `.venv`
+
+Pre_natal stays locked unless the lead_attribution sensor returns a
+non-zero count AND age_days ≥ 28 AND gsc_query_count ≥ 80. In Sprint 2
+the cell is still expected to run pre_natal — sensor readings are
+collected, the thinker proposes action="none", the actor never fires.
+This is the intended steady state until Sprint 3 lands.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+
+logger = logging.getLogger("seo_cell.runner")
+
+
+def _configure_logging(verbose: bool) -> None:
+    """Stdout for INFO+, stderr for WARNING+. LaunchAgent merges them."""
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG if verbose else logging.INFO)
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s %(levelname)s %(name)s %(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%S%z",
+        )
+    )
+    root.handlers = [handler]
+
+
+async def _run_one_pulse() -> int:
+    # Local import — keeps argparse/logging imports cheap when the
+    # package isn't actually being used (e.g. `--help`).
+    from apps.evaluator.seo_cell import create_seo_cell
+
+    cell = create_seo_cell()
+    try:
+        result = await cell.single_pulse()
+    except Exception as e:  # noqa: BLE001
+        logger.exception("[seo_cell] single_pulse raised: %r", e)
+        return 1
+
+    logger.info(
+        "[seo_cell] pulse #%s done health=%s action=%s",
+        result.pulse_number,
+        result.health_status,
+        result.action_taken,
+    )
+    # We treat 'red' health as a soft failure for sentinel purposes —
+    # the cell is still pre_natal and the actor never ran, but a red
+    # signal indicates a sensor is having connectivity issues that
+    # operators should see in monitoring. The cell itself is healthy
+    # enough that exit 0 is honest.
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run one SEO Cell pulse (cron-style)."
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true",
+        help="DEBUG logging (default INFO).",
+    )
+    args = parser.parse_args()
+    _configure_logging(args.verbose)
+
+    try:
+        return asyncio.run(_run_one_pulse())
+    except KeyboardInterrupt:
+        logger.warning("[seo_cell] interrupted by signal")
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/evaluator/seo_cell/sensors/__init__.py
+++ b/apps/evaluator/seo_cell/sensors/__init__.py
@@ -1,15 +1,16 @@
-"""SEO Cell sensors — 6 perception surfaces per v2.1 design.
+"""SEO Cell sensors — 7 perception surfaces (6 v2.1 + lead_attribution).
 
-  1. GSCSensor              — Google Search Console query performance
-  2. GA4Sensor              — Google Analytics 4 conversion funnel
-  3. CompetitorSERPSensor   — SERP positions vs Cekindo + Emerhub (cache 7gg)
-  4. KGSensor               — Knowledge Graph coverage per query
-  5. WarRoomEventSensor     — consumes war_room.event PG channel (Redis fanout)
-  6. CannibalizationSensor  — semantic clustering of own URLs competing
+  1. GSCSensor               — Google Search Console query performance
+  2. GA4Sensor               — Google Analytics 4 conversion funnel
+  3. CompetitorSERPSensor    — SERP positions vs Cekindo + Emerhub (cache 7gg)
+  4. KGSensor                — Knowledge Graph coverage per query
+  5. WarRoomEventSensor      — consumes war_room.event PG channel (Redis fanout)
+  6. CannibalizationSensor   — semantic clustering of own URLs competing
+  7. LeadAttributionSensor   — counts website-organic leads (Sprint 2)
 
-Sprint 1 state: all are STUBS that return yellow status with metadata
-{"stub": True}. Real I/O lands in Sprint 2, guarded by pre_natal gate
-(sensors always read; the thinker ignores them until graduation).
+The 7th sensor is NOT in the Bayesian calibrator's weight contract
+(SENSOR_NAMES is still the original 6) — it feeds the pre_natal unlock
+gate exclusively, not the post-graduation scoring path.
 """
 from apps.evaluator.seo_cell.sensors.gsc_sensor import GSCSensor
 from apps.evaluator.seo_cell.sensors.ga4_sensor import GA4Sensor
@@ -17,6 +18,7 @@ from apps.evaluator.seo_cell.sensors.competitor_serp_sensor import CompetitorSER
 from apps.evaluator.seo_cell.sensors.kg_sensor import KGSensor
 from apps.evaluator.seo_cell.sensors.war_room_event_sensor import WarRoomEventSensor
 from apps.evaluator.seo_cell.sensors.cannibalization_sensor import CannibalizationSensor
+from apps.evaluator.seo_cell.sensors.lead_attribution_sensor import LeadAttributionSensor
 
 __all__ = [
     "GSCSensor",
@@ -25,4 +27,5 @@ __all__ = [
     "KGSensor",
     "WarRoomEventSensor",
     "CannibalizationSensor",
+    "LeadAttributionSensor",
 ]

--- a/apps/evaluator/seo_cell/sensors/lead_attribution_sensor.py
+++ b/apps/evaluator/seo_cell/sensors/lead_attribution_sensor.py
@@ -1,0 +1,246 @@
+"""Lead Attribution Sensor — counts website-organic leads from CRM.
+
+The pre_natal unlock gate (`phase.is_pre_natal`) ANDs three conditions;
+the leads condition was previously hardcoded to 0 in the thinker (A3
+anomaly), permanently locking the gate. This sensor closes the gap by
+reading the `clients` table populated by migration 118
+(`clients.referrer_url` / `landing_page` / `first_touch_at`).
+
+A lead counts as "website-organic" when ALL of:
+
+  - referrer_url IS NOT NULL — first-touch came through HTTP referer
+  - referrer_url DOES NOT match a paid/social/internal pattern
+  - first_touch_at is within the lookback window (default 28d to mirror
+    the GSC query window used elsewhere in the v2.1 design)
+
+Returns SensorReading.value:
+  lead_count        — int, used by the thinker for the unlock gate
+  by_landing_page   — {landing_page: count} for top N
+  recent_leads      — [{first_touch_at, referrer_domain, landing_page}]
+
+Failure policy mirrors the other PG-backed sensors (war_room_event,
+gsc): never raises.
+  - no DATABASE_URL                 → yellow, error_code=db_url_missing
+  - asyncpg import failure          → red,    error_code=import_error
+  - connection/query error          → red,    error_code=db_error
+  - any other exception             → red,    error_code=unexpected
+"""
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from urllib.parse import urlparse
+
+from cell_core.types import SensorReading
+
+logger = logging.getLogger("seo_cell.sensors.lead_attribution")
+
+_DEFAULT_WINDOW_DAYS = 28
+_TOP_N_KEEP = 50
+
+# Domains we treat as paid/social/internal — NOT organic SEO traffic.
+# Conservative: anything we can't classify positively as organic is
+# excluded from the count, so the gate stays defensible.
+_NON_ORGANIC_DOMAINS = frozenset({
+    # Paid / ads
+    "googleads.g.doubleclick.net",
+    "ads.google.com",
+    # Social — these are organic *social* traffic, not organic *search*.
+    # The pre_natal gate is for SEO graduation specifically (decision
+    # memo v2.1), so social leads don't qualify even when unpaid.
+    "facebook.com", "m.facebook.com", "l.facebook.com",
+    "instagram.com", "l.instagram.com",
+    "tiktok.com",
+    "linkedin.com", "lnkd.in",
+    "twitter.com", "x.com", "t.co",
+    "youtube.com", "youtu.be",
+    "wa.me", "api.whatsapp.com",
+    "t.me",
+    # Internal — leads from our own subdomains aren't first-touch SEO.
+    "balizero.com", "kita.balizero.com", "my.balizero.com",
+    "prime.balizero.com", "knowledge.balizero.com", "zantara.balizero.com",
+})
+
+# Search engines whose referer DOES count as organic search.
+_ORGANIC_SEARCH_DOMAINS = frozenset({
+    "google.com", "www.google.com", "google.co.id", "google.com.au",
+    "bing.com", "www.bing.com",
+    "duckduckgo.com",
+    "yahoo.com", "search.yahoo.com",
+    "ecosia.org",
+    "yandex.com", "yandex.ru",
+    "baidu.com",
+})
+
+
+class LeadAttributionSensor:
+    name = "lead_attribution"
+
+    def __init__(
+        self,
+        window_days: int = _DEFAULT_WINDOW_DAYS,
+        db_url: str | None = None,
+    ) -> None:
+        self._window_days = window_days
+        self._db_url_override = db_url
+
+    def _resolve_db_url(self) -> str | None:
+        return self._db_url_override or os.environ.get("DATABASE_URL")
+
+    async def read(self, **context) -> SensorReading:
+        db_url = self._resolve_db_url()
+        if not db_url:
+            return self._yellow(
+                "db_url_missing",
+                "DATABASE_URL not set (and no override)",
+            )
+
+        try:
+            rows = await self._fetch_leads(db_url)
+        except _LeadAttributionError as e:
+            return self._red(e.code, str(e))
+        except Exception as e:  # noqa: BLE001 — sensor must not raise
+            logger.exception("[lead_attribution] unexpected failure")
+            return self._red("unexpected", repr(e))
+
+        organic_rows = [r for r in rows if _is_organic_referrer(r.get("referrer_url"))]
+
+        by_landing_page: dict[str, int] = {}
+        recent: list[dict[str, Any]] = []
+        for r in organic_rows:
+            lp = r.get("landing_page") or "/"
+            by_landing_page[lp] = by_landing_page.get(lp, 0) + 1
+            recent.append({
+                "first_touch_at": _isoformat_or_none(r.get("first_touch_at")),
+                "referrer_domain": _domain_of(r.get("referrer_url")),
+                "landing_page": lp,
+            })
+
+        recent.sort(key=lambda p: p.get("first_touch_at") or "", reverse=True)
+        recent = recent[:_TOP_N_KEEP]
+
+        lead_count = len(organic_rows)
+        # green when at least one organic lead — same logic as
+        # war_room_event_sensor: yellow when window is empty (no signal),
+        # green when there's something to look at. The unlock gate is
+        # evaluated by the thinker, not by colour here.
+        status = "green" if lead_count > 0 else "yellow"
+
+        return SensorReading(
+            sensor_name=self.name,
+            status=status,
+            value={
+                "lead_count": lead_count,
+                "by_landing_page": by_landing_page,
+                "recent_leads": recent,
+            },
+            metadata={
+                "window_days": self._window_days,
+                "table": "clients",
+                "scanned_rows": len(rows),
+            },
+        )
+
+    async def _fetch_leads(self, db_url: str) -> list[dict[str, Any]]:
+        try:
+            import asyncpg
+        except ImportError as e:
+            raise _LeadAttributionError("import_error", f"missing dep: {e}") from e
+
+        cutoff = datetime.now(timezone.utc) - timedelta(days=self._window_days)
+        try:
+            conn = await asyncpg.connect(db_url, timeout=10)
+        except Exception as e:
+            raise _LeadAttributionError("db_error", f"connect failed: {e!r}") from e
+        try:
+            rows = await conn.fetch(
+                """
+                SELECT referrer_url, landing_page, first_touch_at
+                FROM clients
+                WHERE referrer_url IS NOT NULL
+                  AND first_touch_at IS NOT NULL
+                  AND first_touch_at >= $1
+                ORDER BY first_touch_at DESC
+                LIMIT 1000
+                """,
+                cutoff,
+            )
+        except Exception as e:
+            raise _LeadAttributionError("db_error", f"query failed: {e!r}") from e
+        finally:
+            await conn.close()
+        return [dict(r) for r in rows]
+
+    def _yellow(self, code: str, msg: str) -> SensorReading:
+        return SensorReading(
+            sensor_name=self.name,
+            status="yellow",
+            value={
+                "lead_count": 0,
+                "by_landing_page": {},
+                "recent_leads": [],
+            },
+            metadata={
+                "window_days": self._window_days,
+                "error_code": code,
+                "error": msg,
+            },
+        )
+
+    def _red(self, code: str, msg: str) -> SensorReading:
+        logger.warning("[lead_attribution] red: %s — %s", code, msg)
+        return SensorReading(
+            sensor_name=self.name,
+            status="red",
+            value={
+                "lead_count": 0,
+                "by_landing_page": {},
+                "recent_leads": [],
+            },
+            metadata={
+                "window_days": self._window_days,
+                "error_code": code,
+                "error": msg,
+            },
+        )
+
+
+class _LeadAttributionError(RuntimeError):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def _domain_of(url: str | None) -> str | None:
+    if not url:
+        return None
+    try:
+        host = urlparse(url).netloc.lower()
+    except Exception:  # noqa: BLE001
+        return None
+    return host or None
+
+
+def _is_organic_referrer(url: str | None) -> bool:
+    """True iff referer is a known organic search domain.
+
+    Conservative: an unknown referer (random other site, missing, weird
+    scheme) does NOT count. The pre_natal unlock gate prefers a missed
+    signal to a fake non-zero — see thinker.py:118-128.
+    """
+    domain = _domain_of(url)
+    if domain is None:
+        return False
+    if domain in _NON_ORGANIC_DOMAINS:
+        return False
+    return domain in _ORGANIC_SEARCH_DOMAINS
+
+
+def _isoformat_or_none(v: Any) -> str | None:
+    if v is None:
+        return None
+    if isinstance(v, datetime):
+        return v.isoformat()
+    return str(v)

--- a/apps/evaluator/seo_cell/tests/test_cell_factory.py
+++ b/apps/evaluator/seo_cell/tests/test_cell_factory.py
@@ -17,7 +17,8 @@ def test_factory_returns_pulse_loop():
     cell = create_seo_cell()
     assert isinstance(cell, PulseLoop)
     assert cell.config.name == "seo-guardian"
-    assert len(cell.sensors) == 6
+    # Sprint 2: 7 sensors (6 v2.1 + lead_attribution).
+    assert len(cell.sensors) == 7
 
 
 @pytest.mark.asyncio
@@ -33,6 +34,7 @@ async def test_single_pulse_completes_in_pre_natal(monkeypatch):
     ga4 = next(s for s in cell.sensors if s.name == "ga4")
     war = next(s for s in cell.sensors if s.name == "war_room_event")
     kg = next(s for s in cell.sensors if s.name == "kg")
+    leads = next(s for s in cell.sensors if s.name == "lead_attribution")
 
     tmp_creds = Path("/tmp/seo_cell_test_fake_creds.json")
     tmp_creds.write_text("{}")
@@ -57,7 +59,8 @@ async def test_single_pulse_completes_in_pre_natal(monkeypatch):
         with patch.object(gsc, "_fetch_rows_blocking", return_value=[]), \
              patch.object(ga4, "_fetch_report_blocking", return_value={"rows": []}), \
              patch.object(war, "_fetch_posts", return_value=[]), \
-             patch.object(kg, "_fetch_snapshot", return_value=empty_kg):
+             patch.object(kg, "_fetch_snapshot", return_value=empty_kg), \
+             patch.object(leads, "_fetch_leads", return_value=[]):
             result = await cell.single_pulse()
     finally:
         gsc_mod.GOOGLE_CREDENTIALS_PATH = orig_gsc

--- a/apps/evaluator/seo_cell/tests/test_lead_attribution_sensor.py
+++ b/apps/evaluator/seo_cell/tests/test_lead_attribution_sensor.py
@@ -1,0 +1,182 @@
+"""LeadAttributionSensor tests — all DB paths mocked.
+
+Sprint 2 sensor that closes the A3 anomaly: the thinker previously
+hardcoded `lead_count = 0`, permanently locking the pre_natal gate.
+This sensor reads `clients.referrer_url` (migration 118) and counts
+leads whose first-touch came from a known organic search domain.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from cell_core.types import SensorReading
+from apps.evaluator.seo_cell.sensors.lead_attribution_sensor import (
+    LeadAttributionSensor,
+    _is_organic_referrer,
+    _domain_of,
+)
+
+
+def _fake_rows(referrers: list[str]) -> list[dict]:
+    """Build rows that match the SELECT shape in _fetch_leads."""
+    now = datetime(2026, 4, 20, 10, 0, tzinfo=timezone.utc)
+    return [
+        {
+            "referrer_url": ref,
+            "landing_page": f"/visa/post-{i}",
+            "first_touch_at": now,
+        }
+        for i, ref in enumerate(referrers)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_missing_db_url_returns_yellow(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    reading = await LeadAttributionSensor().read()
+    assert isinstance(reading, SensorReading)
+    assert reading.status == "yellow"
+    assert reading.metadata["error_code"] == "db_url_missing"
+    assert reading.value["lead_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_happy_path_counts_only_organic():
+    sensor = LeadAttributionSensor(db_url="postgres://fake")
+    rows = _fake_rows([
+        "https://www.google.com/search?q=bali+visa",     # organic ✓
+        "https://duckduckgo.com/",                        # organic ✓
+        "https://bing.com/?q=kbli",                       # organic ✓
+        "https://facebook.com/balizero",                  # social ✗
+        "https://t.co/xyz",                               # social ✗
+        "https://kita.balizero.com/login",                # internal ✗
+        "https://random-blog.com/article",                # unknown ✗
+    ])
+    with patch.object(sensor, "_fetch_leads", return_value=rows):
+        reading = await sensor.read()
+    assert reading.status == "green"
+    assert reading.value["lead_count"] == 3
+    assert reading.metadata["scanned_rows"] == 7
+
+
+@pytest.mark.asyncio
+async def test_empty_window_returns_yellow():
+    sensor = LeadAttributionSensor(db_url="postgres://fake")
+    with patch.object(sensor, "_fetch_leads", return_value=[]):
+        reading = await sensor.read()
+    assert reading.status == "yellow"
+    assert reading.value["lead_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_only_non_organic_returns_yellow():
+    """All referers are social/internal — gate must NOT advance."""
+    sensor = LeadAttributionSensor(db_url="postgres://fake")
+    rows = _fake_rows([
+        "https://instagram.com/balizero",
+        "https://wa.me/628123456",
+        "https://balizero.com/about",
+    ])
+    with patch.object(sensor, "_fetch_leads", return_value=rows):
+        reading = await sensor.read()
+    assert reading.status == "yellow"
+    assert reading.value["lead_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_db_error_returns_red():
+    sensor = LeadAttributionSensor(db_url="postgres://fake")
+
+    async def _boom(*_a, **_k):  # noqa: ANN001
+        from apps.evaluator.seo_cell.sensors.lead_attribution_sensor import (
+            _LeadAttributionError,
+        )
+        raise _LeadAttributionError("db_error", "connect failed: gaierror(8)")
+
+    with patch.object(sensor, "_fetch_leads", side_effect=_boom):
+        reading = await sensor.read()
+    assert reading.status == "red"
+    assert reading.metadata["error_code"] == "db_error"
+    assert reading.value["lead_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_unexpected_exception_returns_red():
+    sensor = LeadAttributionSensor(db_url="postgres://fake")
+
+    async def _boom(*_a, **_k):  # noqa: ANN001
+        raise RuntimeError("kaboom")
+
+    with patch.object(sensor, "_fetch_leads", side_effect=_boom):
+        reading = await sensor.read()
+    assert reading.status == "red"
+    assert reading.metadata["error_code"] == "unexpected"
+
+
+@pytest.mark.asyncio
+async def test_aggregates_by_landing_page():
+    sensor = LeadAttributionSensor(db_url="postgres://fake")
+    now = datetime(2026, 4, 20, 10, 0, tzinfo=timezone.utc)
+    rows = [
+        {"referrer_url": "https://google.com/search?q=visa",
+         "landing_page": "/visa", "first_touch_at": now},
+        {"referrer_url": "https://google.com/search?q=visa+kitas",
+         "landing_page": "/visa", "first_touch_at": now},
+        {"referrer_url": "https://google.com/search?q=kbli",
+         "landing_page": "/kbli", "first_touch_at": now},
+    ]
+    with patch.object(sensor, "_fetch_leads", return_value=rows):
+        reading = await sensor.read()
+    assert reading.value["by_landing_page"] == {"/visa": 2, "/kbli": 1}
+
+
+@pytest.mark.asyncio
+async def test_recent_leads_top_n_capped():
+    sensor = LeadAttributionSensor(db_url="postgres://fake")
+    rows = _fake_rows(["https://google.com/search"] * 100)
+    with patch.object(sensor, "_fetch_leads", return_value=rows):
+        reading = await sensor.read()
+    assert reading.value["lead_count"] == 100
+    assert len(reading.value["recent_leads"]) == 50  # _TOP_N_KEEP
+
+
+@pytest.mark.asyncio
+async def test_null_referrer_treated_as_non_organic():
+    """SQL filter excludes NULL referrer_url, but defensive: helper too."""
+    sensor = LeadAttributionSensor(db_url="postgres://fake")
+    rows = [
+        {"referrer_url": None, "landing_page": "/", "first_touch_at": None},
+        {"referrer_url": "https://google.com/", "landing_page": "/visa",
+         "first_touch_at": datetime(2026, 4, 1, tzinfo=timezone.utc)},
+    ]
+    with patch.object(sensor, "_fetch_leads", return_value=rows):
+        reading = await sensor.read()
+    assert reading.value["lead_count"] == 1
+
+
+def test_is_organic_referrer_classifier():
+    # Organic search engines
+    assert _is_organic_referrer("https://www.google.com/search?q=visa") is True
+    assert _is_organic_referrer("https://google.co.id/") is True
+    assert _is_organic_referrer("https://duckduckgo.com/") is True
+    # Social
+    assert _is_organic_referrer("https://facebook.com/p/123") is False
+    assert _is_organic_referrer("https://t.co/abc") is False
+    # Internal
+    assert _is_organic_referrer("https://balizero.com/about") is False
+    assert _is_organic_referrer("https://kita.balizero.com/x") is False
+    # Unknown / weird
+    assert _is_organic_referrer(None) is False
+    assert _is_organic_referrer("") is False
+    assert _is_organic_referrer("not-a-url") is False
+    assert _is_organic_referrer("https://random-blog.example/") is False
+
+
+def test_domain_of_helper():
+    assert _domain_of("https://www.google.com/x") == "www.google.com"
+    assert _domain_of("https://X.COM/y") == "x.com"
+    assert _domain_of(None) is None
+    assert _domain_of("") is None

--- a/apps/evaluator/seo_cell/tests/test_sensor_name_contract.py
+++ b/apps/evaluator/seo_cell/tests/test_sensor_name_contract.py
@@ -13,6 +13,15 @@ The tests below fail on any re-introduction of that drift. They also
 guarantee that `BayesianCalibrator._fit` actually reads the non-zero
 scores a real Brief row carries, by reconstructing the Brief → X
 projection end-to-end.
+
+Sprint 2 added a 7th sensor (`lead_attribution`) that feeds the
+pre_natal unlock gate exclusively, NOT the post-graduation Bayesian
+scoring path. It is intentionally excluded from SENSOR_NAMES — the
+contract here is about scoring weights, not sensor inventory. The
+exclusion is asserted explicitly to prevent a future wave from
+silently re-adding lead_attribution to SENSOR_NAMES (which would
+require a corresponding DEFAULT_WEIGHTS rebalance and a calibrator
+training change).
 """
 from __future__ import annotations
 
@@ -30,24 +39,30 @@ from apps.evaluator.seo_cell.sensors import (
     GA4Sensor,
     GSCSensor,
     KGSensor,
+    LeadAttributionSensor,
     WarRoomEventSensor,
 )
 
 
+# Sensors that participate in the Bayesian scoring contract.
+# `lead_attribution` is excluded by design (gate-feeding only).
+_SCORING_SENSOR_CLASSES = (
+    GSCSensor,
+    GA4Sensor,
+    CompetitorSERPSensor,
+    KGSensor,
+    WarRoomEventSensor,
+    CannibalizationSensor,
+)
+
+
 def _live_sensor_names() -> set[str]:
-    """Instantiate each sensor class exactly as `sensors/__init__.py`
-    re-exports them, then read the public `.name` attribute. No I/O
-    happens — the name is a class attribute set at import.
+    """Names of sensors that are part of the calibrator scoring contract.
+
+    Returns the 6 v2.1 scoring sensors. `lead_attribution` is checked
+    separately by `test_lead_attribution_excluded_from_scoring_contract`.
     """
-    sensors = [
-        GSCSensor(),
-        GA4Sensor(),
-        CompetitorSERPSensor(),
-        KGSensor(),
-        WarRoomEventSensor(),
-        CannibalizationSensor(),
-    ]
-    return {s.name for s in sensors}
+    return {cls().name for cls in _SCORING_SENSOR_CLASSES}
 
 
 def test_sensor_names_match_live_sensor_instances():
@@ -106,6 +121,24 @@ def test_calibrator_fit_reads_nonzero_scores_for_every_sensor():
         f"projected={dict(zip(SENSOR_NAMES, projected))}, "
         f"brief_keys={set(scores)}"
     )
+
+
+def test_lead_attribution_excluded_from_scoring_contract():
+    """Sprint 2 sensor feeds the pre_natal unlock gate, NOT the
+    Bayesian calibrator. SENSOR_NAMES + DEFAULT_WEIGHTS must NOT
+    contain `lead_attribution`.
+
+    A future wave that wants to weight leads in the post-graduation
+    scoring must (a) add it to SENSOR_NAMES, (b) rebalance
+    DEFAULT_WEIGHTS, (c) retrain the calibrator with Brief rows that
+    carry a `lead_attribution` score, and (d) update this test. Doing
+    only (a)+(b) without (c)+(d) would silently feed zeros into the
+    fit — exactly the A1 class of bug.
+    """
+    leads = LeadAttributionSensor()
+    assert leads.name == "lead_attribution"
+    assert leads.name not in SENSOR_NAMES
+    assert leads.name not in DEFAULT_WEIGHTS
 
 
 def test_calibrator_mutates_when_briefs_keyed_by_live_sensor_names():

--- a/apps/evaluator/seo_cell/tests/test_sensors_stub.py
+++ b/apps/evaluator/seo_cell/tests/test_sensors_stub.py
@@ -6,6 +6,7 @@ Sensors graduated out of stub-land (own test_*_sensor.py):
   - WarRoomEventSensor     (Sprint 2c)
   - KGSensor               (Sprint 2d)
   - CompetitorSERPSensor   (Sprint 2e)
+  - LeadAttributionSensor  (Sprint 2 — pre_natal gate feeder)
 
 Only CannibalizationSensor remains a stub — per Sprint 2d commit, it
 belongs in the thinker layer, not the sensor layer, and will be
@@ -20,6 +21,7 @@ from apps.evaluator.seo_cell.sensors import (
     GA4Sensor,
     GSCSensor,
     KGSensor,
+    LeadAttributionSensor,
     WarRoomEventSensor,
 )
 
@@ -38,17 +40,18 @@ async def test_stub_sensor_returns_reading(sensor):
     assert reading.metadata.get("stub") is True
 
 
-def test_six_distinct_sensor_names():
-    all_six = [
+def test_seven_distinct_sensor_names():
+    all_seven = [
         *STUB_SENSORS,
         GSCSensor(),
         GA4Sensor(),
         WarRoomEventSensor(),
         KGSensor(),
         CompetitorSERPSensor(),
+        LeadAttributionSensor(),
     ]
-    names = {s.name for s in all_six}
-    assert len(names) == 6
+    names = {s.name for s in all_seven}
+    assert len(names) == 7
     assert names == {
         "gsc",
         "ga4",
@@ -56,4 +59,5 @@ def test_six_distinct_sensor_names():
         "kg",
         "war_room_event",
         "cannibalization",
+        "lead_attribution",
     }

--- a/apps/evaluator/seo_cell/tests/test_thinker_lead_attribution_integration.py
+++ b/apps/evaluator/seo_cell/tests/test_thinker_lead_attribution_integration.py
@@ -1,0 +1,131 @@
+"""Integration: lead_attribution sensor → thinker pre_natal unlock gate.
+
+Sprint 2 closes the A3 anomaly. Before this PR, the thinker hardcoded
+`lead_count = 0` and ignored sensor readings — the gate was always
+locked on the leads criterion. After this PR, `lead_count` is read
+from the `lead_attribution` sensor's value, so a real CRM signal
+(when present, AND the other two conditions are met) lets the cell
+graduate.
+
+These tests drive the thinker directly with synthetic readings to
+prove the wiring without standing up a real PG database. They also
+test the inverse: a yellow/red sensor (lead_count=0) keeps the gate
+locked, which is the safe-default behavior we want preserved.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from cell_core.types import HomeostaticState, SensorReading
+from apps.evaluator.seo_cell.thinker import SEOThinker
+
+
+def _gsc(query_count: int) -> SensorReading:
+    return SensorReading(
+        sensor_name="gsc",
+        status="green",
+        value={"query_count": query_count},
+    )
+
+
+def _leads(lead_count: int, *, status: str = "green") -> SensorReading:
+    return SensorReading(
+        sensor_name="lead_attribution",
+        status=status,
+        value={"lead_count": lead_count, "by_landing_page": {}, "recent_leads": []},
+    )
+
+
+@pytest.mark.asyncio
+async def test_lead_count_flows_from_sensor_into_phase():
+    """Thinker.current_phase reads lead_count from the sensor reading."""
+    thinker = SEOThinker()
+    readings = [_gsc(100), _leads(5)]
+    phase = thinker.current_phase(readings, HomeostaticState())
+    # We only assert the wiring — the actual unlock also depends on
+    # min_age_days, which depends on the persisted birth-date marker.
+    # If the cell is older than 28d AND gsc>=80 AND leads>=3, gate
+    # opens; otherwise it stays pre_natal.
+    assert isinstance(phase.pre_natal, bool)
+
+
+@pytest.mark.asyncio
+async def test_unlock_gate_opens_when_all_three_conditions_met():
+    """Patch the birth-date so age_days clears the threshold deterministically."""
+    thinker = SEOThinker()
+    # 60 days old → age check passes
+    fake_birth = datetime.now(timezone.utc) - timedelta(days=60)
+    with patch(
+        "apps.evaluator.seo_cell.thinker.config.cell_birth_date",
+        return_value=fake_birth,
+    ):
+        readings = [_gsc(100), _leads(5)]
+        phase = thinker.current_phase(readings, HomeostaticState())
+    assert phase.pre_natal is False, (
+        "60d old + gsc=100 + leads=5 should graduate"
+    )
+    assert phase.can_act is True
+    assert phase.can_learn is True
+
+
+@pytest.mark.asyncio
+async def test_unlock_gate_locked_when_leads_zero_even_if_gsc_high():
+    """A yellow/red sensor reports lead_count=0 → gate stays locked."""
+    thinker = SEOThinker()
+    fake_birth = datetime.now(timezone.utc) - timedelta(days=60)
+    with patch(
+        "apps.evaluator.seo_cell.thinker.config.cell_birth_date",
+        return_value=fake_birth,
+    ):
+        readings = [_gsc(100), _leads(0, status="yellow")]
+        phase = thinker.current_phase(readings, HomeostaticState())
+    assert phase.pre_natal is True
+
+
+@pytest.mark.asyncio
+async def test_missing_lead_sensor_keeps_gate_locked():
+    """Defensive: if the sensor isn't in readings, lead_count stays 0."""
+    thinker = SEOThinker()
+    fake_birth = datetime.now(timezone.utc) - timedelta(days=60)
+    with patch(
+        "apps.evaluator.seo_cell.thinker.config.cell_birth_date",
+        return_value=fake_birth,
+    ):
+        # only gsc, no lead_attribution reading at all
+        readings = [_gsc(100)]
+        phase = thinker.current_phase(readings, HomeostaticState())
+    assert phase.pre_natal is True
+
+
+@pytest.mark.asyncio
+async def test_red_sensor_returns_zero_lead_count_via_safe_default():
+    """A red reading (sensor failed) carries lead_count=0 → safe."""
+    thinker = SEOThinker()
+    fake_birth = datetime.now(timezone.utc) - timedelta(days=60)
+    with patch(
+        "apps.evaluator.seo_cell.thinker.config.cell_birth_date",
+        return_value=fake_birth,
+    ):
+        readings = [_gsc(100), _leads(0, status="red")]
+        phase = thinker.current_phase(readings, HomeostaticState())
+    assert phase.pre_natal is True
+
+
+@pytest.mark.asyncio
+async def test_proposal_still_none_pre_natal_with_real_lead_signal():
+    """Even with leads=10, if age<28d the proposal is still no-op."""
+    thinker = SEOThinker()
+    # birth = today → age_days = 0
+    fake_birth = datetime.now(timezone.utc)
+    with patch(
+        "apps.evaluator.seo_cell.thinker.config.cell_birth_date",
+        return_value=fake_birth,
+    ):
+        readings = [_gsc(100), _leads(10)]
+        proposal = await thinker.think(readings, HomeostaticState(), {})
+    assert proposal.action == "none"
+    assert thinker._last_phase is not None
+    assert thinker._last_phase.pre_natal is True

--- a/apps/evaluator/seo_cell/thinker.py
+++ b/apps/evaluator/seo_cell/thinker.py
@@ -110,23 +110,17 @@ class SEOThinker:
         native = Maturation(birth_date=config.cell_birth_date()).phase
 
         gsc_query_count = 0
+        lead_count = 0
         for r in readings:
             if r.sensor_name == "gsc" and isinstance(r.value, dict):
                 gsc_query_count = int(r.value.get("query_count", 0))
-                break
-
-        # website_organic lead count will come from CRM via Sprint 2's
-        # lead_attribution_sensor. That sensor has NOT shipped yet, and
-        # nothing in this codebase currently writes a rolling counter
-        # into memory_context — the earlier comment that claimed the
-        # actor populates one was aspirational, not accurate.
-        #
-        # Consequence: pre_natal stays locked on the leads criterion
-        # regardless of real traffic, which is the intended safe default
-        # until the sensor lands. Do NOT read memory_context here to
-        # paper over the gap — a zero from a missing sensor is honest,
-        # a fake non-zero would silently graduate the cell.
-        lead_count = 0
+            elif r.sensor_name == "lead_attribution" and isinstance(r.value, dict):
+                # Sprint 2: read directly from the sensor (CRM-backed).
+                # If the sensor errors (yellow/red), it returns
+                # value.lead_count=0, which keeps pre_natal locked —
+                # a zero from a failed sensor is honest, the same safe
+                # default as the pre-Sprint-2 hardcoded zero.
+                lead_count = int(r.value.get("lead_count", 0))
 
         pre_natal = is_pre_natal(
             gsc_query_count=gsc_query_count,


### PR DESCRIPTION
## Summary

- New 7th sensor `LeadAttributionSensor` reads `clients.referrer_url` (migration 118), classifies referers as organic-search vs social/internal, returns `lead_count` for the pre_natal unlock gate
- Thinker now reads `lead_count` from the sensor reading instead of the hardcoded `lead_count = 0` (A3 anomaly closed) — `phase.is_pre_natal` finally has all three signals it was designed for
- Cell gets a real caller: `python -m apps.evaluator.seo_cell.run_seo_cell` runner, deployed on Pro as `com.balizero.seo-cell.daily` LaunchAgent (03:30 WITA, mode 0444 per the 2026-04-29 plist-corruption scar antibody, logs to `~/logs/seo-cell/`)

## Why now

The cell shipped Sprint 1 in PR #134 then sat orphan for 9 days — designed but never instantiated, the test suite couldn't even collect because of a venv/PYTHONPATH gap. Earlier today we confirmed 116/116 tests pass once invoked correctly. With the test suite green, Sprint 2 (A3 fix + caller wiring) is the live option to make the cell operational instead of retiring it.

## Tests

134/134 green (was 116, +18 net):
- 11 new in `test_lead_attribution_sensor.py` — organic classifier, error paths (yellow on missing DATABASE_URL, red on import/connection/query errors, red on unexpected exceptions), top-N cap, NULL referrer defensive
- 6 new in `test_thinker_lead_attribution_integration.py` — gate flow with patched birth-date (60d old + GSC=100 + leads=5 → graduates), missing-sensor safe default (gate stays locked), red-sensor safe default, age-still-locks (today's birth + leads=10 → still pre_natal)
- 1 new in `test_sensor_name_contract.py` — pins `lead_attribution` OUT of `SENSOR_NAMES`/`DEFAULT_WEIGHTS` (Bayesian scoring contract is unchanged; the new sensor feeds the gate, not the calibrator)

## Safety properties preserved

The pre-Sprint-2 invariant — "a missed signal is honest, a fake non-zero would silently graduate the cell" — still holds. Every error path of the new sensor returns `value.lead_count = 0`, exactly equivalent to the old hardcoded zero. The wiring change matters only when CRM actually has organic leads to report.

## Caller deployment (Pro-only, NOT in this PR)

```
~/scripts/openclaw-cron/seo-cell-daily.sh         # executable wrapper, sentinel ping
~/Library/LaunchAgents/com.balizero.seo-cell.daily.plist  # mode 0444, KeepAlive=false
```

Smoke-tested via `launchctl kickstart`: pulse #1 ran clean, log written to `~/logs/seo-cell/pulse-20260430-222650.log` with `health=yellow action=None` (designed pre_natal behavior — sensors ran, none crashed, the actor never fired). Sentinel state file `~/.agent/decisions/state/seo_cell_daily.last.json` shows `status:ok`.

## Test plan

- [x] `PYTHONPATH=. .venv/bin/pytest apps/evaluator/seo_cell/tests/ -q` — 134/134 in 0.17s
- [x] `python -m apps.evaluator.seo_cell.run_seo_cell` smoke test on Pro
- [x] LaunchAgent bootstrapped, kickstart returned 0, sentinel state OK
- [x] `plutil -lint` on the new plist
- [ ] Wait for 03:30 WITA cron tick, verify next-day log + sentinel
- [ ] After 28d (cell birth window), check whether organic leads accumulate enough to trigger graduation — if so, Sprint 3 (Bayesian calibrator unlock + actor whitelist) becomes the next move

🤖 Generated with [Claude Code](https://claude.com/claude-code)