### PR TITLE
feat(dashboard): observatory tab in admin-dashboard-local (PR-4)

### DIFF
--- a/apps/admin-dashboard-local/__tests__/observatory-client.test.ts
+++ b/apps/admin-dashboard-local/__tests__/observatory-client.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { observatoryClient } from '../app/observatory/lib/observatory-client';
+
+describe('observatoryClient', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('health() hits the /health endpoint with X-Observatory-Key header', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ alive: true, uptime_s: 0, events_total: 0, events_24h: 0 }),
+    } as Response);
+
+    const result = await observatoryClient.health();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/api/observatory/health'),
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-Observatory-Key': expect.any(String) }),
+        cache: 'no-store',
+      })
+    );
+    expect(result.alive).toBe(true);
+  });
+
+  it('pulses() includes cell_id and since query params when provided', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [] }),
+    } as Response);
+
+    await observatoryClient.pulses('organism', '2026-05-01T00:00:00Z');
+
+    const url = fetchSpy.mock.calls[0][0] as string;
+    expect(url).toContain('cell_id=organism');
+    expect(url).toContain('since=');
+  });
+
+  it('throws Error on non-2xx response', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+    } as Response);
+
+    await expect(observatoryClient.health()).rejects.toThrow('401');
+  });
+});

--- a/apps/admin-dashboard-local/app/observatory/components/AnomalyHotList.tsx
+++ b/apps/admin-dashboard-local/app/observatory/components/AnomalyHotList.tsx
@@ -1,0 +1,60 @@
+import { AnomalyEntry } from '../lib/types';
+
+interface Props {
+  anomalies: AnomalyEntry[];
+}
+
+export default function AnomalyHotList({ anomalies }: Props) {
+  return (
+    <div className="border rounded p-4">
+      <h2 className="font-semibold mb-2">Anomaly Hot List</h2>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left border-b">
+            <th className="pb-1">Time</th>
+            <th className="pb-1">Cell</th>
+            <th className="pb-1">Label</th>
+            <th className="pb-1 text-center">Confidence</th>
+            <th className="pb-1">Reasoning</th>
+          </tr>
+        </thead>
+        <tbody>
+          {anomalies.length === 0 && (
+            <tr>
+              <td colSpan={5} className="text-gray-400 text-center py-2">
+                no anomalies in window
+              </td>
+            </tr>
+          )}
+          {anomalies.map((a) => (
+            <tr key={a.outbox_id} className="border-b last:border-0">
+              <td className="py-1 text-xs">
+                {new Date(a.pulse_timestamp).toLocaleTimeString()}
+              </td>
+              <td className="py-1">{a.cell_id}</td>
+              <td className="py-1">
+                <span
+                  className={
+                    a.label === 'critical'
+                      ? 'text-red-600 font-bold'
+                      : a.label === 'anomaly'
+                      ? 'text-yellow-600'
+                      : 'text-gray-500'
+                  }
+                >
+                  {a.label}
+                </span>
+              </td>
+              <td className="py-1 text-center">
+                {(a.confidence * 100).toFixed(0)}%
+              </td>
+              <td className="py-1 text-xs text-gray-600 truncate max-w-md">
+                {a.reasoning}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/admin-dashboard-local/app/observatory/components/CellBreakdown.tsx
+++ b/apps/admin-dashboard-local/app/observatory/components/CellBreakdown.tsx
@@ -1,0 +1,44 @@
+import { DailyRollup } from '../lib/types';
+
+interface Props {
+  rollups: DailyRollup[];
+}
+
+export default function CellBreakdown({ rollups }: Props) {
+  return (
+    <div className="border rounded p-4">
+      <h2 className="font-semibold mb-2">Per-Cell Breakdown (today)</h2>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left border-b">
+            <th className="pb-1">Cell</th>
+            <th className="pb-1 text-center">Pulses</th>
+            <th className="pb-1 text-center">Anomaly%</th>
+            <th className="pb-1 text-center">Disagree%</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rollups.length === 0 && (
+            <tr>
+              <td colSpan={4} className="text-gray-400 text-center py-2">
+                no data yet
+              </td>
+            </tr>
+          )}
+          {rollups.map((r) => (
+            <tr key={r.cell_id} className="border-b last:border-0">
+              <td className="py-1">{r.cell_id}</td>
+              <td className="py-1 text-center">{r.n_pulse}</td>
+              <td className="py-1 text-center">
+                {r.n_pulse > 0 ? ((r.n_anomaly / r.n_pulse) * 100).toFixed(1) : '0.0'}%
+              </td>
+              <td className="py-1 text-center">
+                {r.n_pulse > 0 ? ((r.n_disagree / r.n_pulse) * 100).toFixed(1) : '0.0'}%
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/admin-dashboard-local/app/observatory/components/CostLedger.tsx
+++ b/apps/admin-dashboard-local/app/observatory/components/CostLedger.tsx
@@ -1,0 +1,24 @@
+import { CostSummary } from '../lib/types';
+
+interface Props {
+  summary: CostSummary | null;
+}
+
+export default function CostLedger({ summary }: Props) {
+  if (!summary) {
+    return <div className="border rounded p-4">Loading cost…</div>;
+  }
+  const overThreshold = summary.total_usd > summary.alert_threshold_usd;
+  return (
+    <div className="border rounded p-4">
+      <h2 className="font-semibold mb-2">MiniMax Cost Ledger</h2>
+      <p className={overThreshold ? 'text-red-600 font-bold' : ''}>
+        {overThreshold && '⚠ '}
+        Today: ${summary.total_usd.toFixed(4)} ({summary.calls} calls)
+      </p>
+      <p className="text-xs text-gray-500 mt-1">
+        Alert threshold: ${summary.alert_threshold_usd.toFixed(2)}/day
+      </p>
+    </div>
+  );
+}

--- a/apps/admin-dashboard-local/app/observatory/components/DisagreementWatch.tsx
+++ b/apps/admin-dashboard-local/app/observatory/components/DisagreementWatch.tsx
@@ -1,0 +1,31 @@
+import { AnomalyEntry } from '../lib/types';
+
+interface Props {
+  anomalies: AnomalyEntry[];
+}
+
+export default function DisagreementWatch({ anomalies }: Props) {
+  const disagreements = anomalies.filter((a) => a.label_diff === 'disagree');
+  return (
+    <div className="border rounded p-4 bg-amber-50">
+      <h2 className="font-semibold mb-2">
+        Disagreement Watch (LLM ≠ cell self-classifier)
+      </h2>
+      <p className="text-xs text-gray-600 mb-2">
+        Cases where MiniMax labeled anomaly/critical but cell self-classified
+        green — the most interesting signal for fase 1+.
+      </p>
+      {disagreements.length === 0 && (
+        <p className="text-gray-400 text-sm">no disagreements yet</p>
+      )}
+      <ul className="text-sm space-y-1">
+        {disagreements.map((a) => (
+          <li key={a.outbox_id}>
+            <strong>{a.cell_id}</strong>: {a.label} (
+            {(a.confidence * 100).toFixed(0)}%) — {a.reasoning}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/admin-dashboard-local/app/observatory/lib/observatory-client.ts
+++ b/apps/admin-dashboard-local/app/observatory/lib/observatory-client.ts
@@ -1,0 +1,89 @@
+/**
+ * Typed fetch wrapper for the Cell Observatory loopback API at 127.0.0.1:17891.
+ * Uses X-Observatory-Key header authentication.
+ */
+import {
+  PulseEvent,
+  AnomalyEntry,
+  DailyRollup,
+  CostSummary,
+  HealthResponse,
+} from './types';
+
+const BASE = process.env.NEXT_PUBLIC_OBSERVATORY_BASE ?? 'http://127.0.0.1:17891';
+const KEY = process.env.NEXT_PUBLIC_OBSERVATORY_API_KEY ?? '';
+
+async function fetchAuth<T>(path: string): Promise<T> {
+  const r = await fetch(`${BASE}${path}`, {
+    headers: { 'X-Observatory-Key': KEY },
+    cache: 'no-store',
+  });
+  if (!r.ok) throw new Error(`${path}: ${r.status} ${r.statusText}`);
+  return r.json();
+}
+
+export const observatoryClient = {
+  /**
+   * GET /api/observatory/health — collector liveness + event count
+   */
+  health: (): Promise<HealthResponse> =>
+    fetchAuth<HealthResponse>('/api/observatory/health'),
+
+  /**
+   * GET /api/observatory/pulse?cell_id=&since=&limit=
+   * Lists raw pulse events ordered by pulse_timestamp DESC.
+   */
+  pulses: (cellId?: string, since?: string): Promise<{ items: PulseEvent[] }> => {
+    const params = new URLSearchParams({
+      ...(cellId && { cell_id: cellId }),
+      ...(since && { since }),
+      limit: '500',
+    });
+    return fetchAuth<{ items: PulseEvent[] }>(
+      `/api/observatory/pulse?${params.toString()}`
+    );
+  },
+
+  /**
+   * GET /api/observatory/anomalies?since=&label=
+   * Lists anomaly/critical/uncertain classifications with cell_id + pulse_timestamp.
+   * Note: response items do NOT include classified_at (PR-4 Task 4.1 known mismatch
+   * with type definition — handle missing field gracefully in UI).
+   */
+  anomalies: (since?: string): Promise<{ items: AnomalyEntry[] }> => {
+    const params = new URLSearchParams({
+      ...(since && { since }),
+    });
+    return fetchAuth<{ items: AnomalyEntry[] }>(
+      `/api/observatory/anomalies?${params.toString()}`
+    );
+  },
+
+  /**
+   * GET /api/observatory/rollup?day=YYYY-MM-DD&cell_id=
+   * Returns daily aggregates per cell.
+   */
+  rollup: (day: string, cellId?: string): Promise<{ items: DailyRollup[] }> => {
+    const params = new URLSearchParams({
+      day,
+      ...(cellId && { cell_id: cellId }),
+    });
+    return fetchAuth<{ items: DailyRollup[] }>(
+      `/api/observatory/rollup?${params.toString()}`
+    );
+  },
+
+  /**
+   * GET /api/observatory/cost?since=
+   * Returns total cost + call count + threshold.
+   * Note: total_usd may be 0.0 (server coerces null → 0.0 server-side).
+   */
+  cost: (since?: string): Promise<CostSummary> => {
+    const params = new URLSearchParams({
+      ...(since && { since }),
+    });
+    return fetchAuth<CostSummary>(
+      `/api/observatory/cost?${params.toString()}`
+    );
+  },
+};

--- a/apps/admin-dashboard-local/app/observatory/lib/types.ts
+++ b/apps/admin-dashboard-local/app/observatory/lib/types.ts
@@ -1,0 +1,96 @@
+/**
+ * TypeScript types mirroring Pydantic models in
+ * apps/cell-observatory-collector/cell_observatory/models.py.
+ *
+ * Keep these in sync with the source Python models — drift is a known risk.
+ */
+
+export type ClassificationLabel = 'normal' | 'anomaly' | 'critical' | 'uncertain';
+export type LabelDiff = 'agree' | 'disagree';
+export type ClassifierSelf = 'green' | 'yellow' | 'red';
+
+/**
+ * Compact pulse event row from /api/observatory/pulse list endpoint.
+ * Mirrors the SELECT projection in storage._fetchall, NOT the full
+ * payload_json.
+ */
+export interface PulseEvent {
+  outbox_id: number;
+  cell_id: string;
+  pulse_id: string;
+  pulse_timestamp: number; // unix ms
+  classifier_self: ClassifierSelf;
+}
+
+/**
+ * Full pulse event detail from /api/observatory/pulse/{outbox_id} (TBD endpoint).
+ * Includes payload_json + reception metadata.
+ */
+export interface PulseEventDetail extends PulseEvent {
+  cell_kind: string;
+  phase: string;
+  payload_json: string;
+  received_at: number;
+  received_lag_ms: number;
+}
+
+/**
+ * Persisted classification result from MiniMax M2 (mirror of
+ * Python ClassificationResult).
+ */
+export interface PulseClassification {
+  outbox_id: number;
+  classified_at: number;
+  label: ClassificationLabel;
+  confidence: number;
+  reasoning: string;
+  label_diff: LabelDiff;
+  cost_usd: number;
+}
+
+/**
+ * Anomaly hot-list entry: classification joined with cell_id + pulse_timestamp
+ * from /api/observatory/anomalies endpoint.
+ */
+export interface AnomalyEntry extends PulseClassification {
+  cell_id: string;
+  pulse_timestamp: number;
+}
+
+/**
+ * Daily rollup row from /api/observatory/rollup.
+ * Mirror of Python pulse_daily_rollup table.
+ */
+export interface DailyRollup {
+  day: string; // YYYY-MM-DD WITA
+  cell_id: string;
+  n_pulse: number;
+  n_self_green: number;
+  n_self_yellow: number;
+  n_self_red: number;
+  n_classified: number;
+  n_anomaly: number;
+  n_critical: number;
+  n_disagree: number;
+  cost_usd: number;
+}
+
+/**
+ * Cost summary from /api/observatory/cost.
+ * total_usd may be null if no classifications yet — convert to 0 in UI.
+ */
+export interface CostSummary {
+  total_usd: number;
+  calls: number;
+  alert_threshold_usd: number;
+}
+
+/**
+ * Health response from /api/observatory/health.
+ */
+export interface HealthResponse {
+  alive: boolean;
+  uptime_s: number;
+  events_total: number;
+  events_24h: number;
+}

--- a/apps/admin-dashboard-local/app/observatory/page.tsx
+++ b/apps/admin-dashboard-local/app/observatory/page.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { observatoryClient } from './lib/observatory-client';
+import {
+  AnomalyEntry,
+  DailyRollup,
+  CostSummary,
+} from './lib/types';
+import CellBreakdown from './components/CellBreakdown';
+import AnomalyHotList from './components/AnomalyHotList';
+import CostLedger from './components/CostLedger';
+import DisagreementWatch from './components/DisagreementWatch';
+
+const REFRESH_INTERVAL_MS = 30_000;
+
+export default function ObservatoryPage() {
+  const today = new Date().toISOString().slice(0, 10);
+  const [rollup, setRollup] = useState<DailyRollup[]>([]);
+  const [anomalies, setAnomalies] = useState<AnomalyEntry[]>([]);
+  const [cost, setCost] = useState<CostSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const [rollupResp, anomaliesResp, costResp] = await Promise.all([
+          observatoryClient.rollup(today),
+          observatoryClient.anomalies(),
+          observatoryClient.cost(),
+        ]);
+        if (cancelled) return;
+        setRollup(rollupResp.items);
+        setAnomalies(anomaliesResp.items);
+        setCost(costResp);
+        setError(null);
+      } catch (e: unknown) {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : 'Unknown error');
+      }
+    }
+
+    load();
+    const interval = setInterval(load, REFRESH_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [today]);
+
+  return (
+    <main className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold">Cell Pulse Observatory</h1>
+      {error && (
+        <div className="border border-red-300 bg-red-50 text-red-700 p-3 rounded">
+          API error: {error}
+        </div>
+      )}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <CellBreakdown rollups={rollup} />
+        <CostLedger summary={cost} />
+      </div>
+      <DisagreementWatch anomalies={anomalies} />
+      <AnomalyHotList anomalies={anomalies} />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

PR-4 of Cell Pulse Observatory implementation. Adds an observatory tab to \`apps/admin-dashboard-local/\` that consumes the loopback API at \`127.0.0.1:17891\` (from PR-3 Task 3.8).

### What

New files under \`apps/admin-dashboard-local/app/observatory/\`:

- **\`lib/types.ts\`** — TypeScript interfaces mirroring Pydantic models from PR-3 (PulseEvent, AnomalyEntry, DailyRollup, CostSummary, HealthResponse, ClassificationLabel/LabelDiff/ClassifierSelf union types)
- **\`lib/observatory-client.ts\`** — typed fetch wrapper for 5 endpoints (health, pulses, anomalies, rollup, cost), authenticated via \`X-Observatory-Key\` header
- **\`page.tsx\`** — client component with useEffect+useState 30s polling (no SWR dep), Promise.all for parallel fetches, error banner
- **\`components/CellBreakdown.tsx\`** — per-cell daily rollup table
- **\`components/CostLedger.tsx\`** — MiniMax spend ledger with overThreshold warning
- **\`components/AnomalyHotList.tsx\`** — labeled events table, color-coded by severity
- **\`components/DisagreementWatch.tsx\`** — LLM vs cell self-classifier disagreement filter

### Adapted from plan

- Plan said \`src/app/observatory/\` — actual structure is flat \`app/observatory/\` (no src/)
- Plan said use SWR — used native useEffect+useState 30s polling (no new deps)
- Plan said use \`@/\` path alias in tests — vitest.config.ts doesn't configure path resolver, used relative imports matching db.test.ts pattern

### Test plan

- [x] \`npm test\` — 6 PASS (3 db.test.ts + 3 observatory-client.test.ts)
- [x] \`npx tsc --noEmit\` — clean

### Deferred

Smoke test of dashboard against live observatory API requires PR-5 (LaunchAgent activation). Visual QA happens in PR-5 Task 5.3 against organism cell pilot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)