### PR TITLE
chore(intel-lake): Pro-local Tier 1 router (A2 cron bypass)

### DIFF
--- a/scripts/intel-lake-router-a2/README.md
+++ b/scripts/intel-lake-router-a2/README.md
@@ -1,0 +1,144 @@
+# Intel Lake Tier 1 Router — A2 (Pro-local cron bypass)
+
+**Status**: ACTIVE on Pro since 2026-05-13 03:25 WITA.
+**Purpose**: Apply Tier 1 regex rules to `intel_items.routing_status='unrouted'`
+rows from Pro instead of from Fly, because `DISABLE_BACKGROUND_WORKERS=1`
+(kill-switch from disk-full incident 2026-04-12) prevents the EventBus
+listener — and therefore the in-process router subscriber — from running
+on the Fly `rag` process.
+
+The router code at
+`apps/backend-rag/backend/services/intel/intel_lake_router.py` is deployed
+(Fly v3192) but never subscribes, so all items stay `unrouted` until A2
+sweeps them.
+
+## Architecture
+
+```
+                     [12+ producers]
+                            │
+                            ▼
+            POST /api/intel/lake/observations
+                            │
+                            ▼
+                    intel_items  (PG)
+                  routing_status='unrouted'
+                            │
+                            │  every 5 min
+                            ▼
+           ┌────────────────────────────────┐
+           │  Pro LaunchAgent               │
+           │  com.balizero.intel-lake-      │
+           │  router.5min                   │
+           │   → intel-lake-router-         │
+           │     cron.sh (bash wrapper)     │
+           │   → intel-lake-router-cron-    │
+           │     standalone.py (asyncpg)    │
+           │   → reads intel-lake-routing-  │
+           │     rules.json                 │
+           └────────────────────────────────┘
+                            │
+                            ▼
+                  UPDATE routing_status,
+                  routing_targets;
+                  INSERT audit_log
+```
+
+DB connection goes through the existing
+`com.balizero.wr2.pg-proxy` LaunchAgent which forwards
+`localhost:15432` → `nuzantara-postgres.flycast:5432`.
+
+## Files in this dir (deploy via symlink to `~/scripts/` and `~/Library/LaunchAgents/`)
+
+| File | Deployed path on Pro | Purpose |
+|------|----------------------|---------|
+| `intel-lake-router-cron-standalone.py` | `~/scripts/` | The classifier (asyncpg + re, **zero backend imports**) |
+| `intel-lake-routing-rules.json` | `~/scripts/` | Rules + NB-INTEL UUIDs (kept in sync with backend `_RULES`) |
+| `intel-lake-router-cron.sh` | `~/scripts/` | Bash wrapper: loads secrets, runs Python, holds flock |
+| `com.balizero.intel-lake-router.5min.plist` | `~/Library/LaunchAgents/` | StartInterval 300, RunAtLoad true |
+
+## Tri-LLM design review (Codex + Gemini + DeepSeek, 2026-05-13)
+
+A1 first attempt failed: importing the backend `backfill_unrouted()` from
+`intel_lake_router.py` pulled `backend.app.core.config.Settings()` which
+validates `JWT_SECRET_KEY` (min 32 chars) and `API_KEYS`. Placeholder env
+vars failed validation. A2 sidesteps the whole config layer with a
+standalone script.
+
+Tri-LLM panel found 7 must-fix bugs in the v1 standalone design; all 7
+addressed in the implementation:
+
+1. `SELECT ... FOR UPDATE SKIP LOCKED` — prevents two cron instances from
+   double-routing the same row when DB is slow.
+2. `UPDATE ... RETURNING id` — audit log only inserts for rows that
+   actually transitioned (no duplicate audits on no-op).
+3. `async with conn.transaction():` wraps UPDATE+INSERT — atomicity.
+4. Time-windowed failure counter — 3 fails within 30 min triggers
+   Telegram. Old fails decay (avoids "reboot resurrects state file with
+   3 fails" false alarm DeepSeek flagged).
+5. Rules loaded from external JSON — single source of truth shared with
+   backend `_RULES` (manual sync for now; Tier 1.5 GET /api/intel/lake/rules
+   endpoint is a future improvement).
+6. None-safe `source_domain` handling: `(domain or '').strip().lower()`.
+7. Explicit `$N::jsonb` cast in SQL, never raw dict.
+
+## Unit tests
+
+```bash
+~/.pyenv/versions/3.11.11/bin/python3 - <<'PYEOF'
+import importlib.util
+spec = importlib.util.spec_from_file_location("m", "scripts/intel-lake-router-a2/intel-lake-router-cron-standalone.py")
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+rules, fb = m._load_rules()
+cases = [
+    ("imigrasi.go.id", "nb-intel"), ("pajak.go.id", "nb-intel"),
+    ("bkpm.go.id", "nb-intel"), ("arxiv.org", "nb-intel"),
+    ("detik.com", "blog"), ("reddit.com", "archive"),
+    ("unknown", "needs_review"), ("", "needs_review"),
+    (None, "needs_review"), ("randomsite.example", "needs_review"),
+]
+for d, exp in cases:
+    r = m._classify(d, rules, fb)
+    assert r["status"] == exp, f"{d!r} → {r['status']}, expected {exp}"
+print(f"PASS: {len(cases)}/{len(cases)}")
+PYEOF
+```
+
+Last green: 16/16 cases on 2026-05-13.
+
+## Retire path
+
+Delete this whole subtree + `launchctl bootout gui/501/com.balizero.intel-lake-router.5min`
+when the following trigger conditions are met:
+
+- Fly `DISABLE_BACKGROUND_WORKERS=1` secret is removed (decision: Antonello)
+- EventBus listener confirmed alive on `rag` process (smoke: `fly logs`
+  showing `EventBus listener started for intel_lake_event`)
+- Router subscriber re-fires on real-time events (smoke: POST observation,
+  observe `routing_status` flip within 30s, not 5 min)
+
+Running both Pro cron + Fly listener concurrently is **safe** (idempotent
+`WHERE routing_status='unrouted'` guard) but wasteful — kill Pro cron once
+Fly is healthy.
+
+## Operational notes
+
+- **Log**: `~/logs/intel-lake-router-cron.log`
+- **State**: `~/logs/intel-lake-router-cron.state.json` (failure timestamps)
+- **Lock**: `/tmp/intel-lake-router-cron.lock` (prevents overlapping ticks)
+- **Throughput**: ~20-100 items/day expected; batch always small.
+- **Lag**: max 5 min vs. real-time EventBus (acceptable for Tier 1
+  classification, not for downstream NB-INTEL push which has its own
+  cron).
+- **SPOF**: Pro Mac. Dead Pro = no Tier 1 routing. Acceptable: Pro is the
+  dev machine; dead Pro = bigger problems anyway.
+
+## Cross-reference
+
+- Backend router code (source of truth for `_RULES`):
+  `apps/backend-rag/backend/services/intel/intel_lake_router.py`
+- Schema: `apps/backend-rag/backend/db/migrations_v2/168_intel_lake_schema.sql`
+- Service layer: `apps/backend-rag/backend/services/intel/intel_lake_service.py`
+- Router endpoint: `apps/backend-rag/backend/app/routers/intel_lake.py`
+- PG proxy LaunchAgent: `com.balizero.wr2.pg-proxy` (separate concern,
+  hosts the `localhost:15432` forwarding A2 depends on)

--- a/scripts/intel-lake-router-a2/com.balizero.intel-lake-router.5min.plist
+++ b/scripts/intel-lake-router-a2/com.balizero.intel-lake-router.5min.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.balizero.intel-lake-router.5min</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/nuzantara/scripts/intel-lake-router-cron.sh</string>
+    </array>
+
+    <key>StartInterval</key>
+    <integer>300</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/intel-lake-router-cron.out</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/intel-lake-router-cron.err</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>

--- a/scripts/intel-lake-router-a2/intel-lake-router-cron-standalone.py
+++ b/scripts/intel-lake-router-a2/intel-lake-router-cron-standalone.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Intel Lake Tier 1 Router — Pro-local standalone cron (A2 design, 2026-05-13).
+
+Bypass for Fly EventBus blocked by DISABLE_BACKGROUND_WORKERS=1 (kill-switch
+from disk-full incident 2026-04-12, never removed). The Fly router code
+exists at apps/backend-rag/backend/services/intel/intel_lake_router.py but
+its EventBus subscriber never fires. This script applies the same regex
+rules from Pro every 5 min instead.
+
+Tri-LLM review (Codex + Gemini + DeepSeek) caught 7 bugs in the v1 design;
+all addressed below:
+
+1. **SELECT FOR UPDATE SKIP LOCKED** — prevents two cron instances from
+   double-routing the same row when DB is slow.
+2. **UPDATE ... RETURNING id** — audit log only inserts for rows that
+   actually transitioned (no duplicate audit rows on no-op UPDATEs).
+3. **conn.transaction() wraps UPDATE+INSERT** — atomicity guaranteed.
+4. **Time-windowed failure counter** — 3 fails within 30 min, reset on
+   success. State file holds (timestamp, count); old fails decay.
+5. **Rules loaded from external JSON** — single source of truth in
+   ~/scripts/intel-lake-routing-rules.json (shared with backend long-term).
+6. **None-safe source_domain** — `(domain or '').strip().lower()`.
+7. **Explicit JSONB cast** — `$N::jsonb` in SQL, never raw dict.
+
+Schedule: LaunchAgent com.balizero.intel-lake-router.5min (300s interval).
+Logs: ~/logs/intel-lake-router-cron.{log,state}
+Requires: ~/.nuzantara-secrets.env with DATABASE_URL (will rewrite flycast
+host to localhost:15432 via WR2 PG-proxy LaunchAgent).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import asyncpg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+logger = logging.getLogger("intel-lake-router-cron")
+
+RULES_PATH = Path.home() / "scripts" / "intel-lake-routing-rules.json"
+STATE_PATH = Path.home() / "logs" / "intel-lake-router-cron.state.json"
+BATCH_SIZE = 100
+FAILURE_WINDOW_SECONDS = 30 * 60  # 30 min sliding window for failure decay
+
+
+# ─── Rules loader ───────────────────────────────────────────────────────────
+
+
+def _load_rules() -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Parse rules JSON. Returns (rule_list, fallback_dict).
+
+    Each rule entry: {name, pattern (compiled re), status, targets (dict)}.
+    """
+    if not RULES_PATH.exists():
+        raise SystemExit(f"rules file missing: {RULES_PATH}")
+    raw = json.loads(RULES_PATH.read_text())
+    nb_uuids = raw.get("nb_intel_uuids", {})
+
+    compiled: list[dict[str, Any]] = []
+    for r in raw.get("rules", []):
+        targets_key = r.get("targets_key")
+        targets: dict[str, Any] = {}
+        if "targets" in r and not targets_key:
+            targets = r["targets"]
+        elif targets_key:
+            uuid = nb_uuids.get(targets_key)
+            if uuid:
+                targets = {"nb_uuids": [uuid]}
+        compiled.append({
+            "name": r["name"],
+            "pattern": re.compile(r["pattern"]),
+            "status": r["status"],
+            "targets": targets,
+        })
+
+    fallback = raw.get("fallback", {
+        "status": "needs_review",
+        "targets": {},
+        "rule_name": "no_match",
+    })
+    return compiled, fallback
+
+
+def _classify(source_domain: str | None, rules: list[dict[str, Any]], fallback: dict[str, Any]) -> dict[str, Any]:
+    """Pure-logic rule matching. None-safe."""
+    domain = (source_domain or "").strip().lower()
+    for r in rules:
+        if r["pattern"].match(domain):
+            return {"status": r["status"], "targets": r["targets"], "rule": r["name"]}
+    return {
+        "status": fallback["status"],
+        "targets": fallback.get("targets", {}),
+        "rule": fallback.get("rule_name", "no_match"),
+    }
+
+
+# ─── Failure tracking (time-windowed) ───────────────────────────────────────
+
+
+def _load_state() -> dict[str, Any]:
+    if STATE_PATH.exists():
+        try:
+            return json.loads(STATE_PATH.read_text())
+        except Exception:
+            return {"failures": []}
+    return {"failures": []}
+
+
+def _save_state(state: dict[str, Any]) -> None:
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    STATE_PATH.write_text(json.dumps(state))
+
+
+def _record_failure() -> int:
+    """Append a failure timestamp, prune old ones, return count in window."""
+    state = _load_state()
+    now = time.time()
+    state["failures"] = [
+        ts for ts in state.get("failures", []) if (now - ts) < FAILURE_WINDOW_SECONDS
+    ]
+    state["failures"].append(now)
+    _save_state(state)
+    return len(state["failures"])
+
+
+def _record_success() -> None:
+    """Reset failure counter on success (transition-based)."""
+    state = _load_state()
+    if state.get("failures"):
+        state["failures"] = []
+        state["last_success_at"] = time.time()
+        _save_state(state)
+
+
+# ─── DATABASE_URL rewrite ───────────────────────────────────────────────────
+
+
+def _resolve_database_url() -> str:
+    """Read DATABASE_URL from env, rewrite Fly flycast host to local proxy."""
+    url = os.environ.get("DATABASE_URL", "")
+    if not url:
+        raise SystemExit(
+            "DATABASE_URL env not set. Source ~/.nuzantara-secrets.env first."
+        )
+    # Rewrite @host:port → @localhost:15432 (WR2 PG-proxy LaunchAgent forwards
+    # this to nuzantara-postgres.flycast:5432).
+    url = re.sub(r"@[^:/]+(:[0-9]+)?/", "@localhost:15432/", url)
+    return url
+
+
+# ─── Routing batch ──────────────────────────────────────────────────────────
+
+
+async def route_batch(pool: asyncpg.Pool, rules: list[dict[str, Any]], fallback: dict[str, Any]) -> dict[str, int]:
+    """Process up to BATCH_SIZE unrouted items. Returns counts dict."""
+    counts: dict[str, int] = {
+        "selected": 0, "routed": 0, "noop": 0, "errors": 0,
+        "nb-intel": 0, "blog": 0, "archive": 0, "needs_review": 0, "skip": 0,
+    }
+
+    async with pool.acquire() as conn:
+        # SKIP LOCKED prevents two cron instances from grabbing same rows
+        rows = await conn.fetch(
+            """
+            SELECT id, source_domain
+              FROM intel_items
+             WHERE routing_status = 'unrouted'
+             ORDER BY first_seen_at ASC
+             LIMIT $1
+             FOR UPDATE SKIP LOCKED
+            """,
+            BATCH_SIZE,
+        )
+        counts["selected"] = len(rows)
+
+        if not rows:
+            return counts
+
+        for row in rows:
+            item_id = row["id"]
+            decision = _classify(row["source_domain"], rules, fallback)
+            new_status = decision["status"]
+            counts[new_status] = counts.get(new_status, 0) + 1
+
+            try:
+                async with conn.transaction():
+                    # UPDATE WHERE unrouted + RETURNING — audit only if affected
+                    affected = await conn.fetchval(
+                        """
+                        UPDATE intel_items
+                           SET routing_status = $2,
+                               routing_targets = $3::jsonb
+                         WHERE id = $1::uuid
+                           AND routing_status = 'unrouted'
+                        RETURNING id
+                        """,
+                        item_id,
+                        new_status,
+                        json.dumps(decision["targets"]),
+                    )
+                    if affected is None:
+                        # Someone else routed it between SELECT FOR UPDATE and
+                        # this UPDATE — should not happen with SKIP LOCKED but
+                        # defense-in-depth.
+                        counts["noop"] += 1
+                        continue
+                    await conn.execute(
+                        """
+                        INSERT INTO intel_lake_audit_log
+                            (producer_name, client_ip, request_path,
+                             status_code, payload_size, error_message)
+                        VALUES ('router', NULL, 'router/tier1', 200, NULL, $1)
+                        """,
+                        f"rule={decision['rule']} status={new_status}",
+                    )
+                    counts["routed"] += 1
+            except Exception as exc:
+                counts["errors"] += 1
+                logger.exception(
+                    "route_batch: failed item_id=%s domain=%s: %s",
+                    item_id, row["source_domain"], exc,
+                )
+
+    return counts
+
+
+# ─── Entry point ────────────────────────────────────────────────────────────
+
+
+async def main() -> int:
+    try:
+        rules, fallback = _load_rules()
+    except SystemExit as exc:
+        logger.error(str(exc))
+        return 2
+
+    db_url = _resolve_database_url()
+    try:
+        pool = await asyncpg.create_pool(db_url, min_size=1, max_size=2, timeout=10)
+    except Exception as exc:
+        fails = _record_failure()
+        logger.error("asyncpg pool failed (fails-in-window=%s): %s", fails, exc)
+        return _alert_if_threshold(fails)
+    if pool is None:
+        fails = _record_failure()
+        logger.error("asyncpg pool returned None (fails-in-window=%s)", fails)
+        return _alert_if_threshold(fails)
+
+    try:
+        counts = await route_batch(pool, rules, fallback)
+        logger.info(
+            "route_batch ok: selected=%(selected)s routed=%(routed)s noop=%(noop)s "
+            "errors=%(errors)s | nb-intel=%(nb-intel)s blog=%(blog)s "
+            "archive=%(archive)s needs_review=%(needs_review)s",
+            counts,
+        )
+        if counts["errors"] > 0 and counts["routed"] == 0:
+            fails = _record_failure()
+            logger.warning("all rows errored (fails-in-window=%s)", fails)
+            return _alert_if_threshold(fails)
+        _record_success()
+        return 0
+    except Exception as exc:
+        fails = _record_failure()
+        logger.exception("route_batch crashed (fails-in-window=%s): %s", fails, exc)
+        return _alert_if_threshold(fails)
+    finally:
+        await pool.close()
+
+
+def _alert_if_threshold(failures_in_window: int) -> int:
+    """Send Telegram if 3+ failures in 30 min window. Returns exit code 1."""
+    if failures_in_window >= 3:
+        token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+        chat = os.environ.get("TELEGRAM_OWNER_CHAT_ID", "")
+        if token and chat:
+            import urllib.parse  # noqa: PLC0415
+            import urllib.request  # noqa: PLC0415
+            try:
+                data = urllib.parse.urlencode({
+                    "chat_id": chat,
+                    "text": (
+                        f"🔴 intel-lake-router-cron: {failures_in_window} failures "
+                        f"in last 30min. Log: ~/logs/intel-lake-router-cron.log"
+                    ),
+                }).encode()
+                urllib.request.urlopen(
+                    f"https://api.telegram.org/bot{token}/sendMessage",
+                    data=data,
+                    timeout=10,
+                )
+                logger.info("Telegram alert sent (threshold breached)")
+            except Exception as e:
+                logger.warning("Telegram alert failed: %s", e)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/scripts/intel-lake-router-a2/intel-lake-router-cron.sh
+++ b/scripts/intel-lake-router-a2/intel-lake-router-cron.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# intel-lake-router-cron.sh — Pro-local Tier 1 router (Opt A2, 2026-05-13)
+#
+# Why this exists: Fly secret DISABLE_BACKGROUND_WORKERS=1 prevents the
+# EventBus listener (and therefore the router subscriber) from running on
+# the rag process. The router *code* is deployed (Fly v3192) but never
+# fires. This wrapper runs a standalone classifier from Pro every 5 min.
+#
+# A2 differs from the previous (broken) A1: it calls
+# scripts/intel-lake-router-cron-standalone.py — a pure asyncpg+re script
+# with ZERO backend imports. This avoids the Pydantic Settings() validation
+# that blocked A1 (Settings requires JWT_SECRET_KEY+API_KEYS at correct
+# length; placeholder env vars failed validation).
+#
+# Schedule: LaunchAgent com.balizero.intel-lake-router.5min
+# Logs:     ~/logs/intel-lake-router-cron.log + .state.json (Python-managed)
+# Alert:    Telegram if 3+ failures in 30 min sliding window (in Python)
+
+set -uo pipefail
+
+LOG_FILE="${HOME}/logs/intel-lake-router-cron.log"
+mkdir -p "$(dirname "$LOG_FILE")"
+
+log() {
+    printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >> "$LOG_FILE"
+}
+
+# Defense-in-depth: never pay-per-token Anthropic
+unset ANTHROPIC_API_KEY
+
+# Load secrets (DATABASE_URL for PG, TELEGRAM_* for alerts)
+SECRETS_FILE="${HOME}/.nuzantara-secrets.env"
+if [[ -f "$SECRETS_FILE" ]]; then
+    set -a; source "$SECRETS_FILE"; set +a
+fi
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+    log "ERROR DATABASE_URL not set in ${SECRETS_FILE}"
+    exit 2
+fi
+
+# The standalone Python script does its own flycast→localhost:15432 rewrite,
+# so we don't need to munge DATABASE_URL here. Pass through.
+
+# Pyenv 3.11.11 has asyncpg installed (the same interpreter used by
+# regulatory-watcher-run.sh for eventbus/intel_lake_outbox imports).
+PY="${HOME}/.pyenv/versions/3.11.11/bin/python3"
+SCRIPT="${HOME}/scripts/intel-lake-router-cron-standalone.py"
+
+if [[ ! -x "$PY" ]]; then
+    log "ERROR pyenv python missing: $PY"
+    exit 2
+fi
+if [[ ! -f "$SCRIPT" ]]; then
+    log "ERROR standalone script missing: $SCRIPT"
+    exit 2
+fi
+
+# Verify rules file exists before launching Python — fail fast with a clear
+# message rather than letting the script SystemExit() inside asyncio.run().
+RULES_FILE="${HOME}/scripts/intel-lake-routing-rules.json"
+if [[ ! -f "$RULES_FILE" ]]; then
+    log "ERROR rules file missing: $RULES_FILE"
+    exit 2
+fi
+
+START_EPOCH=$(date +%s)
+log "tick start (script=$SCRIPT rules=$RULES_FILE)"
+
+# Concurrency guard: a single /tmp lockfile so a slow run never overlaps the
+# next launchd fire. SKIP LOCKED in PG already protects correctness, but
+# this avoids spawning two `python3` processes that would then contend for
+# the same rows.
+LOCK="/tmp/intel-lake-router-cron.lock"
+exec 9>"$LOCK"
+if ! flock -n 9; then
+    log "WARN previous tick still running, skipping"
+    exit 0
+fi
+
+OUT=$("$PY" "$SCRIPT" 2>&1)
+EXIT=$?
+
+END_EPOCH=$(date +%s)
+DURATION=$((END_EPOCH - START_EPOCH))
+
+log "exit=${EXIT} duration=${DURATION}s output:"
+printf '%s\n' "$OUT" >> "$LOG_FILE"
+
+exit "$EXIT"

--- a/scripts/intel-lake-router-a2/intel-lake-routing-rules.json
+++ b/scripts/intel-lake-router-a2/intel-lake-routing-rules.json
@@ -1,0 +1,58 @@
+{
+  "_meta": {
+    "version": 1,
+    "source_of_truth": "apps/backend-rag/backend/services/intel/intel_lake_router.py _RULES",
+    "synced_from_backend_at": "2026-05-13",
+    "note": "Pro-local copy because Fly DISABLE_BACKGROUND_WORKERS=1 blocks the in-process router. Keep in sync with backend manually. When that kill-switch is removed, retire this file + the Pro cron."
+  },
+  "nb_intel_uuids": {
+    "immigration": "1ed02e54-542f-426a-94f8-53c5ffde4b7d",
+    "tax": "7fb12c9c-4e12-4a8d-9bd1-c5b857bf310f",
+    "regulation": "a17f134e-b9ab-42d9-bfc2-5bbc45165c76",
+    "press": "9d262101-abeb-4e15-af9c-c38e028c62fe",
+    "ai_research": "dc5d01cd-e99f-4c8f-aae4-75060b43d0de"
+  },
+  "rules": [
+    {
+      "name": "immigration_govid",
+      "pattern": "^(imigrasi\\.go\\.id|kanwilkemenkumham|kemenkumham\\.go\\.id|kanim\\.|jdih\\.kemenkumham)",
+      "status": "nb-intel",
+      "targets_key": "immigration"
+    },
+    {
+      "name": "tax_govid",
+      "pattern": "^(pajak\\.go\\.id|ortax\\.org|ddtcnews|mucconsulting|ikpi\\.or\\.id|kemenkeu\\.go\\.id|jdih\\.kemenkeu)",
+      "status": "nb-intel",
+      "targets_key": "tax"
+    },
+    {
+      "name": "regulation_govid",
+      "pattern": "^(bkpm\\.go\\.id|oss\\.go\\.id|kemendag\\.go\\.id|jdih\\.bkpm|jdih\\.menpan|jdih\\.setkab|peraturan\\.go\\.id)",
+      "status": "nb-intel",
+      "targets_key": "regulation"
+    },
+    {
+      "name": "ai_research",
+      "pattern": "^(arxiv\\.org|github\\.com|huggingface\\.co|openai\\.com|anthropic\\.com|deepmind\\.com|paperswithcode)",
+      "status": "nb-intel",
+      "targets_key": "ai_research"
+    },
+    {
+      "name": "press_indonesian",
+      "pattern": "^(detik|kompas|tempo|tribunnews|jakartapost|antaranews|bisnis\\.com|cnnindonesia|kontan\\.co\\.id|katadata)",
+      "status": "blog",
+      "targets_key": null
+    },
+    {
+      "name": "osint_social",
+      "pattern": "^(reddit|twitter|x\\.com|youtube|t\\.co|medium\\.com)",
+      "status": "archive",
+      "targets_key": null
+    }
+  ],
+  "fallback": {
+    "status": "needs_review",
+    "targets": {},
+    "rule_name": "no_match"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds Pro-local LaunchAgent that sweeps `intel_items.routing_status='unrouted'` rows every 5 min using same regex rules as backend `intel_lake_router.py`
- Pure asyncpg+re standalone — zero backend imports (A1 failed because Pydantic `Settings()` validates `JWT_SECRET_KEY`/`API_KEYS`)
- Bypass needed because Fly `DISABLE_BACKGROUND_WORKERS=1` kill-switch (from 2026-04-12 disk-full incident) blocks EventBus listener → router subscriber never fires

## Tri-LLM review (Codex + Gemini + DeepSeek)

7 bugs found, all fixed:
1. `SELECT ... FOR UPDATE SKIP LOCKED` — no double-routing under concurrent cron
2. `UPDATE ... RETURNING id` — audit log only on real transitions
3. `async with conn.transaction():` — UPDATE+INSERT atomic
4. Time-windowed failure counter (3 fails / 30 min sliding) — no false alarm post-reboot
5. Rules in external JSON `~/scripts/intel-lake-routing-rules.json` — single source of truth
6. None-safe `(domain or '').strip().lower()` — `unknown`/`""`/`None` → `needs_review`
7. Explicit `$N::jsonb` cast — never raw dict

## Smoke verification (2026-05-13 03:25 WITA)

- 4 unrouted items routed correctly:
  - `imigrasi.go.id` → `nb-intel` + immigration UUID `1ed02e54-542f-...`
  - `detik.com` → `blog`
  - `unknown.example.com`, `test.balizero.com` → `needs_review`
- Audit log: 4 entries with `producer_name='router'`
- Classifier unit-tested 16/16 cases including rule-order ambiguity (`jdih.kemenkumham.go.id`)
- 3 consecutive LaunchAgent ticks exit=0, queue drained to 0 selected

## Retire path

Delete this subtree + `launchctl bootout gui/501/com.balizero.intel-lake-router.5min` when:
- `DISABLE_BACKGROUND_WORKERS=1` Fly secret removed
- EventBus listener confirmed alive on `rag` process
- Real-time router subscriber fires within 30s of observation POST

## Test plan

- [x] Bash syntax check: `bash -n intel-lake-router-cron.sh`
- [x] Python compile: `python3 -m py_compile intel-lake-router-cron-standalone.py`
- [x] Classifier unit test: 16/16 cases
- [x] PG smoke: 4 unrouted → routed correctly via LaunchAgent kick
- [x] flock concurrency guard verified
- [ ] CI checks (E2E Tests + MCP Server Tests) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)