### PR TITLE
feat(crm): surface evidence next actions

### DIFF
--- a/.github/workflows/lint-golden-rule-10.yml
+++ b/.github/workflows/lint-golden-rule-10.yml
@@ -33,12 +33,12 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install ripgrep + pytest
+      - name: Install ripgrep + test dependencies
         run: |
           sudo apt-get update -y
           sudo apt-get install -y ripgrep
           python -m pip install --upgrade pip
-          python -m pip install pytest
+          python -m pip install pytest "pydantic>=2.12.5"
 
       - name: Run regression test (single source of truth)
         working-directory: apps/backend-rag

--- a/apps/backend-rag/backend/services/crm/evidence_dossier.py
+++ b/apps/backend-rag/backend/services/crm/evidence_dossier.py
@@ -104,8 +104,9 @@ def _build_company_map(
 
     people = [_person_from_link(row) for row in rows]
     documents = [_document_from_row(doc) for doc in all_docs]
-    evidence_links = _evidence_links(rows, documents)
     tax_owner = _tax_owner(rows)
+    gaps = _gaps(rows, documents, all_kg, tax_owner)
+    evidence_links = _evidence_links(rows, documents)
 
     return TaxCompanyPilotMap(
         key=f"dynamic-{company_id}",
@@ -128,11 +129,12 @@ def _build_company_map(
                 tax_owner=tax_owner,
                 documents=documents,
                 kg_rows=all_kg,
+                gaps=gaps,
             )
             for person in people
         ],
         duplicate_candidates=[],
-        gaps=_gaps(documents, all_kg),
+        gaps=gaps,
         evidence_links=evidence_links,
         ai_recap=_ai_recap(first, people, documents, all_kg),
         read_only=True,
@@ -168,7 +170,8 @@ def _evidence_story(
     tax_owner: str,
     documents: list[TaxCompanyPilotDocument],
     kg_rows: list[dict[str, Any]],
-) -> Any:
+    gaps: list[dict[str, str]],
+) -> dict[str, Any]:
     items = [
         TaxCompanyPilotStoryEvidence(
             label="Person file",
@@ -192,7 +195,7 @@ def _evidence_story(
         ),
         "relationship_path": [person.name, company_name, f"Tax: {tax_owner}"],
         "evidence_items": items,
-        "next_action": _next_action(documents, kg_rows),
+        "next_action": _next_action(documents, kg_rows, gaps),
         "portal_rule": _PORTAL_RULE,
         "team_rule": _TEAM_RULE,
         "confidence": person.relationship_confidence,
@@ -254,12 +257,38 @@ def _evidence_links(
 
 
 def _gaps(
+    rows: list[dict[str, Any]],
     documents: list[TaxCompanyPilotDocument],
     kg_rows: list[dict[str, Any]],
-) -> list[Any]:
+    tax_owner: str,
+) -> list[dict[str, str]]:
     gaps: list[dict[str, str]] = []
+    if tax_owner == "Unassigned tax owner":
+        gaps.append(
+            {
+                "code": "missing_tax_owner",
+                "label": "Assign tax owner before using this story operationally.",
+                "severity": "high",
+            }
+        )
+    if not any(row.get("client_folder_id") for row in rows):
+        gaps.append(
+            {
+                "code": "missing_person_folder",
+                "label": "Connect the canonical person Drive folder.",
+                "severity": "medium",
+            }
+        )
     if not documents:
         gaps.append({"code": "missing_documents", "label": "Attach source documents.", "severity": "high"})
+    if documents and not any(document.group == "company" for document in documents):
+        gaps.append(
+            {
+                "code": "missing_company_registry",
+                "label": "Attach company registry evidence.",
+                "severity": "medium",
+            }
+        )
     if documents and not any(document.group in ("tax", "lkpm", "coretax") for document in documents):
         gaps.append({"code": "missing_tax_trail", "label": "Attach tax or LKPM evidence.", "severity": "medium"})
     if not kg_rows:
@@ -284,7 +313,10 @@ def _ai_recap(
 def _next_action(
     documents: list[TaxCompanyPilotDocument],
     kg_rows: list[dict[str, Any]],
+    gaps: list[dict[str, str]] | None = None,
 ) -> str:
+    if gaps:
+        return gaps[0]["label"]
     if not documents:
         return "Attach source documents before using this company story operationally."
     if not kg_rows:

--- a/apps/backend-rag/backend/services/crm/tax_company_pilot.py
+++ b/apps/backend-rag/backend/services/crm/tax_company_pilot.py
@@ -299,7 +299,7 @@ def _build_evidence_stories(
 def _action_owner(code: str) -> Literal["crm", "tax", "setup"]:
     if "tax" in code or "finance" in code or "family" in code:
         return "tax"
-    if "individual" in code:
+    if "individual" in code or "person" in code or "folder" in code:
         return "crm"
     return "setup"
 

--- a/apps/backend-rag/backend/tests/unit/services/crm/test_evidence_dossier.py
+++ b/apps/backend-rag/backend/tests/unit/services/crm/test_evidence_dossier.py
@@ -114,6 +114,74 @@ async def test_build_evidence_dossiers_falls_back_to_pilot_when_dynamic_empty() 
     assert result[0].evidence_stories
 
 
+@pytest.mark.asyncio
+async def test_build_evidence_dossiers_flags_operational_next_actions() -> None:
+    from backend.services.crm.evidence_dossier import build_evidence_dossiers
+
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(
+        side_effect=[
+            [
+                {
+                    "client_id": 77,
+                    "client_name": "Unassigned Founder",
+                    "client_folder_id": None,
+                    "assigned_to": None,
+                    "tax_consultant": None,
+                    "company_id": 12,
+                    "company_name": "QUIET HOLDING PT",
+                    "company_type": "PT PMA",
+                    "nib": None,
+                    "npwp_company": None,
+                    "kbli_code": None,
+                    "company_status": "active",
+                    "link_role": None,
+                    "is_primary": True,
+                },
+            ],
+            [
+                {
+                    "client_id": 77,
+                    "file_name": "Passport.pdf",
+                    "document_type": "passport",
+                    "document_category": "personal",
+                    "file_id": "passport_file",
+                    "google_drive_file_url": "https://drive.google.com/file/d/passport_file/view",
+                    "file_url": None,
+                    "status": "uploaded",
+                    "client_visible": False,
+                    "ocr_status": "pending",
+                    "expiry_date": None,
+                },
+            ],
+            [],
+        ],
+    )
+    pool = _pool(conn)
+
+    result = await build_evidence_dossiers(pool, companies=["quiet"], limit=5)
+
+    assert len(result) == 1
+    dossier = result[0]
+    gap_codes = {gap.code for gap in dossier.gaps}
+    assert {
+        "missing_tax_owner",
+        "missing_person_folder",
+        "missing_company_registry",
+        "missing_tax_trail",
+        "missing_kg_edges",
+    }.issubset(gap_codes)
+    assert [
+        action.label for action in dossier.next_best_actions[:2]
+    ] == [
+        "Assign tax owner before using this story operationally.",
+        "Connect the canonical person Drive folder.",
+    ]
+    assert dossier.evidence_stories[0].next_action == (
+        "Assign tax owner before using this story operationally."
+    )
+
+
 def _pool(conn: AsyncMock) -> MagicMock:
     pool = MagicMock()
 

--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/BusinessStoryPanel.test.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/BusinessStoryPanel.test.tsx
@@ -168,14 +168,19 @@ describe("BusinessStoryPanel", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("LKPM Q1 2026")).toBeInTheDocument();
     expect(
-      screen.getByText(
+      screen.getAllByText(
         "Confirm current company tax standing before the next LKPM cycle.",
       ),
-    ).toBeInTheDocument();
+    ).toHaveLength(2);
     expect(
       screen.getByText(
         "Team opens Drive evidence from kita. Client portal stays on approved downloads only.",
       ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Next actions")).toBeInTheDocument();
+    expect(screen.getByText("tax")).toBeInTheDocument();
+    expect(
+      screen.getByText("Needed before the recap can be treated as current."),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /open lkpm q1 2026 evidence/i }),

--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/BusinessStoryPanel.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/BusinessStoryPanel.tsx
@@ -313,6 +313,33 @@ export function BusinessStoryPanel({
                   <p className="text-xs leading-5 text-emerald-200">
                     {nextAction}
                   </p>
+                  {map.next_best_actions.length > 0 && (
+                    <div className="pt-2">
+                      <p className="text-[11px] font-semibold uppercase text-[var(--bz-text-2)]">
+                        Next actions
+                      </p>
+                      <ul className="mt-2 space-y-2">
+                        {map.next_best_actions.slice(0, 3).map((action) => (
+                          <li
+                            key={`${map.key}-${action.owner}-${action.label}`}
+                            className="rounded-md border border-white/[0.06] bg-white/[0.03] p-2"
+                          >
+                            <div className="flex items-center justify-between gap-2">
+                              <span className="text-xs font-medium text-[var(--bz-text-1)]">
+                                {action.label}
+                              </span>
+                              <span className="shrink-0 rounded bg-white/[0.08] px-1.5 py-0.5 text-[10px] font-medium text-[var(--bz-text-2)]">
+                                {action.owner}
+                              </span>
+                            </div>
+                            <p className="mt-1 text-[11px] leading-4 text-[var(--bz-text-2)]">
+                              {action.reason}
+                            </p>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
                 </aside>
               </div>
 


### PR DESCRIPTION
## Summary
- add operational next-action gaps to dynamic CRM evidence dossiers
- make the Business Story panel show a compact team action queue
- keep client portal boundary unchanged: Drive evidence remains team-only

## Verification
- cd apps/backend-rag && source .venv/bin/activate && PYTHONPATH=. pytest backend/tests/unit/services/crm/test_evidence_dossier.py backend/tests/unit/routers/test_crm_intelligence.py -q
- cd apps/mouth && npm run test -- --run 'src/app/(workspace)/clients/[id]/components/BusinessStoryPanel.test.tsx'
- cd apps/mouth && npm run typecheck
- cd apps/mouth && npm run build