### PR TITLE
feat(wr2): fact-stages NET-NEW + atomic deploy (Sprint B B-bis)

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/162_war_room_fact_check.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/162_war_room_fact_check.sql
@@ -1,0 +1,109 @@
+-- Migration 162: war_room fact-check columns
+--
+-- Sprint B B-bis (2026-05-08): re-enable the fact-extractor + fact-checker
+-- pipeline stages between image-generator and canva-apply.
+--
+-- Background: PR #299 (26 Apr) cut over the old 5-cron WR2 chain to the
+-- supervisor-driven event bus. fact-extractor + fact-checker plists
+-- moved to ~/Library/LaunchAgents/.disabled/ as a stop-gap because the
+-- TRANSITIONS dict still routed through them while their executable
+-- scripts (`scripts/wr2_fact_extractor.py`, `scripts/wr2_fact_checker.py`)
+-- did NOT exist on disk → silent kickstart failure → drafts stuck.
+--
+-- This migration adds the columns the new (NET-NEW, B-bis) executables
+-- need: a JSONB blob for extracted claims + verification details, a
+-- TEXT status (NULL until ran, then pass/fail/degraded), and a
+-- TIMESTAMPTZ for the fact-check event.
+--
+-- Decisions:
+--   * fact_check_json JSONB — unstructured because the claim shape will
+--     evolve (add per-claim sources, NB-INTEL doc IDs, confidence). A
+--     dedicated table per claim was rejected: 1 draft × 5-15 claims is
+--     small; querying a JSONB array via fact_check_json->'claims' is
+--     fine for the daily volume.
+--   * fact_check_status TEXT (CHECK NULL/pass/fail/degraded) — explicit
+--     over enum so adding states later (e.g. 'manual_review') is a
+--     CHECK-constraint diff instead of an ALTER TYPE migration.
+--   * fact_check_at TIMESTAMPTZ — wall-clock when fact-checker finished
+--     (NOT when extractor ran; extractor result lives in fact_check_json
+--     timestamps if needed).
+--
+-- Squawk: ADD COLUMN nullable on a populated table is safe (no rewrite,
+-- no ACCESS EXCLUSIVE upgrade). The CHECK constraint is added with
+-- NOT VALID + VALIDATE in two steps so the initial ADD doesn't scan the
+-- table; new rows are checked from inception, the validation pass scans
+-- without blocking writes.
+--
+-- ROLLBACK: drop the three columns. Any populated fact_check_json data
+-- is lost — by design, fact-check artifacts are reproducible from the
+-- source draft. Status downgrade ('drafts_imaged_checked' → 'drafts_imaged')
+-- is handled by the supervisor TRANSITIONS revert in this same PR, NOT
+-- here.
+
+-- =====================================================================
+-- 1. Add columns
+-- =====================================================================
+
+ALTER TABLE war_room_drafts
+    ADD COLUMN IF NOT EXISTS fact_check_json JSONB DEFAULT NULL;
+
+ALTER TABLE war_room_drafts
+    ADD COLUMN IF NOT EXISTS fact_check_status TEXT DEFAULT NULL;
+
+ALTER TABLE war_room_drafts
+    ADD COLUMN IF NOT EXISTS fact_check_at TIMESTAMPTZ DEFAULT NULL;
+
+-- =====================================================================
+-- 2. CHECK constraint on fact_check_status
+-- =====================================================================
+-- NOT VALID first → cheap; we know existing rows are NULL (just added).
+-- VALIDATE second → cheap because CHECK is on a fresh column.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+         WHERE conname = 'war_room_drafts_fact_check_status_chk'
+    ) THEN
+        ALTER TABLE war_room_drafts
+            ADD CONSTRAINT war_room_drafts_fact_check_status_chk
+            CHECK (fact_check_status IS NULL
+                   OR fact_check_status IN ('pass', 'fail', 'degraded'))
+            NOT VALID;
+        ALTER TABLE war_room_drafts
+            VALIDATE CONSTRAINT war_room_drafts_fact_check_status_chk;
+    END IF;
+END $$;
+
+-- =====================================================================
+-- 3. Index for fact-checker reads (status='drafts_imaged_facted' lookups)
+-- =====================================================================
+-- The fact-checker SELECTs WHERE status='drafts_imaged_facted'; the
+-- existing partial index on (status, created_at) covers it. No new
+-- index required.
+
+COMMENT ON COLUMN war_room_drafts.fact_check_json IS
+  'Extracted claims + per-claim verification (Sprint B B-bis, mig 162). '
+  'Shape: {claims: [{claim, slide_index, type, verdict?, note?, ...}]}';
+COMMENT ON COLUMN war_room_drafts.fact_check_status IS
+  'pass=all claims verified; degraded=some unverifiable; fail=discrepancies. '
+  'NULL until fact-checker runs.';
+COMMENT ON COLUMN war_room_drafts.fact_check_at IS
+  'When the fact-checker completed; NULL until then.';
+
+-- === ROLLBACK ===
+-- Soft rollback: drop the three columns. Any populated fact_check_json
+-- payloads are lost. Existing drafts in status='drafts_imaged_facted'
+-- or 'drafts_imaged_checked' must first be reset to 'drafts_imaged' by
+-- the operator (this script intentionally does NOT touch status, so a
+-- partial rollback doesn't corrupt the state machine).
+
+ALTER TABLE war_room_drafts
+    DROP CONSTRAINT IF EXISTS war_room_drafts_fact_check_status_chk;
+
+ALTER TABLE war_room_drafts
+    DROP COLUMN IF EXISTS fact_check_at;
+ALTER TABLE war_room_drafts
+    DROP COLUMN IF EXISTS fact_check_status;
+ALTER TABLE war_room_drafts
+    DROP COLUMN IF EXISTS fact_check_json;

--- a/docs/wr2/2026-05-08-sprint-b-to-f-detailed-plan.md
+++ b/docs/wr2/2026-05-08-sprint-b-to-f-detailed-plan.md
@@ -477,7 +477,66 @@ KeepAlive=true daemon, no schedule, RunAtLoad=true.
 
 **Effort**: 8h (3h supervisor patch + 4h watchdog + 1h E2E test).
 
-### B4 — Restore fact-extractor + fact-checker
+### B-bis — Fact-stages NET-NEW (SHIPPED 2026-05-08)
+
+**Status**: implemented in PR `feat/wr2-fact-stages-2026-05-08`.
+
+The original "B4 restore" was actually a **net-new build** — the launchd
+plists were disabled in PR #299 (26 Apr) but the executable scripts
+`scripts/wr2_fact_extractor.py` and `scripts/wr2_fact_checker.py` were
+never written; only stub plists existed. This PR ships them from scratch.
+
+**Files shipped**:
+- `apps/backend-rag/backend/db/migrations_v2/162_war_room_fact_check.sql` — adds 3 columns (`fact_check_json JSONB`, `fact_check_status TEXT` w/ CHECK constraint NULL/pass/fail/degraded, `fact_check_at TIMESTAMPTZ`); ROLLBACK marker; constraint added NOT VALID + VALIDATE in two steps so ADD COLUMN doesn't scan the table.
+- `scripts/wr2_fact_extractor.py` (NET-NEW) — Claude OPUS via OAuth subprocess (OB-3 invariant), per-slide claim extraction, JSON parser tolerates fenced + bare model output, 1 retry on parse failure → empty list (degrade-open). Sets `fact_check_json.claims` and advances status `drafts_imaged → drafts_imaged_facted`.
+- `scripts/wr2_fact_checker.py` (NET-NEW) — deterministic per-claim verifier (law / quote / number / date / other) + optional LLM cross-check that **only upgrades** unverifiable claims (cannot downgrade verified). Aggregation rules: any contradicted → `fail`, any unverifiable → `degraded`, all verified → `pass`. Empty claims → `pass` (vacuous truth, lets canva-apply consume).
+- `scripts/wr2_supervisor.py` — TRANSITIONS revert: `drafts_imaged → fact-extractor`, `drafts_imaged_facted → fact-checker`, `drafts_imaged_checked → canva-apply`. Same revert in `NONTERMINAL_TO_NEXT_STAGE` for the reconcile path.
+- `scripts/wr2_canva_apply.py` — status filter LOCKED to `drafts_imaged_checked` (no more Sprint A bypass accepting `drafts_imaged`/`drafts`).
+- `infra/launchagents/com.balizero.wr2.fact-extractor.plist` + `…wr2.fact-checker.plist` — NEW (replace the `.disabled/` stubs from PR #299; supervisor kicks via `launchctl kickstart` on transitions).
+- `scripts/tests/test_wr2_fact_extractor.py` — 13 tests (JSON parser fences/prose/garbage; claim type normalisation; OAuth error handling; pipeline persistence; OB-3 AST guard).
+- `scripts/tests/test_wr2_fact_checker.py` — 25 tests (per-claim verifier all 5 types; aggregation pass/fail/degraded; status transition mapping; LLM upgrade-only invariant; OB-3 AST guard).
+- `scripts/tests/test_wr2_supervisor.py` — `test_reconcile_kicks_stalled` now passes after the TRANSITIONS revert (it was failing on main since Sprint A).
+
+**Atomic deploy contract** (single PR, indivisible): supervisor TRANSITIONS revert + canva-apply status filter narrow + new scripts + new plists must land together. Splitting risks a window where canva-apply still consumes `drafts_imaged` while supervisor routes to `fact-extractor` (silent kickstart of a non-existent script before the deploy completes).
+
+**Bootstrap path (post-merge, manual operator step)**:
+```bash
+# 1. Apply migration 162 (auto via run-sql-v2-migrations-post-deploy on Fly).
+# 2. Set the kill-switches to enable the new stages:
+psql $DATABASE_URL -c "
+  INSERT INTO system_settings(key, value) VALUES
+    ('wr2_fact_extractor_enabled', 'true'),
+    ('wr2_fact_checker_enabled', 'true')
+  ON CONFLICT (key) DO UPDATE SET value=EXCLUDED.value;
+"
+# 3. Move plists out of .disabled/ + bootstrap (cicatrix P0-3: chmod 0444 after).
+mv ~/Library/LaunchAgents/.disabled/com.balizero.wr2.fact-extractor.plist \
+   ~/Library/LaunchAgents/
+mv ~/Library/LaunchAgents/.disabled/com.balizero.wr2.fact-checker.plist \
+   ~/Library/LaunchAgents/
+chmod u+w ~/Library/LaunchAgents/com.balizero.wr2.fact-{extractor,checker}.plist
+cp ~/Desktop/nuzantara/infra/launchagents/com.balizero.wr2.fact-extractor.plist \
+   ~/Library/LaunchAgents/
+cp ~/Desktop/nuzantara/infra/launchagents/com.balizero.wr2.fact-checker.plist \
+   ~/Library/LaunchAgents/
+plutil -lint ~/Library/LaunchAgents/com.balizero.wr2.fact-{extractor,checker}.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.balizero.wr2.fact-extractor.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.balizero.wr2.fact-checker.plist
+chmod 0444 ~/Library/LaunchAgents/com.balizero.wr2.fact-{extractor,checker}.plist
+# 4. Trigger one synthetic test run to verify the chain works end-to-end:
+launchctl kickstart gui/$(id -u)/com.balizero.wr2.fact-extractor
+# Watch logs:
+tail -f ~/logs/wr2_fact_extractor.log ~/logs/wr2_fact_checker.log ~/logs/wr2_canva_apply.log
+```
+
+**Rollback** (if a draft fails fact-checking and we need to ship without):
+```bash
+psql $DATABASE_URL -c "UPDATE system_settings SET value='false' WHERE key='wr2_fact_extractor_enabled';"
+# Then patch supervisor TRANSITIONS back to the Sprint A bypass (drafts_imaged → canva-apply)
+# and re-deploy. Migration 162 stays applied; the columns are nullable so canva-apply ignores them.
+```
+
+### B4 — Restore fact-extractor + fact-checker (ORIGINAL OUTLINE — superseded by B-bis above)
 
 **Scope**: ripristinare i 2 plist da `.disabled/` + restore TRANSITIONS chain. Sostituisce il bypass Sprint A.
 

--- a/infra/launchagents/com.balizero.wr2.fact-checker.plist
+++ b/infra/launchagents/com.balizero.wr2.fact-checker.plist
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.balizero.wr2.fact-checker — Sprint B B-bis (2026-05-08).
+
+  Run-on-kickstart only (no schedule). The supervisor calls
+  `launchctl kickstart` whenever a draft transitions to status
+  'drafts_imaged_facted'. The script self-throttles to
+  MAX_DRAFTS_PER_RUN=3.
+
+  Mirror of com.balizero.wr2.fact-extractor — both replace the
+  .disabled/ stubs from PR #299 (26 Apr) now that the scripts exist.
+
+  Install:
+    cp infra/launchagents/com.balizero.wr2.fact-checker.plist \
+       ~/Library/LaunchAgents/
+    launchctl bootstrap gui/$(id -u) \
+       ~/Library/LaunchAgents/com.balizero.wr2.fact-checker.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.balizero.wr2.fact-checker</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/nuzantara/.openclaw/bin/wr2/wr2-script-wrapper.sh</string>
+        <string>scripts/wr2_fact_checker.py</string>
+    </array>
+
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/wr2_fact_checker.launchd.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/wr2_fact_checker.launchd.err.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <key>PATH</key>
+        <string>/Users/nuzantara/.local/bin:/Users/nuzantara/.npm-global/bin:/Users/nuzantara/.pyenv/versions/3.11.11/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/infra/launchagents/com.balizero.wr2.fact-extractor.plist
+++ b/infra/launchagents/com.balizero.wr2.fact-extractor.plist
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.balizero.wr2.fact-extractor — Sprint B B-bis (2026-05-08).
+
+  Run-on-kickstart only (no schedule). The supervisor calls
+  `launchctl kickstart` whenever a draft transitions to status
+  'drafts_imaged'. The script self-throttles to MAX_DRAFTS_PER_RUN=3.
+
+  This plist replaces the .disabled/ stub from PR #299 (26 Apr) — both
+  the script (scripts/wr2_fact_extractor.py) and the launchd config are
+  now in tree.
+
+  Install:
+    cp infra/launchagents/com.balizero.wr2.fact-extractor.plist \
+       ~/Library/LaunchAgents/
+    launchctl bootstrap gui/$(id -u) \
+       ~/Library/LaunchAgents/com.balizero.wr2.fact-extractor.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.balizero.wr2.fact-extractor</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/nuzantara/.openclaw/bin/wr2/wr2-script-wrapper.sh</string>
+        <string>scripts/wr2_fact_extractor.py</string>
+    </array>
+
+    <!-- No RunAtLoad: supervisor kicks via launchctl kickstart on
+         status transitions. RunAtLoad=true would run the script at
+         boot before there are any drafts to process — wasteful but
+         harmless (it would exit cleanly after seeing zero drafts). -->
+
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/wr2_fact_extractor.launchd.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/wr2_fact_extractor.launchd.err.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <key>PATH</key>
+        <string>/Users/nuzantara/.local/bin:/Users/nuzantara/.npm-global/bin:/Users/nuzantara/.pyenv/versions/3.11.11/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/tests/test_wr2_fact_checker.py
+++ b/scripts/tests/test_wr2_fact_checker.py
@@ -1,0 +1,345 @@
+"""Unit tests for scripts/wr2_fact_checker.py (Sprint B B-bis).
+
+Covers:
+- Per-claim deterministic verifier (law / quote / number / date / other)
+- _aggregate_status (pass / degraded / fail rules)
+- Status transition mapping (fail → fact_check_failed; pass/degraded → drafts_imaged_checked)
+- LLM cross-check upgrades only unverifiable, never downgrades verified
+- OB-3 invariant guard
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+CHECKER_PATH = SCRIPTS_DIR / "wr2_fact_checker.py"
+
+
+@pytest.fixture
+def fc(tmp_path):
+    sys.modules.pop("wr2_fact_checker", None)
+    spec = importlib.util.spec_from_file_location("wr2_fact_checker", CHECKER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["wr2_fact_checker"] = mod
+    spec.loader.exec_module(mod)
+    mod.TELEMETRY_PATH = tmp_path / "checker.jsonl"
+    return mod
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Per-claim verifier (deterministic)
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_verify_law_claim_exact_citation_match(fc):
+    src_laws = {"PP 28/2025", "PMK 81/2024"}
+    out = fc._verify_law_claim("Reference: PP 28/2025 supersedes PP 5/2021", src_laws, "PP 28/2025 text")
+    assert out["verdict"] == "verified"
+
+
+def test_verify_law_claim_unknown_citation(fc):
+    out = fc._verify_law_claim("Reference: XYZ 999/9999", set(), "PP 28/2025 text")
+    assert out["verdict"] == "unverifiable"
+
+
+def test_verify_law_claim_substring_fallback(fc):
+    out = fc._verify_law_claim("subhi office", set(), "subhi office is in Kerobokan")
+    assert out["verdict"] == "verified"
+
+
+def test_verify_quote_claim_exact_match(fc):
+    out = fc._verify_quote_claim("we will streamline the process", "Bimo said: we will streamline the process today")
+    assert out["verdict"] == "verified"
+
+
+def test_verify_quote_claim_smart_quotes(fc):
+    """Smart-quote-wrapped claim should match plain source."""
+    out = fc._verify_quote_claim("“we will streamline”", "Bimo: we will streamline today")
+    assert out["verdict"] == "verified"
+
+
+def test_verify_quote_claim_not_found_unverifiable(fc):
+    out = fc._verify_quote_claim("never said this exact thing", "completely different source text")
+    assert out["verdict"] == "unverifiable"
+
+
+def test_verify_number_match(fc):
+    out = fc._verify_number_or_date_claim("rate is 1.5 percent", "rate is 1.5 percent across all categories", "number")
+    assert out["verdict"] == "verified"
+
+
+def test_verify_number_drift_contradicted(fc):
+    out = fc._verify_number_or_date_claim("rate is 999 percent", "actual rate is 1.5 across all categories", "number")
+    assert out["verdict"] == "contradicted"
+
+
+def test_verify_number_partial_match_unverifiable(fc):
+    out = fc._verify_number_or_date_claim("rates are 1.5 and 88", "rate is 1.5 percent only", "number")
+    assert out["verdict"] == "unverifiable"
+
+
+def test_verify_date_year_match(fc):
+    out = fc._verify_number_or_date_claim("deadline 2026", "deadline year 2026 confirmed", "date")
+    assert out["verdict"] == "verified"
+
+
+def test_verify_date_drift_contradicted(fc):
+    out = fc._verify_number_or_date_claim("deadline 2030", "deadline 2026 confirmed", "date")
+    assert out["verdict"] == "contradicted"
+
+
+def test_verify_other_substring(fc):
+    out = fc._verify_other_claim("Bali Zero Kerobokan office", "office at Bali Zero Kerobokan, Jl. Raya")
+    assert out["verdict"] == "verified"
+
+
+def test_verify_other_token_overlap_60pct(fc):
+    """≥60% of >3-char tokens present → verified."""
+    out = fc._verify_other_claim(
+        "Indonesian taxation regulation deadline",
+        "the Indonesian regulation specifies deadline rules for taxation purposes"
+    )
+    assert out["verdict"] == "verified"
+
+
+def test_verify_other_low_overlap_unverifiable(fc):
+    out = fc._verify_other_claim(
+        "completely unrelated nonsense gibberish words",
+        "the Indonesian regulation about taxation"
+    )
+    assert out["verdict"] == "unverifiable"
+
+
+def test_verify_claim_dispatches_by_type(fc):
+    """_verify_claim picks the right helper per claim['type']."""
+    src_text = "The PP 28/2025 deadline is 2026"
+    src_laws = fc._find_law_citations(src_text)
+    # law
+    law_out = fc._verify_claim(
+        {"claim": "PP 28/2025", "type": "law"}, src_text, src_laws
+    )
+    assert law_out["verdict"] == "verified"
+    # date
+    date_out = fc._verify_claim(
+        {"claim": "deadline 2026", "type": "date"}, src_text, src_laws
+    )
+    assert date_out["verdict"] == "verified"
+    # other
+    other_out = fc._verify_claim(
+        {"claim": "deadline", "type": "other"}, src_text, src_laws
+    )
+    assert other_out["verdict"] == "verified"
+
+
+def test_verify_claim_empty_text_unverifiable(fc):
+    out = fc._verify_claim({"claim": "", "type": "law"}, "src", set())
+    assert out["verdict"] == "unverifiable"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Aggregation
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_aggregate_pass_when_all_verified(fc):
+    claims = [
+        {"verdict": "verified"},
+        {"verdict": "verified"},
+    ]
+    assert fc._aggregate_status(claims) == "pass"
+
+
+def test_aggregate_fail_when_any_contradicted(fc):
+    claims = [
+        {"verdict": "verified"},
+        {"verdict": "contradicted"},
+        {"verdict": "verified"},
+    ]
+    assert fc._aggregate_status(claims) == "fail"
+
+
+def test_aggregate_degraded_when_unverifiable_no_contradicted(fc):
+    claims = [
+        {"verdict": "verified"},
+        {"verdict": "unverifiable"},
+    ]
+    assert fc._aggregate_status(claims) == "degraded"
+
+
+def test_aggregate_pass_when_no_claims(fc):
+    """Vacuously true: empty claims list → pass (lets canva-apply consume it)."""
+    assert fc._aggregate_status([]) == "pass"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Status transition mapping
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_persist_checked_pass_advances_to_drafts_imaged_checked(fc):
+    draft_id = uuid.uuid4()
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    asyncio.run(
+        fc._persist_checked(
+            conn, draft_id, {"claims": []}, "pass"
+        )
+    )
+    conn.execute.assert_awaited_once()
+    args = conn.execute.call_args[0]
+    # 4th positional arg is the new status.
+    assert args[4] == "drafts_imaged_checked"
+    assert args[3] == "pass"
+
+
+def test_persist_checked_fail_advances_to_fact_check_failed(fc):
+    draft_id = uuid.uuid4()
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    asyncio.run(
+        fc._persist_checked(
+            conn, draft_id, {"claims": [{"verdict": "contradicted"}]}, "fail"
+        )
+    )
+    args = conn.execute.call_args[0]
+    assert args[4] == "fact_check_failed"
+
+
+def test_persist_checked_degraded_still_proceeds_to_canva_apply(fc):
+    """degraded is NOT a terminal state — canva-apply consumes it."""
+    draft_id = uuid.uuid4()
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    asyncio.run(
+        fc._persist_checked(
+            conn, draft_id, {"claims": [{"verdict": "unverifiable"}]}, "degraded"
+        )
+    )
+    args = conn.execute.call_args[0]
+    assert args[4] == "drafts_imaged_checked"
+    assert args[3] == "degraded"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# End-to-end per-draft pipeline
+# ─────────────────────────────────────────────────────────────────────────
+
+def _make_facted_row(draft_id: uuid.UUID, claims: list[dict], source: str) -> dict:
+    return {
+        "id": draft_id,
+        "topic": "T",
+        "register": "pedagogico",
+        "slides_json": {"slides": [{"index": 1, "title": "X", "body": source}]},
+        "research_json": {"text": source},
+        "council_debate_json": None,
+        "fact_check_json": {"claims": claims, "extracted_at": "2026-05-08T00:00:00+00:00"},
+    }
+
+
+def test_process_one_draft_pass(fc):
+    draft_id = uuid.uuid4()
+    src = "PP 28/2025 establishes 1.5% rate for 2026"
+    row = _make_facted_row(draft_id, [
+        {"claim": "PP 28/2025", "slide_index": 1, "type": "law", "context": ""},
+        {"claim": "rate 1.5", "slide_index": 1, "type": "number", "context": ""},
+    ], src)
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    ok = asyncio.run(fc._process_one_draft(conn, row, llm_enabled=False))
+    assert ok is True
+    args = conn.execute.call_args[0]
+    assert args[3] == "pass"
+    assert args[4] == "drafts_imaged_checked"
+
+
+def test_process_one_draft_fail(fc):
+    draft_id = uuid.uuid4()
+    src = "actual rate is 1.5 percent"
+    row = _make_facted_row(draft_id, [
+        {"claim": "rate 999 percent", "slide_index": 1, "type": "number", "context": ""},
+    ], src)
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    with patch.object(fc, "_send_telegram", lambda *_a, **_kw: None):
+        ok = asyncio.run(fc._process_one_draft(conn, row, llm_enabled=False))
+    assert ok is False  # fail outcome → False so caller can count
+    args = conn.execute.call_args[0]
+    assert args[3] == "fail"
+    assert args[4] == "fact_check_failed"
+
+
+def test_process_one_draft_handles_string_blobs(fc):
+    """asyncpg may return JSONB columns as either dict or str (depending on conn config)."""
+    draft_id = uuid.uuid4()
+    row = {
+        "id": draft_id,
+        "topic": "T",
+        "register": "pedagogico",
+        "slides_json": json.dumps({"slides": [{"index": 1, "title": "X", "body": "PP 28/2025"}]}),
+        "research_json": json.dumps({"text": "PP 28/2025"}),
+        "council_debate_json": None,
+        "fact_check_json": json.dumps({"claims": [{"claim": "PP 28/2025", "slide_index": 1, "type": "law"}]}),
+    }
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    ok = asyncio.run(fc._process_one_draft(conn, row, llm_enabled=False))
+    assert ok is True
+    args = conn.execute.call_args[0]
+    assert args[3] == "pass"
+
+
+def test_llm_cross_check_only_upgrades_unverifiable(fc):
+    """LLM verdict 'verified' upgrades unverifiable claim; cannot downgrade verified."""
+    draft_id = uuid.uuid4()
+    row = _make_facted_row(draft_id, [
+        # Will be unverifiable deterministically (low token overlap)
+        {"claim": "obscure paraphrase no match", "slide_index": 1, "type": "other", "context": ""},
+    ], "completely different source text")
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    fake_llm = AsyncMock(return_value={"verdict": "verified", "note": "LLM says match"})
+    with patch.object(fc, "_llm_verify_claim", fake_llm):
+        ok = asyncio.run(fc._process_one_draft(conn, row, llm_enabled=True))
+    assert ok is True
+    args = conn.execute.call_args[0]
+    # After upgrade, status should be 'pass' not 'degraded'.
+    assert args[3] == "pass"
+
+
+def test_llm_cross_check_skipped_for_already_verified(fc):
+    """If deterministic verifier already says 'verified', don't waste an LLM call."""
+    draft_id = uuid.uuid4()
+    row = _make_facted_row(draft_id, [
+        {"claim": "PP 28/2025", "slide_index": 1, "type": "law"},
+    ], "PP 28/2025 text")
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    llm_mock = AsyncMock()
+    with patch.object(fc, "_llm_verify_claim", llm_mock):
+        asyncio.run(fc._process_one_draft(conn, row, llm_enabled=True))
+    llm_mock.assert_not_awaited()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# OB-3 invariant guard
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_uses_claude_oauth_client_not_anthropic_sdk():
+    """OB-3 hard rule via AST inspection (mirrors fact-extractor test)."""
+    import ast
+    tree = ast.parse(CHECKER_PATH.read_text())
+    used_oauth_client = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert not alias.name.startswith("anthropic")
+        if isinstance(node, ast.ImportFrom):
+            assert not (node.module or "").startswith("anthropic")
+            if node.module and node.module.endswith("claude_oauth_client"):
+                used_oauth_client = True
+    assert used_oauth_client

--- a/scripts/tests/test_wr2_fact_extractor.py
+++ b/scripts/tests/test_wr2_fact_extractor.py
@@ -1,0 +1,287 @@
+"""Unit tests for scripts/wr2_fact_extractor.py (Sprint B B-bis).
+
+Covers:
+- JSON parser tolerates fenced + bare model output
+- Claim type normalisation (rejects unknown types → 'other')
+- Empty / malformed responses produce [] (degrade-open)
+- _process_one_draft persists status='drafts_imaged_facted' on success
+- OAuth failure → returns False, no DB mutation, telemetry recorded
+
+All Claude calls + DB writes are mocked.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+EXTRACTOR_PATH = SCRIPTS_DIR / "wr2_fact_extractor.py"
+
+
+@pytest.fixture
+def fx(tmp_path, monkeypatch):
+    """Fresh import with telemetry redirected to tmp."""
+    sys.modules.pop("wr2_fact_extractor", None)
+    spec = importlib.util.spec_from_file_location("wr2_fact_extractor", EXTRACTOR_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["wr2_fact_extractor"] = mod
+    spec.loader.exec_module(mod)
+    mod.TELEMETRY_PATH = tmp_path / "extractor.jsonl"
+    return mod
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# JSON parser
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_parse_claims_json_bare_object(fx):
+    raw = '{"claims": [{"claim": "PP 28/2025", "slide_index": 2, "type": "law"}]}'
+    out = fx._parse_claims_json(raw, slide_index=2)
+    assert out is not None
+    assert len(out) == 1
+    assert out[0]["claim"] == "PP 28/2025"
+    assert out[0]["type"] == "law"
+    assert out[0]["slide_index"] == 2
+
+
+def test_parse_claims_json_fenced(fx):
+    raw = '```json\n{"claims": [{"claim": "1.5%", "slide_index": 3, "type": "number"}]}\n```'
+    out = fx._parse_claims_json(raw, slide_index=3)
+    assert out is not None and len(out) == 1
+    assert out[0]["type"] == "number"
+
+
+def test_parse_claims_json_with_prose(fx):
+    """Tolerate model wrapping JSON in commentary."""
+    raw = (
+        "Here are the claims:\n"
+        '{"claims": [{"claim": "31 May 2026", "slide_index": 1, "type": "date"}]}\n'
+        "Hope this helps!"
+    )
+    out = fx._parse_claims_json(raw, slide_index=1)
+    assert out is not None and len(out) == 1
+    assert out[0]["type"] == "date"
+
+
+def test_parse_claims_json_empty_list(fx):
+    raw = '{"claims": []}'
+    out = fx._parse_claims_json(raw, slide_index=0)
+    assert out == []
+
+
+def test_parse_claims_json_unknown_type_normalised(fx):
+    """Unknown types collapse to 'other' rather than rejecting the claim."""
+    raw = '{"claims": [{"claim": "X", "slide_index": 0, "type": "weird"}]}'
+    out = fx._parse_claims_json(raw, slide_index=0)
+    assert out is not None and len(out) == 1
+    assert out[0]["type"] == "other"
+
+
+def test_parse_claims_json_missing_claim_text_dropped(fx):
+    raw = '{"claims": [{"claim": "", "slide_index": 0, "type": "law"}, {"claim": "ok", "slide_index": 0, "type": "law"}]}'
+    out = fx._parse_claims_json(raw, slide_index=0)
+    assert out is not None and len(out) == 1
+    assert out[0]["claim"] == "ok"
+
+
+def test_parse_claims_json_garbage_returns_none(fx):
+    """Callers retry on None — never on []."""
+    assert fx._parse_claims_json("totally not json", slide_index=0) is None
+    assert fx._parse_claims_json("", slide_index=0) is None
+    assert fx._parse_claims_json("{invalid", slide_index=0) is None
+
+
+def test_parse_claims_json_invalid_slide_index_falls_back(fx):
+    raw = '{"claims": [{"claim": "X", "slide_index": "not-a-number", "type": "law"}]}'
+    out = fx._parse_claims_json(raw, slide_index=7)
+    assert out is not None and out[0]["slide_index"] == 7
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Per-slide extraction
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_extract_one_slide_empty_body_returns_empty(fx):
+    out = asyncio.run(
+        fx._extract_one_slide(
+            topic="x",
+            register="pedagogico",
+            slide={"index": 1, "title": "T", "body": ""},
+            model="claude-opus-4-7",
+            timeout_s=60,
+        )
+    )
+    assert out == []
+
+
+def test_extract_one_slide_retry_on_parse_failure(fx):
+    """First response is unparseable → retry → succeed."""
+    fake_resp_bad = MagicMock()
+    fake_resp_bad.text = "not json"
+    fake_resp_good = MagicMock()
+    fake_resp_good.text = '{"claims": [{"claim": "Y", "slide_index": 4, "type": "other"}]}'
+    mock = AsyncMock(side_effect=[fake_resp_bad, fake_resp_good])
+    with patch.object(fx, "complete_async", mock):
+        out = asyncio.run(
+            fx._extract_one_slide(
+                topic="t", register="p",
+                slide={"index": 4, "title": "T", "body": "some body"},
+                model="claude-opus-4-7", timeout_s=60,
+            )
+        )
+    assert mock.await_count == 2
+    assert len(out) == 1 and out[0]["claim"] == "Y"
+
+
+def test_extract_one_slide_persistent_parse_failure_returns_empty(fx):
+    """After 2 retries with bad JSON, return empty (degrade-open)."""
+    bad = MagicMock()
+    bad.text = "still not json"
+    mock = AsyncMock(side_effect=[bad, bad])
+    with patch.object(fx, "complete_async", mock):
+        out = asyncio.run(
+            fx._extract_one_slide(
+                topic="t", register="p",
+                slide={"index": 0, "title": "T", "body": "body"},
+                model="claude-opus-4-7", timeout_s=60,
+            )
+        )
+    assert mock.await_count == 2
+    assert out == []
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Per-draft pipeline
+# ─────────────────────────────────────────────────────────────────────────
+
+def _make_row(draft_id: uuid.UUID, slides: list[dict] | None = None) -> dict:
+    return {
+        "id": draft_id,
+        "topic": "Test topic",
+        "register": "pedagogico",
+        "slides_json": {"slides": slides or [{"index": 1, "title": "T", "body": "B"}]},
+    }
+
+
+def test_process_one_draft_success_persists_facted(fx):
+    """Happy path: claims extracted, status advances to drafts_imaged_facted."""
+    draft_id = uuid.uuid4()
+    row = _make_row(draft_id, slides=[
+        {"index": 1, "title": "T1", "body": "Body with PP 28/2025"},
+        {"index": 2, "title": "T2", "body": "Body 2"},
+    ])
+
+    fake_resp = MagicMock()
+    fake_resp.text = '{"claims": [{"claim": "PP 28/2025", "slide_index": 1, "type": "law"}]}'
+
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+
+    with patch.object(fx, "complete_async", AsyncMock(return_value=fake_resp)):
+        ok = asyncio.run(fx._process_one_draft(conn, row))
+
+    assert ok is True
+    conn.execute.assert_awaited_once()
+    args = conn.execute.call_args[0]
+    sql = args[0]
+    assert "fact_check_json" in sql
+    assert "drafts_imaged_facted" in sql
+    # Verify draft_id passed.
+    assert args[1] == draft_id
+    # Verify payload contains the claims.
+    payload = json.loads(args[2])
+    assert "claims" in payload
+    assert len(payload["claims"]) == 2  # one per slide
+    assert all(c["type"] == "law" for c in payload["claims"])
+
+
+def test_process_one_draft_oauth_error_returns_false(fx):
+    """OAuth subprocess failure → no DB write, telemetry recorded, return False."""
+    draft_id = uuid.uuid4()
+    row = _make_row(draft_id)
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+
+    err = fx.ClaudeOAuthError("rate limited on all tokens")
+    with patch.object(fx, "complete_async", AsyncMock(side_effect=err)), \
+         patch.object(fx, "_send_telegram", lambda *_a, **_kw: None):
+        ok = asyncio.run(fx._process_one_draft(conn, row))
+
+    assert ok is False
+    conn.execute.assert_not_awaited()
+    # Telemetry has 'oauth_error' row.
+    tel_lines = fx.TELEMETRY_PATH.read_text().splitlines() if fx.TELEMETRY_PATH.is_file() else []
+    assert any('"outcome": "oauth_error"' in line for line in tel_lines)
+
+
+def test_process_one_draft_no_slides_returns_false(fx):
+    draft_id = uuid.uuid4()
+    row = {
+        "id": draft_id,
+        "topic": "T",
+        "register": "pedagogico",
+        "slides_json": {"slides": []},
+    }
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    ok = asyncio.run(fx._process_one_draft(conn, row))
+    assert ok is False
+    conn.execute.assert_not_awaited()
+
+
+def test_process_one_draft_handles_string_slides_json(fx):
+    """slides_json may arrive as a JSON string from asyncpg."""
+    draft_id = uuid.uuid4()
+    row = {
+        "id": draft_id,
+        "topic": "T",
+        "register": "pedagogico",
+        "slides_json": json.dumps({"slides": [{"index": 1, "title": "X", "body": "Y"}]}),
+    }
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    fake_resp = MagicMock()
+    fake_resp.text = '{"claims": []}'
+    with patch.object(fx, "complete_async", AsyncMock(return_value=fake_resp)):
+        ok = asyncio.run(fx._process_one_draft(conn, row))
+    assert ok is True
+    conn.execute.assert_awaited_once()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# OB-3 invariant guard
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_uses_claude_oauth_client_not_anthropic_sdk():
+    """OB-3 hard rule: never import anthropic / never use ANTHROPIC_API_KEY.
+
+    The docstring/comments mention ANTHROPIC_API_KEY in the prohibition
+    paragraph, so this test parses with `ast` and only inspects code
+    nodes (Import / ImportFrom / Name lookup) rather than raw text.
+    """
+    import ast
+    tree = ast.parse(EXTRACTOR_PATH.read_text())
+    used_oauth_client = False
+    for node in ast.walk(tree):
+        # Forbid `import anthropic` / `from anthropic ...`
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert not alias.name.startswith("anthropic"), (
+                    f"OB-3 violation: import anthropic at line {node.lineno}"
+                )
+        if isinstance(node, ast.ImportFrom):
+            assert not (node.module or "").startswith("anthropic"), (
+                f"OB-3 violation: from anthropic import at line {node.lineno}"
+            )
+            if node.module and node.module.endswith("claude_oauth_client"):
+                used_oauth_client = True
+        # Forbid os.environ access of ANTHROPIC_API_KEY in code (not strings).
+        # We inspect Subscript / Call patterns over the env lookup.
+    assert used_oauth_client, "must import from claude_oauth_client"

--- a/scripts/wr2_canva_apply.py
+++ b/scripts/wr2_canva_apply.py
@@ -159,16 +159,18 @@ async def _kill_switch_enabled(conn: asyncpg.Connection) -> bool:
 
 
 async def _fetch_ready_drafts(conn: asyncpg.Connection, limit: int) -> list[asyncpg.Record]:
-    # 2026-05-07: aligned with wr2_canva_desktop_apply (PR #341 fix).
+    # 2026-05-08 (Sprint B B-bis): status filter LOCKED to
+    # 'drafts_imaged_checked'. The Sprint A bypass that allowed
+    # 'drafts_imaged' / 'drafts' here is REVERTED — only fact-checked
+    # drafts render. fact_check_status='fail' drafts land in
+    # 'fact_check_failed' terminal state and are NOT picked up.
+    #
     # DB column is `register` (text), aliased to `tone` for downstream code.
-    # Status filter widened to include 'drafts_imaged' since fact-checker
-    # and fact-extractor stages are disabled (.disabled/) and canva-apply
-    # consumes drafts directly after image-generator.
     return await conn.fetch(
         """
         SELECT id, topic, register AS tone, slides_json
           FROM war_room_drafts
-         WHERE status IN ('drafts_imaged', 'drafts')
+         WHERE status = 'drafts_imaged_checked'
            AND canva_edit_url IS NULL
          ORDER BY created_at ASC
          LIMIT $1

--- a/scripts/wr2_fact_checker.py
+++ b/scripts/wr2_fact_checker.py
@@ -1,0 +1,619 @@
+#!/usr/bin/env python3
+"""WR2 Fact Checker — Sprint B B-bis (2026-05-08).
+
+Reads `war_room_drafts` rows in status='drafts_imaged_facted', verifies
+each claim previously extracted by `wr2_fact_extractor.py`, then sets:
+
+    fact_check_status = 'pass'      → all claims verified
+                      = 'degraded'  → some unverifiable but no contradiction
+                      = 'fail'      → at least one claim contradicts source
+
+    status            = 'drafts_imaged_checked'  (pass / degraded)
+                      = 'fact_check_failed'      (fail)
+
+This is a NET-NEW build — the original wr2_fact_checker.py was never
+written. Re-enables the chain so canva-apply only renders fact-checked
+drafts (Sprint B B-bis decision: lock canva-apply filter to
+`status = 'drafts_imaged_checked'`).
+
+Verification strategy (per-claim, deterministic + LLM-cross-check):
+
+1. For 'law' claims (regex match like ``PP\\s\\d+/\\d{4}``,
+   ``PMK\\s\\d+/\\d{4}``, ``KEP-\\d+/PJ/\\d{4}``):
+    - String-match the law citation in the slide body and the original
+      research_json (if present). If found verbatim → 'verified'.
+    - If only paraphrased, OPUS cross-check against the source text.
+
+2. For 'number' / 'date' claims:
+    - Match against research_json (where the draft generator pulled
+      facts) and/or council_debate_json. If consistent → 'verified'.
+    - If discrepancy >0 (number drift, year mismatch) → 'contradicted'.
+
+3. For 'quote' claims:
+    - String-substring match in research_json. If exact → 'verified',
+      else 'unverifiable' (no auto-contradicted; quotes paraphrase often).
+
+4. For 'other':
+    - Best-effort: present in research_json text → 'verified', else
+      'unverifiable'.
+
+Aggregation:
+    contradicted_count > 0  → fact_check_status = 'fail'
+    unverifiable_count > 0  → 'degraded'
+    all verified            → 'pass'
+
+The verification per claim is recorded into
+`fact_check_json.claims[i].verdict` ∈ {verified, contradicted, unverifiable}
+plus `fact_check_json.claims[i].note`.
+
+Kill switch
+    `system_settings.wr2_fact_checker_enabled` = 'true'.
+
+Anthropic invariant (OB-3): OPUS calls go through claude_oauth_client.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+# Make backend-rag importable when run from repo root.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "apps" / "backend-rag"))
+
+import asyncpg  # noqa: E402
+
+from backend.llm.claude_oauth_client import (  # noqa: E402
+    ClaudeOAuthError,
+    ClaudeOAuthNotAvailable,
+    complete_async,
+)
+
+logger = logging.getLogger("wr2.fact_checker")
+
+# Tunables
+MAX_DRAFTS_PER_RUN = int(os.environ.get("WR2_FACT_CHECKER_BATCH", "3"))
+DEFAULT_MODEL = os.environ.get("WR2_FACT_CHECKER_MODEL", "claude-opus-4-7")
+DEFAULT_TIMEOUT_S = int(os.environ.get("WR2_FACT_CHECKER_TIMEOUT_S", "120"))
+TELEMETRY_PATH = Path.home() / "logs" / "wr2_fact_checker_telemetry.jsonl"
+
+# Law regexes — compiled once.
+LAW_PATTERNS = [
+    re.compile(r"\bPP\s+\d+/\d{4}\b", re.IGNORECASE),
+    re.compile(r"\bPMK\s+\d+/\d{4}\b", re.IGNORECASE),
+    re.compile(r"\bKEP-\d+/PJ/\d{4}\b", re.IGNORECASE),
+    re.compile(r"\bPENG-\d+/PJ\.\d+/\d{4}\b", re.IGNORECASE),
+    re.compile(r"\bUU\s+\d+/\d{4}\b", re.IGNORECASE),
+    re.compile(r"\bPerbup\s+\d+/\d{4}\b", re.IGNORECASE),
+    re.compile(r"\bPerda\s+\d+/\d{4}\b", re.IGNORECASE),
+]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Logging + Telegram (mirror of wr2_fact_extractor)
+# ─────────────────────────────────────────────────────────────────────────
+
+def _configure_logging() -> None:
+    log_dir = Path.home() / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    fmt = logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
+    fh = logging.FileHandler(str(log_dir / "wr2_fact_checker.log"))
+    fh.setFormatter(fmt)
+    sh = logging.StreamHandler(sys.stderr)
+    sh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.addHandler(fh)
+    root.addHandler(sh)
+
+
+def _send_telegram(text: str) -> None:
+    token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+    chat_id = os.environ.get("TELEGRAM_OWNER_CHAT_ID", "1125336968")
+    if not token:
+        return
+    try:
+        import urllib.parse
+        import urllib.request
+
+        data = urllib.parse.urlencode(
+            {"chat_id": chat_id, "text": text, "parse_mode": "Markdown"}
+        ).encode()
+        urllib.request.urlopen(  # noqa: S310 — known URL
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            data,
+            timeout=10,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Telegram send failed: %s", e)
+
+
+def _log_telemetry(record: dict) -> None:
+    try:
+        TELEMETRY_PATH.parent.mkdir(parents=True, exist_ok=True)
+        record.setdefault("ts", datetime.now(timezone.utc).isoformat())
+        with open(TELEMETRY_PATH, "a") as f:
+            f.write(json.dumps(record) + "\n")
+    except Exception as e:  # noqa: BLE001
+        logger.warning("telemetry write failed (non-fatal): %s", e)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Source-text helpers
+# ─────────────────────────────────────────────────────────────────────────
+
+def _extract_source_text(
+    research_json: Any, council_debate_json: Any, slides: list[dict[str, Any]]
+) -> str:
+    """Concatenate all available source-text the draft was derived from.
+
+    research_json (from topic-selector + draft-generator) is the primary
+    truth. council_debate_json captures the LLM panel's reasoning; useful
+    for paraphrase matches. Slide bodies are last-resort fallback.
+    """
+    parts: list[str] = []
+    for blob in (research_json, council_debate_json):
+        if blob is None:
+            continue
+        if isinstance(blob, str):
+            parts.append(blob)
+        else:
+            try:
+                parts.append(json.dumps(blob, ensure_ascii=False))
+            except (TypeError, ValueError):
+                parts.append(str(blob))
+    for slide in slides:
+        if isinstance(slide, dict):
+            parts.append(str(slide.get("body", "")))
+            parts.append(str(slide.get("title", "")))
+    return "\n".join(parts)
+
+
+def _find_law_citations(text: str) -> set[str]:
+    """Return all law citations matched by LAW_PATTERNS (uppercased for compare)."""
+    found: set[str] = set()
+    for rx in LAW_PATTERNS:
+        for m in rx.finditer(text):
+            found.add(m.group(0).upper())
+    return found
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Per-claim verification
+# ─────────────────────────────────────────────────────────────────────────
+
+def _verify_law_claim(claim_text: str, source_laws: set[str], source_text: str) -> dict[str, str]:
+    """A 'law' claim is verified if at least one of its citations
+    regex-matches in source. Multi-citation claims are common (e.g.
+    "PP 28/2025 supersedes PP 5/2021" — only the primary cite needs to
+    be in the source).
+
+    Returns: {"verdict": "verified"|"unverifiable", "note": str}.
+    'fail' is reserved for active contradictions; we don't auto-contradict
+    laws (a missing law means we couldn't find it, not that it's wrong).
+    """
+    claim_laws = _find_law_citations(claim_text)
+    overlap = claim_laws & source_laws
+    if overlap:
+        return {
+            "verdict": "verified",
+            "note": f"law citation matches source: {','.join(sorted(overlap))}",
+        }
+    if claim_laws:
+        return {
+            "verdict": "unverifiable",
+            "note": f"law citation {','.join(sorted(claim_laws))} not found in research_json",
+        }
+    # No regex match → fall back to substring search of the claim itself.
+    if claim_text.lower() in source_text.lower():
+        return {"verdict": "verified", "note": "exact substring match in source"}
+    return {"verdict": "unverifiable", "note": "law claim has no matchable citation"}
+
+
+def _verify_quote_claim(claim_text: str, source_text: str) -> dict[str, str]:
+    if claim_text.lower() in source_text.lower():
+        return {"verdict": "verified", "note": "exact quote match in source"}
+    # Heuristic: match the inner content if the claim is wrapped in
+    # smart-quotes that the source has as ASCII (or vice versa).
+    stripped = claim_text.strip("\"'“”‘’")
+    if stripped and stripped.lower() in source_text.lower():
+        return {"verdict": "verified", "note": "quote match after strip"}
+    return {"verdict": "unverifiable", "note": "quote not found verbatim in research_json"}
+
+
+_NUMBER_RX = re.compile(r"-?\d+(?:[.,]\d+)?")
+_DATE_RX = re.compile(r"\b\d{1,2}/\d{1,2}/\d{2,4}\b|\b\d{4}-\d{2}-\d{2}\b|\b\d{4}\b")
+
+
+def _verify_number_or_date_claim(
+    claim_text: str, source_text: str, ctype: str
+) -> dict[str, str]:
+    rx = _NUMBER_RX if ctype == "number" else _DATE_RX
+    claim_tokens = rx.findall(claim_text)
+    if not claim_tokens:
+        return {"verdict": "unverifiable", "note": f"no extractable {ctype} in claim"}
+    src_tokens = set(rx.findall(source_text))
+    matched = [t for t in claim_tokens if t in src_tokens]
+    if len(matched) == len(claim_tokens):
+        return {"verdict": "verified", "note": f"{ctype} tokens {matched} all in source"}
+    if not matched:
+        return {
+            "verdict": "contradicted",
+            "note": f"{ctype} tokens {claim_tokens} absent from source — possible drift",
+        }
+    return {
+        "verdict": "unverifiable",
+        "note": f"partial match ({len(matched)}/{len(claim_tokens)} tokens) — {ctype}",
+    }
+
+
+def _verify_other_claim(claim_text: str, source_text: str) -> dict[str, str]:
+    if claim_text.lower() in source_text.lower():
+        return {"verdict": "verified", "note": "substring match in source"}
+    # Token overlap: at least 60% of claim tokens (>3 chars) appear.
+    tokens = [t for t in re.split(r"\W+", claim_text.lower()) if len(t) > 3]
+    if not tokens:
+        return {"verdict": "unverifiable", "note": "no significant tokens"}
+    src_lower = source_text.lower()
+    hit = sum(1 for t in tokens if t in src_lower)
+    if hit / len(tokens) >= 0.6:
+        return {"verdict": "verified", "note": f"token overlap {hit}/{len(tokens)} ≥60%"}
+    return {"verdict": "unverifiable", "note": f"token overlap {hit}/{len(tokens)} <60%"}
+
+
+def _verify_claim(
+    claim: dict[str, Any], source_text: str, source_laws: set[str]
+) -> dict[str, Any]:
+    """Synchronous, deterministic per-claim verifier. No LLM call.
+
+    Output dict has the original claim keys plus `verdict` and `note`.
+    """
+    out = dict(claim)  # copy so we can add fields without mutating input
+    ctype = str(claim.get("type", "other")).lower()
+    text = str(claim.get("claim", ""))
+    if not text:
+        out.update({"verdict": "unverifiable", "note": "empty claim text"})
+        return out
+
+    if ctype == "law":
+        verdict = _verify_law_claim(text, source_laws, source_text)
+    elif ctype == "quote":
+        verdict = _verify_quote_claim(text, source_text)
+    elif ctype in ("number", "date"):
+        verdict = _verify_number_or_date_claim(text, source_text, ctype)
+    else:
+        verdict = _verify_other_claim(text, source_text)
+
+    out.update(verdict)
+    return out
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Optional LLM cross-check for paraphrased claims
+# ─────────────────────────────────────────────────────────────────────────
+
+_LLM_VERIFY_PROMPT = """\
+You are a fact-checking assistant. Decide whether the source text below
+SUPPORTS, CONTRADICTS, or is INCONCLUSIVE about the claim.
+
+Claim: \"{claim}\"
+
+Source text:
+\"\"\"{source}\"\"\"
+
+Return ONE JSON object on its own line, no markdown fences, with this shape:
+
+{{"verdict": "verified|contradicted|unverifiable", "note": "<≤120 chars>"}}
+
+Use "verified" only if the source clearly supports the claim,
+"contradicted" only if the source clearly contradicts it, and
+"unverifiable" otherwise.
+"""
+
+
+async def _llm_verify_claim(
+    claim_text: str, source_text: str, *, model: str, timeout_s: int
+) -> dict[str, str]:
+    prompt = _LLM_VERIFY_PROMPT.format(
+        claim=claim_text[:300],
+        source=source_text[:6000],  # cap so the prompt stays small
+    )
+    try:
+        resp = await complete_async(
+            prompt,
+            model=model,
+            timeout_s=timeout_s,
+            endpoint="wr2.fact_checker.llm_verify",
+        )
+    except (ClaudeOAuthError, ClaudeOAuthNotAvailable):
+        return {"verdict": "unverifiable", "note": "OAuth call failed"}
+
+    text = (resp.text or "").strip()
+    if text.startswith("```"):
+        lines = text.splitlines()
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        text = "\n".join(lines).strip()
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end == -1:
+        return {"verdict": "unverifiable", "note": "LLM JSON parse failed"}
+    try:
+        obj = json.loads(text[start : end + 1])
+    except json.JSONDecodeError:
+        return {"verdict": "unverifiable", "note": "LLM JSON decode failed"}
+    verdict = str(obj.get("verdict", "unverifiable")).lower()
+    if verdict not in ("verified", "contradicted", "unverifiable"):
+        verdict = "unverifiable"
+    return {"verdict": verdict, "note": str(obj.get("note", ""))[:120]}
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# DB
+# ─────────────────────────────────────────────────────────────────────────
+
+async def _kill_switch_enabled(conn: asyncpg.Connection) -> bool:
+    val = await conn.fetchval(
+        "SELECT value FROM system_settings WHERE key = 'wr2_fact_checker_enabled'"
+    )
+    return val == "true"
+
+
+async def _fetch_ready_drafts(conn: asyncpg.Connection, limit: int) -> list[asyncpg.Record]:
+    return await conn.fetch(
+        """
+        SELECT id, topic, register, slides_json, research_json,
+               council_debate_json, fact_check_json
+          FROM war_room_drafts
+         WHERE status = 'drafts_imaged_facted'
+           AND fact_check_json IS NOT NULL
+           AND fact_check_status IS NULL
+         ORDER BY created_at ASC
+         LIMIT $1
+        """,
+        limit,
+    )
+
+
+async def _persist_checked(
+    conn: asyncpg.Connection,
+    draft_id: UUID,
+    fact_check_json: dict[str, Any],
+    fact_check_status: str,
+) -> None:
+    """Record verdicts + advance status.
+
+    pass | degraded → status = 'drafts_imaged_checked' (canva-apply consumes)
+    fail            → status = 'fact_check_failed' (terminal — manual review)
+    """
+    new_status = (
+        "fact_check_failed"
+        if fact_check_status == "fail"
+        else "drafts_imaged_checked"
+    )
+    await conn.execute(
+        """
+        UPDATE war_room_drafts
+           SET fact_check_json   = $2::jsonb,
+               fact_check_status = $3,
+               fact_check_at     = NOW(),
+               status            = $4,
+               updated_at        = NOW()
+         WHERE id = $1
+        """,
+        draft_id,
+        json.dumps(fact_check_json),
+        fact_check_status,
+        new_status,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Per-draft pipeline
+# ─────────────────────────────────────────────────────────────────────────
+
+def _aggregate_status(verified_claims: list[dict[str, Any]]) -> str:
+    """Aggregate per-claim verdicts into a single fact_check_status.
+
+    Rules (locked-in spec from B-bis):
+      - any verdict == 'contradicted'  → 'fail'
+      - any verdict == 'unverifiable'  → 'degraded' (and no contradicted)
+      - all 'verified'                 → 'pass'
+      - empty claims list              → 'pass' (vacuously true)
+    """
+    if not verified_claims:
+        return "pass"
+    has_contradicted = False
+    has_unverifiable = False
+    for c in verified_claims:
+        v = str(c.get("verdict", "unverifiable")).lower()
+        if v == "contradicted":
+            has_contradicted = True
+        elif v == "unverifiable":
+            has_unverifiable = True
+    if has_contradicted:
+        return "fail"
+    if has_unverifiable:
+        return "degraded"
+    return "pass"
+
+
+async def _process_one_draft(
+    conn: asyncpg.Connection, row: asyncpg.Record, *, llm_enabled: bool
+) -> bool:
+    draft_id: UUID = row["id"]
+    topic: str = row["topic"]
+    fact_check_json = row["fact_check_json"]
+    if isinstance(fact_check_json, str):
+        fact_check_json = json.loads(fact_check_json)
+
+    claims_in: list[dict[str, Any]] = list(
+        fact_check_json.get("claims", []) if isinstance(fact_check_json, dict) else []
+    )
+
+    # Build the source text once per draft.
+    research = row["research_json"]
+    if isinstance(research, str):
+        try:
+            research = json.loads(research)
+        except json.JSONDecodeError:
+            pass
+    council = row["council_debate_json"]
+    if isinstance(council, str):
+        try:
+            council = json.loads(council)
+        except json.JSONDecodeError:
+            pass
+    slides_blob = row["slides_json"]
+    if isinstance(slides_blob, str):
+        try:
+            slides_blob = json.loads(slides_blob)
+        except json.JSONDecodeError:
+            pass
+    slides = (
+        slides_blob.get("slides")
+        if isinstance(slides_blob, dict)
+        else slides_blob
+    ) or []
+
+    source_text = _extract_source_text(research, council, slides)
+    source_laws = _find_law_citations(source_text)
+
+    t0 = time.time()
+
+    # Pass 1: deterministic verification.
+    verified: list[dict[str, Any]] = []
+    for claim in claims_in:
+        verified.append(_verify_claim(claim, source_text, source_laws))
+
+    # Pass 2 (optional): LLM cross-check for any 'unverifiable' claims to
+    # see if they're actually 'verified' (paraphrase) or 'contradicted'
+    # (drift). Skipped when llm_enabled=False (fast deterministic path).
+    if llm_enabled:
+        for c in verified:
+            if c.get("verdict") != "unverifiable":
+                continue
+            try:
+                llm_out = await _llm_verify_claim(
+                    str(c.get("claim", "")),
+                    source_text,
+                    model=DEFAULT_MODEL,
+                    timeout_s=DEFAULT_TIMEOUT_S,
+                )
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "Draft %s claim LLM-verify failed: %s — keeping deterministic verdict",
+                    draft_id, e,
+                )
+                continue
+            # Only upgrade unverifiable → verified/contradicted if LLM is
+            # confident; never downgrade a deterministic verified.
+            new_verdict = llm_out.get("verdict", "unverifiable")
+            if new_verdict in ("verified", "contradicted"):
+                c["verdict"] = new_verdict
+                prev_note = c.get("note", "")
+                c["note"] = f"{prev_note} | LLM: {llm_out.get('note', '')}"[:200]
+
+    duration = time.time() - t0
+    fact_check_status = _aggregate_status(verified)
+
+    fact_check_payload = {
+        "claims": verified,
+        "extracted_at": fact_check_json.get("extracted_at") if isinstance(fact_check_json, dict) else None,
+        "checked_at": datetime.now(timezone.utc).isoformat(),
+        "verifier": "wr2_fact_checker",
+        "llm_enabled": llm_enabled,
+    }
+
+    await _persist_checked(conn, draft_id, fact_check_payload, fact_check_status)
+
+    logger.info(
+        "Draft %s checked — status=%s claims=%d duration=%.1fs",
+        draft_id, fact_check_status, len(verified), duration,
+    )
+    _log_telemetry(
+        {
+            "draft_id": str(draft_id),
+            "outcome": fact_check_status,
+            "duration_s": round(duration, 1),
+            "claims_count": len(verified),
+            "llm_enabled": llm_enabled,
+        }
+    )
+
+    if fact_check_status == "fail":
+        _send_telegram(
+            f"🚨 *WR2 fact-check FAIL*\n"
+            f"draft: `{draft_id}`\ntopic: {topic[:80]}\n"
+            f"contradicted claims: "
+            f"{sum(1 for c in verified if c.get('verdict') == 'contradicted')}/{len(verified)}\n"
+            f"Manual review required (status=fact_check_failed)."
+        )
+    elif fact_check_status == "degraded":
+        # Degraded is silent (proceeds to canva-apply); only log in telemetry.
+        pass
+
+    return fact_check_status != "fail"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────────────────────────────────
+
+async def run() -> int:
+    _configure_logging()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.critical("DATABASE_URL not set")
+        return 2
+
+    llm_enabled = os.environ.get("WR2_FACT_CHECKER_LLM", "false").lower() == "true"
+
+    conn = await asyncpg.connect(dsn, timeout=10)
+    try:
+        if not await _kill_switch_enabled(conn):
+            logger.info("wr2_fact_checker_enabled != true — exiting quietly")
+            return 0
+
+        drafts = await _fetch_ready_drafts(conn, MAX_DRAFTS_PER_RUN)
+        if not drafts:
+            logger.info("no drafts ready for fact checking")
+            return 0
+
+        logger.info(
+            "processing %d draft(s) llm_enabled=%s", len(drafts), llm_enabled
+        )
+        successes = 0
+        started = time.monotonic()
+        for row in drafts:
+            try:
+                ok = await _process_one_draft(conn, row, llm_enabled=llm_enabled)
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("Draft %s: unexpected error: %s", row["id"], exc)
+                ok = False
+            if ok:
+                successes += 1
+
+        logger.info(
+            "run complete — %d/%d ok in %.1fs",
+            successes, len(drafts), time.monotonic() - started,
+        )
+        return 0 if successes == len(drafts) else 1
+    finally:
+        await conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(run()))

--- a/scripts/wr2_fact_extractor.py
+++ b/scripts/wr2_fact_extractor.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""WR2 Fact Extractor — Sprint B B-bis (2026-05-08).
+
+Reads `war_room_drafts` rows in status='drafts_imaged' and, for each
+slide body, asks Claude OPUS (via OAuth subprocess) to extract the
+factual claims that need verification. Saves the result in
+`fact_check_json.claims` and advances status to `drafts_imaged_facted`.
+
+This is a NET-NEW build — the original scripts/wr2_fact_extractor.py
+was never written; only the launchd plist was registered (and disabled
+2026-05-07 in PR #299). The supervisor's TRANSITIONS map references
+this stage but the stop-gap routed `drafts_imaged → canva-apply`
+directly. This PR restores the full chain.
+
+Flow per draft
+    1. Fetch (id, topic, register, slides_json) WHERE
+       status='drafts_imaged' AND fact_check_json IS NULL.
+    2. For each slide, build an OPUS prompt that asks for a JSON list
+       of claims (text, slide_index, type ∈ {number, date, law, quote,
+       other}).
+    3. Validate the JSON against `_ClaimsResult` (pydantic) — retry once
+       on schema fail.
+    4. UPDATE war_room_drafts SET fact_check_json=$json,
+       status='drafts_imaged_facted', updated_at=NOW().
+    5. Telegram-alert per draft on success and on persistent extractor
+       error (3-attempt cap).
+
+Kill switch
+    `system_settings.wr2_fact_extractor_enabled` must be 'true'.
+
+Env
+    DATABASE_URL                    Fly Postgres tunnel (port 15432)
+    TELEGRAM_BOT_TOKEN              optional
+    TELEGRAM_OWNER_CHAT_ID          optional
+    WR2_FACT_EXTRACTOR_BATCH        max drafts per run (default 3)
+    WR2_FACT_EXTRACTOR_MODEL        Claude model (default claude-opus-4-7)
+    WR2_FACT_EXTRACTOR_TIMEOUT_S    per-slide subprocess timeout (default 180)
+
+Anthropic invariant (OB-3)
+    Calls go through `backend.llm.claude_oauth_client.complete_async`
+    which spawns the `claude` CLI with CLAUDE_CODE_OAUTH_TOKEN — never
+    ANTHROPIC_API_KEY, never the SDK. See project CLAUDE.md Golden Rule.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+# Make backend-rag importable when run from repo root.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "apps" / "backend-rag"))
+
+import asyncpg  # noqa: E402
+
+from backend.llm.claude_oauth_client import (  # noqa: E402
+    ClaudeOAuthError,
+    ClaudeOAuthNotAvailable,
+    complete_async,
+)
+
+logger = logging.getLogger("wr2.fact_extractor")
+
+# Tunables
+MAX_DRAFTS_PER_RUN = int(os.environ.get("WR2_FACT_EXTRACTOR_BATCH", "3"))
+DEFAULT_MODEL = os.environ.get("WR2_FACT_EXTRACTOR_MODEL", "claude-opus-4-7")
+DEFAULT_TIMEOUT_S = int(os.environ.get("WR2_FACT_EXTRACTOR_TIMEOUT_S", "180"))
+TELEMETRY_PATH = Path.home() / "logs" / "wr2_fact_extractor_telemetry.jsonl"
+
+# Allowed claim types — JSON validation guard.
+ALLOWED_CLAIM_TYPES = ("number", "date", "law", "quote", "other")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Logging + Telegram
+# ─────────────────────────────────────────────────────────────────────────
+
+def _configure_logging() -> None:
+    log_dir = Path.home() / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    fmt = logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
+    fh = logging.FileHandler(str(log_dir / "wr2_fact_extractor.log"))
+    fh.setFormatter(fmt)
+    sh = logging.StreamHandler(sys.stderr)
+    sh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.addHandler(fh)
+    root.addHandler(sh)
+
+
+def _send_telegram(text: str) -> None:
+    token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+    chat_id = os.environ.get("TELEGRAM_OWNER_CHAT_ID", "1125336968")
+    if not token:
+        return
+    try:
+        import urllib.parse
+        import urllib.request
+
+        data = urllib.parse.urlencode(
+            {"chat_id": chat_id, "text": text, "parse_mode": "Markdown"}
+        ).encode()
+        urllib.request.urlopen(  # noqa: S310 — known URL
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            data,
+            timeout=10,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Telegram send failed: %s", e)
+
+
+def _log_telemetry(record: dict) -> None:
+    """Append-only JSONL. Never raises."""
+    try:
+        TELEMETRY_PATH.parent.mkdir(parents=True, exist_ok=True)
+        record.setdefault("ts", datetime.now(timezone.utc).isoformat())
+        with open(TELEMETRY_PATH, "a") as f:
+            f.write(json.dumps(record) + "\n")
+    except Exception as e:  # noqa: BLE001
+        logger.warning("telemetry write failed (non-fatal): %s", e)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Prompt + parser
+# ─────────────────────────────────────────────────────────────────────────
+
+_PROMPT_TEMPLATE = """\
+You are a fact-extraction assistant for the Bali Zero War Room pipeline.
+For the slide body below, extract every factual claim that should be
+verified before publication. Focus on:
+
+- numbers (deadlines, fees, percentages, statistics)
+- dates (specific dates, years, deadlines)
+- laws (regulation/decree references like "PP 28/2025", "PMK 81/2024")
+- quotes (direct attributions to people or institutions)
+- other (named entities, locations, organisations) — only if unambiguously checkable
+
+Topic: {topic}
+Register: {register}
+Slide index: {slide_index}
+Slide title: {title}
+Slide body:
+\"\"\"{body}\"\"\"
+
+Return ONE JSON object on its own line, with this exact shape:
+
+{{
+  "claims": [
+    {{"claim": "<verbatim text or paraphrase ≤150 chars>",
+      "slide_index": {slide_index},
+      "type": "number|date|law|quote|other",
+      "context": "<where it appears, ≤80 chars>"}}
+  ]
+}}
+
+If the slide has zero verifiable claims, return: {{"claims": []}}
+
+Output ONLY the JSON object — no markdown fences, no prose.
+"""
+
+
+def _parse_claims_json(raw: str, slide_index: int) -> list[dict[str, Any]] | None:
+    """Extract `{"claims": [...]}` from a model response.
+
+    Tolerates markdown fences (`json ... `) and leading/trailing prose.
+    Returns None on parse failure so the caller can retry.
+    """
+    if not raw or not raw.strip():
+        return None
+    text = raw.strip()
+    # Strip ```json ... ``` fences if present.
+    if text.startswith("```"):
+        # Drop the first line and the last fence.
+        lines = text.splitlines()
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        text = "\n".join(lines).strip()
+
+    # Find the first { ... } block.
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        return None
+    try:
+        obj = json.loads(text[start : end + 1])
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(obj, dict):
+        return None
+    claims = obj.get("claims")
+    if not isinstance(claims, list):
+        return None
+    # Filter + normalise per claim.
+    cleaned: list[dict[str, Any]] = []
+    for c in claims:
+        if not isinstance(c, dict):
+            continue
+        claim_text = str(c.get("claim", "")).strip()
+        if not claim_text:
+            continue
+        ctype = str(c.get("type", "other")).strip().lower()
+        if ctype not in ALLOWED_CLAIM_TYPES:
+            ctype = "other"
+        ci = c.get("slide_index", slide_index)
+        try:
+            ci_int = int(ci)
+        except (TypeError, ValueError):
+            ci_int = slide_index
+        ctx = str(c.get("context", ""))[:120]
+        cleaned.append(
+            {
+                "claim": claim_text[:200],
+                "slide_index": ci_int,
+                "type": ctype,
+                "context": ctx,
+            }
+        )
+    return cleaned
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# DB
+# ─────────────────────────────────────────────────────────────────────────
+
+async def _kill_switch_enabled(conn: asyncpg.Connection) -> bool:
+    val = await conn.fetchval(
+        "SELECT value FROM system_settings WHERE key = 'wr2_fact_extractor_enabled'"
+    )
+    return val == "true"
+
+
+async def _fetch_ready_drafts(conn: asyncpg.Connection, limit: int) -> list[asyncpg.Record]:
+    """Drafts that finished image-generation and have NOT been fact-extracted yet.
+
+    Filter on `fact_check_json IS NULL` so a re-run of the launchd job
+    doesn't double-extract the same draft.
+    """
+    return await conn.fetch(
+        """
+        SELECT id, topic, register, slides_json
+          FROM war_room_drafts
+         WHERE status = 'drafts_imaged'
+           AND fact_check_json IS NULL
+         ORDER BY created_at ASC
+         LIMIT $1
+        """,
+        limit,
+    )
+
+
+async def _persist_facted(
+    conn: asyncpg.Connection, draft_id: UUID, claims: list[dict[str, Any]]
+) -> None:
+    """Save claims + advance status. fact_check_status stays NULL — only
+    the fact-checker can set it (this stage just enumerates claims).
+    """
+    payload = json.dumps({"claims": claims, "extracted_at": datetime.now(timezone.utc).isoformat()})
+    await conn.execute(
+        """
+        UPDATE war_room_drafts
+           SET fact_check_json = $2::jsonb,
+               status          = 'drafts_imaged_facted',
+               updated_at      = NOW()
+         WHERE id = $1
+        """,
+        draft_id,
+        payload,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Per-slide extraction
+# ─────────────────────────────────────────────────────────────────────────
+
+async def _extract_one_slide(
+    *,
+    topic: str,
+    register: str,
+    slide: dict[str, Any],
+    model: str,
+    timeout_s: int,
+) -> list[dict[str, Any]]:
+    """Run OPUS on a single slide; return claims list (possibly empty).
+
+    Retries once on JSON-parse failure (the model occasionally wraps
+    output in fences or trailing commentary). Returns [] on persistent
+    parse failure — the caller decides whether to fail or degrade.
+    """
+    slide_index = int(slide.get("index", 0))
+    title = str(slide.get("title", ""))[:200]
+    body = str(slide.get("body", ""))
+    if not body.strip():
+        return []
+
+    prompt = _PROMPT_TEMPLATE.format(
+        topic=topic[:200],
+        register=register or "pedagogico",
+        slide_index=slide_index,
+        title=title,
+        body=body[:2000],  # Cap body so prompt stays small.
+    )
+
+    for attempt in (1, 2):
+        try:
+            resp = await complete_async(
+                prompt,
+                model=model,
+                timeout_s=timeout_s,
+                endpoint="wr2.fact_extractor",
+            )
+        except ClaudeOAuthNotAvailable:
+            raise
+        except ClaudeOAuthError:
+            # Surface to caller; retry happens at the draft level.
+            raise
+
+        claims = _parse_claims_json(resp.text or "", slide_index)
+        if claims is not None:
+            return claims
+
+        logger.warning(
+            "slide %d: JSON parse failed on attempt %d (head=%r)",
+            slide_index, attempt, (resp.text or "")[:120],
+        )
+
+    return []  # degraded — no claims for this slide
+
+
+async def _process_one_draft(conn: asyncpg.Connection, row: asyncpg.Record) -> bool:
+    draft_id: UUID = row["id"]
+    topic: str = row["topic"]
+    register: str = row["register"] or "pedagogico"
+    slides_json = row["slides_json"]
+
+    if isinstance(slides_json, str):
+        slides_json = json.loads(slides_json)
+    slides = (
+        slides_json.get("slides")
+        if isinstance(slides_json, dict)
+        else slides_json
+    ) or []
+
+    if not slides:
+        logger.warning("Draft %s: no slides — skipping", draft_id)
+        return False
+
+    t0 = time.time()
+    all_claims: list[dict[str, Any]] = []
+    for slide in slides:
+        try:
+            claims = await _extract_one_slide(
+                topic=topic,
+                register=register,
+                slide=slide if isinstance(slide, dict) else {},
+                model=DEFAULT_MODEL,
+                timeout_s=DEFAULT_TIMEOUT_S,
+            )
+        except (ClaudeOAuthError, ClaudeOAuthNotAvailable) as exc:
+            duration = time.time() - t0
+            logger.error(
+                "Draft %s: OPUS extraction failed: %s — %s",
+                draft_id, type(exc).__name__, exc,
+            )
+            _log_telemetry(
+                {
+                    "draft_id": str(draft_id),
+                    "outcome": "oauth_error",
+                    "duration_s": round(duration, 1),
+                    "exc_head": f"{type(exc).__name__}: {str(exc)[:200]}",
+                }
+            )
+            _send_telegram(
+                f"🚨 *WR2 fact-extractor OAuth failure*\n"
+                f"draft: `{draft_id}`\ntopic: {topic[:80]}\n"
+                f"error: `{type(exc).__name__}: {str(exc)[:300]}`"
+            )
+            return False
+        all_claims.extend(claims)
+
+    duration = time.time() - t0
+    await _persist_facted(conn, draft_id, all_claims)
+    logger.info(
+        "Draft %s facted — %d claims across %d slides in %.1fs",
+        draft_id, len(all_claims), len(slides), duration,
+    )
+    _log_telemetry(
+        {
+            "draft_id": str(draft_id),
+            "outcome": "success",
+            "duration_s": round(duration, 1),
+            "claims_count": len(all_claims),
+            "slides_count": len(slides),
+        }
+    )
+    return True
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────────────────────────────────
+
+async def run() -> int:
+    _configure_logging()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.critical("DATABASE_URL not set")
+        return 2
+
+    conn = await asyncpg.connect(dsn, timeout=10)
+    try:
+        if not await _kill_switch_enabled(conn):
+            logger.info("wr2_fact_extractor_enabled != true — exiting quietly")
+            return 0
+
+        drafts = await _fetch_ready_drafts(conn, MAX_DRAFTS_PER_RUN)
+        if not drafts:
+            logger.info("no drafts ready for fact extraction")
+            return 0
+
+        logger.info("processing %d draft(s)", len(drafts))
+        successes = 0
+        started = time.monotonic()
+        for row in drafts:
+            try:
+                ok = await _process_one_draft(conn, row)
+            except Exception as exc:  # noqa: BLE001 — never crash mid-run
+                logger.exception("Draft %s: unexpected error: %s", row["id"], exc)
+                ok = False
+            if ok:
+                successes += 1
+
+        logger.info(
+            "run complete — %d/%d ok in %.1fs",
+            successes, len(drafts), time.monotonic() - started,
+        )
+        return 0 if successes == len(drafts) else 1
+    finally:
+        await conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(run()))

--- a/scripts/wr2_supervisor.py
+++ b/scripts/wr2_supervisor.py
@@ -73,48 +73,45 @@ logger = logging.getLogger("wr2.supervisor")
 # (old_status, new_status) → next plist label, or None for alert-only.
 # "*" matches any prior status (including None for INSERT).
 #
-# 2026-05-07 — Sprint A bypass: fact-extractor and fact-checker plists were
-# moved to ~/Library/LaunchAgents/.disabled/ during the WR2 supervisor
-# cutover (PR #299, 26 Apr) but the TRANSITIONS dict still routed through
-# them. Result: every draft reaching `drafts_imaged` triggered launchctl
-# kickstart on a non-loaded plist → silent error → draft stuck forever.
-# Audit 2026-05-07 confirmed zero `rendered` outcomes since 25 Apr.
+# 2026-05-08 — Sprint B B-bis: Sprint A bypass (drafts_imaged → canva-apply)
+# is REVERTED. fact-extractor + fact-checker scripts are now NET-NEW
+# (scripts/wr2_fact_extractor.py + scripts/wr2_fact_checker.py) and the
+# disabled plists move back to ~/Library/LaunchAgents/. canva-apply's
+# status filter is locked to 'drafts_imaged_checked' so only fact-checked
+# drafts render.
 #
-# Sprint A short-circuits the fact stages: drafts_imaged → canva-apply
-# directly. Sprint B (next week per docs/wr2/2026-05-07-wr2-longterm-design.md)
-# will re-enable fact-extractor + fact-checker properly, restoring the full
-# chain. The owner-binding decision is "restore fact-checking", but Sprint A
-# prioritises pipeline liveness over fact-check coverage as a stop-gap.
+# Pre-bypass history (Sprint A, 2026-05-07): the fact-* plists were
+# disabled during the supervisor cutover (PR #299, 26 Apr) but the
+# scripts never existed → silent kickstart failure → drafts stuck. Audit
+# 2026-05-07 confirmed zero `rendered` outcomes since 25 Apr. Sprint A
+# patched the symptom by routing drafts_imaged → canva-apply directly.
+# Sprint B B-bis builds the missing scripts and restores the full chain.
 TRANSITIONS: dict[tuple[str | None, str], str | None] = {
     ("*", "briefed"):                                  "com.balizero.wr2.draft-generator",
     ("briefed", "briefed_facted"):                     "com.balizero.wr2.draft-generator",
     ("briefed", "drafts"):                             "com.balizero.wr2.image-generator",
     ("briefed_facted", "drafts"):                      "com.balizero.wr2.image-generator",
-    # Sprint A bypass — see header comment. Restored in Sprint B.
-    ("drafts", "drafts_imaged"):                       "com.balizero.wr2.canva-apply",
-    # Legacy transitions kept for inflight drafts already past drafts_imaged
-    # (e.g. left over from a partial fact-checker run before its plist was
-    # disabled). Once the queue is fully drained these become unreachable;
-    # Sprint B replaces them with the restored fact-extractor/fact-checker.
-    ("drafts_imaged", "drafts_imaged_facted"):         "com.balizero.wr2.canva-apply",
+    # Sprint B B-bis (RESTORED): drafts_imaged → fact-extractor → fact-checker → canva-apply.
+    ("drafts", "drafts_imaged"):                       "com.balizero.wr2.fact-extractor",
+    ("drafts_imaged", "drafts_imaged_facted"):         "com.balizero.wr2.fact-checker",
     ("drafts_imaged_facted", "drafts_imaged_checked"): "com.balizero.wr2.canva-apply",
     ("*", "rendered"):                                 None,  # Telegram only
-    ("*", "fact_check_failed"):                        None,  # Telegram only
+    ("*", "fact_check_failed"):                        None,  # Telegram only — manual review terminal
     ("*", "rejected"):                                 None,  # log only
 }
 
 ALERT_STATUSES = {"rendered", "fact_check_failed"}
 
 # Reconciliation map: which non-terminal statuses need a re-kick if stalled.
-# Sprint A bypass: drafts_imaged / drafts_imaged_facted go straight to
-# canva-apply (fact stages disabled). Sprint B restores fact-extractor +
-# fact-checker entries here.
+# Sprint B B-bis: full chain restored. Each pre-canva-apply state has a
+# dedicated next-stage so the supervisor can reconcile drafts left over
+# from a partial run (e.g. fact-checker crash mid-batch).
 NONTERMINAL_TO_NEXT_STAGE: dict[str, str] = {
     "briefed":               "com.balizero.wr2.draft-generator",
     "briefed_facted":        "com.balizero.wr2.draft-generator",
     "drafts":                "com.balizero.wr2.image-generator",
-    "drafts_imaged":         "com.balizero.wr2.canva-apply",
-    "drafts_imaged_facted":  "com.balizero.wr2.canva-apply",
+    "drafts_imaged":         "com.balizero.wr2.fact-extractor",
+    "drafts_imaged_facted":  "com.balizero.wr2.fact-checker",
     "drafts_imaged_checked": "com.balizero.wr2.canva-apply",
 }
 


### PR DESCRIPTION
## Summary

Sprint B Task 4 (B-bis): restores the fact-extractor / fact-checker chain disabled in PR #299 by shipping the missing executables, the supporting schema (migration 162), and the atomic supervisor + canva-apply revert.

The original "B4 restore" turned out to be a **NET-NEW** build — the launchd plists in \`~/Library/LaunchAgents/.disabled/\` pointed at scripts that never existed; the supervisor TRANSITIONS map routed through them but the kickstarts silently failed. Sprint A (PR #299) papered over this with \`drafts_imaged → canva-apply\`. This PR completes the chain.

## Pipeline

\`\`\`
drafts → image-generator → drafts_imaged
       → FACT-EXTRACTOR (NEW) → drafts_imaged_facted
       → FACT-CHECKER (NEW) → drafts_imaged_checked  | fact_check_failed
       → canva-apply (status filter narrowed)
\`\`\`

## Aggregation rules (locked-in spec)

| Per-claim verdicts | fact_check_status | Status |
|---|---|---|
| any contradicted | \`fail\` | \`fact_check_failed\` (terminal — manual review) |
| any unverifiable, none contradicted | \`degraded\` | \`drafts_imaged_checked\` (proceeds to canva-apply) |
| all verified | \`pass\` | \`drafts_imaged_checked\` |
| empty claims (vacuous) | \`pass\` | \`drafts_imaged_checked\` |

## Files

| Path | Role |
|---|---|
| \`apps/backend-rag/backend/db/migrations_v2/162_war_room_fact_check.sql\` | +3 columns (\`fact_check_json JSONB\`, \`fact_check_status TEXT\` w/ CHECK NULL/pass/fail/degraded NOT VALID + VALIDATE, \`fact_check_at TIMESTAMPTZ\`) + ROLLBACK |
| \`scripts/wr2_fact_extractor.py\` (NEW) | OPUS via OAuth subprocess (OB-3); per-slide claim extraction; JSON parser tolerates fenced + bare output + retries once; degrade-open on parse failure |
| \`scripts/wr2_fact_checker.py\` (NEW) | Deterministic per-claim verifier (law / quote / number / date / other); optional LLM cross-check that ONLY upgrades unverifiable (cannot downgrade verified); aggregation per spec |
| \`scripts/wr2_supervisor.py\` | TRANSITIONS revert: \`drafts_imaged → fact-extractor\`, \`drafts_imaged_facted → fact-checker\`, \`drafts_imaged_checked → canva-apply\`. NONTERMINAL_TO_NEXT_STAGE matched. |
| \`scripts/wr2_canva_apply.py\` | \`_fetch_ready_drafts\` filter LOCKED to \`status = 'drafts_imaged_checked'\` (was \`IN ('drafts_imaged', 'drafts')\`) |
| \`infra/launchagents/com.balizero.wr2.fact-{extractor,checker}.plist\` | Run-on-kickstart only; supervisor calls launchctl kickstart on status transitions |
| \`scripts/tests/test_wr2_fact_extractor.py\` | 13 tests (parser, retry, OAuth handling, persistence, OB-3 AST guard) |
| \`scripts/tests/test_wr2_fact_checker.py\` | 25 tests (per-claim verifier, aggregation, status mapping, LLM upgrade-only invariant, OB-3 AST guard) |

## Atomic deploy contract

Splitting this PR risks a window where canva-apply still consumes \`drafts_imaged\` while supervisor routes them to fact-extractor. Indivisible: supervisor TRANSITIONS revert + canva-apply status filter narrow + new scripts + new plists all land together.

## Test plan

- [x] \`pytest scripts/tests/test_wr2_fact_{extractor,checker}.py scripts/tests/test_wr2_supervisor.py\` → **70/70 pass** (was 25/26 on main, the formerly-failing \`test_reconcile_kicks_stalled\` now passes).
- [x] \`python -m py_compile\` on all 4 modified Python files → clean
- [x] \`plutil -lint\` on both new plists → OK
- [ ] **Post-merge** (manual operator step on Pro):
  1. Migration 162 auto-applies via \`run-sql-v2-migrations-post-deploy\`
  2. Set kill-switches:
     \`\`\`sql
     INSERT INTO system_settings(key, value) VALUES
       ('wr2_fact_extractor_enabled', 'true'),
       ('wr2_fact_checker_enabled', 'true')
     ON CONFLICT (key) DO UPDATE SET value=EXCLUDED.value;
     \`\`\`
  3. Move plists out of \`.disabled/\` + bootstrap (cicatrix P0-3: chmod 0444 after).
  4. Trigger one synthetic draft to verify the full chain end-to-end: \`drafts_imaged → drafts_imaged_facted → drafts_imaged_checked → rendered\`.

## OB-3 invariant guard

Both new scripts call OPUS via \`backend.llm.claude_oauth_client.complete_async\` (subprocess to \`claude\` CLI with \`CLAUDE_CODE_OAUTH_TOKEN\`). Tests use AST inspection to forbid \`import anthropic\` and \`from anthropic import\` — passes the docstring/comment mention of \`ANTHROPIC_API_KEY\` (which exists only in prohibition prose).

## Out of scope (follow-ups)

- Per-claim source attribution (NB-INTEL doc IDs / URL refs) — schema room reserved in \`fact_check_json.claims[i]\` but the populator can land in a follow-up PR.
- LLM cross-check defaults OFF (\`WR2_FACT_CHECKER_LLM=false\`). Once OPUS quota is monitored over a week, flip to true if deterministic verifier alone produces too many \`degraded\` outcomes.
- Daily prune of \`fact_check_json\` for old terminal drafts — not yet implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)