### PR TITLE
feat(kbli): pre-fill search box from ?q= URL param

### DIFF
--- a/apps/mouth/src/app/kbli/page.tsx
+++ b/apps/mouth/src/app/kbli/page.tsx
@@ -19,7 +19,13 @@ export const metadata: Metadata = {
   },
 };
 
-export default function KBLIHomePage() {
+export default async function KBLIHomePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string }>;
+}) {
+  const { q } = await searchParams;
+  const initialQuery = q ? decodeURIComponent(q) : "";
   const sections = getSections().filter((s) => s.codeCount > 0);
 
   return (
@@ -196,7 +202,7 @@ export default function KBLIHomePage() {
           id="search"
           className="sticky top-20 z-40 -mx-4 px-4 py-4 backdrop-blur-2xl bg-[#141416]/80 border border-white/[0.05] sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8 shadow-[0_10px_40px_rgba(0,0,0,0.4),inset_0_1px_0_rgba(255,255,255,0.03)] rounded-3xl mb-8"
         >
-          <KBLISearch autoFocus />
+          <KBLISearch autoFocus initialQuery={initialQuery} />
           <div className="mt-4 flex flex-wrap items-center gap-2 justify-center lg:justify-start">
             <span className="text-xs font-semibold text-zinc-500 uppercase tracking-wider mr-2">
               Quick:

--- a/apps/mouth/src/components/kbli/KBLISearch.tsx
+++ b/apps/mouth/src/components/kbli/KBLISearch.tsx
@@ -13,6 +13,8 @@ interface Props {
   autoFocus?: boolean;
   className?: string;
   placeholder?: string;
+  /** Pre-fill the search input from ?q= URL param (homepage → KBLI deep-link). */
+  initialQuery?: string;
 }
 
 export function KBLISearch({
@@ -20,14 +22,22 @@ export function KBLISearch({
   autoFocus = false,
   className,
   placeholder = "Search KBLI codes (e.g. restaurant, villas, consulting)...",
+  initialQuery = "",
 }: Props) {
-  const [query, setQuery] = React.useState("");
+  const [query, setQuery] = React.useState(initialQuery);
   const [results, setResults] = React.useState<KBLISearchResult[]>([]);
   const [isLoading, setIsLoading] = React.useState(false);
   const [isOpen, setIsOpen] = React.useState(false);
   const [activeIndex, setActiveIndex] = React.useState(-1);
   const router = useRouter();
   const containerRef = React.useRef<HTMLDivElement>(null);
+
+  // Sync initialQuery on mount only (URL ?q= pre-fill).
+  // Not in dep array — intentional: user can freely edit after mount.
+  React.useEffect(() => {
+    if (initialQuery) setQuery(initialQuery);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Close dropdown when clicking outside
   React.useEffect(() => {


### PR DESCRIPTION
PR #[number] ready

What:
User types in homepage search box → hits Enter → lands on /kbli?q=villa
Search box now auto-fills from the URL query param on mount.

Why:
You flagged in review #512: "don't let ?q=… land on 404"
Before this: user lands on /kbli?q=villa with an empty search box — broken UX, zero results shown.

Changes:
- KBLISearch.tsx: added initialQuery prop + useEffect to sync on mount
- kbli/page.tsx: made async, reads searchParams.q, passes to KBLISearch

Test:
1. Open http://localhost:3000/kbli?q=villa
2. Search box should be pre-filled with "villa"
3. Search dropdown should trigger automatically

Branch: sancho/fix-search-prefill