### PR TITLE
Sprint 1 W1: intel-scraper-cell light (genome scar + HGT publisher + event bridge + admission)

### DIFF
--- a/apps/bali-intel-scraper/backend/cell/__init__.py
+++ b/apps/bali-intel-scraper/backend/cell/__init__.py
@@ -1,0 +1,46 @@
+"""intel-scraper-cell — light cell wrapping for the bali-intel-scraper.
+
+Sprint 1 W1 deliverable. Reference:
+  docs/audits/2026-05-02-cell-openclaw-brainstorm/99b_synthesis_v2.md
+  § "Sprint 1 — Intel Scraper light + HGT quarantine (1 settimana)"
+
+The intel scraper is wrapped — NOT rewritten. This package adds 3 lateral
+concerns around the existing scraping logic:
+
+* :mod:`scar_recorder` — recurring failure patterns (rate limit, paywall,
+  schema drift) land in ``packages/cell-core`` Genome as scars so future
+  runs can back off / quarantine the offending source.
+* :mod:`hgt_publisher` — high-confidence STRUCTURAL discoveries (e.g.
+  "regulator X publishes a stable RSS feed at /api/v2/news") are broadcast
+  to sibling cells via the cell-core HGT stream. Article CONTENT stays
+  scoped to UU PDP (never published).
+* :mod:`event_bridge` — every run emits one durable
+  ``intel.scraper.run`` row via :class:`ObservedShellBus`, with JSONL
+  fallback when the DB pool is unavailable.
+
+The :class:`IntelScraperCellRunner` ties the three together so a scraper
+adapter only needs to call ``runner.start_run()`` /
+``runner.record_failure()`` / ``runner.record_pattern()`` /
+``runner.finish_run()`` — implementation in :mod:`runner`.
+"""
+from __future__ import annotations
+
+from .event_bridge import IntelScraperEventBridge
+from .hgt_publisher import IntelScraperHGTBridge, StructuralPattern
+from .runner import IntelScraperCellRunner, RunSummary
+from .scar_recorder import FailureKind, IntelScraperScarRecorder
+
+CELL_NAME = "intel-scraper-cell"
+CELL_VERSION = "0.1.0"
+
+__all__ = [
+    "CELL_NAME",
+    "CELL_VERSION",
+    "IntelScraperEventBridge",
+    "IntelScraperHGTBridge",
+    "StructuralPattern",
+    "IntelScraperCellRunner",
+    "RunSummary",
+    "FailureKind",
+    "IntelScraperScarRecorder",
+]

--- a/apps/bali-intel-scraper/backend/cell/event_bridge.py
+++ b/apps/bali-intel-scraper/backend/cell/event_bridge.py
@@ -1,0 +1,130 @@
+"""Event bridge from intel-scraper-cell runs into ObservedShellBus.
+
+Each scraper run emits exactly ONE row of name ``intel.scraper.run`` to
+``observed_shell_events`` (migration 151, already live on prod) via
+:class:`backend.services.events.observed_shell.ObservedShellBus`. When
+the DB pool is unavailable, the bus auto-falls-back to JSONL at
+``~/logs/observed-shell.jsonl``.
+
+The contract is a strict superset of the schema mandated in the Sprint
+1 W1 spec — we add ``hgt_published_count`` since we already track it.
+
+Field summary::
+
+    {
+      name: "intel.scraper.run",
+      trace_id: <uuid str>,
+      status: ok|degraded|failed,
+      sources_attempted: int,
+      articles_found: int,
+      scars_added: int,
+      hgt_published_count: int,
+      duration_ms: int,
+      started_at: <iso8601>,
+      finished_at: <iso8601>,
+    }
+
+This module is deliberately thin: ObservedShellBus already implements
+all error handling. The bridge only enforces the field contract and
+status enum.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Protocol
+
+logger = logging.getLogger("intel_scraper_cell.event_bridge")
+
+
+# Match the ObservedShellBus VALID_STATUSES, but the cell only ever
+# emits these three. Anything outside the set raises at the bridge
+# layer so a typo in the scraper code is loud, not silent.
+ALLOWED_STATUSES = ("ok", "degraded", "failed")
+
+
+class _ObservedShellBusLike(Protocol):
+    """Subset of ObservedShellBus used by the bridge."""
+
+    async def emit(
+        self,
+        automation_name: str,
+        status: str,
+        payload: dict[str, Any] | None = None,
+        trace_id: str | None = None,
+    ) -> None:
+        ...
+
+
+class IntelScraperEventBridge:
+    """Wraps :class:`ObservedShellBus` for the cell's run-event contract.
+
+    Construct once per process, hand to :class:`IntelScraperCellRunner`
+    so each ``finish_run()`` call lands one row.
+    """
+
+    AUTOMATION_NAME = "intel.scraper.run"
+
+    def __init__(self, bus: _ObservedShellBusLike) -> None:
+        self._bus = bus
+
+    async def emit_run(
+        self,
+        *,
+        trace_id: str,
+        status: str,
+        sources_attempted: int,
+        articles_found: int,
+        scars_added: int,
+        hgt_published_count: int,
+        duration_ms: int,
+        started_at: str,
+        finished_at: str,
+    ) -> None:
+        """Emit one ``intel.scraper.run`` row.
+
+        Validation:
+        * ``status`` must be in :data:`ALLOWED_STATUSES` — typos surface
+          early. ObservedShellBus would coerce unknown statuses to
+          'error', but the cell-level event contract is narrower than
+          that, so we fail fast here. Test contract: a typo in status
+          raises ValueError.
+        * Counters are coerced to ``int`` (no float surprises).
+        """
+        if status not in ALLOWED_STATUSES:
+            raise ValueError(
+                f"intel.scraper.run status must be one of "
+                f"{ALLOWED_STATUSES}, got {status!r}"
+            )
+
+        payload: dict[str, Any] = {
+            "sources_attempted": int(sources_attempted),
+            "articles_found": int(articles_found),
+            "scars_added": int(scars_added),
+            "hgt_published_count": int(hgt_published_count),
+            "duration_ms": int(duration_ms),
+            "started_at": started_at,
+            "finished_at": finished_at,
+        }
+        await self._bus.emit(
+            automation_name=self.AUTOMATION_NAME,
+            status=status,
+            payload=payload,
+            trace_id=trace_id,
+        )
+        logger.info(
+            "intel_scraper.run_event status=%s sources=%d articles=%d "
+            "scars=%d hgt=%d duration_ms=%d trace_id=%s",
+            status,
+            payload["sources_attempted"],
+            payload["articles_found"],
+            payload["scars_added"],
+            payload["hgt_published_count"],
+            payload["duration_ms"],
+            trace_id,
+        )
+
+
+__all__ = [
+    "ALLOWED_STATUSES",
+    "IntelScraperEventBridge",
+]

--- a/apps/bali-intel-scraper/backend/cell/hgt_publisher.py
+++ b/apps/bali-intel-scraper/backend/cell/hgt_publisher.py
@@ -1,0 +1,177 @@
+"""HGT publisher hook for intel-scraper-cell — STRUCTURAL patterns only.
+
+When the scraper successfully discovers a *structural* finding about a
+source — e.g. "regulator X publishes a stable RSS feed at /api/v2/news",
+"site Y exposes a sitemap-index at /sitemaps/news.xml" — that finding
+is a Project-scope skill that benefits sibling cells (mata-garuda,
+research-cell future). It is broadcast via
+:class:`cell_core.hgt.publisher.HGTPublisher` to the ``cell:skills``
+Redis stream.
+
+What is NEVER published:
+ * Article content / title / snippet (UU PDP scope — client-facing
+   downstream pipeline handles content, the cell layer must not leak it).
+ * Author names, byline emails, phone numbers, NIK / NPWP / passport.
+ * Any payload that the scraper itself classifies as PII or low-confidence.
+
+Confidence threshold: ≥0.7 (matches HGTPublisher default). Patterns below
+that threshold stay in local genome only.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+from cell_core.hgt.domains import validate_domain
+from cell_core.hgt.publisher import HGTPublisher
+
+logger = logging.getLogger("intel_scraper_cell.hgt_publisher")
+
+
+@dataclass(frozen=True)
+class StructuralPattern:
+    """A structural discovery suitable for HGT broadcast.
+
+    The fields map onto the skill schema HGTPublisher expects:
+    ``id``, ``procedure``, ``precondition``, ``success_criterion``,
+    ``confidence``, ``scope``, ``type``, ``domain``.
+
+    ``content`` (the raw article body) is intentionally NOT a field —
+    it does not belong in HGT. Add new metadata fields here if needed,
+    but never an article body / title field.
+    """
+
+    pattern_id: str
+    source: str
+    procedure: str               # what the pattern says, in plain English
+    precondition: str            # when this pattern applies
+    success_criterion: str       # how to know the pattern still holds
+    confidence: float
+    domain: str = "news"         # default domain for intel-scraper findings
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_skill_dict(self, cell_origin: str) -> dict[str, Any]:
+        """Render as the dict shape :meth:`HGTPublisher.publish` accepts.
+
+        Always Project-scope, type=skill. The pattern_id is namespaced
+        with ``intel.scraper.pattern.`` so consumers can filter on it.
+        """
+        return {
+            "id": f"intel.scraper.pattern.{self.pattern_id}",
+            "cell_origin": cell_origin,
+            "procedure": self.procedure,
+            "precondition": self.precondition,
+            "success_criterion": self.success_criterion,
+            "confidence": float(self.confidence),
+            "scope": "Project",
+            "type": "skill",
+            "domain": validate_domain(self.domain),
+            "_metadata": dict(self.metadata),
+        }
+
+
+class _RedisLike(Protocol):
+    """Subset of redis.asyncio.Redis used by HGTPublisher."""
+
+    async def xadd(
+        self,
+        stream: str,
+        fields: dict[str, str],
+        maxlen: int | None = None,
+    ) -> Any:
+        ...
+
+
+class IntelScraperHGTBridge:
+    """Wraps :class:`HGTPublisher` with the cell-specific filters.
+
+    Filters in addition to HGTPublisher's confidence ≥0.7 + scope=Project
+    + type≠scar gate:
+
+    * Reject patterns whose ``procedure`` contains any of the PII markers
+      (``email``, ``@``, ``+62``, ``NIK``, ``NPWP``, ``passport``).
+      This is defense-in-depth; the scraper is supposed to never pass
+      such payloads in the first place, but the cell layer must not
+      trust upstream to be clean.
+    * Reject patterns whose ``confidence`` is exactly 1.0 — that's
+      almost always a fixture / test value, not an empirical confidence.
+    """
+
+    # Defense-in-depth PII markers. Conservative — matches a handful of
+    # case-insensitive substrings. False positives here are acceptable
+    # (the pattern stays in local genome instead of being broadcast);
+    # false negatives are not.
+    _PII_MARKERS = ("email", "@", "+62", "nik:", "npwp:", "passport")
+
+    def __init__(self, publisher: HGTPublisher) -> None:
+        self._publisher = publisher
+        self._cell_origin = publisher._cell_name  # type: ignore[attr-defined]
+
+    @classmethod
+    def from_redis(
+        cls,
+        redis_client: _RedisLike | None,
+        cell_name: str = "intel-scraper-cell",
+        maxlen: int = 1000,
+    ) -> "IntelScraperHGTBridge":
+        """Build a bridge from a redis client (or ``None`` for a no-op).
+
+        When ``redis_client`` is None, :class:`HGTPublisher` returns
+        False immediately on every publish call — the pattern stays
+        in local genome, no error propagated to the runner.
+        """
+        publisher = HGTPublisher(
+            redis_client=redis_client,
+            cell_name=cell_name,
+            maxlen=maxlen,
+        )
+        return cls(publisher=publisher)
+
+    def _is_pii_tainted(self, pattern: StructuralPattern) -> bool:
+        """True if the pattern's procedure/precondition mentions PII markers."""
+        haystack = " ".join(
+            (pattern.procedure or "", pattern.precondition or "",
+             pattern.success_criterion or "")
+        ).lower()
+        return any(m in haystack for m in self._PII_MARKERS)
+
+    async def publish(self, pattern: StructuralPattern) -> bool:
+        """Publish one structural pattern. Returns True iff broadcast.
+
+        Filter order: cell-side filters FIRST, then HGTPublisher's
+        threshold checks. We log at INFO when filtered locally so a
+        rejected pattern is auditable without a redis transcript.
+        """
+        if pattern.confidence == 1.0:
+            logger.info(
+                "intel_scraper.hgt_filtered reason=confidence_eq_1 pattern=%s",
+                pattern.pattern_id,
+            )
+            return False
+        if self._is_pii_tainted(pattern):
+            logger.warning(
+                "intel_scraper.hgt_filtered reason=pii_marker pattern=%s",
+                pattern.pattern_id,
+            )
+            return False
+
+        skill = pattern.to_skill_dict(cell_origin=self._cell_origin)
+        published = await self._publisher.publish(skill)
+        logger.info(
+            "intel_scraper.hgt_publish_attempt pattern=%s confidence=%.2f "
+            "published=%s domain=%s ts=%s",
+            pattern.pattern_id,
+            pattern.confidence,
+            published,
+            skill["domain"],
+            datetime.now(timezone.utc).isoformat(),
+        )
+        return published
+
+
+__all__ = [
+    "IntelScraperHGTBridge",
+    "StructuralPattern",
+]

--- a/apps/bali-intel-scraper/backend/cell/runner.py
+++ b/apps/bali-intel-scraper/backend/cell/runner.py
@@ -1,0 +1,268 @@
+"""Orchestrator that ties scar recorder + HGT publisher + event bridge together.
+
+A scraper adapter integrates the cell with three calls per run:
+
+    runner = IntelScraperCellRunner(scar_recorder, hgt_bridge, event_bridge)
+    async with runner.run(trace_id=...) as session:
+        # for each source attempted:
+        session.note_source_attempted("imigrasi.go.id")
+        try:
+            articles = await scrape_source("imigrasi.go.id")
+            session.note_articles_found(len(articles))
+            for pattern in extract_structural_patterns(articles):
+                await session.publish_pattern(pattern)
+        except RateLimit as exc:
+            session.record_failure("imigrasi.go.id",
+                                    FailureKind.RATE_LIMIT, str(exc))
+        except Exception as exc:
+            session.record_failure("imigrasi.go.id",
+                                    FailureKind.HTTP_5XX, repr(exc))
+
+    # On exit the runner emits one observed_shell row with the
+    # accumulated counters and computed status.
+
+The status computation is deterministic:
+
+* 0 sources_attempted        → "failed"  (pipeline never started)
+* ≥1 source_attempted but 0 articles AND ≥1 scars        → "failed"
+* articles_found > 0 AND scars_added == 0                → "ok"
+* articles_found > 0 AND scars_added > 0                 → "degraded"
+* articles_found == 0 AND scars_added == 0               → "degraded"
+  (e.g. scrape ran clean but every feed was empty — operator should
+  inspect, but it's not a hard failure)
+
+The runner never raises on bus / publisher errors — those degrade to
+JSONL or in-memory drop respectively. Caller exceptions propagate.
+"""
+from __future__ import annotations
+
+import contextlib
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import AsyncIterator
+
+from .event_bridge import IntelScraperEventBridge
+from .hgt_publisher import IntelScraperHGTBridge, StructuralPattern
+from .scar_recorder import FailureKind, IntelScraperScarRecorder, ScarRecord
+
+logger = logging.getLogger("intel_scraper_cell.runner")
+
+
+@dataclass
+class RunSummary:
+    """Counters + identifiers for one scraper run.
+
+    Mutated in place by :class:`_RunSession`. ``finish_run`` reads it
+    to populate the observed_shell row.
+    """
+
+    trace_id: str
+    started_at: str
+    sources_attempted: int = 0
+    articles_found: int = 0
+    scars: list[ScarRecord] = field(default_factory=list)
+    hgt_published_count: int = 0
+    finished_at: str = ""
+    duration_ms: int = 0
+
+    @property
+    def scars_added(self) -> int:
+        return len(self.scars)
+
+
+class _RunSession:
+    """The per-run object returned by ``IntelScraperCellRunner.run``.
+
+    It exposes only the four mutator methods the scraper needs. The
+    runner controls finalization (status computation + bus emit).
+    """
+
+    def __init__(
+        self,
+        summary: RunSummary,
+        scar_recorder: IntelScraperScarRecorder,
+        hgt_bridge: IntelScraperHGTBridge,
+    ) -> None:
+        self._summary = summary
+        self._scar_recorder = scar_recorder
+        self._hgt_bridge = hgt_bridge
+
+    @property
+    def trace_id(self) -> str:
+        return self._summary.trace_id
+
+    def note_source_attempted(self, source: str) -> None:
+        """Record one source attempt — counters only, no I/O."""
+        self._summary.sources_attempted += 1
+        logger.debug("intel_scraper.source_attempted source=%s", source)
+
+    def note_articles_found(self, count: int) -> None:
+        """Increment the articles_found counter by `count` (clipped ≥0)."""
+        if count < 0:
+            count = 0
+        self._summary.articles_found += int(count)
+
+    def record_failure(
+        self,
+        source: str,
+        kind: FailureKind,
+        detail: str = "",
+    ) -> ScarRecord:
+        """Record a failure scar via the scar recorder.
+
+        Best-effort: a Genome failure (e.g. SQLite locked) is logged
+        and a synthetic ScarRecord is returned with ``confidence=0.0``
+        so the run summary still reflects the attempt. The run
+        continues — Symbiosis Law 4.
+        """
+        try:
+            scar = self._scar_recorder.record(
+                source=source, kind=kind, detail=detail
+            )
+        except Exception as exc:  # noqa: BLE001  (defense in depth)
+            logger.error(
+                "intel_scraper.scar_recorder_failed source=%s kind=%s err=%r",
+                source,
+                kind.value,
+                exc,
+            )
+            scar = ScarRecord(
+                scar_id=IntelScraperScarRecorder.make_scar_id(source, kind),
+                source=source,
+                kind=kind,
+                detail=(detail or "")[:500],
+                confidence=0.0,
+                recorded_at=datetime.now(timezone.utc).isoformat(),
+            )
+        self._summary.scars.append(scar)
+        return scar
+
+    async def publish_pattern(self, pattern: StructuralPattern) -> bool:
+        """Publish one structural pattern via HGT. Returns True iff broadcast.
+
+        Best-effort: bridge / Redis errors are swallowed; the pattern
+        stays in local genome (caller is responsible for genome-side
+        recording — the bridge is broadcast-only).
+        """
+        try:
+            published = await self._hgt_bridge.publish(pattern)
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "intel_scraper.hgt_publish_failed pattern=%s err=%r",
+                pattern.pattern_id,
+                exc,
+            )
+            return False
+        if published:
+            self._summary.hgt_published_count += 1
+        return published
+
+
+def _compute_status(summary: RunSummary) -> str:
+    """Deterministic status mapping. See module docstring for rules."""
+    if summary.sources_attempted == 0:
+        return "failed"
+    if summary.articles_found == 0 and summary.scars_added > 0:
+        return "failed"
+    if summary.articles_found > 0 and summary.scars_added == 0:
+        return "ok"
+    return "degraded"
+
+
+class IntelScraperCellRunner:
+    """Top-level cell wrapper. One instance per process.
+
+    Holds references to the genome scar recorder, HGT bridge, and event
+    bridge. Each call to :meth:`run` allocates a new :class:`_RunSession`
+    + :class:`RunSummary`. The runner is async-context-manager-shaped
+    via :meth:`run` so the bus emit happens deterministically on exit
+    (including on exception — the run is still recorded as failed).
+    """
+
+    def __init__(
+        self,
+        scar_recorder: IntelScraperScarRecorder,
+        hgt_bridge: IntelScraperHGTBridge,
+        event_bridge: IntelScraperEventBridge,
+    ) -> None:
+        self._scar_recorder = scar_recorder
+        self._hgt_bridge = hgt_bridge
+        self._event_bridge = event_bridge
+        self._last_summary: RunSummary | None = None
+
+    @property
+    def last_summary(self) -> RunSummary | None:
+        """Most recent finished run's summary — for monitoring / tests."""
+        return self._last_summary
+
+    @contextlib.asynccontextmanager
+    async def run(
+        self,
+        trace_id: str | None = None,
+    ) -> AsyncIterator[_RunSession]:
+        """Async context manager that scopes one scraper run.
+
+        On enter: creates the summary, emits no event yet.
+        On exit (success OR exception): computes status from counters,
+        emits exactly one ``intel.scraper.run`` row via the event
+        bridge. Exceptions raised inside the ``with`` block re-raise
+        AFTER the event is emitted (status='failed' if the block
+        recorded ≥1 source but threw, 'failed' is also the case when
+        the block threw before recording any source).
+        """
+        tid = trace_id or f"intel-scraper-{uuid.uuid4()}"
+        started_dt = datetime.now(timezone.utc)
+        started_perf = time.perf_counter()
+        summary = RunSummary(
+            trace_id=tid,
+            started_at=started_dt.isoformat(),
+        )
+        session = _RunSession(
+            summary=summary,
+            scar_recorder=self._scar_recorder,
+            hgt_bridge=self._hgt_bridge,
+        )
+        threw = False
+        try:
+            yield session
+        except Exception:
+            threw = True
+            raise
+        finally:
+            duration_ms = int((time.perf_counter() - started_perf) * 1000)
+            finished_dt = datetime.now(timezone.utc)
+            summary.duration_ms = duration_ms
+            summary.finished_at = finished_dt.isoformat()
+            status = "failed" if threw else _compute_status(summary)
+
+            try:
+                await self._event_bridge.emit_run(
+                    trace_id=summary.trace_id,
+                    status=status,
+                    sources_attempted=summary.sources_attempted,
+                    articles_found=summary.articles_found,
+                    scars_added=summary.scars_added,
+                    hgt_published_count=summary.hgt_published_count,
+                    duration_ms=summary.duration_ms,
+                    started_at=summary.started_at,
+                    finished_at=summary.finished_at,
+                )
+            except Exception as exc:  # noqa: BLE001
+                # ObservedShellBus is supposed to swallow everything,
+                # so reaching here means the bridge layer raised. Log
+                # and continue — the parent must NOT cascade.
+                logger.error(
+                    "intel_scraper.event_bridge_failed trace_id=%s err=%r",
+                    summary.trace_id,
+                    exc,
+                )
+            self._last_summary = summary
+
+
+__all__ = [
+    "IntelScraperCellRunner",
+    "RunSummary",
+]

--- a/apps/bali-intel-scraper/backend/cell/scar_recorder.py
+++ b/apps/bali-intel-scraper/backend/cell/scar_recorder.py
@@ -1,0 +1,179 @@
+"""Genome scar recorder for intel-scraper-cell.
+
+Each known failure pattern hit during a scrape (rate limit, paywall,
+robots.txt block, DNS fail, schema drift) lands as a scar in the cell-core
+Genome. Scars are NEVER blocking — record-then-continue is the contract.
+Cross-run learning later reads them to compute backoff / quarantine windows.
+
+Scope: Personal (somatic, never inherited via HGT). The structural patterns
+that DO get shared with sibling cells go through :mod:`hgt_publisher`.
+
+Scar id namespace: ``intel.scraper.<source_slug>.<failure_kind>``.
+
+This module imports :class:`Genome` lazily so import does not require
+SQLite schema setup at process start (``Genome.__init__`` runs DDL on
+the SQLite file). The scraper passes a Genome instance built once per
+process to :class:`IntelScraperScarRecorder`.
+"""
+from __future__ import annotations
+
+import enum
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Protocol
+
+logger = logging.getLogger("intel_scraper_cell.scar_recorder")
+
+
+class FailureKind(str, enum.Enum):
+    """Known failure pattern classes for intel scraper sources.
+
+    Each value maps to a stable scar id suffix. Add new kinds here as
+    they're identified — never reuse an existing kind for a different
+    semantics, or you'll merge two unrelated scars.
+    """
+
+    RATE_LIMIT = "rate_limit"             # HTTP 429 / Retry-After observed
+    PAYWALL = "paywall"                   # HTTP 402 / 403 with paywall body markers
+    ROBOTS_BLOCKED = "robots_blocked"     # robots.txt forbids the path
+    DNS_FAIL = "dns_fail"                 # NXDOMAIN / SERVFAIL
+    CONNECT_TIMEOUT = "connect_timeout"
+    READ_TIMEOUT = "read_timeout"
+    SCHEMA_DRIFT = "schema_drift"         # parser hit unexpected layout
+    HTTP_5XX = "http_5xx"                 # upstream server error
+    EMPTY_FEED = "empty_feed"             # 200 OK but no articles
+
+
+# `source` slugs are arbitrary lowercase strings (e.g. domain or feed id).
+# We sanitize them so the scar id stays grep-friendly and SQLite-safe.
+_SOURCE_SLUG_RE = re.compile(r"[^a-z0-9_]+")
+
+
+def _slugify(source: str) -> str:
+    """Lowercase + collapse non-[a-z0-9_] runs into single underscores."""
+    s = _SOURCE_SLUG_RE.sub("_", source.strip().lower()).strip("_")
+    return s or "unknown"
+
+
+@dataclass(frozen=True)
+class ScarRecord:
+    """Immutable record of one scar that was just recorded.
+
+    Returned from :meth:`IntelScraperScarRecorder.record` so the runner
+    can include it in the run summary without re-reading the DB.
+    """
+
+    scar_id: str
+    source: str
+    kind: FailureKind
+    detail: str
+    confidence: float
+    recorded_at: str   # ISO 8601 UTC
+
+
+class _GenomeLike(Protocol):
+    """Subset of :class:`cell_core.genome.Genome` used by the recorder.
+
+    Allows tests to pass a stub without instantiating SQLite.
+    """
+
+    def record_scar(
+        self,
+        cell: str,
+        scar_id: str,
+        procedure: str,
+        precondition: str = "",
+    ) -> str:
+        ...
+
+    def use_skill(self, skill_id: str) -> None:
+        ...
+
+
+class IntelScraperScarRecorder:
+    """Record-then-continue scar emitter for intel-scraper-cell.
+
+    Confidence stays at the Genome default for scars (0.9, see
+    ``Genome.record_scar``). Each call to :meth:`record` either inserts
+    a new row or bumps the existing scar's ``uses`` counter via
+    ``Genome.use_skill`` — the second call is the cross-run signal that
+    "domain X has been rate-limiting us 5x in 24h" without us writing
+    a custom counter table.
+    """
+
+    CELL_NAME = "intel-scraper-cell"
+    SCAR_NAMESPACE = "intel.scraper"
+
+    def __init__(self, genome: _GenomeLike) -> None:
+        self._genome = genome
+
+    @staticmethod
+    def make_scar_id(source: str, kind: FailureKind) -> str:
+        """Stable scar id: ``intel.scraper.<source_slug>.<failure_kind>``.
+
+        >>> IntelScraperScarRecorder.make_scar_id("imigrasi.go.id", FailureKind.RATE_LIMIT)
+        'intel.scraper.imigrasi_go_id.rate_limit'
+        """
+        return f"intel.scraper.{_slugify(source)}.{kind.value}"
+
+    def record(
+        self,
+        source: str,
+        kind: FailureKind,
+        detail: str = "",
+    ) -> ScarRecord:
+        """Record one scar. Idempotent at the (source, kind) level.
+
+        On the first call: inserts a Personal-scope scar via
+        ``Genome.record_scar``. On subsequent calls with the same id:
+        ``Genome.record_scar`` upserts (keeps max confidence) and we
+        bump ``uses`` separately via ``use_skill`` so the cross-run
+        signal is observable.
+        """
+        scar_id = self.make_scar_id(source, kind)
+        # detail is kept under 500 chars to avoid pathological growth
+        # if upstream throws a giant traceback as the failure detail.
+        clipped_detail = (detail or "")[:500]
+        procedure = (
+            f"intel-scraper hit {kind.value} on '{source}': {clipped_detail}. "
+            f"Back off this source on next run; if scar uses ≥5 in 24h, "
+            f"quarantine for 2h before retry."
+        )
+        precondition = f"target source = {source}"
+
+        # First record_scar does the insert OR upsert.
+        self._genome.record_scar(
+            cell=self.CELL_NAME,
+            scar_id=scar_id,
+            procedure=procedure,
+            precondition=precondition,
+        )
+        # Then bump uses + last_used so cross-run accumulation is visible.
+        # use_skill is a no-op on a freshly-inserted row except for
+        # uses=1 + last_used=now, which is exactly what we want.
+        self._genome.use_skill(scar_id)
+
+        recorded_at = datetime.now(timezone.utc).isoformat()
+        logger.info(
+            "intel_scraper.scar_recorded source=%s kind=%s scar_id=%s",
+            source,
+            kind.value,
+            scar_id,
+        )
+        return ScarRecord(
+            scar_id=scar_id,
+            source=source,
+            kind=kind,
+            detail=clipped_detail,
+            confidence=0.9,
+            recorded_at=recorded_at,
+        )
+
+
+__all__ = [
+    "FailureKind",
+    "IntelScraperScarRecorder",
+    "ScarRecord",
+]

--- a/apps/bali-intel-scraper/cell.yaml
+++ b/apps/bali-intel-scraper/cell.yaml
@@ -1,0 +1,80 @@
+# intel-scraper-cell (light) — Sprint 1 W1
+#
+# Reference: docs/audits/2026-05-02-cell-openclaw-brainstorm/99b_synthesis_v2.md
+# § "Sprint 1 — Intel Scraper light + HGT quarantine (1 settimana)".
+#
+# Light cell: keeps existing scraper code intact, wraps it with
+#   1. Genome scar registry (failure pattern accumulation)
+#   2. HGT publisher (structural pattern broadcast on confidence ≥0.7)
+#   3. ObservedShellBus event bridge (durable run trace)
+#
+# Validated against the 7 Leggi via packages/cell-core/cell_core/admission_test.py.
+# Run `pytest packages/cell-core/tests/test_admission.py -k intel_scraper -v`
+# before any structural change to this file.
+
+name: intel-scraper-cell
+version: 0.1.0
+level: L1
+runtime: cron-agent-python   # daily 03:00 WITA + intel-radar hourly + intel-feed-processor 2h
+owner: intel-team
+
+cell_class: cell
+
+# 7 Leggi declarations (consumed by AdmissionTest)
+exposes_gui: false
+llm_invocation: deepseek_api   # article_composer uses DeepSeek (~$0.01/query, NOT Anthropic — see Golden Rule #13)
+external_sources:
+  - imigrasi.go.id
+  - bps.go.id
+  - bali.tribunnews.com
+  - djp.go.id
+  - bi.go.id
+  - oss.go.id
+client_data_access: false   # OSINT blindato — never reads CRM / client PII
+publishes_via: pg_notify    # ObservedShellBus → events_outbox → pg_notify
+fallback_modes:
+  - postgres_down            # JSONL fallback in observed_shell.py
+  - redis_down               # HGT publisher returns False (skill stays in local genome)
+  - source_unreachable       # per-source scar recorded, run continues with remaining sources
+  - llm_provider_down        # article_composer skipped, raw findings still persisted
+  - schema_drift             # parser scar recorded, source quarantined for the run
+kill_switch: true            # disable via launchctl unload com.balizero.intel.nightly
+auto_publishes: false        # findings land in Qdrant + DB; carousel/Telegram require human gate
+depends_on_other_cell_decisions: false   # reads OSINT directly, not other cells' verdicts
+
+metrics:
+  - sources_attempted
+  - articles_found
+  - scars_added
+  - hgt_published_count
+  - duration_ms
+  - source_failure_rate
+
+# Event contracts (consumers can rely on these field names + types)
+event_contracts:
+  - name: intel.scraper.run
+    description: One row per scraper run (success | degraded | failed)
+    fields:
+      trace_id: uuid
+      status: enum(ok|degraded|failed)
+      sources_attempted: int
+      articles_found: int
+      scars_added: int
+      hgt_published_count: int
+      duration_ms: int
+      started_at: iso8601
+      finished_at: iso8601
+
+# SLA + ownership
+sla:
+  daily_run_window_wita: "03:00"
+  max_runtime_minutes: 120
+  health_signal: events_outbox row with status in {ok,degraded} within 24h
+  on_silent_failure: light-cell does NOT auto-restart; alert via cron-agent-python silence detector
+
+# Scar id namespace (for cross-run learning)
+scar_namespace_prefix: "intel.scraper"   # e.g. intel.scraper.imigrasi.rate_limit
+
+# HGT publishing rules (in addition to HGTPublisher.CONFIDENCE_THRESHOLD)
+hgt_publish_only_structural_patterns: true   # never publish article CONTENT (UU PDP scope)
+hgt_default_domain: news

--- a/apps/bali-intel-scraper/tests/unit/cell/test_event_bridge.py
+++ b/apps/bali-intel-scraper/tests/unit/cell/test_event_bridge.py
@@ -1,0 +1,106 @@
+"""Unit tests for intel-scraper-cell event_bridge.
+
+Mocks ObservedShellBus with AsyncMock — exercises the contract layer,
+not the bus internals (those have their own tests in
+``apps/backend-rag/backend/tests/services/events/test_observed_shell.py``).
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.cell.event_bridge import (
+    ALLOWED_STATUSES,
+    IntelScraperEventBridge,
+)
+
+
+def _make_kwargs(**overrides):
+    base = {
+        "trace_id": "intel-scraper-test-1",
+        "status": "ok",
+        "sources_attempted": 4,
+        "articles_found": 12,
+        "scars_added": 0,
+        "hgt_published_count": 1,
+        "duration_ms": 4321,
+        "started_at": "2026-05-02T03:00:00+00:00",
+        "finished_at": "2026-05-02T03:00:04+00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_emit_run_calls_bus_with_correct_contract() -> None:
+    fake_bus = AsyncMock()
+    bridge = IntelScraperEventBridge(fake_bus)
+    await bridge.emit_run(**_make_kwargs())
+
+    fake_bus.emit.assert_awaited_once()
+    kwargs = fake_bus.emit.await_args.kwargs
+    assert kwargs["automation_name"] == "intel.scraper.run"
+    assert kwargs["status"] == "ok"
+    assert kwargs["trace_id"] == "intel-scraper-test-1"
+    payload = kwargs["payload"]
+    assert payload == {
+        "sources_attempted": 4,
+        "articles_found": 12,
+        "scars_added": 0,
+        "hgt_published_count": 1,
+        "duration_ms": 4321,
+        "started_at": "2026-05-02T03:00:00+00:00",
+        "finished_at": "2026-05-02T03:00:04+00:00",
+    }
+
+
+@pytest.mark.asyncio
+async def test_emit_run_status_typo_raises_value_error() -> None:
+    """Cell-level event contract is narrower than ObservedShellBus
+    VALID_STATUSES — typos surface as ValueError, not silent coercion."""
+    fake_bus = AsyncMock()
+    bridge = IntelScraperEventBridge(fake_bus)
+    with pytest.raises(ValueError, match="status must be one of"):
+        await bridge.emit_run(**_make_kwargs(status="OKAY"))
+    fake_bus.emit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_emit_run_coerces_floats_to_ints() -> None:
+    fake_bus = AsyncMock()
+    bridge = IntelScraperEventBridge(fake_bus)
+    await bridge.emit_run(**_make_kwargs(
+        sources_attempted=4.0,
+        articles_found=12.7,
+        scars_added=0.0,
+        hgt_published_count=1.9,
+        duration_ms=4321.5,
+    ))
+    payload = fake_bus.emit.await_args.kwargs["payload"]
+    assert isinstance(payload["sources_attempted"], int)
+    assert isinstance(payload["articles_found"], int)
+    assert isinstance(payload["scars_added"], int)
+    assert isinstance(payload["hgt_published_count"], int)
+    assert isinstance(payload["duration_ms"], int)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ALLOWED_STATUSES)
+async def test_emit_run_accepts_each_allowed_status(status: str) -> None:
+    fake_bus = AsyncMock()
+    bridge = IntelScraperEventBridge(fake_bus)
+    await bridge.emit_run(**_make_kwargs(status=status))
+    fake_bus.emit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_emit_run_propagates_bus_exception() -> None:
+    """The bridge does NOT swallow bus exceptions — that's the runner's
+    job. ObservedShellBus is supposed to swallow internally; if it
+    doesn't, the bridge layer raises and the runner catches at finally."""
+    fake_bus = AsyncMock()
+    fake_bus.emit = AsyncMock(side_effect=RuntimeError("bus down"))
+    bridge = IntelScraperEventBridge(fake_bus)
+    with pytest.raises(RuntimeError, match="bus down"):
+        await bridge.emit_run(**_make_kwargs())

--- a/apps/bali-intel-scraper/tests/unit/cell/test_hgt_publisher.py
+++ b/apps/bali-intel-scraper/tests/unit/cell/test_hgt_publisher.py
@@ -1,0 +1,156 @@
+"""Unit tests for intel-scraper-cell hgt_publisher.
+
+Mocks redis.asyncio.Redis with AsyncMock — no real Redis. Cf.
+``packages/cell-core/tests/hgt/`` for the underlying HGTPublisher tests.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.cell.hgt_publisher import (
+    IntelScraperHGTBridge,
+    StructuralPattern,
+)
+
+
+def _make_pattern(
+    *,
+    confidence: float = 0.85,
+    procedure: str = "Site exposes RSS at /api/v2/news with stable schema",
+    precondition: str = "scraper hits djp.go.id homepage",
+    success_criterion: str = "feed parses and yields ≥1 item",
+    domain: str = "news",
+    pattern_id: str = "djp_rss_v2",
+) -> StructuralPattern:
+    return StructuralPattern(
+        pattern_id=pattern_id,
+        source="djp.go.id",
+        procedure=procedure,
+        precondition=precondition,
+        success_criterion=success_criterion,
+        confidence=confidence,
+        domain=domain,
+    )
+
+
+@pytest.mark.asyncio
+async def test_publish_high_confidence_pattern_broadcasts() -> None:
+    fake_redis = MagicMock()
+    fake_redis.xadd = AsyncMock(return_value=b"1-0")
+    bridge = IntelScraperHGTBridge.from_redis(fake_redis,
+                                              cell_name="intel-scraper-cell")
+
+    ok = await bridge.publish(_make_pattern(confidence=0.85))
+    assert ok is True
+    fake_redis.xadd.assert_awaited_once()
+    args, kwargs = fake_redis.xadd.await_args
+    assert args[0] == "cell:skills"
+    fields = args[1]
+    assert fields["skill_id"] == "intel.scraper.pattern.djp_rss_v2"
+    assert fields["cell_origin"] == "intel-scraper-cell"
+    assert fields["confidence"] == "0.85"
+    assert fields["scope"] == "Project"
+    assert fields["domain"] == "news"
+
+
+@pytest.mark.asyncio
+async def test_publish_below_threshold_filtered_by_publisher() -> None:
+    fake_redis = MagicMock()
+    fake_redis.xadd = AsyncMock()
+    bridge = IntelScraperHGTBridge.from_redis(fake_redis,
+                                              cell_name="intel-scraper-cell")
+
+    ok = await bridge.publish(_make_pattern(confidence=0.5))
+    assert ok is False
+    fake_redis.xadd.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_publish_exact_one_confidence_filtered_locally() -> None:
+    """Cell-level rule: confidence == 1.0 is almost always a fixture/test
+    sentinel, NOT an empirical confidence. Filter before HGTPublisher."""
+    fake_redis = MagicMock()
+    fake_redis.xadd = AsyncMock()
+    bridge = IntelScraperHGTBridge.from_redis(fake_redis,
+                                              cell_name="intel-scraper-cell")
+
+    ok = await bridge.publish(_make_pattern(confidence=1.0))
+    assert ok is False
+    fake_redis.xadd.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_publish_pii_marker_blocks_broadcast() -> None:
+    """Defense-in-depth: a procedure containing PII markers (email, +62,
+    NPWP, passport) is filtered before HGT — content stays in local
+    genome, never on the cell:skills stream."""
+    fake_redis = MagicMock()
+    fake_redis.xadd = AsyncMock()
+    bridge = IntelScraperHGTBridge.from_redis(fake_redis,
+                                              cell_name="intel-scraper-cell")
+
+    pattern_with_email = _make_pattern(
+        procedure="ping admin@djp.go.id when feed breaks",
+    )
+    ok = await bridge.publish(pattern_with_email)
+    assert ok is False
+    fake_redis.xadd.assert_not_called()
+
+    pattern_with_phone = _make_pattern(
+        precondition="contact +62 812-3456 if scrape blocked",
+    )
+    ok2 = await bridge.publish(pattern_with_phone)
+    assert ok2 is False
+
+    pattern_with_npwp = _make_pattern(
+        success_criterion="payload contains npwp: 12.345.678.9-012.000",
+    )
+    ok3 = await bridge.publish(pattern_with_npwp)
+    assert ok3 is False
+
+
+@pytest.mark.asyncio
+async def test_publish_redis_none_returns_false_silently() -> None:
+    """Redis unavailable: publish returns False, no exception."""
+    bridge = IntelScraperHGTBridge.from_redis(None,
+                                              cell_name="intel-scraper-cell")
+    ok = await bridge.publish(_make_pattern(confidence=0.9))
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_publish_redis_xadd_failure_returns_false() -> None:
+    """Redis xadd raising: HGTPublisher catches; bridge surfaces False."""
+    fake_redis = MagicMock()
+    fake_redis.xadd = AsyncMock(side_effect=ConnectionError("redis down"))
+    bridge = IntelScraperHGTBridge.from_redis(fake_redis,
+                                              cell_name="intel-scraper-cell")
+    ok = await bridge.publish(_make_pattern(confidence=0.9))
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_publish_unknown_domain_normalized_to_generic() -> None:
+    """Unknown domain falls through validate_domain → 'generic'."""
+    fake_redis = MagicMock()
+    fake_redis.xadd = AsyncMock(return_value=b"1-0")
+    bridge = IntelScraperHGTBridge.from_redis(fake_redis,
+                                              cell_name="intel-scraper-cell")
+
+    ok = await bridge.publish(_make_pattern(domain="some_brand_new_domain"))
+    assert ok is True
+    args, _ = fake_redis.xadd.await_args
+    assert args[1]["domain"] == "generic"
+
+
+def test_to_skill_dict_shape() -> None:
+    pattern = _make_pattern(confidence=0.8)
+    skill = pattern.to_skill_dict(cell_origin="intel-scraper-cell")
+    assert skill["id"] == "intel.scraper.pattern.djp_rss_v2"
+    assert skill["scope"] == "Project"
+    assert skill["type"] == "skill"
+    assert skill["confidence"] == 0.8
+    assert skill["domain"] == "news"
+    assert skill["cell_origin"] == "intel-scraper-cell"

--- a/apps/bali-intel-scraper/tests/unit/cell/test_runner.py
+++ b/apps/bali-intel-scraper/tests/unit/cell/test_runner.py
@@ -1,0 +1,331 @@
+"""Integration tests for IntelScraperCellRunner — all 3 components wired.
+
+These tests exercise the async-context-manager contract end-to-end with:
+* a real :class:`Genome` (tmp_path SQLite)
+* a stubbed :class:`HGTPublisher` (no Redis)
+* an AsyncMock :class:`ObservedShellBus`
+
+Verifies:
+1. successful run → status=ok, ≥1 observed_shell_events row written
+2. degraded run (some scars + some articles) → status=degraded
+3. failed run (sources>0, articles=0, scars>0) → status=failed
+4. no-source run → status=failed (e.g. all sources unreachable)
+5. exception inside the with-block → status=failed, event still emitted
+6. HGT publish counter increments correctly
+7. trace_id auto-generated when caller passes None
+8. last_summary populated after run
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.cell.event_bridge import IntelScraperEventBridge
+from backend.cell.hgt_publisher import (
+    IntelScraperHGTBridge,
+    StructuralPattern,
+)
+from backend.cell.runner import IntelScraperCellRunner
+from backend.cell.scar_recorder import (
+    FailureKind,
+    IntelScraperScarRecorder,
+)
+from cell_core.genome import Genome
+
+
+@pytest.fixture
+def genome(tmp_path) -> Genome:
+    return Genome(db_path=str(tmp_path / "runner-genome.db"))
+
+
+@pytest.fixture
+def fake_bus():
+    bus = AsyncMock()
+    bus.emit = AsyncMock()
+    return bus
+
+
+@pytest.fixture
+def runner(genome: Genome, fake_bus):
+    """Build a runner with all 3 components wired but Redis stubbed off."""
+    fake_redis = MagicMock()
+    fake_redis.xadd = AsyncMock(return_value=b"1-0")
+    return IntelScraperCellRunner(
+        scar_recorder=IntelScraperScarRecorder(genome),
+        hgt_bridge=IntelScraperHGTBridge.from_redis(
+            fake_redis, cell_name="intel-scraper-cell"
+        ),
+        event_bridge=IntelScraperEventBridge(fake_bus),
+    )
+
+
+def _last_emit_payload(fake_bus):
+    """Helper to extract the last bus.emit() call's payload."""
+    assert fake_bus.emit.await_count == 1
+    return fake_bus.emit.await_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_clean_run_emits_status_ok(runner, fake_bus):
+    async with runner.run() as session:
+        session.note_source_attempted("djp.go.id")
+        session.note_source_attempted("imigrasi.go.id")
+        session.note_articles_found(7)
+        session.note_articles_found(5)
+        # success criterion structural pattern
+        await session.publish_pattern(StructuralPattern(
+            pattern_id="djp_rss_v2",
+            source="djp.go.id",
+            procedure="djp.go.id RSS at /api/v2/news returns stable JSON",
+            precondition="GET /api/v2/news",
+            success_criterion="≥1 article",
+            confidence=0.9,
+        ))
+
+    kwargs = _last_emit_payload(fake_bus)
+    assert kwargs["automation_name"] == "intel.scraper.run"
+    assert kwargs["status"] == "ok"
+    payload = kwargs["payload"]
+    assert payload["sources_attempted"] == 2
+    assert payload["articles_found"] == 12
+    assert payload["scars_added"] == 0
+    assert payload["hgt_published_count"] == 1
+    assert payload["duration_ms"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_partial_failure_emits_status_degraded(runner, fake_bus):
+    async with runner.run() as session:
+        session.note_source_attempted("djp.go.id")
+        session.note_source_attempted("imigrasi.go.id")
+        session.note_articles_found(5)
+        session.record_failure(
+            "imigrasi.go.id", FailureKind.RATE_LIMIT, "429 Too Many Requests"
+        )
+
+    kwargs = _last_emit_payload(fake_bus)
+    assert kwargs["status"] == "degraded"
+    payload = kwargs["payload"]
+    assert payload["scars_added"] == 1
+    assert payload["articles_found"] == 5
+
+
+@pytest.mark.asyncio
+async def test_all_sources_failed_emits_status_failed(runner, fake_bus):
+    async with runner.run() as session:
+        session.note_source_attempted("djp.go.id")
+        session.note_source_attempted("imigrasi.go.id")
+        session.record_failure("djp.go.id", FailureKind.HTTP_5XX, "503")
+        session.record_failure(
+            "imigrasi.go.id", FailureKind.CONNECT_TIMEOUT, "timed out"
+        )
+
+    kwargs = _last_emit_payload(fake_bus)
+    assert kwargs["status"] == "failed"
+    payload = kwargs["payload"]
+    assert payload["sources_attempted"] == 2
+    assert payload["articles_found"] == 0
+    assert payload["scars_added"] == 2
+
+
+@pytest.mark.asyncio
+async def test_no_sources_attempted_emits_status_failed(runner, fake_bus):
+    """Runner started but no sources attempted (e.g. config empty) → failed."""
+    async with runner.run() as session:
+        # noop — caller hit a config error before getting to scrape
+        _ = session.trace_id
+    kwargs = _last_emit_payload(fake_bus)
+    assert kwargs["status"] == "failed"
+    assert kwargs["payload"]["sources_attempted"] == 0
+
+
+@pytest.mark.asyncio
+async def test_clean_run_with_zero_articles_emits_degraded(runner, fake_bus):
+    """All sources OK but every feed empty: not a hard failure but
+    operator should investigate. Status=degraded."""
+    async with runner.run() as session:
+        session.note_source_attempted("bps.go.id")
+        # No articles, no scars
+    kwargs = _last_emit_payload(fake_bus)
+    assert kwargs["status"] == "degraded"
+    assert kwargs["payload"]["articles_found"] == 0
+    assert kwargs["payload"]["scars_added"] == 0
+
+
+@pytest.mark.asyncio
+async def test_exception_in_block_marks_status_failed_and_emits(runner, fake_bus):
+    """Exception inside the with-block: event still emitted with
+    status=failed; exception propagates AFTER bus emit."""
+    class _BoomException(RuntimeError):
+        pass
+
+    with pytest.raises(_BoomException):
+        async with runner.run() as session:
+            session.note_source_attempted("djp.go.id")
+            session.note_articles_found(3)
+            raise _BoomException("scraper crashed mid-run")
+
+    # Bus DID receive the event.
+    kwargs = _last_emit_payload(fake_bus)
+    assert kwargs["status"] == "failed"
+    # Counters reflect the partial state.
+    assert kwargs["payload"]["sources_attempted"] == 1
+    assert kwargs["payload"]["articles_found"] == 3
+
+
+@pytest.mark.asyncio
+async def test_trace_id_auto_generated_when_none(runner, fake_bus):
+    async with runner.run(trace_id=None) as session:
+        session.note_source_attempted("djp.go.id")
+        session.note_articles_found(1)
+        # the trace_id must be set on the session and start with the
+        # canonical prefix
+        assert session.trace_id.startswith("intel-scraper-")
+    kwargs = _last_emit_payload(fake_bus)
+    assert kwargs["trace_id"].startswith("intel-scraper-")
+
+
+@pytest.mark.asyncio
+async def test_explicit_trace_id_passed_through(runner, fake_bus):
+    async with runner.run(trace_id="run-2026-05-02T03:00") as session:
+        session.note_source_attempted("djp.go.id")
+        session.note_articles_found(1)
+    kwargs = _last_emit_payload(fake_bus)
+    assert kwargs["trace_id"] == "run-2026-05-02T03:00"
+
+
+@pytest.mark.asyncio
+async def test_last_summary_populated_after_run(runner, fake_bus):
+    assert runner.last_summary is None
+    async with runner.run() as session:
+        session.note_source_attempted("oss.go.id")
+        session.note_articles_found(2)
+    assert runner.last_summary is not None
+    assert runner.last_summary.sources_attempted == 1
+    assert runner.last_summary.articles_found == 2
+
+
+@pytest.mark.asyncio
+async def test_hgt_publish_counter_only_increments_on_success(genome, fake_bus):
+    """Patterns below confidence threshold do NOT bump hgt_published_count."""
+    fake_redis = MagicMock()
+    fake_redis.xadd = AsyncMock(return_value=b"1-0")
+    runner = IntelScraperCellRunner(
+        scar_recorder=IntelScraperScarRecorder(genome),
+        hgt_bridge=IntelScraperHGTBridge.from_redis(
+            fake_redis, cell_name="intel-scraper-cell"
+        ),
+        event_bridge=IntelScraperEventBridge(fake_bus),
+    )
+
+    low = StructuralPattern(
+        pattern_id="lowconf",
+        source="djp.go.id",
+        procedure="something",
+        precondition="x",
+        success_criterion="y",
+        confidence=0.5,    # below 0.7 threshold → filtered
+    )
+    high = StructuralPattern(
+        pattern_id="highconf",
+        source="djp.go.id",
+        procedure="something else",
+        precondition="x",
+        success_criterion="y",
+        confidence=0.95,
+    )
+
+    async with runner.run() as session:
+        session.note_source_attempted("djp.go.id")
+        session.note_articles_found(1)
+        ok_low = await session.publish_pattern(low)
+        ok_high = await session.publish_pattern(high)
+        assert ok_low is False
+        assert ok_high is True
+
+    payload = fake_bus.emit.await_args.kwargs["payload"]
+    assert payload["hgt_published_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_runner_swallows_bus_exception(genome):
+    """If ObservedShellBus.emit raises (shouldn't normally — it's
+    supposed to swallow), the runner must NOT propagate; otherwise the
+    parent automation would crash on observability failure."""
+    bus = AsyncMock()
+    bus.emit = AsyncMock(side_effect=RuntimeError("bus broken"))
+    fake_redis = MagicMock()
+    fake_redis.xadd = AsyncMock(return_value=b"1-0")
+    runner = IntelScraperCellRunner(
+        scar_recorder=IntelScraperScarRecorder(genome),
+        hgt_bridge=IntelScraperHGTBridge.from_redis(
+            fake_redis, cell_name="intel-scraper-cell"
+        ),
+        event_bridge=IntelScraperEventBridge(bus),
+    )
+
+    # Must complete cleanly even though emit raised.
+    async with runner.run() as session:
+        session.note_source_attempted("oss.go.id")
+        session.note_articles_found(1)
+    # Summary still populated.
+    assert runner.last_summary is not None
+    assert runner.last_summary.sources_attempted == 1
+
+
+@pytest.mark.asyncio
+async def test_scar_recorder_failure_synthesizes_record(genome, fake_bus):
+    """If the scar recorder layer raises (e.g. SQLite locked), the
+    runner falls back to a synthetic ScarRecord (confidence=0.0)
+    and the run continues. This is the Symbiosis Law 4 contract."""
+    # We pre-build with a real Genome but stash a stub at the
+    # scar_recorder layer that raises.
+    class _BoomScarRecorder:
+        def record(self, source, kind, detail=""):
+            raise RuntimeError("genome locked")
+
+    fake_redis = MagicMock()
+    fake_redis.xadd = AsyncMock()
+    runner = IntelScraperCellRunner(
+        scar_recorder=_BoomScarRecorder(),  # type: ignore[arg-type]
+        hgt_bridge=IntelScraperHGTBridge.from_redis(
+            fake_redis, cell_name="intel-scraper-cell"
+        ),
+        event_bridge=IntelScraperEventBridge(fake_bus),
+    )
+
+    async with runner.run() as session:
+        session.note_source_attempted("djp.go.id")
+        rec = session.record_failure("djp.go.id", FailureKind.HTTP_5XX, "503")
+        # Synthetic record with confidence=0.0
+        assert rec.confidence == 0.0
+        assert rec.scar_id == "intel.scraper.djp_go_id.http_5xx"
+
+    payload = fake_bus.emit.await_args.kwargs["payload"]
+    assert payload["scars_added"] == 1
+    # Status: 1 source, 0 articles, 1 scar → failed
+    assert fake_bus.emit.await_args.kwargs["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_scars_visible_in_genome_after_run(runner, genome):
+    """After a degraded run, the scar must be queryable in the Genome
+    so the next run can read it for backoff decisions."""
+    async with runner.run() as session:
+        session.note_source_attempted("djp.go.id")
+        session.note_articles_found(2)
+        session.record_failure(
+            "djp.go.id", FailureKind.SCHEMA_DRIFT, "missing field 'pubDate'"
+        )
+
+    rows = genome.get_active(
+        cell="intel-scraper-cell",
+        entry_type="scar",
+        scope="Personal",
+        min_confidence=0.5,
+        limit=10,
+    )
+    assert any(
+        r["id"] == "intel.scraper.djp_go_id.schema_drift" for r in rows
+    ), rows

--- a/apps/bali-intel-scraper/tests/unit/cell/test_scar_recorder.py
+++ b/apps/bali-intel-scraper/tests/unit/cell/test_scar_recorder.py
@@ -1,0 +1,158 @@
+"""Unit tests for intel-scraper-cell scar_recorder.
+
+Tests use both:
+
+* a real :class:`cell_core.genome.Genome` against an in-memory SQLite
+  (``:memory:``) — exercises the round-trip insert/upsert/use_skill path.
+* a stub :class:`_StubGenome` for fault-injection (e.g. SQLite locked).
+
+Running:
+
+    PYTHONPATH=packages/cell-core:apps/bali-intel-scraper \\
+        pytest apps/bali-intel-scraper/tests/unit/cell/test_scar_recorder.py -v
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from backend.cell.scar_recorder import (
+    FailureKind,
+    IntelScraperScarRecorder,
+    ScarRecord,
+    _slugify,
+)
+from cell_core.genome import Genome
+
+
+@pytest.fixture
+def genome(tmp_path) -> Genome:
+    """Real Genome on a tmp_path SQLite (NOT :memory: — SQLite WAL pragmas
+    don't fully apply to memory DBs across threads).
+    """
+    return Genome(db_path=str(tmp_path / "genome-test.db"))
+
+
+def test_slugify_handles_dots_and_uppercase() -> None:
+    assert _slugify("imigrasi.go.id") == "imigrasi_go_id"
+    assert _slugify("BPS.Go.ID") == "bps_go_id"
+    assert _slugify("bali-tribunnews.com") == "bali_tribunnews_com"
+    assert _slugify("") == "unknown"
+    assert _slugify("   ") == "unknown"
+
+
+def test_make_scar_id_format() -> None:
+    sid = IntelScraperScarRecorder.make_scar_id(
+        "imigrasi.go.id", FailureKind.RATE_LIMIT
+    )
+    assert sid == "intel.scraper.imigrasi_go_id.rate_limit"
+    sid2 = IntelScraperScarRecorder.make_scar_id(
+        "bali.tribunnews.com", FailureKind.SCHEMA_DRIFT
+    )
+    assert sid2 == "intel.scraper.bali_tribunnews_com.schema_drift"
+
+
+def test_record_inserts_scar_into_genome(genome: Genome) -> None:
+    rec = IntelScraperScarRecorder(genome)
+    out = rec.record(
+        source="djp.go.id",
+        kind=FailureKind.HTTP_5XX,
+        detail="upstream returned 503",
+    )
+    assert isinstance(out, ScarRecord)
+    assert out.scar_id == "intel.scraper.djp_go_id.http_5xx"
+    assert out.kind == FailureKind.HTTP_5XX
+    assert out.confidence == 0.9
+    # Genome row exists, type=scar, scope=Personal
+    rows = genome.get_active(
+        cell="intel-scraper-cell",
+        entry_type="scar",
+        scope="Personal",
+        min_confidence=0.5,
+        limit=10,
+    )
+    assert any(r["id"] == out.scar_id for r in rows), rows
+
+
+def test_record_upsert_increments_uses_across_runs(genome: Genome) -> None:
+    """Cross-run signal: 5 failures of the same (source, kind) bumps
+    the existing scar's uses counter to 5."""
+    rec = IntelScraperScarRecorder(genome)
+    for i in range(5):
+        rec.record(
+            source="oss.go.id",
+            kind=FailureKind.RATE_LIMIT,
+            detail=f"hit #{i}",
+        )
+    rows = genome.get_active(
+        cell="intel-scraper-cell",
+        entry_type="scar",
+        min_confidence=0.5,
+        limit=10,
+    )
+    matched = [r for r in rows if r["id"] == "intel.scraper.oss_go_id.rate_limit"]
+    assert len(matched) == 1
+    # uses bumped 5 times
+    assert matched[0]["uses"] == 5
+
+
+def test_record_clips_long_detail(genome: Genome) -> None:
+    """A 10K-character traceback must NOT bloat the scar row."""
+    long_detail = "x" * 10_000
+    rec = IntelScraperScarRecorder(genome)
+    out = rec.record(
+        source="bps.go.id",
+        kind=FailureKind.SCHEMA_DRIFT,
+        detail=long_detail,
+    )
+    assert len(out.detail) == 500  # clipped at the dataclass level
+
+
+def test_recorded_at_is_iso_utc(genome: Genome) -> None:
+    rec = IntelScraperScarRecorder(genome)
+    out = rec.record(
+        source="bali.tribunnews.com", kind=FailureKind.PAYWALL, detail=""
+    )
+    parsed = datetime.fromisoformat(out.recorded_at)
+    assert parsed.tzinfo is not None
+    # within the last few seconds
+    delta = (datetime.now(timezone.utc) - parsed).total_seconds()
+    assert -1 < delta < 30
+
+
+# ── Fault injection: Genome stub that raises ───────────────────────────
+
+
+class _StubGenome:
+    """Stub matching :class:`_GenomeLike` protocol used by the recorder."""
+
+    def __init__(self, raise_on_record: Exception | None = None,
+                 raise_on_use: Exception | None = None) -> None:
+        self.raise_on_record = raise_on_record
+        self.raise_on_use = raise_on_use
+        self.recorded: list[tuple[str, str]] = []
+        self.used: list[str] = []
+
+    def record_scar(self, cell: str, scar_id: str, procedure: str,
+                    precondition: str = "") -> str:
+        if self.raise_on_record:
+            raise self.raise_on_record
+        self.recorded.append((cell, scar_id))
+        return "inserted"
+
+    def use_skill(self, skill_id: str) -> None:
+        if self.raise_on_use:
+            raise self.raise_on_use
+        self.used.append(skill_id)
+
+
+def test_record_propagates_genome_exception() -> None:
+    """The recorder itself does NOT swallow Genome errors — the runner
+    layer is responsible for graceful degradation. This protects us
+    from masking a corrupted DB during cross-run analysis."""
+    stub = _StubGenome(raise_on_record=RuntimeError("sqlite locked"))
+    rec = IntelScraperScarRecorder(stub)
+    with pytest.raises(RuntimeError, match="sqlite locked"):
+        rec.record(source="x.com", kind=FailureKind.DNS_FAIL, detail="")
+    assert stub.recorded == []

--- a/docs/cell-core/cognitive-levels-matrix.md
+++ b/docs/cell-core/cognitive-levels-matrix.md
@@ -89,7 +89,7 @@ blocker, I list the remediation Sprint that addresses it.
   - **Law 5 Auto-publish:** must NOT auto-send WhatsApp to clients
     (Sahira approval gate stays).
 
-### #8 `intel-scraper-cell` (light) — L1, Sprint 1
+### #8 `intel-scraper-cell` (light) — L1, Sprint 1 W1 ✅ DELIVERED
 
 - Per Sprint 0 Track B4: 3 production runners map onto this cell
   (`apps/bali-intel-scraper/`, intel-radar, intel-feed-processor).
@@ -97,6 +97,24 @@ blocker, I list the remediation Sprint that addresses it.
   publishes to `trend_signals` which `dossier-compiler` consumes. As long
   as dossier-compiler reads the substrate, not the scraper's reasoning,
   Law 6 is fine.
+- **Sprint 1 W1 delivery (2026-05-02):** declarative cell.yaml at
+  `apps/bali-intel-scraper/cell.yaml` (passes
+  `pytest packages/cell-core/tests/test_admission.py -k intel_scraper`
+  with zero blockers); wrapper modules under
+  `apps/bali-intel-scraper/backend/cell/`:
+    * `scar_recorder.py` — Genome scars at namespace
+      `intel.scraper.<source_slug>.<failure_kind>`, cross-run uses counter.
+    * `hgt_publisher.py` — STRUCTURAL pattern broadcast on confidence ≥0.7
+      with PII marker filter (defense-in-depth).
+    * `event_bridge.py` — emits `intel.scraper.run` row per run via
+      `ObservedShellBus` (migration 151).
+    * `runner.py` — async-context-manager orchestrator with deterministic
+      status (ok|degraded|failed), 35 unit/integration tests.
+- **Out of scope for W1 (deferred):** integration into the scraper's
+  actual entrypoint (`apps/bali-intel-scraper/backend/app/main.py` /
+  cron-agent-python intel-radar / intel-feed-processor); that
+  integration is a 1-PR follow-up tracked separately so reviewers can
+  read the wrapper layer in isolation.
 
 ### #9 `hgt-coordinator-cell` ⭐ NEW — L2, Sprint 1
 

--- a/packages/cell-core/cell_core/admission_test.py
+++ b/packages/cell-core/cell_core/admission_test.py
@@ -42,8 +42,10 @@ Out of scope:
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from enum import Enum
+from pathlib import Path
 from typing import Any, Callable
 
 
@@ -352,3 +354,65 @@ def _check_numbers_first(cd: dict[str, Any]) -> Violation | None:
             severity="blocker",
         )
     return None
+
+
+# === Cell-definition loader =================================================
+#
+# Sprint 1 W1: cells declare their 7 Leggi profile in a sidecar YAML
+# (e.g. ``apps/bali-intel-scraper/cell.yaml``). ``load_cell_definition``
+# parses the file into the same plain dict that
+# ``AdmissionTest.run_all()`` consumes — no schema layer.
+#
+# PyYAML is the canonical loader. When unavailable (e.g. cell-core
+# installed in a minimal env), JSON files are still readable.
+
+
+class CellDefinitionLoadError(ValueError):
+    """Raised when a cell definition file cannot be loaded or parsed."""
+
+
+def load_cell_definition(path: str | Path) -> dict[str, Any]:
+    """Load a cell definition from a YAML or JSON file.
+
+    Returns a plain dict suitable for ``AdmissionTest().run_all(cd)``.
+
+    Raises:
+        FileNotFoundError: when *path* does not exist.
+        CellDefinitionLoadError: when the file cannot be parsed, the
+            root is not a mapping, or PyYAML is not installed for a
+            ``.yaml`` / ``.yml`` file.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"cell definition not found: {p}")
+
+    text = p.read_text(encoding="utf-8")
+
+    if p.suffix.lower() == ".json":
+        try:
+            loaded = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise CellDefinitionLoadError(
+                f"cell definition {p} is not valid JSON: {exc}"
+            ) from exc
+    else:
+        try:
+            import yaml  # type: ignore[import-untyped]
+        except ImportError as exc:  # pragma: no cover  (env-specific)
+            raise CellDefinitionLoadError(
+                f"cell definition {p} is YAML but PyYAML is not installed; "
+                f"install with `pip install pyyaml` or convert to JSON"
+            ) from exc
+        try:
+            loaded = yaml.safe_load(text)
+        except yaml.YAMLError as exc:
+            raise CellDefinitionLoadError(
+                f"cell definition {p} is not valid YAML: {exc}"
+            ) from exc
+
+    if not isinstance(loaded, dict):
+        raise CellDefinitionLoadError(
+            f"cell definition {p} root must be a mapping, got "
+            f"{type(loaded).__name__}"
+        )
+    return loaded

--- a/packages/cell-core/tests/test_admission.py
+++ b/packages/cell-core/tests/test_admission.py
@@ -1,10 +1,29 @@
-"""Tests for the 7 Leggi admission test framework — Sprint 0 Track C1."""
+"""Tests for the 7 Leggi admission test framework — Sprint 0 Track C1.
+
+Sprint 1 W1 added:
+- ``load_cell_definition`` (YAML / JSON loader)
+- intel-scraper-cell admission test against the on-disk cell.yaml
+"""
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
+import pytest
+
 from cell_core.admission_test import (
     AdmissionTest,
+    CellDefinitionLoadError,
     Legge,
+    load_cell_definition,
+)
+
+
+# Repo root (cell.yaml lives at <repo>/apps/bali-intel-scraper/cell.yaml)
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_INTEL_SCRAPER_CELL_YAML = (
+    _REPO_ROOT / "apps" / "bali-intel-scraper" / "cell.yaml"
 )
 
 
@@ -222,3 +241,129 @@ def test_auto_publishes_true_blocks() -> None:
         if v.legge == Legge.ZERO_FINAL_INSTANCE and v.severity == "blocker"
     ]
     assert zero_violations, result.summary()
+
+
+# ── Sprint 1 W1: load_cell_definition + intel-scraper-cell admission ──
+
+
+def test_load_cell_definition_json_round_trip(tmp_path: Path) -> None:
+    """JSON round-trip — must produce the same dict that run_all() consumes."""
+    cd = {
+        "name": "json-cell",
+        "level": "L1",
+        "exposes_gui": False,
+        "external_sources": ["fly-api"],
+        "client_data_access": False,
+        "publishes_via": "pg_notify",
+        "fallback_modes": ["redis_down"],
+        "kill_switch": True,
+        "auto_publishes": False,
+        "depends_on_other_cell_decisions": False,
+        "metrics": ["a", "b", "c"],
+    }
+    p = tmp_path / "json-cell.json"
+    p.write_text(json.dumps(cd))
+    loaded = load_cell_definition(p)
+    assert loaded == cd
+    # And the loaded dict passes admission.
+    assert AdmissionTest().run_all(loaded).passed is True
+
+
+def test_load_cell_definition_missing_file_raises(tmp_path: Path) -> None:
+    """FileNotFoundError surfaces — caller can decide whether to skip."""
+    with pytest.raises(FileNotFoundError):
+        load_cell_definition(tmp_path / "nope.yaml")
+
+
+def test_load_cell_definition_root_not_mapping_raises(tmp_path: Path) -> None:
+    """A list at the root of a JSON file fails loud."""
+    p = tmp_path / "list.json"
+    p.write_text(json.dumps(["not", "a", "dict"]))
+    with pytest.raises(CellDefinitionLoadError):
+        load_cell_definition(p)
+
+
+def test_intel_scraper_cell_yaml_exists() -> None:
+    """The Sprint 1 W1 cell.yaml MUST be on disk at the canonical path."""
+    assert _INTEL_SCRAPER_CELL_YAML.exists(), (
+        f"missing {_INTEL_SCRAPER_CELL_YAML} — Sprint 1 W1 declarative "
+        f"contract not in place"
+    )
+
+
+def test_intel_scraper_cell_passes_admission() -> None:
+    """The intel-scraper-cell definition PASSES all 7 Leggi (zero blockers).
+
+    This is the canonical Sprint 1 W1 acceptance test. If it ever fails,
+    either the cell definition drifted (fix cell.yaml) or the admission
+    rubric changed (fix admission_test.py). Both deserve a code review.
+    """
+    pytest.importorskip("yaml", reason="cell.yaml requires PyYAML to load")
+    cd = load_cell_definition(_INTEL_SCRAPER_CELL_YAML)
+    result = AdmissionTest().run_all(cd)
+    blockers = [v for v in result.violations if v.severity == "blocker"]
+    assert blockers == [], (
+        "intel-scraper-cell admission FAILED:\n" + result.summary()
+    )
+    assert result.passed is True, result.summary()
+    assert result.cell_name == "intel-scraper-cell"
+
+
+def test_intel_scraper_cell_metadata_contracts() -> None:
+    """Cell-yaml-only contract checks (not part of the 7 Leggi).
+
+    These are Sprint 1 W1 specific invariants that don't belong in the
+    generic admission_test runtime check but DO belong in the cell's
+    own test surface.
+    """
+    pytest.importorskip("yaml", reason="cell.yaml requires PyYAML to load")
+    cd = load_cell_definition(_INTEL_SCRAPER_CELL_YAML)
+
+    # Identity
+    assert cd["name"] == "intel-scraper-cell"
+    assert cd["level"] == "L1"
+    assert cd["runtime"] == "cron-agent-python"
+
+    # OSINT-blindato pre-declaration
+    assert cd["client_data_access"] is False
+    assert isinstance(cd["external_sources"], list)
+    assert len(cd["external_sources"]) >= 3
+
+    # Event contracts must include intel.scraper.run with the 8 declared fields
+    contracts = cd.get("event_contracts", [])
+    run_contracts = [c for c in contracts if c.get("name") == "intel.scraper.run"]
+    assert len(run_contracts) == 1, (
+        "exactly one intel.scraper.run contract expected"
+    )
+    fields = set(run_contracts[0].get("fields", {}).keys())
+    required_fields = {
+        "trace_id",
+        "status",
+        "sources_attempted",
+        "articles_found",
+        "scars_added",
+        "duration_ms",
+        "started_at",
+        "finished_at",
+    }
+    missing = required_fields - fields
+    assert not missing, f"intel.scraper.run contract missing fields: {missing}"
+
+    # HGT publish policy: structural patterns only (UU PDP scope)
+    assert cd.get("hgt_publish_only_structural_patterns") is True
+
+
+def test_intel_scraper_cell_drift_blocks_when_fields_missing(tmp_path: Path) -> None:
+    """Defensive: simulate cell.yaml drift (e.g. someone removes
+    ``kill_switch``) and confirm admission FAILS with a clear blocker."""
+    pytest.importorskip("yaml", reason="cell.yaml requires PyYAML to load")
+    cd = load_cell_definition(_INTEL_SCRAPER_CELL_YAML)
+    # Corrupted copy
+    drifted = dict(cd)
+    drifted["kill_switch"] = False   # operator removed the kill switch
+    result = AdmissionTest().run_all(drifted)
+    assert result.passed is False
+    assert any(
+        v.legge == Legge.ZERO_FINAL_INSTANCE and v.severity == "blocker"
+        for v in result.violations
+    ), result.summary()


### PR DESCRIPTION
## Summary

Sprint 1 W1 of the Cell+OpenClaw architecture roadmap (Sprint 0 → PR #426 merged 2026-05-02). Wraps the existing `apps/bali-intel-scraper` as a **light cell** without rewriting the scraper logic.

Three lateral concerns are added around scrape runs:

1. **Genome scar registry** — recurring failure patterns (rate limit, paywall, robots.txt block, DNS fail, schema drift, etc.) land as Personal-scope scars in `cell_core.genome.Genome` under stable id namespace `intel.scraper.<source_slug>.<failure_kind>`. Repeated hits bump the `uses` counter so cross-run learning ("source X has rate-limited us 5x in 24h → backoff 2h") is observable in steady-state SQL.
2. **HGT publisher** — *structural* discoveries (e.g. "regulator X publishes a stable RSS feed at /api/v2/news") are broadcast on the `cell:skills` Redis stream via `cell_core.hgt.HGTPublisher`. Article CONTENT is never published (UU PDP scope). Defense-in-depth filter rejects email / `+62` / NPWP / passport markers and exact-1.0 confidence (test sentinels). Confidence threshold ≥0.7 enforced by HGTPublisher; cell-side adds the PII filter and a `confidence == 1.0` rejection.
3. **Event bridge** — every run emits exactly one `intel.scraper.run` row to `events_outbox` via `ObservedShellBus` (migration 151, already live on prod). JSONL fallback at `~/logs/observed-shell.jsonl` when DB pool unavailable. Runner emits with deterministic status: `failed` if `sources_attempted=0` OR exception in block OR `sources>0 ∧ articles=0 ∧ scars>0`; `ok` if `articles>0 ∧ scars=0`; `degraded` otherwise.

The scraper integration is a follow-up PR (deliberately) — this PR only delivers the wrapper layer + admission contract + tests so reviewers can read the boundary in isolation.

## Files

- `apps/bali-intel-scraper/cell.yaml` — declarative 7 Leggi contract consumed by `cell_core.admission_test`.
- `apps/bali-intel-scraper/backend/cell/__init__.py`, `scar_recorder.py`, `hgt_publisher.py`, `event_bridge.py`, `runner.py` — wrapper modules.
- `packages/cell-core/cell_core/admission_test.py` — added `load_cell_definition()` (PyYAML-preferred, JSON fallback) + `CellDefinitionLoadError`.
- `packages/cell-core/tests/test_admission.py` — +7 admission tests including the canonical `test_intel_scraper_cell_passes_admission`.
- `apps/bali-intel-scraper/tests/unit/cell/{test_scar_recorder,test_hgt_publisher,test_event_bridge,test_runner}.py` — 35 unit + integration tests.
- `docs/cell-core/cognitive-levels-matrix.md` — marked cell #8 delivered.

## Migration touched

**NONE.** Migration 151 (`observed_shell_events`) is already live on prod (Sprint 0 Track C2). No new SQL schema introduced.

## Test plan

```bash
# Spec-mandated acceptance test:
PYTHONPATH=packages/cell-core \
  apps/backend-rag/.venv/bin/python3 -m pytest \
  packages/cell-core/tests/test_admission.py -k intel_scraper -v
# 4 passed (test_intel_scraper_cell_yaml_exists,
#           test_intel_scraper_cell_passes_admission,
#           test_intel_scraper_cell_metadata_contracts,
#           test_intel_scraper_cell_drift_blocks_when_fields_missing)

# Full admission suite (regression-check):
PYTHONPATH=packages/cell-core \
  apps/backend-rag/.venv/bin/python3 -m pytest \
  packages/cell-core/tests/test_admission.py -q
# 22 passed

# Cell wrapper unit + integration tests:
cd apps/bali-intel-scraper && \
  PYTHONPATH=.:../../packages/cell-core \
  /path/to/.venv/bin/python3 -m pytest tests/unit/cell/ -v
# 35 passed (7 scar_recorder, 8 hgt_publisher, 7 event_bridge, 13 runner)

# Full cell-core regression:
PYTHONPATH=packages/cell-core ... pytest packages/cell-core/tests/ -q
# 325 passed (no existing test broken)

# Full ObservedShellBus regression:
cd apps/backend-rag && PYTHONPATH=. .venv/bin/python3 -m pytest \
  backend/tests/services/events/test_observed_shell.py -v
# 8 passed (no existing test broken)
```

- [x] `pytest packages/cell-core/tests/test_admission.py -k intel_scraper -v` passes (4/4)
- [x] Full admission suite passes (22/22)
- [x] Cell wrapper tests pass (35/35)
- [x] cell-core regression: 325/325
- [x] ObservedShellBus regression: 8/8
- [x] No new SQL migration touched
- [x] No paid Anthropic API path introduced (Golden Rule #13)
- [x] No `print()` statements; logger only (Golden Rule #8)
- [x] All async I/O uses `asyncpg` / `AsyncMock` — no `requests` (Golden Rule #4)
- [x] Out-of-scope items respected: HGT coordinator quarantine (W2), scraper-entrypoint integration (follow-up), measurer_event channel (Sprint 1.5)

## Reference

- `docs/audits/2026-05-02-cell-openclaw-brainstorm/99b_synthesis_v2.md` § "Sprint 1 — Intel Scraper light + HGT quarantine (1 settimana)"
- `docs/cell-core/admission-test-rubric.md` (Sprint 0 Track C1)
- `docs/cell-core/cognitive-levels-matrix.md` § "#8 intel-scraper-cell"
- `docs/automations/runtime-register.md` row 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>