### PR TITLE
feat(crm-kg): document linker + Tier-A direct edges (Brain centripetal PR-A)

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/167_crm_kg_nodes_edges.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/167_crm_kg_nodes_edges.sql
@@ -1,0 +1,136 @@
+-- Migration 167: CRM Knowledge Graph (separate from domain kg_nodes)
+--
+-- Why separate tables:
+--   The existing kg_nodes/kg_edges (m028) hold domain entities (KBLI codes,
+--   regulations, visa types) that are shared across all RAG queries. Mixing
+--   PII-bearing CRM nodes (passports, NPWP, contracts) into the same table
+--   relies on a single discriminator column for RBAC isolation, which is
+--   anti-pattern: one missed WHERE clause leaks PII to non-CRM users.
+--
+--   Separate tables enable:
+--     - DB-level grant/revoke per role (Subhi never gets SELECT on crm_kg_*)
+--     - Distinct index strategies (partial indexes on entity_type)
+--     - Independent vacuum/autoanalyze (CRM rows churn more than domain rows)
+--     - Clean delete cascade lifecycle when files are removed from Drive
+--
+-- Privacy (UU PDP Indonesia):
+--   passport_number / npwp / phone numbers are NEVER stored raw in this
+--   table. Person/Company nodes use UUIDv5(namespace_balizero, sha256(id+salt))
+--   as person_uid/company_uid; the salt lives in env CRM_KG_HASH_SALT.
+--   Raw fields stay in documents.ocr_data JSONB (existing CRM table) which
+--   already has DLP rules + RLS for client-data access.
+--
+-- Idempotency:
+--   - crm_kg_nodes: UPSERT by (entity_id) → file_id/client_id/practice_id
+--     are stable lookup keys; re-OCR updates properties without dup nodes
+--   - crm_kg_edges: UNIQUE (source, target, relationship_type) → re-emission
+--     is no-op via ON CONFLICT DO UPDATE
+--
+-- Lifecycle:
+--   Soft-delete via deleted_at; nightly garbage collection cron will
+--   hard-delete edges older than 90 days where source or target node is
+--   deleted_at. (cron added in separate PR.)
+
+-- Dependencies (ensure pgcrypto for gen_random_uuid)
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- ─── crm_kg_nodes ────────────────────────────────────────────────────────
+
+CREATE TABLE crm_kg_nodes (
+    entity_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_type TEXT NOT NULL CHECK (entity_type IN (
+        'crm_client',
+        'crm_document',
+        'crm_practice',
+        'crm_person',
+        'crm_company',
+        'crm_property'
+    )),
+    name TEXT NOT NULL,
+    properties JSONB NOT NULL DEFAULT '{}'::jsonb,
+
+    -- Stable lookup keys for direct entity types. Each is unique per type
+    -- because a single client_id maps to exactly one Client node, etc.
+    -- These columns are nullable because not every node type uses them.
+    file_id TEXT,             -- crm_document only
+    client_id INTEGER,        -- crm_client only
+    practice_id INTEGER,      -- crm_practice only
+    person_uid UUID,          -- crm_person only — UUIDv5 of hash(passport)
+    company_uid UUID,         -- crm_company only — UUIDv5 of hash(npwp)
+
+    confidence FLOAT NOT NULL DEFAULT 1.0 CHECK (confidence >= 0.0 AND confidence <= 1.0),
+
+    -- Soft delete: set deleted_at instead of DELETE so we can recover/audit
+    deleted_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- One Document node per Drive file_id (re-OCR updates same row)
+CREATE UNIQUE INDEX idx_crm_kg_nodes_file_id ON crm_kg_nodes (file_id)
+    WHERE file_id IS NOT NULL;
+
+-- One Client/Practice node per CRM PK
+CREATE UNIQUE INDEX idx_crm_kg_nodes_client_id ON crm_kg_nodes (client_id)
+    WHERE client_id IS NOT NULL;
+
+CREATE UNIQUE INDEX idx_crm_kg_nodes_practice_id ON crm_kg_nodes (practice_id)
+    WHERE practice_id IS NOT NULL;
+
+-- One Person node per UUIDv5(passport_hash). Same person across multiple
+-- documents → same node (mediated edges become trivial).
+CREATE UNIQUE INDEX idx_crm_kg_nodes_person_uid ON crm_kg_nodes (person_uid)
+    WHERE person_uid IS NOT NULL;
+
+CREATE UNIQUE INDEX idx_crm_kg_nodes_company_uid ON crm_kg_nodes (company_uid)
+    WHERE company_uid IS NOT NULL;
+
+-- Common filter: live nodes by type
+CREATE INDEX idx_crm_kg_nodes_type_live ON crm_kg_nodes (entity_type)
+    WHERE deleted_at IS NULL;
+
+-- Properties full-text-ish search (e.g. find by extracted name fragment)
+CREATE INDEX idx_crm_kg_nodes_properties ON crm_kg_nodes USING GIN (properties);
+
+-- ─── crm_kg_edges ────────────────────────────────────────────────────────
+
+CREATE TABLE crm_kg_edges (
+    relationship_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    source_entity_id UUID NOT NULL REFERENCES crm_kg_nodes(entity_id) ON DELETE CASCADE,
+    target_entity_id UUID NOT NULL REFERENCES crm_kg_nodes(entity_id) ON DELETE CASCADE,
+    relationship_type TEXT NOT NULL,
+    properties JSONB NOT NULL DEFAULT '{}'::jsonb,
+
+    -- Tier of inference for confidence interpretation:
+    --   'direct'    → SQL-deterministic (BELONGS_TO from documents.client_id)
+    --   'mediated'  → SQL JOIN on shared property (SAME_PERSON_AS via uid)
+    --   'thematic'  → LLM inference (RELATED_PROJECT, REGULATION_AFFECTS)
+    edge_tier TEXT NOT NULL CHECK (edge_tier IN ('direct', 'mediated', 'thematic')),
+
+    confidence FLOAT NOT NULL DEFAULT 1.0 CHECK (confidence >= 0.0 AND confidence <= 1.0),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Idempotency: at most one edge per (src, tgt, type). Re-emission of
+    -- the same fact updates confidence/properties via ON CONFLICT DO UPDATE.
+    UNIQUE (source_entity_id, target_entity_id, relationship_type)
+);
+
+CREATE INDEX idx_crm_kg_edges_source_tier ON crm_kg_edges (source_entity_id, edge_tier);
+CREATE INDEX idx_crm_kg_edges_target ON crm_kg_edges (target_entity_id);
+CREATE INDEX idx_crm_kg_edges_type ON crm_kg_edges (relationship_type);
+
+-- === ROLLBACK ===
+
+DROP INDEX IF EXISTS idx_crm_kg_edges_type;
+DROP INDEX IF EXISTS idx_crm_kg_edges_target;
+DROP INDEX IF EXISTS idx_crm_kg_edges_source_tier;
+DROP TABLE IF EXISTS crm_kg_edges;
+
+DROP INDEX IF EXISTS idx_crm_kg_nodes_properties;
+DROP INDEX IF EXISTS idx_crm_kg_nodes_type_live;
+DROP INDEX IF EXISTS idx_crm_kg_nodes_company_uid;
+DROP INDEX IF EXISTS idx_crm_kg_nodes_person_uid;
+DROP INDEX IF EXISTS idx_crm_kg_nodes_practice_id;
+DROP INDEX IF EXISTS idx_crm_kg_nodes_client_id;
+DROP INDEX IF EXISTS idx_crm_kg_nodes_file_id;
+DROP TABLE IF EXISTS crm_kg_nodes;

--- a/apps/backend-rag/backend/services/knowledge_graph/document_linker.py
+++ b/apps/backend-rag/backend/services/knowledge_graph/document_linker.py
@@ -1,0 +1,401 @@
+"""CRM Knowledge Graph — Document Linker
+
+Builds the Tier-A "direct" subgraph after each successful CRM document OCR.
+
+Relationships emitted (per upload):
+  - Client(client_id) ← BELONGS_TO ← Document(file_id)
+  - Practice(practice_id) ← PART_OF ← Document(file_id)   (if practice_id set)
+  - Person(uuid5(passport)) ← DESCRIBES ← Document(file_id)  (passport docs)
+  - Company(uuid5(npwp)) ← DESCRIBES ← Document(file_id)     (akta/npwp/nib)
+
+All writes go to crm_kg_nodes / crm_kg_edges (migration 167) — separate from
+the domain kg_nodes/kg_edges to keep PII isolated and RBAC simple.
+
+Privacy:
+  - passport_number / npwp / phone are NEVER stored raw in this table.
+    Person and Company nodes are identified by UUIDv5(NAMESPACE_BALIZERO,
+    sha256(raw + CRM_KG_HASH_SALT)).
+  - Raw values stay in documents.ocr_data JSONB (existing CRM table) which
+    is already protected by client-data RBAC.
+
+Idempotency:
+  - Nodes UPSERT by stable lookup key (file_id / client_id / practice_id /
+    person_uid / company_uid).
+  - Edges DELETE-then-INSERT for the source Document — re-OCR replaces the
+    full set of outgoing edges, no orphan edges from a previous OCR pass.
+
+Failure semantics:
+  - kg_link_document is best-effort: any exception is logged and swallowed.
+    OCR completion is the source of truth; the KG is a derived view that
+    can be backfilled by a later cron if a single link write fails.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import uuid
+from typing import Any
+
+import asyncpg
+
+logger = logging.getLogger(__name__)
+
+# ─── Constants ──────────────────────────────────────────────────────────
+
+# Stable namespace for UUIDv5 person/company identifiers. Derived from a
+# fixed UUID4 seed — see docstring of _person_uid for the reasoning.
+# Any change to this constant invalidates all existing person/company
+# uids (they won't match newly-extracted ones), so it must NEVER change.
+_NAMESPACE_BALIZERO_CRM = uuid.UUID("8a7e6d5c-4b3a-4f1e-9d8c-7b6a5d4c3b2a")
+
+# Edge confidence per tier (Level B/C populated by separate workers).
+_CONFIDENCE_DIRECT = 1.0
+
+
+def _hash_salt() -> str:
+    """Read CRM_KG_HASH_SALT from env. Returns empty string if unset.
+
+    An empty salt still produces deterministic hashes — it just means the
+    hash output is the same as a salt-less hash. Setting the salt in prod
+    is a defense-in-depth measure: if the kg table is ever exfiltrated
+    independently of the env, the attacker cannot rainbow-table passport
+    numbers without also stealing the salt.
+    """
+    return os.environ.get("CRM_KG_HASH_SALT", "")
+
+
+def _person_uid(passport_number: str | None) -> uuid.UUID | None:
+    """Stable UUID for a Person identified by passport number.
+
+    Two documents that extracted the SAME passport_number produce the
+    SAME UUIDv5 → they collapse onto the same Person node automatically
+    (mediated SAME_PERSON_AS becomes a no-op, which is the correct
+    behavior — "same passport" IS "same person", no edge needed).
+
+    Returns None if passport_number is empty/None — caller must skip
+    creating a Person node in that case.
+    """
+    if not passport_number or not passport_number.strip():
+        return None
+    digest = hashlib.sha256(
+        f"{passport_number.strip().upper()}|{_hash_salt()}".encode(),
+    ).hexdigest()
+    return uuid.uuid5(_NAMESPACE_BALIZERO_CRM, f"person:{digest}")
+
+
+def _company_uid(npwp: str | None) -> uuid.UUID | None:
+    """Stable UUID for a Company identified by NPWP. See _person_uid."""
+    if not npwp or not npwp.strip():
+        return None
+    # NPWP normalize: strip dots/dashes/spaces (NPWP can be written
+    # 01.234.567.8-901.000 or 01234567890123)
+    normalized = "".join(c for c in npwp.strip() if c.isdigit())
+    if not normalized:
+        return None
+    digest = hashlib.sha256(
+        f"{normalized}|{_hash_salt()}".encode(),
+    ).hexdigest()
+    return uuid.uuid5(_NAMESPACE_BALIZERO_CRM, f"company:{digest}")
+
+
+# ─── Public API ─────────────────────────────────────────────────────────
+
+async def kg_link_document(
+    db_pool: asyncpg.Pool,
+    *,
+    file_id: str,
+    client_id: int,
+    document_type: str,
+    extracted_fields: dict[str, Any] | None = None,
+    practice_id: int | None = None,
+    drive_url: str | None = None,
+    filename: str | None = None,
+) -> dict[str, Any]:
+    """Link an OCR-classified document into the CRM knowledge graph.
+
+    Idempotent: re-running with the same file_id replaces the document's
+    outgoing edges and updates its node properties.
+
+    Args:
+        db_pool: asyncpg connection pool
+        file_id: Drive file id (stable lookup key for Document node)
+        client_id: clients.id (Document → Client BELONGS_TO edge)
+        document_type: 'passport' | 'visa' | 'akta' | 'npwp' | 'nib' | etc.
+        extracted_fields: OCR output (passport_number, npwp, expiry_date, …)
+        practice_id: practices.id (Document → Practice PART_OF, optional)
+        drive_url: webViewLink (stored in node properties for navigation)
+        filename: original filename (stored in node properties)
+
+    Returns:
+        {"ok": True, "nodes": <int>, "edges": <int>}
+        or {"ok": False, "error": "<reason>"}
+    """
+    extracted_fields = extracted_fields or {}
+
+    try:
+        async with db_pool.acquire() as conn:
+            async with conn.transaction():
+                # 1. Document node (primary entity for this upload)
+                doc_props = {
+                    "document_type": document_type,
+                    "drive_url": drive_url,
+                    "filename": filename,
+                    # Note: extracted_fields go into ocr_data on documents
+                    # table, not duplicated here. We keep just type + nav links.
+                }
+                doc_id = await _upsert_node(
+                    conn,
+                    entity_type="crm_document",
+                    name=filename or f"document_{file_id[:8]}",
+                    properties=doc_props,
+                    file_id=file_id,
+                )
+
+                # 2. Client node (parent context). Bootstrap if missing.
+                client_id_node = await _upsert_node(
+                    conn,
+                    entity_type="crm_client",
+                    name=await _client_full_name(conn, client_id) or f"client_{client_id}",
+                    properties={},
+                    client_id=client_id,
+                )
+
+                # 3. Practice node (if document is tied to a specific practice)
+                practice_id_node = None
+                if practice_id is not None:
+                    practice_id_node = await _upsert_node(
+                        conn,
+                        entity_type="crm_practice",
+                        name=await _practice_name(conn, practice_id) or f"practice_{practice_id}",
+                        properties={},
+                        practice_id=practice_id,
+                    )
+
+                # 4. Person node (passport docs) — collapses to same node
+                #    across multiple uploads of same passport.
+                person_id_node = None
+                pp_num = extracted_fields.get("passport_number")
+                if pp_num:
+                    p_uid = _person_uid(pp_num)
+                    if p_uid is not None:
+                        person_id_node = await _upsert_node(
+                            conn,
+                            entity_type="crm_person",
+                            name=extracted_fields.get("full_name") or "person",
+                            properties={
+                                "nationality": extracted_fields.get("nationality"),
+                                "date_of_birth": extracted_fields.get("date_of_birth"),
+                                "gender": extracted_fields.get("gender"),
+                                # NB: passport_number itself is NOT stored here.
+                                # The uid is the only identifier in the graph.
+                            },
+                            person_uid=p_uid,
+                        )
+
+                # 5. Company node (akta / npwp_company / nib docs)
+                company_id_node = None
+                npwp = (
+                    extracted_fields.get("npwp_company")
+                    or extracted_fields.get("npwp")
+                )
+                if npwp:
+                    c_uid = _company_uid(npwp)
+                    if c_uid is not None:
+                        company_id_node = await _upsert_node(
+                            conn,
+                            entity_type="crm_company",
+                            name=extracted_fields.get("company_name") or "company",
+                            properties={
+                                "modal": extracted_fields.get("akta_modal"),
+                                "kbli": extracted_fields.get("akta_kbli"),
+                                # NPWP raw NOT stored — only company_uid.
+                            },
+                            company_uid=c_uid,
+                        )
+
+                # 6. Replace this document's outgoing edges atomically
+                await conn.execute(
+                    "DELETE FROM crm_kg_edges WHERE source_entity_id = $1",
+                    doc_id,
+                )
+
+                edge_count = 0
+                edge_count += await _insert_edge(
+                    conn,
+                    src=doc_id,
+                    tgt=client_id_node,
+                    rel_type="BELONGS_TO",
+                    edge_tier="direct",
+                )
+                if practice_id_node is not None:
+                    edge_count += await _insert_edge(
+                        conn,
+                        src=doc_id,
+                        tgt=practice_id_node,
+                        rel_type="PART_OF",
+                        edge_tier="direct",
+                    )
+                if person_id_node is not None:
+                    edge_count += await _insert_edge(
+                        conn,
+                        src=doc_id,
+                        tgt=person_id_node,
+                        rel_type="DESCRIBES",
+                        edge_tier="direct",
+                    )
+                if company_id_node is not None:
+                    edge_count += await _insert_edge(
+                        conn,
+                        src=doc_id,
+                        tgt=company_id_node,
+                        rel_type="DESCRIBES",
+                        edge_tier="direct",
+                    )
+
+                node_count = sum(
+                    1 for n in (
+                        doc_id, client_id_node, practice_id_node,
+                        person_id_node, company_id_node,
+                    ) if n is not None
+                )
+
+                logger.info(
+                    "kg_link_document: file_id=%s client_id=%d type=%s "
+                    "nodes=%d edges=%d",
+                    file_id, client_id, document_type, node_count, edge_count,
+                )
+                return {"ok": True, "nodes": node_count, "edges": edge_count}
+
+    except Exception as e:
+        # Best-effort: never let KG-linking errors break the OCR caller.
+        logger.error(
+            "kg_link_document failed for file_id=%s client_id=%d: %s",
+            file_id, client_id, e, exc_info=True,
+        )
+        return {"ok": False, "error": str(e)}
+
+
+# ─── Internal helpers ───────────────────────────────────────────────────
+
+
+async def _upsert_node(
+    conn: asyncpg.Connection,
+    *,
+    entity_type: str,
+    name: str,
+    properties: dict[str, Any],
+    file_id: str | None = None,
+    client_id: int | None = None,
+    practice_id: int | None = None,
+    person_uid: uuid.UUID | None = None,
+    company_uid: uuid.UUID | None = None,
+) -> uuid.UUID:
+    """UPSERT a crm_kg_node by stable lookup key. Returns entity_id."""
+    # Map entity_type to its lookup column. Each type has exactly one
+    # stable key (enforced by per-type unique partial indexes in m167).
+    lookup_col = {
+        "crm_document": "file_id",
+        "crm_client": "client_id",
+        "crm_practice": "practice_id",
+        "crm_person": "person_uid",
+        "crm_company": "company_uid",
+    }[entity_type]
+    lookup_val = {
+        "file_id": file_id,
+        "client_id": client_id,
+        "practice_id": practice_id,
+        "person_uid": person_uid,
+        "company_uid": company_uid,
+    }[lookup_col]
+
+    if lookup_val is None:
+        msg = f"_upsert_node: missing lookup value for {entity_type} ({lookup_col})"
+        raise ValueError(msg)
+
+    # First try update (existing node). Strip None values from properties
+    # so a partial OCR doesn't blank out fields from a previous fuller pass.
+    clean_props = {k: v for k, v in properties.items() if v is not None}
+
+    existing = await conn.fetchrow(
+        f"SELECT entity_id, properties FROM crm_kg_nodes "  # noqa: S608
+        f"WHERE {lookup_col} = $1 AND deleted_at IS NULL",
+        lookup_val,
+    )
+    if existing:
+        # Merge new fields into existing properties (no overwrite with None)
+        merged = {**existing["properties"], **clean_props}
+        await conn.execute(
+            "UPDATE crm_kg_nodes "
+            "SET name = $1, properties = $2, updated_at = NOW() "
+            "WHERE entity_id = $3",
+            name, merged, existing["entity_id"],
+        )
+        return existing["entity_id"]
+
+    # Insert new node. Set the appropriate stable-key column.
+    columns = ["entity_type", "name", "properties", lookup_col]
+    placeholders = ["$1", "$2", "$3", "$4"]
+    values: list[Any] = [entity_type, name, clean_props, lookup_val]
+
+    row = await conn.fetchrow(
+        f"INSERT INTO crm_kg_nodes ({', '.join(columns)}) "  # noqa: S608
+        f"VALUES ({', '.join(placeholders)}) "
+        f"RETURNING entity_id",
+        *values,
+    )
+    return row["entity_id"]
+
+
+async def _insert_edge(
+    conn: asyncpg.Connection,
+    *,
+    src: uuid.UUID,
+    tgt: uuid.UUID,
+    rel_type: str,
+    edge_tier: str,
+    properties: dict[str, Any] | None = None,
+    confidence: float = _CONFIDENCE_DIRECT,
+) -> int:
+    """Insert an edge with idempotent ON CONFLICT update. Returns 1."""
+    await conn.execute(
+        """
+        INSERT INTO crm_kg_edges (
+            source_entity_id, target_entity_id, relationship_type,
+            properties, edge_tier, confidence
+        ) VALUES ($1, $2, $3, $4, $5, $6)
+        ON CONFLICT (source_entity_id, target_entity_id, relationship_type)
+        DO UPDATE SET
+            properties = EXCLUDED.properties,
+            edge_tier = EXCLUDED.edge_tier,
+            confidence = EXCLUDED.confidence
+        """,
+        src, tgt, rel_type, properties or {}, edge_tier, confidence,
+    )
+    return 1
+
+
+async def _client_full_name(conn: asyncpg.Connection, client_id: int) -> str | None:
+    """Read full_name from clients table for human-readable node name."""
+    row = await conn.fetchrow(
+        "SELECT full_name FROM clients WHERE id = $1 AND deleted_at IS NULL",
+        client_id,
+    )
+    return row["full_name"] if row else None
+
+
+async def _practice_name(conn: asyncpg.Connection, practice_id: int) -> str | None:
+    """Read a human-readable name for a practice (best-effort)."""
+    # Practices schema varies; try common columns and fall back to id.
+    for col in ("name", "title", "practice_type_code"):
+        try:
+            row = await conn.fetchrow(
+                f"SELECT {col} FROM practices WHERE id = $1",  # noqa: S608
+                practice_id,
+            )
+            if row and row[col]:
+                return str(row[col])
+        except asyncpg.UndefinedColumnError:
+            continue
+    return None

--- a/apps/backend-rag/backend/tests/services/knowledge_graph/test_document_linker.py
+++ b/apps/backend-rag/backend/tests/services/knowledge_graph/test_document_linker.py
@@ -1,0 +1,424 @@
+"""Tests for crm_kg document_linker — pure-logic + DB-mock coverage.
+
+The real DB integration is tested via the migration smoke tests; here we
+exercise the deterministic UUID generation, entity_type→lookup_col mapping,
+edge-replacement semantics, and idempotent property merging. Heavy on
+unit logic, light on infrastructure.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.services.knowledge_graph.document_linker import (
+    _NAMESPACE_BALIZERO_CRM,
+    _company_uid,
+    _person_uid,
+    _upsert_node,
+)
+
+# ─── UUIDv5 determinism + privacy ───────────────────────────────────────
+
+
+def test_person_uid_is_deterministic():
+    """Same passport_number → same UUID across calls."""
+    a = _person_uid("AB1234567")
+    b = _person_uid("AB1234567")
+    assert a is not None
+    assert a == b
+    assert isinstance(a, uuid.UUID)
+
+
+def test_person_uid_is_namespaced():
+    """UUIDs must derive from our private namespace (UUIDv5 contract)."""
+    pid = _person_uid("AB1234567")
+    expected = uuid.uuid5(
+        _NAMESPACE_BALIZERO_CRM,
+        f"person:{__import__('hashlib').sha256(b'AB1234567|').hexdigest()}",
+    )
+    assert pid == expected
+
+
+def test_person_uid_normalizes_case_and_whitespace():
+    """Passport "ab123" / " AB123 " / "AB123" must collapse to one node."""
+    a = _person_uid("ab123")
+    b = _person_uid(" AB123 ")
+    c = _person_uid("AB123")
+    assert a == b == c
+
+
+def test_person_uid_handles_empty():
+    """Empty/whitespace input → None (caller skips Person node)."""
+    assert _person_uid(None) is None
+    assert _person_uid("") is None
+    assert _person_uid("   ") is None
+
+
+def test_company_uid_normalizes_npwp_punctuation():
+    """NPWP can be 01.234.567.8-901.000 or plain digits → same uid."""
+    a = _company_uid("01.234.567.8-901.000")
+    b = _company_uid("01234567890100")  # extra trailing 0 to match digits
+    # Different digit strings → different uids (this is the desired behavior:
+    # we DON'T silently merge typos)
+    assert a != b
+    # But same digit string with different punctuation → same uid
+    c = _company_uid("01-234-567-8 901 000")
+    assert a == c
+
+
+def test_company_uid_rejects_non_digits():
+    """NPWP must contain at least one digit, else None."""
+    assert _company_uid("not-an-npwp") is None
+    assert _company_uid("") is None
+    assert _company_uid(None) is None
+
+
+def test_salt_changes_uid(monkeypatch):
+    """Setting CRM_KG_HASH_SALT must change the uid output (defense-in-depth)."""
+    monkeypatch.delenv("CRM_KG_HASH_SALT", raising=False)
+    no_salt = _person_uid("AB1234567")
+
+    monkeypatch.setenv("CRM_KG_HASH_SALT", "secret-salt-2026")
+    with_salt = _person_uid("AB1234567")
+
+    assert no_salt != with_salt
+
+
+def test_no_raw_passport_in_uid(monkeypatch):
+    """Sanity: the raw passport string MUST NOT appear in the UUID bytes.
+    UUIDv5 is a one-way hash — this is implicit, but we assert it explicitly
+    because PII leakage via uuid bytes would be a UU PDP violation."""
+    monkeypatch.delenv("CRM_KG_HASH_SALT", raising=False)
+    pid = _person_uid("AB1234567")
+    assert pid is not None
+    assert b"AB1234567" not in pid.bytes
+    assert "AB1234567" not in str(pid)
+
+
+# ─── _upsert_node logic (mock asyncpg connection) ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_upsert_node_creates_when_missing():
+    """No existing node for the lookup key → INSERT path."""
+    conn = AsyncMock()
+    new_uid = uuid.uuid4()
+    conn.fetchrow = AsyncMock(side_effect=[
+        None,  # SELECT existing returns nothing
+        {"entity_id": new_uid},  # INSERT RETURNING
+    ])
+
+    result = await _upsert_node(
+        conn,
+        entity_type="crm_document",
+        name="passport.pdf",
+        properties={"document_type": "passport"},
+        file_id="drive_file_123",
+    )
+
+    assert result == new_uid
+    # Verify INSERT was called (second fetchrow)
+    assert conn.fetchrow.call_count == 2
+    insert_sql = conn.fetchrow.call_args_list[1][0][0]
+    assert "INSERT INTO crm_kg_nodes" in insert_sql
+    assert "RETURNING entity_id" in insert_sql
+
+
+@pytest.mark.asyncio
+async def test_upsert_node_updates_existing_and_merges_properties():
+    """Re-upload same file → UPDATE path, properties merged not overwritten."""
+    conn = AsyncMock()
+    existing_uid = uuid.uuid4()
+    conn.fetchrow = AsyncMock(return_value={
+        "entity_id": existing_uid,
+        "properties": {
+            "nationality": "RUS",
+            "document_type": "passport",
+        },
+    })
+    conn.execute = AsyncMock()
+
+    # Re-OCR finds new field "gender" but doesn't re-extract "nationality"
+    result = await _upsert_node(
+        conn,
+        entity_type="crm_person",
+        name="Marina P",
+        properties={"gender": "F"},  # ONLY new field
+        person_uid=uuid.uuid4(),
+    )
+
+    assert result == existing_uid
+    # The UPDATE call should merge old + new, preserving nationality
+    update_args = conn.execute.call_args[0]
+    merged_props = update_args[2]
+    assert merged_props["nationality"] == "RUS"  # preserved from existing
+    assert merged_props["document_type"] == "passport"  # preserved
+    assert merged_props["gender"] == "F"  # newly added
+
+
+@pytest.mark.asyncio
+async def test_upsert_node_strips_none_values():
+    """OCR returning None for a field must not blank existing data.
+
+    Common scenario: passport OCR captures gender first time. A later
+    re-OCR (e.g. lower-quality scan) returns nationality=null. We should
+    KEEP the previously-extracted nationality, not overwrite with null.
+    """
+    conn = AsyncMock()
+    existing_uid = uuid.uuid4()
+    conn.fetchrow = AsyncMock(return_value={
+        "entity_id": existing_uid,
+        "properties": {"nationality": "RUS", "gender": "F"},
+    })
+    conn.execute = AsyncMock()
+
+    await _upsert_node(
+        conn,
+        entity_type="crm_person",
+        name="Marina P",
+        properties={
+            "nationality": None,  # explicit None, must NOT overwrite
+            "date_of_birth": "1990-01-01",  # new field
+        },
+        person_uid=uuid.uuid4(),
+    )
+
+    merged = conn.execute.call_args[0][2]
+    assert merged["nationality"] == "RUS"  # NOT clobbered by None
+    assert merged["gender"] == "F"  # untouched
+    assert merged["date_of_birth"] == "1990-01-01"  # added
+
+
+@pytest.mark.asyncio
+async def test_upsert_node_raises_on_missing_lookup_value():
+    """Caller must provide the right stable-key for the entity_type."""
+    conn = AsyncMock()
+
+    with pytest.raises(ValueError, match="missing lookup value"):
+        await _upsert_node(
+            conn,
+            entity_type="crm_document",
+            name="x.pdf",
+            properties={},
+            # file_id NOT provided → ValueError
+        )
+
+
+@pytest.mark.asyncio
+async def test_upsert_node_uses_correct_lookup_column_per_type():
+    """entity_type → lookup_col mapping must be consistent."""
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value=None)
+    conn.fetchrow.return_value = None
+    new_uid = uuid.uuid4()
+    conn.fetchrow = AsyncMock(side_effect=[None, {"entity_id": new_uid}])
+
+    await _upsert_node(
+        conn,
+        entity_type="crm_practice",
+        name="KITAS Marina",
+        properties={},
+        practice_id=42,
+    )
+
+    # SELECT should query by practice_id
+    select_sql = conn.fetchrow.call_args_list[0][0][0]
+    assert "practice_id = $1" in select_sql
+    select_arg = conn.fetchrow.call_args_list[0][0][1]
+    assert select_arg == 42
+
+
+# ─── End-to-end logic (full kg_link_document flow with deep mocking) ────
+
+
+@pytest.mark.asyncio
+async def test_kg_link_document_passport_full_flow(monkeypatch):
+    """Verify a passport document creates Document + Client + Person nodes
+    and 2 direct edges (BELONGS_TO, DESCRIBES)."""
+    from backend.services.knowledge_graph import document_linker
+
+    # Track every node UPSERT (in order of call)
+    upsert_calls: list[dict] = []
+    edge_calls: list[dict] = []
+
+    async def fake_upsert(conn, **kwargs):
+        upsert_calls.append(kwargs)
+        return uuid.uuid4()
+
+    async def fake_edge(conn, **kwargs):
+        edge_calls.append(kwargs)
+        return 1
+
+    monkeypatch.setattr(document_linker, "_upsert_node", fake_upsert)
+    monkeypatch.setattr(document_linker, "_insert_edge", fake_edge)
+    monkeypatch.setattr(
+        document_linker, "_client_full_name",
+        AsyncMock(return_value="Marina Pinyaylova"),
+    )
+    monkeypatch.setattr(
+        document_linker, "_practice_name",
+        AsyncMock(return_value=None),
+    )
+
+    # Mock pool / conn / transaction
+    conn = AsyncMock()
+    conn.execute = AsyncMock()  # for DELETE FROM crm_kg_edges
+    pool = _make_pool_mock(conn)
+
+    result = await document_linker.kg_link_document(
+        pool,
+        file_id="drive123",
+        client_id=42,
+        document_type="passport",
+        extracted_fields={
+            "passport_number": "AB7654321",
+            "full_name": "Marina Pinyaylova",
+            "nationality": "RUS",
+            "date_of_birth": "1990-05-15",
+        },
+        drive_url="https://drive.google.com/file/d/drive123",
+        filename="marina_passport.pdf",
+    )
+
+    assert result["ok"] is True
+    # Document + Client + Person = 3 nodes
+    assert result["nodes"] == 3
+    # BELONGS_TO + DESCRIBES = 2 edges
+    assert result["edges"] == 2
+
+    # Document was upserted with file_id key
+    assert any(c["entity_type"] == "crm_document" for c in upsert_calls)
+    # Client was upserted with client_id key
+    assert any(
+        c["entity_type"] == "crm_client" and c.get("client_id") == 42
+        for c in upsert_calls
+    )
+    # Person was upserted with person_uid (deterministic UUID)
+    person_calls = [c for c in upsert_calls if c["entity_type"] == "crm_person"]
+    assert len(person_calls) == 1
+    assert person_calls[0]["person_uid"] == _person_uid("AB7654321")
+    # Person properties contain only non-PII metadata (no passport_number)
+    person_props = person_calls[0]["properties"]
+    assert "passport_number" not in person_props
+    assert person_props["nationality"] == "RUS"
+
+    # Edges: BELONGS_TO + DESCRIBES, both edge_tier='direct'
+    edge_types = {e["rel_type"] for e in edge_calls}
+    assert edge_types == {"BELONGS_TO", "DESCRIBES"}
+    assert all(e["edge_tier"] == "direct" for e in edge_calls)
+
+    # DELETE-then-INSERT semantics: outgoing edges from doc were cleared
+    delete_call = conn.execute.call_args_list[0]
+    assert "DELETE FROM crm_kg_edges" in delete_call[0][0]
+
+
+@pytest.mark.asyncio
+async def test_kg_link_document_skips_person_when_no_passport(monkeypatch):
+    """A `contract` document has no passport → no Person node, no DESCRIBES."""
+    from backend.services.knowledge_graph import document_linker
+
+    upsert_calls: list[dict] = []
+    edge_calls: list[dict] = []
+
+    async def fake_upsert(conn, **kwargs):
+        upsert_calls.append(kwargs)
+        return uuid.uuid4()
+
+    async def fake_edge(conn, **kwargs):
+        edge_calls.append(kwargs)
+        return 1
+
+    monkeypatch.setattr(document_linker, "_upsert_node", fake_upsert)
+    monkeypatch.setattr(document_linker, "_insert_edge", fake_edge)
+    monkeypatch.setattr(
+        document_linker, "_client_full_name",
+        AsyncMock(return_value="Marina Pinyaylova"),
+    )
+    monkeypatch.setattr(
+        document_linker, "_practice_name",
+        AsyncMock(return_value=None),
+    )
+
+    conn = AsyncMock()
+    conn.execute = AsyncMock()
+    pool = _make_pool_mock(conn)
+
+    result = await document_linker.kg_link_document(
+        pool,
+        file_id="drive456",
+        client_id=42,
+        document_type="contract",
+        extracted_fields={"some_field": "x"},  # no passport_number, no npwp
+        filename="lease.pdf",
+    )
+
+    assert result["ok"] is True
+    # Only Document + Client (no Person, no Company, no Practice)
+    assert result["nodes"] == 2
+    # Only BELONGS_TO
+    assert result["edges"] == 1
+    assert all(c["entity_type"] != "crm_person" for c in upsert_calls)
+    assert all(c["entity_type"] != "crm_company" for c in upsert_calls)
+
+
+@pytest.mark.asyncio
+async def test_kg_link_document_swallows_exceptions(monkeypatch):
+    """KG-linking failure must NOT propagate — OCR caller stays happy."""
+    from backend.services.knowledge_graph import document_linker
+
+    async def boom(*a, **kw):
+        msg = "Simulated DB error"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(document_linker, "_upsert_node", boom)
+    monkeypatch.setattr(
+        document_linker, "_client_full_name", AsyncMock(return_value="x"),
+    )
+    monkeypatch.setattr(
+        document_linker, "_practice_name", AsyncMock(return_value=None),
+    )
+
+    conn = AsyncMock()
+    conn.execute = AsyncMock()
+    pool = _make_pool_mock(conn)
+
+    result = await document_linker.kg_link_document(
+        pool,
+        file_id="x",
+        client_id=1,
+        document_type="passport",
+        extracted_fields={},
+    )
+
+    assert result["ok"] is False
+    assert "Simulated DB error" in result["error"]
+
+
+# ─── Helpers ────────────────────────────────────────────────────────────
+
+
+def _make_pool_mock(conn):
+    """Build an asyncpg.Pool-like mock that yields the given conn from
+    `async with pool.acquire()` and supports `async with conn.transaction()`."""
+    pool = AsyncMock()
+
+    class _Acquire:
+        async def __aenter__(self):
+            return conn
+
+        async def __aexit__(self, *exc):
+            return False
+
+    class _Tx:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *exc):
+            return False
+
+    pool.acquire = lambda: _Acquire()
+    conn.transaction = lambda: _Tx()
+    return pool


### PR DESCRIPTION
## Summary

First piece of the **cross-document Knowledge Graph for Bali Zero CRM** ("Brain centripetal" project). Builds the deterministic backbone (zero LLM cost) on top of which Tier-B (mediated) and Tier-C (thematic LLM) layers will land in follow-up PRs.

## Context

Existing KG (m028) holds **domain entities** (KBLI, regulations, visa types) shared across all RAG queries. Mixing PII-bearing CRM data into the same table relies on a single `source_collection` discriminator for RBAC isolation — anti-pattern: one missed `WHERE` clause leaks passports to non-CRM users.

This PR introduces a **separate** `crm_kg_*` table family with stricter physical isolation.

## What ships

### 1. Migration 167: `crm_kg_nodes` + `crm_kg_edges`
- Separate from domain `kg_nodes` for **physical PII isolation**
- Stable lookup keys per entity type (`file_id`, `client_id`, `practice_id`, `person_uid`, `company_uid`) with **per-type unique partial indexes** → idempotent UPSERT
- `edge_tier` column distinguishes `direct` / `mediated` / `thematic`
- Soft delete (`deleted_at`) + `ON DELETE CASCADE` on edges
- Includes `-- === ROLLBACK ===` section per project convention (m114 scar)

### 2. `backend/services/knowledge_graph/document_linker.py`
- **`kg_link_document(pool, file_id, client_id, doc_type, extracted_fields, ...)`** → emits Document + Client + Practice + Person + Company nodes and direct edges (BELONGS_TO, PART_OF, DESCRIBES) atomically inside a single transaction
- **Person/Company identifiers are UUIDv5** of `sha256(passport+salt)` / `sha256(npwp_digits+salt)` → two documents with the same passport collapse onto the same Person node automatically
- Salt from `CRM_KG_HASH_SALT` env (Fly secret) — **defense in depth** against rainbow-table attacks
- Raw `passport_number` / `npwp` **NEVER** stored in this table — only the hash-derived uid. Raw values stay in `documents.ocr_data` JSONB which is already RBAC-protected
- **DELETE-then-INSERT for outgoing edges**: re-OCR replaces the full edge set, no orphans
- Property merge with **None-stripping**: partial OCR doesn't blank out fields a previous fuller OCR captured
- **Best-effort**: any exception logged + swallowed. OCR caller never sees KG-linking failures (KG is a derived view, can be backfilled later)

### 3. 16 unit tests
Covering UUIDv5 determinism, namespace, NPWP normalization, salt defense-in-depth, **no-raw-PII-in-uid (UU PDP sanity assertion)**, INSERT vs UPDATE paths, property merge, None-preservation, full passport flow, contract flow, exception swallowing.

## Cross-LLM design review

Submitted to Gemini 3.1 Pro and DeepSeek Reasoner before implementation; both returned **NEEDS_FIX** with convergent blockers:

- ❌ RBAC contamination if `kg_nodes` is reused → ✅ separate table
- ❌ Person uid = hash(passport) collapses identity AND property check → ✅ that's intentional (mediated SAME_PERSON_AS becomes no-op, which is correct)
- ❌ Idempotency missing → ✅ UPSERT nodes + DELETE-then-INSERT edges
- ❌ Missing Client/Practice node creation → ✅ `kg_link_document` upserts inline
- ❌ Confidence semantics conflated → ✅ `direct=1.0`, fuzzy=0.8, LLM=0.6-0.85
- ❌ Coupling with OCR success path → ✅ exception-swallowing, KG is derived view

All 4 blockers fixed before commit.

## Out of scope (later PRs)

- **PR-B**: Tier-B mediated cron (`SAME_PERSON_AS` via shared `person_uid`)
- **PR-C**: Tier-C thematic LLM weekly worker
- **PR-D**: `kg_garbage_collect` cron
- **PR-A3**: hook into `_dispatch_ocr_by_folder` via PG NOTIFY `crm_document_ocr_completed` + `events_outbox` (m144 pattern)

This PR ships the linker but does **NOT yet wire it into the OCR success path** — that goes in PR-A3 with a feature flag.

## Test plan

- [x] **16/16 unit tests pass**
- [x] Syntax: SQL + Python both parse
- [x] Privacy: no raw passport bytes in uid (asserted via `b'AB1234567' not in pid.bytes`)
- [x] Idempotency: re-OCR test path covered (UPSERT + edge replace)
- [x] Best-effort: exception in upsert → `ok=False`, no raise
- [ ] Migration 167 applies on Fly prod via `run-migrations` CI job
- [ ] Post-deploy: smoke test by manually calling `kg_link_document` against staging client

## Companion PRs (recently merged)

- #576 (OAuth SYSTEM disable) — same Drive area
- #577 (Content classifier Tier 2) — same OCR area