### PR TITLE
fix(crm): prioritize uncovered autowatcher companies

### DIFF
--- a/apps/backend-rag/backend/services/crm/drive_autowatcher_service.py
+++ b/apps/backend-rag/backend/services/crm/drive_autowatcher_service.py
@@ -149,7 +149,12 @@ async def fetch_drive_evidence_for_story_drafts(
     safe_limit = _safe_limit(limit)
     try:
         async with pool.acquire() as conn:
-            rows = await conn.fetch(_EVIDENCE_SQL, client_id, safe_limit)
+            rows = await conn.fetch(
+                _EVIDENCE_SQL,
+                client_id,
+                safe_limit,
+                f"{_NOTE_PREFIX}:%",
+            )
     except asyncpg.UndefinedTableError:
         logger.info("CRM Drive autowatcher skipped: required CRM tables missing")
         return []
@@ -446,19 +451,24 @@ def _safe_limit(limit: int) -> int:
 
 _EVIDENCE_SQL = """
 WITH company_scope AS (
-    SELECT DISTINCT
+    SELECT
         co.id AS company_id,
-        co.company_name
+        co.company_name,
+        BOOL_OR(snap.id IS NOT NULL) AS has_autowatcher_snapshot
     FROM client_company_links ccl
     JOIN clients cl ON cl.id = ccl.client_id
     JOIN companies co ON co.id = ccl.company_id
     JOIN documents d ON d.client_id = cl.id
+    LEFT JOIN crm_workspace_ai_snapshots snap
+        ON snap.company_id = co.id
+        AND snap.note_id LIKE $3::text
     WHERE cl.deleted_at IS NULL
       AND d.file_id IS NOT NULL
       AND d.file_id <> ''
       AND (d.is_archived IS NULL OR d.is_archived = false)
       AND ($1::int IS NULL OR cl.id = $1::int)
-    ORDER BY co.company_name
+    GROUP BY co.id, co.company_name
+    ORDER BY has_autowatcher_snapshot ASC, co.company_name
     LIMIT $2
 )
 SELECT

--- a/apps/backend-rag/backend/tests/services/crm/test_drive_autowatcher_service.py
+++ b/apps/backend-rag/backend/tests/services/crm/test_drive_autowatcher_service.py
@@ -234,3 +234,13 @@ def test_story_draft_payload_uses_human_language_and_no_drive_links() -> None:
     assert "drive.google.com" not in details
     assert "Maria Rossi" in details
     assert payload.facts[-1].detail.startswith("Review this draft")
+
+
+def test_evidence_query_prioritizes_companies_without_autowatcher_drafts() -> None:
+    from backend.services.crm import drive_autowatcher_service
+
+    sql = drive_autowatcher_service._EVIDENCE_SQL
+
+    assert "crm_workspace_ai_snapshots" in sql
+    assert "snap.note_id LIKE $3::text" in sql
+    assert "ORDER BY has_autowatcher_snapshot ASC" in sql


### PR DESCRIPTION
## Summary
- prioritize companies without existing CRM Drive autowatcher drafts before already-covered companies
- keep deterministic draft dedupe by note_id, so reruns can progress across the full Drive-backed CRM scope
- add regression coverage for the evidence query ordering

## Verification
- /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m pytest backend/tests/services/crm/test_drive_autowatcher_service.py backend/tests/routers/test_admin_crm_kg_backfill.py backend/tests/services/documents/test_crm_drive_backfill_service.py backend/tests/unit/services/crm/test_evidence_dossier.py backend/tests/unit/routers/test_crm_intelligence.py -q --tb=short
- /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m ruff check backend/services/crm/drive_autowatcher_service.py backend/app/routers/admin_crm_kg.py backend/tests/services/crm/test_drive_autowatcher_service.py backend/tests/routers/test_admin_crm_kg_backfill.py
- git diff --check