### PR TITLE
hotfix(scripts): IDR-mistag heuristic in compute_client_segments

### DIFF
--- a/apps/backend-rag/backend/tests/scripts/test_compute_client_segments.py
+++ b/apps/backend-rag/backend/tests/scripts/test_compute_client_segments.py
@@ -52,6 +52,23 @@ class TestAmountToUsd:
     def test_lowercase_currency_normalized(self):
         assert amount_to_usd(1500, "usd") == 1500.0
 
+    def test_genuine_usd_below_threshold(self):
+        # $5000 USD genuino — below 50k threshold, no heuristic
+        assert amount_to_usd(5000, "USD") == 5000.0
+
+    def test_idr_mistag_heuristic_triggers_above_threshold(self):
+        # 31M "USD" → almost certainly IDR mistag → ~$2000
+        assert amount_to_usd(31_000_000, "USD") == pytest.approx(2000.0, rel=1e-3)
+
+    def test_idr_mistag_heuristic_at_exact_threshold(self):
+        # 50k exactly USD → genuino, no heuristic
+        assert amount_to_usd(50_000, "USD") == 50_000.0
+
+    def test_idr_mistag_heuristic_just_above_threshold(self):
+        # 50k+1 → triggers heuristic
+        result = amount_to_usd(50_001, "USD")
+        assert result < 100  # ~$3.2 if treated as IDR
+
 
 class TestComputeLtvUsd:
     def test_completed_practice_with_actual_price(self):

--- a/apps/backend-rag/scripts/compute_client_segments.py
+++ b/apps/backend-rag/scripts/compute_client_segments.py
@@ -50,15 +50,32 @@ CURRENCY_TO_USD: dict[str, float] = {
 }
 
 
+# Heuristic threshold: amounts above this with currency='USD' are almost
+# certainly IDR mistagged (Bali Zero realistic max single practice ~$5000).
+# See data quality investigation 2026-05-01: 190/218 completed practices
+# had IDR-magnitude amounts with currency='USD' label.
+IDR_MISTAG_THRESHOLD_USD: float = 50_000.0
+
+
 def amount_to_usd(amount: float | None, currency: str | None) -> float:
-    """Convert amount to USD using static rate table.
+    """Convert amount to USD using static rate table + IDR-mistag heuristic.
 
     Unknown currency → treated as USD passthrough (logs warning).
     None / 0 / negative → 0.
+    Heuristic: if currency='USD' but amount > 50k, treat as IDR mistag.
     """
     if amount is None or amount <= 0:
         return 0.0
     cur = (currency or "USD").upper()
+
+    # IDR-mistag heuristic: large "USD" amounts are almost always IDR
+    # entered with the wrong currency tag in the practices form.
+    if cur == "USD" and float(amount) > IDR_MISTAG_THRESHOLD_USD:
+        logger.debug(
+            f"IDR-mistag detected: amount={amount} currency=USD; treating as IDR"
+        )
+        return float(amount) * CURRENCY_TO_USD["IDR"]
+
     rate = CURRENCY_TO_USD.get(cur)
     if rate is None:
         logger.warning(f"Unknown currency {cur!r}, treating as USD passthrough")


### PR DESCRIPTION
Data quality fix. 190/218 completed practices have IDR amounts mistagged as USD. Heuristic: amount > 50k 'USD' → treat as IDR. Tests: 27/27 pass. After deploy + re-run, tier distribution will be realistic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)