### PR TITLE
fix(wr2/canva): write pending JSON to skill's hardcoded prod path (Sprint A hotfix 3)

### DIFF
--- a/scripts/wr2_canva_apply.py
+++ b/scripts/wr2_canva_apply.py
@@ -55,7 +55,22 @@ from backend.services.canva_renderer.claude_invoker import (  # noqa: E402
 logger = logging.getLogger("wr2.canva_apply")
 
 MAX_DRAFTS_PER_RUN = 3  # avoid stampede; launchd runs every 5 min
-PENDING_TMP_DIR = Path(tempfile.gettempdir())
+
+# 2026-05-07: the canva-apply skill (~/.claude/skills/canva-apply.md) has the
+# pending JSON path HARDCODED to apps/war-room/output/canva/canva_pending.json.
+# Even though invoke_claude_apply passes the actual path in the prompt header,
+# the skill body's "Read the file `<absolute path>`" instruction wins. Live
+# failure 04:34 WITA on draft 37263a1f returned design=D_ALREADY_APPLIED
+# because the skill read the leftover prod pending (status=applied from a
+# previous synthetic test) instead of the per-draft /tmp file we wrote.
+#
+# Fix: write the per-draft pending into the prod path the skill expects.
+# MAX_DRAFTS_PER_RUN=3 still serial (sequential loop), so no race risk.
+# Sprint B can refactor the skill to honour the prompt-passed path; until
+# then this is the single-write convention shared with wr2_canva_desktop_apply.py
+# (which also targets the prod path, per CANVA_PENDING_PATH discovery 2026-05-06).
+PENDING_PROD_DIR = Path.home() / "Desktop" / "nuzantara" / "apps" / "war-room" / "output" / "canva"
+PENDING_PROD_FILE = PENDING_PROD_DIR / "canva_pending.json"
 
 
 def _configure_logging() -> None:
@@ -165,7 +180,9 @@ async def _apply_one_draft(conn: asyncpg.Connection, row: asyncpg.Record) -> boo
         logger.error("Draft %s pending build failed: %s", draft_id, exc)
         return False
 
-    pending_path = PENDING_TMP_DIR / f"wr2_canva_pending_{draft_id}.json"
+    # Write to the prod path that the canva-apply skill hardcodes; see header.
+    PENDING_PROD_DIR.mkdir(parents=True, exist_ok=True)
+    pending_path = PENDING_PROD_FILE
     pending_path.write_text(json.dumps(pending, indent=2), encoding="utf-8")
     logger.info("Wrote pending JSON for draft %s → %s", draft_id, pending_path)
 


### PR DESCRIPTION
## Summary

Third Sprint A hotfix. Live failure 2026-05-07 04:34 WITA on draft \`37263a1f\` returned \`design=D_ALREADY_APPLIED\` — the master template ID, not a new design carousel.

## Root cause

\`~/.claude/skills/canva-apply.md\` has the pending file path **hardcoded**:
\`\`\`
Read the file '/Users/nuzantara/Desktop/nuzantara/apps/war-room/output/canva/canva_pending.json'
\`\`\`

\`invoke_claude_apply\` passes the actual per-draft \`/tmp\` path in the prompt header (\`Apply the canva_pending.json at path: <path>\`), but the skill body's hardcoded \`Read\` instruction wins in the LLM's attention. The skill therefore read the leftover prod pending file (\`status=applied\` from a previous synthetic test) → saw "Already applied" → returned the template ID as fallback.

## Fix

\`wr2_canva_apply.py\` now writes the per-draft pending JSON to the prod path the skill expects, instead of \`/tmp/wr2_canva_pending_<id>.json\`. \`MAX_DRAFTS_PER_RUN=3\` runs serially (sequential loop), so no race risk.

Sprint B can refactor the skill to honour the prompt-passed path properly. Until then this is the single-write convention shared with \`wr2_canva_desktop_apply.py\` (which also targets the prod path, per CANVA_PENDING_PATH discovery 2026-05-06).

## Sprint A summary

This is the **third** Sprint A hotfix in 2 hours:
- **PR #501** — Sprint A core (CLI subprocess pivot + Phase A.5 prewipe + supervisor TRANSITIONS bypass)
- **PR #502** — timeout 600→1500s + claude -p cwd pin
- **PR #503** (this) — pending path to skill's hardcoded location

All three hotfixes share the same surface — they expose dependencies that the synthetic E2E test couldn't catch because it ran from interactive shell with prod path pre-cleared and pending status not pre-applied. Sprint B planning doc (\`docs/wr2/2026-05-07-wr2-longterm-design.md\`) should incorporate "skill must accept prompt-passed pending path" into the runtime contract.

## Test plan

- [x] py_compile / ast.parse OK
- [x] pre-commit hooks all green
- [ ] Live cron exercise post-merge (queue has 2 stuck drafts ready for kickstart)

## Refs

- PR #501 (Sprint A core)
- PR #502 (Sprint A hotfix 1+2: timeout + cwd)
- \`docs/wr2/2026-05-07-wr2-longterm-design.md\` (Sprint B planning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)