### PR TITLE
feat(crm): add Drive autowatcher drafts

### DIFF
--- a/.github/workflows/cron-crm-drive-autowatcher.yml
+++ b/.github/workflows/cron-crm-drive-autowatcher.yml
@@ -1,0 +1,80 @@
+name: cron - CRM Drive autowatcher
+
+# Bounded pass over current CRM Drive documents:
+# 1. backfill indexed documents into OCR/KG
+# 2. create Workspace AI draft snapshots for human review
+#
+# It does not approve facts and does not expose raw Drive evidence to clients.
+
+on:
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: 'Max documents/companies to inspect in this pass'
+        required: false
+        default: '10'
+      allow_ocr:
+        description: 'Allow OCR/Gemini dispatch for pending existing documents'
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+concurrency:
+  group: cron-crm-drive-autowatcher
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: POST /api/admin/crm-kg/autowatch-drive
+        id: autowatch
+        env:
+          API_KEY: ${{ secrets.NUZANTARA_API_KEY }}
+          LIMIT: ${{ github.event.inputs.limit || '10' }}
+          ALLOW_OCR: ${{ github.event.inputs.allow_ocr || 'true' }}
+        run: |
+          set -uo pipefail
+          BODY_FILE="$RUNNER_TEMP/body.json"
+          URL="https://nuzantara-rag.fly.dev/api/admin/crm-kg/autowatch-drive?limit=${LIMIT}&dry_run=false&allow_ocr=${ALLOW_OCR}&story_drafts=true"
+          HTTP_CODE=$(curl -sS -o "$BODY_FILE" -w "%{http_code}" --max-time 240 \
+            -X POST \
+            -H "X-API-Key: $API_KEY" \
+            -H "Content-Type: application/json" \
+            "$URL" || echo "000")
+          BODY=$(cat "$BODY_FILE" 2>/dev/null || echo "")
+          echo "http_code=$HTTP_CODE" >> "$GITHUB_OUTPUT"
+          echo "body<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$BODY" | head -c 800 >> "$GITHUB_OUTPUT"
+          echo "" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "CRM Drive autowatcher accepted: $BODY"
+          else
+            echo "::warning::CRM Drive autowatcher failed (HTTP $HTTP_CODE): $BODY"
+            exit 1
+          fi
+
+      - name: Telegram alert on failure
+        if: failure()
+        env:
+          BOT: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          CHAT: ${{ secrets.TELEGRAM_OWNER_CHAT_ID }}
+          HTTP_CODE: ${{ steps.autowatch.outputs.http_code }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          [ -z "$BOT" ] || [ -z "$CHAT" ] && { echo "Telegram secrets missing"; exit 0; }
+          TEXT="🚨 <b>crm-drive-autowatcher</b> failed
+          HTTP: ${HTTP_CODE:-?}
+          Run: ${RUN_URL}"
+          curl -sS -m 10 -X POST \
+            "https://api.telegram.org/bot${BOT}/sendMessage" \
+            -d "chat_id=${CHAT}" \
+            --data-urlencode "text=${TEXT}" \
+            -d "parse_mode=HTML" >/dev/null || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ See [`INDEX.md`](INDEX.md) for the full atlas including packages, tessuti dati, 
 ### Tech Stack
 
 <!-- DOCSYNC:BACKEND_STATS_START -->
-- **Backend:** Python 3.11+, FastAPI, 265 routers, 560 services, 935 test files
+- **Backend:** Python 3.11+, FastAPI, 265 routers, 561 services, 936 test files
 <!-- DOCSYNC:BACKEND_STATS_END -->
 - **Frontend:** Next.js, TypeScript, Tailwind CSS
 - **Databases:** PostgreSQL (relational), Qdrant (vector), Redis (cache)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 265 routers · 560 services
+- Backend: FastAPI · 265 routers · 561 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 23 · Packages: 5

--- a/apps/backend-rag/backend/app/routers/admin_crm_kg.py
+++ b/apps/backend-rag/backend/app/routers/admin_crm_kg.py
@@ -4,6 +4,8 @@ Endpoints exposed:
   - GET  /api/admin/crm-kg/health           → counts of nodes/edges per type
   - POST /api/admin/crm-kg/backfill-drive-documents
                                              → OCR/KG pass over current CRM docs
+  - POST /api/admin/crm-kg/autowatch-drive  → bounded Drive/OCR/KG pass plus
+                                               review-only Business Story drafts
   - POST /api/admin/crm-kg/build-mediated   → run Tier-B mediated edge pass (PR-B)
   - POST /api/admin/crm-kg/garbage-collect  → soft-delete orphan nodes,
                                                 hard-delete old edges (PR-D)
@@ -73,6 +75,63 @@ async def trigger_backfill_drive_documents(
         "message": "CRM Drive document backfill running in background",
         "dry_run": False,
         "allow_ocr": allow_ocr,
+        "limit": limit,
+        "client_id": client_id,
+    }
+
+
+@router.post("/autowatch-drive")
+async def trigger_autowatch_drive(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    limit: int = Query(25, ge=1, le=100),
+    dry_run: bool = Query(True),
+    client_id: int | None = Query(None, ge=1),
+    allow_ocr: bool = Query(False),
+    story_drafts: bool = Query(True),
+) -> dict[str, Any]:
+    """Run a bounded autonomous Drive intelligence pass.
+
+    This wraps the current Drive backfill/OCR/KG linker and prepares
+    Workspace AI snapshots as draft only. Draft facts never enter Business
+    Story until a team member approves them.
+    """
+    pool = getattr(request.app.state, "db_pool", None)
+    if not pool:
+        return {"status": "error", "message": "Database pool not available"}
+
+    from backend.services.crm.drive_autowatcher_service import (
+        run_crm_drive_autowatch,
+    )
+
+    if dry_run:
+        return await run_crm_drive_autowatch(
+            pool,
+            limit=limit,
+            dry_run=True,
+            client_id=client_id,
+            allow_ocr=allow_ocr,
+            story_drafts=story_drafts,
+        )
+
+    async def _run() -> None:
+        result = await run_crm_drive_autowatch(
+            pool,
+            limit=limit,
+            dry_run=False,
+            client_id=client_id,
+            allow_ocr=allow_ocr,
+            story_drafts=story_drafts,
+        )
+        logger.info("crm_kg.autowatch_drive background result: %s", result)
+
+    background_tasks.add_task(_run)
+    return {
+        "status": "started",
+        "message": "CRM Drive autowatcher running in background",
+        "dry_run": False,
+        "allow_ocr": allow_ocr,
+        "story_drafts": story_drafts,
         "limit": limit,
         "client_id": client_id,
     }

--- a/apps/backend-rag/backend/services/crm/drive_autowatcher_service.py
+++ b/apps/backend-rag/backend/services/crm/drive_autowatcher_service.py
@@ -1,0 +1,493 @@
+"""Autonomous CRM Drive watcher orchestration.
+
+This service combines the existing Drive/OCR/KG workers into one bounded pass
+and prepares human-reviewable Workspace AI draft snapshots. It never approves
+facts and never writes to Google Drive.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+import asyncpg
+
+from backend.services.crm.tax_company_pilot import TaxCompanyPilotWorkspaceAiFact
+from backend.services.crm.workspace_ai_snapshots import (
+    WorkspaceAiSnapshotCreate,
+    create_workspace_ai_snapshot,
+)
+from backend.services.documents.crm_drive_backfill_service import (
+    run_crm_drive_backfill,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_LIMIT = 25
+_MAX_LIMIT = 100
+_SNAPSHOT_PROVIDER = "gemini"
+_NOTE_PREFIX = "crm-drive-autowatcher:v1"
+
+
+@dataclass(frozen=True)
+class DriveEvidenceDocument:
+    """One Drive-backed CRM document used to prepare a review draft."""
+
+    file_id: str
+    file_name: str
+    document_type: str | None
+    document_category: str | None
+    ocr_status: str | None
+    has_kg_node: bool
+
+
+@dataclass(frozen=True)
+class CompanyDriveEvidence:
+    """Person-first evidence bundle for one linked company."""
+
+    company_id: int
+    company_name: str
+    client_ids: list[int]
+    people: list[str]
+    tax_owner: str
+    documents: list[DriveEvidenceDocument] = field(default_factory=list)
+    kg_edge_count: int = 0
+
+
+async def run_crm_drive_autowatch(
+    pool: asyncpg.Pool,
+    *,
+    limit: int = _DEFAULT_LIMIT,
+    dry_run: bool = True,
+    client_id: int | None = None,
+    allow_ocr: bool = False,
+    story_drafts: bool = True,
+    created_by: str | None = "crm-drive-autowatcher",
+) -> dict[str, Any]:
+    """Run one bounded autonomous pass over Drive-backed CRM evidence.
+
+    The pass has two phases:
+    1. Backfill current Drive documents into OCR/KG using the existing worker.
+    2. Create draft Workspace AI snapshots from indexed evidence, deduped by
+       deterministic note_id fingerprint.
+
+    Draft snapshots are intentionally not consumed by Business Story until a
+    team member approves them.
+    """
+    safe_limit = _safe_limit(limit)
+    backfill = await run_crm_drive_backfill(
+        pool,
+        limit=safe_limit,
+        dry_run=dry_run,
+        client_id=client_id,
+        link_kg=True,
+        allow_ocr=allow_ocr,
+    )
+
+    summary: dict[str, Any] = {
+        "status": "ok",
+        "dry_run": dry_run,
+        "allow_ocr": allow_ocr,
+        "story_drafts": story_drafts,
+        "limit": safe_limit,
+        "client_id": client_id,
+        "backfill": backfill,
+        "snapshot_candidates": 0,
+        "snapshots_created": 0,
+        "snapshots_skipped_existing": 0,
+        "snapshot_previews": [],
+        "errors": [],
+    }
+
+    if not story_drafts:
+        return summary
+
+    evidence_items = await fetch_drive_evidence_for_story_drafts(
+        pool,
+        limit=safe_limit,
+        client_id=client_id,
+    )
+    summary["snapshot_candidates"] = len(evidence_items)
+
+    for evidence in evidence_items:
+        payload = build_workspace_ai_snapshot_payload(evidence)
+        summary["snapshot_previews"].append(_snapshot_preview(payload))
+
+        if dry_run:
+            continue
+
+        try:
+            if payload.note_id and await workspace_ai_snapshot_exists(pool, payload.note_id):
+                summary["snapshots_skipped_existing"] += 1
+                continue
+            await create_workspace_ai_snapshot(pool, payload, created_by=created_by)
+            summary["snapshots_created"] += 1
+        except Exception as exc:  # noqa: BLE001 - batch must continue
+            logger.error(
+                "CRM Drive autowatcher failed creating snapshot for company %s: %s",
+                evidence.company_id,
+                exc,
+                exc_info=True,
+            )
+            summary["errors"].append(
+                {"company_id": evidence.company_id, "error": str(exc)[:200]},
+            )
+
+    return summary
+
+
+async def fetch_drive_evidence_for_story_drafts(
+    pool: asyncpg.Pool,
+    *,
+    limit: int = _DEFAULT_LIMIT,
+    client_id: int | None = None,
+) -> list[CompanyDriveEvidence]:
+    """Fetch current person/company/document evidence for draft snapshots."""
+    safe_limit = _safe_limit(limit)
+    try:
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(_EVIDENCE_SQL, client_id, safe_limit)
+    except asyncpg.UndefinedTableError:
+        logger.info("CRM Drive autowatcher skipped: required CRM tables missing")
+        return []
+    return _evidence_from_rows(rows)
+
+
+async def workspace_ai_snapshot_exists(
+    pool: asyncpg.Pool,
+    note_id: str,
+) -> bool:
+    """Return true when this exact autowatcher fingerprint already exists."""
+    try:
+        async with pool.acquire() as conn:
+            return bool(
+                await conn.fetchval(
+                    "SELECT EXISTS(SELECT 1 FROM crm_workspace_ai_snapshots WHERE note_id = $1)",
+                    note_id,
+                )
+            )
+    except asyncpg.UndefinedTableError:
+        return False
+
+
+def build_workspace_ai_snapshot_payload(
+    evidence: CompanyDriveEvidence,
+) -> WorkspaceAiSnapshotCreate:
+    """Build a draft Workspace AI snapshot from indexed Drive evidence."""
+    source_file_ids = _ordered_file_ids(evidence.documents)
+    note_id = _snapshot_note_id(evidence)
+    facts = _facts_from_evidence(evidence)
+    return WorkspaceAiSnapshotCreate(
+        company_id=evidence.company_id,
+        client_id=evidence.client_ids[0] if evidence.client_ids else None,
+        company_name=evidence.company_name,
+        provider=_SNAPSHOT_PROVIDER,
+        notebook_id=None,
+        note_id=note_id,
+        source_file_ids=source_file_ids,
+        facts=facts,
+    )
+
+
+def _facts_from_evidence(
+    evidence: CompanyDriveEvidence,
+) -> list[TaxCompanyPilotWorkspaceAiFact]:
+    people = _human_join(evidence.people, fallback="the linked person")
+    groups = _document_group_counts(evidence.documents)
+    missing = _missing_groups(groups, evidence.kg_edge_count)
+
+    identity_detail = (
+        f"{evidence.company_name} has {len(evidence.documents)} indexed source "
+        f"document{'s' if len(evidence.documents) != 1 else ''} in the CRM workspace."
+    )
+    person_detail = (
+        f"Start from {people}; then open {evidence.company_name} through the confirmed CRM relationship."
+    )
+    compliance_detail = (
+        f"Evidence currently covers {_coverage_sentence(groups)}. "
+        f"Tax owner: {evidence.tax_owner}."
+    )
+    gap_detail = (
+        "Missing or weak evidence: " + ", ".join(missing) + "."
+        if missing
+        else "Company, tax, person, and relationship evidence are all present for team review."
+    )
+    next_action_detail = (
+        "Review this draft, confirm the roles and source documents, then approve it for the Business Story."
+    )
+
+    return [
+        TaxCompanyPilotWorkspaceAiFact(
+            category="identity",
+            label="Company evidence",
+            detail=_clean_detail(identity_detail),
+            source_file_ids=_source_ids_for_groups(evidence.documents, ("company", "tax", "person")),
+            confidence=_confidence_for(evidence.documents, evidence.kg_edge_count),
+        ),
+        TaxCompanyPilotWorkspaceAiFact(
+            category="person",
+            label="Person-first entry",
+            detail=_clean_detail(person_detail),
+            source_file_ids=_source_ids_for_groups(evidence.documents, ("person", "company")),
+            confidence="high" if evidence.people else "medium",
+        ),
+        TaxCompanyPilotWorkspaceAiFact(
+            category="compliance",
+            label="Evidence coverage",
+            detail=_clean_detail(compliance_detail),
+            source_file_ids=_source_ids_for_groups(evidence.documents, ("company", "tax")),
+            confidence=_confidence_for(evidence.documents, evidence.kg_edge_count),
+        ),
+        TaxCompanyPilotWorkspaceAiFact(
+            category="gap",
+            label="Review gaps",
+            detail=_clean_detail(gap_detail),
+            source_file_ids=[],
+            confidence="medium",
+        ),
+        TaxCompanyPilotWorkspaceAiFact(
+            category="next_action",
+            label="Next action",
+            detail=next_action_detail,
+            source_file_ids=[],
+            confidence="confirmed",
+        ),
+    ]
+
+
+def _evidence_from_rows(rows: list[Any]) -> list[CompanyDriveEvidence]:
+    grouped: dict[int, dict[str, Any]] = {}
+    for row in rows:
+        data = dict(row)
+        company_id = int(data["company_id"])
+        bucket = grouped.setdefault(
+            company_id,
+            {
+                "company_id": company_id,
+                "company_name": str(data["company_name"]),
+                "client_ids": set(),
+                "people": [],
+                "tax_owners": [],
+                "documents": {},
+                "kg_edge_count": 0,
+            },
+        )
+        bucket["client_ids"].add(int(data["client_id"]))
+        _append_unique(bucket["people"], str(data["client_name"]))
+        if data.get("tax_owner"):
+            _append_unique(bucket["tax_owners"], str(data["tax_owner"]))
+        if data.get("file_id"):
+            file_id = str(data["file_id"])
+            bucket["documents"][file_id] = DriveEvidenceDocument(
+                file_id=file_id,
+                file_name=str(data.get("file_name") or "Document"),
+                document_type=data.get("document_type"),
+                document_category=data.get("document_category"),
+                ocr_status=data.get("ocr_status"),
+                has_kg_node=bool(data.get("has_kg_node")),
+            )
+        bucket["kg_edge_count"] = max(
+            int(bucket["kg_edge_count"]),
+            int(data.get("kg_edge_count") or 0),
+        )
+
+    evidence: list[CompanyDriveEvidence] = []
+    for bucket in grouped.values():
+        documents = sorted(
+            bucket["documents"].values(),
+            key=lambda doc: (doc.file_name.lower(), doc.file_id),
+        )
+        evidence.append(
+            CompanyDriveEvidence(
+                company_id=bucket["company_id"],
+                company_name=bucket["company_name"],
+                client_ids=sorted(bucket["client_ids"]),
+                people=bucket["people"],
+                tax_owner=bucket["tax_owners"][0] if bucket["tax_owners"] else "Unassigned",
+                documents=documents,
+                kg_edge_count=int(bucket["kg_edge_count"]),
+            )
+        )
+    return evidence
+
+
+def _snapshot_note_id(evidence: CompanyDriveEvidence) -> str:
+    fingerprint = hashlib.sha256(
+        "|".join(
+            [
+                str(evidence.company_id),
+                evidence.company_name,
+                ",".join(
+                    f"{doc.file_id}:{doc.ocr_status or 'none'}:{int(doc.has_kg_node)}"
+                    for doc in sorted(evidence.documents, key=lambda item: item.file_id)
+                ),
+                str(evidence.kg_edge_count),
+            ]
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+    return f"{_NOTE_PREFIX}:{evidence.company_id}:{fingerprint}"
+
+
+def _document_group_counts(documents: list[DriveEvidenceDocument]) -> dict[str, int]:
+    groups: dict[str, int] = {}
+    for document in documents:
+        group = _document_group(document)
+        groups[group] = groups.get(group, 0) + 1
+    return groups
+
+
+def _document_group(document: DriveEvidenceDocument) -> str:
+    text = f"{document.document_category or ''} {document.document_type or ''} {document.file_name}".lower()
+    if any(marker in text for marker in ("spt", "lkpm", "tax", "pajak", "npwp")):
+        return "tax"
+    if any(marker in text for marker in ("passport", "paspor", "visa", "itas", "kitas", "kitap")):
+        return "person"
+    if any(marker in text for marker in ("akta", "nib", "company", "perseroan", "oss")):
+        return "company"
+    return "company"
+
+
+def _coverage_sentence(groups: dict[str, int]) -> str:
+    labels = []
+    if groups.get("company"):
+        labels.append(f"company files ({groups['company']})")
+    if groups.get("tax"):
+        labels.append(f"tax files ({groups['tax']})")
+    if groups.get("person"):
+        labels.append(f"person files ({groups['person']})")
+    return _human_join(labels, fallback="no classified files yet")
+
+
+def _missing_groups(groups: dict[str, int], kg_edge_count: int) -> list[str]:
+    missing: list[str] = []
+    if not groups.get("company"):
+        missing.append("company registry")
+    if not groups.get("tax"):
+        missing.append("tax trail")
+    if not groups.get("person"):
+        missing.append("person file")
+    if kg_edge_count <= 0:
+        missing.append("relationship links")
+    return missing
+
+
+def _source_ids_for_groups(
+    documents: list[DriveEvidenceDocument],
+    groups: tuple[str, ...],
+) -> list[str]:
+    return [
+        document.file_id
+        for document in documents
+        if _document_group(document) in groups
+    ][:12]
+
+
+def _ordered_file_ids(documents: list[DriveEvidenceDocument]) -> list[str]:
+    seen: set[str] = set()
+    file_ids: list[str] = []
+    for document in documents:
+        if document.file_id and document.file_id not in seen:
+            seen.add(document.file_id)
+            file_ids.append(document.file_id)
+    return file_ids
+
+
+def _confidence_for(
+    documents: list[DriveEvidenceDocument],
+    kg_edge_count: int,
+) -> str:
+    if documents and kg_edge_count > 0 and all(doc.ocr_status == "completed" for doc in documents):
+        return "high"
+    if documents and kg_edge_count > 0:
+        return "medium"
+    if documents:
+        return "medium"
+    return "low"
+
+
+def _snapshot_preview(payload: WorkspaceAiSnapshotCreate) -> dict[str, Any]:
+    return {
+        "company_id": payload.company_id,
+        "client_id": payload.client_id,
+        "company_name": payload.company_name,
+        "note_id": payload.note_id,
+        "source_file_count": len(payload.source_file_ids),
+        "facts": [fact.model_dump(mode="json") for fact in payload.facts],
+    }
+
+
+def _human_join(items: list[str], *, fallback: str) -> str:
+    cleaned = [item for item in items if item]
+    if not cleaned:
+        return fallback
+    if len(cleaned) == 1:
+        return cleaned[0]
+    if len(cleaned) == 2:
+        return f"{cleaned[0]} and {cleaned[1]}"
+    return f"{', '.join(cleaned[:-1])}, and {cleaned[-1]}"
+
+
+def _clean_detail(value: str) -> str:
+    no_urls = re.sub(r"https?://\S+", "[internal source]", value)
+    return no_urls.replace("Drive", "source").replace("OCR", "document reading").replace("KG", "relationship")
+
+
+def _append_unique(items: list[str], value: str) -> None:
+    if value and value not in items:
+        items.append(value)
+
+
+def _safe_limit(limit: int) -> int:
+    return max(1, min(int(limit), _MAX_LIMIT))
+
+
+_EVIDENCE_SQL = """
+WITH company_scope AS (
+    SELECT DISTINCT
+        co.id AS company_id,
+        co.company_name
+    FROM client_company_links ccl
+    JOIN clients cl ON cl.id = ccl.client_id
+    JOIN companies co ON co.id = ccl.company_id
+    JOIN documents d ON d.client_id = cl.id
+    WHERE cl.deleted_at IS NULL
+      AND d.file_id IS NOT NULL
+      AND d.file_id <> ''
+      AND (d.is_archived IS NULL OR d.is_archived = false)
+      AND ($1::int IS NULL OR cl.id = $1::int)
+    ORDER BY co.company_name
+    LIMIT $2
+)
+SELECT
+    scope.company_id,
+    scope.company_name,
+    cl.id AS client_id,
+    cl.full_name AS client_name,
+    COALESCE(cl.tax_consultant, cl.assigned_to, '') AS tax_owner,
+    d.file_id,
+    d.file_name,
+    d.document_type,
+    d.document_category,
+    d.ocr_status,
+    kg.entity_id IS NOT NULL AS has_kg_node,
+    COUNT(edge.relationship_id) OVER (PARTITION BY scope.company_id) AS kg_edge_count
+FROM company_scope scope
+JOIN client_company_links ccl ON ccl.company_id = scope.company_id
+JOIN clients cl ON cl.id = ccl.client_id
+JOIN documents d ON d.client_id = cl.id
+LEFT JOIN crm_kg_nodes kg
+    ON kg.file_id = d.file_id
+    AND kg.entity_type = 'crm_document'
+    AND kg.deleted_at IS NULL
+LEFT JOIN crm_kg_edges edge
+    ON edge.source_entity_id = kg.entity_id
+WHERE cl.deleted_at IS NULL
+  AND d.file_id IS NOT NULL
+  AND d.file_id <> ''
+  AND (d.is_archived IS NULL OR d.is_archived = false)
+  AND ($1::int IS NULL OR cl.id = $1::int)
+ORDER BY scope.company_name, cl.full_name, d.file_name
+"""

--- a/apps/backend-rag/backend/tests/routers/test_admin_crm_kg_backfill.py
+++ b/apps/backend-rag/backend/tests/routers/test_admin_crm_kg_backfill.py
@@ -88,3 +88,63 @@ async def test_backfill_drive_documents_live_requires_explicit_ocr_flag() -> Non
     task = background_tasks.tasks[0]
     await task.func(*task.args, **task.kwargs)
     assert mock_backfill.call_args.kwargs["allow_ocr"] is True
+
+
+@pytest.mark.asyncio
+async def test_autowatch_drive_dry_run_returns_summary() -> None:
+    from backend.app.routers.admin_crm_kg import trigger_autowatch_drive
+
+    with patch(
+        "backend.services.crm.drive_autowatcher_service.run_crm_drive_autowatch",
+        new_callable=AsyncMock,
+        return_value={"dry_run": True, "snapshot_candidates": 2},
+    ) as mock_autowatch:
+        result = await trigger_autowatch_drive(
+            request=_request_with_pool(object()),
+            background_tasks=BackgroundTasks(),
+            limit=10,
+            dry_run=True,
+            client_id=42,
+            allow_ocr=False,
+            story_drafts=True,
+        )
+
+    assert result == {"dry_run": True, "snapshot_candidates": 2}
+    mock_autowatch.assert_called_once()
+    assert mock_autowatch.call_args.kwargs["limit"] == 10
+    assert mock_autowatch.call_args.kwargs["dry_run"] is True
+    assert mock_autowatch.call_args.kwargs["client_id"] == 42
+    assert mock_autowatch.call_args.kwargs["allow_ocr"] is False
+    assert mock_autowatch.call_args.kwargs["story_drafts"] is True
+
+
+@pytest.mark.asyncio
+async def test_autowatch_drive_live_runs_in_background() -> None:
+    from backend.app.routers.admin_crm_kg import trigger_autowatch_drive
+
+    background_tasks = BackgroundTasks()
+    with patch(
+        "backend.services.crm.drive_autowatcher_service.run_crm_drive_autowatch",
+        new_callable=AsyncMock,
+    ) as mock_autowatch:
+        result = await trigger_autowatch_drive(
+            request=_request_with_pool(object()),
+            background_tasks=background_tasks,
+            limit=5,
+            dry_run=False,
+            client_id=None,
+            allow_ocr=True,
+            story_drafts=True,
+        )
+
+    assert result["status"] == "started"
+    assert result["dry_run"] is False
+    assert result["allow_ocr"] is True
+    assert result["story_drafts"] is True
+    assert len(background_tasks.tasks) == 1
+    mock_autowatch.assert_not_called()
+
+    task = background_tasks.tasks[0]
+    await task.func(*task.args, **task.kwargs)
+    assert mock_autowatch.call_args.kwargs["dry_run"] is False
+    assert mock_autowatch.call_args.kwargs["allow_ocr"] is True

--- a/apps/backend-rag/backend/tests/services/crm/test_drive_autowatcher_service.py
+++ b/apps/backend-rag/backend/tests/services/crm/test_drive_autowatcher_service.py
@@ -1,0 +1,236 @@
+"""Tests for CRM Drive autowatcher orchestration."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_autowatcher_dry_run_previews_story_drafts_without_writes() -> None:
+    from backend.services.crm.drive_autowatcher_service import (
+        CompanyDriveEvidence,
+        DriveEvidenceDocument,
+        run_crm_drive_autowatch,
+    )
+
+    evidence = [
+        CompanyDriveEvidence(
+            company_id=7,
+            company_name="PT OCEAN CLOTHES AND SHOES",
+            client_ids=[42],
+            people=["Ihor Osmanov"],
+            tax_owner="DEA",
+            documents=[
+                DriveEvidenceDocument(
+                    file_id="drive-profile",
+                    file_name="Profil Perseroan.pdf",
+                    document_type="profile_perseroan",
+                    document_category="company",
+                    ocr_status="completed",
+                    has_kg_node=True,
+                )
+            ],
+            kg_edge_count=2,
+        )
+    ]
+
+    with patch(
+        "backend.services.crm.drive_autowatcher_service.run_crm_drive_backfill",
+        new_callable=AsyncMock,
+        return_value={"processed": 1, "ocr_dispatched": 0, "kg_linked": 1},
+    ), patch(
+        "backend.services.crm.drive_autowatcher_service.fetch_drive_evidence_for_story_drafts",
+        new_callable=AsyncMock,
+        return_value=evidence,
+    ), patch(
+        "backend.services.crm.drive_autowatcher_service.create_workspace_ai_snapshot",
+        new_callable=AsyncMock,
+    ) as create_snapshot:
+        result = await run_crm_drive_autowatch(
+            object(),
+            limit=5,
+            dry_run=True,
+            allow_ocr=False,
+            created_by="autowatcher",
+        )
+
+    assert result["dry_run"] is True
+    assert result["backfill"]["processed"] == 1
+    assert result["snapshot_candidates"] == 1
+    assert result["snapshots_created"] == 0
+    assert result["snapshot_previews"][0]["company_name"] == "PT OCEAN CLOTHES AND SHOES"
+    create_snapshot.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_autowatcher_creates_only_new_draft_snapshots() -> None:
+    from backend.services.crm.drive_autowatcher_service import (
+        CompanyDriveEvidence,
+        DriveEvidenceDocument,
+        run_crm_drive_autowatch,
+    )
+
+    evidence = [
+        CompanyDriveEvidence(
+            company_id=7,
+            company_name="PT OCEAN CLOTHES AND SHOES",
+            client_ids=[42],
+            people=["Ihor Osmanov", "Natan Kleimonov"],
+            tax_owner="DEA",
+            documents=[
+                DriveEvidenceDocument(
+                    file_id="drive-profile",
+                    file_name="Profil Perseroan.pdf",
+                    document_type="profile_perseroan",
+                    document_category="company",
+                    ocr_status="completed",
+                    has_kg_node=True,
+                ),
+                DriveEvidenceDocument(
+                    file_id="drive-npwp",
+                    file_name="NPWP PT Ocean.pdf",
+                    document_type="npwp",
+                    document_category="tax",
+                    ocr_status="completed",
+                    has_kg_node=True,
+                ),
+            ],
+            kg_edge_count=3,
+        )
+    ]
+
+    with patch(
+        "backend.services.crm.drive_autowatcher_service.run_crm_drive_backfill",
+        new_callable=AsyncMock,
+        return_value={"processed": 2, "ocr_dispatched": 1, "kg_linked": 2},
+    ), patch(
+        "backend.services.crm.drive_autowatcher_service.fetch_drive_evidence_for_story_drafts",
+        new_callable=AsyncMock,
+        return_value=evidence,
+    ), patch(
+        "backend.services.crm.drive_autowatcher_service.workspace_ai_snapshot_exists",
+        new_callable=AsyncMock,
+        return_value=False,
+    ), patch(
+        "backend.services.crm.drive_autowatcher_service.create_workspace_ai_snapshot",
+        new_callable=AsyncMock,
+        return_value=object(),
+    ) as create_snapshot:
+        result = await run_crm_drive_autowatch(
+            object(),
+            limit=5,
+            dry_run=False,
+            allow_ocr=True,
+            created_by="autowatcher",
+        )
+
+    assert result["dry_run"] is False
+    assert result["snapshots_created"] == 1
+    assert result["snapshots_skipped_existing"] == 0
+    create_snapshot.assert_awaited_once()
+    payload = create_snapshot.await_args.args[1]
+    assert payload.company_id == 7
+    assert payload.provider == "gemini"
+    assert payload.note_id.startswith("crm-drive-autowatcher:v1:7:")
+    assert payload.source_file_ids == ["drive-profile", "drive-npwp"]
+    assert [fact.category for fact in payload.facts] == [
+        "identity",
+        "person",
+        "compliance",
+        "gap",
+        "next_action",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_autowatcher_skips_existing_snapshot_fingerprint() -> None:
+    from backend.services.crm.drive_autowatcher_service import (
+        CompanyDriveEvidence,
+        DriveEvidenceDocument,
+        run_crm_drive_autowatch,
+    )
+
+    evidence = [
+        CompanyDriveEvidence(
+            company_id=8,
+            company_name="PT BIMALA INVESTMENTS BALI",
+            client_ids=[51],
+            people=["Gianluca Morelli"],
+            tax_owner="Dewa Ayu",
+            documents=[
+                DriveEvidenceDocument(
+                    file_id="drive-tax",
+                    file_name="SPT 2025.pdf",
+                    document_type="spt",
+                    document_category="tax",
+                    ocr_status="completed",
+                    has_kg_node=True,
+                )
+            ],
+            kg_edge_count=1,
+        )
+    ]
+
+    with patch(
+        "backend.services.crm.drive_autowatcher_service.run_crm_drive_backfill",
+        new_callable=AsyncMock,
+        return_value={"processed": 0},
+    ), patch(
+        "backend.services.crm.drive_autowatcher_service.fetch_drive_evidence_for_story_drafts",
+        new_callable=AsyncMock,
+        return_value=evidence,
+    ), patch(
+        "backend.services.crm.drive_autowatcher_service.workspace_ai_snapshot_exists",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "backend.services.crm.drive_autowatcher_service.create_workspace_ai_snapshot",
+        new_callable=AsyncMock,
+    ) as create_snapshot:
+        result = await run_crm_drive_autowatch(
+            object(),
+            dry_run=False,
+            created_by="autowatcher",
+        )
+
+    assert result["snapshots_created"] == 0
+    assert result["snapshots_skipped_existing"] == 1
+    create_snapshot.assert_not_called()
+
+
+def test_story_draft_payload_uses_human_language_and_no_drive_links() -> None:
+    from backend.services.crm.drive_autowatcher_service import (
+        CompanyDriveEvidence,
+        DriveEvidenceDocument,
+        build_workspace_ai_snapshot_payload,
+    )
+
+    payload = build_workspace_ai_snapshot_payload(
+        CompanyDriveEvidence(
+            company_id=9,
+            company_name="PT HUMAN BUSINESS",
+            client_ids=[70],
+            people=["Maria Rossi"],
+            tax_owner="Adit",
+            documents=[
+                DriveEvidenceDocument(
+                    file_id="drive-company",
+                    file_name="AKTA.pdf",
+                    document_type="akta",
+                    document_category="company",
+                    ocr_status="completed",
+                    has_kg_node=True,
+                )
+            ],
+            kg_edge_count=1,
+        )
+    )
+
+    details = " ".join(fact.detail for fact in payload.facts)
+    assert "KG" not in details
+    assert "OCR" not in details
+    assert "drive.google.com" not in details
+    assert "Maria Rossi" in details
+    assert payload.facts[-1].detail.startswith("Review this draft")

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`265 routers · 560 services · 935 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`265 routers · 561 services · 936 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary
- Add a bounded CRM Drive autowatcher endpoint that runs the existing Drive/OCR/KG backfill and prepares Workspace AI draft snapshots.
- Keep the safe gate intact: snapshots are draft-only until team review, and Business Story still consumes only approved facts.
- Add hourly GitHub Actions cron plus manual dispatch for small backlog passes over existing Drive documents.

## Verification
- PYTHONPATH=. /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m pytest backend/tests/services/crm/test_drive_autowatcher_service.py backend/tests/routers/test_admin_crm_kg_backfill.py backend/tests/services/documents/test_crm_drive_backfill_service.py backend/tests/unit/services/crm/test_evidence_dossier.py backend/tests/unit/routers/test_crm_intelligence.py -q --tb=short
- /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m ruff check backend/services/crm/drive_autowatcher_service.py backend/app/routers/admin_crm_kg.py backend/tests/services/crm/test_drive_autowatcher_service.py backend/tests/routers/test_admin_crm_kg_backfill.py
- python scripts/docs_sync.py --check
- python scripts/docs_audit.py --check with Docs Guardian args
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cron-crm-drive-autowatcher.yml")'
- git diff --check