### PR TITLE
feat(llm): migrate DeepSeek client to V4 Pro flagship

### DIFF
--- a/apps/backend-rag/backend/llm/deepseek_client.py
+++ b/apps/backend-rag/backend/llm/deepseek_client.py
@@ -3,13 +3,20 @@
 Used by backend paths that previously ran Claude via Max OAuth but
 suffered from the upstream `claude` CLI non-TTY hang inside the Fly
 container (see `memory/feedback_claude_cli_linux_hang.md`). DeepSeek is
-cheaper (~100x) than Claude Sonnet for structured JSON generation and
+cheaper than Claude Sonnet for structured JSON generation and
 returns usage counters properly.
 
 Endpoint: `https://api.deepseek.com/v1/chat/completions` (OpenAI-style).
-Models:
-- ``deepseek-chat``: DeepSeek V3.2, general-purpose, cheapest.
-- ``deepseek-reasoner``: DeepSeek R1 reasoning (not used here).
+Models (DeepSeek V4 release 2026-04-24, ref api-docs.deepseek.com/news/news260424):
+- ``deepseek-v4-pro``: V4 Pro flagship (1.6T params, 49B activated, 1M ctx).
+- ``deepseek-v4-flash``: V4 Flash (284B params, 13B activated, 1M ctx).
+- Legacy aliases ``deepseek-chat`` (→ V4-Flash non-think) and
+  ``deepseek-reasoner`` (→ V4-Flash thinking) are deprecated 2026-07-24.
+
+V4 supports three reasoning modes via ``reasoning_effort`` parameter:
+- ``"low"``  : Non-think (fast, cheap)
+- ``"high"`` : Think High (balanced)
+- ``"max"``  : Think Max (deep chain-of-thought, recommended for Consiglio)
 
 Auth: ``DEEPSEEK_API_KEY`` env var (already deployed on `nuzantara-rag`).
 """
@@ -20,15 +27,17 @@ import logging
 import os
 import time
 from dataclasses import dataclass
-from typing import Any, Final
+from typing import Any, Final, Literal
 
 import httpx
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_MODEL: Final[str] = "deepseek-chat"
+DEFAULT_MODEL: Final[str] = "deepseek-v4-pro"
 DEFAULT_BASE_URL: Final[str] = "https://api.deepseek.com/v1"
 DEFAULT_TIMEOUT_S: Final[float] = 60.0
+
+ReasoningEffort = Literal["low", "high", "max"]
 
 
 class DeepSeekError(RuntimeError):
@@ -85,6 +94,7 @@ async def complete_async(
     timeout_s: float = DEFAULT_TIMEOUT_S,
     endpoint: str | None = None,
     request_id: str | None = None,
+    reasoning_effort: ReasoningEffort | None = None,
 ) -> DeepSeekResponse:
     """Run a one-shot chat completion against DeepSeek.
 
@@ -96,7 +106,8 @@ async def complete_async(
     Args:
         prompt: User prompt. Kept as a single string for call-site parity
             with the old ``claude -p`` subprocess wrapper.
-        model: Model slug (``deepseek-chat`` by default).
+        model: Model slug. Defaults to ``deepseek-v4-pro`` (V4 flagship).
+            Use ``deepseek-v4-flash`` for cheaper general-purpose calls.
         system: Optional system prompt.
         max_tokens: Upper bound on completion tokens.
         temperature: Sampling temperature. 0.3 is a reasonable default
@@ -110,6 +121,12 @@ async def complete_async(
             it all DeepSeek calls show up as ``endpoint=unknown``.
         request_id: Correlation id propagated from the HTTP request, if
             available.
+        reasoning_effort: DeepSeek V4 reasoning mode. One of
+            ``"low"`` (Non-think, fast), ``"high"`` (Think High,
+            balanced) or ``"max"`` (Think Max, deep chain-of-thought).
+            ``None`` lets the API pick the default. Recommended values:
+            ``"max"`` for Consiglio gate-6 deliberation, ``"low"`` for
+            structured JSON generation, ``"high"`` for general reasoning.
 
     Returns:
         :class:`DeepSeekResponse` with the completion text + usage
@@ -151,6 +168,8 @@ async def complete_async(
         }
         if response_format is not None:
             payload["response_format"] = response_format
+        if reasoning_effort is not None:
+            payload["reasoning_effort"] = reasoning_effort
 
         base_url = os.getenv("DEEPSEEK_BASE_URL", DEFAULT_BASE_URL).rstrip("/")
         url = f"{base_url}/chat/completions"
@@ -196,13 +215,28 @@ async def complete_async(
         cache_hit_tokens = int(usage.get("prompt_cache_hit_tokens") or 0)
         model_returned = str(data.get("model") or model)
 
-        # Cost: DeepSeek V3.2 pricing, in USD per 1M tokens.
-        # Cache hit: $0.07/M input. Cache miss: $0.28/M input. Output: $0.42/M.
+        # Cost: DeepSeek V4 pricing (USD per 1M tokens, 2026-04-24 release).
+        # V4 Pro flagship: cache hit $0.435, cache miss $0.435 (input),
+        # output $0.87. (75% promo until 2026-05-31 lowers cache-hit input
+        # to $0.003625; we use list price here to be conservative.)
+        # V4 Flash: cache hit $0.0028, cache miss $0.14, output $0.28.
+        # Legacy ``deepseek-chat``/``deepseek-reasoner`` aliases route to
+        # V4-Flash on DeepSeek side and are billed at flash rates.
+        model_lc = (model_returned or model).lower()
+        is_v4_pro = "v4-pro" in model_lc or model_lc.endswith("-pro")
+        if is_v4_pro:
+            input_cm_rate = 0.435  # V4-Pro cache-miss input
+            input_ch_rate = 0.435  # V4-Pro cache-hit input (promo aside)
+            output_rate = 0.87     # V4-Pro output
+        else:
+            input_cm_rate = 0.14   # V4-Flash / legacy aliases
+            input_ch_rate = 0.0028
+            output_rate = 0.28
         cache_miss_tokens = max(0, input_tokens - cache_hit_tokens)
         cost_usd = (
-            cache_miss_tokens * 0.28 / 1_000_000
-            + cache_hit_tokens * 0.07 / 1_000_000
-            + output_tokens * 0.42 / 1_000_000
+            cache_miss_tokens * input_cm_rate / 1_000_000
+            + cache_hit_tokens * input_ch_rate / 1_000_000
+            + output_tokens * output_rate / 1_000_000
         )
 
         success = True

--- a/apps/backend-rag/backend/services/council/cli_runners.py
+++ b/apps/backend-rag/backend/services/council/cli_runners.py
@@ -1,7 +1,7 @@
 """Async CLI runners for Council proponents.
 
 Legge 1 compliance: LLM chiamati via subprocess `claude -p`, `gemini -p`.
-Eccezione esplicita: DeepSeek R1 via HTTP (SYMBIOSIS.md:176).
+Eccezione esplicita: DeepSeek V4 Pro Think Max via HTTP (SYMBIOSIS.md:176).
 
 Each runner:
 - is async (asyncio.create_subprocess_exec) to run 3 proponents in parallel
@@ -167,19 +167,23 @@ class DeepSeekHTTPRunner(CLIRunner):
     default_timeout = 120
 
     API_URL = "https://api.deepseek.com/v1/chat/completions"
-    DEFAULT_MODEL = "deepseek-reasoner"  # R1
+    DEFAULT_MODEL = "deepseek-v4-pro"  # V4 Pro, Think Max recommended
 
     def __init__(
         self,
         api_key: str,
         model: str | None = None,
         http_client: httpx.AsyncClient | None = None,
+        reasoning_effort: str | None = "max",
     ) -> None:
         if not api_key:
             raise CLIRunnerError("DeepSeekHTTPRunner requires api_key")
         self.api_key = api_key
         self.model = model or self.DEFAULT_MODEL
         self._client = http_client
+        # Default to "max" for Consiglio gate-6 deliberation; callers can
+        # override with "low"/"high" or pass None to let the API pick.
+        self.reasoning_effort = reasoning_effort
 
     @llm_cost_tracked(provider="deepseek", model_attr="model")
     async def run(
@@ -191,11 +195,13 @@ class DeepSeekHTTPRunner(CLIRunner):
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
         }
-        payload = {
+        payload: dict[str, Any] = {
             "model": self.model,
             "messages": [{"role": "user", "content": prompt}],
             "temperature": 0.7,
         }
+        if self.reasoning_effort is not None:
+            payload["reasoning_effort"] = self.reasoning_effort
 
         client = self._client or _get_module_client(eff_timeout)
 

--- a/apps/backend-rag/backend/services/llm_clients/pricing.py
+++ b/apps/backend-rag/backend/services/llm_clients/pricing.py
@@ -85,9 +85,20 @@ LLM_PRICING: dict[str, dict[str, float]] = {
         "input": 0.075,
         "output": 0.30,
     },
+    # ── DeepSeek V4 flagship (2026-04-24 release) ──
+    "deepseek/deepseek-v4-pro": {
+        "input": 0.435,
+        "output": 0.87,
+    },
+    "deepseek/deepseek-v4-flash": {
+        "input": 0.14,
+        "output": 0.28,
+    },
+    # Legacy alias — V4-Flash rates apply on DeepSeek side
+    # (DEPRECATED 2026-07-24, kept for backward-compat with old logs)
     "deepseek/deepseek-chat": {
-        "input": 0.27,
-        "output": 1.10,
+        "input": 0.14,
+        "output": 0.28,
     },
     # ── Default fallback (conservative estimate) ──
     "unknown": {
@@ -256,15 +267,28 @@ _PRICING_TABLE: dict[tuple[str, str], dict[str, float]] = {
         "input_per_token": 0.0,
         "output_per_token": 0.0,
     },
-    # ── DeepSeek (Council DeepSeekHTTPRunner + article_composer) ──
-    # Source: https://api-docs.deepseek.com/quick_start/pricing (2026-04, cache-miss rates)
+    # ── DeepSeek V4 flagship (2026-04-24 release) ──
+    # Source: https://api-docs.deepseek.com/news/news260424
+    # V4 Pro: 1.6T params, 49B activated, 1M ctx, ``reasoning_effort`` modes
+    #   (cache-miss/output rates; 75% promo to 2026-05-31 not applied here)
+    ("deepseek", "deepseek-v4-pro"): {
+        "input_per_token": 0.435 / 1_000_000,
+        "output_per_token": 0.87 / 1_000_000,
+    },
+    # V4 Flash: 284B params, 13B activated, 1M ctx
+    ("deepseek", "deepseek-v4-flash"): {
+        "input_per_token": 0.14 / 1_000_000,
+        "output_per_token": 0.28 / 1_000_000,
+    },
+    # Legacy aliases — DEPRECATED 2026-07-24, routed to V4-Flash on DeepSeek side
+    # so V4-Flash rates apply. Kept for backward-compat with historical logs.
     ("deepseek", "deepseek-reasoner"): {
-        "input_per_token": 0.55 / 1_000_000,
-        "output_per_token": 2.19 / 1_000_000,
+        "input_per_token": 0.14 / 1_000_000,
+        "output_per_token": 0.28 / 1_000_000,
     },
     ("deepseek", "deepseek-chat"): {
-        "input_per_token": 0.27 / 1_000_000,
-        "output_per_token": 1.10 / 1_000_000,
+        "input_per_token": 0.14 / 1_000_000,
+        "output_per_token": 0.28 / 1_000_000,
     },
 }
 

--- a/apps/backend-rag/backend/services/research/consiglio_orchestrator.py
+++ b/apps/backend-rag/backend/services/research/consiglio_orchestrator.py
@@ -7,7 +7,7 @@ Current members:
   claude     — Claude Opus 4.7 via OAuth CLI (primary analyst)
   gemini     — Gemini 3.1 Pro (1M ctx) via CLI — gracefully degrades
                on 429 rate limit; result simply omits gemini votes
-  deepseek   — DeepSeek Reasoner ($0.01/query, audited exception)
+  deepseek   — DeepSeek V4 Pro Think Max ($0.01/query, audited exception)
   notebooklm — NotebookLM MCP query — grounded authority validator
 
 If a member fails (network error, rate limit, no binary), the orchestrator

--- a/apps/backend-rag/backend/tests/services/council/test_cli_runners.py
+++ b/apps/backend-rag/backend/tests/services/council/test_cli_runners.py
@@ -76,7 +76,7 @@ def test_deepseek_requires_api_key():
 
 def test_deepseek_runner_default_model():
     r = DeepSeekHTTPRunner(api_key="sk-test")
-    assert r.model == "deepseek-reasoner"
+    assert r.model == "deepseek-v4-pro"
 
 
 # ── ClaudeCLIRunner subprocess errors ──────────────────────────────────

--- a/apps/backend-rag/backend/tests/services/council/test_cli_runners_tracking.py
+++ b/apps/backend-rag/backend/tests/services/council/test_cli_runners_tracking.py
@@ -36,7 +36,7 @@ async def test_deepseek_runner_records_cost_on_success() -> None:
     fake_resp.status_code = 200
     fake_resp.json.return_value = {
         "choices": [{"message": {"content": "test reply"}}],
-        "model": "deepseek-reasoner",
+        "model": "deepseek-v4-pro",
         "usage": {"prompt_tokens": 50, "completion_tokens": 20},
     }
     fake_resp.raise_for_status = MagicMock()
@@ -57,7 +57,7 @@ async def test_deepseek_runner_records_cost_on_success() -> None:
     mock_rec.assert_awaited_once()
     kwargs = mock_rec.await_args.kwargs
     assert kwargs["provider"] == "deepseek"
-    assert kwargs["model"] == "deepseek-reasoner"
+    assert kwargs["model"] == "deepseek-v4-pro"
     assert kwargs["input_tokens"] == 50
     assert kwargs["output_tokens"] == 20
     assert kwargs["success"] is True

--- a/apps/evaluator/cep/run_cep.py
+++ b/apps/evaluator/cep/run_cep.py
@@ -3,7 +3,7 @@
 
 Runs the versioned golden query set against a target answer source
 (``--answers-file`` JSON map, or stub for dry-run), grades each result
-with DeepSeek Reasoner against the rubric (required_facts), and emits a
+with DeepSeek V4 Pro (Think Max mode) against the rubric (required_facts), and emits a
 CSV report + summary suitable for cron + Telegram alerting.
 
 Why DeepSeek as evaluator:
@@ -76,7 +76,8 @@ def grade_with_deepseek(
 ) -> dict[str, Any]:
     """Score a single answer against its rubric."""
     body = {
-        "model": "deepseek-reasoner",
+        "model": "deepseek-v4-pro",
+        "reasoning_effort": "max",
         "messages": [
             {"role": "system", "content": "You are an evaluator. Reply only strict JSON."},
             {"role": "user", "content": DEEPSEEK_RUBRIC_PROMPT.format(

--- a/apps/mata-garuda/.disabled-2026-05-06/council/agents.py
+++ b/apps/mata-garuda/.disabled-2026-05-06/council/agents.py
@@ -165,7 +165,7 @@ class DeepSeekAdapter:
     def __init__(
         self,
         timeout: int = COUNCIL_AGENT_TIMEOUT,
-        model: str = "deepseek-reasoner",
+        model: str = "deepseek-v4-pro",
         api_key_env: str = "DEEPSEEK_API_KEY",
     ):
         self._timeout = timeout


### PR DESCRIPTION
## Summary

- Migrate the DeepSeek HTTP client + pricing tables from V3.2 / R1 aliases (``deepseek-chat`` / ``deepseek-reasoner``) to the V4 flagship released 2026-04-24 (ref [api-docs.deepseek.com/news/news260424](https://api-docs.deepseek.com/news/news260424)). New default: ``deepseek-v4-pro`` (1.6T params / 49B activated / 1M ctx).
- Add ``reasoning_effort`` parameter support (``"low"`` / ``"high"`` / ``"max"``) so callers can pick Non-think, Think-High or Think-Max modes. Consiglio gate-6 deliberation and the CEP rubric grader now default to ``"max"``.
- Rewrite the cost math: V4 Pro charges $0.435 / 1M cache-miss input and $0.87 / 1M output; V4 Flash charges $0.14 / $0.28. Legacy aliases stay in the price tables routed to V4-Flash rates for backward-compat with old logs (removable after 2026-07-24 deprecation).

## Files touched (8 files, +95 / -30)

| File | Change |
|---|---|
| ``apps/backend-rag/backend/llm/deepseek_client.py`` | DEFAULT_MODEL → ``deepseek-v4-pro``; ``ReasoningEffort`` Literal + ``reasoning_effort`` kwarg; V4 pricing math |
| ``apps/backend-rag/backend/services/llm_clients/pricing.py`` | V4 Pro / V4 Flash entries in ``LLM_PRICING`` and ``_PRICING_TABLE``; legacy aliases rebased to flash rates |
| ``apps/backend-rag/backend/services/council/cli_runners.py`` | ``DeepSeekHTTPRunner`` default ``deepseek-v4-pro`` + ``reasoning_effort="max"`` |
| ``apps/backend-rag/backend/services/research/consiglio_orchestrator.py`` | docstring → "DeepSeek V4 Pro Think Max" |
| ``apps/backend-rag/backend/tests/services/council/test_cli_runners*.py`` | assertions updated to ``deepseek-v4-pro`` |
| ``apps/evaluator/cep/run_cep.py`` | CEP grader → ``deepseek-v4-pro`` + ``reasoning_effort="max"`` |
| ``apps/mata-garuda/.disabled-2026-05-06/council/agents.py`` | dormant quarantined prototype, consistency only |

## Pricing math (V4 Pro, USD per 1M tokens, 75% promo not applied)

```
cache_hit_input  = $0.435     # V4-Pro list price
cache_miss_input = $0.435     # V4-Pro list price
output           = $0.87      # V4-Pro list price
```

(V4 Flash: $0.14 / $0.28, used by ``deepseek-v4-flash`` and the legacy ``deepseek-chat``/``deepseek-reasoner`` aliases.)

## Test plan

- [x] ``PYTHONPATH=. pytest backend/tests/services/council/ -q`` → **45 passed in 6.31s**
- [x] Import contract: ``from backend.llm.deepseek_client import complete_async, DEFAULT_MODEL, ReasoningEffort`` → ``DEFAULT_MODEL == "deepseek-v4-pro"``
- [ ] Smoke a real call against ``api.deepseek.com/v1/chat/completions`` with ``DEEPSEEK_API_KEY`` (live test post-merge)
- [ ] Post-deploy: watch ``llm_cost`` Prometheus / Postgres tables for V4 cost lines and confirm cache-miss/output rates land in the expected $0.435 / $0.87 ballpark

## Out of scope (follow-up PR)

Operational scripts that still pass ``deepseek-reasoner`` as the model string (they keep working via the legacy alias until 2026-07-24):

- ``scripts/ai-dispatch.sh`` (federation router)
- ``scripts/codex_tri_llm_review.py``
- ``scripts/nlm_shadow_extractor.py``
- ``scripts/wr2_supervisor.py``
- ``scripts/federation_capability_table.py``
- ``scripts/nlm_activation/run_cep_daily.sh``
- ``apps/backend-rag/scripts/{verified_generator,ingest_tier1_gaps}.py``

Historical artifacts (``docs/brainstorms``, ``docs/research``, ``docs/audits``, ``docs/archive``, ``docs/innervation-2026-04-29``, ``apps/mata-garuda/docs/SESSION_HANDOVER_2026-04-10.md``) intentionally left as-is for audit trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)