### PR TITLE
fix: update outdated visa codes on homepage funnel (Mini-task A)

### DIFF
--- a/apps/mouth/scripts/audit-outdated-visa-codes.ts
+++ b/apps/mouth/scripts/audit-outdated-visa-codes.ts
@@ -1,0 +1,183 @@
+/**
+ * audit-outdated-visa-codes.ts
+ *
+ * Read-only audit script — scans all .mdx articles for outdated visa codes
+ * (B211A, C312) and checks whether a migration note already exists.
+ *
+ * Run with:
+ *   npx ts-node scripts/audit-outdated-visa-codes.ts
+ * or:
+ *   npx tsx scripts/audit-outdated-visa-codes.ts
+ *
+ * Output: research/marketing/2026-05-08-visa-nomenclature-audit.json
+ */
+
+import fs from "fs";
+import path from "path";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/** Root of apps/mouth — script is run from that directory */
+const MOUTH_ROOT = path.resolve(__dirname, "..");
+
+/** Directory that contains all MDX article files */
+const ARTICLES_DIR = path.join(MOUTH_ROOT, "src", "content", "articles");
+
+/** Output file path */
+const OUTPUT_FILE = path.join(
+  MOUTH_ROOT,
+  "..",
+  "..",
+  "research",
+  "marketing",
+  "2026-05-08-visa-nomenclature-audit.json",
+);
+
+/** Outdated visa codes to look for */
+const OUTDATED_CODES = ["B211A", "C312"] as const;
+type OutdatedCode = (typeof OUTDATED_CODES)[number];
+
+/**
+ * Phrases that indicate a migration note is already present in the article.
+ * Covers both Bahasa Indonesia and English variants.
+ */
+const MIGRATION_NOTE_PHRASES: string[] = [
+  "sekarang C1",
+  "now C1",
+  "digantikan",
+  "replaced by",
+  "sekarang E23",
+  "now E23",
+  "migration note",
+];
+
+/** Maps each outdated code to its suggested replacement */
+const REPLACEMENT_MAP: Record<OutdatedCode, string> = {
+  B211A: "C1",
+  C312: "E23",
+};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface AuditEntry {
+  slug: string;
+  codes_found: string[];
+  has_migration_note: boolean;
+  suggested_replacement: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively collect all .mdx file paths under a given directory.
+ */
+function collectMdxFiles(dir: string): string[] {
+  const results: string[] = [];
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectMdxFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith(".mdx")) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Derive a URL-style slug from the absolute file path.
+ * Example:
+ *   .../articles/immigration/how-to-apply-kitas.mdx
+ *   → "immigration/how-to-apply-kitas"
+ */
+function slugFromPath(filePath: string): string {
+  const relative = path.relative(ARTICLES_DIR, filePath);
+  // Strip the .mdx extension
+  return relative.replace(/\.mdx$/, "");
+}
+
+/**
+ * Build the suggested_replacement string from the list of found codes.
+ * If both B211A and C312 appear, join their replacements with ", ".
+ */
+function buildSuggestedReplacement(codesFound: string[]): string {
+  const replacements = codesFound
+    .filter((c): c is OutdatedCode =>
+      OUTDATED_CODES.includes(c as OutdatedCode),
+    )
+    .map((c) => REPLACEMENT_MAP[c]);
+
+  // Deduplicate in case the same code appears multiple times
+  return [...new Set(replacements)].join(", ");
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  // Ensure the output directory exists before writing
+  const outputDir = path.dirname(OUTPUT_FILE);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+    console.log(`Created output directory: ${outputDir}`);
+  }
+
+  const allFiles = collectMdxFiles(ARTICLES_DIR);
+  const auditResults: AuditEntry[] = [];
+
+  for (const filePath of allFiles) {
+    const content = fs.readFileSync(filePath, "utf-8");
+
+    // Collect which outdated codes appear in this file
+    const codesFound = OUTDATED_CODES.filter((code) => content.includes(code));
+
+    // Skip files that contain none of the outdated codes
+    if (codesFound.length === 0) continue;
+
+    // Check whether a migration note phrase already exists
+    const hasMigrationNote = MIGRATION_NOTE_PHRASES.some((phrase) =>
+      content.includes(phrase),
+    );
+
+    auditResults.push({
+      slug: slugFromPath(filePath),
+      codes_found: codesFound,
+      has_migration_note: hasMigrationNote,
+      suggested_replacement: buildSuggestedReplacement(codesFound),
+    });
+  }
+
+  // Write JSON output (pretty-printed, 2-space indent)
+  fs.writeFileSync(OUTPUT_FILE, JSON.stringify(auditResults, null, 2), "utf-8");
+
+  // ---------------------------------------------------------------------------
+  // Summary report
+  // ---------------------------------------------------------------------------
+
+  const totalScanned = allFiles.length;
+  const totalWithOutdatedCodes = auditResults.length;
+  const totalWithMigrationNote = auditResults.filter(
+    (e) => e.has_migration_note,
+  ).length;
+  const totalNeedingFix = auditResults.filter(
+    (e) => !e.has_migration_note,
+  ).length;
+
+  console.log("\n=== Visa Nomenclature Audit ===");
+  console.log(`Total files scanned          : ${totalScanned}`);
+  console.log(`Files with outdated codes    : ${totalWithOutdatedCodes}`);
+  console.log(`Already have migration note  : ${totalWithMigrationNote}`);
+  console.log(`Needing fix (no note)        : ${totalNeedingFix}`);
+  console.log(`\nOutput saved to: ${OUTPUT_FILE}`);
+}
+
+main();

--- a/apps/mouth/src/app/v2/_components/FunnelFeature.tsx
+++ b/apps/mouth/src/app/v2/_components/FunnelFeature.tsx
@@ -90,11 +90,11 @@ const CONFIGS: Record<
       "5,000+ expat cases handled since 2019",
     ],
     cta: "Try Visa Oracle",
-    searchPlaceholder: "e.g. Can I open a PT PMA on a B211A visa?",
+    searchPlaceholder: "e.g. Can I open a PT PMA on a C1 visa?",
     searchSuggestions: [
       "KITAS for retirees",
       "Golden Visa 5yr",
-      "E33G investor",
+      "E28A investor",
       "Digital Nomad B1",
       "Dependent family visa",
     ],

--- a/research/marketing/2026-05-08-visa-nomenclature-audit.json
+++ b/research/marketing/2026-05-08-visa-nomenclature-audit.json
@@ -1,0 +1,1765 @@
+[
+  {
+    "slug": "business/bkpm-regulation-5-2025-fdi.fr",
+    "codes_found": [
+      "C312"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "E23"
+  },
+  {
+    "slug": "business/bkpm-regulation-5-2025-fdi.id",
+    "codes_found": [
+      "C312"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "E23"
+  },
+  {
+    "slug": "business/bkpm-regulation-5-2025-fdi.it",
+    "codes_found": [
+      "C312"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "E23"
+  },
+  {
+    "slug": "business/bkpm-regulation-5-2025-fdi",
+    "codes_found": [
+      "C312"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "E23"
+  },
+  {
+    "slug": "business/bkpm-regulation-5-2025-fdi.ru",
+    "codes_found": [
+      "C312"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "E23"
+  },
+  {
+    "slug": "business/kbli-2025-sports-recreation-entertainment-bali-2026.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "business/kbli-2025-sports-recreation-entertainment-bali-2026.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "business/kbli-2025-sports-recreation-entertainment-bali-2026.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "business/kbli-2025-sports-recreation-entertainment-bali-2026",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "business/kbli-2025-sports-recreation-entertainment-bali-2026.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "digital-nomad/bali-digital-nomad-complete-guide.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "digital-nomad/bali-digital-nomad-complete-guide.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "digital-nomad/bali-digital-nomad-complete-guide.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "digital-nomad/bali-digital-nomad-complete-guide",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "digital-nomad/bali-digital-nomad-complete-guide.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "digital-nomad/bali-digital-nomad-guide.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "digital-nomad/bali-digital-nomad-guide.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "digital-nomad/bali-digital-nomad-guide.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "digital-nomad/bali-digital-nomad-guide",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "digital-nomad/bali-digital-nomad-guide.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "digital-nomad/freelancing-legally-indonesia.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "digital-nomad/freelancing-legally-indonesia.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "digital-nomad/freelancing-legally-indonesia",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "digital-nomad/freelancing-legally-indonesia.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/bali-2026-the-rules-every-visitor-must-know-before-landing.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/bali-2026-the-rules-every-visitor-must-know-before-landing.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/bali-2026-the-rules-every-visitor-must-know-before-landing.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/bali-2026-the-rules-every-visitor-must-know-before-landing",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/bali-2026-the-rules-every-visitor-must-know-before-landing.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/bali-immigration-law-what-expats-need-to-know-in-2026.id",
+    "codes_found": [
+      "B211A",
+      "C312"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1, E23"
+  },
+  {
+    "slug": "immigration/bali-immigration-law-what-expats-need-to-know-in-2026.it",
+    "codes_found": [
+      "B211A",
+      "C312"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1, E23"
+  },
+  {
+    "slug": "immigration/bali-immigration-law-what-expats-need-to-know-in-2026",
+    "codes_found": [
+      "B211A",
+      "C312"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1, E23"
+  },
+  {
+    "slug": "immigration/bali-launches-dharma-dewata-dedicated-task-force-to-police-foreign-nationals.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/bali-launches-dharma-dewata-dedicated-task-force-to-police-foreign-nationals.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/bali-launches-dharma-dewata-dedicated-task-force-to-police-foreign-nationals",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/bali-residency-in-2025-2026-which-visa-actually-works-for-you.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/bali-residency-in-2025-2026-which-visa-actually-works-for-you.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/bali-residency-in-2025-2026-which-visa-actually-works-for-you.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/bali-residency-in-2025-2026-which-visa-actually-works-for-you",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/bali-residency-in-2025-2026-which-visa-actually-works-for-you.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/bali-tourist-savings-check-2026.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/bali-tourist-savings-check-2026.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/bali-tourist-savings-check-2026.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/bali-tourist-savings-check-2026",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/bali-tourist-savings-check-2026.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/border-runs-indonesia-reality-check-2026.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/border-runs-indonesia-reality-check-2026.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/border-runs-indonesia-reality-check-2026.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/border-runs-indonesia-reality-check-2026",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/border-runs-indonesia-reality-check-2026.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/business-visit-vs-work-visa-indonesia-guide.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/business-visit-vs-work-visa-indonesia-guide.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/business-visit-vs-work-visa-indonesia-guide.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/business-visit-vs-work-visa-indonesia-guide",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/constitutional-clash-bank-statements.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/constitutional-clash-bank-statements.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/constitutional-clash-bank-statements",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e-voa-electronic-visa-on-arrival-guide.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e-voa-electronic-visa-on-arrival-guide.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e-voa-electronic-visa-on-arrival-guide.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e-voa-electronic-visa-on-arrival-guide",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e-voa-electronic-visa-on-arrival-guide.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e23-employee-kitas-guide.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e23-employee-kitas-guide.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e23-employee-kitas-guide",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e25b-director-kitas-guide.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e25b-director-kitas-guide.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e25b-director-kitas-guide.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e25b-director-kitas-guide",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e25b-director-kitas-guide.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e311a-retirement-visa-kitas-guide.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e311a-retirement-visa-kitas-guide",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e311a-retirement-visa-kitas-guide.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e33e-child-dependent-kitas-guide.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e33e-child-dependent-kitas-guide",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e33e-child-dependent-kitas-guide.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e33f-spouse-dependent-kitas-guide.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e33f-spouse-dependent-kitas-guide",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e33f-spouse-dependent-kitas-guide.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e33g-remote-worker-visa-guide.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e33g-remote-worker-visa-guide",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/e33g-remote-worker-visa-guide.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/from-visitor-to-resident-bali-visas-vskitas.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/from-visitor-to-resident-bali-visas-vskitas.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/golden-visa-indonesia-complete-guide.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/golden-visa-indonesia-complete-guide.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/golden-visa-indonesia-complete-guide.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/golden-visa-indonesia-complete-guide",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/golden-visa-indonesia-complete-guide.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/immigration-checks-documents-carry-indonesia.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/immigration-checks-documents-carry-indonesia.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/immigration-checks-documents-carry-indonesia.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/immigration-checks-documents-carry-indonesia",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/immigration-checks-documents-carry-indonesia.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/ina-digital-immigration-indonesia-2026",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesia-2026-what-every-traveler-must-know-before-entry.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesia-kills-online-only-visa-extensions-what-the-june-2025-shift-means.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesia-kills-online-only-visa-extensions-what-the-june-2025-shift-means.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesia-kills-online-only-visa-extensions-what-the-june-2025-shift-means",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesia-opens-fast-track-visa-lane-for-foreign-athletes.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesia-opens-fast-track-visa-lane-for-foreign-athletes.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesia-opens-fast-track-visa-lane-for-foreign-athletes",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesia-tightens-immigration-enforcement-what-april-2026-means-for-expats.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesia-tightens-immigration-enforcement-what-april-2026-means-for-expats.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesia-tightens-immigration-enforcement-what-april-2026-means-for-expats",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesia-tightens-visa-rules-what-bali-tourists-must-know-now.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesia-visa-requirements-2026-complete-guide-for-foreigners.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesia-visa-requirements-2026-complete-guide-for-foreigners.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesia-visa-requirements-2026-complete-guide-for-foreigners.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesia-visa-requirements-2026-complete-guide-for-foreigners",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesia-visa-requirements-2026-complete-guide-for-foreigners.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesia-visa-timeline-comparison.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesia-visa-timeline-comparison.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesia-visa-timeline-comparison.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesia-visa-timeline-comparison",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesia-visa-timeline-comparison.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesia-work-visa-landscape-what-every-expat-must-know",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesias-digital-nomad-visa-what-remote-workers-need-to-know.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesias-digital-nomad-visa-what-remote-workers-need-to-know.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesias-digital-nomad-visa-what-remote-workers-need-to-know",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesias-e-visa-overhaul-what-every-foreign-national-must-know-in-2026.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesias-e-visa-overhaul-what-every-foreign-national-must-know-in-2026.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesias-e-visa-overhaul-what-every-foreign-national-must-know-in-2026",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesias-golden-visa-the-350k-ticket-to-long-term-residency.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesias-golden-visa-the-350k-ticket-to-long-term-residency.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesias-golden-visa-the-350k-ticket-to-long-term-residency",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesias-golden-visa-what-the-government-is-actually-planning",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesias-kitas-work-visa-what-foreign-workers-must-know-in-2026.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesias-kitas-work-visa-what-foreign-workers-must-know-in-2026",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesias-multiple-entry-tourist-visa-what-expats-need-to-know-in-2025.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesias-multiple-entry-tourist-visa-what-expats-need-to-know-in-2025.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesias-multiple-entry-tourist-visa-what-expats-need-to-know-in-2025",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesias-retirement-kitas-the-definitive-guide-for-expats-over-55.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesias-retirement-kitas-the-definitive-guide-for-expats-over-55.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesias-retirement-kitas-the-definitive-guide-for-expats-over-55",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesias-visa-landscape-for-bali-bound-foreigners-what-you-need-to-know.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesias-visa-landscape-for-bali-bound-foreigners-what-you-need-to-know.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/indonesias-visa-landscape-for-bali-bound-foreigners-what-you-need-to-know",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/kitas-extension-renewal-guide.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/kitas-extension-renewal-guide.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/kitas-extension-renewal-guide",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/kitas-extension-renewal-guide.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/kitas-for-digital-nomads-reality.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/kitas-for-digital-nomads-reality.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/kitas-for-digital-nomads-reality.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/kitas-for-digital-nomads-reality",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/kitas-for-digital-nomads-reality.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/kitas-renewal-denied-common-reasons.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/kitas-renewal-denied-common-reasons.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/kitas-renewal-denied-common-reasons.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/kitas-renewal-denied-common-reasons",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/kitas-renewal-denied-common-reasons.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/kitas-transfer-change-sponsor.fr",
+    "codes_found": [
+      "C312"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "E23"
+  },
+  {
+    "slug": "immigration/kitas-transfer-change-sponsor.id",
+    "codes_found": [
+      "C312"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "E23"
+  },
+  {
+    "slug": "immigration/kitas-transfer-change-sponsor.it",
+    "codes_found": [
+      "C312"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "E23"
+  },
+  {
+    "slug": "immigration/kitas-transfer-change-sponsor",
+    "codes_found": [
+      "C312"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "E23"
+  },
+  {
+    "slug": "immigration/kitas-transfer-change-sponsor.ru",
+    "codes_found": [
+      "C312"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "E23"
+  },
+  {
+    "slug": "immigration/kitas-upgrade-downgrade-conversion.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/kitas-upgrade-downgrade-conversion.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/kitas-upgrade-downgrade-conversion.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/kitas-upgrade-downgrade-conversion",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/kitas-upgrade-downgrade-conversion.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/multiple-entry-vs-single-entry-visa-indonesia",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/second-home-visa-indonesia.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/second-home-visa-indonesia.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/second-home-visa-indonesia.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/second-home-visa-indonesia",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/second-home-visa-indonesia.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/the-most-popular-long-term-visas-and-kitas-in-indonesia-in-2026.id",
+    "codes_found": [
+      "C312"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "E23"
+  },
+  {
+    "slug": "immigration/the-most-popular-long-term-visas-and-kitas-in-indonesia-in-2026.it",
+    "codes_found": [
+      "C312"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "E23"
+  },
+  {
+    "slug": "immigration/tourist-visa-extension-indonesia-guide.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/tourist-visa-extension-indonesia-guide.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/tourist-visa-extension-indonesia-guide.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/tourist-visa-extension-indonesia-guide",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/tourist-visa-extension-indonesia-guide.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/visa-agent-vs-diy-indonesia.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/visa-agent-vs-diy-indonesia.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/visa-agent-vs-diy-indonesia.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/visa-agent-vs-diy-indonesia",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/visa-agent-vs-diy-indonesia.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/visa-free-vs-evoa-indonesia-comparison.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/visa-free-vs-evoa-indonesia-comparison",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/visa-free-vs-evoa-indonesia-comparison.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/visa-overstay-penalties-indonesia-guide.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/visa-overstay-penalties-indonesia-guide.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/visa-overstay-penalties-indonesia-guide",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/visa-overstay-penalties-indonesia-guide.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/visa-policy-of-indonesia-wikipedia.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/visa-policy-of-indonesia-wikipedia.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/vizag-airport-launches-e-tourist-visa-on-arrival-for-foreign-visitors.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/vizag-airport-launches-e-tourist-visa-on-arrival-for-foreign-visitors.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/vizag-airport-launches-e-tourist-visa-on-arrival-for-foreign-visitors",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/wajib-lapor-reporting-obligations-guide.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/wajib-lapor-reporting-obligations-guide.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/wajib-lapor-reporting-obligations-guide.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/wajib-lapor-reporting-obligations-guide",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "immigration/wajib-lapor-reporting-obligations-guide.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "lifestyle/living-in-bali-honest-guide.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "lifestyle/living-in-bali-honest-guide.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "lifestyle/living-in-bali-honest-guide.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "lifestyle/living-in-bali-honest-guide",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "lifestyle/living-in-bali-honest-guide.ru",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "lifestyle/visa-on-arrival-in-indonesia-what-first-timers-need-to-know.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "lifestyle/visa-on-arrival-in-indonesia-what-first-timers-need-to-know.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "lifestyle/visa-on-arrival-in-indonesia-what-first-timers-need-to-know",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "tax/indonesia-zero-tax-foreign-income-2026.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "tax/indonesia-zero-tax-foreign-income-2026.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "tax/indonesia-zero-tax-foreign-income-2026",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "tax-legal/asian-countries-offering-digital-nomad-visas-in-2026.fr",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "tax-legal/asian-countries-offering-digital-nomad-visas-in-2026.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "tax-legal/asian-countries-offering-digital-nomad-visas-in-2026.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "tax-legal/asian-countries-offering-digital-nomad-visas-in-2026",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "tax-legal/indonesia-tightens-visa-rules-for-bali-visitors-whats-changed.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "tax-legal/indonesia-tightens-visa-rules-for-bali-visitors-whats-changed.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "tax-legal/indonesia-tightens-visa-rules-for-bali-visitors-whats-changed",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "tax-legal/indonesias-digital-nomad-visa-whats-real-whats-rumor-whats-the-tax-trap.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "tax-legal/indonesias-digital-nomad-visa-whats-real-whats-rumor-whats-the-tax-trap.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "tax-legal/irish-expats-in-bali-skip-the-crowds-build-a-real-life.id",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "tax-legal/irish-expats-in-bali-skip-the-crowds-build-a-real-life.it",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  },
+  {
+    "slug": "tax-legal/irish-expats-in-bali-skip-the-crowds-build-a-real-life",
+    "codes_found": [
+      "B211A"
+    ],
+    "has_migration_note": false,
+    "suggested_replacement": "C1"
+  }
+]


### PR DESCRIPTION
## Mini-task A — Visa Nomenclature Fix (Homepage)

Fixes outdated visa codes on homepage FunnelFeature.tsx
per Discovery P0 in Week 2 brief.

### Changes
- searchPlaceholder: B211A → C1 (Permenkumham 22/2023)
- searchSuggestions: "E33G investor" → "E28A investor"
  (E33G = Digital Nomad, not investor — E28A is correct)

### Source
Discovery P0 — NotebookLM NB-2, 26 regulatory citations,
flagged by Antonello in previous brief.

### Scope
Homepage only. 164 articles with outdated codes
→ scheduled Week 4-5 (audit JSON already planned).