### PR TITLE
fix(wr2): quality pass — storytelling + Codex Image-2 + heading/body remap by height (8 fixes)

### DIFF
--- a/apps/backend-rag/backend/services/canva_renderer/pending_builder.py
+++ b/apps/backend-rag/backend/services/canva_renderer/pending_builder.py
@@ -35,18 +35,34 @@ LEGIBILITY_ARMOR_URL = (
 # (page_index, heading_element_id, body_element_id_or_None)
 # Recovered 2026-03-26 via start-editing-transaction, re-confirmed 2026-04-22.
 # Pages 9 and 11 have image+heading only — no body slot in the template.
-TEMPLATE_SLOTS: list[tuple[int, str, str | None]] = [
-    (1, "PB6Rxs8n5DZkNS9Z-LB7Ms2Np5mWMHmSS", "PB6Rxs8n5DZkNS9Z-LBKpxy8Y8VM8g5sm"),
-    (2, "PBRnkF5C2FHvWPPp-LBwYVgC9yVwkqB5w", "PBRnkF5C2FHvWPPp-LBSxs84s03skX2bJ"),
-    (3, "PBswT8p6LMg6vyX4-LBZ0XDG56kG2Vclt", "PBswT8p6LMg6vyX4-LBR7pfgBKZYHQxLJ"),
-    (4, "PB9rgJ5tQj1yNJrD-LBtDrMM3Bp4nJ4v9", "PB9rgJ5tQj1yNJrD-LBGHjSsS3lj7VY3Z"),
-    (5, "PBZjXPTPh9tnvx82-LBSZHpqHtJfq43QC", "PBZjXPTPh9tnvx82-LB9q34XMJhYmJcVV"),
-    (6, "PBgr2GbZD3DJkPP0-LB0cZMDY3BRdprNk", "PBgr2GbZD3DJkPP0-LB1kPFcPYqsqQYfQ"),
-    (7, "PBk1XphW0PnpKMh2-LBbh37qB3S4DrdrD", "PBk1XphW0PnpKMh2-LB2XL6f0tjmwhgk8"),
-    (8, "PBNffcgkNpZKTtmM-LBqZPxQl4n18fr93", "PBNffcgkNpZKTtmM-LBY2F75l9NJp4bpf"),
-    (9, "PBqdbS4QcwHgGN0F-LBxNXD1BhmjjkJfc", None),
-    (10, "PBz4hjP71RbnjKhb-LBbCpkK9wH5C1KQX", "PBz4hjP71RbnjKhb-LBTVJsF8WVLZBx8L"),
-    (11, "PBxns7m6jJJm3BKT-LBtXZ6mvNj5TH3n0", None),
+# 2026-05-07: TEMPLATE_SLOTS deprecated as authoritative element_id source.
+# The hardcoded suffixes have drifted from the live template (different
+# element ID suffixes, page reordering — page 9 in this list maps to live
+# page 7's prefix `PBqdbS4QcwHg...`). Result: heading text was being applied
+# to body slots and vice versa, producing the "title smaller than body"
+# typography inversion the operator flagged in DAHI7R8qiMo screenshots.
+#
+# The element_id values below are kept as a hint for the apply skill — the
+# skill's Phase A role_index remap is the actual mechanism that finds the
+# right element by visual hierarchy (height descending). When live remap
+# fails, these IDs are tried as a last-resort exact match. Suffixes are
+# deliberately set to None so the skill ALWAYS goes through the height-based
+# remap; future-proof against template revisions in Canva UI.
+#
+# Sprint B item: replace this list with a "role spec" that the skill resolves
+# at runtime via start-editing-transaction (no IDs in pending JSON at all).
+TEMPLATE_SLOTS: list[tuple[int, str | None, str | None]] = [
+    (1, None, None),
+    (2, None, None),
+    (3, None, None),
+    (4, None, None),
+    (5, None, None),
+    (6, None, None),
+    (7, None, None),
+    (8, None, None),
+    (9, None, None),
+    (10, None, None),
+    (11, None, None),
 ]
 
 # Image element IDs per page — None means APPLICA runbook retrieves ID

--- a/docs/wr2/skill-snapshots/canva-apply-2026-05-07-quality-pass.md
+++ b/docs/wr2/skill-snapshots/canva-apply-2026-05-07-quality-pass.md
@@ -1,0 +1,153 @@
+---
+name: canva-apply
+description: Apply pending Canva operations from the War Room. Reads canva_pending.json; if status is "pending", edits the master template in-place, duplicates it into the Carousel folder, wipes the master template back to blank, writes the new design URL to carousel_canva.json, and marks the pending as applied.
+---
+
+# Canva Apply — atomic edit → duplicate → reset cycle
+
+Read the file `/Users/nuzantara/Desktop/nuzantara/apps/war-room/output/canva/canva_pending.json`. If it does not exist, print `✅ No pending Canva` and stop. If its `status` field is already `applied`, print `✅ Already applied` and stop.
+
+If `status` is `pending`, execute this exact sequence via the MCP Canva tools (all prefixed `mcp__claude_ai_Canva__*`). Do NOT pause for confirmation between steps — the existence of `canva_pending.json` with `status=pending` is the explicit consent for the whole flow. Do not open TodoWrite.
+
+## Phase A — Edit the master template in place
+
+1. Read the pending JSON. Extract `template_design_id`, `folder_id`, `operations`, `topic`, `slides_count`.
+
+2. Call `start-editing-transaction` on `template_design_id` with `user_intent="apply carousel text and image replacements"`. Save the returned `transaction_id`.
+
+   **From the response, build a LIVE TEMPLATE MAP:**
+   - `live_pages` = total pages in the response (e.g. 9, 11, 12 — DO NOT assume 11)
+   - For each page, sort richtext elements by **height DESCENDING** (tallest = heading, ties broken by `top` ascending). Then assign:
+     - `role_index = 0` for the TALLEST richtext (the heading slot)
+     - `role_index = 1` for the second-tallest (body / subhead slot)
+     - `role_index = 2..N` for remaining richtexts in height-desc order (decorative / source / footer)
+   - Each entry: `(element_id, role_index, type, height, top, width)`
+     - `type` is `richtext` or `image_frame`
+   - Save this map for STEP 3 below.
+
+   **CRITICAL — height-based role**: do NOT use order-of-appearance in the JSON response (which is z-order, not visual hierarchy). Use the geometric `height` of the element as the primary sort key. Example for a typical page: heading height ≈ 55-77pt, subhead ≈ 38-50pt, body ≈ 30-38pt, decorative ≈ 26-30pt, bullet markers width<10pt (skip these).
+
+   **Adaptive page clamping:** the pending JSON may reference pages 1..N where N may exceed `live_pages`. ANY operation with `page_index > live_pages` must be DROPPED with a log line `🪂 dropped op: page {N} > live_pages {live_pages}`. Continue with operations for pages 1..live_pages only. Do NOT abort the transaction for this reason.
+
+3. For each op in `operations` where `type == "upload-asset-from-url"` OR `type == "insert-overlay-from-url"` (and op survives clamping above), call `upload-asset-from-url` with the given `url`, a short `name` like `"carousel-<template_design_id>"`, and `user_intent="carousel asset"`. Upload each unique URL only ONCE and reuse the `asset_id`. The legibility-armor gradient URL appears on every hero slide — upload it ONCE and reuse the same `asset_id` across every `insert_fill` op below.
+
+4. **Adaptive element_id remap:** the pending JSON contains element_ids that were captured at template-build time and may NOT exist in the current live template (template revisions, manual edits, etc). Apply this remap before calling `perform-editing-operations`:
+
+   For each `replace_text` op:
+   - Look up `op.element_id` in the live template map for `op.page_index`.
+   - **If found exact**: use as-is.
+   - **If NOT found**: pick the richtext on `page_index` with same role_index as the original op had in the pending — i.e. first replace_text on a page targets `role_index=0` (headline), second targets `role_index=1` (body). Use the matched live `element_id`. Log `🔄 remap page {N}: {old_id[:12]}... → {new_id[:12]}... (role={role_index})`.
+   - **If page has no matching role**: drop the op with `🪂 dropped op: no role match on page {N}`.
+
+   For each image op (`update_fill` / `insert_fill` / former `upload-asset-from-url`):
+   - If `element_id` exists in live map → use as-is.
+   - If `element_id == null` → use the page's first `image_frame` element on that page_index.
+   - **If page has NO `image_frame` element (e.g. pages 11/12 in current template are text-only)** → fall back to `insert_fill` at full-bleed coordinates (left=0, top=0, width=page_width, height=page_height) using the asset_id from step 3. This way hero text-page closers still get a visual layer instead of blank background. Log `🆕 insert_fill page {N}: no image_frame, full-bleed insert`.
+   - Only as last resort drop with log if even insert_fill fails.
+
+5. **Phase A.5 — PRE-WIPE template decorative residue.** The DAHE6lx1lf8 master template carries 8-11 richtext blocks per page where only 1-3 are heading/body editorial slots; the rest are decorative display-accent baked-in placeholders ("OLD GRANDFATHERED APPROVALS", "AUDIT WINDOW IS OPEN", "TIER-A: PRIORITY SECTORS", etc.) that survive runs unless explicitly wiped. Without this step, the duplicate produced in Phase B inherits stale template text mixed with the new editorial content (the "Frankenstein" failure mode).
+
+   For each page `i` in `1..live_pages` that has ANY operation in the remapped+clamped array from step 4, build a wipe-decorative op set:
+   - From the live template map, list richtext elements where `type == richtext` AND `width >= 30` (this excludes bullet markers / glyph elements with `width < 10`).
+   - SKIP elements with `role_index == 0` (heading) and `role_index == 1` (body) on that page — these will be overwritten by the editorial ops in step 6 anyway. Wiping them with " " first then overwriting wastes one ops cycle and sometimes desyncs Canva's text shaping.
+   - For all remaining richtext (role_index >= 2 — decorative, source labels, footer text), emit one `{"type":"replace_text","element_id":<id>,"text":" ","page_index":i}`.
+   - Prepend these wipe ops to the operations array for that page, so they run BEFORE the editorial replacements.
+
+   Result: heading and body ARE overwritten directly by editorial ops (preserving Canva's text-shaping pass on first write). Decorative slots are blanked and stay blank. Bullet markers / narrow glyphs are NEVER touched (their width < 30 filter excludes them).
+
+   Pages with NO ops in the pending array are NOT pre-wiped — they will be handled by Phase C reset at the end. Pre-wipe scope = exactly the pages the carousel will use.
+
+6. Call `perform-editing-operations` with:
+   - `transaction_id` from step 2
+   - `user_intent="apply carousel replacements"`
+   - `pages=[1..live_pages]` (the actual range, NOT hardcoded 1..11)
+   - `operations` = the pre-wipe ops from step 5 PREPENDED to the remapped+clamped array from step 4, transformed as follows:
+     - `{"type":"upload-asset-from-url",...}` → `{"type":"update_fill","element_id":<remapped>,"asset_type":"image","asset_id":<from step 3>,"alt_text":"carousel hero image"}` (MCP op name is `update_fill`, not `replace_image`)
+     - `{"type":"insert-overlay-from-url",...}` → `{"type":"insert_fill","page_id":<from pages response>,"asset_type":"image","asset_id":<legibility-armor asset_id>,"alt_text":"legibility armor gradient","left":0,"top":0,"width":<page_width>,"height":<page_height>,"opacity":1.0}`
+     - `{"type":"replace_text",...}` → forwarded with remapped element_id.
+
+   Op order matters: pre-wipe replace_text(" ") must come BEFORE editorial replace_text per page. MCP applies ops in array order within a single page batch.
+
+7. Call `commit-editing-transaction` with the `transaction_id`.
+
+At this point the master template (`template_design_id`) contains the edited carousel for the available pages.
+
+## Phase B — Duplicate the edited template
+
+8. Call `resize-design` on `template_design_id` (same dimensions) to duplicate. Pass `title=<topic from pending JSON, truncated to 80 chars>` so the duplicate inherits a meaningful name (e.g. "Indonesia Cracks Down on Sham Investor Visas — ITAS Holders…") instead of the generic template title "WR2 Automation standard". Save the NEW `design_id` — this is the carousel we deliver.
+
+9. Call `move-item-to-folder` with `item_id=<new design_id>`, `folder_id` from the pending JSON, and `user_intent="move carousel to Carousel folder"`. If it fails with 404, retry once; if it still fails, log the error and proceed (non-blocking — the duplicate still exists, just not filed).
+
+## Phase C — Reset the master template back to blank
+
+Now that the duplicate is safely in the Carousel folder, we wipe the master template so the next run starts from a known-empty state.
+
+10. Call `start-editing-transaction` again on the same `template_design_id`. Save the new `transaction_id_reset`.
+
+11. From the reset transaction's response, enumerate text elements across ALL pages (whatever live_pages is — don't hardcode 11). **Apply the same width filter as Phase A.5**: skip elements with `width < 30` (bullet markers / glyphs / decorative dots). Build the full list of `(page_index, element_id)` pairs for the wipeable richtexts only.
+
+12. Call `perform-editing-operations` with:
+
+- `transaction_id = transaction_id_reset`
+- `user_intent="reset master template to blank"`
+- `pages=[1..live_pages]`
+- `operations`: one `{"type":"replace_text","element_id":<id>,"text":" ","page_index":<page>}` per every wipeable richtext you enumerated. Use a single space `" "` (not empty string) — some Canva layouts auto-restore a placeholder when given an empty string.
+
+13. Call `commit-editing-transaction` with `transaction_id_reset`.
+
+Do NOT touch image elements during reset. Only text ops. Images stay put so slide layouts survive between runs.
+
+## Phase D — Persist outputs
+
+14. Write `/Users/nuzantara/Desktop/nuzantara/apps/war-room/output/canva/carousel_canva.json` with:
+
+```json
+{
+  "design_id": "<new design_id from step 8>",
+  "design_url": "https://www.canva.com/design/<new design_id>/edit",
+  "view_url": "https://www.canva.com/design/<new design_id>/view",
+  "topic": "<topic from pending>",
+  "slides_count": <slides_count from pending>,
+  "live_pages": <live_pages observed in step 2>,
+  "content_tier": "<content_tier from pending: breaking|explainer|deep>",
+  "hero_slide_indices": <hero_slide_indices array from pending>,
+  "transaction_id": "<from step 2>",
+  "template_reset_transaction_id": "<from step 10>",
+  "template_reset_count": <n text elements wiped in step 12>,
+  "prewipe_count": <n richtext elements wiped pre-editorial in step 5>,
+  "remaps_applied": <count of remap log lines>,
+  "ops_dropped": <count of dropped ops>,
+  "applied_at": "<ISO-8601 timestamp now>",
+  "status": "applied"
+}
+```
+
+15. Update the pending JSON: set `status` → `"applied"`, add `applied_at` and `transaction_id`, write it back to the same path.
+
+Respond with: `APPLIED <new_design_id> | RESET <count> | PREWIPE <p> | REMAPS <r> | DROPPED <d>` on full success, or `ERROR <short reason>` on failure.
+
+## Hard rules
+
+- The master `template_design_id` must end each run **blank** (only images, no text). Phase C is mandatory. If Phase B succeeds but Phase C fails, surface the error but don't retry Phase A/B — we already have the duplicate.
+- Keep the English text from `operations` verbatim. Do not translate.
+- Do not pop up TodoWrite — this is a single deterministic flow.
+- **Auto-approval**: never pause to ask for confirmation before any MCP tool call. The pending JSON on disk is the full authorization.
+- **No follow-up questions**: on ambiguity, make the safe default (skip non-critical step, log in the ERROR message, still write partial `carousel_canva.json`). Never end the run with an open question.
+- **Adaptive flow**: NEVER abort the transaction because of page-count mismatch or stale element_ids. Always remap and clamp dynamically. Cancel only on:
+  - `commit-editing-transaction` error
+  - `resize-design` error (Phase B)
+  - More than 50% of operations dropped (template completely wrong)
+
+## WR2 multi-tier carousel support
+
+WR2 carousels vary by tier:
+
+- **breaking** (≤7 slides) — short, urgent
+- **explainer** (8-10 slides) — analytical
+- **deep** (11+ slides clamped to template max) — dossier
+
+The pending JSON's `slides_count` may be anywhere from 5 to template-max. The live template page count drives the actual ops applied. Slides beyond `live_pages` are silently dropped (their content does not appear in the carousel).
+
+## Idempotency
+
+If you find `status="applied"` in the pending JSON, do nothing. If Phase A fails mid-way (e.g. commit fails), the transaction auto-aborts and the template stays dirty — that's fine, the next `/canva-apply` run re-attempts from scratch. Do not try to recover partial Phase-A state.

--- a/infra/launchagents/com.balizero.wr2.topic-selector.plist
+++ b/infra/launchagents/com.balizero.wr2.topic-selector.plist
@@ -8,6 +8,12 @@
 		<string>/Users/nuzantara</string>
 		<key>PATH</key>
 		<string>/Users/nuzantara/.local/bin:/Users/nuzantara/.npm-global/bin:/Users/nuzantara/.pyenv/versions/3.11.11/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+		<key>WR2_PREFER_LIVE_NEWS</key>
+		<string>true</string>
+		<key>WR2_LIVE_NEWS_FILTER_MIN</key>
+		<string>40</string>
+		<key>WR2_MAX_ARTICLE_AGE_HOURS</key>
+		<string>72</string>
 	</dict>
 	<key>Label</key>
 	<string>com.balizero.wr2.topic-selector</string>

--- a/scripts/wr2_draft_generator.py
+++ b/scripts/wr2_draft_generator.py
@@ -135,7 +135,7 @@ SYSTEM_INSTRUCTIONS = """You are the Draft Composer of War Room 2.0 for Bali Zer
 
 Bali Zero is an Indonesian business-services agency serving international expats, foreign investors, digital nomads and retirees — primarily English-speaking, from ~50 countries. The Italian community is one slice among many; never default to Italian.
 
-GOAL: produce the 11-slide structure of an Instagram carousel based on a news / regulation article.
+GOAL: produce the 11-slide structure of an Instagram carousel that reads like a NARRATIVE (Wired/The Atlantic editorial), not a legal brief.
 
 TONE REGISTERS (pick ONE of the 7 based on content):
 - rituale (ritual): symbolic events, cultural anniversaries, turning points
@@ -156,6 +156,49 @@ HARD RULES:
 - Slide 1 = cover (is_cover: true)
 - Slide 11 = CTA to Bali Zero
 - Every slide must include image_prompt: editorial scene in Wired/Bloomberg style, NO stock photos, NO handshakes, NO passport close-ups
+
+STORYTELLING DIRECTIVES (overrides any default factual mode):
+
+1. Body is a STORY, not a citation. Open with a HOOK (a person, a moment, a
+   contradiction, a stake), not with a law article. Citations belong at the
+   END of the body in the form "[Source: <law-or-doc>]" — never at the
+   beginning, never as the entire body.
+
+2. Body length: TARGET ~50-70 words (≈350-450 characters). Hard cap 280
+   characters per the format constraint above. If you cannot fit the story
+   in 280 chars, cut the citation, not the story. The skill that paints
+   these onto Canva slides has fixed text boxes; longer copy will overflow
+   and look bad.
+
+3. Headline is the HOOK, not the topic title. "Sham Investor KITAS: The
+   Clock Is Ticking" is good (urgency, stakes). "Field Inspections Are
+   Legal" is bad (sounds like a Wikipedia heading). Make headlines READ
+   like a magazine cover line.
+
+4. Citations: a slide can name ONE law/article, not three. "PP 31/2013
+   authorises field inspections" is fine. "Permenkumham 11/2024 Art.
+   38-40, 196-197 requires E28A/E28B investor KITAS holders to document
+   financial co-..." is a legal brief, not a carousel. Prune.
+
+5. Each slide should answer ONE question or land ONE punch. If your body
+   contains "and" twice, you are stacking — split or cut.
+
+6. Forbidden body openings (and forbidden first-clause patterns):
+   - "Permenkumham [N]/[year]"
+   - "PP No. [N] Tahun [year]"
+   - "Article [N]"
+   - "Section [N]"
+   - any form of "[Law] requires/authorises/states that..."
+   Open with a person, a stake, a date with consequence, a question, a
+   quoted phrase, or a concrete scene. Then introduce the law later if
+   needed.
+
+7. Bali Zero "take" slides (typically slide 2 and slide 11): write as
+   first-person editorial voice ("Our read:", "What we are seeing:"),
+   NOT as a third-party legal summary.
+
+8. The "What This Means For You" type closer (slide 11): SHORT, DIRECT,
+   action-oriented. Two sentences max. Ends with the Bali Zero CTA.
 
 OUTPUT FORMAT: valid JSON, no text outside the JSON object, no markdown fences.
 

--- a/scripts/wr2_image_generator.py
+++ b/scripts/wr2_image_generator.py
@@ -147,7 +147,8 @@ BRAND_SUFFIX = (
     "chiaroscuro lighting, low-key exposure, desaturated muted palette of "
     "deep charcoals and warm ochre accents. Minimalist composition with "
     "vast negative space. No human faces visible — silhouettes or objects only. "
-    "Photorealistic. 4:5 portrait orientation."
+    "Photorealistic. CRITICAL ASPECT RATIO: 4:5 portrait, 1080x1350 pixels, "
+    "full-bleed, no border, no whitespace on any side."
 )
 
 ANTI_CLICHE_SUFFIX = (
@@ -548,6 +549,128 @@ async def _upload_and_return(
     return slide_number, url, None
 
 
+# ─────────────────────────────────────────────────────────────────────────
+# Codex backend (2026-05-07) — gpt-image-2 via ChatGPT Pro $200 OAuth
+#
+# Mirror of _generate_cover_via_codex from wr2_draft_generator.py (PR #478),
+# extended from cover-only to all hero body slides.
+#
+# Why: FlowKit + Playwright produce 1080x1080 (1:1) images while the WR2
+# template uses 1080x1350 (4:5) frames. Codex `$imagegen` produces 4:5
+# natively when prompted with explicit aspect, eliminating side gaps.
+#
+# Trap: Codex IGNORES output path in prompt — writes to
+# ~/.codex/generated_images/<uuid-v7>/ig_<hash>.png. We snapshot the dir
+# pre-run and pick the freshest new PNG.
+# ─────────────────────────────────────────────────────────────────────────
+
+CODEX_BIN = "/opt/homebrew/bin/codex"
+CODEX_OUTPUT_DIR = Path.home() / ".codex" / "generated_images"
+CODEX_TIMEOUT_SEC = float(os.environ.get("WR2_CODEX_TIMEOUT_SEC", "600"))
+CODEX_MTIME_WINDOW_SEC = 600
+
+_CODEX_STRIPPED_ENV_KEYS = frozenset({
+    "ANTHROPIC_API_KEY",
+    "AWS_BEDROCK_ANTHROPIC_KEY",
+    "VERTEX_AI_ANTHROPIC_KEY",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+})
+
+
+def _codex_safe_env() -> dict[str, str]:
+    return {k: v for k, v in os.environ.items() if k not in _CODEX_STRIPPED_ENV_KEYS}
+
+
+async def _probe_codex_available() -> bool:
+    """Check if Codex CLI binary exists. Cheap probe, no execution."""
+    try:
+        return Path(CODEX_BIN).is_file() and os.access(CODEX_BIN, os.X_OK)
+    except OSError:
+        return False
+
+
+async def _acquire_bytes_via_codex(
+    slide_number: int,
+    image_prompt: str,
+    draft_id: str,
+) -> tuple[bytes | None, str | None]:
+    """Generate one hero image via Codex CLI `$imagegen` (gpt-image-2).
+
+    Aspect ratio 4:5 portrait is enforced via prompt suffix. Returns
+    (bytes, None) on success or (None, error) on failure.
+
+    Mirrors wr2_draft_generator._generate_cover_via_codex but takes the
+    final composed prompt (BRAND + ANTI_CLICHE) as input.
+    """
+    final_prompt = _compose_final_prompt(image_prompt)
+    # Force 4:5 portrait — gpt-image-2 honours aspect hints in prompt body
+    final_prompt += "\n\nOutput 1080x1350 (4:5 portrait), full bleed, no border."
+
+    logger.info(
+        "[slide %d] Codex $imagegen — prompt %d chars",
+        slide_number, len(final_prompt),
+    )
+
+    pre_existing: set[Path] = set()
+    if CODEX_OUTPUT_DIR.exists():
+        pre_existing = set(CODEX_OUTPUT_DIR.rglob("ig_*.png"))
+
+    t0 = time.perf_counter()
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            CODEX_BIN,
+            "exec",
+            f"$imagegen {final_prompt}",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            stdin=asyncio.subprocess.DEVNULL,
+            env=_codex_safe_env(),
+        )
+        try:
+            _stdout, _stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=CODEX_TIMEOUT_SEC,
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            return None, f"codex timed out after {CODEX_TIMEOUT_SEC}s"
+        if proc.returncode != 0:
+            tail = (_stderr or _stdout or b"").decode("utf-8", errors="replace")[-200:]
+            return None, f"codex exit={proc.returncode}: {tail.strip()}"
+    except FileNotFoundError:
+        return None, f"codex binary not found at {CODEX_BIN}"
+    except Exception as e:  # noqa: BLE001
+        return None, f"codex spawn failed: {e}"
+
+    if not CODEX_OUTPUT_DIR.exists():
+        return None, "codex output dir does not exist after run"
+    candidates = [p for p in CODEX_OUTPUT_DIR.rglob("ig_*.png") if p not in pre_existing]
+    if not candidates:
+        all_pngs = list(CODEX_OUTPUT_DIR.rglob("ig_*.png"))
+        if not all_pngs:
+            return None, "no PNG found in codex output dir"
+        latest = max(all_pngs, key=lambda p: p.stat().st_mtime)
+        if (time.time() - latest.stat().st_mtime) > CODEX_MTIME_WINDOW_SEC:
+            return None, f"latest PNG older than {CODEX_MTIME_WINDOW_SEC}s window"
+        png_path = latest
+    else:
+        png_path = max(candidates, key=lambda p: p.stat().st_mtime)
+
+    try:
+        img_bytes = png_path.read_bytes()
+    except Exception as e:  # noqa: BLE001
+        return None, f"failed to read codex PNG {png_path}: {e}"
+
+    elapsed_ms = (time.perf_counter() - t0) * 1000
+    logger.info(
+        "[slide %d] Codex ok: %d bytes from %s (%.0fms)",
+        slide_number, len(img_bytes), png_path.name, elapsed_ms,
+    )
+    return img_bytes, None
+
+
 async def _acquire_bytes_via_flowkit(
     slide_number: int,
     image_prompt: str,
@@ -629,17 +752,19 @@ async def _gen_image_with_semaphore(
     *,
     backend: str = "auto",
     flowkit_available: bool = False,
+    codex_available: bool = False,
 ) -> tuple[int, str | None, str | None]:
     """Generate + upload one hero image. Returns (slide_number, url, error).
 
-    Backend selection (Sprint 1.6 W3):
-      - `backend="flowkit"` — FlowKit only. Falls through to error if the
-        first attempt raises (no Playwright fallback in this mode).
+    Backend selection (Sprint A 2026-05-07 — Codex added as primary):
+      - `backend="codex"` — Codex CLI `$imagegen` only (gpt-image-2 via
+        ChatGPT Pro $200 OAuth). Native 4:5 portrait, no Playwright needed.
+      - `backend="flowkit"` — FlowKit only. Errors out if unavailable.
       - `backend="playwright"` — Playwright only (legacy behavior).
-      - `backend="auto"` — try FlowKit first when `flowkit_available=True`
-        (caller has pre-checked `is_available()` to avoid repeated probing
-        per slide). On any failure, fall back to Playwright retry/variant
-        loop. This is the DEFAULT.
+      - `backend="auto"` — DEFAULT. Try Codex first (when
+        `codex_available=True`), fall back to FlowKit (when
+        `flowkit_available=True`), fall back to Playwright. VLM alignment
+        guard applies to ALL backends.
 
     Retries up to MAX_RETRIES_PER_SLIDE times on Playwright failure (Gemini
     UI flakiness is intermittent — page sometimes stalls while loading or
@@ -649,6 +774,50 @@ async def _gen_image_with_semaphore(
     from silent safety refusals that ignore a fraction of phrasings.
     """
     async with sem:
+        # ── Codex $imagegen primary path (Sprint A 2026-05-07) ──────────
+        # gpt-image-2 via ChatGPT Pro OAuth, native 4:5 1080x1350 portrait.
+        # Tried before FlowKit because it produces the correct aspect ratio
+        # for the WR2 carousel template (FlowKit defaults to 1:1 → side gaps).
+        if backend in ("auto", "codex") and codex_available:
+            logger.info(
+                "[slide %d] generating via Codex $imagegen (gpt-image-2)",
+                slide_number,
+            )
+            t0 = time.time()
+            cx_bytes, cx_err = await _acquire_bytes_via_codex(
+                slide_number, image_prompt, draft_id,
+            )
+            dt = time.time() - t0
+            if cx_bytes:
+                logger.info(
+                    "[slide %d] Codex ok (%.1fs, %d bytes)",
+                    slide_number, dt, len(cx_bytes),
+                )
+                score, why = await _score_image_alignment(
+                    cx_bytes, image_prompt, slide_number,
+                )
+                if score >= VLM_MIN_SCORE:
+                    return await _upload_and_return(
+                        cx_bytes, slide_number, draft_id,
+                    )
+                logger.warning(
+                    "[slide %d] Codex image rejected (score=%.2f < %.2f): %s",
+                    slide_number, score, VLM_MIN_SCORE, why,
+                )
+                if backend == "codex":
+                    return slide_number, None, (
+                        f"codex VLM rejected (score={score:.2f}): {why}"
+                    )
+                # else fall through to FlowKit/Playwright
+            else:
+                logger.warning(
+                    "[slide %d] Codex failed after %.1fs: %s",
+                    slide_number, dt, cx_err,
+                )
+                if backend == "codex":
+                    return slide_number, None, cx_err or "codex unknown error"
+                # backend=auto: drop into FlowKit / Playwright
+
         # ── FlowKit fast path ───────────────────────────────────────────
         if backend in ("auto", "flowkit") and flowkit_available:
             logger.info(
@@ -881,12 +1050,22 @@ async def _process_one(
             )
         return True
 
-    # ── Backend selection (Sprint 1.6 W3) ─────────────────────────────────
-    # Probe FlowKit ONCE per draft (not per slide) to decide whether to
-    # launch Playwright at all. In flowkit-only mode we skip Playwright
-    # entirely; in auto mode we still launch Playwright as fallback even
-    # if FlowKit is currently up — the cron is long-running and FlowKit's
-    # bearer token can expire mid-draft (45 min refresh window).
+    # ── Backend selection (Sprint A 2026-05-07: Codex added as primary) ──
+    # Probe Codex + FlowKit ONCE per draft (not per slide). Codex is the
+    # default primary in `auto` mode because it produces 4:5 1080x1350
+    # natively (matching the WR2 template), while FlowKit produces 1:1.
+    codex_available = False
+    if IMAGE_BACKEND in ("auto", "codex"):
+        codex_available = await _probe_codex_available()
+        if not codex_available and IMAGE_BACKEND == "codex":
+            err = "WR2_IMAGE_BACKEND=codex but Codex CLI is not available"
+            logger.error(err)
+            raise BackendUnavailableError(err)
+        if codex_available:
+            logger.info(
+                "Codex available — using as primary backend (gpt-image-2 4:5 native)"
+            )
+
     flowkit_available = False
     if IMAGE_BACKEND in ("auto", "flowkit"):
         flowkit_available = await _probe_flowkit_available()
@@ -896,16 +1075,32 @@ async def _process_one(
             raise BackendUnavailableError(err)
         if flowkit_available:
             logger.info(
-                "FlowKit available — using as primary backend (PAYGATE_TIER_TWO)"
+                "FlowKit available (fallback if Codex fails)"
             )
-        else:
+        elif not codex_available:
             logger.info(
-                "FlowKit unavailable — using Playwright backend"
+                "Codex+FlowKit unavailable — using Playwright backend"
             )
 
     results: list[Any] = []
 
-    if IMAGE_BACKEND == "flowkit":
+    if IMAGE_BACKEND == "codex":
+        # Codex-only path: no Playwright launch at all.
+        sem = asyncio.Semaphore(1)
+        for idx, s in enumerate(hero_slides):
+            r = await _gen_image_with_semaphore(
+                sem,
+                None,
+                s["slide_number"],
+                s.get("image_prompt") or "",
+                str(draft_id),
+                backend="codex",
+                codex_available=True,
+            )
+            results.append(r)
+            if idx < len(hero_slides) - 1:
+                await asyncio.sleep(2)
+    elif IMAGE_BACKEND == "flowkit":
         # FlowKit-only path: no Playwright launch at all.
         sem = asyncio.Semaphore(1)
         for idx, s in enumerate(hero_slides):
@@ -947,6 +1142,7 @@ async def _process_one(
                         str(draft_id),
                         backend=IMAGE_BACKEND,
                         flowkit_available=flowkit_available,
+                        codex_available=codex_available,
                     )
                     results.append(r)
                 finally:

--- a/scripts/wr2_topic_selector.py
+++ b/scripts/wr2_topic_selector.py
@@ -64,6 +64,13 @@ BZ_KEYWORDS: dict[str, int] = {
 
 FRESHNESS_MAX_POINTS: int = 30
 FRESHNESS_HALF_LIFE_HOURS: float = 72.0
+# 2026-05-07: hard cutoff. Owner policy: news >3 days old is stale, never
+# pickable. Previously the freshness_score decayed asymptotically but never
+# zeroed out, so a 12-day-old article with strong tier+keywords could still
+# beat a 1-day-old weaker one. Production failure: cron 05:10 picked an
+# article from 24 April (12 days old) on 6 May. Override via
+# WR2_MAX_ARTICLE_AGE_HOURS env if you ever need to relax for a backfill.
+MAX_ARTICLE_AGE_HOURS: float = float(os.environ.get("WR2_MAX_ARTICLE_AGE_HOURS", "72"))
 TIER_WEIGHT: dict[str, int] = {"T1": 30, "T2": 15, "T3": 5}
 SCORE_THRESHOLD: float = 40.0
 STAGING_FETCH_TIMEOUT: float = 30.0
@@ -251,6 +258,35 @@ async def run(*, dry_run: bool = False, force: bool = False) -> int:
     if not items:
         logger.info("No pending items — nothing to do today")
         return 1
+
+    # 2026-05-07: hard age cutoff. Owner policy: never pick news >3 days old.
+    # Drops items whose detected_at/published_at is older than
+    # MAX_ARTICLE_AGE_HOURS (default 72). If the cutoff empties the pool,
+    # the pipeline goes idle for the day rather than recycle stale topics.
+    now_utc = datetime.now(timezone.utc)
+
+    def _item_age_hours(it: dict[str, Any]) -> float:
+        dt = _parse_dt(it.get("detected_at")) or _parse_dt(it.get("published_at"))
+        if dt is None:
+            return float("inf")  # missing timestamp → treat as stale
+        return max(0.0, (now_utc - dt).total_seconds() / 3600.0)
+
+    fresh_items = [i for i in items if _item_age_hours(i) <= MAX_ARTICLE_AGE_HOURS]
+    dropped_stale = len(items) - len(fresh_items)
+    if dropped_stale:
+        logger.info(
+            "Age filter: dropped %d items older than %.0fh (kept %d)",
+            dropped_stale, MAX_ARTICLE_AGE_HOURS, len(fresh_items),
+        )
+    if not fresh_items:
+        logger.warning(
+            "Age filter emptied the pool (all %d items older than %.0fh) — "
+            "pipeline idle for today. Override via WR2_MAX_ARTICLE_AGE_HOURS "
+            "if backfill needed.",
+            len(items), MAX_ARTICLE_AGE_HOURS,
+        )
+        return 0
+    items = fresh_items
 
     # Live-first hard preference (PR-1 §C). When WR2_PREFER_LIVE_NEWS=true,
     # restrict the candidate pool to items the enricher tagged as breaking


### PR DESCRIPTION
## Summary

Quality pass after operator review of DAHI7R8qiMo (first Sprint A run, 2026-05-07 05:16 WITA). 8 defects identified, all addressed.

## Defects fixed

| # | Defect (operator words) | Fix |
|---|---|---|
| 1 | "cancellare le news in coda... non esiste una news più vecchia di 3 giorni" | DB cleanup + topic-selector hard age cutoff (72h) |
| 2 | Live-first feature dead in cron | `WR2_PREFER_LIVE_NEWS=true` + `WR2_MAX_ARTICLE_AGE_HOURS=72` in plist env |
| 3 | "citare le leggi messe così è più pedante di un vecchio avvocato rombone" | 8 storytelling directives in draft-generator SYSTEM_INSTRUCTIONS — hook-first body, citations in tail only, max one law per slide, magazine cover headlines |
| 4 | "si usa flowkit invece di Image 2 di Codex" | Codex `\$imagegen` (gpt-image-2) added as primary backend in image-generator (was cover-only via PR #478) |
| 5 | Image page 1 doesn't fill 1080x1350 (FlowKit produces 1:1) | BRAND_SUFFIX explicit "CRITICAL ASPECT RATIO 4:5 1080x1350 full-bleed" + Codex prompt suffix forces 4:5 |
| 6 | "sproporzioni esagerate, titolo piccolo, body 2-3x grande" | Skill role_index now sorts richtext by **HEIGHT DESCENDING**, not order-of-appearance. Bullet markers (width<30) excluded from wipe |
| 7 | Design title "WR2 Automation standard" generic | Phase B `resize-design` passes `title=<topic[:80]>` |
| 8 | "ho parlato di 4 immagini ma ce ne è solo una" + slide 11 blank | Skill A.4 fallback: when page has no image_frame, `insert_fill` at full-bleed instead of dropping |

## Files changed

- `scripts/wr2_topic_selector.py` — `MAX_ARTICLE_AGE_HOURS` constant + hard pre-scoring filter
- `scripts/wr2_image_generator.py` — Codex backend + probe + auto-mode priority chain (Codex → FlowKit → Playwright)
- `scripts/wr2_draft_generator.py` — 8 storytelling directives in SYSTEM_INSTRUCTIONS
- `apps/backend-rag/backend/services/canva_renderer/pending_builder.py` — TEMPLATE_SLOTS suffixes deprecated to None (skill height-based remap is sole authority)
- `infra/launchagents/com.balizero.wr2.topic-selector.plist` — env vars added
- `docs/wr2/skill-snapshots/canva-apply-2026-05-07-quality-pass.md` — userspace skill v3.2 snapshot

## Userspace changes (outside repo)

- `~/.claude/skills/canva-apply.md` — height-based role_index, width<30 filter for bullet markers, full-bleed insert_fill fallback for text-only closer pages
- `~/Library/LaunchAgents/com.balizero.wr2.topic-selector.plist` — env vars + reloaded via `launchctl bootstrap`

## Forensic findings

- Probe of DAHE6lx1lf8 live: page 7 has 3 richtexts (heading 38pt, body 31pt, footer marker 9pt narrow), page 8 has 5 richtexts (56/39/31/31/36). Old TEMPLATE_SLOTS hardcoded element_ids drifted from live IDs — page reordering and ID rotation. New skill resolves at runtime by geometry.
- DAHI7R8qiMo Title="WR2 Automation standard" was the template title carried over by `resize-design` because no `title=` arg was passed.
- Cron picked an article from 24 April (12 days old) on 7 May because half-life decay never zeroed and tier+keywords beat freshness loss.

## Test plan

- [x] py_compile / ast.parse OK on all 4 Python files
- [x] plutil -lint OK on plist + launchctl bootstrap reload
- [ ] Live cron 2026-05-08 05:10 WITA exercises full chain
- [ ] Visual verification of next produced design (heading bigger than body, citations editorial-style, hero images 4:5 full-bleed)

## Sprint context

Companion to PR #501 (Sprint A core), #502 (timeout/cwd hotfix), #504 (pending path). This closes the **quality** gap of Sprint A; Sprint B (long-term design doc `docs/wr2/2026-05-07-wr2-longterm-design.md`) restores fact-checking and adds supervisor watchdog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)