### PR TITLE
🎨 Palette: Add image attachment previews and fix menu interactions

### DIFF
--- a/apps/mouth/src/app/chat/page.tsx
+++ b/apps/mouth/src/app/chat/page.tsx
@@ -45,7 +45,13 @@ export default function ChatPage() {
     setImageModalOpen
   } = useChatPage();
 
-  // 2. Gestione dello stato di caricamento iniziale (Blocking UI)
+  // 2. Refs e stati locali per componenti UI
+  const userMenuRef = React.useRef<HTMLDivElement>(null);
+  const avatarInputRef = React.useRef<HTMLInputElement>(null);
+  const attachMenuRef = React.useRef<HTMLDivElement>(null);
+  const [showAttachMenu, setShowAttachMenu] = React.useState(false);
+
+  // 3. Gestione dello stato di caricamento iniziale (Blocking UI)
   if (isInitialLoading) {
     return (
       <div className="flex h-screen items-center justify-center bg-[var(--background)] text-white">
@@ -83,8 +89,8 @@ export default function ChatPage() {
           userAvatar={userAvatar}
           showUserMenu={showUserMenu}
           onToggleUserMenu={() => setShowUserMenu(!showUserMenu)}
-          userMenuRef={null as any}
-          avatarInputRef={null as any}
+          userMenuRef={userMenuRef}
+          avatarInputRef={avatarInputRef}
           onAvatarUpload={handleAvatarChange}
           onShowToast={showToast}
         />
@@ -112,15 +118,17 @@ export default function ChatPage() {
           setShowImagePrompt={(val) => chatInput.setImageGenPrompt(val ? " " : "")}
           onSend={handleSend}
           onImageGenerate={() => setImageModalOpen(true)}
-          showAttachMenu={false}
-          setShowAttachMenu={() => {}}
-          attachMenuRef={null as any}
+          showAttachMenu={showAttachMenu}
+          setShowAttachMenu={setShowAttachMenu}
+          attachMenuRef={attachMenuRef}
           fileInputRef={fileInputRef}
           onFileChange={async (e) => chatInput.handleImageAttach(e)}
           isRecording={false}
           recordingTime={0}
           onStartRecording={() => {}}
           onStopRecording={() => {}}
+          attachedImages={chatInput.attachedImages}
+          onRemoveImage={chatInput.removeAttachedImage}
         />
       </div>
 

--- a/apps/mouth/src/components/chat/ChatInputBar.test.tsx
+++ b/apps/mouth/src/components/chat/ChatInputBar.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ChatInputBar } from './ChatInputBar';
+import React from 'react';
+
+describe('ChatInputBar', () => {
+  const defaultProps = {
+    input: '',
+    setInput: vi.fn(),
+    isLoading: false,
+    showImagePrompt: false,
+    setShowImagePrompt: vi.fn(),
+    onSend: vi.fn(),
+    onImageGenerate: vi.fn(),
+    showAttachMenu: false,
+    setShowAttachMenu: vi.fn(),
+    attachMenuRef: { current: null },
+    fileInputRef: { current: null },
+    onFileChange: vi.fn(),
+    isRecording: false,
+    recordingTime: 0,
+    onStartRecording: vi.fn(),
+    onStopRecording: vi.fn(),
+  };
+
+  it('renders image previews when attachedImages are provided', () => {
+    const attachedImages = [
+      { id: '1', base64: 'data:image/png;base64,123', name: 'test.png', size: 100 },
+    ];
+    render(<ChatInputBar {...defaultProps} attachedImages={attachedImages} />);
+
+    expect(screen.getByAltText('test.png')).toBeInTheDocument();
+    expect(screen.getByLabelText('Remove test.png')).toBeInTheDocument();
+  });
+
+  it('calls onRemoveImage when remove button is clicked', () => {
+    const onRemoveImage = vi.fn();
+    const attachedImages = [
+      { id: '1', base64: 'data:image/png;base64,123', name: 'test.png', size: 100 },
+    ];
+    render(
+      <ChatInputBar
+        {...defaultProps}
+        attachedImages={attachedImages}
+        onRemoveImage={onRemoveImage}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('Remove test.png'));
+    expect(onRemoveImage).toHaveBeenCalledWith('1');
+  });
+
+  it('shows attachment menu when showAttachMenu is true', () => {
+    render(<ChatInputBar {...defaultProps} showAttachMenu={true} />);
+
+    expect(screen.getByText('Upload file')).toBeInTheDocument();
+    expect(screen.getByText('Generate image')).toBeInTheDocument();
+  });
+
+  it('calls setShowAttachMenu when attachment button is clicked', () => {
+    render(<ChatInputBar {...defaultProps} />);
+
+    fireEvent.click(screen.getByLabelText('Attach file'));
+    expect(defaultProps.setShowAttachMenu).toHaveBeenCalledWith(true);
+  });
+});

--- a/apps/mouth/src/components/chat/ChatInputBar.tsx
+++ b/apps/mouth/src/components/chat/ChatInputBar.tsx
@@ -1,9 +1,13 @@
 'use client';
 
+import { useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { UI } from '@/constants';
-import { Send, ImageIcon, Plus, Loader2, Upload, Camera, Mic } from 'lucide-react';
+import { Send, ImageIcon, Plus, Loader2, Upload, Camera, Mic, X } from 'lucide-react';
 import { ChatRecordingOverlay } from './ChatRecordingOverlay';
+import Image from 'next/image';
+import { motion, AnimatePresence } from 'framer-motion';
+import { AttachedImage } from '@/hooks/useChatInput';
 
 export interface ChatInputBarProps {
   input: string;
@@ -23,6 +27,8 @@ export interface ChatInputBarProps {
   onStartRecording: () => void;
   onStopRecording: () => void;
   onToggleRecording?: () => void; // Click-to-toggle handler
+  attachedImages?: AttachedImage[];
+  onRemoveImage?: (id: string) => void;
 }
 
 export function ChatInputBar({
@@ -43,7 +49,18 @@ export function ChatInputBar({
   onStartRecording,
   onStopRecording,
   onToggleRecording,
+  attachedImages = [],
+  onRemoveImage,
 }: ChatInputBarProps) {
+  useEffect(() => {
+    if (!showAttachMenu) return;
+    const out = (e: MouseEvent) => attachMenuRef.current?.contains(e.target as Node) || setShowAttachMenu(false);
+    const esc = (e: KeyboardEvent) => e.key === 'Escape' && setShowAttachMenu(false);
+    document.addEventListener('mousedown', out);
+    document.addEventListener('keydown', esc);
+    return () => { document.removeEventListener('mousedown', out); document.removeEventListener('keydown', esc); };
+  }, [showAttachMenu, setShowAttachMenu, attachMenuRef]);
+
   // Use toggle handler if provided, otherwise fall back to start/stop
   const handleMicClick = () => {
     if (onToggleRecording) {
@@ -84,6 +101,17 @@ export function ChatInputBar({
             </Button>
           </div>
         )}
+
+        <div className="flex flex-wrap gap-2 mb-2 px-1">
+          <AnimatePresence mode="popLayout">
+            {attachedImages.map((img) => (
+              <motion.div key={img.id} initial={{ opacity: 0, scale: 0.8 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.8 }} className="relative group w-14 h-14 rounded-lg overflow-hidden border border-[var(--border)] shadow-sm bg-[var(--background-secondary)]">
+                <Image src={img.base64} alt={img.name} fill className="object-cover" unoptimized />
+                <button onClick={() => onRemoveImage?.(img.id)} className="absolute top-0.5 right-0.5 p-0.5 bg-black/60 hover:bg-black/80 rounded-full text-white opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity" aria-label={`Remove ${img.name}`}><X className="w-3 h-3" /></button>
+              </motion.div>
+            ))}
+          </AnimatePresence>
+        </div>
 
         {/* Input Container */}
         <div className="glass-panel rounded-[24px] p-2 relative overflow-hidden group shadow-2xl">


### PR DESCRIPTION
This PR introduces several micro-UX improvements to the Zantara chat interface:

1. **Image Attachment Previews**: Users now see immediate visual feedback when attaching images to a message. Previews include a smooth entrance/exit animation using `framer-motion` and a dedicated button to remove individual attachments before sending.
2. **Accessible Menu Interactions**: The attachment menu in the input bar and the user menu in the header now correctly close when clicking outside or pressing the 'Escape' key, aligning with accessibility best practices.
3. **Ref Bindings**: Fixed a bug where component refs were passed as `null`, which disabled several interactive features. These are now correctly managed in `ChatPage`.
4. **Testing**: Added a new test suite `ChatInputBar.test.tsx` to verify these UI behaviors and ensure future stability.

Accessibility:
- Added `aria-label` to image remove buttons.
- Implemented keyboard-accessible menu closing (Escape key).
- Ensured remove buttons are accessible to keyboard users via focus-visible states.

---
*PR created automatically by Jules for task [18281913928090497222](https://jules.google.com/task/18281913928090497222) started by @Balizero1987*