### PR TITLE
fix(frontend): bump axios lockfile for audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11909,12 +11909,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }


### PR DESCRIPTION
## Summary
- update the locked axios package from 1.15.0 to 1.16.0
- keep top-level package.json unchanged; the existing ^1.15.0 range already allows the fixed version
- unblock the main Tests & Coverage workflow after npm audit started flagging axios 1.15.x

## Verification
- npm install --no-fund
- npm audit --audit-level=high
- cd apps/mouth && npx vitest --run --coverage
- cd apps/mouth && npm run test:coverage:check