### PR TITLE
fix(backend-rag/deps): pin boto3 — Tigris uploads were failing in WR2 image-generator

### DIFF
--- a/apps/backend-rag/requirements-prod.txt
+++ b/apps/backend-rag/requirements-prod.txt
@@ -25,6 +25,13 @@ google-auth>=2.23.0
 google-auth-oauthlib>=1.1.0
 google-auth-httplib2>=0.1.1
 google-cloud-storage>=2.10.0
+
+# Tigris (S3-compatible) — used by scripts/wr2_image_generator.py +
+# scripts/wr2_draft_generator.py to upload hero images to the warroom
+# bucket. No backend module imports it; pinned here so production venv
+# rebuilds (Pro `nuzantara-deploy` worktree) stay self-sufficient.
+boto3>=1.43.0
+
 langchain>=0.1.0
 langchain-core>=0.1.0
 langchain-anthropic>=1.0.0

--- a/apps/backend-rag/requirements.txt
+++ b/apps/backend-rag/requirements.txt
@@ -23,6 +23,12 @@ google-auth-httplib2>=0.1.1
 google-cloud-storage>=2.10.0
 google-cloud-aiplatform>=1.40.0  # Now compatible with OTEL (protobuf 5.x)
 
+# Tigris (S3-compatible) — used by scripts/wr2_image_generator.py +
+# scripts/wr2_draft_generator.py to upload hero images to the warroom
+# bucket. No backend module imports it; pinned here so production venv
+# rebuilds (Pro `nuzantara-deploy` worktree) stay self-sufficient.
+boto3>=1.43.0
+
 # AI/ML - UPGRADED FOR HTTPX 0.28+ COMPATIBILITY
 openai>=2.14.0  # Upgraded for httpx 0.28+ (proxies parameter removed)
 anthropic>=0.75.0  # Upgraded for httpx 0.28+ compatibility


### PR DESCRIPTION
## Summary

Empirical bug discovered during cron audit 2026-05-08 ~10:30 WITA. WR2 `image_generator` cron failed all 3 hero images for draft `a3fd4007-52a6-47cc-be54-8452d8b2d530` at 08:18 WITA with `rejection_reason`:

```
all_images_failed: ["tigris upload failed: No module named 'boto3'", ...]
```

## Root cause

`scripts/wr2_image_generator.py` and `scripts/wr2_draft_generator.py` both `import boto3` to upload generated PNGs to the warroom Tigris bucket. **Neither `requirements.txt` nor `requirements-prod.txt` declared boto3 as a direct dependency.** It had been installed by hand on Pro at some point (transitive via `cloudpathlib`/`smart_open`/`litellm`) and was lost on a venv recreate.

A manual `pip install boto3` at 08:31 WITA unblocked production (draft `a3fd4007` progressed to `status=rendered`), but the fix was not durable — the next venv rebuild on the `nuzantara-deploy` worktree (e.g. on a fresh Pro provision) would re-introduce the bug.

## Changes

- `apps/backend-rag/requirements.txt`: add `boto3>=1.43.0` near `google-cloud-storage` with comment explaining usage
- `apps/backend-rag/requirements-prod.txt`: same addition (the prod deploy uses this file via Dockerfile builder stage)

Version floor `1.43.0` matches what was already installed transitively in the Pro venv.

## Test plan

- [x] Empirical: all 3 hero images failed with No module named boto3 before manual install
- [x] After manual install: draft progressed to status=rendered, Tigris upload OK
- [ ] CI green