### PR TITLE
feat(routing): R5 AIL #1 — migrate skills to Qdrant Cloud (613 docs)

### DIFF
--- a/apps/backend-rag/backend/core/collection_registry.py
+++ b/apps/backend-rag/backend/core/collection_registry.py
@@ -13,6 +13,9 @@ CANONICAL_LOGICAL_COLLECTIONS: Final[tuple[str, ...]] = (
     "training_conversations_hybrid",
     "immigration_circulars",
     "balizero_news",
+    # R5 AIL #1 (2026-05-17): Mata-Garuda skills/reflections/insights mirrored
+    # to Qdrant Cloud (613 docs). Replaces local-only bali_zero_skills_local.
+    "bali_zero_skills_hybrid",
     # Sprint 2 Shadow Graphing (2026-04-25): NLM-extracted claims projected
     # offline into Qdrant for sub-second runtime retrieval. Schema is
     # NLMShadowChunk (NOT HierarchicalChunk) — kept fully separate so
@@ -36,6 +39,8 @@ LOGICAL_TO_PHYSICAL_COLLECTIONS: Final[dict[str, str]] = {
     "tax_knowledge": "tax_genius_hybrid",
     "legal_updates": "legal_unified_hybrid_hybrid",
     "legal_intelligence": "legal_unified_hybrid_hybrid",
+    # R5 AIL #1: skills on Qdrant Cloud
+    "bali_zero_skills_hybrid": "bali_zero_skills_hybrid",
     # Sprint 2 Shadow Graphing
     "nlm_shadow_hybrid": "nlm_shadow_hybrid",
 }
@@ -60,6 +65,8 @@ CANONICAL_COLLECTION_ALIASES: Final[dict[str, str]] = {
     "balizero_news": "balizero_news",
     "intel_authoritative_sources": "balizero_news",
     "nlm_shadow_hybrid": "nlm_shadow_hybrid",
+    # R5 AIL #1
+    "bali_zero_skills_hybrid": "bali_zero_skills_hybrid",
 }
 
 

--- a/apps/backend-rag/backend/scripts/migrate_skills_to_qdrant_cloud.py
+++ b/apps/backend-rag/backend/scripts/migrate_skills_to_qdrant_cloud.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Migrate Mata-Garuda skills/reflections/insights from SQLite → Qdrant Cloud.
+
+R5 AIL #1 (2026-05-17): re-indexes `bali_zero_skills_local` (Pro Docker,
+local-only) to `bali_zero_skills_hybrid` on Qdrant Cloud so the surface
+is reachable from Fly.io production.
+
+Collection name change:
+  bali_zero_skills_local  → bali_zero_skills_hybrid  (Qdrant Cloud)
+
+Source: apps/mata-garuda/data/knowledge.db (613 rows: skill/reflection/insight)
+
+Usage:
+    cd apps/backend-rag
+    PYTHONPATH=. python -m backend.scripts.migrate_skills_to_qdrant_cloud --dry-run
+    PYTHONPATH=. python -m backend.scripts.migrate_skills_to_qdrant_cloud --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sqlite3
+import sys
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+
+logger = logging.getLogger("migrate_skills_cloud")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+COLLECTION_NAME = "bali_zero_skills_hybrid"
+VECTOR_SIZE = 1536  # text-embedding-3-small — FROZEN
+DISTANCE = "Cosine"
+EMBED_MODEL = "text-embedding-3-small"
+EMBED_BATCH_SIZE = 50
+UPSERT_BATCH_SIZE = 50
+
+QDRANT_URL = os.environ.get(
+    "QDRANT_URL",
+    "https://5575d2b7-d895-4697-86e5-5c7ceae3ca74.us-east4-0.gcp.cloud.qdrant.io:6333",
+)
+QDRANT_API_KEY = os.environ.get("QDRANT_API_KEY", "")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+
+DEFAULT_SQLITE_PATH = Path(
+    os.environ.get(
+        "MATA_GARUDA_KB_PATH",
+        str(Path.home() / "Desktop/nuzantara/apps/mata-garuda/data/knowledge.db"),
+    ),
+)
+
+TARGET_TYPES: tuple[str, ...] = ("skill", "reflection", "insight")
+
+# Deterministic UUID namespace — same as migrate_skills_to_qdrant_local.py
+_POINT_NAMESPACE = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class KnowledgeRow:
+    row_id: int
+    agent: str
+    type: str
+    content: str
+    source: str | None
+    confidence: float
+    created_at: str
+
+
+def _row_point_id(row_id: int) -> str:
+    return str(uuid.uuid5(_POINT_NAMESPACE, f"skills:{row_id}"))
+
+
+# ---------------------------------------------------------------------------
+# SQLite reader
+# ---------------------------------------------------------------------------
+
+def load_rows(sqlite_path: Path) -> list[KnowledgeRow]:
+    if not sqlite_path.exists():
+        raise FileNotFoundError(f"SQLite not found: {sqlite_path}")
+    conn = sqlite3.connect(str(sqlite_path))
+    try:
+        cur = conn.execute(
+            "SELECT id, agent, type, content, source, confidence, created_at "
+            "FROM knowledge WHERE type IN ('skill','reflection','insight') "
+            "ORDER BY id"
+        )
+        return [
+            KnowledgeRow(
+                row_id=r[0], agent=r[1], type=r[2], content=r[3],
+                source=r[4], confidence=float(r[5] or 0.5), created_at=r[6] or "",
+            )
+            for r in cur.fetchall()
+        ]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Embedding (OpenAI REST — no SDK, no paid Anthropic key)
+# ---------------------------------------------------------------------------
+
+async def embed_batch(texts: list[str], client: httpx.AsyncClient) -> list[list[float]]:
+    resp = await client.post(
+        "https://api.openai.com/v1/embeddings",
+        headers={"Authorization": f"Bearer {OPENAI_API_KEY}"},
+        json={"model": EMBED_MODEL, "input": texts},
+        timeout=60,
+    )
+    resp.raise_for_status()
+    data = resp.json()["data"]
+    return [d["embedding"] for d in sorted(data, key=lambda x: x["index"])]
+
+
+# ---------------------------------------------------------------------------
+# Qdrant Cloud helpers
+# ---------------------------------------------------------------------------
+
+def _qdrant_headers() -> dict[str, str]:
+    h = {"Content-Type": "application/json"}
+    if QDRANT_API_KEY:
+        h["api-key"] = QDRANT_API_KEY
+    return h
+
+
+async def collection_exists(client: httpx.AsyncClient) -> bool:
+    r = await client.get(
+        f"{QDRANT_URL}/collections/{COLLECTION_NAME}",
+        headers=_qdrant_headers(),
+        timeout=10,
+    )
+    return r.status_code == 200
+
+
+async def create_collection(client: httpx.AsyncClient) -> None:
+    payload = {
+        "vectors": {
+            "size": VECTOR_SIZE,
+            "distance": DISTANCE,
+            "on_disk": False,
+        },
+        "sparse_vectors": {
+            "text-sparse": {"index": {"on_disk": False}}
+        },
+    }
+    r = await client.put(
+        f"{QDRANT_URL}/collections/{COLLECTION_NAME}",
+        headers=_qdrant_headers(),
+        json=payload,
+        timeout=30,
+    )
+    r.raise_for_status()
+    logger.info("Collection %s created", COLLECTION_NAME)
+
+
+async def upsert_points(
+    client: httpx.AsyncClient,
+    rows: list[KnowledgeRow],
+    vectors: list[list[float]],
+) -> None:
+    points = [
+        {
+            "id": _row_point_id(row.row_id),
+            "vector": vec,
+            "payload": {
+                "row_id": row.row_id,
+                "agent": row.agent,
+                "type": row.type,
+                "content": row.content,
+                "source": row.source or "",
+                "confidence": row.confidence,
+                "created_at": row.created_at,
+            },
+        }
+        for row, vec in zip(rows, vectors, strict=True)
+    ]
+    r = await client.put(
+        f"{QDRANT_URL}/collections/{COLLECTION_NAME}/points",
+        headers=_qdrant_headers(),
+        json={"points": points},
+        timeout=60,
+    )
+    r.raise_for_status()
+
+
+async def get_point_count(client: httpx.AsyncClient) -> int:
+    r = await client.get(
+        f"{QDRANT_URL}/collections/{COLLECTION_NAME}",
+        headers=_qdrant_headers(),
+        timeout=10,
+    )
+    if r.status_code == 200:
+        return r.json()["result"].get("points_count", 0)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Main migration
+# ---------------------------------------------------------------------------
+
+async def run_migration(dry_run: bool, sqlite_path: Path) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    if not OPENAI_API_KEY:
+        logger.error("OPENAI_API_KEY not set")
+        sys.exit(1)
+    if not QDRANT_API_KEY:
+        logger.error("QDRANT_API_KEY not set")
+        sys.exit(1)
+
+    logger.info("Loading rows from %s", sqlite_path)
+    rows = load_rows(sqlite_path)
+    logger.info("Loaded %d rows (skill=%d, reflection=%d, insight=%d)",
+        len(rows),
+        sum(1 for r in rows if r.type == "skill"),
+        sum(1 for r in rows if r.type == "reflection"),
+        sum(1 for r in rows if r.type == "insight"),
+    )
+
+    if dry_run:
+        logger.info("[DRY RUN] Would upsert %d points to %s/%s", len(rows), QDRANT_URL[:40], COLLECTION_NAME)
+        return
+
+    async with httpx.AsyncClient() as client:
+        exists = await collection_exists(client)
+        if not exists:
+            logger.info("Creating collection %s on Qdrant Cloud ...", COLLECTION_NAME)
+            await create_collection(client)
+        else:
+            existing_count = await get_point_count(client)
+            logger.info("Collection already exists with %d points — upserting (idempotent)", existing_count)
+
+        # Embed in batches
+        all_vectors: list[list[float]] = []
+        for i in range(0, len(rows), EMBED_BATCH_SIZE):
+            batch = rows[i:i + EMBED_BATCH_SIZE]
+            texts = [r.content for r in batch]
+            logger.info("Embedding batch %d/%d (%d texts) ...",
+                i // EMBED_BATCH_SIZE + 1,
+                (len(rows) - 1) // EMBED_BATCH_SIZE + 1,
+                len(texts),
+            )
+            vecs = await embed_batch(texts, client)
+            all_vectors.extend(vecs)
+
+        # Upsert in batches
+        for i in range(0, len(rows), UPSERT_BATCH_SIZE):
+            batch_rows = rows[i:i + UPSERT_BATCH_SIZE]
+            batch_vecs = all_vectors[i:i + UPSERT_BATCH_SIZE]
+            logger.info("Upserting batch %d/%d (%d points) ...",
+                i // UPSERT_BATCH_SIZE + 1,
+                (len(rows) - 1) // UPSERT_BATCH_SIZE + 1,
+                len(batch_rows),
+            )
+            await upsert_points(client, batch_rows, batch_vecs)
+
+        final_count = await get_point_count(client)
+        logger.info("Done. Collection %s now has %d points (expected %d)",
+            COLLECTION_NAME, final_count, len(rows))
+
+        if final_count < len(rows):
+            logger.error("Point count mismatch! Expected %d, got %d", len(rows), final_count)
+            sys.exit(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Migrate skills to Qdrant Cloud")
+    parser.add_argument("--dry-run", action="store_true", help="Preview only, no writes")
+    parser.add_argument("--apply", action="store_true", help="Execute migration")
+    parser.add_argument("--sqlite-path", default=str(DEFAULT_SQLITE_PATH))
+    args = parser.parse_args()
+
+    if not args.dry_run and not args.apply:
+        parser.print_help()
+        sys.exit(1)
+
+    asyncio.run(run_migration(
+        dry_run=args.dry_run,
+        sqlite_path=Path(args.sqlite_path),
+    ))
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/backend-rag/backend/services/routing/surface_router.py
+++ b/apps/backend-rag/backend/services/routing/surface_router.py
@@ -5,7 +5,7 @@
   Layer 2: Claude Haiku 4.5 classifier when confidence < HAIKU_THRESHOLD (async, mocked in tests).
 
 Feature flag: SURFACE_ROUTER_ENABLED env var (default "false" — shadow mode).
-Skills surface: local-only (QDRANT_LOCAL_URL), is_local_only=True.
+Skills surface: bali_zero_skills_hybrid on Qdrant Cloud (R5 AIL #1, 2026-05-17).
 
 Ref: docs/superpowers/specs/2026-05-16-r5-phase3-surface-router-design.md
 """
@@ -79,8 +79,8 @@ SURFACE_COLLECTIONS: dict[str, tuple[str, list[str]]] = {
         ["balizero_news", "visa_oracle", "legal_unified_hybrid_hybrid"],
     ),
     Surface.QDRANT_SKILLS: (
-        "bali_zero_skills_local",
-        ["bali_zero_skills_local"],
+        "bali_zero_skills_hybrid",
+        ["bali_zero_skills_hybrid"],
     ),
 }
 
@@ -164,7 +164,7 @@ def _make_decision(
         domain=domain,
         confidence=confidence,
         layer_used=layer_used,
-        is_local_only=(surface == Surface.QDRANT_SKILLS),
+        is_local_only=False,  # R5 AIL #1: skills moved to Qdrant Cloud (bali_zero_skills_hybrid)
         latency_ms=latency_ms,
     )
 
@@ -437,7 +437,7 @@ def _collection_to_domain(collection: str) -> str:
         "training_conversations_hybrid": "company",
         "bali_zero_pricing_hybrid": "pricing",
         "balizero_news": "news",
-        "bali_zero_skills_local": "skills",
+        "bali_zero_skills_hybrid": "skills",
     }
     return mapping.get(collection, "legal")
 

--- a/apps/backend-rag/backend/tests/services/routing/test_surface_router.py
+++ b/apps/backend-rag/backend/tests/services/routing/test_surface_router.py
@@ -250,13 +250,14 @@ class TestSkillsSurface:
                 f"Query '{q[:50]}' routed to {decision.surface}, expected qdrant_skills"
             )
 
-    def test_skills_surface_is_local_only(self, router):
+    def test_skills_surface_is_not_local_only(self, router):
+        # R5 AIL #1: skills migrated to Qdrant Cloud (bali_zero_skills_hybrid)
         d = _route(router, "internal ops workflow checklist")
-        assert d.is_local_only is True
+        assert d.is_local_only is False
 
     def test_skills_collection_name(self, router):
         d = _route(router, "skill for handling visa client onboarding")
-        assert d.primary_collection == "bali_zero_skills_local"
+        assert d.primary_collection == "bali_zero_skills_hybrid"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Re-indexes `bali_zero_skills_local` (Pro Docker, local-only) → `bali_zero_skills_hybrid` on Qdrant Cloud
- 613 skill/reflection/insight docs from `mata-garuda/data/knowledge.db`
- Embedding: `text-embedding-3-small` (1536 dims, frozen)
- `SurfaceRouter.SURFACE_COLLECTIONS` updated + `is_local_only=False` for all surfaces
- `collection_registry.py`: registered in all 3 dicts
- Migration script: `backend/scripts/migrate_skills_to_qdrant_cloud.py` (idempotent)

## Why

`qdrant_skills` surface was inaccessible from Fly.io (relied on `127.0.0.1:6333`). Now on Qdrant Cloud alongside the other 12 collections.

## Stats

| Type | Count |
|------|-------|
| skill | 203 |
| reflection | 205 |
| insight | 205 |
| **total** | **613** |

## Test plan

- [x] 29/29 tests passing
- [x] Import chain OK
- [x] Ruff + prettier clean
- [x] Migration dry-run → apply verified (613/613 points on Cloud)

🤖 Generated with [Claude Code](https://claude.com/claude-code)