### PR TITLE
fix(lint): auto-fix W291/W293 trailing whitespace + Zod v4 invalid_type_error

### DIFF
--- a/apps/backend-rag/backend/services/rag/kg_graph_nodes.py
+++ b/apps/backend-rag/backend/services/rag/kg_graph_nodes.py
@@ -21,8 +21,8 @@ from typing import Any
 import asyncpg
 from langchain_core.messages import HumanMessage, SystemMessage
 from langsmith import traceable
-from pydantic import BaseModel, Field, ValidationError
 from prometheus_client import Counter, Histogram
+from pydantic import BaseModel, Field, ValidationError
 
 from backend.services.rag.kg_graph_state import KGAgentState
 
@@ -178,19 +178,19 @@ Return ONLY a JSON object:
             ),
             timeout=30.0,
         )
-        
+
         # Aggiornamento stato con Pydantic model
         state["intent"] = parsed_result.intent
         state["extracted_entities"] = parsed_result.entities
-        
+
         # Store domain for routing decisions
         domain = parsed_result.domain if parsed_result.domain else domain_hints.get("domain", "general")
         state["domain"] = domain
-        
+
         # Update user_context with citizenship and domain
         state["user_context"]["citizenship"] = parsed_result.citizenship
         state["user_context"]["domain"] = domain
-        
+
         logger.info(
             f"✅ [Understand Query] Intent: {state['intent']}, "
             f"Domain: {domain}, "

--- a/apps/backend-rag/backend/services/rag/kg_langgraph_orchestrator.py
+++ b/apps/backend-rag/backend/services/rag/kg_langgraph_orchestrator.py
@@ -16,6 +16,7 @@ from typing import Any
 
 import asyncpg
 from langgraph.graph import END, StateGraph
+from prometheus_client import Counter, Histogram
 
 from backend.services.rag.kg_graph_nodes import (
     kg_checkpoint_operations_total,
@@ -31,8 +32,6 @@ from backend.services.rag.kg_subgraph_company import build_company_subgraph
 from backend.services.rag.kg_subgraph_property import build_property_subgraph
 from backend.services.rag.kg_subgraph_tax import build_tax_subgraph
 from backend.services.rag.kg_subgraph_visa import build_visa_subgraph
-
-from prometheus_client import Counter, Histogram
 
 logger = logging.getLogger(__name__)
 
@@ -211,7 +210,7 @@ def route_after_query_understanding(state: KGAgentState) -> str:
         "company": "company_subgraph",
         "kbli": "company_subgraph",
     }
-    
+
     if domain in domain_to_subgraph:
         target = domain_to_subgraph[domain]
         logger.info(f"📍 [Router] Domain='{domain}', routing strictly to {target}")

--- a/apps/bali-intel-scraper/config/settings.py
+++ b/apps/bali-intel-scraper/config/settings.py
@@ -68,7 +68,7 @@ class DatabaseConfig:
                 pool_timeout=int(os.getenv("DB_POOL_TIMEOUT", "30")),
                 pool_recycle=int(os.getenv("DB_POOL_RECYCLE", "1800")),
             )
-        
+
         return cls(
             host=os.getenv("DB_HOST", "localhost"),
             port=int(os.getenv("DB_PORT", "5432")),

--- a/apps/bali-intel-scraper/scripts/claude_cli_enricher.py
+++ b/apps/bali-intel-scraper/scripts/claude_cli_enricher.py
@@ -153,7 +153,7 @@ def enrich_article_claude_cli(article: Dict[str, Any]) -> Dict[str, Any]:
         Dict with enrichment data
     """
     logger.info(f"Enriching: {article.get('title', 'Unknown')[:50]}...")
-    
+
     # Extract NLM context if available (from step 2.9)
     nlm_ctx = article.get('nlm_context') or {}
     nlm_legal = nlm_ctx.get('legal_basis', '')
@@ -178,15 +178,15 @@ def enrich_article_claude_cli(article: Dict[str, Any]) -> Dict[str, Any]:
         nlm_legal_basis=nlm_legal,
         nlm_web_findings=nlm_web,
     )
-    
+
     try:
         # Call Claude Code CLI
         logger.info("Calling Claude Code CLI...")
-        
+
         # Remove ANTHROPIC_API_KEY from environment to use OAuth
         env = os.environ.copy()
         env.pop('ANTHROPIC_API_KEY', None)
-        
+
         # Use absolute path so launchd (limited PATH) can find claude
         import shutil
         claude_bin = shutil.which('claude') or '/Users/nuzantara/.local/bin/claude'
@@ -199,21 +199,21 @@ def enrich_article_claude_cli(article: Dict[str, Any]) -> Dict[str, Any]:
             check=True,
             env=env
         )
-        
+
         output = result.stdout.strip()
         logger.info(f"Claude response: {len(output)} chars")
-        
+
         # Parse JSON from response
         # Claude might wrap in markdown code blocks, strip those
         if '```json' in output:
             output = output.split('```json')[1].split('```')[0].strip()
         elif '```' in output:
             output = output.split('```')[1].split('```')[0].strip()
-        
+
         # Try to find JSON object
         json_start = output.find('{')
         json_end = output.rfind('}') + 1
-        
+
         if json_start >= 0 and json_end > json_start:
             json_str = output[json_start:json_end]
             enriched = json.loads(json_str)
@@ -237,7 +237,7 @@ def enrich_article_claude_cli(article: Dict[str, Any]) -> Dict[str, Any]:
                 'error': 'No valid JSON in response',
                 'raw_response': output
             }
-            
+
     except subprocess.TimeoutExpired:
         logger.error("Claude CLI timeout (180s)")
         return {
@@ -278,18 +278,18 @@ def batch_enrich_articles(articles: list[Dict[str, Any]], max_articles: int = No
     """
     if max_articles:
         articles = articles[:max_articles]
-    
+
     logger.info(f"Batch enriching {len(articles)} articles...")
-    
+
     enriched_articles = []
     success_count = 0
     error_count = 0
-    
+
     for i, article in enumerate(articles, 1):
         logger.info(f"\n[{i}/{len(articles)}] Processing: {article.get('title', 'Unknown')[:50]}")
-        
+
         result = enrich_article_claude_cli(article)
-        
+
         if result['success']:
             success_count += 1
             enriched_articles.append({
@@ -303,13 +303,13 @@ def batch_enrich_articles(articles: list[Dict[str, Any]], max_articles: int = No
                 **article,
                 'enrichment_error': result.get('error')
             })
-    
+
     logger.info(f"\n{'='*60}")
     logger.info("BATCH COMPLETE")
     logger.info(f"  Success: {success_count}/{len(articles)}")
     logger.info(f"  Errors:  {error_count}/{len(articles)}")
     logger.info(f"{'='*60}")
-    
+
     return enriched_articles
 
 
@@ -327,19 +327,19 @@ if __name__ == "__main__":
         Immigration officials stated this change aims to attract high-skilled foreign talent and 
         boost the digital economy.'''
     }
-    
+
     print("="*60)
     print("TEST: Claude CLI Enricher")
     print("="*60)
     print()
-    
+
     result = enrich_article_claude_cli(test_article)
-    
+
     print("\n" + "="*60)
     print("RESULT:")
     print("="*60)
     print(json.dumps(result, indent=2, ensure_ascii=False))
-    
+
     if result['success']:
         print("\n🎉 TEST PASSED")
         sys.exit(0)

--- a/apps/bali-intel-scraper/scripts/force_publish_today.py
+++ b/apps/bali-intel-scraper/scripts/force_publish_today.py
@@ -22,7 +22,7 @@ async def main():
     logger.info(f"Trovati {len(enriched_articles)} articoli arricchiti da pubblicare.")
 
     headers = {"X-API-Key": API_KEY, "Content-Type": "application/json"}
-    
+
     async with httpx.AsyncClient(timeout=60.0) as client:
         for idx, article in enumerate(enriched_articles):
             # First submit to staging
@@ -30,7 +30,7 @@ async def main():
             content = enr.get("the_facts", "") + "\n\n" + enr.get("bali_zero_take", "")
             if not content.strip():
                 content = enr.get("executive_brief", article.get("text", ""))[:8000]
-                
+
             payload = {
                 "title": enr.get("headline", article.get("title", "")),
                 "content": content,
@@ -41,15 +41,15 @@ async def main():
             }
             if idx < 3:
                 payload["main_news_position"] = idx + 1
-            
+
             logger.info(f"Publishing {idx+1}/{len(enriched_articles)}: {payload['title'][:50]}...")
-            
+
             r = await client.post(f"{BACKEND_URL}/api/intel/scraper/submit", json=payload, headers=headers)
             if r.status_code in (200, 201):
                 res_data = r.json()
                 item_id = res_data.get("item_id")
                 intel_type = res_data.get("intel_type", "news")
-                
+
                 if item_id:
                     # Then force publish
                     pub_r = await client.post(f"{BACKEND_URL}/api/intel/staging/publish/{intel_type}/{item_id}", json={}, headers=headers)
@@ -59,7 +59,7 @@ async def main():
                         logger.error(f"❌ Failed to publish {item_id}: {pub_r.text}")
             else:
                 logger.error(f"❌ Failed to submit: {r.text}")
-            
+
             await asyncio.sleep(7) # Rate limit
 
 if __name__ == "__main__":

--- a/apps/bali-intel-scraper/scripts/load_intel_sources.py
+++ b/apps/bali-intel-scraper/scripts/load_intel_sources.py
@@ -36,14 +36,14 @@ async def create_collection(client: QdrantClient):
     """Crea la collezione se non esiste."""
     collections = client.get_collections().collections
     exists = any(c.name == COLLECTION_NAME for c in collections)
-    
+
     if exists:
         logger.info(f"⚠️ Collezione '{COLLECTION_NAME}' già esistente - cancello e ricreo")
         client.delete_collection(COLLECTION_NAME)
         exists = False
-    
+
     logger.info(f"🛠️ Creazione collezione '{COLLECTION_NAME}'...")
-    
+
     client.create_collection(
         collection_name=COLLECTION_NAME,
         vectors_config={
@@ -63,34 +63,34 @@ async def create_collection(client: QdrantClient):
             full_scan_threshold=10000,
         ),
     )
-    
+
     # Indici payload
     logger.info("📑 Creazione indici payload...")
-    
+
     client.create_payload_index(
         collection_name=COLLECTION_NAME,
         field_name="category_key",
         field_schema=models.PayloadSchemaType.KEYWORD,
     )
-    
+
     client.create_payload_index(
         collection_name=COLLECTION_NAME,
         field_name="tier",
         field_schema=models.PayloadSchemaType.KEYWORD,
     )
-    
+
     client.create_payload_index(
         collection_name=COLLECTION_NAME,
         field_name="authority",
         field_schema=models.PayloadSchemaType.KEYWORD,
     )
-    
+
     client.create_payload_index(
         collection_name=COLLECTION_NAME,
         field_name="url",
         field_schema=models.PayloadSchemaType.KEYWORD,
     )
-    
+
     logger.success("✅ Collezione creata!")
     return True
 
@@ -112,20 +112,20 @@ async def load_sources():
     logger.info(f"   Collection: {COLLECTION_NAME}")
     logger.info(f"   URL: {QDRANT_URL}")
     logger.info("=" * 60)
-    
+
     # 1. Carica JSON
     if not SOURCES_FILE.exists():
         logger.error(f"❌ File non trovato: {SOURCES_FILE}")
         return
-    
+
     with open(SOURCES_FILE, 'r', encoding='utf-8') as f:
         data = json.load(f)
-    
+
     total_sources = data.get('total_sources', 0)
     logger.info(f"📚 Fonti da caricare: {total_sources}")
     logger.info(f"📂 Categorie: {data.get('total_categories', 0)}")
     print()
-    
+
     # 2. Connessione Qdrant
     qdrant_client = QdrantClient(
         url=QDRANT_URL,
@@ -133,22 +133,22 @@ async def load_sources():
         timeout=30,
         prefer_grpc=False,
     )
-    
+
     # 3. Crea collezione
     await create_collection(qdrant_client)
     print()
-    
+
     # 4. Connessione OpenAI
     openai_client = AsyncOpenAI(api_key=OPENAI_API_KEY)
-    
+
     # 5. Prepara dati per upload
     logger.info("🔄 Generazione embeddings...")
     points = []
     point_id = 0
-    
+
     for category_key, category_data in tqdm(data['categories'].items(), desc="Categorie"):
         category_name = category_data.get('name', category_key)
-        
+
         for source in tqdm(category_data.get('sources', []), desc=f"  {category_name}", leave=False):
             # Testo per embedding
             text_for_embedding = f"""
@@ -158,14 +158,14 @@ Description: {source.get('description', '')}
 Authority: {source.get('authority', '')}
 URL: {source.get('url', '')}
             """.strip()
-            
+
             # Genera embedding
             try:
                 embedding = await generate_embedding(text_for_embedding, openai_client)
             except Exception as e:
                 logger.warning(f"⚠️ Errore embedding per {source.get('name')}: {e}")
                 continue
-            
+
             # Payload
             payload = {
                 "name": source.get('name'),
@@ -179,19 +179,19 @@ URL: {source.get('url', '')}
                 "category_priority": category_data.get('priority', ''),
                 "indexed_at": datetime.now().isoformat(),
             }
-            
+
             point = models.PointStruct(
                 id=point_id,
                 vector={"default": embedding},
                 payload=payload
             )
-            
+
             points.append(point)
             point_id += 1
-    
+
     # 6. Upload batch
     logger.info(f"⬆️ Upload {len(points)} punti a Qdrant...")
-    
+
     BATCH_SIZE = 100
     for i in tqdm(range(0, len(points), BATCH_SIZE), desc="Upload batches"):
         batch = points[i:i+BATCH_SIZE]
@@ -200,30 +200,30 @@ URL: {source.get('url', '')}
             points=batch,
             wait=True
         )
-    
+
     logger.success("✅ Upload completato!")
-    
+
     # 7. Verifica
     collection_info = qdrant_client.get_collection(COLLECTION_NAME)
     logger.info(f"📊 Punti nella collezione: {collection_info.points_count}")
-    
+
     # 8. Test retrieval
     logger.info("🔍 Test retrieval...")
     test_query = "Immigration visa regulations Indonesia"
     test_embedding = await generate_embedding(test_query, openai_client)
-    
+
     search_result = qdrant_client.query_points(
         collection_name=COLLECTION_NAME,
         query=test_embedding,
         using="default",
         limit=5
     )
-    
+
     logger.info(f"   Query: '{test_query}'")
     logger.info(f"   Top {len(search_result.points)} risultati:")
     for i, point in enumerate(search_result.points, 1):
         logger.info(f"      {i}. {point.payload['name']} (score: {point.score:.3f})")
-    
+
     logger.success("🎉 Caricamento completato con successo!")
 
 

--- a/apps/bali-intel-scraper/scripts/load_intel_sources_streaming.py
+++ b/apps/bali-intel-scraper/scripts/load_intel_sources_streaming.py
@@ -34,13 +34,13 @@ async def create_collection(client: QdrantClient):
     """Crea collezione."""
     collections = client.get_collections().collections
     exists = any(c.name == COLLECTION_NAME for c in collections)
-    
+
     if exists:
         logger.warning(f"⚠️ Cancello collezione esistente")
         client.delete_collection(COLLECTION_NAME)
-    
+
     logger.info(f"🛠️ Creazione collezione...")
-    
+
     client.create_collection(
         collection_name=COLLECTION_NAME,
         vectors_config={
@@ -58,12 +58,12 @@ async def create_collection(client: QdrantClient):
             ef_construct=100,
         ),
     )
-    
+
     # Indici
     client.create_payload_index(COLLECTION_NAME, "category_key", models.PayloadSchemaType.KEYWORD)
     client.create_payload_index(COLLECTION_NAME, "tier", models.PayloadSchemaType.KEYWORD)
     client.create_payload_index(COLLECTION_NAME, "url", models.PayloadSchemaType.KEYWORD)
-    
+
     logger.success("✅ Collezione creata!")
 
 
@@ -103,16 +103,16 @@ async def load_sources_streaming():
     logger.info(f"   Batch size: {BATCH_SIZE}")
     logger.info(f"   Timeout: {TIMEOUT}s")
     logger.info("=" * 60)
-    
+
     # Carica JSON
     with open(SOURCES_FILE, 'r', encoding='utf-8') as f:
         data = json.load(f)
-    
+
     total_sources = data.get('total_sources', 0)
     logger.info(f"📚 Fonti: {total_sources}")
     logger.info(f"📂 Categorie: {data.get('total_categories', 0)}")
     print()
-    
+
     # Client Qdrant con timeout aumentato
     qdrant_client = QdrantClient(
         url=QDRANT_URL,
@@ -120,29 +120,29 @@ async def load_sources_streaming():
         timeout=TIMEOUT,
         prefer_grpc=False,
     )
-    
+
     # Crea collezione
     await create_collection(qdrant_client)
     print()
-    
+
     # Client OpenAI
     openai_client = AsyncOpenAI(api_key=OPENAI_API_KEY)
-    
+
     # Streaming upload
     logger.info("🔄 Inizio upload streaming...")
-    
+
     point_id = 0
     batch = []
     uploaded = 0
     failed = 0
     start_time = time.time()
-    
+
     for category_key, category_data in data['categories'].items():
         category_name = category_data.get('name', category_key)
         sources = category_data.get('sources', [])
-        
+
         logger.info(f"📁 {category_name}: {len(sources)} fonti")
-        
+
         for source in sources:
             # Genera embedding
             try:
@@ -153,9 +153,9 @@ Description: {source.get('description', '')}
 Authority: {source.get('authority', '')}
 URL: {source.get('url', '')}
                 """.strip()
-                
+
                 embedding = await generate_embedding(text_for_embedding, openai_client)
-                
+
                 # Payload
                 payload = {
                     "name": source.get('name'),
@@ -167,7 +167,7 @@ URL: {source.get('url', '')}
                     "category_name": category_name,
                     "indexed_at": datetime.now().isoformat(),
                 }
-                
+
                 # Aggiungi al batch
                 point = models.PointStruct(
                     id=point_id,
@@ -176,7 +176,7 @@ URL: {source.get('url', '')}
                 )
                 batch.append(point)
                 point_id += 1
-                
+
                 # Upload batch quando raggiunge dimensione target
                 if len(batch) >= BATCH_SIZE:
                     success = await upload_batch_with_retry(qdrant_client, batch)
@@ -188,14 +188,14 @@ URL: {source.get('url', '')}
                     else:
                         failed += len(batch)
                         logger.error(f"   ✗ Batch fallito ({failed} totali)")
-                    
+
                     batch = []
-                
+
             except Exception as e:
                 logger.warning(f"⚠️ Errore per {source.get('name')}: {e}")
                 failed += 1
                 continue
-    
+
     # Upload batch rimanente
     if batch:
         success = await upload_batch_with_retry(qdrant_client, batch)
@@ -203,7 +203,7 @@ URL: {source.get('url', '')}
             uploaded += len(batch)
         else:
             failed += len(batch)
-    
+
     # Report finale
     elapsed = time.time() - start_time
     logger.success("=" * 60)
@@ -212,26 +212,26 @@ URL: {source.get('url', '')}
     logger.success(f"   Falliti: {failed}")
     logger.success(f"   Tempo: {elapsed:.1f}s ({uploaded/elapsed:.1f}/s)")
     logger.success("=" * 60)
-    
+
     # Verifica
     info = qdrant_client.get_collection(COLLECTION_NAME)
     logger.info(f"📊 Punti in collezione: {info.points_count}")
-    
+
     # Test retrieval
     if info.points_count > 0:
         logger.info("🔍 Test query...")
         test_embedding = await generate_embedding("Immigration visa Indonesia", openai_client)
-        
+
         result = qdrant_client.query_points(
             collection_name=COLLECTION_NAME,
             query=test_embedding,
             using="default",
             limit=3
         )
-        
+
         for i, point in enumerate(result.points, 1):
             logger.info(f"   {i}. {point.payload['name']} ({point.score:.3f})")
-    
+
     logger.success("🎉 COMPLETATO CON SUCCESSO!")
 
 

--- a/apps/bali-intel-scraper/scripts/rule_based_deduplicator.py
+++ b/apps/bali-intel-scraper/scripts/rule_based_deduplicator.py
@@ -18,18 +18,18 @@ class RuleBasedDeduplicator:
     Layer 2: Normalized title hash (O(1))
     Layer 3: Keyword overlap + date proximity (O(n) but n=100)
     """
-    
+
     def __init__(self, registry_path: str = "data/published_articles.json"):
         self.registry_path = Path(registry_path)
         self.registry = self.load_registry()
-        
+
         # Stopwords (common words to ignore)
         self.stopwords = {
-            'the', 'a', 'an', 'in', 'on', 'at', 'to', 'for', 'of', 'and', 
+            'the', 'a', 'an', 'in', 'on', 'at', 'to', 'for', 'of', 'and',
             'or', 'but', 'is', 'are', 'was', 'were', 'has', 'have', 'had',
             'this', 'that', 'these', 'those', 'from', 'with', 'as', 'by'
         }
-        
+
         # Key immigration/visa terms for NER-like extraction
         self.key_terms = {
             'kitas', 'kitap', 'visa', 'evisa', 'voa', 'golden', 'digital',
@@ -37,7 +37,7 @@ class RuleBasedDeduplicator:
             'imigrasi', 'extend', 'extension', 'second', 'home', 'indonesia',
             'bali', 'jakarta', 'passport', 'residence', 'stay'
         }
-    
+
     def load_registry(self) -> Dict:
         """Load published articles registry"""
         if not self.registry_path.exists():
@@ -47,14 +47,14 @@ class RuleBasedDeduplicator:
                 "recent_100": [],
                 "all_articles": []
             }
-        
+
         with open(self.registry_path) as f:
             data = json.load(f)
             # Convert lists to sets for O(1) lookup
             data["urls"] = set(data.get("urls", []))
             data["title_hashes"] = set(data.get("title_hashes", []))
             return data
-    
+
     def save_registry(self):
         """Save registry back to disk"""
         # Convert sets back to lists for JSON
@@ -63,10 +63,10 @@ class RuleBasedDeduplicator:
             "urls": list(self.registry["urls"]),
             "title_hashes": list(self.registry["title_hashes"])
         }
-        
+
         with open(self.registry_path, 'w') as f:
             json.dump(data, f, indent=2)
-    
+
     def normalize_hash(self, title: str) -> str:
         """
         Normalize title to hash
@@ -85,7 +85,7 @@ class RuleBasedDeduplicator:
         # Hash
         text = ' '.join(words)
         return hashlib.md5(text.encode()).hexdigest()
-    
+
     def extract_keywords(self, title: str) -> Set[str]:
         """
         Extract key terms from title (NER-like, no ML)
@@ -96,12 +96,12 @@ class RuleBasedDeduplicator:
         words = set(title.lower().split())
         # Find intersection with key terms
         keywords = words & self.key_terms
-        
+
         # Also extract numbers (visa years, percentages, etc.)
         numbers = {w for w in words if w.isdigit() or '%' in w}
-        
+
         return keywords | numbers
-    
+
     def calculate_keyword_overlap(self, keywords1: Set[str], keywords2: Set[str]) -> float:
         """
         Calculate Jaccard similarity between keyword sets
@@ -111,12 +111,12 @@ class RuleBasedDeduplicator:
         """
         if not keywords1 or not keywords2:
             return 0.0
-        
+
         intersection = len(keywords1 & keywords2)
         union = len(keywords1 | keywords2)
-        
+
         return intersection / union if union > 0 else 0.0
-    
+
     def is_duplicate(self, article: Dict) -> Tuple[bool, str, float]:
         """
         Check if article is duplicate
@@ -135,40 +135,40 @@ class RuleBasedDeduplicator:
         # Layer 1: Exact URL match
         if article['url'] in self.registry['urls']:
             return True, "Exact URL match", 1.0
-        
+
         # Layer 2: Title hash collision
         title_hash = self.normalize_hash(article['title'])
         if title_hash in self.registry['title_hashes']:
             return True, f"Title hash collision ({title_hash[:8]}...)", 0.95
-        
+
         # Layer 3: Keyword overlap + date proximity
         keywords = self.extract_keywords(article['title'])
         article_date = datetime.fromisoformat(article['published_at'].replace('Z', '+00:00'))
-        
+
         for published in self.registry['recent_100']:
             pub_keywords = set(published.get('keywords', []))
             pub_date = datetime.fromisoformat(published['published_at'].replace('Z', '+00:00'))
-            
+
             # Calculate overlap
             overlap = self.calculate_keyword_overlap(keywords, pub_keywords)
             date_diff = abs((article_date - pub_date).days)
-            
+
             # Decision rules
             if overlap >= 0.8 and date_diff <= 7:
                 # 80%+ overlap within 7 days = very likely duplicate
                 return True, f"80%+ keyword overlap + {date_diff}d proximity (to: {published['title'][:50]}...)", 0.9
-            
+
             if overlap >= 0.7 and date_diff <= 3:
                 # 70%+ overlap within 3 days = likely duplicate
                 return True, f"70%+ keyword overlap + {date_diff}d proximity (to: {published['title'][:50]}...)", 0.85
-            
+
             if overlap >= 0.9 and date_diff <= 30:
                 # 90%+ overlap within 30 days = same story different angle?
                 return True, f"90%+ keyword overlap + {date_diff}d proximity (to: {published['title'][:50]}...)", 0.8
-        
+
         # Not a duplicate
         return False, "Unique article", 0.0
-    
+
     def add_published_article(self, article: Dict):
         """
         Add article to registry after publishing
@@ -185,27 +185,27 @@ class RuleBasedDeduplicator:
         self.registry['urls'].add(article['url'])
         title_hash = self.normalize_hash(article['title'])
         self.registry['title_hashes'].add(title_hash)
-        
+
         # Extract keywords
         keywords = list(self.extract_keywords(article['title']))
-        
+
         # Add to recent_100 (FIFO)
         recent_entry = {
             **article,
             "keywords": keywords,
             "title_hash": title_hash
         }
-        
+
         self.registry['recent_100'].insert(0, recent_entry)
         # Keep only last 100
         self.registry['recent_100'] = self.registry['recent_100'][:100]
-        
+
         # Add to all_articles
         self.registry['all_articles'].append(recent_entry)
-        
+
         # Save
         self.save_registry()
-    
+
     def get_stats(self) -> Dict:
         """Get registry statistics"""
         return {
@@ -220,9 +220,9 @@ class RuleBasedDeduplicator:
 
 def test_deduplicator():
     """Test the deduplicator with example articles"""
-    
+
     dedup = RuleBasedDeduplicator(registry_path="/tmp/test_registry.json")
-    
+
     # Article 1: Original
     article1 = {
         "title": "Indonesia Extends Digital Nomad Visa to 5 Years",
@@ -230,24 +230,24 @@ def test_deduplicator():
         "published_at": "2026-02-15T10:00:00Z",
         "category": "immigration"
     }
-    
+
     is_dup, reason, conf = dedup.is_duplicate(article1)
     print(f"Article 1: {is_dup} - {reason} (confidence: {conf})")
     # Output: False - Unique article (confidence: 0.0)
-    
+
     # Publish it
     dedup.add_published_article(article1)
-    
+
     # Article 2: Exact duplicate (same URL)
     article2 = {
         **article1,
         "title": "Different Title But Same URL"
     }
-    
+
     is_dup, reason, conf = dedup.is_duplicate(article2)
     print(f"Article 2: {is_dup} - {reason} (confidence: {conf})")
     # Output: True - Exact URL match (confidence: 1.0)
-    
+
     # Article 3: Same content, different URL, 1 day later
     article3 = {
         "title": "Digital Nomad Visa Indonesia Extended Five Years",
@@ -255,11 +255,11 @@ def test_deduplicator():
         "published_at": "2026-02-16T10:00:00Z",
         "category": "immigration"
     }
-    
+
     is_dup, reason, conf = dedup.is_duplicate(article3)
     print(f"Article 3: {is_dup} - {reason} (confidence: {conf})")
     # Output: True - 80%+ keyword overlap + 1d proximity (confidence: 0.9)
-    
+
     # Article 4: Different topic
     article4 = {
         "title": "Indonesia Tax Reform: New NPWP Requirements",
@@ -267,11 +267,11 @@ def test_deduplicator():
         "published_at": "2026-02-16T12:00:00Z",
         "category": "tax"
     }
-    
+
     is_dup, reason, conf = dedup.is_duplicate(article4)
     print(f"Article 4: {is_dup} - {reason} (confidence: {conf})")
     # Output: False - Unique article (confidence: 0.0)
-    
+
     # Stats
     print("\nRegistry Stats:")
     print(json.dumps(dedup.get_stats(), indent=2))

--- a/apps/bali-intel-scraper/scripts/run_intel_pipeline.py
+++ b/apps/bali-intel-scraper/scripts/run_intel_pipeline.py
@@ -75,7 +75,7 @@ class IntelPipeline:
         except (PermissionError, OSError):
             self.pipeline_dir = Path('/tmp/intel_pipeline_runs')
             self.pipeline_dir.mkdir(exist_ok=True)
-        
+
         # State tracking
         self.run_id = datetime.now().strftime('%Y%m%d_%H%M%S')
         self.state_file = self.pipeline_dir / f'run_{self.run_id}.json'
@@ -86,19 +86,19 @@ class IntelPipeline:
             'steps': {},
             'articles': []
         }
-    
+
     def log(self, message: str, level: str = 'INFO'):
         """Log with timestamp"""
         timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
         print(f'[{timestamp}] [{level}] {message}')
         sys.stdout.flush()
-    
+
     def save_state(self):
         """Save pipeline state to disk"""
         with open(self.state_file, 'w') as f:
             json.dump(self.state, f, indent=2)
         self.log(f'State saved: {self.state_file.name}')
-    
+
     def update_step_status(self, step: str, status: str, data: Dict = None):
         """Update step status in state"""
         self.state['steps'][step] = {
@@ -107,13 +107,13 @@ class IntelPipeline:
             'data': data or {}
         }
         self.save_state()
-    
+
     def run_step(self, step: str) -> bool:
         """Execute single pipeline step"""
         self.log(f'{"="*60}')
         self.log(f'STEP: {step}')
         self.log(f'{"="*60}')
-        
+
         try:
             if step == '1_scraping':
                 return self.step_scraping()
@@ -146,7 +146,7 @@ class IntelPipeline:
             self.log(f'Step {step} failed: {e}', 'ERROR')
             self.update_step_status(step, 'failed', {'error': str(e)})
             return False
-    
+
     def step_scraping(self) -> bool:
         """Step 1: Scrape articles from sources via UnifiedScraper"""
         self.log('Starting article scraping...')
@@ -161,14 +161,14 @@ class IntelPipeline:
             from unified_scraper import UnifiedScraper
             categories = self.config.get('categories', ['immigration', 'tax', 'business'])
             limit      = self.config.get('limit_per_source', 5)
-            
+
             import asyncio
             scraper    = UnifiedScraper(categories=categories, limit_per_source=limit)
             async def _run_scraper():
                 res = await scraper.scrape_all()
                 await scraper.close()
                 return res
-            
+
             articles   = asyncio.run(_run_scraper())
             self.log(f'Scraped {len(articles)} articles from {scraper.stats.get("sources_processed",0)} sources')
 
@@ -259,7 +259,7 @@ class IntelPipeline:
             self.state['articles'] = self._mock_scraped_articles()
             self.update_step_status('1_scraping', 'failed', {'error': str(e)})
             return False
-    
+
     def step_validation(self) -> bool:
         """Step 2: Validate articles (URL dedup + title similarity dedup)
 
@@ -374,7 +374,7 @@ class IntelPipeline:
             'dupes_history': dupes_history,
         })
         return True
-    
+
     def step_qwen_filter(self) -> bool:
         """Step 2.5: LLM content quality scoring via Ollama (gemma4:26b).
 
@@ -1148,7 +1148,7 @@ class IntelPipeline:
             self.log(f'Enrichment error: {e}', 'ERROR')
             self.update_step_status('3_enrichment', 'failed', {'error': str(e)})
             return False
-    
+
     def _generate_intel_digest(self, enriched: List[Dict], unenriched: List[Dict]) -> Optional[Dict]:
         """Generate a recap article summarizing ALL scraped topics.
 
@@ -1360,7 +1360,7 @@ IMPORTANT:
         self.log(f'Cover images uploaded: {covers_uploaded}/{images_count}')
         self.update_step_status('8_images', 'completed', {'images_generated': images_count, 'covers_uploaded': covers_uploaded})
         return True
-    
+
     def step_seo(self) -> bool:
         """Step 5: SEO optimization via Gemini.
 
@@ -1415,7 +1415,7 @@ IMPORTANT:
             self.update_step_status('5_seo', 'failed', {'error': str(e)})
             # Non-fatal: pipeline continues without SEO
             return True
-    
+
     def step_approval(self) -> bool:
         """Step 6: Save all enriched articles to a review file + notify owner via Telegram.
 
@@ -1695,11 +1695,11 @@ IMPORTANT:
             'review_file': str(review_file),
         })
         return True
-    
+
     def step_publishing(self) -> bool:
         """Step 7: Publish approved articles"""
         self.log('Publishing articles...')
-        
+
         # FIX2: blocca publishing se approval pending
         approval_status = self.state.get('steps', {}).get('6_approval', {}).get('status', '')
         if approval_status == 'pending' and not self.config.get('auto_approve'):
@@ -1711,7 +1711,7 @@ IMPORTANT:
             self.log('Dry run mode - skipping actual publishing')
             self.update_step_status('7_publishing', 'skipped', {'reason': 'dry_run'})
             return True
-        
+
         # Pubblica articoli arricchiti via backend API
         import asyncio as _asyncio
         import httpx as _httpx
@@ -2015,14 +2015,14 @@ IMPORTANT:
                 'tier': 'T1',
             }
         ]
-    
+
     def run(self):
         """Execute full pipeline"""
         self.log(f'Starting Intel Pipeline - Run ID: {self.run_id}')
         self.log(f'Config: {json.dumps(self.config, indent=2)}')
-        
+
         steps_to_run = PIPELINE_STEPS
-        
+
         # Handle resume
         if self.config.get('resume_from'):
             resume_step = self.config['resume_from']
@@ -2030,13 +2030,13 @@ IMPORTANT:
                 idx = steps_to_run.index(resume_step)
                 steps_to_run = steps_to_run[idx:]
                 self.log(f'Resuming from: {resume_step}')
-        
+
         # Handle skip
         if self.config.get('skip_steps'):
             skip = self.config['skip_steps']
             steps_to_run = [s for s in steps_to_run if s not in skip]
             self.log(f'Skipping steps: {skip}')
-        
+
         # Execute pipeline
         for step in steps_to_run:
             success = self.run_step(step)
@@ -2046,11 +2046,11 @@ IMPORTANT:
                 self.state['failed_at'] = step
                 self.save_state()
                 return False
-        
+
         self.state['status'] = 'completed'
         self.state['completed_at'] = datetime.now().isoformat()
         self.save_state()
-        
+
         self.log(f'{"="*60}')
         self.log('PIPELINE COMPLETED')
         self.log(f'{"="*60}')
@@ -2071,7 +2071,7 @@ IMPORTANT:
             self.log(f'⚠️  Salvataggio intel_output_latest.json fallito: {e}', 'WARN')
 
         return True
-    
+
     def print_summary(self):
         """Print pipeline execution summary"""
         print('\n📊 PIPELINE SUMMARY\n')
@@ -2080,22 +2080,22 @@ IMPORTANT:
         print(f'Started: {self.state["started_at"]}')
         if self.state.get('completed_at'):
             print(f'Completed: {self.state["completed_at"]}')
-        
+
         print('\nSteps:')
         for step, data in self.state.get('steps', {}).items():
             status = data.get('status', 'unknown')
             print(f'  {step}: {status}')
-        
+
         print(f'\nState file: {self.state_file}')
 
 
 def main():
     parser = argparse.ArgumentParser(description='Intel Pipeline Orchestrator')
-    
+
     # Mode
     parser.add_argument('--mode', choices=['full', 'dry-run', 'test'], default='full',
                        help='Pipeline execution mode')
-    
+
     # Data selection
     parser.add_argument('--categories', default='immigration,tax,legal',
                        help='Comma-separated categories')
@@ -2103,7 +2103,7 @@ def main():
                        help='Limit articles per source')
     parser.add_argument('--min-score', type=int, default=40,
                        help='Minimum quality score')
-    
+
     # Flow control
     parser.add_argument('--resume-from', choices=PIPELINE_STEPS,
                        help='Resume from specific step')
@@ -2111,7 +2111,7 @@ def main():
                        help='Comma-separated steps to skip')
     parser.add_argument('--continue-on-error', action='store_true',
                        help='Continue pipeline even if step fails')
-    
+
     # Options
     parser.add_argument('--skip-images', action='store_true',
                        help='Skip image generation')
@@ -2142,13 +2142,13 @@ def main():
         'continue_on_error': args.continue_on_error,
         'max_enrich': args.max_enrich,
     }
-    
+
     if args.resume_from:
         config['resume_from'] = args.resume_from
-    
+
     if args.skip_steps:
         config['skip_steps'] = args.skip_steps.split(',')
-    
+
     # Run pipeline
     pipeline = IntelPipeline(config)
     success = pipeline.run()

--- a/apps/bali-intel-scraper/scripts/unified_scraper.py
+++ b/apps/bali-intel-scraper/scripts/unified_scraper.py
@@ -92,10 +92,10 @@ class UnifiedScraper:
             verify=False,
             follow_redirects=True
         )
-    
+
     async def close(self):
         await self.client.aclose()
-        
+
     def load_sources(self) -> List[Dict]:
         with open(SOURCES_FILE, 'r') as f:
             data = json.load(f)
@@ -135,7 +135,7 @@ class UnifiedScraper:
         url = source.get('url')
         if not url:
             return []
-        
+
         logger.info(f'Scraping: {source.get("name", url)[:50]}...')
 
         source_type = source.get('type', 'web')
@@ -153,12 +153,12 @@ class UnifiedScraper:
             feed = None
             if rss_text:
                 feed = await asyncio.to_thread(feedparser.parse, rss_text)
-            
+
             if not (feed and feed.entries) and rss_url != url:
                 rss_text = await self._fetch_rss(url)
                 if rss_text:
                     feed = await asyncio.to_thread(feedparser.parse, rss_text)
-            
+
             if not (feed and feed.entries):
                 try:
                     resp = await self.client.get(url)
@@ -169,7 +169,7 @@ class UnifiedScraper:
                         if discovered.startswith('/'):
                             p = urlparse(url)
                             discovered = f"{p.scheme}://{p.netloc}{discovered}"
-                        
+
                         r_text = await self._fetch_rss(discovered)
                         if r_text:
                             feed = await asyncio.to_thread(feedparser.parse, r_text)
@@ -195,13 +195,13 @@ class UnifiedScraper:
 
             if not articles:
                 logger.warning(f'  ⚠️  No content extracted for {url}')
-        
+
         except Exception as e:
             logger.error(f'  ❌ Error processing {url}: {str(e)[:100]}')
             self.stats['errors'] += 1
-        
+
         return articles
-    
+
     def _extract_from_feed_entry(self, entry, source: Dict) -> Optional[Dict]:
         try:
             return {
@@ -242,7 +242,7 @@ class UnifiedScraper:
                     candidates.append((href, text))
                 if len(candidates) >= self.limit_per_source * 3:
                     break
-            
+
             def parse_article(href, anchor_text):
                 try:
                     art = Article(href)
@@ -311,22 +311,22 @@ class UnifiedScraper:
     def generate_article_id(self, article: Dict) -> str:
         content = f"{article.get('url', '')}{article.get('title', '')}"
         return hashlib.md5(content.encode()).hexdigest()[:16]
-    
+
     async def scrape_all(self) -> List[Dict]:
         logger.info('='*60)
         logger.info('UNIFIED SCRAPER STARTED (ASYNC)')
         logger.info('='*60)
-        
+
         sources = self.load_sources()
         all_articles = []
-        
+
         # Batch sources to avoid overwhelming the network
         batch_size = 20
         for i in range(0, len(sources), batch_size):
             batch = sources[i:i+batch_size]
             tasks = [self.extract_articles_from_source(s) for s in batch]
             results = await asyncio.gather(*tasks)
-            
+
             for source_articles in results:
                 self.stats['sources_processed'] += 1
                 self.stats['articles_found'] += len(source_articles)
@@ -334,15 +334,15 @@ class UnifiedScraper:
                     article['id'] = self.generate_article_id(article)
                     score = self.score_article(article)
                     self.stats['articles_scored'] += 1
-                    
+
                     if score is not None:
                         article['quality_score'] = score
                         if score >= MIN_SCORE:
                             all_articles.append(article)
                             self.stats['articles_passed'] += 1
-        
+
         return all_articles
-    
+
     def save_results(self, articles: List[Dict]):
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
         output_file = OUTPUT_DIR / f'{timestamp}_articles.json'
@@ -355,7 +355,7 @@ class UnifiedScraper:
             json.dump(output, f, indent=2, ensure_ascii=False)
         logger.info(f'\n💾 Saved: {output_file}')
         return output_file
-    
+
     def print_summary(self):
         logger.info('\n' + '='*60)
         logger.info('SCRAPING COMPLETE')
@@ -456,12 +456,12 @@ def main():
     parser.add_argument('--limit', type=int, default=5, help='Limit articles per source')
     parser.add_argument('--min-score', type=int, default=40, help='Minimum quality score')
     args = parser.parse_args()
-    
+
     global MIN_SCORE
     MIN_SCORE = args.min_score
-    
+
     scraper = UnifiedScraper(categories=args.categories.split(','), limit_per_source=args.limit)
-    
+
     async def run():
         articles = await scraper.scrape_all()
         output_file = scraper.save_results(articles)
@@ -469,7 +469,7 @@ def main():
         await scraper.close()
         print(f'\n✅ Output: {output_file}')
         return 0 if articles else 1
-        
+
     return asyncio.run(run())
 
 if __name__ == '__main__':

--- a/apps/evaluator/core_guardian/agent.py
+++ b/apps/evaluator/core_guardian/agent.py
@@ -31,7 +31,7 @@ def load_state() -> dict:
 async def ask_openclaw_opus(prompt: str) -> str:
     """Invoca l'agente 'main' di OpenClaw (Claude Opus 4.6) via CLI in modalità reale."""
     logger.info("Sending request to OpenClaw (Claude Opus 4.6) via CLI...")
-    
+
     try:
         # Usa il comando ufficiale openclaw agent
         cmd = [
@@ -42,31 +42,31 @@ async def ask_openclaw_opus(prompt: str) -> str:
             "--timeout", "600",
             "--json"
         ]
-        
+
         logger.info(f"Executing: openclaw agent --agent main ... (prompt length: {len(prompt)})")
-        
+
         # Esecuzione reale bloccante (può durare fino a 10 minuti per ragionamenti complessi)
         result = subprocess.run(cmd, capture_output=True, text=True, cwd=str(WORKSPACE_DIR))
-        
+
         if result.returncode != 0:
             logger.error(f"OpenClaw execution failed with code {result.returncode}")
             logger.error(f"Stderr: {result.stderr}")
             return ""
-            
+
         # Parse the JSON response
         try:
             output_data = json.loads(result.stdout)
             # Dipende da come OpenClaw formatta il JSON, assumiamo ci sia un campo text/message/content
             content = output_data.get("text", output_data.get("message", output_data.get("content", result.stdout)))
-            
+
             if isinstance(content, dict):
                  content = content.get("text", str(content))
-                 
+
             return content
         except json.JSONDecodeError:
             logger.warning("Could not parse JSON from OpenClaw, returning raw stdout")
             return result.stdout
-            
+
     except Exception as e:
         logger.error(f"Failed to reach OpenClaw CLI: {e}")
         return ""
@@ -74,15 +74,15 @@ async def ask_openclaw_opus(prompt: str) -> str:
 def create_branch_and_apply(target_file: str, response: str) -> bool:
     """Applica la logica su branch isolata e lancia il test."""
     logger.info("Phase 3: ACT. Extracting python code from response...")
-    
+
     # 1. Estrai il blocco di codice Python dalla risposta di Opus
     code_match = re.search(r"```python(.*?)```", response, re.DOTALL)
     if not code_match:
         logger.error("No python code block found in Opus response.")
         return False
-        
+
     code_content = code_match.group(1).strip()
-    
+
     # Per sicurezza in questa prima esecuzione, non modificheremo i test reali,
     # ma salveremo il fix proposto in un file di patch per la tua review.
     # In produzione, l'agente farebbe:
@@ -90,24 +90,24 @@ def create_branch_and_apply(target_file: str, response: str) -> bool:
     # 2. write code to target_file
     # 3. pytest target_file
     # 4. git commit
-    
+
     patch_file = DECISIONS_DIR / f"proposed_fix_for_{target_file.replace('/', '_')}.py"
     with open(patch_file, "w") as f:
         f.write(code_content)
-        
+
     logger.info(f"✅ Extracted patch saved to {patch_file} for human review before applying.")
     return True
 
 async def handle_pytest_failures(traceback: str):
     logger.info("Preparing OpenClaw payload...")
-    
+
     # Cerchiamo di identificare il file del test che sta fallendo
     # Es: backend/tests/test_conversation_persistence.py
     file_match = re.search(r"backend/tests/[^\s:]+\.py", traceback)
     target_file = file_match.group(0) if file_match else "unknown"
-    
+
     logger.info(f"Target file identified: {target_file}")
-    
+
     prompt = f"""
 SEI IL NUZANTARA CORE GUARDIAN.
 Il tuo ruolo è risolvere il debito tecnico nel backend FastAPI autonomamente.
@@ -128,14 +128,14 @@ ISTRUZIONI:
 2. Fornisci il codice python completo o la funzione da sostituire per fixare il test all'interno di un blocco ```python.
 3. Spiega brevemente il ragionamento architetturale sotto il blocco di codice.
 """
-    
+
     response = await ask_openclaw_opus(prompt)
-    
+
     if response:
         logger.info("✅ Received response from Claude Opus 4.6.")
-        
+
         success = create_branch_and_apply(target_file, response)
-        
+
         if success:
             adr_content = f"""# ADR: Auto-Fix per {target_file}
 
@@ -151,10 +151,10 @@ ISTRUZIONI:
             safe_target = target_file.split('/')[-1].replace('.py', '')
             adr_file = DECISIONS_DIR / f"auto_{timestamp}_{safe_target}.md"
             DECISIONS_DIR.mkdir(parents=True, exist_ok=True)
-            
+
             with open(adr_file, "w") as f:
                 f.write(adr_content)
-            
+
             logger.info(f"💾 ADR salvato in {adr_file}")
             logger.info("🎉 Task completato.")
     else:
@@ -164,9 +164,9 @@ async def run():
     state = load_state()
     if not state:
         return
-        
+
     logger.info("Analyzing state...")
-    
+
     pytest_state = state.get("pytest", {})
     if pytest_state.get("failures_found"):
         logger.info("Critical test failures found. Routing to Claude Opus 4.6.")

--- a/apps/evaluator/core_guardian/observe.py
+++ b/apps/evaluator/core_guardian/observe.py
@@ -53,22 +53,22 @@ def run_pytest_failures() -> dict:
 def observe():
     """Run the observation cycle and save state."""
     logger.info("Starting observation cycle...")
-    
+
     ruff_state = run_ruff_check()
     pytest_state = run_pytest_failures()
-    
+
     state = {
         "timestamp": datetime.now().isoformat(),
         "ruff": ruff_state,
         "pytest": pytest_state,
         "status": "ready"
     }
-    
+
     STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
-    
+
     with open(STATE_FILE, "w") as f:
         json.dump(state, f, indent=2)
-        
+
     logger.info(f"Observation complete. State saved to {STATE_FILE}")
 
 if __name__ == "__main__":

--- a/apps/kbli-navigator/scripts/add-gold-codes.py
+++ b/apps/kbli-navigator/scripts/add-gold-codes.py
@@ -29,7 +29,7 @@ if not match:
 
 if match:
     insertion_point = match.start(2)
-    
+
     new_codes = '''
   // ---------------------------------------------------------------------------
   // Creative Industries & Design Services (90xxx, 73xxx, 74xxx)
@@ -125,14 +125,14 @@ if match:
       "Game content design business in Bali? 74194 is brand new in KBLI 2025 — first dedicated game design code. It's BPS_ONLY, so NIB only for now. The key distinction: this is design work, not programming. Full game studio needs 74194 + 62199. Let me explain the setup.",
   },
 '''
-    
+
     # Insert new codes before the closing brace
     content = content[:insertion_point] + new_codes + content[insertion_point:]
-    
+
     # Write back
     with open('/Users/nuzantara/Desktop/kbli-navigator-rebuild/lib/kbli-gold-content.ts', 'w') as f:
         f.write(content)
-    
+
     print("Successfully added 6 new KBLI codes")
 else:
     print("Could not find insertion point")

--- a/apps/kbli-navigator/scripts/fix_duplicates_08.py
+++ b/apps/kbli-navigator/scripts/fix_duplicates_08.py
@@ -168,18 +168,18 @@ for code, new_content in [('77100', NEW_77100), ('79110', NEW_79110), ('82300', 
     pattern = f'  "{code}": {{'
     positions = [m.start() for m in re.finditer(re.escape(pattern), content)]
     print(f"{code}: {len(positions)} occurrences at lines {[content[:p].count(chr(10))+1 for p in positions]}")
-    
+
     if len(positions) < 2:
         print(f"  ERROR: Expected 2 occurrences for {code}, found {len(positions)}")
         continue
-    
+
     # Remove the LAST occurrence (the duplicate we just inserted)
     last_pos = positions[-1]
     last_end = find_entry_end(content, last_pos)
     removed_chunk = content[last_pos:last_end]
     print(f"  Removing duplicate at line {content[:last_pos].count(chr(10))+1}, length {len(removed_chunk)} chars")
     content = content[:last_pos] + content[last_end:]
-    
+
     # Now replace the FIRST (old) occurrence with new content
     first_pos = content.find(f'  "{code}": {{')
     if first_pos < 0:
@@ -189,7 +189,7 @@ for code, new_content in [('77100', NEW_77100), ('79110', NEW_79110), ('82300', 
     old_chunk = content[first_pos:first_end]
     print(f"  Replacing old entry at line {content[:first_pos].count(chr(10))+1}, length {len(old_chunk)} chars")
     content = content[:first_pos] + new_content + content[first_end:]
-    
+
     print(f"  ✓ {code} done. File now {len(content.split(chr(10)))} lines")
 
 # ============================================================

--- a/apps/mouth/src/lib/api/crm/crm.schemas.ts
+++ b/apps/mouth/src/lib/api/crm/crm.schemas.ts
@@ -32,7 +32,7 @@ export const leadSourceEnum = z.enum([
 // Practice type codes are now loaded dynamically from the backend catalog
 // (69 services across 9 categories). Validate as non-empty string.
 export const practiceTypeCodeEnum = z
-  .string({ invalid_type_error: "Service type is required" })
+  .string({ error: "Service type is required" })
   .min(1, "Service type is required");
 
 export const practiceStatusEnum = z.enum([
@@ -163,7 +163,7 @@ export type CreateClientOutput = z.output<typeof createClientSchema>;
 export const createPracticeSchema = z
   .object({
     client_id: z
-      .number({ invalid_type_error: "Client is required" })
+      .number({ error: "Client is required" })
       .positive("Invalid client ID"),
     practice_type_code: practiceTypeCodeEnum,
     status: practiceStatusEnum.default("inquiry"),

--- a/apps/nuzantara-mcp-advanced/nuzantara_mcp_advanced/server.py
+++ b/apps/nuzantara-mcp-advanced/nuzantara_mcp_advanced/server.py
@@ -128,7 +128,7 @@ async def check_deployment_readiness() -> dict:
         "ready": True,
         "timestamp": None
     }
-    
+
     # Check 1: Import chain
     try:
         result = subprocess.run(
@@ -148,7 +148,7 @@ async def check_deployment_readiness() -> dict:
         }
     except Exception as e:
         results["checks"]["import_chain"] = {"pass": False, "error": str(e)}
-    
+
     # Check 2: Core tests
     try:
         result = subprocess.run(
@@ -171,7 +171,7 @@ async def check_deployment_readiness() -> dict:
         }
     except Exception as e:
         results["checks"]["core_tests"] = {"pass": False, "error": str(e)}
-    
+
     # Check 3: Git status for rogue changes
     try:
         result = subprocess.run(
@@ -189,7 +189,7 @@ async def check_deployment_readiness() -> dict:
         }
     except Exception as e:
         results["checks"]["rogue_changes"] = {"pass": False, "error": str(e)}
-    
+
     results["ready"] = all(c.get("pass", False) for c in results["checks"].values())
     return results
 
@@ -226,7 +226,7 @@ async def run_backend_tests(test_path: str = "", verbose: bool = False) -> dict:
             env={**os.environ, "PYTHONPATH": "."},
             timeout=300,
         )
-        
+
         return {
             "success": result.returncode == 0,
             "return_code": result.returncode,
@@ -381,7 +381,7 @@ async def run_linting() -> dict:
             cwd=f"{PROJECT_ROOT}/apps/backend-rag",
             timeout=60,
         )
-        
+
         return {
             "format_ok": format_result.returncode == 0,
             "lint_ok": lint_result.returncode == 0,
@@ -415,7 +415,7 @@ async def check_system_health() -> dict:
         "overall": "unknown",
         "components": {}
     }
-    
+
     # Check backend health
     client = _get_health_client()
     try:
@@ -440,7 +440,7 @@ async def check_system_health() -> dict:
         }
     except Exception as e:
         health["components"]["services"] = {"status": "error", "error": str(e)}
-    
+
     # Determine overall health
     all_healthy = all(
         c.get("status") == "healthy" or c.get("status") == "ok"
@@ -448,7 +448,7 @@ async def check_system_health() -> dict:
         if isinstance(c, dict) and "status" in c
     )
     health["overall"] = "healthy" if all_healthy else "degraded"
-    
+
     return health
 
 
@@ -521,15 +521,15 @@ async def find_documentation(topic: str) -> dict:
             timeout=15,
         )
         files = result.stdout.strip().split("\n") if result.stdout.strip() else []
-        
+
         # Filter by topic relevance (simple keyword matching)
         topic_lower = topic.lower()
         relevant = [
             f for f in files
-            if topic_lower in f.lower() or 
+            if topic_lower in f.lower() or
             topic_lower.replace(" ", "_") in f.lower()
         ]
-        
+
         return {
             "topic": topic,
             "matches": len(relevant),
@@ -558,7 +558,7 @@ async def get_file_structure(path: str = "apps/backend-rag/backend") -> dict:
             timeout=15,
         )
         files = result.stdout.strip().split("\n") if result.stdout.strip() else []
-        
+
         # Organize by directory
         structure = {}
         for f in files:
@@ -572,7 +572,7 @@ async def get_file_structure(path: str = "apps/backend-rag/backend") -> dict:
             if "_files" not in current:
                 current["_files"] = []
             current["_files"].append(parts[-1])
-        
+
         return {
             "path": path,
             "total_files": len(files),

--- a/apps/nuzantara-mcp/nuzantara_mcp/tools/google_bridge.py
+++ b/apps/nuzantara-mcp/nuzantara_mcp/tools/google_bridge.py
@@ -20,7 +20,7 @@ async def upload_to_notebooklm(file_path: str, title: Optional[str] = None) -> d
     """
     if not os.path.exists(file_path):
         return {"error": f"File not found: {file_path}"}
-        
+
     from playwright.async_api import async_playwright
     async with async_playwright() as p:
         try:
@@ -31,28 +31,28 @@ async def upload_to_notebooklm(file_path: str, title: Optional[str] = None) -> d
             )
             page = await browser.new_page()
             await page.goto("https://notebooklm.google/", wait_until="networkidle")
-            
+
             # Check if we are logged in
             if await page.query_selector("text='Sign in'"):
                 return {"error": "Not logged in to Google. Please log in manually in the browser first."}
-            
+
             # Basic NotebookLM upload interaction (2026 UI)
             # Find the "New Notebook" button
             new_notebook_btn = await page.query_selector("text='New Notebook'")
             if not new_notebook_btn:
                 # Fallback to selector
                 new_notebook_btn = await page.query_selector("button:has-text('New Notebook')")
-            
+
             if new_notebook_btn:
                 await new_notebook_btn.click()
                 await page.wait_for_timeout(2000)
-                
+
                 # Look for "Local files" or upload area
                 async with page.expect_file_chooser() as fc_info:
                     await page.click("text='Local files'")
                 file_chooser = await fc_info.value
                 await file_chooser.set_files(file_path)
-                
+
                 await page.wait_for_timeout(8000) # Give more time for upload
                 return {"success": True, "msg": f"Uploaded {os.path.basename(file_path)} to NotebookLM"}
             else:


### PR DESCRIPTION
## Summary

- 262 trailing whitespace violations (W291/W293) auto-fixed via `ruff --fix` across 16 files
- Fix pre-existing Zod v4 breaking change: `invalid_type_error` → `error` in `crm.schemas.ts` (was blocking typecheck on any PR touching mouth)
- Fix I001 import sorting in 2 backend RAG files uncovered during staging

## Scope
- `apps/backend-rag/backend/services/rag/` — 2 files
- `apps/bali-intel-scraper/` — 6 files  
- `apps/evaluator/core_guardian/` — 2 files
- `apps/kbli-navigator/scripts/` — 2 files
- `apps/nuzantara-mcp-advanced/` — 1 file
- `apps/nuzantara-mcp/` — 1 file
- `apps/mouth/src/lib/api/crm/crm.schemas.ts` — Zod v4 fix

## Remaining technical debt
50 W291/W293 violations inside multi-line SQL string literals require `--unsafe-fixes` — left as known debt, does not affect runtime behavior.

## Test plan
- [ ] Pre-commit hooks pass (verified locally: typecheck ✅, ruff ✅, import chain ✅)
- [ ] CI E2E tests
- [ ] Detect Secrets scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)