### PR TITLE
fix(crm): require explicit OCR for drive backfill

### DIFF
--- a/apps/backend-rag/backend/app/routers/admin_crm_kg.py
+++ b/apps/backend-rag/backend/app/routers/admin_crm_kg.py
@@ -33,11 +33,12 @@ async def trigger_backfill_drive_documents(
     limit: int = Query(25, ge=1, le=250),
     dry_run: bool = Query(True),
     client_id: int | None = Query(None, ge=1),
+    allow_ocr: bool = Query(False),
 ) -> dict[str, Any]:
     """Backfill current CRM Drive documents into OCR and crm_kg.
 
     Dry-run returns the candidate summary immediately. Live mode runs in a
-    background task so admin/cron callers do not block on Gemini OCR.
+    background task. OCR/Gemini dispatch is disabled unless allow_ocr=true.
     """
     pool = getattr(request.app.state, "db_pool", None)
     if not pool:
@@ -53,6 +54,7 @@ async def trigger_backfill_drive_documents(
             limit=limit,
             dry_run=True,
             client_id=client_id,
+            allow_ocr=allow_ocr,
         )
 
     async def _run() -> None:
@@ -61,6 +63,7 @@ async def trigger_backfill_drive_documents(
             limit=limit,
             dry_run=False,
             client_id=client_id,
+            allow_ocr=allow_ocr,
         )
         logger.info("crm_kg.backfill_drive_documents background result: %s", result)
 
@@ -69,6 +72,7 @@ async def trigger_backfill_drive_documents(
         "status": "started",
         "message": "CRM Drive document backfill running in background",
         "dry_run": False,
+        "allow_ocr": allow_ocr,
         "limit": limit,
         "client_id": client_id,
     }

--- a/apps/backend-rag/backend/services/documents/crm_drive_backfill_service.py
+++ b/apps/backend-rag/backend/services/documents/crm_drive_backfill_service.py
@@ -45,6 +45,7 @@ async def run_crm_drive_backfill(
     dry_run: bool = True,
     client_id: int | None = None,
     link_kg: bool = True,
+    allow_ocr: bool = False,
 ) -> dict[str, Any]:
     """Run one bounded backfill pass over existing CRM Drive documents.
 
@@ -54,6 +55,7 @@ async def run_crm_drive_backfill(
         dry_run: When true, only counts and previews candidates.
         client_id: Optional single-client scope.
         link_kg: Whether to create crm_kg edges after OCR/direct link.
+        allow_ocr: Whether this pass may dispatch missing documents to OCR.
 
     Returns:
         Summary counters safe for admin endpoints and cron logs.
@@ -62,9 +64,11 @@ async def run_crm_drive_backfill(
         pool,
         limit=limit,
         client_id=client_id,
+        allow_ocr=allow_ocr,
     )
     summary: dict[str, Any] = {
         "dry_run": dry_run,
+        "allow_ocr": allow_ocr,
         "candidate_count": len(candidates),
         "processed": 0,
         "ocr_dispatched": 0,
@@ -79,7 +83,12 @@ async def run_crm_drive_backfill(
 
     for candidate in candidates:
         try:
-            outcome = await _process_candidate(pool, candidate, link_kg=link_kg)
+            outcome = await _process_candidate(
+                pool,
+                candidate,
+                link_kg=link_kg,
+                allow_ocr=allow_ocr,
+            )
         except Exception as exc:  # noqa: BLE001 - batch worker must continue
             logger.error(
                 "CRM Drive backfill failed for document %s: %s",
@@ -105,11 +114,12 @@ async def fetch_crm_drive_backfill_candidates(
     *,
     limit: int = _DEFAULT_LIMIT,
     client_id: int | None = None,
+    allow_ocr: bool = False,
 ) -> list[CrmDriveBackfillCandidate]:
     """Fetch existing Drive-backed documents that still need OCR or KG."""
     safe_limit = max(1, min(limit, _MAX_LIMIT))
     async with pool.acquire() as conn:
-        rows = await conn.fetch(_CANDIDATE_SQL, client_id, safe_limit)
+        rows = await conn.fetch(_CANDIDATE_SQL, client_id, safe_limit, allow_ocr)
     return [_candidate_from_row(row) for row in rows]
 
 
@@ -118,10 +128,14 @@ async def _process_candidate(
     candidate: CrmDriveBackfillCandidate,
     *,
     link_kg: bool,
+    allow_ocr: bool,
 ) -> dict[str, int]:
     if _can_link_without_ocr(candidate):
         linked = await _link_candidate_to_kg(pool, candidate, candidate.document_type)
         return {"ocr_dispatched": 0, "kg_linked": int(linked), "skipped": int(not linked)}
+
+    if not allow_ocr:
+        return {"ocr_dispatched": 0, "kg_linked": 0, "skipped": 1}
 
     from backend.services.documents.ocr_dispatcher_service import dispatch_ocr_by_folder
 
@@ -278,6 +292,13 @@ WHERE c.deleted_at IS NULL
   AND (d.is_archived IS NULL OR d.is_archived = false)
   AND ($1::int IS NULL OR d.client_id = $1::int)
   AND kg.entity_id IS NULL
+  AND (
+      $3::boolean = true
+      OR (
+          d.ocr_status = 'completed'
+          AND d.ocr_extracted_data IS NOT NULL
+      )
+  )
 ORDER BY
     CASE
         WHEN d.ocr_status = 'completed' AND kg.entity_id IS NULL THEN 0

--- a/apps/backend-rag/backend/tests/routers/test_admin_crm_kg_backfill.py
+++ b/apps/backend-rag/backend/tests/routers/test_admin_crm_kg_backfill.py
@@ -28,6 +28,7 @@ async def test_backfill_drive_documents_dry_run_returns_summary() -> None:
             limit=10,
             dry_run=True,
             client_id=42,
+            allow_ocr=False,
         )
 
     assert result == {"dry_run": True, "candidate_count": 3}
@@ -35,6 +36,7 @@ async def test_backfill_drive_documents_dry_run_returns_summary() -> None:
     assert mock_backfill.call_args.kwargs["limit"] == 10
     assert mock_backfill.call_args.kwargs["dry_run"] is True
     assert mock_backfill.call_args.kwargs["client_id"] == 42
+    assert mock_backfill.call_args.kwargs["allow_ocr"] is False
 
 
 @pytest.mark.asyncio
@@ -52,9 +54,37 @@ async def test_backfill_drive_documents_live_runs_in_background() -> None:
             limit=5,
             dry_run=False,
             client_id=None,
+            allow_ocr=False,
         )
 
     assert result["status"] == "started"
     assert result["dry_run"] is False
+    assert result["allow_ocr"] is False
     assert len(background_tasks.tasks) == 1
     mock_backfill.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_backfill_drive_documents_live_requires_explicit_ocr_flag() -> None:
+    from backend.app.routers.admin_crm_kg import trigger_backfill_drive_documents
+
+    background_tasks = BackgroundTasks()
+    with patch(
+        "backend.services.documents.crm_drive_backfill_service.run_crm_drive_backfill",
+        new_callable=AsyncMock,
+    ) as mock_backfill:
+        result = await trigger_backfill_drive_documents(
+            request=_request_with_pool(object()),
+            background_tasks=background_tasks,
+            limit=5,
+            dry_run=False,
+            client_id=None,
+            allow_ocr=True,
+        )
+
+    assert result["status"] == "started"
+    assert result["allow_ocr"] is True
+
+    task = background_tasks.tasks[0]
+    await task.func(*task.args, **task.kwargs)
+    assert mock_backfill.call_args.kwargs["allow_ocr"] is True

--- a/apps/backend-rag/backend/tests/services/documents/test_crm_drive_backfill_service.py
+++ b/apps/backend-rag/backend/tests/services/documents/test_crm_drive_backfill_service.py
@@ -122,7 +122,7 @@ async def test_backfill_links_completed_json_string_without_ocr(monkeypatch: pyt
 
 
 @pytest.mark.asyncio
-async def test_backfill_dispatches_pending_existing_document_to_ocr(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_backfill_skips_pending_existing_document_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
     from backend.services.documents.crm_drive_backfill_service import run_crm_drive_backfill
 
     monkeypatch.delenv("CRM_KG_ENABLED", raising=False)
@@ -159,6 +159,60 @@ async def test_backfill_dispatches_pending_existing_document_to_ocr(monkeypatch:
         return_value={"ok": True, "nodes": 3, "edges": 2},
     ) as mock_kg:
         result = await run_crm_drive_backfill(pool, limit=5, dry_run=False)
+
+    assert result["processed"] == 1
+    assert result["ocr_dispatched"] == 0
+    assert result["kg_linked"] == 0
+    assert result["skipped"] == 1
+    mock_dispatch.assert_not_called()
+    mock_kg.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_backfill_dispatches_pending_existing_document_to_ocr_when_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from backend.services.documents.crm_drive_backfill_service import run_crm_drive_backfill
+
+    monkeypatch.delenv("CRM_KG_ENABLED", raising=False)
+    pool = _FakePool(
+        [
+            {
+                "document_id": 11,
+                "client_id": 42,
+                "file_id": "drive-pending",
+                "file_name": "scan_001.pdf",
+                "document_type": "unknown",
+                "document_category": "tax",
+                "practice_id": 7,
+                "google_drive_file_url": None,
+                "file_url": None,
+                "ocr_status": "pending",
+                "ocr_extracted_data": None,
+                "has_kg_node": False,
+            },
+        ],
+    )
+
+    with patch(
+        "backend.services.documents.ocr_dispatcher_service.dispatch_ocr_by_folder",
+        new_callable=AsyncMock,
+        return_value={
+            "dispatched": True,
+            "handler": "npwp",
+            "result": {"success": True, "extracted": {"npwp": "01.234"}},
+        },
+    ) as mock_dispatch, patch(
+        "backend.services.knowledge_graph.document_linker.kg_link_document",
+        new_callable=AsyncMock,
+        return_value={"ok": True, "nodes": 3, "edges": 2},
+    ) as mock_kg:
+        result = await run_crm_drive_backfill(
+            pool,
+            limit=5,
+            dry_run=False,
+            allow_ocr=True,
+        )
 
     assert result["processed"] == 1
     assert result["ocr_dispatched"] == 1
@@ -207,7 +261,12 @@ async def test_backfill_does_not_double_link_when_dispatcher_kg_enabled(
         "backend.services.knowledge_graph.document_linker.kg_link_document",
         new_callable=AsyncMock,
     ) as mock_kg:
-        result = await run_crm_drive_backfill(pool, limit=5, dry_run=False)
+        result = await run_crm_drive_backfill(
+            pool,
+            limit=5,
+            dry_run=False,
+            allow_ocr=True,
+        )
 
     assert result["processed"] == 1
     assert result["ocr_dispatched"] == 1
@@ -268,4 +327,5 @@ async def test_fetch_candidates_only_selects_documents_without_kg_node() -> None
     query, args = pool.conn.fetch_calls[0]
     assert "AND kg.entity_id IS NULL" in query
     assert "OR d.ocr_status IN" not in query
-    assert args == (None, 5)
+    assert "d.ocr_status = 'completed'" in query
+    assert args == (None, 5, False)


### PR DESCRIPTION
## Summary
- make CRM Drive backfill no-OCR by default
- require explicit allow_ocr=true before Gemini/OCR dispatch can run
- keep completed OCR documents linkable into crm_kg without dispatching new OCR

## Verification
- PYTHONPATH=. /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m ruff check backend/services/documents/crm_drive_backfill_service.py backend/app/routers/admin_crm_kg.py backend/tests/services/documents/test_crm_drive_backfill_service.py backend/tests/routers/test_admin_crm_kg_backfill.py
- PYTHONPATH=. /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m pytest backend/tests/services/documents/test_crm_drive_backfill_service.py backend/tests/routers/test_admin_crm_kg_backfill.py -q