### PR TITLE
fix(crm): keep tax pilot panel keys unique

### DIFF
--- a/apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.test.tsx
+++ b/apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { TaxCompanyPilotWorkspace } from "./TaxCompanyPilotWorkspace";
 import type { TaxCompanyPilotMap } from "@/lib/api/crm/crm.types";
 
@@ -126,6 +126,10 @@ const bimalaMap: TaxCompanyPilotMap = {
 };
 
 describe("TaxCompanyPilotWorkspace", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("renders company maps as business dossiers instead of technical audit panels", () => {
     render(<TaxCompanyPilotWorkspace maps={[oceanMap, bimalaMap]} />);
 
@@ -167,5 +171,22 @@ describe("TaxCompanyPilotWorkspace", () => {
     expect(screen.queryByText("Duplicate Candidates")).not.toBeInTheDocument();
     expect(screen.queryByText("Read-only")).not.toBeInTheDocument();
     expect(screen.queryByText(/Confidence:/)).not.toBeInTheDocument();
+  });
+
+  it("does not warn when company maps share the same backend key", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    render(
+      <TaxCompanyPilotWorkspace
+        maps={[oceanMap, { ...bimalaMap, key: oceanMap.key }]}
+      />,
+    );
+
+    expect(screen.getByText("Business dossiers")).toBeInTheDocument();
+    expect(consoleError.mock.calls.flat().join("\n")).not.toContain(
+      "Encountered two children with the same key",
+    );
   });
 });

--- a/apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.tsx
+++ b/apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.tsx
@@ -308,8 +308,11 @@ export function TaxCompanyPilotWorkspace({
         </div>
       </header>
       <div className="grid gap-4 xl:grid-cols-2">
-        {maps.map((map) => (
-          <CompanyPilotPanel key={map.key} map={map} />
+        {maps.map((map, index) => (
+          <CompanyPilotPanel
+            key={`${map.key}-${map.company.name}-${index}`}
+            map={map}
+          />
         ))}
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Make tax pilot dossier panel keys unique even if backend keys collide
- Add regression coverage for duplicate backend keys

## Test Plan
- npm run test -- src/components/crm/TaxCompanyPilotWorkspace.test.tsx --run
- npx prettier --check apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.tsx apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.test.tsx
- npm run typecheck