### PR TITLE
fix(crm): include company Drive docs in autowatcher evidence

### DIFF
--- a/apps/backend-rag/backend/services/crm/drive_autowatcher_service.py
+++ b/apps/backend-rag/backend/services/crm/drive_autowatcher_service.py
@@ -450,54 +450,126 @@ def _safe_limit(limit: int) -> int:
 
 
 _EVIDENCE_SQL = """
-WITH company_scope AS (
+WITH linked_people AS (
     SELECT
-        co.id AS company_id,
-        co.company_name,
-        BOOL_OR(snap.id IS NOT NULL) AS has_autowatcher_snapshot
+        ccl.company_id,
+        cl.id AS client_id,
+        cl.full_name AS client_name,
+        COALESCE(cl.tax_consultant, cl.assigned_to, '') AS tax_owner
     FROM client_company_links ccl
     JOIN clients cl ON cl.id = ccl.client_id
-    JOIN companies co ON co.id = ccl.company_id
-    JOIN documents d ON d.client_id = cl.id
-    LEFT JOIN crm_workspace_ai_snapshots snap
-        ON snap.company_id = co.id
-        AND snap.note_id LIKE $3::text
     WHERE cl.deleted_at IS NULL
-      AND d.file_id IS NOT NULL
+      AND ($1::int IS NULL OR cl.id = $1::int)
+),
+company_scope AS (
+    SELECT
+        base.company_id,
+        base.company_name,
+        BOOL_OR(snap.id IS NOT NULL) AS has_autowatcher_snapshot
+    FROM (
+        SELECT
+            co.id AS company_id,
+            co.company_name
+        FROM linked_people lp
+        JOIN companies co ON co.id = lp.company_id
+        JOIN documents d ON d.client_id = lp.client_id
+        WHERE d.file_id IS NOT NULL
+          AND d.file_id <> ''
+          AND (d.is_archived IS NULL OR d.is_archived = false)
+
+        UNION
+
+        SELECT
+            co.id AS company_id,
+            co.company_name
+        FROM linked_people lp
+        JOIN companies co ON co.id = lp.company_id
+        JOIN company_documents cd ON cd.company_id = co.id
+        WHERE cd.google_drive_file_id IS NOT NULL
+          AND cd.google_drive_file_id <> ''
+          AND COALESCE(cd.status, 'active') <> 'deleted'
+    ) base
+    LEFT JOIN crm_workspace_ai_snapshots snap
+        ON snap.company_id = base.company_id
+        AND snap.note_id LIKE $3::text
+    GROUP BY base.company_id, base.company_name
+    ORDER BY has_autowatcher_snapshot ASC, base.company_name
+    LIMIT $2
+),
+evidence_rows AS (
+    SELECT
+        scope.company_id,
+        scope.company_name,
+        lp.client_id,
+        lp.client_name,
+        lp.tax_owner,
+        d.file_id,
+        d.file_name,
+        d.document_type,
+        d.document_category,
+        d.ocr_status,
+        kg.entity_id IS NOT NULL AS has_kg_node,
+        kg.entity_id AS kg_entity_id
+    FROM company_scope scope
+    JOIN linked_people lp ON lp.company_id = scope.company_id
+    JOIN documents d ON d.client_id = lp.client_id
+    LEFT JOIN crm_kg_nodes kg
+        ON kg.file_id = d.file_id
+        AND kg.entity_type = 'crm_document'
+        AND kg.deleted_at IS NULL
+    WHERE d.file_id IS NOT NULL
       AND d.file_id <> ''
       AND (d.is_archived IS NULL OR d.is_archived = false)
-      AND ($1::int IS NULL OR cl.id = $1::int)
-    GROUP BY co.id, co.company_name
-    ORDER BY has_autowatcher_snapshot ASC, co.company_name
-    LIMIT $2
+
+    UNION ALL
+
+    SELECT
+        scope.company_id,
+        scope.company_name,
+        lp.client_id,
+        lp.client_name,
+        lp.tax_owner,
+        cd.google_drive_file_id AS file_id,
+        cd.file_name,
+        cd.document_type,
+        COALESCE(cd.document_subtype, 'company') AS document_category,
+        NULL::text AS ocr_status,
+        kg.entity_id IS NOT NULL AS has_kg_node,
+        kg.entity_id AS kg_entity_id
+    FROM company_scope scope
+    JOIN linked_people lp ON lp.company_id = scope.company_id
+    JOIN company_documents cd ON cd.company_id = scope.company_id
+    LEFT JOIN crm_kg_nodes kg
+        ON kg.file_id = cd.google_drive_file_id
+        AND kg.entity_type = 'crm_document'
+        AND kg.deleted_at IS NULL
+    WHERE cd.google_drive_file_id IS NOT NULL
+      AND cd.google_drive_file_id <> ''
+      AND COALESCE(cd.status, 'active') <> 'deleted'
+),
+kg_counts AS (
+    SELECT
+        er.company_id,
+        COUNT(DISTINCT edge.relationship_id) AS kg_edge_count
+    FROM evidence_rows er
+    LEFT JOIN crm_kg_edges edge
+        ON edge.source_entity_id = er.kg_entity_id
+    GROUP BY er.company_id
 )
 SELECT
-    scope.company_id,
-    scope.company_name,
-    cl.id AS client_id,
-    cl.full_name AS client_name,
-    COALESCE(cl.tax_consultant, cl.assigned_to, '') AS tax_owner,
-    d.file_id,
-    d.file_name,
-    d.document_type,
-    d.document_category,
-    d.ocr_status,
-    kg.entity_id IS NOT NULL AS has_kg_node,
-    COUNT(edge.relationship_id) OVER (PARTITION BY scope.company_id) AS kg_edge_count
-FROM company_scope scope
-JOIN client_company_links ccl ON ccl.company_id = scope.company_id
-JOIN clients cl ON cl.id = ccl.client_id
-JOIN documents d ON d.client_id = cl.id
-LEFT JOIN crm_kg_nodes kg
-    ON kg.file_id = d.file_id
-    AND kg.entity_type = 'crm_document'
-    AND kg.deleted_at IS NULL
-LEFT JOIN crm_kg_edges edge
-    ON edge.source_entity_id = kg.entity_id
-WHERE cl.deleted_at IS NULL
-  AND d.file_id IS NOT NULL
-  AND d.file_id <> ''
-  AND (d.is_archived IS NULL OR d.is_archived = false)
-  AND ($1::int IS NULL OR cl.id = $1::int)
-ORDER BY scope.company_name, cl.full_name, d.file_name
+    er.company_id,
+    er.company_name,
+    er.client_id,
+    er.client_name,
+    er.tax_owner,
+    er.file_id,
+    er.file_name,
+    er.document_type,
+    er.document_category,
+    er.ocr_status,
+    er.has_kg_node,
+    COALESCE(kc.kg_edge_count, 0) AS kg_edge_count
+FROM evidence_rows er
+LEFT JOIN kg_counts kc ON kc.company_id = er.company_id
+ORDER BY er.company_name, er.client_name, er.file_name
 """

--- a/apps/backend-rag/backend/tests/services/crm/test_drive_autowatcher_service.py
+++ b/apps/backend-rag/backend/tests/services/crm/test_drive_autowatcher_service.py
@@ -244,3 +244,47 @@ def test_evidence_query_prioritizes_companies_without_autowatcher_drafts() -> No
     assert "crm_workspace_ai_snapshots" in sql
     assert "snap.note_id LIKE $3::text" in sql
     assert "ORDER BY has_autowatcher_snapshot ASC" in sql
+    assert "company_documents" in sql
+    assert "google_drive_file_id" in sql
+
+
+def test_evidence_rows_dedupe_company_documents_across_linked_people() -> None:
+    from backend.services.crm.drive_autowatcher_service import _evidence_from_rows
+
+    evidence = _evidence_from_rows(
+        [
+            {
+                "company_id": 1762,
+                "company_name": "PT FRA Real Estate Consulting",
+                "client_id": 146,
+                "client_name": "Michele Porinelli",
+                "tax_owner": "sahira@balizero.com",
+                "file_id": "company-drive-file",
+                "file_name": "Profil Perseroan April 2025.pdf",
+                "document_type": "company_profile",
+                "document_category": "company",
+                "ocr_status": None,
+                "has_kg_node": False,
+                "kg_edge_count": 0,
+            },
+            {
+                "company_id": 1762,
+                "company_name": "PT FRA Real Estate Consulting",
+                "client_id": 176,
+                "client_name": "Francesca rizzo",
+                "tax_owner": "krisna@balizero.com",
+                "file_id": "company-drive-file",
+                "file_name": "Profil Perseroan April 2025.pdf",
+                "document_type": "company_profile",
+                "document_category": "company",
+                "ocr_status": None,
+                "has_kg_node": False,
+                "kg_edge_count": 0,
+            },
+        ]
+    )
+
+    assert len(evidence) == 1
+    assert evidence[0].client_ids == [146, 176]
+    assert evidence[0].people == ["Michele Porinelli", "Francesca rizzo"]
+    assert [document.file_id for document in evidence[0].documents] == ["company-drive-file"]


### PR DESCRIPTION
## Summary
- include company_documents Drive files when building CRM autowatcher evidence bundles
- dedupe company Drive files across linked people while preserving person-first links
- keep snapshots draft-only and source-file based

## Verification
- cd apps/backend-rag && python -m pytest backend/tests/services/crm/test_drive_autowatcher_service.py backend/tests/routers/test_admin_crm_kg_backfill.py backend/tests/unit/services/crm/test_evidence_dossier.py -q --tb=short
- cd apps/backend-rag && python -m ruff check backend/services/crm/drive_autowatcher_service.py backend/tests/services/crm/test_drive_autowatcher_service.py
- git diff --check

## Live check
- tested the new evidence SQL against prod for client_id=146; PT FRA returns 144 evidence rows including company_documents.
