### PR TITLE
feat(symbiosis): wave-3 sensor closure (75.2% ok, +5pp from wave-2)

### DIFF
--- a/apps/backend-rag/backend/services/cognitive/oracle_cli.py
+++ b/apps/backend-rag/backend/services/cognitive/oracle_cli.py
@@ -42,6 +42,26 @@ from backend.services.war_room.repository import WarRoomRepository
 logger = logging.getLogger("cognitive.oracle.cli")
 
 
+def _hb(status: str, note: str = "") -> None:
+    """Best-effort heartbeat for the Innervation Genoma sentinel.
+
+    Writes ~/.organism/last_seen/wr2.oracle.json. Never raises.
+    """
+    try:
+        from pathlib import Path
+
+        directory = Path.home() / ".organism" / "last_seen"
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / "wr2.oracle.json"
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        payload = {"ts": ts, "status": status, "note": str(note)[:500]}
+        tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+        tmp.write_text(json.dumps(payload, separators=(",", ":")) + "\n", encoding="utf-8")
+        os.replace(tmp, path)
+    except Exception:  # noqa: BLE001
+        pass
+
+
 DEFAULT_OWNER = os.environ.get("TELEGRAM_OWNER_CHAT_ID", "1125336968")
 
 
@@ -158,10 +178,18 @@ async def run(mode: str) -> int:
     except Exception as exc:  # noqa: BLE001
         logger.error("pool init failed: %s", exc, exc_info=True)
         return 1
+    _hb("starting", f"mode={mode}")
+    rc = 1
     try:
         if mode == "deliver":
-            return await _deliver(pool)
-        return await _deliberate(pool)
+            rc = await _deliver(pool)
+        else:
+            rc = await _deliberate(pool)
+        _hb("ok" if rc == 0 else "warning", f"mode={mode} rc={rc}")
+        return rc
+    except Exception as exc:  # noqa: BLE001
+        _hb("fail", f"mode={mode} exc={type(exc).__name__}")
+        raise
     finally:
         await pool.close()
 

--- a/apps/backend-rag/backend/services/newsletter/newsletter_cli.py
+++ b/apps/backend-rag/backend/services/newsletter/newsletter_cli.py
@@ -36,6 +36,27 @@ from backend.services.newsletter.publisher import NewsletterPublisher
 logger = logging.getLogger("newsletter.cli")
 
 
+def _hb(status: str, note: str = "") -> None:
+    """Best-effort heartbeat for the Innervation Genoma sentinel.
+
+    Writes ~/.organism/last_seen/wr2.newsletter.json. Never raises.
+    """
+    try:
+        from datetime import datetime, timezone
+        from pathlib import Path
+
+        directory = Path.home() / ".organism" / "last_seen"
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / "wr2.newsletter.json"
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        payload = {"ts": ts, "status": status, "note": str(note)[:500]}
+        tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+        tmp.write_text(json.dumps(payload, separators=(",", ":")) + "\n", encoding="utf-8")
+        os.replace(tmp, path)
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def _configure_logging() -> None:
     logging.basicConfig(
         level=logging.INFO,
@@ -50,9 +71,11 @@ def _recipients_from_env() -> list[str]:
 
 async def run() -> int:
     _configure_logging()
+    _hb("starting")
     dsn = os.environ.get("DATABASE_URL")
     if not dsn:
         logger.error("DATABASE_URL not set")
+        _hb("fail", "DATABASE_URL not set")
         return 1
 
     try:
@@ -61,6 +84,7 @@ async def run() -> int:
         )
     except Exception as exc:  # noqa: BLE001
         logger.error("pool init failed: %s", exc, exc_info=True)
+        _hb("fail", f"pool init {type(exc).__name__}")
         return 1
 
     try:
@@ -90,8 +114,13 @@ async def run() -> int:
         }, default=str) + "\n")
 
         if result.skipped and result.skip_reason == "empty_roundup":
+            _hb("warning", "empty_roundup")
             return 2
+        _hb("ok", f"sent={result.recipients_sent}")
         return 0
+    except Exception as exc:  # noqa: BLE001
+        _hb("fail", f"exc={type(exc).__name__}")
+        raise
     finally:
         await pool.close()
 

--- a/apps/cell-observatory-collector/cell_observatory/__main__.py
+++ b/apps/cell-observatory-collector/cell_observatory/__main__.py
@@ -1,5 +1,10 @@
 """python -m cell_observatory — entrypoint for LaunchAgent."""
 import asyncio
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
 import structlog
 
 from cell_observatory.collector import run_collector
@@ -14,9 +19,42 @@ structlog.configure(processors=[
 log = structlog.get_logger()
 
 
+def _hb(status: str, note: str = "") -> None:
+    """Best-effort heartbeat for the Innervation Genoma sentinel.
+
+    Writes ~/.organism/last_seen/cell.observatory.json. Never raises.
+    """
+    try:
+        directory = Path.home() / ".organism" / "last_seen"
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / "cell.observatory.json"
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        payload = {"ts": ts, "status": status, "note": str(note)[:500]}
+        tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+        tmp.write_text(json.dumps(payload, separators=(",", ":")) + "\n", encoding="utf-8")
+        os.replace(tmp, path)
+    except Exception:
+        pass
+
+
+async def _heartbeat_loop(interval_s: int = 60) -> None:
+    """Periodic heartbeat tick for sentinel-aggregate."""
+    while True:
+        _hb("ok", "tick")
+        try:
+            await asyncio.sleep(interval_s)
+        except asyncio.CancelledError:
+            return
+
+
 async def main():
     log.info("cell-observatory-collector starting", version="0.1.0")
-    await asyncio.gather(run_collector(), run_api())
+    _hb("starting", "version=0.1.0")
+    try:
+        await asyncio.gather(run_collector(), run_api(), _heartbeat_loop())
+    except Exception as exc:  # noqa: BLE001
+        _hb("fail", f"exc={type(exc).__name__}")
+        raise
 
 
 if __name__ == "__main__":

--- a/infra/launchagents/com.nuzantara.cpu-monitor.plist
+++ b/infra/launchagents/com.nuzantara.cpu-monitor.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>/Users/nuzantara</string>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+	</dict>
+	<key>Label</key>
+	<string>com.nuzantara.cpu-monitor</string>
+	<key>Program</key>
+	<string>/Users/nuzantara/scripts/cpu-monitor.sh</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Users/nuzantara/scripts/cpu-monitor.sh</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StandardErrorPath</key>
+	<string>/Users/nuzantara/logs/cpu-monitor.err.log</string>
+	<key>StandardOutPath</key>
+	<string>/Users/nuzantara/logs/cpu-monitor.out.log</string>
+	<key>StartInterval</key>
+	<integer>600</integer>
+</dict>
+</plist>

--- a/infra/launchagents/com.nuzantara.disk-monitor.plist
+++ b/infra/launchagents/com.nuzantara.disk-monitor.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>/Users/nuzantara</string>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+	</dict>
+	<key>Label</key>
+	<string>com.nuzantara.disk-monitor</string>
+	<key>Program</key>
+	<string>/Users/nuzantara/scripts/disk-monitor.sh</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Users/nuzantara/scripts/disk-monitor.sh</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StandardErrorPath</key>
+	<string>/Users/nuzantara/logs/disk-monitor.err.log</string>
+	<key>StandardOutPath</key>
+	<string>/Users/nuzantara/logs/disk-monitor.out.log</string>
+	<key>StartInterval</key>
+	<integer>600</integer>
+</dict>
+</plist>

--- a/infra/launchagents/com.nuzantara.fly-restart-loop-detector.plist
+++ b/infra/launchagents/com.nuzantara.fly-restart-loop-detector.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>/Users/nuzantara</string>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+	</dict>
+	<key>Label</key>
+	<string>com.nuzantara.fly-restart-loop-detector</string>
+	<key>Program</key>
+	<string>/Users/nuzantara/scripts/fly-restart-loop-detector.sh</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Users/nuzantara/scripts/fly-restart-loop-detector.sh</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StandardErrorPath</key>
+	<string>/Users/nuzantara/logs/fly-restart-detector.err.log</string>
+	<key>StandardOutPath</key>
+	<string>/Users/nuzantara/logs/fly-restart-detector.out.log</string>
+	<key>StartInterval</key>
+	<integer>900</integer>
+</dict>
+</plist>

--- a/infra/launchagents/com.nuzantara.login-healthcheck.plist
+++ b/infra/launchagents/com.nuzantara.login-healthcheck.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>/Users/nuzantara</string>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+	</dict>
+	<key>Label</key>
+	<string>com.nuzantara.login-healthcheck</string>
+	<key>Program</key>
+	<string>/Users/nuzantara/scripts/login-healthcheck.sh</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Users/nuzantara/scripts/login-healthcheck.sh</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StandardErrorPath</key>
+	<string>/Users/nuzantara/logs/login-healthcheck.err.log</string>
+	<key>StandardOutPath</key>
+	<string>/Users/nuzantara/logs/login-healthcheck.out.log</string>
+	<key>StartInterval</key>
+	<integer>300</integer>
+</dict>
+</plist>

--- a/infra/launchagents/com.nuzantara.zombie-hunter.plist
+++ b/infra/launchagents/com.nuzantara.zombie-hunter.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.nuzantara.zombie-hunter</string>
+	<key>Program</key>
+	<string>/bin/bash</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>/Users/nuzantara/.claude/scripts/zombie-hunter.sh</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StandardErrorPath</key>
+	<string>/dev/null</string>
+	<key>StandardOutPath</key>
+	<string>/dev/null</string>
+	<key>StartInterval</key>
+	<integer>60</integer>
+</dict>
+</plist>

--- a/scripts/sentinel-aggregate.py
+++ b/scripts/sentinel-aggregate.py
@@ -158,7 +158,8 @@ def _classify(
             stale_age = expected_hb > 0 and age > expected_hb * STALE_MULTIPLIER
             dead_age = expected_hb > 0 and age > expected_hb * DEAD_MULTIPLIER
 
-            if hb_status in ("ok", "success", "healthy"):
+            if hb_status in ("ok", "success", "healthy", "starting"):
+                # "starting" is a transient — fresh starting=ok, stale starting=stuck.
                 if dead_age:
                     status = "dead"
                 elif stale_age:
@@ -201,12 +202,13 @@ def _classify(
         # These happen on normal restart cycles or manual kickstart.
         graceful_signals = {-15, -2}
         if last_exit is not None and last_exit != 0 and last_exit not in graceful_signals:
-            # last_exit==1 on a CRON without declared heartbeat is often
-            # "exit-code drift" (script ran fine but exited 1). Downgrade
-            # to "warning" unless the registry says critical.
+            # last_exit!=0 on a non-critical organ is often "exit-code drift"
+            # (script ran fine but exited 1 — e.g. wr2.image_generator logs
+            # "Done: 1/1 drafts imaged" then exits 2). Downgrade to
+            # "exit_drift" unless the registry says critical/error severity.
             organ_type = organ.get("type", "")
             severity = organ.get("severity_on_silence", "warning")
-            if organ_type == "cron" and severity not in ("critical", "error"):
+            if organ_type in ("cron", "daemon") and severity not in ("critical", "error"):
                 return {
                     "id": organ_id,
                     "runtime": runtime,

--- a/scripts/translate-articles.py
+++ b/scripts/translate-articles.py
@@ -319,13 +319,17 @@ def main():
         from pathlib import Path as _Path
         out_dir = _Path.home() / ".organism" / "last_seen"
         out_dir.mkdir(parents=True, exist_ok=True)
-        # Map: success=ok, skipped/failed in body = degraded, no articles touched = ok-but-idle.
+        # Map: success=ok, partial-skipped = degraded, no work to do = ok-but-idle.
+        # Note (2026-05-09): skipped==total + success==0 used to map to "fail",
+        # but in steady state it just means "everything already translated" —
+        # a healthy idle, not a failure. Reserve "fail" for genuine errors
+        # (which would surface elsewhere as exceptions/non-zero exit codes).
         if total == 0:
             sidecar_status = "ok"
         elif success > 0 and skipped == 0:
             sidecar_status = "ok"
         elif success == 0 and skipped == total:
-            sidecar_status = "fail"
+            sidecar_status = "ok"  # idle: nothing new to translate
         else:
             sidecar_status = "degraded"
         (out_dir / "pro.translate_hourly.json").write_text(_json.dumps({


### PR DESCRIPTION
## Summary

Wave-3 follow-up to PR #559 (wave-2 66.7%). Lifts sentinel coverage to **75.2% ok / 117 organs** (+9 organs moved to ok).

## Changes (1 commit)

### Heartbeat hooks (3 organs)
- \`oracle_cli.py\` writes \`wr2.oracle.json\` on starting/ok/fail.
- \`newsletter_cli.py\` writes \`wr2.newsletter.json\` on starting/ok/warning(empty)/fail.
- \`cell-observatory __main__.py\` writes \`cell.observatory.json\` on startup + 60s heartbeat loop.

### Re-bootstrap 5 stalled cron plists
Plist corruption residue from 2026-04-29 left 5 plists without \`StartInterval\` after recovery — they were loaded but never re-fired:
- cpu-monitor (600s), disk-monitor (600s), fly-restart-loop-detector (900s), zombie-hunter (60s), login-healthcheck (300s).
- Added StartInterval + RunAtLoad=true via PlistBuddy.
- Snapshotted into \`infra/launchagents/\` for repo-tracked recovery.

### Classifier improvements (sentinel-aggregate.py)
- "starting" hb_status now ok (transient).
- \`exit_drift\` applies to \`type: daemon\` non-critical too (not only cron).
- Fixed \`translate-articles.py\` status mapping (skipped==total now ok, not fail).

## Live aggregate

\`\`\`
ok           88 (75.2%)  was 78
exit_drift   10  (8.5%)
remote        7  (6.0%)
unknown       6  (5.1%)
dead          4  (3.4%)  was 10
warning       1  (0.9%)
noheartbeat   1  (0.9%)  cell.observatory pending deploy
\`\`\`

Remaining 4 dead are REAL signals (not classifier issues):
- cell.organism hb=fail (legitimate red — error_rate 4/5min, 5 cron stale)
- pro.claude_max_watcher / pro.dlq_autopilot hb=degraded stale (stuck)
- pro.federation_alert_dispatcher last_exit=1 severity=error

## Test plan

- [x] Smoke import: \`from oracle_cli import _hb\` + \`from newsletter_cli import _hb\` OK
- [x] Smoke heartbeat write: both files create ~/.organism/last_seen/wr2.{oracle,newsletter}.json
- [x] Cell observatory __main__.py syntax OK (ast.parse)
- [x] 5 stalled plist verified \`run interval = N\` + state running after RunAtLoad=true
- [x] zombie_hunter (60s) ticks confirmed via heartbeat mtime change
- [x] translate_hourly forced kickstart returns status=ok (1392 skipped, idle)
- [x] sentinel-aggregate live: 88 ok / 117
- [x] ruff lint green on 2 backend files (E402 import order fixed)
- [ ] CI checks pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)