### PR TITLE
feat(crm-kg): garbage collector cron + admin endpoints (PR-D)

### DIFF
--- a/apps/backend-rag/backend/app/routers/admin_crm_kg.py
+++ b/apps/backend-rag/backend/app/routers/admin_crm_kg.py
@@ -1,18 +1,15 @@
-"""Admin endpoints for the CRM Knowledge Graph mediated/thematic builders.
+"""Admin endpoints for the CRM Knowledge Graph workers.
 
 Endpoints exposed:
-  - POST /api/admin/crm-kg/build-mediated  → run Tier-B mediated edge pass
-  - GET  /api/admin/crm-kg/health          → counts of nodes/edges per type
+  - GET  /api/admin/crm-kg/health           → counts of nodes/edges per type
+  - POST /api/admin/crm-kg/build-mediated   → run Tier-B mediated edge pass (PR-B)
+  - POST /api/admin/crm-kg/garbage-collect  → soft-delete orphan nodes,
+                                                hard-delete old edges (PR-D)
 
-Both are admin-API-key-gated via the existing X-API-Key middleware. Designed
-to be invoked by:
-  - Mini-Pro2 cron via curl (every 6h)
-  - Manual ops trigger when populating after a backfill
-  - Future LaunchAgent on Pro/Mini if remote cron fails
-
-This router does NOT call the builder synchronously inline if it could
-take >30s; it delegates to a BackgroundTask so the cron caller gets
-HTTP 200 immediately and can move on.
+All admin-API-key-gated via the existing X-API-Key middleware. Designed
+to be invoked by Mini-Pro2 cron via curl. Background-task pattern: HTTP
+200 returns in <1s, work happens async on the api machine without
+blocking other requests.
 """
 
 from __future__ import annotations
@@ -53,12 +50,40 @@ async def trigger_build_mediated(
     return {"status": "started", "message": "Mediated edge builder running in background"}
 
 
+@router.post("/garbage-collect")
+async def trigger_garbage_collect(
+    request: Request,
+    background_tasks: BackgroundTasks,
+) -> dict[str, Any]:
+    """Trigger one pass of the CRM KG garbage collector (PR-D).
+
+    Soft-deletes nodes whose backing CRM data is gone, hard-deletes
+    edges past grace window. See garbage_collector.py docstring.
+
+    Cron-friendly: returns HTTP 200 immediately. Best-effort behavior.
+    """
+    pool = getattr(request.app.state, "db_pool", None)
+    if not pool:
+        return {"status": "error", "message": "Database pool not available"}
+
+    async def _run() -> None:
+        from backend.services.knowledge_graph.garbage_collector import (
+            garbage_collect,
+        )
+        result = await garbage_collect(pool)
+        logger.info("crm_kg.garbage_collect background result: %s", result)
+
+    background_tasks.add_task(_run)
+    return {"status": "started", "message": "Garbage collector running in background"}
+
+
 @router.get("/health")
 async def crm_kg_health(request: Request) -> dict[str, Any]:
     """Quick counts of crm_kg_nodes and crm_kg_edges by type/tier.
 
-    Useful for monitoring growth and verifying the linker / builders
-    are actually emitting data.
+    Splits live vs soft_deleted node counts so PR-D's garbage collector
+    progress is visible. Useful for monitoring dashboards and verifying
+    the linker / builders are actually emitting data.
     """
     pool = getattr(request.app.state, "db_pool", None)
     if not pool:
@@ -90,9 +115,11 @@ async def crm_kg_health(request: Request) -> dict[str, Any]:
 
             nodes_by_type = await conn.fetch(
                 """
-                SELECT entity_type, COUNT(*) AS cnt
+                SELECT
+                    entity_type,
+                    COUNT(*) FILTER (WHERE deleted_at IS NULL) AS live,
+                    COUNT(*) FILTER (WHERE deleted_at IS NOT NULL) AS soft_deleted
                 FROM crm_kg_nodes
-                WHERE deleted_at IS NULL
                 GROUP BY entity_type
                 ORDER BY entity_type
                 """,
@@ -109,7 +136,11 @@ async def crm_kg_health(request: Request) -> dict[str, Any]:
         return {
             "status": "healthy",
             "nodes_by_type": {
-                row["entity_type"]: row["cnt"] for row in nodes_by_type
+                row["entity_type"]: {
+                    "live": row["live"],
+                    "soft_deleted": row["soft_deleted"],
+                }
+                for row in nodes_by_type
             },
             "edges_by_tier": [
                 {

--- a/apps/backend-rag/backend/services/knowledge_graph/garbage_collector.py
+++ b/apps/backend-rag/backend/services/knowledge_graph/garbage_collector.py
@@ -1,0 +1,234 @@
+"""CRM Knowledge Graph — Garbage Collector
+
+Soft-deletes crm_kg_nodes when their backing CRM data has been removed,
+keeping the graph in sync with the source-of-truth tables.
+
+Two phases:
+
+  Phase 1 — Soft delete: mark `deleted_at = NOW()` on nodes whose backing
+            row in `documents` / `clients` / `practices` is gone (or
+            already soft-deleted there). Edges are NOT removed yet —
+            they remain queryable for audit/recovery for a grace window.
+
+  Phase 2 — Hard delete edges: drop `crm_kg_edges` rows whose source OR
+            target node has been soft-deleted for more than the grace
+            window (default 30 days). Hard delete cascades on the FK,
+            so the edges go automatically when we hard-delete the nodes
+            themselves — but we do edges first to keep the graph
+            queryable from non-deleted neighbors.
+
+Rationale for grace window:
+  - 30 days lets ops recover from accidental Drive deletions
+  - Aligns with typical UU PDP retention review cadence
+  - Hard delete is irreversible; soft is the safe default
+
+Idempotency:
+  Safe to run on every cron tick — soft-deleting an already-soft-deleted
+  node is a no-op (WHERE deleted_at IS NULL filters them out).
+
+Failure mode:
+  Best-effort. Any DB error is logged and swallowed. The next cron tick
+  retries from a clean slate; no partial state can corrupt the graph
+  because each phase is its own SQL statement.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import asyncpg
+
+logger = logging.getLogger(__name__)
+
+# Grace window between soft-delete and hard-delete. Generous default —
+# 30 days lets a careless Drive deletion be recovered without losing the
+# graph context (audit trail, related-doc edges still queryable).
+_HARD_DELETE_GRACE_DAYS = 30
+
+# Per-pass safety caps — protect against a runaway single transaction
+# locking the table for minutes if something pathological happens
+# (e.g., 100k orphan rows after a bulk Drive cleanup).
+_MAX_SOFT_DELETE_PER_PASS = 5_000
+_MAX_HARD_DELETE_PER_PASS = 5_000
+
+
+async def garbage_collect(db_pool: asyncpg.Pool) -> dict[str, Any]:
+    """Run a single pass of the garbage collector.
+
+    Returns:
+        {
+            "ok": True,
+            "soft_deleted": {
+                "documents": <int>,
+                "clients": <int>,
+                "practices": <int>,
+            },
+            "hard_deleted_edges": <int>,
+            "elapsed_s": <float>,
+        }
+        or {"ok": False, "error": "<reason>"}
+    """
+    started = time.monotonic()
+
+    try:
+        async with db_pool.acquire() as conn:
+            soft_doc = await _soft_delete_orphan_documents(conn)
+            soft_cli = await _soft_delete_orphan_clients(conn)
+            soft_prac = await _soft_delete_orphan_practices(conn)
+            hard_edges = await _hard_delete_old_edges(conn)
+
+        elapsed = time.monotonic() - started
+        result = {
+            "ok": True,
+            "soft_deleted": {
+                "documents": soft_doc,
+                "clients": soft_cli,
+                "practices": soft_prac,
+            },
+            "hard_deleted_edges": hard_edges,
+            "elapsed_s": round(elapsed, 2),
+        }
+        logger.info("crm_kg garbage_collect: %s", result)
+        return result
+
+    except Exception as e:
+        logger.error(
+            "crm_kg garbage_collect failed: %s", e, exc_info=True,
+        )
+        return {"ok": False, "error": str(e)}
+
+
+async def _soft_delete_orphan_documents(conn: asyncpg.Connection) -> int:
+    """Soft-delete crm_document nodes whose file_id is gone from documents.
+
+    A row is "gone" if either:
+      - documents row no longer exists for that file_id, OR
+      - documents.is_archived = true (existing CRM convention)
+
+    The node remains in the graph (queryable) until the grace window
+    expires and _hard_delete_old_edges fires. Source-of-truth is the
+    `documents` table; the graph just lags behind in soft-delete state.
+    """
+    sql = """
+    UPDATE crm_kg_nodes
+    SET deleted_at = NOW(), updated_at = NOW()
+    WHERE entity_id IN (
+        SELECT n.entity_id
+        FROM crm_kg_nodes n
+        WHERE n.entity_type = 'crm_document'
+          AND n.deleted_at IS NULL
+          AND n.file_id IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1 FROM documents d
+              WHERE d.file_id = n.file_id
+                AND COALESCE(d.is_archived, FALSE) = FALSE
+          )
+        LIMIT $1
+    )
+    """
+    result = await conn.execute(sql, _MAX_SOFT_DELETE_PER_PASS)
+    return _parse_updated_count(result)
+
+
+async def _soft_delete_orphan_clients(conn: asyncpg.Connection) -> int:
+    """Soft-delete crm_client nodes whose clients row is soft-deleted."""
+    sql = """
+    UPDATE crm_kg_nodes
+    SET deleted_at = NOW(), updated_at = NOW()
+    WHERE entity_id IN (
+        SELECT n.entity_id
+        FROM crm_kg_nodes n
+        WHERE n.entity_type = 'crm_client'
+          AND n.deleted_at IS NULL
+          AND n.client_id IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1 FROM clients c
+              WHERE c.id = n.client_id
+                AND c.deleted_at IS NULL
+          )
+        LIMIT $1
+    )
+    """
+    result = await conn.execute(sql, _MAX_SOFT_DELETE_PER_PASS)
+    return _parse_updated_count(result)
+
+
+async def _soft_delete_orphan_practices(conn: asyncpg.Connection) -> int:
+    """Soft-delete crm_practice nodes whose practices row is missing.
+
+    practices table convention varies (some installs have deleted_at,
+    others don't) — we just check existence by id.
+    """
+    sql = """
+    UPDATE crm_kg_nodes
+    SET deleted_at = NOW(), updated_at = NOW()
+    WHERE entity_id IN (
+        SELECT n.entity_id
+        FROM crm_kg_nodes n
+        WHERE n.entity_type = 'crm_practice'
+          AND n.deleted_at IS NULL
+          AND n.practice_id IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1 FROM practices p
+              WHERE p.id = n.practice_id
+          )
+        LIMIT $1
+    )
+    """
+    result = await conn.execute(sql, _MAX_SOFT_DELETE_PER_PASS)
+    return _parse_updated_count(result)
+
+
+async def _hard_delete_old_edges(conn: asyncpg.Connection) -> int:
+    """Hard-delete edges whose source or target node has been soft-deleted
+    for more than the grace window. The cascading FK on crm_kg_edges
+    would do this automatically when we eventually hard-delete the nodes,
+    but we run it explicitly so edges go away on a predictable cadence
+    regardless of when (or if) the nodes are physically removed.
+
+    NB: we do NOT hard-delete the nodes themselves yet. Audit recovery
+    can still resurrect a soft-deleted node by clearing deleted_at,
+    but only re-running the linker will rebuild its edges.
+    """
+    sql = """
+    DELETE FROM crm_kg_edges
+    WHERE relationship_id IN (
+        SELECT e.relationship_id
+        FROM crm_kg_edges e
+        JOIN crm_kg_nodes ns ON ns.entity_id = e.source_entity_id
+        JOIN crm_kg_nodes nt ON nt.entity_id = e.target_entity_id
+        WHERE
+            (ns.deleted_at IS NOT NULL AND ns.deleted_at < NOW() - ($1 || ' days')::interval)
+            OR
+            (nt.deleted_at IS NOT NULL AND nt.deleted_at < NOW() - ($1 || ' days')::interval)
+        LIMIT $2
+    )
+    """
+    result = await conn.execute(
+        sql, str(_HARD_DELETE_GRACE_DAYS), _MAX_HARD_DELETE_PER_PASS,
+    )
+    return _parse_deleted_count(result)
+
+
+def _parse_updated_count(execute_result: str) -> int:
+    """Parse asyncpg execute() return string ('UPDATE N') for row count."""
+    try:
+        parts = (execute_result or "").split()
+        if len(parts) >= 2 and parts[0] == "UPDATE":
+            return int(parts[1])
+    except (ValueError, IndexError, AttributeError):
+        pass
+    return 0
+
+
+def _parse_deleted_count(execute_result: str) -> int:
+    """Parse asyncpg execute() return string ('DELETE N') for row count."""
+    try:
+        parts = (execute_result or "").split()
+        if len(parts) >= 2 and parts[0] == "DELETE":
+            return int(parts[1])
+    except (ValueError, IndexError, AttributeError):
+        pass
+    return 0

--- a/apps/backend-rag/backend/tests/services/knowledge_graph/test_garbage_collector.py
+++ b/apps/backend-rag/backend/tests/services/knowledge_graph/test_garbage_collector.py
@@ -1,0 +1,203 @@
+"""Tests for crm_kg garbage_collector — orphan node soft-delete + edge GC."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.services.knowledge_graph.garbage_collector import (
+    _HARD_DELETE_GRACE_DAYS,
+    _MAX_HARD_DELETE_PER_PASS,
+    _MAX_SOFT_DELETE_PER_PASS,
+    _parse_deleted_count,
+    _parse_updated_count,
+    garbage_collect,
+)
+
+# ─── Defensive parsers ──────────────────────────────────────────────────
+
+
+def test_parse_updated_count_normal():
+    assert _parse_updated_count("UPDATE 0") == 0
+    assert _parse_updated_count("UPDATE 7") == 7
+    assert _parse_updated_count("UPDATE 9999") == 9999
+
+
+def test_parse_updated_count_handles_garbage():
+    assert _parse_updated_count("") == 0
+    assert _parse_updated_count("INSERT 0 5") == 0  # wrong verb
+    assert _parse_updated_count("UPDATE not_a_number") == 0
+    assert _parse_updated_count(None) == 0  # type: ignore[arg-type]
+
+
+def test_parse_deleted_count_normal():
+    assert _parse_deleted_count("DELETE 0") == 0
+    assert _parse_deleted_count("DELETE 42") == 42
+
+
+def test_parse_deleted_count_handles_garbage():
+    assert _parse_deleted_count("") == 0
+    assert _parse_deleted_count("UPDATE 5") == 0  # wrong verb
+    assert _parse_deleted_count(None) == 0  # type: ignore[arg-type]
+
+
+# ─── Constants sanity ───────────────────────────────────────────────────
+
+
+def test_grace_days_is_safe_default():
+    """Window must be long enough for ops recovery, not too long for stale."""
+    assert 7 <= _HARD_DELETE_GRACE_DAYS <= 90
+
+
+def test_max_per_pass_is_bounded():
+    """Per-pass cap protects against runaway transactions."""
+    assert 0 < _MAX_SOFT_DELETE_PER_PASS <= 100_000
+    assert 0 < _MAX_HARD_DELETE_PER_PASS <= 100_000
+
+
+# ─── garbage_collect happy-path + failure modes ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_garbage_collect_happy_path():
+    """4 SQL statements (3 soft + 1 hard) → counts aggregated in result."""
+    conn = AsyncMock()
+    # Order matches function: orphan_documents, orphan_clients,
+    # orphan_practices, hard_delete_old_edges
+    conn.execute = AsyncMock(side_effect=[
+        "UPDATE 3",   # documents
+        "UPDATE 1",   # clients
+        "UPDATE 2",   # practices
+        "DELETE 7",   # edges
+    ])
+    pool = _make_pool_mock(conn)
+
+    result = await garbage_collect(pool)
+
+    assert result["ok"] is True
+    assert result["soft_deleted"]["documents"] == 3
+    assert result["soft_deleted"]["clients"] == 1
+    assert result["soft_deleted"]["practices"] == 2
+    assert result["hard_deleted_edges"] == 7
+    assert conn.execute.call_count == 4
+
+
+@pytest.mark.asyncio
+async def test_garbage_collect_swallows_db_error():
+    """DB exception → ok=False with error message, no raise."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock(side_effect=RuntimeError("PG timeout"))
+    pool = _make_pool_mock(conn)
+
+    result = await garbage_collect(pool)
+
+    assert result["ok"] is False
+    assert "PG timeout" in result["error"]
+    assert "soft_deleted" not in result
+
+
+@pytest.mark.asyncio
+async def test_garbage_collect_zero_orphans_is_normal():
+    """Steady state (no orphans) is the expected case after first cleanup."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock(side_effect=[
+        "UPDATE 0", "UPDATE 0", "UPDATE 0", "DELETE 0",
+    ])
+    pool = _make_pool_mock(conn)
+
+    result = await garbage_collect(pool)
+
+    assert result["ok"] is True
+    assert sum(result["soft_deleted"].values()) == 0
+    assert result["hard_deleted_edges"] == 0
+
+
+@pytest.mark.asyncio
+async def test_garbage_collect_passes_grace_days_to_sql():
+    """The hard-delete query must receive the configured grace days."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock(side_effect=[
+        "UPDATE 0", "UPDATE 0", "UPDATE 0", "DELETE 0",
+    ])
+    pool = _make_pool_mock(conn)
+
+    await garbage_collect(pool)
+
+    # Last call is _hard_delete_old_edges
+    hard_args = conn.execute.call_args_list[3][0]
+    # hard_args = (sql, grace_days_str, max_delete)
+    assert hard_args[1] == str(_HARD_DELETE_GRACE_DAYS)
+    assert hard_args[2] == _MAX_HARD_DELETE_PER_PASS
+
+
+# ─── SQL contract guards ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_documents_query_filters_archived():
+    """Documents that are is_archived = TRUE should also be considered orphan."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock(side_effect=[
+        "UPDATE 0", "UPDATE 0", "UPDATE 0", "DELETE 0",
+    ])
+    pool = _make_pool_mock(conn)
+
+    await garbage_collect(pool)
+
+    docs_sql = conn.execute.call_args_list[0][0][0]
+    assert "crm_document" in docs_sql
+    assert "is_archived" in docs_sql
+    # Must filter live nodes only (don't re-soft-delete already deleted)
+    assert "deleted_at IS NULL" in docs_sql
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_clients_respects_clients_deleted_at():
+    """clients table uses soft-delete via deleted_at — same pattern."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock(side_effect=[
+        "UPDATE 0", "UPDATE 0", "UPDATE 0", "DELETE 0",
+    ])
+    pool = _make_pool_mock(conn)
+
+    await garbage_collect(pool)
+
+    clients_sql = conn.execute.call_args_list[1][0][0]
+    assert "crm_client" in clients_sql
+    assert "c.deleted_at IS NULL" in clients_sql
+
+
+@pytest.mark.asyncio
+async def test_hard_delete_edges_uses_grace_window():
+    """Edge GC must use NOW() - interval to filter expired soft-deletes."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock(side_effect=[
+        "UPDATE 0", "UPDATE 0", "UPDATE 0", "DELETE 0",
+    ])
+    pool = _make_pool_mock(conn)
+
+    await garbage_collect(pool)
+
+    edges_sql = conn.execute.call_args_list[3][0][0]
+    assert "DELETE FROM crm_kg_edges" in edges_sql
+    assert "deleted_at IS NOT NULL" in edges_sql
+    # Interval expression for grace window
+    assert "interval" in edges_sql.lower()
+
+
+# ─── Helpers ────────────────────────────────────────────────────────────
+
+
+def _make_pool_mock(conn):
+    pool = AsyncMock()
+
+    class _Acquire:
+        async def __aenter__(self):
+            return conn
+
+        async def __aexit__(self, *exc):
+            return False
+
+    pool.acquire = lambda: _Acquire()
+    return pool


### PR DESCRIPTION
## Summary

Closes lifecycle gap in CRM Knowledge Graph: cleans up `crm_kg_nodes` when their backing CRM data (documents/clients/practices) is gone.

## Two-phase strategy

- **Phase 1 — soft delete**: mark `deleted_at` on nodes whose backing row is missing or archived. Edges remain queryable for grace window so audits/recovery still work.
- **Phase 2 — hard delete edges**: drop `crm_kg_edges` rows whose endpoint nodes have been soft-deleted >30 days. Nodes themselves stay soft-deleted (recoverable) but edges go.

## Components

- `garbage_collector.py` — 4-phase SQL orchestration (3 soft-delete + 1 hard-delete-edges), LIMIT 5k/phase guards, best-effort with exception swallowing, idempotent re-runs.
- `admin_crm_kg.py` — `POST /api/admin/crm-kg/garbage-collect` (background task) + `GET /health` (live + soft_deleted counts).
- `router_manifest.py` + `router_registration.py` updated.

## Note on overlap with PR #581 (PR-B)

Both PRs add endpoints to `admin_crm_kg.py`. They are **additive only** (different endpoint paths, no conflicting code). Merge order is independent — whichever lands second will need a tiny rebase to combine the imports.

## Cron deployment plan (follow-up)

Mini-Pro2 daily 03:00 WITA via `curl POST /api/admin/crm-kg/garbage-collect`.

## Test plan

- [x] **13/13 unit tests pass**
- [x] Syntax: all files parse
- [x] No new migration (uses m167 tables)
- [x] SQL contract guards: archived check, c.deleted_at filter, interval syntax
- [ ] Post-deploy: GET /health shows live + soft_deleted counts; POST /garbage-collect smoke test

## Companion merged PRs (Brain centripetal series)

- #580 (PR-A3 dispatcher hook)
- #578 (PR-A linker)
- #577 (Tier 2 content classifier)
- #576 (OAuth SYSTEM cleanup)