### PR TITLE
feat(crm-kg): wire kg_link_document into OCR dispatcher (PR-A3, feature flagged)

### DIFF
--- a/apps/backend-rag/backend/services/documents/ocr_dispatcher_service.py
+++ b/apps/backend-rag/backend/services/documents/ocr_dispatcher_service.py
@@ -8,9 +8,14 @@ Routes documents to the correct OCR handler. Two-tier strategy:
            1 cheap Vision call, kicks the right OCR handler if confidence
            is high enough)
 
+After a successful OCR handler call, optionally links the document into
+the CRM Knowledge Graph (Tier-A direct edges). Controlled by env var
+CRM_KG_ENABLED — off by default during gradual rollout.
+
 Used by both CRM uploads and Portal uploads.
 """
 
+import os
 from typing import Any
 
 from backend.app.utils.logging_utils import get_logger
@@ -21,6 +26,102 @@ logger = get_logger(__name__)
 # Below this threshold the file is logged as 'unknown' and skipped — better
 # than running the wrong handler and writing bad data to the client record.
 _CONTENT_CONFIDENCE_THRESHOLD = 0.70
+
+
+def _kg_enabled() -> bool:
+    """Feature flag for CRM Knowledge Graph linking.
+
+    Off by default. Set CRM_KG_ENABLED=true (or 1, yes, on) to activate.
+    Allows progressive rollout: deploy the wiring first, observe metrics,
+    flip the flag once the linker is verified safe in prod.
+    """
+    return os.environ.get("CRM_KG_ENABLED", "").lower() in ("true", "1", "yes", "on")
+
+
+async def _kg_link_after_ocr(
+    db_pool: Any,
+    *,
+    file_id: str,
+    client_id: int,
+    doc_type: str,
+    handler_result: Any,
+    doc_id: int | None = None,  # noqa: ARG001 — reserved for PR-B backfill via documents.id
+    filename: str | None = None,
+) -> None:
+    """Best-effort fire-and-forget hook to crm_kg document_linker.
+
+    Called from inside dispatch_ocr_by_folder after a handler succeeds.
+    All exceptions are swallowed: KG linking is a derived view, never
+    a blocker for the OCR caller. If this fails, a backfill cron will
+    pick up the orphan documents on the next sweep.
+
+    Extracts the OCR fields from the handler result envelope. Each
+    handler returns a dict shaped like:
+        {"success": bool, "extracted": {<fields>}, ...}
+
+    """
+    if not _kg_enabled():
+        return
+
+    try:
+        # Lazy import — keeps dispatch_ocr_by_folder import-cheap
+        from backend.services.knowledge_graph.document_linker import kg_link_document
+
+        # Pull extracted_fields out of the handler envelope. Handlers vary
+        # in shape: some put fields under 'extracted', some under
+        # 'raw_response', some return a flat dict. Be defensive.
+        extracted: dict[str, Any] = {}
+        practice_id: int | None = None
+        drive_url: str | None = None
+
+        if isinstance(handler_result, dict):
+            # Common envelope: {"success": True, "extracted": {...}}
+            if isinstance(handler_result.get("extracted"), dict):
+                extracted = handler_result["extracted"]
+            # OCR data field used by passport/visa handlers
+            elif isinstance(handler_result.get("raw_response"), dict):
+                extracted = handler_result["raw_response"]
+            # Fallback: top-level keys are the extraction
+            elif "passport_number" in handler_result or "npwp" in handler_result:
+                extracted = handler_result
+
+            practice_id = handler_result.get("practice_id") or practice_id
+            drive_url = handler_result.get("drive_url") or drive_url
+
+        result = await kg_link_document(
+            db_pool,
+            file_id=file_id,
+            client_id=client_id,
+            document_type=doc_type,
+            extracted_fields=extracted,
+            practice_id=practice_id,
+            drive_url=drive_url,
+            filename=filename,
+        )
+
+        if result.get("ok"):
+            logger.info(
+                "kg_link_document OK for file %s (client %d, type %s): "
+                "nodes=%d edges=%d",
+                file_id, client_id, doc_type,
+                result.get("nodes", 0), result.get("edges", 0),
+            )
+        else:
+            # ok=False is logged by document_linker itself; just note here
+            # that the dispatcher saw the failure so it shows up in trace.
+            logger.warning(
+                "kg_link_document returned ok=False for file %s: %s",
+                file_id, result.get("error"),
+            )
+
+    except Exception as e:  # noqa: BLE001 — broad-except is the contract here
+        # Total swallow: KG linking failures must NEVER cause an OCR caller
+        # to think the upload failed. Document state of truth lives in the
+        # documents table, populated by the handler before this hook fires.
+        logger.error(
+            "kg_link_document hook crashed for file %s (client %d): %s",
+            file_id, client_id, e, exc_info=True,
+        )
 
 
 async def dispatch_ocr_by_folder(
@@ -36,6 +137,9 @@ async def dispatch_ocr_by_folder(
     Central OCR dispatcher. Routes to the correct OCR handler based on:
       1. Subfolder name + filename keywords + explicit document_type (Tier 1)
       2. Gemini Vision content classifier as fallback (Tier 2)
+
+    On successful handler dispatch (Tier 1 or Tier 2), optionally fires the
+    crm_kg document_linker hook (controlled by CRM_KG_ENABLED env var).
 
     Returns:
         {"dispatched": True, "handler": "<type>", "tier": "filename"|"content",
@@ -62,11 +166,17 @@ async def dispatch_ocr_by_folder(
     # Passport detection
     if "passport" in fn_lower or (folder_lower.startswith("00_") and "passport" in fn_lower):
         logger.info(f"OCR dispatch: passport detected for client {client_id}, file {filename}")
+        ocr_result = await _auto_ocr_passport(db_pool, client_id, file_id)
+        await _kg_link_after_ocr(
+            db_pool, file_id=file_id, client_id=client_id,
+            doc_type="passport", handler_result=ocr_result,
+            doc_id=doc_id, filename=filename,
+        )
         return {
             "dispatched": True,
             "handler": "passport",
             "tier": "filename",
-            "result": await _auto_ocr_passport(db_pool, client_id, file_id),
+            "result": ocr_result,
         }
 
     # Visa / KITAS / KITAP detection
@@ -77,31 +187,49 @@ async def dispatch_ocr_by_folder(
     if any(kw in fn_lower for kw in visa_keywords):
         if any(kw in fn_lower for kw in visa_keywords) or "permit" in fn_lower or "stay" in fn_lower:
             logger.info(f"OCR dispatch: visa detected for client {client_id}, file {filename}")
+            ocr_result = await _auto_ocr_visa(db_pool, client_id, file_id, doc_id)
+            await _kg_link_after_ocr(
+                db_pool, file_id=file_id, client_id=client_id,
+                doc_type="visa", handler_result=ocr_result,
+                doc_id=doc_id, filename=filename,
+            )
             return {
                 "dispatched": True,
                 "handler": "visa",
                 "tier": "filename",
-                "result": await _auto_ocr_visa(db_pool, client_id, file_id, doc_id),
+                "result": ocr_result,
             }
 
     # NIB detection
     if "nib" in fn_lower or "berusaha" in fn_lower or "oss" in fn_lower:
         logger.info(f"OCR dispatch: NIB detected for client {client_id}, file {filename}")
+        ocr_result = await _auto_ocr_nib(db_pool, client_id, file_id, doc_id)
+        await _kg_link_after_ocr(
+            db_pool, file_id=file_id, client_id=client_id,
+            doc_type="nib", handler_result=ocr_result,
+            doc_id=doc_id, filename=filename,
+        )
         return {
             "dispatched": True,
             "handler": "nib",
             "tier": "filename",
-            "result": await _auto_ocr_nib(db_pool, client_id, file_id, doc_id),
+            "result": ocr_result,
         }
 
     # NPWP detection
     if "npwp" in fn_lower or ("tax" in fn_lower and "id" in fn_lower):
         logger.info(f"OCR dispatch: NPWP detected for client {client_id}, file {filename}")
+        ocr_result = await _auto_ocr_npwp(db_pool, client_id, file_id, doc_id)
+        await _kg_link_after_ocr(
+            db_pool, file_id=file_id, client_id=client_id,
+            doc_type="npwp", handler_result=ocr_result,
+            doc_id=doc_id, filename=filename,
+        )
         return {
             "dispatched": True,
             "handler": "npwp",
             "tier": "filename",
-            "result": await _auto_ocr_npwp(db_pool, client_id, file_id, doc_id),
+            "result": ocr_result,
         }
 
     # Company Profile / Profil Perseroan
@@ -114,6 +242,11 @@ async def dispatch_ocr_by_folder(
     ):
         logger.info(f"OCR dispatch: company_profile for client {client_id}")
         result = await _auto_ocr_company_profile(db_pool, client_id, file_id, doc_id)
+        await _kg_link_after_ocr(
+            db_pool, file_id=file_id, client_id=client_id,
+            doc_type="company_profile", handler_result=result,
+            doc_id=doc_id, filename=filename,
+        )
         # Existing handler returns its own dict; preserve it as-is for
         # backward compatibility but enrich with tier metadata.
         if isinstance(result, dict):
@@ -187,6 +320,12 @@ async def dispatch_ocr_by_folder(
                 "classifier": classification,
                 "handler_error": str(e),
             }
+        # Fire KG hook after content-tier dispatch too
+        await _kg_link_after_ocr(
+            db_pool, file_id=file_id, client_id=client_id,
+            doc_type=handler_name, handler_result=result,
+            doc_id=doc_id, filename=filename,
+        )
         # Normalize handler return shape (some handlers return raw dicts,
         # others return the already-wrapped {dispatched, handler, result}).
         if isinstance(result, dict) and "dispatched" in result:

--- a/apps/backend-rag/backend/tests/services/documents/test_ocr_dispatcher_service.py
+++ b/apps/backend-rag/backend/tests/services/documents/test_ocr_dispatcher_service.py
@@ -310,3 +310,141 @@ async def test_dispatch_no_match_falls_through_to_classifier():
         assert result["dispatched"] is False
         # Tier 2 must have been reached (filename had no match)
         mock_classifier.assert_called_once_with("f1")
+
+
+# ─── PR-A3: KG hook (feature-flag) ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_kg_hook_off_by_default():
+    """With CRM_KG_ENABLED unset, dispatcher must NOT call kg_link_document.
+    Critical for backward compat: deployed before flag is flipped."""
+    from backend.services.documents.ocr_dispatcher_service import dispatch_ocr_by_folder
+
+    with patch(
+        "backend.app.routers.crm_enhanced._auto_ocr_passport",
+        new_callable=AsyncMock,
+        return_value={"success": True, "extracted": {"passport_number": "AB123"}},
+    ), patch(
+        "backend.services.knowledge_graph.document_linker.kg_link_document",
+        new_callable=AsyncMock,
+    ) as mock_kg:
+        result = await dispatch_ocr_by_folder(
+            db_pool=AsyncMock(), client_id=1, file_id="f1",
+            folder_name="00_Profile", filename="passport.pdf",
+        )
+        assert result["dispatched"] is True
+        # KG link NOT called because flag is off
+        mock_kg.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_kg_hook_fires_when_flag_on(monkeypatch):
+    """With CRM_KG_ENABLED=true, dispatcher must call kg_link_document
+    after successful OCR with the extracted fields."""
+    monkeypatch.setenv("CRM_KG_ENABLED", "true")
+    from backend.services.documents.ocr_dispatcher_service import dispatch_ocr_by_folder
+
+    extracted = {"passport_number": "AB123", "nationality": "RUS"}
+    ocr_result = {"success": True, "extracted": extracted}
+
+    with patch(
+        "backend.app.routers.crm_enhanced._auto_ocr_passport",
+        new_callable=AsyncMock,
+        return_value=ocr_result,
+    ), patch(
+        "backend.services.knowledge_graph.document_linker.kg_link_document",
+        new_callable=AsyncMock,
+        return_value={"ok": True, "nodes": 3, "edges": 2},
+    ) as mock_kg:
+        await dispatch_ocr_by_folder(
+            db_pool=AsyncMock(), client_id=42, file_id="drive_x",
+            folder_name="00_Profile", filename="passport.pdf",
+        )
+
+        mock_kg.assert_called_once()
+        call_kwargs = mock_kg.call_args.kwargs
+        assert call_kwargs["file_id"] == "drive_x"
+        assert call_kwargs["client_id"] == 42
+        assert call_kwargs["document_type"] == "passport"
+        assert call_kwargs["extracted_fields"] == extracted
+        assert call_kwargs["filename"] == "passport.pdf"
+
+
+@pytest.mark.asyncio
+async def test_kg_hook_swallows_exceptions(monkeypatch):
+    """KG-link failure must NOT break the dispatcher return path. The
+    OCR caller still gets dispatched=True with the OCR result intact."""
+    monkeypatch.setenv("CRM_KG_ENABLED", "1")
+    from backend.services.documents.ocr_dispatcher_service import dispatch_ocr_by_folder
+
+    with patch(
+        "backend.app.routers.crm_enhanced._auto_ocr_passport",
+        new_callable=AsyncMock,
+        return_value={"success": True, "extracted": {"passport_number": "AB"}},
+    ), patch(
+        "backend.services.knowledge_graph.document_linker.kg_link_document",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("DB pool exhausted"),
+    ):
+        result = await dispatch_ocr_by_folder(
+            db_pool=AsyncMock(), client_id=1, file_id="f1",
+            folder_name="00_Profile", filename="passport.pdf",
+        )
+        # Despite KG crash, dispatcher returns success
+        assert result["dispatched"] is True
+        assert result["handler"] == "passport"
+
+
+@pytest.mark.asyncio
+async def test_kg_hook_after_content_tier_dispatch(monkeypatch):
+    """Tier-2 content-classifier dispatch must also fire the KG hook."""
+    monkeypatch.setenv("CRM_KG_ENABLED", "true")
+    from backend.services.documents.ocr_dispatcher_service import dispatch_ocr_by_folder
+
+    classifier_result = {
+        "document_type": "npwp",
+        "confidence": 0.93,
+        "language": "id",
+        "reasoning": "NPWP card detected",
+    }
+    ocr_result = {"success": True, "extracted": {"npwp": "01.234.567.8-901.000"}}
+
+    with patch(
+        "backend.app.routers.crm_enhanced._auto_classify_content",
+        new_callable=AsyncMock,
+        return_value=classifier_result,
+    ), patch(
+        "backend.app.routers.crm_enhanced._auto_ocr_npwp",
+        new_callable=AsyncMock,
+        return_value=ocr_result,
+    ), patch(
+        "backend.services.knowledge_graph.document_linker.kg_link_document",
+        new_callable=AsyncMock,
+        return_value={"ok": True, "nodes": 3, "edges": 2},
+    ) as mock_kg:
+        await dispatch_ocr_by_folder(
+            db_pool=AsyncMock(), client_id=42, file_id="drive_x",
+            folder_name="99_Misc", filename="IMG_5555.pdf",
+        )
+
+        mock_kg.assert_called_once()
+        assert mock_kg.call_args.kwargs["document_type"] == "npwp"
+        assert mock_kg.call_args.kwargs["extracted_fields"]["npwp"] == "01.234.567.8-901.000"
+
+
+@pytest.mark.asyncio
+async def test_kg_flag_recognizes_truthy_values(monkeypatch):
+    """Flag accepts true/1/yes/on (case-insensitive)."""
+    from backend.services.documents.ocr_dispatcher_service import _kg_enabled
+
+    for val in ("true", "TRUE", "True", "1", "yes", "YES", "on", "On"):
+        monkeypatch.setenv("CRM_KG_ENABLED", val)
+        assert _kg_enabled() is True, f"failed for {val!r}"
+
+    for val in ("false", "0", "no", "off", "", "anything", "TRUEISH"):
+        monkeypatch.setenv("CRM_KG_ENABLED", val)
+        assert _kg_enabled() is False, f"failed for {val!r}"
+
+    monkeypatch.delenv("CRM_KG_ENABLED", raising=False)
+    assert _kg_enabled() is False


### PR DESCRIPTION
## Summary

After **#578** landed the `document_linker`, this PR connects it to the OCR success path. The hook fires after each handler (Tier 1 filename match or Tier 2 content classifier) returns a successful result, building the CRM Knowledge Graph subgraph automatically as documents flow through the pipeline.

## Activation: `CRM_KG_ENABLED` env var

**Off by default**. Flip to `true` / `1` / `yes` / `on` (case-insensitive) to activate.
Flag allows progressive rollout: deploy the wiring first, observe metrics, flip when ready. No-op behavior with flag off is **asserted by tests**.

## Hook semantics

- **Best-effort**: any exception in `kg_link_document` is logged and swallowed. The dispatcher's return path is unaffected. KG is a derived view; OCR completion is the source of truth.
- **Field extraction defensive**: handler envelopes vary (`extracted` / `raw_response` / flat dict) — the hook tries each shape.
- **Fires for both Tier 1 (filename) and Tier 2 (content classifier) paths**.

## Files

### `backend/services/documents/ocr_dispatcher_service.py`
- new: `_kg_enabled()` reads `CRM_KG_ENABLED` env var
- new: `_kg_link_after_ocr()` calls document_linker, swallows exceptions
- 5 OCR handlers (passport/visa/nib/npwp/company_profile) call the hook after success — both in Tier 1 path and after Tier 2 classifier match

### `backend/tests/services/documents/test_ocr_dispatcher_service.py`
- 5 new tests covering:
  - flag-off no-op (critical for backward compat)
  - flag-on triggers hook with correct payload
  - exception swallowing
  - content-tier hook firing
  - flag truthy-value recognition (true/1/yes/on case-insensitive)
- 12 existing tests unchanged and still pass — verifies hook is **transparent when flag is off**

## Test plan

- [x] **17/17 unit tests pass** (12 existing + 5 new)
- [x] Backward compat: flag-off path unchanged (existing tests intact)
- [x] Cost guard: no DB/KG call when flag off
- [x] Safety guard: exception swallowing asserted
- [ ] Post-deploy: flip `CRM_KG_ENABLED=true` on staging, upload a passport, verify `crm_kg_nodes` has 3 rows + `crm_kg_edges` has 2 rows
- [ ] Post-deploy: monitor Fly logs for `kg_link_document OK` lines

## Companion PRs (recently merged)

- **#578** (KG document_linker + Tier-A schema)
- **#577** (Tier 2 content classifier)
- **#576** (OAuth SYSTEM cleanup)