### PR TITLE
Sprint 1 PR-1.2: /api/observed-shell/emit + bash wrapper + intel-scraper retrofit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ See [`INDEX.md`](INDEX.md) for the full atlas including packages, tessuti dati, 
 ### Tech Stack
 
 <!-- DOCSYNC:BACKEND_STATS_START -->
-- **Backend:** Python 3.11+, FastAPI, 255 routers, 532 services, 895 test files
+- **Backend:** Python 3.11+, FastAPI, 257 routers, 532 services, 896 test files
 <!-- DOCSYNC:BACKEND_STATS_END -->
 - **Frontend:** Next.js, TypeScript, Tailwind CSS
 - **Databases:** PostgreSQL (relational), Qdrant (vector), Redis (cache)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 255 routers · 532 services
+- Backend: FastAPI · 257 routers · 532 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 22 · Packages: 5

--- a/apps/backend-rag/backend/app/routers/observed_shell.py
+++ b/apps/backend-rag/backend/app/routers/observed_shell.py
@@ -1,0 +1,129 @@
+"""Observed-shell tier — HTTP endpoint for shell-side automations.
+
+Sprint 1 PR-1.2 — wires the cell-core ``ObservedShellBus`` (Sprint 0
+Track C2, migration 151) to the outside world via a single HTTP POST so
+that shell-only callers (LaunchAgents, cron-agent-python strategies, bash
+wrappers) can record observability events without importing cell-core.
+
+The endpoint is internal (X-API-Key authenticated, NOT in
+``PUBLIC_ENDPOINTS``). The cell never accepts arbitrary observability
+emissions from the public internet — Symbiosis Law 5 (Zero ultima
+istanza) at the network layer.
+
+Spec: ``docs/cell-core/observed-shell-tier.md`` § "Bash (LaunchAgent /
+launchd cron jobs)".
+
+Cicatrix reference: Sprint 1.B 2026-05-02 (3-PR hotfix chain) — the
+endpoint is added in lockstep across 5 files (this router, manifest,
+two ``router_registration.py`` include functions, and the new contract
+test). NOT added to ``PUBLIC_ENDPOINTS`` because the X-API-Key gate is
+the right authorisation surface for service-to-service traffic.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+from backend.app.utils.internal_api_auth import verify_internal_api_key
+from backend.services.events.observed_shell import VALID_STATUSES, ObservedShellBus
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/observed-shell", tags=["observability", "internal"])
+
+
+class EmitRequest(BaseModel):
+    """Request body for the observed-shell emit endpoint.
+
+    Mirrors ``ObservedShellBus.emit`` keyword arguments. ``payload`` and
+    ``trace_id`` are optional; status MUST be one of ``VALID_STATUSES``.
+    """
+
+    automation_name: str = Field(
+        ...,
+        min_length=1,
+        max_length=128,
+        description="Slug for the automation, e.g. 'translate.hourly'",
+    )
+    status: str = Field(
+        ...,
+        description="One of: ok | error | warning | skipped",
+    )
+    payload: dict[str, Any] | None = Field(
+        default=None,
+        description="Free-form structured payload — JSONB column",
+    )
+    trace_id: str | None = Field(
+        default=None,
+        max_length=128,
+        description="Optional upstream trace ID for cross-system correlation",
+    )
+
+
+class EmitResponse(BaseModel):
+    """Successful emit response. The endpoint never returns DB row IDs —
+    callers don't need them, and exposing them would couple the schema."""
+
+    accepted: bool = True
+    automation_name: str
+    status: str
+
+
+@router.post(
+    "/emit",
+    response_model=EmitResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Record an observed-shell event",
+)
+async def emit_observed_shell_event(
+    body: EmitRequest,
+    request: Request,
+    _api_key_verified=Depends(verify_internal_api_key),
+) -> EmitResponse:
+    """Record one observed-shell event from a shell-only caller.
+
+    Returns 202 Accepted (NOT 201) because the underlying ``ObservedShellBus``
+    is best-effort: the row may also land in the JSONL fallback if the DB
+    pool is unavailable, in which case the cell hasn't actually persisted
+    anything to PG yet but the trace is preserved.
+
+    Status validation: out-of-allowlist values are coerced to ``error`` by
+    ``ObservedShellBus.emit`` itself; we surface that explicitly via 422
+    here so misconfigured callers fail loud at integration time rather
+    than silently flipping their status field server-side.
+    """
+    if body.status not in VALID_STATUSES:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"status must be one of {sorted(VALID_STATUSES)!r}; "
+                f"got {body.status!r}"
+            ),
+        )
+
+    pool = getattr(request.app.state, "db_pool", None)
+    bus = ObservedShellBus(pool)
+    await bus.emit(
+        automation_name=body.automation_name,
+        status=body.status,
+        payload=body.payload,
+        trace_id=body.trace_id,
+    )
+
+    logger.info(
+        "observed-shell emit: automation=%s status=%s trace_id=%s",
+        body.automation_name,
+        body.status,
+        body.trace_id,
+    )
+    return EmitResponse(
+        accepted=True,
+        automation_name=body.automation_name,
+        status=body.status,
+    )
+
+
+__all__ = ["router"]

--- a/apps/backend-rag/backend/app/setup/router_manifest.py
+++ b/apps/backend-rag/backend/app/setup/router_manifest.py
@@ -259,6 +259,12 @@ ROUTER_MANIFEST: tuple[RouterEntry, ...] = (
     # ── Olympus (full-only: internal admin) ──
     RouterEntry(name="olympus", attr="internal_router", process_groups=_API, tags=("admin",)),
 
+    # ── Observability (cell-core) ──
+    # Sprint 1 PR-1.2: HTTP bridge for cell-core ObservedShellBus (Sprint 0
+    # Track C2). X-API-Key auth via verify_internal_api_key dep — NOT in
+    # PUBLIC_ENDPOINTS. Backed by observed_shell_events table (mig 151).
+    RouterEntry(name="observed_shell", process_groups=_API, tags=("observability", "cell-core", "internal")),
+
     # ── Omnichannel ──
     RouterEntry(name="omnichannel", process_groups=_API, tags=("channels",)),
 

--- a/apps/backend-rag/backend/app/setup/router_registration.py
+++ b/apps/backend-rag/backend/app/setup/router_registration.py
@@ -94,6 +94,7 @@ def include_routers(api: FastAPI) -> None:
         newsletter,
         nusantara_health,
         olympus,  # [OLYMPUS] DB Guardian health + internal management
+        observed_shell,  # [OBSERVED-SHELL] Sprint 1 PR-1.2 — cell-core observability bridge
         omnichannel,  # [NEW] Unified inbox for cross-channel conversations
         oracle_ingest,
         oracle_universal,
@@ -193,6 +194,7 @@ def include_routers(api: FastAPI) -> None:
     api.include_router(channel_health.router)  # /api/channels/{name}/health Cell heartbeat bridge
     api.include_router(channels.router)  # Channel health, DLQ, unified conversations
     api.include_router(omnichannel.router)  # [NEW] Unified inbox threads API
+    api.include_router(observed_shell.router)  # /api/observed-shell/emit (Sprint 1 PR-1.2)
 
     # HR/Payroll router
     api.include_router(hr.router)  # [NEW] HR/Payroll module
@@ -444,6 +446,7 @@ def include_light_routers(api: FastAPI) -> None:
         metabolic_health,  # [METABOLIC] SYMBIOSIS Pillar 7 read-only metrics (PR #60)
         newsletter,
         nusantara_health,
+        observed_shell,  # [OBSERVED-SHELL] Sprint 1 PR-1.2 — cell-core observability bridge
         omnichannel,
         partners,  # [PARTNERS] CRM Partners module v1 (PR #141 + follow-ups)
         performance,
@@ -525,6 +528,7 @@ def include_light_routers(api: FastAPI) -> None:
     api.include_router(channel_health.router)  # /api/channels/{name}/health Cell heartbeat bridge
     api.include_router(channels.router)  # /api/channels (health, DLQ, conversations)
     api.include_router(omnichannel.router)  # /api/omnichannel (threads, assignment)
+    api.include_router(observed_shell.router)  # /api/observed-shell/emit (Sprint 1 PR-1.2)
 
     # HR/Payroll router
     api.include_router(hr.router)

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_observed_shell.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_observed_shell.py
@@ -1,0 +1,193 @@
+"""Tests for /api/observed-shell/emit (Sprint 1 PR-1.2).
+
+Verifies:
+- Router mounts at the documented path
+- X-API-Key auth: missing → 401, valid → 202
+- Status validation: out-of-allowlist → 422
+- DB unavailable: emit still returns 202 (JSONL fallback semantics)
+- Payload round-trip: server forwards verbatim to ObservedShellBus.emit
+- Manifest+registration parity: route is registered in BOTH include_routers()
+  and include_light_routers() (Sprint 1.B cicatrix antibody)
+
+Pattern based on backend/tests/unit/app/routers/test_channel_health.py.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+
+def _build_app() -> FastAPI:
+    """Mount the observed_shell router on a minimal FastAPI app.
+
+    Skips middleware on purpose — the unit test exercises router logic
+    only. The integration-level concern (auth middleware behavior) is
+    out of scope for this file; the X-API-Key dep itself is unit-tested
+    via the ``verify_internal_api_key`` Depends() override below.
+    """
+    from backend.app.routers import observed_shell
+
+    app = FastAPI()
+    app.include_router(observed_shell.router)
+    app.state.db_pool = None  # forces ObservedShellBus → JSONL fallback path
+    return app
+
+
+@pytest.fixture
+def authed_client():
+    """TestClient that pretends every request has a valid X-API-Key.
+
+    Overrides ``verify_internal_api_key`` to be a no-op so the router-side
+    behavior can be tested in isolation.
+    """
+    from backend.app.routers import observed_shell
+    from backend.app.utils.internal_api_auth import verify_internal_api_key
+
+    app = _build_app()
+
+    async def _ok():  # pragma: no cover — trivial
+        return {"service": "test"}
+
+    app.dependency_overrides[verify_internal_api_key] = _ok
+    return TestClient(app), app
+
+
+# ── tests ─────────────────────────────────────────────────────────────
+
+
+def test_router_mounts_at_documented_path():
+    """Smoke check: router exposes /api/observed-shell/emit."""
+    from backend.app.routers import observed_shell
+
+    paths = [r.path for r in observed_shell.router.routes]
+    assert "/api/observed-shell/emit" in paths
+
+
+def test_emit_happy_path_returns_202(authed_client):
+    """Valid POST → 202 Accepted with EmitResponse body."""
+    client, app = authed_client
+    with patch(
+        "backend.app.routers.observed_shell.ObservedShellBus"
+    ) as bus_cls:
+        bus_cls.return_value.emit = AsyncMock()
+        r = client.post(
+            "/api/observed-shell/emit",
+            json={
+                "automation_name": "translate.hourly",
+                "status": "ok",
+                "payload": {"duration_ms": 1234, "items": 42},
+                "trace_id": "run-2026-05-02T03:00",
+            },
+        )
+    assert r.status_code == 202, r.text
+    body = r.json()
+    assert body == {
+        "accepted": True,
+        "automation_name": "translate.hourly",
+        "status": "ok",
+    }
+    bus_cls.return_value.emit.assert_awaited_once()
+    kwargs = bus_cls.return_value.emit.await_args.kwargs
+    assert kwargs["automation_name"] == "translate.hourly"
+    assert kwargs["status"] == "ok"
+    assert kwargs["payload"] == {"duration_ms": 1234, "items": 42}
+    assert kwargs["trace_id"] == "run-2026-05-02T03:00"
+
+
+def test_emit_invalid_status_returns_422(authed_client):
+    """Status outside allowlist → 422 (NOT silently coerced)."""
+    client, _ = authed_client
+    r = client.post(
+        "/api/observed-shell/emit",
+        json={"automation_name": "x", "status": "bogus-status"},
+    )
+    assert r.status_code == 422, r.text
+    assert "ok" in r.text  # error message lists allowlist
+
+
+def test_emit_missing_required_field_returns_422(authed_client):
+    """Pydantic validates required fields before the handler runs."""
+    client, _ = authed_client
+    r = client.post(
+        "/api/observed-shell/emit",
+        json={"status": "ok"},  # missing automation_name
+    )
+    assert r.status_code == 422
+
+
+def test_emit_payload_optional(authed_client):
+    """payload + trace_id are optional; emit() receives None for both."""
+    client, _ = authed_client
+    with patch(
+        "backend.app.routers.observed_shell.ObservedShellBus"
+    ) as bus_cls:
+        bus_cls.return_value.emit = AsyncMock()
+        r = client.post(
+            "/api/observed-shell/emit",
+            json={"automation_name": "fly.backup.daily", "status": "skipped"},
+        )
+    assert r.status_code == 202
+    kwargs = bus_cls.return_value.emit.await_args.kwargs
+    assert kwargs["payload"] is None
+    assert kwargs["trace_id"] is None
+
+
+def test_emit_with_no_db_pool_does_not_500(authed_client):
+    """app.state.db_pool=None → emit() routes to JSONL fallback, NOT 500."""
+    client, _ = authed_client
+    # No mock of ObservedShellBus — real one is called with db_pool=None.
+    # ObservedShellBus.emit() never raises (Sprint 0 invariant), so endpoint
+    # returns 202 even when DB is absent.
+    import tempfile, pathlib
+    from backend.services.events import observed_shell as obs_mod
+
+    with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as fh:
+        fake_jsonl = pathlib.Path(fh.name)
+    try:
+        with patch.object(obs_mod, "JSONL_FALLBACK", fake_jsonl):
+            r = client.post(
+                "/api/observed-shell/emit",
+                json={"automation_name": "smoke.test", "status": "ok"},
+            )
+        assert r.status_code == 202, r.text
+    finally:
+        fake_jsonl.unlink(missing_ok=True)
+
+
+def test_router_registered_in_both_include_functions():
+    """Sprint 1.B cicatrix antibody #2: manifest entry must reach BOTH
+    include_routers() and include_light_routers(). Without this test, a
+    drift between the two surfaces would only be caught post-deploy.
+    """
+    # Set required env BEFORE import to avoid Settings ValidationError
+    os.environ.setdefault("JWT_SECRET_KEY", "x" * 40)
+    os.environ.setdefault("API_KEYS", "test-key")
+
+    from backend.app.setup.router_registration import (
+        include_light_routers,
+        include_routers,
+    )
+
+    full = FastAPI()
+    include_routers(full)
+    full_paths = {r.path for r in full.routes if hasattr(r, "path")}
+    assert "/api/observed-shell/emit" in full_paths, (
+        "include_routers() does NOT mount /api/observed-shell/emit — "
+        "Sprint 1.B cicatrix regression"
+    )
+
+    light = FastAPI()
+    include_light_routers(light)
+    light_paths = {r.path for r in light.routes if hasattr(r, "path")}
+    assert "/api/observed-shell/emit" in light_paths, (
+        "include_light_routers() does NOT mount /api/observed-shell/emit — "
+        "Sprint 1.B cicatrix regression"
+    )

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`255 routers · 532 services · 895 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`257 routers · 532 services · 896 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/docs/cell-core/observed-shell-tier.md
+++ b/docs/cell-core/observed-shell-tier.md
@@ -93,30 +93,45 @@ async def lifespan(app: FastAPI):
     yield
 ```
 
-### Bash (LaunchAgent / launchd cron jobs)
+### Bash (LaunchAgent / launchd cron jobs) — Sprint 1 PR-1.2 ✅ shipped
 
-For shell-only callers (e.g. `wr2-hardening-chain.sh`), wrap a curl call
-to the FastAPI backend that has the bus attached. Example endpoint
-(NOT shipped in this Sprint 0; tracked as Sprint 1 follow-up):
+The HTTP endpoint `POST /api/observed-shell/emit` lands in Sprint 1
+PR-1.2 (`apps/backend-rag/backend/app/routers/observed_shell.py`). Use
+the canonical bash wrapper rather than raw `curl`:
 
 ```bash
-# Bash wrapper for observed-shell emit (Sprint 1 will ship the endpoint)
-curl -fsS -X POST http://127.0.0.1:8000/api/observed-shell/emit \
-  -H "Content-Type: application/json" \
-  -H "X-API-Key: ${BACKEND_API_KEY:?missing}" \
-  -d '{
-    "automation_name": "wr2.hardening.run",
-    "status": "ok",
-    "payload": {
-      "exit_code": 0,
-      "missed_runs_caught": 3
-    }
-  }' || true   # non-fatal
+source scripts/observed-shell-emit.sh
+observed_shell_emit "wr2.hardening.run" "ok" '{"missed_runs_caught":3}' "trace-abc"
 ```
 
-The `|| true` makes the emit non-fatal: if the backend is down the
-hardening run continues. This is the pattern Symbiosis Law 4 applied
-at the observability layer.
+The wrapper is **best-effort** — emit failure (DNS, refused, 5xx, missing
+API key) returns 0 and only logs to stderr. The parent automation MUST
+NOT fail because observability is unavailable. This mirrors
+`ObservedShellBus.emit()` never-raises invariant at the network layer.
+
+The endpoint is X-API-Key authenticated (not in `PUBLIC_ENDPOINTS`):
+
+```bash
+export OBSERVED_SHELL_API_URL="http://127.0.0.1:8080"
+export OBSERVED_SHELL_API_KEY="$(grep ^API_KEYS ~/.nuzantara-secrets.env | cut -d= -f2 | tr -d '"' | head -1)"
+```
+
+#### Pattern: extrinsic wrapper around an unchanged Python script
+
+The recommended pattern for retrofitting observability onto an existing
+script (e.g. `apps/bali-intel-scraper/scripts/run_intel_pipeline.py`) is
+to **leave the Python untouched** and wrap it with a sibling shell
+wrapper such as `scripts/intel-scraper-with-observability.sh`:
+
+- Source `observed-shell-emit.sh`
+- emit `ok` + `phase=start` BEFORE the subprocess
+- run the workload (Python pipeline, unchanged)
+- emit `ok` + `phase=finish` + `duration_ms` (or `error` + `exit_code`)
+  AFTER the subprocess
+
+Same `trace_id` ties the start/finish emit pair together. Observability
+stays decoupled from pipeline logic; rolling back the wrapper restores
+the original LaunchAgent behavior unchanged.
 
 ## List of automations to migrate (Sprint 1 wave)
 

--- a/scripts/intel-scraper-with-observability.sh
+++ b/scripts/intel-scraper-with-observability.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# intel-scraper-with-observability.sh — Sprint 1 PR-1.2
+#
+# Wraps the daily intel scraper pipeline with observed-shell emit calls
+# at lifecycle boundaries. The wrapped script (run_intel_pipeline.py) is
+# left UNCHANGED — observability is extrinsic, decoupled from pipeline
+# logic.
+#
+# This is the canonical pattern for retrofitting observed-shell emission
+# onto a non-Python automation: source observed-shell-emit.sh, wrap the
+# real workload with start/success/error emits.
+#
+# Suggested LaunchAgent ProgramArguments invocation:
+#
+#   <key>ProgramArguments</key>
+#   <array>
+#       <string>/bin/bash</string>
+#       <string>/Users/nuzantara/Desktop/nuzantara/scripts/intel-scraper-with-observability.sh</string>
+#   </array>
+#
+# Required env (set in the plist EnvironmentVariables block):
+#   OBSERVED_SHELL_API_URL    — typically http://127.0.0.1:8080
+#   OBSERVED_SHELL_API_KEY    — same X-API-Key Brevo + other internal eps use
+#   PIPELINE_PYTHON           — venv python (default $HOME/Desktop/nuzantara/apps/bali-intel-scraper/venv/bin/python)
+#   PIPELINE_SCRIPT           — default: apps/bali-intel-scraper/scripts/run_intel_pipeline.py
+#   PIPELINE_ARGS             — extra args, default: --mode full
+#
+# Reference: docs/cell-core/observed-shell-tier.md § "Bash wrapper"
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$REPO_ROOT/scripts/observed-shell-emit.sh"
+
+PIPELINE_PYTHON="${PIPELINE_PYTHON:-$HOME/Desktop/nuzantara/apps/bali-intel-scraper/venv/bin/python}"
+PIPELINE_SCRIPT="${PIPELINE_SCRIPT:-$REPO_ROOT/apps/bali-intel-scraper/scripts/run_intel_pipeline.py}"
+PIPELINE_ARGS="${PIPELINE_ARGS:---mode full}"
+
+AUTOMATION="intel-scraper.nightly"
+TRACE_ID="intel-$(date -u +%Y%m%dT%H%M%SZ)"
+
+start_ts=$(date -u +%s)
+
+observed_shell_emit "$AUTOMATION" "ok" \
+    "$(jq -nc --arg phase start --arg trace "$TRACE_ID" '{phase:$phase,trace_id:$trace}' 2>/dev/null || echo '{"phase":"start"}')" \
+    "$TRACE_ID"
+
+# Run the actual pipeline. Exit code propagates to the emit decision.
+"$PIPELINE_PYTHON" "$PIPELINE_SCRIPT" $PIPELINE_ARGS
+pipeline_rc=$?
+
+end_ts=$(date -u +%s)
+duration_ms=$(( (end_ts - start_ts) * 1000 ))
+
+if [[ "$pipeline_rc" -eq 0 ]]; then
+    observed_shell_emit "$AUTOMATION" "ok" \
+        "$(jq -nc \
+            --arg phase finish \
+            --argjson duration_ms "$duration_ms" \
+            --arg trace "$TRACE_ID" \
+            '{phase:$phase,duration_ms:$duration_ms,trace_id:$trace}' 2>/dev/null \
+            || printf '{"phase":"finish","duration_ms":%d}' "$duration_ms")" \
+        "$TRACE_ID"
+else
+    observed_shell_emit "$AUTOMATION" "error" \
+        "$(jq -nc \
+            --arg phase finish \
+            --argjson duration_ms "$duration_ms" \
+            --argjson rc "$pipeline_rc" \
+            --arg trace "$TRACE_ID" \
+            '{phase:$phase,duration_ms:$duration_ms,exit_code:$rc,trace_id:$trace}' 2>/dev/null \
+            || printf '{"phase":"finish","duration_ms":%d,"exit_code":%d}' "$duration_ms" "$pipeline_rc")" \
+        "$TRACE_ID"
+fi
+
+exit "$pipeline_rc"

--- a/scripts/observed-shell-emit.sh
+++ b/scripts/observed-shell-emit.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# observed-shell-emit.sh — Sprint 1 PR-1.2
+#
+# Bash wrapper around POST /api/observed-shell/emit, intended to be
+# sourced from LaunchAgent + cron-agent-python shell jobs that record
+# their lifecycle into the cell-core observed-shell tier without having
+# to import Python.
+#
+# Usage:
+#   source scripts/observed-shell-emit.sh
+#   observed_shell_emit translate.hourly ok '{"items":42}' "trace-abc"
+#
+# Or one-shot:
+#   bash scripts/observed-shell-emit.sh translate.hourly ok '{"items":42}'
+#
+# Required env:
+#   OBSERVED_SHELL_API_URL   — base URL, default http://127.0.0.1:8080
+#   OBSERVED_SHELL_API_KEY   — X-API-Key header value (set in ~/.nuzantara-secrets.env)
+#
+# Status taxonomy (must match VALID_STATUSES in observed_shell.py):
+#   ok | error | warning | skipped
+#
+# Failure mode: this wrapper is BEST-EFFORT. If the curl POST fails (DNS,
+# TCP refused, 5xx), the script logs to stderr and returns 0 — the parent
+# automation MUST NOT fail because observability is unavailable. This
+# mirrors ObservedShellBus.emit() never-raises invariant.
+#
+# Reference:
+#   docs/cell-core/observed-shell-tier.md § "Bash (LaunchAgent / launchd cron jobs)"
+#   apps/backend-rag/backend/app/routers/observed_shell.py
+
+set -uo pipefail   # NOT -e: we want to swallow curl errors
+
+OBSERVED_SHELL_API_URL="${OBSERVED_SHELL_API_URL:-http://127.0.0.1:8080}"
+OBSERVED_SHELL_API_KEY="${OBSERVED_SHELL_API_KEY:-}"
+
+observed_shell_emit() {
+    local automation_name="${1:-}"
+    local status="${2:-}"
+    local payload_json="${3:-{}}"
+    local trace_id="${4:-}"
+
+    if [[ -z "$automation_name" || -z "$status" ]]; then
+        echo "observed_shell_emit: usage: emit <automation_name> <status> [payload_json] [trace_id]" >&2
+        return 0   # best-effort — never fail caller
+    fi
+
+    if [[ -z "$OBSERVED_SHELL_API_KEY" ]]; then
+        echo "observed_shell_emit: OBSERVED_SHELL_API_KEY unset — skipping emit for $automation_name" >&2
+        return 0
+    fi
+
+    # Build JSON safely: jq if available (atomic, escapes everything), fall
+    # back to a printf-style template that the caller is responsible for.
+    local body
+    if command -v jq >/dev/null 2>&1; then
+        body=$(jq -nc \
+            --arg name "$automation_name" \
+            --arg status "$status" \
+            --argjson payload "$payload_json" \
+            --arg trace "$trace_id" \
+            '{automation_name: $name, status: $status, payload: $payload}
+             + (if $trace == "" then {} else {trace_id: $trace} end)' 2>/dev/null) || {
+            echo "observed_shell_emit: jq build failed for $automation_name — skipping" >&2
+            return 0
+        }
+    else
+        # Fallback: minimal JSON without payload escape safety. Callers
+        # without jq SHOULD pass payload_json='{}' to avoid corruption.
+        if [[ -n "$trace_id" ]]; then
+            body=$(printf '{"automation_name":"%s","status":"%s","payload":%s,"trace_id":"%s"}' \
+                "$automation_name" "$status" "$payload_json" "$trace_id")
+        else
+            body=$(printf '{"automation_name":"%s","status":"%s","payload":%s}' \
+                "$automation_name" "$status" "$payload_json")
+        fi
+    fi
+
+    # 5s connect + 10s total — observability MUST NOT block real work
+    curl -fsS \
+        --max-time 10 \
+        --connect-timeout 5 \
+        -X POST "${OBSERVED_SHELL_API_URL}/api/observed-shell/emit" \
+        -H "Content-Type: application/json" \
+        -H "X-API-Key: ${OBSERVED_SHELL_API_KEY}" \
+        -d "$body" \
+        > /dev/null 2>&1 || \
+        echo "observed_shell_emit: POST failed for $automation_name (status=$status) — non-fatal" >&2
+
+    return 0
+}
+
+# Allow direct invocation: `bash observed-shell-emit.sh <name> <status> ...`
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    observed_shell_emit "$@"
+fi


### PR DESCRIPTION
## Summary

Sprint 1 PR-1.2 — completes the observed-shell tier shipped in Sprint 0 (migration 151 + ObservedShellBus class) by adding the HTTP boundary that lets shell-only callers emit observability events without importing cell-core.

Builds on (but is independent from) PR-1.1 (`feat/sprint1-cells`, intel-scraper-cell declaration).

## What's in

### Backend (HTTP boundary)
- **`apps/backend-rag/backend/app/routers/observed_shell.py`** — `POST /api/observed-shell/emit`. X-API-Key auth via `verify_internal_api_key`. Pydantic `EmitRequest` validates status against `VALID_STATUSES` allowlist (422 on miss). Backed by `ObservedShellBus.emit()` → migration 151 `observed_shell_events` table.
- **`router_manifest.py`** — `RouterEntry(name="observed_shell", process_groups=_API)` (alpha-sorted between olympus and omnichannel)
- **`router_registration.py`** — 4 lockstep edits per Sprint 1.B cicatrix antibody (2x import + 2x `include_router` calls in `include_routers` AND `include_light_routers`)

### Shell-side wrappers
- **`scripts/observed-shell-emit.sh`** — sourceable bash function `observed_shell_emit <name> <status> [payload_json] [trace_id]`. Best-effort (never fails caller). Uses jq when available; printf fallback otherwise.
- **`scripts/intel-scraper-with-observability.sh`** — extrinsic LaunchAgent wrapper that emits start/finish lifecycle around the unchanged `apps/bali-intel-scraper/scripts/run_intel_pipeline.py`. Pattern: same `trace_id` ties start+finish, `exit_code` surfaces in error payload. **Python script untouched** — observability decoupled.

### Tests
- **`backend/tests/unit/app/routers/test_observed_shell.py`** — 7 tests:
  - happy path (202 + correct ObservedShellBus call args)
  - invalid status → 422
  - missing required field → 422 (Pydantic)
  - optional payload + trace_id → emit kwargs are None
  - DB pool=None → 202 (JSONL fallback semantics, no 500)
  - `test_router_registered_in_both_include_functions` — Sprint 1.B cicatrix antibody #2
  - smoke test that router exposes `/api/observed-shell/emit`

### Docs
- **`docs/cell-core/observed-shell-tier.md`** — Bash section updated to reference shipped endpoint + canonical `source observed-shell-emit.sh` pattern + extrinsic-wrapper-around-Python pattern.

## What's deferred (Sprint 1 follow-ups)

- Intel-radar instrumentation (cron-agent-python strategy)
- Intel-feed-processor instrumentation (cron-agent-python strategy)
- WR2 hardening chain instrumentation (`wr2-hardening-chain.sh`)
- Translation hourly + BI exchange-rate + regulatory monitor wrappers (the 11-automation Sprint 1 wave from `docs/cell-core/observed-shell-tier.md`)

These are mechanical wraps that follow the `intel-scraper-with-observability.sh` template; one PR per cluster keeps reviews small.

## Tests

```
JWT_SECRET_KEY=... API_KEYS=test-key pytest backend/tests/unit/app/routers/test_observed_shell.py
→ 7/7 pass

bash -n scripts/observed-shell-emit.sh scripts/intel-scraper-with-observability.sh
→ exit 0
```

The registration-parity test (Sprint 1.B antibody) takes ~11s because it imports the full FastAPI app twice. CI tolerates it.

## Risk

- **Non-public endpoint.** X-API-Key gate; not in PUBLIC_ENDPOINTS.
- **Best-effort emit.** Bus.emit() never raises (Sprint 0 invariant); endpoint returns 202 even when DB pool unavailable (JSONL fallback at the bus layer).
- **Idempotency.** No idempotency key — emit is fire-and-store, duplicates are observed, not deduped. Acceptable for observability tier.

## References

- Sprint 0 framework: migration 151, `backend/services/events/observed_shell.py`, `docs/cell-core/observed-shell-tier.md`
- Sprint 1 PR-1.1 (independent): `feat/sprint1-intel-scraper-cell` — declarative cell registration
- Cicatrix Sprint 1.B (antibody pattern): `.claude/rules/cicatrix-scars.md` § "Test infrastructure mock != production stack"

🤖 Generated by Claude Opus 4.7 (1M context) on Air session