### PR TITLE
fix(organism): W2-C mata_garuda active-active cleanup (13 labels)

### DIFF
--- a/apps/organism/organism/genome.yaml
+++ b/apps/organism/organism/genome.yaml
@@ -483,21 +483,6 @@ organs:
       label: com.matagaruda.watcher.daily
     severity_on_silence: warning
     cicatrix_refs: []
-    duplicates_id: mata_garuda.watcher_daily.mini
-  - id: mata_garuda.watcher_daily.mini
-    runtime: mini_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/mata-garuda/scripts/run_watcher.sh
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: mini
-      label: com.matagaruda.watcher.daily
-    severity_on_silence: warning
-    cicatrix_refs: []
-    duplicates_id: mata_garuda.watcher_daily.pro
   - id: mata_garuda.reg_alert_30min.pro
     runtime: pro_launchd
     type: cron
@@ -511,21 +496,6 @@ organs:
       label: com.matagaruda.reg-alert.30min
     severity_on_silence: warning
     cicatrix_refs: []
-    duplicates_id: mata_garuda.reg_alert_30min.mini
-  - id: mata_garuda.reg_alert_30min.mini
-    runtime: mini_launchd
-    type: cron
-    expected_hb_seconds: 5400
-    owner_module: apps/mata-garuda/scripts/run_regulation_alert.py
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: mini
-      label: com.matagaruda.reg-alert.30min
-    severity_on_silence: warning
-    cicatrix_refs: []
-    duplicates_id: mata_garuda.reg_alert_30min.pro
   - id: mata_garuda.kg_linker.pro
     runtime: pro_launchd
     type: cron
@@ -540,22 +510,6 @@ organs:
       label: com.matagaruda.kg-linker
     severity_on_silence: warning
     cicatrix_refs: []
-    duplicates_id: mata_garuda.kg_linker.mini
-  - id: mata_garuda.kg_linker.mini
-    runtime: mini_launchd
-    type: cron
-    expected_hb_seconds: 7200
-    owner_module: apps/mata-garuda/mata_garuda/workers/kg_linker.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: mini
-      label: com.matagaruda.kg-linker
-    severity_on_silence: warning
-    cicatrix_refs: []
-    duplicates_id: mata_garuda.kg_linker.pro
   - id: mata_garuda.wr_topic.pro
     runtime: pro_launchd
     type: cron
@@ -569,21 +523,6 @@ organs:
       label: com.matagaruda.wr-topic
     severity_on_silence: warning
     cicatrix_refs: []
-    duplicates_id: mata_garuda.wr_topic.mini
-  - id: mata_garuda.wr_topic.mini
-    runtime: mini_launchd
-    type: cron
-    expected_hb_seconds: 691200
-    owner_module: apps/mata-garuda/scripts/run_wr_topic.py
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: mini
-      label: com.matagaruda.wr-topic
-    severity_on_silence: warning
-    cicatrix_refs: []
-    duplicates_id: mata_garuda.wr_topic.pro
   - id: mata_garuda.wr2_bridge_hourly.pro
     runtime: pro_launchd
     type: cron
@@ -594,24 +533,9 @@ organs:
     recovery_action: launchctl_kickstart
     recovery_params:
       host: pro
-      label: com.matagaruda.wr2-bridge.hourly
+      label: com.matagaruda.wr2-bridge
     severity_on_silence: warning
     cicatrix_refs: []
-    duplicates_id: mata_garuda.wr2_bridge_hourly.mini
-  - id: mata_garuda.wr2_bridge_hourly.mini
-    runtime: mini_launchd
-    type: cron
-    expected_hb_seconds: 7200
-    owner_module: apps/mata-garuda/scripts/run_wr2_bridge.py
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: mini
-      label: com.matagaruda.wr2-bridge.hourly
-    severity_on_silence: warning
-    cicatrix_refs: []
-    duplicates_id: mata_garuda.wr2_bridge_hourly.pro
   - id: mata_garuda.bridge_adaptive.pro
     runtime: pro_launchd
     type: daemon
@@ -626,36 +550,6 @@ organs:
       label: com.matagaruda.bridge.adaptive
     severity_on_silence: error
     cicatrix_refs: []
-    duplicates_id: mata_garuda.bridge_adaptive.mini
-  - id: mata_garuda.bridge_adaptive.mini
-    runtime: mini_launchd
-    type: daemon
-    expected_hb_seconds: 180
-    owner_module: apps/mata-garuda/scripts/run_bridge_adaptive.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: mini
-      label: com.matagaruda.bridge.adaptive
-    severity_on_silence: error
-    cicatrix_refs: []
-    duplicates_id: mata_garuda.bridge_adaptive.pro
-  - id: mata_garuda.sentinel_daily.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/mata-garuda/scripts/run_sentinel.py
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.sentinel.daily
-    severity_on_silence: warning
-    cicatrix_refs: []
-    duplicates_id: mata_garuda.sentinel_daily.mini
   - id: mata_garuda.sentinel_daily.mini
     runtime: mini_launchd
     type: cron
@@ -669,22 +563,6 @@ organs:
       label: com.matagaruda.sentinel.daily
     severity_on_silence: warning
     cicatrix_refs: []
-    duplicates_id: mata_garuda.sentinel_daily.pro
-  - id: mata_garuda.intel_bridge_daily.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/mata-garuda/scripts/run_intel_bridge.py
-    dependencies:
-      - infra.redis
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.intel-bridge.daily
-    severity_on_silence: warning
-    cicatrix_refs: []
-    duplicates_id: mata_garuda.intel_bridge_daily.mini
   - id: mata_garuda.intel_bridge_daily.mini
     runtime: mini_launchd
     type: cron
@@ -699,7 +577,6 @@ organs:
       label: com.matagaruda.intel-bridge.daily
     severity_on_silence: warning
     cicatrix_refs: []
-    duplicates_id: mata_garuda.intel_bridge_daily.pro
   - id: mata_garuda.daily_briefing.pro
     runtime: pro_launchd
     type: cron
@@ -714,22 +591,6 @@ organs:
       label: com.matagaruda.daily-briefing
     severity_on_silence: warning
     cicatrix_refs: []
-    duplicates_id: mata_garuda.daily_briefing.mini
-  - id: mata_garuda.daily_briefing.mini
-    runtime: mini_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/mata-garuda/scripts/run_daily_briefing.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: mini
-      label: com.matagaruda.daily-briefing
-    severity_on_silence: warning
-    cicatrix_refs: []
-    duplicates_id: mata_garuda.daily_briefing.pro
   - id: mata_garuda.kita_feed_daily.pro
     runtime: pro_launchd
     type: cron
@@ -741,25 +602,9 @@ organs:
     recovery_action: launchctl_kickstart
     recovery_params:
       host: pro
-      label: com.matagaruda.kita-feed.daily
+      label: com.matagaruda.kita-feed
     severity_on_silence: warning
     cicatrix_refs: []
-    duplicates_id: mata_garuda.kita_feed_daily.mini
-  - id: mata_garuda.kita_feed_daily.mini
-    runtime: mini_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/mata-garuda/scripts/run_kita_feed.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: mini
-      label: com.matagaruda.kita-feed.daily
-    severity_on_silence: warning
-    cicatrix_refs: []
-    duplicates_id: mata_garuda.kita_feed_daily.pro
   - id: mata_garuda.public_channel.pro
     runtime: pro_launchd
     type: cron
@@ -774,22 +619,6 @@ organs:
       label: com.matagaruda.public-channel
     severity_on_silence: warning
     cicatrix_refs: []
-    duplicates_id: mata_garuda.public_channel.mini
-  - id: mata_garuda.public_channel.mini
-    runtime: mini_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/mata-garuda/scripts/run_public_channel.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: mini
-      label: com.matagaruda.public-channel
-    severity_on_silence: warning
-    cicatrix_refs: []
-    duplicates_id: mata_garuda.public_channel.pro
   - id: mata_garuda.weekly_digest.pro
     runtime: pro_launchd
     type: cron
@@ -804,22 +633,6 @@ organs:
       label: com.matagaruda.weekly-digest
     severity_on_silence: warning
     cicatrix_refs: []
-    duplicates_id: mata_garuda.weekly_digest.mini
-  - id: mata_garuda.weekly_digest.mini
-    runtime: mini_launchd
-    type: cron
-    expected_hb_seconds: 691200
-    owner_module: apps/mata-garuda/scripts/run_weekly_digest.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: mini
-      label: com.matagaruda.weekly-digest
-    severity_on_silence: warning
-    cicatrix_refs: []
-    duplicates_id: mata_garuda.weekly_digest.pro
   - id: mata_garuda.gap_consumer.pro
     runtime: pro_launchd
     type: cron
@@ -834,22 +647,6 @@ organs:
       label: com.matagaruda.gap.consumer
     severity_on_silence: warning
     cicatrix_refs: []
-    duplicates_id: mata_garuda.gap_consumer.mini
-  - id: mata_garuda.gap_consumer.mini
-    runtime: mini_launchd
-    type: cron
-    expected_hb_seconds: 4200
-    owner_module: apps/mata-garuda/mata_garuda/workers/gap_consumer.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: mini
-      label: com.matagaruda.gap.consumer
-    severity_on_silence: warning
-    cicatrix_refs: []
-    duplicates_id: mata_garuda.gap_consumer.pro
   - id: mata_garuda.invalidation_sweep.pro
     runtime: pro_launchd
     type: cron

--- a/apps/organism/tests/test_genome_no_active_active.py
+++ b/apps/organism/tests/test_genome_no_active_active.py
@@ -1,0 +1,128 @@
+"""W2-C: Guard against active-active enrollment regressions in genome.yaml.
+
+Cicatrix ref: STRUCTURAL P1 in `.claude/rules/cicatrix-scars.md` line 8 —
+13 launchd labels firing simultaneously on Pro + Mini. Once the cleanup PR
+ships (this one), no `recovery_params.label` should appear with both
+`host: pro` AND `host: mini`. An empty whitelist enforces that.
+
+If a future organ legitimately requires active-active enrollment (e.g.
+leader-election with explicit dedup), add the label to ACTIVE_ACTIVE_WHITELIST
+with a justification comment. The current state is "no whitelist needed".
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+import yaml
+
+GENOME_YAML = Path(__file__).resolve().parents[1] / "organism" / "genome.yaml"
+
+
+# Whitelist of labels intentionally enrolled active-active.
+# Empty by design — anything sharing host: pro AND host: mini fails CI.
+ACTIVE_ACTIVE_WHITELIST: set[str] = set()
+
+
+def _load_organs() -> list[dict]:
+    """Load the 'organs' list from genome.yaml.
+
+    We load the file as raw YAML (without the project's ``Genome.from_yaml``
+    helper) to keep the test free of import-time dependencies and to make
+    failures point at the YAML directly.
+    """
+    with GENOME_YAML.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    if not isinstance(data, dict):
+        pytest.fail(f"genome.yaml root is not a mapping: {type(data).__name__}")
+
+    organs = data.get("organs")
+    if not isinstance(organs, list):
+        pytest.fail("genome.yaml missing 'organs' list at top level")
+
+    return organs
+
+
+def _label_host_pairs(organs: list[dict]) -> dict[str, set[str]]:
+    """Return mapping of recovery_params.label -> set of hosts seen.
+
+    Only entries that have BOTH ``recovery_params.label`` AND
+    ``recovery_params.host`` are considered — those are the ones the
+    Supervisor's launchctl_kickstart action consumes.
+    """
+    by_label: dict[str, set[str]] = defaultdict(set)
+    for entry in organs:
+        if not isinstance(entry, dict):
+            continue
+        rp = entry.get("recovery_params") or {}
+        if not isinstance(rp, dict):
+            continue
+        label = rp.get("label")
+        host = rp.get("host")
+        if not isinstance(label, str) or not isinstance(host, str):
+            continue
+        by_label[label].add(host)
+    return by_label
+
+
+def test_genome_yaml_loads_cleanly():
+    """Sanity guard: malformed YAML would silently skip the next test."""
+    organs = _load_organs()
+    assert organs, "expected non-empty organs list"
+
+
+def test_no_active_active_enrollment_outside_whitelist():
+    """Fail if any recovery_params.label appears with both pro and mini hosts.
+
+    The 13 mata_garuda labels were ratified by Zero into single-host
+    enrollment per W2-C decision matrix. Any regression (a future PR that
+    re-introduces a ``host: mini`` entry for a Pro-canonical label, or vice
+    versa) must surface here — that's the whole point of the test.
+    """
+    organs = _load_organs()
+    by_label = _label_host_pairs(organs)
+
+    offenders: list[tuple[str, set[str]]] = []
+    for label, hosts in by_label.items():
+        if "pro" in hosts and "mini" in hosts and label not in ACTIVE_ACTIVE_WHITELIST:
+            offenders.append((label, hosts))
+
+    if offenders:
+        msg = (
+            "Active-active enrollment detected (cicatrix STRUCTURAL P1 regression).\n"
+            "Each label below has BOTH host:pro AND host:mini entries in genome.yaml.\n"
+            "Either drop one host or add the label to ACTIVE_ACTIVE_WHITELIST with "
+            "a justification.\n\n"
+            + "\n".join(f"  - {label}: hosts={sorted(hosts)}" for label, hosts in offenders)
+        )
+        pytest.fail(msg)
+
+
+def test_whitelist_entries_are_actually_dual_host():
+    """If a label is whitelisted, it must currently appear on BOTH hosts.
+
+    Stale whitelist entries (label removed from genome.yaml but kept in
+    the whitelist) would silently mask future regressions. This test
+    keeps the whitelist tight.
+    """
+    if not ACTIVE_ACTIVE_WHITELIST:
+        pytest.skip("whitelist empty — nothing to validate")
+
+    organs = _load_organs()
+    by_label = _label_host_pairs(organs)
+
+    stale = []
+    for label in ACTIVE_ACTIVE_WHITELIST:
+        hosts = by_label.get(label, set())
+        if not ("pro" in hosts and "mini" in hosts):
+            stale.append((label, sorted(hosts)))
+
+    if stale:
+        msg = (
+            "Whitelist contains stale entries no longer dual-host in genome.yaml:\n"
+            + "\n".join(f"  - {label}: hosts={hosts}" for label, hosts in stale)
+        )
+        pytest.fail(msg)

--- a/docs/superpowers/plans/2026-05-07-mata-garuda-active-active-cleanup.md
+++ b/docs/superpowers/plans/2026-05-07-mata-garuda-active-active-cleanup.md
@@ -1,0 +1,152 @@
+# W2-C Mata Garuda Active-Active Cleanup Plan
+
+**Date:** 2026-05-07
+**Branch:** `feat/mata-garuda-active-active-cleanup-2026-05-07`
+**Cicatrix:** STRUCTURAL P1 — 13 launchd labels active-active Pro+Mini
+**Reference:** `.claude/rules/cicatrix-scars.md` line 8
+
+## Decision Map (Zero-ratified, NOT for relitigation)
+
+| Label (filename basis) | Canonical Side | Losing Side | Rationale |
+|---|---|---|---|
+| `com.matagaruda.intel-bridge.daily` | Mini | Pro | Mini = OSINT producer (Modo B) |
+| `com.matagaruda.sentinel.daily` | Mini | Pro | Sentinel = OSINT layer 1 |
+| `com.matagaruda.reg-alert.30min` | Pro | Mini | Telegram bot token Pro |
+| `com.matagaruda.kg-linker` | Pro | Mini | Postgres KG locale Pro |
+| `com.matagaruda.wr-topic` | Pro | Mini | WR2 producer suite Pro |
+| `com.matagaruda.wr2-bridge.hourly` | Pro | Mini | WR2 producer suite Pro |
+| `com.matagaruda.bridge.adaptive` | Pro | Mini | Mediator MCP Pro |
+| `com.matagaruda.daily-briefing` | Pro | Mini | Telegram delivery Pro |
+| `com.matagaruda.kita-feed.daily` | Pro | Mini | kita.balizero.com Vercel deploy Pro |
+| `com.matagaruda.public-channel` | Pro | Mini | Outbound socials Pro orchestrator |
+| `com.matagaruda.weekly-digest` | Pro | Mini | Telegram delivery Pro |
+| `com.matagaruda.gap.consumer` | Pro | Mini | KG gaps consumer Pro |
+| `com.matagaruda.watcher.daily` | Pro | Mini | Generic watchdog Pro |
+
+**Target state:** 2 labels Mini-only (intel-bridge, sentinel), 11 labels Pro-only.
+
+## Validation Findings
+
+### Label/Filename Discrepancy
+
+Two plist files have an internal `Label` key that differs from the filename:
+- `com.matagaruda.kita-feed.daily.plist` → Label = `com.matagaruda.kita-feed`
+- `com.matagaruda.wr2-bridge.hourly.plist` → Label = `com.matagaruda.wr2-bridge`
+
+`launchctl bootout` requires the **actual Label** (what `launchctl list` shows), NOT the filename.
+However, `genome.yaml` references the **filename-style label** (e.g., `com.matagaruda.kita-feed.daily`).
+This means:
+- bootout target: actual Label key (from `PlistBuddy -c "Print :Label"`)
+- genome.yaml drop target: filename-style (matches existing entries verbatim)
+
+### File Mode Hardening (Cicatrix 2026-04-29 P0-3)
+
+All project plist files are now `chmod 0444` (readonly). Before `rm`, must `chmod u+w "$plist"` first.
+
+### SMOKE Check Results (2026-05-07)
+
+Pro launchctl list shows 13/13 mata_garuda doubled labels.
+Mini launchctl list (via SSH `ssh mini`) shows same 13/13 doubled labels.
+SSH to Mini reachable via mDNS or Tailscale alias.
+
+## Execution Plan
+
+### Phase 1: Test-First (TDD)
+
+1. Create `apps/organism/tests/test_genome_no_active_active.py`:
+   - Parse `apps/organism/organism/genome.yaml`
+   - Group entries by `recovery_params.label`
+   - Fail if any label appears with both `host: pro` AND `host: mini`
+   - Whitelist parameter (empty by default — anything failing is a regression)
+2. Run pytest — expect 13 failures (current state).
+
+### Phase 2: Bootout Sequence (Atomic Per Label)
+
+For each of the 13 labels, on the LOSING side:
+
+```
+LABEL=<actual launchd Label>          # e.g. com.matagaruda.kita-feed (not .daily)
+PLIST=~/Library/LaunchAgents/<filename>.plist
+UID=$(id -u)
+
+# Step 1: Backup (REQUIRED before any mutation)
+cp "$PLIST" "$PLIST.pre-W2C-2026-05-07"
+
+# Step 2: Bootout
+launchctl bootout gui/$UID/$LABEL
+
+# Step 3: Verify bootout succeeded
+launchctl print gui/$UID/$LABEL 2>&1 | grep -q "Could not find service"
+[ $? -eq 0 ] || { echo "ABORT: $LABEL still loaded"; exit 1; }
+
+# Step 4: Make plist writable (cicatrix protection chmod 0444 default)
+chmod u+w "$PLIST"
+
+# Step 5: Remove
+rm "$PLIST"
+```
+
+Atomic per label. If ANY step fails, abort and do not proceed to next label.
+
+### Phase 3: genome.yaml Edit
+
+Drop the LOSING-side entries (13 blocks, ~13-15 lines each) from `apps/organism/organism/genome.yaml`.
+
+Each block to remove follows the pattern:
+```yaml
+  - id: mata_garuda.<name>.<losing_side>
+    runtime: <pro|mini>_launchd
+    type: cron|daemon
+    expected_hb_seconds: ...
+    owner_module: ...
+    dependencies: [...]
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: <losing_side>
+      label: com.matagaruda.<label>
+    severity_on_silence: warning|error
+    cicatrix_refs: []
+    duplicates_id: mata_garuda.<name>.<canonical_side>
+```
+
+Also strip the `duplicates_id` cross-link line from the canonical-side entries (since the duplicate no longer exists).
+
+### Phase 4: CI Test Verification
+
+Run pytest again — test should now PASS (no active-active pairs).
+
+### Phase 5: Resolver Hardening (Best-Effort)
+
+Update `~/scripts/wave1-pro-mini-dup-resolver.sh` if it tracks per-label whitelists.
+This is per-machine state on Pro, not in git, so the patch is local-only.
+
+## Bootout Sequence Order
+
+Mini-canonical (remove from Pro):
+1. com.matagaruda.intel-bridge.daily
+2. com.matagaruda.sentinel.daily
+
+Pro-canonical (remove from Mini, via SSH):
+3. com.matagaruda.reg-alert.30min
+4. com.matagaruda.kg-linker
+5. com.matagaruda.wr-topic
+6. com.matagaruda.wr2-bridge (filename `wr2-bridge.hourly.plist`)
+7. com.matagaruda.bridge.adaptive
+8. com.matagaruda.daily-briefing
+9. com.matagaruda.kita-feed (filename `kita-feed.daily.plist`)
+10. com.matagaruda.public-channel
+11. com.matagaruda.weekly-digest
+12. com.matagaruda.gap.consumer
+13. com.matagaruda.watcher.daily
+
+## Rollback
+
+If a bootout fails partway:
+- All `.pre-W2C-2026-05-07` backups remain on disk
+- Restore via: `cp "$PLIST.pre-W2C-2026-05-07" "$PLIST" && launchctl bootstrap gui/$UID "$PLIST"`
+
+## Risk Assessment
+
+- **Low risk for cron labels** — double-firing is just 2× metric inflation, no data corruption (per cicatrix entry).
+- **Medium risk for `bridge.adaptive` daemon** — losing one side means the daemon only runs on Pro. If Mini was the canonical mediator, this would silently break MCP. Decision per spec: Pro is canonical. Verify post-cleanup via `launchctl list` on Pro confirms it stays loaded.
+- **No risk to gap.consumer/kg-linker** — these are Pro-only writers per spec; Mini was firing redundantly.


### PR DESCRIPTION
## Summary

Reconciles 13 launchd labels firing simultaneously on Pro and Mini (STRUCTURAL P1 cicatrix). Decision per W2-C spec ratified by Zero — 2 labels Mini-only (OSINT producer side), 11 labels Pro-only (Telegram bot, Postgres KG, WR2 producers, kita.balizero.com deploy, outbound socials).

- **13 plists removed**: 2 on Pro (intel-bridge.daily, sentinel.daily), 11 on Mini (reg-alert.30min, kg-linker, wr-topic, wr2-bridge.hourly, bridge.adaptive, daily-briefing, kita-feed.daily, public-channel, weekly-digest, gap.consumer, watcher.daily). Each preserved as `.pre-W2C-2026-05-07` backup; bootout verified via `Could not find service` before `rm`.
- **`apps/organism/organism/genome.yaml`**: 13 losing-side entries dropped + `duplicates_id` stripped from canonical entries. **Fixed 2 launchd Label mismatches** discovered via Codex sandbox review — `kita-feed.daily.plist` internal Label is `com.matagaruda.kita-feed` (no `.daily` suffix); same shape for `wr2-bridge.hourly.plist`. Without this fix the Supervisor's `launchctl_kickstart` action would target non-existent services.
- **New CI test** `apps/organism/tests/test_genome_no_active_active.py` — fails if any `recovery_params.label` appears with both `host:pro` and `host:mini` outside an explicit (empty) whitelist, plus a stale-whitelist guard. TDD: was RED with 13 offenders before the edit, now GREEN.
- **Plan doc** at `docs/superpowers/plans/2026-05-07-mata-garuda-active-active-cleanup.md` with decision matrix, validation findings (label/filename discrepancy, plist 0444 hardening from cicatrix 2026-04-29), and per-label bootout sequence.
- **Out of git**: `~/scripts/wave1-pro-mini-dup-resolver.sh` PROTECTED list extended on Pro to cover the 11 Pro-canonical labels (Pro-local script, not in repo).

## Test plan

- [x] `apps/organism/tests/test_genome_no_active_active.py` (3 tests, 2 passed + 1 skipped — whitelist empty)
- [x] `apps/organism/tests/test_schemas.py` regression (4/4 still passing)
- [x] Empirical: `launchctl list | grep matagaruda` on both nodes shows expected 14 (Pro) and 5 (Mini) labels post-cleanup
- [x] All 13 bootouts produced `Could not find service` post-bootout (no silent failures)
- [x] All 13 plists have `.pre-W2C-2026-05-07` backup on disk
- [ ] Required CI checks (E2E + MCP + Frontend + Detect Secrets) pass

Refs: STRUCTURAL P1 cicatrix `2026-05-07: 12+1 mata_garuda LaunchAgents active-active Pro+Mini`. Symbiosis W2 wave-2 target W2-C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)