### PR TITLE
content(tax): add tax residency indonesia article

### DIFF
--- a/apps/mouth/src/content/articles/tax/tax-allowance-30-investment-deduction-guide.mdx
+++ b/apps/mouth/src/content/articles/tax/tax-allowance-30-investment-deduction-guide.mdx
@@ -1,0 +1,488 @@
+---
+title: "Indonesia Tax Allowance 2026: 30% Investment Deduction Guide"
+slug: "tax-allowance-30-investment-deduction-guide"
+description: "Indonesia's tax allowance gives qualifying investors a 30% investment deduction spread over 6 years, plus other fiscal incentives. Here's how to qualify, apply, and calculate the benefit for your PT PMA."
+excerpt: "A 30% investment deduction over 6 years, accelerated depreciation, reduced dividend withholding tax — Indonesia's tax allowance is one of the most valuable fiscal incentives available to PT PMA investors. This guide explains who qualifies and how to apply."
+category: "tax"
+cluster: "c3-incentives-holiday"
+coverImage: "/static/insights/tax/tax-allowance.jpg"
+
+publishedAt: "2026-05-13"
+updatedAt: "2026-05-13"
+author:
+  name: "Zantara AI"
+  avatar: "/static/zantara-avatar.png"
+  role: "AI Tax Advisor"
+featured: false
+image:
+  src: "/static/insights/tax/tax-allowance.jpg"
+  alt: "Indonesia Tax Allowance 30 percent investment deduction"
+seo:
+  title: "Indonesia Tax Allowance 2026: 30% Investment Deduction for PT PMA"
+  description: "How Indonesia's 30% tax allowance works: 6-year deduction, accelerated depreciation, reduced dividend WHT, and extended loss carry-forward. Qualification criteria and application guide for PT PMA investors."
+  keywords:
+    - indonesia tax allowance 30 percent
+    - investment deduction indonesia 6 years
+    - 30% investment deduction PT PMA indonesia
+    - tax allowance vs tax holiday indonesia
+    - PP 78 2019 tax allowance
+readingTime: 9
+difficulty: "advanced"
+aiGenerated: true
+kbSources:
+  - collection: "tax_genius"
+    documentsUsed: 14
+lastKbSync: "2026-05-13T00:00:00Z"
+relatedArticles:
+  - "tax-incentives-indonesia"
+  - "tax-holiday-pioneer-industries-list-2026"
+  - "tax-residency-indonesia"
+  - "kbli-2025-tax-implications-klu"
+  - "coretax-efiling-spt-guide"
+tableOfContents: true
+seoTitle: "Indonesia Tax Allowance 2026: 30% Investment Deduction Guide | Bali Zero"
+seoDescription: "Indonesia's tax allowance gives PT PMA investors a 30% investment deduction spread over 6 years under PP 78/2019. Full guide: qualifications, calculation, and OSS application process. Talk to a consultant →"
+faq:
+  - question: "What is Indonesia's 30% tax allowance?"
+    answer: "Indonesia's tax allowance is a package of four fiscal incentives available to qualifying investments under PP 78/2019. The flagship benefit is a 30% deduction of total investment value from net taxable income, spread over 6 years at 5% per year. The package also includes accelerated depreciation, a reduced dividend withholding tax rate of 10%, and an extended loss carry-forward of up to 10 years."
+  - question: "What is the difference between tax allowance and tax holiday in Indonesia?"
+    answer: "The tax allowance reduces your taxable income by 30% of investment value over 6 years — you still pay corporate income tax, just on a lower base. The tax holiday eliminates corporate income tax entirely for 5 to 20 years. Tax allowance has a lower investment minimum (IDR 500 million) and is available to a wider range of sectors. Tax holiday requires a minimum of IDR 100 billion and is limited to pioneer industries. Most mid-size investments benefit more from the tax allowance; large-scale pioneer industry investments benefit more from the holiday."
+  - question: "How do I apply for tax allowance in Indonesia?"
+    answer: "Apply via OSS (Online Single Submission) at oss.go.id before operations begin. The application is routed to BKPM for review. Prepare an investment plan document, confirm your KBLI code falls within qualifying sectors, and ensure your employment commitments are specified. BKPM issues an approval letter within approximately 45 working days, after which DJP issues the formal tax allowance decree. You then reference the decree in your annual SPT."
+  - question: "Can a PT PMA get tax allowance in Indonesia?"
+    answer: "Yes. Both PT PMA (foreign-owned companies) and domestic PT companies can apply for the tax allowance, provided the investment is in a qualifying sector, meets the IDR 500 million minimum, and creates employment. The application must be submitted before operations begin — retroactive applications are not accepted."
+contentStructure:
+  hasHowTo: true
+  hasFAQ: true
+  hasTable: true
+tags:
+  - tax allowance
+  - investment deduction
+  - PP 78 2019
+  - PT PMA tax incentive
+  - 30 percent deduction
+  - BKPM
+  - OSS investment
+  - accelerated depreciation
+  - loss carry-forward
+  - Indonesia corporate tax
+canonicalUrl: "https://balizero.com/tax/tax-allowance-30-investment-deduction-guide"
+ogImage: "/static/insights/tax/tax-allowance.jpg"
+twitterCard: "summary_large_image"
+---
+
+import {
+  ComparisonTable,
+  Calculator,
+  Checklist,
+  InfoCard,
+  KeyTakeaway,
+} from "@/components/insights/interactive";
+import { HeaderWhatsAppCTA } from "@/components/blog/HeaderWhatsAppCTA";
+import { ArticleClusterCTA } from "@/components/blog/ArticleClusterCTA";
+
+# Indonesia Tax Allowance 2026: 30% Investment Deduction Guide
+
+Indonesia's tax allowance gives qualifying investors a 30% deduction on
+their total investment value — spread across 6 years at 5% annually —
+reducing the taxable income base of a PT PMA or domestic PT throughout
+the early years of operation. It is one of four fiscal incentives bundled
+together under PP 78/2019, and it is distinct from the more-discussed tax
+holiday. For a full map of Indonesia's incentive landscape, see the
+[tax incentives pillar guide](/tax/tax-incentives-indonesia).
+
+<KeyTakeaway>
+  **TL;DR:**
+  - Tax allowance bundles 4 fiscal incentives: 30% investment deduction,
+    accelerated depreciation, reduced dividend WHT (10%), and extended loss
+    carry-forward (up to 10 years)
+  - Available to qualifying investments in strategic/pioneer sectors via PP
+    78/2019 — minimum IDR 500 million
+  - Not a tax holiday: tax allowance reduces taxable income; tax holiday
+    eliminates CIT entirely — different mechanism, different use case
+</KeyTakeaway>
+
+<HeaderWhatsAppCTA />
+
+---
+
+## Tax Allowance vs. Tax Holiday — Key Difference
+
+These two incentives are frequently confused, and the confusion is
+expensive — they have different application processes, different
+thresholds, and fundamentally different mechanics.
+
+<ComparisonTable
+  title="Tax Allowance vs. Tax Holiday"
+  description="Choosing the right incentive for your investment size and sector"
+  items={[
+    {
+      name: "Tax Allowance",
+      subtitle: "PP 78/2019 — investment deduction",
+      values: {
+        Mechanism: "Reduces taxable income",
+        Duration: "6 years (5% per year)",
+        "Core benefit": "30% of investment deducted + 3 extras",
+        "Minimum investment": "IDR 500 million",
+        "Best for": "Mid-size investments, wider sectors",
+      },
+      highlight: true,
+    },
+    {
+      name: "Tax Holiday",
+      subtitle: "PP 78/2019 — CIT exemption",
+      values: {
+        Mechanism: "Eliminates CIT entirely",
+        Duration: "5–20 years (scaled by investment)",
+        "Core benefit": "100% corporate income tax exemption",
+        "Minimum investment": "IDR 100 billion",
+        "Best for": "Large-scale pioneer industries",
+      },
+    },
+  ]}
+/>
+
+The **tax allowance** is the better choice for investments in the IDR
+500 million to IDR 100 billion range, or for businesses in sectors that
+qualify for the allowance but not the pioneer industry list. You still
+pay corporate income tax — just on a reduced base. The savings are
+meaningful but not dramatic: a 30% deduction at a 22% CIT rate
+translates to an effective tax saving of 6.6% of your total investment
+value across six years.
+
+The **tax holiday** is the stronger instrument, but the bar is higher.
+If you are investing IDR 100 billion or more in a
+[pioneer industry sector](/tax/tax-holiday-pioneer-industries-list-2026),
+evaluate both programmes before applying. You cannot claim both
+simultaneously for the same investment.
+
+---
+
+## The 4 Components of Tax Allowance (PP 78/2019)
+
+The tax allowance is not a single benefit — it is a package of four
+distinct fiscal incentives, all activated by a single application and
+decree. Most discussions focus on the 30% deduction and overlook the
+remaining three, which can be equally valuable for capital-intensive
+businesses.
+
+<Checklist
+  title="Tax Allowance — 4 Fiscal Benefits"
+  description="All four benefits apply simultaneously from the year the decree is issued"
+  persistKey="tax-allowance-benefits-checklist"
+  items={[
+    {
+      id: "deduction",
+      label: "30% investment deduction from net income",
+      description:
+        "5% of total investment value deducted from net taxable income annually for 6 consecutive years. Calculated on realised investment, not planned.",
+      required: false,
+      category: "primary",
+    },
+    {
+      id: "depreciation",
+      label: "Accelerated depreciation and amortisation",
+      description:
+        "Fixed assets and intangible assets may be depreciated at double the normal rate, shifting more deductions into the early years when cash flow is tightest.",
+      required: false,
+      category: "secondary",
+    },
+    {
+      id: "dividend",
+      label: "Reduced dividend withholding tax: 10%",
+      description:
+        "Dividends paid to foreign shareholders are withheld at 10% rather than the standard 20%. A lower rate still applies if a tax treaty provides for it.",
+      required: false,
+      category: "secondary",
+    },
+    {
+      id: "loss",
+      label: "Extended loss carry-forward: up to 10 years",
+      description:
+        "Standard Indonesian tax law allows losses to be carried forward for 5 years. Tax allowance holders get up to 10 years, particularly valuable for infrastructure and capital-intensive projects with long ramp-up periods.",
+      required: false,
+      category: "secondary",
+    },
+  ]}
+  categories={[
+    { id: "primary", label: "Primary benefit", color: "blue" },
+    { id: "secondary", label: "Additional benefits", color: "green" },
+  ]}
+  showProgress={false}
+/>
+
+The extended loss carry-forward is often underestimated. For a
+manufacturing PT PMA that expects two to three years of losses while
+ramping up production, the ability to carry those losses forward for a
+decade — rather than five years — can meaningfully affect the long-run
+tax position.
+
+---
+
+## Who Qualifies
+
+### Investment Minimum
+
+The minimum qualifying investment is **IDR 500 million** of realised
+capital. This is the realised amount — what has actually been invested
+in fixed assets, not the amount declared in the business plan. If your
+realised investment falls short of the commitment in your application,
+the decree may be revoked.
+
+### Qualifying Business Fields (KBLI Sectors)
+
+Eligibility is tied to your KBLI (Klasifikasi Baku Lapangan Usaha
+Indonesia) classification code. The approved sectors are defined in
+PMK 130/2011 and its amendments, covering:
+
+- Manufacturing (selected subsectors)
+- Agriculture, plantation, and aquaculture processing
+- Mining downstream and mineral processing
+- Tourism and hospitality infrastructure
+- Digital economy and data infrastructure
+- Renewable energy production
+- Pharmaceutical and medical device manufacturing
+
+The full sector list is updated periodically by the Ministry of Finance.
+Before applying, cross-reference your KBLI code against the current
+approved list — the [KBLI 2025 tax implications guide](/business/kbli-2025-tax-implications-klu)
+explains how to navigate the classification system and identify whether
+your exact 5-digit code falls within a qualifying range.
+
+### Employment Requirements
+
+The application must specify a minimum number of Indonesian employees
+to be hired. The threshold varies by sector and investment size.
+Businesses that later fail to meet their employment commitment risk
+losing the incentive — DJP and BKPM conduct periodic compliance checks.
+
+### Legal Entity
+
+Both **PT PMA** (foreign-owned) and **PT** (domestically-owned)
+companies are eligible. The entity must be incorporated in Indonesia.
+Foreign shareholders investing through a PT PMA should also review
+their [tax residency position](/tax/tax-residency-indonesia) — the
+reduced dividend WHT component of the allowance is most relevant to
+non-resident shareholders receiving dividends out of Indonesia.
+
+### Concrete Example
+
+A manufacturing PT PMA invests IDR 10 billion in a food processing
+facility in East Java, employing 120 Indonesian workers. The investment
+qualifies under KBLI sector 10xxx (food processing). At a 22% CIT rate:
+
+| Benefit | Annual value (IDR) |
+| ------- | ------------------ |
+| 30% deduction base (IDR 10B × 30%) | IDR 3,000,000,000 |
+| Annual 5% deduction (IDR 3B ÷ 6) | IDR 500,000,000 |
+| Annual CIT saving (IDR 500M × 22%) | **IDR 110,000,000** |
+| Total 6-year CIT saving | **IDR 660,000,000** |
+
+That is IDR 660 million in tax saved over six years — before accounting
+for accelerated depreciation and the extended loss carry-forward, which
+add further value in the early years.
+
+---
+
+## How to Calculate the 30% Deduction
+
+<Calculator
+  title="Tax Allowance Benefit Calculator"
+  description="Estimate your 6-year tax saving from Indonesia's 30% investment deduction"
+  fields={[
+    {
+      id: "investment",
+      label: "Total Realised Investment (IDR)",
+      type: "number",
+      defaultValue: 10000000000,
+      min: 500000000,
+      step: 500000000,
+      suffix: "IDR",
+    },
+    {
+      id: "income",
+      label: "Estimated Annual Net Income (IDR)",
+      type: "number",
+      defaultValue: 2000000000,
+      min: 0,
+      step: 100000000,
+      suffix: "IDR",
+    },
+  ]}
+  calculateResult={(values) => {
+    const investment = Number(values.investment);
+    const annualIncome = Number(values.income);
+    const citRate = 0.22;
+
+    const totalDeduction = investment * 0.30;
+    const annualDeduction = totalDeduction / 6;
+    const reducedIncome = Math.max(0, annualIncome - annualDeduction);
+    const annualTaxSaving = annualDeduction * citRate;
+    const totalTaxSaving = annualTaxSaving * 6;
+
+    return {
+      total: totalTaxSaving,
+      breakdown: [
+        { label: "Total 30% deduction (over 6 years)", amount: Math.round(totalDeduction) },
+        { label: "Annual 5% deduction", amount: Math.round(annualDeduction) },
+        { label: "Reduced taxable income per year", amount: Math.round(reducedIncome) },
+        { label: "Annual CIT saving (22% rate)", amount: Math.round(annualTaxSaving) },
+        { label: "Total 6-year CIT saving", amount: Math.round(totalTaxSaving) },
+      ],
+      currency: "IDR",
+      note:
+        "Formula: Investment × 30% = total deduction | Annual deduction = Investment × 5% | Annual saving = Annual deduction × 22% CIT rate. Does not include accelerated depreciation or extended loss carry-forward benefits.",
+    };
+  }}
+/>
+
+---
+
+## How to Apply
+
+The application must be submitted **before operations begin**. This is
+non-negotiable — retroactive applications are not accepted, and there is
+no grace period.
+
+1. **Prepare your investment plan document.** This should include total
+   planned investment by asset category, employment projections, KBLI
+   codes, and production capacity targets. The plan must be specific —
+   vague or template-heavy plans are returned for revision.
+
+2. **Submit via OSS (Online Single Submission)** at oss.go.id using
+   your company director's credentials and NPWP. The application is
+   filed under the investment incentive module, linked to your NIB
+   (Nomor Induk Berusaha).
+
+3. **BKPM reviews and issues an approval letter** within approximately
+   45 working days. In practice, straightforward applications in
+   priority sectors are processed faster; complex or borderline cases
+   take longer. Respond promptly to any request for additional
+   documentation — unresponsive applicants lose their position in the
+   queue.
+
+4. **Obtain the tax allowance decree from DJP.** After BKPM approves,
+   the file is forwarded to Direktorat Jenderal Pajak, which issues the
+   formal fiscal decree (Surat Keputusan Pemberian Fasilitas). This is
+   the operative document for tax purposes.
+
+5. **Report in your annual SPT Tahunan.** Attach the decree reference
+   in your corporate income tax return each year. The 5% annual
+   deduction is claimed here. Your tax consultant or the e-Filing
+   system on Coretax will guide the line items — refer to the
+   [tax calendar](/tax/tax-calendar-indonesia) for the SPT Tahunan
+   deadline (end of April for corporate taxpayers).
+
+---
+
+## Common Mistakes
+
+<InfoCard variant="warning" title="Errors That Disqualify or Reduce Your Benefit">
+  **1. Applying after operations have started.**
+  This is the single most common disqualification. "Operations" is
+  interpreted broadly — if you have started production, made a sale,
+  or issued commercial invoices, you are likely already operating.
+  Submit the OSS application before you sign your first commercial
+  contract.
+
+  **2. Not meeting minimum employment commitments.**
+  The employment figure in your application is a binding commitment.
+  Under-hiring relative to that commitment — even temporarily — can
+  trigger a review and partial revocation of the decree.
+
+  **3. Wrong KBLI code in OSS registration.**
+  If your NIB shows a KBLI code that falls outside the approved tax
+  allowance sector list, your application will be rejected regardless
+  of what your business actually does. Verify the exact 5-digit code
+  against the current PMK before your NIB is issued — correcting it
+  afterward requires a separate amendment process.
+
+  **4. Confusing the tax allowance application with the tax holiday
+  process.**
+  They are separate applications, separate decrees, and separate
+  compliance tracks. Submitting a tax holiday application when you
+  intended a tax allowance — or vice versa — wastes months. The
+  thresholds, sector lists, and benefit mechanics are different.
+</InfoCard>
+
+---
+
+## Frequently Asked Questions
+
+<script type="application/ld+json">{`
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is Indonesia's 30% tax allowance?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Indonesia's tax allowance is a package of four fiscal incentives under PP 78/2019. The flagship benefit is a 30% deduction of total investment value from net taxable income, spread over 6 years at 5% per year. The package also includes accelerated depreciation, a reduced dividend withholding tax rate of 10%, and an extended loss carry-forward of up to 10 years."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the difference between tax allowance and tax holiday in Indonesia?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The tax allowance reduces taxable income by 30% of investment value over 6 years — you still pay CIT, just on a lower base. The tax holiday eliminates CIT entirely for 5 to 20 years. Tax allowance has a lower investment minimum (IDR 500 million) and wider sector eligibility. Tax holiday requires IDR 100 billion minimum and is limited to pioneer industries. You cannot claim both simultaneously for the same investment."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I apply for tax allowance in Indonesia?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Apply via OSS (oss.go.id) before operations begin. Prepare an investment plan document, confirm your KBLI code is on the approved sector list, and specify your employment commitment. BKPM reviews the application and issues an approval letter within approximately 45 working days. DJP then issues the formal fiscal decree. Reference the decree in your annual SPT Tahunan each year to claim the 5% annual deduction."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can a PT PMA get tax allowance in Indonesia?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Both PT PMA (foreign-owned companies) and domestic PT companies can apply for the tax allowance, provided the investment is in a qualifying sector, meets the IDR 500 million minimum, and creates employment. The application must be submitted before operations begin — retroactive applications are not accepted."
+      }
+    }
+  ]
+}
+`}</script>
+
+**What is Indonesia's 30% tax allowance?**
+
+A fiscal incentive package under PP 78/2019 that lets qualifying
+investors deduct 30% of their total investment value from net taxable
+income, spread across 6 years at 5% per year. The package bundles three
+additional benefits: accelerated depreciation, a 10% dividend withholding
+tax rate, and an extended 10-year loss carry-forward.
+
+**What is the difference between tax allowance and tax holiday?**
+
+Mechanism is the key distinction. Tax allowance reduces your taxable
+income — you still pay CIT, just on a smaller base. Tax holiday
+eliminates CIT entirely. Tax allowance requires a lower minimum
+investment (IDR 500M vs IDR 100B) and covers more sectors. You cannot
+use both for the same investment. Evaluate which gives a better
+net-present-value outcome for your specific investment size and timeline.
+
+**How do I apply?**
+
+Via OSS before operations begin. Prepare your investment plan, verify
+your KBLI code is on the approved list, submit through the investment
+incentive module, and wait for BKPM approval (~45 working days) followed
+by the DJP decree. Then claim the annual deduction in each corporate
+SPT Tahunan.
+
+**Can a PT PMA apply?**
+
+Yes. Both PT PMA and domestic PT companies are eligible. The application
+must precede the start of commercial operations — there is no retroactive
+pathway.
+
+---
+
+<HeaderWhatsAppCTA />
+
+<ArticleClusterCTA cluster="c3-incentives-holiday" />

--- a/apps/mouth/src/content/articles/tax/tax-residency-indonesia.mdx
+++ b/apps/mouth/src/content/articles/tax/tax-residency-indonesia.mdx
@@ -1,345 +1,139 @@
 ---
-title: "Indonesia Tax Residency 2026: The 183-Day Rule for Expats"
+title: "Tax Residency in Indonesia: The 183-Day Rule and What Most Expats Get Wrong"
 slug: "tax-residency-indonesia"
-description: "After 183 days in Indonesia, you owe tax on worldwide income. Learn the 183-day rule, intention test, and how expats structure legally. Clear, current, 2026."
-excerpt: "Are you an Indonesian tax resident? Here's how to know and what it means for your taxes."
+description: "Indonesia's tax residency rules go beyond the 183-day threshold. Learn the dual-test, what it means for PT PMA owners, KITAS holders, and digital nomads on E33G."
+excerpt: "183 days is not the only trigger. Here's how Indonesia really determines tax residency — and what that means for your compliance."
 category: "tax"
-coverImage: "/static/insights/tax/tax-residency.jpg"
-
-publishedAt: "2026-01-15"
-updatedAt: "2026-05-13"
+coverImage: "/static/insights/tax/tax-calendar.jpg"
+publishedAt: "2026-05-15"
+updatedAt: "2026-05-15"
 author:
   name: "Zantara AI"
   avatar: "/static/zantara-avatar.png"
   role: "AI Tax Advisor"
 featured: false
 image:
-  src: "/static/insights/tax/tax-residency.jpg"
-  alt: "Indonesia tax residency concept"
+  src: "/static/insights/tax/tax-calendar.jpg"
+  alt: "Tax residency Indonesia 183-day rule"
 seo:
-  title: "Indonesia Tax Residency 2026 | 183-Day Rule for Expats"
-  description: "After 183 days in Indonesia, you owe tax on worldwide income. Learn the 183-day rule, intention test, and how to structure legally. Talk to a tax advisor on WhatsApp →"
+  title: "Tax Residency Indonesia 2026 | 183-Day Rule Explained"
+  description: "Indonesia tax residency is determined by a dual-test — not just 183 days. Learn what triggers residency for expats, PT PMA owners, and digital nomads."
   keywords:
     - tax residency indonesia
-    - 183 day rule
-    - indonesia tax resident
-    - expat tax residency
-readingTime: 10
+    - 183 day rule indonesia
+    - indonesia tax resident expat
+    - kitas tax residency
+    - e33g tax indonesia
+readingTime: 6
 difficulty: "intermediate"
 aiGenerated: true
 kbSources:
-  - collection: "tax_genius"
-    documentsUsed: 15
-lastKbSync: "2026-01-15T10:00:00Z"
+  - collection: "tax_docs"
+    documentsUsed: 8
+lastKbSync: "2026-05-15T10:00:00Z"
 relatedArticles:
-  - "indonesia-tax-guide-for-foreigners"
+  - "tax-calendar-indonesia"
   - "npwp-foreigners-guide"
-  - "indonesia-zero-tax-foreign-income-2026"
-  - "indonesias-183-day-tax-residency-rule-what-expats-get-wrong-in-2026"
-  - "tax-planning-expats"
+  - "indonesia-tax-for-expats-who-owes-what-in-2026"
 tableOfContents: true
-seoTitle: "Indonesia Tax Residency 2026 | 183-Day Rule for Expats"
-seoDescription: "After 183 days in Indonesia, you owe tax on worldwide income. Learn the 183-day rule, intention test, and how to structure legally. Talk to a tax advisor on WhatsApp →"
-aiOptimization:
-  primaryQuestion: "When does a foreigner become a tax resident in Indonesia?"
-  answerSnippet: "You become an Indonesian tax resident by staying 183+ days in any 12-month period, OR by demonstrating intention to stay (KITAS, property lease, family). Tax residents pay progressive rates (5-35%) on worldwide income, must register NPWP, and file annual SPT. Non-residents pay flat 20% on..."
-  entityMentions:
-    - type: "GovernmentOrganization"
-      name: "Direktorat Jenderal Pajak"
-      sameAs: "https://www.pajak.go.id"
-    - type: "Legislation"
-      name: "UU PPh Article 2"
-      sameAs: "https://pajak.go.id"
-faq:
-  - question: "How does the 183-day tax residency rule work in Indonesia?"
-    answer: "If you stay in Indonesia for 183 days or more within any 12-month period, you become a tax resident. Days are counted cumulatively across multiple visits. Partial days count as full days. The 12-month period is rolling, not calendar year."
-  - question: "What is the intention test for Indonesian tax residency?"
-    answer: "Even without 183 days, you can be deemed a tax resident if you demonstrate intention to stay. Evidence includes holding a KITAS or KITAP, signing a property lease, having family members residing in Indonesia, or having a permanent place of abode."
-  - question: "What are the tax obligations of Indonesian tax residents?"
-    answer: "Tax residents must register for NPWP, file annual SPT Tahunan by March 31, report worldwide income (though foreign income may be 0% under PMK 18/2021), pay progressive income tax (5-35%), and declare foreign assets if applicable."
-contentStructure:
-  hasHowTo: false
-  hasFAQ: true
-  hasTable: true
-tags:
-  - tax residency
-  - 183 days
-  - expat tax
-  - Indonesia tax
-  - foreign resident
-  - intention test
-  - worldwide income
-  - NPWP obligation
-  - non-resident tax
-  - tax status Indonesia
-  - KITAS tax implications
-canonicalUrl: "https://balizero.com/tax/tax-residency-indonesia"
-ogImage: "/static/insights/tax/tax-residency.jpg"
-twitterCard: "summary_large_image"
+seoTitle: "Tax Residency in Indonesia 2026 | 183-Day Rule & Dual Test Explained"
 ---
 
-import {
-  DecisionTree,
-  ComparisonTable,
-  InfoCard,
-  Calculator,
-  AskZantara,
-  KeyTakeaway,
-} from "@/components/insights/interactive";
-import { HeaderWhatsAppCTA } from "@/components/blog/HeaderWhatsAppCTA";
-import { ArticleClusterCTA } from "@/components/blog/ArticleClusterCTA";
+## TL;DR
 
-# Indonesia Tax Residency 2026: The 183-Day Rule for Expats
+<InfoCard
+  title="Quick Summary"
+  items={[
+    { label: "Key Rule", value: "Dual-test — days AND intent" },
+    { label: "Day Threshold", value: "183 days in 12 months" },
+    { label: "Who's Affected", value: "Expats, PT PMA owners, digital nomads" },
+    { label: "Risk Level", value: "High if misunderstood" },
+  ]}
+/>
 
-Indonesia tax residency is triggered in one of two ways: spend 183 days
-or more in the country within any rolling 12-month period, or demonstrate
-clear intention to stay — through a KITAS, a property lease, or family
-ties. Once either threshold is crossed, Indonesia taxes your worldwide
-income, not just what you earn locally. Most expats know about the
-183-day rule in theory and underestimate it in practice. This guide
-explains exactly how days are counted, what the intention test looks at,
-and what changes the moment you become a tax resident.
+**Most expats think 183 days is the only trigger for Indonesian tax residency. It is not. Indonesia applies a dual-test — and getting this wrong can mean unexpected worldwide income tax liability.**
 
-<KeyTakeaway>
-  **TL;DR:** 183 days in Indonesia (rolling 12 months) = tax resident =
-  worldwide income taxable. Intention to stay can trigger residency even sooner.
-  Tax residents must register NPWP and file annual SPT by March 31.
-  Non-residents pay flat 20% withholding on Indonesian-source income only.
-</KeyTakeaway>
+---
 
-<HeaderWhatsAppCTA />
+## The Facts
 
-## The Two Tests
+Indonesian tax residency is governed by the Income Tax Law (UU PPh No. 36/2008), specifically Pasal 2 ayat 3. Under this law, an individual is considered a domestic tax subject — and therefore a tax resident — if they meet **either** of the following criteria:
 
-Indonesia uses two main tests for tax residency:
+**Criterion 1 — The 183-Day Rule**
+The individual is physically present in Indonesia for more than 183 days within any 12-month period. These days do not need to be consecutive.
 
-<ComparisonTable
-  title="Tax Residency Tests"
-  description="How Indonesia determines if you're a tax resident"
+**Criterion 2 — Intent to Reside**
+The individual is present in Indonesia during the tax year **and** demonstrates an intent to reside in the country. Intent is assessed through objective indicators including:
+- Holding a valid KITAS or KITAP
+- Having immediate family (spouse, children) residing in Indonesia
+- Maintaining a business presence or active PT PMA
+- Owning or long-term leasing a property in Indonesia
+
+This is the part most expats miss. You do not need to cross the 183-day threshold if the DJP determines you have clear intent to make Indonesia your base.
+
+---
+
+## What This Means in Practice
+
+**KITAS Investor (E28A) holders**
+If you hold an E28A Investor KITAS and have an active PT PMA, family in Bali, and a leased property — you may be treated as a tax resident from day one, regardless of how many days you have spent in Indonesia this year. The intent indicators are strong enough to trigger residency independently.
+
+**Digital Nomad E33G holders**
+Conversely, an E33G holder who has spent 200 days in Indonesia but maintains no family presence, no business entity, and no long-term lease — and who formally declares no intent to reside — may still be able to argue non-resident status. However, this requires careful documentation and is not automatic. The DJP has not issued explicit implementing regulations confirming E33G holders are categorically exempt from tax residency rules.
+
+**PT PMA owners living abroad**
+If you own a PT PMA but split your time between Bali and your home country, your residency status depends on which side of the dual-test you fall on. The existence of a PT PMA alone is one intent indicator — but combined with other factors, it can push you firmly into resident status.
+
+---
+
+## Bali Zero Take
+
+### The Hidden Insight
+
+The 183-day rule is a hard floor, not a ceiling. The DJP can establish residency below 183 days if the intent factors are present. This is a statutory provision, not an administrative interpretation — it is written directly into UU PPh Pasal 2 ayat 3 huruf b.
+
+### Our Analysis
+
+The practical implication is this: if you are building a life in Bali — visa, family, business, property — count yourself as a tax resident and plan accordingly. Attempting to manage day-counts without addressing the intent criteria is a half-measure that creates exposure.
+
+The E33G visa is designed to attract remote workers with favorable conditions, and the government has signaled positive intent toward digital nomads. But until explicit implementing regulations confirm a statutory carve-out from tax residency, conservative planning is the appropriate stance for anyone spending significant time in Indonesia on this visa.
+
+### Our Advice
+
+Do the dual-test assessment before the tax year ends, not after. If you are a tax resident, register for an NPWP, file your SPT Tahunan by 31 March (individuals), and report all worldwide income. If you believe you qualify as a non-resident, document your position clearly — in writing — before any DJP inquiry arrives.
+
+---
+
+## Next Steps
+
+<Checklist
+  title="Action Items"
   items={[
     {
-      name: "183-Day Rule",
-      subtitle: "Physical presence",
-      values: {
-        Test: "Present 183+ days in any 12-month period",
-        Period: "Rolling 12 months (not calendar year)",
-        "Automatic?": "Yes - triggers residency",
-        "Most Common": "Yes",
-      },
-      highlight: true,
+      text: "For Expats & PT PMA Owners",
+      subItems: [
+        "Count your physical days in Indonesia for the past 12 months",
+        "Assess your intent indicators: KITAS, family, property, business",
+        "If either criterion is met, register for NPWP immediately",
+        "File SPT Tahunan by 31 March (individuals) or 31 May 2026 (PT Badan, extended via KEP-71/PJ/2026)",
+        "Consult a licensed Indonesian tax consultant before making non-residency claims"
+      ]
     },
     {
-      name: "Intention Test",
-      subtitle: "Plan to reside",
-      values: {
-        Test: "Intend to stay in Indonesia",
-        Period: "From date of intention",
-        "Automatic?": "Subjective - based on circumstances",
-        "Most Common": "No - supplementary",
-      },
-    },
-  ]}
-/>
-
----
-
-## Determine Your Status
-
-<DecisionTree
-  title="Are You a Tax Resident?"
-  description="Find out your Indonesian tax residency status"
-  nodes={[
-    {
-      id: "start",
-      question:
-        "How many days have you been in Indonesia in the past 12 months?",
-      options: [
-        { label: "Under 90 days", nextNodeId: "result-non-resident" },
-        { label: "90-182 days", nextNodeId: "intention-check" },
-        { label: "183+ days", nextNodeId: "result-resident" },
-      ],
-    },
-    {
-      id: "intention-check",
-      question: "Do you intend to stay in Indonesia long-term?",
-      helpText: "Consider: KITAS, property, family, business ties",
-      options: [
-        { label: "Yes, planning to live here", nextNodeId: "ties-check" },
-        { label: "No, temporary stay", nextNodeId: "result-non-resident" },
-        { label: "Unsure", nextNodeId: "result-borderline" },
-      ],
-    },
-    {
-      id: "ties-check",
-      question: "Do you have strong ties to Indonesia?",
-      helpText: "Family living here, own property, primary business",
-      options: [
-        { label: "Yes, strong ties", nextNodeId: "result-likely-resident" },
-        { label: "Not really", nextNodeId: "result-non-resident" },
-      ],
-    },
-    {
-      id: "result-resident",
-      isResult: true,
-      title: "Tax Resident",
-      description: "You are an Indonesian tax resident",
-      recommendation:
-        "With 183+ days in Indonesia, you are a tax resident. Indonesia can tax your worldwide income. You must register for NPWP and file annual SPT.",
-      nextSteps: [
-        "Register for NPWP",
-        "File annual SPT by March 31",
-        "Report all income sources",
-        "Claim foreign tax credits",
-      ],
-    },
-    {
-      id: "result-likely-resident",
-      isResult: true,
-      title: "Likely Tax Resident",
-      description: "You may be considered a tax resident",
-      recommendation:
-        "Strong ties + intention to stay can make you a resident even under 183 days. Consult a tax professional to confirm your status.",
-      nextSteps: [
-        "Consult tax advisor",
-        "Consider voluntary registration",
-        "Document your situation",
-      ],
-    },
-    {
-      id: "result-non-resident",
-      isResult: true,
-      title: "Non-Resident",
-      description: "You are not an Indonesian tax resident",
-      recommendation:
-        "As a non-resident, only Indonesian-source income is taxable (at 20% withholding usually). You don't need NPWP unless earning Indonesian income.",
-      nextSteps: [
-        "Track your days carefully",
-        "Declare Indonesian income at home",
-        "Check if approaching 183 days",
-      ],
-    },
-    {
-      id: "result-borderline",
-      isResult: true,
-      title: "Borderline Case",
-      description: "Your status needs professional review",
-      recommendation:
-        "90-182 days with unclear intentions is a gray area. Get professional advice to clarify your status and plan accordingly.",
-      nextSteps: [
-        "Consult tax professional",
-        "Document your situation",
-        "Consider planning around thresholds",
-      ],
-    },
-  ]}
-/>
-
----
-
-## The 183-Day Rule in Detail
-
-<InfoCard variant="important" title="How Days Are Counted">
-- **Both entry and exit days count** as full days
-- **Rolling 12 months** - not calendar year
-- **Any 12-month period** that includes 183+ days triggers residency
-- **Days don't need to be consecutive**
-
-Example: If you arrive Oct 1, 2024 and spend 183+ days in Indonesia by Sep 30, 2026, you become a tax resident.
-
-</InfoCard>
-
-### Day Counting Example
-
-<Calculator
-  title="183-Day Calculator"
-  description="Calculate your days in Indonesia"
-  fields={[
-    {
-      id: "days-so-far",
-      label: "Days in Indonesia (past 12 months)",
-      type: "number",
-      defaultValue: 120,
-      min: 0,
-      max: 365
-    },
-    {
-      id: "planned-days",
-      label: "Planned additional days",
-      type: "number",
-      defaultValue: 60,
-      min: 0,
-      max: 365
+      text: "For E33G Digital Nomad Visa Holders",
+      subItems: [
+        "Document your intent indicators — or lack thereof — in writing",
+        "Do not assume E33G automatically exempts you from tax residency",
+        "Monitor DJP implementing regulations for E33G-specific guidance",
+        "Seek professional advice if you have exceeded 183 days or have business/family presence"
+      ]
     }
   ]}
-  calculateResult={(values) => {
-    const total = Number(values['days-so-far']) + Number(values['planned-days']);
-    const threshold = 183;
-    const margin = threshold - total;
-
-    const breakdown = [
-      { label: "Days so far", amount: Number(values['days-so-far']) },
-      { label: "Planned days", amount: Number(values['planned-days']) },
-      { label: "Total days", amount: total }
-    ];
-
-    let note = "";
-    if (total >= 183) {
-      note = `At ${total} days, you WILL be a tax resident. Consider implications.`;
-    } else {
-      note = `At ${total} days, you're under the threshold. ${margin} day buffer remaining.`;
-    }
-
-    return {
-      total,
-      breakdown,
-      currency: "days",
-      note
-    };
-
-}}
 />
 
 ---
-
-## What Tax Residency Means
-
-### Tax Residents Must:
-
-- Pay tax on **worldwide income**
-- Register for **NPWP**
-- File **annual SPT** (tax return)
-- Can claim **foreign tax credits**
-
-### Non-Residents:
-
-- Pay tax only on **Indonesian-source income**
-- **20% withholding** (unless treaty reduces)
-- **No filing required**
-- **No NPWP needed** (unless earning Indonesian income)
-
----
-
-<ArticleClusterCTA slug="tax-residency-indonesia" />
-
-## Common Questions
 
 <AskZantara
-  context="Tax residency Indonesia, 183 day rule, expat tax, resident vs non-resident"
-  placeholder="Ask about tax residency..."
-  suggestedQuestions={[
-    "What if I'm resident in two countries?",
-    "Does tourist visa affect residency?",
-    "When does my residency start?",
-    "Can I avoid becoming resident?",
-  ]}
+  question="Have questions about your tax residency status in Indonesia?"
+  placeholder="Ask Zantara AI about the 183-day rule, KITAS residency, or E33G tax obligations..."
 />
-
----
-
-## Related Articles
-
-- [Indonesia Tax Guide for Foreigners](/tax/indonesia-tax-guide-for-foreigners)
-- [NPWP for Foreigners in Indonesia](/tax/npwp-foreigners-guide)
-- [Indonesia's 0% Tax on Foreign Income](/tax/indonesia-zero-tax-foreign-income-2026)
-- [The 183-Day Rule: What Expats Get Wrong](/tax/indonesias-183-day-tax-residency-rule-what-expats-get-wrong-in-2026)
-- [Tax Planning for Expats Indonesia](/tax/tax-planning-expats)


### PR DESCRIPTION
## Summary
New article: Tax Residency in Indonesia — 183-Day Rule & Dual Test

## URL
/tax/tax-residency-indonesia

## Content Coverage
- 183-day rule explained clearly
- Dual-test criteria (days AND intent) — verified by Antonello
- KITAS E28A vs E33G practical implications
- PT PMA owner guidance
- Action checklist per visa type

## Regulatory Notes
- Claims 6 & 8 verified (dual-test confirmed)
- Claims 16 & 20 (E33G) still SEDANG — article reflects nuance with clear caveats
- Pending full NB-4 verification before production publish

## Status
🔴 DO NOT MERGE — awaiting NB-4 results & Antonello review