### PR TITLE
🎨 Palette: Add image attachment previews to chat input bar

### DIFF
--- a/apps/mouth/src/app/chat/page.tsx
+++ b/apps/mouth/src/app/chat/page.tsx
@@ -121,6 +121,8 @@ export default function ChatPage() {
           recordingTime={0}
           onStartRecording={() => {}}
           onStopRecording={() => {}}
+          attachedImages={chatInput.attachedImages}
+          onRemoveImage={chatInput.removeAttachedImage}
         />
       </div>
 

--- a/apps/mouth/src/components/chat/ChatInputBar.test.tsx
+++ b/apps/mouth/src/components/chat/ChatInputBar.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ChatInputBar } from './ChatInputBar';
+import React from 'react';
+
+// Mock dependencies
+vi.mock('./ChatRecordingOverlay', () => ({
+  ChatRecordingOverlay: () => <div data-testid="recording-overlay" />,
+}));
+
+describe('ChatInputBar', () => {
+  const defaultProps = {
+    input: '',
+    setInput: vi.fn(),
+    isLoading: false,
+    showImagePrompt: false,
+    setShowImagePrompt: vi.fn(),
+    onSend: vi.fn(),
+    onImageGenerate: vi.fn(),
+    showAttachMenu: false,
+    setShowAttachMenu: vi.fn(),
+    attachMenuRef: { current: null },
+    fileInputRef: { current: null },
+    onFileChange: vi.fn(),
+    isRecording: false,
+    recordingTime: 0,
+    onStartRecording: vi.fn(),
+    onStopRecording: vi.fn(),
+  };
+
+  it('renders image previews when attachedImages are provided', () => {
+    const attachedImages = [
+      { id: '1', base64: 'data:image/png;base64,123', name: 'image1.png', size: 100 },
+      { id: '2', base64: 'data:image/png;base64,456', name: 'image2.png', size: 200 },
+    ];
+
+    render(<ChatInputBar {...defaultProps} attachedImages={attachedImages} />);
+
+    expect(screen.getByAltText('image1.png')).toBeDefined();
+    expect(screen.getByAltText('image2.png')).toBeDefined();
+  });
+
+  it('calls onRemoveImage when remove button is clicked', () => {
+    const onRemoveImage = vi.fn();
+    const attachedImages = [
+      { id: '1', base64: 'data:image/png;base64,123', name: 'image1.png', size: 100 },
+    ];
+
+    render(
+      <ChatInputBar
+        {...defaultProps}
+        attachedImages={attachedImages}
+        onRemoveImage={onRemoveImage}
+      />
+    );
+
+    const removeButton = screen.getByLabelText('Remove image: image1.png');
+    fireEvent.click(removeButton);
+
+    expect(onRemoveImage).toHaveBeenCalledWith('1');
+  });
+});

--- a/apps/mouth/src/components/chat/ChatInputBar.tsx
+++ b/apps/mouth/src/components/chat/ChatInputBar.tsx
@@ -2,8 +2,11 @@
 
 import { Button } from '@/components/ui/button';
 import { UI } from '@/constants';
-import { Send, ImageIcon, Plus, Loader2, Upload, Camera, Mic } from 'lucide-react';
+import { Send, ImageIcon, Plus, Loader2, Upload, Camera, Mic, X } from 'lucide-react';
 import { ChatRecordingOverlay } from './ChatRecordingOverlay';
+import { AttachedImage } from '@/hooks/useChatInput';
+import { motion, AnimatePresence } from 'framer-motion';
+import Image from 'next/image';
 
 export interface ChatInputBarProps {
   input: string;
@@ -23,6 +26,8 @@ export interface ChatInputBarProps {
   onStartRecording: () => void;
   onStopRecording: () => void;
   onToggleRecording?: () => void; // Click-to-toggle handler
+  attachedImages?: AttachedImage[];
+  onRemoveImage?: (id: string) => void;
 }
 
 export function ChatInputBar({
@@ -43,6 +48,8 @@ export function ChatInputBar({
   onStartRecording,
   onStopRecording,
   onToggleRecording,
+  attachedImages = [],
+  onRemoveImage,
 }: ChatInputBarProps) {
   // Use toggle handler if provided, otherwise fall back to start/stop
   const handleMicClick = () => {
@@ -68,6 +75,36 @@ export function ChatInputBar({
   return (
     <div className="fixed bottom-0 left-0 right-0 p-4 pointer-events-none z-10">
       <div className="max-w-3xl mx-auto pointer-events-auto">
+        {/* Image Previews */}
+        <div className="flex flex-wrap gap-2 mb-2 px-2">
+          <AnimatePresence>
+            {attachedImages.map((img) => (
+              <motion.div
+                key={img.id}
+                initial={{ opacity: 0, scale: 0.8, y: 10 }}
+                animate={{ opacity: 1, scale: 1, y: 0 }}
+                exit={{ opacity: 0, scale: 0.8, y: 10 }}
+                className="relative group w-16 h-16 rounded-lg overflow-hidden border border-[var(--border)] shadow-md"
+              >
+                <Image
+                  src={img.base64}
+                  alt={img.name}
+                  fill
+                  className="object-cover"
+                  unoptimized
+                />
+                <button
+                  onClick={() => onRemoveImage?.(img.id)}
+                  className="absolute top-1 right-1 p-0.5 bg-black/60 text-white rounded-full opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity hover:bg-black/80"
+                  aria-label={`Remove image: ${img.name}`}
+                >
+                  <X className="w-3 h-3" />
+                </button>
+              </motion.div>
+            ))}
+          </AnimatePresence>
+        </div>
+
         {showImagePrompt && (
           <div className="mb-2 p-2 bg-[var(--background-secondary)] rounded-lg flex items-center gap-2 shadow-lg border border-[var(--border)]">
             <ImageIcon className="w-4 h-4 text-[var(--accent)]" />


### PR DESCRIPTION
This PR adds a key micro-UX improvement to the chat interface by providing immediate visual feedback for image attachments. Users can now see thumbnails of images they've selected and remove them individually before sending the message. The implementation follows the app's accessibility standards by ensuring remove buttons are reachable and visible to keyboard users. Unit tests have been added to verify the rendering and removal logic.

---
*PR created automatically by Jules for task [16089389171946842811](https://jules.google.com/task/16089389171946842811) started by @Balizero1987*