### PR TITLE
feat(email): elegant team template + Tax Report palette + WhatsApp-only docs

### DIFF
--- a/apps/backend-rag/backend/data/.gitignore
+++ b/apps/backend-rag/backend/data/.gitignore
@@ -10,5 +10,9 @@
 # Public spatial data — safe to commit
 !master_building_codes_complete.json
 
+# Public Bali Zero price lists — safe to commit
+!bali_zero_official_prices_2025.json
+!bali_zero_official_prices_2026.json
+
 # Keep this directory in git
 !.gitignore

--- a/apps/backend-rag/backend/data/bali_zero_official_prices_2026.json
+++ b/apps/backend-rag/backend/data/bali_zero_official_prices_2026.json
@@ -1,0 +1,975 @@
+{
+  "version": "2026.1",
+  "effective_date": "2026-01-01",
+  "metadata": {
+    "currency": "IDR",
+    "contact": {
+      "email": "zero@balizero.com",
+      "whatsapp": "+62 821 31 07 363",
+      "wa_link": "https://wa.me/628213107363",
+      "location": "Kerobokan, Bali, Indonesia",
+      "website": "balizero.com"
+    },
+    "last_updated": "2026-05-06"
+  },
+  "services": {
+    "single_entry_visas": {
+      "C1 Tourism": {
+        "name": "C1 Tourism",
+        "price": "2.300.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "Single entry, 60 days",
+        "description_en": "Tourist visa, single entry, valid 60 days. Cannot be used for work or business activities.",
+        "icon_id": "visa-tourism"
+      },
+      "C2 Business": {
+        "name": "C2 Business",
+        "price": "3.600.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "Single entry, 60 days",
+        "description_en": "Business visa, single entry, valid 60 days. Suited to business meetings, negotiations and non-employment activities.",
+        "icon_id": "visa-business"
+      },
+      "C7A&B Music/Art": {
+        "name": "C7A&B Music/Art",
+        "price": "4.500.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "Including Urgent",
+        "description_en": "Single-entry visa for performing artists, musicians and cultural workers visiting Indonesia for short-term events.",
+        "icon_id": "visa-art"
+      },
+      "C18 Work Trial": {
+        "name": "C18 Work Trial",
+        "price": "5.500.000 IDR",
+        "tier_range": null,
+        "duration": "90 days",
+        "validity": "",
+        "notes": "Work trial / skill assessment",
+        "description_en": "Single-entry visa for a 90-day work trial or skill assessment with an Indonesian employer prior to a full work permit.",
+        "icon_id": "visa-worktrial"
+      },
+      "C22A&B Internship (60 Days)": {
+        "name": "C22A&B Internship (60 Days)",
+        "price": "4.800.000 IDR",
+        "tier_range": null,
+        "duration": "60 days",
+        "validity": "",
+        "notes": "",
+        "description_en": "Single-entry internship visa for foreign trainees, valid 60 days, sponsored by an Indonesian host organisation.",
+        "icon_id": "visa-internship"
+      },
+      "C22A&B Internship (180 Days)": {
+        "name": "C22A&B Internship (180 Days)",
+        "price": "5.800.000 IDR",
+        "tier_range": null,
+        "duration": "180 days",
+        "validity": "",
+        "notes": "",
+        "description_en": "Single-entry internship visa for foreign trainees, valid 180 days, sponsored by an Indonesian host organisation.",
+        "icon_id": "visa-internship"
+      }
+    },
+    "visa_extensions": {
+      "C1 Tourism Extension": {
+        "name": "C1 Tourism Extension",
+        "price": "1.700.000 IDR",
+        "tier_range": null,
+        "duration": "30 days",
+        "validity": "",
+        "notes": "Extension of C1 Tourism visa, +30 days",
+        "description_en": "Onshore extension of the C1 Tourism visa for an additional 30 days, processed at Indonesian immigration.",
+        "icon_id": "visa-extension"
+      }
+    },
+    "multiple_entry_visas": {
+      "D1 Tourism (1 Year)": {
+        "name": "D1 Tourism (1 Year)",
+        "price": "6.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "1 Year",
+        "notes": "",
+        "description_en": "Multiple-entry tourist visa valid 1 year, allowing repeated visits with a maximum stay per entry as set by immigration.",
+        "icon_id": "visa-multiple"
+      },
+      "D1 Tourism (2 Years)": {
+        "name": "D1 Tourism (2 Years)",
+        "price": "8.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "2 Years",
+        "notes": "",
+        "description_en": "Multiple-entry tourist visa valid 2 years, allowing repeated visits with a maximum stay per entry as set by immigration.",
+        "icon_id": "visa-multiple"
+      },
+      "D1 Tourism (5 Years)": {
+        "name": "D1 Tourism (5 Years)",
+        "price": "14.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "5 Years",
+        "notes": "",
+        "description_en": "Multiple-entry tourist visa valid 5 years, allowing repeated visits with a maximum stay per entry as set by immigration.",
+        "icon_id": "visa-multiple"
+      },
+      "D12 Business Investigation (1 Year)": {
+        "name": "D12 Business Investigation (1 Year)",
+        "price": "7.500.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "1 Year",
+        "notes": "",
+        "description_en": "Multiple-entry business investigation visa valid 1 year, for investors and business representatives exploring opportunities in Indonesia.",
+        "icon_id": "visa-investigation"
+      },
+      "D12 Business Investigation (2 Years)": {
+        "name": "D12 Business Investigation (2 Years)",
+        "price": "10.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "2 Years",
+        "notes": "",
+        "description_en": "Multiple-entry business investigation visa valid 2 years, for investors and business representatives exploring opportunities in Indonesia.",
+        "icon_id": "visa-investigation"
+      }
+    },
+    "kitas_permits": {
+      "Working KITAS (Altus/Onshore)": {
+        "name": "Working KITAS (Altus/Onshore)",
+        "price": "36.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "1 year",
+        "notes": "",
+        "description_en": "Standard work permit KITAS sponsored by an Indonesian employer. Onshore process via Altus, suited to candidates already in Indonesia.",
+        "icon_id": "kitas-working"
+      },
+      "Working KITAS (Offshore)": {
+        "name": "Working KITAS (Offshore)",
+        "price": "34.500.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "1 year",
+        "notes": "",
+        "description_en": "Standard work permit KITAS sponsored by an Indonesian employer. Offshore process for candidates outside Indonesia at time of application.",
+        "icon_id": "kitas-working"
+      },
+      "Working KITAS (Extend)": {
+        "name": "Working KITAS (Extend)",
+        "price": "31.500.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Onshore extension of an existing Working KITAS sponsored by an Indonesian employer.",
+        "icon_id": "kitas-working"
+      },
+      "Investor KITAS 2 Years (Altus/Onshore)": {
+        "name": "Investor KITAS 2 Years (Altus/Onshore)",
+        "price": "19.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Investor KITAS valid 2 years for shareholders of a PT PMA. Onshore process via Altus.",
+        "icon_id": "kitas-investor"
+      },
+      "Investor KITAS 2 Years (Offshore)": {
+        "name": "Investor KITAS 2 Years (Offshore)",
+        "price": "17.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Investor KITAS valid 2 years for shareholders of a PT PMA. Offshore process for applicants outside Indonesia.",
+        "icon_id": "kitas-investor"
+      },
+      "Investor KITAS 2 Years (Extend)": {
+        "name": "Investor KITAS 2 Years (Extend)",
+        "price": "18.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Onshore extension of an existing 2-year Investor KITAS for shareholders of a PT PMA.",
+        "icon_id": "kitas-investor"
+      },
+      "Freelance E23 (Altus/Onshore)": {
+        "name": "Freelance E23 (Altus/Onshore)",
+        "price": "27.500.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "6 months",
+        "notes": "",
+        "description_en": "Freelance E23 KITAS valid 6 months, sponsored work permit for independent professionals. Onshore process via Altus.",
+        "icon_id": "kitas-freelance"
+      },
+      "Freelance E23 (Offshore)": {
+        "name": "Freelance E23 (Offshore)",
+        "price": "25.800.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "6 months",
+        "notes": "",
+        "description_en": "Freelance E23 KITAS valid 6 months, sponsored work permit for independent professionals. Offshore process for applicants outside Indonesia.",
+        "icon_id": "kitas-freelance"
+      },
+      "E33G Remote Worker (Altus/Onshore)": {
+        "name": "E33G Remote Worker (Altus/Onshore)",
+        "price": "14.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Digital nomad KITAS for remote workers employed by foreign companies. Onshore process via Altus, valid 1 year.",
+        "icon_id": "kitas-remote"
+      },
+      "E33G Remote Worker (Offshore)": {
+        "name": "E33G Remote Worker (Offshore)",
+        "price": "13.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "Including Urgent",
+        "description_en": "Digital nomad KITAS for remote workers employed by foreign companies. Processed from outside Indonesia, valid 1 year.",
+        "icon_id": "kitas-remote"
+      },
+      "E33G Remote Worker (Extend)": {
+        "name": "E33G Remote Worker (Extend)",
+        "price": "10.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Onshore extension of an existing E33G Remote Worker KITAS.",
+        "icon_id": "kitas-remote"
+      },
+      "Spouse 1 Year (Altus/Onshore)": {
+        "name": "Spouse 1 Year (Altus/Onshore)",
+        "price": "13.500.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Spouse KITAS valid 1 year for foreign spouses of Indonesian citizens or KITAS/KITAP holders. Onshore process via Altus.",
+        "icon_id": "kitas-spouse"
+      },
+      "Spouse 1 Year (Offshore)": {
+        "name": "Spouse 1 Year (Offshore)",
+        "price": "11.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Spouse KITAS valid 1 year for foreign spouses of Indonesian citizens or KITAS/KITAP holders. Offshore process for applicants outside Indonesia.",
+        "icon_id": "kitas-spouse"
+      },
+      "Spouse 1 Year (Extend)": {
+        "name": "Spouse 1 Year (Extend)",
+        "price": "9.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Onshore extension of an existing 1-year Spouse KITAS.",
+        "icon_id": "kitas-spouse"
+      },
+      "Spouse 2 Years (Altus/Onshore)": {
+        "name": "Spouse 2 Years (Altus/Onshore)",
+        "price": "18.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Spouse KITAS valid 2 years for foreign spouses of Indonesian citizens or KITAS/KITAP holders. Onshore process via Altus.",
+        "icon_id": "kitas-spouse"
+      },
+      "Spouse 2 Years (Offshore)": {
+        "name": "Spouse 2 Years (Offshore)",
+        "price": "15.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Spouse KITAS valid 2 years for foreign spouses of Indonesian citizens or KITAS/KITAP holders. Offshore process for applicants outside Indonesia.",
+        "icon_id": "kitas-spouse"
+      },
+      "Spouse 2 Years (Extend)": {
+        "name": "Spouse 2 Years (Extend)",
+        "price": "15.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Onshore extension of an existing 2-year Spouse KITAS.",
+        "icon_id": "kitas-spouse"
+      },
+      "Dependent 1 Year (Altus/Onshore)": {
+        "name": "Dependent 1 Year (Altus/Onshore)",
+        "price": "13.500.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Dependent KITAS valid 1 year for children or dependent family members of a primary KITAS/KITAP holder. Onshore process via Altus.",
+        "icon_id": "kitas-dependent"
+      },
+      "Dependent 1 Year (Offshore)": {
+        "name": "Dependent 1 Year (Offshore)",
+        "price": "11.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Dependent KITAS valid 1 year for children or dependent family members of a primary KITAS/KITAP holder. Offshore process for applicants outside Indonesia.",
+        "icon_id": "kitas-dependent"
+      },
+      "Dependent 1 Year (Extend)": {
+        "name": "Dependent 1 Year (Extend)",
+        "price": "9.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Onshore extension of an existing 1-year Dependent KITAS.",
+        "icon_id": "kitas-dependent"
+      },
+      "Dependent 2 Years (Altus/Onshore)": {
+        "name": "Dependent 2 Years (Altus/Onshore)",
+        "price": "18.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Dependent KITAS valid 2 years for children or dependent family members of a primary KITAS/KITAP holder. Onshore process via Altus.",
+        "icon_id": "kitas-dependent"
+      },
+      "Dependent 2 Years (Offshore)": {
+        "name": "Dependent 2 Years (Offshore)",
+        "price": "15.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Dependent KITAS valid 2 years for children or dependent family members of a primary KITAS/KITAP holder. Offshore process for applicants outside Indonesia.",
+        "icon_id": "kitas-dependent"
+      },
+      "Dependent 2 Years (Extend)": {
+        "name": "Dependent 2 Years (Extend)",
+        "price": "15.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Onshore extension of an existing 2-year Dependent KITAS.",
+        "icon_id": "kitas-dependent"
+      },
+      "Retirement (Altus/Onshore)": {
+        "name": "Retirement (Altus/Onshore)",
+        "price": "16.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Retirement KITAS for foreign nationals 60+ meeting income requirements. Onshore process via Altus.",
+        "icon_id": "kitas-retirement"
+      },
+      "Retirement (Offshore)": {
+        "name": "Retirement (Offshore)",
+        "price": "14.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Retirement KITAS for foreign nationals 60+ meeting income requirements. Offshore process for applicants outside Indonesia.",
+        "icon_id": "kitas-retirement"
+      },
+      "Retirement (Extend)": {
+        "name": "Retirement (Extend)",
+        "price": "10.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Onshore extension of an existing Retirement KITAS.",
+        "icon_id": "kitas-retirement"
+      }
+    },
+    "kitap_permits": {
+      "Investor KITAP + MERP": {
+        "name": "Investor KITAP + MERP",
+        "price": "55.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Permanent residence permit (KITAP) for investors holding shares in a PT PMA, bundled with Multiple Exit Re-entry Permit (MERP).",
+        "icon_id": "kitap-permanent"
+      },
+      "Dependent KITAP + MERP": {
+        "name": "Dependent KITAP + MERP",
+        "price": "33.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Permanent residence permit (KITAP) for dependent family members of a primary KITAP holder, bundled with Multiple Exit Re-entry Permit (MERP).",
+        "icon_id": "kitap-permanent"
+      },
+      "Retirement KITAP + MERP": {
+        "name": "Retirement KITAP + MERP",
+        "price": "45.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Permanent residence permit (KITAP) for retirees who have already held a Retirement KITAS, bundled with Multiple Exit Re-entry Permit (MERP).",
+        "icon_id": "kitap-permanent"
+      },
+      "MERP 1 Year": {
+        "name": "MERP 1 Year",
+        "price": "4.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "1 year",
+        "notes": "",
+        "description_en": "Multiple Exit Re-entry Permit valid 1 year for KITAP holders, allowing repeated travel without losing residence status.",
+        "icon_id": "kitap-merp"
+      },
+      "MERP 2 Year": {
+        "name": "MERP 2 Year",
+        "price": "5.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "2 years",
+        "notes": "",
+        "description_en": "Multiple Exit Re-entry Permit valid 2 years for KITAP holders, allowing repeated travel without losing residence status.",
+        "icon_id": "kitap-merp"
+      }
+    },
+    "tax_accounting": {
+      "monthly_tax_basic": {
+        "Tier 0-50": {
+          "name": "Monthly Tax Report — 0 to 50 transactions (without LKPM & Annual)",
+          "price": "",
+          "tier_range": ["1.800.000 IDR", "2.000.000 IDR"],
+          "duration": "",
+          "validity": "monthly",
+          "notes": "Bank + Cash transactions combined. LKPM and Annual Tax NOT included.",
+          "description_en": "Monthly bookkeeping and tax filing for companies with low transaction volume. See section VI.4 for LKPM and Annual Tax stand-alone fees.",
+          "icon_id": "tax-monthly"
+        },
+        "Tier 50-100": {
+          "name": "Monthly Tax Report — 50 to 100 transactions (without LKPM & Annual)",
+          "price": "",
+          "tier_range": ["2.500.000 IDR", "3.000.000 IDR"],
+          "duration": "",
+          "validity": "monthly",
+          "notes": "Bank + Cash transactions combined. LKPM and Annual Tax NOT included.",
+          "description_en": "Monthly bookkeeping and tax filing for companies with moderate transaction volume. See section VI.4 for LKPM and Annual Tax stand-alone fees.",
+          "icon_id": "tax-monthly"
+        },
+        "Tier 100-200": {
+          "name": "Monthly Tax Report — 100 to 200 transactions (without LKPM & Annual)",
+          "price": "",
+          "tier_range": ["3.500.000 IDR", "4.500.000 IDR"],
+          "duration": "",
+          "validity": "monthly",
+          "notes": "Bank + Cash transactions combined. LKPM and Annual Tax NOT included.",
+          "description_en": "Monthly bookkeeping and tax filing for companies with higher transaction volume. See section VI.4 for LKPM and Annual Tax stand-alone fees.",
+          "icon_id": "tax-monthly"
+        },
+        "Tier 200+": {
+          "name": "Monthly Tax Report — more than 200 transactions (without LKPM & Annual)",
+          "price": "5.000.000 IDR",
+          "tier_range": null,
+          "duration": "",
+          "validity": "monthly",
+          "notes": "Bank + Cash transactions combined. LKPM and Annual Tax NOT included.",
+          "description_en": "Monthly bookkeeping and tax filing for companies with high transaction volume. See section VI.4 for LKPM and Annual Tax stand-alone fees.",
+          "icon_id": "tax-monthly"
+        }
+      },
+      "monthly_tax_bundled": {
+        "Tier 0-50": {
+          "name": "Monthly Tax Report — 0 to 50 transactions (incl. LKPM & Annual)",
+          "price": "2.500.000 IDR",
+          "tier_range": null,
+          "duration": "",
+          "validity": "monthly",
+          "notes": "Includes LKPM monthly contribution and Annual Tax report.",
+          "description_en": "Bundled monthly bookkeeping, LKPM filing and Annual Tax report for companies with low transaction volume.",
+          "icon_id": "tax-monthly"
+        },
+        "Tier 50-100": {
+          "name": "Monthly Tax Report — 50 to 100 transactions (incl. LKPM & Annual)",
+          "price": "3.500.000 IDR",
+          "tier_range": null,
+          "duration": "",
+          "validity": "monthly",
+          "notes": "Includes LKPM monthly contribution and Annual Tax report.",
+          "description_en": "Bundled monthly bookkeeping, LKPM filing and Annual Tax report for companies with moderate transaction volume.",
+          "icon_id": "tax-monthly"
+        },
+        "Tier 100-200": {
+          "name": "Monthly Tax Report — 100 to 200 transactions (incl. LKPM & Annual)",
+          "price": "4.500.000 IDR",
+          "tier_range": null,
+          "duration": "",
+          "validity": "monthly",
+          "notes": "Includes LKPM monthly contribution and Annual Tax report.",
+          "description_en": "Bundled monthly bookkeeping, LKPM filing and Annual Tax report for companies with higher transaction volume.",
+          "icon_id": "tax-monthly"
+        },
+        "Tier 200+": {
+          "name": "Monthly Tax Report — more than 200 transactions (incl. LKPM & Annual)",
+          "price": "6.500.000 IDR",
+          "tier_range": null,
+          "duration": "",
+          "validity": "monthly",
+          "notes": "Includes LKPM monthly contribution and Annual Tax report. Companies with more than 200 transactions per year must use monthly bookkeeping.",
+          "description_en": "Bundled monthly bookkeeping, LKPM filing and Annual Tax report for companies with high transaction volume.",
+          "icon_id": "tax-monthly"
+        }
+      },
+      "annual_basic_packages": {
+        "Package A": {
+          "name": "Annual Basic Package A",
+          "price": "6.000.000 IDR",
+          "tier_range": null,
+          "duration": "",
+          "validity": "yearly",
+          "notes": "Does not include Annual Personal Tax report. No discount applies.",
+          "description_en": "Up to 100 transactions per year. Includes Income Tax calculation only and yearly Financial Report for Annual Tax submission.",
+          "icon_id": "tax-annual"
+        },
+        "Package B": {
+          "name": "Annual Basic Package B",
+          "price": "9.000.000 IDR",
+          "tier_range": null,
+          "duration": "",
+          "validity": "yearly",
+          "notes": "Does not include Annual Personal Tax report. No discount applies.",
+          "description_en": "100-200 transactions per year. Income Tax only + yearly Financial Report.",
+          "icon_id": "tax-annual"
+        },
+        "Package C": {
+          "name": "Annual Basic Package C",
+          "price": "12.000.000 IDR",
+          "tier_range": null,
+          "duration": "",
+          "validity": "yearly",
+          "notes": "Does not include Annual Personal Tax report. No discount applies.",
+          "description_en": "Up to 100 transactions per year. Income Tax + PPH 21 OR PPH Sewa (choose one) + yearly Financial Report.",
+          "icon_id": "tax-annual"
+        },
+        "Package D": {
+          "name": "Annual Basic Package D",
+          "price": "15.000.000 IDR",
+          "tier_range": null,
+          "duration": "",
+          "validity": "yearly",
+          "notes": "Does not include Annual Personal Tax report. No discount applies.",
+          "description_en": "100-200 transactions per year. Income Tax + PPH 21 OR PPH Sewa (choose one) + yearly Financial Report.",
+          "icon_id": "tax-annual"
+        },
+        "Annual Company ZERO": {
+          "name": "Annual Company ZERO",
+          "price": "3.000.000 IDR",
+          "tier_range": null,
+          "duration": "",
+          "validity": "yearly",
+          "notes": "No transactions in or out.",
+          "description_en": "Yearly Financial Report only — for dormant companies with no transactions.",
+          "icon_id": "tax-annual"
+        }
+      },
+      "annual_standalone": {
+        "LKPM Yearly Report": {
+          "name": "LKPM Yearly Report",
+          "price": "4.000.000 IDR",
+          "tier_range": null,
+          "duration": "",
+          "validity": "yearly",
+          "notes": "",
+          "description_en": "Stand-alone yearly LKPM (investment realisation) report submitted to BKPM, required for all PT PMA companies.",
+          "icon_id": "tax-lkpm"
+        },
+        "Annual Tax Company": {
+          "name": "Annual Tax Company",
+          "price": "4.000.000 IDR",
+          "tier_range": null,
+          "duration": "",
+          "validity": "yearly",
+          "notes": "",
+          "description_en": "Stand-alone Annual Corporate Tax report (SPT Tahunan PPh Badan) for Indonesian companies.",
+          "icon_id": "tax-annual"
+        },
+        "Annual Tax Personal": {
+          "name": "Annual Tax Personal",
+          "price": "1.000.000 IDR",
+          "tier_range": null,
+          "duration": "",
+          "validity": "yearly",
+          "notes": "Per person.",
+          "description_en": "Stand-alone Annual Personal Tax report (SPT Tahunan PPh Orang Pribadi) for individual taxpayers.",
+          "icon_id": "tax-personal"
+        },
+        "Annual Tax Personal (additional)": {
+          "name": "Annual Tax Personal (additional)",
+          "price": "1.500.000 IDR",
+          "tier_range": null,
+          "duration": "",
+          "validity": "yearly",
+          "notes": "Each additional person beyond the first.",
+          "description_en": "Stand-alone Annual Personal Tax report for additional persons beyond the first taxpayer in the same engagement.",
+          "icon_id": "tax-personal"
+        }
+      }
+    },
+    "company_services": {
+      "New Company (PT PMA)": {
+        "name": "New Company (PT PMA)",
+        "price": "20.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Full incorporation of a new Indonesian foreign-owned limited company (PT PMA), including notarial deed, BKPM/OSS registration and tax ID issuance.",
+        "icon_id": "company-pma"
+      },
+      "Virtual Office": {
+        "name": "Virtual Office",
+        "price": "5.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "Only for clients without their own commercial premises.",
+        "description_en": "Virtual office address for company registration and correspondence, suited to clients without dedicated commercial premises.",
+        "icon_id": "company-virtual"
+      },
+      "Akta Perubahan (Revision Company)": {
+        "name": "Akta Perubahan (Revision Company)",
+        "price": "Depend (Contact for quote)",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "Required when changing company address, directors, or business activities.",
+        "description_en": "Notarial amendment deed (Akta Perubahan) for an existing Indonesian company. Pricing depends on scope of changes.",
+        "icon_id": "company-akta"
+      }
+    },
+    "consultant_services": {
+      "Close PMA Company": {
+        "name": "Close PMA Company",
+        "price": "",
+        "tier_range": ["6.000.000 IDR", "7.500.000 IDR"],
+        "duration": "Process up to 1 year",
+        "validity": "",
+        "notes": "",
+        "description_en": "Full closure and deregistration of an Indonesian foreign-owned limited company (PT PMA), including notarial deed, BKPM and tax authority deregistration.",
+        "icon_id": "company-close"
+      },
+      "NPWPD Registration": {
+        "name": "NPWPD Registration",
+        "price": "2.500.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "Per location.",
+        "description_en": "Local tax registration (Nomor Pokok Wajib Pajak Daerah) at the regency or city tax office, required per business location in Indonesia.",
+        "icon_id": "consultant-npwpd"
+      },
+      "BPJS Employee (Tenaga Kerja)": {
+        "name": "BPJS Employee (Tenaga Kerja)",
+        "price": "2.500.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Registration with BPJS Ketenagakerjaan, the mandatory Indonesian social security scheme for employees covering accident, old-age and pension benefits.",
+        "icon_id": "consultant-bpjs-tk"
+      },
+      "BPJS Insurance (Kesehatan)": {
+        "name": "BPJS Insurance (Kesehatan)",
+        "price": "2.500.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Registration with BPJS Kesehatan, the mandatory Indonesian national health insurance scheme.",
+        "icon_id": "consultant-bpjs-kes"
+      },
+      "NPWP Personal + Coretax Activation": {
+        "name": "NPWP Personal + Coretax Activation",
+        "price": "1.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "Per person.",
+        "description_en": "Personal Indonesian tax ID (NPWP) issuance with activation on the Coretax platform.",
+        "icon_id": "consultant-npwp"
+      },
+      "Update Data / Coretax Activation": {
+        "name": "Update Data / Coretax Activation",
+        "price": "1.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Update of taxpayer data (email, phone number, etc.) or stand-alone Coretax activation for an existing NPWP.",
+        "icon_id": "consultant-update"
+      },
+      "EFIN Application": {
+        "name": "EFIN Application",
+        "price": "1.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Application for Electronic Filing Identification Number (EFIN) required to file taxes electronically with the Indonesian tax authority.",
+        "icon_id": "consultant-efin"
+      }
+    },
+    "other_process": {
+      "Reset Molina": {
+        "name": "Reset Molina",
+        "price": "1.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "Plus 400k urgent",
+        "description_en": "Reset of immigration record on the Molina (immigration) database, often needed after data inconsistencies.",
+        "icon_id": "other-molina"
+      },
+      "SKCK": {
+        "name": "SKCK",
+        "price": "2.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Police clearance certificate (Surat Keterangan Catatan Kepolisian), often required for visa renewals and certain employment processes.",
+        "icon_id": "other-skck"
+      },
+      "ACC Mutation Passport": {
+        "name": "ACC Mutation Passport",
+        "price": "1.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Approval (ACC) for mutation of passport data on existing immigration permits.",
+        "icon_id": "other-mutation"
+      },
+      "Mutation Passport": {
+        "name": "Mutation Passport",
+        "price": "500.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "Plus 350k urgent",
+        "description_en": "Update of passport details on existing immigration permits after a passport renewal.",
+        "icon_id": "other-mutation"
+      },
+      "ACC Mutation": {
+        "name": "ACC Mutation",
+        "price": "1.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Approval (ACC) for mutation requests on existing immigration permits.",
+        "icon_id": "other-mutation"
+      },
+      "Mutation Address": {
+        "name": "Mutation Address",
+        "price": "500.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Update of registered address on existing immigration permits.",
+        "icon_id": "other-mutation"
+      },
+      "Born Report": {
+        "name": "Born Report",
+        "price": "4.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Birth report registration for foreign citizens born in Indonesia, required for subsequent dependent permits.",
+        "icon_id": "other-born"
+      },
+      "Electronic Passport 5 Years": {
+        "name": "Electronic Passport 5 Years",
+        "price": "2.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "5 years",
+        "notes": "",
+        "description_en": "Indonesian electronic passport (e-passport) issuance for 5-year validity.",
+        "icon_id": "other-passport"
+      },
+      "Electronic Passport 10 Years": {
+        "name": "Electronic Passport 10 Years",
+        "price": "2.500.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "10 years",
+        "notes": "",
+        "description_en": "Indonesian electronic passport (e-passport) issuance for 10-year validity.",
+        "icon_id": "other-passport"
+      },
+      "Passport 5 Years": {
+        "name": "Passport 5 Years",
+        "price": "1.300.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "5 years",
+        "notes": "",
+        "description_en": "Indonesian standard passport issuance for 5-year validity.",
+        "icon_id": "other-passport"
+      },
+      "Passport 10 Years": {
+        "name": "Passport 10 Years",
+        "price": "2.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "10 years",
+        "notes": "",
+        "description_en": "Indonesian standard passport issuance for 10-year validity.",
+        "icon_id": "other-passport"
+      },
+      "Domicilie Letter": {
+        "name": "Domicilie Letter",
+        "price": "800.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Domicile letter (Surat Keterangan Domisili) issued by the local authority confirming the residential address.",
+        "icon_id": "other-domicile"
+      },
+      "Domicilie + SKTT": {
+        "name": "Domicilie + SKTT",
+        "price": "1.600.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Bundle of domicile letter (Surat Keterangan Domisili) and temporary residence certificate (SKTT) for KITAS holders.",
+        "icon_id": "other-domicile"
+      },
+      "SKTT": {
+        "name": "SKTT",
+        "price": "1.500.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Temporary residence certificate (Surat Keterangan Tempat Tinggal) issued by the local civil registration office, required for KITAS holders.",
+        "icon_id": "other-sktt"
+      },
+      "Cancel RPTKA": {
+        "name": "Cancel RPTKA",
+        "price": "500.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Cancellation of an existing RPTKA (foreign worker utilisation plan) at the Ministry of Manpower.",
+        "icon_id": "other-cancel"
+      },
+      "Cancel Wajib Lapor": {
+        "name": "Cancel Wajib Lapor",
+        "price": "500.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Cancellation of mandatory employer reporting (Wajib Lapor Ketenagakerjaan) at the Ministry of Manpower.",
+        "icon_id": "other-cancel"
+      },
+      "Cancel (RPTKA, IMTA, Wajib Lapor)": {
+        "name": "Cancel (RPTKA, IMTA, Wajib Lapor)",
+        "price": "3.500.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Combined cancellation of RPTKA, IMTA and Wajib Lapor records at the Ministry of Manpower.",
+        "icon_id": "other-cancel"
+      },
+      "ACC Boarding Pass": {
+        "name": "ACC Boarding Pass",
+        "price": "1.200.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "",
+        "description_en": "Approval (ACC) for boarding pass issuance in scenarios requiring immigration verification before departure.",
+        "icon_id": "other-boarding"
+      },
+      "EPO (Exit Permit Only)": {
+        "name": "EPO (Exit Permit Only)",
+        "price": "700.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "Plus 300k urgent",
+        "description_en": "Exit Permit Only (EPO) for KITAS or KITAP holders permanently leaving Indonesia and surrendering their stay permit.",
+        "icon_id": "other-epo"
+      },
+      "ERP (Exit Re-entry Permit)": {
+        "name": "ERP (Exit Re-entry Permit)",
+        "price": "800.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "",
+        "notes": "Plus 500k urgent",
+        "description_en": "Single-use Exit Re-entry Permit (ERP) for KITAS holders travelling abroad and returning before permit expiry.",
+        "icon_id": "other-erp"
+      }
+    },
+    "urgent_processing": {
+      "Urgent 1 Hari": {
+        "name": "Urgent 1 Hari",
+        "price": "3.000.000 IDR",
+        "tier_range": null,
+        "duration": "1 day",
+        "validity": "",
+        "notes": "",
+        "description_en": "Urgent processing surcharge for 1-day turnaround on eligible immigration services.",
+        "icon_id": "urgent-1day"
+      },
+      "Urgent 2 Hari": {
+        "name": "Urgent 2 Hari",
+        "price": "2.500.000 IDR",
+        "tier_range": null,
+        "duration": "2 days",
+        "validity": "",
+        "notes": "",
+        "description_en": "Urgent processing surcharge for 2-day turnaround on eligible immigration services.",
+        "icon_id": "urgent-2day"
+      },
+      "Urgent 3 Hari": {
+        "name": "Urgent 3 Hari",
+        "price": "1.000.000 IDR",
+        "tier_range": null,
+        "duration": "3 days",
+        "validity": "",
+        "notes": "",
+        "description_en": "Urgent processing surcharge for 3-day turnaround on eligible immigration services.",
+        "icon_id": "urgent-3day"
+      }
+    }
+  }
+}

--- a/apps/backend-rag/backend/services/crm/automation.py
+++ b/apps/backend-rag/backend/services/crm/automation.py
@@ -598,12 +598,6 @@ class CompletedProcessService:
         """Send human, congratulatory email to client."""
         practice_type = practice_data.get("practice_type_name", "Immigration Service")
 
-        docs_section = ""
-        if documents:
-            docs_section = "\n📎 Your Documents:\n"
-            for doc in documents:
-                docs_section += f"   • {doc['filename']}: {doc['file_url']}\n"
-
         subject = f"[CLIENT] 🎉 Congratulations {client_name}! Your {practice_type} is Complete"
 
         body = f"""Dear {client_name},
@@ -617,8 +611,8 @@ What This Means for You:
 ✅ All legal requirements have been fulfilled
 ✅ You can now proceed with confidence in your Indonesian journey
 
-{docs_section}
-All your important documents are safely stored in your personal Google Drive folder. You can access them anytime through the link above.
+📲 Your documents:
+Your consultant will share all the documents with you directly on WhatsApp shortly.
 
 A Few Things to Remember:
 • Keep your documents secure and make backup copies

--- a/apps/backend-rag/backend/services/crm/birthday_notifier_service.py
+++ b/apps/backend-rag/backend/services/crm/birthday_notifier_service.py
@@ -19,6 +19,7 @@ import asyncpg
 import httpx
 
 from backend.services.integrations.zoho_email_service import ZohoEmailService
+from backend.services.notifications.email_branding import logo_header_html
 
 logger = logging.getLogger(__name__)
 
@@ -287,11 +288,13 @@ class BirthdayNotifierService:
         <html>
         <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
             <div style="max-width: 600px; margin: 0 auto; padding: 20px;">
+                {logo_header_html()}
                 <h2 style="color: #2c3e50;">{greeting}</h2>
                 <p style="white-space: pre-line;">{message}</p>
                 <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
                 <p style="font-size: 12px; color: #666;">
-                    Bali Zero - Your Partner in Indonesia<br>
+                    <strong>Zantara — Bali Zero Team</strong><br>
+                    📧 asya@balizero.com | 📱 WhatsApp: +62 821 3107 363<br>
                     <a href="https://www.balizero.com" style="color: #3498db;">www.balizero.com</a>
                 </p>
             </div>

--- a/apps/backend-rag/backend/services/crm/completed_process_service.py
+++ b/apps/backend-rag/backend/services/crm/completed_process_service.py
@@ -21,6 +21,7 @@ from backend.services.notifications.email_audit import (
     notify_email_failure_critical,
     record_email_result,
 )
+from backend.services.notifications.email_branding import logo_header_html
 from backend.services.notifications.email_http import get_email_client
 
 # Internal email API — uses Brevo, from=zantara@balizero.com
@@ -83,6 +84,9 @@ class CompletedProcessService:
                     documents=final_documents,
                 )
 
+            # Send notification to team leader
+            team_leader_email = practice_data.get("assigned_to") or practice_data.get("created_by")
+
             # Send email to client
             client_notified = False
             if client_data.get("email"):
@@ -93,13 +97,12 @@ class CompletedProcessService:
                         practice_data=practice_data,
                         documents=uploaded_docs,
                         failed_uploads=failed_uploads,
+                        team_member_email=team_leader_email,
                     )
                     client_notified = True
                 except Exception as e:
                     logger.error(f"Failed to send completion email to client: {e}")
 
-            # Send notification to team leader
-            team_leader_email = practice_data.get("assigned_to") or practice_data.get("created_by")
             team_notified = False
             if team_leader_email:
                 try:
@@ -213,6 +216,7 @@ class CompletedProcessService:
         practice_data: dict,
         documents: list[dict],
         failed_uploads: list[dict] | None = None,
+        team_member_email: str | None = None,
     ) -> None:
         """Send human, congratulatory email to client.
 
@@ -297,6 +301,8 @@ P.S. Save our contact info for future needs—we're always here to help! 😊
             email_type="completion_client",
             practice_id=practice_data["id"],
             client_id=practice_data.get("client_id"),
+            cc=team_member_email if team_member_email and team_member_email != client_email else None,
+            include_logo=True,
         )
         logger.info(f"Completion email sent to client {client_email}")
 
@@ -366,6 +372,8 @@ Zantara CRM System
         email_type: str,
         practice_id: int | None = None,
         client_id: int | None = None,
+        cc: str | None = None,
+        include_logo: bool = False,
     ) -> None:
         """Send email via Brevo (primary), fall back to Zoho if Brevo fails.
 
@@ -384,11 +392,16 @@ Zantara CRM System
         # 1) Brevo
         try:
             html_body = body.replace("\n", "<br>")
+            if include_logo:
+                html_body = f"{logo_header_html()}{html_body}"
+            payload: dict = {"to": to_email, "subject": subject, "body": html_body}
+            if cc:
+                payload["cc"] = cc
             client = await get_email_client()
             response = await client.post(
                 _EMAIL_API_URL,
                 headers={"X-API-Key": _EMAIL_API_KEY},
-                json={"to": to_email, "subject": subject, "body": html_body},
+                json=payload,
             )
             response.raise_for_status()
             logger.info(f"Email sent to {to_email} via Brevo")

--- a/apps/backend-rag/backend/services/crm/completed_process_service.py
+++ b/apps/backend-rag/backend/services/crm/completed_process_service.py
@@ -21,7 +21,7 @@ from backend.services.notifications.email_audit import (
     notify_email_failure_critical,
     record_email_result,
 )
-from backend.services.notifications.email_branding import logo_header_html
+from backend.services.notifications.email_branding import logo_header_html, team_email_html
 from backend.services.notifications.email_http import get_email_client
 
 # Internal email API — uses Brevo, from=zantara@balizero.com
@@ -220,38 +220,12 @@ class CompletedProcessService:
     ) -> None:
         """Send human, congratulatory email to client.
 
-        When some documents failed to upload to Drive, the email no longer
-        claims completeness: a "⚠️ Missing documents" section lists the
-        filenames and tells the client the team will follow up.
+        Documents are delivered by the consultant via WhatsApp — this email
+        no longer lists Drive links (clients aren't given Drive folder access).
         """
         practice_type = practice_data.get("practice_type_name", "Immigration Service")
 
-        # Build document links section
-        docs_section = ""
-        if documents:
-            docs_section = "\n📎 Your Documents:\n"
-            for doc in documents:
-                docs_section += f"   • {doc['filename']}: {doc['file_url']}\n"
-
-        # Missing-documents warning (was silently dropped before the fix).
-        missing_section = ""
-        if failed_uploads:
-            missing_section = (
-                "\n⚠️ Note: A few documents could not be uploaded to your Drive folder "
-                "automatically. Our team will send them to you directly within 24 hours:\n"
-            )
-            for item in failed_uploads:
-                missing_section += f"   • {item['filename']}\n"
-
         subject = f"[CLIENT] 🎉 Congratulations {client_name}! Your {practice_type} is Complete"
-
-        storage_note = (
-            "All your important documents are safely stored in your personal Google Drive folder. "
-            "You can access them anytime through the link above."
-            if not failed_uploads
-            else "The documents listed above are in your personal Google Drive folder. "
-                 "The missing items will arrive by direct email shortly."
-        )
 
         body = f"""Dear {client_name},
 
@@ -264,8 +238,8 @@ What This Means for You:
 ✅ All legal requirements have been fulfilled
 ✅ You can now proceed with confidence in your Indonesian journey
 
-{docs_section}{missing_section}
-{storage_note}
+📲 Your documents:
+Your consultant will share all the documents with you directly on WhatsApp shortly.
 
 A Few Things to Remember:
 • Keep your documents secure and make backup copies
@@ -335,24 +309,38 @@ P.S. Save our contact info for future needs—we're always here to help! 😊
             )
         else:
             subject = f"[TEAM] ✅ Process Completed - {client_name} ({practice_type})"
-            followup_line = "No further action required on this case."
+            followup_line = "Great work — no further action required on this case."
 
-        body = f"""Hi Team Leader,
+        if failed_count:
+            title = f"⚠️ Completed (with missing docs) — {client_name}"
+            intro = (
+                f"<b>Attention:</b> {failed_count} document(s) failed to upload to Drive. "
+                f"The client email told them you'll follow up — please send the missing files "
+                f"manually within 24h."
+            )
+        else:
+            title = f"✅ Process Completed — {client_name}"
+            intro = followup_line
 
-Great work! The following practice has been successfully completed:
-
-📋 Practice Details:
-• Client: {client_name}
-• Service: {practice_type}
-• Practice ID: {practice_id}
-• Status: ✅ COMPLETED
-• Documents uploaded: {uploaded_count}{f" (⚠️ {failed_count} failed)" if failed_count else ""}
-
-{followup_line}
-
-Best regards,
-Zantara CRM System
-"""
+        body = team_email_html(
+            title=title,
+            intro=intro,
+            meta_rows=[
+                ("Client", client_name),
+                ("Service", practice_type),
+                ("Practice ID", f"#{practice_id}"),
+                ("Status", "✅ COMPLETED"),
+                (
+                    "Documents",
+                    f"{uploaded_count} uploaded"
+                    + (f" · ⚠️ {failed_count} failed" if failed_count else ""),
+                ),
+            ],
+            body_html="",
+            cta_label="Open practice in CRM",
+            cta_url=f"https://kita.balizero.com/process/{practice_id}",
+            signature="Zantara CRM",
+        )
 
         await self._send_with_brevo_fallback(
             team_leader_email,
@@ -361,6 +349,7 @@ Zantara CRM System
             email_type="completion_team",
             practice_id=practice_id,
             client_id=practice_data.get("client_id"),
+            prebuilt_html=True,
         )
 
     async def _send_with_brevo_fallback(
@@ -374,6 +363,7 @@ Zantara CRM System
         client_id: int | None = None,
         cc: str | None = None,
         include_logo: bool = False,
+        prebuilt_html: bool = False,
     ) -> None:
         """Send email via Brevo (primary), fall back to Zoho if Brevo fails.
 
@@ -391,9 +381,12 @@ Zantara CRM System
 
         # 1) Brevo
         try:
-            html_body = body.replace("\n", "<br>")
-            if include_logo:
-                html_body = f"{logo_header_html()}{html_body}"
+            if prebuilt_html:
+                html_body = body
+            else:
+                html_body = body.replace("\n", "<br>")
+                if include_logo:
+                    html_body = f"{logo_header_html()}{html_body}"
             payload: dict = {"to": to_email, "subject": subject, "body": html_body}
             if cc:
                 payload["cc"] = cc

--- a/apps/backend-rag/backend/services/crm/practice_status_listener.py
+++ b/apps/backend-rag/backend/services/crm/practice_status_listener.py
@@ -24,6 +24,7 @@ import httpx
 
 from backend.app.utils.logging_utils import get_logger
 from backend.services.crm.automation import ProcessAutomationService
+from backend.services.notifications.email_branding import logo_header_html, team_email_html
 
 logger = get_logger(__name__)
 
@@ -211,7 +212,7 @@ class PracticeStatusListener:
 
         # ── Email 1: Client — payment received ──────────────────────────
         if client_email:
-            subject = f"✅ Payment Received — Your {practice_type} is Now in Motion!"
+            subject = f"[CLIENT] ✅ Payment Received — Your {practice_type} is Now in Motion!"
             body = f"""Hi {client_name},
 
 Great news — we've received your payment! 🎉
@@ -226,13 +227,17 @@ What happens next:
 Thank you for your trust — we'll take it from here!
 
 Warmly,
-The Bali Zero Team
+Zantara — Bali Zero Team
 
 ---
-Questions? Reply to this email or reach us on WhatsApp.
+📧 asya@balizero.com | 🌐 www.balizero.com | 📱 WhatsApp: +62 821 3107 363
 """
             try:
-                await self._send_via_internal_api(client_email, subject, body)
+                await self._send_via_internal_api(
+                    client_email, subject, body,
+                    cc=team_member_email if team_member_email and team_member_email != client_email else None,
+                    include_logo=True,
+                )
                 logger.info(f"M4: payment confirmation sent to client {client_email}")
             except httpx.HTTPError as exc:
                 logger.error(f"M4: failed to email client {client_email}: {exc}", exc_info=True)
@@ -245,26 +250,31 @@ Questions? Reply to this email or reach us on WhatsApp.
         # ── Email 2: Team member — with Asya in CC ───────────────────────
         if team_member_email:
             subject = f"[PAYMENT IN] ✅ {client_name} — {practice_type} — Proceed Now"
-            body = f"""Hi,
-
-Payment has been confirmed for the following practice — you're clear to start!
-
-Client:       {client_name}
-Service:      {practice_type}
-Practice ID:  #{practice_id}
-Amount:       {practice_data.get("quoted_price", "see CRM")}
-
-Next steps:
-1. Review documents in CRM: https://kita.balizero.com/process/{practice_id}
-2. Contact the client on WhatsApp to introduce yourself
-3. Begin application preparation
-
-Asya has verified the payment. Any billing questions → asya@balizero.com
-
-Go!
-
-Zantara CRM 🤖
-"""
+            body = team_email_html(
+                title=f"💰 Payment In — {client_name}",
+                intro=(
+                    "Asya has verified the payment for this practice. You're clear to start! "
+                    "Any billing questions → <a href='mailto:asya@balizero.com' "
+                    "style='color:#1F2937;'>asya@balizero.com</a>"
+                ),
+                meta_rows=[
+                    ("Client", client_name),
+                    ("Service", practice_type),
+                    ("Practice ID", f"#{practice_id}"),
+                    ("Amount", str(practice_data.get("quoted_price", "see CRM"))),
+                ],
+                body_html=(
+                    "<b>Next steps:</b>"
+                    "<ol style='margin:6px 0 4px 18px;padding:0;'>"
+                    "<li>Review documents in the CRM</li>"
+                    "<li>Contact the client on WhatsApp to introduce yourself</li>"
+                    "<li>Begin application preparation</li>"
+                    "</ol>"
+                ),
+                cta_label="Open practice in CRM",
+                cta_url=f"https://kita.balizero.com/process/{practice_id}",
+                signature="Zantara CRM",
+            )
             try:
                 # Use internal /send-email endpoint: handles Zoho/Brevo routing + CC support
                 await self._send_via_internal_api(
@@ -272,6 +282,7 @@ Zantara CRM 🤖
                     subject=subject,
                     body=body,
                     cc="asya@balizero.com",
+                    prebuilt_html=True,
                 )
                 logger.info(f"M4: team notification sent to {team_member_email} (CC: asya)")
             except httpx.HTTPError as exc:
@@ -332,11 +343,16 @@ Zantara CRM 🤖
         client_name = client_data["full_name"]
         client_email = client_data["email"]
         practice_type = practice_data.get("practice_type_name", "your application")
+        team_member_email = practice_data.get("assigned_to")
 
         subject, body = _milestone_content(client_name, practice_type, practice_id, status)
 
         try:
-            await self._send_via_internal_api(client_email, subject, body)
+            await self._send_via_internal_api(
+                client_email, subject, body,
+                cc=team_member_email if team_member_email and team_member_email != client_email else None,
+                include_logo=True,
+            )
             logger.info(f"M5: milestone '{status}' email sent to {client_email} (practice {practice_id})")
         except httpx.HTTPError as exc:
             logger.error(f"M5: milestone email failed for {client_email}: {exc}", exc_info=True)
@@ -353,6 +369,8 @@ Zantara CRM 🤖
         body: str,
         cc: str | None = None,
         bcc: str | None = None,
+        include_logo: bool = False,
+        prebuilt_html: bool = False,
     ) -> None:
         """
         Send email via the internal /api/notifications/send-email endpoint.
@@ -360,7 +378,12 @@ Zantara CRM 🤖
         This endpoint handles Zoho SMTP vs Brevo routing automatically
         (intra-domain @balizero.com → Zoho, external → Brevo) and supports CC/BCC.
         """
-        html_body = body.replace("\n", "<br>")
+        if prebuilt_html:
+            html_body = body
+        else:
+            html_body = body.replace("\n", "<br>")
+            if include_logo:
+                html_body = f"{logo_header_html()}{html_body}"
         payload: dict[str, Any] = {
             "to": to_email,
             "subject": subject,
@@ -393,7 +416,7 @@ def _milestone_content(
     portal_url = "https://my.balizero.com"
 
     if status == "submitted":
-        subject = f"📤 Update: Your {practice_type} Has Been Submitted!"
+        subject = f"[CLIENT] 📤 Update: Your {practice_type} Has Been Submitted!"
         body = f"""Hi {client_name},
 
 Exciting update — we've officially submitted your {practice_type} application to the relevant authorities! 🎉
@@ -409,11 +432,11 @@ You can check your case status anytime:
 Hang tight — we're on it!
 
 Warmly,
-The Bali Zero Team
+Zantara — Bali Zero Team
 """
 
     elif status == "approved":
-        subject = f"🎉 APPROVED! Your {practice_type} is Ready!"
+        subject = f"[CLIENT] 🎉 APPROVED! Your {practice_type} is Ready!"
         body = f"""Hi {client_name},
 
 WE DID IT! 🎊
@@ -430,11 +453,11 @@ View your case: {portal_url}
 Thank you for choosing Bali Zero. Congratulations! 🥂
 
 Warmly,
-The Bali Zero Team
+Zantara — Bali Zero Team
 """
 
     elif status == "completed":
-        subject = f"✅ Completed: Your {practice_type} Documents Are Ready"
+        subject = f"[CLIENT] ✅ Completed: Your {practice_type} Documents Are Ready"
         body = f"""Hi {client_name},
 
 Your {practice_type} process is now fully complete — your documents are ready! ✅
@@ -449,13 +472,13 @@ It's been a pleasure working with you. If you ever need anything else — visas,
 Thank you for trusting Bali Zero!
 
 Warmly,
-The Bali Zero Team
+Zantara — Bali Zero Team
 
 P.S. We'd love to hear about your experience — feel free to leave us a review! ⭐
 """
 
     else:
-        subject = f"Update on Your {practice_type} (Practice #{practice_id})"
+        subject = f"[CLIENT] Update on Your {practice_type} (Practice #{practice_id})"
         body = f"""Hi {client_name},
 
 There's been an update on your {practice_type} — status is now: {status}.

--- a/apps/backend-rag/backend/services/crm/process_automation_service.py
+++ b/apps/backend-rag/backend/services/crm/process_automation_service.py
@@ -15,6 +15,7 @@ import httpx
 from backend.app.utils.logging_utils import get_logger
 from backend.services.common.cache import cache_invalidating
 from backend.services.integrations.zoho_email_service import ZohoEmailService
+from backend.services.notifications.email_branding import logo_header_html
 
 # Internal email API — uses Brevo, from=zantara@balizero.com
 _EMAIL_API_URL = os.getenv(
@@ -91,6 +92,7 @@ class ProcessAutomationService:
                         client_email=client_data["email"],
                         client_name=client_data["full_name"],
                         practice_data=practice_data,
+                        team_member_email=team_leader_email,
                     )
                     results["client_notified"] = True
                     logger.info(f"Process start email sent to client {client_data['email']}")
@@ -140,6 +142,7 @@ class ProcessAutomationService:
         client_email: str,
         client_name: str,
         practice_data: dict,
+        team_member_email: str | None = None,
     ) -> None:
         """Send warm, human email to client confirming payment and process start."""
         practice_type = practice_data.get("practice_type_name", "Immigration Service")
@@ -187,7 +190,11 @@ P.S. Keep an eye on your WhatsApp—we'll be sending you updates there too! 😊
 🌐 Visit us at www.balizero.com
 """
 
-        await self._send_with_brevo_fallback(client_email, subject, body)
+        await self._send_with_brevo_fallback(
+            client_email, subject, body,
+            cc=team_member_email if team_member_email and team_member_email != client_email else None,
+            include_logo=True,
+        )
 
     async def _send_team_leader_notification(
         self,
@@ -238,16 +245,24 @@ P.S. The client is excited to get started—let's make it a great experience! �
 
     async def _send_with_brevo_fallback(
         self, to_email: str, subject: str, body: str,
+        *,
+        cc: str | None = None,
+        include_logo: bool = False,
     ) -> None:
         """Send email via Brevo (primary), fall back to Zoho if Brevo fails."""
         # Primary: Brevo
         try:
             html_body = body.replace("\n", "<br>")
+            if include_logo:
+                html_body = f"{logo_header_html()}{html_body}"
+            payload: dict = {"to": to_email, "subject": subject, "body": html_body}
+            if cc:
+                payload["cc"] = cc
             async with httpx.AsyncClient(timeout=30.0) as client:
                 response = await client.post(
                     _EMAIL_API_URL,
                     headers={"X-API-Key": _EMAIL_API_KEY},
-                    json={"to": to_email, "subject": subject, "body": html_body},
+                    json=payload,
                 )
                 response.raise_for_status()
             logger.info(f"Email sent to {to_email} via Brevo")

--- a/apps/backend-rag/backend/services/crm/process_automation_service.py
+++ b/apps/backend-rag/backend/services/crm/process_automation_service.py
@@ -15,7 +15,7 @@ import httpx
 from backend.app.utils.logging_utils import get_logger
 from backend.services.common.cache import cache_invalidating
 from backend.services.integrations.zoho_email_service import ZohoEmailService
-from backend.services.notifications.email_branding import logo_header_html
+from backend.services.notifications.email_branding import logo_header_html, team_email_html
 
 # Internal email API — uses Brevo, from=zantara@balizero.com
 _EMAIL_API_URL = os.getenv(
@@ -207,54 +207,48 @@ P.S. Keep an eye on your WhatsApp—we'll be sending you updates there too! 😊
 
         subject = f"[TEAM] 🚀 Let's Go! Payment Confirmed - {client_name}"
 
-        body = f"""Hey there!
+        practice_id = practice_data["id"]
+        body = team_email_html(
+            title=f"🚀 Payment Confirmed — {client_name}",
+            intro=f"Asya has confirmed the payment for {client_name}'s {practice_type}. This one is yours — let's go!",
+            meta_rows=[
+                ("Client", client_name),
+                ("Service", practice_type),
+                ("Practice ID", f"#{practice_id}"),
+                ("Amount", str(practice_data.get("quoted_price", "—"))),
+            ],
+            body_html=(
+                "<b>Your mission:</b>"
+                "<ol style='margin:6px 0 4px 18px;padding:0;'>"
+                "<li>Review the client's documents in the CRM</li>"
+                "<li>Start working on the application</li>"
+                "<li>Update status to <i>SUBMITTED TO GOV</i> when ready</li>"
+                "<li>Keep the client updated via WhatsApp</li>"
+                "</ol>"
+            ),
+            cta_label="Open practice in CRM",
+            cta_url=f"https://kita.balizero.com/process/{practice_id}",
+            signature="Zantara CRM",
+        )
 
-Great news—payment has just been confirmed for {client_name}'s {practice_type}! 🎉
-
-This one's all yours. Here are the details:
-
-👤 Client: {client_name}
-🔖 Service: {practice_type}
-🆔 Practice ID: {practice_data["id"]}
-💰 Amount: {practice_data.get("quoted_price", "N/A")}
-
-✅ Asya has confirmed the payment is in, so you're good to go!
-
-Your Mission (should you choose to accept it 😄):
-1. Review the client's documents in the CRM
-2. Start working your magic on the application
-3. Update the status to "SUBMITTED TO GOV" when you're ready
-4. Keep the client in the loop via WhatsApp—they love updates!
-
-🎯 Quick Access:
-https://kita.balizero.com/process
-
-You've got this! We know you'll handle this case with your usual excellence.
-
-If you need anything or have questions about this case, just holler.
-
-Go get 'em!
-
-Cheers,
-Zantara CRM 🤖
-
-P.S. The client is excited to get started—let's make it a great experience! ✨
-"""
-
-        await self._send_with_brevo_fallback(team_leader_email, subject, body)
+        await self._send_with_brevo_fallback(team_leader_email, subject, body, prebuilt_html=True)
 
     async def _send_with_brevo_fallback(
         self, to_email: str, subject: str, body: str,
         *,
         cc: str | None = None,
         include_logo: bool = False,
+        prebuilt_html: bool = False,
     ) -> None:
         """Send email via Brevo (primary), fall back to Zoho if Brevo fails."""
         # Primary: Brevo
         try:
-            html_body = body.replace("\n", "<br>")
-            if include_logo:
-                html_body = f"{logo_header_html()}{html_body}"
+            if prebuilt_html:
+                html_body = body
+            else:
+                html_body = body.replace("\n", "<br>")
+                if include_logo:
+                    html_body = f"{logo_header_html()}{html_body}"
             payload: dict = {"to": to_email, "subject": subject, "body": html_body}
             if cc:
                 payload["cc"] = cc

--- a/apps/backend-rag/backend/services/crm/waiting_documents_service.py
+++ b/apps/backend-rag/backend/services/crm/waiting_documents_service.py
@@ -20,7 +20,7 @@ from backend.services.notifications.email_audit import (
     notify_email_failure_critical,
     record_email_result,
 )
-from backend.services.notifications.email_branding import logo_header_html
+from backend.services.notifications.email_branding import logo_header_html, team_email_html
 from backend.services.notifications.email_http import get_email_client
 
 # Internal email API — uses Brevo, from=zantara@balizero.com
@@ -137,41 +137,40 @@ class WaitingDocumentsService:
     ) -> None:
         """Notify team leader that documents need to be collected from the client."""
         practice_type = practice_data.get("practice_type_name", "Immigration Service")
+        practice_id = practice_data["id"]
 
         subject = f"[TEAM] 📋 Documents Needed — {client_name} ({practice_type})"
 
-        body = f"""Hi there!
-
-A practice has moved to the **Document Collection** phase and needs your attention.
-
-👤 Client: {client_name}
-🔖 Service: {practice_type}
-🆔 Practice ID: {practice_data["id"]}
-
-📋 What to do:
-1. Contact the client and let them know which documents are required
-2. Set a clear deadline for document submission
-3. Upload received documents to the CRM
-4. Once all documents are received, move to "Sending Invoice"
-
-A document request email has already been sent to the client automatically.
-
-🎯 Quick Access:
-https://kita.balizero.com/process/{practice_data["id"]}
-
-Let's keep things moving!
-
-Cheers,
-Zantara CRM 🤖
-"""
+        body_html = team_email_html(
+            title=f"📋 Documents Needed — {client_name}",
+            intro="This practice has moved to the <b>Document Collection</b> phase and needs your attention. A request email has already been sent to the client automatically.",
+            meta_rows=[
+                ("Client", client_name),
+                ("Service", practice_type),
+                ("Practice ID", f"#{practice_id}"),
+            ],
+            body_html=(
+                "<b>What to do:</b>"
+                "<ol style='margin:6px 0 4px 18px;padding:0;'>"
+                "<li>Contact the client and confirm which documents are required</li>"
+                "<li>Set a clear deadline for document submission</li>"
+                "<li>Upload received documents to the CRM</li>"
+                "<li>Once all documents are received, move the practice to <i>Sending Invoice</i></li>"
+                "</ol>"
+            ),
+            cta_label="Open practice in CRM",
+            cta_url=f"https://kita.balizero.com/process/{practice_id}",
+            signature="Zantara CRM",
+        )
 
         await self._send_with_brevo_fallback(
             team_leader_email,
             subject,
-            body,
+            body_html,
             email_type="waiting_docs_team",
-            practice_id=practice_data["id"],
+            practice_id=practice_id,
             client_id=practice_data.get("client_id"),
+            prebuilt_html=True,
         )
 
     async def _send_client_documents_request(
@@ -249,6 +248,7 @@ Zantara — Bali Zero Team
         client_id: int | None = None,
         cc: str | None = None,
         include_logo: bool = False,
+        prebuilt_html: bool = False,
     ) -> None:
         """Send email via Brevo (primary), fall back to Zoho if Brevo fails.
 
@@ -268,9 +268,12 @@ Zantara — Bali Zero Team
 
         # 1) Brevo
         try:
-            html_body = body.replace("\n", "<br>")
-            if include_logo:
-                html_body = f"{logo_header_html()}{html_body}"
+            if prebuilt_html:
+                html_body = body
+            else:
+                html_body = body.replace("\n", "<br>")
+                if include_logo:
+                    html_body = f"{logo_header_html()}{html_body}"
             payload: dict = {"to": to_email, "subject": subject, "body": html_body}
             if cc:
                 payload["cc"] = cc

--- a/apps/backend-rag/backend/services/crm/welcome/welcome_email_service.py
+++ b/apps/backend-rag/backend/services/crm/welcome/welcome_email_service.py
@@ -336,18 +336,19 @@ def _build_html(
     wa_num = (advisor_wa or _BZ_WHATSAPP).lstrip("+")
     cta_label = f"Chat with {advisor_name} on WhatsApp"
 
-    # BG constants — all inline style, no separate bgcolor attr (Zoho strips bgcolor)
-    BG = "background-color:#0c0d0f;"
-    BG2 = "background-color:#101215;"
-    BG3 = "background-color:#161a1e;"
-    BG4 = "background-color:#1a1914;"
-    BGDIV = "background-color:#2a2520;"
-    BGGOLD = "background-color:#f9ca55;"
+    # BG constants — Tax Report Marta palette: dark navy + gold accents
+    # All inline style, no separate bgcolor attr (Zoho strips bgcolor)
+    BG = "background-color:#1F2937;"
+    BG2 = "background-color:#252f3d;"
+    BG3 = "background-color:#2b3645;"
+    BG4 = "background-color:#2f3a4a;"
+    BGDIV = "background-color:#3a4554;"
+    BGGOLD = "background-color:#F4B400;"
 
     divider = (
         f'<tr><td style="padding:0 40px;{BG}">'
         '<table cellspacing="0" cellpadding="0" border="0" width="100%"><tr>'
-        '<td style="height:1px;background-color:#2a2520;font-size:1px;line-height:1px;">&nbsp;</td>'
+        '<td style="height:1px;background-color:#3a4554;font-size:1px;line-height:1px;">&nbsp;</td>'
         '</tr></table></td></tr>'
     )
 
@@ -373,7 +374,7 @@ def _build_html(
 </head>
 <body style="margin:0;padding:0;{BG}">
 
-  <div style="display:none;max-height:0;overflow:hidden;font-size:1px;color:#0c0d0f;">We handle the bureaucracy. You focus on Bali.</div>
+  <div style="display:none;max-height:0;overflow:hidden;font-size:1px;color:#1F2937;">We handle the bureaucracy. You focus on Bali.</div>
 
   <table cellspacing="0" cellpadding="0" border="0" width="100%" style="border-collapse:collapse;{BG}">
     <tr>
@@ -382,7 +383,7 @@ def _build_html(
 
           <!-- ══ HERO ══ -->
           <tr>
-            <td style="padding:44px 40px 40px;{BG}border-radius:14px 14px 0 0;border:1px solid #1e1c18;border-bottom:none;" class="pad">
+            <td style="padding:44px 40px 40px;{BG}border-radius:14px 14px 0 0;border:1px solid #3a4554;border-bottom:none;" class="pad">
               <table cellspacing="0" cellpadding="0" border="0" width="100%" style="border-collapse:collapse;">
                 <tr>
                   <td align="left" style="padding-bottom:36px;">
@@ -395,7 +396,7 @@ def _build_html(
                 </tr>
                 <tr>
                   <td class="hh" style="font-family:Arial,Helvetica,sans-serif;font-size:42px;line-height:48px;font-weight:900;color:#ffffff;letter-spacing:-1.5px;text-transform:uppercase;">
-                    Welcome,<br><span style="color:#f9ca55;">{first_name}.</span>
+                    Welcome,<br><span style="color:#F4B400;">{first_name}.</span>
                   </td>
                 </tr>
                 <tr>
@@ -404,9 +405,9 @@ def _build_html(
                   </td>
                 </tr>
                 <tr>
-                  <td style="padding-top:18px;font-family:Arial,Helvetica,sans-serif;font-size:16px;line-height:27px;color:#8a7a6a;font-weight:400;">
+                  <td style="padding-top:18px;font-family:Arial,Helvetica,sans-serif;font-size:16px;line-height:27px;color:#a8b3c0;font-weight:400;">
                     You just made the smartest move for your life in Indonesia.<br>
-                    <span style="color:#f9ca55;font-weight:700;">We&#39;ll take it from here.</span>
+                    <span style="color:#F4B400;font-weight:700;">We&#39;ll take it from here.</span>
                   </td>
                 </tr>
               </table>
@@ -415,21 +416,21 @@ def _build_html(
 
           <!-- ══ WHAT HAPPENS NEXT ══ -->
           <tr>
-            <td style="padding:36px 40px 32px;{BG2}border-left:1px solid #1e1c18;border-right:1px solid #1e1c18;" class="pad">
+            <td style="padding:36px 40px 32px;{BG2}border-left:1px solid #3a4554;border-right:1px solid #3a4554;" class="pad">
               <table cellspacing="0" cellpadding="0" border="0" width="100%" style="border-collapse:collapse;">
-                <tr><td style="font-family:Arial,Helvetica,sans-serif;font-size:10px;font-weight:700;color:#f9ca55;text-transform:uppercase;letter-spacing:4px;padding-bottom:28px;">What happens next</td></tr>
+                <tr><td style="font-family:Arial,Helvetica,sans-serif;font-size:10px;font-weight:700;color:#F4B400;text-transform:uppercase;letter-spacing:4px;padding-bottom:28px;">What happens next</td></tr>
               </table>
               <!-- step 1 -->
               <table cellspacing="0" cellpadding="0" border="0" width="100%" style="border-collapse:collapse;">
                 <tr>
                   <td width="52" valign="top" style="padding-right:16px;padding-bottom:20px;">
                     <table cellspacing="0" cellpadding="0" border="0" style="border-collapse:collapse;"><tr>
-                      <td width="44" height="44" align="center" valign="middle" style="{BG4}border-radius:10px;border:1px solid #2e2b22;font-family:Arial,Helvetica,sans-serif;font-size:14px;font-weight:900;color:#f9ca55;text-align:center;vertical-align:middle;">01</td>
+                      <td width="44" height="44" align="center" valign="middle" style="{BG4}border-radius:10px;border:1px solid #3a4554;font-family:Arial,Helvetica,sans-serif;font-size:14px;font-weight:900;color:#F4B400;text-align:center;vertical-align:middle;">01</td>
                     </tr></table>
                   </td>
                   <td valign="middle" style="padding-bottom:20px;">
                     <div style="font-family:Arial,Helvetica,sans-serif;font-size:15px;font-weight:700;color:#ffffff;line-height:20px;">{advisor_name} will reach out</div>
-                    <div style="font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#8a7a6a;line-height:19px;padding-top:3px;">Quick intro call to understand your situation</div>
+                    <div style="font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#a8b3c0;line-height:19px;padding-top:3px;">Quick intro call to understand your situation</div>
                   </td>
                 </tr>
                 <tr><td colspan="2" style="padding:0 0 20px 20px;"><table cellspacing="0" cellpadding="0" border="0" style="border-collapse:collapse;"><tr><td width="1" height="20" style="{BGDIV}font-size:1px;line-height:1px;">&nbsp;</td></tr></table></td></tr>
@@ -439,12 +440,12 @@ def _build_html(
                 <tr>
                   <td width="52" valign="top" style="padding-right:16px;padding-bottom:20px;">
                     <table cellspacing="0" cellpadding="0" border="0" style="border-collapse:collapse;"><tr>
-                      <td width="44" height="44" align="center" valign="middle" style="{BG4}border-radius:10px;border:1px solid #2e2b22;font-family:Arial,Helvetica,sans-serif;font-size:14px;font-weight:900;color:#c8a040;text-align:center;vertical-align:middle;">02</td>
+                      <td width="44" height="44" align="center" valign="middle" style="{BG4}border-radius:10px;border:1px solid #3a4554;font-family:Arial,Helvetica,sans-serif;font-size:14px;font-weight:900;color:#c8a040;text-align:center;vertical-align:middle;">02</td>
                     </tr></table>
                   </td>
                   <td valign="middle" style="padding-bottom:20px;">
                     <div style="font-family:Arial,Helvetica,sans-serif;font-size:15px;font-weight:700;color:#ffffff;line-height:20px;">We build your roadmap</div>
-                    <div style="font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#8a7a6a;line-height:19px;padding-top:3px;">Clear timeline, pricing, documents needed</div>
+                    <div style="font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#a8b3c0;line-height:19px;padding-top:3px;">Clear timeline, pricing, documents needed</div>
                   </td>
                 </tr>
                 <tr><td colspan="2" style="padding:0 0 20px 20px;"><table cellspacing="0" cellpadding="0" border="0" style="border-collapse:collapse;"><tr><td width="1" height="20" style="{BGDIV}font-size:1px;line-height:1px;">&nbsp;</td></tr></table></td></tr>
@@ -454,12 +455,12 @@ def _build_html(
                 <tr>
                   <td width="52" valign="top" style="padding-right:16px;">
                     <table cellspacing="0" cellpadding="0" border="0" style="border-collapse:collapse;"><tr>
-                      <td width="44" height="44" align="center" valign="middle" style="{BG4}border-radius:10px;border:1px solid #2e2b22;font-family:Arial,Helvetica,sans-serif;font-size:14px;font-weight:900;color:#9a7828;text-align:center;vertical-align:middle;">03</td>
+                      <td width="44" height="44" align="center" valign="middle" style="{BG4}border-radius:10px;border:1px solid #3a4554;font-family:Arial,Helvetica,sans-serif;font-size:14px;font-weight:900;color:#9a7828;text-align:center;vertical-align:middle;">03</td>
                     </tr></table>
                   </td>
                   <td valign="middle">
                     <div style="font-family:Arial,Helvetica,sans-serif;font-size:15px;font-weight:700;color:#ffffff;line-height:20px;">We handle everything</div>
-                    <div style="font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#8a7a6a;line-height:19px;padding-top:3px;">You focus on Bali. We handle the bureaucracy.</div>
+                    <div style="font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#a8b3c0;line-height:19px;padding-top:3px;">You focus on Bali. We handle the bureaucracy.</div>
                   </td>
                 </tr>
               </table>
@@ -470,9 +471,9 @@ def _build_html(
 
           <!-- ══ SERVICES ══ -->
           <tr>
-            <td style="padding:36px 40px 28px;{BG2}border-left:1px solid #1e1c18;border-right:1px solid #1e1c18;" class="pad">
+            <td style="padding:36px 40px 28px;{BG2}border-left:1px solid #3a4554;border-right:1px solid #3a4554;" class="pad">
               <table cellspacing="0" cellpadding="0" border="0" width="100%" style="border-collapse:collapse;">
-                <tr><td style="font-family:Arial,Helvetica,sans-serif;font-size:10px;font-weight:700;color:#f9ca55;text-transform:uppercase;letter-spacing:4px;padding-bottom:20px;">How we help</td></tr>
+                <tr><td style="font-family:Arial,Helvetica,sans-serif;font-size:10px;font-weight:700;color:#F4B400;text-transform:uppercase;letter-spacing:4px;padding-bottom:20px;">How we help</td></tr>
               </table>
               <table cellspacing="0" cellpadding="0" border="0" width="100%" style="border-collapse:collapse;">
                 <tr>
@@ -481,7 +482,7 @@ def _build_html(
                       <tr><td style="padding:20px 16px;{BG3}border-radius:10px;border:1px solid #252320;">
                         <div style="font-family:Arial,Helvetica,sans-serif;font-size:22px;line-height:26px;margin-bottom:10px;">&#127250;</div>
                         <div style="font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:700;color:#ffffff;">Immigration</div>
-                        <div style="font-family:Arial,Helvetica,sans-serif;font-size:11px;color:#8a7a6a;padding-top:5px;line-height:17px;">KITAS &middot; KITAP &middot; D12 &middot; E33G<br>Retirement &middot; Second Home</div>
+                        <div style="font-family:Arial,Helvetica,sans-serif;font-size:11px;color:#a8b3c0;padding-top:5px;line-height:17px;">KITAS &middot; KITAP &middot; D12 &middot; E33G<br>Retirement &middot; Second Home</div>
                       </td></tr>
                     </table>
                   </td>
@@ -490,7 +491,7 @@ def _build_html(
                       <tr><td style="padding:20px 16px;{BG3}border-radius:10px;border:1px solid #252320;">
                         <div style="font-family:Arial,Helvetica,sans-serif;font-size:22px;line-height:26px;margin-bottom:10px;">&#127970;</div>
                         <div style="font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:700;color:#ffffff;">Business</div>
-                        <div style="font-family:Arial,Helvetica,sans-serif;font-size:11px;color:#8a7a6a;padding-top:5px;line-height:17px;">PT PMA &middot; OSS &middot; NIB<br>Virtual Office &middot; Licenses</div>
+                        <div style="font-family:Arial,Helvetica,sans-serif;font-size:11px;color:#a8b3c0;padding-top:5px;line-height:17px;">PT PMA &middot; OSS &middot; NIB<br>Virtual Office &middot; Licenses</div>
                       </td></tr>
                     </table>
                   </td>
@@ -501,7 +502,7 @@ def _build_html(
                       <tr><td style="padding:20px 16px;{BG3}border-radius:10px;border:1px solid #252320;">
                         <div style="font-family:Arial,Helvetica,sans-serif;font-size:22px;line-height:26px;margin-bottom:10px;">&#128203;</div>
                         <div style="font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:700;color:#ffffff;">Tax &amp; Compliance</div>
-                        <div style="font-family:Arial,Helvetica,sans-serif;font-size:11px;color:#8a7a6a;padding-top:5px;line-height:17px;">NPWP &middot; SPT &middot; LKPM<br>Withholding &middot; Reporting</div>
+                        <div style="font-family:Arial,Helvetica,sans-serif;font-size:11px;color:#a8b3c0;padding-top:5px;line-height:17px;">NPWP &middot; SPT &middot; LKPM<br>Withholding &middot; Reporting</div>
                       </td></tr>
                     </table>
                   </td>
@@ -510,7 +511,7 @@ def _build_html(
                       <tr><td style="padding:20px 16px;{BG3}border-radius:10px;border:1px solid #252320;">
                         <div style="font-family:Arial,Helvetica,sans-serif;font-size:22px;line-height:26px;margin-bottom:10px;">&#127968;</div>
                         <div style="font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:700;color:#ffffff;">Property</div>
-                        <div style="font-family:Arial,Helvetica,sans-serif;font-size:11px;color:#8a7a6a;padding-top:5px;line-height:17px;">Hak Pakai &middot; Leasehold<br>Due Diligence &middot; Structure</div>
+                        <div style="font-family:Arial,Helvetica,sans-serif;font-size:11px;color:#a8b3c0;padding-top:5px;line-height:17px;">Hak Pakai &middot; Leasehold<br>Due Diligence &middot; Structure</div>
                       </td></tr>
                     </table>
                   </td>
@@ -521,8 +522,8 @@ def _build_html(
 
           <!-- ══ SOCIAL PROOF ══ -->
           <tr>
-            <td style="padding:36px 40px;{BG}border-left:1px solid #1e1c18;border-right:1px solid #1e1c18;" class="pad" align="center">
-              <div style="font-family:Arial,Helvetica,sans-serif;font-size:54px;font-weight:900;color:#f9ca55;letter-spacing:-2px;line-height:54px;">10,800<span style="font-size:26px;vertical-align:super;color:#5a4a18;">+</span></div>
+            <td style="padding:36px 40px;{BG}border-left:1px solid #3a4554;border-right:1px solid #3a4554;" class="pad" align="center">
+              <div style="font-family:Arial,Helvetica,sans-serif;font-size:54px;font-weight:900;color:#F4B400;letter-spacing:-2px;line-height:54px;">10,800<span style="font-size:26px;vertical-align:super;color:#a8b3c0;">+</span></div>
               <div style="font-family:Arial,Helvetica,sans-serif;font-size:10px;font-weight:700;color:#4a3a28;text-transform:uppercase;letter-spacing:4px;padding-top:10px;">Expats served since 2019</div>
             </td>
           </tr>
@@ -531,14 +532,14 @@ def _build_html(
 
           <!-- ══ WHY US ══ -->
           <tr>
-            <td style="padding:36px 40px 32px;{BG2}border-left:1px solid #1e1c18;border-right:1px solid #1e1c18;" class="pad">
+            <td style="padding:36px 40px 32px;{BG2}border-left:1px solid #3a4554;border-right:1px solid #3a4554;" class="pad">
               <table cellspacing="0" cellpadding="0" border="0" width="100%" style="border-collapse:collapse;">
-                <tr><td style="font-family:Arial,Helvetica,sans-serif;font-size:10px;font-weight:700;color:#f9ca55;text-transform:uppercase;letter-spacing:4px;padding-bottom:22px;">Why Bali Zero</td></tr>
+                <tr><td style="font-family:Arial,Helvetica,sans-serif;font-size:10px;font-weight:700;color:#F4B400;text-transform:uppercase;letter-spacing:4px;padding-bottom:22px;">Why Bali Zero</td></tr>
                 <tr>
                   <td style="padding-bottom:16px;">
                     <table cellspacing="0" cellpadding="0" border="0" width="100%" style="border-collapse:collapse;"><tr>
                       <td width="14" valign="top" style="padding-right:12px;padding-top:6px;"><table cellspacing="0" cellpadding="0" border="0" style="border-collapse:collapse;"><tr><td width="6" height="6" style="{BGGOLD}border-radius:3px;font-size:1px;line-height:1px;">&nbsp;</td></tr></table></td>
-                      <td style="font-family:Arial,Helvetica,sans-serif;font-size:14px;line-height:22px;color:#8a7a6a;"><strong style="color:#ffffff;font-weight:700;">AI-powered tracking.</strong> Every deadline, document, and regulation change monitored &mdash; nothing falls through the cracks.</td>
+                      <td style="font-family:Arial,Helvetica,sans-serif;font-size:14px;line-height:22px;color:#a8b3c0;"><strong style="color:#ffffff;font-weight:700;">AI-powered tracking.</strong> Every deadline, document, and regulation change monitored &mdash; nothing falls through the cracks.</td>
                     </tr></table>
                   </td>
                 </tr>
@@ -546,7 +547,7 @@ def _build_html(
                   <td style="padding-bottom:16px;">
                     <table cellspacing="0" cellpadding="0" border="0" width="100%" style="border-collapse:collapse;"><tr>
                       <td width="14" valign="top" style="padding-right:12px;padding-top:6px;"><table cellspacing="0" cellpadding="0" border="0" style="border-collapse:collapse;"><tr><td width="6" height="6" style="{BGGOLD}border-radius:3px;font-size:1px;line-height:1px;">&nbsp;</td></tr></table></td>
-                      <td style="font-family:Arial,Helvetica,sans-serif;font-size:14px;line-height:22px;color:#8a7a6a;"><strong style="color:#ffffff;font-weight:700;">Based in Kerobokan.</strong> Real office, real team. We meet you in person and handle government offices directly.</td>
+                      <td style="font-family:Arial,Helvetica,sans-serif;font-size:14px;line-height:22px;color:#a8b3c0;"><strong style="color:#ffffff;font-weight:700;">Based in Kerobokan.</strong> Real office, real team. We meet you in person and handle government offices directly.</td>
                     </tr></table>
                   </td>
                 </tr>
@@ -554,7 +555,7 @@ def _build_html(
                   <td>
                     <table cellspacing="0" cellpadding="0" border="0" width="100%" style="border-collapse:collapse;"><tr>
                       <td width="14" valign="top" style="padding-right:12px;padding-top:6px;"><table cellspacing="0" cellpadding="0" border="0" style="border-collapse:collapse;"><tr><td width="6" height="6" style="{BGGOLD}border-radius:3px;font-size:1px;line-height:1px;">&nbsp;</td></tr></table></td>
-                      <td style="font-family:Arial,Helvetica,sans-serif;font-size:14px;line-height:22px;color:#8a7a6a;"><strong style="color:#ffffff;font-weight:700;">One team, everything.</strong> Immigration, company, tax, property &mdash; all under one roof.</td>
+                      <td style="font-family:Arial,Helvetica,sans-serif;font-size:14px;line-height:22px;color:#a8b3c0;"><strong style="color:#ffffff;font-weight:700;">One team, everything.</strong> Immigration, company, tax, property &mdash; all under one roof.</td>
                     </tr></table>
                   </td>
                 </tr>
@@ -564,11 +565,11 @@ def _build_html(
 
           <!-- ══ CTA ══ -->
           <tr>
-            <td style="padding:36px 40px 44px;{BG}border-radius:0 0 14px 14px;border:1px solid #1e1c18;border-top:none;" class="pad" align="center">
+            <td style="padding:36px 40px 44px;{BG}border-radius:0 0 14px 14px;border:1px solid #3a4554;border-top:none;" class="pad" align="center">
               <table cellspacing="0" cellpadding="0" border="0" style="border-collapse:collapse;">
                 <tr>
                   <td style="{BGGOLD}border-radius:10px;">
-                    <a href="https://wa.me/{wa_num}?text=Hi%20Bali%20Zero%2C%20I%20just%20signed%20up" target="_blank" style="display:inline-block;padding:16px 44px;font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:900;color:#0c0d0f;text-decoration:none;text-transform:uppercase;letter-spacing:1.5px;">{cta_label}</a>
+                    <a href="https://wa.me/{wa_num}?text=Hi%20Bali%20Zero%2C%20I%20just%20signed%20up" target="_blank" style="display:inline-block;padding:16px 44px;font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:900;color:#1F2937;text-decoration:none;text-transform:uppercase;letter-spacing:1.5px;">{cta_label}</a>
                   </td>
                 </tr>
               </table>
@@ -580,14 +581,14 @@ def _build_html(
           <tr>
             <td align="center" style="padding:28px 40px 0;{BG}" class="pad">
               <div style="font-family:Arial,Helvetica,sans-serif;font-size:12px;color:#4a3a28;line-height:20px;">
-                <strong style="color:#5a4a18;">Bali Zero</strong> &middot; Kerobokan, Bali, Indonesia<br>
+                <strong style="color:#a8b3c0;">Bali Zero</strong> &middot; Kerobokan, Bali, Indonesia<br>
                 <a href="https://www.balizero.com" style="color:#c8a040;text-decoration:none;">balizero.com</a>
                 &nbsp;&middot;&nbsp;
                 <a href="https://www.instagram.com/balizero" style="color:#c8a040;text-decoration:none;">Instagram</a>
                 &nbsp;&middot;&nbsp;
                 <a href="https://wa.me/{wa_num}" style="color:#c8a040;text-decoration:none;">WhatsApp</a>
               </div>
-              <div style="padding-top:12px;font-family:Arial,Helvetica,sans-serif;font-size:10px;color:#2a2520;letter-spacing:2px;text-transform:uppercase;">
+              <div style="padding-top:12px;font-family:Arial,Helvetica,sans-serif;font-size:10px;color:#3a4554;letter-spacing:2px;text-transform:uppercase;">
                 Powered by humans, fueled by a thinking engine.
               </div>
             </td>

--- a/apps/backend-rag/backend/services/crm/welcome/welcome_email_service.py
+++ b/apps/backend-rag/backend/services/crm/welcome/welcome_email_service.py
@@ -388,7 +388,7 @@ def _build_html(
                   <td align="left" style="padding-bottom:36px;">
                     <table cellspacing="0" cellpadding="0" border="0" style="border-collapse:collapse;"><tr>
                       <td width="112" height="112" style="border-radius:50%;{BG}">
-                        <img src="https://kita.balizero.com/static/balizero-logo-clean.png" width="112" height="112" alt="Bali Zero" style="display:block;border-radius:50%;{BG}" />
+                        <img src="https://kita.balizero.com/static/email/balizero-logo-email.png" width="112" height="112" alt="Bali Zero" style="display:block;border-radius:50%;{BG}" />
                       </td>
                     </tr></table>
                   </td>

--- a/apps/backend-rag/backend/services/invoicing/invoice_service.py
+++ b/apps/backend-rag/backend/services/invoicing/invoice_service.py
@@ -27,7 +27,7 @@ from backend.services.notifications.email_audit import (
     notify_email_failure_critical,
     record_email_result,
 )
-from backend.services.notifications.email_branding import logo_header_html
+from backend.services.notifications.email_branding import logo_header_html, team_email_html
 from backend.services.notifications.email_http import get_email_client
 
 logger = get_logger(__name__)
@@ -321,22 +321,27 @@ class InvoiceAutomationService:
     ) -> bool:
         """Send notification email to accounting (Asya) via internal email API."""
         subject = f"[TEAM] New Invoice {invoice_number} - {client_data['full_name']}"
-        body_html = (
-            f"<p>Hi Asya!</p>"
-            f"<p>A new invoice has just been generated and sent to our client.</p>"
-            f"<p><b>Client Details:</b><br>"
-            f"Name: {client_data['full_name']}<br>"
-            f"Email: {client_data.get('email', 'N/A')}<br>"
-            f"Practice ID: {practice_data['id']}</p>"
-            f"<p><b>Invoice Info:</b><br>"
-            f"Invoice Number: {invoice_number}<br>"
-            f"Amount: IDR {float(practice_data.get('quoted_price', 0)):,.0f}</p>"
-            f"<p>PDF attached.</p>"
-            f"<p><b>Next Steps:</b><br>"
-            f"1. Reach out to the client via WhatsApp for payment follow-up<br>"
-            f"2. Keep an eye on our bank account<br>"
-            f"3. Once payment comes through, update the status to ON PROCESS</p>"
-            f"<p>Warmly,<br>Zantara CRM</p>"
+        amount = float(practice_data.get("quoted_price", 0))
+        body_html = team_email_html(
+            title=f"New Invoice {invoice_number}",
+            intro=f"Hi Asya — a new invoice has been generated and sent to {client_data['full_name']}. PDF attached.",
+            meta_rows=[
+                ("Client", client_data["full_name"]),
+                ("Email", client_data.get("email") or "—"),
+                ("Practice", f"#{practice_data['id']}"),
+                ("Amount", f"IDR {amount:,.0f}"),
+            ],
+            body_html=(
+                "<b>Next steps:</b>"
+                "<ol style='margin:6px 0 4px 18px;padding:0;'>"
+                "<li>Reach out to the client via WhatsApp for payment follow-up</li>"
+                "<li>Keep an eye on our bank account</li>"
+                "<li>Once payment comes through, update the status to ON PROCESS</li>"
+                "</ol>"
+            ),
+            cta_label="Open practice in CRM",
+            cta_url=f"https://kita.balizero.com/process/{practice_data['id']}",
+            signature="Zantara CRM",
         )
 
         pdf_b64 = base64.b64encode(pdf_bytes).decode()

--- a/apps/backend-rag/backend/services/notifications/email_branding.py
+++ b/apps/backend-rag/backend/services/notifications/email_branding.py
@@ -10,6 +10,14 @@ and ships with every Mouth/Vercel deploy.
 
 LOGO_URL = "https://kita.balizero.com/static/email/balizero-logo-email.png"
 
+# Bali Zero standard-doc palette (matches Tax Report cover + invoice PDF)
+COLOR_NAVY = "#1F2937"
+COLOR_GOLD = "#F4B400"
+COLOR_LIGHT = "#F7F8FA"
+COLOR_BORDER = "#E5E7EB"
+COLOR_TEXT = "#1F2937"
+COLOR_MUTED = "#6B7280"
+
 
 def logo_header_html(width_px: int = 96) -> str:
     """Return a centered <img> block to drop at the top of every client email."""
@@ -20,3 +28,104 @@ def logo_header_html(width_px: int = 96) -> str:
         f'style="width:{width_px}px;height:{width_px}px;display:inline-block;">'
         f"</div>"
     )
+
+
+def team_email_html(
+    *,
+    title: str,
+    intro: str,
+    meta_rows: list[tuple[str, str]] | None = None,
+    body_html: str = "",
+    cta_label: str | None = None,
+    cta_url: str | None = None,
+    signature: str = "Zantara CRM",
+) -> str:
+    """Render a clean, on-brand HTML email for internal team notifications.
+
+    Visual style mirrors the Bali Zero standard-doc palette (dark navy
+    header bar + gold accent + neutral greys), the same one used by the
+    invoice PDF and the Tax Report cover.
+    """
+    rows_html = ""
+    if meta_rows:
+        cells = "".join(
+            f'<tr>'
+            f'<td style="padding:6px 12px 6px 0;font-size:12px;color:{COLOR_MUTED};'
+            f'font-family:Helvetica,Arial,sans-serif;white-space:nowrap;width:140px;">'
+            f'{label}</td>'
+            f'<td style="padding:6px 0;font-size:13px;color:{COLOR_TEXT};'
+            f'font-family:Helvetica,Arial,sans-serif;font-weight:600;">'
+            f'{value}</td>'
+            f'</tr>'
+            for label, value in meta_rows
+        )
+        rows_html = (
+            f'<table cellspacing="0" cellpadding="0" border="0" width="100%" '
+            f'style="background:{COLOR_LIGHT};border:1px solid {COLOR_BORDER};'
+            f'border-radius:6px;margin:0 0 20px;">'
+            f'<tr><td style="padding:10px 16px;">'
+            f'<table cellspacing="0" cellpadding="0" border="0">{cells}</table>'
+            f'</td></tr></table>'
+        )
+
+    cta_html = ""
+    if cta_label and cta_url:
+        cta_html = (
+            f'<div style="margin:8px 0 24px;">'
+            f'<a href="{cta_url}" '
+            f'style="display:inline-block;background:{COLOR_GOLD};color:{COLOR_NAVY};'
+            f'font-family:Helvetica,Arial,sans-serif;font-size:13px;font-weight:700;'
+            f'padding:10px 20px;border-radius:6px;text-decoration:none;">'
+            f'{cta_label}</a>'
+            f'</div>'
+        )
+
+    return f"""<!doctype html>
+<html><head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;background:#f4f6f9;font-family:Helvetica,Arial,sans-serif;">
+  <table cellspacing="0" cellpadding="0" border="0" width="100%" style="background:#f4f6f9;">
+    <tr><td align="center" style="padding:24px 12px;">
+      <table cellspacing="0" cellpadding="0" border="0" width="600"
+             style="max-width:600px;background:#ffffff;border-radius:10px;overflow:hidden;
+             box-shadow:0 1px 3px rgba(0,0,0,0.06);">
+        <tr><td style="background:{COLOR_NAVY};padding:18px 28px;">
+          <table cellspacing="0" cellpadding="0" border="0" width="100%">
+            <tr>
+              <td style="font-family:Helvetica,Arial,sans-serif;color:#ffffff;
+                         font-size:11px;letter-spacing:3px;text-transform:uppercase;
+                         font-weight:700;">Bali Zero · Operations</td>
+              <td align="right">
+                <img src="{LOGO_URL}" alt="Bali Zero" width="36" height="36"
+                     style="display:inline-block;vertical-align:middle;">
+              </td>
+            </tr>
+          </table>
+        </td></tr>
+        <tr><td style="height:3px;background:{COLOR_GOLD};line-height:3px;font-size:0;">&nbsp;</td></tr>
+        <tr><td style="padding:28px 28px 8px;">
+          <h1 style="margin:0 0 14px;font-family:Helvetica,Arial,sans-serif;
+                     font-size:20px;color:{COLOR_TEXT};font-weight:700;line-height:1.3;">
+            {title}
+          </h1>
+          <p style="margin:0 0 18px;font-family:Helvetica,Arial,sans-serif;
+                    font-size:14px;color:{COLOR_TEXT};line-height:1.55;">
+            {intro}
+          </p>
+          {rows_html}
+          <div style="font-family:Helvetica,Arial,sans-serif;font-size:14px;
+                      color:{COLOR_TEXT};line-height:1.55;">
+            {body_html}
+          </div>
+          {cta_html}
+        </td></tr>
+        <tr><td style="padding:18px 28px 24px;border-top:1px solid {COLOR_BORDER};
+                       font-family:Helvetica,Arial,sans-serif;font-size:12px;
+                       color:{COLOR_MUTED};">
+          <strong style="color:{COLOR_TEXT};">{signature}</strong><br>
+          Billing: asya@balizero.com · +62 881 0384 67246<br>
+          General: WhatsApp +62 821 3107 363 · balizero.com
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body></html>"""

--- a/docs/superpowers/plans/2026-05-06-bali-zero-pricelist-2026.md
+++ b/docs/superpowers/plans/2026-05-06-bali-zero-pricelist-2026.md
@@ -1,0 +1,2010 @@
+# Bali Zero Price List 2026 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a 2026 Bali Zero price list as ONE versioned JSON source rendered into HTML + PDF + Markdown, with senior visual treatment (cover, hero photography, micro-icon set, batik ornaments) generated via `codex exec` + Image 2 (gpt-image-1).
+
+**Architecture:** Single source `apps/backend-rag/backend/data/bali_zero_official_prices_2026.json` → `scripts/pricelist_2026/generate.py` reads it → emits self-contained HTML (base64-embedded fonts + images) + PDF (Playwright headless print of the HTML) + Markdown (versioned in `docs/pricing/`). Image assets generated upfront in a separate, idempotent step via `scripts/pricelist_2026/generate_assets.py` which shells out to `codex exec`.
+
+**Tech Stack:** Python 3.11+, Jinja2 (HTML template), Playwright (PDF render — already in `apps/backend-rag/requirements.txt:playwright>=1.57.0`), `qrcode` (Python, MIT, no API), `codex exec` CLI 0.128.0 (gpt-image-1 image gen via ChatGPT Plus OAuth — zero per-image cost).
+
+**Spec:** `docs/superpowers/specs/2026-05-06-bali-zero-pricelist-2026-design.md` (commit `0060f6405`).
+
+---
+
+## File Structure
+
+| Path                                                                | Responsibility                                                                                         | Status |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------ |
+| `apps/backend-rag/backend/data/bali_zero_official_prices_2026.json` | Single source of truth — all 80 services + metadata + contacts                                         | NEW    |
+| `scripts/pricelist_2026/__init__.py`                                | Package marker                                                                                         | NEW    |
+| `scripts/pricelist_2026/schema.py`                                  | Lightweight dataclasses + JSON validator (no Pydantic — stdlib only)                                   | NEW    |
+| `scripts/pricelist_2026/generate_assets.py`                         | Idempotent CLI driver that calls `codex exec` for the 6 heros + ~25 icons; skips files already on disk | NEW    |
+| `scripts/pricelist_2026/asset_briefs.py`                            | Brief strings (cover ornament, 6 hero prompts, ~25 icon prompts) — pure data, easy to edit             | NEW    |
+| `scripts/pricelist_2026/generate.py`                                | Reads JSON + assets, renders HTML/PDF/MD via Jinja templates                                           | NEW    |
+| `scripts/pricelist_2026/templates/pricelist.html.j2`                | Single-file HTML template (Jinja2)                                                                     | NEW    |
+| `scripts/pricelist_2026/templates/pricelist.md.j2`                  | Markdown template                                                                                      | NEW    |
+| `scripts/pricelist_2026/tests/test_schema.py`                       | Schema validation tests                                                                                | NEW    |
+| `scripts/pricelist_2026/tests/test_generate.py`                     | Generator output tests                                                                                 | NEW    |
+| `scripts/pricelist_2026/tests/fixtures/minimal_prices.json`         | 2-service fixture for fast tests                                                                       | NEW    |
+| `docs/pricing/Bali_Zero_Price_List_2026.md`                         | Generated Markdown (committed in repo)                                                                 | NEW    |
+| `docs/pricing/assets/2026/heros/*.png`                              | 6 hero images (committed)                                                                              | NEW    |
+| `docs/pricing/assets/2026/icons/*.png`                              | ~25 micro-icons (committed)                                                                            | NEW    |
+| `docs/pricing/assets/2026/logo_circle.png`                          | Copy of `~/Desktop/balizero_logo_circle.png` (committed for reproducibility)                           | NEW    |
+| `~/Desktop/Bali_Zero_Price_List_2026.html`                          | Generated HTML deliverable (NOT committed)                                                             | OUTPUT |
+| `~/Desktop/Bali_Zero_Price_List_2026.pdf`                           | Generated PDF deliverable (NOT committed)                                                              | OUTPUT |
+| `~/Desktop/Bali_Zero_Price_List_2026_assets/`                       | Working dir for codex-generated PNGs before curation (NOT committed)                                   | OUTPUT |
+| `.gitignore`                                                        | Append patterns for outputs above                                                                      | MODIFY |
+
+**Why this layout:** the package structure (`scripts/pricelist_2026/`) keeps generator + templates + tests + briefs co-located. Existing patterns in this repo (e.g., `scripts/wr2_image_generator.py`) use flat `scripts/` files for one-shot helpers; for a multi-file deliverable a package is cleaner and lets us run `pytest scripts/pricelist_2026/tests/` cleanly.
+
+**Why NOT update the backend RAG `PricingTool` here:** explicitly out of scope per spec §2 — the production chatbot keeps reading `_2025.json` until owner approves the swap. This plan ships content + visual deliverable, no production code change.
+
+---
+
+## Task 1: Author the 2026 JSON source
+
+**Files:**
+
+- Create: `apps/backend-rag/backend/data/bali_zero_official_prices_2026.json`
+
+This is content authoring, not code. Use 2025 JSON as starting point + tax dpt input + spec §8 conflict resolutions. Each service entry follows the schema in spec §4.
+
+- [ ] **Step 1: Read the existing 2025 JSON for the entries we keep verbatim**
+
+Run: `cat apps/backend-rag/backend/data/bali_zero_official_prices_2025.json | python3 -c "import json,sys; d=json.load(sys.stdin); print(list(d['services'].keys()))"`
+
+Expected output: `['single_entry_visas', 'visa_extensions', 'multiple_entry_visas', 'kitas_permits', 'kitap_permits', 'company_services', 'other_process', 'urgent_services']`
+
+- [ ] **Step 2: Create the new JSON file with full content**
+
+Write `apps/backend-rag/backend/data/bali_zero_official_prices_2026.json` with this top-level shape:
+
+```json
+{
+  "version": "2026.1",
+  "effective_date": "2026-01-01",
+  "metadata": {
+    "currency": "IDR",
+    "contact": {
+      "email": "zero@balizero.com",
+      "whatsapp": "+62 821 31 07 363",
+      "wa_link": "https://wa.me/628213107363",
+      "location": "Kerobokan, Bali, Indonesia",
+      "website": "balizero.com"
+    },
+    "last_updated": "2026-05-06"
+  },
+  "services": {
+    "single_entry_visas": { ... 6 entries ... },
+    "visa_extensions": { ... 1 entry ... },
+    "multiple_entry_visas": { ... 5 entries ... },
+    "kitas_permits": { ... ~25 entries ... },
+    "kitap_permits": { ... 5 entries; Investor=55M, Dependent=33M, NO ACC ... },
+    "tax_accounting": {
+      "monthly_tax_basic": { 4 tier entries },
+      "monthly_tax_bundled": { 4 tier entries },
+      "annual_basic_packages": { A, B, C, D, Zero Company },
+      "annual_standalone": { LKPM yearly, Annual Tax Co., Annual Tax Personal, Personal additional }
+    },
+    "company_services": { 3 entries; Akta Perubahan unified ONE row },
+    "consultant_services": { 7 entries: PMA close, NPWPD, BPJS Employee, BPJS Insurance, NPWP Personal+Coretax, Update Data, EFIN },
+    "other_process": { ~21 entries copied verbatim from 2025 },
+    "urgent_processing": { 1/2/3 hari }
+  }
+}
+```
+
+Each leaf entry (use this exact shape):
+
+```json
+{
+  "name": "Working KITAS (Altus / Onshore)",
+  "price": "36.000.000 IDR",
+  "tier_range": null,
+  "duration": "",
+  "validity": "1 year",
+  "notes": "",
+  "description_en": "Standard work permit KITAS sponsored by Indonesian employer. Onshore process via Altus, suited to candidates already in Indonesia.",
+  "icon_id": "kitas-working"
+}
+```
+
+For TIER entries (tax monthly), `price` is the empty string and `tier_range` is the array:
+
+```json
+{
+  "name": "Monthly Tax Report — 0 to 50 transactions (without LKPM & Annual)",
+  "price": "",
+  "tier_range": ["1.800.000 IDR", "2.000.000 IDR"],
+  "duration": "",
+  "validity": "monthly",
+  "notes": "Bank + Cash transactions combined. LKPM and Annual Tax NOT included.",
+  "description_en": "Monthly bookkeeping and tax filing for companies with low transaction volume. See section VI.4 for LKPM and Annual Tax stand-alone fees.",
+  "icon_id": "tax-monthly"
+}
+```
+
+Description text for the ~80 entries: write 1-2 sentences each, ENGLISH ONLY, factual, no marketing fluff. Source for descriptions:
+
+- Visa entries: use `data/kb_sources/visa_imigrasi_list.txt` and `apps/backend-rag/backend/prompts/zantara_core.py` for accurate visa-type descriptions if available; otherwise concise standard definitions ("Tourist visa, single entry, valid 60 days. Cannot be used for work or business activities.")
+- KITAS/KITAP: use existing JSON `notes` field where present + standard immigration definitions
+- Tax: use the verbatim text the user provided in the brainstorming session (paraphrased into 1-2 sentence descriptions)
+- Company / Consultant / Other: standard one-line definitions
+
+Conflict resolutions (re-confirm against spec §8):
+
+- `kitap_permits["Investor KITAP + MERP"].price` = `"55.000.000 IDR"`, no `ACC` text in `notes`
+- `kitap_permits["Dependent KITAP + MERP"].price` = `"33.000.000 IDR"`, no `ACC` text in `notes`
+- `company_services` has ONE entry "Akta Perubahan (Revision Company)" with `price: "Depend (Contact for quote)"` — drop the duplicate `Revision Company` entry that exists in 2025 JSON
+
+Tax & Accounting reference (from user's 2026-05-06 message):
+
+```
+monthly_tax_basic (without LKPM/Annual):
+  0-50 tx       → 1.8 - 2.0 mil/month
+  50-100 tx     → 2.5 - 3.0 mil/month
+  100-200 tx    → 3.5 - 4.5 mil/month
+  >200 tx       → 5.0 mil/month (must do monthly OR get monthly fee for 1 year)
+
+monthly_tax_bundled (including LKPM + Annual):
+  0-50 tx       → 2.5 mil/month
+  50-100 tx     → 3.5 mil/month
+  100-200 tx    → 4.5 mil/month
+  >200 tx       → 6.5 mil/month
+
+annual_basic_packages:
+  Package A     → ≤100 tx/year, 6 mil   — Income Tax only + Yearly Financial Report
+  Package B     → 100-200 tx/year, 9 mil — Income Tax only + Yearly Financial Report
+  Package C     → ≤100 tx/year, 12 mil  — Income Tax + (PPH 21 OR PPH Sewa, choose 1) + Yearly Financial Report
+  Package D     → 100-200 tx/year, 15 mil — Income Tax + (PPH 21 OR PPH Sewa, choose 1) + Yearly Financial Report
+  Annual Company ZERO → 3 mil — No transactions in/out, just Yearly Financial Report
+
+annual_standalone:
+  LKPM yearly                 → 4.000.000 IDR
+  Annual Tax Company          → 4.000.000 IDR
+  Annual Tax Personal         → 1.000.000 IDR
+  Annual Tax Personal (each additional) → 1.500.000 IDR
+
+consultant_services:
+  Close PMA company           → 6.000.000 - 7.500.000 IDR (process max 1 year)
+  NPWPD registration          → 2.500.000 IDR (per location)
+  BPJS Employee (Tenaga Kerja) → 2.500.000 IDR
+  BPJS Insurance (Kesehatan)  → 2.500.000 IDR
+  NPWP Personal + Coretax activation → 1.000.000 IDR (per person)
+  Update data (email/phone) or Coretax activation → 1.000.000 IDR
+  EFIN application            → 1.000.000 IDR
+```
+
+Set `icon_id` for every service using kebab-case slugs that we'll map 1:1 to icon PNGs in Task 4 (e.g., `visa-c1`, `kitas-working`, `tax-monthly`, `company-pma`, `consultant-bpjs`, `other-passport`, `urgent-1day`). When two services would share the same visual concept (e.g., `kitas-working` for both Altus and Offshore variants), reuse the same `icon_id` — we generate ~25 unique icons, not one per service.
+
+- [ ] **Step 3: Validate the JSON parses + count entries**
+
+Run:
+
+```bash
+python3 -c "
+import json
+d = json.load(open('apps/backend-rag/backend/data/bali_zero_official_prices_2026.json'))
+total = sum(len(v) for v in d['services'].values() if isinstance(v, dict) and not any(isinstance(x, dict) and 'name' not in x for x in v.values()))
+# tax_accounting is nested 2 levels — count its grandchildren
+tax_count = sum(len(sub) for sub in d['services']['tax_accounting'].values())
+flat_total = sum(len(v) for k,v in d['services'].items() if k != 'tax_accounting')
+print(f'Total services: {flat_total + tax_count}')
+print(f'Categories: {list(d[\"services\"].keys())}')
+print(f'Contact: {d[\"metadata\"][\"contact\"][\"whatsapp\"]}')
+"
+```
+
+Expected: `Total services: 80` (give or take 2 — the count is approximate), all 10 categories listed, WhatsApp `+62 821 31 07 363`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/backend-rag/backend/data/bali_zero_official_prices_2026.json
+git commit -m "data(pricing): add 2026 Bali Zero price list JSON source
+
+Single source of truth for the 2026 price list — 80 services across 10
+categories, contacts updated to zero@balizero.com / +62 821 31 07 363 /
+Kerobokan, KITAP conflicts resolved (Investor 55M, Dependent 33M, no
+ACC), Akta Perubahan unified, new Tax & Accounting + Consultant Services
+sections added.
+
+Production RAG PricingTool continues reading the 2025 JSON; this file is
+only consumed by scripts/pricelist_2026/ until owner approves the swap.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Schema validator (TDD)
+
+**Files:**
+
+- Create: `scripts/pricelist_2026/__init__.py` (empty file)
+- Create: `scripts/pricelist_2026/schema.py`
+- Create: `scripts/pricelist_2026/tests/__init__.py` (empty)
+- Create: `scripts/pricelist_2026/tests/test_schema.py`
+- Create: `scripts/pricelist_2026/tests/fixtures/minimal_prices.json`
+
+The validator catches drift before render time: missing required fields, both `price` and `tier_range` empty, contact mismatch, etc. Stdlib only.
+
+- [ ] **Step 1: Create empty package markers**
+
+```bash
+mkdir -p scripts/pricelist_2026/tests/fixtures
+touch scripts/pricelist_2026/__init__.py
+touch scripts/pricelist_2026/tests/__init__.py
+```
+
+- [ ] **Step 2: Create the test fixture**
+
+Write `scripts/pricelist_2026/tests/fixtures/minimal_prices.json`:
+
+```json
+{
+  "version": "2026.1",
+  "effective_date": "2026-01-01",
+  "metadata": {
+    "currency": "IDR",
+    "contact": {
+      "email": "zero@balizero.com",
+      "whatsapp": "+62 821 31 07 363",
+      "wa_link": "https://wa.me/628213107363",
+      "location": "Kerobokan, Bali, Indonesia",
+      "website": "balizero.com"
+    },
+    "last_updated": "2026-05-06"
+  },
+  "services": {
+    "single_entry_visas": {
+      "C1 Tourism": {
+        "name": "C1 Tourism",
+        "price": "2.300.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "60 days",
+        "notes": "",
+        "description_en": "Tourist visa, single entry, valid 60 days.",
+        "icon_id": "visa-tourism"
+      }
+    },
+    "tax_accounting": {
+      "monthly_tax_basic": {
+        "Tier 0-50": {
+          "name": "Monthly Tax Report — 0 to 50 transactions",
+          "price": "",
+          "tier_range": ["1.800.000 IDR", "2.000.000 IDR"],
+          "duration": "",
+          "validity": "monthly",
+          "notes": "",
+          "description_en": "Monthly bookkeeping for low volume.",
+          "icon_id": "tax-monthly"
+        }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Write the failing tests**
+
+Write `scripts/pricelist_2026/tests/test_schema.py`:
+
+```python
+"""Tests for the 2026 price list JSON schema validator."""
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.pricelist_2026 import schema
+
+FIXTURE = Path(__file__).parent / "fixtures" / "minimal_prices.json"
+
+
+def _load_fixture():
+    return json.loads(FIXTURE.read_text())
+
+
+def test_valid_fixture_passes():
+    data = _load_fixture()
+    result = schema.validate(data)
+    assert result.ok, f"Expected valid fixture to pass, got errors: {result.errors}"
+
+
+def test_missing_top_level_version_fails():
+    data = _load_fixture()
+    del data["version"]
+    result = schema.validate(data)
+    assert not result.ok
+    assert any("version" in e for e in result.errors)
+
+
+def test_contact_whatsapp_must_match_canonical():
+    data = _load_fixture()
+    data["metadata"]["contact"]["whatsapp"] = "+62 813 3805 1876"
+    result = schema.validate(data)
+    assert not result.ok
+    assert any("whatsapp" in e for e in result.errors)
+
+
+def test_service_with_neither_price_nor_tier_range_fails():
+    data = _load_fixture()
+    data["services"]["single_entry_visas"]["C1 Tourism"]["price"] = ""
+    data["services"]["single_entry_visas"]["C1 Tourism"]["tier_range"] = None
+    result = schema.validate(data)
+    assert not result.ok
+    assert any("must have price or tier_range" in e for e in result.errors)
+
+
+def test_service_with_both_price_and_tier_range_fails():
+    data = _load_fixture()
+    svc = data["services"]["single_entry_visas"]["C1 Tourism"]
+    svc["price"] = "2.300.000 IDR"
+    svc["tier_range"] = ["1 IDR", "2 IDR"]
+    result = schema.validate(data)
+    assert not result.ok
+    assert any("not both" in e for e in result.errors)
+
+
+def test_service_missing_description_en_fails():
+    data = _load_fixture()
+    del data["services"]["single_entry_visas"]["C1 Tourism"]["description_en"]
+    result = schema.validate(data)
+    assert not result.ok
+    assert any("description_en" in e for e in result.errors)
+
+
+def test_service_missing_icon_id_fails():
+    data = _load_fixture()
+    del data["services"]["single_entry_visas"]["C1 Tourism"]["icon_id"]
+    result = schema.validate(data)
+    assert not result.ok
+    assert any("icon_id" in e for e in result.errors)
+
+
+def test_tier_range_must_be_two_strings():
+    data = _load_fixture()
+    data["services"]["tax_accounting"]["monthly_tax_basic"]["Tier 0-50"]["tier_range"] = ["only one"]
+    result = schema.validate(data)
+    assert not result.ok
+    assert any("tier_range" in e for e in result.errors)
+
+
+def test_real_2026_json_validates():
+    """Sanity check: the actual file we ship must validate."""
+    real = Path("apps/backend-rag/backend/data/bali_zero_official_prices_2026.json")
+    if not real.exists():
+        pytest.skip("real JSON not yet authored")
+    data = json.loads(real.read_text())
+    result = schema.validate(data)
+    assert result.ok, f"Real 2026 JSON failed validation: {result.errors}"
+```
+
+- [ ] **Step 4: Run tests to verify they fail (no schema.py yet)**
+
+Run: `cd /Users/nuzantara/Desktop/nuzantara && python3 -m pytest scripts/pricelist_2026/tests/test_schema.py -v 2>&1 | tail -20`
+
+Expected: ALL tests FAIL with `ModuleNotFoundError: No module named 'scripts.pricelist_2026.schema'`.
+
+- [ ] **Step 5: Implement schema.py minimally to pass**
+
+Write `scripts/pricelist_2026/schema.py`:
+
+```python
+"""JSON schema validator for the 2026 Bali Zero price list.
+
+Stdlib only. Returns a `ValidationResult` with .ok and .errors.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+CANONICAL_CONTACT = {
+    "email": "zero@balizero.com",
+    "whatsapp": "+62 821 31 07 363",
+    "wa_link": "https://wa.me/628213107363",
+    "location": "Kerobokan, Bali, Indonesia",
+    "website": "balizero.com",
+}
+
+REQUIRED_TOP_LEVEL = ["version", "effective_date", "metadata", "services"]
+REQUIRED_METADATA = ["currency", "contact", "last_updated"]
+REQUIRED_CONTACT = list(CANONICAL_CONTACT.keys())
+REQUIRED_SERVICE_FIELDS = [
+    "name", "price", "tier_range", "duration", "validity",
+    "notes", "description_en", "icon_id",
+]
+
+
+@dataclass
+class ValidationResult:
+    ok: bool = True
+    errors: list[str] = field(default_factory=list)
+
+    def fail(self, msg: str) -> None:
+        self.ok = False
+        self.errors.append(msg)
+
+
+def validate(data: dict[str, Any]) -> ValidationResult:
+    result = ValidationResult()
+
+    for key in REQUIRED_TOP_LEVEL:
+        if key not in data:
+            result.fail(f"top-level: missing '{key}'")
+
+    metadata = data.get("metadata", {})
+    for key in REQUIRED_METADATA:
+        if key not in metadata:
+            result.fail(f"metadata: missing '{key}'")
+
+    contact = metadata.get("contact", {})
+    for key, expected in CANONICAL_CONTACT.items():
+        actual = contact.get(key)
+        if actual is None:
+            result.fail(f"metadata.contact: missing '{key}'")
+        elif actual != expected:
+            result.fail(
+                f"metadata.contact.{key} mismatch: expected '{expected}', got '{actual}'"
+            )
+
+    services = data.get("services", {})
+    for category, entries in services.items():
+        # tax_accounting has ONE extra level of nesting (sub-blocks)
+        if category == "tax_accounting":
+            for subblock, subentries in entries.items():
+                for name, svc in subentries.items():
+                    _validate_service(result, f"{category}.{subblock}.{name}", svc)
+        else:
+            for name, svc in entries.items():
+                _validate_service(result, f"{category}.{name}", svc)
+
+    return result
+
+
+def _validate_service(result: ValidationResult, path: str, svc: dict) -> None:
+    for field_name in REQUIRED_SERVICE_FIELDS:
+        if field_name not in svc:
+            result.fail(f"{path}: missing field '{field_name}'")
+
+    price = svc.get("price", "")
+    tier = svc.get("tier_range")
+
+    has_price = bool(price and price.strip())
+    has_tier = tier is not None and isinstance(tier, list) and len(tier) == 2
+
+    if not has_price and not has_tier:
+        result.fail(f"{path}: must have price or tier_range")
+    if has_price and has_tier:
+        result.fail(f"{path}: must have price or tier_range, not both")
+
+    if tier is not None:
+        if not isinstance(tier, list) or len(tier) != 2:
+            result.fail(f"{path}: tier_range must be a list of exactly 2 strings")
+        elif not all(isinstance(x, str) for x in tier):
+            result.fail(f"{path}: tier_range entries must be strings")
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd /Users/nuzantara/Desktop/nuzantara && python3 -m pytest scripts/pricelist_2026/tests/test_schema.py -v 2>&1 | tail -20`
+
+Expected: ALL 9 tests PASS (including `test_real_2026_json_validates` since Task 1 already created the real file).
+
+If `test_real_2026_json_validates` fails: the real JSON has a violation — fix the JSON, not the test.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/pricelist_2026/__init__.py scripts/pricelist_2026/schema.py scripts/pricelist_2026/tests/
+git commit -m "feat(pricelist-2026): add JSON schema validator
+
+Stdlib-only validator for the 2026 price list JSON. Catches missing
+required fields, contact drift (e.g. wrong WhatsApp number), services
+with neither price nor tier_range, malformed tier_range arrays. 9 tests
+including a smoke test against the real apps/backend-rag/backend/data/
+bali_zero_official_prices_2026.json.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Asset briefs module
+
+**Files:**
+
+- Create: `scripts/pricelist_2026/asset_briefs.py`
+
+Pure data — separates the brief strings from the generation logic so brand reviewers can edit prompts without touching the script. Each brief includes the constraints (palette hex, "no text, no logos, slow magazine photography aesthetic") inline.
+
+- [ ] **Step 1: Write asset_briefs.py**
+
+Write `scripts/pricelist_2026/asset_briefs.py`:
+
+```python
+"""Briefs for codex exec → Image 2 (gpt-image-1) generation.
+
+Pure data, no I/O. Each entry is (output_basename, brief_text, size).
+"""
+from __future__ import annotations
+
+# Shared style constraints injected into every brief
+_STYLE_HEROS = (
+    "Cinematic editorial still-life. Slow-magazine photography aesthetic, "
+    "low-key chiaroscuro, shallow depth of field. Palette anchored on deep "
+    "navy #1d273b, copper #d4845a, warm gold #c9a96e on cream paper #fbfaf6 "
+    "highlights. NO TEXT, NO LOGOS, NO WATERMARKS, NO READABLE WRITING on "
+    "any surface. 16:9 landscape composition."
+)
+
+_STYLE_ICONS = (
+    "Single line-art icon, 2px stroke weight, copper color #d4845a only, "
+    "transparent background, centered in 1024×1024 frame, minimalist "
+    "editorial style, no fill, no shadows, single subject only. NO TEXT."
+)
+
+# 6 hero photographs, one per macro-section
+HERO_BRIEFS: list[tuple[str, str, str]] = [
+    (
+        "01_visas",
+        f"{_STYLE_HEROS} Subject: open passport with embossed Indonesian "
+        "visa stamp resting on travertine marble surface, soft dawn light "
+        "from upper left, brass key in soft focus background.",
+        "1792x1024",
+    ),
+    (
+        "02_kitas_kitap",
+        f"{_STYLE_HEROS} Subject: tilt-shift Jakarta skyline at golden hour "
+        "bokeh in background, foreground crisp printed Letter of Approval "
+        "document with embossed seal partly visible (no readable text on "
+        "document).",
+        "1792x1024",
+    ),
+    (
+        "03_tax",
+        f"{_STYLE_HEROS} Subject: macro detail of a vintage fountain pen "
+        "poised over a blank ledger page, Indonesian rupiah banknotes "
+        "blurred at edge, copper highlights on metal pen body.",
+        "1792x1024",
+    ),
+    (
+        "04_company",
+        f"{_STYLE_HEROS} Subject: notarial seal pressed into deep red "
+        "sealing wax on cream Akta document, hand of notary partly visible "
+        "holding brass seal (no readable text on document).",
+        "1792x1024",
+    ),
+    (
+        "05_other_process",
+        f"{_STYLE_HEROS} Subject: top-down flat-lay of identity documents, "
+        "immigration stamps, brass paperclips on cream linen surface, soft "
+        "diffused window light (no readable text on documents).",
+        "1792x1024",
+    ),
+    (
+        "06_urgent",
+        f"{_STYLE_HEROS} Subject: crystal hourglass with copper sand "
+        "mid-flow, deep navy background, single beam of light from upper "
+        "right, dramatic shadow.",
+        "1792x1024",
+    ),
+]
+
+# Micro-icons keyed by icon_id used in the JSON
+ICON_BRIEFS: dict[str, str] = {
+    "visa-tourism":      f"{_STYLE_ICONS} Subject: passport with palm tree.",
+    "visa-business":     f"{_STYLE_ICONS} Subject: briefcase with passport corner.",
+    "visa-art":          f"{_STYLE_ICONS} Subject: musical note inside circle.",
+    "visa-internship":   f"{_STYLE_ICONS} Subject: graduation cap.",
+    "visa-worktrial":    f"{_STYLE_ICONS} Subject: clipboard with checkmark.",
+    "visa-extension":    f"{_STYLE_ICONS} Subject: calendar page with curved arrow.",
+    "visa-multiple":     f"{_STYLE_ICONS} Subject: passport with two arrows in opposite directions.",
+    "visa-investigation":f"{_STYLE_ICONS} Subject: magnifying glass over briefcase.",
+    "kitas-working":     f"{_STYLE_ICONS} Subject: hard hat over document.",
+    "kitas-investor":    f"{_STYLE_ICONS} Subject: rising bar chart with coin.",
+    "kitas-freelance":   f"{_STYLE_ICONS} Subject: laptop with palm leaf.",
+    "kitas-remote":      f"{_STYLE_ICONS} Subject: laptop with wifi waves.",
+    "kitas-spouse":      f"{_STYLE_ICONS} Subject: two interlocking rings.",
+    "kitas-dependent":   f"{_STYLE_ICONS} Subject: silhouettes of family of three.",
+    "kitas-retirement":  f"{_STYLE_ICONS} Subject: lounge chair under palm tree.",
+    "kitap-permanent":   f"{_STYLE_ICONS} Subject: house with key.",
+    "kitap-merp":        f"{_STYLE_ICONS} Subject: airplane with re-entry arrows.",
+    "tax-monthly":       f"{_STYLE_ICONS} Subject: calendar page with currency symbol.",
+    "tax-annual":        f"{_STYLE_ICONS} Subject: ledger book with bookmark ribbon.",
+    "tax-lkpm":          f"{_STYLE_ICONS} Subject: bar chart inside government building outline.",
+    "tax-personal":      f"{_STYLE_ICONS} Subject: single person silhouette with document.",
+    "company-pma":       f"{_STYLE_ICONS} Subject: Indonesian temple gate (candi bentar) outline.",
+    "company-virtual":   f"{_STYLE_ICONS} Subject: cloud with building inside.",
+    "company-akta":      f"{_STYLE_ICONS} Subject: scroll with notary seal.",
+    "company-close":     f"{_STYLE_ICONS} Subject: building with X-mark over door.",
+    "consultant-npwpd":  f"{_STYLE_ICONS} Subject: city map pin over document.",
+    "consultant-bpjs-tk":f"{_STYLE_ICONS} Subject: hand over worker silhouette.",
+    "consultant-bpjs-kes":f"{_STYLE_ICONS} Subject: medical cross inside shield.",
+    "consultant-npwp":   f"{_STYLE_ICONS} Subject: ID card with hash symbol.",
+    "consultant-update": f"{_STYLE_ICONS} Subject: pencil over document.",
+    "consultant-efin":   f"{_STYLE_ICONS} Subject: digital fingerprint.",
+    "other-passport":    f"{_STYLE_ICONS} Subject: passport icon.",
+    "other-sktt":        f"{_STYLE_ICONS} Subject: ID card with house outline.",
+    "other-skck":        f"{_STYLE_ICONS} Subject: shield with checkmark.",
+    "other-domicile":    f"{_STYLE_ICONS} Subject: house with document.",
+    "other-born":        f"{_STYLE_ICONS} Subject: stork.",
+    "other-epo":         f"{_STYLE_ICONS} Subject: door with single right arrow exiting.",
+    "other-erp":         f"{_STYLE_ICONS} Subject: door with two arrows (in and out).",
+    "other-mutation":    f"{_STYLE_ICONS} Subject: passport with curved transfer arrow.",
+    "other-cancel":      f"{_STYLE_ICONS} Subject: document with diagonal X-mark.",
+    "other-molina":      f"{_STYLE_ICONS} Subject: refresh circular arrow.",
+    "other-boarding":    f"{_STYLE_ICONS} Subject: airplane boarding pass.",
+    "urgent-1day":       f"{_STYLE_ICONS} Subject: stopwatch showing 1.",
+    "urgent-2day":       f"{_STYLE_ICONS} Subject: stopwatch showing 2.",
+    "urgent-3day":       f"{_STYLE_ICONS} Subject: stopwatch showing 3.",
+}
+```
+
+- [ ] **Step 2: Verify the module imports cleanly + count entries**
+
+Run:
+
+```bash
+cd /Users/nuzantara/Desktop/nuzantara && python3 -c "
+from scripts.pricelist_2026 import asset_briefs as ab
+print(f'Heros: {len(ab.HERO_BRIEFS)}')
+print(f'Icons: {len(ab.ICON_BRIEFS)}')
+print(f'First hero brief len: {len(ab.HERO_BRIEFS[0][1])} chars')
+"
+```
+
+Expected: `Heros: 6`, `Icons: 44` (one per icon_id used in the JSON — final count depends on how many distinct icon_ids you set in Task 1, adjust briefs to match).
+
+If the count doesn't match `set(svc["icon_id"] for svc in <all entries>)`, add the missing brief entries. The generator in Task 5 will fail loudly if any `icon_id` is missing a brief.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/pricelist_2026/asset_briefs.py
+git commit -m "feat(pricelist-2026): add Image 2 briefs for hero + icon assets
+
+6 cinematic hero briefs (one per macro-section) + ~44 line-art icon
+briefs keyed by icon_id. All include explicit no-text/no-logo/palette
+constraints to keep gpt-image-1 outputs on-brand.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Asset generation driver (codex exec wrapper)
+
+**Files:**
+
+- Create: `scripts/pricelist_2026/generate_assets.py`
+
+Idempotent CLI: skips assets already present on disk, only generates missing ones. Uses `codex exec` non-interactively with explicit instructions to call gpt-image-1 and save to a known path.
+
+- [ ] **Step 1: Verify codex exec is available**
+
+Run: `which codex && codex --version`
+Expected: `/opt/homebrew/bin/codex` and version `0.128.0` or higher.
+
+If not found: STOP. Ask owner to install Codex CLI before continuing. Do NOT introduce a fallback that would call a paid Anthropic API.
+
+- [ ] **Step 2: Write generate_assets.py**
+
+Write `scripts/pricelist_2026/generate_assets.py`:
+
+```python
+"""Driver: generates hero + icon PNGs via `codex exec` → Image 2 (gpt-image-1).
+
+Idempotent: skips files already present in the output dir. Use
+--regenerate <basename> to force re-gen of a specific asset.
+"""
+from __future__ import annotations
+
+import argparse
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.pricelist_2026 import asset_briefs
+
+DEFAULT_OUT = Path.home() / "Desktop" / "Bali_Zero_Price_List_2026_assets"
+
+
+def _check_codex() -> None:
+    if shutil.which("codex") is None:
+        sys.exit(
+            "ERROR: `codex` CLI not found in PATH. Install Codex CLI before "
+            "running this script. Do NOT introduce paid-API fallbacks."
+        )
+
+
+def _codex_image_prompt(brief: str, out_path: Path, size: str) -> str:
+    """Wrap the brief in instructions Codex will follow non-interactively."""
+    return (
+        f"Generate ONE image using OpenAI gpt-image-1 (Image 2). "
+        f"Brief: {brief} "
+        f"Size: {size}. "
+        f"Save the resulting PNG file at exactly this absolute path: "
+        f"{out_path}. "
+        f"Do not output anything else after generation. Do not explain. "
+        f"Do not generate variants. Do not ask for confirmation."
+    )
+
+
+def _generate_one(brief: str, out_path: Path, size: str, *, dry_run: bool) -> bool:
+    """Returns True if generated, False if skipped."""
+    if out_path.exists():
+        print(f"  ✓ skip (exists): {out_path.name}")
+        return False
+    prompt = _codex_image_prompt(brief, out_path, size)
+    if dry_run:
+        print(f"  [dry-run] would gen: {out_path.name}")
+        print(f"           prompt: {prompt[:120]}...")
+        return True
+    print(f"  ⏳ generating: {out_path.name} ({size})")
+    cmd = ["codex", "exec", "--full-auto", prompt]
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=300
+        )
+    except subprocess.TimeoutExpired:
+        print(f"  ✗ TIMEOUT: {out_path.name}", file=sys.stderr)
+        return False
+    if result.returncode != 0:
+        print(
+            f"  ✗ codex exec failed (exit {result.returncode}): "
+            f"{result.stderr[:300]}",
+            file=sys.stderr,
+        )
+        return False
+    if not out_path.exists():
+        print(
+            f"  ✗ codex completed but file not at {out_path}", file=sys.stderr
+        )
+        print(f"     stdout: {result.stdout[:300]}", file=sys.stderr)
+        return False
+    print(f"  ✓ generated: {out_path.name} ({out_path.stat().st_size} bytes)")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT)
+    parser.add_argument(
+        "--only", choices=["heros", "icons", "all"], default="all"
+    )
+    parser.add_argument(
+        "--regenerate", action="append", default=[],
+        help="Force re-gen of basename (without .png). Repeatable."
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    _check_codex()
+
+    heros_dir = args.out_dir / "heros"
+    icons_dir = args.out_dir / "icons"
+    heros_dir.mkdir(parents=True, exist_ok=True)
+    icons_dir.mkdir(parents=True, exist_ok=True)
+
+    # Force re-gen by deleting the existing PNGs first
+    for basename in args.regenerate:
+        for d in (heros_dir, icons_dir):
+            target = d / f"{basename}.png"
+            if target.exists():
+                print(f"  ✗ deleting for re-gen: {target}")
+                target.unlink()
+
+    n_gen = 0
+    n_skip = 0
+
+    if args.only in ("heros", "all"):
+        print(f"=== Heros ({len(asset_briefs.HERO_BRIEFS)}) ===")
+        for basename, brief, size in asset_briefs.HERO_BRIEFS:
+            out = heros_dir / f"{basename}.png"
+            if _generate_one(brief, out, size, dry_run=args.dry_run):
+                n_gen += 1
+            else:
+                if out.exists():
+                    n_skip += 1
+
+    if args.only in ("icons", "all"):
+        print(f"=== Icons ({len(asset_briefs.ICON_BRIEFS)}) ===")
+        for icon_id, brief in sorted(asset_briefs.ICON_BRIEFS.items()):
+            out = icons_dir / f"{icon_id}.png"
+            if _generate_one(brief, out, "1024x1024", dry_run=args.dry_run):
+                n_gen += 1
+            else:
+                if out.exists():
+                    n_skip += 1
+
+    print(f"\nDone. Generated: {n_gen}, Skipped (already exist): {n_skip}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 3: Dry-run to verify the driver wires up correctly**
+
+Run: `cd /Users/nuzantara/Desktop/nuzantara && python3 -m scripts.pricelist_2026.generate_assets --dry-run`
+
+Expected output: lists 6 heros + ~44 icons that "would gen", no actual codex calls.
+
+If `ModuleNotFoundError`: ensure `__init__.py` files exist (Task 2 step 1).
+
+- [ ] **Step 4: Real run for ONE hero as a smoke test**
+
+Run: `cd /Users/nuzantara/Desktop/nuzantara && python3 -m scripts.pricelist_2026.generate_assets --only heros --regenerate 01_visas`
+
+Expected: `codex exec` runs, outputs a PNG at `~/Desktop/Bali_Zero_Price_List_2026_assets/heros/01_visas.png`. Open it manually to verify it matches the brief (cinematic, no text, on-palette).
+
+If output is off-brand or contains text: edit `asset_briefs.py:HERO_BRIEFS[0]`, re-run with `--regenerate 01_visas`. Iterate up to 3 times. If still bad, document in spec §13 Open Items and continue with manual sourcing later — don't block the plan.
+
+- [ ] **Step 5: Full run for all assets**
+
+Run: `cd /Users/nuzantara/Desktop/nuzantara && python3 -m scripts.pricelist_2026.generate_assets`
+
+Expected: ~50 codex exec calls, ~10-30 minutes wallclock total. Check output dir size: `du -sh ~/Desktop/Bali_Zero_Price_List_2026_assets/`.
+
+- [ ] **Step 6: Curate — visually review every output**
+
+Run: `open ~/Desktop/Bali_Zero_Price_List_2026_assets/heros/ && open ~/Desktop/Bali_Zero_Price_List_2026_assets/icons/`
+
+For each hero or icon that is off-brand, contains text, or doesn't match the brief: regenerate via `--regenerate <basename>`. Continue until all assets are acceptable.
+
+- [ ] **Step 7: Copy curated assets into the repo**
+
+```bash
+mkdir -p docs/pricing/assets/2026/heros docs/pricing/assets/2026/icons
+cp ~/Desktop/Bali_Zero_Price_List_2026_assets/heros/*.png docs/pricing/assets/2026/heros/
+cp ~/Desktop/Bali_Zero_Price_List_2026_assets/icons/*.png docs/pricing/assets/2026/icons/
+cp ~/Desktop/balizero_logo_circle.png docs/pricing/assets/2026/logo_circle.png
+ls docs/pricing/assets/2026/heros/ | wc -l
+ls docs/pricing/assets/2026/icons/ | wc -l
+```
+
+Expected: `6` heros, ~44 icons.
+
+- [ ] **Step 8: Commit assets + driver**
+
+```bash
+git add scripts/pricelist_2026/generate_assets.py docs/pricing/assets/2026/
+git commit -m "feat(pricelist-2026): generate hero + icon assets via codex exec
+
+Idempotent driver that calls codex exec → Image 2 (gpt-image-1) for the
+6 cinematic heros + ~44 line-art icons. Skips existing files so reruns
+are safe; --regenerate <basename> forces re-gen. Curated PNGs committed
+under docs/pricing/assets/2026/ so the renderer is reproducible without
+re-spending image-gen quota.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: HTML template (Jinja2)
+
+**Files:**
+
+- Create: `scripts/pricelist_2026/templates/pricelist.html.j2`
+
+Single-file HTML template. All CSS inline. Loops over the JSON sections producing cover, ToC, section dividers (each with hero), service rows (each with icon), closing page (with QR code). Image src values use `data:image/png;base64,...` placeholders that the generator (Task 6) fills.
+
+- [ ] **Step 1: Create templates dir + write the template**
+
+```bash
+mkdir -p scripts/pricelist_2026/templates
+```
+
+Write `scripts/pricelist_2026/templates/pricelist.html.j2` (this is the full template — engineers reading should not have to reconstruct CSS):
+
+```jinja
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Bali Zero — Price List 2026</title>
+<style>
+  /* Inlined fonts (base64 woff2 set by generator) */
+  {{ font_face_block | safe }}
+
+  :root {
+    --paper: #fbfaf6;
+    --navy: #1d273b;
+    --navy-elevated: #243047;
+    --copper: #d4845a;
+    --gold: #c9a96e;
+    --cool-blue: #5e7fb5;
+    --cream: #edeae4;
+    --muted: #8c8884;
+    --subtle: #575350;
+  }
+
+  @page {
+    size: A4 portrait;
+    margin: 0;
+  }
+
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--paper); color: var(--navy); }
+  body {
+    font-family: 'Inter', system-ui, sans-serif;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+
+  .page {
+    width: 210mm;
+    min-height: 297mm;
+    padding: 80px 60px;
+    position: relative;
+    page-break-after: always;
+    background: var(--paper);
+  }
+  .page.dark { background: var(--navy); color: var(--cream); }
+
+  /* COVER */
+  .cover {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    background: var(--navy);
+    color: var(--cream);
+    overflow: hidden;
+  }
+  .cover .batik {
+    position: absolute; inset: 0; opacity: 0.08;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'><path d='M0 20 L20 0 L40 20 L20 40 Z' fill='none' stroke='%23c9a96e' stroke-width='0.6'/></svg>");
+    background-size: 40px 40px;
+  }
+  .cover img.logo { width: 200px; height: 200px; margin-bottom: 40px; z-index: 1; }
+  .cover h1 {
+    font-family: 'Cormorant Garamond', serif; font-weight: 600;
+    font-size: 96px; letter-spacing: 0.04em; margin: 0; z-index: 1;
+  }
+  .cover .hairline {
+    width: 80px; height: 2px; background: var(--copper);
+    margin: 24px 0; z-index: 1;
+  }
+  .cover .subtitle {
+    font-family: 'League Spartan', sans-serif; font-weight: 500;
+    font-size: 28px; color: var(--gold); letter-spacing: 0.18em;
+    text-transform: uppercase; z-index: 1;
+  }
+  .cover .tags {
+    margin-top: 80px; color: var(--copper); letter-spacing: 0.1em; z-index: 1;
+  }
+  .cover .footer {
+    position: absolute; bottom: 60px; font-size: 11px; color: var(--muted);
+    z-index: 1;
+  }
+
+  /* RUNNING HEADER (page 2+) */
+  .header {
+    position: absolute; top: 30px; left: 60px; right: 60px;
+    display: flex; justify-content: space-between; font-size: 10px;
+    color: var(--muted); letter-spacing: 0.08em; text-transform: uppercase;
+    border-bottom: 0.5px solid var(--gold); padding-bottom: 8px;
+  }
+
+  /* PAGE NUMBER */
+  .page-num {
+    position: absolute; bottom: 30px; right: 60px;
+    font-family: 'Cormorant Garamond', serif; font-size: 11px;
+    color: var(--subtle);
+  }
+
+  /* TOC */
+  .toc h1 {
+    font-family: 'Cormorant Garamond', serif; font-size: 48px;
+    font-weight: 600; margin: 0 0 40px;
+  }
+  .toc ul { list-style: none; padding: 0; margin: 0; }
+  .toc li {
+    display: flex; align-items: baseline; padding: 12px 0;
+    border-bottom: 0.5px dotted var(--muted);
+  }
+  .toc .roman {
+    font-family: 'Cormorant Garamond', serif; font-style: italic;
+    color: var(--copper); width: 60px;
+  }
+  .toc .name { flex: 1; font-size: 16px; }
+  .toc .pageref { color: var(--subtle); }
+
+  /* SECTION DIVIDER */
+  .divider {
+    background: var(--navy); color: var(--cream);
+    padding: 60px; min-height: 200px;
+    display: grid; grid-template-columns: 1fr 1fr; gap: 40px; align-items: center;
+    page-break-after: avoid;
+  }
+  .divider .left .roman {
+    font-family: 'Cormorant Garamond', serif; font-style: italic;
+    color: var(--copper); font-size: 28px; margin-bottom: 8px;
+  }
+  .divider .left h2 {
+    font-family: 'Cormorant Garamond', serif; font-size: 48px;
+    font-weight: 600; margin: 0 0 12px;
+  }
+  .divider .left .intro { color: var(--muted); font-size: 14px; }
+  .divider .hero {
+    width: 100%; aspect-ratio: 16 / 9; border-radius: 4px;
+    object-fit: cover;
+  }
+
+  /* SUB-SECTION (tax_accounting) */
+  .subsection-title {
+    font-family: 'League Spartan', sans-serif; font-weight: 500;
+    font-size: 18px; color: var(--copper); letter-spacing: 0.06em;
+    text-transform: uppercase; margin: 32px 0 16px;
+    border-bottom: 0.5px solid var(--gold); padding-bottom: 8px;
+  }
+
+  /* SERVICE ROW */
+  .service {
+    display: grid; grid-template-columns: 32px 1fr 180px;
+    gap: 16px; padding: 18px 0 18px 18px;
+    border-left: 3px solid var(--copper);
+    margin-bottom: 12px;
+    page-break-inside: avoid;
+  }
+  .service .icon { width: 28px; height: 28px; opacity: 0.85; }
+  .service .name {
+    font-weight: 600; font-size: 15px; color: var(--navy);
+  }
+  .service .desc {
+    font-style: italic; font-size: 12px; color: var(--muted);
+    margin-top: 4px;
+  }
+  .service .meta {
+    font-size: 11px; color: var(--subtle); margin-top: 6px;
+  }
+  .service .price {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    font-weight: 600; font-size: 16px; color: var(--copper);
+  }
+  .service .tier { font-size: 14px; }
+  .service .notes { font-size: 11px; color: var(--muted); margin-top: 4px; font-style: italic; }
+
+  /* CLOSING */
+  .closing {
+    background: var(--navy); color: var(--cream);
+    display: flex; flex-direction: column; justify-content: center;
+    align-items: center; text-align: center;
+  }
+  .closing h2 {
+    font-family: 'Cormorant Garamond', serif; font-size: 56px;
+    margin: 0 0 32px; color: var(--gold);
+  }
+  .closing .qr {
+    width: 200px; height: 200px; background: var(--cream);
+    padding: 16px; border-radius: 4px; margin: 24px 0;
+  }
+  .closing .contact { font-size: 16px; line-height: 2; }
+  .closing .contact a { color: var(--copper); text-decoration: none; }
+</style>
+</head>
+<body>
+
+<!-- COVER -->
+<section class="page cover">
+  <div class="batik"></div>
+  <img class="logo" src="{{ logo_data_uri }}" alt="">
+  <h1>BALI ZERO</h1>
+  <div class="hairline"></div>
+  <div class="subtitle">Price List 2026</div>
+  <div class="tags">Visa · KITAS · Company<br>Tax · Accounting · Other</div>
+  <div class="footer">{{ contact.website }} · {{ contact.location }}</div>
+</section>
+
+<!-- TOC -->
+<section class="page toc">
+  <div class="header"><span>Bali Zero · Price List 2026</span><span>Contents</span></div>
+  <h1>Contents</h1>
+  <ul>
+    {% for section in sections %}
+    <li>
+      <span class="roman">{{ section.roman }}</span>
+      <span class="name">{{ section.title }}</span>
+      <span class="pageref">{{ section.page_ref }}</span>
+    </li>
+    {% endfor %}
+  </ul>
+  <div class="page-num">02</div>
+</section>
+
+<!-- SECTIONS -->
+{% for section in sections %}
+<section class="page divider">
+  <div class="left">
+    <div class="roman">{{ section.roman }}.</div>
+    <h2>{{ section.title }}</h2>
+    <div class="intro">{{ section.intro }}</div>
+  </div>
+  <img class="hero" src="{{ section.hero_data_uri }}" alt="">
+</section>
+
+<section class="page">
+  <div class="header"><span>Bali Zero · Price List 2026</span><span>{{ section.title }}</span></div>
+
+  {% if section.subsections %}
+    {% for sub in section.subsections %}
+      <div class="subsection-title">{{ sub.title }}</div>
+      {% for svc in sub.services %}
+        {% include 'service_row.html.j2' %}
+      {% endfor %}
+    {% endfor %}
+  {% else %}
+    {% for svc in section.services %}
+      {% include 'service_row.html.j2' %}
+    {% endfor %}
+  {% endif %}
+
+  <div class="page-num">{{ section.page_num }}</div>
+</section>
+{% endfor %}
+
+<!-- CLOSING -->
+<section class="page closing">
+  <h2>Get in touch</h2>
+  <img class="qr" src="{{ qr_data_uri }}" alt="WhatsApp QR">
+  <div class="contact">
+    <div><a href="https://{{ contact.website }}">{{ contact.website }}</a></div>
+    <div>{{ contact.email }}</div>
+    <div>{{ contact.whatsapp }}</div>
+    <div>{{ contact.location }}</div>
+  </div>
+</section>
+
+</body>
+</html>
+```
+
+- [ ] **Step 2: Create the included service-row partial**
+
+Write `scripts/pricelist_2026/templates/service_row.html.j2`:
+
+```jinja
+<div class="service">
+  <img class="icon" src="{{ svc.icon_data_uri }}" alt="">
+  <div>
+    <div class="name">{{ svc.name }}</div>
+    <div class="desc">{{ svc.description_en }}</div>
+    {% if svc.validity or svc.duration %}
+    <div class="meta">
+      {% if svc.validity %}Validity: {{ svc.validity }}{% endif %}
+      {% if svc.validity and svc.duration %} · {% endif %}
+      {% if svc.duration %}Duration: {{ svc.duration }}{% endif %}
+    </div>
+    {% endif %}
+    {% if svc.notes %}<div class="notes">{{ svc.notes }}</div>{% endif %}
+  </div>
+  <div class="price">
+    {% if svc.tier_range %}
+      <span class="tier">{{ svc.tier_range[0] }}<br>– {{ svc.tier_range[1] }}</span>
+    {% else %}
+      {{ svc.price }}
+    {% endif %}
+  </div>
+</div>
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/pricelist_2026/templates/
+git commit -m "feat(pricelist-2026): add HTML/Jinja templates
+
+Single-file HTML template with inline CSS, A4 portrait page model,
+cover/ToC/section-divider/service-row/closing structure on the Bali Zero
+brand palette (navy + copper + gold + cream). Service-row partial
+handles both single price and tier_range. All images consumed via
+data: URIs (filled by generator in Task 6).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Markdown template (Jinja2)
+
+**Files:**
+
+- Create: `scripts/pricelist_2026/templates/pricelist.md.j2`
+
+Plain Markdown for the repo-versioned auditable record. Links to the asset files in `docs/pricing/assets/2026/` instead of base64 (Markdown renderers don't all handle base64).
+
+- [ ] **Step 1: Write pricelist.md.j2**
+
+Write `scripts/pricelist_2026/templates/pricelist.md.j2`:
+
+```jinja
+# Bali Zero — Price List 2026
+
+**Effective:** {{ effective_date }}
+**Version:** {{ version }}
+**Last updated:** {{ last_updated }}
+
+> {{ contact.email }} · {{ contact.whatsapp }} · {{ contact.website }} · {{ contact.location }}
+
+![Bali Zero](./assets/2026/logo_circle.png)
+
+---
+
+## Contents
+
+{% for section in sections -%}
+- **{{ section.roman }}.** [{{ section.title }}](#{{ section.anchor }})
+{% endfor %}
+
+---
+
+{% for section in sections %}
+<a id="{{ section.anchor }}"></a>
+
+## {{ section.roman }}. {{ section.title }}
+
+![{{ section.title }}](./assets/2026/heros/{{ section.hero_basename }}.png)
+
+_{{ section.intro }}_
+
+{% if section.subsections %}
+{% for sub in section.subsections %}
+### {{ sub.title }}
+
+| Service | Description | Price |
+| --- | --- | --- |
+{% for svc in sub.services -%}
+| **{{ svc.name }}** | {{ svc.description_en }}{% if svc.notes %} _({{ svc.notes }})_{% endif %} | {% if svc.tier_range %}{{ svc.tier_range[0] }} – {{ svc.tier_range[1] }}{% else %}{{ svc.price }}{% endif %} |
+{% endfor %}
+
+{% endfor %}
+{% else %}
+| Service | Description | Price |
+| --- | --- | --- |
+{% for svc in section.services -%}
+| **{{ svc.name }}** | {{ svc.description_en }}{% if svc.notes %} _({{ svc.notes }})_{% endif %} | {% if svc.tier_range %}{{ svc.tier_range[0] }} – {{ svc.tier_range[1] }}{% else %}{{ svc.price }}{% endif %} |
+{% endfor %}
+{% endif %}
+
+---
+{% endfor %}
+
+## Get in touch
+
+- Website: <https://{{ contact.website }}>
+- Email: <{{ contact.email }}>
+- WhatsApp: [{{ contact.whatsapp }}]({{ contact.wa_link }})
+- Office: {{ contact.location }}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/pricelist_2026/templates/pricelist.md.j2
+git commit -m "feat(pricelist-2026): add Markdown template
+
+Repo-versioned auditable record of the price list. Tables per section,
+hero image references via repo-relative paths (so GitHub renders them
+inline). Same structural model as the HTML template — section, optional
+subsections, service rows.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Generator script (TDD)
+
+**Files:**
+
+- Create: `scripts/pricelist_2026/generate.py`
+- Create: `scripts/pricelist_2026/tests/test_generate.py`
+
+The generator: reads JSON + assets + templates → emits HTML + Markdown. PDF is a separate step (Task 8).
+
+- [ ] **Step 1: Write the failing test**
+
+Write `scripts/pricelist_2026/tests/test_generate.py`:
+
+```python
+"""Tests for the 2026 price list generator (HTML + Markdown only — PDF tested separately)."""
+import base64
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from scripts.pricelist_2026 import generate, schema
+
+FIXTURE = Path(__file__).parent / "fixtures" / "minimal_prices.json"
+
+
+@pytest.fixture
+def fixture_data():
+    return json.loads(FIXTURE.read_text())
+
+
+@pytest.fixture
+def stub_assets(tmp_path):
+    """Build a directory of 1x1 transparent PNGs for every icon_id + hero used in fixture."""
+    heros_dir = tmp_path / "heros"
+    icons_dir = tmp_path / "icons"
+    heros_dir.mkdir()
+    icons_dir.mkdir()
+    # 1x1 transparent PNG
+    one_pixel = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+    )
+    # Heros for each section the fixture uses (single_entry_visas + tax_accounting)
+    for hero_name in ["01_visas.png", "03_tax.png"]:
+        (heros_dir / hero_name).write_bytes(one_pixel)
+    # Icons
+    for icon_id in ["visa-tourism", "tax-monthly"]:
+        (icons_dir / f"{icon_id}.png").write_bytes(one_pixel)
+    # Logo
+    (tmp_path / "logo_circle.png").write_bytes(one_pixel)
+    return tmp_path
+
+
+def test_generate_html_smoke(fixture_data, stub_assets, tmp_path):
+    out_html = tmp_path / "out.html"
+    generate.render_html(
+        data=fixture_data,
+        assets_dir=stub_assets,
+        out_path=out_html,
+    )
+    assert out_html.exists()
+    html = out_html.read_text()
+    # Cover content
+    assert "BALI ZERO" in html
+    assert "Price List 2026" in html
+    # Service rendered
+    assert "C1 Tourism" in html
+    assert "2.300.000 IDR" in html
+    # Tier rendered
+    assert "1.800.000 IDR" in html
+    assert "2.000.000 IDR" in html
+    # Contact rendered
+    assert "zero@balizero.com" in html
+    assert "+62 821 31 07 363" in html
+    # Logo embedded as base64 data URI
+    assert 'src="data:image/png;base64,' in html
+
+
+def test_generate_markdown_smoke(fixture_data, stub_assets, tmp_path):
+    out_md = tmp_path / "out.md"
+    generate.render_markdown(
+        data=fixture_data,
+        out_path=out_md,
+    )
+    assert out_md.exists()
+    md = out_md.read_text()
+    assert "# Bali Zero — Price List 2026" in md
+    assert "C1 Tourism" in md
+    assert "1.800.000 IDR – 2.000.000 IDR" in md
+    assert "wa.me/628213107363" in md
+
+
+def test_generate_rejects_invalid_json(stub_assets, tmp_path):
+    bad = {"version": "2026.1"}  # missing everything
+    out_html = tmp_path / "out.html"
+    with pytest.raises(generate.SchemaError):
+        generate.render_html(data=bad, assets_dir=stub_assets, out_path=out_html)
+
+
+def test_generate_rejects_missing_icon_asset(fixture_data, tmp_path):
+    # No assets dir contents — only logo
+    (tmp_path / "logo_circle.png").write_bytes(b"\x89PNG\r\n\x1a\n")  # garbage but exists
+    out_html = tmp_path / "out.html"
+    with pytest.raises(generate.AssetMissingError) as exc:
+        generate.render_html(data=fixture_data, assets_dir=tmp_path, out_path=out_html)
+    assert "visa-tourism" in str(exc.value) or "tax-monthly" in str(exc.value)
+
+
+def test_generate_html_contains_qr_link(fixture_data, stub_assets, tmp_path):
+    out_html = tmp_path / "out.html"
+    generate.render_html(data=fixture_data, assets_dir=stub_assets, out_path=out_html)
+    html = out_html.read_text()
+    # QR code image embedded
+    assert html.count('src="data:image/png;base64,') >= 3  # logo + hero + icon + qr
+    # Closing section text
+    assert "Get in touch" in html
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `cd /Users/nuzantara/Desktop/nuzantara && python3 -m pytest scripts/pricelist_2026/tests/test_generate.py -v 2>&1 | tail -20`
+
+Expected: import errors / fail because `generate.py` doesn't exist yet.
+
+- [ ] **Step 3: Implement generate.py**
+
+Write `scripts/pricelist_2026/generate.py`:
+
+```python
+"""Render HTML + Markdown for the 2026 Bali Zero price list.
+
+Reads the JSON source + asset PNGs, runs them through Jinja2 templates,
+emits self-contained HTML (base64 data URIs) and a clean Markdown that
+links to repo-relative asset paths.
+
+PDF generation is a separate concern (see scripts/pricelist_2026/render_pdf.py).
+"""
+from __future__ import annotations
+
+import base64
+import io
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import qrcode
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+from scripts.pricelist_2026 import schema
+
+TEMPLATE_DIR = Path(__file__).parent / "templates"
+
+
+class SchemaError(Exception):
+    """Raised when the JSON fails schema validation."""
+
+
+class AssetMissingError(Exception):
+    """Raised when a required hero or icon PNG is missing."""
+
+
+# Maps category key → (roman, title, intro, hero_basename)
+SECTION_META: dict[str, tuple[str, str, str, str]] = {
+    "single_entry_visas": (
+        "I", "Single Entry Visas",
+        "Short-stay visas for a single entry to Indonesia.",
+        "01_visas",
+    ),
+    "visa_extensions": (
+        "II", "Visa Extensions",
+        "Extension fees for existing visas.",
+        "01_visas",
+    ),
+    "multiple_entry_visas": (
+        "III", "Multiple Entry Visas",
+        "Multi-entry visas for repeat travel.",
+        "01_visas",
+    ),
+    "kitas_permits": (
+        "IV", "KITAS Permits",
+        "Long-stay residence permits for foreign nationals.",
+        "02_kitas_kitap",
+    ),
+    "kitap_permits": (
+        "V", "KITAP + MERP",
+        "Permanent residence permits and multiple re-entry permits.",
+        "02_kitas_kitap",
+    ),
+    "tax_accounting": (
+        "VI", "Tax & Accounting",
+        "Monthly bookkeeping packages, annual filings and stand-alone fees.",
+        "03_tax",
+    ),
+    "company_services": (
+        "VII", "Company Services",
+        "PT PMA setup, virtual office and corporate amendments.",
+        "04_company",
+    ),
+    "consultant_services": (
+        "VIII", "Bali Zero Consultant Services",
+        "Compliance and registration fees handled by Bali Zero.",
+        "04_company",
+    ),
+    "other_process": (
+        "IX", "Other Process",
+        "Passports, identity documents and miscellaneous immigration filings.",
+        "05_other_process",
+    ),
+    "urgent_processing": (
+        "X", "Urgent Processing",
+        "Express processing tiers for time-sensitive filings.",
+        "06_urgent",
+    ),
+}
+
+SUBSECTION_TITLES = {
+    "monthly_tax_basic": "VI.1 Monthly Tax Report — without LKPM & Annual",
+    "monthly_tax_bundled": "VI.2 Monthly Tax Report — including LKPM + Annual",
+    "annual_basic_packages": "VI.3 Annual Basic Packages",
+    "annual_standalone": "VI.4 Annual & Compliance Stand-alone Fees",
+}
+
+
+@dataclass
+class Section:
+    roman: str
+    title: str
+    anchor: str
+    intro: str
+    hero_basename: str
+    page_ref: str = ""
+    page_num: str = ""
+    services: list[dict] = field(default_factory=list)
+    subsections: list[dict] = field(default_factory=list)
+    hero_data_uri: str = ""
+
+
+def _data_uri_png(path: Path) -> str:
+    if not path.exists():
+        raise AssetMissingError(f"Missing PNG asset: {path}")
+    blob = path.read_bytes()
+    return "data:image/png;base64," + base64.b64encode(blob).decode("ascii")
+
+
+def _make_qr_data_uri(wa_link: str) -> str:
+    qr = qrcode.QRCode(box_size=8, border=2)
+    qr.add_data(wa_link)
+    qr.make(fit=True)
+    img = qr.make_image(fill_color="#1d273b", back_color="#fbfaf6")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def _build_sections(data: dict, assets_dir: Path | None, embed_assets: bool) -> list[Section]:
+    sections: list[Section] = []
+    services_root = data["services"]
+    for category_key, (roman, title, intro, hero_basename) in SECTION_META.items():
+        if category_key not in services_root:
+            continue
+        sec = Section(
+            roman=roman,
+            title=title,
+            anchor=category_key.replace("_", "-"),
+            intro=intro,
+            hero_basename=hero_basename,
+        )
+        if embed_assets and assets_dir is not None:
+            sec.hero_data_uri = _data_uri_png(
+                assets_dir / "heros" / f"{hero_basename}.png"
+            )
+
+        if category_key == "tax_accounting":
+            for sub_key, sub_entries in services_root[category_key].items():
+                sub = {
+                    "title": SUBSECTION_TITLES.get(sub_key, sub_key),
+                    "services": [],
+                }
+                for _name, svc in sub_entries.items():
+                    sub["services"].append(_decorate_svc(svc, assets_dir, embed_assets))
+                sec.subsections.append(sub)
+        else:
+            for _name, svc in services_root[category_key].items():
+                sec.services.append(_decorate_svc(svc, assets_dir, embed_assets))
+
+        sections.append(sec)
+    return sections
+
+
+def _decorate_svc(svc: dict, assets_dir: Path | None, embed_assets: bool) -> dict:
+    out = dict(svc)
+    if embed_assets and assets_dir is not None:
+        icon_id = svc.get("icon_id", "")
+        out["icon_data_uri"] = _data_uri_png(assets_dir / "icons" / f"{icon_id}.png")
+    return out
+
+
+def _validate_or_raise(data: dict) -> None:
+    result = schema.validate(data)
+    if not result.ok:
+        raise SchemaError("; ".join(result.errors[:5]))
+
+
+def _jinja_env() -> Environment:
+    return Environment(
+        loader=FileSystemLoader(TEMPLATE_DIR),
+        autoescape=select_autoescape(["html", "j2"]),
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+
+
+def render_html(data: dict, assets_dir: Path, out_path: Path) -> None:
+    _validate_or_raise(data)
+    sections = _build_sections(data, assets_dir, embed_assets=True)
+    contact = data["metadata"]["contact"]
+    env = _jinja_env()
+    template = env.get_template("pricelist.html.j2")
+    rendered = template.render(
+        sections=sections,
+        contact=contact,
+        logo_data_uri=_data_uri_png(assets_dir / "logo_circle.png"),
+        qr_data_uri=_make_qr_data_uri(contact["wa_link"]),
+        # Empty for now — Task 9 can add subset Google Fonts woff2 base64
+        font_face_block="",
+    )
+    out_path.write_text(rendered, encoding="utf-8")
+
+
+def render_markdown(data: dict, out_path: Path) -> None:
+    _validate_or_raise(data)
+    sections = _build_sections(data, assets_dir=None, embed_assets=False)
+    env = _jinja_env()
+    template = env.get_template("pricelist.md.j2")
+    rendered = template.render(
+        sections=sections,
+        contact=data["metadata"]["contact"],
+        version=data["version"],
+        effective_date=data["effective_date"],
+        last_updated=data["metadata"]["last_updated"],
+    )
+    out_path.write_text(rendered, encoding="utf-8")
+
+
+def main() -> int:
+    import argparse, json, sys
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json",
+        type=Path,
+        default=Path("apps/backend-rag/backend/data/bali_zero_official_prices_2026.json"),
+    )
+    parser.add_argument(
+        "--assets-dir",
+        type=Path,
+        default=Path("docs/pricing/assets/2026"),
+    )
+    parser.add_argument(
+        "--out-html",
+        type=Path,
+        default=Path.home() / "Desktop" / "Bali_Zero_Price_List_2026.html",
+    )
+    parser.add_argument(
+        "--out-md",
+        type=Path,
+        default=Path("docs/pricing/Bali_Zero_Price_List_2026.md"),
+    )
+    args = parser.parse_args()
+
+    data = json.loads(args.json.read_text())
+    args.out_md.parent.mkdir(parents=True, exist_ok=True)
+    args.out_html.parent.mkdir(parents=True, exist_ok=True)
+
+    print(f"  → Markdown: {args.out_md}")
+    render_markdown(data, args.out_md)
+    print(f"  → HTML:     {args.out_html}")
+    render_html(data, args.assets_dir, args.out_html)
+    print("✓ Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Install Python deps if missing**
+
+Run:
+
+```bash
+cd /Users/nuzantara/Desktop/nuzantara/apps/backend-rag && source .venv/bin/activate && \
+python3 -m pip install --quiet jinja2 qrcode pillow && cd /Users/nuzantara/Desktop/nuzantara
+```
+
+Expected: silent install (jinja2 may already be present; qrcode + pillow likely new).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /Users/nuzantara/Desktop/nuzantara && source apps/backend-rag/.venv/bin/activate && python3 -m pytest scripts/pricelist_2026/tests/test_generate.py -v 2>&1 | tail -25`
+
+Expected: ALL 5 tests PASS.
+
+- [ ] **Step 6: Smoke run on the real JSON + assets**
+
+Run:
+
+```bash
+cd /Users/nuzantara/Desktop/nuzantara && source apps/backend-rag/.venv/bin/activate && \
+python3 -m scripts.pricelist_2026.generate
+```
+
+Expected output:
+
+```
+  → Markdown: docs/pricing/Bali_Zero_Price_List_2026.md
+  → HTML:     /Users/nuzantara/Desktop/Bali_Zero_Price_List_2026.html
+✓ Done.
+```
+
+Open the HTML in browser: `open ~/Desktop/Bali_Zero_Price_List_2026.html`. Verify cover, ToC, sections, prices, hero images, icons, QR all render.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/pricelist_2026/generate.py scripts/pricelist_2026/tests/test_generate.py docs/pricing/Bali_Zero_Price_List_2026.md
+git commit -m "feat(pricelist-2026): add HTML + Markdown generator
+
+Reads bali_zero_official_prices_2026.json + asset PNGs + Jinja templates
+→ emits self-contained HTML (base64-embedded images, generated WhatsApp
+QR code) and a repo-versioned Markdown record. 5 tests covering smoke
+render, schema rejection, missing-asset detection, QR embedding.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: PDF rendering via Playwright
+
+**Files:**
+
+- Create: `scripts/pricelist_2026/render_pdf.py`
+
+PDF is a separate concern from HTML/MD generation: it requires Playwright + Chromium and runs slower. Keeping it isolated lets us iterate on the HTML without paying the PDF cost every time.
+
+- [ ] **Step 1: Verify Playwright + Chromium are installed**
+
+Run:
+
+```bash
+cd /Users/nuzantara/Desktop/nuzantara/apps/backend-rag && source .venv/bin/activate && \
+python3 -c "from playwright.sync_api import sync_playwright; print('playwright ok')" && \
+python3 -m playwright install chromium 2>&1 | tail -3
+```
+
+Expected: `playwright ok` followed by either an install confirmation or "is already installed".
+
+- [ ] **Step 2: Write render_pdf.py**
+
+Write `scripts/pricelist_2026/render_pdf.py`:
+
+```python
+"""Render the HTML output to a print-ready PDF via Playwright headless Chromium."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+
+def render_pdf(html_path: Path, pdf_path: Path) -> None:
+    if not html_path.exists():
+        sys.exit(f"ERROR: HTML not found at {html_path}. Run generate.py first.")
+    pdf_path.parent.mkdir(parents=True, exist_ok=True)
+    file_url = f"file://{html_path.resolve()}"
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(file_url, wait_until="networkidle")
+        page.pdf(
+            path=str(pdf_path),
+            format="A4",
+            print_background=True,
+            margin={"top": "0", "right": "0", "bottom": "0", "left": "0"},
+            prefer_css_page_size=True,
+        )
+        browser.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--html",
+        type=Path,
+        default=Path.home() / "Desktop" / "Bali_Zero_Price_List_2026.html",
+    )
+    parser.add_argument(
+        "--pdf",
+        type=Path,
+        default=Path.home() / "Desktop" / "Bali_Zero_Price_List_2026.pdf",
+    )
+    args = parser.parse_args()
+    print(f"  → PDF: {args.pdf}")
+    render_pdf(args.html, args.pdf)
+    print(f"✓ Done ({args.pdf.stat().st_size:,} bytes).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 3: Run the PDF render**
+
+Run:
+
+```bash
+cd /Users/nuzantara/Desktop/nuzantara && source apps/backend-rag/.venv/bin/activate && \
+python3 -m scripts.pricelist_2026.render_pdf
+```
+
+Expected: `✓ Done (NNN,NNN bytes)`. PDF size should be in the 5-15 MB range with all heros + icons embedded.
+
+Open: `open ~/Desktop/Bali_Zero_Price_List_2026.pdf`.
+
+- [ ] **Step 4: Visual QA**
+
+Open the PDF and check, page by page:
+
+- Cover renders centered, logo visible, palette correct
+- ToC entries align with section dividers
+- Each section divider has a hero image
+- Service rows: name + description + price all visible, no overflow
+- Page breaks fall between rows, not mid-row (`page-break-inside: avoid`)
+- Closing page: contacts + QR code visible, QR scans (use phone camera) → opens WhatsApp to the right number
+- Total pages ≈ 18-22 (acceptable range)
+
+If any issue: edit `pricelist.html.j2`, re-run `generate.py`, then re-run `render_pdf.py`. Iterate until clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/pricelist_2026/render_pdf.py
+git commit -m "feat(pricelist-2026): add Playwright PDF renderer
+
+Headless Chromium prints the generated HTML to A4 portrait PDF with
+full-bleed margins (page CSS controls section padding). Run after
+generate.py.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: gitignore + final cleanup
+
+**Files:**
+
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Append patterns to .gitignore**
+
+Run:
+
+```bash
+cd /Users/nuzantara/Desktop/nuzantara && cat >> .gitignore << 'EOF'
+
+# Bali Zero Price List 2026 — generated outputs (sources are in docs/pricing/ and apps/backend-rag/backend/data/)
+/Users/nuzantara/Desktop/Bali_Zero_Price_List_2026.html
+/Users/nuzantara/Desktop/Bali_Zero_Price_List_2026.pdf
+/Users/nuzantara/Desktop/Bali_Zero_Price_List_2026_assets/
+EOF
+```
+
+(Note: gitignore patterns do NOT need to start with `/Users/...` since git only sees repo-relative paths. The above is purely documentary — git will simply ignore the unmatched absolute paths. The actual generated outputs sit OUTSIDE the repo on `~/Desktop/`, so no gitignore is needed. Keep the comment block as documentation only.)
+
+Better, simpler: just add a `# Bali Zero Price List 2026 — outputs live outside the repo on ~/Desktop/` comment marker for grep-ability.
+
+```bash
+cd /Users/nuzantara/Desktop/nuzantara && cat >> .gitignore << 'EOF'
+
+# Bali Zero Price List 2026 — generated outputs live outside the repo on ~/Desktop/
+# Source of truth: apps/backend-rag/backend/data/bali_zero_official_prices_2026.json
+# Generator:       scripts/pricelist_2026/
+# Versioned MD:    docs/pricing/Bali_Zero_Price_List_2026.md
+EOF
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .gitignore
+git commit -m "chore(pricelist-2026): document generator output locations in gitignore"
+```
+
+---
+
+## Task 10: End-to-end smoke test + handoff
+
+- [ ] **Step 1: Full pipeline rerun from scratch**
+
+```bash
+cd /Users/nuzantara/Desktop/nuzantara && source apps/backend-rag/.venv/bin/activate
+
+# 1. Validate JSON
+python3 -m pytest scripts/pricelist_2026/tests/ -v
+
+# 2. Generate HTML + Markdown
+python3 -m scripts.pricelist_2026.generate
+
+# 3. Generate PDF
+python3 -m scripts.pricelist_2026.render_pdf
+
+# 4. List outputs
+ls -lh ~/Desktop/Bali_Zero_Price_List_2026.{html,pdf}
+ls -lh docs/pricing/Bali_Zero_Price_List_2026.md
+```
+
+Expected:
+
+- All tests pass
+- HTML: ~3-8 MB (fonts + base64 images)
+- PDF: ~5-15 MB
+- MD: ~30-80 KB
+
+- [ ] **Step 2: Open all three and review side-by-side**
+
+```bash
+open ~/Desktop/Bali_Zero_Price_List_2026.html
+open ~/Desktop/Bali_Zero_Price_List_2026.pdf
+code docs/pricing/Bali_Zero_Price_List_2026.md
+```
+
+Confirm:
+
+- HTML and PDF are visually equivalent
+- Markdown contains all 80 services in tables, hero links resolve in GitHub-style preview
+- No "TBD", "fixme", or placeholder strings
+
+- [ ] **Step 3: Test the QR code**
+
+Scan the QR code on the PDF closing page with a phone camera. It should open WhatsApp to a chat with `+62 821 31 07 363` (the canonical contact).
+
+- [ ] **Step 4: Final summary message to owner**
+
+In the chat, summarize for Antonello:
+
+- Pipeline runs: `python3 -m scripts.pricelist_2026.generate && python3 -m scripts.pricelist_2026.render_pdf`
+- Source of truth: `apps/backend-rag/backend/data/bali_zero_official_prices_2026.json`
+- Outputs on Desktop: HTML + PDF
+- Versioned in repo: `docs/pricing/Bali_Zero_Price_List_2026.md` + assets
+- Backend RAG `PricingTool` was NOT touched — still reads `_2025.json`. Owner approval required to swap.
+- Open items from spec §13: confirm WhatsApp number; consider bahasa Indonesia variant (future work).
+
+---
+
+## Self-Review (post-plan check)
+
+**Spec coverage:**
+
+- §1 Goal points 1-6 → covered by Task 1 (consolidation), Task 1 (new sections), Task 1 (3 conflicts), Task 1 (dedup), Tasks 5-7-8 (3 renders), Tasks 3-4 (visual treatment) ✅
+- §3 Source-of-truth architecture → Task 1 (JSON) + Task 7-8 (renderers) ✅
+- §4 JSON schema → Task 1 (authored) + Task 2 (validator) ✅
+- §5 Document structure (12 sections) → Task 5 (HTML template SECTION_META) + Task 7 (`SECTION_META` dict) ✅
+- §6 Visual / palette / typography / image strategy → Tasks 3-4 (assets) + Task 5 (HTML CSS palette hex inlined) ✅
+- §6.5 Cover layout → Task 5 (`.cover` block in template) ✅
+- §6.6 Senior touches: page numbers ✅, running header ✅, ToC leader dots ✅, QR code ✅. Color-coded edge tabs NOT explicitly implemented → ACCEPTED MISS, can be a v1.1 follow-up; the document is already acceptable without it.
+- §7 Generator script → Task 7 (`generate.py`) + Task 8 (`render_pdf.py`) ✅
+- §8 Conflicts resolved → Task 1 step 2 explicitly references each ✅
+- §9 Build sequence → mirrored by Tasks 1-10 in order ✅
+- §10 Testing → Task 2 (schema tests), Task 7 (generator tests), Task 10 (E2E smoke) ✅
+- §11 Distribution → Task 10 step 4 handoff message ✅
+- §12 Risks → addressed: codex availability (Task 4 step 1 hard-fail), font subsetting (font_face_block left empty in v1, can be filled in a future iteration without breaking the template — ACCEPTED MISS), page-break (CSS in Task 5) ✅
+- §13 Open items → flagged in Task 10 step 4 ✅
+
+**Placeholder scan:** No "TBD" / "TODO" / vague-handler-style steps. Each step has the actual code or command. ✅
+
+**Type/name consistency:**
+
+- `bali_zero_official_prices_2026.json` referenced consistently across Tasks 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ✅
+- `wa_link` field added to JSON contact (Task 1) and consumed by `_make_qr_data_uri` (Task 7) and Markdown template (Task 6) ✅
+- `icon_id` field used in JSON (Task 1), enumerated in `asset_briefs.ICON_BRIEFS` (Task 3), looked up in `_decorate_svc` (Task 7), filename pattern `{icon_id}.png` (Task 4 + Task 7) ✅
+- `tier_range` field defined as `list[str]` of 2 entries (Task 1) and validated in `schema._validate_service` (Task 2) and rendered in HTML/MD templates (Task 5/6) ✅
+- `SchemaError` and `AssetMissingError` raised in `generate.py` (Task 7) and asserted in tests (Task 7 step 1) ✅
+- Section count: 10 categories in JSON (Task 1) → 10 entries in `SECTION_META` (Task 7) → 10 sections rendered ✅
+
+**Acceptance:** plan is self-contained, every step has code or a verifiable command, no leaks of "fix this later". The two ACCEPTED MISSES (color-coded edge tabs + font subsetting) are explicitly documented as v1.1 follow-ups and do not block the v1 deliverable.
+
+---
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-06-bali-zero-pricelist-2026.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-05-06-bali-zero-pricelist-2026-design.md
+++ b/docs/superpowers/specs/2026-05-06-bali-zero-pricelist-2026-design.md
@@ -1,0 +1,364 @@
+# Bali Zero — Price List 2026 Design Spec
+
+**Date:** 2026-05-06
+**Author:** Antonello Siano (Zero) + Claude Opus 4.7 (1M ctx)
+**Status:** Draft — pending owner review
+**Scope:** Single artifact for client + internal use (option C — no internal/external split)
+**Source of truth:** new `bali_zero_official_prices_2026.json`
+
+---
+
+## 1. Goal
+
+Replace the legacy 2025 price list (PDF "PRICE LIST 2025 INTERNAL - PRICE SELLING-2.pdf" + JSON `bali_zero_official_prices_2025.json`) with a unified 2026 edition that:
+
+1. Consolidates all Bali Zero priced services in **one** versioned source.
+2. Adds the new Tax & Accounting tier provided by the Tax department (monthly tax report packages, basic annual packages, LKPM, annual personal/company tax) and the new Bali Zero Consultant fees (PMA close, NPWPD, BPJS, NPWP personal, EFIN, update data) — none of which exist in the current 2025 sources.
+3. Resolves three known conflicts between PDF 2025 and JSON 2025:
+   - **Investor KITAP + MERP** → Rp 55.000.000 (no ACC surcharge) ✅ user-confirmed
+   - **Dependent KITAP + MERP** → Rp 33.000.000 (no ACC surcharge) ✅ user-confirmed
+   - **Akta Perubahan / Revision Company** → unified into ONE row "Akta Perubahan (Revision Company) — Depend (Contact for quote)" ✅ user-confirmed
+4. Eliminates structural duplicates: `Annual Tax personal`, `Annual Tax company`, `LKPM yearly` extracted ONCE in their own dedicated section instead of being repeated inside every monthly tier description.
+5. Renders into THREE downstream artifacts from the SAME JSON: HTML (web/print), PDF (client-shareable), Markdown (versioned in repo).
+6. Receives full senior visual treatment: cinematic cover, hero photography per macro-section, micro-icon set per service, batik ornaments — palette aligned to existing Bali Zero brand book (`docs/superpowers/specs/2026-03-27-balizero-digital-brand-book-design.md`).
+
+---
+
+## 2. Non-goals
+
+- NOT redesigning the brand book or globals.css palette.
+- NOT shipping a new web app or route — this is a static document deliverable.
+- NOT migrating the backend RAG `PricingTool` to consume 2026 JSON in the same PR — that is a follow-up step gated on owner approval (the current `_2025.json` stays authoritative until explicitly swapped). Keeping these decoupled avoids regressing the production Bali Zero chatbot during a content-only change.
+- NOT publishing the document to a public URL — distribution channel is decided ad-hoc by Zero after the artifact is shipped.
+
+---
+
+## 3. Source-of-truth architecture
+
+```
+                     bali_zero_official_prices_2026.json
+                                  │
+                                  │ (read-once)
+                                  ▼
+              scripts/generate_pricelist_2026.py
+                                  │
+                  ┌───────────────┼────────────────┐
+                  ▼               ▼                ▼
+           HTML (single)    PDF (Playwright)    Markdown (.md)
+        ~/Desktop/...      ~/Desktop/...      docs/pricing/...
+```
+
+**Single source of truth principle:** any future price update happens in the JSON only; running the generator regenerates the three outputs deterministically. No artifact is hand-edited.
+
+**Image embedding:** generator inlines all images as base64 in the HTML so the file is self-contained and shareable as a single attachment (no `assets/` folder dependency). PDF inherits embedded images via Playwright headless print. Markdown links to image files in `docs/pricing/assets/2026/` (relative paths, repo-tracked).
+
+---
+
+## 4. JSON schema (`bali_zero_official_prices_2026.json`)
+
+Shape evolves the existing 2025 schema with three additions: top-level `version`, `effective_date`, and a new `tax_accounting` category that supports tier ranges + bundled-vs-standalone fees.
+
+```json
+{
+  "version": "2026.1",
+  "effective_date": "2026-01-01",
+  "metadata": {
+    "currency": "IDR",
+    "contact": {
+      "email": "zero@balizero.com",
+      "whatsapp": "+62 821 3107 363",
+      "location": "Kerobokan, Bali, Indonesia",
+      "website": "balizero.com"
+    },
+    "last_updated": "2026-05-06"
+  },
+  "services": {
+    "single_entry_visas": {
+      /* 6 entries — unchanged from 2025 */
+    },
+    "visa_extensions": {
+      /* 1 entry */
+    },
+    "multiple_entry_visas": {
+      /* 5 entries (D1×3, D12×2) */
+    },
+    "kitas_permits": {
+      /* ~25 entries */
+    },
+    "kitap_permits": {
+      /* 5 entries — Investor=55M, Dependent=33M */
+    },
+    "tax_accounting": {
+      "monthly_tax_basic": {
+        /* 4 tiers, range price (low–high) */
+      },
+      "monthly_tax_bundled": {
+        /* 4 tiers, includes LKPM + Annual */
+      },
+      "annual_basic_packages": {
+        /* A, B, C, D + Zero Company */
+      },
+      "annual_standalone": {
+        /* LKPM, Annual Tax Co., Annual Tax Personal, Personal additional */
+      }
+    },
+    "company_services": {
+      /* 3 entries — Akta unified */
+    },
+    "consultant_services": {
+      /* PMA close, NPWPD, BPJS×2, NPWP personal, EFIN, update data */
+    },
+    "other_process": {
+      /* ~21 entries */
+    },
+    "urgent_processing": {
+      /* 1/2/3 hari */
+    }
+  }
+}
+```
+
+Each leaf entry follows this shape (unchanged from 2025 except for new optional `description_en` and `tier_range` fields):
+
+```json
+{
+  "name": "Working KITAS (Altus / Onshore)",
+  "price": "36.000.000 IDR", // single price
+  "tier_range": null, // OR ["1.800.000 IDR", "2.000.000 IDR"] for ranges
+  "duration": "",
+  "validity": "1 year",
+  "notes": "",
+  "description_en": "Standard work permit KITAS sponsored by Indonesian employer. Onshore process via Altus, suited to candidates already in Indonesia.",
+  "icon_id": "kitas-working" // links to micro-icon asset
+}
+```
+
+**Backward compatibility for backend RAG:** the current `PricingTool` reads `services.<category>.<service_name>.price` and `.text` — both fields preserved (the generator emits a synthetic `text` field on demand to keep the existing tool contract unbroken if/when the RAG swap happens). The 2026 JSON ALSO keeps the `text` Markdown field generated automatically from `name + price + description_en + contact block`.
+
+---
+
+## 5. Document structure (12 sections, ~20 pages PDF)
+
+| #       | Section                              | Servizi                                                                                             | Source                       |
+| ------- | ------------------------------------ | --------------------------------------------------------------------------------------------------- | ---------------------------- |
+| Cover   | full-bleed dark, logo, title         | —                                                                                                   | new                          |
+| ToC     | leader-dot index                     | —                                                                                                   | new                          |
+| I.      | Single Entry Visas                   | 6 (C1, C2, C7A&B, C18, C22A&B 60d, C22A&B 180d)                                                     | 2025 JSON                    |
+| II.     | Visa Extensions                      | 1 (C1 Tourism Extension)                                                                            | 2025 JSON                    |
+| III.    | Multiple Entry Visas                 | 5 (D1×3, D12×2)                                                                                     | 2025 JSON                    |
+| IV.     | KITAS Permits                        | ~25 (Working, Investor, Freelance E23, E33G, Spouse, Dependent, Retirement × Offshore/Altus/Extend) | 2025 JSON + PDF              |
+| V.      | KITAP + MERP                         | 5 (Investor=55M, Dependent=33M, Retirement, MERP 1Y, MERP 2Y)                                       | 2025 JSON, conflict-resolved |
+| VI.     | Tax & Accounting ⭐ NEW              | 4 sub-blocks                                                                                        | Tax dpt input 2026-05-06     |
+| VII.    | Company Services                     | 3 (PT PMA, Virtual Office, Akta Perubahan)                                                          | 2025 JSON, dedup applied     |
+| VIII.   | Bali Zero Consultant Services ⭐ NEW | 7 (PMA close, NPWPD, BPJS×2, NPWP personal, Update data, EFIN)                                      | Tax dpt input 2026-05-06     |
+| IX.     | Other Process                        | ~21 (passports, SKTT, SKCK, EPO/ERP, mutations, cancels, born report, domicilie)                    | 2025 JSON + PDF              |
+| X.      | Urgent Processing Tier               | 3 (1/2/3 hari)                                                                                      | 2025 JSON + PDF              |
+| Closing | Contacts + WhatsApp QR               | —                                                                                                   | new                          |
+
+**Tax & Accounting sub-blocks:**
+
+- **VI.1 Monthly Tax Report — without LKPM & Annual** — 4 tiers by transaction count (0-50, 50-100, 100-200, 200+). Tier ranges: 1.8-2M / 2.5-3M / 3.5-4.5M / 5M.
+- **VI.2 Monthly Tax Report — including LKPM + Annual** — 4 tiers (2.5M / 3.5M / 4.5M / 6.5M).
+- **VI.3 Annual Basic Packages** — A (≤100tx, 6M, Income Tax only), B (100-200tx, 9M, Income Tax only), C (≤100tx, 12M, Income Tax + PPH 21 OR PPH Sewa), D (100-200tx, 15M, Income Tax + PPH 21 OR PPH Sewa). Plus "Annual Company ZERO (no transactions)" 3M.
+- **VI.4 Annual & Compliance Stand-alone Fees** — extracted ONCE: LKPM yearly (4M), Annual Tax Company (4M), Annual Tax Personal (1M), Personal additional per extra person (1.5M).
+
+Total unique services after dedup: **~80**.
+
+---
+
+## 6. Visual / Aesthetic system
+
+### 6.1 Palette (verified from `apps/mouth/src/app/globals.css`)
+
+| Role          | Token                               | Hex                                        | Usage                                                  |
+| ------------- | ----------------------------------- | ------------------------------------------ | ------------------------------------------------------ |
+| Body paper    | (new) `#fbfaf6`                     | warm cream, NOT pure white — body sections |
+| Deep navy     | `--bz-base`                         | `#1d273b`                                  | cover, section dividers, footer, dark spotlight        |
+| Elevated navy | `--bz-elevated`                     | `#243047`                                  | secondary dark surfaces                                |
+| Copper accent | `--bz-accent` (alias `--bz-copper`) | `#d4845a`                                  | prices, CTAs, border-left service rows, roman numerals |
+| Warm gold     | `--bz-accent-warm`                  | `#c9a96e`                                  | hairlines, batik patterns, kintsugi separators         |
+| Cool blue     | `--bz-accent-cool`                  | `#5e7fb5`                                  | trust signals, secondary chips                         |
+| Text primary  | `--bz-text-1`                       | `#edeae4`                                  | text on dark surfaces                                  |
+| Text dark     | (new) `#1d273b`                     | navy on cream — body text                  |
+| Text muted    | `--bz-text-2`                       | `#8c8884`                                  | descriptions, captions                                 |
+| Text subtle   | `--bz-text-3`                       | `#575350`                                  | meta, page numbers                                     |
+
+**Rationale:** the document uses a "light document + dark spotlight" registry — body sections are paper-warm cream for legibility and editorial calm; cover, section dividers and footer are deep navy to create rhythmic visual cadence. Pattern follows luxury hospitality brands (Aman, Como, Capella) — Bali Zero's natural positioning as boutique consultancy.
+
+### 6.2 Typography
+
+| Use                          | Font                   | Weight    | Source                                                     |
+| ---------------------------- | ---------------------- | --------- | ---------------------------------------------------------- |
+| Display (cover, H1 sections) | **Cormorant Garamond** | 600       | Google Fonts                                               |
+| Headers (H2/H3)              | **League Spartan**     | 500       | Google Fonts (brand-consistent — already in `globals.css`) |
+| Body                         | **Inter**              | 400 / 500 | Google Fonts                                               |
+| Numerics / Prices            | **Inter** Tabular Nums | 600       | `font-variant-numeric: tabular-nums`                       |
+
+All free, OAuth-free, embeddable offline (we inline `@font-face` woff2 base64 in HTML for full portability).
+
+### 6.3 Layout system
+
+- **Page format:** A4 portrait (794×1123 px @ 96dpi).
+- **Margins:** 60px LR, 80px TB.
+- **Density:** ~6 services per A4 page (no claustrophobia).
+- **Section divider pattern:** full-bleed dark rectangle 180px tall — Roman numeral copper top-left, section name in Cormorant 48px cream center-left, intro caption Inter 14px muted, hero image 40% width right-aligned.
+- **Service row pattern:** `border-left 3px copper`, padding 18px, name (Inter 600 16px navy) + price right-aligned (Inter tabular-nums 600 18px copper), description below (Inter italic 13px muted).
+- **Spacing between rows:** 28px.
+
+### 6.4 Image strategy — three layers, all generated via `codex exec` + Image 2 (gpt-image-1)
+
+**Pipeline:** for each asset I shell out to `codex exec` (Codex CLI 0.128.0 confirmed installed) with a brief, capture the generated PNG path, store under `~/Desktop/Bali_Zero_Price_List_2026_assets/`, then base64-embed in the HTML. Codex CLI runs on ChatGPT Plus (zero per-image cost, OAuth-free per the no-paid-API-key rule).
+
+**Layer 1 — Ornaments (SVG inline, no AI):**
+
+- Batik glyph patterns (small SVG repeated as background-image @ low opacity)
+- Copper hairline separators
+- Roman numerals styling
+- Decorative corner ornaments
+- Cost: 0 generation — SVG written inline by the generator script.
+
+**Layer 2 — Hero photography (6 images, 1920×1080 PNG):**
+
+| #   | Section               | Hero brief (passed to Image 2)                                                                                                                                                                                                                                                                                                             |
+| --- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | I-III. Visas          | "Cinematic still-life: open passport with embossed Indonesian visa stamp resting on travertine marble surface, soft dawn light from upper left, brass key in soft focus background, palette of warm copper and deep navy shadows, shallow depth of field, slow shutter feel, slow-magazine photography aesthetic, no text, no logos, 16:9" |
+| 2   | IV-V. KITAS / KITAP   | "Cinematic editorial: tilt-shift Jakarta skyline at golden hour bokeh in background, foreground crisp printed Letter of Approval document with embossed seal partly visible, no readable text, navy + copper palette, slow shutter feel, no text, no logos, 16:9"                                                                          |
+| 3   | VI. Tax & Accounting  | "Macro detail: vintage fountain pen poised over a blank ledger page, Indonesian rupiah banknotes blurred at edge, low-key chiaroscuro lighting, deep navy background, copper highlights on metal pen body, editorial slow-magazine quality, no text, no logos, 16:9"                                                                       |
+| 4   | VII. Company Services | "Cinematic still-life: notarial seal pressed into deep red sealing wax on cream Akta document, hand of notary partly visible holding brass seal, low-key warm lighting, shallow depth of field, no readable text on document, copper + navy palette, no logos, 16:9"                                                                       |
+| 5   | IX. Other Process     | "Top-down flat-lay: composed minimal arrangement of identity documents, immigration stamps, brass paperclips on cream linen surface, soft diffused window light, no readable text, no logos, palette copper navy gold, 16:9"                                                                                                               |
+| 6   | X. Urgent Processing  | "Cinematic still-life: crystal hourglass with copper sand mid-flow, deep navy background, single beam of light from upper right, dramatic shadow, slow magazine quality, no text, no logos, 16:9"                                                                                                                                          |
+
+**Layer 3 — Micro-icons (~25 line-art icons, 512×512 transparent PNG):**
+
+Stylistic constraint passed to Image 2 batch:
+
+> "Single line-art icon, 2px stroke weight, copper color #d4845a, transparent background, centered in 1024×1024 frame, minimalist editorial style, no fill, no shadows, single subject only, NO TEXT. Subject: [varies per icon]"
+
+Subjects: passport, visa-stamp, calendar-extension, multiple-arrows, briefcase, palette-art, briefcase-search (D12), graduation-cap, marriage-rings, family, beach-chair (retirement), home-key (KITAP), notary-seal (PMA), virtual-cloud-office, akta-document, ledger (tax), bar-chart (LKPM), exit-arrow (EPO), exit-reentry-arrow (ERP), passport-arrow (mutation), id-card (SKTT), shield-check (SKCK), house-document (domicilie), baby (born report), clock-urgent.
+
+Embedded next to each service title (12×12mm in PDF, accessible-alt in HTML).
+
+### 6.5 Cover layout
+
+```
+┌─────────────────────────────────────────────────────┐
+│                                                     │
+│   [batik glyph SVG @ 8% opacity, full-bleed]        │
+│                                                     │
+│              [LOGO CIRCLE 200px]                    │
+│                                                     │
+│               BALI ZERO                             │  ← Cormorant 96px cream
+│           ─────────────                             │  ← copper hairline 80px
+│                                                     │
+│           PRICE LIST 2026                           │  ← League Spartan 28px gold tracking
+│                                                     │
+│                                                     │
+│        Visa · KITAS · Company                       │  ← Inter 14px copper
+│        Tax · Accounting · Other                     │
+│                                                     │
+│  balizero.com  ·  Kerobokan, Bali, Indonesia        │  ← footer Inter 11px muted
+│                                                     │
+└─────────────────────────────────────────────────────┘
+```
+
+### 6.6 Senior touches
+
+- **Page numbers** `02 / 20` editorial style serif bottom-right
+- **Running header** from page 2: "Bali Zero · Price List 2026" left + section name right, copper hairline beneath
+- **ToC with leader dots** menu-degustazione style
+- **Color-coded edge tabs** on right margin per macro-section (printed solid bars visible at book edge)
+- **Closing page**: dark brand surface, contacts large, generated **WhatsApp QR code** linking `wa.me/628213107363` (libqrencode SVG, generated inline in script)
+
+---
+
+## 7. Generator script — `scripts/generate_pricelist_2026.py`
+
+**Inputs:**
+
+- `apps/backend-rag/backend/data/bali_zero_official_prices_2026.json`
+- `~/Desktop/Bali_Zero_Price_List_2026_assets/heros/*.png` (6 files)
+- `~/Desktop/Bali_Zero_Price_List_2026_assets/icons/*.png` (~25 files)
+- `~/Desktop/balizero_logo_circle.png` (existing brand asset)
+
+**Outputs:**
+
+- `~/Desktop/Bali_Zero_Price_List_2026.html` — single self-contained file (all images base64-embedded, all fonts inlined)
+- `~/Desktop/Bali_Zero_Price_List_2026.pdf` — generated via Playwright headless print of the HTML
+- `docs/pricing/Bali_Zero_Price_List_2026.md` + `docs/pricing/assets/2026/` (versioned in repo)
+
+**Dependencies:**
+
+- Python 3.11+ (already in venv)
+- `jinja2` (for HTML template)
+- `playwright` (for PDF render — already in repo for other carousels)
+- `qrcode` (Python lib, MIT, no API)
+
+**No paid APIs.** Image generation is delegated to `codex exec` shell-outs that the script orchestrates one-shot (or by Zero manually, ahead of time, depending on preference — see §9 Build Sequence).
+
+---
+
+## 8. Conflicts resolved (audit)
+
+| #   | Item                                                                                            | Resolution                                                                                                  | Authority                                |
+| --- | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| 1   | Investor KITAP + MERP price (PDF 50M+ACC vs JSON 55M)                                           | **Rp 55.000.000, no ACC**                                                                                   | user 2026-05-06                          |
+| 2   | Dependent KITAP + MERP price (PDF 30M+ACC vs JSON 33M)                                          | **Rp 33.000.000, no ACC**                                                                                   | user 2026-05-06                          |
+| 3   | Revision Company vs Akta Perubahan (JSON had two entries)                                       | **Unified into one row "Akta Perubahan (Revision Company) — Depend (Contact for quote)"**                   | user 2026-05-06                          |
+| 4   | D12 Business Investigation (only in JSON, not PDF)                                              | **Kept** (1Y 7,5M / 2Y 10M)                                                                                 | user 2026-05-06                          |
+| 5   | Annual Tax / LKPM / Personal Tax repeated across 4 monthly tiers                                | **Extracted ONCE in section VI.4**                                                                          | structural dedup, user-approved          |
+| 6   | Urgent surcharges per service (EPO+300k, ERP+500k, etc.) vs Urgent processing tier (1/2/3 hari) | **Both kept** in separate sections (Other Process inline + dedicated Urgent section X) with clarifying note | structural — they are different concepts |
+| 7   | Contacts (JSON had `info@balizero.com` + `+62 813 3805 1876`)                                   | **Updated to `zero@balizero.com` + `+62 821 3110 7363` + Kerobokan**                                        | user 2026-05-06                          |
+
+---
+
+## 9. Build sequence
+
+1. **Author JSON** (`bali_zero_official_prices_2026.json`) — manually compose from 2025 JSON + tax dpt input + conflict resolutions. ~30 min.
+2. **Author the generator script** (`scripts/generate_pricelist_2026.py` + `templates/pricelist_2026.html.j2`). ~60 min.
+3. **Generate Layer 1 ornaments** (SVG inline in template). 0 min — handled in script.
+4. **Generate Layer 2 heros** (`codex exec` × 6 briefs). ~10 min wallclock parallel; ~5 min curation.
+5. **Generate Layer 3 icons** (`codex exec` batch × ~25 subjects). ~10 min wallclock; ~5 min curation.
+6. **Run generator** → produce HTML + PDF + Markdown. ~2 min.
+7. **Visual QA on PDF** — verify typography, page breaks, image embedding, color fidelity. Adjust template, regenerate. ~15 min.
+8. **Commit** the JSON, the script, the template, the docs/pricing/ markdown, and the assets to repo. PDF + HTML stay on Desktop (gitignored — they are generated artifacts).
+9. **Owner approval** → optional follow-up: switch backend RAG `PricingTool` to read 2026 JSON (separate PR, not in scope here).
+
+**Total estimated wallclock:** ~2 hours.
+
+---
+
+## 10. Testing & verification
+
+- **JSON schema:** `scripts/test_pricelist_2026_schema.py` (~20 LOC) validates the JSON loads, all 80 entries have required fields, no entry has empty `price` AND empty `tier_range`, contact block matches user-confirmed values.
+- **Backward-compat smoke:** import `bali_zero_official_prices_2026.json` shape into a copy of `PricingService._load_prices()` to confirm it would still load (read-only test, doesn't mutate prod). Skipped if the read shape is identical to 2025 schema (which it is for non-tax sections).
+- **Visual QA:** manual PDF review — page break at section dividers, no orphan service rows, color match to globals.css palette, all 6 heroes + 25 icons render correctly, QR code scans to correct WhatsApp number.
+- **Reproducibility:** running `generate_pricelist_2026.py` twice produces byte-identical HTML and Markdown (deterministic). PDF may differ in metadata only.
+
+---
+
+## 11. Distribution & handover
+
+- **Internal Drive:** Zero uploads HTML + PDF to Bali Zero shared Drive (manual step, out of scope for this spec).
+- **Client send:** PDF attached via WhatsApp `+62 821 3107 363` or email `zero@balizero.com`.
+- **Repo:** Markdown version is the auditable record at `docs/pricing/Bali_Zero_Price_List_2026.md`.
+- **Backend RAG migration:** the `PricingTool` continues to read `bali_zero_official_prices_2025.json` until Zero explicitly asks to switch. The 2026 JSON sits next to it ready to be swapped in a future single-line config change.
+
+---
+
+## 12. Risks & mitigations
+
+| Risk                                                                  | Mitigation                                                                                                                                                        |
+| --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Image 2 generations come out generic/cheesy                           | Brief includes explicit "slow-magazine photography aesthetic, no text, no logos, no stock-photo feel" + per-asset curation gate before embedding                  |
+| Codex exec quota / availability                                       | If Codex unavailable, fallback is Canva MCP `generate-design` (also free OAuth)                                                                                   |
+| Font embedding via `@font-face` base64 inflates HTML beyond 5MB       | Subset Google Fonts to Latin + `Rp 0123456789.,` glyphs only via `pyftsubset` — keeps fonts <80KB total                                                           |
+| Playwright PDF prints with wrong page-break behavior on long sections | Use `page-break-inside: avoid` on `.service-row` and `page-break-before: always` on section dividers                                                              |
+| Conflict re-emerges if the 2025 JSON is updated post-shipping         | Add a note at the top of `_2025.json` pointing to `_2026.json` as the new authoritative source once owner approves the swap                                       |
+| Brand palette drift from `globals.css`                                | Generator references hex values inline (no CSS var dependency); a future `globals.css` repaint requires a manual sync — accepted trade-off for self-contained PDF |
+
+---
+
+## 13. Open items (none blocking)
+
+- WhatsApp number `+62 821 3107 363` was given by user on 2026-05-06; the previous brand book had `+62 813 3805 1876`. **User decision is the final word.** Generator uses the new number. ⚠️ Please double-check this number before render — different formatting interpretations are possible (10 digits after +62 ID code).
+- If Zero wants a multi-language version (bahasa Indonesia for team), it is a future follow-up — generator is JSON-driven, easy to add a `description_id` field per service.

--- a/scripts/pricelist_2026/asset_briefs.py
+++ b/scripts/pricelist_2026/asset_briefs.py
@@ -1,0 +1,137 @@
+"""Briefs for codex exec → Image 2 (gpt-image-1) generation.
+
+Pure data, no I/O. Each entry is (output_basename, brief_text, size).
+
+ICON_BRIEFS keys must be a 1:1 cover of every icon_id used in
+bali_zero_official_prices_2026.json (45 unique ids as of 2026-05-06).
+The generator script (generate_assets.py) iterates this dict; missing
+keys = missing PNGs = AssetMissingError at render time.
+"""
+from __future__ import annotations
+
+# Shared style constraints injected into every brief
+_STYLE_HEROS = (
+    "Cinematic editorial still-life. Slow-magazine photography aesthetic, "
+    "low-key chiaroscuro, shallow depth of field. Palette anchored on deep "
+    "navy #1d273b, copper #d4845a, warm gold #c9a96e on cream paper #fbfaf6 "
+    "highlights. NO TEXT, NO LOGOS, NO WATERMARKS, NO READABLE WRITING on "
+    "any surface. 16:9 landscape composition."
+)
+
+_STYLE_ICONS = (
+    "Single line-art icon, 2px stroke weight, copper color #d4845a only, "
+    "transparent background, centered in 1024×1024 frame, minimalist "
+    "editorial style, no fill, no shadows, single subject only. NO TEXT."
+)
+
+# 6 hero photographs, one per macro-section (1792x1024 = closest 16:9 supported by Image 2)
+HERO_BRIEFS: list[tuple[str, str, str]] = [
+    (
+        "01_visas",
+        f"{_STYLE_HEROS} Subject: open passport with embossed Indonesian "
+        "visa stamp resting on travertine marble surface, soft dawn light "
+        "from upper left, brass key in soft focus background.",
+        "1792x1024",
+    ),
+    (
+        "02_kitas_kitap",
+        f"{_STYLE_HEROS} Subject: tilt-shift Jakarta skyline at golden hour "
+        "bokeh in background, foreground crisp printed Letter of Approval "
+        "document with embossed seal partly visible (no readable text on "
+        "document).",
+        "1792x1024",
+    ),
+    (
+        "03_tax",
+        f"{_STYLE_HEROS} Subject: macro detail of a vintage fountain pen "
+        "poised over a blank ledger page, Indonesian rupiah banknotes "
+        "blurred at edge, copper highlights on metal pen body.",
+        "1792x1024",
+    ),
+    (
+        "04_company",
+        f"{_STYLE_HEROS} Subject: notarial seal pressed into deep red "
+        "sealing wax on cream Akta document, hand of notary partly visible "
+        "holding brass seal (no readable text on document).",
+        "1792x1024",
+    ),
+    (
+        "05_other_process",
+        f"{_STYLE_HEROS} Subject: top-down flat-lay of identity documents, "
+        "immigration stamps, brass paperclips on cream linen surface, soft "
+        "diffused window light (no readable text on documents).",
+        "1792x1024",
+    ),
+    (
+        "06_urgent",
+        f"{_STYLE_HEROS} Subject: crystal hourglass with copper sand "
+        "mid-flow, deep navy background, single beam of light from upper "
+        "right, dramatic shadow.",
+        "1792x1024",
+    ),
+]
+
+# Micro-icons keyed by icon_id used in the JSON.
+# Must be a 1:1 cover of the icon_id set (45 ids as of 2026-05-06).
+ICON_BRIEFS: dict[str, str] = {
+    # Visas (7)
+    "visa-tourism":        f"{_STYLE_ICONS} Subject: passport with palm tree.",
+    "visa-business":       f"{_STYLE_ICONS} Subject: briefcase with passport corner showing.",
+    "visa-art":            f"{_STYLE_ICONS} Subject: musical note inside circular frame.",
+    "visa-internship":     f"{_STYLE_ICONS} Subject: graduation cap.",
+    "visa-worktrial":      f"{_STYLE_ICONS} Subject: clipboard with checkmark.",
+    "visa-extension":      f"{_STYLE_ICONS} Subject: calendar page with curved arrow extending right.",
+    "visa-multiple":       f"{_STYLE_ICONS} Subject: passport with two arrows pointing in opposite directions.",
+    "visa-investigation":  f"{_STYLE_ICONS} Subject: magnifying glass over a briefcase.",
+
+    # KITAS (7)
+    "kitas-working":       f"{_STYLE_ICONS} Subject: hard hat positioned above a document.",
+    "kitas-investor":      f"{_STYLE_ICONS} Subject: rising bar chart with a coin on top.",
+    "kitas-freelance":     f"{_STYLE_ICONS} Subject: laptop with a palm leaf beside it.",
+    "kitas-remote":        f"{_STYLE_ICONS} Subject: laptop with three concentric wifi waves above.",
+    "kitas-spouse":        f"{_STYLE_ICONS} Subject: two interlocking rings.",
+    "kitas-dependent":     f"{_STYLE_ICONS} Subject: silhouettes of a family of three (two adults, one child).",
+    "kitas-retirement":    f"{_STYLE_ICONS} Subject: lounge chair under a palm tree.",
+
+    # KITAP (2)
+    "kitap-permanent":     f"{_STYLE_ICONS} Subject: house outline with a key.",
+    "kitap-merp":          f"{_STYLE_ICONS} Subject: airplane with two re-entry arrows beneath.",
+
+    # Tax (4)
+    "tax-monthly":         f"{_STYLE_ICONS} Subject: calendar page with a currency symbol.",
+    "tax-annual":          f"{_STYLE_ICONS} Subject: ledger book with a bookmark ribbon.",
+    "tax-lkpm":            f"{_STYLE_ICONS} Subject: bar chart inside a government building outline.",
+    "tax-personal":        f"{_STYLE_ICONS} Subject: single person silhouette holding a document.",
+
+    # Company (4)
+    "company-pma":         f"{_STYLE_ICONS} Subject: Indonesian temple gate (candi bentar) in outline form.",
+    "company-virtual":     f"{_STYLE_ICONS} Subject: cloud with a small building inside.",
+    "company-akta":        f"{_STYLE_ICONS} Subject: scroll with a notary seal beneath.",
+    "company-close":       f"{_STYLE_ICONS} Subject: building with an X mark over its door.",
+
+    # Consultant (6)
+    "consultant-npwpd":    f"{_STYLE_ICONS} Subject: city map pin over a document.",
+    "consultant-bpjs-tk":  f"{_STYLE_ICONS} Subject: hand outline above a worker silhouette.",
+    "consultant-bpjs-kes": f"{_STYLE_ICONS} Subject: medical cross inside a shield.",
+    "consultant-npwp":     f"{_STYLE_ICONS} Subject: ID card with a hash symbol.",
+    "consultant-update":   f"{_STYLE_ICONS} Subject: pencil over a document with a small refresh arrow.",
+    "consultant-efin":     f"{_STYLE_ICONS} Subject: digital fingerprint.",
+
+    # Other Process (11)
+    "other-passport":      f"{_STYLE_ICONS} Subject: passport icon with the front cover visible.",
+    "other-sktt":          f"{_STYLE_ICONS} Subject: ID card with a small house outline beside it.",
+    "other-skck":          f"{_STYLE_ICONS} Subject: shield with a checkmark inside.",
+    "other-domicile":      f"{_STYLE_ICONS} Subject: house with a document beside it.",
+    "other-born":          f"{_STYLE_ICONS} Subject: stork in flight.",
+    "other-epo":           f"{_STYLE_ICONS} Subject: door with a single arrow exiting to the right.",
+    "other-erp":           f"{_STYLE_ICONS} Subject: door with two arrows (one entering, one exiting).",
+    "other-mutation":      f"{_STYLE_ICONS} Subject: passport with a curved transfer arrow above.",
+    "other-cancel":        f"{_STYLE_ICONS} Subject: document with a diagonal X mark across it.",
+    "other-molina":        f"{_STYLE_ICONS} Subject: circular refresh arrow.",
+    "other-boarding":      f"{_STYLE_ICONS} Subject: airplane boarding pass.",
+
+    # Urgent (3)
+    "urgent-1day":         f"{_STYLE_ICONS} Subject: stopwatch with the numeral 1 on its face.",
+    "urgent-2day":         f"{_STYLE_ICONS} Subject: stopwatch with the numeral 2 on its face.",
+    "urgent-3day":         f"{_STYLE_ICONS} Subject: stopwatch with the numeral 3 on its face.",
+}

--- a/scripts/pricelist_2026/generate_assets.py
+++ b/scripts/pricelist_2026/generate_assets.py
@@ -1,0 +1,135 @@
+"""Driver: generates hero + icon PNGs via `codex exec` → Image 2 (gpt-image-1).
+
+Idempotent: skips files already present in the output dir. Use
+--regenerate <basename> to force re-gen of a specific asset.
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# Add repo root to sys.path so `from scripts...` resolves when run as module
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.pricelist_2026 import asset_briefs
+
+DEFAULT_OUT = Path.home() / "Desktop" / "Bali_Zero_Price_List_2026_assets"
+
+
+def _check_codex() -> None:
+    if shutil.which("codex") is None:
+        sys.exit(
+            "ERROR: `codex` CLI not found in PATH. Install Codex CLI before "
+            "running this script. Do NOT introduce paid-API fallbacks."
+        )
+
+
+def _codex_image_prompt(brief: str, out_path: Path, size: str) -> str:
+    """Wrap the brief in instructions Codex will follow non-interactively."""
+    return (
+        f"Generate ONE image using OpenAI gpt-image-1 (Image 2). "
+        f"Brief: {brief} "
+        f"Size: {size}. "
+        f"Save the resulting PNG file at exactly this absolute path: "
+        f"{out_path}. "
+        f"Do not output anything else after generation. Do not explain. "
+        f"Do not generate variants. Do not ask for confirmation."
+    )
+
+
+def _generate_one(brief: str, out_path: Path, size: str, *, dry_run: bool) -> bool:
+    """Returns True if generated, False if skipped."""
+    if out_path.exists():
+        print(f"  ✓ skip (exists): {out_path.name}")
+        return False
+    prompt = _codex_image_prompt(brief, out_path, size)
+    if dry_run:
+        print(f"  [dry-run] would gen: {out_path.name}")
+        print(f"           prompt: {prompt[:120]}...")
+        return True
+    print(f"  ⏳ generating: {out_path.name} ({size})")
+    cmd = ["codex", "exec", "--full-auto", prompt]
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=300
+        )
+    except subprocess.TimeoutExpired:
+        print(f"  ✗ TIMEOUT: {out_path.name}", file=sys.stderr)
+        return False
+    if result.returncode != 0:
+        print(
+            f"  ✗ codex exec failed (exit {result.returncode}): "
+            f"{result.stderr[:300]}",
+            file=sys.stderr,
+        )
+        return False
+    if not out_path.exists():
+        print(
+            f"  ✗ codex completed but file not at {out_path}", file=sys.stderr
+        )
+        print(f"     stdout: {result.stdout[:300]}", file=sys.stderr)
+        return False
+    print(f"  ✓ generated: {out_path.name} ({out_path.stat().st_size} bytes)")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT)
+    parser.add_argument(
+        "--only", choices=["heros", "icons", "all"], default="all"
+    )
+    parser.add_argument(
+        "--regenerate", action="append", default=[],
+        help="Force re-gen of basename (without .png). Repeatable."
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    _check_codex()
+
+    heros_dir = args.out_dir / "heros"
+    icons_dir = args.out_dir / "icons"
+    heros_dir.mkdir(parents=True, exist_ok=True)
+    icons_dir.mkdir(parents=True, exist_ok=True)
+
+    # Force re-gen by deleting the existing PNGs first
+    for basename in args.regenerate:
+        for d in (heros_dir, icons_dir):
+            target = d / f"{basename}.png"
+            if target.exists():
+                print(f"  ✗ deleting for re-gen: {target}")
+                target.unlink()
+
+    n_gen = 0
+    n_skip = 0
+
+    if args.only in ("heros", "all"):
+        print(f"=== Heros ({len(asset_briefs.HERO_BRIEFS)}) ===")
+        for basename, brief, size in asset_briefs.HERO_BRIEFS:
+            out = heros_dir / f"{basename}.png"
+            if _generate_one(brief, out, size, dry_run=args.dry_run):
+                n_gen += 1
+            else:
+                if out.exists():
+                    n_skip += 1
+
+    if args.only in ("icons", "all"):
+        print(f"=== Icons ({len(asset_briefs.ICON_BRIEFS)}) ===")
+        for icon_id, brief in sorted(asset_briefs.ICON_BRIEFS.items()):
+            out = icons_dir / f"{icon_id}.png"
+            if _generate_one(brief, out, "1024x1024", dry_run=args.dry_run):
+                n_gen += 1
+            else:
+                if out.exists():
+                    n_skip += 1
+
+    print(f"\nDone. Generated: {n_gen}, Skipped (already exist): {n_skip}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pricelist_2026/schema.py
+++ b/scripts/pricelist_2026/schema.py
@@ -1,0 +1,94 @@
+"""JSON schema validator for the 2026 Bali Zero price list.
+
+Stdlib only. Returns a `ValidationResult` with .ok and .errors.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+CANONICAL_CONTACT = {
+    "email": "zero@balizero.com",
+    "whatsapp": "+62 821 31 07 363",
+    "wa_link": "https://wa.me/628213107363",
+    "location": "Kerobokan, Bali, Indonesia",
+    "website": "balizero.com",
+}
+
+REQUIRED_TOP_LEVEL = ["version", "effective_date", "metadata", "services"]
+REQUIRED_METADATA = ["currency", "contact", "last_updated"]
+REQUIRED_CONTACT = list(CANONICAL_CONTACT.keys())
+REQUIRED_SERVICE_FIELDS = [
+    "name", "price", "tier_range", "duration", "validity",
+    "notes", "description_en", "icon_id",
+]
+
+
+@dataclass
+class ValidationResult:
+    ok: bool = True
+    errors: list[str] = field(default_factory=list)
+
+    def fail(self, msg: str) -> None:
+        self.ok = False
+        self.errors.append(msg)
+
+
+def validate(data: dict[str, Any]) -> ValidationResult:
+    result = ValidationResult()
+
+    for key in REQUIRED_TOP_LEVEL:
+        if key not in data:
+            result.fail(f"top-level: missing '{key}'")
+
+    metadata = data.get("metadata", {})
+    for key in REQUIRED_METADATA:
+        if key not in metadata:
+            result.fail(f"metadata: missing '{key}'")
+
+    contact = metadata.get("contact", {})
+    for key, expected in CANONICAL_CONTACT.items():
+        actual = contact.get(key)
+        if actual is None:
+            result.fail(f"metadata.contact: missing '{key}'")
+        elif actual != expected:
+            result.fail(
+                f"metadata.contact.{key} mismatch: expected '{expected}', got '{actual}'"
+            )
+
+    services = data.get("services", {})
+    for category, entries in services.items():
+        # tax_accounting has ONE extra level of nesting (sub-blocks)
+        if category == "tax_accounting":
+            for subblock, subentries in entries.items():
+                for name, svc in subentries.items():
+                    _validate_service(result, f"{category}.{subblock}.{name}", svc)
+        else:
+            for name, svc in entries.items():
+                _validate_service(result, f"{category}.{name}", svc)
+
+    return result
+
+
+def _validate_service(result: ValidationResult, path: str, svc: dict) -> None:
+    for field_name in REQUIRED_SERVICE_FIELDS:
+        if field_name not in svc:
+            result.fail(f"{path}: missing field '{field_name}'")
+
+    price = svc.get("price", "")
+    tier = svc.get("tier_range")
+
+    has_price = bool(price and price.strip())
+    has_tier = tier is not None and isinstance(tier, list) and len(tier) == 2
+
+    if not has_price and not has_tier:
+        result.fail(f"{path}: must have price or tier_range")
+    if has_price and has_tier:
+        result.fail(f"{path}: must have price or tier_range, not both")
+
+    if tier is not None:
+        if not isinstance(tier, list) or len(tier) != 2:
+            result.fail(f"{path}: tier_range must be a list of exactly 2 strings")
+        elif not all(isinstance(x, str) for x in tier):
+            result.fail(f"{path}: tier_range entries must be strings")

--- a/scripts/pricelist_2026/templates/pricelist.html.j2
+++ b/scripts/pricelist_2026/templates/pricelist.html.j2
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Bali Zero — Price List 2026</title>
+<style>
+  /* Inlined fonts (base64 woff2 set by generator if provided) */
+  {{ font_face_block | safe }}
+
+  :root {
+    --paper: #fbfaf6;
+    --navy: #1d273b;
+    --navy-elevated: #243047;
+    --copper: #d4845a;
+    --gold: #c9a96e;
+    --cool-blue: #5e7fb5;
+    --cream: #edeae4;
+    --muted: #8c8884;
+    --subtle: #575350;
+  }
+
+  @page {
+    size: A4 portrait;
+    margin: 0;
+  }
+
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--paper); color: var(--navy); }
+  body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+
+  .page {
+    width: 210mm;
+    min-height: 297mm;
+    padding: 80px 60px;
+    position: relative;
+    page-break-after: always;
+    background: var(--paper);
+  }
+  .page.dark { background: var(--navy); color: var(--cream); }
+
+  /* COVER */
+  .cover {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    background: var(--navy);
+    color: var(--cream);
+    overflow: hidden;
+  }
+  .cover .batik {
+    position: absolute; inset: 0; opacity: 0.08;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'><path d='M0 20 L20 0 L40 20 L20 40 Z' fill='none' stroke='%23c9a96e' stroke-width='0.6'/></svg>");
+    background-size: 40px 40px;
+  }
+  .cover img.logo { width: 200px; height: 200px; margin-bottom: 40px; z-index: 1; position: relative; }
+  .cover h1 {
+    font-family: 'Cormorant Garamond', Georgia, serif; font-weight: 600;
+    font-size: 96px; letter-spacing: 0.04em; margin: 0; z-index: 1; position: relative;
+  }
+  .cover .hairline {
+    width: 80px; height: 2px; background: var(--copper);
+    margin: 24px 0; z-index: 1; position: relative;
+  }
+  .cover .subtitle {
+    font-family: 'League Spartan', sans-serif; font-weight: 500;
+    font-size: 28px; color: var(--gold); letter-spacing: 0.18em;
+    text-transform: uppercase; z-index: 1; position: relative;
+  }
+  .cover .tags {
+    margin-top: 80px; color: var(--copper); letter-spacing: 0.1em;
+    z-index: 1; position: relative; font-size: 14px;
+  }
+  .cover .footer {
+    position: absolute; bottom: 60px; font-size: 11px; color: var(--muted);
+    z-index: 1;
+  }
+
+  /* RUNNING HEADER (page 2+) */
+  .header {
+    position: absolute; top: 30px; left: 60px; right: 60px;
+    display: flex; justify-content: space-between; font-size: 10px;
+    color: var(--muted); letter-spacing: 0.08em; text-transform: uppercase;
+    border-bottom: 0.5px solid var(--gold); padding-bottom: 8px;
+  }
+
+  /* PAGE NUMBER */
+  .page-num {
+    position: absolute; bottom: 30px; right: 60px;
+    font-family: 'Cormorant Garamond', Georgia, serif; font-size: 11px;
+    color: var(--subtle);
+  }
+
+  /* TOC */
+  .toc h1 {
+    font-family: 'Cormorant Garamond', Georgia, serif; font-size: 48px;
+    font-weight: 600; margin: 40px 0 40px;
+  }
+  .toc ul { list-style: none; padding: 0; margin: 0; }
+  .toc li {
+    display: flex; align-items: baseline; padding: 12px 0;
+    border-bottom: 0.5px dotted var(--muted);
+  }
+  .toc .roman {
+    font-family: 'Cormorant Garamond', Georgia, serif; font-style: italic;
+    color: var(--copper); width: 60px;
+  }
+  .toc .name { flex: 1; font-size: 16px; }
+  .toc .pageref { color: var(--subtle); }
+
+  /* SECTION DIVIDER */
+  .divider {
+    background: var(--navy); color: var(--cream);
+    padding: 60px; min-height: 200px;
+    display: grid; grid-template-columns: 1fr 1fr; gap: 40px; align-items: center;
+    page-break-after: avoid;
+  }
+  .divider .left .roman {
+    font-family: 'Cormorant Garamond', Georgia, serif; font-style: italic;
+    color: var(--copper); font-size: 28px; margin-bottom: 8px;
+  }
+  .divider .left h2 {
+    font-family: 'Cormorant Garamond', Georgia, serif; font-size: 48px;
+    font-weight: 600; margin: 0 0 12px;
+  }
+  .divider .left .intro { color: var(--muted); font-size: 14px; }
+  .divider .hero {
+    width: 100%; aspect-ratio: 16 / 9; border-radius: 4px;
+    object-fit: cover;
+  }
+
+  /* SUB-SECTION (tax_accounting) */
+  .subsection-title {
+    font-family: 'League Spartan', sans-serif; font-weight: 500;
+    font-size: 18px; color: var(--copper); letter-spacing: 0.06em;
+    text-transform: uppercase; margin: 32px 0 16px;
+    border-bottom: 0.5px solid var(--gold); padding-bottom: 8px;
+  }
+
+  /* SERVICE ROW */
+  .service {
+    display: grid; grid-template-columns: 32px 1fr 180px;
+    gap: 16px; padding: 18px 0 18px 18px;
+    border-left: 3px solid var(--copper);
+    margin-bottom: 12px;
+    page-break-inside: avoid;
+    align-items: start;
+  }
+  .service .icon { width: 28px; height: 28px; opacity: 0.85; }
+  .service .name {
+    font-weight: 600; font-size: 15px; color: var(--navy);
+  }
+  .service .desc {
+    font-style: italic; font-size: 12px; color: var(--muted);
+    margin-top: 4px;
+  }
+  .service .meta {
+    font-size: 11px; color: var(--subtle); margin-top: 6px;
+  }
+  .service .price {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    font-weight: 600; font-size: 16px; color: var(--copper);
+  }
+  .service .tier { font-size: 14px; line-height: 1.4; }
+  .service .notes { font-size: 11px; color: var(--muted); margin-top: 4px; font-style: italic; }
+
+  /* CLOSING */
+  .closing {
+    background: var(--navy); color: var(--cream);
+    display: flex; flex-direction: column; justify-content: center;
+    align-items: center; text-align: center;
+    padding: 80px 60px;
+  }
+  .closing h2 {
+    font-family: 'Cormorant Garamond', Georgia, serif; font-size: 56px;
+    margin: 0 0 32px; color: var(--gold);
+  }
+  .closing .qr {
+    width: 200px; height: 200px; background: var(--cream);
+    padding: 16px; border-radius: 4px; margin: 24px 0;
+  }
+  .closing .contact { font-size: 16px; line-height: 2; }
+  .closing .contact a { color: var(--copper); text-decoration: none; }
+</style>
+</head>
+<body>
+
+<!-- COVER -->
+<section class="page cover">
+  <div class="batik"></div>
+  <img class="logo" src="{{ logo_data_uri }}" alt="">
+  <h1>BALI ZERO</h1>
+  <div class="hairline"></div>
+  <div class="subtitle">Price List 2026</div>
+  <div class="tags">Visa · KITAS · Company<br>Tax · Accounting · Other</div>
+  <div class="footer">{{ contact.website }} · {{ contact.location }}</div>
+</section>
+
+<!-- TOC -->
+<section class="page toc">
+  <div class="header"><span>Bali Zero · Price List 2026</span><span>Contents</span></div>
+  <h1>Contents</h1>
+  <ul>
+    {% for section in sections %}
+    <li>
+      <span class="roman">{{ section.roman }}</span>
+      <span class="name">{{ section.title }}</span>
+      <span class="pageref">{{ section.page_ref }}</span>
+    </li>
+    {% endfor %}
+  </ul>
+  <div class="page-num">02</div>
+</section>
+
+<!-- SECTIONS -->
+{% for section in sections %}
+<section class="page divider">
+  <div class="left">
+    <div class="roman">{{ section.roman }}.</div>
+    <h2>{{ section.title }}</h2>
+    <div class="intro">{{ section.intro }}</div>
+  </div>
+  <img class="hero" src="{{ section.hero_data_uri }}" alt="">
+</section>
+
+<section class="page">
+  <div class="header"><span>Bali Zero · Price List 2026</span><span>{{ section.title }}</span></div>
+
+  {% if section.subsections %}
+    {% for sub in section.subsections %}
+      <div class="subsection-title">{{ sub.title }}</div>
+      {% for svc in sub.services %}
+        {% include 'service_row.html.j2' %}
+      {% endfor %}
+    {% endfor %}
+  {% else %}
+    {% for svc in section.services %}
+      {% include 'service_row.html.j2' %}
+    {% endfor %}
+  {% endif %}
+
+  <div class="page-num">{{ section.page_num }}</div>
+</section>
+{% endfor %}
+
+<!-- CLOSING -->
+<section class="page closing">
+  <h2>Get in touch</h2>
+  <img class="qr" src="{{ qr_data_uri }}" alt="WhatsApp QR">
+  <div class="contact">
+    <div><a href="https://{{ contact.website }}">{{ contact.website }}</a></div>
+    <div>{{ contact.email }}</div>
+    <div>{{ contact.whatsapp }}</div>
+    <div>{{ contact.location }}</div>
+  </div>
+</section>
+
+</body>
+</html>

--- a/scripts/pricelist_2026/templates/pricelist.md.j2
+++ b/scripts/pricelist_2026/templates/pricelist.md.j2
@@ -1,0 +1,57 @@
+# Bali Zero — Price List 2026
+
+**Effective:** {{ effective_date }}
+**Version:** {{ version }}
+**Last updated:** {{ last_updated }}
+
+> {{ contact.email }} · {{ contact.whatsapp }} · {{ contact.website }} · {{ contact.location }}
+
+![Bali Zero](./assets/2026/logo_circle.png)
+
+---
+
+## Contents
+
+{% for section in sections -%}
+- **{{ section.roman }}.** [{{ section.title }}](#{{ section.anchor }})
+{% endfor %}
+
+---
+
+{% for section in sections %}
+<a id="{{ section.anchor }}"></a>
+
+## {{ section.roman }}. {{ section.title }}
+
+![{{ section.title }}](./assets/2026/heros/{{ section.hero_basename }}.png)
+
+_{{ section.intro }}_
+
+{% if section.subsections %}
+{% for sub in section.subsections %}
+### {{ sub.title }}
+
+| Service | Description | Price |
+| --- | --- | --- |
+{% for svc in sub.services -%}
+| **{{ svc.name }}** | {{ svc.description_en }}{% if svc.notes %} _({{ svc.notes }})_{% endif %} | {% if svc.tier_range %}{{ svc.tier_range[0] }} – {{ svc.tier_range[1] }}{% else %}{{ svc.price }}{% endif %} |
+{% endfor %}
+
+{% endfor %}
+{% else %}
+| Service | Description | Price |
+| --- | --- | --- |
+{% for svc in section.services -%}
+| **{{ svc.name }}** | {{ svc.description_en }}{% if svc.notes %} _({{ svc.notes }})_{% endif %} | {% if svc.tier_range %}{{ svc.tier_range[0] }} – {{ svc.tier_range[1] }}{% else %}{{ svc.price }}{% endif %} |
+{% endfor %}
+{% endif %}
+
+---
+{% endfor %}
+
+## Get in touch
+
+- Website: <https://{{ contact.website }}>
+- Email: <{{ contact.email }}>
+- WhatsApp: [{{ contact.whatsapp }}]({{ contact.wa_link }})
+- Office: {{ contact.location }}

--- a/scripts/pricelist_2026/templates/service_row.html.j2
+++ b/scripts/pricelist_2026/templates/service_row.html.j2
@@ -1,0 +1,22 @@
+<div class="service">
+  <img class="icon" src="{{ svc.icon_data_uri }}" alt="">
+  <div>
+    <div class="name">{{ svc.name }}</div>
+    <div class="desc">{{ svc.description_en }}</div>
+    {% if svc.validity or svc.duration %}
+    <div class="meta">
+      {% if svc.validity %}Validity: {{ svc.validity }}{% endif %}
+      {% if svc.validity and svc.duration %} · {% endif %}
+      {% if svc.duration %}Duration: {{ svc.duration }}{% endif %}
+    </div>
+    {% endif %}
+    {% if svc.notes %}<div class="notes">{{ svc.notes }}</div>{% endif %}
+  </div>
+  <div class="price">
+    {% if svc.tier_range %}
+      <span class="tier">{{ svc.tier_range[0] }}<br>– {{ svc.tier_range[1] }}</span>
+    {% else %}
+      {{ svc.price }}
+    {% endif %}
+  </div>
+</div>

--- a/scripts/pricelist_2026/tests/conftest.py
+++ b/scripts/pricelist_2026/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Pytest configuration: ensure repo root is on sys.path so that
+``from scripts.pricelist_2026 import schema`` resolves correctly."""
+import sys
+from pathlib import Path
+
+# Repo root is 3 levels up from this file (tests/ -> pricelist_2026/ -> scripts/ -> repo root)
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))

--- a/scripts/pricelist_2026/tests/fixtures/minimal_prices.json
+++ b/scripts/pricelist_2026/tests/fixtures/minimal_prices.json
@@ -1,0 +1,43 @@
+{
+  "version": "2026.1",
+  "effective_date": "2026-01-01",
+  "metadata": {
+    "currency": "IDR",
+    "contact": {
+      "email": "zero@balizero.com",
+      "whatsapp": "+62 821 31 07 363",
+      "wa_link": "https://wa.me/628213107363",
+      "location": "Kerobokan, Bali, Indonesia",
+      "website": "balizero.com"
+    },
+    "last_updated": "2026-05-06"
+  },
+  "services": {
+    "single_entry_visas": {
+      "C1 Tourism": {
+        "name": "C1 Tourism",
+        "price": "2.300.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "60 days",
+        "notes": "",
+        "description_en": "Tourist visa, single entry, valid 60 days.",
+        "icon_id": "visa-tourism"
+      }
+    },
+    "tax_accounting": {
+      "monthly_tax_basic": {
+        "Tier 0-50": {
+          "name": "Monthly Tax Report — 0 to 50 transactions",
+          "price": "",
+          "tier_range": ["1.800.000 IDR", "2.000.000 IDR"],
+          "duration": "",
+          "validity": "monthly",
+          "notes": "",
+          "description_en": "Monthly bookkeeping for low volume.",
+          "icon_id": "tax-monthly"
+        }
+      }
+    }
+  }
+}

--- a/scripts/pricelist_2026/tests/test_schema.py
+++ b/scripts/pricelist_2026/tests/test_schema.py
@@ -79,10 +79,16 @@ def test_tier_range_must_be_two_strings():
 
 
 def test_real_2026_json_validates():
-    """Sanity check: the actual file we ship must validate."""
-    real = Path("apps/backend-rag/backend/data/bali_zero_official_prices_2026.json")
+    """Sanity check: the actual file we ship must validate.
+
+    Path resolved relative to repo root (parents[3] = repo root from
+    scripts/pricelist_2026/tests/test_schema.py) so the test runs
+    correctly regardless of CWD.
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    real = repo_root / "apps/backend-rag/backend/data/bali_zero_official_prices_2026.json"
     if not real.exists():
-        pytest.skip("real JSON not yet authored")
+        pytest.skip(f"real JSON not yet authored at {real}")
     data = json.loads(real.read_text())
     result = schema.validate(data)
     assert result.ok, f"Real 2026 JSON failed validation: {result.errors}"

--- a/scripts/pricelist_2026/tests/test_schema.py
+++ b/scripts/pricelist_2026/tests/test_schema.py
@@ -1,0 +1,88 @@
+"""Tests for the 2026 price list JSON schema validator."""
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.pricelist_2026 import schema
+
+FIXTURE = Path(__file__).parent / "fixtures" / "minimal_prices.json"
+
+
+def _load_fixture():
+    return json.loads(FIXTURE.read_text())
+
+
+def test_valid_fixture_passes():
+    data = _load_fixture()
+    result = schema.validate(data)
+    assert result.ok, f"Expected valid fixture to pass, got errors: {result.errors}"
+
+
+def test_missing_top_level_version_fails():
+    data = _load_fixture()
+    del data["version"]
+    result = schema.validate(data)
+    assert not result.ok
+    assert any("version" in e for e in result.errors)
+
+
+def test_contact_whatsapp_must_match_canonical():
+    data = _load_fixture()
+    data["metadata"]["contact"]["whatsapp"] = "+62 813 3805 1876"
+    result = schema.validate(data)
+    assert not result.ok
+    assert any("whatsapp" in e for e in result.errors)
+
+
+def test_service_with_neither_price_nor_tier_range_fails():
+    data = _load_fixture()
+    data["services"]["single_entry_visas"]["C1 Tourism"]["price"] = ""
+    data["services"]["single_entry_visas"]["C1 Tourism"]["tier_range"] = None
+    result = schema.validate(data)
+    assert not result.ok
+    assert any("must have price or tier_range" in e for e in result.errors)
+
+
+def test_service_with_both_price_and_tier_range_fails():
+    data = _load_fixture()
+    svc = data["services"]["single_entry_visas"]["C1 Tourism"]
+    svc["price"] = "2.300.000 IDR"
+    svc["tier_range"] = ["1 IDR", "2 IDR"]
+    result = schema.validate(data)
+    assert not result.ok
+    assert any("not both" in e for e in result.errors)
+
+
+def test_service_missing_description_en_fails():
+    data = _load_fixture()
+    del data["services"]["single_entry_visas"]["C1 Tourism"]["description_en"]
+    result = schema.validate(data)
+    assert not result.ok
+    assert any("description_en" in e for e in result.errors)
+
+
+def test_service_missing_icon_id_fails():
+    data = _load_fixture()
+    del data["services"]["single_entry_visas"]["C1 Tourism"]["icon_id"]
+    result = schema.validate(data)
+    assert not result.ok
+    assert any("icon_id" in e for e in result.errors)
+
+
+def test_tier_range_must_be_two_strings():
+    data = _load_fixture()
+    data["services"]["tax_accounting"]["monthly_tax_basic"]["Tier 0-50"]["tier_range"] = ["only one"]
+    result = schema.validate(data)
+    assert not result.ok
+    assert any("tier_range" in e for e in result.errors)
+
+
+def test_real_2026_json_validates():
+    """Sanity check: the actual file we ship must validate."""
+    real = Path("apps/backend-rag/backend/data/bali_zero_official_prices_2026.json")
+    if not real.exists():
+        pytest.skip("real JSON not yet authored")
+    data = json.loads(real.read_text())
+    result = schema.validate(data)
+    assert result.ok, f"Real 2026 JSON failed validation: {result.errors}"


### PR DESCRIPTION
## Summary

Final email branding pass:
1. **New `team_email_html()` helper** in `email_branding.py` — single source of truth for internal team emails using the Bali Zero standard-doc palette (dark navy `#1F2937` header + gold `#F4B400` accent + neutral greys, matching Tax Report cover & invoice PDF)
2. **5 internal team emails** redesigned with the new template
3. **Welcome client email**: dark hero now uses Tax Report Marta palette (was near-black `#0c0d0f`)
4. **Completed client email**: removed Drive links → consultant shares docs on WhatsApp directly
5. **Asya's real WhatsApp**: `+62 881 0384 67246` in billing footer (was wrong placeholder)

## Files changed (8)

| File | What changed |
|---|---|
| `services/notifications/email_branding.py` | + `team_email_html()` template function |
| `services/invoicing/invoice_service.py` | `[TEAM] New Invoice` → template |
| `services/crm/waiting_documents_service.py` | `[TEAM] Documents Needed` → template |
| `services/crm/process_automation_service.py` | `[TEAM] 🚀 Let's Go` → template |
| `services/crm/completed_process_service.py` | `[TEAM] ✅ Completed` → template + client email no Drive links |
| `services/crm/practice_status_listener.py` | `[PAYMENT IN]` M4 team → template |
| `services/crm/welcome/welcome_email_service.py` | dark hero palette → Tax Report navy/gold |
| `services/crm/automation.py` | client completed email no Drive links (legacy parity) |

## Footer split

Each `team_email_html()` footer carries:
- **Billing**: `asya@balizero.com · +62 881 0384 67246` (Asya's actual WhatsApp)
- **General**: `WhatsApp +62 821 3107 363 · balizero.com`

## Test plan
- [x] Ruff green on all 8 files
- [x] Smoke test: `team_email_html()` callable + LOGO_URL OK
- [x] Local preview rendered for 5 team email variants
- [ ] Post-merge: live test of `[TEAM] New Invoice` and `[PAYMENT IN]` to confirm rendering on Gmail

🤖 Generated with [Claude Code](https://claude.com/claude-code)