### PR TITLE
feat(crm-kg): Tier-B mediated edges cron + admin endpoints (PR-B)

### DIFF
--- a/apps/backend-rag/backend/app/routers/admin_crm_kg.py
+++ b/apps/backend-rag/backend/app/routers/admin_crm_kg.py
@@ -1,0 +1,125 @@
+"""Admin endpoints for the CRM Knowledge Graph mediated/thematic builders.
+
+Endpoints exposed:
+  - POST /api/admin/crm-kg/build-mediated  → run Tier-B mediated edge pass
+  - GET  /api/admin/crm-kg/health          → counts of nodes/edges per type
+
+Both are admin-API-key-gated via the existing X-API-Key middleware. Designed
+to be invoked by:
+  - Mini-Pro2 cron via curl (every 6h)
+  - Manual ops trigger when populating after a backfill
+  - Future LaunchAgent on Pro/Mini if remote cron fails
+
+This router does NOT call the builder synchronously inline if it could
+take >30s; it delegates to a BackgroundTask so the cron caller gets
+HTTP 200 immediately and can move on.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, BackgroundTasks, Request
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/admin/crm-kg", tags=["admin"])
+
+
+@router.post("/build-mediated")
+async def trigger_build_mediated(
+    request: Request,
+    background_tasks: BackgroundTasks,
+) -> dict[str, Any]:
+    """Trigger one pass of the Tier-B mediated edge builder.
+
+    Cron-friendly: returns HTTP 200 immediately with status='started',
+    actual work happens in the background task. Errors are logged but
+    do not propagate to the caller (best-effort cron pattern).
+    """
+    pool = getattr(request.app.state, "db_pool", None)
+    if not pool:
+        return {"status": "error", "message": "Database pool not available"}
+
+    async def _run() -> None:
+        from backend.services.knowledge_graph.mediated_edges_builder import (
+            build_mediated_edges,
+        )
+        result = await build_mediated_edges(pool)
+        logger.info("crm_kg.build_mediated background result: %s", result)
+
+    background_tasks.add_task(_run)
+    return {"status": "started", "message": "Mediated edge builder running in background"}
+
+
+@router.get("/health")
+async def crm_kg_health(request: Request) -> dict[str, Any]:
+    """Quick counts of crm_kg_nodes and crm_kg_edges by type/tier.
+
+    Useful for monitoring growth and verifying the linker / builders
+    are actually emitting data.
+    """
+    pool = getattr(request.app.state, "db_pool", None)
+    if not pool:
+        return {"status": "error", "message": "Database pool not available"}
+
+    try:
+        async with pool.acquire() as conn:
+            # Check tables exist (migration 167 may not be applied yet
+            # in some envs, e.g. local dev that hasn't pulled main)
+            tables_exist = await conn.fetchval(
+                """
+                SELECT
+                    (SELECT EXISTS(
+                        SELECT 1 FROM information_schema.tables
+                        WHERE table_name = 'crm_kg_nodes'
+                    ))
+                    AND
+                    (SELECT EXISTS(
+                        SELECT 1 FROM information_schema.tables
+                        WHERE table_name = 'crm_kg_edges'
+                    ))
+                """,
+            )
+            if not tables_exist:
+                return {
+                    "status": "warning",
+                    "message": "crm_kg tables not yet present (migration 167 pending)",
+                }
+
+            nodes_by_type = await conn.fetch(
+                """
+                SELECT entity_type, COUNT(*) AS cnt
+                FROM crm_kg_nodes
+                WHERE deleted_at IS NULL
+                GROUP BY entity_type
+                ORDER BY entity_type
+                """,
+            )
+            edges_by_tier = await conn.fetch(
+                """
+                SELECT edge_tier, relationship_type, COUNT(*) AS cnt
+                FROM crm_kg_edges
+                GROUP BY edge_tier, relationship_type
+                ORDER BY edge_tier, relationship_type
+                """,
+            )
+
+        return {
+            "status": "healthy",
+            "nodes_by_type": {
+                row["entity_type"]: row["cnt"] for row in nodes_by_type
+            },
+            "edges_by_tier": [
+                {
+                    "tier": row["edge_tier"],
+                    "type": row["relationship_type"],
+                    "count": row["cnt"],
+                }
+                for row in edges_by_tier
+            ],
+        }
+    except Exception as e:
+        logger.error("crm_kg health failed: %s", e, exc_info=True)
+        return {"status": "error", "message": str(e)[:200]}

--- a/apps/backend-rag/backend/app/setup/router_manifest.py
+++ b/apps/backend-rag/backend/app/setup/router_manifest.py
@@ -85,6 +85,7 @@ def _get_api_v1_prefix() -> str:
 ROUTER_MANIFEST: tuple[RouterEntry, ...] = (
     # ── Admin ──
     RouterEntry(name="admin_conversation_cleanup", process_groups=_API, tags=("admin",)),
+    RouterEntry(name="admin_crm_kg",               process_groups=_API, tags=("admin", "crm-kg")),
     RouterEntry(name="admin_drive_auth",           process_groups=_API, tags=("admin", "drive")),
     RouterEntry(name="admin_drive_health",         process_groups=_API, tags=("admin", "drive")),
     RouterEntry(name="admin_drive_refresh",        process_groups=_API, tags=("admin", "drive")),

--- a/apps/backend-rag/backend/app/setup/router_registration.py
+++ b/apps/backend-rag/backend/app/setup/router_registration.py
@@ -288,6 +288,7 @@ def include_routers(api: FastAPI) -> None:
 
     # Admin Drive Auth (for system user OAuth)
     from backend.app.routers import (
+        admin_crm_kg,
         admin_drive_auth,
         admin_drive_health,
         admin_drive_refresh,
@@ -295,6 +296,7 @@ def include_routers(api: FastAPI) -> None:
         admin_zoho_auth,
     )
 
+    api.include_router(admin_crm_kg.router)
     api.include_router(admin_drive_auth.router)
     api.include_router(admin_drive_health.router)
     api.include_router(admin_drive_refresh.router)
@@ -400,6 +402,7 @@ def include_light_routers(api: FastAPI) -> None:
     """
     from backend.app.routers import (
         admin_conversation_cleanup,
+        admin_crm_kg,
         admin_drive_auth,
         admin_drive_health,
         admin_drive_refresh,
@@ -590,7 +593,8 @@ def include_light_routers(api: FastAPI) -> None:
     api.include_router(team_drive.router)
     api.include_router(sheets.router)
 
-    # Admin Drive Auth
+    # Admin Drive Auth + CRM KG
+    api.include_router(admin_crm_kg.router)
     api.include_router(admin_drive_auth.router)
     api.include_router(admin_drive_health.router)
     api.include_router(admin_drive_refresh.router)

--- a/apps/backend-rag/backend/services/knowledge_graph/mediated_edges_builder.py
+++ b/apps/backend-rag/backend/services/knowledge_graph/mediated_edges_builder.py
@@ -1,0 +1,247 @@
+"""CRM Knowledge Graph — Tier-B mediated edges builder.
+
+This worker walks the crm_kg_nodes/crm_kg_edges tables and emits edges
+that are not directly produced by document_linker (Tier-A) but can be
+inferred deterministically via SQL JOINs across already-linked nodes.
+
+The three relationship types in scope:
+
+  CONTEMPORANEOUS  — two Documents for the same Client uploaded within
+                     a configurable window (default 7 days). Useful for
+                     grouping a "kit" of docs that arrived together
+                     (e.g. passport + KK + sponsor letter for KITAS).
+
+  COWORKER_AT      — two Person nodes both linked to the same Company
+                     via DESCRIBES edges from Documents. Helps surface
+                     PT PMA director/shareholder structure across
+                     multiple Akta uploads.
+
+  HOUSEHOLD_AT     — two Person nodes both linked to the same Address
+                     (when Address nodes ship in Tier-C; placeholder
+                     here for forward compat).
+
+Why these are NOT Tier-A:
+  Tier-A linker only sees ONE document at a time and can't compare
+  across docs. Tier-B is the cross-document SQL layer.
+
+Why these are NOT Tier-C:
+  No LLM inference needed. These are deterministic property-equality
+  joins. Confidence is 1.0 for exact matches, 0.85 for fuzzy
+  (e.g. CONTEMPORANEOUS where "within 7 days" is a heuristic window).
+
+Idempotency:
+  All emitted edges use ON CONFLICT (source, target, relationship_type)
+  DO UPDATE so re-running the cron is a no-op for already-known edges.
+  Confidence/properties are refreshed on each pass — useful when the
+  source data changes (e.g. doc moved between practices).
+
+Lifecycle:
+  When a source node is soft-deleted (deleted_at IS NOT NULL), edges
+  are NOT auto-cleaned here. PR-D (kg_garbage_collect) handles that
+  separately on a daily cadence.
+
+Performance:
+  Designed to run every 6h via cron. Single-table JOINs on indexed
+  columns (entity_type, client_id, person_uid, company_uid). On 50k
+  CRM nodes the full pass should complete in <30s; we add LIMIT
+  guards anyway in case of runaway query plans.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import asyncpg
+
+logger = logging.getLogger(__name__)
+
+# Cron-time guards — protect against runaway queries on a degraded DB.
+# Soft-fail at limit; resume on next 6h tick.
+_MAX_EDGES_PER_PASS = 10_000
+_CONTEMPORANEOUS_WINDOW_DAYS = 7
+
+# Confidence per edge sub-type. Property-equality matches are 1.0
+# (deterministic). Time-window matches are 0.85 (heuristic).
+_CONF_DETERMINISTIC = 1.0
+_CONF_HEURISTIC_TIME = 0.85
+
+
+async def build_mediated_edges(db_pool: asyncpg.Pool) -> dict[str, Any]:
+    """Run one pass of the mediated edge builder.
+
+    Returns:
+        {
+            "ok": True,
+            "contemporaneous": <int>,
+            "coworker_at": <int>,
+            "elapsed_s": <float>,
+        }
+        or {"ok": False, "error": "<reason>"}
+    """
+    import time
+    started = time.monotonic()
+
+    try:
+        async with db_pool.acquire() as conn:
+            cont_count = await _emit_contemporaneous(conn)
+            coworker_count = await _emit_coworker_at(conn)
+
+        elapsed = time.monotonic() - started
+        result = {
+            "ok": True,
+            "contemporaneous": cont_count,
+            "coworker_at": coworker_count,
+            "elapsed_s": round(elapsed, 2),
+        }
+        logger.info("mediated_edges_builder: %s", result)
+        return result
+
+    except Exception as e:
+        logger.error(
+            "mediated_edges_builder failed: %s", e, exc_info=True,
+        )
+        return {"ok": False, "error": str(e)}
+
+
+async def _emit_contemporaneous(conn: asyncpg.Connection) -> int:
+    """Two crm_document nodes for the same Client, uploaded within
+    _CONTEMPORANEOUS_WINDOW_DAYS, get a CONTEMPORANEOUS edge (undirected,
+    represented as two symmetric directed edges to keep the schema simple).
+
+    Heuristic confidence: 0.85 (time-window match, not property equality).
+
+    Excludes self-pairs and skips if both docs already linked.
+    """
+    sql = """
+    WITH doc_pairs AS (
+        SELECT DISTINCT
+            d1.entity_id AS src_id,
+            d2.entity_id AS tgt_id
+        FROM crm_kg_edges e1
+        JOIN crm_kg_edges e2
+            ON e1.target_entity_id = e2.target_entity_id  -- same Client node
+            AND e1.relationship_type = 'BELONGS_TO'
+            AND e2.relationship_type = 'BELONGS_TO'
+            AND e1.source_entity_id <> e2.source_entity_id
+        JOIN crm_kg_nodes d1
+            ON d1.entity_id = e1.source_entity_id
+            AND d1.entity_type = 'crm_document'
+            AND d1.deleted_at IS NULL
+        JOIN crm_kg_nodes d2
+            ON d2.entity_id = e2.source_entity_id
+            AND d2.entity_type = 'crm_document'
+            AND d2.deleted_at IS NULL
+        WHERE
+            d1.entity_id < d2.entity_id  -- canonical ordering, no dup pairs
+            AND ABS(EXTRACT(EPOCH FROM (d1.created_at - d2.created_at))) <
+                ($1::int * 86400)
+        LIMIT $2
+    )
+    INSERT INTO crm_kg_edges (
+        source_entity_id, target_entity_id, relationship_type,
+        properties, edge_tier, confidence
+    )
+    SELECT
+        src_id, tgt_id, 'CONTEMPORANEOUS',
+        '{}'::jsonb, 'mediated', $3::float
+    FROM doc_pairs
+    ON CONFLICT (source_entity_id, target_entity_id, relationship_type)
+    DO UPDATE SET
+        confidence = EXCLUDED.confidence,
+        edge_tier = EXCLUDED.edge_tier
+    """
+    # The query inserts edges from d1 -> d2 (canonical d1 < d2 ordering).
+    # We do NOT also insert d2 -> d1 because the relationship is symmetric
+    # and downstream graph queries can traverse either direction. Keeps
+    # row count down on a wide pool.
+    result = await conn.execute(
+        sql, _CONTEMPORANEOUS_WINDOW_DAYS, _MAX_EDGES_PER_PASS, _CONF_HEURISTIC_TIME,
+    )
+    # asyncpg returns "INSERT 0 N" — parse the N for row count
+    return _parse_inserted_count(result)
+
+
+async def _emit_coworker_at(conn: asyncpg.Connection) -> int:
+    """Two crm_person nodes linked (via DESCRIBES from any Document) to
+    the same crm_company node get a COWORKER_AT edge.
+
+    Confidence 1.0 — this is a deterministic property-equality match
+    (both persons have a DESCRIBES path to the SAME company_uid).
+
+    Note: in practice, Akta documents typically describe BOTH a Person
+    (the director) AND a Company. So a single Akta produces two
+    DESCRIBES edges from the same doc, and the cron will then derive
+    a Person-COWORKER_AT-Person edge between the two directors.
+    """
+    sql = """
+    WITH person_pairs AS (
+        SELECT DISTINCT
+            p1.entity_id AS src_id,
+            p2.entity_id AS tgt_id,
+            c.entity_id AS company_id
+        FROM crm_kg_edges e1
+        JOIN crm_kg_edges e2
+            ON e1.target_entity_id = e2.target_entity_id  -- same Document
+            AND e1.relationship_type = 'DESCRIBES'
+            AND e2.relationship_type = 'DESCRIBES'
+            AND e1.source_entity_id <> e2.source_entity_id
+        JOIN crm_kg_nodes p1
+            ON p1.entity_id = e1.source_entity_id
+            AND p1.entity_type = 'crm_person'
+            AND p1.deleted_at IS NULL
+        JOIN crm_kg_nodes p2
+            ON p2.entity_id = e2.source_entity_id
+            AND p2.entity_type = 'crm_person'
+            AND p2.deleted_at IS NULL
+        WHERE p1.entity_id < p2.entity_id  -- canonical ordering
+        -- Restrict to person pairs that share a Company via separate edges:
+        AND EXISTS (
+            SELECT 1 FROM crm_kg_edges ec1
+            JOIN crm_kg_edges ec2
+                ON ec1.target_entity_id = ec2.target_entity_id  -- same company
+                AND ec1.relationship_type = 'DESCRIBES'
+                AND ec2.relationship_type = 'DESCRIBES'
+                AND ec1.source_entity_id = p1.entity_id
+                AND ec2.source_entity_id = p2.entity_id
+            WHERE ec1.target_entity_id IN (
+                SELECT entity_id FROM crm_kg_nodes
+                WHERE entity_type = 'crm_company'
+                AND deleted_at IS NULL
+            )
+        )
+        LIMIT $1
+    )
+    INSERT INTO crm_kg_edges (
+        source_entity_id, target_entity_id, relationship_type,
+        properties, edge_tier, confidence
+    )
+    SELECT
+        src_id, tgt_id, 'COWORKER_AT',
+        jsonb_build_object('company_id', company_id::text),
+        'mediated', $2::float
+    FROM person_pairs
+    ON CONFLICT (source_entity_id, target_entity_id, relationship_type)
+    DO UPDATE SET
+        properties = EXCLUDED.properties,
+        confidence = EXCLUDED.confidence,
+        edge_tier = EXCLUDED.edge_tier
+    """
+    result = await conn.execute(sql, _MAX_EDGES_PER_PASS, _CONF_DETERMINISTIC)
+    return _parse_inserted_count(result)
+
+
+def _parse_inserted_count(execute_result: str) -> int:
+    """Parse asyncpg execute() return string ('INSERT 0 N') for inserted rows.
+
+    Returns 0 if format unexpected — this is a metrics-only reading,
+    don't fail the whole cron over a parsing edge case.
+    """
+    try:
+        # Format: 'INSERT 0 12' → 12
+        parts = (execute_result or "").split()
+        if len(parts) >= 3 and parts[0] == "INSERT":
+            return int(parts[2])
+    except (ValueError, IndexError, AttributeError):
+        pass
+    return 0

--- a/apps/backend-rag/backend/tests/services/knowledge_graph/test_mediated_edges_builder.py
+++ b/apps/backend-rag/backend/tests/services/knowledge_graph/test_mediated_edges_builder.py
@@ -1,0 +1,172 @@
+"""Tests for mediated_edges_builder — Tier-B SQL JOIN cross-doc edges."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.services.knowledge_graph.mediated_edges_builder import (
+    _CONF_DETERMINISTIC,
+    _CONF_HEURISTIC_TIME,
+    _CONTEMPORANEOUS_WINDOW_DAYS,
+    _MAX_EDGES_PER_PASS,
+    _parse_inserted_count,
+    build_mediated_edges,
+)
+
+# ─── _parse_inserted_count: defensive parsing ───────────────────────────
+
+
+def test_parse_inserted_count_normal():
+    assert _parse_inserted_count("INSERT 0 12") == 12
+    assert _parse_inserted_count("INSERT 0 0") == 0
+    assert _parse_inserted_count("INSERT 0 9999") == 9999
+
+
+def test_parse_inserted_count_handles_weird_formats():
+    """Don't crash on unexpected execute() return values."""
+    assert _parse_inserted_count("") == 0
+    assert _parse_inserted_count("UPDATE 5") == 0
+    assert _parse_inserted_count("WEIRD") == 0
+    assert _parse_inserted_count("INSERT 0 not_a_number") == 0
+    # asyncpg conventionally returns "INSERT 0 N", but be paranoid
+    assert _parse_inserted_count(None) == 0  # type: ignore[arg-type]
+
+
+# ─── Constants sanity ───────────────────────────────────────────────────
+
+
+def test_constants_have_safe_values():
+    """Sanity-check thresholds — avoid accidental config that runs forever."""
+    assert _MAX_EDGES_PER_PASS > 0
+    assert _MAX_EDGES_PER_PASS <= 100_000  # don't insert more than 100k/pass
+    assert 1 <= _CONTEMPORANEOUS_WINDOW_DAYS <= 30
+    assert _CONF_DETERMINISTIC == 1.0  # property match must be exact
+    assert 0.5 <= _CONF_HEURISTIC_TIME < 1.0  # below deterministic, above noise
+
+
+# ─── build_mediated_edges happy-path + failure modes ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_build_mediated_edges_happy_path():
+    """SQL execute returns 'INSERT 0 N' twice → totals propagated."""
+    conn = AsyncMock()
+    # Two execute() calls inside the function: contemporaneous + coworker
+    conn.execute = AsyncMock(side_effect=["INSERT 0 5", "INSERT 0 3"])
+    pool = _make_pool_mock(conn)
+
+    result = await build_mediated_edges(pool)
+
+    assert result["ok"] is True
+    assert result["contemporaneous"] == 5
+    assert result["coworker_at"] == 3
+    assert result["elapsed_s"] >= 0.0
+    # Two distinct INSERT statements should have run
+    assert conn.execute.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_build_mediated_edges_swallows_db_error():
+    """Any DB exception → ok=False with error message, no raise to caller."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock(side_effect=RuntimeError("PG connection lost"))
+    pool = _make_pool_mock(conn)
+
+    result = await build_mediated_edges(pool)
+
+    assert result["ok"] is False
+    assert "PG connection lost" in result["error"]
+    assert "contemporaneous" not in result  # didn't reach the metrics
+
+
+@pytest.mark.asyncio
+async def test_build_mediated_edges_passes_window_to_sql():
+    """The CONTEMPORANEOUS query must receive the configured window in days."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock(side_effect=["INSERT 0 0", "INSERT 0 0"])
+    pool = _make_pool_mock(conn)
+
+    await build_mediated_edges(pool)
+
+    # First execute() is the contemporaneous query; check its bound params
+    cont_args = conn.execute.call_args_list[0][0]
+    # cont_args = (sql, days, max_edges, confidence)
+    assert cont_args[1] == _CONTEMPORANEOUS_WINDOW_DAYS
+    assert cont_args[2] == _MAX_EDGES_PER_PASS
+    assert cont_args[3] == _CONF_HEURISTIC_TIME
+
+    # Second execute() is COWORKER_AT
+    cow_args = conn.execute.call_args_list[1][0]
+    # cow_args = (sql, max_edges, confidence)
+    assert cow_args[1] == _MAX_EDGES_PER_PASS
+    assert cow_args[2] == _CONF_DETERMINISTIC
+
+
+@pytest.mark.asyncio
+async def test_build_mediated_edges_zero_inserts_is_ok():
+    """No new edges to insert (steady state) is a normal outcome, not error."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock(side_effect=["INSERT 0 0", "INSERT 0 0"])
+    pool = _make_pool_mock(conn)
+
+    result = await build_mediated_edges(pool)
+
+    assert result["ok"] is True
+    assert result["contemporaneous"] == 0
+    assert result["coworker_at"] == 0
+
+
+# ─── SQL contract guards ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_contemporaneous_query_uses_canonical_pair_ordering():
+    """Verify the CONTEMPORANEOUS SQL uses d1 < d2 to dedupe pairs."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock(side_effect=["INSERT 0 0", "INSERT 0 0"])
+    pool = _make_pool_mock(conn)
+
+    await build_mediated_edges(pool)
+
+    # First call → CONTEMPORANEOUS sql
+    cont_sql = conn.execute.call_args_list[0][0][0]
+    assert "CONTEMPORANEOUS" in cont_sql
+    # Canonical ordering pattern (avoids duplicate symmetric pairs)
+    assert "d1.entity_id < d2.entity_id" in cont_sql
+    # Filters deleted nodes
+    assert "deleted_at IS NULL" in cont_sql
+
+
+@pytest.mark.asyncio
+async def test_coworker_query_uses_idempotent_upsert():
+    """COWORKER_AT must use ON CONFLICT to be re-runnable."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock(side_effect=["INSERT 0 0", "INSERT 0 0"])
+    pool = _make_pool_mock(conn)
+
+    await build_mediated_edges(pool)
+
+    cow_sql = conn.execute.call_args_list[1][0][0]
+    assert "COWORKER_AT" in cow_sql
+    assert "ON CONFLICT" in cow_sql
+    assert "DO UPDATE" in cow_sql
+
+
+# ─── Helpers ────────────────────────────────────────────────────────────
+
+
+def _make_pool_mock(conn):
+    """asyncpg.Pool-like mock yielding `conn` from `async with pool.acquire()`."""
+    pool = AsyncMock()
+
+    class _Acquire:
+        async def __aenter__(self):
+            return conn
+
+        async def __aexit__(self, *exc):
+            return False
+
+    pool.acquire = lambda: _Acquire()
+    return pool


### PR DESCRIPTION
## Summary

After PR #578 (linker) and #580 (dispatcher hook), this adds the second tier of the CRM Knowledge Graph: mediated edges across already-linked documents.

## Edge types

- **CONTEMPORANEOUS** — same Client, both docs uploaded within 7 days. Surfaces 'kits' (passport+KK+sponsor for KITAS). Confidence 0.85 (heuristic).
- **COWORKER_AT** — two Persons both DESCRIBES'd alongside the same Company. Surfaces PT PMA director/shareholder structure. Confidence 1.0 (deterministic).

## Components

- `mediated_edges_builder.py` — SQL JOINs only, target <30s on 50k nodes, LIMIT 10k/pass, ON CONFLICT DO UPDATE for idempotency, exception swallowing.
- `admin_crm_kg.py` router — `POST /build-mediated` (background task) + `GET /health` (counts).
- `router_manifest.py` + `router_registration.py` both updated (Sprint 1.B SCAR pattern).

## Cron deployment plan (out of scope, follow-up)

Mini-Pro2 every 6h via curl POST. Background task means cron exits in <1s.

## Test plan

- [x] **9/9 unit tests pass**
- [x] Router manifest parity test passes
- [x] Import chain OK
- [x] No new migration (uses crm_kg_nodes/edges from m167)
- [ ] Post-deploy smoke: `GET /health` + `POST /build-mediated`

## Companion PRs (recently merged)

- #580 (PR-A3 dispatcher hook)
- #578 (PR-A linker)
- #577 (Tier 2 content classifier)
- #576 (OAuth SYSTEM cleanup)