### PR TITLE
hotfix(api): register channel_health in router_registration (Sprint 1.B PR #422 missed it)

### DIFF
--- a/apps/backend-rag/backend/app/auth/public_endpoints.py
+++ b/apps/backend-rag/backend/app/auth/public_endpoints.py
@@ -74,6 +74,34 @@ _INFRA = (
     # Removed 2026-04-18: /api/health had no mounted router (health.py mounts
     # under /health, not /api/health). Entry was stale — external probes MUST
     # use /health.
+    # Sprint 1.B 2026-05-02: per-channel health endpoint for Cell-side
+    # heartbeat bridge. Cell on Pro polls these to write
+    # ~/.organism/last_seen/channel.{name}.json sidecars.
+    # Spec: docs/superpowers/specs/2026-05-01-post-agentic-injection-design.md §3.3.5
+    PublicEndpoint(
+        "/api/channels/whatsapp/health",
+        Category.INFRA,
+        "Channel health (whatsapp) — Cell heartbeat bridge poll target",
+        match="exact",
+    ),
+    PublicEndpoint(
+        "/api/channels/telegram/health",
+        Category.INFRA,
+        "Channel health (telegram) — Cell heartbeat bridge poll target",
+        match="exact",
+    ),
+    PublicEndpoint(
+        "/api/channels/instagram/health",
+        Category.INFRA,
+        "Channel health (instagram) — Cell heartbeat bridge poll target",
+        match="exact",
+    ),
+    PublicEndpoint(
+        "/api/channels/web/health",
+        Category.INFRA,
+        "Channel health (web) — Cell heartbeat bridge poll target",
+        match="exact",
+    ),
 )
 
 _AUTH = (

--- a/apps/backend-rag/backend/app/routers/channel_health.py
+++ b/apps/backend-rag/backend/app/routers/channel_health.py
@@ -1,0 +1,92 @@
+"""Channel health endpoint for Cell-side heartbeat bridge.
+
+Sprint 1.B (2026-05-02) — exposes per-channel health for Cell's
+channel_sensor to poll. Cell on Pro then writes sidecar files to
+~/.organism/last_seen/channel.{name}.json which genome_aggregator_sensor
+consumes.
+
+Spec: docs/superpowers/specs/2026-05-01-post-agentic-injection-design.md §3.3.5
+
+Status thresholds (mirror of ChannelSensor):
+- ok:        queue_depth <= 20
+- degraded:  21 <= queue_depth <= 100
+- fail:      queue_depth > 100
+"""
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from backend.app.dependencies import get_optional_database_pool
+
+router = APIRouter(prefix="/api/channels", tags=["channels", "health"])
+
+KNOWN_CHANNELS: frozenset[str] = frozenset(
+    {"whatsapp", "telegram", "instagram", "web"}
+)
+
+_OK_CEILING = 20
+_DEGRADED_CEILING = 100
+
+
+def _classify(queue_depth: int) -> str:
+    if queue_depth <= _OK_CEILING:
+        return "ok"
+    if queue_depth <= _DEGRADED_CEILING:
+        return "degraded"
+    return "fail"
+
+
+@router.get("/{name}/health")
+async def channel_health(
+    name: str,
+    db_pool: Any = Depends(get_optional_database_pool),
+) -> dict[str, Any]:
+    """Return current health for a known channel name.
+
+    Args:
+        name: one of whatsapp/telegram/instagram/web.
+
+    Returns:
+        {status, ts, channel, queue_depth, last_event_seen_at, metadata}.
+
+    Raises:
+        404: if name not in KNOWN_CHANNELS.
+    """
+    if name not in KNOWN_CHANNELS:
+        raise HTTPException(status_code=404, detail=f"unknown channel: {name}")
+
+    queue_depth = 0
+    last_event_seen_at: float | None = None
+
+    if db_pool is not None:
+        async with db_pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT
+                    COUNT(*) FILTER (WHERE processed_at IS NULL) AS pending,
+                    EXTRACT(EPOCH FROM MAX(received_at)) AS last_ts
+                FROM inbound_webhooks
+                WHERE channel = $1 AND received_at >= NOW() - INTERVAL '60 minutes'
+                """,
+                name,
+            )
+            if row is not None:
+                queue_depth = int(row["pending"] or 0)
+                last_event_seen_at = (
+                    float(row["last_ts"]) if row["last_ts"] is not None else None
+                )
+
+    return {
+        "status": _classify(queue_depth),
+        "ts": time.time(),
+        "channel": name,
+        "queue_depth": queue_depth,
+        "last_event_seen_at": last_event_seen_at,
+        "metadata": {
+            "thresholds": {"ok": _OK_CEILING, "degraded": _DEGRADED_CEILING},
+            "window_minutes": 60,
+        },
+    }

--- a/apps/backend-rag/backend/app/setup/router_manifest.py
+++ b/apps/backend-rag/backend/app/setup/router_manifest.py
@@ -121,6 +121,7 @@ ROUTER_MANIFEST: tuple[RouterEntry, ...] = (
 
     # ── Channels ──
     RouterEntry(name="channels",    process_groups=_API, tags=("channels",)),
+    RouterEntry(name="channel_health", process_groups=_API, tags=("channels", "health")),
 
     # ── CRM ──
     RouterEntry(name="crm_analytics",          process_groups=_API, tags=("crm",)),

--- a/apps/backend-rag/backend/app/setup/router_registration.py
+++ b/apps/backend-rag/backend/app/setup/router_registration.py
@@ -38,6 +38,7 @@ def include_routers(api: FastAPI) -> None:
         blog_ask,
         bridge,  # [BRIDGE] Pro<->Fly bidirectional bridge
         cell_status,  # [CELL] CELL organism dashboard status
+        channel_health,  # [HEARTBEAT] Sprint 1.B 2026-05-02 — Cell-side bridge
         channels,  # Channel health, DLQ, unified conversations
         collective_memory,
         conversations,
@@ -189,6 +190,7 @@ def include_routers(api: FastAPI) -> None:
     api.include_router(crm_portal_integration.router)  # Team ↔ Portal integration
 
     # Channel system + Omnichannel router (unified inbox)
+    api.include_router(channel_health.router)  # /api/channels/{name}/health Cell heartbeat bridge
     api.include_router(channels.router)  # Channel health, DLQ, unified conversations
     api.include_router(omnichannel.router)  # [NEW] Unified inbox threads API
 
@@ -407,6 +409,7 @@ def include_light_routers(api: FastAPI) -> None:
         auth,
         bridge,  # [BRIDGE] Pro<->Fly bidirectional bridge (Phase 1 Sinapsi)
         cell_status,
+        channel_health,  # [HEARTBEAT] Sprint 1.B 2026-05-02 — Cell-side bridge
         channels,  # Channel health, DLQ, unified conversations
         crm_analytics,
         crm_clients_documents,
@@ -519,6 +522,7 @@ def include_light_routers(api: FastAPI) -> None:
     api.include_router(partners.router)  # [PARTNERS] /api/partners/* — CRM Partners module
 
     # Channel system + Omnichannel router (unified inbox)
+    api.include_router(channel_health.router)  # /api/channels/{name}/health Cell heartbeat bridge
     api.include_router(channels.router)  # /api/channels (health, DLQ, conversations)
     api.include_router(omnichannel.router)  # /api/omnichannel (threads, assignment)
 

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_channel_health.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_channel_health.py
@@ -1,0 +1,102 @@
+"""Verify /api/channels/{name}/health endpoint structure for Sprint 1.B Cell-side bridge.
+
+Spec ref: docs/superpowers/specs/2026-05-01-post-agentic-injection-design.md §3.3.5
+"""
+from fastapi.testclient import TestClient
+
+
+def _build_app_with_db_pool(db_pool=None):
+    """Build minimal FastAPI app with channel_health router only.
+
+    Avoids importing backend.app.main (heavy startup deps).
+    """
+    from fastapi import FastAPI
+
+    from backend.app.dependencies import get_optional_database_pool
+    from backend.app.routers import channel_health
+
+    app = FastAPI()
+    app.include_router(channel_health.router)
+    app.dependency_overrides[get_optional_database_pool] = lambda: db_pool
+    return app
+
+
+def _fake_pool(pending: int = 5, last_ts: float | None = 12345.0):
+    """Build a fake db_pool that returns the given queue depth."""
+
+    class FakePool:
+        def acquire(self):
+            class _Cm:
+                async def __aenter__(self_inner):
+                    class _Conn:
+                        async def fetchrow(self_c, sql, *args):
+                            return {"pending": pending, "last_ts": last_ts}
+
+                    return _Conn()
+
+                async def __aexit__(self_inner, *exc):
+                    return False
+
+            return _Cm()
+
+    return FakePool()
+
+
+def test_channel_health_returns_correct_schema_for_known_channels():
+    """Endpoint returns the heartbeat schema for each of the 4 known channels."""
+    app = _build_app_with_db_pool(db_pool=_fake_pool(pending=5))
+    client = TestClient(app)
+
+    for name in ("whatsapp", "telegram", "instagram", "web"):
+        r = client.get(f"/api/channels/{name}/health")
+        assert r.status_code == 200, f"{name} returned {r.status_code}"
+        body = r.json()
+        assert body["channel"] == name
+        assert body["status"] in {"ok", "degraded", "fail"}
+        assert isinstance(body["ts"], (int, float))
+        assert isinstance(body["queue_depth"], int)
+        assert "last_event_seen_at" in body  # may be null
+        assert isinstance(body["metadata"], dict)
+
+
+def test_channel_health_unknown_channel_returns_404():
+    """Unknown channel name → 404 (whitelist of 4 known names)."""
+    app = _build_app_with_db_pool(db_pool=None)
+    client = TestClient(app)
+
+    r = client.get("/api/channels/unknown_channel/health")
+    assert r.status_code == 404
+
+
+def test_channel_health_no_db_pool_returns_zero_queue_depth():
+    """When db_pool is None (no DB available), endpoint returns ok with queue_depth=0."""
+    app = _build_app_with_db_pool(db_pool=None)
+    client = TestClient(app)
+
+    r = client.get("/api/channels/whatsapp/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["queue_depth"] == 0
+    assert body["status"] == "ok"
+    assert body["last_event_seen_at"] is None
+
+
+def test_channel_health_classifies_status_by_queue_depth():
+    """Verify thresholds: <=20 ok, 21-100 degraded, >100 fail."""
+    test_cases = [
+        (0, "ok"),
+        (20, "ok"),
+        (21, "degraded"),
+        (100, "degraded"),
+        (101, "fail"),
+        (5000, "fail"),
+    ]
+
+    for pending_count, expected_status in test_cases:
+        app = _build_app_with_db_pool(db_pool=_fake_pool(pending=pending_count))
+        client = TestClient(app)
+        r = client.get("/api/channels/telegram/health")
+        body = r.json()
+        assert body["status"] == expected_status, (
+            f"queue_depth={pending_count} → expected {expected_status}, got {body['status']}"
+        )

--- a/apps/cell/cell/sensors/channel_sensor.py
+++ b/apps/cell/cell/sensors/channel_sensor.py
@@ -10,11 +10,24 @@ that the ack-first persistence layer (P0-6 audit 2026-04-29) is healthy:
 
 Reads from the database via an asyncpg connection; the sensor is meant
 to be called from Cell's PulseLoop with a per-machine connection.
+
+Sprint 1.B 2026-05-02: bridge_channels_to_sidecar() polls per-channel
+HTTP /api/channels/{name}/health and emits ~/.organism/last_seen/channel.{name}.json
+sidecar files for genome_aggregator_sensor consumption (closes gap 2 of
+Era Post-Agentica brief for channel.* organi).
 """
 from __future__ import annotations
 
+import logging
+import os
 from dataclasses import dataclass, field
 from typing import Any
+
+import httpx
+
+from cell.utils.organ_emitter import emit_organ_last_seen
+
+logger = logging.getLogger("cell.sensors.channel")
 
 
 # Same thresholds as elsewhere in the audit — keep in sync with brainstorm
@@ -26,6 +39,13 @@ _RED_THRESHOLD = 100
 # from the green/yellow/red classification — a row stuck for >2 days is
 # effectively a dead letter, not a live queue depth signal.
 _RECENT_WINDOW_MINUTES = 60
+
+# Sprint 1.B Cell-side bridge — known channels + backend base URL
+_KNOWN_CHANNELS: tuple[str, ...] = ("whatsapp", "telegram", "instagram", "web")
+_BACKEND_BASE_URL = os.environ.get(
+    "NUZANTARA_BACKEND_BASE_URL",
+    "https://nuzantara-rag.fly.dev",
+)
 
 
 @dataclass
@@ -120,6 +140,52 @@ class ChannelSensor:
                 "red_threshold": self._red,
             },
         )
+
+    async def _http_get_channel_health(self, url: str) -> dict[str, Any]:
+        """HTTP GET wrapper, returns parsed JSON. Raises on network/HTTP error.
+
+        Override-friendly seam for tests.
+        """
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            r = await client.get(url)
+            r.raise_for_status()
+            return r.json()
+
+    async def bridge_channels_to_sidecar(self) -> dict[str, str]:
+        """Poll /api/channels/{name}/health for each known channel + emit sidecar.
+
+        Sprint 1.B 2026-05-02: closes gap 2 (channel.* visibility) for the
+        genome_aggregator_sensor on Pro. Each channel becomes one sidecar
+        file at ~/.organism/last_seen/channel.{name}.json.
+
+        Returns:
+            dict {channel_name: emitted_status} — always 4 entries.
+
+        Best-effort:
+            - A single channel HTTP failure produces fail status for that
+              channel only; others continue.
+            - emit_organ_last_seen failures are logged at debug, never raise.
+        """
+        results: dict[str, str] = {}
+        for name in _KNOWN_CHANNELS:
+            url = f"{_BACKEND_BASE_URL}/api/channels/{name}/health"
+            organ_id = f"channel.{name}"
+            try:
+                body = await self._http_get_channel_health(url)
+                status = body.get("status", "fail")
+                metadata: dict[str, Any] = {
+                    "queue_depth": body.get("queue_depth", -1),
+                    "last_event_seen_at": body.get("last_event_seen_at"),
+                }
+            except Exception as exc:  # noqa: BLE001
+                status = "fail"
+                metadata = {"error": str(exc)[:200]}
+            results[name] = status
+            try:
+                emit_organ_last_seen(organ_id, status, metadata=metadata)
+            except Exception as exc:  # pragma: no cover — best-effort
+                logger.debug(f"sidecar emit failed for {organ_id}: {exc}")
+        return results
 
 
 __all__ = ["ChannelReading", "ChannelSensor"]

--- a/apps/cell/cell/sensors/health_sensor.py
+++ b/apps/cell/cell/sensors/health_sensor.py
@@ -1,8 +1,21 @@
 """Health sensor — reads /health endpoint from Nuzantara backend.
-CELL's primary sensory organ. Every 60 seconds, checks if backend is alive."""
+CELL's primary sensory organ. Every 60 seconds, checks if backend is alive.
+
+Sprint 1.B 2026-05-02: HealthSensor.read() now bridges the result into
+~/.organism/last_seen/backend.api.json via emit_organ_last_seen, so the
+genome_aggregator_sensor can classify backend.api correctly.
+"""
+import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
+
+from cell.utils.organ_emitter import emit_organ_last_seen
+
+logger = logging.getLogger("cell.sensors.health")
+
+_BACKEND_API_ORGAN_ID = "backend.api"
+
 
 @dataclass
 class HealthReading:
@@ -12,6 +25,38 @@ class HealthReading:
     response_time_seconds: float = 0.0
     body: dict[str, Any] | None = None
     error: str = ""
+
+
+def bridge_reading_to_sidecar(reading: HealthReading) -> bool:
+    """Translate a HealthReading into a Genoma sidecar file.
+
+    Sprint 1.B 2026-05-02: backend.api lives on Fly.io with ephemeral
+    filesystem; it cannot write the sidecar itself. Cell on Pro polls
+    /health and bridges the result into ~/.organism/last_seen/backend.api.json
+    via emit_organ_last_seen.
+
+    Best-effort: never raises. Returns True on emit success, False otherwise.
+
+    Mapping:
+        reachable=True, status=200      → "ok"
+        reachable=True, status!=200     → "degraded"
+        reachable=False                 → "fail"
+    """
+    if not reading.reachable:
+        status = "fail"
+    elif reading.status_code == 200:
+        status = "ok"
+    else:
+        status = "degraded"
+
+    metadata: dict[str, Any] = {"http_status": reading.status_code}
+    if reading.response_time_seconds:
+        metadata["latency_ms"] = round(reading.response_time_seconds * 1000.0, 2)
+    if reading.error:
+        metadata["error"] = reading.error[:200]
+
+    return emit_organ_last_seen(_BACKEND_API_ORGAN_ID, status, metadata=metadata)
+
 
 class HealthSensor:
     def __init__(self, client: Any, url: str, timeout: float = 10.0) -> None:
@@ -28,6 +73,20 @@ class HealthSensor:
                 body = response.json()
             except Exception:
                 pass
-            return HealthReading(timestamp=now, reachable=True, status_code=response.status_code, response_time_seconds=response.elapsed.total_seconds(), body=body)
+            reading = HealthReading(
+                timestamp=now,
+                reachable=True,
+                status_code=response.status_code,
+                response_time_seconds=response.elapsed.total_seconds(),
+                body=body,
+            )
         except Exception as e:
-            return HealthReading(timestamp=now, reachable=False, error=str(e))
+            reading = HealthReading(timestamp=now, reachable=False, error=str(e))
+
+        # Sprint 1.B Cell-side bridge: translate to Genoma sidecar (best-effort)
+        try:
+            bridge_reading_to_sidecar(reading)
+        except Exception as exc:  # pragma: no cover — bridge never raises out
+            logger.debug(f"sidecar bridge failed: {exc}")
+
+        return reading

--- a/apps/cell/tests/test_channel_sensor_emits_sidecar.py
+++ b/apps/cell/tests/test_channel_sensor_emits_sidecar.py
@@ -1,0 +1,101 @@
+"""Sprint 1.B 2026-05-02: ChannelSensor.bridge_channels_to_sidecar() emits one
+sidecar per channel after HTTP poll.
+
+Spec ref: docs/superpowers/specs/2026-05-01-post-agentic-injection-design.md §3.3.5
+"""
+from unittest.mock import patch
+
+import pytest
+
+from cell.sensors.channel_sensor import ChannelSensor
+
+
+@pytest.mark.asyncio
+async def test_bridge_emits_sidecar_per_channel():
+    """4 channels polled → 4 sidecars emitted with mapped status."""
+    sensor = ChannelSensor()
+
+    fake_responses = {
+        "whatsapp": {"status": "ok", "queue_depth": 5, "last_event_seen_at": 12345.0},
+        "telegram": {"status": "ok", "queue_depth": 0, "last_event_seen_at": None},
+        "instagram": {"status": "ok", "queue_depth": 1, "last_event_seen_at": 67890.0},
+        "web": {"status": "degraded", "queue_depth": 50, "last_event_seen_at": 11111.0},
+    }
+
+    async def fake_http_get(url):
+        for name, body in fake_responses.items():
+            if f"/{name}/health" in url:
+                return body
+        raise AssertionError(f"unexpected url {url}")
+
+    captured: list[tuple[str, str, dict]] = []
+
+    def fake_emit(organ_id, status, metadata=None, **kwargs):
+        captured.append((organ_id, status, dict(metadata or {})))
+        return True
+
+    with (
+        patch.object(sensor, "_http_get_channel_health", side_effect=fake_http_get),
+        patch("cell.sensors.channel_sensor.emit_organ_last_seen", side_effect=fake_emit),
+    ):
+        results = await sensor.bridge_channels_to_sidecar()
+
+    assert len(captured) == 4
+    organ_ids = {entry[0] for entry in captured}
+    assert organ_ids == {
+        "channel.whatsapp",
+        "channel.telegram",
+        "channel.instagram",
+        "channel.web",
+    }
+
+    by_organ = {entry[0]: entry for entry in captured}
+    assert by_organ["channel.whatsapp"][1] == "ok"
+    assert by_organ["channel.web"][1] == "degraded"
+    assert by_organ["channel.web"][2]["queue_depth"] == 50
+
+    assert results == {
+        "whatsapp": "ok",
+        "telegram": "ok",
+        "instagram": "ok",
+        "web": "degraded",
+    }
+
+
+@pytest.mark.asyncio
+async def test_bridge_emits_fail_on_http_error():
+    """HTTP error on a single channel → fail sidecar for that channel only;
+    others continue normally."""
+    sensor = ChannelSensor()
+
+    async def fake_http_get(url):
+        if "/whatsapp/" in url:
+            raise ConnectionError("simulated network failure")
+        return {"status": "ok", "queue_depth": 0, "last_event_seen_at": None}
+
+    captured: list[tuple[str, str, dict]] = []
+
+    def fake_emit(organ_id, status, metadata=None, **kwargs):
+        captured.append((organ_id, status, dict(metadata or {})))
+        return True
+
+    with (
+        patch.object(sensor, "_http_get_channel_health", side_effect=fake_http_get),
+        patch("cell.sensors.channel_sensor.emit_organ_last_seen", side_effect=fake_emit),
+    ):
+        results = await sensor.bridge_channels_to_sidecar()
+
+    assert len(captured) == 4
+    statuses = {entry[0]: entry[1] for entry in captured}
+    assert statuses["channel.whatsapp"] == "fail"
+    assert statuses["channel.telegram"] == "ok"
+    assert statuses["channel.instagram"] == "ok"
+    assert statuses["channel.web"] == "ok"
+
+    whatsapp_meta = next(
+        entry[2] for entry in captured if entry[0] == "channel.whatsapp"
+    )
+    assert "error" in whatsapp_meta
+    assert "simulated network failure" in whatsapp_meta["error"]
+
+    assert results["whatsapp"] == "fail"

--- a/apps/cell/tests/test_health_sensor_emits_sidecar.py
+++ b/apps/cell/tests/test_health_sensor_emits_sidecar.py
@@ -1,0 +1,79 @@
+"""Sprint 1.B 2026-05-02: HealthSensor must emit sidecar liveness file post-poll.
+
+Spec ref: docs/superpowers/specs/2026-05-01-post-agentic-injection-design.md §3.3.5
+"""
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from cell.sensors import health_sensor as hs
+
+
+def test_bridge_emits_ok_sidecar_on_200():
+    """Reachable + status=200 → emit ok with metadata (http_status + latency_ms)."""
+    fake_reading = hs.HealthReading(
+        timestamp=datetime.now(tz=timezone.utc),
+        reachable=True,
+        status_code=200,
+        response_time_seconds=0.047,
+    )
+
+    captured: list[tuple[str, str, dict]] = []
+
+    def fake_emit(organ_id, status, metadata=None, **kwargs):
+        captured.append((organ_id, status, dict(metadata or {})))
+        return True
+
+    with patch.object(hs, "emit_organ_last_seen", side_effect=fake_emit):
+        hs.bridge_reading_to_sidecar(fake_reading)
+
+    assert len(captured) == 1
+    organ_id, status, metadata = captured[0]
+    assert organ_id == "backend.api"
+    assert status == "ok"
+    assert metadata["http_status"] == 200
+    assert metadata["latency_ms"] == 47.0  # 0.047s * 1000 = 47 ms
+
+
+def test_bridge_emits_degraded_sidecar_on_non_200():
+    """Reachable + non-200 → degraded."""
+    fake_reading = hs.HealthReading(
+        timestamp=datetime.now(tz=timezone.utc),
+        reachable=True,
+        status_code=503,
+        response_time_seconds=0.012,
+    )
+
+    captured: list[tuple[str, str, dict]] = []
+
+    def fake_emit(organ_id, status, metadata=None, **kwargs):
+        captured.append((organ_id, status, dict(metadata or {})))
+        return True
+
+    with patch.object(hs, "emit_organ_last_seen", side_effect=fake_emit):
+        hs.bridge_reading_to_sidecar(fake_reading)
+
+    assert captured[0][:2] == ("backend.api", "degraded")
+    assert captured[0][2]["http_status"] == 503
+
+
+def test_bridge_emits_fail_sidecar_on_unreachable():
+    """Unreachable → fail with error metadata."""
+    fake_reading = hs.HealthReading(
+        timestamp=datetime.now(tz=timezone.utc),
+        reachable=False,
+        status_code=0,
+        error="connection timeout after 10s",
+    )
+
+    captured: list[tuple[str, str, dict]] = []
+
+    def fake_emit(organ_id, status, metadata=None, **kwargs):
+        captured.append((organ_id, status, dict(metadata or {})))
+        return True
+
+    with patch.object(hs, "emit_organ_last_seen", side_effect=fake_emit):
+        hs.bridge_reading_to_sidecar(fake_reading)
+
+    assert captured[0][:2] == ("backend.api", "fail")
+    assert "error" in captured[0][2]
+    assert "connection timeout" in captured[0][2]["error"]


### PR DESCRIPTION
PR #422 added channel_health module + manifest entry but router_registration.py uses explicit imports (manifest is for tests). Result: 404 in prod. Same scar as PRs #54/#55/#60. Adds 2 imports + 2 includes (main + main_api), mirroring channels router placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)