### PR TITLE
feat(core/analytics): add 16 funnel home-block event names

### DIFF
--- a/packages/core/analytics/funnel-view.ts
+++ b/packages/core/analytics/funnel-view.ts
@@ -1,18 +1,39 @@
 export const FUNNEL_EVENTS = [
+  // --- Visa Oracle ---
   "visa_quiz_completed",
   "visa_result_viewed",
   "visa_chat_question",
   "visa_whatsapp_cta",
   "visa_calling_block",
+  // Funnel home-block CTAs (4 per funnel × 4 funnels = 16)
+  "visa_cta_click",
+  "visa_consult_click",
+  "visa_search_submit",
+  "visa_suggestion_click",
+  // --- KBLI Navigator ---
   "kbli_code_viewed",
   "kbli_search",
   "kbli_chat_question",
   "kbli_whatsapp_cta",
+  "kbli_cta_click",
+  "kbli_consult_click",
+  "kbli_search_submit",
+  "kbli_suggestion_click",
+  // --- Tax Intelligence ---
   "tax_dashboard_viewed",
   "tax_whatsapp_cta",
+  "tax_cta_click",
+  "tax_consult_click",
+  "tax_search_submit",
+  "tax_suggestion_click",
+  // --- Property Map ---
   "property_cta_clicked",
   "property_chat_question",
   "property_whatsapp_cta",
+  "property_cta_click",
+  "property_consult_click",
+  "property_search_submit",
+  "property_suggestion_click",
 ] as const;
 
 export type FunnelEventName = (typeof FUNNEL_EVENTS)[number];


### PR DESCRIPTION
## Why
FUNNEL_EVENTS in packages/core is the single source of truth for
trackFunnelEvent(). FunnelFeature CTAs had no entries here, so
tracking would bypass the funnel store.

## What
16 new event names — 4 per funnel (visa / kbli / tax / property):
  {funnel}_cta_click        → main CTA button clicked
  {funnel}_consult_click    → pricing/consult link clicked
  {funnel}_search_submit    → search form submitted
  {funnel}_suggestion_click → suggestion chip clicked

## Scope
1 file: packages/core/analytics/funnel-view.ts
Additive only. No existing events removed or renamed.

## Review note for Antonello
This is purely a registry change — adding names to a const array.
PR 2 (sancho/funnel-cta-tracking) depends on this and wires the
actual component. Merge this first.
