### PR TITLE
fix(lint): rename ambiguous variable l (E741) + fix Zod v4 invalid_type_error

### DIFF
--- a/apps/backend-rag/backend/tests/unit/scripts/test_fix_lkpm_q1_2026_client_ids.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_fix_lkpm_q1_2026_client_ids.py
@@ -9,15 +9,12 @@ Tests for scripts/fix_lkpm_q1_2026_client_ids.py
 
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
-
 from scripts.fix_lkpm_q1_2026_client_ids import (
     KNOWN_FAKE_FOUNDER_IDS,
     make_decision,
     pick_director_from_links,
     resolve_and_fix,
 )
-
 
 # =====================================================================
 # Helpers
@@ -60,8 +57,8 @@ class _FakeRecord(dict):
     def __getattr__(self, name: str):
         try:
             return self[name]
-        except KeyError:
-            raise AttributeError(name)
+        except KeyError as exc:
+            raise AttributeError(name) from exc
 
 
 def _make_pool_for_fix(
@@ -77,7 +74,7 @@ def _make_pool_for_fix(
             return [_FakeRecord(row) for row in lkpm_rows]
         if "client_company_links" in sql:
             company_id = args[0]
-            return [_FakeRecord(l) for l in links_by_company.get(company_id, [])]
+            return [_FakeRecord(link) for link in links_by_company.get(company_id, [])]
         return []
 
     conn.fetch = fake_fetch

--- a/apps/backend-rag/scripts/fix_lkpm_q1_2026_client_ids.py
+++ b/apps/backend-rag/scripts/fix_lkpm_q1_2026_client_ids.py
@@ -76,7 +76,7 @@ def pick_director_from_links(
         return None
 
     # Filter out fake founders
-    filtered = [l for l in links if l["client_id"] not in fake_founder_ids]
+    filtered = [lnk for lnk in links if lnk["client_id"] not in fake_founder_ids]
     if not filtered:
         return None
 
@@ -188,7 +188,7 @@ async def resolve_and_fix(
             company_id = row_dict["client_id"]
 
             links_raw = await conn.fetch(_LINKS_FOR_COMPANY_QUERY, company_id)
-            links = [dict(l) for l in links_raw]
+            links = [dict(lnk) for lnk in links_raw]
 
             picked = pick_director_from_links(links)
             decision = make_decision(row_dict, picked)

--- a/apps/backend-rag/scripts/ingest_tier1_gaps.py
+++ b/apps/backend-rag/scripts/ingest_tier1_gaps.py
@@ -168,12 +168,12 @@ async def run_ingestion(
     # Apply filters
     laws = TIER1_LAWS
     if domain_filter:
-        laws = [l for l in laws if l["domain"] == domain_filter.lower()]
+        laws = [law for law in laws if law["domain"] == domain_filter.lower()]
         if not laws:
             logger.error("No laws for domain: '%s'. Valid: property, immigration, tax", domain_filter)
             return
     if file_filter:
-        laws = [l for l in laws if file_filter.lower() in l["filename"].lower()]
+        laws = [law for law in laws if file_filter.lower() in law["filename"].lower()]
         if not laws:
             logger.error("No files matching: '%s'", file_filter)
             return

--- a/apps/backend-rag/scripts/kbli_enrichment_pipeline.py
+++ b/apps/backend-rag/scripts/kbli_enrichment_pipeline.py
@@ -544,11 +544,11 @@ def call_gemini_cli(system: str, user_prompt: str, timeout: int = 120) -> str:
     # Strip CLI noise lines (Keychain errors, MCP logs) — keep only JSON
     lines = result.stdout.splitlines()
     clean = "\n".join(
-        l for l in lines
-        if not l.startswith("Keychain") and not l.startswith("Using") and
-           not l.startswith("Loaded") and not l.startswith("Server") and
-           not l.startswith("Scheduling") and not l.startswith("Executing") and
-           not l.startswith("MCP")
+        line for line in lines
+        if not line.startswith("Keychain") and not line.startswith("Using") and
+           not line.startswith("Loaded") and not line.startswith("Server") and
+           not line.startswith("Scheduling") and not line.startswith("Executing") and
+           not line.startswith("MCP")
     ).strip()
     return clean
 

--- a/apps/backend-rag/scripts/kg_populate_property_tax.py
+++ b/apps/backend-rag/scripts/kg_populate_property_tax.py
@@ -788,7 +788,7 @@ async def _extract_with_ollama(
     if cleaned.startswith("```"):
         lines = cleaned.split("\n")
         # Remove first line (```json) and last line (```)
-        lines = [l for l in lines if not l.strip().startswith("```")]
+        lines = [line for line in lines if not line.strip().startswith("```")]
         cleaned = "\n".join(lines)
 
     try:

--- a/apps/cell/cell/effectors/logs_effector.py
+++ b/apps/cell/cell/effectors/logs_effector.py
@@ -93,8 +93,8 @@ class LogsEffector:
                     )
 
                 # Extract ERROR/WARN lines for summary
-                errors = [l for l in lines if any(kw in l.upper() for kw in ("ERROR", "CRITICAL", "EXCEPTION", "TRACEBACK"))]
-                warns = [l for l in lines if "WARN" in l.upper() and l not in errors]
+                errors = [line for line in lines if any(kw in line.upper() for kw in ("ERROR", "CRITICAL", "EXCEPTION", "TRACEBACK"))]
+                warns = [line for line in lines if "WARN" in line.upper() and line not in errors]
 
                 if errors:
                     summary = f"{len(errors)} errors in last {len(lines)} lines: {errors[0][:120]}"

--- a/apps/cell/cell/fast/log_anomaly.py
+++ b/apps/cell/cell/fast/log_anomaly.py
@@ -120,7 +120,7 @@ def scan_watched_paths(
         # `exit code [1-9]` is the canonical cron-agent failure marker that
         # the plain regex in detect_anomaly() might miss when it is the only
         # signal in the file — pick it up explicitly.
-        has_exit_failure = any(_EXIT_CODE_RE.search(l) for l in lines)
+        has_exit_failure = any(_EXIT_CODE_RE.search(line) for line in lines)
 
         if per_file.critical_keywords:
             report.anomaly = True

--- a/apps/evaluator/core_guardian/scout.py
+++ b/apps/evaluator/core_guardian/scout.py
@@ -178,7 +178,7 @@ def run_mypy() -> dict:
             cwd=str(BACKEND_DIR), timeout=180,
             env=build_test_env(),
         )
-        lines = [l for l in result.stdout.splitlines() if l.strip()]
+        lines = [line for line in result.stdout.splitlines() if line.strip()]
         errors = len(lines)
         return {"errors": errors, "output": result.stdout[:2000], "status": "ok" if errors == 0 else "failed"}
     except FileNotFoundError:
@@ -206,7 +206,7 @@ def run_vulture() -> dict:
             cwd=str(BACKEND_DIR), timeout=120,
             env=build_test_env(),
         )
-        lines = [l for l in result.stdout.splitlines() if l.strip()]
+        lines = [line for line in result.stdout.splitlines() if line.strip()]
         dead = len(lines)
         return {"dead_code": dead, "output": result.stdout[:2000], "status": "ok" if dead == 0 else "found"}
     except FileNotFoundError:

--- a/apps/evaluator/core_guardian/surgeon.py
+++ b/apps/evaluator/core_guardian/surgeon.py
@@ -267,7 +267,7 @@ def enforce_diff_limits(worktree_path: Path) -> str | None:
             )
 
         # Conta file modificati
-        diff_lines = [l for l in result.stdout.strip().split("\n") if l.strip() and "|" in l]
+        diff_lines = [line for line in result.stdout.strip().split("\n") if line.strip() and "|" in line]
         files_changed = len(diff_lines)
         if files_changed > MAX_FILES_PER_COMMIT:
             return f"Too many files changed: {files_changed} > {MAX_FILES_PER_COMMIT}"

--- a/apps/evaluator/nlm_deep_research/db_nlm_templates.py
+++ b/apps/evaluator/nlm_deep_research/db_nlm_templates.py
@@ -202,7 +202,7 @@ def render_practices_pipeline(
         for status, count in status_map.items():
             trend_lines.append(_delta_line(f"  {status}", count, prev_map.get(status, 0)))
         # Anomaly summary
-        anomalies = [l for l in trend_lines if "ANOMALIA" in l]
+        anomalies = [line for line in trend_lines if "ANOMALIA" in line]
         trend_section = f"""
 ## Confronto Settimana Precedente
 {chr(10).join(trend_lines)}

--- a/apps/evaluator/nlm_deep_research/tests/test_verify_ingestion.py
+++ b/apps/evaluator/nlm_deep_research/tests/test_verify_ingestion.py
@@ -45,7 +45,7 @@ def test_verify_ingestion_happy_path(tmp_path, monkeypatch):
             text_idx = cmd.index("--text") + 1
             text = cmd[text_idx]
             # marker is the 12-char hex after "Query marker:"
-            marker_line = [l for l in text.splitlines() if "Query marker:" in l][0]
+            marker_line = [line for line in text.splitlines() if "Query marker:" in line][0]
             captured_marker["m"] = marker_line.split("Query marker:")[1].strip().rstrip(".")
             return _fake_completed(stdout=f"Source ID: fake-src-id\n✓ Added")
         if cmd[1] == "notebook" and cmd[2] == "query":

--- a/apps/mata-garuda/mata_garuda/agents/daily_briefing_agent.py
+++ b/apps/mata-garuda/mata_garuda/agents/daily_briefing_agent.py
@@ -79,7 +79,7 @@ def _xrevrange(stream: str, count: int = 200) -> list[dict[str, Any]]:
         return []
 
     items: list[dict[str, Any]] = []
-    lines = [l for l in raw.split("\n") if l.strip()]
+    lines = [line for line in raw.split("\n") if line.strip()]
     i = 0
     while i < len(lines):
         line = lines[i].strip()

--- a/apps/mouth/src/lib/api/crm/crm.schemas.ts
+++ b/apps/mouth/src/lib/api/crm/crm.schemas.ts
@@ -32,7 +32,7 @@ export const leadSourceEnum = z.enum([
 // Practice type codes are now loaded dynamically from the backend catalog
 // (69 services across 9 categories). Validate as non-empty string.
 export const practiceTypeCodeEnum = z
-  .string({ invalid_type_error: "Service type is required" })
+  .string({ error: "Service type is required" })
   .min(1, "Service type is required");
 
 export const practiceStatusEnum = z.enum([
@@ -163,7 +163,7 @@ export type CreateClientOutput = z.output<typeof createClientSchema>;
 export const createPracticeSchema = z
   .object({
     client_id: z
-      .number({ invalid_type_error: "Client is required" })
+      .number({ error: "Client is required" })
       .positive("Invalid client ID"),
     practice_type_code: practiceTypeCodeEnum,
     status: practiceStatusEnum.default("inquiry"),

--- a/apps/organism/organism/actuators/cleanup_zombie_plist.py
+++ b/apps/organism/organism/actuators/cleanup_zombie_plist.py
@@ -46,7 +46,7 @@ class CleanupZombiePlist(ActuatorBase):
         return {
             "would_remove_count": len(zombies),
             "would_remove": [
-                {"path": str(p), "label": l} for p, l in zombies
+                {"path": str(p), "label": lbl} for p, lbl in zombies
             ],
         }
 

--- a/scripts/system_doctor.py
+++ b/scripts/system_doctor.py
@@ -570,8 +570,8 @@ def collect_cron_agent_logs() -> list[SystemCheck]:
         lines = text.splitlines()
         tail = lines[-200:] if len(lines) > 200 else lines
         matches = [
-            l for l in tail
-            if CRON_AGENT_ERROR_RE.search(l) or CRON_AGENT_EXIT_CODE_RE.search(l)
+            line for line in tail
+            if CRON_AGENT_ERROR_RE.search(line) or CRON_AGENT_EXIT_CODE_RE.search(line)
         ]
 
         if matches:
@@ -820,8 +820,8 @@ def collect_fly_resources() -> list[SystemCheck]:
         )
         if result.returncode == 0:
             oom_lines = [
-                l for l in result.stdout.splitlines()
-                if any(k in l.lower() for k in ["oom", "out of memory", "killed", "sigkill"])
+                line for line in result.stdout.splitlines()
+                if any(k in line.lower() for k in ["oom", "out of memory", "killed", "sigkill"])
             ]
             if oom_lines:
                 checks.append(SystemCheck(
@@ -893,8 +893,8 @@ def collect_llm_api_health() -> list[SystemCheck]:
             lines = result.stdout.splitlines()
             # Count recent LLM errors
             llm_errors = [
-                l for l in lines
-                if any(k in l for k in [
+                line for line in lines
+                if any(k in line for k in [
                     "Circuit breaker", "OPENED",
                     "All LLM models failed",
                     "Quota exhausted",
@@ -902,7 +902,7 @@ def collect_llm_api_health() -> list[SystemCheck]:
                     "ServiceUnavailable",
                 ])
             ]
-            circuit_opens = [l for l in llm_errors if "OPENED" in l]
+            circuit_opens = [line for line in llm_errors if "OPENED" in line]
 
             if circuit_opens:
                 checks.append(SystemCheck(
@@ -1202,7 +1202,7 @@ def _parse_log_section(sys_id: str, name: str, group: str, text: str) -> SystemC
         return SystemCheck(id=sys_id, name=name, group=group,
                            status="warning", message="Log file empty or missing")
 
-    lines = [l.strip() for l in text.splitlines() if l.strip()]
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
     if not lines:
         return SystemCheck(id=sys_id, name=name, group=group,
                            status="warning", message="No log entries")

--- a/scripts/tests/test_docs_audit.py
+++ b/scripts/tests/test_docs_audit.py
@@ -182,10 +182,10 @@ def test_idempotent(aged_fixture):
     _run_audit(aged_fixture, *common)
     first = (aged_fixture / "docs" / "DOCS_INVENTORY.md").read_text()
     # Strip timestamp line; body must be identical
-    first_body = "\n".join(l for l in first.splitlines() if "Last run:" not in l)
+    first_body = "\n".join(line for line in first.splitlines() if "Last run:" not in line)
     _run_audit(aged_fixture, *common)
     second = (aged_fixture / "docs" / "DOCS_INVENTORY.md").read_text()
-    second_body = "\n".join(l for l in second.splitlines() if "Last run:" not in l)
+    second_body = "\n".join(line for line in second.splitlines() if "Last run:" not in line)
     assert first_body == second_body
 
 


### PR DESCRIPTION
## Summary

- Renames loop variable `l` (ruff E741 — ambiguous, looks like `1` or `I`) to descriptive alternatives (`line`, `lnk`, `law`, `lbl`) across **15 files** in apps/backend-rag, apps/cell, apps/evaluator, apps/mata-garuda, apps/organism, and scripts/
- Fixes pre-existing TypeScript error in `apps/mouth/src/lib/api/crm/crm.schemas.ts`: replaces Zod v3 `invalid_type_error` with Zod v4 `error` parameter (2 occurrences — blocked typecheck on every PR touching mouth)
- Fixes pre-existing ruff issues in `backend/tests/unit/scripts/test_fix_lkpm_q1_2026_client_ids.py`: I001 import order, F401 unused import, B904 exception chaining

All changes are pure renames / API-version updates with no logic change. Pre-push suite: **13399 passed, 808 skipped**.

## Test plan

- [x] `python3 -m ruff check apps/ scripts/ packages/ --select E741,E731` → All checks passed
- [x] `npm run typecheck -w apps/mouth` → clean
- [x] Pre-push suite 13399/0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)