### PR TITLE
feat(supervisor): activate W2 dispatch with kill switch + Telegram monitoring (FASE 5)

### DIFF
--- a/apps/organism/organism/launchd/com.nuzantara.organism.supervisor.plist
+++ b/apps/organism/organism/launchd/com.nuzantara.organism.supervisor.plist
@@ -10,10 +10,22 @@
   </array>
   <key>EnvironmentVariables</key>
   <dict>
-    <key>ORGANISM_SHADOW_MODE</key><string>true</string>
+    <!-- W2 dispatch is controlled by ~/.agent/supervisor/active.flag (see
+         supervisor/active_flag.py). Set ORGANISM_SHADOW_MODE=true here only
+         to force-pin the daemon in shadow during an incident; default
+         (unset / "false") makes the file flag authoritative. -->
     <key>ORGANISM_RULES_PATH</key><string>/Users/nuzantara/Desktop/nuzantara/apps/organism/organism/rules/base.yaml</string>
     <key>ORGANISM_DECISIONS_LOG</key><string>/Users/nuzantara/logs/organism/decisions.jsonl</string>
     <key>ORGANISM_REDIS_URL</key><string>redis://127.0.0.1:6379/0</string>
+    <key>ORGANISM_ACTIVE_FLAG_PATH</key><string>/Users/nuzantara/.agent/supervisor/active.flag</string>
+    <key>ORGANISM_BLACKOUT_FLAG_PATH</key><string>/Users/nuzantara/.agent/supervisor/pause.flag</string>
+    <!-- TELEGRAM_BOT_TOKEN + TELEGRAM_OWNER_CHAT_ID are intentionally NOT
+         declared here (cicatrix scar 2026-04-29: world-readable plist
+         leaks). Operator sets them via `launchctl setenv TELEGRAM_BOT_TOKEN
+         <token>` + `launchctl setenv TELEGRAM_OWNER_CHAT_ID 1125336968`
+         BEFORE flipping the active flag. The notify_telegram actuator
+         silently skips alerts when these are unset, so an unset env keeps
+         the supervise loop healthy and just disables Telegram side-effects. -->
     <key>PYTHONPATH</key><string>/Users/nuzantara/Desktop/nuzantara/apps/organism</string>
   </dict>
   <key>RunAtLoad</key><true/>

--- a/apps/organism/organism/supervisor/active_flag.py
+++ b/apps/organism/organism/supervisor/active_flag.py
@@ -1,0 +1,39 @@
+"""W2 active-mode kill switch — file-based flag.
+
+Why a file (not env var, Redis key, etc.):
+- Reachable in <1s without restarting the daemon (`echo 0 > flag` flips it).
+- Survives reboot (boot-time launchd reads it on first run_once cycle).
+- mtime gives audit trail when an operator paged a flip.
+- No external dependency: works even if Redis is down.
+
+Semantics:
+- File missing → inactive (shadow).
+- File contents `"1"` (after strip) → active (W2 dispatch).
+- Anything else (`"0"`, `""`, garbage) → inactive.
+
+The flag is re-read on every `is_active()` call. Do NOT cache: the operator
+flips it without restarting the daemon, and the daemon must observe the
+change on the very next supervise cycle.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class ActiveFlag:
+    path: Path
+
+    def is_active(self) -> bool:
+        try:
+            return self.path.read_text().strip() == "1"
+        except (FileNotFoundError, IsADirectoryError, PermissionError):
+            return False
+        except OSError:
+            log.exception("active_flag: unexpected read error at %s", self.path)
+            return False

--- a/apps/organism/organism/supervisor/daemon.py
+++ b/apps/organism/organism/supervisor/daemon.py
@@ -1,7 +1,12 @@
 """Stateless Supervisor daemon — main consume loop.
 
-W1: shadow mode (logs decisions to JSONL, does NOT dispatch any actuator).
-W1.C / W2 will flip the switch for a whitelisted set of safe actuators.
+Modes:
+- W1 shadow_mode=True: logs decisions to JSONL, does NOT invoke actuators.
+- W2 shadow_mode=False: looks up actuator in `actuator_registry`, calls
+  `await actuator.run(...)`, optionally fires `on_dispatched` callback for
+  Telegram alerts. Kill switch is the file `~/.agent/supervisor/active.flag`
+  (read by `ActiveFlag.is_active()`); when set to "1" the daemon flips to
+  W2. Anything else (file missing, "0", empty) → shadow.
 
 Architecture:
     - consumes events from Redis stream `organism:events` via the
@@ -11,6 +16,8 @@ Architecture:
       restarted freely)
     - asks Decider for an ActionDecision (L0 YAML only in W1)
     - appends a decision record to ~/logs/organism/decisions.jsonl
+    - in active mode: routes the decision through Dispatcher → actuator
+      registry → optional Telegram callback
     - writes a heartbeat every cycle so W0.3 guardians can enter
       local_emergency_mode if the Supervisor dies
 """
@@ -22,11 +29,16 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Awaitable, Callable, Mapping
 
+from organism.blackout import BlackoutManager
 from organism.schemas import Event
+from organism.supervisor.active_flag import ActiveFlag
+from organism.supervisor.circuit_breaker import CircuitBreaker
 from organism.supervisor.decider import Decider
+from organism.supervisor.dispatch import Dispatcher, DispatchOutcome
 from organism.supervisor.incident_context import IncidentStore
+from organism.supervisor.mutex import Mutex
 from organism.supervisor.yaml_rules import RuleMatcher
 
 
@@ -37,6 +49,10 @@ SUPERVISOR_HB_KEY = "organism:supervisor:heartbeat"
 HB_TTL = 600  # 10 min — matches heartbeat.DEFAULT_MAX_LAG_SECONDS safety window
 CONSUMER_GROUP = "organism-supervisor"
 CONSUMER_NAME = "supervisor-1"
+
+# Operator-controlled active flag — file at ~/.agent/supervisor/active.flag
+DEFAULT_ACTIVE_FLAG_PATH = Path.home() / ".agent" / "supervisor" / "active.flag"
+DEFAULT_BLACKOUT_FLAG_PATH = Path.home() / ".agent" / "supervisor" / "pause.flag"
 
 
 async def _write_heartbeat(redis) -> None:
@@ -76,6 +92,27 @@ def _decode_data_field(fields: Any) -> str:
     return str(raw)
 
 
+def _target_for(decision_actuator: str, params: Mapping[str, Any]) -> str:
+    """Compute a stable per-target key for circuit breaker / mutex.
+
+    For restart_agent the target is the agent name. For other actuators we
+    fall back to a sentinel so cross-target calls don't share a single
+    bucket. Keep this in sync with rules/base.yaml param shapes.
+    """
+    if decision_actuator == "restart_agent":
+        ref = params.get("agent_ref")
+        if isinstance(ref, str) and ref:
+            return ref
+    if decision_actuator == "adopt_module":
+        path = params.get("module_path")
+        if isinstance(path, str) and path:
+            return path
+    if decision_actuator == "cleanup_log":
+        # cleanup_log is global per-host — single target lane is fine.
+        return "global"
+    return "global"
+
+
 async def run_once(
     *,
     redis,
@@ -85,8 +122,23 @@ async def run_once(
     shadow_mode: bool = True,
     block_ms: int = 1000,
     count: int = 100,
+    actuator_registry: Mapping[str, Any] | None = None,
+    blackout_flag: Path | None = None,
+    on_dispatched: Callable[..., Awaitable[None]] | None = None,
 ) -> int:
-    """Run one consume+decide+log cycle. Returns number of events processed."""
+    """Run one consume+decide+dispatch+log cycle. Returns events processed.
+
+    Active-mode behavior (shadow_mode=False):
+      - constructs Dispatcher with shared CircuitBreaker, Mutex, BlackoutManager
+        on the supplied flag path
+      - looks up the decided actuator in `actuator_registry` and invokes it
+      - on a DISPATCHED outcome, fires `on_dispatched` (best-effort Telegram)
+
+    Shadow-mode behavior (shadow_mode=True):
+      - everything above except the actuator is invoked in DRY-RUN through
+        Dispatcher's shadow path; in practice run_once short-circuits to
+        SHADOW_LOGGED. `on_dispatched` is NOT called in shadow.
+    """
     await _write_heartbeat(redis)
     await _ensure_consumer_group(redis)
 
@@ -95,6 +147,17 @@ async def run_once(
     matcher = RuleMatcher.from_yaml_text(rules_yaml or "rules: []")
     decider = Decider(
         matcher=matcher, incident_store=IncidentStore(redis=redis),
+    )
+
+    blackout_path = blackout_flag or DEFAULT_BLACKOUT_FLAG_PATH
+    dispatcher = Dispatcher(
+        redis=redis,
+        circuit_breaker=CircuitBreaker(redis=redis),
+        mutex=Mutex(redis=redis),
+        blackout=BlackoutManager(flag_path=blackout_path),
+        shadow_mode=shadow_mode,
+        actuator_registry=actuator_registry or {},
+        on_dispatched=on_dispatched if not shadow_mode else None,
     )
 
     result = await redis.xreadgroup(
@@ -115,6 +178,14 @@ async def run_once(
                 raw = _decode_data_field(fields)
                 event = Event.model_validate_json(raw)
                 decision = await decider.decide(event)
+                target = _target_for(decision.actuator, decision.params)
+
+                outcome = await dispatcher.dispatch(
+                    decision=decision,
+                    target=target,
+                    correlation_id=event.correlation_id,
+                )
+
                 entry = {
                     "ts": time.time(),
                     "event_kind": event.kind,
@@ -123,15 +194,12 @@ async def run_once(
                     "tier": decision.tier,
                     "confidence": decision.confidence,
                     "shadow_mode": shadow_mode,
+                    "dispatch_outcome": outcome.value,
+                    "target": target,
                 }
                 with decisions_log.open("a", encoding="utf-8") as f:
                     f.write(json.dumps(entry) + "\n")
-                if not shadow_mode:
-                    # W1 is shadow-only; W1.C/W2 will replace this with real
-                    # actuator dispatch for whitelisted safe actions.
-                    log.warning(
-                        "active mode dispatch not yet implemented (W1.C/W2)",
-                    )
+
                 await redis.xack(STREAM_KEY, CONSUMER_GROUP, msg_id)
                 processed += 1
             except Exception:
@@ -141,6 +209,8 @@ async def run_once(
 
 async def main() -> None:  # pragma: no cover — launchd entrypoint
     import redis.asyncio as _redis  # local import so tests don't need live Redis
+
+    from organism.actuators import build_actuator_registry
 
     r = _redis.from_url(
         os.getenv("ORGANISM_REDIS_URL", "redis://127.0.0.1:6379/0"),
@@ -153,14 +223,42 @@ async def main() -> None:  # pragma: no cover — launchd entrypoint
         "ORGANISM_DECISIONS_LOG",
         str(Path.home() / "logs" / "organism" / "decisions.jsonl"),
     ))
-    shadow = os.getenv("ORGANISM_SHADOW_MODE", "true").lower() == "true"
+    active_flag_path = Path(os.getenv(
+        "ORGANISM_ACTIVE_FLAG_PATH", str(DEFAULT_ACTIVE_FLAG_PATH),
+    ))
+    blackout_flag_path = Path(os.getenv(
+        "ORGANISM_BLACKOUT_FLAG_PATH", str(DEFAULT_BLACKOUT_FLAG_PATH),
+    ))
+    # ORGANISM_SHADOW_MODE remains a backward-compat hard-off switch:
+    # if explicitly set to "true", we stay in shadow regardless of file flag.
+    forced_shadow_env = (
+        os.getenv("ORGANISM_SHADOW_MODE", "true").lower() == "true"
+    )
+    active_flag = ActiveFlag(path=active_flag_path)
+    registry = build_actuator_registry(redis=r)
+
+    # Lazy import to keep the daemon import light when telegram bits absent
+    from organism.supervisor.telegram_alert import build_dispatch_alerter
+
+    on_dispatched = build_dispatch_alerter(registry)
+
     while True:
         try:
+            file_active = active_flag.is_active()
+            shadow = (not file_active) or forced_shadow_env
+            if file_active and forced_shadow_env:
+                log.warning(
+                    "active.flag=1 BUT ORGANISM_SHADOW_MODE=true — staying "
+                    "in shadow. Unset env var to enable W2.",
+                )
             await run_once(
                 redis=r,
                 rules_path=rules_path,
                 decisions_log=decisions_log,
                 shadow_mode=shadow,
+                actuator_registry=registry,
+                blackout_flag=blackout_flag_path,
+                on_dispatched=on_dispatched if not shadow else None,
             )
         except Exception:
             log.exception("run_once failed; sleeping 5s")

--- a/apps/organism/organism/supervisor/daemon.py
+++ b/apps/organism/organism/supervisor/daemon.py
@@ -229,10 +229,13 @@ async def main() -> None:  # pragma: no cover — launchd entrypoint
     blackout_flag_path = Path(os.getenv(
         "ORGANISM_BLACKOUT_FLAG_PATH", str(DEFAULT_BLACKOUT_FLAG_PATH),
     ))
-    # ORGANISM_SHADOW_MODE remains a backward-compat hard-off switch:
-    # if explicitly set to "true", we stay in shadow regardless of file flag.
+    # ORGANISM_SHADOW_MODE is a panic-mode override. Default (unset or
+    # "false") makes the file flag authoritative. Set to "true" only to
+    # force shadow during incidents — survives daemon restart so an operator
+    # cannot accidentally re-arm W2 by deleting the active.flag while
+    # forgetting the env override is still in place.
     forced_shadow_env = (
-        os.getenv("ORGANISM_SHADOW_MODE", "true").lower() == "true"
+        os.getenv("ORGANISM_SHADOW_MODE", "false").lower() == "true"
     )
     active_flag = ActiveFlag(path=active_flag_path)
     registry = build_actuator_registry(redis=r)

--- a/apps/organism/organism/supervisor/dispatch.py
+++ b/apps/organism/organism/supervisor/dispatch.py
@@ -9,12 +9,20 @@ Integrates:
   the L0 rule matcher, but dispatcher asserts the decision was not born
   from an actuation event)
 
-In W1 shadow mode: logs the decision then returns SHADOW_LOGGED without
-invoking the actuator. W2 will flip shadow_mode=False and the dispatcher
-will actually call actuator.run().
+Modes:
+- shadow_mode=True: log decision and return SHADOW_LOGGED, do NOT invoke actuator.
+- shadow_mode=False (W2): look up actuator in `actuator_registry`,
+  call `await actuator.run(params=..., correlation_id=..., dry_run=False)`,
+  invoke optional `on_dispatched` callback (Telegram side-effect), return
+  DISPATCHED. Actuator's own ActuatorBase.run() captures exceptions and
+  emits done/failed events; the dispatcher only crashes if the actuator
+  test double explicitly raises (it then records a CB failure and reports
+  DISPATCHED — the upstream supervise loop continues).
 """
 import logging
 from enum import Enum
+from typing import Any, Awaitable, Callable, Mapping, Protocol
+
 from organism.schemas import ActionDecision
 
 
@@ -55,6 +63,15 @@ class DispatchOutcome(str, Enum):
     DEFERRED_DEFER_ACTUATOR = "deferred_defer_actuator"
 
 
+class _ActuatorLike(Protocol):
+    name: str
+
+    async def run(self, *, params, correlation_id, dry_run=False): ...
+
+
+OnDispatchedCallback = Callable[..., Awaitable[None]]
+
+
 class Dispatcher:
     def __init__(
         self,
@@ -64,12 +81,19 @@ class Dispatcher:
         mutex,
         blackout,
         shadow_mode: bool = True,
+        actuator_registry: Mapping[str, _ActuatorLike] | None = None,
+        on_dispatched: OnDispatchedCallback | None = None,
     ):
         self.redis = redis
         self.circuit_breaker = circuit_breaker
         self.mutex = mutex
         self.blackout = blackout
         self.shadow_mode = shadow_mode
+        # Registry is required in active mode but allowed to be None in shadow
+        # so callers (esp. tests) can construct a dispatcher without wiring
+        # the full actuator graph just to verify shadow paths.
+        self.actuator_registry = dict(actuator_registry or {})
+        self.on_dispatched = on_dispatched
 
     def _target_key(self, decision: ActionDecision, target: str) -> str:
         return f"{decision.actuator}:{target}"
@@ -137,12 +161,65 @@ class Dispatcher:
                     actuator, decision.params, correlation_id,
                 )
                 return DispatchOutcome.SHADOW_LOGGED
-            # Active mode — W2 wires actual actuator invocation here.
-            # For W1 we just return DISPATCHED to prove the guard chain passed.
+
+            # 6. W2 active mode — invoke the actuator.
+            instance = self.actuator_registry.get(actuator)
+            if instance is None:
+                # Active mode but we have no implementation wired. Treat as
+                # unknown so upstream observability (and operators) catch the
+                # gap immediately rather than silently no-op'ing.
+                log.error(
+                    "dispatch (active): actuator=%s in SAFE list but not in "
+                    "registry — rejected corr=%s",
+                    actuator, correlation_id,
+                )
+                return DispatchOutcome.REJECTED_UNKNOWN
+
             log.info(
-                "dispatch (active): actuator=%s params=%s corr=%s — invocation placeholder (W2)",
+                "dispatch (active): actuator=%s params=%s corr=%s",
                 actuator, decision.params, correlation_id,
             )
+            result: Any
+            try:
+                result = await instance.run(
+                    params=decision.params,
+                    correlation_id=correlation_id,
+                    dry_run=False,
+                )
+            except Exception as exc:  # actuator misbehaved (raised instead of returning {success: False})
+                log.exception(
+                    "dispatch (active): actuator=%s raised — recording CB "
+                    "failure corr=%s",
+                    actuator, correlation_id,
+                )
+                try:
+                    await self.circuit_breaker.record_failure(target_key)
+                except Exception:
+                    log.exception("dispatch: CB record_failure failed (non-fatal)")
+                result = {"success": False, "error": str(exc)[:500]}
+            else:
+                if not result.get("success", False):
+                    try:
+                        await self.circuit_breaker.record_failure(target_key)
+                    except Exception:
+                        log.exception("dispatch: CB record_failure failed (non-fatal)")
+
+            # 7. Best-effort callback (e.g. Telegram alert). Failures here
+            #    must NOT propagate — they would cascade into supervise-loop
+            #    crashes the moment the bot token expires.
+            if self.on_dispatched is not None:
+                try:
+                    await self.on_dispatched(
+                        decision=decision,
+                        target=target,
+                        correlation_id=correlation_id,
+                        result=result,
+                    )
+                except Exception:
+                    log.exception(
+                        "dispatch: on_dispatched callback raised (non-fatal)",
+                    )
+
             return DispatchOutcome.DISPATCHED
         finally:
             await self.mutex.release(target_key, lock_id)

--- a/apps/organism/organism/supervisor/telegram_alert.py
+++ b/apps/organism/organism/supervisor/telegram_alert.py
@@ -1,0 +1,95 @@
+"""Telegram alerter — best-effort `on_dispatched` callback for Dispatcher.
+
+Builds a callable that the daemon passes to `Dispatcher(on_dispatched=...)`.
+The callback formats one short Telegram message per DISPATCHED outcome and
+delegates to the `notify_telegram` actuator already in the registry, so we
+reuse its httpx client + bot credentials without duplicating env-var logic.
+
+Best-effort by design: any exception from NotifyTelegram is logged and
+swallowed. The dispatcher already wraps the callback in its own try/except,
+this layer adds a second guard so a failing telegram API call cannot lock
+out the supervise loop.
+
+Self-recursion guard: when the dispatched actuator is itself
+`notify_telegram` we do NOT alert — that would loop on every alert sent.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Mapping
+
+from organism.schemas import ActionDecision
+
+
+log = logging.getLogger(__name__)
+
+
+_MAX_TELEGRAM_BODY = 3500  # Telegram caps at 4096 chars; leave headroom
+
+
+def _format_message(
+    *,
+    decision: ActionDecision,
+    target: str,
+    correlation_id: str,
+    result: Mapping[str, Any],
+) -> str:
+    success = bool(result.get("success", False))
+    icon = "✅" if success else "❌"
+    header = f"{icon} Supervisor W2 dispatch — {decision.actuator}"
+    lines = [
+        header,
+        f"target: {target}",
+        f"corr:   {correlation_id[:32]}",
+        f"tier:   {decision.tier} (conf={decision.confidence:.2f})",
+        f"status: {'success' if success else 'FAILED'}",
+    ]
+    if not success:
+        err = str(result.get("error", "(no error message)"))
+        lines.append(f"error:  {err[:300]}")
+    body = "\n".join(lines)
+    return body[:_MAX_TELEGRAM_BODY]
+
+
+def build_dispatch_alerter(
+    actuator_registry: Mapping[str, Any],
+) -> Callable[..., Awaitable[None]]:
+    """Return an async on_dispatched callback bound to the registry.
+
+    The returned callable matches Dispatcher's contract:
+        async def(*, decision, target, correlation_id, result) -> None
+    """
+    notifier = actuator_registry.get("notify_telegram")
+
+    async def on_dispatched(
+        *,
+        decision: ActionDecision,
+        target: str,
+        correlation_id: str,
+        result: Mapping[str, Any],
+    ) -> None:
+        if decision.actuator == "notify_telegram":
+            # Avoid feedback loop: NotifyTelegram dispatched → don't alert about it.
+            return
+        if notifier is None:
+            log.debug(
+                "telegram_alert: notify_telegram missing from registry — skip",
+            )
+            return
+        try:
+            await notifier.run(
+                params={
+                    "message": _format_message(
+                        decision=decision,
+                        target=target,
+                        correlation_id=correlation_id,
+                        result=result,
+                    ),
+                },
+                correlation_id=correlation_id,
+                dry_run=False,
+            )
+        except Exception:
+            log.exception("telegram_alert: notifier.run raised (non-fatal)")
+
+    return on_dispatched

--- a/apps/organism/scripts/supervisor_canary.py
+++ b/apps/organism/scripts/supervisor_canary.py
@@ -1,0 +1,149 @@
+"""W2 dispatch canary — emits a synthetic event, verifies decision logged.
+
+Usage:
+    cd apps/organism
+    PYTHONPATH=. python scripts/supervisor_canary.py \\
+        [--mode shadow|active] [--actuator restart_agent|cleanup_log|...] \\
+        [--target NAME]
+
+What it does:
+    1. Emits a synthetic event onto `organism:events` Redis stream that the
+       L0 YAML rules will match (default: scheduled_tick at 03:00 → cleanup_log).
+    2. Polls ~/logs/organism/decisions.jsonl for a new entry matching the
+       canary correlation_id (timeout 30s).
+    3. In active mode: also tails ~/logs/organism/wal/ for an actuator WAL
+       entry as proof the actuator was actually invoked.
+
+Exit code 0 on success, 1 on timeout or assertion failure. Designed for
+manual invocation pre-flag-flip and as a precondition gate in the canary
+runbook.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import redis.asyncio as redis_async
+
+from organism.schemas import Event, Severity
+
+
+DECISIONS_LOG = Path.home() / "logs" / "organism" / "decisions.jsonl"
+WAL_DIR = Path.home() / "logs" / "organism" / "wal"
+STREAM_KEY = "organism:events"
+TIMEOUT_S = 30
+
+
+async def _emit_synthetic_event(*, kind: str, payload: dict, correlation_id: str) -> None:
+    r = redis_async.from_url("redis://127.0.0.1:6379/0")
+    e = Event(
+        severity=Severity.INFO,
+        source="canary.supervisor",
+        kind=kind,
+        payload=payload,
+        correlation_id=correlation_id,
+        host="Pro",
+    )
+    await r.xadd(STREAM_KEY, {"data": e.model_dump_json()})
+    await r.aclose()
+
+
+def _wait_for_decision(correlation_id: str, *, deadline: float) -> dict | None:
+    """Tail decisions.jsonl until we see correlation_id or timeout."""
+    if not DECISIONS_LOG.exists():
+        return None
+    start_size = DECISIONS_LOG.stat().st_size
+    while time.time() < deadline:
+        try:
+            with DECISIONS_LOG.open() as f:
+                f.seek(max(0, start_size - 4096))  # back up a tiny bit in case the line landed before our snapshot
+                for line in f:
+                    if not line.strip():
+                        continue
+                    try:
+                        entry = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if entry.get("correlation_id") == correlation_id:
+                        return entry
+        except OSError:
+            pass
+        time.sleep(0.5)
+    return None
+
+
+def _wait_for_wal(actuator: str, *, since: float, deadline: float) -> Path | None:
+    """Find a WAL entry written for actuator after `since`."""
+    while time.time() < deadline:
+        if WAL_DIR.exists():
+            for p in WAL_DIR.glob(f"{actuator}-*.json"):
+                try:
+                    if p.stat().st_mtime >= since:
+                        return p
+                except FileNotFoundError:
+                    continue
+        time.sleep(0.5)
+    return None
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=["shadow", "active"], default="shadow")
+    parser.add_argument("--kind", default="scheduled_tick")
+    parser.add_argument("--actuator", default="cleanup_log",
+                        help="actuator to expect in the decision (matches L0 YAML rule)")
+    parser.add_argument("--payload", default='{"hour": 3}',
+                        help="JSON event payload that triggers the rule")
+    args = parser.parse_args()
+
+    correlation_id = f"canary-{uuid.uuid4()}"
+    payload = json.loads(args.payload)
+
+    print(f"[canary] mode={args.mode} corr={correlation_id} kind={args.kind} payload={payload}")
+    started = time.time()
+    await _emit_synthetic_event(
+        kind=args.kind, payload=payload, correlation_id=correlation_id,
+    )
+    print(f"[canary] emitted synthetic event at {started:.3f}, waiting up to {TIMEOUT_S}s for decision …")
+
+    deadline = started + TIMEOUT_S
+    entry = _wait_for_decision(correlation_id, deadline=deadline)
+    if entry is None:
+        print("[canary] FAIL: no decision logged within timeout", file=sys.stderr)
+        return 1
+
+    print(f"[canary] decision: {json.dumps(entry, indent=2)}")
+    if entry["actuator"] != args.actuator:
+        print(
+            f"[canary] FAIL: expected actuator={args.actuator}, got {entry['actuator']}",
+            file=sys.stderr,
+        )
+        return 1
+
+    expected_outcome = "shadow_logged" if args.mode == "shadow" else "dispatched"
+    if entry.get("dispatch_outcome") != expected_outcome:
+        print(
+            f"[canary] FAIL: expected dispatch_outcome={expected_outcome}, got {entry.get('dispatch_outcome')}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.mode == "active":
+        print("[canary] looking for WAL entry to confirm actuator invocation …")
+        wal = _wait_for_wal(args.actuator, since=started, deadline=deadline)
+        if wal is None:
+            print("[canary] FAIL: no WAL entry found for actuator", file=sys.stderr)
+            return 1
+        print(f"[canary] WAL: {wal}")
+
+    print("[canary] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/apps/organism/tests/supervisor/test_active_flag.py
+++ b/apps/organism/tests/supervisor/test_active_flag.py
@@ -1,0 +1,50 @@
+"""Tests for ActiveFlag — file-based kill switch for W2 dispatch."""
+from pathlib import Path
+
+import pytest
+
+from organism.supervisor.active_flag import ActiveFlag
+
+
+def test_active_flag_default_is_inactive(tmp_path: Path) -> None:
+    flag = ActiveFlag(path=tmp_path / "active.flag")
+    assert flag.is_active() is False
+
+
+def test_active_flag_file_with_one_is_active(tmp_path: Path) -> None:
+    p = tmp_path / "active.flag"
+    p.write_text("1")
+    flag = ActiveFlag(path=p)
+    assert flag.is_active() is True
+
+
+def test_active_flag_file_with_zero_is_inactive(tmp_path: Path) -> None:
+    p = tmp_path / "active.flag"
+    p.write_text("0")
+    flag = ActiveFlag(path=p)
+    assert flag.is_active() is False
+
+
+def test_active_flag_file_empty_is_inactive(tmp_path: Path) -> None:
+    p = tmp_path / "active.flag"
+    p.write_text("")
+    flag = ActiveFlag(path=p)
+    assert flag.is_active() is False
+
+
+def test_active_flag_file_with_whitespace_one_is_active(tmp_path: Path) -> None:
+    p = tmp_path / "active.flag"
+    p.write_text(" 1\n")
+    flag = ActiveFlag(path=p)
+    assert flag.is_active() is True
+
+
+def test_active_flag_re_reads_on_each_call(tmp_path: Path) -> None:
+    """Operator flips the file with `echo 1 >`; daemon must NOT cache."""
+    p = tmp_path / "active.flag"
+    flag = ActiveFlag(path=p)
+    assert flag.is_active() is False
+    p.write_text("1")
+    assert flag.is_active() is True
+    p.write_text("0")
+    assert flag.is_active() is False

--- a/apps/organism/tests/supervisor/test_daemon.py
+++ b/apps/organism/tests/supervisor/test_daemon.py
@@ -44,3 +44,182 @@ async def test_run_once_writes_heartbeat(fake_redis, tmp_path):
     assert hb is not None
     ts = float(hb)
     assert abs(time.time() - ts) < 5
+
+
+# ============================================================================
+# W2 active-mode tests (FASE 5)
+# ============================================================================
+
+
+class _RecordingActuator:
+    """Test double for actuator registry — records calls."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.calls: list[dict] = []
+
+    async def run(self, *, params, correlation_id, dry_run=False):
+        self.calls.append({
+            "params": dict(params),
+            "correlation_id": correlation_id,
+            "dry_run": dry_run,
+        })
+        return {"success": True}
+
+
+@pytest.mark.asyncio
+async def test_run_once_active_mode_invokes_actuator(fake_redis, tmp_path):
+    """W2: shadow_mode=False + actuator_registry → real run() called."""
+    e = Event(severity=Severity.ERROR, source="s", kind="cron_agent_failure",
+              payload={"agent": "foo"}, correlation_id="c-active", host="Pro")
+    await fake_redis.xadd("organism:events", {"data": e.model_dump_json()})
+
+    rules_yaml = """rules:
+  - id: r1
+    match: {kind: cron_agent_failure}
+    action: {actuator: restart_agent, params: {agent_ref: "{payload.agent}"}}
+    confidence: 0.95
+"""
+    fake = _RecordingActuator(name="restart_agent")
+    decisions_log = tmp_path / "decisions.jsonl"
+    blackout_flag = tmp_path / "pause.flag"
+
+    processed = await run_once(
+        redis=fake_redis,
+        rules_yaml=rules_yaml,
+        decisions_log=decisions_log,
+        shadow_mode=False,
+        actuator_registry={"restart_agent": fake},
+        blackout_flag=blackout_flag,
+    )
+    assert processed >= 1
+    assert len(fake.calls) == 1
+    assert fake.calls[0]["correlation_id"] == "c-active"
+    assert fake.calls[0]["params"]["agent_ref"] == "foo"
+    assert fake.calls[0]["dry_run"] is False
+
+    entry = json.loads(decisions_log.read_text().strip().splitlines()[0])
+    assert entry["actuator"] == "restart_agent"
+    assert entry["shadow_mode"] is False
+    assert entry["dispatch_outcome"] == "dispatched"
+
+
+@pytest.mark.asyncio
+async def test_run_once_shadow_does_not_invoke_actuator(fake_redis, tmp_path):
+    """Shadow mode: actuator MUST NOT be called even if registry provided."""
+    e = Event(severity=Severity.ERROR, source="s", kind="cron_agent_failure",
+              payload={"agent": "foo"}, correlation_id="c-shadow", host="Pro")
+    await fake_redis.xadd("organism:events", {"data": e.model_dump_json()})
+
+    rules_yaml = """rules:
+  - id: r1
+    match: {kind: cron_agent_failure}
+    action: {actuator: restart_agent, params: {agent_ref: "{payload.agent}"}}
+    confidence: 0.95
+"""
+    fake = _RecordingActuator(name="restart_agent")
+    processed = await run_once(
+        redis=fake_redis,
+        rules_yaml=rules_yaml,
+        decisions_log=tmp_path / "d.jsonl",
+        shadow_mode=True,
+        actuator_registry={"restart_agent": fake},
+        blackout_flag=tmp_path / "pause.flag",
+    )
+    assert processed >= 1
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+async def test_run_once_active_invokes_on_dispatched_callback(fake_redis, tmp_path):
+    """W2 Telegram path: on_dispatched fires once per DISPATCHED outcome."""
+    e = Event(severity=Severity.ERROR, source="s", kind="cron_agent_failure",
+              payload={"agent": "foo"}, correlation_id="c-cb", host="Pro")
+    await fake_redis.xadd("organism:events", {"data": e.model_dump_json()})
+
+    rules_yaml = """rules:
+  - id: r1
+    match: {kind: cron_agent_failure}
+    action: {actuator: restart_agent, params: {agent_ref: "{payload.agent}"}}
+    confidence: 0.95
+"""
+    fake = _RecordingActuator(name="restart_agent")
+    captured: list[dict] = []
+
+    async def cb(*, decision, target, correlation_id, result):
+        captured.append({
+            "actuator": decision.actuator,
+            "target": target,
+            "correlation_id": correlation_id,
+            "success": result.get("success"),
+        })
+
+    await run_once(
+        redis=fake_redis,
+        rules_yaml=rules_yaml,
+        decisions_log=tmp_path / "d.jsonl",
+        shadow_mode=False,
+        actuator_registry={"restart_agent": fake},
+        blackout_flag=tmp_path / "pause.flag",
+        on_dispatched=cb,
+    )
+    assert len(captured) == 1
+    assert captured[0]["actuator"] == "restart_agent"
+    assert captured[0]["correlation_id"] == "c-cb"
+    assert captured[0]["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_run_once_active_with_blackout_does_not_invoke_actuator(fake_redis, tmp_path):
+    """Blackout flag set → DEFERRED_BLACKOUT, actuator NOT called."""
+    e = Event(severity=Severity.ERROR, source="s", kind="cron_agent_failure",
+              payload={"agent": "foo"}, correlation_id="c-blk", host="Pro")
+    await fake_redis.xadd("organism:events", {"data": e.model_dump_json()})
+
+    rules_yaml = """rules:
+  - id: r1
+    match: {kind: cron_agent_failure}
+    action: {actuator: restart_agent, params: {agent_ref: "{payload.agent}"}}
+    confidence: 0.95
+"""
+    from organism.blackout import BlackoutManager
+    blackout_flag = tmp_path / "pause.flag"
+    BlackoutManager(flag_path=blackout_flag).pause(minutes=5)
+
+    fake = _RecordingActuator(name="restart_agent")
+    processed = await run_once(
+        redis=fake_redis,
+        rules_yaml=rules_yaml,
+        decisions_log=tmp_path / "d.jsonl",
+        shadow_mode=False,
+        actuator_registry={"restart_agent": fake},
+        blackout_flag=blackout_flag,
+    )
+    assert processed >= 1
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+async def test_run_once_active_defer_to_human_does_not_invoke_actuator(fake_redis, tmp_path):
+    """No rule match → defer_to_human → no actuator invoked, no Telegram callback."""
+    e = Event(severity=Severity.INFO, source="s", kind="scheduled_tick",
+              payload={"hour": 12}, correlation_id="c-defer", host="Pro")
+    await fake_redis.xadd("organism:events", {"data": e.model_dump_json()})
+
+    fake = _RecordingActuator(name="restart_agent")
+    captured: list = []
+
+    async def cb(**_):
+        captured.append(1)
+
+    await run_once(
+        redis=fake_redis,
+        rules_yaml="rules: []",  # no matching rule
+        decisions_log=tmp_path / "d.jsonl",
+        shadow_mode=False,
+        actuator_registry={"restart_agent": fake},
+        blackout_flag=tmp_path / "pause.flag",
+        on_dispatched=cb,
+    )
+    assert fake.calls == []
+    assert captured == []

--- a/apps/organism/tests/supervisor/test_dispatch.py
+++ b/apps/organism/tests/supervisor/test_dispatch.py
@@ -122,3 +122,175 @@ async def test_dispatch_unknown_actuator_rejected(fake_redis, tmp_path):
         target="x", correlation_id="c",
     )
     assert outcome == DispatchOutcome.REJECTED_UNKNOWN
+
+
+# ============================================================================
+# W2: Active-mode actuator invocation (FASE 5)
+# ============================================================================
+
+
+class _RecordingActuator:
+    """Test double — records its run() invocations without side effects."""
+
+    def __init__(self, *, name: str, raises: Exception | None = None) -> None:
+        self.name = name
+        self.calls: list[dict] = []
+        self._raises = raises
+
+    async def run(self, *, params, correlation_id, dry_run=False):
+        self.calls.append({
+            "params": dict(params),
+            "correlation_id": correlation_id,
+            "dry_run": dry_run,
+        })
+        if self._raises is not None:
+            raise self._raises
+        return {"success": True, "fake": True}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_active_invokes_actuator(fake_redis, tmp_path):
+    """Active mode + DISPATCHED outcome → actuator.run() called once."""
+    fake = _RecordingActuator(name="restart_agent")
+    d = Dispatcher(
+        redis=fake_redis,
+        circuit_breaker=CircuitBreaker(redis=fake_redis),
+        mutex=Mutex(redis=fake_redis),
+        blackout=BlackoutManager(flag_path=tmp_path / "pause.flag"),
+        shadow_mode=False,
+        actuator_registry={"restart_agent": fake},
+    )
+    outcome = await d.dispatch(
+        decision=_decision(),
+        target="core-guardian",
+        correlation_id="c1",
+    )
+    assert outcome == DispatchOutcome.DISPATCHED
+    assert len(fake.calls) == 1
+    assert fake.calls[0]["correlation_id"] == "c1"
+    assert fake.calls[0]["dry_run"] is False
+    assert fake.calls[0]["params"] == {"agent_ref": "core-guardian"}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_shadow_does_not_invoke_actuator(fake_redis, tmp_path):
+    """Shadow mode → actuator.run() must NOT be called."""
+    fake = _RecordingActuator(name="restart_agent")
+    d = Dispatcher(
+        redis=fake_redis,
+        circuit_breaker=CircuitBreaker(redis=fake_redis),
+        mutex=Mutex(redis=fake_redis),
+        blackout=BlackoutManager(flag_path=tmp_path / "pause.flag"),
+        shadow_mode=True,
+        actuator_registry={"restart_agent": fake},
+    )
+    outcome = await d.dispatch(
+        decision=_decision(), target="x", correlation_id="c",
+    )
+    assert outcome == DispatchOutcome.SHADOW_LOGGED
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_active_actuator_missing_in_registry(fake_redis, tmp_path):
+    """Active + actuator in SAFE list but missing from registry → rejected."""
+    d = Dispatcher(
+        redis=fake_redis,
+        circuit_breaker=CircuitBreaker(redis=fake_redis),
+        mutex=Mutex(redis=fake_redis),
+        blackout=BlackoutManager(flag_path=tmp_path / "pause.flag"),
+        shadow_mode=False,
+        actuator_registry={},  # empty: restart_agent not present
+    )
+    outcome = await d.dispatch(
+        decision=_decision(), target="x", correlation_id="c",
+    )
+    assert outcome == DispatchOutcome.REJECTED_UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_dispatch_active_actuator_failure_records_cb(fake_redis, tmp_path):
+    """Actuator raising → circuit breaker records failure, outcome DISPATCHED.
+
+    The actuator's own `.run()` swallows exceptions and returns
+    {"success": False, "error": ...}, so an exception bubbling up to the
+    dispatcher is unexpected — but if it happens (registry test double
+    raising), we still record a CB failure so subsequent dispatches against
+    the same target back off, and we surface DISPATCHED with success=False
+    via the actuator base class. We model it here by having the test double
+    raise; the dispatcher must NOT crash.
+    """
+    boom = _RecordingActuator(name="restart_agent", raises=RuntimeError("boom"))
+    cb = CircuitBreaker(redis=fake_redis, max_tries=2)
+    d = Dispatcher(
+        redis=fake_redis,
+        circuit_breaker=cb,
+        mutex=Mutex(redis=fake_redis),
+        blackout=BlackoutManager(flag_path=tmp_path / "pause.flag"),
+        shadow_mode=False,
+        actuator_registry={"restart_agent": boom},
+    )
+    outcome = await d.dispatch(
+        decision=_decision(), target="x", correlation_id="c",
+    )
+    # We treat actuator-raised exception as a failure but not a crash.
+    assert outcome == DispatchOutcome.DISPATCHED
+    assert len(boom.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_active_calls_on_dispatched_callback(fake_redis, tmp_path):
+    """Caller can register an `on_dispatched` callback for Telegram side-effects."""
+    fake = _RecordingActuator(name="restart_agent")
+    captured: list[dict] = []
+
+    async def callback(*, decision, target, correlation_id, result):
+        captured.append({
+            "actuator": decision.actuator,
+            "target": target,
+            "correlation_id": correlation_id,
+            "result": result,
+        })
+
+    d = Dispatcher(
+        redis=fake_redis,
+        circuit_breaker=CircuitBreaker(redis=fake_redis),
+        mutex=Mutex(redis=fake_redis),
+        blackout=BlackoutManager(flag_path=tmp_path / "pause.flag"),
+        shadow_mode=False,
+        actuator_registry={"restart_agent": fake},
+        on_dispatched=callback,
+    )
+    outcome = await d.dispatch(
+        decision=_decision(),
+        target="core-guardian",
+        correlation_id="c1",
+    )
+    assert outcome == DispatchOutcome.DISPATCHED
+    assert len(captured) == 1
+    assert captured[0]["actuator"] == "restart_agent"
+    assert captured[0]["target"] == "core-guardian"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_callback_failure_does_not_break_dispatch(fake_redis, tmp_path):
+    """If callback raises, dispatch must still report DISPATCHED — Telegram is best-effort."""
+    fake = _RecordingActuator(name="restart_agent")
+
+    async def bad_callback(**kwargs):
+        raise RuntimeError("telegram down")
+
+    d = Dispatcher(
+        redis=fake_redis,
+        circuit_breaker=CircuitBreaker(redis=fake_redis),
+        mutex=Mutex(redis=fake_redis),
+        blackout=BlackoutManager(flag_path=tmp_path / "pause.flag"),
+        shadow_mode=False,
+        actuator_registry={"restart_agent": fake},
+        on_dispatched=bad_callback,
+    )
+    outcome = await d.dispatch(
+        decision=_decision(), target="x", correlation_id="c",
+    )
+    assert outcome == DispatchOutcome.DISPATCHED
+    assert len(fake.calls) == 1

--- a/apps/organism/tests/supervisor/test_telegram_alert.py
+++ b/apps/organism/tests/supervisor/test_telegram_alert.py
@@ -1,0 +1,113 @@
+"""Tests for telegram_alert.build_dispatch_alerter — best-effort Telegram side-effect."""
+from __future__ import annotations
+
+import pytest
+
+from organism.schemas import ActionDecision
+from organism.supervisor.telegram_alert import build_dispatch_alerter
+
+
+class _FakeNotifyTelegram:
+    """Test double matching the NotifyTelegram actuator surface."""
+
+    name = "notify_telegram"
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def run(self, *, params, correlation_id, dry_run=False):
+        self.calls.append({
+            "params": dict(params),
+            "correlation_id": correlation_id,
+            "dry_run": dry_run,
+        })
+        return {"success": True}
+
+
+def _decision(actuator="restart_agent"):
+    return ActionDecision(
+        actuator=actuator,
+        params={"agent_ref": "core-guardian"},
+        confidence=0.9,
+        tier="L0_yaml",
+        reasoning="test",
+    )
+
+
+@pytest.mark.asyncio
+async def test_alerter_sends_message_on_success():
+    notifier = _FakeNotifyTelegram()
+    alerter = build_dispatch_alerter({"notify_telegram": notifier})
+    await alerter(
+        decision=_decision(),
+        target="core-guardian",
+        correlation_id="abc",
+        result={"success": True, "label": "com.balizero.core-guardian"},
+    )
+    assert len(notifier.calls) == 1
+    msg = notifier.calls[0]["params"]["message"]
+    assert "restart_agent" in msg
+    assert "core-guardian" in msg
+    assert "✅" in msg or "ok" in msg.lower() or "success" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_alerter_marks_failure_explicitly():
+    notifier = _FakeNotifyTelegram()
+    alerter = build_dispatch_alerter({"notify_telegram": notifier})
+    await alerter(
+        decision=_decision(),
+        target="x",
+        correlation_id="c",
+        result={"success": False, "error": "kickstart returned 1"},
+    )
+    assert len(notifier.calls) == 1
+    msg = notifier.calls[0]["params"]["message"]
+    assert "fail" in msg.lower() or "❌" in msg or "error" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_alerter_skips_self_alert_for_notify_telegram():
+    """If the dispatched actuator IS notify_telegram, don't recurse."""
+    notifier = _FakeNotifyTelegram()
+    alerter = build_dispatch_alerter({"notify_telegram": notifier})
+    await alerter(
+        decision=_decision(actuator="notify_telegram"),
+        target="x",
+        correlation_id="c",
+        result={"success": True},
+    )
+    assert notifier.calls == []
+
+
+@pytest.mark.asyncio
+async def test_alerter_no_op_when_notify_telegram_missing():
+    """Registry without notify_telegram → silent no-op (best-effort)."""
+    alerter = build_dispatch_alerter({})
+    # Must not raise.
+    await alerter(
+        decision=_decision(),
+        target="x",
+        correlation_id="c",
+        result={"success": True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_alerter_swallows_notifier_exceptions():
+    """If NotifyTelegram raises, alerter must not propagate."""
+
+    class _Boom:
+        name = "notify_telegram"
+
+        async def run(self, **_):
+            raise RuntimeError("telegram api 500")
+
+    alerter = build_dispatch_alerter({"notify_telegram": _Boom()})
+    # Must not raise.
+    await alerter(
+        decision=_decision(),
+        target="x",
+        correlation_id="c",
+        result={"success": True},
+    )

--- a/apps/organism/tests/supervisor/test_w2_integration.py
+++ b/apps/organism/tests/supervisor/test_w2_integration.py
@@ -1,0 +1,183 @@
+"""Integration tests for FASE 5 W2 dispatch — end-to-end through run_once.
+
+These cover the soft-canary scenarios from the FASE 5 brief Steps T2/T3
+without needing a live daemon: exercise daemon.run_once with a real fakeredis
+stream and a recording actuator double, then assert (a) the decision JSONL
+matches the contract, (b) actuator was invoked once, (c) Telegram callback
+fired once, (d) outcome is `dispatched`.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from organism.schemas import Event, Severity
+from organism.supervisor.daemon import run_once
+
+
+class _RecordingActuator:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.calls: list[dict] = []
+
+    async def run(self, *, params, correlation_id, dry_run=False):
+        self.calls.append({
+            "params": dict(params),
+            "correlation_id": correlation_id,
+            "dry_run": dry_run,
+        })
+        return {"success": True, "fake": True}
+
+
+class _RecordingNotifyTelegram:
+    name = "notify_telegram"
+
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    async def run(self, *, params, correlation_id, dry_run=False):
+        self.messages.append(params["message"])
+        return {"success": True}
+
+
+@pytest.mark.asyncio
+async def test_canary_t2_shadow_low_stakes_target(fake_redis, tmp_path):
+    """T2-equivalent: emit a low-stakes event in SHADOW mode → no actuator,
+    JSONL records shadow_logged outcome."""
+    e = Event(
+        severity=Severity.WARNING,
+        source="canary.test",
+        kind="cron_agent_failure",
+        payload={"agent": "low-stakes-test-cron"},
+        correlation_id="canary-t2",
+        host="Pro",
+    )
+    await fake_redis.xadd("organism:events", {"data": e.model_dump_json()})
+
+    rules_yaml = """rules:
+  - id: r1
+    match: {kind: cron_agent_failure}
+    action: {actuator: restart_agent, params: {agent_ref: "{payload.agent}"}}
+    confidence: 0.95
+"""
+    actuator = _RecordingActuator(name="restart_agent")
+    decisions_log = tmp_path / "decisions.jsonl"
+
+    await run_once(
+        redis=fake_redis,
+        rules_yaml=rules_yaml,
+        decisions_log=decisions_log,
+        shadow_mode=True,  # canonical T2 = shadow
+        actuator_registry={"restart_agent": actuator},
+        blackout_flag=tmp_path / "pause.flag",
+    )
+
+    assert actuator.calls == [], "shadow mode must NOT invoke actuator"
+    entry = json.loads(decisions_log.read_text().strip().splitlines()[0])
+    assert entry["actuator"] == "restart_agent"
+    assert entry["target"] == "low-stakes-test-cron"
+    assert entry["dispatch_outcome"] == "shadow_logged"
+    assert entry["shadow_mode"] is True
+
+
+@pytest.mark.asyncio
+async def test_canary_t3_active_low_stakes_target_with_telegram(fake_redis, tmp_path):
+    """T3-equivalent: kill switch ON, low-stakes target → actuator called once,
+    Telegram alert fires once, JSONL records dispatched."""
+    e = Event(
+        severity=Severity.WARNING,
+        source="canary.test",
+        kind="cron_agent_failure",
+        payload={"agent": "low-stakes-test-cron"},
+        correlation_id="canary-t3",
+        host="Pro",
+    )
+    await fake_redis.xadd("organism:events", {"data": e.model_dump_json()})
+
+    rules_yaml = """rules:
+  - id: r1
+    match: {kind: cron_agent_failure}
+    action: {actuator: restart_agent, params: {agent_ref: "{payload.agent}"}}
+    confidence: 0.95
+"""
+    actuator = _RecordingActuator(name="restart_agent")
+    notifier = _RecordingNotifyTelegram()
+    registry = {"restart_agent": actuator, "notify_telegram": notifier}
+
+    from organism.supervisor.telegram_alert import build_dispatch_alerter
+    alerter = build_dispatch_alerter(registry)
+
+    decisions_log = tmp_path / "decisions.jsonl"
+
+    await run_once(
+        redis=fake_redis,
+        rules_yaml=rules_yaml,
+        decisions_log=decisions_log,
+        shadow_mode=False,  # kill switch ON
+        actuator_registry=registry,
+        blackout_flag=tmp_path / "pause.flag",
+        on_dispatched=alerter,
+    )
+
+    # Actuator invoked exactly once with expected params
+    assert len(actuator.calls) == 1
+    assert actuator.calls[0]["correlation_id"] == "canary-t3"
+    assert actuator.calls[0]["params"]["agent_ref"] == "low-stakes-test-cron"
+
+    # Telegram alert fired exactly once with success marker
+    assert len(notifier.messages) == 1
+    msg = notifier.messages[0]
+    assert "restart_agent" in msg
+    assert "low-stakes-test-cron" in msg
+    assert "✅" in msg or "success" in msg.lower()
+
+    # JSONL contract
+    entry = json.loads(decisions_log.read_text().strip().splitlines()[0])
+    assert entry["dispatch_outcome"] == "dispatched"
+    assert entry["target"] == "low-stakes-test-cron"
+    assert entry["shadow_mode"] is False
+
+
+@pytest.mark.asyncio
+async def test_canary_blackout_blocks_active_dispatch(fake_redis, tmp_path):
+    """Operator paused via blackout flag → DEFERRED_BLACKOUT, no actuator."""
+    e = Event(
+        severity=Severity.WARNING,
+        source="canary.test",
+        kind="cron_agent_failure",
+        payload={"agent": "test"},
+        correlation_id="canary-blackout",
+        host="Pro",
+    )
+    await fake_redis.xadd("organism:events", {"data": e.model_dump_json()})
+
+    from organism.blackout import BlackoutManager
+    blackout_flag = tmp_path / "pause.flag"
+    BlackoutManager(flag_path=blackout_flag).pause(minutes=5)
+
+    actuator = _RecordingActuator(name="restart_agent")
+    notifier = _RecordingNotifyTelegram()
+
+    rules_yaml = """rules:
+  - id: r1
+    match: {kind: cron_agent_failure}
+    action: {actuator: restart_agent, params: {agent_ref: "{payload.agent}"}}
+    confidence: 0.95
+"""
+    decisions_log = tmp_path / "decisions.jsonl"
+
+    await run_once(
+        redis=fake_redis,
+        rules_yaml=rules_yaml,
+        decisions_log=decisions_log,
+        shadow_mode=False,
+        actuator_registry={"restart_agent": actuator, "notify_telegram": notifier},
+        blackout_flag=blackout_flag,
+    )
+
+    assert actuator.calls == [], "blackout must skip actuator invocation"
+    assert notifier.messages == [], "blackout must skip telegram alert"
+
+    entry = json.loads(decisions_log.read_text().strip().splitlines()[0])
+    assert entry["dispatch_outcome"] == "deferred_blackout"


### PR DESCRIPTION
## Summary

Activates Supervisor W2 dispatch — moves the daemon from W1 SHADOW (decisions logged, no actuation) to W2 ACTIVE (auto-recovery on whitelisted SAFE actuators), with a file-flag kill switch reachable in <1s without daemon restart and Telegram alerts on every dispatched outcome.

* New `ActiveFlag` (`~/.agent/supervisor/active.flag`) — re-read every supervise cycle. \"1\" → active, anything else → shadow. Operator flips via `~/scripts/supervisor-kill-switch.sh on|off|status`.
* `Dispatcher` now invokes `actuator.run()` in active mode (replaces the W2 placeholder); registry passed in. Optional `on_dispatched` callback fires after each `DISPATCHED` outcome — best-effort, swallows exceptions so a failing Telegram bot can not lock the supervise loop.
* `daemon.run_once` constructs Dispatcher every cycle from CircuitBreaker + Mutex + BlackoutManager + ActuatorRegistry, calls `dispatcher.dispatch()` after writing decision JSONL, records `dispatch_outcome` and `target` per entry.
* `telegram_alert.build_dispatch_alerter` — formats one short message per DISPATCHED outcome and routes through the existing `notify_telegram` actuator. Self-recursion guarded.
* `daemon.main()` defaults `ORGANISM_SHADOW_MODE` to \"false\" — the file flag is now the single source of truth. Env stays available as a panic-mode override.
* Plist drops the env-var entry; `TELEGRAM_BOT_TOKEN` + `TELEGRAM_OWNER_CHAT_ID` intentionally NOT in the plist (cicatrix scar 2026-04-29: world-readable plist leaks). Operator sets via `launchctl setenv` outside this PR.
* Soft-canary script `apps/organism/scripts/supervisor_canary.py` — emits a synthetic event onto `organism:events`, polls `decisions.jsonl` for matching `correlation_id`, asserts the dispatch_outcome is `shadow_logged` (mode shadow) or `dispatched` + WAL entry exists (mode active).

## W1 audit data (empirical baseline)

326 decisions over 9 unique days (2026-04-30 → 2026-05-08), driven by hourly `scheduled_tick` + a one-off Apr-30 `new_module` test burst:

| Day | defer_to_human | adopt_module | cleanup_log | other |
|------------|---:|---:|---:|---:|
| 2026-04-30 | 24 | 136 | 1 | 0 |
| 2026-05-01 | 23 | 0   | 1 | 0 |
| 2026-05-02 | 24 | 0   | 1 | 0 |
| 2026-05-03 | 20 | 0   | 1 | 3 |
| 2026-05-04 | 23 | 0   | 1 | 0 |
| 2026-05-05 | 22 | 0   | 1 | 0 |
| 2026-05-06 | 17 | 0   | 1 | 0 |
| 2026-05-07 | 23 | 0   | 2 | 0 |
| 2026-05-08 | 2  | 0   | 0 | 0 |

| Actuator | 9-day count |
|---|---:|
| defer_to_human | 178 |
| adopt_module | 136 (single Apr-30 test-event burst) |
| cleanup_log | 9 |
| cleanup_cache / cleanup_branches / cleanup_zombie_plist | 1 each |

After flag flip the daily baseline becomes ≥1 \`cleanup_log\` dispatch from \`scheduled_cleanup_log_nightly\` rule (target metric from PR #479: ≥1 dispatch/day) plus actual recovery for whatever cron / zombie / disk-fill events fire.

## Test plan

- [x] `pytest tests/supervisor/ tests/actuators/` → 174 passed, 0 failed (`apps/organism/`, Python 3.11.11 via pyenv)
- [x] `pytest tests/ --ignore=tests/gauntlet --ignore=tests/tools/test_validate_genome.py` → 223 passed, 1 skipped, 0 failed
- [x] `pytest tests/tools/test_validate_genome.py::test_live_genome_is_valid` → already FAILS on origin/main; pre-existing genome-checksum drift, not introduced by this PR.
- [x] `~/scripts/supervisor-kill-switch.sh` — verified `on` writes `1` to flag, `off` removes flag, `status` reads correctly.
- [x] Soft canary T2 + T3 covered by `test_w2_integration.py` (shadow no-actuator + active dispatched + Telegram fired + blackout-blocks-active).

## Activation runbook (post-merge — to be executed manually)

1. Reload daemon to pick up new code + plist:
   \`\`\`bash
   launchctl bootout gui/$(id -u)/com.nuzantara.organism.supervisor
   launchctl bootstrap gui/$(id -u) ~/Desktop/nuzantara/apps/organism/organism/launchd/com.nuzantara.organism.supervisor.plist
   \`\`\`
2. Set Telegram secrets at user-launchd level (NOT in plist — cicatrix scar):
   \`\`\`bash
   launchctl setenv TELEGRAM_BOT_TOKEN \"$TELEGRAM_BOT_TOKEN\"
   launchctl setenv TELEGRAM_OWNER_CHAT_ID 1125336968
   launchctl kickstart -k gui/$(id -u)/com.nuzantara.organism.supervisor
   \`\`\`
3. Run T2 canary in shadow (flag still OFF):
   \`\`\`bash
   cd ~/Desktop/nuzantara/apps/organism
   PYTHONPATH=. python scripts/supervisor_canary.py --mode shadow
   \`\`\` Expect \`PASS\`, JSONL shows \`dispatch_outcome=shadow_logged\`.
4. Flip the flag and rerun in active:
   \`\`\`bash
   ~/scripts/supervisor-kill-switch.sh on
   PYTHONPATH=. python scripts/supervisor_canary.py --mode active
   \`\`\` Expect \`PASS\`, JSONL shows \`dispatch_outcome=dispatched\`, WAL entry written, Telegram message received.
5. 7-day soak — daily count of \`dispatched\` outcomes via:
   \`\`\`bash
   awk -F'\"dispatch_outcome\": \"' '{print \$2}' ~/logs/organism/decisions.jsonl | awk -F'\"' '{print \$1}' | sort | uniq -c
   \`\`\`
   Kill switch reachable from anywhere via \`~/scripts/supervisor-kill-switch.sh off\`.

## Rollback

Single command: \`~/scripts/supervisor-kill-switch.sh off\`. Daemon falls back to shadow on the next supervise cycle (~1s). For full code rollback: revert merge commit on \`main\`; the plist change is benign (env defaults preserve old behavior).

## Out of scope

- Consiglio cron Sunday 16:00 (separate FASE 5b brief).
- Heartbeat-gap detection / Mini-side Supervisor / new actuators.
- Telegram bot-token rotation (cicatrix follow-up tracked separately).

Refs: PR #479 §FASE 4 promise of \"week 4 with kill switch + Telegram monitoring\". Cicatrix \`13 active-active dup\`, \`nuz-sync excluded from genome\` consulted (no new active-active organs introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)