### PR TITLE
feat(mata-garuda): run_sentinel_cell shim (Phase 3 TICKET C)

### DIFF
--- a/apps/mata-garuda/scripts/run_sentinel_cell.py
+++ b/apps/mata-garuda/scripts/run_sentinel_cell.py
@@ -1,0 +1,136 @@
+"""Sentinel Cell hourly runner — single-pulse driver for cron / LaunchAgent.
+
+Phase 3 TICKET C — switches sentinel cron entry from legacy
+``run_sentinel_py.py`` (bypass) to ``PulseLoop.single_pulse()`` invocation
+via ``create_sentinel_cell()``. Activates HGTConsumer reflect phase
+(``sentinel_cell.py:167-170``) which consumes from ``cell:skills`` via
+sentinel-1 consumer group.
+
+This is a CLONE of ``apps/evaluator/seo_cell/run_seo_cell.py`` canonical
+pattern (NB-1 ground-truth signal from 4-panel brainstorm 2026-05-13).
+Boilerplate replicated verbatim for:
+
+- KeyboardInterrupt handling (exit 130)
+- structured logging stdout/stderr merge for LaunchAgent
+- Gap 1 Layer 2 fix: ``asyncio.all_tasks()`` blanket wait with 10s timeout
+  after ``single_pulse()`` so fire-and-forget observatory emit task
+  completes before ``asyncio.run()`` destroys the event loop
+
+The Gap 1 Layer 2 fix OVERRIDES Phase 3 spec v2 CORR-9 (which forbade
+``asyncio.all_tasks``) per empirical evidence from the seo_cell
+precedent. ``cell_core.pulse:265`` schedules observatory emit as
+fire-and-forget ``asyncio.create_task``; without the blanket wait the
+task gets cancelled before sqlite/PG write completes →
+``observatory.db`` row LOST.
+
+Layer A (plist target) and Layer B (script bypass) are BOTH fixed by
+switching the plist ``ProgramArguments`` to invoke this file. The
+legacy ``run_sentinel_py.py`` is preserved for manual debug
+invocation.
+
+Reference:
+- Spec v2: ``research/symbiosis/2026-05-13-ticket-c-narrow-spec.md``
+- Canonical pattern: ``apps/evaluator/seo_cell/run_seo_cell.py``
+- Gap 1 Layer 2: ``research/symbiosis/2026-05-12-cell-silenti-root-cause-and-fix.md``
+- Parent Phase 3 spec v2: ``docs/superpowers/specs/2026-05-12-phase3-hgt-execution-spec.md``
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+# Add apps/mata-garuda to sys.path so imports resolve from cron context.
+# Necessary because plist invokes the script directly (not via python -m).
+_PACKAGE_PATH = Path(__file__).resolve().parents[1]
+if str(_PACKAGE_PATH) not in sys.path:
+    sys.path.insert(0, str(_PACKAGE_PATH))
+
+logger = logging.getLogger("sentinel_cell.runner")
+
+
+def _configure_logging(verbose: bool) -> None:
+    """Stdout for INFO+, stderr for WARNING+. LaunchAgent merges them."""
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG if verbose else logging.INFO)
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s %(levelname)s %(name)s %(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%S%z",
+        )
+    )
+    root.handlers = [handler]
+
+
+async def _run_one_pulse() -> int:
+    """Drive one PulseLoop.single_pulse() and exit with health-based code.
+
+    Returns:
+        0 if pulse health != 'red' (or single_pulse returned cleanly)
+        1 on single_pulse exception or health == 'red'
+    """
+    # Local import — keeps argparse/logging imports cheap when --help.
+    from mata_garuda.cells.sentinel_cell import create_sentinel_cell
+
+    cell = create_sentinel_cell()
+    try:
+        result = await cell.single_pulse()
+    except Exception as e:  # noqa: BLE001
+        logger.exception("[sentinel] single_pulse raised: %r", e)
+        return 1
+
+    logger.info(
+        "[sentinel] pulse #%s done health=%s action=%s halted=%s",
+        result.pulse_number,
+        result.health_status,
+        result.action_taken,
+        result.halted,
+    )
+
+    # Gap 1 Layer 2 fix 2026-05-12 (cloned from seo_cell run_seo_cell.py):
+    # cell_core.pulse:265 schedules the observatory emit as fire-and-forget
+    # asyncio.create_task. Without this cleanup wait, asyncio.run() exits
+    # before the emit task can finish its PG INSERT + NOTIFY, leaving
+    # observatory.db without the sentinel row.
+    # OVERRIDES Phase 3 spec v2 CORR-9 (forbidding asyncio.all_tasks()
+    # blanket wait) per empirical evidence from seo_cell precedent.
+    pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    if pending:
+        logger.info(
+            "[sentinel] awaiting %d fire-and-forget tasks (observatory emit)",
+            len(pending),
+        )
+        try:
+            await asyncio.wait(pending, timeout=10.0)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("[sentinel] pending-task wait raised: %r", e)
+
+    # 'red' health is a soft failure — the cell is still running but a
+    # sensor is having connectivity issues. cron exits 0 = healthy enough
+    # to keep running. cron alerts (via shell wrapper) on non-zero exit.
+    return 0 if result.health_status != "red" else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run one Sentinel Cell pulse (cron-style)."
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true",
+        help="DEBUG logging (default INFO).",
+    )
+    args = parser.parse_args()
+    _configure_logging(args.verbose)
+
+    try:
+        return asyncio.run(_run_one_pulse())
+    except KeyboardInterrupt:
+        logger.warning("[sentinel] interrupted by signal")
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/mata-garuda/tests/test_run_sentinel_cell.py
+++ b/apps/mata-garuda/tests/test_run_sentinel_cell.py
@@ -1,0 +1,90 @@
+"""Phase 3 TICKET C EXECUTION — run_sentinel_cell shim tests.
+
+4 unit tests with concrete mocks (per spec v2 CORR-C5):
+- _run_one_pulse returns 0 on health='green'
+- _run_one_pulse returns 1 on health='red' (cron alerts on non-zero)
+- _run_one_pulse returns 0 on health='yellow' (only red triggers alert)
+- _run_one_pulse returns 1 on single_pulse() exception
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Add the mata-garuda package to sys.path so scripts/ + mata_garuda/ resolve
+_PACKAGE_PATH = Path(__file__).resolve().parents[1]
+if str(_PACKAGE_PATH) not in sys.path:
+    sys.path.insert(0, str(_PACKAGE_PATH))
+
+# Import the shim module (triggers its own sys.path insert as side effect)
+from scripts.run_sentinel_cell import _run_one_pulse  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_run_one_pulse_returns_0_on_green_health() -> None:
+    """health='green' → _run_one_pulse() returns 0."""
+    mock_cell = MagicMock()
+    mock_result = MagicMock()
+    mock_result.pulse_number = 1
+    mock_result.health_status = "green"
+    mock_result.action_taken = "none"
+    mock_result.halted = False
+    mock_cell.single_pulse = AsyncMock(return_value=mock_result)
+
+    with patch(
+        "mata_garuda.cells.sentinel_cell.create_sentinel_cell",
+        return_value=mock_cell,
+    ):
+        assert await _run_one_pulse() == 0
+
+
+@pytest.mark.asyncio
+async def test_run_one_pulse_returns_1_on_red_health() -> None:
+    """health='red' → _run_one_pulse() returns 1 (cron alerts on non-zero)."""
+    mock_cell = MagicMock()
+    mock_result = MagicMock()
+    mock_result.pulse_number = 2
+    mock_result.health_status = "red"
+    mock_result.action_taken = None
+    mock_result.halted = False
+    mock_cell.single_pulse = AsyncMock(return_value=mock_result)
+
+    with patch(
+        "mata_garuda.cells.sentinel_cell.create_sentinel_cell",
+        return_value=mock_cell,
+    ):
+        assert await _run_one_pulse() == 1
+
+
+@pytest.mark.asyncio
+async def test_run_one_pulse_returns_0_on_yellow_health() -> None:
+    """health='yellow' → _run_one_pulse() returns 0 (only red triggers alert)."""
+    mock_cell = MagicMock()
+    mock_result = MagicMock()
+    mock_result.pulse_number = 3
+    mock_result.health_status = "yellow"
+    mock_result.action_taken = "none"
+    mock_result.halted = False
+    mock_cell.single_pulse = AsyncMock(return_value=mock_result)
+
+    with patch(
+        "mata_garuda.cells.sentinel_cell.create_sentinel_cell",
+        return_value=mock_cell,
+    ):
+        assert await _run_one_pulse() == 0
+
+
+@pytest.mark.asyncio
+async def test_run_one_pulse_returns_1_on_single_pulse_exception() -> None:
+    """single_pulse() raises → _run_one_pulse() returns 1, no propagation."""
+    mock_cell = MagicMock()
+    mock_cell.single_pulse = AsyncMock(side_effect=RuntimeError("test error"))
+
+    with patch(
+        "mata_garuda.cells.sentinel_cell.create_sentinel_cell",
+        return_value=mock_cell,
+    ):
+        assert await _run_one_pulse() == 1


### PR DESCRIPTION
## Summary
- **Phase 3 TICKET C EXECUTION** — NEW \`run_sentinel_cell.py\` shim cloning canonical \`apps/evaluator/seo_cell/run_seo_cell.py\` pattern (NB-1 ground-truth signal).
- 4 unit tests with concrete mocks (all green local).
- Plist swap is OPERATOR-GATED (separate manual action per spec v2 7-step workflow).

## Verification (all green local)
- ✅ **4/4** new \`test_run_sentinel_cell.py\` tests
- ✅ **10/10** mata-garuda regression (test_sentinel_cell.py preserved)
- ✅ **134/134** seo_cell regression (canonical pattern preserved)
- ✅ **18/18** cell-core consumer + publisher regression
- **Total: 166 tests passing**

## Diff stats
- 2 files changed (+226)
- \`apps/mata-garuda/scripts/run_sentinel_cell.py\` NEW (+136)
- \`apps/mata-garuda/tests/test_run_sentinel_cell.py\` NEW (+90)

## CRITICAL: Phase 3 spec v2 CORR-9 OVERRIDDEN

This shim uses \`asyncio.all_tasks()\` blanket wait with 10s timeout after \`single_pulse()\`. This OVERRIDES Phase 3 spec v2 CORR-9 which forbade it. Empirical evidence from \`apps/evaluator/seo_cell/run_seo_cell.py\` Gap 1 Layer 2 fix (2026-05-12):
- \`cell_core.pulse:265\` schedules observatory emit as fire-and-forget \`asyncio.create_task()\`
- \`asyncio.run()\` shutdown CANCELS pending tasks
- Without blanket wait → \`observatory.db\` row LOST

CORR-9 was empirically wrong; this PR uses the correct pattern per seo_cell precedent.

## Architecture (clone seo_cell)
\`\`\`
com.matagaruda.sentinel.hourly cron (hourly)
  ↓ ProgramArguments invokes (post operator plist swap)
.venv/bin/python -u scripts/run_sentinel_cell.py
  ↓ main() asyncio.run(_run_one_pulse)
_run_one_pulse():
  create_sentinel_cell() → PulseLoop with HGTConsumer wired
  ↓
  await cell.single_pulse()  ← one PulseResult
  ↓ sense→think→act→reflect→dream→mature
  sentinel_cell.py:167-170 reflect phase:
    await hgt_consumer.ensure_group()
    await hgt_consumer.consume_once()
  ↓
  Gap 1 Layer 2 fix: asyncio.all_tasks() wait 10s
  → observatory emit task completes
  ↓
  observatory.db cell_id='sentinel' row written
  ↓
  exit 0 if health != 'red' else 1
\`\`\`

## Post-merge plan (operator-gated)

After PR #641 merges:
1. **Operator manual smoke test** (verifies code works before plist swap):
   \`\`\`bash
   cd ~/Desktop/nuzantara/apps/mata-garuda && \\
     .venv/bin/python -u scripts/run_sentinel_cell.py --verbose
   \`\`\`
   Expected: exit 0, log lines \`[sentinel] pulse #N done health=green/yellow\`, observatory.db gains 1 row \`cell_id='sentinel'\` within 30s.

2. **Operator 7-step plist swap workflow** (spec v2 §"Implementation File 2"):
   - chmod u+w (lift antibody)
   - plutil -replace ProgramArguments (point to run_sentinel_cell.py)
   - plutil -lint
   - Verify swap + EnvironmentVariables preserved
   - chmod 0444 (restore antibody)
   - launchctl print state pre-check (no active tick)
   - bootout + bootstrap + log verification

3. **First hourly tick post-swap**:
   - observatory.db cell_id='sentinel' ≥1 row in last 1h
   - sentinel-1 consumer group entries-read > 0 (if XLEN > 18)
   - sentinel-1 pending=0 post-tick

4. **Rollback procedure** documented in spec v2 §"Rollback".

## Empirical state preserved
- ✅ A.0 → B chain merged (PR #626/#632/#636/#639)
- ✅ \`sentinel_cell.py:46\` create_sentinel_cell() exists
- ✅ HGTConsumer wired sentinel_cell.py lines 25/91/95/126/136/141/167-170
- ✅ \`pulse.py:82\` single_pulse method
- ✅ \`consumer.py:50\` ensure_group, \`consumer.py:61\` consume_once
- ✅ run_seo_cell.py canonical pattern (111 LOC) — cloned verbatim
- ✅ observatory.db cell_id='sentinel' 24h = 0 events (confirms bypass to be replaced)
- ✅ sentinel-1 consumer group idle (will activate post-plist-swap)
- ✅ redis-cli XLEN cell:skills = 18 (Phase 2.5 seed)

## Refusals respected (Phase 3 spec v2 §14)
- ❌ NO autonomous \`launchctl bootstrap\` (refusal #1 — operator manual)
- ❌ NO edits to \`packages/cell-core/cell_core/hgt/*\` (refusal #9, A.0 only)
- ❌ NO edits to \`apps/evaluator/seo_cell/\` (refusal #13 — clone target preserved)
- ❌ NO edits to \`run_sentinel_py.py\` (legacy preserved for debug)
- ❌ NO edits to \`sentinel_cell.py\` (HGTConsumer already wired correctly)
- ❌ NO HGT kill-switch lift
- ❌ NO synchronous \`asyncio.run\` in HGT app code (handler async)
- ❌ NO plist edits in this PR (operator manual workflow)
- **Phase 3 spec v2 CORR-9 OVERRIDDEN** per empirical seo_cell precedent

## Reference
- Narrow spec v2 PR: #640 (auto-merge armed)
- Canonical clone target: \`apps/evaluator/seo_cell/run_seo_cell.py\`
- Gap 1 Layer 2 fix: \`research/symbiosis/2026-05-12-cell-silenti-root-cause-and-fix.md\`
- Parent Phase 3 spec v2: \`docs/superpowers/specs/2026-05-12-phase3-hgt-execution-spec.md\` (CORR-9 OVERRIDDEN)
- A.0 merge: PR #626 → \`6e92046d8\`
- A.1 EXECUTION merge: PR #632 → \`84953041b\`
- A.2 EXECUTION merge: PR #636 → \`848e76a65\`
- B EXECUTION merge: PR #639 → \`ad09a0876\`

## Test plan
- [x] Local unit tests pass (4/4 new + 162 regression)
- [x] Pre-commit hooks pass
- [ ] Required CI: E2E + Frontend + MCP + Detect Secrets
- [ ] Auto-merge SQUASH on CI green
- [ ] Operator manual smoke test post-merge
- [ ] Operator 7-step plist swap (manual, gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)