### PR TITLE
fix(wr2): timedelta instead of string-cast interval in watchdog

### DIFF
--- a/scripts/wr2_supervisor_watchdog.py
+++ b/scripts/wr2_supervisor_watchdog.py
@@ -55,7 +55,7 @@ import signal
 import sys
 import urllib.parse
 import urllib.request
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -197,6 +197,11 @@ async def _probe_pipeline_state(conn: asyncpg.Connection) -> dict[str, Any]:
                           'drafts_imaged_checked')
         """
     )
+    # asyncpg accepts datetime.timedelta and binds it directly as
+    # `interval`. Passing a string and casting via $1::interval fails
+    # with "'str' object has no attribute 'days'" because asyncpg's
+    # codec dispatches by Python type, not target type. Empirical
+    # repro 2026-05-08 08:10 WITA on production tunnel.
     rendered_recent = await conn.fetchval(
         """
         SELECT COUNT(*)
@@ -204,7 +209,7 @@ async def _probe_pipeline_state(conn: asyncpg.Connection) -> dict[str, Any]:
          WHERE status = 'rendered'
            AND canva_applied_at > NOW() - $1::interval
         """,
-        f"{int(RENDERED_24H_HOURS)} hours",
+        timedelta(hours=RENDERED_24H_HOURS),
     )
     return {
         "oldest_pending_hours": float(oldest_pending) if oldest_pending else 0.0,


### PR DESCRIPTION
## Summary

Hotfix for empirical bug discovered post-bootstrap on Pro 2026-05-08 08:10 WITA:

\`\`\`
WARNING watchdog connection lost: invalid input for query argument \$1:
'24 hours' ('str' object has no attribute 'days')
\`\`\`

asyncpg's codec dispatch is by Python type, not by SQL target type. Passing a string with \`\$1::interval\` cast fails because asyncpg's interval encoder calls \`.days\` on the Python value BEFORE the SQL cast happens.

## Fix

Pass \`datetime.timedelta(hours=RENDERED_24H_HOURS)\` directly. asyncpg binds \`timedelta\` natively as PostgreSQL \`interval\`.

## Verification

- 16/16 existing watchdog tests still pass (they mock fetchval, don't exercise the encoder).
- Manually swapped script on Pro deploy worktree → watchdog now stable, no reconnect spam.
- Watchdog correctly fired its first real P1 alert: \`success_rate_low rate=16.7% attempts=6\` (5 cold-sentinel/timeout failures + 1 success over the 7-day window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)