### PR TITLE
fix(bridge): light-init Redis fallback for /api/bridge/skills (TICKET G hotfix)

### DIFF
--- a/apps/backend-rag/backend/app/routers/bridge.py
+++ b/apps/backend-rag/backend/app/routers/bridge.py
@@ -179,6 +179,40 @@ class SkillsResponse(BaseModel):
     stream_lowest_id: str | None = None
 
 
+async def _get_skills_redis_client(request: Request) -> Any:
+    """Return an async Redis client for the cell:skills stream.
+
+    Tries `app.state.redis_manager.get_async_client()` first (rag process group,
+    full init). Falls back to a fresh `redis.asyncio.from_url(REDIS_URL)` client
+    on the api process group (light init, no RedisManager singleton — see
+    `service_initializer.initialize_services_light` which omits the manager).
+
+    Returns the client or raises HTTPException(503) on failure.
+
+    Empirical context (2026-05-13 03:58 WITA, post-deploy of PR #647):
+    Fly api machine `7847d95ce257d8` logged "redis_manager unavailable" for
+    every /api/bridge/skills request — light init doesn't wire the manager.
+    This helper restores Redis access without changing the light init contract.
+    """
+    redis_manager = getattr(request.app.state, "redis_manager", None)
+    if redis_manager is not None and getattr(redis_manager, "available", False):
+        client = redis_manager.get_async_client()
+        if client is not None:
+            return client
+    # Light-init fallback: build ad-hoc async client from REDIS_URL env var.
+    redis_url = os.getenv("REDIS_URL", "")
+    if not redis_url:
+        logger.warning("Bridge skills: no redis_manager AND REDIS_URL unset")
+        raise HTTPException(status_code=503, detail="Redis unavailable")
+    try:
+        import redis.asyncio as aioredis
+        client = aioredis.from_url(redis_url, decode_responses=False)
+        return client
+    except Exception as e:
+        logger.exception("Bridge skills: ad-hoc redis client init failed")
+        raise HTTPException(status_code=503, detail=f"Redis init failed: {e}")
+
+
 @router.get("/skills", response_model=SkillsResponse)
 async def get_skills(
     request: Request,
@@ -189,21 +223,21 @@ async def get_skills(
     """Pro polls this endpoint to pull cell:skills Redis stream entries from Fly Upstash.
 
     Per TICKET G spec v2 (research/symbiosis/2026-05-13-ticket-G-narrow-spec.md):
-    - CORR-G1: get_async_client() via app.state.redis_manager
+    - CORR-G1 (fixed 2026-05-13 post-deploy): redis client via
+      `_get_skills_redis_client(request)` which prefers app.state.redis_manager
+      but falls back to ad-hoc REDIS_URL client on light-init api process.
     - CORR-G3: dedicated BRIDGE_SKILLS_API_KEY
     - CORR-G4: XINFO STREAM gap detection — events_orphaned=true if
       after_id < stream lowest entry ID (Pro should reset last_id to "$")
     """
     _check_skills_auth(x_bridge_skills_auth)
 
-    redis_manager = getattr(request.app.state, "redis_manager", None)
-    if redis_manager is None or not getattr(redis_manager, "available", False):
-        logger.warning("Bridge skills: redis_manager unavailable")
-        raise HTTPException(status_code=503, detail="Redis unavailable")
-    client = redis_manager.get_async_client()
-    if client is None:
-        logger.warning("Bridge skills: async client not initialized")
-        raise HTTPException(status_code=503, detail="Redis async client not initialized")
+    client = await _get_skills_redis_client(request)
+    # Track ad-hoc client so we can close it cleanly at the end
+    is_adhoc = (
+        getattr(request.app.state, "redis_manager", None) is None
+        or not getattr(getattr(request.app.state, "redis_manager", None), "available", False)
+    )
 
     events_orphaned = False
     stream_lowest_id: str | None = None
@@ -226,6 +260,11 @@ async def get_skills(
     try:
         result = await client.xread({"cell:skills": after_id}, count=count)
     except Exception as e:
+        if is_adhoc:
+            try:
+                await client.aclose()
+            except Exception:
+                pass
         logger.exception("Bridge skills: XREAD failed")
         raise HTTPException(status_code=503, detail=f"Stream read failed: {e}")
 
@@ -242,9 +281,15 @@ async def get_skills(
                 }
                 events.append({"id": last_id, "fields": decoded_fields})
 
+    if is_adhoc:
+        try:
+            await client.aclose()
+        except Exception:
+            pass
+
     logger.info(
-        "Bridge skills: returned %d events (after_id=%s last_id=%s orphaned=%s)",
-        len(events), after_id, last_id, events_orphaned,
+        "Bridge skills: returned %d events (after_id=%s last_id=%s orphaned=%s adhoc=%s)",
+        len(events), after_id, last_id, events_orphaned, is_adhoc,
     )
     return SkillsResponse(
         events=events,

--- a/apps/backend-rag/backend/tests/routers/test_bridge_router.py
+++ b/apps/backend-rag/backend/tests/routers/test_bridge_router.py
@@ -1,7 +1,7 @@
 """Tests for /api/bridge/* endpoints."""
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -248,9 +248,15 @@ def test_get_skills_503_when_skills_key_unset(monkeypatch):
     assert r.status_code == 503
 
 
-def test_get_skills_503_when_redis_unavailable(monkeypatch):
-    """If redis_manager.available is False, return 503."""
+def test_get_skills_503_when_redis_unavailable_and_no_redis_url(monkeypatch):
+    """If redis_manager.available is False AND REDIS_URL env var is missing, return 503.
+
+    Light-init fallback path: when there's no redis_manager singleton, the
+    endpoint falls back to building an ad-hoc client from REDIS_URL. If both
+    paths are unavailable, return 503.
+    """
     monkeypatch.setenv("BRIDGE_SKILLS_API_KEY", SKILLS_KEY)
+    monkeypatch.delenv("REDIS_URL", raising=False)
     from fastapi import FastAPI
     from backend.app.routers import bridge as bridge_router
 
@@ -268,6 +274,44 @@ def test_get_skills_503_when_redis_unavailable(monkeypatch):
         headers={"X-Bridge-Skills-Auth": SKILLS_KEY},
     )
     assert r.status_code == 503
+
+
+def test_get_skills_falls_back_to_redis_url_on_light_init(monkeypatch):
+    """When app.state.redis_manager is missing (light init on Fly api process),
+    endpoint should build an ad-hoc client from REDIS_URL env var.
+
+    Fix 2026-05-13 post-deploy: Fly api machine doesn't init RedisManager
+    (initialize_services_light skips it), so the original CORR-G1 broke
+    the endpoint on api process group. Fallback added.
+    """
+    monkeypatch.setenv("BRIDGE_SKILLS_API_KEY", SKILLS_KEY)
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+
+    from fastapi import FastAPI
+    from backend.app.routers import bridge as bridge_router
+
+    app = FastAPI()
+    app.include_router(bridge_router.router)
+    # app.state.redis_manager NOT set — simulates light init
+
+    fake_async_client = AsyncMock()
+    fake_async_client.xread = AsyncMock(return_value=None)
+    fake_async_client.aclose = AsyncMock()
+
+    with patch("redis.asyncio.from_url", return_value=fake_async_client) as from_url_mock:
+        client = TestClient(app)
+        r = client.get(
+            "/api/bridge/skills?after_id=0-0",
+            headers={"X-Bridge-Skills-Auth": SKILLS_KEY},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["events"] == []
+        assert body["last_stream_id"] == "0-0"
+        # Verify the ad-hoc fallback path was taken
+        from_url_mock.assert_called_once()
+        # Verify ad-hoc client was closed (no leak)
+        fake_async_client.aclose.assert_called()
 
 
 def test_get_skills_empty_stream_returns_empty_events(skills_client, app_with_skills):


### PR DESCRIPTION
## Summary

Hotfix for **PR #647 (TICKET G.1)** post-deploy: `/api/bridge/skills` returned `503 "Redis unavailable"` for every request on the Fly api machine.

**Empirical Fly log diagnosis** (2026-05-13 03:58 WITA, machine `7847d95ce257d8`):

```
Bridge skills: redis_manager unavailable
HTTPException: 503 - GET /api/bridge/skills. Detail: Redis unavailable
```

## Root cause

Fly has two process groups serving different routers:

- **api process** (light init via `initialize_services_light()`): sets up `CacheService` but does NOT instantiate `RedisManager.get_instance()`.
- **rag process** (full init via `initialize_services()`): wires `RedisManager` to `app.state.redis_manager`.

The bridge router is in `_API` process_group (`router_manifest.py:118`), so it runs on the api process. CORR-G1's `getattr(app.state, "redis_manager", None)` always returned `None` → endpoint stuck at 503.

## Fix

New `_get_skills_redis_client(request)` helper:
1. Prefer `app.state.redis_manager.get_async_client()` (rag process).
2. Fall back to `redis.asyncio.from_url(REDIS_URL)` ad-hoc client (api process).
3. 503 only if both paths unavailable.

The ad-hoc client is closed (`aclose()`) before returning to avoid connection leaks on the api process (limited pool budget).

## Constraint preserved

- `initialize_services_light` contract unchanged — no `RedisManager` added there. Light init stays light.
- Fix lives only in the bridge router, the only consumer that needs raw Redis access on the api process.

## Test plan

- [x] `test_get_skills_falls_back_to_redis_url_on_light_init` — NEW, covers the fallback path
- [x] `test_get_skills_503_when_redis_unavailable_and_no_redis_url` — REWORKED, requires both paths unavailable for 503
- [x] 18/18 bridge router tests pass on `apps/backend-rag/.venv`
- [ ] CI E2E + MCP green
- [ ] Post-deploy: curl `/api/bridge/skills` → 200 instead of 503
- [ ] Pro `skills_bridge_consumer` first tick → log shows success, Pro `XLEN cell:skills` increments

## Empirical pre-fix evidence

Pre-fix Fly logs (machine `7847d95ce257d8`):
```
Rate limiter using in-memory storage — no Redis available, rate limits not shared across workers
Bridge skills: redis_manager unavailable
HTTPException: 503
```

The `rate_limiter` warning confirms `redis_manager` is missing on the api process — it's an architectural choice (light init), not a bug. The fix accepts that and routes around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)