### PR TITLE
fix(mata-garuda): NER retry-on-error + opt-in content fetcher + bahasa hints (A1+A2+A3)

### DIFF
--- a/apps/mata-garuda/mata_garuda/agents/intel_scraper_bridge.py
+++ b/apps/mata-garuda/mata_garuda/agents/intel_scraper_bridge.py
@@ -12,6 +12,9 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import os
+import re
+import subprocess
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -37,10 +40,95 @@ DEFAULT_MAX_ITEMS = 50
 SEEN_SET_KEY = "garuda:intel_bridge:seen_urls"
 SEEN_TTL_DAYS = 90  # URL history window; older URLs re-publish
 
+# Article-content fetch (opt-in via MATAGARUDA_FETCH_CONTENT=1).
+# Without it NER works on title-only and produces 0-2 entities/article.
+# With it, fetcher hits each URL with curl, strips HTML, keeps first 2KB.
+FETCH_TIMEOUT_S = 10
+FETCH_MAX_BYTES = 2000  # what NER sees as `content`
+_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+)
+_RE_SCRIPT = re.compile(r"<script\b[^<]*(?:(?!</script>)<[^<]*)*</script>", re.I | re.S)
+_RE_STYLE = re.compile(r"<style\b[^<]*(?:(?!</style>)<[^<]*)*</style>", re.I | re.S)
+_RE_TAG = re.compile(r"<[^>]+>")
+_RE_WS = re.compile(r"\s+")
+
 
 def _url_hash(url: str) -> str:
     """Stable short hash for URL dedup in Redis SET."""
     return hashlib.sha256(url.encode("utf-8")).hexdigest()[:16]
+
+
+def _strip_html(html: str | None) -> str:
+    """Reduce raw HTML to plain visible text.
+
+    Minimal-stack rule (no BeautifulSoup): regex-only. Removes
+    <script>/<style> bodies first, then all tags, then collapses
+    whitespace. Lossy but adequate for NER consumption.
+    """
+    if not html:
+        return ""
+    text = _RE_SCRIPT.sub(" ", html)
+    text = _RE_STYLE.sub(" ", text)
+    text = _RE_TAG.sub(" ", text)
+    text = _RE_WS.sub(" ", text)
+    return text.strip()
+
+
+def _fetch_article_text(url: str) -> str | None:
+    """Fetch article HTML via curl, strip to plain text, cap to FETCH_MAX_BYTES.
+
+    Returns None on any transport-level failure (timeout, non-2xx,
+    network, missing curl). Caller treats None as "leave content empty,
+    don't fail the bridge".
+
+    curl-only (no httpx/requests dep — minimal stack rule). Polite UA so
+    we're not flagged as a generic bot. --max-filesize caps the on-the-wire
+    payload so a long-form article doesn't get pulled in full just to
+    discard most of it.
+    """
+    if not url:
+        return None
+    try:
+        result = subprocess.run(
+            [
+                "curl",
+                "-sSL",
+                "--max-time", str(FETCH_TIMEOUT_S),
+                "--max-filesize", "1000000",  # 1 MB on-wire cap
+                "-A", _USER_AGENT,
+                "-w", "\n%{http_code}",
+                "-o", "-",
+                url,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=FETCH_TIMEOUT_S + 2,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        logger.debug("[intel_bridge] fetch timeout/missing curl for %s: %s", url, e)
+        return None
+
+    if result.returncode != 0:
+        logger.debug("[intel_bridge] fetch non-zero (%s): %s", result.returncode, url)
+        return None
+
+    body = result.stdout or ""
+    # The trailing http_code from -w lives on its own line.
+    last_nl = body.rfind("\n")
+    if last_nl == -1:
+        return None
+    http_code = body[last_nl + 1:].strip()
+    body = body[:last_nl]
+    if not http_code.startswith("2"):
+        logger.debug("[intel_bridge] fetch HTTP %s for %s", http_code, url)
+        return None
+
+    text = _strip_html(body)
+    if not text:
+        return None
+    return text[:FETCH_MAX_BYTES]
 
 
 def _already_seen(url_hash: str) -> bool:
@@ -99,6 +187,8 @@ def bridge_intel_scraper(
                 "reason": f"no items newer than {since}",
             }
 
+    fetch_content = os.environ.get("MATAGARUDA_FETCH_CONTENT", "").strip() == "1"
+
     published = 0
     skipped_seen = 0
     failures = 0
@@ -113,13 +203,25 @@ def bridge_intel_scraper(
 
         title = art.get("title", "") or url
         src = art.get("source") or _infer_source(url)
+
+        # Article body — opt-in via MATAGARUDA_FETCH_CONTENT=1. Empty by
+        # default to keep the bridge fast (max_items × FETCH_TIMEOUT_S
+        # worst case otherwise) and to preserve backward compatibility
+        # with the existing pipeline. On fetch failure: leave empty,
+        # don't fail the publish.
+        content = ""
+        if fetch_content:
+            fetched = _fetch_article_text(url)
+            if fetched:
+                content = fetched
+
         fields = {
             "title": title[:300],
             "url": url,
             "source": src,
             "source_type": "intel_scraper",
             "source_agent": AGENT_NAME,
-            "content": "",
+            "content": content,
             "agent": AGENT_NAME,
             "timestamp": art.get("published_at")
             or datetime.now().isoformat(timespec="seconds"),

--- a/apps/mata-garuda/mata_garuda/workers/ner_worker.py
+++ b/apps/mata-garuda/mata_garuda/workers/ner_worker.py
@@ -48,11 +48,22 @@ _NER_PROMPT = """Extract named entities from the text. Return STRICT JSON (no pr
 
 Required keys — each an array of strings (empty array if none found):
   persons         full personal names only (no honorifics alone)
-  organizations   companies, ministries, agencies, NGOs
-  locations       cities, provinces, countries, landmarks
-  laws            statutes, regulations, decrees (e.g. "UU 6/2023", "PP No. 28")
-  monetary_values numeric amounts with currency (e.g. "Rp 500 juta", "USD 1.2M")
-  dates           explicit dates or date ranges ("12 March 2026", "Q2 2026")
+  organizations   companies, ministries, agencies, NGOs.
+                  Indonesian ministry/agency abbreviations are organizations
+                  too: Mendagri, Kemendagri, Kemenkumham, Kemenkeu, Kemlu,
+                  DJP, BKPM, BPN, BPS, BPK, BUMN, DPMPTSP, KPK, OJK, BI,
+                  Bareskrim, Polri, TNI.
+  locations       cities, provinces, countries, landmarks.
+                  NOT currencies (rupiah, USD, IDR are NOT locations).
+  laws            statutes, regulations, decrees. Indonesian formats:
+                  "UU 6/2023", "PP 28/2025", "Perpres 12/2024", "Perda",
+                  "SKB N Menteri", "KEP-71/PJ/2026", "PER-NN/PJ/AAAA",
+                  "PMK 81/2024", "Permendagri", "Perbup".
+                  NOT visa types (e-Tourist Visa, KITAS are NOT laws).
+  monetary_values numeric amounts with currency (e.g. "Rp 500 juta",
+                  "USD 1.2M", "IDR 27.5jt").
+  dates           explicit dates or date ranges ("12 March 2026", "Q2 2026",
+                  "31 Mei 2026").
 
 Include only entities explicitly in the text. Do not infer.
 
@@ -99,16 +110,38 @@ def extract_entities(
     *,
     llm: Callable[..., dict | None] = generate_json,
 ) -> dict:
-    """Extract entities from a single item. Always returns a full dict."""
+    """Extract entities from a single item. Always returns a full dict
+    (empty buckets on transport error). Use extract_entities_status() if
+    you need to distinguish 'LLM ok but no entities' from 'LLM failed'."""
+    entities, _ok = extract_entities_status(title, content, llm=llm)
+    return entities
+
+
+def extract_entities_status(
+    title: str,
+    content: str,
+    *,
+    llm: Callable[..., dict | None] = generate_json,
+) -> tuple[dict, bool]:
+    """Extract entities AND report whether the LLM call succeeded.
+
+    Returns (entities, ok). `ok=False` only on transport-level failure
+    (None response, exception). `ok=True` even when the LLM returned a
+    valid empty dict — that's a legitimate "no entities found" answer
+    and the caller should treat the message as successfully processed.
+    """
     prompt = _NER_PROMPT.format(title=title[:300], content=content[:1000])
 
     try:
         raw = llm(NER_MODEL, prompt, num_predict=400)
     except Exception as e:  # noqa: BLE001 — broad: LLM transport is best-effort
         logger.warning(f"[ner] LLM error: {e}")
-        raw = None
+        return _coerce_entities(None), False
 
-    return _coerce_entities(raw)
+    if raw is None:
+        return _coerce_entities(None), False
+
+    return _coerce_entities(raw), True
 
 
 def run_ner(
@@ -126,7 +159,7 @@ def run_ner(
     publish = publish or (lambda stream, data: stream_publish(stream, data))
     ack = ack or (lambda stream, group, msg_id: stream_ack(stream, group, msg_id))
 
-    stats = {"processed": 0, "extracted": 0, "empty": 0}
+    stats = {"processed": 0, "extracted": 0, "empty": 0, "failed": 0}
 
     items = stream_read_new(
         STREAM_ENRICHED, CONSUMER_GROUP, CONSUMER_NAME, count=max_items
@@ -143,9 +176,17 @@ def run_ner(
             ack(STREAM_ENRICHED, CONSUMER_GROUP, msg_id)
             continue
 
-        entities = extract_entities(
+        entities, ok = extract_entities_status(
             data.get("title", ""), data.get("content", ""), llm=llm
         )
+
+        if not ok:
+            # LLM transport failure — leave msg pending in consumer group
+            # so the next run retries. Do NOT publish a contaminated copy
+            # nor ack: that would mark the item processed forever with
+            # empty entities. (Pre-fix bug: 300 msgs stuck this way.)
+            stats["failed"] += 1
+            continue
 
         # Serialise as JSON string (Redis Streams is flat string-to-string)
         data["entities"] = json.dumps(entities, ensure_ascii=False)
@@ -162,6 +203,7 @@ def run_ner(
 
     logger.info(
         f"[ner] Done: {stats['processed']} processed, "
-        f"{stats['extracted']} with entities, {stats['empty']} empty"
+        f"{stats['extracted']} with entities, {stats['empty']} empty, "
+        f"{stats['failed']} failed (will retry)"
     )
     return stats

--- a/apps/mata-garuda/tests/test_intel_scraper_bridge.py
+++ b/apps/mata-garuda/tests/test_intel_scraper_bridge.py
@@ -191,6 +191,129 @@ def test_bridge_file_missing(tmp_path, monkeypatch):
     fake_publish.assert_not_called()
 
 
+def test_bridge_content_empty_by_default(tmp_path, monkeypatch):
+    """Default behavior: content="" — no network fetch. Backward compat."""
+    monkeypatch.delenv("MATAGARUDA_FETCH_CONTENT", raising=False)
+    _write_articles(
+        tmp_path,
+        [
+            {
+                "url": "https://example.com/a",
+                "title": "A",
+                "published_at": "2999-01-01T00:00:00",
+            }
+        ],
+    )
+    monkeypatch.setenv("BALI_INTEL_SCRAPER_DATA_DIR", str(tmp_path))
+
+    with patch(
+        "mata_garuda.agents.intel_scraper_bridge.stream_publish_redis",
+        return_value="1-0",
+    ) as fake_publish, patch(
+        "mata_garuda.agents.intel_scraper_bridge.redis_cmd",
+        side_effect=_stub_redis_cmd_factory(set()),
+    ):
+        bridge_intel_scraper()
+
+    _, fields = fake_publish.call_args.args
+    assert fields["content"] == ""
+
+
+def test_bridge_fetches_content_when_env_set(tmp_path, monkeypatch):
+    """MATAGARUDA_FETCH_CONTENT=1 enables HTTP fetch + HTML strip."""
+    monkeypatch.setenv("MATAGARUDA_FETCH_CONTENT", "1")
+    _write_articles(
+        tmp_path,
+        [
+            {
+                "url": "https://example.com/a",
+                "title": "A",
+                "published_at": "2999-01-01T00:00:00",
+            }
+        ],
+    )
+    monkeypatch.setenv("BALI_INTEL_SCRAPER_DATA_DIR", str(tmp_path))
+
+    with patch(
+        "mata_garuda.agents.intel_scraper_bridge.stream_publish_redis",
+        return_value="1-0",
+    ) as fake_publish, patch(
+        "mata_garuda.agents.intel_scraper_bridge.redis_cmd",
+        side_effect=_stub_redis_cmd_factory(set()),
+    ), patch(
+        "mata_garuda.agents.intel_scraper_bridge._fetch_article_text",
+        return_value="Indonesia announced new visa rules on 12 March 2026.",
+    ) as fake_fetch:
+        bridge_intel_scraper()
+
+    fake_fetch.assert_called_once_with("https://example.com/a")
+    _, fields = fake_publish.call_args.args
+    assert "Indonesia announced new visa rules" in fields["content"]
+
+
+def test_bridge_fetch_failure_leaves_content_empty(tmp_path, monkeypatch):
+    """If _fetch_article_text returns None (network/4xx/5xx), publish still
+    proceeds with content="" — graceful degradation, not a hard failure."""
+    monkeypatch.setenv("MATAGARUDA_FETCH_CONTENT", "1")
+    _write_articles(
+        tmp_path,
+        [
+            {
+                "url": "https://example.com/a",
+                "title": "A",
+                "published_at": "2999-01-01T00:00:00",
+            }
+        ],
+    )
+    monkeypatch.setenv("BALI_INTEL_SCRAPER_DATA_DIR", str(tmp_path))
+
+    with patch(
+        "mata_garuda.agents.intel_scraper_bridge.stream_publish_redis",
+        return_value="1-0",
+    ) as fake_publish, patch(
+        "mata_garuda.agents.intel_scraper_bridge.redis_cmd",
+        side_effect=_stub_redis_cmd_factory(set()),
+    ), patch(
+        "mata_garuda.agents.intel_scraper_bridge._fetch_article_text",
+        return_value=None,
+    ):
+        result = bridge_intel_scraper()
+
+    assert result["case_resolved"] is True
+    assert result["published"] == 1
+    _, fields = fake_publish.call_args.args
+    assert fields["content"] == ""
+
+
+def test_strip_html_removes_tags_scripts_and_collapses_whitespace():
+    from mata_garuda.agents.intel_scraper_bridge import _strip_html
+    html = """
+    <html><head><script>var x=1;</script><style>body{}</style><title>T</title></head>
+    <body>
+      <h1>Headline</h1>
+      <p>Paragraph one.</p>
+      <p>Paragraph    two.</p>
+      <script>alert('x');</script>
+    </body></html>
+    """
+    out = _strip_html(html)
+    assert "var x" not in out
+    assert "body{}" not in out
+    assert "alert" not in out
+    assert "<" not in out and ">" not in out
+    assert "Headline" in out
+    assert "Paragraph one." in out
+    assert "Paragraph two." in out  # collapsed whitespace
+    # No giant blank runs
+    assert "    " not in out
+
+
+def test_strip_html_handles_empty_input():
+    from mata_garuda.agents.intel_scraper_bridge import _strip_html
+    assert _strip_html("") == ""
+    assert _strip_html(None) == ""  # type: ignore[arg-type]
+
+
 def test_agent_registered_and_has_genome():
     import mata_garuda.agents.intel_scraper_bridge  # noqa: F401
     from mata_garuda.registry import get_agent

--- a/apps/mata-garuda/tests/test_ner_worker.py
+++ b/apps/mata-garuda/tests/test_ner_worker.py
@@ -103,28 +103,83 @@ def test_run_ner_publishes_entities_and_acks():
             ack=lambda s, g, m: acked.append(m),
         )
 
-    assert stats == {"processed": 1, "extracted": 1, "empty": 0}
+    assert stats == {"processed": 1, "extracted": 1, "empty": 0, "failed": 0}
     assert published[0]["ner_completed"] == "true"
     entities = json.loads(published[0]["entities"])
     assert entities["persons"] == ["A"]
     assert acked == ["1-0"]
 
 
-def test_run_ner_counts_empty_when_no_entities_found():
+def test_run_ner_counts_empty_when_llm_returns_empty_dict():
+    """LLM responded with valid empty dict (genuine 'no entities found') —
+    msg is acked + ner_completed=true so we don't retry forever on truly
+    empty content."""
     items = [{"id": "1-0", "data": {"title": "t", "content": "c"}}]
     published = []
+    acked = []
+
+    empty_but_valid = {
+        "persons": [], "organizations": [], "locations": [],
+        "laws": [], "monetary_values": [], "dates": [],
+    }
 
     with patch.object(ner_worker, "stream_read_new", return_value=items):
         stats = ner_worker.run_ner(
-            llm=lambda *a, **kw: None,
+            llm=lambda *a, **kw: empty_but_valid,
             publish=lambda s, d: published.append(dict(d)) or "ok",
-            ack=lambda s, g, m: None,
+            ack=lambda s, g, m: acked.append(m),
         )
 
     assert stats["empty"] == 1
     assert stats["extracted"] == 0
+    assert stats["failed"] == 0
+    assert acked == ["1-0"]
+    assert published[0]["ner_completed"] == "true"
     entities = json.loads(published[0]["entities"])
     assert all(v == [] for v in entities.values())
+
+
+def test_run_ner_does_not_ack_on_llm_error():
+    """LLM transport error (None or exception) must NOT mark ner_completed
+    nor ack the msg — it stays pending in the consumer group for retry on
+    the next run. Counted as 'failed' for observability."""
+    items = [{"id": "7-0", "data": {"title": "t", "content": "c"}}]
+    published = []
+    acked = []
+
+    with patch.object(ner_worker, "stream_read_new", return_value=items):
+        stats = ner_worker.run_ner(
+            llm=lambda *a, **kw: None,  # transport-level failure
+            publish=lambda s, d: published.append(dict(d)) or "ok",
+            ack=lambda s, g, m: acked.append(m),
+        )
+
+    assert stats["failed"] == 1
+    assert stats["empty"] == 0
+    assert stats["extracted"] == 0
+    assert published == []
+    assert acked == []
+
+
+def test_run_ner_does_not_ack_when_llm_raises():
+    """Same protection on raised exception path — msg must stay pending."""
+    items = [{"id": "8-0", "data": {"title": "t", "content": "c"}}]
+    published = []
+    acked = []
+
+    def boom(*a, **kw):
+        raise RuntimeError("ollama unreachable")
+
+    with patch.object(ner_worker, "stream_read_new", return_value=items):
+        stats = ner_worker.run_ner(
+            llm=boom,
+            publish=lambda s, d: published.append(dict(d)) or "ok",
+            ack=lambda s, g, m: acked.append(m),
+        )
+
+    assert stats["failed"] == 1
+    assert published == []
+    assert acked == []
 
 
 def test_run_ner_skips_already_processed():
@@ -144,7 +199,7 @@ def test_run_ner_skips_already_processed():
             ack=lambda s, g, m: acked.append(m),
         )
 
-    assert stats == {"processed": 1, "extracted": 0, "empty": 0}
+    assert stats == {"processed": 1, "extracted": 0, "empty": 0, "failed": 0}
     assert published == []
     assert acked == ["9-0"]
 
@@ -152,4 +207,21 @@ def test_run_ner_skips_already_processed():
 def test_run_ner_empty_stream():
     with patch.object(ner_worker, "stream_read_new", return_value=[]):
         stats = ner_worker.run_ner()
-    assert stats == {"processed": 0, "extracted": 0, "empty": 0}
+    assert stats == {"processed": 0, "extracted": 0, "empty": 0, "failed": 0}
+
+
+def test_ner_prompt_guides_indonesian_government_abbreviations():
+    """Prompt must hint qwen3.5:9b about Indonesian government abbreviations
+    (Mendagri, Kemenkumham, DJP, BKPM, SKB, KEP-NN/PJ, UU/PP/Perpres). Without
+    these hints the model under-extracts on bahasa governmental titles
+    (verified empirically 2026-05-06: 'Mendagri Tandatangani SKB 7 Menteri'
+    yielded 0 entities)."""
+    p = ner_worker._NER_PROMPT
+    org_hints = ["Mendagri", "Kemenkumham", "DJP", "BKPM"]
+    assert any(h in p for h in org_hints), (
+        "prompt must hint at Indonesian ministry/agency abbreviations"
+    )
+    law_hints = ["SKB", "KEP-", "PER-", "Perpres", "Perda"]
+    assert any(h in p for h in law_hints), (
+        "prompt must hint at Indonesian decree formats (SKB, KEP/PER, Perpres, Perda)"
+    )


### PR DESCRIPTION
## Summary

Three fixes to the mata-garuda NER pipeline, surfaced after `qwen3.5:9b` was found missing on Mini and the worker had silently been processing 300 messages with empty entities.

- **A1** — `ner_worker.py` no longer marks `ner_completed=true` on LLM transport error. New `extract_entities_status()` returns `(entities, ok)`; `run_ner` skips ack and counts `failed` so the message stays pending in the consumer group for retry on the next tick. Pre-fix: 300 contaminated msgs in `garuda:enriched` were ack-ed forever with empty entities.
- **A2** — `intel_scraper_bridge.py` gains opt-in content fetcher behind `MATAGARUDA_FETCH_CONTENT=1`. Previously hardcoded `content=""`. Now: `curl` + regex HTML strip + 2 KB cap. On fetch failure (timeout/non-2xx/network), content stays empty — bridge never blocks publish. Empirical comparison on 3 real URLs (Harvey Law / Bali Nusa Nirwana / Imigrasi gov): **6-18× more entities** extracted by NER vs title-only. Default OFF preserves backward compat.
- **A3** — NER prompt enriched with hints for Indonesian governmental abbreviations (Mendagri, Kemendagri, Kemenkumham, DJP, BKPM, BPN, BUMN, KPK, OJK, BI, ...) and decree formats (UU, PP, Perpres, Perda, SKB, KEP-NN/PJ/AAAA, PMK, Permendagri, Perbup). Plus negative hints: rupiah/USD are NOT locations, e-Tourist Visa/KITAS are NOT laws. Verified: title `Mendagri Tandatangani SKB 7 Menteri...` now extracts 2 entities (was 0 pre-fix).

Minimal-stack rule honored throughout: regex-only HTML strip, curl-only fetch, no new deps.

## Test plan

- [x] 14/14 `test_ner_worker.py` green (4 new for A1, 1 new for A3)
- [x] 14/14 `test_intel_scraper_bridge.py` green (5 new for A2)
- [x] 599/600 mata-garuda full suite green (1 preexisting `test_create_sentinel_cell` failure, sqlite tmp path, unrelated)
- [x] Empirical NER verification on Mini against real qwen3.5:9b
- [x] Empirical fetcher verification on 3 real URLs (latency 0.65-2.51s, 2 KB content extracted)

## Notes

- The bug was discovered when the NER LaunchAgent on Mini reported `processed: 200, extracted: 0, empty: 150` — root cause was `qwen3.5:9b` not installed on Mini. Pulling the model unblocked the pipeline; A1+A2+A3 close the design gaps that let the silent-failure mode persist for so long.
- 300 contaminated msgs in `garuda:enriched` are left as-is (decision: not worth force-reprocess; future msgs flow correctly via A1).
- To activate A2 in production: set `MATAGARUDA_FETCH_CONTENT=1` in the `com.matagaruda.intel-bridge.daily.plist` `EnvironmentVariables` on Mini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)