### PR TITLE
fix(crm): reuse JSON OCR in drive backfill

### DIFF
--- a/apps/backend-rag/backend/services/documents/crm_drive_backfill_service.py
+++ b/apps/backend-rag/backend/services/documents/crm_drive_backfill_service.py
@@ -8,7 +8,9 @@ unprocessed documents through the existing OCR dispatcher.
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
+from json import JSONDecodeError, loads
 from typing import Any
 
 import asyncpg
@@ -137,7 +139,7 @@ async def _process_candidate(
         return {"ocr_dispatched": 0, "kg_linked": 0, "skipped": 1}
 
     linked = False
-    if link_kg:
+    if link_kg and not _dispatcher_links_kg():
         handler_name = str(result.get("handler") or candidate.document_type)
         linked = await _link_candidate_to_kg(
             pool,
@@ -172,7 +174,7 @@ async def _link_candidate_to_kg(
 
 def _candidate_from_row(row: Any) -> CrmDriveBackfillCandidate:
     data = dict(row)
-    raw_ocr = data.get("ocr_extracted_data")
+    raw_ocr = _coerce_extracted_data(data.get("ocr_extracted_data"))
     return CrmDriveBackfillCandidate(
         document_id=int(data["document_id"]),
         client_id=int(data["client_id"]),
@@ -183,7 +185,7 @@ def _candidate_from_row(row: Any) -> CrmDriveBackfillCandidate:
         practice_id=data.get("practice_id"),
         drive_url=data.get("google_drive_file_url") or data.get("file_url"),
         ocr_status=data.get("ocr_status"),
-        ocr_extracted_data=raw_ocr if isinstance(raw_ocr, dict) else {},
+        ocr_extracted_data=raw_ocr,
         has_kg_node=bool(data.get("has_kg_node")),
     )
 
@@ -205,6 +207,23 @@ def _extract_fields_from_dispatch(result: dict[str, Any]) -> dict[str, Any]:
         if "passport_number" in payload or "npwp" in payload or "npwp_company" in payload:
             return payload
     return {}
+
+
+def _coerce_extracted_data(raw_ocr: Any) -> dict[str, Any]:
+    if isinstance(raw_ocr, dict):
+        return raw_ocr
+    if isinstance(raw_ocr, str) and raw_ocr.strip():
+        try:
+            parsed = loads(raw_ocr)
+        except JSONDecodeError:
+            return {}
+        if isinstance(parsed, dict):
+            return parsed
+    return {}
+
+
+def _dispatcher_links_kg() -> bool:
+    return os.environ.get("CRM_KG_ENABLED", "").lower() in ("true", "1", "yes", "on")
 
 
 def _folder_hint(category: str | None) -> str:

--- a/apps/backend-rag/backend/tests/services/documents/test_crm_drive_backfill_service.py
+++ b/apps/backend-rag/backend/tests/services/documents/test_crm_drive_backfill_service.py
@@ -37,9 +37,10 @@ class _FakeConn:
 
 
 @pytest.mark.asyncio
-async def test_backfill_links_completed_existing_document_without_ocr() -> None:
+async def test_backfill_links_completed_existing_document_without_ocr(monkeypatch: pytest.MonkeyPatch) -> None:
     from backend.services.documents.crm_drive_backfill_service import run_crm_drive_backfill
 
+    monkeypatch.delenv("CRM_KG_ENABLED", raising=False)
     pool = _FakePool(
         [
             {
@@ -80,9 +81,51 @@ async def test_backfill_links_completed_existing_document_without_ocr() -> None:
 
 
 @pytest.mark.asyncio
-async def test_backfill_dispatches_pending_existing_document_to_ocr() -> None:
+async def test_backfill_links_completed_json_string_without_ocr(monkeypatch: pytest.MonkeyPatch) -> None:
     from backend.services.documents.crm_drive_backfill_service import run_crm_drive_backfill
 
+    monkeypatch.delenv("CRM_KG_ENABLED", raising=False)
+    pool = _FakePool(
+        [
+            {
+                "document_id": 13,
+                "client_id": 43,
+                "file_id": "drive-json-completed",
+                "file_name": "visa.pdf",
+                "document_type": "visa",
+                "document_category": "immigration",
+                "practice_id": None,
+                "google_drive_file_url": "https://drive/file",
+                "file_url": None,
+                "ocr_status": "completed",
+                "ocr_extracted_data": '{"visa_type":"C1","full_name":"Anna"}',
+                "has_kg_node": False,
+            },
+        ],
+    )
+
+    with patch(
+        "backend.services.knowledge_graph.document_linker.kg_link_document",
+        new_callable=AsyncMock,
+        return_value={"ok": True, "nodes": 2, "edges": 1},
+    ) as mock_kg, patch(
+        "backend.services.documents.ocr_dispatcher_service.dispatch_ocr_by_folder",
+        new_callable=AsyncMock,
+    ) as mock_dispatch:
+        result = await run_crm_drive_backfill(pool, limit=5, dry_run=False)
+
+    assert result["processed"] == 1
+    assert result["kg_linked"] == 1
+    assert result["ocr_dispatched"] == 0
+    mock_dispatch.assert_not_called()
+    assert mock_kg.call_args.kwargs["extracted_fields"]["visa_type"] == "C1"
+
+
+@pytest.mark.asyncio
+async def test_backfill_dispatches_pending_existing_document_to_ocr(monkeypatch: pytest.MonkeyPatch) -> None:
+    from backend.services.documents.crm_drive_backfill_service import run_crm_drive_backfill
+
+    monkeypatch.delenv("CRM_KG_ENABLED", raising=False)
     pool = _FakePool(
         [
             {
@@ -124,6 +167,53 @@ async def test_backfill_dispatches_pending_existing_document_to_ocr() -> None:
     assert mock_dispatch.call_args.kwargs["folder_name"] == "03_Tax"
     mock_kg.assert_called_once()
     assert mock_kg.call_args.kwargs["document_type"] == "npwp"
+
+
+@pytest.mark.asyncio
+async def test_backfill_does_not_double_link_when_dispatcher_kg_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from backend.services.documents.crm_drive_backfill_service import run_crm_drive_backfill
+
+    monkeypatch.setenv("CRM_KG_ENABLED", "true")
+    pool = _FakePool(
+        [
+            {
+                "document_id": 14,
+                "client_id": 44,
+                "file_id": "drive-pending",
+                "file_name": "npwp.pdf",
+                "document_type": "unknown",
+                "document_category": "tax",
+                "practice_id": 7,
+                "google_drive_file_url": None,
+                "file_url": None,
+                "ocr_status": "pending",
+                "ocr_extracted_data": None,
+                "has_kg_node": False,
+            },
+        ],
+    )
+
+    with patch(
+        "backend.services.documents.ocr_dispatcher_service.dispatch_ocr_by_folder",
+        new_callable=AsyncMock,
+        return_value={
+            "dispatched": True,
+            "handler": "npwp",
+            "result": {"success": True, "extracted": {"npwp": "01.234"}},
+        },
+    ) as mock_dispatch, patch(
+        "backend.services.knowledge_graph.document_linker.kg_link_document",
+        new_callable=AsyncMock,
+    ) as mock_kg:
+        result = await run_crm_drive_backfill(pool, limit=5, dry_run=False)
+
+    assert result["processed"] == 1
+    assert result["ocr_dispatched"] == 1
+    assert result["kg_linked"] == 0
+    mock_dispatch.assert_called_once()
+    mock_kg.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- parse existing OCR JSON strings before deciding whether to re-run OCR
- avoid a second explicit KG link when the dispatcher KG hook is already enabled
- add tests for JSON-string OCR and dispatcher-owned KG linking

## Verification
- PYTHONPATH=. /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m ruff check backend/services/documents/crm_drive_backfill_service.py backend/tests/services/documents/test_crm_drive_backfill_service.py
- PYTHONPATH=. /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m pytest backend/tests/services/documents/test_crm_drive_backfill_service.py -q