### PR TITLE
feat(crm): add evidence readiness score

### DIFF
--- a/apps/backend-rag/backend/services/crm/tax_company_pilot.py
+++ b/apps/backend-rag/backend/services/crm/tax_company_pilot.py
@@ -82,6 +82,13 @@ class TaxCompanyPilotNextAction(BaseModel):
     severity: Literal["high", "medium", "low"]
 
 
+class TaxCompanyPilotReadiness(BaseModel):
+    status: Literal["ready", "needs_review", "blocked"]
+    score: int = Field(ge=0, le=100)
+    label: str
+    reasons: list[str] = Field(default_factory=list)
+
+
 class TaxCompanyPilotEvidenceStory(BaseModel):
     person_name: str
     company_name: str
@@ -107,6 +114,7 @@ class TaxCompanyPilotMap(BaseModel):
     person_dossiers: list[TaxCompanyPilotPersonDossier] = Field(default_factory=list)
     evidence_stories: list[TaxCompanyPilotEvidenceStory] = Field(default_factory=list)
     next_best_actions: list[TaxCompanyPilotNextAction] = Field(default_factory=list)
+    readiness: TaxCompanyPilotReadiness | None = None
     business_story: list[str] = Field(default_factory=list)
     duplicate_candidates: list[TaxCompanyPilotDuplicateCandidate]
     gaps: list[TaxCompanyPilotGap]
@@ -122,6 +130,8 @@ class TaxCompanyPilotMap(BaseModel):
             object.__setattr__(self, "evidence_stories", _build_evidence_stories(self))
         if not self.next_best_actions:
             object.__setattr__(self, "next_best_actions", _build_next_best_actions(self))
+        if self.readiness is None:
+            object.__setattr__(self, "readiness", _build_readiness(self))
         if not self.business_story:
             object.__setattr__(self, "business_story", _build_business_story(self))
 
@@ -314,6 +324,64 @@ def _build_next_best_actions(pilot_map: TaxCompanyPilotMap) -> list[TaxCompanyPi
         )
         for gap in pilot_map.gaps
     ]
+
+
+def _readiness_penalty(severity: Literal["high", "medium", "low"]) -> int:
+    if severity == "high":
+        return 45
+    if severity == "medium":
+        return 20
+    return 10
+
+
+def _readiness_reason_priority(action: TaxCompanyPilotNextAction) -> tuple[int, int]:
+    severity_order = {"high": 0, "medium": 1, "low": 2}
+    code_order = {
+        "company": 0,
+        "registry": 0,
+        "tax": 1,
+        "lkpm": 1,
+        "person": 2,
+        "folder": 2,
+        "kg": 3,
+        "linking": 3,
+    }
+    label = action.label.lower()
+    business_order = min(
+        (order for marker, order in code_order.items() if marker in label),
+        default=4,
+    )
+    return severity_order[action.severity], business_order
+
+
+def _build_readiness(pilot_map: TaxCompanyPilotMap) -> TaxCompanyPilotReadiness:
+    if not pilot_map.gaps:
+        return TaxCompanyPilotReadiness(
+            status="ready",
+            score=100,
+            label="Ready to operate",
+            reasons=[
+                "Tax owner, person folder, company evidence, tax trail, and KG links are present."
+            ],
+        )
+
+    score = max(
+        5,
+        100 - sum(_readiness_penalty(gap.severity) for gap in pilot_map.gaps),
+    )
+    status: Literal["needs_review", "blocked"] = (
+        "blocked"
+        if any(gap.severity == "high" for gap in pilot_map.gaps)
+        else "needs_review"
+    )
+    label = "Blocked" if status == "blocked" else "Needs review"
+    actions = sorted(pilot_map.next_best_actions, key=_readiness_reason_priority)
+    return TaxCompanyPilotReadiness(
+        status=status,
+        score=score,
+        label=label,
+        reasons=[action.label for action in actions[:4]],
+    )
 
 
 def _build_business_story(pilot_map: TaxCompanyPilotMap) -> list[str]:

--- a/apps/backend-rag/backend/tests/unit/services/crm/test_evidence_dossier.py
+++ b/apps/backend-rag/backend/tests/unit/services/crm/test_evidence_dossier.py
@@ -82,6 +82,12 @@ async def test_build_evidence_dossiers_reads_db_and_kg_rows() -> None:
     assert dossier.persons[0].name == "Natan Kleimonov"
     assert dossier.persons[0].role == "Director"
     assert {document.group for document in dossier.documents} == {"company", "tax"}
+    assert dossier.readiness.status == "ready"
+    assert dossier.readiness.score == 100
+    assert dossier.readiness.label == "Ready to operate"
+    assert dossier.readiness.reasons == [
+        "Tax owner, person folder, company evidence, tax trail, and KG links are present."
+    ]
     assert dossier.evidence_stories[0].relationship_path == [
         "Natan Kleimonov",
         "OCEAN CLOTHES AND SHOES PT",
@@ -176,6 +182,13 @@ async def test_build_evidence_dossiers_flags_operational_next_actions() -> None:
     ] == [
         "Assign tax owner before using this story operationally.",
         "Connect the canonical person Drive folder.",
+    ]
+    assert dossier.readiness.status == "blocked"
+    assert dossier.readiness.score == 5
+    assert dossier.readiness.label == "Blocked"
+    assert dossier.readiness.reasons[:2] == [
+        "Assign tax owner before using this story operationally.",
+        "Attach company registry evidence.",
     ]
     assert dossier.evidence_stories[0].next_action == (
         "Assign tax owner before using this story operationally."

--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/BusinessStoryPanel.test.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/BusinessStoryPanel.test.tsx
@@ -99,6 +99,12 @@ const giuliaMap: TaxCompanyPilotMap = {
       severity: "medium",
     },
   ],
+  readiness: {
+    status: "needs_review",
+    score: 76,
+    label: "Needs review",
+    reasons: ["Confirm current company tax standing before the next LKPM cycle."],
+  },
   business_story: [
     "Bimala is visible through a person-first path, not a company-only archive.",
   ],
@@ -161,6 +167,8 @@ describe("BusinessStoryPanel", () => {
     ).not.toBeInTheDocument();
     expect(screen.getByText("Giulia Del Giudice")).toBeInTheDocument();
     expect(screen.getByText("Tax owner: Dewa Ayu")).toBeInTheDocument();
+    expect(screen.getByText("Needs review")).toBeInTheDocument();
+    expect(screen.getByText("76%")).toBeInTheDocument();
     expect(
       screen.getByText(
         "Start from Giulia, then follow the Bimala company record, LKPM evidence, and tax owner.",
@@ -171,7 +179,7 @@ describe("BusinessStoryPanel", () => {
       screen.getAllByText(
         "Confirm current company tax standing before the next LKPM cycle.",
       ),
-    ).toHaveLength(2);
+    ).toHaveLength(3);
     expect(
       screen.getByText(
         "Team opens Drive evidence from kita. Client portal stays on approved downloads only.",

--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/BusinessStoryPanel.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/BusinessStoryPanel.tsx
@@ -15,6 +15,7 @@ import type {
   TaxCompanyPilotEvidenceStory,
   TaxCompanyPilotMap,
   TaxCompanyPilotPersonDossier,
+  TaxCompanyPilotReadiness,
   TaxCompanyPilotStoryEvidence,
 } from "@/lib/api/crm/crm.types";
 
@@ -136,6 +137,25 @@ function getNextAction(
     map.next_best_actions[0]?.label ??
     "Review the company evidence and decide the next operational step."
   );
+}
+
+function getReadiness(map: TaxCompanyPilotMap): TaxCompanyPilotReadiness {
+  if (map.readiness) return map.readiness;
+  const hasHighGap = map.gaps.some((gap) => gap.severity === "high");
+  if (!map.gaps.length) {
+    return {
+      status: "ready",
+      score: 100,
+      label: "Ready to operate",
+      reasons: ["No blocking evidence gaps."],
+    };
+  }
+  return {
+    status: hasHighGap ? "blocked" : "needs_review",
+    score: hasHighGap ? 35 : 70,
+    label: hasHighGap ? "Blocked" : "Needs review",
+    reasons: map.gaps.slice(0, 3).map((gap) => gap.label),
+  };
 }
 
 function EmptyBusinessStory({ companyNames }: { companyNames: string[] }) {
@@ -265,6 +285,7 @@ export function BusinessStoryPanel({
             map.company.name,
             `Tax: ${map.tax_member.name}`,
           ];
+          const readiness = getReadiness(map);
           const personName =
             story?.person_name ?? dossier?.person_name ?? clientName;
           const recap =
@@ -303,6 +324,21 @@ export function BusinessStoryPanel({
                 </div>
 
                 <aside className="space-y-2 rounded-lg border border-white/[0.06] bg-black/10 p-3">
+                  <div className="rounded-md border border-white/[0.06] bg-white/[0.03] p-2">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-xs font-semibold text-[var(--bz-text-1)]">
+                        {readiness.label}
+                      </span>
+                      <span className="rounded bg-white/[0.08] px-1.5 py-0.5 text-[10px] font-medium text-[var(--bz-text-2)]">
+                        {readiness.score}%
+                      </span>
+                    </div>
+                    {readiness.reasons.length > 0 && (
+                      <p className="mt-1 text-[11px] leading-4 text-[var(--bz-text-2)]">
+                        {readiness.reasons[0]}
+                      </p>
+                    )}
+                  </div>
                   <div className="flex items-center gap-2 text-sm font-medium text-[var(--bz-text-1)]">
                     <Building2 className="h-4 w-4 text-[var(--bz-accent)]" />
                     {personName}

--- a/apps/mouth/src/lib/api/crm/crm.types.ts
+++ b/apps/mouth/src/lib/api/crm/crm.types.ts
@@ -116,6 +116,13 @@ export interface TaxCompanyPilotNextAction {
   severity: "high" | "medium" | "low";
 }
 
+export interface TaxCompanyPilotReadiness {
+  status: "ready" | "needs_review" | "blocked";
+  score: number;
+  label: string;
+  reasons: string[];
+}
+
 export interface TaxCompanyPilotEvidenceStory {
   person_name: string;
   company_name: string;
@@ -141,6 +148,7 @@ export interface TaxCompanyPilotMap {
   person_dossiers: TaxCompanyPilotPersonDossier[];
   evidence_stories?: TaxCompanyPilotEvidenceStory[];
   next_best_actions: TaxCompanyPilotNextAction[];
+  readiness?: TaxCompanyPilotReadiness | null;
   business_story: string[];
   duplicate_candidates: TaxCompanyPilotDuplicateCandidate[];
   gaps: TaxCompanyPilotGap[];


### PR DESCRIPTION
## Summary
- add structured CRM evidence readiness status, score, label, and reasons to pilot maps
- surface readiness in the person-first Business Story panel on kita
- cover ready and blocked dossier scoring plus frontend rendering

## Tests
- cd apps/backend-rag && source .venv/bin/activate && PYTHONPATH=. pytest backend/tests/unit/services/crm/test_evidence_dossier.py backend/tests/unit/routers/test_crm_intelligence.py -q
- cd apps/backend-rag && source .venv/bin/activate && ruff check backend/services/crm/tax_company_pilot.py backend/services/crm/evidence_dossier.py backend/tests/unit/services/crm/test_evidence_dossier.py backend/tests/unit/routers/test_crm_intelligence.py
- cd apps/mouth && npm run test -- --run 'src/app/(workspace)/clients/[id]/components/BusinessStoryPanel.test.tsx'
- cd apps/mouth && npm run typecheck
- cd apps/mouth && npm run build
- git diff --check