### PR TITLE
fix(crm): parse workspace AI facts jsonb readback

### DIFF
--- a/apps/backend-rag/backend/services/crm/workspace_ai_snapshots.py
+++ b/apps/backend-rag/backend/services/crm/workspace_ai_snapshots.py
@@ -98,10 +98,7 @@ async def create_workspace_ai_snapshot(
         notebook_id=row["notebook_id"],
         note_id=row["note_id"],
         source_file_ids=list(row["source_file_ids"] or []),
-        facts=[
-            TaxCompanyPilotWorkspaceAiFact.model_validate(fact)
-            for fact in (row["facts"] or [])
-        ],
+        facts=_facts_from_db_value(row["facts"]),
         status=row["status"],
         created_by=row["created_by"],
         approved_by=row["approved_by"],
@@ -119,14 +116,18 @@ def _snapshot_from_row(row: Any) -> TaxCompanyPilotWorkspaceAiSnapshot:
         notebook_id=data.get("notebook_id"),
         note_id=data.get("note_id"),
         source_file_ids=list(data.get("source_file_ids") or []),
-        facts=[
-            TaxCompanyPilotWorkspaceAiFact.model_validate(fact)
-            for fact in (data.get("facts") or [])
-        ],
+        facts=_facts_from_db_value(data.get("facts")),
         approved_by=data.get("approved_by"),
         approved_at=approved_at.isoformat() if hasattr(approved_at, "isoformat") else approved_at,
         created_at=created_at.isoformat() if hasattr(created_at, "isoformat") else created_at,
     )
+
+
+def _facts_from_db_value(value: Any) -> list[TaxCompanyPilotWorkspaceAiFact]:
+    if not value:
+        return []
+    parsed = json.loads(value) if isinstance(value, str) else value
+    return [TaxCompanyPilotWorkspaceAiFact.model_validate(fact) for fact in parsed]
 
 
 _LATEST_BY_COMPANY_SQL = """

--- a/apps/backend-rag/backend/tests/services/crm/test_workspace_ai_snapshots.py
+++ b/apps/backend-rag/backend/tests/services/crm/test_workspace_ai_snapshots.py
@@ -42,7 +42,6 @@ class _FakeConn:
         self.args = args
         facts_arg = args[7]
         assert isinstance(facts_arg, str)
-        facts = json.loads(facts_arg)
         return {
             "id": "draft-1",
             "company_id": args[0],
@@ -52,7 +51,7 @@ class _FakeConn:
             "notebook_id": args[4],
             "note_id": args[5],
             "source_file_ids": args[6],
-            "facts": facts,
+            "facts": facts_arg,
             "status": "draft",
             "created_by": args[8],
             "approved_by": None,
@@ -89,5 +88,6 @@ async def test_create_workspace_ai_snapshot_serializes_facts_for_jsonb() -> None
     )
 
     assert response.status == "draft"
+    assert response.facts[0].category == "identity"
     assert pool.conn.args is not None
     assert json.loads(pool.conn.args[7])[0]["category"] == "identity"


### PR DESCRIPTION
## Summary
- parse `crm_workspace_ai_snapshots.facts` when asyncpg returns jsonb as a JSON string
- reuse the parser for create response and latest approved snapshot reads
- extend the regression test to mirror asyncpg jsonb readback behavior

## Verification
- /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m pytest backend/tests/services/crm/test_workspace_ai_snapshots.py backend/tests/services/crm/test_drive_autowatcher_service.py backend/tests/routers/test_admin_crm_kg_backfill.py backend/tests/unit/services/crm/test_evidence_dossier.py -q --tb=short
- /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m ruff check backend/services/crm/workspace_ai_snapshots.py backend/tests/services/crm/test_workspace_ai_snapshots.py
- python3 scripts/docs_sync.py --check
- git diff --check