### PR TITLE
feat(routing): R5 Phase 4 — KG surface as 8th SurfaceRouter surface

### DIFF
--- a/apps/backend-rag/backend/services/routing/surface_router.py
+++ b/apps/backend-rag/backend/services/routing/surface_router.py
@@ -1,4 +1,4 @@
-"""SurfaceRouter — R5 Phase 3.
+"""SurfaceRouter — R5 Phase 3+4.
 
 2-layer routing:
   Layer 1: Keyword scoring via QueryRouterIntegration (< 1 ms, ~80 % of queries).
@@ -6,6 +6,7 @@
 
 Feature flag: SURFACE_ROUTER_ENABLED env var (default "false" — shadow mode).
 Skills surface: bali_zero_skills_hybrid on Qdrant Cloud (R5 AIL #1, 2026-05-17).
+KG surface: routes entity/relationship queries to KGOrchestrator (Neo4j, R5 Phase 4, 2026-05-17).
 
 Ref: docs/superpowers/specs/2026-05-16-r5-phase3-surface-router-design.md
 """
@@ -46,6 +47,8 @@ class Surface:
     QDRANT_PRICING = "qdrant_pricing"
     QDRANT_NEWS = "qdrant_news"
     QDRANT_SKILLS = "qdrant_skills"
+    # R5 Phase 4: Neo4j KG as 8th surface — entity/relationship queries
+    KG = "kg"
 
 
 # ---------------------------------------------------------------------------
@@ -132,6 +135,27 @@ _NEWS_TERMS: frozenset[str] = frozenset({
     "pengumuman", "announcement",
 })
 
+# KG-trigger keywords — entity/relationship queries routed to Neo4j KGOrchestrator
+# Multilingual: EN + IT + ID (R5 Phase 4, 2026-05-17)
+_KG_ENTITY_KEYWORDS: frozenset[str] = frozenset({
+    # Entity resolution
+    "chi è", "who is", "siapa", "direttore", "direktur", "owner of", "pemilik",
+    "entity", "entità", "entitas",
+    # Relationship traversal
+    "relazione tra", "relationship between", "hubungan antara",
+    "collegato a", "linked to", "terhubung ke", "terhubung dengan",
+    "connected to", "kolega", "associated with",
+    # Structure / hierarchy
+    "struttura societaria", "company structure", "struktur perusahaan",
+    "organigramma", "company ownership", "kepemilikan perusahaan",
+    "ownership structure", "shareholder", "pemegang saham",
+    # Graph-specific
+    "graph traversal", "graph search", "knowledge graph",
+    "chi conosce", "who knows", "siapa yang mengenal",
+    "collegato a quale", "linked to which",
+    "entity relationship", "relasi entitas",
+})
+
 
 # ---------------------------------------------------------------------------
 # SurfaceDecision dataclass
@@ -147,6 +171,7 @@ class SurfaceDecision:
     layer_used: int           # 1 = keyword, 2 = haiku
     is_local_only: bool
     latency_ms: float
+    is_kg_surface: bool = False  # R5 Phase 4: True → route to KGOrchestrator, skip Qdrant
 
 
 def _make_decision(
@@ -166,6 +191,22 @@ def _make_decision(
         layer_used=layer_used,
         is_local_only=False,  # R5 AIL #1: skills moved to Qdrant Cloud (bali_zero_skills_hybrid)
         latency_ms=latency_ms,
+        is_kg_surface=False,
+    )
+
+
+def _make_kg_decision(latency_ms: float) -> SurfaceDecision:
+    """Build a KG SurfaceDecision — no Qdrant collections, routes to KGOrchestrator."""
+    return SurfaceDecision(
+        surface=Surface.KG,
+        primary_collection="",  # no Qdrant collection — caller uses KGOrchestrator
+        collections=[],
+        domain="kg",
+        confidence=0.88,
+        layer_used=1,
+        is_local_only=False,
+        latency_ms=latency_ms,
+        is_kg_surface=True,
     )
 
 
@@ -185,7 +226,8 @@ def _get_integration() -> QueryRouterIntegration:
 _HAIKU_SYSTEM = (
     "You are a query router for Bali Zero, an Indonesian business services company. "
     "Classify the user query into exactly ONE domain from this list: "
-    "visa, tax, company, property, pricing, news, skills. "
+    "visa, tax, company, property, pricing, news, skills, kg. "
+    "Use 'kg' for entity/relationship queries (who is, ownership structure, graph traversal). "
     "Reply ONLY with a JSON object: "
     '{"domain": "<domain>", "confidence": <0.0-1.0>}'
 )
@@ -224,6 +266,15 @@ class SurfaceRouter:
         if self._integration is None:
             self._integration = _get_integration()
         return self._integration
+
+    # ------------------------------------------------------------------
+    # KG detection (entity/relationship queries → Neo4j KGOrchestrator)
+    # R5 Phase 4 — checked BEFORE skills and pricing to prioritise entity intent
+    # ------------------------------------------------------------------
+
+    def _is_kg_query(self, query: str) -> bool:
+        q = query.lower()
+        return any(kw in q for kw in _KG_ENTITY_KEYWORDS)
 
     # ------------------------------------------------------------------
     # Skills detection (pre-check before domain routing)
@@ -305,8 +356,11 @@ class SurfaceRouter:
                 "pricing": Surface.QDRANT_PRICING,
                 "news": Surface.QDRANT_NEWS,
                 "skills": Surface.QDRANT_SKILLS,
+                "kg": Surface.KG,
             }
             surface = domain_surface_map.get(domain, Surface.QDRANT_VISA)
+            if surface == Surface.KG:
+                return _make_kg_decision(latency_ms=0.0)
             return _make_decision(surface, domain, haiku_confidence, layer_used=2, latency_ms=0.0)
         except (TimeoutError, asyncio.TimeoutError):
             logger.warning("SurfaceRouter: Haiku timeout on query '%s'", query[:60])
@@ -339,6 +393,11 @@ class SurfaceRouter:
         For Haiku enrichment on ambiguous queries, use adecide() from async context.
         """
         t0 = time.perf_counter()
+
+        # R5 Phase 4: KG surface — entity/relationship queries (checked first)
+        if self._is_kg_query(query):
+            elapsed = (time.perf_counter() - t0) * 1000
+            return _make_kg_decision(elapsed)
 
         # Fast pre-checks (ordered by specificity — pricing first to catch "KITAS renewal cost")
         if self._is_skills_query(query):
@@ -383,6 +442,11 @@ class SurfaceRouter:
     async def adecide(self, query: str) -> SurfaceDecision:
         """Route a query with optional Haiku enrichment for ambiguous cases."""
         t0 = time.perf_counter()
+
+        # R5 Phase 4: KG surface — entity/relationship queries (no Haiku needed)
+        if self._is_kg_query(query):
+            elapsed = (time.perf_counter() - t0) * 1000
+            return _make_kg_decision(elapsed)
 
         # Fast pre-checks (no Haiku needed)
         if self._is_skills_query(query):

--- a/apps/backend-rag/backend/tests/services/routing/test_surface_router.py
+++ b/apps/backend-rag/backend/tests/services/routing/test_surface_router.py
@@ -375,3 +375,81 @@ class TestDisabledMode:
     def test_enabled_mode_flag(self):
         r = SurfaceRouter(enabled=True)
         assert r.enabled is True
+
+
+# ---------------------------------------------------------------------------
+# 11. KG surface (R5 Phase 4 — Neo4j Knowledge Graph as 8th surface)
+# ---------------------------------------------------------------------------
+
+class TestKGSurface:
+    """KG surface routes entity/relationship queries to KGOrchestrator (Neo4j).
+
+    KG surface is flagged is_kg_surface=True so callers skip Qdrant collections.
+    No primary_collection is required (primary_collection = "" sentinel).
+    """
+
+    QUERIES = [
+        # Entity resolution
+        "chi è il direttore di PT XYZ Bali?",
+        "who is the owner of this company in Indonesia?",
+        "siapa direktur utama perusahaan ini?",
+        # Relationship traversal
+        "qual è la relazione tra permesso di lavoro e KITAS?",
+        "what is the relationship between KBLI and business license?",
+        "hubungan antara NIB dan SIUP di Indonesia",
+        # Structure / hierarchy
+        "struttura societaria PT PMA Bali",
+        "organigramma aziendale per PMA",
+        "company ownership structure Indonesia",
+        # Graph-specific patterns
+        "chi conosce questo cliente?",
+        "collegato a quale pratica?",
+        "linked to which visa application?",
+        "graph traversal company directors",
+        "entity relationship company founder",
+    ]
+
+    def test_all_kg_queries_route_to_kg_surface(self, router):
+        for q in self.QUERIES:
+            decision = _route(router, q)
+            assert decision.surface == Surface.KG, (
+                f"Query '{q[:60]}' routed to {decision.surface}, expected kg"
+            )
+
+    def test_kg_is_kg_surface_flag(self, router):
+        d = _route(router, "chi è il direttore di questa azienda?")
+        assert d.is_kg_surface is True
+
+    def test_kg_not_local_only(self, router):
+        d = _route(router, "struttura societaria PT PMA")
+        assert d.is_local_only is False
+
+    def test_kg_primary_collection_empty(self, router):
+        d = _route(router, "entity relationship company founder")
+        assert d.primary_collection == ""
+
+    def test_kg_collections_empty(self, router):
+        d = _route(router, "organigramma aziendale")
+        assert d.collections == []
+
+    def test_kg_layer_is_keyword(self, router):
+        d = _route(router, "chi conosce questo cliente?")
+        assert d.layer_used == 1
+
+    def test_kg_confidence_above_threshold(self, router):
+        d = _route(router, "struttura societaria azienda Indonesia")
+        assert d.confidence >= 0.80
+
+    def test_kg_surface_constant_exists(self):
+        assert hasattr(Surface, "KG")
+        assert Surface.KG == "kg"
+
+    def test_kg_decision_has_domain(self, router):
+        d = _route(router, "relationship between KBLI and business permit")
+        assert d.domain == "kg"
+
+    def test_kg_latency_keyword_path(self, router):
+        start = time.perf_counter()
+        _route(router, "entity relationship company directors Indonesia")
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        assert elapsed_ms < 200, f"KG keyword path too slow: {elapsed_ms:.1f}ms"


### PR DESCRIPTION
## Summary

- Add `Surface.KG = "kg"` as 8th surface to `SurfaceRouter` (R5 Phase 4)
- `_KG_ENTITY_KEYWORDS` frozenset: 30+ triggers in EN/IT/ID (entity resolution, relationship traversal, graph structure)
- `_make_kg_decision()` factory: `primary_collection=""`, `collections=[]`, `is_kg_surface=True` — callers skip Qdrant, route to `KGOrchestrator.query()`
- `SurfaceDecision.is_kg_surface: bool = False` — default-safe for existing 7 surfaces
- KG pre-check fires first in `decide()` + `adecide()` before skills/pricing/visa intercepts
- Haiku classifier updated: `domain_surface_map["kg"]` + `_HAIKU_SYSTEM` mentions `kg` domain

## Test plan

- [x] TDD: 10 red → 10 green (`TestKGSurface`, 14 canonical queries EN/IT/ID)
- [x] Full suite regression: 39/39 pass (0 new failures)
- [x] Import chain: `from backend.app.dependencies import get_current_user` OK
- [x] Pre-push hook: all pre-commit checks passed

## Notes

- `is_kg_surface=True` is the contract signal for callers (RAG orchestrator, reasoning.py) to route to `KGOrchestrator` instead of Qdrant hybrid search
- KG surface is keyword-only (no Haiku fallback needed — entity queries have unambiguous lexical markers)
- No migration required (pure routing logic, no schema changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)