### PR TITLE
feat(symbiosis): wave-5 close Layer 1 + Layer 3 (totale interattività)

### DIFF
--- a/apps/cell/cell/main.py
+++ b/apps/cell/cell/main.py
@@ -54,6 +54,74 @@ logger = logging.getLogger("cell")
 _shutdown = asyncio.Event()
 
 
+def _emit_cell_pulse_event(
+    *,
+    pulse_count: int,
+    health: str,
+    organ_status: str,
+    tier: int | None,
+    action: str | None,
+) -> None:
+    """Best-effort emit a cell_pulse Event onto the organism Redis stream.
+
+    Mirrors organism.redis_bus.EventBus.emit semantics: JSONL first, Redis
+    XADD second. We don't import organism.redis_bus directly because it
+    pulls Pydantic + redis.asyncio which are not always available inside
+    the Cell venv; instead we write JSONL + shell out to redis-cli.
+    Closes Layer 3 of "totale interattività" wave-5.
+    """
+    import json as _json
+    import os as _os
+    import subprocess as _sp
+    from datetime import datetime as _dt
+    from datetime import timezone as _tz
+    from pathlib import Path as _P
+
+    # Severity mapping: red→error, yellow→warning, green→info, anything→info.
+    sev_map = {"red": "error", "yellow": "warning", "green": "info"}
+    severity = sev_map.get(health, "info")
+
+    ts = _dt.now(_tz.utc).isoformat(timespec="seconds")
+    event = {
+        "ts": ts,
+        "severity": severity,
+        "source": "cell.organism",
+        "kind": "cell_pulse",
+        "payload": {
+            "pulse_count": pulse_count,
+            "health": health,
+            "organ_status": organ_status,
+            "tier": tier,
+            "action": action,
+        },
+        "correlation_id": f"cell-pulse-{pulse_count}-{ts}",
+        "is_actuation": False,
+        "host": "Pro",
+    }
+
+    # JSONL first (durable).
+    try:
+        events_path = _P.home() / ".organism" / "events" / "cell.jsonl"
+        events_path.parent.mkdir(parents=True, exist_ok=True)
+        line = _json.dumps(event, separators=(",", ":"), default=str)
+        with events_path.open("a", encoding="utf-8") as f:
+            f.write(line + "\n")
+    except Exception:
+        return  # never propagate
+
+    # Redis XADD second (best-effort).
+    try:
+        _sp.run(
+            [
+                "redis-cli", "XADD", "organism:events", "*",
+                "data", _json.dumps(event, separators=(",", ":"), default=str),
+            ],
+            capture_output=True, timeout=2, check=False,
+        )
+    except Exception:
+        pass
+
+
 def _handle_signal(sig: int, frame: object) -> None:
     logger.info(f"Received signal {sig}, shutting down...")
     _shutdown.set()
@@ -314,6 +382,19 @@ async def main() -> None:
                         "tier": result.thought_tier,
                         "action": result.action_taken,
                     },
+                )
+
+                # Wave-5: emit Event onto organism:events Redis stream so the
+                # Supervisor sees Cell pulses (not just the PG bus pulse).
+                # Closes Layer 3 of "totale interattività" — Cell was isolated
+                # from the Supervisor's actuator pipeline before this. Best-
+                # effort: stream emit failure must not crash the pulse loop.
+                _emit_cell_pulse_event(
+                    pulse_count=pulse_count,
+                    health=status_str,
+                    organ_status=_organ_status,
+                    tier=result.thought_tier,
+                    action=result.action_taken,
                 )
 
                 # Episodic forgetting — every 1000 pulses (~17h at 60s intervals)

--- a/apps/organism/organism/actuators/__init__.py
+++ b/apps/organism/organism/actuators/__init__.py
@@ -52,4 +52,5 @@ def build_actuator_registry(*, redis) -> dict[str, ActuatorBase]:
         CleanupBranches.name: CleanupBranches(),
         CleanupZombiePlist.name: CleanupZombiePlist(),
         ProposeYamlRule.name: ProposeYamlRule(),
+        FlyMachinesStart.name: FlyMachinesStart(),
     }

--- a/apps/organism/organism/actuators/fly_machines_start.py
+++ b/apps/organism/organism/actuators/fly_machines_start.py
@@ -1,0 +1,76 @@
+"""Actuator: start a Fly.io machine via `fly machines start`.
+
+Used to recover the 7 organs in organs_registry.yaml whose
+recovery_action == "fly_machines_start" (infra.postgres, infra.qdrant,
+backend.api, channel.whatsapp, channel.telegram, channel.instagram,
+channel.web). Wave-5 closes the dead-letter on these — before this
+actuator existed, the Supervisor received the heartbeat_silent event
+and could not act on it.
+
+Params:
+  app:      Fly app name (mandatory; e.g. "nuzantara-rag")
+  machine:  optional machine id (when omitted, fly auto-routes to all
+            stopped machines in the app — same as `fly machines start -a APP`
+            without --machine)
+
+Behaviour:
+  Shells out to `fly machines start -a <app> [<machine>]` with a 60s
+  timeout. The Fly API returns ~immediately once the start request is
+  accepted; actual cold-start takes seconds-to-minutes. We do NOT wait
+  for the machine to be `started` here — the next sentinel cycle will
+  pick it up via heartbeat freshness. Soft-failure on non-zero exit
+  (returncode + stdout + stderr surfaced) so the caller decides.
+"""
+import asyncio
+import os
+
+from organism.actuators.base import ActuatorBase
+
+
+class FlyMachinesStart(ActuatorBase):
+    name = "fly_machines_start"
+
+    def _build_argv(self, params: dict) -> list[str]:
+        app = params["app"]
+        argv = ["fly", "machines", "start", "-a", app]
+        machine = params.get("machine") or params.get("machine_id")
+        if machine:
+            argv.append(str(machine))
+        return argv
+
+    async def _execute(self, params: dict) -> dict:
+        if "app" not in params:
+            raise ValueError("fly_machines_start requires 'app' in params")
+        argv = self._build_argv(params)
+        # Inherit FLY_API_TOKEN / FLY_ACCESS_TOKEN from environment so the
+        # supervisor process must already have them sourced (it does — see
+        # com.nuzantara.organism.supervisor plist EnvironmentVariables).
+        env = os.environ.copy()
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        try:
+            out, err = await asyncio.wait_for(proc.communicate(), timeout=60.0)
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+                await proc.wait()
+            except ProcessLookupError:
+                pass
+            raise RuntimeError(
+                f"fly machines start timed out after 60s (argv={argv})"
+            )
+        return {
+            "argv": argv,
+            "returncode": proc.returncode,
+            "stdout": out.decode("utf-8", errors="replace")[:1000],
+            "stderr": err.decode("utf-8", errors="replace")[:1000],
+        }
+
+    async def _dry_run(self, params: dict) -> dict:
+        if "app" not in params:
+            return {"would_start": "<missing app param>"}
+        return {"would_run": self._build_argv(params)}

--- a/apps/organism/organism/organs_registry.yaml
+++ b/apps/organism/organism/organs_registry.yaml
@@ -53,7 +53,7 @@
 
 version: 1
 checksum_algo: sha256
-checksum: ccb3ce14ead30fa6680b6b72cf2752e02f370be0eea7a9176f5e0d0031d8aa59
+checksum: 3bf9146ac12938499ca0a0f89f6c0dc3b83fbecea6c5b6192524daa050a31e71
 organs:
   - id: infra.postgres
     runtime: fly_machine
@@ -1687,6 +1687,29 @@ organs:
       label: com.balizero.regulatory-watcher.daily
     severity_on_silence: warning
     cicatrix_refs: []
+
+  # PG → organism Redis stream bridge (2026-05-09 wave-5).
+  # Closes Layer 1 of "totale interattività" audit: bridges the 13 PG
+  # LISTEN/NOTIFY channels to organism:events stream consumed by Supervisor.
+  - id: pro.pg_organism_bridge
+    runtime: pro_launchd
+    type: daemon
+    expected_hb_seconds: 120
+    owner_module: scripts/pg-to-organism-bridge.py
+    dependencies:
+      - infra.postgres
+      - infra.redis
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      host: pro
+      label: com.nuzantara.pg-organism-bridge
+    severity_on_silence: warning
+    cicatrix_refs: []
+    bridge_source:
+      type: state_file
+      path: ~/.organism/last_seen/pro.pg_organism_bridge.json
+      timestamp_field: ts
+      status_field: status
 
   # Sentinel aggregator (2026-05-09) — single pane of glass for all organs.
   # Reads ~/.organism/last_seen/*.json + launchctl list, classifies each

--- a/infra/launchagents/com.nuzantara.pg-organism-bridge.plist
+++ b/infra/launchagents/com.nuzantara.pg-organism-bridge.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.nuzantara.pg-organism-bridge</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>/Users/nuzantara</string>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/Users/nuzantara/.pyenv/versions/3.11.11/bin</string>
+	</dict>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>-lc</string>
+		<string>set -a; [ -f "$HOME/.nuzantara-secrets.env" ] &amp;&amp; source "$HOME/.nuzantara-secrets.env"; set +a; cd /Users/nuzantara/Desktop/nuzantara/apps/backend-rag &amp;&amp; PYTHONPATH=. /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python /Users/nuzantara/Desktop/nuzantara/scripts/pg-to-organism-bridge.py</string>
+	</array>
+	<key>KeepAlive</key>
+	<true/>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StandardOutPath</key>
+	<string>/Users/nuzantara/logs/pg-organism-bridge.log</string>
+	<key>StandardErrorPath</key>
+	<string>/Users/nuzantara/logs/pg-organism-bridge.error.log</string>
+</dict>
+</plist>

--- a/scripts/cli/nz
+++ b/scripts/cli/nz
@@ -564,6 +564,151 @@ EOF
 }
 
 # ─────────────────────────────────────────────────────────────────────────
+# nz events tail|recent|count|sources
+# ─────────────────────────────────────────────────────────────────────────
+
+cmd_events() {
+    local sub="${1:-recent}"
+    shift || true
+    local events_dir="$HOME/.organism/events"
+
+    case "$sub" in
+        tail)
+            local source="${1:-all}"
+            if [ "$source" = "all" ]; then
+                tail -F "$events_dir"/*.jsonl 2>/dev/null
+            else
+                local f="$events_dir/${source}.jsonl"
+                [ -f "$f" ] || die "no events file: $f"
+                tail -F "$f"
+            fi
+            ;;
+        recent)
+            local limit="${1:-20}"
+            for f in "$events_dir"/*.jsonl; do
+                [ -f "$f" ] || continue
+                tail -n "$limit" "$f" 2>/dev/null
+            done | "$DEFAULT_PYTHON" -c "
+import json, sys
+lines = sorted(sys.stdin.readlines(), key=lambda l: json.loads(l).get('ts',''), reverse=True)[:int('$limit')]
+for line in lines:
+    e = json.loads(line)
+    print(f\"{e['ts'][:19]:20s} [{e['severity']:8s}] {e['source']:30s} {e['kind']:30s} {json.dumps(e.get('payload',{}))[:80]}\")
+"
+            ;;
+        count)
+            for f in "$events_dir"/*.jsonl; do
+                [ -f "$f" ] || continue
+                local n
+                n=$(wc -l < "$f")
+                printf "  %-30s %s\n" "$(basename "$f")" "$n"
+            done
+            echo "  ---"
+            local stream_len
+            stream_len=$(redis-cli XLEN organism:events 2>/dev/null || echo "?")
+            echo "  redis stream organism:events: $stream_len entries"
+            ;;
+        sources)
+            for f in "$events_dir"/*.jsonl; do
+                [ -f "$f" ] || continue
+                "$DEFAULT_PYTHON" -c "
+import json
+sources = set()
+for line in open('$f'):
+    try:
+        sources.add(json.loads(line).get('source','?'))
+    except Exception: pass
+print(f\"$(basename "$f"):\", ', '.join(sorted(sources)))
+"
+            done
+            ;;
+        ""|help|-h|--help)
+            cat <<EOF
+usage: nz events <sub> [args]
+
+  recent [N]            print N most recent events across all jsonl files
+  tail [source|all]     follow ~/.organism/events/<source>.jsonl
+  count                 line counts per JSONL + redis stream length
+  sources               distinct event sources per JSONL
+EOF
+            ;;
+        *)
+            die "unknown events subcommand: $sub"
+            ;;
+    esac
+}
+
+# ─────────────────────────────────────────────────────────────────────────
+# nz actuator list|dry-run
+# ─────────────────────────────────────────────────────────────────────────
+
+cmd_actuator() {
+    local sub="${1:-list}"
+    shift || true
+    case "$sub" in
+        list)
+            cd "$REPO_ROOT/apps/organism" 2>/dev/null && \
+                "$DEFAULT_PYTHON" -c "
+import os
+acts = sorted(
+    f.replace('.py','')
+    for f in os.listdir('organism/actuators')
+    if f.endswith('.py') and not f.startswith('_') and f not in ('base.py',)
+)
+for a in acts:
+    print(f'  {a}')
+"
+            ;;
+        dry-run)
+            local actuator="${1:?usage: nz actuator dry-run <name> [key=value ...]}"
+            shift
+            local params_json="{}"
+            if [ $# -gt 0 ]; then
+                params_json=$("$DEFAULT_PYTHON" -c "
+import json, sys
+params = {}
+for arg in sys.argv[1:]:
+    if '=' in arg:
+        k, v = arg.split('=', 1)
+        params[k] = v
+print(json.dumps(params))
+" "$@")
+            fi
+            cd "$REPO_ROOT/apps/organism" || die "organism dir missing"
+            "$DEFAULT_PYTHON" -c "
+import asyncio, importlib, json, sys
+sys.path.insert(0, '.')
+mod = importlib.import_module('organism.actuators.$actuator')
+# Find the class (CamelCase of snake_case actuator name)
+cls_name = ''.join(p.capitalize() for p in '$actuator'.split('_'))
+# Special-case: 'fly_machines_start' -> 'FlyMachinesStart' which it does correctly.
+cls = getattr(mod, cls_name, None)
+if cls is None:
+    print(f'class {cls_name} not in module organism.actuators.$actuator', file=sys.stderr)
+    sys.exit(1)
+inst = cls()
+async def go():
+    return await inst._dry_run(json.loads('$params_json'))
+print(json.dumps(asyncio.run(go()), indent=2, default=str))
+"
+            ;;
+        ""|help|-h|--help)
+            cat <<EOF
+usage: nz actuator <sub> [args]
+
+  list                          list registered actuators
+  dry-run <name> [key=value ...]
+                                run actuator._dry_run with params
+                                example: nz actuator dry-run fly_machines_start app=nuzantara-rag
+EOF
+            ;;
+        *)
+            die "unknown actuator subcommand: $sub"
+            ;;
+    esac
+}
+
+# ─────────────────────────────────────────────────────────────────────────
 # nz translate
 # ─────────────────────────────────────────────────────────────────────────
 
@@ -599,6 +744,8 @@ commands:
   status [organ_id]            full aggregate or single-organ status
   organ <list|show|kickstart|halt|recover>
   bus <channels|tail|count|replay|prune>
+  events <recent|tail|count|sources>
+  actuator <list|dry-run>
   sentinel <run|tail>
   wr2 <generate|supervisor|queue>
   cell <status|log|kickstart>
@@ -622,6 +769,8 @@ main() {
         status)     cmd_status "$@" ;;
         organ)      cmd_organ "$@" ;;
         bus)        cmd_bus "$@" ;;
+        events)     cmd_events "$@" ;;
+        actuator)   cmd_actuator "$@" ;;
         sentinel)   cmd_sentinel "$@" ;;
         wr2)        cmd_wr2 "$@" ;;
         cell)       cmd_cell "$@" ;;

--- a/scripts/pg-to-organism-bridge.py
+++ b/scripts/pg-to-organism-bridge.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""pg-to-organism-bridge.py — bridge PG LISTEN/NOTIFY → organism Redis stream.
+
+Subscribes to all 13 PG_CHANNEL_MAP channels via asyncpg LISTEN. For every
+notification received, builds an organism Event and emits it onto:
+  1. Redis stream `organism:events` (best-effort)
+  2. ~/.organism/events/pg-bridge.jsonl (durable mirror)
+
+This closes Layer 1 of the "totale interattività" audit: until this
+bridge existed, the backend PG bus and the Pro-side Supervisor stream
+were two universes — events on `compliance_alert` / `intel_event` /
+`war_room_event` etc. never reached the Supervisor's actuator pipeline.
+
+Schedule: continuous daemon under launchd
+  ~/Library/LaunchAgents/com.nuzantara.pg-organism-bridge.plist
+  KeepAlive=true, RunAtLoad=true.
+
+Connection: uses local pg-proxy at 127.0.0.1:15432 (DATABASE_URL_LOCAL).
+Reconnects on disconnect with exponential backoff (cap 60s).
+Heartbeat written each 60s tick to ~/.organism/last_seen/pro.pg_organism_bridge.json.
+
+Severity mapping per channel (organism schema requires Severity enum):
+  compliance_alert, federation_alert, war_room_event → warning (or payload.severity)
+  intel_event, cognitive_event, cell_pulse_observed → info
+  practice_changed, client_changed, partner_commission_changed → info
+  measurer_event, asset_provenance, crm_welcome_completed → info
+  lkpm_ingest_completed, wr2_status_change → info
+
+Each emitted Event:
+  source = "pg_bus.<channel>"
+  kind = channel name
+  payload = parsed JSON of NOTIFY payload (truncated to 2KB per schema)
+
+Exit codes:
+  0  graceful shutdown via SIGTERM
+  1  fatal config (missing DATABASE_URL etc.)
+  2  fatal asyncpg error not recoverable
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import signal
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import asyncpg
+
+logger = logging.getLogger("pg-organism-bridge")
+
+# ─────────────────────────────────────────────────────────────────────────
+# Config
+# ─────────────────────────────────────────────────────────────────────────
+
+CHANNELS = [
+    "practice_changed",
+    "client_changed",
+    "compliance_alert",
+    "lkpm_ingest_completed",
+    "war_room_event",
+    "intel_event",
+    "cognitive_event",
+    "partner_commission_changed",
+    "federation_alert",
+    "cell_pulse_observed",
+    "measurer_event",
+    "crm_welcome_completed",
+    "asset_provenance",
+    "wr2_status_change",
+]
+
+WARNING_CHANNELS = {"compliance_alert", "federation_alert"}
+
+EVENTS_JSONL = Path.home() / ".organism" / "events" / "pg-bridge.jsonl"
+HEARTBEAT_PATH = Path.home() / ".organism" / "last_seen" / "pro.pg_organism_bridge.json"
+ORGANISM_STREAM_KEY = "organism:events"
+
+_RECONNECT_DELAY_S = 1.0
+_RECONNECT_DELAY_CAP = 60.0
+_HEARTBEAT_INTERVAL_S = 60
+
+_shutdown = asyncio.Event()
+
+
+def _load_secrets() -> None:
+    secrets_path = os.path.expanduser("~/.nuzantara-secrets.env")
+    if not os.path.isfile(secrets_path):
+        return
+    try:
+        with open(secrets_path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                k, v = line.split("=", 1)
+                os.environ.setdefault(k, v.strip().strip('"').strip("'"))
+    except Exception as exc:
+        logger.warning("could not source secrets: %s", exc)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Heartbeat
+# ─────────────────────────────────────────────────────────────────────────
+
+def _write_heartbeat(status: str = "ok", note: str = "") -> None:
+    try:
+        HEARTBEAT_PATH.parent.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        payload = {"ts": ts, "status": status, "note": str(note)[:500]}
+        tmp = HEARTBEAT_PATH.with_suffix(HEARTBEAT_PATH.suffix + f".tmp.{os.getpid()}")
+        tmp.write_text(json.dumps(payload, separators=(",", ":")) + "\n", encoding="utf-8")
+        os.replace(tmp, HEARTBEAT_PATH)
+    except Exception:
+        pass
+
+
+async def _heartbeat_loop() -> None:
+    while not _shutdown.is_set():
+        _write_heartbeat("ok", "tick")
+        try:
+            await asyncio.wait_for(_shutdown.wait(), timeout=_HEARTBEAT_INTERVAL_S)
+        except asyncio.TimeoutError:
+            pass
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Event emission
+# ─────────────────────────────────────────────────────────────────────────
+
+def _truncate_payload(payload: dict) -> dict:
+    """Honour organism Event 2KB payload limit. If too big, keep keys but
+    truncate string values and drop oversized nested dicts."""
+    serialised = json.dumps(payload, separators=(",", ":"), default=str)
+    if len(serialised) <= 2000:
+        return payload
+    truncated: dict = {}
+    for k, v in payload.items():
+        if isinstance(v, str) and len(v) > 256:
+            truncated[k] = v[:256] + "...(truncated)"
+        elif isinstance(v, (dict, list)):
+            truncated[k] = "(nested-truncated)"
+        else:
+            truncated[k] = v
+    truncated["_pg_bridge_truncated"] = True
+    return truncated
+
+
+def _build_event(channel: str, payload_str: str) -> dict:
+    try:
+        payload = json.loads(payload_str)
+        if not isinstance(payload, dict):
+            payload = {"raw": payload_str[:512]}
+    except json.JSONDecodeError:
+        payload = {"raw": payload_str[:512], "_parse_error": True}
+
+    payload = _truncate_payload(payload)
+
+    severity = "warning" if channel in WARNING_CHANNELS else "info"
+    # Honour explicit payload.severity if present and valid.
+    explicit = payload.get("severity")
+    if isinstance(explicit, str) and explicit.lower() in ("critical", "error", "warning", "info"):
+        severity = explicit.lower()
+
+    correlation_id = (
+        payload.get("_outbox_id")
+        or payload.get("correlation_id")
+        or f"pg-{channel}-{datetime.now(timezone.utc).timestamp()}"
+    )
+
+    return {
+        "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "severity": severity,
+        "source": f"pg_bus.{channel}",
+        "kind": channel,
+        "payload": payload,
+        "correlation_id": str(correlation_id),
+        "is_actuation": False,
+        "host": "Pro",
+    }
+
+
+def _emit_event(event: dict) -> None:
+    """JSONL first (durable), Redis XADD second (best-effort)."""
+    try:
+        EVENTS_JSONL.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(event, separators=(",", ":"), default=str)
+        with EVENTS_JSONL.open("a", encoding="utf-8") as f:
+            f.write(line + "\n")
+    except Exception as exc:
+        logger.warning("JSONL write failed: %s", exc)
+        return
+
+    try:
+        subprocess.run(
+            [
+                "redis-cli", "XADD", ORGANISM_STREAM_KEY, "*",
+                "data", json.dumps(event, separators=(",", ":"), default=str),
+            ],
+            capture_output=True, timeout=2, check=False,
+        )
+    except Exception as exc:
+        logger.debug("redis XADD failed (non-fatal): %s", exc)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Listener
+# ─────────────────────────────────────────────────────────────────────────
+
+def _on_notification(_conn, _pid, channel: str, payload: str) -> None:
+    """asyncpg sync callback. Build + emit Event."""
+    try:
+        event = _build_event(channel, payload)
+        _emit_event(event)
+        logger.debug("emitted %s (corr=%s)", channel, event["correlation_id"])
+    except Exception:
+        logger.exception("emit failed for channel=%s", channel)
+
+
+async def _run_listener(dsn: str) -> None:
+    backoff = _RECONNECT_DELAY_S
+    while not _shutdown.is_set():
+        conn = None
+        try:
+            logger.info("connecting to PG: %s", dsn.split("@")[-1] if "@" in dsn else dsn)
+            conn = await asyncpg.connect(dsn=dsn, command_timeout=30)
+            for ch in CHANNELS:
+                await conn.add_listener(ch, _on_notification)
+            logger.info("LISTEN on %d channels active", len(CHANNELS))
+            backoff = _RECONNECT_DELAY_S
+
+            # Keep-alive SELECT every 5s — stops idle Fly proxy from dropping.
+            while not _shutdown.is_set():
+                try:
+                    await asyncio.wait_for(_shutdown.wait(), timeout=5.0)
+                    break
+                except asyncio.TimeoutError:
+                    await conn.execute("SELECT 1")
+        except (asyncpg.PostgresError, OSError, asyncio.TimeoutError) as exc:
+            logger.warning("connection lost: %s — reconnecting in %.1fs", exc, backoff)
+            _write_heartbeat("warning", f"disconnected: {type(exc).__name__}")
+        finally:
+            if conn is not None:
+                try:
+                    await asyncio.wait_for(conn.close(), timeout=5)
+                except (asyncio.TimeoutError, Exception):
+                    try:
+                        conn.terminate()
+                    except Exception:
+                        pass
+
+        if _shutdown.is_set():
+            break
+        await asyncio.sleep(backoff)
+        backoff = min(backoff * 2, _RECONNECT_DELAY_CAP)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────────────────────────────────
+
+def _setup_signals(loop: asyncio.AbstractEventLoop) -> None:
+    def _stop():
+        logger.info("shutdown signal received")
+        _shutdown.set()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, _stop)
+        except NotImplementedError:
+            pass
+
+
+async def _amain() -> int:
+    _load_secrets()
+    dsn = os.environ.get("DATABASE_URL_LOCAL") or os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL[_LOCAL] not set — cannot connect")
+        return 1
+    # Rewrite flycast/.internal hosts to local pg-proxy if needed.
+    if ".flycast" in dsn or ".internal" in dsn:
+        # quick check pg-proxy reachability
+        try:
+            r = subprocess.run(["nc", "-z", "127.0.0.1", "15432"], timeout=2, capture_output=True)
+            if r.returncode == 0:
+                import re
+                dsn = re.sub(r"@[^:/]+:[0-9]+", "@127.0.0.1:15432", dsn)
+                logger.info("rewrote DSN to local pg-proxy")
+            else:
+                logger.error("DSN points to flycast but pg-proxy :15432 unreachable")
+                return 2
+        except Exception as exc:
+            logger.error("nc check failed: %s", exc)
+            return 2
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    loop = asyncio.get_running_loop()
+    _setup_signals(loop)
+    _write_heartbeat("starting", f"channels={len(CHANNELS)}")
+
+    listener_task = asyncio.create_task(_run_listener(dsn))
+    heartbeat_task = asyncio.create_task(_heartbeat_loop())
+
+    await _shutdown.wait()
+    listener_task.cancel()
+    heartbeat_task.cancel()
+    for t in (listener_task, heartbeat_task):
+        try:
+            await t
+        except (asyncio.CancelledError, Exception):
+            pass
+    _write_heartbeat("ok", "stopped clean")
+    return 0
+
+
+def main() -> int:
+    try:
+        return asyncio.run(_amain())
+    except KeyboardInterrupt:
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sentinel-aggregate.py
+++ b/scripts/sentinel-aggregate.py
@@ -47,6 +47,8 @@ import yaml
 REGISTRY_PATH = Path.home() / "Desktop" / "nuzantara" / "apps" / "organism" / "organism" / "organs_registry.yaml"
 LAST_SEEN_DIR = Path.home() / ".organism" / "last_seen"
 AGGREGATE_PATH = Path.home() / ".organism" / "aggregate.json"
+EVENTS_JSONL = Path.home() / ".organism" / "events" / "sentinel.jsonl"
+ORGANISM_STREAM_KEY = "organism:events"
 
 STALE_MULTIPLIER = 1.0
 DEAD_MULTIPLIER = 3.0
@@ -318,6 +320,72 @@ def _classify(
     }
 
 
+def _emit_organism_event(event: dict[str, Any]) -> None:
+    """Emit an Event onto the local organism bus (Redis stream + JSONL mirror).
+
+    JSONL first (durable), Redis second (best-effort). Never raises.
+    Mirrors apps/organism/organism/redis_bus.EventBus.emit semantics so
+    the Supervisor's existing consumer can pick these up unchanged.
+    """
+    try:
+        EVENTS_JSONL.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(event, separators=(",", ":"), default=str)
+        with EVENTS_JSONL.open("a", encoding="utf-8") as f:
+            f.write(line + "\n")
+    except Exception:
+        return  # never propagate
+
+    # Best-effort Redis XADD via redis-cli (no Python redis dep needed).
+    try:
+        subprocess.run(
+            [
+                "redis-cli", "XADD", ORGANISM_STREAM_KEY, "*",
+                "data", json.dumps(event, separators=(",", ":"), default=str),
+            ],
+            capture_output=True, timeout=2, check=False,
+        )
+    except Exception:
+        pass
+
+
+def _emit_dead_organs_to_supervisor(results: list[dict[str, Any]]) -> int:
+    """For every organ classified as dead with critical/error severity,
+    emit a heartbeat_silent Event onto the organism bus. Returns count
+    of events emitted. Wave-5 closes Layer 3 (sentinel→supervisor)."""
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    emitted = 0
+    for o in results:
+        if o.get("status") != "dead":
+            continue
+        sev = (o.get("severity") or "warning").lower()
+        # Only escalate the ones the registry wants escalated.
+        if sev not in ("critical", "error"):
+            continue
+        organ_id = o.get("id", "")
+        if not organ_id:
+            continue
+        event = {
+            "ts": now,
+            "severity": sev,
+            "source": "sentinel.aggregate",
+            "kind": "heartbeat_silent",
+            "payload": {
+                "organ_id": organ_id,
+                "age_seconds": o.get("age_seconds"),
+                "hb_status": o.get("hb_status"),
+                "last_exit": o.get("last_exit"),
+                "recovery_action": o.get("recovery_action"),
+                "owner_module": o.get("owner_module"),
+            },
+            "correlation_id": f"sentinel-{organ_id}-{now}",
+            "is_actuation": False,
+            "host": "Pro",
+        }
+        _emit_organism_event(event)
+        emitted += 1
+    return emitted
+
+
 def _atomic_write(path: Path, data: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + ".tmp")
@@ -415,6 +483,12 @@ def main() -> int:
         )
     except OSError:
         pass
+
+    # Wave-5: emit heartbeat_silent events for dead+critical/error organs
+    # so the Supervisor (organism:events stream consumer) can drive recovery.
+    emitted = _emit_dead_organs_to_supervisor(results)
+    if emitted:
+        print(f"[organism-bus] emitted {emitted} heartbeat_silent event(s)")
 
     _print_summary(rollup)
     return 0


### PR DESCRIPTION
## Summary

Closes the 2 partial layers from \"totale interattività\" audit. After this, the system interacts end-to-end:

- **Layer 1 (bus end-to-end)**: PG ↔ Redis stream bridge daemon
- **Layer 3 (self-action / autonomy)**:
  - Sentinel-aggregate emits \`heartbeat_silent\` events for dead+critical organs
  - Cell.organism emits \`cell_pulse\` events on every pulse
  - New \`fly_machines_start\` actuator (sblocca 7 organi recovery dead-letter)
- **Bonus CLI**: \`nz events\` + \`nz actuator\` for human visibility into the loop

## Files

| File | Purpose |
|---|---|
| \`scripts/pg-to-organism-bridge.py\` | NEW. Daemon: 14 PG channels → organism:events Redis stream (+ JSONL mirror) |
| \`infra/launchagents/com.nuzantara.pg-organism-bridge.plist\` | NEW. KeepAlive=true LaunchAgent |
| \`scripts/sentinel-aggregate.py\` | \`_emit_dead_organs_to_supervisor\` step at end of run |
| \`apps/organism/organism/actuators/fly_machines_start.py\` | NEW. fly machines start actuator |
| \`apps/organism/organism/actuators/__init__.py\` | Register FlyMachinesStart |
| \`apps/cell/cell/main.py\` | \`_emit_cell_pulse_event\` after every pulse |
| \`apps/organism/organism/organs_registry.yaml\` | +1 organ pro.pg_organism_bridge (118 total) |
| \`scripts/cli/nz\` | New \`events\` + \`actuator\` subcommands |

## Live verification

- Sentinel emit: artificial dead injection produced \`[organism-bus] emitted 1 heartbeat_silent event(s)\` + valid JSONL row
- PG bridge: 8s smoke run connected, \"LISTEN on 14 channels active\", clean shutdown, heartbeat written
- Actuator dry-run: \`nz actuator dry-run fly_machines_start app=nuzantara-rag\` → correct argv
- CLI: \`nz events count\` shows redis stream 374 entries; \`nz actuator list\` shows 11 actuators incl fly_machines_start
- Validator: 24/24 organism tests pass
- Registry checksum: 3bf9146ac12938499ca0a0f89f6c0dc3b83fbecea6c5b6192524daa050a31e71

## Out of scope (follow-ups)

- launchctl bootstrap of pg-organism-bridge plist (manual post-merge)
- Supervisor YAML rule to route \`heartbeat_silent\` → restart_agent or fly_machines_start (rule mapping, not actuator code)
- Telegram approval gate for fly_machines_start in autonomous mode

## Test plan

- [x] AST + bash -n syntax
- [x] PG bridge live smoke (8s)
- [x] Sentinel emit live smoke (injected dead heartbeat)
- [x] Actuator dry-run live
- [x] CLI nz events + actuator subcommands live
- [x] 24/24 organism validator tests pass
- [ ] CI checks pending (only mouth npm-audit expected fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)