### PR TITLE
feat(bridge): GET /api/bridge/skills endpoint for Pro<->Fly stream sync (TICKET G.1)

### DIFF
--- a/.claude/rules/cicatrix-scars.md
+++ b/.claude/rules/cicatrix-scars.md
@@ -5,7 +5,52 @@ Each entry has TRAUMA (what went wrong), ANTIBODY (how it's now protected), and 
 
 ---
 
-### ⚠️ STRUCTURAL: WR2 master template requires verified richtext slot count (2026-05-10)
+### ⚠️ STRUCTURAL: WR2 master template requires verified richtext slot count (2026-05-10 → architecturally bypassed 2026-05-13)
+
+_Discovered: 2026-05-10 02:53 WITA during run #1 of the post-DAHE6lx1lf8 recovery cycle · Patched 2026-05-10 via `chore/wr2-pipeline-hardening-2026-05-10` (validator + unit test + docstring guard) · **Architecturally bypassed 2026-05-13 via `feat/wr2-canva-pdf-render-2026-05-13`** (ReportLab→Tigris→Canva import flow, no master template required) · Severity: P0 (now defanged)_
+
+**RESOLUTION (2026-05-13 — DAHJEkWpkzY validation gap FINALLY closed):**
+
+The structural validation gap (master template richtext slot count) is now moot
+because the new rendering pipeline does not depend on a Canva master template
+at all. The PDF is generated server-side via ReportLab (`wr2_canva_pdf_render.py`,
+12 layout families auto-routed via `slide.layout_family`), uploaded to Tigris
+S3, then imported into Canva via `import-design-from-url` MCP which yields a
+layer-editable design without needing pre-existing richtext slots.
+
+Status of the three failing master template IDs:
+
+| Design ID | Status | Reason |
+|---|---|---|
+| `DAHE6lx1lf8` | DECOMMISSIONED 2026-05-08 | Original master, obsolete |
+| `DAHJLYRn_3E` | KEPT AS FAILURE EXAMPLE | Only 2 usable pages (PR #565 failed promotion) |
+| `DAHJEkWpkzY` | UNUSED IN NEW FLOW | Was the 2026-05-10 "fix" master; the new flow doesn't read any master |
+
+The validator `scripts/wr2_validate_master.py` is preserved in repo for
+documentation and as a tool if anyone needs to evaluate a Canva design's
+shape (e.g. for new editorial surfaces). The unit-test contract
+`test_template_design_id_format` in
+`apps/backend-rag/backend/tests/unit/services/canva_renderer/test_pending_builder.py`
+is preserved for the legacy `wr2_canva_apply.py` orchestrator (now disabled
+via kill switch — see below).
+
+**Production cron disabled 2026-05-13**: `com.balizero.wr2.canva-renderer.plist`
+called the legacy orchestrator (`wr2_canva_apply.py`) which relied on the
+broken master template flow. Disabled via:
+1. Kill switch flipped to `false`: `system_settings.wr2_canva_renderer_enabled='false'`
+2. Plist bootout: `launchctl bootout gui/$(id -u)/com.balizero.wr2.canva-renderer`
+
+Plist file `~/Library/LaunchAgents/com.balizero.wr2.canva-renderer.plist`
+preserved on disk for future reload AFTER the orchestrator refactor
+integrates the new renderer. Until then: queue stays empty (verified
+0 drafts pending at decommission time, status distribution 20 rendered
++ 15 rejected). When the orchestrator refactor lands, the plist will be
+updated to call the new pipeline (ReportLab → Tigris → Canva MCP import)
+and the kill switch flipped back on.
+
+Branch: `feat/wr2-canva-pdf-render-2026-05-13`. Commits:
+- `fafa25267` — feat(wr2): rebuild wr2_canva_pdf_render.py production renderer
+- `e697328d5` — fix(wr2): 3 visual fixes (body vcenter + punctuation glue + Quartz stat-card)
 
 _Discovered: 2026-05-10 02:53 WITA during run #1 of the post-DAHE6lx1lf8 recovery cycle · Patched 2026-05-10 via `chore/wr2-pipeline-hardening-2026-05-10` (validator + unit test + docstring guard) · Severity: P0_
 

--- a/apps/backend-rag/backend/db/migrations_v2/169_wr2_draft_lease.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/169_wr2_draft_lease.sql
@@ -1,0 +1,18 @@
+-- 169_wr2_draft_lease.sql
+-- Adds per-draft CAS lease to war_room_drafts.
+-- Two columns: lease_owner (PID@host string) + lease_acquired_at (timestamptz).
+-- Used by canva_renderer_v2 orchestrator to prevent double-processing.
+
+ALTER TABLE war_room_drafts
+  ADD COLUMN IF NOT EXISTS lease_owner text,           -- squawk-ignore: prefer-text-field
+  ADD COLUMN IF NOT EXISTS lease_acquired_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_war_room_drafts_lease_recovery
+  ON war_room_drafts (lease_acquired_at)
+  WHERE status = 'rendering' AND lease_acquired_at IS NOT NULL;
+
+-- === ROLLBACK ===
+DROP INDEX IF EXISTS idx_war_room_drafts_lease_recovery;
+ALTER TABLE war_room_drafts
+  DROP COLUMN IF EXISTS lease_acquired_at,
+  DROP COLUMN IF EXISTS lease_owner;

--- a/apps/backend-rag/backend/services/canva_renderer_v2/__init__.py
+++ b/apps/backend-rag/backend/services/canva_renderer_v2/__init__.py
@@ -1,0 +1,7 @@
+"""WR2 orchestrator v2 — PDF render pipeline.
+
+Replaces legacy backend.services.canva_renderer (which depended on
+claude -p subprocess with 50% MCP cold-fail rate).
+
+See docs/superpowers/specs/2026-05-13-wr2-orchestrator-pdf-render-design.md
+"""

--- a/apps/backend-rag/backend/services/canva_renderer_v2/_pdf_pipeline.py
+++ b/apps/backend-rag/backend/services/canva_renderer_v2/_pdf_pipeline.py
@@ -1,0 +1,66 @@
+"""Subprocess wrapper for scripts/wr2_canva_pdf_render.py.
+
+Writes slides_json to a temp path, invokes the renderer Python script
+via subprocess with 120s timeout, returns the output PDF path or raises
+PdfRenderError. The renderer itself is a separate process so a hung
+ReportLab call doesn't take down the orchestrator.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parents[4]  # backend-rag/backend/services/canva_renderer_v2/ → repo root
+RENDER_SCRIPT = REPO_ROOT / "scripts" / "wr2_canva_pdf_render.py"
+
+DEFAULT_TIMEOUT_S = 120
+
+
+class PdfRenderError(RuntimeError):
+    """Raised when the renderer subprocess fails."""
+
+
+def render_pdf(
+    slides_json: dict[str, Any],
+    *,
+    draft_id: str,
+    out_path: Path,
+    timeout_s: int = DEFAULT_TIMEOUT_S,
+) -> Path:
+    """Render slides_json → PDF at out_path. Raise PdfRenderError on failure."""
+    slides_tmp = Path(tempfile.mkstemp(prefix=f"slides_{draft_id}_", suffix=".json")[1])
+    slides_tmp.write_text(json.dumps(slides_json))
+
+    cmd = [
+        sys.executable,
+        str(RENDER_SCRIPT),
+        "--slides-json", str(slides_tmp),
+        "--out", str(out_path),
+    ]
+    logger.info("Render draft %s → %s", draft_id, out_path)
+
+    try:
+        result = subprocess.run(  # noqa: S603 — known python interpreter
+            cmd, capture_output=True, text=True, timeout=timeout_s, check=False,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise PdfRenderError(f"timeout {timeout_s}s for draft {draft_id}") from e
+    finally:
+        slides_tmp.unlink(missing_ok=True)
+
+    if result.returncode != 0:
+        raise PdfRenderError(
+            f"subprocess exit≠0 for draft {draft_id}: {result.stderr[:500]}"
+        )
+    if not out_path.exists() or out_path.stat().st_size == 0:
+        raise PdfRenderError(
+            f"renderer produced zero-size output for draft {draft_id}"
+        )
+    return out_path

--- a/apps/backend-rag/backend/services/canva_renderer_v2/_schema_adapter.py
+++ b/apps/backend-rag/backend/services/canva_renderer_v2/_schema_adapter.py
@@ -1,0 +1,137 @@
+"""Legacy slides_json schema → v2 (Article 14 layout_family) adapter.
+
+Detection: presence of `slide_type` field on first slide AND absence of
+`layout_family` → legacy. Otherwise v2 passes through unchanged.
+
+Used for drafts created before 2026-05-13 by storyboarder versions that
+emitted slide_type strings. Storyboarder patched 2026-05-13 emits v2
+schema directly; orchestrator handles both via this adapter inline.
+
+Source material: /tmp/wr2_legacy_adapter.py (working draft 2026-05-13).
+"""
+from __future__ import annotations
+
+import logging
+import re
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+LEGACY_TO_LAYOUT = {
+    "cover": "cover-photo",
+    "take": "photo-headline-yellow-sub",
+    "context": "photo-headline-yellow-sub",
+    "shift": "evidence-carved",
+    "mechanism": "swiss-grid-asymmetry",
+    "stake": "photo-headline-yellow-sub",
+    "law": "thin-red-rule-divider",
+    "fiction-vs-substance": "dark-status-list",
+    "numbers": "stat-card-hero",
+    "signal": "photo-headline-yellow-sub",
+    "cta": "elegant-close",
+    "closing": "statement-bomb",
+    "statement": "statement-bomb",
+    "insight": "photo-headline-yellow-sub",
+}
+
+HERO_CACHE_DIR = Path("/tmp/wr2_hero_cache")
+
+
+def is_legacy_schema(data: dict[str, Any]) -> bool:
+    """Detect legacy schema by presence of `slide_type` on any slide."""
+    slides = data.get("slides", [])
+    if not slides:
+        return False
+    first = slides[0]
+    return "slide_type" in first and "layout_family" not in first
+
+
+def _download_hero(url: str, slide_n: int) -> str | None:
+    if not url:
+        return None
+    HERO_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    dest = HERO_CACHE_DIR / f"hero_{slide_n:02d}.jpg"
+    if dest.exists():
+        return str(dest)
+    try:
+        urllib.request.urlretrieve(url, dest)  # noqa: S310
+        return str(dest)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("hero %d download failed: %s", slide_n, e)
+        return None
+
+
+def _map_swiss_grid_steps(body: str) -> list[dict]:
+    sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", body) if s.strip()]
+    steps: list[dict] = []
+    for k, sent in enumerate(sentences[:3]):
+        words = sent.split()
+        head = " ".join(words[:4]).rstrip(",.;:")
+        rest = " ".join(words[4:]).strip()
+        steps.append({"num": f"{k + 1:02d}", "head": head, "body": rest[:90]})
+    return steps
+
+
+def adapt_legacy_schema(legacy: dict[str, Any], *, topic: str) -> dict[str, Any]:
+    """Convert legacy slides_json → v2 Article 14 layout schema."""
+    slides_in = legacy.get("slides", [])
+    n = len(slides_in)
+    adapted: list[dict] = []
+
+    for i, ls in enumerate(slides_in):
+        slide_type = ls.get("slide_type", "")
+        layout = LEGACY_TO_LAYOUT.get(slide_type, "photo-headline-yellow-sub")
+        if i == n - 1 and slide_type == "cta":
+            layout = "statement-bomb"
+
+        hero_path = None
+        if ls.get("is_hero_image") and ls.get("image_url"):
+            hero_path = _download_hero(ls["image_url"], ls.get("slide_number", i + 1))
+
+        new: dict[str, Any] = {
+            "index": ls.get("slide_number", i + 1),
+            "layout_family": layout,
+            "heading": ls.get("headline") or "",
+            "subheading": ls.get("subhead") or "",
+            "body": ls.get("body") or "",
+        }
+        if hero_path:
+            new["hero_image_path"] = hero_path
+
+        if layout == "statement-bomb":
+            new["statement"] = ls.get("headline") or (ls.get("body", "") or "")[:120]
+        elif layout == "stat-card-hero":
+            text = (ls.get("body") or "") + " " + (ls.get("headline") or "")
+            m = re.search(r"\b(\d+(?:,\d{3})*(?:\.\d+)?[KMB%]?)\b", text)
+            new["stat"] = m.group(1) if m else "—"
+            new["caption"] = (ls.get("body") or "")[:120]
+            new["source"] = ls.get("subhead") or ""
+        elif layout == "thin-red-rule-divider":
+            new["body"] = ls.get("body") or ls.get("headline") or ""
+            new["source"] = ls.get("subhead") or ""
+        elif layout == "swiss-grid-asymmetry":
+            new["yellow_accent"] = ls.get("subhead") or "MECHANISM"
+            new["steps"] = _map_swiss_grid_steps(ls.get("body") or "")
+        elif layout == "dark-status-list":
+            new["list_items"] = [
+                {"label": "FICTION", "value": "MYTH", "status": "critical"},
+                {"label": "SUBSTANCE", "value": "FACT", "status": "positive"},
+            ]
+        elif layout == "elegant-close":
+            new["heading"] = "Want to act on this?"
+            new["body"] = ls.get("body") or ""
+            new["email"] = "zantara@balizero.com"
+            new["whatsapp"] = "wa.me/6285954680980"
+        elif layout == "evidence-carved":
+            new["evidence_code"] = ls.get("subhead") or ""
+
+        adapted.append(new)
+
+    out = {
+        "carousel_id": legacy.get("carousel_id", topic.lower().replace(" ", "-")[:80]),
+        "slide_count": len(adapted),
+        "slides": adapted,
+    }
+    return out

--- a/apps/backend-rag/backend/services/canva_renderer_v2/_telegram.py
+++ b/apps/backend-rag/backend/services/canva_renderer_v2/_telegram.py
@@ -1,0 +1,31 @@
+"""Best-effort Telegram notify. Failures are swallowed (no raise).
+
+Reads TELEGRAM_BOT_TOKEN + TELEGRAM_OWNER_CHAT_ID env vars.
+If TELEGRAM_BOT_TOKEN absent, silently no-op.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import urllib.parse
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+
+def send_telegram(text: str) -> None:
+    token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+    chat_id = os.environ.get("TELEGRAM_OWNER_CHAT_ID", "1125336968")
+    if not token:
+        return
+    try:
+        data = urllib.parse.urlencode(
+            {"chat_id": chat_id, "text": text, "parse_mode": "Markdown"},
+        ).encode()
+        urllib.request.urlopen(  # noqa: S310 — known URL
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            data,
+            timeout=10,
+        )
+    except Exception as e:  # noqa: BLE001 — best-effort
+        logger.warning("Telegram send failed (swallowed): %s", e)

--- a/apps/backend-rag/backend/services/canva_renderer_v2/_tigris.py
+++ b/apps/backend-rag/backend/services/canva_renderer_v2/_tigris.py
@@ -1,0 +1,89 @@
+"""Tigris S3 client wrapper. boto3 put_object with 3-retry + delete + URL build.
+
+Bucket: nuzantara-warroom-images (public-read prefix wr2-pdf/).
+Endpoint: https://fly.storage.tigris.dev
+Credentials: AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY env (Tigris-compat).
+"""
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+logger = logging.getLogger(__name__)
+
+BUCKET = "nuzantara-warroom-images"
+ENDPOINT = "https://fly.storage.tigris.dev"
+PUBLIC_HOST = f"{BUCKET}.fly.storage.tigris.dev"
+
+MAX_RETRIES = 3
+BACKOFF_BASE_S = 2.0  # 2s, 4s, 8s
+
+TRANSIENT_ERROR_CODES = {"503", "502", "504", "RequestTimeout", "SlowDown", "Throttling"}
+
+
+class TigrisError(RuntimeError):
+    """Tigris S3 operation failed after retries."""
+
+
+def get_s3_client():
+    return boto3.client(
+        "s3",
+        endpoint_url=ENDPOINT,
+        region_name="auto",
+    )
+
+
+def _is_transient(exc: Exception) -> bool:
+    if isinstance(exc, ClientError):
+        code = exc.response.get("Error", {}).get("Code", "")
+        return code in TRANSIENT_ERROR_CODES
+    return isinstance(exc, BotoCoreError)
+
+
+def upload_pdf(s3, pdf_path: Path, *, draft_id: str, prefix: str = "wr2-pdf") -> str:
+    """Upload PDF to s3://BUCKET/{prefix}/{draft_id}.pdf, return public URL."""
+    key = f"{prefix}/{draft_id}.pdf"
+    body = pdf_path.read_bytes()
+
+    last_exc: Exception | None = None
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            s3.put_object(
+                Bucket=BUCKET,
+                Key=key,
+                Body=body,
+                ContentType="application/pdf",
+                ACL="public-read",
+            )
+            logger.info("Tigris upload OK: %s (attempt %d)", key, attempt)
+            return build_public_url(draft_id, prefix=prefix)
+        except (ClientError, BotoCoreError) as e:
+            last_exc = e
+            if not _is_transient(e):
+                raise TigrisError(f"Tigris non-transient error: {e}") from e
+            if attempt < MAX_RETRIES:
+                delay = BACKOFF_BASE_S * (2 ** (attempt - 1))
+                logger.warning(
+                    "Tigris transient error attempt %d/%d: %s — sleep %.1fs",
+                    attempt, MAX_RETRIES, e, delay,
+                )
+                time.sleep(delay)
+    raise TigrisError(f"Tigris exhausted retries for {key}: {last_exc}") from last_exc
+
+
+def delete_pdf(s3, *, draft_id: str, prefix: str = "wr2-pdf") -> None:
+    """Best-effort delete. Never raises (S3 lifecycle is the safety net)."""
+    key = f"{prefix}/{draft_id}.pdf"
+    try:
+        s3.delete_object(Bucket=BUCKET, Key=key)
+        logger.info("Tigris delete OK: %s", key)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Tigris delete failed (swallowed): %s — %s", key, e)
+
+
+def build_public_url(draft_id: str, *, prefix: str = "wr2-pdf") -> str:
+    return f"https://{PUBLIC_HOST}/{prefix}/{draft_id}.pdf"

--- a/apps/backend-rag/backend/services/canva_renderer_v2/_token_storage.py
+++ b/apps/backend-rag/backend/services/canva_renderer_v2/_token_storage.py
@@ -1,0 +1,194 @@
+"""Orchestrator-owned OAuth token storage.
+
+Independent from mcp-remote npm cache (see spec §3 + memory
+fact_canva_mcp_dynamic_client_registration). Path:
+~/.config/wr2/canva_tokens.json (mode 0600).
+
+Features:
+- HMAC-SHA256 integrity check on every read (key from WR2_CANVA_HMAC_KEY hex).
+- fcntl.flock advisory exclusive lock around read+write.
+- Proactive refresh: needs_refresh() True when <300s + jitter to expiry.
+- Atomic write via temp+rename.
+- Preserves refresh_token if Canva omits it in refresh response.
+- NO mtime-compare-before-replace (anti-pattern per panel).
+
+Public API matches mcp.client.auth.TokenStorage (async). Sync helpers
+exposed for bootstrap script + tests.
+"""
+from __future__ import annotations
+
+import asyncio
+import fcntl
+import hashlib
+import hmac
+import json
+import logging
+import os
+import random
+import time
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+REFRESH_MARGIN_S = 300
+JITTER_MAX_S = 15
+
+
+class TokenStorageError(RuntimeError):
+    pass
+
+
+def _canonical(payload: dict[str, Any]) -> str:
+    without = {k: v for k, v in payload.items() if k != "_hmac"}
+    return json.dumps(without, sort_keys=True, separators=(",", ":"))
+
+
+def sign_payload(payload: dict[str, Any], *, key: bytes) -> dict[str, Any]:
+    sig = hmac.new(key, _canonical(payload).encode(), hashlib.sha256).hexdigest()
+    return {**{k: v for k, v in payload.items() if k != "_hmac"}, "_hmac": sig}
+
+
+def verify_payload(payload: dict[str, Any], *, key: bytes) -> dict[str, Any]:
+    stored = payload.get("_hmac")
+    if not stored:
+        raise TokenStorageError("Token file missing HMAC field")
+    computed = hmac.new(key, _canonical(payload).encode(), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(stored, computed):
+        raise TokenStorageError("Token HMAC mismatch — corrupt or tampered")
+    return {k: v for k, v in payload.items() if k != "_hmac"}
+
+
+class OrchestratorTokenStorage:
+    """Sync-first storage; async wrappers below for mcp SDK contract."""
+
+    def __init__(self) -> None:
+        path_env = os.environ.get("WR2_CANVA_TOKEN_FILE")
+        if not path_env:
+            raise TokenStorageError(
+                "WR2_CANVA_TOKEN_FILE env var required (e.g. ~/.config/wr2/canva_tokens.json)"
+            )
+        self.path = Path(path_env).expanduser()
+        self.lock_path = self.path.with_suffix(self.path.suffix + ".lock")
+
+        hex_key = os.environ.get("WR2_CANVA_HMAC_KEY")
+        if not hex_key:
+            raise TokenStorageError("WR2_CANVA_HMAC_KEY env var required (32-byte hex)")
+        try:
+            self.hmac_key = bytes.fromhex(hex_key)
+        except ValueError as e:
+            raise TokenStorageError(f"WR2_CANVA_HMAC_KEY not valid hex: {e}") from e
+
+    @contextmanager
+    def _lock(self):
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.lock_path, "w") as fp:
+            fcntl.flock(fp.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(fp.fileno(), fcntl.LOCK_UN)
+
+    def load_sync(self) -> dict[str, Any]:
+        if not self.path.exists():
+            raise TokenStorageError(
+                f"Token file not found: {self.path}. Run scripts/wr2_bootstrap_canva_oauth.py"
+            )
+        with self._lock():
+            payload = json.loads(self.path.read_text())
+            return verify_payload(payload, key=self.hmac_key)
+
+    def needs_refresh(self) -> bool:
+        try:
+            tokens = self.load_sync()
+        except TokenStorageError:
+            return True  # treat unloadable as expired
+        remaining = float(tokens.get("expires_at_epoch", 0)) - time.time()
+        threshold = REFRESH_MARGIN_S + random.uniform(0, JITTER_MAX_S)
+        return remaining < threshold
+
+    def save_sync(self, new_tokens: dict[str, Any]) -> None:
+        """Merge new_tokens into existing, sign, atomic write."""
+        with self._lock():
+            existing = {}
+            if self.path.exists():
+                try:
+                    existing = verify_payload(
+                        json.loads(self.path.read_text()), key=self.hmac_key
+                    )
+                except TokenStorageError:
+                    logger.warning(
+                        "Existing token file unverifiable; backup + replace"
+                    )
+                    backup = self.path.with_suffix(
+                        f".broken-{datetime.now().strftime('%Y%m%d-%H%M%S')}.json"
+                    )
+                    self.path.rename(backup)
+
+            merged = {**existing, **new_tokens}
+            # Preserve refresh_token if Canva omitted it on refresh
+            if not new_tokens.get("refresh_token") and existing.get("refresh_token"):
+                merged["refresh_token"] = existing["refresh_token"]
+            merged["last_refreshed_iso"] = datetime.now(timezone.utc).isoformat()
+            expires_in = new_tokens.get("expires_in", 3600)
+            merged["expires_at_epoch"] = time.time() + float(expires_in)
+
+            signed = sign_payload(merged, key=self.hmac_key)
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+            tmp.write_text(json.dumps(signed, indent=2))
+            tmp.chmod(0o600)
+            tmp.replace(self.path)
+
+    # Async wrappers for mcp SDK TokenStorage contract
+    async def get_tokens(self):
+        return await asyncio.to_thread(self._load_for_sdk)
+
+    async def set_tokens(self, tokens) -> None:
+        await asyncio.to_thread(self._save_from_sdk, tokens)
+
+    async def get_client_info(self):
+        return await asyncio.to_thread(self._load_client_info)
+
+    async def set_client_info(self, info) -> None:
+        # client_info is owned by the orchestrator and written during bootstrap
+        # only. Runtime no-op. (Subsequent OAuth flows in this orchestrator
+        # always reuse the bootstrap-time client_id.)
+        return
+
+    def _load_for_sdk(self):
+        from mcp.shared.auth import OAuthToken
+        if self.needs_refresh():
+            return None  # mcp SDK will trigger refresh
+        data = self.load_sync()
+        return OAuthToken(
+            access_token=data["access_token"],
+            token_type=data.get("token_type", "bearer"),
+            expires_in=int(max(0, data["expires_at_epoch"] - time.time())),
+            refresh_token=data.get("refresh_token"),
+            scope=data.get("scope"),
+        )
+
+    def _save_from_sdk(self, tokens):
+        self.save_sync({
+            "access_token": tokens.access_token,
+            "token_type": tokens.token_type,
+            "expires_in": tokens.expires_in,
+            "refresh_token": tokens.refresh_token,
+            "scope": tokens.scope,
+        })
+
+    def _load_client_info(self):
+        from mcp.shared.auth import OAuthClientInformationFull
+        data = self.load_sync()
+        return OAuthClientInformationFull(
+            client_id=data["client_id"],
+            client_secret=data.get("client_secret") or None,
+            redirect_uris=data.get("redirect_uris", []),
+            grant_types=data.get("grant_types", ["authorization_code", "refresh_token"]),
+            response_types=data.get("response_types", ["code"]),
+            token_endpoint_auth_method=data.get("token_endpoint_auth_method", "none"),
+            scope=data.get("scope"),
+        )

--- a/apps/backend-rag/backend/tests/fixtures/canva_renderer_v2/draft_legacy_parq.json
+++ b/apps/backend-rag/backend/tests/fixtures/canva_renderer_v2/draft_legacy_parq.json
@@ -1,0 +1,11 @@
+{
+  "slides": [
+    {"slide_number": 1, "slide_type": "cover", "headline": "Parq Ambassador",
+     "subhead": "Immigration designates Parq", "body": "...", "is_hero_image": true,
+     "image_url": "https://example.com/parq-hero.jpg"},
+    {"slide_number": 2, "slide_type": "take", "headline": "What happened",
+     "subhead": "16 October 2026", "body": "Indonesia immigration appointed Parq..."},
+    {"slide_number": 3, "slide_type": "law", "headline": "The provision",
+     "subhead": "Permenkumham 22/2023", "body": "Article 14 ayat 2..."}
+  ]
+}

--- a/apps/backend-rag/backend/tests/fixtures/canva_renderer_v2/draft_v2_deep.json
+++ b/apps/backend-rag/backend/tests/fixtures/canva_renderer_v2/draft_v2_deep.json
@@ -1,0 +1,18 @@
+{
+  "carousel_id": "deep-test",
+  "slide_count": 4,
+  "slides": [
+    {"index": 1, "layout_family": "stat-card-hero", "stat": "31 MAY",
+     "caption": "PPh Badan", "source": "KEP-71/PJ/2026"},
+    {"index": 2, "layout_family": "thin-red-rule-divider",
+     "body": "Late filing penalty: Rp 1jt", "source": "UU KUP"},
+    {"index": 3, "layout_family": "swiss-grid-asymmetry",
+     "yellow_accent": "MECHANISM",
+     "steps": [
+       {"num": "01", "head": "Check NPWP", "body": "Verify status"},
+       {"num": "02", "head": "Submit SPT", "body": "Before deadline"}
+     ]},
+    {"index": 4, "layout_family": "statement-bomb",
+     "statement": "Pay on time or pay double"}
+  ]
+}

--- a/apps/backend-rag/backend/tests/fixtures/canva_renderer_v2/draft_v2_kep71.json
+++ b/apps/backend-rag/backend/tests/fixtures/canva_renderer_v2/draft_v2_kep71.json
@@ -1,0 +1,11 @@
+{
+  "carousel_id": "kep71-pj-2026",
+  "slide_count": 6,
+  "primary_regulation_code": "KEP-71/PJ/2026",
+  "slides": [
+    {"index": 1, "layout_family": "cover-photo", "heading": "SPT Deadline",
+     "subheading": "Extended", "body": "From 30/04 to 31/05/2026"},
+    {"index": 2, "layout_family": "evidence-carved", "heading": "KEP-71",
+     "evidence_code": "KEP-71/PJ/2026", "body": "Issued by Bimo Wijayanto"}
+  ]
+}

--- a/apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/__init__.py
+++ b/apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for canva_renderer_v2."""

--- a/apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/conftest.py
+++ b/apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/conftest.py
@@ -1,0 +1,4 @@
+"""Shared fixtures for canva_renderer_v2 tests."""
+from pathlib import Path
+
+FIXTURES_DIR = Path(__file__).parent.parent.parent.parent / "fixtures" / "canva_renderer_v2"

--- a/apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_pdf_pipeline.py
+++ b/apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_pdf_pipeline.py
@@ -1,0 +1,55 @@
+"""PDF pipeline: invoke wr2_canva_pdf_render.py via subprocess, return path or None."""
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from backend.services.canva_renderer_v2._pdf_pipeline import render_pdf, PdfRenderError
+
+
+def test_render_pdf_success(tmp_path):
+    slides = {"carousel_id": "test", "slide_count": 1, "slides": [
+        {"index": 1, "layout_family": "cover-photo", "heading": "x", "body": "y"}
+    ]}
+    pdf_dest = tmp_path / "wr2_test.pdf"
+
+    def fake_run(args, **kwargs):
+        # Write a valid-looking PDF (first 4 bytes %PDF)
+        pdf_dest.write_bytes(b"%PDF-1.4\n... fake pdf body\n%%EOF")
+        return MagicMock(returncode=0, stderr="")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        result = render_pdf(slides, draft_id="test", out_path=pdf_dest)
+        assert result == pdf_dest
+        assert pdf_dest.exists() and pdf_dest.stat().st_size > 4
+
+
+def test_render_pdf_subprocess_exit_nonzero(tmp_path):
+    slides = {"slides": []}
+    pdf_dest = tmp_path / "wr2_test.pdf"
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=1, stderr="ReportLab error")
+        with pytest.raises(PdfRenderError, match="exit≠0"):
+            render_pdf(slides, draft_id="test", out_path=pdf_dest)
+
+
+def test_render_pdf_zero_size_output(tmp_path):
+    slides = {"slides": []}
+    pdf_dest = tmp_path / "wr2_test.pdf"
+    pdf_dest.write_bytes(b"")  # zero size
+
+    def fake_run(args, **kwargs):
+        return MagicMock(returncode=0, stderr="")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        with pytest.raises(PdfRenderError, match="zero.size"):
+            render_pdf(slides, draft_id="test", out_path=pdf_dest)
+
+
+def test_render_pdf_timeout(tmp_path):
+    slides = {"slides": []}
+    pdf_dest = tmp_path / "wr2_test.pdf"
+    with patch("subprocess.run", side_effect=__import__("subprocess").TimeoutExpired("python", 120)):
+        with pytest.raises(PdfRenderError, match="timeout"):
+            render_pdf(slides, draft_id="test", out_path=pdf_dest)

--- a/apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_schema_adapter.py
+++ b/apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_schema_adapter.py
@@ -1,0 +1,58 @@
+"""Schema adapter: detect legacy + adapt to v2."""
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.services.canva_renderer_v2._schema_adapter import (
+    adapt_legacy_schema,
+    is_legacy_schema,
+)
+
+FIXTURES = Path(__file__).parent.parent.parent.parent / "fixtures" / "canva_renderer_v2"
+
+
+def _load(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text())
+
+
+def test_is_legacy_schema_detects_slide_type():
+    data = _load("draft_legacy_parq.json")
+    assert is_legacy_schema(data) is True
+
+
+def test_is_legacy_schema_rejects_v2():
+    assert is_legacy_schema(_load("draft_v2_kep71.json")) is False
+    assert is_legacy_schema(_load("draft_v2_deep.json")) is False
+
+
+def test_adapt_legacy_maps_cover_to_cover_photo():
+    legacy = _load("draft_legacy_parq.json")
+    adapted = adapt_legacy_schema(legacy, topic="Parq Ambassador")
+    assert adapted["slide_count"] == 3
+    assert adapted["slides"][0]["layout_family"] == "cover-photo"
+    assert adapted["slides"][0]["heading"] == "Parq Ambassador"
+
+
+def test_adapt_legacy_maps_law_to_thin_red_rule_divider():
+    legacy = _load("draft_legacy_parq.json")
+    adapted = adapt_legacy_schema(legacy, topic="Parq")
+    slide_3 = adapted["slides"][2]
+    assert slide_3["layout_family"] == "thin-red-rule-divider"
+    assert slide_3["source"] == "Permenkumham 22/2023"
+
+
+def test_adapt_legacy_no_hero_url_no_path():
+    legacy = _load("draft_legacy_parq.json")
+    # Strip the hero URL
+    legacy["slides"][0]["image_url"] = ""
+    adapted = adapt_legacy_schema(legacy, topic="Parq")
+    assert "hero_image_path" not in adapted["slides"][0]
+
+
+def test_v2_schema_passes_through_unchanged():
+    """is_legacy=False drafts should not be touched."""
+    v2 = _load("draft_v2_kep71.json")
+    # adapt_legacy_schema is only called when is_legacy_schema is True,
+    # but assert the detector says False.
+    assert is_legacy_schema(v2) is False

--- a/apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_telegram.py
+++ b/apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_telegram.py
@@ -1,0 +1,26 @@
+"""Telegram notify is best-effort: never raises, swallows network errors."""
+from unittest.mock import patch
+from backend.services.canva_renderer_v2._telegram import send_telegram
+
+
+def test_send_telegram_success(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")
+    monkeypatch.setenv("TELEGRAM_OWNER_CHAT_ID", "1125336968")
+    with patch("urllib.request.urlopen") as mock_open:
+        send_telegram("hello world")
+        assert mock_open.called
+        url = mock_open.call_args[0][0]
+        assert "api.telegram.org" in url
+
+
+def test_send_telegram_swallows_network_error(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")
+    with patch("urllib.request.urlopen", side_effect=OSError("network down")):
+        send_telegram("hello")  # MUST NOT raise
+
+
+def test_send_telegram_no_token_silent(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    with patch("urllib.request.urlopen") as mock_open:
+        send_telegram("hello")
+        assert not mock_open.called

--- a/apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_tigris.py
+++ b/apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_tigris.py
@@ -1,0 +1,81 @@
+"""Tigris S3 client: put_object with retry + delete + URL build."""
+import io
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.services.canva_renderer_v2._tigris import (
+    build_public_url,
+    delete_pdf,
+    upload_pdf,
+    TigrisError,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fast_sleep(monkeypatch):
+    monkeypatch.setattr("backend.services.canva_renderer_v2._tigris.time.sleep", lambda *_: None)
+
+
+@pytest.fixture
+def fake_s3():
+    """boto3 client stub. Return success unless overridden by test."""
+    client = MagicMock()
+    client.put_object.return_value = {"ETag": '"abc123"'}
+    client.delete_object.return_value = {}
+    return client
+
+
+def test_upload_pdf_success(tmp_path, fake_s3):
+    pdf = tmp_path / "test.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n...\n%%EOF")
+    url = upload_pdf(fake_s3, pdf, draft_id="abc-123", prefix="wr2-pdf")
+    assert url == "https://nuzantara-warroom-images.fly.storage.tigris.dev/wr2-pdf/abc-123.pdf"
+    fake_s3.put_object.assert_called_once()
+    call = fake_s3.put_object.call_args
+    assert call.kwargs["Key"] == "wr2-pdf/abc-123.pdf"
+    assert call.kwargs["ContentType"] == "application/pdf"
+    assert call.kwargs["ACL"] == "public-read"
+
+
+def test_upload_pdf_retries_on_transient_error(tmp_path):
+    from botocore.exceptions import ClientError
+    pdf = tmp_path / "test.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+    s3 = MagicMock()
+    # Fail twice (503), succeed third
+    s3.put_object.side_effect = [
+        ClientError({"Error": {"Code": "503"}}, "PutObject"),
+        ClientError({"Error": {"Code": "503"}}, "PutObject"),
+        {"ETag": '"abc"'},
+    ]
+    url = upload_pdf(s3, pdf, draft_id="abc", prefix="wr2-pdf")
+    assert url.endswith("/wr2-pdf/abc.pdf")
+    assert s3.put_object.call_count == 3
+
+
+def test_upload_pdf_exhausts_retries(tmp_path):
+    from botocore.exceptions import ClientError
+    pdf = tmp_path / "test.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+    s3 = MagicMock()
+    s3.put_object.side_effect = ClientError({"Error": {"Code": "503"}}, "PutObject")
+    with pytest.raises(TigrisError, match="exhausted retries"):
+        upload_pdf(s3, pdf, draft_id="abc", prefix="wr2-pdf")
+    assert s3.put_object.call_count == 3
+
+
+def test_delete_pdf_best_effort(fake_s3):
+    delete_pdf(fake_s3, draft_id="abc", prefix="wr2-pdf")
+    fake_s3.delete_object.assert_called_once()
+    # Must not raise even if delete fails
+    fake_s3.delete_object.side_effect = Exception("boom")
+    delete_pdf(fake_s3, draft_id="abc", prefix="wr2-pdf")  # no raise
+
+
+def test_build_public_url():
+    url = build_public_url("abc", prefix="wr2-pdf")
+    assert url == "https://nuzantara-warroom-images.fly.storage.tigris.dev/wr2-pdf/abc.pdf"
+    url2 = build_public_url("xyz", prefix="wr2-pdf-tests")
+    assert url2 == "https://nuzantara-warroom-images.fly.storage.tigris.dev/wr2-pdf-tests/xyz.pdf"

--- a/apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_token_storage.py
+++ b/apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_token_storage.py
@@ -1,0 +1,146 @@
+"""OrchestratorTokenStorage: HMAC + flock + proactive refresh + atomic write."""
+import hmac
+import hashlib
+import json
+import multiprocessing
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from backend.services.canva_renderer_v2._token_storage import (
+    OrchestratorTokenStorage,
+    TokenStorageError,
+    sign_payload,
+)
+
+
+HMAC_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+
+def _seed_valid(path: Path, expires_in_s: int = 3600) -> dict:
+    payload = {
+        "client_id": "cid",
+        "client_secret": "",
+        "access_token": "tok",
+        "refresh_token": "ref",
+        "scope": "user:read teams:read",
+        "token_type": "bearer",
+        "expires_at_epoch": time.time() + expires_in_s,
+        "issued_at": "2026-05-13T18:30:00Z",
+        "last_refreshed_iso": "2026-05-13T18:30:00Z",
+    }
+    signed = sign_payload(payload, key=bytes.fromhex(HMAC_KEY))
+    path.write_text(json.dumps(signed))
+    return signed
+
+
+def test_token_load_valid(tmp_path, monkeypatch):
+    p = tmp_path / "canva_tokens.json"
+    _seed_valid(p)
+    monkeypatch.setenv("WR2_CANVA_TOKEN_FILE", str(p))
+    monkeypatch.setenv("WR2_CANVA_HMAC_KEY", HMAC_KEY)
+    storage = OrchestratorTokenStorage()
+    tokens = storage.load_sync()
+    assert tokens["access_token"] == "tok"
+
+
+def test_token_hmac_mismatch_raises(tmp_path, monkeypatch):
+    p = tmp_path / "canva_tokens.json"
+    _seed_valid(p)
+    # Corrupt the file
+    data = json.loads(p.read_text())
+    data["access_token"] = "TAMPERED"
+    p.write_text(json.dumps(data))
+
+    monkeypatch.setenv("WR2_CANVA_TOKEN_FILE", str(p))
+    monkeypatch.setenv("WR2_CANVA_HMAC_KEY", HMAC_KEY)
+    storage = OrchestratorTokenStorage()
+    with pytest.raises(TokenStorageError, match="HMAC"):
+        storage.load_sync()
+
+
+def test_token_missing_file_raises(tmp_path, monkeypatch):
+    p = tmp_path / "canva_tokens.json"
+    monkeypatch.setenv("WR2_CANVA_TOKEN_FILE", str(p))
+    monkeypatch.setenv("WR2_CANVA_HMAC_KEY", HMAC_KEY)
+    storage = OrchestratorTokenStorage()
+    with pytest.raises(TokenStorageError, match="not found"):
+        storage.load_sync()
+
+
+def test_proactive_refresh_signals_expiry(tmp_path, monkeypatch):
+    p = tmp_path / "canva_tokens.json"
+    _seed_valid(p, expires_in_s=60)  # 1min < 300s margin
+    monkeypatch.setenv("WR2_CANVA_TOKEN_FILE", str(p))
+    monkeypatch.setenv("WR2_CANVA_HMAC_KEY", HMAC_KEY)
+    storage = OrchestratorTokenStorage()
+    assert storage.needs_refresh() is True
+
+
+def test_proactive_refresh_not_needed(tmp_path, monkeypatch):
+    p = tmp_path / "canva_tokens.json"
+    _seed_valid(p, expires_in_s=3600)  # 1h > 300s margin
+    monkeypatch.setenv("WR2_CANVA_TOKEN_FILE", str(p))
+    monkeypatch.setenv("WR2_CANVA_HMAC_KEY", HMAC_KEY)
+    storage = OrchestratorTokenStorage()
+    assert storage.needs_refresh() is False
+
+
+def test_set_tokens_preserves_refresh_token_on_omission(tmp_path, monkeypatch):
+    p = tmp_path / "canva_tokens.json"
+    _seed_valid(p)
+    monkeypatch.setenv("WR2_CANVA_TOKEN_FILE", str(p))
+    monkeypatch.setenv("WR2_CANVA_HMAC_KEY", HMAC_KEY)
+    storage = OrchestratorTokenStorage()
+
+    # Canva omits refresh_token in refresh response (common pattern)
+    new_tokens = {
+        "access_token": "new_tok",
+        "refresh_token": None,  # omitted
+        "expires_in": 3600,
+        "token_type": "bearer",
+        "scope": "user:read teams:read",
+    }
+    storage.save_sync(new_tokens)
+    saved = json.loads(p.read_text())
+    assert saved["refresh_token"] == "ref"  # preserved from existing
+    assert saved["access_token"] == "new_tok"
+
+
+def _worker_lock_test(token_file: str, hmac_key: str, barrier_path: str):
+    """Worker that loads + immediately saves under flock. Used in concurrency test."""
+    os.environ["WR2_CANVA_TOKEN_FILE"] = token_file
+    os.environ["WR2_CANVA_HMAC_KEY"] = hmac_key
+    # Wait for sibling
+    while not Path(barrier_path).exists():
+        time.sleep(0.05)
+    s = OrchestratorTokenStorage()
+    tok = s.load_sync()
+    s.save_sync({**tok, "access_token": f"by_pid_{os.getpid()}",
+                 "expires_in": 3600, "refresh_token": tok["refresh_token"]})
+
+
+def test_flock_serializes_concurrent_writes(tmp_path, monkeypatch):
+    """Two processes saving concurrently → final file is consistent (HMAC valid)."""
+    p = tmp_path / "canva_tokens.json"
+    _seed_valid(p)
+    barrier = tmp_path / "go"
+    barrier.touch()
+
+    procs = [
+        multiprocessing.Process(target=_worker_lock_test, args=(str(p), HMAC_KEY, str(barrier)))
+        for _ in range(2)
+    ]
+    for proc in procs:
+        proc.start()
+    for proc in procs:
+        proc.join(timeout=10)
+        assert proc.exitcode == 0
+
+    # File must still be valid (HMAC intact)
+    monkeypatch.setenv("WR2_CANVA_TOKEN_FILE", str(p))
+    monkeypatch.setenv("WR2_CANVA_HMAC_KEY", HMAC_KEY)
+    final = OrchestratorTokenStorage().load_sync()
+    assert final["access_token"].startswith("by_pid_")

--- a/apps/bali-intel-scraper/scripts/run_intel_pipeline.py
+++ b/apps/bali-intel-scraper/scripts/run_intel_pipeline.py
@@ -2123,6 +2123,8 @@ def main():
                        help='Dry run (no publishing)')
     parser.add_argument('--max-enrich', type=int, default=15,
                        help='Max articles to enrich with Claude (default: 15)')
+    parser.add_argument('--no-cell-emit', action='store_true',
+                       help='Disable Phase 3 TICKET B cell-aware HGT post-emit (debug only)')
 
     args = parser.parse_args()
 
@@ -2150,7 +2152,27 @@ def main():
     # Run pipeline
     pipeline = IntelPipeline(config)
     success = pipeline.run()
-    
+
+    # Phase 3 TICKET B — IntelScraperHGTBridge async post-emit (bounded blast).
+    # See spec v2: research/symbiosis/2026-05-13-ticket-b-narrow-spec.md
+    if not args.no_cell_emit:
+        try:
+            import asyncio
+            from backend.cell.cell_post_emit import emit_pipeline_run
+
+            asyncio.run(
+                asyncio.wait_for(
+                    emit_pipeline_run(pipeline.state),
+                    timeout=60.0,
+                )
+            )
+        except asyncio.TimeoutError:
+            print("⚠️ cell post-emit timeout after 60s (non-fatal)",
+                  file=sys.stderr)
+        except Exception as cell_exc:
+            print(f"⚠️ cell post-emit skipped (non-fatal): {cell_exc}",
+                  file=sys.stderr)
+
     sys.exit(0 if success else 1)
 
 

--- a/docs/superpowers/plans/2026-05-13-wr2-orchestrator-pdf-render.md
+++ b/docs/superpowers/plans/2026-05-13-wr2-orchestrator-pdf-render.md
@@ -1,0 +1,3411 @@
+# WR2 Orchestrator PDF Render Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a Python orchestrator that closes the WR2 carousel loop end-to-end (`PG draft → ReportLab PDF → Tigris S3 upload → Canva MCP import-design-from-url → PG update`) without any LLM in the orchestration path. Replaces the legacy `wr2_canva_apply.py` which has a 50% MCP cold-fail rate.
+
+**Architecture:** Python asyncio orchestrator using `mcp` SDK 1.12.4 (Anthropic official) over HTTP streamable transport with orchestrator-owned OAuth tokens at `~/.config/wr2/canva_tokens.json` (HMAC + flock + proactive refresh). Per-draft CAS lease in PG prevents overlapping launchd-tick processing. Tigris orphan PDFs cleaned via S3 lifecycle + explicit step on failure paths. Launchd plist uses `zsh -lc 'source ~/.nuzantara-secrets.env && exec flock -n <lock> python <orchestrator>'` for secret rotation + single-instance.
+
+**Tech Stack:** Python 3.11+, asyncio, asyncpg, boto3, httpx, mcp SDK 1.12.4, ReportLab (renderer existing), flock 0.4.0 brew, launchd, PostgreSQL (Fly tunnel via flycast localhost:15432), Tigris S3 (fly.storage.tigris.dev), Canva remote MCP (mcp.canva.com/mcp HTTP+OAuth+RFC7591), Telegram bot API.
+
+**Spec reference:** [`docs/superpowers/specs/2026-05-13-wr2-orchestrator-pdf-render-design.md`](../specs/2026-05-13-wr2-orchestrator-pdf-render-design.md) at commit `cee3e5c3b`.
+
+---
+
+## File structure
+
+### Production code (10 modules + 4 scripts + 3 plist)
+
+| Path | Purpose | Lines est. |
+|---|---|---|
+| `apps/backend-rag/backend/services/canva_renderer_v2/__init__.py` | package marker | 10 |
+| `apps/backend-rag/backend/services/canva_renderer_v2/_telegram.py` | best-effort Telegram notify | 40 |
+| `apps/backend-rag/backend/services/canva_renderer_v2/_pg.py` | asyncpg conn + kill switch + lease CAS + fetch + persist + cleanup | 180 |
+| `apps/backend-rag/backend/services/canva_renderer_v2/_schema_adapter.py` | detect legacy schema + adapt to v2 | 140 |
+| `apps/backend-rag/backend/services/canva_renderer_v2/_pdf_pipeline.py` | subprocess wrapper for `wr2_canva_pdf_render.py` | 70 |
+| `apps/backend-rag/backend/services/canva_renderer_v2/_tigris.py` | boto3 upload + delete + retry + URL build | 120 |
+| `apps/backend-rag/backend/services/canva_renderer_v2/_token_storage.py` | `OrchestratorTokenStorage(TokenStorage)` HMAC+flock+proactive | 200 |
+| `apps/backend-rag/backend/services/canva_renderer_v2/_canva_mcp.py` | `mcp.ClientSession` init + `call_tool` wrapper + transient classifier | 150 |
+| `apps/backend-rag/backend/services/canva_renderer_v2/_telemetry.py` | append-only JSONL telemetry | 50 |
+| `apps/backend-rag/backend/services/canva_renderer_v2/orchestrator.py` | top-level `run()` composing all above | 180 |
+| `apps/backend-rag/backend/db/migrations_v2/NNN_wr2_draft_lease.sql` | new lease columns | 30 |
+| `scripts/wr2_canva_pdf_apply.py` | thin launchd entrypoint | 30 |
+| `scripts/wr2_bootstrap_canva_oauth.py` | one-shot interactive OAuth bootstrap | 180 |
+| `scripts/wr2_canva_token_watchdog.py` | daily token expiry watchdog | 80 |
+| `scripts/wr2_canva_lease_watchdog.py` | 10min stale-lease recovery | 80 |
+| `scripts/wr2_e2e_create_fixture_draft.py` | E2E test draft creator | 70 |
+| `infra/launchagents/com.balizero.wr2.canva-renderer.plist` | replaces existing plist | xml |
+| `infra/launchagents/com.balizero.wr2.canva-token-watchdog.daily.plist` | new daily plist | xml |
+| `infra/launchagents/com.balizero.wr2.canva-lease-watchdog.10min.plist` | new 10min plist | xml |
+| `infra/tigris/wr2-pdf-lifecycle.json` | S3 retention policy | json |
+
+### Tests (8 unit + 1 e2e fixtures)
+
+| Path | Purpose |
+|---|---|
+| `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/conftest.py` | pytest fixtures shared |
+| `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_telegram.py` | notify mock |
+| `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_pg.py` | asyncpg mock + lease CAS |
+| `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_schema_adapter.py` | 3 fixture drafts |
+| `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_pdf_pipeline.py` | subprocess mock |
+| `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_tigris.py` | moto S3 |
+| `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_token_storage.py` | tmp dir + HMAC + flock concurrency |
+| `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_canva_mcp.py` | httpx_mock |
+| `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_orchestrator.py` | integration with all mocks |
+| `apps/backend-rag/backend/tests/fixtures/canva_renderer_v2/draft_legacy_parq.json` | data |
+| `apps/backend-rag/backend/tests/fixtures/canva_renderer_v2/draft_v2_kep71.json` | data |
+| `apps/backend-rag/backend/tests/fixtures/canva_renderer_v2/draft_v2_deep.json` | data |
+
+---
+
+## Task 1: DB migration for per-draft lease
+
+**Files:**
+- Create: `apps/backend-rag/backend/db/migrations_v2/146_wr2_draft_lease.sql`
+
+> Numbering: most recent on prod is `145_*`. Verify on Pro before commit: `psql -c "SELECT max(migration_number) FROM schema_migrations"`. If higher than 145, bump.
+
+- [ ] **Step 1: Write migration SQL**
+
+Create file with content:
+
+```sql
+-- 146_wr2_draft_lease.sql
+-- Adds per-draft CAS lease to war_room_drafts.
+-- Two columns: lease_owner (PID@host string) + lease_acquired_at (timestamptz).
+-- Used by canva_renderer_v2 orchestrator to prevent double-processing.
+
+ALTER TABLE war_room_drafts
+  ADD COLUMN IF NOT EXISTS lease_owner text,           -- squawk-ignore: prefer-text-field
+  ADD COLUMN IF NOT EXISTS lease_acquired_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_war_room_drafts_lease_recovery
+  ON war_room_drafts (lease_acquired_at)
+  WHERE status = 'rendering' AND lease_acquired_at IS NOT NULL;
+
+-- === ROLLBACK ===
+DROP INDEX IF EXISTS idx_war_room_drafts_lease_recovery;
+ALTER TABLE war_room_drafts
+  DROP COLUMN IF EXISTS lease_acquired_at,
+  DROP COLUMN IF EXISTS lease_owner;
+```
+
+- [ ] **Step 2: Verify Squawk lint passes locally**
+
+Run: `cd ~/Desktop/nuzantara && squawk apps/backend-rag/backend/db/migrations_v2/146_wr2_draft_lease.sql 2>&1 | tail -5`
+
+Expected: no violations (partial index + IF NOT EXISTS pattern is Squawk-clean).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd ~/Desktop/nuzantara
+git add apps/backend-rag/backend/db/migrations_v2/146_wr2_draft_lease.sql
+git commit -m "feat(db): migration 146 wr2_draft_lease columns for orchestrator v2
+
+Adds lease_owner (text) + lease_acquired_at (timestamptz) to
+war_room_drafts. Used by canva_renderer_v2 orchestrator for CAS lease
+that prevents overlapping launchd-tick double-processing.
+
+Partial index on (lease_acquired_at) WHERE status='rendering' supports
+the 10min stale-lease watchdog query path.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+git push origin feat/wr2-canva-pdf-render-2026-05-13
+```
+
+---
+
+## Task 2: Package skeleton + `_telegram.py`
+
+**Files:**
+- Create: `apps/backend-rag/backend/services/canva_renderer_v2/__init__.py`
+- Create: `apps/backend-rag/backend/services/canva_renderer_v2/_telegram.py`
+- Create: `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/__init__.py`
+- Create: `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/conftest.py`
+- Create: `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_telegram.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_telegram.py`:
+
+```python
+"""Telegram notify is best-effort: never raises, swallows network errors."""
+from unittest.mock import patch
+from backend.services.canva_renderer_v2._telegram import send_telegram
+
+
+def test_send_telegram_success(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")
+    monkeypatch.setenv("TELEGRAM_OWNER_CHAT_ID", "1125336968")
+    with patch("urllib.request.urlopen") as mock_open:
+        send_telegram("hello world")
+        assert mock_open.called
+        url = mock_open.call_args[0][0]
+        assert "api.telegram.org" in url
+
+
+def test_send_telegram_swallows_network_error(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")
+    with patch("urllib.request.urlopen", side_effect=OSError("network down")):
+        send_telegram("hello")  # MUST NOT raise
+
+
+def test_send_telegram_no_token_silent(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    with patch("urllib.request.urlopen") as mock_open:
+        send_telegram("hello")
+        assert not mock_open.called
+```
+
+Create empty `__init__.py` in both test dir and the service dir.
+Create `conftest.py`:
+
+```python
+"""Shared fixtures for canva_renderer_v2 tests."""
+import pytest
+from pathlib import Path
+
+FIXTURES_DIR = Path(__file__).parent.parent.parent.parent / "fixtures" / "canva_renderer_v2"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd ~/Desktop/nuzantara/apps/backend-rag && source .venv/bin/activate && PYTHONPATH=. pytest backend/tests/unit/services/canva_renderer_v2/test_telegram.py -v`
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'backend.services.canva_renderer_v2._telegram'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/backend-rag/backend/services/canva_renderer_v2/__init__.py`:
+
+```python
+"""WR2 orchestrator v2 — PDF render pipeline.
+
+Replaces legacy backend.services.canva_renderer (which depended on
+claude -p subprocess with 50% MCP cold-fail rate).
+
+See docs/superpowers/specs/2026-05-13-wr2-orchestrator-pdf-render-design.md
+"""
+```
+
+Create `apps/backend-rag/backend/services/canva_renderer_v2/_telegram.py`:
+
+```python
+"""Best-effort Telegram notify. Failures are swallowed (no raise).
+
+Reads TELEGRAM_BOT_TOKEN + TELEGRAM_OWNER_CHAT_ID env vars.
+If TELEGRAM_BOT_TOKEN absent, silently no-op.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import urllib.parse
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+
+def send_telegram(text: str) -> None:
+    token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+    chat_id = os.environ.get("TELEGRAM_OWNER_CHAT_ID", "1125336968")
+    if not token:
+        return
+    try:
+        data = urllib.parse.urlencode(
+            {"chat_id": chat_id, "text": text, "parse_mode": "Markdown"},
+        ).encode()
+        urllib.request.urlopen(  # noqa: S310 — known URL
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            data,
+            timeout=10,
+        )
+    except Exception as e:  # noqa: BLE001 — best-effort
+        logger.warning("Telegram send failed (swallowed): %s", e)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd ~/Desktop/nuzantara/apps/backend-rag && PYTHONPATH=. pytest backend/tests/unit/services/canva_renderer_v2/test_telegram.py -v`
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Desktop/nuzantara
+git add apps/backend-rag/backend/services/canva_renderer_v2/__init__.py \
+        apps/backend-rag/backend/services/canva_renderer_v2/_telegram.py \
+        apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/__init__.py \
+        apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/conftest.py \
+        apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_telegram.py
+git commit -m "feat(canva-renderer-v2): pkg init + _telegram.py best-effort notify
+
+Telegram notify swallows network errors. No-op when TELEGRAM_BOT_TOKEN
+unset. Pattern reused verbatim from legacy wr2_canva_apply.py.
+
+3 unit tests cover success, network error swallowing, missing-token
+silence.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+git push origin feat/wr2-canva-pdf-render-2026-05-13
+```
+
+---
+
+## Task 3: `_schema_adapter.py` with 3 fixtures
+
+**Files:**
+- Create: `apps/backend-rag/backend/services/canva_renderer_v2/_schema_adapter.py`
+- Create: `apps/backend-rag/backend/tests/fixtures/canva_renderer_v2/draft_legacy_parq.json`
+- Create: `apps/backend-rag/backend/tests/fixtures/canva_renderer_v2/draft_v2_kep71.json`
+- Create: `apps/backend-rag/backend/tests/fixtures/canva_renderer_v2/draft_v2_deep.json`
+- Create: `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_schema_adapter.py`
+
+Source material: `/tmp/wr2_legacy_adapter.py` (130 LOC, working). Adapt for proper module structure + tests.
+
+- [ ] **Step 1: Create fixture files**
+
+`draft_legacy_parq.json` — legacy schema (slide_type field, no layout_family):
+
+```json
+{
+  "slides": [
+    {"slide_number": 1, "slide_type": "cover", "headline": "Parq Ambassador",
+     "subhead": "Immigration designates Parq", "body": "...", "is_hero_image": true,
+     "image_url": "https://example.com/parq-hero.jpg"},
+    {"slide_number": 2, "slide_type": "take", "headline": "What happened",
+     "subhead": "16 October 2026", "body": "Indonesia immigration appointed Parq..."},
+    {"slide_number": 3, "slide_type": "law", "headline": "The provision",
+     "subhead": "Permenkumham 22/2023", "body": "Article 14 ayat 2..."}
+  ]
+}
+```
+
+`draft_v2_kep71.json` — v2 schema (layout_family present):
+
+```json
+{
+  "carousel_id": "kep71-pj-2026",
+  "slide_count": 6,
+  "primary_regulation_code": "KEP-71/PJ/2026",
+  "slides": [
+    {"index": 1, "layout_family": "cover-photo", "heading": "SPT Deadline",
+     "subheading": "Extended", "body": "From 30/04 to 31/05/2026"},
+    {"index": 2, "layout_family": "evidence-carved", "heading": "KEP-71",
+     "evidence_code": "KEP-71/PJ/2026", "body": "Issued by Bimo Wijayanto"}
+  ]
+}
+```
+
+`draft_v2_deep.json` — v2 with multiple layout types:
+
+```json
+{
+  "carousel_id": "deep-test",
+  "slide_count": 4,
+  "slides": [
+    {"index": 1, "layout_family": "stat-card-hero", "stat": "31 MAY",
+     "caption": "PPh Badan", "source": "KEP-71/PJ/2026"},
+    {"index": 2, "layout_family": "thin-red-rule-divider",
+     "body": "Late filing penalty: Rp 1jt", "source": "UU KUP"},
+    {"index": 3, "layout_family": "swiss-grid-asymmetry",
+     "yellow_accent": "MECHANISM",
+     "steps": [
+       {"num": "01", "head": "Check NPWP", "body": "Verify status"},
+       {"num": "02", "head": "Submit SPT", "body": "Before deadline"}
+     ]},
+    {"index": 4, "layout_family": "statement-bomb",
+     "statement": "Pay on time or pay double"}
+  ]
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_schema_adapter.py`:
+
+```python
+"""Schema adapter: detect legacy + adapt to v2."""
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.services.canva_renderer_v2._schema_adapter import (
+    adapt_legacy_schema,
+    is_legacy_schema,
+)
+
+FIXTURES = Path(__file__).parent.parent.parent.parent / "fixtures" / "canva_renderer_v2"
+
+
+def _load(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text())
+
+
+def test_is_legacy_schema_detects_slide_type():
+    data = _load("draft_legacy_parq.json")
+    assert is_legacy_schema(data) is True
+
+
+def test_is_legacy_schema_rejects_v2():
+    assert is_legacy_schema(_load("draft_v2_kep71.json")) is False
+    assert is_legacy_schema(_load("draft_v2_deep.json")) is False
+
+
+def test_adapt_legacy_maps_cover_to_cover_photo():
+    legacy = _load("draft_legacy_parq.json")
+    adapted = adapt_legacy_schema(legacy, topic="Parq Ambassador")
+    assert adapted["slide_count"] == 3
+    assert adapted["slides"][0]["layout_family"] == "cover-photo"
+    assert adapted["slides"][0]["heading"] == "Parq Ambassador"
+
+
+def test_adapt_legacy_maps_law_to_thin_red_rule_divider():
+    legacy = _load("draft_legacy_parq.json")
+    adapted = adapt_legacy_schema(legacy, topic="Parq")
+    slide_3 = adapted["slides"][2]
+    assert slide_3["layout_family"] == "thin-red-rule-divider"
+    assert slide_3["source"] == "Permenkumham 22/2023"
+
+
+def test_adapt_legacy_no_hero_url_no_path():
+    legacy = _load("draft_legacy_parq.json")
+    # Strip the hero URL
+    legacy["slides"][0]["image_url"] = ""
+    adapted = adapt_legacy_schema(legacy, topic="Parq")
+    assert "hero_image_path" not in adapted["slides"][0]
+
+
+def test_v2_schema_passes_through_unchanged():
+    """is_legacy=False drafts should not be touched."""
+    v2 = _load("draft_v2_kep71.json")
+    # adapt_legacy_schema is only called when is_legacy_schema is True,
+    # but assert the detector says False.
+    assert is_legacy_schema(v2) is False
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd ~/Desktop/nuzantara/apps/backend-rag && PYTHONPATH=. pytest backend/tests/unit/services/canva_renderer_v2/test_schema_adapter.py -v`
+
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 4: Write minimal implementation**
+
+Create `apps/backend-rag/backend/services/canva_renderer_v2/_schema_adapter.py`:
+
+```python
+"""Legacy slides_json schema → v2 (Article 14 layout_family) adapter.
+
+Detection: presence of `slide_type` field on first slide AND absence of
+`layout_family` → legacy. Otherwise v2 passes through unchanged.
+
+Used for drafts created before 2026-05-13 by storyboarder versions that
+emitted slide_type strings. Storyboarder patched 2026-05-13 emits v2
+schema directly; orchestrator handles both via this adapter inline.
+
+Source material: /tmp/wr2_legacy_adapter.py (working draft 2026-05-13).
+"""
+from __future__ import annotations
+
+import logging
+import re
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+LEGACY_TO_LAYOUT = {
+    "cover": "cover-photo",
+    "take": "photo-headline-yellow-sub",
+    "context": "photo-headline-yellow-sub",
+    "shift": "evidence-carved",
+    "mechanism": "swiss-grid-asymmetry",
+    "stake": "photo-headline-yellow-sub",
+    "law": "thin-red-rule-divider",
+    "fiction-vs-substance": "dark-status-list",
+    "numbers": "stat-card-hero",
+    "signal": "photo-headline-yellow-sub",
+    "cta": "elegant-close",
+    "closing": "statement-bomb",
+    "statement": "statement-bomb",
+    "insight": "photo-headline-yellow-sub",
+}
+
+HERO_CACHE_DIR = Path("/tmp/wr2_hero_cache")
+
+
+def is_legacy_schema(data: dict[str, Any]) -> bool:
+    """Detect legacy schema by presence of `slide_type` on any slide."""
+    slides = data.get("slides", [])
+    if not slides:
+        return False
+    first = slides[0]
+    return "slide_type" in first and "layout_family" not in first
+
+
+def _download_hero(url: str, slide_n: int) -> str | None:
+    if not url:
+        return None
+    HERO_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    dest = HERO_CACHE_DIR / f"hero_{slide_n:02d}.jpg"
+    if dest.exists():
+        return str(dest)
+    try:
+        urllib.request.urlretrieve(url, dest)  # noqa: S310
+        return str(dest)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("hero %d download failed: %s", slide_n, e)
+        return None
+
+
+def _map_swiss_grid_steps(body: str) -> list[dict]:
+    sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", body) if s.strip()]
+    steps: list[dict] = []
+    for k, sent in enumerate(sentences[:3]):
+        words = sent.split()
+        head = " ".join(words[:4]).rstrip(",.;:")
+        rest = " ".join(words[4:]).strip()
+        steps.append({"num": f"{k + 1:02d}", "head": head, "body": rest[:90]})
+    return steps
+
+
+def adapt_legacy_schema(legacy: dict[str, Any], *, topic: str) -> dict[str, Any]:
+    """Convert legacy slides_json → v2 Article 14 layout schema."""
+    slides_in = legacy.get("slides", [])
+    n = len(slides_in)
+    adapted: list[dict] = []
+
+    for i, ls in enumerate(slides_in):
+        slide_type = ls.get("slide_type", "")
+        layout = LEGACY_TO_LAYOUT.get(slide_type, "photo-headline-yellow-sub")
+        if i == n - 1 and slide_type == "cta":
+            layout = "statement-bomb"
+
+        hero_path = None
+        if ls.get("is_hero_image") and ls.get("image_url"):
+            hero_path = _download_hero(ls["image_url"], ls.get("slide_number", i + 1))
+
+        new: dict[str, Any] = {
+            "index": ls.get("slide_number", i + 1),
+            "layout_family": layout,
+            "heading": ls.get("headline") or "",
+            "subheading": ls.get("subhead") or "",
+            "body": ls.get("body") or "",
+        }
+        if hero_path:
+            new["hero_image_path"] = hero_path
+
+        if layout == "statement-bomb":
+            new["statement"] = ls.get("headline") or (ls.get("body", "") or "")[:120]
+        elif layout == "stat-card-hero":
+            text = (ls.get("body") or "") + " " + (ls.get("headline") or "")
+            m = re.search(r"\b(\d+(?:,\d{3})*(?:\.\d+)?[KMB%]?)\b", text)
+            new["stat"] = m.group(1) if m else "—"
+            new["caption"] = (ls.get("body") or "")[:120]
+            new["source"] = ls.get("subhead") or ""
+        elif layout == "thin-red-rule-divider":
+            new["body"] = ls.get("body") or ls.get("headline") or ""
+            new["source"] = ls.get("subhead") or ""
+        elif layout == "swiss-grid-asymmetry":
+            new["yellow_accent"] = ls.get("subhead") or "MECHANISM"
+            new["steps"] = _map_swiss_grid_steps(ls.get("body") or "")
+        elif layout == "dark-status-list":
+            new["list_items"] = [
+                {"label": "FICTION", "value": "MYTH", "status": "critical"},
+                {"label": "SUBSTANCE", "value": "FACT", "status": "positive"},
+            ]
+        elif layout == "elegant-close":
+            new["heading"] = "Want to act on this?"
+            new["body"] = ls.get("body") or ""
+            new["email"] = "zantara@balizero.com"
+            new["whatsapp"] = "wa.me/6285954680980"
+        elif layout == "evidence-carved":
+            new["evidence_code"] = ls.get("subhead") or ""
+
+        adapted.append(new)
+
+    out = {
+        "carousel_id": legacy.get("carousel_id", topic.lower().replace(" ", "-")[:80]),
+        "slide_count": len(adapted),
+        "slides": adapted,
+    }
+    return out
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd ~/Desktop/nuzantara/apps/backend-rag && PYTHONPATH=. pytest backend/tests/unit/services/canva_renderer_v2/test_schema_adapter.py -v`
+
+Expected: 6 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ~/Desktop/nuzantara
+git add apps/backend-rag/backend/services/canva_renderer_v2/_schema_adapter.py \
+        apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_schema_adapter.py \
+        apps/backend-rag/backend/tests/fixtures/canva_renderer_v2/
+git commit -m "feat(canva-renderer-v2): _schema_adapter.py + 3 fixtures
+
+Detects legacy slides_json (slide_type field) and adapts to v2 Article
+14 layout_family schema. Pure function, no DB/network IO except hero
+download via urllib (best-effort, returns None on failure).
+
+3 fixtures: legacy Parq Ambassador, v2 KEP-71, v2 deep schema.
+6 unit tests cover detection + layout mapping + missing hero URL.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+git push origin feat/wr2-canva-pdf-render-2026-05-13
+```
+
+---
+
+## Task 4: `_pdf_pipeline.py` subprocess wrapper
+
+**Files:**
+- Create: `apps/backend-rag/backend/services/canva_renderer_v2/_pdf_pipeline.py`
+- Create: `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_pdf_pipeline.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""PDF pipeline: invoke wr2_canva_pdf_render.py via subprocess, return path or None."""
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from backend.services.canva_renderer_v2._pdf_pipeline import render_pdf, PdfRenderError
+
+
+def test_render_pdf_success(tmp_path):
+    slides = {"carousel_id": "test", "slide_count": 1, "slides": [
+        {"index": 1, "layout_family": "cover-photo", "heading": "x", "body": "y"}
+    ]}
+    pdf_dest = tmp_path / "wr2_test.pdf"
+
+    def fake_run(args, **kwargs):
+        # Write a valid-looking PDF (first 4 bytes %PDF)
+        pdf_dest.write_bytes(b"%PDF-1.4\n... fake pdf body\n%%EOF")
+        return MagicMock(returncode=0, stderr="")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        result = render_pdf(slides, draft_id="test", out_path=pdf_dest)
+        assert result == pdf_dest
+        assert pdf_dest.exists() and pdf_dest.stat().st_size > 4
+
+
+def test_render_pdf_subprocess_exit_nonzero(tmp_path):
+    slides = {"slides": []}
+    pdf_dest = tmp_path / "wr2_test.pdf"
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=1, stderr="ReportLab error")
+        with pytest.raises(PdfRenderError, match="exit≠0"):
+            render_pdf(slides, draft_id="test", out_path=pdf_dest)
+
+
+def test_render_pdf_zero_size_output(tmp_path):
+    slides = {"slides": []}
+    pdf_dest = tmp_path / "wr2_test.pdf"
+    pdf_dest.write_bytes(b"")  # zero size
+
+    def fake_run(args, **kwargs):
+        return MagicMock(returncode=0, stderr="")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        with pytest.raises(PdfRenderError, match="zero.size"):
+            render_pdf(slides, draft_id="test", out_path=pdf_dest)
+
+
+def test_render_pdf_timeout(tmp_path):
+    slides = {"slides": []}
+    pdf_dest = tmp_path / "wr2_test.pdf"
+    with patch("subprocess.run", side_effect=__import__("subprocess").TimeoutExpired("python", 120)):
+        with pytest.raises(PdfRenderError, match="timeout"):
+            render_pdf(slides, draft_id="test", out_path=pdf_dest)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd ~/Desktop/nuzantara/apps/backend-rag && PYTHONPATH=. pytest backend/tests/unit/services/canva_renderer_v2/test_pdf_pipeline.py -v`
+
+Expected: FAIL `ModuleNotFoundError`.
+
+- [ ] **Step 3: Write implementation**
+
+```python
+"""Subprocess wrapper for scripts/wr2_canva_pdf_render.py.
+
+Writes slides_json to a temp path, invokes the renderer Python script
+via subprocess with 120s timeout, returns the output PDF path or raises
+PdfRenderError. The renderer itself is a separate process so a hung
+ReportLab call doesn't take down the orchestrator.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parents[4]  # backend-rag/backend/services/canva_renderer_v2/ → repo root
+RENDER_SCRIPT = REPO_ROOT / "scripts" / "wr2_canva_pdf_render.py"
+
+DEFAULT_TIMEOUT_S = 120
+
+
+class PdfRenderError(RuntimeError):
+    """Raised when the renderer subprocess fails."""
+
+
+def render_pdf(
+    slides_json: dict[str, Any],
+    *,
+    draft_id: str,
+    out_path: Path,
+    timeout_s: int = DEFAULT_TIMEOUT_S,
+) -> Path:
+    """Render slides_json → PDF at out_path. Raise PdfRenderError on failure."""
+    slides_tmp = Path(tempfile.mkstemp(prefix=f"slides_{draft_id}_", suffix=".json")[1])
+    slides_tmp.write_text(json.dumps(slides_json))
+
+    cmd = [
+        sys.executable,
+        str(RENDER_SCRIPT),
+        "--slides-json", str(slides_tmp),
+        "--out", str(out_path),
+    ]
+    logger.info("Render draft %s → %s", draft_id, out_path)
+
+    try:
+        result = subprocess.run(  # noqa: S603 — known python interpreter
+            cmd, capture_output=True, text=True, timeout=timeout_s, check=False,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise PdfRenderError(f"timeout {timeout_s}s for draft {draft_id}") from e
+    finally:
+        slides_tmp.unlink(missing_ok=True)
+
+    if result.returncode != 0:
+        raise PdfRenderError(
+            f"subprocess exit≠0 for draft {draft_id}: {result.stderr[:500]}"
+        )
+    if not out_path.exists() or out_path.stat().st_size == 0:
+        raise PdfRenderError(
+            f"renderer produced zero-size output for draft {draft_id}"
+        )
+    return out_path
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd ~/Desktop/nuzantara/apps/backend-rag && PYTHONPATH=. pytest backend/tests/unit/services/canva_renderer_v2/test_pdf_pipeline.py -v`
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Desktop/nuzantara
+git add apps/backend-rag/backend/services/canva_renderer_v2/_pdf_pipeline.py \
+        apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_pdf_pipeline.py
+git commit -m "feat(canva-renderer-v2): _pdf_pipeline.py subprocess wrapper
+
+Invokes scripts/wr2_canva_pdf_render.py via subprocess with 120s
+timeout. Returns PDF path or raises PdfRenderError (exit≠0, zero-size,
+or timeout). Subprocess isolation prevents hung ReportLab from
+taking down the orchestrator.
+
+4 unit tests cover success, exit≠0, zero-size output, timeout.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+git push origin feat/wr2-canva-pdf-render-2026-05-13
+```
+
+---
+
+## Task 5: `_tigris.py` boto3 upload + delete + S3 lifecycle JSON
+
+**Files:**
+- Create: `apps/backend-rag/backend/services/canva_renderer_v2/_tigris.py`
+- Create: `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_tigris.py`
+- Create: `infra/tigris/wr2-pdf-lifecycle.json`
+
+- [ ] **Step 1: Write S3 lifecycle policy**
+
+`infra/tigris/wr2-pdf-lifecycle.json`:
+
+```json
+{
+  "Rules": [
+    {
+      "ID": "wr2-pdf-prod-30d",
+      "Status": "Enabled",
+      "Filter": {"Prefix": "wr2-pdf/"},
+      "Expiration": {"Days": 30}
+    },
+    {
+      "ID": "wr2-pdf-tests-1d",
+      "Status": "Enabled",
+      "Filter": {"Prefix": "wr2-pdf-tests/"},
+      "Expiration": {"Days": 1}
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+"""Tigris S3 client: put_object with retry + delete + URL build."""
+import io
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.services.canva_renderer_v2._tigris import (
+    build_public_url,
+    delete_pdf,
+    upload_pdf,
+    TigrisError,
+)
+
+
+@pytest.fixture
+def fake_s3():
+    """boto3 client stub. Return success unless overridden by test."""
+    client = MagicMock()
+    client.put_object.return_value = {"ETag": '"abc123"'}
+    client.delete_object.return_value = {}
+    return client
+
+
+def test_upload_pdf_success(tmp_path, fake_s3):
+    pdf = tmp_path / "test.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n...\n%%EOF")
+    url = upload_pdf(fake_s3, pdf, draft_id="abc-123", prefix="wr2-pdf")
+    assert url == "https://nuzantara-warroom-images.fly.storage.tigris.dev/wr2-pdf/abc-123.pdf"
+    fake_s3.put_object.assert_called_once()
+    call = fake_s3.put_object.call_args
+    assert call.kwargs["Key"] == "wr2-pdf/abc-123.pdf"
+    assert call.kwargs["ContentType"] == "application/pdf"
+    assert call.kwargs["ACL"] == "public-read"
+
+
+def test_upload_pdf_retries_on_transient_error(tmp_path):
+    from botocore.exceptions import ClientError
+    pdf = tmp_path / "test.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+    s3 = MagicMock()
+    # Fail twice (503), succeed third
+    s3.put_object.side_effect = [
+        ClientError({"Error": {"Code": "503"}}, "PutObject"),
+        ClientError({"Error": {"Code": "503"}}, "PutObject"),
+        {"ETag": '"abc"'},
+    ]
+    url = upload_pdf(s3, pdf, draft_id="abc", prefix="wr2-pdf")
+    assert url.endswith("/wr2-pdf/abc.pdf")
+    assert s3.put_object.call_count == 3
+
+
+def test_upload_pdf_exhausts_retries(tmp_path):
+    from botocore.exceptions import ClientError
+    pdf = tmp_path / "test.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+    s3 = MagicMock()
+    s3.put_object.side_effect = ClientError({"Error": {"Code": "503"}}, "PutObject")
+    with pytest.raises(TigrisError, match="exhausted retries"):
+        upload_pdf(s3, pdf, draft_id="abc", prefix="wr2-pdf")
+    assert s3.put_object.call_count == 3
+
+
+def test_delete_pdf_best_effort(fake_s3):
+    delete_pdf(fake_s3, draft_id="abc", prefix="wr2-pdf")
+    fake_s3.delete_object.assert_called_once()
+    # Must not raise even if delete fails
+    fake_s3.delete_object.side_effect = Exception("boom")
+    delete_pdf(fake_s3, draft_id="abc", prefix="wr2-pdf")  # no raise
+
+
+def test_build_public_url():
+    url = build_public_url("abc", prefix="wr2-pdf")
+    assert url == "https://nuzantara-warroom-images.fly.storage.tigris.dev/wr2-pdf/abc.pdf"
+    url2 = build_public_url("xyz", prefix="wr2-pdf-tests")
+    assert url2 == "https://nuzantara-warroom-images.fly.storage.tigris.dev/wr2-pdf-tests/xyz.pdf"
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `cd ~/Desktop/nuzantara/apps/backend-rag && PYTHONPATH=. pytest backend/tests/unit/services/canva_renderer_v2/test_tigris.py -v`
+
+Expected: FAIL `ModuleNotFoundError`.
+
+- [ ] **Step 4: Write implementation**
+
+```python
+"""Tigris S3 client wrapper. boto3 put_object with 3-retry + delete + URL build.
+
+Bucket: nuzantara-warroom-images (public-read prefix wr2-pdf/).
+Endpoint: https://fly.storage.tigris.dev
+Credentials: AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY env (Tigris-compat).
+"""
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+logger = logging.getLogger(__name__)
+
+BUCKET = "nuzantara-warroom-images"
+ENDPOINT = "https://fly.storage.tigris.dev"
+PUBLIC_HOST = f"{BUCKET}.fly.storage.tigris.dev"
+
+MAX_RETRIES = 3
+BACKOFF_BASE_S = 2.0  # 2s, 4s, 8s
+
+TRANSIENT_ERROR_CODES = {"503", "502", "504", "RequestTimeout", "SlowDown", "Throttling"}
+
+
+class TigrisError(RuntimeError):
+    """Tigris S3 operation failed after retries."""
+
+
+def get_s3_client():
+    return boto3.client(
+        "s3",
+        endpoint_url=ENDPOINT,
+        region_name="auto",
+    )
+
+
+def _is_transient(exc: Exception) -> bool:
+    if isinstance(exc, ClientError):
+        code = exc.response.get("Error", {}).get("Code", "")
+        return code in TRANSIENT_ERROR_CODES
+    return isinstance(exc, BotoCoreError)
+
+
+def upload_pdf(s3, pdf_path: Path, *, draft_id: str, prefix: str = "wr2-pdf") -> str:
+    """Upload PDF to s3://BUCKET/{prefix}/{draft_id}.pdf, return public URL."""
+    key = f"{prefix}/{draft_id}.pdf"
+    body = pdf_path.read_bytes()
+
+    last_exc: Exception | None = None
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            s3.put_object(
+                Bucket=BUCKET,
+                Key=key,
+                Body=body,
+                ContentType="application/pdf",
+                ACL="public-read",
+            )
+            logger.info("Tigris upload OK: %s (attempt %d)", key, attempt)
+            return build_public_url(draft_id, prefix=prefix)
+        except (ClientError, BotoCoreError) as e:
+            last_exc = e
+            if not _is_transient(e):
+                raise TigrisError(f"Tigris non-transient error: {e}") from e
+            if attempt < MAX_RETRIES:
+                delay = BACKOFF_BASE_S * (2 ** (attempt - 1))
+                logger.warning(
+                    "Tigris transient error attempt %d/%d: %s — sleep %.1fs",
+                    attempt, MAX_RETRIES, e, delay,
+                )
+                time.sleep(delay)
+    raise TigrisError(f"Tigris exhausted retries for {key}: {last_exc}") from last_exc
+
+
+def delete_pdf(s3, *, draft_id: str, prefix: str = "wr2-pdf") -> None:
+    """Best-effort delete. Never raises (S3 lifecycle is the safety net)."""
+    key = f"{prefix}/{draft_id}.pdf"
+    try:
+        s3.delete_object(Bucket=BUCKET, Key=key)
+        logger.info("Tigris delete OK: %s", key)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Tigris delete failed (swallowed): %s — %s", key, e)
+
+
+def build_public_url(draft_id: str, *, prefix: str = "wr2-pdf") -> str:
+    return f"https://{PUBLIC_HOST}/{prefix}/{draft_id}.pdf"
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd ~/Desktop/nuzantara/apps/backend-rag && PYTHONPATH=. pytest backend/tests/unit/services/canva_renderer_v2/test_tigris.py -v`
+
+Expected: 5 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ~/Desktop/nuzantara
+git add apps/backend-rag/backend/services/canva_renderer_v2/_tigris.py \
+        apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_tigris.py \
+        infra/tigris/wr2-pdf-lifecycle.json
+git commit -m "feat(canva-renderer-v2): _tigris.py boto3 upload + S3 lifecycle
+
+upload_pdf with 3-retry exp backoff (2s/4s/8s) classifies transient
+codes (503/502/504/RequestTimeout/SlowDown/Throttling) vs permanent.
+delete_pdf best-effort (S3 lifecycle is safety net).
+
+infra/tigris/wr2-pdf-lifecycle.json: 30d retention on wr2-pdf/, 1d
+on wr2-pdf-tests/ (E2E auto-cleanup).
+
+5 unit tests cover success, transient retry, exhausted retries,
+best-effort delete, URL builder.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+git push origin feat/wr2-canva-pdf-render-2026-05-13
+```
+
+---
+
+## Task 6: `_token_storage.py` HMAC + flock + proactive refresh
+
+**Files:**
+- Create: `apps/backend-rag/backend/services/canva_renderer_v2/_token_storage.py`
+- Create: `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_token_storage.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""OrchestratorTokenStorage: HMAC + flock + proactive refresh + atomic write."""
+import hmac
+import hashlib
+import json
+import multiprocessing
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from backend.services.canva_renderer_v2._token_storage import (
+    OrchestratorTokenStorage,
+    TokenStorageError,
+    sign_payload,
+)
+
+
+HMAC_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+
+def _seed_valid(path: Path, expires_in_s: int = 3600) -> dict:
+    payload = {
+        "client_id": "cid",
+        "client_secret": "",
+        "access_token": "tok",
+        "refresh_token": "ref",
+        "scope": "user:read teams:read",
+        "token_type": "bearer",
+        "expires_at_epoch": time.time() + expires_in_s,
+        "issued_at": "2026-05-13T18:30:00Z",
+        "last_refreshed_iso": "2026-05-13T18:30:00Z",
+    }
+    signed = sign_payload(payload, key=bytes.fromhex(HMAC_KEY))
+    path.write_text(json.dumps(signed))
+    return signed
+
+
+def test_token_load_valid(tmp_path, monkeypatch):
+    p = tmp_path / "canva_tokens.json"
+    _seed_valid(p)
+    monkeypatch.setenv("WR2_CANVA_TOKEN_FILE", str(p))
+    monkeypatch.setenv("WR2_CANVA_HMAC_KEY", HMAC_KEY)
+    storage = OrchestratorTokenStorage()
+    tokens = storage.load_sync()
+    assert tokens["access_token"] == "tok"
+
+
+def test_token_hmac_mismatch_raises(tmp_path, monkeypatch):
+    p = tmp_path / "canva_tokens.json"
+    _seed_valid(p)
+    # Corrupt the file
+    data = json.loads(p.read_text())
+    data["access_token"] = "TAMPERED"
+    p.write_text(json.dumps(data))
+
+    monkeypatch.setenv("WR2_CANVA_TOKEN_FILE", str(p))
+    monkeypatch.setenv("WR2_CANVA_HMAC_KEY", HMAC_KEY)
+    storage = OrchestratorTokenStorage()
+    with pytest.raises(TokenStorageError, match="HMAC"):
+        storage.load_sync()
+
+
+def test_token_missing_file_raises(tmp_path, monkeypatch):
+    p = tmp_path / "canva_tokens.json"
+    monkeypatch.setenv("WR2_CANVA_TOKEN_FILE", str(p))
+    monkeypatch.setenv("WR2_CANVA_HMAC_KEY", HMAC_KEY)
+    storage = OrchestratorTokenStorage()
+    with pytest.raises(TokenStorageError, match="not found"):
+        storage.load_sync()
+
+
+def test_proactive_refresh_signals_expiry(tmp_path, monkeypatch):
+    p = tmp_path / "canva_tokens.json"
+    _seed_valid(p, expires_in_s=60)  # 1min < 300s margin
+    monkeypatch.setenv("WR2_CANVA_TOKEN_FILE", str(p))
+    monkeypatch.setenv("WR2_CANVA_HMAC_KEY", HMAC_KEY)
+    storage = OrchestratorTokenStorage()
+    assert storage.needs_refresh() is True
+
+
+def test_proactive_refresh_not_needed(tmp_path, monkeypatch):
+    p = tmp_path / "canva_tokens.json"
+    _seed_valid(p, expires_in_s=3600)  # 1h > 300s margin
+    monkeypatch.setenv("WR2_CANVA_TOKEN_FILE", str(p))
+    monkeypatch.setenv("WR2_CANVA_HMAC_KEY", HMAC_KEY)
+    storage = OrchestratorTokenStorage()
+    assert storage.needs_refresh() is False
+
+
+def test_set_tokens_preserves_refresh_token_on_omission(tmp_path, monkeypatch):
+    p = tmp_path / "canva_tokens.json"
+    _seed_valid(p)
+    monkeypatch.setenv("WR2_CANVA_TOKEN_FILE", str(p))
+    monkeypatch.setenv("WR2_CANVA_HMAC_KEY", HMAC_KEY)
+    storage = OrchestratorTokenStorage()
+
+    # Canva omits refresh_token in refresh response (common pattern)
+    new_tokens = {
+        "access_token": "new_tok",
+        "refresh_token": None,  # omitted
+        "expires_in": 3600,
+        "token_type": "bearer",
+        "scope": "user:read teams:read",
+    }
+    storage.save_sync(new_tokens)
+    saved = json.loads(p.read_text())
+    assert saved["refresh_token"] == "ref"  # preserved from existing
+    assert saved["access_token"] == "new_tok"
+
+
+def _worker_lock_test(token_file: str, hmac_key: str, barrier_path: str):
+    """Worker that loads + immediately saves under flock. Used in concurrency test."""
+    os.environ["WR2_CANVA_TOKEN_FILE"] = token_file
+    os.environ["WR2_CANVA_HMAC_KEY"] = hmac_key
+    # Wait for sibling
+    while not Path(barrier_path).exists():
+        time.sleep(0.05)
+    s = OrchestratorTokenStorage()
+    tok = s.load_sync()
+    s.save_sync({**tok, "access_token": f"by_pid_{os.getpid()}",
+                 "expires_in": 3600, "refresh_token": tok["refresh_token"]})
+
+
+def test_flock_serializes_concurrent_writes(tmp_path, monkeypatch):
+    """Two processes saving concurrently → final file is consistent (HMAC valid)."""
+    p = tmp_path / "canva_tokens.json"
+    _seed_valid(p)
+    barrier = tmp_path / "go"
+    barrier.touch()
+
+    procs = [
+        multiprocessing.Process(target=_worker_lock_test, args=(str(p), HMAC_KEY, str(barrier)))
+        for _ in range(2)
+    ]
+    for proc in procs:
+        proc.start()
+    for proc in procs:
+        proc.join(timeout=10)
+        assert proc.exitcode == 0
+
+    # File must still be valid (HMAC intact)
+    monkeypatch.setenv("WR2_CANVA_TOKEN_FILE", str(p))
+    monkeypatch.setenv("WR2_CANVA_HMAC_KEY", HMAC_KEY)
+    final = OrchestratorTokenStorage().load_sync()
+    assert final["access_token"].startswith("by_pid_")
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd ~/Desktop/nuzantara/apps/backend-rag && PYTHONPATH=. pytest backend/tests/unit/services/canva_renderer_v2/test_token_storage.py -v`
+
+Expected: FAIL `ModuleNotFoundError`.
+
+- [ ] **Step 3: Write implementation**
+
+```python
+"""Orchestrator-owned OAuth token storage.
+
+Independent from mcp-remote npm cache (see spec §3 + memory
+fact_canva_mcp_dynamic_client_registration). Path:
+~/.config/wr2/canva_tokens.json (mode 0600).
+
+Features:
+- HMAC-SHA256 integrity check on every read (key from WR2_CANVA_HMAC_KEY hex).
+- fcntl.flock advisory exclusive lock around read+write.
+- Proactive refresh: needs_refresh() True when <300s + jitter to expiry.
+- Atomic write via temp+rename.
+- Preserves refresh_token if Canva omits it in refresh response.
+- NO mtime-compare-before-replace (anti-pattern per panel).
+
+Public API matches mcp.client.auth.TokenStorage (async). Sync helpers
+exposed for bootstrap script + tests.
+"""
+from __future__ import annotations
+
+import asyncio
+import fcntl
+import hashlib
+import hmac
+import json
+import logging
+import os
+import random
+import time
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+REFRESH_MARGIN_S = 300
+JITTER_MAX_S = 15
+
+
+class TokenStorageError(RuntimeError):
+    pass
+
+
+def _canonical(payload: dict[str, Any]) -> str:
+    without = {k: v for k, v in payload.items() if k != "_hmac"}
+    return json.dumps(without, sort_keys=True, separators=(",", ":"))
+
+
+def sign_payload(payload: dict[str, Any], *, key: bytes) -> dict[str, Any]:
+    sig = hmac.new(key, _canonical(payload).encode(), hashlib.sha256).hexdigest()
+    return {**{k: v for k, v in payload.items() if k != "_hmac"}, "_hmac": sig}
+
+
+def verify_payload(payload: dict[str, Any], *, key: bytes) -> dict[str, Any]:
+    stored = payload.get("_hmac")
+    if not stored:
+        raise TokenStorageError("Token file missing HMAC field")
+    computed = hmac.new(key, _canonical(payload).encode(), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(stored, computed):
+        raise TokenStorageError("Token HMAC mismatch — corrupt or tampered")
+    return {k: v for k, v in payload.items() if k != "_hmac"}
+
+
+class OrchestratorTokenStorage:
+    """Sync-first storage; async wrappers below for mcp SDK contract."""
+
+    def __init__(self) -> None:
+        path_env = os.environ.get("WR2_CANVA_TOKEN_FILE")
+        if not path_env:
+            raise TokenStorageError(
+                "WR2_CANVA_TOKEN_FILE env var required (e.g. ~/.config/wr2/canva_tokens.json)"
+            )
+        self.path = Path(path_env).expanduser()
+        self.lock_path = self.path.with_suffix(self.path.suffix + ".lock")
+
+        hex_key = os.environ.get("WR2_CANVA_HMAC_KEY")
+        if not hex_key:
+            raise TokenStorageError("WR2_CANVA_HMAC_KEY env var required (32-byte hex)")
+        try:
+            self.hmac_key = bytes.fromhex(hex_key)
+        except ValueError as e:
+            raise TokenStorageError(f"WR2_CANVA_HMAC_KEY not valid hex: {e}") from e
+
+    @contextmanager
+    def _lock(self):
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.lock_path, "w") as fp:
+            fcntl.flock(fp.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(fp.fileno(), fcntl.LOCK_UN)
+
+    def load_sync(self) -> dict[str, Any]:
+        if not self.path.exists():
+            raise TokenStorageError(
+                f"Token file not found: {self.path}. Run scripts/wr2_bootstrap_canva_oauth.py"
+            )
+        with self._lock():
+            payload = json.loads(self.path.read_text())
+            return verify_payload(payload, key=self.hmac_key)
+
+    def needs_refresh(self) -> bool:
+        try:
+            tokens = self.load_sync()
+        except TokenStorageError:
+            return True  # treat unloadable as expired
+        remaining = float(tokens.get("expires_at_epoch", 0)) - time.time()
+        threshold = REFRESH_MARGIN_S + random.uniform(0, JITTER_MAX_S)
+        return remaining < threshold
+
+    def save_sync(self, new_tokens: dict[str, Any]) -> None:
+        """Merge new_tokens into existing, sign, atomic write."""
+        with self._lock():
+            existing = {}
+            if self.path.exists():
+                try:
+                    existing = verify_payload(
+                        json.loads(self.path.read_text()), key=self.hmac_key
+                    )
+                except TokenStorageError:
+                    logger.warning(
+                        "Existing token file unverifiable; backup + replace"
+                    )
+                    backup = self.path.with_suffix(
+                        f".broken-{datetime.now().strftime('%Y%m%d-%H%M%S')}.json"
+                    )
+                    self.path.rename(backup)
+
+            merged = {**existing, **new_tokens}
+            # Preserve refresh_token if Canva omitted it on refresh
+            if not new_tokens.get("refresh_token") and existing.get("refresh_token"):
+                merged["refresh_token"] = existing["refresh_token"]
+            merged["last_refreshed_iso"] = datetime.now(timezone.utc).isoformat()
+            expires_in = new_tokens.get("expires_in", 3600)
+            merged["expires_at_epoch"] = time.time() + float(expires_in)
+
+            signed = sign_payload(merged, key=self.hmac_key)
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+            tmp.write_text(json.dumps(signed, indent=2))
+            tmp.chmod(0o600)
+            tmp.replace(self.path)
+
+    # Async wrappers for mcp SDK TokenStorage contract
+    async def get_tokens(self):
+        return await asyncio.to_thread(self._load_for_sdk)
+
+    async def set_tokens(self, tokens) -> None:
+        await asyncio.to_thread(self._save_from_sdk, tokens)
+
+    async def get_client_info(self):
+        return await asyncio.to_thread(self._load_client_info)
+
+    async def set_client_info(self, info) -> None:
+        # client_info is owned by the orchestrator and written during bootstrap
+        # only. Runtime no-op. (Subsequent OAuth flows in this orchestrator
+        # always reuse the bootstrap-time client_id.)
+        return
+
+    def _load_for_sdk(self):
+        from mcp.shared.auth import OAuthToken
+        if self.needs_refresh():
+            return None  # mcp SDK will trigger refresh
+        data = self.load_sync()
+        return OAuthToken(
+            access_token=data["access_token"],
+            token_type=data.get("token_type", "bearer"),
+            expires_in=int(max(0, data["expires_at_epoch"] - time.time())),
+            refresh_token=data.get("refresh_token"),
+            scope=data.get("scope"),
+        )
+
+    def _save_from_sdk(self, tokens):
+        self.save_sync({
+            "access_token": tokens.access_token,
+            "token_type": tokens.token_type,
+            "expires_in": tokens.expires_in,
+            "refresh_token": tokens.refresh_token,
+            "scope": tokens.scope,
+        })
+
+    def _load_client_info(self):
+        from mcp.shared.auth import OAuthClientInformationFull
+        data = self.load_sync()
+        return OAuthClientInformationFull(
+            client_id=data["client_id"],
+            client_secret=data.get("client_secret") or None,
+            redirect_uris=data.get("redirect_uris", []),
+            grant_types=data.get("grant_types", ["authorization_code", "refresh_token"]),
+            response_types=data.get("response_types", ["code"]),
+            token_endpoint_auth_method=data.get("token_endpoint_auth_method", "none"),
+            scope=data.get("scope"),
+        )
+```
+
+- [ ] **Step 4: Install deps + run tests**
+
+Run:
+```bash
+cd ~/Desktop/nuzantara/apps/backend-rag && source .venv/bin/activate && pip install 'mcp>=1.12.4' --quiet
+PYTHONPATH=. pytest backend/tests/unit/services/canva_renderer_v2/test_token_storage.py -v
+```
+
+Expected: 7 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Desktop/nuzantara
+git add apps/backend-rag/backend/services/canva_renderer_v2/_token_storage.py \
+        apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_token_storage.py
+git commit -m "feat(canva-renderer-v2): _token_storage.py HMAC+flock+proactive
+
+OrchestratorTokenStorage owns OAuth tokens at WR2_CANVA_TOKEN_FILE
+(default ~/.config/wr2/canva_tokens.json). Decoupled from mcp-remote
+npm cache (see spec §3 + memory fact_canva_mcp_dynamic_client_registration).
+
+Features: HMAC-SHA256 integrity, fcntl.flock advisory exclusive,
+proactive refresh (5min margin + 0-15s jitter), atomic write,
+refresh_token preservation on Canva omission, async-wrapper for mcp
+SDK TokenStorage contract.
+
+7 unit tests cover load/HMAC/missing-file/proactive/refresh-preserve/
+concurrent-flock.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+git push origin feat/wr2-canva-pdf-render-2026-05-13
+```
+
+---
+
+## Task 7: `_canva_mcp.py` ClientSession wrapper + transient classifier
+
+**Files:**
+- Create: `apps/backend-rag/backend/services/canva_renderer_v2/_canva_mcp.py`
+- Create: `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_canva_mcp.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Canva MCP wrapper: call_tool + transient-vs-permanent classifier."""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.services.canva_renderer_v2._canva_mcp import (
+    CanvaMcpClient,
+    is_transient_error,
+    CanvaImportError,
+)
+
+
+def test_is_transient_429():
+    err = Exception("429 Too Many Requests")
+    err.status_code = 429
+    assert is_transient_error(err) is True
+
+
+def test_is_transient_503():
+    err = Exception("503 Service Unavailable")
+    err.status_code = 503
+    assert is_transient_error(err) is True
+
+
+def test_is_transient_400_permanent():
+    err = Exception("400 Bad Request")
+    err.status_code = 400
+    assert is_transient_error(err) is False
+
+
+def test_is_transient_network():
+    import httpx
+    assert is_transient_error(httpx.ConnectTimeout("boom")) is True
+    assert is_transient_error(httpx.NetworkError("nope")) is True
+
+
+def test_parse_design_id_from_mcp_result():
+    from backend.services.canva_renderer_v2._canva_mcp import parse_design_id
+    result_payload = {
+        "content": [{"type": "text", "text": '{"design_id": "DAGabc1234"}'}]
+    }
+    assert parse_design_id(result_payload) == "DAGabc1234"
+
+
+def test_parse_design_id_from_text_url():
+    from backend.services.canva_renderer_v2._canva_mcp import parse_design_id
+    result_payload = {
+        "content": [{"type": "text",
+                     "text": "Created: https://www.canva.com/design/DAGxyz9876/edit"}]
+    }
+    assert parse_design_id(result_payload) == "DAGxyz9876"
+
+
+@pytest.mark.asyncio
+async def test_import_design_calls_mcp_tool():
+    client = CanvaMcpClient(server_url="https://mcp.canva.com/mcp")
+    mock_session = AsyncMock()
+    mock_session.call_tool.return_value = type(
+        "Result", (),
+        {"content": [type("C", (), {"text": '{"design_id": "DAGabc"}'})()]},
+    )()
+    client._session = mock_session
+
+    design_id, edit_url = await client.import_design_from_url(
+        "https://example.com/foo.pdf", title="Test"
+    )
+    assert design_id == "DAGabc"
+    assert edit_url == "https://www.canva.com/design/DAGabc/edit"
+    mock_session.call_tool.assert_awaited_once_with(
+        "import-design-from-url",
+        arguments={"url": "https://example.com/foo.pdf", "title": "Test"},
+    )
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd ~/Desktop/nuzantara/apps/backend-rag && PYTHONPATH=. pytest backend/tests/unit/services/canva_renderer_v2/test_canva_mcp.py -v`
+
+Expected: FAIL `ModuleNotFoundError`.
+
+- [ ] **Step 3: Write implementation**
+
+```python
+"""Canva MCP client wrapper over mcp SDK 1.12.4 streamable HTTP transport.
+
+Provides:
+- CanvaMcpClient async context manager — manages ClientSession lifecycle.
+- import_design_from_url() — wraps mcp call_tool + parses design_id.
+- move_item_to_folder() — best-effort, non-fatal on failure.
+- Transient-vs-permanent error classifier for orchestrator backoff logic.
+
+OAuth handled by OrchestratorTokenStorage passed to OAuthClientProvider.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+from mcp import ClientSession
+from mcp.client.auth import OAuthClientProvider
+from mcp.client.streamable_http import streamable_http_client
+from mcp.shared.auth import OAuthClientMetadata
+from pydantic import AnyUrl
+
+from backend.services.canva_renderer_v2._token_storage import OrchestratorTokenStorage
+
+logger = logging.getLogger(__name__)
+
+CANVA_MCP_URL = "https://mcp.canva.com/mcp"
+TRANSIENT_HTTP_STATUS = {408, 425, 429, 500, 502, 503, 504}
+
+
+class CanvaImportError(RuntimeError):
+    """Raised by import_design_from_url on permanent failure."""
+
+
+def is_transient_error(exc: Exception) -> bool:
+    status = getattr(exc, "status_code", None)
+    if status in TRANSIENT_HTTP_STATUS:
+        return True
+    if isinstance(exc, (httpx.NetworkError, httpx.TimeoutException)):
+        return True
+    return False
+
+
+_DESIGN_ID_RE = re.compile(r"DA[A-Za-z0-9_-]{6,}")
+
+
+def parse_design_id(result: Any) -> str:
+    """Extract design_id from mcp call_tool response payload.
+
+    Tolerates 2 shapes:
+    1. {"content": [{"text": '{"design_id": "..."}'}]} — JSON-in-text
+    2. {"content": [{"text": "https://www.canva.com/design/DA.../edit"}]} — URL embed
+    """
+    content = result.get("content") if isinstance(result, dict) else getattr(result, "content", None)
+    if not content:
+        raise CanvaImportError(f"MCP result missing content: {result!r}")
+
+    first = content[0]
+    text = first.get("text") if isinstance(first, dict) else getattr(first, "text", None)
+    if not text:
+        raise CanvaImportError(f"MCP result text empty: {first!r}")
+
+    # Try JSON first
+    try:
+        parsed = json.loads(text)
+        if isinstance(parsed, dict) and "design_id" in parsed:
+            return parsed["design_id"]
+    except json.JSONDecodeError:
+        pass
+
+    m = _DESIGN_ID_RE.search(text)
+    if m:
+        return m.group(0)
+    raise CanvaImportError(f"design_id not found in MCP response: {text[:200]!r}")
+
+
+class CanvaMcpClient:
+    """Async context manager wrapping mcp.ClientSession against Canva HTTP MCP."""
+
+    def __init__(self, server_url: str = CANVA_MCP_URL) -> None:
+        self.server_url = server_url
+        self._session: ClientSession | None = None
+        self._cm = None  # context manager stack
+
+    async def __aenter__(self) -> "CanvaMcpClient":
+        storage = OrchestratorTokenStorage()
+        info = await storage.get_client_info()
+        oauth = OAuthClientProvider(
+            server_url=self.server_url,
+            client_metadata=OAuthClientMetadata(
+                client_name="WR2 Pipeline Orchestrator",
+                redirect_uris=[AnyUrl(u) for u in info.redirect_uris],
+                grant_types=info.grant_types,
+                response_types=info.response_types,
+                token_endpoint_auth_method=info.token_endpoint_auth_method,
+                scope=info.scope,
+            ),
+            storage=storage,
+            redirect_handler=self._reject_interactive,
+            callback_handler=self._reject_interactive,
+        )
+        self._http_client = httpx.AsyncClient(auth=oauth, follow_redirects=True, timeout=60.0)
+        self._stream_cm = streamable_http_client(self.server_url, http_client=self._http_client)
+        (read, write, _) = await self._stream_cm.__aenter__()
+        self._session = ClientSession(read, write)
+        await self._session.__aenter__()
+        await self._session.initialize()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        if self._session is not None:
+            await self._session.__aexit__(exc_type, exc, tb)
+        if self._stream_cm is not None:
+            await self._stream_cm.__aexit__(exc_type, exc, tb)
+        if self._http_client is not None:
+            await self._http_client.aclose()
+
+    @staticmethod
+    async def _reject_interactive(*args, **kwargs):
+        raise CanvaImportError(
+            "OAuth interactive flow required — refresh token revoked. "
+            "Run scripts/wr2_bootstrap_canva_oauth.py on Pro."
+        )
+
+    async def import_design_from_url(self, url: str, *, title: str) -> tuple[str, str]:
+        if self._session is None:
+            raise RuntimeError("CanvaMcpClient not entered")
+        result = await self._session.call_tool(
+            "import-design-from-url",
+            arguments={"url": url, "title": title},
+        )
+        design_id = parse_design_id(result.__dict__ if not isinstance(result, dict) else result)
+        edit_url = f"https://www.canva.com/design/{design_id}/edit"
+        return design_id, edit_url
+
+    async def move_item_to_folder(self, item_id: str, folder_id: str) -> None:
+        if self._session is None:
+            raise RuntimeError("CanvaMcpClient not entered")
+        try:
+            await self._session.call_tool(
+                "move-item-to-folder",
+                arguments={"item_id": item_id, "folder_id": folder_id},
+            )
+        except Exception as e:  # noqa: BLE001 — best-effort
+            logger.warning("move-item-to-folder failed (non-fatal): %s", e)
+```
+
+- [ ] **Step 4: Install pytest-asyncio + run tests**
+
+Run:
+```bash
+cd ~/Desktop/nuzantara/apps/backend-rag && source .venv/bin/activate && pip install pytest-asyncio --quiet
+PYTHONPATH=. pytest backend/tests/unit/services/canva_renderer_v2/test_canva_mcp.py -v
+```
+
+Expected: 7 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Desktop/nuzantara
+git add apps/backend-rag/backend/services/canva_renderer_v2/_canva_mcp.py \
+        apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_canva_mcp.py
+git commit -m "feat(canva-renderer-v2): _canva_mcp.py ClientSession wrapper
+
+CanvaMcpClient async context manager wraps mcp SDK 1.12.4 streamable
+HTTP client + OAuthClientProvider against https://mcp.canva.com/mcp.
+OAuth tokens via OrchestratorTokenStorage. Interactive re-auth handler
+raises (cron path can't open browser).
+
+import_design_from_url + move_item_to_folder (best-effort).
+parse_design_id tolerates 2 result shapes (JSON-in-text, URL-embed).
+is_transient_error classifies 408/425/429/5xx + httpx Network/Timeout.
+
+7 unit tests cover classifier + parser + tool call shape.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+git push origin feat/wr2-canva-pdf-render-2026-05-13
+```
+
+---
+
+## Task 8: `_pg.py` asyncpg + kill switch + lease CAS + fetch + persist
+
+**Files:**
+- Create: `apps/backend-rag/backend/services/canva_renderer_v2/_pg.py`
+- Create: `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_pg.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""PG layer: kill switch + lease CAS fetch + persist + cleanup."""
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.services.canva_renderer_v2._pg import (
+    acquire_lease_and_fetch,
+    is_kill_switch_enabled,
+    persist_canva_result,
+    release_lease_permanent,
+    release_lease_transient,
+    reset_stale_leases,
+)
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_true():
+    conn = AsyncMock()
+    conn.fetchval.return_value = "true"
+    assert await is_kill_switch_enabled(conn) is True
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_false():
+    conn = AsyncMock()
+    conn.fetchval.return_value = "false"
+    assert await is_kill_switch_enabled(conn) is False
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_missing_row_treated_as_false():
+    conn = AsyncMock()
+    conn.fetchval.return_value = None
+    assert await is_kill_switch_enabled(conn) is False
+
+
+@pytest.mark.asyncio
+async def test_acquire_lease_success_returns_row():
+    conn = AsyncMock()
+    fake_row = {"id": "abc", "topic": "T", "tone": "ped", "slides_json": "{}"}
+    conn.fetchrow.return_value = fake_row
+    row = await acquire_lease_and_fetch(conn, draft_id="abc", lease_owner="pid@host")
+    assert row == fake_row
+    args, kwargs = conn.fetchrow.call_args
+    assert "UPDATE war_room_drafts" in args[0]
+    assert args[1] == "pid@host"
+
+
+@pytest.mark.asyncio
+async def test_acquire_lease_loss_returns_none():
+    conn = AsyncMock()
+    conn.fetchrow.return_value = None
+    row = await acquire_lease_and_fetch(conn, draft_id="abc", lease_owner="pid@host")
+    assert row is None
+
+
+@pytest.mark.asyncio
+async def test_persist_canva_result_clears_lease():
+    conn = AsyncMock()
+    await persist_canva_result(
+        conn, draft_id="abc",
+        canva_design_id="DAG1", canva_edit_url="https://canva.com/...",
+        canva_view_url=None,
+    )
+    sql = conn.execute.call_args[0][0]
+    assert "status = 'rendered'" in sql
+    assert "lease_owner = NULL" in sql
+    assert "lease_acquired_at = NULL" in sql
+
+
+@pytest.mark.asyncio
+async def test_release_lease_transient_reverts_status():
+    conn = AsyncMock()
+    await release_lease_transient(conn, draft_id="abc", reason="429 rate limited")
+    sql = conn.execute.call_args[0][0]
+    assert "status = 'drafts_imaged_checked'" in sql
+    assert "lease_owner = NULL" in sql
+
+
+@pytest.mark.asyncio
+async def test_release_lease_permanent_sets_terminal():
+    conn = AsyncMock()
+    await release_lease_permanent(
+        conn, draft_id="abc", status="canva_import_failed", reason="400 invalid",
+    )
+    sql = conn.execute.call_args[0][0]
+    assert "status = $2" in sql
+    assert "lease_owner = NULL" in sql
+
+
+@pytest.mark.asyncio
+async def test_reset_stale_leases_returns_count():
+    conn = AsyncMock()
+    conn.fetch.return_value = [{"id": "abc"}, {"id": "xyz"}]
+    ids = await reset_stale_leases(conn, stale_after_minutes=15)
+    assert ids == ["abc", "xyz"]
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd ~/Desktop/nuzantara/apps/backend-rag && PYTHONPATH=. pytest backend/tests/unit/services/canva_renderer_v2/test_pg.py -v`
+
+Expected: FAIL `ModuleNotFoundError`.
+
+- [ ] **Step 3: Write implementation**
+
+```python
+"""PostgreSQL layer for canva_renderer_v2.
+
+Functions:
+- is_kill_switch_enabled(conn) — reads system_settings.wr2_canva_renderer_enabled
+- fetch_pending_draft_ids(conn, limit) — pre-scan IDs to attempt lease
+- acquire_lease_and_fetch(conn, draft_id, lease_owner) — CAS, returns row or None
+- persist_canva_result(conn, ...) — UPDATE status='rendered' + canva_* + clear lease
+- release_lease_transient(conn, ...) — revert status='drafts_imaged_checked'
+- release_lease_permanent(conn, ..., status=...) — set terminal status
+- reset_stale_leases(conn, stale_after_minutes) — watchdog recovery
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID
+
+import asyncpg
+
+logger = logging.getLogger(__name__)
+
+
+async def is_kill_switch_enabled(conn: asyncpg.Connection) -> bool:
+    value = await conn.fetchval(
+        "SELECT value FROM system_settings WHERE key = 'wr2_canva_renderer_enabled'"
+    )
+    return value == "true"
+
+
+async def fetch_pending_draft_ids(
+    conn: asyncpg.Connection, limit: int = 3
+) -> list[UUID]:
+    rows = await conn.fetch(
+        """
+        SELECT id FROM war_room_drafts
+         WHERE status = 'drafts_imaged_checked'
+           AND canva_edit_url IS NULL
+           AND lease_owner IS NULL
+         ORDER BY created_at ASC
+         LIMIT $1
+        """,
+        limit,
+    )
+    return [r["id"] for r in rows]
+
+
+async def acquire_lease_and_fetch(
+    conn: asyncpg.Connection, *, draft_id: UUID | str, lease_owner: str,
+) -> dict[str, Any] | None:
+    """CAS lease + return row payload, or None if another process won."""
+    row = await conn.fetchrow(
+        """
+        UPDATE war_room_drafts
+           SET status = 'rendering',
+               lease_owner = $1,
+               lease_acquired_at = NOW(),
+               updated_at = NOW()
+         WHERE id = $2
+           AND status = 'drafts_imaged_checked'
+           AND canva_edit_url IS NULL
+           AND lease_owner IS NULL
+        RETURNING id, topic, register AS tone, slides_json
+        """,
+        lease_owner, draft_id,
+    )
+    if row is None:
+        logger.info("Draft %s lease lost to another process", draft_id)
+    return dict(row) if row else None
+
+
+async def persist_canva_result(
+    conn: asyncpg.Connection, *,
+    draft_id: UUID | str,
+    canva_design_id: str,
+    canva_edit_url: str,
+    canva_view_url: str | None,
+) -> None:
+    await conn.execute(
+        """
+        UPDATE war_room_drafts
+           SET canva_design_id = $2,
+               canva_edit_url = $3,
+               canva_view_url = $4,
+               canva_applied_at = NOW(),
+               status = 'rendered',
+               lease_owner = NULL,
+               lease_acquired_at = NULL,
+               updated_at = NOW()
+         WHERE id = $1
+        """,
+        draft_id, canva_design_id, canva_edit_url, canva_view_url,
+    )
+
+
+async def release_lease_transient(
+    conn: asyncpg.Connection, *, draft_id: UUID | str, reason: str,
+) -> None:
+    """Revert to drafts_imaged_checked for natural retry on next tick."""
+    logger.info("Draft %s released as transient: %s", draft_id, reason)
+    await conn.execute(
+        """
+        UPDATE war_room_drafts
+           SET status = 'drafts_imaged_checked',
+               lease_owner = NULL,
+               lease_acquired_at = NULL,
+               updated_at = NOW()
+         WHERE id = $1
+        """,
+        draft_id,
+    )
+
+
+async def release_lease_permanent(
+    conn: asyncpg.Connection, *, draft_id: UUID | str, status: str, reason: str,
+) -> None:
+    """Mark terminal failure status. Not picked up by next tick."""
+    logger.warning("Draft %s permanent failure (%s): %s", draft_id, status, reason)
+    await conn.execute(
+        """
+        UPDATE war_room_drafts
+           SET status = $2,
+               lease_owner = NULL,
+               lease_acquired_at = NULL,
+               updated_at = NOW()
+         WHERE id = $1
+        """,
+        draft_id, status,
+    )
+
+
+async def reset_stale_leases(
+    conn: asyncpg.Connection, *, stale_after_minutes: int = 15,
+) -> list[UUID]:
+    """Watchdog: revert status='rendering' rows with old lease_acquired_at."""
+    rows = await conn.fetch(
+        """
+        UPDATE war_room_drafts
+           SET status = 'drafts_imaged_checked',
+               lease_owner = NULL,
+               lease_acquired_at = NULL,
+               updated_at = NOW()
+         WHERE status = 'rendering'
+           AND lease_acquired_at < NOW() - ($1 || ' minutes')::interval
+        RETURNING id
+        """,
+        str(stale_after_minutes),
+    )
+    return [r["id"] for r in rows]
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd ~/Desktop/nuzantara/apps/backend-rag && PYTHONPATH=. pytest backend/tests/unit/services/canva_renderer_v2/test_pg.py -v`
+
+Expected: 9 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Desktop/nuzantara
+git add apps/backend-rag/backend/services/canva_renderer_v2/_pg.py \
+        apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_pg.py
+git commit -m "feat(canva-renderer-v2): _pg.py asyncpg + lease CAS
+
+PG layer with:
+- is_kill_switch_enabled (system_settings.wr2_canva_renderer_enabled)
+- fetch_pending_draft_ids (pre-scan)
+- acquire_lease_and_fetch (CAS, returns None if lost race)
+- persist_canva_result (UPDATE status='rendered' + clear lease)
+- release_lease_transient (revert to drafts_imaged_checked)
+- release_lease_permanent (terminal status)
+- reset_stale_leases (watchdog recovery >15min)
+
+9 unit tests cover all paths with asyncpg mock.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+git push origin feat/wr2-canva-pdf-render-2026-05-13
+```
+
+---
+
+## Task 9: `_telemetry.py` JSONL append + log rotation
+
+**Files:**
+- Create: `apps/backend-rag/backend/services/canva_renderer_v2/_telemetry.py`
+- Create: `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_telemetry.py`
+
+- [ ] **Step 1: Write test**
+
+```python
+"""Telemetry: JSONL append-only with size-based rotation."""
+import json
+from pathlib import Path
+
+from backend.services.canva_renderer_v2._telemetry import log_telemetry
+
+
+def test_telemetry_append(tmp_path, monkeypatch):
+    log = tmp_path / "telemetry.jsonl"
+    monkeypatch.setenv("WR2_TELEMETRY_PATH", str(log))
+    log_telemetry(draft_id="abc", outcome="success", duration_s=12.3)
+    log_telemetry(draft_id="xyz", outcome="canva_import_failed", duration_s=4.5, attempt=2)
+    lines = log.read_text().strip().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["draft_id"] == "abc"
+    assert json.loads(lines[1])["attempt"] == 2
+
+
+def test_telemetry_swallows_io_error(tmp_path, monkeypatch):
+    # Point to unwritable path; must not raise
+    monkeypatch.setenv("WR2_TELEMETRY_PATH", "/proc/cannot-write-here.jsonl")
+    log_telemetry(draft_id="abc", outcome="success", duration_s=1.0)
+
+
+def test_telemetry_rotation_at_size_cap(tmp_path, monkeypatch):
+    log = tmp_path / "telemetry.jsonl"
+    monkeypatch.setenv("WR2_TELEMETRY_PATH", str(log))
+    monkeypatch.setenv("WR2_TELEMETRY_MAX_BYTES", "200")  # tiny cap for test
+    for i in range(20):
+        log_telemetry(draft_id=f"d{i}", outcome="success", duration_s=1.0)
+    # Rotated file should exist alongside
+    rotated = list(tmp_path.glob("telemetry.jsonl.*"))
+    assert len(rotated) >= 1
+```
+
+- [ ] **Step 2: Run to verify fails**
+
+Expected: FAIL `ModuleNotFoundError`.
+
+- [ ] **Step 3: Write implementation**
+
+```python
+"""Append-only JSONL telemetry with size-based rotation.
+
+Path: $WR2_TELEMETRY_PATH or ~/logs/wr2_canva_pdf_apply_telemetry.jsonl.
+Rotation: when file > $WR2_TELEMETRY_MAX_BYTES (default 50MB), rename
+to .jsonl.<timestamp>. Old rotated files auto-deleted via OS cron
+or manual cleanup (not this module's responsibility).
+
+Never raises — telemetry must never break the orchestrator.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _path() -> Path:
+    p = os.environ.get(
+        "WR2_TELEMETRY_PATH",
+        str(Path.home() / "logs" / "wr2_canva_pdf_apply_telemetry.jsonl"),
+    )
+    return Path(p)
+
+
+def _max_bytes() -> int:
+    return int(os.environ.get("WR2_TELEMETRY_MAX_BYTES", str(50 * 1024 * 1024)))
+
+
+def _maybe_rotate(path: Path) -> None:
+    if not path.exists():
+        return
+    if path.stat().st_size < _max_bytes():
+        return
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    rotated = path.with_suffix(path.suffix + f".{stamp}")
+    try:
+        path.rename(rotated)
+    except OSError as e:
+        logger.warning("Telemetry rotation failed: %s", e)
+
+
+def log_telemetry(
+    *, draft_id: str, outcome: str, duration_s: float,
+    attempt: int = 1, exc_head: str = "",
+) -> None:
+    try:
+        path = _path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _maybe_rotate(path)
+        record = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "draft_id": str(draft_id),
+            "attempt": attempt,
+            "outcome": outcome,
+            "duration_s": round(duration_s, 1),
+            "exc_head": exc_head[:240] if exc_head else "",
+        }
+        with open(path, "a") as f:
+            f.write(json.dumps(record) + "\n")
+    except Exception as e:  # noqa: BLE001 — telemetry must never break run
+        logger.warning("Telemetry write failed (swallowed): %s", e)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd ~/Desktop/nuzantara/apps/backend-rag && PYTHONPATH=. pytest backend/tests/unit/services/canva_renderer_v2/test_telemetry.py -v`
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Desktop/nuzantara
+git add apps/backend-rag/backend/services/canva_renderer_v2/_telemetry.py \
+        apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_telemetry.py
+git commit -m "feat(canva-renderer-v2): _telemetry.py JSONL with rotation
+
+Append-only JSONL at WR2_TELEMETRY_PATH (default
+~/logs/wr2_canva_pdf_apply_telemetry.jsonl). Size-based rotation at
+WR2_TELEMETRY_MAX_BYTES (default 50MB). Never raises.
+
+3 unit tests cover append, IO swallowing, rotation.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+git push origin feat/wr2-canva-pdf-render-2026-05-13
+```
+
+---
+
+## Task 10: `orchestrator.py` top-level integration + test
+
+**Files:**
+- Create: `apps/backend-rag/backend/services/canva_renderer_v2/orchestrator.py`
+- Create: `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_orchestrator.py`
+
+- [ ] **Step 1: Write the failing integration test**
+
+```python
+"""Orchestrator top-level: kill-switch + per-draft pipeline + happy path."""
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.services.canva_renderer_v2.orchestrator import (
+    ExitCode,
+    process_draft,
+    run,
+)
+
+
+@pytest.mark.asyncio
+async def test_run_exits_quiet_when_kill_switch_off():
+    with patch("backend.services.canva_renderer_v2.orchestrator._connect", new=AsyncMock()) as mc:
+        conn = AsyncMock()
+        conn.fetchval.return_value = "false"  # kill switch off
+        mc.return_value = conn
+        result = await run()
+        assert result == ExitCode.KILL_SWITCH_OFF
+
+
+@pytest.mark.asyncio
+async def test_process_draft_happy_path(tmp_path, monkeypatch):
+    """Full happy path: schema adapt → render → upload → import → persist."""
+    monkeypatch.setenv("TIGRIS_BUCKET", "test-bucket")
+
+    conn = AsyncMock()
+    conn.fetchrow.return_value = {
+        "id": "abc-uuid", "topic": "Test",
+        "tone": "ped", "slides_json": json.dumps({"slides": []}),
+    }
+
+    mcp_client = AsyncMock()
+    mcp_client.import_design_from_url.return_value = ("DAG123", "https://canva.com/design/DAG123/edit")
+    mcp_client.move_item_to_folder = AsyncMock()
+
+    s3 = MagicMock()
+
+    with patch(
+        "backend.services.canva_renderer_v2.orchestrator.render_pdf",
+        return_value=tmp_path / "fake.pdf",
+    ), patch(
+        "backend.services.canva_renderer_v2.orchestrator.upload_pdf",
+        return_value="https://nuzantara-warroom-images.fly.storage.tigris.dev/wr2-pdf/abc-uuid.pdf",
+    ), patch(
+        "backend.services.canva_renderer_v2.orchestrator.delete_pdf",
+    ):
+        (tmp_path / "fake.pdf").write_bytes(b"%PDF-1.4")
+        ok = await process_draft(
+            conn=conn, mcp_client=mcp_client, s3=s3,
+            draft_id="abc-uuid", lease_owner="pid@host",
+        )
+        assert ok is True
+        # persist_canva_result was called → status='rendered'
+        sql_calls = [c.args[0] for c in conn.execute.call_args_list]
+        assert any("status = 'rendered'" in s for s in sql_calls)
+
+
+@pytest.mark.asyncio
+async def test_process_draft_429_releases_transient_and_deletes_pdf(tmp_path):
+    """429 from MCP → release_lease_transient + Tigris delete."""
+    conn = AsyncMock()
+    conn.fetchrow.return_value = {
+        "id": "abc-uuid", "topic": "T", "tone": "ped",
+        "slides_json": json.dumps({"slides": []}),
+    }
+
+    mcp_client = AsyncMock()
+    err = Exception("429")
+    err.status_code = 429
+    mcp_client.import_design_from_url.side_effect = err
+
+    s3 = MagicMock()
+    deleted: list[str] = []
+
+    def fake_delete(s3_, **kwargs):
+        deleted.append(kwargs.get("draft_id", ""))
+
+    with patch(
+        "backend.services.canva_renderer_v2.orchestrator.render_pdf",
+        return_value=tmp_path / "fake.pdf",
+    ), patch(
+        "backend.services.canva_renderer_v2.orchestrator.upload_pdf",
+        return_value="https://test/wr2-pdf/abc-uuid.pdf",
+    ), patch(
+        "backend.services.canva_renderer_v2.orchestrator.delete_pdf",
+        side_effect=fake_delete,
+    ):
+        (tmp_path / "fake.pdf").write_bytes(b"%PDF-1.4")
+        ok = await process_draft(
+            conn=conn, mcp_client=mcp_client, s3=s3,
+            draft_id="abc-uuid", lease_owner="pid@host",
+        )
+        assert ok is False
+        assert "abc-uuid" in deleted
+        # release_lease_transient called → status='drafts_imaged_checked'
+        sql_calls = [c.args[0] for c in conn.execute.call_args_list]
+        assert any("status = 'drafts_imaged_checked'" in s for s in sql_calls)
+```
+
+- [ ] **Step 2: Run to verify fails**
+
+Expected: FAIL `ModuleNotFoundError`.
+
+- [ ] **Step 3: Write implementation**
+
+```python
+"""WR2 orchestrator top-level: composes all submodules.
+
+Flow per run():
+1. Connect to PG.
+2. Check kill switch — exit 3 if off.
+3. Reset stale leases (>15min watchdog).
+4. Fetch up to MAX_DRAFTS_PER_RUN pending draft IDs.
+5. For each ID: acquire CAS lease → process_draft().
+6. Close PG. Return ExitCode.
+
+Each draft has its own try/except so one failure doesn't block siblings.
+"""
+from __future__ import annotations
+
+import asyncio
+import enum
+import json
+import logging
+import os
+import socket
+import sys
+import time
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+import asyncpg
+
+from backend.services.canva_renderer_v2 import _pg
+from backend.services.canva_renderer_v2._canva_mcp import (
+    CanvaImportError, CanvaMcpClient, is_transient_error,
+)
+from backend.services.canva_renderer_v2._pdf_pipeline import PdfRenderError, render_pdf
+from backend.services.canva_renderer_v2._schema_adapter import (
+    adapt_legacy_schema, is_legacy_schema,
+)
+from backend.services.canva_renderer_v2._telegram import send_telegram
+from backend.services.canva_renderer_v2._telemetry import log_telemetry
+from backend.services.canva_renderer_v2._tigris import (
+    delete_pdf, get_s3_client, upload_pdf, TigrisError,
+)
+from backend.services.canva_renderer_v2._token_storage import TokenStorageError
+
+logger = logging.getLogger(__name__)
+
+MAX_DRAFTS_PER_RUN = 3
+STALE_LEASE_MINUTES = 15
+WR2_DRAFTS_FOLDER_ID = os.environ.get("WR2_DRAFTS_FOLDER_ID", "")
+WR2_DRAFTS_FOLDER_ID_E2E = os.environ.get("WR2_DRAFTS_FOLDER_ID_E2E", "")
+
+
+class ExitCode(enum.IntEnum):
+    OK = 0
+    TRANSIENT_ERROR = 1
+    CONFIG_INVALID = 2
+    KILL_SWITCH_OFF = 3
+    TOKEN_FILE_MISSING = 4
+    OAUTH_REFRESH_REVOKED = 5
+    FLOCK_CONTENTION = 6
+    TOKEN_CORRUPT = 7
+
+
+def _configure_logging() -> None:
+    log_dir = Path.home() / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+        handlers=[
+            logging.FileHandler(log_dir / "wr2_canva_pdf_apply.log"),
+            logging.StreamHandler(),
+        ],
+    )
+
+
+async def _connect(dsn: str) -> asyncpg.Connection:
+    return await asyncpg.connect(dsn, timeout=10)
+
+
+def _lease_owner() -> str:
+    return f"{os.getpid()}@{socket.gethostname()}"
+
+
+async def process_draft(
+    *, conn: asyncpg.Connection, mcp_client: CanvaMcpClient, s3: Any,
+    draft_id: UUID | str, lease_owner: str,
+) -> bool:
+    """Acquire lease + run pipeline. Returns True on success, False on any failure."""
+    row = await _pg.acquire_lease_and_fetch(conn, draft_id=draft_id, lease_owner=lease_owner)
+    if row is None:
+        return False  # lost race, silent
+
+    topic = row["topic"]
+    slides_raw = row["slides_json"]
+    slides = json.loads(slides_raw) if isinstance(slides_raw, str) else slides_raw
+
+    t0 = time.time()
+    e2e_mode = os.environ.get("WR2_E2E_MODE") == "true"
+    tigris_prefix = "wr2-pdf-tests" if e2e_mode else "wr2-pdf"
+    folder_id = WR2_DRAFTS_FOLDER_ID_E2E if e2e_mode else WR2_DRAFTS_FOLDER_ID
+
+    # Step A — schema adapt
+    if is_legacy_schema(slides):
+        slides = adapt_legacy_schema(slides, topic=topic)
+        logger.info("Draft %s: adapted legacy schema", draft_id)
+
+    # Step B — PDF render
+    pdf_path = Path(f"/tmp/wr2_{draft_id}.pdf")
+    try:
+        render_pdf(slides, draft_id=str(draft_id), out_path=pdf_path)
+    except PdfRenderError as e:
+        await _pg.release_lease_permanent(
+            conn, draft_id=draft_id, status="pdf_render_failed", reason=str(e),
+        )
+        send_telegram(f"🚨 WR2 PDF render FAILED\ndraft: `{draft_id}`\ntopic: {topic[:80]}\nerr: `{str(e)[:300]}`")
+        log_telemetry(draft_id=str(draft_id), outcome="pdf_render_failed",
+                      duration_s=time.time() - t0, exc_head=str(e))
+        return False
+
+    # Step C — Tigris upload
+    try:
+        pdf_url = upload_pdf(s3, pdf_path, draft_id=str(draft_id), prefix=tigris_prefix)
+    except TigrisError as e:
+        await _pg.release_lease_permanent(
+            conn, draft_id=draft_id, status="pdf_render_failed", reason=str(e),
+        )
+        send_telegram(f"🚨 WR2 Tigris upload FAILED\ndraft: `{draft_id}`\nerr: `{str(e)[:300]}`")
+        log_telemetry(draft_id=str(draft_id), outcome="tigris_failed",
+                      duration_s=time.time() - t0, exc_head=str(e))
+        return False
+
+    # Step D — Canva import
+    try:
+        design_id, edit_url = await mcp_client.import_design_from_url(pdf_url, title=topic[:80])
+    except Exception as e:
+        delete_pdf(s3, draft_id=str(draft_id), prefix=tigris_prefix)
+        if is_transient_error(e):
+            await _pg.release_lease_transient(conn, draft_id=draft_id, reason=f"{type(e).__name__}: {e}")
+            log_telemetry(draft_id=str(draft_id), outcome="canva_transient",
+                          duration_s=time.time() - t0, exc_head=str(e))
+        else:
+            await _pg.release_lease_permanent(
+                conn, draft_id=draft_id, status="canva_import_failed", reason=str(e),
+            )
+            send_telegram(f"🚨 WR2 Canva import FAILED\ndraft: `{draft_id}`\nerr: `{str(e)[:300]}`")
+            log_telemetry(draft_id=str(draft_id), outcome="canva_import_failed",
+                          duration_s=time.time() - t0, exc_head=str(e))
+        return False
+
+    # Step E — move-to-folder (best effort)
+    if folder_id:
+        await mcp_client.move_item_to_folder(design_id, folder_id)
+
+    # Step F — persist
+    try:
+        await _pg.persist_canva_result(
+            conn, draft_id=draft_id,
+            canva_design_id=design_id, canva_edit_url=edit_url, canva_view_url=None,
+        )
+    except Exception as e:  # noqa: BLE001
+        # Orphan: Canva design exists but DB didn't record. Alert + leave lease for watchdog.
+        send_telegram(
+            f"🚨 WR2 PG persist FAILED (Canva design EXISTS but DB unaware)\n"
+            f"draft: `{draft_id}` design: `{design_id}` err: `{str(e)[:300]}`"
+        )
+        log_telemetry(draft_id=str(draft_id), outcome="persist_failed",
+                      duration_s=time.time() - t0, exc_head=str(e))
+        return False
+
+    duration = time.time() - t0
+    send_telegram(f"🎨 WR2 rendered: {topic[:80]}\n{edit_url}\nduration: {duration:.1f}s")
+    log_telemetry(draft_id=str(draft_id), outcome="success", duration_s=duration)
+    pdf_path.unlink(missing_ok=True)
+    return True
+
+
+async def run() -> ExitCode:
+    _configure_logging()
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.critical("DATABASE_URL not set")
+        return ExitCode.CONFIG_INVALID
+
+    try:
+        conn = await _connect(dsn)
+    except Exception as e:
+        logger.error("PG connect failed: %s", e)
+        return ExitCode.TRANSIENT_ERROR
+
+    try:
+        if not await _pg.is_kill_switch_enabled(conn):
+            logger.info("wr2_canva_renderer_enabled != true — exiting quiet")
+            return ExitCode.KILL_SWITCH_OFF
+
+        # Stale lease watchdog (only emits Telegram, doesn't process)
+        recovered = await _pg.reset_stale_leases(conn, stale_after_minutes=STALE_LEASE_MINUTES)
+        if recovered:
+            send_telegram(
+                f"🪂 WR2 orchestrator recovered {len(recovered)} stale leases: "
+                f"{[str(x)[:8] for x in recovered[:5]]}"
+            )
+
+        draft_ids = await _pg.fetch_pending_draft_ids(conn, limit=MAX_DRAFTS_PER_RUN)
+        if not draft_ids:
+            logger.info("no pending drafts")
+            return ExitCode.OK
+
+        lease_owner = _lease_owner()
+        s3 = get_s3_client()
+
+        try:
+            async with CanvaMcpClient() as mcp_client:
+                for draft_id in draft_ids:
+                    try:
+                        await process_draft(
+                            conn=conn, mcp_client=mcp_client, s3=s3,
+                            draft_id=draft_id, lease_owner=lease_owner,
+                        )
+                    except Exception as exc:  # noqa: BLE001 — siblings
+                        logger.error("Draft %s unexpected exception: %s", draft_id, exc)
+                        try:
+                            await _pg.release_lease_transient(
+                                conn, draft_id=draft_id, reason=f"unexpected: {exc}"
+                            )
+                        except Exception:  # noqa: BLE001
+                            pass
+        except TokenStorageError as e:
+            msg = str(e).lower()
+            if "not found" in msg:
+                send_telegram(f"🚨 WR2 token file missing — run scripts/wr2_bootstrap_canva_oauth.py\n{e}")
+                return ExitCode.TOKEN_FILE_MISSING
+            if "hmac" in msg:
+                send_telegram(f"🚨 WR2 token file CORRUPT — manual repair\n{e}")
+                return ExitCode.TOKEN_CORRUPT
+            send_telegram(f"🚨 WR2 token storage error\n{e}")
+            return ExitCode.CONFIG_INVALID
+        except CanvaImportError as e:
+            if "refresh token revoked" in str(e).lower() or "interactive" in str(e).lower():
+                send_telegram(f"🚨 WR2 OAuth refresh revoked — re-bootstrap needed\n{e}")
+                return ExitCode.OAUTH_REFRESH_REVOKED
+            send_telegram(f"🚨 WR2 Canva MCP error: {e}")
+            return ExitCode.TRANSIENT_ERROR
+
+        return ExitCode.OK
+    finally:
+        await conn.close()
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd ~/Desktop/nuzantara/apps/backend-rag && PYTHONPATH=. pytest backend/tests/unit/services/canva_renderer_v2/test_orchestrator.py -v`
+
+Expected: 3 passed.
+
+Then run full suite to verify nothing else broke:
+
+```bash
+PYTHONPATH=. pytest backend/tests/unit/services/canva_renderer_v2/ -v
+```
+
+Expected: 47 passed (all from tasks 2-10).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Desktop/nuzantara
+git add apps/backend-rag/backend/services/canva_renderer_v2/orchestrator.py \
+        apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_orchestrator.py
+git commit -m "feat(canva-renderer-v2): orchestrator.py top-level integration
+
+Composes all canva_renderer_v2 submodules into top-level run():
+1. Connect PG → kill-switch check (exit 3)
+2. Stale-lease watchdog (>15min)
+3. Fetch up to MAX_DRAFTS_PER_RUN pending IDs
+4. Per-draft: acquire CAS lease → process_draft pipeline
+5. ExitCode enum maps exit codes 0/1/2/3/4/5/6/7
+
+process_draft handles:
+- schema adapt → render → Tigris upload → Canva import → folder move → persist
+- transient (429/5xx/network) → release_lease_transient + Tigris cleanup
+- permanent → release_lease_permanent + Telegram alert
+
+3 integration unit tests cover kill-switch + happy path + 429 transient.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+git push origin feat/wr2-canva-pdf-render-2026-05-13
+```
+
+---
+
+## Task 11: `scripts/wr2_canva_pdf_apply.py` thin entrypoint
+
+**Files:**
+- Create: `scripts/wr2_canva_pdf_apply.py`
+
+- [ ] **Step 1: Write entrypoint**
+
+```python
+#!/usr/bin/env python3
+"""WR2 Canva PDF orchestrator entrypoint — invoked by launchd plist every 5min.
+
+Thin wrapper around backend.services.canva_renderer_v2.orchestrator.run().
+Returns ExitCode integer for launchd SuccessfulExit evaluation.
+"""
+import asyncio
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "apps" / "backend-rag"))
+
+from backend.services.canva_renderer_v2.orchestrator import run  # noqa: E402
+
+
+if __name__ == "__main__":
+    exit_code = asyncio.run(run())
+    sys.exit(int(exit_code))
+```
+
+- [ ] **Step 2: Smoke import test (no PG/network)**
+
+```bash
+cd ~/Desktop/nuzantara/apps/backend-rag && source .venv/bin/activate
+python -c "import sys; sys.path.insert(0, 'apps/backend-rag'); from backend.services.canva_renderer_v2.orchestrator import run, ExitCode; print('OK', ExitCode.OK)"
+```
+
+Expected: `OK ExitCode.OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd ~/Desktop/nuzantara
+git add scripts/wr2_canva_pdf_apply.py
+chmod +x scripts/wr2_canva_pdf_apply.py
+git commit -m "feat(wr2): scripts/wr2_canva_pdf_apply.py thin entrypoint
+
+30-LOC launchd entrypoint. Adds apps/backend-rag to sys.path, runs
+orchestrator.run() via asyncio, exits with ExitCode integer.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+git push origin feat/wr2-canva-pdf-render-2026-05-13
+```
+
+---
+
+## Task 12: Bootstrap + watchdogs + E2E fixture creator
+
+**Files:**
+- Create: `scripts/wr2_bootstrap_canva_oauth.py`
+- Create: `scripts/wr2_canva_token_watchdog.py`
+- Create: `scripts/wr2_canva_lease_watchdog.py`
+- Create: `scripts/wr2_e2e_create_fixture_draft.py`
+
+- [ ] **Step 1: Write bootstrap script**
+
+```python
+#!/usr/bin/env python3
+"""WR2 Canva OAuth one-shot bootstrap.
+
+Run interactively on Pro (browser available):
+    export WR2_CANVA_TOKEN_FILE=~/.config/wr2/canva_tokens.json
+    export WR2_CANVA_HMAC_KEY=$(openssl rand -hex 32)  # save to ~/.nuzantara-secrets.env
+    python scripts/wr2_bootstrap_canva_oauth.py
+
+Performs:
+1. RFC 7591 dynamic client registration at mcp.canva.com/register
+2. OAuth authorization code flow via local HTTP callback (ephemeral port)
+3. Token exchange → token storage HMAC-signed
+4. Smoke test: list-brand-kits via MCP, assert Bali Zero team in result
+
+Idempotent: if token file already exists and is valid, prints status
+and exits. To force re-bootstrap: delete WR2_CANVA_TOKEN_FILE first.
+"""
+import asyncio
+import http.server
+import json
+import logging
+import os
+import socket
+import socketserver
+import sys
+import threading
+import time
+import urllib.parse
+import urllib.request
+import webbrowser
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "apps" / "backend-rag"))
+
+from backend.services.canva_renderer_v2._token_storage import (  # noqa: E402
+    OrchestratorTokenStorage, TokenStorageError, sign_payload,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("bootstrap")
+
+CANVA_REGISTER = "https://mcp.canva.com/register"
+CANVA_AUTHORIZE = "https://mcp.canva.com/authorize"
+CANVA_TOKEN = "https://mcp.canva.com/token"
+SCOPE = "user:read offline_access account:read teams:read"
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _register_client(redirect_uri: str) -> dict:
+    body = json.dumps({
+        "client_name": "WR2 Pipeline Orchestrator",
+        "redirect_uris": [redirect_uri],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+        "scope": SCOPE,
+    }).encode()
+    req = urllib.request.Request(
+        CANVA_REGISTER, data=body, headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=15) as r:
+        return json.loads(r.read())
+
+
+def _exchange_code(client_id: str, code: str, code_verifier: str, redirect_uri: str) -> dict:
+    body = urllib.parse.urlencode({
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "client_id": client_id,
+        "code_verifier": code_verifier,
+    }).encode()
+    req = urllib.request.Request(
+        CANVA_TOKEN, data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    with urllib.request.urlopen(req, timeout=15) as r:
+        return json.loads(r.read())
+
+
+def _smoke_test_list_brand_kits(access_token: str) -> bool:
+    body = json.dumps({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"protocolVersion": "2024-11-05", "capabilities": {},
+                   "clientInfo": {"name": "wr2-bootstrap", "version": "1.0"}},
+    }).encode()
+    req = urllib.request.Request(
+        "https://mcp.canva.com/mcp", data=body,
+        headers={"Content-Type": "application/json",
+                 "Accept": "application/json, text/event-stream",
+                 "Authorization": f"Bearer {access_token}"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            r.read(200)
+            logger.info("Smoke initialize: HTTP %s", r.status)
+            return True
+    except Exception as e:
+        logger.error("Smoke failed: %s", e)
+        return False
+
+
+def main() -> int:
+    storage = OrchestratorTokenStorage()
+    if storage.path.exists():
+        try:
+            storage.load_sync()
+            logger.info("Token file already exists and valid: %s", storage.path)
+            logger.info("To force re-bootstrap: rm %s", storage.path)
+            return 0
+        except TokenStorageError as e:
+            logger.warning("Existing token invalid, re-running bootstrap: %s", e)
+
+    port = _free_port()
+    redirect_uri = f"http://localhost:{port}/oauth/callback"
+    logger.info("Registering client at %s ...", CANVA_REGISTER)
+    client_info = _register_client(redirect_uri)
+    client_id = client_info["client_id"]
+    logger.info("client_id assigned: %s", client_id)
+
+    import base64, hashlib, secrets
+    code_verifier = secrets.token_urlsafe(96)[:128]
+    code_challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(code_verifier.encode()).digest()
+    ).rstrip(b"=").decode()
+    state = secrets.token_urlsafe(16)
+
+    auth_url = (
+        f"{CANVA_AUTHORIZE}?response_type=code&client_id={client_id}"
+        f"&redirect_uri={urllib.parse.quote(redirect_uri, safe='')}"
+        f"&scope={urllib.parse.quote(SCOPE)}"
+        f"&state={state}&code_challenge={code_challenge}&code_challenge_method=S256"
+    )
+
+    received: dict = {}
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            parsed = urllib.parse.urlparse(self.path)
+            params = urllib.parse.parse_qs(parsed.query)
+            received["code"] = params.get("code", [""])[0]
+            received["state"] = params.get("state", [""])[0]
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(
+                b"<html><body><h2>WR2 OAuth: code received. You can close this window.</h2></body></html>"
+            )
+
+        def log_message(self, format, *args):  # noqa: A002 — silence
+            pass
+
+    server = socketserver.TCPServer(("127.0.0.1", port), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    logger.info("Local callback server listening on %d. Opening browser ...", port)
+    webbrowser.open(auth_url)
+
+    # Wait for callback (max 5min)
+    for _ in range(300):
+        if received.get("code"):
+            break
+        time.sleep(1)
+    server.shutdown()
+
+    if not received.get("code"):
+        logger.error("No callback within 5min")
+        return 2
+    if received["state"] != state:
+        logger.error("State mismatch — possible CSRF")
+        return 2
+
+    logger.info("Exchanging code for tokens ...")
+    tokens = _exchange_code(client_id, received["code"], code_verifier, redirect_uri)
+
+    # Persist with HMAC. Use save_sync but enrich with client_info first.
+    payload = {
+        "client_id": client_id,
+        "client_secret": "",
+        "redirect_uris": [redirect_uri],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+        "scope": tokens.get("scope", SCOPE),
+        "access_token": tokens["access_token"],
+        "refresh_token": tokens.get("refresh_token", ""),
+        "token_type": tokens.get("token_type", "bearer"),
+        "expires_in": tokens.get("expires_in", 3600),
+    }
+    storage.save_sync(payload)
+    logger.info("Wrote token file: %s", storage.path)
+
+    # Smoke test
+    if _smoke_test_list_brand_kits(tokens["access_token"]):
+        logger.info("✅ Bootstrap complete")
+        return 0
+    logger.error("❌ Smoke failed — token might still work but verify manually")
+    return 3
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: Write `wr2_canva_token_watchdog.py`**
+
+```python
+#!/usr/bin/env python3
+"""Daily Canva OAuth refresh-token expiry watchdog.
+
+Canva refresh tokens decay ~90 days unused. This watchdog reads
+last_refreshed_iso from canva_tokens.json and alerts at 75d (warn)
+and 85d (critical). Runs daily via launchd 09:00 WITA.
+"""
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "apps" / "backend-rag"))
+
+from backend.services.canva_renderer_v2._token_storage import (  # noqa: E402
+    OrchestratorTokenStorage, TokenStorageError,
+)
+from backend.services.canva_renderer_v2._telegram import send_telegram  # noqa: E402
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("token-watchdog")
+
+
+def main() -> int:
+    try:
+        storage = OrchestratorTokenStorage()
+        data = storage.load_sync()
+    except TokenStorageError as e:
+        send_telegram(f"🚨 WR2 Canva token UNREADABLE\n{e}")
+        return 1
+
+    last_iso = data.get("last_refreshed_iso")
+    if not last_iso:
+        logger.warning("No last_refreshed_iso — bootstrap predates this field")
+        return 0
+
+    last = datetime.fromisoformat(last_iso.replace("Z", "+00:00"))
+    now = datetime.now(timezone.utc)
+    days = (now - last).days
+
+    if days > 85:
+        send_telegram(
+            f"🚨 *WR2 Canva refresh CRITICAL*\nDays since last refresh: {days}\n"
+            f"Token decays at 90d — re-bootstrap NOW.\nRun: scripts/wr2_bootstrap_canva_oauth.py"
+        )
+    elif days > 75:
+        send_telegram(
+            f"⚠️ *WR2 Canva refresh WARN*\nDays since last refresh: {days}\n"
+            f"Plan re-bootstrap within 15 days."
+        )
+    logger.info("Days since last refresh: %d", days)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 3: Write `wr2_canva_lease_watchdog.py`**
+
+```python
+#!/usr/bin/env python3
+"""10-min watchdog: reset stale war_room_drafts.status='rendering' leases."""
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "apps" / "backend-rag"))
+
+import asyncpg  # noqa: E402
+
+from backend.services.canva_renderer_v2._pg import reset_stale_leases  # noqa: E402
+from backend.services.canva_renderer_v2._telegram import send_telegram  # noqa: E402
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("lease-watchdog")
+
+
+async def main() -> int:
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.critical("DATABASE_URL not set")
+        return 2
+    conn = await asyncpg.connect(dsn, timeout=10)
+    try:
+        recovered = await reset_stale_leases(conn, stale_after_minutes=15)
+        if recovered:
+            ids_short = [str(x)[:8] for x in recovered[:5]]
+            send_telegram(
+                f"🪂 WR2 stale-lease watchdog recovered {len(recovered)}: {ids_short}"
+            )
+            logger.info("Recovered %d stale leases", len(recovered))
+        return 0
+    finally:
+        await conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))
+```
+
+- [ ] **Step 4: Write `wr2_e2e_create_fixture_draft.py`**
+
+```python
+#!/usr/bin/env python3
+"""Create a synthetic war_room_drafts row for E2E testing.
+
+Inserts a draft with fixed UUID 00000000-0000-0000-e2e0-000000000001,
+client_id 'e2e_test_client', topic prefixed [E2E TEST], status
+'drafts_imaged_checked'.
+
+Idempotent: ON CONFLICT (id) UPDATE re-resets fields for re-run.
+"""
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+import asyncpg
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("e2e-fixture")
+
+FIXTURE_UUID = "00000000-0000-0000-e2e0-000000000001"
+FIXTURE_CLIENT = "e2e_test_client"
+
+SLIDES_JSON = {
+    "carousel_id": "e2e-smoke",
+    "slide_count": 2,
+    "slides": [
+        {"index": 1, "layout_family": "cover-photo",
+         "heading": "[E2E TEST] WR2 Pipeline Smoke",
+         "subheading": "Synthetic test draft",
+         "body": "If you see this in Canva, the pipeline works."},
+        {"index": 2, "layout_family": "statement-bomb",
+         "statement": "E2E success."},
+    ],
+}
+
+
+async def main() -> int:
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.critical("DATABASE_URL not set")
+        return 2
+    conn = await asyncpg.connect(dsn, timeout=10)
+    try:
+        await conn.execute(
+            """
+            INSERT INTO war_room_drafts
+              (id, topic, register, slides_json, status, created_at, updated_at)
+            VALUES ($1, $2, $3, $4::jsonb, 'drafts_imaged_checked', NOW(), NOW())
+            ON CONFLICT (id) DO UPDATE
+              SET topic = EXCLUDED.topic,
+                  slides_json = EXCLUDED.slides_json,
+                  status = 'drafts_imaged_checked',
+                  canva_edit_url = NULL,
+                  canva_design_id = NULL,
+                  lease_owner = NULL,
+                  lease_acquired_at = NULL,
+                  updated_at = NOW()
+            """,
+            FIXTURE_UUID, "[E2E TEST] WR2 Pipeline Smoke",
+            "pedagogico", json.dumps(SLIDES_JSON),
+        )
+        logger.info("E2E fixture draft ready: id=%s", FIXTURE_UUID)
+        return 0
+    finally:
+        await conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))
+```
+
+- [ ] **Step 5: Smoke-import all 4 scripts**
+
+```bash
+cd ~/Desktop/nuzantara
+for f in scripts/wr2_bootstrap_canva_oauth.py scripts/wr2_canva_token_watchdog.py \
+         scripts/wr2_canva_lease_watchdog.py scripts/wr2_e2e_create_fixture_draft.py; do
+  python -c "import ast; ast.parse(open('$f').read()); print('$f: syntax OK')"
+done
+```
+
+Expected: 4 × "syntax OK".
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ~/Desktop/nuzantara
+chmod +x scripts/wr2_bootstrap_canva_oauth.py \
+         scripts/wr2_canva_token_watchdog.py \
+         scripts/wr2_canva_lease_watchdog.py \
+         scripts/wr2_e2e_create_fixture_draft.py
+git add scripts/wr2_bootstrap_canva_oauth.py \
+        scripts/wr2_canva_token_watchdog.py \
+        scripts/wr2_canva_lease_watchdog.py \
+        scripts/wr2_e2e_create_fixture_draft.py
+git commit -m "feat(wr2): bootstrap + token/lease watchdogs + E2E fixture creator
+
+- wr2_bootstrap_canva_oauth.py: RFC 7591 dynamic registration + OAuth
+  authorization code + PKCE + local HTTP callback + token persist with
+  HMAC + smoke test.
+- wr2_canva_token_watchdog.py: daily watchdog reads last_refreshed_iso,
+  Telegram alert at 75d (warn) / 85d (critical) of 90d Canva decay.
+- wr2_canva_lease_watchdog.py: 10min watchdog resets >15min stale
+  war_room_drafts.status='rendering' leases.
+- wr2_e2e_create_fixture_draft.py: synthetic draft with fixed UUID
+  for E2E smoke testing.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+git push origin feat/wr2-canva-pdf-render-2026-05-13
+```
+
+---
+
+## Task 13: launchd plist files
+
+**Files:**
+- Create: `infra/launchagents/com.balizero.wr2.canva-renderer.plist`
+- Create: `infra/launchagents/com.balizero.wr2.canva-token-watchdog.daily.plist`
+- Create: `infra/launchagents/com.balizero.wr2.canva-lease-watchdog.10min.plist`
+
+- [ ] **Step 1: Write renderer plist**
+
+`infra/launchagents/com.balizero.wr2.canva-renderer.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.balizero.wr2.canva-renderer</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/zsh</string>
+    <string>-lc</string>
+    <string>source ~/.nuzantara-secrets.env 2>/dev/null; exec /opt/homebrew/bin/flock -n /tmp/wr2_canva_pdf_apply.lock /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -u /Users/nuzantara/Desktop/nuzantara/scripts/wr2_canva_pdf_apply.py</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>/Users/nuzantara/Desktop/nuzantara</string>
+  <key>StartInterval</key>
+  <integer>300</integer>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>SuccessfulExit</key>
+  <array>
+    <integer>0</integer>
+    <integer>3</integer>
+    <integer>4</integer>
+    <integer>5</integer>
+    <integer>7</integer>
+  </array>
+  <key>ThrottleInterval</key>
+  <integer>300</integer>
+  <key>StandardOutPath</key>
+  <string>/Users/nuzantara/logs/wr2_canva_pdf_apply.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/nuzantara/logs/wr2_canva_pdf_apply.error.log</string>
+</dict>
+</plist>
+```
+
+- [ ] **Step 2: Write daily token watchdog plist**
+
+`infra/launchagents/com.balizero.wr2.canva-token-watchdog.daily.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.balizero.wr2.canva-token-watchdog</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/zsh</string>
+    <string>-lc</string>
+    <string>source ~/.nuzantara-secrets.env 2>/dev/null; exec /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -u /Users/nuzantara/Desktop/nuzantara/scripts/wr2_canva_token_watchdog.py</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>/Users/nuzantara/Desktop/nuzantara</string>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>9</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>StandardOutPath</key>
+  <string>/Users/nuzantara/logs/wr2_canva_token_watchdog.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/nuzantara/logs/wr2_canva_token_watchdog.error.log</string>
+</dict>
+</plist>
+```
+
+- [ ] **Step 3: Write 10-min lease watchdog plist**
+
+`infra/launchagents/com.balizero.wr2.canva-lease-watchdog.10min.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.balizero.wr2.canva-lease-watchdog</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/zsh</string>
+    <string>-lc</string>
+    <string>source ~/.nuzantara-secrets.env 2>/dev/null; exec /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -u /Users/nuzantara/Desktop/nuzantara/scripts/wr2_canva_lease_watchdog.py</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>/Users/nuzantara/Desktop/nuzantara</string>
+  <key>StartInterval</key>
+  <integer>600</integer>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>ThrottleInterval</key>
+  <integer>600</integer>
+  <key>StandardOutPath</key>
+  <string>/Users/nuzantara/logs/wr2_canva_lease_watchdog.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/nuzantara/logs/wr2_canva_lease_watchdog.error.log</string>
+</dict>
+</plist>
+```
+
+- [ ] **Step 4: Validate plist syntax**
+
+```bash
+cd ~/Desktop/nuzantara
+for p in infra/launchagents/com.balizero.wr2.canva-renderer.plist \
+         infra/launchagents/com.balizero.wr2.canva-token-watchdog.daily.plist \
+         infra/launchagents/com.balizero.wr2.canva-lease-watchdog.10min.plist; do
+  plutil -lint "$p"
+done
+```
+
+Expected: `OK` × 3.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Desktop/nuzantara
+git add infra/launchagents/com.balizero.wr2.canva-renderer.plist \
+        infra/launchagents/com.balizero.wr2.canva-token-watchdog.daily.plist \
+        infra/launchagents/com.balizero.wr2.canva-lease-watchdog.10min.plist
+git commit -m "feat(infra): launchd plist for v2 renderer + 2 watchdogs
+
+- canva-renderer.plist: 5min interval, /bin/zsh -lc wrapper sourcing
+  ~/.nuzantara-secrets.env, /opt/homebrew/bin/flock -n single-instance
+  guard, SuccessfulExit array [0,3,4,5,7] to suppress restart loops.
+- canva-token-watchdog.daily.plist: 09:00 WITA refresh-token expiry
+  check.
+- canva-lease-watchdog.10min.plist: 10min stale-lease recovery.
+
+All 3 validated via plutil -lint.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+git push origin feat/wr2-canva-pdf-render-2026-05-13
+```
+
+---
+
+## Task 14: Production runbook + cicatrix scar update
+
+**Files:**
+- Create: `docs/runbooks/wr2-orchestrator-pdf-render-runbook.md`
+- Modify: `.claude/rules/cicatrix-scars.md` (status section of DAHJEkWpkzY scar)
+
+- [ ] **Step 1: Write runbook**
+
+Create `docs/runbooks/wr2-orchestrator-pdf-render-runbook.md`:
+
+```markdown
+# WR2 Orchestrator PDF Render — Production Runbook
+
+## Initial deployment (one-time)
+
+### 1. Generate HMAC key
+
+```bash
+echo "WR2_CANVA_HMAC_KEY=$(openssl rand -hex 32)" >> ~/.nuzantara-secrets.env
+echo "WR2_CANVA_TOKEN_FILE=$HOME/.config/wr2/canva_tokens.json" >> ~/.nuzantara-secrets.env
+echo "WR2_DRAFTS_FOLDER_ID=<your-canva-folder-id>" >> ~/.nuzantara-secrets.env
+mkdir -p ~/.config/wr2 && chmod 700 ~/.config/wr2
+```
+
+### 2. Apply DB migration
+
+```bash
+ssh into Fly or run via flycast tunnel:
+psql -h 127.0.0.1 -p 15432 -U postgres -d nuzantara_rag \
+  -f apps/backend-rag/backend/db/migrations_v2/146_wr2_draft_lease.sql
+```
+
+### 3. Apply Tigris S3 lifecycle
+
+```bash
+source ~/.nuzantara-secrets.env
+aws s3api put-bucket-lifecycle-configuration \
+  --bucket nuzantara-warroom-images \
+  --lifecycle-configuration file://infra/tigris/wr2-pdf-lifecycle.json \
+  --endpoint-url https://fly.storage.tigris.dev
+```
+
+### 4. Bootstrap Canva OAuth
+
+```bash
+source ~/.nuzantara-secrets.env
+cd ~/Desktop/nuzantara
+apps/backend-rag/.venv/bin/python scripts/wr2_bootstrap_canva_oauth.py
+# Browser opens. Authorize Bali Zero team. Wait "✅ Bootstrap complete".
+ls -la ~/.config/wr2/canva_tokens.json  # mode 0600
+```
+
+### 5. Install plists
+
+```bash
+cp infra/launchagents/com.balizero.wr2.canva-renderer.plist ~/Library/LaunchAgents/
+cp infra/launchagents/com.balizero.wr2.canva-token-watchdog.daily.plist ~/Library/LaunchAgents/
+cp infra/launchagents/com.balizero.wr2.canva-lease-watchdog.10min.plist ~/Library/LaunchAgents/
+```
+
+### 6. Flip PG kill switch + bootstrap plists
+
+```bash
+psql -h 127.0.0.1 -p 15432 -U postgres -d nuzantara_rag \
+  -c "UPDATE system_settings SET value='true' WHERE key='wr2_canva_renderer_enabled'"
+
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.balizero.wr2.canva-renderer.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.balizero.wr2.canva-token-watchdog.daily.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.balizero.wr2.canva-lease-watchdog.10min.plist
+```
+
+### 7. Monitor first 2-3 ticks
+
+```bash
+tail -F ~/logs/wr2_canva_pdf_apply.log
+
+psql -h 127.0.0.1 -p 15432 -U postgres -d nuzantara_rag \
+  -c "SELECT id, status, canva_edit_url FROM war_room_drafts
+      WHERE updated_at > NOW() - INTERVAL '15 minutes'
+      ORDER BY updated_at DESC LIMIT 10"
+```
+
+## End-to-end smoke (after deployment)
+
+```bash
+# 1. Insert synthetic draft
+python scripts/wr2_e2e_create_fixture_draft.py
+
+# 2. Wait <=5 minutes for the next cron tick.
+
+# 3. Verify
+psql -c "SELECT status, canva_edit_url FROM war_room_drafts
+         WHERE id = '00000000-0000-0000-e2e0-000000000001'"
+# Expected: status='rendered', canva_edit_url populated.
+```
+
+## Rollback
+
+```bash
+launchctl bootout gui/$(id -u)/com.balizero.wr2.canva-renderer
+psql -c "UPDATE system_settings SET value='false' WHERE key='wr2_canva_renderer_enabled'"
+```
+
+## Diagnostics
+
+| Symptom | Check | Fix |
+|---|---|---|
+| "Exit 4" in log | `ls ~/.config/wr2/canva_tokens.json` | Bootstrap step 4 |
+| "Exit 5" in log | Telegram says "refresh revoked" | Re-bootstrap step 4 |
+| "Exit 7" in log | HMAC corruption | Backup at `.broken-*.json`, re-bootstrap |
+| Drafts stuck `rendering` | Lease watchdog 10min interval | Should self-heal in ≤25min |
+| Canva 429 spam | Tigris/MCP rate | Reduce MAX_DRAFTS_PER_RUN |
+
+## Refresh-token expiry handling
+
+Canva refresh tokens decay ~90 days. Telegram alerts at 75d (warn) and
+85d (critical). Re-bootstrap:
+
+```bash
+rm ~/.config/wr2/canva_tokens.json
+apps/backend-rag/.venv/bin/python scripts/wr2_bootstrap_canva_oauth.py
+```
+```
+
+- [ ] **Step 2: Update cicatrix scar**
+
+Modify `~/Desktop/nuzantara/.claude/rules/cicatrix-scars.md`, find the section starting `### ⚠️ STRUCTURAL: WR2 master template requires verified richtext slot count (2026-05-10 → architecturally bypassed 2026-05-13)` and append in the **RESOLUTION** block at the bottom:
+
+```markdown
+
+**2026-05-13 v3 orchestrator end-to-end live** (commit `<final-tag>`):
+
+The new `canva_renderer_v2` orchestrator + `wr2_canva_pdf_apply.py`
+script is live on Pro via `com.balizero.wr2.canva-renderer.plist`.
+End-to-end loop closed: PG draft → ReportLab → Tigris → Canva
+`import-design-from-url` → PG update. No master template required.
+
+First production draft processed: `<draft_id>` at `<timestamp>`,
+duration `<X>s`. Tigris S3 lifecycle policy active (30d/1d retention).
+Token + lease watchdogs running.
+
+Legacy `wr2_canva_apply.py` remains in repo for ~2 weeks as
+documented fallback, then removed in cleanup PR. Kill switch
+`system_settings.wr2_canva_renderer_enabled='true'` flipped.
+
+Scar now archival — orchestrator architecture moved past the master
+template dependency entirely. Validation gap permanently closed.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd ~/Desktop/nuzantara
+git add docs/runbooks/wr2-orchestrator-pdf-render-runbook.md \
+        .claude/rules/cicatrix-scars.md
+git commit -m "docs(wr2): production runbook + cicatrix scar update v3 live
+
+- runbook covers initial deployment (7 steps), E2E smoke, rollback,
+  diagnostics, refresh-token expiry handling
+- cicatrix scar DAHJEkWpkzY validation gap appends 2026-05-13 v3
+  live resolution note
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+git push origin feat/wr2-canva-pdf-render-2026-05-13
+```
+
+---
+
+## Task 15: Open PR + final acceptance
+
+- [ ] **Step 1: Confirm all 14 prior tasks committed and pushed**
+
+```bash
+cd ~/Desktop/nuzantara
+git log --oneline -20 | head -20
+# Expected: 14+ commits since branch root (fbba52327)
+```
+
+- [ ] **Step 2: Run full unit-test suite locally**
+
+```bash
+cd ~/Desktop/nuzantara/apps/backend-rag && source .venv/bin/activate
+PYTHONPATH=. pytest backend/tests/unit/services/canva_renderer_v2/ -v
+```
+
+Expected: ~47-50 unit tests, all passing.
+
+- [ ] **Step 3: Open PR**
+
+```bash
+cd ~/Desktop/nuzantara
+gh pr create --base main --head feat/wr2-canva-pdf-render-2026-05-13 \
+  --title "feat(wr2): orchestrator PDF render pipeline (replaces legacy canva-apply)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Replaces legacy `scripts/wr2_canva_apply.py` (50% MCP cold-fail rate) with deterministic Python orchestrator using `mcp` SDK 1.12.4 + httpx + boto3 + asyncpg.
+- New `canva_renderer_v2` package (~1100 LOC across 10 modules), 4 scripts, 3 launchd plists, 1 SQL migration, S3 lifecycle JSON.
+- OAuth tokens orchestrator-owned at `~/.config/wr2/canva_tokens.json` with HMAC + flock + proactive refresh, decoupled from `mcp-remote` cache.
+- Per-draft CAS lease prevents overlapping launchd-tick double-processing.
+- Tigris orphan PDFs cleaned via S3 lifecycle + explicit cleanup on failure.
+- Transient-vs-permanent classifier (429/5xx/network → retry; 4xx structural → terminal).
+- Spec at `docs/superpowers/specs/2026-05-13-wr2-orchestrator-pdf-render-design.md` (passed 3-LLM panel review: Gemini + GPT-5.5 + DeepSeek V4 Pro).
+
+## Test plan
+
+- [ ] All ~50 unit tests pass: `pytest backend/tests/unit/services/canva_renderer_v2/ -v`
+- [ ] DB migration 146 applies cleanly + rollback restores
+- [ ] Squawk lint passes on migration
+- [ ] `plutil -lint` passes on 3 plist files
+- [ ] Bootstrap script obtains Canva OAuth tokens (manual on Pro)
+- [ ] Token watchdog detects 75d/85d threshold (manual time-travel test)
+- [ ] Lease watchdog recovers stale lease (manual insert + verify)
+- [ ] E2E fixture draft processes end-to-end (run after deployment)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Validate spec coverage**
+
+Manually open `docs/superpowers/specs/2026-05-13-wr2-orchestrator-pdf-render-design.md` side-by-side with PR diff and tick each acceptance gate in §10. Address any gap found before requesting merge.
+
+---
+
+## Self-review checklist
+
+After plan written, verify:
+
+**1. Spec coverage:** Every section of the spec maps to ≥1 task:
+- §1 Background → Task 1 (migration sets up DB) + Task 14 (runbook recap)
+- §2 Architecture / Module decomp → Tasks 2-10 (one module per task)
+- §3 Token storage → Task 6 (storage) + Task 12 (bootstrap)
+- §4 Per-draft flow + Lease + Failure classification → Task 1 (DB) + Task 8 (PG layer) + Task 10 (orchestrator)
+- §5 launchd plist + Kill switch + S3 lifecycle + Stale lease watchdog → Task 5 (lifecycle JSON) + Task 12 (lease watchdog script) + Task 13 (plists) + Task 14 (runbook)
+- §6 Testing strategy + E2E isolation → unit tests embedded in tasks 2-10 + Task 12 (E2E fixture script)
+- §7 Deliverables + commit plan → this 15-task structure mirrors §7.3
+
+**2. Placeholder scan:** No `TBD`, `TODO`, `placeholder`, `...similar to`, or "add appropriate" found in code blocks.
+
+**3. Type consistency:**
+- `process_draft` signature in test_orchestrator.py matches definition in orchestrator.py (both take `conn`, `mcp_client`, `s3`, `draft_id`, `lease_owner` kwargs).
+- `acquire_lease_and_fetch` return type `dict[str, Any] | None` matches usage in orchestrator.py.
+- `ExitCode` enum used identically in test_orchestrator.py and orchestrator.py.
+- `parse_design_id` defined in `_canva_mcp.py`, tested in `test_canva_mcp.py`, called in `_canva_mcp.py:CanvaMcpClient.import_design_from_url`.
+
+All consistent.
+
+---

--- a/docs/superpowers/specs/2026-05-13-wr2-orchestrator-pdf-render-design.md
+++ b/docs/superpowers/specs/2026-05-13-wr2-orchestrator-pdf-render-design.md
@@ -254,6 +254,21 @@ operation on Pro.
 
 ## 4. Per-draft flow and error handling
 
+### 4.0 Cross-LLM panel revisions (2026-05-13, post sez 4-7 review)
+
+3-LLM panel (Gemini + GPT-5.5 codex + DeepSeek V4 Pro) caught **6 flaws**
+in earlier sez 4-7 drafts. Applied inline below; full table in §1.4.
+
+| Convergence | Flaw | Mitigation in this section |
+|---|---|---|
+| 2/3 (high) | **Per-draft lease / idempotency** — overlapping launchd run can double-process same draft mid-tigris-upload, before PG UPDATE | §4.1.1 lease table |
+| 3/3 (medium) | **Tigris orphan PDF** on `canva_import_failed` path | §4.3 cleanup step |
+| 2/3 (high) | **Overlapping launchd runs** — default launchd does NOT serialize a job with itself on `StartInterval` | §5.1 LaunchOnlyOnce + flock advisory in orchestrator |
+| 2/3 (high) | **429/5xx → mark `canva_import_failed` aggressive** — should backoff + leave in `drafts_imaged_checked` for retry | §4.3 transient-vs-permanent classifier |
+| 2/3 (high) | **Plist envvar rotation gap** — secrets baked at bootstrap, no hot-reload | §5.1 zsh wrapper `source ~/.nuzantara-secrets.env && exec ...` (consistent with legacy plist) |
+| 2/3 (medium) | **E2E test on real PG draft pollutes production** | §6.4 synthetic `e2e_test_client` + namespaced Tigris prefix + dedicated Canva folder |
+| 2/3 (split) | **Commit ordering bisectability** — keep imports green at every commit | §7.3 restructure |
+
 ### 4.1 Draft lifecycle
 
 ```
@@ -281,6 +296,37 @@ Two new terminal status values are added to the schema vocabulary:
 Both are terminal and NOT picked up by the next cron tick. Antonello
 manually re-promotes them to `drafts_imaged_checked` after fixing the
 underlying issue.
+
+### 4.1.1 Per-draft lease (new, post-panel)
+
+Race condition discovered by panel: even with `MAX_DRAFTS_PER_RUN=3`,
+two overlapping orchestrator runs (slow MCP call extending past 5min
+StartInterval) can both SELECT the same draft, double-upload PDF to
+Tigris, and double-import to Canva.
+
+**Fix — compare-and-swap status transition** at fetch time:
+
+```sql
+UPDATE war_room_drafts
+   SET status = 'rendering',
+       lease_owner = $1,           -- new column: text (orchestrator PID + hostname)
+       lease_acquired_at = NOW()    -- new column: timestamptz
+ WHERE id = $2
+   AND status = 'drafts_imaged_checked'
+   AND canva_edit_url IS NULL
+RETURNING id, topic, register, slides_json
+```
+
+Only the row that wins the CAS is processed. After success → status
+`'rendered'` clears the lease. After terminal failure → status
+`'pdf_render_failed'` / `'canva_import_failed'` clears the lease.
+
+Stale lease watchdog: `lease_acquired_at < NOW() - INTERVAL '15 minutes'`
+AND `status='rendering'` → reset to `'drafts_imaged_checked'`,
+nullify lease fields, alert Telegram (orphan recovery).
+
+Schema migration: new SQL v2 migration `NNN_wr2_draft_lease.sql` adds
+`lease_owner text` + `lease_acquired_at timestamptz` to `war_room_drafts`.
 
 ### 4.2 Per-draft pseudo-code
 
@@ -338,19 +384,37 @@ async def _apply_one_draft(conn, mcp_session, row, *, dsn):
     return True
 ```
 
-### 4.3 Failure classification
+### 4.3 Failure classification (revised post-panel)
 
-| Failure point | New status | Retry-able? | Alert? |
-|---|---|---|---|
-| A schema adapt KeyError | no DB change | no, fixable in code | logger.error, no Telegram |
-| B PDF render exit≠0 | `pdf_render_failed` | manual re-promote | Telegram |
-| B subprocess timeout 120s | `pdf_render_failed` | manual | Telegram |
-| C Tigris boto3 ClientError | `pdf_render_failed` | auto 3 retry then terminal | Telegram |
-| D MCP call_tool raises | `canva_import_failed` | manual | Telegram (escalation) |
-| D OAuth token expired AND refresh succeeded | (transparent retry) | yes | no |
-| D OAuth refresh revoked | (orchestrator exits 5) | re-bootstrap | Telegram high prio |
-| E move-to-folder fails | status stays `rendered` | non-fatal | warn log |
-| F PG UPDATE crashes | orphan (Canva exists, DB unaware) | reconnect-on-dead-conn (legacy) | Telegram persist_failed |
+Two new classes added for panel feedback: **transient** (retry naturally
+next cron tick, stay in `drafts_imaged_checked` after lease release)
+vs **permanent** (mark terminal). MCP 429/5xx and OAuth transient errors
+are transient; structural failures are permanent.
+
+| Failure point | Classification | DB status | Lease release | Tigris cleanup | Telegram |
+|---|---|---|---|---|---|
+| A schema adapt KeyError | permanent | `pdf_render_failed` | yes | n/a (pre-upload) | yes |
+| B PDF render exit≠0 | permanent | `pdf_render_failed` | yes | n/a | yes |
+| B subprocess timeout 120s | permanent | `pdf_render_failed` | yes | n/a | yes |
+| C Tigris boto3 ClientError (3 retry exh) | permanent | `pdf_render_failed` | yes | best-effort delete partial | yes |
+| D MCP `call_tool` raises 429 / 5xx / Retry-After | **transient** | revert to `drafts_imaged_checked` | yes | **delete uploaded PDF** | warn log only |
+| D MCP `call_tool` raises 4xx structural | permanent | `canva_import_failed` | yes | **delete uploaded PDF** | yes (escalation) |
+| D OAuth token expired AND refresh succeeded | transparent retry | (no change mid-flow) | held | n/a | no |
+| D OAuth refresh revoked | (orchestrator exits 5) | revert to `drafts_imaged_checked` | yes | **delete uploaded PDF** | yes high prio |
+| E move-to-folder fails | non-fatal | stays `rendered` | yes | n/a | warn log |
+| F PG UPDATE crashes | orphan | (Canva exists, DB unaware) | held → watchdog resets | n/a | yes persist_failed |
+
+**Tigris cleanup (new step §4.3.1)**: on transient or permanent path D
+failure, orchestrator MUST call `boto3.delete_object` on the uploaded
+PDF before mutating DB. Best-effort: failure to delete is logged but
+does not change status flow (S3 lifecycle policy is the safety net,
+see §5.6).
+
+**Backoff classifier**: MCP responses with `Retry-After` header or
+HTTP 429/502/503/504 → classified transient. Other HTTP 4xx →
+permanent. `httpx.NetworkError` / `httpx.TimeoutException` → transient
+with cap (after 3 consecutive transient failures on same draft across
+ticks, escalate to permanent).
 
 ### 4.4 Inherited patterns from legacy
 
@@ -368,10 +432,19 @@ Three patterns from `scripts/wr2_canva_apply.py` are reused verbatim:
 
 ## 5. launchd plist and operational lifecycle
 
-### 5.1 Production plist
+### 5.1 Production plist (revised post-panel)
 
-File: `infra/launchagents/com.balizero.wr2.canva-renderer.plist`
-(replaces existing plist of same label):
+Two changes from v1 driven by panel:
+
+1. **No inline `EnvironmentVariables`** — use bash wrapper that sources
+   `~/.nuzantara-secrets.env` at execution time. Fresh secrets every
+   tick, no `bootout`+`bootstrap` for rotation. Consistent with legacy
+   plist convention (verified empirically via `launchctl print`).
+2. **Single-instance flock** in `ProgramArguments` wrapper — prevents
+   overlapping runs from launchd (StartInterval=300 doesn't serialize
+   on slow tick).
+
+File: `infra/launchagents/com.balizero.wr2.canva-renderer.plist`:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -382,34 +455,12 @@ File: `infra/launchagents/com.balizero.wr2.canva-renderer.plist`
   <string>com.balizero.wr2.canva-renderer</string>
   <key>ProgramArguments</key>
   <array>
-    <string>/Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python</string>
-    <string>/Users/nuzantara/Desktop/nuzantara/scripts/wr2_canva_pdf_apply.py</string>
+    <string>/bin/zsh</string>
+    <string>-lc</string>
+    <string>source ~/.nuzantara-secrets.env 2>/dev/null; exec /opt/homebrew/bin/flock -n /tmp/wr2_canva_pdf_apply.lock /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -u /Users/nuzantara/Desktop/nuzantara/scripts/wr2_canva_pdf_apply.py</string>
   </array>
   <key>WorkingDirectory</key>
   <string>/Users/nuzantara/Desktop/nuzantara</string>
-  <key>EnvironmentVariables</key>
-  <dict>
-    <key>PATH</key>
-    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
-    <key>DATABASE_URL</key>
-    <string>postgresql://...127.0.0.1:15432/nuzantara_rag</string>
-    <key>WR2_CANVA_TOKEN_FILE</key>
-    <string>/Users/nuzantara/.config/wr2/canva_tokens.json</string>
-    <key>WR2_CANVA_HMAC_KEY</key>
-    <string>${SECRET_HEX}</string>
-    <key>AWS_ACCESS_KEY_ID</key>
-    <string>${TIGRIS_ACCESS_KEY}</string>
-    <key>AWS_SECRET_ACCESS_KEY</key>
-    <string>${TIGRIS_SECRET_KEY}</string>
-    <key>AWS_ENDPOINT_URL_S3</key>
-    <string>https://fly.storage.tigris.dev</string>
-    <key>TIGRIS_BUCKET</key>
-    <string>nuzantara-warroom-images</string>
-    <key>TELEGRAM_BOT_TOKEN</key>
-    <string>${TELEGRAM_BOT_TOKEN}</string>
-    <key>TELEGRAM_OWNER_CHAT_ID</key>
-    <string>1125336968</string>
-  </dict>
   <key>StartInterval</key>
   <integer>300</integer>
   <key>RunAtLoad</key>
@@ -431,6 +482,18 @@ File: `infra/launchagents/com.balizero.wr2.canva-renderer.plist`
 </dict>
 </plist>
 ```
+
+Notes:
+- `flock -n` (non-blocking): if a previous instance still holds the
+  lock, this tick exits 1 (non-success, but no error log). Next tick
+  retries naturally. Lock file `/tmp/wr2_canva_pdf_apply.lock`.
+- `flock` binary at `/opt/homebrew/bin/flock` (brew, v0.4.0,
+  verified 2026-05-13). Pre-existing in stack (cf. git-pull.5min plist
+  + mini-migration `lessons_python_ssh_heredoc_escape.md` fix).
+- `-l` on `/bin/zsh` ensures `.zshrc` is sourced (PATH+brew available),
+  matching the empirically-verified legacy plist convention.
+- `exec` replaces the shell process → launchd sees the Python PID
+  directly for accurate `SuccessfulExit` evaluation.
 
 Token watchdog plist
 (`infra/launchagents/com.balizero.wr2.canva-token-watchdog.daily.plist`)
@@ -500,6 +563,42 @@ psql -c "UPDATE system_settings SET value='false' WHERE key='wr2_canva_renderer_
 #    (legacy script still in repo for ~2 weeks)
 ```
 
+### 5.6 Tigris S3 lifecycle policies (new post-panel)
+
+Two prefixes with distinct retention:
+
+```
+s3://nuzantara-warroom-images/wr2-pdf/                  retention 30 days (production)
+s3://nuzantara-warroom-images/wr2-pdf-tests/             retention 1 day  (E2E namespace)
+```
+
+`infra/tigris/wr2-pdf-lifecycle.json` defines the policy. Applied via:
+
+```bash
+aws s3api put-bucket-lifecycle-configuration \
+  --bucket nuzantara-warroom-images \
+  --lifecycle-configuration file://infra/tigris/wr2-pdf-lifecycle.json \
+  --endpoint-url https://fly.storage.tigris.dev
+```
+
+Rationale: 30-day retention covers re-import-from-url replay if Canva
+design is accidentally deleted client-side. 1-day on `tests/` prefix
+auto-cleans E2E artifacts. Both serve as safety net for orphan-PDF
+class even when orchestrator cleanup step fails.
+
+### 5.7 Stale-lease watchdog (new post-panel)
+
+`scripts/wr2_canva_lease_watchdog.py` runs every 10 minutes via plist
+`com.balizero.wr2.canva-lease-watchdog.10min.plist`:
+
+1. SELECT id, lease_owner, lease_acquired_at FROM war_room_drafts
+   WHERE status='rendering' AND lease_acquired_at < NOW() - INTERVAL '15 minutes'.
+2. UPDATE status='drafts_imaged_checked', clear lease fields.
+3. Telegram alert per orphan recovered (sample: 5 max per run to avoid
+   flood).
+
+This + Tigris S3 lifecycle = belt+suspenders against orphan state.
+
 ## 6. Testing strategy
 
 | Test layer | Coverage | Tool |
@@ -513,6 +612,39 @@ psql -c "UPDATE system_settings SET value='false' WHERE key='wr2_canva_renderer_
 CI: existing PR-checks (E2E, MCP Server Tests) cover unrelated code
 paths. New unit tests added under
 `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/`.
+
+### 6.4 E2E isolation strategy (new post-panel)
+
+Panel flagged that "1 real draft from PG" as test fixture pollutes
+production data. Revised approach:
+
+| Layer | Production | E2E |
+|---|---|---|
+| PG client_id | real Bali Zero clients | permanent synthetic `e2e_test_client` row in `clients` table |
+| PG draft | created by storyboarder | created by `scripts/wr2_e2e_create_fixture_draft.py` with `client_id=e2e_test_client`, `topic="[E2E TEST]..."`, fixed UUID `00000000-0000-0000-e2e0-000000000001` |
+| Tigris prefix | `wr2-pdf/` | `wr2-pdf-tests/` (1-day lifecycle) |
+| Canva folder | "WR2 Drafts 2026" | "E2E Tests (Auto-Delete)" (separate `WR2_DRAFTS_FOLDER_ID_E2E` env) |
+| Status terminal | normal | teardown script DELETEs Canva design + PG row immediately after assert |
+
+Orchestrator detects E2E mode via `WR2_E2E_MODE=true` env var (set by
+test runner only). In E2E mode: uses test Tigris prefix, test Canva
+folder, and outputs more verbose diagnostics. Production never sets
+this var.
+
+E2E test scenarios:
+
+1. **Happy path** — synthetic draft → fully rendered + Canva URL valid
+2. **Lease race** — spawn 2 orchestrator instances simultaneously,
+   assert only 1 processes
+3. **OAuth refresh mid-flow** — pre-expire token, assert transparent
+   refresh + success
+4. **Tigris 503 transient** — moto intercepts, assert backoff
+5. **Stale lease recovery** — manually insert `status='rendering'`
+   row with `lease_acquired_at` 20min ago, assert watchdog resets
+
+E2E pytest fixtures live in
+`apps/backend-rag/backend/tests/e2e/canva_renderer_v2/`. Run manually
+on Pro after bootstrap; not in CI (browser-bound OAuth flow).
 
 ## 7. Deliverables and commit plan
 
@@ -549,24 +681,35 @@ paths. New unit tests added under
 | `apps/backend-rag/backend/tests/fixtures/canva_renderer_v2/draft_legacy_parq.json` | data |
 | `apps/backend-rag/backend/tests/fixtures/canva_renderer_v2/draft_v2_kep71.json` | data |
 
-### 7.3 Commit sequence (WIP-every-step anti-hijack)
+### 7.3 Commit sequence (revised post-panel — bisect-safe)
 
-| Commit | Subject | Files |
-|---|---|---|
-| 1 | `docs(wr2): spec for orchestrator PDF render pipeline` | this design doc |
-| 2 | `feat(canva-renderer-v2): module scaffolding + _pg.py + _telegram.py` | 2 modules + tests |
-| 3 | `feat(canva-renderer-v2): _schema_adapter.py with 3 fixtures` | adapter + fixtures + tests |
-| 4 | `feat(canva-renderer-v2): _pdf_pipeline.py subprocess wrapper` | pipeline + tests |
-| 5 | `feat(canva-renderer-v2): _tigris.py boto3 with 3-retry` | tigris + tests |
-| 6 | `feat(canva-renderer-v2): _token_storage.py HMAC+flock+proactive-refresh` | storage + tests |
-| 7 | `feat(canva-renderer-v2): _canva_mcp.py ClientSession wrapper` | mcp + tests |
-| 8 | `feat(canva-renderer-v2): orchestrator.py top-level + scripts entrypoint` | orchestrator + script + integration test |
-| 9 | `feat(wr2): bootstrap_canva_oauth.py one-shot interactive script` | bootstrap |
-| 10 | `feat(wr2): canva_token_watchdog.py daily expiry check` | watchdog |
-| 11 | `feat(infra): launchd plist for v2 renderer + token watchdog` | 2 plist files |
-| 12 | `docs(cicatrix): update DAHJEkWpkzY scar — v3 orchestrator live` | scar update |
+Panel split on commit ordering (Gemini OK, GPT-5.5 + DeepSeek
+"restructure for bisectability"). Resolution: every commit must keep
+`pytest --collect-only` green (no missing-import errors) even if
+feature is incomplete. Pure-library modules first, then wiring last.
+
+| # | Subject | Files | Bisect-safe? |
+|---|---|---|---|
+| 1 | `docs(wr2): spec for orchestrator PDF render pipeline` | this design doc | yes |
+| 2 | `feat(db): SQL v2 migration NNN_wr2_draft_lease.sql` | lease columns | yes |
+| 3 | `feat(canva-renderer-v2): pkg init + _telegram.py + _pg.py (read-only)` | 3 files + tests | yes (no external IO except mocked PG) |
+| 4 | `feat(canva-renderer-v2): _schema_adapter.py + fixtures` | adapter + 3 fixtures + tests | yes (pure function) |
+| 5 | `feat(canva-renderer-v2): _pdf_pipeline.py subprocess wrapper` | pipeline + tests | yes (mocks subprocess) |
+| 6 | `feat(canva-renderer-v2): _tigris.py boto3 + S3 lifecycle JSON` | tigris + tests + infra/tigris/ | yes (moto S3) |
+| 7 | `feat(canva-renderer-v2): _token_storage.py HMAC+flock+proactive-refresh` | storage + tests | yes (tmp fixture) |
+| 8 | `feat(canva-renderer-v2): _canva_mcp.py ClientSession wrapper` | mcp + tests | yes (httpx_mock) |
+| 9 | `feat(canva-renderer-v2): _pg.py write path + lease CAS` | pg lease + tests | yes |
+| 10 | `feat(canva-renderer-v2): orchestrator.py top-level (wired)` | orchestrator + integration test | yes (all deps committed) |
+| 11 | `feat(wr2): scripts/wr2_canva_pdf_apply.py thin entrypoint` | script | yes |
+| 12 | `feat(wr2): bootstrap_canva_oauth.py + canva_token_watchdog.py + lease_watchdog.py` | 3 scripts | yes |
+| 13 | `feat(infra): launchd plist for v2 renderer + token watchdog + lease watchdog` | 3 plist files | yes |
+| 14 | `feat(canva-renderer-v2): E2E fixtures + scripts/wr2_e2e_create_fixture_draft.py` | e2e infra | yes |
+| 15 | `docs(cicatrix): update DAHJEkWpkzY scar — v3 orchestrator live` | scar update | yes |
 
 Push after every commit. WIP-commit-every-10min anti-hijack.
+`git bisect` valid across all 15 commits because each isolated module
+has its own passing test suite and no commit leaves the imports
+broken (orchestrator.py last, after all deps shipped).
 
 ### 7.4 Stop condition
 

--- a/docs/superpowers/specs/2026-05-13-wr2-orchestrator-pdf-render-design.md
+++ b/docs/superpowers/specs/2026-05-13-wr2-orchestrator-pdf-render-design.md
@@ -1,0 +1,621 @@
+---
+date: 2026-05-13
+component: wr2-orchestrator
+status: draft (design phase, not yet implemented)
+author: Antonello + Claude Opus 4.7
+cross_llm_panel: Gemini 3.1 Pro + GPT-5.5 codex + DeepSeek V4 Pro
+related_branch: feat/wr2-canva-pdf-render-2026-05-13
+supersedes: scripts/wr2_canva_apply.py (legacy, to be disabled)
+---
+
+# WR2 Orchestrator PDF Render Design
+
+End-to-end pipeline closing the loop `slides.json → PDF → Tigris → Canva
+import` without an LLM in the orchestration path. Replaces the legacy
+`scripts/wr2_canva_apply.py` (`claude -p APPLICA_WAR_ROOM.md` subprocess
+with 50% MCP cold-fail rate documented in 7 days of telemetry).
+
+## 1. Background
+
+### 1.1 Existing state at design time (2026-05-13)
+
+| Component | Status | Notes |
+|---|---|---|
+| `scripts/wr2_canva_pdf_render.py` (renderer) | ✅ shipped on branch | 1176 LOC, 12 layout families, ReportLab text-layered PDF |
+| `scripts/wr2_canva_apply.py` (legacy orchestrator) | ⚠️ kill-switch OFF | Plist boot-out 2026-05-13. PG `system_settings.wr2_canva_renderer_enabled='false'`. Plist file preserved on disk |
+| Yellow badge WCAG AAA | ✅ commit 940fc77 in ~/.claude | Article 14.4 |
+| Constitution Article 15 (5 banned type-as-design) | ✅ commit 9cb50c2 in ~/.claude | |
+| Smoke PDFs v2 | ✅ visually approved | `/tmp/wr2_smoke_v2.pdf` (6pp KEP-71), `/tmp/wr2_parq_v2.pdf` (11pp Parq Ambassador) |
+| Adapter legacy schema → v2 | ✅ working draft | `/tmp/wr2_legacy_adapter.py` (130 LOC) |
+| Canva MCP dynamic client registration | ✅ verified empirically | `POST mcp.canva.com/register` returns 201 + client_id |
+
+### 1.2 Why a new orchestrator
+
+The legacy `wr2_canva_apply.py` shells out to `claude -p` with the
+`canva-apply` skill (~1200 LOC of MCP element_id remapping). It carries
+inherent fragility:
+
+- 50% cold-fail rate on MCP Canva (`MCP_NOT_AVAILABLE_SENTINELS` retry
+  pattern). Empirical telemetry 2026-05-07 → 2026-05-13.
+- 25-32 minute subprocess execution per draft. The Fly Postgres tunnel
+  closes idle TCP sockets inside this window — observed crash
+  2026-05-07 23:53 → 00:26 UTC, `_persist_canva_result` raised
+  `ConnectionDoesNotExistError`.
+- Master template `DAHJEkWpkzY` required structural validation (Phase
+  -1, see cicatrix-scars-archive entry "WR2 master template
+  structural validation gap"). The new flow bypasses master templates
+  entirely.
+
+The new pipeline runs **deterministic**: PG select → ReportLab
+subprocess → boto3 Tigris upload → Canva MCP `import-design-from-url`
+→ PG update. 5 steps, ~5-15 seconds per draft, no LLM in the loop.
+
+### 1.3 Architectural decisions log
+
+| ID | Decision | Approved by | Date |
+|---|---|---|---|
+| D0 | Orchestrator runtime: Python + httpx + official `mcp` SDK 1.12.4 (NOT claude -p subprocess, NOT OpenClaw+GPT-5.5) | Antonello + 3-LLM panel | 2026-05-13 |
+| D1 | File location: NEW `scripts/wr2_canva_pdf_apply.py` accanto al legacy (rollback-friendly) | Antonello | 2026-05-13 |
+| D2 | Legacy slides_json schema: adapter inline in orchestrator (riusa `/tmp/wr2_legacy_adapter.py` as `_schema_adapter.py`) | Antonello | 2026-05-13 |
+| D3 (v1, discarded) | OAuth token storage: shared `~/.mcp-auth/mcp-remote-0.1.37/` cache | rejected after 3-LLM panel | 2026-05-13 |
+| D3 (v3, final) | OAuth token storage: orchestrator-owned `~/.config/wr2/canva_tokens.json` + dedicated bootstrap script + HMAC integrity + proactive refresh + flock + dynamic client registration | Antonello + 3-LLM panel + empirical verify | 2026-05-13 |
+
+### 1.4 Cross-LLM design-review trail
+
+This spec passed through a structured 3-LLM panel review at each section
+(rule established 2026-05-13, memory `feedback_always_review_spec_with_4_llm.md`).
+Convergent flaws caught by panel:
+
+- **OAuth client_id binding** (v1 → v2 pivot): all 3 LLMs identified
+  that tokens are bound to `client_id` at registration time. Sharing
+  the `mcp-remote` cache would cross-corrupt the Claude Code interactive
+  session. → drove pivot to orchestrator-owned storage.
+- **mtime compare-before-replace** (v2 → v3 pivot): DeepSeek V4 Pro
+  caught that mtime check inside flock causes self-lockout if any
+  non-flocking process touches the file. → removed in v3.
+- **launchd restart loop** (v2 → v3 pivot): both Gemini and DeepSeek
+  flagged that `SuccessfulExit=true` alone doesn't prevent loops on
+  exit 4/5/7. v3 uses array form `SuccessfulExit: [0, 4, 5, 7]`.
+- **Token expiry race** (v2 → v3 pivot): Gemini caught absence of
+  proactive refresh. v3 adds 5min margin + 0-15s jitter.
+
+Empirical verifications that overruled panel claims:
+
+- **Canva dynamic client registration**: 2/3 LLMs claimed "Canva
+  requires manual Developer Portal registration." Live HTTP POST to
+  `mcp.canva.com/register` returned 201 with valid `client_id`. Panel
+  wrong. Stored as fact `canva-mcp-dynamic-client-registration`.
+
+Cost of panel: ~$0.03 DeepSeek + 0 Gemini + 0 codex = $0.03 for entire
+spec. Wall time: ~5min for 2 rounds.
+
+## 2. Architecture
+
+### 2.1 High-level diagram
+
+```
+                ┌──────────────────────────────────────────────────────┐
+                │  com.balizero.wr2.canva-renderer.plist  (every 5min) │
+                │  exec: python3 scripts/wr2_canva_pdf_apply.py        │
+                └────────────────────────┬─────────────────────────────┘
+                                         │
+                                         ▼
+            ┌────────────────────────────────────────────────────────┐
+            │  scripts/wr2_canva_pdf_apply.py  (orchestrator)        │
+            │                                                        │
+            │  1. kill_switch_check (PG SELECT)                      │
+            │  2. fetch_ready_drafts (PG SELECT, LIMIT 3)            │
+            │  3. for draft in drafts:                               │
+            │     a. adapt_legacy_schema if needed                   │
+            │     b. write slides_json → /tmp/slides_<id>.json       │
+            │     c. subprocess.run(wr2_canva_pdf_render.py)         │
+            │        → /tmp/wr2_<id>.pdf                             │
+            │     d. boto3.put_object → Tigris s3://...wr2-pdf/<id>  │
+            │     e. mcp_session.call_tool(import-design-from-url)   │
+            │        + move-item-to-folder  (WR2 Drafts 2026)        │
+            │     f. PG UPDATE canva_design_id, canva_edit_url,      │
+            │        status='rendered'                               │
+            │     g. Telegram notify                                 │
+            │  4. log telemetry JSONL (riuso pattern legacy)         │
+            └────────────────────────────────────────────────────────┘
+                            │           │              │
+                ┌───────────┼───────────┼──────────────┼─────────────┐
+                ▼           ▼           ▼              ▼             ▼
+            asyncpg      ReportLab   boto3        mcp.ClientSession  urllib
+            (PG)       (subprocess)  (Tigris)     (Canva HTTP MCP)   (Telegram)
+```
+
+### 2.2 Module decomposition
+
+| Module | LOC est. | Responsibility | Isolated test |
+|---|---|---|---|
+| `_pg.py` | 80 | asyncpg connect, kill switch, fetch drafts, persist result | mock `asyncpg.Connection` |
+| `_schema_adapter.py` | 130 | Detect legacy schema (`slide_type` present, no `layout_family`) + adapt | Pure function, 3 fixture drafts |
+| `_pdf_pipeline.py` | 60 | subprocess `wr2_canva_pdf_render` + verify file size > 0 | tmp_path fixture |
+| `_tigris.py` | 90 | boto3 `put_object` with 3 retry + public URL build | `moto` mock S3 |
+| `_canva_mcp.py` | 120 | `mcp.ClientSession` init + `call_tool` import-design + move-to-folder | mock `streamable_http_client` |
+| `_token_storage.py` | 180 | `OrchestratorTokenStorage(TokenStorage)` with flock + HMAC + proactive refresh | tmp dir fixture |
+| `_telegram.py` | 40 | Best-effort notify (legacy pattern) | requests-mock |
+| `wr2_canva_pdf_apply.py` | 120 | Top-level orchestrator composing the above | asyncio integration test |
+| `wr2_bootstrap_canva_oauth.py` | 150 | One-shot interactive bootstrap (run on Pro once) | manual smoke |
+| `wr2_canva_token_watchdog.py` | 60 | Daily check `last_refreshed_iso`, alert >75d/>85d | tmp file fixture |
+| **Total** | **~1030** | | |
+
+All modules go under `apps/backend-rag/backend/services/canva_renderer_v2/`
+to keep test infra co-located with the legacy `canva_renderer/` package.
+The launcher `scripts/wr2_canva_pdf_apply.py` is a thin entrypoint
+(~30 LOC) that imports `from backend.services.canva_renderer_v2 import run`.
+
+## 3. Token storage and OAuth lifecycle
+
+### 3.1 Bootstrap (one-shot, interactive)
+
+`scripts/wr2_bootstrap_canva_oauth.py`:
+
+1. Construct `mcp.client.auth.OAuthClientProvider` with own `OAuthClientMetadata`:
+   ```python
+   client_name = "WR2 Pipeline Orchestrator"
+   redirect_uris = ["http://localhost:0/oauth/callback"]  # ephemeral port
+   grant_types = ["authorization_code", "refresh_token"]
+   response_types = ["code"]
+   token_endpoint_auth_method = "none"  # Canva confirmed public-client
+   scope = "user:read offline_access account:read teams:read"
+   ```
+2. Bind local HTTP server on `127.0.0.1:0` (kernel-assigned ephemeral
+   port). Record the assigned port and patch `redirect_uri` in the
+   metadata before initiating the flow.
+3. POST `https://mcp.canva.com/register` → receive `client_id`.
+4. Open browser to authorization endpoint with PKCE challenge.
+5. Operator authorizes. Local server receives callback with auth code.
+6. Exchange code for tokens at `mcp.canva.com/token`.
+7. Compute HMAC-SHA256 over canonical JSON. Write to
+   `~/.config/wr2/canva_tokens.json` (0600):
+   ```json
+   {
+     "client_id": "...",
+     "client_secret": "",  // empty, none auth method
+     "access_token": "...",
+     "refresh_token": "...",
+     "scope": "user:read offline_access account:read teams:read",
+     "token_type": "bearer",
+     "expires_at_epoch": 1778614000.0,
+     "issued_at": "2026-05-13T18:30:00Z",
+     "last_refreshed_iso": "2026-05-13T18:30:00Z",
+     "_hmac": "0123abcd..."  // hex-encoded SHA-256
+   }
+   ```
+8. Smoke test: `mcp_session.call_tool("list-brand-kits")` → assert
+   returns Bali Zero team. Failure → exit 2 with diagnostic.
+
+The `WR2_CANVA_HMAC_KEY` env var (32 random bytes hex-encoded) lives
+in `~/.nuzantara-secrets.env`. Bootstrap script asserts presence
+before running.
+
+### 3.2 Runtime: `OrchestratorTokenStorage(TokenStorage)`
+
+Key invariants:
+- Reads/writes are protected by `fcntl.LOCK_EX` on a sidecar
+  `canva_tokens.lock` file (advisory exclusive).
+- Every read verifies HMAC. Mismatch → `RuntimeError("Token HMAC
+  mismatch")` → orchestrator exits 7 with backup copy
+  `canva_tokens.broken-<YYYYMMDD-HHMMSS>.json`.
+- Proactive refresh: `get_tokens()` returns `None` if
+  `expires_at_epoch - now() < 300 + uniform(0, 15)` seconds, forcing
+  `OAuthClientProvider` to refresh.
+- On refresh, Canva may omit `refresh_token` in the response (standard
+  OAuth pattern). `set_tokens` merges and preserves the existing
+  `refresh_token` if absent.
+- Atomic write: temp file in same dir + `replace()`.
+- NO mtime-compare check (anti-pattern per DeepSeek panel).
+
+### 3.3 Refresh-token expiry watchdog
+
+`scripts/wr2_canva_token_watchdog.py` invoked daily via
+`com.balizero.wr2.canva-token-watchdog.daily.plist` (09:00 WITA):
+
+1. Read `canva_tokens.json`. Verify HMAC.
+2. Compute days since `last_refreshed_iso`.
+3. If >75 days → Telegram warn "Canva refresh token expires in 15d.
+   Plan re-bootstrap."
+4. If >85 days → Telegram critical "Canva refresh expires in 5d.
+   Re-bootstrap NOW."
+5. If file missing or HMAC mismatch → Telegram alert.
+
+Canva's documented refresh-token decay window is 90 days of non-use;
+the watchdog gives a 15-day buffer. Re-bootstrap is a 30-second manual
+operation on Pro.
+
+### 3.4 Failure exit codes
+
+| Exit | Meaning | launchd `SuccessfulExit`? | Telegram? |
+|---|---|---|---|
+| 0 | Normal | yes | no (per-draft notify) |
+| 1 | Transient (network, PG transient) | no (auto-retry next tick) | no |
+| 2 | DSN missing or config invalid | no | yes |
+| 3 | Kill switch off (expected quiet exit) | yes | no |
+| 4 | Token file missing → run bootstrap | yes (no restart loop) | yes |
+| 5 | Refresh revoked → re-auth needed | yes | yes (high priority) |
+| 6 | flock contention exhausted | no (retry) | no |
+| 7 | Token JSON corrupt | yes | yes |
+
+`com.balizero.wr2.canva-renderer.plist`:
+```xml
+<key>SuccessfulExit</key>
+<array>
+  <integer>0</integer>
+  <integer>3</integer>
+  <integer>4</integer>
+  <integer>5</integer>
+  <integer>7</integer>
+</array>
+<key>ThrottleInterval</key>
+<integer>300</integer>
+```
+
+## 4. Per-draft flow and error handling
+
+### 4.1 Draft lifecycle
+
+```
+drafts_imaged_checked  ─[orchestrator pickup]→  (transient)
+                                                    │
+                                                    ├─ PDF gen OK ────────────┐
+                                                    │                         │
+                                                    └─ PDF gen FAIL ──→ status='pdf_render_failed' (new terminal)
+                                                                              │
+                                                                     ┌────────┴────────┐
+                                                                     │ MCP import OK   │
+                                                                     ├──→ status='rendered'
+                                                                     │   canva_*=populated
+                                                                     │
+                                                                     │ MCP import FAIL
+                                                                     └──→ status='canva_import_failed' (new terminal)
+```
+
+Two new terminal status values are added to the schema vocabulary:
+- `pdf_render_failed` — ReportLab subprocess exit≠0, file size==0,
+  or Tigris upload exhausted retries
+- `canva_import_failed` — MCP `import-design-from-url` raised after
+  retries
+
+Both are terminal and NOT picked up by the next cron tick. Antonello
+manually re-promotes them to `drafts_imaged_checked` after fixing the
+underlying issue.
+
+### 4.2 Per-draft pseudo-code
+
+See section 2.2 of this spec for module boundaries. The orchestrator
+top-level (`wr2_canva_pdf_apply.py`) iterates over drafts:
+
+```python
+async def _apply_one_draft(conn, mcp_session, row, *, dsn):
+    draft_id = row["id"]
+    t0 = time.time()
+
+    # A — schema adapt
+    slides = json.loads(row["slides_json"]) if isinstance(row["slides_json"], str) else row["slides_json"]
+    if _is_legacy_schema(slides):
+        slides = adapt_legacy_schema(slides, topic=row["topic"])
+
+    # B — PDF render via subprocess
+    pdf_path = await _render_pdf(slides, draft_id)  # raises PdfRenderError
+    if pdf_path is None:
+        await _mark_failed(conn, draft_id, "pdf_render_failed", "subprocess exit≠0")
+        return False
+
+    # C — Tigris upload
+    pdf_url = await _upload_to_tigris(pdf_path, draft_id)  # 3 retries
+    if pdf_url is None:
+        await _mark_failed(conn, draft_id, "pdf_render_failed", "tigris exhausted")
+        return False
+
+    # D — MCP import-design-from-url
+    try:
+        result = await mcp_session.call_tool(
+            "import-design-from-url",
+            arguments={"url": pdf_url, "title": row["topic"][:80]},
+        )
+        design_id = _parse_design_id(result)
+        edit_url = f"https://www.canva.com/design/{design_id}/edit"
+    except Exception as exc:
+        await _mark_failed(conn, draft_id, "canva_import_failed", f"{type(exc).__name__}: {exc}")
+        _send_telegram(f"🚨 WR2 MCP import FAILED draft={draft_id} err={exc}")
+        return False
+
+    # E — move-to-folder (best effort, non-fatal)
+    try:
+        await mcp_session.call_tool(
+            "move-item-to-folder",
+            arguments={"item_id": design_id, "folder_id": WR2_DRAFTS_FOLDER_ID},
+        )
+    except Exception as exc:
+        logger.warning("Draft %s move-to-folder failed: %s", draft_id, exc)
+
+    # F — persist with reconnect-on-dead-conn (legacy pattern)
+    await _persist_canva_result(conn, draft_id, design_id, edit_url, dsn=dsn)
+    _send_telegram(f"🎨 WR2 rendered: {row['topic'][:80]}\n{edit_url}\nduration: {time.time()-t0:.1f}s")
+    _log_telemetry(draft_id, "success", time.time() - t0)
+    return True
+```
+
+### 4.3 Failure classification
+
+| Failure point | New status | Retry-able? | Alert? |
+|---|---|---|---|
+| A schema adapt KeyError | no DB change | no, fixable in code | logger.error, no Telegram |
+| B PDF render exit≠0 | `pdf_render_failed` | manual re-promote | Telegram |
+| B subprocess timeout 120s | `pdf_render_failed` | manual | Telegram |
+| C Tigris boto3 ClientError | `pdf_render_failed` | auto 3 retry then terminal | Telegram |
+| D MCP call_tool raises | `canva_import_failed` | manual | Telegram (escalation) |
+| D OAuth token expired AND refresh succeeded | (transparent retry) | yes | no |
+| D OAuth refresh revoked | (orchestrator exits 5) | re-bootstrap | Telegram high prio |
+| E move-to-folder fails | status stays `rendered` | non-fatal | warn log |
+| F PG UPDATE crashes | orphan (Canva exists, DB unaware) | reconnect-on-dead-conn (legacy) | Telegram persist_failed |
+
+### 4.4 Inherited patterns from legacy
+
+Three patterns from `scripts/wr2_canva_apply.py` are reused verbatim:
+
+1. **`_persist_canva_result` reconnect-on-dead-conn** — the `conn`
+   opened in `run()` may close during long MCP HTTP call. Although
+   the Fly tunnel scenario is less acute here (MCP HTTP not Fly
+   tunnel), the pattern stays safe.
+2. **Telemetry JSONL append-only** at
+   `~/logs/wr2_canva_pdf_apply_telemetry.jsonl` — outcome / duration
+   / attempt fields kept identical to legacy for log analyzer
+   continuity.
+3. **`MAX_DRAFTS_PER_RUN = 3`** — limit stampede on launchd 5-min tick.
+
+## 5. launchd plist and operational lifecycle
+
+### 5.1 Production plist
+
+File: `infra/launchagents/com.balizero.wr2.canva-renderer.plist`
+(replaces existing plist of same label):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.balizero.wr2.canva-renderer</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python</string>
+    <string>/Users/nuzantara/Desktop/nuzantara/scripts/wr2_canva_pdf_apply.py</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>/Users/nuzantara/Desktop/nuzantara</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <key>DATABASE_URL</key>
+    <string>postgresql://...127.0.0.1:15432/nuzantara_rag</string>
+    <key>WR2_CANVA_TOKEN_FILE</key>
+    <string>/Users/nuzantara/.config/wr2/canva_tokens.json</string>
+    <key>WR2_CANVA_HMAC_KEY</key>
+    <string>${SECRET_HEX}</string>
+    <key>AWS_ACCESS_KEY_ID</key>
+    <string>${TIGRIS_ACCESS_KEY}</string>
+    <key>AWS_SECRET_ACCESS_KEY</key>
+    <string>${TIGRIS_SECRET_KEY}</string>
+    <key>AWS_ENDPOINT_URL_S3</key>
+    <string>https://fly.storage.tigris.dev</string>
+    <key>TIGRIS_BUCKET</key>
+    <string>nuzantara-warroom-images</string>
+    <key>TELEGRAM_BOT_TOKEN</key>
+    <string>${TELEGRAM_BOT_TOKEN}</string>
+    <key>TELEGRAM_OWNER_CHAT_ID</key>
+    <string>1125336968</string>
+  </dict>
+  <key>StartInterval</key>
+  <integer>300</integer>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>SuccessfulExit</key>
+  <array>
+    <integer>0</integer>
+    <integer>3</integer>
+    <integer>4</integer>
+    <integer>5</integer>
+    <integer>7</integer>
+  </array>
+  <key>ThrottleInterval</key>
+  <integer>300</integer>
+  <key>StandardOutPath</key>
+  <string>/Users/nuzantara/logs/wr2_canva_pdf_apply.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/nuzantara/logs/wr2_canva_pdf_apply.error.log</string>
+</dict>
+</plist>
+```
+
+Token watchdog plist
+(`infra/launchagents/com.balizero.wr2.canva-token-watchdog.daily.plist`)
+runs at 09:00 WITA daily, similar structure but `StartCalendarInterval`
+instead of `StartInterval`.
+
+### 5.2 PG kill switch
+
+Stays at `system_settings.wr2_canva_renderer_enabled` (boolean as
+text 'true'/'false'). Orchestrator checks first thing; if not 'true',
+exits 3 (quiet). To flip: `psql -c "UPDATE system_settings SET
+value='true' WHERE key='wr2_canva_renderer_enabled'"`. Same kill
+switch as legacy — reused.
+
+### 5.3 Bootstrap sequence (one-time)
+
+```bash
+# 1. Ensure env vars set in ~/.nuzantara-secrets.env
+#    WR2_CANVA_HMAC_KEY=<openssl rand -hex 32>
+#    AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, TIGRIS_BUCKET already present
+
+# 2. Run bootstrap (Pro, browser available)
+source ~/.nuzantara-secrets.env
+mkdir -p ~/.config/wr2 && chmod 700 ~/.config/wr2
+cd ~/Desktop/nuzantara
+apps/backend-rag/.venv/bin/python scripts/wr2_bootstrap_canva_oauth.py
+
+# Browser opens. Authorize Bali Zero team. Wait for "✅ Bootstrap complete".
+
+# 3. Verify
+ls -la ~/.config/wr2/canva_tokens.json  # mode 0600
+python -c "from backend.services.canva_renderer_v2._token_storage import OrchestratorTokenStorage; \
+           import asyncio; \
+           t = OrchestratorTokenStorage(); \
+           print(asyncio.run(t.get_tokens()))"
+```
+
+### 5.4 Flip-on sequence
+
+```bash
+# After bootstrap done + spec approved:
+# 1. Update plist file
+cp infra/launchagents/com.balizero.wr2.canva-renderer.plist ~/Library/LaunchAgents/
+
+# 2. Flip PG kill switch
+psql -h 127.0.0.1 -p 15432 -U postgres -d nuzantara_rag \
+  -c "UPDATE system_settings SET value='true' WHERE key='wr2_canva_renderer_enabled'"
+
+# 3. Bootstrap plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.balizero.wr2.canva-renderer.plist
+
+# 4. Monitor first 2-3 ticks (10-15min wall-clock)
+tail -F ~/logs/wr2_canva_pdf_apply.log
+psql -c "SELECT id, status, canva_edit_url FROM war_room_drafts WHERE status IN ('drafts_imaged_checked','rendered') ORDER BY created_at DESC LIMIT 5"
+```
+
+### 5.5 Rollback procedure
+
+If new orchestrator misbehaves:
+
+```bash
+# 1. Stop new
+launchctl bootout gui/$(id -u)/com.balizero.wr2.canva-renderer
+# 2. PG kill switch OFF
+psql -c "UPDATE system_settings SET value='false' WHERE key='wr2_canva_renderer_enabled'"
+# 3. (Optional) Restart legacy: switch ProgramArguments back to wr2_canva_apply.py
+#    (legacy script still in repo for ~2 weeks)
+```
+
+## 6. Testing strategy
+
+| Test layer | Coverage | Tool |
+|---|---|---|
+| Unit (per module) | 80%+ | pytest + asyncpg mock + moto S3 + httpx_mock |
+| Schema adapter | 3 fixture drafts (Parq, KEP-71, deep schema v2) | pytest |
+| Token storage flock + HMAC | concurrent process spawn test | pytest + multiprocessing |
+| Bootstrap script | manual smoke (browser-bound) | wiki runbook |
+| End-to-end | 1 real draft from PG | manual on staging UUID |
+
+CI: existing PR-checks (E2E, MCP Server Tests) cover unrelated code
+paths. New unit tests added under
+`apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/`.
+
+## 7. Deliverables and commit plan
+
+### 7.1 Files to create (production code)
+
+| Path | LOC est. | Module |
+|---|---|---|
+| `apps/backend-rag/backend/services/canva_renderer_v2/__init__.py` | 5 | package init |
+| `apps/backend-rag/backend/services/canva_renderer_v2/_pg.py` | 80 | DB layer |
+| `apps/backend-rag/backend/services/canva_renderer_v2/_schema_adapter.py` | 130 | legacy schema adapt |
+| `apps/backend-rag/backend/services/canva_renderer_v2/_pdf_pipeline.py` | 60 | renderer subprocess |
+| `apps/backend-rag/backend/services/canva_renderer_v2/_tigris.py` | 90 | S3 upload |
+| `apps/backend-rag/backend/services/canva_renderer_v2/_canva_mcp.py` | 120 | MCP client |
+| `apps/backend-rag/backend/services/canva_renderer_v2/_token_storage.py` | 180 | OAuth |
+| `apps/backend-rag/backend/services/canva_renderer_v2/_telegram.py` | 40 | notify |
+| `apps/backend-rag/backend/services/canva_renderer_v2/orchestrator.py` | 120 | top-level `run()` |
+| `scripts/wr2_canva_pdf_apply.py` | 30 | thin entrypoint |
+| `scripts/wr2_bootstrap_canva_oauth.py` | 150 | bootstrap |
+| `scripts/wr2_canva_token_watchdog.py` | 60 | daily watchdog |
+| `infra/launchagents/com.balizero.wr2.canva-renderer.plist` | xml | updated plist |
+| `infra/launchagents/com.balizero.wr2.canva-token-watchdog.daily.plist` | xml | new watchdog plist |
+
+### 7.2 Files to create (tests)
+
+| Path | LOC est. |
+|---|---|
+| `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_pg.py` | 100 |
+| `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_schema_adapter.py` | 120 |
+| `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_pdf_pipeline.py` | 60 |
+| `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_tigris.py` | 90 |
+| `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_canva_mcp.py` | 100 |
+| `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_token_storage.py` | 150 |
+| `apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_orchestrator_integration.py` | 100 |
+| `apps/backend-rag/backend/tests/fixtures/canva_renderer_v2/draft_legacy_parq.json` | data |
+| `apps/backend-rag/backend/tests/fixtures/canva_renderer_v2/draft_v2_kep71.json` | data |
+
+### 7.3 Commit sequence (WIP-every-step anti-hijack)
+
+| Commit | Subject | Files |
+|---|---|---|
+| 1 | `docs(wr2): spec for orchestrator PDF render pipeline` | this design doc |
+| 2 | `feat(canva-renderer-v2): module scaffolding + _pg.py + _telegram.py` | 2 modules + tests |
+| 3 | `feat(canva-renderer-v2): _schema_adapter.py with 3 fixtures` | adapter + fixtures + tests |
+| 4 | `feat(canva-renderer-v2): _pdf_pipeline.py subprocess wrapper` | pipeline + tests |
+| 5 | `feat(canva-renderer-v2): _tigris.py boto3 with 3-retry` | tigris + tests |
+| 6 | `feat(canva-renderer-v2): _token_storage.py HMAC+flock+proactive-refresh` | storage + tests |
+| 7 | `feat(canva-renderer-v2): _canva_mcp.py ClientSession wrapper` | mcp + tests |
+| 8 | `feat(canva-renderer-v2): orchestrator.py top-level + scripts entrypoint` | orchestrator + script + integration test |
+| 9 | `feat(wr2): bootstrap_canva_oauth.py one-shot interactive script` | bootstrap |
+| 10 | `feat(wr2): canva_token_watchdog.py daily expiry check` | watchdog |
+| 11 | `feat(infra): launchd plist for v2 renderer + token watchdog` | 2 plist files |
+| 12 | `docs(cicatrix): update DAHJEkWpkzY scar — v3 orchestrator live` | scar update |
+
+Push after every commit. WIP-commit-every-10min anti-hijack.
+
+### 7.4 Stop condition
+
+The wave terminates when:
+1. Branch `feat/wr2-orchestrator-pdf-render-2026-MM-DD` opened as PR
+2. Bootstrap script run manually on Pro, `~/.config/wr2/canva_tokens.json` exists with HMAC valid
+3. 1 real draft from PG processed end-to-end → `canva_edit_url`
+   populated → design opens in Chrome Bali Zero team → layer-editable
+   verified visually
+4. 2-3 cron ticks monitored (15min wall) zero errors
+5. Cicatrix-scar updated with "loop chiuso end-to-end live"
+6. Telegram alert to Antonello: "WR2 pipeline live, first draft
+   processed $DRAFT_ID"
+
+Do NOT batch-regenerate 35 legacy drafts in same wave — that's a
+separate ticket (rate limits on MCP Canva + Codex imagegen cost if
+hero needed).
+
+## 8. Risks and mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Canva removes RFC 7591 dynamic registration | high | Token watchdog detects 401 on `/register` rebootstrap path, falls back to Canva Developer Portal manual |
+| `mcp` Python SDK 1.12.4 breaking change in 1.13+ | medium | Pin in `requirements.txt`. Renovate PR review opt-in for MCP-SDK bump |
+| Tigris bucket policy change (no public PDF read) | high | Pre-validate bucket policy in bootstrap. Telegram alert if signed-url fallback path triggers |
+| Refresh token decay >90d during long idle | medium | Daily watchdog at 75d/85d warning |
+| Sibling automation branch hijack during code write | high | WIP-commit-every-10min + scope-limited git add (no `-A` bare) |
+| `mcp.canva.com` rate limit (288 runs/day) | low | MAX_DRAFTS_PER_RUN=3 → max 864 calls/day. Canva published limit unknown, monitor empirically |
+| Yellow-badge regression in renderer | medium | renderer is on the branch and committed; no regression expected. Smoke PDFs re-runnable any time |
+
+## 9. Out of scope
+
+- Re-rendering 35 legacy drafts → separate ticket, requires manual decision per draft (hero re-gen Codex imagegen cost ~$0.04 each)
+- Migration of legacy slides_json schema in PG → status quo: adapter inline
+- WR2 image-generator backend (Sprint 1.6 W3, see CLAUDE.md §11) → unrelated, already shipped
+- Article 15 banned type-as-design enforcement at slide level → renderer handles this already
+
+## 10. Acceptance gates
+
+| Gate | Owner | Pass criteria |
+|---|---|---|
+| 3-LLM spec review | Claude + Gemini + DeepSeek (+ Codex when alive) | This document already passed sections 1-3. Sections 4-7 panel pending if Antonello requests. |
+| User review of written spec | Antonello | This file approved as-is, or change requests merged via Edit + re-review |
+| Unit test coverage 80%+ | CI | pytest-cov ≥0.8 per module |
+| Bootstrap smoke | Antonello on Pro | `list-brand-kits` returns Bali Zero team |
+| End-to-end real draft | Antonello + me on Pro | 1 draft `rendered`, Canva edit URL opens, layer-editable |
+| Cicatrix-scar update | me | "loop chiuso end-to-end live" appended to active scar |
+
+---
+
+**Status**: draft, awaiting user review before transitioning to
+implementation plan (writing-plans skill).

--- a/infra/tigris/wr2-pdf-lifecycle.json
+++ b/infra/tigris/wr2-pdf-lifecycle.json
@@ -1,0 +1,16 @@
+{
+  "Rules": [
+    {
+      "ID": "wr2-pdf-prod-30d",
+      "Status": "Enabled",
+      "Filter": {"Prefix": "wr2-pdf/"},
+      "Expiration": {"Days": 30}
+    },
+    {
+      "ID": "wr2-pdf-tests-1d",
+      "Status": "Enabled",
+      "Filter": {"Prefix": "wr2-pdf-tests/"},
+      "Expiration": {"Days": 1}
+    }
+  ]
+}

--- a/scripts/wr2_canva_pdf_render.py
+++ b/scripts/wr2_canva_pdf_render.py
@@ -159,9 +159,21 @@ def split_for_yellow(text: str) -> list[tuple[str, bool]]:
     return segments if segments else [(text, False)]
 
 
+_TRAILING_PUNCT = ".,;:!?)»\"'"
+_LEADING_PUNCT = ".,;:!?)»\"'"
+
+
 def wrap_segments(text: str, font: str, size: int,
                   max_w: int) -> list[list[tuple[str, bool]]]:
-    """Wrap text into lines, preserving (segment, is_yellow) tuples."""
+    """Wrap text into lines, preserving (segment, is_yellow) tuples.
+
+    Fix 2 (2026-05-13): punctuation glue. Previously every token was emitted
+    with a trailing space, so "DAYS" + "." became "DAYS ." (orphan punctuation
+    after a yellow-highlight token). Now: if a word begins with punctuation
+    AND the previous emitted token in the same line ends with a trailing space,
+    strip that trailing space before appending the punctuation. This collapses
+    "31 DAYS ." → "31 DAYS." while preserving normal word spacing.
+    """
     full_segs = split_for_yellow(text)
     lines: list[list[tuple[str, bool]]] = []
     cur_line: list[tuple[str, bool]] = []
@@ -170,6 +182,18 @@ def wrap_segments(text: str, font: str, size: int,
         for word in seg_text.split(" "):
             if not word:
                 continue
+            # If word starts with punctuation AND previous token in this line
+            # ended with space, strip that space.
+            if cur_line and word[0] in _LEADING_PUNCT:
+                prev_word, prev_y = cur_line[-1]
+                if prev_word.endswith(" "):
+                    stripped = prev_word.rstrip(" ")
+                    width_delta = (
+                        stringWidth(prev_word, font, size)
+                        - stringWidth(stripped, font, size)
+                    )
+                    cur_line[-1] = (stripped, prev_y)
+                    cur_width -= width_delta
             word_w = stringWidth(word + " ", font, size)
             if cur_width + word_w > max_w and cur_line:
                 lines.append(cur_line)
@@ -493,15 +517,36 @@ def render_photo_headline_yellow_sub(c: canvas.Canvas, s: dict[str, Any],
             cur_x += stringWidth(seg, ctx.font_bold, head_size)
         y_head -= head_line_h
 
-    # Body (UPPERCASE)
+    # Body (UPPERCASE) — vcentered in space between heading bottom and logo top.
+    # Fix 1 (2026-05-13): previously body anchored just below heading, leaving
+    # 50-70% of canvas as empty antracite. Now compute body block height and
+    # center it vertically within [logo_top + 60pt, heading_bottom - 30pt].
     body = (s.get("body") or "").upper()
     if body:
         body_size = 30
         body_line_h = body_size + 12
-        body_y_top = y_head - 20
-        draw_wrapped_highlights(c, 60, body_y_top, body, ctx.font_bold,
-                                body_size, max_w, body_line_h,
-                                max_lines=8, shadow=has_hero)
+        # Pre-wrap to know the line count
+        body_lines_segs = wrap_segments(body, ctx.font_bold, body_size, max_w)
+        body_lines_segs = body_lines_segs[:8]
+        body_total_h = len(body_lines_segs) * body_line_h
+
+        # Available zone: top = just below last heading baseline; bottom = logo top edge + safety
+        zone_top = y_head + head_line_h - 30
+        logo_top_edge = 80 + 90 + 60  # logo y=80, h=90, safety 60
+        zone_bottom = logo_top_edge
+
+        # Center body block in [zone_bottom, zone_top]
+        vcenter = (zone_top + zone_bottom) / 2
+        body_start_y = vcenter + body_total_h / 2 - body_size / 2
+        # Clamp: never push above zone_top, never below zone_bottom
+        body_start_y = min(body_start_y, zone_top - body_size)
+        body_start_y = max(body_start_y, zone_bottom + body_total_h - body_size)
+
+        cur_y = body_start_y
+        for line in body_lines_segs:
+            draw_highlighted_line(c, 60, cur_y, line, ctx.font_bold,
+                                  body_size, shadow=has_hero)
+            cur_y -= body_line_h
 
     draw_logo(c)
     if ctx.is_inner:
@@ -817,37 +862,61 @@ def render_elegant_close(c: canvas.Canvas, s: dict[str, Any],
 
 def render_stat_card_hero(c: canvas.Canvas, s: dict[str, Any],
                           ctx: RenderContext) -> None:
-    """ADOPT pattern 1 — big number center (Quartz/ProPublica)."""
+    """ADOPT pattern 1 — Quartz/ProPublica big-number stat card.
+
+    Fix 3 (2026-05-13): canonical Quartz layout — kicker mute TOP, giant
+    number vertically centered, caption block BELOW number, source mono
+    footer above logo. Previously caption was above number (wrong direction).
+    """
     c.setFillColor(HexColor(COLOR_BG_ANTRACITE))
     c.rect(0, 0, W, H, fill=1, stroke=0)
 
     stat = s.get("stat") or s.get("heading") or ""
     caption = s.get("caption") or s.get("body") or ""
     source = s.get("source") or s.get("yellow_accent") or ""
+    # Optional kicker (small label top — Quartz convention).
+    # Falls back to source-like field if no explicit kicker.
+    kicker = (s.get("kicker") or s.get("subheading") or "").upper()
 
-    # Adapt stat font size based on length
+    # 1. Kicker (small mute label top)
+    if kicker:
+        c.setFillColor(HexColor(COLOR_TEXT_MUTED))
+        c.setFont(ctx.font_mono, 20)
+        kw = stringWidth(kicker[:60], ctx.font_mono, 20)
+        c.drawString((W - kw) / 2, H - 180, kicker[:60])
+
+    # 2. Giant number (vertically centered, ~middle of canvas)
     stat_size = 380 if len(stat) <= 4 else (280 if len(stat) <= 6 else 200)
     c.setFillColor(HexColor(COLOR_ACCENT_YELLOW))
     c.setFont(ctx.font_bold, stat_size)
     stat_w = stringWidth(stat, ctx.font_bold, stat_size)
-    c.drawString((W - stat_w) / 2, 620, stat)
+    # Anchor stat so its center sits near vertical middle of canvas
+    # (canvas vertical center = 675, stat baseline ~ center + stat_size*0.35)
+    stat_baseline = H / 2 - stat_size * 0.35
+    c.drawString((W - stat_w) / 2, stat_baseline, stat)
 
+    # 3. Caption (BELOW the number — Quartz readout)
     if caption:
-        lines = wrap_simple(caption.upper(), ctx.font_bold, 36, W - 200)[:3]
-        cur_y = 540
+        cap_size = 32
+        lines = wrap_simple(caption.upper(), ctx.font_bold, cap_size, W - 200)[:3]
+        # Anchor caption block top just below the stat baseline minus
+        # some safety (stat_baseline - 60 is "below the number's bottom")
+        cap_top = stat_baseline - 90
+        cur_y = cap_top
         for ln in lines:
-            lw = stringWidth(ln, ctx.font_bold, 36)
+            lw = stringWidth(ln, ctx.font_bold, cap_size)
             c.setFillColor(HexColor(COLOR_TEXT_WHITE))
-            c.setFont(ctx.font_bold, 36)
+            c.setFont(ctx.font_bold, cap_size)
             c.drawString((W - lw) / 2, cur_y, ln)
-            cur_y -= 50
+            cur_y -= 46
 
+    # 4. Source mono footer (above logo)
     if source:
         c.setFillColor(HexColor(COLOR_TEXT_MUTED))
-        c.setFont(ctx.font_mono, 22)
+        c.setFont(ctx.font_mono, 20)
         meta = f"SOURCE: {source.upper()}"
-        mw = stringWidth(meta, ctx.font_mono, 22)
-        c.drawString((W - mw) / 2, 250, meta)
+        mw = stringWidth(meta, ctx.font_mono, 20)
+        c.drawString((W - mw) / 2, 230, meta)
 
     draw_logo(c)
     if ctx.is_inner:

--- a/scripts/wr2_canva_pdf_render.py
+++ b/scripts/wr2_canva_pdf_render.py
@@ -1,0 +1,1107 @@
+#!/usr/bin/env python3
+"""WR2 Canva PDF renderer — production multi-page.
+
+Architecture:
+  slides.json  →  ReportLab PDF (text-layered, editable in Canva)  →  Tigris S3
+  upload  →  Canva import-design-from-url (MCP)  →  layer-editable design.
+
+Slide types supported (auto-routed via `slide.layout_family`):
+  - cover-photo                  → cover with hero + yellow subhead + heading
+                                   + regulation badge (Article 14.4, yellow AAA)
+  - photo-headline-yellow-sub    → inner hero + body
+  - dark-status-list             → 3-6 status items neutral/critical/positive
+  - evidence-carved              → "Hammurabi" code+evidence+ledger structure
+  - qa-dialogue                  → 2-3 voice exchanges
+  - timeline-pinboard            → date+event list
+  - three-verdicts               → decision-tree three columns
+  - statement-bomb               → closing single-statement
+  - elegant-close                → soft CTA (email + WA + IF/WHEN)
+  - stat-card-hero               → big number center (ADOPT pattern 1)
+  - thin-red-rule-divider        → red rule + body + mono footer (ADOPT 2)
+  - swiss-grid-asymmetry         → numerals + steps (ADOPT 3)
+  - monospace-evidence-block     → system output as evidence (ADOPT 4)
+
+Inputs:
+  Either:
+    --slides-json /path/to/slides.json   (file mode, smoke tests)
+  Or:
+    --draft-id <uuid>                    (PG mode, production cron)
+
+Outputs (when --apply set):
+  - PDF at /tmp/wr2_<draft_id>.pdf
+  - Tigris upload to s3://nuzantara-warroom-images/wr2-pdf/<draft_id>.pdf
+  - Canva design created via MCP import-design-from-url
+  - PG update: war_room_drafts.canva_design_id, .status='rendered'
+
+Without --apply: only writes PDF to /tmp for visual review.
+
+Design tokens — SOURCE OF TRUTH: ~/.claude/skills/bali-zero-brand/tokens.json
+This renderer mirrors those values for offline use; if tokens.json changes,
+update RGB constants below. Yellow badge migration applied 2026-05-13
+(commit 940fc77 in ~/.claude).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from PIL import Image
+from reportlab.lib.colors import Color, HexColor
+from reportlab.pdfbase import pdfmetrics
+from reportlab.pdfbase.pdfmetrics import stringWidth
+from reportlab.pdfbase.ttfonts import TTFont
+from reportlab.pdfgen import canvas
+
+# ---------- Constants (mirror of tokens.json) ----------
+W, H = 1080, 1350
+
+COLOR_BG_ANTRACITE = "#2C2F38"
+COLOR_BG_BLACK = "#000000"
+COLOR_TEXT_WHITE = "#FFFFFF"
+COLOR_TEXT_MUTED = "#9CA3AF"
+COLOR_ACCENT_YELLOW = "#F4C430"
+COLOR_STATUS_RED = "#C8102E"
+
+LOGO_PATH = Path.home() / ".claude/skills/bali-zero-brand/assets/logo.png"
+
+# ---------- Yellow highlight regex (Article 6.9 anchor family) ----------
+# These patterns identify "verifiable facts" tokens that get yellow color
+# in body text (numbers, regulations, verdicts). Mirrors split_for_yellow().
+YELLOW_TOKEN_PATTERNS = [
+    # Numbers + currency + percentages + units
+    r"\b\d+([,.\d]+)*[KMB]?(?:\s+(?:DAYS|YEARS|MONTHS|HECTARES|VILLAS|"
+    r"BILLION|MILLION|RIBU|JUTA|MILIAR|TRILYUN))?\b",
+    r"\b(?:RP|IDR|USD|EUR|\$)\s?\d+([,.\d]+)*[KMB]?\b",
+    r"\b\d+%\b",
+    # Indonesian regulations (verbatim — Article 6.4)
+    r"\b(?:PP|PERMENKUMHAM|PERMEN\w+|UU|KEP-\d+|PERPRES|PERMENDAGRI|"
+    r"PERMENKES|PMK|PER-?BKPM|PERDA)[\s-]?\d+/\d{4}\b",
+    # Verdict / state-change verbs (Article 6.9 anchor 4)
+    r"\b(?:WON|LOST|BANS|BANNED|RESCINDED|WAIVED|"
+    r"SHUTS\s+DOWN|BLOCKED|RESTORED|EXPIRES|KILLED|"
+    r"MUST|CANNOT|FORBIDDEN|ABOLISHED|SUSPENDED|REVOKED|"
+    r"REJECTED|APPROVED|EXTENDED|DEFERRED|"
+    r"SIGNAL|WIN|LOSS|END|START|STOP|CHANGE|RESET|"
+    r"RECRUITING|COMPETING|FILTERING|"
+    r"NAMED|APPOINTED|PROMOTED|DEMOTED|REPLACED|"
+    r"DROPPED|RAISED|CUT)\b",
+]
+YELLOW_COMPILED = [re.compile(p, re.IGNORECASE) for p in YELLOW_TOKEN_PATTERNS]
+
+
+# ---------- Font registry ----------
+
+def register_fonts() -> None:
+    """Register Montserrat/Arial/Menlo into ReportLab. Idempotent."""
+    candidates = [
+        ("/Users/nuzantara/Library/Fonts/Montserrat-ExtraBold.ttf",
+         "Montserrat-ExtraBold"),
+        ("/Users/nuzantara/Library/Fonts/Montserrat-Bold.ttf",
+         "Montserrat-Bold"),
+        ("/Users/nuzantara/Library/Fonts/Montserrat-Regular.ttf",
+         "Montserrat-Regular"),
+        ("/System/Library/Fonts/Supplemental/Arial Bold.ttf", "ArialBold"),
+        ("/System/Library/Fonts/Supplemental/Arial.ttf", "Arial"),
+        ("/System/Library/Fonts/Supplemental/Courier New Bold.ttf",
+         "CourierNewBold"),
+        ("/System/Library/Fonts/Supplemental/Courier New.ttf", "CourierNew"),
+        ("/System/Library/Fonts/Menlo.ttc", "Menlo"),
+    ]
+    for path, name in candidates:
+        if Path(path).exists():
+            try:
+                pdfmetrics.registerFont(TTFont(name, path))
+            except Exception:
+                pass
+
+
+def pick_font(prefer: list[str]) -> str:
+    for f in prefer:
+        try:
+            pdfmetrics.getFont(f)
+            return f
+        except Exception:
+            continue
+    return "Helvetica"
+
+
+# ---------- Text utilities ----------
+
+def split_for_yellow(text: str) -> list[tuple[str, bool]]:
+    """Return [(segment, is_yellow), ...] covering the input text."""
+    matches: list[tuple[int, int]] = []
+    for pat in YELLOW_COMPILED:
+        for m in pat.finditer(text):
+            matches.append((m.start(), m.end()))
+    matches.sort()
+    merged: list[tuple[int, int]] = []
+    for s, e in matches:
+        if merged and s < merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], e))
+        else:
+            merged.append((s, e))
+    segments: list[tuple[str, bool]] = []
+    last = 0
+    for s, e in merged:
+        if s > last:
+            segments.append((text[last:s], False))
+        segments.append((text[s:e], True))
+        last = e
+    if last < len(text):
+        segments.append((text[last:], False))
+    return segments if segments else [(text, False)]
+
+
+def wrap_segments(text: str, font: str, size: int,
+                  max_w: int) -> list[list[tuple[str, bool]]]:
+    """Wrap text into lines, preserving (segment, is_yellow) tuples."""
+    full_segs = split_for_yellow(text)
+    lines: list[list[tuple[str, bool]]] = []
+    cur_line: list[tuple[str, bool]] = []
+    cur_width = 0.0
+    for seg_text, is_y in full_segs:
+        for word in seg_text.split(" "):
+            if not word:
+                continue
+            word_w = stringWidth(word + " ", font, size)
+            if cur_width + word_w > max_w and cur_line:
+                lines.append(cur_line)
+                cur_line = []
+                cur_width = 0.0
+            cur_line.append((word + " ", is_y))
+            cur_width += word_w
+    if cur_line:
+        lines.append(cur_line)
+    return lines
+
+
+def smart_wrap_heading(text: str, font: str, size: int,
+                       max_w: int) -> list[str]:
+    """Wrap heading, keeping N+adjacent-noun atoms (e.g. '31 EXTRA DAYS') together."""
+    nbsp = " "
+    protected = text
+    # Detect "<number> <word>" or "<number> <word> <word>" patterns
+    matches = list(re.finditer(
+        r"\b(\d+([,.\d]+)*[KMB]?)\s+(\w+(?:\s+\w+){0,1})\b", text))
+    for m in reversed(matches):
+        atom = m.group(0)
+        if stringWidth(atom, font, size) <= max_w:
+            protected = protected[:m.start()] + atom.replace(
+                " ", nbsp) + protected[m.end():]
+    words = protected.split(" ")
+    lines: list[str] = []
+    cur: list[str] = []
+    for word in words:
+        cand = " ".join(cur + [word])
+        cand_disp = cand.replace(nbsp, " ")
+        if stringWidth(cand_disp, font, size) <= max_w or not cur:
+            cur.append(word)
+        else:
+            lines.append(" ".join(cur).replace(nbsp, " "))
+            cur = [word]
+    if cur:
+        lines.append(" ".join(cur).replace(nbsp, " "))
+    return lines
+
+
+def adaptive_heading(text: str, font: str, max_w: int, max_size: int = 64,
+                     min_size: int = 40, max_lines: int = 3) -> tuple[int, list[str]]:
+    """Find largest font size where heading fits ≤max_lines."""
+    for size in range(max_size, min_size - 1, -4):
+        lines = smart_wrap_heading(text, font, size, max_w)
+        if len(lines) <= max_lines:
+            return size, lines
+    return min_size, smart_wrap_heading(text, font, min_size, max_w)[:max_lines]
+
+
+def wrap_simple(text: str, font: str, size: int, max_w: int) -> list[str]:
+    """Plain word-wrap without yellow segmentation."""
+    words = text.split()
+    lines: list[str] = []
+    cur: list[str] = []
+    for w in words:
+        cand = " ".join(cur + [w])
+        if stringWidth(cand, font, size) <= max_w or not cur:
+            cur.append(w)
+        else:
+            lines.append(" ".join(cur))
+            cur = [w]
+    if cur:
+        lines.append(" ".join(cur))
+    return lines
+
+
+def draw_text_shadow(c: canvas.Canvas, x: float, y: float, text: str,
+                     font: str, size: int, fill_hex: str,
+                     shadow_off: int = 3, shadow_a: float = 0.75) -> None:
+    c.saveState()
+    c.setFillColor(Color(0, 0, 0, alpha=shadow_a))
+    c.setFont(font, size)
+    c.drawString(x + shadow_off, y - shadow_off, text)
+    c.restoreState()
+    c.setFillColor(HexColor(fill_hex))
+    c.setFont(font, size)
+    c.drawString(x, y, text)
+
+
+def draw_highlighted_line(c: canvas.Canvas, x: float, y: float,
+                          line: list[tuple[str, bool]], font: str, size: int,
+                          shadow: bool = False) -> None:
+    cur_x = x
+    for seg, is_y in line:
+        if shadow:
+            c.saveState()
+            c.setFillColor(Color(0, 0, 0, alpha=0.6))
+            c.setFont(font, size)
+            c.drawString(cur_x + 2, y - 2, seg)
+            c.restoreState()
+        c.setFillColor(HexColor(COLOR_ACCENT_YELLOW if is_y else COLOR_TEXT_WHITE))
+        c.setFont(font, size)
+        c.drawString(cur_x, y, seg)
+        cur_x += stringWidth(seg, font, size)
+
+
+def draw_wrapped_highlights(c: canvas.Canvas, x: float, y: float, text: str,
+                            font: str, size: int, max_w: int, line_h: int,
+                            max_lines: int | None = None,
+                            shadow: bool = True) -> float:
+    lines = wrap_segments(text, font, size, max_w)
+    if max_lines:
+        lines = lines[:max_lines]
+    cur_y = y
+    for line in lines:
+        draw_highlighted_line(c, x, cur_y, line, font, size, shadow=shadow)
+        cur_y -= line_h
+    return cur_y
+
+
+def draw_centered_highlights(c: canvas.Canvas, center_x: float, y: float,
+                             text: str, font: str, size: int, max_w: int,
+                             line_h: int, max_lines: int | None = None,
+                             shadow: bool = False) -> float:
+    lines = wrap_segments(text, font, size, max_w)
+    if max_lines:
+        lines = lines[:max_lines]
+    cur_y = y
+    for line in lines:
+        total_w = sum(stringWidth(seg, font, size) for seg, _ in line)
+        cur_x = center_x - total_w / 2
+        draw_highlighted_line(c, cur_x, cur_y, line, font, size, shadow=shadow)
+        cur_y -= line_h
+    return cur_y
+
+
+# ---------- Image / hero helpers ----------
+
+def _gradient_png(w: int, h: int, top_a: float, bot_a: float,
+                  out_path: str) -> str:
+    img = Image.new("RGBA", (w, h), (0, 0, 0, 0))
+    px = img.load()
+    for y in range(h):
+        a = top_a + (bot_a - top_a) * (y / max(1, h - 1))
+        for x in range(w):
+            px[x, y] = (0, 0, 0, int(a * 255))
+    img.save(out_path, format="PNG")
+    return out_path
+
+
+def _crop_hero_to_canvas(hero_path: str, out_path: str) -> str | None:
+    if not Path(hero_path).exists():
+        return None
+    try:
+        img = Image.open(hero_path).convert("RGB")
+    except Exception:
+        return None
+    sw, sh = img.size
+    target_ratio = W / H
+    src_ratio = sw / sh
+    if src_ratio > target_ratio:
+        nw = int(sh * target_ratio)
+        l = (sw - nw) // 2
+        img = img.crop((l, 0, l + nw, sh))
+    else:
+        nh = int(sw / target_ratio)
+        t = max(0, (sh - nh) // 2)
+        img = img.crop((0, t, sw, t + nh))
+    img = img.resize((W, H), Image.LANCZOS)
+    img.save(out_path, quality=92)
+    return out_path
+
+
+def draw_logo(c: canvas.Canvas, x_center: float = W / 2,
+              y_bottom: float = 80, size: float = 90) -> None:
+    if LOGO_PATH.exists():
+        c.drawImage(str(LOGO_PATH), x_center - size / 2, y_bottom,
+                    width=size, height=size, mask="auto")
+
+
+def draw_swipe_indicator(c: canvas.Canvas) -> None:
+    """SOTA Pattern #10 (Article 14.1) — yellow dot bottom-right on inner slides."""
+    c.setFillColor(HexColor(COLOR_ACCENT_YELLOW))
+    c.circle(W - 32, 32, 6, fill=1, stroke=0)
+
+
+def draw_regulation_badge(c: canvas.Canvas, code: str, font_mono: str) -> None:
+    """SOTA Pattern #3 (Article 14.4 revised 2026-05-13) — yellow rounded badge
+    top-right with regulation code in IBM Plex Mono / Menlo fallback.
+
+    WCAG: yellow #F4C430 vs antracite #2C2F38 = 8.14:1 AAA;
+          black text on yellow = 12.79:1 AAA inside.
+    """
+    if not code:
+        return
+    text_w = stringWidth(code, font_mono, 16)
+    pad_x, pad_y = 12, 6
+    badge_w = text_w + pad_x * 2
+    badge_h = 16 + pad_y * 2
+    x = W - 32 - badge_w
+    y = H - 32 - badge_h
+    c.setFillColor(HexColor(COLOR_ACCENT_YELLOW))
+    c.roundRect(x, y, badge_w, badge_h, 4, fill=1, stroke=0)
+    c.setFillColor(HexColor(COLOR_BG_BLACK))
+    c.setFont(font_mono, 16)
+    c.drawString(x + pad_x, y + pad_y + 3, code)
+
+
+# ---------- Layout renderers ----------
+
+@dataclass
+class RenderContext:
+    font_bold: str
+    font_reg: str
+    font_mono: str
+    slide_count: int
+    is_inner: bool  # slides 2..N-1
+    primary_regulation_code: str | None
+
+
+def render_cover_photo(c: canvas.Canvas, s: dict[str, Any],
+                       ctx: RenderContext) -> None:
+    """Cover slide — hero + yellow subhead + heading + optional badge."""
+    c.setFillColor(HexColor(COLOR_BG_ANTRACITE))
+    c.rect(0, 0, W, H, fill=1, stroke=0)
+
+    hero = s.get("hero_image_path") or s.get("image_path")
+    if hero:
+        cropped = _crop_hero_to_canvas(hero, "/tmp/_wr2_cover_hero.jpg")
+        if cropped:
+            c.drawImage(cropped, 0, 0, width=W, height=H)
+            grad = _gradient_png(W, H // 2, 0.0, 0.92,
+                                 "/tmp/_wr2_cover_grad.png")
+            c.drawImage(grad, 0, 0, width=W, height=H // 2, mask="auto")
+
+    # Regulation badge top-right (Article 14.4)
+    if ctx.primary_regulation_code:
+        draw_regulation_badge(c, ctx.primary_regulation_code, ctx.font_mono)
+
+    max_w = W - 120
+
+    # Heading + subhead with dynamic gap (fix #1)
+    heading_text = s.get("heading", "") or ""
+    sub_text = s.get("subheading") or s.get("sub_heading") or ""
+
+    head_size, head_lines = adaptive_heading(
+        heading_text.upper(), ctx.font_bold, max_w,
+        max_size=72, min_size=48, max_lines=3)
+    head_line_h = head_size + 14
+
+    sub_size = 36
+    sub_lines = smart_wrap_heading(
+        sub_text.upper(), ctx.font_bold, sub_size, max_w)[:2] if sub_text else []
+    sub_line_h = 50
+
+    y_head_bottom_line = 240
+    y_head_top_line = y_head_bottom_line + (len(head_lines) - 1) * head_line_h
+    head_top_edge = y_head_top_line + head_size
+    y_sub_bottom_line = head_top_edge + 60
+    y_sub_top_line = y_sub_bottom_line + (len(sub_lines) - 1) * sub_line_h
+
+    cur_y = y_sub_top_line
+    for line in sub_lines:
+        draw_text_shadow(c, 60, cur_y, line, ctx.font_bold, sub_size,
+                         COLOR_ACCENT_YELLOW, shadow_off=2, shadow_a=0.75)
+        cur_y -= sub_line_h
+
+    cur_y = y_head_top_line
+    for line_text in head_lines:
+        line_segs = split_for_yellow(line_text)
+        cur_x = 60
+        for seg, is_y in line_segs:
+            c.saveState()
+            c.setFillColor(Color(0, 0, 0, alpha=0.75))
+            c.setFont(ctx.font_bold, head_size)
+            c.drawString(cur_x + 3, cur_y - 3, seg)
+            c.restoreState()
+            c.setFillColor(HexColor(COLOR_ACCENT_YELLOW if is_y else COLOR_TEXT_WHITE))
+            c.setFont(ctx.font_bold, head_size)
+            c.drawString(cur_x, cur_y, seg)
+            cur_x += stringWidth(seg, ctx.font_bold, head_size)
+        cur_y -= head_line_h
+
+    draw_logo(c, y_bottom=80, size=110)
+
+
+def render_photo_headline_yellow_sub(c: canvas.Canvas, s: dict[str, Any],
+                                     ctx: RenderContext) -> None:
+    """Inner hero slide — top heading + body + (optional) hero photo."""
+    c.setFillColor(HexColor(COLOR_BG_ANTRACITE))
+    c.rect(0, 0, W, H, fill=1, stroke=0)
+
+    hero = s.get("hero_image_path") or s.get("image_path")
+    has_hero = False
+    if hero:
+        cropped = _crop_hero_to_canvas(hero, "/tmp/_wr2_inner_hero.jpg")
+        if cropped:
+            c.drawImage(cropped, 0, 0, width=W, height=H)
+            grad = _gradient_png(W, H, 0.55, 0.85, "/tmp/_wr2_inner_grad.png")
+            c.drawImage(grad, 0, 0, width=W, height=H, mask="auto")
+            has_hero = True
+
+    if not has_hero:
+        c.setFillColor(HexColor(COLOR_BG_ANTRACITE))
+        c.rect(0, 0, W, H, fill=1, stroke=0)
+
+    max_w = W - 120
+
+    # Yellow sub (top)
+    sub_text = (s.get("subheading") or s.get("yellow_accent") or "").upper()
+    if sub_text:
+        c.setFillColor(HexColor(COLOR_ACCENT_YELLOW))
+        c.setFont(ctx.font_bold, 28)
+        c.drawString(60, H - 110, sub_text[:60])
+
+    # Heading
+    heading = (s.get("heading") or "").upper()
+    head_size, head_lines = adaptive_heading(
+        heading, ctx.font_bold, max_w, max_size=56, min_size=40, max_lines=3)
+    head_line_h = head_size + 12
+    y_head = H - 170
+    for line in head_lines:
+        segs = split_for_yellow(line)
+        cur_x = 60
+        for seg, is_y in segs:
+            c.setFillColor(HexColor(COLOR_ACCENT_YELLOW if is_y else COLOR_TEXT_WHITE))
+            c.setFont(ctx.font_bold, head_size)
+            c.drawString(cur_x, y_head, seg)
+            cur_x += stringWidth(seg, ctx.font_bold, head_size)
+        y_head -= head_line_h
+
+    # Body (UPPERCASE)
+    body = (s.get("body") or "").upper()
+    if body:
+        body_size = 30
+        body_line_h = body_size + 12
+        body_y_top = y_head - 20
+        draw_wrapped_highlights(c, 60, body_y_top, body, ctx.font_bold,
+                                body_size, max_w, body_line_h,
+                                max_lines=8, shadow=has_hero)
+
+    draw_logo(c)
+    if ctx.is_inner:
+        draw_swipe_indicator(c)
+
+
+def render_dark_status_list(c: canvas.Canvas, s: dict[str, Any],
+                            ctx: RenderContext) -> None:
+    """3-6 items label:value, status colors neutral/critical/positive."""
+    c.setFillColor(HexColor(COLOR_BG_ANTRACITE))
+    c.rect(0, 0, W, H, fill=1, stroke=0)
+
+    heading = (s.get("heading") or "").upper()
+    max_w = W - 120
+    head_size, head_lines = adaptive_heading(
+        heading, ctx.font_bold, max_w, max_size=48, min_size=36, max_lines=2)
+    y_head = H - 130
+    for line in head_lines:
+        c.setFillColor(HexColor(COLOR_TEXT_WHITE))
+        c.setFont(ctx.font_bold, head_size)
+        c.drawString(60, y_head, line)
+        y_head -= head_size + 12
+
+    # Red rule
+    c.setStrokeColor(HexColor(COLOR_STATUS_RED))
+    c.setLineWidth(4)
+    c.line(60, y_head - 10, 220, y_head - 10)
+
+    items = s.get("list_items") or []
+    cur_y = y_head - 80
+    for it in items[:6]:
+        label = (it.get("label") or "").upper()
+        value = (it.get("value") or "")[:35].upper()
+        status = it.get("status") or "neutral"
+        color = {
+            "critical": COLOR_STATUS_RED,
+            "positive": COLOR_ACCENT_YELLOW,
+            "neutral": COLOR_TEXT_WHITE,
+        }.get(status, COLOR_TEXT_WHITE)
+
+        c.setFillColor(HexColor(COLOR_TEXT_MUTED))
+        c.setFont(ctx.font_mono, 18)
+        c.drawString(60, cur_y, label)
+
+        c.setFillColor(HexColor(color))
+        c.setFont(ctx.font_bold, 32)
+        c.drawString(60, cur_y - 40, value)
+        cur_y -= 110
+
+    draw_logo(c)
+    if ctx.is_inner:
+        draw_swipe_indicator(c)
+
+
+def render_evidence_carved(c: canvas.Canvas, s: dict[str, Any],
+                           ctx: RenderContext) -> None:
+    """Hammurabi — heading carved + body + small mono code below."""
+    c.setFillColor(HexColor(COLOR_BG_ANTRACITE))
+    c.rect(0, 0, W, H, fill=1, stroke=0)
+
+    heading = (s.get("heading") or "").upper()
+    body = (s.get("body") or "").upper()
+    code_line = s.get("evidence_code") or s.get("yellow_accent") or ""
+
+    max_w = W - 120
+
+    # Carved heading (large, embossed shadow)
+    head_size, head_lines = adaptive_heading(
+        heading, ctx.font_bold, max_w, max_size=60, min_size=44, max_lines=3)
+    head_line_h = head_size + 14
+    y_head = H - 150
+    for line in head_lines:
+        # Engraved effect: dark shadow above, light below
+        c.saveState()
+        c.setFillColor(Color(0, 0, 0, alpha=0.6))
+        c.setFont(ctx.font_bold, head_size)
+        c.drawString(62, y_head - 3, line)
+        c.restoreState()
+        c.setFillColor(HexColor(COLOR_TEXT_WHITE))
+        c.setFont(ctx.font_bold, head_size)
+        c.drawString(60, y_head, line)
+        y_head -= head_line_h
+
+    # Yellow rule
+    rule_y = y_head - 10
+    c.setStrokeColor(HexColor(COLOR_ACCENT_YELLOW))
+    c.setLineWidth(3)
+    c.line(60, rule_y, 280, rule_y)
+
+    # Body
+    if body:
+        body_y_top = rule_y - 50
+        draw_wrapped_highlights(c, 60, body_y_top, body, ctx.font_bold,
+                                28, max_w, 40, max_lines=10, shadow=False)
+
+    # Code/source line (mono bottom)
+    if code_line:
+        c.setFillColor(HexColor(COLOR_TEXT_MUTED))
+        c.setFont(ctx.font_mono, 18)
+        c.drawString(60, 210, code_line.upper())
+
+    draw_logo(c)
+    if ctx.is_inner:
+        draw_swipe_indicator(c)
+
+
+def render_qa_dialogue(c: canvas.Canvas, s: dict[str, Any],
+                       ctx: RenderContext) -> None:
+    """2-3 voice exchanges (founder/Bali Zero/etc)."""
+    c.setFillColor(HexColor(COLOR_BG_ANTRACITE))
+    c.rect(0, 0, W, H, fill=1, stroke=0)
+
+    heading = (s.get("heading") or "").upper()
+    if heading:
+        c.setFillColor(HexColor(COLOR_TEXT_WHITE))
+        c.setFont(ctx.font_bold, 32)
+        c.drawString(60, H - 110, heading[:50])
+
+    pairs = s.get("qa_pairs") or []
+    cur_y = H - 220
+    max_w = W - 160
+    for p in pairs[:3]:
+        voice = (p.get("voice") or "").upper()
+        line = p.get("line") or ""
+        # Voice label yellow
+        c.setFillColor(HexColor(COLOR_ACCENT_YELLOW))
+        c.setFont(ctx.font_mono, 18)
+        c.drawString(60, cur_y, voice)
+        cur_y -= 30
+        # Line body white
+        body_lines = wrap_simple(line, ctx.font_bold, 26, max_w)
+        for bl in body_lines:
+            c.setFillColor(HexColor(COLOR_TEXT_WHITE))
+            c.setFont(ctx.font_bold, 26)
+            c.drawString(60, cur_y, bl)
+            cur_y -= 36
+        cur_y -= 30
+
+    draw_logo(c)
+    if ctx.is_inner:
+        draw_swipe_indicator(c)
+
+
+def render_timeline_pinboard(c: canvas.Canvas, s: dict[str, Any],
+                             ctx: RenderContext) -> None:
+    """date+event vertical timeline with red rule."""
+    c.setFillColor(HexColor(COLOR_BG_ANTRACITE))
+    c.rect(0, 0, W, H, fill=1, stroke=0)
+
+    heading = (s.get("heading") or "").upper()
+    c.setFillColor(HexColor(COLOR_TEXT_WHITE))
+    c.setFont(ctx.font_bold, 36)
+    c.drawString(60, H - 110, heading[:40])
+
+    # Vertical red rule
+    c.setStrokeColor(HexColor(COLOR_STATUS_RED))
+    c.setLineWidth(3)
+    c.line(80, H - 200, 80, 240)
+
+    events = s.get("timeline") or []
+    cur_y = H - 220
+    for ev in events[:6]:
+        date = ev.get("date") or ""
+        event = (ev.get("event") or "").upper()
+        # Dot on rule
+        c.setFillColor(HexColor(COLOR_STATUS_RED))
+        c.circle(80, cur_y, 7, fill=1, stroke=0)
+        # Date yellow
+        c.setFillColor(HexColor(COLOR_ACCENT_YELLOW))
+        c.setFont(ctx.font_mono, 18)
+        c.drawString(110, cur_y + 8, date)
+        # Event
+        evt_lines = wrap_simple(event, ctx.font_bold, 24, W - 180)[:2]
+        evt_y = cur_y - 8
+        for el in evt_lines:
+            c.setFillColor(HexColor(COLOR_TEXT_WHITE))
+            c.setFont(ctx.font_bold, 24)
+            c.drawString(110, evt_y, el)
+            evt_y -= 30
+        cur_y -= 130
+
+    draw_logo(c)
+    if ctx.is_inner:
+        draw_swipe_indicator(c)
+
+
+def render_three_verdicts(c: canvas.Canvas, s: dict[str, Any],
+                          ctx: RenderContext) -> None:
+    """3 columns side-by-side (GO/CAUTION/STOP color-coded)."""
+    c.setFillColor(HexColor(COLOR_BG_ANTRACITE))
+    c.rect(0, 0, W, H, fill=1, stroke=0)
+
+    heading = (s.get("heading") or "").upper()
+    c.setFillColor(HexColor(COLOR_TEXT_WHITE))
+    c.setFont(ctx.font_bold, 32)
+    c.drawString(60, H - 110, heading[:40])
+
+    verdicts = s.get("verdicts") or []
+    col_w = (W - 200) / max(1, min(3, len(verdicts)))
+    color_map = {
+        "go": COLOR_ACCENT_YELLOW,
+        "positive": COLOR_ACCENT_YELLOW,
+        "caution": COLOR_TEXT_WHITE,
+        "neutral": COLOR_TEXT_WHITE,
+        "stop": COLOR_STATUS_RED,
+        "critical": COLOR_STATUS_RED,
+    }
+    for i, v in enumerate(verdicts[:3]):
+        x = 80 + i * (col_w + 40)
+        verdict_kind = (v.get("kind") or "neutral").lower()
+        color = color_map.get(verdict_kind, COLOR_TEXT_WHITE)
+        label = (v.get("label") or "").upper()
+        body = (v.get("body") or "")
+
+        # Label (large color)
+        c.setFillColor(HexColor(color))
+        c.setFont(ctx.font_bold, 44)
+        c.drawString(x, H - 280, label[:8])
+        # Body wrapped
+        body_lines = wrap_simple(body, ctx.font_bold, 22, col_w)[:8]
+        body_y = H - 340
+        for bl in body_lines:
+            c.setFillColor(HexColor(COLOR_TEXT_WHITE))
+            c.setFont(ctx.font_bold, 22)
+            c.drawString(x, body_y, bl)
+            body_y -= 30
+
+    draw_logo(c)
+    if ctx.is_inner:
+        draw_swipe_indicator(c)
+
+
+def render_statement_bomb(c: canvas.Canvas, s: dict[str, Any],
+                          ctx: RenderContext) -> None:
+    """Closing slide — single statement centered, adaptive shrink."""
+    c.setFillColor(HexColor(COLOR_BG_ANTRACITE))
+    c.rect(0, 0, W, H, fill=1, stroke=0)
+
+    statement = (s.get("statement") or s.get("heading") or "").upper().strip()
+    if not statement:
+        return
+
+    # If statement has 2 sentences, render as 2 stanzas
+    sentences = [t.strip() for t in re.split(r"(?<=[.!?])\s+", statement) if t.strip()]
+    if not sentences:
+        sentences = [statement]
+
+    max_w = W - 120
+    # Adaptive shrink: find size where each sentence fits ≤2 lines
+    size = 80
+    while size >= 48:
+        ok = all(len(smart_wrap_heading(snt, ctx.font_bold, size, max_w)) <= 2
+                 for snt in sentences)
+        if ok:
+            break
+        size -= 4
+    line_h = size + 18
+    sentence_gap = 30
+
+    total_lines = sum(len(smart_wrap_heading(snt, ctx.font_bold, size, max_w))
+                      for snt in sentences)
+    total_h = total_lines * line_h + sentence_gap * max(0, len(sentences) - 1)
+    center_y_top = (H + total_h) / 2 - size
+
+    cur_y = center_y_top
+    for snt in sentences:
+        lines = smart_wrap_heading(snt, ctx.font_bold, size, max_w)
+        for line in lines:
+            draw_centered_highlights(c, W / 2, cur_y, line, ctx.font_bold,
+                                     size, max_w, line_h, max_lines=1)
+            cur_y -= line_h
+        cur_y -= sentence_gap
+
+    draw_logo(c, y_bottom=80, size=110)
+
+
+def render_elegant_close(c: canvas.Canvas, s: dict[str, Any],
+                         ctx: RenderContext) -> None:
+    """Optional last slide — soft CTA (Article 6.6.1)."""
+    c.setFillColor(HexColor(COLOR_BG_ANTRACITE))
+    c.rect(0, 0, W, H, fill=1, stroke=0)
+
+    heading = (s.get("heading") or "").upper()
+    body = s.get("body") or ""
+    email = s.get("email") or "zantara@balizero.com"
+    whatsapp = s.get("whatsapp") or "wa.me/6285954680980"
+
+    c.setFillColor(HexColor(COLOR_TEXT_WHITE))
+    c.setFont(ctx.font_bold, 40)
+    c.drawString(60, H - 200, heading[:38])
+
+    if body:
+        lines = wrap_simple(body, ctx.font_bold, 26, W - 120)[:5]
+        cur_y = H - 280
+        for ln in lines:
+            c.setFillColor(HexColor(COLOR_TEXT_WHITE))
+            c.setFont(ctx.font_bold, 26)
+            c.drawString(60, cur_y, ln)
+            cur_y -= 36
+
+    # Soft CTA mono
+    c.setFillColor(HexColor(COLOR_ACCENT_YELLOW))
+    c.setFont(ctx.font_mono, 20)
+    c.drawString(60, 380, email.upper())
+    c.setFillColor(HexColor(COLOR_TEXT_MUTED))
+    c.setFont(ctx.font_mono, 18)
+    c.drawString(60, 350, whatsapp.upper())
+
+    draw_logo(c, y_bottom=80, size=90)
+
+
+# ---------- 4 ADOPT type-as-design patterns (research 2026-05-12) ----------
+
+def render_stat_card_hero(c: canvas.Canvas, s: dict[str, Any],
+                          ctx: RenderContext) -> None:
+    """ADOPT pattern 1 — big number center (Quartz/ProPublica)."""
+    c.setFillColor(HexColor(COLOR_BG_ANTRACITE))
+    c.rect(0, 0, W, H, fill=1, stroke=0)
+
+    stat = s.get("stat") or s.get("heading") or ""
+    caption = s.get("caption") or s.get("body") or ""
+    source = s.get("source") or s.get("yellow_accent") or ""
+
+    # Adapt stat font size based on length
+    stat_size = 380 if len(stat) <= 4 else (280 if len(stat) <= 6 else 200)
+    c.setFillColor(HexColor(COLOR_ACCENT_YELLOW))
+    c.setFont(ctx.font_bold, stat_size)
+    stat_w = stringWidth(stat, ctx.font_bold, stat_size)
+    c.drawString((W - stat_w) / 2, 620, stat)
+
+    if caption:
+        lines = wrap_simple(caption.upper(), ctx.font_bold, 36, W - 200)[:3]
+        cur_y = 540
+        for ln in lines:
+            lw = stringWidth(ln, ctx.font_bold, 36)
+            c.setFillColor(HexColor(COLOR_TEXT_WHITE))
+            c.setFont(ctx.font_bold, 36)
+            c.drawString((W - lw) / 2, cur_y, ln)
+            cur_y -= 50
+
+    if source:
+        c.setFillColor(HexColor(COLOR_TEXT_MUTED))
+        c.setFont(ctx.font_mono, 22)
+        meta = f"SOURCE: {source.upper()}"
+        mw = stringWidth(meta, ctx.font_mono, 22)
+        c.drawString((W - mw) / 2, 250, meta)
+
+    draw_logo(c)
+    if ctx.is_inner:
+        draw_swipe_indicator(c)
+
+
+def render_thin_red_rule_divider(c: canvas.Canvas, s: dict[str, Any],
+                                 ctx: RenderContext) -> None:
+    """ADOPT pattern 2 — FT-style red rule + body + mono footer."""
+    c.setFillColor(HexColor(COLOR_BG_ANTRACITE))
+    c.rect(0, 0, W, H, fill=1, stroke=0)
+
+    rule_y = H - 480
+    c.setStrokeColor(HexColor(COLOR_STATUS_RED))
+    c.setLineWidth(3)
+    c.line(60, rule_y, 380, rule_y)
+
+    body = (s.get("body") or s.get("heading") or "").upper()
+    body_lines = wrap_segments(body, ctx.font_bold, 38, W - 120)[:5]
+    cur_y = rule_y - 70
+    for line in body_lines:
+        draw_highlighted_line(c, 60, cur_y, line, ctx.font_bold, 38)
+        cur_y -= 52
+
+    code = s.get("regulation_code") or ctx.primary_regulation_code or ""
+    source = s.get("source") or ""
+    effective = s.get("effective") or ""
+
+    c.setStrokeColor(HexColor(COLOR_STATUS_RED))
+    c.setLineWidth(1)
+    c.line(60, 260, W - 60, 260)
+
+    c.setFillColor(HexColor(COLOR_TEXT_MUTED))
+    c.setFont(ctx.font_mono, 20)
+    footer = "  ·  ".join(x for x in [code, source] if x)
+    if footer:
+        c.drawString(60, 220, footer)
+    if effective:
+        c.setFont(ctx.font_mono, 18)
+        c.drawString(60, 195, effective)
+
+    draw_logo(c)
+    if ctx.is_inner:
+        draw_swipe_indicator(c)
+
+
+def render_swiss_grid_asymmetry(c: canvas.Canvas, s: dict[str, Any],
+                                ctx: RenderContext) -> None:
+    """ADOPT pattern 3 — Pentagram-style numerals + steps."""
+    c.setFillColor(HexColor(COLOR_BG_ANTRACITE))
+    c.rect(0, 0, W, H, fill=1, stroke=0)
+
+    title_meta = (s.get("yellow_accent") or s.get("subheading") or "").upper()
+    if title_meta:
+        c.setFillColor(HexColor(COLOR_TEXT_MUTED))
+        c.setFont(ctx.font_mono, 20)
+        c.drawString(60, H - 100, title_meta[:60])
+
+    steps = s.get("steps") or []
+    cur_y = H - 220
+    for i, st in enumerate(steps[:4]):
+        num = st.get("num") or f"{i + 1:02d}"
+        head = (st.get("head") or "").upper()
+        body = (st.get("body") or "")
+        emphasis = i == 0
+
+        c.setFillColor(HexColor(COLOR_STATUS_RED if emphasis else COLOR_TEXT_WHITE))
+        c.setFont(ctx.font_bold, 110)
+        c.drawString(60, cur_y - 90, num)
+
+        c.setFillColor(HexColor(COLOR_TEXT_WHITE))
+        c.setFont(ctx.font_bold, 40)
+        c.drawString(220, cur_y - 30, head)
+        c.setFillColor(HexColor(COLOR_TEXT_MUTED))
+        c.setFont(ctx.font_reg, 26)
+        c.drawString(220, cur_y - 65, body)
+
+        cur_y -= 230
+
+    draw_logo(c)
+    if ctx.is_inner:
+        draw_swipe_indicator(c)
+
+
+def render_monospace_evidence_block(c: canvas.Canvas, s: dict[str, Any],
+                                    ctx: RenderContext) -> None:
+    """ADOPT pattern 4 — The Markup-style system output as evidence."""
+    c.setFillColor(HexColor(COLOR_BG_ANTRACITE))
+    c.rect(0, 0, W, H, fill=1, stroke=0)
+
+    heading = (s.get("heading") or "").upper()
+    c.setFillColor(HexColor(COLOR_TEXT_WHITE))
+    c.setFont(ctx.font_bold, 28)
+    c.drawString(60, H - 130, heading[:50])
+
+    c.setStrokeColor(HexColor(COLOR_ACCENT_YELLOW))
+    c.setLineWidth(3)
+    c.line(60, H - 155, 300, H - 155)
+
+    evidence = s.get("evidence_lines") or []
+    cur_y = H - 270
+    for ln_obj in evidence[:14]:
+        if isinstance(ln_obj, str):
+            text = ln_obj
+            color = COLOR_TEXT_WHITE
+        else:
+            text = ln_obj.get("text") or ""
+            color_kind = (ln_obj.get("color") or "white").lower()
+            color = {
+                "white": COLOR_TEXT_WHITE,
+                "yellow": COLOR_ACCENT_YELLOW,
+                "red": COLOR_STATUS_RED,
+                "muted": COLOR_TEXT_MUTED,
+            }.get(color_kind, COLOR_TEXT_WHITE)
+
+        c.setFillColor(HexColor(color))
+        c.setFont(ctx.font_mono, 28)
+        c.drawString(80, cur_y, text)
+        cur_y -= 38
+
+    source = s.get("source") or ""
+    captured = s.get("captured") or ""
+    if source or captured:
+        c.setFillColor(HexColor(COLOR_TEXT_MUTED))
+        c.setFont(ctx.font_mono, 18)
+        footer = "  ·  ".join(x for x in [source, captured] if x).upper()
+        c.drawString(60, 220, footer)
+
+    draw_logo(c)
+    if ctx.is_inner:
+        draw_swipe_indicator(c)
+
+
+# ---------- Router ----------
+
+LAYOUT_DISPATCH = {
+    "cover-photo": render_cover_photo,
+    "cover": render_cover_photo,
+    "photo-headline-yellow-sub": render_photo_headline_yellow_sub,
+    "dark-status-list": render_dark_status_list,
+    "evidence-carved": render_evidence_carved,
+    "qa-dialogue": render_qa_dialogue,
+    "timeline-pinboard": render_timeline_pinboard,
+    "three-verdicts": render_three_verdicts,
+    "statement-bomb": render_statement_bomb,
+    "elegant-close": render_elegant_close,
+    "stat-card-hero": render_stat_card_hero,
+    "thin-red-rule-divider": render_thin_red_rule_divider,
+    "swiss-grid-asymmetry": render_swiss_grid_asymmetry,
+    "monospace-evidence-block": render_monospace_evidence_block,
+}
+
+
+def render_slide(c: canvas.Canvas, slide: dict[str, Any],
+                 ctx: RenderContext) -> None:
+    family = (slide.get("layout_family") or "photo-headline-yellow-sub").strip()
+    fn = LAYOUT_DISPATCH.get(family)
+    if fn is None:
+        sys.stderr.write(
+            f"[wr2-render] unknown layout_family={family!r} on slide "
+            f"{slide.get('index')!r} — falling back to "
+            f"photo-headline-yellow-sub\n")
+        fn = render_photo_headline_yellow_sub
+    fn(c, slide, ctx)
+
+
+# ---------- PDF assembly ----------
+
+def render_carousel(slides_json: dict[str, Any], out_pdf: str) -> int:
+    register_fonts()
+    font_bold = pick_font(["Montserrat-ExtraBold", "Montserrat-Bold",
+                           "ArialBold", "Helvetica-Bold"])
+    font_reg = pick_font(["Montserrat-Regular", "Arial", "Helvetica"])
+    font_mono = pick_font(["Menlo", "CourierNewBold", "CourierNew", "Courier"])
+
+    slides = slides_json.get("slides") or []
+    n = len(slides)
+    primary_regulation_code = (slides_json.get("primary_regulation_code")
+                               or slides_json.get("brief", {}).get(
+                                   "primary_regulation_code"))
+
+    c = canvas.Canvas(out_pdf, pagesize=(W, H))
+    for i, s in enumerate(slides):
+        is_inner = (i > 0) and (i < n - 1)
+        ctx = RenderContext(
+            font_bold=font_bold,
+            font_reg=font_reg,
+            font_mono=font_mono,
+            slide_count=n,
+            is_inner=is_inner,
+            primary_regulation_code=primary_regulation_code,
+        )
+        render_slide(c, s, ctx)
+        c.showPage()
+    c.save()
+    return n
+
+
+# ---------- CLI ----------
+
+def load_slides_from_pg(draft_id: str) -> dict[str, Any]:
+    import psycopg
+
+    dsn = os.environ.get(
+        "WR2_PG_DSN",
+        "postgresql://postgres@127.0.0.1:15432/postgres")
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT topic, slides_json FROM war_room_drafts WHERE id = %s",
+                (draft_id,))
+            row = cur.fetchone()
+            if not row:
+                raise SystemExit(f"draft {draft_id} not found")
+            topic, slides_json = row
+    if isinstance(slides_json, str):
+        slides_json = json.loads(slides_json)
+    slides_json.setdefault("topic", topic)
+    return slides_json
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument("--slides-json", type=str,
+                     help="Local slides.json file (smoke test)")
+    src.add_argument("--draft-id", type=str,
+                     help="war_room_drafts.id (PG mode)")
+    p.add_argument("--out", type=str, default=None,
+                   help="Output PDF path (default /tmp/wr2_<id>.pdf)")
+    p.add_argument("--apply", action="store_true",
+                   help="Upload to Tigris + import into Canva via MCP "
+                        "(otherwise only writes local PDF)")
+    args = p.parse_args()
+
+    if args.slides_json:
+        with open(args.slides_json) as f:
+            slides_json = json.load(f)
+        slug = Path(args.slides_json).stem
+    else:
+        slides_json = load_slides_from_pg(args.draft_id)
+        slug = args.draft_id
+
+    out_pdf = args.out or f"/tmp/wr2_{slug}.pdf"
+    n = render_carousel(slides_json, out_pdf)
+    size = Path(out_pdf).stat().st_size
+    print(f"[wr2-render] wrote {out_pdf} — {n} pages, {size} bytes")
+
+    if args.apply:
+        print("[wr2-render] --apply is a TODO at this stage. The Tigris upload + "
+              "Canva import-design-from-url MCP call is driven by the orchestrator "
+              "(canva-renderer wrapper) — this script only produces the PDF.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

TICKET G.1 — adds `GET /api/bridge/skills` endpoint that lets the Pro side pull `cell:skills` Redis stream entries from Fly Upstash, solving the split-brain detected post Phase 3 organism turn-on.

**Empirical state pre-fix** (verified 2026-05-13 03:09 WITA):
- Fly Upstash `cell:skills` — `XLEN=0`, stream missing (IPv6 6PN private, unreachable from Pro)
- Pro localhost `cell:skills` — `XLEN=19` (B intel-scraper events only)
- A.2 CRM HGT handlers were publishing to dead-end Upstash with no consumer

**Architecture chosen** (per 4-LLM brainstorm 2026-05-13 02:58):
- HTTP request/response pattern (canonical `bridge.py` — same auth model as `/api/bridge/events`)
- Respects SYMBIOSIS Law 3 (no central orchestrator) — Pro pulls on cron tick
- Respects OSINT-blindato (Sentinel stays Pro-local)

## Corrections applied (from 3-LLM brainstorm 2026-05-13 03:18, NB-1 unavailable)

| CORR | Severity | Source | Change |
|---|---|---|---|
| G1 | CRITICAL | Claude self | Redis access via `request.app.state.redis_manager.get_async_client()` (NOT a global `get_redis_client()` — that doesn't exist) |
| G3 | HIGH | Gemini F2 | Dedicated `BRIDGE_SKILLS_API_KEY` (X-Bridge-Skills-Auth header) — isolates HGT skill payloads from generic bridge auth blast radius |
| G4 | HIGH | Gemini F1 | `XINFO STREAM` gap detection — if `after_id` precedes stream's lowest entry ID, respond with `events_orphaned=true` so Pro consumer can reset `last_id` to `"$"` |

## Idempotency (CORR-G2 resolved empirically)

DeepSeek F2 raised concerns about duplicate XADD on consumer crash. Empirical verify at `packages/cell-core/cell_core/genome.py:273`:

```sql
INSERT INTO genome ... ON CONFLICT(id) DO UPDATE SET ...
```

Sentinel-side dedup already exists. The Pro consumer (TICKET G.2, separate PR) will add defense-in-depth via incremental state save every 50 events.

## Test plan

- [x] `apps/backend-rag/backend/tests/routers/test_bridge_router.py` — 17/17 pass (8 existing + 9 new for skills endpoint)
- [x] Empirical pre-flight section in spec v2 — all 5 checks PASS
- [ ] CI E2E + MCP green
- [ ] Operator: add `BRIDGE_SKILLS_API_KEY` to `~/.nuzantara-secrets.env` + Fly secrets BEFORE deploying TICKET G.3 plist

## Artifacts

- Spec v2: `research/symbiosis/2026-05-13-ticket-G-narrow-spec.md`
- Spec v1 DRAFT (kept for archaeology): `research/symbiosis/2026-05-13-ticket-G-narrow-spec-DRAFT.md`
- Brainstorm artifacts: `/tmp/symbiosis-ticket-G-brainstorm-2026-05-13/` (00_briefing + 01_claude + 02_gemini + 03_deepseek + 04_nb1_error + 05_synthesis)
- Split-brain decision context: `/tmp/symbiosis-splitbrain-brainstorm-2026-05-13/05_synthesis.md`

## NB-1 caveat

NotebookLM NB-1 was queried 3 separate times tonight and returned `INVALID_ARGUMENT (error code 3 — account-level restriction)`. Operator should run `nlm login` reauthentication before the next 4-panel brainstorm to restore the 4th seat. 3-LLM quorum was met (Claude self + Gemini 3.1 Pro + DeepSeek Reasoner all APPROVE_WITH_CONDITIONS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)