### PR TITLE
feat(wr2): Codex Image-2 primary cover provider, Playwright fallback

### DIFF
--- a/scripts/wr2_draft_generator.py
+++ b/scripts/wr2_draft_generator.py
@@ -377,45 +377,142 @@ def _upload_to_tigris(image_bytes: bytes, key: str, content_type: str = "image/p
     return f"{TIGRIS_PUBLIC_BASE}/{key}"
 
 
-async def generate_cover_image(scene_core: str, draft_id: str) -> tuple[str | None, str | None]:
-    """Return (public_url, error_msg). Never raises.
+# ─────────────────────────────────────────────────────────────────────────
+# Cover provider chain (2026-05-06): Codex `$imagegen` (gpt-image-2) PRIMARY,
+# Gemini Nano Banana 2 Pro via Playwright as FALLBACK.
+#
+# Why ribaltato: Nano Banana via Playwright failed twice under load (4 maggio
+# timeout 240s, 6 maggio chromium_headless_shell-1208 missing). Codex CLI
+# v0.128.0 (21 apr 2026) ships `$imagegen` skill backed by gpt-image-2,
+# included in ChatGPT Pro $200 plan (no per-call billing, OAuth, allineato a
+# Golden Rule #13 anti-paid-API). Smoke test 2026-05-06 14:24: 113s wall-clock,
+# 2.2 MB PNG, exit code 0.
+#
+# Trap operativo: Codex IGNORA output path nel prompt — scrive sempre in
+# `~/.codex/generated_images/<uuid-v7>/ig_<hash>.png`. Trovare il PNG
+# generato by mtime (not by name).
+#
+# Memo: ~/.claude/projects/-Users-nuzantara/memory/discovery_codex_imagegen_default_path_2026_05_06.md
+# ─────────────────────────────────────────────────────────────────────────
 
-    Uses Gemini Nano Banana 2 Pro via Playwright (logged-in browser session,
-    no API spend). Mirrors the body-slide generator path in
-    wr2_image_generator. Strictly serial (one tab) to avoid the cross-tab
-    quality degradation observed on the persistent profile.
+CODEX_BIN = "/opt/homebrew/bin/codex"
+CODEX_OUTPUT_DIR = Path.home() / ".codex" / "generated_images"
+CODEX_TIMEOUT_SEC = 600  # 5x margin over observed 113s
+CODEX_MTIME_WINDOW_SEC = 600  # search window for "fresh" PNG (10min)
+# Strip provider API keys before spawning Codex subprocess. Mirror of
+# backend.services.federation_alerts.actions.codex_image_gen._safe_env().
+# OPENAI_API_KEY is held by parent for text-embedding-3-small only;
+# image gen MUST go via Codex OAuth Pro $200 plan, never per-call billing.
+_CODEX_STRIPPED_ENV_KEYS = frozenset({
+    "ANTHROPIC_API_KEY",
+    "AWS_BEDROCK_ANTHROPIC_KEY",
+    "VERTEX_AI_ANTHROPIC_KEY",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+})
 
-    Falls back to a clear error tuple on any failure — caller decides whether
-    to abort the draft or proceed without cover.
+
+def _codex_safe_env() -> dict[str, str]:
+    return {k: v for k, v in os.environ.items() if k not in _CODEX_STRIPPED_ENV_KEYS}
+
+
+async def _generate_cover_via_codex(scene_core: str) -> tuple[bytes | None, str | None]:
+    """Generate cover via Codex CLI `$imagegen`. Return (img_bytes, error_msg).
+
+    Never raises. On any failure returns (None, error_msg) so caller can
+    fall through to the Playwright/Nano Banana legacy path.
     """
-    # Lazy import: keeps wr2_image_generator's heavy Playwright dep out of the
-    # draft_generator critical path until cover time.
+    bare_prompt = scene_core.strip()
+    logger.info(
+        "Cover via Codex $imagegen (gpt-image-2) — prompt (%d chars): %s...",
+        len(bare_prompt),
+        bare_prompt[:120],
+    )
+    # Snapshot pre-existing PNGs so we can identify the fresh one by exclusion.
+    pre_existing: set[Path] = set()
+    if CODEX_OUTPUT_DIR.exists():
+        pre_existing = set(CODEX_OUTPUT_DIR.rglob("ig_*.png"))
+
+    t0 = time.perf_counter()
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            CODEX_BIN,
+            "exec",
+            f"$imagegen {bare_prompt}",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            stdin=asyncio.subprocess.DEVNULL,
+            env=_codex_safe_env(),
+        )
+        try:
+            _stdout, _stderr = await asyncio.wait_for(proc.communicate(), timeout=CODEX_TIMEOUT_SEC)
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            return None, f"codex $imagegen timed out after {CODEX_TIMEOUT_SEC}s"
+        if proc.returncode != 0:
+            tail = (_stderr or _stdout or b"").decode("utf-8", errors="replace")[-200:]
+            return None, f"codex exit={proc.returncode}: {tail.strip()}"
+    except FileNotFoundError:
+        return None, f"codex binary not found at {CODEX_BIN}"
+    except Exception as e:
+        return None, f"codex spawn failed: {e}"
+
+    # Find the freshest PNG NOT in the pre-existing set.
+    if not CODEX_OUTPUT_DIR.exists():
+        return None, "codex output dir does not exist after run"
+    candidates = [p for p in CODEX_OUTPUT_DIR.rglob("ig_*.png") if p not in pre_existing]
+    if not candidates:
+        # Fallback: take latest by mtime if it falls within the window.
+        all_pngs = list(CODEX_OUTPUT_DIR.rglob("ig_*.png"))
+        if not all_pngs:
+            return None, "no PNG found in codex output dir"
+        latest = max(all_pngs, key=lambda p: p.stat().st_mtime)
+        if (time.time() - latest.stat().st_mtime) > CODEX_MTIME_WINDOW_SEC:
+            return None, f"latest PNG older than {CODEX_MTIME_WINDOW_SEC}s window"
+        png_path = latest
+    else:
+        png_path = max(candidates, key=lambda p: p.stat().st_mtime)
+
+    try:
+        img_bytes = png_path.read_bytes()
+    except Exception as e:
+        return None, f"failed to read codex PNG {png_path}: {e}"
+
+    elapsed_ms = (time.perf_counter() - t0) * 1000
+    logger.info(
+        "Codex cover generated: %d bytes from %s (%.0fms)",
+        len(img_bytes),
+        png_path.name,
+        elapsed_ms,
+    )
+    return img_bytes, None
+
+
+async def _generate_cover_via_playwright(bare_prompt: str) -> tuple[bytes | None, str | None]:
+    """Generate cover via Gemini Nano Banana 2 Pro via Playwright (LEGACY).
+
+    Return (img_bytes, error_msg). Never raises. Used as fallback when
+    Codex `$imagegen` fails. Lazy-imports wr2_image_generator so the
+    Playwright dependency is not loaded unless we hit this path.
+    """
     sys.path.insert(0, str(_REPO_ROOT / "scripts"))
     try:
         from wr2_image_generator import (  # noqa: E402
             GEMINI_PROFILE_DIR,
             _gen_one_image,
-            _score_image_alignment,
-            _upload_to_tigris as _img_upload_to_tigris,
-            VLM_MIN_SCORE,
         )
     except Exception as e:
         return None, f"wr2_image_generator import failed: {e}"
 
     from playwright.async_api import async_playwright  # noqa: E402
 
-    # The image_generator's _gen_one_image already wraps the prompt with
-    # BRAND_SUFFIX + ANTI_CLICHE_SUFFIX, which is exactly what the cover
-    # also wants — so we feed the bare scene_core (don't pre-build with
-    # build_imagen_prompt, which decorates for the Imagen API).
-    bare_prompt = scene_core.strip()
     logger.info(
-        "Cover via Gemini Nano Banana — prompt (%d chars): %s...",
+        "Cover via Gemini Nano Banana (FALLBACK) — prompt (%d chars): %s...",
         len(bare_prompt),
         bare_prompt[:120],
     )
-
-    t0 = time.perf_counter()
     img_bytes: bytes | None = None
     last_err: str | None = None
 
@@ -432,7 +529,6 @@ async def generate_cover_image(scene_core: str, draft_id: str) -> tuple[str | No
                 args=["--disable-blink-features=AutomationControlled"],
             )
             try:
-                # Cover slide_number == 0 sentinel for log readability.
                 img_bytes, last_err = await _gen_one_image(context, 0, bare_prompt)
             finally:
                 await context.close()
@@ -441,8 +537,26 @@ async def generate_cover_image(scene_core: str, draft_id: str) -> tuple[str | No
 
     if not img_bytes:
         return None, f"cover gen returned no bytes: {last_err or 'unknown'}"
+    return img_bytes, None
 
-    # Reuse the same VLM alignment gate the body slides go through.
+
+async def _finalize_cover(
+    img_bytes: bytes,
+    bare_prompt: str,
+    draft_id: str,
+    t0: float,
+) -> tuple[str | None, str | None]:
+    """VLM alignment gate + Tigris upload. Shared between Codex and Playwright paths."""
+    sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+    try:
+        from wr2_image_generator import (  # noqa: E402
+            _score_image_alignment,
+            _upload_to_tigris as _img_upload_to_tigris,
+            VLM_MIN_SCORE,
+        )
+    except Exception as e:
+        return None, f"wr2_image_generator import failed (finalize): {e}"
+
     try:
         score, why = await _score_image_alignment(img_bytes, bare_prompt, 0)
         if score < VLM_MIN_SCORE:
@@ -471,6 +585,37 @@ async def generate_cover_image(scene_core: str, draft_id: str) -> tuple[str | No
         duration_ms,
     )
     return url, None
+
+
+async def generate_cover_image(scene_core: str, draft_id: str) -> tuple[str | None, str | None]:
+    """Return (public_url, error_msg). Never raises.
+
+    Provider chain (PRIMARY → FALLBACK):
+      1. Codex CLI `$imagegen` (gpt-image-2 via OAuth Pro $200) — preferred
+      2. Gemini Nano Banana 2 Pro via Playwright (legacy) — fallback
+
+    On both failures returns a clear error tuple — caller proceeds without cover.
+    """
+    bare_prompt = scene_core.strip()
+    t0 = time.perf_counter()
+
+    # ── PRIMARY: Codex `$imagegen` ──
+    img_bytes, codex_err = await _generate_cover_via_codex(bare_prompt)
+    if img_bytes is not None:
+        return await _finalize_cover(img_bytes, bare_prompt, draft_id, t0)
+
+    logger.warning(
+        "Codex cover failed (%s) — falling back to Playwright/Nano Banana",
+        codex_err,
+    )
+
+    # ── FALLBACK: Playwright + Gemini Nano Banana 2 Pro ──
+    img_bytes, pw_err = await _generate_cover_via_playwright(bare_prompt)
+    if img_bytes is not None:
+        return await _finalize_cover(img_bytes, bare_prompt, draft_id, t0)
+
+    # Both providers failed — return composite error for diagnosis.
+    return None, f"Both providers failed: codex={codex_err}; playwright={pw_err}"
 
 
 # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Reverses cover-image provider chain in `wr2_draft_generator.py`:
- **PRIMARY**: Codex CLI v0.128 `\$imagegen` skill (gpt-image-2 via OAuth Pro \$200)
- **FALLBACK**: Gemini Nano Banana 2 Pro via Playwright (legacy, kept for safety)

Smoke test E2E **PASSED** 2026-05-06 15:19: Codex 196.5s + VLM gate + Tigris upload → public URL OK.

## Why

Two cover-gen failures observed in the last 48h:
- 2026-05-04 22:50 + 22:43 — Nano Banana cover failed twice with Playwright timeout 240s under load
- 2026-05-06 15:00 — Playwright cover failed for new draft `cd9b7b0f` because `chromium_headless_shell-1208` binary missing (Playwright 1.58.0 cache mismatch — has 1217, expected 1208). All cover gen broken until manual `playwright install chromium` re-download.

Codex Image-2 bypasses both failure modes. Runs via OAuth Pro \$200 plan — zero per-call billing, aligned with Golden Rule #13 (no paid Anthropic API; OpenAI here is OAuth-only, not API key).

## Changes

- New `_generate_cover_via_codex(scene_core)` — async subprocess to `codex exec "\$imagegen <prompt>"`, 600s timeout, env-stripped (strips ANTHROPIC/OPENAI/GEMINI/GOOGLE keys before subprocess spawn).
- New `_generate_cover_via_playwright(bare_prompt)` — extracted legacy path, unchanged behavior.
- New `_finalize_cover(img_bytes, ...)` — shared VLM gate + Tigris upload, used by both providers.
- Refactored `generate_cover_image` orchestrator: try Codex → fall through to Playwright on any failure → composite error tuple if both fail.

## Trap operativo

Codex IGNORES output path in prompt — always writes to `~/.codex/generated_images/<uuid-v7>/ig_<hash>.png`. The new helper finds the fresh PNG by mtime exclusion (snapshot pre-existing set, take latest new). Memo: `~/.claude/projects/-Users-nuzantara/memory/discovery_codex_imagegen_default_path_2026_05_06.md`.

## Test plan

- [x] `python3 -m py_compile scripts/wr2_draft_generator.py` → clean
- [x] E2E smoke test 2026-05-06 15:19: 214s total, 2.29 MB PNG → Tigris URL ✅
- [x] Pre-commit hooks all passed (lint, typecheck, no print/console.log, no hardcoded secrets)
- [x] Pre-push hooks passed
- [ ] First production draft post-merge (expected next topic-selector cron 05:10 WITA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)