### PR TITLE
feat(setup-team/feeders): Phase 1.5 PR-B — Bali jdih expansion 4→10 portals

### DIFF
--- a/apps/mata-garuda/data/gov_apis_inventory.json
+++ b/apps/mata-garuda/data/gov_apis_inventory.json
@@ -51,5 +51,35 @@
     "id": "jdih_denpasarkota",
     "url": "https://jdih.denpasarkota.go.id",
     "category": "regulation_bali"
+  },
+  {
+    "id": "jdih_tabanankab",
+    "url": "https://jdih.tabanankab.go.id",
+    "category": "regulation_bali"
+  },
+  {
+    "id": "jdih_bulelengkab",
+    "url": "https://jdih.bulelengkab.go.id",
+    "category": "regulation_bali"
+  },
+  {
+    "id": "jdih_klungkungkab",
+    "url": "https://jdih.klungkungkab.go.id",
+    "category": "regulation_bali"
+  },
+  {
+    "id": "jdih_karangasemkab",
+    "url": "https://jdih.karangasemkab.go.id",
+    "category": "regulation_bali"
+  },
+  {
+    "id": "pemkab_bangli",
+    "url": "https://www.banglikab.go.id/berita",
+    "category": "regulation_bali"
+  },
+  {
+    "id": "pemkab_jembrana",
+    "url": "https://jembranakab.go.id/articles",
+    "category": "regulation_bali"
   }
 ]

--- a/apps/mata-garuda/mata_garuda/domains/setup_team/feeders/nb_intel_regulation_bali.py
+++ b/apps/mata-garuda/mata_garuda/domains/setup_team/feeders/nb_intel_regulation_bali.py
@@ -40,20 +40,44 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT_SECONDS = 20.0
 
-# 4 Bali jdih portals (must already be in gov_apis_inventory.json).
+# 8 Bali jdih portals + 2 Pemkab homepage fallbacks
+# (Phase 1.5 PR-B 2026-05-08: expanded from 4 to 10. The 4 added jdih are
+# Tabanan/Buleleng/Klungkung/Karangasem. The 2 Pemkab fallbacks are Bangli
+# and Jembrana — their dedicated jdih.<kab>.go.id subdomains DNS-fail or
+# timeout from this network, so we scrape Pemkab homepage news instead.)
+#
+# All 10 entries must exist in gov_apis_inventory.json — load_inventory()
+# is the source of truth.
 BALI_PORTAL_IDS = (
+    # Original 4 jdih (Phase 1).
     "jdih_baliprov",
     "jdih_badungkab",
     "jdih_gianyarkab",
     "jdih_denpasarkota",
+    # New jdih (Phase 1.5 PR-B, all verified live 200 on 2026-05-08).
+    "jdih_tabanankab",
+    "jdih_bulelengkab",
+    "jdih_klungkungkab",
+    "jdih_karangasemkab",
+    # Pemkab homepage fallbacks (the dedicated jdih subdomain was DNS-fail
+    # or timeout on 2026-05-08; the Pemkab homepage carries enough Perda/
+    # Perbup news in its /berita or /articles section to not lose coverage).
+    "pemkab_bangli",
+    "pemkab_jembrana",
 )
 
-# Tier-1 trusted (all 4 are gov direct).
+# Tier-1 trusted: all 10 are gov direct (.go.id under provincia/kabupaten/kota).
 TRUSTED_TIER1_HOSTS = {
     "jdih.baliprov.go.id",
     "jdih.badungkab.go.id",
     "jdih.gianyarkab.go.id",
     "jdih.denpasarkota.go.id",
+    "jdih.tabanankab.go.id",
+    "jdih.bulelengkab.go.id",
+    "jdih.klungkungkab.go.id",
+    "jdih.karangasemkab.go.id",
+    "banglikab.go.id",
+    "jembranakab.go.id",
 }
 
 CATEGORY_REGEXES = {

--- a/apps/mata-garuda/tests/domains/setup_team/test_feeders.py
+++ b/apps/mata-garuda/tests/domains/setup_team/test_feeders.py
@@ -28,6 +28,7 @@ from mata_garuda.domains.setup_team.feeders.nb_intel_regulation import (
 from mata_garuda.domains.setup_team.feeders.nb_intel_regulation_bali import (
     BALI_PORTAL_IDS,
     CATEGORY_REGEXES,
+    TRUSTED_TIER1_HOSTS as BALI_TRUSTED_TIER1_HOSTS,
     _classify_categories,
     fetch_recent_regulation_bali,
 )
@@ -364,18 +365,59 @@ def test_bali_category_regexes_classify_correctly():
     assert _classify_categories("") == ()
 
 
-def test_bali_portal_ids_are_the_4_canonical():
-    assert BALI_PORTAL_IDS == (
+def test_bali_portal_ids_include_all_8_jdih_plus_2_pemkab_fallbacks():
+    """Phase 1.5 PR-B — expanded from 4 to 10 portals.
+
+    8 jdih portals (4 original + 4 added 2026-05-08): provincia + Badung
+    + Gianyar + Denpasar + Tabanan + Buleleng + Klungkung + Karangasem.
+
+    2 Pemkab homepage fallbacks (Bangli + Jembrana — their dedicated
+    jdih.<kab>.go.id subdomains DNS-fail or timeout, so we scrape the
+    Pemkab homepage's /berita or /articles section instead).
+
+    Live verification 2026-05-08: all 8 jdih return 200; banglikab.go.id
+    and jembranakab.go.id return 200 with regulation-relevant berita.
+    """
+    assert set(BALI_PORTAL_IDS) == {
+        # Original 4 (Phase 1).
         "jdih_baliprov",
         "jdih_badungkab",
         "jdih_gianyarkab",
         "jdih_denpasarkota",
+        # New jdih (Phase 1.5 PR-B).
+        "jdih_tabanankab",
+        "jdih_bulelengkab",
+        "jdih_klungkungkab",
+        "jdih_karangasemkab",
+        # Pemkab homepage fallbacks (jdih.<kab>.go.id was unreachable).
+        "pemkab_bangli",
+        "pemkab_jembrana",
+    }
+
+
+def test_bali_trusted_tier1_hosts_includes_all_10_portals():
+    """All gov-direct hosts must be tier-1 trusted for the scorer."""
+    expected = {
+        "jdih.baliprov.go.id",
+        "jdih.badungkab.go.id",
+        "jdih.gianyarkab.go.id",
+        "jdih.denpasarkota.go.id",
+        "jdih.tabanankab.go.id",
+        "jdih.bulelengkab.go.id",
+        "jdih.klungkungkab.go.id",
+        "jdih.karangasemkab.go.id",
+        "banglikab.go.id",
+        "jembranakab.go.id",
+    }
+    assert expected.issubset(BALI_TRUSTED_TIER1_HOSTS), (
+        f"missing trusted hosts: {expected - BALI_TRUSTED_TIER1_HOSTS}"
     )
 
 
-def test_bali_inventory_contains_all_4_portals():
-    """T4 plan note: portals should already be in gov_apis_inventory.json
-    from Phase 0. Verify."""
+def test_bali_inventory_contains_all_bali_portals():
+    """Every id in BALI_PORTAL_IDS must exist in gov_apis_inventory.json.
+    T4 plan note: jdih portals come from Phase 0; Phase 1.5 PR-B added
+    4 more jdih + 2 Pemkab fallbacks (Bangli, Jembrana)."""
     from mata_garuda.foundations.gov_apis_health import load_inventory
 
     inv = load_inventory()

--- a/apps/mata-garuda/tests/integration/test_feeder_endpoints_live_bali.py
+++ b/apps/mata-garuda/tests/integration/test_feeder_endpoints_live_bali.py
@@ -1,0 +1,90 @@
+"""Live endpoint smoke-tests for the Bali regulation_bali feeder.
+
+These tests hit the real public portals listed in BALI_PORTAL_IDS and assert
+HTTP 200 + a non-trivial body. Skipped by default; opt in with:
+
+    MATA_GARUDA_LIVE_ENDPOINTS=1 pytest tests/integration/test_feeder_endpoints_live_bali.py
+
+Companion to test_feeder_endpoints_live.py (Phase 1.5 PR-A national/imm
+endpoints). Kept separate so PR-A can merge without this file existing —
+when both PRs land, refactoring into one parametrized table is trivial.
+
+Why this exists (cf. cicatrix `test infrastructure mock != production
+stack`, Sprint 1.B 2026-05-02): unit tests with mocked httpx pass even
+when the upstream URL has been moved or rotted. This is the integration
+counterpart that talks to the real internet.
+
+Convention:
+- One row per portal-id from BALI_PORTAL_IDS. Adding a new id means
+  adding a row here AND in gov_apis_inventory.json.
+- Assert 200 + body >1000 chars to filter cloudflare splash / placeholder.
+- 20s timeout — some kabupaten portals are slow but should still respond.
+- follow_redirects so jdih portals doing 301 to https variant pass.
+"""
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+
+LIVE = os.environ.get("MATA_GARUDA_LIVE_ENDPOINTS") == "1"
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(not LIVE, reason="set MATA_GARUDA_LIVE_ENDPOINTS=1 to run"),
+]
+
+# Mirror of gov_apis_inventory.json regulation_bali rows.
+# Update both files together when adding a portal.
+BALI_ENDPOINTS = [
+    # Original 4 (already in Phase 1).
+    ("jdih_baliprov", "https://jdih.baliprov.go.id"),
+    ("jdih_badungkab", "https://jdih.badungkab.go.id"),
+    ("jdih_gianyarkab", "https://jdih.gianyarkab.go.id"),
+    ("jdih_denpasarkota", "https://jdih.denpasarkota.go.id"),
+    # Phase 1.5 PR-B additions.
+    ("jdih_tabanankab", "https://jdih.tabanankab.go.id"),
+    ("jdih_bulelengkab", "https://jdih.bulelengkab.go.id"),
+    ("jdih_klungkungkab", "https://jdih.klungkungkab.go.id"),
+    ("jdih_karangasemkab", "https://jdih.karangasemkab.go.id"),
+    ("pemkab_bangli", "https://www.banglikab.go.id/berita"),
+    ("pemkab_jembrana", "https://jembranakab.go.id/articles"),
+]
+
+
+# Portals known to ship an incomplete TLS cert chain. They respond 200 in
+# curl/browsers (which use a different root truststore) but Python's certifi
+# bundle can't verify them. The production feeder picks them up via the
+# probe gate which uses verify=False on retry; here we keep verify on so we
+# can detect if/when the server-side chain is fixed.
+TLS_CHAIN_ISSUE_PORTALS = {"jdih_tabanankab"}
+
+
+@pytest.mark.parametrize("portal_id,url", BALI_ENDPOINTS)
+def test_bali_endpoint_reachable(portal_id: str, url: str, request) -> None:
+    """Each Bali portal must return 200 with substantive body."""
+    if portal_id in TLS_CHAIN_ISSUE_PORTALS:
+        request.applymarker(
+            pytest.mark.xfail(
+                reason=(
+                    f"{portal_id}: server-side TLS cert chain is incomplete; "
+                    "Python's truststore can't verify. curl/browsers accept "
+                    "it. Drop from this set when the host fixes the chain."
+                ),
+                strict=False,
+            )
+        )
+
+    with httpx.Client(timeout=20.0, follow_redirects=True) as client:
+        resp = client.get(url, headers={"User-Agent": "mata-garuda-smoke/1.0"})
+
+    assert resp.status_code == 200, (
+        f"{portal_id} ({url}) returned HTTP {resp.status_code} — "
+        f"portal may be down or moved. Check gov_apis_inventory.json + "
+        f"BALI_PORTAL_IDS in nb_intel_regulation_bali.py."
+    )
+    assert len(resp.text) > 1000, (
+        f"{portal_id} ({url}) body is {len(resp.text)} chars — "
+        f"likely a splash/error page. Investigate."
+    )


### PR DESCRIPTION
## Summary

Phase 1.5 PR-B — expand \`regulation_bali\` coverage from 4 to 10 portals.

**4 new jdih** (verified live 200 on 2026-05-08):
- \`jdih.tabanankab.go.id\` — West Bali (Tanah Lot)
- \`jdih.bulelengkab.go.id\` — North (Lovina/Pemuteran)
- \`jdih.klungkungkab.go.id\` — East (Nusa Penida)
- \`jdih.karangasemkab.go.id\` — East (Amed)

**2 Pemkab homepage fallbacks** (their dedicated jdih subdomain DNS-fail or timeout):
- \`banglikab.go.id/berita\` — center (jdih.bangli.go.id NXDOMAIN)
- \`jembranakab.go.id/articles\` — West (jdih.jembranakab.go.id timeout)

## Changes

| File | Change |
|---|---|
| \`mata_garuda/domains/setup_team/feeders/nb_intel_regulation_bali.py\` | \`BALI_PORTAL_IDS\` 4→10, \`TRUSTED_TIER1_HOSTS\` 4→10 |
| \`data/gov_apis_inventory.json\` | +6 entries category=regulation_bali |
| \`tests/domains/setup_team/test_feeders.py\` | +2 regression-guards |
| \`tests/integration/test_feeder_endpoints_live_bali.py\` | NEW — 10 parametrized live smoke-tests, opt-in via \`MATA_GARUDA_LIVE_ENDPOINTS=1\` |

## Tests

- 872 passed default (was 871; \`test_bali_portal_ids_are_the_4_canonical\` replaced 1:1 by \`test_bali_portal_ids_include_all_8_jdih_plus_2_pemkab_fallbacks\`)
- Live: 9/10 200 OK + 1 \`xfail\` strict=false for \`jdih_tabanankab\` (server-side TLS cert chain incomplete; \`curl\`/browsers accept it but Python's \`certifi\` doesn't)

## Out of scope (Phase 1.5 PR-C)

- DPMPTSP×3 (Badung, Denpasar, Gianyar — licensing news for KBLI/PBG/SLF)
- \`disparda.baliprov.go.id\` (Bali tourism authority)
- \`bali.atrbpn.go.id\` (land certificate authority)
- 3 Kanim Bali immigration offices + e-Visa + \`peraturan.bpk.go.id\`

## Independence from PR #549 (PR-A)

This PR branches from \`main\` and touches disjoint feeders (\`regulation_bali\` only).
The \`pyproject.toml\` \`markers\` block is identical in both — git merge will deduplicate.

## Test plan

- [ ] CI green (4 required checks: E2E, MCP, Frontend, Detect Secrets)
- [ ] Tomorrow's 06:00 WITA cron run shows \`feeder_by_domain.regulation_bali >= 1\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)