### PR TITLE
🎨 Palette: Enhance keyboard focus visibility in Chat interface

### DIFF
--- a/apps/mouth/src/components/chat/ChatHeader.tsx
+++ b/apps/mouth/src/components/chat/ChatHeader.tsx
@@ -101,7 +101,7 @@ export function ChatHeader({
             size="icon"
             onClick={onToggleSidebar}
             aria-label={isSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
-            className="flex-shrink-0"
+            className="flex-shrink-0 focus-ring"
           >
             <Menu className="w-5 h-5" />
           </Button>
@@ -111,7 +111,7 @@ export function ChatHeader({
             size="sm"
             disabled={isClockLoading}
             aria-label={isClockIn ? 'Clock Out' : 'Clock In'}
-            className={`gap-2 ${isClockIn ? 'bg-[var(--success)] hover:bg-[var(--success)]/90' : ''}`}
+            className={`gap-2 focus-ring ${isClockIn ? 'bg-[var(--success)] hover:bg-[var(--success)]/90' : ''}`}
           >
             {isClockLoading ? (
               <Loader2 className="w-4 h-4 animate-spin" />
@@ -155,7 +155,7 @@ export function ChatHeader({
           <Button
             variant="ghost"
             size="icon"
-            className="relative"
+            className="relative focus-ring"
             aria-label="Notifications"
             onClick={() => router.push('/notifications')}
           >

--- a/apps/mouth/src/components/chat/ChatInputBar.tsx
+++ b/apps/mouth/src/components/chat/ChatInputBar.tsx
@@ -124,7 +124,7 @@ export function ChatInputBar({
                   <button
                     type="button"
                     onClick={() => onRemoveImage?.(img.id)}
-                    className="absolute top-1 right-1 p-0.5 bg-black/60 text-white rounded-full opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
+                    className="absolute top-1 right-1 p-0.5 bg-black/60 text-white rounded-full opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity focus-ring"
                     aria-label={`Remove image ${img.name}`}
                   >
                     <X className="w-3 h-3" />
@@ -162,7 +162,7 @@ export function ChatInputBar({
             <Button
               variant="ghost"
               size="sm"
-              className="h-7 w-7 p-0 rounded-full text-zinc-400 hover:bg-[var(--accent)]/10 hover:text-[var(--accent)]"
+              className="h-7 w-7 p-0 rounded-full text-zinc-400 hover:bg-[var(--accent)]/10 hover:text-[var(--accent)] focus-ring"
               onClick={() => fileInputRef.current?.click()}
               title="Upload File"
               aria-label="Upload File"
@@ -173,7 +173,7 @@ export function ChatInputBar({
             <Button
               variant="ghost"
               size="sm"
-              className={`h-7 w-7 p-0 rounded-full transition-all duration-200 ${
+              className={`h-7 w-7 p-0 rounded-full transition-all duration-200 focus-ring ${
                 isRecording
                   ? 'bg-red-500 text-white hover:bg-red-600 animate-pulse scale-110'
                   : 'text-zinc-600 hover:bg-[var(--accent)]/10 hover:text-[var(--accent)]'
@@ -191,7 +191,7 @@ export function ChatInputBar({
             <Button
               variant="ghost"
               size="sm"
-              className="h-7 w-7 p-0 rounded-full text-zinc-400 hover:bg-[var(--accent)]/10 hover:text-[var(--accent)]"
+              className="h-7 w-7 p-0 rounded-full text-zinc-400 hover:bg-[var(--accent)]/10 hover:text-[var(--accent)] focus-ring"
               onClick={() => setShowImagePrompt(!showImagePrompt)}
               title="Generate/Analyze Image"
               aria-label="Generate/Analyze Image"
@@ -207,7 +207,7 @@ export function ChatInputBar({
                 variant="ghost"
                 size="icon"
                 onClick={() => setShowAttachMenu(!showAttachMenu)}
-                className={`rounded-xl ${showAttachMenu ? 'text-[var(--accent)] bg-[var(--accent)]/10' : ''}`}
+                className={`rounded-xl focus-ring ${showAttachMenu ? 'text-[var(--accent)] bg-[var(--accent)]/10' : ''}`}
                 aria-label="Attach file"
                 aria-haspopup="true"
                 aria-expanded={showAttachMenu}
@@ -265,7 +265,7 @@ export function ChatInputBar({
               onClick={showImagePrompt ? onImageGenerate : onSend}
               disabled={!input.trim() || isLoading}
               size="icon"
-              className="rounded-full flex-shrink-0 w-10 h-10 glow-button border-0"
+              className="rounded-full flex-shrink-0 w-10 h-10 glow-button border-0 focus-ring"
               aria-label={
                 isLoading ? 'Sending...' : showImagePrompt ? 'Generate image' : 'Send message'
               }

--- a/apps/mouth/src/components/chat/MessageBubble.tsx
+++ b/apps/mouth/src/components/chat/MessageBubble.tsx
@@ -380,7 +380,7 @@ function MessageBubbleComponent({
                 <button
                   type="button"
                   onClick={() => setIsThinkingExpanded(!isThinkingExpanded)}
-                  className="flex items-center gap-2 text-xs font-medium text-[var(--foreground-muted)] hover:text-[var(--accent)] transition-colors mb-2"
+                  className="flex items-center gap-2 text-xs font-medium text-[var(--foreground-muted)] hover:text-[var(--accent)] transition-colors mb-2 focus-ring rounded"
                   aria-expanded={isThinkingExpanded}
                 >
                   <Lightbulb className="w-3.5 h-3.5" />
@@ -535,7 +535,7 @@ function MessageBubbleComponent({
                         type="button"
                         key={idx}
                         onClick={() => onFollowUpClick?.(question)}
-                        className="text-xs text-left px-3 py-1.5 rounded-lg bg-[var(--background-secondary)] hover:bg-[var(--accent)]/10 hover:text-[var(--accent)] border border-[var(--border)] transition-colors duration-200"
+                        className="text-xs text-left px-3 py-1.5 rounded-lg bg-[var(--background-secondary)] hover:bg-[var(--accent)]/10 hover:text-[var(--accent)] border border-[var(--border)] transition-colors duration-200 focus-ring"
                       >
                         {question}
                       </button>
@@ -567,7 +567,7 @@ function MessageBubbleComponent({
             <button
               type="button"
               onClick={handleCopy}
-              className="transition-opacity p-1 hover:bg-[var(--background-secondary)] rounded opacity-70 hover:opacity-100"
+              className="transition-opacity p-1 hover:bg-[var(--background-secondary)] rounded opacity-70 hover:opacity-100 focus-ring"
               aria-label="Copy message"
             >
               {copied ? (


### PR DESCRIPTION
This PR enhances keyboard accessibility in the chat interface by adding consistent focus indicators to all primary interactive elements. By leveraging the existing `.focus-ring` utility class, we ensure that users navigating via keyboard can clearly identify the currently focused element, making the application more inclusive and pleasant to use.

Key changes:
- Applied `.focus-ring` to icon-only and standard buttons in `ChatHeader`.
- Enhanced `MessageBubble` accessibility with focus rings on follow-ups, thinking toggle, and copy actions.
- Improved `ChatInputBar` by adding focus visibility to media controls and the send button.
- Verified changes using the existing Vitest suite in `apps/mouth`.

---
*PR created automatically by Jules for task [8484392044212396964](https://jules.google.com/task/8484392044212396964) started by @Balizero1987*