### PR TITLE
fix(lint): auto-fix 45 UP/SIM modernization violations

### DIFF
--- a/apps/backend-rag/backend/services/backup/nlm_drive_backup.py
+++ b/apps/backend-rag/backend/services/backup/nlm_drive_backup.py
@@ -370,11 +370,11 @@ def _drive_upload_json(
         f"{json.dumps(metadata)}\r\n"
         f"--{boundary}\r\n"
         f"Content-Type: application/json\r\n\r\n"
-    ).encode("utf-8") + body_bytes + f"\r\n--{boundary}--\r\n".encode("utf-8")
+    ).encode() + body_bytes + f"\r\n--{boundary}--\r\n".encode()
 
     # Sanity check boundary not present in payload (defense-in-depth)
     if boundary.encode("utf-8") in body_bytes:
-        raise BackupError(f"multipart boundary collision with payload — regenerate")
+        raise BackupError("multipart boundary collision with payload — regenerate")
 
     def _post() -> dict[str, Any]:
         req = urllib.request.Request(

--- a/apps/backend-rag/backend/tests/services/rag/test_graphrag_evolution.py
+++ b/apps/backend-rag/backend/tests/services/rag/test_graphrag_evolution.py
@@ -12,9 +12,7 @@ Run: cd apps/backend-rag && PYTHONPATH=. python -m pytest backend/tests/services
 """
 
 import hashlib
-import math
-import re
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -49,7 +47,7 @@ class TestQueryPlan:
 
         plan = QueryPlan(query="What is KITAS?")
         assert len(plan.query_hash) == 16
-        expected = hashlib.sha256("What is KITAS?".encode()).hexdigest()[:16]
+        expected = hashlib.sha256(b"What is KITAS?").hexdigest()[:16]
         assert plan.query_hash == expected
 
     def test_kg_strategy_enum_values(self) -> None:
@@ -421,7 +419,6 @@ class TestKGAutoExpansion:
     @pytest.mark.asyncio
     async def test_extracts_from_source_chunks_not_response(self) -> None:
         """CRITICAL: Must extract from source chunks, NOT from LLM response text."""
-        from contextlib import asynccontextmanager
 
         from backend.services.rag.kg_auto_expansion import KGAutoExpansion
 

--- a/apps/bali-intel-scraper/backend/services/base_service.py
+++ b/apps/bali-intel-scraper/backend/services/base_service.py
@@ -125,9 +125,7 @@ def classify_error(error: Exception) -> ErrorCategory:
         return ErrorCategory.VALIDATION
     elif isinstance(error, NotFoundError):
         return ErrorCategory.NOT_FOUND
-    elif isinstance(error, ExternalServiceError):
-        return ErrorCategory.EXTERNAL
-    elif isinstance(error, RateLimitError):
+    elif isinstance(error, ExternalServiceError) or isinstance(error, RateLimitError):
         return ErrorCategory.EXTERNAL
     elif "database" in str(error).lower() or "connection" in str(error).lower():
         return ErrorCategory.DATABASE

--- a/apps/bali-intel-scraper/scripts/force_publish_today.py
+++ b/apps/bali-intel-scraper/scripts/force_publish_today.py
@@ -13,7 +13,7 @@ async def main():
         logger.error("SCRAPER_API_KEY env var not set — aborting")
         return
 
-    with open(RUN_FILE, "r") as f:
+    with open(RUN_FILE) as f:
         data = json.load(f)
 
     articles = data.get("articles", [])

--- a/apps/bali-intel-scraper/scripts/load_intel_sources.py
+++ b/apps/bali-intel-scraper/scripts/load_intel_sources.py
@@ -118,7 +118,7 @@ async def load_sources():
         logger.error(f"❌ File non trovato: {SOURCES_FILE}")
         return
 
-    with open(SOURCES_FILE, 'r', encoding='utf-8') as f:
+    with open(SOURCES_FILE, encoding='utf-8') as f:
         data = json.load(f)
 
     total_sources = data.get('total_sources', 0)

--- a/apps/bali-intel-scraper/scripts/load_intel_sources_streaming.py
+++ b/apps/bali-intel-scraper/scripts/load_intel_sources_streaming.py
@@ -105,7 +105,7 @@ async def load_sources_streaming():
     logger.info("=" * 60)
 
     # Carica JSON
-    with open(SOURCES_FILE, 'r', encoding='utf-8') as f:
+    with open(SOURCES_FILE, encoding='utf-8') as f:
         data = json.load(f)
 
     total_sources = data.get('total_sources', 0)

--- a/apps/bali-intel-scraper/scripts/publish_articles.py
+++ b/apps/bali-intel-scraper/scripts/publish_articles.py
@@ -18,7 +18,7 @@ async def publish_article(article_file: Path, main_news_position: int = None):
     """Publish single article to backend"""
 
     # Read article data
-    with open(article_file, "r") as f:
+    with open(article_file) as f:
         article = json.load(f)
 
     # Prepare payload

--- a/apps/bali-intel-scraper/scripts/unified_scraper.py
+++ b/apps/bali-intel-scraper/scripts/unified_scraper.py
@@ -97,7 +97,7 @@ class UnifiedScraper:
         await self.client.aclose()
 
     def load_sources(self) -> List[Dict]:
-        with open(SOURCES_FILE, 'r') as f:
+        with open(SOURCES_FILE) as f:
             data = json.load(f)
         sources = []
         categories_data = data.get('categories', {})

--- a/apps/cell/cell/cortex/strategy_mutator.py
+++ b/apps/cell/cell/cortex/strategy_mutator.py
@@ -373,9 +373,7 @@ class StrategyMutator:
             action_taken = ep.get("action_taken", "")
             outcome = ep.get("outcome", "partial")
 
-            if outcome == "failure" and action_taken not in proposed_actions:
-                improvements += 1
-            elif outcome == "success" and action_taken in proposed_actions:
+            if outcome == "failure" and action_taken not in proposed_actions or outcome == "success" and action_taken in proposed_actions:
                 improvements += 1
 
         return improvements / len(sample) if sample else 0.5

--- a/apps/cell/tests/test_skill_library.py
+++ b/apps/cell/tests/test_skill_library.py
@@ -342,7 +342,7 @@ class TestSkillLibraryCapacity:
         assert count == 5
         # Verify the LIMIT in the UPDATE subquery
         call_args = conn.execute.call_args[0]
-        assert 5 == call_args[1]  # $1 parameter = excess
+        assert call_args[1] == 5  # $1 parameter = excess
 
     @pytest.mark.asyncio
     async def test_custom_max_active(self, mock_pool):

--- a/apps/evaluator/causal_regression/regression_report.py
+++ b/apps/evaluator/causal_regression/regression_report.py
@@ -242,8 +242,8 @@ def build_html(inputs: ReportInputs) -> str:
     )
     for cause, color in ROOT_CAUSE_COLORS.items():
         parts.append(
-            '<span class="item"><span class="swatch" style="background:{c}"></span>'
-            "{label}</span>".format(c=color, label=_escape_html(cause))
+            f'<span class="item"><span class="swatch" style="background:{color}"></span>'
+            f"{_escape_html(cause)}</span>"
         )
     parts.append("</div>")
 
@@ -279,7 +279,7 @@ def build_html(inputs: ReportInputs) -> str:
     # Warnings section
     warns = sorted(set(inputs.warnings))
     if warns:
-        parts.append("<details><summary>Warnings ({n})</summary><ul>".format(n=len(warns)))
+        parts.append(f"<details><summary>Warnings ({len(warns)})</summary><ul>")
         for w in warns[:100]:
             parts.append(f"<li><code>{_escape_html(w)}</code></li>")
         parts.append("</ul></details>")

--- a/apps/evaluator/core_guardian/watchdog.py
+++ b/apps/evaluator/core_guardian/watchdog.py
@@ -577,7 +577,7 @@ def _watchdog_core() -> None:
             format_report as _cache_format,
         )
         _cache_findings = _cache_audit(PROJECT_ROOT)
-        _baseline_cache = baseline.get("cache_audit_count", None)
+        _baseline_cache = baseline.get("cache_audit_count")
         logger.info(f"Cache audit: {len(_cache_findings)} endpoint senza invalidate_cache")
         if _baseline_cache is None:
             # Prima run — salva baseline silenziosamente
@@ -608,7 +608,7 @@ def _watchdog_core() -> None:
         )
         _catch_result = _catch_audit(PROJECT_ROOT)
         _catch_count = _catch_result.total
-        _baseline_catch = baseline.get("empty_catch_count", None)
+        _baseline_catch = baseline.get("empty_catch_count")
         logger.info(f"Empty catch audit: {_catch_count} findings in {_catch_result.files_scanned} files")
         if _baseline_catch is None:
             baseline["empty_catch_count"] = _catch_count
@@ -636,7 +636,7 @@ def _watchdog_core() -> None:
         )
         _rbac_result = _rbac_audit(PROJECT_ROOT)
         _rbac_errors = len([f for f in _rbac_result.findings if f.severity == "error"])
-        _baseline_rbac = baseline.get("rbac_error_count", None)
+        _baseline_rbac = baseline.get("rbac_error_count")
         logger.info(f"RBAC audit: {_rbac_errors} errors, {_rbac_result.total - _rbac_errors} warnings across {_rbac_result.endpoints_scanned} endpoints")
         if _baseline_rbac is None:
             baseline["rbac_error_count"] = _rbac_errors
@@ -664,7 +664,7 @@ def _watchdog_core() -> None:
         )
         _dead_result = _dead_audit(PROJECT_ROOT)
         _dead_count = _dead_result.total
-        _baseline_dead = baseline.get("dead_code_count", None)
+        _baseline_dead = baseline.get("dead_code_count")
         logger.info(f"Dead code audit: {_dead_count} findings in {_dead_result.files_scanned} files")
         if _baseline_dead is None:
             baseline["dead_code_count"] = _dead_count
@@ -692,7 +692,7 @@ def _watchdog_core() -> None:
         )
         _contract_result = _contract_audit(PROJECT_ROOT)
         _ghost_count = _contract_result.total
-        _baseline_ghost = baseline.get("ghost_endpoint_count", None)
+        _baseline_ghost = baseline.get("ghost_endpoint_count")
         logger.info(
             f"API contract audit: {_ghost_count} ghost endpoints "
             f"(frontend: {len(_contract_result.frontend_endpoints)}, backend: {len(_contract_result.backend_endpoints)})"

--- a/apps/kbli-navigator/scripts/add-gold-codes.py
+++ b/apps/kbli-navigator/scripts/add-gold-codes.py
@@ -6,7 +6,7 @@ Script to add 6 new KBLI gold codes while removing any existing duplicates.
 import re
 
 # Read the file
-with open('/Users/nuzantara/Desktop/kbli-navigator-rebuild/lib/kbli-gold-content.ts', 'r') as f:
+with open('/Users/nuzantara/Desktop/kbli-navigator-rebuild/lib/kbli-gold-content.ts') as f:
     content = f.read()
 
 # Codes to add/replace

--- a/apps/kbli-navigator/scripts/fix_duplicates_08.py
+++ b/apps/kbli-navigator/scripts/fix_duplicates_08.py
@@ -2,7 +2,7 @@
 """Fix duplicate entries created by Session 08 script for 77100, 79110, 82300"""
 import re
 
-with open('lib/kbli-gold-content.ts', 'r') as f:
+with open('lib/kbli-gold-content.ts') as f:
     content = f.read()
 
 print(f"Starting: {len(content.split(chr(10)))} lines")

--- a/apps/kbli-navigator/scripts/update_gold.py
+++ b/apps/kbli-navigator/scripts/update_gold.py
@@ -5,10 +5,10 @@ import re
 # ============================================================
 # Read files
 # ============================================================
-with open('lib/kbli-gold-content.ts', 'r') as f:
+with open('lib/kbli-gold-content.ts') as f:
     content = f.read()
 
-with open('app/kbli/[code]/page.tsx', 'r') as f:
+with open('app/kbli/[code]/page.tsx') as f:
     page = f.read()
 
 original_len = len(content.split('\n'))

--- a/apps/kbli-navigator/scripts/update_gold_08.py
+++ b/apps/kbli-navigator/scripts/update_gold_08.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Apply Session 08 gold content updates — 6 Transport/Logistics/Tourism KBLI codes"""
 
-with open('lib/kbli-gold-content.ts', 'r') as f:
+with open('lib/kbli-gold-content.ts') as f:
     content = f.read()
 
-with open('app/kbli/[code]/page.tsx', 'r') as f:
+with open('app/kbli/[code]/page.tsx') as f:
     page = f.read()
 
 print(f"Starting: {len(content.split(chr(10)))} lines in gold content")

--- a/apps/kbli-navigator/scripts/update_gold_13.py
+++ b/apps/kbli-navigator/scripts/update_gold_13.py
@@ -2,10 +2,10 @@
 """Apply Session 13 gold content — 6 Wholesale Food/Grocery KBLI codes"""
 import re
 
-with open('lib/kbli-gold-content.ts', 'r') as f:
+with open('lib/kbli-gold-content.ts') as f:
     content = f.read()
 
-with open('app/kbli/[code]/page.tsx', 'r') as f:
+with open('app/kbli/[code]/page.tsx') as f:
     page = f.read()
 
 print(f"Starting: {len(content.split(chr(10)))} lines")

--- a/apps/mata-garuda/tests/domains/setup_team/test_obligation_engine.py
+++ b/apps/mata-garuda/tests/domains/setup_team/test_obligation_engine.py
@@ -289,10 +289,10 @@ def test_schema_creates_obligations_table_with_indexes(tmp_path):
 
 
 def test_valid_obligation_types_includes_5_canonical():
-    assert VALID_OBLIGATION_TYPES == {
+    assert {
         "filing",
         "reporting",
         "payment",
         "operational",
         "registration",
-    }
+    } == VALID_OBLIGATION_TYPES

--- a/apps/mata-garuda/tests/test_compat_shim.py
+++ b/apps/mata-garuda/tests/test_compat_shim.py
@@ -29,7 +29,7 @@ def test_legacy_dict_byte_identical_to_pre_pr_snapshot():
 def test_legacy_dict_matches_registry():
     from mata_garuda.config import NLM_NOTEBOOKS
     from mata_garuda.notebook_registry import get_legacy_notebooks_dict
-    assert NLM_NOTEBOOKS == get_legacy_notebooks_dict()
+    assert get_legacy_notebooks_dict() == NLM_NOTEBOOKS
 
 
 def test_legacy_dict_keys_match_expected_set():

--- a/apps/mata-garuda/tests/test_goid_harvesters.py
+++ b/apps/mata-garuda/tests/test_goid_harvesters.py
@@ -163,7 +163,7 @@ def test_agent_registers_and_wires_config(mod, agent_name, source_domain):
     assert agent.name == agent_name
 
     # Wiring: SOURCE_DOMAIN matches expected, allow prefixes non-empty
-    assert mod.SOURCE_DOMAIN == source_domain
+    assert source_domain == mod.SOURCE_DOMAIN
     assert mod.ALLOW_PREFIXES and all(
         source_domain in p or p.startswith("https://www.") for p in mod.ALLOW_PREFIXES
     )

--- a/apps/mouth/scripts/analyze_coverage.py
+++ b/apps/mouth/scripts/analyze_coverage.py
@@ -277,7 +277,7 @@ def main():
         sys.exit(1)
 
     print(f"📖 Leggendo {coverage_file}...")
-    with open(coverage_file, "r", encoding="utf-8") as f:
+    with open(coverage_file, encoding="utf-8") as f:
         coverage_data = json.load(f)
 
     print("🔍 Analizzando coverage...")

--- a/apps/organism/tests/actuators/test_registry.py
+++ b/apps/organism/tests/actuators/test_registry.py
@@ -10,7 +10,7 @@ W1_BASELINE = {"restart_agent", "cleanup_log", "notify_telegram", "quarantine"}
 @pytest.mark.asyncio
 async def test_registry_has_all_baseline_actuators(fake_redis):
     reg = build_actuator_registry(redis=fake_redis)
-    assert W1_BASELINE <= set(reg.keys())
+    assert set(reg.keys()) >= W1_BASELINE
 
 
 @pytest.mark.asyncio

--- a/apps/zantara-media/tests/test_atomic.py
+++ b/apps/zantara-media/tests/test_atomic.py
@@ -5,7 +5,7 @@ Per spec: if Qdrant fails, Postgres must never be written.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
@@ -32,7 +32,7 @@ def _make_file(
         mime_type=mime_type,
         parents=parents or ["1n3VjN-YZGGH-6-yByxIi0rLGxi4iTDu1"],
         size=size,
-        modified_time=datetime(2024, 6, 15, tzinfo=timezone.utc),
+        modified_time=datetime(2024, 6, 15, tzinfo=UTC),
         version=3,
         trashed=False,
     )

--- a/apps/zantara-media/tests/test_dedup.py
+++ b/apps/zantara-media/tests/test_dedup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -30,7 +30,7 @@ def _make_file(
         mime_type=mime_type,
         parents=parents or ["1n3VjN-YZGGH-6-yByxIi0rLGxi4iTDu1"],
         size=size,
-        modified_time=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        modified_time=datetime(2024, 1, 1, tzinfo=UTC),
         version=version,
         trashed=False,
     )

--- a/apps/zantara-media/tests/test_e2e_integration.py
+++ b/apps/zantara-media/tests/test_e2e_integration.py
@@ -6,7 +6,7 @@ All external services are mocked.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -34,7 +34,7 @@ def make_drive_file(
         mime_type=mime_type,
         parents=parents or ["1c9QnRb22XdcrFH8ukxgJeWW41soZhzVq"],  # photos subfolder
         size=size,
-        modified_time=datetime(2026, 4, 14, 10, 0, 0, tzinfo=timezone.utc),
+        modified_time=datetime(2026, 4, 14, 10, 0, 0, tzinfo=UTC),
         version=version,
         trashed=False,
     )

--- a/apps/zantara-media/tests/test_handlers.py
+++ b/apps/zantara-media/tests/test_handlers.py
@@ -252,7 +252,7 @@ async def test_extract_content_routes_audio():
 @pytest.mark.asyncio
 async def test_extract_content_utf8_fallback():
     """Unknown MIME type should attempt UTF-8 decode."""
-    raw = "Hello world in UTF-8".encode("utf-8")
+    raw = b"Hello world in UTF-8"
     text, meta = await extract_content(raw, "application/octet-stream", "file.bin")
     assert "Hello world" in text
 

--- a/apps/zantara-media/zantara_media/cli/garuda_indexer.py
+++ b/apps/zantara-media/zantara_media/cli/garuda_indexer.py
@@ -9,6 +9,7 @@ import logging
 import os
 import sys
 from pathlib import Path
+from datetime import UTC
 
 
 # Load .env from apps/backend-rag/.env (sibling app)
@@ -74,7 +75,7 @@ async def async_main(worker_name: str, dry_run: bool) -> int:
             )
             if row and row["expires_at"]:
                 from datetime import datetime, timezone
-                days_left = (row["expires_at"] - datetime.now(tz=timezone.utc)).days
+                days_left = (row["expires_at"] - datetime.now(tz=UTC)).days
                 if days_left < 7:
                     await send_critical_alert(
                         f"⚠️ GARUDA: Google Drive OAuth token expires in {days_left} days!\n"

--- a/packages/cell-core/cell_core/homeostasis.py
+++ b/packages/cell-core/cell_core/homeostasis.py
@@ -85,9 +85,7 @@ class HomeostaticController:
         # 6. Circadian phase
         if self._sleep_start <= hour_utc < self._sleep_end:
             self.state.circadian_phase = "asleep"
-        elif hour_utc == (self._sleep_start - 1) % 24:
-            self.state.circadian_phase = "drowsy"
-        elif hour_utc == self._sleep_end:
+        elif hour_utc == (self._sleep_start - 1) % 24 or hour_utc == self._sleep_end:
             self.state.circadian_phase = "drowsy"
         else:
             self.state.circadian_phase = "awake"

--- a/scripts/bz_content_broadcaster.py
+++ b/scripts/bz_content_broadcaster.py
@@ -122,9 +122,7 @@ def select_top_per_domain(articles: List[Dict]) -> List[Dict]:
         # Store the normalized domain on the article for later use
         a["_news_domain"] = domain
 
-        if domain not in by_domain:
-            by_domain[domain] = a
-        elif a.get("quality_score", 0) > by_domain[domain].get("quality_score", 0):
+        if domain not in by_domain or a.get("quality_score", 0) > by_domain[domain].get("quality_score", 0):
             by_domain[domain] = a
 
     selected = []

--- a/scripts/docs_audit.py
+++ b/scripts/docs_audit.py
@@ -396,7 +396,7 @@ def render_inventory(rows: List[DocRow], clusters: List[ClusterDef]) -> str:
 
     orphan_rows = [r for r in rows if r.action.startswith("archive: orphan")]
     if orphan_rows:
-        out.append("### Orphans (mtime>{}d AND refs_in==0)".format(0))
+        out.append(f"### Orphans (mtime>{0}d AND refs_in==0)")
         for r in orphan_rows:
             out.append(f"- `{r.path}` (mtime={r.mtime_days}d, zero inbound refs)")
         out.append("")

--- a/scripts/exporters/cron_exporter.py
+++ b/scripts/exporters/cron_exporter.py
@@ -51,7 +51,7 @@ def collect_metrics() -> dict[str, dict[str, Any]]:
 
     for filepath in jsonl_files:
         try:
-            with open(filepath, "r") as f:
+            with open(filepath) as f:
                 for line in f:
                     line = line.strip()
                     if not line:

--- a/scripts/nlm_nb1_daily_refresh.py
+++ b/scripts/nlm_nb1_daily_refresh.py
@@ -179,7 +179,7 @@ def create_bundle(bundle_name: str, patterns: list[str], excludes: list[str]) ->
 
         for filepath in sorted(files_to_include):
             try:
-                with open(filepath, "r", encoding="utf-8") as infile:
+                with open(filepath, encoding="utf-8") as infile:
                     content = infile.read()
                 rel_path = os.path.relpath(filepath, PROJECT_ROOT)
                 outfile.write(f"\n{'=' * 60}\n")

--- a/scripts/tests/test_sentinel_v33.py
+++ b/scripts/tests/test_sentinel_v33.py
@@ -210,7 +210,7 @@ class TestPhaseTransitionMatrix:
 
     def test_valid_phases_constant(self):
         from sentinel_lib.circuit_breaker import VALID_PHASES
-        assert VALID_PHASES == frozenset({"T0", "T1", "T2", "T3", "T4", "TERMINAL"})
+        assert frozenset({"T0", "T1", "T2", "T3", "T4", "TERMINAL"}) == VALID_PHASES
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/scripts/translate-articles.py
+++ b/scripts/translate-articles.py
@@ -324,9 +324,7 @@ def main():
         # but in steady state it just means "everything already translated" —
         # a healthy idle, not a failure. Reserve "fail" for genuine errors
         # (which would surface elsewhere as exceptions/non-zero exit codes).
-        if total == 0:
-            sidecar_status = "ok"
-        elif success > 0 and skipped == 0:
+        if total == 0 or success > 0 and skipped == 0:
             sidecar_status = "ok"
         elif success == 0 and skipped == total:
             sidecar_status = "ok"  # idle: nothing new to translate

--- a/scripts/zantara-gateway/gateway.py
+++ b/scripts/zantara-gateway/gateway.py
@@ -447,14 +447,14 @@ async def handle_chat(request: web.Request) -> web.StreamResponse:
         # ── Path 3: Ollama fallback ──
         if not streamed:
             fallback_msg = json.dumps({"type": "system", "data": "Switching to local model..."})
-            await response.write(f"data: {fallback_msg}\n\n".encode("utf-8"))
+            await response.write(f"data: {fallback_msg}\n\n".encode())
             try:
                 async for sse_line in stream_ollama_react(query, config, mcp_client):
                     await response.write(sse_line.encode("utf-8"))
             except Exception as e2:
                 logger.error("All paths failed: %s", e2)
                 error_msg = json.dumps({"type": "error", "data": f"All AI backends unavailable: {e2}"})
-                await response.write(f"data: {error_msg}\n\n".encode("utf-8"))
+                await response.write(f"data: {error_msg}\n\n".encode())
                 await response.write(b"data: [DONE]\n\n")
 
     except ConnectionResetError:


### PR DESCRIPTION
## Summary

45 auto-fixable modernization violations cleaned up via `ruff --fix`.

| Rule | Count | Description |
|---|---|---|
| UP015 | 16 | Remove redundant `open()` mode arg (`'r'` → default) |
| SIM300 | 6 | Yoda conditions (`None == x` → `x is None`) |
| UP012 | 6 | `.encode('utf-8')` → `.encode()` (utf-8 is the default) |
| SIM114 | 5 | Merge if-branches with identical bodies |
| SIM910 | 5 | `dict.get(key, None)` → `dict.get(key)` |
| UP017 | 4 | `datetime.timezone.utc` → `datetime.UTC` |
| UP032 | 3 | `'%s' % x` → `f'{x}'` f-string |

Also fixed F541 (empty f-string) and F401 (unused imports) in files touched during staging.

## Test plan
- [ ] Pre-commit hooks pass (verified: typecheck ✅, ruff ✅, import chain ✅)
- [ ] CI Backend Tests (logic unchanged — pure style modernization)
- [ ] CI E2E Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)