### PR TITLE
fix(wr2/db): mig 163 — extend war_room_drafts status CHECK for fact-stages

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/163_war_room_status_fact_stages.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/163_war_room_status_fact_stages.sql
@@ -94,4 +94,8 @@ ALTER TABLE war_room_drafts
         'rejected'::text,
         'published'::text,
         'missed'::text
-    ]));
+    ]))
+    NOT VALID;
+
+ALTER TABLE war_room_drafts
+    VALIDATE CONSTRAINT war_room_drafts_status_check;

--- a/apps/backend-rag/backend/db/migrations_v2/163_war_room_status_fact_stages.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/163_war_room_status_fact_stages.sql
@@ -1,0 +1,97 @@
+-- Migration 163: war_room_drafts.status — extend CHECK constraint
+-- to accept fact-stages values used by the B-bis chain (mig 162 + PR #533).
+--
+-- Sprint B B-bis (PR #533) restored the fact-extractor / fact-checker
+-- pipeline. The supervisor TRANSITIONS now route:
+--   drafts_imaged → drafts_imaged_facted (fact-extractor)
+--   drafts_imaged_facted → drafts_imaged_checked (fact-checker)
+-- but the existing `war_room_drafts_status_check` from mig 112 only
+-- accepted values up to 'drafts_imaged' / 'fact_check_failed'.
+--
+-- Live failure 2026-05-08 09:28 WITA after Pro restart of the
+-- supervisor with the new TRANSITIONS:
+--   asyncpg.exceptions.CheckViolationError: new row for relation
+--   "war_room_drafts" violates check constraint
+--   "war_room_drafts_status_check"
+--   DETAIL: ... drafts_imaged_facted ...
+--
+-- DB on Pro hotfixed manually 09:30 WITA so the pipeline could resume.
+-- This migration is the durable fix that lands on Fly Postgres at the
+-- next deploy via `run-sql-v2-migrations-post-deploy`.
+--
+-- Squawk: DROP CONSTRAINT + ADD CONSTRAINT NOT VALID + VALIDATE in
+-- two steps so we never hold ACCESS EXCLUSIVE while scanning the
+-- table (low-risk on this small table but safe-by-default).
+
+-- =====================================================================
+-- 1. Drop the old constraint (idempotent via IF EXISTS)
+-- =====================================================================
+
+ALTER TABLE war_room_drafts
+    DROP CONSTRAINT IF EXISTS war_room_drafts_status_check;
+
+-- =====================================================================
+-- 2. Add the extended constraint (NOT VALID first, then VALIDATE)
+-- =====================================================================
+
+ALTER TABLE war_room_drafts
+    ADD CONSTRAINT war_room_drafts_status_check
+    CHECK (status = ANY (ARRAY[
+        'briefed'::text,
+        'briefed_facted'::text,
+        'researched'::text,
+        'concept'::text,
+        'drafts'::text,
+        'drafts_checked'::text,
+        'drafts_imaged'::text,
+        'drafts_imaged_facted'::text,
+        'drafts_imaged_checked'::text,
+        'fact_check_failed'::text,
+        'image_failed'::text,
+        'rendered'::text,
+        'pending_review'::text,
+        'approved'::text,
+        'rejected'::text,
+        'published'::text,
+        'missed'::text
+    ]))
+    NOT VALID;
+
+ALTER TABLE war_room_drafts
+    VALIDATE CONSTRAINT war_room_drafts_status_check;
+
+-- === ROLLBACK ===
+-- Restore the pre-163 constraint (status set without the two new
+-- fact-stage values). Any drafts already in the new states would
+-- violate the rollback constraint VALIDATE pass, so the rollback
+-- script preemptively reverts them to 'drafts_imaged' (the parent
+-- state that produced them). This is a soft rollback — the work
+-- product (claims in fact_check_json) is preserved; only the status
+-- gauge resets.
+
+UPDATE war_room_drafts
+   SET status = 'drafts_imaged'
+ WHERE status IN ('drafts_imaged_facted', 'drafts_imaged_checked');
+
+ALTER TABLE war_room_drafts
+    DROP CONSTRAINT IF EXISTS war_room_drafts_status_check;
+
+ALTER TABLE war_room_drafts
+    ADD CONSTRAINT war_room_drafts_status_check
+    CHECK (status = ANY (ARRAY[
+        'briefed'::text,
+        'briefed_facted'::text,
+        'researched'::text,
+        'concept'::text,
+        'drafts'::text,
+        'drafts_checked'::text,
+        'drafts_imaged'::text,
+        'fact_check_failed'::text,
+        'image_failed'::text,
+        'rendered'::text,
+        'pending_review'::text,
+        'approved'::text,
+        'rejected'::text,
+        'published'::text,
+        'missed'::text
+    ]));


### PR DESCRIPTION
## Summary

Empirical bug discovered post-Fly-deploy 2026-05-08 09:28 WITA after restart of the supervisor with the new TRANSITIONS map (PR #533):

\`\`\`
asyncpg.exceptions.CheckViolationError: new row for relation
"war_room_drafts" violates check constraint
"war_room_drafts_status_check"
DETAIL: ... drafts_imaged_facted ...
\`\`\`

## Root cause

PR #533 added migration 162 (\`fact_check_json\` / \`fact_check_status\` / \`fact_check_at\` columns) and updated the supervisor TRANSITIONS to route \`drafts_imaged → drafts_imaged_facted → drafts_imaged_checked\`. But the existing \`war_room_drafts_status_check\` from migration 112 only accepted values up to \`'drafts_imaged'\` / \`'fact_check_failed'\` — the two new intermediate states were never added to the CHECK array.

## Fix

Migration 163 drops the old constraint and adds an extended one with both \`'drafts_imaged_facted'\` and \`'drafts_imaged_checked'\`. Uses NOT VALID + VALIDATE pattern so we never hold ACCESS EXCLUSIVE while scanning the table (low risk on this small table but safe-by-default).

## Already deployed live

Pro DB tunnel was hotfixed manually 09:30 WITA so the pipeline could resume. This migration is the durable fix that lands on Fly Postgres at the next deploy via \`run-sql-v2-migrations-post-deploy\`. Idempotent: \`DROP CONSTRAINT IF EXISTS\` + \`VALIDATE\` is safe to re-run.

## ROLLBACK

The ROLLBACK section preemptively resets any drafts in the two new states back to \`'drafts_imaged'\` before re-applying the narrower constraint, so the rollback VALIDATE pass succeeds without a CheckViolationError. Soft rollback: \`fact_check_json\` payloads are preserved; only the status gauge resets.

## Test plan

- [x] Migration 163 file: present + ROLLBACK marker
- [x] Live verification: hotfix already applied to Pro DB; supervisor + fact-extractor now writing without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)