### PR TITLE
feat(cli): nz unified dispatcher (Layer 2 — human↔system interactivity)

### DIFF
--- a/scripts/cli/nz
+++ b/scripts/cli/nz
@@ -1,0 +1,605 @@
+#!/usr/bin/env bash
+# nz — Nuzantara unified CLI dispatcher.
+#
+# Single entry point for routine operations on the 117-organ Nuzantara
+# system. Resolves organs via organs_registry.yaml; routes commands to
+# the right launchctl/fly/ssh path based on registry runtime.
+#
+# Install:
+#   ln -sf "$HOME/Desktop/nuzantara/scripts/cli/nz" "$HOME/.local/bin/nz"
+#
+# Run `nz` with no args for the help screen.
+
+set -o pipefail
+
+# ─────────────────────────────────────────────────────────────────────────
+# Constants
+# ─────────────────────────────────────────────────────────────────────────
+
+readonly REPO_ROOT="${NZ_REPO_ROOT:-$HOME/Desktop/nuzantara}"
+readonly REGISTRY="$REPO_ROOT/apps/organism/organism/organs_registry.yaml"
+readonly AGGREGATE="$HOME/.organism/aggregate.json"
+readonly OUTBOX_PRUNE_SH="$REPO_ROOT/scripts/outbox-prune.sh"
+readonly SENTINEL_AGG_PY="$REPO_ROOT/scripts/sentinel-aggregate.py"
+readonly DEFAULT_PYTHON="${NZ_PYTHON:-/Users/nuzantara/.pyenv/versions/3.11.11/bin/python3}"
+
+# Ensure brew + libpq psql is reachable even from sandboxed callers.
+export PATH="/opt/homebrew/opt/libpq/bin:/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
+
+# Colors (auto-disabled when stdout is not a TTY)
+if [ -t 1 ]; then
+    readonly C_RED=$'\033[0;31m'
+    readonly C_GREEN=$'\033[0;32m'
+    readonly C_YELLOW=$'\033[0;33m'
+    readonly C_BLUE=$'\033[0;34m'
+    readonly C_DIM=$'\033[2m'
+    readonly C_RESET=$'\033[0m'
+else
+    readonly C_RED=""
+    readonly C_GREEN=""
+    readonly C_YELLOW=""
+    readonly C_BLUE=""
+    readonly C_DIM=""
+    readonly C_RESET=""
+fi
+
+# ─────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────
+
+die() {
+    echo "${C_RED}error:${C_RESET} $*" >&2
+    exit 1
+}
+
+note() {
+    echo "${C_DIM}$*${C_RESET}" >&2
+}
+
+require_registry() {
+    [ -f "$REGISTRY" ] || die "registry not found: $REGISTRY (set NZ_REPO_ROOT?)"
+}
+
+# Parse organs_registry.yaml. Output one line per organ:
+#   <id> <runtime> <type> <recovery_action> <recovery_label_or_app> <severity>
+_organs_table() {
+    require_registry
+    "$DEFAULT_PYTHON" - "$REGISTRY" <<'PY'
+import sys, yaml
+data = yaml.safe_load(open(sys.argv[1]).read())
+for o in data.get("organs", []):
+    rp = o.get("recovery_params") or {}
+    label = rp.get("label") or rp.get("app") or ""
+    print(
+        o.get("id", "?"),
+        o.get("runtime", "?"),
+        o.get("type", "?"),
+        o.get("recovery_action", "?"),
+        label,
+        o.get("severity_on_silence", "?"),
+        sep="\t",
+    )
+PY
+}
+
+# Resolve an organ id to its registry row. Empty stdout if not found.
+_organ_resolve() {
+    local id="$1"
+    _organs_table | awk -F'\t' -v id="$id" '$1==id {print; exit}'
+}
+
+# Pretty-print a single aggregate.json organ row.
+_aggregate_organ() {
+    local id="$1"
+    [ -f "$AGGREGATE" ] || die "aggregate.json missing — is sentinel-aggregate running?"
+    "$DEFAULT_PYTHON" - "$AGGREGATE" "$id" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+target = sys.argv[2]
+for o in d.get("organs", []):
+    if o.get("id") == target:
+        print(json.dumps(o, indent=2))
+        sys.exit(0)
+print(f"organ '{target}' not in aggregate", file=sys.stderr)
+sys.exit(1)
+PY
+}
+
+# ─────────────────────────────────────────────────────────────────────────
+# nz status [organ_id]
+# ─────────────────────────────────────────────────────────────────────────
+
+cmd_status() {
+    [ -f "$AGGREGATE" ] || die "aggregate.json missing — run \`nz sentinel run\` first"
+
+    if [ $# -gt 0 ]; then
+        _aggregate_organ "$1"
+        return
+    fi
+
+    "$DEFAULT_PYTHON" - "$AGGREGATE" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+total = d.get("classified_count", 0)
+ts = d.get("ts", "?")
+print(f"Aggregate @ {ts}  total={total}")
+print()
+by = d.get("by_status", {})
+for k, v in sorted(by.items(), key=lambda x: -x[1]):
+    pct = 100*v/total if total else 0
+    print(f"  {k:12s} {v:3d}  ({pct:5.1f}%)")
+
+# Show problematic organs (not ok / exit_drift / remote)
+print()
+print("Problematic:")
+shown = 0
+for o in sorted(d.get("organs", []), key=lambda x: x.get("id","")):
+    s = o.get("status", "?")
+    if s in ("ok", "exit_drift", "remote", "disabled"):
+        continue
+    age = o.get("age_seconds")
+    age_s = f"age={age}s" if age is not None else "age=n/a"
+    hb = o.get("hb_status") or "-"
+    print(f"  [{s:11s}] {o.get('id'):44s} hb={hb:9s} {age_s}")
+    shown += 1
+if shown == 0:
+    print("  (none)")
+PY
+}
+
+# ─────────────────────────────────────────────────────────────────────────
+# nz organ list|show|kickstart|halt|recover
+# ─────────────────────────────────────────────────────────────────────────
+
+cmd_organ() {
+    local sub="${1:-}"
+    shift || true
+
+    case "$sub" in
+        list|ls)
+            _organs_table | awk -F'\t' '{
+                printf "  %-40s %-15s %-10s %-25s %s\n", $1, $2, $3, $4, $6
+            }'
+            ;;
+        show)
+            local id="${1:?usage: nz organ show <id>}"
+            local row
+            row=$(_organ_resolve "$id")
+            [ -n "$row" ] || die "organ '$id' not in registry"
+            echo "$row" | awk -F'\t' '{
+                printf "id:               %s\nruntime:          %s\ntype:             %s\nrecovery_action:  %s\nrecovery_label:   %s\nseverity:         %s\n", $1, $2, $3, $4, $5, $6
+            }'
+            echo
+            note "live aggregate:"
+            _aggregate_organ "$id" 2>/dev/null || note "  (not in aggregate.json — sentinel-aggregate may not have classified yet)"
+            ;;
+        kickstart|kick)
+            local id="${1:?usage: nz organ kickstart <id>}"
+            local row
+            row=$(_organ_resolve "$id")
+            [ -n "$row" ] || die "organ '$id' not in registry"
+            local runtime label action
+            runtime=$(echo "$row" | awk -F'\t' '{print $2}')
+            label=$(echo "$row" | awk -F'\t' '{print $5}')
+            action=$(echo "$row" | awk -F'\t' '{print $4}')
+            case "$runtime" in
+                pro_launchd)
+                    [ -n "$label" ] || die "no recovery_params.label for $id"
+                    echo "${C_BLUE}kickstart${C_RESET} $label (Pro)"
+                    launchctl kickstart "gui/$(id -u)/$label"
+                    ;;
+                mini_launchd)
+                    [ -n "$label" ] || die "no recovery_params.label for $id"
+                    echo "${C_BLUE}kickstart${C_RESET} $label (Mini)"
+                    ssh -o ConnectTimeout=5 mini-remote "launchctl kickstart 'gui/\$(id -u)/$label'" \
+                        || ssh -o ConnectTimeout=5 mini "launchctl kickstart 'gui/\$(id -u)/$label'" \
+                        || die "Mini unreachable"
+                    ;;
+                fly_machine)
+                    [ -n "$label" ] || die "no recovery_params.app for $id"
+                    [ "$action" = "fly_machines_start" ] || die "unsupported action $action for $id"
+                    echo "${C_BLUE}fly machines start${C_RESET} -a $label"
+                    fly machines start -a "$label"
+                    ;;
+                *)
+                    die "unsupported runtime $runtime for $id"
+                    ;;
+            esac
+            ;;
+        halt|stop)
+            local id="${1:?usage: nz organ halt <id>}"
+            local row
+            row=$(_organ_resolve "$id")
+            [ -n "$row" ] || die "organ '$id' not in registry"
+            local runtime label
+            runtime=$(echo "$row" | awk -F'\t' '{print $2}')
+            label=$(echo "$row" | awk -F'\t' '{print $5}')
+            case "$runtime" in
+                pro_launchd)
+                    [ -n "$label" ] || die "no label for $id"
+                    echo "${C_YELLOW}bootout${C_RESET} $label (Pro)"
+                    launchctl bootout "gui/$(id -u)/$label" && echo "ok"
+                    ;;
+                mini_launchd)
+                    [ -n "$label" ] || die "no label for $id"
+                    echo "${C_YELLOW}bootout${C_RESET} $label (Mini)"
+                    ssh -o ConnectTimeout=5 mini-remote "launchctl bootout 'gui/\$(id -u)/$label'" && echo ok
+                    ;;
+                fly_machine)
+                    echo "${C_YELLOW}fly machines stop${C_RESET} -a $label"
+                    fly machines stop -a "$label"
+                    ;;
+                *)
+                    die "unsupported runtime $runtime for $id"
+                    ;;
+            esac
+            ;;
+        recover)
+            # Bulk: kickstart every organ currently in 'dead' state.
+            [ -f "$AGGREGATE" ] || die "aggregate.json missing"
+            "$DEFAULT_PYTHON" - "$AGGREGATE" <<'PY' | while read -r id; do
+import json, sys
+d = json.load(open(sys.argv[1]))
+for o in d.get("organs", []):
+    if o.get("status") == "dead":
+        print(o.get("id", ""))
+PY
+                [ -n "$id" ] && cmd_organ kickstart "$id" || true
+            done
+            ;;
+        ""|help|-h|--help)
+            cat <<EOF
+usage: nz organ <sub> [args]
+
+  list              list all organs in registry
+  show <id>         show organ + live aggregate row
+  kickstart <id>    launchctl kickstart / fly machines start / mini ssh
+  halt <id>         launchctl bootout / fly machines stop
+  recover           kickstart every organ currently 'dead' in aggregate
+EOF
+            ;;
+        *)
+            die "unknown organ subcommand: $sub (try \`nz organ help\`)"
+            ;;
+    esac
+}
+
+# ─────────────────────────────────────────────────────────────────────────
+# nz bus channels|tail|replay|count
+# ─────────────────────────────────────────────────────────────────────────
+
+cmd_bus() {
+    local sub="${1:-}"
+    shift || true
+
+    # Source secrets for DATABASE_URL etc.
+    if [ -f "$HOME/.nuzantara-secrets.env" ]; then
+        set -a
+        # shellcheck disable=SC1091
+        . "$HOME/.nuzantara-secrets.env"
+        set +a
+    fi
+    local db_url="${DATABASE_URL_LOCAL:-${DATABASE_URL:-postgresql://postgres@127.0.0.1:15432/nuzantara_rag}}"
+
+    case "$sub" in
+        channels|ls)
+            "$DEFAULT_PYTHON" - <<'PY'
+from importlib import import_module
+import sys
+sys.path.insert(0, "/Users/nuzantara/Desktop/nuzantara/apps/backend-rag")
+try:
+    mod = import_module("backend.services.events.event_bus")
+    chans = getattr(mod, "PG_CHANNEL_MAP", {})
+    print(f"PG_CHANNEL_MAP ({len(chans)} channels):")
+    for k, v in chans.items():
+        print(f"  {k:35s} -> {v}")
+except Exception as e:
+    print(f"unable to import PG_CHANNEL_MAP: {e}", file=sys.stderr)
+    sys.exit(1)
+PY
+            ;;
+        tail)
+            local channel="${1:?usage: nz bus tail <channel>}"
+            command -v psql >/dev/null || die "psql not found in PATH"
+            note "psql LISTEN $channel  (Ctrl-C to stop)"
+            db_url="${DATABASE_URL_LOCAL:-${DATABASE_URL:-postgresql://postgres@127.0.0.1:15432/nuzantara_rag}}"
+            psql "$db_url" -c "LISTEN $channel" -c "SELECT pg_sleep(86400)"
+            ;;
+        count)
+            local channel="${1:-}"
+            command -v psql >/dev/null || die "psql not found"
+            db_url="${DATABASE_URL_LOCAL:-${DATABASE_URL:-postgresql://postgres@127.0.0.1:15432/nuzantara_rag}}"
+            if [ -n "$channel" ]; then
+                psql "$db_url" -c "SELECT channel, COUNT(*) FILTER (WHERE consumed_at IS NULL) AS unconsumed, COUNT(*) AS total FROM events_outbox WHERE channel='$channel' GROUP BY channel"
+            else
+                psql "$db_url" -c "SELECT channel, COUNT(*) FILTER (WHERE consumed_at IS NULL) AS unconsumed, COUNT(*) AS total FROM events_outbox GROUP BY channel ORDER BY channel"
+            fi
+            ;;
+        replay)
+            local channel="${1:?usage: nz bus replay <channel>}"
+            cd "$REPO_ROOT/apps/backend-rag" || die "backend-rag dir missing"
+            PYTHONPATH=. .venv/bin/python -c "
+import asyncio, asyncpg, os, sys
+from backend.services.events.outbox import replay_unconsumed
+async def main():
+    dsn = os.environ.get('DATABASE_URL','postgresql://postgres@127.0.0.1:15432/nuzantara_rag')
+    conn = await asyncpg.connect(dsn)
+    try:
+        async def noop(payload): pass
+        n = await replay_unconsumed(conn, noop, channel='$channel')
+        print(f'replayed {n} events on $channel')
+    finally:
+        await conn.close()
+asyncio.run(main())
+"
+            ;;
+        prune)
+            [ -x "$OUTBOX_PRUNE_SH" ] || die "outbox-prune.sh not executable: $OUTBOX_PRUNE_SH"
+            "$OUTBOX_PRUNE_SH"
+            ;;
+        ""|help|-h|--help)
+            cat <<EOF
+usage: nz bus <sub> [args]
+
+  channels             list PG_CHANNEL_MAP entries
+  tail <channel>       psql LISTEN on channel (Ctrl-C to stop)
+  count [channel]      events_outbox row counts (unconsumed/total)
+  replay <channel>     replay unconsumed rows for channel
+  prune                run outbox-prune.sh (deletes consumed >30d)
+EOF
+            ;;
+        *)
+            die "unknown bus subcommand: $sub (try \`nz bus help\`)"
+            ;;
+    esac
+}
+
+# ─────────────────────────────────────────────────────────────────────────
+# nz sentinel run|tail
+# ─────────────────────────────────────────────────────────────────────────
+
+cmd_sentinel() {
+    local sub="${1:-run}"
+    shift || true
+    case "$sub" in
+        run)
+            "$DEFAULT_PYTHON" "$SENTINEL_AGG_PY"
+            ;;
+        tail)
+            tail -f "$HOME/logs/sentinel-aggregate.log"
+            ;;
+        ""|help|-h|--help)
+            cat <<EOF
+usage: nz sentinel <sub>
+
+  run    execute sentinel-aggregate now (writes ~/.organism/aggregate.json)
+  tail   tail the sentinel-aggregate log
+EOF
+            ;;
+        *)
+            die "unknown sentinel subcommand: $sub"
+            ;;
+    esac
+}
+
+# ─────────────────────────────────────────────────────────────────────────
+# nz wr2 generate|supervisor|queue|fact
+# ─────────────────────────────────────────────────────────────────────────
+
+cmd_wr2() {
+    local sub="${1:-}"
+    shift || true
+    case "$sub" in
+        generate|gen)
+            local topic="${1:-}"
+            [ -n "$topic" ] || die "usage: nz wr2 generate <topic>"
+            local script="$REPO_ROOT/scripts/wr2_draft_generator.py"
+            [ -f "$script" ] || die "wr2_draft_generator.py missing"
+            cd "$REPO_ROOT/apps/backend-rag" && PYTHONPATH=. .venv/bin/python "$script" --topic "$topic"
+            ;;
+        supervisor)
+            local action="${1:-status}"
+            case "$action" in
+                status)
+                    launchctl print "gui/$(id -u)/com.balizero.wr2.supervisor" 2>&1 | grep -E "state =|last exit" | head -3
+                    cat "$HOME/.organism/last_seen/wr2.supervisor.json" 2>/dev/null | head -1
+                    ;;
+                restart)
+                    launchctl kickstart -k "gui/$(id -u)/com.balizero.wr2.supervisor"
+                    echo "wr2.supervisor restarted"
+                    ;;
+                log)
+                    tail -50 "$HOME/logs/wr2_supervisor.log"
+                    ;;
+                *)
+                    die "usage: nz wr2 supervisor {status|restart|log}"
+                    ;;
+            esac
+            ;;
+        queue)
+            local pending=("$REPO_ROOT/apps/war-room/output/canva/canva_pending.json")
+            for f in "${pending[@]}"; do
+                [ -f "$f" ] && echo "=== $f ===" && cat "$f"
+            done
+            ;;
+        ""|help|-h|--help)
+            cat <<EOF
+usage: nz wr2 <sub> [args]
+
+  generate <topic>            run wr2_draft_generator on a topic
+  supervisor {status|restart|log}
+  queue                       show canva_pending.json
+EOF
+            ;;
+        *)
+            die "unknown wr2 subcommand: $sub"
+            ;;
+    esac
+}
+
+# ─────────────────────────────────────────────────────────────────────────
+# nz cell status|log|kickstart
+# ─────────────────────────────────────────────────────────────────────────
+
+cmd_cell() {
+    local sub="${1:-status}"
+    shift || true
+    case "$sub" in
+        status)
+            cat "$HOME/.organism/last_seen/cell.organism.json" 2>/dev/null && echo
+            launchctl print "gui/$(id -u)/com.cell.organism" 2>&1 | grep -E "state =|last exit" | head -3
+            ;;
+        log)
+            tail -50 "$HOME/Library/Logs/cell-organism.log"
+            ;;
+        kickstart|restart)
+            launchctl kickstart -k "gui/$(id -u)/com.cell.organism"
+            echo "cell.organism restarted"
+            ;;
+        ""|help|-h|--help)
+            cat <<EOF
+usage: nz cell <sub>
+
+  status        latest pulse + launchctl state
+  log           tail cell-organism.log
+  kickstart     restart cell.organism daemon
+EOF
+            ;;
+        *)
+            die "unknown cell subcommand: $sub"
+            ;;
+    esac
+}
+
+# ─────────────────────────────────────────────────────────────────────────
+# nz fad list|approve|status
+# ─────────────────────────────────────────────────────────────────────────
+
+cmd_fad() {
+    local sub="${1:-status}"
+    shift || true
+
+    if [ -f "$HOME/.nuzantara-secrets.env" ]; then
+        set -a
+        # shellcheck disable=SC1091
+        . "$HOME/.nuzantara-secrets.env"
+        set +a
+    fi
+    local db_url="${DATABASE_URL_LOCAL:-${DATABASE_URL:-postgresql://postgres@127.0.0.1:15432/nuzantara_rag}}"
+
+    case "$sub" in
+        status)
+            launchctl print "gui/$(id -u)/com.nuzantara.federation-alert-dispatcher" 2>&1 | grep -E "state =|last exit" | head -3
+            ;;
+        list)
+            # Schema-tolerant: select common columns; lists pending only.
+            psql "$db_url" <<'SQL'
+SELECT proposal_id,
+       severity,
+       status,
+       created_at
+  FROM federation_alert_proposals
+ WHERE status IN ('pending','proposed','awaiting_review')
+ ORDER BY created_at DESC
+ LIMIT 20;
+SQL
+            ;;
+        approve)
+            local pid="${1:?usage: nz fad approve <proposal_id>}"
+            psql "$db_url" -v pid="$pid" <<'SQL'
+UPDATE federation_alert_proposals
+   SET status = 'approved'
+ WHERE proposal_id = :'pid'
+RETURNING proposal_id, status;
+SQL
+            ;;
+        log)
+            tail -50 "$HOME/logs/alert-dispatcher/launchd.err.log"
+            ;;
+        ""|help|-h|--help)
+            cat <<EOF
+usage: nz fad <sub>
+
+  status                  launchd state of FAD daemon
+  list                    pending proposals from federation_alert_proposals
+  approve <proposal_id>   mark proposal approved
+  log                     tail FAD log
+EOF
+            ;;
+        *)
+            die "unknown fad subcommand: $sub"
+            ;;
+    esac
+}
+
+# ─────────────────────────────────────────────────────────────────────────
+# nz translate
+# ─────────────────────────────────────────────────────────────────────────
+
+cmd_translate() {
+    "$DEFAULT_PYTHON" "$REPO_ROOT/scripts/translate-articles.py" "$@"
+}
+
+# ─────────────────────────────────────────────────────────────────────────
+# nz health
+# ─────────────────────────────────────────────────────────────────────────
+
+cmd_health() {
+    echo "Backend health (Fly):"
+    curl -fsS https://nuzantara-rag.fly.dev/health 2>&1 | head -30 || echo "  unreachable"
+    echo
+    echo "Local services:"
+    nc -z 127.0.0.1 15432 2>/dev/null && echo "  pg-proxy   :15432  UP" || echo "  pg-proxy   :15432  DOWN"
+    nc -z 127.0.0.1 6379 2>/dev/null && echo "  redis      :6379   UP" || echo "  redis      :6379   DOWN"
+    nc -z 127.0.0.1 11434 2>/dev/null && echo "  ollama     :11434  UP" || echo "  ollama     :11434  DOWN"
+}
+
+# ─────────────────────────────────────────────────────────────────────────
+# Top-level dispatch
+# ─────────────────────────────────────────────────────────────────────────
+
+usage() {
+    cat <<EOF
+nz — Nuzantara unified CLI
+
+usage: nz <command> [args]
+
+commands:
+  status [organ_id]            full aggregate or single-organ status
+  organ <list|show|kickstart|halt|recover>
+  bus <channels|tail|count|replay|prune>
+  sentinel <run|tail>
+  wr2 <generate|supervisor|queue>
+  cell <status|log|kickstart>
+  fad <status|list|approve|log>
+  translate [args...]          run translate-articles.py
+  health                       backend + local services snapshot
+  help                         this screen
+
+env:
+  NZ_REPO_ROOT     repo location (default: \$HOME/Desktop/nuzantara)
+  NZ_PYTHON        python interpreter (default: pyenv 3.11.11)
+
+Each subcommand accepts \`help\` for its own usage.
+EOF
+}
+
+main() {
+    local cmd="${1:-help}"
+    shift || true
+    case "$cmd" in
+        status)     cmd_status "$@" ;;
+        organ)      cmd_organ "$@" ;;
+        bus)        cmd_bus "$@" ;;
+        sentinel)   cmd_sentinel "$@" ;;
+        wr2)        cmd_wr2 "$@" ;;
+        cell)       cmd_cell "$@" ;;
+        fad)        cmd_fad "$@" ;;
+        translate)  cmd_translate "$@" ;;
+        health)     cmd_health "$@" ;;
+        help|-h|--help|"") usage ;;
+        *)          die "unknown command: $cmd (try \`nz help\`)" ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

\`nz\` — single CLI entry point for the 117-organ Nuzantara system. Replaces \"remember which of 194 scripts in scripts/\" with a registry-aware router that resolves organ id → launchctl label / fly app / mini ssh.

## Install

\`\`\`bash
ln -sf ~/Desktop/nuzantara/scripts/cli/nz ~/.local/bin/nz
\`\`\`

(already done on Pro for live verification)

## Commands

| Command | Purpose |
|---|---|
| \`nz status [organ_id]\` | full aggregate or single organ row |
| \`nz organ list/show/kickstart/halt/recover\` | registry-driven launchctl/fly/ssh routing |
| \`nz bus channels/tail/count/replay/prune\` | events_outbox + LISTEN/NOTIFY ops |
| \`nz sentinel run/tail\` | trigger or follow sentinel-aggregate |
| \`nz wr2 generate/supervisor/queue\` | WR2 carousel pipeline |
| \`nz cell status/log/kickstart\` | Cell organism daemon |
| \`nz fad status/list/approve/log\` | Federation Alert Dispatcher |
| \`nz translate [args]\` | translate-articles.py |
| \`nz health\` | backend Fly + local pg-proxy/redis/ollama snapshot |

## Live verification (post-install on Pro)

- \`nz status\` → 88.0% ok / 117 organs, 0 dead, 0 noheartbeat
- \`nz organ list\` → 117 organs enumerated from registry
- \`nz organ show wr2.supervisor\` → registry row + aggregate row joined
- \`nz bus channels\` → 13 PG_CHANNEL_MAP entries
- \`nz bus count\` → 9 channels with events (cell_pulse_observed: 8082 total / 80 unconsumed)
- \`nz fad list\` → 0 pending proposals
- \`nz health\` → all local services UP

## Closes / does NOT close

✅ Layer 2 of \"totale interattività\" audit: human ↔ system via single CLI.

⏳ Layer 1 (bus end-to-end): 2 stack paralleli (PG bus / Redis stream) still not bridged.

⏳ Layer 3 (self-action / autonomy): sentinel-aggregate emits no recovery event yet; supervisor missing \`fly_machines_start\` actuator.

## Test plan

- [x] bash -n syntax OK
- [x] live smoke tests (status, organ list, organ show, bus channels, bus count, fad list, sentinel run, cell status, health)
- [x] symlink \`~/.local/bin/nz\` → repo path verified
- [x] pre-commit hooks pass
- [ ] CI checks (only Frontend mouth npm-audit expected to fail, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)