### PR TITLE
fix(nlm-feeder): resurrect NB-INTEL pipeline (Pro/Mini Redis split-brain + KB WAL hardening)

### DIFF
--- a/.claude/rules/cicatrix-scars.md
+++ b/.claude/rules/cicatrix-scars.md
@@ -5,6 +5,138 @@ Each entry has TRAUMA (what went wrong), ANTIBODY (how it's now protected), and 
 
 ---
 
+### ⚠️ STRUCTURAL: NLM feeder split-brain — base_worker redis-cli has no host arg, prod has two local Redis instances (2026-05-06)
+
+_Discovered: 2026-05-06 22:00 WITA during NB-INTEL pipeline resurrection ·
+Patched: same day, branch `fix/nlm-feeder-resurrect-2026-05-06` · Severity: P0 ·
+Status: code patched + Mini Redis configured; code activates on next merge to main_
+
+**TRAUMA:** `apps/mata-garuda/mata_garuda/workers/base_worker.py` at lines
+21–34 (pre-patch) shells out via `subprocess.run(["redis-cli", *args])` with
+no `-h` / `-p` flags, so every call connects to **127.0.0.1**. After the
+2026-05-02 Modo B reorganization the sentinel was moved to Mini and the
+feeder kept running on Pro. Both machines run their own brew-managed
+Redis at port 6379:
+
+* Pro Redis `garuda:alerts` — 258 entries, last fresh 2026-05-05 02:01 (frozen)
+* Mini Redis `garuda:alerts` — fresh today (latest 2026-05-06 02:01)
+
+The feeder consumed Pro's stale stream every hour for ~36h while NotebookLM
+saw `last delivered` of `2026-05-04T07:52:41Z`. Logs showed `processed=0,
+fed=0` and operator read it as "stream healthy, no new items" — actually
+"feeder pointing at the wrong Redis". The 753 nlm_fed entries in the local
+KB are all from the Pro stream, so dedup masks the divergence.
+
+Compounding fault: 2 transient `sqlite3.OperationalError: disk I/O error`
+out of 106 hourly runs because `KnowledgeBase.__init__` opened the connection
+without enabling WAL — a momentary lock collision between two overlapping
+hourly invocations crashed the second one entirely instead of waiting on
+the busy_timeout (Python's 5s default). Same class of bug, different
+amplitude than the auth/CLI problems that the prompt suspected.
+
+Concrete sentinel ground-truth (2026-05-06 22:30 WITA via `nlm notebook list`):
+
+```
+NB-INTEL-Immigration  61 sources  last_updated 2026-05-04T07:52:41Z
+NB-INTEL-Tax          14 sources  last_updated 2026-04-19T18:54:05Z
+NB-INTEL-Regulation   34 sources  last_updated 2026-05-04T07:52:52Z
+NB-INTEL-Press        28 sources  last_updated 2026-05-04T07:52:40Z
+NB-INTEL-AIResearch   75 sources  last_updated 2026-05-04T16:43:27Z
+```
+
+**ANTIBODY (shipped on `fix/nlm-feeder-resurrect-2026-05-06`):**
+
+1. **`base_worker.redis_cmd` reads `GARUDA_REDIS_HOST` + optional
+   `GARUDA_REDIS_PORT` from env** and prepends `-h $host` (and `-p $port`
+   when both are set) to every redis-cli invocation. Empty/unset → no flags
+   → localhost default (preserves backward compatibility for any caller
+   running on the producer host). New `_redis_host_args()` helper documents
+   the contract.
+2. **`KnowledgeBase.__init__` now enables WAL + `synchronous=NORMAL`** on
+   the connection. WAL allows readers + a single writer concurrently and
+   makes transient lock contention wait on the busy_timeout instead of
+   propagating an I/O error. WAL setting is persisted in the DB header so
+   it's a no-op after the first open of an existing DB.
+3. **9 new tests** in `tests/test_redis_host_override.py` (5) and
+   `tests/test_knowledge_resilience.py` (4): empty/missing env, port-
+   without-host ignored, host+port routing, parent dir creation, busy
+   timeout ≥1s, journal_mode=wal, concurrent open without I/O error.
+4. **Mini Redis reconfigured 2026-05-06 22:35 WITA**:
+   `bind 127.0.0.1 ::1 100.93.236.6`, `protected-mode no`, `CONFIG REWRITE`
+   persisted. Backup at
+   `/opt/homebrew/etc/redis.conf.pre-tailscale-bind-2026-05-06`. Tailnet
+   `balizero` is restricted to Pro+Mini devices (Subhi has admin role but
+   no enrolled device, no SSH keys), so 6379 on the Tailscale IP is
+   private-LAN-only.
+5. **Pro plist** `~/Library/LaunchAgents/com.matagaruda.nlm-feeder-stream.hourly.plist`
+   gains `GARUDA_REDIS_HOST=100.93.236.6` in `EnvironmentVariables`. Backup
+   at `*.pre-redis-host-2026-05-06`. Reloaded via `launchctl bootout` +
+   `bootstrap` 2026-05-06 22:38 WITA — verified live via `launchctl print`.
+
+**Empirical AFTER (2026-05-06 23:00 WITA, after manual draining + 1 cron tick):**
+
+```
+NB-INTEL-Immigration  79 sources  +18
+NB-INTEL-Tax          15 sources  +1
+NB-INTEL-Regulation   38 sources  +4
+NB-INTEL-Press        56 sources  +28
+NB-INTEL-AIResearch   85 sources  +10
+                      ──────────
+                      +61 total
+```
+
+Press +28 and Immigration +18 hit the ≥5 threshold; Tax +1 and Regulation +4
+reflect the actual sentinel topic distribution today, not a remaining
+plumbing issue. Mini consumer group `nlm_feeder_alerts` shows
+`entries-read=23, lag=0` after a synthetic test alert was injected and
+consumed end-to-end via the new env path.
+
+**GOTCHA:**
+
+- **`redis-cli` itself does NOT honor `GARUDA_REDIS_HOST`**. The env var is
+  read only by the Python `base_worker.redis_cmd` wrapper. A debug session
+  that runs `GARUDA_REDIS_HOST=… redis-cli XLEN …` from a Pro shell will
+  silently hit Pro localhost, returning numbers that LOOK like they came
+  from Mini. Always use the Python wrapper or `redis-cli -h $host`
+  explicitly when you debug. Compare `INFO server | grep run_id` — Pro and
+  Mini each have a unique `run_id` and that's the only reliable way to
+  tell which Redis answered.
+- The plist's `WorkingDirectory` and Python interpreter path point at the
+  main repo (`apps/mata-garuda/.venv/bin/python` against
+  `/Users/nuzantara/Desktop/nuzantara/apps/mata-garuda`), so the env-var
+  override **only takes effect after `fix/nlm-feeder-resurrect-2026-05-06`
+  merges to main**. Until then, hourly cron runs against the unpatched
+  base_worker and silently keeps reading Pro localhost (i.e. a 0/0/0
+  no-op). The fix is in production launchd config but inert until the
+  binary code matches.
+- Both Pro and Mini run a brew-managed Redis listening on 6379. Pro's
+  `bind` was unchanged; only Mini's was extended. Future cross-host
+  consumers MUST set `GARUDA_REDIS_HOST=100.93.236.6` explicitly — there
+  is no auto-discovery. Mini Redis stays the OSINT producer per Modo B
+  ("Mini=workhorse, Pro=consumer"); reversing that direction would
+  require the symmetric Pro Redis bind change which we did NOT do.
+- The KB `data/knowledge.db` retains 753 nlm_fed dedup entries from the
+  pre-patch Pro-stream era. Items present in Mini's stream that share a
+  URL with a Pro-fed item will be skipped on the first cycle after the
+  pivot. This is correct behavior (no double-feed to NotebookLM) but
+  visible as `skipped=N` in the JSON summary. The numbers above already
+  account for this — Tax +1 / Regulation +4 are honest gains from
+  non-overlapping URLs, not undercounts caused by dedup.
+- TCC `getcwd: cannot access parent directories: Operation not permitted`
+  errors flooding `~/logs/matagaruda-nlm-feeder-stream.error.log` are a
+  RED HERRING. They originate from `/bin/zsh -lc` reading shell startup
+  files under `/Users/nuzantara/.zshrc` etc. while launchd holds the
+  process in a sandboxed cwd; the actual python interpreter starts cleanly
+  and the feeder works (verified by the 612/612 test pass and the live
+  source_count growth). A `bash` bridge or removing `-l` from the plist
+  would silence them but does not change behavior. Out of scope here.
+
+Brainstorm artifacts: none yet (acted directly on diagnostic evidence
+visible in logs + `XINFO STREAM`). MOS records the diagnosis as discovery
+2026-05-06 22:30 WITA importance 8 + the base_worker fact at importance 7.
+
+---
+
 ### ⚠️ STRUCTURAL: Test infrastructure mock != production stack (Sprint 1.B 2026-05-02, 3 hotfix in chain)
 
 _Discovered: 2026-05-02 during Sprint 1.B Era Post-Agentica deploy — 3 hotfix

--- a/apps/mata-garuda/mata_garuda/runtime/knowledge.py
+++ b/apps/mata-garuda/mata_garuda/runtime/knowledge.py
@@ -33,6 +33,12 @@ class KnowledgeBase:
         # reads via WAL.
         self._conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
+        # WAL allows readers + a single writer concurrently and survives the
+        # transient "disk I/O error" we saw 2026-05-06 when an hourly feeder
+        # collided with a still-running previous instance. journal_mode is
+        # persisted in the DB, so this is a no-op after the first open.
+        self._conn.execute("PRAGMA journal_mode = WAL")
+        self._conn.execute("PRAGMA synchronous = NORMAL")
         self._init_tables()
 
     def _init_tables(self) -> None:

--- a/apps/mata-garuda/mata_garuda/workers/base_worker.py
+++ b/apps/mata-garuda/mata_garuda/workers/base_worker.py
@@ -3,12 +3,18 @@ Mata Garuda — Base worker for Redis Stream consumers.
 
 Workers read from garuda:raw, process items, and write to garuda:enriched.
 Uses redis-cli subprocess — no redis-py dependency.
+
+Cross-host topology (2026-05-06): when GARUDA_REDIS_HOST is set, every
+redis-cli call is routed to that host (with optional GARUDA_REDIS_PORT).
+This lets the feeder running on Pro consume the alerts stream produced
+by the sentinel running on Mini, without standing up a redis-py client.
 """
 from __future__ import annotations
 
 import hashlib
 import json
 import logging
+import os
 import subprocess
 from datetime import datetime
 from typing import Optional
@@ -18,9 +24,25 @@ logger = logging.getLogger("mata_garuda.workers")
 REDIS_CLI = "redis-cli"
 
 
+def _redis_host_args() -> list[str]:
+    """Return ['-h', host] (and optional ['-p', port]) from env vars.
+
+    GARUDA_REDIS_HOST empty/unset → no -h/-p (redis-cli defaults to 127.0.0.1).
+    GARUDA_REDIS_PORT without HOST → ignored (avoid surprising localhost:port).
+    """
+    host = (os.environ.get("GARUDA_REDIS_HOST") or "").strip()
+    if not host:
+        return []
+    args = ["-h", host]
+    port = (os.environ.get("GARUDA_REDIS_PORT") or "").strip()
+    if port:
+        args += ["-p", port]
+    return args
+
+
 def redis_cmd(*args: str, timeout: int = 10) -> str:
     """Execute a redis-cli command and return output."""
-    cmd = [REDIS_CLI] + list(args)
+    cmd = [REDIS_CLI] + _redis_host_args() + list(args)
     try:
         result = subprocess.run(
             cmd, capture_output=True, text=True, timeout=timeout

--- a/apps/mata-garuda/tests/test_knowledge_resilience.py
+++ b/apps/mata-garuda/tests/test_knowledge_resilience.py
@@ -1,0 +1,93 @@
+"""Tests for KnowledgeBase resilience hardening.
+
+Background (2026-05-06): nlm-feeder logged 2 transient errors out of 106
+runs: `sqlite3.OperationalError: disk I/O error` followed once by
+`unable to open database file`. Root cause: KB opened with default
+busy_timeout=0, returning immediately on any momentary lock contention,
+combined with no parent-dir mkdir guard (prompt's claim, currently
+already handled but only when parent exists at instance creation time).
+
+Hardening:
+  1. busy_timeout > 0 (default 5s) so a lock contention waits, not raises.
+  2. journal_mode WAL to allow concurrent reads with a writer.
+  3. Parent dir always created idempotently (safety net for
+     ~/.mata-garuda/-style alternate paths if user redirects DEFAULT_DB_PATH).
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+class TestKnowledgeBaseResilience:
+    def test_init_creates_parent_dir(self, tmp_path):
+        """KB.__init__ creates the parent directory if missing (idempotent)."""
+        from mata_garuda.runtime.knowledge import KnowledgeBase
+
+        nested = tmp_path / "deeply" / "nested" / "data"
+        assert not nested.exists()
+
+        kb = KnowledgeBase(db_path=nested / "kb.db")
+        try:
+            assert nested.exists()
+            assert (nested / "kb.db").exists()
+        finally:
+            kb.close()
+
+    def test_busy_timeout_set_nonzero(self, tmp_path):
+        """KB sets busy_timeout > 0 to wait on transient lock contention."""
+        from mata_garuda.runtime.knowledge import KnowledgeBase
+
+        kb = KnowledgeBase(db_path=tmp_path / "kb.db")
+        try:
+            cursor = kb._conn.execute("PRAGMA busy_timeout")
+            timeout_ms = cursor.fetchone()[0]
+            # We expect at least 1s — current default in code = 0 (the bug).
+            assert timeout_ms >= 1000, (
+                f"busy_timeout={timeout_ms}ms — must be >= 1000 to ride out "
+                "transient WAL lock contention from concurrent writers."
+            )
+        finally:
+            kb.close()
+
+    def test_journal_mode_wal(self, tmp_path):
+        """KB uses WAL journal mode for concurrent read while writer holds lock."""
+        from mata_garuda.runtime.knowledge import KnowledgeBase
+
+        kb = KnowledgeBase(db_path=tmp_path / "kb.db")
+        try:
+            cursor = kb._conn.execute("PRAGMA journal_mode")
+            mode = cursor.fetchone()[0]
+            assert mode.lower() == "wal", f"journal_mode={mode}, expected wal"
+        finally:
+            kb.close()
+
+    def test_concurrent_open_no_io_error(self, tmp_path):
+        """Two concurrent KB instances both write without raising disk I/O error.
+
+        Reproduces the failure mode observed 2026-05-06: a feeder run
+        spawned while a previous run still held the WAL lock raised
+        sqlite3.OperationalError: disk I/O error. With busy_timeout
+        and WAL mode, the second open should succeed.
+        """
+        from mata_garuda.runtime.knowledge import KnowledgeBase
+
+        db_path = tmp_path / "kb.db"
+
+        kb1 = KnowledgeBase(db_path=db_path)
+        kb2 = KnowledgeBase(db_path=db_path)
+        try:
+            kb1.store("a1", "t", "c1", "s1", 0.5)
+            kb2.store("a2", "t", "c2", "s2", 0.5)
+            # both writes visible to a fresh reader
+            kb3 = KnowledgeBase(db_path=db_path)
+            try:
+                rows = kb3.get_by_type("t", limit=10)
+                assert len(rows) == 2
+            finally:
+                kb3.close()
+        finally:
+            kb1.close()
+            kb2.close()

--- a/apps/mata-garuda/tests/test_redis_host_override.py
+++ b/apps/mata-garuda/tests/test_redis_host_override.py
@@ -1,0 +1,102 @@
+"""Tests for GARUDA_REDIS_HOST/PORT env var override in base_worker.redis_cmd.
+
+Background (2026-05-06): Pro and Mini both run local Redis with the same
+stream name (garuda:alerts). Sentinel produces alerts on Mini; feeder runs
+on Pro reading localhost ⇒ silent split-brain on stream data. The feeder
+needs an env-var override to point at Mini's Redis when running on Pro.
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import patch, MagicMock
+
+
+class TestRedisHostOverride:
+    def test_default_no_host_flag(self, monkeypatch):
+        """When no env var is set, redis-cli runs with no -h/-p — localhost."""
+        monkeypatch.delenv("GARUDA_REDIS_HOST", raising=False)
+        monkeypatch.delenv("GARUDA_REDIS_PORT", raising=False)
+
+        from mata_garuda.workers import base_worker
+
+        with patch.object(base_worker.subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="OK", stderr="")
+            base_worker.redis_cmd("PING")
+
+        called_cmd = mock_run.call_args[0][0]
+        assert called_cmd[0].endswith("redis-cli")
+        # No -h flag means default localhost
+        assert "-h" not in called_cmd
+        assert "-p" not in called_cmd
+        assert "PING" in called_cmd
+
+    def test_host_env_var_injects_h_flag(self, monkeypatch):
+        """GARUDA_REDIS_HOST=foo.bar adds '-h foo.bar' before the command args."""
+        monkeypatch.setenv("GARUDA_REDIS_HOST", "100.93.236.6")
+        monkeypatch.delenv("GARUDA_REDIS_PORT", raising=False)
+
+        from mata_garuda.workers import base_worker
+
+        with patch.object(base_worker.subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="OK", stderr="")
+            base_worker.redis_cmd("XLEN", "garuda:alerts")
+
+        called_cmd = mock_run.call_args[0][0]
+        assert "-h" in called_cmd
+        h_idx = called_cmd.index("-h")
+        assert called_cmd[h_idx + 1] == "100.93.236.6"
+        # XLEN args still present after the flag
+        assert "XLEN" in called_cmd
+        assert "garuda:alerts" in called_cmd
+
+    def test_port_env_var_injects_p_flag(self, monkeypatch):
+        """GARUDA_REDIS_PORT=6380 adds '-p 6380' to the args."""
+        monkeypatch.setenv("GARUDA_REDIS_HOST", "mini.tail461666.ts.net")
+        monkeypatch.setenv("GARUDA_REDIS_PORT", "6380")
+
+        from mata_garuda.workers import base_worker
+
+        with patch.object(base_worker.subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="OK", stderr="")
+            base_worker.redis_cmd("PING")
+
+        called_cmd = mock_run.call_args[0][0]
+        assert "-h" in called_cmd
+        assert "-p" in called_cmd
+        p_idx = called_cmd.index("-p")
+        assert called_cmd[p_idx + 1] == "6380"
+
+    def test_port_without_host_is_ignored(self, monkeypatch):
+        """Setting only PORT without HOST is invalid — fall back to localhost.
+
+        We don't synthesize a partial -p without -h since redis-cli would
+        connect to localhost on the custom port, which is rarely intentional.
+        Better to require both or neither — keep the contract explicit.
+        """
+        monkeypatch.delenv("GARUDA_REDIS_HOST", raising=False)
+        monkeypatch.setenv("GARUDA_REDIS_PORT", "6380")
+
+        from mata_garuda.workers import base_worker
+
+        with patch.object(base_worker.subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="OK", stderr="")
+            base_worker.redis_cmd("PING")
+
+        called_cmd = mock_run.call_args[0][0]
+        # Without HOST, port flag is dropped — localhost default
+        assert "-p" not in called_cmd
+        assert "-h" not in called_cmd
+
+    def test_empty_host_treated_as_unset(self, monkeypatch):
+        """Empty string GARUDA_REDIS_HOST='' should not inject -h (whitespace too)."""
+        monkeypatch.setenv("GARUDA_REDIS_HOST", "")
+        monkeypatch.delenv("GARUDA_REDIS_PORT", raising=False)
+
+        from mata_garuda.workers import base_worker
+
+        with patch.object(base_worker.subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="OK", stderr="")
+            base_worker.redis_cmd("PING")
+
+        called_cmd = mock_run.call_args[0][0]
+        assert "-h" not in called_cmd


### PR DESCRIPTION
## Summary

NB-INTEL daily feeder hadn't shipped a single new source to NotebookLM since
2026-05-04 morning. The 5 specialised notebooks (Immigration / Tax /
Regulation / Press / AIResearch) were stuck on stale counts while the
hourly LaunchAgent kept emitting clean \`{processed: 0, fed: 0, ...}\` JSON
summaries. Ground-truth from \`nlm notebook list\` (2026-05-06 22:30 WITA):

| NB-INTEL | sources | last_updated |
|---|---|---|
| Immigration | 61 | 2026-05-04T07:52:41Z |
| Tax | 14 | 2026-04-19T18:54:05Z |
| Regulation | 34 | 2026-05-04T07:52:52Z |
| Press | 28 | 2026-05-04T07:52:40Z |
| AIResearch | 75 | 2026-05-04T16:43:27Z |

Root cause = single-symbol fix: **\`base_worker.redis_cmd\` shells out to
\`redis-cli\` with no \`-h\` / \`-p\` flags, so every call connects to
127.0.0.1**. After Modo B reorganization (sentinel on Mini, feeder on Pro)
each machine ran its own Redis on 6379, and the Pro feeder kept consuming
**Pro's stale \`garuda:alerts\` stream** while the sentinel produced fresh
items into **Mini's stream**. Same pre-existing \`base_worker.py\` worked
perfectly when feeder + sentinel co-located on a single host; it became
a silent split-brain only after the topology split.

Compounding fault — 2 transient \`sqlite3.OperationalError: disk I/O error\`
out of 106 hourly runs because the KB connection didn't enable WAL, so
overlapping invocations crashed instead of waiting on the busy_timeout.
Same class as the \`unable to open database file\` line near the bottom
of the log.

## Fixes

1. **\`apps/mata-garuda/mata_garuda/workers/base_worker.py\`** — new
   \`_redis_host_args()\` helper reads \`GARUDA_REDIS_HOST\` and optional
   \`GARUDA_REDIS_PORT\` from env. Empty/unset → no flags → localhost
   default (backward-compatible). \`redis_cmd\` prepends those flags
   before the user args. Single env var per process now switches every
   redis-cli call to the right Redis without a redis-py dependency
   (mata-garuda CLAUDE.md §1 forbids it).
2. **\`apps/mata-garuda/mata_garuda/runtime/knowledge.py\`** —
   \`KnowledgeBase.__init__\` now executes
   \`PRAGMA journal_mode = WAL\` + \`PRAGMA synchronous = NORMAL\` on
   connect. WAL allows readers + a writer concurrently and forces
   transient lock contention to wait on the existing 5s busy_timeout.
   Persisted in the DB header → no-op after first open.
3. **9 new tests** —
   \`tests/test_redis_host_override.py\` (5: empty/missing env, port-
   without-host ignored, host+port routing, h-flag injection, p-flag
   injection) + \`tests/test_knowledge_resilience.py\` (4: parent dir
   creation, busy_timeout ≥1s, journal_mode=wal, concurrent open without
   I/O error). Existing 603 mata-garuda tests keep passing → 612/612
   green.
4. **Operational changes (NOT in the diff, performed live on Pro+Mini):**
   - Mini Redis: \`bind 127.0.0.1 ::1 100.93.236.6\`,
     \`protected-mode no\`, \`CONFIG REWRITE\` persisted. Backup at
     \`/opt/homebrew/etc/redis.conf.pre-tailscale-bind-2026-05-06\`.
     Tailnet \`balizero\` is private (Pro+Mini only, no other devices),
     so 6379 on the Tailscale IP is private-LAN-only.
   - Pro plist
     \`~/Library/LaunchAgents/com.matagaruda.nlm-feeder-stream.hourly.plist\`
     gains \`GARUDA_REDIS_HOST=100.93.236.6\` in
     \`EnvironmentVariables\`. Backup at \`*.pre-redis-host-2026-05-06\`.
     Reloaded via \`launchctl bootout\` + \`bootstrap\` (verified live).
   - The plist already runs against \`apps/mata-garuda/.venv/bin/python\`
     with \`WorkingDirectory\` on the main checkout, so the env var sits
     idle until this PR merges and the binary code in main matches.

## Empirical AFTER (2026-05-06 23:00 WITA)

After draining the Mini stream end-to-end through the worktree code path
and one launchd-triggered cycle, with one synthetic test alert injected:

| NB-INTEL | BEFORE | AFTER | Δ |
|---|---|---|---|
| Immigration | 61 | 79 | **+18** |
| Tax | 14 | 15 | +1 |
| Regulation | 34 | 38 | +4 |
| Press | 28 | 56 | **+28** |
| AIResearch | 75 | 85 | **+10** |
| **Total** | **212** | **273** | **+61** |

Press +28 and Immigration +18 hit the ≥5 success threshold. Tax +1 and
Regulation +4 reflect the actual sentinel topic distribution from the
last daily run, not a remaining plumbing issue (Mini's
\`garuda:alerts\` stream contained 22 entries with topic distribution
heavy on \`immigration_visa\` / \`property\` / \`provincial_bali\`).
Mini consumer group \`nlm_feeder_alerts\` shows
\`entries-read=23, lag=0\` after the synthetic test alert was consumed
end-to-end via the new env path — proves the round-trip Redis→KB→NLM.

## Cicatrix entry

Added in \`.claude/rules/cicatrix-scars.md\` —
\"NLM feeder split-brain — base_worker redis-cli has no host arg, prod
has two local Redis instances (2026-05-06)\". Captures three GOTCHAs
that future agents will need:

- \`redis-cli\` itself does NOT honor \`GARUDA_REDIS_HOST\` (the wrapper
  does). Compare \`INFO server | grep run_id\` to verify which Redis
  answered when debugging.
- The plist's \`GARUDA_REDIS_HOST\` is inert until this PR merges and
  main carries the patched \`base_worker\`.
- TCC \`getcwd: cannot access parent directories\` errors flooding the
  feeder error log are a red herring from \`/bin/zsh -lc\` reading
  startup files under a sandboxed cwd; not the actual blocker.

## Test plan

- [x] 612/612 mata-garuda pytest green
- [x] Manual feeder run through worktree code with \`GARUDA_REDIS_HOST=Mini\`
      consumed all 22 fresh Mini alerts on first call
- [x] LaunchAgent kickstart with new env var → exit 0, no
      \`disk I/O error\`, no \`unable to open database file\`
- [x] Synthetic \`XADD garuda:alerts\` on Mini → consumed end-to-end via
      worktree code (\`processed=1, fed=1\` plus enriched fed=10)
- [x] NB-INTEL source counts captured BEFORE and AFTER, +61 total
- [ ] After merge: confirm next hourly tick shows non-zero \`processed\`
      in JSON and \`source_count\` continues to climb on at least 3 of 5
      NBs over 24h
- [ ] After merge + 24h: cleanup synthetic test alert from
      \`NB-INTEL-Immigration\` if it shows as a separate source there
      (\`url=https://test.example/e2e-check\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)