### PR TITLE
chore(mata-garuda): track normalizer + NER worker runners (Mini follow-up)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -646,3 +646,6 @@ docs/codex-reviews/
 # Generator:       scripts/pricelist_2026/
 # Versioned MD:    docs/pricing/Bali_Zero_Price_List_2026.md
 # Working assets:  ~/Desktop/Bali_Zero_Price_List_2026_assets/
+
+# Mini-Pro2 venv aside (transient backup during venv recreations)
+apps/backend-rag/.venv.mini-aside-*/

--- a/apps/mata-garuda/scripts/run_ner_worker.py
+++ b/apps/mata-garuda/scripts/run_ner_worker.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Mata Garuda — NER Worker runner (Layer 2.5 Pre-KG).
+
+Reads garuda:enriched without entities, runs qwen3.5:9b NER extraction
+via Ollama, republishes items with entities JSON populated. This is
+the upstream prerequisite for run_kg_linker.py.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from mata_garuda.workers.ner_worker import run_ner
+
+
+def main() -> int:
+    total = {"processed": 0, "extracted": 0, "empty": 0}
+
+    # Drain in batches of 20 (NER is heavier than normalize); cap 200/run
+    for _ in range(10):
+        r = run_ner(max_items=20)
+        if r.get("processed", 0) == 0:
+            break
+        for k in total:
+            total[k] += r.get(k, 0)
+
+    print(json.dumps({"run": total}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/mata-garuda/scripts/run_normalizer.py
+++ b/apps/mata-garuda/scripts/run_normalizer.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Mata Garuda — Normalizer runner (Layer 2 Kognitif).
+
+Drains garuda:raw through the normalizer worker to populate
+garuda:enriched with deduplicated, schema-normalized items.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from mata_garuda.runtime.knowledge import KnowledgeBase
+from mata_garuda.workers.normalizer import run_normalizer
+
+
+def main() -> int:
+    kb = KnowledgeBase()
+    total = {"processed": 0, "duplicates": 0, "published": 0, "errors": 0}
+
+    # Drain in batches of 50; cap 1000 items/run
+    for _ in range(20):
+        r = run_normalizer(kb, max_items=50)
+        if r.get("processed", 0) == 0:
+            break
+        for k in total:
+            total[k] += r.get(k, 0)
+
+    kb.close()
+    print(json.dumps({"run": total}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Track `apps/mata-garuda/scripts/run_normalizer.py` and `apps/mata-garuda/scripts/run_ner_worker.py` (already driving production LaunchAgents on Mini-Pro2 — `com.matagaruda.normalizer.hourly` and `com.matagaruda.ner-worker.hourly`)
- Add `.gitignore` entry for `apps/backend-rag/.venv.mini-aside-*/` (transient backup during venv recreations on Mini)

## Context
Both scripts were created locally on Mini during the W2 KG-bridge work, ran in production via LaunchAgents, but were never committed. PR #489 (W2 KG bridge) was squash-merged without them. This is the cleanup follow-up.

Both follow the existing `run_kg_linker.py` pattern: drain-loop with batch cap, sys.path bootstrap, JSON summary on stdout.

## Test plan
- [x] Both scripts already running in production on Mini (verified via launchctl list)
- [ ] CI green