### PR TITLE
fix(crm): serialize workspace AI facts jsonb

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ See [`INDEX.md`](INDEX.md) for the full atlas including packages, tessuti dati, 
 ### Tech Stack
 
 <!-- DOCSYNC:BACKEND_STATS_START -->
-- **Backend:** Python 3.11+, FastAPI, 265 routers, 561 services, 936 test files
+- **Backend:** Python 3.11+, FastAPI, 265 routers, 561 services, 937 test files
 <!-- DOCSYNC:BACKEND_STATS_END -->
 - **Frontend:** Next.js, TypeScript, Tailwind CSS
 - **Databases:** PostgreSQL (relational), Qdrant (vector), Redis (cache)

--- a/apps/backend-rag/backend/services/crm/workspace_ai_snapshots.py
+++ b/apps/backend-rag/backend/services/crm/workspace_ai_snapshots.py
@@ -6,6 +6,7 @@ approved facts, so raw AI output cannot leak into the team UI or client portal.
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any, Literal
 
@@ -81,7 +82,10 @@ async def create_workspace_ai_snapshot(
             payload.notebook_id,
             payload.note_id,
             payload.source_file_ids,
-            [fact.model_dump(mode="json") for fact in payload.facts],
+            json.dumps(
+                [fact.model_dump(mode="json") for fact in payload.facts],
+                default=str,
+            ),
             created_by,
         )
 

--- a/apps/backend-rag/backend/tests/services/crm/test_workspace_ai_snapshots.py
+++ b/apps/backend-rag/backend/tests/services/crm/test_workspace_ai_snapshots.py
@@ -1,0 +1,93 @@
+"""Tests for CRM Workspace AI snapshot persistence."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from backend.services.crm.tax_company_pilot import TaxCompanyPilotWorkspaceAiFact
+from backend.services.crm.workspace_ai_snapshots import (
+    WorkspaceAiSnapshotCreate,
+    create_workspace_ai_snapshot,
+)
+
+
+class _FakeAcquire:
+    def __init__(self, conn: _FakeConn) -> None:
+        self._conn = conn
+
+    async def __aenter__(self) -> _FakeConn:
+        return self._conn
+
+    async def __aexit__(self, *_exc_info: object) -> None:
+        return None
+
+
+class _FakePool:
+    def __init__(self) -> None:
+        self.conn = _FakeConn()
+
+    def acquire(self) -> _FakeAcquire:
+        return _FakeAcquire(self.conn)
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        self.args: tuple[Any, ...] | None = None
+
+    async def fetchrow(self, _query: str, *args: Any) -> dict[str, Any]:
+        self.args = args
+        facts_arg = args[7]
+        assert isinstance(facts_arg, str)
+        facts = json.loads(facts_arg)
+        return {
+            "id": "draft-1",
+            "company_id": args[0],
+            "client_id": args[1],
+            "company_name": args[2],
+            "provider": args[3],
+            "notebook_id": args[4],
+            "note_id": args[5],
+            "source_file_ids": args[6],
+            "facts": facts,
+            "status": "draft",
+            "created_by": args[8],
+            "approved_by": None,
+            "approved_at": None,
+            "created_at": datetime(2026, 5, 12, tzinfo=timezone.utc),
+        }
+
+
+@pytest.mark.asyncio
+async def test_create_workspace_ai_snapshot_serializes_facts_for_jsonb() -> None:
+    pool = _FakePool()
+    payload = WorkspaceAiSnapshotCreate(
+        company_id=1762,
+        client_id=146,
+        company_name="PT FRA Real Estate Consulting",
+        provider="gemini",
+        note_id="crm-drive-autowatcher:v1:1762:test",
+        source_file_ids=["drive-file-1"],
+        facts=[
+            TaxCompanyPilotWorkspaceAiFact(
+                category="identity",
+                label="Company evidence",
+                detail="Company source documents are indexed for review.",
+                source_file_ids=["drive-file-1"],
+                confidence="medium",
+            )
+        ],
+    )
+
+    response = await create_workspace_ai_snapshot(
+        pool,  # type: ignore[arg-type]
+        payload,
+        created_by="test",
+    )
+
+    assert response.status == "draft"
+    assert pool.conn.args is not None
+    assert json.loads(pool.conn.args[7])[0]["category"] == "identity"

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`265 routers · 561 services · 936 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`265 routers · 561 services · 937 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary
- serialize Workspace AI snapshot facts before sending them to the jsonb insert
- add a regression test that reproduces the asyncpg jsonb failure from the live autowatcher run

## Verification
- /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m pytest backend/tests/services/crm/test_workspace_ai_snapshots.py backend/tests/services/crm/test_drive_autowatcher_service.py backend/tests/routers/test_admin_crm_kg_backfill.py backend/tests/unit/services/crm/test_evidence_dossier.py -q --tb=short
- /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m ruff check backend/services/crm/workspace_ai_snapshots.py backend/tests/services/crm/test_workspace_ai_snapshots.py
- git diff --check