### PR TITLE
feat(graph-engine): add gated checkpointer factory

### DIFF
--- a/apps/graph-engine/src/nuzantara_graph/config.py
+++ b/apps/graph-engine/src/nuzantara_graph/config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -46,6 +48,22 @@ class Settings(BaseSettings):
     retrieval_top_k: int = 10
     rerank_top_k: int = 5
     semantic_cache_ttl_seconds: int = 3600
+    checkpointer_enabled: bool = Field(
+        default=False,
+        description="Enable LangGraph checkpoint persistence. Disabled by default to avoid DB writes.",
+    )
+    checkpointer_backend: Literal["postgres", "memory"] = Field(
+        default="postgres",
+        description="Checkpoint backend. 'memory' is explicit test/dev only.",
+    )
+    checkpointer_database_url: str = Field(
+        default="",
+        description="Dedicated PostgreSQL URL for LangGraph checkpoints.",
+    )
+    checkpointer_postgres_pipeline: bool = Field(
+        default=True,
+        description="Use psycopg pipeline mode for PostgresSaver writes.",
+    )
 
     # Auth
     jwt_secret: str = ""

--- a/apps/graph-engine/src/nuzantara_graph/graph/checkpointer.py
+++ b/apps/graph-engine/src/nuzantara_graph/graph/checkpointer.py
@@ -1,10 +1,100 @@
-"""LangGraph checkpointer setup — PostgresSaver for state persistence."""
+"""LangGraph checkpointer factory.
+
+Checkpoint persistence is feature-gated and disabled by default. Enabling
+Postgres requires a dedicated checkpointer DSN so the graph cannot silently
+write checkpoints to the app database just because ``database_url`` has a
+development default.
+"""
 
 from __future__ import annotations
 
-# TODO (Batch 3): Implement PostgresSaver checkpointer
-# from langgraph.checkpoint.postgres import PostgresSaver
-# from nuzantara_graph.config import settings
-#
-# def get_checkpointer() -> PostgresSaver:
-#     return PostgresSaver.from_conn_string(settings.database_url)
+from collections.abc import Iterator
+from contextlib import contextmanager
+from importlib import import_module
+from typing import Any
+
+import structlog
+from langgraph.checkpoint.base import BaseCheckpointSaver
+
+from nuzantara_graph.config import Settings, settings
+
+logger = structlog.get_logger()
+
+
+class CheckpointerError(RuntimeError):
+    """Base exception for graph checkpointer setup failures."""
+
+
+class CheckpointerConfigurationError(CheckpointerError):
+    """Raised when checkpoint persistence is enabled with invalid config."""
+
+
+class CheckpointerDependencyError(CheckpointerError):
+    """Raised when the selected checkpoint backend is not installed."""
+
+
+@contextmanager
+def get_checkpointer(config: Settings | None = None) -> Iterator[BaseCheckpointSaver | None]:
+    """Yield a configured LangGraph checkpointer or ``None``.
+
+    The function is a context manager because ``PostgresSaver.from_conn_string``
+    owns a database connection. Callers that compile a graph with persistence
+    should keep this context open for the lifetime of the compiled graph.
+    """
+    cfg = config or settings
+
+    if not cfg.checkpointer_enabled:
+        logger.info("graph_checkpointer_disabled")
+        yield None
+        return
+
+    if cfg.checkpointer_backend == "memory":
+        saver = _make_memory_saver()
+        logger.warning("graph_checkpointer_memory_enabled")
+        yield saver
+        return
+
+    if cfg.checkpointer_backend == "postgres":
+        database_url = cfg.checkpointer_database_url.strip()
+        if not database_url:
+            raise CheckpointerConfigurationError(
+                "NUZANTARA_CHECKPOINTER_DATABASE_URL is required when "
+                "NUZANTARA_CHECKPOINTER_ENABLED=true and backend=postgres"
+            )
+
+        postgres_saver = _load_postgres_saver()
+        logger.info("graph_checkpointer_postgres_enabled")
+        with postgres_saver.from_conn_string(
+            database_url,
+            pipeline=cfg.checkpointer_postgres_pipeline,
+        ) as saver:
+            yield saver
+        return
+
+    raise CheckpointerConfigurationError(
+        f"Unsupported checkpointer backend: {cfg.checkpointer_backend}"
+    )
+
+
+def _load_postgres_saver() -> type[Any]:
+    try:
+        module = import_module("langgraph.checkpoint.postgres")
+    except ModuleNotFoundError as exc:
+        raise CheckpointerDependencyError(
+            "Install langgraph-checkpoint-postgres to enable Postgres checkpointing"
+        ) from exc
+    return module.PostgresSaver
+
+
+def _make_memory_saver() -> BaseCheckpointSaver:
+    try:
+        module = import_module("langgraph.checkpoint.memory")
+    except ModuleNotFoundError as exc:
+        raise CheckpointerDependencyError(
+            "langgraph.checkpoint.memory is required for the explicit memory checkpointer"
+        ) from exc
+
+    saver_cls = getattr(module, "MemorySaver", None) or getattr(module, "InMemorySaver", None)
+    if saver_cls is None:
+        raise CheckpointerDependencyError("LangGraph memory checkpointer is unavailable")
+    return saver_cls()

--- a/apps/graph-engine/tests/unit/test_checkpointer.py
+++ b/apps/graph-engine/tests/unit/test_checkpointer.py
@@ -1,0 +1,112 @@
+"""Tests for the LangGraph checkpointer factory."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from langgraph.checkpoint.base import empty_checkpoint
+
+from nuzantara_graph.config import Settings
+from nuzantara_graph.graph import checkpointer
+
+
+def test_default_disabled_does_not_import_postgres(monkeypatch: pytest.MonkeyPatch) -> None:
+    imports: list[str] = []
+
+    def fail_on_import(name: str) -> Any:
+        imports.append(name)
+        raise AssertionError(f"unexpected import: {name}")
+
+    monkeypatch.setattr(checkpointer, "import_module", fail_on_import, raising=False)
+
+    with checkpointer.get_checkpointer(Settings(database_url="postgresql://default/db")) as saver:
+        assert saver is None
+
+    assert imports == []
+
+
+def test_enabled_postgres_requires_dedicated_checkpointer_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_on_import(name: str) -> Any:
+        raise AssertionError(f"unexpected import before config validation: {name}")
+
+    monkeypatch.setattr(checkpointer, "import_module", fail_on_import, raising=False)
+    cfg = Settings(
+        checkpointer_enabled=True,
+        checkpointer_backend="postgres",
+        checkpointer_database_url="",
+    )
+
+    with pytest.raises(checkpointer.CheckpointerConfigurationError, match="CHECKPOINTER_DATABASE_URL"):
+        with checkpointer.get_checkpointer(cfg):
+            pass
+
+
+def test_enabled_postgres_reports_missing_optional_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def missing_postgres(name: str) -> Any:
+        if name == "langgraph.checkpoint.postgres":
+            raise ModuleNotFoundError("No module named 'langgraph.checkpoint.postgres'")
+        raise AssertionError(f"unexpected import: {name}")
+
+    monkeypatch.setattr(checkpointer, "import_module", missing_postgres, raising=False)
+    cfg = Settings(
+        checkpointer_enabled=True,
+        checkpointer_backend="postgres",
+        checkpointer_database_url="postgresql://user:pass@localhost:5432/checkpoints",
+    )
+
+    with pytest.raises(checkpointer.CheckpointerDependencyError, match="langgraph-checkpoint-postgres"):
+        with checkpointer.get_checkpointer(cfg):
+            pass
+
+
+def test_enabled_postgres_uses_configured_url_without_touching_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentinel = object()
+    calls: list[tuple[str, bool]] = []
+
+    class FakePostgresSaver:
+        @classmethod
+        def from_conn_string(cls, conn_string: str, *, pipeline: bool = False) -> Any:
+            calls.append((conn_string, pipeline))
+            return nullcontext(sentinel)
+
+    def fake_import(name: str) -> Any:
+        assert name == "langgraph.checkpoint.postgres"
+        return SimpleNamespace(PostgresSaver=FakePostgresSaver)
+
+    monkeypatch.setattr(checkpointer, "import_module", fake_import, raising=False)
+    cfg = Settings(
+        checkpointer_enabled=True,
+        checkpointer_backend="postgres",
+        checkpointer_database_url="postgresql://user:pass@localhost:5432/checkpoints",
+    )
+
+    with checkpointer.get_checkpointer(cfg) as saver:
+        assert saver is sentinel
+
+    assert calls == [("postgresql://user:pass@localhost:5432/checkpoints", True)]
+
+
+def test_explicit_memory_backend_round_trips_checkpoint_payload() -> None:
+    cfg = Settings(checkpointer_enabled=True, checkpointer_backend="memory")
+
+    with checkpointer.get_checkpointer(cfg) as saver:
+        assert saver is not None
+        config = {"configurable": {"thread_id": "unit-test", "checkpoint_ns": ""}}
+        checkpoint = empty_checkpoint()
+        checkpoint["channel_values"]["payload"] = {"answer": "ok", "items": [1, 2]}
+        checkpoint["channel_versions"]["payload"] = "1"
+
+        saved_config = saver.put(config, checkpoint, {"source": "unit-test"}, {"payload": "1"})
+        restored = saver.get(saved_config)
+
+    assert restored is not None
+    assert restored["channel_values"]["payload"] == {"answer": "ok", "items": [1, 2]}


### PR DESCRIPTION
## Scope
- Adds a default-off graph-engine checkpointer factory.
- Supports explicit memory backend for tests/dev.
- Requires explicit Postgres feature gate plus dedicated DB URL before touching Postgres.

## Verification
- `PYTHONPATH=src:../../packages/shared-schemas/src:tests /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m pytest tests/unit/test_checkpointer.py tests/unit/test_graph_builder.py tests/integration -q` -> 29 passed
- `ruff check` on touched graph-engine files -> passed

## Notes
- Existing full unit suite still has unrelated `tests/unit/api/test_routes.py` import failure for missing `nuzantara_graph.main`.
