### PR TITLE
hotfix(scripts): align compute_client_segments with REAL prod schema

### DIFF
--- a/apps/backend-rag/backend/tests/scripts/test_compute_client_segments.py
+++ b/apps/backend-rag/backend/tests/scripts/test_compute_client_segments.py
@@ -3,48 +3,108 @@
 Tests synthetic in-memory data only. Real-DB integration test happens via
 deploy verification (Task 7-8).
 
-Schema reality (verified 2026-05-01 against repo code):
-- practices.total_invoiced_idr NUMERIC(16,2)  — IDR only, single currency
-- practices.completed_at TIMESTAMPTZ          — set on status='completed' transition
-- practices.status TEXT                       — 'completed' | 'on_process' | etc.
+Schema reality (verified 2026-05-01 against prod DB):
+- practices.actual_price NUMERIC          — final invoiced amount (preferred)
+- practices.quoted_price NUMERIC          — fallback if actual_price NULL
+- practices.currency VARCHAR              — per-row currency (USD/IDR/etc.)
+- practices.completion_date TIMESTAMPTZ   — completion timestamp
+- practices.status VARCHAR                — 'completed' | 'on_process' | etc.
+
+Earlier draft assumed total_invoiced_idr + completed_at — those columns
+are referenced by services/crm/partners/commission_engine.py:89 but NOT
+present in prod schema. verify_schema() catches the drift.
 """
 import pytest
 
-from scripts.compute_client_segments import assign_tier, compute_ltv_usd
+from scripts.compute_client_segments import (
+    amount_to_usd,
+    assign_tier,
+    compute_ltv_usd,
+)
+
+
+class TestAmountToUsd:
+    def test_usd_passthrough(self):
+        assert amount_to_usd(1500, "USD") == 1500.0
+
+    def test_idr_converted(self):
+        # 31M IDR @ 15500 IDR/USD = $2000
+        assert amount_to_usd(31_000_000, "IDR") == pytest.approx(2000.0, rel=1e-3)
+
+    def test_eur_converted(self):
+        assert amount_to_usd(1000, "EUR") == 1100.0
+
+    def test_unknown_currency_passthrough(self):
+        assert amount_to_usd(100, "XYZ") == 100.0
+
+    def test_none_amount_returns_zero(self):
+        assert amount_to_usd(None, "USD") == 0.0
+
+    def test_zero_amount_returns_zero(self):
+        assert amount_to_usd(0, "USD") == 0.0
+
+    def test_negative_amount_returns_zero(self):
+        assert amount_to_usd(-100, "USD") == 0.0
+
+    def test_none_currency_treated_as_usd(self):
+        assert amount_to_usd(500, None) == 500.0
+
+    def test_lowercase_currency_normalized(self):
+        assert amount_to_usd(1500, "usd") == 1500.0
 
 
 class TestComputeLtvUsd:
-    def test_completed_practice_idr_converts_to_usd(self):
-        # 31,000,000 IDR @ 15500 IDR/USD = $2000
-        practices = [{"total_invoiced_idr": 31_000_000, "status": "completed"}]
+    def test_completed_practice_with_actual_price(self):
+        practices = [
+            {"actual_price": 2000, "quoted_price": 1500, "currency": "USD", "status": "completed"},
+        ]
+        assert compute_ltv_usd(practices) == 2000.0  # actual_price wins over quoted
+
+    def test_completed_practice_falls_back_to_quoted_price_when_actual_null(self):
+        practices = [
+            {"actual_price": None, "quoted_price": 1500, "currency": "USD", "status": "completed"},
+        ]
+        assert compute_ltv_usd(practices) == 1500.0
+
+    def test_idr_practice_converts_to_usd(self):
+        # 31M IDR @ 15500 IDR/USD = $2000
+        practices = [
+            {"actual_price": 31_000_000, "quoted_price": None, "currency": "IDR", "status": "completed"},
+        ]
         assert compute_ltv_usd(practices) == pytest.approx(2000.0, rel=1e-3)
 
     def test_multiple_completed_practices_sum(self):
-        # 31M + 15.5M = 46.5M IDR = $3000
         practices = [
-            {"total_invoiced_idr": 31_000_000, "status": "completed"},
-            {"total_invoiced_idr": 15_500_000, "status": "completed"},
+            {"actual_price": 2000, "quoted_price": None, "currency": "USD", "status": "completed"},
+            {"actual_price": 1000, "quoted_price": None, "currency": "USD", "status": "completed"},
         ]
-        assert compute_ltv_usd(practices) == pytest.approx(3000.0, rel=1e-3)
+        assert compute_ltv_usd(practices) == 3000.0
 
     def test_only_completed_status_counts(self):
         practices = [
-            {"total_invoiced_idr": 15_500_000, "status": "completed"},  # $1000
-            {"total_invoiced_idr": 31_000_000, "status": "on_process"},  # not counted
-            {"total_invoiced_idr": 46_500_000, "status": "cancelled"},  # not counted
-            {"total_invoiced_idr": 15_500_000, "status": "sending_invoice"},  # not counted
+            {"actual_price": 1000, "quoted_price": None, "currency": "USD", "status": "completed"},
+            {"actual_price": 5000, "quoted_price": None, "currency": "USD", "status": "on_process"},
+            {"actual_price": 2000, "quoted_price": None, "currency": "USD", "status": "cancelled"},
+            {"actual_price": 1500, "quoted_price": None, "currency": "USD", "status": "sending_invoice"},
         ]
-        assert compute_ltv_usd(practices) == pytest.approx(1000.0, rel=1e-3)
+        assert compute_ltv_usd(practices) == 1000.0
 
     def test_no_practices_returns_zero(self):
         assert compute_ltv_usd([]) == 0.0
 
-    def test_null_total_invoiced_idr_treated_as_zero(self):
-        practices = [{"total_invoiced_idr": None, "status": "completed"}]
+    def test_both_prices_null_returns_zero(self):
+        practices = [
+            {"actual_price": None, "quoted_price": None, "currency": "USD", "status": "completed"},
+        ]
         assert compute_ltv_usd(practices) == 0.0
 
-    def test_zero_total_invoiced_idr(self):
-        practices = [{"total_invoiced_idr": 0, "status": "completed"}]
+    def test_zero_actual_price_falls_back_to_quoted(self):
+        # 0 is falsy via amount_to_usd → returns 0; but compute_ltv_usd still tries
+        # quoted_price as fallback only if actual_price is None, not 0. So zero stays zero.
+        practices = [
+            {"actual_price": 0, "quoted_price": 1500, "currency": "USD", "status": "completed"},
+        ]
+        # actual_price=0 is treated as 0 (falsy in amount_to_usd guard, so 0); does not fall back
         assert compute_ltv_usd(practices) == 0.0
 
 

--- a/apps/backend-rag/scripts/compute_client_segments.py
+++ b/apps/backend-rag/scripts/compute_client_segments.py
@@ -5,10 +5,18 @@ Run once post-deploy of migration 149. Idempotent: re-running updates rows.
 From Sprint 4 onward, Cell skill `measure_conversion` will trigger weekly
 re-computation; this script is the bootstrap.
 
-Schema reality (verified 2026-05-01):
-    practices.total_invoiced_idr NUMERIC  — pre-aggregated IDR amount
-    practices.completed_at TIMESTAMPTZ    — completion timestamp
-    practices.status TEXT                 — 'completed' | etc.
+Schema reality (verified 2026-05-01 against prod DB):
+    practices.actual_price NUMERIC      — final invoiced amount (preferred)
+    practices.quoted_price NUMERIC      — fallback when actual_price IS NULL
+    practices.currency VARCHAR          — per-row currency (USD/IDR/etc.)
+    practices.completion_date TIMESTAMPTZ — completion timestamp (sometimes NULL)
+    practices.status VARCHAR            — 'completed' | 'on_process' | etc.
+    clients.id INTEGER, clients.deleted_at TIMESTAMPTZ
+
+Note: earlier draft (commit 5bd02c380) assumed practices.total_invoiced_idr +
+practices.completed_at, columns referenced by services/crm/partners/
+commission_engine.py:89 but NOT actually present in prod schema.
+verify_schema() catches this drift and aborts cleanly.
 
 Spec: docs/superpowers/specs/2026-05-01-post-agentic-injection-design.md §4 Sprint 0.2
 
@@ -30,28 +38,60 @@ import asyncpg
 logger = logging.getLogger("compute_client_segments")
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 
-# Static USD conversion. Refresh rate quarterly; design choice: simplicity > FX accuracy.
-IDR_PER_USD: float = 15_500.0
+# Static currency conversion rates (USD baseline). Refresh quarterly.
+# Design choice: simplicity > FX accuracy.
+CURRENCY_TO_USD: dict[str, float] = {
+    "USD": 1.0,
+    "IDR": 1.0 / 15_500.0,
+    "EUR": 1.10,
+    "AUD": 0.66,
+    "GBP": 1.27,
+    "SGD": 0.74,
+}
+
+
+def amount_to_usd(amount: float | None, currency: str | None) -> float:
+    """Convert amount to USD using static rate table.
+
+    Unknown currency → treated as USD passthrough (logs warning).
+    None / 0 / negative → 0.
+    """
+    if amount is None or amount <= 0:
+        return 0.0
+    cur = (currency or "USD").upper()
+    rate = CURRENCY_TO_USD.get(cur)
+    if rate is None:
+        logger.warning(f"Unknown currency {cur!r}, treating as USD passthrough")
+        rate = 1.0
+    return float(amount) * rate
 
 
 def compute_ltv_usd(practices: list[dict[str, Any]]) -> float:
-    """Sum completed practice IDR amounts converted to USD.
+    """Sum completed practice prices converted to USD.
 
     Args:
-        practices: list of dicts with keys total_invoiced_idr (numeric|None), status (str).
+        practices: list of dicts with keys actual_price, quoted_price, currency, status.
 
     Returns:
         Total LTV in USD; 0.0 if no completed practices or all amounts null/zero.
+
+    Logic:
+        For each practice with status='completed':
+            price = COALESCE(actual_price, quoted_price, 0)
+            convert price to USD via currency rate
+            add to total
     """
-    total_idr: float = 0.0
+    total: float = 0.0
     for p in practices:
         if p.get("status") != "completed":
             continue
-        amount = p.get("total_invoiced_idr")
+        # Prefer actual_price; fall back to quoted_price.
+        amount = p.get("actual_price")
         if amount is None:
-            continue
-        total_idr += float(amount)
-    return total_idr / IDR_PER_USD if total_idr else 0.0
+            amount = p.get("quoted_price")
+        currency = p.get("currency")
+        total += amount_to_usd(amount, currency)
+    return total
 
 
 def assign_tier(ltv_usd: float) -> int:
@@ -74,8 +114,9 @@ async def verify_schema(conn: asyncpg.Connection) -> None:
     Aborts with clear error if schema drift renamed/removed required columns.
     """
     required = [
-        ("practices", "total_invoiced_idr"),
-        ("practices", "completed_at"),
+        ("practices", "actual_price"),
+        ("practices", "quoted_price"),
+        ("practices", "currency"),
         ("practices", "status"),
         ("practices", "client_id"),
         ("clients", "id"),
@@ -114,7 +155,9 @@ async def compute_for_all_clients(
         SELECT
             c.id AS client_id,
             COALESCE(json_agg(json_build_object(
-                'total_invoiced_idr', p.total_invoiced_idr,
+                'actual_price', p.actual_price,
+                'quoted_price', p.quoted_price,
+                'currency', p.currency,
                 'status', p.status
             )) FILTER (WHERE p.id IS NOT NULL), '[]'::json) AS practices_json
         FROM clients c


### PR DESCRIPTION
## Summary

Hotfix on top of merged PR #404. The original draft of compute_client_segments.py assumed practices.total_invoiced_idr + practices.completed_at — these are referenced by services/crm/partners/commission_engine.py:89 but DO NOT EXIST in prod schema (verified 2026-05-01 via fly ssh).

verify_schema() defensive check caught the drift on first dry-run — would have produced wrong data otherwise. This is exactly what the defensive guard was for.

## Real prod schema (verified)

- practices.actual_price NUMERIC (preferred), quoted_price NUMERIC (fallback)
- practices.currency VARCHAR — per-row, USD/IDR/EUR/AUD/GBP/SGD multi-currency
- practices.completion_date TIMESTAMPTZ (not completed_at)
- 1335 clients alive, 328 practices (218 completed), 0 renewal_alerts

## LTV logic

- COALESCE(actual_price, quoted_price, 0) — actual wins, quoted as fallback
- Static currency conversion table (USD baseline)
- amount_to_usd helper extracted for testability
- 23 unit tests pass (added 11 for currency edge cases)

## Skipped

- backfill_renewal_outcomes.py: renewal_alerts table is empty in prod (0 rows), script naturally returns total=0. No fix needed.
- commission_engine.py:89 broken-path fix: out of scope, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)