### PR TITLE
feat(setup-team/feeders): Phase 1.5 PR-C — tier-2 sources (BPK + 3 Kanim Bali + disparda)

### DIFF
--- a/apps/mata-garuda/data/gov_apis_inventory.json
+++ b/apps/mata-garuda/data/gov_apis_inventory.json
@@ -81,5 +81,10 @@
     "id": "pemkab_jembrana",
     "url": "https://jembranakab.go.id/articles",
     "category": "regulation_bali"
+  },
+  {
+    "id": "disparda_baliprov",
+    "url": "https://disparda.baliprov.go.id/category/info-terkini/",
+    "category": "regulation_bali"
   }
 ]

--- a/apps/mata-garuda/mata_garuda/domains/setup_team/feeders/nb_intel_immigration.py
+++ b/apps/mata-garuda/mata_garuda/domains/setup_team/feeders/nb_intel_immigration.py
@@ -36,11 +36,42 @@ logger = logging.getLogger(__name__)
 IMIGRASI_BERITA_URL = "https://www.imigrasi.go.id/berita"
 KEMENKUM_BERITA_URL = "https://www.kemenkum.go.id/berita-utama"
 TEMPO_IMIGRASI_TAG_URL = "https://www.tempo.co/tag/imigrasi"
+
+# Phase 1.5 PR-C: 3 Bali Kantor Imigrasi (regional offices). Each entry is
+# (layer_tag, news_url, host_filter). Live verified 2026-05-08:
+#   - Ngurah Rai (airport) uses /berita-dan-siaran-pers/
+#   - Denpasar (city) uses /kat/berita
+#   - Singaraja (north) uses /berita-keimigrasian/
+# Path varies per office — don't assume a uniform schema. All Kanim sites
+# render article links with relative hrefs (e.g. href="/berita/123") so the
+# harvester resolves them against the source URL host.
+KANIM_BALI_LAYERS: tuple[tuple[str, str, str], ...] = (
+    (
+        "kanim_ngurahrai",
+        "https://ngurahrai.imigrasi.go.id/berita-dan-siaran-pers/",
+        "ngurahrai.imigrasi.go.id",
+    ),
+    (
+        "kanim_denpasar",
+        "https://denpasar.imigrasi.go.id/kat/berita",
+        "denpasar.imigrasi.go.id",
+    ),
+    (
+        "kanim_singaraja",
+        "https://singaraja.imigrasi.go.id/berita-keimigrasian/",
+        "singaraja.imigrasi.go.id",
+    ),
+)
+
 DEFAULT_TIMEOUT_SECONDS = 20.0
 
 TRUSTED_TIER1_HOSTS = {
     "imigrasi.go.id",
     "kemenkum.go.id",  # post-2024 rebrand
+    # Phase 1.5 PR-C — 3 Bali Kantor Imigrasi subdomains.
+    "ngurahrai.imigrasi.go.id",
+    "denpasar.imigrasi.go.id",
+    "singaraja.imigrasi.go.id",
 }
 
 IMMIGRATION_REGEX = re.compile(
@@ -97,6 +128,11 @@ async def _fetch_url_links(
         return out
 
     body = resp.text
+    # Resolve relative hrefs against the source URL's scheme+host. The
+    # Kanim Bali portals (PR-C) emit href="/berita/123" not absolute URLs,
+    # and the central imigrasi.go.id site occasionally does the same.
+    base_host = _extract_base_host(url)
+
     link_re = re.compile(
         r'<a[^>]+href="(?P<url>[^"]+)"[^>]*>(?P<title>[^<]+)</a>',
         re.IGNORECASE,
@@ -105,6 +141,11 @@ async def _fetch_url_links(
     for m in link_re.finditer(body):
         href = m.group("url").strip()
         title = m.group("title").strip()
+        # Resolve relative → absolute
+        if href.startswith("/"):
+            href = f"{base_host}{href}"
+        elif not href.startswith("http"):
+            continue  # Skip mailto:/javascript:/anchor refs.
         if domain_filter and domain_filter not in href:
             continue
         if href in seen:
@@ -126,6 +167,23 @@ async def _fetch_url_links(
             )
         )
     return out
+
+
+def _extract_base_host(url: str) -> str:
+    """Return scheme+host from a URL, e.g.
+    'https://ngurahrai.imigrasi.go.id/berita-dan-siaran-pers/' →
+    'https://ngurahrai.imigrasi.go.id'.
+    Used to resolve relative hrefs back to absolute URLs."""
+    if not url.startswith("http"):
+        return ""
+    scheme_end = url.find("://")
+    if scheme_end == -1:
+        return ""
+    host_start = scheme_end + 3
+    host_end = url.find("/", host_start)
+    if host_end == -1:
+        return url
+    return url[:host_end]
 
 
 def _dedupe(regulations: Iterable[Regulation]) -> list[Regulation]:
@@ -158,6 +216,13 @@ async def fetch_recent_immigration(
         layer_kemenkum = await _fetch_url_links(
             http, KEMENKUM_BERITA_URL, "kemenkum", domain_filter="kemenkum.go.id"
         )
+        kanim_results: list[list[Regulation]] = []
+        for layer_tag, kanim_url, host_filter in KANIM_BALI_LAYERS:
+            kanim_results.append(
+                await _fetch_url_links(
+                    http, kanim_url, layer_tag, domain_filter=host_filter
+                )
+            )
         layer_tempo = await _fetch_url_links(
             http, TEMPO_IMIGRASI_TAG_URL, "tempo", domain_filter="tempo.co"
         )
@@ -165,7 +230,10 @@ async def fetch_recent_immigration(
         if own_http:
             await http.aclose()
 
-    combined = list(layer_imigrasi) + list(layer_kemenkum) + list(layer_tempo)
+    combined: list[Regulation] = list(layer_imigrasi) + list(layer_kemenkum)
+    for kanim_layer in kanim_results:
+        combined.extend(kanim_layer)
+    combined.extend(layer_tempo)
     deduped = _dedupe(combined)
     in_window = [r for r in deduped if _within_window(r.published_at, days)]
     return in_window
@@ -173,6 +241,8 @@ async def fetch_recent_immigration(
 
 __all__ = [
     "IMMIGRATION_REGEX",
+    "KANIM_BALI_LAYERS",
+    "KEMENKUM_BERITA_URL",
     "LIFESTYLE_BLOCKLIST",
     "TRUSTED_TIER1_HOSTS",
     "fetch_recent_immigration",

--- a/apps/mata-garuda/mata_garuda/domains/setup_team/feeders/nb_intel_regulation.py
+++ b/apps/mata-garuda/mata_garuda/domains/setup_team/feeders/nb_intel_regulation.py
@@ -44,6 +44,16 @@ logger = logging.getLogger(__name__)
 # Current JDIHN navigation exposes /dokumen-hukum (HTTP 200 verified).
 JDIHN_SEARCH_URL = "https://jdihn.go.id/dokumen-hukum"
 SETKAB_PRESS_URL = "https://setkab.go.id/category/berita/"
+
+# Phase 1.5 PR-C tier-2 sources (national).
+# BPK = Badan Pemeriksa Keuangan, official gov regulation index. Search
+# parametrized by `type=peraturan` returns the index page with links to
+# /Details/<id>/<slug>. Live verified 2026-05-08.
+BPK_SEARCH_URL = "https://peraturan.bpk.go.id/Search?type=peraturan"
+# peraturan.go.id apex returns 500 (server-side bug); www subdomain is the
+# working canonical. Live verified 2026-05-08.
+PERATURAN_GO_ID_URL = "https://www.peraturan.go.id/"
+
 DEFAULT_TIMEOUT_SECONDS = 20.0
 
 # Domains we trust as tier-1 gov direct.
@@ -171,6 +181,83 @@ async def _fetch_jdihn(http: httpx.AsyncClient, days: int) -> list[Regulation]:
     return out
 
 
+async def _fetch_generic_html(
+    http: httpx.AsyncClient,
+    url: str,
+    layer_tag: str,
+    base_host: str,
+) -> list[Regulation]:
+    """Generic best-effort HTML link harvester for regulation portals.
+
+    Resolves relative hrefs against `base_host` (e.g. "https://peraturan.bpk.go.id")
+    so the resulting Regulation.url is always absolute. Filters by
+    REGULATION_REGEX on the link's anchor text.
+
+    Used by Phase 1.5 PR-C BPK + peraturan.go.id layers.
+    """
+    out: list[Regulation] = []
+    try:
+        resp = await http.get(url)
+    except (httpx.HTTPError, httpx.TimeoutException) as exc:
+        logger.warning("%s fetch failed: %s", layer_tag, exc)
+        return out
+    if resp.status_code != 200:
+        logger.warning("%s returned %s, skipping", layer_tag, resp.status_code)
+        return out
+
+    body = resp.text
+    link_re = re.compile(
+        r'<a[^>]+href="(?P<url>[^"]+)"[^>]*>(?P<title>[^<]+)</a>',
+        re.IGNORECASE,
+    )
+    seen_urls: set[str] = set()
+    for m in link_re.finditer(body):
+        title = m.group("title").strip()
+        href = m.group("url").strip()
+        # Resolve relative → absolute against base_host
+        if href.startswith("/"):
+            href_abs = f"{base_host.rstrip('/')}{href}"
+        elif href.startswith("http"):
+            href_abs = href
+        else:
+            continue  # Skip mailto:/javascript:/etc.
+        if href_abs in seen_urls:
+            continue
+        seen_urls.add(href_abs)
+        if not _matches_regulation_regex(title):
+            continue
+        sid = f"{layer_tag}:{abs(hash(href_abs))}"
+        out.append(
+            Regulation(
+                source_id=sid,
+                domain="regulation",
+                tier=_classify_tier(href_abs),
+                title=title,
+                url=href_abs,
+                published_at=None,
+                body_excerpt="",
+                tags=(f"layer:{layer_tag}",),
+            )
+        )
+    return out
+
+
+async def _fetch_bpk(http: httpx.AsyncClient, days: int) -> list[Regulation]:
+    """Layer 4 (PR-C): peraturan.bpk.go.id Search index."""
+    return await _fetch_generic_html(
+        http, BPK_SEARCH_URL, "bpk", "https://peraturan.bpk.go.id"
+    )
+
+
+async def _fetch_peraturan_go_id(
+    http: httpx.AsyncClient, days: int
+) -> list[Regulation]:
+    """Layer 5 (PR-C): www.peraturan.go.id homepage scrape."""
+    return await _fetch_generic_html(
+        http, PERATURAN_GO_ID_URL, "peraturan_go_id", "https://www.peraturan.go.id"
+    )
+
+
 async def _fetch_setkab(http: httpx.AsyncClient, days: int) -> list[Regulation]:
     """Layer 3: setkab.go.id press signals (Perpres/PP). Best-effort scrape."""
     out: list[Regulation] = []
@@ -259,12 +346,20 @@ async def fetch_recent_regulations(
     try:
         layer_pasal = await _fetch_pasal_id(pid_client, days)
         layer_jdihn = await _fetch_jdihn(http, days)
+        layer_bpk = await _fetch_bpk(http, days)
+        layer_peraturan = await _fetch_peraturan_go_id(http, days)
         layer_setkab = await _fetch_setkab(http, days)
     finally:
         if own_http:
             await http.aclose()
 
-    combined = list(layer_pasal) + list(layer_jdihn) + list(layer_setkab)
+    combined = (
+        list(layer_pasal)
+        + list(layer_jdihn)
+        + list(layer_bpk)
+        + list(layer_peraturan)
+        + list(layer_setkab)
+    )
     deduped = _dedupe(combined)
     in_window = [r for r in deduped if _within_window(r.published_at, days)]
     return in_window

--- a/apps/mata-garuda/mata_garuda/domains/setup_team/feeders/nb_intel_regulation_bali.py
+++ b/apps/mata-garuda/mata_garuda/domains/setup_team/feeders/nb_intel_regulation_bali.py
@@ -64,9 +64,13 @@ BALI_PORTAL_IDS = (
     # Perbup news in its /berita or /articles section to not lose coverage).
     "pemkab_bangli",
     "pemkab_jembrana",
+    # Phase 1.5 PR-C: Bali tourism authority — publishes PERDA on
+    # akomodasi pariwisata, desa adat, subak heritage. Slow (~30s) so
+    # the probe gate timeout matters here. Verified live 200 on 2026-05-08.
+    "disparda_baliprov",
 )
 
-# Tier-1 trusted: all 10 are gov direct (.go.id under provincia/kabupaten/kota).
+# Tier-1 trusted: all 11 are gov direct (.go.id under provincia/kabupaten/kota).
 TRUSTED_TIER1_HOSTS = {
     "jdih.baliprov.go.id",
     "jdih.badungkab.go.id",
@@ -78,6 +82,7 @@ TRUSTED_TIER1_HOSTS = {
     "jdih.karangasemkab.go.id",
     "banglikab.go.id",
     "jembranakab.go.id",
+    "disparda.baliprov.go.id",
 }
 
 CATEGORY_REGEXES = {

--- a/apps/mata-garuda/tests/domains/setup_team/test_feeders.py
+++ b/apps/mata-garuda/tests/domains/setup_team/test_feeders.py
@@ -11,15 +11,21 @@ import pytest
 
 from mata_garuda.domains.setup_team.feeders.nb_intel_immigration import (
     IMMIGRATION_REGEX,
+    KANIM_BALI_LAYERS,
     KEMENKUM_BERITA_URL,
     LIFESTYLE_BLOCKLIST,
+    TRUSTED_TIER1_HOSTS as IMMIGRATION_TRUSTED_TIER1_HOSTS,
+    _fetch_url_links,
     _matches_immigration_regex,
     fetch_recent_immigration,
 )
 from mata_garuda.domains.setup_team.feeders.nb_intel_regulation import (
+    BPK_SEARCH_URL,
     JDIHN_SEARCH_URL,
+    PERATURAN_GO_ID_URL,
     REGULATION_REGEX,
     SETKAB_PRESS_URL,
+    TRUSTED_TIER1_HOSTS as REGULATION_TRUSTED_TIER1_HOSTS,
     _classify_tier,
     _fetch_jdihn,
     _matches_regulation_regex,
@@ -85,6 +91,80 @@ def test_setkab_press_url_uses_category_berita_path():
     assert SETKAB_PRESS_URL == "https://setkab.go.id/category/berita/"
 
 
+# ---------------- T1.5 PR-C: tier-2 source constants ---------------- #
+
+
+def test_bpk_search_url_filters_by_peraturan_type():
+    """peraturan.bpk.go.id/Search?type=peraturan returns 200 with the
+    Peraturan index page (Permenkop/PMK/PP/UU links). Live verified
+    2026-05-08."""
+    assert BPK_SEARCH_URL == "https://peraturan.bpk.go.id/Search?type=peraturan"
+
+
+def test_peraturan_go_id_url_uses_www_subdomain():
+    """peraturan.go.id apex returns 500; www.peraturan.go.id returns 200.
+    Live verified 2026-05-08."""
+    assert PERATURAN_GO_ID_URL == "https://www.peraturan.go.id/"
+
+
+def test_regulation_trusted_hosts_include_new_tier2():
+    """BPK + peraturan.go.id were already in TRUSTED_TIER1_HOSTS from
+    Phase 0; pin them here so a future cleanup doesn't drop them."""
+    assert "peraturan.bpk.go.id" in REGULATION_TRUSTED_TIER1_HOSTS
+    assert "peraturan.go.id" in REGULATION_TRUSTED_TIER1_HOSTS
+
+
+def test_kanim_bali_layers_include_3_offices():
+    """Phase 1.5 PR-C: 3 Bali immigration offices added (Ngurah Rai
+    airport, Denpasar city, Singaraja north). All under <office>.imigrasi.go.id.
+
+    Each entry is (layer_tag, url, host_filter). Live verified 2026-05-08."""
+    layer_tags = {entry[0] for entry in KANIM_BALI_LAYERS}
+    assert layer_tags == {"kanim_ngurahrai", "kanim_denpasar", "kanim_singaraja"}
+
+
+def test_immigration_trusted_hosts_include_kanim_bali_subdomains():
+    """All 3 Kanim Bali subdomains must be tier-1 trusted (gov direct)."""
+    expected = {
+        "ngurahrai.imigrasi.go.id",
+        "denpasar.imigrasi.go.id",
+        "singaraja.imigrasi.go.id",
+    }
+    assert expected.issubset(IMMIGRATION_TRUSTED_TIER1_HOSTS), (
+        f"missing: {expected - IMMIGRATION_TRUSTED_TIER1_HOSTS}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_url_links_resolves_relative_hrefs_against_base_url():
+    """Kanim portals link articles via relative hrefs (e.g. href="/berita/123").
+    The harvester must convert them to absolute URLs before storing —
+    otherwise tier classification + dedup get the wrong key.
+    Phase 1.5 PR-C requirement."""
+    http = AsyncMock()
+    html = (
+        '<html><body>'
+        '<a href="/berita/123">KITAS aturan baru WNA</a>'
+        '<a href="https://ngurahrai.imigrasi.go.id/berita/456">VOA exit permit</a>'
+        '</body></html>'
+    )
+    http.get = AsyncMock(return_value=MagicMock(status_code=200, text=html))
+
+    out = await _fetch_url_links(
+        http,
+        url="https://ngurahrai.imigrasi.go.id/berita-dan-siaran-pers/",
+        layer_tag="kanim_ngurahrai",
+        domain_filter="ngurahrai.imigrasi.go.id",
+    )
+    urls = {r.url for r in out}
+    # Relative href resolved to absolute against the host of the source URL:
+    assert "https://ngurahrai.imigrasi.go.id/berita/123" in urls, (
+        f"relative href not resolved; got urls={urls}"
+    )
+    # Already-absolute href passes through unchanged:
+    assert "https://ngurahrai.imigrasi.go.id/berita/456" in urls
+
+
 # ---------------- T2: nb_intel_regulation ---------------- #
 
 
@@ -123,10 +203,10 @@ async def test_fetch_recent_regulations_swallows_pasal_id_auth_error():
     pid.search_laws = AsyncMock(side_effect=PasalIdAuthError("no token"))
 
     http = AsyncMock()
-    # JDIHN response — empty body so no links match.
-    jdihn_resp = MagicMock(status_code=200, text="<html><body></body></html>")
-    setkab_resp = MagicMock(status_code=200, text="<html><body></body></html>")
-    http.get = AsyncMock(side_effect=[jdihn_resp, setkab_resp])
+    # 4 layers fetched in order: JDIHN, BPK, peraturan_go_id, setkab.
+    # All return empty bodies so no links match.
+    empty_resp = MagicMock(status_code=200, text="<html><body></body></html>")
+    http.get = AsyncMock(side_effect=[empty_resp, empty_resp, empty_resp, empty_resp])
 
     result = await fetch_recent_regulations(
         days=30,
@@ -155,11 +235,13 @@ async def test_fetch_recent_regulations_dedupes_across_layers():
     <a href="https://example.com/lifestyle">Top 10 cafe</a>
     </body></html>
     """
-    setkab_resp = MagicMock(status_code=200, text="")
+    empty_resp = MagicMock(status_code=200, text="")
     http.get = AsyncMock(
         side_effect=[
-            MagicMock(status_code=200, text=jdihn_html),
-            setkab_resp,
+            MagicMock(status_code=200, text=jdihn_html),  # JDIHN
+            empty_resp,  # BPK
+            empty_resp,  # peraturan.go.id
+            empty_resp,  # setkab
         ]
     )
 
@@ -215,6 +297,8 @@ async def test_fetch_recent_regulations_jdihn_5xx_does_not_kill_other_layers():
     http.get = AsyncMock(
         side_effect=[
             MagicMock(status_code=503, text=""),  # JDIHN dead
+            MagicMock(status_code=200, text=""),  # BPK empty
+            MagicMock(status_code=200, text=""),  # peraturan.go.id empty
             MagicMock(status_code=200, text=""),  # setkab fine
         ]
     )
@@ -292,10 +376,15 @@ async def test_fetch_recent_immigration_dedupes_and_filters():
     <a href="https://www.tempo.co/imigrasi/aturan-baru">imigrasi memperketat aturan WNA</a>
     </body></html>
     """
+    empty_resp = MagicMock(status_code=200, text="")
+    # Order: imigrasi, kemenkum, 3 Kanim Bali (PR-C), tempo. 6 layers total.
     http.get = AsyncMock(
         side_effect=[
             MagicMock(status_code=200, text=imigrasi_html),
             MagicMock(status_code=200, text=kemenkum_html),
+            empty_resp,  # kanim_ngurahrai
+            empty_resp,  # kanim_denpasar
+            empty_resp,  # kanim_singaraja
             MagicMock(status_code=200, text=tempo_html),
         ]
     )
@@ -317,6 +406,8 @@ async def test_fetch_recent_immigration_dedupes_and_filters():
 @pytest.mark.asyncio
 async def test_fetch_recent_immigration_one_layer_dead_does_not_kill_others():
     http = AsyncMock()
+    empty_resp = MagicMock(status_code=200, text="")
+    # Order: imigrasi, kemenkum, 3 Kanim Bali (PR-C), tempo.
     http.get = AsyncMock(
         side_effect=[
             MagicMock(status_code=503, text=""),  # imigrasi dead
@@ -324,6 +415,9 @@ async def test_fetch_recent_immigration_one_layer_dead_does_not_kill_others():
                 status_code=200,
                 text='<a href="https://www.kemenkum.go.id/x">RPTKA aturan</a>',
             ),
+            empty_resp,  # kanim_ngurahrai
+            empty_resp,  # kanim_denpasar
+            empty_resp,  # kanim_singaraja
             MagicMock(status_code=500, text=""),  # tempo dead
         ]
     )
@@ -365,37 +459,33 @@ def test_bali_category_regexes_classify_correctly():
     assert _classify_categories("") == ()
 
 
-def test_bali_portal_ids_include_all_8_jdih_plus_2_pemkab_fallbacks():
-    """Phase 1.5 PR-B — expanded from 4 to 10 portals.
+def test_bali_portal_ids_include_jdih_pemkab_and_disparda():
+    """Phase 1.5 evolution: 4 (Phase 1) → 10 (PR-B) → 11 (PR-C, +disparda).
 
-    8 jdih portals (4 original + 4 added 2026-05-08): provincia + Badung
-    + Gianyar + Denpasar + Tabanan + Buleleng + Klungkung + Karangasem.
-
-    2 Pemkab homepage fallbacks (Bangli + Jembrana — their dedicated
-    jdih.<kab>.go.id subdomains DNS-fail or timeout, so we scrape the
-    Pemkab homepage's /berita or /articles section instead).
-
-    Live verification 2026-05-08: all 8 jdih return 200; banglikab.go.id
-    and jembranakab.go.id return 200 with regulation-relevant berita.
+    8 jdih portals + 2 Pemkab homepage fallbacks + 1 tourism authority
+    (disparda.baliprov.go.id, the provincial tourism office that publishes
+    PERDA on akomodasi pariwisata, desa adat, subak heritage).
     """
     assert set(BALI_PORTAL_IDS) == {
-        # Original 4 (Phase 1).
+        # Original 4 jdih (Phase 1).
         "jdih_baliprov",
         "jdih_badungkab",
         "jdih_gianyarkab",
         "jdih_denpasarkota",
-        # New jdih (Phase 1.5 PR-B).
+        # PR-B jdih.
         "jdih_tabanankab",
         "jdih_bulelengkab",
         "jdih_klungkungkab",
         "jdih_karangasemkab",
-        # Pemkab homepage fallbacks (jdih.<kab>.go.id was unreachable).
+        # PR-B Pemkab homepage fallbacks.
         "pemkab_bangli",
         "pemkab_jembrana",
+        # PR-C tourism authority.
+        "disparda_baliprov",
     }
 
 
-def test_bali_trusted_tier1_hosts_includes_all_10_portals():
+def test_bali_trusted_tier1_hosts_include_jdih_pemkab_and_disparda():
     """All gov-direct hosts must be tier-1 trusted for the scorer."""
     expected = {
         "jdih.baliprov.go.id",
@@ -408,6 +498,7 @@ def test_bali_trusted_tier1_hosts_includes_all_10_portals():
         "jdih.karangasemkab.go.id",
         "banglikab.go.id",
         "jembranakab.go.id",
+        "disparda.baliprov.go.id",
     }
     assert expected.issubset(BALI_TRUSTED_TIER1_HOSTS), (
         f"missing trusted hosts: {expected - BALI_TRUSTED_TIER1_HOSTS}"

--- a/apps/mata-garuda/tests/integration/test_feeder_endpoints_live.py
+++ b/apps/mata-garuda/tests/integration/test_feeder_endpoints_live.py
@@ -38,19 +38,34 @@ pytestmark = [
 ]
 
 ENDPOINTS = [
-    # (name, url, allow_404_for_now) — Phase 1.5 PR-A baseline
+    # Phase 1.5 PR-A baseline (regulation + immigration national + media).
     ("imigrasi_berita", "https://www.imigrasi.go.id/berita"),
     ("kemenkum_berita_utama", "https://www.kemenkum.go.id/berita-utama"),
     ("jdihn_dokumen_hukum", "https://jdihn.go.id/dokumen-hukum?keyword=2026"),
     ("setkab_category_berita", "https://setkab.go.id/category/berita/"),
     ("tempo_imigrasi_tag", "https://www.tempo.co/tag/imigrasi"),
+    # Phase 1.5 PR-C: regulation tier-2.
+    ("bpk_search", "https://peraturan.bpk.go.id/Search?type=peraturan"),
+    ("peraturan_go_id", "https://www.peraturan.go.id/"),
+    # Phase 1.5 PR-C: 3 Bali Kantor Imigrasi (regional).
+    (
+        "kanim_ngurahrai",
+        "https://ngurahrai.imigrasi.go.id/berita-dan-siaran-pers/",
+    ),
+    ("kanim_denpasar", "https://denpasar.imigrasi.go.id/kat/berita"),
+    (
+        "kanim_singaraja",
+        "https://singaraja.imigrasi.go.id/berita-keimigrasian/",
+    ),
 ]
 
 
 @pytest.mark.parametrize("name,url", ENDPOINTS)
 def test_endpoint_reachable(name: str, url: str) -> None:
-    """Each Phase 1 source must return 200 with substantive body."""
-    with httpx.Client(timeout=15.0, follow_redirects=True) as client:
+    """Each Phase 1.5 source must return 200 with substantive body."""
+    # 30s timeout — some Bali offices and the regulation portals can be
+    # slow under load (live verified 2026-05-08).
+    with httpx.Client(timeout=30.0, follow_redirects=True) as client:
         resp = client.get(url, headers={"User-Agent": "mata-garuda-smoke/1.0"})
 
     assert resp.status_code == 200, (

--- a/apps/mata-garuda/tests/integration/test_feeder_endpoints_live_bali.py
+++ b/apps/mata-garuda/tests/integration/test_feeder_endpoints_live_bali.py
@@ -50,6 +50,11 @@ BALI_ENDPOINTS = [
     ("jdih_karangasemkab", "https://jdih.karangasemkab.go.id"),
     ("pemkab_bangli", "https://www.banglikab.go.id/berita"),
     ("pemkab_jembrana", "https://jembranakab.go.id/articles"),
+    # Phase 1.5 PR-C: provincial tourism authority.
+    (
+        "disparda_baliprov",
+        "https://disparda.baliprov.go.id/category/info-terkini/",
+    ),
 ]
 
 
@@ -76,7 +81,8 @@ def test_bali_endpoint_reachable(portal_id: str, url: str, request) -> None:
             )
         )
 
-    with httpx.Client(timeout=20.0, follow_redirects=True) as client:
+    # 45s timeout — disparda.baliprov.go.id can take 30+ seconds to respond.
+    with httpx.Client(timeout=45.0, follow_redirects=True) as client:
         resp = client.get(url, headers={"User-Agent": "mata-garuda-smoke/1.0"})
 
     assert resp.status_code == 200, (


### PR DESCRIPTION
## Summary

Phase 1.5 PR-C — add 5 tier-2 regulation/immigration sources. **Cron empirically went from \`feeders=4\` to \`feeders=45\`** (11× growth, all 3 domains now producing).

## Sources added

**Regulation national (+2 layers in \`nb_intel_regulation\`):**
| Source | URL |
|---|---|
| BPK official index | \`peraturan.bpk.go.id/Search?type=peraturan\` |
| peraturan.go.id (www subdomain — apex 500s) | \`www.peraturan.go.id/\` |

**Immigration Bali regional (+3 layers in \`nb_intel_immigration\`):**
| Office | URL |
|---|---|
| Kanim Ngurah Rai (airport) | \`ngurahrai.imigrasi.go.id/berita-dan-siaran-pers/\` |
| Kanim Denpasar (city) | \`denpasar.imigrasi.go.id/kat/berita\` |
| Kanim Singaraja (north) | \`singaraja.imigrasi.go.id/berita-keimigrasian/\` |

All 3 under \`<office>.imigrasi.go.id\` (NOT \`kemenkumham.go.id\` — those subdomains DNS-fail post-2024 ministry split). Path varies per office; don't assume a uniform schema.

**Regulation Bali (+1 portal in \`nb_intel_regulation_bali\`):**
| Source | URL |
|---|---|
| Disparda Bali (provincial tourism authority) | \`disparda.baliprov.go.id/category/info-terkini/\` |

## Implementation

- New \`_fetch_generic_html(url, layer_tag, base_host)\` helper in \`nb_intel_regulation\` handles relative→absolute URL resolution and link extraction. Reused for BPK + peraturan.go.id.
- \`_fetch_url_links\` in \`nb_intel_immigration\` patched to resolve relative hrefs against the source URL host (Kanim portals emit \`href="/berita/123"\`).
- \`KANIM_BALI_LAYERS\` tuple drives the 3 Kanim layers without code duplication.
- e-Visa **explicitly excluded** — it's an application portal, not a news feed.
- DPMPTSP×3 + ATRBPN Bali **deferred to Phase 2 nb_intel_property** (more natural fit per spec).

## Empirical verification (cron kickstart 14:46 WITA)

\`\`\`
Pre-PR-C:   feeders=4   (regulation=0, immigration=4, regulation_bali=0)
Post-PR-C:  feeders=45  (regulation=16, immigration=21, regulation_bali=8)
\`\`\`

## Tests

- 882 default tests + 6 new regression-guards
- 5 existing mock tests updated for new layer call ordering
- Live: 19/20 PASSED + 1 xfailed (\`jdih.tabanankab\` TLS chain known issue inherited from PR-B)

## Test plan

- [ ] CI green (4 required: E2E, MCP, Frontend, Detect Secrets)
- [ ] Tomorrow's 06:00 WITA cron run logs \`feeders >= 30\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)