### PR TITLE
feat(wr2): hardening chain emits to observed-shell tier (Sprint 2 W3)

### DIFF
--- a/scripts/wr2-hardening-chain.sh
+++ b/scripts/wr2-hardening-chain.sh
@@ -5,6 +5,17 @@
 # invokes them in sequence, aggregates exit codes, and returns the max so
 # launchd can detect overall failure.
 #
+# Sprint 2 W3 (2026-05-03): emits to the cell-core observed-shell tier
+# (events_outbox via POST /api/observed-shell/emit) so silent failures
+# of the hardening chain are caught by monitoring. Per-CLI emits use
+# automation_name = wr2.hardening.<short>; final aggregate emit uses
+# wr2.hardening.run with sub_run_count + max_exit. Trace ID is generated
+# once per chain invocation so per-CLI emits can be joined to the parent
+# run row in observed_shell_events. The emit path is best-effort and
+# never fails the parent automation (mirrors ObservedShellBus.emit
+# never-raises invariant). Reference contract:
+# docs/wr2/sprint2-mapping.md § "hardening (Sprint 2 W3 candidate)".
+#
 # Run from LaunchAgent every 6h (StartInterval 21600).
 
 set -uo pipefail
@@ -13,7 +24,31 @@ WRAPPER="${WR2_WRAPPER:-$HOME/Desktop/nuzantara/scripts/wr2-cron-wrapper.sh}"
 LOG_DIR="${WR2_LOG_DIR:-$HOME/.openclaw/workspace/logs/war-room-v2}"
 mkdir -p "$LOG_DIR"
 
+# Source observed-shell helper if available (best-effort observability — the
+# helper's own failure modes are non-fatal). Path is the canonical Sprint 1
+# location; if missing, observed_shell_emit becomes a no-op stub.
+OBSERVED_SHELL_HELPER="${OBSERVED_SHELL_HELPER:-$(dirname "$0")/observed-shell-emit.sh}"
+if [[ -f "$OBSERVED_SHELL_HELPER" ]]; then
+    # shellcheck disable=SC1090
+    source "$OBSERVED_SHELL_HELPER"
+else
+    observed_shell_emit() { return 0; }
+fi
+
+# Generate one trace_id per chain invocation. uuidgen is BSD on macOS;
+# fallback to /proc/sys/kernel/random/uuid (Linux) or a date-based ID
+# if neither is available. Format: 36-char UUID-ish so consumers can
+# join across observed_shell_events rows without parsing.
+if command -v uuidgen >/dev/null 2>&1; then
+    TRACE_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+elif [[ -r /proc/sys/kernel/random/uuid ]]; then
+    TRACE_ID=$(< /proc/sys/kernel/random/uuid)
+else
+    TRACE_ID="hardening-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+fi
+
 MAX_EXIT=0
+SUB_RUN_COUNT=0
 
 for MOD in \
     backend.services.hardening.missed_runs_cli \
@@ -26,9 +61,43 @@ do
     "$WRAPPER" "$MOD" >> "$LOG" 2>&1
     EC=$?
     echo "[$(date -Iseconds)] ◀ $MOD exit=$EC" >> "$LOG"
+    SUB_RUN_COUNT=$((SUB_RUN_COUNT + 1))
     if (( EC > MAX_EXIT )); then
         MAX_EXIT=$EC
     fi
+
+    # Per-CLI observed-shell emit. Status maps exit code: 0 → ok, 1 → warning,
+    # else → error. Payload is intentionally compact (we have a 8 KB pg_notify
+    # limit and CLIs already log full JSON to LOG_DIR). The trace_id ties
+    # this row back to the aggregate emit at the bottom.
+    if (( EC == 0 )); then
+        STATUS="ok"
+    elif (( EC == 1 )); then
+        STATUS="warning"
+    else
+        STATUS="error"
+    fi
+    observed_shell_emit \
+        "wr2.hardening.${SHORT}" \
+        "$STATUS" \
+        "$(printf '{"module":"%s","exit_code":%d,"log_path":"%s"}' "$MOD" "$EC" "$LOG")" \
+        "$TRACE_ID"
 done
+
+# Aggregate emit — single row representing the chain run. Consumers (Sentinel,
+# dashboards) prefer this over scanning per-CLI rows for "did the run happen".
+if (( MAX_EXIT == 0 )); then
+    AGG_STATUS="ok"
+elif (( MAX_EXIT == 1 )); then
+    AGG_STATUS="warning"
+else
+    AGG_STATUS="error"
+fi
+
+observed_shell_emit \
+    "wr2.hardening.run" \
+    "$AGG_STATUS" \
+    "$(printf '{"sub_run_count":%d,"max_exit":%d,"log_dir":"%s"}' "$SUB_RUN_COUNT" "$MAX_EXIT" "$LOG_DIR")" \
+    "$TRACE_ID"
 
 exit "$MAX_EXIT"

--- a/tests/scripts/test_wr2_hardening_chain.py
+++ b/tests/scripts/test_wr2_hardening_chain.py
@@ -1,0 +1,276 @@
+"""Tests for scripts/wr2-hardening-chain.sh — Sprint 2 W3 observed-shell bridge.
+
+The chain script is best-effort: per-CLI ObservedShellBus emits + final
+aggregate emit. The tests mock the helper via OBSERVED_SHELL_HELPER env
+and capture what gets called.
+"""
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "wr2-hardening-chain.sh"
+
+
+def _make_wrapper(tmp_path: Path, exit_codes: dict[str, int]) -> Path:
+    """Build a fake WR2_WRAPPER that exits with the per-module code from the
+    mapping. The wrapper receives the module name as its first arg."""
+    wrapper = tmp_path / "wrapper.sh"
+    cases = "\n".join(
+        f'        {mod}) exit {ec} ;;'
+        for mod, ec in exit_codes.items()
+    )
+    wrapper.write_text(
+        "#!/bin/bash\n"
+        'case "$1" in\n'
+        f"{cases}\n"
+        "        *) exit 99 ;;\n"
+        "esac\n"
+    )
+    wrapper.chmod(wrapper.stat().st_mode | stat.S_IXUSR)
+    return wrapper
+
+
+def _make_emit_helper(tmp_path: Path, capture_path: Path) -> Path:
+    """Build a fake observed-shell-emit.sh that appends every call as a TSV
+    line so the test can assert on (name, status, payload, trace_id)."""
+    helper = tmp_path / "observed-shell-emit.sh"
+    helper.write_text(
+        "#!/bin/bash\n"
+        "observed_shell_emit() {\n"
+        f'    printf "%s\\t%s\\t%s\\t%s\\n" "$1" "$2" "$3" "$4" >> "{capture_path}"\n'
+        "    return 0\n"
+        "}\n"
+    )
+    helper.chmod(helper.stat().st_mode | stat.S_IXUSR)
+    return helper
+
+
+def _run_chain(tmp_path: Path, exit_codes: dict[str, int]) -> tuple[int, list[tuple[str, str, str, str]]]:
+    """Run the chain script with mocked wrapper + emit helper. Returns
+    (exit_code, list of (name, status, payload, trace_id) emit calls)."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    capture = tmp_path / "emits.tsv"
+    capture.write_text("")
+    wrapper = _make_wrapper(tmp_path, exit_codes)
+    helper = _make_emit_helper(tmp_path, capture)
+
+    env = os.environ.copy()
+    env["WR2_WRAPPER"] = str(wrapper)
+    env["WR2_LOG_DIR"] = str(log_dir)
+    env["OBSERVED_SHELL_HELPER"] = str(helper)
+
+    result = subprocess.run(
+        ["/bin/bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    emits: list[tuple[str, str, str, str]] = []
+    for line in capture.read_text().splitlines():
+        if not line:
+            continue
+        parts = line.split("\t")
+        # Pad to 4 in case trace_id is empty (it shouldn't be in our chain)
+        while len(parts) < 4:
+            parts.append("")
+        emits.append((parts[0], parts[1], parts[2], parts[3]))
+
+    return result.returncode, emits
+
+
+def test_all_clis_ok_emits_ok_status():
+    """When every CLI exits 0, all 3 per-CLI emits + 1 aggregate emit are 'ok'."""
+    with pytest.MonkeyPatch.context() as mp:
+        # Use a fresh tmpdir to avoid env var pollution
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            exit_code, emits = _run_chain(
+                Path(td),
+                {
+                    "backend.services.hardening.missed_runs_cli": 0,
+                    "backend.services.hardening.token_watchdog_cli": 0,
+                    "backend.services.hardening.quota_cli": 0,
+                },
+            )
+    assert exit_code == 0
+    assert len(emits) == 4, f"expected 3 per-CLI + 1 aggregate, got {len(emits)}: {emits}"
+    statuses = [e[1] for e in emits]
+    assert statuses == ["ok", "ok", "ok", "ok"]
+    # Last emit is the aggregate
+    assert emits[-1][0] == "wr2.hardening.run"
+    # Per-CLI emits use wr2.hardening.<short>
+    per_cli_names = {e[0] for e in emits[:-1]}
+    assert per_cli_names == {
+        "wr2.hardening.missed_runs_cli",
+        "wr2.hardening.token_watchdog_cli",
+        "wr2.hardening.quota_cli",
+    }
+
+
+def test_one_cli_warning_aggregate_is_warning():
+    """exit 1 from any CLI → that emit is 'warning'; aggregate carries max."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        exit_code, emits = _run_chain(
+            Path(td),
+            {
+                "backend.services.hardening.missed_runs_cli": 0,
+                "backend.services.hardening.token_watchdog_cli": 1,
+                "backend.services.hardening.quota_cli": 0,
+            },
+        )
+    assert exit_code == 1
+    assert len(emits) == 4
+    # Find the token_watchdog emit
+    token_emit = next(e for e in emits if "token_watchdog" in e[0])
+    assert token_emit[1] == "warning"
+    # Aggregate carries max severity (warning, since max_exit=1)
+    agg = emits[-1]
+    assert agg[0] == "wr2.hardening.run"
+    assert agg[1] == "warning"
+
+
+def test_one_cli_error_aggregate_is_error():
+    """exit >=2 → status='error'; aggregate carries max."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        exit_code, emits = _run_chain(
+            Path(td),
+            {
+                "backend.services.hardening.missed_runs_cli": 2,
+                "backend.services.hardening.token_watchdog_cli": 0,
+                "backend.services.hardening.quota_cli": 0,
+            },
+        )
+    assert exit_code == 2
+    miss_emit = next(e for e in emits if "missed_runs" in e[0])
+    assert miss_emit[1] == "error"
+    agg = emits[-1]
+    assert agg[1] == "error"
+
+
+def test_aggregate_payload_carries_sub_run_count_and_max_exit():
+    """The aggregate emit payload must include sub_run_count=3 and max_exit."""
+    import json
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        _, emits = _run_chain(
+            Path(td),
+            {
+                "backend.services.hardening.missed_runs_cli": 0,
+                "backend.services.hardening.token_watchdog_cli": 1,
+                "backend.services.hardening.quota_cli": 2,
+            },
+        )
+    agg = emits[-1]
+    payload = json.loads(agg[2])
+    assert payload["sub_run_count"] == 3
+    assert payload["max_exit"] == 2
+
+
+def test_trace_id_shared_across_emits_in_one_run():
+    """Per-CLI emits + aggregate emit MUST share the same trace_id so
+    consumers can join the rows in observed_shell_events."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        _, emits = _run_chain(
+            Path(td),
+            {
+                "backend.services.hardening.missed_runs_cli": 0,
+                "backend.services.hardening.token_watchdog_cli": 0,
+                "backend.services.hardening.quota_cli": 0,
+            },
+        )
+    trace_ids = {e[3] for e in emits}
+    assert len(trace_ids) == 1, f"trace_id must be constant per run, got {trace_ids}"
+    # Trace ID must be non-empty
+    assert all(tid for tid in trace_ids)
+
+
+def test_per_cli_payload_includes_module_exit_code_log_path():
+    """Per-CLI payload must carry module / exit_code / log_path so dashboards
+    can deep-link to the JSON-line log file."""
+    import json
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        _, emits = _run_chain(
+            Path(td),
+            {
+                "backend.services.hardening.missed_runs_cli": 0,
+                "backend.services.hardening.token_watchdog_cli": 0,
+                "backend.services.hardening.quota_cli": 0,
+            },
+        )
+    miss_emit = next(e for e in emits if "missed_runs" in e[0])
+    payload = json.loads(miss_emit[2])
+    assert payload["module"] == "backend.services.hardening.missed_runs_cli"
+    assert payload["exit_code"] == 0
+    assert payload["log_path"].endswith("hardening-missed_runs_cli.log")
+
+
+def test_chain_continues_through_failures():
+    """A non-zero exit on the FIRST CLI must NOT abort subsequent CLIs.
+    All 3 CLIs always run; the chain reports max exit at the end."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        exit_code, emits = _run_chain(
+            Path(td),
+            {
+                "backend.services.hardening.missed_runs_cli": 2,
+                "backend.services.hardening.token_watchdog_cli": 1,
+                "backend.services.hardening.quota_cli": 0,
+            },
+        )
+    # All 3 CLIs ran
+    per_cli = [e for e in emits if e[0] != "wr2.hardening.run"]
+    assert len(per_cli) == 3
+    # Quota was the last and got an emit even though missed_runs and token_watchdog
+    # had failures earlier
+    quota_emit = next(e for e in emits if "quota" in e[0])
+    assert quota_emit[1] == "ok"
+    # Max exit propagates
+    assert exit_code == 2
+
+
+def test_helper_missing_does_not_break_chain():
+    """If OBSERVED_SHELL_HELPER points to a non-existent file, the script
+    must still complete (best-effort observability invariant). The internal
+    fallback defines observed_shell_emit as a no-op."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        log_dir = Path(td) / "logs"
+        log_dir.mkdir()
+        wrapper = _make_wrapper(
+            Path(td),
+            {
+                "backend.services.hardening.missed_runs_cli": 0,
+                "backend.services.hardening.token_watchdog_cli": 0,
+                "backend.services.hardening.quota_cli": 0,
+            },
+        )
+        env = os.environ.copy()
+        env["WR2_WRAPPER"] = str(wrapper)
+        env["WR2_LOG_DIR"] = str(log_dir)
+        env["OBSERVED_SHELL_HELPER"] = str(Path(td) / "nonexistent.sh")
+
+        result = subprocess.run(
+            ["/bin/bash", str(SCRIPT)],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+    assert result.returncode == 0, (
+        f"chain must succeed when helper is missing — stdout={result.stdout!r} "
+        f"stderr={result.stderr!r}"
+    )


### PR DESCRIPTION
## Summary

Wires \`scripts/wr2-hardening-chain.sh\` to the cell-core observed-shell
tier (events_outbox via \`POST /api/observed-shell/emit\` through the
\`scripts/observed-shell-emit.sh\` helper). Closes the Sprint 0 grey-area
item — hardening was filesystem + Telegram only and silent failures
went unnoticed by monitoring.

### What changes

- **Per-CLI emit** — \`wr2.hardening.<short>\` (one of
  \`missed_runs_cli\`, \`token_watchdog_cli\`, \`quota_cli\`) with
  \`status\` mapped from exit code: 0 → \`ok\`, 1 → \`warning\`,
  ≥2 → \`error\`. Payload carries \`module\`, \`exit_code\`, \`log_path\`.
- **Aggregate emit** — \`wr2.hardening.run\` with payload \`{sub_run_count,
  max_exit, log_dir}\`. Single row per chain run, preferred by dashboards
  over scanning per-CLI rows.
- **Trace ID** — generated once per chain invocation (\`uuidgen\` /
  \`/proc/sys/kernel/random/uuid\` / fallback) and propagated to all 4
  emits so consumers can join them in \`observed_shell_events\`.
- **Best-effort observability** — \`OBSERVED_SHELL_HELPER\` env points to
  the helper script; if missing, the script defines a no-op stub so the
  hardening chain itself never breaks because of monitoring setup.
  The helper's own curl call is bounded (5s connect / 10s total).

### Why observed-shell instead of PG_CHANNEL_MAP

Per Sprint 0 audit, \`hardening\` is **operational maintenance**, not
**cell IPC**. The Symbiosis Law 4 (Event-driven) pertains to inter-cell
communication; the observed-shell tier is the correct substrate for
"did the maintenance run?" telemetry. This decision is documented in
\`docs/wr2/sprint2-mapping.md\` § "hardening (Sprint 2 W3 candidate)".

### Test plan

Unit: \`tests/scripts/test_wr2_hardening_chain.py\` (8 tests, ~3.7s):

- [x] all-ok → 4×ok emits (3 per-CLI + 1 aggregate)
- [x] one-warning → that emit + aggregate are \`warning\`
- [x] one-error → that emit + aggregate are \`error\`
- [x] aggregate payload carries \`sub_run_count=3\` + \`max_exit\`
- [x] trace_id constant across all 4 emits in one run
- [x] per-CLI payload includes \`module\`/\`exit_code\`/\`log_path\`
- [x] chain continues through failures (all 3 CLIs always run)
- [x] helper missing → script still completes (stub fallback)

Integration (post-merge, manual on Pro):

- [ ] Trigger the LaunchAgent (\`launchctl kickstart -k
      gui/501/com.balizero.wr2.hardening\`)
- [ ] Verify rows in \`observed_shell_events\` table — 4 rows with
      same \`trace_id\`, statuses match the actual run

## Refs

- \`docs/wr2/sprint2-mapping.md\` § "hardening (Sprint 2 W3 candidate)"
  (PR #440 — contract definition)
- \`docs/audits/sprint0/wr2-ipc-mechanism.md\` § "Grey area"
- \`docs/cell-core/observed-shell-tier.md\`
- \`scripts/observed-shell-emit.sh\` (Sprint 1 PR-1.2)
- Migration 151 \`observed_shell_events\` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)