### PR TITLE
🎨 Palette: Accessibility improvements for chat verification components

### DIFF
--- a/apps/mouth/src/components/chat/NLMCitationPanel.tsx
+++ b/apps/mouth/src/components/chat/NLMCitationPanel.tsx
@@ -27,8 +27,10 @@ export const NLMCitationPanel: React.FC<NLMCitationPanelProps> = ({
     <div className="mt-3 rounded-lg border-l-2 border-amber-600 overflow-hidden">
       {/* Header — always visible, toggles expand */}
       <button
+        type="button"
         onClick={onToggle}
-        className="w-full flex items-center justify-between gap-2 px-3 py-2 bg-zinc-900/50 hover:bg-zinc-900/70 transition-colors text-left"
+        aria-expanded={expanded}
+        className="w-full flex items-center justify-between gap-2 px-3 py-2 bg-zinc-900/50 hover:bg-zinc-900/70 transition-colors text-left focus-ring"
       >
         <div className="flex items-center gap-2 text-xs font-medium text-amber-600">
           <BookOpen size={14} />

--- a/apps/mouth/src/components/chat/TeamVerificationBadge.tsx
+++ b/apps/mouth/src/components/chat/TeamVerificationBadge.tsx
@@ -14,9 +14,7 @@ export const TeamVerificationBadge: React.FC<TeamVerificationBadgeProps> = ({
   domainLabel,
   onToggleCitations,
 }) => {
-  if (status === "not_needed") {
-    return null;
-  }
+  if (status === "not_needed") return null;
 
   if (status === "consulting") {
     return (
@@ -30,11 +28,11 @@ export const TeamVerificationBadge: React.FC<TeamVerificationBadgeProps> = ({
     );
   }
 
-  // status === "verified"
   return (
     <button
+      type="button"
       onClick={onToggleCitations}
-      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-medium text-amber-600 hover:text-amber-500 mt-3 select-none transition-colors cursor-pointer"
+      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-medium text-amber-600 hover:text-amber-500 mt-3 select-none transition-colors cursor-pointer focus-ring"
     >
       <Users size={13} />
       <span>Verificato dal team{domainLabel ? ` ${domainLabel}` : ""}</span>


### PR DESCRIPTION
Improved accessibility and focus states for TeamVerificationBadge and NLMCitationPanel in apps/mouth. Added type="button", aria-expanded, and .focus-ring utility.

---
*PR created automatically by Jules for task [9091838252423910812](https://jules.google.com/task/9091838252423910812) started by @Balizero1987*