### PR TITLE
feat(cell): LEVA 3 — wire OutboxSensor into PulseEngine

### DIFF
--- a/apps/cell/cell/core/pulse.py
+++ b/apps/cell/cell/core/pulse.py
@@ -124,6 +124,7 @@ class PulseEngine:
         cortex: Any = None,
         ai_intel_sensor: Any = None,
         nlm_effector: Any = None,
+        outbox_sensor: Any = None,
         metrics: PulseMetrics | None = None,
     ) -> None:
         self._dna = dna_loader
@@ -157,6 +158,7 @@ class PulseEngine:
         self._cortex = cortex
         self._ai_intel_sensor = ai_intel_sensor
         self._nlm_effector = nlm_effector
+        self._outbox_sensor = outbox_sensor
         self._metrics = metrics
         self._recent_pulses: list[dict] = []
         self._ltm_cache: str = ""
@@ -257,6 +259,20 @@ class PulseEngine:
             sensor_metadata["vercel"] = vercel_reading.metadata
             vercel_status = vercel_reading.status
 
+        # LEVA 3 (2026-05-13): outbox lag — perceives durable EventBus
+        # pressure on business channels. cell_pulse_observed is excluded
+        # because CELL itself emits those (would self-flood the count).
+        # The sensor handles PG-down internally and never raises.
+        outbox_status = "green"
+        if self._outbox_sensor is not None:
+            try:
+                outbox_reading = await self._outbox_sensor.read()
+                sensor_metadata["outbox"] = outbox_reading.metadata
+                outbox_status = outbox_reading.status
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"OutboxSensor read failed: {e}")
+                outbox_status = "yellow"
+
         # Aggregate: final status is the worst across all sensors
         sensor_statuses = [http_status.value]
         if self._db_sensor is not None:
@@ -265,7 +281,9 @@ class PulseEngine:
             sensor_statuses.append(qdrant_reading.status)  # type: ignore[possibly-undefined]
         if self._error_rate_sensor is not None:
             sensor_statuses.append(error_reading.status)  # type: ignore[possibly-undefined]
-        sensor_statuses.extend([ollama_status, backup_status, cron_status, vercel_status])
+        sensor_statuses.extend([
+            ollama_status, backup_status, cron_status, vercel_status, outbox_status,
+        ])
 
         # AI Intel Sensor — daily harvest (24h cooldown)
         ai_intel_items: list[dict] = []

--- a/apps/cell/cell/main.py
+++ b/apps/cell/cell/main.py
@@ -24,6 +24,8 @@ from cell.effectors.local_effector import LocalEffector
 from cell.fast.trend_detector import TrendDetector
 from cell.memory.long_term import LongTermMemory
 from cell.memory.short_term import ShortTermMemory
+from cell_core.sensors.outbox_sensor import OutboxSensor
+
 from cell.sensors.backup_sensor import BackupSensor
 from cell.sensors.cron_sensor import CronSensor
 from cell.sensors.database_sensor import DatabaseSensor
@@ -314,6 +316,23 @@ async def main() -> None:
         nlm_effector = NLMEffector()
         logger.info("AI Intel Sensor + NLM Effector initialized")
 
+        # LEVA 3 (2026-05-13): outbox lag — perceives business-channel
+        # pressure on events_outbox. Excludes cell_pulse_observed (CELL
+        # itself emits those, ~12k/30d, would flood the metric). 1-hour
+        # lookback caps the count so an abandoned consumer's queue
+        # doesn't make every pulse look red.
+        outbox_sensor = OutboxSensor(
+            pool_factory=lambda: _db_pool_ep,
+            channels=["cell_pulse_observed"],
+            exclude=True,
+            lookback_seconds=3600,
+            red_threshold=200,
+        )
+        logger.info(
+            "OutboxSensor initialized (exclude=[cell_pulse_observed], "
+            "lookback=1h, red_threshold=200)"
+        )
+
         engine = PulseEngine(
             dna_loader=dna_loader,
             safety_gate=safety_gate,
@@ -346,6 +365,7 @@ async def main() -> None:
             cortex=cortex,
             ai_intel_sensor=ai_intel_sensor,
             nlm_effector=nlm_effector,
+            outbox_sensor=outbox_sensor,
         )
 
         logger.info("CELL organism online. Starting pulse loop. Brain: ACTIVE.")

--- a/apps/cell/tests/test_pulse.py
+++ b/apps/cell/tests/test_pulse.py
@@ -81,3 +81,97 @@ async def test_pulse_updates_homeostatic_state(mock_deps: dict) -> None:
 
     # Setpoint should have moved toward 500ms (from default ~100ms)
     assert homeo.state.setpoint_rt_ms != initial_setpoint
+
+
+# ---------------------------------------------------------------------------
+# TestPulseOutboxWiring (LEVA 3, 2026-05-13)
+# ---------------------------------------------------------------------------
+
+
+def _make_healthy_pulse_deps() -> dict:
+    """Same shape as the mock_deps fixture but inlined for the wiring tests."""
+    dna = MagicMock()
+    dna.verify_integrity.return_value = True
+    safety = AsyncMock()
+    safety_result = MagicMock()
+    safety_result.can_proceed = True
+    safety.check.return_value = safety_result
+    health = AsyncMock()
+    health_reading = MagicMock()
+    health_reading.reachable = True
+    health_reading.status_code = 200
+    health_reading.response_time_seconds = 0.1
+    health.read.return_value = health_reading
+    metabolism = MagicMock()
+    return {
+        "dna_loader": dna,
+        "safety_gate": safety,
+        "health_sensor": health,
+        "metabolism": metabolism,
+    }
+
+
+def _make_outbox_sensor(status: str, count: int = 0) -> MagicMock:
+    """Return an outbox sensor mock that returns a deterministic reading."""
+    reading = MagicMock()
+    reading.status = status
+    reading.metadata = {
+        "unconsumed_count": count,
+        "channel": None,
+        "channels": ["cell_pulse_observed"],
+        "exclude": True,
+        "lookback_seconds": 3600,
+        "red_threshold": 200,
+    }
+    sensor = MagicMock()
+    sensor.read = AsyncMock(return_value=reading)
+    return sensor
+
+
+@pytest.mark.asyncio
+async def test_pulse_without_outbox_sensor_is_no_op() -> None:
+    """A PulseEngine with outbox_sensor=None (default) must work unchanged."""
+    deps = _make_healthy_pulse_deps()
+    engine = PulseEngine(**deps, dna_expected_hash="hash")
+    result = await engine.single_pulse(pulse_number=1)
+    assert result.halted is False
+    assert result.skipped is False
+    assert result.health_status == HealthStatus.GREEN
+
+
+@pytest.mark.asyncio
+async def test_pulse_with_outbox_sensor_green_records_metadata() -> None:
+    """outbox_sensor green-reading is recorded in sensor_metadata."""
+    deps = _make_healthy_pulse_deps()
+    outbox = _make_outbox_sensor("green", count=0)
+    engine = PulseEngine(**deps, dna_expected_hash="hash", outbox_sensor=outbox)
+    result = await engine.single_pulse(pulse_number=1)
+    outbox.read.assert_awaited_once()
+    # green outbox does not downgrade the overall status
+    assert result.health_status == HealthStatus.GREEN
+
+
+@pytest.mark.asyncio
+async def test_pulse_with_outbox_sensor_red_escalates_status() -> None:
+    """outbox_sensor red-reading must escalate the overall status to RED."""
+    deps = _make_healthy_pulse_deps()
+    outbox = _make_outbox_sensor("red", count=500)
+    engine = PulseEngine(**deps, dna_expected_hash="hash", outbox_sensor=outbox)
+    result = await engine.single_pulse(pulse_number=1)
+    outbox.read.assert_awaited_once()
+    assert result.health_status == HealthStatus.RED
+
+
+@pytest.mark.asyncio
+async def test_pulse_outbox_sensor_exception_does_not_break_pulse() -> None:
+    """If outbox_sensor.read() raises, pulse continues (logged at WARNING)."""
+    deps = _make_healthy_pulse_deps()
+    outbox = MagicMock()
+    outbox.read = AsyncMock(side_effect=RuntimeError("PG down"))
+    engine = PulseEngine(**deps, dna_expected_hash="hash", outbox_sensor=outbox)
+    result = await engine.single_pulse(pulse_number=1)
+    # exception isolated → yellow contribution → overall YELLOW (worst of
+    # green http + yellow outbox = yellow)
+    assert result.halted is False
+    assert result.skipped is False
+    assert result.health_status == HealthStatus.YELLOW

--- a/packages/cell-core/cell_core/sensors/outbox_sensor.py
+++ b/packages/cell-core/cell_core/sensors/outbox_sensor.py
@@ -48,7 +48,22 @@ class OutboxSensor:
             daemon can recover from a transient PG outage between
             pulses without re-instantiating the sensor.
         channel: Optional PG channel name (e.g. ``practice_changed``)
-            to scope the count. If None, counts across all channels.
+            to scope the count. If None and ``channels`` is None,
+            counts across all channels. Mutually exclusive with
+            ``channels``.
+        channels: Optional list of PG channel names (e.g.
+            ``["cell_pulse_observed"]``). Combined with ``exclude`` to
+            filter the count. LEVA 3 use case: exclude
+            ``cell_pulse_observed`` so CELL doesn't self-flood the
+            metric.
+        exclude: When ``channels`` is non-empty, ``True`` counts rows
+            whose channel is NOT in the list, ``False`` counts rows
+            whose channel IS in the list. Ignored if ``channels`` is
+            None.
+        lookback_seconds: Optional lookback window. When set, counts
+            only rows whose ``created_at > NOW() - INTERVAL N second``.
+            Prevents an abandoned consumer's lag from growing
+            unbounded.
         red_threshold: Lag count at which status escalates to red.
         name: Sensor name (default ``outbox``).
     """
@@ -57,11 +72,30 @@ class OutboxSensor:
         self,
         pool_factory: Callable[[], Any | None],
         channel: str | None = None,
+        channels: list[str] | None = None,
+        exclude: bool = False,
+        lookback_seconds: int | None = None,
         red_threshold: int = _DEFAULT_RED_THRESHOLD,
         name: str = "outbox",
     ) -> None:
+        # LEVA 3 (2026-05-13): `channels` and `channel` are mutually
+        # exclusive. `exclude=True` flips the channel-list filter from
+        # IN to NOT-IN. `lookback_seconds` caps the window so an
+        # abandoned consumer doesn't make the count grow unbounded.
+        if channel is not None and channels is not None:
+            raise ValueError(
+                "OutboxSensor: pass either `channel` (single) or "
+                "`channels` (list), not both"
+            )
         self._pool_factory = pool_factory
         self._channel = channel
+        self._channels = list(channels) if channels else None
+        self._exclude = bool(exclude)
+        self._lookback_seconds = (
+            int(lookback_seconds)
+            if lookback_seconds and lookback_seconds > 0
+            else None
+        )
         self._red_threshold = red_threshold
         self.name = name
 
@@ -78,6 +112,7 @@ class OutboxSensor:
                 metadata={
                     "error": "no pool configured (PG unreachable at boot?)",
                     "channel": self._channel,
+                    "channels": list(self._channels) if self._channels else None,
                 },
             )
 
@@ -93,6 +128,7 @@ class OutboxSensor:
                 metadata={
                     "error": str(exc),
                     "channel": self._channel,
+                    "channels": list(self._channels) if self._channels else None,
                 },
             )
 
@@ -110,9 +146,52 @@ class OutboxSensor:
             metadata={
                 "unconsumed_count": count,
                 "channel": self._channel,
+                "channels": list(self._channels) if self._channels else None,
+                "exclude": self._exclude if self._channels else None,
+                "lookback_seconds": self._lookback_seconds,
                 "red_threshold": self._red_threshold,
             },
         )
+
+    def _build_query(self) -> tuple[str, tuple[Any, ...]]:
+        """Build the COUNT query + parameter tuple for the current config.
+
+        Returns a literal SQL string with positional placeholders ($1, $2,
+        ...) and the parameter tuple. The query always starts with
+        ``SELECT COUNT(*) FROM events_outbox WHERE consumed_at IS NULL``;
+        optional clauses are added in this order:
+        - single channel:    AND channel = $N
+        - channels include:  AND channel = ANY($N::text[])
+        - channels exclude:  AND NOT (channel = ANY($N::text[]))
+        - lookback:          AND created_at > NOW() - INTERVAL '$N seconds'
+                             (literal-substituted; ``__init__`` validates
+                             the value to int so injection is impossible)
+        """
+        clauses: list[str] = []
+        params: list[Any] = []
+        next_idx = 1
+
+        if self._channel is not None:
+            clauses.append(f"channel = ${next_idx}")
+            params.append(self._channel)
+            next_idx += 1
+        elif self._channels:
+            if self._exclude:
+                clauses.append(f"NOT (channel = ANY(${next_idx}::text[]))")
+            else:
+                clauses.append(f"channel = ANY(${next_idx}::text[])")
+            params.append(self._channels)
+            next_idx += 1
+
+        if self._lookback_seconds is not None:
+            clauses.append(
+                f"created_at > NOW() - INTERVAL '{self._lookback_seconds} seconds'"
+            )
+
+        query = "SELECT COUNT(*) FROM events_outbox WHERE consumed_at IS NULL"
+        if clauses:
+            query += " AND " + " AND ".join(clauses)
+        return query, tuple(params)
 
     async def _fetch_count(self, pool: Any) -> int:
         """Run COUNT(*) against events_outbox using the supplied pool.
@@ -122,12 +201,7 @@ class OutboxSensor:
           with ``fetchval(query, *params)`` (asyncpg shape), or
         * a pool exposing ``fetchval`` directly (test fakes).
         """
-        if self._channel is not None:
-            query = _QUERY_PER_CHANNEL
-            params: tuple[Any, ...] = (self._channel,)
-        else:
-            query = _QUERY_ALL
-            params = ()
+        query, params = self._build_query()
 
         # Prefer the acquire-based path because asyncpg recommends it.
         if hasattr(pool, "acquire"):

--- a/packages/cell-core/tests/sensors/test_outbox_sensor.py
+++ b/packages/cell-core/tests/sensors/test_outbox_sensor.py
@@ -153,3 +153,107 @@ async def test_per_channel_filtering():
 
     assert reading.status == "yellow"
     assert reading.metadata["channel"] == "practice_changed"
+
+
+# ──────────────────────────────────────────────────────────────────
+# LEVA 3 extensions (2026-05-13): channels list, exclude, lookback
+# ──────────────────────────────────────────────────────────────────
+
+
+def test_channel_and_channels_are_mutex():
+    """Constructor rejects both single-channel and list-channel at once."""
+    from cell_core.sensors.outbox_sensor import OutboxSensor
+
+    with pytest.raises(ValueError):
+        OutboxSensor(
+            pool_factory=lambda: None,
+            channel="practice_changed",
+            channels=["client_changed"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_channels_include_emits_ANY_query():
+    """channels=[a,b] + exclude=False -> WHERE channel = ANY(...)."""
+    from cell_core.sensors.outbox_sensor import OutboxSensor
+
+    pool = _FakePool(count=7)
+    sensor = OutboxSensor(
+        pool_factory=lambda: pool,
+        channels=["practice_changed", "client_changed"],
+        exclude=False,
+    )
+    query, params = sensor._build_query()
+    assert "= ANY($1::text[])" in query
+    assert "NOT " not in query
+    assert params == (["practice_changed", "client_changed"],)
+    reading = await sensor.read()
+    assert reading.status == "yellow"
+    assert reading.metadata["channels"] == ["practice_changed", "client_changed"]
+    assert reading.metadata["exclude"] is False
+
+
+@pytest.mark.asyncio
+async def test_channels_exclude_emits_NOT_ANY_query():
+    """channels=[x] + exclude=True -> WHERE NOT (channel = ANY(...))."""
+    from cell_core.sensors.outbox_sensor import OutboxSensor
+
+    pool = _FakePool(count=4)
+    sensor = OutboxSensor(
+        pool_factory=lambda: pool,
+        channels=["cell_pulse_observed"],
+        exclude=True,
+    )
+    query, params = sensor._build_query()
+    assert "NOT (channel = ANY($1::text[]))" in query
+    assert params == (["cell_pulse_observed"],)
+    reading = await sensor.read()
+    assert reading.metadata["exclude"] is True
+
+
+def test_lookback_seconds_appended_to_query():
+    """lookback_seconds=3600 -> INTERVAL '3600 seconds' clause."""
+    from cell_core.sensors.outbox_sensor import OutboxSensor
+
+    sensor = OutboxSensor(
+        pool_factory=lambda: None,
+        lookback_seconds=3600,
+    )
+    query, _ = sensor._build_query()
+    assert "INTERVAL '3600 seconds'" in query
+    assert "created_at > NOW() -" in query
+
+
+def test_lookback_zero_or_negative_ignored():
+    """lookback_seconds=0/negative is normalised to None (no clause)."""
+    from cell_core.sensors.outbox_sensor import OutboxSensor
+
+    s1 = OutboxSensor(pool_factory=lambda: None, lookback_seconds=0)
+    s2 = OutboxSensor(pool_factory=lambda: None, lookback_seconds=-10)
+    q1, _ = s1._build_query()
+    q2, _ = s2._build_query()
+    assert "INTERVAL" not in q1
+    assert "INTERVAL" not in q2
+
+
+@pytest.mark.asyncio
+async def test_channels_exclude_with_lookback_combined():
+    """Combined query: exclude + lookback both active."""
+    from cell_core.sensors.outbox_sensor import OutboxSensor
+
+    pool = _FakePool(count=12)
+    sensor = OutboxSensor(
+        pool_factory=lambda: pool,
+        channels=["cell_pulse_observed"],
+        exclude=True,
+        lookback_seconds=3600,
+        red_threshold=200,
+    )
+    query, params = sensor._build_query()
+    assert "NOT (channel = ANY($1::text[]))" in query
+    assert "INTERVAL '3600 seconds'" in query
+    assert params == (["cell_pulse_observed"],)
+    reading = await sensor.read()
+    assert reading.status == "yellow"  # 12 < 200
+    assert reading.metadata["lookback_seconds"] == 3600
+    assert reading.metadata["red_threshold"] == 200


### PR DESCRIPTION
## Summary

LEVA 3 of `docs/superpowers/plans/2026-05-13-organism-potenziamento-5-leve.md`. Closes the sensors loop business-events → CELL: until now `events_outbox` reached ~1.250 business events/30d (practice/client/war_room/wr2/intel) without CELL ever sensing the bus pressure. After LEVA 3 the pulse loop reads OutboxSensor each cycle and exposes the count in `sensor_metadata["outbox"]`.

## What changed

**Two commits**:
1. `310c7ab9b` — cell-core OutboxSensor extension (channels list + exclude + lookback)
2. `7e0c8aa2c` — cell main + PulseEngine wire

### Cell-core (commit 1)

`OutboxSensor.__init__` gains 3 optional params:
- `channels: list[str] | None` (mutex with `channel`)
- `exclude: bool = False` (flips IN/NOT-IN)
- `lookback_seconds: int | None` (caps window)

Backward compat: existing `channel=`/`red_threshold=`/`name=` callers unchanged. New `_build_query()` helper composes SQL with positional placeholders; `lookback_seconds` is literal-substituted after `int()` validation in `__init__` (injection-safe).

### Cell (commit 2)

- `PulseEngine.__init__` adds `outbox_sensor: Any = None`
- `single_pulse()` reads outbox after vercel_sensor block, stores metadata, contributes status to aggregate
- `main.py` builds sensor with: `pool_factory=lambda: _db_pool_ep`, `channels=["cell_pulse_observed"]`, `exclude=True`, `lookback_seconds=3600`, `red_threshold=200`
- Pre-existing unrelated failure in `tests/test_pulse_with_cortex.py` (status_code=500 → expected YELLOW but classify_http_status correctly returns RED) is on `main` and NOT introduced by this PR

## Empirical motivation

| Channel | Last 30d | Notes |
|---|---|---|
| cell_pulse_observed | 12.371 | CELL's own pulses — excluded |
| practice_changed | 454 | client business |
| client_changed | 384 | client business |
| war_room_event | 183 | client business |
| wr2_status_change | 105 | content pipeline |
| intel_event | 48 | intel pipeline |
| asset_provenance | 30 | content pipeline |
| inbound_webhook_queued | 28 | webhooks |
| cognitive_event | 13 | reasoning |
| intel_lake_event | 4 | intel pipeline |

Last 5 min: 5 cell_pulse_observed (excluded), 0 business → outbox reading expected `count=0` / `status=green` immediately post-deploy. Spike to `count > 200` triggers red contribution (eg practice queue stuck).

## Brainstorm trail

Single-LLM panel (DeepSeek V4 Pro). Gemini CLI silenced by Conseca safety gate (same pattern as LEVA 2+1). Codex CLI instant-exit. Synthesis: 8/8 questions answered, full convergence on Opt A (extend library) over Opt B (4 sensors) / Opt C (count-everything noise).

Key calls from the panel:
- **red_threshold=200** (Q2): quiet bus <5, spikes <few dozen, 200 gives headroom
- **Exclude `cell_pulse_observed`** (Q3): 11k+ rows would mask real backlog
- **lookback=1h** (Q7): prevents unbounded count from abandoned consumers
- **No `investigate_event_burst` action** (Q6): strictly LEVA 4 territory
- **Yellow on PG-down** (Q4): visibility > green-noop

## Expected post-deploy effect

Next pulse (60s cron) emits `sensor_metadata["outbox"]={unconsumed_count: 0..N, channels: [cell_pulse_observed], exclude: true, lookback_seconds: 3600, red_threshold: 200}` to `cell_pulse_log` and Organism Supervisor sees it. Verify:

```sql
SELECT created_at, action_taken, sensor_metadata->'outbox'->>'unconsumed_count' AS outbox_lag
FROM cell_pulse_log
WHERE created_at > NOW() - INTERVAL '5 minutes'
ORDER BY created_at DESC;
```

Expected: 1-5 rows, `outbox_lag` either NULL (sensor not wired yet — first cycle after deploy) or a small integer (e.g. 0-10 in steady state).

## Test plan

- [x] Cell-core: 13/13 outbox_sensor tests (7 pre-existing + 6 new for mutex/include/exclude/lookback/combined)
- [x] Cell: 8/8 test_pulse.py (4 pre-existing + 4 new for wiring: no-op, green metadata, red escalation, exception isolation)
- [x] Combined: 91 apps/cell + 13 cell-core = **104 green**
- [x] Pre-existing unrelated failure `test_during_idle_not_called_when_yellow` is on main (verified by `git stash` + run), NOT introduced here
- [ ] CI green (E2E + MCP + no migration → no Squawk)
- [ ] Post-deploy: `sensor_metadata->outbox` visible in cell_pulse_log within 5 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)