### PR TITLE
feat(email): finish branding rollout — logo + CC team on remaining 4 client emails

### DIFF
--- a/apps/backend-rag/backend/services/crm/birthday_notifier_service.py
+++ b/apps/backend-rag/backend/services/crm/birthday_notifier_service.py
@@ -19,6 +19,7 @@ import asyncpg
 import httpx
 
 from backend.services.integrations.zoho_email_service import ZohoEmailService
+from backend.services.notifications.email_branding import logo_header_html
 
 logger = logging.getLogger(__name__)
 
@@ -287,11 +288,13 @@ class BirthdayNotifierService:
         <html>
         <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
             <div style="max-width: 600px; margin: 0 auto; padding: 20px;">
+                {logo_header_html()}
                 <h2 style="color: #2c3e50;">{greeting}</h2>
                 <p style="white-space: pre-line;">{message}</p>
                 <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
                 <p style="font-size: 12px; color: #666;">
-                    Bali Zero - Your Partner in Indonesia<br>
+                    <strong>Zantara — Bali Zero Team</strong><br>
+                    📧 asya@balizero.com | 📱 WhatsApp: +62 821 3107 363<br>
                     <a href="https://www.balizero.com" style="color: #3498db;">www.balizero.com</a>
                 </p>
             </div>

--- a/apps/backend-rag/backend/services/crm/completed_process_service.py
+++ b/apps/backend-rag/backend/services/crm/completed_process_service.py
@@ -21,6 +21,7 @@ from backend.services.notifications.email_audit import (
     notify_email_failure_critical,
     record_email_result,
 )
+from backend.services.notifications.email_branding import logo_header_html
 from backend.services.notifications.email_http import get_email_client
 
 # Internal email API — uses Brevo, from=zantara@balizero.com
@@ -83,6 +84,9 @@ class CompletedProcessService:
                     documents=final_documents,
                 )
 
+            # Send notification to team leader
+            team_leader_email = practice_data.get("assigned_to") or practice_data.get("created_by")
+
             # Send email to client
             client_notified = False
             if client_data.get("email"):
@@ -93,13 +97,12 @@ class CompletedProcessService:
                         practice_data=practice_data,
                         documents=uploaded_docs,
                         failed_uploads=failed_uploads,
+                        team_member_email=team_leader_email,
                     )
                     client_notified = True
                 except Exception as e:
                     logger.error(f"Failed to send completion email to client: {e}")
 
-            # Send notification to team leader
-            team_leader_email = practice_data.get("assigned_to") or practice_data.get("created_by")
             team_notified = False
             if team_leader_email:
                 try:
@@ -213,6 +216,7 @@ class CompletedProcessService:
         practice_data: dict,
         documents: list[dict],
         failed_uploads: list[dict] | None = None,
+        team_member_email: str | None = None,
     ) -> None:
         """Send human, congratulatory email to client.
 
@@ -297,6 +301,8 @@ P.S. Save our contact info for future needs—we're always here to help! 😊
             email_type="completion_client",
             practice_id=practice_data["id"],
             client_id=practice_data.get("client_id"),
+            cc=team_member_email if team_member_email and team_member_email != client_email else None,
+            include_logo=True,
         )
         logger.info(f"Completion email sent to client {client_email}")
 
@@ -366,6 +372,8 @@ Zantara CRM System
         email_type: str,
         practice_id: int | None = None,
         client_id: int | None = None,
+        cc: str | None = None,
+        include_logo: bool = False,
     ) -> None:
         """Send email via Brevo (primary), fall back to Zoho if Brevo fails.
 
@@ -384,11 +392,16 @@ Zantara CRM System
         # 1) Brevo
         try:
             html_body = body.replace("\n", "<br>")
+            if include_logo:
+                html_body = f"{logo_header_html()}{html_body}"
+            payload: dict = {"to": to_email, "subject": subject, "body": html_body}
+            if cc:
+                payload["cc"] = cc
             client = await get_email_client()
             response = await client.post(
                 _EMAIL_API_URL,
                 headers={"X-API-Key": _EMAIL_API_KEY},
-                json={"to": to_email, "subject": subject, "body": html_body},
+                json=payload,
             )
             response.raise_for_status()
             logger.info(f"Email sent to {to_email} via Brevo")

--- a/apps/backend-rag/backend/services/crm/process_automation_service.py
+++ b/apps/backend-rag/backend/services/crm/process_automation_service.py
@@ -15,6 +15,7 @@ import httpx
 from backend.app.utils.logging_utils import get_logger
 from backend.services.common.cache import cache_invalidating
 from backend.services.integrations.zoho_email_service import ZohoEmailService
+from backend.services.notifications.email_branding import logo_header_html
 
 # Internal email API — uses Brevo, from=zantara@balizero.com
 _EMAIL_API_URL = os.getenv(
@@ -91,6 +92,7 @@ class ProcessAutomationService:
                         client_email=client_data["email"],
                         client_name=client_data["full_name"],
                         practice_data=practice_data,
+                        team_member_email=team_leader_email,
                     )
                     results["client_notified"] = True
                     logger.info(f"Process start email sent to client {client_data['email']}")
@@ -140,6 +142,7 @@ class ProcessAutomationService:
         client_email: str,
         client_name: str,
         practice_data: dict,
+        team_member_email: str | None = None,
     ) -> None:
         """Send warm, human email to client confirming payment and process start."""
         practice_type = practice_data.get("practice_type_name", "Immigration Service")
@@ -187,7 +190,11 @@ P.S. Keep an eye on your WhatsApp—we'll be sending you updates there too! 😊
 🌐 Visit us at www.balizero.com
 """
 
-        await self._send_with_brevo_fallback(client_email, subject, body)
+        await self._send_with_brevo_fallback(
+            client_email, subject, body,
+            cc=team_member_email if team_member_email and team_member_email != client_email else None,
+            include_logo=True,
+        )
 
     async def _send_team_leader_notification(
         self,
@@ -238,16 +245,24 @@ P.S. The client is excited to get started—let's make it a great experience! �
 
     async def _send_with_brevo_fallback(
         self, to_email: str, subject: str, body: str,
+        *,
+        cc: str | None = None,
+        include_logo: bool = False,
     ) -> None:
         """Send email via Brevo (primary), fall back to Zoho if Brevo fails."""
         # Primary: Brevo
         try:
             html_body = body.replace("\n", "<br>")
+            if include_logo:
+                html_body = f"{logo_header_html()}{html_body}"
+            payload: dict = {"to": to_email, "subject": subject, "body": html_body}
+            if cc:
+                payload["cc"] = cc
             async with httpx.AsyncClient(timeout=30.0) as client:
                 response = await client.post(
                     _EMAIL_API_URL,
                     headers={"X-API-Key": _EMAIL_API_KEY},
-                    json={"to": to_email, "subject": subject, "body": html_body},
+                    json=payload,
                 )
                 response.raise_for_status()
             logger.info(f"Email sent to {to_email} via Brevo")

--- a/apps/backend-rag/backend/services/crm/welcome/welcome_email_service.py
+++ b/apps/backend-rag/backend/services/crm/welcome/welcome_email_service.py
@@ -388,7 +388,7 @@ def _build_html(
                   <td align="left" style="padding-bottom:36px;">
                     <table cellspacing="0" cellpadding="0" border="0" style="border-collapse:collapse;"><tr>
                       <td width="112" height="112" style="border-radius:50%;{BG}">
-                        <img src="https://kita.balizero.com/static/balizero-logo-clean.png" width="112" height="112" alt="Bali Zero" style="display:block;border-radius:50%;{BG}" />
+                        <img src="https://kita.balizero.com/static/email/balizero-logo-email.png" width="112" height="112" alt="Bali Zero" style="display:block;border-radius:50%;{BG}" />
                       </td>
                     </tr></table>
                   </td>


### PR DESCRIPTION
## Summary

Follow-up to #470. Applies the same logo header + CC-team-leader pattern to the **4 remaining client-facing emails** that were not covered in the first pass.

## Files modified

| # | File | Email | Logo added | CC team added |
|---|---|---|---|---|
| 1 | `services/crm/process_automation_service.py` | "🎉 Great News {name}! We're Starting Your {practice_type}" (sent on payment confirmed) | ✅ | ✅ |
| 2 | `services/crm/completed_process_service.py` | "🎉 Congratulations {name}! Your {practice_type} is Complete" | ✅ | ✅ |
| 3 | `services/crm/welcome/welcome_email_service.py` | Multilingual welcome (IT/EN/ID/UK/RU) | URL-fix only* | already wired |
| 4 | `services/crm/birthday_notifier_service.py` | Multilingual birthday (5 languages) | ✅ | ❌ (intentional, see below) |

\* The dark-premium template already had a logo, but pointed at `/static/balizero-logo-clean.png` (a different file). Updated to `/static/email/balizero-logo-email.png` so all client emails render the same 240px asset.

## Birthday email — no CC team (intentional)

Birthday wishes are a personal touch from Zantara → client. CCing every birthday in the database would be noise for the team. Documented in commit message.

## Other minor changes

- `completed_process_service.py`: reordered the function so `team_leader_email` is resolved BEFORE the client-email send call (was after, would have NameError'd on the new `team_member_email` kwarg).
- Each modified `_send_with_brevo_fallback` helper got two new optional kwargs: `cc=None` and `include_logo=False`, mirroring the helper added on PR #470 in `waiting_documents_service.py`.
- The Zoho fallback path is left untouched (fallback signature mismatch is a separate pre-existing bug, out of scope here).

## Test plan
- [x] Ruff green on all 4 files
- [x] AST-parse smoke test on all 4
- [x] Verified logo URL `https://kita.balizero.com/static/email/balizero-logo-email.png` returns 200 (already live from PR #470)
- [ ] Post-merge: trigger one kickoff + one completion email on a real practice and confirm Gmail renders the logo + the team member receives the CC
- [ ] Post-merge: trigger a welcome email and confirm logo URL is the new one
- [ ] Post-merge: cross-check next birthday cron run shows the new template

🤖 Generated with [Claude Code](https://claude.com/claude-code)