### PR TITLE
fix(ci): repair restore drill workflow yaml

### DIFF
--- a/.github/workflows/restore-drill.yml
+++ b/.github/workflows/restore-drill.yml
@@ -94,12 +94,15 @@ jobs:
           test "$PRACTICES" != "ERROR" || { echo "practices table broken"; exit 3; }
 
           # Telegram success
-          MSG="✅ Restore drill passed (CI)
-backup: $LATEST
-tables: $TABLES
-clients: $CLIENTS
-practices: $PRACTICES
-dump: $DUMP_SIZE bytes"
+          MSG=$(cat <<EOF
+          ✅ Restore drill passed (CI)
+          backup: $LATEST
+          tables: $TABLES
+          clients: $CLIENTS
+          practices: $PRACTICES
+          dump: $DUMP_SIZE bytes
+          EOF
+          )
           curl -s --max-time 10 \
             -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             -d chat_id="${TELEGRAM_OWNER_CHAT_ID}" \


### PR DESCRIPTION
## Summary
- Fix invalid YAML in the monthly restore drill workflow success Telegram message
- Use an indented heredoc so GitHub can parse the workflow and stop creating empty failed push runs

## Verification
- actionlint -color=false .github/workflows/restore-drill.yml
- git diff --check
- Confirmed pushing this branch did not create a new empty restore-drill push run