### PR TITLE
feat(crm): Gemini Vision content classifier as Tier 2 OCR fallback

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_enhanced.py
+++ b/apps/backend-rag/backend/app/routers/crm_enhanced.py
@@ -749,6 +749,82 @@ async def _auto_ocr_company_profile(db_pool: Any, client_id: int, file_id: str, 
         return {"success": False, "error": str(e)}
 
 
+async def _auto_classify_content(file_id: str) -> dict[str, Any]:
+    """Content-based document classification via Gemini Vision.
+
+    Used as a fallback when filename keywords don't match any known doc-type
+    in dispatch_ocr_by_folder. Reads the actual file content from Drive,
+    asks Gemini Vision to classify into one of the known types, returns a
+    dict with the detected type + confidence.
+
+    The classifier is deliberately small/cheap (single Vision call, JSON-only
+    response) so it can run on every uploaded file without blowing the OCR
+    budget. The downstream OCR handler (passport/visa/nib/npwp/etc.) is the
+    expensive step and only runs when classification confidence > 0.7.
+
+    Returns:
+        {
+            "document_type": "passport" | "visa" | "nib" | "npwp" |
+                             "company_profile" | "akta" | "spt" | "faktur" |
+                             "bukti_potong" | "contract" | "family_doc" |
+                             "unknown",
+            "confidence": float (0.0-1.0),
+            "language": "id" | "en" | "mixed" | "unknown",
+            "reasoning": str (one-line),
+        }
+        or {"error": str} on failure.
+    """
+    try:
+        image_data, mime_type = await _download_drive_file(file_id)
+
+        classification_prompt = (
+            "You are a document classifier for an Indonesian business services CRM "
+            "(immigration, visa, company setup, tax). "
+            "Classify the document shown in the image/PDF into ONE of these types:\n"
+            "- passport: any passport bio page (any nationality)\n"
+            "- visa: KITAS, KITAP, ITAS, ITAP, VOA, B211, C2, C7, telex visa, e-visa\n"
+            "- nib: Nomor Induk Berusaha (Indonesian business ID), OSS document\n"
+            "- npwp: Nomor Pokok Wajib Pajak (Indonesian tax ID), personal or company\n"
+            "- company_profile: Profil Perseroan, company presentation, profilo aziendale\n"
+            "- akta: Akta Pendirian/Perubahan, notarial deed (Indonesian)\n"
+            "- spt: Surat Pemberitahuan Tahunan (Indonesian annual tax return)\n"
+            "- faktur: Faktur Pajak (Indonesian VAT/PPN tax invoice)\n"
+            "- bukti_potong: bukti potong PPh (Indonesian withholding tax certificate)\n"
+            "- contract: lease, rental agreement, MOU, perjanjian, kontrak\n"
+            "- family_doc: kartu keluarga (KK), akta nikah (marriage), akta kelahiran (birth)\n"
+            "- unknown: cannot classify with confidence\n\n"
+            'Return ONLY valid JSON: {"document_type": "<type>", "confidence": <0.0-1.0>, '
+            '"language": "id|en|mixed|unknown", "reasoning": "<one-line why>"}. '
+            "No markdown, no extra text."
+        )
+
+        response_text = await _gemini_ocr(image_data, mime_type, classification_prompt)
+        extracted = extract_json_from_llm_response(response_text)
+        if not extracted:
+            logger.warning(
+                f"Content classifier: JSON parse failed for file {file_id}. "
+                f"Raw: {response_text[:200]}",
+            )
+            return {"error": "Could not parse classifier response"}
+
+        doc_type = extracted.get("document_type", "unknown")
+        confidence = float(extracted.get("confidence", 0.0))
+        logger.info(
+            f"Content classifier: file {file_id} → type={doc_type} "
+            f"confidence={confidence:.2f} language={extracted.get('language', '?')}",
+        )
+        return {
+            "document_type": doc_type,
+            "confidence": confidence,
+            "language": extracted.get("language", "unknown"),
+            "reasoning": extracted.get("reasoning", ""),
+        }
+
+    except Exception as e:
+        logger.error(f"Content classifier failed for file {file_id}: {e}")
+        return {"error": str(e)}
+
+
 async def _dispatch_ocr_by_folder(
     db_pool: Any,
     client_id: int,

--- a/apps/backend-rag/backend/services/documents/ocr_dispatcher_service.py
+++ b/apps/backend-rag/backend/services/documents/ocr_dispatcher_service.py
@@ -1,7 +1,13 @@
 """
 Shared OCR Dispatcher Service.
 
-Routes documents to the correct OCR handler based on filename keywords.
+Routes documents to the correct OCR handler. Two-tier strategy:
+
+  Tier 1 — filename keywords + folder hints (fast, free, no API call)
+  Tier 2 — Gemini Vision content classifier (fallback when Tier 1 misses,
+           1 cheap Vision call, kicks the right OCR handler if confidence
+           is high enough)
+
 Used by both CRM uploads and Portal uploads.
 """
 
@@ -10,6 +16,11 @@ from typing import Any
 from backend.app.utils.logging_utils import get_logger
 
 logger = get_logger(__name__)
+
+# Minimum content classifier confidence to trigger an OCR handler.
+# Below this threshold the file is logged as 'unknown' and skipped — better
+# than running the wrong handler and writing bad data to the client record.
+_CONTENT_CONFIDENCE_THRESHOLD = 0.70
 
 
 async def dispatch_ocr_by_folder(
@@ -22,15 +33,19 @@ async def dispatch_ocr_by_folder(
     document_type: str | None = None,
 ) -> dict:
     """
-    Central OCR dispatcher. Routes to the correct OCR handler based on
-    subfolder name, filename keywords, and document_type.
+    Central OCR dispatcher. Routes to the correct OCR handler based on:
+      1. Subfolder name + filename keywords + explicit document_type (Tier 1)
+      2. Gemini Vision content classifier as fallback (Tier 2)
 
     Returns:
-        {"dispatched": True, "handler": "<type>", "result": <ocr_result>}
+        {"dispatched": True, "handler": "<type>", "tier": "filename"|"content",
+         "result": <ocr_result>}
+        or {"dispatched": False, "tier": "content", "classifier": <class_result>}
         or {"dispatched": False}
     """
     # Lazy import to avoid circular dependencies — handlers live in the router module
     from backend.app.routers.crm_enhanced import (
+        _auto_classify_content,
         _auto_ocr_company_profile,
         _auto_ocr_nib,
         _auto_ocr_npwp,
@@ -42,12 +57,15 @@ async def dispatch_ocr_by_folder(
     folder_lower = folder_name.lower() if folder_name else ""
     dtype_lower = (document_type or "").lower().replace("_", " ")
 
+    # ─── Tier 1: filename / folder keyword match ─────────────────────────
+
     # Passport detection
     if "passport" in fn_lower or (folder_lower.startswith("00_") and "passport" in fn_lower):
         logger.info(f"OCR dispatch: passport detected for client {client_id}, file {filename}")
         return {
             "dispatched": True,
             "handler": "passport",
+            "tier": "filename",
             "result": await _auto_ocr_passport(db_pool, client_id, file_id),
         }
 
@@ -62,6 +80,7 @@ async def dispatch_ocr_by_folder(
             return {
                 "dispatched": True,
                 "handler": "visa",
+                "tier": "filename",
                 "result": await _auto_ocr_visa(db_pool, client_id, file_id, doc_id),
             }
 
@@ -71,6 +90,7 @@ async def dispatch_ocr_by_folder(
         return {
             "dispatched": True,
             "handler": "nib",
+            "tier": "filename",
             "result": await _auto_ocr_nib(db_pool, client_id, file_id, doc_id),
         }
 
@@ -80,6 +100,7 @@ async def dispatch_ocr_by_folder(
         return {
             "dispatched": True,
             "handler": "npwp",
+            "tier": "filename",
             "result": await _auto_ocr_npwp(db_pool, client_id, file_id, doc_id),
         }
 
@@ -92,7 +113,98 @@ async def dispatch_ocr_by_folder(
         "company profile", "profile perseroan", "company_profile",
     ):
         logger.info(f"OCR dispatch: company_profile for client {client_id}")
-        return await _auto_ocr_company_profile(db_pool, client_id, file_id, doc_id)
+        result = await _auto_ocr_company_profile(db_pool, client_id, file_id, doc_id)
+        # Existing handler returns its own dict; preserve it as-is for
+        # backward compatibility but enrich with tier metadata.
+        if isinstance(result, dict):
+            result.setdefault("dispatched", True)
+            result.setdefault("handler", "company_profile")
+            result.setdefault("tier", "filename")
+        return result
 
-    logger.debug(f"OCR dispatch: no handler matched for file {filename} in {folder_name}")
-    return {"dispatched": False}
+    # ─── Tier 2: Gemini Vision content classifier (fallback) ─────────────
+    #
+    # If filename gave us no signal, ask Gemini to look at the actual
+    # content. One cheap Vision call (Ollama qwen2.5vl:7b → Gemini CLI →
+    # Gemini API). The classifier is robust against filename obfuscation
+    # ("IMG_2847.pdf", "scan_001.jpeg", clienti che caricano dal cellulare).
+    logger.info(
+        f"OCR dispatch: filename '{filename}' did not match Tier 1 keywords — "
+        f"trying content classifier for client {client_id}",
+    )
+    classification = await _auto_classify_content(file_id)
+
+    if "error" in classification:
+        logger.warning(
+            f"OCR dispatch: content classifier failed for file {filename}: "
+            f"{classification['error']}",
+        )
+        return {"dispatched": False, "tier": "content", "classifier": classification}
+
+    detected_type = classification.get("document_type", "unknown")
+    confidence = float(classification.get("confidence", 0.0))
+
+    if confidence < _CONTENT_CONFIDENCE_THRESHOLD or detected_type == "unknown":
+        logger.info(
+            f"OCR dispatch: content classifier returned {detected_type} "
+            f"(confidence {confidence:.2f} < {_CONTENT_CONFIDENCE_THRESHOLD}) — "
+            f"no handler triggered for client {client_id}, file {filename}",
+        )
+        return {"dispatched": False, "tier": "content", "classifier": classification}
+
+    # Confidence high enough → re-route to the matching OCR handler.
+    # Only types that already have a handler are listed here. Akta / SPT /
+    # Faktur / bukti_potong / contract / family_doc are recognized by the
+    # classifier but produce {"dispatched": False, "classifier": ...} until
+    # their handlers ship in Phase 2.
+    handler_map = {
+        "passport": ("passport", lambda: _auto_ocr_passport(db_pool, client_id, file_id)),
+        "visa": ("visa", lambda: _auto_ocr_visa(db_pool, client_id, file_id, doc_id)),
+        "nib": ("nib", lambda: _auto_ocr_nib(db_pool, client_id, file_id, doc_id)),
+        "npwp": ("npwp", lambda: _auto_ocr_npwp(db_pool, client_id, file_id, doc_id)),
+        "company_profile": (
+            "company_profile",
+            lambda: _auto_ocr_company_profile(db_pool, client_id, file_id, doc_id),
+        ),
+    }
+    if detected_type in handler_map:
+        handler_name, handler_call = handler_map[detected_type]
+        logger.info(
+            f"OCR dispatch: content classifier matched {detected_type} "
+            f"(confidence {confidence:.2f}) for client {client_id}, file {filename} — "
+            f"running {handler_name} handler",
+        )
+        try:
+            result = await handler_call()
+        except Exception as e:
+            logger.error(
+                f"OCR dispatch: handler {handler_name} failed after content "
+                f"classification for file {filename}: {e}",
+            )
+            return {
+                "dispatched": False,
+                "tier": "content",
+                "classifier": classification,
+                "handler_error": str(e),
+            }
+        # Normalize handler return shape (some handlers return raw dicts,
+        # others return the already-wrapped {dispatched, handler, result}).
+        if isinstance(result, dict) and "dispatched" in result:
+            result.setdefault("tier", "content")
+            result.setdefault("classifier", classification)
+            return result
+        return {
+            "dispatched": True,
+            "handler": handler_name,
+            "tier": "content",
+            "classifier": classification,
+            "result": result,
+        }
+
+    # Recognized type but no handler yet (akta/spt/faktur/etc — Phase 2).
+    logger.info(
+        f"OCR dispatch: content classifier matched {detected_type} "
+        f"(confidence {confidence:.2f}) but no handler implemented yet — "
+        f"file {filename} cataloged as classified but unprocessed",
+    )
+    return {"dispatched": False, "tier": "content", "classifier": classification}

--- a/apps/backend-rag/backend/tests/services/documents/test_ocr_dispatcher_service.py
+++ b/apps/backend-rag/backend/tests/services/documents/test_ocr_dispatcher_service.py
@@ -1,8 +1,17 @@
-"""Tests for OCR dispatcher service — routes documents to correct OCR handler."""
+"""Tests for OCR dispatcher service — routes documents to correct OCR handler.
+
+Two-tier dispatch coverage:
+  - Tier 1: filename / folder keyword match (fast path, no API call)
+  - Tier 2: Gemini Vision content classifier fallback (when filename
+            doesn't match — verifies classifier triggers, confidence
+            threshold, handler re-routing, and graceful failure modes)
+"""
 
 from unittest.mock import AsyncMock, patch
 
 import pytest
+
+# ─── Tier 1: filename / folder keyword match ──────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -20,6 +29,7 @@ async def test_dispatch_passport():
         )
         assert result["dispatched"] is True
         assert result["handler"] == "passport"
+        assert result["tier"] == "filename"
 
 
 @pytest.mark.asyncio
@@ -37,6 +47,7 @@ async def test_dispatch_visa():
         )
         assert result["dispatched"] is True
         assert result["handler"] == "visa"
+        assert result["tier"] == "filename"
 
 
 @pytest.mark.asyncio
@@ -54,6 +65,7 @@ async def test_dispatch_nib():
         )
         assert result["dispatched"] is True
         assert result["handler"] == "nib"
+        assert result["tier"] == "filename"
 
 
 @pytest.mark.asyncio
@@ -71,14 +83,230 @@ async def test_dispatch_npwp():
         )
         assert result["dispatched"] is True
         assert result["handler"] == "npwp"
+        assert result["tier"] == "filename"
+
+
+# ─── Tier 2: content classifier fallback ──────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_dispatch_no_match():
+async def test_content_classifier_high_confidence_passport():
+    """Filename gives no signal; classifier identifies passport with high
+    confidence → dispatcher must run the passport OCR handler."""
     from backend.services.documents.ocr_dispatcher_service import dispatch_ocr_by_folder
 
-    result = await dispatch_ocr_by_folder(
-        db_pool=AsyncMock(), client_id=1, file_id="f1",
-        folder_name="99_Misc", filename="random_letter.pdf",
-    )
-    assert result["dispatched"] is False
+    classifier_result = {
+        "document_type": "passport",
+        "confidence": 0.92,
+        "language": "en",
+        "reasoning": "MRZ + 'PASSPORT' header detected",
+    }
+
+    with patch(
+        "backend.app.routers.crm_enhanced._auto_classify_content",
+        new_callable=AsyncMock,
+        return_value=classifier_result,
+    ), patch(
+        "backend.app.routers.crm_enhanced._auto_ocr_passport",
+        new_callable=AsyncMock,
+        return_value={"success": True, "extracted": {"passport_number": "AB123456"}},
+    ):
+        result = await dispatch_ocr_by_folder(
+            db_pool=AsyncMock(), client_id=1, file_id="f1",
+            folder_name="99_Misc", filename="IMG_2847.pdf",
+        )
+        assert result["dispatched"] is True
+        assert result["handler"] == "passport"
+        assert result["tier"] == "content"
+        assert result["classifier"]["document_type"] == "passport"
+
+
+@pytest.mark.asyncio
+async def test_content_classifier_low_confidence_skipped():
+    """Classifier returns a known type but confidence below threshold →
+    dispatcher must NOT trigger any handler (avoid bad-data writes)."""
+    from backend.services.documents.ocr_dispatcher_service import dispatch_ocr_by_folder
+
+    classifier_result = {
+        "document_type": "passport",
+        "confidence": 0.55,  # below 0.70 threshold
+        "language": "en",
+        "reasoning": "low quality scan, partial visibility",
+    }
+
+    with patch(
+        "backend.app.routers.crm_enhanced._auto_classify_content",
+        new_callable=AsyncMock,
+        return_value=classifier_result,
+    ), patch(
+        "backend.app.routers.crm_enhanced._auto_ocr_passport",
+        new_callable=AsyncMock,
+    ) as mock_passport:
+        result = await dispatch_ocr_by_folder(
+            db_pool=AsyncMock(), client_id=1, file_id="f1",
+            folder_name="99_Misc", filename="blurry_scan.pdf",
+        )
+        assert result["dispatched"] is False
+        assert result["tier"] == "content"
+        assert result["classifier"]["confidence"] == 0.55
+        # Most important: handler must NOT have been called
+        mock_passport.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_content_classifier_unknown_type():
+    """Classifier returns 'unknown' → no handler triggered, returns False."""
+    from backend.services.documents.ocr_dispatcher_service import dispatch_ocr_by_folder
+
+    classifier_result = {
+        "document_type": "unknown",
+        "confidence": 0.20,
+        "language": "unknown",
+        "reasoning": "unable to classify",
+    }
+
+    with patch(
+        "backend.app.routers.crm_enhanced._auto_classify_content",
+        new_callable=AsyncMock,
+        return_value=classifier_result,
+    ):
+        result = await dispatch_ocr_by_folder(
+            db_pool=AsyncMock(), client_id=1, file_id="f1",
+            folder_name="99_Misc", filename="random_doc.pdf",
+        )
+        assert result["dispatched"] is False
+        assert result["tier"] == "content"
+
+
+@pytest.mark.asyncio
+async def test_content_classifier_recognized_but_no_handler():
+    """Classifier identifies akta with high confidence, but akta handler is
+    not yet implemented (Phase 2). Must return dispatched=False but record
+    the classification for audit/cataloging."""
+    from backend.services.documents.ocr_dispatcher_service import dispatch_ocr_by_folder
+
+    classifier_result = {
+        "document_type": "akta",
+        "confidence": 0.88,
+        "language": "id",
+        "reasoning": "Akta Pendirian header + notarial seal visible",
+    }
+
+    with patch(
+        "backend.app.routers.crm_enhanced._auto_classify_content",
+        new_callable=AsyncMock,
+        return_value=classifier_result,
+    ):
+        result = await dispatch_ocr_by_folder(
+            db_pool=AsyncMock(), client_id=1, file_id="f1",
+            folder_name="02_Company", filename="document_001.pdf",
+        )
+        assert result["dispatched"] is False
+        assert result["tier"] == "content"
+        assert result["classifier"]["document_type"] == "akta"
+        assert result["classifier"]["confidence"] == 0.88
+
+
+@pytest.mark.asyncio
+async def test_content_classifier_error_graceful():
+    """Classifier itself raises an error (Drive download fail, Vision API
+    timeout, etc.) → dispatcher must return False without crashing."""
+    from backend.services.documents.ocr_dispatcher_service import dispatch_ocr_by_folder
+
+    with patch(
+        "backend.app.routers.crm_enhanced._auto_classify_content",
+        new_callable=AsyncMock,
+        return_value={"error": "Drive 503 timeout"},
+    ):
+        result = await dispatch_ocr_by_folder(
+            db_pool=AsyncMock(), client_id=1, file_id="f1",
+            folder_name="99_Misc", filename="anything.pdf",
+        )
+        assert result["dispatched"] is False
+        assert result["tier"] == "content"
+        assert "error" in result["classifier"]
+
+
+@pytest.mark.asyncio
+async def test_content_classifier_handler_failure_recorded():
+    """Classifier matches passport, handler runs but raises → dispatcher
+    must return False with handler_error captured for observability."""
+    from backend.services.documents.ocr_dispatcher_service import dispatch_ocr_by_folder
+
+    classifier_result = {
+        "document_type": "passport",
+        "confidence": 0.95,
+        "language": "en",
+        "reasoning": "passport detected",
+    }
+
+    with patch(
+        "backend.app.routers.crm_enhanced._auto_classify_content",
+        new_callable=AsyncMock,
+        return_value=classifier_result,
+    ), patch(
+        "backend.app.routers.crm_enhanced._auto_ocr_passport",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("OCR pipeline crashed"),
+    ):
+        result = await dispatch_ocr_by_folder(
+            db_pool=AsyncMock(), client_id=1, file_id="f1",
+            folder_name="99_Misc", filename="IMG.pdf",
+        )
+        assert result["dispatched"] is False
+        assert result["tier"] == "content"
+        assert "handler_error" in result
+        assert "OCR pipeline crashed" in result["handler_error"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_filename_priority_over_content():
+    """If filename matches Tier 1, content classifier must NOT be called
+    (cost optimization — Tier 1 is free, Tier 2 costs a Vision API call)."""
+    from backend.services.documents.ocr_dispatcher_service import dispatch_ocr_by_folder
+
+    with patch(
+        "backend.app.routers.crm_enhanced._auto_classify_content",
+        new_callable=AsyncMock,
+    ) as mock_classifier, patch(
+        "backend.app.routers.crm_enhanced._auto_ocr_passport",
+        new_callable=AsyncMock,
+        return_value={"success": True},
+    ):
+        result = await dispatch_ocr_by_folder(
+            db_pool=AsyncMock(), client_id=1, file_id="f1",
+            folder_name="00_Profile", filename="passport.pdf",
+        )
+        assert result["tier"] == "filename"
+        # Critical: classifier (expensive) must NOT have been called
+        mock_classifier.assert_not_called()
+
+
+# ─── Original no-match test, updated for Tier 2 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_no_match_falls_through_to_classifier():
+    """File with no Tier 1 match falls through to Tier 2. Verify the
+    classifier is invoked. (Old test ran with no mocks and would now
+    perform real Drive + Vision calls — replaced with mocked classifier
+    that returns 'unknown' so the dispatcher returns False as before.)"""
+    from backend.services.documents.ocr_dispatcher_service import dispatch_ocr_by_folder
+
+    with patch(
+        "backend.app.routers.crm_enhanced._auto_classify_content",
+        new_callable=AsyncMock,
+        return_value={
+            "document_type": "unknown",
+            "confidence": 0.30,
+            "language": "unknown",
+            "reasoning": "no clear signal",
+        },
+    ) as mock_classifier:
+        result = await dispatch_ocr_by_folder(
+            db_pool=AsyncMock(), client_id=1, file_id="f1",
+            folder_name="99_Misc", filename="random_letter.pdf",
+        )
+        assert result["dispatched"] is False
+        # Tier 2 must have been reached (filename had no match)
+        mock_classifier.assert_called_once_with("f1")


### PR DESCRIPTION
## Summary

Existing `dispatch_ocr_by_folder()` routed documents based on **filename keywords** (Tier 1). When clients upload generic-named files like `IMG_2847.pdf`, `scan_001.jpeg`, or WhatsApp screenshots, none of the keyword rules match and the document gets cataloged with **no OCR, no field extraction, no auto-rename, no scadenza tracking**.

This adds a **Tier 2 fallback**: when Tier 1 misses, run a single Gemini Vision call asking *"what kind of document is this?"*. The classifier returns one of:

- `passport / visa / nib / npwp / company_profile` — existing handlers, dispatcher re-routes
- `akta / spt / faktur / bukti_potong / contract / family_doc` — Phase 2 (separate PR)
- `unknown`

If confidence ≥ 0.70 AND a handler exists → re-route to OCR. Below threshold or unknown → file logged as classified-but-unprocessed (avoids bad-data writes).

## Cost optimization

| Tier | Cost | Coverage |
|---|---|---|
| Tier 1 (filename + folder hints) | free, instant | ~80% well-named files |
| Tier 2 (Gemini Vision call) | 1 cheap Vision call | ~20% obfuscated/generic-named |

Reuses existing `_gemini_ocr()` with its **Ollama qwen2.5vl:7b → Gemini CLI → Gemini API** fallback chain. No new dependencies, no new env vars, no schema change.

## Files

- `backend/app/routers/crm_enhanced.py` (+73 lines)
  - new: `_auto_classify_content(file_id)` → `{document_type, confidence, language, reasoning}`
- `backend/services/documents/ocr_dispatcher_service.py` (rewritten)
  - tiered routing with classifier fallback + handler re-dispatch
  - all existing return shapes preserved + `tier` metadata added
- `backend/tests/services/documents/test_ocr_dispatcher_service.py` (+180 lines)
  - 8 new Tier 2 tests + 4 existing Tier 1 tests updated with `tier=filename`

## Test plan

- [x] **12/12 tests pass** (4 Tier 1 + 8 Tier 2)
- [x] Syntax: both modified files parse
- [x] Import chain OK
- [x] Backward compat: existing handler return shapes preserved
- [x] **Cost guard** (asserted): filename match short-circuits before Vision call
- [x] **Safety guard** (asserted): confidence < 0.70 blocks handler call
- [x] **Graceful degradation**: classifier error / handler failure → returns False with metadata, doesn't crash dispatcher
- [ ] Post-deploy: live test with generic-named file in `99_Misc/` → expect Tier 2 classifier triggers

## Phase 2 (separate PR, not in this scope)

Add OCR handlers for `akta`, `spt`, `faktur`, `bukti_potong` with PG schema migration (`akta_data`, `spt_data`, `faktur_data` JSONB columns on documents table).

## Companion to merged PRs

- #576 (chore/disable-oauth-system) — same area, OAuth → Service Account
- #575 (drive SA DWD) — same area, SA quota fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)