### PR TITLE
fix(mata-garuda): curl --compressed + UnicodeDecodeError handler

### DIFF
--- a/apps/mata-garuda/mata_garuda/agents/intel_scraper_bridge.py
+++ b/apps/mata-garuda/mata_garuda/agents/intel_scraper_bridge.py
@@ -95,6 +95,11 @@ def _fetch_article_text(url: str) -> str | None:
             [
                 "curl",
                 "-sSL",
+                "--compressed",  # decode gzip/deflate transparently — without
+                                 # this, servers like tempo.co return raw gzip
+                                 # bytes and subprocess(text=True) crashes on
+                                 # the 0x8b magic byte. Verified empirically
+                                 # 2026-05-06 first prod run.
                 "--max-time", str(FETCH_TIMEOUT_S),
                 "--max-filesize", "1000000",  # 1 MB on-wire cap
                 "-A", _USER_AGENT,
@@ -108,6 +113,13 @@ def _fetch_article_text(url: str) -> str | None:
         )
     except (subprocess.TimeoutExpired, FileNotFoundError) as e:
         logger.debug("[intel_bridge] fetch timeout/missing curl for %s: %s", url, e)
+        return None
+    except Exception as e:  # noqa: BLE001 — fetch is best-effort; a single
+        # malformed URL must NOT take down the 50-URL batch (e.g. server
+        # sends gzip despite our --compressed request, or sends invalid
+        # UTF-8 in a non-Content-Encoding-declared body, or any other
+        # subprocess oddity). Log + skip + caller publishes content="".
+        logger.debug("[intel_bridge] fetch unexpected error for %s: %s", url, e)
         return None
 
     if result.returncode != 0:

--- a/apps/mata-garuda/tests/test_intel_scraper_bridge.py
+++ b/apps/mata-garuda/tests/test_intel_scraper_bridge.py
@@ -314,6 +314,54 @@ def test_strip_html_handles_empty_input():
     assert _strip_html(None) == ""  # type: ignore[arg-type]
 
 
+def test_fetch_curl_uses_compressed_flag():
+    """curl must run with --compressed so gzip/deflate responses are
+    decoded transparently. Without it, subprocess(text=True) blows up
+    with UnicodeDecodeError on byte 0x8b (gzip magic) — verified
+    empirically against tempo.co on 2026-05-06 first prod run."""
+    from mata_garuda.agents.intel_scraper_bridge import _fetch_article_text
+    captured = {}
+    fake_completed = type("R", (), {
+        "returncode": 0,
+        "stdout": "<html><body>hi</body></html>\n200",
+        "stderr": "",
+    })()
+    def fake_run(cmd, *a, **kw):
+        captured["cmd"] = cmd
+        return fake_completed
+    with patch("mata_garuda.agents.intel_scraper_bridge.subprocess.run", side_effect=fake_run):
+        out = _fetch_article_text("https://example.com/foo")
+    assert "--compressed" in captured["cmd"], (
+        "curl invocation must include --compressed to decode gzip responses"
+    )
+    assert out is not None and "hi" in out
+
+
+def test_fetch_swallows_unicode_decode_error():
+    """If subprocess.run raises UnicodeDecodeError (e.g. server sent gzip
+    bytes despite our --compressed request), the bridge must NOT crash
+    — return None and let the caller publish content="" gracefully."""
+    from mata_garuda.agents.intel_scraper_bridge import _fetch_article_text
+    def boom(*a, **kw):
+        raise UnicodeDecodeError("utf-8", b"\x1f\x8b", 1, 2, "invalid start byte")
+    with patch("mata_garuda.agents.intel_scraper_bridge.subprocess.run", side_effect=boom):
+        out = _fetch_article_text("https://example.com/gzip-only")
+    assert out is None  # graceful: no exception, no partial content
+
+
+def test_fetch_swallows_generic_exception():
+    """Any other unexpected exception from curl/subprocess (e.g. OSError,
+    UnicodeError variants, malformed redirect chain) must also be
+    contained — bridge processes 50 URLs/run, one bad URL must NOT take
+    down the whole batch."""
+    from mata_garuda.agents.intel_scraper_bridge import _fetch_article_text
+    def boom(*a, **kw):
+        raise RuntimeError("unexpected curl crash")
+    with patch("mata_garuda.agents.intel_scraper_bridge.subprocess.run", side_effect=boom):
+        out = _fetch_article_text("https://example.com/weird")
+    assert out is None
+
+
 def test_agent_registered_and_has_genome():
     import mata_garuda.agents.intel_scraper_bridge  # noqa: F401
     from mata_garuda.registry import get_agent


### PR DESCRIPTION
## Summary

Hotfix surfaced 30 minutes after PR #475 merged — first kickstart of \`com.matagaruda.intel-bridge.daily\` with \`MATAGARUDA_FETCH_CONTENT=1\` crashed on a tempo.co URL.

## Root cause

\`subprocess.run(curl, text=True)\` blew up with:

\`\`\`
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte
\`\`\`

\`0x8b\` is the gzip magic byte (\`0x1f 0x8b\`). curl invocation lacked \`--compressed\` so the server returned gzip-encoded bytes that Python's text mode couldn't decode. Stack ended the run after 20/50 URLs published.

## Fix

1. **\`curl --compressed\`**: requests \`Accept-Encoding: gzip,deflate\` AND transparently decodes the response. Standard pattern, no new dep.
2. **Widened exception handler** in \`_fetch_article_text\`: catches \`Exception\` broadly. Comment cites the design rationale (50 URLs/run, one bad URL must not kill the batch).

## Test plan

- [x] 17/17 \`test_intel_scraper_bridge.py\` green (3 new TDD: \`--compressed\` flag presence, UnicodeDecodeError swallowed, generic exception swallowed)
- [x] 602/603 mata-garuda full suite green (1 preexisting sentinel sqlite-tmp fail unrelated)

## Empirical verification

20 articles published successfully before crash on the failing URL (visible in \`garuda:raw\` from the partial run). Sample entry from tempo.co showed full content extraction works:

\`\`\`
title: Indonesia Named Among World's 28 Most Beautiful Countries...
content: <1500 chars of extracted body>
\`\`\`

So the fetcher logic is sound — only the gzip decode path was broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)