### PR TITLE
refactor(analytics): unify funnel home-block CTA tracking via shared helpers

### DIFF
--- a/apps/mouth/DOCUMENTATION.md
+++ b/apps/mouth/DOCUMENTATION.md
@@ -33,6 +33,7 @@
 14. [Deployment](#14-deployment)
 15. [Performance](#15-performance)
 16. [Troubleshooting](#16-troubleshooting)
+17. [Analytics Tracking](#17-analytics-tracking)
 
 ---
 
@@ -1354,6 +1355,161 @@ API:           camelCase.ts       (e.g., chat.api.ts)
 MDX:           kebab-case.mdx     (e.g., visa-guide-2025.mdx)
 Images:        kebab-case.jpg     (e.g., golden-visa.jpg)
 ```
+
+---
+
+## 17. Analytics Tracking
+
+> **Last updated:** 2026-05-07
+> **PRs:** `sancho/funnel-event-names` · `sancho/funnel-cta-tracking`
+
+Analytics tracking uses a **triple-dispatch** pattern: every event is sent
+simultaneously to three destinations.
+
+```
+User interaction
+       │
+       ▼
+  Helper function  (lib/analytics.ts)
+       │
+       ├──► sendGA4Event()       → Google Analytics 4 (gtag)
+       ├──► trackEvent()         → Internal CRM analytics bus
+       └──► trackFunnelEvent()   → Funnel store (POST /api/analytics/funnel-event)
+```
+
+---
+
+### 17.1 Event Registry
+
+All valid event names live in one place:
+
+```
+packages/core/analytics/funnel-view.ts  ← Single Source of Truth
+```
+
+`FUNNEL_EVENTS` is a `const` array. `FunnelEventName` is derived automatically:
+
+```typescript
+export type FunnelEventName = (typeof FUNNEL_EVENTS)[number];
+```
+
+**Adding a new event:** append the string to `FUNNEL_EVENTS`. The type updates
+automatically — no other changes needed in the registry file.
+
+---
+
+### 17.2 Funnel Home-Block CTA Events (added 2026-05-07)
+
+Four interaction types × four funnels = **16 events**:
+
+| Action            | Visa                    | KBLI                    | Tax                    | Property                    |
+| ----------------- | ----------------------- | ----------------------- | ---------------------- | --------------------------- |
+| Main CTA click    | `visa_cta_click`        | `kbli_cta_click`        | `tax_cta_click`        | `property_cta_click`        |
+| Pricing CTA click | `visa_consult_click`    | `kbli_consult_click`    | `tax_consult_click`    | `property_consult_click`    |
+| Search submit     | `visa_search_submit`    | `kbli_search_submit`    | `tax_search_submit`    | `property_search_submit`    |
+| Suggestion chip   | `visa_suggestion_click` | `kbli_suggestion_click` | `tax_suggestion_click` | `property_suggestion_click` |
+
+---
+
+### 17.3 Helper Functions
+
+Located in `apps/mouth/src/lib/analytics.ts`.
+
+#### Funnel home-block helpers (new — 2026-05-07)
+
+```typescript
+import { trackVisaCTA, trackKBLICTA, trackTaxCTA, trackPropertyCTA } from "@/lib/analytics";
+
+// All four helpers share the same signature
+trackVisaCTA(
+  action: "cta_click" | "consult_click" | "search_submit" | "suggestion_click",
+  extra?: Record<string, string | number | boolean>,
+): void
+
+// Examples
+trackVisaCTA("cta_click");
+trackKBLICTA("search_submit", { query_length: 12 });
+trackPropertyCTA("suggestion_click", { suggestion: "Canggu villa zone" });
+```
+
+#### Article-page property helper (renamed 2026-05-07)
+
+```typescript
+// Old name: trackPropertyCTA  ← freed for funnel-scoped helper above
+trackPropertyArticleCTA(articleSlug: string, ctaType: string): void
+```
+
+> **Note:** `trackPropertyCTA` now refers to the funnel home-block helper.
+> Use `trackPropertyArticleCTA` for article-page CTAs.
+
+---
+
+### 17.4 Usage in FunnelFeature
+
+`FunnelFeature.tsx` uses a dispatch map to avoid a switch in JSX:
+
+```typescript
+const CTA_TRACKER: Record<Exclude<Funnel, null>, typeof trackVisaCTA> = {
+  visa: trackVisaCTA,
+  kbli: trackKBLICTA,
+  tax: trackTaxCTA,
+  property: trackPropertyCTA,
+};
+
+const track = CTA_TRACKER[funnel]; // resolved once per render
+
+// Wired interactions
+<a onClick={() => track("cta_click")}>Try Visa Oracle</a>
+<a onClick={() => track("consult_click")}>See transparent pricing</a>
+<form onSubmit={() => track("search_submit", { query_length: n })}>...</form>
+<button onClick={() => track("suggestion_click", { suggestion: sug })}>...</button>
+```
+
+---
+
+### 17.5 Verifying in Browser DevTools
+
+1. Open DevTools → **Network** tab
+2. Filter by: `funnel-event`
+3. Click any CTA on the home page
+4. Expect: `POST /api/analytics/funnel-event` → **status 200**
+5. Check **Payload** tab — should contain:
+
+```json
+{
+  "session_id": "...",
+  "event": "visa_cta_click",
+  "payload": { "funnel": "visa" }
+}
+```
+
+**Red flags:**
+
+| Symptom                        | Cause                             | Fix                            |
+| ------------------------------ | --------------------------------- | ------------------------------ |
+| `422` response                 | Event name not in `FUNNEL_EVENTS` | Add to registry (PR 1 pattern) |
+| No request                     | Helper not called                 | Check `CTA_TRACKER` map        |
+| Initiator not `funnel-view.ts` | Local tracker still active        | Should not happen after PR 2   |
+
+---
+
+### 17.6 Pre-existing Helpers Reference
+
+| Helper                      | Category    | GA4 Event Name           |
+| --------------------------- | ----------- | ------------------------ |
+| `trackVisaQuizCompleted`    | Visa Oracle | `visa_quiz_completed`    |
+| `trackVisaResultViewed`     | Visa Oracle | `visa_result_viewed`     |
+| `trackVisaChatQuestion`     | Visa Oracle | `visa_chat_question`     |
+| `trackVisaWhatsAppCTA`      | Visa Oracle | `visa_whatsapp_cta`      |
+| `trackVisaCallingBlock`     | Visa Oracle | `visa_calling_block`     |
+| `trackKBLICodeViewed`       | KBLI        | `kbli_code_viewed`       |
+| `trackKBLISearch`           | KBLI        | `kbli_search`            |
+| `trackKBLIChatQuestion`     | KBLI        | `kbli_chat_question`     |
+| `trackTaxDashboardViewed`   | Tax         | `tax_dashboard_viewed`   |
+| `trackPropertyArticleCTA`   | Property    | `property_cta_clicked`   |
+| `trackPropertyAnalyzeCTA`   | Property    | `property_cta_clicked`   |
+| `trackPropertyChatQuestion` | Property    | `property_chat_question` |
+| `trackPropertyWACTA`        | Property    | `property_chat_question` |
 
 ---
 

--- a/apps/mouth/src/app/v2/_components/FunnelFeature.tsx
+++ b/apps/mouth/src/app/v2/_components/FunnelFeature.tsx
@@ -20,8 +20,8 @@ import {
   trackKBLICTA,
   trackTaxCTA,
   trackPropertyCTA,
+  trackFunnelCTA,
 } from "@/lib/analytics";
-
 
 type LayoutMode = "full" | "half";
 
@@ -415,15 +415,7 @@ export function FunnelFeature({
                 switch. Now FUNNEL_PRICING_HREF (real pricing page). */}
               <a
                 href={FUNNEL_PRICING_HREF[funnel]}
-                // CTA-2: "See transparent pricing" — track sebelum navigasi ke halaman pricing
-                onClick={() =>
-                  trackFunnelCTA(
-                    funnel,
-                    "pricing",
-                    "See transparent pricing",
-                    FUNNEL_PRICING_HREF[funnel],
-                  )
-                }
+                onClick={() => trackFunnelCTA(funnel, "consult_click")}
                 className="inline-flex items-center gap-2 rounded-xl px-4 py-2.5 transition-all hover:-translate-y-0.5"
                 style={{
                   background:
@@ -434,7 +426,6 @@ export function FunnelFeature({
                   fontSize: 12,
                   fontWeight: 600,
                 }}
-                onClick={() => track("consult_click")}
               >
                 <span
                   className="text-[10px] font-semibold uppercase tracking-[0.12em]"
@@ -487,7 +478,9 @@ export function FunnelFeature({
                     // CTA-7: Search input — track hanya saat user tekan Enter dengan query non-kosong
                     onKeyDown={(e) => {
                       if (e.key === "Enter" && query.trim()) {
-                        trackFunnelCTA(funnel, "search", query.trim());
+                        trackFunnelCTA(funnel, "search_submit", {
+                          query_length: query.trim().length,
+                        });
                       }
                     }}
                     placeholder={cfg.searchPlaceholder}

--- a/apps/mouth/src/app/v2/_components/FunnelFeature.tsx
+++ b/apps/mouth/src/app/v2/_components/FunnelFeature.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Image from "next/image";
-import Link from "next/link";
+
 import {
   Search,
   IdCard,
@@ -15,64 +15,13 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import type { Funnel } from "@balizero/core/components/ThemeProvider";
+import {
+  trackVisaCTA,
+  trackKBLICTA,
+  trackTaxCTA,
+  trackPropertyCTA,
+} from "@/lib/analytics";
 
-// ---------------------------------------------------------------------------
-// Tracking lokal — self-contained, tidak bergantung pada file di luar /v2.
-// Mengirim event ke GA4 via gtag (no-op jika gtag belum dimuat di halaman).
-// ---------------------------------------------------------------------------
-type GtagFn = (...args: unknown[]) => void;
-
-// Maps funnel × ctaType → specific GA4 event name.
-// Each entry corresponds to one of the 8 tracked CTA surfaces in FunnelFeature.
-const FUNNEL_EVENT_MAP: Record<
-  string,
-  Record<"primary" | "pricing" | "search" | "suggestion", string>
-> = {
-  visa: {
-    primary: "visa_cta_click",
-    pricing: "visa_consult_click",
-    search: "visa_search_submit",
-    suggestion: "visa_suggestion_click",
-  },
-  kbli: {
-    primary: "kbli_cta_click",
-    pricing: "kbli_consult_click",
-    search: "kbli_search_submit",
-    suggestion: "kbli_suggestion_click",
-  },
-  tax: {
-    primary: "tax_cta_click",
-    pricing: "tax_consult_click",
-    search: "tax_search_submit",
-    suggestion: "tax_suggestion_click",
-  },
-  property: {
-    primary: "property_cta_click",
-    pricing: "property_consult_click",
-    search: "property_search_submit",
-    suggestion: "property_suggestion_click",
-  },
-};
-
-function trackFunnelCTA(
-  funnel: string,
-  ctaType: "primary" | "pricing" | "suggestion" | "search",
-  label: string,
-  destination?: string,
-): void {
-  if (typeof window === "undefined") return;
-  const gtag = (window as Window & { gtag?: GtagFn }).gtag;
-  if (typeof gtag !== "function") return;
-  const eventName =
-    FUNNEL_EVENT_MAP[funnel]?.[ctaType] ?? `${funnel}_${ctaType}_clicked`;
-  gtag("event", eventName, {
-    event_category: "FunnelFeature",
-    funnel,
-    cta_type: ctaType,
-    label,
-    ...(destination ? { destination } : {}),
-  });
-}
 
 type LayoutMode = "full" | "half";
 
@@ -253,6 +202,14 @@ const CONFIGS: Record<
   },
 };
 
+// Per-funnel helper dispatch map — avoids a switch in JSX.
+const CTA_TRACKER: Record<Exclude<Funnel, null>, typeof trackVisaCTA> = {
+  visa: trackVisaCTA,
+  kbli: trackKBLICTA,
+  tax: trackTaxCTA,
+  property: trackPropertyCTA,
+};
+
 export function FunnelFeature({
   funnel,
   layout,
@@ -261,6 +218,7 @@ export function FunnelFeature({
   layout: LayoutMode;
 }) {
   const cfg = CONFIGS[funnel];
+  const track = CTA_TRACKER[funnel];
   const [query, setQuery] = useState("");
   const isFull = layout === "full";
 
@@ -425,7 +383,8 @@ export function FunnelFeature({
             )}
 
             <div className="flex items-center gap-4 flex-wrap">
-              <Link
+              {/* Primary CTA — opens funnel app. Track before navigation. */}
+              <a
                 href={FUNNEL_HREF[funnel]}
                 target={
                   FUNNEL_HREF[funnel].startsWith("http") ? "_blank" : undefined
@@ -434,15 +393,6 @@ export function FunnelFeature({
                   FUNNEL_HREF[funnel].startsWith("http")
                     ? "noopener noreferrer"
                     : undefined
-                }
-                // CTA-1: Primary action — track PRIMA che il browser navighi (non blocca)
-                onClick={() =>
-                  trackFunnelCTA(
-                    funnel,
-                    "primary",
-                    cfg.cta,
-                    FUNNEL_HREF[funnel],
-                  )
                 }
                 className="inline-flex items-center gap-2 px-6 py-3 rounded-xl font-bold transition-transform hover:-translate-y-0.5"
                 style={{
@@ -453,13 +403,14 @@ export function FunnelFeature({
                     "0 8px 32px color-mix(in srgb, var(--accent-funnel) 40%, transparent)",
                   textDecoration: "none",
                 }}
+                onClick={() => track("cta_click")}
               >
                 {cfg.cta}
                 <ArrowRight size={14} strokeWidth={2} />
-              </Link>
+              </a>
 
-              {/* Pricing pointer — avoids fixed-price commitment on home.
-                Full pricing lives on the dedicated service detail page.
+              {/* Consult/pricing CTA — avoids fixed-price commitment on homepage.
+                Full pricing lives on the dedicated service page.
                 Fix 2026-04-22: was FUNNEL_HREF (landing page) → bait-and-
                 switch. Now FUNNEL_PRICING_HREF (real pricing page). */}
               <a
@@ -483,6 +434,7 @@ export function FunnelFeature({
                   fontSize: 12,
                   fontWeight: 600,
                 }}
+                onClick={() => track("consult_click")}
               >
                 <span
                   className="text-[10px] font-semibold uppercase tracking-[0.12em]"
@@ -496,7 +448,7 @@ export function FunnelFeature({
               </a>
             </div>
 
-            {/* Search input + chips — merged into glass card (hidden in full homepage layout) */}
+            {/* Search input + suggestion chips — hidden in full homepage layout */}
             {!isFull && (
               <div
                 className="relative rounded-2xl overflow-hidden mt-8 mb-4"
@@ -510,7 +462,19 @@ export function FunnelFeature({
                     "inset 0 1px 0 rgba(255,255,255,0.08), 0 0 30px color-mix(in srgb, var(--accent-funnel) 15%, transparent)",
                 }}
               >
-                <div className="flex items-center gap-3 px-4 py-3">
+                <form
+                  onSubmit={(e) => {
+                    e.preventDefault();
+                    // Track search submit only when query is non-empty
+                    if (query.trim()) {
+                      track("search_submit", {
+                        query_length: query.trim().length,
+                      });
+                    }
+                    window.location.href = `${FUNNEL_HREF[funnel]}?q=${encodeURIComponent(query.trim())}`;
+                  }}
+                  className="flex items-center gap-3 px-4 py-3"
+                >
                   <Search
                     size={14}
                     strokeWidth={2}
@@ -543,7 +507,7 @@ export function FunnelFeature({
                   >
                     ⌘K
                   </kbd>
-                </div>
+                </form>
               </div>
             )}
 
@@ -552,10 +516,10 @@ export function FunnelFeature({
                 {cfg.searchSuggestions.slice(0, 4).map((sug) => (
                   <button
                     key={sug}
-                    // CTA-3..6: Suggestion chip — track chip mana yang diklik + isi query
                     onClick={() => {
                       setQuery(sug);
-                      trackFunnelCTA(funnel, "suggestion", sug);
+                      // Track suggestion selection with the chip label
+                      track("suggestion_click", { suggestion: sug });
                     }}
                     className="px-2.5 py-1 rounded-full text-[11px] font-medium transition-all"
                     style={{

--- a/apps/mouth/src/lib/analytics.ts
+++ b/apps/mouth/src/lib/analytics.ts
@@ -479,7 +479,12 @@ type FunnelCTAAction =
   | "search_submit"
   | "suggestion_click";
 
-function _trackFunnelCTA(
+/** Generic funnel home-block CTA dispatcher.
+ * Fires triple-dispatch: GA4 + internal CRM bus + funnel store.
+ * Used directly by FunnelFeature for cross-funnel callsites (pricing CTA,
+ * search submit). Per-funnel wrappers below for typed callsites.
+ */
+export function trackFunnelCTA(
   funnel: "visa" | "kbli" | "tax" | "property",
   action: FunnelCTAAction,
   extra?: Record<string, string | number | boolean>,
@@ -501,7 +506,7 @@ export function trackVisaCTA(
   action: FunnelCTAAction,
   extra?: Record<string, string | number | boolean>,
 ): void {
-  _trackFunnelCTA("visa", action, extra);
+  trackFunnelCTA("visa", action, extra);
 }
 
 /** Track KBLI Navigator funnel block CTA interactions */
@@ -509,7 +514,7 @@ export function trackKBLICTA(
   action: FunnelCTAAction,
   extra?: Record<string, string | number | boolean>,
 ): void {
-  _trackFunnelCTA("kbli", action, extra);
+  trackFunnelCTA("kbli", action, extra);
 }
 
 /** Track Tax Intelligence funnel block CTA interactions */
@@ -517,7 +522,7 @@ export function trackTaxCTA(
   action: FunnelCTAAction,
   extra?: Record<string, string | number | boolean>,
 ): void {
-  _trackFunnelCTA("tax", action, extra);
+  trackFunnelCTA("tax", action, extra);
 }
 
 /** Track Property Map funnel home-block CTA interactions */
@@ -525,5 +530,5 @@ export function trackPropertyCTA(
   action: FunnelCTAAction,
   extra?: Record<string, string | number | boolean>,
 ): void {
-  _trackFunnelCTA("property", action, extra);
+  trackFunnelCTA("property", action, extra);
 }

--- a/apps/mouth/src/lib/analytics.ts
+++ b/apps/mouth/src/lib/analytics.ts
@@ -405,8 +405,11 @@ export function trackTaxDashboardViewed(
 
 // --- Property ---
 
-/** Track property article CTA interaction */
-export function trackPropertyCTA(articleSlug: string, ctaType: string): void {
+/** Track property article-page CTA interaction (article slug + CTA type) */
+export function trackPropertyArticleCTA(
+  articleSlug: string,
+  ctaType: string,
+): void {
   sendGA4Event("property_cta_clicked", {
     event_category: "Property",
     article_slug: articleSlug,
@@ -461,4 +464,66 @@ export function trackPropertyWACTA(): void {
     sessionId: getOrCreateSessionId(),
     payload: { cta_type: "whatsapp" },
   });
+}
+
+// ============================================================
+// Funnel Home-Block CTA Helpers
+// Dispatches to GA4 + internal CRM bus + funnel store.
+// Used by FunnelFeature component for main CTA, consult/pricing
+// CTA, search submit, and suggestion chip interactions.
+// ============================================================
+
+type FunnelCTAAction =
+  | "cta_click"
+  | "consult_click"
+  | "search_submit"
+  | "suggestion_click";
+
+function _trackFunnelCTA(
+  funnel: "visa" | "kbli" | "tax" | "property",
+  action: FunnelCTAAction,
+  extra?: Record<string, string | number | boolean>,
+): void {
+  // Event name: e.g. "visa_cta_click", "kbli_search_submit"
+  const eventName = `${funnel}_${action}` as const;
+  const params = { event_category: "FunnelCTA", funnel, ...extra };
+  sendGA4Event(eventName, params);
+  trackEvent(eventName, { funnel, ...extra });
+  void trackFunnelEvent(
+    // Cast is safe: all 16 combinations are in FUNNEL_EVENTS
+    eventName as Parameters<typeof trackFunnelEvent>[0],
+    { sessionId: getOrCreateSessionId(), payload: { funnel, ...extra } },
+  );
+}
+
+/** Track Visa Oracle funnel block CTA interactions */
+export function trackVisaCTA(
+  action: FunnelCTAAction,
+  extra?: Record<string, string | number | boolean>,
+): void {
+  _trackFunnelCTA("visa", action, extra);
+}
+
+/** Track KBLI Navigator funnel block CTA interactions */
+export function trackKBLICTA(
+  action: FunnelCTAAction,
+  extra?: Record<string, string | number | boolean>,
+): void {
+  _trackFunnelCTA("kbli", action, extra);
+}
+
+/** Track Tax Intelligence funnel block CTA interactions */
+export function trackTaxCTA(
+  action: FunnelCTAAction,
+  extra?: Record<string, string | number | boolean>,
+): void {
+  _trackFunnelCTA("tax", action, extra);
+}
+
+/** Track Property Map funnel home-block CTA interactions */
+export function trackPropertyCTA(
+  action: FunnelCTAAction,
+  extra?: Record<string, string | number | boolean>,
+): void {
+  _trackFunnelCTA("property", action, extra);
 }


### PR DESCRIPTION
## Context

Noted in PR #471 review: FunnelFeature CTAs were only sending events
to GA4, bypassing the internal funnel store.

Root cause: no shared helper existed for home-block CTA interactions.
Tracking was local-only and incomplete.

---

## Changes

### `lib/analytics.ts`

New helpers — same triple-dispatch pattern as `trackVisaWhatsAppCTA`
(GA4 + CRM bus + funnel store):

| Helper               | Funnel           |
|----------------------|------------------|
| `trackVisaCTA`       | Visa Oracle      |
| `trackKBLICTA`       | KBLI Navigator   |
| `trackTaxCTA`        | Tax Intelligence |
| `trackPropertyCTA`   | Property Map     |

Rename: `trackPropertyCTA` (article-scoped, zero consumers)
→ `trackPropertyArticleCTA` to free the name for the funnel helper.

### `FunnelFeature.tsx`

- Wired 4 interactions to shared helpers via `CTA_TRACKER` dispatch map
- Wrapped search box in `<form onSubmit>` so Enter key triggers `search_submit`
- Standardised all inline comments to English

---

## Verified locally

- `tsc --noEmit` → exit 0
- Network tab: 2× `POST /api/analytics/funnel-event` → status 200
- Initiator: `funnel-view.ts:64` (correct call path, not local tracker)

---

## Open question

Search `onSubmit` currently navigates to the funnel app with `?q=...`.
Is this intended, or should the search box remain decorative (track only)?

- ✅ YES → keep as-is
- ❌ NO  → I'll remove the redirect

---

## Depends on

`sancho/funnel-event-names` — must merge first.
Base branch is set accordingly.
