### PR TITLE
fix(backend): align Canva MCP import test

### DIFF
--- a/apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_canva_mcp.py
+++ b/apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_canva_mcp.py
@@ -70,5 +70,9 @@ async def test_import_design_calls_mcp_tool():
     assert edit_url == "https://www.canva.com/design/DAGabc/edit"
     mock_session.call_tool.assert_awaited_once_with(
         "import-design-from-url",
-        arguments={"url": "https://example.com/foo.pdf", "title": "Test"},
+        arguments={
+            "url": "https://example.com/foo.pdf",
+            "name": "Test",
+            "user_intent": "Import WR2 carousel PDF into Canva for editing",
+        },
     )


### PR DESCRIPTION
## Summary\n- Update the Canva MCP import unit test to match the current import-design-from-url contract: url, name, and user_intent.\n\n## Tests\n- cd apps/backend-rag && source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && PYTHONPATH=. pytest backend/tests/unit/services/canva_renderer_v2/test_canva_mcp.py -q\n- git diff --check