### PR TITLE
fix(drive+rag): page_token pagination for Drive list + shared ENTITY_PATTERNS

### DIFF
--- a/apps/backend-rag/backend/services/integrations/google_drive_service.py
+++ b/apps/backend-rag/backend/services/integrations/google_drive_service.py
@@ -725,23 +725,31 @@ class GoogleDriveService:
         limit: int = 50,
         offset: int = 0,
         search: str | None = None,
+        page_token: str | None = None,
     ) -> dict[str, Any]:
         """
         List files in a specific folder with pagination and search.
+
+        Supports both cursor-based (page_token) and offset-based pagination.
+        When page_token is provided, offset is ignored and Drive's native
+        cursor pagination is used — avoiding full-scan on large folders.
 
         Args:
             user_id: User ID
             folder_id: Google Drive folder ID
             limit: Max number of files to return (default: 50, max: 200)
-            offset: Offset for pagination
+            offset: Offset for pagination (ignored when page_token is set)
             search: Optional search query (searches in file name)
+            page_token: Drive API page token for cursor-based pagination
 
         Returns:
             {
                 "files": [...],
                 "total": 23,
                 "limit": 50,
-                "offset": 0
+                "offset": 0,
+                "next_page_token": "abc..." | None,
+                "has_more": True | False,
             }
         """
         access_token = await self.get_valid_token(user_id)
@@ -756,16 +764,21 @@ class GoogleDriveService:
             query_parts.append(f"name contains '{safe_search}'")
         query = " and ".join(query_parts)
 
-        # Calculate page token from offset (Drive API uses page tokens, not offset)
-        # For simplicity, we'll fetch all and paginate in memory for now
-        # TODO(#82): Switch to native Drive pageToken pagination (offset is deprecated).
-
-        params = {
+        params: dict[str, Any] = {
             "q": query,
             "fields": "nextPageToken, files(id, name, mimeType, size, modifiedTime, createdTime, webViewLink, thumbnailLink)",
             "orderBy": "folder, name",
-            "pageSize": min(limit + offset, 200),  # Fetch enough to cover offset
+            "pageSize": min(limit, 200),
         }
+
+        if page_token:
+            # Cursor-based: one Drive page, no in-memory scan
+            params["pageToken"] = page_token
+        else:
+            # Offset-based fallback: fetch enough rows to apply offset in memory.
+            # Capped at 200 (Drive API max) — callers with large offsets should
+            # switch to cursor-based via the next_page_token in the response.
+            params["pageSize"] = min(limit + offset, 200)
 
         client = self._get_client()
         response = await client.get(
@@ -783,11 +796,13 @@ class GoogleDriveService:
 
         data = response.json()
         files = data.get("files", [])
+        next_page_token: str | None = data.get("nextPageToken")
 
-        # Apply offset and limit in memory
-        paginated_files = files[offset : offset + limit]
+        if page_token:
+            paginated_files = files
+        else:
+            paginated_files = files[offset : offset + limit]
 
-        # Transform files to include proxy URLs
         transformed_files = []
         for file_info in paginated_files:
             file_id = file_info.get("id")
@@ -809,10 +824,11 @@ class GoogleDriveService:
 
         return {
             "files": transformed_files,
-            "total": len(files),  # Total available (may be more than returned)
+            "total": len(files),
             "limit": limit,
-            "offset": offset,
-            "has_more": len(files) > offset + limit,
+            "offset": 0 if page_token else offset,
+            "next_page_token": next_page_token,
+            "has_more": next_page_token is not None or (not page_token and len(files) > offset + limit),
         }
 
     async def get_folder_structure(

--- a/apps/backend-rag/backend/tests/unit/core/test_embeddings.py
+++ b/apps/backend-rag/backend/tests/unit/core/test_embeddings.py
@@ -263,6 +263,7 @@ class TestEmbeddingsGenerator:
         mock_st.return_value = mock_transformer
 
         generator = EmbeddingsGenerator(provider="sentence-transformers")
+        await generator.clear_cache()  # prevent cache hit masking the error
         with pytest.raises(Exception, match="Encoding error"):
             await generator.generate_embeddings(["test"])
 

--- a/apps/backend-rag/backend/tests/unit/services/integrations/test_google_drive_service.py
+++ b/apps/backend-rag/backend/tests/unit/services/integrations/test_google_drive_service.py
@@ -471,6 +471,39 @@ class TestListFolderFiles:
         assert result["files"][0]["size_bytes"] == 1024
         assert result["files"][1]["is_folder"] is True
 
+    async def test_cursor_pagination_uses_page_token(self):
+        """When page_token is provided, Drive pageToken param is sent and result uses cursor."""
+        svc, _, _ = _make_service()
+        svc.get_valid_token = AsyncMock(return_value="token")
+        mock_client = AsyncMock()
+        mock_client.is_closed = False
+        mock_client.get.return_value = _make_mock_response(200, {
+            "files": [{"id": "f3", "name": "c.pdf", "mimeType": "application/pdf", "size": "512", "modifiedTime": "2026-01-01", "createdTime": "2026-01-01"}],
+            "nextPageToken": "cursor-next",
+        })
+        svc._client = mock_client
+        result = await svc.list_folder_files("user-1", "folder-1", limit=50, page_token="cursor-abc")
+        # pageToken must appear in the params sent to Drive
+        call_params = mock_client.get.call_args[1]["params"]
+        assert call_params.get("pageToken") == "cursor-abc"
+        assert result["next_page_token"] == "cursor-next"
+        assert result["has_more"] is True
+        assert result["files"][0]["id"] == "f3"
+
+    async def test_no_page_token_returns_none_when_no_more(self):
+        """Without page_token and no more data, next_page_token is None and has_more False."""
+        svc, _, _ = _make_service()
+        svc.get_valid_token = AsyncMock(return_value="token")
+        mock_client = AsyncMock()
+        mock_client.is_closed = False
+        mock_client.get.return_value = _make_mock_response(200, {
+            "files": [{"id": "f1", "name": "a.pdf", "mimeType": "application/pdf", "size": "100", "modifiedTime": "2026-01-01", "createdTime": "2026-01-01"}],
+        })
+        svc._client = mock_client
+        result = await svc.list_folder_files("user-1", "folder-1", limit=10, offset=0)
+        assert result["next_page_token"] is None
+        assert result["has_more"] is False
+
 
 @pytest.mark.asyncio
 class TestUploadFileToFolder:


### PR DESCRIPTION
## Summary

- **fix(drive)**: `list_folder_files` now accepts `page_token` for native Drive cursor pagination, avoiding full-scan on large folders (resolves #82). Backward-compatible — `offset` still works.
- **refactor(rag)**: Extracts `ENTITY_PATTERNS` into `backend/services/rag/entity_patterns.py` as single source of truth (resolves #81). `kg_auto_expansion.py` imports from it; eliminates try/except inline duplication + 4 parity tests.

## Test plan

- [ ] `TestListFolderFiles` — 3 new tests: offset-based, cursor-based, no-more
- [ ] `test_entity_patterns.py` — 4 parity tests including `_KG_PATTERNS is ENTITY_PATTERNS` identity check
- [ ] All pre-commit checks pass
- [ ] CI green

Closes #81, #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)