### PR TITLE
feat(intel-lake): Wave 5 — Bali Intel Scraper dual-write

### DIFF
--- a/apps/bali-intel-scraper/scripts/run_intel_pipeline.py
+++ b/apps/bali-intel-scraper/scripts/run_intel_pipeline.py
@@ -1794,6 +1794,50 @@ IMPORTANT:
                         self.log(f'Submitted to staging: {item_id} ({intel_type}) — awaiting News Room approval')
                         art['_staging_item_id'] = item_id
                         art['_staging_intel_type'] = intel_type
+
+                    # Intel Lake Wave 5 (2026-05-12): enqueue observation to
+                    # local SQLite outbox so the unified pipeline sees this
+                    # finding alongside other producers (intel_radar, mata-garuda,
+                    # imigrasi_monitor, ...). Best-effort — failure must not
+                    # break the existing staging submission flow.
+                    try:
+                        import hashlib as _h  # noqa: PLC0415
+                        import sys as _sys  # noqa: PLC0415
+                        _sys.path.insert(0, "/Users/nuzantara/scripts")
+                        from intel_lake_outbox import enqueue as _lake_enqueue  # type: ignore
+                        _url = art.get("url") or art.get("source_url") or f"bali-intel-scraper://item/{item_id or 'unknown'}"
+                        _title = art.get("title") or "untitled"
+                        _ch = _h.sha256((_title + " " + _url).encode()).hexdigest()[:32]
+                        # Domain inferred from URL when possible
+                        try:
+                            from urllib.parse import urlparse as _up  # noqa: PLC0415
+                            _domain = _up(_url).netloc or "bali-intel-scraper"
+                        except Exception:
+                            _domain = "bali-intel-scraper"
+                        _lake_enqueue(
+                            "bali_intel_scraper",
+                            {
+                                "producer_name": "bali_intel_scraper",
+                                "canonical_url": _url,
+                                "content_hash": _ch,
+                                "title": _title[:500],
+                                "summary": (art.get("summary") or art.get("description") or "")[:2000],
+                                "source_domain": _domain,
+                                "language": art.get("language") or "id",
+                                "jurisdiction": "ID-bali" if intel_type == "news" else "ID-national",
+                                "topic_tags": [intel_type, "news-room", art.get("category", "general")],
+                                "published_at": art.get("published_at") or art.get("scraped_at"),
+                                "score": art.get("score"),
+                                "raw_payload": {
+                                    "intel_type": intel_type,
+                                    "staging_item_id": item_id,
+                                    "tier": art.get("tier"),
+                                    "source": art.get("source"),
+                                },
+                            },
+                        )
+                    except Exception as _exc:
+                        self.log(f"intel-lake enqueue failed: {_exc}", "WARN")
                     return True
                 return False
 

--- a/research/symbiosis/2026-05-12-intel-lake-wave5-plan.md
+++ b/research/symbiosis/2026-05-12-intel-lake-wave5-plan.md
@@ -1,0 +1,69 @@
+---
+date: 2026-05-12
+wave: 5
+producer: bali_intel_scraper
+status: implemented
+---
+
+# Wave 5 — Bali Intel Scraper → Intel Lake
+
+## Scope
+
+`apps/bali-intel-scraper/scripts/run_intel_pipeline.py` (cron 03:00 WITA, Pro-local via OpenClaw) is the highest-volume producer with 5 native destinations:
+
+1. Qdrant `intel_articles` collection (vector search)
+2. Fly `/api/intel/scraper/submit` → News Room staging (Postgres + filesystem)
+3. Fly `/api/intel/staging/<type>/<id>/cover` (cover image upload)
+4. Telegram notification (bilingual)
+5. `data/published_articles.json` history dedup
+
+Wave 5 adds a 6th hook: enqueue to local SQLite outbox at the moment of successful staging submission, so the Intel Lake observation table captures every news/visa article — alongside intel_radar (Wave 1), mata-garuda nlm_feeder (Wave 6), and the rest.
+
+## Patch applied
+
+Inside `_push()` async helper of the publish step (the function that POSTs to `/api/intel/scraper/submit`), after `r.status_code in (200, 201)` and `item_id` extraction, call `intel_lake_outbox.enqueue` with:
+
+- `producer_name=bali_intel_scraper`
+- `canonical_url=art.url || f"bali-intel-scraper://item/{item_id}"` (fallback for missing URL)
+- `content_hash=sha256(title + " " + url)[:32]`
+- `source_domain=parsed_netloc || "bali-intel-scraper"`
+- `language=art.language || "id"`
+- `jurisdiction="ID-bali" if intel_type=='news' else "ID-national"`
+- `topic_tags=[intel_type, "news-room", category]`
+- `raw_payload={intel_type, staging_item_id, tier, source}`
+
+Best-effort: failure to import or enqueue is logged as WARN and swallowed — MUST NOT break the existing staging submission.
+
+## Verification
+
+- `ast.parse` clean on patched file
+- Outbox module already smoke-tested in Wave 1 + Wave 3
+
+## Volume estimate
+
+Bali Intel Scraper is the highest-volume producer:
+
+- 609 URL fixed sources × variable scrape success rate × dedup
+- Empirical: ~40-100 articles published per daily run (post-dedup, post-scoring)
+- Combined with Wave 1/2/3/4 producers: total observation rate to outbox now ~100-200/day
+
+Drain worker (60s tick, batch=100) is well within capacity. Backend `/api/intel/lake/observations:batch` rate-limit assumed at 1 batch/s = 100k/day theoretical ceiling, several orders of magnitude above current need.
+
+## Multi-destination invariant
+
+The 5 native destinations stay untouched. Wave 5 adds a 6th observation channel (SQLite outbox) without touching the existing flow. If the lake outbox or backend is unavailable, the scraper still:
+
+- Pushes to Qdrant (RAG)
+- Submits to News Room staging (blog pipeline)
+- Sends Telegram
+- Updates `published_articles.json`
+
+This is the "additive observability" pattern; failure isolation by design.
+
+## Stop-loss
+
+Same as previous waves: `~/.intel-lake-wave2-blocked` file pauses Wave 6 if shadow-validate detects >15% divergence.
+
+## Next: Wave 6 (Mata Garuda)
+
+24 harvester agents share a common `base_worker.py`. Single patch point: add enqueue inside `stream_publish_redis` so every Mata Garuda producer (arxiv, reddit, twitter, youtube, github, imigrasi_harvester, kemkumham_harvester, bkpm_harvester, ...) becomes a lake producer in one shot.


### PR DESCRIPTION
## Summary

Wave 5 of Intel Lake unified pipeline. **Highest-volume producer** (~40-100 articles/day) now enqueues to local SQLite outbox after successful POST to /api/intel/scraper/submit, alongside its 5 native destinations (Qdrant intel_articles, Fly staging, cover upload, Telegram, history JSON).

## Deliverable

- `apps/bali-intel-scraper/scripts/run_intel_pipeline.py` (patch, in repo)
- `research/symbiosis/2026-05-12-intel-lake-wave5-plan.md` (design)

## Test plan
- [x] ast.parse clean
- [ ] Post-merge: monitor outbox audit log for producer_name='bali_intel_scraper'

🤖 Generated with Claude Code