### PR TITLE
fix(intel-lake): parse ISO 8601 published_at + alert on rejected drains

### DIFF
--- a/apps/backend-rag/backend/services/intel/intel_lake_service.py
+++ b/apps/backend-rag/backend/services/intel/intel_lake_service.py
@@ -18,12 +18,40 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 from urllib.parse import urldefrag, urlparse, urlunparse
 
 import asyncpg
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_iso_datetime(value: str | None) -> datetime | None:
+    """Parse an ISO 8601 string into a datetime for asyncpg timestamptz binding.
+
+    asyncpg's timestamptz codec requires a Python `datetime`, NOT a string.
+    Wave 4 producers (regulatory_watcher, intel_radar) send ISO 8601 strings
+    like ``2026-05-13T07:00:00+08:00``; binding them directly produced
+    ``invalid input for query argument $9: ... (expected a date object)``
+    and the endpoint returned 500. The bug silently dropped every item with
+    a non-null ``published_at`` since Wave 4 deploy (2026-05-12) because the
+    drainer trusts the audit log for rejection accounting.
+
+    Returns ``None`` for empty / unparseable input — better to lose the
+    timestamp than to drop the whole item.
+    """
+    if not value:
+        return None
+    try:
+        # Python 3.11+ fromisoformat handles trailing 'Z' and offsets
+        return datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        logger.warning(
+            "intel-lake: unparseable published_at=%r — storing as NULL",
+            value,
+        )
+        return None
 
 MAX_RAW_PAYLOAD_BYTES = 50_000
 ROUTING_STATUS_VALUES = {
@@ -152,7 +180,7 @@ class IntelLakeService:
                     obs.language,
                     obs.jurisdiction,
                     obs.topic_tags or [],
-                    obs.published_at,
+                    _parse_iso_datetime(obs.published_at),
                     raw_json,
                 )
 

--- a/apps/backend-rag/backend/tests/unit/services/intel/test_intel_lake_service.py
+++ b/apps/backend-rag/backend/tests/unit/services/intel/test_intel_lake_service.py
@@ -6,8 +6,11 @@ DB-backed tests live in tests/integration/ (require live PG).
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from backend.services.intel.intel_lake_service import (
     MAX_RAW_PAYLOAD_BYTES,
+    _parse_iso_datetime,
     canonicalize_url,
 )
 
@@ -50,3 +53,44 @@ class TestCanonicalizeUrl:
 class TestPayloadSizeLimit:
     def test_max_payload_constant_is_50kb(self) -> None:
         assert MAX_RAW_PAYLOAD_BYTES == 50_000
+
+
+class TestParseIsoDatetime:
+    """Regression for 2026-05-13 — silent drop of items with published_at.
+
+    asyncpg's timestamptz codec requires a datetime, not a string. Wave 4
+    producers send ISO 8601 strings. Helper must parse them, return None
+    for empty/invalid, and never raise.
+    """
+
+    def test_none_returns_none(self) -> None:
+        assert _parse_iso_datetime(None) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert _parse_iso_datetime("") is None
+
+    def test_iso_with_offset_parses(self) -> None:
+        result = _parse_iso_datetime("2026-05-13T07:00:00+08:00")
+        assert isinstance(result, datetime)
+        assert result.tzinfo is not None
+
+    def test_iso_with_z_parses(self) -> None:
+        result = _parse_iso_datetime("2026-05-13T07:00:00Z")
+        assert isinstance(result, datetime)
+        assert result.tzinfo is not None
+
+    def test_iso_date_only_parses(self) -> None:
+        result = _parse_iso_datetime("2026-05-13")
+        assert isinstance(result, datetime)
+        assert result.year == 2026
+
+    def test_invalid_returns_none(self) -> None:
+        assert _parse_iso_datetime("not-a-date") is None
+
+    def test_garbage_does_not_raise(self) -> None:
+        # Defense in depth — any unparseable input must not propagate
+        assert _parse_iso_datetime("\x00\xff") is None
+
+    def test_returns_none_for_non_string_type(self) -> None:
+        # Type-narrowing fallback
+        assert _parse_iso_datetime(12345) is None  # type: ignore[arg-type]

--- a/scripts/intel-lake-outbox-drain/README.md
+++ b/scripts/intel-lake-outbox-drain/README.md
@@ -1,0 +1,46 @@
+# Intel Lake outbox drainer (Pro-local, Wave 4)
+
+Pro-local cron LaunchAgent that drains the SQLite outbox
+(`~/.intel-lake-outbox.db`) to Fly endpoint `/api/intel/lake/observations-batch`.
+
+**Status**: tracking in repo from 2026-05-13 (this PR). Was Pro-local-only
+since Wave 4 deploy. Versioning here preserves both the helper module
+(`intel_lake_outbox.py`) used by producers AND the cron driver
+(`intel-lake-outbox-drain.py`).
+
+## Deploy paths on Pro
+
+| File | Deployed path |
+|---|---|
+| `intel-lake-outbox-drain.py` | `~/scripts/intel-lake-outbox-drain.py` |
+| `intel_lake_outbox.py` | `~/scripts/intel_lake_outbox.py` |
+
+LaunchAgent: `~/Library/LaunchAgents/com.balizero.intel-lake.outbox-drain.minute.plist`
+(StartInterval 60s).
+
+## 2026-05-13 fix — Telegram alert on rejected items
+
+The drainer's original Wave 4 design unconditionally marked all rows
+`delivered_at=NOW()` regardless of backend `rejected` count, trusting
+the `intel_lake_audit_log` table on Fly to record rejections. That
+trust was misplaced: a regression on 2026-05-12 in
+`apps/backend-rag/backend/services/intel/intel_lake_service.py:155`
+(asyncpg cannot auto-bind ISO 8601 string to timestamptz) caused
+every item with `published_at` to return HTTP 500. Producers
+(`regulatory_watcher`, `intel_radar`) had **zero visibility** because
+the drainer reported success.
+
+Fix (this PR): when `rejected > 0` in the backend response, the
+drainer now emits a Telegram alert (debounced 30min via
+`~/logs/intel-lake-outbox-drain.alert-state.json`). The
+`mark_delivered(ids)` call is preserved — we still avoid infinite
+retry loops — but the silent-drop blind spot is closed.
+
+The server-side root cause is fixed in the same PR in
+`intel_lake_service.py` via a new `_parse_iso_datetime()` helper.
+
+## Cross-references
+- Pro-local nb-pusher (downstream consumer): `scripts/intel-lake-nb-pusher-a2/`
+- Pro-local router (upstream classifier): `scripts/intel-lake-router-a2/`
+- Discovery memo:
+  `~/.claude/projects/-Users-nuzantara/memory/discovery_intel_lake_published_at_silent_drop_2026_05_13.md`

--- a/scripts/intel-lake-outbox-drain/intel-lake-outbox-drain.py
+++ b/scripts/intel-lake-outbox-drain/intel-lake-outbox-drain.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Intel Lake outbox drain (Wave 1, 2026-05-12).
+
+Reads up to 100 pending rows from ~/.intel-lake-outbox.db and POSTs them
+to the backend Fly endpoint `/api/intel/lake/observations:batch`.
+
+Scheduled every 60s via LaunchAgent `com.balizero.intel-lake.outbox-drain.minute`.
+
+Env required:
+  INTEL_LAKE_PRODUCER_TOKEN  — bearer for X-Producer-Token header
+  NUZANTARA_BACKEND_URL      — default https://nuzantara-rag.fly.dev
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+sys.path.insert(0, str(Path(__file__).parent))
+from intel_lake_outbox import fetch_pending, mark_delivered, mark_failed, stats  # type: ignore
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [outbox-drain] %(message)s",
+)
+logger = logging.getLogger("intel-lake-outbox-drain")
+
+BACKEND_URL = os.environ.get("NUZANTARA_BACKEND_URL", "https://nuzantara-rag.fly.dev")
+PRODUCER_TOKEN = os.environ.get("INTEL_LAKE_PRODUCER_TOKEN", "")
+BATCH_SIZE = int(os.environ.get("INTEL_LAKE_DRAIN_BATCH", "100"))
+HTTP_TIMEOUT = float(os.environ.get("INTEL_LAKE_DRAIN_TIMEOUT", "30"))
+
+
+def main() -> int:
+    if not PRODUCER_TOKEN:
+        logger.error("INTEL_LAKE_PRODUCER_TOKEN missing — refusing to drain")
+        return 2
+
+    rows = fetch_pending(BATCH_SIZE)
+    if not rows:
+        # No work — print stats every 5 minutes (cheap)
+        s = stats()
+        if s["pending"] or s["abandoned"]:
+            logger.info("idle (pending=%(pending)s delivered=%(delivered)s abandoned=%(abandoned)s)", s)
+        return 0
+
+    ids = [r[0] for r in rows]
+    observations: list[dict[str, Any]] = []
+    for _id, _producer, payload_json in rows:
+        try:
+            observations.append(json.loads(payload_json))
+        except Exception as e:
+            logger.warning("row %s malformed JSON: %s — abandoning", _id, e)
+            # Mark as 10 attempts to abandon
+            for _ in range(10):
+                mark_failed(_id, f"malformed JSON: {e}")
+            continue
+
+    url = f"{BACKEND_URL.rstrip('/')}/api/intel/lake/observations-batch"
+    payload = {"observations": observations}
+    headers = {
+        "X-Producer-Token": PRODUCER_TOKEN,
+        "Content-Type": "application/json",
+    }
+
+    try:
+        with httpx.Client(timeout=HTTP_TIMEOUT) as client:
+            r = client.post(url, json=payload, headers=headers)
+            r.raise_for_status()
+            body = r.json()
+    except httpx.HTTPStatusError as e:
+        # 401/413 etc. — definitely won't recover by retrying
+        for _id in ids:
+            mark_failed(_id, f"http {e.response.status_code}: {e.response.text[:200]}")
+        logger.error("HTTP %s draining %s rows: %s", e.response.status_code, len(ids), e.response.text[:200])
+        return 1
+    except Exception as e:
+        # Network / timeout — retryable, increment attempts and retry next tick
+        for _id in ids:
+            mark_failed(_id, f"network: {type(e).__name__}: {e}")
+        logger.warning("network error draining %s rows: %s — will retry", len(ids), e)
+        return 1
+
+    accepted = int(body.get("accepted", 0))
+    rejected = int(body.get("rejected", 0))
+
+    # Mark all delivered to avoid infinite retry loops. The backend audit log
+    # is the system of record for rejected items.
+    #
+    # However: a non-zero rejected count means producer-side data is being
+    # silently dropped. Emit a WARNING + Telegram alert (debounced via state
+    # file) when rejected > 0 — discovered 2026-05-13 that a `published_at`
+    # bind error in intel_lake_service.py was silently dropping every item
+    # with a date since Wave 4 deploy, with zero visibility from producers.
+    mark_delivered(ids)
+    if rejected > 0:
+        logger.warning(
+            "drained %s rows but %s REJECTED by backend — check intel_lake_audit_log on Fly. "
+            "accepted=%s rejected=%s url=%s",
+            len(ids), rejected, accepted, rejected, BACKEND_URL,
+        )
+        _alert_rejected(rejected, accepted, len(ids))
+    else:
+        logger.info(
+            "drained %s rows (accepted=%s rejected=%s) → backend %s",
+            len(ids), accepted, rejected, BACKEND_URL,
+        )
+    return 0
+
+
+_ALERT_STATE_PATH = Path.home() / "logs" / "intel-lake-outbox-drain.alert-state.json"
+_ALERT_COOLDOWN_S = 30 * 60  # 30 min between alerts
+
+
+def _alert_rejected(rejected: int, accepted: int, total: int) -> None:
+    """Send Telegram alert if rejected > 0, debounced 30min.
+
+    Reads/writes a state file with the last-alert timestamp. The first alert
+    fires immediately; subsequent alerts for the same condition wait at
+    least 30min to avoid spamming during a backend regression.
+    """
+    import json as _json
+    import time as _time
+    import urllib.parse as _up
+    import urllib.request as _ur
+
+    token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+    chat = os.environ.get("TELEGRAM_OWNER_CHAT_ID", "")
+    if not (token and chat):
+        return
+
+    now = _time.time()
+    state: dict[str, Any] = {}
+    try:
+        if _ALERT_STATE_PATH.exists():
+            state = _json.loads(_ALERT_STATE_PATH.read_text())
+    except Exception:
+        state = {}
+    last_alert = float(state.get("last_alert_at", 0))
+    if now - last_alert < _ALERT_COOLDOWN_S:
+        return  # debounced
+
+    text = (
+        f"\U0001F534 intel-lake-outbox-drain: {rejected}/{total} items REJECTED by backend "
+        f"(accepted={accepted}). Check intel_lake_audit_log on Fly for root cause."
+    )
+    try:
+        data = _up.urlencode({"chat_id": chat, "text": text}).encode()
+        _ur.urlopen(
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            data=data,
+            timeout=10,
+        )
+        state["last_alert_at"] = now
+        _ALERT_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _ALERT_STATE_PATH.write_text(_json.dumps(state))
+        logger.info("Telegram alert sent (rejected=%s)", rejected)
+    except Exception as e:
+        logger.warning("Telegram alert failed: %s", e)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/intel-lake-outbox-drain/intel_lake_outbox.py
+++ b/scripts/intel-lake-outbox-drain/intel_lake_outbox.py
@@ -1,0 +1,151 @@
+"""Intel Lake producer-side outbox (Wave 1).
+
+Each producer (intel_radar, imigrasi_monitor, ...) writes observations to a
+local SQLite outbox in their own transaction. A separate cron worker
+(`intel-lake-outbox-drain.py`) reads the outbox and POSTs to the Fly
+backend `/api/intel/lake/observations:batch` endpoint.
+
+This decouples producer success from backend availability:
+- Producer never fails because backend is down
+- Outbox row persists across reboots
+- Drain worker retries with exponential backoff
+
+Schema is intentionally tiny — no indexes beyond the obvious because
+volume is low (~100-1000 rows/day, drained every 60s).
+
+Design: research/symbiosis/2026-05-12-intel-lake-design.md
+Plan:   research/symbiosis/2026-05-12-intel-lake-wave1-plan.md
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+OUTBOX_PATH = Path.home() / ".intel-lake-outbox.db"
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS intel_lake_outbox (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    producer_name TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    enqueued_at TEXT NOT NULL DEFAULT (datetime('now')),
+    delivered_at TEXT,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_outbox_pending
+    ON intel_lake_outbox(id) WHERE delivered_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_outbox_stale
+    ON intel_lake_outbox(enqueued_at) WHERE delivered_at IS NULL AND attempts >= 10;
+"""
+
+
+def _connect() -> sqlite3.Connection:
+    OUTBOX_PATH.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(OUTBOX_PATH), timeout=10.0)
+    conn.execute("PRAGMA journal_mode=WAL;")
+    conn.execute("PRAGMA synchronous=NORMAL;")
+    conn.executescript(_SCHEMA)
+    return conn
+
+
+def enqueue(producer_name: str, payload: dict[str, Any]) -> int:
+    """Append a payload to the outbox. Returns row id.
+
+    Best-effort: producer SHOULD NOT fail if outbox is unreachable. Caller
+    catches exceptions; this function raises on truly broken disk only.
+    """
+    conn = _connect()
+    try:
+        cur = conn.execute(
+            "INSERT INTO intel_lake_outbox (producer_name, payload_json) VALUES (?, ?)",
+            (producer_name, json.dumps(payload, default=str)),
+        )
+        conn.commit()
+        return int(cur.lastrowid)
+    finally:
+        conn.close()
+
+
+def fetch_pending(limit: int = 100) -> list[tuple[int, str, str]]:
+    """Returns up to `limit` undelivered rows as (id, producer_name, payload_json).
+
+    Drain worker uses this. Sort by id ASC for fairness.
+    """
+    conn = _connect()
+    try:
+        cur = conn.execute(
+            """
+            SELECT id, producer_name, payload_json
+              FROM intel_lake_outbox
+             WHERE delivered_at IS NULL AND attempts < 10
+             ORDER BY id ASC
+             LIMIT ?
+            """,
+            (limit,),
+        )
+        return cur.fetchall()
+    finally:
+        conn.close()
+
+
+def mark_delivered(ids: list[int]) -> None:
+    """Mark rows as delivered. Idempotent."""
+    if not ids:
+        return
+    conn = _connect()
+    try:
+        conn.executemany(
+            "UPDATE intel_lake_outbox SET delivered_at = datetime('now') WHERE id = ?",
+            [(i,) for i in ids],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def mark_failed(id_: int, error_message: str) -> None:
+    """Increment attempts + record error. After 10 attempts row is left for manual review."""
+    conn = _connect()
+    try:
+        conn.execute(
+            """
+            UPDATE intel_lake_outbox
+               SET attempts = attempts + 1,
+                   last_error = ?
+             WHERE id = ?
+            """,
+            (error_message[:500], id_),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def stats() -> dict[str, int]:
+    """Return outbox counts: pending, delivered, abandoned."""
+    conn = _connect()
+    try:
+        cur = conn.execute(
+            """
+            SELECT
+                SUM(CASE WHEN delivered_at IS NULL AND attempts < 10 THEN 1 ELSE 0 END) AS pending,
+                SUM(CASE WHEN delivered_at IS NOT NULL THEN 1 ELSE 0 END) AS delivered,
+                SUM(CASE WHEN delivered_at IS NULL AND attempts >= 10 THEN 1 ELSE 0 END) AS abandoned
+              FROM intel_lake_outbox
+            """
+        )
+        row = cur.fetchone()
+        return {
+            "pending": row[0] or 0,
+            "delivered": row[1] or 0,
+            "abandoned": row[2] or 0,
+        }
+    finally:
+        conn.close()


### PR DESCRIPTION
## P1 regression — silent drop of every item with `published_at`

Discovered 2026-05-13 07:55 WITA during routine pipeline monitor.

### Symptom

`intel_lake_audit_log` shows HTTP 500 on every POST containing a non-null `published_at`:

\`\`\`
invalid input for query argument \$9: '2026-05-13T07:00:00+08:00'
(expected a date object)
\`\`\`

`regulatory_watcher` 03:00 WITA cron silently dropped 2 items (PER-6/PJ/2026 + PER-3/BC/2026). Producers had zero visibility — the SQLite outbox drainer marked them `delivered_at=NOW()` regardless of backend rejection (Wave 4 design "trust audit log").

### Root cause

`apps/backend-rag/backend/services/intel/intel_lake_service.py:155` passes `obs.published_at` (`str | None`) directly to asyncpg, which requires a Python `datetime` for timestamptz binding. The `\$9::timestamptz` SQL cast runs AFTER bind, not during, so the bind fails first.

### Blast radius

- Every item with `published_at` since Wave 4 deploy (2026-05-12)
- regulatory_watcher (cron 03:00, 07:00, 13:00, 19:00 WITA + ad-hoc) → silently lost
- intel_radar + any future producer with dates → silently lost
- Items WITHOUT `published_at` (smoke tests, test_wave3) → fine (passes `None`, binds OK)

Explains why Intel Lake nb-pusher queue has been at 0 selected despite active producers — upstream was 100% failing.

## Fix

### Path 1 — server-side parse (`intel_lake_service.py`)

New `_parse_iso_datetime()` helper:
- `None` / `""` → `None`
- Valid ISO 8601 (with offset, with Z, date-only) → `datetime`
- Invalid / non-string → `None` + log warning (never raises)

Bind site changed: `obs.published_at` → `_parse_iso_datetime(obs.published_at)`.

8 new unit tests in `TestParseIsoDatetime` class.

### Path 2 — drainer alert (`scripts/intel-lake-outbox-drain/`)

Drainer now emits Telegram WARNING + alert when `rejected > 0`. Debounced 30min via `~/logs/intel-lake-outbox-drain.alert-state.json`. `mark_delivered(ids)` preserved to avoid infinite retry loops.

Drainer + helper module now tracked in repo at `scripts/intel-lake-outbox-drain/` (were Pro-local only since Wave 4).

## Test plan

- [x] `pytest backend/tests/unit/services/intel/test_intel_lake_service.py -v` → 18/18 PASS (10 existing + 8 new)
- [x] `python3 -m py_compile` on drainer
- [x] `_parse_iso_datetime` smoke: `'2026-05-13T07:00:00+08:00'` → `datetime(2026,5,13,7,0,0, tzinfo=+08:00)`
- [x] `_parse_iso_datetime` smoke: `'2026-05-13T07:00:00Z'` → `datetime(2026,5,13,7,0,0, tzinfo=UTC)`
- [x] `_parse_iso_datetime` smoke: `'garbage'` → `None` + WARN log, no raise
- [ ] Required CI: E2E Tests (Playwright) + MCP Server Tests
- [ ] Post-deploy verify: next regulatory_watcher 13:00 WITA cron lands items in `intel_items` (currently 0 from regulatory_watcher)

## Companion bug (NOT addressed here)

`pajak_monitor` outbox ids 4, 5 stuck with `attempts=10 err="http 401: Authentication required"` since 2026-05-12 16:00 UTC. Separate scope — `INTEL_LAKE_PRODUCER_TOKEN` not set in pajak_monitor's environment or token rotation. Track separately.

## Cross-references

- Discovery memo: `~/.claude/projects/-Users-nuzantara/memory/discovery_intel_lake_published_at_silent_drop_2026_05_13.md`
- Pro-local pipeline (router + pusher, both functional): PR #645 (Tier 1 router) + PR #650 (Tier 1.5 pusher)
- Intel Lake schema: PR #621
- Migration 168 introduced `published_at` column as `timestamptz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)