### PR TITLE
chore(drive): disable OAuth SYSTEM legacy refresh loop

### DIFF
--- a/apps/backend-rag/backend/app/routers/admin_drive_health.py
+++ b/apps/backend-rag/backend/app/routers/admin_drive_health.py
@@ -138,68 +138,66 @@ router = APIRouter(prefix="/api/admin/drive", tags=["admin"])
 
 @router.get("/health")
 async def drive_health(request: Request) -> dict[str, Any]:
-    """Verifica stato token Google Drive (public endpoint)."""
+    """Verifica stato Drive integration (public endpoint).
+
+    Post-2026-05-10: primary auth is Service Account (domain-wide delegation
+    impersonating zero@balizero.com), not the legacy SYSTEM OAuth token.
+    Health is determined by SA reachability; OAuth SYSTEM info is reported
+    informationally for debugging legacy callers but does NOT influence the
+    overall status.
+    """
     pool = getattr(request.app.state, "db_pool", None)
-    if not pool:
-        return {"status": "error", "message": "Database pool not available"}
 
-    async with pool.acquire() as conn:
-        # Check table exists
-        table_exists = await conn.fetchval(
-            """SELECT EXISTS (
-                SELECT FROM information_schema.tables
-                WHERE table_name = 'google_drive_tokens'
-            )""",
+    # Primary check: Service Account reachability
+    sa_working = False
+    sa_error: str | None = None
+    try:
+        from backend.services.integrations.service_account_drive_service import (
+            ServiceAccountDriveService,
         )
 
-        if not table_exists:
-            return {"status": "error", "message": "google_drive_tokens table not found"}
+        sa_drive = ServiceAccountDriveService()
+        # get_start_page_token is the cheapest authenticated call (no list)
+        await sa_drive.get_start_page_token()
+        sa_working = True
+    except Exception as e:
+        sa_error = str(e)[:200]
 
-        # Check SYSTEM token
-        token = await conn.fetchrow(
-            """SELECT user_id, expires_at, refresh_token IS NOT NULL as has_refresh, updated_at
-               FROM google_drive_tokens WHERE user_id = 'SYSTEM'""",
-        )
-
-        if not token:
-            return {
-                "status": "error",
-                "message": "SYSTEM token not found. Re-authorize required.",
-                "auth_url": "/api/admin/google-drive/auth",
-            }
-
-        from datetime import datetime, timezone
-
-        now = datetime.now(timezone.utc)
-        expires = token["expires_at"]
-
-        if expires.tzinfo is None:
-            expires = expires.replace(tzinfo=timezone.utc)
-
-        time_left = expires - now
-
-        # Try actual Drive API call
+    # Informational: legacy OAuth SYSTEM token state (no longer load-bearing)
+    oauth_info: dict[str, Any] = {"disabled": True, "note": "OAuth SYSTEM disabled 2026-05-10 — Drive uses Service Account"}
+    if pool is not None:
         try:
-            from backend.services.integrations.google_drive_service import GoogleDriveService
-
-            drive = GoogleDriveService(pool)
-            drive_token = await drive.get_valid_token("SYSTEM")
-            api_working = drive_token is not None
+            async with pool.acquire() as conn:
+                table_exists = await conn.fetchval(
+                    """SELECT EXISTS (
+                        SELECT FROM information_schema.tables
+                        WHERE table_name = 'google_drive_tokens'
+                    )""",
+                )
+                if table_exists:
+                    token = await conn.fetchrow(
+                        """SELECT user_id, expires_at, refresh_token IS NOT NULL as has_refresh, updated_at
+                           FROM google_drive_tokens WHERE user_id = 'SYSTEM'""",
+                    )
+                    if token:
+                        oauth_info["legacy_token_present"] = True
+                        oauth_info["legacy_expires_at"] = token["expires_at"].isoformat()
         except Exception:
-            api_working = False
+            # Legacy info is best-effort only
+            pass
 
-        return {
-            "status": "healthy" if time_left.total_seconds() > 0 and api_working else "warning",
-            "token": {
-                "user_id": token["user_id"],
-                "expires_at": token["expires_at"].isoformat(),
-                "has_refresh": token["has_refresh"],
-                "updated_at": token["updated_at"].isoformat() if token["updated_at"] else None,
-            },
-            "time_left_seconds": time_left.total_seconds(),
-            "time_left_human": str(time_left),
-            "api_working": api_working,
-        }
+    return {
+        "status": "healthy" if sa_working else "error",
+        "auth_mode": "service_account",
+        "service_account": {
+            "working": sa_working,
+            "error": sa_error,
+            "delegated_user": "zero@balizero.com",
+        },
+        "oauth_legacy": oauth_info,
+        # Backward-compat top-level field for any external monitor still keying on this
+        "api_working": sa_working,
+    }
 
 
 @router.post("/poll")

--- a/apps/backend-rag/backend/services/integrations/google_drive_service.py
+++ b/apps/backend-rag/backend/services/integrations/google_drive_service.py
@@ -235,7 +235,27 @@ class GoogleDriveService:
         return row["access_token"]
 
     async def _refresh_token(self, user_id: str, refresh_token: str) -> str | None:
-        """Refresh access token using refresh token."""
+        """Refresh access token using refresh token.
+
+        OAuth SYSTEM disabled 2026-05-10: legacy SYSTEM-wide OAuth flow has been
+        replaced by ServiceAccountDriveService (domain-wide delegation
+        impersonating zero@balizero.com). Drive operations should go through
+        backend.services.integrations.service_account_drive_service. The
+        SYSTEM token in google_drive_tokens is intentionally left unrefreshed:
+        callers that still request it receive None (and degrade gracefully or
+        error) instead of generating an OAuth refresh storm against a revoked
+        token. Per-user (non-SYSTEM) OAuth flows remain unchanged.
+        """
+        if user_id == self.SYSTEM_USER_ID:
+            if not getattr(self, "_oauth_system_disabled_logged", False):
+                logger.info(
+                    "[GDRIVE] OAuth SYSTEM disabled — Drive operations use "
+                    "ServiceAccountDriveService (domain-wide delegation). "
+                    "Returning None for SYSTEM token requests.",
+                )
+                self._oauth_system_disabled_logged = True
+            return None
+
         logger.info(f"[GDRIVE] Refreshing token for user {user_id}")
 
         client = self._get_client()


### PR DESCRIPTION
## Summary

Drive operations have migrated to `ServiceAccountDriveService` (domain-wide delegation impersonating `zero@balizero.com`), but the legacy SYSTEM-wide OAuth flow in `google_drive_service.py` keeps attempting refreshes every ~minute against a token revoked since 2026-04-27.

**Symptoms today (production):**
- Fly logs flooded with `[GDRIVE] Token refresh failed for user SYSTEM` every ~minute
- `/api/admin/drive/health` reports `status=warning, api_working=false`
- No operational impact (`drive_poll` uses SA directly; all bridges have SA fallback)
- But noise hides real issues + misleads on-call about Drive being broken

## Two minimal changes

### 1. `google_drive_service.py:_refresh_token`
- Early return `None` for `user_id == SYSTEM` with one-shot info log
- Per-user (non-SYSTEM) OAuth flows untouched
- Existing callers of `get_valid_token(SYSTEM)` already handle `None` gracefully (RuntimeError or 503 on portal endpoints, no-op on drive_poll which uses SA directly)

### 2. `admin_drive_health.py:drive_health`
- Health check now uses Service Account `get_start_page_token()` as primary signal (cheapest authenticated SA call)
- Legacy OAuth token state reported informationally for debugging but does NOT influence overall status
- Backward-compat: top-level `api_working` field preserved (now reflects SA reachability instead of OAuth)

## Companion PR

Companion to **PR #575** (DWD impersonation for SA upload quota): both fixes converge on `zero@balizero.com` as the canonical Drive identity. This PR is independent and rebase-clean — file-disjoint with #573, #574, #575.

## Test plan

- [x] AST contract test for `drive_poll_service`: 5/5 PASS (`backend/tests/unit/services/crm/test_drive_poll_service_methods.py`)
- [x] Python syntax check: both files parse
- [x] Import chain: `GoogleDriveService` + `drive_health` imports OK
- [x] Live test (pre-deploy): `drive_poll` endpoint already SA-based, returns 200 in 0.8s
- [ ] Post-deploy: `/api/admin/drive/health` reports `status=healthy, api_working=true, auth_mode=service_account`
- [ ] Post-deploy: Fly logs no longer show `[GDRIVE] Token refresh failed for user SYSTEM`

🤖 Generated with [Claude Code](https://claude.com/claude-code)