### PR TITLE
feat(bali-intel-scraper): IntelScraperHGTBridge post-pipeline emit (Phase 3 TICKET B)

### DIFF
--- a/apps/bali-intel-scraper/backend/cell/cell_post_emit.py
+++ b/apps/bali-intel-scraper/backend/cell/cell_post_emit.py
@@ -1,0 +1,208 @@
+"""Phase 3 TICKET B — IntelScraperHGTBridge post-pipeline emit.
+
+Wires the existing IntelScraperHGTBridge (from
+``apps/bali-intel-scraper/backend/cell/hgt_publisher.py:116``) into the
+nightly cron entry script ``apps/bali-intel-scraper/scripts/run_intel_pipeline.py``
+via async post-emit sidecar.
+
+ARCHITECTURAL PIVOT (post 4-panel review): uses HGT-only path,
+NOT ``IntelScraperCellRunner``. Reasons (see spec v2 §"Pivot"):
+- ``IntelScraperCellRunner`` requires ``event_bridge: IntelScraperEventBridge``
+- ``IntelScraperEventBridge`` constructor needs ``ObservedShellBus``
+  (lives in ``backend-rag``, cross-package import smell)
+- ``DATABASE_URL`` NOT in ``com.balizero.intel.nightly.plist`` (verified
+  via ``plutil -extract EnvironmentVariables``)
+- HGT-only path sidesteps both dependencies
+
+Best-effort: any failure (Redis unreachable, wrong instance, import
+error, runner exception) results in graceful no-op. Caller wraps with
+``asyncio.wait_for(..., timeout=60.0)`` for cron safety.
+
+Refusals respected (Phase 3 spec v2 §14):
+- No edits to ``com.balizero.intel.nightly.plist``
+- No new PG_CHANNEL_MAP entries
+- No edits to ``packages/cell-core/cell_core/hgt/*`` (TICKET A.0 only)
+- No edits to ``runner.py`` or ``event_bridge.py`` (HGT-only sidesteps)
+- No HGT kill-switch lift
+- No synchronous Redis calls
+- No edits to ``apps/backend-rag/backend/services/events/observed_shell.py``
+
+Reference:
+- Spec v2: ``research/symbiosis/2026-05-13-ticket-b-narrow-spec.md``
+- Brainstorm: ``docs/audits/2026-05-13-ticket-b-spec-brainstorm/``
+- Parent Phase 3 spec v2: ``docs/superpowers/specs/2026-05-12-phase3-hgt-execution-spec.md``
+"""
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def _build_hgt_bridge() -> Any:
+    """Build ``IntelScraperHGTBridge`` with Redis preflight + fallback.
+
+    Returns bridge instance on success, ``None`` on any failure.
+    Mandatory ``XLEN cell:skills >= 18`` signature check (Phase 2.5
+    seed) confirms canonical Pro localhost Redis vs Mini split-brain.
+
+    Best-effort: cleanly closes the redis client on any exception path.
+    """
+    import os
+
+    redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379")
+    client = None
+    try:
+        import redis.asyncio as redis_async
+
+        from backend.cell.hgt_publisher import IntelScraperHGTBridge
+
+        client = redis_async.from_url(redis_url, decode_responses=False)
+        cell_skills_len = await client.xlen("cell:skills")
+        if cell_skills_len < 18:
+            logger.error(
+                "intel_scraper.preflight_failed cell_skills_len=%d expected_min=18 "
+                "redis_url=%s — likely WRONG Redis instance. Aborting cell emit.",
+                cell_skills_len,
+                redis_url,
+            )
+            await client.aclose()
+            return None
+        logger.info(
+            "intel_scraper.preflight_ok cell_skills_len=%d redis_url=%s",
+            cell_skills_len,
+            redis_url,
+        )
+
+        bridge = IntelScraperHGTBridge.from_redis(
+            redis_client=client,
+            cell_name="intel-scraper-cell",
+            maxlen=1000,
+        )
+        return bridge
+    except Exception as exc:  # noqa: BLE001 — defense in depth
+        logger.error(
+            "intel_scraper.hgt_bridge_assembly_failed err=%r — fallback to no-op",
+            exc,
+        )
+        if client is not None:
+            try:
+                await client.aclose()
+            except Exception:  # noqa: BLE001
+                pass
+        return None
+
+
+def _extract_source(article: dict[str, Any]) -> str:
+    """Extract canonical source name with schema-drift fallback chain.
+
+    Empirical (verified 2026-05-13 00:55 WITA): articles in
+    ``pipeline.state['articles']`` use ``'source_name'`` as primary
+    (5 grep matches in ``run_intel_pipeline.py`` at lines
+    429/959/1169/1475/1750), ``'source'`` as fallback. Final fallback
+    to URL string, then literal ``'unknown'``.
+    """
+    return (
+        article.get("source_name")
+        or article.get("source")
+        or article.get("url", "unknown")
+    )
+
+
+async def emit_pipeline_run(pipeline_state: dict[str, Any]) -> None:
+    """Post-pipeline emit: compute ``rss_feed_stable`` pattern + publish via HGT.
+
+    Best-effort: any exception swallowed with log. Single structural
+    pattern v1: ``intel.source.rss_feed_stable_<source>_<run_id>``
+    emitted when ≥1 source yielded ≥3 articles in this nightly run.
+
+    Args:
+        pipeline_state: ``IntelPipeline.state`` dict with ``articles`` list
+            and ``run_id`` string. Tolerates missing keys via ``.get()``.
+    """
+    bridge = await _build_hgt_bridge()
+    if bridge is None:
+        return
+
+    articles = pipeline_state.get("articles", [])
+    if not articles:
+        logger.info(
+            "intel_scraper.hgt_emit_skipped reason=no_articles "
+            "pipeline_state_keys=%s",
+            list(pipeline_state.keys()),
+        )
+        return
+
+    # Aggregate articles per canonical source
+    source_counts: dict[str, int] = defaultdict(int)
+    for article in articles:
+        src = _extract_source(article)
+        source_counts[src] += 1
+
+    # Emit pattern only for strong sources (>= 3 articles)
+    strong_sources = [
+        (src, n) for src, n in source_counts.items() if n >= 3
+    ]
+    if not strong_sources:
+        max_count = max(source_counts.values()) if source_counts else 0
+        logger.info(
+            "intel_scraper.hgt_emit_no_strong_sources articles=%d "
+            "unique_sources=%d max_count=%d",
+            len(articles),
+            len(source_counts),
+            max_count,
+        )
+        return
+
+    try:
+        from backend.cell.hgt_publisher import StructuralPattern
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "intel_scraper.structural_pattern_import_failed err=%r", exc,
+        )
+        return
+
+    published_count = 0
+    run_id = pipeline_state.get("run_id", "unknown")
+    for source_name, article_count in strong_sources:
+        pattern = StructuralPattern(
+            pattern_id=f"rss_feed_stable_{source_name}_{run_id}",
+            source=source_name,
+            procedure=(
+                f"Source {source_name} consistently yields articles "
+                f"({article_count} in nightly run {run_id})"
+            ),
+            precondition="nightly intel-scraper crawl",
+            success_criterion=(
+                f"source {source_name} yields ≥3 articles in next "
+                "nightly run"
+            ),
+            confidence=0.8,
+            domain="news",
+        )
+        try:
+            published = await bridge.publish(pattern)
+            if published:
+                published_count += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "intel_scraper.pattern_publish_failed source=%s err=%r",
+                source_name,
+                exc,
+            )
+
+    logger.info(
+        "intel_scraper.hgt_emit_complete strong_sources=%d "
+        "published=%d run_id=%s",
+        len(strong_sources),
+        published_count,
+        run_id,
+    )
+
+
+__all__ = [
+    "emit_pipeline_run",
+    "_extract_source",
+]

--- a/apps/bali-intel-scraper/scripts/run_intel_pipeline.py
+++ b/apps/bali-intel-scraper/scripts/run_intel_pipeline.py
@@ -2123,6 +2123,8 @@ def main():
                        help='Dry run (no publishing)')
     parser.add_argument('--max-enrich', type=int, default=15,
                        help='Max articles to enrich with Claude (default: 15)')
+    parser.add_argument('--no-cell-emit', action='store_true',
+                       help='Disable Phase 3 TICKET B cell-aware HGT post-emit (debug only)')
 
     args = parser.parse_args()
 
@@ -2150,7 +2152,27 @@ def main():
     # Run pipeline
     pipeline = IntelPipeline(config)
     success = pipeline.run()
-    
+
+    # Phase 3 TICKET B — IntelScraperHGTBridge async post-emit (bounded blast).
+    # See spec v2: research/symbiosis/2026-05-13-ticket-b-narrow-spec.md
+    if not args.no_cell_emit:
+        try:
+            import asyncio
+            from backend.cell.cell_post_emit import emit_pipeline_run
+
+            asyncio.run(
+                asyncio.wait_for(
+                    emit_pipeline_run(pipeline.state),
+                    timeout=60.0,
+                )
+            )
+        except asyncio.TimeoutError:
+            print("⚠️ cell post-emit timeout after 60s (non-fatal)",
+                  file=sys.stderr)
+        except Exception as cell_exc:
+            print(f"⚠️ cell post-emit skipped (non-fatal): {cell_exc}",
+                  file=sys.stderr)
+
     sys.exit(0 if success else 1)
 
 

--- a/apps/bali-intel-scraper/tests/integration/test_cell_post_emit.py
+++ b/apps/bali-intel-scraper/tests/integration/test_cell_post_emit.py
@@ -1,0 +1,147 @@
+"""Phase 3 TICKET B EXECUTION — cell_post_emit integration tests.
+
+6 unit tests + 4 _extract_source schema-drift tests covering:
+- _build_hgt_bridge success path (XLEN=18 → bridge instantiated)
+- _build_hgt_bridge failure path (XLEN<18 → returns None, client closed)
+- emit_pipeline_run no-bridge no-op
+- emit_pipeline_run no-articles skip with state-keys log
+- emit_pipeline_run publishes pattern above threshold (≥3 articles/source)
+- _extract_source schema-drift fallback chain (4 sub-tests)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_PACKAGE_PATH = Path(__file__).resolve().parents[2]
+if str(_PACKAGE_PATH) not in sys.path:
+    sys.path.insert(0, str(_PACKAGE_PATH))
+
+from backend.cell.cell_post_emit import (  # noqa: E402
+    _build_hgt_bridge,
+    _extract_source,
+    emit_pipeline_run,
+)
+
+
+@pytest.mark.asyncio
+async def test_build_hgt_bridge_succeeds_with_seed_signature() -> None:
+    """XLEN cell:skills returns 18 → bridge instantiated, no exception."""
+    import redis.asyncio as redis_async
+
+    mock_client = AsyncMock()
+    mock_client.xlen = AsyncMock(return_value=18)
+
+    mock_bridge = MagicMock()
+
+    with (
+        patch.object(redis_async, "from_url", return_value=mock_client),
+        patch(
+            "backend.cell.hgt_publisher.IntelScraperHGTBridge.from_redis",
+            return_value=mock_bridge,
+        ),
+    ):
+        bridge = await _build_hgt_bridge()
+
+    assert bridge is mock_bridge
+    mock_client.xlen.assert_awaited_once_with("cell:skills")
+
+
+@pytest.mark.asyncio
+async def test_build_hgt_bridge_fails_below_seed() -> None:
+    """XLEN cell:skills returns 0 → returns None + closes client."""
+    import redis.asyncio as redis_async
+
+    mock_client = AsyncMock()
+    mock_client.xlen = AsyncMock(return_value=0)
+    mock_client.aclose = AsyncMock()
+
+    with patch.object(redis_async, "from_url", return_value=mock_client):
+        bridge = await _build_hgt_bridge()
+
+    assert bridge is None
+    mock_client.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_emit_pipeline_run_no_bridge_is_noop() -> None:
+    """bridge=None → emit_pipeline_run returns silently, no exception."""
+    with patch(
+        "backend.cell.cell_post_emit._build_hgt_bridge",
+        return_value=None,
+    ):
+        # Should NOT raise
+        await emit_pipeline_run({"run_id": "test", "articles": []})
+
+
+@pytest.mark.asyncio
+async def test_emit_pipeline_run_no_articles_skips() -> None:
+    """Empty articles list → log info + return without exception."""
+    mock_bridge = AsyncMock()
+    mock_bridge.publish = AsyncMock(return_value=True)
+
+    with patch(
+        "backend.cell.cell_post_emit._build_hgt_bridge",
+        return_value=mock_bridge,
+    ):
+        await emit_pipeline_run({"run_id": "t1", "articles": []})
+
+    mock_bridge.publish.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_emit_pipeline_run_publishes_pattern_above_threshold() -> None:
+    """≥3 articles from same source → bridge.publish called with canonical pattern."""
+    mock_bridge = AsyncMock()
+    mock_bridge.publish = AsyncMock(return_value=True)
+
+    state = {
+        "run_id": "20260513_010000",
+        "articles": [
+            {"source_name": "djp.go.id", "title": "a1"},
+            {"source_name": "djp.go.id", "title": "a2"},
+            {"source_name": "djp.go.id", "title": "a3"},
+            {"source_name": "imigrasi.go.id", "title": "b1"},
+            {"source_name": "imigrasi.go.id", "title": "b2"},
+        ],
+    }
+
+    with patch(
+        "backend.cell.cell_post_emit._build_hgt_bridge",
+        return_value=mock_bridge,
+    ):
+        await emit_pipeline_run(state)
+
+    # djp.go.id has 3 articles (≥3 threshold), imigrasi.go.id has only 2
+    mock_bridge.publish.assert_awaited_once()
+    pattern = mock_bridge.publish.call_args[0][0]
+    assert pattern.pattern_id == "rss_feed_stable_djp.go.id_20260513_010000"
+    assert pattern.source == "djp.go.id"
+    assert "djp.go.id" in pattern.procedure
+    assert "3" in pattern.procedure  # article_count in message
+    assert pattern.confidence == 0.8
+    assert pattern.domain == "news"
+    assert pattern.precondition == "nightly intel-scraper crawl"
+
+
+def test_extract_source_schema_drift_primary_source_name() -> None:
+    """source_name takes precedence over source and url."""
+    assert _extract_source({"source_name": "a", "source": "b", "url": "c"}) == "a"
+
+
+def test_extract_source_schema_drift_fallback_source() -> None:
+    """source used when source_name absent."""
+    assert _extract_source({"source": "b", "url": "c"}) == "b"
+
+
+def test_extract_source_schema_drift_fallback_url() -> None:
+    """url used when source_name and source absent."""
+    assert _extract_source({"url": "c"}) == "c"
+
+
+def test_extract_source_schema_drift_fallback_unknown() -> None:
+    """unknown literal returned when all fields absent."""
+    assert _extract_source({}) == "unknown"


### PR DESCRIPTION
## Summary
- **Phase 3 TICKET B EXECUTION** — wires IntelScraperHGTBridge into nightly cron via async post-emit sidecar.
- NEW \`cell_post_emit.py\` (~210 LOC) + NEW \`test_cell_post_emit.py\` (~150 LOC, 9 tests) + modify \`run_intel_pipeline.py\` main() (+24 LOC argparse + asyncio.wait_for guard).
- **Architectural PIVOT**: HGT-only path (no event_bridge dependency). DATABASE_URL plist env not needed.

## Verification (all green local)
- ✅ **9/9** new test_cell_post_emit.py tests
- ✅ **35/35** intel-scraper-cell regression
- ✅ **9/9** cell-core publisher regression (A.0 preserved)
- ✅ **15/15** crm-cell regression (A.1 preserved)
- ✅ **24/24** backend-rag crm_hgt_handlers regression (A.2 preserved)
- **Total: 92 tests passing across A.0→A.1→A.2→B chain**

## Diff stats
- 3 files changed (+379 / -1)
- \`apps/bali-intel-scraper/backend/cell/cell_post_emit.py\` NEW (+208)
- \`apps/bali-intel-scraper/tests/integration/test_cell_post_emit.py\` NEW (+147)
- \`apps/bali-intel-scraper/scripts/run_intel_pipeline.py\` MODIFY (+23 / -1)

## Pattern shipped (v1 scope)
- **intel.source.rss_feed_stable_<source>_<run_id>** — domain="news", confidence=0.8, threshold ≥3 articles/source/run
- emit via IntelScraperHGTBridge.publish() → cell:skills XADD
- Aggregation per canonical source (schema-drift handled via _extract_source)

## Empirical state preserved
- ✅ A.0 (PR #626) cell_name property consumed via public API
- ✅ A.1 (PR #632) CrmHGTBridge async — unaffected
- ✅ A.2 (PR #636) crm_hgt_handlers — unaffected
- ✅ "crm" CANONICAL_DOMAINS line 18
- ✅ redis-cli XLEN cell:skills = 18 (will increment after first nightly cron with ≥3 articles/source)
- ✅ apps/evaluator/seo_cell/ zero HGT touch (no regression risk)

## Refusals respected (Phase 3 spec v2 §14)
- ❌ No plist edits (HGT-only pivot avoids DATABASE_URL requirement)
- ❌ No new PG_CHANNEL_MAP entries
- ❌ No edits to packages/cell-core/cell_core/hgt/* (A.0 only)
- ❌ No edits to runner.py or event_bridge.py (HGT-only sidesteps)
- ❌ No HGT kill-switch lift
- ❌ No synchronous Redis calls
- ❌ No edits to observed_shell.py

## Post-merge behavior
After this PR + first nightly cron run with ≥3 articles per source:
- redis-cli XLEN cell:skills increments with intel.source.rss_feed_stable* entries
- cell_origin="intel-scraper-cell", domain="news" in stream entries
- Combined with A.2 crm-cell publisher, cell:skills has 2 production publishers
- Sentinel-1 consumer-group (when TICKET C ships) consumes both

## Bounded blast
- asyncio.wait_for 60s timeout prevents cron stall (Gemini F2 MEDIUM)
- try/except around asyncio.run prevents pipeline failure cascade
- TimeoutError + generic Exception logged as non-fatal warnings
- Production cron exit code unaffected by cell emit failures
- --no-cell-emit CLI flag for emergency debug bypass

## Reference
- Narrow spec v2 (merged via PR #637 auto-merge): research/symbiosis/2026-05-13-ticket-b-narrow-spec.md
- 4-panel brainstorm: docs/audits/2026-05-13-ticket-b-spec-brainstorm/
- Parent Phase 3 spec v2: docs/superpowers/specs/2026-05-12-phase3-hgt-execution-spec.md
- A.0 merge: PR #626 → 6e92046d8
- A.1 EXECUTION merge: PR #632 → 84953041b
- A.2 EXECUTION merge: PR #636 → 848e76a65
- B spec PR: #637

## Test plan
- [x] Local unit tests pass (92/92 across A.0→A.1→A.2→B chain)
- [x] Pre-commit hooks pass (import chain validation OK)
- [ ] Required CI: E2E + Frontend + MCP + Detect Secrets
- [ ] Auto-merge SQUASH on CI green
- [ ] Operator manually validates first nightly cron post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)