### PR TITLE
feat(email): elegant team template + Tax Report palette + WhatsApp-only docs (clean)

### DIFF
--- a/apps/backend-rag/backend/services/crm/automation.py
+++ b/apps/backend-rag/backend/services/crm/automation.py
@@ -598,12 +598,6 @@ class CompletedProcessService:
         """Send human, congratulatory email to client."""
         practice_type = practice_data.get("practice_type_name", "Immigration Service")
 
-        docs_section = ""
-        if documents:
-            docs_section = "\n📎 Your Documents:\n"
-            for doc in documents:
-                docs_section += f"   • {doc['filename']}: {doc['file_url']}\n"
-
         subject = f"[CLIENT] 🎉 Congratulations {client_name}! Your {practice_type} is Complete"
 
         body = f"""Dear {client_name},
@@ -617,8 +611,8 @@ What This Means for You:
 ✅ All legal requirements have been fulfilled
 ✅ You can now proceed with confidence in your Indonesian journey
 
-{docs_section}
-All your important documents are safely stored in your personal Google Drive folder. You can access them anytime through the link above.
+📲 Your documents:
+Your consultant will share all the documents with you directly on WhatsApp shortly.
 
 A Few Things to Remember:
 • Keep your documents secure and make backup copies

--- a/apps/backend-rag/backend/services/crm/completed_process_service.py
+++ b/apps/backend-rag/backend/services/crm/completed_process_service.py
@@ -21,7 +21,7 @@ from backend.services.notifications.email_audit import (
     notify_email_failure_critical,
     record_email_result,
 )
-from backend.services.notifications.email_branding import logo_header_html
+from backend.services.notifications.email_branding import logo_header_html, team_email_html
 from backend.services.notifications.email_http import get_email_client
 
 # Internal email API — uses Brevo, from=zantara@balizero.com
@@ -220,38 +220,12 @@ class CompletedProcessService:
     ) -> None:
         """Send human, congratulatory email to client.
 
-        When some documents failed to upload to Drive, the email no longer
-        claims completeness: a "⚠️ Missing documents" section lists the
-        filenames and tells the client the team will follow up.
+        Documents are delivered by the consultant via WhatsApp — this email
+        no longer lists Drive links (clients aren't given Drive folder access).
         """
         practice_type = practice_data.get("practice_type_name", "Immigration Service")
 
-        # Build document links section
-        docs_section = ""
-        if documents:
-            docs_section = "\n📎 Your Documents:\n"
-            for doc in documents:
-                docs_section += f"   • {doc['filename']}: {doc['file_url']}\n"
-
-        # Missing-documents warning (was silently dropped before the fix).
-        missing_section = ""
-        if failed_uploads:
-            missing_section = (
-                "\n⚠️ Note: A few documents could not be uploaded to your Drive folder "
-                "automatically. Our team will send them to you directly within 24 hours:\n"
-            )
-            for item in failed_uploads:
-                missing_section += f"   • {item['filename']}\n"
-
         subject = f"[CLIENT] 🎉 Congratulations {client_name}! Your {practice_type} is Complete"
-
-        storage_note = (
-            "All your important documents are safely stored in your personal Google Drive folder. "
-            "You can access them anytime through the link above."
-            if not failed_uploads
-            else "The documents listed above are in your personal Google Drive folder. "
-                 "The missing items will arrive by direct email shortly."
-        )
 
         body = f"""Dear {client_name},
 
@@ -264,8 +238,8 @@ What This Means for You:
 ✅ All legal requirements have been fulfilled
 ✅ You can now proceed with confidence in your Indonesian journey
 
-{docs_section}{missing_section}
-{storage_note}
+📲 Your documents:
+Your consultant will share all the documents with you directly on WhatsApp shortly.
 
 A Few Things to Remember:
 • Keep your documents secure and make backup copies
@@ -335,24 +309,38 @@ P.S. Save our contact info for future needs—we're always here to help! 😊
             )
         else:
             subject = f"[TEAM] ✅ Process Completed - {client_name} ({practice_type})"
-            followup_line = "No further action required on this case."
+            followup_line = "Great work — no further action required on this case."
 
-        body = f"""Hi Team Leader,
+        if failed_count:
+            title = f"⚠️ Completed (with missing docs) — {client_name}"
+            intro = (
+                f"<b>Attention:</b> {failed_count} document(s) failed to upload to Drive. "
+                f"The client email told them you'll follow up — please send the missing files "
+                f"manually within 24h."
+            )
+        else:
+            title = f"✅ Process Completed — {client_name}"
+            intro = followup_line
 
-Great work! The following practice has been successfully completed:
-
-📋 Practice Details:
-• Client: {client_name}
-• Service: {practice_type}
-• Practice ID: {practice_id}
-• Status: ✅ COMPLETED
-• Documents uploaded: {uploaded_count}{f" (⚠️ {failed_count} failed)" if failed_count else ""}
-
-{followup_line}
-
-Best regards,
-Zantara CRM System
-"""
+        body = team_email_html(
+            title=title,
+            intro=intro,
+            meta_rows=[
+                ("Client", client_name),
+                ("Service", practice_type),
+                ("Practice ID", f"#{practice_id}"),
+                ("Status", "✅ COMPLETED"),
+                (
+                    "Documents",
+                    f"{uploaded_count} uploaded"
+                    + (f" · ⚠️ {failed_count} failed" if failed_count else ""),
+                ),
+            ],
+            body_html="",
+            cta_label="Open practice in CRM",
+            cta_url=f"https://kita.balizero.com/process/{practice_id}",
+            signature="Zantara CRM",
+        )
 
         await self._send_with_brevo_fallback(
             team_leader_email,
@@ -361,6 +349,7 @@ Zantara CRM System
             email_type="completion_team",
             practice_id=practice_id,
             client_id=practice_data.get("client_id"),
+            prebuilt_html=True,
         )
 
     async def _send_with_brevo_fallback(
@@ -374,6 +363,7 @@ Zantara CRM System
         client_id: int | None = None,
         cc: str | None = None,
         include_logo: bool = False,
+        prebuilt_html: bool = False,
     ) -> None:
         """Send email via Brevo (primary), fall back to Zoho if Brevo fails.
 
@@ -391,9 +381,12 @@ Zantara CRM System
 
         # 1) Brevo
         try:
-            html_body = body.replace("\n", "<br>")
-            if include_logo:
-                html_body = f"{logo_header_html()}{html_body}"
+            if prebuilt_html:
+                html_body = body
+            else:
+                html_body = body.replace("\n", "<br>")
+                if include_logo:
+                    html_body = f"{logo_header_html()}{html_body}"
             payload: dict = {"to": to_email, "subject": subject, "body": html_body}
             if cc:
                 payload["cc"] = cc

--- a/apps/backend-rag/backend/services/crm/practice_status_listener.py
+++ b/apps/backend-rag/backend/services/crm/practice_status_listener.py
@@ -24,7 +24,7 @@ import httpx
 
 from backend.app.utils.logging_utils import get_logger
 from backend.services.crm.automation import ProcessAutomationService
-from backend.services.notifications.email_branding import logo_header_html
+from backend.services.notifications.email_branding import logo_header_html, team_email_html
 
 logger = get_logger(__name__)
 
@@ -250,26 +250,31 @@ Zantara — Bali Zero Team
         # ── Email 2: Team member — with Asya in CC ───────────────────────
         if team_member_email:
             subject = f"[PAYMENT IN] ✅ {client_name} — {practice_type} — Proceed Now"
-            body = f"""Hi,
-
-Payment has been confirmed for the following practice — you're clear to start!
-
-Client:       {client_name}
-Service:      {practice_type}
-Practice ID:  #{practice_id}
-Amount:       {practice_data.get("quoted_price", "see CRM")}
-
-Next steps:
-1. Review documents in CRM: https://kita.balizero.com/process/{practice_id}
-2. Contact the client on WhatsApp to introduce yourself
-3. Begin application preparation
-
-Asya has verified the payment. Any billing questions → asya@balizero.com
-
-Go!
-
-Zantara CRM 🤖
-"""
+            body = team_email_html(
+                title=f"💰 Payment In — {client_name}",
+                intro=(
+                    "Asya has verified the payment for this practice. You're clear to start! "
+                    "Any billing questions → <a href='mailto:asya@balizero.com' "
+                    "style='color:#1F2937;'>asya@balizero.com</a>"
+                ),
+                meta_rows=[
+                    ("Client", client_name),
+                    ("Service", practice_type),
+                    ("Practice ID", f"#{practice_id}"),
+                    ("Amount", str(practice_data.get("quoted_price", "see CRM"))),
+                ],
+                body_html=(
+                    "<b>Next steps:</b>"
+                    "<ol style='margin:6px 0 4px 18px;padding:0;'>"
+                    "<li>Review documents in the CRM</li>"
+                    "<li>Contact the client on WhatsApp to introduce yourself</li>"
+                    "<li>Begin application preparation</li>"
+                    "</ol>"
+                ),
+                cta_label="Open practice in CRM",
+                cta_url=f"https://kita.balizero.com/process/{practice_id}",
+                signature="Zantara CRM",
+            )
             try:
                 # Use internal /send-email endpoint: handles Zoho/Brevo routing + CC support
                 await self._send_via_internal_api(
@@ -277,6 +282,7 @@ Zantara CRM 🤖
                     subject=subject,
                     body=body,
                     cc="asya@balizero.com",
+                    prebuilt_html=True,
                 )
                 logger.info(f"M4: team notification sent to {team_member_email} (CC: asya)")
             except httpx.HTTPError as exc:
@@ -364,6 +370,7 @@ Zantara CRM 🤖
         cc: str | None = None,
         bcc: str | None = None,
         include_logo: bool = False,
+        prebuilt_html: bool = False,
     ) -> None:
         """
         Send email via the internal /api/notifications/send-email endpoint.
@@ -371,9 +378,12 @@ Zantara CRM 🤖
         This endpoint handles Zoho SMTP vs Brevo routing automatically
         (intra-domain @balizero.com → Zoho, external → Brevo) and supports CC/BCC.
         """
-        html_body = body.replace("\n", "<br>")
-        if include_logo:
-            html_body = f"{logo_header_html()}{html_body}"
+        if prebuilt_html:
+            html_body = body
+        else:
+            html_body = body.replace("\n", "<br>")
+            if include_logo:
+                html_body = f"{logo_header_html()}{html_body}"
         payload: dict[str, Any] = {
             "to": to_email,
             "subject": subject,

--- a/apps/backend-rag/backend/services/crm/process_automation_service.py
+++ b/apps/backend-rag/backend/services/crm/process_automation_service.py
@@ -15,7 +15,7 @@ import httpx
 from backend.app.utils.logging_utils import get_logger
 from backend.services.common.cache import cache_invalidating
 from backend.services.integrations.zoho_email_service import ZohoEmailService
-from backend.services.notifications.email_branding import logo_header_html
+from backend.services.notifications.email_branding import logo_header_html, team_email_html
 
 # Internal email API — uses Brevo, from=zantara@balizero.com
 _EMAIL_API_URL = os.getenv(
@@ -207,54 +207,48 @@ P.S. Keep an eye on your WhatsApp—we'll be sending you updates there too! 😊
 
         subject = f"[TEAM] 🚀 Let's Go! Payment Confirmed - {client_name}"
 
-        body = f"""Hey there!
+        practice_id = practice_data["id"]
+        body = team_email_html(
+            title=f"🚀 Payment Confirmed — {client_name}",
+            intro=f"Asya has confirmed the payment for {client_name}'s {practice_type}. This one is yours — let's go!",
+            meta_rows=[
+                ("Client", client_name),
+                ("Service", practice_type),
+                ("Practice ID", f"#{practice_id}"),
+                ("Amount", str(practice_data.get("quoted_price", "—"))),
+            ],
+            body_html=(
+                "<b>Your mission:</b>"
+                "<ol style='margin:6px 0 4px 18px;padding:0;'>"
+                "<li>Review the client's documents in the CRM</li>"
+                "<li>Start working on the application</li>"
+                "<li>Update status to <i>SUBMITTED TO GOV</i> when ready</li>"
+                "<li>Keep the client updated via WhatsApp</li>"
+                "</ol>"
+            ),
+            cta_label="Open practice in CRM",
+            cta_url=f"https://kita.balizero.com/process/{practice_id}",
+            signature="Zantara CRM",
+        )
 
-Great news—payment has just been confirmed for {client_name}'s {practice_type}! 🎉
-
-This one's all yours. Here are the details:
-
-👤 Client: {client_name}
-🔖 Service: {practice_type}
-🆔 Practice ID: {practice_data["id"]}
-💰 Amount: {practice_data.get("quoted_price", "N/A")}
-
-✅ Asya has confirmed the payment is in, so you're good to go!
-
-Your Mission (should you choose to accept it 😄):
-1. Review the client's documents in the CRM
-2. Start working your magic on the application
-3. Update the status to "SUBMITTED TO GOV" when you're ready
-4. Keep the client in the loop via WhatsApp—they love updates!
-
-🎯 Quick Access:
-https://kita.balizero.com/process
-
-You've got this! We know you'll handle this case with your usual excellence.
-
-If you need anything or have questions about this case, just holler.
-
-Go get 'em!
-
-Cheers,
-Zantara CRM 🤖
-
-P.S. The client is excited to get started—let's make it a great experience! ✨
-"""
-
-        await self._send_with_brevo_fallback(team_leader_email, subject, body)
+        await self._send_with_brevo_fallback(team_leader_email, subject, body, prebuilt_html=True)
 
     async def _send_with_brevo_fallback(
         self, to_email: str, subject: str, body: str,
         *,
         cc: str | None = None,
         include_logo: bool = False,
+        prebuilt_html: bool = False,
     ) -> None:
         """Send email via Brevo (primary), fall back to Zoho if Brevo fails."""
         # Primary: Brevo
         try:
-            html_body = body.replace("\n", "<br>")
-            if include_logo:
-                html_body = f"{logo_header_html()}{html_body}"
+            if prebuilt_html:
+                html_body = body
+            else:
+                html_body = body.replace("\n", "<br>")
+                if include_logo:
+                    html_body = f"{logo_header_html()}{html_body}"
             payload: dict = {"to": to_email, "subject": subject, "body": html_body}
             if cc:
                 payload["cc"] = cc

--- a/apps/backend-rag/backend/services/crm/waiting_documents_service.py
+++ b/apps/backend-rag/backend/services/crm/waiting_documents_service.py
@@ -20,7 +20,7 @@ from backend.services.notifications.email_audit import (
     notify_email_failure_critical,
     record_email_result,
 )
-from backend.services.notifications.email_branding import logo_header_html
+from backend.services.notifications.email_branding import logo_header_html, team_email_html
 from backend.services.notifications.email_http import get_email_client
 
 # Internal email API — uses Brevo, from=zantara@balizero.com
@@ -137,41 +137,40 @@ class WaitingDocumentsService:
     ) -> None:
         """Notify team leader that documents need to be collected from the client."""
         practice_type = practice_data.get("practice_type_name", "Immigration Service")
+        practice_id = practice_data["id"]
 
         subject = f"[TEAM] 📋 Documents Needed — {client_name} ({practice_type})"
 
-        body = f"""Hi there!
-
-A practice has moved to the **Document Collection** phase and needs your attention.
-
-👤 Client: {client_name}
-🔖 Service: {practice_type}
-🆔 Practice ID: {practice_data["id"]}
-
-📋 What to do:
-1. Contact the client and let them know which documents are required
-2. Set a clear deadline for document submission
-3. Upload received documents to the CRM
-4. Once all documents are received, move to "Sending Invoice"
-
-A document request email has already been sent to the client automatically.
-
-🎯 Quick Access:
-https://kita.balizero.com/process/{practice_data["id"]}
-
-Let's keep things moving!
-
-Cheers,
-Zantara CRM 🤖
-"""
+        body_html = team_email_html(
+            title=f"📋 Documents Needed — {client_name}",
+            intro="This practice has moved to the <b>Document Collection</b> phase and needs your attention. A request email has already been sent to the client automatically.",
+            meta_rows=[
+                ("Client", client_name),
+                ("Service", practice_type),
+                ("Practice ID", f"#{practice_id}"),
+            ],
+            body_html=(
+                "<b>What to do:</b>"
+                "<ol style='margin:6px 0 4px 18px;padding:0;'>"
+                "<li>Contact the client and confirm which documents are required</li>"
+                "<li>Set a clear deadline for document submission</li>"
+                "<li>Upload received documents to the CRM</li>"
+                "<li>Once all documents are received, move the practice to <i>Sending Invoice</i></li>"
+                "</ol>"
+            ),
+            cta_label="Open practice in CRM",
+            cta_url=f"https://kita.balizero.com/process/{practice_id}",
+            signature="Zantara CRM",
+        )
 
         await self._send_with_brevo_fallback(
             team_leader_email,
             subject,
-            body,
+            body_html,
             email_type="waiting_docs_team",
-            practice_id=practice_data["id"],
+            practice_id=practice_id,
             client_id=practice_data.get("client_id"),
+            prebuilt_html=True,
         )
 
     async def _send_client_documents_request(
@@ -249,6 +248,7 @@ Zantara — Bali Zero Team
         client_id: int | None = None,
         cc: str | None = None,
         include_logo: bool = False,
+        prebuilt_html: bool = False,
     ) -> None:
         """Send email via Brevo (primary), fall back to Zoho if Brevo fails.
 
@@ -268,9 +268,12 @@ Zantara — Bali Zero Team
 
         # 1) Brevo
         try:
-            html_body = body.replace("\n", "<br>")
-            if include_logo:
-                html_body = f"{logo_header_html()}{html_body}"
+            if prebuilt_html:
+                html_body = body
+            else:
+                html_body = body.replace("\n", "<br>")
+                if include_logo:
+                    html_body = f"{logo_header_html()}{html_body}"
             payload: dict = {"to": to_email, "subject": subject, "body": html_body}
             if cc:
                 payload["cc"] = cc

--- a/apps/backend-rag/backend/services/crm/welcome/welcome_email_service.py
+++ b/apps/backend-rag/backend/services/crm/welcome/welcome_email_service.py
@@ -336,18 +336,19 @@ def _build_html(
     wa_num = (advisor_wa or _BZ_WHATSAPP).lstrip("+")
     cta_label = f"Chat with {advisor_name} on WhatsApp"
 
-    # BG constants — all inline style, no separate bgcolor attr (Zoho strips bgcolor)
-    BG = "background-color:#0c0d0f;"
-    BG2 = "background-color:#101215;"
-    BG3 = "background-color:#161a1e;"
-    BG4 = "background-color:#1a1914;"
-    BGDIV = "background-color:#2a2520;"
-    BGGOLD = "background-color:#f9ca55;"
+    # BG constants — Tax Report Marta palette: dark navy + gold accents
+    # All inline style, no separate bgcolor attr (Zoho strips bgcolor)
+    BG = "background-color:#1F2937;"
+    BG2 = "background-color:#252f3d;"
+    BG3 = "background-color:#2b3645;"
+    BG4 = "background-color:#2f3a4a;"
+    BGDIV = "background-color:#3a4554;"
+    BGGOLD = "background-color:#F4B400;"
 
     divider = (
         f'<tr><td style="padding:0 40px;{BG}">'
         '<table cellspacing="0" cellpadding="0" border="0" width="100%"><tr>'
-        '<td style="height:1px;background-color:#2a2520;font-size:1px;line-height:1px;">&nbsp;</td>'
+        '<td style="height:1px;background-color:#3a4554;font-size:1px;line-height:1px;">&nbsp;</td>'
         '</tr></table></td></tr>'
     )
 
@@ -373,7 +374,7 @@ def _build_html(
 </head>
 <body style="margin:0;padding:0;{BG}">
 
-  <div style="display:none;max-height:0;overflow:hidden;font-size:1px;color:#0c0d0f;">We handle the bureaucracy. You focus on Bali.</div>
+  <div style="display:none;max-height:0;overflow:hidden;font-size:1px;color:#1F2937;">We handle the bureaucracy. You focus on Bali.</div>
 
   <table cellspacing="0" cellpadding="0" border="0" width="100%" style="border-collapse:collapse;{BG}">
     <tr>
@@ -382,7 +383,7 @@ def _build_html(
 
           <!-- ══ HERO ══ -->
           <tr>
-            <td style="padding:44px 40px 40px;{BG}border-radius:14px 14px 0 0;border:1px solid #1e1c18;border-bottom:none;" class="pad">
+            <td style="padding:44px 40px 40px;{BG}border-radius:14px 14px 0 0;border:1px solid #3a4554;border-bottom:none;" class="pad">
               <table cellspacing="0" cellpadding="0" border="0" width="100%" style="border-collapse:collapse;">
                 <tr>
                   <td align="left" style="padding-bottom:36px;">
@@ -395,7 +396,7 @@ def _build_html(
                 </tr>
                 <tr>
                   <td class="hh" style="font-family:Arial,Helvetica,sans-serif;font-size:42px;line-height:48px;font-weight:900;color:#ffffff;letter-spacing:-1.5px;text-transform:uppercase;">
-                    Welcome,<br><span style="color:#f9ca55;">{first_name}.</span>
+                    Welcome,<br><span style="color:#F4B400;">{first_name}.</span>
                   </td>
                 </tr>
                 <tr>
@@ -404,9 +405,9 @@ def _build_html(
                   </td>
                 </tr>
                 <tr>
-                  <td style="padding-top:18px;font-family:Arial,Helvetica,sans-serif;font-size:16px;line-height:27px;color:#8a7a6a;font-weight:400;">
+                  <td style="padding-top:18px;font-family:Arial,Helvetica,sans-serif;font-size:16px;line-height:27px;color:#a8b3c0;font-weight:400;">
                     You just made the smartest move for your life in Indonesia.<br>
-                    <span style="color:#f9ca55;font-weight:700;">We&#39;ll take it from here.</span>
+                    <span style="color:#F4B400;font-weight:700;">We&#39;ll take it from here.</span>
                   </td>
                 </tr>
               </table>
@@ -415,21 +416,21 @@ def _build_html(
 
           <!-- ══ WHAT HAPPENS NEXT ══ -->
           <tr>
-            <td style="padding:36px 40px 32px;{BG2}border-left:1px solid #1e1c18;border-right:1px solid #1e1c18;" class="pad">
+            <td style="padding:36px 40px 32px;{BG2}border-left:1px solid #3a4554;border-right:1px solid #3a4554;" class="pad">
               <table cellspacing="0" cellpadding="0" border="0" width="100%" style="border-collapse:collapse;">
-                <tr><td style="font-family:Arial,Helvetica,sans-serif;font-size:10px;font-weight:700;color:#f9ca55;text-transform:uppercase;letter-spacing:4px;padding-bottom:28px;">What happens next</td></tr>
+                <tr><td style="font-family:Arial,Helvetica,sans-serif;font-size:10px;font-weight:700;color:#F4B400;text-transform:uppercase;letter-spacing:4px;padding-bottom:28px;">What happens next</td></tr>
               </table>
               <!-- step 1 -->
               <table cellspacing="0" cellpadding="0" border="0" width="100%" style="border-collapse:collapse;">
                 <tr>
                   <td width="52" valign="top" style="padding-right:16px;padding-bottom:20px;">
                     <table cellspacing="0" cellpadding="0" border="0" style="border-collapse:collapse;"><tr>
-                      <td width="44" height="44" align="center" valign="middle" style="{BG4}border-radius:10px;border:1px solid #2e2b22;font-family:Arial,Helvetica,sans-serif;font-size:14px;font-weight:900;color:#f9ca55;text-align:center;vertical-align:middle;">01</td>
+                      <td width="44" height="44" align="center" valign="middle" style="{BG4}border-radius:10px;border:1px solid #3a4554;font-family:Arial,Helvetica,sans-serif;font-size:14px;font-weight:900;color:#F4B400;text-align:center;vertical-align:middle;">01</td>
                     </tr></table>
                   </td>
                   <td valign="middle" style="padding-bottom:20px;">
                     <div style="font-family:Arial,Helvetica,sans-serif;font-size:15px;font-weight:700;color:#ffffff;line-height:20px;">{advisor_name} will reach out</div>
-                    <div style="font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#8a7a6a;line-height:19px;padding-top:3px;">Quick intro call to understand your situation</div>
+                    <div style="font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#a8b3c0;line-height:19px;padding-top:3px;">Quick intro call to understand your situation</div>
                   </td>
                 </tr>
                 <tr><td colspan="2" style="padding:0 0 20px 20px;"><table cellspacing="0" cellpadding="0" border="0" style="border-collapse:collapse;"><tr><td width="1" height="20" style="{BGDIV}font-size:1px;line-height:1px;">&nbsp;</td></tr></table></td></tr>
@@ -439,12 +440,12 @@ def _build_html(
                 <tr>
                   <td width="52" valign="top" style="padding-right:16px;padding-bottom:20px;">
                     <table cellspacing="0" cellpadding="0" border="0" style="border-collapse:collapse;"><tr>
-                      <td width="44" height="44" align="center" valign="middle" style="{BG4}border-radius:10px;border:1px solid #2e2b22;font-family:Arial,Helvetica,sans-serif;font-size:14px;font-weight:900;color:#c8a040;text-align:center;vertical-align:middle;">02</td>
+                      <td width="44" height="44" align="center" valign="middle" style="{BG4}border-radius:10px;border:1px solid #3a4554;font-family:Arial,Helvetica,sans-serif;font-size:14px;font-weight:900;color:#c8a040;text-align:center;vertical-align:middle;">02</td>
                     </tr></table>
                   </td>
                   <td valign="middle" style="padding-bottom:20px;">
                     <div style="font-family:Arial,Helvetica,sans-serif;font-size:15px;font-weight:700;color:#ffffff;line-height:20px;">We build your roadmap</div>
-                    <div style="font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#8a7a6a;line-height:19px;padding-top:3px;">Clear timeline, pricing, documents needed</div>
+                    <div style="font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#a8b3c0;line-height:19px;padding-top:3px;">Clear timeline, pricing, documents needed</div>
                   </td>
                 </tr>
                 <tr><td colspan="2" style="padding:0 0 20px 20px;"><table cellspacing="0" cellpadding="0" border="0" style="border-collapse:collapse;"><tr><td width="1" height="20" style="{BGDIV}font-size:1px;line-height:1px;">&nbsp;</td></tr></table></td></tr>
@@ -454,12 +455,12 @@ def _build_html(
                 <tr>
                   <td width="52" valign="top" style="padding-right:16px;">
                     <table cellspacing="0" cellpadding="0" border="0" style="border-collapse:collapse;"><tr>
-                      <td width="44" height="44" align="center" valign="middle" style="{BG4}border-radius:10px;border:1px solid #2e2b22;font-family:Arial,Helvetica,sans-serif;font-size:14px;font-weight:900;color:#9a7828;text-align:center;vertical-align:middle;">03</td>
+                      <td width="44" height="44" align="center" valign="middle" style="{BG4}border-radius:10px;border:1px solid #3a4554;font-family:Arial,Helvetica,sans-serif;font-size:14px;font-weight:900;color:#9a7828;text-align:center;vertical-align:middle;">03</td>
                     </tr></table>
                   </td>
                   <td valign="middle">
                     <div style="font-family:Arial,Helvetica,sans-serif;font-size:15px;font-weight:700;color:#ffffff;line-height:20px;">We handle everything</div>
-                    <div style="font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#8a7a6a;line-height:19px;padding-top:3px;">You focus on Bali. We handle the bureaucracy.</div>
+                    <div style="font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#a8b3c0;line-height:19px;padding-top:3px;">You focus on Bali. We handle the bureaucracy.</div>
                   </td>
                 </tr>
               </table>
@@ -470,9 +471,9 @@ def _build_html(
 
           <!-- ══ SERVICES ══ -->
           <tr>
-            <td style="padding:36px 40px 28px;{BG2}border-left:1px solid #1e1c18;border-right:1px solid #1e1c18;" class="pad">
+            <td style="padding:36px 40px 28px;{BG2}border-left:1px solid #3a4554;border-right:1px solid #3a4554;" class="pad">
               <table cellspacing="0" cellpadding="0" border="0" width="100%" style="border-collapse:collapse;">
-                <tr><td style="font-family:Arial,Helvetica,sans-serif;font-size:10px;font-weight:700;color:#f9ca55;text-transform:uppercase;letter-spacing:4px;padding-bottom:20px;">How we help</td></tr>
+                <tr><td style="font-family:Arial,Helvetica,sans-serif;font-size:10px;font-weight:700;color:#F4B400;text-transform:uppercase;letter-spacing:4px;padding-bottom:20px;">How we help</td></tr>
               </table>
               <table cellspacing="0" cellpadding="0" border="0" width="100%" style="border-collapse:collapse;">
                 <tr>
@@ -481,7 +482,7 @@ def _build_html(
                       <tr><td style="padding:20px 16px;{BG3}border-radius:10px;border:1px solid #252320;">
                         <div style="font-family:Arial,Helvetica,sans-serif;font-size:22px;line-height:26px;margin-bottom:10px;">&#127250;</div>
                         <div style="font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:700;color:#ffffff;">Immigration</div>
-                        <div style="font-family:Arial,Helvetica,sans-serif;font-size:11px;color:#8a7a6a;padding-top:5px;line-height:17px;">KITAS &middot; KITAP &middot; D12 &middot; E33G<br>Retirement &middot; Second Home</div>
+                        <div style="font-family:Arial,Helvetica,sans-serif;font-size:11px;color:#a8b3c0;padding-top:5px;line-height:17px;">KITAS &middot; KITAP &middot; D12 &middot; E33G<br>Retirement &middot; Second Home</div>
                       </td></tr>
                     </table>
                   </td>
@@ -490,7 +491,7 @@ def _build_html(
                       <tr><td style="padding:20px 16px;{BG3}border-radius:10px;border:1px solid #252320;">
                         <div style="font-family:Arial,Helvetica,sans-serif;font-size:22px;line-height:26px;margin-bottom:10px;">&#127970;</div>
                         <div style="font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:700;color:#ffffff;">Business</div>
-                        <div style="font-family:Arial,Helvetica,sans-serif;font-size:11px;color:#8a7a6a;padding-top:5px;line-height:17px;">PT PMA &middot; OSS &middot; NIB<br>Virtual Office &middot; Licenses</div>
+                        <div style="font-family:Arial,Helvetica,sans-serif;font-size:11px;color:#a8b3c0;padding-top:5px;line-height:17px;">PT PMA &middot; OSS &middot; NIB<br>Virtual Office &middot; Licenses</div>
                       </td></tr>
                     </table>
                   </td>
@@ -501,7 +502,7 @@ def _build_html(
                       <tr><td style="padding:20px 16px;{BG3}border-radius:10px;border:1px solid #252320;">
                         <div style="font-family:Arial,Helvetica,sans-serif;font-size:22px;line-height:26px;margin-bottom:10px;">&#128203;</div>
                         <div style="font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:700;color:#ffffff;">Tax &amp; Compliance</div>
-                        <div style="font-family:Arial,Helvetica,sans-serif;font-size:11px;color:#8a7a6a;padding-top:5px;line-height:17px;">NPWP &middot; SPT &middot; LKPM<br>Withholding &middot; Reporting</div>
+                        <div style="font-family:Arial,Helvetica,sans-serif;font-size:11px;color:#a8b3c0;padding-top:5px;line-height:17px;">NPWP &middot; SPT &middot; LKPM<br>Withholding &middot; Reporting</div>
                       </td></tr>
                     </table>
                   </td>
@@ -510,7 +511,7 @@ def _build_html(
                       <tr><td style="padding:20px 16px;{BG3}border-radius:10px;border:1px solid #252320;">
                         <div style="font-family:Arial,Helvetica,sans-serif;font-size:22px;line-height:26px;margin-bottom:10px;">&#127968;</div>
                         <div style="font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:700;color:#ffffff;">Property</div>
-                        <div style="font-family:Arial,Helvetica,sans-serif;font-size:11px;color:#8a7a6a;padding-top:5px;line-height:17px;">Hak Pakai &middot; Leasehold<br>Due Diligence &middot; Structure</div>
+                        <div style="font-family:Arial,Helvetica,sans-serif;font-size:11px;color:#a8b3c0;padding-top:5px;line-height:17px;">Hak Pakai &middot; Leasehold<br>Due Diligence &middot; Structure</div>
                       </td></tr>
                     </table>
                   </td>
@@ -521,8 +522,8 @@ def _build_html(
 
           <!-- ══ SOCIAL PROOF ══ -->
           <tr>
-            <td style="padding:36px 40px;{BG}border-left:1px solid #1e1c18;border-right:1px solid #1e1c18;" class="pad" align="center">
-              <div style="font-family:Arial,Helvetica,sans-serif;font-size:54px;font-weight:900;color:#f9ca55;letter-spacing:-2px;line-height:54px;">10,800<span style="font-size:26px;vertical-align:super;color:#5a4a18;">+</span></div>
+            <td style="padding:36px 40px;{BG}border-left:1px solid #3a4554;border-right:1px solid #3a4554;" class="pad" align="center">
+              <div style="font-family:Arial,Helvetica,sans-serif;font-size:54px;font-weight:900;color:#F4B400;letter-spacing:-2px;line-height:54px;">10,800<span style="font-size:26px;vertical-align:super;color:#a8b3c0;">+</span></div>
               <div style="font-family:Arial,Helvetica,sans-serif;font-size:10px;font-weight:700;color:#4a3a28;text-transform:uppercase;letter-spacing:4px;padding-top:10px;">Expats served since 2019</div>
             </td>
           </tr>
@@ -531,14 +532,14 @@ def _build_html(
 
           <!-- ══ WHY US ══ -->
           <tr>
-            <td style="padding:36px 40px 32px;{BG2}border-left:1px solid #1e1c18;border-right:1px solid #1e1c18;" class="pad">
+            <td style="padding:36px 40px 32px;{BG2}border-left:1px solid #3a4554;border-right:1px solid #3a4554;" class="pad">
               <table cellspacing="0" cellpadding="0" border="0" width="100%" style="border-collapse:collapse;">
-                <tr><td style="font-family:Arial,Helvetica,sans-serif;font-size:10px;font-weight:700;color:#f9ca55;text-transform:uppercase;letter-spacing:4px;padding-bottom:22px;">Why Bali Zero</td></tr>
+                <tr><td style="font-family:Arial,Helvetica,sans-serif;font-size:10px;font-weight:700;color:#F4B400;text-transform:uppercase;letter-spacing:4px;padding-bottom:22px;">Why Bali Zero</td></tr>
                 <tr>
                   <td style="padding-bottom:16px;">
                     <table cellspacing="0" cellpadding="0" border="0" width="100%" style="border-collapse:collapse;"><tr>
                       <td width="14" valign="top" style="padding-right:12px;padding-top:6px;"><table cellspacing="0" cellpadding="0" border="0" style="border-collapse:collapse;"><tr><td width="6" height="6" style="{BGGOLD}border-radius:3px;font-size:1px;line-height:1px;">&nbsp;</td></tr></table></td>
-                      <td style="font-family:Arial,Helvetica,sans-serif;font-size:14px;line-height:22px;color:#8a7a6a;"><strong style="color:#ffffff;font-weight:700;">AI-powered tracking.</strong> Every deadline, document, and regulation change monitored &mdash; nothing falls through the cracks.</td>
+                      <td style="font-family:Arial,Helvetica,sans-serif;font-size:14px;line-height:22px;color:#a8b3c0;"><strong style="color:#ffffff;font-weight:700;">AI-powered tracking.</strong> Every deadline, document, and regulation change monitored &mdash; nothing falls through the cracks.</td>
                     </tr></table>
                   </td>
                 </tr>
@@ -546,7 +547,7 @@ def _build_html(
                   <td style="padding-bottom:16px;">
                     <table cellspacing="0" cellpadding="0" border="0" width="100%" style="border-collapse:collapse;"><tr>
                       <td width="14" valign="top" style="padding-right:12px;padding-top:6px;"><table cellspacing="0" cellpadding="0" border="0" style="border-collapse:collapse;"><tr><td width="6" height="6" style="{BGGOLD}border-radius:3px;font-size:1px;line-height:1px;">&nbsp;</td></tr></table></td>
-                      <td style="font-family:Arial,Helvetica,sans-serif;font-size:14px;line-height:22px;color:#8a7a6a;"><strong style="color:#ffffff;font-weight:700;">Based in Kerobokan.</strong> Real office, real team. We meet you in person and handle government offices directly.</td>
+                      <td style="font-family:Arial,Helvetica,sans-serif;font-size:14px;line-height:22px;color:#a8b3c0;"><strong style="color:#ffffff;font-weight:700;">Based in Kerobokan.</strong> Real office, real team. We meet you in person and handle government offices directly.</td>
                     </tr></table>
                   </td>
                 </tr>
@@ -554,7 +555,7 @@ def _build_html(
                   <td>
                     <table cellspacing="0" cellpadding="0" border="0" width="100%" style="border-collapse:collapse;"><tr>
                       <td width="14" valign="top" style="padding-right:12px;padding-top:6px;"><table cellspacing="0" cellpadding="0" border="0" style="border-collapse:collapse;"><tr><td width="6" height="6" style="{BGGOLD}border-radius:3px;font-size:1px;line-height:1px;">&nbsp;</td></tr></table></td>
-                      <td style="font-family:Arial,Helvetica,sans-serif;font-size:14px;line-height:22px;color:#8a7a6a;"><strong style="color:#ffffff;font-weight:700;">One team, everything.</strong> Immigration, company, tax, property &mdash; all under one roof.</td>
+                      <td style="font-family:Arial,Helvetica,sans-serif;font-size:14px;line-height:22px;color:#a8b3c0;"><strong style="color:#ffffff;font-weight:700;">One team, everything.</strong> Immigration, company, tax, property &mdash; all under one roof.</td>
                     </tr></table>
                   </td>
                 </tr>
@@ -564,11 +565,11 @@ def _build_html(
 
           <!-- ══ CTA ══ -->
           <tr>
-            <td style="padding:36px 40px 44px;{BG}border-radius:0 0 14px 14px;border:1px solid #1e1c18;border-top:none;" class="pad" align="center">
+            <td style="padding:36px 40px 44px;{BG}border-radius:0 0 14px 14px;border:1px solid #3a4554;border-top:none;" class="pad" align="center">
               <table cellspacing="0" cellpadding="0" border="0" style="border-collapse:collapse;">
                 <tr>
                   <td style="{BGGOLD}border-radius:10px;">
-                    <a href="https://wa.me/{wa_num}?text=Hi%20Bali%20Zero%2C%20I%20just%20signed%20up" target="_blank" style="display:inline-block;padding:16px 44px;font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:900;color:#0c0d0f;text-decoration:none;text-transform:uppercase;letter-spacing:1.5px;">{cta_label}</a>
+                    <a href="https://wa.me/{wa_num}?text=Hi%20Bali%20Zero%2C%20I%20just%20signed%20up" target="_blank" style="display:inline-block;padding:16px 44px;font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:900;color:#1F2937;text-decoration:none;text-transform:uppercase;letter-spacing:1.5px;">{cta_label}</a>
                   </td>
                 </tr>
               </table>
@@ -580,14 +581,14 @@ def _build_html(
           <tr>
             <td align="center" style="padding:28px 40px 0;{BG}" class="pad">
               <div style="font-family:Arial,Helvetica,sans-serif;font-size:12px;color:#4a3a28;line-height:20px;">
-                <strong style="color:#5a4a18;">Bali Zero</strong> &middot; Kerobokan, Bali, Indonesia<br>
+                <strong style="color:#a8b3c0;">Bali Zero</strong> &middot; Kerobokan, Bali, Indonesia<br>
                 <a href="https://www.balizero.com" style="color:#c8a040;text-decoration:none;">balizero.com</a>
                 &nbsp;&middot;&nbsp;
                 <a href="https://www.instagram.com/balizero" style="color:#c8a040;text-decoration:none;">Instagram</a>
                 &nbsp;&middot;&nbsp;
                 <a href="https://wa.me/{wa_num}" style="color:#c8a040;text-decoration:none;">WhatsApp</a>
               </div>
-              <div style="padding-top:12px;font-family:Arial,Helvetica,sans-serif;font-size:10px;color:#2a2520;letter-spacing:2px;text-transform:uppercase;">
+              <div style="padding-top:12px;font-family:Arial,Helvetica,sans-serif;font-size:10px;color:#3a4554;letter-spacing:2px;text-transform:uppercase;">
                 Powered by humans, fueled by a thinking engine.
               </div>
             </td>

--- a/apps/backend-rag/backend/services/invoicing/invoice_service.py
+++ b/apps/backend-rag/backend/services/invoicing/invoice_service.py
@@ -27,7 +27,7 @@ from backend.services.notifications.email_audit import (
     notify_email_failure_critical,
     record_email_result,
 )
-from backend.services.notifications.email_branding import logo_header_html
+from backend.services.notifications.email_branding import logo_header_html, team_email_html
 from backend.services.notifications.email_http import get_email_client
 
 logger = get_logger(__name__)
@@ -321,22 +321,27 @@ class InvoiceAutomationService:
     ) -> bool:
         """Send notification email to accounting (Asya) via internal email API."""
         subject = f"[TEAM] New Invoice {invoice_number} - {client_data['full_name']}"
-        body_html = (
-            f"<p>Hi Asya!</p>"
-            f"<p>A new invoice has just been generated and sent to our client.</p>"
-            f"<p><b>Client Details:</b><br>"
-            f"Name: {client_data['full_name']}<br>"
-            f"Email: {client_data.get('email', 'N/A')}<br>"
-            f"Practice ID: {practice_data['id']}</p>"
-            f"<p><b>Invoice Info:</b><br>"
-            f"Invoice Number: {invoice_number}<br>"
-            f"Amount: IDR {float(practice_data.get('quoted_price', 0)):,.0f}</p>"
-            f"<p>PDF attached.</p>"
-            f"<p><b>Next Steps:</b><br>"
-            f"1. Reach out to the client via WhatsApp for payment follow-up<br>"
-            f"2. Keep an eye on our bank account<br>"
-            f"3. Once payment comes through, update the status to ON PROCESS</p>"
-            f"<p>Warmly,<br>Zantara CRM</p>"
+        amount = float(practice_data.get("quoted_price", 0))
+        body_html = team_email_html(
+            title=f"New Invoice {invoice_number}",
+            intro=f"Hi Asya — a new invoice has been generated and sent to {client_data['full_name']}. PDF attached.",
+            meta_rows=[
+                ("Client", client_data["full_name"]),
+                ("Email", client_data.get("email") or "—"),
+                ("Practice", f"#{practice_data['id']}"),
+                ("Amount", f"IDR {amount:,.0f}"),
+            ],
+            body_html=(
+                "<b>Next steps:</b>"
+                "<ol style='margin:6px 0 4px 18px;padding:0;'>"
+                "<li>Reach out to the client via WhatsApp for payment follow-up</li>"
+                "<li>Keep an eye on our bank account</li>"
+                "<li>Once payment comes through, update the status to ON PROCESS</li>"
+                "</ol>"
+            ),
+            cta_label="Open practice in CRM",
+            cta_url=f"https://kita.balizero.com/process/{practice_data['id']}",
+            signature="Zantara CRM",
         )
 
         pdf_b64 = base64.b64encode(pdf_bytes).decode()

--- a/apps/backend-rag/backend/services/notifications/email_branding.py
+++ b/apps/backend-rag/backend/services/notifications/email_branding.py
@@ -10,6 +10,14 @@ and ships with every Mouth/Vercel deploy.
 
 LOGO_URL = "https://kita.balizero.com/static/email/balizero-logo-email.png"
 
+# Bali Zero standard-doc palette (matches Tax Report cover + invoice PDF)
+COLOR_NAVY = "#1F2937"
+COLOR_GOLD = "#F4B400"
+COLOR_LIGHT = "#F7F8FA"
+COLOR_BORDER = "#E5E7EB"
+COLOR_TEXT = "#1F2937"
+COLOR_MUTED = "#6B7280"
+
 
 def logo_header_html(width_px: int = 96) -> str:
     """Return a centered <img> block to drop at the top of every client email."""
@@ -20,3 +28,104 @@ def logo_header_html(width_px: int = 96) -> str:
         f'style="width:{width_px}px;height:{width_px}px;display:inline-block;">'
         f"</div>"
     )
+
+
+def team_email_html(
+    *,
+    title: str,
+    intro: str,
+    meta_rows: list[tuple[str, str]] | None = None,
+    body_html: str = "",
+    cta_label: str | None = None,
+    cta_url: str | None = None,
+    signature: str = "Zantara CRM",
+) -> str:
+    """Render a clean, on-brand HTML email for internal team notifications.
+
+    Visual style mirrors the Bali Zero standard-doc palette (dark navy
+    header bar + gold accent + neutral greys), the same one used by the
+    invoice PDF and the Tax Report cover.
+    """
+    rows_html = ""
+    if meta_rows:
+        cells = "".join(
+            f'<tr>'
+            f'<td style="padding:6px 12px 6px 0;font-size:12px;color:{COLOR_MUTED};'
+            f'font-family:Helvetica,Arial,sans-serif;white-space:nowrap;width:140px;">'
+            f'{label}</td>'
+            f'<td style="padding:6px 0;font-size:13px;color:{COLOR_TEXT};'
+            f'font-family:Helvetica,Arial,sans-serif;font-weight:600;">'
+            f'{value}</td>'
+            f'</tr>'
+            for label, value in meta_rows
+        )
+        rows_html = (
+            f'<table cellspacing="0" cellpadding="0" border="0" width="100%" '
+            f'style="background:{COLOR_LIGHT};border:1px solid {COLOR_BORDER};'
+            f'border-radius:6px;margin:0 0 20px;">'
+            f'<tr><td style="padding:10px 16px;">'
+            f'<table cellspacing="0" cellpadding="0" border="0">{cells}</table>'
+            f'</td></tr></table>'
+        )
+
+    cta_html = ""
+    if cta_label and cta_url:
+        cta_html = (
+            f'<div style="margin:8px 0 24px;">'
+            f'<a href="{cta_url}" '
+            f'style="display:inline-block;background:{COLOR_GOLD};color:{COLOR_NAVY};'
+            f'font-family:Helvetica,Arial,sans-serif;font-size:13px;font-weight:700;'
+            f'padding:10px 20px;border-radius:6px;text-decoration:none;">'
+            f'{cta_label}</a>'
+            f'</div>'
+        )
+
+    return f"""<!doctype html>
+<html><head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;background:#f4f6f9;font-family:Helvetica,Arial,sans-serif;">
+  <table cellspacing="0" cellpadding="0" border="0" width="100%" style="background:#f4f6f9;">
+    <tr><td align="center" style="padding:24px 12px;">
+      <table cellspacing="0" cellpadding="0" border="0" width="600"
+             style="max-width:600px;background:#ffffff;border-radius:10px;overflow:hidden;
+             box-shadow:0 1px 3px rgba(0,0,0,0.06);">
+        <tr><td style="background:{COLOR_NAVY};padding:18px 28px;">
+          <table cellspacing="0" cellpadding="0" border="0" width="100%">
+            <tr>
+              <td style="font-family:Helvetica,Arial,sans-serif;color:#ffffff;
+                         font-size:11px;letter-spacing:3px;text-transform:uppercase;
+                         font-weight:700;">Bali Zero · Operations</td>
+              <td align="right">
+                <img src="{LOGO_URL}" alt="Bali Zero" width="36" height="36"
+                     style="display:inline-block;vertical-align:middle;">
+              </td>
+            </tr>
+          </table>
+        </td></tr>
+        <tr><td style="height:3px;background:{COLOR_GOLD};line-height:3px;font-size:0;">&nbsp;</td></tr>
+        <tr><td style="padding:28px 28px 8px;">
+          <h1 style="margin:0 0 14px;font-family:Helvetica,Arial,sans-serif;
+                     font-size:20px;color:{COLOR_TEXT};font-weight:700;line-height:1.3;">
+            {title}
+          </h1>
+          <p style="margin:0 0 18px;font-family:Helvetica,Arial,sans-serif;
+                    font-size:14px;color:{COLOR_TEXT};line-height:1.55;">
+            {intro}
+          </p>
+          {rows_html}
+          <div style="font-family:Helvetica,Arial,sans-serif;font-size:14px;
+                      color:{COLOR_TEXT};line-height:1.55;">
+            {body_html}
+          </div>
+          {cta_html}
+        </td></tr>
+        <tr><td style="padding:18px 28px 24px;border-top:1px solid {COLOR_BORDER};
+                       font-family:Helvetica,Arial,sans-serif;font-size:12px;
+                       color:{COLOR_MUTED};">
+          <strong style="color:{COLOR_TEXT};">{signature}</strong><br>
+          Billing: asya@balizero.com · +62 881 0384 67246<br>
+          General: WhatsApp +62 821 3107 363 · balizero.com
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body></html>"""


### PR DESCRIPTION
Replaces #476 (which had unrelated pricelist-2026 commits). Single commit only.

## Same content as #476:

1. **New `team_email_html()` helper** in `email_branding.py` — Bali Zero standard-doc palette (navy #1F2937 + gold #F4B400)
2. **5 internal team emails** redesigned with the template
3. **Welcome client email**: dark hero now uses Tax Report Marta palette
4. **Completed client email**: removed Drive links → consultant shares docs on WhatsApp
5. **Asya's real WhatsApp**: `+62 881 0384 67246` in billing footer

## 8 files changed
- email_branding.py (template)
- invoice_service.py, waiting_documents_service.py, process_automation_service.py, completed_process_service.py, practice_status_listener.py (5 team emails)
- welcome_email_service.py (palette navy)
- automation.py (legacy parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)