### PR TITLE
fix(wr2/canva): emit body replace_text ops even when body_eid is None

### DIFF
--- a/apps/backend-rag/backend/services/canva_renderer/pending_builder.py
+++ b/apps/backend-rag/backend/services/canva_renderer/pending_builder.py
@@ -138,9 +138,19 @@ def slides_to_operations(slides: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "page_index": page_index,
             })
 
-        # Body only if both slot exists AND slide carries body text
+        # Body op whenever the slide carries body text. element_id is
+        # ALWAYS None — TEMPLATE_SLOTS was deliberately None-filled
+        # 2026-05-07 to defer to the apply skill's runtime remap. The
+        # canva-apply skill (~/.claude/skills/canva-apply.md step 8)
+        # resolves slot via top-ascending role_index per page: first
+        # replace_text op → role_index=0 (heading, emitted above),
+        # second → role_index=1 (body, emitted here). Skipping body
+        # ops when body_eid is None — the previous behaviour — meant
+        # ZERO body text ever reached Canva, producing the
+        # "headline-only, body blank" pattern observed in
+        # DAHJDtWApaw / DAHJCzTzn1I PDFs (2026-05-08).
         body = (slide.get("body") or "").strip()
-        if body and body_eid:
+        if body:
             operations.append({
                 "type": "replace_text",
                 "element_id": body_eid,

--- a/apps/backend-rag/backend/tests/unit/services/canva_renderer/test_pending_builder.py
+++ b/apps/backend-rag/backend/tests/unit/services/canva_renderer/test_pending_builder.py
@@ -12,7 +12,6 @@ import pytest
 
 from backend.services.canva_renderer.pending_builder import (
     TEMPLATE_DESIGN_ID,
-    TEMPLATE_SLOTS,
     build_canva_pending,
     slides_to_operations,
 )
@@ -75,16 +74,21 @@ class TestSlidesToOperations:
         # In current TEMPLATE_SLOTS, element_id is None
         assert slide_1_heading_ops[0]["element_id"] is None
 
-    def test_body_text_goes_to_body_element_id(self) -> None:
-        # Note: TEMPLATE_SLOTS now has None for all body slots,
-        # so body ops are skipped in slides_to_operations.
+    def test_body_text_emitted_even_when_body_eid_is_none(self) -> None:
+        # TEMPLATE_SLOTS has None for all body slots in the live template.
+        # The builder MUST still emit the body op (element_id=None) so the
+        # canva-apply skill can remap to the body slot via top-ascending
+        # role_index. Skipping body ops produces the headline-only carousel
+        # bug observed in DAHJDtWApaw / DAHJCzTzn1I (2026-05-08).
         ops = slides_to_operations(_slides_fixture())
         body_ops = [
             op for op in ops
             if op["type"] == "replace_text"
             and "100 officers" in (op.get("text") or "")
         ]
-        assert len(body_ops) == 0  # skipped because body_eid is None
+        assert len(body_ops) == 1
+        assert body_ops[0]["element_id"] is None
+        assert body_ops[0]["page_index"] == 1
 
     def test_image_url_produces_upload_asset_op(self) -> None:
         ops = slides_to_operations(_slides_fixture())
@@ -105,36 +109,41 @@ class TestSlidesToOperations:
         ]
         assert page_3_upload_ops == []
 
-    def test_slide_9_and_11_body_skipped(self) -> None:
-        """Slides 9 and 11 have no body slot in template DAHE6lx1lf8 —
-        builder must not emit body replace_text for them."""
+    def test_body_ops_emitted_for_slides_9_and_11(self) -> None:
+        """Slides 9/11 have no body slot in the original template, but
+        TEMPLATE_SLOTS is now None-filled across all pages. The builder
+        emits body ops uniformly (element_id=None); the canva-apply
+        skill is responsible for resolving — or skipping — the body
+        slot at apply time via runtime remap. Builder MUST NOT make
+        per-page exceptions, otherwise the headline-only-carousel
+        regression returns whenever template page geometry changes."""
         slides = [
             {
                 "slide_number": 9,
                 "headline": "ENFORCEMENT IS NOT THEORETICAL.",
-                "body": "this body should be skipped because slot is absent",
+                "body": "body text reaches Canva — skill decides if slot exists",
                 "image_url": None,
             },
             {
                 "slide_number": 11,
                 "headline": "KNOW YOUR CLOCK.",
-                "body": "also skipped",
+                "body": "same here — apply skill remaps via role_index",
                 "image_url": None,
             },
         ]
         ops = slides_to_operations(slides)
 
-        # Heading replace_text for both slides still present
-        heading_ops = [op for op in ops if op["type"] == "replace_text"]
-        assert len(heading_ops) == 2
+        replace_ops = [op for op in ops if op["type"] == "replace_text"]
+        # 2 heading ops + 2 body ops, one of each per slide
+        assert len(replace_ops) == 4
 
-        # No body ops for page 9 or 11
-        for op in heading_ops:
-            page_idx = op["page_index"]
-            slot = TEMPLATE_SLOTS[page_idx - 1]
-            assert slot[2] is None or op["element_id"] == slot[1], (
-                f"page {page_idx} should only have heading ops, not body"
+        for page_index in (9, 11):
+            page_ops = [op for op in replace_ops if op["page_index"] == page_index]
+            assert len(page_ops) == 2, (
+                f"page {page_index} must have heading + body ops"
             )
+            # All element_ids are None because TEMPLATE_SLOTS is None-filled
+            assert all(op["element_id"] is None for op in page_ops)
 
 
 class TestBuildCanvaPending:


### PR DESCRIPTION
## Summary

- WR2 carousels were rendering headline-only (body slot left as template placeholder) — observed in PDFs DAHJDtWApaw (WR2 Automation standard 8) and DAHJCzTzn1I (Golden Visa) on 2026-05-08.
- Root cause: `pending_builder.slides_to_operations` gated body ops behind `if body and body_eid:`, but `TEMPLATE_SLOTS` has been deliberately `None`-filled since 2026-05-07 to defer slot resolution to the canva-apply skill's runtime remap. Conjunction made the body clause permanently unreachable → ZERO body `replace_text` ops emitted in any pending JSON.
- Fix: drop the `body_eid` predicate. Always emit the body op (`element_id=None`); the apply skill (`~/.claude/skills/canva-apply.md` step 8) resolves the slot via top-ascending `role_index` per page.

## Test plan

- [x] `PYTHONPATH=. .venv/bin/pytest backend/tests/unit/services/canva_renderer/test_pending_builder.py -q` — 10 passed (added one regression-guard, rewrote two that previously asserted the silent-skip behaviour).
- [x] `python -m py_compile backend/services/canva_renderer/pending_builder.py`.
- [ ] Required CI checks (E2E + MCP Server Tests + Detect Secrets).
- [ ] Post-merge: re-render affected drafts (de69f035 → DAHJDtWApaw, a3fd4007 → DAHJCzTzn1I, Golden Visa) once the new build reaches the WR2 cron path so they pick up body text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)