### PR TITLE
fix(docs-audit): mask mtime_days drift in --check

### DIFF
--- a/scripts/docs_audit.py
+++ b/scripts/docs_audit.py
@@ -439,11 +439,35 @@ def main() -> int:
     inventory_path = repo / "docs" / "DOCS_INVENTORY.md"
     old_content = inventory_path.read_text(encoding="utf-8") if inventory_path.exists() else ""
 
-    # Strip "Last run:" line for comparison (timestamp changes every run)
-    def strip_ts(s: str) -> str:
-        return "\n".join(l for l in s.splitlines() if "Last run:" not in l)
+    # Normalise volatile fields before comparing committed vs. rendered:
+    #   * "Last run: …" — wall-clock timestamp, changes every run
+    #   * mtime_days column in the file table — increments daily for every
+    #     row because git commit-mtime grows with calendar time, even if
+    #     no doc was touched. Without stripping this, `--check` returns 1
+    #     on every PR touching docs/** the day after the last regen.
+    def strip_volatile(s: str) -> str:
+        out: List[str] = []
+        for line in s.splitlines():
+            if "Last run:" in line:
+                continue
+            # File table rows look like:
+            #   | path | STATUS | <int> | <int> | <int> | yes/no | cluster | action |
+            # mtime_days is column 3 (1-indexed) — replace with placeholder
+            # so daily drift doesn't trip the comparison. Header row
+            # ("File | Status | mtime_days | …") is preserved verbatim.
+            if line.startswith("| ") and "|" in line[2:] and "mtime_days" not in line:
+                parts = line.split("|")
+                # Expected layout: ['', ' path ', ' STATUS ', ' mtime_days ',
+                #                   ' refs_in ', ' broken ', ' drift ',
+                #                   ' cluster ', ' action ', '']
+                # Skip the alignment row "|------|...".
+                if len(parts) >= 9 and "---" not in line:
+                    parts[3] = " <mtime> "
+                    line = "|".join(parts)
+            out.append(line)
+        return "\n".join(out)
 
-    stale_delta = strip_ts(new_content) != strip_ts(old_content)
+    stale_delta = strip_volatile(new_content) != strip_volatile(old_content)
 
     if args.json:
         payload = {

--- a/scripts/tests/test_docs_audit.py
+++ b/scripts/tests/test_docs_audit.py
@@ -207,6 +207,78 @@ def test_check_flag_exit_codes(aged_fixture):
     assert result.returncode == 1
 
 
+def test_check_ignores_mtime_days_drift(aged_fixture):
+    """`--check` must NOT fail when the only delta is mtime_days incrementing.
+
+    Calendar time advances every day; if `--check` flagged that, every PR
+    touching `docs/**` would fail Docs Guardian on the day after the last
+    inventory regen — making the gate noise instead of signal. Regression
+    for the 2026-05-01 incident on PR #401, where the `inventory-check`
+    job in `.github/workflows/docs-guardian.yml` flagged a 1-day
+    mtime_days drift on every row even though no doc was actually stale.
+    """
+    common = [
+        "--whitelist", "docs/WHITELIST_KEEPER.md",
+        "--cluster", "test-dup:docs/DUP_V1.md,docs/DUP_V2.md:docs/DUP_V2.md",
+    ]
+    # Generate inventory at the fixture's current "today".
+    _run_audit(aged_fixture, *common)
+
+    # Bump every mtime_days by 1 to simulate "the next calendar day".
+    inventory = aged_fixture / "docs" / "DOCS_INVENTORY.md"
+    bumped: list[str] = []
+    in_table = False
+    for line in inventory.read_text().splitlines():
+        if line.startswith("|") and "mtime_days" in line:
+            in_table = True
+            bumped.append(line)
+            continue
+        if in_table and line.startswith("| ") and "---" not in line:
+            parts = line.split("|")
+            # | path | STATUS | mtime_days | refs_in | broken | drift | …
+            if len(parts) >= 9:
+                try:
+                    parts[3] = f" {int(parts[3].strip()) + 1} "
+                    line = "|".join(parts)
+                except ValueError:
+                    pass
+        bumped.append(line)
+    inventory.write_text("\n".join(bumped) + "\n")
+
+    # Drift is mtime-only → the fix in render_inventory's strip_volatile
+    # must mask it, so --check must still exit 0.
+    result = _run_audit(aged_fixture, *common, "--check")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    # Sanity: re-running without --check must rewrite the file with the
+    # real (smaller) mtime values, restoring byte-identical state.
+    _run_audit(aged_fixture, *common)
+    result = _run_audit(aged_fixture, *common, "--check")
+    assert result.returncode == 0
+
+
+def test_check_still_catches_real_drift(aged_fixture):
+    """Counterpart to the mtime-drift mask: a real status change must trip --check.
+
+    Without this guarantee, the strip_volatile mask could over-strip and
+    silently hide actual drift (e.g. a doc going LIVE → STALE).
+    """
+    common = [
+        "--whitelist", "docs/WHITELIST_KEEPER.md",
+        "--cluster", "test-dup:docs/DUP_V1.md,docs/DUP_V2.md:docs/DUP_V2.md",
+    ]
+    _run_audit(aged_fixture, *common)
+    inventory = aged_fixture / "docs" / "DOCS_INVENTORY.md"
+    content = inventory.read_text()
+    # Flip first LIVE row to STALE.
+    mutated = content.replace("| LIVE |", "| STALE |", 1)
+    assert mutated != content, "fixture has no LIVE rows — adjust"
+    inventory.write_text(mutated)
+
+    result = _run_audit(aged_fixture, *common, "--check")
+    assert result.returncode == 1
+
+
 def test_git_mtime_beats_stat_mtime(tmp_path):
     """When the file is in a git repo, the audit must use `git log` for mtime,
     not `os.stat().st_mtime`. This protects against git-checkout resetting


### PR DESCRIPTION
## Summary

`Docs Guardian` (the `inventory-check` job in `.github/workflows/docs-guardian.yml`) was failing deterministically on every PR touching `docs/**` the day after the last inventory regen.

Root cause: `scripts/docs_audit.py --check` compares the committed `docs/DOCS_INVENTORY.md` against a fresh rendering. The file table carries an `mtime_days` column derived from `git log --format=%ct`, which **increments every day for every row**, even when no doc was edited.

Concrete failure observed on **PR #401** (2026-05-01): had to push an extra commit just to refresh `DOCS_INVENTORY.md` mtime values — every other column was unchanged. Pure noise.

## Fix

Extend the existing `strip_ts` helper (renamed `strip_volatile`) to also mask `mtime_days`. The mask is targeted:

- File table rows: column 3 (`mtime_days`) → `<mtime>` placeholder.
- Header row, alignment row, every other column: untouched.

Any **real** drift (status flip, broken-link delta, cluster membership change, drift flag toggle, refs_in change) still trips `--check`.

## Tests

Two new tests in `scripts/tests/test_docs_audit.py`:

- `test_check_ignores_mtime_days_drift` — bump every `mtime_days` by 1 to simulate +1 calendar day, assert `--check` exits 0. **Without the fix, exits 1.**
- `test_check_still_catches_real_drift` — flip a `LIVE` row to `STALE`, assert `--check` exits 1. Guards against the mask becoming too aggressive in the future.

```
$ python3 -m pytest scripts/tests/test_docs_audit.py -q
15 passed in 9.23s   (13 baseline + 2 new)
```

## Out of scope

There are 4 pre-existing `ruff` warnings in these files (F401 unused imports, E741 `l` variable). Not introduced by this PR — leaving them to a focused cleanup so the diff stays minimal and reviewable.

## Test plan

- [x] `python3 -m pytest scripts/tests/test_docs_audit.py -q` → 15 passed
- [x] Manual: simulate +1 day mtime drift → `--check` exits 0
- [x] Manual: inject real `LIVE → STALE` drift → `--check` exits 1
- [ ] CI: `inventory-check` passes on this PR
- [ ] Post-merge: next docs-touching PR should not need an inventory-refresh commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)