### PR TITLE
fix(wr2/canva): replace deleted master template DAHE6lx1lf8 → DAHJLYRn_3E

### DIFF
--- a/apps/backend-rag/backend/services/canva_renderer/pending_builder.py
+++ b/apps/backend-rag/backend/services/canva_renderer/pending_builder.py
@@ -4,7 +4,8 @@ Format is the one consumed by the APPLICA_WAR_ROOM.md runbook (shipped
 alongside claude_invoker.py at runbooks/APPLICA_WAR_ROOM.md). The
 Council decides tone + structure, the Visual service produces images,
 and this module composes the operations array using stable element IDs
-of template DAHE6lx1lf8.
+of the master template (currently DAHJLYRn_3E; was DAHE6lx1lf8 until
+2026-05-09 when that ID became invalid).
 
 Historical note: the legacy WR1 pipeline (apps/war-room/, removed
 2026-04-22) used to emit this same schema from a bash-composed
@@ -17,7 +18,14 @@ from __future__ import annotations
 from typing import Any
 
 # Master carousel template. See runbooks/APPLICA_WAR_ROOM.md.
-TEMPLATE_DESIGN_ID = "DAHE6lx1lf8"
+# Master template — replaced 2026-05-09 after the previous master
+# DAHE6lx1lf8 was deleted from Canva (404 / "Design not found" returned
+# from start-editing-transaction starting around 18:24-18:40 WITA).
+# DAHJLYRn_3E is a 12-page replacement with the same gray Bali-Zero
+# brand background. The renderer still clamps to MAX_SLIDES_TEMPLATE
+# (11), so page 12 is left untouched on every run — that is by design,
+# Instagram auto-crops trailing blank pages.
+TEMPLATE_DESIGN_ID = "DAHJLYRn_3E"
 CAROUSEL_FOLDER_ID = "FAHEwkTYduI"
 
 # Legibility Armor gradient overlay — 4:5 PNG with strong dark at top (heading
@@ -93,7 +101,7 @@ VALID_TONES = frozenset({
     "tecnico",
 })
 
-# Template DAHE6lx1lf8 has exactly 11 pages. Carousels SHORTER than 11 use the
+# Master template has at least 11 pages used by the renderer. Carousels SHORTER than 11 use the
 # first N pages; the apply skill resets (wipes) the unused pages to blank so
 # the Canva duplicate in the output folder only exposes N slides when a user
 # views it (Canva engine still renders all 11 internally, but blank pages are
@@ -102,7 +110,7 @@ VALID_TONES = frozenset({
 MIN_SLIDES = 5
 MAX_SLIDES = 11
 MAX_SLIDES_REQUESTED = 13  # what the draft generator is allowed to output
-MAX_SLIDES_TEMPLATE = 11  # hard cap of DAHE6lx1lf8 template
+MAX_SLIDES_TEMPLATE = 11  # hard cap of master template usable area
 
 
 def slides_to_operations(slides: list[dict[str, Any]]) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary

- WR2 canva pipeline started failing 2026-05-09 with `phase0_failed: master template DAHE6lx1lf8 not found`. Browser check confirms 404 on https://www.canva.com/design/DAHE6lx1lf8/edit; the design was not in trash, so it has been deleted definitively. Last successful render against the old master: 2026-05-08 18:24:06.
- Replacement master `DAHJLYRn_3E` — 12-page Bali Zero gray-background design supplied by the operator. The renderer clamps to `MAX_SLIDES_TEMPLATE = 11`, so page 12 is left untouched (Instagram auto-crops trailing blanks).
- Single-line constant change in `pending_builder.py`. The skill `~/.claude/skills/canva-apply.md` reads the template id from the pending JSON, so the new ID propagates without skill-file edits. Comments updated for cohesion; fixture strings in mata-garuda + review tests left as static reference data (deliberately out of scope).

## Test plan

- [x] `PYTHONPATH=. .venv/bin/pytest backend/tests/unit/services/canva_renderer/test_pending_builder.py -q` — 10/10 pass (tests import `TEMPLATE_DESIGN_ID` from the module, not a literal).
- [ ] Required CI checks (Backend Tests + E2E + MCP + Detect Secrets).
- [ ] Post-merge: pull deploy worktree and re-render the 3 stuck drafts (de69f035 / a3fd4007 / 6ace6b26 — currently in `drafts_imaged` after the body-ops fix in PR #552 and the template missing).

## Context — chained fixes

This is the second hotfix in a chain that started yesterday:
1. PR #552 (merged 2026-05-08) — `pending_builder.py` was emitting zero body `replace_text` ops because TEMPLATE_SLOTS body_eid is None across all 11 pages and the gate was `if body and body_eid:`. Fixed to `if body:`. Verified: post-fix pending JSON contains 22 replace_text ops (11 heading + 11 body).
2. Today (this PR) — re-rendering the 3 affected drafts surfaced that the master template itself had been deleted from Canva. Body-ops fix is correct and orthogonal; it just couldn't ship the corrected output because Phase 0 of the apply skill aborts when start-editing-transaction returns "Design not found" on the master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)