### PR TITLE
fix(backend): classify wa mirror event as direct outbox channel

### DIFF
--- a/apps/backend-rag/backend/tests/services/events/test_outbox_callsite_integration.py
+++ b/apps/backend-rag/backend/tests/services/events/test_outbox_callsite_integration.py
@@ -324,6 +324,11 @@ _PG_NOTIFY_ONLY_CHANNELS = frozenset({
     # from legacy "partner.commission_changed" so it passes validate_channel
     # and gets durable replay-on-reconnect via PG_CHANNEL_MAP registration.
     "partner_commission_changed",
+    # whatsapp_message_received: emitted by the external Node wa-mirror bridge
+    # after writing whatsapp_message_context. The bridge writes events_outbox
+    # directly, then sends pg_notify; no DB trigger or migration-146 function
+    # owns this channel.
+    "whatsapp_message_received",
 })
 # Channels that DO have DB triggers but whose triggers live in migrations
 # OTHER than 146. Migration 146 was the bulk refactor of the original 6


### PR DESCRIPTION
## Summary
- exclude whatsapp_message_received from migration 146 trigger coverage
- document that wa-mirror writes events_outbox directly before pg_notify

## Verification
- cd apps/backend-rag && source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && PYTHONPATH=. pytest backend/tests/services/events/test_outbox_callsite_integration.py -q
- cd apps/backend-rag && source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && PYTHONPATH=. pytest backend/tests/unit/services/canva_renderer_v2/test_canva_mcp.py -q
- git diff --check origin/main...HEAD