### PR TITLE
feat(organism): launchd env loader for boot-time TELEGRAM setenv (#541 task 1)

### DIFF
--- a/apps/organism/organism/launchd/com.nuzantara.launchd-env-loader.plist
+++ b/apps/organism/organism/launchd/com.nuzantara.launchd-env-loader.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.nuzantara.launchd-env-loader</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/nuzantara/Desktop/nuzantara/scripts/launchd_env_loader.sh</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>43200</integer>
+  <key>KeepAlive</key>
+  <false/>
+  <key>StandardOutPath</key>
+  <string>/Users/nuzantara/logs/launchd-env-loader.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/nuzantara/logs/launchd-env-loader.err</string>
+</dict>
+</plist>

--- a/scripts/launchd_env_loader.sh
+++ b/scripts/launchd_env_loader.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# launchd_env_loader.sh — boot-time setenv loader for nuzantara secrets.
+#
+# Problem: launchctl setenv vars do NOT persist across logout/reboot. After
+# every reboot Pro, organs that depend on TELEGRAM_BOT_TOKEN (Supervisor,
+# liveness watchdog, sentinel, etc.) lose their alert capability silently.
+#
+# This script runs at boot via com.nuzantara.launchd-env-loader plist
+# (RunAtLoad=true, StartInterval=43200 = 12h refresh) and:
+#   1. Sources ~/.nuzantara-secrets.env
+#   2. Calls launchctl setenv for the env vars enumerated below
+#
+# Why launchctl setenv (not just export):
+#   - launchd-spawned processes inherit env from launchctl, NOT from shell
+#   - Setting in shell rc files (.zshrc) only affects interactive sessions
+#   - Daemons need explicit launchctl setenv for env propagation
+#
+# Why an explicit allowlist (not all secrets):
+#   - launchd env is global to all spawned processes — narrow exposure
+#   - Secrets needed by daemons (Telegram, GH, Telegram chat IDs) only
+#   - DB_URL, API_KEYS for Fly stay confined to per-process spawn
+#
+# Reference:
+#   - cicatrix STRUCTURAL P0-3 RECURRENCE PATTERN (2026-05-08 P1)
+#   - Issue #541 task 1
+#   - Pre-existing pattern: some secrets ARE in plist EnvironmentVariables;
+#     this script is the safer alternative (env via setenv, not in plist file).
+
+set -u -o pipefail
+
+LOG_FILE="${LOG_FILE:-$HOME/logs/launchd-env-loader.log}"
+mkdir -p "$(dirname "$LOG_FILE")"
+log() { echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*" >>"$LOG_FILE"; }
+
+SECRETS_FILE="$HOME/.nuzantara-secrets.env"
+if [ ! -f "$SECRETS_FILE" ]; then
+  log "ERROR: $SECRETS_FILE missing — cannot load env"
+  exit 1
+fi
+
+# shellcheck disable=SC1091
+source "$SECRETS_FILE"
+
+# Allowlist: only env vars actually needed by launchd-spawned organs.
+# Add new entries here as needed; do NOT setenv blanket-everything.
+ENV_VARS=(
+  TELEGRAM_BOT_TOKEN
+  TELEGRAM_OWNER_CHAT_ID
+  TELEGRAM_ADMIN_CHAT_ID
+  TELEGRAM_ZERO_CHAT_ID
+)
+
+LOADED=()
+SKIPPED=()
+for var in "${ENV_VARS[@]}"; do
+  val="${!var:-}"
+  if [ -z "$val" ]; then
+    SKIPPED+=("$var")
+    continue
+  fi
+  launchctl setenv "$var" "$val"
+  LOADED+=("$var")
+done
+
+log "Loaded env: ${LOADED[*]}"
+if [ "${#SKIPPED[@]}" -gt 0 ]; then
+  log "Skipped (not in secrets): ${SKIPPED[*]}"
+fi
+log "Done. Total loaded: ${#LOADED[@]}, skipped: ${#SKIPPED[@]}"


### PR DESCRIPTION
## Summary

Solves issue #541 task 1: launchctl setenv vars don't persist across logout/reboot. Every reboot Pro = Telegram alerts OFF for Supervisor + liveness watchdog + sentinel until manual setenv.

## Approach

- `scripts/launchd_env_loader.sh` sources `~/.nuzantara-secrets.env` + launchctl setenv for explicit allowlist (4 vars: TELEGRAM_BOT_TOKEN + 3 chat IDs)
- Plist `com.nuzantara.launchd-env-loader` runs at boot (RunAtLoad=true), refreshes every 12h (StartInterval=43200) for rotation propagation
- Allowlist explicit (not blanket export-everything) — minimal env surface

## Why launchctl setenv (not plist EnvironmentVariables block)

Cicatrix P0-3 RECURRENCE PATTERN 2026-05-08: sub-session FASE 5 wrote TELEGRAM_BOT_TOKEN plaintext in plist. World-readable in backups + git archive + .pre-fase5 backup file. This loader uses launchctl setenv (memory-only) instead.

## Live verification

- Smoke run: 4 vars loaded
- launchctl getenv TELEGRAM_BOT_TOKEN returns correct prefix
- LaunchAgent bootstrapped on Pro: exit 0, loaded

## Refs

- Cicatrix STRUCTURAL P0-3 RECURRENCE PATTERN 2026-05-08
- Issue #541 task 1
- Companion to PR #545 (Supervisor liveness watchdog merged 2026-05-08 03:06 UTC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)