### PR TITLE
feat(wr2/canva): OAuth watchdog (Sprint B B-NEW, replaces B1+B2)

### DIFF
--- a/docs/wr2/2026-05-08-sprint-b-to-f-detailed-plan.md
+++ b/docs/wr2/2026-05-08-sprint-b-to-f-detailed-plan.md
@@ -171,6 +171,29 @@ The first B0 implementation (PR #516) wrote `_log_run_telemetry(draft_id, n, "su
 
 **Fix**: PR `fix/wr2-canva-persist-race-2026-05-08` reorders telemetry to write `success` only AFTER `_persist_canva_result` returns; on persist exception writes `outcome="persist_failed"` so JSONL truthfully mirrors DB state. `_persist_canva_result` accepts `dsn` and re-opens a fresh connection if `conn.is_closed()` — making persist resilient to wireguard idle-timeout. Tests: `scripts/tests/test_wr2_canva_apply_persist_race.py` (4 scenarios). The B0 success-rate denominator now equals the DB-persisted-rendered count, not the apply-returned-result count.
 
+### B-NEW — Canva OAuth watchdog (SHIPPED 2026-05-08, replaces B1+B2)
+
+**Scope**: every 6h, probe whether `claude -p` subprocess sees ≥30 `mcp__claude_ai_Canva__*` tools loaded. If fewer (or non-numeric output), the OAuth token in `~/.mcp-auth/` has gone stale → fetch the re-auth URL via a second `claude -p` calling `mcp__claude_ai_Canva__authenticate` and Telegram alert (P0) the operator with the URL embedded as a click link. 24h cooldown between alerts; first healthy→stale transition always alerts.
+
+**Why this replaces B1 (MCP pre-warm wrapper) and B2 (session keeper daemon)**: 4 review streams (Codex/Gemini/DeepSeek/NotebookLM, 2026-05-07) independently rejected the "MCP cache warming" hypothesis as architecturally unfounded. Empirical 4 datapoints from B0 telemetry showed the only consistent failure mode is "MCP Canva not visible in `claude -p` subprocess" — which `claude -p` cannot self-heal because re-auth is browser-OAuth-interactive. A watchdog that pages an operator is the cheapest-correct mitigation; a wrapper that probes pre-call would just double the failure surface without unblocking re-auth.
+
+**Files (Pro-local, NOT in repo, with snapshot for audit)**:
+
+- `~/scripts/wr2-canva-oauth-watchdog.sh` — bash script (set -uo pipefail, flock single-instance, key=value state file)
+- `~/Library/LaunchAgents/com.balizero.wr2.canva-oauth-watchdog.plist` — `StartInterval=21600` + `RunAtLoad=true`, mode 0444 per cicatrix P0-3
+- `infra/launchagents/com.balizero.wr2.canva-oauth-watchdog.plist` — repo mirror
+- `docs/wr2/skill-snapshots/canva-oauth-watchdog-2026-05-08.md` — script body snapshot for repo tracking + operator runbook
+- `tests/lint/test_canva_oauth_watchdog.sh` — extracts the bash body from the snapshot, runs 6 scenarios with a stub `claude` (healthy / first stale / cooldown active / cooldown elapsed / non-numeric output / boundary count=29), 17 assertions
+
+**Probe contract**:
+- Healthy → integer ≥ `MIN_TOOLS=30` → exit 0, state.last_status=healthy.
+- Stale → empty/non-numeric or < 30 → exit 1, state.last_status=stale, alert if no cooldown.
+- 60s probe timeout (`PROBE_TIMEOUT`); 86400s alert cooldown (`ALERT_COOLDOWN_SEC`).
+
+**Empirical post-bootstrap (2026-05-08)**: launchd `state=not running, last exit code=0`; first probe at 04:34:37 WITA logged `OK: 32 mcp__claude_ai_Canva__* tools visible (>= 30)`; next fire +21600s.
+
+**Discovery during build**: sourcing `~/.nuzantara-secrets.env` with `set -a` poisons the `claude -p` subprocess env (likely `OPENROUTER_API_KEY` or `MINIMAX_API_KEY`) — the count probe silently returned 0. Mitigated by extracting only `TELEGRAM_BOT_TOKEN` + `TELEGRAM_OWNER_CHAT_ID` via grep+cut. `< /dev/null` is mandatory on the probe call (otherwise the "no stdin data received in 3s" warning pollutes the captured output).
+
 ### B1 — MCP pre-warm wrapper (PARKED — pending B0 data)
 
 **Scope**: prima del `claude -p` "vero", lancia un probe `claude -p` short-running per portare in cache la connessione MCP Canva. Se probe fallisce → retry con backoff. Se persiste fail → Telegram alert + skip draft.

--- a/docs/wr2/skill-snapshots/canva-oauth-watchdog-2026-05-08.md
+++ b/docs/wr2/skill-snapshots/canva-oauth-watchdog-2026-05-08.md
@@ -1,0 +1,284 @@
+# wr2-canva-oauth-watchdog (Pro-local script snapshot)
+
+Live path: `~/scripts/wr2-canva-oauth-watchdog.sh` (Pro only, **NOT** git-tracked).
+Plist: `~/Library/LaunchAgents/com.balizero.wr2.canva-oauth-watchdog.plist` (mirrored at `infra/launchagents/com.balizero.wr2.canva-oauth-watchdog.plist`).
+Sprint: B B-NEW (replaces the original B1+B2 "MCP cache warming" hypothesis after 4 review streams falsified it).
+
+This snapshot is the contractual repo copy: any edit to the live script body must be reflected here in the same PR. Reviewers can audit watchdog logic via this file without granting them shell access to Pro.
+
+## What it does
+
+Probes the Claude Code OAuth state for the Canva MCP connector by spawning `claude -p` with a minimal prompt that asks for the count of `mcp__claude_ai_Canva__*` tools visible in the subprocess. Healthy = integer ≥ 30. Stale = empty/non-numeric or < 30.
+
+When stale:
+1. Spawns a second `claude -p` carrying explicit operator authorization context, calling `mcp__claude_ai_Canva__authenticate`. Greps `https://*canva.com/authorize?...` from the response.
+2. Telegram alerts owner chat (P0) with the URL embedded as a click link plus brief operator instructions.
+3. Honors a 24h cooldown via `~/.agent/decisions/state/wr2_canva_oauth.state` so a 6-hour cron does not page 4× per day.
+4. Exits 0 on healthy, 1 on stale (with or without alert).
+
+Failure modes considered:
+- claude binary missing → script exits with `set -uo pipefail` propagation, plist captures stderr in launchd err log.
+- TELEGRAM_BOT_TOKEN missing → log "Telegram skipped"; no exception.
+- claude -p stdin warning polluting output → suppressed via `< /dev/null`.
+- Sourcing `~/.nuzantara-secrets.env` poisoned the `claude -p` env (verified empirically 2026-05-08 04:10 WITA — full source caused the count probe to silently return 0). Mitigated by extracting only `TELEGRAM_BOT_TOKEN` + `TELEGRAM_OWNER_CHAT_ID` via grep+cut.
+
+## Empirical baseline at install (2026-05-08)
+
+```
+$ bash ~/scripts/wr2-canva-oauth-watchdog.sh; echo "exit=$?"
+exit=0
+$ cat ~/.agent/decisions/state/wr2_canva_oauth.state
+last_status=healthy
+last_count=33
+last_check_ts=1778185931
+```
+
+## Test matrix
+
+| Path | State setup | Stub | Expected |
+|------|-------------|------|----------|
+| Healthy | (clean) | none | exit 0, state.healthy, count logged |
+| Stale + cooldown elapsed | last_alert_ts T-25h | claude returns "5" | exit 1, alert fires, state.stale |
+| Stale + cooldown active | last_alert_ts T-1h | claude returns "5" | exit 1, "alert suppressed" log line |
+
+Stub via `CANVA_WATCHDOG_TEST_PATH_PREFIX=/tmp/watchdog-shim` (test-only env var; unset in production launchd). All three paths verified live 2026-05-08 04:30-04:31 WITA before plist bootstrap.
+
+## Script body (mirror — keep byte-identical with `~/scripts/wr2-canva-oauth-watchdog.sh`)
+
+```bash
+#!/usr/bin/env bash
+# wr2-canva-oauth-watchdog.sh — Sprint B B-NEW (2026-05-08)
+#
+# Probes the Claude Code OAuth state for the Canva MCP connector and
+# pages Antonello on Telegram when the token has gone stale (i.e. when
+# `claude -p` no longer sees the mcp__claude_ai_Canva__* tool family).
+#
+# Why: Sprint B B0 instrumentation (PR #516, telemetry JSONL) showed the
+# canva-apply pipeline's only consistent failure mode is "MCP Canva not
+# available in subprocess" — empirical 4 datapoints, all preceded by a
+# stale OAuth token in ~/.mcp-auth/. Reauth is interactive (browser
+# OAuth flow), so the watchdog cannot self-heal — it pages so an
+# operator can click the link.
+#
+# Cadence: launchctl every 6h (StartInterval=21600). Cooldown: only
+# alert when token has BEEN stale at least once before AND ≥24h
+# since the last alert. State file
+# ~/.agent/decisions/state/wr2_canva_oauth.state.
+#
+# Healthy threshold: claude -p with the count-tool prompt must return
+# an integer ≥ MIN_TOOLS (currently 30). Below that is treated as
+# token-stale. The exact count is also logged to the watchdog log.
+#
+# Pro-local: this script is NOT git-tracked. A snapshot lives at
+# docs/wr2/skill-snapshots/canva-oauth-watchdog-2026-05-08.md for
+# audit. Edit there + here when you change the script body.
+
+set -uo pipefail
+
+LOG="${HOME}/logs/wr2-canva-oauth-watchdog.log"
+STATE="${HOME}/.agent/decisions/state/wr2_canva_oauth.state"
+LOCK="${HOME}/.agent/decisions/state/wr2_canva_oauth.lock"
+SECRETS="${HOME}/.nuzantara-secrets.env"
+
+MIN_TOOLS=30
+PROBE_TIMEOUT=60
+ALERT_COOLDOWN_SEC=86400  # 24h
+
+# Make sure log + state dirs exist before we write anything.
+mkdir -p "$(dirname "$LOG")" "$(dirname "$STATE")"
+
+log() {
+  printf '%s [wr2-canva-oauth-watchdog] %s\n' \
+    "$(date '+%Y-%m-%d %H:%M:%S WITA')" "$*" >> "$LOG"
+}
+
+# Pull JUST the Telegram credentials from the secrets file. We do NOT
+# `source` the whole file because some keys (e.g. OPENROUTER_API_KEY,
+# MINIMAX_API_KEY) leak into the `claude -p` subprocess env and cause
+# its MCP-tool count probe to silently return 0 — verified empirically
+# 2026-05-08 04:10 WITA. The targeted grep keeps the watchdog
+# self-contained and side-effect-free for the probe.
+if [[ -f "$SECRETS" ]]; then
+  TELEGRAM_BOT_TOKEN="$(grep '^TELEGRAM_BOT_TOKEN=' "$SECRETS" | head -1 | cut -d= -f2- | tr -d '"' )" || true
+  TELEGRAM_OWNER_CHAT_ID="$(grep '^TELEGRAM_OWNER_CHAT_ID=' "$SECRETS" | head -1 | cut -d= -f2- | tr -d '"' )" || true
+  export TELEGRAM_BOT_TOKEN TELEGRAM_OWNER_CHAT_ID
+fi
+
+# Single-instance lock — `flock` is /usr/bin/flock from coreutils on
+# brew, but we fall back to the macOS `lockfile` if flock is missing.
+if command -v flock >/dev/null 2>&1; then
+  exec 9>"$LOCK"
+  if ! flock -n 9; then
+    log "another watchdog run is in progress, skipping"
+    exit 0
+  fi
+fi
+
+# Optional test-only PATH prefix — lets a stub `claude` shim short-
+# circuit the probe for unit testing without touching real OAuth state.
+# In production this env var is unset and PATH follows the standard
+# hierarchy (claude under ~/.local/bin first).
+PATH="${CANVA_WATCHDOG_TEST_PATH_PREFIX:+${CANVA_WATCHDOG_TEST_PATH_PREFIX}:}/Users/nuzantara/.local/bin:/Users/nuzantara/.npm-global/bin:/Users/nuzantara/.pyenv/versions/3.11.11/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${PATH:-}"
+export PATH
+
+now_epoch() { date '+%s'; }
+
+# state file lives in /etc-style key=value form: easy to grep, easy to
+# update with sed. Unknown keys are tolerated.
+state_get() {
+  local key="$1"
+  [[ -f "$STATE" ]] || return 0
+  awk -F= -v k="$key" '$1==k {print $2}' "$STATE" | tail -1
+}
+state_set() {
+  local key="$1" val="$2"
+  mkdir -p "$(dirname "$STATE")"
+  if [[ -f "$STATE" ]]; then
+    awk -F= -v k="$key" -v v="$val" '
+      BEGIN{found=0}
+      $1==k {print k"="v; found=1; next}
+      {print}
+      END{if(!found) print k"="v}
+    ' "$STATE" > "${STATE}.tmp" && mv "${STATE}.tmp" "$STATE"
+  else
+    printf '%s=%s\n' "$key" "$val" > "$STATE"
+  fi
+}
+
+send_telegram() {
+  local text="$1"
+  if [[ -z "${TELEGRAM_BOT_TOKEN:-}" ]]; then
+    log "Telegram skipped (no TELEGRAM_BOT_TOKEN)"
+    return 0
+  fi
+  local chat_id="${TELEGRAM_OWNER_CHAT_ID:-1125336968}"
+  curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+    --data-urlencode "chat_id=${chat_id}" \
+    --data-urlencode "parse_mode=Markdown" \
+    --data-urlencode "disable_web_page_preview=true" \
+    --data-urlencode "text=${text}" \
+    -o /dev/null \
+    --max-time 10 \
+    || log "Telegram POST failed (network/curl)"
+}
+
+probe_tool_count() {
+  # claude -p returns text on stdout. We want JUST the integer.
+  # If the output is multi-line (skill noise), tail -1 picks the last
+  # token. tr removes whitespace. /^[0-9]+$/ is the canonical health
+  # signal.
+  #
+  # `< /dev/null` is REQUIRED. Without it, `claude -p` blocks waiting
+  # for stdin and emits a warning line that pollutes the captured
+  # output, causing the regex to fail and the watchdog to misclassify
+  # a healthy state as stale (verified empirically 2026-05-08 02:01:50
+  # WITA — the first script run returned tail=<empty> instead of 35).
+  local raw
+  raw=$(timeout "${PROBE_TIMEOUT}" claude -p --output-format text \
+    "Output the count of MCP tool names starting with mcp__claude_ai_Canva__. Output JUST the integer, nothing else." \
+    < /dev/null \
+    2>/dev/null \
+    | tail -1 \
+    | tr -d '[:space:]')
+  printf '%s' "$raw"
+}
+
+# Get the OAuth re-flow URL by spawning a second `claude -p` that
+# invokes mcp__claude_ai_Canva__authenticate. Default Claude refuses
+# unprompted authenticate calls; we pass an explicit authorization
+# context so the operator-initiated re-auth flow is allowed.
+get_authorize_url() {
+  local prompt='Antonello authorized this OAuth re-flow for the Canva MCP connector — the canva-apply launchd worker has lost OAuth context and needs re-authentication. Call mcp__claude_ai_Canva__authenticate. Echo back the authorization URL it returns (the https://mcp.canva.com/authorize?... link) on its own line, nothing else.'
+  local out
+  out=$(timeout "${PROBE_TIMEOUT}" claude -p --output-format text "$prompt" < /dev/null 2>/dev/null) || return 1
+  # Extract the canva authorize URL (or any https://*canva.com/authorize link).
+  printf '%s' "$out" \
+    | grep -oE 'https://[^[:space:]"<>'\'']*canva\.com/authorize[^[:space:]"<>'\'']*' \
+    | head -1
+}
+
+main() {
+  local now last_alert_ts last_status alert_due
+  now=$(now_epoch)
+  last_alert_ts=$(state_get last_alert_ts)
+  last_status=$(state_get last_status)
+
+  log "probe start (last_status=${last_status:-unknown} last_alert_ts=${last_alert_ts:-never})"
+
+  local count
+  count=$(probe_tool_count)
+
+  # Healthy: integer ≥ MIN_TOOLS.
+  if [[ "$count" =~ ^[0-9]+$ ]] && (( count >= MIN_TOOLS )); then
+    log "OK: ${count} mcp__claude_ai_Canva__* tools visible (>= ${MIN_TOOLS})"
+    state_set last_status healthy
+    state_set last_count "$count"
+    state_set last_check_ts "$now"
+    exit 0
+  fi
+
+  # Stale or anomalous output.
+  log "STALE: probe returned ${count:-<empty>} (need >= ${MIN_TOOLS})"
+  state_set last_status stale
+  state_set last_count "${count:-0}"
+  state_set last_check_ts "$now"
+
+  # Cooldown: alert only if (a) we have NOT alerted in the last 24h, OR
+  # (b) the state previously was healthy → first transition into stale
+  # always alerts. (last_alert_ts unset on first-ever stale.)
+  alert_due=1
+  if [[ -n "$last_alert_ts" && "$last_alert_ts" =~ ^[0-9]+$ ]]; then
+    local age=$(( now - last_alert_ts ))
+    if (( age < ALERT_COOLDOWN_SEC )); then
+      log "alert suppressed (last alert ${age}s ago, cooldown ${ALERT_COOLDOWN_SEC}s)"
+      alert_due=0
+    fi
+  fi
+
+  if (( alert_due == 0 )); then
+    exit 1
+  fi
+
+  log "fetching re-auth URL via claude -p mcp__claude_ai_Canva__authenticate"
+  local url
+  url=$(get_authorize_url) || url=""
+
+  local msg
+  if [[ -n "$url" ]]; then
+    msg=$(printf '🚨 *WR2 Canva OAuth STALE*\nclaude -p sees only %s mcp\\_\\_claude\\_ai\\_Canva\\_\\_ tools (need ≥ %s).\n\n*Action*: open the link below in a browser, sign in to Canva, then return.\n\n%s\n\n_Re-auth restores subprocess OAuth context for the canva-apply worker._' \
+      "${count:-0}" "$MIN_TOOLS" "$url")
+  else
+    msg=$(printf '🚨 *WR2 Canva OAuth STALE*\nclaude -p sees only %s mcp\\_\\_claude\\_ai\\_Canva\\_\\_ tools (need ≥ %s).\n\nFailed to fetch the authorize URL automatically. Run:\n`claude` then `/mcp authenticate canva` from the main repo workspace.' \
+      "${count:-0}" "$MIN_TOOLS")
+  fi
+
+  send_telegram "$msg"
+  state_set last_alert_ts "$now"
+  log "alert sent (url=${url:-<missing>})"
+  exit 1
+}
+
+main "$@"
+```
+
+## Operator runbook
+
+When the Telegram alert fires:
+
+1. Open the embedded `https://mcp.canva.com/authorize?...` URL in a browser logged into the Canva account used for the Bali Zero / Nuzantara workspace.
+2. Complete the OAuth handshake.
+3. The new tokens land in `~/.mcp-auth/mcp-remote-*` automatically; the next watchdog cycle (≤6h) will see ≥30 Canva tools and revert state to `healthy`. To verify immediately: `bash ~/scripts/wr2-canva-oauth-watchdog.sh; echo $?` (expect 0 + `last_status=healthy` in state file).
+4. If the count remains low, run `claude` interactively in `~/Desktop/nuzantara` and execute `/mcp` → check that the Canva server is `Connected`. If not, `/mcp authenticate canva`.
+
+## Bootstrap commands
+
+```bash
+# 1. plist permissions follow the cicatrix P0-3 hardening (chmod 0444 in
+#    production). Use chmod u+w to edit, then restore.
+plutil -lint ~/Library/LaunchAgents/com.balizero.wr2.canva-oauth-watchdog.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.balizero.wr2.canva-oauth-watchdog.plist
+launchctl print gui/$(id -u)/com.balizero.wr2.canva-oauth-watchdog | head -40
+
+# 2. Smoke test post-bootstrap (next-fire timestamp should be roughly now+6h):
+launchctl print gui/$(id -u)/com.balizero.wr2.canva-oauth-watchdog | grep -E 'state|next start'
+```

--- a/infra/launchagents/com.balizero.wr2.canva-oauth-watchdog.plist
+++ b/infra/launchagents/com.balizero.wr2.canva-oauth-watchdog.plist
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.balizero.wr2.canva-oauth-watchdog — Sprint B B-NEW (2026-05-08).
+
+  Probes the Claude Code OAuth state for the Canva MCP connector every
+  6 hours and pages Antonello on Telegram when the token has gone stale.
+  Self-contained Pro-local script (NOT git-tracked); snapshot at
+  docs/wr2/skill-snapshots/canva-oauth-watchdog-2026-05-08.md.
+
+  Cadence: 21600s (6h). Cooldown enforced inside the script
+  (24h between alerts; first transition healthy→stale always alerts).
+  StandardOutPath/StandardErrorPath route to ~/logs for forensic.
+
+  Install:
+    cp infra/launchagents/com.balizero.wr2.canva-oauth-watchdog.plist \
+       ~/Library/LaunchAgents/
+    launchctl bootstrap gui/$(id -u) \
+       ~/Library/LaunchAgents/com.balizero.wr2.canva-oauth-watchdog.plist
+
+  Plist permissions hardened to 0444 per cicatrix P0-3 (chmod u+w
+  before legitimate edits).
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.balizero.wr2.canva-oauth-watchdog</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/nuzantara/scripts/wr2-canva-oauth-watchdog.sh</string>
+    </array>
+
+    <!-- Periodic probe: every 6h. RunAtLoad seeds the first probe so we
+         do not wait 6h post-bootstrap to detect a stale token. -->
+    <key>StartInterval</key>
+    <integer>21600</integer>
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Run-to-completion script; no KeepAlive. exit code conveys state:
+         0 = healthy, 1 = stale (alert path), >1 = unexpected. -->
+
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/wr2-canva-oauth-watchdog.launchd.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/wr2-canva-oauth-watchdog.launchd.err.log</string>
+
+    <!-- HOME so $HOME expands inside the script. PATH includes
+         ~/.local/bin (claude CLI) plus the standard hierarchy used by
+         all WR2 plists. The script also sets its own PATH defensively
+         after sourcing TELEGRAM_* secrets. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <key>PATH</key>
+        <string>/Users/nuzantara/.local/bin:/Users/nuzantara/.npm-global/bin:/Users/nuzantara/.pyenv/versions/3.11.11/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <!-- Avoid tight respawn loops if the script keeps exiting 1. -->
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+</dict>
+</plist>

--- a/tests/lint/test_canva_oauth_watchdog.sh
+++ b/tests/lint/test_canva_oauth_watchdog.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# test_canva_oauth_watchdog.sh — TDD harness for the Canva OAuth
+# watchdog (Sprint B B-NEW, 2026-05-08).
+#
+# The watchdog itself is Pro-local at ~/scripts/wr2-canva-oauth-watchdog.sh
+# (NOT in this repo); the canonical body lives at
+# docs/wr2/skill-snapshots/canva-oauth-watchdog-2026-05-08.md.
+# These tests embed the script via the snapshot — extracting the bash
+# code block, writing it to a sandbox path, then running it with
+# isolated state + a stub `claude` binary so we exercise the three
+# code paths (healthy / stale-with-alert / stale-with-cooldown) without
+# touching real OAuth state, real Telegram, or real launchd.
+#
+# Run from repo root:
+#   bash tests/lint/test_canva_oauth_watchdog.sh
+# Exit 0 = all paths pass, 1 = any failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SNAPSHOT="$REPO_ROOT/docs/wr2/skill-snapshots/canva-oauth-watchdog-2026-05-08.md"
+
+if [[ ! -f "$SNAPSHOT" ]]; then
+  echo "FAIL: snapshot not found at $SNAPSHOT" >&2
+  exit 2
+fi
+
+TMP="$(mktemp -d -t canva_oauth_watchdog.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Extract the first ```bash fenced block from the snapshot (the script body).
+# Markdown-aware: matches '```bash' on a line, copies until the next ``` line.
+SCRIPT="$TMP/wr2-canva-oauth-watchdog.sh"
+awk '
+  /^```bash$/ { inside=1; next }
+  /^```$/    { if (inside) exit }
+  inside     { print }
+' "$SNAPSHOT" > "$SCRIPT"
+
+if [[ ! -s "$SCRIPT" ]]; then
+  echo "FAIL: could not extract bash body from $SNAPSHOT" >&2
+  exit 2
+fi
+chmod +x "$SCRIPT"
+
+# Override HOME so the script writes its log + state into the sandbox.
+export HOME="$TMP/home"
+mkdir -p "$HOME/.agent/decisions/state" "$HOME/logs" "$HOME/scripts"
+
+# Drop a stub `claude` binary the script will pick up via the test
+# PATH-prefix env var. STUB_OUTPUT controls what it echoes.
+STUB="$TMP/shim"
+mkdir -p "$STUB"
+cat > "$STUB/claude" <<'STUBSH'
+#!/usr/bin/env bash
+# Stub: emits the contents of $STUB_OUTPUT (or "stub_default" if unset).
+printf '%s\n' "${STUB_OUTPUT:-stub_default}"
+STUBSH
+chmod +x "$STUB/claude"
+export CANVA_WATCHDOG_TEST_PATH_PREFIX="$STUB"
+
+# No real Telegram even if a real token leaked in.
+export TELEGRAM_BOT_TOKEN=""
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    printf '  PASS: %-50s (got=%s)\n' "$label" "$actual"
+    PASS=$((PASS + 1))
+  else
+    printf '  FAIL: %-50s (expected=%s actual=%s)\n' "$label" "$expected" "$actual" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_grep() {
+  local label="$1" pattern="$2" file="$3"
+  if grep -qE "$pattern" "$file"; then
+    printf '  PASS: %-50s (matched /%s/)\n' "$label" "$pattern"
+    PASS=$((PASS + 1))
+  else
+    printf '  FAIL: %-50s (no match for /%s/ in %s)\n' "$label" "$pattern" "$file" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+reset_state() {
+  rm -f "$HOME/.agent/decisions/state/wr2_canva_oauth.state" \
+        "$HOME/.agent/decisions/state/wr2_canva_oauth.lock"
+}
+
+# Run the watchdog and capture exit code without tripping `set -e`.
+run_watchdog() {
+  set +e
+  rc=0
+  "$SCRIPT" >/dev/null 2>&1
+  rc=$?
+  set -e
+}
+
+state_get() {
+  local key="$1"
+  awk -F= -v k="$key" '$1==k {print $2}' \
+    "$HOME/.agent/decisions/state/wr2_canva_oauth.state" 2>/dev/null \
+    | tail -1
+}
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 1: healthy probe (count >= 30 → exit 0, state.healthy)
+# ─────────────────────────────────────────────────────────────────────
+echo "TEST 1: healthy probe"
+reset_state
+STUB_OUTPUT=33 run_watchdog
+assert_eq "healthy exit code" "0" "$rc"
+assert_eq "state.last_status" "healthy" "$(state_get last_status)"
+assert_eq "state.last_count" "33" "$(state_get last_count)"
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 2: first stale transition (no prior alert → alert fires)
+# ─────────────────────────────────────────────────────────────────────
+echo "TEST 2: first stale transition"
+reset_state
+STUB_OUTPUT=5 run_watchdog
+assert_eq "stale exit code" "1" "$rc"
+assert_eq "state.last_status" "stale" "$(state_get last_status)"
+assert_eq "state.last_count" "5" "$(state_get last_count)"
+LAST_ALERT="$(state_get last_alert_ts)"
+if [[ "$LAST_ALERT" =~ ^[0-9]+$ ]]; then
+  printf '  PASS: %-50s (epoch=%s)\n' "alert_ts written" "$LAST_ALERT"
+  PASS=$((PASS + 1))
+else
+  printf '  FAIL: alert_ts not numeric (got=%s)\n' "$LAST_ALERT" >&2
+  FAIL=$((FAIL + 1))
+fi
+assert_grep "log shows alert sent" \
+  "alert sent" "$HOME/logs/wr2-canva-oauth-watchdog.log"
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 3: stale + cooldown active (recent alert → suppression)
+# ─────────────────────────────────────────────────────────────────────
+echo "TEST 3: stale + cooldown active"
+reset_state
+NOW=$(date +%s)
+RECENT=$(( NOW - 3600 ))   # 1h ago, well within 24h cooldown
+cat > "$HOME/.agent/decisions/state/wr2_canva_oauth.state" <<EOF
+last_status=stale
+last_count=5
+last_check_ts=$RECENT
+last_alert_ts=$RECENT
+EOF
+STUB_OUTPUT=5 run_watchdog
+assert_eq "stale exit code" "1" "$rc"
+# alert_ts must NOT have been bumped; remains $RECENT.
+LAST_ALERT_AFTER="$(state_get last_alert_ts)"
+assert_eq "alert_ts unchanged (cooldown)" "$RECENT" "$LAST_ALERT_AFTER"
+assert_grep "log shows alert suppressed" \
+  "alert suppressed" "$HOME/logs/wr2-canva-oauth-watchdog.log"
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 4: stale + cooldown elapsed (>24h since last alert → fires again)
+# ─────────────────────────────────────────────────────────────────────
+echo "TEST 4: stale + cooldown elapsed"
+reset_state
+OLD=$(( NOW - 90000 ))     # 25h ago, cooldown elapsed
+cat > "$HOME/.agent/decisions/state/wr2_canva_oauth.state" <<EOF
+last_status=stale
+last_count=5
+last_check_ts=$OLD
+last_alert_ts=$OLD
+EOF
+STUB_OUTPUT=5 run_watchdog
+assert_eq "stale exit code" "1" "$rc"
+LAST_ALERT_AFTER="$(state_get last_alert_ts)"
+if [[ "$LAST_ALERT_AFTER" =~ ^[0-9]+$ ]] && (( LAST_ALERT_AFTER > OLD )); then
+  printf '  PASS: %-50s (was=%s now=%s)\n' "alert_ts bumped" "$OLD" "$LAST_ALERT_AFTER"
+  PASS=$((PASS + 1))
+else
+  printf '  FAIL: alert_ts not bumped (was=%s now=%s)\n' "$OLD" "$LAST_ALERT_AFTER" >&2
+  FAIL=$((FAIL + 1))
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 5: probe returns non-numeric (anomalous) → treated as stale
+# ─────────────────────────────────────────────────────────────────────
+echo "TEST 5: non-numeric probe output"
+reset_state
+STUB_OUTPUT="ERROR: API limit" run_watchdog
+assert_eq "stale exit code (non-numeric)" "1" "$rc"
+assert_eq "state.last_status (non-numeric)" "stale" "$(state_get last_status)"
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 6: probe returns 29 (just below MIN_TOOLS) → stale
+# ─────────────────────────────────────────────────────────────────────
+echo "TEST 6: probe returns 29 (below threshold)"
+reset_state
+STUB_OUTPUT=29 run_watchdog
+assert_eq "stale exit code (29)" "1" "$rc"
+assert_eq "state.last_count (29)" "29" "$(state_get last_count)"
+
+# ─────────────────────────────────────────────────────────────────────
+# Summary
+# ─────────────────────────────────────────────────────────────────────
+echo ""
+echo "RESULT: ${PASS} passed, ${FAIL} failed"
+if (( FAIL > 0 )); then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Sprint B Task 2 (B-NEW): build the Canva OAuth watchdog that probes every 6h whether \`claude -p\` subprocess sees ≥30 \`mcp__claude_ai_Canva__*\` tools loaded; on stale, fetches the re-auth URL via a second \`claude -p\` calling \`mcp__claude_ai_Canva__authenticate\` and Telegram-pages the operator with a click link. 24h cooldown between alerts; first healthy→stale transition always alerts.

**Why this replaces B1 (MCP pre-warm wrapper) and B2 (session keeper)**: 4 review streams (Codex/Gemini/DeepSeek/NotebookLM, 2026-05-07) independently rejected the \"MCP cache warming\" hypothesis. Empirical 4 datapoints from B0 telemetry showed the only consistent failure mode is OAuth token staleness, which \`claude -p\` cannot self-heal because re-auth is browser-interactive. A watchdog that pages an operator is the cheapest-correct mitigation.

## Files

| Path | Role | Tracked? |
|------|------|----------|
| \`~/scripts/wr2-canva-oauth-watchdog.sh\` | Live script body | **No** (Pro-local) |
| \`docs/wr2/skill-snapshots/canva-oauth-watchdog-2026-05-08.md\` | Repo-tracked snapshot of the script body + operator runbook | Yes |
| \`~/Library/LaunchAgents/com.balizero.wr2.canva-oauth-watchdog.plist\` | Live plist (StartInterval=21600, RunAtLoad=true, mode 0444 per cicatrix P0-3) | No |
| \`infra/launchagents/com.balizero.wr2.canva-oauth-watchdog.plist\` | Repo mirror | Yes |
| \`tests/lint/test_canva_oauth_watchdog.sh\` | Extracts bash body from snapshot, runs 6 scenarios with stub \`claude\` | Yes |
| \`docs/wr2/2026-05-08-sprint-b-to-f-detailed-plan.md\` | Replaces B1/B2 sections with the implemented B-NEW design | Yes (modified) |

The live script lives at \`~/scripts/\` (NOT in repo) by design — it touches Pro-local OAuth state in \`~/.mcp-auth/\` and reads \`~/.nuzantara-secrets.env\`. The snapshot is the audit trail.

## Test plan

- [x] \`bash tests/lint/test_canva_oauth_watchdog.sh\` — **17/17 assertions pass** across 6 scenarios (healthy / first stale → alert / stale + cooldown active → suppress / stale + cooldown elapsed → alert / non-numeric output / boundary count=29).
- [x] \`plutil -lint ~/Library/LaunchAgents/com.balizero.wr2.canva-oauth-watchdog.plist\` → OK
- [x] Live bootstrap on Pro 2026-05-08 04:32 WITA via \`launchctl bootstrap gui/\$(id -u)\`. Verified \`launchctl print\` shows \`run interval = 21600 seconds\`, \`last exit code = 0\`. RunAtLoad probe at 04:34:37 logged: \`OK: 32 mcp__claude_ai_Canva__* tools visible (>= 30)\`.
- [x] All 3 state-machine paths verified live via PATH-prefix stub (\`CANVA_WATCHDOG_TEST_PATH_PREFIX=/tmp/watchdog-shim\`) before bootstrap: healthy, stale-with-alert, stale-with-cooldown.
- [ ] Wait 6h, verify next-fire timestamp moved (next 04:34 WITA tomorrow → look for new log line).

## Build discoveries (documented in design doc + snapshot)

1. **Secrets-env poisons claude -p**: sourcing \`~/.nuzantara-secrets.env\` with \`set -a\` leaks env vars (likely \`OPENROUTER_API_KEY\` or \`MINIMAX_API_KEY\`) into the \`claude -p\` subprocess and silently makes the count probe return 0. Mitigated by extracting only \`TELEGRAM_BOT_TOKEN\` + \`TELEGRAM_OWNER_CHAT_ID\` via grep+cut.
2. **stdin closure mandatory**: without \`< /dev/null\`, \`claude -p\` emits a \"no stdin data received in 3s\" warning that lands on stdout and pollutes the captured tool count.
3. **PATH-prefix testing hook**: the script honors \`CANVA_WATCHDOG_TEST_PATH_PREFIX\` env var to let test harnesses inject a stub \`claude\` shim. Unset in production.

## Out of scope (follow-ups)

- The watchdog **alerts**, it does not **self-heal** — OAuth re-flow is browser-interactive by Canva MCP design. Operator must click the link.
- If we ever want self-heal, the right level is a Pro-side helper that opens the URL in a sandboxed Chrome with Canva session cookies + Hammerspoon focus assertion. Not in this PR; track as Sprint D candidate.
- The 6h cadence is conservative. If empirical data shows tokens drift in <6h, drop to 1h (StartInterval=3600) without code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)