### PR TITLE
feat(cell): LEVA 1 — dream rules persist as candidate skills

### DIFF
--- a/apps/cell/cell/memory/dreamer.py
+++ b/apps/cell/cell/memory/dreamer.py
@@ -6,16 +6,46 @@ extracts generalizable rules, identifies knowledge gaps, and writes
 a dream summary to cell_dreams.
 
 Inspired by MemGPT (paged memory consolidation) + sleep consolidation research.
+
+LEVA 1 (2026-05-13): after the dream is persisted, every rule in
+``rules_extracted`` is upserted into ``cell_skills`` as a candidate skill
+(``kind='skill'``, ``status='candidate'``, ``source='dreamer'``). This closes
+the loop ``dream → persisted skill`` so subsequent pulses can recall the rule
+across cell restarts. Dedup is hash-based on the normalised rule text.
 """
+import hashlib
 import json
 import logging
+import re
 from dataclasses import dataclass, field
 from datetime import date, datetime, timezone
 from typing import Any
 
 import httpx
 
+from cell.cortex.skill_library import compute_embedding
+
 logger = logging.getLogger("cell.memory.dreamer")
+
+# LEVA 1 (2026-05-13): cap rules-as-skills per dream cycle to bound bloat if
+# the Qwen 9B consolidator emits an outlier high count.
+_MAX_RULES_PER_DREAM = 20
+
+# Normalisation helpers for rule dedup. We match on case-insensitive, trailing-
+# punctuation-stripped, whitespace-collapsed form so "Rule!  " collides with
+# "rule" (this happens daily — empirical: last 3 dreams emit identical rules).
+_WHITESPACE_RE = re.compile(r"\s+")
+_TRAILING_PUNCT_RE = re.compile(r"[.!?\s]+$")
+
+
+def _normalize_rule(rule: str) -> str:
+    """Lowercase + strip trailing punctuation + collapse whitespace. Cap 4000."""
+    if not rule:
+        return ""
+    s = rule.lower().strip()
+    s = _TRAILING_PUNCT_RE.sub("", s)
+    s = _WHITESPACE_RE.sub(" ", s)
+    return s[:4000]
 
 _DREAMER_SYSTEM = """You are CELL's consolidation process, running during sleep.
 Analyze today's episodes and extract generalizable rules.
@@ -145,6 +175,93 @@ class Dreamer:
             logger.warning(f"Dreamer LLM extraction failed: {e}")
             return [], []
 
+    async def _upsert_rules_as_skills(
+        self, rules: list[str], dream_date: date
+    ) -> int:
+        """Upsert dream-extracted rules as candidate skills in cell_skills.
+
+        Returns the number of NEW skills inserted (0 if all dedup hits).
+        Best-effort: any exception is logged at WARNING and swallowed; the
+        outer ``dream()`` call must never break because of a skill upsert.
+
+        LEVA 1 contract:
+        - ``kind='skill'`` (LEVA 2 column, default already set by migration 172
+          but written explicitly to stay self-describing).
+        - ``status='candidate'`` (only ``status='active'`` is returned by
+          ``SkillLibrary.recall()``; promotion is a LEVA 4 concern).
+        - ``fitness=0.0`` (initial; the existing ``record_use()`` formula will
+          recompute it on the first use). The source confidence (0.6) is stored
+          in ``precondition.source_confidence`` instead, so the formula is not
+          shadowed.
+        - ``scope='Project'`` (germline-inheritable via HGT, LEVA 5).
+        - ``source='dreamer'``.
+        - Dedup: ``name = f"rule:{sha1(normalised)[:24]}"``; SELECT-then-INSERT
+          inside a single connection. Single-process dreamer cron makes the
+          race window trivial.
+        """
+        if not rules:
+            return 0
+
+        rules = rules[:_MAX_RULES_PER_DREAM]
+        inserted = 0
+
+        for rule_text in rules:
+            try:
+                norm = _normalize_rule(rule_text)
+                if not norm:
+                    continue
+                skill_name = f"rule:{hashlib.sha1(norm.encode()).hexdigest()[:24]}"
+                trigger_nl = rule_text[:4000]
+                embedding = compute_embedding(norm)
+                precondition = {
+                    "source": "dreamer",
+                    "source_confidence": 0.6,
+                    "source_dream_date": dream_date.isoformat(),
+                    "rule_text_sha1": skill_name.removeprefix("rule:"),
+                }
+
+                async with self._pool.acquire() as conn:
+                    existing = await conn.fetchval(
+                        "SELECT id FROM cell_skills WHERE name = $1",
+                        skill_name,
+                    )
+                    if existing is not None:
+                        continue
+                    await conn.execute(
+                        """
+                        INSERT INTO cell_skills
+                            (name, trigger_nl, action_sequence, rationale_nl,
+                             fitness, success_count, failure_count, use_count,
+                             generation, parent_id, embedding, status, source,
+                             kind, scope, precondition)
+                        VALUES
+                            ($1, $2, '[]'::jsonb, $3,
+                             0.0, 0, 0, 0,
+                             0, NULL, $4, 'candidate', 'dreamer',
+                             'skill', 'Project', $5::jsonb)
+                        """,
+                        skill_name,
+                        trigger_nl,
+                        f"Rule extracted by Dreamer on {dream_date.isoformat()}.",
+                        embedding,
+                        json.dumps(precondition),
+                    )
+                    inserted += 1
+            except Exception as exc:
+                logger.warning(
+                    "Failed to upsert rule as skill: %s -- %s",
+                    rule_text[:80],
+                    exc,
+                )
+
+        if inserted:
+            logger.info(
+                "Dreamer: upserted %d new candidate skills from %d rules",
+                inserted,
+                len(rules),
+            )
+        return inserted
+
     async def _persist_dream(self, result: DreamResult) -> None:
         """Write dream result to cell_dreams."""
         async with self._pool.acquire() as conn:
@@ -201,6 +318,16 @@ class Dreamer:
             summary=summary,
         )
         await self._persist_dream(result)
+
+        # LEVA 1: close the loop dream -> persisted candidate skill.
+        # Best-effort: never blocks the caller.
+        if result.rules_extracted:
+            try:
+                await self._upsert_rules_as_skills(
+                    result.rules_extracted, result.dream_date
+                )
+            except Exception as exc:
+                logger.warning("Dreamer skill upsert failed: %s", exc)
 
         logger.info(
             f"Dreamer: consolidated {len(episodes)} episodes -> "

--- a/apps/cell/tests/test_dreamer.py
+++ b/apps/cell/tests/test_dreamer.py
@@ -5,7 +5,12 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from datetime import date
 
-from cell.memory.dreamer import Dreamer, DreamResult
+from cell.memory.dreamer import (
+    Dreamer,
+    DreamResult,
+    _MAX_RULES_PER_DREAM,
+    _normalize_rule,
+)
 
 
 class TestDreamResult:
@@ -146,3 +151,248 @@ class TestDreamerRun:
         assert result.rules_extracted == []
         assert result.gaps_identified == []
         assert "episode" in result.summary.lower() or "rule" in result.summary.lower()
+
+
+# ---------------------------------------------------------------------------
+# TestNormalizeRule (LEVA 1, 2026-05-13)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeRule:
+    def test_strips_trailing_punctuation(self):
+        assert _normalize_rule("Rule!  ") == "rule"
+        assert _normalize_rule("Rule.") == "rule"
+        assert _normalize_rule("Rule?") == "rule"
+
+    def test_lowercases(self):
+        assert _normalize_rule("RULE TEXT") == "rule text"
+
+    def test_collapses_whitespace(self):
+        assert _normalize_rule("rule    with     gaps") == "rule with gaps"
+
+    def test_empty_returns_empty(self):
+        assert _normalize_rule("") == ""
+        assert _normalize_rule(None) == ""  # type: ignore[arg-type]
+
+    def test_dedup_invariance(self):
+        # Same canonical form for trivial variants.
+        a = _normalize_rule("When health is RED, restart_service is required.")
+        b = _normalize_rule("when  health is red, restart_service is required!  ")
+        assert a == b
+
+
+# ---------------------------------------------------------------------------
+# TestUpsertRulesAsSkills (LEVA 1, 2026-05-13)
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertRulesAsSkills:
+    @pytest.fixture
+    def pool_no_existing(self):
+        """Pool whose SELECT id returns None (no dedup hit) — every INSERT runs."""
+        acquire_ctx = AsyncMock()
+        acquire_ctx.__aenter__ = AsyncMock(return_value=acquire_ctx)
+        acquire_ctx.__aexit__ = AsyncMock(return_value=None)
+        acquire_ctx.fetchval = AsyncMock(return_value=None)
+        acquire_ctx.execute = AsyncMock()
+        acquire_ctx.fetch = AsyncMock(return_value=[])
+        pool = MagicMock()
+        pool.acquire = MagicMock(return_value=acquire_ctx)
+        return pool, acquire_ctx
+
+    @pytest.fixture
+    def pool_all_existing(self):
+        """Pool whose SELECT id always returns an int — every rule is dedup'd."""
+        acquire_ctx = AsyncMock()
+        acquire_ctx.__aenter__ = AsyncMock(return_value=acquire_ctx)
+        acquire_ctx.__aexit__ = AsyncMock(return_value=None)
+        acquire_ctx.fetchval = AsyncMock(return_value=42)
+        acquire_ctx.execute = AsyncMock()
+        pool = MagicMock()
+        pool.acquire = MagicMock(return_value=acquire_ctx)
+        return pool, acquire_ctx
+
+    @pytest.mark.asyncio
+    async def test_empty_list_returns_zero(self, pool_no_existing):
+        pool, _ = pool_no_existing
+        d = Dreamer(pool=pool)
+        inserted = await d._upsert_rules_as_skills([], date(2026, 5, 13))
+        assert inserted == 0
+
+    @pytest.mark.asyncio
+    async def test_inserts_new_rules(self, pool_no_existing):
+        pool, conn = pool_no_existing
+        d = Dreamer(pool=pool)
+        rules = [
+            "When health is red, restart_service is required.",
+            "When yellow with high RT, scale_up is proposed.",
+        ]
+        inserted = await d._upsert_rules_as_skills(rules, date(2026, 5, 13))
+        assert inserted == 2
+        # Two INSERTs ran (one per rule).
+        insert_calls = [
+            c for c in conn.execute.await_args_list
+            if "INSERT INTO cell_skills" in c.args[0]
+        ]
+        assert len(insert_calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_dedup_skips_existing(self, pool_all_existing):
+        pool, conn = pool_all_existing
+        d = Dreamer(pool=pool)
+        rules = ["Rule one.", "Rule two."]
+        inserted = await d._upsert_rules_as_skills(rules, date(2026, 5, 13))
+        assert inserted == 0
+        # No INSERT calls — only the SELECTs ran.
+        assert all(
+            "INSERT INTO cell_skills" not in c.args[0]
+            for c in conn.execute.await_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_caps_at_max_rules(self, pool_no_existing):
+        pool, conn = pool_no_existing
+        d = Dreamer(pool=pool)
+        # Distinct strings so dedup doesn't trim them.
+        rules = [f"Rule number {i}." for i in range(50)]
+        inserted = await d._upsert_rules_as_skills(rules, date(2026, 5, 13))
+        assert inserted == _MAX_RULES_PER_DREAM == 20
+
+    @pytest.mark.asyncio
+    async def test_insert_failure_isolated(self):
+        """An exception inside INSERT must not blow up the whole upsert call."""
+        acquire_ctx = AsyncMock()
+        acquire_ctx.__aenter__ = AsyncMock(return_value=acquire_ctx)
+        acquire_ctx.__aexit__ = AsyncMock(return_value=None)
+        acquire_ctx.fetchval = AsyncMock(return_value=None)
+        # First execute call (INSERT) raises; subsequent ones succeed.
+        call_count = [0]
+
+        async def flaky_execute(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise RuntimeError("simulated DB outage")
+            return None
+
+        acquire_ctx.execute = AsyncMock(side_effect=flaky_execute)
+        pool = MagicMock()
+        pool.acquire = MagicMock(return_value=acquire_ctx)
+
+        d = Dreamer(pool=pool)
+        rules = ["Rule A.", "Rule B."]
+        inserted = await d._upsert_rules_as_skills(rules, date(2026, 5, 13))
+        # One INSERT failed, one succeeded.
+        assert inserted == 1
+
+    @pytest.mark.asyncio
+    async def test_skill_name_is_deterministic(self, pool_no_existing):
+        """Same rule -> same skill_name across calls (dedup hash stable)."""
+        pool, conn = pool_no_existing
+        d = Dreamer(pool=pool)
+        await d._upsert_rules_as_skills(
+            ["Same rule text."], date(2026, 5, 13)
+        )
+        await d._upsert_rules_as_skills(
+            ["same rule text!  "], date(2026, 5, 13)
+        )
+        # 2 SELECT calls fired (one per call). Compare the name parameter.
+        select_calls = [
+            c for c in conn.fetchval.await_args_list
+            if "SELECT id FROM cell_skills" in c.args[0]
+        ]
+        assert len(select_calls) == 2
+        # Both selects use the same skill_name parameter -> dedup hash stable.
+        assert select_calls[0].args[1] == select_calls[1].args[1]
+
+    @pytest.mark.asyncio
+    async def test_precondition_has_dreamer_provenance(self, pool_no_existing):
+        pool, conn = pool_no_existing
+        d = Dreamer(pool=pool)
+        await d._upsert_rules_as_skills(
+            ["A rule."], date(2026, 5, 13)
+        )
+        insert_call = next(
+            c for c in conn.execute.await_args_list
+            if "INSERT INTO cell_skills" in c.args[0]
+        )
+        # precondition is positional arg 5 in the INSERT.
+        precondition_json = insert_call.args[5]
+        precondition = json.loads(precondition_json)
+        assert precondition["source"] == "dreamer"
+        assert precondition["source_confidence"] == 0.6
+        assert precondition["source_dream_date"] == "2026-05-13"
+        assert "rule_text_sha1" in precondition
+
+    @pytest.mark.asyncio
+    async def test_dream_end_to_end_upserts_rules(self):
+        """dream() with non-empty rules calls _upsert_rules_as_skills."""
+        rows = [
+            {
+                "id": 1, "timestamp": 1743700000.0,
+                "situation": json.dumps({"health_status": "red"}),
+                "emotion": "stressed", "action_taken": "restart_service",
+                "outcome": "success", "lesson": "Restart fixed it",
+                "recall_count": 1,
+            }
+        ]
+        acquire_ctx = AsyncMock()
+        acquire_ctx.__aenter__ = AsyncMock(return_value=acquire_ctx)
+        acquire_ctx.__aexit__ = AsyncMock(return_value=None)
+        acquire_ctx.fetch = AsyncMock(return_value=rows)
+        acquire_ctx.fetchval = AsyncMock(return_value=None)
+        acquire_ctx.execute = AsyncMock()
+        pool = MagicMock()
+        pool.acquire = MagicMock(return_value=acquire_ctx)
+
+        dreamer = Dreamer(pool=pool, ollama_url="http://localhost:11434")
+
+        with patch.object(
+            dreamer, "_extract_rules_with_llm", new_callable=AsyncMock
+        ) as mock_rules, patch.object(
+            dreamer, "_upsert_rules_as_skills", new_callable=AsyncMock
+        ) as mock_upsert:
+            mock_rules.return_value = (
+                ["Rule one from dream."],
+                [],
+            )
+            mock_upsert.return_value = 1
+            result = await dreamer.dream()
+
+        assert result.rules_extracted == ["Rule one from dream."]
+        mock_upsert.assert_awaited_once()
+        # Verify positional args: (rules_list, dream_date)
+        upsert_args = mock_upsert.await_args
+        assert upsert_args.args[0] == ["Rule one from dream."]
+
+    @pytest.mark.asyncio
+    async def test_dream_upsert_failure_does_not_break_dream(self):
+        """If _upsert_rules_as_skills raises, dream() still returns result."""
+        rows = [
+            {
+                "id": 1, "timestamp": 1743700000.0,
+                "situation": json.dumps({"health_status": "red"}),
+                "emotion": "stressed", "action_taken": "restart_service",
+                "outcome": "success", "lesson": "Restart fixed it",
+                "recall_count": 1,
+            }
+        ]
+        acquire_ctx = AsyncMock()
+        acquire_ctx.__aenter__ = AsyncMock(return_value=acquire_ctx)
+        acquire_ctx.__aexit__ = AsyncMock(return_value=None)
+        acquire_ctx.fetch = AsyncMock(return_value=rows)
+        acquire_ctx.fetchval = AsyncMock(return_value=None)
+        acquire_ctx.execute = AsyncMock()
+        pool = MagicMock()
+        pool.acquire = MagicMock(return_value=acquire_ctx)
+
+        dreamer = Dreamer(pool=pool, ollama_url="http://localhost:11434")
+        with patch.object(
+            dreamer, "_extract_rules_with_llm", new_callable=AsyncMock
+        ) as mock_rules, patch.object(
+            dreamer, "_upsert_rules_as_skills",
+            new=AsyncMock(side_effect=RuntimeError("simulated upsert crash")),
+        ):
+            mock_rules.return_value = (["A rule."], [])
+            result = await dreamer.dream()
+        assert result.episodes_count == 1
+        assert result.rules_extracted == ["A rule."]


### PR DESCRIPTION
## Summary

LEVA 1 of `docs/superpowers/plans/2026-05-13-organism-potenziamento-5-leve.md`. Closes the dream→skill loop so cell_skills starts populating from Dreamer output (today 0 rows; 1900 raw rules sitting unused in `cell_dreams.rules_extracted`).

## What changed

- **`dreamer.py`**: new `_upsert_rules_as_skills(rules, dream_date)` helper invoked by `dream()` after `_persist_dream`. Per-rule:
  - normalize → `sha1(normalised)[:24]` → `name="rule:<hash>"` (dedup key)
  - SELECT-then-INSERT (race-safe in single-process dreamer cron)
  - `kind='skill', status='candidate', source='dreamer', scope='Project', fitness=0.0`
  - `precondition` JSONB carries `source_confidence=0.6` + `source_dream_date` + sha1 (NOT in `fitness` — DeepSeek catch on existing `record_use` math)
  - cap `_MAX_RULES_PER_DREAM=20`
  - errors logged at WARNING, never propagate
- **`test_dreamer.py`**: 14 new tests (5 `TestNormalizeRule` + 9 `TestUpsertRulesAsSkills`), full suite 19/19 green.

## Empirical motivation (pre-flight 2026-05-13 06:50 WITA)

| Metric | Value |
|---|---|
| `cell_dreams` total | 1019 |
| `cell_dreams.rules_extracted` total cardinality | 1900 |
| `cell_skills` rows | 0 (loop spezzato pre-LEVA 1) |
| Last 3 dreams | emitting **identical** rule strings → hash dedup will collapse to ~30-100 unique semantic rules |

## Brainstorm trail

Single-LLM panel (DeepSeek V4 Pro, 8/8 answers). Gemini CLI dies on Conseca safety policy gate (same 429 class as on LEVA 2). Codex CLI exits instantly (same pattern). NB-1 CLI has no non-interactive `chat` subcommand. Synthesis at `/tmp/leva1-brainstorm-2026-05-13/05_synthesis.md`.

**DeepSeek's critical catch on Q3** (`fitness=0.6` anti-pattern): the existing `skill_library.record_use()` formula computes `fitness=(success-failure)/use_count` and would overwrite any seed value on first call. Solution: init `fitness=0.0`, carry confidence in `precondition` JSONB. Preserves both math AND provenance.

Devils-advocate review pre-PR (DeepSeek V4 Pro on the diff): 3 findings, 1 hallucinated (claimed `compute_embedding` returns list — false, returns `bytes` per `skill_library.py:37,54`), 2 race-condition findings scoped to LEVA 5 territory (no cross-cell writers exist today).

## Expected post-deploy effect

Next dream cycle (cell.organism plist) will emit ~3 rules and write 3 rows to `cell_skills` (assuming all distinct). Verify:

```sql
SELECT COUNT(*), kind, status, source FROM cell_skills GROUP BY kind, status, source;
-- Expect: kind=skill / status=candidate / source=dreamer / count>=3 within 24h
```

Long-term (14 days): ~30-100 unique rules accumulate, ready for LEVA 4 promotion logic.

## Test plan

- [x] Unit: 19/19 dreamer tests green (`apps/cell` Pro venv, 0.15s)
- [x] Adjacent suites untouched: 32/32 critic + 32+ skill_library tests still green (83/83 combined)
- [x] Syntax + ast parse OK
- [x] DeepSeek devils-advocate cleared (3 findings, 1 hallucinated + 2 scoped to LEVA 5)
- [ ] CI green (E2E + MCP + no migration → no Squawk)
- [ ] Post-deploy: first dream cycle inserts >=1 row in cell_skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)