### PR TITLE
🎨 Palette: Add image attachment previews to chat input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-04-25 - [Keyboard Visibility for Actions]
 **Learning:** Actions that only appear on hover (e.g., a "Delete" button) are inaccessible to keyboard-only users unless they are also triggered by focus.
 **Action:** Use Tailwind's `group-focus-within:opacity-100` (or similar focus-based classes) alongside `group-hover:opacity-100` to ensure secondary actions become visible when a user tabs through a list.
+
+## 2026-04-25 - [Immediate Visual Feedback for Attachments]
+**Learning:** Providing immediate visual feedback for file attachments (like image previews) in a chat interface significantly improves the user's sense of control and reduces errors. Users can verify they attached the correct file before sending.
+**Action:** Always include animated previews for file attachments in input components, and provide an easy, accessible way to remove them (visible on hover/focus).

--- a/apps/mouth/src/app/chat/page.tsx
+++ b/apps/mouth/src/app/chat/page.tsx
@@ -121,6 +121,8 @@ export default function ChatPage() {
           recordingTime={0}
           onStartRecording={() => {}}
           onStopRecording={() => {}}
+          attachedImages={chatInput.attachedImages}
+          onRemoveImage={chatInput.removeAttachedImage}
         />
       </div>
 

--- a/apps/mouth/src/components/chat/ChatInputBar.test.tsx
+++ b/apps/mouth/src/components/chat/ChatInputBar.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ChatInputBar } from './ChatInputBar';
+import { vi, describe, it, expect } from 'vitest';
+
+describe('ChatInputBar', () => {
+  const defaultProps = {
+    input: '',
+    setInput: vi.fn(),
+    isLoading: false,
+    showImagePrompt: false,
+    setShowImagePrompt: vi.fn(),
+    onSend: vi.fn(),
+    onImageGenerate: vi.fn(),
+    showAttachMenu: false,
+    setShowAttachMenu: vi.fn(),
+    attachMenuRef: { current: null },
+    fileInputRef: { current: null },
+    onFileChange: vi.fn(),
+    isRecording: false,
+    recordingTime: 0,
+    onStartRecording: vi.fn(),
+    onStopRecording: vi.fn(),
+    attachedImages: [],
+    onRemoveImage: vi.fn(),
+  };
+
+  it('renders input field', () => {
+    render(<ChatInputBar {...defaultProps} />);
+    expect(screen.getByPlaceholderText(/Type your message/i)).toBeDefined();
+  });
+
+  it('displays image previews when attachedImages are provided', () => {
+    const attachedImages = [
+      { id: '1', base64: 'data:image/png;base64,abc', name: 'test.png', size: 100 },
+    ];
+    render(<ChatInputBar {...defaultProps} attachedImages={attachedImages} />);
+    expect(screen.getByAltText('test.png')).toBeDefined();
+    expect(screen.getByLabelText(/Remove image test.png/i)).toBeDefined();
+  });
+
+  it('calls onRemoveImage when remove button is clicked', () => {
+    const onRemoveImage = vi.fn();
+    const attachedImages = [
+      { id: '1', base64: 'data:image/png;base64,abc', name: 'test.png', size: 100 },
+    ];
+    render(<ChatInputBar {...defaultProps} attachedImages={attachedImages} onRemoveImage={onRemoveImage} />);
+
+    const removeButton = screen.getByLabelText(/Remove image test.png/i);
+    fireEvent.click(removeButton);
+
+    expect(onRemoveImage).toHaveBeenCalledWith('1');
+  });
+});

--- a/apps/mouth/src/components/chat/ChatInputBar.tsx
+++ b/apps/mouth/src/components/chat/ChatInputBar.tsx
@@ -2,8 +2,11 @@
 
 import { Button } from '@/components/ui/button';
 import { UI } from '@/constants';
-import { Send, ImageIcon, Plus, Loader2, Upload, Camera, Mic } from 'lucide-react';
+import { Send, ImageIcon, Plus, Loader2, Upload, Camera, Mic, X } from 'lucide-react';
 import { ChatRecordingOverlay } from './ChatRecordingOverlay';
+import { motion, AnimatePresence } from 'framer-motion';
+import Image from 'next/image';
+import { AttachedImage } from '@/hooks/useChatInput';
 
 export interface ChatInputBarProps {
   input: string;
@@ -23,6 +26,8 @@ export interface ChatInputBarProps {
   onStartRecording: () => void;
   onStopRecording: () => void;
   onToggleRecording?: () => void; // Click-to-toggle handler
+  attachedImages?: AttachedImage[];
+  onRemoveImage?: (id: string) => void;
 }
 
 export function ChatInputBar({
@@ -43,6 +48,8 @@ export function ChatInputBar({
   onStartRecording,
   onStopRecording,
   onToggleRecording,
+  attachedImages = [],
+  onRemoveImage,
 }: ChatInputBarProps) {
   // Use toggle handler if provided, otherwise fall back to start/stop
   const handleMicClick = () => {
@@ -132,6 +139,44 @@ export function ChatInputBar({
               <Camera className="w-3.5 h-3.5" />
             </Button>
           </div>
+
+          {/* Image Previews */}
+          <AnimatePresence>
+            {attachedImages.length > 0 && (
+              <motion.div
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: 'auto' }}
+                exit={{ opacity: 0, height: 0 }}
+                className="flex flex-wrap gap-2 px-2 py-2 mb-1 border-b border-[var(--border)]/50"
+              >
+                {attachedImages.map((img) => (
+                  <motion.div
+                    key={img.id}
+                    layout
+                    initial={{ opacity: 0, scale: 0.8 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    exit={{ opacity: 0, scale: 0.8 }}
+                    className="relative group w-16 h-16 rounded-lg overflow-hidden border border-[var(--border)]"
+                  >
+                    <Image
+                      src={img.base64}
+                      alt={img.name}
+                      fill
+                      className="object-cover"
+                      unoptimized
+                    />
+                    <button
+                      onClick={() => onRemoveImage?.(img.id)}
+                      className="absolute top-1 right-1 bg-black/60 text-white rounded-full p-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
+                      aria-label={`Remove image ${img.name}`}
+                    >
+                      <X className="w-3 h-3" />
+                    </button>
+                  </motion.div>
+                ))}
+              </motion.div>
+            )}
+          </AnimatePresence>
 
           <div className="flex items-end gap-2">
             {/* Attachment Menu */}


### PR DESCRIPTION
This PR adds a delightful and accessible micro-UX enhancement to the chat interface: **Image Attachment Previews**.

Previously, when a user attached an image to their message, there was no visual indication that the attachment was successful or what images were pending. This led to a lack of feedback and the inability to manage (remove) attachments before sending.

### 💡 What:
- Integrated `AttachedImage` previews directly into the `ChatInputBar`.
- Used `framer-motion` for smooth entering/exiting animations of the preview list.
- Implemented a "Remove" button on each preview with proper ARIA labels.
- Ensured keyboard accessibility by making the remove buttons visible on focus (`group-focus-within:opacity-100`).

### 🎯 Why:
- **Better Feedback:** Users instantly see what they've attached.
- **Error Prevention:** Users can remove accidental attachments before hitting send.
- **Improved Accessibility:** Secondary actions are now discoverable and usable for keyboard/screen-reader users.

### ♿ Accessibility:
- Added `aria-label` to the remove buttons ("Remove image [filename]").
- Ensured focus visibility for secondary actions as per repository standards.

### ✅ Verification:
- Created and ran a new Vitest suite: `ChatInputBar.test.tsx` (all passed).
- Verified that existing chat functionality remains intact.
- Targeted linting of modified files passed.

---
*PR created automatically by Jules for task [8854629873661435297](https://jules.google.com/task/8854629873661435297) started by @Balizero1987*