### PR TITLE
feat(cell): standalone heartbeat-bridge LaunchAgent (Sprint 1.B Task 5 partial)

### DIFF
--- a/apps/cell/com.nuzantara.heartbeat-bridge.plist
+++ b/apps/cell/com.nuzantara.heartbeat-bridge.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.nuzantara.heartbeat-bridge</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/nuzantara/Desktop/nuzantara/apps/cell/scripts/launch_heartbeat_bridge.sh</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>/Users/nuzantara/Desktop/nuzantara/apps/cell</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <key>NUZANTARA_BACKEND_BASE_URL</key>
+        <string>https://nuzantara-rag.fly.dev</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/heartbeat-bridge.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/heartbeat-bridge.stderr.log</string>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+</dict>
+</plist>

--- a/apps/cell/scripts/heartbeat_bridge_loop.py
+++ b/apps/cell/scripts/heartbeat_bridge_loop.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Standalone heartbeat bridge loop for the 4 channel webhooks.
+
+Sprint 1.B Task 5 partial (2026-05-02): the originally-planned wire-up
+into `cell/main.py` PulseEngine was deferred to Sprint 1.C to avoid
+touching the cell/main.py + cell_core/pulse.py hot path concurrently
+with the in-flight Cell Pulse Observatory PR-5 organism activation.
+
+This standalone loop bypasses that coordination concern entirely: a
+separate LaunchAgent (`com.nuzantara.heartbeat-bridge`) calls
+`ChannelSensor.bridge_channels_to_sidecar()` every 60 seconds. Each
+iteration writes 4 sidecar files to `~/.organism/last_seen/channel.{name}.json`
+which `genome_aggregator_sensor` reads to classify the organi as green.
+
+backend.api is already covered: Cell main loop's `HealthSensor.read()`
+calls `bridge_reading_to_sidecar()` post-poll (PR #422), and that emits
+`~/.organism/last_seen/backend.api.json`. This script ONLY adds the 4
+channel sidecars.
+
+Why standalone instead of wiring into cell/main.py:
+- Zero touchpoint with cell_core.observatory / pulse.py (in-flight Sprint
+  by another session — see docs/superpowers/specs/2026-05-01-cell-observatory-fase0-design.md)
+- Reversible: `launchctl bootout gui/$(id -u)/com.nuzantara.heartbeat-bridge`
+  removes the loop with no Cell behavior change
+- Survives Cell daemon restart cycles independently
+
+Spec ref: docs/superpowers/specs/2026-05-01-post-agentic-injection-design.md §3.3.5
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+import sys
+from typing import Any
+
+from cell.sensors.channel_sensor import ChannelSensor
+
+logger = logging.getLogger("cell.heartbeat_bridge")
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+
+DEFAULT_INTERVAL_SECONDS: float = 60.0
+
+_shutdown = asyncio.Event()
+
+
+def _handle_signal(sig: int, frame: Any) -> None:
+    logger.info(f"Received signal {sig}, shutting down...")
+    _shutdown.set()
+
+
+async def run_loop(interval_seconds: float = DEFAULT_INTERVAL_SECONDS) -> None:
+    """Loop forever: every interval_seconds, run channel bridge once.
+
+    Args:
+        interval_seconds: between consecutive bridge runs.
+
+    The bridge itself swallows per-channel HTTP failures (returns "fail"
+    sidecar for that channel only); this loop only catches loop-level
+    errors (e.g. KeyboardInterrupt) and logs them.
+    """
+    sensor = ChannelSensor()
+    iteration = 0
+    while not _shutdown.is_set():
+        iteration += 1
+        try:
+            results = await sensor.bridge_channels_to_sidecar()
+            logger.info(
+                f"iter={iteration} bridge results: {results}",
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(f"iter={iteration} bridge raised (caught): {exc}")
+        try:
+            await asyncio.wait_for(_shutdown.wait(), timeout=interval_seconds)
+        except asyncio.TimeoutError:
+            continue
+
+
+async def main() -> int:
+    signal.signal(signal.SIGINT, _handle_signal)
+    signal.signal(signal.SIGTERM, _handle_signal)
+
+    logger.info(
+        f"heartbeat-bridge starting; interval={DEFAULT_INTERVAL_SECONDS}s; "
+        f"emits sidecar files to ~/.organism/last_seen/channel.*.json"
+    )
+    await run_loop(DEFAULT_INTERVAL_SECONDS)
+    logger.info("heartbeat-bridge stopped cleanly")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/apps/cell/scripts/launch_heartbeat_bridge.sh
+++ b/apps/cell/scripts/launch_heartbeat_bridge.sh
@@ -12,6 +12,10 @@ CELL_CORE_DIR="$REPO_ROOT/packages/cell-core"
 cd "$CELL_DIR"
 export PYTHONPATH=".:$CELL_CORE_DIR:${PYTHONPATH:-}"
 
-# Use system python3 (3.11+); the loop has no heavy deps beyond httpx
-# (already a Cell dep) + cell.sensors.channel_sensor.
-exec python3 scripts/heartbeat_bridge_loop.py
+# Use brew python 3.12 explicitly. macOS LaunchAgents resolve `python3` to
+# Xcode's 3.9 even with /opt/homebrew/bin in PATH — the env var just
+# isn't enough for command lookup at exec time. Discovered 2026-05-02:
+# 3.9 raises "got Future attached to a different loop" on asyncio.Event
+# inside asyncio.wait_for, breaking the polling loop.
+PYTHON_BIN="${HEARTBEAT_PYTHON:-/opt/homebrew/bin/python3.12}"
+exec "$PYTHON_BIN" scripts/heartbeat_bridge_loop.py

--- a/apps/cell/scripts/launch_heartbeat_bridge.sh
+++ b/apps/cell/scripts/launch_heartbeat_bridge.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Launcher for com.nuzantara.heartbeat-bridge LaunchAgent (Sprint 1.B Task 5 partial).
+#
+# Spec: docs/superpowers/specs/2026-05-01-post-agentic-injection-design.md §3.3.5
+# Cicatrix: 2026-05-02 test-mock-vs-prod (new 3-PR chain that this resolves).
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$HOME/Desktop/nuzantara}"
+CELL_DIR="$REPO_ROOT/apps/cell"
+CELL_CORE_DIR="$REPO_ROOT/packages/cell-core"
+
+cd "$CELL_DIR"
+export PYTHONPATH=".:$CELL_CORE_DIR:${PYTHONPATH:-}"
+
+# Use system python3 (3.11+); the loop has no heavy deps beyond httpx
+# (already a Cell dep) + cell.sensors.channel_sensor.
+exec python3 scripts/heartbeat_bridge_loop.py

--- a/apps/cell/scripts/launch_heartbeat_bridge.sh
+++ b/apps/cell/scripts/launch_heartbeat_bridge.sh
@@ -12,10 +12,10 @@ CELL_CORE_DIR="$REPO_ROOT/packages/cell-core"
 cd "$CELL_DIR"
 export PYTHONPATH=".:$CELL_CORE_DIR:${PYTHONPATH:-}"
 
-# Use brew python 3.12 explicitly. macOS LaunchAgents resolve `python3` to
-# Xcode's 3.9 even with /opt/homebrew/bin in PATH — the env var just
-# isn't enough for command lookup at exec time. Discovered 2026-05-02:
-# 3.9 raises "got Future attached to a different loop" on asyncio.Event
-# inside asyncio.wait_for, breaking the polling loop.
-PYTHON_BIN="${HEARTBEAT_PYTHON:-/opt/homebrew/bin/python3.12}"
+# Use Cell's own .venv python (3.11) so we share dependencies (httpx,
+# pydantic, etc.) with the main Cell daemon. macOS launchctl resolves
+# `python3` to Xcode 3.9 even with /opt/homebrew/bin in PATH env var,
+# and 3.9 has an asyncio cross-loop bug that breaks the polling loop.
+# Brew python3.12 fixes the asyncio bug but lacks httpx; .venv has both.
+PYTHON_BIN="${HEARTBEAT_PYTHON:-$CELL_DIR/.venv/bin/python3}"
 exec "$PYTHON_BIN" scripts/heartbeat_bridge_loop.py


### PR DESCRIPTION
Standalone bypass of Sprint 1.B Task 5 wire-up: instead of touching cell/main.py (hot-path conflict with Observatory PR-5), a separate LaunchAgent runs ChannelSensor.bridge_channels_to_sidecar() every 60s. Writes 4 sidecar files (~/.organism/last_seen/channel.*.json). backend.api already covered by Cell main loop's HealthSensor post-poll wire (PR #422). Total: 5 organi visible to genome_aggregator_sensor. Reversible. Tested: 4 sidecars created correctly on Pro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)