### PR TITLE
feat(cell-core): SENSE OutboxSensor + THINK RuleBasedThinker (Wave 2 [1/2])

### DIFF
--- a/docs/superpowers/plans/2026-05-07-cell-core-pulse-activate.md
+++ b/docs/superpowers/plans/2026-05-07-cell-core-pulse-activate.md
@@ -1,0 +1,183 @@
+# Plan — W2-D Cell-Core PulseLoop Activation (FASE 3 Symbiosis Turn-On)
+
+**Date:** 2026-05-07
+**Branch:** `feat/cell-core-pulse-activate-2026-05-07`
+**Doctrine ref:** PR #479 §FASE 3 (cell-core PulseLoop currently ~10% active, target 100%)
+**Sub-session:** W2-D parallel wave (file scope: `apps/cell/`, `packages/cell-core/`)
+
+## Existing State (~10% active assessment)
+
+The state machine SENSE→THINK→ACT→REFLECT→DREAM→MATURE is already implemented
+in `packages/cell-core/cell_core/pulse.py` (321 lines). 14 unit tests pass.
+What is NOT yet wired:
+
+1. **MATURE phase does NOT call `genome.promote_skills()`** — skill graduation
+   (tier2 ≥ 30 uses + 0.70 confidence; tier1 ≥ 100 uses + 0.85 confidence)
+   defined in `cell_core/genome.py` but never invoked from PulseLoop.
+2. **REFLECT phase does NOT record reflection into Genome** — episodes go to
+   episodic store only, no `record_skill(type='insight')` after success.
+3. **No event-stream sensor** for `events_outbox` PG durable bus — required
+   per task spec for SENSE step.
+4. **No daemon entrypoint** for cell-core PulseLoop standalone (the existing
+   `apps/cell/cell/main.py` runs the older `PulseEngine`, not `PulseLoop`).
+5. **No graceful Ollama-down rule-based classifier fallback** in the THINK
+   path of the canonical PulseLoop.
+
+## Schema Divergence Note
+
+Task spec describes separate SQLite tables `skills`, `reflections`, `insights`
+with graduation rule. Repo reality (canonical):
+
+* Single `genome` table at `~/.cell/genome.db` with `type` discriminator
+  (`skill | pattern | scar | insight | trajectory`) — `cell_core/genome.py`.
+* Graduation via `tier` column (`NULL → tier2 → tier1`) using thresholds
+  `TIER2_MIN_USES=30 / TIER2_MIN_CONFIDENCE=0.70` and
+  `TIER1_MIN_USES=100 / TIER1_MIN_CONFIDENCE=0.85`.
+
+**Decision:** implement against existing schema (Option A per task brief).
+Map task-spec semantics to repo:
+
+| Task spec       | Repo reality                                        |
+| --------------- | --------------------------------------------------- |
+| skills          | `genome` rows where `type='skill'`                  |
+| reflections     | `genome` rows where `type='trajectory'` (episodes)  |
+| insights        | `genome` rows where `type='insight'`                |
+| graduated skill | `genome.tier='tier1'` (top tier)                    |
+
+The "reflection ≥3 → insight; insight ≥2 + score ≥0.7 → graduated" rule maps
+cleanly to existing `promote_skills` thresholds; the Genome already enforces
+monotonic promotion. We add a thin `mature_skills()` that invokes
+`promote_skills()` on a cadence and persists telemetry into the cell journal.
+
+## SMOKE Findings
+
+* **Genome SQLite** — `~/.cell/genome.db` does **NOT** exist on Pro yet.
+  Genome class auto-creates on first instantiation. We will create on demand
+  inside the daemon entrypoint (test will use temp file).
+* **Ollama** — `ollama serve` is **DOWN** at smoke time (`ollama list` →
+  "could not connect"). Per spec Law 4, PulseLoop must degrade. Existing
+  `cell_core.pulse` has graceful behavior: thinker is injected via Protocol;
+  if no real thinker is configured, FakeThinker / rule-based stays in path.
+* **Redis** — UP (`redis-cli ping → PONG`).
+* **events_outbox** — table is created by SQL migration 144 (verified live
+  on prod), schema in `apps/backend-rag/backend/services/events/outbox.py`
+  with columns `(id BIGSERIAL, channel, payload JSONB, created_at,
+  consumed_at, consumer_id)`.
+* **Import** — `from cell_core.pulse import PulseLoop` works under py3.11.
+* **Existing tests** — 14/14 pass on `tests/test_pulse.py` (cell-core).
+
+## Codex Review Adjustments (2026-05-07)
+
+Codex sandbox review flagged 4 P1s (no P0). All addressed below:
+
+1. **`record_skill` kwarg is `entry_type`, not `type`.** Plan now uses
+   `entry_type='skill'` for graduation candidates.
+2. **`promote_skills()` only promotes `type='skill'` rows.** REFLECT MUST
+   record actual skill rows (with `entry_type='skill'`) and `use_skill()`
+   to bump `uses`. Trajectories are recorded separately for audit; only
+   skill rows reach graduation.
+3. **`memory_sqlite._get_conn()` lacks `busy_timeout`.** We add it inside
+   the daemon entrypoint immediately after instantiation via a small
+   helper that invokes `PRAGMA busy_timeout=5000` on the connection,
+   matching Genome's setting. Tests verify the pragma is set.
+4. **Pulse phases must catch `sqlite3.OperationalError` and degrade.**
+   Each phase wraps the SQLite touch in `try/except OperationalError →
+   log + record yellow status`, never aborts the pulse. DREAM is bounded
+   (max 50 episodes) and on lock error returns yellow rather than crashing.
+5. **Daemon must lazy-connect Redis/PG/Ollama and swallow startup errors.**
+   The entrypoint connects on first use, every helper has a NoOp fallback
+   when the dependency is unreachable at boot.
+
+## Implementation Plan (TDD per state)
+
+### State 1 — SENSE (event-bus sensor)
+
+* `cell_core/sensors/outbox_sensor.py` — new sensor reading from PG
+  `events_outbox` (last N unconsumed rows for one or more channels). Uses
+  asyncpg if available; degrades gracefully when `db_pool=None`.
+* Tests: empty bus → green, populated → yellow with metadata, DB unreachable
+  → red but no crash (Law 4 isolation).
+
+### State 2 — THINK (rule-based classifier with optional Ollama)
+
+* `cell_core/thinkers/rule_based.py` — concrete Thinker that classifies a
+  reading into a proposed action using a simple rule table (severity →
+  action). Implements the `Thinker` Protocol.
+* `cell_core/thinkers/ollama_aware.py` — wraps RuleBasedThinker; tries Ollama
+  first with a 2s timeout, falls back to rules on timeout/error/down.
+  Documents Ollama-not-real-time-critical constraint.
+* Tests: rule-based output deterministic; Ollama unreachable → rule fallback
+  fires; Ollama timeout → rule fallback fires.
+
+### State 3 — ACT (already implemented)
+
+PulseLoop.act() already gates on `lifecycle.action_confidence_threshold()`
+and `actor.can_execute()`. Only addition: a guard test ensuring an Actor
+that raises does not crash the loop.
+
+### State 4 — REFLECT (Genome write)
+
+* Extend PulseLoop with optional `genome` parameter (already in constructor)
+  and a new `_reflect_to_genome()` helper that calls
+  `genome.record_skill(type='trajectory', ...)` on every reflection-worthy
+  pulse. Thin layer; no behavior change when `genome=None`.
+* Tests: reflection-worthy pulse writes a trajectory row; non-worthy pulse
+  does not; genome=None → no crash, no write.
+
+### State 5 — DREAM (already implemented; add genome metric)
+
+PulseLoop.DREAM already condenses episodic → LTM rules. Add an optional
+`_dream_metric_to_genome()` that records the day's dream summary as a row
+of `type='insight'` in Genome (precondition=dream_date, procedure=summary,
+confidence=0.5 default). Tests cover write + skip-when-no-genome.
+
+### State 6 — MATURE (skill graduation)
+
+Add `_mature_skills()` step that runs at most once per pulse-window
+(every 60 pulses by default to match the existing LTM-cache cadence). It
+calls `genome.promote_skills()` and emits the result as a metric. Tests:
+runs only on cadence, no-op on idle DB, returns count.
+
+## Daemon Entrypoint
+
+* `apps/cell/scripts/run_pulse_loop.py` — new CLI that wires:
+  - SQLite Genome at `~/.cell/genome.db`
+  - SqliteSTM/SqliteEpisodic/SqliteLTM at the same DB
+  - OutboxSensor (DSN from env), HealthSensor (existing)
+  - OllamaAwareRuleBasedThinker (env: OLLAMA_URL, OLLAMA_MODEL=qwen3.5:9b)
+  - SafetyGate stub (Redis kill-switch, degrade-open)
+  - PulseLoop with `metrics=None` for v0.
+  - 3-cycle smoke harness: `--smoke 3` runs three cycles and prints Genome
+    counts to stdout.
+
+## LaunchAgent (post-merge step, NOT bootstrapped from PR)
+
+`apps/cell/com.cell.organism.pulse.daemon.plist` (mode 0444 per cicatrix
+P0-3): KeepAlive=true, RunAtLoad=true, ProgramArguments pointing at the
+new CLI. Bootstrap step left for the operator after PR merge.
+
+## Test Coverage Target
+
+* ≥85% on the new modules. Unit tests per state transition (sense→think,
+  think→act, act→reflect, reflect→dream, dream→mature). Integration test
+  full cycle in-memory using temp-file SQLite. Live smoke test on Pro
+  using `--smoke 3`.
+
+## Constraints Honored
+
+* **No `ANTHROPIC_API_KEY`, no `pip install anthropic`, no Anthropic SDK
+  imports.** Ollama for local LLM; rule-based fallback when Ollama down.
+* **Genome SQLite WAL** — already enabled by `cell_core.genome.Genome`
+  (`PRAGMA journal_mode=WAL` + `busy_timeout=5000`).
+* **Symbiosis Law 4** — outbox sensor degrades gracefully (PG down →
+  yellow, never crash).
+* **WIP commit cadence** — every state gets its own commit + push.
+* **Branch hijack antibody** — verify branch before each Edit/Write.
+* **Atomic git add+commit+push <30s** between writes.
+
+## Out-of-Scope (Wave 3)
+
+* HGT Pro↔Mini (`cell_core/hgt/`)
+* Cell observatory dashboard
+* Telegram CMD interface
+* Replacing the older `PulseEngine` in `apps/cell/cell/main.py` (separate PR)

--- a/packages/cell-core/cell_core/sensors/__init__.py
+++ b/packages/cell-core/cell_core/sensors/__init__.py
@@ -1,0 +1,15 @@
+"""Concrete sensors for cell-core PulseLoop.
+
+Sensors must implement the ``cell_core.protocols.Sensor`` Protocol:
+they expose a ``name`` attribute and an async ``read(**context)`` method
+returning a ``SensorReading``.
+
+All sensors here degrade gracefully (Symbiosis Law 4) — when their
+upstream dependency is unreachable they return a yellow/red reading
+with metadata, never raise.
+"""
+from __future__ import annotations
+
+from cell_core.sensors.outbox_sensor import OutboxSensor
+
+__all__ = ["OutboxSensor"]

--- a/packages/cell-core/cell_core/sensors/outbox_sensor.py
+++ b/packages/cell-core/cell_core/sensors/outbox_sensor.py
@@ -1,0 +1,144 @@
+"""OutboxSensor — perceives durable EventBus pressure.
+
+Reads the count of unconsumed rows in the PostgreSQL ``events_outbox``
+table (migration 144) so the cell can sense when the bus is backed up.
+
+Status mapping (defaults):
+* 0 unconsumed rows → green
+* 1..red_threshold-1 → yellow
+* ≥ red_threshold → red
+
+Symbiosis Law 4: when the database is unreachable (or no pool is
+configured), the sensor returns *yellow* with error metadata. It never
+raises; cells must keep pulsing on other sensors.
+
+The constructor takes a ``pool_factory`` callable so the daemon can lazy
+connect once asyncpg is available. ``pool_factory()`` may return ``None``
+or any object with an ``acquire`` async context manager that yields a
+connection exposing ``fetchval(query, *params)``.
+"""
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from cell_core.types import SensorReading
+
+logger = logging.getLogger("cell_core.sensors.outbox")
+
+# Default count threshold for red severity. Operators can override to
+# match their consumer throughput; 100 is a conservative starting point
+# matching the EventBus phase-1 lag alert in the fly_watcher script.
+_DEFAULT_RED_THRESHOLD = 100
+
+_QUERY_ALL = "SELECT COUNT(*) FROM events_outbox WHERE consumed_at IS NULL"
+_QUERY_PER_CHANNEL = (
+    "SELECT COUNT(*) FROM events_outbox "
+    "WHERE consumed_at IS NULL AND channel = $1"
+)
+
+
+class OutboxSensor:
+    """Reads ``events_outbox`` lag from PostgreSQL.
+
+    Args:
+        pool_factory: Zero-arg callable returning the asyncpg pool (or
+            None when not yet connected). Called on every read so the
+            daemon can recover from a transient PG outage between
+            pulses without re-instantiating the sensor.
+        channel: Optional PG channel name (e.g. ``practice_changed``)
+            to scope the count. If None, counts across all channels.
+        red_threshold: Lag count at which status escalates to red.
+        name: Sensor name (default ``outbox``).
+    """
+
+    def __init__(
+        self,
+        pool_factory: Callable[[], Any | None],
+        channel: str | None = None,
+        red_threshold: int = _DEFAULT_RED_THRESHOLD,
+        name: str = "outbox",
+    ) -> None:
+        self._pool_factory = pool_factory
+        self._channel = channel
+        self._red_threshold = red_threshold
+        self.name = name
+
+    async def read(self, **_context: Any) -> SensorReading:
+        """Read the current lag and return a SensorReading.
+
+        Never raises. PG-down or pool=None → yellow with error metadata.
+        """
+        pool = self._pool_factory()
+        if pool is None:
+            return SensorReading(
+                sensor_name=self.name,
+                status="yellow",
+                metadata={
+                    "error": "no pool configured (PG unreachable at boot?)",
+                    "channel": self._channel,
+                },
+            )
+
+        try:
+            count = await self._fetch_count(pool)
+        except Exception as exc:  # noqa: BLE001 - sensor must never crash PulseLoop
+            logger.warning(
+                "OutboxSensor: PG unreachable, degrading to yellow: %s", exc
+            )
+            return SensorReading(
+                sensor_name=self.name,
+                status="yellow",
+                metadata={
+                    "error": str(exc),
+                    "channel": self._channel,
+                },
+            )
+
+        if count <= 0:
+            status = "green"
+        elif count >= self._red_threshold:
+            status = "red"
+        else:
+            status = "yellow"
+
+        return SensorReading(
+            sensor_name=self.name,
+            status=status,
+            value=count,
+            metadata={
+                "unconsumed_count": count,
+                "channel": self._channel,
+                "red_threshold": self._red_threshold,
+            },
+        )
+
+    async def _fetch_count(self, pool: Any) -> int:
+        """Run COUNT(*) against events_outbox using the supplied pool.
+
+        Accepts either:
+        * an ``acquire()`` async context manager yielding a connection
+          with ``fetchval(query, *params)`` (asyncpg shape), or
+        * a pool exposing ``fetchval`` directly (test fakes).
+        """
+        if self._channel is not None:
+            query = _QUERY_PER_CHANNEL
+            params: tuple[Any, ...] = (self._channel,)
+        else:
+            query = _QUERY_ALL
+            params = ()
+
+        # Prefer the acquire-based path because asyncpg recommends it.
+        if hasattr(pool, "acquire"):
+            async with pool.acquire() as conn:
+                result = conn.fetchval(query, *params)
+                if isinstance(result, Awaitable):
+                    result = await result
+                return int(result or 0)
+
+        # Fallback for fakes that expose fetchval directly.
+        result = pool.fetchval(query, *params)
+        if isinstance(result, Awaitable):
+            result = await result
+        return int(result or 0)

--- a/packages/cell-core/cell_core/thinkers/__init__.py
+++ b/packages/cell-core/cell_core/thinkers/__init__.py
@@ -1,0 +1,23 @@
+"""Concrete Thinker implementations for cell-core PulseLoop.
+
+A Thinker satisfies ``cell_core.protocols.Thinker``: given sensor readings,
+homeostatic state, and a memory context, it proposes an action.
+
+The two thinkers shipped here:
+
+* :class:`RuleBasedThinker` — deterministic rule table. Zero LLM cost,
+  zero latency, zero dependencies. Always available.
+* :class:`OllamaAwareThinker` — wraps a delegate (typically a more
+  expressive Ollama-backed thinker). Adds graceful degradation: if the
+  delegate raises or times out, falls back to the rule-based thinker.
+
+Per project Cost constraint and Symbiosis Law 4, Ollama is **never** in
+the critical path. Rule-based output is the source of truth; Ollama
+output, when available, only enriches it.
+"""
+from __future__ import annotations
+
+from cell_core.thinkers.ollama_aware import OllamaAwareThinker
+from cell_core.thinkers.rule_based import RuleBasedThinker
+
+__all__ = ["RuleBasedThinker", "OllamaAwareThinker"]

--- a/packages/cell-core/cell_core/thinkers/ollama_aware.py
+++ b/packages/cell-core/cell_core/thinkers/ollama_aware.py
@@ -1,0 +1,83 @@
+"""OllamaAwareThinker — graceful Ollama wrapper for any Thinker.
+
+Implements ``cell_core.protocols.Thinker``. Tries the delegate (typically
+an Ollama-backed thinker) with a hard timeout. On timeout / exception
+falls back to a configured fallback Thinker (default: RuleBasedThinker).
+
+Why a wrapper, not a flag inside the Ollama thinker:
+* Keeps the Ollama logic free of fallback bookkeeping.
+* Lets callers compose any "expensive" thinker with any "cheap" fallback
+  without touching either.
+* Symbiosis Law 4 — the fallback is structural, not opt-in.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from cell_core.protocols import Thinker
+from cell_core.thinkers.rule_based import RuleBasedThinker
+from cell_core.types import HomeostaticState, Proposal, SensorReading
+
+logger = logging.getLogger("cell_core.thinkers.ollama_aware")
+
+_DEFAULT_TIMEOUT_SECONDS = 2.0
+
+
+class OllamaAwareThinker:
+    """Compose an expensive primary thinker with a cheap fallback.
+
+    Args:
+        primary: The expensive thinker (e.g. Ollama-backed).
+        fallback: The cheap deterministic thinker. Defaults to
+            :class:`RuleBasedThinker`.
+        timeout_seconds: Hard timeout for the primary call. Defaults
+            to 2 s — keeps the THINK phase well under the 30-120 s
+            Ollama latency upper bound and well below the 60 s pulse
+            interval. Per project rule, Ollama is NEVER in the critical
+            decisional path.
+    """
+
+    name = "ollama_aware"
+
+    def __init__(
+        self,
+        primary: Thinker | None,
+        fallback: Thinker | None = None,
+        timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self._primary = primary
+        self._fallback = fallback or RuleBasedThinker()
+        self._timeout = timeout_seconds
+
+    async def think(
+        self,
+        readings: list[SensorReading],
+        state: HomeostaticState,
+        memory_context: dict[str, Any],
+    ) -> Proposal:
+        # No primary configured → straight to fallback.
+        if self._primary is None:
+            return await self._fallback.think(readings, state, memory_context)
+
+        try:
+            return await asyncio.wait_for(
+                self._primary.think(readings, state, memory_context),
+                timeout=self._timeout,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "OllamaAwareThinker: primary timed out after %.1fs, "
+                "falling back to %s",
+                self._timeout,
+                getattr(self._fallback, "name", "fallback"),
+            )
+            return await self._fallback.think(readings, state, memory_context)
+        except Exception as exc:  # noqa: BLE001 - any failure must fall back
+            logger.warning(
+                "OllamaAwareThinker: primary raised %s, falling back to %s",
+                type(exc).__name__,
+                getattr(self._fallback, "name", "fallback"),
+            )
+            return await self._fallback.think(readings, state, memory_context)

--- a/packages/cell-core/cell_core/thinkers/rule_based.py
+++ b/packages/cell-core/cell_core/thinkers/rule_based.py
@@ -1,0 +1,108 @@
+"""RuleBasedThinker — zero-dependency, zero-latency Thinker.
+
+Implements the ``cell_core.protocols.Thinker`` Protocol. Maps the worst
+sensor status (and optionally the originating sensor name) into a
+hardcoded action proposal. No LLM, no I/O.
+
+Used both as the cell's primary classifier when Ollama is unavailable
+(Symbiosis Law 4) and as the fallback wrapped by ``OllamaAwareThinker``.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from cell_core.types import HomeostaticState, Proposal, SensorReading
+
+# ──────────────────────────────────────────────────────────────────
+# Constants — kept private and module-level so callers can patch
+# them in tests if domain-specific tuning is needed.
+# ──────────────────────────────────────────────────────────────────
+
+_HIGH_STRESS_THRESHOLD = 0.8
+_STATUS_RANK = {"green": 0, "yellow": 1, "red": 2}
+
+# Domain-specific routes: when a sensor with a known name is the worst
+# offender, suggest a more specific action than the generic alert_*.
+_RED_DOMAIN_ACTIONS = {
+    "outbox": "drain_outbox",
+    "ollama": "ollama_restart",
+    "backup": "run_backup",
+}
+
+
+class RuleBasedThinker:
+    """Deterministic Thinker."""
+
+    name = "rule_based"
+
+    async def think(
+        self,
+        readings: list[SensorReading],
+        state: HomeostaticState,
+        memory_context: dict[str, Any],
+    ) -> Proposal:
+        worst = self._worst_status(readings)
+        worst_sensor = self._worst_sensor_name(readings, worst)
+
+        # All-green path: nothing to do.
+        if worst == "green":
+            return Proposal(
+                action="none",
+                reason="all sensors green",
+                confidence=0.5,
+                tier_used=0,
+            )
+
+        # High-stress override: any non-green signal escalates to human.
+        if state.stress_level >= _HIGH_STRESS_THRESHOLD:
+            return Proposal(
+                action="alert_human",
+                reason=(
+                    f"high stress ({state.stress_level:.2f}) + "
+                    f"{worst} signal from sensor '{worst_sensor}'"
+                ),
+                confidence=0.85,
+                tier_used=0,
+            )
+
+        if worst == "red":
+            domain_action = _RED_DOMAIN_ACTIONS.get(worst_sensor)
+            if domain_action is not None:
+                return Proposal(
+                    action=domain_action,
+                    reason=(
+                        f"red signal on sensor '{worst_sensor}' → "
+                        f"{domain_action}"
+                    ),
+                    confidence=0.75,
+                    tier_used=0,
+                )
+            return Proposal(
+                action="alert_human",
+                reason=f"red signal from sensor '{worst_sensor}'",
+                confidence=0.80,
+                tier_used=0,
+            )
+
+        # worst == "yellow"
+        return Proposal(
+            action="alert_silent",
+            reason=f"yellow signal from sensor '{worst_sensor}'",
+            confidence=0.55,
+            tier_used=0,
+        )
+
+    @staticmethod
+    def _worst_status(readings: list[SensorReading]) -> str:
+        if not readings:
+            return "green"
+        return max(readings, key=lambda r: _STATUS_RANK.get(r.status, 0)).status
+
+    @staticmethod
+    def _worst_sensor_name(
+        readings: list[SensorReading], worst: str
+    ) -> str:
+        for r in readings:
+            if r.status == worst:
+                return r.sensor_name
+        return "unknown"

--- a/packages/cell-core/tests/sensors/test_outbox_sensor.py
+++ b/packages/cell-core/tests/sensors/test_outbox_sensor.py
@@ -1,0 +1,155 @@
+"""Tests for OutboxSensor — reads from PG events_outbox.
+
+Sensor contract:
+- name attribute
+- async read(**context) -> SensorReading
+- Symbiosis Law 4: graceful degradation when DB unreachable
+- Status mapping:
+  * 0 unconsumed rows → green
+  * 1..N (under threshold) → yellow with count metadata
+  * over threshold → red with count metadata
+  * DB unreachable → yellow with error metadata (NOT red — Cell still
+    senses other things; outbox down is a degraded but not critical state)
+"""
+from __future__ import annotations
+
+import pytest
+
+from cell_core.types import SensorReading
+
+
+# ──────────────────────────────────────────────────────────────────
+# Fakes
+# ──────────────────────────────────────────────────────────────────
+
+
+class _FakeConn:
+    def __init__(self, count: int):
+        self._count = count
+
+    async def fetchval(self, _query, *_args):
+        return self._count
+
+
+class _AcquireCM:
+    """Mimics asyncpg's ``pool.acquire()`` async context manager."""
+
+    def __init__(self, count: int, raise_on_enter: Exception | None = None):
+        self._count = count
+        self._raise = raise_on_enter
+
+    async def __aenter__(self) -> _FakeConn:
+        if self._raise is not None:
+            raise self._raise
+        return _FakeConn(self._count)
+
+    async def __aexit__(self, *_args) -> bool:
+        return False
+
+
+class _FakePool:
+    """In-memory fake of asyncpg.Pool with deterministic count."""
+
+    def __init__(self, count: int = 0, raise_on_acquire: Exception | None = None):
+        self._count = count
+        self._raise = raise_on_acquire
+
+    def acquire(self) -> _AcquireCM:
+        # asyncpg's pool.acquire() returns an awaitable that is also an
+        # async context manager. Tests use the ``async with`` form.
+        return _AcquireCM(self._count, raise_on_enter=self._raise)
+
+
+# ──────────────────────────────────────────────────────────────────
+# Tests
+# ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_outbox_sensor_protocol_compliance():
+    """OutboxSensor satisfies the Sensor Protocol."""
+    from cell_core.protocols import Sensor
+    from cell_core.sensors.outbox_sensor import OutboxSensor
+
+    sensor = OutboxSensor(pool_factory=lambda: None)
+    assert isinstance(sensor, Sensor)
+    assert sensor.name == "outbox"
+
+
+@pytest.mark.asyncio
+async def test_empty_outbox_returns_green():
+    from cell_core.sensors.outbox_sensor import OutboxSensor
+
+    pool = _FakePool(count=0)
+    sensor = OutboxSensor(pool_factory=lambda: pool)
+    reading = await sensor.read()
+
+    assert isinstance(reading, SensorReading)
+    assert reading.status == "green"
+    assert reading.metadata.get("unconsumed_count") == 0
+
+
+@pytest.mark.asyncio
+async def test_populated_outbox_returns_yellow_with_count():
+    from cell_core.sensors.outbox_sensor import OutboxSensor
+
+    pool = _FakePool(count=5)
+    sensor = OutboxSensor(pool_factory=lambda: pool)
+    reading = await sensor.read()
+
+    assert reading.status == "yellow"
+    assert reading.metadata["unconsumed_count"] == 5
+
+
+@pytest.mark.asyncio
+async def test_overflow_outbox_returns_red():
+    from cell_core.sensors.outbox_sensor import OutboxSensor
+
+    pool = _FakePool(count=500)
+    # threshold defaults to 100
+    sensor = OutboxSensor(pool_factory=lambda: pool, red_threshold=100)
+    reading = await sensor.read()
+
+    assert reading.status == "red"
+    assert reading.metadata["unconsumed_count"] == 500
+
+
+@pytest.mark.asyncio
+async def test_db_unreachable_degrades_to_yellow_no_crash():
+    """Symbiosis Law 4 — PG down → yellow with error metadata, never raises."""
+    from cell_core.sensors.outbox_sensor import OutboxSensor
+
+    err = ConnectionError("postgres unreachable")
+    pool = _FakePool(raise_on_acquire=err)
+    sensor = OutboxSensor(pool_factory=lambda: pool)
+    reading = await sensor.read()
+
+    assert reading.status == "yellow"
+    assert reading.metadata.get("error") is not None
+    assert "postgres unreachable" in reading.metadata["error"]
+
+
+@pytest.mark.asyncio
+async def test_pool_factory_returns_none_degrades_yellow():
+    """When the daemon couldn't connect at boot the factory returns None."""
+    from cell_core.sensors.outbox_sensor import OutboxSensor
+
+    sensor = OutboxSensor(pool_factory=lambda: None)
+    reading = await sensor.read()
+
+    assert reading.status == "yellow"
+    assert reading.metadata.get("error") is not None
+    assert reading.metadata.get("unconsumed_count") is None
+
+
+@pytest.mark.asyncio
+async def test_per_channel_filtering():
+    """When channel argument is provided, sensor scopes the count query."""
+    from cell_core.sensors.outbox_sensor import OutboxSensor
+
+    pool = _FakePool(count=2)
+    sensor = OutboxSensor(pool_factory=lambda: pool, channel="practice_changed")
+    reading = await sensor.read()
+
+    assert reading.status == "yellow"
+    assert reading.metadata["channel"] == "practice_changed"

--- a/packages/cell-core/tests/thinkers/test_ollama_aware.py
+++ b/packages/cell-core/tests/thinkers/test_ollama_aware.py
@@ -1,0 +1,129 @@
+"""Tests for OllamaAwareThinker — graceful Ollama wrapper."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from cell_core.types import HomeostaticState, Proposal, SensorReading
+
+
+def _state() -> HomeostaticState:
+    return HomeostaticState(
+        stress_level=0.2,
+        energy_level=0.8,
+        arousal=0.3,
+        comfort_zone=(0.0, 1.0),
+        setpoint_rt_ms=200,
+        circadian_phase="awake",
+    )
+
+
+class _RecordingThinker:
+    """Thinker that records call count and emits a fixed proposal."""
+
+    name = "primary"
+
+    def __init__(self, action: str = "magic", confidence: float = 0.95):
+        self.calls = 0
+        self._action = action
+        self._confidence = confidence
+
+    async def think(self, readings, state, memory_context):
+        self.calls += 1
+        return Proposal(
+            action=self._action,
+            reason="primary",
+            confidence=self._confidence,
+            tier_used=2,
+        )
+
+
+class _SlowThinker:
+    """Thinker that sleeps longer than the timeout."""
+
+    name = "slow"
+
+    async def think(self, readings, state, memory_context):
+        await asyncio.sleep(5.0)
+        return Proposal(action="never", reason="slow", confidence=0.0, tier_used=2)
+
+
+class _RaisingThinker:
+    name = "raising"
+
+    async def think(self, readings, state, memory_context):
+        raise ConnectionError("ollama is down")
+
+
+@pytest.mark.asyncio
+async def test_protocol_compliance():
+    from cell_core.protocols import Thinker
+    from cell_core.thinkers.ollama_aware import OllamaAwareThinker
+
+    t = OllamaAwareThinker(primary=None)
+    assert isinstance(t, Thinker)
+
+
+@pytest.mark.asyncio
+async def test_primary_used_when_responsive():
+    from cell_core.thinkers.ollama_aware import OllamaAwareThinker
+
+    primary = _RecordingThinker(action="restart_service")
+    t = OllamaAwareThinker(primary=primary)
+    readings = [SensorReading(sensor_name="health", status="red")]
+    proposal = await t.think(readings, _state(), {})
+
+    assert proposal.action == "restart_service"
+    assert primary.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_fallback_when_primary_none():
+    from cell_core.thinkers.ollama_aware import OllamaAwareThinker
+
+    t = OllamaAwareThinker(primary=None)
+    readings = [SensorReading(sensor_name="health", status="red")]
+    proposal = await t.think(readings, _state(), {})
+
+    # Default fallback is RuleBasedThinker → red without specific domain
+    # mapping yields "alert_human".
+    assert proposal.action == "alert_human"
+
+
+@pytest.mark.asyncio
+async def test_fallback_on_timeout():
+    from cell_core.thinkers.ollama_aware import OllamaAwareThinker
+
+    t = OllamaAwareThinker(primary=_SlowThinker(), timeout_seconds=0.05)
+    readings = [SensorReading(sensor_name="health", status="red")]
+    proposal = await t.think(readings, _state(), {})
+
+    # Should land in the fallback path.
+    assert proposal.action != "never"
+    assert proposal.tier_used == 0
+
+
+@pytest.mark.asyncio
+async def test_fallback_on_exception():
+    from cell_core.thinkers.ollama_aware import OllamaAwareThinker
+
+    t = OllamaAwareThinker(primary=_RaisingThinker(), timeout_seconds=2.0)
+    readings = [SensorReading(sensor_name="health", status="red")]
+    proposal = await t.think(readings, _state(), {})
+
+    # Should land in the fallback path.
+    assert proposal.tier_used == 0
+
+
+@pytest.mark.asyncio
+async def test_primary_call_counts_only_once():
+    from cell_core.thinkers.ollama_aware import OllamaAwareThinker
+
+    primary = _RecordingThinker()
+    t = OllamaAwareThinker(primary=primary)
+    readings = [SensorReading(sensor_name="health", status="green")]
+    await t.think(readings, _state(), {})
+    await t.think(readings, _state(), {})
+
+    assert primary.calls == 2

--- a/packages/cell-core/tests/thinkers/test_rule_based.py
+++ b/packages/cell-core/tests/thinkers/test_rule_based.py
@@ -1,0 +1,113 @@
+"""Tests for RuleBasedThinker — deterministic Thinker with no LLM dependency."""
+from __future__ import annotations
+
+import pytest
+
+from cell_core.types import HomeostaticState, Proposal, SensorReading
+
+
+def _state(stress: float = 0.2, energy: float = 0.8) -> HomeostaticState:
+    return HomeostaticState(
+        stress_level=stress,
+        energy_level=energy,
+        arousal=0.3,
+        comfort_zone=(0.0, 1.0),
+        setpoint_rt_ms=200,
+        circadian_phase="awake",
+    )
+
+
+@pytest.mark.asyncio
+async def test_protocol_compliance():
+    from cell_core.protocols import Thinker
+    from cell_core.thinkers.rule_based import RuleBasedThinker
+
+    t = RuleBasedThinker()
+    assert isinstance(t, Thinker)
+
+
+@pytest.mark.asyncio
+async def test_all_green_proposes_none():
+    from cell_core.thinkers.rule_based import RuleBasedThinker
+
+    t = RuleBasedThinker()
+    readings = [SensorReading(sensor_name="health", status="green")]
+    proposal = await t.think(readings, _state(), {})
+
+    assert isinstance(proposal, Proposal)
+    assert proposal.action == "none"
+    assert proposal.tier_used == 0
+
+
+@pytest.mark.asyncio
+async def test_yellow_proposes_alert_silent():
+    from cell_core.thinkers.rule_based import RuleBasedThinker
+
+    t = RuleBasedThinker()
+    readings = [SensorReading(sensor_name="outbox", status="yellow")]
+    proposal = await t.think(readings, _state(), {})
+
+    assert proposal.action == "alert_silent"
+    assert proposal.confidence > 0.0
+
+
+@pytest.mark.asyncio
+async def test_red_proposes_alert_human():
+    from cell_core.thinkers.rule_based import RuleBasedThinker
+
+    t = RuleBasedThinker()
+    readings = [SensorReading(sensor_name="health", status="red")]
+    proposal = await t.think(readings, _state(), {})
+
+    assert proposal.action == "alert_human"
+    # Confidence should be high (≥0.7) — Codex review wanted graduation gates
+    # to be reachable from rule-based output.
+    assert proposal.confidence >= 0.7
+
+
+@pytest.mark.asyncio
+async def test_red_outbox_proposes_drain_outbox():
+    """When the outbox sensor is red, propose a domain-specific action."""
+    from cell_core.thinkers.rule_based import RuleBasedThinker
+
+    t = RuleBasedThinker()
+    readings = [SensorReading(sensor_name="outbox", status="red", value=500)]
+    proposal = await t.think(readings, _state(), {})
+
+    assert proposal.action == "drain_outbox"
+
+
+@pytest.mark.asyncio
+async def test_high_stress_overrides_to_alert_human():
+    """When stress > 0.8, escalate even on yellow signals."""
+    from cell_core.thinkers.rule_based import RuleBasedThinker
+
+    t = RuleBasedThinker()
+    readings = [SensorReading(sensor_name="outbox", status="yellow")]
+    proposal = await t.think(readings, _state(stress=0.9), {})
+
+    assert proposal.action == "alert_human"
+
+
+@pytest.mark.asyncio
+async def test_uses_worst_status_across_sensors():
+    from cell_core.thinkers.rule_based import RuleBasedThinker
+
+    t = RuleBasedThinker()
+    readings = [
+        SensorReading(sensor_name="a", status="green"),
+        SensorReading(sensor_name="b", status="yellow"),
+        SensorReading(sensor_name="c", status="green"),
+    ]
+    proposal = await t.think(readings, _state(), {})
+    assert proposal.action == "alert_silent"
+
+
+@pytest.mark.asyncio
+async def test_proposal_carries_human_readable_reason():
+    from cell_core.thinkers.rule_based import RuleBasedThinker
+
+    t = RuleBasedThinker()
+    readings = [SensorReading(sensor_name="health", status="red")]
+    proposal = await t.think(readings, _state(stress=0.95), {})
+    assert "red" in proposal.reason.lower()


### PR DESCRIPTION
## Partial: 1/2 of W2-D scope

This PR ships two pure-additive building blocks for `cell-core` PulseLoop. Zero modifications to the existing state machine. All new tests green.

### Empirical correction to the orchestrator brief

The W2-D brief framed cell-core PulseLoop as "~10% active". Empirical reality (verified by reading the code and running tests pre-PR):

- `packages/cell-core/cell_core/pulse.py` is **321 LOC, state machine SENSE→THINK→ACT→REFLECT→DREAM→MATURE already implemented, 14 unit tests passing**.
- The actual gap is **5 specific wirings** (per the plan doc in this PR), not 90% of states missing.
- Therefore the path forward is *additive* (new sensors, new thinkers, new genome writebacks), NOT *full reimplementation*.

This PR delivers the additive building blocks. The wirings into the existing PulseLoop are deferred to `[2/2]`.

### Scope this PR (additive only)

| Module | LOC | Tests | Purpose |
|---|---|---|---|
| `cell_core.sensors.outbox_sensor.OutboxSensor` | 144 | 155 (test_outbox_sensor.py) | SENSE step — events_outbox PG lag reading |
| `cell_core.thinkers.rule_based.RuleBasedThinker` | 108 | 113 (test_rule_based.py) | THINK step — zero-LLM deterministic classifier, sub-millisecond, no I/O |
| `cell_core.thinkers.ollama_aware.OllamaAwareThinker` | 83 | 129 (test_ollama_aware.py) | THINK step — wraps a primary thinker, 2s hard timeout, falls back to RuleBasedThinker on timeout/exception/None |
| `docs/superpowers/plans/2026-05-07-cell-core-pulse-activate.md` | 183 | n/a | Plan doc: SMOKE findings, schema divergence, 5-wiring catalogue |

**Total: 953 insertions, 11 files, all new.**

### Codex sandbox review (pre-commit)

Spec reviewed via `codex exec --sandbox read-only`. All resulting findings addressed before commit (see commit messages on `f83c8ad99` and `c0734df25`). The integration test contract that captured Codex's P1 #4 (sqlite3.OperationalError wrapping) is preserved as `/tmp/test_pulse_genome_integration.py.pending-W2-D-resume` on the dev host, ready for `[2/2]`.

### Symbiosis Law 4 compliance

- `OllamaAwareThinker` enforces 2s hard timeout (vs 30-120s typical Ollama latency) → falls back to rule-based on timeout, exception, or None primary. Ollama-not-real-time rule (CLAUDE.md cost constraint) honoured by construction.
- `OutboxSensor` does not raise on PG unreachable — graceful degradation per Law 4.
- Verified at SMOKE time: Ollama was actually DOWN on Pro, the fallback path is the tested-by-default path.

### Schema divergence note

Brief described separate SQLite tables `skills`, `reflections`, `insights` with graduation rule. Repo reality:

- Single `genome` table at `~/.cell/genome.db` with `type` discriminator (`skill | pattern | scar | insight | trajectory`) — `cell_core/genome.py`.
- Graduation via `tier` column (`NULL → tier2 → tier1`), thresholds `TIER2_MIN_USES=30 / 0.70`, `TIER1_MIN_USES=100 / 0.85`.

Followed Option (a) of the brief: implement against existing schema, document semantics mapping. Mapping table is in the plan doc §2.

### What is NOT in this PR (deferred to [2/2])

Tracked in follow-up issue (linked below):

1. REFLECT phase → `genome.record_skill(type='skill')` writeback
2. REFLECT phase → `genome.record_skill(type='trajectory')` audit row
3. DREAM phase → `genome.record_skill(type='insight')` daily summary
4. MATURE phase → `genome.promote_skills()` invocation on cadence
5. Daemon entrypoint (`com.cell.organism.pulse.daemon` plist + CLI module)
6. Live smoke test (3-cycle PulseLoop run with skills/reflections/insights non-empty assertions)

The integration test that pins the contract for items 1-4 lives at `/tmp/test_pulse_genome_integration.py.pending-W2-D-resume` on the dev host. Resume agent picks it up.

### Resume context for [2/2]

- Branch base for `[2/2]`: this PR's merge commit.
- Plan doc with full 5-wiring catalogue: `docs/superpowers/plans/2026-05-07-cell-core-pulse-activate.md` (committed in this PR).
- Pending integration test: `/tmp/test_pulse_genome_integration.py.pending-W2-D-resume` (269 LOC, red state, 100% additive against new wirings).

### Why this PR was split

W2-D sub-agent hit a Claude rate-limit at minute 18, returning before it could implement the 5 wirings or the integration test. Rather than wait 2h+ for quota reset and risk further drift, the orchestrator (with Zero's ratification) chose Option A: ship the 953 LOC of fully-tested additive code now, defer the wirings to a fresh-quota mini-wave.

The work in this PR is **independently valuable**: it could be reused by any downstream consumer of `cell-core` even if `[2/2]` never landed. The choice is honest scope, not partial completion masquerading as full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)