### PR TITLE
feat(events): register cell_pulse_observed PG channel (PR-2)

### DIFF
--- a/apps/backend-rag/backend/services/events/event_bus.py
+++ b/apps/backend-rag/backend/services/events/event_bus.py
@@ -82,6 +82,14 @@ PG_CHANNEL_MAP: dict[str, str] = {
     #   {v: 1, proposal_id, run_id, idempotency_key, source, severity,
     #    action_hint, _outbox_id}
     "federation_alert": "federation.alert",
+    # Emitted by cell_core.observatory.emit_pulse_observed() (PR-1, 2026-05-01)
+    # for any cell with CELL_OBSERVATORY_EMIT=true. Payload v1:
+    # {event_version, cell_id, cell_kind, pulse_id, pulse_timestamp,
+    #  phase, sensors[], pulse_result{classifier_self,...},
+    #  homeostatic_state{stress_level,energy_level,...}, scar_signals[],
+    #  metadata{host,machine_role,...}, _outbox_id}.
+    # Consumer: apps/cell-observatory-collector (PR-3, Pro local SQLite).
+    "cell_pulse_observed": "cell.pulse.observed",
 }
 
 _RECONNECT_DELAY_S = 5

--- a/apps/backend-rag/backend/tests/services/events/test_channels.py
+++ b/apps/backend-rag/backend/tests/services/events/test_channels.py
@@ -1,0 +1,15 @@
+"""Test PG_CHANNEL_MAP registration for cell_pulse_observed."""
+
+
+def test_cell_pulse_observed_channel_registered():
+    from backend.services.events.event_bus import PG_CHANNEL_MAP
+    assert "cell_pulse_observed" in PG_CHANNEL_MAP
+    # Event type must follow dotted convention
+    event_type = PG_CHANNEL_MAP["cell_pulse_observed"]
+    assert "." in event_type, f"event_type {event_type!r} must use dotted notation"
+
+
+def test_cell_pulse_observed_channel_name_matches_outbox_validation():
+    """The channel name must satisfy outbox.validate_channel regex."""
+    from backend.services.events.outbox import validate_channel
+    validate_channel("cell_pulse_observed")  # raises if invalid


### PR DESCRIPTION
## Summary

PR-2 of Cell Pulse Observatory implementation. Registers the `cell_pulse_observed` PG channel in `PG_CHANNEL_MAP` so the EventBus listener knows about it.

### What

Added entry to `apps/backend-rag/backend/services/events/event_bus.py`:

\`\`\`python
\"cell_pulse_observed\": \"cell.pulse.observed\",
\`\`\`

Channel is emitted by \`cell_core.observatory.emit_pulse_observed()\` (PR-1, merged in d55c5ccde). Channel name passes \`outbox.validate_channel\` regex (PR-0 Task 0.1 verified).

### Test plan

- [x] \`pytest backend/tests/services/events/test_channels.py -v\` — 2 PASS
- [x] Existing PG_CHANNEL_MAP entries unchanged

### Defer

Consumer (\`apps/cell-observatory-collector\`) ships in PR-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)