### PR TITLE
fix(indexing-sweep): Pro paths in repo plist + restore venv bootstrap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ See [`INDEX.md`](INDEX.md) for the full atlas including packages, tessuti dati, 
 ### Tech Stack
 
 <!-- DOCSYNC:BACKEND_STATS_START -->
-- **Backend:** Python 3.11+, FastAPI, 257 routers, 541 services, 906 test files
+- **Backend:** Python 3.11+, FastAPI, 257 routers, 541 services, 907 test files
 <!-- DOCSYNC:BACKEND_STATS_END -->
 - **Frontend:** Next.js, TypeScript, Tailwind CSS
 - **Databases:** PostgreSQL (relational), Qdrant (vector), Redis (cache)
@@ -268,13 +268,12 @@ Sections: `SECURITY_BOUNDARY` · `TOOL_USAGE_POLICY` · `SYSTEM_INSTRUCTIONS` ·
 
 ## 8. Deployment Architecture
 
-### Fly.io — 3 APP ONLY
+### Fly.io — 2 APP ONLY (Qdrant migrated to Qdrant Cloud)
 
 | App                  | CPU       | RAM | Auto-stop  | Note                    |
 | -------------------- | --------- | --- | ---------- | ----------------------- |
 | `nuzantara-rag`      | shared-2x | 2GB | off, min=1 | Always-on, EventBus     |
 | `nuzantara-postgres` | shared-1x | 2GB | no         | v0.1.0, backup → Tigris |
-| `nuzantara-qdrant`   | shared-1x | 2GB | no         | v1.17.0                 |
 
 - **Frontend:** Vercel (auto-deploy on `git push origin main`)
 - **Backend deploy:** `cd apps/backend-rag && fly deploy --strategy rolling`

--- a/infra/launchagents/com.balizero.indexing-sweep.daily.plist
+++ b/infra/launchagents/com.balizero.indexing-sweep.daily.plist
@@ -3,33 +3,33 @@
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.balizero.indexing-sweep</string>
+    <string>com.balizero.indexing-sweep.daily</string>
 
-    <!-- Daily Google Search Console Indexing Sweep
+    <!-- Daily Google Search Console Indexing Sweep (Pro)
          Phase 1: Articles (max 200/day)
          Phase 2: KBLI (max 600/day via 3 SAs × 200 each)
          Submits unindexed URLs to Google Indexing API, updates state JSON,
-         reports results to Telegram.
+         reports results to Telegram via OpenClaw bridge.
 
-         Runs daily at 00:30 WITA (17:30 UTC prev day) on Air only.
-         Requires: Google credentials (.secrets/*.json), OpenClaw for Telegram bridge.
+         Schedule: daily at 00:30 WITA (17:30 UTC prev day) on Pro.
+         Requires: Google credentials (apps/evaluator/*.json), OpenClaw for Telegram bridge.
     -->
 
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
-        <string>/Users/antonellosiano/Projects/nuzantara/scripts/daily_indexing_cron_wrapper.sh</string>
+        <string>/Users/nuzantara/Desktop/nuzantara/scripts/daily_indexing_cron_wrapper.sh</string>
     </array>
 
     <key>WorkingDirectory</key>
-    <string>/Users/antonellosiano/Projects/nuzantara</string>
+    <string>/Users/nuzantara/Desktop/nuzantara</string>
 
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
         <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
         <key>HOME</key>
-        <string>/Users/antonellosiano</string>
+        <string>/Users/nuzantara</string>
     </dict>
 
     <key>StartCalendarInterval</key>
@@ -47,5 +47,8 @@
     <string>/tmp/balizero-indexing-sweep.stdout.log</string>
     <key>StandardErrorPath</key>
     <string>/tmp/balizero-indexing-sweep.stderr.log</string>
+
+    <key>KeepAlive</key>
+    <false/>
 </dict>
 </plist>

--- a/scripts/daily_indexing_cron_wrapper.sh
+++ b/scripts/daily_indexing_cron_wrapper.sh
@@ -23,10 +23,14 @@ mkdir -p "$LOG_DIR"
   echo "[$(date '+%Y-%m-%d %H:%M:%S %Z')] Daily Indexing Sweep started (Pro)"
   echo "==============================================================================="
 
-  # Activate venv (required for import chain)
+  # Activate venv (required for import chain). Bootstrap if missing so a
+  # fresh Pro provision self-heals — matches pre-2026-05-07 behavior.
   if [ ! -f "$VENV_DIR/bin/python" ]; then
-    echo "[ERROR] .venv not found at $VENV_DIR. Cannot proceed."
-    exit 1
+    echo "[INFO] .venv not found at $VENV_DIR, creating..."
+    python3 -m venv "$VENV_DIR"
+    echo "[INFO] Installing requirements..."
+    "$VENV_DIR/bin/pip" install -q --upgrade pip
+    "$VENV_DIR/bin/pip" install -q google-auth google-auth-oauthlib google-auth-httplib2 google-api-python-client
   fi
 
   source "$VENV_DIR/bin/activate"


### PR DESCRIPTION
## Summary
- `infra/launchagents/com.balizero.indexing-sweep.daily.plist` still pointed at the decommissioned Air paths (`/Users/antonellosiano/...`). The loaded copy in `~/Library/LaunchAgents/` had been hand-edited to Pro, but a recovery from the canonical `infra/` source — including the procedure documented in the existing cicatrix scar for the 2026-04-29 plist-corruption incident — would silently re-install the broken Air-pointing config. Aligned the repo file byte-for-byte to the loaded Pro copy (Label, ProgramArguments, WorkingDirectory, HOME, KeepAlive=false). `plutil -lint` OK.
- `scripts/daily_indexing_cron_wrapper.sh`: restored the venv bootstrap (`python3 -m venv` + pip install) that the previous edit replaced with `exit 1`. A fresh Pro provision now self-heals; matches pre-2026-05-07 behavior.
- `CLAUDE.md` §8: dropped `nuzantara-qdrant` and changed "3 APP ONLY" to "2 APP ONLY (Qdrant migrated to Qdrant Cloud)". Verified empirically via `fly apps list` — only `nuzantara-rag` and `nuzantara-postgres` remain. The branch's GEMINI.md edit had already moved Qdrant to Cloud; this aligns the project doc.

## Test plan
- [x] `plutil -lint infra/launchagents/com.balizero.indexing-sweep.daily.plist` → OK
- [x] `diff` against loaded `~/Library/LaunchAgents/...` → identical
- [x] `bash -n scripts/daily_indexing_cron_wrapper.sh` → OK
- [x] `fly apps list` → 2 apps (rag + postgres), confirms CLAUDE.md §8 edit
- [ ] Reviewer: confirm the active LaunchAgent (label `com.balizero.indexing-sweep.daily`) keeps running through merge — repo change does not touch the loaded copy, but is the source of truth for any future recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)