### PR TITLE
fix(symbiosis): wave-4 close cell red signals + migration 120 race

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -345,27 +345,73 @@ jobs:
           echo "❌ New image does not expose apply_migration_119.py after 60s"
           exit 1
 
+      - name: Pin Python migrations to a fresh-image machine in the api group (sentinel)
+        id: sentinel
+        timeout-minutes: 5
+        run: |
+          # Wave-4 fix (2026-05-09): without this filter, migration 120
+          # timed out after auto-routing to a `rag`-group machine that
+          # lacks asyncpg (run 25596634798 / commit db23d8c78). Mirrors
+          # the sentinel used by `run-sql-v2-migrations-post-deploy`.
+          # nuzantara-rag has TWO process groups: api (asyncpg installed)
+          # and rag (no asyncpg). Pin to api before running migrations.
+          for i in $(seq 1 18); do
+            JSON=$(flyctl machines list --app nuzantara-rag --json 2>/dev/null || echo '[]')
+            STARTED_TAGS=$(echo "$JSON" | jq -r '[.[] | select(.state=="started") | .image_ref.tag] | unique')
+            STARTED_COUNT=$(echo "$STARTED_TAGS" | jq 'length')
+            if [ "$STARTED_COUNT" = "1" ]; then
+              TAG=$(echo "$STARTED_TAGS" | jq -r '.[0]')
+              MACHINE=$(echo "$JSON" | jq -r --arg tag "$TAG" '
+                [.[]
+                 | select(.state=="started"
+                          and .image_ref.tag==$tag
+                          and (.config.metadata.fly_process_group == "api"))]
+                | .[0].id // empty')
+              if [ -n "$MACHINE" ]; then
+                echo "✅ Pinning Python migrations to api-group machine: $MACHINE (tag $TAG)"
+                echo "machine=$MACHINE" >> $GITHUB_OUTPUT
+                exit 0
+              fi
+              echo "Tentativo $i/18 — image tag converged ($TAG) but no started machine in api process group yet"
+            else
+              echo "Tentativo $i/18 — started_unique_tags=$STARTED_COUNT (rolling not yet converged)"
+            fi
+            sleep 10
+          done
+          echo "❌ Could not isolate a fresh-image machine in the api process group after 3 min"
+          echo "$JSON" | jq '.[] | {id, state, group: .config.metadata.fly_process_group, tag: .image_ref.tag}'
+          exit 1
+
       - name: Run Python migration 119 (partners)
         timeout-minutes: 2
         run: |
+          MACHINE="${{ steps.sentinel.outputs.machine }}"
           flyctl ssh console \
             --app nuzantara-rag \
+            --machine "$MACHINE" \
+            --process-group api \
             --command "/bin/sh -c 'cd /app && python -m backend.migrations.apply_migration_119'"
           echo "✅ Python migration 119 OK"
 
       - name: Run Python migration 120 (partner_email_outbox)
         timeout-minutes: 2
         run: |
+          MACHINE="${{ steps.sentinel.outputs.machine }}"
           flyctl ssh console \
             --app nuzantara-rag \
+            --machine "$MACHINE" \
+            --process-group api \
             --command "/bin/sh -c 'cd /app && python -m backend.migrations.apply_migration_120'"
           echo "✅ Python migration 120 OK"
 
       - name: Run Python migration 121 (practices.family_member_id)
         timeout-minutes: 2
         run: |
+          MACHINE="${{ steps.sentinel.outputs.machine }}"
           flyctl ssh console \
             --app nuzantara-rag \
+            --machine "$MACHINE" \
+            --process-group api \
             --command "/bin/sh -c 'cd /app && python -m backend.migrations.apply_migration_121'"
           echo "✅ Python migration 121 OK"
 
@@ -484,7 +530,6 @@ jobs:
       always() &&
       (needs.run-migrations.result == 'failure' || needs.deploy.result == 'failure')
     runs-on: ubuntu-latest
-
     steps:
       - name: Determine failing stage
         id: stage

--- a/apps/cell/cell/sensors/cron_sensor.py
+++ b/apps/cell/cell/sensors/cron_sensor.py
@@ -41,7 +41,9 @@ _JOB_PERIODS: dict[str, float] = {
     # heartbeat and flooding Cell pulses red every minute.
     "system_doctor":       24.0,   # daily 08:00
     "expiry_alerter":      24.0,   # daily
-    "knowledge_graph_builder": 24.0,
+    # 2026-05-09 — corrected: crontab schedule is `0 2 * * 0` (weekly Sunday
+    # 02:00), not daily. Period 168h. Yellow at 1.5×=252h, red at 3×=504h.
+    "knowledge_graph_builder": 168.0,
     "metabolic_rollup":        24.0,   # daily 23:30
 }
 

--- a/scripts/fly-pg-backup.sh
+++ b/scripts/fly-pg-backup.sh
@@ -89,8 +89,13 @@ else
     exit 1
 fi
 
-# Verify pg_dump header (gunzip -t passes even for corrupt/empty SQL dumps)
-if ! gunzip -c "$BACKUP_FILE" 2>/dev/null | grep -m1 "PostgreSQL database dump" > /dev/null 2>&1; then
+# Verify pg_dump header (gunzip -t passes even for corrupt/empty SQL dumps).
+# Bug fix 2026-05-09: previous form `gunzip -c | grep -m1 ...` failed under
+# `set -o pipefail` because grep -m1 closes its stdin on first match,
+# triggering SIGPIPE on gunzip (exit 141), which propagated as failure.
+# Use `head -c 4096` to bound the read to the header region instead.
+HEADER_PREVIEW=$(gunzip -c "$BACKUP_FILE" 2>/dev/null | head -c 4096 || true)
+if ! echo "$HEADER_PREVIEW" | grep -q "PostgreSQL database dump"; then
     log "ERROR: Backup file does not contain valid pg_dump header — dump may be corrupt or empty"
     log "CRITICAL: pg_dump header missing in $BACKUP_FILE — backup integrity check FAILED"
     exit 1

--- a/scripts/openclaw-state-bridge.py
+++ b/scripts/openclaw-state-bridge.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+OpenClaw → Sentinel bridge.
+Reads ~/.openclaw/cron/jobs.json and writes .last.json for every job.
+Run every 5 minutes via cron (same frequency as sentinel).
+"""
+import json
+import os
+import pathlib
+import time
+
+OPENCLAW_JOBS = pathlib.Path.home() / ".openclaw" / "cron" / "jobs.json"
+STATE_DIR = pathlib.Path.home() / ".agent" / "decisions" / "state"
+
+# OpenClaw schedule_seconds per job — used to set staleness context
+# (sentinel uses registry for thresholds, this is just FYI in the state file)
+SCHEDULE_MAP = {
+    "health-check":           14400,   # 4h
+    "daily-ops-autopilot":    86400,
+    "compliance-autopilot":   86400,
+    "practice-lifecycle-check": 86400,
+    "weekly-report":          604800,
+    "client-health-monitor":  86400,
+    "weekly-dep-audit":       604800,
+    "nightly-code-quality":   86400,
+    "kbli-indexing-daily":    86400,
+    "articles-indexing-daily": 86400,
+    "seo-guardian-measure":   86400,
+    "seo-guardian-weekly":    604800,
+    "conversation-cleanup":   86400,
+    "biz-orchestrator":       86400,
+    "tech-orchestrator":      86400,
+    "quality-orchestrator":   604800,
+    "system-doctor":          86400,
+    "core-guardian":          10800,   # 3h
+    "seo-guardian-observe":   86400,
+}
+
+
+def main() -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+    try:
+        data = json.loads(OPENCLAW_JOBS.read_text())
+    except Exception as e:
+        print(f"[openclaw-bridge] Cannot read jobs.json: {e}")
+        return
+
+    jobs = data.get("jobs", [])
+    written = 0
+
+    for job in jobs:
+        name = job.get("name", "")
+        if not name:
+            continue
+
+        state = job.get("state", {})
+        last_run_ms = state.get("lastRunAtMs")
+        last_status = state.get("lastStatus", "unknown")
+        consecutive_errors = state.get("consecutiveErrors", 0)
+
+        # Convert lastRunAtMs (ms) to unix ts (s)
+        ts = int(last_run_ms / 1000) if last_run_ms else int(time.time())
+
+        # Map OpenClaw status → sentinel status.
+        # Bug fix 2026-05-09: "unknown" lastStatus + consecutiveErrors==0 was
+        # being mapped to "failed", flooding cell.organism with false-red
+        # signals for jobs that simply hadn't completed yet (or whose
+        # producer doesn't write final status). Now we only mark "failed"
+        # when there is real evidence of failure (consecutiveErrors>0 OR
+        # explicit fail/error/timeout status).
+        if last_status in ("ok", "delivered"):
+            sentinel_status = "ok"
+        elif consecutive_errors > 0 or last_status in ("failed", "error", "timeout"):
+            sentinel_status = "failed"
+        else:
+            # last_status is "unknown" / "" / "running" / etc with zero
+            # consecutive errors — no failure signal. Mark "ok" so the
+            # downstream sensor doesn't flood red on a benign state.
+            sentinel_status = "ok"
+
+        # Build last_error from consecutive errors
+        last_error = None
+        if sentinel_status == "failed":
+            last_error = f"OpenClaw consecutiveErrors={consecutive_errors}, lastStatus={last_status}"
+
+        heartbeat = {
+            "job": name,
+            "ts": ts,
+            "status": sentinel_status,
+            "host": "Nuzantara",
+            "source": "openclaw-bridge",
+        }
+        if last_error:
+            heartbeat["last_error"] = last_error
+        if last_run_ms:
+            heartbeat["duration_ms"] = state.get("lastDurationMs", 0)
+
+        # Write state file (job name normalized: hyphens → underscores)
+        filename = name.replace("-", "_") + ".last.json"
+        (STATE_DIR / filename).write_text(json.dumps(heartbeat))
+        written += 1
+
+    print(f"[openclaw-bridge] Written {written}/{len(jobs)} state files")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes 3 separate residual issues from PR #559 + #560 deploy:

1. **5 cron stale that cell.organism kept flagging red**:
   - \`fly_pg_backup\` — pipefail/grep -m1 SIGPIPE on integrity check (backup data was OK, only the script logic broke). Fixed via \`head -c 4096 + grep -q\`.
   - \`nlm_deep_research / t4_monitor_daily / system_doctor\` — false positives from openclaw-state-bridge mapping \`lastStatus="unknown"\` → \"failed\" even when consecutiveErrors==0. Fixed mapping to require real evidence of failure.
   - \`knowledge_graph_builder\` — cron_sensor period was 24h but crontab is weekly. Period bumped 24h → 168h.

2. **federation_alert_dispatcher exit=1** — stale 2026-05-07 ConnectionRefused on pg-proxy startup race. pg-proxy now stable. No code change; documented for cicatrix archive.

3. **Migration 120 timeout race in fly-deploy.yml** — \`run-python-migrations\` job ssh'd without machine filter; flyctl auto-routed to a \`rag\`-group machine without asyncpg → 120 hung 2 min. Fix mirrors the proven pattern from \`run-sql-v2-migrations-post-deploy\`: new sentinel step pins to api-group machine; 119/120/121 use \`--machine $MACHINE --process-group api\`.

## Test plan

- [x] openclaw-state-bridge.py: ran live, 3 jobs flipped failed→ok
- [x] fly-pg-backup.sh: bash -n syntax OK; backup file gunzip+grep manually verified header present
- [x] cron_sensor.py: period bump to 168.0 unit-test compatible (no fixture relies on 24h literal for kg_builder)
- [x] fly-deploy.yml: python yaml.safe_load OK, prettier clean
- [x] FAD: launchctl kickstart + 30s wait, state=running stable
- [ ] CI checks pending
- [ ] Migration 120 will be re-tested on next deploy after merge

## Live aggregate snapshot pre-merge

\`\`\`
ok           88 (75.2%)   wave-3 baseline
exit_drift   10  (8.5%)
remote        7  (6.0%)
unknown       6  (5.1%)
dead          2  (1.7%)   cell.organism (will recover after this PR's bridge fix
                          flushes red OpenClaw bridge entries) + FAD (stale stamp)
warning       3  (2.6%)
noheartbeat   1  (0.9%)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)