### PR TITLE
fix(fad): replay_unconsumed kwarg + dict-vs-str payload

### DIFF
--- a/apps/backend-rag/backend/services/federation_alerts/daemon.py
+++ b/apps/backend-rag/backend/services/federation_alerts/daemon.py
@@ -95,7 +95,7 @@ class FederationAlertDaemon:
             async with self._pool.acquire() as conn:
                 await replay_unconsumed(
                     conn,
-                    dispatch=self._enqueue_replay,
+                    self._enqueue_replay,
                     channel=PG_CHANNEL,
                     consumer_id=self._config.daemon_owner,
                 )
@@ -195,11 +195,17 @@ class FederationAlertDaemon:
     # Per-payload processing
     # ------------------------------------------------------------------
 
-    async def _enqueue_replay(self, payload_str: str) -> None:
-        """Callback invoked by replay_unconsumed for each unconsumed row."""
-        # The daemon's main loop handles the same shape, so just delegate.
+    async def _enqueue_replay(self, payload: dict[str, Any]) -> None:
+        """Callback invoked by replay_unconsumed for each unconsumed row.
+
+        ``replay_unconsumed`` decodes the JSONB column into a dict and
+        injects ``_outbox_id`` / ``_replay`` keys before dispatching.
+        The daemon's main NOTIFY loop, by contrast, receives the raw
+        payload string from ``add_listener``. Re-serialise here so both
+        paths funnel through ``_process_notify_payload``.
+        """
         repo = FederationAlertRepo(pool=self._pool)  # type: ignore[arg-type]
-        await self._process_notify_payload(payload_str, repo)
+        await self._process_notify_payload(json.dumps(payload), repo)
 
     async def _process_notify_payload(
         self, payload_str: str, repo: FederationAlertRepo

--- a/apps/backend-rag/backend/tests/services/federation_alerts/test_daemon.py
+++ b/apps/backend-rag/backend/tests/services/federation_alerts/test_daemon.py
@@ -352,3 +352,67 @@ async def test_process_notify_payload_terminal_proposal_skipped(
         json.dumps({"v": 1, "proposal_id": "pid-1"}), repo
     )
     repo.acquire_lease.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_enqueue_replay_serialises_dict_payload(
+    daemon_with_audit_mock,
+) -> None:
+    """Replay path receives a dict from outbox; daemon must JSON-encode it.
+
+    Regression for the replay-kwarg + dict-vs-str mismatch surfaced during
+    the live smoke test on Pro (2026-04-30). ``replay_unconsumed`` decodes
+    the JSONB column and injects ``_outbox_id`` / ``_replay`` before
+    dispatch — the daemon's ``_enqueue_replay`` must accept a dict and
+    funnel it through ``_process_notify_payload`` (which expects str).
+    """
+    daemon = daemon_with_audit_mock
+    daemon._pool = MagicMock()  # FederationAlertRepo() requires pool|conn
+    captured: list[str] = []
+
+    async def fake_process(payload_str, _repo):  # noqa: ANN001
+        captured.append(payload_str)
+
+    daemon._process_notify_payload = fake_process  # type: ignore[assignment]
+
+    payload_dict = {
+        "v": 1,
+        "proposal_id": "replay-pid",
+        "run_id": "replay-run",
+        "_outbox_id": 42,
+        "_replay": True,
+    }
+    await daemon._enqueue_replay(payload_dict)
+
+    assert len(captured) == 1
+    decoded = json.loads(captured[0])
+    assert decoded["proposal_id"] == "replay-pid"
+    assert decoded["_outbox_id"] == 42
+    assert decoded["_replay"] is True
+
+
+def test_replay_unconsumed_signature_uses_positional_dispatch_fn() -> None:
+    """``replay_unconsumed`` takes ``dispatch_fn`` as positional arg.
+
+    The daemon must NOT pass it as ``dispatch=`` kwarg — that crashed at
+    boot during the 2026-04-30 smoke test with::
+
+        TypeError: replay_unconsumed() got an unexpected keyword argument
+        'dispatch'
+
+    This test pins the contract so a future refactor can't reintroduce
+    the mismatch silently.
+    """
+    import inspect
+
+    from backend.services.events.outbox import replay_unconsumed
+
+    sig = inspect.signature(replay_unconsumed)
+    params = list(sig.parameters.values())
+    # conn (positional), dispatch_fn (positional-or-keyword), then kw-only
+    assert params[1].name == "dispatch_fn"
+    assert params[1].kind in (
+        inspect.Parameter.POSITIONAL_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    )
+    assert "dispatch" not in sig.parameters


### PR DESCRIPTION
## Summary

Two follow-up bugs from the FAD trilogy (#391/#393/#395/#397) surfaced during the live smoke test on Pro (2026-04-30):

1. `replay_unconsumed(..., dispatch=...)` → `TypeError`. The helper signature is `(conn, dispatch_fn, *, channel, ...)`. Switched to positional binding.
2. `_enqueue_replay(payload_str: str)` was wrong: `replay_unconsumed` decodes the JSONB column to a dict (with `_outbox_id` / `_replay` injected) before dispatch. Annotation is now `dict[str, Any]` and we re-serialise with `json.dumps(...)` before delegating to `_process_notify_payload` (which still receives a string — live-NOTIFY path byte-identical).

## Smoke test (Pro, 2026-04-30)

- Daemon boot pre-fix: LISTEN active, but `daemon.replay_failed` audit event fired every boot with the TypeError above.
- Forward NOTIFY path unaffected — the end-to-end test (insert proposal → `pg_notify` → status=`observed` in <500ms) passed pre-fix because it bypasses the replay codepath.
- Will re-verify post-merge: kickstart → expect clean boot, no `replay_failed` event.

## Tests

- `test_enqueue_replay_serialises_dict_payload` — exercises `_enqueue_replay` with the dict shape `replay_unconsumed` actually delivers and asserts the string reaches `_process_notify_payload`.
- `test_replay_unconsumed_signature_uses_positional_dispatch_fn` — inspects `replay_unconsumed`'s signature and pins `dispatch_fn` as positional, refusing any parameter named `dispatch`. A future refactor of the helper must update the daemon together.

`backend/tests/services/federation_alerts/`: 139 passed (137 baseline + 2 new). `ruff` clean.

## Test plan

- [x] `PYTHONPATH=. pytest backend/tests/services/federation_alerts/ -q` → 139 passed
- [x] `ruff check apps/backend-rag/backend/services/federation_alerts/daemon.py …/test_daemon.py` → clean
- [ ] Post-merge: kickstart daemon on Pro; confirm `daemon.starting` → `daemon.listener_active` with no `daemon.replay_failed` between them

🤖 Generated with [Claude Code](https://claude.com/claude-code)