### PR TITLE
fix(wr2/canva): persist race — telemetry success before DB UPDATE crashed

### DIFF
--- a/docs/wr2/2026-05-08-sprint-b-to-f-detailed-plan.md
+++ b/docs/wr2/2026-05-08-sprint-b-to-f-detailed-plan.md
@@ -165,6 +165,12 @@ except CanvaInvokeError as exc:
 
 **Effort**: 2h.
 
+#### B0 known issue: telemetry success vs DB persist race (FIXED 2026-05-08)
+
+The first B0 implementation (PR #516) wrote `_log_run_telemetry(draft_id, n, "success", ...)` BEFORE `_persist_canva_result`, so the JSONL recorded "success" while DB persist could still crash. Empirical case: draft `0e8e1cf5` 2026-05-07 23:53 → 2026-05-08 00:26 UTC — telemetry shows `outcome="success" duration_s=1943.4` but DB row has `canva_design_id=NULL`. Root cause: the asyncpg connection opened in `run()` was held open across the 32-min synchronous `subprocess.run([claude, -p, ...])` blocking call inside `invoke_claude_apply()`. The Fly Postgres tunnel / wireguard proxy closed the idle TCP socket. `_persist_canva_result` then raised `asyncpg.exceptions.ConnectionDoesNotExistError: connection was closed in the middle of operation` (two empirical occurrences in `~/logs/wr2_canva_apply.launchd.err.log`, both at the persist call site post-32min subprocess).
+
+**Fix**: PR `fix/wr2-canva-persist-race-2026-05-08` reorders telemetry to write `success` only AFTER `_persist_canva_result` returns; on persist exception writes `outcome="persist_failed"` so JSONL truthfully mirrors DB state. `_persist_canva_result` accepts `dsn` and re-opens a fresh connection if `conn.is_closed()` — making persist resilient to wireguard idle-timeout. Tests: `scripts/tests/test_wr2_canva_apply_persist_race.py` (4 scenarios). The B0 success-rate denominator now equals the DB-persisted-rendered count, not the apply-returned-result count.
+
 ### B1 — MCP pre-warm wrapper (PARKED — pending B0 data)
 
 **Scope**: prima del `claude -p` "vero", lancia un probe `claude -p` short-running per portare in cache la connessione MCP Canva. Se probe fallisce → retry con backoff. Se persiste fail → Telegram alert + skip draft.

--- a/scripts/tests/test_wr2_canva_apply_persist_race.py
+++ b/scripts/tests/test_wr2_canva_apply_persist_race.py
@@ -1,0 +1,256 @@
+"""Unit tests for the persist race in scripts/wr2_canva_apply.py.
+
+Empirical bug captured 2026-05-07 23:53 → 00:26 UTC for draft 0e8e1cf5:
+the asyncpg connection opened in `run()` is held open for the duration of
+the synchronous `subprocess.run([claude, -p, ...])` call inside
+`invoke_claude_apply()`. After 24-32 minutes the Fly Postgres tunnel /
+wireguard proxy closes the idle TCP socket. When `_apply_one_draft` then
+calls `_persist_canva_result(conn, ...)`, asyncpg raises
+`ConnectionDoesNotExistError`. Two empirical occurrences in
+~/logs/wr2_canva_apply.launchd.err.log; both at the persist call site.
+
+Pre-fix bug: `_log_run_telemetry(success)` runs BEFORE the persist, so
+telemetry JSONL records "success" while the DB still has
+`canva_design_id IS NULL`. The B0 instrumentation thus over-reports
+the success rate.
+
+Tests:
+1. When `_persist_canva_result` raises (e.g. ConnectionDoesNotExistError),
+   telemetry MUST NOT contain a "success" row for the attempt — only
+   "persist_failed" with the exception text.
+2. When the `conn` arg passed in is dead and a DSN is available, persist
+   MUST re-open a fresh connection and complete the UPDATE successfully.
+3. Happy path: telemetry "success" is written exactly once, AFTER persist
+   has completed.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+APPLY_PATH = SCRIPTS_DIR / "wr2_canva_apply.py"
+
+
+@pytest.fixture
+def apply_mod(tmp_path, monkeypatch):
+    """Load wr2_canva_apply with TELEMETRY_PATH redirected to tmp_path."""
+    sys.modules.pop("wr2_canva_apply", None)
+    spec = importlib.util.spec_from_file_location("wr2_canva_apply", APPLY_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["wr2_canva_apply"] = mod
+    spec.loader.exec_module(mod)
+    # Redirect telemetry to tmp so tests can assert on file contents.
+    telemetry_file = tmp_path / "telemetry.jsonl"
+    mod.TELEMETRY_PATH = telemetry_file
+    # Pin pending dir to tmp so the .write_text in _apply_one_draft is harmless.
+    pending_dir = tmp_path / "pending"
+    mod.PENDING_PROD_DIR = pending_dir
+    mod.PENDING_PROD_FILE = pending_dir / "canva_pending.json"
+    return mod
+
+
+def _make_row(draft_id: uuid.UUID) -> dict:
+    return {
+        "id": draft_id,
+        "topic": "Indonesia Cracks Down on Sham Investor Visas",
+        "tone": "pedagogico",
+        "slides_json": {
+            "slides": [
+                {"index": 1, "title": "T1", "body": "B1"},
+                {"index": 2, "title": "T2", "body": "B2"},
+                {"index": 3, "title": "T3", "body": "B3"},
+            ],
+        },
+    }
+
+
+def _read_telemetry(path: Path) -> list[dict]:
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def test_persist_failure_does_not_log_telemetry_success(apply_mod):
+    """When _persist_canva_result raises, telemetry must NOT have an outcome=success row.
+
+    This reproduces the empirical 2026-05-07 23:53 bug: telemetry recorded
+    "success" while the DB persist crashed with ConnectionDoesNotExistError.
+    """
+    draft_id = uuid.uuid4()
+    row = _make_row(draft_id)
+
+    fake_result = apply_mod.CanvaApplyResult(
+        design_id="DAHITEST123",
+        edit_url="https://www.canva.com/d/abc",
+        view_url="https://www.canva.com/d/xyz",
+        stdout_tail="ok",
+        duration_sec=1943.4,
+    )
+
+    # invoke_claude_apply succeeds.
+    invoke_mock = MagicMock(return_value=fake_result)
+
+    # _persist_canva_result raises (simulating the dead-conn crash).
+    class _ConnDead(Exception):
+        pass
+
+    persist_mock = AsyncMock(side_effect=_ConnDead("connection was closed in the middle of operation"))
+
+    with patch.object(apply_mod, "invoke_claude_apply", invoke_mock), \
+         patch.object(apply_mod, "_persist_canva_result", persist_mock), \
+         patch.object(apply_mod, "_send_telegram", lambda *_a, **_kw: None), \
+         patch.object(apply_mod, "build_canva_pending", lambda **_kw: {"slides": []}):
+        ok = asyncio.run(apply_mod._apply_one_draft(MagicMock(), row, dsn="postgres://stub"))
+
+    # Bug: persist failed → return False expected.
+    assert ok is False, "Persist failure must propagate as False (not silent success)"
+
+    # CORE ASSERTION: no "success" row in telemetry — only the persist failure.
+    rows = _read_telemetry(apply_mod.TELEMETRY_PATH)
+    success_rows = [r for r in rows if r.get("outcome") == "success"]
+    assert success_rows == [], (
+        f"Telemetry must NOT contain success when persist failed. "
+        f"Got: {success_rows}"
+    )
+
+    # POSITIVE: there IS a row recording the persist failure.
+    persist_failed_rows = [r for r in rows if r.get("outcome") == "persist_failed"]
+    assert len(persist_failed_rows) == 1, (
+        f"Expected exactly 1 persist_failed telemetry row, got {persist_failed_rows}"
+    )
+    assert "connection was closed" in persist_failed_rows[0].get("exc_head", "")
+    assert persist_failed_rows[0]["draft_id"] == str(draft_id)
+
+
+def test_persist_reopens_dead_connection(apply_mod, monkeypatch):
+    """If the conn passed into _persist_canva_result is dead, the helper must
+    re-open a fresh connection from DSN and complete the UPDATE.
+
+    This is the runtime resilience: the existing `conn` was opened in run()
+    before the long subprocess call; if the wireguard tunnel timed it out
+    during the 32-min invoke_claude_apply, persist needs to reconnect.
+    """
+    draft_id = uuid.uuid4()
+
+    # Simulated dead conn: is_closed() returns True.
+    dead_conn = MagicMock()
+    dead_conn.is_closed = MagicMock(return_value=True)
+    dead_conn.execute = AsyncMock(side_effect=AssertionError("dead conn must NOT be used"))
+
+    # Fresh conn the helper should reach for via asyncpg.connect.
+    fresh_conn = MagicMock()
+    fresh_conn.execute = AsyncMock(return_value="UPDATE 1")
+    fresh_conn.close = AsyncMock()
+
+    connect_mock = AsyncMock(return_value=fresh_conn)
+    monkeypatch.setattr(apply_mod.asyncpg, "connect", connect_mock)
+
+    fake_result = apply_mod.CanvaApplyResult(
+        design_id="DAHITEST123",
+        edit_url="https://www.canva.com/d/abc",
+        view_url="https://www.canva.com/d/xyz",
+        stdout_tail="ok",
+        duration_sec=10.0,
+    )
+
+    asyncio.run(
+        apply_mod._persist_canva_result(
+            dead_conn, draft_id, fake_result, dsn="postgres://stub"
+        )
+    )
+
+    # Dead conn must NOT have been used.
+    dead_conn.execute.assert_not_called()
+    # asyncpg.connect must have been invoked with the DSN.
+    connect_mock.assert_awaited_once()
+    args, kwargs = connect_mock.call_args
+    # asyncpg.connect accepts dsn as first positional or as `dsn=` kwarg
+    assert (args and args[0] == "postgres://stub") or kwargs.get("dsn") == "postgres://stub"
+    # Fresh conn ran the UPDATE.
+    fresh_conn.execute.assert_awaited_once()
+    fresh_conn.close.assert_awaited_once()
+
+
+def test_persist_uses_existing_conn_when_alive(apply_mod, monkeypatch):
+    """Happy path: the existing conn is alive, no reconnect needed."""
+    draft_id = uuid.uuid4()
+
+    live_conn = MagicMock()
+    live_conn.is_closed = MagicMock(return_value=False)
+    live_conn.execute = AsyncMock(return_value="UPDATE 1")
+
+    # asyncpg.connect MUST NOT be called.
+    connect_mock = AsyncMock(side_effect=AssertionError("should not reconnect when conn alive"))
+    monkeypatch.setattr(apply_mod.asyncpg, "connect", connect_mock)
+
+    fake_result = apply_mod.CanvaApplyResult(
+        design_id="DAHITEST123",
+        edit_url="https://www.canva.com/d/abc",
+        view_url="https://www.canva.com/d/xyz",
+        stdout_tail="ok",
+        duration_sec=10.0,
+    )
+
+    asyncio.run(
+        apply_mod._persist_canva_result(
+            live_conn, draft_id, fake_result, dsn="postgres://stub"
+        )
+    )
+
+    live_conn.execute.assert_awaited_once()
+    connect_mock.assert_not_awaited()
+
+
+def test_happy_path_logs_success_after_persist(apply_mod):
+    """End-to-end happy path: telemetry success row is written AFTER persist
+    completes (i.e. exactly once, with the design_id surviving in DB).
+    """
+    draft_id = uuid.uuid4()
+    row = _make_row(draft_id)
+
+    fake_result = apply_mod.CanvaApplyResult(
+        design_id="DAHITEST123",
+        edit_url="https://www.canva.com/d/abc",
+        view_url="https://www.canva.com/d/xyz",
+        stdout_tail="ok",
+        duration_sec=120.0,
+    )
+
+    # Ordered events list to verify ordering.
+    events: list[str] = []
+
+    def _fake_invoke(_path):
+        events.append("invoke")
+        return fake_result
+
+    async def _fake_persist(_conn, _draft_id, _result, dsn=None):
+        events.append("persist")
+
+    # Wrap _log_run_telemetry to record call order.
+    original_log = apply_mod._log_run_telemetry
+
+    def _spy_log(*args, **kwargs):
+        events.append(f"telemetry:{args[2]}")  # outcome is positional arg 2
+        return original_log(*args, **kwargs)
+
+    with patch.object(apply_mod, "invoke_claude_apply", _fake_invoke), \
+         patch.object(apply_mod, "_persist_canva_result", _fake_persist), \
+         patch.object(apply_mod, "_log_run_telemetry", _spy_log), \
+         patch.object(apply_mod, "_send_telegram", lambda *_a, **_kw: None), \
+         patch.object(apply_mod, "build_canva_pending", lambda **_kw: {"slides": []}):
+        ok = asyncio.run(apply_mod._apply_one_draft(MagicMock(), row, dsn="postgres://stub"))
+
+    assert ok is True
+    # Order MUST be: invoke → persist → telemetry:success.
+    # The bug was: invoke → telemetry:success → persist (race).
+    assert events == ["invoke", "persist", "telemetry:success"], (
+        f"Wrong ordering: {events}. Telemetry success must come AFTER persist."
+    )

--- a/scripts/wr2_canva_apply.py
+++ b/scripts/wr2_canva_apply.py
@@ -181,24 +181,63 @@ async def _persist_canva_result(
     conn: asyncpg.Connection,
     draft_id: UUID,
     result: CanvaApplyResult,
+    *,
+    dsn: str | None = None,
 ) -> None:
-    """Store edit URL + advance status to 'rendered'."""
-    await conn.execute(
-        """
-        UPDATE war_room_drafts
-           SET canva_design_id  = $2,
-               canva_edit_url   = $3,
-               canva_view_url   = $4,
-               canva_applied_at = NOW(),
-               status           = 'rendered',
-               updated_at       = NOW()
-         WHERE id = $1
-        """,
-        draft_id,
-        result.design_id,
-        result.edit_url,
-        result.view_url,
-    )
+    """Store edit URL + advance status to 'rendered'.
+
+    The `conn` passed in was opened in `run()` BEFORE `_apply_one_draft`
+    invoked the synchronous `subprocess.run([claude, -p, ...])` blocking
+    call inside `invoke_claude_apply()`. That subprocess routinely runs
+    25-32 minutes; the Fly Postgres tunnel / wireguard proxy closes idle
+    TCP sockets in that window. Empirical 2026-05-07 23:53 → 00:26 UTC
+    crash on draft 0e8e1cf5 raised
+    `asyncpg.exceptions.ConnectionDoesNotExistError` exactly here, AFTER
+    `_log_run_telemetry(success)` had already written a "success" row.
+    Result: telemetry over-reports the success rate while DB stays at
+    `canva_design_id IS NULL`.
+
+    Mitigation: if the existing `conn` is closed and a `dsn` is provided,
+    open a fresh asyncpg connection just for this UPDATE and close it
+    after. Caller is responsible for not logging telemetry success until
+    this function returns.
+    """
+    use_conn = conn
+    fresh_owned = False
+    if conn.is_closed():
+        if not dsn:
+            raise RuntimeError(
+                f"_persist_canva_result: conn is closed and no dsn provided "
+                f"(draft={draft_id}). Cannot persist Canva result."
+            )
+        logger.warning(
+            "Draft %s: persist conn was closed (likely wireguard idle-timeout "
+            "across long subprocess) — reconnecting from DSN",
+            draft_id,
+        )
+        use_conn = await asyncpg.connect(dsn, timeout=10)
+        fresh_owned = True
+
+    try:
+        await use_conn.execute(
+            """
+            UPDATE war_room_drafts
+               SET canva_design_id  = $2,
+                   canva_edit_url   = $3,
+                   canva_view_url   = $4,
+                   canva_applied_at = NOW(),
+                   status           = 'rendered',
+                   updated_at       = NOW()
+             WHERE id = $1
+            """,
+            draft_id,
+            result.design_id,
+            result.edit_url,
+            result.view_url,
+        )
+    finally:
+        if fresh_owned:
+            await use_conn.close()
 
 
 def _send_telegram(text: str) -> None:
@@ -223,7 +262,12 @@ def _send_telegram(text: str) -> None:
         logger.warning("Telegram send failed: %s", e)
 
 
-async def _apply_one_draft(conn: asyncpg.Connection, row: asyncpg.Record) -> bool:
+async def _apply_one_draft(
+    conn: asyncpg.Connection,
+    row: asyncpg.Record,
+    *,
+    dsn: str | None = None,
+) -> bool:
     """Process a single draft. Returns True on success."""
     draft_id: UUID = row["id"]
     topic: str = row["topic"]
@@ -254,11 +298,23 @@ async def _apply_one_draft(conn: asyncpg.Connection, row: asyncpg.Record) -> boo
     # On the happy path (50% baseline), this adds zero overhead beyond a
     # JSONL log line. On cold-sentinel detection, sleep 60s and retry once
     # before giving up — far cheaper than the 25-min wasted timeout.
+    #
+    # Persist-race fix (2026-05-08): the empirical 2026-05-07 23:53 → 00:26
+    # UTC crash showed `_log_run_telemetry(success)` was being written
+    # BEFORE `_persist_canva_result`, then asyncpg raised
+    # ConnectionDoesNotExistError because the connection was closed by the
+    # Fly tunnel during the 32-min subprocess. Telemetry now records
+    # "success" only AFTER persist returns; if persist itself raises, an
+    # extra "persist_failed" row is written so the JSONL truthfully
+    # mirrors DB state.
     t0 = time.time()
     result = None
+    successful_attempt = 0
+    successful_duration = 0.0
     try:
         result = invoke_claude_apply(pending_path)
-        _log_run_telemetry(draft_id, 1, "success", time.time() - t0, "")
+        successful_attempt = 1
+        successful_duration = time.time() - t0
     except CanvaInvokeError as exc:
         d1 = time.time() - t0
         outcome1 = _classify_failure(exc)
@@ -272,7 +328,8 @@ async def _apply_one_draft(conn: asyncpg.Connection, row: asyncpg.Record) -> boo
             t1 = time.time()
             try:
                 result = invoke_claude_apply(pending_path)
-                _log_run_telemetry(draft_id, 2, "success", time.time() - t1, "")
+                successful_attempt = 2
+                successful_duration = time.time() - t1
             except CanvaInvokeError as exc2:
                 d2 = time.time() - t1
                 outcome2 = _classify_failure(exc2)
@@ -296,7 +353,29 @@ async def _apply_one_draft(conn: asyncpg.Connection, row: asyncpg.Record) -> boo
             )
             return False
 
-    await _persist_canva_result(conn, draft_id, result)
+    # Persist with reconnect-on-dead-conn + truthful telemetry.
+    try:
+        await _persist_canva_result(conn, draft_id, result, dsn=dsn)
+    except Exception as exc:  # noqa: BLE001 — telemetry must capture every persist failure
+        _log_run_telemetry(
+            draft_id,
+            successful_attempt,
+            "persist_failed",
+            successful_duration,
+            f"{type(exc).__name__}: {exc}",
+        )
+        logger.error(
+            "Draft %s: Canva apply succeeded but DB persist failed (%s: %s)",
+            draft_id, type(exc).__name__, exc,
+        )
+        _send_telegram(
+            f"🚨 *WR2 Canva persist failed*\ndraft: `{draft_id}`\n"
+            f"topic: {topic[:80]}\noutcome: `persist_failed`\n"
+            f"error: `{type(exc).__name__}: {str(exc)[:400]}`",
+        )
+        return False
+
+    _log_run_telemetry(draft_id, successful_attempt, "success", successful_duration, "")
     logger.info(
         "Draft %s applied — design=%s edit_url=%s duration=%.1fs",
         draft_id,
@@ -340,7 +419,7 @@ async def run() -> int:
         successes = 0
         started = time.monotonic()
         for row in drafts:
-            ok = await _apply_one_draft(conn, row)
+            ok = await _apply_one_draft(conn, row, dsn=dsn)
             if ok:
                 successes += 1
 


### PR DESCRIPTION
## Summary

Sprint B Task 1: fix the **B0 known issue** where telemetry recorded `outcome=\"success\"` for draft `0e8e1cf5` (2026-05-07 23:53 → 2026-05-08 00:26 UTC, `duration_s=1943.4`) while the DB row stayed at `canva_design_id=NULL` and `status=drafts_imaged`.

**Root cause**: the asyncpg connection opened in `run()` is held open across the 32-min synchronous `subprocess.run([claude, -p, ...])` blocking call inside `invoke_claude_apply()`. The Fly Postgres tunnel / wireguard proxy closes idle TCP sockets in that window. `_persist_canva_result` then raises `asyncpg.exceptions.ConnectionDoesNotExistError: connection was closed in the middle of operation` — but **after** `_log_run_telemetry(success)` had already been logged (B0 instrumentation, PR #516). Two empirical occurrences captured in `~/logs/wr2_canva_apply.launchd.err.log`, both at the persist call site post long subprocess.

## Fix

1. `_persist_canva_result(conn, draft_id, result, *, dsn=None)` — if `conn.is_closed()` and `dsn` is provided, opens a fresh asyncpg connection just for the UPDATE and closes it after. Survives wireguard idle-timeout.
2. `_apply_one_draft` reorders telemetry: `_log_run_telemetry(success)` now writes only AFTER `_persist_canva_result` returns. If persist itself raises, an extra `outcome=\"persist_failed\"` row is written so JSONL truthfully mirrors DB state.
3. `run()` passes `dsn` through to `_apply_one_draft`.

The B0 success-rate denominator now equals the **DB-persisted-rendered count**, not the apply-returned-result count.

## Test plan

- [x] `scripts/tests/test_wr2_canva_apply_persist_race.py` — 4 scenarios:
  - `test_persist_failure_does_not_log_telemetry_success` — when persist raises, JSONL has `persist_failed`, NOT `success`
  - `test_persist_reopens_dead_connection` — dead conn → asyncpg.connect from DSN, fresh conn used, fresh conn closed
  - `test_persist_uses_existing_conn_when_alive` — live conn → no reconnect (asyncpg.connect MUST NOT be called)
  - `test_happy_path_logs_success_after_persist` — verifies invoke → persist → telemetry:success ordering
- [x] `python -m py_compile` + `ast.parse` clean
- [x] Pre-existing `test_wr2_supervisor.py::test_reconcile_kicks_stalled` failure is unrelated (Sprint A bypass: `drafts_imaged → canva-apply`, not `→ fact-extractor` as test expects). Verified the same test fails on `main`.
- [ ] Live smoke after merge: trigger `launchctl kickstart com.balizero.wr2.canva-apply`, verify (a) telemetry success comes only after DB UPDATE persists, (b) on successful persist, log line `Draft X applied — design=...` follows the JSONL success entry.

## Out of scope (follow-ups)

- `wr2_canva_desktop_apply.py` has the same persist pattern but durations are typically 5-9 min (sometimes ~25 min). Not yet seen empirical conn-closed crashes — left untouched here to limit blast radius. Consider applying the same `is_closed()` reconnect helper in a separate PR.
- The 2026-05-07 23:28:42 `rendered → drafts_imaged` reset of draft `0e8e1cf5` (separate from the persist race) was not traced in this PR. The supervisor only OBSERVES the change via `wr2_status_change` NOTIFY; the writer is not yet identified. Tracked as a Sprint B follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)