### PR TITLE
feat(skills): Sprint 1.A — seed 5 crm renewals skills

### DIFF
--- a/apps/backend-rag/backend/scripts/seed_initial_skills.py
+++ b/apps/backend-rag/backend/scripts/seed_initial_skills.py
@@ -231,6 +231,77 @@ SEED_SKILLS: list[dict[str, Any]] = [
         "confidence": 0.85,
     },
 
+    # ─── crm cell — renewals domain (Sprint 1.A 2026-05-02) ───────
+    {
+        "cell": "crm",
+        "skill_id": "crm:detect_expiring_kitas",
+        "procedure": (
+            "Query clients table for KITAS expiring in [today, today + N days]. "
+            "Return list of (client_id, days_until_expiry, kitas_expiry_date) "
+            "ordered by urgency. Source column: clients.kitas_expiry_date. "
+            "Filter out clients with deleted_at IS NOT NULL."
+        ),
+        "precondition": "kitas_expiry_date populated for active clients (data quality assumption).",
+        "success_criterion": "All clients with KITAS expiring within window are returned, none missed.",
+        "confidence": 0.6,
+        "domain": "crm",
+    },
+    {
+        "cell": "crm",
+        "skill_id": "crm:propose_renewal_outreach",
+        "procedure": (
+            "For each (client_id, days_until_expiry) from detect_expiring_kitas, "
+            "build a Proposal with channel='whatsapp', urgency = "
+            "{<=7d: 'critical', <=30d: 'high', <=60d: 'medium', else: 'low'}, "
+            "and a one-line reasoning string. Skip clients with last_outreach < 14 days ago."
+        ),
+        "precondition": "crm:detect_expiring_kitas produced at least one candidate.",
+        "success_criterion": "One Proposal per eligible client; correct urgency tier; no duplicates within 14d.",
+        "confidence": 0.6,
+        "domain": "crm",
+    },
+    {
+        "cell": "crm",
+        "skill_id": "crm:draft_wa_renewal_message",
+        "procedure": (
+            "Generate WhatsApp draft via Ollama deepseek-r1:32b on Pro local. "
+            "Template parameters: client.full_name, kitas_expiry_date, days_until_expiry, "
+            "client.preferred_language (default 'en'). Output <= 1000 chars. "
+            "Never include NPWP / NIB / passport in payload outside Pro local."
+        ),
+        "precondition": "Proposal approved by Zero via Telegram; client.phone populated.",
+        "success_criterion": "Draft text generated, locale-correct, <= 1000 chars, zero PII leakage.",
+        "confidence": 0.6,
+        "domain": "crm",
+    },
+    {
+        "cell": "crm",
+        "skill_id": "crm:measure_renewal_conversion",
+        "procedure": (
+            "Cron 24h post-execute: SELECT outcome FROM renewal_alert_outcomes "
+            "WHERE alert_id IN (recent_proposals_24h) GROUP BY outcome. "
+            "Compute conversion_rate = client_renewed / total_executed. "
+            "Store in materialized view renewal_baseline_2024_2026 (Sprint 0 §3.4)."
+        ),
+        "precondition": "Outreach Proposal executed at least 24h ago; renewal_alert_outcomes populated.",
+        "success_criterion": "Conversion rate computed per (skill, segment) tuple; updated weekly.",
+        "confidence": 0.6,
+        "domain": "crm",
+    },
+    {
+        "cell": "crm",
+        "skill_id": "crm:update_renewal_confidence",
+        "procedure": (
+            "Lamarckian update: on outcome='client_renewed' bump confidence by +0.05 (max 0.95). "
+            "On outcome='expired_no_action' decay confidence by -0.10 (min 0.10). "
+            "Call Genome.record_skill with new confidence; valid_from = NOW()."
+        ),
+        "precondition": "At least N=10 outcomes observed for this skill in last 30 days.",
+        "success_criterion": "Confidence drifts toward empirical conversion_rate over time; bounded [0.10, 0.95].",
+        "confidence": 0.6,
+        "domain": "crm",
+    },
+
     # ─── visa / oracle cell ───────────────────────────────────────
     {
         "cell": "visa_oracle",
@@ -473,6 +544,7 @@ def apply_seed(seeds: list[dict[str, Any]], genome) -> dict[str, int]:
                 success_criterion=s["success_criterion"],
                 confidence=s.get("confidence", 0.6),
                 scope=s.get("scope", "Project"),
+                domain=s.get("domain", "generic"),
             )
             counts[action] += 1
         except Exception as exc:

--- a/apps/backend-rag/backend/tests/unit/scripts/test_seed_initial_skills.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_seed_initial_skills.py
@@ -8,10 +8,6 @@ intended for ``--apply`` in the Week 3-4 PR.
 """
 from __future__ import annotations
 
-from pathlib import Path
-
-import pytest
-
 from backend.scripts.seed_initial_skills import (
     SEED_SKILLS,
     apply_seed,
@@ -109,3 +105,62 @@ def test_main_apply_writes(tmp_path):
 
     g = Genome(db_path=str(db))
     assert g.stats()["total"] == len(SEED_SKILLS)
+
+
+# ─── Sprint 1.A 2026-05-02: 5 crm renewals skills ─────────────────────
+
+_RENEWAL_SKILL_IDS = frozenset(
+    {
+        "crm:detect_expiring_kitas",
+        "crm:propose_renewal_outreach",
+        "crm:draft_wa_renewal_message",
+        "crm:measure_renewal_conversion",
+        "crm:update_renewal_confidence",
+    }
+)
+
+
+def test_seed_includes_renewals_skills():
+    """Sprint 1.A: 5 crm renewals skills must be present in SEED_SKILLS."""
+    seeded_ids = {s["skill_id"] for s in SEED_SKILLS}
+    missing = _RENEWAL_SKILL_IDS - seeded_ids
+    assert not missing, f"Renewal skills missing from SEED_SKILLS: {missing}"
+
+
+def test_seed_renewals_have_correct_metadata():
+    """All 5 renewal skills must have cell='crm', domain='crm', confidence=0.6."""
+    renewals = [s for s in SEED_SKILLS if s["skill_id"] in _RENEWAL_SKILL_IDS]
+    assert len(renewals) == 5, f"Expected 5 renewal skills, got {len(renewals)}"
+    for s in renewals:
+        assert s.get("cell") == "crm", (
+            f"Skill {s['skill_id']} has cell={s.get('cell')!r}, expected 'crm'"
+        )
+        assert s.get("domain") == "crm", (
+            f"Skill {s['skill_id']} has domain={s.get('domain')!r}, expected 'crm'"
+        )
+        assert s.get("confidence") == 0.6, (
+            f"Skill {s['skill_id']} has confidence={s.get('confidence')!r}, expected 0.6"
+        )
+        # Required fields populated
+        for field in ("procedure", "precondition", "success_criterion"):
+            value = s.get(field, "")
+            assert isinstance(value, str) and len(value) > 20, (
+                f"Skill {s['skill_id']} has {field}={value!r}, expected non-trivial string"
+            )
+
+
+def test_seed_renewals_persisted_with_domain(tmp_path):
+    """After --apply, 5 renewal rows in genome have domain='crm'."""
+    from cell_core.genome import Genome
+
+    db = tmp_path / "renewals.db"
+    rc = main(["--db-path", str(db), "--apply"])
+    assert rc == 0
+
+    g = Genome(db_path=str(db))
+    # get_active filters by cell + domain (cf. cell_core/genome.py:get_active)
+    crm_skills = g.get_active(cell="crm", domain="crm", limit=100)
+    crm_ids = {s["id"] for s in crm_skills}
+    assert _RENEWAL_SKILL_IDS.issubset(crm_ids), (
+        f"Renewal skills missing from genome cell='crm' domain='crm': {_RENEWAL_SKILL_IDS - crm_ids}"
+    )


### PR DESCRIPTION
Sprint 1.A of Era Post-Agentica injection. Extends existing cell_core.genome skill registry with 5 renewals-domain skills via SEED_SKILLS in seed_initial_skills.py.

## Skills added (cell='crm', domain='crm', confidence=0.6)

- crm:detect_expiring_kitas — query KITAS expiring in window
- crm:propose_renewal_outreach — Proposal with urgency tier
- crm:draft_wa_renewal_message — Ollama deepseek-r1 draft (Pro local)
- crm:measure_renewal_conversion — 24h post-execute conversion
- crm:update_renewal_confidence — Lamarckian confidence drift

## Bug fix

`apply_seed` now passes `domain` kwarg to `Genome.record_skill` (was defaulting to 'generic' for all seeded skills).

## Tests

13/13 pass. Added 3:
- test_seed_includes_renewals_skills (5 IDs present)
- test_seed_renewals_have_correct_metadata
- test_seed_renewals_persisted_with_domain (g.get_active(cell='crm', domain='crm'))

Total SEED_SKILLS: 32 → 37 (within 30-40 target range).

Plan: docs/superpowers/plans/2026-05-02-sprint-1a-skill-registry-extension.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)