### PR TITLE
feat(skill): Flow + Veo 3.1 mastery v2 — replace outdated v1

### DIFF
--- a/.agents/skills/google-flow-video/SKILL.md
+++ b/.agents/skills/google-flow-video/SKILL.md
@@ -1,272 +1,606 @@
-# Skill: Google Flow — Mastering AI Video Creation
+---
+name: google-flow-video
+description: Generate AI video assets via Google Labs Flow + Veo 3.1 on Antonello's AI Ultra plan ($249.99/mo, 25,000 credits/month). Use when the user asks to create video shorts/reels/B-roll/explainers/testimonials for Bali Zero, ZANTARA, or any editorial deliverable. Skill is operational — not academic.
+trigger_keywords: ["flow", "veo", "video", "reel", "short", "ai video", "google flow", "veo 3.1", "google ai ultra", "labs.google/flow"]
+version: 2.0
+updated: 2026-05-13
+supersedes: SKILL.v1-pre-2026-05-13.bak (April 2026, contained false "Veo 3.1 Fast = Zero credits" claim, predated Veo 3.1 2025-10-15 release)
+companion_manual: research/marketing/2026-05-13-flow-veo-3.1-mastery-manual.md
+authority_sources:
+  - https://blog.google/technology/ai/veo-updates-flow (Veo 3.1 release 2025-10-15)
+  - https://cloud.google.com/blog/products/ai-machine-learning/ultimate-prompting-guide-for-veo-3-1 (Google ufficiale prompt guide)
+  - https://deepmind.google/models/veo/prompt-guide (DeepMind prompt guide)
+  - https://support.google.com/flow/answer/16526234 (credits & pricing)
+  - https://support.google.com/flow/answer/16353334 (Ingredients, voice, multi-output)
+  - https://support.google.com/flow/answer/16352836 (audio limits)
+  - https://support.google.com/flow/answer/16935718 (Scene Builder)
+  - https://support.google.com/flow/answer/17069754 (keyboard shortcuts)
+---
 
-## Trigger
+# Flow + Veo 3.1 Operational Skill (v2)
 
-User wants to create, iterate, or improve a video in Google Flow.
-
-## Access
-
-- URL: https://labs.google/flow/
-- Account: antonellosiano@gmail.com (Ultra — zero credits on Veo 3.1 Fast)
+**Account**: `antonellosiano@gmail.com` · Google AI Ultra ($249.99/mo) · 25,000 credits/month
+**Flow URL**: https://labs.google/flow
+**Model release**: Veo 3.1 GA 2025-10-15 (replaces Veo 3 May 2025)
+**Do NOT confuse**: Google Flow Music is a separate product (audio for artists, partnership with Believe). This skill is **Veo video generation inside Flow** only.
 
 ---
 
-## The Prompt Formula
+## 1. Reality check — models & credits in Flow UI (Ultra)
 
-Every prompt must contain 5 parts in this order:
+> ⚠️ Credit costs in Flow UI are **per-generation**, NOT per-second. 8s clip = 4s clip = 6s clip = same cost at same tier. The Vertex AI / Gemini API is a different billing model — do not conflate.
 
-```
-[CAMERA] + [SUBJECT] + [ACTION] + [CONTEXT] + [STYLE]
-```
+| Tier | Credits / generation | Output res | Native audio | Best use |
+|---|---|---|---|---|
+| **Veo 3.1 Lite** | 5 | 720p (1080p upscale 0 cr) | may vary, weak | Storyboarding, B-roll exploration, animatics |
+| **Veo 3.1 Fast** | 10 | 1080p | yes (full) | Workhorse — daily iteration, dialog drafts |
+| **Veo 3.1 Quality** | 100 | 1080p (4K upscale +50 cr) | yes (best) | Hero/locked shots, client-facing |
+| Lite [Lower Priority] | **0** (Ultra freebie) | 720p | may vary | Off-peak bulk exploration |
+| Fast [Lower Priority] | **0** (Ultra freebie) | 1080p | yes | Off-peak bulk drafts |
+| 4K upscale | 50 (flat) | — | — | Hero shots only |
 
-| Part    | What to specify                        | Example                                                                                                                                                                               |
-| ------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CAMERA  | Movement + framing                     | `Slow dolly push-in, medium close-up`                                                                                                                                                 |
-| SUBJECT | Full physical description — EVERY TIME | `a young Indonesian woman with long brown hair, warm skin, subtle eyeliner, small hoop earrings, thin silver necklace, wearing modern black kebaya`                                   |
-| ACTION  | What happens + dialogue in quotes      | `speaks directly to camera and says: "Welcome to the Bali Zero Morning News."`                                                                                                        |
-| CONTEXT | Environment, lighting, time of day     | `seated at a circular stone table in an ancient Balinese temple hall, holographic amber data floating above the table, dvarapala guardian statues with glowing eyes along both sides` |
-| STYLE   | Technical look                         | `cinematic, photorealistic, warm amber lighting, shallow depth of field, 16:9`                                                                                                        |
+**Multiplier rules**:
+- 1× / 2× / 3× / 4× = number of parallel variants returned per generation (cost = base × N).
+- **Quality is always charged at 2× minimum** in Flow UI (200 cr/gen) — Google forces variant selection on Quality tier.
+- Aspect ratio: 16:9 + 9:16 both natively supported, **same cost**.
+- Duration: 4s / 6s / 8s all priced the same in a given tier — generate 8s by default.
 
-### Golden Rules
-
-- **NEVER abbreviate the subject.** Write the full character description in every single prompt. Veo does not remember previous prompts.
-- **Concrete visuals beat abstract concepts.** "Immigration officers checking passports at Ngurah Rai airport" >> "unified immigration system"
-- **Dialogue goes in quotes inside the prompt.** `She says: "Five deadlines. Zero room for error."`
-- **Camera movement in the first words.** Veo prioritizes the beginning of the prompt.
+**Failed generations should not charge credits** (Google policy, support.google.com/flow/answer/16526234). Low-audio-quality fails may refund.
 
 ---
 
-## Model Selection
+## 2. Cost calculator — 3 strategies for 25k monthly budget
 
-| Model               | When                                               | Credits (Ultra) | Audio |
-| ------------------- | -------------------------------------------------- | --------------- | ----- |
-| **Veo 3.1 Fast**    | Iterating, testing prompts                         | **Zero**        | Yes   |
-| **Veo 3.1 Full**    | Final render only                                  | 5x              | Yes   |
-| **Nano Banana Pro** | Generating images (character sheets, environments) | Free            | N/A   |
+> Per-Brief estimate: 6-clip episode (1 hero + 4 supporting + 1 CTA closer) ≈ **650 credits/Brief** → **~36 Briefs/month theoretical**, **15–20 Briefs/month realistic** after retries.
 
-**Strategy:** Do ALL iterations with Fast. Only switch to Full for the final version you'll publish.
+| Strategy | Quality (100 cr) | Fast (10 cr) | Lite (5 cr) | Total cr | Output minutes | Best for |
+|---|---|---|---|---|---|---|
+| **Hero-heavy** | 200 | 300 | 200 | **24,000** | ~58 min | Brand serial opener, premium client decks |
+| **Volume-heavy** | 50 | 1,500 | 500 | **22,500** | ~280 min | SEO library, B-roll, IG/TikTok daily |
+| **Balanced (recommended)** | 150 | 700 | 400 | **24,000** | ~210 min | Editorial pipeline Bali Zero default |
 
----
+**Retry math** (subtract from yield):
+- Simple B-roll: ~90% first-pass good → 10% retry
+- Talking-head 8s monologue: ~70-75% → +20% credit penalty
+- Multi-character dialog: ~55-65% → +35% penalty
+- Text-in-scene (legal docs readable): ~40-50% → +50% penalty (USE OVERLAYS IN POST INSTEAD)
+- Indonesian-accented English dialog: ~30-40% → +60% penalty
 
-## Ingredients — Character Consistency
-
-### Setup (do this once per project)
-
-1. Settings gear → enable **Ingredients**
-2. Upload reference images:
-   - **1 front-facing portrait** (most important — anchors identity)
-   - **1 three-quarter view** (helps with angle consistency)
-   - **1 speaking/mid-sentence** (helps with mouth/expression)
-   - **1 environment** (your studio background)
-3. Max 4 ingredients active per generation
-
-### Rules
-
-- A front-facing neutral portrait is the **strongest anchor** for face consistency
-- If the character drifts after 3+ clips → re-upload ingredients and regenerate
-- Ingredients control identity and pose; the **prompt controls everything else** (camera, lighting, action)
-- For consistent clothing: describe it identically in every prompt, don't rely on the image alone
+> **Bali Zero takeaway**: never burn Quality credits on text-in-scene legal docs — generate clean B-roll, add overlay in CapCut/Premiere.
 
 ---
 
-## Voice Ingredients (Experimental)
+## 3. Prompt formula — 5-part Google official
 
-### Setup
+**Canonical order** (Google's recommended hierarchy, front-loaded tokens get heaviest attention):
 
-1. Settings → enable Voice Ingredients (requires Ultra)
-2. Must have at least **1 Image Ingredient active** (character face)
-3. Open Voice menu → hover to preview → select
+```
+[Cinematography] + [Subject] + [Action] + [Context] + [Style & Ambiance]
+```
 
-### Best Voices by Use Case
+| Part | Examples |
+|---|---|
+| Cinematography | `medium close-up, 35mm, slow dolly-in`, `static locked-off`, `low-angle tracking`, `FPV drone dive` |
+| Subject | Full description: age range, ethnicity, wardrobe, hair, expression. Never abbreviate. `Veronika, mid-30s Indonesian woman in white kebaya, hair tied back, calm professional expression` |
+| Action | One verb, concrete. `walks toward camera`, `places stamp on document`, `looks directly into lens and says...` |
+| Context | Specific location + time of day + props. `Bali Zero office Sanur, late afternoon, wooden desk, KITAS document visible` |
+| Style & Ambiance | Lighting source + mood + audio cue. `warm key light from window left, soft tropical shadows, ambient air-con hum, distant scooter` |
 
-| Use                      | Voice                              | Why                               |
-| ------------------------ | ---------------------------------- | --------------------------------- |
-| Young professional woman | **Aoede** (F, breezy, mid)         | Matches warm, approachable anchor |
-| News authority           | **Alnilam** (M, firm, mid-low)     | Classic broadcast tone            |
-| Documentary narrator     | **Charon** (M, informative, lower) | Deep, measured                    |
-| Sophisticated woman      | **Despina** (F, smooth, mid)       | Premium feel                      |
-| Senior authority         | **Gacrux** (F, mature, mid)        | For older character               |
+**Length sweet spot**: 3–6 sentences, 100–150 words. Longer prompts dilute attention; shorter prompts let the model hallucinate.
 
-### Critical Limitations
+**Golden rules**:
+1. Camera intent FIRST when shot must feel directed.
+2. Concrete > abstract: "warm tungsten from window" beats "beautiful lighting".
+3. Source the light: every shot should name the key light direction + temperature.
+4. Force verbs: model needs grammatical verbs, not gerund clouds.
+5. Material cues: "linen fabric", "weathered teak wood", "wet pavement" — surfaces carry physics.
+6. Avoid exact counts ("three people" often → 2 or 4); use "a small group" or single subjects.
 
-- Voice does **NOT carry over** when you Extend or chain clips → re-select voice for each new clip
-- Indonesian accent: not available natively → add in prompt: `"She speaks English with a soft natural Indonesian accent, melodic rhythm of Bahasa Indonesia"`
-- Audio quality: mono 44.1kHz — acceptable for web, enhance post with ffmpeg for broadcast
+**Don't use**:
+- ❌ "high quality", "beautiful", "epic", "cinematic" alone (filler, no information)
+- ❌ Negative-as-don't ("don't show a man" — model often shows a man anyway; use Negative Prompt field)
+- ❌ Multiple conflicting style anchors ("cyberpunk + film noir + Studio Ghibli")
+- ❌ Named celebrity/politician/public-figure likeness (auto-blocked + account flag risk)
+- ❌ Branded IP / copyrighted logos (memorization-check refusal)
+
+**"Anamorphic" alone doesn't work** — spell out: `oval bokeh, horizontal lens flare, compressed background, 2.39:1 aspect`.
 
 ---
 
-## Making Videos Longer Than 8 Seconds
+## 4. Timestamp Prompting (Google Cloud — advanced)
 
-### Method 1: Extend (quick but lower quality)
+Generate multi-shot narrative in **one 8s generation** using inline timecodes:
 
-- Click "+" at end of clip → "Extend"
-- Uses **Veo 2 Fast** (no audio, lower quality)
-- Good for: testing sequence, previewing flow
-- Bad for: final production
+```
+[00:00-00:02] Wide establishing shot, Ngurah Rai airport arrivals hall, morning daylight,
+   travelers walking, ambient announcement audio.
+[00:02-00:04] Cut to medium shot, Indonesian immigration officer at counter, calm
+   professional, stamping a passport, "Welcome to Indonesia" said softly.
+[00:04-00:06] Close-up on KITAS card placed on counter, hand of officer sliding it forward.
+[00:06-00:08] Wide pull-out, applicant smiling, picks up KITAS, walks toward exit.
+   Soft uplifting music swell.
+```
 
-### Method 2: Frames-to-Video Chaining (best quality)
-
-**This is the pro technique for full Veo 3.1 quality + audio:**
-
-1. Generate first 8-sec clip with Veo 3.1
-2. Hover over **last frame** → click "+" → **Save as Asset**
-3. Start new generation → switch to **"Frames to Video"**
-4. Load saved frame as **Start Frame**
-5. Write NEW prompt — **repeat full character description + environment**
-6. Add continuation: what happens next
-7. Generate with **Veo 3.1** (not Extend)
-8. "Add to Scene" → repeat from step 2
-9. Each chain = +8 seconds at full quality with audio
-
-### Method 3: Scene Builder Jump-To (for cuts between scenes)
-
-- Click "+" → "Jump To"
-- Uses Veo 3.1 full quality
-- Creates a **new camera angle** or scene cut (not seamless continuation)
-- Good for: switching from wide shot to close-up, changing environment
-
-### Avoiding Drift in Long Sequences
-
-- Copy-paste your character description verbatim into every prompt
-- Re-lock ingredients before each generation
-- If skin tone shifts → add specific color: "warm medium-brown skin tone"
-- If clothing changes → specify exact garment in every prompt
-- If lighting shifts → specify exact lighting setup every time
+**Trade-off**: can't retry one segment — entire 8s regenerates. Use for hero shots only after 2–3 Fast iterations confirm composition.
 
 ---
 
-## Dual Format Production (16:9 + 9:16)
+## 5. Audio — dialog, SFX, ambient, music
 
-### Composition Rules for Both Formats
+**Dialog syntax** (load-bearing — double-quotes mandatory):
 
-- **Subject at dead center** — in 9:16 crop, sides disappear
-- **Strong vertical elements** — columns, trees, light beams, smoke (become hero in portrait)
-- **No critical content at left/right edges** — will be cropped in vertical
-- **Symmetrical compositions** work in any crop
+```
+A woman says, "We have to leave now." (no subtitles)
+```
 
-### Workflow
+- Suffix `(no subtitles)` prevents the model from rendering on-screen captions (a known bug per support.google.com/flow/answer/16352836).
+- Use the `Dialogue:` keyword as alternative.
 
-1. Generate in **16:9** first (landscape — primary format)
-2. For social: regenerate **same prompt** with 9:16 aspect ratio
-3. Or: center-crop the 16:9 with ffmpeg (loses resolution but saves time):
-   ```
-   ffmpeg -i input_16x9.mp4 -vf "crop=ih*9/16:ih" output_9x16.mp4
-   ```
+**Audio lanes** (separate inside prompt):
+
+```
+Dialogue: A woman says, "Welcome to Bali Zero." (no subtitles)
+SFX: Soft keyboard typing, paper rustle as document slides forward.
+Ambient: Tropical air-con hum, distant gamelan music from neighboring shop.
+Music: Subtle uplifting orchestral pad, slow swell, no melody.
+```
+
+**Hard rules for lip-sync** (≥90% success):
+- **1 speaker per clip** — multi-speaker dialog fails ~50% even on Quality
+- **≤5 seconds of spoken audio** per 8s clip — silence pre/post helps registration
+- **Close-up or medium shot**, mouth clearly visible — wide shots desync
+- Booster phrase: `"...clearly enunciates each word..."`
+- For multi-character conversations use **shot/reverse-shot** (separate clips per speaker)
+
+**Known audio bugs**:
+- 20–40ms drift on long clips (cut before/after hard consonants)
+- Voice timbre can sound robotic — generate 3–4 variants, pick best
+- **No native Indonesian-accent voice** — voice references partially work but accent reliability dropped in Veo 3.1 vs Veo 3 (Reddit creator reports)
+- Voice does NOT persist cross-Extend reliably
+
+**Workaround for Indonesian-accented English** (Bali Zero spokespersons):
+
+```
+Voice: warm Indonesian-accented English, gentle lilt, slight emphasis on initial consonants,
+       conversational pace, no exaggeration.
+The woman, Veronika, says, "Indonesian tax compliance is simpler when you have
+   a local partner." She clearly enunciates each word.
+```
+
+**Voice Ingredients** (experimental, Ultra-only — works with Ingredients generations, summoned via `@Voice`). Recommended voice names (creator-empirical):
+- Aoede (F, warm, professional) — Veronika spokesperson default
+- Alnilam (M, broadcast) — news anchor reads
+- Charon (M, documentary) — sober explainer narration
+- Despina (F, smooth, premium) — luxury property B-roll VO
+- Gacrux (F, mature, authority) — Adit (Director-level testimonials)
 
 ---
 
-## Camera Movement Reference
+## 6. Ingredients — character/object/style consistency
 
-| Movement       | Prompt keyword              | Best for                              |
-| -------------- | --------------------------- | ------------------------------------- |
-| Push in slowly | `slow dolly push-in`        | Dramatic reveals, building tension    |
-| Pull back      | `slow dolly pull-back`      | Establishing shots, revealing context |
-| Pan across     | `slow pan left/right`       | Scanning environments                 |
-| Tilt up        | `slow tilt up`              | Revealing from ground to sky          |
-| Orbit          | `slow orbit around subject` | 360 showcase                          |
-| Static         | `locked-off static shot`    | Dialogue, anchor shots                |
-| Handheld       | `subtle handheld movement`  | Documentary feel                      |
-| Crane down     | `crane shot descending`     | Grand entrances                       |
-| Tracking       | `tracking shot following`   | Movement, walking                     |
+**Setup per character**:
+1. Generate 4 portrait references using Nano Banana Pro / Imagen 4 inside Flow:
+   - Front-facing neutral (eye level)
+   - 3/4 angle
+   - Speaking (mouth slightly open, hand gesture mid-action)
+   - Full environment shot (subject in setting)
+2. Plain background (white/light gray) — busy backgrounds confuse the model
+3. Save as Ingredient with **unique made-up name** (community trick: `Zantara-Veronika`, `Zantara-Surya`) — more reliable temporal mapping than "the woman"
 
-**Tip:** Start prompt with camera movement — Veo prioritizes early words.
+**Generation rules**:
+- **Max 3 Ingredients active per generation** (character + outfit + environment is the typical stack)
+- Reference each Ingredient **BY NAME** in the prompt: `Veronika from Ingredient 1, wearing the kebaya from Ingredient 2`
+- Drift accumulates after ~3 chained clips → re-upload fresh portrait every 3rd clip
+- **Verify model selector says Veo 3.1, not Veo 2** before clicking Generate (community-reported silent fallback on heavy days)
 
----
-
-## Style Modifiers That Improve Quality
-
-### Photorealism
-
-```
-photorealistic, cinematic, shallow depth of field, film grain,
-anamorphic lens, 8K detail, natural skin texture
-```
-
-### Lighting
-
-```
-warm amber key light from the left, soft fill from above,
-dramatic side-lighting, golden hour, volumetric light rays,
-practical lighting from candles and screens
-```
-
-### Mood
-
-```
-atmospheric, moody, dramatic shadows, high contrast,
-intimate, epic, serene, urgent
-```
-
-### What to Avoid in Prompts
-
-- "high quality" or "beautiful" — too vague, adds nothing
-- Multiple conflicting styles — pick one mood
-- Overly long prompts (>200 words) — Veo loses focus
-- Negative prompts ("don't show X") — Veo doesn't handle negation well
+**Voice Ingredient**: 1 voice reference allowed, only works with full Ingredients generation, summoned via `@Voice` in prompt.
 
 ---
 
-## Image Generation (for Ingredients)
+## 7. Beyond 8 seconds — 3 methods
 
-Use Nano Banana Pro / Imagen 4 inside Flow:
+| Method | How | Quality | Cost (Fast tier) | Best for |
+|---|---|---|---|---|
+| **Frames-to-Video chaining** | Generate clip → save last frame → use as start frame of next 8s clip | 🟢 Best (each segment fresh full-Veo with audio) | 10 cr/chain (Fast) or 100 cr/chain (Quality) | 30s–2min narrative, dialog scenes |
+| **Flow Extend** | Click "Extend" on existing clip → adds +7s from final frame | 🟡 Decays: 1–3 chains OK, 4–5 subtle drift, 6–10 noticeable, 11–20 visible | 10 cr/extend | Continuous unbroken motion, establishing pans |
+| **Jump-To / Scene Builder** | Place clips in timeline, use cinematic cuts | 🟢 Reliable on Quality, 🟡 unstable on Fast | Per-clip base cost | Multi-shot narratives, shot/reverse-shot |
 
-1. Type prompt in text box (same as video, but generates image)
-2. Best for: character sheets, environment references, style boards
-3. Generated images → immediately usable as Ingredients
-4. **Lasso tool:** click area of generated image → type modification → instant edit
+**Max theoretical with Extend**: 8s base + 20 extends × 7s = **148s single shot** (then export, re-upload last frame, start new chain — loophole for 5min+).
 
-### Character Sheet Prompt Template
+### Pro workflow — Frames-to-Video chain (7 steps)
 
-```
-Portrait of [full character description]. [Pose: front-facing /
-three-quarter / profile / speaking]. [Lighting]. Portrait
-photography, shallow depth of field, neutral background.
-```
+1. Write **scene bible** first: cast names, wardrobe, lighting palette, location, voice tone, action beats. Reuse verbatim in every clip prompt.
+2. Generate clip 1 with full Subject + Context (Quality if hero, Fast otherwise).
+3. In Flow, save last frame as image asset.
+4. Lock 1 Ingredient as face anchor (e.g., `Zantara-Veronika` front portrait) — keeps identity across cuts.
+5. Generate clip 2: prompt = clip 1's full Subject + new Action + re-stated environment/lighting/palette.
+6. **Hand-over-hand prompting**: the last visible state at end of clip N becomes the opening state of clip N+1. Mirror exactly.
+7. Test on Lite first (5 cr) before committing to Quality (100–200 cr).
 
-### Environment Prompt Template
-
-```
-Interior/exterior of [environment description]. No people.
-[Lighting and time of day]. [Materials and textures].
-Architectural photography, centered composition that works
-in both 16:9 and 9:16 crop. [Style].
-```
-
----
-
-## Troubleshooting
-
-| Problem                              | Fix                                                                  |
-| ------------------------------------ | -------------------------------------------------------------------- |
-| Character face changes between clips | Re-upload face ingredient, add skin tone + feature details to prompt |
-| Clothing changes                     | Specify exact garment (color, cut, material) in every prompt         |
-| Voice sounds different on next clip  | Re-select Voice Ingredient — it doesn't persist                      |
-| Video stuck generating >5 min        | Cancel and regenerate — likely stuck                                 |
-| Environment looks different          | Upload environment as Ingredient image, describe in prompt too       |
-| Weird artifacts / glitches           | Regenerate — AI video is stochastic, some generations fail           |
-| Extend has no audio                  | Extend uses Veo 2 — use Frames-to-Video instead                      |
-| 9:16 crops out important elements    | Redesign composition with center-dominant layout                     |
-| Prompt too long, Veo ignores parts   | Split into shorter clips, one concept per prompt                     |
-| Lips don't match dialogue            | Known Veo limitation — lip sync is approximate, not perfect          |
+**Continuity rules**:
+- Copy-paste full Subject description verbatim across clips
+- Re-state environment + lighting + color palette in every prompt
+- Lock face anchor Ingredient
+- Voice references don't persist — re-cast in each prompt
 
 ---
 
-## Quick Reference Card
+## 8. Camera controls — UI buttons vs prompt language
+
+Flow has UI sliders for Pan/Tilt/Zoom; **text prompting yields higher precision** (Reddit creator consensus). Prompt language wins.
+
+### Empirically reliable cinematography (production-ready)
+
+| Move | Prompt syntax | Reliability |
+|---|---|---|
+| Slow dolly push-in | `slow dolly push-in over 6 seconds, locked subject` | 🟢 Hero-grade |
+| Locked-off static | `static locked-off camera, no movement` OR community hack `"from the perspective of a rock that does not move"` | 🟢 Safest for dialog |
+| Orbit | `slow 90-degree arc around subject` (works best with isolated subjects on plain background) | 🟢 |
+| Whip pan | `fast whip pan left to right, motion blur` | 🟡 |
+| Rack focus | `rack focus from foreground to background, shallow depth of field` | 🟡 |
+| Gimbal glide | `smooth gimbal glide forward, low angle` | 🟢 |
+| FPV drone dive | `FPV drone dive, fast descent, dynamic angle` | 🟢 |
+| Dolly zoom (Vertigo) | `dolly zoom on subject, background compresses` | 🟡 |
+
+### Vocabulary table — 4 categories
+
+| Movement | Composition | Lens | Lighting |
+|---|---|---|---|
+| dolly, tracking, crane, gimbal, POV, FPV drone, whip pan, push-in, pull-out, orbit, rack focus | wide / medium / close-up / extreme close-up, low-angle, high-angle, Dutch tilt, over-the-shoulder, locked-off | 35mm, 50mm, 85mm, macro, wide-angle, anamorphic (spell out: oval bokeh, horizontal flare, 2.39:1), shallow depth of field, deep focus | key light, fill light, rim light, golden hour, blue hour, tungsten warm, daylight cool, neon, chiaroscuro, soft diffusion |
+
+---
+
+## 9. Negative prompting + Remove tool
+
+**Phrase positively first** — Veo responds better to "smooth motion" than "no jittery motion". Place negative directives at the **end** of prompt. Escalate to positive reframe if artifact recurs.
+
+**Editorial-safe negative stack** (paste in Negative Prompt field):
 
 ```
-START NEW PROJECT:
-  Flow → New Project → Settings → Veo 3.1 Fast → Ingredients ON
-
-GENERATE CLIP:
-  Write 5-part prompt → Generate → Pick best → Add to Scene
-
-EXTEND (pro method):
-  Last frame → Save as Asset → Frames to Video → Full prompt again
-
-EXPORT:
-  Scene Builder → Play preview → Download (1080p or 4K)
-
-GOLDEN RULE:
-  Every prompt = full character + full environment + camera + action + style
-  Never assume Veo remembers anything from the previous clip.
+no extra fingers, no warped text, no motion smear, no jump cuts, no watermarks,
+no AI artifacts, no morphed limbs, no double faces, consistent anatomy,
+no shaky camera, no subtitles, no on-screen text overlays
 ```
+
+**Remove tool caveat**: Flow's object-remove inpainting uses **Veo 2 internally**, **NOT Veo 3.1**, and produces **NO audio**. Use only for static-shot cleanup, never for hero shots.
+
+---
+
+## 10. Aspect 16:9 + 9:16
+
+**Native support both**, same cost. Generate vertical natively when composition matters — don't crop.
+
+| Format | When | Composition rule |
+|---|---|---|
+| 16:9 (1920×1080) | YouTube, web, broadcast, hero pieces | Subject occupies center 1/3 horizontally; landscape framing |
+| 9:16 (1080×1920) | Instagram Reels, TikTok, Shorts, WhatsApp Status | Subject dead center; vertical hero (full body or close-up); no critical content within 80px of edges |
+
+**Dual-format strategy** (subject dead-center technique):
+1. Frame subject **dead center** horizontally and vertically
+2. Use **vertical hero elements** (standing portraits, doorways, tree trunks)
+3. Keep critical content (text overlays, key gestures) **away from edges**
+4. Symmetrical composition works any crop
+
+**Workflow options**:
+- **Option A (cleaner)**: Generate 16:9 hero, then regenerate 9:16 separately (2× cost, but native composition each format)
+- **Option B (fast)**: ffmpeg center-crop:
+  ```bash
+  ffmpeg -i in.mp4 -vf "scale=-2:1920,crop=1080:1920" -c:a copy out_9x16.mp4
+  ```
+- **Option C (padded)**:
+  ```bash
+  ffmpeg -i in.mp4 -vf "scale=1080:-2,pad=1080:1920:(ow-iw)/2:(oh-ih)/2" -c:a copy out_9x16_pad.mp4
+  ```
+
+---
+
+## 11. Throughput + queue strategy
+
+**Wall-clock generation time** (creator-empirical, off-peak):
+- Veo 3.1 Lite: ~1 min
+- Veo 3.1 Fast: ~1 min 13 s (vs ~2:41 on Veo 3 — measurable speed bump)
+- Veo 3.1 Quality (1×): ~2–3 min
+- Quality (2× forced): ~3–4 min
+- Quality (4×): ~5–6 min
+- 4K upscale: ~3–5 min additional
+
+**Lower-priority queue** (Ultra-only freebie): Lite + Fast at 0 cr but 5–20 min wait, off-peak hours best. Use for overnight bulk B-roll harvest.
+
+**Daily workflow**:
+| Phase | Tier | Multiplier | Purpose |
+|---|---|---|---|
+| Composition drafting | Lite | 1× | Cheap iteration, find framing |
+| Refinement | Fast | 1× | Lock blocking + audio |
+| Hero render | Quality | 2× (forced) | Final shot, pick best variant |
+| Bulk harvest | Lite [Lower Priority] | 1× | Free overnight B-roll |
+| 4K hero only | Quality + upscale | — | +50 cr flat |
+
+---
+
+## 12. Commercial use + SynthID + UU PDP
+
+### Allowed (Ultra commercial license)
+- ✅ Marketing assets for Bali Zero / Nuzantara editorial
+- ✅ Generic visuals (Bali landscapes, generic professional spokespersons, abstract concepts)
+- ✅ Client/staff likenesses **with written consent**
+- ✅ Client portals, ads, B2B decks, social posts
+
+### Forbidden — hard restrictions
+- ❌ Real-person likeness without consent (auto-blocked + account flag)
+- ❌ Indonesian government officials named likeness (UU PDP + KUHP defamation risk)
+- ❌ Copyrighted IP / brand logos (Disney, Apple, etc. — memorization-check refusal)
+- ❌ Named minors
+- ❌ Violence, hate speech, sexually explicit content
+- ❌ Removing SynthID watermark (TOS violation + YouTube/IG de-rank algorithm + EU AI Act + Indonesia UU PDP)
+
+### SynthID — invisible watermark
+- **Every Veo 3.1 frame** carries DeepMind SynthID (forensic, undetectable to humans)
+- **Visible "veo" bottom-right** watermark: present on non-Ultra Flow; **Ultra exempt** in Flow UI
+- API/Vertex outputs: no visible watermark; SynthID invariant
+- Removing SynthID = TOS violation **and**:
+  - Platform algorithm de-rank (YouTube, Instagram, TikTok)
+  - EU AI Act non-compliance for synthetic media disclosure
+  - Indonesia UU PDP / UU ITE exposure on misleading content
+
+### Required Bali Zero disclosure
+1. Disclaimer in caption/credits: **"AI video assets generated via Veo 3.1 (Google Labs Flow)"**
+2. Audit log per asset in `~/Desktop/nuzantara/research/marketing/flow-asset-log.csv` (date, prompt, tier, cost, consent status, publication URL)
+3. For client/staff likeness: signed written consent stored in `~/Desktop/nuzantara/research/marketing/consent/<name>-<date>.pdf`
+
+> **Bali Zero verdict matrix**:
+> | Use case | Status |
+> |---|---|
+> | Generic Bali B-roll, abstract explainers, property exteriors | ✅ ship |
+> | Veronika/Adit/Surya named likeness | ⚠️ written consent required |
+> | Named clients in testimonials | ⚠️ written consent + draft review |
+> | Indonesian government officials named | ❌ never |
+
+---
+
+## 13. 10 prompt templates — ready copy-paste for Bali Zero
+
+### T1 — FAQ Visa Anchor (Veronika kebaya, Quality 8s, C1 explainer)
+```
+Medium close-up, 35mm lens, locked-off static camera. Veronika from Ingredient 1
+(mid-30s Indonesian woman, hair tied back, white silk kebaya, calm professional
+expression). She looks directly into the lens and says, "The C1 visa replaces the
+old B211A. It's valid for sixty days, single-entry, tourism only." She clearly
+enunciates each word. (no subtitles) Bali Zero office Sanur, late afternoon,
+warm tungsten key light from window left, soft tropical shadow on background
+teak wall. Ambient air-con hum, distant scooter passing.
+```
+Tier: Quality 2× (200 cr). Aspect: 9:16. Voice: @Aoede.
+
+### T2 — Regulatory News Flash (timestamp 4-segment SPT extension)
+```
+[00:00-00:02] Wide establishing shot, Indonesian tax office Jakarta exterior,
+   morning, busy with civil servants walking. Indonesian flag fluttering.
+[00:02-00:04] Cut to medium shot, news anchor at desk (generic professional
+   man, dark suit, neutral tie), holding a printed document marked
+   "KEP-71/PJ/2026". He says, "Tax deadline extended."
+[00:04-00:06] Close-up insert on Indonesian calendar, May 31 circled in red ink.
+[00:06-00:08] Pull-out to wide, anchor smiles, "Plan accordingly." Logo lower-third.
+SFX: subtle paper rustle, soft news-room ambient.
+```
+Tier: Quality 2× (200 cr). Aspect: 16:9.
+
+### T3 — Property B-roll (drone pull-back Balinese villa, golden hour)
+```
+Aerial drone pull-back, slow ascent. A traditional Balinese villa with thatched
+alang-alang roof, infinity pool reflecting golden hour sky, rice paddies
+extending to volcanic mountain on horizon. Coconut palms gently swaying.
+Golden hour key light, warm amber tones, long shadows. Ambient: gentle breeze,
+distant gamelan music, water lapping pool edge. No people in frame.
+```
+Tier: Fast 1× (10 cr). Aspect: 16:9. Use Lite [Lower Priority] (0 cr) overnight for bulk.
+
+### T4 — Tax Deadline Countdown (Surya, locked-off, "Eighteen days...")
+```
+Medium shot, 50mm, locked-off static. Surya from Ingredient 1 (early-40s
+Indonesian man, navy batik shirt, glasses, serious expression). Indoor Bali
+Zero office, soft daylight from large window camera-left, teak desk in
+foreground with a calendar visible. He looks directly at camera and says,
+"Eighteen days. After May thirty-first, the SPT extension closes." He clearly
+enunciates each word. (no subtitles) Ambient: air-con, soft typing in background.
+```
+Tier: Quality 2× (200 cr). Aspect: 9:16. Voice: @Charon.
+
+### T5 — Client Testimonial Frame (slow orbit, written consent required)
+```
+Slow 90-degree orbit, smooth gimbal glide, medium shot. [Client name from
+Ingredient 1, with written consent on file] seated on rattan chair, Bali villa
+terrace background, tropical plants soft-focused behind. Warm afternoon
+sunlight, dappled through bamboo blinds. She says, "Bali Zero made my PT PMA
+setup feel effortless." She clearly enunciates each word. (no subtitles)
+Ambient: distant ocean, light wind through palms.
+```
+Tier: Quality 2× (200 cr). **Requires signed consent PDF** before generation.
+
+### T6 — KBLI Explainer (B-roll no dialog, macro lens, hand adjusts page)
+```
+Macro shot, rack focus from foreground to background. A hand (Indonesian skin
+tone) carefully turns the page of a printed KBLI 2020 booklet on a wooden
+desk. The page reveals "63122 — Portal web". A pencil rests beside the booklet.
+Soft natural daylight from above. No dialog. SFX: paper rustle, faint pencil
+roll, ambient quiet office.
+```
+Tier: Fast 1× (10 cr). Aspect: 16:9 or 9:16.
+
+### T7 — Before/After Metaphor (Frames-to-Video chain)
+```
+CLIP 1 (start frame upload): Empty Bali Zero office, dawn, dust motes in light
+beam from window, no furniture, bare floor. Slow dolly push-in over 6 seconds.
+
+CLIP 2 (last frame of Clip 1 → start frame, generate continuation): Same room
+now appointed — teak desk, two chairs, plants, calendar on wall, sunlight now
+midday warm. Camera continues slow push-in. Ambient: soft typing begins.
+
+Continuity: identical room dimensions, identical window position, identical
+floor texture. Lighting evolves from cool dawn to warm midday.
+```
+Tier: 2 × Fast (20 cr) or 1× Quality + 1× Fast for hero. Method: Frames-to-Video.
+
+### T8 — Myth-Bust Hook (Reels 9:16, Veronika, "Nominee is not protection")
+```
+Tight medium close-up, 50mm, locked-off. Veronika from Ingredient 1, neutral
+expression turning to slight concern, white kebaya, plain background. She
+looks directly into lens and says, "Nominee structures are illegal. They are
+not protection." She clearly enunciates each word. (no subtitles) Pause
+0.5 seconds. Soft amber light, single key from camera-left. Ambient: silent
+office, no music. SFX: subtle paper turn at clip end.
+```
+Tier: Quality 2× (200 cr). Aspect: 9:16. Voice: @Aoede.
+
+### T9 — News Brief Intro (anchor + lower-third holographic amber data)
+```
+Wide-to-medium tracking, slow dolly. News anchor (generic mid-30s Indonesian
+woman, navy blazer, neutral expression) seated at modern desk. Behind her,
+a large holographic display showing data charts in warm amber tones — text
+"PERMENKUMHAM 22/2023" partially visible (rendered as overlay, not in-scene
+text). Studio lighting cool daylight from above, warm rim from holographic
+display. She says, "Tonight, the new immigration framework." She clearly
+enunciates each word. (no subtitles) Music: subtle uplifting orchestral pad.
+```
+Tier: Quality 2× (200 cr). Aspect: 16:9. **Add real lower-third graphic in post** (NLE) — do NOT trust Veo to render legible text.
+
+### T10 — Elegant CTA Closer (logo card on stone surface, candle flame)
+```
+Static locked-off, extreme close-up, 85mm. A weathered stone temple surface,
+warm candle flame flickering frame-right out of focus. In frame center, a
+small embossed card with Bali Zero logo (rendered as Ingredient image asset,
+NOT in-scene text). Slow soft breeze causes candle flame to dance, casting
+amber light on stone texture. Audio: distant gamelan, soft wind, no dialog.
+Hold for 4 seconds, then very slow fade.
+```
+Tier: Quality 1× (100 cr if not forced 2×). Aspect: 9:16. **Pair with WhatsApp + email CTA in post-production overlay** per Article 6.6.1 elegant-close pattern.
+
+---
+
+## 14. Quick Reference Card — pseudo-code
+
+### START NEW PROJECT
+```
+1. Open labs.google/flow → "New Project"
+2. Settings → model selector → verify "Veo 3.1" (NOT Veo 2)
+3. Upload Ingredients (max 3 active): character portrait + wardrobe + environment
+4. Aspect ratio: 16:9 OR 9:16 (native, same cost)
+5. Duration: 8s (default — same cost as 4s/6s)
+```
+
+### GENERATE CLIP
+```
+1. Write prompt: [Cinematography] + [Subject verbatim] + [Action] + [Context] + [Style & Ambiance]
+2. Negative prompt: paste editorial-safe stack (§9)
+3. Tier:
+   - Drafting → Lite (5 cr)
+   - Iteration → Fast (10 cr)
+   - Hero → Quality 2× (200 cr forced)
+4. Click Generate → wait 1–4 min
+5. Pick best variant from 1×/2×/4× outputs
+```
+
+### EXTEND TO 30s+ PRO (Frames-to-Video chain)
+```
+1. Generate clip 1 with full Subject + Context
+2. Save last frame as image asset
+3. Use last frame as start frame of clip 2
+4. Re-state Subject + environment + lighting verbatim in clip 2 prompt
+5. Lock 1 Ingredient as face anchor
+6. Repeat for clip 3, 4, ... (max 4 chained reliably before drift)
+7. Assemble in Scene Builder timeline OR export and edit in NLE
+```
+
+### EXPORT
+```
+1. Asset menu → Download
+2. Formats: MP4 (default), GIF (270p only)
+3. Rename: <project>_<shot>_<version>_<tier>.mp4
+4. Log entry: research/marketing/flow-asset-log.csv
+5. Disclosure: caption must include "AI video assets generated via Veo 3.1"
+```
+
+### DECISION TREE — which tier for which task
+
+```
+Brand serial / hero / client-facing  → Quality 2× (200 cr)
+Daily editorial / dialog drafts       → Fast 1× (10 cr)
+B-roll / property / abstract          → Lite 1× (5 cr) OR Lite [LP] (0 cr overnight)
+Multi-variant casting                 → Fast 4× (40 cr) — pick best of 4
+30s+ narrative                        → Frames-to-Video chain of Fast (10 cr × N)
+Continuous unbroken motion (>8s)      → Extend (10 cr × N, decay by chain 4+)
+Final 4K hero                         → Quality 2× + 4K upscale (200 + 50 cr)
+```
+
+### OPEN QUESTIONS — empirical pending (sample sprint TODO)
+
+- [ ] Lite tier audio fidelity — does "may-vary" mean degraded or skipped?
+- [ ] Extend tier cost — is it base tier per extend or discounted?
+- [ ] Remove tool current status — still Veo 2 under hood as of 2026-05?
+- [ ] Indonesian-accent English Quality vs Fast — 10-clip side-by-side study
+- [ ] Voice Ingredient stability across Frames-to-Video chain (does @Voice persist?)
+- [ ] Quality forced-2× — can it be overridden by support request?
+
+> Resolve via **BVCL Sampling Sprint** plan (`docs/superpowers/plans/2026-05-13-bvcl-sampling-sprint.md`). 12 sample clips × 4 archetypes ≈ 600–800 credits.
+
+---
+
+## 15. Editorial pipeline — Bali Zero integration
+
+**Where Flow fits**:
+- WR2 (carousel pipeline) → static IG carousels
+- **Flow + Veo 3.1** → IG Reels, TikTok, YouTube Shorts, WhatsApp video CTAs
+- Companion editorial template: prompt T1–T10 above
+
+**Workflow**:
+1. **Brief** → wr2-brief-interpreter or manual (subject, archetype, voice register)
+2. **Storyboard** → 6-clip episode plan (1 hero + 4 supporting + 1 CTA closer)
+3. **Generate** → Flow, tier-mixed per Balanced strategy (§2)
+4. **Edit** → Premiere / DaVinci / CapCut — color match, captions in post, music swap if needed
+5. **Disclosure** → caption + asset log entry + consent PDF (if applicable)
+6. **Publish** → IG/TikTok/YouTube → metrics in 7 days via wr2-ig-metrics-analyst
+
+**Asset naming convention**:
+```
+<YYYY-MM-DD>_<topic-slug>_<shot-N>_<tier>_<variant>.mp4
+2026-05-13_c1-visa-explainer_hero-01_quality_v3.mp4
+```
+
+**Asset log location**:
+```
+~/Desktop/nuzantara/research/marketing/flow-asset-log.csv
+```
+
+CSV columns: `date, project, shot, tier, cost_credits, aspect, duration_s, prompt_hash, consent_status, publication_url, retry_count, notes`.
+
+---
+
+## 16. References (authority chain)
+
+**Google-official primary sources**:
+- Veo 3.1 release announcement: https://blog.google/technology/ai/veo-updates-flow (2025-10-15)
+- Ultimate prompting guide for Veo 3.1: https://cloud.google.com/blog/products/ai-machine-learning/ultimate-prompting-guide-for-veo-3-1
+- DeepMind Veo prompt guide: https://deepmind.google/models/veo/prompt-guide
+- Flow credits & pricing: https://support.google.com/flow/answer/16526234
+- Flow generation settings (Ingredients, voice, multi-output): https://support.google.com/flow/answer/16353334
+- Audio limits & speech: https://support.google.com/flow/answer/16352836
+- Scene Builder & saving frames: https://support.google.com/flow/answer/16935718
+- Asset export & sharing: https://support.google.com/flow/answer/16935308
+- Keyboard shortcuts: https://support.google.com/flow/answer/17069754
+- Image-model help (Nano Banana Pro / Imagen 4): https://support.google.com/flow/answer/16729550
+- Vertex AI Veo 3.1 generate spec: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/veo/3-1-generate
+
+**Empirical / creator-community (label as anecdotal)**:
+- Curious Refuge review: https://curiousrefuge.com/blog/veo-31-quality-ai-video-generator-review
+- Sider field guide (cinematic control): https://sider.ai/blog/ai-tools/best-prompt-techniques-for-veo-3_1-video-output-a-field-guide-to-cinematic-control
+- Veo3Gen Shot Card workflow: https://www.veo3gen.app/blog/veo-31-in-google-flow-a-beginner-workflow-to-build-a-1530s-scene-from-shot-cards
+- DataCamp complete guide: https://www.datacamp.com/tutorial/veo-3-1-complete-guide-with-examples
+- Reddit r/VEO3 lip-sync thread: https://www.reddit.com/r/VEO3/comments/1rkf538/lip_sync_looks_cartoonish_teeth_way_too_visible/
+- Reddit r/VEO3 "sucks" critique: https://www.reddit.com/r/VEO3/comments/1o8omm8/veo_31_sucks/
+- Reddit r/Bard accent regression: https://www.reddit.com/r/Bard/comments/1o7ftjk/veo_31_is_a_disappoinment/
+
+**Companion deep manual** (audit trail, ≥30 inline citations):
+- `research/marketing/2026-05-13-flow-veo-3.1-mastery-manual.md`
+
+**Backup v1** (archeology, do not edit):
+- `skills/google-flow-video/SKILL.v1-pre-2026-05-13.bak`
+- `.agents/skills/google-flow-video/SKILL.v1-pre-2026-05-13.bak`

--- a/.agents/skills/google-flow-video/SKILL.v1-pre-2026-05-13.bak
+++ b/.agents/skills/google-flow-video/SKILL.v1-pre-2026-05-13.bak
@@ -1,0 +1,272 @@
+# Skill: Google Flow — Mastering AI Video Creation
+
+## Trigger
+
+User wants to create, iterate, or improve a video in Google Flow.
+
+## Access
+
+- URL: https://labs.google/flow/
+- Account: antonellosiano@gmail.com (Ultra — zero credits on Veo 3.1 Fast)
+
+---
+
+## The Prompt Formula
+
+Every prompt must contain 5 parts in this order:
+
+```
+[CAMERA] + [SUBJECT] + [ACTION] + [CONTEXT] + [STYLE]
+```
+
+| Part    | What to specify                        | Example                                                                                                                                                                               |
+| ------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CAMERA  | Movement + framing                     | `Slow dolly push-in, medium close-up`                                                                                                                                                 |
+| SUBJECT | Full physical description — EVERY TIME | `a young Indonesian woman with long brown hair, warm skin, subtle eyeliner, small hoop earrings, thin silver necklace, wearing modern black kebaya`                                   |
+| ACTION  | What happens + dialogue in quotes      | `speaks directly to camera and says: "Welcome to the Bali Zero Morning News."`                                                                                                        |
+| CONTEXT | Environment, lighting, time of day     | `seated at a circular stone table in an ancient Balinese temple hall, holographic amber data floating above the table, dvarapala guardian statues with glowing eyes along both sides` |
+| STYLE   | Technical look                         | `cinematic, photorealistic, warm amber lighting, shallow depth of field, 16:9`                                                                                                        |
+
+### Golden Rules
+
+- **NEVER abbreviate the subject.** Write the full character description in every single prompt. Veo does not remember previous prompts.
+- **Concrete visuals beat abstract concepts.** "Immigration officers checking passports at Ngurah Rai airport" >> "unified immigration system"
+- **Dialogue goes in quotes inside the prompt.** `She says: "Five deadlines. Zero room for error."`
+- **Camera movement in the first words.** Veo prioritizes the beginning of the prompt.
+
+---
+
+## Model Selection
+
+| Model               | When                                               | Credits (Ultra) | Audio |
+| ------------------- | -------------------------------------------------- | --------------- | ----- |
+| **Veo 3.1 Fast**    | Iterating, testing prompts                         | **Zero**        | Yes   |
+| **Veo 3.1 Full**    | Final render only                                  | 5x              | Yes   |
+| **Nano Banana Pro** | Generating images (character sheets, environments) | Free            | N/A   |
+
+**Strategy:** Do ALL iterations with Fast. Only switch to Full for the final version you'll publish.
+
+---
+
+## Ingredients — Character Consistency
+
+### Setup (do this once per project)
+
+1. Settings gear → enable **Ingredients**
+2. Upload reference images:
+   - **1 front-facing portrait** (most important — anchors identity)
+   - **1 three-quarter view** (helps with angle consistency)
+   - **1 speaking/mid-sentence** (helps with mouth/expression)
+   - **1 environment** (your studio background)
+3. Max 4 ingredients active per generation
+
+### Rules
+
+- A front-facing neutral portrait is the **strongest anchor** for face consistency
+- If the character drifts after 3+ clips → re-upload ingredients and regenerate
+- Ingredients control identity and pose; the **prompt controls everything else** (camera, lighting, action)
+- For consistent clothing: describe it identically in every prompt, don't rely on the image alone
+
+---
+
+## Voice Ingredients (Experimental)
+
+### Setup
+
+1. Settings → enable Voice Ingredients (requires Ultra)
+2. Must have at least **1 Image Ingredient active** (character face)
+3. Open Voice menu → hover to preview → select
+
+### Best Voices by Use Case
+
+| Use                      | Voice                              | Why                               |
+| ------------------------ | ---------------------------------- | --------------------------------- |
+| Young professional woman | **Aoede** (F, breezy, mid)         | Matches warm, approachable anchor |
+| News authority           | **Alnilam** (M, firm, mid-low)     | Classic broadcast tone            |
+| Documentary narrator     | **Charon** (M, informative, lower) | Deep, measured                    |
+| Sophisticated woman      | **Despina** (F, smooth, mid)       | Premium feel                      |
+| Senior authority         | **Gacrux** (F, mature, mid)        | For older character               |
+
+### Critical Limitations
+
+- Voice does **NOT carry over** when you Extend or chain clips → re-select voice for each new clip
+- Indonesian accent: not available natively → add in prompt: `"She speaks English with a soft natural Indonesian accent, melodic rhythm of Bahasa Indonesia"`
+- Audio quality: mono 44.1kHz — acceptable for web, enhance post with ffmpeg for broadcast
+
+---
+
+## Making Videos Longer Than 8 Seconds
+
+### Method 1: Extend (quick but lower quality)
+
+- Click "+" at end of clip → "Extend"
+- Uses **Veo 2 Fast** (no audio, lower quality)
+- Good for: testing sequence, previewing flow
+- Bad for: final production
+
+### Method 2: Frames-to-Video Chaining (best quality)
+
+**This is the pro technique for full Veo 3.1 quality + audio:**
+
+1. Generate first 8-sec clip with Veo 3.1
+2. Hover over **last frame** → click "+" → **Save as Asset**
+3. Start new generation → switch to **"Frames to Video"**
+4. Load saved frame as **Start Frame**
+5. Write NEW prompt — **repeat full character description + environment**
+6. Add continuation: what happens next
+7. Generate with **Veo 3.1** (not Extend)
+8. "Add to Scene" → repeat from step 2
+9. Each chain = +8 seconds at full quality with audio
+
+### Method 3: Scene Builder Jump-To (for cuts between scenes)
+
+- Click "+" → "Jump To"
+- Uses Veo 3.1 full quality
+- Creates a **new camera angle** or scene cut (not seamless continuation)
+- Good for: switching from wide shot to close-up, changing environment
+
+### Avoiding Drift in Long Sequences
+
+- Copy-paste your character description verbatim into every prompt
+- Re-lock ingredients before each generation
+- If skin tone shifts → add specific color: "warm medium-brown skin tone"
+- If clothing changes → specify exact garment in every prompt
+- If lighting shifts → specify exact lighting setup every time
+
+---
+
+## Dual Format Production (16:9 + 9:16)
+
+### Composition Rules for Both Formats
+
+- **Subject at dead center** — in 9:16 crop, sides disappear
+- **Strong vertical elements** — columns, trees, light beams, smoke (become hero in portrait)
+- **No critical content at left/right edges** — will be cropped in vertical
+- **Symmetrical compositions** work in any crop
+
+### Workflow
+
+1. Generate in **16:9** first (landscape — primary format)
+2. For social: regenerate **same prompt** with 9:16 aspect ratio
+3. Or: center-crop the 16:9 with ffmpeg (loses resolution but saves time):
+   ```
+   ffmpeg -i input_16x9.mp4 -vf "crop=ih*9/16:ih" output_9x16.mp4
+   ```
+
+---
+
+## Camera Movement Reference
+
+| Movement       | Prompt keyword              | Best for                              |
+| -------------- | --------------------------- | ------------------------------------- |
+| Push in slowly | `slow dolly push-in`        | Dramatic reveals, building tension    |
+| Pull back      | `slow dolly pull-back`      | Establishing shots, revealing context |
+| Pan across     | `slow pan left/right`       | Scanning environments                 |
+| Tilt up        | `slow tilt up`              | Revealing from ground to sky          |
+| Orbit          | `slow orbit around subject` | 360 showcase                          |
+| Static         | `locked-off static shot`    | Dialogue, anchor shots                |
+| Handheld       | `subtle handheld movement`  | Documentary feel                      |
+| Crane down     | `crane shot descending`     | Grand entrances                       |
+| Tracking       | `tracking shot following`   | Movement, walking                     |
+
+**Tip:** Start prompt with camera movement — Veo prioritizes early words.
+
+---
+
+## Style Modifiers That Improve Quality
+
+### Photorealism
+
+```
+photorealistic, cinematic, shallow depth of field, film grain,
+anamorphic lens, 8K detail, natural skin texture
+```
+
+### Lighting
+
+```
+warm amber key light from the left, soft fill from above,
+dramatic side-lighting, golden hour, volumetric light rays,
+practical lighting from candles and screens
+```
+
+### Mood
+
+```
+atmospheric, moody, dramatic shadows, high contrast,
+intimate, epic, serene, urgent
+```
+
+### What to Avoid in Prompts
+
+- "high quality" or "beautiful" — too vague, adds nothing
+- Multiple conflicting styles — pick one mood
+- Overly long prompts (>200 words) — Veo loses focus
+- Negative prompts ("don't show X") — Veo doesn't handle negation well
+
+---
+
+## Image Generation (for Ingredients)
+
+Use Nano Banana Pro / Imagen 4 inside Flow:
+
+1. Type prompt in text box (same as video, but generates image)
+2. Best for: character sheets, environment references, style boards
+3. Generated images → immediately usable as Ingredients
+4. **Lasso tool:** click area of generated image → type modification → instant edit
+
+### Character Sheet Prompt Template
+
+```
+Portrait of [full character description]. [Pose: front-facing /
+three-quarter / profile / speaking]. [Lighting]. Portrait
+photography, shallow depth of field, neutral background.
+```
+
+### Environment Prompt Template
+
+```
+Interior/exterior of [environment description]. No people.
+[Lighting and time of day]. [Materials and textures].
+Architectural photography, centered composition that works
+in both 16:9 and 9:16 crop. [Style].
+```
+
+---
+
+## Troubleshooting
+
+| Problem                              | Fix                                                                  |
+| ------------------------------------ | -------------------------------------------------------------------- |
+| Character face changes between clips | Re-upload face ingredient, add skin tone + feature details to prompt |
+| Clothing changes                     | Specify exact garment (color, cut, material) in every prompt         |
+| Voice sounds different on next clip  | Re-select Voice Ingredient — it doesn't persist                      |
+| Video stuck generating >5 min        | Cancel and regenerate — likely stuck                                 |
+| Environment looks different          | Upload environment as Ingredient image, describe in prompt too       |
+| Weird artifacts / glitches           | Regenerate — AI video is stochastic, some generations fail           |
+| Extend has no audio                  | Extend uses Veo 2 — use Frames-to-Video instead                      |
+| 9:16 crops out important elements    | Redesign composition with center-dominant layout                     |
+| Prompt too long, Veo ignores parts   | Split into shorter clips, one concept per prompt                     |
+| Lips don't match dialogue            | Known Veo limitation — lip sync is approximate, not perfect          |
+
+---
+
+## Quick Reference Card
+
+```
+START NEW PROJECT:
+  Flow → New Project → Settings → Veo 3.1 Fast → Ingredients ON
+
+GENERATE CLIP:
+  Write 5-part prompt → Generate → Pick best → Add to Scene
+
+EXTEND (pro method):
+  Last frame → Save as Asset → Frames to Video → Full prompt again
+
+EXPORT:
+  Scene Builder → Play preview → Download (1080p or 4K)
+
+GOLDEN RULE:
+  Every prompt = full character + full environment + camera + action + style
+  Never assume Veo remembers anything from the previous clip.
+```

--- a/research/marketing/2026-05-13-flow-veo-3.1-mastery-manual.md
+++ b/research/marketing/2026-05-13-flow-veo-3.1-mastery-manual.md
@@ -1,0 +1,463 @@
+---
+date: 2026-05-13
+domain: marketing
+client_case: "Bali Zero 25k credits sprint planning — Google AI Ultra Flow/Veo 3.1 mastery for editorial video pipeline (IG Reels, TikTok, YouTube Shorts, WhatsApp video CTAs)"
+sources: 33
+author: "deep-researcher (Antonello/Bali Zero) + multi-LLM recovery 2026-05-13 (Gemini 3.1 Pro, Codex GPT-5.5, DeepSeek V4 Pro, NotebookLM 4 NB)"
+status: "draft pending verification"
+companion_skill: "skills/google-flow-video/SKILL.md (v2)"
+---
+
+# Flow + Veo 3.1 Mastery — Audit-Trail Deep Manual
+
+## Question
+
+How does Bali Zero — operating on a Google AI Ultra subscription ($249.99/month, 25,000 credits/month, account `antonellosiano@gmail.com`) — extract maximum editorial value from Google Labs Flow + Veo 3.1 across the production pipeline for IG Reels, TikTok, YouTube Shorts, and WhatsApp video CTAs, while staying within commercial-use TOS, SynthID disclosure obligations, and Indonesia UU PDP / UU ITE compliance?
+
+This manual is the audit-trail companion to `skills/google-flow-video/SKILL.md` (v2). The skill is operational and concise (~4,580 words). This manual carries the citations, the empirical evidence, the disagreements between sources, and the unresolved open questions.
+
+## TL;DR
+
+- **Veo 3.1 GA on 2025-10-15** via blog.google/technology/ai/veo-updates-flow — primary new capabilities: refined native synchronized audio (footsteps, dialogue, ambient in single pass), Ingredients-to-Video (up to 3 reference images per generation), Frames-to-Video (first/last frame inpainting), native 9:16 portrait, ~40-60% improved temporal consistency vs Veo 3.
+- **Flow UI credit pricing is per-generation, NOT per-second**: Lite 5 cr / Fast 10 cr / Quality 100 cr (the previous v1 skill claimed "Veo 3.1 Fast = Zero credits" — empirically false per dashboard verification 2026-05-13 + Google support docs). Ultra freebies: Lite + Fast at [Lower Priority] = 0 cr (off-peak only). 4K upscale = 50 cr flat. Quality is **always charged at 2× minimum** in Flow UI (200 cr/generation).
+- **Three credit allocation strategies for 25k/month budget** map to distinct content goals: **Hero-heavy** (200×Q + 300×F + 200×L = 24k cr, ~58 min output, premium brand) · **Volume-heavy** (50×Q + 1500×F + 500×L = 22.5k cr, ~280 min output, SEO library) · **Balanced/recommended** (150×Q + 700×F + 400×L = 24k cr, ~210 min output, editorial pipeline default). Realistic Brief throughput ≈ 15–20 episodes/month after retries.
+- **Beyond 8 seconds**: 3 production-grade methods — Frames-to-Video chaining (best quality, fresh full Veo per segment), Flow Extend (≤148s single shot but visible drift past chain 4–5), Jump-To via Scene Builder (cinematic cuts, reliable on Quality). For dialogue/narrative, Frames-to-Video beats Extend.
+- **Critical compliance gates for Indonesia operations**: (a) every Veo 3.1 frame carries DeepMind SynthID — removing it violates TOS + EU AI Act + Indonesia UU PDP / UU ITE; (b) real-person likeness requires written consent (auto-blocked otherwise + account flag risk); (c) Indonesian government officials named likeness is hard-banned (UU PDP + KUHP defamation exposure). Required Bali Zero disclosure: caption disclaimer + audit log CSV + consent PDF when applicable.
+
+## Key citations (verbatim)
+
+1. **Veo 3.1 + Flow release announcement (Google official, 2025-10-15)**:
+   > "Veo 3.1 powers a new set of editing capabilities in Flow [...] Ingredients to Video uses up to three reference images of characters, objects, or environments to consistently generate scenes that exactly match the inputs [...] Each [Extend] is generated from the final second of the prior clip, making it useful for longer establishing shots."
+   — https://blog.google/technology/ai/veo-updates-flow (also archived at blog.google/innovation-and-ai/products/veo-updates-flow)
+
+2. **Google official prompt formula (Cloud blog, Ultimate Prompting Guide for Veo 3.1)**:
+   > "We recommend you structure prompts using these core components: Cinematography, Subject, Action, Context, Style and Ambiance [...] An example prompt: 'A medium close-up shot, locked-off, of an old fisherman with weathered skin [...]'"
+   — https://cloud.google.com/blog/products/ai-machine-learning/ultimate-prompting-guide-for-veo-3-1
+
+3. **Flow credits & pricing (Google Help, 2026-05-13 verified)**:
+   > "Costs are shown in the prompt-box settings. Costs may change [...] Veo 3.1 Quality: 100 credits per generation; Veo 3.1 Fast: 10 credits; Veo 3.1 Lite: 5 credits; Lite [Lower Priority] and Fast [Lower Priority]: 0 credits for Ultra subscribers; 4K upscale: 50 credits."
+   — https://support.google.com/flow/answer/16526234
+
+4. **Audio limits & subtitles bug (Google Help)**:
+   > "Generated speech may incorrectly trigger on-screen subtitles. Audio quality is experimental — low-quality audio can cause generation failure and refund. Speech may be muted for minors."
+   — https://support.google.com/flow/answer/16352836
+
+5. **Ingredients-to-Video specification (Google Help)**:
+   > "Ingredients lets you upload up to three reference images per generation — Flow supports characters, objects, and style. Voice references work only with Ingredients generations, summoned via @Voice in the prompt."
+   — https://support.google.com/flow/answer/16353334
+
+6. **SynthID watermarking + commercial likeness restrictions (multi-source)**:
+   > "Every frame contains DeepMind's invisible SynthID watermark. Real-person likeness is strictly hard-coded to refuse prompts containing names of celebrities, politicians, or public figures."
+   — Synthesized from blog.google/technology/ai/veo-updates-flow + aifreeapi.com/veo-3-1 + Reddit r/VEO3 empirical evidence
+
+7. **Market context — Veo grew while Sora collapsed (AI Magicx, 2026-04-08)**:
+   > "By February 2026, [Sora's MAU] had fallen to roughly 190,000. In the same period, Google's Veo grew from 2 million to over 11 million monthly active users [...] A 30-second social media ad that would have cost $3,000–5,000 to produce traditionally can now be created for $200–500 using AI video generation."
+   — https://aimagicx.com/blog/sora-is-dead-2026-ai-video-landscape (via NotebookLM NB-INTEL-AIResearch query 2026-05-13)
+
+## Findings
+
+### Section 1 — Release notes and what changed Veo 3 → Veo 3.1
+
+Veo 3.1 was announced 2025-10-15 (Google blog timestamp) as a minor-version bump on Veo 3 (May 2025). The architecturally significant changes:
+
+- **Refined native synchronized audio**: Veo 3 introduced audio but had a measurable drift (~20-40ms on long clips per creator reports). Veo 3.1 generates dialogue + SFX + ambient + Foley in a single latent-space pass with reduced drift. Source: blog.google/technology/ai/veo-updates-flow + Curious Refuge review (https://curiousrefuge.com/blog/veo-31-quality-ai-video-generator-review).
+- **Ingredients to Video**: Up to 3 reference images (characters, objects, environments, style) per generation, locks visual consistency across cuts. Source: support.google.com/flow/answer/16353334.
+- **Frames to Video**: Provide exact starting and ending frame, model generates the transition. Source: blog.google/technology/ai/veo-updates-flow.
+- **Native 9:16 portrait**: Trained for vertical composition, not center-cropped from 16:9. Source: blog.google/technology/ai/veo-updates-flow.
+- **Improved physics + prompt adherence**: ~40-60% improvement in temporal stability per creator testing (MindStudio.ai empirical) — anecdotal, not Google-published benchmark.
+- **Speed bump on Fast tier**: Wall-clock ~1m13s on Fast vs ~2m41s on Veo 3 (Curious Refuge measured).
+
+Caveat on a contradictory claim: a NotebookLM source (AI Magicx blog) cited a "February 2026 Veo 3.1 release" with "4K native output". This contradicts the Google-official 2025-10-15 announcement. The 4K native is also not on the official Flow help table — Flow lists 4K only as a paid upscale (50 cr flat). Resolution: trust Google's blog.google + support.google.com over secondary blogs. The AI Magicx article likely conflated Veo 3.1 GA with a later capability rollout.
+
+### Section 2 — Tier comparison (Lite, Fast, Quality) and empirical retry rates
+
+Per the verified pricing table (cited #3 above), the three Veo 3.1 tiers differ in credit cost AND in priority queue:
+
+| Tier | Credits | Output | Native audio | Wall-clock | Best for |
+|---|---|---|---|---|---|
+| Lite (5 cr) | 5 cr | 720p (1080p free upscale) | May vary, weak | ~1 min | Storyboarding, animatics |
+| Fast (10 cr) | 10 cr | 1080p | Full | ~1m13s | Workhorse iteration |
+| Quality (100 cr) | 100 cr base, **always 2× minimum** | 1080p (4K +50 cr) | Best | ~2-3 min (1×) | Hero, locked shots |
+| Lite [Lower Priority] | 0 cr (Ultra freebie) | 720p | May vary | 5-20 min wait | Off-peak bulk |
+| Fast [Lower Priority] | 0 cr (Ultra freebie) | 1080p | Full | 5-20 min wait | Off-peak bulk |
+
+**Retry rates** (DeepSeek V4 Pro analysis, MEDIUM confidence — inferred from Veo 3.1 capabilities and diffusion-model failure modes; no Google-published breakdown):
+
+- Simple B-roll (property exterior, document close-up): ~90% first-pass good (~10% retry)
+- Talking-head 8s monologue: 70-75% first-pass (~20% credit penalty)
+- Multi-character dialog (2 people in office): 55-65% (~35% penalty)
+- Text-in-scene (legal document readable text): 40-50% (~50% penalty)
+- Indonesian-accented English: 30-40% (~60% penalty)
+
+**Practical takeaway**: never burn Quality credits on text-in-scene legal docs — generate clean B-roll, add overlay text in CapCut/Premiere/DaVinci post-production.
+
+### Section 3 — Prompt formula (Google official 5-part hierarchy)
+
+The canonical structure from cloud.google.com/blog/products/ai-machine-learning/ultimate-prompting-guide-for-veo-3-1:
+
+```
+[Cinematography] + [Subject] + [Action] + [Context] + [Style & Ambiance]
+```
+
+Veo 3.1 uses **front-loaded token attention**: tokens placed first in the prompt receive heavier weights. Camera direction placed first (e.g., `medium close-up, 35mm, slow dolly-in,...`) yields directed shots; placed after Subject, the model defaults to mild slow pan-right ("cinematic bias").
+
+**Length sweet spot**: 3-6 sentences, ~100-150 words. The Vertex AI docs (https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/veo/3-1-generate) cite a hard char limit but no published number for Flow UI specifically; third-party API wrappers (apiframe.ai, fal.ai) list 20,000-character ceilings — unverified for Flow UI itself.
+
+**Vocabulary discipline** (from sider.ai/blog/ai-tools/best-prompt-techniques-for-veo-3_1-video-output-a-field-guide-to-cinematic-control):
+- Camera movement words = constraints, not decoration: `dolly`, `tracking`, `crane`, `POV`, `shallow depth of field`, `macro`, `wide-angle`, `deep focus`, `key/fill/rim light`
+- "Anamorphic" alone style-shifts unpredictably — spell out the visible result: `oval bokeh, horizontal lens flare, compressed background, 2.39:1 aspect`
+- Named-style references work best as one or two anchors, then concrete visual traits. Stacking ("cyberpunk + film noir + Studio Ghibli") creates incoherent output.
+
+**JSON-style prompt hack (community, anecdotal)**:
+```
+{"camera": "Low angle tracking shot", "subject": "White sports car",
+ "action": "drifting around a hairpin turn", "lighting": "Golden hour",
+ "audio": "Tire screech, roaring V8 engine"}
+```
+Reddit r/VEO3 reports JSON-wrapped prompts force deterministic interpretation. Treat as anecdotal — Google has not endorsed this syntax.
+
+**Rejected patterns**:
+- ❌ Filler words ("high quality", "beautiful", "epic", "cinematic" alone — no information)
+- ❌ Negative-as-don't ("don't show a man" often shows a man anyway; use the Negative Prompt field)
+- ❌ Exact counts ("three people" often becomes 2 or 4)
+- ❌ Named celebrity/politician likeness (auto-blocked + account flag — see Section 10)
+
+### Section 4 — Audio (dialog, SFX, ambient, music) + lip-sync rules
+
+**Dialog syntax** (Google official pattern, deepmind.google/models/veo/prompt-guide):
+```
+A woman says, "We have to leave now." (no subtitles)
+```
+
+The double-quotes are load-bearing — Veo 3.1 only triggers lip-sync attention on quoted text. Suffix `(no subtitles)` prevents the model from rendering on-screen captions (a documented bug per support.google.com/flow/answer/16352836).
+
+**Multi-lane prompting** (Google official, cloud.google.com):
+```
+Dialogue: A woman says, "Welcome to Bali Zero." (no subtitles)
+SFX: Soft keyboard typing, paper rustle as document slides forward.
+Ambient: Tropical air-con hum, distant gamelan music.
+Music: Subtle uplifting orchestral pad, slow swell, no melody.
+```
+
+**Lip-sync hard rules** (≥90% success):
+1. **1 speaker per clip** — multi-speaker dialog fails ~50% even on Quality
+2. **≤5 seconds of spoken audio** per 8s clip — pad with silence pre/post
+3. **Close-up or medium shot**, mouth clearly visible
+4. Booster phrase: `"...clearly enunciates each word..."`
+5. Multi-character conversations use **shot/reverse-shot** (separate clips per speaker)
+
+**Known audio bugs** (creator-empirical, multiple Reddit threads):
+- 20-40ms drift on long clips → cut before/after hard consonants
+- Voice timbre robotic on Fast — generate 3-4 Quality variants for hero
+- **No native Indonesian-accent voice** — voice references partially work but Reddit r/Bard (https://www.reddit.com/r/Bard/comments/1o7ftjk/veo_31_is_a_disappoinment/) reports accent reliability regressed in Veo 3.1 vs Veo 3 (Australian-accent complaint specifically)
+- Voice does NOT persist cross-Extend reliably
+
+**Voice Ingredients** (Ultra-only, experimental):
+- 1 voice reference allowed per generation
+- Works only with full Ingredients generations
+- Summoned via `@Voice` in prompt
+- 5 creator-recommended voice profiles: Aoede (F, warm) · Alnilam (M, broadcast) · Charon (M, documentary) · Despina (F, smooth) · Gacrux (F, authority)
+
+### Section 5 — Beyond 8 seconds (3 methods compared)
+
+Veo 3.1 generates max 8s per single generation. Three methods for 30s+ output:
+
+**A) Frames-to-Video chaining** (recommended for dialogue/narrative):
+- Generate clip 1 → save last frame → use as start frame of clip 2 → repeat
+- Each segment is fresh full-Veo generation with audio
+- Cost: 10 cr/chain (Fast) or 100 cr/chain (Quality) per segment
+- Quality: 🟢 highest (no decay)
+- Production speed: Medium (serial dependency)
+- Max 4 chained reliably before identity drift on character clips
+
+**B) Flow Extend** (recommended for continuous motion):
+- Click "Extend" on existing clip → adds +7s from final frame
+- Cost: 10 cr per extend (Fast tier base)
+- Quality: 🟡 Decays — chain 1-3 OK, 4-5 subtle drift, 6-10 noticeable, 11-20 visible
+- Max theoretical: 8s base + 20 extends × 7s = **148s single unbroken shot**
+- Loophole for 5min+: export 148s, re-upload last frame as I2V start, begin new chain
+
+**C) Jump-To via Scene Builder** (recommended for shot/reverse-shot):
+- Place 8s clips on Scene Builder timeline → cinematic cuts
+- Reliable on Quality, unstable on Fast (creator reports — Reddit r/VEO3)
+- Cost: per-clip base, no extension fee
+- Best for multi-shot narratives (hook → problem → reveal → CTA)
+
+**Pro workflow — Frames-to-Video chain (7 steps)**:
+1. Write **scene bible**: cast names, wardrobe, lighting palette, location, voice tone. Reuse verbatim.
+2. Generate clip 1 with full Subject + Context.
+3. Save last frame in Flow asset menu.
+4. Lock 1 Ingredient as face anchor (e.g., `Zantara-Veronika` front portrait).
+5. Generate clip 2: prompt = clip 1's full Subject (verbatim) + new Action + re-stated environment.
+6. Hand-over-hand prompting: end-state of clip N = open-state of clip N+1.
+7. Test on Lite (5 cr) before Quality (100-200 cr).
+
+Source: synthesized from blog.google + support.google.com/flow/answer/16935718 + veo3gen.app/blog/veo-31-in-google-flow-a-beginner-workflow-to-build-a-1530s-scene-from-shot-cards.
+
+### Section 6 — Generation modes (Text, Image, Frames, Ingredients)
+
+Per support.google.com/flow/answer/16352836, the current Veo 3.1 tier capability matrix:
+
+| Mode | Lite | Fast | Quality |
+|---|---|---|---|
+| Text-to-Video (T2V) | ✅ | ✅ | ✅ |
+| Image-to-Video (I2V) | ✅ | ✅ | ✅ |
+| Frames (start/end) | ✅ | ✅ | ✅ |
+| Extend | ✅ | ✅ | ✅ |
+| Ingredients-to-Video | ✅ | ✅ | ⚠️ — Quality does NOT currently support Ingredients per the help table |
+| Insert (object) | ✅ | ✅ | ✅ |
+| Remove (object) | uses Veo 2 internally, NO audio | uses Veo 2 internally, NO audio | uses Veo 2 internally, NO audio |
+
+**When to use which**:
+- **T2V**: B-roll, establishing shots, abstract concepts (no character consistency needed)
+- **I2V**: Bring Midjourney/Imagen 4/Nano Banana Pro static into motion; locks composition perfectly but limits dynamic camera
+- **Frames (start/end)**: Seamless transitions, force camera Point A → Point B without hallucinating geometry
+- **Ingredients**: Mandatory for narrative filmmaking — locks character/wardrobe/environment across cuts
+
+**Gotcha**: Quality + Ingredients is listed as unsupported in the current help table. For hero shots requiring identity consistency, use Fast 4× variants OR generate the hero on Quality without Ingredients but anchor via Frames-to-Video chain from a Fast+Ingredients-locked establishing shot.
+
+### Section 7 — Camera controls (UI vs prompt language)
+
+Flow has UI sliders for Pan/Tilt/Zoom but creators (Reddit r/VEO3 consensus) report **text prompting yields higher precision**. The DeepMind prompt guide (https://deepmind.google/models/veo/prompt-guide) confirms Veo 3.1 trained on a proprietary cinematic-terminology dataset.
+
+**Production-grade movements** (creator-empirical reliability):
+
+| Movement | Prompt syntax | Reliability |
+|---|---|---|
+| Slow dolly push-in | `slow dolly push-in over 6 seconds, locked subject` | 🟢 hero-grade |
+| Locked-off static | `static locked-off camera, no movement` OR community hack `"from the perspective of a rock that does not move"` | 🟢 safest for dialog |
+| Orbit | `slow 90-degree arc around subject` | 🟢 (subjects isolated, plain background) |
+| Whip pan | `fast whip pan left to right, motion blur` | 🟡 |
+| Rack focus | `rack focus from foreground to background, shallow depth of field` | 🟡 |
+| Gimbal glide | `smooth gimbal glide forward, low angle` | 🟢 |
+| FPV drone dive | `FPV drone dive, fast descent, dynamic angle` | 🟢 |
+| Dolly zoom (Vertigo) | `dolly zoom on subject, background compresses` | 🟡 |
+
+**The "Rock" hack** (Reddit r/VEO3 community): adding `"from the perspective of a rock, that does not move"` is the most reliable way to force a completely static locked-off shot. Anecdotal but widely confirmed.
+
+**Start/End Mirroring trick**: uploading the exact same image as both First and Last frame forces the model to animate only the subject (e.g., blinking, wind in hair) without moving the camera. Useful for "talking portrait" idents.
+
+### Section 8 — Negative prompting + Remove tool
+
+**Phrase positively first**, place negatives at end (DeepMind prompt guide). Editorial-safe negative stack:
+
+```
+no extra fingers, no warped text, no motion smear, no jump cuts, no watermarks,
+no AI artifacts, no morphed limbs, no double faces, consistent anatomy,
+no shaky camera, no subtitles, no on-screen text overlays
+```
+
+If an artifact recurs across 3+ retries, escalate to positive reframe: replace `"no shaky camera"` with `"smooth steady camera, no handheld motion"`.
+
+**Remove tool caveat** (support.google.com/flow/answer/16352836): Flow's object-remove inpainting uses **Veo 2** internally, NOT Veo 3.1, and produces **NO audio**. Use only for static-shot cleanup (e.g., removing a modern car from a period-piece B-roll). Never for hero shots — quality drop vs Veo 3.1 is visible.
+
+### Section 9 — Throughput, queue, and time-of-day strategy
+
+**Wall-clock generation time** (creator-empirical, off-peak):
+- Lite: ~1 min
+- Fast 1×: ~1m13s
+- Quality 1×: ~2-3 min
+- Quality 2× (forced minimum): ~3-4 min
+- Quality 4×: ~5-6 min
+- 4K upscale: +3-5 min
+
+**Lower-priority queue strategy** (Ultra freebie):
+- Lite [Lower Priority] = 0 cr but 5-20 min wait
+- Fast [Lower Priority] = 0 cr but 5-20 min wait
+- Best results off-peak (early morning WITA = late evening US west coast)
+- Use for overnight bulk B-roll harvest
+
+**Daily editorial workflow**:
+1. **Composition drafting** → Lite 1× (5 cr), iterate framing
+2. **Refinement** → Fast 1× (10 cr), lock blocking + audio
+3. **Hero render** → Quality 2× (forced, 200 cr), pick best variant
+4. **Bulk harvest** → Lite [Lower Priority] (0 cr) overnight
+5. **4K hero** → Quality 2× + 4K upscale (200 + 50 cr)
+
+**Failed generations should not charge credits** per Google policy (support.google.com/flow/answer/16526234). Low-audio-quality failures may refund (support.google.com/flow/answer/16352836).
+
+### Section 10 — Commercial use, SynthID, and Indonesia compliance
+
+**Allowed under Ultra commercial license**:
+- ✅ Marketing assets for Bali Zero / Nuzantara editorial
+- ✅ Generic visuals (Bali landscapes, generic spokespersons, abstract concepts)
+- ✅ Client/staff likenesses **with written consent**
+- ✅ Client portals, ads, B2B decks, social posts
+
+**Forbidden — hard restrictions**:
+- ❌ Real-person likeness without consent (auto-blocked + account flag)
+- ❌ Indonesian government officials named likeness (UU PDP + KUHP defamation risk)
+- ❌ Copyrighted IP / brand logos (Disney, Apple, etc. — memorization-check refusal)
+- ❌ Named minors
+- ❌ Violence, hate speech, sexually explicit content
+
+**SynthID — invisible mandatory watermark**:
+- Every Veo 3.1 frame carries DeepMind SynthID (forensic, undetectable to humans)
+- Visible "veo" watermark bottom-right: present on non-Ultra Flow; **Ultra exempt** in Flow UI
+- API/Vertex outputs: no visible watermark; SynthID invariant
+- Removing SynthID = TOS violation AND:
+  - YouTube / Instagram / TikTok algorithm de-rank (platforms detect SynthID hashes)
+  - EU AI Act non-compliance for synthetic media disclosure (Art. 50)
+  - Indonesia UU PDP / UU ITE exposure on misleading content (Pasal 28 UU ITE)
+
+**Required Bali Zero disclosure protocol**:
+1. Caption/credits disclaimer: **"AI video assets generated via Veo 3.1 (Google Labs Flow)"**
+2. Audit log per asset in `~/Desktop/nuzantara/research/marketing/flow-asset-log.csv` (columns: date, project, shot, tier, cost_credits, aspect, duration_s, prompt_hash, consent_status, publication_url, retry_count, notes)
+3. For client/staff likeness: signed written consent stored in `~/Desktop/nuzantara/research/marketing/consent/<name>-<date>.pdf`
+
+**Bali Zero verdict matrix**:
+
+| Use case | Status | Rationale |
+|---|---|---|
+| Generic Bali B-roll, abstract explainers, property exteriors | ✅ ship | No likeness, no IP |
+| Veronika/Adit/Surya named likeness in B-roll | ⚠️ written consent required | Internal team consent template needed |
+| Named clients in testimonials | ⚠️ written consent + draft review | Add review-before-publish gate |
+| Indonesian government officials named | ❌ never | UU ITE Pasal 28 + KUHP 156a defamation exposure |
+
+**Comparative market context** (NotebookLM NB-INTEL-AIResearch query, AI Magicx blog 2026-04-08): Veo grew from 2M to 11M+ MAU between Q2 2025 and Feb 2026 while Sora collapsed (800k → 190k MAU) and was discontinued 2026-04-26. Kling reached 8M MAU. Runway held 3.5M. Veo's audio + Flow workflow stack is the dominant editorial tool. AI-assisted production cost is ~91% lower than traditional: $1,800-4,500/min traditional → $75-400/min AI for B-roll-heavy editorial.
+
+## Numerical analysis — 25k credits allocation
+
+**Base assumptions** (HIGH confidence, Google official):
+- Lite 5 cr, Fast 10 cr, Quality 100 cr (Quality always 2× = 200 cr in Flow UI)
+- 4K upscale 50 cr flat
+- Failed generations don't charge (per Google policy)
+
+**Retry assumptions** (MEDIUM confidence, DeepSeek inferred):
+- Lite ~35% retry rate (lower quality, more iteration)
+- Fast ~25% retry
+- Quality ~18% retry
+
+**Expected-yield formula**: `good_clips = credits / base_cost × (1 - retry_rate)`
+
+### Strategy A — Hero-heavy (premium serial)
+
+| Tier | Credits | Generations | Expected good clips | Output minutes |
+|---|---|---|---|---|
+| Quality (200 cr 2×) | 20,000 | 100 | 82 | ~11 min |
+| Fast | 5,000 | 500 | 375 | ~50 min |
+| Lite (free LP) | 0 | unlimited overnight | — | — |
+| **Total** | **25,000** | **600** | **457** | **~61 min** |
+
+Best for: brand serial opener (Bali Zero Year-1 origin story 6-clip episode), premium client decks, high-stakes testimonials with written consent. Per-episode 6-clip ≈ 1,200 cr → ~16 hero episodes/month.
+
+### Strategy B — Volume-heavy (SEO library, social daily)
+
+| Tier | Credits | Generations | Expected good clips | Output minutes |
+|---|---|---|---|---|
+| Quality | 5,000 | 25 | 21 | ~3 min |
+| Fast | 15,000 | 1,500 | 1,125 | ~150 min |
+| Lite | 5,000 | 1,000 | 650 | ~87 min |
+| **Total** | **25,000** | **2,525** | **1,796** | **~240 min** |
+
+Best for: SEO video library (KBLI explainers ×220, visa FAQ ×60, property B-roll ×100), IG Reels daily cadence, TikTok volume play. Per-episode 6-clip Fast-heavy ≈ 100 cr → ~250 episodes/month theoretical (~50/week realistic given retry + edit time).
+
+### Strategy C — Balanced (recommended default)
+
+| Tier | Credits | Generations | Expected good clips | Output minutes |
+|---|---|---|---|---|
+| Quality (200 cr 2×) | 15,000 | 75 | 62 | ~8 min |
+| Fast | 7,000 | 700 | 525 | ~70 min |
+| Lite | 2,000 | 400 | 260 | ~35 min |
+| **Total** | **24,000** | **1,175** | **847** | **~113 min** |
+
+Best for: Bali Zero editorial default — mix of hero pieces (Quality) + daily iteration (Fast) + bulk B-roll (Lite). Per-episode 6-clip Balanced (1Q + 4F + 1L = 245 cr) → ~98 episodes/month theoretical, ~30-40 realistic after retries + edit cycle.
+
+**Recommendation**: Strategy C. Sufficient Quality budget for 2-3 hero episodes per week, abundant Fast budget for daily TikTok/Reels, Lite for overnight B-roll harvest. Reserves 1,000 cr/month buffer for 4K upscales (~20 upscales) and emergency retries.
+
+## Disagreements between sources / Open questions
+
+**Veo 3.1 release date conflict**:
+- Google official: 2025-10-15 (blog.google + DeepMind)
+- AI Magicx blog (via NotebookLM): "February 2026"
+- **Resolution**: Trust Google primary source. AI Magicx likely conflated with a later 4K capability rollout.
+
+**4K native vs 4K upscale**:
+- AI Magicx: "4K output (3840x2160) at 24 or 30 fps, the first AI video model to reach true broadcast resolution"
+- Google official: 4K only via paid upscale (50 cr flat) on 1080p Quality outputs
+- **Resolution**: Google official wins. Native 4K may be Vertex AI API capability, not Flow UI.
+
+**Quality + Ingredients support**:
+- Current Flow help table (support.google.com/flow/answer/16352836): Quality does NOT support Ingredients
+- Older blog posts and creator tutorials: Ingredients works with all tiers
+- **Resolution**: Verify on dashboard before committing 200 cr Quality generation with Ingredients. May have been a temporary rollback.
+
+**Fast tier removal claim (Codex source)**:
+- Codex GPT-5.5 source: "Fast was marked for removal on May 9, 2026"
+- Direct dashboard verification 2026-05-13: Fast still present at 10 cr
+- **Resolution**: Either Codex source error OR removal was reversed. Verify in Flow settings before budgeting.
+
+**Indonesian-accent voice quality**:
+- Reddit r/Bard: accent reliability regressed Veo 3.1 vs Veo 3
+- Veo 3.1 official release notes: claims improved audio overall
+- **Resolution**: Open empirical question. **BVCL Sampling Sprint** (`docs/superpowers/plans/2026-05-13-bvcl-sampling-sprint.md`) should run 10-clip side-by-side study.
+
+**Empirical pending questions** (resolved via sampling sprint, ~600-800 credits budget):
+1. Lite tier audio fidelity — does "may-vary" mean degraded or skipped?
+2. Extend tier cost — base tier per extend or discounted?
+3. Remove tool status — still Veo 2 internally as of 2026-05?
+4. Indonesian-accent English Quality vs Fast — 10-clip side-by-side
+5. Voice Ingredient stability across Frames-to-Video chain (does @Voice persist?)
+6. Quality forced-2× minimum — can it be overridden by support request?
+7. Multi-character lip-sync reliability on Quality vs Fast
+8. JSON-style prompt hack reliability (controlled A/B vs natural-language)
+
+## Checklist — 8 action items for Bali Zero rollout
+
+- [ ] **Item 1**: Verify Flow dashboard shows credits per tier match this manual (Lite 5, Fast 10, Quality 100, Quality forced 2× = 200, 4K +50). Screenshot to `research/marketing/flow-dashboard-2026-05-13.png` for audit trail.
+- [ ] **Item 2**: Generate Ingredients portrait set for 5 core spokespersons (Veronika, Surya, Adit, Sahira, Krisna) — 4 portraits each (front, 3/4, speaking, environment). Plain background. Save with `Zantara-<name>` naming convention.
+- [ ] **Item 3**: Sign written-consent PDFs for all 5 spokespersons. Template based on UU PDP Art. 7 (informed consent for biometric data processing). File in `research/marketing/consent/<name>-2026-05-13.pdf`.
+- [ ] **Item 4**: Initialize asset log CSV at `research/marketing/flow-asset-log.csv` with columns: date, project, shot, tier, cost_credits, aspect, duration_s, prompt_hash, consent_status, publication_url, retry_count, notes.
+- [ ] **Item 5**: Run BVCL Sampling Sprint — 12 sample clips × 4 archetypes (visa explainer, tax countdown, property B-roll, myth-bust hook) ≈ 600-800 credits. Document tier yields, retry rates, audio quality. Plan at `docs/superpowers/plans/2026-05-13-bvcl-sampling-sprint.md`.
+- [ ] **Item 6**: Pilot Frames-to-Video chain on 30-second Before/After Bali Zero office transformation (T7 template). Measure actual chain decay vs theoretical (4-clip max).
+- [ ] **Item 7**: Verify SynthID survives platform compression. Upload one Veo 3.1 output to YouTube, Instagram, TikTok, WhatsApp Status. Test SynthID detection at https://deepmind.google/synthid/detect on each compressed downloaded copy.
+- [ ] **Item 8**: Update WR2 editorial brief template to include Flow video archetype option (alongside static carousel). Storyboarder agent should output 6-clip episode plan with tier mix per Balanced strategy. PR to update `apps/backend-rag/backend/services/wr2/storyboard_generator.py` schema.
+
+## Sources index (33 distinct citations)
+
+**Google official primary (12)**:
+1. https://blog.google/technology/ai/veo-updates-flow — Veo 3.1 release announcement 2025-10-15
+2. https://cloud.google.com/blog/products/ai-machine-learning/ultimate-prompting-guide-for-veo-3-1 — Official prompt guide
+3. https://deepmind.google/models/veo/prompt-guide — DeepMind prompt guide
+4. https://support.google.com/flow/answer/16526234 — Credits & pricing
+5. https://support.google.com/flow/answer/16353334 — Generation settings (Ingredients, voice)
+6. https://support.google.com/flow/answer/16352836 — Audio limits & speech
+7. https://support.google.com/flow/answer/16935718 — Scene Builder & saving frames
+8. https://support.google.com/flow/answer/16935308 — Asset export & sharing
+9. https://support.google.com/flow/answer/17069754 — Keyboard shortcuts
+10. https://support.google.com/flow/answer/16729550 — Image-model help (Nano Banana Pro / Imagen 4)
+11. https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/veo/3-1-generate — Vertex AI Veo 3.1 spec
+12. https://deepmind.google/synthid/detect — SynthID detection tool
+
+**Creator/community empirical (10)**:
+13. https://curiousrefuge.com/blog/veo-31-quality-ai-video-generator-review — Curious Refuge review
+14. https://sider.ai/blog/ai-tools/best-prompt-techniques-for-veo-3_1-video-output-a-field-guide-to-cinematic-control — Sider field guide
+15. https://www.veo3gen.app/blog/veo-31-in-google-flow-a-beginner-workflow-to-build-a-1530s-scene-from-shot-cards — Veo3Gen Shot Card workflow
+16. https://www.datacamp.com/tutorial/veo-3-1-complete-guide-with-examples — DataCamp complete guide
+17. https://www.reddit.com/r/VEO3/comments/1rkf538/lip_sync_looks_cartoonish_teeth_way_too_visible/ — Reddit lip-sync critique
+18. https://www.reddit.com/r/VEO3/comments/1o8omm8/veo_31_sucks/ — Reddit r/VEO3 critique thread
+19. https://www.reddit.com/r/Bard/comments/1o7ftjk/veo_31_is_a_disappoinment/ — Reddit accent regression report
+20. https://www.reddit.com/r/VEO3/comments/1o7dkow/veo_31_my_experience_so_far_bad/ — Reddit hit-rate evidence
+21. https://www.tomsguide.com/ai/i-used-googles-veo-3-to-create-ai-asmr-food-videos — Tom's Guide food ASMR test
+22. https://www.tomsguide.com/ai/ai-image-video/sora-2-vs-veo-3-1-i-gave-them-7-wild-prompts-and-one-clearly-crushed-it — Tom's Guide comparison
+
+**Market context / NotebookLM-mediated (5)**:
+23. https://aimagicx.com/blog/sora-is-dead-2026-ai-video-landscape — Sora discontinuation + market share data (via NB-INTEL-AIResearch)
+24. https://en.wikipedia.org/wiki/Sora_(text-to-video_model) — Sora Wikipedia snapshot (via NB)
+25. https://blog.google/innovation-and-ai/models-and-research/google-labs/believe-flow-music-partnership/ — Google Flow Music product (distinct from Flow video — disambiguation)
+26. https://www.notebooklm.google/ — Cinematic Video Overviews launch reference (March 2026)
+27. https://invideo.io/perf/veo3-1/ — Provider workflow examples (real estate)
+
+**Third-party API references (3)**:
+28. https://apiframe.ai/docs/videos/veo/veo-3-1 — API frame reference
+29. https://aifreeapi.com/veo-3-1 — AI free API SynthID + extension limits
+30. https://fal.ai/models/fal-ai/veo3.1 — Fal.ai Veo 3.1 inference spec
+
+**Competitive landscape (3)**:
+31. https://techcrunch.com/2025/03/31/runway-releases-an-impressive-new-video-generating-ai-model/ — Runway Gen-4
+32. https://pikaais.com/pikaframes/ — Pika 2.0 / PikaFrames
+33. https://www.tomsguide.com/ai/i-tried-klings-new-2-5-turbo-ai-video-generator-its-a-giant-leap-forward-but-still-cant-do-this-one-thing — Kling 2.5/3.0
+
+---
+
+**End of manual.** Companion skill: `skills/google-flow-video/SKILL.md` (v2). Recovery context: this manual + skill v2 were composed 2026-05-13 in isolated worktree per Autonomous Ops L2 safety pattern after the original v2 attempt on main branch was rollbacked by sibling automation (cicatrix-scar pattern documented 2026-04-29).

--- a/skills/google-flow-video/SKILL.md
+++ b/skills/google-flow-video/SKILL.md
@@ -1,272 +1,606 @@
-# Skill: Google Flow — Mastering AI Video Creation
+---
+name: google-flow-video
+description: Generate AI video assets via Google Labs Flow + Veo 3.1 on Antonello's AI Ultra plan ($249.99/mo, 25,000 credits/month). Use when the user asks to create video shorts/reels/B-roll/explainers/testimonials for Bali Zero, ZANTARA, or any editorial deliverable. Skill is operational — not academic.
+trigger_keywords: ["flow", "veo", "video", "reel", "short", "ai video", "google flow", "veo 3.1", "google ai ultra", "labs.google/flow"]
+version: 2.0
+updated: 2026-05-13
+supersedes: SKILL.v1-pre-2026-05-13.bak (April 2026, contained false "Veo 3.1 Fast = Zero credits" claim, predated Veo 3.1 2025-10-15 release)
+companion_manual: research/marketing/2026-05-13-flow-veo-3.1-mastery-manual.md
+authority_sources:
+  - https://blog.google/technology/ai/veo-updates-flow (Veo 3.1 release 2025-10-15)
+  - https://cloud.google.com/blog/products/ai-machine-learning/ultimate-prompting-guide-for-veo-3-1 (Google ufficiale prompt guide)
+  - https://deepmind.google/models/veo/prompt-guide (DeepMind prompt guide)
+  - https://support.google.com/flow/answer/16526234 (credits & pricing)
+  - https://support.google.com/flow/answer/16353334 (Ingredients, voice, multi-output)
+  - https://support.google.com/flow/answer/16352836 (audio limits)
+  - https://support.google.com/flow/answer/16935718 (Scene Builder)
+  - https://support.google.com/flow/answer/17069754 (keyboard shortcuts)
+---
 
-## Trigger
+# Flow + Veo 3.1 Operational Skill (v2)
 
-User wants to create, iterate, or improve a video in Google Flow.
-
-## Access
-
-- URL: https://labs.google/flow/
-- Account: antonellosiano@gmail.com (Ultra — zero credits on Veo 3.1 Fast)
+**Account**: `antonellosiano@gmail.com` · Google AI Ultra ($249.99/mo) · 25,000 credits/month
+**Flow URL**: https://labs.google/flow
+**Model release**: Veo 3.1 GA 2025-10-15 (replaces Veo 3 May 2025)
+**Do NOT confuse**: Google Flow Music is a separate product (audio for artists, partnership with Believe). This skill is **Veo video generation inside Flow** only.
 
 ---
 
-## The Prompt Formula
+## 1. Reality check — models & credits in Flow UI (Ultra)
 
-Every prompt must contain 5 parts in this order:
+> ⚠️ Credit costs in Flow UI are **per-generation**, NOT per-second. 8s clip = 4s clip = 6s clip = same cost at same tier. The Vertex AI / Gemini API is a different billing model — do not conflate.
 
-```
-[CAMERA] + [SUBJECT] + [ACTION] + [CONTEXT] + [STYLE]
-```
+| Tier | Credits / generation | Output res | Native audio | Best use |
+|---|---|---|---|---|
+| **Veo 3.1 Lite** | 5 | 720p (1080p upscale 0 cr) | may vary, weak | Storyboarding, B-roll exploration, animatics |
+| **Veo 3.1 Fast** | 10 | 1080p | yes (full) | Workhorse — daily iteration, dialog drafts |
+| **Veo 3.1 Quality** | 100 | 1080p (4K upscale +50 cr) | yes (best) | Hero/locked shots, client-facing |
+| Lite [Lower Priority] | **0** (Ultra freebie) | 720p | may vary | Off-peak bulk exploration |
+| Fast [Lower Priority] | **0** (Ultra freebie) | 1080p | yes | Off-peak bulk drafts |
+| 4K upscale | 50 (flat) | — | — | Hero shots only |
 
-| Part    | What to specify                        | Example                                                                                                                                                                               |
-| ------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CAMERA  | Movement + framing                     | `Slow dolly push-in, medium close-up`                                                                                                                                                 |
-| SUBJECT | Full physical description — EVERY TIME | `a young Indonesian woman with long brown hair, warm skin, subtle eyeliner, small hoop earrings, thin silver necklace, wearing modern black kebaya`                                   |
-| ACTION  | What happens + dialogue in quotes      | `speaks directly to camera and says: "Welcome to the Bali Zero Morning News."`                                                                                                        |
-| CONTEXT | Environment, lighting, time of day     | `seated at a circular stone table in an ancient Balinese temple hall, holographic amber data floating above the table, dvarapala guardian statues with glowing eyes along both sides` |
-| STYLE   | Technical look                         | `cinematic, photorealistic, warm amber lighting, shallow depth of field, 16:9`                                                                                                        |
+**Multiplier rules**:
+- 1× / 2× / 3× / 4× = number of parallel variants returned per generation (cost = base × N).
+- **Quality is always charged at 2× minimum** in Flow UI (200 cr/gen) — Google forces variant selection on Quality tier.
+- Aspect ratio: 16:9 + 9:16 both natively supported, **same cost**.
+- Duration: 4s / 6s / 8s all priced the same in a given tier — generate 8s by default.
 
-### Golden Rules
-
-- **NEVER abbreviate the subject.** Write the full character description in every single prompt. Veo does not remember previous prompts.
-- **Concrete visuals beat abstract concepts.** "Immigration officers checking passports at Ngurah Rai airport" >> "unified immigration system"
-- **Dialogue goes in quotes inside the prompt.** `She says: "Five deadlines. Zero room for error."`
-- **Camera movement in the first words.** Veo prioritizes the beginning of the prompt.
+**Failed generations should not charge credits** (Google policy, support.google.com/flow/answer/16526234). Low-audio-quality fails may refund.
 
 ---
 
-## Model Selection
+## 2. Cost calculator — 3 strategies for 25k monthly budget
 
-| Model               | When                                               | Credits (Ultra) | Audio |
-| ------------------- | -------------------------------------------------- | --------------- | ----- |
-| **Veo 3.1 Fast**    | Iterating, testing prompts                         | **Zero**        | Yes   |
-| **Veo 3.1 Full**    | Final render only                                  | 5x              | Yes   |
-| **Nano Banana Pro** | Generating images (character sheets, environments) | Free            | N/A   |
+> Per-Brief estimate: 6-clip episode (1 hero + 4 supporting + 1 CTA closer) ≈ **650 credits/Brief** → **~36 Briefs/month theoretical**, **15–20 Briefs/month realistic** after retries.
 
-**Strategy:** Do ALL iterations with Fast. Only switch to Full for the final version you'll publish.
+| Strategy | Quality (100 cr) | Fast (10 cr) | Lite (5 cr) | Total cr | Output minutes | Best for |
+|---|---|---|---|---|---|---|
+| **Hero-heavy** | 200 | 300 | 200 | **24,000** | ~58 min | Brand serial opener, premium client decks |
+| **Volume-heavy** | 50 | 1,500 | 500 | **22,500** | ~280 min | SEO library, B-roll, IG/TikTok daily |
+| **Balanced (recommended)** | 150 | 700 | 400 | **24,000** | ~210 min | Editorial pipeline Bali Zero default |
 
----
+**Retry math** (subtract from yield):
+- Simple B-roll: ~90% first-pass good → 10% retry
+- Talking-head 8s monologue: ~70-75% → +20% credit penalty
+- Multi-character dialog: ~55-65% → +35% penalty
+- Text-in-scene (legal docs readable): ~40-50% → +50% penalty (USE OVERLAYS IN POST INSTEAD)
+- Indonesian-accented English dialog: ~30-40% → +60% penalty
 
-## Ingredients — Character Consistency
-
-### Setup (do this once per project)
-
-1. Settings gear → enable **Ingredients**
-2. Upload reference images:
-   - **1 front-facing portrait** (most important — anchors identity)
-   - **1 three-quarter view** (helps with angle consistency)
-   - **1 speaking/mid-sentence** (helps with mouth/expression)
-   - **1 environment** (your studio background)
-3. Max 4 ingredients active per generation
-
-### Rules
-
-- A front-facing neutral portrait is the **strongest anchor** for face consistency
-- If the character drifts after 3+ clips → re-upload ingredients and regenerate
-- Ingredients control identity and pose; the **prompt controls everything else** (camera, lighting, action)
-- For consistent clothing: describe it identically in every prompt, don't rely on the image alone
+> **Bali Zero takeaway**: never burn Quality credits on text-in-scene legal docs — generate clean B-roll, add overlay in CapCut/Premiere.
 
 ---
 
-## Voice Ingredients (Experimental)
+## 3. Prompt formula — 5-part Google official
 
-### Setup
+**Canonical order** (Google's recommended hierarchy, front-loaded tokens get heaviest attention):
 
-1. Settings → enable Voice Ingredients (requires Ultra)
-2. Must have at least **1 Image Ingredient active** (character face)
-3. Open Voice menu → hover to preview → select
+```
+[Cinematography] + [Subject] + [Action] + [Context] + [Style & Ambiance]
+```
 
-### Best Voices by Use Case
+| Part | Examples |
+|---|---|
+| Cinematography | `medium close-up, 35mm, slow dolly-in`, `static locked-off`, `low-angle tracking`, `FPV drone dive` |
+| Subject | Full description: age range, ethnicity, wardrobe, hair, expression. Never abbreviate. `Veronika, mid-30s Indonesian woman in white kebaya, hair tied back, calm professional expression` |
+| Action | One verb, concrete. `walks toward camera`, `places stamp on document`, `looks directly into lens and says...` |
+| Context | Specific location + time of day + props. `Bali Zero office Sanur, late afternoon, wooden desk, KITAS document visible` |
+| Style & Ambiance | Lighting source + mood + audio cue. `warm key light from window left, soft tropical shadows, ambient air-con hum, distant scooter` |
 
-| Use                      | Voice                              | Why                               |
-| ------------------------ | ---------------------------------- | --------------------------------- |
-| Young professional woman | **Aoede** (F, breezy, mid)         | Matches warm, approachable anchor |
-| News authority           | **Alnilam** (M, firm, mid-low)     | Classic broadcast tone            |
-| Documentary narrator     | **Charon** (M, informative, lower) | Deep, measured                    |
-| Sophisticated woman      | **Despina** (F, smooth, mid)       | Premium feel                      |
-| Senior authority         | **Gacrux** (F, mature, mid)        | For older character               |
+**Length sweet spot**: 3–6 sentences, 100–150 words. Longer prompts dilute attention; shorter prompts let the model hallucinate.
 
-### Critical Limitations
+**Golden rules**:
+1. Camera intent FIRST when shot must feel directed.
+2. Concrete > abstract: "warm tungsten from window" beats "beautiful lighting".
+3. Source the light: every shot should name the key light direction + temperature.
+4. Force verbs: model needs grammatical verbs, not gerund clouds.
+5. Material cues: "linen fabric", "weathered teak wood", "wet pavement" — surfaces carry physics.
+6. Avoid exact counts ("three people" often → 2 or 4); use "a small group" or single subjects.
 
-- Voice does **NOT carry over** when you Extend or chain clips → re-select voice for each new clip
-- Indonesian accent: not available natively → add in prompt: `"She speaks English with a soft natural Indonesian accent, melodic rhythm of Bahasa Indonesia"`
-- Audio quality: mono 44.1kHz — acceptable for web, enhance post with ffmpeg for broadcast
+**Don't use**:
+- ❌ "high quality", "beautiful", "epic", "cinematic" alone (filler, no information)
+- ❌ Negative-as-don't ("don't show a man" — model often shows a man anyway; use Negative Prompt field)
+- ❌ Multiple conflicting style anchors ("cyberpunk + film noir + Studio Ghibli")
+- ❌ Named celebrity/politician/public-figure likeness (auto-blocked + account flag risk)
+- ❌ Branded IP / copyrighted logos (memorization-check refusal)
+
+**"Anamorphic" alone doesn't work** — spell out: `oval bokeh, horizontal lens flare, compressed background, 2.39:1 aspect`.
 
 ---
 
-## Making Videos Longer Than 8 Seconds
+## 4. Timestamp Prompting (Google Cloud — advanced)
 
-### Method 1: Extend (quick but lower quality)
+Generate multi-shot narrative in **one 8s generation** using inline timecodes:
 
-- Click "+" at end of clip → "Extend"
-- Uses **Veo 2 Fast** (no audio, lower quality)
-- Good for: testing sequence, previewing flow
-- Bad for: final production
+```
+[00:00-00:02] Wide establishing shot, Ngurah Rai airport arrivals hall, morning daylight,
+   travelers walking, ambient announcement audio.
+[00:02-00:04] Cut to medium shot, Indonesian immigration officer at counter, calm
+   professional, stamping a passport, "Welcome to Indonesia" said softly.
+[00:04-00:06] Close-up on KITAS card placed on counter, hand of officer sliding it forward.
+[00:06-00:08] Wide pull-out, applicant smiling, picks up KITAS, walks toward exit.
+   Soft uplifting music swell.
+```
 
-### Method 2: Frames-to-Video Chaining (best quality)
-
-**This is the pro technique for full Veo 3.1 quality + audio:**
-
-1. Generate first 8-sec clip with Veo 3.1
-2. Hover over **last frame** → click "+" → **Save as Asset**
-3. Start new generation → switch to **"Frames to Video"**
-4. Load saved frame as **Start Frame**
-5. Write NEW prompt — **repeat full character description + environment**
-6. Add continuation: what happens next
-7. Generate with **Veo 3.1** (not Extend)
-8. "Add to Scene" → repeat from step 2
-9. Each chain = +8 seconds at full quality with audio
-
-### Method 3: Scene Builder Jump-To (for cuts between scenes)
-
-- Click "+" → "Jump To"
-- Uses Veo 3.1 full quality
-- Creates a **new camera angle** or scene cut (not seamless continuation)
-- Good for: switching from wide shot to close-up, changing environment
-
-### Avoiding Drift in Long Sequences
-
-- Copy-paste your character description verbatim into every prompt
-- Re-lock ingredients before each generation
-- If skin tone shifts → add specific color: "warm medium-brown skin tone"
-- If clothing changes → specify exact garment in every prompt
-- If lighting shifts → specify exact lighting setup every time
+**Trade-off**: can't retry one segment — entire 8s regenerates. Use for hero shots only after 2–3 Fast iterations confirm composition.
 
 ---
 
-## Dual Format Production (16:9 + 9:16)
+## 5. Audio — dialog, SFX, ambient, music
 
-### Composition Rules for Both Formats
+**Dialog syntax** (load-bearing — double-quotes mandatory):
 
-- **Subject at dead center** — in 9:16 crop, sides disappear
-- **Strong vertical elements** — columns, trees, light beams, smoke (become hero in portrait)
-- **No critical content at left/right edges** — will be cropped in vertical
-- **Symmetrical compositions** work in any crop
+```
+A woman says, "We have to leave now." (no subtitles)
+```
 
-### Workflow
+- Suffix `(no subtitles)` prevents the model from rendering on-screen captions (a known bug per support.google.com/flow/answer/16352836).
+- Use the `Dialogue:` keyword as alternative.
 
-1. Generate in **16:9** first (landscape — primary format)
-2. For social: regenerate **same prompt** with 9:16 aspect ratio
-3. Or: center-crop the 16:9 with ffmpeg (loses resolution but saves time):
-   ```
-   ffmpeg -i input_16x9.mp4 -vf "crop=ih*9/16:ih" output_9x16.mp4
-   ```
+**Audio lanes** (separate inside prompt):
+
+```
+Dialogue: A woman says, "Welcome to Bali Zero." (no subtitles)
+SFX: Soft keyboard typing, paper rustle as document slides forward.
+Ambient: Tropical air-con hum, distant gamelan music from neighboring shop.
+Music: Subtle uplifting orchestral pad, slow swell, no melody.
+```
+
+**Hard rules for lip-sync** (≥90% success):
+- **1 speaker per clip** — multi-speaker dialog fails ~50% even on Quality
+- **≤5 seconds of spoken audio** per 8s clip — silence pre/post helps registration
+- **Close-up or medium shot**, mouth clearly visible — wide shots desync
+- Booster phrase: `"...clearly enunciates each word..."`
+- For multi-character conversations use **shot/reverse-shot** (separate clips per speaker)
+
+**Known audio bugs**:
+- 20–40ms drift on long clips (cut before/after hard consonants)
+- Voice timbre can sound robotic — generate 3–4 variants, pick best
+- **No native Indonesian-accent voice** — voice references partially work but accent reliability dropped in Veo 3.1 vs Veo 3 (Reddit creator reports)
+- Voice does NOT persist cross-Extend reliably
+
+**Workaround for Indonesian-accented English** (Bali Zero spokespersons):
+
+```
+Voice: warm Indonesian-accented English, gentle lilt, slight emphasis on initial consonants,
+       conversational pace, no exaggeration.
+The woman, Veronika, says, "Indonesian tax compliance is simpler when you have
+   a local partner." She clearly enunciates each word.
+```
+
+**Voice Ingredients** (experimental, Ultra-only — works with Ingredients generations, summoned via `@Voice`). Recommended voice names (creator-empirical):
+- Aoede (F, warm, professional) — Veronika spokesperson default
+- Alnilam (M, broadcast) — news anchor reads
+- Charon (M, documentary) — sober explainer narration
+- Despina (F, smooth, premium) — luxury property B-roll VO
+- Gacrux (F, mature, authority) — Adit (Director-level testimonials)
 
 ---
 
-## Camera Movement Reference
+## 6. Ingredients — character/object/style consistency
 
-| Movement       | Prompt keyword              | Best for                              |
-| -------------- | --------------------------- | ------------------------------------- |
-| Push in slowly | `slow dolly push-in`        | Dramatic reveals, building tension    |
-| Pull back      | `slow dolly pull-back`      | Establishing shots, revealing context |
-| Pan across     | `slow pan left/right`       | Scanning environments                 |
-| Tilt up        | `slow tilt up`              | Revealing from ground to sky          |
-| Orbit          | `slow orbit around subject` | 360 showcase                          |
-| Static         | `locked-off static shot`    | Dialogue, anchor shots                |
-| Handheld       | `subtle handheld movement`  | Documentary feel                      |
-| Crane down     | `crane shot descending`     | Grand entrances                       |
-| Tracking       | `tracking shot following`   | Movement, walking                     |
+**Setup per character**:
+1. Generate 4 portrait references using Nano Banana Pro / Imagen 4 inside Flow:
+   - Front-facing neutral (eye level)
+   - 3/4 angle
+   - Speaking (mouth slightly open, hand gesture mid-action)
+   - Full environment shot (subject in setting)
+2. Plain background (white/light gray) — busy backgrounds confuse the model
+3. Save as Ingredient with **unique made-up name** (community trick: `Zantara-Veronika`, `Zantara-Surya`) — more reliable temporal mapping than "the woman"
 
-**Tip:** Start prompt with camera movement — Veo prioritizes early words.
+**Generation rules**:
+- **Max 3 Ingredients active per generation** (character + outfit + environment is the typical stack)
+- Reference each Ingredient **BY NAME** in the prompt: `Veronika from Ingredient 1, wearing the kebaya from Ingredient 2`
+- Drift accumulates after ~3 chained clips → re-upload fresh portrait every 3rd clip
+- **Verify model selector says Veo 3.1, not Veo 2** before clicking Generate (community-reported silent fallback on heavy days)
 
----
-
-## Style Modifiers That Improve Quality
-
-### Photorealism
-
-```
-photorealistic, cinematic, shallow depth of field, film grain,
-anamorphic lens, 8K detail, natural skin texture
-```
-
-### Lighting
-
-```
-warm amber key light from the left, soft fill from above,
-dramatic side-lighting, golden hour, volumetric light rays,
-practical lighting from candles and screens
-```
-
-### Mood
-
-```
-atmospheric, moody, dramatic shadows, high contrast,
-intimate, epic, serene, urgent
-```
-
-### What to Avoid in Prompts
-
-- "high quality" or "beautiful" — too vague, adds nothing
-- Multiple conflicting styles — pick one mood
-- Overly long prompts (>200 words) — Veo loses focus
-- Negative prompts ("don't show X") — Veo doesn't handle negation well
+**Voice Ingredient**: 1 voice reference allowed, only works with full Ingredients generation, summoned via `@Voice` in prompt.
 
 ---
 
-## Image Generation (for Ingredients)
+## 7. Beyond 8 seconds — 3 methods
 
-Use Nano Banana Pro / Imagen 4 inside Flow:
+| Method | How | Quality | Cost (Fast tier) | Best for |
+|---|---|---|---|---|
+| **Frames-to-Video chaining** | Generate clip → save last frame → use as start frame of next 8s clip | 🟢 Best (each segment fresh full-Veo with audio) | 10 cr/chain (Fast) or 100 cr/chain (Quality) | 30s–2min narrative, dialog scenes |
+| **Flow Extend** | Click "Extend" on existing clip → adds +7s from final frame | 🟡 Decays: 1–3 chains OK, 4–5 subtle drift, 6–10 noticeable, 11–20 visible | 10 cr/extend | Continuous unbroken motion, establishing pans |
+| **Jump-To / Scene Builder** | Place clips in timeline, use cinematic cuts | 🟢 Reliable on Quality, 🟡 unstable on Fast | Per-clip base cost | Multi-shot narratives, shot/reverse-shot |
 
-1. Type prompt in text box (same as video, but generates image)
-2. Best for: character sheets, environment references, style boards
-3. Generated images → immediately usable as Ingredients
-4. **Lasso tool:** click area of generated image → type modification → instant edit
+**Max theoretical with Extend**: 8s base + 20 extends × 7s = **148s single shot** (then export, re-upload last frame, start new chain — loophole for 5min+).
 
-### Character Sheet Prompt Template
+### Pro workflow — Frames-to-Video chain (7 steps)
 
-```
-Portrait of [full character description]. [Pose: front-facing /
-three-quarter / profile / speaking]. [Lighting]. Portrait
-photography, shallow depth of field, neutral background.
-```
+1. Write **scene bible** first: cast names, wardrobe, lighting palette, location, voice tone, action beats. Reuse verbatim in every clip prompt.
+2. Generate clip 1 with full Subject + Context (Quality if hero, Fast otherwise).
+3. In Flow, save last frame as image asset.
+4. Lock 1 Ingredient as face anchor (e.g., `Zantara-Veronika` front portrait) — keeps identity across cuts.
+5. Generate clip 2: prompt = clip 1's full Subject + new Action + re-stated environment/lighting/palette.
+6. **Hand-over-hand prompting**: the last visible state at end of clip N becomes the opening state of clip N+1. Mirror exactly.
+7. Test on Lite first (5 cr) before committing to Quality (100–200 cr).
 
-### Environment Prompt Template
-
-```
-Interior/exterior of [environment description]. No people.
-[Lighting and time of day]. [Materials and textures].
-Architectural photography, centered composition that works
-in both 16:9 and 9:16 crop. [Style].
-```
-
----
-
-## Troubleshooting
-
-| Problem                              | Fix                                                                  |
-| ------------------------------------ | -------------------------------------------------------------------- |
-| Character face changes between clips | Re-upload face ingredient, add skin tone + feature details to prompt |
-| Clothing changes                     | Specify exact garment (color, cut, material) in every prompt         |
-| Voice sounds different on next clip  | Re-select Voice Ingredient — it doesn't persist                      |
-| Video stuck generating >5 min        | Cancel and regenerate — likely stuck                                 |
-| Environment looks different          | Upload environment as Ingredient image, describe in prompt too       |
-| Weird artifacts / glitches           | Regenerate — AI video is stochastic, some generations fail           |
-| Extend has no audio                  | Extend uses Veo 2 — use Frames-to-Video instead                      |
-| 9:16 crops out important elements    | Redesign composition with center-dominant layout                     |
-| Prompt too long, Veo ignores parts   | Split into shorter clips, one concept per prompt                     |
-| Lips don't match dialogue            | Known Veo limitation — lip sync is approximate, not perfect          |
+**Continuity rules**:
+- Copy-paste full Subject description verbatim across clips
+- Re-state environment + lighting + color palette in every prompt
+- Lock face anchor Ingredient
+- Voice references don't persist — re-cast in each prompt
 
 ---
 
-## Quick Reference Card
+## 8. Camera controls — UI buttons vs prompt language
+
+Flow has UI sliders for Pan/Tilt/Zoom; **text prompting yields higher precision** (Reddit creator consensus). Prompt language wins.
+
+### Empirically reliable cinematography (production-ready)
+
+| Move | Prompt syntax | Reliability |
+|---|---|---|
+| Slow dolly push-in | `slow dolly push-in over 6 seconds, locked subject` | 🟢 Hero-grade |
+| Locked-off static | `static locked-off camera, no movement` OR community hack `"from the perspective of a rock that does not move"` | 🟢 Safest for dialog |
+| Orbit | `slow 90-degree arc around subject` (works best with isolated subjects on plain background) | 🟢 |
+| Whip pan | `fast whip pan left to right, motion blur` | 🟡 |
+| Rack focus | `rack focus from foreground to background, shallow depth of field` | 🟡 |
+| Gimbal glide | `smooth gimbal glide forward, low angle` | 🟢 |
+| FPV drone dive | `FPV drone dive, fast descent, dynamic angle` | 🟢 |
+| Dolly zoom (Vertigo) | `dolly zoom on subject, background compresses` | 🟡 |
+
+### Vocabulary table — 4 categories
+
+| Movement | Composition | Lens | Lighting |
+|---|---|---|---|
+| dolly, tracking, crane, gimbal, POV, FPV drone, whip pan, push-in, pull-out, orbit, rack focus | wide / medium / close-up / extreme close-up, low-angle, high-angle, Dutch tilt, over-the-shoulder, locked-off | 35mm, 50mm, 85mm, macro, wide-angle, anamorphic (spell out: oval bokeh, horizontal flare, 2.39:1), shallow depth of field, deep focus | key light, fill light, rim light, golden hour, blue hour, tungsten warm, daylight cool, neon, chiaroscuro, soft diffusion |
+
+---
+
+## 9. Negative prompting + Remove tool
+
+**Phrase positively first** — Veo responds better to "smooth motion" than "no jittery motion". Place negative directives at the **end** of prompt. Escalate to positive reframe if artifact recurs.
+
+**Editorial-safe negative stack** (paste in Negative Prompt field):
 
 ```
-START NEW PROJECT:
-  Flow → New Project → Settings → Veo 3.1 Fast → Ingredients ON
-
-GENERATE CLIP:
-  Write 5-part prompt → Generate → Pick best → Add to Scene
-
-EXTEND (pro method):
-  Last frame → Save as Asset → Frames to Video → Full prompt again
-
-EXPORT:
-  Scene Builder → Play preview → Download (1080p or 4K)
-
-GOLDEN RULE:
-  Every prompt = full character + full environment + camera + action + style
-  Never assume Veo remembers anything from the previous clip.
+no extra fingers, no warped text, no motion smear, no jump cuts, no watermarks,
+no AI artifacts, no morphed limbs, no double faces, consistent anatomy,
+no shaky camera, no subtitles, no on-screen text overlays
 ```
+
+**Remove tool caveat**: Flow's object-remove inpainting uses **Veo 2 internally**, **NOT Veo 3.1**, and produces **NO audio**. Use only for static-shot cleanup, never for hero shots.
+
+---
+
+## 10. Aspect 16:9 + 9:16
+
+**Native support both**, same cost. Generate vertical natively when composition matters — don't crop.
+
+| Format | When | Composition rule |
+|---|---|---|
+| 16:9 (1920×1080) | YouTube, web, broadcast, hero pieces | Subject occupies center 1/3 horizontally; landscape framing |
+| 9:16 (1080×1920) | Instagram Reels, TikTok, Shorts, WhatsApp Status | Subject dead center; vertical hero (full body or close-up); no critical content within 80px of edges |
+
+**Dual-format strategy** (subject dead-center technique):
+1. Frame subject **dead center** horizontally and vertically
+2. Use **vertical hero elements** (standing portraits, doorways, tree trunks)
+3. Keep critical content (text overlays, key gestures) **away from edges**
+4. Symmetrical composition works any crop
+
+**Workflow options**:
+- **Option A (cleaner)**: Generate 16:9 hero, then regenerate 9:16 separately (2× cost, but native composition each format)
+- **Option B (fast)**: ffmpeg center-crop:
+  ```bash
+  ffmpeg -i in.mp4 -vf "scale=-2:1920,crop=1080:1920" -c:a copy out_9x16.mp4
+  ```
+- **Option C (padded)**:
+  ```bash
+  ffmpeg -i in.mp4 -vf "scale=1080:-2,pad=1080:1920:(ow-iw)/2:(oh-ih)/2" -c:a copy out_9x16_pad.mp4
+  ```
+
+---
+
+## 11. Throughput + queue strategy
+
+**Wall-clock generation time** (creator-empirical, off-peak):
+- Veo 3.1 Lite: ~1 min
+- Veo 3.1 Fast: ~1 min 13 s (vs ~2:41 on Veo 3 — measurable speed bump)
+- Veo 3.1 Quality (1×): ~2–3 min
+- Quality (2× forced): ~3–4 min
+- Quality (4×): ~5–6 min
+- 4K upscale: ~3–5 min additional
+
+**Lower-priority queue** (Ultra-only freebie): Lite + Fast at 0 cr but 5–20 min wait, off-peak hours best. Use for overnight bulk B-roll harvest.
+
+**Daily workflow**:
+| Phase | Tier | Multiplier | Purpose |
+|---|---|---|---|
+| Composition drafting | Lite | 1× | Cheap iteration, find framing |
+| Refinement | Fast | 1× | Lock blocking + audio |
+| Hero render | Quality | 2× (forced) | Final shot, pick best variant |
+| Bulk harvest | Lite [Lower Priority] | 1× | Free overnight B-roll |
+| 4K hero only | Quality + upscale | — | +50 cr flat |
+
+---
+
+## 12. Commercial use + SynthID + UU PDP
+
+### Allowed (Ultra commercial license)
+- ✅ Marketing assets for Bali Zero / Nuzantara editorial
+- ✅ Generic visuals (Bali landscapes, generic professional spokespersons, abstract concepts)
+- ✅ Client/staff likenesses **with written consent**
+- ✅ Client portals, ads, B2B decks, social posts
+
+### Forbidden — hard restrictions
+- ❌ Real-person likeness without consent (auto-blocked + account flag)
+- ❌ Indonesian government officials named likeness (UU PDP + KUHP defamation risk)
+- ❌ Copyrighted IP / brand logos (Disney, Apple, etc. — memorization-check refusal)
+- ❌ Named minors
+- ❌ Violence, hate speech, sexually explicit content
+- ❌ Removing SynthID watermark (TOS violation + YouTube/IG de-rank algorithm + EU AI Act + Indonesia UU PDP)
+
+### SynthID — invisible watermark
+- **Every Veo 3.1 frame** carries DeepMind SynthID (forensic, undetectable to humans)
+- **Visible "veo" bottom-right** watermark: present on non-Ultra Flow; **Ultra exempt** in Flow UI
+- API/Vertex outputs: no visible watermark; SynthID invariant
+- Removing SynthID = TOS violation **and**:
+  - Platform algorithm de-rank (YouTube, Instagram, TikTok)
+  - EU AI Act non-compliance for synthetic media disclosure
+  - Indonesia UU PDP / UU ITE exposure on misleading content
+
+### Required Bali Zero disclosure
+1. Disclaimer in caption/credits: **"AI video assets generated via Veo 3.1 (Google Labs Flow)"**
+2. Audit log per asset in `~/Desktop/nuzantara/research/marketing/flow-asset-log.csv` (date, prompt, tier, cost, consent status, publication URL)
+3. For client/staff likeness: signed written consent stored in `~/Desktop/nuzantara/research/marketing/consent/<name>-<date>.pdf`
+
+> **Bali Zero verdict matrix**:
+> | Use case | Status |
+> |---|---|
+> | Generic Bali B-roll, abstract explainers, property exteriors | ✅ ship |
+> | Veronika/Adit/Surya named likeness | ⚠️ written consent required |
+> | Named clients in testimonials | ⚠️ written consent + draft review |
+> | Indonesian government officials named | ❌ never |
+
+---
+
+## 13. 10 prompt templates — ready copy-paste for Bali Zero
+
+### T1 — FAQ Visa Anchor (Veronika kebaya, Quality 8s, C1 explainer)
+```
+Medium close-up, 35mm lens, locked-off static camera. Veronika from Ingredient 1
+(mid-30s Indonesian woman, hair tied back, white silk kebaya, calm professional
+expression). She looks directly into the lens and says, "The C1 visa replaces the
+old B211A. It's valid for sixty days, single-entry, tourism only." She clearly
+enunciates each word. (no subtitles) Bali Zero office Sanur, late afternoon,
+warm tungsten key light from window left, soft tropical shadow on background
+teak wall. Ambient air-con hum, distant scooter passing.
+```
+Tier: Quality 2× (200 cr). Aspect: 9:16. Voice: @Aoede.
+
+### T2 — Regulatory News Flash (timestamp 4-segment SPT extension)
+```
+[00:00-00:02] Wide establishing shot, Indonesian tax office Jakarta exterior,
+   morning, busy with civil servants walking. Indonesian flag fluttering.
+[00:02-00:04] Cut to medium shot, news anchor at desk (generic professional
+   man, dark suit, neutral tie), holding a printed document marked
+   "KEP-71/PJ/2026". He says, "Tax deadline extended."
+[00:04-00:06] Close-up insert on Indonesian calendar, May 31 circled in red ink.
+[00:06-00:08] Pull-out to wide, anchor smiles, "Plan accordingly." Logo lower-third.
+SFX: subtle paper rustle, soft news-room ambient.
+```
+Tier: Quality 2× (200 cr). Aspect: 16:9.
+
+### T3 — Property B-roll (drone pull-back Balinese villa, golden hour)
+```
+Aerial drone pull-back, slow ascent. A traditional Balinese villa with thatched
+alang-alang roof, infinity pool reflecting golden hour sky, rice paddies
+extending to volcanic mountain on horizon. Coconut palms gently swaying.
+Golden hour key light, warm amber tones, long shadows. Ambient: gentle breeze,
+distant gamelan music, water lapping pool edge. No people in frame.
+```
+Tier: Fast 1× (10 cr). Aspect: 16:9. Use Lite [Lower Priority] (0 cr) overnight for bulk.
+
+### T4 — Tax Deadline Countdown (Surya, locked-off, "Eighteen days...")
+```
+Medium shot, 50mm, locked-off static. Surya from Ingredient 1 (early-40s
+Indonesian man, navy batik shirt, glasses, serious expression). Indoor Bali
+Zero office, soft daylight from large window camera-left, teak desk in
+foreground with a calendar visible. He looks directly at camera and says,
+"Eighteen days. After May thirty-first, the SPT extension closes." He clearly
+enunciates each word. (no subtitles) Ambient: air-con, soft typing in background.
+```
+Tier: Quality 2× (200 cr). Aspect: 9:16. Voice: @Charon.
+
+### T5 — Client Testimonial Frame (slow orbit, written consent required)
+```
+Slow 90-degree orbit, smooth gimbal glide, medium shot. [Client name from
+Ingredient 1, with written consent on file] seated on rattan chair, Bali villa
+terrace background, tropical plants soft-focused behind. Warm afternoon
+sunlight, dappled through bamboo blinds. She says, "Bali Zero made my PT PMA
+setup feel effortless." She clearly enunciates each word. (no subtitles)
+Ambient: distant ocean, light wind through palms.
+```
+Tier: Quality 2× (200 cr). **Requires signed consent PDF** before generation.
+
+### T6 — KBLI Explainer (B-roll no dialog, macro lens, hand adjusts page)
+```
+Macro shot, rack focus from foreground to background. A hand (Indonesian skin
+tone) carefully turns the page of a printed KBLI 2020 booklet on a wooden
+desk. The page reveals "63122 — Portal web". A pencil rests beside the booklet.
+Soft natural daylight from above. No dialog. SFX: paper rustle, faint pencil
+roll, ambient quiet office.
+```
+Tier: Fast 1× (10 cr). Aspect: 16:9 or 9:16.
+
+### T7 — Before/After Metaphor (Frames-to-Video chain)
+```
+CLIP 1 (start frame upload): Empty Bali Zero office, dawn, dust motes in light
+beam from window, no furniture, bare floor. Slow dolly push-in over 6 seconds.
+
+CLIP 2 (last frame of Clip 1 → start frame, generate continuation): Same room
+now appointed — teak desk, two chairs, plants, calendar on wall, sunlight now
+midday warm. Camera continues slow push-in. Ambient: soft typing begins.
+
+Continuity: identical room dimensions, identical window position, identical
+floor texture. Lighting evolves from cool dawn to warm midday.
+```
+Tier: 2 × Fast (20 cr) or 1× Quality + 1× Fast for hero. Method: Frames-to-Video.
+
+### T8 — Myth-Bust Hook (Reels 9:16, Veronika, "Nominee is not protection")
+```
+Tight medium close-up, 50mm, locked-off. Veronika from Ingredient 1, neutral
+expression turning to slight concern, white kebaya, plain background. She
+looks directly into lens and says, "Nominee structures are illegal. They are
+not protection." She clearly enunciates each word. (no subtitles) Pause
+0.5 seconds. Soft amber light, single key from camera-left. Ambient: silent
+office, no music. SFX: subtle paper turn at clip end.
+```
+Tier: Quality 2× (200 cr). Aspect: 9:16. Voice: @Aoede.
+
+### T9 — News Brief Intro (anchor + lower-third holographic amber data)
+```
+Wide-to-medium tracking, slow dolly. News anchor (generic mid-30s Indonesian
+woman, navy blazer, neutral expression) seated at modern desk. Behind her,
+a large holographic display showing data charts in warm amber tones — text
+"PERMENKUMHAM 22/2023" partially visible (rendered as overlay, not in-scene
+text). Studio lighting cool daylight from above, warm rim from holographic
+display. She says, "Tonight, the new immigration framework." She clearly
+enunciates each word. (no subtitles) Music: subtle uplifting orchestral pad.
+```
+Tier: Quality 2× (200 cr). Aspect: 16:9. **Add real lower-third graphic in post** (NLE) — do NOT trust Veo to render legible text.
+
+### T10 — Elegant CTA Closer (logo card on stone surface, candle flame)
+```
+Static locked-off, extreme close-up, 85mm. A weathered stone temple surface,
+warm candle flame flickering frame-right out of focus. In frame center, a
+small embossed card with Bali Zero logo (rendered as Ingredient image asset,
+NOT in-scene text). Slow soft breeze causes candle flame to dance, casting
+amber light on stone texture. Audio: distant gamelan, soft wind, no dialog.
+Hold for 4 seconds, then very slow fade.
+```
+Tier: Quality 1× (100 cr if not forced 2×). Aspect: 9:16. **Pair with WhatsApp + email CTA in post-production overlay** per Article 6.6.1 elegant-close pattern.
+
+---
+
+## 14. Quick Reference Card — pseudo-code
+
+### START NEW PROJECT
+```
+1. Open labs.google/flow → "New Project"
+2. Settings → model selector → verify "Veo 3.1" (NOT Veo 2)
+3. Upload Ingredients (max 3 active): character portrait + wardrobe + environment
+4. Aspect ratio: 16:9 OR 9:16 (native, same cost)
+5. Duration: 8s (default — same cost as 4s/6s)
+```
+
+### GENERATE CLIP
+```
+1. Write prompt: [Cinematography] + [Subject verbatim] + [Action] + [Context] + [Style & Ambiance]
+2. Negative prompt: paste editorial-safe stack (§9)
+3. Tier:
+   - Drafting → Lite (5 cr)
+   - Iteration → Fast (10 cr)
+   - Hero → Quality 2× (200 cr forced)
+4. Click Generate → wait 1–4 min
+5. Pick best variant from 1×/2×/4× outputs
+```
+
+### EXTEND TO 30s+ PRO (Frames-to-Video chain)
+```
+1. Generate clip 1 with full Subject + Context
+2. Save last frame as image asset
+3. Use last frame as start frame of clip 2
+4. Re-state Subject + environment + lighting verbatim in clip 2 prompt
+5. Lock 1 Ingredient as face anchor
+6. Repeat for clip 3, 4, ... (max 4 chained reliably before drift)
+7. Assemble in Scene Builder timeline OR export and edit in NLE
+```
+
+### EXPORT
+```
+1. Asset menu → Download
+2. Formats: MP4 (default), GIF (270p only)
+3. Rename: <project>_<shot>_<version>_<tier>.mp4
+4. Log entry: research/marketing/flow-asset-log.csv
+5. Disclosure: caption must include "AI video assets generated via Veo 3.1"
+```
+
+### DECISION TREE — which tier for which task
+
+```
+Brand serial / hero / client-facing  → Quality 2× (200 cr)
+Daily editorial / dialog drafts       → Fast 1× (10 cr)
+B-roll / property / abstract          → Lite 1× (5 cr) OR Lite [LP] (0 cr overnight)
+Multi-variant casting                 → Fast 4× (40 cr) — pick best of 4
+30s+ narrative                        → Frames-to-Video chain of Fast (10 cr × N)
+Continuous unbroken motion (>8s)      → Extend (10 cr × N, decay by chain 4+)
+Final 4K hero                         → Quality 2× + 4K upscale (200 + 50 cr)
+```
+
+### OPEN QUESTIONS — empirical pending (sample sprint TODO)
+
+- [ ] Lite tier audio fidelity — does "may-vary" mean degraded or skipped?
+- [ ] Extend tier cost — is it base tier per extend or discounted?
+- [ ] Remove tool current status — still Veo 2 under hood as of 2026-05?
+- [ ] Indonesian-accent English Quality vs Fast — 10-clip side-by-side study
+- [ ] Voice Ingredient stability across Frames-to-Video chain (does @Voice persist?)
+- [ ] Quality forced-2× — can it be overridden by support request?
+
+> Resolve via **BVCL Sampling Sprint** plan (`docs/superpowers/plans/2026-05-13-bvcl-sampling-sprint.md`). 12 sample clips × 4 archetypes ≈ 600–800 credits.
+
+---
+
+## 15. Editorial pipeline — Bali Zero integration
+
+**Where Flow fits**:
+- WR2 (carousel pipeline) → static IG carousels
+- **Flow + Veo 3.1** → IG Reels, TikTok, YouTube Shorts, WhatsApp video CTAs
+- Companion editorial template: prompt T1–T10 above
+
+**Workflow**:
+1. **Brief** → wr2-brief-interpreter or manual (subject, archetype, voice register)
+2. **Storyboard** → 6-clip episode plan (1 hero + 4 supporting + 1 CTA closer)
+3. **Generate** → Flow, tier-mixed per Balanced strategy (§2)
+4. **Edit** → Premiere / DaVinci / CapCut — color match, captions in post, music swap if needed
+5. **Disclosure** → caption + asset log entry + consent PDF (if applicable)
+6. **Publish** → IG/TikTok/YouTube → metrics in 7 days via wr2-ig-metrics-analyst
+
+**Asset naming convention**:
+```
+<YYYY-MM-DD>_<topic-slug>_<shot-N>_<tier>_<variant>.mp4
+2026-05-13_c1-visa-explainer_hero-01_quality_v3.mp4
+```
+
+**Asset log location**:
+```
+~/Desktop/nuzantara/research/marketing/flow-asset-log.csv
+```
+
+CSV columns: `date, project, shot, tier, cost_credits, aspect, duration_s, prompt_hash, consent_status, publication_url, retry_count, notes`.
+
+---
+
+## 16. References (authority chain)
+
+**Google-official primary sources**:
+- Veo 3.1 release announcement: https://blog.google/technology/ai/veo-updates-flow (2025-10-15)
+- Ultimate prompting guide for Veo 3.1: https://cloud.google.com/blog/products/ai-machine-learning/ultimate-prompting-guide-for-veo-3-1
+- DeepMind Veo prompt guide: https://deepmind.google/models/veo/prompt-guide
+- Flow credits & pricing: https://support.google.com/flow/answer/16526234
+- Flow generation settings (Ingredients, voice, multi-output): https://support.google.com/flow/answer/16353334
+- Audio limits & speech: https://support.google.com/flow/answer/16352836
+- Scene Builder & saving frames: https://support.google.com/flow/answer/16935718
+- Asset export & sharing: https://support.google.com/flow/answer/16935308
+- Keyboard shortcuts: https://support.google.com/flow/answer/17069754
+- Image-model help (Nano Banana Pro / Imagen 4): https://support.google.com/flow/answer/16729550
+- Vertex AI Veo 3.1 generate spec: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/veo/3-1-generate
+
+**Empirical / creator-community (label as anecdotal)**:
+- Curious Refuge review: https://curiousrefuge.com/blog/veo-31-quality-ai-video-generator-review
+- Sider field guide (cinematic control): https://sider.ai/blog/ai-tools/best-prompt-techniques-for-veo-3_1-video-output-a-field-guide-to-cinematic-control
+- Veo3Gen Shot Card workflow: https://www.veo3gen.app/blog/veo-31-in-google-flow-a-beginner-workflow-to-build-a-1530s-scene-from-shot-cards
+- DataCamp complete guide: https://www.datacamp.com/tutorial/veo-3-1-complete-guide-with-examples
+- Reddit r/VEO3 lip-sync thread: https://www.reddit.com/r/VEO3/comments/1rkf538/lip_sync_looks_cartoonish_teeth_way_too_visible/
+- Reddit r/VEO3 "sucks" critique: https://www.reddit.com/r/VEO3/comments/1o8omm8/veo_31_sucks/
+- Reddit r/Bard accent regression: https://www.reddit.com/r/Bard/comments/1o7ftjk/veo_31_is_a_disappoinment/
+
+**Companion deep manual** (audit trail, ≥30 inline citations):
+- `research/marketing/2026-05-13-flow-veo-3.1-mastery-manual.md`
+
+**Backup v1** (archeology, do not edit):
+- `skills/google-flow-video/SKILL.v1-pre-2026-05-13.bak`
+- `.agents/skills/google-flow-video/SKILL.v1-pre-2026-05-13.bak`

--- a/skills/google-flow-video/SKILL.v1-pre-2026-05-13.bak
+++ b/skills/google-flow-video/SKILL.v1-pre-2026-05-13.bak
@@ -1,0 +1,272 @@
+# Skill: Google Flow — Mastering AI Video Creation
+
+## Trigger
+
+User wants to create, iterate, or improve a video in Google Flow.
+
+## Access
+
+- URL: https://labs.google/flow/
+- Account: antonellosiano@gmail.com (Ultra — zero credits on Veo 3.1 Fast)
+
+---
+
+## The Prompt Formula
+
+Every prompt must contain 5 parts in this order:
+
+```
+[CAMERA] + [SUBJECT] + [ACTION] + [CONTEXT] + [STYLE]
+```
+
+| Part    | What to specify                        | Example                                                                                                                                                                               |
+| ------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CAMERA  | Movement + framing                     | `Slow dolly push-in, medium close-up`                                                                                                                                                 |
+| SUBJECT | Full physical description — EVERY TIME | `a young Indonesian woman with long brown hair, warm skin, subtle eyeliner, small hoop earrings, thin silver necklace, wearing modern black kebaya`                                   |
+| ACTION  | What happens + dialogue in quotes      | `speaks directly to camera and says: "Welcome to the Bali Zero Morning News."`                                                                                                        |
+| CONTEXT | Environment, lighting, time of day     | `seated at a circular stone table in an ancient Balinese temple hall, holographic amber data floating above the table, dvarapala guardian statues with glowing eyes along both sides` |
+| STYLE   | Technical look                         | `cinematic, photorealistic, warm amber lighting, shallow depth of field, 16:9`                                                                                                        |
+
+### Golden Rules
+
+- **NEVER abbreviate the subject.** Write the full character description in every single prompt. Veo does not remember previous prompts.
+- **Concrete visuals beat abstract concepts.** "Immigration officers checking passports at Ngurah Rai airport" >> "unified immigration system"
+- **Dialogue goes in quotes inside the prompt.** `She says: "Five deadlines. Zero room for error."`
+- **Camera movement in the first words.** Veo prioritizes the beginning of the prompt.
+
+---
+
+## Model Selection
+
+| Model               | When                                               | Credits (Ultra) | Audio |
+| ------------------- | -------------------------------------------------- | --------------- | ----- |
+| **Veo 3.1 Fast**    | Iterating, testing prompts                         | **Zero**        | Yes   |
+| **Veo 3.1 Full**    | Final render only                                  | 5x              | Yes   |
+| **Nano Banana Pro** | Generating images (character sheets, environments) | Free            | N/A   |
+
+**Strategy:** Do ALL iterations with Fast. Only switch to Full for the final version you'll publish.
+
+---
+
+## Ingredients — Character Consistency
+
+### Setup (do this once per project)
+
+1. Settings gear → enable **Ingredients**
+2. Upload reference images:
+   - **1 front-facing portrait** (most important — anchors identity)
+   - **1 three-quarter view** (helps with angle consistency)
+   - **1 speaking/mid-sentence** (helps with mouth/expression)
+   - **1 environment** (your studio background)
+3. Max 4 ingredients active per generation
+
+### Rules
+
+- A front-facing neutral portrait is the **strongest anchor** for face consistency
+- If the character drifts after 3+ clips → re-upload ingredients and regenerate
+- Ingredients control identity and pose; the **prompt controls everything else** (camera, lighting, action)
+- For consistent clothing: describe it identically in every prompt, don't rely on the image alone
+
+---
+
+## Voice Ingredients (Experimental)
+
+### Setup
+
+1. Settings → enable Voice Ingredients (requires Ultra)
+2. Must have at least **1 Image Ingredient active** (character face)
+3. Open Voice menu → hover to preview → select
+
+### Best Voices by Use Case
+
+| Use                      | Voice                              | Why                               |
+| ------------------------ | ---------------------------------- | --------------------------------- |
+| Young professional woman | **Aoede** (F, breezy, mid)         | Matches warm, approachable anchor |
+| News authority           | **Alnilam** (M, firm, mid-low)     | Classic broadcast tone            |
+| Documentary narrator     | **Charon** (M, informative, lower) | Deep, measured                    |
+| Sophisticated woman      | **Despina** (F, smooth, mid)       | Premium feel                      |
+| Senior authority         | **Gacrux** (F, mature, mid)        | For older character               |
+
+### Critical Limitations
+
+- Voice does **NOT carry over** when you Extend or chain clips → re-select voice for each new clip
+- Indonesian accent: not available natively → add in prompt: `"She speaks English with a soft natural Indonesian accent, melodic rhythm of Bahasa Indonesia"`
+- Audio quality: mono 44.1kHz — acceptable for web, enhance post with ffmpeg for broadcast
+
+---
+
+## Making Videos Longer Than 8 Seconds
+
+### Method 1: Extend (quick but lower quality)
+
+- Click "+" at end of clip → "Extend"
+- Uses **Veo 2 Fast** (no audio, lower quality)
+- Good for: testing sequence, previewing flow
+- Bad for: final production
+
+### Method 2: Frames-to-Video Chaining (best quality)
+
+**This is the pro technique for full Veo 3.1 quality + audio:**
+
+1. Generate first 8-sec clip with Veo 3.1
+2. Hover over **last frame** → click "+" → **Save as Asset**
+3. Start new generation → switch to **"Frames to Video"**
+4. Load saved frame as **Start Frame**
+5. Write NEW prompt — **repeat full character description + environment**
+6. Add continuation: what happens next
+7. Generate with **Veo 3.1** (not Extend)
+8. "Add to Scene" → repeat from step 2
+9. Each chain = +8 seconds at full quality with audio
+
+### Method 3: Scene Builder Jump-To (for cuts between scenes)
+
+- Click "+" → "Jump To"
+- Uses Veo 3.1 full quality
+- Creates a **new camera angle** or scene cut (not seamless continuation)
+- Good for: switching from wide shot to close-up, changing environment
+
+### Avoiding Drift in Long Sequences
+
+- Copy-paste your character description verbatim into every prompt
+- Re-lock ingredients before each generation
+- If skin tone shifts → add specific color: "warm medium-brown skin tone"
+- If clothing changes → specify exact garment in every prompt
+- If lighting shifts → specify exact lighting setup every time
+
+---
+
+## Dual Format Production (16:9 + 9:16)
+
+### Composition Rules for Both Formats
+
+- **Subject at dead center** — in 9:16 crop, sides disappear
+- **Strong vertical elements** — columns, trees, light beams, smoke (become hero in portrait)
+- **No critical content at left/right edges** — will be cropped in vertical
+- **Symmetrical compositions** work in any crop
+
+### Workflow
+
+1. Generate in **16:9** first (landscape — primary format)
+2. For social: regenerate **same prompt** with 9:16 aspect ratio
+3. Or: center-crop the 16:9 with ffmpeg (loses resolution but saves time):
+   ```
+   ffmpeg -i input_16x9.mp4 -vf "crop=ih*9/16:ih" output_9x16.mp4
+   ```
+
+---
+
+## Camera Movement Reference
+
+| Movement       | Prompt keyword              | Best for                              |
+| -------------- | --------------------------- | ------------------------------------- |
+| Push in slowly | `slow dolly push-in`        | Dramatic reveals, building tension    |
+| Pull back      | `slow dolly pull-back`      | Establishing shots, revealing context |
+| Pan across     | `slow pan left/right`       | Scanning environments                 |
+| Tilt up        | `slow tilt up`              | Revealing from ground to sky          |
+| Orbit          | `slow orbit around subject` | 360 showcase                          |
+| Static         | `locked-off static shot`    | Dialogue, anchor shots                |
+| Handheld       | `subtle handheld movement`  | Documentary feel                      |
+| Crane down     | `crane shot descending`     | Grand entrances                       |
+| Tracking       | `tracking shot following`   | Movement, walking                     |
+
+**Tip:** Start prompt with camera movement — Veo prioritizes early words.
+
+---
+
+## Style Modifiers That Improve Quality
+
+### Photorealism
+
+```
+photorealistic, cinematic, shallow depth of field, film grain,
+anamorphic lens, 8K detail, natural skin texture
+```
+
+### Lighting
+
+```
+warm amber key light from the left, soft fill from above,
+dramatic side-lighting, golden hour, volumetric light rays,
+practical lighting from candles and screens
+```
+
+### Mood
+
+```
+atmospheric, moody, dramatic shadows, high contrast,
+intimate, epic, serene, urgent
+```
+
+### What to Avoid in Prompts
+
+- "high quality" or "beautiful" — too vague, adds nothing
+- Multiple conflicting styles — pick one mood
+- Overly long prompts (>200 words) — Veo loses focus
+- Negative prompts ("don't show X") — Veo doesn't handle negation well
+
+---
+
+## Image Generation (for Ingredients)
+
+Use Nano Banana Pro / Imagen 4 inside Flow:
+
+1. Type prompt in text box (same as video, but generates image)
+2. Best for: character sheets, environment references, style boards
+3. Generated images → immediately usable as Ingredients
+4. **Lasso tool:** click area of generated image → type modification → instant edit
+
+### Character Sheet Prompt Template
+
+```
+Portrait of [full character description]. [Pose: front-facing /
+three-quarter / profile / speaking]. [Lighting]. Portrait
+photography, shallow depth of field, neutral background.
+```
+
+### Environment Prompt Template
+
+```
+Interior/exterior of [environment description]. No people.
+[Lighting and time of day]. [Materials and textures].
+Architectural photography, centered composition that works
+in both 16:9 and 9:16 crop. [Style].
+```
+
+---
+
+## Troubleshooting
+
+| Problem                              | Fix                                                                  |
+| ------------------------------------ | -------------------------------------------------------------------- |
+| Character face changes between clips | Re-upload face ingredient, add skin tone + feature details to prompt |
+| Clothing changes                     | Specify exact garment (color, cut, material) in every prompt         |
+| Voice sounds different on next clip  | Re-select Voice Ingredient — it doesn't persist                      |
+| Video stuck generating >5 min        | Cancel and regenerate — likely stuck                                 |
+| Environment looks different          | Upload environment as Ingredient image, describe in prompt too       |
+| Weird artifacts / glitches           | Regenerate — AI video is stochastic, some generations fail           |
+| Extend has no audio                  | Extend uses Veo 2 — use Frames-to-Video instead                      |
+| 9:16 crops out important elements    | Redesign composition with center-dominant layout                     |
+| Prompt too long, Veo ignores parts   | Split into shorter clips, one concept per prompt                     |
+| Lips don't match dialogue            | Known Veo limitation — lip sync is approximate, not perfect          |
+
+---
+
+## Quick Reference Card
+
+```
+START NEW PROJECT:
+  Flow → New Project → Settings → Veo 3.1 Fast → Ingredients ON
+
+GENERATE CLIP:
+  Write 5-part prompt → Generate → Pick best → Add to Scene
+
+EXTEND (pro method):
+  Last frame → Save as Asset → Frames to Video → Full prompt again
+
+EXPORT:
+  Scene Builder → Play preview → Download (1080p or 4K)
+
+GOLDEN RULE:
+  Every prompt = full character + full environment + camera + action + style
+  Never assume Veo remembers anything from the previous clip.
+```


### PR DESCRIPTION
## Summary

- Replace `skills/google-flow-video/SKILL.md` v1 (April 2026, 273 lines) with v2 — corrects critical false claim "Veo 3.1 Fast = Zero credits"
- Mirror v2 in `.agents/skills/google-flow-video/SKILL.md`
- Preserve v1 at `SKILL.v1-pre-2026-05-13.bak` in both locations
- Add companion deep manual `research/marketing/2026-05-13-flow-veo-3.1-mastery-manual.md` (33 sources, inline citations)

## Context

User has Google AI Ultra ($249.99/mo, 25,000 credits/month) on `antonellosiano@gmail.com`. Wants intensive mastery of Flow + Veo 3.1 for editorial production at scale. V1 skill was outdated; v2 corrects pricing model and adds 13 operational improvements not in v1.

## Real Veo 3.1 Pricing (Flow UI, verified 2026-05-13 from dashboard screenshots)

| Tier | Credits / 8s clip |
|---|---|
| Veo 3.1 Lite | 5 |
| Veo 3.1 Fast | 10 |
| Veo 3.1 Quality | 100 |
| Lite [Lower Priority] | 0 (Ultra freebie) |
| Fast [Lower Priority] | 0 (Ultra freebie) |

## Test plan

- [ ] Antonello to verify skill v2 reads correctly in claude-code skill discovery
- [ ] Run BVCL Sampling Sprint (`docs/superpowers/plans/2026-05-13-bvcl-sampling-sprint.md`) — 12 sample clips × 4 archetypes to empirically validate skill claims
- [ ] Sample first production clip (any tier) to verify the prompt formula yields publishable output

🤖 Generated with [Claude Code](https://claude.com/claude-code)