### PR TITLE
fix(organism): supervisor actuator import + bridge XADD MAXLEN cap

### DIFF
--- a/apps/organism/organism/actuators/__init__.py
+++ b/apps/organism/organism/actuators/__init__.py
@@ -15,6 +15,7 @@ from organism.actuators.cleanup_cache import CleanupCache
 from organism.actuators.cleanup_branches import CleanupBranches
 from organism.actuators.cleanup_zombie_plist import CleanupZombiePlist
 from organism.actuators.propose_yaml_rule import ProposeYamlRule
+from organism.actuators.fly_machines_start import FlyMachinesStart
 
 
 __all__ = [
@@ -29,6 +30,7 @@ __all__ = [
     "CleanupBranches",
     "CleanupZombiePlist",
     "ProposeYamlRule",
+    "FlyMachinesStart",
     "build_actuator_registry",
 ]
 

--- a/scripts/pg-to-organism-bridge.py
+++ b/scripts/pg-to-organism-bridge.py
@@ -195,9 +195,15 @@ def _emit_event(event: dict) -> None:
         return
 
     try:
+        # MAXLEN ~ 100000 caps the stream to ~100k entries (approximate, O(1)
+        # via the `~` modifier vs O(N) for exact MAXLEN). Prevents unbounded
+        # growth when Supervisor consumer is down/slow. At ~100 events/min
+        # peak, 100k entries = ~16h of buffer. JSONL mirror remains the
+        # durable record for longer history.
         subprocess.run(
             [
-                "redis-cli", "XADD", ORGANISM_STREAM_KEY, "*",
+                "redis-cli", "XADD", ORGANISM_STREAM_KEY,
+                "MAXLEN", "~", "100000", "*",
                 "data", json.dumps(event, separators=(",", ":"), default=str),
             ],
             capture_output=True, timeout=2, check=False,


### PR DESCRIPTION
## Summary

Two punctual fixes uncovered during TST (Tutto Sente Tutto) audit. Both are scope-contained and verified live on Pro before commit.

## Fix 1: Supervisor crash loop on FlyMachinesStart

`apps/organism/organism/actuators/__init__.py:55` referenced `FlyMachinesStart.name` and `FlyMachinesStart()` in `build_actuator_registry` without importing the class. Result: every supervisor boot crashed with `NameError: name 'FlyMachinesStart' is not defined`, leaving the `organism:events` Redis stream un-consumed.

The `fly_machines_start.py` module already defines the class — the import was simply missing.

## Fix 2: Bridge XADD without MAXLEN cap

`scripts/pg-to-organism-bridge.py:198-204` issued `redis-cli XADD organism:events * data <event>` with no MAXLEN parameter. With Supervisor crashing (Fix 1), `organism:events` grew unbounded — at ~100 events/min peak that's ~144k entries/day with no consumer.

Added `MAXLEN ~ 100000` (approximate trim, O(1) via `~` modifier vs O(N) for exact MAXLEN). At peak rate, 100k entries = ~16h of buffer.

## Test plan

- [x] `python3 -c "from organism.actuators import build_actuator_registry"` passes (system Python 3.11.11 used by supervisor plist)
- [x] `redis-cli XADD test:k MAXLEN ~ 5 * data x` returns valid stream ID (syntax accepted)
- [x] Supervisor restart via `launchctl bootout/bootstrap`: PID alive 30s+ post-fix, no new error in `~/logs/organism/supervisor.err`
- [x] Bridge restart: "LISTEN on 14 channels active", current stream length 1841 (well below cap)
- [x] Pre-commit hooks: all green
- [ ] CI gates pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)