### PR TITLE
fix(crm): send passport OCR base64 payload

### DIFF
--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/PassportCard.test.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/PassportCard.test.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PassportCard } from "./PassportCard";
+import { api } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    crm: {
+      extractPassportForClient: vi.fn(),
+    },
+    post: vi.fn(),
+    request: vi.fn(),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+const client = {
+  id: 42,
+  full_name: "Test Client",
+  passport_number: null,
+  passport_expiry: null,
+  date_of_birth: null,
+  gender: null,
+};
+
+const documents = [
+  {
+    id: 7,
+    document_type: "passport",
+    document_category: "personal",
+    file_name: "passport.jpg",
+    google_drive_file_url: "https://drive.google.com/file/d/drive-file-123/view",
+    family_member_id: null,
+  },
+];
+
+describe("PassportCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(["passport image"], { type: "image/jpeg" }),
+    } as Response);
+    vi.mocked(api.crm.extractPassportForClient).mockResolvedValue({
+      success: true,
+      confidence: 0.95,
+      full_name: null,
+      surname: null,
+      given_names: null,
+      nationality: null,
+      date_of_birth: null,
+      gender: null,
+      passport_number: "A1234567",
+      passport_expiry: "2030-01-01",
+      issuing_country: null,
+      birthplace: null,
+      warnings: [],
+      message: null,
+    });
+  });
+
+  it("does not auto-call the deprecated file_id OCR path for existing Drive passports", async () => {
+    render(
+      <PassportCard
+        client={client as any}
+        documents={documents as any}
+        formatDate={(value) => value}
+        onRefresh={vi.fn()}
+        clientId={42}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(api.post).not.toHaveBeenCalled();
+      expect(api.crm.extractPassportForClient).not.toHaveBeenCalled();
+    });
+  });
+
+  it("extracts existing Drive passports by sending image_base64 to the enhanced OCR endpoint", async () => {
+    const onRefresh = vi.fn();
+
+    render(
+      <PassportCard
+        client={client as any}
+        documents={documents as any}
+        formatDate={(value) => value}
+        onRefresh={onRefresh}
+        clientId={42}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /extract/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/api/documents/proxy/drive-file-123");
+      expect(api.crm.extractPassportForClient).toHaveBeenCalledWith(
+        expect.any(String),
+        "image/jpeg",
+        42,
+      );
+      expect(api.post).not.toHaveBeenCalledWith(
+        "/api/crm/clients/extract-passport-enhanced",
+        expect.objectContaining({ file_id: "drive-file-123" }),
+      );
+      expect(onRefresh).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/PassportCard.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/PassportCard.tsx
@@ -117,9 +117,18 @@ export function PassportCard({
     }
   };
 
-  // Auto-trigger OCR when passport image exists but no extracted data
-  const hasTriggeredOcr = useRef(false);
   const isExtractingRef = useRef(false);
+
+  const blobToBase64 = async (blob: Blob): Promise<string> =>
+    new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = reader.result as string;
+        resolve(result.split(',')[1] ?? result);
+      };
+      reader.onerror = reject;
+      reader.readAsDataURL(blob);
+    });
 
   // Enhanced OCR extraction with Gemini Vision
   const handleExtractData = useCallback(async () => {
@@ -133,23 +142,25 @@ export function PassportCard({
     isExtractingRef.current = true;
     setOcrError(null);
     try {
-      const response = (await api.post('/api/crm/clients/extract-passport-enhanced', {
-        client_id: client.id,
-        file_id: fileId,
-      })) as {
-        success: boolean;
-        passport_number?: string;
-        expiry_date?: string;
-        full_name?: string;
-        gender?: string;
-        birthplace?: string;
-        name_match?: boolean;
-        message?: string;
-      };
+      const proxyUrl = getDriveProxyUrl(passportImageUrl, 'full');
+      if (!proxyUrl) {
+        throw new Error('Passport document cannot be proxied for OCR');
+      }
+
+      const fileResponse = await fetch(proxyUrl);
+      if (!fileResponse.ok) {
+        throw new Error(`Passport download failed (${fileResponse.status})`);
+      }
+
+      const blob = await fileResponse.blob();
+      const imageBase64 = await blobToBase64(blob);
+      const mimeType = blob.type || (passportIsPdf ? 'application/pdf' : 'image/jpeg');
+      const response = await api.crm.extractPassportForClient(imageBase64, mimeType, client.id);
+
       if (response.success) {
         const details = [];
         if (response.passport_number) details.push(`Passport: ${response.passport_number}`);
-        if (response.expiry_date) details.push(`Expiry: ${response.expiry_date}`);
+        if (response.passport_expiry) details.push(`Expiry: ${response.passport_expiry}`);
         if (response.gender) details.push(`Gender: ${response.gender}`);
         if (response.birthplace) details.push(`Birthplace: ${response.birthplace}`);
         if (response.name_match === false) {
@@ -169,20 +180,12 @@ export function PassportCard({
     } catch (err) {
       logger.error('Passport OCR failed', { metadata: { error: String(err) } });
       setOcrError('OCR failed. Click to retry.');
-      hasTriggeredOcr.current = false;
       toast.error('Extraction failed', { description: (err as Error).message });
     } finally {
       setIsExtracting(false);
       isExtractingRef.current = false;
     }
-  }, [passportImageUrl, client.id, onRefresh]);
-
-  useEffect(() => {
-    if (passportImageUrl && !client.passport_number && !isExtractingRef.current && !hasTriggeredOcr.current) {
-      hasTriggeredOcr.current = true;
-      handleExtractData();
-    }
-  }, [passportImageUrl, client.passport_number, handleExtractData]);
+  }, [passportImageUrl, passportIsPdf, client.id, onRefresh]);
 
   const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];

--- a/apps/mouth/src/lib/api/crm/crm.api.ts
+++ b/apps/mouth/src/lib/api/crm/crm.api.ts
@@ -347,6 +347,28 @@ export class CrmApi {
   }
 
   /**
+   * Extract passport data from an existing client document and persist it.
+   */
+  async extractPassportForClient(
+    imageBase64: string,
+    mimeType: string,
+    clientId: number,
+  ): Promise<PassportOcrResult> {
+    return this.client.request<PassportOcrResult>(
+      "/api/crm/clients/extract-passport-enhanced",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          image_base64: imageBase64,
+          mime_type: mimeType,
+          client_id: clientId,
+        }),
+      },
+      120000,
+    );
+  }
+
+  /**
    * Get practice types catalog grouped by category (for process creation form)
    */
   async getPracticeTypesCatalog(): Promise<{

--- a/apps/mouth/src/lib/api/crm/crm.types.ts
+++ b/apps/mouth/src/lib/api/crm/crm.types.ts
@@ -482,6 +482,7 @@ export interface PassportOcrResult {
   passport_expiry: string | null;
   issuing_country: string | null;
   birthplace: string | null;
+  name_match?: boolean | null;
   warnings: string[];
   message: string | null;
 }


### PR DESCRIPTION
## Summary\n- stop PassportCard from auto-triggering the deprecated file_id OCR request on mount\n- fetch existing Drive passport through the document proxy before OCR\n- send image_base64 + mime_type + client_id to the enhanced OCR endpoint so extracted fields can persist\n- add regression coverage for the console error path\n\n## Verification\n- cd apps/mouth && npm run test -- --run 'src/app/(workspace)/clients/[id]/components/PassportCard.test.tsx' 'src/app/(workspace)/clients/[id]/components/BusinessStoryPanel.test.tsx'\n- cd apps/mouth && npm run typecheck\n- cd apps/mouth && npm run build