### PR TITLE
fix(intel-lake): bypass auth middleware + heavy router registration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ See [`INDEX.md`](INDEX.md) for the full atlas including packages, tessuti dati, 
 ### Tech Stack
 
 <!-- DOCSYNC:BACKEND_STATS_START -->
-- **Backend:** Python 3.11+, FastAPI, 264 routers, 548 services, 924 test files
+- **Backend:** Python 3.11+, FastAPI, 265 routers, 548 services, 924 test files
 <!-- DOCSYNC:BACKEND_STATS_END -->
 - **Frontend:** Next.js, TypeScript, Tailwind CSS
 - **Databases:** PostgreSQL (relational), Qdrant (vector), Redis (cache)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 264 routers · 548 services
+- Backend: FastAPI · 265 routers · 548 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 23 · Packages: 5

--- a/apps/backend-rag/backend/app/auth/public_endpoints.py
+++ b/apps/backend-rag/backend/app/auth/public_endpoints.py
@@ -102,6 +102,22 @@ _INFRA = (
         "Channel health (web) — Cell heartbeat bridge poll target",
         match="exact",
     ),
+    # Intel Lake Wave 1 (2026-05-12, mig 168): unified intel pipeline ingest
+    # endpoint. Public to bypass HybridAuthMiddleware — but enforces its own
+    # X-Producer-Token header auth in the router (env INTEL_LAKE_PRODUCER_TOKEN).
+    # See backend/app/routers/intel_lake.py and research/symbiosis/2026-05-12-intel-lake-design.md
+    PublicEndpoint(
+        "/api/intel/lake/observations",
+        Category.INFRA,
+        "Intel Lake observation ingest — X-Producer-Token auth in-router",
+        match="exact",
+    ),
+    PublicEndpoint(
+        "/api/intel/lake/observations-batch",
+        Category.INFRA,
+        "Intel Lake batched observation ingest — X-Producer-Token auth in-router",
+        match="exact",
+    ),
 )
 
 _AUTH = (

--- a/apps/backend-rag/backend/app/routers/intel_lake.py
+++ b/apps/backend-rag/backend/app/routers/intel_lake.py
@@ -157,7 +157,7 @@ async def post_observation(
     )
 
 
-@router.post("/observations:batch", response_model=BatchObservationResponse)
+@router.post("/observations-batch", response_model=BatchObservationResponse)
 async def post_observations_batch(
     payload: BatchObservationPayload,
     request: Request,

--- a/apps/backend-rag/backend/app/setup/router_manifest.py
+++ b/apps/backend-rag/backend/app/setup/router_manifest.py
@@ -207,7 +207,7 @@ ROUTER_MANIFEST: tuple[RouterEntry, ...] = (
     # ── Intel (RAG process only — needs /data volume) ──
     RouterEntry(name="intel",           process_groups=_RAG, tags=("intel",)),
     RouterEntry(name="intel_analytics", process_groups=_RAG, tags=("intel",)),
-    RouterEntry(name="intel_lake",      process_groups=_API, tags=("intel", "intel-lake")),
+    RouterEntry(name="intel_lake",      process_groups=_BOTH, tags=("intel", "intel-lake")),
     RouterEntry(name="intel_scraper",   process_groups=_RAG, tags=("intel",)),
 
     # ── KBLI ──

--- a/apps/backend-rag/backend/app/setup/router_registration.py
+++ b/apps/backend-rag/backend/app/setup/router_registration.py
@@ -78,6 +78,7 @@ def include_routers(api: FastAPI) -> None:
         hr_owner_cashout,  # [NEW] Owner-only weekly cashout
         ingest,
         instagram_chat,
+        intel_lake,
         kbli_notebook,
         kbli_notebook_chat,
         kg_agentic,
@@ -276,6 +277,7 @@ def include_routers(api: FastAPI) -> None:
     )  # Omnichannel WhatsApp conversations API (dashboard only)
     api.include_router(instagram_chat.router)  # Instagram DM auto-reply via RAG
     api.include_router(instagram_chat.webhook_router)  # [NEW] Instagram webhook
+    api.include_router(intel_lake.router)  # Intel Lake Wave 1 ingest (mig 168)
     api.include_router(webhooks.router)  # External webhooks (OpenClaw, etc.)
     api.include_router(
         messaging_identity.router,

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`264 routers · 548 services · 924 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`265 routers · 548 services · 924 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Problem

Drain worker hit 401 Unauthorized:
- HybridAuthMiddleware blocked /api/intel/lake/observations before reaching the router (X-Producer-Token check was never invoked)
- Router only registered in include_light_routers() — heavy/_RAG process app routes test failed

## Fix

1. Add /api/intel/lake/observations + /api/intel/lake/observations-batch to PUBLIC_ENDPOINTS._INFRA (X-Producer-Token enforced in-router)
2. Rename router path observations:batch → observations-batch (FastAPI test rejected `:` segment)
3. Manifest entry intel_lake _API → _BOTH
4. Register intel_lake.router in include_routers() (heavy) alongside existing include_light_routers()

Drain client patched to new URL.

## Test plan
- [x] 39 tests passing (public_endpoints_registry + router_manifest + migration 168)
- [ ] Post-deploy curl smoke test → 200

🤖 Generated with Claude Code