### PR TITLE
feat(mata-garuda): Layer-1 headless auth refresh for nlm-feeder

### DIFF
--- a/apps/mata-garuda/mata_garuda/workers/nlm_feeder.py
+++ b/apps/mata-garuda/mata_garuda/workers/nlm_feeder.py
@@ -64,18 +64,86 @@ def _nlm_add_url(notebook_id: str, url: str) -> bool:
         return False
 
 
+def _try_headless_auth_refresh() -> bool:
+    """Best-effort: spawn headless Chrome from saved nlm profile to refresh
+    cookies + CSRF, then write back to ~/.notebooklm-mcp-cli/auth.json.
+
+    Only works if the user has previously run `nlm login --clear` interactively
+    (creating an isolated Chrome profile with persistent Google session).
+    Returns True if tokens were extracted; False otherwise.
+
+    NOTE: requires the `notebooklm-mcp-cli` package to be installed in the
+    same Python env as the feeder OR available via the uv tool path.
+    """
+    try:
+        from notebooklm_tools.utils.cdp import run_headless_auth  # type: ignore
+    except ImportError:
+        # mata-garuda venv doesn't bundle notebooklm-mcp-cli; fall back to
+        # subprocess against the uv tool venv where it IS installed.
+        try:
+            uv_python = Path(
+                "/Users/nuzantara/.local/share/uv/tools/notebooklm-mcp-cli/bin/python"
+            )
+            if not uv_python.exists():
+                return False
+            result = subprocess.run(
+                [str(uv_python), "-c",
+                 "from notebooklm_tools.utils.cdp import run_headless_auth; "
+                 "t = run_headless_auth(profile_name='default', timeout=45); "
+                 "print('OK' if t else 'FAIL')"],
+                capture_output=True, text=True, timeout=60,
+            )
+            return "OK" in result.stdout
+        except Exception as e:
+            logger.warning(f"[nlm_feeder] headless auth refresh subprocess failed: {e}")
+            return False
+
+    try:
+        tokens = run_headless_auth(profile_name="default", timeout=45)
+        return tokens is not None
+    except Exception as e:
+        logger.warning(f"[nlm_feeder] headless auth refresh failed: {e}")
+        return False
+
+
 def _nlm_add_text(notebook_id: str, title: str, text: str) -> bool:
-    """Add text content to NLM notebook via temp file."""
+    """Add text content to NLM notebook via temp file.
+
+    On auth-error stderr from `nlm` CLI, attempts ONE headless refresh
+    + retry. Subsequent auth failures within the same run are NOT retried
+    (Layer-1 recovery only — if Chrome profile is stale too, only an
+    interactive `nlm login --clear` will fix it).
+    """
     if not notebook_id:
         return False
     tmp = Path(f"/tmp/nlm_feed_{uuid4().hex[:8]}.txt")
     try:
         tmp.write_text(f"# {title}\n\n{text}")
-        result = subprocess.run(
-            ["nlm", "source", "add", notebook_id, "--file", str(tmp)],
-            capture_output=True, text=True, timeout=60,
-        )
-        return result.returncode == 0
+
+        for attempt in (1, 2):
+            result = subprocess.run(
+                ["nlm", "source", "add", notebook_id, "--file", str(tmp)],
+                capture_output=True, text=True, timeout=60,
+            )
+            if result.returncode == 0:
+                return True
+
+            stderr = (result.stderr or "") + (result.stdout or "")
+            auth_err = (
+                "Authentication expired" in stderr
+                or "Authentication Error" in stderr
+                or "auth" in stderr.lower() and "expir" in stderr.lower()
+            )
+            if attempt == 1 and auth_err:
+                logger.info(
+                    "[nlm_feeder] auth expired on add_text — attempting headless refresh"
+                )
+                if not _try_headless_auth_refresh():
+                    return False
+                # loop back for retry with refreshed auth.json
+                continue
+            return False
+        return False
     except Exception as e:
         logger.warning(f"[nlm_feeder] Failed to add text '{title}': {e}")
         return False


### PR DESCRIPTION
## Summary

When the nlm CLI subprocess fails with `Authentication expired` during the hourly cron run, attempt one headless re-auth using the saved nlm Chrome profile + retry the source add. Avoids silent fed=0 errors=N for the rest of the run.

## Background

Verified 2026-05-04: `nlm login` attaches to running Chrome → cookies are session-volatile (~5 min TTL) → cron pushes ~5 sources, then auth expires for the rest of the hour.

`run_headless_auth(profile_name="default")` is exposed by notebooklm-mcp-cli and can extract fresh tokens without user interaction, IF the saved Chrome profile has a persistent Google web session. This PR wires that recovery path into `_nlm_add_text`.

## Caveat (documented inline + in runbook)

If `nlm login` was originally run while attached to an external Chrome (the warning "Profile isolation may not apply"), the saved Chrome profile may not have a persistent session either, and headless refresh produces equally-expired cookies. Permanent fix is for the user to run `nlm login --clear` once interactively.

Runbook: `~/.claude/projects/-Users-nuzantara/memory/runbook_nlm_auth_stability_fix.md`.

## Implementation

- New `_try_headless_auth_refresh()` helper. Two import paths:
  1. Direct `from notebooklm_tools.utils.cdp import run_headless_auth` if available in mata-garuda venv (currently NOT — kept as future-proof).
  2. Subprocess against the uv tool venv at `~/.local/share/uv/tools/notebooklm-mcp-cli/bin/python` (current path, since notebooklm_tools is uv-isolated).
- `_nlm_add_text` retries once on auth-error stderr; subsequent failures still propagate.

## Test plan

- [x] Verified `run_headless_auth` is callable from uv tool venv (returns AuthTokens with 27 cookies)
- [ ] Once user runs `nlm login --clear`, kickstart the cron and verify `alerts.fed=10 errors=0`
- [ ] Monitor `~/logs/matagaruda-nlm-feeder-stream.log` for "auth expired on add_text — attempting headless refresh" lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)