### PR TITLE
chore(deps): remove unused fastmcp — closes 8 Dependabot alerts

### DIFF
--- a/apps/backend-rag/requirements.txt
+++ b/apps/backend-rag/requirements.txt
@@ -153,7 +153,13 @@ redis>=7.1.0  # Already present, used for caching
 
 # MCP (Model Context Protocol)
 mcp>=1.25.0  # Upgraded for pydantic 2.12+ compatibility
-fastmcp==2.1.0  # Downgraded 2026-04-25 to resolve python-dotenv conflict with litellm 1.83.7
+# fastmcp removed 2026-05-03: not imported by backend-rag runtime. The MCP
+# server lives in apps/nuzantara-mcp/ with its own venv (fastmcp 3.2.4).
+# Removal closes 8 Dependabot alerts on fastmcp 2.1.0 (1 critical + 4 high
+# + 3 medium): SSRF/Path Traversal (GHSA-vv7q-7jx5-f767), OAuth Proxy
+# Confused Deputy (GHSA-rww4-4w9c-7733, GHSA-c2jp-c369-7pvx), token reuse
+# (GHSA-5h2m-4q8j-pqpj), CVE-2025-66416 (GHSA-rcfx-77hg-w2wv), command
+# injection variants, reflected XSS callback page.
 python-json-logger>=2.0.0
 
 # Security & HTTP


### PR DESCRIPTION
## Summary

- **What:** Remove `fastmcp==2.1.0` line from `apps/backend-rag/requirements.txt`
- **Why:** Closes 8 Dependabot alerts (1 critical + 4 high + 3 medium) with zero runtime impact — the dep is declared but never imported by backend-rag. The actual MCP server lives in `apps/nuzantara-mcp/` with its own venv (fastmcp 3.2.4).
- **Risk:** Minimal. Verified by grepping `from fastmcp` / `import fastmcp` across `apps/backend-rag/backend/` — only match was inside `requirements.txt` itself.

## Alerts closed

| # | Sev | GHSA |
|---|---|---|
| #400 | critical | GHSA-vv7q-7jx5-f767 (SSRF + Path Traversal in OpenAPI Provider) |
| #399 | high | GHSA-rww4-4w9c-7733 (Missing Consent Verification OAuth Proxy) |
| #397 | high | GHSA-5h2m-4q8j-pqpj (OAuth Proxy token reuse) |
| #396 | high | GHSA-rcfx-77hg-w2wv (CVE-2025-66416, MCP 1.23+ required) |
| #393 | high | GHSA-c2jp-c369-7pvx (Confused Deputy Account Takeover) |
| #398 | medium | GHSA-m8x7-r2rg-vh5g (Command Injection — Gemini CLI) |
| #395 | medium | GHSA-rj5c-58rq-j5g5 (Windows command injection — Cursor installer) |
| #394 | medium | GHSA-mxxr-jv3v-6pgc (Reflected XSS callback page) |

## Why removal instead of upgrade

Upgrading to `fastmcp>=3.2.4` would have required also bumping `litellm>=1.83.14` (relaxes `python-dotenv` pin from `==1.0.1` to `==1.2.2`). Removal is the lower-risk path since backend-rag does not actually use fastmcp at runtime.

## Test plan

- [x] Import chain: `python -c "from backend.app.dependencies import get_current_user"` → OK
- [x] Core RAG tests: `PYTHONPATH=. pytest backend/tests/services/rag/test_confidence.py -q` → 24/24 passed
- [ ] CI must pass (E2E, MCP, Frontend, Detect Secrets) before auto-merge
- [ ] Verify `apps/nuzantara-mcp/.venv` is unaffected (no requirements.txt change there — separate venv)

🤖 Generated with [Claude Code](https://claude.com/claude-code)