### PR TITLE
chore(infra): rsync 4 Pro-only WR2 plist into repo (Sprint 0 Track B1)

### DIFF
--- a/infra/launchagents/com.balizero.wr2.canva-apply.plist
+++ b/infra/launchagents/com.balizero.wr2.canva-apply.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>/Users/nuzantara</string>
+		<key>PATH</key>
+		<string>/Users/nuzantara/.local/bin:/Users/nuzantara/.npm-global/bin:/Users/nuzantara/.pyenv/versions/3.11.11/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+	</dict>
+	<key>Label</key>
+	<string>com.balizero.wr2.canva-apply</string>
+	<key>Program</key>
+	<string>/Users/nuzantara/.openclaw/bin/wr2/wr2-script-wrapper.sh</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Users/nuzantara/.openclaw/bin/wr2/wr2-script-wrapper.sh</string>
+		<string>scripts/wr2_canva_desktop_apply.py</string>
+	</array>
+	<key>StandardErrorPath</key>
+	<string>/Users/nuzantara/logs/wr2_canva_apply.launchd.err.log</string>
+	<key>StandardOutPath</key>
+	<string>/Users/nuzantara/logs/wr2_canva_apply.launchd.out.log</string>
+</dict>
+</plist>

--- a/infra/launchagents/com.balizero.wr2.draft-generator.plist
+++ b/infra/launchagents/com.balizero.wr2.draft-generator.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>/Users/nuzantara</string>
+		<key>PATH</key>
+		<string>/Users/nuzantara/.local/bin:/Users/nuzantara/.npm-global/bin:/Users/nuzantara/.pyenv/versions/3.11.11/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+	</dict>
+	<key>Label</key>
+	<string>com.balizero.wr2.draft-generator</string>
+	<key>Program</key>
+	<string>/Users/nuzantara/.openclaw/bin/wr2/wr2-script-wrapper.sh</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Users/nuzantara/.openclaw/bin/wr2/wr2-script-wrapper.sh</string>
+		<string>scripts/wr2_draft_generator.py</string>
+	</array>
+	<key>StandardErrorPath</key>
+	<string>/Users/nuzantara/logs/wr2_draft_generator.launchd.err.log</string>
+	<key>StandardOutPath</key>
+	<string>/Users/nuzantara/logs/wr2_draft_generator.launchd.out.log</string>
+</dict>
+</plist>

--- a/infra/launchagents/com.balizero.wr2.image-generator.plist
+++ b/infra/launchagents/com.balizero.wr2.image-generator.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>/Users/nuzantara</string>
+		<key>PATH</key>
+		<string>/Users/nuzantara/.local/bin:/Users/nuzantara/.npm-global/bin:/Users/nuzantara/.pyenv/versions/3.11.11/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+	</dict>
+	<key>Label</key>
+	<string>com.balizero.wr2.image-generator</string>
+	<key>Program</key>
+	<string>/Users/nuzantara/.openclaw/bin/wr2/wr2-script-wrapper.sh</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Users/nuzantara/.openclaw/bin/wr2/wr2-script-wrapper.sh</string>
+		<string>scripts/wr2_image_generator.py</string>
+	</array>
+	<key>StandardErrorPath</key>
+	<string>/Users/nuzantara/logs/wr2_image_generator.launchd.err.log</string>
+	<key>StandardOutPath</key>
+	<string>/Users/nuzantara/logs/wr2_image_generator.launchd.out.log</string>
+</dict>
+</plist>

--- a/infra/launchagents/com.balizero.wr2.topic-selector.plist
+++ b/infra/launchagents/com.balizero.wr2.topic-selector.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>/Users/nuzantara</string>
+		<key>PATH</key>
+		<string>/Users/nuzantara/.local/bin:/Users/nuzantara/.npm-global/bin:/Users/nuzantara/.pyenv/versions/3.11.11/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+	</dict>
+	<key>Label</key>
+	<string>com.balizero.wr2.topic-selector</string>
+	<key>Program</key>
+	<string>/Users/nuzantara/.openclaw/bin/wr2/wr2-script-wrapper.sh</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Users/nuzantara/.openclaw/bin/wr2/wr2-script-wrapper.sh</string>
+		<string>scripts/wr2_topic_selector.py</string>
+	</array>
+	<key>StandardErrorPath</key>
+	<string>/Users/nuzantara/logs/wr2_topic_selector.launchd.err.log</string>
+	<key>StandardOutPath</key>
+	<string>/Users/nuzantara/logs/wr2_topic_selector.launchd.out.log</string>
+	<key>StartCalendarInterval</key>
+	<dict>
+		<key>Hour</key>
+		<integer>5</integer>
+		<key>Minute</key>
+		<integer>10</integer>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Sprint 0 Track B1 follow-up — closes the WR2 plist drift identified in `docs/audits/sprint0/bali-dispatch-normalization.md`.

Pro launchd had 16 `com.balizero.wr2.*` plist files, but the repo only versioned 13. The 4 Pro-only plist (canva-apply, draft-generator, image-generator, topic-selector) were backed by `scripts/wr2_*.py` in the repo but had their launchd configuration uncommitted. This rsync's them verbatim from Pro.

## Verification

- `plutil -lint infra/launchagents/com.balizero.wr2.{canva-apply,draft-generator,image-generator,topic-selector}.plist` → OK
- After: `ls infra/launchagents/com.balizero.wr2.*.plist | wc -l` → 17
  (the +1 vs Pro's 16 is `canva-renderer`, a repo-only orphan tracked separately for review)

## Risk

Zero. plist files are configuration, not code. Repo→Pro deployment is manual; this commit only updates the source-of-truth in version control.

## Reference

- `docs/audits/sprint0/bali-dispatch-normalization.md` § "Action items"
- `docs/audits/2026-05-02-cell-openclaw-brainstorm/99b_synthesis_v2.md` § "Sprint 0 verdict — 9 cognitive backbone organelle"