### PR TITLE
fix(observatory): OpenRouter classifier + sleep window emit (#416 followup)

### DIFF
--- a/apps/backend-rag/backend/tests/services/events/test_outbox_callsite_integration.py
+++ b/apps/backend-rag/backend/tests/services/events/test_outbox_callsite_integration.py
@@ -310,7 +310,16 @@ def _read_migration_146() -> str:
 #
 # The remaining channels DO have DB triggers (migrations 075/076/112/113/114)
 # and migration 146 must wrap each one in an events_outbox INSERT.
-_PG_NOTIFY_ONLY_CHANNELS = frozenset({"lkpm_ingest_completed", "federation_alert"})
+_PG_NOTIFY_ONLY_CHANNELS = frozenset({
+    "lkpm_ingest_completed",
+    "federation_alert",
+    # cell_pulse_observed: emitted by cell_core.observatory.emit_pulse_observed
+    # (Python direct asyncpg INSERT to events_outbox + pg_notify) inside the
+    # cell process itself, NOT via DB trigger. The events_outbox row IS
+    # written, but the path is Python-callsite, not migration-146-trigger.
+    # Track A 2026-05-02 — see PR #411 + #416 + #425.
+    "cell_pulse_observed",
+})
 _TRIGGER_BACKED_CHANNELS = frozenset(
     ch for ch in PG_CHANNEL_MAP if ch not in _PG_NOTIFY_ONLY_CHANNELS
 )

--- a/apps/cell-observatory-collector/cell_observatory/classifier.py
+++ b/apps/cell-observatory-collector/cell_observatory/classifier.py
@@ -58,10 +58,12 @@ class MinimaxClassifier:
     $1.20/M output) by overriding MODEL via OBSERVATORY_CLASSIFIER_MODEL env.
     """
     BASE_URL = "https://openrouter.ai/api/v1/chat/completions"
-    MODEL = "minimax/minimax-m2.5:free"
-    # Pricing fields preserved for cost ledger semantics — set to 0 for :free.
-    PRICE_INPUT_USD_PER_M = 0.0
-    PRICE_OUTPUT_USD_PER_M = 0.0
+    # Default to paid m2.7 (~$0.0001 per pulse classification, trivial for fase 0).
+    # The :free variant requires OpenRouter privacy "Free Model Usage" enabled —
+    # account guardrail blocks otherwise. Paid skips the guardrail.
+    MODEL = "minimax/minimax-m2.7"
+    PRICE_INPUT_USD_PER_M = 0.30
+    PRICE_OUTPUT_USD_PER_M = 1.20
 
     def __init__(self, api_key: str, circuit_threshold: int = 5,
                  circuit_recovery_s: float = 60.0):

--- a/apps/cell-observatory-collector/cell_observatory/classifier.py
+++ b/apps/cell-observatory-collector/cell_observatory/classifier.py
@@ -58,12 +58,13 @@ class MinimaxClassifier:
     $1.20/M output) by overriding MODEL via OBSERVATORY_CLASSIFIER_MODEL env.
     """
     BASE_URL = "https://openrouter.ai/api/v1/chat/completions"
-    # Default to paid m2.7 (~$0.0001 per pulse classification, trivial for fase 0).
-    # The :free variant requires OpenRouter privacy "Free Model Usage" enabled —
-    # account guardrail blocks otherwise. Paid skips the guardrail.
-    MODEL = "minimax/minimax-m2.7"
-    PRICE_INPUT_USD_PER_M = 0.30
-    PRICE_OUTPUT_USD_PER_M = 1.20
+    # m2.5 (non-reasoning): puts JSON output into choices[0].message.content
+    # as expected. m2.7 is a reasoning model and routes the model output to
+    # `reasoning` field, leaving `content=null` — broke our model_validate_json.
+    # m2.5 paid (~$0.00008 per pulse) skips the privacy guardrail that blocks :free.
+    MODEL = "minimax/minimax-m2.5"
+    PRICE_INPUT_USD_PER_M = 0.15
+    PRICE_OUTPUT_USD_PER_M = 1.15
 
     def __init__(self, api_key: str, circuit_threshold: int = 5,
                  circuit_recovery_s: float = 60.0):
@@ -78,13 +79,43 @@ class MinimaxClassifier:
         await self._client.aclose()
 
     async def _call_api(self, messages: list[dict[str, str]]) -> dict[str, Any]:
+        # max_tokens=1000: m2.5 routes long internal reasoning to `reasoning`
+        # field, leaving content empty if budget is too tight. 1000 gives
+        # ~3-5s additional latency vs 200 but ensures content is generated.
+        # response_format=json_object forces structured output (OpenRouter
+        # passes it through to MiniMax).
         resp = await self._client.post(
             self.BASE_URL,
             headers={"Authorization": f"Bearer {self._api_key}"},
-            json={"model": self.MODEL, "messages": messages, "temperature": 0.1, "max_tokens": 200},
+            json={
+                "model": self.MODEL,
+                "messages": messages,
+                "temperature": 0.1,
+                "max_tokens": 1000,
+                "response_format": {"type": "json_object"},
+            },
         )
         resp.raise_for_status()
         return resp.json()
+
+    @staticmethod
+    def _extract_content(resp: dict[str, Any]) -> str:
+        """Extract JSON content. Prefers `choices[0].message.content`; if null,
+        attempts `reasoning` field (m2.5 reasoning model fallback)."""
+        msg = resp["choices"][0]["message"]
+        content = msg.get("content")
+        if content:
+            return content
+        # Reasoning model fallback: try to extract JSON from `reasoning` field
+        reasoning = msg.get("reasoning") or ""
+        if reasoning:
+            # Look for JSON object in reasoning
+            import re
+            match = re.search(r"\{[^{}]*\"label\"[^{}]*\}", reasoning, re.DOTALL)
+            if match:
+                return match.group(0)
+        # Both empty: signal to caller via empty string
+        return ""
 
     def _check_circuit(self) -> None:
         if time.monotonic() < self._circuit_open_until:
@@ -115,16 +146,22 @@ class MinimaxClassifier:
         self._record_success()
 
         latency_ms = int((time.monotonic() - start) * 1000)
-        content = resp["choices"][0]["message"]["content"]
+        content = self._extract_content(resp)
 
         try:
+            if not content:
+                raise ValidationError.from_exception_data(
+                    "ClassificationOutput", [
+                        {"type": "missing", "loc": ("content",), "msg": "empty response"}
+                    ]
+                ) if False else ValueError("empty response from API (content+reasoning both null)")
             parsed = ClassificationOutput.model_validate_json(content)
-        except ValidationError:
+        except (ValidationError, ValueError):
             # Retry once (PR #311 pattern); if second fail propagate
-            messages.append({"role": "assistant", "content": content})
-            messages.append({"role": "user", "content": "Output was not valid JSON. Re-emit ONLY the JSON object."})
+            messages.append({"role": "assistant", "content": content or "(empty)"})
+            messages.append({"role": "user", "content": "Output was not valid JSON. Re-emit ONLY the JSON object: {\"reasoning\": \"...\", \"label\": \"normal|anomaly|critical|uncertain\", \"confidence\": 0.0}"})
             resp2 = await self._call_api(messages)
-            content2 = resp2["choices"][0]["message"]["content"]
+            content2 = self._extract_content(resp2)
             parsed = ClassificationOutput.model_validate_json(content2)
 
         usage = resp.get("usage", {})

--- a/apps/cell-observatory-collector/cell_observatory/classifier.py
+++ b/apps/cell-observatory-collector/cell_observatory/classifier.py
@@ -49,10 +49,19 @@ def _render_user_prompt(event: PulseEventV1) -> str:
 
 
 class MinimaxClassifier:
-    BASE_URL = "https://api.minimax.io/v1/chat/completions"
-    MODEL = "MiniMax-M2"
-    PRICE_INPUT_USD_PER_M = 0.30
-    PRICE_OUTPUT_USD_PER_M = 1.20
+    """
+    Routes through OpenRouter to minimax/minimax-m2.5:free (Track A activation
+    2026-05-02). Original direct minimax.io endpoint had insufficient_balance
+    on the user's account; OpenRouter free tier costs zero per call.
+
+    Switch to a paid model (e.g. `minimax/minimax-m2.7` at $0.30/M input,
+    $1.20/M output) by overriding MODEL via OBSERVATORY_CLASSIFIER_MODEL env.
+    """
+    BASE_URL = "https://openrouter.ai/api/v1/chat/completions"
+    MODEL = "minimax/minimax-m2.5:free"
+    # Pricing fields preserved for cost ledger semantics — set to 0 for :free.
+    PRICE_INPUT_USD_PER_M = 0.0
+    PRICE_OUTPUT_USD_PER_M = 0.0
 
     def __init__(self, api_key: str, circuit_threshold: int = 5,
                  circuit_recovery_s: float = 60.0):

--- a/apps/cell-observatory-collector/cell_observatory/config.py
+++ b/apps/cell-observatory-collector/cell_observatory/config.py
@@ -20,12 +20,19 @@ class Config:
     def from_env(cls) -> "Config":
         try:
             # Track A activation 2026-05-02: MiniMax classifier routes through
-            # OpenRouter (free tier minimax-m2.5:free). Reuse the existing
-            # MINIMAXM2_API_KEY env (OpenRouter key with 'sk-or-v1-' prefix).
-            # Falls back to direct MINIMAX_API_KEY for backward-compat.
-            minimax_api_key = os.environ.get("MINIMAXM2_API_KEY") or os.environ["MINIMAX_API_KEY"]
+            # OpenRouter (free tier minimax-m2.5:free). Cascade priority:
+            #   1. OPENROUTER_API_KEY (canonical OpenRouter env name)
+            #   2. MINIMAXM2_API_KEY (legacy alias)
+            #   3. MINIMAX_API_KEY (direct minimax.io fallback for paid mode)
+            minimax_api_key = (
+                os.environ.get("OPENROUTER_API_KEY")
+                or os.environ.get("MINIMAXM2_API_KEY")
+                or os.environ["MINIMAX_API_KEY"]
+            )
         except KeyError as e:
-            raise RuntimeError("MINIMAXM2_API_KEY (OpenRouter) or MINIMAX_API_KEY required") from e
+            raise RuntimeError(
+                "OPENROUTER_API_KEY or MINIMAXM2_API_KEY or MINIMAX_API_KEY required"
+            ) from e
 
         try:
             eventbus_database_url = os.environ["EVENTBUS_DATABASE_URL"]

--- a/apps/cell-observatory-collector/cell_observatory/config.py
+++ b/apps/cell-observatory-collector/cell_observatory/config.py
@@ -19,9 +19,13 @@ class Config:
     @classmethod
     def from_env(cls) -> "Config":
         try:
-            minimax_api_key = os.environ["MINIMAX_API_KEY"]
+            # Track A activation 2026-05-02: MiniMax classifier routes through
+            # OpenRouter (free tier minimax-m2.5:free). Reuse the existing
+            # MINIMAXM2_API_KEY env (OpenRouter key with 'sk-or-v1-' prefix).
+            # Falls back to direct MINIMAX_API_KEY for backward-compat.
+            minimax_api_key = os.environ.get("MINIMAXM2_API_KEY") or os.environ["MINIMAX_API_KEY"]
         except KeyError as e:
-            raise RuntimeError("MINIMAX_API_KEY required") from e
+            raise RuntimeError("MINIMAXM2_API_KEY (OpenRouter) or MINIMAX_API_KEY required") from e
 
         try:
             eventbus_database_url = os.environ["EVENTBUS_DATABASE_URL"]

--- a/apps/cell-observatory-collector/cell_observatory/models.py
+++ b/apps/cell-observatory-collector/cell_observatory/models.py
@@ -18,7 +18,10 @@ class PulseEventV1(BaseModel):
     cell_id: str
     cell_kind: str
     pulse_id: str
-    pulse_timestamp: str  # ISO 8601 string; collector converts to int ms
+    # cell-core observatory.emit_pulse_observed sends pulse_timestamp as int
+    # (epoch ms). Older brainstorm payloads + smoke fixtures used ISO str.
+    # Both must validate — Storage._to_epoch_ms handles both.
+    pulse_timestamp: int | str
     phase: str
     sensors: list[dict[str, Any]]
     pulse_result: dict[str, Any]

--- a/apps/cell-observatory-collector/tests/test_classifier.py
+++ b/apps/cell-observatory-collector/tests/test_classifier.py
@@ -25,7 +25,8 @@ async def test_classify_returns_structured():
         result = await clf.classify(event)
     assert result.label.value == "normal"
     assert result.confidence == 0.9
-    assert result.cost_usd > 0
+    # cost_usd >= 0 (zero on free OpenRouter tier minimax-m2.5:free, positive on paid models)
+    assert result.cost_usd >= 0
     await clf.aclose()
 
 

--- a/apps/cell/cell/core/pulse.py
+++ b/apps/cell/cell/core/pulse.py
@@ -410,12 +410,59 @@ class PulseEngine:
                 _m.record_pulse(
                     _cell, status.value, time.monotonic() - _t_pulse_start,
                 )
-            return PulseResult(
+
+            sleep_pulse_result = PulseResult(
                 timestamp=now,
                 health_status=status,
                 skipped=True,
                 skip_reason="sleeping — dreaming and consolidating",
             )
+
+            # Cell Pulse Observatory hook (sleep path).
+            # Emit even during sleep so observers see the full circadian cycle:
+            # dreaming pulses are interesting signal (memory consolidation,
+            # cortex hook 4) distinct from awake pulses. phase="sleep" lets
+            # downstream consumers filter.
+            try:
+                from cell_core import observatory
+                if observatory.is_enabled():
+                    import asyncio as _asyncio
+                    import os as _os
+                    import socket as _socket
+                    _asyncio.create_task(observatory.emit_pulse_observed(
+                        cell_id=_cell,
+                        cell_kind="cell",
+                        pulse_id=getattr(sleep_pulse_result, "pulse_id", f"organism-sleep-{pulse_number}"),
+                        pulse_timestamp_ms=int(now.timestamp() * 1000),
+                        phase="sleep",
+                        sensors=[
+                            {"name": k, "status": v.get("status") if isinstance(v, dict) else None,
+                             "value": v if not isinstance(v, dict) else None,
+                             "metadata": v if isinstance(v, dict) else {}}
+                            for k, v in (sensor_metadata or {}).items()
+                        ],
+                        pulse_result={
+                            "classifier_self": status.value if hasattr(status, "value") else str(status),
+                            "trend_window_min": None,
+                            "trend_label": None,
+                            "skipped": True,
+                            "skip_reason": "sleeping — dreaming and consolidating",
+                        },
+                        homeostatic_state={
+                            "circadian_phase": "asleep",
+                            "did_dream": _did_dream,
+                        },
+                        scar_signals=[],
+                        metadata={
+                            "host": _socket.gethostname(),
+                            "machine_role": _os.environ.get("MACHINE_ROLE", "unknown"),
+                            "pulse_number": pulse_number,
+                        },
+                    ))
+            except Exception as exc:
+                logger.warning(f"observatory sleep hook scheduling error (non-blocking): {exc}")
+
+            return sleep_pulse_result
 
         # LTM context — refresh every 60 pulses (~1h)
         ltm_context = self._ltm_cache


### PR DESCRIPTION
## Summary

5 commit follow-up to PR #416 (which squashed only first 3 commits). These ship the **live activation hot-fixes** verified end-to-end on Pro 2026-05-02.

### What

- **Route classifier through OpenRouter** (commit fc3930): direct minimax.io API insufficient_balance → use OpenRouter cascade priority OPENROUTER_API_KEY → MINIMAXM2_API_KEY → MINIMAX_API_KEY
- **Use paid minimax/minimax-m2.5** (3d0ac5): :free tier blocked by OpenRouter privacy guardrail; m2.7 is reasoning-only model with content=null. m2.5 (paid) ~\$0.0005/call is right balance
- **PulseEventV1.pulse_timestamp accepts int|str** (78031c2): cell-core sends int (epoch ms), brainstorm fixtures used ISO str
- **Emit during sleep cycle** (024e550): organism early-returns at line 413 with skipped=True during 02-06 UTC sleep window. Add parallel observatory hook with phase='sleep' so dataset covers full circadian cycle (24/7 instead of 20/24h)
- **max_tokens 1000 + reasoning fallback + json_object format** (3590f66): m2.5 routes long internal reasoning to message.reasoning when budget too tight; max_tokens=200 left content=null. Increase to 1000 + extract from reasoning field as fallback + force JSON output

### Verified live

- Pulse 284 (awake): label=critical, confidence=0.85, latency 6s, cost \$0.000267
- Pulse 286 (sleep): label=critical, confidence=0.95, latency 2.9s, cost \$0.000185
- 18/18 unit tests pass

### Cost estimate

~\$0.30-0.50/day at organism cadence (50-100 awake pulses/h × 20h + 12 sleep pulses/h × 4h = ~1100-2050 pulses/day × \$0.0003 avg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)