### PR TITLE
feat(mata-garuda): C.1-C.4 — fix Pilastro 1 reflection regression via ACL

### DIFF
--- a/apps/mata-garuda/mata_garuda/workers/gap_consumer.py
+++ b/apps/mata-garuda/mata_garuda/workers/gap_consumer.py
@@ -25,7 +25,11 @@ from typing import Any, Callable, Optional
 
 from mata_garuda.config import STREAM_NEXUS_GAPS
 from mata_garuda.workers.base_worker import stream_ack, stream_read_new
-from mata_garuda.workers.gap_legacy import coerce_to_canonical, is_legacy_shape
+from mata_garuda.workers.gap_legacy import (
+    coerce_to_canonical,
+    consume_unmapped_counter,
+    is_legacy_shape,
+)
 
 logger = logging.getLogger("mata_garuda.workers.gap_consumer")
 
@@ -38,6 +42,16 @@ MAX_DISPATCH_PER_RUN = 5
 DISPATCH_SLEEP_S = 2
 
 # Gap type → agent name (None = Phase 2, skipped with ack)
+#
+# Two classes of None entries:
+#   - "Phase 2 deferred"     — agent will exist in a future sprint, gap is
+#                              legitimately routable just not implemented yet
+#                              (e.g. gap.missing_procurement → lpse_harvester).
+#   - "gap.dlq:<reason>"     — explicit dead-letter for orphan attributes
+#                              that arrive from OSINT but have no agent
+#                              roadmap. These are still ACKed (no PEL bloat)
+#                              but logged + counted separately so future
+#                              audits can decide if they deserve an agent.
 GAP_DISPATCH: dict[str, Optional[str]] = {
     "gap.missing_nip":          "lhkpn_harvester",
     "gap.missing_lhkpn":        "lhkpn_harvester",
@@ -47,6 +61,13 @@ GAP_DISPATCH: dict[str, Optional[str]] = {
     "gap.missing_office":       "regulation_watcher",
     "gap.kanim_struktur":       "regulation_watcher",
     "gap.missing_procurement":  None,  # Phase 2: lpse_harvester
+    # C.4 — explicit DLQ for orphan attribute namespaces.
+    # The 4-LLM brainstorm 2026-05-16 (research/symbiosis/.../dispatch-alias)
+    # identified these as "OSINT emits them, no agent target exists today".
+    # Routing them to a distinct gap.dlq:* canonical keeps them visible in
+    # logs + audit counter, distinct from genuinely-unknown gap types.
+    "gap.dlq:phone":             None,
+    "gap.dlq:profile":           None,
 }
 
 
@@ -225,8 +246,52 @@ def run_gap_consumer(
         if i < len(items) - 1 and result.get("agent"):
             time.sleep(DISPATCH_SLEEP_S)
 
+    # C.2 — Persist unmapped counter snapshot to knowledge.db for daily audit.
+    # Non-fatal: failure to record must not break the consumer cycle.
+    unmapped_snapshot = consume_unmapped_counter()
+    if unmapped_snapshot:
+        try:
+            _persist_unmapped_snapshot(unmapped_snapshot)
+        except Exception as e:  # noqa: BLE001 — defensive: audit is opt-in
+            logger.warning("Failed to persist unmapped audit snapshot: %s", e)
+
     logger.info("Gap consumer cycle: %s", stats)
     return stats
+
+
+def _persist_unmapped_snapshot(
+    snapshot: dict[tuple[str, Optional[str]], int],
+) -> None:
+    """Append unmapped (gap_type, attribute) → count rows to knowledge.db.
+
+    One row per tuple per consumer tick. The daily audit script aggregates
+    rows over a rolling 24h window and alerts via Telegram if the unmapped
+    rate exceeds the configured threshold.
+
+    Stored as `knowledge.type='unmapped_gap'` with content as a single-line
+    JSON object {"gap_type": str, "attribute": str|null, "count": int} so
+    existing FTS5 indexes and prune cron don't need schema changes.
+    """
+    import json as _json
+
+    from mata_garuda.runtime.knowledge import KnowledgeBase
+
+    kb = KnowledgeBase()
+    try:
+        for (gtype, attr), count in snapshot.items():
+            content = _json.dumps(
+                {"gap_type": gtype, "attribute": attr, "count": count},
+                ensure_ascii=False,
+            )
+            kb.store(
+                agent="gap_consumer",
+                entry_type="unmapped_gap",
+                content=content,
+                source="nexus:gaps",
+                confidence=1.0,
+            )
+    finally:
+        kb.close()
 
 
 def main() -> None:

--- a/apps/mata-garuda/mata_garuda/workers/gap_legacy.py
+++ b/apps/mata-garuda/mata_garuda/workers/gap_legacy.py
@@ -1,47 +1,56 @@
 """
-Mata Garuda — Legacy gap entry adapter.
+Mata Garuda — Legacy gap entry adapter (Anti-Corruption Layer).
 
-The `nexus:gaps` Redis stream contains 828 entries from the pre-envelope era
-(2026-04-10 → 2026-04-13) that use a different shape and `gap_type` taxonomy
-than the canonical envelope used by gap_consumer.
+The `nexus:gaps` Redis stream contains entries produced by the OSINT-Nexus
+gap-detector (~/Desktop/OSINT-Nexus/), a SEPARATE repo whose schema evolves
+independently from this consumer. This module is the Anti-Corruption Layer
+between the two schemas — see SYMBIOSIS.md Pilastro 3 Condivisione.
 
-This module bridges the two:
+It bridges the two by:
   - `coerce_to_canonical()` accepts ANY entry data dict from the stream
-  - returns (canonical_gap_type, payload) when the legacy entry maps to a
-    type currently in `gap_consumer.GAP_DISPATCH`
-  - returns None for legacy shapes we choose to drain (skip+ack with a
-    forensic log line)
+  - returns (canonical_gap_type, payload) when the entry can be routed to an
+    agent currently in `gap_consumer.GAP_DISPATCH`
+  - returns None for shapes we choose to drain (skip+ack with a forensic log
+    line)
 
-Translation matrix (from a histogram of the live 828 legacy entries on
-2026-04-16, see docs/PHASE1_METRICS_2026-04-16.md):
+Translation matrix (live histogram 4059 entries on 2026-05-16, from
+research/symbiosis/2026-05-16-dispatch-alias-brainstorm.md):
 
-    LEGACY (gap_type, attribute)        CANONICAL gap_type           COUNT
-    ----------------------------------  ---------------------------  -----
-    missing_attribute / nip             gap.missing_nip                260
-    missing_attribute / lhkpn           gap.missing_lhkpn               39
-    missing_attribute / angkatan        gap.missing_angkatan            13
-    missing_attribute / officials_struktur  gap.kanim_struktur          26
-    missing_attribute / procurement_link  gap.missing_procurement      130
-    stale_attribute  / *                gap.stale_official             195
-    ------------------------------------ subtotal MAPPED                663
+    OSINT (gap_type, attribute)              CANONICAL gap_type        COUNT
+    ----------------------------------       --------------------      -----
+    missing_attribute / nip                  gap.missing_nip            1180
+    missing_attribute / lhkpn                gap.missing_lhkpn           177
+    missing_attribute / angkatan             gap.missing_angkatan         58
+    missing_attribute / officials_struktur   gap.kanim_struktur            0  ★
+    missing_attribute / procurement_link     gap.missing_procurement       0  ★
+    stale_attribute   / *                    gap.stale_official          885
+    missing_relation  / officials_struktur   gap.kanim_struktur          116  ✚ 2026-05-16
+    missing_relation  / officials_or_documents  gap.orphan_org           886  ✚ 2026-05-16
+    missing_relation  / procurement_link     gap.missing_procurement     580  ✚ 2026-05-16
+    missing_relation  / WORKS_AT:<kanim>     gap.kanim_struktur          177  ✚ 2026-05-16 (prefix)
+    ----------------------------------       --------------------      -----
+                                                       subtotal MAPPED 4059  (100%)
 
-    missing_attribute / profile         <drain — no canonical mapping> 195
-    missing_attribute / officials_or_documents  <drain>                195
-    missing_attribute / WORKS_AT:*      <drain — relation, not attr>    39
-    missing_relation / *                <drain — no canonical mapping> 390 (some overlap above)
-    ------------------------------------ subtotal DRAINED              ~360
+    ★ The two zero-count rows are kept for forward-compat with older
+      OSINT-Nexus schema versions that emitted them on `missing_attribute`
+      instead of `missing_relation`. Removing them would silently regress
+      if OSINT ever rolls back.
 
-The 4 DRAINED legacy types correspond to gap detector probes that were
-designed before the canonical 8-type taxonomy in
-`docs/superpowers/specs/2026-04-14-organism-nervous-system-design.md §5`
-was finalized. They have no agent able to act on them today; draining them
-with a forensic log entry is the pragmatic choice. If a legacy type later
-acquires an agent, add the mapping here — no schema migration needed.
+Schema drift history:
+  - 2026-04-13: pre-envelope legacy era (828 entries with mixed shapes).
+  - 2026-04-14: canonical 8-type taxonomy declared in
+    `docs/superpowers/specs/2026-04-14-organism-nervous-system-design.md §5`.
+  - 2026-05-08: OSINT-Nexus refactored to emit (gap_type, attribute) tuples
+    drawn from {missing_attribute, missing_relation, stale_attribute} × full
+    attribute namespace. This broke ~43% of routing (1759 unmapped entries)
+    until 2026-05-16 extension. Reference incident: Pilastro 1 Riflessione
+    regression doc.
 
 Entries that already use the new envelope shape (have `id`+`type`+`source`)
 pass through unchanged.
 
-Reference: `docs/PHASE1_SINAPSI_STATUS_2026-04-16.md` open item #2.
+Reference: `docs/PHASE1_SINAPSI_STATUS_2026-04-16.md` open item #2 +
+`research/symbiosis/2026-05-16-reflection-regression-2026-05-08.md`.
 """
 from __future__ import annotations
 
@@ -53,13 +62,31 @@ logger = logging.getLogger("mata_garuda.workers.gap_legacy")
 
 # (legacy gap_type, legacy attribute) → canonical gap_type
 # Wildcard attribute uses None as the second key.
+# Prefix attributes use a separate _PREFIX_TRANSLATION table.
 _TRANSLATION: dict[tuple[str, Optional[str]], str] = {
+    # Pre-2026-05-08 OSINT schema (still emitted by older deployments)
     ("missing_attribute", "nip"):                "gap.missing_nip",
     ("missing_attribute", "lhkpn"):              "gap.missing_lhkpn",
     ("missing_attribute", "angkatan"):           "gap.missing_angkatan",
     ("missing_attribute", "officials_struktur"): "gap.kanim_struktur",
     ("missing_attribute", "procurement_link"):   "gap.missing_procurement",
     ("stale_attribute",   None):                 "gap.stale_official",
+    # Post-2026-05-08 OSINT schema (current production emitters)
+    ("missing_relation",  "officials_struktur"): "gap.kanim_struktur",
+    ("missing_relation",  "officials_or_documents"): "gap.orphan_org",
+    ("missing_relation",  "procurement_link"):   "gap.missing_procurement",
+    # C.4 — explicit DLQ for orphan attributes (no agent target by design).
+    # Mapped instead of drained so they appear in dispatch counters and can
+    # be distinguished from genuinely-unknown gap shapes in the audit.
+    ("missing_attribute", "phone"):              "gap.dlq:phone",
+    ("missing_attribute", "profile"):            "gap.dlq:profile",
+}
+
+# (legacy gap_type, attribute prefix) → canonical gap_type
+# Used when OSINT emits structured attribute names like "WORKS_AT:<kanim_name>"
+# where the prefix encodes the relation type but the suffix is data.
+_PREFIX_TRANSLATION: dict[tuple[str, str], str] = {
+    ("missing_relation", "WORKS_AT:"): "gap.kanim_struktur",
 }
 
 
@@ -70,6 +97,20 @@ def is_legacy_shape(data: dict[str, Any]) -> bool:
     entries have `gap_type` instead of `type` and lack `id`/`source`.
     """
     return "type" not in data or "source" not in data
+
+
+def _lookup_prefix(legacy_type: str, legacy_attr: Optional[str]) -> Optional[str]:
+    """Match legacy_attr against _PREFIX_TRANSLATION prefixes.
+
+    Returns canonical gap_type if any (legacy_type, prefix) where
+    legacy_attr.startswith(prefix) is registered, else None.
+    """
+    if legacy_attr is None:
+        return None
+    for (lt, prefix), canonical in _PREFIX_TRANSLATION.items():
+        if lt == legacy_type and legacy_attr.startswith(prefix):
+            return canonical
+    return None
 
 
 def coerce_to_canonical(
@@ -86,9 +127,12 @@ def coerce_to_canonical(
         - Canonical envelope entries are returned unchanged (caller still
           parses payload from JSON string itself; we just re-expose the
           fields here for a uniform interface).
-        - Legacy entries are mapped via `_TRANSLATION`. The full original
-          dict becomes the payload, so the agent retains every field.
-        - Unmapped legacy entries log a structured warning and return None.
+        - Legacy entries are mapped via `_TRANSLATION` (exact match) or
+          `_PREFIX_TRANSLATION` (prefix match for structured attributes
+          like ``WORKS_AT:<kanim_name>``). The full original dict becomes
+          the payload, so the agent retains every field.
+        - Unmapped legacy entries log a structured warning, record via
+          `_record_unmapped` for daily audit, and return None.
     """
     if not is_legacy_shape(data):
         # Already canonical — caller continues with its existing parsing.
@@ -97,10 +141,14 @@ def coerce_to_canonical(
     legacy_type = data.get("gap_type", "") or ""
     legacy_attr = data.get("attribute") or None
 
-    # Try (type, attr) then (type, None) as a fallback.
+    # Resolution order:
+    # 1. exact (type, attr)
+    # 2. exact (type, None) — wildcard attr
+    # 3. prefix (type, "PREFIX:") for structured attribute names
     canonical = (
         _TRANSLATION.get((legacy_type, legacy_attr))
         or _TRANSLATION.get((legacy_type, None))
+        or _lookup_prefix(legacy_type, legacy_attr)
     )
 
     if canonical is None:
@@ -111,6 +159,7 @@ def coerce_to_canonical(
             legacy_attr,
             data.get("entity_name") or data.get("entity_type") or "?",
         )
+        _record_unmapped(legacy_type, legacy_attr)
         return None
 
     # Whole legacy dict becomes payload, plus an explicit marker for
@@ -118,3 +167,24 @@ def coerce_to_canonical(
     payload: dict[str, Any] = dict(data)
     payload["_legacy_source"] = "nexus:gaps:pre-2026-04-14"
     return canonical, payload
+
+
+# ── Unmapped audit counter (C.2 — loud failure signature) ─────────────────
+# In-process counter; persisted snapshot via record_unmapped_snapshot() called
+# by the gap_consumer at the end of each tick. SQLite (knowledge.db) is the
+# authoritative store — see mata_garuda.runtime.knowledge.
+
+_UNMAPPED_COUNTER: dict[tuple[str, Optional[str]], int] = {}
+
+
+def _record_unmapped(legacy_type: str, legacy_attr: Optional[str]) -> None:
+    """In-process counter increment. Persistence happens in snapshot fn."""
+    key = (legacy_type, legacy_attr)
+    _UNMAPPED_COUNTER[key] = _UNMAPPED_COUNTER.get(key, 0) + 1
+
+
+def consume_unmapped_counter() -> dict[tuple[str, Optional[str]], int]:
+    """Atomic snapshot+reset of the in-process counter. Caller persists."""
+    snapshot = dict(_UNMAPPED_COUNTER)
+    _UNMAPPED_COUNTER.clear()
+    return snapshot

--- a/apps/mata-garuda/tests/test_gap_consumer.py
+++ b/apps/mata-garuda/tests/test_gap_consumer.py
@@ -1,18 +1,30 @@
 """Tests for gap consumer — reads nexus:gaps and dispatches agents."""
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from mata_garuda.workers.gap_consumer import (
     GAP_DISPATCH,
     process_gap,
     run_gap_consumer,
 )
+from mata_garuda.workers.gap_legacy import consume_unmapped_counter
+
+
+@pytest.fixture(autouse=True)
+def _reset_unmapped_counter():
+    """Counter state must not leak across consumer tests."""
+    consume_unmapped_counter()
+    yield
+    consume_unmapped_counter()
 
 
 def test_gap_dispatch_table_complete():
-    """All 8 gap types from the design spec are mapped (1 to None for Phase 2)."""
+    """8 canonical gap types + 2 explicit DLQ slots (C.4 2026-05-16)."""
     expected = {
+        # Canonical agent-targeted
         "gap.missing_nip",
         "gap.missing_lhkpn",
         "gap.missing_angkatan",
@@ -21,11 +33,16 @@ def test_gap_dispatch_table_complete():
         "gap.missing_office",
         "gap.kanim_struktur",
         "gap.missing_procurement",
+        # C.4 explicit DLQ — no agent target by design
+        "gap.dlq:phone",
+        "gap.dlq:profile",
     }
     assert set(GAP_DISPATCH.keys()) == expected
-    # Phase 1: 7 gaps mapped to an agent, 1 unmapped (procurement)
+    # 7 routable, 3 None (1 phase-2 deferred + 2 DLQ)
     mapped = {k for k, v in GAP_DISPATCH.items() if v is not None}
     assert "gap.missing_procurement" not in mapped
+    assert "gap.dlq:phone" not in mapped
+    assert "gap.dlq:profile" not in mapped
     assert len(mapped) == 7
 
 
@@ -328,3 +345,114 @@ def test_run_gap_consumer_mixed_canonical_and_legacy_batch():
     assert fake_dispatch.call_count == 2
     # All three entries got acked (2 via process_gap on resolve, 1 via drain)
     assert fake_xack.call_count == 3
+
+
+# ── C.2 — unmapped persistence ──────────────────────────────────────────
+
+
+def test_run_gap_consumer_persists_unmapped_snapshot():
+    """Drained legacy entries must be persisted to knowledge.db at cycle end."""
+    msgs = [
+        {"id": "300-0", "data": {
+            "gap_type": "totally_invented", "attribute": "x",
+        }},
+        {"id": "300-1", "data": {
+            "gap_type": "totally_invented", "attribute": "x",
+        }},
+        {"id": "300-2", "data": {
+            "gap_type": "another_unknown",
+        }},
+    ]
+    fake_read = MagicMock(return_value=msgs)
+    fake_xack = MagicMock()
+
+    captured_stores: list[dict] = []
+
+    class _FakeKB:
+        def store(self, **kwargs):
+            captured_stores.append(kwargs)
+            return 1
+
+        def close(self):
+            pass
+
+    with patch(
+        "mata_garuda.runtime.knowledge.KnowledgeBase", return_value=_FakeKB()
+    ):
+        stats = run_gap_consumer(
+            max_items=10,
+            stream_read=fake_read,
+            xack=fake_xack,
+        )
+
+    assert stats["skipped"] == 3
+    # Two distinct unmapped tuples → two persistence rows
+    assert len(captured_stores) == 2
+    types_seen = {c["entry_type"] for c in captured_stores}
+    assert types_seen == {"unmapped_gap"}
+    agents_seen = {c["agent"] for c in captured_stores}
+    assert agents_seen == {"gap_consumer"}
+
+
+def test_run_gap_consumer_no_persistence_when_zero_unmapped():
+    """If all entries are mapped, no audit row is written."""
+    msgs = [
+        {"id": "400-0", "data": {
+            "gap_type": "missing_attribute", "attribute": "nip",
+            "entity_name": "OK",
+        }},
+    ]
+    fake_read = MagicMock(return_value=msgs)
+    fake_dispatch = MagicMock(return_value={"case_resolved": True})
+    fake_xack = MagicMock()
+
+    captured_stores: list[dict] = []
+
+    class _FakeKB:
+        def store(self, **kwargs):
+            captured_stores.append(kwargs)
+            return 1
+
+        def close(self):
+            pass
+
+    with patch(
+        "mata_garuda.runtime.knowledge.KnowledgeBase", return_value=_FakeKB()
+    ):
+        run_gap_consumer(
+            max_items=10,
+            stream_read=fake_read,
+            dispatch_agent=fake_dispatch,
+            xack=fake_xack,
+        )
+
+    assert captured_stores == []
+
+
+def test_run_gap_consumer_persistence_failure_does_not_break_cycle():
+    """A crash in the audit persister must not poison the consumer cycle."""
+    msgs = [
+        {"id": "500-0", "data": {"gap_type": "totally_invented", "attribute": "x"}},
+    ]
+    fake_read = MagicMock(return_value=msgs)
+    fake_xack = MagicMock()
+
+    class _BrokenKB:
+        def store(self, **kwargs):
+            raise RuntimeError("disk full")
+
+        def close(self):
+            pass
+
+    with patch(
+        "mata_garuda.runtime.knowledge.KnowledgeBase", return_value=_BrokenKB()
+    ):
+        stats = run_gap_consumer(
+            max_items=10,
+            stream_read=fake_read,
+            xack=fake_xack,
+        )
+
+    # Consumer still completed its work; only the audit step swallowed.
+    assert stats["skipped"] == 1
+    fake_xack.assert_called_once()

--- a/apps/mata-garuda/tests/test_gap_legacy.py
+++ b/apps/mata-garuda/tests/test_gap_legacy.py
@@ -1,11 +1,23 @@
 """Tests for legacy gap entry adapter — coerce_to_canonical()."""
 from __future__ import annotations
 
+import pytest
+
 from mata_garuda.workers.gap_legacy import (
+    _PREFIX_TRANSLATION,
     _TRANSLATION,
+    consume_unmapped_counter,
     coerce_to_canonical,
     is_legacy_shape,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_unmapped_counter():
+    """Each test gets a clean unmapped counter."""
+    consume_unmapped_counter()
+    yield
+    consume_unmapped_counter()
 
 
 # ── shape detection ────────────────────────────────────────────────────
@@ -112,23 +124,48 @@ def test_coerce_legacy_stale_attribute_wildcard_attr():
 # ── legacy translation: drained cases ──────────────────────────────────
 
 
-def test_coerce_legacy_profile_drained():
+def test_coerce_legacy_profile_routes_to_dlq():
+    """profile attribute now routes to explicit DLQ (C.4 2026-05-16).
+
+    Was previously drained silently — see brainstorm doc §C.4 reasoning.
+    DLQ has GAP_DISPATCH[None] but the entry is visible in counters.
+    """
     data = {"gap_type": "missing_attribute", "attribute": "profile"}
-    assert coerce_to_canonical("1-0", data) is None
+    result = coerce_to_canonical("1-0", data)
+    assert result is not None
+    gap_type, _ = result
+    assert gap_type == "gap.dlq:profile"
 
 
-def test_coerce_legacy_officials_or_documents_drained():
+def test_coerce_legacy_phone_routes_to_dlq():
+    """phone attribute → DLQ (C.4)."""
+    data = {"gap_type": "missing_attribute", "attribute": "phone"}
+    gap_type, _ = coerce_to_canonical("1-0", data)  # type: ignore[misc]
+    assert gap_type == "gap.dlq:phone"
+
+
+def test_coerce_legacy_officials_or_documents_on_missing_attribute_drained():
+    """On `missing_attribute`, `officials_or_documents` has no canonical agent.
+
+    The semantic shifted in 2026-05-08 OSINT refactor: the same attribute
+    name now arrives under `missing_relation` (see test_coerce_missing_relation_*).
+    """
     data = {"gap_type": "missing_attribute", "attribute": "officials_or_documents"}
     assert coerce_to_canonical("1-0", data) is None
 
 
-def test_coerce_legacy_missing_relation_drained():
+def test_coerce_legacy_missing_relation_bare_drained():
+    """Bare missing_relation without recognized attribute still drains."""
     data = {"gap_type": "missing_relation", "from": "Foo", "to": "Bar"}
     assert coerce_to_canonical("1-0", data) is None
 
 
-def test_coerce_legacy_works_at_relation_drained():
-    """WORKS_AT:* attribute is a relation reference, not an attribute name."""
+def test_coerce_legacy_works_at_under_missing_attribute_drained():
+    """WORKS_AT:* on `missing_attribute` (legacy pre-2026-05-08) → drained.
+
+    The OSINT-Nexus refactor moved WORKS_AT:* under `missing_relation` where
+    it IS mapped — see test_coerce_missing_relation_works_at_prefix.
+    """
     data = {
         "gap_type": "missing_attribute",
         "attribute": "WORKS_AT:Kanim Kelas I Khusus TPI Ngurah Rai",
@@ -141,6 +178,111 @@ def test_coerce_unknown_legacy_shape_drained():
     assert coerce_to_canonical("1-0", data) is None
 
 
+# ── 2026-05-16 schema extension: missing_relation taxonomy ──────────────
+
+
+def test_coerce_missing_relation_officials_struktur_to_kanim():
+    """missing_relation+officials_struktur → gap.kanim_struktur (116 entries live)."""
+    data = {
+        "gap_type": "missing_relation",
+        "attribute": "officials_struktur",
+        "entity_name": "Kanim Kelas I Khusus TPI Ngurah Rai",
+    }
+    result = coerce_to_canonical("1-0", data)
+    assert result is not None
+    gap_type, payload = result
+    assert gap_type == "gap.kanim_struktur"
+    assert payload["_legacy_source"] == "nexus:gaps:pre-2026-04-14"
+
+
+def test_coerce_missing_relation_officials_or_documents_to_orphan_org():
+    """missing_relation+officials_or_documents → gap.orphan_org (886 entries live)."""
+    data = {
+        "gap_type": "missing_relation",
+        "attribute": "officials_or_documents",
+        "entity_name": "Kementerian Keuangan",
+    }
+    gap_type, _ = coerce_to_canonical("1-0", data)  # type: ignore[misc]
+    assert gap_type == "gap.orphan_org"
+
+
+def test_coerce_missing_relation_procurement_link():
+    """missing_relation+procurement_link → gap.missing_procurement (580 entries live)."""
+    data = {
+        "gap_type": "missing_relation",
+        "attribute": "procurement_link",
+        "entity_name": "OJK",
+    }
+    gap_type, _ = coerce_to_canonical("1-0", data)  # type: ignore[misc]
+    assert gap_type == "gap.missing_procurement"
+
+
+# ── 2026-05-16 prefix translation: WORKS_AT:<kanim_name> ────────────────
+
+
+def test_coerce_missing_relation_works_at_prefix():
+    """WORKS_AT:<any> on missing_relation → gap.kanim_struktur (177 entries live)."""
+    data = {
+        "gap_type": "missing_relation",
+        "attribute": "WORKS_AT:Kanim Kelas I Khusus TPI Ngurah Rai",
+        "entity_name": "Felucia Sengky Ratna",
+    }
+    result = coerce_to_canonical("1-0", data)
+    assert result is not None
+    gap_type, payload = result
+    assert gap_type == "gap.kanim_struktur"
+    # Suffix must reach the agent verbatim — it's the kanim identifier.
+    assert payload["attribute"] == "WORKS_AT:Kanim Kelas I Khusus TPI Ngurah Rai"
+
+
+def test_coerce_missing_relation_works_at_different_kanim():
+    """Prefix match works for any kanim suffix, not just the live one."""
+    for kanim in ("Kanim Denpasar", "Kanim Jakarta Selatan", "Kanim Surabaya"):
+        data = {
+            "gap_type": "missing_relation",
+            "attribute": f"WORKS_AT:{kanim}",
+        }
+        gap_type, _ = coerce_to_canonical("1-0", data)  # type: ignore[misc]
+        assert gap_type == "gap.kanim_struktur", f"prefix routing broke for {kanim}"
+
+
+def test_coerce_prefix_does_not_match_unrelated_attribute():
+    """Prefix WORKS_AT: must NOT match a bare 'WORKS_AT' attribute (no colon)."""
+    data = {"gap_type": "missing_relation", "attribute": "WORKS_AT"}
+    # "WORKS_AT" doesn't start with "WORKS_AT:" — should fall through to drain.
+    assert coerce_to_canonical("1-0", data) is None
+
+
+# ── Unmapped counter (C.2) ──────────────────────────────────────────────
+
+
+def test_unmapped_counter_increments_on_drain():
+    """Every drain must increment the in-process counter."""
+    coerce_to_canonical("1-0", {"gap_type": "totally_invented", "attribute": "x"})
+    coerce_to_canonical("1-1", {"gap_type": "totally_invented", "attribute": "x"})
+    coerce_to_canonical("1-2", {"gap_type": "another_unknown"})
+    snapshot = consume_unmapped_counter()
+    assert snapshot[("totally_invented", "x")] == 2
+    assert snapshot[("another_unknown", None)] == 1
+
+
+def test_unmapped_counter_does_not_increment_on_mapped():
+    """Mapped entries must NOT touch the counter."""
+    coerce_to_canonical("1-0", {"gap_type": "missing_attribute", "attribute": "nip"})
+    coerce_to_canonical("1-1", {"gap_type": "missing_relation", "attribute": "procurement_link"})
+    snapshot = consume_unmapped_counter()
+    assert snapshot == {}
+
+
+def test_consume_resets_counter():
+    """consume_unmapped_counter returns and clears in one atomic step."""
+    coerce_to_canonical("1-0", {"gap_type": "totally_invented"})
+    first = consume_unmapped_counter()
+    second = consume_unmapped_counter()
+    assert first[("totally_invented", None)] == 1
+    assert second == {}
+
+
 # ── translation table coverage ─────────────────────────────────────────
 
 
@@ -150,4 +292,13 @@ def test_translation_targets_are_in_dispatch_table():
     for canonical in _TRANSLATION.values():
         assert canonical in GAP_DISPATCH, (
             f"_TRANSLATION points at {canonical!r} which is not in GAP_DISPATCH"
+        )
+
+
+def test_prefix_translation_targets_are_in_dispatch_table():
+    """Every prefix-translation target must also exist in GAP_DISPATCH."""
+    from mata_garuda.workers.gap_consumer import GAP_DISPATCH
+    for canonical in _PREFIX_TRANSLATION.values():
+        assert canonical in GAP_DISPATCH, (
+            f"_PREFIX_TRANSLATION points at {canonical!r} which is not in GAP_DISPATCH"
         )

--- a/infra/launchagents/com.matagaruda.unmapped-audit.daily.plist
+++ b/infra/launchagents/com.matagaruda.unmapped-audit.daily.plist
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.matagaruda.unmapped-audit.daily</string>
+
+    <!-- Mata-Garuda C.2 — Daily audit of unmapped gap_legacy entries.
+
+         Runs once per day at 09:00 WITA (Pro-only) and emits a Telegram
+         alert if the rolling 24h total of `knowledge.type='unmapped_gap'`
+         rows exceeds the threshold (default 50, override via env
+         MATAGARUDA_UNMAPPED_ALERT_THRESHOLD).
+
+         Why this exists: the schema drift between OSINT-Nexus and
+         mata_garuda.workers.gap_legacy._TRANSLATION was invisible for
+         8 days (2026-05-08 → 2026-05-16) because 2137 "Legacy gap
+         drained" warnings stayed in the log file without any alert.
+         This LaunchAgent provides the "loud failure" signature recommended
+         by the 4-LLM brainstorm:
+           research/symbiosis/2026-05-16-dispatch-alias-brainstorm.md §C.2
+
+         KeepAlive=false because this is a daily audit, not a daemon. The
+         cicatrix-scars §"53 LaunchAgents Pro, only 7 KeepAlive=true"
+         classifies StartCalendarInterval entries as "cron jobs" —
+         KeepAlive=false is correct here.
+    -->
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/nuzantara/Desktop/nuzantara/scripts/mata_garuda_unmapped_audit_wrapper.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/nuzantara/Desktop/nuzantara</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <!-- TELEGRAM_BOT_TOKEN, TELEGRAM_OWNER_CHAT_ID, and
+             MATAGARUDA_UNMAPPED_ALERT_THRESHOLD (optional) are
+             sourced by the wrapper from ~/.nuzantara-secrets.env
+             (mode 0600) — do NOT inline secrets here (cicatrix P0-3
+             secrets-leak incident 2026-04-29). -->
+    </dict>
+
+    <!-- Daily 09:00 WITA. Off-cycle from gap-detector (07:00/18:00) so
+         it audits a complete-ish observation window.
+
+         macOS launchd evaluates StartCalendarInterval in SYSTEM LOCAL
+         TIME (NOT UTC). -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>KeepAlive</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/mata-garuda-unmapped-audit.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/mata-garuda-unmapped-audit.stderr.log</string>
+</dict>
+</plist>

--- a/scripts/mata_garuda_unmapped_audit_wrapper.sh
+++ b/scripts/mata_garuda_unmapped_audit_wrapper.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Mata-Garuda C.2 — Daily unmapped gap audit.
+# Reads knowledge.db `type='unmapped_gap'` rows from last 24h,
+# aggregates by (gap_type, attribute), alerts Telegram if total > threshold.
+#
+# Reference:
+#   research/symbiosis/2026-05-16-dispatch-alias-brainstorm.md §C.2
+#   apps/mata-garuda/mata_garuda/workers/gap_legacy.py:_record_unmapped
+#
+# Scheduled: 09:00 WITA daily via com.matagaruda.unmapped-audit.daily.plist.
+
+set -euo pipefail
+
+REPO="$HOME/Desktop/nuzantara"
+APP_DIR="$REPO/apps/mata-garuda"
+DB="$APP_DIR/data/knowledge.db"
+LOG_DIR="$HOME/logs"
+LOG="$LOG_DIR/mata-garuda-unmapped-audit.log"
+
+# Alert when unmapped count exceeds this in the last 24h.
+THRESHOLD="${MATAGARUDA_UNMAPPED_ALERT_THRESHOLD:-50}"
+
+# Source secrets (Telegram bot token + chat id) defensively.
+if [ -f "$HOME/.nuzantara-secrets.env" ]; then
+    # shellcheck disable=SC1091
+    set -a; source "$HOME/.nuzantara-secrets.env"; set +a
+fi
+
+mkdir -p "$LOG_DIR"
+
+now() { date '+%Y-%m-%d %H:%M:%S %Z'; }
+
+echo "" >> "$LOG"
+echo "=== Unmapped Gap Audit — $(now) ===" >> "$LOG"
+
+if [ ! -f "$DB" ]; then
+    echo "[unmapped-audit] FATAL: knowledge.db not found at $DB" >> "$LOG"
+    exit 2
+fi
+
+# Aggregate last 24h unmapped count by (gap_type, attribute) tuple.
+# Content is JSON like {"gap_type":"...","attribute":"...","count":N}.
+SUMMARY=$(sqlite3 "$DB" <<SQL
+SELECT
+    json_extract(content, '\$.gap_type') AS gtype,
+    json_extract(content, '\$.attribute') AS attr,
+    SUM(CAST(json_extract(content, '\$.count') AS INTEGER)) AS total
+FROM knowledge
+WHERE type = 'unmapped_gap'
+  AND created_at > datetime('now', '-24 hours')
+GROUP BY gtype, attr
+ORDER BY total DESC;
+SQL
+)
+
+TOTAL_24H=$(sqlite3 "$DB" "
+SELECT COALESCE(SUM(CAST(json_extract(content, '\$.count') AS INTEGER)), 0)
+FROM knowledge
+WHERE type = 'unmapped_gap'
+  AND created_at > datetime('now', '-24 hours');
+")
+
+echo "[unmapped-audit] 24h total=$TOTAL_24H threshold=$THRESHOLD" >> "$LOG"
+if [ -n "$SUMMARY" ]; then
+    echo "[unmapped-audit] breakdown:" >> "$LOG"
+    echo "$SUMMARY" >> "$LOG"
+fi
+
+if [ "${TOTAL_24H:-0}" -le "${THRESHOLD:-50}" ]; then
+    echo "[unmapped-audit] OK — under threshold" >> "$LOG"
+    exit 0
+fi
+
+# Alert path. hotfix-notify.sh is the canonical Telegram dispatcher.
+NOTIFY="$HOME/.claude/scripts/hotfix-notify.sh"
+MSG="📉 Mata-Garuda unmapped gaps last 24h: $TOTAL_24H (threshold $THRESHOLD)\n\nTop:\n$SUMMARY\n\nSee gap_legacy.py:_TRANSLATION — likely schema drift."
+
+if [ -x "$NOTIFY" ]; then
+    "$NOTIFY" "$MSG" >> "$LOG" 2>&1 || echo "[unmapped-audit] notify failed (non-fatal)" >> "$LOG"
+else
+    echo "[unmapped-audit] notify script missing at $NOTIFY — alert NOT sent" >> "$LOG"
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Pilastro 1 Riflessione regressed silently from ~7 reflections/day to ~1/day between 2026-05-08 and 2026-05-16 (−85% throughput, no alert). Root cause: schema drift between OSINT-Nexus gap-detector and `mata_garuda.workers.gap_consumer`. **43% of `nexus:gaps` entries (1759/4059) silently drained** with no Telegram alert.

This PR applies the 4-LLM brainstorm (Codex + Gemini + DeepSeek) verdict: **Option C — Anti-Corruption Layer**. Discovery: `gap_legacy.py` already implements one, it just needed extension.

## Diagnostic chain (read in order)
1. `research/symbiosis/2026-05-16-lifecycle-state-snapshot.md` — full lifecycle state cell/genome/organism
2. `research/symbiosis/2026-05-16-reflection-regression-2026-05-08.md` — 3-layer root cause
3. `research/symbiosis/2026-05-16-dispatch-alias-brainstorm.md` — 4-LLM panel verdict

## Changes (4 sub-fixes, single commit)
- **C.1** Extend `_TRANSLATION` with 3 new (gap_type, attribute) tuples → covers 1582 entries
- **C.3** Add `_PREFIX_TRANSLATION` for `WORKS_AT:<kanim>` → covers remaining 177 entries (100% mapped)
- **C.2** Add unmapped counter + knowledge.db persistence + daily audit script (operator-install plist)
- **C.4** Add 2 explicit DLQ slots (`gap.dlq:phone`, `gap.dlq:profile`) instead of silent drain

## Test plan
- [x] `pytest tests/test_gap_legacy.py tests/test_gap_consumer.py` (43/43 pass)
- [x] Full `pytest tests/` mata-garuda suite (900 passed, 21 skipped, 0 failed)
- [x] `plutil -lint` on new plist (OK)
- [x] `bash -n` on new wrapper script (OK)

## Operator action required AFTER merge (NOT in this PR scope)
1. Restart Docker Desktop + `osint-neo4j` container — gap-detector currently FATAL since 2026-05-10
2. Install daily audit cron manually (chmod 0444 hardened per cicatrix-scars 2026-04-29):
   ```bash
   cp infra/launchagents/com.matagaruda.unmapped-audit.daily.plist ~/Library/LaunchAgents/
   chmod 0444 ~/Library/LaunchAgents/com.matagaruda.unmapped-audit.daily.plist
   launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.matagaruda.unmapped-audit.daily.plist
   ```
3. Add `MATAGARUDA_UNMAPPED_ALERT_THRESHOLD` (optional) to `~/.nuzantara-secrets.env` (default 50)

## Verification after deploy
Once Docker is back + cron tick runs:
- `redis-cli XINFO GROUPS nexus:gaps` should show `lag` decreasing as 1759 previously-drained entries now route to agents
- `sqlite3 apps/mata-garuda/data/knowledge.db "SELECT COUNT(*) FROM knowledge WHERE type='reflection' AND created_at > datetime('now','-24 hours')"` should climb back toward baseline (~7/day)

🤖 Generated with [Claude Code](https://claude.com/claude-code)