### PR TITLE
feat(intel-lake): Wave 4 — regulatory-watcher + peraturan_ingestion_trigger dual-write

### DIFF
--- a/apps/evaluator/nlm_deep_research/peraturan_ingestion_trigger.py
+++ b/apps/evaluator/nlm_deep_research/peraturan_ingestion_trigger.py
@@ -361,7 +361,47 @@ def _ingest_to_backend(pdf_path: Path, row: RegulationRow) -> dict:
                 headers={"X-API-Key": SCRAPER_API_KEY},
             )
             response.raise_for_status()
-            return response.json()
+            result = response.json()
+
+    # Intel Lake Wave 4 (2026-05-12): enqueue regulation observation to
+    # local SQLite outbox. Best-effort — failure must not block ingestion.
+    try:
+        import hashlib  # noqa: PLC0415
+        import sys as _sys  # noqa: PLC0415
+        _sys.path.insert(0, "/Users/nuzantara/scripts")
+        from intel_lake_outbox import enqueue as _lake_enqueue  # type: ignore
+        url = row.url or f"peraturan://{row.tipo}/{row.anno}/{row.nome or 'unknown'}"
+        ch = hashlib.sha256(
+            ((title or "") + " " + url).encode()
+        ).hexdigest()[:32]
+        _lake_enqueue(
+            "peraturan_ingestion_trigger",
+            {
+                "producer_name": "peraturan_ingestion_trigger",
+                "canonical_url": url,
+                "content_hash": ch,
+                "title": (title or row.nome or "untitled")[:500],
+                "summary": None,
+                "source_domain": "peraturan.go.id",
+                "language": "id",
+                "jurisdiction": "ID-national",
+                "topic_tags": ["regulation", "legal", (row.tipo or "unknown").lower()],
+                "published_at": str(row.anno) if row.anno else None,
+                "score": None,
+                "raw_payload": {
+                    "tipo": row.tipo,
+                    "anno": row.anno,
+                    "tier": params.get("tier"),
+                    "backend_response_chunks": result.get("chunks") if isinstance(result, dict) else None,
+                },
+            },
+        )
+    except Exception as _exc:
+        # Logger not available at this scope; print to stderr is best we can do
+        import sys as _sys2  # noqa: PLC0415
+        print(f"intel_lake_outbox enqueue failed: {_exc}", file=_sys2.stderr)
+
+    return result
 
 
 # ─── Drive upload ─────────────────────────────────────────────────────────────

--- a/research/symbiosis/2026-05-12-intel-lake-wave4-plan.md
+++ b/research/symbiosis/2026-05-12-intel-lake-wave4-plan.md
@@ -1,0 +1,77 @@
+---
+date: 2026-05-12
+wave: 4
+producers: regulatory_watcher, peraturan_ingestion_trigger
+status: implemented
+---
+
+# Wave 4 — regulatory-watcher + peraturan_ingestion_trigger → Intel Lake
+
+## Scope
+
+2 producers focused on legal/regulatory documents:
+
+- `regulatory-watcher` (`~/scripts/regulatory-watcher-run.sh`, daily 07:00 WITA): multi-LLM cascade scans JDIH / Hukumonline / Ortax / MUC, emits `~/Desktop/nuzantara/research/regulatory/<date>-delta.json` + Telegram + EventBus (`regulatory.delta.detected`).
+- `peraturan_ingestion_trigger` (`apps/evaluator/nlm_deep_research/peraturan_ingestion_trigger.py`, scheduled): Google Sheet driven PDF download → backend `/api/legal/upload` (RAG + KG) → Drive PERATURAN folder → NB-6 NotebookLM → Sheet status.
+
+Both are CRITICAL producers (legal exposure for Bali Zero if data drifts) — Wave 4 plan calls for **dual-write retained for first 30 days post-cut-over** as defensive measure.
+
+## Patches applied
+
+### regulatory-watcher-run.sh
+
+Inside the inline Python block that publishes to EventBus, after each delta is emitted, also enqueue to Intel Lake outbox:
+
+```python
+import hashlib
+from intel_lake_outbox import enqueue as _lake_enqueue
+for delta in deltas:
+    ...
+    _lake_enqueue('regulatory_watcher', {
+        'producer_name': 'regulatory_watcher',
+        'canonical_url': delta.source or f'regulatory-watcher://delta/{citation}',
+        'content_hash': sha256(citation + title)[:32],
+        'title': citation + ' — ' + title,
+        'summary': delta.summary,
+        'source_domain': delta.source_domain or 'regulatory-watcher',
+        'language': 'id',
+        'jurisdiction': 'ID-national',
+        'topic_tags': ['regulation', regulation_type] + service_lines,
+        'published_at': first_seen_at,
+        'raw_payload': {
+            'citation': citation,
+            'urgency': urgency,
+            'verbatim_excerpt': verbatim_excerpt[:2000],
+        },
+    })
+```
+
+Failure to import or enqueue is logged and swallowed — must NOT block the watcher daily cron.
+
+### peraturan_ingestion_trigger.py
+
+Inside `_ingest_to_backend()`, after successful POST to `/api/legal/upload`, enqueue observation with `source_domain=peraturan.go.id`, `topic_tags=['regulation','legal', row.tipo]`. The raw_payload preserves `tipo`, `anno`, `tier`, and `backend_response_chunks` for downstream auditability.
+
+## Verification
+
+- `bash -n` clean on regulatory-watcher-run.sh
+- Inline Python block parsed via ast: OK (3003 chars)
+- `ast.parse` clean on peraturan_ingestion_trigger.py
+
+## Volume estimate (24h)
+
+- `regulatory_watcher`: daily 07:00, typical 1-5 new deltas/day, peaks at 10-20 during Permenkumham/PMK release weeks
+- `peraturan_ingestion_trigger`: scheduled (~daily), ~1-3 new PDFs/day driven by Google Sheet PENDING rows
+
+Combined: ~5-25 observations/day. Trivial drain volume.
+
+## Out of scope this PR
+
+This PR contains ONLY the design doc. The patches live in:
+
+- `~/scripts/regulatory-watcher-run.sh` (NOT in repo — operator-managed script on Pro)
+- `apps/evaluator/nlm_deep_research/peraturan_ingestion_trigger.py` (IN repo — separate commit on this branch)
+
+## Stop-loss
+
+Same as Wave 1/3: `~/.intel-lake-wave2-blocked` file pauses Wave 5 if shadow-validate detects divergence >15%.


### PR DESCRIPTION
## Summary

Wave 4 Intel Lake unified pipeline. 2 CRITICAL legal/regulatory producers:

- `regulatory-watcher` (~/scripts/regulatory-watcher-run.sh, NOT in repo): inline Python block now enqueues each delta to intel_lake_outbox after EventBus publish.
- `peraturan_ingestion_trigger.py` (in repo): enqueues observation after successful /api/legal/upload POST.

Both kept dual-write for 30d post cut-over (legal exposure if data drifts).

## Deliverable

- `research/symbiosis/2026-05-12-intel-lake-wave4-plan.md` (design)
- `apps/evaluator/nlm_deep_research/peraturan_ingestion_trigger.py` (patched, in repo)

## Test plan
- [x] bash -n clean on regulatory-watcher-run.sh
- [x] ast.parse clean on peraturan_ingestion_trigger.py
- [ ] Post-merge: monitor outbox stats + audit log for producer_name='regulatory_watcher' and 'peraturan_ingestion_trigger'

🤖 Generated with Claude Code