### PR TITLE
fix(intel-lake): stop jsonb double-encoding of routing_targets + raw_payload

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/174_intel_lake_jsonb_double_encoding_repair.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/174_intel_lake_jsonb_double_encoding_repair.sql
@@ -1,0 +1,70 @@
+-- migration 174_intel_lake_jsonb_double_encoding_repair
+-- Data-only repair for the jsonb double-encoding regression (2026-05-14).
+--
+-- Root cause: the asyncpg pool registers a jsonb codec with
+-- `encoder=json.dumps` (backend/app/core/database.py + service_initializer.py).
+-- Two Intel Lake call sites also called `json.dumps(...)` on the value before
+-- binding it:
+--   - intel_lake_router.py:158  → routing_targets
+--   - intel_lake_service.py:184,205 → raw_payload (intel_items + intel_observations)
+-- The value was serialized twice and stored as a jsonb *string* scalar
+-- (e.g. `"{}"`) instead of a jsonb *object* (`{}`). The Pro-local router
+-- and nb-pusher then read `jsonb_typeof = 'string'` and could not extract
+-- `nb_uuids`, so every affected item fell through to `needs_review`.
+--
+-- The code fix ships in the same PR. This migration repairs the rows
+-- already written with the broken path. Each broken value is itself a
+-- valid JSON document, so `col #>> '{}'` extracts the inner text and
+-- `::jsonb` re-parses it into the correct object form.
+--
+-- Empirical scope verified on Fly PG 2026-05-14 — every string-typed value
+-- in all three columns has `jsonb_typeof((col #>> '{}')::jsonb) = 'object'`,
+-- i.e. exactly one extra encoding layer (no triple-encoding, no jsonb-null
+-- scalars). The `WHERE` guard below additionally restricts to values whose
+-- inner text re-parses as an `object`, so any future deeper-encoded or
+-- non-object string scalar is skipped rather than aborting the migration.
+--
+-- Idempotent: the guard means a second run is a no-op (already-repaired
+-- rows are `object`, not `string`).
+--
+-- Rolling-deploy race: the migration runner executes this before all Fly
+-- instances have the fixed code. Old-code instances still serving
+-- `intel_lake.event` / `observations` writes during the 1-3 minute rollout
+-- window can write NEW double-encoded rows after this migration has run.
+-- The migration is not re-run automatically — a second manual run after
+-- full rollout is safe (idempotent). For a ~20-30 row corpus this is
+-- acceptable; the RAISE NOTICE below lets the operator see the final count.
+
+DO $$
+DECLARE
+    n_routing  bigint;
+    n_items    bigint;
+    n_obs      bigint;
+BEGIN
+    UPDATE intel_items
+       SET routing_targets = (routing_targets #>> '{}')::jsonb
+     WHERE jsonb_typeof(routing_targets) = 'string'
+       AND jsonb_typeof((routing_targets #>> '{}')::jsonb) = 'object';
+    GET DIAGNOSTICS n_routing = ROW_COUNT;
+
+    UPDATE intel_items
+       SET raw_payload = (raw_payload #>> '{}')::jsonb
+     WHERE jsonb_typeof(raw_payload) = 'string'
+       AND jsonb_typeof((raw_payload #>> '{}')::jsonb) = 'object';
+    GET DIAGNOSTICS n_items = ROW_COUNT;
+
+    UPDATE intel_observations
+       SET raw_payload = (raw_payload #>> '{}')::jsonb
+     WHERE jsonb_typeof(raw_payload) = 'string'
+       AND jsonb_typeof((raw_payload #>> '{}')::jsonb) = 'object';
+    GET DIAGNOSTICS n_obs = ROW_COUNT;
+
+    RAISE NOTICE 'm174 jsonb repair: intel_items.routing_targets=% intel_items.raw_payload=% intel_observations.raw_payload=%',
+        n_routing, n_items, n_obs;
+END $$;
+
+-- === ROLLBACK ===
+-- No-op: this migration only repairs malformed data into its correct
+-- shape. Re-introducing the double-encoded form would re-create the bug,
+-- so rollback intentionally does nothing.
+SELECT 1;

--- a/apps/backend-rag/backend/services/intel/intel_lake_router.py
+++ b/apps/backend-rag/backend/services/intel/intel_lake_router.py
@@ -34,7 +34,6 @@ Design: research/symbiosis/2026-05-13-intel-lake-router-tier1-design.md
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 from typing import TYPE_CHECKING, Any
@@ -144,6 +143,11 @@ class IntelLakeRouter:
 
         try:
             async with self._pool.acquire() as conn:
+                # NOTE: bind ``new_targets`` as a raw dict, NOT json.dumps(...).
+                # The pool's jsonb codec (``backend/app/core/database.py``)
+                # registers ``encoder=json.dumps`` — pre-serializing here
+                # double-encodes and lands a jsonb *string* ("{}") instead of
+                # a jsonb *object* ({}). Regression fixed 2026-05-14.
                 affected = await conn.fetchval(
                     """
                     UPDATE intel_items
@@ -155,7 +159,7 @@ class IntelLakeRouter:
                     """,
                     item_id,
                     new_status,
-                    json.dumps(new_targets),
+                    new_targets,
                 )
                 await conn.execute(
                     """

--- a/apps/backend-rag/backend/services/intel/intel_lake_service.py
+++ b/apps/backend-rag/backend/services/intel/intel_lake_service.py
@@ -151,7 +151,14 @@ class IntelLakeService:
         if not canonical:
             raise IntelLakeError(f"empty canonical_url after normalize: {obs.canonical_url!r}")
 
-        raw_json = json.dumps(obs.raw_payload or {})
+        # ``raw_json`` is computed ONLY for the 50KB size guard below.
+        # The DB binds ``raw_payload_obj`` (the raw dict) — the pool's jsonb
+        # codec (``backend/app/core/database.py``) registers
+        # ``encoder=json.dumps``, so binding pre-serialized text would
+        # double-encode it into a jsonb *string* scalar. Regression fixed
+        # 2026-05-14.
+        raw_payload_obj = obs.raw_payload or {}
+        raw_json = json.dumps(raw_payload_obj)
         if len(raw_json.encode()) > MAX_RAW_PAYLOAD_BYTES:
             raise PayloadTooLargeError(
                 f"raw_payload {len(raw_json)} bytes exceeds limit {MAX_RAW_PAYLOAD_BYTES}"
@@ -181,7 +188,7 @@ class IntelLakeService:
                     obs.jurisdiction,
                     obs.topic_tags or [],
                     _parse_iso_datetime(obs.published_at),
-                    raw_json,
+                    raw_payload_obj,
                 )
 
                 item_id = str(row["id"])
@@ -202,7 +209,7 @@ class IntelLakeService:
                     """,
                     row["id"],
                     obs.producer_name,
-                    raw_json,
+                    raw_payload_obj,
                     obs.score,
                 )
 

--- a/apps/backend-rag/backend/tests/unit/services/intel/test_intel_lake_router.py
+++ b/apps/backend-rag/backend/tests/unit/services/intel/test_intel_lake_router.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+
 from backend.services.intel.intel_lake_router import (
     NB_INTEL_AI_RESEARCH,
     NB_INTEL_IMMIGRATION,
@@ -13,6 +18,32 @@ from backend.services.intel.intel_lake_router import (
 
 def _make_router() -> IntelLakeRouter:
     return IntelLakeRouter(None)  # type: ignore[arg-type]
+
+
+class _CapturingConn:
+    """Fake asyncpg connection that records fetchval/execute call args."""
+
+    def __init__(self) -> None:
+        self.fetchval_calls: list[tuple[Any, ...]] = []
+        self.execute_calls: list[tuple[Any, ...]] = []
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        self.fetchval_calls.append((query, *args))
+        return "00000000-0000-0000-0000-000000000001"  # pretend a row was updated
+
+    async def execute(self, query: str, *args: Any) -> None:
+        self.execute_calls.append((query, *args))
+
+
+class _CapturingPool:
+    """Fake asyncpg pool yielding a single shared _CapturingConn."""
+
+    def __init__(self) -> None:
+        self.conn = _CapturingConn()
+
+    @asynccontextmanager
+    async def acquire(self) -> Any:
+        yield self.conn
 
 
 class TestClassifyImmigration:
@@ -151,3 +182,74 @@ class TestRulesNoOverlap:
     def test_reddit_does_not_match_blog(self) -> None:
         d = _make_router()._classify("reddit.com")
         assert d["status"] != "blog"
+
+
+class TestRoutingTargetsBindType:
+    """Regression for 2026-05-14 — jsonb double-encoding.
+
+    The asyncpg pool registers a jsonb codec with ``encoder=json.dumps``
+    (see ``backend/app/core/database.py``). If ``route_event`` ALSO calls
+    ``json.dumps`` on ``routing_targets`` before binding, the value is
+    serialized twice and lands in PG as a jsonb *string* scalar (``"{}"``)
+    instead of a jsonb *object* (``{}``). The Pro-local router + nb-pusher
+    then see ``jsonb_typeof = 'string'`` and cannot read ``nb_uuids``.
+
+    The fix: bind the raw dict and let the pool codec serialize it once.
+    These tests assert the value reaching ``conn.fetchval`` is a ``dict``.
+    """
+
+    @staticmethod
+    def _update_call(pool: _CapturingPool) -> tuple[Any, ...]:
+        """Locate the captured UPDATE intel_items fetchval call.
+
+        Anchors assertions to the routing UPDATE by SQL content rather than
+        a fragile positional index.
+        """
+        for call in pool.conn.fetchval_calls:
+            if "UPDATE intel_items" in call[0]:
+                return call
+        raise AssertionError("route_event did not issue an UPDATE intel_items")
+
+    @pytest.mark.asyncio
+    async def test_routing_targets_bound_as_dict_not_str_for_nbintel(self) -> None:
+        pool = _CapturingPool()
+        router = IntelLakeRouter(pool)  # type: ignore[arg-type]
+        await router.route_event(
+            {"item_id": "11111111-1111-1111-1111-111111111111",
+             "source_domain": "imigrasi.go.id"}
+        )
+        # UPDATE args after query: item_id, new_status, routing_targets
+        bound_targets = self._update_call(pool)[3]
+        assert isinstance(bound_targets, dict), (
+            f"routing_targets bound as {type(bound_targets).__name__}, "
+            f"expected dict — json.dumps + pool codec = double-encoding"
+        )
+        assert bound_targets == {"nb_uuids": [NB_INTEL_IMMIGRATION]}
+
+    @pytest.mark.asyncio
+    async def test_routing_targets_bound_as_dict_not_str_for_fallback(self) -> None:
+        pool = _CapturingPool()
+        router = IntelLakeRouter(pool)  # type: ignore[arg-type]
+        await router.route_event(
+            {"item_id": "22222222-2222-2222-2222-222222222222",
+             "source_domain": "regulatory-watcher"}
+        )
+        bound_targets = self._update_call(pool)[3]
+        assert isinstance(bound_targets, dict), (
+            f"empty routing_targets bound as {type(bound_targets).__name__}, "
+            f"expected dict {{}} — would land in PG as jsonb string '\"{{}}\"'"
+        )
+        assert bound_targets == {}
+
+    @pytest.mark.asyncio
+    async def test_routing_status_still_bound_as_str(self) -> None:
+        # Guard against over-correction: status IS a plain text column.
+        pool = _CapturingPool()
+        router = IntelLakeRouter(pool)  # type: ignore[arg-type]
+        await router.route_event(
+            {"item_id": "33333333-3333-3333-3333-333333333333",
+             "source_domain": "detik.com"}
+        )
+        bound_status = self._update_call(pool)[2]
+        assert bound_status == "blog"
+        assert isinstance(bound_status, str)

--- a/apps/backend-rag/backend/tests/unit/services/intel/test_intel_lake_service.py
+++ b/apps/backend-rag/backend/tests/unit/services/intel/test_intel_lake_service.py
@@ -6,13 +6,72 @@ DB-backed tests live in tests/integration/ (require live PG).
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from datetime import datetime
+from typing import Any
+
+import pytest
 
 from backend.services.intel.intel_lake_service import (
     MAX_RAW_PAYLOAD_BYTES,
+    IntelLakeService,
+    ObservationInput,
+    PayloadTooLargeError,
     _parse_iso_datetime,
     canonicalize_url,
 )
+
+
+class _CapturingConn:
+    """Fake asyncpg connection recording fetchrow/fetchval call args."""
+
+    def __init__(self) -> None:
+        self.fetchrow_calls: list[tuple[Any, ...]] = []
+        self.fetchval_calls: list[tuple[Any, ...]] = []
+
+    @asynccontextmanager
+    async def transaction(self) -> Any:
+        yield
+
+    async def fetchrow(self, query: str, *args: Any) -> Any:
+        self.fetchrow_calls.append((query, *args))
+        # stored_hash == _make_obs content_hash so is_content_drift is
+        # consistently False for a fresh item (is_new_item True).
+        return {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "is_new_item": True,
+            "stored_hash": "hash123",
+        }
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        self.fetchval_calls.append((query, *args))
+        return 42
+
+    async def execute(self, query: str, *args: Any) -> None:
+        pass
+
+
+class _CapturingPool:
+    """Fake asyncpg pool yielding a single shared _CapturingConn."""
+
+    def __init__(self) -> None:
+        self.conn = _CapturingConn()
+
+    @asynccontextmanager
+    async def acquire(self) -> Any:
+        yield self.conn
+
+
+def _make_obs(raw_payload: dict[str, Any] | None = None) -> ObservationInput:
+    return ObservationInput(
+        producer_name="test_producer",
+        canonical_url="https://imigrasi.go.id/news",
+        content_hash="hash123",
+        title="Test item",
+        summary="summary",
+        source_domain="imigrasi.go.id",
+        raw_payload=raw_payload,
+    )
 
 
 class TestCanonicalizeUrl:
@@ -94,3 +153,81 @@ class TestParseIsoDatetime:
     def test_returns_none_for_non_string_type(self) -> None:
         # Type-narrowing fallback
         assert _parse_iso_datetime(12345) is None  # type: ignore[arg-type]
+
+
+class TestRawPayloadBindType:
+    """Regression for 2026-05-14 — jsonb double-encoding of raw_payload.
+
+    The asyncpg pool registers a jsonb codec with ``encoder=json.dumps``
+    (``backend/app/core/database.py``). ``record_observation`` must bind
+    ``raw_payload`` as a raw dict so the codec serializes it ONCE. The
+    pre-fix code bound ``json.dumps(...)`` output, double-encoding it into
+    a jsonb *string* scalar instead of a jsonb *object*.
+
+    The ``raw_json`` string is still computed — but only for the 50KB
+    size check, not for binding.
+    """
+
+    @staticmethod
+    def _find_call(calls: list[tuple[Any, ...]], sql_marker: str) -> tuple[Any, ...]:
+        """Locate the captured call whose query contains ``sql_marker``.
+
+        Anchors assertions to a specific INSERT/UPDATE by SQL content rather
+        than a fragile positional index into the calls list.
+        """
+        for call in calls:
+            if sql_marker in call[0]:
+                return call
+        raise AssertionError(f"no captured call matched SQL marker {sql_marker!r}")
+
+    @pytest.mark.asyncio
+    async def test_raw_payload_bound_as_dict_in_intel_items(self) -> None:
+        pool = _CapturingPool()
+        svc = IntelLakeService(pool)  # type: ignore[arg-type]
+        payload = {"url": "https://imigrasi.go.id/x", "extra": [1, 2, 3]}
+        await svc.record_observation(_make_obs(raw_payload=payload))
+        call = self._find_call(pool.conn.fetchrow_calls, "INSERT INTO intel_items")
+        # args after query: canonical, hash, title, summary, domain,
+        #   language, jurisdiction, topic_tags, published_at, raw_payload
+        bound_raw = call[10]
+        assert isinstance(bound_raw, dict), (
+            f"intel_items.raw_payload bound as {type(bound_raw).__name__}, "
+            f"expected dict — json.dumps + pool codec = double-encoding"
+        )
+        assert bound_raw == payload
+
+    @pytest.mark.asyncio
+    async def test_raw_payload_bound_as_dict_in_intel_observations(self) -> None:
+        pool = _CapturingPool()
+        svc = IntelLakeService(pool)  # type: ignore[arg-type]
+        payload = {"k": "v"}
+        await svc.record_observation(_make_obs(raw_payload=payload))
+        call = self._find_call(
+            pool.conn.fetchval_calls, "INSERT INTO intel_observations"
+        )
+        # args after query: item_id, producer_name, raw_payload, score
+        bound_raw = call[3]
+        assert isinstance(bound_raw, dict), (
+            f"intel_observations.raw_payload bound as {type(bound_raw).__name__}, "
+            f"expected dict"
+        )
+        assert bound_raw == payload
+
+    @pytest.mark.asyncio
+    async def test_none_raw_payload_bound_as_empty_dict(self) -> None:
+        pool = _CapturingPool()
+        svc = IntelLakeService(pool)  # type: ignore[arg-type]
+        await svc.record_observation(_make_obs(raw_payload=None))
+        call = self._find_call(pool.conn.fetchrow_calls, "INSERT INTO intel_items")
+        bound_raw = call[10]
+        assert bound_raw == {}
+        assert isinstance(bound_raw, dict)
+
+    @pytest.mark.asyncio
+    async def test_oversize_payload_still_rejected(self) -> None:
+        # Guard: the 50KB size check must survive the refactor.
+        pool = _CapturingPool()
+        svc = IntelLakeService(pool)  # type: ignore[arg-type]
+        huge = {"blob": "x" * (MAX_RAW_PAYLOAD_BYTES + 100)}
+        with pytest.raises(PayloadTooLargeError):
+            await svc.record_observation(_make_obs(raw_payload=huge))


### PR DESCRIPTION
## Summary

The asyncpg pool registers a jsonb type codec with `encoder=json.dumps` (`database.py:30`, `service_initializer.py:460`). Two Intel Lake call sites **also** called `json.dumps(...)` on the value before binding it — double-encoding it into a jsonb **string** scalar (`"{}"`) instead of a jsonb **object** (`{}`).

Downstream, the Pro-local router + nb-pusher crons read `jsonb_typeof(routing_targets)`, see `'string'`, can't extract `nb_uuids`, and every affected item falls through to `needs_review`. Empirically verified on Fly PG 2026-05-14: ~20-30 rows across `intel_items.routing_targets`, `intel_items.raw_payload`, `intel_observations.raw_payload` are double-encoded.

- `intel_lake_router.py` — bind `new_targets` as a raw dict (drop `json.dumps`, drop now-unused `import json`).
- `intel_lake_service.py` — keep `raw_json` only for the 50KB `MAX_RAW_PAYLOAD_BYTES` size guard, bind the raw `raw_payload_obj` dict at both INSERT sites.
- `migration 174` — idempotent data repair: `(col #>> '{}')::jsonb` with a guard that the inner value re-parses as an `object` (skips deeper-encoded scalars instead of aborting the transaction). `RAISE NOTICE` reports the repaired row count.
- tests — fake asyncpg pool capturing bind args, anchored to the SQL statement (not a fragile positional index), asserting the jsonb values reach the connection as `dict` not `str`. **52/52 pass.**

## The discriminant

A pool created **without** `init=init_db_connection` has **no codec** — there `json.dumps(...)` + `$N::jsonb` is correct (e.g. `dossier_repository.py` + its CLI pools). The bug is *mixing* a manual `json.dumps` with a codec-on pool. Rule: codec-on pool → bind raw dict; raw pool → serialize yourself.

## Red-team

`devils-advocate` review: verdict NEEDS_FIX, **0 critical / 3 HIGH**. The 3 HIGH are the *same pattern* in 3 other writers:
- `intel_kg_bridge.py` — dormant (test-only callers), low urgency
- `workflow_analytics_repository.py` + `query_analytics_repository.py` — **live**, written on every RAG query

These are **out of scope** for this PR (analytics tables, not Intel Lake) — kept separate to ship the pipeline-blocking Intel Lake fix fast. Tracked in `discovery_jsonb_double_encoding_systemic_2026_05_14.md` for a follow-up `fix/analytics-jsonb-double-encoding` PR. F4/F5/F6 (migration triple-encode guard, test positional-index fragility, rolling-deploy race acknowledgment) were addressed in this PR.

## Test plan

- [x] `pytest backend/tests/unit/services/intel/` — 52/52 pass
- [x] `ruff check` on all 4 changed Python files — clean
- [x] migration `#>> '{}'` verified empirically against all ~30 string-typed rows on Fly PG: `jsonb_typeof((col #>> '{}')::jsonb) = 'object'` for 100% (no triple-encoding, no jsonb-null scalars)
- [ ] CI: migration-lint (Squawk) on `174_*.sql`
- [ ] Post-deploy: confirm migration 174 `RAISE NOTICE` count in deploy log; re-run router cron and verify new `intel_items` get `routing_targets` as jsonb `object`

🤖 Generated with [Claude Code](https://claude.com/claude-code)