### PR TITLE
feat(observatory): cell-observatory-collector service (PR-3)

### DIFF
--- a/apps/cell-observatory-collector/README.md
+++ b/apps/cell-observatory-collector/README.md
@@ -1,0 +1,19 @@
+# cell-observatory-collector
+
+Pro-local Python service that listens to `cell_pulse_observed` PG channel,
+classifies events with MiniMax M2, and persists to local SQLite.
+
+Part of the Cell Pulse Observatory (Phase 0). See:
+- Spec: [`docs/superpowers/specs/2026-05-01-cell-observatory-fase0-design.md`](../../docs/superpowers/specs/2026-05-01-cell-observatory-fase0-design.md)
+- Plan: [`docs/superpowers/plans/2026-05-01-cell-observatory-fase0-implementation.md`](../../docs/superpowers/plans/2026-05-01-cell-observatory-fase0-implementation.md)
+
+## Components (filled in across PR-3 sub-tasks)
+
+- `cell_observatory/collector.py` — asyncpg LISTEN + dedup + dispatch (Task 3.6)
+- `cell_observatory/classifier.py` — MiniMax M2 client + prompt (Task 3.5)
+- `cell_observatory/storage.py` — SQLite WAL, idempotent insert (Task 3.4)
+- `cell_observatory/rollup.py` — daily rollup job (Task 3.7)
+- `cell_observatory/prune.py` — 90-day retention (Task 3.7)
+- `cell_observatory/api.py` — FastAPI loopback :17891 for dashboard (Task 3.8)
+- `cell_observatory/models.py` — Pydantic v2 schemas (Task 3.2)
+- `cell_observatory/config.py` — env-based config (Task 3.3)

--- a/apps/cell-observatory-collector/cell_observatory/__init__.py
+++ b/apps/cell-observatory-collector/cell_observatory/__init__.py
@@ -1,0 +1,2 @@
+"""Cell Pulse Observatory — listener + classifier + storage on Pro local."""
+__version__ = "0.1.0"

--- a/apps/cell-observatory-collector/cell_observatory/__main__.py
+++ b/apps/cell-observatory-collector/cell_observatory/__main__.py
@@ -1,0 +1,23 @@
+"""python -m cell_observatory — entrypoint for LaunchAgent."""
+import asyncio
+import structlog
+
+from cell_observatory.collector import run_collector
+from cell_observatory.api import run_api
+
+structlog.configure(processors=[
+    structlog.processors.add_log_level,
+    structlog.processors.TimeStamper(fmt="iso", utc=True),
+    structlog.processors.JSONRenderer(),
+])
+
+log = structlog.get_logger()
+
+
+async def main():
+    log.info("cell-observatory-collector starting", version="0.1.0")
+    await asyncio.gather(run_collector(), run_api())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/apps/cell-observatory-collector/cell_observatory/api.py
+++ b/apps/cell-observatory-collector/cell_observatory/api.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+import asyncio
+from datetime import datetime, timezone, timedelta
+from fastapi import FastAPI, Header, HTTPException, Request
+from typing import Optional
+
+from cell_observatory.config import Config
+from cell_observatory.storage import Storage
+
+
+async def build_app() -> tuple[FastAPI, Storage]:
+    cfg = Config.from_env()
+    storage = Storage(db_path=cfg.db_path)
+    await storage.init()
+
+    app = FastAPI(title="Cell Observatory API", version="0.1.0")
+
+    def _require_auth(x_observatory_key: Optional[str]) -> None:
+        if not cfg.api_key:
+            return
+        if x_observatory_key != cfg.api_key:
+            raise HTTPException(status_code=401, detail="Unauthorized")
+
+    @app.get("/api/observatory/health")
+    async def health(x_observatory_key: Optional[str] = Header(None, alias="X-Observatory-Key")):
+        _require_auth(x_observatory_key)
+        rows = await storage._fetchall("SELECT COUNT(*) AS n FROM pulse_events")
+        events_24h = await storage._fetchall(
+            "SELECT COUNT(*) AS n FROM pulse_events WHERE pulse_timestamp > ?",
+            ((datetime.now(timezone.utc) - timedelta(hours=24)).timestamp() * 1000,),
+        )
+        return {
+            "alive": True, "uptime_s": 0,  # stub for fase 0
+            "events_total": rows[0]["n"],
+            "events_24h": events_24h[0]["n"],
+        }
+
+    @app.get("/api/observatory/pulse")
+    async def list_pulses(
+        cell_id: Optional[str] = None,
+        since: Optional[str] = None,
+        limit: int = 100,
+        x_observatory_key: Optional[str] = Header(None, alias="X-Observatory-Key"),
+    ):
+        _require_auth(x_observatory_key)
+        clauses, params = [], []
+        if cell_id:
+            clauses.append("cell_id = ?"); params.append(cell_id)
+        if since:
+            since_ms = int(datetime.fromisoformat(since.replace("Z", "+00:00")).timestamp() * 1000)
+            clauses.append("pulse_timestamp >= ?"); params.append(since_ms)
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        params.append(min(limit, 1000))
+        rows = await storage._fetchall(
+            f"SELECT outbox_id, cell_id, pulse_id, pulse_timestamp, classifier_self "
+            f"FROM pulse_events {where} ORDER BY pulse_timestamp DESC LIMIT ?",
+            tuple(params),
+        )
+        return {"items": rows}
+
+    @app.get("/api/observatory/anomalies")
+    async def anomalies(
+        since: Optional[str] = None,
+        label: Optional[str] = None,
+        x_observatory_key: Optional[str] = Header(None, alias="X-Observatory-Key"),
+    ):
+        _require_auth(x_observatory_key)
+        clauses, params = [], []
+        if label:
+            clauses.append("c.label = ?"); params.append(label)
+        else:
+            clauses.append("c.label IN ('anomaly', 'critical', 'uncertain')")
+        if since:
+            since_ms = int(datetime.fromisoformat(since.replace("Z", "+00:00")).timestamp() * 1000)
+            clauses.append("c.classified_at >= ?"); params.append(since_ms)
+        where = "WHERE " + " AND ".join(clauses)
+        rows = await storage._fetchall(
+            f"SELECT c.outbox_id, c.label, c.confidence, c.reasoning, c.label_diff, "
+            f"e.cell_id, e.pulse_timestamp "
+            f"FROM pulse_classifications c JOIN pulse_events e ON e.outbox_id = c.outbox_id "
+            f"{where} ORDER BY c.confidence DESC LIMIT 100",
+            tuple(params),
+        )
+        return {"items": rows}
+
+    @app.get("/api/observatory/rollup")
+    async def rollup(
+        day: str,
+        cell_id: Optional[str] = None,
+        x_observatory_key: Optional[str] = Header(None, alias="X-Observatory-Key"),
+    ):
+        _require_auth(x_observatory_key)
+        if cell_id:
+            rows = await storage._fetchall(
+                "SELECT * FROM pulse_daily_rollup WHERE day = ? AND cell_id = ?", (day, cell_id),
+            )
+        else:
+            rows = await storage._fetchall("SELECT * FROM pulse_daily_rollup WHERE day = ?", (day,))
+        return {"items": rows}
+
+    @app.get("/api/observatory/cost")
+    async def cost(
+        since: Optional[str] = None,
+        x_observatory_key: Optional[str] = Header(None, alias="X-Observatory-Key"),
+    ):
+        _require_auth(x_observatory_key)
+        params = []
+        clause = ""
+        if since:
+            since_ms = int(datetime.fromisoformat(since.replace("Z", "+00:00")).timestamp() * 1000)
+            clause = "WHERE classified_at >= ?"
+            params.append(since_ms)
+        rows = await storage._fetchall(
+            f"SELECT SUM(cost_usd) AS total, COUNT(*) AS calls FROM pulse_classifications {clause}",
+            tuple(params),
+        )
+        return {"total_usd": rows[0]["total"] or 0.0, "calls": rows[0]["calls"] or 0,
+                "alert_threshold_usd": cfg.cost_alert_threshold_usd}
+
+    return app, storage
+
+
+async def run_api() -> None:
+    """Entrypoint used by __main__."""
+    import uvicorn
+    cfg = Config.from_env()
+    app, _ = await build_app()
+    config = uvicorn.Config(app, host="127.0.0.1", port=cfg.api_port, log_level="info")
+    server = uvicorn.Server(config)
+    await server.serve()

--- a/apps/cell-observatory-collector/cell_observatory/classifier.py
+++ b/apps/cell-observatory-collector/cell_observatory/classifier.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+import time
+from typing import Any
+import httpx
+from pydantic import ValidationError
+
+from cell_observatory.models import (
+    ClassificationLabel, ClassificationOutput, ClassificationResult, PulseEventV1
+)
+
+
+class CircuitOpenError(Exception):
+    """Raised when MiniMax circuit breaker is open."""
+
+
+_PROMPT_VERSION = "v1"
+_SYSTEM_PROMPT = """You are an SRE classifier for biological-cell-style health pulses.
+Given sensor readings + self-classification by the cell, output a JSON with:
+- reasoning: 1-2 sentences, what catches your attention or confirms normality
+- label: 'normal' | 'anomaly' | 'critical' | 'uncertain'
+- confidence: 0.0 to 1.0
+
+Rules:
+- 'normal' = sensors within expected band, no trend break
+- 'anomaly' = ONE sensor unusual but not failing, OR self-yellow with stable trend
+- 'critical' = multi-sensor failure, OR self-red, OR trend break crossing threshold
+- 'uncertain' = ambiguous, missing data, never seen pattern
+
+Confidence calibration: 0.9+ only when symptom matches known scar OR signals are unambiguous.
+
+Respond ONLY with valid JSON, no markdown."""
+
+
+def _render_user_prompt(event: PulseEventV1) -> str:
+    sensors_fmt = "\n".join(
+        f"- {s.get('name', '?')}: " + ", ".join(f"{k}={v}" for k, v in s.items() if k != "name")
+        for s in event.sensors
+    ) or "  (no sensors)"
+    return (
+        f"Cell: {event.cell_id} ({event.cell_kind}, phase={event.phase})\n"
+        f"Self-classification: {event.pulse_result.get('classifier_self', '?')}\n"
+        f"Sensors:\n{sensors_fmt}\n"
+        f"Trend: {event.pulse_result.get('trend_label', '?')} "
+        f"over {event.pulse_result.get('trend_window_min', '?')}min\n"
+        f"Homeostatic state: energy={event.homeostatic_state.get('energy_pct', '?')}%, "
+        f"load={event.homeostatic_state.get('load_factor', '?')}\n\n"
+        f"Classify."
+    )
+
+
+class MinimaxClassifier:
+    BASE_URL = "https://api.minimax.io/v1/chat/completions"
+    MODEL = "MiniMax-M2"
+    PRICE_INPUT_USD_PER_M = 0.30
+    PRICE_OUTPUT_USD_PER_M = 1.20
+
+    def __init__(self, api_key: str, circuit_threshold: int = 5,
+                 circuit_recovery_s: float = 60.0):
+        self._api_key = api_key
+        self._client = httpx.AsyncClient(timeout=10.0)
+        self._consecutive_failures = 0
+        self._circuit_threshold = circuit_threshold
+        self._circuit_open_until: float = 0.0
+        self._circuit_recovery_s = circuit_recovery_s
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def _call_api(self, messages: list[dict[str, str]]) -> dict[str, Any]:
+        resp = await self._client.post(
+            self.BASE_URL,
+            headers={"Authorization": f"Bearer {self._api_key}"},
+            json={"model": self.MODEL, "messages": messages, "temperature": 0.1, "max_tokens": 200},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def _check_circuit(self) -> None:
+        if time.monotonic() < self._circuit_open_until:
+            raise CircuitOpenError("MiniMax circuit open")
+
+    def _record_success(self) -> None:
+        self._consecutive_failures = 0
+
+    def _record_failure(self) -> None:
+        self._consecutive_failures += 1
+        if self._consecutive_failures >= self._circuit_threshold:
+            self._circuit_open_until = time.monotonic() + self._circuit_recovery_s
+
+    async def classify(self, event: PulseEventV1) -> ClassificationResult:
+        self._check_circuit()
+        start = time.monotonic()
+
+        messages = [
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": _render_user_prompt(event)},
+        ]
+
+        try:
+            resp = await self._call_api(messages)
+        except Exception:
+            self._record_failure()
+            raise
+        self._record_success()
+
+        latency_ms = int((time.monotonic() - start) * 1000)
+        content = resp["choices"][0]["message"]["content"]
+
+        try:
+            parsed = ClassificationOutput.model_validate_json(content)
+        except ValidationError:
+            # Retry once (PR #311 pattern); if second fail propagate
+            messages.append({"role": "assistant", "content": content})
+            messages.append({"role": "user", "content": "Output was not valid JSON. Re-emit ONLY the JSON object."})
+            resp2 = await self._call_api(messages)
+            content2 = resp2["choices"][0]["message"]["content"]
+            parsed = ClassificationOutput.model_validate_json(content2)
+
+        usage = resp.get("usage", {})
+        cost = (
+            usage.get("prompt_tokens", 0) / 1_000_000 * self.PRICE_INPUT_USD_PER_M
+            + usage.get("completion_tokens", 0) / 1_000_000 * self.PRICE_OUTPUT_USD_PER_M
+        )
+
+        cell_self = event.pulse_result.get("classifier_self", "unknown")
+        label_diff = "agree" if (
+            (cell_self == "green" and parsed.label == ClassificationLabel.NORMAL)
+            or (cell_self in ("yellow", "red") and parsed.label != ClassificationLabel.NORMAL)
+        ) else "disagree"
+
+        return ClassificationResult(
+            outbox_id=event.outbox_id,
+            label=parsed.label,
+            confidence=parsed.confidence,
+            reasoning=parsed.reasoning[:500],
+            label_diff=label_diff,
+            model=f"minimax-m2-{_PROMPT_VERSION}",
+            model_version=resp.get("model"),
+            cost_usd=round(cost, 6),
+            latency_ms=latency_ms,
+            error=None,
+        )

--- a/apps/cell-observatory-collector/cell_observatory/collector.py
+++ b/apps/cell-observatory-collector/cell_observatory/collector.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+import asyncio
+import json
+import structlog
+from typing import Any
+
+import asyncpg
+
+from cell_observatory.classifier import CircuitOpenError, MinimaxClassifier
+from cell_observatory.config import Config
+from cell_observatory.models import PulseEventV1
+from cell_observatory.storage import Storage
+
+log = structlog.get_logger(__name__)
+
+
+class Collector:
+    """Listens to cell_pulse_observed PG channel + replays unconsumed outbox rows."""
+
+    def __init__(
+        self,
+        storage: Storage,
+        classifier: MinimaxClassifier,
+        classifier_max_inflight: int = 50,
+        classifier_queue_maxsize: int = 10000,
+    ):
+        self.storage = storage
+        self.classifier = classifier
+        self._semaphore = asyncio.Semaphore(classifier_max_inflight)
+        self._classification_queue: asyncio.Queue = asyncio.Queue(maxsize=classifier_queue_maxsize)
+        self._classification_workers: list[asyncio.Task] = []
+
+    def _enqueue_for_classification(self, payload: dict[str, Any]) -> None:
+        """G1 fix: drop-oldest on overflow, log WARN."""
+        try:
+            self._classification_queue.put_nowait(payload)
+        except asyncio.QueueFull:
+            try:
+                dropped = self._classification_queue.get_nowait()
+                log.warning("classification queue full, dropped oldest",
+                            dropped_outbox_id=dropped.get("outbox_id"),
+                            new_outbox_id=payload.get("outbox_id"))
+                self._classification_queue.put_nowait(payload)
+            except asyncio.QueueEmpty:
+                pass
+
+    async def _classification_worker(self) -> None:
+        while True:
+            payload = await self._classification_queue.get()
+            try:
+                async with self._semaphore:
+                    event = PulseEventV1.model_validate(payload)
+                    try:
+                        result = await self.classifier.classify(event)
+                        await self.storage.upsert_classification(result.model_dump())
+                    except CircuitOpenError:
+                        log.warning("classifier circuit open, skipping",
+                                    outbox_id=event.outbox_id)
+                    except Exception as exc:
+                        log.error("classification failed",
+                                  outbox_id=event.outbox_id, error=str(exc))
+                        # Persist error row so backfill knows we tried
+                        await self.storage.upsert_classification({
+                            "outbox_id": event.outbox_id, "label": "uncertain",
+                            "confidence": 0.0, "reasoning": "",
+                            "label_diff": "agree", "model": "minimax-m2-v1",
+                            "model_version": None, "cost_usd": 0.0,
+                            "latency_ms": 0, "error": str(exc)[:500],
+                        })
+            finally:
+                self._classification_queue.task_done()
+
+    async def _replay_outbox_unconsumed(self, conn: asyncpg.Connection) -> None:
+        rows = await conn.fetch(
+            "SELECT outbox_id, payload FROM events_outbox "
+            "WHERE channel='cell_pulse_observed' AND consumed_at IS NULL "
+            "ORDER BY outbox_id ASC LIMIT 1000"
+        )
+        for row in rows:
+            try:
+                payload = json.loads(row["payload"])
+                payload["_outbox_id"] = row["outbox_id"]
+                inserted = await self.storage.insert_pulse_event(payload)
+                if inserted:
+                    self._enqueue_for_classification(payload)
+                await conn.execute(
+                    "UPDATE events_outbox SET consumed_at=NOW() WHERE outbox_id=$1",
+                    row["outbox_id"],
+                )
+            except Exception as exc:
+                log.warning("replay row failed", outbox_id=row["outbox_id"], error=str(exc))
+
+    def _on_notify(self, conn, pid, channel, payload_str):
+        try:
+            payload = json.loads(payload_str)
+        except json.JSONDecodeError:
+            log.warning("invalid notify payload", payload=payload_str[:200])
+            return
+        # Schedule the async work without blocking the listener
+        asyncio.create_task(self._handle_notification(payload))
+
+    async def _handle_notification(self, payload: dict[str, Any]) -> None:
+        try:
+            inserted = await self.storage.insert_pulse_event(payload)
+            if inserted:
+                self._enqueue_for_classification(payload)
+        except Exception as exc:
+            log.error("notification handling failed", error=str(exc))
+
+    async def run(self, db_url: str, num_workers: int = 4) -> None:
+        # Start classification workers
+        self._classification_workers = [
+            asyncio.create_task(self._classification_worker())
+            for _ in range(num_workers)
+        ]
+
+        while True:
+            try:
+                conn = await asyncpg.connect(db_url)
+                try:
+                    await conn.add_listener("cell_pulse_observed", self._on_notify)
+                    log.info("listener attached, replaying outbox")
+                    await self._replay_outbox_unconsumed(conn)
+                    log.info("replay complete, awaiting events")
+                    while True:
+                        await asyncio.sleep(30)
+                        # heartbeat
+                        await conn.execute("SELECT 1")
+                finally:
+                    await conn.close()
+            except (asyncpg.PostgresError, OSError) as exc:
+                log.warning("listener disconnected, retry in 5s", error=str(exc))
+                await asyncio.sleep(5)
+
+
+async def run_collector():
+    """Entrypoint used by __main__."""
+    cfg = Config.from_env()
+    storage = Storage(db_path=cfg.db_path)
+    await storage.init()
+    classifier = MinimaxClassifier(api_key=cfg.minimax_api_key)
+    collector = Collector(
+        storage=storage, classifier=classifier,
+        classifier_max_inflight=cfg.classifier_max_inflight,
+        classifier_queue_maxsize=cfg.classifier_queue_maxsize,
+    )
+    try:
+        await collector.run(cfg.eventbus_database_url)
+    finally:
+        await classifier.aclose()
+        await storage.close()

--- a/apps/cell-observatory-collector/cell_observatory/config.py
+++ b/apps/cell-observatory-collector/cell_observatory/config.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Config:
+    minimax_api_key: str
+    eventbus_database_url: str
+    db_path: Path
+    api_port: int
+    api_key: str
+    cost_alert_threshold_usd: float
+    retention_days: int
+    classifier_max_inflight: int
+    classifier_queue_maxsize: int
+
+    @classmethod
+    def from_env(cls) -> "Config":
+        try:
+            minimax_api_key = os.environ["MINIMAX_API_KEY"]
+        except KeyError as e:
+            raise RuntimeError("MINIMAX_API_KEY required") from e
+
+        try:
+            eventbus_database_url = os.environ["EVENTBUS_DATABASE_URL"]
+        except KeyError as e:
+            raise RuntimeError("EVENTBUS_DATABASE_URL required") from e
+
+        db_path = Path(os.environ.get(
+            "OBSERVATORY_DB_PATH",
+            str(Path.home() / ".cell-observatory" / "observatory.db"),
+        ))
+
+        return cls(
+            minimax_api_key=minimax_api_key,
+            eventbus_database_url=eventbus_database_url,
+            db_path=db_path,
+            api_port=int(os.environ.get("OBSERVATORY_API_PORT", "17891")),
+            api_key=os.environ.get("OBSERVATORY_API_KEY", ""),
+            cost_alert_threshold_usd=float(os.environ.get("OBSERVATORY_COST_ALERT_THRESHOLD_USD", "1.0")),
+            retention_days=int(os.environ.get("OBSERVATORY_RETENTION_DAYS", "90")),
+            classifier_max_inflight=int(os.environ.get("OBSERVATORY_CLASSIFIER_MAX_INFLIGHT", "50")),
+            classifier_queue_maxsize=int(os.environ.get("OBSERVATORY_CLASSIFIER_QUEUE_MAXSIZE", "10000")),
+        )

--- a/apps/cell-observatory-collector/cell_observatory/models.py
+++ b/apps/cell-observatory-collector/cell_observatory/models.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+from enum import Enum
+from typing import Any, Literal
+from pydantic import BaseModel, Field
+
+
+class ClassificationLabel(str, Enum):
+    NORMAL = "normal"
+    ANOMALY = "anomaly"
+    CRITICAL = "critical"
+    UNCERTAIN = "uncertain"
+
+
+class PulseEventV1(BaseModel):
+    """Schema for cell_pulse_observed events. Frozen v1 — bump to v2 if shape changes."""
+    outbox_id: int = Field(alias="_outbox_id")
+    event_version: Literal["v1"]
+    cell_id: str
+    cell_kind: str
+    pulse_id: str
+    pulse_timestamp: str  # ISO 8601 string; collector converts to int ms
+    phase: str
+    sensors: list[dict[str, Any]]
+    pulse_result: dict[str, Any]
+    homeostatic_state: dict[str, Any]
+    scar_signals: list[dict[str, Any]] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = {"populate_by_name": True}
+
+
+class ClassificationOutput(BaseModel):
+    """Strict schema for MiniMax classifier output (Pydantic v2 generate_structured pattern)."""
+    reasoning: str = Field(min_length=1, max_length=500)
+    label: ClassificationLabel
+    confidence: float = Field(ge=0.0, le=1.0)
+
+
+class ClassificationResult(BaseModel):
+    """Persisted classification (output + metadata)."""
+    outbox_id: int
+    label: ClassificationLabel
+    confidence: float
+    reasoning: str
+    label_diff: Literal["agree", "disagree"]
+    model: str
+    model_version: str | None = None
+    cost_usd: float
+    latency_ms: int
+    error: str | None = None

--- a/apps/cell-observatory-collector/cell_observatory/prune.py
+++ b/apps/cell-observatory-collector/cell_observatory/prune.py
@@ -1,0 +1,44 @@
+import asyncio
+import structlog
+from datetime import datetime, timezone, timedelta
+
+from cell_observatory.config import Config
+from cell_observatory.storage import Storage
+
+log = structlog.get_logger(__name__)
+
+
+async def prune_old_events(storage: Storage, retention_days: int) -> int:
+    """Delete pulse_events older than retention_days. Cascade deletes classifications via FK."""
+    assert storage._conn is not None
+    cutoff_ms = int((datetime.now(timezone.utc) - timedelta(days=retention_days)).timestamp() * 1000)
+
+    cur = await storage._conn.execute(
+        "DELETE FROM pulse_classifications WHERE outbox_id IN "
+        "(SELECT outbox_id FROM pulse_events WHERE pulse_timestamp < ?)",
+        (cutoff_ms,),
+    )
+    deleted_class = cur.rowcount
+
+    cur = await storage._conn.execute(
+        "DELETE FROM pulse_events WHERE pulse_timestamp < ?", (cutoff_ms,)
+    )
+    deleted_events = cur.rowcount
+    await storage._conn.commit()
+
+    log.info("pruned old events", deleted_events=deleted_events, deleted_classifications=deleted_class)
+    return deleted_events
+
+
+async def main():
+    cfg = Config.from_env()
+    s = Storage(db_path=cfg.db_path)
+    await s.init()
+    try:
+        await prune_old_events(s, cfg.retention_days)
+    finally:
+        await s.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/apps/cell-observatory-collector/cell_observatory/rollup.py
+++ b/apps/cell-observatory-collector/cell_observatory/rollup.py
@@ -1,0 +1,28 @@
+from cell_observatory.storage import Storage
+
+
+async def compute_daily_rollup(storage: Storage, day: str) -> None:
+    """Aggregate pulse_events + classifications into pulse_daily_rollup for `day` (YYYY-MM-DD WITA)."""
+    sql = """
+    INSERT OR REPLACE INTO pulse_daily_rollup
+        (day, cell_id, n_pulse, n_self_green, n_self_yellow, n_self_red,
+         n_classified, n_anomaly, n_critical, n_disagree, cost_usd)
+    SELECT
+        ?, e.cell_id,
+        COUNT(*),
+        SUM(CASE WHEN e.classifier_self='green' THEN 1 ELSE 0 END),
+        SUM(CASE WHEN e.classifier_self='yellow' THEN 1 ELSE 0 END),
+        SUM(CASE WHEN e.classifier_self='red' THEN 1 ELSE 0 END),
+        COUNT(c.outbox_id),
+        SUM(CASE WHEN c.label='anomaly' THEN 1 ELSE 0 END),
+        SUM(CASE WHEN c.label='critical' THEN 1 ELSE 0 END),
+        SUM(CASE WHEN c.label_diff='disagree' THEN 1 ELSE 0 END),
+        COALESCE(SUM(c.cost_usd), 0.0)
+    FROM pulse_events e
+    LEFT JOIN pulse_classifications c ON c.outbox_id = e.outbox_id
+    WHERE date(e.pulse_timestamp/1000, 'unixepoch', '+8 hours') = ?
+    GROUP BY e.cell_id
+    """
+    assert storage._conn is not None
+    await storage._conn.execute(sql, (day, day))
+    await storage._conn.commit()

--- a/apps/cell-observatory-collector/cell_observatory/storage.py
+++ b/apps/cell-observatory-collector/cell_observatory/storage.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import aiosqlite
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS pulse_events (
+    outbox_id INTEGER PRIMARY KEY,
+    cell_id TEXT NOT NULL, cell_kind TEXT NOT NULL,
+    pulse_id TEXT NOT NULL, pulse_timestamp INTEGER NOT NULL,
+    phase TEXT NOT NULL, classifier_self TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    received_at INTEGER NOT NULL, received_lag_ms INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS ix_pulse_events_cell_ts ON pulse_events(cell_id, pulse_timestamp DESC);
+CREATE INDEX IF NOT EXISTS ix_pulse_events_classifier ON pulse_events(classifier_self, pulse_timestamp DESC);
+
+CREATE TABLE IF NOT EXISTS pulse_classifications (
+    outbox_id INTEGER PRIMARY KEY REFERENCES pulse_events(outbox_id),
+    classified_at INTEGER NOT NULL,
+    label TEXT NOT NULL, confidence REAL NOT NULL,
+    reasoning TEXT, label_diff TEXT,
+    model TEXT NOT NULL, model_version TEXT,
+    cost_usd REAL NOT NULL, latency_ms INTEGER NOT NULL,
+    error TEXT
+);
+CREATE INDEX IF NOT EXISTS ix_classifications_label ON pulse_classifications(label, classified_at DESC);
+CREATE INDEX IF NOT EXISTS ix_classifications_disagree ON pulse_classifications(label, outbox_id) WHERE label_diff='disagree';
+
+CREATE TABLE IF NOT EXISTS pulse_daily_rollup (
+    day TEXT NOT NULL, cell_id TEXT NOT NULL,
+    n_pulse INTEGER NOT NULL, n_self_green INTEGER NOT NULL,
+    n_self_yellow INTEGER NOT NULL, n_self_red INTEGER NOT NULL,
+    n_classified INTEGER NOT NULL, n_anomaly INTEGER NOT NULL,
+    n_critical INTEGER NOT NULL, n_disagree INTEGER NOT NULL,
+    cost_usd REAL NOT NULL,
+    PRIMARY KEY (day, cell_id)
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS pulse_classifications_fts USING fts5(
+    outbox_id UNINDEXED, label, reasoning,
+    content='pulse_classifications', content_rowid='outbox_id'
+);
+
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL
+);
+INSERT OR IGNORE INTO schema_version VALUES (1, strftime('%s','now')*1000);
+"""
+
+
+def _to_epoch_ms(iso: str) -> int:
+    dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+    return int(dt.timestamp() * 1000)
+
+
+def _now_ms() -> int:
+    return int(datetime.now(timezone.utc).timestamp() * 1000)
+
+
+class Storage:
+    def __init__(self, db_path: Path):
+        self.db_path = Path(db_path)
+        self._conn: aiosqlite.Connection | None = None
+
+    async def init(self) -> None:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = await aiosqlite.connect(self.db_path)
+        self._conn.row_factory = aiosqlite.Row
+        await self._conn.execute("PRAGMA journal_mode=WAL")
+        await self._conn.execute("PRAGMA synchronous=NORMAL")
+        await self._conn.executescript(_SCHEMA)
+        await self._conn.commit()
+
+    async def close(self) -> None:
+        if self._conn is not None:
+            await self._conn.close()
+            self._conn = None
+
+    async def _fetchall(self, sql: str, params: tuple = ()) -> list[dict[str, Any]]:
+        assert self._conn is not None
+        async with self._conn.execute(sql, params) as cur:
+            rows = await cur.fetchall()
+            return [dict(r) for r in rows]
+
+    async def insert_pulse_event(self, payload: dict[str, Any]) -> bool:
+        """Idempotent insert. Returns True if inserted, False if outbox_id already present."""
+        assert self._conn is not None
+        ts_ms = _to_epoch_ms(payload["pulse_timestamp"])
+        now = _now_ms()
+        cursor = await self._conn.execute(
+            "INSERT OR IGNORE INTO pulse_events "
+            "(outbox_id, cell_id, cell_kind, pulse_id, pulse_timestamp, phase, "
+            " classifier_self, payload_json, received_at, received_lag_ms) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                payload["outbox_id"], payload["cell_id"], payload["cell_kind"],
+                payload["pulse_id"], ts_ms, payload["phase"],
+                payload["pulse_result"].get("classifier_self", "unknown"),
+                json.dumps(payload),
+                now, max(0, now - ts_ms),
+            ),
+        )
+        await self._conn.commit()
+        return cursor.rowcount > 0
+
+    async def upsert_classification(self, c: dict[str, Any]) -> None:
+        """A1 fix: ON CONFLICT DO UPDATE so backfill can re-classify."""
+        assert self._conn is not None
+        await self._conn.execute(
+            "INSERT INTO pulse_classifications "
+            "(outbox_id, classified_at, label, confidence, reasoning, label_diff, "
+            " model, model_version, cost_usd, latency_ms, error) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(outbox_id) DO UPDATE SET "
+            "classified_at=excluded.classified_at, label=excluded.label, "
+            "confidence=excluded.confidence, reasoning=excluded.reasoning, "
+            "label_diff=excluded.label_diff, model=excluded.model, "
+            "model_version=excluded.model_version, cost_usd=excluded.cost_usd, "
+            "latency_ms=excluded.latency_ms, error=excluded.error",
+            (
+                c["outbox_id"], _now_ms(), c["label"], c["confidence"],
+                c["reasoning"], c["label_diff"], c["model"], c["model_version"],
+                c["cost_usd"], c["latency_ms"], c["error"],
+            ),
+        )
+        await self._conn.commit()

--- a/apps/cell-observatory-collector/pyproject.toml
+++ b/apps/cell-observatory-collector/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cell-observatory-collector"
+version = "0.1.0"
+description = "Listen to cell pulse events, classify with MiniMax M2, persist to local SQLite"
+requires-python = ">=3.11"
+dependencies = [
+    "asyncpg>=0.29",
+    "aiosqlite>=0.20",
+    "fastapi>=0.110",
+    "uvicorn[standard]>=0.27",
+    "httpx>=0.27",
+    "pydantic>=2.6",
+    "structlog>=24.1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+    "pytest-mock>=3.12",
+]
+
+[tool.setuptools.packages.find]
+include = ["cell_observatory*"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/apps/cell-observatory-collector/scripts/bootstrap_db.sh
+++ b/apps/cell-observatory-collector/scripts/bootstrap_db.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p ~/.cell-observatory ~/logs/cell-observatory
+set -a; source ~/.nuzantara-secrets.env; set +a
+~/Desktop/nuzantara/apps/cell-observatory-collector/.venv/bin/python \
+    -c "
+import asyncio
+from cell_observatory.storage import Storage
+from cell_observatory.config import Config
+
+async def main():
+    cfg = Config.from_env()
+    s = Storage(db_path=cfg.db_path)
+    await s.init()
+    await s.close()
+
+asyncio.run(main())
+"
+echo "DB initialized at ~/.cell-observatory/observatory.db"

--- a/apps/cell-observatory-collector/scripts/healthcheck.sh
+++ b/apps/cell-observatory-collector/scripts/healthcheck.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+set -a
+source ~/.nuzantara-secrets.env
+set +a
+
+URL="http://127.0.0.1:${OBSERVATORY_API_PORT:-17891}/api/observatory/health"
+KEY="${OBSERVATORY_API_KEY:-}"
+
+resp=$(curl -fsS -m 5 -H "X-Observatory-Key: $KEY" "$URL" || echo "FAIL")
+
+if [ "$resp" = "FAIL" ]; then
+    echo "[$(date -u +%FT%TZ)] CRITICAL: cell-observatory unreachable" >&2
+    exit 1
+fi
+
+echo "[$(date -u +%FT%TZ)] OK: $resp"

--- a/apps/cell-observatory-collector/tests/test_api.py
+++ b/apps/cell-observatory-collector/tests/test_api.py
@@ -1,0 +1,27 @@
+import pytest
+from fastapi.testclient import TestClient
+from cell_observatory.api import build_app
+
+
+@pytest.fixture
+async def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("MINIMAX_API_KEY", "sk-fake")
+    monkeypatch.setenv("EVENTBUS_DATABASE_URL", "postgresql://x/y")
+    monkeypatch.setenv("OBSERVATORY_API_KEY", "secret123")
+    monkeypatch.setenv("OBSERVATORY_DB_PATH", str(tmp_path / "x.db"))
+    app, _ = await build_app()
+    yield app
+
+
+def test_health_unauth(app):
+    client = TestClient(app)
+    resp = client.get("/api/observatory/health")
+    assert resp.status_code == 401
+
+
+def test_health_authed(app):
+    client = TestClient(app)
+    resp = client.get("/api/observatory/health", headers={"X-Observatory-Key": "secret123"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["alive"] is True

--- a/apps/cell-observatory-collector/tests/test_classifier.py
+++ b/apps/cell-observatory-collector/tests/test_classifier.py
@@ -1,0 +1,60 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from cell_observatory.classifier import MinimaxClassifier, CircuitOpenError
+from cell_observatory.models import PulseEventV1
+
+
+def event_factory():
+    return PulseEventV1(
+        _outbox_id=1, event_version="v1", cell_id="x", cell_kind="x",
+        pulse_id="x", pulse_timestamp="2026-05-01T00:00:00.000Z",
+        phase="x", sensors=[], pulse_result={"classifier_self": "green"},
+        homeostatic_state={}, scar_signals=[], metadata={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_classify_returns_structured():
+    event = event_factory()
+    clf = MinimaxClassifier(api_key="sk-fake")
+    fake_response = {
+        "choices": [{"message": {"content": '{"reasoning": "all good", "label": "normal", "confidence": 0.9}'}}],
+        "usage": {"prompt_tokens": 100, "completion_tokens": 30},
+    }
+    with patch.object(clf, "_call_api", AsyncMock(return_value=fake_response)):
+        result = await clf.classify(event)
+    assert result.label.value == "normal"
+    assert result.confidence == 0.9
+    assert result.cost_usd > 0
+    await clf.aclose()
+
+
+@pytest.mark.asyncio
+async def test_classify_label_diff_disagree():
+    """Cell self=green, LLM=anomaly → label_diff='disagree'."""
+    event = event_factory()
+    clf = MinimaxClassifier(api_key="sk-fake")
+    fake_response = {
+        "choices": [{"message": {"content": '{"reasoning": "subtle issue", "label": "anomaly", "confidence": 0.7}'}}],
+        "usage": {"prompt_tokens": 100, "completion_tokens": 30},
+    }
+    with patch.object(clf, "_call_api", AsyncMock(return_value=fake_response)):
+        result = await clf.classify(event)
+    assert result.label_diff == "disagree"
+    await clf.aclose()
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_opens_after_n_failures():
+    """M3 fix: 5 consecutive failures → circuit opens, raises CircuitOpenError on 6th call."""
+    clf = MinimaxClassifier(api_key="sk-fake", circuit_threshold=5)
+    failing = AsyncMock(side_effect=Exception("500"))
+    with patch.object(clf, "_call_api", failing):
+        # 5 failures will increment _consecutive_failures
+        for _ in range(5):
+            with pytest.raises(Exception):
+                await clf.classify(event_factory())
+    # 6th call: circuit should be OPEN
+    with pytest.raises(CircuitOpenError):
+        await clf.classify(event_factory())
+    await clf.aclose()

--- a/apps/cell-observatory-collector/tests/test_collector.py
+++ b/apps/cell-observatory-collector/tests/test_collector.py
@@ -1,0 +1,47 @@
+import asyncio
+import pytest
+from unittest.mock import AsyncMock
+from cell_observatory.collector import Collector
+
+
+@pytest.mark.asyncio
+async def test_bounded_queue_drops_oldest_on_overflow():
+    """G1 fix: queue maxsize=10000, drop-oldest on overflow."""
+    storage = AsyncMock()
+    storage.insert_pulse_event = AsyncMock(return_value=True)
+    classifier = AsyncMock()
+
+    collector = Collector(storage=storage, classifier=classifier,
+                          classifier_max_inflight=2, classifier_queue_maxsize=3)
+
+    for i in range(10):
+        collector._enqueue_for_classification({"outbox_id": i})
+
+    # Queue should be capped at maxsize, oldest dropped
+    assert collector._classification_queue.qsize() == 3
+
+
+@pytest.mark.asyncio
+async def test_outbox_replay_on_startup():
+    """Replay unconsumed events_outbox rows on collector startup."""
+    storage = AsyncMock()
+    storage.insert_pulse_event = AsyncMock(return_value=True)
+    classifier = AsyncMock()
+
+    collector = Collector(storage=storage, classifier=classifier)
+
+    fake_conn_rows = [
+        {
+            "outbox_id": 1,
+            "payload": '{"_outbox_id": 1, "event_version": "v1", "cell_id": "x", "cell_kind": "x", "pulse_id": "x", "pulse_timestamp": "2026-05-01T00:00:00Z", "phase": "x", "sensors": [], "pulse_result": {"classifier_self": "green"}, "homeostatic_state": {}, "scar_signals": [], "metadata": {}}'
+        },
+    ]
+
+    fake_conn = AsyncMock()
+    fake_conn.fetch = AsyncMock(return_value=fake_conn_rows)
+    fake_conn.execute = AsyncMock()
+
+    await collector._replay_outbox_unconsumed(fake_conn)
+
+    storage.insert_pulse_event.assert_called_once()
+    fake_conn.execute.assert_called()  # ack via consumed_at

--- a/apps/cell-observatory-collector/tests/test_config.py
+++ b/apps/cell-observatory-collector/tests/test_config.py
@@ -1,0 +1,31 @@
+import pytest
+from cell_observatory.config import Config
+
+
+def test_config_defaults(monkeypatch):
+    monkeypatch.setenv("MINIMAX_API_KEY", "sk-fake")
+    monkeypatch.setenv("EVENTBUS_DATABASE_URL", "postgresql://x/y")
+    cfg = Config.from_env()
+    assert cfg.minimax_api_key == "sk-fake"
+    assert cfg.api_port == 17891
+    assert cfg.cost_alert_threshold_usd == 1.0  # M6 default
+    assert cfg.retention_days == 90
+    assert cfg.classifier_max_inflight == 50
+    assert cfg.classifier_queue_maxsize == 10000  # G1 fix
+
+
+def test_config_overrides(monkeypatch):
+    monkeypatch.setenv("MINIMAX_API_KEY", "sk-fake")
+    monkeypatch.setenv("EVENTBUS_DATABASE_URL", "postgresql://x/y")
+    monkeypatch.setenv("OBSERVATORY_COST_ALERT_THRESHOLD_USD", "5.0")
+    monkeypatch.setenv("OBSERVATORY_API_PORT", "17892")
+    cfg = Config.from_env()
+    assert cfg.cost_alert_threshold_usd == 5.0
+    assert cfg.api_port == 17892
+
+
+def test_config_required_keys_missing(monkeypatch):
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    monkeypatch.delenv("EVENTBUS_DATABASE_URL", raising=False)
+    with pytest.raises(RuntimeError, match="MINIMAX_API_KEY"):
+        Config.from_env()

--- a/apps/cell-observatory-collector/tests/test_models.py
+++ b/apps/cell-observatory-collector/tests/test_models.py
@@ -1,0 +1,40 @@
+import pytest
+from cell_observatory.models import PulseEventV1, ClassificationLabel
+
+
+def test_pulse_event_v1_minimal():
+    event = PulseEventV1(
+        _outbox_id=1,
+        event_version="v1",
+        cell_id="organism",
+        cell_kind="innervation",
+        pulse_id="01ABC",
+        pulse_timestamp="2026-05-01T00:00:00.000Z",
+        phase="homeostatic",
+        sensors=[],
+        pulse_result={"classifier_self": "green", "trend_window_min": 15, "trend_label": "stable"},
+        homeostatic_state={"energy_pct": 80, "load_factor": 0.3},
+        scar_signals=[],
+        metadata={"host": "Nuzantara", "machine_role": "Pro", "cell_core_version": "0.1.4"},
+    )
+    assert event.cell_id == "organism"
+    assert event.outbox_id == 1  # underscore-prefixed alias
+
+
+def test_classification_label_enum():
+    assert ClassificationLabel.NORMAL.value == "normal"
+    assert ClassificationLabel.ANOMALY.value == "anomaly"
+    assert ClassificationLabel.CRITICAL.value == "critical"
+    assert ClassificationLabel.UNCERTAIN.value == "uncertain"
+
+
+def test_pulse_event_v1_rejects_event_version_mismatch():
+    with pytest.raises(ValueError):
+        PulseEventV1(
+            _outbox_id=1,
+            event_version="v2",  # wrong
+            cell_id="x", cell_kind="x", pulse_id="x",
+            pulse_timestamp="2026-05-01T00:00:00.000Z",
+            phase="x", sensors=[], pulse_result={}, homeostatic_state={},
+            scar_signals=[], metadata={},
+        )

--- a/apps/cell-observatory-collector/tests/test_rollup.py
+++ b/apps/cell-observatory-collector/tests/test_rollup.py
@@ -1,0 +1,29 @@
+import pytest
+from cell_observatory.rollup import compute_daily_rollup
+from cell_observatory.storage import Storage
+
+
+@pytest.mark.asyncio
+async def test_compute_rollup(tmp_path):
+    s = Storage(db_path=tmp_path / "x.db")
+    await s.init()
+    # seed 3 events for cell 'organism', 2 green 1 yellow
+    for i, label in enumerate(["green", "green", "yellow"]):
+        await s.insert_pulse_event({
+            "outbox_id": i, "event_version": "v1", "cell_id": "organism",
+            "cell_kind": "x", "pulse_id": f"01{i}",
+            "pulse_timestamp": "2026-05-01T00:00:00.000Z",
+            "phase": "x", "sensors": [],
+            "pulse_result": {"classifier_self": label},
+            "homeostatic_state": {}, "scar_signals": [], "metadata": {},
+        })
+
+    await compute_daily_rollup(s, "2026-05-01")
+    rows = await s._fetchall(
+        "SELECT * FROM pulse_daily_rollup WHERE day='2026-05-01' AND cell_id='organism'"
+    )
+    assert len(rows) == 1
+    assert rows[0]["n_pulse"] == 3
+    assert rows[0]["n_self_green"] == 2
+    assert rows[0]["n_self_yellow"] == 1
+    await s.close()

--- a/apps/cell-observatory-collector/tests/test_storage.py
+++ b/apps/cell-observatory-collector/tests/test_storage.py
@@ -1,0 +1,68 @@
+import pytest
+from pathlib import Path
+from cell_observatory.storage import Storage
+
+
+@pytest.fixture
+async def storage(tmp_path):
+    db_path = tmp_path / "test.db"
+    s = Storage(db_path=db_path)
+    await s.init()
+    yield s
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_init_creates_schema(storage):
+    rows = await storage._fetchall("SELECT name FROM sqlite_master WHERE type='table'")
+    table_names = {r["name"] for r in rows}
+    assert "pulse_events" in table_names
+    assert "pulse_classifications" in table_names
+    assert "pulse_daily_rollup" in table_names
+    assert "pulse_classifications_fts" in table_names
+    assert "schema_version" in table_names
+
+
+@pytest.mark.asyncio
+async def test_wal_mode_enabled(storage):
+    rows = await storage._fetchall("PRAGMA journal_mode")
+    assert rows[0]["journal_mode"].lower() == "wal"
+
+
+@pytest.mark.asyncio
+async def test_insert_pulse_event_idempotent(storage):
+    payload = {
+        "outbox_id": 1, "event_version": "v1", "cell_id": "organism",
+        "cell_kind": "test", "pulse_id": "01ABC",
+        "pulse_timestamp": "2026-05-01T00:00:00.000Z",
+        "phase": "homeostatic",
+        "sensors": [], "pulse_result": {"classifier_self": "green"},
+        "homeostatic_state": {}, "scar_signals": [], "metadata": {},
+    }
+    inserted_first = await storage.insert_pulse_event(payload)
+    inserted_second = await storage.insert_pulse_event(payload)
+    assert inserted_first is True
+    assert inserted_second is False  # already exists, skipped
+
+
+@pytest.mark.asyncio
+async def test_classification_upsert(storage):
+    """Backfill must overwrite existing classification — A1 fix."""
+    pulse = {"outbox_id": 1, "event_version": "v1", "cell_id": "x", "cell_kind": "x",
+             "pulse_id": "x", "pulse_timestamp": "2026-05-01T00:00:00.000Z",
+             "phase": "x", "sensors": [], "pulse_result": {"classifier_self": "green"},
+             "homeostatic_state": {}, "scar_signals": [], "metadata": {}}
+    await storage.insert_pulse_event(pulse)
+
+    cls1 = {"outbox_id": 1, "label": "normal", "confidence": 0.9, "reasoning": "calm",
+            "label_diff": "agree", "model": "minimax-m2", "model_version": None,
+            "cost_usd": 0.0001, "latency_ms": 100, "error": None}
+    cls2 = {**cls1, "label": "anomaly", "confidence": 0.6, "reasoning": "rethink"}
+
+    await storage.upsert_classification(cls1)
+    await storage.upsert_classification(cls2)
+
+    rows = await storage._fetchall("SELECT label, confidence FROM pulse_classifications WHERE outbox_id=1")
+    assert len(rows) == 1
+    assert rows[0]["label"] == "anomaly"  # second won
+    assert rows[0]["confidence"] == 0.6

--- a/infra/launchagents/com.nuzantara.cell-observatory-prune.plist
+++ b/infra/launchagents/com.nuzantara.cell-observatory-prune.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.nuzantara.cell-observatory-prune</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-lc</string>
+        <string>set -a; source ~/.nuzantara-secrets.env; set +a; exec ~/Desktop/nuzantara/apps/cell-observatory-collector/.venv/bin/python -m cell_observatory.prune</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict><key>Hour</key><integer>4</integer><key>Minute</key><integer>0</integer></dict>
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/cell-observatory/prune.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/cell-observatory/prune.log</string>
+</dict>
+</plist>

--- a/infra/launchagents/com.nuzantara.cell-observatory-selfcheck.plist
+++ b/infra/launchagents/com.nuzantara.cell-observatory-selfcheck.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.nuzantara.cell-observatory-selfcheck</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-lc</string>
+        <string>~/Desktop/nuzantara/apps/cell-observatory-collector/scripts/healthcheck.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/cell-observatory/selfcheck.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/cell-observatory/selfcheck.log</string>
+</dict>
+</plist>

--- a/infra/launchagents/com.nuzantara.cell-observatory.plist
+++ b/infra/launchagents/com.nuzantara.cell-observatory.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.nuzantara.cell-observatory</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-lc</string>
+        <string>set -a; source ~/.nuzantara-secrets.env; set +a; exec ~/Desktop/nuzantara/apps/cell-observatory-collector/.venv/bin/python -m cell_observatory</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/cell-observatory/collector.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/cell-observatory/collector.err.log</string>
+    <key>WorkingDirectory</key>
+    <string>/Users/nuzantara/Desktop/nuzantara/apps/cell-observatory-collector</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <key>MACHINE_ROLE</key>
+        <string>Pro</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

PR-3 of Cell Pulse Observatory implementation. Builds the Python service that runs on Pro local, listens to PG channel \`cell_pulse_observed\` (registered in PR-2), classifies events with MiniMax M2, and persists to local SQLite.

### What

New package \`apps/cell-observatory-collector/\` with:

- **\`models.py\`** — Pydantic v2 schemas: PulseEventV1 (with _outbox_id alias), ClassificationLabel enum, ClassificationOutput (strict, min_length=1 reasoning forces think-before-commit), ClassificationResult
- **\`config.py\`** — frozen dataclass Config from env, with G1 (queue maxsize=10000) + M6 (cost threshold=$1.0) defaults
- **\`storage.py\`** — SQLite WAL + 5 tables (pulse_events, pulse_classifications, pulse_daily_rollup, pulse_classifications_fts FTS5, schema_version), idempotent insert + A1 upsert pattern
- **\`classifier.py\`** — httpx async to MiniMax M2 OpenAI-compat, Pydantic v2 retry-once, cost ledger (\$0.30/M input, \$1.20/M output), M3 circuit breaker (5 failures → 60s open)
- **\`collector.py\`** — asyncpg LISTEN cell_pulse_observed, _replay_outbox_unconsumed (PR #342 contract), G1 bounded queue with drop-oldest, N classification workers, 5s reconnect backoff
- **\`rollup.py\`** — compute_daily_rollup() aggregates events+classifications grouped by cell with WITA timezone offset
- **\`prune.py\`** — 90-day retention deletes
- **\`api.py\`** — FastAPI loopback :17891, 5 endpoints with X-Observatory-Key auth

### LaunchAgents (NOT installed yet — Track B PR-5)

- \`com.nuzantara.cell-observatory.plist\` — KeepAlive=true daemon (scar P0-3)
- \`com.nuzantara.cell-observatory-prune.plist\` — daily 04:00 WITA
- \`com.nuzantara.cell-observatory-selfcheck.plist\` — 5-min health probe (M2 fix)

Secrets sourced from \`~/.nuzantara-secrets.env\` via bash wrapper, NOT in plist EnvironmentVariables (scar P0-3 secret-leak prevention). Logs to \`~/logs/cell-observatory/\` (NOT /tmp).

### Cross-LLM blockers / fixes resolved

- **G1** — bounded asyncio.Queue + drop-oldest in collector
- **A1** — UPSERT on classification (allows backfill reclassify)
- **M2** — selfcheck LaunchAgent (5-min health probe)
- **M3** — Circuit breaker on MiniMax (5 failures → 60s open)
- **M6** — Configurable cost threshold env var

### Test plan

- [x] \`pytest apps/cell-observatory-collector/tests/ -q\` → 18 PASS / 0 FAIL
  - test_models.py: 3 PASS
  - test_config.py: 3 PASS
  - test_storage.py: 4 PASS
  - test_classifier.py: 3 PASS
  - test_collector.py: 2 PASS
  - test_rollup.py: 1 PASS
  - test_api.py: 2 PASS
- [x] All 3 plist files pass \`plutil -lint\`
- [x] Both bash scripts pass \`bash -n\` syntax check

### Deferred to PR-4 / PR-5

- Dashboard tab in admin-dashboard-local (PR-4)
- LaunchAgent activation + smoke test M1 (PR-5 Task 5.3 with 48h gate)
- Cell activation (PR-5/PR-6 with patch_launchagents.sh from PR-0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)