### PR TITLE
feat(symbiosis): close everyone-hears-everything gaps (registry + WR2 outbox + sentinel-aggregate)

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/164_wr2_status_change_outbox.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/164_wr2_status_change_outbox.sql
@@ -1,0 +1,92 @@
+-- 164_wr2_status_change_outbox.sql
+--
+-- "Everyone hears everything" #2: close the WR2 durability gap.
+--
+-- Migration 138 created the wr2_status_change_notify() trigger function
+-- which fires pg_notify('wr2_status_change', ...) when war_room_drafts
+-- rows insert or change status. Consumer: scripts/wr2_supervisor.py
+-- (long-running launchd daemon, not registered in PG_CHANNEL_MAP).
+--
+-- Phase-2 EventBus refactor (migration 146) deliberately skipped this
+-- channel because its consumer is dedicated, not the in-process EventBus
+-- replay-on-reconnect path. Result: when wr2_supervisor.py is offline,
+-- pg_notify packets are dropped on the floor — no durability.
+--
+-- This migration mirrors the 146 pattern: payload is built first, INSERT
+-- INTO events_outbox PRESERVES the event durably, THEN pg_notify fires
+-- with _outbox_id injected so the consumer can ack idempotently.
+--
+-- wr2_supervisor.py is expected to read events_outbox WHERE
+-- channel='wr2_status_change' AND consumed_at IS NULL on startup
+-- (replay path) and to call outbox.acknowledge(_outbox_id) after each
+-- successful dispatch. That work is in apps/war-room — NOT this
+-- migration. The migration only opens the door; the supervisor walks
+-- through it.
+--
+-- Atomicity: the INSERT INTO events_outbox + pg_notify run inside the
+-- user transaction that produced the war_room_drafts INSERT/UPDATE.
+-- Same contract as 146.
+--
+-- Idempotency: CREATE OR REPLACE FUNCTION + DROP TRIGGER IF EXISTS +
+-- CREATE TRIGGER. Safe to re-apply.
+
+CREATE OR REPLACE FUNCTION wr2_status_change_notify() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+    payload    JSONB;
+    outbox_id  BIGINT;
+BEGIN
+    -- INSERT always fires; UPDATE only when status really changed
+    -- (IS DISTINCT FROM handles NULL on either side correctly).
+    IF (TG_OP = 'INSERT') OR (NEW.status IS DISTINCT FROM OLD.status) THEN
+        payload := jsonb_build_object(
+            'draft_id',   NEW.id::text,
+            'old_status', CASE WHEN TG_OP = 'INSERT' THEN NULL ELSE OLD.status END,
+            'new_status', NEW.status,
+            'changed_at', extract(epoch FROM NOW())
+        );
+
+        INSERT INTO events_outbox (channel, payload)
+        VALUES ('wr2_status_change', payload)
+        RETURNING id INTO outbox_id;
+
+        PERFORM pg_notify(
+            'wr2_status_change',
+            (payload || jsonb_build_object('_outbox_id', outbox_id))::text
+        );
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+-- Trigger itself unchanged from migration 138 — only the function body is
+-- refactored. We don't drop+recreate the trigger to avoid any window where
+-- it's missing within this transaction. The trigger keeps pointing at the
+-- same function name (CREATE OR REPLACE replaced the body in place).
+
+COMMENT ON FUNCTION wr2_status_change_notify() IS
+    'Emits NOTIFY wr2_status_change with JSON payload {draft_id, old_status, new_status, changed_at, _outbox_id}. Writes to events_outbox FIRST for durability across listener disconnect windows. Consumed by wr2_supervisor.py — replay path reads events_outbox WHERE channel=wr2_status_change AND consumed_at IS NULL. See migration 164 + apps/war-room/scripts/wr2_supervisor.py.';
+
+-- === ROLLBACK ===
+-- Reverts the function body to the migration 138 form (pg_notify only,
+-- no events_outbox row). Trigger and outbox table are NOT dropped — the
+-- table is shared infrastructure (migration 144), and the trigger keeps
+-- pointing at the same function name. Rolling back simply removes the
+-- durability layer; consumers fall back to ephemeral pg_notify only.
+CREATE OR REPLACE FUNCTION wr2_status_change_notify() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+    IF (TG_OP = 'INSERT') OR (NEW.status IS DISTINCT FROM OLD.status) THEN
+        PERFORM pg_notify(
+            'wr2_status_change',
+            json_build_object(
+                'draft_id',   NEW.id::text,
+                'old_status', CASE WHEN TG_OP = 'INSERT' THEN NULL ELSE OLD.status END,
+                'new_status', NEW.status,
+                'changed_at', extract(epoch FROM NOW())
+            )::text
+        );
+    END IF;
+    RETURN NEW;
+END;
+$$;

--- a/apps/backend-rag/backend/services/events/outbox.py
+++ b/apps/backend-rag/backend/services/events/outbox.py
@@ -10,16 +10,19 @@ This module records every publication in the ``events_outbox`` table
 (migration 144) so the EventBus can replay missed events when its
 listener comes back online.
 
-Phase 1 contract (this PR):
+Status (post phase-3, 2026-05-09):
 
-* ``publish()`` is callable directly but is NOT yet wired into the
-  existing ``emit_pg()`` callers. The only consumer in this PR is the
-  new EventBus reconnect hook in ``event_bus.py``.
-* ``replay_unconsumed()`` re-dispatches lost events to in-process
-  handlers via the caller-provided ``dispatch_fn`` and auto-acknowledges
-  rows after the dispatch returns. A crash inside the handler still
-  leaves the row marked consumed in phase 1 — this is a known limitation
-  documented in the synthesis. Phase 2 introduces per-handler ack.
+* Phase 1 (PR #342, migration 144): ``publish()`` + ``replay_unconsumed()``
+  callable, EventBus reconnect hook wired.
+* Phase 2 (migration 146 + ``EventBus.emit_pg`` delegation): six DB-trigger
+  functions refactored to write events_outbox FIRST, then pg_notify with
+  ``_outbox_id`` injected.
+* Phase 3 (this file as-shipped): ``replay_unconsumed()`` only acks rows
+  AFTER ``dispatch_fn`` returns successfully — handler crash leaves the
+  row unconsumed for next replay (at-least-once semantics). Consumers
+  must dedupe via ``_outbox_id``. A daily ``prune_consumed(30)`` cron
+  (LaunchAgent ``com.nuzantara.outbox-prune.daily``) keeps the table
+  bounded.
 
 Reference impl: ``apps/backend-rag/backend/services/bridge/outbox.py``
 (generalised here — bridge_outbox is a different table for Pro/Air
@@ -179,9 +182,11 @@ async def replay_unconsumed(
     Called from the EventBus reconnect handler so events lost during a
     listener-disconnect window are not silently dropped.
 
-    Phase 1 contract: each row is dispatched once, then acked. If
-    ``dispatch_fn`` raises, the exception is logged and the row stays
-    unconsumed (will be retried on the next replay).
+    Phase-3 contract: each row is dispatched once, and acked only AFTER
+    ``dispatch_fn`` returns successfully. If ``dispatch_fn`` raises, the
+    exception is logged and the row stays unconsumed (retried on the
+    next replay). At-least-once semantics — handlers must dedupe via
+    ``_outbox_id`` for idempotency.
 
     Args:
         conn: asyncpg connection.

--- a/apps/mata-garuda/data/gov_apis_inventory.json
+++ b/apps/mata-garuda/data/gov_apis_inventory.json
@@ -81,5 +81,10 @@
     "id": "pemkab_jembrana",
     "url": "https://jembranakab.go.id/articles",
     "category": "regulation_bali"
+  },
+  {
+    "id": "disparda_baliprov",
+    "url": "https://disparda.baliprov.go.id/category/info-terkini/",
+    "category": "regulation_bali"
   }
 ]

--- a/apps/mata-garuda/mata_garuda/domains/setup_team/feeders/nb_intel_immigration.py
+++ b/apps/mata-garuda/mata_garuda/domains/setup_team/feeders/nb_intel_immigration.py
@@ -36,11 +36,42 @@ logger = logging.getLogger(__name__)
 IMIGRASI_BERITA_URL = "https://www.imigrasi.go.id/berita"
 KEMENKUM_BERITA_URL = "https://www.kemenkum.go.id/berita-utama"
 TEMPO_IMIGRASI_TAG_URL = "https://www.tempo.co/tag/imigrasi"
+
+# Phase 1.5 PR-C: 3 Bali Kantor Imigrasi (regional offices). Each entry is
+# (layer_tag, news_url, host_filter). Live verified 2026-05-08:
+#   - Ngurah Rai (airport) uses /berita-dan-siaran-pers/
+#   - Denpasar (city) uses /kat/berita
+#   - Singaraja (north) uses /berita-keimigrasian/
+# Path varies per office — don't assume a uniform schema. All Kanim sites
+# render article links with relative hrefs (e.g. href="/berita/123") so the
+# harvester resolves them against the source URL host.
+KANIM_BALI_LAYERS: tuple[tuple[str, str, str], ...] = (
+    (
+        "kanim_ngurahrai",
+        "https://ngurahrai.imigrasi.go.id/berita-dan-siaran-pers/",
+        "ngurahrai.imigrasi.go.id",
+    ),
+    (
+        "kanim_denpasar",
+        "https://denpasar.imigrasi.go.id/kat/berita",
+        "denpasar.imigrasi.go.id",
+    ),
+    (
+        "kanim_singaraja",
+        "https://singaraja.imigrasi.go.id/berita-keimigrasian/",
+        "singaraja.imigrasi.go.id",
+    ),
+)
+
 DEFAULT_TIMEOUT_SECONDS = 20.0
 
 TRUSTED_TIER1_HOSTS = {
     "imigrasi.go.id",
     "kemenkum.go.id",  # post-2024 rebrand
+    # Phase 1.5 PR-C — 3 Bali Kantor Imigrasi subdomains.
+    "ngurahrai.imigrasi.go.id",
+    "denpasar.imigrasi.go.id",
+    "singaraja.imigrasi.go.id",
 }
 
 IMMIGRATION_REGEX = re.compile(
@@ -97,6 +128,11 @@ async def _fetch_url_links(
         return out
 
     body = resp.text
+    # Resolve relative hrefs against the source URL's scheme+host. The
+    # Kanim Bali portals (PR-C) emit href="/berita/123" not absolute URLs,
+    # and the central imigrasi.go.id site occasionally does the same.
+    base_host = _extract_base_host(url)
+
     link_re = re.compile(
         r'<a[^>]+href="(?P<url>[^"]+)"[^>]*>(?P<title>[^<]+)</a>',
         re.IGNORECASE,
@@ -105,6 +141,11 @@ async def _fetch_url_links(
     for m in link_re.finditer(body):
         href = m.group("url").strip()
         title = m.group("title").strip()
+        # Resolve relative → absolute
+        if href.startswith("/"):
+            href = f"{base_host}{href}"
+        elif not href.startswith("http"):
+            continue  # Skip mailto:/javascript:/anchor refs.
         if domain_filter and domain_filter not in href:
             continue
         if href in seen:
@@ -126,6 +167,23 @@ async def _fetch_url_links(
             )
         )
     return out
+
+
+def _extract_base_host(url: str) -> str:
+    """Return scheme+host from a URL, e.g.
+    'https://ngurahrai.imigrasi.go.id/berita-dan-siaran-pers/' →
+    'https://ngurahrai.imigrasi.go.id'.
+    Used to resolve relative hrefs back to absolute URLs."""
+    if not url.startswith("http"):
+        return ""
+    scheme_end = url.find("://")
+    if scheme_end == -1:
+        return ""
+    host_start = scheme_end + 3
+    host_end = url.find("/", host_start)
+    if host_end == -1:
+        return url
+    return url[:host_end]
 
 
 def _dedupe(regulations: Iterable[Regulation]) -> list[Regulation]:
@@ -158,6 +216,13 @@ async def fetch_recent_immigration(
         layer_kemenkum = await _fetch_url_links(
             http, KEMENKUM_BERITA_URL, "kemenkum", domain_filter="kemenkum.go.id"
         )
+        kanim_results: list[list[Regulation]] = []
+        for layer_tag, kanim_url, host_filter in KANIM_BALI_LAYERS:
+            kanim_results.append(
+                await _fetch_url_links(
+                    http, kanim_url, layer_tag, domain_filter=host_filter
+                )
+            )
         layer_tempo = await _fetch_url_links(
             http, TEMPO_IMIGRASI_TAG_URL, "tempo", domain_filter="tempo.co"
         )
@@ -165,7 +230,10 @@ async def fetch_recent_immigration(
         if own_http:
             await http.aclose()
 
-    combined = list(layer_imigrasi) + list(layer_kemenkum) + list(layer_tempo)
+    combined: list[Regulation] = list(layer_imigrasi) + list(layer_kemenkum)
+    for kanim_layer in kanim_results:
+        combined.extend(kanim_layer)
+    combined.extend(layer_tempo)
     deduped = _dedupe(combined)
     in_window = [r for r in deduped if _within_window(r.published_at, days)]
     return in_window
@@ -173,6 +241,8 @@ async def fetch_recent_immigration(
 
 __all__ = [
     "IMMIGRATION_REGEX",
+    "KANIM_BALI_LAYERS",
+    "KEMENKUM_BERITA_URL",
     "LIFESTYLE_BLOCKLIST",
     "TRUSTED_TIER1_HOSTS",
     "fetch_recent_immigration",

--- a/apps/mata-garuda/mata_garuda/domains/setup_team/feeders/nb_intel_regulation.py
+++ b/apps/mata-garuda/mata_garuda/domains/setup_team/feeders/nb_intel_regulation.py
@@ -44,6 +44,16 @@ logger = logging.getLogger(__name__)
 # Current JDIHN navigation exposes /dokumen-hukum (HTTP 200 verified).
 JDIHN_SEARCH_URL = "https://jdihn.go.id/dokumen-hukum"
 SETKAB_PRESS_URL = "https://setkab.go.id/category/berita/"
+
+# Phase 1.5 PR-C tier-2 sources (national).
+# BPK = Badan Pemeriksa Keuangan, official gov regulation index. Search
+# parametrized by `type=peraturan` returns the index page with links to
+# /Details/<id>/<slug>. Live verified 2026-05-08.
+BPK_SEARCH_URL = "https://peraturan.bpk.go.id/Search?type=peraturan"
+# peraturan.go.id apex returns 500 (server-side bug); www subdomain is the
+# working canonical. Live verified 2026-05-08.
+PERATURAN_GO_ID_URL = "https://www.peraturan.go.id/"
+
 DEFAULT_TIMEOUT_SECONDS = 20.0
 
 # Domains we trust as tier-1 gov direct.
@@ -171,6 +181,83 @@ async def _fetch_jdihn(http: httpx.AsyncClient, days: int) -> list[Regulation]:
     return out
 
 
+async def _fetch_generic_html(
+    http: httpx.AsyncClient,
+    url: str,
+    layer_tag: str,
+    base_host: str,
+) -> list[Regulation]:
+    """Generic best-effort HTML link harvester for regulation portals.
+
+    Resolves relative hrefs against `base_host` (e.g. "https://peraturan.bpk.go.id")
+    so the resulting Regulation.url is always absolute. Filters by
+    REGULATION_REGEX on the link's anchor text.
+
+    Used by Phase 1.5 PR-C BPK + peraturan.go.id layers.
+    """
+    out: list[Regulation] = []
+    try:
+        resp = await http.get(url)
+    except (httpx.HTTPError, httpx.TimeoutException) as exc:
+        logger.warning("%s fetch failed: %s", layer_tag, exc)
+        return out
+    if resp.status_code != 200:
+        logger.warning("%s returned %s, skipping", layer_tag, resp.status_code)
+        return out
+
+    body = resp.text
+    link_re = re.compile(
+        r'<a[^>]+href="(?P<url>[^"]+)"[^>]*>(?P<title>[^<]+)</a>',
+        re.IGNORECASE,
+    )
+    seen_urls: set[str] = set()
+    for m in link_re.finditer(body):
+        title = m.group("title").strip()
+        href = m.group("url").strip()
+        # Resolve relative → absolute against base_host
+        if href.startswith("/"):
+            href_abs = f"{base_host.rstrip('/')}{href}"
+        elif href.startswith("http"):
+            href_abs = href
+        else:
+            continue  # Skip mailto:/javascript:/etc.
+        if href_abs in seen_urls:
+            continue
+        seen_urls.add(href_abs)
+        if not _matches_regulation_regex(title):
+            continue
+        sid = f"{layer_tag}:{abs(hash(href_abs))}"
+        out.append(
+            Regulation(
+                source_id=sid,
+                domain="regulation",
+                tier=_classify_tier(href_abs),
+                title=title,
+                url=href_abs,
+                published_at=None,
+                body_excerpt="",
+                tags=(f"layer:{layer_tag}",),
+            )
+        )
+    return out
+
+
+async def _fetch_bpk(http: httpx.AsyncClient, days: int) -> list[Regulation]:
+    """Layer 4 (PR-C): peraturan.bpk.go.id Search index."""
+    return await _fetch_generic_html(
+        http, BPK_SEARCH_URL, "bpk", "https://peraturan.bpk.go.id"
+    )
+
+
+async def _fetch_peraturan_go_id(
+    http: httpx.AsyncClient, days: int
+) -> list[Regulation]:
+    """Layer 5 (PR-C): www.peraturan.go.id homepage scrape."""
+    return await _fetch_generic_html(
+        http, PERATURAN_GO_ID_URL, "peraturan_go_id", "https://www.peraturan.go.id"
+    )
+
+
 async def _fetch_setkab(http: httpx.AsyncClient, days: int) -> list[Regulation]:
     """Layer 3: setkab.go.id press signals (Perpres/PP). Best-effort scrape."""
     out: list[Regulation] = []
@@ -259,12 +346,20 @@ async def fetch_recent_regulations(
     try:
         layer_pasal = await _fetch_pasal_id(pid_client, days)
         layer_jdihn = await _fetch_jdihn(http, days)
+        layer_bpk = await _fetch_bpk(http, days)
+        layer_peraturan = await _fetch_peraturan_go_id(http, days)
         layer_setkab = await _fetch_setkab(http, days)
     finally:
         if own_http:
             await http.aclose()
 
-    combined = list(layer_pasal) + list(layer_jdihn) + list(layer_setkab)
+    combined = (
+        list(layer_pasal)
+        + list(layer_jdihn)
+        + list(layer_bpk)
+        + list(layer_peraturan)
+        + list(layer_setkab)
+    )
     deduped = _dedupe(combined)
     in_window = [r for r in deduped if _within_window(r.published_at, days)]
     return in_window

--- a/apps/mata-garuda/mata_garuda/domains/setup_team/feeders/nb_intel_regulation_bali.py
+++ b/apps/mata-garuda/mata_garuda/domains/setup_team/feeders/nb_intel_regulation_bali.py
@@ -64,9 +64,13 @@ BALI_PORTAL_IDS = (
     # Perbup news in its /berita or /articles section to not lose coverage).
     "pemkab_bangli",
     "pemkab_jembrana",
+    # Phase 1.5 PR-C: Bali tourism authority — publishes PERDA on
+    # akomodasi pariwisata, desa adat, subak heritage. Slow (~30s) so
+    # the probe gate timeout matters here. Verified live 200 on 2026-05-08.
+    "disparda_baliprov",
 )
 
-# Tier-1 trusted: all 10 are gov direct (.go.id under provincia/kabupaten/kota).
+# Tier-1 trusted: all 11 are gov direct (.go.id under provincia/kabupaten/kota).
 TRUSTED_TIER1_HOSTS = {
     "jdih.baliprov.go.id",
     "jdih.badungkab.go.id",
@@ -78,6 +82,7 @@ TRUSTED_TIER1_HOSTS = {
     "jdih.karangasemkab.go.id",
     "banglikab.go.id",
     "jembranakab.go.id",
+    "disparda.baliprov.go.id",
 }
 
 CATEGORY_REGEXES = {

--- a/apps/mata-garuda/tests/domains/setup_team/test_feeders.py
+++ b/apps/mata-garuda/tests/domains/setup_team/test_feeders.py
@@ -11,15 +11,21 @@ import pytest
 
 from mata_garuda.domains.setup_team.feeders.nb_intel_immigration import (
     IMMIGRATION_REGEX,
+    KANIM_BALI_LAYERS,
     KEMENKUM_BERITA_URL,
     LIFESTYLE_BLOCKLIST,
+    TRUSTED_TIER1_HOSTS as IMMIGRATION_TRUSTED_TIER1_HOSTS,
+    _fetch_url_links,
     _matches_immigration_regex,
     fetch_recent_immigration,
 )
 from mata_garuda.domains.setup_team.feeders.nb_intel_regulation import (
+    BPK_SEARCH_URL,
     JDIHN_SEARCH_URL,
+    PERATURAN_GO_ID_URL,
     REGULATION_REGEX,
     SETKAB_PRESS_URL,
+    TRUSTED_TIER1_HOSTS as REGULATION_TRUSTED_TIER1_HOSTS,
     _classify_tier,
     _fetch_jdihn,
     _matches_regulation_regex,
@@ -85,6 +91,80 @@ def test_setkab_press_url_uses_category_berita_path():
     assert SETKAB_PRESS_URL == "https://setkab.go.id/category/berita/"
 
 
+# ---------------- T1.5 PR-C: tier-2 source constants ---------------- #
+
+
+def test_bpk_search_url_filters_by_peraturan_type():
+    """peraturan.bpk.go.id/Search?type=peraturan returns 200 with the
+    Peraturan index page (Permenkop/PMK/PP/UU links). Live verified
+    2026-05-08."""
+    assert BPK_SEARCH_URL == "https://peraturan.bpk.go.id/Search?type=peraturan"
+
+
+def test_peraturan_go_id_url_uses_www_subdomain():
+    """peraturan.go.id apex returns 500; www.peraturan.go.id returns 200.
+    Live verified 2026-05-08."""
+    assert PERATURAN_GO_ID_URL == "https://www.peraturan.go.id/"
+
+
+def test_regulation_trusted_hosts_include_new_tier2():
+    """BPK + peraturan.go.id were already in TRUSTED_TIER1_HOSTS from
+    Phase 0; pin them here so a future cleanup doesn't drop them."""
+    assert "peraturan.bpk.go.id" in REGULATION_TRUSTED_TIER1_HOSTS
+    assert "peraturan.go.id" in REGULATION_TRUSTED_TIER1_HOSTS
+
+
+def test_kanim_bali_layers_include_3_offices():
+    """Phase 1.5 PR-C: 3 Bali immigration offices added (Ngurah Rai
+    airport, Denpasar city, Singaraja north). All under <office>.imigrasi.go.id.
+
+    Each entry is (layer_tag, url, host_filter). Live verified 2026-05-08."""
+    layer_tags = {entry[0] for entry in KANIM_BALI_LAYERS}
+    assert layer_tags == {"kanim_ngurahrai", "kanim_denpasar", "kanim_singaraja"}
+
+
+def test_immigration_trusted_hosts_include_kanim_bali_subdomains():
+    """All 3 Kanim Bali subdomains must be tier-1 trusted (gov direct)."""
+    expected = {
+        "ngurahrai.imigrasi.go.id",
+        "denpasar.imigrasi.go.id",
+        "singaraja.imigrasi.go.id",
+    }
+    assert expected.issubset(IMMIGRATION_TRUSTED_TIER1_HOSTS), (
+        f"missing: {expected - IMMIGRATION_TRUSTED_TIER1_HOSTS}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_url_links_resolves_relative_hrefs_against_base_url():
+    """Kanim portals link articles via relative hrefs (e.g. href="/berita/123").
+    The harvester must convert them to absolute URLs before storing —
+    otherwise tier classification + dedup get the wrong key.
+    Phase 1.5 PR-C requirement."""
+    http = AsyncMock()
+    html = (
+        '<html><body>'
+        '<a href="/berita/123">KITAS aturan baru WNA</a>'
+        '<a href="https://ngurahrai.imigrasi.go.id/berita/456">VOA exit permit</a>'
+        '</body></html>'
+    )
+    http.get = AsyncMock(return_value=MagicMock(status_code=200, text=html))
+
+    out = await _fetch_url_links(
+        http,
+        url="https://ngurahrai.imigrasi.go.id/berita-dan-siaran-pers/",
+        layer_tag="kanim_ngurahrai",
+        domain_filter="ngurahrai.imigrasi.go.id",
+    )
+    urls = {r.url for r in out}
+    # Relative href resolved to absolute against the host of the source URL:
+    assert "https://ngurahrai.imigrasi.go.id/berita/123" in urls, (
+        f"relative href not resolved; got urls={urls}"
+    )
+    # Already-absolute href passes through unchanged:
+    assert "https://ngurahrai.imigrasi.go.id/berita/456" in urls
+
+
 # ---------------- T2: nb_intel_regulation ---------------- #
 
 
@@ -123,10 +203,10 @@ async def test_fetch_recent_regulations_swallows_pasal_id_auth_error():
     pid.search_laws = AsyncMock(side_effect=PasalIdAuthError("no token"))
 
     http = AsyncMock()
-    # JDIHN response — empty body so no links match.
-    jdihn_resp = MagicMock(status_code=200, text="<html><body></body></html>")
-    setkab_resp = MagicMock(status_code=200, text="<html><body></body></html>")
-    http.get = AsyncMock(side_effect=[jdihn_resp, setkab_resp])
+    # 4 layers fetched in order: JDIHN, BPK, peraturan_go_id, setkab.
+    # All return empty bodies so no links match.
+    empty_resp = MagicMock(status_code=200, text="<html><body></body></html>")
+    http.get = AsyncMock(side_effect=[empty_resp, empty_resp, empty_resp, empty_resp])
 
     result = await fetch_recent_regulations(
         days=30,
@@ -155,11 +235,13 @@ async def test_fetch_recent_regulations_dedupes_across_layers():
     <a href="https://example.com/lifestyle">Top 10 cafe</a>
     </body></html>
     """
-    setkab_resp = MagicMock(status_code=200, text="")
+    empty_resp = MagicMock(status_code=200, text="")
     http.get = AsyncMock(
         side_effect=[
-            MagicMock(status_code=200, text=jdihn_html),
-            setkab_resp,
+            MagicMock(status_code=200, text=jdihn_html),  # JDIHN
+            empty_resp,  # BPK
+            empty_resp,  # peraturan.go.id
+            empty_resp,  # setkab
         ]
     )
 
@@ -215,6 +297,8 @@ async def test_fetch_recent_regulations_jdihn_5xx_does_not_kill_other_layers():
     http.get = AsyncMock(
         side_effect=[
             MagicMock(status_code=503, text=""),  # JDIHN dead
+            MagicMock(status_code=200, text=""),  # BPK empty
+            MagicMock(status_code=200, text=""),  # peraturan.go.id empty
             MagicMock(status_code=200, text=""),  # setkab fine
         ]
     )
@@ -292,10 +376,15 @@ async def test_fetch_recent_immigration_dedupes_and_filters():
     <a href="https://www.tempo.co/imigrasi/aturan-baru">imigrasi memperketat aturan WNA</a>
     </body></html>
     """
+    empty_resp = MagicMock(status_code=200, text="")
+    # Order: imigrasi, kemenkum, 3 Kanim Bali (PR-C), tempo. 6 layers total.
     http.get = AsyncMock(
         side_effect=[
             MagicMock(status_code=200, text=imigrasi_html),
             MagicMock(status_code=200, text=kemenkum_html),
+            empty_resp,  # kanim_ngurahrai
+            empty_resp,  # kanim_denpasar
+            empty_resp,  # kanim_singaraja
             MagicMock(status_code=200, text=tempo_html),
         ]
     )
@@ -317,6 +406,8 @@ async def test_fetch_recent_immigration_dedupes_and_filters():
 @pytest.mark.asyncio
 async def test_fetch_recent_immigration_one_layer_dead_does_not_kill_others():
     http = AsyncMock()
+    empty_resp = MagicMock(status_code=200, text="")
+    # Order: imigrasi, kemenkum, 3 Kanim Bali (PR-C), tempo.
     http.get = AsyncMock(
         side_effect=[
             MagicMock(status_code=503, text=""),  # imigrasi dead
@@ -324,6 +415,9 @@ async def test_fetch_recent_immigration_one_layer_dead_does_not_kill_others():
                 status_code=200,
                 text='<a href="https://www.kemenkum.go.id/x">RPTKA aturan</a>',
             ),
+            empty_resp,  # kanim_ngurahrai
+            empty_resp,  # kanim_denpasar
+            empty_resp,  # kanim_singaraja
             MagicMock(status_code=500, text=""),  # tempo dead
         ]
     )
@@ -365,37 +459,33 @@ def test_bali_category_regexes_classify_correctly():
     assert _classify_categories("") == ()
 
 
-def test_bali_portal_ids_include_all_8_jdih_plus_2_pemkab_fallbacks():
-    """Phase 1.5 PR-B — expanded from 4 to 10 portals.
+def test_bali_portal_ids_include_jdih_pemkab_and_disparda():
+    """Phase 1.5 evolution: 4 (Phase 1) → 10 (PR-B) → 11 (PR-C, +disparda).
 
-    8 jdih portals (4 original + 4 added 2026-05-08): provincia + Badung
-    + Gianyar + Denpasar + Tabanan + Buleleng + Klungkung + Karangasem.
-
-    2 Pemkab homepage fallbacks (Bangli + Jembrana — their dedicated
-    jdih.<kab>.go.id subdomains DNS-fail or timeout, so we scrape the
-    Pemkab homepage's /berita or /articles section instead).
-
-    Live verification 2026-05-08: all 8 jdih return 200; banglikab.go.id
-    and jembranakab.go.id return 200 with regulation-relevant berita.
+    8 jdih portals + 2 Pemkab homepage fallbacks + 1 tourism authority
+    (disparda.baliprov.go.id, the provincial tourism office that publishes
+    PERDA on akomodasi pariwisata, desa adat, subak heritage).
     """
     assert set(BALI_PORTAL_IDS) == {
-        # Original 4 (Phase 1).
+        # Original 4 jdih (Phase 1).
         "jdih_baliprov",
         "jdih_badungkab",
         "jdih_gianyarkab",
         "jdih_denpasarkota",
-        # New jdih (Phase 1.5 PR-B).
+        # PR-B jdih.
         "jdih_tabanankab",
         "jdih_bulelengkab",
         "jdih_klungkungkab",
         "jdih_karangasemkab",
-        # Pemkab homepage fallbacks (jdih.<kab>.go.id was unreachable).
+        # PR-B Pemkab homepage fallbacks.
         "pemkab_bangli",
         "pemkab_jembrana",
+        # PR-C tourism authority.
+        "disparda_baliprov",
     }
 
 
-def test_bali_trusted_tier1_hosts_includes_all_10_portals():
+def test_bali_trusted_tier1_hosts_include_jdih_pemkab_and_disparda():
     """All gov-direct hosts must be tier-1 trusted for the scorer."""
     expected = {
         "jdih.baliprov.go.id",
@@ -408,6 +498,7 @@ def test_bali_trusted_tier1_hosts_includes_all_10_portals():
         "jdih.karangasemkab.go.id",
         "banglikab.go.id",
         "jembranakab.go.id",
+        "disparda.baliprov.go.id",
     }
     assert expected.issubset(BALI_TRUSTED_TIER1_HOSTS), (
         f"missing trusted hosts: {expected - BALI_TRUSTED_TIER1_HOSTS}"

--- a/apps/mata-garuda/tests/integration/test_feeder_endpoints_live.py
+++ b/apps/mata-garuda/tests/integration/test_feeder_endpoints_live.py
@@ -38,19 +38,34 @@ pytestmark = [
 ]
 
 ENDPOINTS = [
-    # (name, url, allow_404_for_now) — Phase 1.5 PR-A baseline
+    # Phase 1.5 PR-A baseline (regulation + immigration national + media).
     ("imigrasi_berita", "https://www.imigrasi.go.id/berita"),
     ("kemenkum_berita_utama", "https://www.kemenkum.go.id/berita-utama"),
     ("jdihn_dokumen_hukum", "https://jdihn.go.id/dokumen-hukum?keyword=2026"),
     ("setkab_category_berita", "https://setkab.go.id/category/berita/"),
     ("tempo_imigrasi_tag", "https://www.tempo.co/tag/imigrasi"),
+    # Phase 1.5 PR-C: regulation tier-2.
+    ("bpk_search", "https://peraturan.bpk.go.id/Search?type=peraturan"),
+    ("peraturan_go_id", "https://www.peraturan.go.id/"),
+    # Phase 1.5 PR-C: 3 Bali Kantor Imigrasi (regional).
+    (
+        "kanim_ngurahrai",
+        "https://ngurahrai.imigrasi.go.id/berita-dan-siaran-pers/",
+    ),
+    ("kanim_denpasar", "https://denpasar.imigrasi.go.id/kat/berita"),
+    (
+        "kanim_singaraja",
+        "https://singaraja.imigrasi.go.id/berita-keimigrasian/",
+    ),
 ]
 
 
 @pytest.mark.parametrize("name,url", ENDPOINTS)
 def test_endpoint_reachable(name: str, url: str) -> None:
-    """Each Phase 1 source must return 200 with substantive body."""
-    with httpx.Client(timeout=15.0, follow_redirects=True) as client:
+    """Each Phase 1.5 source must return 200 with substantive body."""
+    # 30s timeout — some Bali offices and the regulation portals can be
+    # slow under load (live verified 2026-05-08).
+    with httpx.Client(timeout=30.0, follow_redirects=True) as client:
         resp = client.get(url, headers={"User-Agent": "mata-garuda-smoke/1.0"})
 
     assert resp.status_code == 200, (

--- a/apps/mata-garuda/tests/integration/test_feeder_endpoints_live_bali.py
+++ b/apps/mata-garuda/tests/integration/test_feeder_endpoints_live_bali.py
@@ -50,6 +50,11 @@ BALI_ENDPOINTS = [
     ("jdih_karangasemkab", "https://jdih.karangasemkab.go.id"),
     ("pemkab_bangli", "https://www.banglikab.go.id/berita"),
     ("pemkab_jembrana", "https://jembranakab.go.id/articles"),
+    # Phase 1.5 PR-C: provincial tourism authority.
+    (
+        "disparda_baliprov",
+        "https://disparda.baliprov.go.id/category/info-terkini/",
+    ),
 ]
 
 
@@ -76,7 +81,8 @@ def test_bali_endpoint_reachable(portal_id: str, url: str, request) -> None:
             )
         )
 
-    with httpx.Client(timeout=20.0, follow_redirects=True) as client:
+    # 45s timeout — disparda.baliprov.go.id can take 30+ seconds to respond.
+    with httpx.Client(timeout=45.0, follow_redirects=True) as client:
         resp = client.get(url, headers={"User-Agent": "mata-garuda-smoke/1.0"})
 
     assert resp.status_code == 200, (

--- a/apps/organism/organism/organs_registry.yaml
+++ b/apps/organism/organism/organs_registry.yaml
@@ -53,7 +53,7 @@
 
 version: 1
 checksum_algo: sha256
-checksum: 4c97900b466df729c48fbf4d7788ce2f6f3729581bfcac8f21dd95f45c3304e6
+checksum: 870561659d4ba8c2c10f925659604b40c0c92b411c4efbcc148fb6a59922f8b0
 organs:
   - id: infra.postgres
     runtime: fly_machine
@@ -1667,3 +1667,45 @@ organs:
       label: com.nuzantara.nb-mitochondrial-monitor.daily
     severity_on_silence: warning
     cicatrix_refs: []
+
+  # Sentinel aggregator (2026-05-09) — single pane of glass for all organs.
+  # Reads ~/.organism/last_seen/*.json + launchctl list, classifies each
+  # organ as ok/stale/dead/noheartbeat/unknown, writes ~/.organism/aggregate.json.
+  - id: pro.sentinel_aggregate
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 600
+    owner_module: scripts/sentinel-aggregate.py
+    dependencies: []
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.sentinel-aggregate
+    severity_on_silence: warning
+    cicatrix_refs: []
+    bridge_source:
+      type: state_file
+      path: ~/.organism/last_seen/pro.sentinel_aggregate.json
+      timestamp_field: ts
+      status_field: status
+
+  # Phase-3 Outbox prune (2026-05-09) — daily GC of consumed events_outbox
+  # rows older than 30d. Bounds table growth post phase-2 EventBus refactor.
+  - id: pro.outbox_prune_daily
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 90000
+    owner_module: scripts/outbox-prune.sh
+    dependencies:
+      - infra.postgres
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.outbox-prune.daily
+    severity_on_silence: warning
+    cicatrix_refs: []
+    bridge_source:
+      type: state_file
+      path: ~/.organism/last_seen/pro.outbox_prune_daily.json
+      timestamp_field: ts
+      status_field: status

--- a/apps/organism/organism/organs_registry.yaml
+++ b/apps/organism/organism/organs_registry.yaml
@@ -53,7 +53,7 @@
 
 version: 1
 checksum_algo: sha256
-checksum: 9ed0b2991528497aa2adc4294f09531e87351ff678a6ab9d611a92050d9130f1
+checksum: 4c97900b466df729c48fbf4d7788ce2f6f3729581bfcac8f21dd95f45c3304e6
 organs:
   - id: infra.postgres
     runtime: fly_machine
@@ -1134,5 +1134,536 @@ organs:
     recovery_params:
       host: pro
       label: com.balizero.sota.m13-weekly
+    severity_on_silence: warning
+    cicatrix_refs: []
+
+  # Wave 2 — 2026-05-09: enroll 40 LaunchAgent previously siloed (full-system
+  # "everyone hears everything" gap #1). Brings registry from 67/107 to 107/107.
+  # Producer audit: launchctl list ∩ {com.{balizero,nuzantara,cell,matagaruda}.*}
+  # diff'd against registry labels. No bridge_source on these — supervisor uses
+  # launchctl print to detect silence (no last_seen heartbeat writers exist for
+  # this batch). Heartbeat hooks ship in a follow-up PR per category.
+
+  # WR2 children (9) — all under wr2.supervisor parent.
+  - id: wr2.canva_oauth_watchdog
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 3600
+    owner_module: scripts/wr2-canva-oauth-watchdog.sh
+    dependencies:
+      - wr2.supervisor
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.balizero.wr2.canva-oauth-watchdog
+    severity_on_silence: warning
+    cicatrix_refs: []
+  - id: wr2.deploy_puller
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 600
+    owner_module: scripts/wr2-deploy-pull.sh
+    dependencies: []
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.balizero.wr2.deploy-puller
+    severity_on_silence: warning
+    cicatrix_refs: []
+  - id: wr2.fact_checker
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 1800
+    owner_module: apps/war-room/scripts/wr2_fact_checker.py
+    dependencies:
+      - wr2.supervisor
+      - infra.postgres
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.balizero.wr2.fact-checker
+    severity_on_silence: warning
+    cicatrix_refs: []
+  - id: wr2.fact_extractor
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 1800
+    owner_module: apps/war-room/scripts/wr2_fact_extractor.py
+    dependencies:
+      - wr2.supervisor
+      - infra.postgres
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.balizero.wr2.fact-extractor
+    severity_on_silence: warning
+    cicatrix_refs: []
+  - id: wr2.ig_scraper_daily
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 90000
+    owner_module: .claude/skills/bali-zero-brand/_ig-metrics-scraper.py
+    dependencies:
+      - wr2.supervisor
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.balizero.wr2.ig-scraper.daily
+    severity_on_silence: info
+    cicatrix_refs: []
+  - id: wr2.queue_server
+    runtime: pro_launchd
+    type: daemon
+    expected_hb_seconds: 300
+    owner_module: .claude/skills/bali-zero-brand/_damar-queue-server.py
+    dependencies:
+      - wr2.supervisor
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.balizero.wr2.queue-server
+    severity_on_silence: error
+    cicatrix_refs: []
+  - id: wr2.reflexion_weekly
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 691200
+    owner_module: .claude/skills/bali-zero-brand/_reflexion-synthesis.py
+    dependencies:
+      - wr2.supervisor
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.balizero.wr2.reflexion.weekly
+    severity_on_silence: info
+    cicatrix_refs: []
+  - id: wr2.supervisor_watchdog
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 600
+    owner_module: apps/war-room/scripts/wr2_supervisor_watchdog.py
+    dependencies:
+      - wr2.supervisor
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.balizero.wr2.supervisor-watchdog
+    severity_on_silence: critical
+    cicatrix_refs: []
+  - id: wr2.voyager_weekly
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 691200
+    owner_module: .claude/skills/bali-zero-brand/_voyager-curriculum.py
+    dependencies:
+      - wr2.supervisor
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.balizero.wr2.voyager.weekly
+    severity_on_silence: info
+    cicatrix_refs: []
+
+  # Codex agents (5) — autonomous overnight workers + cost advisor weekly.
+  - id: codex.spalla_calibrate
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 90000
+    owner_module: scripts/codex-spalla-calibrate.sh
+    dependencies: []
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.balizero.codex-spalla-calibrate
+    severity_on_silence: info
+    cicatrix_refs: []
+  - id: codex.coverage_improver
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 90000
+    owner_module: scripts/codex-nightly-coverage-improver.sh
+    dependencies: []
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.codex-coverage-improver
+    severity_on_silence: info
+    cicatrix_refs: []
+  - id: codex.overnight_feeder
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 90000
+    owner_module: scripts/codex-overnight-queue-feeder.sh
+    dependencies: []
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.codex-overnight-feeder
+    severity_on_silence: info
+    cicatrix_refs: []
+  - id: codex.research_actor
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 90000
+    owner_module: scripts/codex-daily-research-actor.sh
+    dependencies: []
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.codex-research-actor
+    severity_on_silence: info
+    cicatrix_refs: []
+  - id: pro.cost_advisor_weekly
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 691200
+    owner_module: apps/backend-rag/backend/scripts/cost_advisor_cli.py
+    dependencies:
+      - infra.postgres
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.cost-advisor-weekly
+    severity_on_silence: info
+    cicatrix_refs: []
+
+  # Automap (3) — Pro-local automation map server + telegram + watchdog.
+  - id: pro.automap_server
+    runtime: pro_launchd
+    type: daemon
+    expected_hb_seconds: 300
+    owner_module: scripts/automap/automap_server.py
+    dependencies: []
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.automap-server
+    severity_on_silence: warning
+    cicatrix_refs: []
+  - id: pro.automap_telegram
+    runtime: pro_launchd
+    type: daemon
+    expected_hb_seconds: 300
+    owner_module: scripts/automap/automap_telegram.py
+    dependencies:
+      - pro.automap_server
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.automap-telegram
+    severity_on_silence: warning
+    cicatrix_refs: []
+  - id: pro.automap_watchdog
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 90
+    owner_module: scripts/automap/automap_watchdog.py
+    dependencies:
+      - pro.automap_server
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.automap-watchdog
+    severity_on_silence: warning
+    cicatrix_refs: []
+
+  # Organism core (2) — the Supervisor itself + scheduled tick. Self-enrollment
+  # is intentional (meta-observability); recovery=human_only on supervisor since
+  # a dead supervisor cannot recover itself.
+  - id: organism.supervisor
+    runtime: pro_launchd
+    type: daemon
+    expected_hb_seconds: 120
+    owner_module: apps/organism/organism/supervisor/daemon.py
+    dependencies:
+      - infra.postgres
+    recovery_action: human_only
+    recovery_params:
+      host: pro
+      label: com.nuzantara.organism.supervisor
+    severity_on_silence: critical
+    cicatrix_refs: []
+  - id: organism.scheduled_tick
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 600
+    owner_module: apps/organism/organism/scheduled_tick.py
+    dependencies:
+      - organism.supervisor
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.organism.scheduled-tick
+    severity_on_silence: warning
+    cicatrix_refs: []
+
+  # Cell bridges (3) — heartbeat-bridge feeds Cell from launchd state, the other
+  # two are liveness watchdogs. All critical: Cell observability dies without them.
+  - id: pro.heartbeat_bridge
+    runtime: pro_launchd
+    type: daemon
+    expected_hb_seconds: 120
+    owner_module: apps/cell/scripts/launch_heartbeat_bridge.sh
+    dependencies:
+      - infra.postgres
+      - cell.organism
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.heartbeat-bridge
+    severity_on_silence: critical
+    cicatrix_refs: []
+  - id: pro.launchagent_state_bridge
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 600
+    owner_module: scripts/launchagent-state-bridge.py
+    dependencies: []
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.launchagent-state-bridge
+    severity_on_silence: warning
+    cicatrix_refs: []
+  - id: pro.supervisor_liveness_watchdog
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 900
+    owner_module: scripts/supervisor_liveness_watchdog.sh
+    dependencies:
+      - organism.supervisor
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.supervisor-liveness-watchdog
+    severity_on_silence: critical
+    cicatrix_refs: []
+
+  # Pro↔Mini sync daemons (2).
+  - id: pro.memory_sync_bidirectional
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 600
+    owner_module: scripts/mini-setup/memory-sync-bidirectional.sh
+    dependencies: []
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.memory-sync-bidirectional
+    severity_on_silence: warning
+    cicatrix_refs: []
+  - id: pro.claude_config_sync
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 90000
+    owner_module: scripts/mini-setup/claude-config-sync.sh
+    dependencies: []
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.claude-config-sync
+    severity_on_silence: info
+    cicatrix_refs: []
+
+  # Daily ops crons (10).
+  - id: pro.indexing_sweep_daily
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 90000
+    owner_module: scripts/daily_indexing_cron_wrapper.sh
+    dependencies:
+      - infra.postgres
+      - infra.qdrant
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.balizero.indexing-sweep.daily
+    severity_on_silence: warning
+    cicatrix_refs: []
+  - id: pro.intel_radar_daily_digest
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 90000
+    owner_module: scripts/cron-agent-python/intel_radar_daily_digest.py
+    dependencies:
+      - infra.postgres
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.balizero.intel-radar-daily-digest
+    severity_on_silence: warning
+    cicatrix_refs: []
+  - id: pro.post_publish_webhook
+    runtime: pro_launchd
+    type: webhook
+    expected_hb_seconds: 300
+    owner_module: apps/bali-intel-scraper/scripts/post_publish_webhook.py
+    dependencies:
+      - backend.api
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.balizero.post-publish-webhook
+    severity_on_silence: error
+    cicatrix_refs: []
+  - id: pro.setup_team_daily
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 90000
+    owner_module: infra/scripts/setup-team-cron.sh
+    dependencies:
+      - infra.postgres
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.balizero.setup-team.daily
+    severity_on_silence: warning
+    cicatrix_refs: []
+  - id: pro.seo_cell_daily
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 90000
+    owner_module: scripts/openclaw-cron/seo-cell-daily.sh
+    dependencies: []
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.balizero.seo-cell.daily
+    severity_on_silence: warning
+    cicatrix_refs: []
+  - id: pro.seo_cell_28d_check
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 2419200
+    owner_module: scripts/openclaw-cron/seo-cell-28d-check.sh
+    dependencies: []
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.balizero.seo-cell.28d-check
+    severity_on_silence: info
+    cicatrix_refs: []
+  - id: pro.bz_daily_visual_pipeline
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 90000
+    owner_module: scripts/bz-daily-visual-pipeline.sh
+    dependencies: []
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.balizero.bz-daily-visual-pipeline
+    severity_on_silence: warning
+    cicatrix_refs: []
+  - id: pro.domain_mesh_foundations_daily
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 90000
+    owner_module: scripts/domain-mesh-foundations-cron.sh
+    dependencies: []
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.balizero.domain-mesh.foundations.daily
+    severity_on_silence: info
+    cicatrix_refs: []
+  - id: pro.client_value_predictor
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 90000
+    owner_module: scripts/openclaw-cron/client-value-predictor.sh
+    dependencies:
+      - infra.postgres
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.balizero.client-value-predictor
+    severity_on_silence: info
+    cicatrix_refs: []
+  - id: pro.automations_reference
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 90000
+    owner_module: scripts/generate-automations-all.sh
+    dependencies: []
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.automations-reference
+    severity_on_silence: info
+    cicatrix_refs: []
+
+  # Infra-ish (6) — local infrastructure helpers.
+  - id: pro.prime_tunnel
+    runtime: pro_launchd
+    type: daemon
+    expected_hb_seconds: 300
+    owner_module: cloudflared/config-prime.yml
+    dependencies: []
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.prime-tunnel
+    severity_on_silence: error
+    cicatrix_refs: []
+  - id: pro.ollama_warm_pin
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 900
+    owner_module: scripts/ollama-warm-pin.sh
+    dependencies: []
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.ollama-warm-pin
+    severity_on_silence: warning
+    cicatrix_refs: []
+  - id: pro.vector_reindex_check
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 90000
+    owner_module: scripts/vector-reindex-check.py
+    dependencies:
+      - infra.qdrant
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.vector-reindex-check
+    severity_on_silence: warning
+    cicatrix_refs: []
+  - id: pro.launchd_env_loader
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 90000
+    owner_module: scripts/launchd_env_loader.sh
+    dependencies: []
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.launchd-env-loader
+    severity_on_silence: info
+    cicatrix_refs: []
+  - id: pro.openclaw_logrotate
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 90000
+    owner_module: scripts/openclaw-logrotate.sh
+    dependencies: []
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.openclaw-logrotate
+    severity_on_silence: info
+    cicatrix_refs: []
+  - id: pro.nb_mitochondrial_monitor_daily
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 90000
+    owner_module: apps/mata-garuda/mata_garuda/scripts/nb_monitor/run.py
+    dependencies: []
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.nb-mitochondrial-monitor.daily
     severity_on_silence: warning
     cicatrix_refs: []

--- a/infra/launchagents/com.nuzantara.outbox-prune.daily.plist
+++ b/infra/launchagents/com.nuzantara.outbox-prune.daily.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.nuzantara.outbox-prune.daily</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>/Users/nuzantara</string>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+		<key>OUTBOX_PRUNE_DAYS</key>
+		<string>30</string>
+	</dict>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>/Users/nuzantara/Desktop/nuzantara/scripts/outbox-prune.sh</string>
+	</array>
+	<key>StartCalendarInterval</key>
+	<dict>
+		<key>Hour</key>
+		<integer>3</integer>
+		<key>Minute</key>
+		<integer>15</integer>
+	</dict>
+	<key>RunAtLoad</key>
+	<false/>
+	<key>StandardOutPath</key>
+	<string>/Users/nuzantara/logs/outbox-prune.log</string>
+	<key>StandardErrorPath</key>
+	<string>/Users/nuzantara/logs/outbox-prune.error.log</string>
+</dict>
+</plist>

--- a/infra/launchagents/com.nuzantara.sentinel-aggregate.plist
+++ b/infra/launchagents/com.nuzantara.sentinel-aggregate.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.nuzantara.sentinel-aggregate</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>/Users/nuzantara</string>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/Users/nuzantara/.pyenv/versions/3.11.11/bin</string>
+	</dict>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Users/nuzantara/.pyenv/versions/3.11.11/bin/python3</string>
+		<string>/Users/nuzantara/Desktop/nuzantara/scripts/sentinel-aggregate.py</string>
+	</array>
+	<key>StartInterval</key>
+	<integer>300</integer>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StandardOutPath</key>
+	<string>/Users/nuzantara/logs/sentinel-aggregate.log</string>
+	<key>StandardErrorPath</key>
+	<string>/Users/nuzantara/logs/sentinel-aggregate.error.log</string>
+</dict>
+</plist>

--- a/scripts/outbox-prune.sh
+++ b/scripts/outbox-prune.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# outbox-prune.sh — daily prune of consumed events_outbox rows older than 30 days.
+#
+# Phase-3 Outbox companion: replay_unconsumed leaves rows acked but not deleted
+# so audit/debugging stays possible. Without pruning the table grows unbounded
+# (~10k rows/day at current write volume). This script bounds retention at 30d.
+#
+# Schedule: ~/Library/LaunchAgents/com.nuzantara.outbox-prune.daily.plist
+#   StartCalendarInterval Hour=3, Minute=15 (after fly-pg-backup at 03:00).
+#
+# Exit codes: 0 success (prints rows deleted), 1 prune RPC failed, 2 env missing.
+
+set -euo pipefail
+
+LOG_DIR="${HOME}/logs"
+mkdir -p "$LOG_DIR"
+LOG="${LOG_DIR}/outbox-prune.log"
+
+log() {
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" | tee -a "$LOG"
+}
+
+# Source secrets.
+SECRETS_FILE="${HOME}/.nuzantara-secrets.env"
+if [ -f "$SECRETS_FILE" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$SECRETS_FILE"
+    set +a
+fi
+
+if [ -z "${DATABASE_URL:-}" ]; then
+    log "ERROR: DATABASE_URL not set, exiting"
+    exit 2
+fi
+
+REPO_ROOT="${HOME}/Desktop/nuzantara"
+VENV="${REPO_ROOT}/apps/backend-rag/.venv/bin/python"
+
+if [ ! -x "$VENV" ]; then
+    log "ERROR: backend-rag .venv not found at $VENV"
+    exit 2
+fi
+
+OLDER_THAN_DAYS="${OUTBOX_PRUNE_DAYS:-30}"
+
+log "starting prune: older_than_days=$OLDER_THAN_DAYS"
+
+cd "$REPO_ROOT/apps/backend-rag"
+
+DELETED=$(PYTHONPATH=. "$VENV" -c "
+import asyncio
+import os
+import sys
+import asyncpg
+from backend.services.events.outbox import prune_consumed
+
+async def main():
+    conn = await asyncpg.connect(os.environ['DATABASE_URL'], command_timeout=300)
+    try:
+        n = await prune_consumed(conn, older_than_days=int(os.environ.get('OUTBOX_PRUNE_DAYS', '30')))
+        print(n)
+    finally:
+        await conn.close()
+
+asyncio.run(main())
+" 2>>"$LOG")
+
+if [ -z "$DELETED" ]; then
+    log "ERROR: prune RPC returned empty output"
+    exit 1
+fi
+
+log "completed: deleted $DELETED row(s)"
+
+# Heartbeat for the Innervation Genoma supervisor.
+HEARTBEAT_DIR="${HOME}/.organism/last_seen"
+mkdir -p "$HEARTBEAT_DIR"
+cat > "${HEARTBEAT_DIR}/pro.outbox_prune_daily.json" <<EOF
+{"ts": "$(date -u +%Y-%m-%dT%H:%M:%SZ)", "status": "ok", "deleted": $DELETED}
+EOF
+
+exit 0

--- a/scripts/sentinel-aggregate.py
+++ b/scripts/sentinel-aggregate.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""sentinel-aggregate.py — single pane of glass for the Innervation Genoma.
+
+Reads the organs_registry.yaml and aggregates per-organ status by combining:
+  1. ~/.organism/last_seen/<id>.json (heartbeat written by the organ itself
+     or by its wrapper script).
+  2. `launchctl list` output for `runtime: pro_launchd` organs (PID + last
+     exit code, gives liveness when no last_seen file exists).
+  3. `expected_hb_seconds` from the registry to classify silence as
+     ok / stale / dead based on age vs threshold.
+
+Output:
+  - Writes a JSON snapshot to ~/.organism/aggregate.json (atomic via
+    write-then-rename) for dashboard / Telegram consumers.
+  - Prints a human-readable summary table to stdout, grouped by severity.
+
+Status classification (per organ):
+  ok        last_seen age <= expected_hb_seconds, status field = ok
+  stale     expected_hb_seconds < age <= 3 * expected_hb_seconds
+  dead      age > 3 * expected_hb_seconds  OR  status field != ok
+  unknown   no heartbeat file AND no launchctl entry (or registry-only fly_machine)
+  noheartbeat  organ has no bridge_source AND launchctl shows it loaded
+               (registry coverage exists but no liveness signal)
+
+Schedule: ~/Library/LaunchAgents/com.nuzantara.sentinel-aggregate.plist
+  StartInterval = 300 seconds (5 min).
+
+Exit codes:
+  0  successful aggregation
+  1  registry parse error
+  2  cannot write aggregate.json
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REGISTRY_PATH = Path.home() / "Desktop" / "nuzantara" / "apps" / "organism" / "organism" / "organs_registry.yaml"
+LAST_SEEN_DIR = Path.home() / ".organism" / "last_seen"
+AGGREGATE_PATH = Path.home() / ".organism" / "aggregate.json"
+
+STALE_MULTIPLIER = 1.0
+DEAD_MULTIPLIER = 3.0
+
+
+def _now_epoch() -> float:
+    return time.time()
+
+
+def _parse_ts(ts: Any) -> float | None:
+    """Accept ISO-8601 string OR float epoch seconds. Returns epoch float."""
+    if isinstance(ts, (int, float)):
+        return float(ts)
+    if isinstance(ts, str):
+        try:
+            return datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            try:
+                return float(ts)
+            except ValueError:
+                return None
+    return None
+
+
+def _read_last_seen(organ_id: str) -> dict[str, Any] | None:
+    path = LAST_SEEN_DIR / f"{organ_id}.json"
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _launchctl_loaded() -> dict[str, dict[str, Any]]:
+    """Return {label: {pid, last_exit}} from `launchctl list`."""
+    try:
+        out = subprocess.check_output(
+            ["launchctl", "list"], text=True, timeout=10
+        )
+    except (subprocess.SubprocessError, OSError):
+        return {}
+
+    result: dict[str, dict[str, Any]] = {}
+    for line in out.splitlines()[1:]:
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        pid_str, exit_str, label = parts[0].strip(), parts[1].strip(), parts[2].strip()
+        try:
+            pid = int(pid_str) if pid_str != "-" else None
+        except ValueError:
+            pid = None
+        try:
+            last_exit = int(exit_str)
+        except ValueError:
+            last_exit = None
+        result[label] = {"pid": pid, "last_exit": last_exit}
+    return result
+
+
+def _classify(
+    organ: dict[str, Any],
+    hb: dict[str, Any] | None,
+    launchctl_entry: dict[str, Any] | None,
+    now: float,
+) -> dict[str, Any]:
+    organ_id = organ["id"]
+    runtime = organ.get("runtime", "")
+    expected_hb = organ.get("expected_hb_seconds", 0)
+    severity_on_silence = organ.get("severity_on_silence", "warning")
+
+    # fly_machine: no local launchctl, status comes from health endpoint —
+    # out of scope for this aggregator. Mark as remote.
+    if runtime == "fly_machine":
+        return {
+            "id": organ_id,
+            "runtime": runtime,
+            "status": "remote",
+            "age_seconds": None,
+            "severity": "info",
+            "owner_module": organ.get("owner_module"),
+            "recovery_action": organ.get("recovery_action"),
+        }
+
+    # Heartbeat present: compute freshness.
+    if hb is not None:
+        ts = _parse_ts(hb.get("ts"))
+        age = (now - ts) if ts is not None else None
+        hb_status = str(hb.get("status", "ok")).lower()
+
+        if age is None:
+            status = "unknown"
+        elif hb_status not in ("ok", "success", "healthy"):
+            status = "dead"
+        elif expected_hb > 0 and age > expected_hb * DEAD_MULTIPLIER:
+            status = "dead"
+        elif expected_hb > 0 and age > expected_hb * STALE_MULTIPLIER:
+            status = "stale"
+        else:
+            status = "ok"
+
+        return {
+            "id": organ_id,
+            "runtime": runtime,
+            "status": status,
+            "age_seconds": int(age) if age is not None else None,
+            "severity": severity_on_silence if status in ("dead", "stale") else "info",
+            "owner_module": organ.get("owner_module"),
+            "recovery_action": organ.get("recovery_action"),
+            "hb_status": hb_status,
+        }
+
+    # No heartbeat. Fall back to launchctl liveness.
+    if launchctl_entry is not None:
+        pid = launchctl_entry.get("pid")
+        last_exit = launchctl_entry.get("last_exit")
+        # Loaded but no PID = idle (cron between ticks). Acceptable for cron.
+        # Loaded with non-zero last_exit = recent failure.
+        if last_exit is not None and last_exit != 0:
+            return {
+                "id": organ_id,
+                "runtime": runtime,
+                "status": "dead",
+                "age_seconds": None,
+                "severity": severity_on_silence,
+                "owner_module": organ.get("owner_module"),
+                "recovery_action": organ.get("recovery_action"),
+                "last_exit": last_exit,
+            }
+        return {
+            "id": organ_id,
+            "runtime": runtime,
+            "status": "noheartbeat",
+            "age_seconds": None,
+            "severity": "info",
+            "owner_module": organ.get("owner_module"),
+            "recovery_action": organ.get("recovery_action"),
+            "pid": pid,
+        }
+
+    # Not loaded in launchctl AND no heartbeat = unknown / not running.
+    return {
+        "id": organ_id,
+        "runtime": runtime,
+        "status": "unknown",
+        "age_seconds": None,
+        "severity": severity_on_silence,
+        "owner_module": organ.get("owner_module"),
+        "recovery_action": organ.get("recovery_action"),
+    }
+
+
+def _atomic_write(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=False), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _print_summary(rollup: dict[str, list[dict[str, Any]]]) -> None:
+    print(
+        f"=== Sentinel Aggregate @ {datetime.now(timezone.utc).isoformat(timespec='seconds')} ==="
+    )
+    for status in ("dead", "stale", "noheartbeat", "unknown", "remote", "ok"):
+        items = rollup.get(status, [])
+        if not items:
+            continue
+        print(f"\n[{status.upper()}] {len(items)} organ(s):")
+        for item in items:
+            age_str = (
+                f"age={item['age_seconds']}s" if item.get("age_seconds") is not None else "age=n/a"
+            )
+            print(f"  - {item['id']:50s} {age_str:20s} severity={item.get('severity')}")
+
+
+def main() -> int:
+    if not REGISTRY_PATH.exists():
+        print(f"ERROR: registry not found at {REGISTRY_PATH}", file=sys.stderr)
+        return 1
+
+    try:
+        registry = yaml.safe_load(REGISTRY_PATH.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        print(f"ERROR: registry parse failed: {exc}", file=sys.stderr)
+        return 1
+
+    organs = registry.get("organs", [])
+    if not isinstance(organs, list):
+        print("ERROR: registry has no organs list", file=sys.stderr)
+        return 1
+
+    launchctl_map = _launchctl_loaded()
+    now = _now_epoch()
+
+    results: list[dict[str, Any]] = []
+    for organ in organs:
+        if not isinstance(organ, dict) or "id" not in organ:
+            continue
+        organ_id = organ["id"]
+        hb = _read_last_seen(organ_id)
+        label = (organ.get("recovery_params") or {}).get("label")
+        launchctl_entry = launchctl_map.get(label) if label else None
+        results.append(_classify(organ, hb, launchctl_entry, now))
+
+    rollup: dict[str, list[dict[str, Any]]] = {}
+    for r in results:
+        rollup.setdefault(r["status"], []).append(r)
+
+    aggregate = {
+        "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "registry_organ_count": len(organs),
+        "classified_count": len(results),
+        "by_status": {k: len(v) for k, v in rollup.items()},
+        "organs": results,
+    }
+
+    try:
+        _atomic_write(AGGREGATE_PATH, aggregate)
+    except OSError as exc:
+        print(f"ERROR: cannot write aggregate.json: {exc}", file=sys.stderr)
+        return 2
+
+    # Heartbeat for self.
+    self_hb = LAST_SEEN_DIR / "pro.sentinel_aggregate.json"
+    try:
+        _atomic_write(
+            self_hb,
+            {
+                "ts": aggregate["ts"],
+                "status": "ok",
+                "by_status": aggregate["by_status"],
+            },
+        )
+    except OSError:
+        pass
+
+    _print_summary(rollup)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wr2_supervisor.py
+++ b/scripts/wr2_supervisor.py
@@ -497,6 +497,63 @@ async def _heartbeat_loop(conn_hb: asyncpg.Connection) -> None:
 
 
 # ─────────────────────────────────────────────────────────────────────────
+# Outbox replay (migration 164 — wr2_status_change durability)
+# ─────────────────────────────────────────────────────────────────────────
+
+async def _replay_outbox(conn: asyncpg.Connection) -> int:
+    """Replay unconsumed wr2_status_change events from events_outbox.
+
+    Reads rows where channel='wr2_status_change' AND consumed_at IS NULL,
+    ordered by id ASC (commit order). For each row, dispatches via
+    _handle_payload and ONLY THEN marks consumed_at = NOW(). If
+    _handle_payload raises, the row stays unconsumed and will be retried
+    on the next supervisor restart — at-least-once semantics, consumer
+    must dedupe via _recently_dispatched (which it already does).
+
+    Returns the count of successfully dispatched + acked rows.
+    """
+    rows = await conn.fetch(
+        """
+        SELECT id, payload
+          FROM events_outbox
+         WHERE channel = 'wr2_status_change' AND consumed_at IS NULL
+         ORDER BY id ASC
+         LIMIT 500
+        """
+    )
+    if not rows:
+        return 0
+
+    acked = 0
+    for row in rows:
+        outbox_id = row["id"]
+        payload = row["payload"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        if not isinstance(payload, dict):
+            logger.warning("outbox row %d has non-dict payload, marking consumed", outbox_id)
+            await conn.execute(
+                "UPDATE events_outbox SET consumed_at = NOW() WHERE id = $1",
+                outbox_id,
+            )
+            continue
+
+        try:
+            await _handle_payload(payload, conn)
+        except Exception:
+            logger.exception("outbox replay handler failed for id=%d, leaving unconsumed", outbox_id)
+            continue
+
+        await conn.execute(
+            "UPDATE events_outbox SET consumed_at = NOW() WHERE id = $1",
+            outbox_id,
+        )
+        acked += 1
+
+    return acked
+
+
+# ─────────────────────────────────────────────────────────────────────────
 # Connection loop with auto-reconnect
 # ─────────────────────────────────────────────────────────────────────────
 
@@ -519,6 +576,19 @@ async def _run_loop() -> None:
             conn = await asyncpg.connect(dsn=dsn, command_timeout=30)
             await conn.add_listener("wr2_status_change", _on_notification)
             logger.info("LISTEN wr2_status_change active")
+
+            # Outbox replay (migration 164): drain any wr2_status_change
+            # events that landed in events_outbox while we were down. The
+            # trigger writes to events_outbox FIRST, then pg_notify — so
+            # any pg_notify we missed is recoverable via outbox SELECT.
+            # Ack each row only AFTER _handle_payload returns successfully
+            # (per-handler ack — no blanket auto-ack).
+            try:
+                replayed = await _replay_outbox(conn)
+                if replayed:
+                    logger.info("outbox replay: dispatched %d missed event(s)", replayed)
+            except Exception:
+                logger.exception("outbox replay failed (non-fatal, continuing)")
 
             # Dedicated heartbeat connection: SECOND asyncpg.connect, NEVER
             # shared with the LISTEN conn. asyncpg.Connection allows only


### PR DESCRIPTION
## Summary

Closes 5/5 audit gaps from the cross-cutting "everyone hears everything" full-system review (bus + memory + observability backbone).

- **#1** — Enroll 40 siloed LaunchAgents in \`organs_registry.yaml\`. Coverage 67/107 → 107/107 = 100%.
- **#2** — WR2 channel becomes durable: migration 164 + \`wr2_supervisor.py\` outbox replay on connect.
- **#3** — Phase-3 Outbox: docstring sync + daily prune cron (\`com.nuzantara.outbox-prune.daily\`, 03:15).
- **#4** — Single pane: \`sentinel-aggregate.py\` + LaunchAgent (every 5min) writes \`~/.organism/aggregate.json\`.
- **#5** — Out-of-repo: \`~/scripts/wave1-pro-mini-dup-resolver.sh\` gains \`--resolve-mata-garuda\` mode (Pro-canonical bootout on Mini for the 13 cicatrix labels).

Registry final: 116 organs, validator green, checksum \`870561659d…\`.

## Test plan

- [x] \`python -m organism.tools.validate_organs_registry\` green (no dup ids, no cycles, checksum matches)
- [x] \`plutil -lint\` on both new plists: OK
- [x] \`python3 scripts/sentinel-aggregate.py\` live run: classifies 116 organs, writes aggregate.json
- [x] \`~/scripts/wave1-pro-mini-dup-resolver.sh --check\` + \`--resolve-mata-garuda\` (read-only): 0 active double-fires today, resolver structurally ready
- [x] Pre-commit hooks both commits: import chain OK, Python lint OK, Prettier OK, OFF-LIMITS OK
- [ ] Required CI checks: E2E Tests (Playwright) + MCP Server Tests
- [ ] Migration 164 will apply via \`run-sql-v2-migrations-post-deploy\` job on next backend deploy
- [ ] Manual launchctl bootstrap of the 2 new plists post-merge (not part of CI)

## Out of scope (deferred)

- Heartbeat hooks (\`bridge_source\` writers) for the 83 noheartbeat organs — per-category follow-up.
- Real Mini bootout of the 13 mata_garuda labels — trigger when Mini Tailscale stabilizes and labels reload.
- SYMBIOSIS.md doc update ("Redis Streams" → "PG LISTEN/NOTIFY + Outbox") — separate low-priority PR.
- P0-0 \`/health\` startup_failed check from prior audit — separate scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)