### PR TITLE
Sprint 1.6 W3: FlowKit secondary backend for WR2 image-generator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,6 +385,8 @@ before the pre-deploy gate even runs. To bypass on a legitimate destructive
 change: `-- squawk-ignore: <rule-name>` on the offending statement. Full
 reference: [`docs/oss-injections-2026-04-26.md`](docs/oss-injections-2026-04-26.md).
 
+**WR2 image-generator backend** (Sprint 1.6 W3, 2026-05-03): `WR2_IMAGE_BACKEND` selects FlowKit (`auto` default — opt-in primary, falls back to Playwright) / `flowkit` / `playwright`. See [`docs/wr2/flowkit-integration.md`](docs/wr2/flowkit-integration.md).
+
 ## 12. AI Dispatch System
 
 > `./scripts/ai-dispatch.sh help` for full commands. Details: `docs/AI_DISPATCH_REFERENCE.md`

--- a/docs/wr2/flowkit-integration.md
+++ b/docs/wr2/flowkit-integration.md
@@ -1,0 +1,182 @@
+# WR2 Image Generator — FlowKit Integration
+
+> **Status**: Shipped Sprint 1.6 W3, 2026-05-03. FlowKit is the **secondary
+> backend**, opt-in via `WR2_IMAGE_BACKEND=auto` (the new default). The
+> existing Playwright path is preserved as fallback and remains the
+> production behavior whenever FlowKit is unreachable.
+
+## Why FlowKit
+
+The empirical POC on 2026-05-03 (Antonello's Ultra account, see memory
+`discovery_flowkit_poc_test_2026_05_03.md`) verified that FlowKit gives a
+direct HTTP path to the same `GEM_PIX_2` (Nano Banana Pro) model that the
+Playwright path drives via the Gemini web UI. Concrete numbers:
+
+| Path | Latency / image | Credit cost | Setup overhead |
+|---|---|---|---|
+| Playwright (existing) | 30-90 s | 0 (web UI quota) | persistent Chrome profile, hover-reveal selectors |
+| FlowKit (new) | 5-15 s | **0** (FREE for `PAYGATE_TIER_TWO`) | local agent on `:8100` + Chrome extension |
+
+Same model, same image quality, **5-10× faster**, same $0 marginal cost.
+The slow path is preserved because FlowKit's bearer token expires every
+~45 min (extension auto-refreshes on Flow tab activity, but if the tab
+sits idle the next call returns `NO_FLOW_KEY` until refresh).
+
+## Architecture
+
+```mermaid
+flowchart LR
+    DB[(Postgres<br/>war_room_drafts)] --> WR2[wr2_image_generator.py]
+    WR2 -->|probe once per draft| Probe{FlowKit<br/>is_available?}
+    Probe -->|yes| FK[FlowKit<br/>:8100]
+    Probe -->|no| PW[Playwright<br/>Gemini web UI]
+    FK -->|fails| PW
+    FK --> Tigris[Tigris S3<br/>nuzantara-warroom-images]
+    PW --> Tigris
+    Tigris --> WR2
+    WR2 -->|status=drafts_imaged| DB
+```
+
+The dispatch is per-slide but the FlowKit availability probe is **once per
+draft** — we don't re-probe between slides because (a) it's wasteful and
+(b) we want consistent backend choice within a single dispatch carousel.
+
+## Env-var matrix
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `WR2_IMAGE_BACKEND` | `auto` | `auto` = FlowKit first, fall back to Playwright. `flowkit` = FlowKit only, raise `BackendUnavailableError` if down. `playwright` = legacy Playwright only. |
+| `WR2_FLOWKIT_BASE_URL` | `http://127.0.0.1:8100` | FlowKit local agent endpoint. |
+| `WR2_FLOWKIT_TIMEOUT_S` | `60` | HTTP timeout for individual FlowKit calls. |
+| `WR2_FLOWKIT_MATERIAL` | `realistic` | FlowKit project material/style preset. `realistic` matches the WR2 brand bar (editorial photo aesthetic). |
+| `WR2_FLOWKIT_LANGUAGE` | `en` | Project language hint. |
+
+The existing Playwright vars (`WR2_GEMINI_PROFILE_DIR`, `WR2_IMAGE_TIMEOUT_PER_SLIDE`,
+`WR2_IMAGE_MAX_RETRIES`, `WR2_IMAGE_VLM_VALIDATION` etc.) are unchanged
+and still apply to the Playwright path. **`WR2_IMAGE_VLM_VALIDATION`
+applies to BOTH backends** — Nano Banana Pro can also produce off-prompt
+outputs and the WR2 brand bar is the same regardless of producer.
+
+## Trigger conditions for fallback
+
+The `auto` backend falls back to Playwright on ANY of:
+
+1. FlowKit local agent (`:8100`) not reachable (TCP connection refused, timeout).
+2. `/health` returns `extension_connected: false` (Chrome extension not loaded
+   or service worker idle).
+3. `/api/flow/credits` returns `NO_FLOW_KEY` (bearer token expired or
+   never captured) — surfaced as HTTP 401 OR 200+detail-envelope.
+4. `/api/flow/generate-image` returns 5xx, malformed JSON, or
+   `detail: "MODEL_ACCESS_DENIED"` (region-blocked / model not in tier).
+5. Signed CDN download fails (URL expired past 30-min TTL, or Tigris
+   network issue between Pro and the CDN).
+6. Local read of the downloaded PNG produces zero bytes.
+7. VLM alignment validation rejects the FlowKit output (off-prompt
+   stock-style content) — same threshold as Playwright (`WR2_IMAGE_MIN_ALIGN_SCORE=0.5`).
+
+In `flowkit`-only mode the same conditions instead surface as an error in
+the per-slide tuple (`(slide_number, None, error_msg)`) — there is no
+Playwright fallback. The draft is marked `image_failed` if every slide
+errors.
+
+## Operational runbook
+
+### Start FlowKit on Pro (manual, one-time per session)
+
+```bash
+# 1. Boot the local agent (assumes setup per the skill doc)
+cd /tmp/flowkit-poc/flowkit
+source venv/bin/activate
+python -m agent.main &  # listens on :8100 (HTTP) + :9222 (extension WS)
+
+# 2. Open the Flow tab and pin the extension (one-time per Chrome restart)
+open "https://labs.google/fx/tools/flow"
+# → Click the FlowKit extension icon (puzzle 🧩 → pin → click)
+
+# 3. Verify
+curl -s http://127.0.0.1:8100/health \
+  | python3 -c "import json,sys;d=json.load(sys.stdin);print('connected:',d['extension_connected'])"
+# connected: True
+
+curl -s http://127.0.0.1:8100/api/flow/credits | python3 -m json.tool | head -10
+# Should NOT be {"detail":"NO_FLOW_KEY"}
+```
+
+If `connected: false` after 30 s, refresh the Flow tab and click the
+extension icon again — the WebSocket bridge re-establishes within ~5 s.
+
+### Verify the WR2 cron picks up FlowKit
+
+```bash
+# Run wr2_image_generator.py manually with a known draft in 'drafts' status:
+cd ~/Desktop/nuzantara
+DATABASE_URL=postgresql://localhost/nuzantara_local \
+  WR2_IMAGE_BACKEND=auto \
+  apps/backend-rag/.venv/bin/python scripts/wr2_image_generator.py --draft-id <UUID>
+
+# Look for these log lines:
+#   FlowKit available — using as primary backend (PAYGATE_TIER_TWO)
+#   [slide N] generating via FlowKit (Nano Banana Pro)
+#   [slide N] FlowKit ok (8.3s, 1234567 bytes)
+#   [slide N] uploading to Tigris
+#   [slide N] uploaded → https://...
+```
+
+If FlowKit is down you should see instead:
+
+```
+FlowKit unavailable — using Playwright backend
+[slide N] generating image (overall 1, primary attempt 1/3)
+```
+
+### Failure modes (none of which require operator action)
+
+| Symptom | What's happening | Action |
+|---|---|---|
+| `FlowKit /health unreachable` (DEBUG-level log) | Local agent not running. | None — auto path falls back to Playwright. Restart agent next time you boot Chrome. |
+| `FlowKit token not captured (NO_FLOW_KEY)` | Bearer expired (>45 min idle on Flow tab). | None — auto fallback. To restore primary: refresh `labs.google/fx/tools/flow` and click extension icon. |
+| `FlowKit generate-image status=403 ... MODEL_ACCESS_DENIED` | Region block on the requested model (Veo 3 from Bali, etc.). | None — auto fallback. Image gen via `GEM_PIX_2` is NOT region-blocked, so this should not fire for hero images. |
+| `flowkit VLM rejected (score=0.4 < 0.5)` | FlowKit output didn't match prompt (off-brand) | None — auto path falls back to Playwright; flowkit-only path returns error and slide is marked failed. |
+
+## What does NOT change
+
+This integration is purely additive:
+
+- The Playwright path (`_gen_one_image`, `_gen_one_image_raw`,
+  `_build_prompt_variants`) is **byte-identical** to before.
+- The launchd plist (`infra/launchagents/com.balizero.wr2.image-generator.plist`)
+  is **unchanged** — no new env var is set there, so production cron
+  defaults to `WR2_IMAGE_BACKEND=auto` and silently uses Playwright until
+  FlowKit is set up on Pro.
+- DB schema, status transitions (`drafts/drafts_checked` →
+  `drafts_imaged`/`image_failed`), `slides_json` shape, Tigris bucket and
+  key naming convention are all unchanged.
+- VLM alignment validation, retry loop, prompt variant fallback all apply
+  to the Playwright path identically.
+
+The only observable behavior difference when FlowKit IS available:
+hero-slide generation drops from ~30-90s/image to ~5-15s/image, and the
+`council_debate_json` `image_generated_at` timestamp closes on the draft
+~3-7 minutes earlier on a 4-hero carousel.
+
+## Anthropic SDK compliance
+
+FlowKit's `agent/services/video_reviewer.py` has a lazy-import path that
+uses the Anthropic SDK if `ANTHROPIC_API_KEY` is set. The Bali Zero setup
+procedure (per the skill doc) **strips `anthropic` from
+`requirements.txt`** during install, and we never call the video reviewer
+from this integration — we only use `/api/flow/generate-image` and
+`/api/flow/credits`. Defense in depth: even if a future FlowKit patch adds
+`import anthropic` at module top, pip install will fail on the missing
+package, which is the desired outcome under Golden Rule #13.
+
+The reference implementation in `scripts/wr2_flowkit_client.py` uses only
+`httpx` — no Anthropic SDK, no LLM calls.
+
+## References
+
+- Skill: `~/.claude/skills/nuzantara-flowkit-flow-generation.md`
+- Memory: `discovery_flowkit_poc_test_2026_05_03.md`
+- POC repo: `github.com/crisng95/flowkit` (MIT, OSS)
+- Existing pipeline: [`wr2_image_generator.py`](../../scripts/wr2_image_generator.py)
+- Sibling docs: [`docs/wr2/SUPERVISOR.md`](SUPERVISOR.md)

--- a/scripts/tests/test_wr2_flowkit_client.py
+++ b/scripts/tests/test_wr2_flowkit_client.py
@@ -1,0 +1,409 @@
+"""Unit tests for scripts/wr2_flowkit_client.py.
+
+Covers the public surface of FlowKitClient with httpx.MockTransport so no
+real network calls happen. Tests:
+
+- health() returns dict when extension_connected=True, None otherwise
+- get_credits() returns dict on 200, None on NO_FLOW_KEY (401 or detail)
+- is_available() composes health + credits results
+- ensure_project() POSTs once and caches the project_id
+- generate_image() parses the empirical FlowKit response shape
+- generate_image() raises FlowKitGenerationError on 5xx / detail-error / malformed
+- download_image() writes bytes to disk; raises on non-2xx / zero bytes
+- _parse_image_response() handles missing fields cleanly
+
+All HTTP traffic is intercepted via httpx.MockTransport — zero real I/O.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+# Load the client module from scripts/ (it is not on PYTHONPATH).
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+CLIENT_PATH = SCRIPTS_DIR / "wr2_flowkit_client.py"
+
+
+@pytest.fixture
+def fk_module():
+    """Fresh import of wr2_flowkit_client with clean module-level state."""
+    sys.modules.pop("wr2_flowkit_client", None)
+    spec = importlib.util.spec_from_file_location(
+        "wr2_flowkit_client", CLIENT_PATH,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["wr2_flowkit_client"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_transport(handler):
+    return httpx.MockTransport(handler)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# health()
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_health_returns_dict_when_connected(fk_module):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/health"
+        return httpx.Response(
+            200,
+            json={
+                "status": "ok",
+                "version": "0.2.0",
+                "extension_connected": True,
+                "ws": {},
+            },
+        )
+
+    async with fk_module.FlowKitClient(transport=_make_transport(handler)) as fk:
+        result = await fk.health()
+    assert result is not None
+    assert result["extension_connected"] is True
+    assert result["version"] == "0.2.0"
+
+
+@pytest.mark.asyncio
+async def test_health_returns_none_when_extension_disconnected(fk_module):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"status": "ok", "extension_connected": False},
+        )
+
+    async with fk_module.FlowKitClient(transport=_make_transport(handler)) as fk:
+        result = await fk.health()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_health_returns_none_on_connection_error(fk_module):
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    async with fk_module.FlowKitClient(transport=_make_transport(handler)) as fk:
+        result = await fk.health()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_health_returns_none_on_5xx(fk_module):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503)
+
+    async with fk_module.FlowKitClient(transport=_make_transport(handler)) as fk:
+        result = await fk.health()
+    assert result is None
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# get_credits()
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_credits_returns_dict_on_200(fk_module):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/flow/credits"
+        return httpx.Response(
+            200,
+            json={
+                "credits": 26635,
+                "userPaygateTier": "PAYGATE_TIER_TWO",
+                "sku": "G1_TIER2",
+                "topUpCredits": 2500,
+                "subscriptionCredits": 24135,
+            },
+        )
+
+    async with fk_module.FlowKitClient(transport=_make_transport(handler)) as fk:
+        result = await fk.get_credits()
+    assert result is not None
+    assert result["credits"] == 26635
+    assert result["userPaygateTier"] == "PAYGATE_TIER_TWO"
+
+
+@pytest.mark.asyncio
+async def test_get_credits_returns_none_on_401_no_flow_key(fk_module):
+    """FlowKit returns 401 when extension hasn't yet captured the token."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"detail": "NO_FLOW_KEY"})
+
+    async with fk_module.FlowKitClient(transport=_make_transport(handler)) as fk:
+        result = await fk.get_credits()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_credits_returns_none_on_200_with_detail_envelope(fk_module):
+    """Some FlowKit builds wrap NO_FLOW_KEY as 200 + detail field."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"detail": "NO_FLOW_KEY"})
+
+    async with fk_module.FlowKitClient(transport=_make_transport(handler)) as fk:
+        result = await fk.get_credits()
+    assert result is None
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# is_available()
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_is_available_true_when_health_and_credits_ok(fk_module):
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"extension_connected": True})
+        if request.url.path == "/api/flow/credits":
+            return httpx.Response(
+                200,
+                json={"credits": 26635, "userPaygateTier": "PAYGATE_TIER_TWO"},
+            )
+        return httpx.Response(404)
+
+    async with fk_module.FlowKitClient(transport=_make_transport(handler)) as fk:
+        assert await fk.is_available() is True
+
+
+@pytest.mark.asyncio
+async def test_is_available_false_when_no_flow_key(fk_module):
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"extension_connected": True})
+        if request.url.path == "/api/flow/credits":
+            return httpx.Response(401, json={"detail": "NO_FLOW_KEY"})
+        return httpx.Response(404)
+
+    async with fk_module.FlowKitClient(transport=_make_transport(handler)) as fk:
+        assert await fk.is_available() is False
+
+
+@pytest.mark.asyncio
+async def test_is_available_false_when_extension_disconnected(fk_module):
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"extension_connected": False})
+        return httpx.Response(404)
+
+    async with fk_module.FlowKitClient(transport=_make_transport(handler)) as fk:
+        assert await fk.is_available() is False
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# ensure_project()
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ensure_project_creates_and_caches(fk_module):
+    call_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/projects":
+            call_count["n"] += 1
+            return httpx.Response(
+                201,
+                json={"id": "proj-uuid-abc", "name": "test-project"},
+            )
+        return httpx.Response(404)
+
+    async with fk_module.FlowKitClient(transport=_make_transport(handler)) as fk:
+        pid1 = await fk.ensure_project("test-project")
+        pid2 = await fk.ensure_project("test-project")
+    assert pid1 == "proj-uuid-abc"
+    assert pid2 == "proj-uuid-abc"
+    # Cache should mean only ONE POST.
+    assert call_count["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_project_raises_on_500(fk_module):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="server error")
+
+    async with fk_module.FlowKitClient(transport=_make_transport(handler)) as fk:
+        with pytest.raises(fk_module.FlowKitProjectError):
+            await fk.ensure_project("test")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# generate_image()
+# ─────────────────────────────────────────────────────────────────────────
+
+
+_HAPPY_RESPONSE = {
+    "media": [
+        {
+            "name": "media-uuid",
+            "workflowId": "workflow-uuid",
+            "image": {
+                "generatedImage": {
+                    "seed": 784277,
+                    "mediaGenerationId": "CAMS...",
+                    "mediaId": "644aeb34-1ac2-4509-90c8-652fcb8bfead",
+                    "modelNameType": "GEM_PIX_2",
+                    "fifeUrl": "https://flow-content.google/image/x?Expires=1&Signature=s",
+                    "aspectRatio": "IMAGE_ASPECT_RATIO_PORTRAIT",
+                }
+            },
+            "dimensions": {"width": 768, "height": 1376},
+        }
+    ],
+    "workflows": [],
+}
+
+
+@pytest.mark.asyncio
+async def test_generate_image_happy_path(fk_module):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/flow/generate-image"
+        return httpx.Response(200, json=_HAPPY_RESPONSE)
+
+    async with fk_module.FlowKitClient(transport=_make_transport(handler)) as fk:
+        result = await fk.generate_image(
+            project_id="proj-1",
+            prompt="Editorial photograph of a Bali Zero KITAS",
+            orientation="PORTRAIT",
+        )
+    assert result["media_id"] == "644aeb34-1ac2-4509-90c8-652fcb8bfead"
+    assert result["fife_url"].startswith("https://flow-content.google/")
+    assert result["model"] == "GEM_PIX_2"
+    assert result["width"] == 768
+    assert result["height"] == 1376
+    assert result["seed"] == 784277
+
+
+@pytest.mark.asyncio
+async def test_generate_image_raises_on_5xx(fk_module):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="internal server error")
+
+    async with fk_module.FlowKitClient(transport=_make_transport(handler)) as fk:
+        with pytest.raises(fk_module.FlowKitGenerationError):
+            await fk.generate_image(project_id="p", prompt="x")
+
+
+@pytest.mark.asyncio
+async def test_generate_image_raises_on_detail_envelope(fk_module):
+    """FlowKit sometimes returns 200 + {"detail": "..."} for errors."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"detail": "MODEL_ACCESS_DENIED"},
+        )
+
+    async with fk_module.FlowKitClient(transport=_make_transport(handler)) as fk:
+        with pytest.raises(fk_module.FlowKitGenerationError):
+            await fk.generate_image(project_id="p", prompt="x")
+
+
+@pytest.mark.asyncio
+async def test_generate_image_raises_on_missing_media_id(fk_module):
+    def handler(request: httpx.Request) -> httpx.Response:
+        bad = {
+            "media": [
+                {"image": {"generatedImage": {"fifeUrl": "https://x"}}}
+            ]
+        }
+        return httpx.Response(200, json=bad)
+
+    async with fk_module.FlowKitClient(transport=_make_transport(handler)) as fk:
+        with pytest.raises(fk_module.FlowKitGenerationError):
+            await fk.generate_image(project_id="p", prompt="x")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# download_image()
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_download_image_writes_bytes_to_disk(fk_module, tmp_path):
+    expected = b"\x89PNG\r\n\x1a\n" + b"\x00" * 1024  # PNG header + payload
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert "flow-content" in str(request.url)
+        return httpx.Response(200, content=expected)
+
+    dest = tmp_path / "out" / "image.png"
+    async with fk_module.FlowKitClient(transport=_make_transport(handler)) as fk:
+        path = await fk.download_image(
+            "https://flow-content.google/image/x?Expires=1&Signature=s",
+            dest,
+        )
+    assert path == dest
+    assert dest.exists()
+    assert dest.read_bytes() == expected
+
+
+@pytest.mark.asyncio
+async def test_download_image_raises_on_404(fk_module, tmp_path):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404)
+
+    async with fk_module.FlowKitClient(transport=_make_transport(handler)) as fk:
+        with pytest.raises(fk_module.FlowKitDownloadError):
+            await fk.download_image(
+                "https://flow-content.google/image/x",
+                tmp_path / "x.png",
+            )
+
+
+@pytest.mark.asyncio
+async def test_download_image_raises_on_zero_bytes(fk_module, tmp_path):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"")
+
+    async with fk_module.FlowKitClient(transport=_make_transport(handler)) as fk:
+        with pytest.raises(fk_module.FlowKitDownloadError):
+            await fk.download_image(
+                "https://flow-content.google/image/x",
+                tmp_path / "x.png",
+            )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _parse_image_response — direct unit tests
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_parse_image_response_happy(fk_module):
+    out = fk_module._parse_image_response(_HAPPY_RESPONSE)
+    assert out["media_id"] == "644aeb34-1ac2-4509-90c8-652fcb8bfead"
+    assert out["model"] == "GEM_PIX_2"
+
+
+def test_parse_image_response_raises_on_empty_media(fk_module):
+    with pytest.raises(fk_module.FlowKitGenerationError):
+        fk_module._parse_image_response({"media": []})
+
+
+def test_parse_image_response_raises_on_non_dict(fk_module):
+    with pytest.raises(fk_module.FlowKitGenerationError):
+        fk_module._parse_image_response("not a dict")
+
+
+def test_parse_image_response_raises_on_detail_envelope(fk_module):
+    with pytest.raises(fk_module.FlowKitGenerationError):
+        fk_module._parse_image_response({"detail": "MODEL_ACCESS_DENIED"})
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Context manager guard
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_methods_raise_outside_context_manager(fk_module):
+    fk = fk_module.FlowKitClient()
+    with pytest.raises(fk_module.FlowKitError):
+        await fk.health()

--- a/scripts/tests/test_wr2_image_generator_backend.py
+++ b/scripts/tests/test_wr2_image_generator_backend.py
@@ -1,0 +1,322 @@
+"""Integration tests for the WR2_IMAGE_BACKEND selector in wr2_image_generator.py.
+
+Verifies the dispatch logic between FlowKit and Playwright:
+- backend="auto" + FlowKit available → FlowKit called, Playwright NOT called
+- backend="auto" + FlowKit unavailable → Playwright called as fallback
+- backend="flowkit" + FlowKit unavailable → BackendUnavailableError
+- backend="flowkit" + FlowKit fails per-slide → no Playwright fallback,
+  error returned in tuple
+- backend="playwright" → Playwright called even if FlowKit available
+- _gen_image_with_semaphore returns the standard (slide, url, err) tuple
+  regardless of backend
+
+All HTTP / Playwright / Tigris calls are mocked. No real network, no real
+browser, no real S3 bucket touched.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+GEN_PATH = SCRIPTS_DIR / "wr2_image_generator.py"
+
+
+@pytest.fixture
+def wig(monkeypatch):
+    """Fresh import of wr2_image_generator with isolated module state.
+
+    Stubs out heavy module-level deps (Tigris/Playwright/Ollama) so the
+    module loads without side effects, and resets WR2_IMAGE_BACKEND to a
+    known value so the test controls dispatch.
+    """
+    sys.modules.pop("wr2_image_generator", None)
+    sys.modules.pop("wr2_flowkit_client", None)
+    monkeypatch.setenv("WR2_IMAGE_BACKEND", "auto")
+    monkeypatch.setenv("WR2_IMAGE_VLM_VALIDATION", "false")  # bypass Ollama
+    spec = importlib.util.spec_from_file_location(
+        "wr2_image_generator", GEN_PATH,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["wr2_image_generator"] = mod
+    spec.loader.exec_module(mod)
+    # Patch the upload helper so no S3 traffic happens.
+    mod._upload_to_tigris = MagicMock(
+        return_value="https://nuzantara-warroom-images.fly.storage.tigris.dev/warroom/x/slide-01.png"
+    )
+    return mod
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _gen_image_with_semaphore — backend dispatch
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_backend_auto_uses_flowkit_when_available(wig):
+    """auto + flowkit_available=True → FlowKit called, Playwright NOT called."""
+    import asyncio
+
+    fake_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+
+    # Patch FlowKit byte acquisition to succeed
+    wig._acquire_bytes_via_flowkit = AsyncMock(return_value=(fake_bytes, None))
+    # Patch Playwright path so we can detect if it was called
+    wig._gen_one_image = AsyncMock(return_value=(b"WRONG_SHOULD_NOT_BE_CALLED", None))
+    wig._gen_one_image_raw = AsyncMock(return_value=(b"WRONG", None))
+
+    sem = asyncio.Semaphore(1)
+    result = await wig._gen_image_with_semaphore(
+        sem,
+        context=MagicMock(),  # would be a Playwright context
+        slide_number=1,
+        image_prompt="A test prompt",
+        draft_id="abcd-1234",
+        backend="auto",
+        flowkit_available=True,
+    )
+    slide_number, url, err = result
+    assert slide_number == 1
+    assert url is not None
+    assert err is None
+    wig._acquire_bytes_via_flowkit.assert_awaited_once()
+    wig._gen_one_image.assert_not_awaited()
+    wig._gen_one_image_raw.assert_not_awaited()
+    wig._upload_to_tigris.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_backend_auto_falls_back_to_playwright_when_flowkit_unavailable(wig):
+    """auto + flowkit_available=False → only Playwright called."""
+    import asyncio
+
+    fake_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+
+    wig._acquire_bytes_via_flowkit = AsyncMock(
+        return_value=(None, "should not be called"),
+    )
+    wig._gen_one_image = AsyncMock(return_value=(fake_bytes, None))
+    wig._gen_one_image_raw = AsyncMock(return_value=(b"WRONG", None))
+
+    sem = asyncio.Semaphore(1)
+    result = await wig._gen_image_with_semaphore(
+        sem,
+        context=MagicMock(),
+        slide_number=2,
+        image_prompt="A test prompt",
+        draft_id="abcd-1234",
+        backend="auto",
+        flowkit_available=False,
+    )
+    slide_number, url, err = result
+    assert slide_number == 2
+    assert url is not None
+    assert err is None
+    wig._acquire_bytes_via_flowkit.assert_not_awaited()
+    wig._gen_one_image.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_backend_auto_falls_back_when_flowkit_fails_at_runtime(wig):
+    """auto + FlowKit returns error → Playwright is invoked as fallback."""
+    import asyncio
+
+    fake_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+
+    wig._acquire_bytes_via_flowkit = AsyncMock(
+        return_value=(None, "flowkit unhandled error: connection refused"),
+    )
+    wig._gen_one_image = AsyncMock(return_value=(fake_bytes, None))
+    wig._gen_one_image_raw = AsyncMock(return_value=(b"WRONG", None))
+
+    sem = asyncio.Semaphore(1)
+    result = await wig._gen_image_with_semaphore(
+        sem,
+        context=MagicMock(),
+        slide_number=3,
+        image_prompt="A test prompt",
+        draft_id="abcd-1234",
+        backend="auto",
+        flowkit_available=True,
+    )
+    slide_number, url, err = result
+    assert slide_number == 3
+    assert url is not None
+    assert err is None
+    wig._acquire_bytes_via_flowkit.assert_awaited_once()
+    wig._gen_one_image.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_backend_flowkit_returns_error_when_flowkit_fails(wig):
+    """backend=flowkit + FlowKit fails → error tuple, NO Playwright fallback."""
+    import asyncio
+
+    wig._acquire_bytes_via_flowkit = AsyncMock(
+        return_value=(None, "flowkit generation error: MODEL_ACCESS_DENIED"),
+    )
+    wig._gen_one_image = AsyncMock(return_value=(b"WRONG", None))
+    wig._gen_one_image_raw = AsyncMock(return_value=(b"WRONG", None))
+
+    sem = asyncio.Semaphore(1)
+    result = await wig._gen_image_with_semaphore(
+        sem,
+        context=None,  # flowkit-only never gets a Playwright context
+        slide_number=4,
+        image_prompt="A test prompt",
+        draft_id="abcd-1234",
+        backend="flowkit",
+        flowkit_available=True,
+    )
+    slide_number, url, err = result
+    assert slide_number == 4
+    assert url is None
+    assert err is not None
+    assert "MODEL_ACCESS_DENIED" in err
+    wig._acquire_bytes_via_flowkit.assert_awaited_once()
+    wig._gen_one_image.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_backend_playwright_skips_flowkit_even_if_available(wig):
+    """backend=playwright → never call FlowKit, even if flowkit_available."""
+    import asyncio
+
+    fake_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+
+    wig._acquire_bytes_via_flowkit = AsyncMock(return_value=(b"WRONG", None))
+    wig._gen_one_image = AsyncMock(return_value=(fake_bytes, None))
+
+    sem = asyncio.Semaphore(1)
+    result = await wig._gen_image_with_semaphore(
+        sem,
+        context=MagicMock(),
+        slide_number=5,
+        image_prompt="A test prompt",
+        draft_id="abcd-1234",
+        backend="playwright",
+        flowkit_available=True,  # ignored
+    )
+    slide_number, url, err = result
+    assert slide_number == 5
+    assert url is not None
+    assert err is None
+    wig._acquire_bytes_via_flowkit.assert_not_awaited()
+    wig._gen_one_image.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_flowkit_only_with_no_context_does_not_crash(wig):
+    """flowkit-only path doesn't dereference the None Playwright context."""
+    import asyncio
+
+    fake_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+    wig._acquire_bytes_via_flowkit = AsyncMock(return_value=(fake_bytes, None))
+
+    sem = asyncio.Semaphore(1)
+    result = await wig._gen_image_with_semaphore(
+        sem,
+        context=None,
+        slide_number=6,
+        image_prompt="A test prompt",
+        draft_id="abcd-1234",
+        backend="flowkit",
+        flowkit_available=True,
+    )
+    slide_number, url, err = result
+    assert slide_number == 6
+    assert url is not None
+    assert err is None
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _upload_and_return — shared upload helper
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_upload_and_return_returns_canonical_tuple(wig):
+    """_upload_and_return → (slide_number, https URL, None) on success."""
+    img_bytes = b"\x89PNG" + b"\x00" * 50
+    result = await wig._upload_and_return(img_bytes, 7, "draft-abc")
+    slide_number, url, err = result
+    assert slide_number == 7
+    assert err is None
+    assert url is not None and url.startswith("https://")
+    wig._upload_to_tigris.assert_called_once()
+    # Verify the key path matches the standard warroom/<draft>/slide-NN-TS.png
+    call_args = wig._upload_to_tigris.call_args
+    assert call_args[0][0] == img_bytes  # bytes argument
+    key = call_args[0][1]
+    assert key.startswith("warroom/draft-abc/slide-07-")
+    assert key.endswith(".png")
+    assert call_args[0][2] == "image/png"
+
+
+@pytest.mark.asyncio
+async def test_upload_and_return_surfaces_tigris_failure(wig):
+    """_upload_and_return → (slide, None, error_msg) on Tigris exception."""
+    wig._upload_to_tigris = MagicMock(side_effect=RuntimeError("S3 5xx"))
+    result = await wig._upload_and_return(b"x", 8, "draft-fail")
+    slide_number, url, err = result
+    assert slide_number == 8
+    assert url is None
+    assert err is not None
+    assert "tigris upload failed" in err
+    assert "S3 5xx" in err
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _probe_flowkit_available — backend-availability probe
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_false_when_flowkit_unreachable(wig, monkeypatch):
+    """_probe_flowkit_available → False when FlowKit server is down."""
+    # Point at a port nothing listens on
+    monkeypatch.setattr(wig, "FLOWKIT_BASE_URL", "http://127.0.0.1:1")
+    monkeypatch.setattr(wig, "FLOWKIT_TIMEOUT_S", 1.0)
+    result = await wig._probe_flowkit_available()
+    assert result is False
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Env var contract — module-level constants reflect WR2_IMAGE_BACKEND
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_default_backend_is_auto(monkeypatch):
+    """When WR2_IMAGE_BACKEND is unset, IMAGE_BACKEND defaults to 'auto'."""
+    monkeypatch.delenv("WR2_IMAGE_BACKEND", raising=False)
+    sys.modules.pop("wr2_image_generator", None)
+    spec = importlib.util.spec_from_file_location(
+        "wr2_image_generator", GEN_PATH,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["wr2_image_generator"] = mod
+    spec.loader.exec_module(mod)
+    assert mod.IMAGE_BACKEND == "auto"
+
+
+def test_backend_lowercased(monkeypatch):
+    """WR2_IMAGE_BACKEND='Flowkit' is normalized to 'flowkit'."""
+    monkeypatch.setenv("WR2_IMAGE_BACKEND", "FLOWKIT")
+    sys.modules.pop("wr2_image_generator", None)
+    spec = importlib.util.spec_from_file_location(
+        "wr2_image_generator", GEN_PATH,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["wr2_image_generator"] = mod
+    spec.loader.exec_module(mod)
+    assert mod.IMAGE_BACKEND == "flowkit"
+
+
+def test_backend_unavailable_error_is_runtime_error(wig):
+    """BackendUnavailableError extends RuntimeError so existing exception
+    handlers in cron wrappers don't need updating."""
+    assert issubclass(wig.BackendUnavailableError, RuntimeError)

--- a/scripts/wr2_flowkit_client.py
+++ b/scripts/wr2_flowkit_client.py
@@ -1,0 +1,440 @@
+"""WR2 FlowKit client — async HTTP wrapper around the FlowKit local agent.
+
+FlowKit is a Python+Chrome-extension bridge that proxies image/video gen
+calls through the user's logged-in `labs.google/fx/tools/flow` session. The
+local agent serves on `http://127.0.0.1:8100` by default.
+
+Empirically verified 2026-05-03 on Antonello's Ultra account:
+- `GEM_PIX_2` (Nano Banana Pro) image generation is FREE for AI Ultra
+  (`PAYGATE_TIER_TWO`) — 0 credit consumed across two consecutive images.
+- Latency ~5-15s per image (vs ~30-90s through the WR2 Playwright path).
+
+This module provides a thin, fail-soft client for use as a SECONDARY
+backend in `scripts/wr2_image_generator.py`. When FlowKit is offline
+(extension not loaded, server not running, token not captured) every
+method that returns an `Optional` returns `None` so the caller can fall
+back to the existing Playwright path.
+
+Reference skill: ~/.claude/skills/nuzantara-flowkit-flow-generation.md
+Reference memory: discovery_flowkit_poc_test_2026_05_03.md
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from types import TracebackType
+from typing import Any, Literal
+
+import httpx
+
+logger = logging.getLogger("wr2.flowkit_client")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Exceptions
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class FlowKitError(Exception):
+    """Base exception for FlowKit client errors."""
+
+
+class FlowKitGenerationError(FlowKitError):
+    """Raised when /api/flow/generate-image returns non-2xx or malformed payload."""
+
+
+class FlowKitDownloadError(FlowKitError):
+    """Raised when fetching the signed CDN URL fails or yields zero bytes."""
+
+
+class FlowKitProjectError(FlowKitError):
+    """Raised when /api/projects fails to create or return a usable project_id."""
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Client
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class FlowKitClient:
+    """Async HTTP client for the FlowKit local agent.
+
+    Use as an async context manager so the underlying httpx.AsyncClient is
+    created in `__aenter__` and closed in `__aexit__` (Golden Rule #10 —
+    persistent client, never instantiated inside methods/loops).
+
+    Example:
+        async with FlowKitClient() as fk:
+            if not await fk.is_available():
+                return None  # caller falls back
+            project_id = await fk.ensure_project("wr2-spt-2026-05")
+            result = await fk.generate_image(
+                project_id=project_id,
+                prompt="Editorial photograph of ...",
+                orientation="PORTRAIT",
+            )
+            await fk.download_image(result["fife_url"], dest_path)
+    """
+
+    def __init__(
+        self,
+        base_url: str = "http://127.0.0.1:8100",
+        timeout_s: float = 30.0,
+        *,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._timeout_s = float(timeout_s)
+        # `transport` lets tests inject httpx.MockTransport without monkeypatching.
+        self._transport = transport
+        self._client: httpx.AsyncClient | None = None
+        # Cache the last project_id created via ensure_project(), keyed by
+        # (name, material, language). Cheap O(1) avoids unnecessary POSTs
+        # when generating multiple images in the same project.
+        self._project_cache: dict[tuple[str, str, str], str] = {}
+
+    # ── Context manager ──────────────────────────────────────────────────
+
+    async def __aenter__(self) -> "FlowKitClient":
+        self._client = httpx.AsyncClient(
+            base_url=self._base_url,
+            timeout=self._timeout_s,
+            transport=self._transport,
+        )
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    # ── Internals ────────────────────────────────────────────────────────
+
+    def _require_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            raise FlowKitError(
+                "FlowKitClient must be used as an async context manager",
+            )
+        return self._client
+
+    # ── Public API ───────────────────────────────────────────────────────
+
+    async def health(self) -> dict[str, Any] | None:
+        """GET /health — return the dict only if `extension_connected` is True.
+
+        Returns:
+            The full health JSON dict if the FlowKit server is up AND the
+            Chrome extension is connected. None on any failure (server down,
+            timeout, extension disconnected) so the caller can fall back.
+        """
+        client = self._require_client()
+        try:
+            resp = await client.get("/health")
+        except (httpx.HTTPError, OSError) as e:
+            logger.debug("FlowKit /health unreachable: %s", e)
+            return None
+        if resp.status_code != 200:
+            logger.debug("FlowKit /health status=%d", resp.status_code)
+            return None
+        try:
+            data = resp.json()
+        except ValueError:
+            logger.debug("FlowKit /health returned non-JSON")
+            return None
+        if not isinstance(data, dict):
+            return None
+        if not data.get("extension_connected"):
+            logger.info("FlowKit extension not connected — falling back")
+            return None
+        return data
+
+    async def get_credits(self) -> dict[str, Any] | None:
+        """GET /api/flow/credits — return credits dict, or None on NO_FLOW_KEY.
+
+        FlowKit returns `{"detail":"NO_FLOW_KEY"}` (with HTTP 401 or 200
+        depending on version) when the bearer token has not yet been captured
+        by the extension. We treat any failure as "fall back to Playwright"
+        rather than raising.
+
+        Returns:
+            Dict with at minimum `credits`, `subscriptionCredits`,
+            `topUpCredits`, `userPaygateTier`. None on any failure.
+        """
+        client = self._require_client()
+        try:
+            resp = await client.get("/api/flow/credits")
+        except (httpx.HTTPError, OSError) as e:
+            logger.debug("FlowKit /api/flow/credits unreachable: %s", e)
+            return None
+        if resp.status_code != 200:
+            # 401, 5xx, etc. — most commonly NO_FLOW_KEY surfaced as 401.
+            logger.info(
+                "FlowKit /api/flow/credits status=%d (likely token not captured)",
+                resp.status_code,
+            )
+            return None
+        try:
+            data = resp.json()
+        except ValueError:
+            logger.debug("FlowKit /api/flow/credits returned non-JSON")
+            return None
+        if not isinstance(data, dict):
+            return None
+        # Some FlowKit builds return 200 with a `detail` error envelope.
+        detail = data.get("detail")
+        if detail == "NO_FLOW_KEY":
+            logger.info(
+                "FlowKit token not captured (NO_FLOW_KEY) — falling back",
+            )
+            return None
+        if "credits" not in data:
+            logger.debug("FlowKit credits payload missing `credits` field: %r", data)
+            return None
+        return data
+
+    async def is_available(self) -> bool:
+        """Convenience: True iff health() AND get_credits() both succeed.
+
+        Use this as the single gate before attempting generation. Avoids
+        wasting time POSTing a generation request that will fail with
+        NO_FLOW_KEY or extension-disconnected.
+        """
+        health = await self.health()
+        if health is None:
+            return False
+        credits = await self.get_credits()
+        if credits is None:
+            return False
+        return True
+
+    async def ensure_project(
+        self,
+        name: str,
+        material: str = "realistic",
+        language: str = "en",
+    ) -> str:
+        """Create-or-return a FlowKit project_id for the given (name, material, language).
+
+        FlowKit projects are namespaced containers for generation calls. The
+        `material` field selects a built-in style preset (see skill doc:
+        `realistic` is the default for editorial photo aesthetic). For
+        Bali Zero WR2 hero slides we always want `realistic`.
+
+        Cached in-process so generating N hero slides for the same dispatch
+        doesn't POST N projects.
+
+        Raises:
+            FlowKitProjectError: on non-2xx response or missing `id` field.
+        """
+        client = self._require_client()
+        cache_key = (name, material, language)
+        cached = self._project_cache.get(cache_key)
+        if cached:
+            return cached
+        body = {"name": name, "material": material, "language": language}
+        try:
+            resp = await client.post("/api/projects", json=body)
+        except httpx.HTTPError as e:
+            raise FlowKitProjectError(
+                f"FlowKit /api/projects unreachable: {e}",
+            ) from e
+        if resp.status_code not in (200, 201):
+            raise FlowKitProjectError(
+                f"FlowKit /api/projects status={resp.status_code} body={resp.text[:200]}",
+            )
+        try:
+            data = resp.json()
+        except ValueError as e:
+            raise FlowKitProjectError(
+                f"FlowKit /api/projects returned non-JSON: {e}",
+            ) from e
+        # FlowKit response shape varies slightly by version; accept either
+        # `id` or `project_id` at top level, or nested under `project`.
+        project_id = (
+            data.get("id")
+            or data.get("project_id")
+            or (data.get("project") or {}).get("id")
+        )
+        if not project_id or not isinstance(project_id, str):
+            raise FlowKitProjectError(
+                f"FlowKit /api/projects response missing project id: {data!r}",
+            )
+        self._project_cache[cache_key] = project_id
+        return project_id
+
+    async def generate_image(
+        self,
+        *,
+        project_id: str,
+        prompt: str,
+        orientation: Literal["PORTRAIT", "LANDSCAPE"] = "PORTRAIT",
+    ) -> dict[str, Any]:
+        """POST /api/flow/generate-image — return parsed media metadata.
+
+        Args:
+            project_id: from ensure_project().
+            prompt: full prompt text. Brand/anti-cliche modifiers should be
+                applied by the caller — this client is intentionally
+                modifier-unaware so it stays reusable for other Bali Zero
+                surfaces (dispatch, marketing, etc.).
+            orientation: PORTRAIT (4:5 / 9:16) or LANDSCAPE (16:9).
+
+        Returns:
+            Dict with keys:
+                - media_id (str, UUID)
+                - fife_url (str, signed CDN URL ~30 min TTL)
+                - model (str, e.g. "GEM_PIX_2")
+                - width, height (int)
+                - seed (int)
+
+        Raises:
+            FlowKitGenerationError: on 4xx/5xx, malformed response, or
+                missing required fields. Caller should catch and decide
+                whether to retry or fall back.
+        """
+        client = self._require_client()
+        body = {
+            "project_id": project_id,
+            "prompt": prompt,
+            "orientation": orientation,
+            "characters": [],
+        }
+        try:
+            resp = await client.post("/api/flow/generate-image", json=body)
+        except httpx.HTTPError as e:
+            raise FlowKitGenerationError(
+                f"FlowKit /api/flow/generate-image unreachable: {e}",
+            ) from e
+        if resp.status_code != 200:
+            raise FlowKitGenerationError(
+                f"FlowKit generate-image status={resp.status_code} "
+                f"body={resp.text[:300]}",
+            )
+        try:
+            data = resp.json()
+        except ValueError as e:
+            raise FlowKitGenerationError(
+                f"FlowKit generate-image returned non-JSON: {e}",
+            ) from e
+        return _parse_image_response(data)
+
+    async def download_image(
+        self,
+        fife_url: str,
+        dest_path: Path,
+    ) -> Path:
+        """Async download a signed CDN URL to `dest_path`.
+
+        Uses the same persistent httpx client (the CDN endpoint is on a
+        different host but httpx handles the redirect/host swap fine).
+
+        Raises:
+            FlowKitDownloadError: on non-2xx response or zero-byte payload.
+        """
+        client = self._require_client()
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            # `follow_redirects=True` is required because the signed CDN URL
+            # sometimes 302s through a Google-internal hop before serving.
+            resp = await client.get(fife_url, follow_redirects=True)
+        except httpx.HTTPError as e:
+            raise FlowKitDownloadError(
+                f"FlowKit CDN download unreachable: {e}",
+            ) from e
+        if resp.status_code != 200:
+            raise FlowKitDownloadError(
+                f"FlowKit CDN download status={resp.status_code}",
+            )
+        content = resp.content
+        if not content:
+            raise FlowKitDownloadError(
+                "FlowKit CDN download returned zero bytes",
+            )
+        dest_path.write_bytes(content)
+        # Defensive: write_bytes can succeed but produce empty file if
+        # `content` was unexpectedly empty (already checked) or disk full.
+        if dest_path.stat().st_size == 0:
+            raise FlowKitDownloadError(
+                f"FlowKit CDN download produced empty file at {dest_path}",
+            )
+        return dest_path
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Response parser (separate function for unit-testability)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _parse_image_response(data: Any) -> dict[str, Any]:
+    """Extract the canonical fields from a FlowKit generate-image response.
+
+    The empirically-verified shape (see skill doc) is:
+
+        {
+          "media": [{
+            "image": {
+              "generatedImage": {
+                "mediaId": "<uuid>",
+                "fifeUrl": "https://flow-content.google/image/<id>?...",
+                "modelNameType": "GEM_PIX_2",
+                "seed": 784277,
+                ...
+              }
+            },
+            "dimensions": {"width": 768, "height": 1376}
+          }],
+          ...
+        }
+
+    Raises FlowKitGenerationError if the shape is unexpected or required
+    fields are missing.
+    """
+    if not isinstance(data, dict):
+        raise FlowKitGenerationError(
+            f"generate-image response is not a dict: {type(data).__name__}",
+        )
+    media = data.get("media")
+    if not isinstance(media, list) or not media:
+        # Some FlowKit builds wrap errors as `{"detail": "..."}` with HTTP 200.
+        detail = data.get("detail")
+        if detail:
+            raise FlowKitGenerationError(
+                f"generate-image error detail={detail!r}",
+            )
+        raise FlowKitGenerationError(
+            f"generate-image response has no `media` array: {data!r}",
+        )
+    first = media[0]
+    if not isinstance(first, dict):
+        raise FlowKitGenerationError(
+            "generate-image media[0] is not a dict",
+        )
+    image_obj = (first.get("image") or {}).get("generatedImage") or {}
+    media_id = image_obj.get("mediaId")
+    fife_url = image_obj.get("fifeUrl")
+    model = image_obj.get("modelNameType", "")
+    seed = image_obj.get("seed", 0)
+    dimensions = first.get("dimensions") or {}
+    width = dimensions.get("width", 0)
+    height = dimensions.get("height", 0)
+    if not media_id or not isinstance(media_id, str):
+        raise FlowKitGenerationError(
+            f"generate-image response missing mediaId: {image_obj!r}",
+        )
+    if not fife_url or not isinstance(fife_url, str):
+        raise FlowKitGenerationError(
+            f"generate-image response missing fifeUrl: {image_obj!r}",
+        )
+    return {
+        "media_id": media_id,
+        "fife_url": fife_url,
+        "model": str(model),
+        "width": int(width or 0),
+        "height": int(height or 0),
+        "seed": int(seed or 0),
+    }

--- a/scripts/wr2_image_generator.py
+++ b/scripts/wr2_image_generator.py
@@ -77,6 +77,36 @@ TIGRIS_BUCKET = "nuzantara-warroom-images"
 TIGRIS_PUBLIC_BASE = f"https://{TIGRIS_BUCKET}.fly.storage.tigris.dev"
 
 # ─────────────────────────────────────────────────────────────────────────
+# Backend selection (Sprint 1.6 W3 — FlowKit secondary backend)
+# ─────────────────────────────────────────────────────────────────────────
+# WR2_IMAGE_BACKEND chooses the image-generation path:
+#   "auto"        — try FlowKit first if available, else Playwright (DEFAULT)
+#   "flowkit"     — FlowKit only; raise BackendUnavailableError if down
+#   "playwright"  — Playwright only (legacy / opt-out path)
+#
+# FlowKit is the empirically-faster path (5-15s/image vs 30-90s for
+# Playwright on the same Nano Banana Pro model, GEM_PIX_2 — verified
+# 2026-05-03 on Antonello's Ultra account, FREE for PAYGATE_TIER_TWO).
+# It requires the FlowKit local agent at http://127.0.0.1:8100 + Chrome
+# extension loaded + bearer token captured. When any of those is missing
+# we silently fall back to the existing Playwright path so the cron stays
+# resilient.
+IMAGE_BACKEND = os.environ.get("WR2_IMAGE_BACKEND", "auto").lower()
+FLOWKIT_BASE_URL = os.environ.get("WR2_FLOWKIT_BASE_URL", "http://127.0.0.1:8100")
+FLOWKIT_TIMEOUT_S = float(os.environ.get("WR2_FLOWKIT_TIMEOUT_S", "60"))
+FLOWKIT_MATERIAL = os.environ.get("WR2_FLOWKIT_MATERIAL", "realistic")
+FLOWKIT_LANGUAGE = os.environ.get("WR2_FLOWKIT_LANGUAGE", "en")
+
+
+class BackendUnavailableError(RuntimeError):
+    """Raised when the requested image backend cannot be used.
+
+    Only fires when WR2_IMAGE_BACKEND is pinned to a specific backend
+    (e.g. `flowkit`) and that backend is unavailable. In `auto` mode we
+    fall back silently rather than raising.
+    """
+
+# ─────────────────────────────────────────────────────────────────────────
 # VLM validation (CLIP-style prompt-image alignment via local Ollama Qwen2.5VL)
 # ─────────────────────────────────────────────────────────────────────────
 # Empirical bug observed 2026-04-25 on draft 0e8e1cf5: 2/4 hero images came
@@ -468,23 +498,212 @@ def _build_prompt_variants(image_prompt: str) -> list[str]:
     return [full, v2, v3]
 
 
+async def _probe_flowkit_available() -> bool:
+    """Single-shot probe for FlowKit availability.
+
+    Imports the client lazily (so Playwright-only deployments don't pull
+    httpx churn at module load) and runs `is_available()` once. Logs the
+    outcome at INFO level so the operator sees which backend handled the
+    draft without trawling per-slide logs.
+    """
+    try:
+        # Lazy import — see _acquire_bytes_via_flowkit for path setup.
+        import sys
+        from pathlib import Path as _P
+        sys.path.insert(0, str(_P(__file__).resolve().parent))
+        from wr2_flowkit_client import FlowKitClient  # noqa: E402
+    except ImportError as e:
+        logger.warning("FlowKit client import failed: %s", e)
+        return False
+    try:
+        async with FlowKitClient(
+            base_url=FLOWKIT_BASE_URL,
+            timeout_s=FLOWKIT_TIMEOUT_S,
+        ) as fk:
+            return await fk.is_available()
+    except Exception as e:  # noqa: BLE001
+        logger.info("FlowKit probe raised %s — treating as unavailable", e)
+        return False
+
+
+async def _upload_and_return(
+    img_bytes: bytes,
+    slide_number: int,
+    draft_id: str,
+) -> tuple[int, str | None, str | None]:
+    """Upload image bytes to Tigris and return the standard tuple.
+
+    Shared by both FlowKit and Playwright backends — single source of truth
+    for the (slide_number, image_url, error) contract that
+    `_gen_image_with_semaphore` returns.
+    """
+    logger.info("[slide %d] uploading to Tigris", slide_number)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    key = f"warroom/{draft_id}/slide-{slide_number:02d}-{ts}.png"
+    try:
+        url = _upload_to_tigris(img_bytes, key, "image/png")
+    except Exception as e:
+        return slide_number, None, f"tigris upload failed: {e}"
+    logger.info("[slide %d] uploaded → %s", slide_number, url)
+    return slide_number, url, None
+
+
+async def _acquire_bytes_via_flowkit(
+    slide_number: int,
+    image_prompt: str,
+    draft_id: str,
+) -> tuple[bytes | None, str | None]:
+    """Generate one hero image via FlowKit (Nano Banana Pro / GEM_PIX_2).
+
+    Returns (bytes, None) on success or (None, error_msg) on failure. Uses
+    the brand+anti-cliche-wrapped prompt (`_compose_final_prompt`) so the
+    visual constraints encoded in the draft generator's SYSTEM_INSTRUCTIONS
+    still reach the model.
+
+    Caller is responsible for VLM alignment validation, Tigris upload, and
+    retry policy — this helper is a single-shot byte producer matching the
+    contract of `_gen_one_image`.
+    """
+    # Local import keeps Playwright-only code paths free of httpx churn at
+    # import time, and keeps the FlowKit dependency optional for Air boxes
+    # that haven't been set up.
+    import sys
+    from pathlib import Path as _P
+    sys.path.insert(0, str(_P(__file__).resolve().parent))
+    from wr2_flowkit_client import (  # noqa: E402
+        FlowKitClient,
+        FlowKitDownloadError,
+        FlowKitGenerationError,
+        FlowKitProjectError,
+    )
+
+    final_prompt = _compose_final_prompt(image_prompt)
+    project_name = f"wr2-{draft_id[:8]}"
+    tmp_path = Path("/tmp") / f"wr2-flowkit-{draft_id}-slide-{slide_number:02d}.png"
+    try:
+        async with FlowKitClient(
+            base_url=FLOWKIT_BASE_URL,
+            timeout_s=FLOWKIT_TIMEOUT_S,
+        ) as fk:
+            project_id = await fk.ensure_project(
+                project_name,
+                material=FLOWKIT_MATERIAL,
+                language=FLOWKIT_LANGUAGE,
+            )
+            result = await fk.generate_image(
+                project_id=project_id,
+                prompt=final_prompt,
+                orientation="PORTRAIT",
+            )
+            await fk.download_image(result["fife_url"], tmp_path)
+    except FlowKitProjectError as e:
+        return None, f"flowkit project error: {e}"
+    except FlowKitGenerationError as e:
+        return None, f"flowkit generation error: {e}"
+    except FlowKitDownloadError as e:
+        return None, f"flowkit download error: {e}"
+    except Exception as e:  # noqa: BLE001 — defensive, network is unpredictable
+        return None, f"flowkit unhandled error: {e}"
+    try:
+        img_bytes = tmp_path.read_bytes()
+    except OSError as e:
+        return None, f"flowkit local read failed: {e}"
+    finally:
+        # Clean up the temp file even on success — Tigris upload happens
+        # from in-memory bytes, no need to keep the local copy around.
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+    if not img_bytes:
+        return None, "flowkit returned zero bytes"
+    return img_bytes, None
+
+
 async def _gen_image_with_semaphore(
     sem: asyncio.Semaphore,
     context: Any,
     slide_number: int,
     image_prompt: str,
     draft_id: str,
+    *,
+    backend: str = "auto",
+    flowkit_available: bool = False,
 ) -> tuple[int, str | None, str | None]:
     """Generate + upload one hero image. Returns (slide_number, url, error).
 
-    Retries up to MAX_RETRIES_PER_SLIDE times on failure (Gemini UI flakiness
-    is intermittent — page sometimes stalls while loading or the send button
-    vanishes briefly; a fresh tab usually succeeds). After exhausting retries
-    on the primary prompt, falls back to progressively stripped prompt
-    variants (see _build_prompt_variants) — this recovers from silent safety
-    refusals that ignore a fraction of phrasings.
+    Backend selection (Sprint 1.6 W3):
+      - `backend="flowkit"` — FlowKit only. Falls through to error if the
+        first attempt raises (no Playwright fallback in this mode).
+      - `backend="playwright"` — Playwright only (legacy behavior).
+      - `backend="auto"` — try FlowKit first when `flowkit_available=True`
+        (caller has pre-checked `is_available()` to avoid repeated probing
+        per slide). On any failure, fall back to Playwright retry/variant
+        loop. This is the DEFAULT.
+
+    Retries up to MAX_RETRIES_PER_SLIDE times on Playwright failure (Gemini
+    UI flakiness is intermittent — page sometimes stalls while loading or
+    the send button vanishes briefly; a fresh tab usually succeeds). After
+    exhausting retries on the primary prompt, falls back to progressively
+    stripped prompt variants (see _build_prompt_variants) — this recovers
+    from silent safety refusals that ignore a fraction of phrasings.
     """
     async with sem:
+        # ── FlowKit fast path ───────────────────────────────────────────
+        if backend in ("auto", "flowkit") and flowkit_available:
+            logger.info(
+                "[slide %d] generating via FlowKit (Nano Banana Pro)",
+                slide_number,
+            )
+            t0 = time.time()
+            fk_bytes, fk_err = await _acquire_bytes_via_flowkit(
+                slide_number, image_prompt, draft_id,
+            )
+            dt = time.time() - t0
+            if fk_bytes:
+                logger.info(
+                    "[slide %d] FlowKit ok (%.1fs, %d bytes)",
+                    slide_number, dt, len(fk_bytes),
+                )
+                # VLM alignment guard applies to ALL backends — FlowKit can
+                # also produce off-prompt outputs and the WR2 brand bar is
+                # the same regardless of producer.
+                score, why = await _score_image_alignment(
+                    fk_bytes, image_prompt, slide_number,
+                )
+                if score >= VLM_MIN_SCORE:
+                    return await _upload_and_return(
+                        fk_bytes, slide_number, draft_id,
+                    )
+                logger.warning(
+                    "[slide %d] FlowKit image rejected (score=%.2f < %.2f): %s",
+                    slide_number, score, VLM_MIN_SCORE, why,
+                )
+                if backend == "flowkit":
+                    return slide_number, None, (
+                        f"flowkit VLM rejected (score={score:.2f}): {why}"
+                    )
+                # else: fall through to Playwright path
+            else:
+                logger.warning(
+                    "[slide %d] FlowKit failed after %.1fs: %s",
+                    slide_number, dt, fk_err,
+                )
+                if backend == "flowkit":
+                    return slide_number, None, fk_err or "flowkit unknown error"
+                # backend=auto: drop into Playwright retry loop below.
+
+        # ── Playwright path (legacy + auto-fallback) ────────────────────
+        if backend == "flowkit":
+            # Should not reach here — flowkit-only never enters Playwright.
+            return slide_number, None, "WR2_IMAGE_BACKEND=flowkit but FlowKit not available"
+        if context is None:
+            # backend=auto + flowkit unavailable + no Playwright context
+            # provided → caller must have skipped browser launch. Surface
+            # a clear error so the run aborts rather than silently failing.
+            return slide_number, None, (
+                "no Playwright context available and FlowKit unreachable"
+            )
         last_err: str | None = None
         img_bytes: bytes | None = None
         prompt_variants = _build_prompt_variants(image_prompt)
@@ -558,15 +777,7 @@ async def _gen_image_with_semaphore(
             logger.error("[slide %d] all variants+attempts failed, last err=%s", slide_number, last_err)
             return slide_number, None, last_err or "all retries failed"
 
-        logger.info("[slide %d] uploading to Tigris", slide_number)
-        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-        key = f"warroom/{draft_id}/slide-{slide_number:02d}-{ts}.png"
-        try:
-            url = _upload_to_tigris(img_bytes, key, "image/png")
-        except Exception as e:
-            return slide_number, None, f"tigris upload failed: {e}"
-        logger.info("[slide %d] uploaded → %s", slide_number, url)
-        return slide_number, url, None
+        return await _upload_and_return(img_bytes, slide_number, draft_id)
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -670,41 +881,80 @@ async def _process_one(
             )
         return True
 
-    # Launch Playwright with the gemini profile
-    from playwright.async_api import async_playwright
+    # ── Backend selection (Sprint 1.6 W3) ─────────────────────────────────
+    # Probe FlowKit ONCE per draft (not per slide) to decide whether to
+    # launch Playwright at all. In flowkit-only mode we skip Playwright
+    # entirely; in auto mode we still launch Playwright as fallback even
+    # if FlowKit is currently up — the cron is long-running and FlowKit's
+    # bearer token can expire mid-draft (45 min refresh window).
+    flowkit_available = False
+    if IMAGE_BACKEND in ("auto", "flowkit"):
+        flowkit_available = await _probe_flowkit_available()
+        if not flowkit_available and IMAGE_BACKEND == "flowkit":
+            err = "WR2_IMAGE_BACKEND=flowkit but FlowKit is not available"
+            logger.error(err)
+            raise BackendUnavailableError(err)
+        if flowkit_available:
+            logger.info(
+                "FlowKit available — using as primary backend (PAYGATE_TIER_TWO)"
+            )
+        else:
+            logger.info(
+                "FlowKit unavailable — using Playwright backend"
+            )
 
     results: list[Any] = []
-    # Strictly serial: fresh browser context per slide, one tab at a time.
-    # Empirical (Apr 25-26 2026, Ultra plan): parallel tabs on the persistent
-    # Gemini profile silently degrade output (returns stock-style content
-    # unrelated to the prompt). Hero images are too important to speculate on.
-    # The old shared-context branch (WR2_IMAGE_ISOLATE_BROWSER=false) is
-    # removed; ISOLATE_PER_SLIDE is now a no-op kept for backwards-compat.
-    logger.info("Serial mode — one fresh browser context per hero slide")
-    async with async_playwright() as p:
+
+    if IMAGE_BACKEND == "flowkit":
+        # FlowKit-only path: no Playwright launch at all.
+        sem = asyncio.Semaphore(1)
         for idx, s in enumerate(hero_slides):
-            context = await p.chromium.launch_persistent_context(
-                user_data_dir=str(GEMINI_PROFILE_DIR),
-                headless=True,
-                viewport={"width": 1440, "height": 900},
-                args=["--disable-blink-features=AutomationControlled"],
+            r = await _gen_image_with_semaphore(
+                sem,
+                None,  # no Playwright context
+                s["slide_number"],
+                s.get("image_prompt") or "",
+                str(draft_id),
+                backend="flowkit",
+                flowkit_available=True,
             )
-            try:
-                sem = asyncio.Semaphore(1)
-                r = await _gen_image_with_semaphore(
-                    sem,
-                    context,
-                    s["slide_number"],
-                    s.get("image_prompt") or "",
-                    str(draft_id),
-                )
-                results.append(r)
-            finally:
-                await context.close()
-            # Inter-slide cooldown except after last (lets server-side
-            # rate-limits clear before the next tab).
+            results.append(r)
             if idx < len(hero_slides) - 1:
-                await asyncio.sleep(5)
+                await asyncio.sleep(2)  # short cooldown, FlowKit is fast
+    else:
+        # `auto` or `playwright`: launch Playwright as fallback / primary.
+        # Strictly serial: fresh browser context per slide, one tab at a time.
+        # Empirical (Apr 25-26 2026, Ultra plan): parallel tabs on the persistent
+        # Gemini profile silently degrade output (returns stock-style content
+        # unrelated to the prompt). Hero images are too important to speculate on.
+        from playwright.async_api import async_playwright
+        logger.info("Serial mode — one fresh browser context per hero slide")
+        async with async_playwright() as p:
+            for idx, s in enumerate(hero_slides):
+                context = await p.chromium.launch_persistent_context(
+                    user_data_dir=str(GEMINI_PROFILE_DIR),
+                    headless=True,
+                    viewport={"width": 1440, "height": 900},
+                    args=["--disable-blink-features=AutomationControlled"],
+                )
+                try:
+                    sem = asyncio.Semaphore(1)
+                    r = await _gen_image_with_semaphore(
+                        sem,
+                        context,
+                        s["slide_number"],
+                        s.get("image_prompt") or "",
+                        str(draft_id),
+                        backend=IMAGE_BACKEND,
+                        flowkit_available=flowkit_available,
+                    )
+                    results.append(r)
+                finally:
+                    await context.close()
+                # Inter-slide cooldown except after last (lets server-side
+                # rate-limits clear before the next tab).
+                if idx < len(hero_slides) - 1:
+                    await asyncio.sleep(5)
 
     # Stitch URLs back into slides
     url_by_slide: dict[int, str] = {}
@@ -775,7 +1025,9 @@ async def run(*, dry_run: bool = False, draft_id: str | None = None) -> int:
         logger.error("DATABASE_URL not set")
         return 2
 
-    if not GEMINI_PROFILE_DIR.exists():
+    # Playwright profile is only required if Playwright is reachable from the
+    # selected backend. `flowkit`-only mode skips browser launch entirely.
+    if IMAGE_BACKEND != "flowkit" and not GEMINI_PROFILE_DIR.exists():
         logger.error(
             "Gemini profile not found at %s — run "
             "`bash scripts/playwright/login-all.sh gemini` first",


### PR DESCRIPTION
## Summary

- New `scripts/wr2_flowkit_client.py` (~370 LOC) — thin async client around the FlowKit local agent (`http://127.0.0.1:8100`). Persistent `httpx.AsyncClient` via `__aenter__/__aexit__` (Golden Rule #10), graceful `None` returns on offline / `NO_FLOW_KEY` (caller fall-back path).
- `scripts/wr2_image_generator.py` refactored: new `WR2_IMAGE_BACKEND` env (`auto` default → FlowKit primary + Playwright fallback; `flowkit` → FlowKit only; `playwright` → legacy). Existing Playwright path is byte-identical, including retry loop, prompt variants, VLM alignment guard.
- 36 new tests passing in 0.08s — 24 unit (`test_wr2_flowkit_client.py`, `httpx.MockTransport` only, no real network) + 12 integration (`test_wr2_image_generator_backend.py`, `AsyncMock` over both backends).
- New `docs/wr2/flowkit-integration.md` runbook + 1-line CLAUDE.md §11 entry.

## Why FlowKit (POC verified)

POC empirically verified 2026-05-03 on Antonello's Ultra account (memory `discovery_flowkit_poc_test_2026_05_03.md`):

| Path | Latency / image | Credit cost |
|---|---|---|
| Playwright (existing) | 30-90 s | 0 (web UI quota) |
| FlowKit (new) | **5-15 s** | **0** (FREE for `PAYGATE_TIER_TWO`) |

Same `GEM_PIX_2` (Nano Banana Pro) model, **5-10× faster**. The Playwright path is preserved as fallback because FlowKit's bearer token expires every ~45 min when the Flow tab is idle — `auto` mode degrades gracefully without operator intervention.

## Test plan

```bash
cd /Users/nuzantara/Desktop/nuzantara/.worktrees/sprint1-6-flowkit-wr2
/Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m pytest \
  scripts/tests/test_wr2_flowkit_client.py \
  scripts/tests/test_wr2_image_generator_backend.py
```

Actual output:

```
============================== 36 passed in 0.08s ==============================
```

Existing WR2 tests still green (regression check):

```
$ pytest scripts/tests/test_wr2_supervisor.py scripts/tests/test_wr2_draft_generator_enriched_prompt.py scripts/tests/test_wr2_topic_selector_live_news.py
======================== 61 passed, 1 warning in 0.64s =========================
```

- [ ] CI: 36 new tests pass
- [ ] CI: 61 existing WR2 tests still pass (no regression)
- [ ] Manual: `WR2_IMAGE_BACKEND=playwright` reproduces existing behavior byte-for-byte
- [ ] Manual: `WR2_IMAGE_BACKEND=auto` with FlowKit running on Pro → log "FlowKit available — using as primary backend (PAYGATE_TIER_TWO)"
- [ ] Manual: `WR2_IMAGE_BACKEND=auto` with FlowKit down → log "FlowKit unavailable — using Playwright backend"
- [ ] Manual: end-to-end on a hero-slide draft, verify `image_url` populated in `slides_json`, status flips to `drafts_imaged`

## Backwards compatibility

**Existing Playwright path is UNCHANGED at the byte level.**

- `_gen_one_image`, `_gen_one_image_raw`, `_build_prompt_variants` are unmodified.
- `MAX_RETRIES_PER_SLIDE`, prompt variants, VLM alignment guard, Tigris key naming, PNG content-type, status transitions (`drafts/drafts_checked` → `drafts_imaged`/`image_failed`), `slides_json` shape — all preserved.
- LaunchAgent `infra/launchagents/com.balizero.wr2.image-generator.plist` is **untouched**. Production cron defaults to `WR2_IMAGE_BACKEND=auto`, which probes FlowKit and silently uses Playwright when FlowKit is offline.
- `WR2_IMAGE_VLM_VALIDATION` (and `WR2_IMAGE_MIN_ALIGN_SCORE`) apply to BOTH backends — Nano Banana Pro can also produce off-prompt outputs; the WR2 brand bar is the same regardless of producer.
- DB schema, Tigris bucket, Tigris key path (`warroom/{draft_id}/slide-NN-TS.png`) all unchanged.

The only observable behavior difference when FlowKit IS available: hero-slide generation drops from ~30-90s/image to ~5-15s/image and the `image_generated_at` timestamp closes ~3-7 minutes earlier on a 4-hero carousel.

## Anthropic SDK compliance (Golden Rule #13)

The reference implementation in `scripts/wr2_flowkit_client.py` uses **only `httpx`** — no Anthropic SDK, no LLM calls. FlowKit's optional `agent/services/video_reviewer.py` is NOT invoked from this integration; the Bali Zero FlowKit setup procedure strips `anthropic` from `requirements.txt` as documented in the skill.

## References

- Skill: `~/.claude/skills/nuzantara-flowkit-flow-generation.md`
- Memory: `discovery_flowkit_poc_test_2026_05_03.md`
- POC repo: github.com/crisng95/flowkit (MIT, OSS)
- Existing pipeline: `scripts/wr2_image_generator.py` (845 LOC pre, ~1100 LOC post)
- Sibling docs: `docs/wr2/SUPERVISOR.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)