### PR TITLE
fix(mata-garuda): shellout LHKPN scraping to OSINT-Nexus after KPK portal migration

### DIFF
--- a/apps/mata-garuda/mata_garuda/agents/lhkpn_harvester.py
+++ b/apps/mata-garuda/mata_garuda/agents/lhkpn_harvester.py
@@ -2,11 +2,20 @@
 Mata Garuda — LHKPN Harvester Agent.
 
 Harvests Indonesian state officials' wealth declarations from
-antv.kpk.go.id/elhkpn/. Closes 4 of 8 gap types from the gap detector:
+``elhkpn.kpk.go.id`` (KPK migrated from ``antv.kpk.go.id`` on 2026-04-26
+to a SPA + reCAPTCHA v3 portal — see
+``research/2026-05-16-lhkpn-flow-triage.md``).
+
+Closes 4 of 8 gap types from the gap detector:
 - gap.missing_nip
 - gap.missing_lhkpn
 - gap.missing_angkatan
 - gap.stale_official (when the staleness is on LHKPN-related fields)
+
+The actual portal interaction lives in OSINT-Nexus
+(``osint_nexus.scrapers.lhkpn``); this agent shells out to it via
+``mata_garuda.tools.lhkpn_tools`` to keep the Mata Garuda runtime free
+of heavy browser/playwright dependencies (CLAUDE.md §1).
 
 Layer: 1 (Harvester)
 
@@ -60,11 +69,12 @@ def harvest_lhkpn_for_nip(nip: str) -> dict[str, Any]:
 
     fields = {
         "title": title,
-        "url": (
-            f"https://antv.kpk.go.id/elhkpn/index.php/searchpenyelenggara/"
-            f"profilelhkpn/{nip}"
-        ),
-        "source": "antv.kpk.go.id",
+        # Portal migrated 2026-04-26: antv.kpk.go.id is NXDOMAIN; the
+        # post-migration SPA at elhkpn.kpk.go.id has no per-NIP deep
+        # link, so we point at the search root and let consumers
+        # cross-reference via the NIP in `content`.
+        "url": "https://elhkpn.kpk.go.id/",
+        "source": "elhkpn.kpk.go.id",
         "source_type": "lhkpn",
         "content": content,
         "agent": "lhkpn_harvester",
@@ -116,7 +126,8 @@ def get_lhkpn_harvester(model: str = "claude") -> Agent:
         return """You are the LHKPN Harvester agent for Mata Garuda intelligence hub.
 
 Your mission: given a person's name or NIP, fetch their wealth declaration from
-antv.kpk.go.id and publish to the garuda:raw Redis Stream.
+elhkpn.kpk.go.id (the post-2026-04-26 KPK e-Announcement portal) and
+publish to the garuda:raw Redis Stream.
 
 WORKFLOW:
 1. If you have a NIP, call harvest_lhkpn_for_nip(nip)
@@ -125,17 +136,18 @@ WORKFLOW:
 4. On failure → call case_not_resolved with the reason
 
 CONSTRAINTS (from GENOME.md):
-- Source: https://antv.kpk.go.id/elhkpn/
-- Rate limit: 10 req/min (6s between calls — handled in tools)
-- User-Agent rotation on 403 (handled in tools)
+- Source: https://elhkpn.kpk.go.id/ (SPA + reCAPTCHA v3)
+- Rate limit: 10 req/min (6s between calls — handled by OSINT-Nexus scraper)
+- reCAPTCHA token injected by OSINT-Nexus browser-core (no UA rotation needed)
+- Scraping is delegated via subprocess to osint_nexus.cli.lhkpn_scrape
 - Maximum 1 person per gap (avoid flooding)
 - NEVER export data outside Mata Garuda (OSINT blindato)
 - All data goes to garuda:raw Redis Stream only
 
 ERROR HANDLING:
-- Empty profile → case_not_resolved with "NIP not found or HTTP failure"
+- Empty profile → case_not_resolved with "NIP not found or scraper failure"
 - No search results → case_not_resolved with "no search results for {name}"
-- 3 consecutive 403s → escalate to meta-agent (handled in tools)
+- Scraper timeout / reCAPTCHA failure → escalate via reflection
 """
 
     return Agent(

--- a/apps/mata-garuda/mata_garuda/tools/lhkpn_tools.py
+++ b/apps/mata-garuda/mata_garuda/tools/lhkpn_tools.py
@@ -1,29 +1,63 @@
 """
 Mata Garuda — LHKPN scraping tools.
 
-Targets antv.kpk.go.id/elhkpn/ — Indonesian state officials' wealth
-declarations. Tools are pure functions where possible; HTTP calls are
-isolated for testability.
+Targets the KPK e-Announcement portal for Indonesian state officials'
+wealth declarations. As of 2026-04-26 KPK decommissioned
+``antv.kpk.go.id`` (NXDOMAIN) and migrated to ``elhkpn.kpk.go.id`` with
+reCAPTCHA v3 gating + a SPA UI. Programmatic access via ``curl`` is no
+longer possible.
 
-Reference: docs/superpowers/specs/2026-04-14-organism-nervous-system-design.md §5
-GENOME constraints: max 10 req/min, User-Agent rotation, fallback on 403.
+To stay within the Mata Garuda stack ceiling (only ``pydantic`` and
+``pytest`` are allowed runtime deps — see ``apps/mata-garuda/CLAUDE.md``
+§1 "Stack minimale"), this module no longer talks to the portal
+directly. Instead it shells out to the OSINT-Nexus scraper which already
+implements the new flow (browser-core + reCAPTCHA token injection + PDF
+auto-download). This preserves Symbiosis Law 2 ("OSINT data stays on
+Pro, no cloud egress") because OSINT-Nexus is a separate Pro-local
+package and the subprocess is a localhost-only ``python -m`` invocation.
 
-No httpx — uses subprocess + curl (Mata Garuda only allows pydantic + pytest).
+Reference: ``research/2026-05-16-lhkpn-flow-triage.md`` (FIX-1).
+GENOME constraints (max 10 req/min, UA rotation, fallback on 403) are
+now enforced inside the OSINT-Nexus scraper.
+
+The module deliberately keeps the legacy pure parsers
+(``parse_lhkpn_search_html``, ``parse_lhkpn_profile_html``,
+``LHKPN_USER_AGENTS``) intact so the existing unit-test suite
+(``tests/test_lhkpn_tools.py``) continues to pass. They are dead code
+for the new flow but cheap insurance if the portal ever exposes
+HTML-renderable views again.
 """
 from __future__ import annotations
 
+import json as _json
 import logging
+import os
 import re
 import subprocess
-import time
 from typing import Any
-from urllib.parse import quote_plus
 
 logger = logging.getLogger("mata_garuda.tools.lhkpn")
 
 
-LHKPN_BASE_URL = "https://antv.kpk.go.id/elhkpn"
-LHKPN_RATE_LIMIT_S = 6  # 10 req/min = 6s between requests
+# ── New portal config ──────────────────────────────────────────────────
+
+LHKPN_BASE_URL = "https://elhkpn.kpk.go.id"  # post-2026-04-26 migration
+LHKPN_RATE_LIMIT_S = 6  # 10 req/min — kept for parity, enforced by OSINT-Nexus
+
+# OSINT-Nexus subprocess wiring. The defaults assume a standard Pro
+# layout; both can be overridden via environment to keep the path out of
+# source for prod packaging or to point at a worktree during dev.
+OSINT_NEXUS_PYTHON = os.environ.get(
+    "OSINT_NEXUS_PYTHON",
+    "/Users/nuzantara/Desktop/OSINT-Nexus/.venv/bin/python",
+)
+OSINT_NEXUS_MODULE = os.environ.get(
+    "OSINT_NEXUS_MODULE", "osint_nexus.cli.lhkpn_scrape"
+)
+# Hard cap. The scraper boots a Chromium context (~3s) and the portal
+# adds ~10s for reCAPTCHA + ~30s for the PDF auto-download timer; allow
+# headroom for slow runs but cap to prevent gap_consumer from hanging.
+OSINT_NEXUS_TIMEOUT_S = int(os.environ.get("OSINT_NEXUS_TIMEOUT_S", "180"))
 
 LHKPN_USER_AGENTS = [
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36 "
@@ -36,12 +70,16 @@ LHKPN_USER_AGENTS = [
 
 
 # ── Pure parsers (no I/O, easy to test) ────────────────────────────────
+# Kept verbatim from the curl-based implementation so the existing
+# pytest suite remains green and we retain a fallback path if KPK ever
+# re-exposes server-rendered HTML.
 
 
 def parse_lhkpn_search_html(html: str) -> list[dict[str, Any]]:
-    """Extract search results from antv.kpk.go.id search page.
+    """Extract search results from a legacy server-rendered search page.
 
     Returns list of dicts with: nama, nip, jabatan, report_year.
+    Used by the test suite; not invoked by the live shellout path.
     """
     table_match = re.search(
         r'<table[^>]*id="resultsTable"[^>]*>(.*?)</table>',
@@ -67,7 +105,7 @@ def parse_lhkpn_search_html(html: str) -> list[dict[str, Any]]:
 
 
 def parse_lhkpn_profile_html(html: str) -> dict[str, Any]:
-    """Extract profile fields from antv.kpk.go.id detail page."""
+    """Extract profile fields from a legacy server-rendered detail page."""
 
     def get_span(span_id: str) -> str:
         m = re.search(
@@ -112,95 +150,202 @@ def _parse_idr(s: str) -> int:
     return int(digits) if digits else 0
 
 
-# ── HTTP wrappers (effectful — invoked by the agent) ───────────────────
+# ── Shellout to OSINT-Nexus (effectful — invoked by the agent) ─────────
 
 
-def _http_get_with_rotation(
-    url: str,
-    timeout: int = 15,
-    user_agent_index: int = 0,
-) -> tuple[int, str]:
-    """GET via curl with User-Agent rotation. Returns (status_code, body).
+def _invoke_osint_nexus(
+    *,
+    mode: str,
+    query: str | None = None,
+    nip: str | None = None,
+    download_pdf: bool = True,
+) -> dict[str, Any]:
+    """Run the OSINT-Nexus LHKPN scraper as a subprocess.
 
-    Returns (0, "") on transport failure.
+    Returns a dict with the same shape as the CLI emits. On any error
+    (timeout, missing CLI, non-zero exit) returns a dict with
+    ``ok=False`` and a non-empty ``error`` string — never raises.
+
+    Exit-code mapping (see ``osint_nexus/cli/lhkpn_scrape.py``):
+        0 ok          → returned as-is
+        1 transient   → ok=False, error="recaptcha_failed_retry_later"
+        2 not_found   → ok=False, error="no_results"
+        3 fatal       → ok=False, error="subprocess_fatal:..."
     """
-    ua = LHKPN_USER_AGENTS[user_agent_index % len(LHKPN_USER_AGENTS)]
-    cmd = [
-        "curl", "-sS", "-L",  # follow redirects
-        "--max-time", str(timeout),
-        "-w", "\\n%{http_code}",
-        "-H", f"User-Agent: {ua}",
-        "-H", "Accept-Language: id-ID,id;q=0.9,en;q=0.7",
-        "-H", "Accept: text/html,application/xhtml+xml",
-        url,
-    ]
+    cmd: list[str] = [OSINT_NEXUS_PYTHON, "-m", OSINT_NEXUS_MODULE, "--mode", mode]
+    if nip is not None:
+        cmd.extend(["--nip", nip])
+    elif query is not None:
+        cmd.extend(["--query", query])
+    else:
+        return {
+            "ok": False,
+            "error": "neither query nor nip provided",
+            "records": [],
+            "profile": None,
+            "pdf_paths": [],
+        }
+    if not download_pdf:
+        cmd.append("--no-download-pdf")
+
     try:
         result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=timeout + 5,
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=OSINT_NEXUS_TIMEOUT_S,
         )
     except subprocess.TimeoutExpired:
-        logger.warning("LHKPN curl timeout %s", url)
-        return 0, ""
-    except Exception as e:
-        logger.warning("LHKPN curl exception %s: %s", url, e)
-        return 0, ""
+        logger.warning(
+            "OSINT-Nexus LHKPN scraper timed out after %ds (mode=%s, query=%r, nip=%r)",
+            OSINT_NEXUS_TIMEOUT_S, mode, query, nip,
+        )
+        return {
+            "ok": False,
+            "error": f"scraper_timeout_{OSINT_NEXUS_TIMEOUT_S}s",
+            "records": [],
+            "profile": None,
+            "pdf_paths": [],
+        }
+    except FileNotFoundError:
+        logger.error(
+            "OSINT-Nexus CLI not found at %s (set OSINT_NEXUS_PYTHON env var)",
+            OSINT_NEXUS_PYTHON,
+        )
+        return {
+            "ok": False,
+            "error": f"osint_nexus_cli_not_found:{OSINT_NEXUS_PYTHON}",
+            "records": [],
+            "profile": None,
+            "pdf_paths": [],
+        }
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("OSINT-Nexus shellout raised unexpectedly")
+        return {
+            "ok": False,
+            "error": f"shellout_exception:{type(exc).__name__}:{exc}",
+            "records": [],
+            "profile": None,
+            "pdf_paths": [],
+        }
 
-    if result.returncode != 0:
-        logger.warning("LHKPN curl exit %d: %s", result.returncode, result.stderr.strip())
-        return 0, ""
-
-    output = result.stdout
-    nl = output.rfind("\n")
-    if nl == -1:
-        return 0, ""
-
-    body = output[:nl]
+    # The CLI always emits valid JSON on stdout, even on non-zero exit.
+    # Parse defensively: if stdout is corrupt we still want to surface
+    # the exit code rather than crash the caller.
+    stdout = (result.stdout or "").strip()
+    if not stdout:
+        return {
+            "ok": False,
+            "error": (
+                f"empty_stdout exit={result.returncode} "
+                f"stderr={result.stderr.strip()[:200]}"
+            ),
+            "records": [],
+            "profile": None,
+            "pdf_paths": [],
+        }
     try:
-        status = int(output[nl + 1:].strip())
-    except ValueError:
-        return 0, ""
+        payload: dict[str, Any] = _json.loads(stdout)
+    except _json.JSONDecodeError as exc:
+        return {
+            "ok": False,
+            "error": (
+                f"invalid_json_from_cli:{exc} exit={result.returncode} "
+                f"stdout_head={stdout[:200]}"
+            ),
+            "records": [],
+            "profile": None,
+            "pdf_paths": [],
+        }
 
-    return status, body
+    # Trust the CLI's `ok` flag for the success path. If the CLI exited
+    # non-zero AND the payload is missing `ok`, synthesise a failure so
+    # callers don't see a half-populated dict.
+    if "ok" not in payload:
+        payload["ok"] = result.returncode == 0
+        payload.setdefault("error", f"missing_ok_flag exit={result.returncode}")
+
+    return payload
 
 
 def scrape_lhkpn_search(query: str) -> list[dict[str, Any]]:
-    """Search LHKPN by name. Honors rate limit + UA rotation on 403."""
-    url = (
-        f"{LHKPN_BASE_URL}/index.php/searchpenyelenggara/searchpencarian"
-        f"?q={quote_plus(query)}"
-    )
+    """Search LHKPN by free-text name.
 
-    for attempt in range(len(LHKPN_USER_AGENTS)):
-        time.sleep(LHKPN_RATE_LIMIT_S)
-        status, body = _http_get_with_rotation(url, user_agent_index=attempt)
-        if status == 200:
-            return parse_lhkpn_search_html(body)
-        if status == 403:
-            logger.warning("LHKPN search 403 attempt %d — rotating UA", attempt + 1)
-            continue
-        logger.error("LHKPN search non-200/403: status=%d", status)
+    Returns list[dict] with keys ``nama, nip, jabatan, report_year`` to
+    preserve the legacy contract consumed by ``lhkpn_harvester``. The
+    new portal does NOT expose NIP in the search-row payload (see the
+    cell layout in ``osint_nexus/scrapers/lhkpn.py``). For backward
+    compatibility we set ``nip=""`` and surface the additional 2026
+    fields under ``_raw`` for callers that want them.
+
+    Returns ``[]`` on any failure path (no_results, transient, fatal).
+    """
+    payload = _invoke_osint_nexus(mode="search", query=query)
+    if not payload.get("ok"):
+        # Logged at the appropriate level inside _invoke_osint_nexus.
         return []
 
-    logger.error("LHKPN search exhausted UA rotation for query=%s", query)
-    return []
+    records = payload.get("records") or []
+    out: list[dict[str, Any]] = []
+    for r in records:
+        out.append({
+            "nama": r.get("nama", ""),
+            # Portal no longer returns NIP in the row — caller may need
+            # to derive it from another source (CSV, KG, prior reflection).
+            "nip": "",
+            "jabatan": r.get("jabatan", ""),
+            "report_year": str(r.get("tahun_data", "")),
+            "_raw": r,
+        })
+    return out
 
 
 def scrape_lhkpn_profile(nip: str) -> dict[str, Any]:
-    """Fetch detail page for a NIP. Honors rate limit + UA rotation on 403."""
-    url = (
-        f"{LHKPN_BASE_URL}/index.php/searchpenyelenggara/profilelhkpn/{nip}"
-    )
+    """Fetch the LHKPN profile keyed by NIP.
 
-    for attempt in range(len(LHKPN_USER_AGENTS)):
-        time.sleep(LHKPN_RATE_LIMIT_S)
-        status, body = _http_get_with_rotation(url, user_agent_index=attempt)
-        if status == 200:
-            return parse_lhkpn_profile_html(body)
-        if status == 403:
-            logger.warning("LHKPN profile 403 attempt %d — rotating UA", attempt + 1)
-            continue
-        logger.error("LHKPN profile non-200/403: status=%d", status)
+    Returns a dict with the legacy-shape keys
+    ``nama, nip, jabatan, angkatan, total_harta_idr, properties_count,
+    vehicles_count, accounts_count`` consumed by ``lhkpn_harvester``.
+    The new portal does not expose ``angkatan`` or per-asset row counts
+    in the search index (counts require parsing the downloaded PDF
+    via ``osint_nexus.parsers.lhkpn_parser`` — out of scope here), so
+    those fields are returned as the empty string / ``0`` rather than
+    fabricated.
+
+    Returns ``{}`` on any failure path so that the caller's
+    ``if not profile`` check still works.
+
+    Caveat (post-2026-04-26 portal migration)
+    -----------------------------------------
+    The new SPA only accepts free-text NAMES in its search field; NIK
+    queries return zero rows because the portal does not index NIPs in
+    the visible search index. Calling this function with a NIP that has
+    no corresponding name lookup will return ``{}`` (empty profile).
+    The healthy path is now ``scrape_lhkpn_search(name)`` followed by
+    selecting a hit; the lhkpn_harvester agent already prefers
+    ``harvest_lhkpn_by_name`` when a name is available. See
+    ``research/2026-05-16-lhkpn-flow-triage.md`` AIL-1/AIL-2 for the
+    longer-term remedy (CSV→name resolver upstream of this call).
+    """
+    # We forward the NIP as both the search query AND the canonical NIP
+    # echoed back in `profile.nip`. The CLI's `profile` mode then
+    # normalises the first hit to the legacy profile shape; if the
+    # portal returns no rows the CLI exits 2 → we surface {}.
+    payload = _invoke_osint_nexus(mode="profile", nip=nip)
+    if not payload.get("ok"):
         return {}
 
-    logger.error("LHKPN profile exhausted UA rotation for nip=%s", nip)
-    return {}
+    profile = payload.get("profile") or {}
+    if not profile:
+        return {}
+    # Defensive copy — strip the OSINT-Nexus-specific `_raw` blob so
+    # callers and tests that snapshot the legacy keys don't accidentally
+    # depend on it.
+    legacy = {k: profile.get(k) for k in (
+        "nama", "nip", "jabatan", "angkatan",
+        "total_harta_idr", "properties_count",
+        "vehicles_count", "accounts_count",
+    )}
+    if "_raw" in profile:
+        legacy["_raw"] = profile["_raw"]
+    return legacy

--- a/apps/mata-garuda/tests/test_lhkpn_harvester.py
+++ b/apps/mata-garuda/tests/test_lhkpn_harvester.py
@@ -34,7 +34,9 @@ def test_harvest_by_nip_publishes_to_garuda_raw():
     assert stream == "garuda:raw"
     assert fields["agent"] == "lhkpn_harvester"
     assert "Budi Santoso" in fields["title"]
-    assert fields["source"] == "antv.kpk.go.id"
+    # Portal migrated 2026-04-26: antv.kpk.go.id is NXDOMAIN, KPK now
+    # serves at elhkpn.kpk.go.id (see research/2026-05-16-lhkpn-flow-triage.md).
+    assert fields["source"] == "elhkpn.kpk.go.id"
     assert fields["source_type"] == "lhkpn"
 
 


### PR DESCRIPTION
## Summary

- KPK decommissioned `antv.kpk.go.id` ~2026-04-26 → migrated to `elhkpn.kpk.go.id` with reCAPTCHA v3 + SPA UI.
- `apps/mata-garuda/mata_garuda/tools/lhkpn_tools.py` had `LHKPN_BASE_URL = "https://antv.kpk.go.id/elhkpn"` hardcoded — silently failing since 2026-05-08 (last successful publish to `garuda:raw`); the agent's own reflection on 2026-05-12 records the NXDOMAIN+reCAPTCHA detection but cannot self-fix per Symbiosis §1.4.
- This PR shells out from mata-garuda to a new OSINT-Nexus CLI (`osint_nexus.cli.lhkpn_scrape`, separate companion branch on the OSINT-Nexus tree) which already implements the new portal flow via browser-core + reCAPTCHA v3 token injection.

Preserves:
- **Symbiosis Law 2** — OSINT data stays on Pro, no cloud egress (the subprocess is a localhost `python -m` invocation).
- **Mata Garuda CLAUDE.md §1 "stack minimale"** — no playwright / browser-core / heavy deps added to mata-garuda; runtime stays at `pydantic + pytest`.
- **Legacy public API** — `scrape_lhkpn_search`/`scrape_lhkpn_profile` keep the same signature; the four pure parsers used by the test suite are kept verbatim. Blast radius on `lhkpn_harvester` and other call sites is zero apart from the source-attribution string (`source: antv.kpk.go.id` → `source: elhkpn.kpk.go.id`).

## Triage

[`research/2026-05-16-lhkpn-flow-triage.md`](research/2026-05-16-lhkpn-flow-triage.md) — full root-cause analysis (KPK migration timeline, reCAPTCHA v3 evidence, end-to-end flow status table, three FIX options, three AIL items).

This PR implements **FIX-1**.

## Test plan

- [x] **Unit tests** — `PYTHONPATH=apps/mata-garuda pytest tests/test_lhkpn_tools.py tests/test_lhkpn_harvester.py` → 17/17 passed (one assertion updated for new source attribution).
- [x] **Direct OSINT-Nexus CLI smoke** — `python -m osint_nexus.cli.lhkpn_scrape --query "Raja Ulul Azmi" --mode profile --no-download-pdf` → exit 0 in ~16s, profile.total_harta_idr = `2.409.000.000` IDR (matches CSV "ALREADY DONE" entry for Raja Ulul Azmi Syahwali, 2022).
- [x] **End-to-end mata-garuda shellout smoke** — `from mata_garuda.tools.lhkpn_tools import scrape_lhkpn_search; scrape_lhkpn_search('Raja Ulul Azmi')` → 6 hits in ~86s with default `--download-pdf`; 6 PDFs (~870KB total) written to `OSINT-Nexus RAW_DIR/lhkpn/pdfs/`.
- [ ] **Post-merge re-enable** — `launchctl kickstart gui/$(id -u)/com.matagaruda.gap.consumer` and watch the next `gap.missing_lhkpn` dispatch via `knowledge.db` reflections (manual, owner: Antonello).

## Out of scope (separate AIL items, see triage report §4)

- **AIL-1 (resolved here)** — chose option (a) thin shellout CLI to OSINT-Nexus, in line with Symbiosis §1 "LLM CLI-only".
- **AIL-2** — bootstrap Officials in Neo4j. The `gap_detector.officials_missing_lhkpn` Cypher query currently returns 0 because the graph is empty; even with this fix, no `gap.missing_lhkpn` would be dispatched until Officials are seeded.
- **AIL-3** — cleanup the 101 `gap.orphan_org` entries in PEL `gap-consumer` (`regulation_watcher` not registered). Pure noise, not LHKPN.
- The `harvest_lhkpn_for_nip` direct path is documented as a known limitation under the new portal: the SPA does not index NIPs in its search field, so NIP-only lookups fail. The healthy path is `harvest_lhkpn_by_name`. A CSV→name resolver upstream of this call is the long-term remedy (also AIL-2 territory).

## Companion branch (OSINT-Nexus side)

`feature/lhkpn-cli-entrypoint-2026-05-16` on `mini-bare` (Tailscale bare repo, no GitHub mirror). Adds `osint_nexus/cli/lhkpn_scrape.py` (~292 LOC, exit-code conventions: 0 ok / 1 transient / 2 not_found / 3 fatal; explicit browser close + `os._exit` to avoid the atexit-deadlock observed during smoke testing).

## Blast radius

- 3 files changed (Nuzantara): `lhkpn_tools.py` (~+220/-100), `lhkpn_harvester.py` (~+15/-10), `test_lhkpn_harvester.py` (1-line assertion update).
- 2 files changed (OSINT-Nexus, separate commit): new `osint_nexus/cli/lhkpn_scrape.py`, `pyproject.toml` `[project.scripts]` entry.
- No DB migration, no plist change, no cron schedule change.
- Existing `lhkpn_harvester` agent registration unchanged; gap_consumer / gap_detector untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)