### PR TITLE
fix(setup-team): cron PATH includes ~/.local/bin for claude binary

### DIFF
--- a/infra/launchagents/com.balizero.setup-team.daily.plist
+++ b/infra/launchagents/com.balizero.setup-team.daily.plist
@@ -22,7 +22,7 @@
         <key>HOME</key>
         <string>/Users/nuzantara</string>
         <key>PATH</key>
-        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>/Users/nuzantara/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     </dict>
     <key>StandardOutPath</key>
     <string>/Users/nuzantara/logs/setup-team/launchd-stdout.log</string>

--- a/infra/scripts/setup-team-cron.sh
+++ b/infra/scripts/setup-team-cron.sh
@@ -45,6 +45,13 @@ if [ ! -x "$VENV_PY" ]; then
     exit 2
 fi
 
+# Probe claude CLI: obligation engine subprocess-shells `claude --print`.
+# launchd PATH is minimal; if `claude` not findable, log and continue (engine
+# will skip extraction gracefully — feeders + alerts still run).
+if ! command -v claude >/dev/null 2>&1; then
+    echo "$(date) WARNING: claude binary not found in PATH=$PATH — obligation extraction will be skipped" >> "$LOG_FILE"
+fi
+
 # Pipeline runner. Captures all sub-steps in one Python invocation so we
 # don't pay the ~300ms cold-start penalty per stage. Atomic snapshot mv
 # at the end — partial pipeline = no snapshot file.


### PR DESCRIPTION
## Summary

First Phase 1 cron run on Pro (2026-05-08 06:51 WITA) revealed:

\`\`\`
pipeline step failed for imigrasi:8557861550177086351:
  [Errno 2] No such file or directory: 'claude'
\`\`\`

## Root cause

LaunchAgent PATH was \`/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin\` but \`claude\` binary lives at \`/Users/nuzantara/.local/bin/claude\` on Pro.

Verified: \`which claude\` returns \`/Users/nuzantara/.local/bin/claude\`.

## Fix

1. Plist PATH now includes \`/Users/nuzantara/.local/bin\` first
2. Cron wrapper probes \`command -v claude\` and logs warning if missing (obligation extraction degrades gracefully; feeders + alerts continue)

## Reload steps on Pro after merge

\`\`\`bash
launchctl bootout gui/$(id -u)/com.balizero.setup-team.daily
cp ~/Desktop/nuzantara/infra/launchagents/com.balizero.setup-team.daily.plist ~/Library/LaunchAgents/
launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.balizero.setup-team.daily.plist
launchctl kickstart gui/$(id -u)/com.balizero.setup-team.daily
\`\`\`

## Other observations from first cron run (NOT bugs)

- \`pasal.id auth failed 401\` → expected, \`PASAL_ID_API_TOKEN\` not set
- \`JDIHN returned 404\` → portal redirect, graceful skip
- \`kemenkumham fetch failed: nodename\` → DNS transient

These are handled correctly (no crash, pipeline continues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)