### PR TITLE
fix(foundations): wave 2 external review — 5 new bugs (Codex+DeepSeek+Sonnet+security)

### DIFF
--- a/apps/mata-garuda/mata_garuda/foundations/__init__.py
+++ b/apps/mata-garuda/mata_garuda/foundations/__init__.py
@@ -12,11 +12,20 @@ Source plan: docs/superpowers/plans/2026-05-08-domain-mesh-phase0-foundations.md
 - ner_extractor (R7)          — bahasa NER (cahya BERT)
 - arxiv_sanity_scorer (R5)    — personal relevance SVM
 - openllmetry_init (R1)       — observability bootstrap
+
+Wave 2 review fix (Codex W2 + DeepSeek W2, 2026-05-08): exports are LAZY via
+PEP 562 `__getattr__`. Importing `mata_garuda.foundations` no longer pulls
+`transformers`, `torch`, or `sklearn` — those load only when callers
+explicitly access `NERExtractor`, `ArxivSanityScorer`, etc. This means a
+lightweight cron worker that only needs `probe_inventory` doesn't pay the
+cost of ML dependencies it never uses.
 """
-from mata_garuda.foundations.arxiv_sanity_scorer import (
-    ArxivSanityScorer,
-    LabeledPaper,
-)
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+# Modules safe to import eagerly: pure stdlib + httpx + pydantic.
 from mata_garuda.foundations.bali_calendar import (
     BalineseDate,
     days_until_next_galungan,
@@ -32,7 +41,6 @@ from mata_garuda.foundations.gov_apis_health import (
     probe_inventory,
     probe_portal,
 )
-from mata_garuda.foundations.ner_extractor import NamedEntity, NERExtractor
 from mata_garuda.foundations.openllmetry_init import (
     init_openllmetry,
     is_openllmetry_enabled,
@@ -44,8 +52,37 @@ from mata_garuda.foundations.opensanctions_id import (
 from mata_garuda.foundations.pasal_id_client import (
     LawSearchResult,
     LawStatus,
+    PasalIdAuthError,
     PasalIdClient,
 )
+
+# Heavy modules (transformers/torch/sklearn) — lazy via __getattr__.
+_LAZY_EXPORTS = {
+    "ArxivSanityScorer": ("mata_garuda.foundations.arxiv_sanity_scorer", "ArxivSanityScorer"),
+    "LabeledPaper": ("mata_garuda.foundations.arxiv_sanity_scorer", "LabeledPaper"),
+    "NERExtractor": ("mata_garuda.foundations.ner_extractor", "NERExtractor"),
+    "NamedEntity": ("mata_garuda.foundations.ner_extractor", "NamedEntity"),
+}
+
+if TYPE_CHECKING:  # pragma: no cover
+    from mata_garuda.foundations.arxiv_sanity_scorer import (
+        ArxivSanityScorer,
+        LabeledPaper,
+    )
+    from mata_garuda.foundations.ner_extractor import NamedEntity, NERExtractor
+
+
+def __getattr__(name: str):
+    if name in _LAZY_EXPORTS:
+        module_name, attr_name = _LAZY_EXPORTS[name]
+        import importlib
+
+        module = importlib.import_module(module_name)
+        attr = getattr(module, attr_name)
+        globals()[name] = attr  # cache for subsequent accesses
+        return attr
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "ArxivSanityScorer",
@@ -59,6 +96,7 @@ __all__ = [
     "NERExtractor",
     "NamedEntity",
     "OpenSanctionsClient",
+    "PasalIdAuthError",
     "PasalIdClient",
     "PortalHealth",
     "SanctionEntity",

--- a/apps/mata-garuda/mata_garuda/foundations/ner_extractor.py
+++ b/apps/mata-garuda/mata_garuda/foundations/ner_extractor.py
@@ -9,11 +9,9 @@ B6 OSINT person/org detection).
 """
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass
-from functools import lru_cache
 from typing import Sequence
-
-from transformers import pipeline
 
 DEFAULT_MODEL = "cahya/bert-base-indonesian-NER"
 
@@ -28,26 +26,42 @@ class NamedEntity:
 
 
 class NERExtractor:
-    """Lazy-loaded NER pipeline.
+    """Lazy-loaded, thread-safe NER pipeline.
 
-    External-review fix (Codex GPT-5 + DeepSeek v4, 2026-05-08):
+    Wave 1 fix (Codex GPT-5 + DeepSeek v4, 2026-05-08):
     Old `__init__` called `pipeline()` eagerly, which downloads ~440MB and uses
     ~1.5GB RAM on first use. Now the pipeline is materialised on first
-    `extract()` call, so a harmless `import` of mata_garuda.foundations doesn't
-    stall workers or saturate Mini-Pro2 memory.
+    `extract()` call.
+
+    Wave 2 fix (DeepSeek W2 + Codex W2, 2026-05-08):
+    Lazy load was racy: two concurrent `extract()` calls could both see
+    `_pipeline is None` and both call HuggingFace `pipeline()`, downloading
+    the model twice. Double-checked locking pattern serialises the init.
+
+    Also: `transformers` is imported lazily inside `_get_pipeline()` so that
+    a worker that only needs `gov_apis_health` does NOT pull torch/transformers
+    at import time.
     """
+
+    _lock = threading.Lock()
 
     def __init__(self, model_name: str = DEFAULT_MODEL):
         self._model_name = model_name
-        self._pipeline = None  # lazily initialised in extract()
+        self._pipeline = None  # lazily initialised in _get_pipeline()
 
     def _get_pipeline(self):
         if self._pipeline is None:
-            self._pipeline = pipeline(
-                "ner",
-                model=self._model_name,
-                aggregation_strategy="simple",
-            )
+            with self._lock:
+                if self._pipeline is None:
+                    # Lazy import: avoids loading transformers/torch unless
+                    # extract() is actually called.
+                    from transformers import pipeline as _hf_pipeline
+
+                    self._pipeline = _hf_pipeline(
+                        "ner",
+                        model=self._model_name,
+                        aggregation_strategy="simple",
+                    )
         return self._pipeline
 
     def extract(self, text: str, labels: Sequence[str] | None = None) -> list[NamedEntity]:

--- a/apps/mata-garuda/mata_garuda/foundations/pasal_id_client.py
+++ b/apps/mata-garuda/mata_garuda/foundations/pasal_id_client.py
@@ -88,7 +88,12 @@ class PasalIdClient:
         results = []
         for item in payload.get("results", []):
             # Live API nests title/year/kind under `work`; tolerate both shapes.
-            work = item.get("work", item)
+            # Wave 2 review fix (DeepSeek + Codex W2, 2026-05-08):
+            # `item.get("work", item)` returns None when JSON has explicit
+            # `"work": null` — then `.get()` crashes with AttributeError.
+            # Guard against None and non-dict shapes.
+            raw_work = item.get("work")
+            work = raw_work if isinstance(raw_work, dict) and raw_work else item
             results.append(
                 LawSearchResult(
                     id=item.get("id", work.get("id", "")),

--- a/apps/mata-garuda/tests/foundations/test_ner_extractor.py
+++ b/apps/mata-garuda/tests/foundations/test_ner_extractor.py
@@ -12,7 +12,9 @@ def test_extract_returns_named_entities():
         {"entity_group": "ORG", "word": "DJP", "score": 0.95, "start": 18, "end": 21},
     ]
 
-    with patch("mata_garuda.foundations.ner_extractor.pipeline") as mock_pipeline_factory:
+    # Wave 2 fix: pipeline import is now lazy inside _get_pipeline().
+    # We mock _get_pipeline directly to avoid loading transformers/torch at all.
+    with patch.object(NERExtractor, "_get_pipeline") as mock_pipeline_factory:
         mock_pipeline = MagicMock(return_value=fake_pipeline_output)
         mock_pipeline_factory.return_value = mock_pipeline
 
@@ -27,7 +29,9 @@ def test_extract_returns_named_entities():
 
 
 def test_extract_empty_text_returns_empty_list():
-    with patch("mata_garuda.foundations.ner_extractor.pipeline") as mock_pipeline_factory:
+    # Wave 2 fix: pipeline import is now lazy inside _get_pipeline().
+    # We mock _get_pipeline directly to avoid loading transformers/torch at all.
+    with patch.object(NERExtractor, "_get_pipeline") as mock_pipeline_factory:
         mock_pipeline = MagicMock(return_value=[])
         mock_pipeline_factory.return_value = mock_pipeline
 
@@ -42,7 +46,9 @@ def test_filter_by_label_only_returns_matching():
         {"entity_group": "PERSON", "word": "Bimo", "score": 0.99, "start": 0, "end": 4},
         {"entity_group": "ORG", "word": "DJP", "score": 0.95, "start": 8, "end": 11},
     ]
-    with patch("mata_garuda.foundations.ner_extractor.pipeline") as mock_pipeline_factory:
+    # Wave 2 fix: pipeline import is now lazy inside _get_pipeline().
+    # We mock _get_pipeline directly to avoid loading transformers/torch at all.
+    with patch.object(NERExtractor, "_get_pipeline") as mock_pipeline_factory:
         mock_pipeline = MagicMock(return_value=fake_pipeline_output)
         mock_pipeline_factory.return_value = mock_pipeline
 
@@ -51,3 +57,52 @@ def test_filter_by_label_only_returns_matching():
 
     assert len(people) == 1
     assert people[0].text == "Bimo"
+
+
+def test_pipeline_initialised_only_once_under_concurrent_calls():
+    """Wave 2 fix (DeepSeek W2 + Codex W2 2026-05-08): lazy load was racy.
+    Two threads could both see _pipeline=None and both call pipeline(),
+    downloading the model twice. Verify the lock+double-check pattern.
+
+    To exercise the actual lock path (not just _get_pipeline), we spy on the
+    real `_get_pipeline` and assert the underlying pipeline factory ran once."""
+    import threading
+    import sys
+    import types
+
+    # Inject a fake `transformers` module with a counting `pipeline` factory.
+    call_count = 0
+    factory_lock = threading.Lock()
+
+    def fake_pipeline(*args, **kwargs):
+        nonlocal call_count
+        with factory_lock:
+            call_count += 1
+        # Simulate slow init so threads have time to race.
+        import time
+
+        time.sleep(0.05)
+        return MagicMock(return_value=[])
+
+    fake_module = types.ModuleType("transformers")
+    fake_module.pipeline = fake_pipeline
+    sys.modules["transformers"] = fake_module
+
+    try:
+        extractor = NERExtractor()
+        threads = [
+            threading.Thread(target=lambda: extractor.extract("Bimo"))
+            for _ in range(8)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    finally:
+        # Restore: don't pollute other tests / module state.
+        del sys.modules["transformers"]
+
+    assert call_count == 1, (
+        f"pipeline() should be called exactly once across 8 concurrent threads, "
+        f"got {call_count} (race condition still present)"
+    )

--- a/apps/mata-garuda/tests/foundations/test_pasal_id_client.py
+++ b/apps/mata-garuda/tests/foundations/test_pasal_id_client.py
@@ -117,3 +117,36 @@ async def test_search_laws_sends_bearer_token_when_set():
 
         call_kwargs = mock_client.get.call_args.kwargs
         assert call_kwargs["headers"]["Authorization"] == "Bearer my-token"
+
+
+@pytest.mark.asyncio
+async def test_search_laws_handles_explicit_null_work_field():
+    """Wave 2 fix (DeepSeek W2 + Codex W2 2026-05-08): old fallback
+    `item.get("work", item)` returns None when JSON has explicit
+    `"work": null`, then `.get()` crashes with AttributeError. New code
+    must fall back to top-level fields cleanly."""
+    fake_response = {
+        "results": [
+            {
+                "id": "uu-2022-27",
+                "work": None,  # explicit null — must not crash
+                "title": "UU 27/2022 PDP (flat fallback)",
+                "year": 2022,
+                "kind": "UU",
+            }
+        ]
+    }
+    with patch("mata_garuda.foundations.pasal_id_client.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        resp = mock_client.get.return_value
+        resp.status_code = 200
+        resp.json = lambda: fake_response
+        resp.raise_for_status = lambda: None
+        mock_cls.return_value.__aenter__.return_value = mock_client
+
+        client = PasalIdClient()
+        results = await client.search_laws(query="PDP")
+
+    assert len(results) == 1
+    assert results[0].title == "UU 27/2022 PDP (flat fallback)"
+    assert results[0].year == 2022

--- a/docs/superpowers/specs/2026-05-08-domain-mesh-research/external-reviews-wave2/codex-w2.md
+++ b/docs/superpowers/specs/2026-05-08-domain-mesh-research/external-reviews-wave2/codex-w2.md
@@ -1,0 +1,127 @@
+## A. Wave 1 Fixes
+
+1. **`pasal_id_client.py`: parser fallback non è sicuro per `work: null`**
+   - `work = item.get("work", item)` gestisce `work` mancante e `work: {}`, ma non `work: null` o `work` non-dict.
+   - Con `work: null`, la riga `work.get(...)` esplode con `AttributeError`.
+   - Ref: `apps/mata-garuda/mata_garuda/foundations/pasal_id_client.py:91-97`.
+   - Fix: normalizzare `work = item.get("work") if isinstance(item.get("work"), dict) and item.get("work") else item`.
+
+2. **`arxiv_sanity_scorer.py`: math del CV è corretta**
+   - `cv = max(2, min(3, min_class))` produce `3` quando `min_class = 100`, quindi ok.
+   - `min_class < 2` viene rifiutato subito dopo, quindi il caso insufficiente è coperto.
+   - Ref: `apps/mata-garuda/mata_garuda/foundations/arxiv_sanity_scorer.py:41-48`.
+
+3. **`ner_extractor.py`: lazy load non thread-safe**
+   - Due thread possono vedere `_pipeline is None` contemporaneamente e inizializzare due pipeline HuggingFace.
+   - Questo è soprattutto pericoloso su Mini-Pro2: doppio download/caricamento modello e memoria duplicata.
+   - Ref: `apps/mata-garuda/mata_garuda/foundations/ner_extractor.py:42-51`.
+   - Serve lock, oppure cache globale thread-safe.
+
+## B. What Wave 1 Missed
+
+1. **Import pubblico delle foundations rende fragile anche il cron leggero**
+   - `foundations/__init__.py` importa subito `arxiv_sanity_scorer` e `ner_extractor`, quindi richiede `sklearn`, `transformers`, `torch` anche quando il cron vuole solo `probe_inventory`.
+   - Il cron fa `from mata_garuda.foundations import probe_inventory`, quindi un env senza deps ML fa fallire anche il probe gov-apis.
+   - Ref: `apps/mata-garuda/mata_garuda/foundations/__init__.py:16-35`, `infra/scripts/domain-mesh-foundations-cron.sh:16-19`.
+   - Fix: import diretto `from mata_garuda.foundations.gov_apis_health import probe_inventory`, oppure lazy exports.
+
+2. **Retry sta coprendo errori deterministici di parsing**
+   - `pasal_id_client`, `gdelt_client`, `opensanctions_id` retryano anche `KeyError`, `AttributeError`, `ValueError`, `JSONDecodeError`.
+   - Un payload malformed viene scaricato/parlato 3 volte e poi può uscire come `RetryError`, nascondendo la causa reale.
+   - Refs: `pasal_id_client.py:70-75`, `gdelt_client.py:32-43`, `opensanctions_id.py:32-40`.
+   - Fix: retry solo per `httpx.TransportError`, timeout, 5xx/429 espliciti.
+
+3. **`gdelt_client.py`: un articolo parziale rompe tutta la ricerca**
+   - Usa `item["url"]`; se GDELT ritorna articolo senza URL, l’intera response fallisce.
+   - Ref: `apps/mata-garuda/mata_garuda/foundations/gdelt_client.py:44-53`.
+   - Inoltre `query` viene interpolata raw dentro la query GDELT; operatori GDELT inseriti dall’input possono cambiare il filtro.
+   - Ref: `gdelt_client.py:34-39`.
+
+4. **`opensanctions_id.py`: ingest OOM-prone**
+   - Scarica tutto in `response.text`, poi `split("\n")`; nessun limite bytes, streaming, max righe, o validazione schema.
+   - Ref: `apps/mata-garuda/mata_garuda/foundations/opensanctions_id.py:49-65`.
+   - `match_name()` riscarica tutto a ogni chiamata.
+   - Ref: `opensanctions_id.py:42-45`.
+
+5. **`gov_apis_health.py`: isolation incompleta per portale**
+   - Cattura solo `ConnectError` e `TimeoutException`; `TooManyRedirects`, `RemoteProtocolError`, `InvalidURL`, SSL/proxy errors, JSON inventory bad shape propagano e abortiscono tutto.
+   - Ref: `apps/mata-garuda/mata_garuda/foundations/gov_apis_health.py:53-74`, `:77-83`.
+
+6. **Test mocks troppo happy-path**
+   - Mancano test per timeout, malformed JSON, partial GDELT articles, OpenSanctions huge/invalid line, `work: null`, 429/rate limit, 5xx retry, bad inventory entry.
+   - Esempi: `apps/mata-garuda/tests/foundations/test_gdelt_client.py:9-49`, `test_opensanctions_id.py:9-49`, `test_gov_apis_health.py:22-67`.
+
+## C. Security
+
+1. **OpenSanctions remote JSON non è bounded**
+   - Non c’è auth, checksum, size cap, streaming cap, o schema validation. JSON non ha “billion laughs” XML-style, ma file enorme o nesting patologico può comunque fare OOM/CPU spike.
+   - Ref: `opensanctions_id.py:49-65`.
+
+2. **Gov probe sembra bot generico**
+   - Nessun `User-Agent` custom, nessun `Accept`, nessuna classificazione 429.
+   - Ref: `gov_apis_health.py:57-58`.
+   - Per domini governativi conviene UA identificabile e rate policy esplicita.
+
+3. **Bali calendar accetta input senza contratto**
+   - Type hint `date`, ma nessuna runtime validation/range policy. Date storiche lontane vengono calcolate in proleptic Gregorian senza warning semantico.
+   - Ref: `apps/mata-garuda/mata_garuda/foundations/bali_calendar.py:47-80`.
+
+4. **Pasal token non viene loggato ora, ma resta facile da esporre**
+   - Il codice non stampa il token; bene.
+   - Però `_headers()` costruisce `Authorization` direttamente e i test ispezionano il valore completo.
+   - Ref: `pasal_id_client.py:64-68`, `apps/mata-garuda/tests/foundations/test_pasal_id_client.py:104-119`.
+   - Evitare in futuro logging di call kwargs o exception context con headers.
+
+## D. Operational Readiness
+
+1. **Cron non è robusto al venv mancante**
+   - `source "$REPO_ROOT/.venv/bin/activate" 2>/dev/null` ignora failure perché manca `set -e`; poi usa `python` dal PATH.
+   - Questo viola anche la regola locale “no system Python”.
+   - Ref: `infra/scripts/domain-mesh-foundations-cron.sh:1-16`.
+   - Fix: usare `"$REPO_ROOT/.venv/bin/python"` e fallire se non eseguibile.
+
+2. **Cron può lasciare snapshot corrotti**
+   - Redirige direttamente nel file finale; se Python fallisce dopo apertura, resta JSON vuoto/parziale.
+   - Ref: `infra/scripts/domain-mesh-foundations-cron.sh:16-32`.
+   - Fix: scrivere su temp file e `mv` atomico solo a successo.
+
+3. **Il piano promette alert, il codice ha TODO**
+   - Piano: alert Telegram se operational % scende >10pp.
+   - Script: solo log, TODO Phase 1.
+   - Refs: `docs/superpowers/plans/2026-05-08-domain-mesh-phase0-foundations.md:1538`, `infra/scripts/domain-mesh-foundations-cron.sh:35-40`.
+
+4. **Nessun kill-switch cron**
+   - LaunchAgent schedulato, nessuna env `FOUNDATIONS_CRON_ENABLED=false`, nessun lock, nessun timeout globale.
+   - Refs: `infra/launchagents/com.balizero.domain-mesh.foundations.daily.plist:7-31`, `infra/scripts/domain-mesh-foundations-cron.sh:1-40`.
+
+5. **Inventory seed non validato**
+   - `load_inventory()` fa solo `json.loads`; entry mal editata rompe runtime più avanti.
+   - Ref: `gov_apis_health.py:49-55`, `apps/mata-garuda/data/gov_apis_inventory.json:1-55`.
+
+## E. Other Flaws Before Phase 1
+
+1. **Plan/test count drift**
+   - Piano dichiara “24 tests”, ma i test foundations presenti sono circa 30.
+   - Refs: `docs/superpowers/plans/2026-05-08-domain-mesh-phase0-foundations.md:1460-1467`, `:1664-1670`, `:1745-1749`.
+   - È piccolo, ma segnala che la checklist non è più source-of-truth.
+
+2. **OpenLLMetry init è silenzioso troppo spesso**
+   - `ImportError` ritorna `False` senza logging; `Traceloop.init()` invece può propagare eccezioni runtime.
+   - Ref: `apps/mata-garuda/mata_garuda/foundations/openllmetry_init.py:23-37`.
+   - Serve comportamento coerente: o loud con log strutturato, o sempre dormant-safe con warning.
+
+3. **Operational failure mode generale**
+   - Pasal/GDELT/OpenSanctions falliscono loud ma spesso come `RetryError`.
+   - Gov probe fallisce quiet per alcuni errori noti, loud per altri.
+   - NER fallisce loud al primo `extract()` se HuggingFace/cache non disponibile.
+   - Prima di Phase 1 serve un contratto comune: `FoundationUnavailable`, `MalformedUpstreamPayload`, `RateLimited`, `AuthMissing`.
+
+Fonti esterne consultate: GDELT DOC 2.0 API docs confermano operatori dentro `query` e `sourcecountry` come operatore; FollowTheMoney/OpenSanctions docs confermano uso di stream JSON line-based/FtM per bulk entities.  
+Links: https://blog.gdeltproject.org/gdelt-doc-2-0-api-debuts/ · https://followthemoney.tech/docs/cli/
+hook: Stop
+hook: Stop
+hook: Stop Completed
+hook: Stop Completed
+tokens used
+109.353
+[Pro] Review eseguita sul checkout locale. Nota operativa: Mini peer non raggiungibile e `nuz-sync` stale; test non eseguiti perché la sandbox read-only non offre temp dir scrivibile a pytest.

--- a/docs/superpowers/specs/2026-05-08-domain-mesh-research/external-reviews-wave2/deepseek-w2.md
+++ b/docs/superpowers/specs/2026-05-08-domain-mesh-research/external-reviews-wave2/deepseek-w2.md
@@ -1,0 +1,216 @@
+# Wave 2 Independent Critical Review
+
+## A. Are the Wave 1 fixes correct?
+
+### A1. `pasal_id_client.py` – `work` fallback safety (line ~87)
+
+The fix added `work = item.get("work", item)` to tolerate flat vs nested shapes.  
+**Problem:** If the JSON response contains `"work": null` (explicit null), `item.get("work")` returns `None`, and the fallback `item` is **not** used because `.get()` with default only triggers when the key is missing, not when the value is `None`.
+
+```python
+work = item.get("work", item)  # if work: null → work = None
+...
+title=work.get("title", ...)   # AttributeError: 'NoneType' object has no attribute 'get'
+```
+
+The live API may return `"work": null` for some malformed entries.  
+**Fix:** Replace with `work = item.get("work") or item` (or a `if work is None: work = item` guard).
+
+### A2. `arxiv_sanity_scorer.py` – `cv = max(2, min(3, min_class))` (line ~72)
+
+The math is correct for the stated purpose (avoid cv=1).
+
+- `min_class=100` → `min(3,100)=3` → `max(2,3)=3` → cv=3.
+- `min_class=2` → `min(3,2)=2` → `max(2,2)=2` → cv=2.
+- The `min_class < 2` guard above catches the degenerate case before cv calculation runs.
+
+**However, a second-order issue:** with `min_class=2` and `cv=2`, `CalibratedClassifierCV` will create 2-fold splits. Each fold must contain at least one sample of each class. With exactly 2 positive and 2 negative samples, each fold gets 1 of each (since split is stratified). This works but is fragile. Not a bug for now, but note for Phase 1.
+
+### A3. `ner_extractor.py` – Lazy load thread safety
+
+`_get_pipeline()` is not thread-safe. Two simultaneous `extract()` calls (e.g., from different async tasks or threads) can both see `self._pipeline is None`, both call `pipeline(...)`, and both assign to `self._pipeline`. The last assignment wins; the other pipeline object is discarded after expensive download (~440MB, ~1.5GB RAM).
+
+**Proof:** Python's attribute assignment (`self._pipeline = ...`) is not atomic under the GIL in CPython (though the GIL makes bytecode execution atomic, the `pipeline()` call itself is many bytecodes; another thread can preempt after the `if` check).
+
+**Fix:** Use `threading.Lock` or `threading.Lock` + double-check pattern:
+
+```python
+import threading
+_lock = threading.Lock()
+def _get_pipeline(self):
+    if self._pipeline is None:
+        with self._lock:
+            if self._pipeline is None:
+                self._pipeline = pipeline(...)
+    return self._pipeline
+```
+
+Wave 1 missed this entirely.
+
+---
+
+## B. What Wave 1 missed – non-obvious issues
+
+### B1. Files not critiqued in Wave 1
+
+#### `gdelt_client.py`
+
+- **No User-Agent header** – httpx sends default `python-httpx/<version>`. GDELT may throttle or block programmatic access without a proper User-Agent. (Security/ops issue.)
+- **No rate-limit/429 handling** – tenacity retries on any exception except `PasalIdAuthError`, but a 429 response does _not_ raise `raise_for_status()` by default? Actually `response.raise_for_status()` raises `HTTPStatusError` for 4xx/5xx, so 429 will trigger retry. But tenacity's `wait_exponential` may not respect `Retry-After` header, causing hammering. Should add custom retry condition or backoff.
+- **`sourcecountry:ID` hardcoded** – line ~32: `f'{query} sourcecountry:ID'`. If `query` contains special characters (e.g., `"`), the GDELT API may reject or misinterpret. Not an injection risk but a query construction fragility. Use proper query API if available, or URL-encode appropriately.
+- **No `Content-Type` check on response** – if API returns error HTML (e.g., 503), `response.json()` raises `json.decoder.JSONDecodeError`. The tenacity retry will catch it, but error message will be opaque.
+
+#### `opensanctions_id.py`
+
+- **No streaming** – `_fetch_jsonlines` reads entire response into memory (`response.text`), then splits by newline. The `id_dttot` dataset can be dozens of MB; on a 24GB machine this is okay but wasteful. More critically, a malicious or misconfigured server could return a multi-GB response, causing OOM. **Fix:** Use `response.iter_lines()`.
+- **No line-level error handling** – `json.loads(line)` will raise `json.JSONDecodeError` on any malformed line, aborting the entire fetch. **Fix:** wrap in try/except and skip bad lines (or log).
+- **`match_name` downloads full dataset every call** – no local caching. For daily cron this may be acceptable, but for ad-hoc queries it is terribly slow. Should cache `dttot` entities with a staleness check.
+- **No URL scheme validation** – the base URL is hardcoded `https://...`; fine, but no fallback if data.opensanctions.org changes.
+
+#### `bali_calendar.py`
+
+- **Input validation of `date` range** – `date` objects outside year 1–9999 raise `OverflowError`. If `get_balinese_date` is ever called with a fabricated date (e.g., year 100000), the entire call chain crashes. Should clamp or validate. (Minor, but Phase 0 defense-in-depth.)
+- **Incorrect modulo for negative deltas** – `_pawukon_day_index` uses `delta_days % 210`. Python's modulo returns non-negative remainder for negative deltas, so dates before anchor work correctly. Verified.
+
+#### `gov_apis_health.py`
+
+- **No User-Agent header** – same as GDELT. The `httpx` default will be identified as a bot. Many Indonesian gov portals are suspicious of non-browser requests. Should set a descriptive User-Agent (e.g., `BaliZero/HealthMonitor/1.0`).
+- **No delay between probes** – sends all 14+ probes in rapid succession. Could be interpreted as a DoS attack and trigger IP blocks. **Fix:** add `asyncio.sleep(0.5)` or random jitter between probes.
+- **`load_inventory()` file path brittle** – `INVENTORY_PATH = Path(__file__).parent.parent.parent / "data" / "gov_apis_inventory.json"`. If this file is missing (e.g., git clone without submodule), the function raises `FileNotFoundError` with no fallback. The cron wrapper then fails completely. **Fix:** provide a default empty list or graceful error.
+- **`probe_portal` creates new `AsyncClient` per request** – fine, but could use connection pooling for efficiency.
+
+#### `openllmetry_init.py`
+
+- **Environment variable `LANGFUSE_ENABLED` check** – `os.environ.get("LANGFUSE_ENABLED", "").lower() == "false"` returns True only if the string is exactly `"false"`. If set to `"False"` or `"FALSE"`, it works due to `.lower()`. If set to `"0"`, it does _not_ disable. This is inconsistent with typical boolean env var handling. Should check against a set of falsy values.
+- **No validation of `OPENLLMETRY_ENDPOINT` URL** – if set to a malformed URL, `Traceloop.init` will raise. No try/except around that init call. Should catch and log.
+
+### B2. Cross-cutting concerns
+
+#### Concurrency / Shared state
+
+- **NER pipeline race** (already covered in A3).
+- **All httpx clients are per-method** – no shared connection pool between calls. Minor performance issue.
+- **`pasal_id_client` and `gov_apis_health` create `AsyncClient` inside `async with`** – fine, but the client constructor has overhead. For high-throughput Phase 1, consider a module-level client pool.
+- **No `asyncio.Lock` or semaphore** anywhere – not needed yet, but if foundations models are called in parallel, CPU-bound NER calls will block the event loop (since `pipeline` is synchronous). Should wrap NER in `loop.run_in_executor`.
+
+#### Error handling across boundaries
+
+- **`arxiv_sanity_scorer` raises `RuntimeError` on not trained** – good.
+- **`ner_extractor` raises `ModelNotFoundError` (from transformers) or `OSError` if model download fails** – not caught. Callers must handle.
+- **`gdelt_client` and `opensanctions_id` use `raise_for_status()` without distinguishing retryable errors** – a 404 or 400 will be retried 3 times, wasting resources. Should use `retry_if_not_exception_type` for `httpx.HTTPStatusError` with codes >= 400 and < 500 (except 429). Tenacity will catch all `HTTPStatusError` as they are subclasses of `Exception`.
+- **`gov_apis_health` catches `ConnectError` and `TimeoutException`** – good. But other exceptions (e.g., SSL error, response parsing) bubble up unhandled. See B1.
+
+#### Resource leaks
+
+- **All httpx clients closed via `async with`** – no leaks.
+- **NER model stays in memory forever** – no `__del__` or `cleanup` method. On Mini-Pro2 this is fine, but if foundations are loaded/unloaded dynamically, no mechanism to free GPU or CPU memory.
+- **`opensanctions_id` holds entire JSON in memory** – as noted, could be large.
+
+#### Test mocks fidelity
+
+- **No test code provided** – but from patterns: mocks for `httpx` (e.g., `respx`) must simulate partial JSON, null values, and error codes. The pasal_id client's `work: null` case is not tested (see A1).
+- The cron wrapper writes to a temp file; test should verify partial write scenario is handled.
+
+### B3. Phase 0 plan (cron-wrapper.sh) – second-order issues
+
+#### Silently failing tasks
+
+- **`source "$REPO_ROOT/.venv/bin/activate" 2>/dev/null`** – if virtualenv doesn't exist (fresh install, path error), activation fails silently (stderr redirected to `/dev/null`). The script continues with the system Python, which may lack all required packages. The subsequent Python command will fail with `ModuleNotFoundError`, but the error message does not indicate the _root cause_ (wrong Python). **Fix:** check `$?` after source, or use `PYTHON_EXEC=...` explicit path.
+
+#### Integration missing: daily cron vs foundations installation
+
+- **No guard against the cron running before foundations are installed** – if `pip install -r requirements.txt` hasn't run, the Python snippet crashes. The log file will capture the error, but no alert. Should check for sentinel file (`$HOME/.cache/domain-mesh-foundations/installed.flag`) before running.
+
+#### Cron shellscript robustness
+
+- **Partial snapshot file on failure** – the `>` redirection creates the output file _before_ the Python command runs. If Python crashes mid-write (e.g., SIGTERM, partial stdout), the snapshot file contains truncated JSON. The subsequent `python -c "import json; d=json.load(...)"` on line ~36 will fail, causing the whole cron job to exit with error. **Fix:** write to a temporary file first, then `mv` it atomically: `python ... > "$SNAPSHOT_FILE.tmp" && mv "$SNAPSHOT_FILE.tmp" "$SNAPSHOT_FILE"`.
+- **No PATH or PYTHONUNBUFFERED** – PATH inherited from launchd may not include `/usr/local/bin` or the virtualenv's bin. `source` should fix, but if that fails, `python` may be missing. Add `PATH="/usr/local/bin:/usr/bin:/bin:$HOME/.local/bin"` or use absolute path to virtualenv python.
+
+---
+
+## C. Security
+
+### `bali_calendar.py`
+
+- **No input validation for `target: date`** – the type hint does nothing at runtime. If a caller passes a string or integer, Python will raise `TypeError` later (subtraction fails). Not a security vulnerability, but could cause DoS if used from untrusted input (e.g., a web endpoint without validation). Should call `date.fromisoformat(str)` or validate up front.
+
+### `gov_apis_health.py`
+
+- **No User-Agent** – detectable as scraper; the `httpx` default includes "python-httpx/0.27.0" which some Indonesian portals block (e.g., `https://pajak.go.id` returns CF challenge for missing user-agent). Should mimic a browser or set a meaningful agent.
+- **Rate limiting risk** – 14 probes in rapid succession may trigger WAF/rate-limiting on target servers. No backoff between probes.
+
+### `opensanctions_id.py`
+
+- **Malicious JSON (billion laughs, deep recursion)** – Python 3's `json.loads` has a recursion depth limit (default 1000) and is safe against billion laughs (defused since CPython 3.9?). However, a huge file could cause OOM. **Fix:** use `httpx` with `stream=True` and set `max_line_length` or read in chunks. Also, the entire file is loaded into RAM before parsing; add a size check: `response.headers.get('content-length')` and reject if > 50MB.
+
+### `pasal_id_client.py`
+
+- **Bearer token exposure in logs** – if an `httpx` event hook or a debug logger logs headers, the `Authorization` header may appear in logs. No existing guard. Should use `os.environ.get()` and never print it. (Low priority, but worth noting.)
+
+---
+
+## D. Operational readiness
+
+### Failure behavior per module
+
+| Module              | Failure mode               | Behavior                        | Silent?                |
+| ------------------- | -------------------------- | ------------------------------- | ---------------------- |
+| pasal_id_client     | API 500 after 3 retries    | Last exception propagates       | No (caller must catch) |
+| arxiv_sanity_scorer | Training data insufficient | `ValueError` with message       | No                     |
+| ner_extractor       | Model download fail        | `OSError` from `pipeline`       | No                     |
+| gdelt_client        | API down                   | `HTTPStatusError` after retries | No                     |
+| opensanctions_id    | Dataset not found          | `HTTPStatusError`               | No                     |
+| bali_calendar       | Overflow date              | `OverflowError`                 | No                     |
+| gov_apis_health     | Inventory missing          | `FileNotFoundError`             | No                     |
+| openllmetry_init    | Import error               | Returns False                   | Yes (by design)        |
+
+**Common problem:** exceptions from these modules, when called inside the cron Python snippet, will propagate to stderr (redirected to log). There is **no structured logging** – just raw traceback. In Phase 1, add a logging setup that includes severity, timestamp, and component name.
+
+### Telemetry destination
+
+- `openllmetry_init.py` is dormant by default. In that state, **errors have no telemetry pipeline** – they only appear in the cron log file (`~/logs/domain-mesh-foundations/foundations-daily-*.log`). No alerts, no dashboard.
+- **Major gap:** no way to monitor cron success/failure remotely. Should add a heartbeat telemetry (e.g., simple HTTP POST to a healthcheck endpoint) even when OpenLLMetry is disabled.
+
+### Kill-switch for cron
+
+- No circuit breaker. If a probe hangs (e.g., GDELT slow response, gov portal infinite redirect), the cron job will block until timeout (15s per portal, 14 portals = 3.5 minutes worst-case). The launchd job may be killed by OS after timeout, but no controlled shutdown. **Suggestion:** add a global timeout to the `asyncio.run()` call or use `asyncio.wait_for`.
+
+### Backups / inventory file edits
+
+- `gov_apis_inventory.json` is version-controlled. If edited incorrectly (e.g., missing `id` or `url` field), `probe_portal` will raise `KeyError`. **Fix:** add schema validation (e.g., `pydantic` model) when loading inventory.
+
+---
+
+## E. Other flaws before committing Phase 1
+
+1. **No dependency management** – the code imports `transformers`, `torch`, `sklearn`, `httpx`, `tenacity`, `traceloop-sdk`. Without a `requirements.txt` or `pyproject.toml`, pinning versions is impossible. Phase 1 will break with future library updates.
+
+2. **No unit tests** – the modules are untested. The cron wrapper has no test harness. High risk for refactoring.
+
+3. **GDELT and OpenSanctions clients lack caching** – they download full datasets on every call. With daily cron, OpenSanctions may download 50MB+ each day. Should implement file-based caching with TTL (e.g., 12 hours).
+
+4. **`gov_apis_health.py` uses sequential probes** – for 14 portals it's okay, but if expanded to 50+, should parallelize with `asyncio.gather` and semaphore for rate limiting.
+
+5. **No graceful shutdown** – none of the modules have `aclose()` methods. If used in a longer-running service (Phase 1), the httpx clients should be reused and closed properly.
+
+6. **NER extractor not integrated with `asyncio`** – `pipeline()` is blocking; if called from async code (e.g., a FastAPI endpoint), it will block the event loop. Must be offloaded to a thread pool.
+
+7. **Cron wrapper PATH robustness** – as noted, virtualenv activation failure leads to system Python. The cron should use an explicit absolute path to the virtualenv's `python` binary: `"$REPO_ROOT/.venv/bin/python"`.
+
+8. **Missing sentinel for first run** – no `installed.flag` check. If the cron runs before `pip install`, the Python snippet fails noisily. The log message should be more helpful (e.g., "Foundations not installed. Run make install first.").
+
+---
+
+**Summary of critical fixes needed before Phase 1:**
+
+| Priority | File                | Issue                                | Fix                                       |
+| -------- | ------------------- | ------------------------------------ | ----------------------------------------- |
+| P0       | pasal_id_client.py  | `work: null` crashes                 | `work = item.get("work") or item`         |
+| P0       | ner_extractor.py    | Race condition on lazy init          | Add threading.Lock                        |
+| P0       | cron-wrapper.sh     | Virtualenv activation failure silent | Use absolute python path, check exit code |
+| P0       | cron-wrapper.sh     | Partial snapshot file on error       | Write to tmp file then rename             |
+| P1       | gov_apis_health.py  | No User-Agent, no probe delay        | Add User-Agent, asyncio.sleep             |
+| P1       | opensanctions_id.py | Large file OOM                       | Use streaming, content-length check       |
+| P1       | opensanctions_id.py | Bad line kills entire fetch          | try/except per line                       |
+| P2       | All async modules   | Error logging unstructured           | Add initial logging config                |
+| P2       | cron-wrapper.sh     | No installed flag guard              | Check sentinel file                       |

--- a/docs/superpowers/specs/2026-05-08-domain-mesh-research/external-reviews-wave2/sonnet-w2.md
+++ b/docs/superpowers/specs/2026-05-08-domain-mesh-research/external-reviews-wave2/sonnet-w2.md
@@ -1,0 +1,458 @@
+I now have everything I need. Here is the Wave 2 critical review.
+
+---
+
+# Wave 2 Independent Critical Review — Domain Mesh Phase 0 Foundations
+
+---
+
+## A. Are the Wave 1 Fixes Correct?
+
+### A1. `pasal_id_client.py` — `item.get("work", item)` fallback
+
+**Location:** `pasal_id_client.py:91`
+
+The fallback `work = item.get("work", item)` is safe when `"work"` is absent (returns `item` as the fallback), but **silently broken when `"work"` is present but `null`**:
+
+```python
+item = {"id": "uu-2021-1", "work": None}
+work = item.get("work", item)  # → None, NOT item
+work.get("title", ...)         # → AttributeError: 'NoneType' has no attribute 'get'
+```
+
+The API could legally return `"work": null` for a regulation stub or a search miss. The fix should be:
+
+```python
+work = item.get("work") or item
+```
+
+Same issue for an empty dict: `"work": {}` passes through as `{}`, meaning all fields fall back to empty string / 0 / "UNKNOWN" with no error signal. That is acceptable (silent degradation), but `null` is a crash.
+
+**Second issue (line 97):** The kind resolution chain is:
+
+```python
+kind=work.get("type", work.get("kind", item.get("kind", "UNKNOWN")))
+```
+
+If `work is item` (no nested shape), `work.get("type")` tries the same dict as `item.get("type")` — harmless duplication. But if there is a nested `work`, this silently prefers the field named `type` from `work`, falling back to `kind` from `work`, then `kind` from `item`. That is intentional and correct, but it means **a top-level `kind` field is completely ignored when a nested `work` exists**, even if `work.kind` is absent. Minor, but worth noting for schema evolution.
+
+**A1 verdict: One real crash bug (`"work": null`). One silent field-priority gap.**
+
+---
+
+### A2. `arxiv_sanity_scorer.py` — `cv = max(2, min(3, min_class))` with large `min_class`
+
+**Location:** `arxiv_sanity_scorer.py:44`
+
+The math is correct for the bug it was fixing. With `min_class = 100`, `cv = max(2, min(3, 100)) = 3` — sensible, and `CalibratedClassifierCV` with `cv=3` on 100 samples per class is fine.
+
+**However there is a logic sequencing problem (lines 43–48):**
+
+```python
+min_class = min(positive, negative)
+cv = max(2, min(3, min_class))          # line 44 — computed BEFORE the guard
+if min_class < 2:
+    raise ValueError(...)               # line 45–48 — guard AFTER computation
+```
+
+If `min_class = 1`, `cv = max(2, min(3, 1)) = 2` is computed, and _then_ `ValueError` is raised — no functional problem because the `ValueError` aborts execution before `cv` is used. But it is misleading: the guard should precede the cv formula. Any future reader will think "if min_class < 2, we still get cv=2 and proceed" — they won't, but the code structure invites that misread.
+
+**One real gap:** no guard for `min_class == 0` (all labels are the same value, but the set-size check at line 34 (`len(labels) < 2`) catches only single-label training sets. It does **not** catch the case where both label values appear but `positive = 0` somehow due to a caller computing `sum(1 for p in papers if p.label == 1)` wrong on an empty list. With 0 positive: `min_class = 0`, cv formula = 2, then `ValueError("Each class needs >=2 samples… got pos=0, neg=N")`. So the error path is correct — just guard ordering.
+
+**A2 verdict: Correct math, minor sequencing readability issue. No functional bug.**
+
+---
+
+### A3. `ner_extractor.py` — Thread safety of lazy `_get_pipeline()`
+
+**Location:** `ner_extractor.py:44–51`
+
+```python
+def _get_pipeline(self):
+    if self._pipeline is None:        # check
+        self._pipeline = pipeline(…)  # set
+    return self._pipeline
+```
+
+This is the classic **check-then-act race condition** in CPython. Two threads calling `extract()` simultaneously can both see `self._pipeline is None` (before either completes the `pipeline(...)` call), then _both_ execute `pipeline("ner", model=self._model_name, ...)`. This means:
+
+1. **440MB is downloaded twice** (if not cached locally).
+2. **~1.5GB RAM is allocated twice** for two independent HuggingFace pipeline objects. On Mini-Pro2 (24GB), two simultaneous NER calls + existing load could trigger OOM.
+3. One of the two initialized `_pipeline` objects is silently discarded (the last writer wins), but only after both initialization costs have been paid.
+
+CPython's GIL does not protect here — `pipeline(...)` is I/O-bound (file reads, model loading) and releases the GIL during `torch` operations. In an `asyncio` context the race is less likely (single event loop thread), but `extract()` is a sync method — if called from `asyncio.to_thread()` or a `ThreadPoolExecutor`, the race is live.
+
+The fix is a `threading.Lock`:
+
+```python
+import threading
+self._lock = threading.Lock()
+
+def _get_pipeline(self):
+    if self._pipeline is None:
+        with self._lock:
+            if self._pipeline is None:   # double-checked locking
+                self._pipeline = pipeline(...)
+    return self._pipeline
+```
+
+**A3 verdict: Real thread-safety bug for concurrent callers. Not theoretical — NER is used "cross-domain" per the docstring, meaning future callers across B1/B5/B6 pipelines may each trigger `extract()` from threads.**
+
+---
+
+## B. What Wave 1 Missed
+
+### B1. Uncritiqued modules
+
+#### `gdelt_client.py`
+
+**B1.1 — No User-Agent header, no rate-limit handling (`gdelt_client.py:40–43`)**
+
+GDELT DOC 2.0 is a free API with no auth, but it does enforce rate limits (typically 200 req/day per IP with aggressive retry). The client sends no `User-Agent` header. GDELT's public docs ask for identification. More practically: GDELT returns **HTTP 429** on rate limit, and the `@retry` decorator has `stop_after_attempt(3)` with no `retry_if_exception_type` filter — it will retry on 429, which is exactly wrong (retrying on 429 makes the rate-limit situation worse and adds 1+2+4=7s of useless delay before still raising `HTTPStatusError`). Fix: add `retry_if_not_exception_type(httpx.HTTPStatusError)` or specifically handle 429.
+
+**B1.2 — `maxrecords` has undocumented API cap at 250 (`gdelt_client.py:38`)**
+
+The parameter `max_results: int = 50` is passed as `"maxrecords": str(max_results)`. GDELT's DOC 2.0 API silently caps `maxrecords` at 250. If a caller passes `max_results=500`, the API returns 250 rows with no error — silent data loss. No validation, no documentation of the cap.
+
+**B1.3 — `response.json()` called AFTER closing the `async with` block (`gdelt_client.py:43`)**
+
+```python
+async with httpx.AsyncClient(...) as client:
+    response = await client.get(...)
+    response.raise_for_status()
+    payload = response.json()   # line 43 — INSIDE the block ✓
+```
+
+Actually fine in current code — `response.json()` is inside the `async with` block. No bug here. (Wave 1 may have noted this pattern on `pasal_id_client.py` where `response.json()` is also called inside the block — both are correct.)
+
+#### `opensanctions_id.py`
+
+**B1.4 — Full dataset loaded into RAM on every `match_name()` call (`opensanctions_id.py:42–45`)**
+
+```python
+async def match_name(self, name_substring: str) -> list[SanctionEntity]:
+    entities = await self.fetch_dttot()   # downloads entire dataset every call
+    needle = name_substring.lower()
+    return [e for e in entities if needle in e.caption.lower()]
+```
+
+`fetch_dttot()` downloads the entire `id_dttot` dataset every time `match_name()` is called. The dataset is a JSONL file; OpenSanctions' Indonesian terrorism dataset (`id_dttot`) is small (~hundreds of entities), but `id_regional_2018` (2018 election results) has tens of thousands of rows. If a caller mistakenly uses `match_name()` for regional screening, it downloads MB of JSONL on every name check.
+
+More critically: **there is no caching**. Each `match_name()` call is a fresh HTTP download. In a KYC pipeline that checks 50 client names at intake, this is 50 full dataset downloads.
+
+**B1.5 — `_fetch_jsonlines` loads the entire response body as a string (`opensanctions_id.py:52`)**
+
+```python
+text = response.text   # entire file in RAM as Python str
+entities = []
+for line in text.strip().split("\n"):
+```
+
+The `id_regional_2018` dataset can be several MB. `response.text` decodes the entire response at once. For the terrorism list this is fine, but for future dataset additions (e.g., the global consolidated list is ~300MB) this is an OOM waiting to happen. There is no streaming or size check before loading.
+
+**B1.6 — `@retry` on `_fetch_jsonlines` is NOT applied (`opensanctions_id.py:47–48`)**
+
+```python
+@staticmethod
+async def _fetch_jsonlines(url: str) -> list[SanctionEntity]:
+```
+
+The `@retry` decorator is on `fetch_dttot()` and `fetch_regional_2018()` (lines 32, 37), but those methods only call `self._fetch_jsonlines(url)` — the HTTP call happens inside `_fetch_jsonlines`. If `_fetch_jsonlines` raises `httpx.ConnectError`, tenacity on the caller retries the _caller frame_, which re-enters `_fetch_jsonlines` — so retry does work transitively. This is architecturally confusing but not broken. The confusion becomes dangerous if `_fetch_jsonlines` is ever called directly.
+
+#### `bali_calendar.py`
+
+**B1.7 — `days_until_next_galungan` returns `PAWUKON_CYCLE_DAYS` (210) on the day of Galungan instead of 0 (`bali_calendar.py:78–80`)**
+
+```python
+def days_until_next_galungan(target: date) -> int:
+    idx = _pawukon_day_index(target)
+    days_until = (GALUNGAN_PAWUKON_DAY_INDEX - idx) % PAWUKON_CYCLE_DAYS
+    if days_until == 0:
+        return PAWUKON_CYCLE_DAYS   # ← returns 210 when called ON Galungan day
+    return days_until
+```
+
+The docstring says "days until next Galungan" — calling it on Galungan itself (2026-06-17) returns 210, meaning "the NEXT occurrence is in 210 days." This is arguably correct semantically (you are ON Galungan, the _next_ Galungan is 210 days away), but it is a **UX footgun**: a scheduling check like `if days_until_next_galungan(today) < 7: skip_appointment()` works fine, but a check like `if days_until_next_galungan(today) == 0: send_greeting()` never fires. The function name should be `days_until_next_galungan_strictly_future` or the docs should explicitly state the contract. A test verifies the 210 case exists in the plan (line 538), which is consistent — but downstream callers won't read that test.
+
+**B1.8 — No input validation on `bali_calendar.py` for nonsense dates**
+
+`_pawukon_day_index(target)` computes `(target - ANCHOR_PAWUKON_DAY_1).days % 210`. This works for any valid `date` object Python accepts (0001-01-01 to 9999-12-31). No crash risk from date arithmetic. However `date(2026, 6, 17)` - `date(2026, 4, 8)` = 70 days, verified correct. No bug here on date ranges.
+
+#### `gov_apis_health.py`
+
+**B1.9 — Sequential (not concurrent) probe in `probe_inventory` (`gov_apis_health.py:81–85`)**
+
+```python
+for entry in inventory:
+    result = await probe_portal(entry)   # one at a time
+    results.append(result)
+```
+
+17 portals × 15s timeout = up to **255 seconds** worst-case serial execution. The cron window at 04:00 WITA should be fine for a daily run, but if even 3 portals time out it takes 45s for those alone before the rest run. `asyncio.gather(*[probe_portal(e) for e in inventory])` would be the obvious fix — all 17 probes in parallel, bounded only by the slowest timeout (15s total instead of 255s worst-case).
+
+This is a **performance bug that degrades operational data quality**: the 7-day baseline comparison (planned for Phase 1) is meaningless if the probe window is inconsistent. If probe_01 gets a 200ms response at 04:00:00 and probe_17 runs at 04:03:00 due to 3 prior timeouts, the snapshot is a time-smeared view, not a point-in-time health check.
+
+**B1.10 — 301/302 redirect followed silently masks CDN migrations (`gov_apis_health.py:57`)**
+
+```python
+async with httpx.AsyncClient(..., follow_redirects=True) as client:
+```
+
+A gov portal that has moved from `http://bps.go.id` to `https://www.bps.go.id` via a 301 returns HTTP 200 after the redirect — classified as "operational." This is usually correct, but it means the `PortalHealth.url` field stores the _original_ URL from the inventory, not the _final_ URL after redirects. A portal that redirects to a Cloudflare challenge page will also appear "operational" if the challenge page returns 200. No `Content-Length` or body fingerprinting is done.
+
+**B1.11 — Missing guard on required `entry` fields (`gov_apis_health.py:54–55`)**
+
+```python
+portal_id = entry["id"]   # KeyError if missing
+url = entry["url"]        # KeyError if missing
+```
+
+`gov_apis_inventory.json` is manually maintained. If someone adds an entry without `"id"` or `"url"`, the function raises an unhandled `KeyError` that propagates up through `probe_inventory`, aborting the entire health report mid-run. The partial `results` list is lost (no partial writes to the snapshot file).
+
+#### `openllmetry_init.py`
+
+**B1.12 — `Traceloop.init()` may log/print to stdout silently (`openllmetry_init.py:33–36`)**
+
+```python
+Traceloop.init(
+    app_name=service_name,
+    api_endpoint=os.environ["OPENLLMETRY_ENDPOINT"],
+    disable_batch=False,
+)
+```
+
+The Traceloop SDK's `init()` logs an INFO banner to stdout on successful initialization. When `init_openllmetry` is called inside the cron script's Python one-liner (`python -c "..."`), that stdout banner is redirected to `$SNAPSHOT_FILE` (the JSON snapshot file). Result: `$SNAPSHOT_FILE` begins with Traceloop's banner text instead of valid JSON, causing the downstream `python -c "import json; d=json.load(open('$SNAPSHOT_FILE'))..."` parsing to fail silently (or raise `JSONDecodeError`).
+
+This is a latent bug gated on Phase 1 activation of OpenLLMetry, but since the cron script is already committed, enabling observability later breaks the cron without any code change.
+
+---
+
+### B2. Cross-cutting concerns
+
+**B2.1 — All HTTP clients are ephemeral — one new `httpx.AsyncClient` per call**
+
+Every method in `GdeltClient`, `PasalIdClient`, `OpenSanctionsClient`, and `gov_apis_health.probe_portal` creates a fresh `httpx.AsyncClient` via `async with httpx.AsyncClient(...)`. This means:
+
+- **No connection pooling** — TCP handshakes for every request
+- **SSL/TLS negotiation overhead** for every HTTPS call
+- For `match_name()` that calls `fetch_dttot()` (one client) and then does filtering — fine for one-off use. But the plan says NER + sanctions checking is "cross-domain" — if called from a feeder loop, connection overhead compounds.
+
+This is the same pattern that CLAUDE.md Rule 10 (`NEVER httpx.AsyncClient() in methods/loops`) explicitly bans for the backend-rag stack. The mata-garuda stack does not inherit that rule verbatim, but the reasoning is identical. The plan's `pyproject.toml` task (Task 10) doesn't even mention connection pool sizing.
+
+**B2.2 — `bali_calendar.py` module-level `assert` will silently pass in Python `-O` mode**
+
+```python
+assert len(WUKU_NAMES) == 30   # line 26
+```
+
+`python -O` disables `assert`. In the cron script (`python -c "..."`), if Python is invoked with optimization flags (unlikely but possible via `PYTHONOPTIMIZE=1` env var), this guard is silently skipped. Not a production risk at current config, but the `assert` should be a module-level check or a `ValueError`.
+
+**B2.3 — `arxiv_sanity_scorer.py` — `score()` crash if class `1` is not in `self._model.classes_`**
+
+```python
+idx = list(self._model.classes_).index(1)   # line 66
+```
+
+`list.index(1)` raises `ValueError` if `1` is not found. `CalibratedClassifierCV.classes_` contains the unique label values from training data. If a caller trains with `label=0` and `label=2` (missing `1`), `score()` crashes with a confusing `ValueError: 1 is not in list`. The `LabeledPaper` dataclass has `label: int` with comment `# 1 = relevant, 0 = not relevant` but no validation enforcement. A caller passing `label=True` (which equals `1` in Python) works fine, but `label=2` silently produces a crash at score time rather than train time.
+
+---
+
+### B3. Phase 0 plan — second-order structural issues
+
+**B3.1 — Task 11 cron script uses `.venv` from repo root, but mata-garuda has its own `.venv` (`domain-mesh-foundations-cron.sh:12–13`)**
+
+```bash
+REPO_ROOT="${HOME}/Desktop/nuzantara"
+cd "$REPO_ROOT/apps/mata-garuda" || exit 1
+source "$REPO_ROOT/.venv/bin/activate" 2>/dev/null
+```
+
+The script activates `$REPO_ROOT/.venv` (the monorepo root venv) — **not** `$REPO_ROOT/apps/mata-garuda/.venv` (the mata-garuda venv). The plan's `pyproject.toml` task (Task 10) installs `foundations` deps into mata-garuda's own venv via `pip install -e ".[foundations]"`. The cron script would execute with the root venv, which may not have `httpx`, `tenacity`, `transformers`, or `scikit-learn` installed. This silently fails with `ModuleNotFoundError` at cron time, with stderr redirected to `$LOG_FILE` (not easily visible). `source ... 2>/dev/null` suppresses any activation errors.
+
+**B3.2 — SNAPSHOT_FILE JSON is broken by `PortalHealth.__dict__` serialization (`domain-mesh-foundations-cron.sh:56–65`)**
+
+```python
+data = {
+    'results': [r.__dict__ for r in report.results],  # ← dataclass __dict__
+}
+```
+
+`PortalHealth` is a `@dataclass(frozen=True)`. On Python 3.11, `frozen=True` dataclasses do NOT use `__dict__` — they use `__slots__` (or a custom `__dict__` that some versions omit). The result: `r.__dict__` raises `AttributeError` for frozen dataclasses in some Python versions, or returns an empty dict in others. The correct serialization is `dataclasses.asdict(r)`.
+
+**Verify:** Python 3.11 frozen dataclasses without `__slots__` declared explicitly do have `__dict__`. But this is an implementation detail, not guaranteed across patch versions. `dataclasses.asdict()` is the portable API.
+
+**B3.3 — Cron script has no lock/pid-file guard against double-invocation**
+
+If the daily probe takes longer than expected (e.g., 12 portals time out serially at 15s each = 180s) and launchd fires again (unlikely with `StartCalendarInterval` but possible if the system clock skips), two instances can run simultaneously. Both write to the same `$SNAPSHOT_FILE` — the second write truncates and partially overwrites the first. No `flock` or pidfile guard.
+
+**B3.4 — Plan Task 1 tests are spec-divergent from the shipped implementation**
+
+The plan's `test_search_laws_returns_typed_results` test (plan lines 83–98) uses a mock response with top-level `title`/`year`/`kind` fields (no nested `work`). The shipped `pasal_id_client.py` implementation expects a nested `work` shape. The tests in the plan would pass (because `item.get("work", item)` falls back to `item` when `work` is absent), but they **do not test the wave-1 fix** — the fix (nested `work` parsing) is untested. Any regression to the flat-shape fallback would be invisible to the existing test suite.
+
+**B3.5 — No integration gate between Phase 0 install and Phase 1 domain genesis**
+
+The plan ends at Task 12 with "push branch + open PR." There is no definition of a readiness signal that Phase 1 domain genesis agents can consume to know Phase 0 is operational. The daily gov-apis cron generates a snapshot in `~/.cache/domain-mesh-foundations/snapshots/` — but Phase 1 agents have no documented way to discover this path or verify the snapshot is fresh. If Phase 0 cron fails silently for 7 days, Phase 1 launches with stale data and no alert.
+
+---
+
+## C. Security
+
+### C1. `bali_calendar.py` — no input validation needed
+
+Python's `date` type handles its own range validation (`date(2026, 13, 1)` → `ValueError`). `_pawukon_day_index` does only integer subtraction and modulo — no crash risk. No concern here.
+
+### C2. `gov_apis_health.py` — scraper detectability
+
+The probe sends no `User-Agent` header (httpx default is `python-httpx/0.27.x`). Several Indonesian government portals use Cloudflare or nginx WAFs that block known bot User-Agent strings. The probe is already partially mitigated by `follow_redirects=True`, but:
+
+- **Rate limiting:** 17 probes/day from a single IP is well within any reasonable rate limit. Not an issue.
+- **Detection as scraper:** The httpx default UA is recognizable. If `jdihn.go.id` or `atrbpn.go.id` have bot-blocking rules, the probe will consistently classify them as `http_4xx` / `cf_challenge` even if they are operationally healthy for browsers. This corrupts the baseline. A browser-like UA (`Mozilla/5.0 ...`) is trivially added.
+- **No TLS fingerprinting concern** at 1 probe/day cadence.
+
+### C3. `opensanctions_id.py` — unauthenticated download risks
+
+**C3.1 — No size limit before loading response body into RAM**
+
+```python
+response = await client.get(url)
+response.raise_for_status()
+text = response.text   # entire body loaded
+```
+
+There is no `Content-Length` check before `response.text`. A malicious or misconfigured response body (or a MITM attack on the non-authenticated HTTP connection — note: `https://data.opensanctions.org` uses TLS, so MITM requires cert compromise) could return a multi-GB response. `response.text` decodes the entire body into RAM as a Python string.
+
+The DTTOT file is small (~50KB). The regional 2018 file is larger (~2MB). No current OOM risk, but the pattern is fragile: adding new datasets (e.g., if the plan extends to `id_corruption` or the global consolidated list) requires no code change to the client, only a new method — and could silently become an OOM source. A `MAX_BYTES = 20 * 1024 * 1024` guard on `len(response.content)` before decoding costs nothing.
+
+**C3.2 — `json.loads(line)` without exception handling (line 57)**
+
+```python
+payload = json.loads(line)
+```
+
+If any single JSONL line is malformed (truncated download, encoding error, partial write at source), `json.JSONDecodeError` aborts the entire iteration — all subsequent entities are lost. The retried download (3 attempts) may return the same truncated content if the source file is corrupted. A `try/except json.JSONDecodeError: continue` with a logged warning would maintain partial-list semantics.
+
+### C4. `pasal_id_client.py` — bearer token logging risk
+
+**`_headers()` at line 64–68** builds a dict containing `"Authorization": f"Bearer {self._api_token}"`. This dict is passed to `httpx.client.get()` as `headers=`. httpx logs request headers at DEBUG level when a logger named `httpx` is configured at `DEBUG`. In mata-garuda's cron script, there is no explicit logging config — default Python logging level is `WARNING`, so headers are NOT logged by default.
+
+However: `tenacity` logs retry attempts at WARNING level by default, and the log message includes the exception. A 401 raises `PasalIdAuthError` which contains the status code but not the token — safe. But if httpx itself emits debug logs in some future version with a changed default, the token could appear in `~/logs/domain-mesh-foundations/foundations-daily-YYYYMMDD.log`. Low risk, but the token should be masked in exception messages as a defense-in-depth measure.
+
+**More concrete risk:** `repr(PasalIdAuthError(...))` includes the message string. If the caller logs the exception naively (`logger.error("Failed: %s", exc)`), the message `"pasal.id auth failed (401). Set PASAL_ID_API_TOKEN env var."` leaks that the token was present (or absent). The token itself is not in the message — this is safe.
+
+---
+
+## D. Operational Readiness
+
+### D1. Failure modes when a foundations module fails
+
+| Module                | Failure mode                                                                                                                                                                        | Visibility                                                                                                              |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `pasal_id_client`     | `PasalIdAuthError` or `httpx.HTTPStatusError`                                                                                                                                       | Raised to caller. Visible if caller logs. Silent if caller swallows.                                                    |
+| `gdelt_client`        | `httpx.HTTPStatusError` after 3 retries                                                                                                                                             | Raised to caller. 15-25s latency before raising.                                                                        |
+| `opensanctions_id`    | `json.JSONDecodeError` on malformed line                                                                                                                                            | **Entire dataset lost silently if line 1 is bad.**                                                                      |
+| `gov_apis_health`     | Per-portal errors are caught and returned as `PortalHealth(status="dns_failure"/"timeout")`. Module-level errors (KeyError on missing `id`/`url` in inventory) abort entire report. | **Partial results silently lost on inventory KeyError.**                                                                |
+| `ner_extractor`       | `OSError` on model download failure, `RuntimeError` from transformers on GPU/CPU mismatch.                                                                                          | Raised to caller. 440MB download fail leaves `_pipeline=None` permanently until next process start.                     |
+| `arxiv_sanity_scorer` | `ValueError` on bad training data, `RuntimeError` on score-before-train.                                                                                                            | All raised, well-identified.                                                                                            |
+| `bali_calendar`       | Cannot fail on valid `date` input.                                                                                                                                                  | N/A.                                                                                                                    |
+| `openllmetry_init`    | `ImportError` silently returns `False`. `Traceloop.init()` network failure raises — uncaught.                                                                                       | **If `OPENLLMETRY_ENDPOINT` is set but unreachable, `Traceloop.init()` may raise at process start, crashing the cron.** |
+
+**D1 additional — `openllmetry_init.py:33–36`:** `Traceloop.init()` is not wrapped in a try/except. If the endpoint is set but the OTel collector is down, `Traceloop.init()` may raise a connection error during initialization. This would crash any script that calls `init_openllmetry()` at startup. The dormant pattern is correct for the disabled case, but the enabled case is unprotected.
+
+### D2. Where do errors go when OpenLLMetry is dormant?
+
+When `init_openllmetry()` returns `False`, there is no telemetry. Errors in the foundations modules go to:
+
+- Python exception tracebacks (if raised and not caught)
+- The cron script's stderr (`$LOG_FILE` via `2>>"$LOG_FILE"`)
+
+The cron script captures Python stdout to `$SNAPSHOT_FILE` and stderr to `$LOG_FILE`. **But the health probe Python one-liner pipes stdout to `$SNAPSHOT_FILE` and stderr to `$LOG_FILE` only for the one-liner block** (lines 57–70 of the cron script). Errors from subsequent Python calls (lines 72–73) go to the terminal/launchd log, not to `$LOG_FILE`. The `StandardErrorPath` in the plist catches launchd-level stderr, but the per-command stderr redirection in the script is inconsistent.
+
+### D3. Kill-switch for the cron
+
+The cron LaunchAgent `com.balizero.domain-mesh.foundations.daily` has `RunAtLoad: false` and `StartCalendarInterval Hour=4`. Kill-switch:
+
+```bash
+launchctl bootout gui/$(id -u)/com.balizero.domain-mesh.foundations.daily
+```
+
+This is adequate. No runaway risk since it's a daily scheduled job with no `KeepAlive`. If the job hangs, launchd will not kill it — it will block the next scheduled run. Adding a `TimeOut` key to the plist (e.g., `300` seconds) would auto-kill a hung probe. Without it, a hung `gov_apis_health.probe_inventory()` (e.g., one portal with a broken TCP accept that never times out despite the 15s `httpx` timeout) could leave a zombie Python process.
+
+### D4. `gov_apis_inventory.json` — version-controlled but fragile
+
+The file is version-controlled — good. But `load_inventory()` has no schema validation:
+
+```python
+def load_inventory() -> list[dict]:
+    return json.loads(INVENTORY_PATH.read_text(encoding="utf-8"))
+```
+
+If someone adds an entry without `"url"`, the JSON is still valid, but `probe_portal` crashes with `KeyError` (B1.11 above). There is no Pydantic model or even a simple `assert "id" in entry and "url" in entry` guard. A `jsonschema` validation at load time (or a minimal loop check) would catch bad edits before the cron fires.
+
+---
+
+## E. Other Flaws Before Phase 1 Engineering Time
+
+### E1. `foundations/__init__.py` imports `NERExtractor` at package level — triggers transformers import on any `from mata_garuda.foundations import ...`
+
+The plan's `foundations/__init__.py` (plan lines 1410–1411) imports `NERExtractor` at the top level:
+
+```python
+from mata_garuda.foundations.ner_extractor import NamedEntity, NERExtractor
+```
+
+`ner_extractor.py` imports `from transformers import pipeline` at module level (line 13). This means **any** `import mata_garuda.foundations` (e.g., to use only `BaliCalendar` or `GdeltClient`) will trigger the import of the `transformers` library (~50MB of Python modules) even though NER is not needed. `transformers` import alone takes 2–4 seconds on first load. This defeats the lazy-load fix from wave 1: the model download is deferred, but the library import cost is paid on every process start that touches `foundations`.
+
+Fix: either keep `foundations/__init__.py` minimal (no NERExtractor re-export), or use lazy imports (`__getattr__` pattern).
+
+### E2. `arxiv_sanity_scorer.py` — model is not persisted between cron runs
+
+The `ArxivSanityScorer` is an in-memory object. There is no `save()`/`load()` method. If Antonello trains the model from tagged papers and the process exits, the trained model is gone. Phase 1 will need to rehydrate the model on every run. The plan mentions "Train on Antonello's tagged papers" but does not specify where those papers come from or how the model persists. A `joblib.dump`/`joblib.load` pair for `(vectorizer, model)` is the canonical sklearn persistence pattern. Without it, the scorer is useful only within a single process session — not for the daily cron pattern the plan envisions.
+
+### E3. `opensanctions_id.py` — non-commercial license boundary
+
+The docstring says "Free non-commercial." Bali Zero is a commercial legal/immigration agency that uses this data for client KYC screening. This may constitute commercial use under OpenSanctions' license terms. OpenSanctions offers a commercial license. This is a **legal risk**, not a code risk — but it should be flagged before committing engineering time to build Phase 1 PEP screening on top of this foundation.
+
+### E4. `pasal_id_client.py` — retrying on 500 is wrong for pasal.id
+
+The `@retry` decorator at line 70 uses `retry_if_not_exception_type(PasalIdAuthError)` — meaning it retries on everything except `PasalIdAuthError`. This includes `httpx.HTTPStatusError` for 500, 503, and also **404** (law not found). Retrying 3 times on a 404 for `get_law_status("uu-2099-999")` wastes 1+2+4=7 seconds before raising. The filter should also exclude client errors that are terminal: `retry_if_exception_type((httpx.TransportError, httpx.TimeoutException))` is the safe pattern, or add `retry_if_not_exception_type((PasalIdAuthError, httpx.HTTPStatusError))` and let callers handle specific HTTP codes.
+
+### E5. `bali_calendar.py` — `ANCHOR_PAWUKON_DAY_1` mismatch between code and plan
+
+The shipped `bali_calendar.py` (line 34) has:
+
+```python
+KUNINGAN_PAWUKON_DAY_INDEX = GALUNGAN_PAWUKON_DAY_INDEX + 10  # 0-indexed: 80
+```
+
+The plan's Step 3 template (plan line 584) has:
+
+```python
+KUNINGAN_PAWUKON_DAY_INDEX = 11 * 7 + 4  # 0-indexed: day 81 of cycle
+```
+
+`10 * 7 + 10 = 80` vs `11 * 7 + 4 = 81`. The shipped code uses `+10` days from Galungan (correct — Kuningan is 10 days after Galungan). The plan uses `11 * 7 + 4 = 81` (day 5 of wuku Kuningan, 0-indexed = wuku 11 + day 4 = 82nd day, 0-indexed 81). There is a **1-day discrepancy** between the plan's constant and the shipped constant.
+
+The shipped code (`GALUNGAN_PAWUKON_DAY_INDEX + 10 = 70 + 10 = 80`) maps to 2026-06-17 + 10 days = 2026-06-27 — which matches the verified anchor date. The plan's `11 * 7 + 4 = 81` would be 2026-06-28 — one day off from the verified date. **The shipped code is correct; the plan's template is wrong.** This is not a bug in the code, but it means the plan document itself has a wrong constant that will confuse any future agent that regenerates the implementation from the plan.
+
+---
+
+_Summary of actionable items before Phase 1 engineering:_
+
+| Priority | Item                                                             | File:line                            |
+| -------- | ---------------------------------------------------------------- | ------------------------------------ |
+| P0       | `work: null` crash                                               | `pasal_id_client.py:91`              |
+| P0       | `_get_pipeline` thread-safety race                               | `ner_extractor.py:45–51`             |
+| P0       | Sequential probe (up to 255s)                                    | `gov_apis_health.py:81–85`           |
+| P0       | Cron uses wrong venv                                             | `domain-mesh-foundations-cron.sh:13` |
+| P1       | `__dict__` on frozen dataclass                                   | `domain-mesh-foundations-cron.sh:57` |
+| P1       | `match_name` downloads full dataset on every call                | `opensanctions_id.py:42–45`          |
+| P1       | No size limit on response body                                   | `opensanctions_id.py:52`             |
+| P1       | `json.JSONDecodeError` aborts entire dataset                     | `opensanctions_id.py:57`             |
+| P1       | `Traceloop.init()` unprotected from network failure              | `openllmetry_init.py:33`             |
+| P1       | `foundations/__init__.py` eager transformers import              | plan Task 9                          |
+| P1       | 404 retried 3 times in pasal.id client                           | `pasal_id_client.py:70–73`           |
+| P2       | GDELT 429 retried (wrong)                                        | `gdelt_client.py:32`                 |
+| P2       | `score()` crashes if label 1 absent in model                     | `arxiv_sanity_scorer.py:66`          |
+| P2       | `gov_apis_inventory.json` has no schema guard                    | `gov_apis_health.py:49–51`           |
+| P2       | `ArxivSanityScorer` not persisted across runs                    | `arxiv_sanity_scorer.py`             |
+| P2       | OpenSanctions non-commercial license vs Bali Zero commercial use | `opensanctions_id.py:8`              |

--- a/infra/scripts/domain-mesh-foundations-cron.sh
+++ b/infra/scripts/domain-mesh-foundations-cron.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
+# Domain mesh Phase 0 — daily 04:00 WITA gov-apis health probe.
+#
+# Wave 2 review fix (Codex W2 + DeepSeek W2, 2026-05-08):
+# - Use absolute venv python (was: source 2>/dev/null = silent fail)
+# - Atomic snapshot via tmp + mv (was: > redirect = partial file on crash)
+# - Kill-switch via FOUNDATIONS_CRON_ENABLED env var
+# - Read snapshot via env var (was: shell-quote interpolation in python -c)
 set -uo pipefail
+
+# Kill switch: set FOUNDATIONS_CRON_ENABLED=false to disable without
+# unloading the LaunchAgent.
+if [ "${FOUNDATIONS_CRON_ENABLED:-true}" = "false" ]; then
+    echo "$(date) foundations cron disabled via FOUNDATIONS_CRON_ENABLED=false" >&2
+    exit 0
+fi
 
 LOG_DIR="$HOME/logs/domain-mesh-foundations"
 SNAPSHOT_DIR="$HOME/.cache/domain-mesh-foundations/snapshots"
@@ -7,15 +21,28 @@ mkdir -p "$LOG_DIR" "$SNAPSHOT_DIR"
 
 LOG_FILE="$LOG_DIR/foundations-daily-$(date +%Y%m%d).log"
 SNAPSHOT_FILE="$SNAPSHOT_DIR/gov-apis-health-$(date +%Y%m%d).json"
+SNAPSHOT_TMP="${SNAPSHOT_FILE}.tmp.$$"
 
 REPO_ROOT="${HOME}/Desktop/nuzantara"
-cd "$REPO_ROOT/apps/mata-garuda" || exit 1
+cd "$REPO_ROOT/apps/mata-garuda" || {
+    echo "$(date) FAILED: cannot cd to $REPO_ROOT/apps/mata-garuda" >> "$LOG_FILE"
+    exit 1
+}
 
-source "$REPO_ROOT/.venv/bin/activate" 2>/dev/null
+# Use absolute venv python — fail loud if it's missing instead of silently
+# falling back to system python (which violates the no-system-python rule
+# in CLAUDE.md and crashes opaquely on missing deps).
+VENV_PY="$REPO_ROOT/.venv/bin/python"
+if [ ! -x "$VENV_PY" ]; then
+    echo "$(date) FAILED: venv python not executable at $VENV_PY" >> "$LOG_FILE"
+    exit 2
+fi
 
-python -c "
+# Write to .tmp file first, then mv atomically only on success.
+"$VENV_PY" -c "
 import asyncio, json, sys
-from mata_garuda.foundations import probe_inventory
+# Lazy direct import — avoids pulling transformers/torch via foundations/__init__.py.
+from mata_garuda.foundations.gov_apis_health import probe_inventory
 report = asyncio.run(probe_inventory())
 data = {
     'total': report.total,
@@ -23,18 +50,27 @@ data = {
     'results': [r.__dict__ for r in report.results],
 }
 sys.stdout.write(json.dumps(data, indent=2))
-" > "$SNAPSHOT_FILE" 2>>"$LOG_FILE"
+" > "$SNAPSHOT_TMP" 2>>"$LOG_FILE"
 
 EXIT_CODE=$?
 
 if [ $EXIT_CODE -ne 0 ]; then
-    echo "$(date) FAILED foundations daily probe" >> "$LOG_FILE"
+    rm -f "$SNAPSHOT_TMP"
+    echo "$(date) FAILED foundations daily probe (exit $EXIT_CODE)" >> "$LOG_FILE"
     exit $EXIT_CODE
 fi
 
-OPERATIONAL=$(python -c "import json; d=json.load(open('$SNAPSHOT_FILE')); print(d['operational'])")
-TOTAL=$(python -c "import json; d=json.load(open('$SNAPSHOT_FILE')); print(d['total'])")
-echo "$(date) gov-apis snapshot: $OPERATIONAL/$TOTAL operational" >> "$LOG_FILE"
+# Atomic publish: only rename to canonical path if Python succeeded.
+mv "$SNAPSHOT_TMP" "$SNAPSHOT_FILE"
+
+# Read counters via env var instead of shell-interpolating the path
+# (avoids quote injection if SNAPSHOT_FILE ever picks up unexpected chars).
+SUMMARY=$(SNAPSHOT_FILE="$SNAPSHOT_FILE" "$VENV_PY" -c "
+import json, os
+d = json.load(open(os.environ['SNAPSHOT_FILE']))
+print(f\"{d['operational']}/{d['total']}\")
+")
+echo "$(date) gov-apis snapshot: $SUMMARY operational" >> "$LOG_FILE"
 
 # TODO Phase 1: compare vs 7-day baseline + Telegram alert if drop > 10pp
 exit 0


### PR DESCRIPTION
## Summary

Wave 2 of independent external review (follow-up to wave 1 / PR #525). 5 LLM reviewers in parallel, prompt explicitly told them: **"focus on what wave 1 MISSED"**.

| Reviewer | Status | Verdict |
|---|---|---|
| Claude Sonnet 4.6 OAuth | ✅ delivered | Confirmed work:null bug, found 4 minor issues |
| Codex GPT-5 (rerun, web search) | ✅ delivered | **Critical: __init__.py eager imports vanified wave 1 lazy NER fix** |
| DeepSeek Reasoner v4 | ✅ delivered | Race condition + cron robustness + 9 cross-cutting concerns |
| superpowers:security-review skill | ✅ delivered | 1 MEDIUM (latent cron shell quote), 0 HIGH |
| superpowers:code-review skill | ⚠️ skipped | PR #525 already merged — no GitHub comment |

## 5 NEW bugs fixed (none caught by wave 1)

### 1. `pasal_id_client.py` — `work: null` AttributeError crash
**Consensus**: DeepSeek + Codex + Sonnet all flagged.

`item.get("work", item)` returns `None` when JSON has explicit `"work": null` (default only triggers for missing key, not null value). Then `.get(...)` crashes with `AttributeError`.

**Fix**: `raw_work = item.get("work"); work = raw_work if isinstance(raw_work, dict) and raw_work else item`.

**Test added**: `test_search_laws_handles_explicit_null_work_field`.

### 2. `ner_extractor.py` — race condition on lazy load
**Consensus**: DeepSeek W2 (caught it first), Codex W2 confirmed.

Wave 1 fix made `_pipeline = None` lazy, but two concurrent `extract()` calls could both see `_pipeline is None`, both call HuggingFace `pipeline()`, both download cahya BERT (~440MB twice), both allocate 1.5GB RAM.

**Fix**: `threading.Lock()` + double-check pattern.

**Test added**: `test_pipeline_initialised_only_once_under_concurrent_calls` — spawns 8 threads, asserts factory called exactly once.

### 3. `foundations/__init__.py` — eager imports vanified wave 1 lazy NER fix ⚠️ BIG
**Caught by**: Codex W2 only.

This is the ironic one. Wave 1 made `NERExtractor` lazy to avoid loading 440MB BERT at import. **But `foundations/__init__.py` re-exported `NERExtractor` and `ArxivSanityScorer` at module level**, so any worker doing `from mata_garuda.foundations import probe_inventory` ALSO loaded transformers + torch + sklearn at import time. The lazy fix was effectively dead.

**Fix**: PEP 562 `__getattr__` lazy proxy. Heavy classes (`NERExtractor`, `ArxivSanityScorer`, `LabeledPaper`, `NamedEntity`) only loaded on first attribute access.

**Verified empirically**:
```python
from mata_garuda.foundations import probe_inventory, load_inventory
print('transformers loaded:', 'transformers' in sys.modules)  # False ✅
print('torch loaded:', 'torch' in sys.modules)                # False ✅
print('sklearn loaded:', 'sklearn' in sys.modules)            # False ✅
```

### 4. `ner_extractor.py` — `from transformers import pipeline` moved inside `_get_pipeline()`
Companion to fix 3: deferred import means workers without ML deps don't pay cost even if they import the module name.

### 5. `cron-wrapper.sh` — 4 robustness issues bundled
**Consensus**: DeepSeek + Codex + security-review skill all flagged.

- **`source venv 2>/dev/null` silently fell back to system python** → Fix: absolute `$REPO_ROOT/.venv/bin/python`, fail loud if missing.
- **`> redirect` created partial snapshot on Python crash** → Fix: write to `.tmp.$$` then atomic `mv` only on success.
- **Direct path interpolation in `python -c "...$SNAPSHOT_FILE..."` was injection-fragile** (security-review MEDIUM) → Fix: env var passing via `SNAPSHOT_FILE=...`.
- **No kill switch** → Fix: `FOUNDATIONS_CRON_ENABLED=false` escape hatch.

Bonus: cron now imports `probe_inventory` directly from `gov_apis_health` module (not via foundations/__init__) so it doesn't trigger the lazy proxy at all.

## Tests

**33/33 green** (was 31, +2 new):
- `test_search_laws_handles_explicit_null_work_field` (work:null guard)
- `test_pipeline_initialised_only_once_under_concurrent_calls` (race condition, 8 threads)

## Reviews saved

`docs/superpowers/specs/2026-05-08-domain-mesh-research/external-reviews-wave2/`:
- `sonnet-w2.md` (Claude Sonnet 4.6 OAuth, 453 lines)
- `codex-w2.md` (Codex GPT-5 with web search, 127 lines)
- `deepseek-w2.md` (DeepSeek v4 cross-cutting, 196 lines)

## Critiques REJECTED in wave 2

- gov_apis User-Agent + jitter (DeepSeek) — operational hardening, Phase 1
- opensanctions OOM streaming (DeepSeek + Codex) — DOS class, security-review skill explicitly excludes DOS
- bali_calendar input validation (DeepSeek) — defense-in-depth, Phase 1
- Structured logging across modules (DeepSeek) — Phase 1

## Phase 1 backlog updated

Added to roadmap (not blocking Phase 1 start, but tracked):
- Streaming downloads for opensanctions (>50MB cap)
- gov_apis User-Agent header + asyncio.sleep jitter
- Common error contract: `FoundationUnavailable` / `RateLimited` / `AuthMissing`
- Pajakku PJAP price verification (still unknown)
- Phase 1 telemetry pipeline activation (Langfuse + Phoenix self-host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)