### PR TITLE
feat(cell-core): observatory emitter + pulse hook (PR-1)

### DIFF
--- a/packages/cell-core/cell_core/__init__.py
+++ b/packages/cell-core/cell_core/__init__.py
@@ -10,6 +10,7 @@ from cell_core.reasoner import ReasonerFramework, TierConfig
 from cell_core.safety import DNAInterpreter, DNAIntegrityError, DNALoader, SafetyGate
 from cell_core.metabolic import MetabolicSnapshot, MetabolicStore, MetricValue, TrendAnalyzer
 from cell_core.observability import CardinalityGuard, CellMetricsExporter, PulseMetrics
+from cell_core import observatory  # noqa: F401 — opt-in emit module
 from cell_core.types import (
     CellConfig,
     DNAConfig,
@@ -38,4 +39,5 @@ __all__ = [
     "ReasonerFramework", "TierConfig",
     "MetabolicSnapshot", "MetabolicStore", "MetricValue", "TrendAnalyzer",
     "PulseMetrics", "CellMetricsExporter", "CardinalityGuard",
+    "observatory",
 ]

--- a/packages/cell-core/cell_core/observatory.py
+++ b/packages/cell-core/cell_core/observatory.py
@@ -27,3 +27,37 @@ _pool_lock_pid: Optional[int] = None  # detect fork without inherit
 def is_enabled() -> bool:
     """Return True iff CELL_OBSERVATORY_EMIT env var is the literal 'true' (case-insensitive)."""
     return os.environ.get("CELL_OBSERVATORY_EMIT", "").lower() == "true"
+
+
+async def _get_or_create_pool() -> Optional[asyncpg.Pool]:
+    """Return the lazy-initialized asyncpg pool, or None if EVENTBUS_DATABASE_URL is unset."""
+    global _pool, _pool_lock_pid
+
+    current_pid = os.getpid()
+    if _pool_lock_pid is not None and _pool_lock_pid != current_pid:
+        # Process forked since pool creation; pool is invalid in child.
+        _pool = None
+        _pool_lock_pid = None
+
+    if _pool is not None:
+        return _pool
+
+    dsn = os.environ.get("EVENTBUS_DATABASE_URL")
+    if not dsn:
+        return None
+
+    _pool = await asyncpg.create_pool(
+        dsn,
+        min_size=1,
+        max_size=3,
+        command_timeout=5.0,
+    )
+    _pool_lock_pid = current_pid
+    return _pool
+
+
+def _reset_pool_for_tests() -> None:
+    """Internal test hook — DO NOT use in production."""
+    global _pool, _pool_lock_pid
+    _pool = None
+    _pool_lock_pid = None

--- a/packages/cell-core/cell_core/observatory.py
+++ b/packages/cell-core/cell_core/observatory.py
@@ -1,0 +1,29 @@
+"""Cell pulse observatory emitter.
+
+Writes pulse events directly to the EventBus events_outbox via asyncpg,
+then triggers pg_notify on the 'cell_pulse_observed' channel. Designed
+to run inside any cell process (standalone LaunchAgent or in-app), with
+NO dependency on backend-rag's Python package — that was BLOCKER B1
+from the 2026-05-01 cross-LLM review.
+
+Failures are swallowed (WARN log) — pulse loop must NEVER block on
+observability.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Optional
+
+import asyncpg
+
+logger = logging.getLogger(__name__)
+
+_pool: Optional[asyncpg.Pool] = None
+_pool_lock_pid: Optional[int] = None  # detect fork without inherit
+
+
+def is_enabled() -> bool:
+    """Return True iff CELL_OBSERVATORY_EMIT env var is the literal 'true' (case-insensitive)."""
+    return os.environ.get("CELL_OBSERVATORY_EMIT", "").lower() == "true"

--- a/packages/cell-core/cell_core/observatory.py
+++ b/packages/cell-core/cell_core/observatory.py
@@ -14,13 +14,14 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import Any, Optional
+from typing import Any, Optional, TYPE_CHECKING
 
-import asyncpg
+if TYPE_CHECKING:
+    import asyncpg
 
 logger = logging.getLogger(__name__)
 
-_pool: Optional[asyncpg.Pool] = None
+_pool: Optional["asyncpg.Pool"] = None
 _pool_lock_pid: Optional[int] = None  # detect fork without inherit
 
 
@@ -29,9 +30,18 @@ def is_enabled() -> bool:
     return os.environ.get("CELL_OBSERVATORY_EMIT", "").lower() == "true"
 
 
-async def _get_or_create_pool() -> Optional[asyncpg.Pool]:
-    """Return the lazy-initialized asyncpg pool, or None if EVENTBUS_DATABASE_URL is unset."""
+async def _get_or_create_pool() -> "Optional[asyncpg.Pool]":
+    """Return the lazy-initialized asyncpg pool, or None if EVENTBUS_DATABASE_URL is unset.
+
+    Returns None also when asyncpg is not installed (cell-core installed
+    without the [postgres] optional extra).
+    """
     global _pool, _pool_lock_pid
+    try:
+        import asyncpg
+    except ImportError:
+        # Cell-core installed without [postgres] extra; observatory disabled.
+        return None
 
     current_pid = os.getpid()
     if _pool_lock_pid is not None and _pool_lock_pid != current_pid:
@@ -65,7 +75,7 @@ def _reset_pool_for_tests() -> None:
 
 _INSERT_SQL = (
     "INSERT INTO events_outbox (channel, payload) "
-    "VALUES ($1, $2) RETURNING outbox_id"
+    "VALUES ($1, $2) RETURNING id"
 )
 _NOTIFY_SQL = "SELECT pg_notify($1, $2)"
 
@@ -112,7 +122,7 @@ async def emit_pulse_observed(
         async with pool.acquire() as conn:
             async with conn.transaction():
                 row = await conn.fetchrow(_INSERT_SQL, "cell_pulse_observed", json.dumps(payload))
-                outbox_id = row["outbox_id"]
+                outbox_id = int(row["id"])
                 payload["_outbox_id"] = outbox_id
                 await conn.execute(_NOTIFY_SQL, "cell_pulse_observed", json.dumps(payload))
     except Exception as exc:

--- a/packages/cell-core/cell_core/observatory.py
+++ b/packages/cell-core/cell_core/observatory.py
@@ -61,3 +61,62 @@ def _reset_pool_for_tests() -> None:
     global _pool, _pool_lock_pid
     _pool = None
     _pool_lock_pid = None
+
+
+_INSERT_SQL = (
+    "INSERT INTO events_outbox (channel, payload) "
+    "VALUES ($1, $2) RETURNING outbox_id"
+)
+_NOTIFY_SQL = "SELECT pg_notify($1, $2)"
+
+
+async def emit_pulse_observed(
+    cell_id: str,
+    cell_kind: str,
+    pulse_id: str,
+    pulse_timestamp_ms: int,
+    phase: str,
+    sensors: list[dict[str, Any]],
+    pulse_result: dict[str, Any],
+    homeostatic_state: dict[str, Any],
+    scar_signals: Optional[list[dict[str, Any]]] = None,
+    metadata: Optional[dict[str, Any]] = None,
+) -> None:
+    """Emit a pulse-observed event to events_outbox + pg_notify.
+
+    No-op when CELL_OBSERVATORY_EMIT != 'true' or EVENTBUS_DATABASE_URL is unset.
+    Errors are swallowed (WARN log) — caller MUST NOT block on this.
+    """
+    if not is_enabled():
+        return
+
+    try:
+        pool = await _get_or_create_pool()
+        if pool is None:
+            return
+
+        payload: dict[str, Any] = {
+            "event_version": "v1",
+            "cell_id": cell_id,
+            "cell_kind": cell_kind,
+            "pulse_id": pulse_id,
+            "pulse_timestamp": pulse_timestamp_ms,
+            "phase": phase,
+            "sensors": sensors,
+            "pulse_result": pulse_result,
+            "homeostatic_state": homeostatic_state,
+            "scar_signals": scar_signals or [],
+            "metadata": metadata or {},
+        }
+
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                row = await conn.fetchrow(_INSERT_SQL, "cell_pulse_observed", json.dumps(payload))
+                outbox_id = row["outbox_id"]
+                payload["_outbox_id"] = outbox_id
+                await conn.execute(_NOTIFY_SQL, "cell_pulse_observed", json.dumps(payload))
+    except Exception as exc:
+        logger.warning(
+            "cell_observatory emit failed (non-blocking): cell=%s pulse=%s err=%s",
+            cell_id, pulse_id, exc,
+        )

--- a/packages/cell-core/cell_core/pulse.py
+++ b/packages/cell-core/cell_core/pulse.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
+import socket
 import time
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
@@ -246,7 +248,7 @@ class PulseLoop:
                 _m.observe_genome(_cell, self.genome)
                 _m.observe_genome_tiers(_cell, self.genome)
 
-        return PulseResult(
+        pulse_result = PulseResult(
             timestamp=now,
             pulse_number=self.pulse_count,
             health_status=worst_status,
@@ -254,6 +256,48 @@ class PulseLoop:
             action_reason=proposal.reason if action_taken else None,
             thought_tier=proposal.tier_used if should_think else None,
         )
+
+        # NEW (B2 fix from cross-LLM review): fire-and-forget observatory emit.
+        # Wrapped in try/except so a misconfigured observatory cannot break
+        # the homeostatic loop.
+        try:
+            from cell_core import observatory
+            if observatory.is_enabled():
+                asyncio.create_task(observatory.emit_pulse_observed(
+                    cell_id=self.config.name,
+                    cell_kind="cell",
+                    pulse_id=pulse_result.pulse_id,
+                    pulse_timestamp_ms=int(now.timestamp() * 1000),
+                    phase="active",
+                    sensors=[
+                        {
+                            "name": r.sensor_name,
+                            "status": r.status,
+                            "value": r.value,
+                            "timestamp": r.timestamp.isoformat() if r.timestamp else None,
+                            "metadata": r.metadata,
+                        }
+                        for r in readings
+                    ],
+                    pulse_result={
+                        "classifier_self": worst_status,
+                        "trend_window_min": None,
+                        "trend_label": None,
+                    },
+                    homeostatic_state={
+                        "energy_pct": getattr(state, "energy_pct", None),
+                        "load_factor": getattr(state, "load_factor", None),
+                    },
+                    scar_signals=[],
+                    metadata={
+                        "host": socket.gethostname(),
+                        "machine_role": os.environ.get("MACHINE_ROLE", "unknown"),
+                    },
+                ))
+        except Exception as exc:
+            logger.warning("observatory hook scheduling error (non-blocking): %s", exc)
+
+        return pulse_result
 
     @staticmethod
     def _worst_status(readings: list[SensorReading]) -> str:

--- a/packages/cell-core/cell_core/pulse.py
+++ b/packages/cell-core/cell_core/pulse.py
@@ -285,8 +285,12 @@ class PulseLoop:
                         "trend_label": None,
                     },
                     homeostatic_state={
-                        "energy_pct": getattr(state, "energy_pct", None),
-                        "load_factor": getattr(state, "load_factor", None),
+                        "stress_level": state.stress_level,
+                        "energy_level": state.energy_level,
+                        "arousal": state.arousal,
+                        "comfort_zone": list(state.comfort_zone),
+                        "setpoint_rt_ms": state.setpoint_rt_ms,
+                        "circadian_phase": state.circadian_phase,
                     },
                     scar_signals=[],
                     metadata={

--- a/packages/cell-core/tests/test_observatory.py
+++ b/packages/cell-core/tests/test_observatory.py
@@ -1,0 +1,25 @@
+import os
+import pytest
+from cell_core import observatory
+
+
+def test_is_enabled_default_false(monkeypatch):
+    monkeypatch.delenv("CELL_OBSERVATORY_EMIT", raising=False)
+    assert observatory.is_enabled() is False
+
+
+def test_is_enabled_when_true(monkeypatch):
+    monkeypatch.setenv("CELL_OBSERVATORY_EMIT", "true")
+    assert observatory.is_enabled() is True
+
+
+def test_is_enabled_case_insensitive(monkeypatch):
+    monkeypatch.setenv("CELL_OBSERVATORY_EMIT", "TRUE")
+    assert observatory.is_enabled() is True
+
+
+def test_is_enabled_other_values_are_false(monkeypatch):
+    monkeypatch.setenv("CELL_OBSERVATORY_EMIT", "yes")
+    assert observatory.is_enabled() is False
+    monkeypatch.setenv("CELL_OBSERVATORY_EMIT", "1")
+    assert observatory.is_enabled() is False

--- a/packages/cell-core/tests/test_observatory.py
+++ b/packages/cell-core/tests/test_observatory.py
@@ -98,7 +98,7 @@ async def test_emit_pulse_observed_writes_outbox_and_notifies(monkeypatch):
         async def fetchrow(self, sql, *args):
             captured["insert_sql"] = sql
             captured["insert_args"] = args
-            return {"outbox_id": 42}
+            return {"id": 42}
 
         async def execute(self, sql, *args):
             captured["notify_sql"] = sql
@@ -136,6 +136,7 @@ async def test_emit_pulse_observed_writes_outbox_and_notifies(monkeypatch):
     )
 
     assert "INSERT INTO events_outbox" in captured["insert_sql"]
+    assert "RETURNING id" in captured["insert_sql"]  # pins schema contract: PK is 'id', not 'outbox_id'
     assert captured["insert_args"][0] == "cell_pulse_observed"
     payload = json.loads(captured["insert_args"][1])
     assert payload["cell_id"] == "organism"
@@ -168,3 +169,31 @@ async def test_emit_pulse_observed_swallows_db_errors(monkeypatch, caplog):
         sensors=[], pulse_result={}, homeostatic_state={},
     )
     assert any("emit failed" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_pool_returns_none_if_asyncpg_missing(monkeypatch):
+    """When asyncpg is not installed, _get_or_create_pool returns None silently."""
+    monkeypatch.setenv("EVENTBUS_DATABASE_URL", "postgresql://x/y")
+    from cell_core import observatory
+    observatory._reset_pool_for_tests()
+
+    # Simulate asyncpg ImportError by removing it from sys.modules + blocking import
+    import sys
+    saved = sys.modules.pop("asyncpg", None)
+    try:
+        # Insert a sentinel that raises ImportError when 'asyncpg' is imported
+        class _BlockedFinder:
+            def find_module(self, name, path=None):
+                if name == "asyncpg":
+                    raise ImportError("blocked by test")
+                return None
+        sys.meta_path.insert(0, _BlockedFinder())
+        try:
+            pool = await observatory._get_or_create_pool()
+            assert pool is None
+        finally:
+            sys.meta_path.pop(0)
+    finally:
+        if saved is not None:
+            sys.modules["asyncpg"] = saved

--- a/packages/cell-core/tests/test_observatory.py
+++ b/packages/cell-core/tests/test_observatory.py
@@ -1,3 +1,4 @@
+import json
 import os
 import pytest
 from cell_core import observatory
@@ -63,3 +64,107 @@ async def test_get_or_create_pool_returns_none_if_url_unset(monkeypatch):
     observatory._reset_pool_for_tests()
     pool = await observatory._get_or_create_pool()
     assert pool is None
+
+
+@pytest.mark.asyncio
+async def test_emit_pulse_observed_disabled_no_op(monkeypatch):
+    monkeypatch.delenv("CELL_OBSERVATORY_EMIT", raising=False)
+    from cell_core import observatory
+    observatory._reset_pool_for_tests()
+
+    # Should NOT call create_pool when disabled
+    import asyncpg
+    monkeypatch.setattr(asyncpg, "create_pool",
+                        lambda *a, **kw: pytest.fail("must not call create_pool when disabled"))
+
+    await observatory.emit_pulse_observed(
+        cell_id="test", cell_kind="test", pulse_id="01ABC",
+        pulse_timestamp_ms=0, phase="homeostatic",
+        sensors=[], pulse_result={}, homeostatic_state={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_emit_pulse_observed_writes_outbox_and_notifies(monkeypatch):
+    monkeypatch.setenv("CELL_OBSERVATORY_EMIT", "true")
+    monkeypatch.setenv("EVENTBUS_DATABASE_URL", "postgresql://fake/db")
+
+    from cell_core import observatory
+    observatory._reset_pool_for_tests()
+
+    captured = {"insert_sql": None, "notify_sql": None, "insert_args": None, "notify_args": None}
+
+    class FakeConn:
+        async def fetchrow(self, sql, *args):
+            captured["insert_sql"] = sql
+            captured["insert_args"] = args
+            return {"outbox_id": 42}
+
+        async def execute(self, sql, *args):
+            captured["notify_sql"] = sql
+            captured["notify_args"] = args
+
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): pass
+
+    class FakeTx:
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): pass
+
+    class FakeConnContext:
+        def __init__(self, conn): self.conn = conn
+        async def __aenter__(self): return self.conn
+        async def __aexit__(self, *a): pass
+
+    fake_conn = FakeConn()
+    fake_conn.transaction = lambda: FakeTx()
+
+    class FakePool:
+        def acquire(self): return FakeConnContext(fake_conn)
+
+    async def fake_create_pool(*a, **kw):
+        return FakePool()
+
+    import asyncpg
+    monkeypatch.setattr(asyncpg, "create_pool", fake_create_pool)
+
+    await observatory.emit_pulse_observed(
+        cell_id="organism", cell_kind="innervation",
+        pulse_id="01TEST", pulse_timestamp_ms=1000,
+        phase="homeostatic", sensors=[],
+        pulse_result={"classifier_self": "green"}, homeostatic_state={"energy_pct": 80},
+    )
+
+    assert "INSERT INTO events_outbox" in captured["insert_sql"]
+    assert captured["insert_args"][0] == "cell_pulse_observed"
+    payload = json.loads(captured["insert_args"][1])
+    assert payload["cell_id"] == "organism"
+    assert payload["pulse_id"] == "01TEST"
+
+    assert "pg_notify" in captured["notify_sql"]
+    assert captured["notify_args"][0] == "cell_pulse_observed"
+    notify_payload = json.loads(captured["notify_args"][1])
+    assert notify_payload["_outbox_id"] == 42  # injected after insert
+
+
+@pytest.mark.asyncio
+async def test_emit_pulse_observed_swallows_db_errors(monkeypatch, caplog):
+    monkeypatch.setenv("CELL_OBSERVATORY_EMIT", "true")
+    monkeypatch.setenv("EVENTBUS_DATABASE_URL", "postgresql://fake/db")
+
+    from cell_core import observatory
+    observatory._reset_pool_for_tests()
+
+    async def fake_create_pool(*a, **kw):
+        raise asyncpg.PostgresError("connection refused")
+
+    import asyncpg
+    monkeypatch.setattr(asyncpg, "create_pool", fake_create_pool)
+
+    # Must NOT raise
+    await observatory.emit_pulse_observed(
+        cell_id="test", cell_kind="test", pulse_id="01X",
+        pulse_timestamp_ms=0, phase="homeostatic",
+        sensors=[], pulse_result={}, homeostatic_state={},
+    )
+    assert any("emit failed" in r.message for r in caplog.records)

--- a/packages/cell-core/tests/test_observatory.py
+++ b/packages/cell-core/tests/test_observatory.py
@@ -23,3 +23,43 @@ def test_is_enabled_other_values_are_false(monkeypatch):
     assert observatory.is_enabled() is False
     monkeypatch.setenv("CELL_OBSERVATORY_EMIT", "1")
     assert observatory.is_enabled() is False
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_pool_returns_pool(monkeypatch):
+    """Lazy-init pool from EVENTBUS_DATABASE_URL env var."""
+    monkeypatch.setenv("EVENTBUS_DATABASE_URL", "postgresql://invalid-host/test")
+
+    # Pool creation is lazy; we just verify the function returns a callable that
+    # produces an asyncpg.Pool object (we don't actually connect — the URL is fake).
+    from cell_core import observatory
+    observatory._reset_pool_for_tests()  # test hook
+
+    # We mock asyncpg.create_pool to avoid real network call
+    import asyncpg
+    called = {}
+
+    async def fake_create_pool(dsn, **kwargs):
+        called["dsn"] = dsn
+        called["kwargs"] = kwargs
+        # Return a minimal mock pool
+        class _MockPool:
+            async def close(self): pass
+        return _MockPool()
+
+    monkeypatch.setattr(asyncpg, "create_pool", fake_create_pool)
+
+    pool = await observatory._get_or_create_pool()
+    assert pool is not None
+    assert called["dsn"] == "postgresql://invalid-host/test"
+    assert called["kwargs"]["min_size"] == 1
+    assert called["kwargs"]["max_size"] == 3
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_pool_returns_none_if_url_unset(monkeypatch):
+    monkeypatch.delenv("EVENTBUS_DATABASE_URL", raising=False)
+    from cell_core import observatory
+    observatory._reset_pool_for_tests()
+    pool = await observatory._get_or_create_pool()
+    assert pool is None

--- a/packages/cell-core/tests/test_pulse_observatory_hook.py
+++ b/packages/cell-core/tests/test_pulse_observatory_hook.py
@@ -1,0 +1,118 @@
+"""Tests for pulse.single_pulse fire-and-forget observatory hook (BLOCKER B2 fix).
+
+Verifies:
+1. When CELL_OBSERVATORY_EMIT=true, single_pulse schedules emit_pulse_observed.
+2. A slow observatory emit does NOT delay the pulse cycle return (<1s).
+3. When CELL_OBSERVATORY_EMIT is unset, no emit task is scheduled.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from conftest import (
+    FakeActor, FakeEpisodic, FakeLTM, FakeSensor, FakeSTM, FakeThinker,
+)
+from cell_core.types import CellConfig, SafetyCheckResult
+
+
+def _make_pulse_loop(config=None, sensors=None):
+    """Minimal PulseLoop for observatory hook tests."""
+    from cell_core.pulse import PulseLoop
+    from cell_core.lifecycle import Maturation
+    from cell_core.homeostasis import HomeostaticController
+
+    if config is None:
+        config = CellConfig(
+            name="test-cell",
+            dna_path="/tmp/fake-dna.yaml",
+            birth_date=datetime.now(timezone.utc) - timedelta(days=50),
+        )
+
+    class FakeSafetyGate:
+        async def check(self):
+            return SafetyCheckResult(can_proceed=True)
+
+    return PulseLoop(
+        config=config,
+        sensors=sensors or [FakeSensor()],
+        thinker=FakeThinker(),
+        actor=FakeActor(),
+        stm=FakeSTM(),
+        ltm=FakeLTM(),
+        episodic=FakeEpisodic(),
+        lifecycle=Maturation(config.birth_date),
+        safety=FakeSafetyGate(),
+        homeostasis=HomeostaticController(config.sleep_hours),
+    )
+
+
+@pytest.mark.asyncio
+async def test_single_pulse_emits_to_observatory_when_enabled(monkeypatch):
+    """When CELL_OBSERVATORY_EMIT=true, single_pulse schedules a fire-and-forget emit."""
+    monkeypatch.setenv("CELL_OBSERVATORY_EMIT", "true")
+
+    from cell_core import observatory
+
+    fake_emit = AsyncMock()
+    monkeypatch.setattr(observatory, "emit_pulse_observed", fake_emit)
+    monkeypatch.setattr(observatory, "is_enabled", lambda: True)
+
+    loop = _make_pulse_loop()
+    result = await loop.single_pulse()
+
+    # Allow the fire-and-forget create_task to run
+    await asyncio.sleep(0)
+
+    fake_emit.assert_called_once()
+    call_kwargs = fake_emit.call_args.kwargs
+    assert call_kwargs["cell_id"] == "test-cell"
+    assert call_kwargs["pulse_id"] == result.pulse_id
+    assert call_kwargs["cell_kind"] == "cell"
+    assert call_kwargs["phase"] == "active"
+    assert isinstance(call_kwargs["sensors"], list)
+    assert "classifier_self" in call_kwargs["pulse_result"]
+
+
+@pytest.mark.asyncio
+async def test_single_pulse_does_not_block_on_emit(monkeypatch):
+    """A slow observatory emit MUST NOT delay the pulse cycle return (<1s)."""
+    monkeypatch.setenv("CELL_OBSERVATORY_EMIT", "true")
+
+    from cell_core import observatory
+
+    async def slow_emit(**kw):
+        await asyncio.sleep(5.0)
+
+    monkeypatch.setattr(observatory, "emit_pulse_observed", slow_emit)
+    monkeypatch.setattr(observatory, "is_enabled", lambda: True)
+
+    loop = _make_pulse_loop()
+
+    start = time.monotonic()
+    await loop.single_pulse()
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 1.0, f"pulse blocked on observatory: {elapsed:.3f}s"
+
+
+@pytest.mark.asyncio
+async def test_single_pulse_no_emit_when_disabled(monkeypatch):
+    """When CELL_OBSERVATORY_EMIT is unset, NO emit task is scheduled."""
+    monkeypatch.delenv("CELL_OBSERVATORY_EMIT", raising=False)
+
+    from cell_core import observatory
+
+    fake_emit = AsyncMock()
+    monkeypatch.setattr(observatory, "emit_pulse_observed", fake_emit)
+    monkeypatch.setattr(observatory, "is_enabled", lambda: False)
+
+    loop = _make_pulse_loop()
+    await loop.single_pulse()
+    await asyncio.sleep(0)
+
+    fake_emit.assert_not_called()

--- a/packages/cell-core/tests/test_pulse_observatory_hook.py
+++ b/packages/cell-core/tests/test_pulse_observatory_hook.py
@@ -80,13 +80,16 @@ async def test_single_pulse_emits_to_observatory_when_enabled(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_single_pulse_does_not_block_on_emit(monkeypatch):
-    """A slow observatory emit MUST NOT delay the pulse cycle return (<1s)."""
+    """Slow observatory emit MUST NOT delay pulse cycle return."""
     monkeypatch.setenv("CELL_OBSERVATORY_EMIT", "true")
 
     from cell_core import observatory
 
+    scheduled = {"flag": False}  # captured by slow_emit closure
+
     async def slow_emit(**kw):
-        await asyncio.sleep(5.0)
+        scheduled["flag"] = True  # synchronous mark BEFORE the sleep
+        await asyncio.sleep(5.0)  # simulates slow Postgres
 
     monkeypatch.setattr(observatory, "emit_pulse_observed", slow_emit)
     monkeypatch.setattr(observatory, "is_enabled", lambda: True)
@@ -94,9 +97,16 @@ async def test_single_pulse_does_not_block_on_emit(monkeypatch):
     loop = _make_pulse_loop()
 
     start = time.monotonic()
-    await loop.single_pulse()
+    result = await loop.single_pulse()
     elapsed = time.monotonic() - start
 
+    # Allow the create_task'd coroutine to start
+    await asyncio.sleep(0)
+
+    # Both assertions are required:
+    # 1. The slow_emit was actually SCHEDULED (not just absent)
+    # 2. The pulse cycle did NOT block on it
+    assert scheduled["flag"] is True, "slow_emit was never scheduled — hook may be missing"
     assert elapsed < 1.0, f"pulse blocked on observatory: {elapsed:.3f}s"
 
 


### PR DESCRIPTION
## Summary

PR-1 of Cell Pulse Observatory implementation. Implements §6 of design spec
and resolves cross-LLM review BLOCKERS B1, B2, B4.

### What

New module `packages/cell-core/cell_core/observatory.py` providing:
- `is_enabled()` — env-controlled flag (`CELL_OBSERVATORY_EMIT=true`)
- `_get_or_create_pool()` — fork-safe asyncpg pool with PID-based fork detection
- `emit_pulse_observed()` — direct asyncpg INSERT to events_outbox + pg_notify, _outbox_id injection, all swallow-on-error

Hook in `packages/cell-core/cell_core/pulse.py` — `single_pulse()` schedules
a fire-and-forget `asyncio.create_task(observatory.emit_pulse_observed(...))`
on the NORMAL pulse path (not halted). Pulse cycle never blocks on observatory.

### Cross-LLM blockers resolved

- **B1 (Gemini + DeepSeek)** — Lazy import of `backend.services.events.EventBus`
  would have silently no-op'd for ALL standalone cells. Replaced with direct
  asyncpg path.
- **B2 (Gemini)** — `await observatory.emit_pulse_observed(...)` would block
  pulse loop on Postgres latency. Replaced with `asyncio.create_task(...)`.
- **B4 (DeepSeek)** — Channel name `cell_pulse_observed` validated against
  `outbox.validate_channel` regex. `_outbox_id` injection via INSERT RETURNING id.

### Code quality issues caught during PR review

Pre-emptive fixes from per-task code-quality review:
- SQL `RETURNING outbox_id` was wrong (column is `id` per migration 144) — fixed
- `import asyncpg` module-level conflicted with `[postgres]` optional extra — lazy import
- HomeostaticState fields `energy_pct`/`load_factor` don't exist — mapped to real fields
- B2 regression test was tautological — added synchronous flag mechanism

### Test plan

- [x] `pytest packages/cell-core/tests/test_observatory.py -v` — 10 PASS
- [x] `pytest packages/cell-core/tests/test_pulse_observatory_hook.py -v` — 3 PASS
- [x] `pytest packages/cell-core/tests/ -q` — 273 passed, 30 skipped, 0 failed
- [x] Empirical tautology check: removing hook → test 2 fails as expected

### Deferred to follow-up
- asyncpg in `[postgres]` optional extra — module imports lazy, runs without it
- cell_kind/phase hardcoded "cell"/"active" v1 — to be sourced from CellConfig.kind + Maturation in fase 1
- Pulse-storm OOM (G1) — bounded queue lives in collector (PR-3), not in cell-core emit
- ScarDetector wiring (M7) — fase 1+ work

🤖 Generated with [Claude Code](https://claude.com/claude-code)