### PR TITLE
fix(mouth): npm audit fix — basic-ftp HIGH vulnerability bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12269,9 +12269,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary
- `npm audit fix` on `apps/mouth/package-lock.json` to resolve HIGH-severity vulnerability in transitive dep `basic-ftp <=5.3.0` (CVE GHSA-rpmf-866q-6p89)
- 3-line lockfile-only change (no source code, no public API)

## Why now
Frontend Tests (Next.js) (mouth) CI required check has been failing on all open PRs since this advisory landed in npm registry. Currently blocking #503 (nb-lifecycle R1.5) auto-merge — and any future PR until we bump.

## Out of scope
- `ip-address` MODERATE XSS (GHSA-v2v4-37r5-5v8g) — requires `npm audit fix --force` (breaking). Defer to dedicated PR.

## Test plan
- [x] `cd apps/mouth && npm audit --audit-level=high` passes (1 moderate residue, no high)
- CI Frontend Tests (Next.js) (mouth) should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>