### PR TITLE
feat(crm): make tax pilot workspace business-first

### DIFF
--- a/apps/mouth/src/app/globals.css
+++ b/apps/mouth/src/app/globals.css
@@ -702,6 +702,13 @@ main,
   display: none;
 }
 
+/* Hide the public contact FAB inside the authenticated workspace.
+   Workspace routes already have AppSidebar plus internal assistant widgets,
+   and the public FAB overlaps dense CRM surfaces on mobile. */
+:has(.glass-panel-deep) .fab-whatsapp {
+  display: none;
+}
+
 .fab-whatsapp,
 .fab-zantara {
   bottom: 20px;

--- a/apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.test.tsx
+++ b/apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.test.tsx
@@ -126,8 +126,17 @@ const bimalaMap: TaxCompanyPilotMap = {
 };
 
 describe("TaxCompanyPilotWorkspace", () => {
-  it("renders company maps, people, gaps, duplicates, and Drive links", () => {
+  it("renders company maps as business dossiers instead of technical audit panels", () => {
     render(<TaxCompanyPilotWorkspace maps={[oceanMap, bimalaMap]} />);
+
+    expect(screen.getByText("Business dossiers")).toBeInTheDocument();
+    expect(screen.getByText("Companies under review")).toBeInTheDocument();
+    expect(screen.getAllByText("Open decisions")).toHaveLength(3);
+    expect(screen.getAllByText("Tax owner")).toHaveLength(2);
+    expect(screen.getAllByText("Business recap")).toHaveLength(2);
+    expect(screen.getAllByText("Client relationships")).toHaveLength(2);
+    expect(screen.getAllByText("Key company records")).toHaveLength(2);
+    expect(screen.getAllByText("Folder cleanup")).toHaveLength(2);
 
     expect(screen.getByText("OCEAN CLOTHES AND SHOES PT")).toBeInTheDocument();
     expect(
@@ -148,8 +157,15 @@ describe("TaxCompanyPilotWorkspace", () => {
         "Operational tax folder vs canonical-like company folder",
       ),
     ).toBeInTheDocument();
-    expect(screen.getAllByRole("link", { name: /open drive/i })).toHaveLength(
-      2,
-    );
+    expect(
+      screen.getAllByRole("link", {
+        name: /open operational folder in drive/i,
+      }),
+    ).toHaveLength(2);
+    expect(screen.queryByText("Evidence")).not.toBeInTheDocument();
+    expect(screen.queryByText("Gaps")).not.toBeInTheDocument();
+    expect(screen.queryByText("Duplicate Candidates")).not.toBeInTheDocument();
+    expect(screen.queryByText("Read-only")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Confidence:/)).not.toBeInTheDocument();
   });
 });

--- a/apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.tsx
+++ b/apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.tsx
@@ -1,10 +1,9 @@
 import {
   AlertTriangle,
-  Building2,
   ExternalLink,
   FileText,
   Link2,
-  ShieldCheck,
+  Sparkles,
   UserRound,
 } from "lucide-react";
 import type {
@@ -14,18 +13,24 @@ import type {
 } from "@/lib/api/crm/crm.types";
 
 const severityClass: Record<TaxCompanyPilotGap["severity"], string> = {
-  high: "border-red-400/35 bg-red-500/10 text-red-100",
-  medium: "border-amber-400/35 bg-amber-500/10 text-amber-100",
-  low: "border-sky-400/35 bg-sky-500/10 text-sky-100",
+  high: "border-red-200 bg-red-50 text-red-800",
+  medium: "border-amber-200 bg-amber-50 text-amber-800",
+  low: "border-sky-200 bg-sky-50 text-sky-800",
+};
+
+const severityLabel: Record<TaxCompanyPilotGap["severity"], string> = {
+  high: "Decision needed",
+  medium: "Check",
+  low: "Watch",
 };
 
 const documentGroupLabel: Record<TaxCompanyPilotDocument["group"], string> = {
-  company: "Company",
-  tax: "Tax",
-  lkpm: "LKPM",
+  company: "Company registry",
+  tax: "Tax filings",
+  lkpm: "Investment reports",
   finance: "Finance",
-  person: "Person",
-  coretax: "Coretax",
+  person: "Person files",
+  coretax: "Coretax access",
 };
 
 function groupDocuments(documents: TaxCompanyPilotDocument[]) {
@@ -39,64 +44,85 @@ function groupDocuments(documents: TaxCompanyPilotDocument[]) {
   );
 }
 
+function relationshipLabel(person: TaxCompanyPilotMap["persons"][number]) {
+  if (person.relationship_confidence === "confirmed") return "Confirmed link";
+  if (person.relationship_confidence === "high") return "Strong link";
+  if (person.relationship_confidence === "medium") return "Likely link";
+  return "Relationship to confirm";
+}
+
+function getCompanyStatus(map: TaxCompanyPilotMap) {
+  const highCount = map.gaps.filter((gap) => gap.severity === "high").length;
+  if (highCount > 0) return "Needs business review";
+  if (map.gaps.length > 0) return "Almost ready";
+  return "Ready to operate";
+}
+
 function CompanyPilotPanel({ map }: { map: TaxCompanyPilotMap }) {
   const documentsByGroup = groupDocuments(map.documents);
+  const companyStatus = getCompanyStatus(map);
 
   return (
-    <article className="rounded-lg border border-white/10 bg-[#111827] p-4 shadow-sm">
-      <header className="flex flex-col gap-3 border-b border-white/10 pb-4 md:flex-row md:items-start md:justify-between">
+    <article className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
+      <header className="grid gap-4 border-b border-slate-200 bg-slate-50 p-4 lg:grid-cols-[1fr_240px]">
         <div className="min-w-0">
-          <div className="mb-2 flex flex-wrap items-center gap-2">
-            <span className="inline-flex items-center gap-1 rounded-md bg-emerald-500/10 px-2 py-1 text-[11px] font-semibold text-emerald-200">
-              <ShieldCheck size={13} />
-              Read-only
-            </span>
-            <span className="rounded-md bg-white/5 px-2 py-1 text-[11px] text-white/60">
-              Confidence: {map.confidence}
-            </span>
-          </div>
-          <h2 className="text-xl font-semibold text-white">
+          <p className="mb-2 text-xs font-semibold uppercase text-emerald-700">
+            {companyStatus}
+          </p>
+          <h2 className="text-xl font-semibold text-slate-950">
             {map.company.name}
           </h2>
-          <p className="mt-1 text-sm text-white/50">
+          <p className="mt-1 text-sm text-slate-500">
             {map.company.aliases.join(" · ")}
           </p>
         </div>
-        <div className="rounded-lg border border-white/10 bg-black/20 px-3 py-2 text-sm">
-          <p className="text-[11px] font-semibold uppercase text-white/40">
-            Tax member
+        <div className="border-l border-slate-200 pl-4 text-sm">
+          <p className="text-[11px] font-semibold uppercase text-slate-500">
+            Tax owner
           </p>
-          <p className="font-semibold text-white">{map.tax_member.name}</p>
-          <p className="mt-1 text-xs text-white/45">
+          <p className="font-semibold text-slate-950">{map.tax_member.name}</p>
+          <p className="mt-1 text-xs text-slate-500">
             {map.tax_member.workspace_branch}
           </p>
         </div>
       </header>
 
-      <div className="grid gap-4 py-4 lg:grid-cols-[1fr_1.15fr]">
+      <div className="grid gap-6 p-4 lg:grid-cols-[1fr_1.05fr]">
         <section>
-          <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-white">
-            <UserRound size={16} />
-            People
+          <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-slate-950">
+            <Sparkles size={16} />
+            Business recap
           </div>
-          <div className="divide-y divide-white/10 rounded-lg border border-white/10">
+          <ul className="space-y-2 text-sm leading-6 text-slate-700">
+            {map.ai_recap.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </section>
+
+        <section>
+          <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-slate-950">
+            <UserRound size={16} />
+            Client relationships
+          </div>
+          <div className="divide-y divide-slate-100">
             {map.persons.map((person) => (
-              <div key={person.name} className="p-3">
+              <div key={person.name} className="py-3 first:pt-0 last:pb-0">
                 <div className="flex items-start justify-between gap-3">
                   <div>
-                    <p className="font-medium text-white">{person.name}</p>
-                    <p className="mt-1 text-xs text-white/45">
-                      relationship {person.relationship_confidence}
-                      {person.role ? ` · ${person.role}` : ""}
+                    <p className="font-medium text-slate-950">{person.name}</p>
+                    <p className="mt-1 text-xs text-slate-500">
+                      {person.role ?? "Role to confirm"} ·{" "}
+                      {relationshipLabel(person)}
                     </p>
                   </div>
                   {person.folder_url && (
                     <a
-                      aria-label={`Open person folder for ${person.name}`}
+                      aria-label={`Open ${person.name} in Drive`}
                       href={person.folder_url}
                       target="_blank"
                       rel="noreferrer"
-                      className="rounded-md p-1.5 text-white/50 hover:bg-white/10 hover:text-white"
+                      className="rounded-md p-1.5 text-slate-400 hover:bg-slate-100 hover:text-slate-900"
                     >
                       <ExternalLink size={15} />
                     </a>
@@ -106,7 +132,7 @@ function CompanyPilotPanel({ map }: { map: TaxCompanyPilotMap }) {
                   {person.evidence.map((item) => (
                     <span
                       key={item}
-                      className="rounded bg-white/5 px-2 py-1 text-[11px] text-white/60"
+                      className="rounded bg-slate-100 px-2 py-1 text-[11px] text-slate-600"
                     >
                       {item}
                     </span>
@@ -116,19 +142,21 @@ function CompanyPilotPanel({ map }: { map: TaxCompanyPilotMap }) {
             ))}
           </div>
         </section>
+      </div>
 
+      <div className="grid gap-6 border-t border-slate-200 px-4 py-4 lg:grid-cols-[1.1fr_0.9fr]">
         <section>
-          <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-white">
+          <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-slate-950">
             <FileText size={16} />
-            Evidence
+            Key company records
           </div>
           <div className="space-y-3">
             {Object.entries(documentsByGroup).map(([group, documents]) => (
               <div
                 key={group}
-                className="rounded-lg border border-white/10 p-3"
+                className="border-l-2 border-slate-200 bg-slate-50 px-3 py-2"
               >
-                <p className="mb-2 text-xs font-semibold uppercase text-white/45">
+                <p className="mb-2 text-xs font-semibold uppercase text-slate-500">
                   {group}
                 </p>
                 <div className="flex flex-wrap gap-2">
@@ -138,12 +166,12 @@ function CompanyPilotPanel({ map }: { map: TaxCompanyPilotMap }) {
                       href={document.evidence_url ?? "#"}
                       target={document.evidence_url ? "_blank" : undefined}
                       rel="noreferrer"
-                      className="inline-flex items-center gap-1.5 rounded-md bg-white/5 px-2 py-1 text-xs text-white/70 hover:bg-white/10 hover:text-white"
+                      className="inline-flex items-center gap-1.5 rounded-md bg-white px-2 py-1 text-xs text-slate-700 ring-1 ring-slate-200 hover:bg-slate-100 hover:text-slate-950"
                     >
                       {document.name}
                       {document.sensitivity === "financial" ||
                       document.sensitivity === "credential" ? (
-                        <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] text-amber-100">
+                        <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-800">
                           {document.sensitivity}
                         </span>
                       ) : null}
@@ -154,68 +182,58 @@ function CompanyPilotPanel({ map }: { map: TaxCompanyPilotMap }) {
             ))}
           </div>
         </section>
-      </div>
 
-      <section className="grid gap-4 border-t border-white/10 pt-4 lg:grid-cols-2">
-        <div>
-          <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-white">
+        <section>
+          <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-slate-950">
             <AlertTriangle size={16} />
-            Gaps
+            Open decisions
           </div>
           <div className="space-y-2">
             {map.gaps.map((gap) => (
-              <p
+              <div
                 key={gap.code}
                 className={`rounded-md border px-3 py-2 text-sm ${severityClass[gap.severity]}`}
               >
-                {gap.label}
-              </p>
+                <p className="text-[11px] font-semibold uppercase">
+                  {severityLabel[gap.severity]}
+                </p>
+                <p className="mt-1">{gap.label}</p>
+              </div>
             ))}
           </div>
-        </div>
+        </section>
+      </div>
 
+      <section className="grid gap-4 border-t border-slate-200 p-4 lg:grid-cols-[1fr_auto]">
         <div>
-          <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-white">
+          <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-slate-950">
             <Link2 size={16} />
-            Duplicate Candidates
+            Folder cleanup
           </div>
           <div className="space-y-2">
             {map.duplicate_candidates.map((candidate) => (
               <div
                 key={candidate.label}
-                className="rounded-md border border-white/10 px-3 py-2"
+                className="border-l-2 border-slate-200 px-3 py-1.5"
               >
-                <p className="text-sm text-white">{candidate.label}</p>
-                <p className="mt-1 text-xs text-white/45">
-                  confidence {candidate.confidence}
+                <p className="text-sm text-slate-900">{candidate.label}</p>
+                <p className="mt-1 text-xs text-slate-500">
+                  Keep one client-facing source of truth before creating team
+                  shortcuts.
                 </p>
               </div>
             ))}
           </div>
         </div>
-      </section>
-
-      <section className="mt-4 grid gap-4 border-t border-white/10 pt-4 lg:grid-cols-[1fr_auto]">
-        <div>
-          <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-white">
-            <Building2 size={16} />
-            Recap
-          </div>
-          <ul className="space-y-2 text-sm text-white/65">
-            {map.ai_recap.map((item) => (
-              <li key={item}>{item}</li>
-            ))}
-          </ul>
-        </div>
-        <div className="flex flex-wrap content-start gap-2 lg:max-w-[260px]">
+        <div className="flex flex-wrap content-start gap-2 lg:max-w-[280px]">
           {map.evidence_links.map((link) => (
             <a
               key={link.url}
               href={link.url}
               target="_blank"
               rel="noreferrer"
-              aria-label={`Open Drive ${link.label}`}
-              className="inline-flex items-center gap-1.5 rounded-md border border-white/10 px-2.5 py-1.5 text-xs font-medium text-white/70 hover:bg-white/10 hover:text-white"
+              aria-label={`Open ${link.label} in Drive`}
+              className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 px-2.5 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-100 hover:text-slate-950"
             >
               {link.label}
               <ExternalLink size={13} />
@@ -242,32 +260,50 @@ export function TaxCompanyPilotWorkspace({
       sum + map.gaps.filter((gap) => gap.severity === "high").length,
     0,
   );
+  const openDecisions = maps.reduce((sum, map) => sum + map.gaps.length, 0);
 
   return (
-    <main className="min-h-screen bg-[#0b1020] px-4 py-5 text-white md:px-6">
-      <header className="mb-5 flex flex-col gap-4 border-b border-white/10 pb-4 lg:flex-row lg:items-end lg:justify-between">
+    <section className="min-h-screen bg-[#f4f6f1] px-4 py-5 text-slate-950 md:px-6">
+      <header className="mb-5 flex flex-col gap-4 border-b border-slate-200 pb-4 lg:flex-row lg:items-end lg:justify-between">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-emerald-300/80">
-            CRM tax pilot
+          <p className="text-xs font-semibold uppercase text-emerald-700">
+            CRM tax workspace
           </p>
           <h1 className="mt-1 text-2xl font-semibold md:text-3xl">
-            Tax company map
+            Business dossiers
           </h1>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+            People-first company view for tax work: who is connected, who owns
+            the file, which records matter, and what still needs a decision.
+          </p>
         </div>
-        <div className="grid grid-cols-3 gap-2 text-right">
-          <div className="rounded-lg border border-white/10 px-3 py-2">
+        <div className="grid grid-cols-2 gap-2 text-right md:grid-cols-4">
+          <div className="rounded-lg border border-slate-200 bg-white px-3 py-2">
             <p className="text-xl font-semibold">{maps.length}</p>
-            <p className="text-[11px] uppercase text-white/40">Companies</p>
-          </div>
-          <div className="rounded-lg border border-white/10 px-3 py-2">
-            <p className="text-xl font-semibold">{totalPeople}</p>
-            <p className="text-[11px] uppercase text-white/40">People</p>
-          </div>
-          <div className="rounded-lg border border-white/10 px-3 py-2">
-            <p className="text-xl font-semibold">{totalDocuments}</p>
-            <p className="text-[11px] uppercase text-white/40">
-              {highGaps} high gaps
+            <p className="text-[11px] uppercase text-slate-500">
+              Companies under review
             </p>
+          </div>
+          <div className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+            <p className="text-xl font-semibold">{totalPeople}</p>
+            <p className="text-[11px] uppercase text-slate-500">
+              People connected
+            </p>
+          </div>
+          <div className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+            <p className="text-xl font-semibold">{totalDocuments}</p>
+            <p className="text-[11px] uppercase text-slate-500">
+              Records mapped
+            </p>
+          </div>
+          <div className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+            <p className="text-xl font-semibold">{openDecisions}</p>
+            <p className="text-[11px] uppercase text-slate-500">
+              Open decisions
+            </p>
+            {highGaps > 0 && (
+              <p className="mt-1 text-[10px] text-red-700">{highGaps} urgent</p>
+            )}
           </div>
         </div>
       </header>
@@ -276,6 +312,6 @@ export function TaxCompanyPilotWorkspace({
           <CompanyPilotPanel key={map.key} map={map} />
         ))}
       </div>
-    </main>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary
- Reframe the tax pilot workspace from technical audit language into business dossiers
- Surface recap, client relationships, key records, open decisions, and folder cleanup
- Hide the public WhatsApp FAB inside authenticated workspace surfaces to avoid mobile overlap

## Verification
- npm run test -- src/lib/api/crm/crm.api.test.ts src/components/crm/TaxCompanyPilotWorkspace.test.tsx --run
- npm run typecheck
- npm run build
- npx prettier --check apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.tsx apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.test.tsx apps/mouth/src/app/globals.css
- Playwright local visual check on /clients/tax-pilot desktop/mobile with API mocks