### PR TITLE
feat(domain-mesh): Phase 0 foundations — 8 modules R1-R7 SOTA

### DIFF
--- a/apps/mata-garuda/data/gov_apis_inventory.json
+++ b/apps/mata-garuda/data/gov_apis_inventory.json
@@ -1,0 +1,55 @@
+[
+  { "id": "djp", "url": "https://pajak.go.id", "category": "tax" },
+  {
+    "id": "kemenkeu_jdih",
+    "url": "https://jdih.kemenkeu.go.id",
+    "category": "regulation"
+  },
+  { "id": "setkab", "url": "https://setkab.go.id", "category": "regulation" },
+  {
+    "id": "peraturan_go_id",
+    "url": "https://peraturan.go.id",
+    "category": "regulation"
+  },
+  {
+    "id": "peraturan_bpk",
+    "url": "https://peraturan.bpk.go.id",
+    "category": "regulation"
+  },
+  { "id": "jdihn", "url": "https://jdihn.go.id", "category": "regulation" },
+  { "id": "bps", "url": "https://bps.go.id", "category": "macro_economy" },
+  { "id": "bi", "url": "https://www.bi.go.id", "category": "macro_economy" },
+  { "id": "ojk", "url": "https://ojk.go.id", "category": "macro_economy" },
+  {
+    "id": "imigrasi",
+    "url": "https://www.imigrasi.go.id",
+    "category": "immigration"
+  },
+  {
+    "id": "kemenkumham",
+    "url": "https://www.kemenkumham.go.id",
+    "category": "immigration"
+  },
+  { "id": "kemnaker", "url": "https://kemnaker.go.id", "category": "labor" },
+  { "id": "atrbpn", "url": "https://www.atrbpn.go.id", "category": "property" },
+  {
+    "id": "jdih_baliprov",
+    "url": "https://jdih.baliprov.go.id",
+    "category": "regulation_bali"
+  },
+  {
+    "id": "jdih_badungkab",
+    "url": "https://jdih.badungkab.go.id",
+    "category": "regulation_bali"
+  },
+  {
+    "id": "jdih_gianyarkab",
+    "url": "https://jdih.gianyarkab.go.id",
+    "category": "regulation_bali"
+  },
+  {
+    "id": "jdih_denpasarkota",
+    "url": "https://jdih.denpasarkota.go.id",
+    "category": "regulation_bali"
+  }
+]

--- a/apps/mata-garuda/mata_garuda/foundations/__init__.py
+++ b/apps/mata-garuda/mata_garuda/foundations/__init__.py
@@ -1,0 +1,74 @@
+"""Domain Mesh foundations layer (Phase 0).
+
+Source spec: docs/superpowers/specs/2026-05-08-domain-mesh-autonomic-design.md §9
+Source plan: docs/superpowers/plans/2026-05-08-domain-mesh-phase0-foundations.md
+
+8 modules backed by R1-R7 SOTA research (2026-05-08):
+- pasal_id_client (R2)        — 40k Indonesian regulations
+- gov_apis_health (R2)        — gov portal status tracker
+- bali_calendar (R6)          — Saka/Pawukon ceremonies
+- gdelt_client (R6)           — Indonesia news raw signal
+- opensanctions_id (R7)       — Indonesia sanctions/PEP
+- ner_extractor (R7)          — bahasa NER (cahya BERT)
+- arxiv_sanity_scorer (R5)    — personal relevance SVM
+- openllmetry_init (R1)       — observability bootstrap
+"""
+from mata_garuda.foundations.arxiv_sanity_scorer import (
+    ArxivSanityScorer,
+    LabeledPaper,
+)
+from mata_garuda.foundations.bali_calendar import (
+    BalineseDate,
+    days_until_next_galungan,
+    get_balinese_date,
+    is_galungan,
+    is_kuningan,
+)
+from mata_garuda.foundations.gdelt_client import GdeltArticle, GdeltClient
+from mata_garuda.foundations.gov_apis_health import (
+    HealthReport,
+    PortalHealth,
+    load_inventory,
+    probe_inventory,
+    probe_portal,
+)
+from mata_garuda.foundations.ner_extractor import NamedEntity, NERExtractor
+from mata_garuda.foundations.openllmetry_init import (
+    init_openllmetry,
+    is_openllmetry_enabled,
+)
+from mata_garuda.foundations.opensanctions_id import (
+    OpenSanctionsClient,
+    SanctionEntity,
+)
+from mata_garuda.foundations.pasal_id_client import (
+    LawSearchResult,
+    LawStatus,
+    PasalIdClient,
+)
+
+__all__ = [
+    "ArxivSanityScorer",
+    "BalineseDate",
+    "GdeltArticle",
+    "GdeltClient",
+    "HealthReport",
+    "LabeledPaper",
+    "LawSearchResult",
+    "LawStatus",
+    "NERExtractor",
+    "NamedEntity",
+    "OpenSanctionsClient",
+    "PasalIdClient",
+    "PortalHealth",
+    "SanctionEntity",
+    "days_until_next_galungan",
+    "get_balinese_date",
+    "init_openllmetry",
+    "is_galungan",
+    "is_kuningan",
+    "is_openllmetry_enabled",
+    "load_inventory",
+    "probe_inventory",
+    "probe_portal",
+]

--- a/apps/mata-garuda/mata_garuda/foundations/arxiv_sanity_scorer.py
+++ b/apps/mata-garuda/mata_garuda/foundations/arxiv_sanity_scorer.py
@@ -1,0 +1,55 @@
+"""arxiv-sanity SVM-on-tfidf scorer.
+
+Discovered in R5 SOTA 2026-05-08. Karpathy's pattern: zero LLM cost,
+self-host. Port of arxiv-sanity-lite core algorithm.
+
+Train on Antonello's tagged papers, score new candidates by per-tag SVM.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.svm import LinearSVC
+from sklearn.calibration import CalibratedClassifierCV
+
+
+@dataclass(frozen=True)
+class LabeledPaper:
+    id: str
+    abstract: str
+    label: int  # 1 = relevant, 0 = not relevant
+
+
+class ArxivSanityScorer:
+    def __init__(self, max_features: int = 5000):
+        self._max_features = max_features
+        self._vectorizer: Optional[TfidfVectorizer] = None
+        self._model: Optional[CalibratedClassifierCV] = None
+
+    def train(self, papers: list[LabeledPaper]) -> None:
+        labels = {p.label for p in papers}
+        if len(labels) < 2:
+            raise ValueError("Training requires at least two classes (positive and negative)")
+        self._vectorizer = TfidfVectorizer(
+            max_features=self._max_features,
+            ngram_range=(1, 2),
+            stop_words="english",
+        )
+        X = self._vectorizer.fit_transform([p.abstract for p in papers])
+        y = np.array([p.label for p in papers])
+        base = LinearSVC()
+        # CalibratedClassifierCV gives us probability output for ranking
+        self._model = CalibratedClassifierCV(base, cv=min(3, len(papers) // 2 or 2))
+        self._model.fit(X, y)
+
+    def score(self, abstract: str) -> float:
+        if self._vectorizer is None or self._model is None:
+            raise RuntimeError("Scorer not trained. Call train() first.")
+        X = self._vectorizer.transform([abstract])
+        proba = self._model.predict_proba(X)[0]
+        # Return P(label=1)
+        idx = list(self._model.classes_).index(1)
+        return float(proba[idx])

--- a/apps/mata-garuda/mata_garuda/foundations/bali_calendar.py
+++ b/apps/mata-garuda/mata_garuda/foundations/bali_calendar.py
@@ -1,0 +1,80 @@
+"""Balinese Pawukon + Saka calendar.
+
+Discovered in R6 SOTA 2026-05-08. Source: babadbali.com + peradnya/balinese-date-js-lib (port).
+
+Pawukon cycle = 210 days. 30 wuku of 7 days each. Galungan = Buda (Wed) Kliwon Dungulan
+(day 1 of wuku Dunggulan, position 11/30). Kuningan = Saniscara (Sat) Kliwon Kuningan
+(day 5 of wuku Kuningan, position 12/30, 10 days after Galungan).
+
+Anchor: 2026-06-17 (Wed) IS Galungan — verified against
+https://kalenderbali.org/?bulan=6&tanggal=17&tahun=2026 (R6).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+
+PAWUKON_CYCLE_DAYS = 210
+
+WUKU_NAMES = [
+    "Sinta", "Landep", "Ukir", "Kulantir", "Tolu", "Gumbreg", "Wariga",
+    "Warigadean", "Julungwangi", "Sungsang", "Dunggulan", "Kuningan",
+    "Langkir", "Medangsia", "Pujut", "Pahang", "Krulut", "Merakih",
+    "Tambir", "Medangkungan", "Matal", "Uye", "Menail", "Prangbakat",
+    "Bala", "Ugu", "Wayang", "Kelawu", "Dukut", "Watugunung",
+]
+assert len(WUKU_NAMES) == 30
+
+# Anchor: 2026-06-17 = Galungan = day 1 of Dunggulan (wuku 11, 0-indexed 10).
+# Wuku Dunggulan starts on 2026-06-17 in this anchor convention.
+# Therefore Pawukon day 1 of cycle (Sinta day 1) = 2026-06-17 - (10 * 7) days = 2026-04-08.
+ANCHOR_PAWUKON_DAY_1 = date(2026, 4, 8)
+GALUNGAN_PAWUKON_DAY_INDEX = 10 * 7  # 0-indexed: day 70 of cycle (1-indexed: 71)
+# Kuningan = Galungan + 10 days (Sat 2026-06-27 verified via R6 source).
+KUNINGAN_PAWUKON_DAY_INDEX = GALUNGAN_PAWUKON_DAY_INDEX + 10  # 0-indexed: 80
+
+
+@dataclass(frozen=True)
+class BalineseDate:
+    gregorian: date
+    pawukon_day: int  # 1..210
+    wuku: str
+    wuku_day: int  # 1..7 within current wuku
+    is_galungan: bool
+    is_kuningan: bool
+
+
+def _pawukon_day_index(target: date) -> int:
+    """Return 0-indexed position in 210-day Pawukon cycle."""
+    delta_days = (target - ANCHOR_PAWUKON_DAY_1).days
+    return delta_days % PAWUKON_CYCLE_DAYS
+
+
+def get_balinese_date(target: date) -> BalineseDate:
+    idx = _pawukon_day_index(target)
+    wuku_position = idx // 7  # 0..29
+    wuku_day = (idx % 7) + 1  # 1..7
+    return BalineseDate(
+        gregorian=target,
+        pawukon_day=idx + 1,
+        wuku=WUKU_NAMES[wuku_position],
+        wuku_day=wuku_day,
+        is_galungan=(idx == GALUNGAN_PAWUKON_DAY_INDEX),
+        is_kuningan=(idx == KUNINGAN_PAWUKON_DAY_INDEX),
+    )
+
+
+def is_galungan(target: date) -> bool:
+    return _pawukon_day_index(target) == GALUNGAN_PAWUKON_DAY_INDEX
+
+
+def is_kuningan(target: date) -> bool:
+    return _pawukon_day_index(target) == KUNINGAN_PAWUKON_DAY_INDEX
+
+
+def days_until_next_galungan(target: date) -> int:
+    idx = _pawukon_day_index(target)
+    days_until = (GALUNGAN_PAWUKON_DAY_INDEX - idx) % PAWUKON_CYCLE_DAYS
+    if days_until == 0:
+        return PAWUKON_CYCLE_DAYS
+    return days_until

--- a/apps/mata-garuda/mata_garuda/foundations/gdelt_client.py
+++ b/apps/mata-garuda/mata_garuda/foundations/gdelt_client.py
@@ -1,0 +1,63 @@
+"""GDELT DOC 2.0 API client.
+
+Discovered in R6 SOTA 2026-05-08. Free, no auth, 65 languages translated to EN.
+Indonesia FIPS-2 = ID. Update frequency: every 15 minutes.
+
+API base: https://api.gdeltproject.org/api/v2/doc/doc
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+import httpx
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+GDELT_DOC_API = "https://api.gdeltproject.org/api/v2/doc/doc"
+DEFAULT_TIMEOUT = 30.0
+
+
+@dataclass(frozen=True)
+class GdeltArticle:
+    url: str
+    title: str
+    seen_date: Optional[datetime]
+    domain: str
+    language: str
+    source_country: str
+
+
+class GdeltClient:
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=8))
+    async def search_indonesia(self, query: str, max_results: int = 50) -> list[GdeltArticle]:
+        params = {
+            "query": f'{query} sourcecountry:ID',
+            "mode": "ArtList",
+            "format": "json",
+            "maxrecords": str(max_results),
+        }
+        async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+            response = await client.get(GDELT_DOC_API, params=params)
+            response.raise_for_status()
+            payload = response.json()
+        return [
+            GdeltArticle(
+                url=item["url"],
+                title=item.get("title", ""),
+                seen_date=self._parse_seen_date(item.get("seendate")),
+                domain=item.get("domain", ""),
+                language=item.get("language", ""),
+                source_country=item.get("sourcecountry", ""),
+            )
+            for item in payload.get("articles", [])
+        ]
+
+    @staticmethod
+    def _parse_seen_date(raw: Optional[str]) -> Optional[datetime]:
+        if not raw:
+            return None
+        try:
+            return datetime.strptime(raw, "%Y%m%dT%H%M%SZ")
+        except ValueError:
+            return None

--- a/apps/mata-garuda/mata_garuda/foundations/gov_apis_health.py
+++ b/apps/mata-garuda/mata_garuda/foundations/gov_apis_health.py
@@ -1,0 +1,85 @@
+"""Indonesian gov-apis health monitor.
+
+Forks the spirit of suryast/indonesia-gov-apis (50+ portal status tracker).
+We probe a curated subset of 14+ portals relevant to Bali Zero monthly.
+
+Discovery: R2 SOTA 2026-05-08 — "22 operational, 6 geo-blocked,
+5 CF/bot-challenged, 16 DNS failures (28% infrastructure dead)".
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import httpx
+
+INVENTORY_PATH = Path(__file__).parent.parent.parent / "data" / "gov_apis_inventory.json"
+PROBE_TIMEOUT_SECONDS = 15.0
+
+PortalStatus = Literal[
+    "operational",
+    "dns_failure",
+    "cf_challenge",
+    "geo_blocked",
+    "http_5xx",
+    "http_4xx",
+    "timeout",
+    "unknown",
+]
+
+
+@dataclass(frozen=True)
+class PortalHealth:
+    id: str
+    url: str
+    status: PortalStatus
+    http_code: int | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class HealthReport:
+    total: int
+    operational: int
+    results: list[PortalHealth]
+
+
+def load_inventory() -> list[dict]:
+    return json.loads(INVENTORY_PATH.read_text(encoding="utf-8"))
+
+
+async def probe_portal(entry: dict) -> PortalHealth:
+    portal_id = entry["id"]
+    url = entry["url"]
+    try:
+        async with httpx.AsyncClient(timeout=PROBE_TIMEOUT_SECONDS, follow_redirects=True) as client:
+            response = await client.get(url)
+        code = response.status_code
+        if code == 200:
+            return PortalHealth(id=portal_id, url=url, status="operational", http_code=code)
+        if code == 403 and "cloudflare" in response.headers.get("server", "").lower():
+            return PortalHealth(id=portal_id, url=url, status="cf_challenge", http_code=code)
+        if code == 451 or code == 403:
+            return PortalHealth(id=portal_id, url=url, status="geo_blocked", http_code=code)
+        if code >= 500:
+            return PortalHealth(id=portal_id, url=url, status="http_5xx", http_code=code)
+        if code >= 400:
+            return PortalHealth(id=portal_id, url=url, status="http_4xx", http_code=code)
+        return PortalHealth(id=portal_id, url=url, status="unknown", http_code=code)
+    except httpx.ConnectError as exc:
+        return PortalHealth(id=portal_id, url=url, status="dns_failure", error=str(exc))
+    except httpx.TimeoutException as exc:
+        return PortalHealth(id=portal_id, url=url, status="timeout", error=str(exc))
+
+
+async def probe_inventory(inventory: list[dict] | None = None) -> HealthReport:
+    if inventory is None:
+        inventory = load_inventory()
+    results = []
+    for entry in inventory:
+        result = await probe_portal(entry)
+        results.append(result)
+    operational = sum(1 for r in results if r.status == "operational")
+    return HealthReport(total=len(results), operational=operational, results=results)

--- a/apps/mata-garuda/mata_garuda/foundations/ner_extractor.py
+++ b/apps/mata-garuda/mata_garuda/foundations/ner_extractor.py
@@ -1,0 +1,56 @@
+"""Bahasa Indonesia NER extractor.
+
+Discovered in R7 SOTA 2026-05-08.
+Model: cahya/bert-base-indonesian-NER (HuggingFace, free).
+Labels: PERSON, ORG, LOC, TIME, QUANTITY.
+
+Used cross-domain (B1 regulation entity extraction, B5 macro stakeholders,
+B6 OSINT person/org detection).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Sequence
+
+from transformers import pipeline
+
+DEFAULT_MODEL = "cahya/bert-base-indonesian-NER"
+
+
+@dataclass(frozen=True)
+class NamedEntity:
+    label: str  # "PERSON" | "ORG" | "LOC" | "TIME" | "QUANTITY"
+    text: str
+    score: float
+    start: int
+    end: int
+
+
+class NERExtractor:
+    def __init__(self, model_name: str = DEFAULT_MODEL):
+        self._model_name = model_name
+        self._pipeline = pipeline(
+            "ner",
+            model=model_name,
+            aggregation_strategy="simple",
+        )
+
+    def extract(self, text: str, labels: Sequence[str] | None = None) -> list[NamedEntity]:
+        if not text:
+            return []
+        raw = self._pipeline(text)
+        entities = [
+            NamedEntity(
+                label=item["entity_group"],
+                text=item["word"],
+                score=float(item["score"]),
+                start=int(item["start"]),
+                end=int(item["end"]),
+            )
+            for item in raw
+        ]
+        if labels is None:
+            return entities
+        labelset = set(labels)
+        return [e for e in entities if e.label in labelset]

--- a/apps/mata-garuda/mata_garuda/foundations/openllmetry_init.py
+++ b/apps/mata-garuda/mata_garuda/foundations/openllmetry_init.py
@@ -1,0 +1,37 @@
+"""OpenLLMetry SDK initialization helper.
+
+Discovered in R1 SOTA 2026-05-08. OpenLLMetry (Traceloop) is OTel-native;
+pair with Langfuse + Phoenix backend (Phase 1 deferred).
+
+Dormant mode pattern (Nuzantara PR #312 cicatrix): when env vars unset,
+init returns False and SDK is not loaded. Zero overhead.
+
+Activation: set OPENLLMETRY_ENDPOINT (e.g. http://mini-pro2.local:4318)
+plus optional Langfuse keys to forward to Langfuse self-host.
+"""
+from __future__ import annotations
+
+import os
+
+
+def is_openllmetry_enabled() -> bool:
+    if os.environ.get("LANGFUSE_ENABLED", "").lower() == "false":
+        return False
+    return bool(os.environ.get("OPENLLMETRY_ENDPOINT"))
+
+
+def init_openllmetry(service_name: str) -> bool:
+    """Initialize OpenLLMetry SDK if env-enabled. Returns True if active."""
+    if not is_openllmetry_enabled():
+        return False
+    try:
+        from traceloop.sdk import Traceloop
+    except ImportError:
+        # SDK not installed — dormant mode.
+        return False
+    Traceloop.init(
+        app_name=service_name,
+        api_endpoint=os.environ["OPENLLMETRY_ENDPOINT"],
+        disable_batch=False,
+    )
+    return True

--- a/apps/mata-garuda/mata_garuda/foundations/opensanctions_id.py
+++ b/apps/mata-garuda/mata_garuda/foundations/opensanctions_id.py
@@ -1,0 +1,66 @@
+"""OpenSanctions Indonesia datasets client.
+
+Discovered in R7 SOTA 2026-05-08. Free non-commercial.
+Datasets:
+  - id_dttot (Indonesian Suspected Terrorists, daily)
+  - id_regional_2018 (2018 Regional Head Election Results)
+
+Used for KYC/PEP screening of Bali Zero clients (B6 sink).
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+OPENSANCTIONS_BASE = "https://data.opensanctions.org/datasets"
+DEFAULT_TIMEOUT = 60.0
+
+
+@dataclass(frozen=True)
+class SanctionEntity:
+    id: str
+    schema: str  # "Person" | "Organization" | "Address" etc.
+    caption: str
+    properties: dict
+
+
+class OpenSanctionsClient:
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=8))
+    async def fetch_dttot(self) -> list[SanctionEntity]:
+        url = f"{OPENSANCTIONS_BASE}/latest/id_dttot/entities.ftm.json"
+        return await self._fetch_jsonlines(url)
+
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=8))
+    async def fetch_regional_2018(self) -> list[SanctionEntity]:
+        url = f"{OPENSANCTIONS_BASE}/latest/id_regional_2018/entities.ftm.json"
+        return await self._fetch_jsonlines(url)
+
+    async def match_name(self, name_substring: str) -> list[SanctionEntity]:
+        entities = await self.fetch_dttot()
+        needle = name_substring.lower()
+        return [e for e in entities if needle in e.caption.lower()]
+
+    @staticmethod
+    async def _fetch_jsonlines(url: str) -> list[SanctionEntity]:
+        async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+            text = response.text
+        entities = []
+        for line in text.strip().split("\n"):
+            if not line.strip():
+                continue
+            payload = json.loads(line)
+            entities.append(
+                SanctionEntity(
+                    id=payload["id"],
+                    schema=payload["schema"],
+                    caption=payload.get("caption", ""),
+                    properties=payload.get("properties", {}),
+                )
+            )
+        return entities

--- a/apps/mata-garuda/mata_garuda/foundations/pasal_id_client.py
+++ b/apps/mata-garuda/mata_garuda/foundations/pasal_id_client.py
@@ -1,0 +1,73 @@
+"""pasal.id API client wrapper.
+
+Source: ilhamfp/pasal (https://pasal.id) — 40,143 Indonesian regulations indexed.
+Discovered in R2 SOTA research 2026-05-08.
+
+This client uses the public REST surface; the FastMCP server upstream
+exposes the same primitives. We use httpx async for parity with the rest of
+the mata-garuda stack.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+import httpx
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+PASAL_ID_BASE_URL = "https://pasal.id/api"
+DEFAULT_TIMEOUT_SECONDS = 30.0
+
+
+@dataclass(frozen=True)
+class LawSearchResult:
+    id: str
+    title: str
+    year: int
+    kind: str  # "UU" | "PP" | "Perpres" | "PMK" | "PER" | "KEP" | "SE" | etc.
+
+
+@dataclass(frozen=True)
+class LawStatus:
+    id: str
+    status: Literal["berlaku", "dicabut", "diubah", "tidak_berlaku"]
+    superseded_by: Optional[str]
+
+
+class PasalIdClient:
+    """Async client for pasal.id regulation search + status lookup."""
+
+    def __init__(self, base_url: str = PASAL_ID_BASE_URL, timeout: float = DEFAULT_TIMEOUT_SECONDS):
+        self._base_url = base_url
+        self._timeout = timeout
+
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=8))
+    async def search_laws(self, query: str, limit: int = 10) -> list[LawSearchResult]:
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(
+                f"{self._base_url}/laws/search",
+                params={"q": query, "limit": limit},
+            )
+            response.raise_for_status()
+            payload = response.json()
+        return [
+            LawSearchResult(
+                id=item["id"],
+                title=item["title"],
+                year=int(item["year"]),
+                kind=item.get("kind", "UNKNOWN"),
+            )
+            for item in payload.get("results", [])
+        ]
+
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=8))
+    async def get_law_status(self, law_id: str) -> LawStatus:
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(f"{self._base_url}/laws/{law_id}/status")
+            response.raise_for_status()
+            payload = response.json()
+        return LawStatus(
+            id=payload["id"],
+            status=payload["status"],
+            superseded_by=payload.get("superseded_by"),
+        )

--- a/apps/mata-garuda/pyproject.toml
+++ b/apps/mata-garuda/pyproject.toml
@@ -19,6 +19,18 @@ dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
 ]
+foundations = [
+    "httpx>=0.27,<1.0",
+    "tenacity>=8.2,<10.0",
+    "transformers>=4.40,<5.0",
+    "torch>=2.1,<3.0",
+    "sentencepiece>=0.2,<1.0",
+    "scikit-learn>=1.4,<2.0",
+    "numpy>=1.26,<3.0",
+]
+foundations-observability = [
+    "traceloop-sdk>=0.20,<1.0",
+]
 
 [project.scripts]
 mata-garuda = "mata_garuda.cli:main"

--- a/apps/mata-garuda/tests/foundations/test_arxiv_sanity_scorer.py
+++ b/apps/mata-garuda/tests/foundations/test_arxiv_sanity_scorer.py
@@ -1,0 +1,45 @@
+import pytest
+from mata_garuda.foundations.arxiv_sanity_scorer import (
+    ArxivSanityScorer,
+    LabeledPaper,
+)
+
+
+def test_scorer_trains_and_predicts_higher_score_for_in_class():
+    positive_papers = [
+        LabeledPaper(id="p1", abstract="agentic LLM RAG retrieval", label=1),
+        LabeledPaper(id="p2", abstract="RAG corrective self-RAG retrieval augmented", label=1),
+        LabeledPaper(id="p3", abstract="agentic deep research multi-agent", label=1),
+    ]
+    negative_papers = [
+        LabeledPaper(id="n1", abstract="quantum chromodynamics lattice gauge", label=0),
+        LabeledPaper(id="n2", abstract="cosmology dark matter halo simulation", label=0),
+        LabeledPaper(id="n3", abstract="condensed matter superconductivity bcs", label=0),
+    ]
+
+    scorer = ArxivSanityScorer()
+    scorer.train(positive_papers + negative_papers)
+
+    in_class = scorer.score("agentic RAG corrective retrieval")
+    out_class = scorer.score("quantum lattice gauge theory")
+
+    assert in_class > out_class
+    assert 0.0 <= in_class <= 1.0
+    assert 0.0 <= out_class <= 1.0
+
+
+def test_scorer_raises_if_predict_before_train():
+    scorer = ArxivSanityScorer()
+    with pytest.raises(RuntimeError, match="not trained"):
+        scorer.score("anything")
+
+
+def test_scorer_handles_single_class_training_gracefully():
+    """If user has only positive samples, scorer should not crash."""
+    only_positive = [
+        LabeledPaper(id="p1", abstract="agentic LLM", label=1),
+        LabeledPaper(id="p2", abstract="RAG retrieval", label=1),
+    ]
+    scorer = ArxivSanityScorer()
+    with pytest.raises(ValueError, match="at least two classes"):
+        scorer.train(only_positive)

--- a/apps/mata-garuda/tests/foundations/test_bali_calendar.py
+++ b/apps/mata-garuda/tests/foundations/test_bali_calendar.py
@@ -1,0 +1,41 @@
+from datetime import date
+from mata_garuda.foundations.bali_calendar import (
+    get_balinese_date,
+    is_galungan,
+    is_kuningan,
+    days_until_next_galungan,
+)
+
+
+def test_galungan_2026_06_17():
+    """R6 source-of-truth: Galungan = Wed 2026-06-17."""
+    assert is_galungan(date(2026, 6, 17)) is True
+
+
+def test_kuningan_2026_06_27():
+    """R6 source-of-truth: Kuningan = Sat 2026-06-27."""
+    assert is_kuningan(date(2026, 6, 27)) is True
+
+
+def test_non_ceremony_day_returns_false():
+    assert is_galungan(date(2026, 5, 8)) is False
+    assert is_kuningan(date(2026, 5, 8)) is False
+
+
+def test_get_balinese_date_returns_wuku_and_pawukon_day():
+    result = get_balinese_date(date(2026, 6, 17))
+    assert result.wuku == "Dunggulan"
+    assert result.is_galungan is True
+    assert result.is_kuningan is False
+
+
+def test_days_until_next_galungan_from_2026_05_08():
+    """40 days from 2026-05-08 to 2026-06-17."""
+    delta = days_until_next_galungan(date(2026, 5, 8))
+    assert delta == 40
+
+
+def test_days_until_next_galungan_after_event_returns_next_cycle():
+    """From 2026-06-18 (day after), next Galungan = 2027-01-13 (210 days later)."""
+    delta = days_until_next_galungan(date(2026, 6, 18))
+    assert delta == 210 - 1  # 209 days

--- a/apps/mata-garuda/tests/foundations/test_gdelt_client.py
+++ b/apps/mata-garuda/tests/foundations/test_gdelt_client.py
@@ -1,0 +1,49 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from mata_garuda.foundations.gdelt_client import (
+    GdeltClient,
+    GdeltArticle,
+)
+
+
+@pytest.mark.asyncio
+async def test_search_articles_indonesia_filters_country_id():
+    fake_response = {
+        "articles": [
+            {
+                "url": "https://kompas.com/article/1",
+                "title": "Kabinet reshuffle Indonesia",
+                "seendate": "20260508T100000Z",
+                "domain": "kompas.com",
+                "language": "Indonesian",
+                "sourcecountry": "Indonesia",
+            }
+        ]
+    }
+    with patch("mata_garuda.foundations.gdelt_client.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value.json = lambda: fake_response
+        mock_client.get.return_value.raise_for_status = lambda: None
+        mock_cls.return_value.__aenter__.return_value = mock_client
+
+        client = GdeltClient()
+        articles = await client.search_indonesia(query="kabinet", max_results=10)
+
+    assert len(articles) == 1
+    assert isinstance(articles[0], GdeltArticle)
+    assert articles[0].source_country == "Indonesia"
+
+
+@pytest.mark.asyncio
+async def test_search_articles_handles_empty_response():
+    fake_response = {"articles": []}
+    with patch("mata_garuda.foundations.gdelt_client.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value.json = lambda: fake_response
+        mock_client.get.return_value.raise_for_status = lambda: None
+        mock_cls.return_value.__aenter__.return_value = mock_client
+
+        client = GdeltClient()
+        articles = await client.search_indonesia(query="zzzznotrending", max_results=10)
+
+    assert articles == []

--- a/apps/mata-garuda/tests/foundations/test_gov_apis_health.py
+++ b/apps/mata-garuda/tests/foundations/test_gov_apis_health.py
@@ -1,0 +1,67 @@
+import json
+from pathlib import Path
+import pytest
+from unittest.mock import AsyncMock, patch
+from mata_garuda.foundations.gov_apis_health import (
+    PortalHealth,
+    HealthReport,
+    probe_portal,
+    probe_inventory,
+    load_inventory,
+)
+
+
+def test_load_inventory_returns_seed_entries():
+    inventory = load_inventory()
+    assert len(inventory) >= 14
+    assert any(p["id"] == "djp" for p in inventory)
+    assert any(p["id"] == "bps" for p in inventory)
+    assert any(p["id"] == "jdihn" for p in inventory)
+
+
+@pytest.mark.asyncio
+async def test_probe_portal_marks_operational_on_200():
+    with patch("mata_garuda.foundations.gov_apis_health.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value.status_code = 200
+        mock_cls.return_value.__aenter__.return_value = mock_client
+
+        result = await probe_portal({"id": "djp", "url": "https://pajak.go.id"})
+
+    assert isinstance(result, PortalHealth)
+    assert result.id == "djp"
+    assert result.status == "operational"
+    assert result.http_code == 200
+
+
+@pytest.mark.asyncio
+async def test_probe_portal_marks_dns_failure_on_connect_error():
+    with patch("mata_garuda.foundations.gov_apis_health.httpx.AsyncClient") as mock_cls:
+        from httpx import ConnectError
+
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = ConnectError("DNS resolution failed")
+        mock_cls.return_value.__aenter__.return_value = mock_client
+
+        result = await probe_portal({"id": "dead-portal", "url": "https://dead.go.id"})
+
+    assert result.status == "dns_failure"
+
+
+@pytest.mark.asyncio
+async def test_probe_inventory_aggregates_results():
+    fake_inventory = [
+        {"id": "djp", "url": "https://pajak.go.id"},
+        {"id": "bps", "url": "https://bps.go.id"},
+    ]
+    with patch("mata_garuda.foundations.gov_apis_health.probe_portal") as mock_probe:
+        mock_probe.side_effect = [
+            PortalHealth(id="djp", url="https://pajak.go.id", status="operational", http_code=200),
+            PortalHealth(id="bps", url="https://bps.go.id", status="cf_challenge", http_code=403),
+        ]
+        report = await probe_inventory(fake_inventory)
+
+    assert isinstance(report, HealthReport)
+    assert report.total == 2
+    assert report.operational == 1
+    assert len(report.results) == 2

--- a/apps/mata-garuda/tests/foundations/test_ner_extractor.py
+++ b/apps/mata-garuda/tests/foundations/test_ner_extractor.py
@@ -1,0 +1,53 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from mata_garuda.foundations.ner_extractor import (
+    NERExtractor,
+    NamedEntity,
+)
+
+
+def test_extract_returns_named_entities():
+    fake_pipeline_output = [
+        {"entity_group": "PERSON", "word": "Bimo Wijayanto", "score": 0.99, "start": 0, "end": 14},
+        {"entity_group": "ORG", "word": "DJP", "score": 0.95, "start": 18, "end": 21},
+    ]
+
+    with patch("mata_garuda.foundations.ner_extractor.pipeline") as mock_pipeline_factory:
+        mock_pipeline = MagicMock(return_value=fake_pipeline_output)
+        mock_pipeline_factory.return_value = mock_pipeline
+
+        extractor = NERExtractor()
+        entities = extractor.extract("Bimo Wijayanto dari DJP")
+
+    assert len(entities) == 2
+    assert isinstance(entities[0], NamedEntity)
+    assert entities[0].label == "PERSON"
+    assert entities[0].text == "Bimo Wijayanto"
+    assert entities[1].label == "ORG"
+
+
+def test_extract_empty_text_returns_empty_list():
+    with patch("mata_garuda.foundations.ner_extractor.pipeline") as mock_pipeline_factory:
+        mock_pipeline = MagicMock(return_value=[])
+        mock_pipeline_factory.return_value = mock_pipeline
+
+        extractor = NERExtractor()
+        entities = extractor.extract("")
+
+    assert entities == []
+
+
+def test_filter_by_label_only_returns_matching():
+    fake_pipeline_output = [
+        {"entity_group": "PERSON", "word": "Bimo", "score": 0.99, "start": 0, "end": 4},
+        {"entity_group": "ORG", "word": "DJP", "score": 0.95, "start": 8, "end": 11},
+    ]
+    with patch("mata_garuda.foundations.ner_extractor.pipeline") as mock_pipeline_factory:
+        mock_pipeline = MagicMock(return_value=fake_pipeline_output)
+        mock_pipeline_factory.return_value = mock_pipeline
+
+        extractor = NERExtractor()
+        people = extractor.extract("Bimo dari DJP", labels=("PERSON",))
+
+    assert len(people) == 1
+    assert people[0].text == "Bimo"

--- a/apps/mata-garuda/tests/foundations/test_openllmetry_init.py
+++ b/apps/mata-garuda/tests/foundations/test_openllmetry_init.py
@@ -1,0 +1,34 @@
+import os
+import pytest
+from unittest.mock import patch
+from mata_garuda.foundations.openllmetry_init import (
+    init_openllmetry,
+    is_openllmetry_enabled,
+)
+
+
+def test_is_disabled_when_no_env_vars():
+    with patch.dict(os.environ, {}, clear=True):
+        assert is_openllmetry_enabled() is False
+
+
+def test_is_enabled_when_endpoint_set():
+    with patch.dict(os.environ, {"OPENLLMETRY_ENDPOINT": "http://localhost:4318"}, clear=True):
+        assert is_openllmetry_enabled() is True
+
+
+def test_is_disabled_via_kill_switch():
+    """LANGFUSE_ENABLED=false acts as full kill-switch (Nuzantara PR #312 pattern)."""
+    with patch.dict(
+        os.environ,
+        {"OPENLLMETRY_ENDPOINT": "http://localhost:4318", "LANGFUSE_ENABLED": "false"},
+        clear=True,
+    ):
+        assert is_openllmetry_enabled() is False
+
+
+def test_init_returns_quickly_when_disabled():
+    """Dormant mode = 1ms no-op (Nuzantara cicatrix pattern)."""
+    with patch.dict(os.environ, {}, clear=True):
+        result = init_openllmetry(service_name="test-service")
+    assert result is False  # not initialized

--- a/apps/mata-garuda/tests/foundations/test_opensanctions_id.py
+++ b/apps/mata-garuda/tests/foundations/test_opensanctions_id.py
@@ -1,0 +1,49 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from mata_garuda.foundations.opensanctions_id import (
+    OpenSanctionsClient,
+    SanctionEntity,
+)
+
+
+@pytest.mark.asyncio
+async def test_fetch_dttot_dataset_returns_entities():
+    fake_jsonlines = (
+        '{"id":"id-dttot-1","schema":"Person","caption":"Suspected Person 1",'
+        '"properties":{"name":["Suspected Person 1"]}}\n'
+        '{"id":"id-dttot-2","schema":"Person","caption":"Suspected Person 2",'
+        '"properties":{"name":["Suspected Person 2"]}}\n'
+    )
+    with patch("mata_garuda.foundations.opensanctions_id.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value.text = fake_jsonlines
+        mock_client.get.return_value.raise_for_status = lambda: None
+        mock_cls.return_value.__aenter__.return_value = mock_client
+
+        client = OpenSanctionsClient()
+        entities = await client.fetch_dttot()
+
+    assert len(entities) == 2
+    assert isinstance(entities[0], SanctionEntity)
+    assert entities[0].id == "id-dttot-1"
+
+
+@pytest.mark.asyncio
+async def test_match_entity_by_name_substring():
+    fake_jsonlines = (
+        '{"id":"id-dttot-1","schema":"Person","caption":"Marina Pinyaylova",'
+        '"properties":{"name":["Marina Pinyaylova"]}}\n'
+        '{"id":"id-dttot-2","schema":"Person","caption":"Other",'
+        '"properties":{"name":["Other Person"]}}\n'
+    )
+    with patch("mata_garuda.foundations.opensanctions_id.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value.text = fake_jsonlines
+        mock_client.get.return_value.raise_for_status = lambda: None
+        mock_cls.return_value.__aenter__.return_value = mock_client
+
+        client = OpenSanctionsClient()
+        matches = await client.match_name("Marina")
+
+    assert len(matches) == 1
+    assert matches[0].caption == "Marina Pinyaylova"

--- a/apps/mata-garuda/tests/foundations/test_pasal_id_client.py
+++ b/apps/mata-garuda/tests/foundations/test_pasal_id_client.py
@@ -1,0 +1,51 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from mata_garuda.foundations.pasal_id_client import (
+    PasalIdClient,
+    LawSearchResult,
+    LawStatus,
+)
+
+
+@pytest.mark.asyncio
+async def test_search_laws_returns_typed_results():
+    fake_response = {
+        "results": [
+            {"id": "uu-2022-27", "title": "UU 27/2022 PDP", "year": 2022, "kind": "UU"}
+        ],
+        "total": 1,
+    }
+    with patch("mata_garuda.foundations.pasal_id_client.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value.json = lambda: fake_response
+        mock_client.get.return_value.raise_for_status = lambda: None
+        mock_cls.return_value.__aenter__.return_value = mock_client
+
+        client = PasalIdClient()
+        result = await client.search_laws(query="PDP", limit=10)
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert isinstance(result[0], LawSearchResult)
+    assert result[0].id == "uu-2022-27"
+
+
+@pytest.mark.asyncio
+async def test_get_law_status_returns_active_or_superseded():
+    fake_response = {
+        "id": "pmk-2024-81",
+        "status": "berlaku",
+        "superseded_by": None,
+    }
+    with patch("mata_garuda.foundations.pasal_id_client.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value.json = lambda: fake_response
+        mock_client.get.return_value.raise_for_status = lambda: None
+        mock_cls.return_value.__aenter__.return_value = mock_client
+
+        client = PasalIdClient()
+        status = await client.get_law_status(law_id="pmk-2024-81")
+
+    assert isinstance(status, LawStatus)
+    assert status.status == "berlaku"
+    assert status.superseded_by is None

--- a/docs/superpowers/plans/2026-05-08-domain-mesh-phase0-foundations.md
+++ b/docs/superpowers/plans/2026-05-08-domain-mesh-phase0-foundations.md
@@ -1,0 +1,1781 @@
+# Domain Mesh Phase 0 — Foundations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the 9 foundational components for the Domain Mesh autonomic system (R1-R7 SOTA-validated): pasal.id MCP integration, gov-apis health monitor, Wikibase self-host (deferred to Phase 1), Langfuse + Phoenix self-host (deferred), OpenLLMetry SDK (5 critical scripts), cahya BERT-NER deploy, arxiv-sanity SVM, Bali calendar, GDELT API client, OpenSanctions Indonesia ingest.
+
+**Architecture:** Each component is a thin, independent module under `apps/mata-garuda/` (workhorse domain) or `~/scripts/` (LaunchAgent cron). Zero new paid Anthropic API calls. Local-first stack: Mini-Pro2 for self-host, Pro for dev. SQLite per-machine state, Wikidata SPARQL for federation.
+
+**Tech Stack:** Python 3.11+, FastMCP (for pasal.id wrapper), Hugging Face transformers (cahya BERT), scikit-learn (SVM tfidf), httpx (async), tenacity (retry), pydantic (schema), SQLite (state), launchd (cron Mini-Pro2 + Pro).
+
+**Source spec:** `docs/superpowers/specs/2026-05-08-domain-mesh-autonomic-design.md` §9 Phase 0.
+
+**Out of scope this phase (Phase 1):** Wikibase self-host (Phase 1, requires Mini-Pro2 docker setup), Langfuse + Phoenix (Phase 1, depends on observability strategy), per-domain genesis (Phase 1).
+
+---
+
+## File structure
+
+### New directory: `apps/mata-garuda/mata_garuda/foundations/`
+
+Single responsibility: foundational utilities used by all 6 domains.
+
+- `__init__.py` (re-exports public API)
+- `pasal_id_client.py` — pasal.id MCP wrapper (search_laws, get_law_status)
+- `gov_apis_health.py` — fork suryast/indonesia-gov-apis health probe
+- `bali_calendar.py` — Saka/Pawukon date calculator
+- `gdelt_client.py` — GDELT DOC 2.0 API client (Indonesia FIPS-2 = ID)
+- `opensanctions_id.py` — OpenSanctions Indonesia datasets pull
+- `ner_extractor.py` — cahya/bert-base-indonesian-NER wrapper
+- `arxiv_sanity_scorer.py` — SVM-on-tfidf personal relevance scorer
+- `openllmetry_init.py` — OpenLLMetry SDK initialization helper
+
+### New directory: `apps/mata-garuda/tests/foundations/`
+
+- `test_pasal_id_client.py`
+- `test_gov_apis_health.py`
+- `test_bali_calendar.py`
+- `test_gdelt_client.py`
+- `test_opensanctions_id.py`
+- `test_ner_extractor.py`
+- `test_arxiv_sanity_scorer.py`
+- `test_openllmetry_init.py`
+
+### New scripts: `~/scripts/`
+
+- `domain-mesh-foundations-cron.sh` — daily wrapper for foundations cron jobs
+
+### New LaunchAgent: `~/Library/LaunchAgents/`
+
+- `com.balizero.domain-mesh.foundations.daily.plist` — daily 04:00 WITA, runs cron-wrapper
+
+### Existing files to modify
+
+- `apps/mata-garuda/pyproject.toml` — add deps (httpx, transformers, scikit-learn, sentencepiece)
+- `apps/mata-garuda/mata_garuda/__init__.py` — re-export `foundations.*`
+
+---
+
+## Task 1: pasal.id MCP client wrapper
+
+**Files:**
+
+- Create: `apps/mata-garuda/mata_garuda/foundations/pasal_id_client.py`
+- Test: `apps/mata-garuda/tests/foundations/test_pasal_id_client.py`
+
+**Context:** R2 discovered `ilhamfp/pasal` has 40,143 Indonesian regulations with FastMCP server (`search_laws`, `get_pasal`, `get_law_status`, `list_laws`). This task wraps it as a Python async client we can call from feeders.
+
+**Endpoint base:** `https://pasal.id/api/mcp` (provisional — verify in Step 1 by hitting actual URL or fall back to scraping `https://pasal.id/api/laws/search?q=...` JSON endpoint).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# apps/mata-garuda/tests/foundations/test_pasal_id_client.py
+import pytest
+from unittest.mock import AsyncMock, patch
+from mata_garuda.foundations.pasal_id_client import (
+    PasalIdClient,
+    LawSearchResult,
+    LawStatus,
+)
+
+
+@pytest.mark.asyncio
+async def test_search_laws_returns_typed_results():
+    fake_response = {
+        "results": [
+            {"id": "uu-2022-27", "title": "UU 27/2022 PDP", "year": 2022, "kind": "UU"}
+        ],
+        "total": 1,
+    }
+    with patch("mata_garuda.foundations.pasal_id_client.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value.json = lambda: fake_response
+        mock_client.get.return_value.raise_for_status = lambda: None
+        mock_cls.return_value.__aenter__.return_value = mock_client
+
+        client = PasalIdClient()
+        result = await client.search_laws(query="PDP", limit=10)
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert isinstance(result[0], LawSearchResult)
+    assert result[0].id == "uu-2022-27"
+
+
+@pytest.mark.asyncio
+async def test_get_law_status_returns_active_or_superseded():
+    fake_response = {
+        "id": "pmk-2024-81",
+        "status": "berlaku",
+        "superseded_by": None,
+    }
+    with patch("mata_garuda.foundations.pasal_id_client.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value.json = lambda: fake_response
+        mock_client.get.return_value.raise_for_status = lambda: None
+        mock_cls.return_value.__aenter__.return_value = mock_client
+
+        client = PasalIdClient()
+        status = await client.get_law_status(law_id="pmk-2024-81")
+
+    assert isinstance(status, LawStatus)
+    assert status.status == "berlaku"
+    assert status.superseded_by is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/mata-garuda && source ../../.venv/bin/activate && python -m pytest tests/foundations/test_pasal_id_client.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'mata_garuda.foundations.pasal_id_client'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# apps/mata-garuda/mata_garuda/foundations/pasal_id_client.py
+"""pasal.id API client wrapper.
+
+Source: ilhamfp/pasal (https://pasal.id) — 40,143 Indonesian regulations indexed.
+Discovered in R2 SOTA research 2026-05-08.
+
+This client uses the public REST surface; the FastMCP server upstream
+exposes the same primitives. We use httpx async for parity with the rest of
+the mata-garuda stack.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+import httpx
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+PASAL_ID_BASE_URL = "https://pasal.id/api"
+DEFAULT_TIMEOUT_SECONDS = 30.0
+
+
+@dataclass(frozen=True)
+class LawSearchResult:
+    id: str
+    title: str
+    year: int
+    kind: str  # "UU" | "PP" | "Perpres" | "PMK" | "PER" | "KEP" | "SE" | etc.
+
+
+@dataclass(frozen=True)
+class LawStatus:
+    id: str
+    status: Literal["berlaku", "dicabut", "diubah", "tidak_berlaku"]
+    superseded_by: Optional[str]
+
+
+class PasalIdClient:
+    """Async client for pasal.id regulation search + status lookup."""
+
+    def __init__(self, base_url: str = PASAL_ID_BASE_URL, timeout: float = DEFAULT_TIMEOUT_SECONDS):
+        self._base_url = base_url
+        self._timeout = timeout
+
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=8))
+    async def search_laws(self, query: str, limit: int = 10) -> list[LawSearchResult]:
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(
+                f"{self._base_url}/laws/search",
+                params={"q": query, "limit": limit},
+            )
+            response.raise_for_status()
+            payload = response.json()
+        return [
+            LawSearchResult(
+                id=item["id"],
+                title=item["title"],
+                year=int(item["year"]),
+                kind=item.get("kind", "UNKNOWN"),
+            )
+            for item in payload.get("results", [])
+        ]
+
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=8))
+    async def get_law_status(self, law_id: str) -> LawStatus:
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(f"{self._base_url}/laws/{law_id}/status")
+            response.raise_for_status()
+            payload = response.json()
+        return LawStatus(
+            id=payload["id"],
+            status=payload["status"],
+            superseded_by=payload.get("superseded_by"),
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/mata-garuda && python -m pytest tests/foundations/test_pasal_id_client.py -v`
+Expected: PASS, 2 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mata-garuda/mata_garuda/foundations/__init__.py \
+        apps/mata-garuda/mata_garuda/foundations/pasal_id_client.py \
+        apps/mata-garuda/tests/foundations/__init__.py \
+        apps/mata-garuda/tests/foundations/test_pasal_id_client.py
+git commit -m "feat(foundations): pasal.id MCP client wrapper (R2 SOTA)"
+```
+
+---
+
+## Task 2: gov-apis health monitor (suryast fork)
+
+**Files:**
+
+- Create: `apps/mata-garuda/mata_garuda/foundations/gov_apis_health.py`
+- Test: `apps/mata-garuda/tests/foundations/test_gov_apis_health.py`
+- Create: `apps/mata-garuda/data/gov_apis_inventory.json` (seed list, 14 entries from R2)
+
+**Context:** R2 discovered `suryast/indonesia-gov-apis` tracks 50+ Indonesian gov portals: "22 portals fully operational, 6 portals geo-blocked, 5 portals CF/bot-challenged, 16 portals have DNS failures." We probe the 14 most relevant for Bali Zero monthly.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# apps/mata-garuda/tests/foundations/test_gov_apis_health.py
+import json
+from pathlib import Path
+import pytest
+from unittest.mock import AsyncMock, patch
+from mata_garuda.foundations.gov_apis_health import (
+    PortalHealth,
+    HealthReport,
+    probe_portal,
+    probe_inventory,
+    load_inventory,
+)
+
+
+def test_load_inventory_returns_seed_entries():
+    inventory = load_inventory()
+    assert len(inventory) >= 14
+    assert any(p["id"] == "djp" for p in inventory)
+    assert any(p["id"] == "bps" for p in inventory)
+    assert any(p["id"] == "jdihn" for p in inventory)
+
+
+@pytest.mark.asyncio
+async def test_probe_portal_marks_operational_on_200():
+    with patch("mata_garuda.foundations.gov_apis_health.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value.status_code = 200
+        mock_cls.return_value.__aenter__.return_value = mock_client
+
+        result = await probe_portal({"id": "djp", "url": "https://pajak.go.id"})
+
+    assert isinstance(result, PortalHealth)
+    assert result.id == "djp"
+    assert result.status == "operational"
+    assert result.http_code == 200
+
+
+@pytest.mark.asyncio
+async def test_probe_portal_marks_dns_failure_on_connect_error():
+    with patch("mata_garuda.foundations.gov_apis_health.httpx.AsyncClient") as mock_cls:
+        from httpx import ConnectError
+
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = ConnectError("DNS resolution failed")
+        mock_cls.return_value.__aenter__.return_value = mock_client
+
+        result = await probe_portal({"id": "dead-portal", "url": "https://dead.go.id"})
+
+    assert result.status == "dns_failure"
+
+
+@pytest.mark.asyncio
+async def test_probe_inventory_aggregates_results():
+    fake_inventory = [
+        {"id": "djp", "url": "https://pajak.go.id"},
+        {"id": "bps", "url": "https://bps.go.id"},
+    ]
+    with patch("mata_garuda.foundations.gov_apis_health.probe_portal") as mock_probe:
+        mock_probe.side_effect = [
+            PortalHealth(id="djp", url="https://pajak.go.id", status="operational", http_code=200),
+            PortalHealth(id="bps", url="https://bps.go.id", status="cf_challenge", http_code=403),
+        ]
+        report = await probe_inventory(fake_inventory)
+
+    assert isinstance(report, HealthReport)
+    assert report.total == 2
+    assert report.operational == 1
+    assert len(report.results) == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/mata-garuda && python -m pytest tests/foundations/test_gov_apis_health.py -v`
+Expected: FAIL with ModuleNotFoundError
+
+- [ ] **Step 3: Write seed inventory**
+
+```json
+[
+  { "id": "djp", "url": "https://pajak.go.id", "category": "tax" },
+  {
+    "id": "kemenkeu_jdih",
+    "url": "https://jdih.kemenkeu.go.id",
+    "category": "regulation"
+  },
+  { "id": "setkab", "url": "https://setkab.go.id", "category": "regulation" },
+  {
+    "id": "peraturan_go_id",
+    "url": "https://peraturan.go.id",
+    "category": "regulation"
+  },
+  {
+    "id": "peraturan_bpk",
+    "url": "https://peraturan.bpk.go.id",
+    "category": "regulation"
+  },
+  { "id": "jdihn", "url": "https://jdihn.go.id", "category": "regulation" },
+  { "id": "bps", "url": "https://bps.go.id", "category": "macro_economy" },
+  { "id": "bi", "url": "https://www.bi.go.id", "category": "macro_economy" },
+  { "id": "ojk", "url": "https://ojk.go.id", "category": "macro_economy" },
+  {
+    "id": "imigrasi",
+    "url": "https://www.imigrasi.go.id",
+    "category": "immigration"
+  },
+  {
+    "id": "kemenkumham",
+    "url": "https://www.kemenkumham.go.id",
+    "category": "immigration"
+  },
+  { "id": "kemnaker", "url": "https://kemnaker.go.id", "category": "labor" },
+  { "id": "atrbpn", "url": "https://www.atrbpn.go.id", "category": "property" },
+  {
+    "id": "jdih_baliprov",
+    "url": "https://jdih.baliprov.go.id",
+    "category": "regulation_bali"
+  },
+  {
+    "id": "jdih_badungkab",
+    "url": "https://jdih.badungkab.go.id",
+    "category": "regulation_bali"
+  },
+  {
+    "id": "jdih_gianyarkab",
+    "url": "https://jdih.gianyarkab.go.id",
+    "category": "regulation_bali"
+  },
+  {
+    "id": "jdih_denpasarkota",
+    "url": "https://jdih.denpasarkota.go.id",
+    "category": "regulation_bali"
+  }
+]
+```
+
+Save to `apps/mata-garuda/data/gov_apis_inventory.json`.
+
+- [ ] **Step 4: Write minimal implementation**
+
+```python
+# apps/mata-garuda/mata_garuda/foundations/gov_apis_health.py
+"""Indonesian gov-apis health monitor.
+
+Forks the spirit of suryast/indonesia-gov-apis (50+ portal status tracker).
+We probe a curated subset of 14+ portals relevant to Bali Zero monthly.
+
+Discovery: R2 SOTA 2026-05-08 — "22 operational, 6 geo-blocked,
+5 CF/bot-challenged, 16 DNS failures (28% infrastructure dead)".
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import httpx
+
+INVENTORY_PATH = Path(__file__).parent.parent.parent / "data" / "gov_apis_inventory.json"
+PROBE_TIMEOUT_SECONDS = 15.0
+
+PortalStatus = Literal[
+    "operational",
+    "dns_failure",
+    "cf_challenge",
+    "geo_blocked",
+    "http_5xx",
+    "http_4xx",
+    "timeout",
+    "unknown",
+]
+
+
+@dataclass(frozen=True)
+class PortalHealth:
+    id: str
+    url: str
+    status: PortalStatus
+    http_code: int | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class HealthReport:
+    total: int
+    operational: int
+    results: list[PortalHealth]
+
+
+def load_inventory() -> list[dict]:
+    return json.loads(INVENTORY_PATH.read_text(encoding="utf-8"))
+
+
+async def probe_portal(entry: dict) -> PortalHealth:
+    portal_id = entry["id"]
+    url = entry["url"]
+    try:
+        async with httpx.AsyncClient(timeout=PROBE_TIMEOUT_SECONDS, follow_redirects=True) as client:
+            response = await client.get(url)
+        code = response.status_code
+        if code == 200:
+            return PortalHealth(id=portal_id, url=url, status="operational", http_code=code)
+        if code == 403 and "cloudflare" in response.headers.get("server", "").lower():
+            return PortalHealth(id=portal_id, url=url, status="cf_challenge", http_code=code)
+        if code == 451 or code == 403:
+            return PortalHealth(id=portal_id, url=url, status="geo_blocked", http_code=code)
+        if code >= 500:
+            return PortalHealth(id=portal_id, url=url, status="http_5xx", http_code=code)
+        if code >= 400:
+            return PortalHealth(id=portal_id, url=url, status="http_4xx", http_code=code)
+        return PortalHealth(id=portal_id, url=url, status="unknown", http_code=code)
+    except httpx.ConnectError as exc:
+        return PortalHealth(id=portal_id, url=url, status="dns_failure", error=str(exc))
+    except httpx.TimeoutException as exc:
+        return PortalHealth(id=portal_id, url=url, status="timeout", error=str(exc))
+
+
+async def probe_inventory(inventory: list[dict] | None = None) -> HealthReport:
+    if inventory is None:
+        inventory = load_inventory()
+    results = []
+    for entry in inventory:
+        result = await probe_portal(entry)
+        results.append(result)
+    operational = sum(1 for r in results if r.status == "operational")
+    return HealthReport(total=len(results), operational=operational, results=results)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/mata-garuda && python -m pytest tests/foundations/test_gov_apis_health.py -v`
+Expected: PASS, 4 tests
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/mata-garuda/mata_garuda/foundations/gov_apis_health.py \
+        apps/mata-garuda/tests/foundations/test_gov_apis_health.py \
+        apps/mata-garuda/data/gov_apis_inventory.json
+git commit -m "feat(foundations): gov-apis health monitor (R2 SOTA)"
+```
+
+---
+
+## Task 3: Bali calendar (Saka/Pawukon)
+
+**Files:**
+
+- Create: `apps/mata-garuda/mata_garuda/foundations/bali_calendar.py`
+- Test: `apps/mata-garuda/tests/foundations/test_bali_calendar.py`
+
+**Context:** R6 found `peradnya/balinese-date-js-lib` (JS library) and Babad Bali source. We port the algorithm to Python. Critical dates 2026: Galungan 2026-06-17 (Wed), Kuningan 2026-06-27 (Sat). Used cross-domain (B1 skip appointments, B2 filing slow window, B3 content scheduled).
+
+The Pawukon cycle is 210 days. The 30 wuku list (Sinta, Landep, Ukir, Kulantir, Tolu, Gumbreg, Wariga, Warigadean, Julungwangi, Sungsang, Dunggulan, Kuningan, Langkir, Medangsia, Pujut, Pahang, Krulut, Merakih, Tambir, Medangkungan, Matal, Uye, Menail, Prangbakat, Bala, Ugu, Wayang, Kelawu, Dukut, Watugunung) — Galungan = day 1 of Dunggulan (wuku 11), Kuningan = day 1 of Kuningan (wuku 12).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# apps/mata-garuda/tests/foundations/test_bali_calendar.py
+from datetime import date
+from mata_garuda.foundations.bali_calendar import (
+    get_balinese_date,
+    is_galungan,
+    is_kuningan,
+    days_until_next_galungan,
+)
+
+
+def test_galungan_2026_06_17():
+    """R6 source-of-truth: Galungan = Wed 2026-06-17."""
+    assert is_galungan(date(2026, 6, 17)) is True
+
+
+def test_kuningan_2026_06_27():
+    """R6 source-of-truth: Kuningan = Sat 2026-06-27."""
+    assert is_kuningan(date(2026, 6, 27)) is True
+
+
+def test_non_ceremony_day_returns_false():
+    assert is_galungan(date(2026, 5, 8)) is False
+    assert is_kuningan(date(2026, 5, 8)) is False
+
+
+def test_get_balinese_date_returns_wuku_and_pawukon_day():
+    result = get_balinese_date(date(2026, 6, 17))
+    assert result.wuku == "Dunggulan"
+    assert result.is_galungan is True
+    assert result.is_kuningan is False
+
+
+def test_days_until_next_galungan_from_2026_05_08():
+    """40 days from 2026-05-08 to 2026-06-17."""
+    delta = days_until_next_galungan(date(2026, 5, 8))
+    assert delta == 40
+
+
+def test_days_until_next_galungan_after_event_returns_next_cycle():
+    """From 2026-06-18 (day after), next Galungan = 2027-01-13 (210 days later)."""
+    delta = days_until_next_galungan(date(2026, 6, 18))
+    assert delta == 210 - 1  # 209 days
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/mata-garuda && python -m pytest tests/foundations/test_bali_calendar.py -v`
+Expected: FAIL with ModuleNotFoundError
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# apps/mata-garuda/mata_garuda/foundations/bali_calendar.py
+"""Balinese Pawukon + Saka calendar.
+
+Discovered in R6 SOTA 2026-05-08. Source: babadbali.com + peradnya/balinese-date-js-lib (port).
+
+Pawukon cycle = 210 days. 30 wuku of 7 days each. Galungan = Buda (Wed) Kliwon Dungulan
+(day 1 of wuku Dunggulan, position 11/30). Kuningan = Saniscara (Sat) Kliwon Kuningan
+(day 5 of wuku Kuningan, position 12/30, 10 days after Galungan).
+
+Anchor: 2026-06-17 (Wed) IS Galungan — verified against
+https://kalenderbali.org/?bulan=6&tanggal=17&tahun=2026 (R6).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+
+PAWUKON_CYCLE_DAYS = 210
+
+WUKU_NAMES = [
+    "Sinta", "Landep", "Ukir", "Kulantir", "Tolu", "Gumbreg", "Wariga",
+    "Warigadean", "Julungwangi", "Sungsang", "Dunggulan", "Kuningan",
+    "Langkir", "Medangsia", "Pujut", "Pahang", "Krulut", "Merakih",
+    "Tambir", "Medangkungan", "Matal", "Uye", "Menail", "Prangbakat",
+    "Bala", "Ugu", "Wayang", "Kelawu", "Dukut", "Watugunung",
+]
+assert len(WUKU_NAMES) == 30
+
+# Anchor: 2026-06-17 = Galungan = day 1 of Dunggulan (wuku 11, 0-indexed 10).
+# Wuku Dunggulan starts on 2026-06-17 in this anchor convention.
+# Therefore Pawukon day 1 of cycle (Sinta day 1) = 2026-06-17 - (10 * 7) days = 2026-04-08.
+ANCHOR_PAWUKON_DAY_1 = date(2026, 4, 8)
+GALUNGAN_PAWUKON_DAY_INDEX = 10 * 7  # 0-indexed: day 71 of cycle (1-indexed: 71)
+KUNINGAN_PAWUKON_DAY_INDEX = 11 * 7 + 4  # 0-indexed: day 81 of cycle (1-indexed: 81)
+
+
+@dataclass(frozen=True)
+class BalineseDate:
+    gregorian: date
+    pawukon_day: int  # 1..210
+    wuku: str
+    wuku_day: int  # 1..7 within current wuku
+    is_galungan: bool
+    is_kuningan: bool
+
+
+def _pawukon_day_index(target: date) -> int:
+    """Return 0-indexed position in 210-day Pawukon cycle."""
+    delta_days = (target - ANCHOR_PAWUKON_DAY_1).days
+    return delta_days % PAWUKON_CYCLE_DAYS
+
+
+def get_balinese_date(target: date) -> BalineseDate:
+    idx = _pawukon_day_index(target)
+    wuku_position = idx // 7  # 0..29
+    wuku_day = (idx % 7) + 1  # 1..7
+    return BalineseDate(
+        gregorian=target,
+        pawukon_day=idx + 1,
+        wuku=WUKU_NAMES[wuku_position],
+        wuku_day=wuku_day,
+        is_galungan=(idx == GALUNGAN_PAWUKON_DAY_INDEX),
+        is_kuningan=(idx == KUNINGAN_PAWUKON_DAY_INDEX),
+    )
+
+
+def is_galungan(target: date) -> bool:
+    return _pawukon_day_index(target) == GALUNGAN_PAWUKON_DAY_INDEX
+
+
+def is_kuningan(target: date) -> bool:
+    return _pawukon_day_index(target) == KUNINGAN_PAWUKON_DAY_INDEX
+
+
+def days_until_next_galungan(target: date) -> int:
+    idx = _pawukon_day_index(target)
+    days_until = (GALUNGAN_PAWUKON_DAY_INDEX - idx) % PAWUKON_CYCLE_DAYS
+    if days_until == 0:
+        return PAWUKON_CYCLE_DAYS
+    return days_until
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/mata-garuda && python -m pytest tests/foundations/test_bali_calendar.py -v`
+Expected: PASS, 6 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mata-garuda/mata_garuda/foundations/bali_calendar.py \
+        apps/mata-garuda/tests/foundations/test_bali_calendar.py
+git commit -m "feat(foundations): Bali calendar Saka/Pawukon (R6 SOTA)"
+```
+
+---
+
+## Task 4: GDELT API client
+
+**Files:**
+
+- Create: `apps/mata-garuda/mata_garuda/foundations/gdelt_client.py`
+- Test: `apps/mata-garuda/tests/foundations/test_gdelt_client.py`
+
+**Context:** R6 discovered GDELT Project (`gdeltproject.org`) — free real-time news API, 65 languages translated to EN, FIPS-2 country code `ID`. DOC 2.0 endpoint: `https://api.gdeltproject.org/api/v2/doc/doc?query=...&format=json`. Used by NB-INTEL-IndonesiaPolicy as layer-zero raw signal (15-min cadence).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# apps/mata-garuda/tests/foundations/test_gdelt_client.py
+import pytest
+from unittest.mock import AsyncMock, patch
+from mata_garuda.foundations.gdelt_client import (
+    GdeltClient,
+    GdeltArticle,
+)
+
+
+@pytest.mark.asyncio
+async def test_search_articles_indonesia_filters_country_id():
+    fake_response = {
+        "articles": [
+            {
+                "url": "https://kompas.com/article/1",
+                "title": "Kabinet reshuffle Indonesia",
+                "seendate": "20260508T100000Z",
+                "domain": "kompas.com",
+                "language": "Indonesian",
+                "sourcecountry": "Indonesia",
+            }
+        ]
+    }
+    with patch("mata_garuda.foundations.gdelt_client.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value.json = lambda: fake_response
+        mock_client.get.return_value.raise_for_status = lambda: None
+        mock_cls.return_value.__aenter__.return_value = mock_client
+
+        client = GdeltClient()
+        articles = await client.search_indonesia(query="kabinet", max_results=10)
+
+    assert len(articles) == 1
+    assert isinstance(articles[0], GdeltArticle)
+    assert articles[0].source_country == "Indonesia"
+
+
+@pytest.mark.asyncio
+async def test_search_articles_handles_empty_response():
+    fake_response = {"articles": []}
+    with patch("mata_garuda.foundations.gdelt_client.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value.json = lambda: fake_response
+        mock_client.get.return_value.raise_for_status = lambda: None
+        mock_cls.return_value.__aenter__.return_value = mock_client
+
+        client = GdeltClient()
+        articles = await client.search_indonesia(query="zzzznotrending", max_results=10)
+
+    assert articles == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/mata-garuda && python -m pytest tests/foundations/test_gdelt_client.py -v`
+Expected: FAIL with ModuleNotFoundError
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# apps/mata-garuda/mata_garuda/foundations/gdelt_client.py
+"""GDELT DOC 2.0 API client.
+
+Discovered in R6 SOTA 2026-05-08. Free, no auth, 65 languages translated to EN.
+Indonesia FIPS-2 = ID. Update frequency: every 15 minutes.
+
+API base: https://api.gdeltproject.org/api/v2/doc/doc
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+import httpx
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+GDELT_DOC_API = "https://api.gdeltproject.org/api/v2/doc/doc"
+DEFAULT_TIMEOUT = 30.0
+
+
+@dataclass(frozen=True)
+class GdeltArticle:
+    url: str
+    title: str
+    seen_date: Optional[datetime]
+    domain: str
+    language: str
+    source_country: str
+
+
+class GdeltClient:
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=8))
+    async def search_indonesia(self, query: str, max_results: int = 50) -> list[GdeltArticle]:
+        params = {
+            "query": f'{query} sourcecountry:ID',
+            "mode": "ArtList",
+            "format": "json",
+            "maxrecords": str(max_results),
+        }
+        async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+            response = await client.get(GDELT_DOC_API, params=params)
+            response.raise_for_status()
+            payload = response.json()
+        return [
+            GdeltArticle(
+                url=item["url"],
+                title=item.get("title", ""),
+                seen_date=self._parse_seen_date(item.get("seendate")),
+                domain=item.get("domain", ""),
+                language=item.get("language", ""),
+                source_country=item.get("sourcecountry", ""),
+            )
+            for item in payload.get("articles", [])
+        ]
+
+    @staticmethod
+    def _parse_seen_date(raw: Optional[str]) -> Optional[datetime]:
+        if not raw:
+            return None
+        try:
+            return datetime.strptime(raw, "%Y%m%dT%H%M%SZ")
+        except ValueError:
+            return None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/mata-garuda && python -m pytest tests/foundations/test_gdelt_client.py -v`
+Expected: PASS, 2 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mata-garuda/mata_garuda/foundations/gdelt_client.py \
+        apps/mata-garuda/tests/foundations/test_gdelt_client.py
+git commit -m "feat(foundations): GDELT API client Indonesia (R6 SOTA)"
+```
+
+---
+
+## Task 5: OpenSanctions Indonesia ingest
+
+**Files:**
+
+- Create: `apps/mata-garuda/mata_garuda/foundations/opensanctions_id.py`
+- Test: `apps/mata-garuda/tests/foundations/test_opensanctions_id.py`
+
+**Context:** R7 discovered OpenSanctions has direct Indonesia datasets:
+
+- `id_dttot` (Indonesian Suspected Terrorists, daily update)
+- `id_regional_2018` (2018 Regional Head Election Results)
+
+Free non-commercial. Used by NB-INTEL-Authorities (B6) for KYC/PEP screening of clients.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# apps/mata-garuda/tests/foundations/test_opensanctions_id.py
+import pytest
+from unittest.mock import AsyncMock, patch
+from mata_garuda.foundations.opensanctions_id import (
+    OpenSanctionsClient,
+    SanctionEntity,
+)
+
+
+@pytest.mark.asyncio
+async def test_fetch_dttot_dataset_returns_entities():
+    fake_jsonlines = (
+        '{"id":"id-dttot-1","schema":"Person","caption":"Suspected Person 1",'
+        '"properties":{"name":["Suspected Person 1"]}}\n'
+        '{"id":"id-dttot-2","schema":"Person","caption":"Suspected Person 2",'
+        '"properties":{"name":["Suspected Person 2"]}}\n'
+    )
+    with patch("mata_garuda.foundations.opensanctions_id.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value.text = fake_jsonlines
+        mock_client.get.return_value.raise_for_status = lambda: None
+        mock_cls.return_value.__aenter__.return_value = mock_client
+
+        client = OpenSanctionsClient()
+        entities = await client.fetch_dttot()
+
+    assert len(entities) == 2
+    assert isinstance(entities[0], SanctionEntity)
+    assert entities[0].id == "id-dttot-1"
+
+
+@pytest.mark.asyncio
+async def test_match_entity_by_name_substring():
+    fake_jsonlines = (
+        '{"id":"id-dttot-1","schema":"Person","caption":"Marina Pinyaylova",'
+        '"properties":{"name":["Marina Pinyaylova"]}}\n'
+        '{"id":"id-dttot-2","schema":"Person","caption":"Other",'
+        '"properties":{"name":["Other Person"]}}\n'
+    )
+    with patch("mata_garuda.foundations.opensanctions_id.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value.text = fake_jsonlines
+        mock_client.get.return_value.raise_for_status = lambda: None
+        mock_cls.return_value.__aenter__.return_value = mock_client
+
+        client = OpenSanctionsClient()
+        matches = await client.match_name("Marina")
+
+    assert len(matches) == 1
+    assert matches[0].caption == "Marina Pinyaylova"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/mata-garuda && python -m pytest tests/foundations/test_opensanctions_id.py -v`
+Expected: FAIL with ModuleNotFoundError
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# apps/mata-garuda/mata_garuda/foundations/opensanctions_id.py
+"""OpenSanctions Indonesia datasets client.
+
+Discovered in R7 SOTA 2026-05-08. Free non-commercial.
+Datasets:
+  - id_dttot (Indonesian Suspected Terrorists, daily)
+  - id_regional_2018 (2018 Regional Head Election Results)
+
+Used for KYC/PEP screening of Bali Zero clients (B6 sink).
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+OPENSANCTIONS_BASE = "https://data.opensanctions.org/datasets"
+DEFAULT_TIMEOUT = 60.0
+
+
+@dataclass(frozen=True)
+class SanctionEntity:
+    id: str
+    schema: str  # "Person" | "Organization" | "Address" etc.
+    caption: str
+    properties: dict
+
+
+class OpenSanctionsClient:
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=8))
+    async def fetch_dttot(self) -> list[SanctionEntity]:
+        url = f"{OPENSANCTIONS_BASE}/latest/id_dttot/entities.ftm.json"
+        return await self._fetch_jsonlines(url)
+
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=8))
+    async def fetch_regional_2018(self) -> list[SanctionEntity]:
+        url = f"{OPENSANCTIONS_BASE}/latest/id_regional_2018/entities.ftm.json"
+        return await self._fetch_jsonlines(url)
+
+    async def match_name(self, name_substring: str) -> list[SanctionEntity]:
+        entities = await self.fetch_dttot()
+        needle = name_substring.lower()
+        return [e for e in entities if needle in e.caption.lower()]
+
+    @staticmethod
+    async def _fetch_jsonlines(url: str) -> list[SanctionEntity]:
+        async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+            text = response.text
+        entities = []
+        for line in text.strip().split("\n"):
+            if not line.strip():
+                continue
+            payload = json.loads(line)
+            entities.append(
+                SanctionEntity(
+                    id=payload["id"],
+                    schema=payload["schema"],
+                    caption=payload.get("caption", ""),
+                    properties=payload.get("properties", {}),
+                )
+            )
+        return entities
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/mata-garuda && python -m pytest tests/foundations/test_opensanctions_id.py -v`
+Expected: PASS, 2 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mata-garuda/mata_garuda/foundations/opensanctions_id.py \
+        apps/mata-garuda/tests/foundations/test_opensanctions_id.py
+git commit -m "feat(foundations): OpenSanctions Indonesia client (R7 SOTA)"
+```
+
+---
+
+## Task 6: cahya/bert-base-indonesian-NER wrapper
+
+**Files:**
+
+- Create: `apps/mata-garuda/mata_garuda/foundations/ner_extractor.py`
+- Test: `apps/mata-garuda/tests/foundations/test_ner_extractor.py`
+
+**Context:** R7 recommended `cahya/bert-base-indonesian-NER` (HuggingFace, free) for Bahasa NER. Production-ready 2026 baseline. Labels: Person, Organization, Location, Time, Quantity (Money). Used cross-domain for entity extraction.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# apps/mata-garuda/tests/foundations/test_ner_extractor.py
+import pytest
+from unittest.mock import patch, MagicMock
+from mata_garuda.foundations.ner_extractor import (
+    NERExtractor,
+    NamedEntity,
+)
+
+
+def test_extract_returns_named_entities():
+    fake_pipeline_output = [
+        {"entity_group": "PERSON", "word": "Bimo Wijayanto", "score": 0.99, "start": 0, "end": 14},
+        {"entity_group": "ORG", "word": "DJP", "score": 0.95, "start": 18, "end": 21},
+    ]
+
+    with patch("mata_garuda.foundations.ner_extractor.pipeline") as mock_pipeline_factory:
+        mock_pipeline = MagicMock(return_value=fake_pipeline_output)
+        mock_pipeline_factory.return_value = mock_pipeline
+
+        extractor = NERExtractor()
+        entities = extractor.extract("Bimo Wijayanto dari DJP")
+
+    assert len(entities) == 2
+    assert isinstance(entities[0], NamedEntity)
+    assert entities[0].label == "PERSON"
+    assert entities[0].text == "Bimo Wijayanto"
+    assert entities[1].label == "ORG"
+
+
+def test_extract_empty_text_returns_empty_list():
+    with patch("mata_garuda.foundations.ner_extractor.pipeline") as mock_pipeline_factory:
+        mock_pipeline = MagicMock(return_value=[])
+        mock_pipeline_factory.return_value = mock_pipeline
+
+        extractor = NERExtractor()
+        entities = extractor.extract("")
+
+    assert entities == []
+
+
+def test_filter_by_label_only_returns_matching():
+    fake_pipeline_output = [
+        {"entity_group": "PERSON", "word": "Bimo", "score": 0.99, "start": 0, "end": 4},
+        {"entity_group": "ORG", "word": "DJP", "score": 0.95, "start": 8, "end": 11},
+    ]
+    with patch("mata_garuda.foundations.ner_extractor.pipeline") as mock_pipeline_factory:
+        mock_pipeline = MagicMock(return_value=fake_pipeline_output)
+        mock_pipeline_factory.return_value = mock_pipeline
+
+        extractor = NERExtractor()
+        people = extractor.extract("Bimo dari DJP", labels=("PERSON",))
+
+    assert len(people) == 1
+    assert people[0].text == "Bimo"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/mata-garuda && python -m pytest tests/foundations/test_ner_extractor.py -v`
+Expected: FAIL with ModuleNotFoundError
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# apps/mata-garuda/mata_garuda/foundations/ner_extractor.py
+"""Bahasa Indonesia NER extractor.
+
+Discovered in R7 SOTA 2026-05-08.
+Model: cahya/bert-base-indonesian-NER (HuggingFace, free).
+Labels: PERSON, ORG, LOC, TIME, QUANTITY.
+
+Used cross-domain (B1 regulation entity extraction, B5 macro stakeholders,
+B6 OSINT person/org detection).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Sequence
+
+from transformers import pipeline
+
+DEFAULT_MODEL = "cahya/bert-base-indonesian-NER"
+
+
+@dataclass(frozen=True)
+class NamedEntity:
+    label: str  # "PERSON" | "ORG" | "LOC" | "TIME" | "QUANTITY"
+    text: str
+    score: float
+    start: int
+    end: int
+
+
+class NERExtractor:
+    def __init__(self, model_name: str = DEFAULT_MODEL):
+        self._model_name = model_name
+        self._pipeline = pipeline(
+            "ner",
+            model=model_name,
+            aggregation_strategy="simple",
+        )
+
+    def extract(self, text: str, labels: Sequence[str] | None = None) -> list[NamedEntity]:
+        if not text:
+            return []
+        raw = self._pipeline(text)
+        entities = [
+            NamedEntity(
+                label=item["entity_group"],
+                text=item["word"],
+                score=float(item["score"]),
+                start=int(item["start"]),
+                end=int(item["end"]),
+            )
+            for item in raw
+        ]
+        if labels is None:
+            return entities
+        labelset = set(labels)
+        return [e for e in entities if e.label in labelset]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/mata-garuda && python -m pytest tests/foundations/test_ner_extractor.py -v`
+Expected: PASS, 3 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mata-garuda/mata_garuda/foundations/ner_extractor.py \
+        apps/mata-garuda/tests/foundations/test_ner_extractor.py
+git commit -m "feat(foundations): cahya BERT-NER bahasa wrapper (R7 SOTA)"
+```
+
+---
+
+## Task 7: arxiv-sanity SVM-on-tfidf personal scorer
+
+**Files:**
+
+- Create: `apps/mata-garuda/mata_garuda/foundations/arxiv_sanity_scorer.py`
+- Test: `apps/mata-garuda/tests/foundations/test_arxiv_sanity_scorer.py`
+
+**Context:** R5 — arxiv-sanity-lite uses SVM-on-tfidf (zero LLM cost) for per-tag personal relevance recommendation. We port the core to Python class. Used by B4 Antonello Lab for paper ranking.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# apps/mata-garuda/tests/foundations/test_arxiv_sanity_scorer.py
+import pytest
+from mata_garuda.foundations.arxiv_sanity_scorer import (
+    ArxivSanityScorer,
+    LabeledPaper,
+)
+
+
+def test_scorer_trains_and_predicts_higher_score_for_in_class():
+    positive_papers = [
+        LabeledPaper(id="p1", abstract="agentic LLM RAG retrieval", label=1),
+        LabeledPaper(id="p2", abstract="RAG corrective self-RAG retrieval augmented", label=1),
+        LabeledPaper(id="p3", abstract="agentic deep research multi-agent", label=1),
+    ]
+    negative_papers = [
+        LabeledPaper(id="n1", abstract="quantum chromodynamics lattice gauge", label=0),
+        LabeledPaper(id="n2", abstract="cosmology dark matter halo simulation", label=0),
+        LabeledPaper(id="n3", abstract="condensed matter superconductivity bcs", label=0),
+    ]
+
+    scorer = ArxivSanityScorer()
+    scorer.train(positive_papers + negative_papers)
+
+    in_class = scorer.score("agentic RAG corrective retrieval")
+    out_class = scorer.score("quantum lattice gauge theory")
+
+    assert in_class > out_class
+    assert 0.0 <= in_class <= 1.0
+    assert 0.0 <= out_class <= 1.0
+
+
+def test_scorer_raises_if_predict_before_train():
+    scorer = ArxivSanityScorer()
+    with pytest.raises(RuntimeError, match="not trained"):
+        scorer.score("anything")
+
+
+def test_scorer_handles_single_class_training_gracefully():
+    """If user has only positive samples, scorer should not crash."""
+    only_positive = [
+        LabeledPaper(id="p1", abstract="agentic LLM", label=1),
+        LabeledPaper(id="p2", abstract="RAG retrieval", label=1),
+    ]
+    scorer = ArxivSanityScorer()
+    with pytest.raises(ValueError, match="at least two classes"):
+        scorer.train(only_positive)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/mata-garuda && python -m pytest tests/foundations/test_arxiv_sanity_scorer.py -v`
+Expected: FAIL with ModuleNotFoundError
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# apps/mata-garuda/mata_garuda/foundations/arxiv_sanity_scorer.py
+"""arxiv-sanity SVM-on-tfidf scorer.
+
+Discovered in R5 SOTA 2026-05-08. Karpathy's pattern: zero LLM cost,
+self-host. Port of arxiv-sanity-lite core algorithm.
+
+Train on Antonello's tagged papers, score new candidates by per-tag SVM.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.svm import LinearSVC
+from sklearn.calibration import CalibratedClassifierCV
+
+
+@dataclass(frozen=True)
+class LabeledPaper:
+    id: str
+    abstract: str
+    label: int  # 1 = relevant, 0 = not relevant
+
+
+class ArxivSanityScorer:
+    def __init__(self, max_features: int = 5000):
+        self._max_features = max_features
+        self._vectorizer: Optional[TfidfVectorizer] = None
+        self._model: Optional[CalibratedClassifierCV] = None
+
+    def train(self, papers: list[LabeledPaper]) -> None:
+        labels = {p.label for p in papers}
+        if len(labels) < 2:
+            raise ValueError("Training requires at least two classes (positive and negative)")
+        self._vectorizer = TfidfVectorizer(
+            max_features=self._max_features,
+            ngram_range=(1, 2),
+            stop_words="english",
+        )
+        X = self._vectorizer.fit_transform([p.abstract for p in papers])
+        y = np.array([p.label for p in papers])
+        base = LinearSVC()
+        # CalibratedClassifierCV gives us probability output for ranking
+        self._model = CalibratedClassifierCV(base, cv=min(3, len(papers) // 2 or 2))
+        self._model.fit(X, y)
+
+    def score(self, abstract: str) -> float:
+        if self._vectorizer is None or self._model is None:
+            raise RuntimeError("Scorer not trained. Call train() first.")
+        X = self._vectorizer.transform([abstract])
+        proba = self._model.predict_proba(X)[0]
+        # Return P(label=1)
+        idx = list(self._model.classes_).index(1)
+        return float(proba[idx])
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/mata-garuda && python -m pytest tests/foundations/test_arxiv_sanity_scorer.py -v`
+Expected: PASS, 3 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mata-garuda/mata_garuda/foundations/arxiv_sanity_scorer.py \
+        apps/mata-garuda/tests/foundations/test_arxiv_sanity_scorer.py
+git commit -m "feat(foundations): arxiv-sanity SVM scorer (R5 SOTA)"
+```
+
+---
+
+## Task 8: OpenLLMetry initialization helper
+
+**Files:**
+
+- Create: `apps/mata-garuda/mata_garuda/foundations/openllmetry_init.py`
+- Test: `apps/mata-garuda/tests/foundations/test_openllmetry_init.py`
+
+**Context:** R1 recommended OpenLLMetry SDK (OTel-native) → Langfuse + Phoenix backend. This task ships the SDK init helper. Langfuse + Phoenix self-host on Mini-Pro2 is Phase 1 (deferred). For now, the helper is dormant when env vars unset (1ms no-op per call), matching the Nuzantara pattern (PR #312 cicatrix).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# apps/mata-garuda/tests/foundations/test_openllmetry_init.py
+import os
+import pytest
+from unittest.mock import patch
+from mata_garuda.foundations.openllmetry_init import (
+    init_openllmetry,
+    is_openllmetry_enabled,
+)
+
+
+def test_is_disabled_when_no_env_vars():
+    with patch.dict(os.environ, {}, clear=True):
+        assert is_openllmetry_enabled() is False
+
+
+def test_is_enabled_when_endpoint_set():
+    with patch.dict(os.environ, {"OPENLLMETRY_ENDPOINT": "http://localhost:4318"}, clear=True):
+        assert is_openllmetry_enabled() is True
+
+
+def test_is_disabled_via_kill_switch():
+    """LANGFUSE_ENABLED=false acts as full kill-switch (Nuzantara PR #312 pattern)."""
+    with patch.dict(
+        os.environ,
+        {"OPENLLMETRY_ENDPOINT": "http://localhost:4318", "LANGFUSE_ENABLED": "false"},
+        clear=True,
+    ):
+        assert is_openllmetry_enabled() is False
+
+
+def test_init_returns_quickly_when_disabled():
+    """Dormant mode = 1ms no-op (Nuzantara cicatrix pattern)."""
+    with patch.dict(os.environ, {}, clear=True):
+        result = init_openllmetry(service_name="test-service")
+    assert result is False  # not initialized
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/mata-garuda && python -m pytest tests/foundations/test_openllmetry_init.py -v`
+Expected: FAIL with ModuleNotFoundError
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# apps/mata-garuda/mata_garuda/foundations/openllmetry_init.py
+"""OpenLLMetry SDK initialization helper.
+
+Discovered in R1 SOTA 2026-05-08. OpenLLMetry (Traceloop) is OTel-native;
+pair with Langfuse + Phoenix backend (Phase 1 deferred).
+
+Dormant mode pattern (Nuzantara PR #312 cicatrix): when env vars unset,
+init returns False and SDK is not loaded. Zero overhead.
+
+Activation: set OPENLLMETRY_ENDPOINT (e.g. http://mini-pro2.local:4318)
+plus optional Langfuse keys to forward to Langfuse self-host.
+"""
+from __future__ import annotations
+
+import os
+
+
+def is_openllmetry_enabled() -> bool:
+    if os.environ.get("LANGFUSE_ENABLED", "").lower() == "false":
+        return False
+    return bool(os.environ.get("OPENLLMETRY_ENDPOINT"))
+
+
+def init_openllmetry(service_name: str) -> bool:
+    """Initialize OpenLLMetry SDK if env-enabled. Returns True if active."""
+    if not is_openllmetry_enabled():
+        return False
+    try:
+        from traceloop.sdk import Traceloop
+    except ImportError:
+        # SDK not installed — dormant mode.
+        return False
+    Traceloop.init(
+        app_name=service_name,
+        api_endpoint=os.environ["OPENLLMETRY_ENDPOINT"],
+        disable_batch=False,
+    )
+    return True
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/mata-garuda && python -m pytest tests/foundations/test_openllmetry_init.py -v`
+Expected: PASS, 4 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mata-garuda/mata_garuda/foundations/openllmetry_init.py \
+        apps/mata-garuda/tests/foundations/test_openllmetry_init.py
+git commit -m "feat(foundations): OpenLLMetry SDK init dormant helper (R1 SOTA)"
+```
+
+---
+
+## Task 9: foundations package public API
+
+**Files:**
+
+- Create: `apps/mata-garuda/mata_garuda/foundations/__init__.py`
+- Modify: `apps/mata-garuda/mata_garuda/__init__.py`
+
+- [ ] **Step 1: Write `foundations/__init__.py`**
+
+```python
+# apps/mata-garuda/mata_garuda/foundations/__init__.py
+"""Domain Mesh foundations layer (Phase 0).
+
+Source spec: docs/superpowers/specs/2026-05-08-domain-mesh-autonomic-design.md §9
+Source plan: docs/superpowers/plans/2026-05-08-domain-mesh-phase0-foundations.md
+
+8 modules backed by R1-R7 SOTA research (2026-05-08):
+- pasal_id_client (R2)        — 40k Indonesian regulations
+- gov_apis_health (R2)        — gov portal status tracker
+- bali_calendar (R6)          — Saka/Pawukon ceremonies
+- gdelt_client (R6)           — Indonesia news raw signal
+- opensanctions_id (R7)       — Indonesia sanctions/PEP
+- ner_extractor (R7)          — bahasa NER (cahya BERT)
+- arxiv_sanity_scorer (R5)    — personal relevance SVM
+- openllmetry_init (R1)       — observability bootstrap
+"""
+from mata_garuda.foundations.arxiv_sanity_scorer import (
+    ArxivSanityScorer,
+    LabeledPaper,
+)
+from mata_garuda.foundations.bali_calendar import (
+    BalineseDate,
+    days_until_next_galungan,
+    get_balinese_date,
+    is_galungan,
+    is_kuningan,
+)
+from mata_garuda.foundations.gdelt_client import GdeltArticle, GdeltClient
+from mata_garuda.foundations.gov_apis_health import (
+    HealthReport,
+    PortalHealth,
+    load_inventory,
+    probe_inventory,
+    probe_portal,
+)
+from mata_garuda.foundations.ner_extractor import NamedEntity, NERExtractor
+from mata_garuda.foundations.openllmetry_init import (
+    init_openllmetry,
+    is_openllmetry_enabled,
+)
+from mata_garuda.foundations.opensanctions_id import (
+    OpenSanctionsClient,
+    SanctionEntity,
+)
+from mata_garuda.foundations.pasal_id_client import (
+    LawSearchResult,
+    LawStatus,
+    PasalIdClient,
+)
+
+__all__ = [
+    "ArxivSanityScorer",
+    "BalineseDate",
+    "GdeltArticle",
+    "GdeltClient",
+    "HealthReport",
+    "LabeledPaper",
+    "LawSearchResult",
+    "LawStatus",
+    "NERExtractor",
+    "NamedEntity",
+    "OpenSanctionsClient",
+    "PasalIdClient",
+    "PortalHealth",
+    "SanctionEntity",
+    "days_until_next_galungan",
+    "get_balinese_date",
+    "init_openllmetry",
+    "is_galungan",
+    "is_kuningan",
+    "is_openllmetry_enabled",
+    "load_inventory",
+    "probe_inventory",
+    "probe_portal",
+]
+```
+
+- [ ] **Step 2: Add `tests/foundations/__init__.py`**
+
+```python
+# apps/mata-garuda/tests/foundations/__init__.py
+```
+
+(empty file, for pytest discovery)
+
+- [ ] **Step 3: Run full foundations test suite**
+
+```bash
+cd apps/mata-garuda && python -m pytest tests/foundations/ -v
+```
+
+Expected: PASS — all 24 tests across 8 modules
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/mata-garuda/mata_garuda/foundations/__init__.py \
+        apps/mata-garuda/tests/foundations/__init__.py
+git commit -m "feat(foundations): public API package init"
+```
+
+---
+
+## Task 10: Add deps to pyproject.toml
+
+**Files:**
+
+- Modify: `apps/mata-garuda/pyproject.toml`
+
+**Context:** mata-garuda is OSINT blindato CLI-only with deps minimali (pydantic + pytest only per §1 CLAUDE.md). Phase 0 foundations adds: httpx, tenacity, transformers, scikit-learn, numpy, sentencepiece, traceloop-sdk (optional). We add them as `foundations` extra to keep minimal install option.
+
+- [ ] **Step 1: Read current pyproject.toml**
+
+```bash
+cat apps/mata-garuda/pyproject.toml
+```
+
+- [ ] **Step 2: Add foundations optional deps**
+
+Append to `[project.optional-dependencies]` (create section if absent):
+
+```toml
+[project.optional-dependencies]
+foundations = [
+    "httpx>=0.27,<1.0",
+    "tenacity>=8.2,<10.0",
+    "transformers>=4.40,<5.0",
+    "torch>=2.1,<3.0",
+    "sentencepiece>=0.2,<1.0",
+    "scikit-learn>=1.4,<2.0",
+    "numpy>=1.26,<3.0",
+]
+foundations-observability = [
+    "traceloop-sdk>=0.20,<1.0",
+]
+```
+
+- [ ] **Step 3: Verify install**
+
+```bash
+cd apps/mata-garuda && source ../../.venv/bin/activate
+pip install -e ".[foundations]"
+python -c "from mata_garuda.foundations import PasalIdClient, BalineseDate; print('OK')"
+```
+
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/mata-garuda/pyproject.toml
+git commit -m "chore(foundations): add httpx/tenacity/transformers/sklearn deps as foundations extra"
+```
+
+---
+
+## Task 11: Daily cron LaunchAgent
+
+**Files:**
+
+- Create: `~/scripts/domain-mesh-foundations-cron.sh`
+- Create: `~/Library/LaunchAgents/com.balizero.domain-mesh.foundations.daily.plist`
+
+**Context:** Daily 04:00 WITA cron on Pro: probe gov-apis health, log to JSON snapshot, alert Telegram if operational % drops > 10pp vs 7-day baseline. Mini-Pro2 deferred to Phase 1 (when self-host stack lands).
+
+- [ ] **Step 1: Write cron wrapper script**
+
+```bash
+# ~/scripts/domain-mesh-foundations-cron.sh
+#!/bin/bash
+set -uo pipefail
+
+LOG_DIR="$HOME/logs/domain-mesh-foundations"
+SNAPSHOT_DIR="$HOME/.cache/domain-mesh-foundations/snapshots"
+mkdir -p "$LOG_DIR" "$SNAPSHOT_DIR"
+
+LOG_FILE="$LOG_DIR/foundations-daily-$(date +%Y%m%d).log"
+SNAPSHOT_FILE="$SNAPSHOT_DIR/gov-apis-health-$(date +%Y%m%d).json"
+
+REPO_ROOT="${HOME}/Desktop/nuzantara"
+cd "$REPO_ROOT/apps/mata-garuda" || exit 1
+
+source "$REPO_ROOT/.venv/bin/activate" 2>/dev/null
+
+python -c "
+import asyncio, json, sys
+from mata_garuda.foundations import probe_inventory
+report = asyncio.run(probe_inventory())
+data = {
+    'total': report.total,
+    'operational': report.operational,
+    'results': [r.__dict__ for r in report.results],
+}
+sys.stdout.write(json.dumps(data, indent=2))
+" > "$SNAPSHOT_FILE" 2>>"$LOG_FILE"
+
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -ne 0 ]; then
+    echo "$(date) FAILED foundations daily probe" >> "$LOG_FILE"
+    exit $EXIT_CODE
+fi
+
+OPERATIONAL=$(python -c "import json; d=json.load(open('$SNAPSHOT_FILE')); print(d['operational'])")
+TOTAL=$(python -c "import json; d=json.load(open('$SNAPSHOT_FILE')); print(d['total'])")
+echo "$(date) gov-apis snapshot: $OPERATIONAL/$TOTAL operational" >> "$LOG_FILE"
+
+# TODO Phase 1: compare vs 7-day baseline + Telegram alert if drop > 10pp
+exit 0
+```
+
+- [ ] **Step 2: chmod +x**
+
+```bash
+chmod +x ~/scripts/domain-mesh-foundations-cron.sh
+```
+
+- [ ] **Step 3: Write LaunchAgent plist**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.balizero.domain-mesh.foundations.daily</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>/Users/nuzantara/scripts/domain-mesh-foundations-cron.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>4</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/domain-mesh-foundations/launchd-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/domain-mesh-foundations/launchd-stderr.log</string>
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>
+```
+
+Save to `~/Library/LaunchAgents/com.balizero.domain-mesh.foundations.daily.plist`.
+
+- [ ] **Step 4: Validate plist + load**
+
+```bash
+plutil -lint ~/Library/LaunchAgents/com.balizero.domain-mesh.foundations.daily.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.balizero.domain-mesh.foundations.daily.plist
+launchctl print gui/$(id -u)/com.balizero.domain-mesh.foundations.daily | head -10
+```
+
+Expected: `OK` for plutil, no error for bootstrap, label shown by print.
+
+- [ ] **Step 5: Commit**
+
+```bash
+# wrapper script lives in ~/scripts (not in repo) — copy reference into repo
+mkdir -p ~/Desktop/nuzantara/infra/launchagents/
+cp ~/Library/LaunchAgents/com.balizero.domain-mesh.foundations.daily.plist \
+   ~/Desktop/nuzantara/infra/launchagents/
+
+cd ~/Desktop/nuzantara
+mkdir -p infra/scripts
+cp ~/scripts/domain-mesh-foundations-cron.sh infra/scripts/
+
+git add infra/launchagents/com.balizero.domain-mesh.foundations.daily.plist \
+        infra/scripts/domain-mesh-foundations-cron.sh
+git commit -m "feat(foundations): daily 04:00 WITA cron LaunchAgent for gov-apis health"
+```
+
+---
+
+## Task 12: Final integration smoke test + push branch
+
+- [ ] **Step 1: Run full foundations suite**
+
+```bash
+cd apps/mata-garuda && python -m pytest tests/foundations/ -v --tb=short
+```
+
+Expected: 24 tests pass.
+
+- [ ] **Step 2: Smoke test pasal.id end-to-end (NETWORK REQUIRED)**
+
+```bash
+cd apps/mata-garuda
+python -c "
+import asyncio
+from mata_garuda.foundations import PasalIdClient
+
+async def main():
+    c = PasalIdClient()
+    try:
+        results = await c.search_laws('PDP', limit=3)
+        print(f'pasal.id: {len(results)} results')
+    except Exception as e:
+        print(f'pasal.id: FAIL ({e}) — endpoint may be unavailable, fallback design needed')
+
+asyncio.run(main())
+"
+```
+
+Expected: either `pasal.id: 3 results` or `pasal.id: FAIL (...)` with clear error. If FAIL with 404, the endpoint URL may need updating (out of scope for plan; documented as known risk).
+
+- [ ] **Step 3: Bali calendar smoke test**
+
+```bash
+python -c "
+from datetime import date
+from mata_garuda.foundations import is_galungan, is_kuningan, days_until_next_galungan
+print('2026-06-17 Galungan?', is_galungan(date(2026, 6, 17)))
+print('2026-06-27 Kuningan?', is_kuningan(date(2026, 6, 27)))
+print('Days until Galungan from today:', days_until_next_galungan(date.today()))
+"
+```
+
+Expected:
+
+```
+2026-06-17 Galungan? True
+2026-06-27 Kuningan? True
+Days until Galungan from today: <integer>
+```
+
+- [ ] **Step 4: Commit any remaining files**
+
+```bash
+git status
+# If nothing pending, skip. Otherwise stage + commit.
+```
+
+- [ ] **Step 5: Push branch + open PR**
+
+```bash
+git push -u origin feat/domain-mesh-phase0-foundations
+
+gh pr create --base main --head feat/domain-mesh-phase0-foundations \
+  --title "feat(domain-mesh): Phase 0 foundations — 8 modules R1-R7 SOTA" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Phase 0 of Domain Mesh autonomic design (spec: docs/superpowers/specs/2026-05-08-domain-mesh-autonomic-design.md).
+
+8 foundational modules under apps/mata-garuda/mata_garuda/foundations/:
+- pasal_id_client (R2): 40k Indonesian regulations API wrapper
+- gov_apis_health (R2): 17 portal status probe + JSON snapshot
+- bali_calendar (R6): Saka/Pawukon Galungan/Kuningan calculator
+- gdelt_client (R6): Indonesia raw signal news API (free)
+- opensanctions_id (R7): Indonesia sanctions/PEP datasets
+- ner_extractor (R7): cahya BERT bahasa NER
+- arxiv_sanity_scorer (R5): SVM-on-tfidf personal relevance (zero LLM)
+- openllmetry_init (R1): observability SDK dormant helper
+
+Plus daily 04:00 WITA cron LaunchAgent on Pro: gov-apis health snapshot to ~/.cache.
+
+## Test plan
+- [x] 24 unit tests pass (pytest tests/foundations/)
+- [x] Bali calendar smoke test (Galungan 2026-06-17, Kuningan 2026-06-27 verified)
+- [x] LaunchAgent plutil-lint OK + bootstrap OK
+- [ ] pasal.id endpoint smoke test (may FAIL if endpoint URL changed — known risk, fallback design TBD Phase 1)
+
+## Out of scope (Phase 1)
+- Wikibase self-host on Mini-Pro2
+- Langfuse + Phoenix self-host
+- Per-domain genesis manifests (B1-B6 implementations)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+---
+
+## Self-review
+
+**Spec coverage**: Phase 0 §9 of design doc lists 9 items. This plan covers 8 (Wikibase + Langfuse + Phoenix self-host moved to Phase 1, documented in plan header). The 8 covered: pasal.id (Task 1), gov-apis (Task 2), Bali calendar (Task 3), GDELT (Task 4 — added because R6 layer-zero signal), OpenSanctions (Task 5 — added because R7 KYC), cahya BERT-NER (Task 6), arxiv-sanity SVM (Task 7), OpenLLMetry SDK (Task 8). Bonus: foundations API (Task 9), deps (Task 10), cron (Task 11), smoke test (Task 12) = 12 tasks total.
+
+**Placeholder scan**: 1 TODO in Task 11 cron wrapper (`# TODO Phase 1: compare vs 7-day baseline + Telegram alert`) — documented as Phase 1 deferral, not a placeholder failure. All other steps have full code.
+
+**Type consistency**: All cross-task types match — `LawSearchResult.id`, `PortalHealth.id`, `SanctionEntity.id`, `NamedEntity.label`, `BalineseDate.wuku` consistent. `LabeledPaper.label` (int 0/1) used consistently in arxiv_sanity_scorer train + score path. NER `pipeline()` signature mocked with `entity_group` matching transformers ≥4.40.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-08-domain-mesh-phase0-foundations.md`.
+
+User said "go, senza chiedere fino alla fine" — proceeding with **Subagent-Driven** execution (recommended).
+
+REQUIRED SUB-SKILL: `superpowers:subagent-driven-development` for fresh subagent per task + two-stage review.

--- a/infra/launchagents/com.balizero.domain-mesh.foundations.daily.plist
+++ b/infra/launchagents/com.balizero.domain-mesh.foundations.daily.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.balizero.domain-mesh.foundations.daily</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>/Users/nuzantara/scripts/domain-mesh-foundations-cron.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>4</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/domain-mesh-foundations/launchd-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/domain-mesh-foundations/launchd-stderr.log</string>
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/infra/scripts/domain-mesh-foundations-cron.sh
+++ b/infra/scripts/domain-mesh-foundations-cron.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -uo pipefail
+
+LOG_DIR="$HOME/logs/domain-mesh-foundations"
+SNAPSHOT_DIR="$HOME/.cache/domain-mesh-foundations/snapshots"
+mkdir -p "$LOG_DIR" "$SNAPSHOT_DIR"
+
+LOG_FILE="$LOG_DIR/foundations-daily-$(date +%Y%m%d).log"
+SNAPSHOT_FILE="$SNAPSHOT_DIR/gov-apis-health-$(date +%Y%m%d).json"
+
+REPO_ROOT="${HOME}/Desktop/nuzantara"
+cd "$REPO_ROOT/apps/mata-garuda" || exit 1
+
+source "$REPO_ROOT/.venv/bin/activate" 2>/dev/null
+
+python -c "
+import asyncio, json, sys
+from mata_garuda.foundations import probe_inventory
+report = asyncio.run(probe_inventory())
+data = {
+    'total': report.total,
+    'operational': report.operational,
+    'results': [r.__dict__ for r in report.results],
+}
+sys.stdout.write(json.dumps(data, indent=2))
+" > "$SNAPSHOT_FILE" 2>>"$LOG_FILE"
+
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -ne 0 ]; then
+    echo "$(date) FAILED foundations daily probe" >> "$LOG_FILE"
+    exit $EXIT_CODE
+fi
+
+OPERATIONAL=$(python -c "import json; d=json.load(open('$SNAPSHOT_FILE')); print(d['operational'])")
+TOTAL=$(python -c "import json; d=json.load(open('$SNAPSHOT_FILE')); print(d['total'])")
+echo "$(date) gov-apis snapshot: $OPERATIONAL/$TOTAL operational" >> "$LOG_FILE"
+
+# TODO Phase 1: compare vs 7-day baseline + Telegram alert if drop > 10pp
+exit 0


### PR DESCRIPTION
## Summary

Phase 0 of Domain Mesh autonomic design (spec PR #518, design doc `docs/superpowers/specs/2026-05-08-domain-mesh-autonomic-design.md`).

8 foundational modules under `apps/mata-garuda/mata_garuda/foundations/`, backed by R1-R7 SOTA research (5752 lines):

- **pasal_id_client** (R2) — 40k Indonesian regulations API wrapper
- **gov_apis_health** (R2) — 17 portal status probe + JSON snapshot
- **bali_calendar** (R6) — Saka/Pawukon Galungan/Kuningan calculator
- **gdelt_client** (R6) — Indonesia raw signal news API (free)
- **opensanctions_id** (R7) — Indonesia sanctions/PEP datasets
- **ner_extractor** (R7) — cahya BERT bahasa NER
- **arxiv_sanity_scorer** (R5) — SVM-on-tfidf personal relevance (zero LLM)
- **openllmetry_init** (R1) — observability SDK dormant helper

Plus daily 04:00 WITA cron LaunchAgent on Pro: gov-apis health snapshot to `~/.cache/domain-mesh-foundations/`.

## Test plan

- [x] **26 unit tests pass** (pytest tests/foundations/ — 0.12s)
- [x] **Bali calendar empirical verification**: Galungan 2026-06-17 = True, Kuningan 2026-06-27 = True, 40 days from 2026-05-08
- [x] LaunchAgent plutil-lint OK + bootstrap OK
- [x] foundations package import smoke test OK
- [x] All 11 commits pushed to origin

## Implementation discipline

- TDD per task (test fail → impl → test pass → commit)
- Each commit pushed to origin immediately (branch-hijack scar protection)
- Mata-garuda CLAUDE.md "minimal deps" constraint respected via `[project.optional-dependencies] foundations` (NOT core)

## Discovery during impl

**Bali calendar math correction**: plan had `KUNINGAN_PAWUKON_DAY_INDEX = 11*7+4 = 81`, but empirical test (2026-06-27 = Kuningan, 80 days after anchor 2026-04-08) required index 80. Implementer corrected to `GALUNGAN_PAWUKON_DAY_INDEX + 10 = 80` — canonical 10-day Galungan→Kuningan relationship, plan code had a +1 error.

## Out of scope (Phase 1)

- Wikibase self-host on Mini-Pro2
- Langfuse + Phoenix self-host
- Per-domain genesis manifests (B1-B6 implementations)

## Files changed

- `apps/mata-garuda/mata_garuda/foundations/` (8 new modules + __init__)
- `apps/mata-garuda/tests/foundations/` (8 new test files + __init__)
- `apps/mata-garuda/data/gov_apis_inventory.json` (17 portal seed)
- `apps/mata-garuda/pyproject.toml` (foundations extras)
- `infra/launchagents/com.balizero.domain-mesh.foundations.daily.plist`
- `infra/scripts/domain-mesh-foundations-cron.sh`
- `docs/superpowers/plans/2026-05-08-domain-mesh-phase0-foundations.md` (1781 lines)

## Cost impact

Zero new paid Anthropic API. All modules use public/free endpoints (pasal.id, GDELT, OpenSanctions free tier, HuggingFace cahya/bert) or local compute (sklearn SVM, Bali calendar deterministic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)