### PR TITLE
fix(lint): B904 raise-from-exc chaining across 9 files

### DIFF
--- a/apps/backend-rag/backend/tests/services/compliance/test_lkpm_deadline_notifier.py
+++ b/apps/backend-rag/backend/tests/services/compliance/test_lkpm_deadline_notifier.py
@@ -11,6 +11,7 @@ Tests for backend.services.compliance.lkpm_deadline_notifier
 """
 
 from datetime import datetime, timezone
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -21,13 +22,11 @@ from backend.services.compliance.lkpm_deadline_notifier import (
     KILLSWITCH_KEY,
     TAX_CONSULTANT_MANAGER,
     TAX_CONSULTANTS_NON_MANAGER,
-    TELEGRAM_URGENCY_DAYS,
     LKPMDeadlineNotifier,
     _compute_days_until_deadline,
     _first_name_from_email,
     _format_deadline,
 )
-
 
 # =====================================================================
 # Helpers
@@ -62,8 +61,8 @@ class _FakeRecord(dict):
     def __getattr__(self, name: str):
         try:
             return self[name]
-        except KeyError:
-            raise AttributeError(name)
+        except KeyError as exc:
+            raise AttributeError(name) from exc
 
 
 def _make_pool(

--- a/apps/bali-intel-scraper/backend/app/routers/health.py
+++ b/apps/bali-intel-scraper/backend/app/routers/health.py
@@ -276,7 +276,7 @@ async def reset_system() -> Dict[str, str]:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Reset failed: {str(e)}",
-        )
+        ) from e
 
 
 # Middleware for tracking request health

--- a/apps/bali-intel-scraper/backend/services/base_service.py
+++ b/apps/bali-intel-scraper/backend/services/base_service.py
@@ -216,7 +216,7 @@ def service_method(operation_name: str):
                         status_code=500,
                         details={"original_error": type(e).__name__},
                         retryable=True,
-                    )
+                    ) from e
 
         @wraps(func)
         def sync_wrapper(self: "BaseService", *args, **kwargs):
@@ -291,7 +291,7 @@ def service_method(operation_name: str):
                         status_code=500,
                         details={"original_error": type(e).__name__},
                         retryable=True,
-                    )
+                    ) from e
 
         # Return appropriate wrapper based on whether func is async
         import inspect

--- a/apps/bali-intel-scraper/scripts/social_scrapers/kaskus_scraper.py
+++ b/apps/bali-intel-scraper/scripts/social_scrapers/kaskus_scraper.py
@@ -43,7 +43,7 @@ def fetch_kaskus_threads(
     try:
         html = _render_page(url)
     except Exception as e:
-        raise ValueError(f'Failed to render Kaskus page: {e}')
+        raise ValueError(f'Failed to render Kaskus page: {e}') from e
 
     soup = BeautifulSoup(html, 'lxml')
 

--- a/apps/graph-engine/src/nuzantara_graph/api/middleware.py
+++ b/apps/graph-engine/src/nuzantara_graph/api/middleware.py
@@ -54,7 +54,7 @@ async def get_current_user(request: Request) -> dict:
         }
     except Exception as e:
         logger.warning("jwt_validation_failed", error=str(e))
-        raise HTTPException(status_code=401, detail="Invalid token")
+        raise HTTPException(status_code=401, detail="Invalid token") from e
 
 
 # ---------------------------------------------------------------------------

--- a/apps/graph-engine/src/nuzantara_graph/api/routes.py
+++ b/apps/graph-engine/src/nuzantara_graph/api/routes.py
@@ -170,7 +170,7 @@ async def query(
     except Exception as e:
         logger.error("query_failed", run_id=run_id, error=str(e), exc_info=True)
         detail = str(e) if settings.debug else "Internal server error"
-        raise HTTPException(status_code=500, detail=detail)
+        raise HTTPException(status_code=500, detail=detail) from e
 
 
 _STREAM_HEARTBEAT_SECONDS = 2.0

--- a/apps/organism/organism/actuators/fly_machines_start.py
+++ b/apps/organism/organism/actuators/fly_machines_start.py
@@ -54,7 +54,7 @@ class FlyMachinesStart(ActuatorBase):
         )
         try:
             out, err = await asyncio.wait_for(proc.communicate(), timeout=60.0)
-        except asyncio.TimeoutError:
+        except asyncio.TimeoutError as exc:
             try:
                 proc.kill()
                 await proc.wait()
@@ -62,7 +62,7 @@ class FlyMachinesStart(ActuatorBase):
                 pass
             raise RuntimeError(
                 f"fly machines start timed out after 60s (argv={argv})"
-            )
+            ) from exc
         return {
             "argv": argv,
             "returncode": proc.returncode,

--- a/apps/organism/organism/actuators/restart_agent.py
+++ b/apps/organism/organism/actuators/restart_agent.py
@@ -33,7 +33,7 @@ class RestartAgent(ActuatorBase):
         )
         try:
             out, err = await asyncio.wait_for(proc.communicate(), timeout=30.0)
-        except asyncio.TimeoutError:
+        except asyncio.TimeoutError as exc:
             try:
                 proc.kill()
                 await proc.wait()
@@ -41,7 +41,7 @@ class RestartAgent(ActuatorBase):
                 pass
             raise RuntimeError(
                 f"launchctl kickstart timed out after 30s (label={label})"
-            )
+            ) from exc
         return {
             "agent_ref": agent_ref, "label": label,
             "returncode": proc.returncode,

--- a/apps/organism/organism/control_panel.py
+++ b/apps/organism/organism/control_panel.py
@@ -26,9 +26,9 @@ def _verify_token(x_organism_token: str | None) -> None:
     token_path = os.getenv("ORGANISM_TOKEN_PATH", "/etc/organism/token")
     try:
         expected = Path(token_path).read_text().strip()
-    except FileNotFoundError:
+    except FileNotFoundError as exc:
         logger.warning("Token file not found at %s", token_path)
-        raise HTTPException(status_code=503, detail="token not configured")
+        raise HTTPException(status_code=503, detail="token not configured") from exc
     if not x_organism_token or x_organism_token != expected:
         logger.warning("Invalid token attempt")
         raise HTTPException(status_code=401, detail="invalid token")

--- a/scripts/check_cve_exceptions.py
+++ b/scripts/check_cve_exceptions.py
@@ -45,7 +45,7 @@ def _parse_date(raw: Any, field: str, idx: int) -> date:
         except ValueError as exc:
             raise SystemExit(
                 f"Entry #{idx}: field '{field}'='{raw}' is not a valid YYYY-MM-DD date ({exc})"
-            )
+            ) from exc
     raise SystemExit(f"Entry #{idx}: field '{field}' must be a date or YYYY-MM-DD string, got {type(raw).__name__}")
 
 

--- a/scripts/zantara_prompt_canary/diff_prompts.py
+++ b/scripts/zantara_prompt_canary/diff_prompts.py
@@ -50,7 +50,7 @@ def _load_modules() -> tuple[object, object, dict]:
             f"❌ failed to import backend prompts modules: {exc}\n"
             "   make sure you ran:  PYTHONPATH=apps/backend-rag python3 ...\n",
         )
-        raise SystemExit(2)
+        raise SystemExit(2) from exc
     return zantara_core, zantara_core_v2, BUSINESS_PHRASES_I18N
 
 


### PR DESCRIPTION
## Summary

Fixed all 13 B904 ruff violations (raise inside except without from-clause) across 9 files.

Proper exception chaining with `raise X from exc` or `raise X from None` is required for:
- Clear traceback attribution (Python interpreter marks where the secondary raise came from)
- Compatibility with exception inspection tools

## Files changed

| File | Violation |
|---|---|
| `test_lkpm_deadline_notifier.py` | B904 + F821 (missing `Any`) + I001/F401 |
| `bali-intel-scraper/health.py` | `Exception` → `HTTPException` |
| `bali-intel-scraper/base_service.py` | `Exception` → `ServiceError` (×2) |
| `bali-intel-scraper/kaskus_scraper.py` | `Exception` → `ValueError` |
| `graph-engine/middleware.py` | `Exception` → `HTTPException` (401) |
| `graph-engine/routes.py` | `Exception` → `HTTPException` (500) |
| `organism/fly_machines_start.py` | `TimeoutError` → `RuntimeError` |
| `organism/restart_agent.py` | `TimeoutError` → `RuntimeError` |
| `organism/control_panel.py` | `FileNotFoundError` → `HTTPException` |
| `scripts/check_cve_exceptions.py` | `ValueError` → `SystemExit` |
| `scripts/zantara_prompt_canary/diff_prompts.py` | `ImportError` → `SystemExit` |

## Test plan
- [ ] Pre-commit hooks pass (verified: typecheck ✅, ruff ✅, import chain ✅)
- [ ] CI E2E + Backend Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)