### PR TITLE
fix(wr2): mandate is_hero_image + timeout 1500→2400s (PR #506 follow-up)

### DIFF
--- a/apps/backend-rag/backend/services/canva_renderer/claude_invoker.py
+++ b/apps/backend-rag/backend/services/canva_renderer/claude_invoker.py
@@ -22,11 +22,14 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_TIMEOUT_SEC = 1500  # 25 min — empirical: deep-tier 11-slide draft
-# with hero images + Phase A.5 pre-wipe (~50 ops) + Phase B duplicate + Phase C
-# reset (~50 ops) reaches 8-12 min on Pro M4. Synthetic 5-slide no-image test
-# was 283s. 600s timed out on real drafts (37263a1f at 04:09 WITA 2026-05-07).
-# 1500s leaves headroom for Canva MCP rate-limit pauses inside the skill flow.
+DEFAULT_TIMEOUT_SEC = 2400  # 40 min — bumped from 1500 after empirical
+# evidence on 7 May 2026: skill v3.2 (height-based remap + width<30 filter
+# in BOTH Phase A.5 and Phase C) added ~12-15 min to wall clock. Run
+# 0e8e1cf5 (skill v3.1, 2026-05-07 05:16 WITA) finished in 1474s. Run
+# e21c86c0 (skill v3.2, 2026-05-07 08:53 WITA) timed out at 1500s. Each
+# Canva MCP round-trip is ~3-8s; the new height/width inspection pass on
+# 12 pages × ~10 elements each is ~120 inspections. 2400s budgets for
+# pathological cases (Canva MCP rate-limit pauses, transient API stalls).
 DEFAULT_CLAUDE_BIN = "claude"  # resolved from PATH
 # 2026-05-07: APPLICA_WAR_ROOM.md was at apps/war-room/ but that directory was
 # removed in PR #171 (WR1 decommission). The authoritative runbook is now the

--- a/scripts/wr2_draft_generator.py
+++ b/scripts/wr2_draft_generator.py
@@ -153,9 +153,23 @@ HARD RULES:
 - Language: ENGLISH (international expat audience)
 - Headlines max 60 characters
 - Body max 280 characters
-- Slide 1 = cover (is_cover: true)
+- Slide 1 = cover (is_cover: true, is_hero_image: true ALWAYS)
 - Slide 11 = CTA to Bali Zero
 - Every slide must include image_prompt: editorial scene in Wired/Bloomberg style, NO stock photos, NO handshakes, NO passport close-ups
+
+HERO IMAGE SELECTION (MANDATORY):
+You MUST mark exactly 4 slides as `is_hero_image: true`:
+- Slide 1 (cover) — ALWAYS hero
+- Slide 11 (CTA closer "What This Means For You") — ALWAYS hero
+- 2 mid-carousel slides at NARRATIVE TURNING POINTS — pick the slides that
+  open a new beat (e.g. "the shift", "the stakes", "fiction vs substance"),
+  not the ones that list facts or numbers.
+
+The remaining 7 slides have `is_hero_image: false` — they keep the
+template's tipografia layout without an image. Hero slides get a
+full-bleed photo as background; non-hero slides are clean text-on-color.
+
+Output exactly 4 slides with `is_hero_image: true`. Not 3, not 5.
 
 STORYTELLING DIRECTIVES (overrides any default factual mode):
 


### PR DESCRIPTION
Two follow-up fixes after live pipeline run de69f035 post PR #506:

1. **is_hero_image MANDATE re-added** — new storytelling SYSTEM_INSTRUCTIONS lost the explicit hero rule. Image-gen logged 'no hero slides — nothing to generate'. Restored: slide 1 + slide 11 + 2 mid-carousel turning points = exactly 4 hero slides.

2. **Skill v3.2 timeout bump 1500→2400s** — height-based remap + width<30 filter in Phase A.5 + Phase C added 12-15 min wall clock. Run e21c86c0 timed out at 1500s.

✅ FIX 3 storytelling **CONFIRMED working** in same run (sample bodies show hook-first narrative, magazine cover headlines, no 'Permenkumham N/year' patterns).

Refs: PR #506 quality pass, PR #501 Sprint A core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)