### PR TITLE
docs(prompts): drop-in continuation prompts for domain-mesh phases 2-8

### DIFF
--- a/docs/superpowers/prompts/domain-mesh/00-MASTER-ORCHESTRATOR.md
+++ b/docs/superpowers/prompts/domain-mesh/00-MASTER-ORCHESTRATOR.md
@@ -1,0 +1,55 @@
+# Domain Mesh — Master Orchestrator Prompt
+
+> **Cosa fa**: prompt da incollare in nuova sessione Claude Code per **continuare** il domain-mesh autonomic system. Si auto-orienta leggendo lo stato.
+>
+> **Quando usare**: ogni volta che vuoi avanzare il sistema senza ripartire da zero.
+
+---
+
+## PROMPT (copia-incolla nella prima riga della nuova sessione)
+
+Sei in continuazione di un progetto in corso: il **Domain Mesh autonomic system** di Bali Zero / Nuzantara. Prima di fare qualsiasi cosa:
+
+1. Leggi `docs/superpowers/specs/2026-05-08-domain-mesh-autonomic-design.md` (il design master, 14 sezioni)
+2. Leggi `docs/superpowers/plans/2026-05-08-domain-mesh-phase0-foundations.md` (Phase 0 plan, già implementato)
+3. Leggi `docs/superpowers/plans/2026-05-08-domain-mesh-phase1-setup-team.md` (Phase 1 plan, già implementato)
+4. Verifica stato implementazione attuale:
+   ```bash
+   ls apps/mata-garuda/mata_garuda/foundations/  # 8 moduli Phase 0
+   ls apps/mata-garuda/mata_garuda/domains/     # B1 setup_team in Phase 1; verifica quali altri ci sono
+   ```
+5. Verifica cron attivi:
+   ```bash
+   launchctl list | grep balizero
+   ```
+
+Una volta orientato, chiedimi quale fase devo avanzare. Le fasi pendenti sono:
+
+- **Phase 2**: Setup Team estensione (NB-INTEL-Property + NB-INTEL-Labor) — vedi `docs/superpowers/prompts/domain-mesh/01-phase2-setup-team-extend.md`
+- **Phase 3 / B2**: Tax Engine — vedi `docs/superpowers/prompts/domain-mesh/02-phase3-tax-engine.md`
+- **Phase 4 / B3**: Marketing Pulse — vedi `docs/superpowers/prompts/domain-mesh/03-phase4-marketing.md`
+- **Phase 5 / B4**: Antonello Lab — vedi `docs/superpowers/prompts/domain-mesh/04-phase5-antonello-lab.md`
+- **Phase 6 / B5**: Bali Macro — vedi `docs/superpowers/prompts/domain-mesh/05-phase6-bali-macro.md`
+- **Phase 7 / B6**: Nexus OSINT — vedi `docs/superpowers/prompts/domain-mesh/06-phase7-nexus-osint.md`
+- **Phase 8**: Cross-domain layer (federation graph + alert dispatcher + skill graduation)
+
+**Regole non negoziabili** (controlla `apps/mata-garuda/CLAUDE.md` + root `CLAUDE.md`):
+
+- Niente Anthropic API key. Solo `claude --print` subprocess via OAuth Max.
+- mata-garuda: deps core SOLO `pydantic>=2`, deps test SOLO `pytest`. Cose pesanti in `[project.optional-dependencies] foundations`.
+- Lazy imports (PEP 562) per tutto ciò che tocca ML deps.
+- Branch hijack scar: `git push` dopo OGNI commit. Branch verify prima di Edit/Write.
+- TDD per task (test fail → impl → test pass → commit + push).
+- Cron LaunchAgent: absolute venv python, atomic mv snapshot, `*_CRON_ENABLED=false` kill switch, PATH includes `/Users/nuzantara/.local/bin` per `claude`.
+
+**Pattern da seguire (Phase 0/1 hanno mostrato)**:
+
+1. Brainstorm domain (skill `superpowers:brainstorming`) → conferma 5-fase lifecycle (nasce/cresce/auto-correct/cosciente/canalizza)
+2. Spec doc → `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
+3. Plan → `docs/superpowers/plans/YYYY-MM-DD-<topic>.md`
+4. Subagent-driven implementation (skill `superpowers:subagent-driven-development`)
+5. External review wave (Codex GPT-5 + DeepSeek v4 + NotebookLM NB-1 minimum, Sonnet 4.6 + security-review skill optional)
+6. Triage feedback indipendente, fix bug reali (non taste)
+7. PR + auto-merge
+
+Aspetta che io ti dica quale fase avanzare prima di partire.

--- a/docs/superpowers/prompts/domain-mesh/01-phase2-setup-team-extend.md
+++ b/docs/superpowers/prompts/domain-mesh/01-phase2-setup-team-extend.md
@@ -1,0 +1,90 @@
+# Phase 2 — Setup Team Extend (Property + Labor)
+
+> **Prerequisiti**: Phase 1 mergiata (PR #534 + #536 + #540). Cron `com.balizero.setup-team.daily` attivo.
+>
+> **Stima**: 5-7 giorni solo-dev.
+
+---
+
+## PROMPT (drop-in)
+
+Continuiamo il Domain Mesh. Phase 2: estendi il dominio Setup Team aggiungendo i 2 sub-stream INTEL mancanti (Property + Labor) che erano stati deferred in Phase 1.
+
+Prima di tutto, leggi:
+
+1. `docs/superpowers/specs/2026-05-08-domain-mesh-autonomic-design.md` §2 B1 (genesi Setup Team con tutti 4 NB-INTEL)
+2. `docs/superpowers/plans/2026-05-08-domain-mesh-phase1-setup-team.md` (pattern Phase 1)
+3. `apps/mata-garuda/mata_garuda/domains/setup_team/feeders/` (3 feeder esistenti come reference)
+
+Poi invoca `superpowers:brainstorming` per confermare l'approccio (sub-domains Property/Labor sono identici come pattern a Regulation/Immigration?), poi `superpowers:writing-plans` per il plan.
+
+### Scope
+
+**In**:
+
+- `feeders/nb_intel_property.py` con sources:
+  - atrbpn.go.id (BPN nazionale)
+  - Pemkab Badung DPMPTSP, PUPR
+  - Bali property tier-1 (Bali Realty, Exotiq, Property Bali Indo)
+- `feeders/nb_intel_labor.py` con sources:
+  - kemnaker.go.id/berita
+  - bpjsketenagakerjaan.go.id
+  - BNP2TKI / BP2MI
+  - Hukumonline labor tag
+  - Twitter @KemnakerRI (RSS via nitter mirror, fallback)
+- Scorer fast-path:
+  - Property: `PBG|HGB|HGU|hak ?pakai|hak ?milik|sertifikat|ATR|BPN|land ?cert|tanah ?cert|villa|properti`
+  - Labor: `RPTKA|IMTA|BPJS ?(TK|Kesehatan)|UU ?13|UU ?6\/2023|cipta ?kerja|kemnaker|tenaga ?kerja|TKA`
+- Estendere il cron `setup-team-cron.sh` per chiamare anche Property + Labor feeders
+- Aggiornare obligation_engine + client_match per supportare i nuovi domain types
+- Test: stesso pattern di Phase 1 (mock httpx, mock subprocess, verify regex)
+
+**Out**:
+
+- Skill graduation pipeline (Phase 8)
+- Cross-domain alert dispatcher (Phase 8)
+
+### Pattern da seguire
+
+I 3 feeder Phase 1 sono il template. Ogni feeder:
+
+1. Definisce `*_BERITA_URL` constants
+2. `TRUSTED_TIER1_HOSTS` set (gov direct hosts)
+3. `*_REGEX` con scorer fast-path
+4. `_LIFESTYLE_BLOCKLIST` per skip rumore
+5. `async def fetch_recent_*(days=30, http_client=None) -> list[Regulation]`
+6. Try/except per layer in modo che 1 fonte morta non kill gli altri
+7. Dedup by `(domain, source_id)`
+
+Test pattern in `tests/domains/setup_team/test_feeders.py` — copia struttura.
+
+### Regole forti
+
+- Niente Anthropic SDK. `claude --print` subprocess.
+- Lazy imports.
+- Cron LaunchAgent PATH include `/Users/nuzantara/.local/bin`.
+- Atomic mv snapshot.
+- TDD per ogni nuovo file: scrivi test prima.
+- Branch hijack: `git push` dopo ogni commit.
+- mata-garuda CLAUDE.md: deps minimal (no nuovi pesanti).
+
+### Output finale
+
+PR auto-merge ON con:
+
+- 2 nuovi feeder
+- ~20 nuovi test (feeder pattern di Phase 1)
+- Cron wrapper aggiornato
+- Plist invariato (stessa LaunchAgent — solo lo script Python aggiunge i 2 layer)
+
+Quando finito, una verifica live:
+
+```bash
+launchctl kickstart gui/$(id -u)/com.balizero.setup-team.daily
+sleep 10
+tail -50 ~/logs/setup-team/setup-team-daily-$(date +%Y%m%d).log
+```
+
+Atteso: nuovo summary con `feeders=` aumentato (era 1 in Phase 1, ora dovrebbe essere fino a 5 con i 2 nuovi se i portali rispondono).
+
+Procedi.

--- a/docs/superpowers/prompts/domain-mesh/02-phase3-tax-engine.md
+++ b/docs/superpowers/prompts/domain-mesh/02-phase3-tax-engine.md
@@ -1,0 +1,120 @@
+# Phase 3 — Tax Engine (B2)
+
+> **Prerequisiti**: Phase 1+2 mergiate. Setup Team domain operativo.
+>
+> **Stima**: 10-14 giorni solo-dev (B2 è il dominio più complesso — Coretax instability + PJAP partner contract).
+>
+> **Pre-azione richiesta a te (Antonello)**: contratto Pajakku PJAP (~€85/mese) o PajakExpress. Senza, il dominio funziona solo in dry-run mode.
+
+---
+
+## PROMPT (drop-in)
+
+Continuiamo il Domain Mesh. Phase 3: implementa il dominio **Tax Engine (B2)**.
+
+Prima di tutto, leggi:
+
+1. `docs/superpowers/specs/2026-05-08-domain-mesh-autonomic-design.md` §3 B2 (genesi Tax Engine completa)
+2. `docs/superpowers/specs/2026-05-08-domain-mesh-research/r3-djp-coretax-tax-tech-2026-05-08.md` (R3 SOTA, 8 sezioni dettagliate su DJP/Coretax/PJAP)
+3. `docs/superpowers/plans/2026-05-08-domain-mesh-phase1-setup-team.md` (pattern Phase 1)
+4. `apps/mata-garuda/mata_garuda/domains/setup_team/` (template completo da imitare)
+
+Verifica anche se Antonello ha già firmato il contratto Pajakku (PJAP). Cerca:
+
+```bash
+grep -ri "PAJAKKU_API_TOKEN\|PJAP" ~/.nuzantara-secrets.env ~/.nuzantara-backend-secrets.env 2>/dev/null
+```
+
+Se token presente → modalità live. Se assente → modalità dry-run (mock submit, log ma non chiama Coretax).
+
+Poi `superpowers:brainstorming` (verifica se le decisioni B2.a + B2.b del design sono ancora valide), `superpowers:writing-plans`, `superpowers:subagent-driven-development`.
+
+### Scope
+
+**Domains/tax/**init**.py** (PEP 562 lazy) + sotto-moduli:
+
+1. **Feeders (NB-INTEL ingestion, simile pattern Setup Team)**:
+   - `feeders/nb_intel_tax.py`: pajak.go.id/siaran-pers + jdih.kemenkeu.go.id + setkab Kemenkeu filter + Ortax + DDTC
+   - `feeders/nb_intel_coretax.py` **DEDICATO** (R3 conferma instability strutturale): DJP Coretax incident bulletin + Twitter community + Reddit r/PersonalFinanceIndonesia + KIP DJP press
+
+2. **PJAP adapter**:
+   - `pjap_client.py`: abstraction layer su Pajakku (primary) + PajakExpress (fallback). Interface `PJAPClient` con metodi `submit_faktur`, `submit_e_bupot`, `submit_efiling`, `submit_spt`. Retry policy exponential backoff max 5, escalation Telegram Veronika su >5 fail.
+   - `coretax_incident_taxonomy.py`: enum dei 12 incident types da R3 (login_fail_face_verif, save_invalid_faktur, error_404_mass, error_500_api_queue, period_spt_default_off, upload_attachment_fail, nik_validation_dukcapil_timeout, digital_cert_refresh_expired, pph_21_23_ebupot_xml_broken, faktur_xml_import_bug, approval_workflow_stuck, browser_specific_ui_break)
+   - `workaround_library.py`: SQLite `~/Desktop/nuzantara/apps/mata-garuda/data/coretax_workarounds.sqlite` con tabella `incident_workarounds` (incident_type, workaround_text, last_verified, screenshots_dir)
+
+3. **Tax engine layers** (R3 workflow automation map, 6 layer):
+   - `engine/L1_ingestion.py`: OCR fatture (foundations qwen2.5vl:7b via Ollama subprocess, NOT Anthropic SDK), parse e-bupot XML, parse fattura PDF
+   - `engine/L2_classification.py`: tax code classifier (rule-based + LLM via `claude --print` for edge cases). KBLI → tax obligations mapping (federation con NB-3 setup_team)
+   - `engine/L3_compute.py`: PPh 21/23/26/25 deterministic, PPN output-input
+   - `engine/L4_equalization.py`: PPN ↔ SPT Tahunan reconciliation, variance flag if > 5% → Veronika alert
+   - `engine/L5_submission.py`: chiama PJAPClient con retry + incident taxonomy detection
+   - `engine/L6_human_gate.py`: Veronika sign-off final (HARD), no auto-submit per audit response
+
+4. **Promotion gate** (riusa pattern setup-team, ma PIÙ STRINGENTE per tax):
+   - Solo tier ≤ 1 (gov direct: pajak.go.id, kemenkeu.go.id, setkab.go.id) può triggherare promotion
+   - **NO auto-approve dopo SLA** (Veronika click obbligatorio anche se tier 1 — accuracy fiscale > convenience)
+
+5. **Quote engine grounding** (R3 Sink 3):
+   - `quote_engine.py`: input cliente profile + KBLI + complexity factors, output draft XLSX/PDF
+   - Grounding: NB-4 (procedure), NB-3 (KBLI), NB-WORKBENCH casi simili (Marta storia)
+   - Sign-off Veronika via signed-by field
+
+6. **Cron LaunchAgent**:
+   - `infra/scripts/tax-engine-cron.sh`
+   - `infra/launchagents/com.balizero.tax-engine.daily.plist`
+   - Schedule: 07:00 WITA (dopo Setup Team 06:00)
+   - Kill switch: `TAX_ENGINE_CRON_ENABLED=false`
+   - Dry-run mode: `TAX_ENGINE_DRY_RUN=true` (default per testing senza PJAP token)
+
+### Sink (output)
+
+1. Telegram `#tax-alerts` — KEP/PMK/Coretax incidents
+2. CRM tax workflow trigger
+3. Quote engine grounding draft
+4. Mouth content tax-vertical (NB-INTEL-Tax → article generator)
+5. Coretax workaround library Veronika quick-access
+6. **NEW**: IndoTax-LLM positioning (R3 discovery: gap competitivo, no public Indonesian tax LLM esiste)
+
+### Cose specifiche da R3
+
+- **Zero Coretax public API**: NON tentare di chiamare Coretax direttamente. Solo via PJAP.
+- **Coretax instability strutturale**: 18/21 issues ancora pending da MUC May 2025. NB-INTEL-Coretax dedicato è giustificato.
+- **Indonesian tax-LLM gap**: posizionamento "Bali Zero machine-augmented" vs joki phenomenon. Aggiungilo al sink dispatcher per articoli editorial.
+- **PajakExpress unico con pricing pubblico** (~Rp 1.5jt/mese stima); Pajakku più maturo ma richiede sales contract.
+
+### Regole forti
+
+- **Anthropic SDK BANNED**. Solo `claude --print` subprocess. (mata-garuda CLAUDE.md)
+- Lazy imports PEP 562.
+- TDD per task: 80+ test attesi (engine layers + feeders + PJAP adapter + workaround lib).
+- Cron PATH include `/Users/nuzantara/.local/bin`.
+- Atomic mv snapshot.
+- Branch hijack scar: `git push` post commit.
+- Cicatrice etica: PJAP credenziali in `~/.nuzantara-secrets.env`, MAI nel repo.
+
+### External review wave (mandatory per dominio Tax — alta accuracy)
+
+Dopo l'implementazione, lancia 3-LLM wave (Codex + DeepSeek + NotebookLM NB-1) **prima** del merge. Il pattern Phase 1 ha trovato 9 bug in 3 wave; per Tax (compliance fiscale) il rischio è più alto. Prompt review focus su:
+
+- PJAP adapter retry semantics
+- Coretax workaround library semantic accuracy (cita PMK/PER source per ogni workaround)
+- Promotion gate stringency (no auto-approve)
+- L4 equalization variance threshold (5% troppo basso? troppo alto?)
+
+### Pre-condizioni per merge
+
+- 80+ test green
+- Live PJAP smoke test (con token o dry-run)
+- Veronika consultata su workflow L1-L6 (non implementare quello che lei rifiuta)
+- `~/logs/tax-engine/tax-engine-daily-YYYYMMDD.log` mostra summary pulito
+
+### Pre-azione richiesta a Antonello
+
+**PRIMA di partire questa fase**:
+
+1. Decidi PJAP partner (Pajakku vs PajakExpress) e firma contratto. Senza, dry-run only.
+2. Conferma con Veronika che il workflow L1-L6 + Veronika sign-off finale è compatibile col modo in cui lei lavora oggi (Marta Reyes case ha mostrato 4 cicatrici evitate, non aggiungerne nuove).
+3. Decidi B2.a (NB-INTEL-Coretax dedicato vs sub-tag) — R3 conferma fortemente "dedicato".
+4. Decidi B2.b (Quote consistency detector attivo/silent/off) — default suggerito: silent (logga ma non alert real-time).
+
+Procedi quando hai conferma su questi 4 punti.

--- a/docs/superpowers/prompts/domain-mesh/03-phase4-marketing.md
+++ b/docs/superpowers/prompts/domain-mesh/03-phase4-marketing.md
@@ -1,0 +1,122 @@
+# Phase 4 — Marketing Pulse (B3)
+
+> **Prerequisiti**: Phase 1+2 mergiate. Phase 3 (Tax) opzionale ma utile per cross-pollination.
+>
+> **Stima**: 7-10 giorni solo-dev.
+>
+> **Pre-azione richiesta a Antonello**: decisione su B3.a (Competitor scraping yes/no) e B3.b (WR2 auto-publish autonomy level).
+
+---
+
+## PROMPT (drop-in)
+
+Continuiamo il Domain Mesh. Phase 4: implementa il dominio **Marketing Pulse (B3)**.
+
+Prima di tutto, leggi:
+
+1. `docs/superpowers/specs/2026-05-08-domain-mesh-autonomic-design.md` §4 B3
+2. `docs/superpowers/specs/2026-05-08-domain-mesh-research/r4-marketing-intelligence-2026-05-08.md` (R4 SOTA)
+3. `apps/mata-garuda/mata_garuda/domains/setup_team/` (pattern template)
+4. `apps/mouth/` (Astro content site esistente)
+5. Cerca WR2 references: `grep -rn "wr2\|WR2" apps/backend-rag/backend/services/ docs/wr2/ 2>/dev/null | head -20`
+6. NB-7 Editorial NB UUID — cerca in memoria: `~/.claude/projects/-Users-nuzantara/memory/reference_notebooklm_arsenal_full.md`
+
+`superpowers:brainstorming` → `writing-plans` → `subagent-driven-development`.
+
+### Scope
+
+**domains/marketing/** modules:
+
+1. **Feeders (3 NB-INTEL)**:
+   - `feeders/nb_intel_press.py`: 14 fonti (tier-1 EN/ID Indonesia + Bali tier-1 + expat verticals)
+   - `feeders/nb_intel_trends.py`: HN Algolia API (R4 free zero-cost) + pytrends + Reddit r/bali r/indonesia free tier (10k req/month) + TikTok Creative Center (manual scrape) — **ZERO COST**
+   - `feeders/nb_intel_competitor.py` (CONDIZIONALE su decisione B3.a): Wayback Machine CDX API per Emerhub/Cekindo/InvestinAsia cadence tracker
+
+2. **Editorial orchestrator**:
+   - `orchestrator.py`: relevance scoring, audience match (expat_it/expat_ru/expat_en/investor/nomad), brief candidates ranking
+   - Pattern AscentAI bottom-up: estrai topic atomici da articoli, aggrega frequency, propose brief
+   - SQLite `marketing.sqlite` con tabelle `content_items`, `trends`, `competitors`, `brief_candidates`
+
+3. **WR2 integration**:
+   - `wr2_brief_generator.py`: trasforma brief candidate in WR2 input format
+   - Trigger automatico (CONDIZIONALE su decisione B3.b)
+   - Hook su `apps/backend-rag/backend/services/wr2/` (esistente)
+
+4. **C2PA Content Credentials** (R4 quick-win 2026 differentiator):
+   - `c2pa_signer.py`: aggiunge content credentials a articoli WR2 prima di publish su mouth
+   - Standard C2PA v2.2/v2.3 (R4 verified, OpenAI/Google/Adobe membri)
+   - Zero cost (open standard)
+
+5. **AI authenticity** (skip Originality.ai per R4 — 7.3% recall su GPT-5-mini, useless):
+   - Use GPTZero (~99% recall) come optional verifier, OR human review hard gate
+
+6. **Reddit organic dispatch** (manuale, NON scraper):
+   - `reddit_dispatch_helper.py`: prepara post text + suggested target subreddits, ma NESSUN auto-post
+   - Antonello/team posta a mano 2-3x/settimana r/digitalnomad, r/IndoBali
+
+7. **Drone Emprit exploratory** (R4 partnership lead):
+   - Spawn `NB-WORKBENCH-DroneEmprit-partnership` (workbench Notion-style markdown in `~/Desktop/nuzantara/research/marketing/`)
+   - NO codice automation per ora; solo case file per discussione con Ismail Fahmi
+
+8. **Cron**:
+   - `infra/scripts/marketing-pulse-cron.sh`
+   - Schedule: 08:00 WITA daily
+   - Kill switch: `MARKETING_CRON_ENABLED=false`
+   - Sink: morning briefing Telegram `#editorial` (3 brief candidates + 1 competitor signal + 1 trending topic)
+
+### Sink (output)
+
+1. **WR2 brief auto-generation** (autonomy level depends on B3.b decision)
+2. **IG carousel suggestion** (NB-INTEL-Trends + NB-7 methodology)
+3. **Telegram `#editorial`** alert daily 8am WITA
+4. **Newsletter digest Brevo** (R4: Brevo MCP server already exists, integrate)
+5. **Mouth dispatch trigger** (article ready → IG + LinkedIn + newsletter orchestrated)
+6. **Reddit organic helper** (manual post text generation)
+
+### R4 traps to avoid
+
+- **Sora 2 deprecation 24 settembre 2026** — NO video generation pipeline su Sora 2.
+- **Originality.ai 7.3% recall** — NO usare per AI detection. GPTZero solo se serve.
+- **Reddit scraping aggressivo** — viola TOS. Solo defensive use (free tier 10k req/month).
+- **Trendpop $250+/min, Talkwalker enterprise** — SKIP. Brand24 Individual $99 sufficient se Antonello vuole social listening Bahasa.
+- **Anthropic Constitution CC0-licensed** (R4 discovery) — usabile come reference per policy AI editorial interna.
+
+### Regole forti
+
+- mata-garuda CLAUDE.md hard rules invariate
+- Lazy imports PEP 562
+- TDD: 50+ test attesi
+- Cron PATH include `/Users/nuzantara/.local/bin`
+- Atomic mv snapshot
+- Branch hijack push post commit
+- C2PA implementation: usa `c2pa-rs` (Rust binary) o `c2pa-python` se esiste, altrimenti tooling Adobe via subprocess
+
+### Pre-condizioni per merge
+
+- 50+ test green
+- WR2 integration smoke test (mock WR2 service, verify brief format)
+- Mouth publish step verifica content credentials presenti
+- External review wave (3 LLM minimum)
+
+### Pre-azione richiesta a Antonello
+
+**PRIMA di partire**:
+
+1. **B3.a**: NB-INTEL-Competitor (Emerhub/Cekindo/InvestinAsia tracking)?
+   - Sì full / Sì weekly digest only / **No** (default consigliato: weekly digest only — competitive awareness senza ansia continua)
+
+2. **B3.b**: WR2 auto-trigger autonomy level?
+   - **A** (consigliato): Auto-brief → auto-WR2 → human review pre-publish (low risk, mid latency)
+   - B: Auto-brief → auto-WR2 → auto-publish con QA gate (low latency, editorial risk)
+   - C: Manuale tutto (safe ma morto)
+
+3. C2PA Content Credentials su mouth — implementarlo?
+   - Pro: differentiator EEAT 2026 + content provenance
+   - Contro: ~3-5 giorni implementation extra
+   - Consigliato: **Sì**, è quick-win zero-cost.
+
+4. Drone Emprit partnership exploration — autorizzi contatto Ismail Fahmi?
+   - Solo case file iniziale, no commitment.
+   - Consigliato: **Sì**, exploratory.
+
+Procedi quando hai conferma su questi 4 punti.

--- a/docs/superpowers/prompts/domain-mesh/04-phase5-antonello-lab.md
+++ b/docs/superpowers/prompts/domain-mesh/04-phase5-antonello-lab.md
@@ -1,0 +1,144 @@
+# Phase 5 — Antonello Lab (B4)
+
+> **Prerequisiti**: Phase 0 foundations. Phase 1+ optional ma utile.
+>
+> **Stima**: 6-9 giorni solo-dev.
+>
+> **Pre-azione richiesta a Antonello**: decisione su B4.a (4/2/1 NB-INTEL distinti) + B4.b (morning briefing daily/weekly/on-demand).
+>
+> **Differenza dagli altri domini**: questo è **personale**, non Bali Zero. Lifecycle ottimizzato per Antonello come singolo utente.
+
+---
+
+## PROMPT (drop-in)
+
+Continuiamo il Domain Mesh. Phase 5: implementa il dominio **Antonello Lab (B4)** — research personale (AI papers, code, robotics, frontier science).
+
+Prima di tutto, leggi:
+
+1. `docs/superpowers/specs/2026-05-08-domain-mesh-autonomic-design.md` §5 B4
+2. `docs/superpowers/specs/2026-05-08-domain-mesh-research/r5-research-agents-2026-05-08.md` (R5 SOTA)
+3. `apps/mata-garuda/mata_garuda/foundations/arxiv_sanity_scorer.py` (Phase 0, già implementato — è la base personalization!)
+4. NB-INTEL-AIResearch UUID: cerca in `~/.claude/projects/-Users-nuzantara/memory/reference_notebooklm_arsenal_full.md`
+
+`superpowers:brainstorming` → `writing-plans` → `subagent-driven-development`.
+
+### Scope
+
+**domains/antonello_lab/** modules:
+
+1. **Feeders (4 NB-INTEL — DECISIONE B4.a, default A=4 distinti)**:
+   - `feeders/nb_intel_airesearch.py`: arxiv API (cs.AI/cs.LG/cs.CL/cs.CV/cs.RO) + Hugging Face papers + Anthropic/OpenAI/DeepMind/Meta blogs + LessWrong AI tag + HN AI stories + Karpathy/Simon Willison + Latent Space + The Batch + TLDR AI subscription parser
+   - `feeders/nb_intel_code.py`: GitHub Trending (huchenme/github-trending-api free) + Star History slope detection + HF Trending Models + Sourcegraph search clusters
+   - `feeders/nb_intel_robotics.py`: Helix Figure blog + π0 Physical Intelligence + Gemini Robotics DeepMind + GR00T NVIDIA + OpenVLA + RT-X + Tesla Optimus + arxiv cs.RO + IROS/ICRA papers
+   - `feeders/nb_intel_frontier_science.py`: Nature RSS + Science RSS + Quanta + Astral Codex Ten + Marginal Revolution + Construction Physics + Asterisk + Nautilus
+
+2. **Personal relevance scorer** (R5 zero-cost):
+   - **Already in Phase 0**: `arxiv_sanity_scorer.py` (SVM-on-tfidf, calibrated)
+   - **Train data**: Antonello tags papers/repos via `/lab tag <id> relevant|not_relevant` slash command
+   - Salva in SQLite `antonello_lab.sqlite` table `tagged_items`
+   - **Zero LLM cost** scoring (R5 Karpathy pattern)
+
+3. **GitHub trending 4-tier signal** (R5):
+   - HN submission >100 pts first 6h on github.com/ URLs (signal 1)
+   - TLDR AI / Latent Space / The Batch mentions (signal 2)
+   - Star History slope jump 5x daily (signal 3)
+   - Sourcegraph search hit cluster (signal 4)
+   - Composite scorer: ≥2 signals → high priority
+
+4. **Morning briefing** (DECISIONE B4.b, default A=daily 7am WITA):
+   - `briefing.py`: top-5 papers + repos trending + robotics + science + 1 Bali Zero cross-pollination
+   - Output: Telegram `#antonello-lab` private channel
+   - Format: structured markdown con priority indicators
+
+5. **Deep-read trigger**:
+   - `/research deep-read <paper_id>` slash command
+   - Spawn `NB-WORKBENCH-Antonello-{paper_topic}` workbench (markdown in `~/Desktop/nuzantara/research/ai/`)
+   - Auto-include: paper PDF, related work map, code repo cloned (if any), summary draft
+
+6. **Research session orchestration**:
+   - `/research <topic>` slash command
+   - gpt-researcher MCP integration (R5: LLM-agnostic, MCP-ready, supports DeepSeek + Ollama)
+   - Multi-agent parallel research (3-5 agent)
+   - Output consolidato in workbench
+
+7. **Cross-pollination**:
+   - Detector: paper letto da Antonello → check rilevanza Bali Zero (es. tax-LLM paper → alert Veronika)
+   - Telegram `#antonello-lab` segnala anche al canale del dominio relevant
+
+8. **Long-term KG**:
+   - `mem0_integration.py`: Mem0 vector + KG mirror su Mini-Pro2
+   - Each deep_read note → entity extraction (NER via Phase 0 ner_extractor) → personal KG
+   - Query "what did I read about RAG in past 6 months?" → cross-paper retrieval
+
+9. **Cron**:
+   - `infra/scripts/antonello-lab-cron.sh`
+   - Schedule: 07:00 WITA daily (briefing pre-work)
+   - Kill switch: `ANTONELLO_LAB_CRON_ENABLED=false`
+
+### Feeder updates from R5 (importante)
+
+**REMOVE da feed list**:
+
+- Papers With Code (DEAD July 2025) → use HF Papers Trending instead
+- Asimov Press (HIATUS April 2026) → cleared
+
+**ADD R5-validated**:
+
+- HF Papers Trending (PWC replacement, R5 confirmed)
+- TLDR AI subscription (1.25M readers, daily digest)
+- gpt-researcher OSS via MCP
+
+### R5 quick-wins zero-cost
+
+- **arXiv API rate**: 1 req/3s (rispetta strict)
+- **OAI-PMH bulk** per backfill se serve catch-up
+- **Semantic Scholar API** 1 req/s con key (gratis)
+- **HN API Firebase** no auth, no rate limit
+- **arxiv-sanity SVM** già in Phase 0 (ZERO cost personalization)
+
+### R5 architecture pattern (R5 §7)
+
+3-tier "second brain" Antonello:
+
+- **Tier 1 (Obsidian-like)**: notes locali in `~/Desktop/nuzantara/research/`
+- **Tier 2 (Readwise-like)**: NB-INTEL-\* aggregator with scoring → SQLite
+- **Tier 3 (NotebookLM)**: NB-9 synthesis + workbench deep dives via MCP
+
+Daily Telegram briefing è il "punto di accesso" al sistema, non il sistema stesso.
+
+### Regole forti
+
+- mata-garuda CLAUDE.md hard rules
+- Lazy imports per ML (transformers/torch)
+- TDD: 40+ test
+- Cron PATH `/Users/nuzantara/.local/bin`
+- Atomic mv snapshot
+- Branch hijack push post commit
+
+### Pre-azione richiesta a Antonello
+
+**PRIMA di partire**:
+
+1. **B4.a**: 4 NB-INTEL distinti (AIResearch+Code+Robotics+FrontierScience)?
+   - **A** (default): 4 distinti — max specialization, cron 4×
+   - B: 2 (AIRes+Code, Rob+Sci) — mid load
+   - C: 1 unificato — min load, max noise
+   - D: priority Robotics+Science first (deferra Code a Phase 6)
+
+2. **B4.b**: Morning briefing format?
+   - **A** (default): Daily 7am WITA Telegram message
+   - B: Weekly Sunday digest (calmo, perdi velocità AI fast-moving)
+   - C: On-demand `/research-pulse` (tu controlli, rischio dimenticarlo)
+
+3. gpt-researcher MCP integration — accetti?
+   - Pro: research orchestration potente, LLM-agnostic
+   - Contro: MCP server da gestire (deps Python, può rompersi)
+   - Default consigliato: Sì.
+
+4. Mem0 long-term KG su Mini-Pro2 — accetti?
+   - Pro: cross-paper query "cosa ho letto su X negli ultimi 6 mesi"
+   - Contro: SQLite + embeddings ~500MB-2GB su Mini disk
+   - Default consigliato: Sì.
+
+Procedi quando confermato.

--- a/docs/superpowers/prompts/domain-mesh/05-phase6-bali-macro.md
+++ b/docs/superpowers/prompts/domain-mesh/05-phase6-bali-macro.md
@@ -1,0 +1,139 @@
+# Phase 6 — Bali Zero Macro (B5)
+
+> **Prerequisiti**: Phase 1 (Setup Team) + Phase 3 (Tax) preferibili — il dominio macro alimenta cross-domain alert routing.
+>
+> **Stima**: 5-8 giorni solo-dev.
+>
+> **Pre-azione richiesta a Antonello**: B5.a (NB-IndonesiaMacro nuova vs estendere NB-8) + B5.b (3 NB-INTEL distinti vs 1 unificato).
+
+---
+
+## PROMPT (drop-in)
+
+Continuiamo il Domain Mesh. Phase 6: implementa il dominio **Bali Zero Macro (B5)** — Indonesia macro intelligence (politica/economia/società/cultura/geo).
+
+Prima di tutto, leggi:
+
+1. `docs/superpowers/specs/2026-05-08-domain-mesh-autonomic-design.md` §6 B5
+2. `docs/superpowers/specs/2026-05-08-domain-mesh-research/r6-country-intelligence-id-2026-05-08.md` (R6 SOTA)
+3. `apps/mata-garuda/mata_garuda/foundations/bali_calendar.py` (Phase 0 — già implementato, integrare in macro per cross-domain calendar guard)
+4. `apps/mata-garuda/mata_garuda/foundations/gdelt_client.py` (Phase 0 — già implementato!)
+5. NB-8 Expat Life Bali UUID + MATA GARUDA gov data UUID — cerca in `~/.claude/projects/-Users-nuzantara/memory/reference_notebooklm_arsenal_full.md`
+
+`superpowers:brainstorming` → `writing-plans` → `subagent-driven-development`.
+
+### Scope
+
+**domains/bali_macro/** modules:
+
+1. **Authority NB**:
+   - DECISIONE B5.a: NB-IndonesiaMacro NEW (default consigliato, R6 conferma) vs estendere NB-8
+   - Se nuova: bootstrap con CSIS Indonesia 2026 + ISEAS Perspective + Lowy Indonesia + World Bank IEU + IMF Article IV + ADB CPS + BPS Statistical Yearbook (~30 seed sources)
+
+2. **Feeders (3 NB-INTEL — DECISIONE B5.b, default A=3 distinti)**:
+   - `feeders/nb_intel_indonesia_policy.py`: setkab cabinet decisions + kemenkeu press + Bank Indonesia press + OJK press + Twitter @prabowo @gibran (verified) + CSIS commentary + ISEAS Indonesia briefs + Lowy Interpreter Indonesia tag
+   - `feeders/nb_intel_indonesia_economy.py`: BPS WebAPI (R2 confirmed REST endpoint) + Bank Indonesia REST + World Bank Indonesia API + IMF Indonesia + ADB Indonesia + Bisnis.com macro + Kontan macro + Asia Nikkei Indonesia
+   - `feeders/nb_intel_indonesia_social.py`: Drone Emprit pers.droneemprit.id (R6: free public releases, NO partnership needed) + Indonesia Indicator periodic + X trends24.in/indonesia + TikTok Indonesia trends manual scrape + Reddit r/indonesia top weekly
+
+3. **Already in Phase 0 — integrate**:
+   - `foundations/gdelt_client.py`: `search_indonesia(query, max_results)` ready to use
+   - `foundations/bali_calendar.py`: Galungan/Kuningan integration
+
+4. **R6 lifecycle 5-layer mapping** (adopt as-is from §6.2 design):
+   - Layer 0 raw signal (15min-daily): GDELT + ACLED + Antara RSS + BPS WebAPI
+   - Layer 1 curated press (daily): Tempo + Kompas.id + Jakarta Post + Project Multatuli + Tirto + NusaBali
+   - Layer 2 thinktank (weekly): CSIS + ISEAS + Lowy + New Mandala + FULCRUM + Habibie + TII + FKP
+   - Layer 3 social pulse (weekly digest): Drone Emprit + Indonesia Indicator + trends24 + TikTok + Reddit
+   - Layer 4 business quarterly: World Bank API + IMF Article IV + ADB CPS + OJK SJK Public + chambers (BritCham/EuroCham/AmCham/IABC)
+
+5. **PolicyEvent entity tracking**:
+   - SQLite `bali_macro.sqlite` table `policy_events`
+   - Schema R6-extended: date, type, regulator, sectors_affected, stakeholders_named, **asta_cita_alignment** (1-8 priority missions), **geopolitical_context**, **dissent_posture_change**, indicator_signal
+   - Cross-domain trigger: PolicyEvent → route to relevant domain orchestrator (Setup Team / Tax / Marketing)
+
+6. **EconomicIndicator tracking**:
+   - GDP, CPI, BI rate, Rupiah, PMI Manufacturing
+   - Drift detector: BI rate hike, CPI spike, Rupiah > 17000/USD → auto-spawn workbench "Indonesia Q-X mid-quarter update"
+
+7. **Bali calendar integration cross-domain**:
+   - `bali_calendar_module.py`: query function `get_balinese_date(gregorian_date) → {saka_year, pawukon_day, ceremonies_today}`
+   - Cross-domain expose: setup-team skip PBG/SLF appointments, tax filing slow window, marketing content "Galungan for expats" 1 week before, CRM "we are closed [DATE]" template
+
+8. **Quarterly outlook auto-draft** (R6 sink 1):
+   - Last week of quarter → auto-generate "Indonesia Outlook Q-X" 8-page PDF from workbench
+   - Antonello reviews then optional publish to clients (newsletter premium)
+
+9. **Cross-domain alert dispatcher** (R6 sink 2):
+   - PolicyEvent classified → route:
+     - Kemenkeu PMK → tax domain
+     - Kemenkumham → setup-team
+     - Kemenparekraf → marketing (tourism vertical)
+     - Bank Indonesia → macro outlook update
+
+10. **Cron**:
+    - `infra/scripts/bali-macro-cron.sh`
+    - Schedule: 09:00 WITA daily
+    - Kill switch: `BALI_MACRO_CRON_ENABLED=false`
+
+### R6 quick-wins
+
+- **GDELT API gratis** (Phase 0 already done!) — 15-min cadence Indonesia FIPS-2 = ID
+- **BPS WebAPI free token-auth** — economic data REST endpoint documented
+- **Drone Emprit pers.droneemprit.id** — free public releases (NO partnership commercial needed for this)
+- **Bali calendar 2026 verified**: Galungan 17 Jun, Kuningan 27 Jun (Phase 0 hardcoded + verified)
+- **Coconuts Bali DEAD post-2023** — remove from any feed list
+
+### R6 geopolitical timeline 2026 anchor (seed)
+
+| Date        | Event                                |
+| ----------- | ------------------------------------ |
+| 2026-01-07  | BRICS membership effective           |
+| 2026-01-21  | IMF Article IV publ.                 |
+| 2026-02-19  | US-Indonesia ART signed $33B         |
+| 2026-02-20  | SCOTUS shakes ART                    |
+| 2026-02 mid | Jakarta Treaty (Australia)           |
+| 2026-04-15  | Prabowo Moscow + new US defense pact |
+| 2026-05-05  | CSIS militarization warning          |
+| 2026-06-17  | Galungan                             |
+| 2026-06-27  | Kuningan                             |
+
+Pre-popola `policy_events` table con questi.
+
+### Sink (output)
+
+1. Quarterly outlook PDF auto-draft
+2. Cross-domain alert dispatcher
+3. Mouth long-form analysis (multi-month framework articles)
+4. Telegram `#bali-macro` weekly strategic alerts (NOT daily — strategic timing)
+5. NB cross-pollination
+
+### Regole forti
+
+- mata-garuda CLAUDE.md
+- Lazy imports
+- TDD: 40+ test
+- Cron PATH
+- Atomic mv
+- Branch hijack push post commit
+
+### Pre-azione richiesta a Antonello
+
+**PRIMA di partire**:
+
+1. **B5.a**: NB-IndonesiaMacro nuova vs estendere NB-8?
+   - **A** (default, R6 conferma): nuova NB-IndonesiaMacro — separata da NB-8 lifestyle
+   - B: estendere NB-8 — meno overhead ma mix lifestyle + strategic
+
+2. **B5.b**: 3 NB-INTEL Macro distinti (Policy + Economy + Social) vs 1?
+   - **A** (default, R6 conferma): 3 distinti — feeder + cadenza + scorer diversi
+   - B: 1 unificato — meno NB ma mix segnale
+
+3. Quarterly outlook PDF — accettazione publish a clienti?
+   - Solo internal / newsletter premium opt-in / blog pubblico
+   - Default consigliato: internal-first, decision Antonello dopo Q1 draft
+
+4. Cross-domain alert dispatcher unified vs domain-specific channels?
+   - NLM W1 ground-truth: bot @Balizerobot unificato — usa lui, NO new channels
+   - Default consigliato: routing all'unico bot esistente.
+
+Procedi quando confermato.

--- a/docs/superpowers/prompts/domain-mesh/06-phase7-nexus-osint.md
+++ b/docs/superpowers/prompts/domain-mesh/06-phase7-nexus-osint.md
@@ -1,0 +1,231 @@
+# Phase 7 — Nexus OSINT (B6)
+
+> **Prerequisiti**: Phase 0+1 mergiate. Phase 6 (Bali Macro) preferibile per cross-pollination.
+>
+> **Stima**: 7-10 giorni solo-dev.
+>
+> **Pre-azione richiesta a Antonello**: B6.a (2 NB-INTEL distinti vs 1) + B6.b (privacy line strict/aggressive/on-demand).
+>
+> **CRITICAL**: questo dominio ha **red lines legali** UU PDP 27/2022. Implementazione errata = 5 anni / Rp 5B sanction. Compliance stance OBBLIGATORIA prima di codice.
+
+---
+
+## PROMPT (drop-in)
+
+Continuiamo il Domain Mesh. Phase 7: implementa il dominio **Nexus OSINT (B6)** — entity tracking + people-graph autorità Indonesia.
+
+**Prima azione**: leggi compliance. NON scrivere codice prima di:
+
+1. `docs/superpowers/specs/2026-05-08-domain-mesh-autonomic-design.md` §7 B6 (compliance stance 10-point)
+2. `docs/superpowers/specs/2026-05-08-domain-mesh-research/r7-osint-entity-people-2026-05-08.md` (R7 SOTA — sezioni 4 e 8 obbligatorie)
+3. **§8.1 R7 UU PDP 27/2022 red lines tabella**: cosa è LEGAL vs ILLEGAL
+
+Solo dopo, leggi: 4. `apps/mata-garuda/mata_garuda/foundations/opensanctions_id.py` (Phase 0 — già implementato!) 5. `apps/mata-garuda/mata_garuda/foundations/ner_extractor.py` (Phase 0 — cahya BERT NER bahasa) 6. MATA GARUDA Indonesia Gov Data Sources NB UUID
+
+`superpowers:brainstorming` (focus su privacy line decision B6.b!) → `writing-plans` → `subagent-driven-development`.
+
+### Scope CRITICAL — privacy first
+
+**Compliance stance 10-point** (R7-validated, OBBLIGATORIO commit before any code):
+
+1. Internal-use only dossier policy
+2. Source restriction: solo public/official Indonesian (KPK/KPU/DPR/BPK/MA/Setkab) + sanctioned international (OpenSanctions free)
+3. **NO data breach DB use**
+4. **NO address/NIK in dossier** (UU PDP Art. 67(2), 5y / Rp 5B)
+5. Hunchly chain-of-custody (opzionale, $130/yr)
+6. 24-month retention max
+7. Privacy notice in client engagement letter
+8. **NO automated mass scraping**
+9. EU clients: GDPR Art. 6(1)(b) + Art. 6(1)(f) balancing test documented
+10. Bellingcat-style ethics review before external output
+
+**Output**: `apps/mata-garuda/mata_garuda/domains/nexus_osint/compliance/compliance_stance.md` — first commit.
+
+### Architecture 3-layer (R7 Palantir-pattern, NOT prodotto)
+
+```
+domains/nexus_osint/
+├── semantic/
+│   └── entity_definition.yaml  # Person, Organization, Event, Sanction
+├── kinetic/
+│   ├── lhkpn_scraper.py
+│   ├── wikidata_sparql.py
+│   ├── opensanctions_id_pull.py  # already in Phase 0
+│   ├── tempo_rss_ingest.py
+│   ├── ner_extractor.py  # already in Phase 0
+│   └── maigret_username.py
+├── dynamic/
+│   ├── privacy_guardrails.rego  # UU PDP enforcement (CRITICAL)
+│   ├── role_change_detection.py
+│   └── publication_gate.py  # auto-redact NIK/address before any external output
+└── compliance/
+    └── compliance_stance.md  # 10-point policy
+```
+
+### Storage backend — Wikibase self-host (R7 recommendation)
+
+- Self-hosted Wikibase instance su Mini-Pro2 (docker)
+- Same data model as Wikidata (interoperable)
+- SPARQL query interface (standard)
+- JSON entity export
+- Federated query Wikidata + local
+
+**Bootstrap quick-win** (R7 §6.6 Wikidata SPARQL):
+
+```sparql
+SELECT ?person ?personLabel ?roleLabel ?orgLabel ?dob WHERE {
+  ?person p:P39 ?role_statement.
+  ?role_statement ps:P39 ?role.
+  ?role wdt:P31* wd:Q294414.  # public office Indonesia
+  ?role wdt:P17 wd:Q252.      # country: Indonesia
+  OPTIONAL { ?person wdt:P569 ?dob. }
+  ?role pq:P108 ?org.
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+}
+LIMIT 500
+```
+
+→ 200-500 Indonesian public officials seed entries. Effort: 4-6 hours.
+
+### Feeders (DECISIONE B6.a, default A=2 distinti)
+
+1. **`feeders/nb_intel_authorities.py`** (formal):
+   - e-LHKPN scraper (kpk.go.id) — wealth declarations
+   - DPR.go.id members API
+   - KPU Daftar Caleg infopemilu.kpu.go.id
+   - Setkab cabinet (setkab.go.id/profil-kabinet)
+   - BKN Satu Data ASN (limited public)
+   - BPK audit reports
+   - Mahkamah Agung Direktori Putusan
+   - **OpenSanctions Indonesia datasets** (already Phase 0!): `id_dttot`, `id_regional_2018`
+
+2. **`feeders/nb_intel_curiosities.py`** (informal/long-form):
+   - Tempo "tokoh" tag RSS
+   - Kompas politicians database
+   - Tirto.id deep dive
+   - Project Multatuli investigations
+   - Watchdoc YouTube channel monitoring (RSS via youtube-rss)
+   - Mata Najwa interviews (Narasi.tv)
+
+### NER pipeline cross-domain (R7 §5)
+
+Phase 0 `ner_extractor` con `cahya/bert-base-indonesian-NER` già pronto.
+
+Estrai cross-domain:
+
+- **B5 macro press**: Person, Org da Tempo/Tirto/Multatuli articles
+- **B1 setup-team regulation**: Person (regulator firmatario), Org (ministero)
+- **B2 tax**: Person, Org da DJP press
+- **B6 nexus**: NER è il core per entity extraction
+
+### Stack zero-cost (R7 confirmed, $130/yr only Hunchly)
+
+| Layer                | Tool                                           | Cost         |
+| -------------------- | ---------------------------------------------- | ------------ |
+| Entity ontology      | Wikibase self-host + Wikidata seed             | FREE         |
+| Sanctions            | OpenSanctions API (Phase 0 done)               | FREE         |
+| People-graph         | Wikidata SPARQL + LittleSis API + LHKPN scrape | FREE         |
+| Investigative search | OCCRP Aleph (request access journos)           | FREE/journos |
+| Username pivots      | Maigret 3000+ sites                            | FREE         |
+| Email pivots         | Holehe + Mosint                                | FREE         |
+| NER                  | cahya BERT (Phase 0 done)                      | FREE         |
+| Visualization        | Gephi + NetworkX                               | FREE         |
+| Evidence custody     | Hunchly                                        | $130/yr      |
+| News surveillance    | Tempo/Tirto/Multatuli/Watchdoc RSS             | FREE         |
+
+**Skip**: Maltego ($$$$), Sayari ($$$$$), World-Check ($$$$$+), Palantir (cost + ETHICS red flags vedi memory `palantir-anthropic-hybris`).
+
+### Sinks (R7 §7.9)
+
+1. **`/whois <name>` CLI** — instant card from Wikibase + recent NB-INTEL mentions
+2. **Strategic intel briefing monthly** — top 5 people changes + top 3 org reshuffle
+3. **Editorial fodder** — Curiosities NB → marketing brief candidates (federation con B3)
+4. **Cross-domain alert** — Person change → relevant domain (DG Pajak → tax, BKPM head → setup-team)
+5. **Network graph viz** — Gephi + NetworkX export
+6. **NEW Client Due Diligence Hunchly workflow**:
+   - Trigger: nuovo cliente high-value (quote > €10k)
+   - Maigret username search → social presence map
+   - OpenSanctions check → no PEP/sanction match
+   - Wikidata cross-ref → no public profile flags
+   - Hunchly capture all evidence pages → SHA-256 hash
+   - Internal dossier → `NB-WORKBENCH-Nexus-Client-{id}`
+   - Engagement letter privacy notice signed
+   - Cost: $130/yr Hunchly + 30min analyst time per cliente
+7. **NEW OCCRP Aleph partnership exploration**:
+   - Spawn workbench, contact OCCRP ID research desk
+   - Use case: due diligence cliente high-value multi-jurisdiction
+
+### Privacy guardrails (CRITICAL)
+
+`dynamic/publication_gate.py`:
+
+- Auto-redact NIK pattern (`\d{16}`) prima di qualsiasi output esterno
+- Auto-redact home address pattern (Jl. + numero + RT/RW)
+- Block emit Telegram alert se entity ha `controversy.unverified=True`
+- Manual override: `force_publish=True` requires Antonello signature in code path
+
+### R7 red flag check (legal)
+
+Prima di ogni feature implementata, attraversa il flow di R7 §8.4 doxing line:
+
+| Activity                                       | Legal?                                      |
+| ---------------------------------------------- | ------------------------------------------- |
+| Reading e-LHKPN public data                    | LEGAL                                       |
+| Querying Daftar Caleg KPU                      | LEGAL                                       |
+| Compiling internal dossier from public sources | LEGAL (internal)                            |
+| Publishing pejabat home address                | **ILLEGAL — UU PDP Art. 67(2), 5y / Rp 5B** |
+| Publishing pejabat NIK / KTP                   | **ILLEGAL — sensitive data UU PDP Art. 4**  |
+| Cross-ref data breach DB                       | **ILLEGAL — UU PDP Art. 65**                |
+| OSINT for KYC due diligence (internal)         | LEGAL — lawful interest, document           |
+
+### Cron
+
+- `infra/scripts/nexus-osint-cron.sh`
+- Schedule: 10:00 WITA daily
+- Kill switch: `NEXUS_OSINT_CRON_ENABLED=false`
+
+### Regole forti
+
+- mata-garuda CLAUDE.md hard rules invariate
+- Lazy imports
+- TDD: 50+ test (incluso compliance test che assert privacy_guardrails enforce)
+- Cron PATH
+- Branch hijack push post commit
+- **Compliance stance.md committed PRIMA di qualsiasi codice**
+
+### External review wave (mandatory per Nexus — alta sensibilità legale)
+
+3-LLM minimum (Codex GPT-5 + DeepSeek + NotebookLM NB-1) + **security-review skill obbligatorio**. Focus su:
+
+- Privacy guardrails enforce realmente?
+- LHKPN scraping rate-limited (no UA rotation aggressiva)?
+- Hunchly integration o solo theatrical?
+- UU PDP red lines respect in OGNI sink?
+
+### Pre-azione richiesta a Antonello
+
+**PRIMA di partire**:
+
+1. **B6.a**: 2 NB-INTEL OSINT distinti (Authorities + Curiosities) vs 1?
+   - **A** (default): 2 distinti — Authorities formal, Curiosities informal
+   - B: 1 unificato — mix segnale formal vs informal
+
+2. **B6.b**: Privacy line — quanto profondo vai?
+   - A: Strict open-source only (UU PDP max compliant, profile magri)
+   - B: Aggressive OSINT (LinkedIn scraping, social cross-ref) — **R7 dice ILLEGAL, NO**
+   - **C** (default, R7 confirmed UU PDP-compliant): Strict + manual deep-dive on demand — caso-per-caso
+
+3. Hunchly $130/yr — confermi acquisto?
+   - Pro: chain-of-custody legalmente difendibile
+   - Contro: $130/yr operational cost
+   - Default consigliato: Sì (cost basso, valore reputazionale alto)
+
+4. Wikibase self-host su Mini-Pro2 — accetti docker overhead (5-8 ore/mese maintenance)?
+   - Alternativa: SQLite triple store custom (R7 DeepSeek W1 alternative)
+   - Default consigliato: SQLite first, Wikibase Phase 8+ se serve federation Wikidata
+
+5. OCCRP Aleph access request — autorizzi?
+   - Solo discovery, no commitment
+   - Default consigliato: Sì exploratory
+
+Procedi SOLO quando confermato. Compliance stance file commit PRIMA di codice.

--- a/docs/superpowers/prompts/domain-mesh/07-phase8-cross-domain-federation.md
+++ b/docs/superpowers/prompts/domain-mesh/07-phase8-cross-domain-federation.md
@@ -1,0 +1,134 @@
+# Phase 8 — Cross-Domain Federation Layer
+
+> **Prerequisiti**: TUTTE le 6 fasi domain (B1-B6) implementate. Senza, non c'è "cross" da fare.
+>
+> **Stima**: 8-12 giorni solo-dev.
+>
+> **Pre-azione richiesta a Antonello**: nessuna. Questa fase è puramente integrativa.
+>
+> **Differenza dalle fasi precedenti**: questa NON aggiunge un nuovo dominio, **collega quelli esistenti** in un grafo federato + skill graduation pipeline (la promessa Round 2 dal R1.5 NB lifecycle).
+
+---
+
+## PROMPT (drop-in)
+
+Continuiamo il Domain Mesh. Phase 8 (finale): implementa il **Cross-Domain Federation Layer**.
+
+Verifica precondizione:
+
+```bash
+ls apps/mata-garuda/mata_garuda/domains/
+# Deve contenere: setup_team/ tax/ marketing/ antonello_lab/ bali_macro/ nexus_osint/
+```
+
+Se mancano domini → STOP e implementa quelli prima.
+
+Poi leggi:
+
+1. `docs/superpowers/specs/2026-05-08-domain-mesh-autonomic-design.md` §8 (cross-domain federation completa)
+2. Phase 0 mitochondrial value monitor (PR #493 reference) — è la base per Phase 8 auto-correct
+3. NB lifecycle R1+R1.5 closure (memoria `~/.claude/projects/-Users-nuzantara/memory/MEMORY.md` cerca "NB Lifecycle R1+R1.5 closed")
+
+`superpowers:brainstorming` → `writing-plans` → `subagent-driven-development`.
+
+### Scope
+
+**`apps/mata-garuda/mata_garuda/federation/`** modules:
+
+1. **Cross-domain entity overlap layer**:
+   - `entity_registry.py`: SQLite + Wikibase (se Phase 7 ha implementato) per shared entity store
+   - 12 entity types (design §8.2 matrix): Person, Organization, KBLI, RegulatoryDoc, Property, ContentItem, Trend, Paper, PolicyEvent, Obligation, CoretaxIncident, CalendarBaliCeremony
+   - Each entity has `owned_by` (B1-B6) + `referenced_by` (lista)
+   - Cross-domain query: `lookup_entity(name) → list[(domain, ref_url)]`
+
+2. **Cross-domain alert routing** (design §8.4):
+   - `alert_router.py`: PolicyEvent → tax/setup, KEP-71 → tax+content brief candidate, etc.
+   - Single Telegram bot @Balizerobot (NLM ground-truth W1: NO per-domain channels)
+   - Routing rules in `alert_routing_rules.yaml` (declarative)
+   - Test: feed PolicyEvent payload, assert routes correctly
+
+3. **Multi-LLM fallback strategy** (design §8.5):
+   - `llm_fallback.py`: priority Claude OAuth → DeepSeek → Gemini CLI → Codex CLI → Ollama local
+   - Cost-aware: each call logs to Langfuse/Phoenix (Phase 0 OpenLLMetry SDK if activated)
+   - Graceful degradation: max 30s wait per single LLM exhaust, then queue + Telegram alert
+
+4. **Auto-correct layer** (design §1.4):
+   - `drift_detector.py`: weekly cron — check superseded regulations (PMK abrogated by newer)
+   - `conflict_detector.py`: nightly — cross-NB queries on overlapping entities (es. KITAS C312 validity NB-2 vs NB-INTEL-Immigration)
+   - `self_coherence_probe.py`: per AUTHORITY NB, weekly LLM internal consistency check
+
+5. **Telemetry & explainability** (design §1.5):
+   - `mitochondrial_monitor_extended.py`: Phase 0 monitor extended a TUTTI i NB (non solo NB-INTEL)
+   - `decision_log.py`: JSONL append-only di ogni autonomous action
+   - Schema: `{ts, actor, action, target_nb, source_url, scorer_confidence, router_decision, reasoning, policy_applied}`
+   - `explainability_api.py`: `GET /nb/{id}/why?source={source_id}` returns decision log entry
+   - `weekly_self_report.py`: cron Sunday genera markdown report per dominio
+
+6. **Skill graduation pipeline** (design §1.6 sink 5):
+   - `skill_graduation.py`: detector di NB-WORKBENCH che hanno raggiunto maturity (3+ deep items, sustained query traffic, no internal conflicts)
+   - Auto-spawn proposal in `~/.claude/plugins/proposed-skills/<name>/SKILL.md`
+   - Antonello review + approve via `/skills/graduate <name>` slash command
+   - Once approved: skill copied to `~/.claude/plugins/cache/.../skills/`
+
+7. **ADR auto-generator** (design §1.6 sink 6):
+   - `adr_generator.py`: critical autonomous decisions (NB-merge, NB-decommission, federation rule change) → ADR markdown in `docs/adr/`
+   - Format: standard MADR template
+   - Sign-off: system + Antonello approval timestamp
+
+8. **Cross-domain cron orchestrator**:
+   - `infra/scripts/federation-cron.sh`
+   - Schedule: 11:00 WITA daily (after all domain crons 06:00-10:00)
+   - Tasks: drift detection, conflict detection, mitochondrial scan, weekly self-report (Sunday only)
+   - Kill switch: `FEDERATION_CRON_ENABLED=false`
+
+### Integration con codebase esistente
+
+- **EventBus** (PG LISTEN/NOTIFY + outbox): cross-domain alerts pubblicano su events_outbox
+- **Innervation Genoma**: federation-cron è enrolled organism in `apps/organism/organism/genome.yaml`
+- **Symbiosis Law 4** redundancy: ogni cross-domain alert handler is idempotent (replay-safe)
+- **Mitochondrial Monitor** Phase 0 PR #493: estendi per supportare Phase 1-8 NB
+
+### Deliverables
+
+1. 6 nuovi moduli core in `mata_garuda/federation/`
+2. `alert_routing_rules.yaml` declarative
+3. SQLite migrations per `decision_log`, `entity_registry`
+4. ADR template
+5. Skill graduation slash command
+6. Cron LaunchAgent
+7. 80+ test (entity registry CRUD + routing rules + drift simulation + mitochondrial scoring)
+
+### Sink (chiusura del lifecycle)
+
+A questo punto, il sistema è **completo** secondo il design 5-fase:
+
+- ① **Nascita**: genesis manifests per ogni dominio
+- ② **Crescita**: 4 modalità (manual, cron, promotion, federation) attive
+- ③ **Auto-correct**: drift + conflict + self-coherence
+- ④ **Coscienza**: mitochondrial + decision log + explainability + weekly report
+- ⑤ **Canalizzazione**: 6 sink (mouth, telegram, CRM, dispatch, skill graduation, ADR) tutti vivi
+
+### Regole forti
+
+- mata-garuda CLAUDE.md
+- Lazy imports
+- TDD strict (federation è critico, ogni regola routing test-coperta)
+- Cron PATH
+- Branch hijack push
+- External review wave OBBLIGATORIO 5-LLM (3 wave) prima merge — federation tocca tutti i domini, blast radius alto
+
+### Pre-condizioni per merge
+
+- 80+ test green
+- Smoke test: PolicyEvent fake → assert routes a 3+ domini correttamente
+- Mitochondrial monitor smoke su 3+ NB: scoring corretto
+- Decision log audit: 24h di esecuzione produce JSONL valido
+- Antonello approva alert routing rules YAML
+
+### Esito finale
+
+Quando questa fase merga, hai il sistema autonomico completo end-to-end: 6 domini × 5 fasi lifecycle × federation graph × auto-correct × explainability × skill graduation pipeline.
+
+A quel punto il sistema è in modalità **operational**: nuove feature solo via PR review umano + brainstorm session ad-hoc, non più phased rollout.
+
+Procedi.

--- a/docs/superpowers/prompts/domain-mesh/README.md
+++ b/docs/superpowers/prompts/domain-mesh/README.md
@@ -1,0 +1,96 @@
+# Domain Mesh — Phase Continuation Prompts
+
+Prompt drop-in per continuare il **Domain Mesh autonomic system** (Bali Zero / Nuzantara) dopo l'implementazione iniziale del 2026-05-08.
+
+## Stato corrente (snapshot 2026-05-08)
+
+✅ **Implementato e merged in main**:
+
+- Phase 0 (foundations, 8 moduli) — PR #523
+- Phase 1 (B1 Setup Team, 9 moduli) — PR #534 + #536 + #540
+- Design doc + 7 SOTA research reports — PR #518
+- 9 bug fixed via 3 wave external review (PR #525, #526, #529)
+- 106 test green
+- Cron `com.balizero.setup-team.daily` LIVE su Pro
+
+📦 **Pendente**:
+
+| Fase | Dominio | Prompt | Stima |
+|---|---|---|---|
+| **Phase 2** | Setup Team extend (Property + Labor) | `01-phase2-setup-team-extend.md` | 5-7 giorni |
+| **Phase 3** | B2 Tax Engine | `02-phase3-tax-engine.md` | 10-14 giorni |
+| **Phase 4** | B3 Marketing Pulse | `03-phase4-marketing.md` | 7-10 giorni |
+| **Phase 5** | B4 Antonello Lab | `04-phase5-antonello-lab.md` | 6-9 giorni |
+| **Phase 6** | B5 Bali Macro | `05-phase6-bali-macro.md` | 5-8 giorni |
+| **Phase 7** | B6 Nexus OSINT | `06-phase7-nexus-osint.md` | 7-10 giorni |
+| **Phase 8** | Cross-domain federation | `07-phase8-cross-domain-federation.md` | 8-12 giorni |
+
+Totale stima: **48-70 giorni solo-dev** per completamento full mesh.
+
+## Come usare
+
+1. **Apri nuova sessione Claude Code**.
+2. **Decidi quale fase avanzare** (di solito sequenza naturale: 2 → 3 → 4 → 5 → 6 → 7 → 8).
+3. **Copia il prompt corrispondente** dal file `.md` della fase.
+4. **Incollalo come PRIMA riga** della sessione.
+5. Claude leggerà spec + research + codebase, poi eseguirà brainstorm → plan → implementation con subagent-driven.
+
+In alternativa: usa il **master orchestrator** (`00-MASTER-ORCHESTRATOR.md`) che si auto-orienta e ti chiede quale fase.
+
+## Pattern condiviso da tutte le fasi
+
+Tutte seguono questa pipeline:
+
+1. Read spec + research + codebase
+2. `superpowers:brainstorming` (conferma 5-fase lifecycle adattato al dominio)
+3. `superpowers:writing-plans` → file in `docs/superpowers/plans/`
+4. `superpowers:subagent-driven-development` (TDD per task, push dopo ogni commit)
+5. External review wave (Codex GPT-5 + DeepSeek v4 + NotebookLM NB-1, optional Sonnet 4.6 + security-review skill)
+6. Triage feedback indipendente, fix bug reali (non taste)
+7. PR + auto-merge
+
+## Regole non negoziabili (in ogni fase)
+
+- **Niente Anthropic API key** — solo `claude --print` subprocess via OAuth Max
+- **mata-garuda deps minimal** — `pydantic>=2` core, pesanti in `[project.optional-dependencies] foundations`
+- **Lazy imports PEP 562** — per tutto ciò che tocca ML deps
+- **Branch hijack scar protection** — `git push` dopo OGNI commit, branch verify pre-Edit
+- **Cron LaunchAgent** — absolute venv python, atomic mv snapshot, kill switch env var, PATH includes `/Users/nuzantara/.local/bin`
+- **TDD per task** — test fail → impl → test pass → commit + push
+- **External review obbligatorio** prima del merge (qualità SOTA)
+
+## Ordine consigliato (priorità business)
+
+Se Antonello vuole massimo impatto business veloce:
+
+1. **Phase 2** (Setup Team complete) — chiude il dominio già operativo
+2. **Phase 3** (Tax Engine) — Veronika beneficia direttamente, alta utilizzazione clienti
+3. **Phase 4** (Marketing) — content engine accelera dispatch
+4. **Phase 6** (Bali Macro) — feeds altre fasi con cross-domain context
+5. **Phase 7** (Nexus OSINT) — KYC due diligence + curiosità autorità
+6. **Phase 5** (Antonello Lab) — personale, può aspettare
+7. **Phase 8** (Federation) — chiusura sistema
+
+Se Antonello vuole **systems thinking first** (federation power asap):
+
+1. Phase 2 quick-win
+2. Phase 8 SUBSET (cross-domain alert routing solo) — sblocca routing tra B1 + B6
+3. Poi domini residui
+
+## Reference
+
+- **Master spec**: `docs/superpowers/specs/2026-05-08-domain-mesh-autonomic-design.md`
+- **Phase 0 plan**: `docs/superpowers/plans/2026-05-08-domain-mesh-phase0-foundations.md`
+- **Phase 1 plan**: `docs/superpowers/plans/2026-05-08-domain-mesh-phase1-setup-team.md`
+- **R1-R7 research**: `docs/superpowers/specs/2026-05-08-domain-mesh-research/`
+- **External reviews wave 1+2+3**: `docs/superpowers/specs/2026-05-08-domain-mesh-research/external-reviews*/`
+
+## Quick start (master prompt)
+
+In nuova sessione, incolla:
+
+```
+Continuiamo il Domain Mesh autonomic system. Leggi `docs/superpowers/prompts/domain-mesh/00-MASTER-ORCHESTRATOR.md` e dimmi quale fase posso avanzare.
+```
+
+Claude si orienta da solo e ti propone il prossimo step.


### PR DESCRIPTION
## Summary

7 phase-continuation prompts + 1 master orchestrator + README for the Domain Mesh autonomic system.

After 9 PR shipped today (Phase 0+1 + 3 review wave + endpoints fixes), the design needs ~48-70 more solo-dev days to complete (Phase 2-8). These prompts are drop-in: paste into a new Claude Code session and the work continues.

## Files added

\`docs/superpowers/prompts/domain-mesh/\`:

- \`README.md\` — index + current state + priority ordering + quick start
- \`00-MASTER-ORCHESTRATOR.md\` — auto-orient, asks which phase to advance
- \`01-phase2-setup-team-extend.md\` — B1 extend (Property + Labor), 5-7 days
- \`02-phase3-tax-engine.md\` — B2 Tax Engine, 10-14 days, needs PJAP partner
- \`03-phase4-marketing.md\` — B3 Marketing + WR2 + C2PA, 7-10 days
- \`04-phase5-antonello-lab.md\` — B4 personal research lab, 6-9 days
- \`05-phase6-bali-macro.md\` — B5 Indonesia macro (GDELT + 5-layer R6), 5-8 days
- \`06-phase7-nexus-osint.md\` — B6 OSINT (UU PDP compliance critical), 7-10 days
- \`07-phase8-cross-domain-federation.md\` — federation + skill graduation, 8-12 days

## Each prompt is self-contained

Pre-conditions, estimate, pre-actions for Antonello (B1.a-B6.b decisions), scope (in/out), R1-R7 SOTA quick-wins, pattern from Phase 0/1 to follow, hard rules (mata-garuda CLAUDE.md, no Anthropic SDK, lazy imports), external review wave obligation.

## How to use

In a new Claude Code session, paste:

\`\`\`
Continuiamo il Domain Mesh autonomic system.
Leggi \`docs/superpowers/prompts/domain-mesh/00-MASTER-ORCHESTRATOR.md\`
e dimmi quale fase posso avanzare.
\`\`\`

Claude reads current state, proposes next step with the corresponding prompt file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)