### PR TITLE
feat(cep): add backend answer source

### DIFF
--- a/apps/evaluator/cep/run_cep.py
+++ b/apps/evaluator/cep/run_cep.py
@@ -2,9 +2,10 @@
 """Sprint 2 CEP — Continuous Evaluation Pipeline.
 
 Runs the versioned golden query set against a target answer source
-(``--answers-file`` JSON map, or stub for dry-run), grades each result
-with DeepSeek V4 Pro (Think Max mode) against the rubric (required_facts), and emits a
-CSV report + summary suitable for cron + Telegram alerting.
+(``--answers-file`` JSON map, thin HTTP backend source, or stub for
+dry-run), optionally grades each result with DeepSeek V4 Pro (Think Max
+mode) against the rubric (required_facts), and emits a CSV report +
+summary suitable for cron + Telegram alerting.
 
 Why DeepSeek as evaluator:
   - Cheap (~$0.01/query) — 50 queries × 4 runs/day = ~$60/month, in
@@ -20,10 +21,17 @@ Usage:
     # Dry-run on synthetic answers (CI smoke)
     python -m apps.evaluator.cep.run_cep --golden golden_v20260425.json --dry-run
 
-    # Real run with pre-collected answers JSON
+    # Collect answers from a live/shadow backend without paid evaluation
+    python -m apps.evaluator.cep.run_cep \\
+        --golden golden_v20260425.json \\
+        --backend-url http://localhost:8000 \\
+        --report /tmp/cep-answers-$(date +%F).csv
+
+    # Real run with pre-collected answers JSON and explicit paid evaluator
     python -m apps.evaluator.cep.run_cep \\
         --golden golden_v20260425.json \\
         --answers-file /tmp/cep-answers.json \\
+        --enable-evaluator \\
         --report /tmp/cep-report-$(date +%F).csv
 """
 
@@ -31,6 +39,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+from dataclasses import dataclass
 import json
 import logging
 import os
@@ -39,6 +48,9 @@ import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import urljoin
+
+import httpx
 
 logger = logging.getLogger("cep")
 
@@ -55,6 +67,26 @@ DEEPSEEK_RUBRIC_PROMPT = (
 )
 
 
+@dataclass(frozen=True)
+class BackendAnswerSourceConfig:
+    """Thin HTTP answer-source configuration for live/shadow RAG backends."""
+
+    base_url: str
+    endpoint: str = "/api/agentic-rag/query"
+    api_key_env: str | None = None
+    timeout: float = 30.0
+    transport: httpx.BaseTransport | None = None
+
+
+@dataclass(frozen=True)
+class AnswerSourceResult:
+    """Resolved answer text plus source metadata for one golden query."""
+
+    answer: str
+    answer_source: str
+    source_error: str | None = None
+
+
 def load_golden(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text())
 
@@ -64,6 +96,89 @@ def iter_queries(golden: dict[str, Any]):
     for domain, queries in golden.get("domains", {}).items():
         for q in queries:
             yield domain, q
+
+
+def _short_error(value: Any) -> str:
+    return " ".join(str(value).split())[:200]
+
+
+def _join_backend_url(base_url: str, endpoint: str) -> str:
+    """Join a backend base URL and endpoint without importing backend code."""
+    return urljoin(f"{base_url.rstrip('/')}/", endpoint.lstrip("/"))
+
+
+def _extract_answer_text(payload: dict[str, Any]) -> str:
+    """Extract answer text from common RAG/shadow response shapes."""
+    if payload.get("success") is False:
+        error = payload.get("error") or payload.get("warning") or "backend returned success=false"
+        raise ValueError(f"backend success=false: {_short_error(error)}")
+
+    containers: list[dict[str, Any]] = [payload]
+    for nested_key in ("data", "result"):
+        nested = payload.get(nested_key)
+        if isinstance(nested, dict):
+            containers.append(nested)
+
+    for container in containers:
+        for key in ("answer", "response", "final_answer", "text"):
+            value = container.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+
+    raise ValueError("backend response did not contain an answer field")
+
+
+def fetch_backend_answer(
+    *,
+    query_id: str,
+    query: str,
+    config: BackendAnswerSourceConfig,
+) -> AnswerSourceResult:
+    """Fetch a single answer through HTTP, returning row-local errors."""
+    headers = {"Content-Type": "application/json"}
+    if config.api_key_env:
+        api_key = os.environ.get(config.api_key_env, "").strip()
+        if not api_key:
+            return AnswerSourceResult(
+                answer="",
+                answer_source="backend",
+                source_error=f"missing api key env {config.api_key_env}",
+            )
+        headers["Authorization"] = f"Bearer {api_key}"
+        headers["x-api-key"] = api_key
+
+    payload = {
+        "query": query,
+        "user_id": "cep_eval",
+        "session_id": f"cep-{query_id}",
+        "conversation_history": [],
+    }
+    url = _join_backend_url(config.base_url, config.endpoint)
+
+    try:
+        with httpx.Client(timeout=config.timeout, transport=config.transport) as client:
+            response = client.post(url, json=payload, headers=headers)
+            response.raise_for_status()
+            answer = _extract_answer_text(response.json())
+        return AnswerSourceResult(answer=answer, answer_source="backend")
+    except httpx.HTTPStatusError as exc:
+        return AnswerSourceResult(
+            answer="",
+            answer_source="backend",
+            source_error=f"HTTP {exc.response.status_code}: {_short_error(exc.response.text)}",
+        )
+    except httpx.TimeoutException as exc:
+        return AnswerSourceResult(
+            answer="",
+            answer_source="backend",
+            source_error=f"timeout: {_short_error(exc)}",
+        )
+    except (httpx.HTTPError, ValueError, json.JSONDecodeError) as exc:
+        return AnswerSourceResult(
+            answer="",
+            answer_source="backend",
+            source_error=_short_error(exc),
+        )
 
 
 def grade_with_deepseek(
@@ -129,6 +244,12 @@ def run_cep(
     dry_run: bool = False,
     report_path: Optional[Path] = None,
     deepseek_key: Optional[str] = None,
+    enable_evaluator: bool = False,
+    backend_url: Optional[str] = None,
+    backend_endpoint: str = "/api/agentic-rag/query",
+    backend_api_key_env: Optional[str] = None,
+    backend_timeout: float = 30.0,
+    backend_transport: httpx.BaseTransport | None = None,
 ) -> dict[str, Any]:
     """Run the CEP and return aggregate metrics.
 
@@ -139,25 +260,62 @@ def run_cep(
         dry_run: Skip DeepSeek; use a stub answer ("dry-run stub") and
             mark each row as evaluator_error="dry_run". Hit rate = 0.
         report_path: Where to write the CSV report.
-        deepseek_key: Override env DEEPSEEK_API_KEY.
+        deepseek_key: Explicit API key override. Passing a non-empty key
+            enables evaluator calls for programmatic usage.
+        enable_evaluator: Explicitly allow paid DeepSeek evaluation via env.
+        backend_url: Base URL for a live/shadow answer source.
+        backend_endpoint: POST endpoint relative to backend_url.
+        backend_api_key_env: Optional env var whose value is sent as bearer
+            and x-api-key. Missing env is recorded as source_error.
+        backend_timeout: Per-query HTTP timeout in seconds.
+        backend_transport: Test hook for httpx.MockTransport.
     """
     golden = load_golden(golden_path)
+    answers_loaded_from_file = answers is None and answers_file is not None
     if answers is None and answers_file is not None:
         answers = json.loads(answers_file.read_text())
     answers = answers or {}
 
-    if not dry_run:
-        deepseek_key = deepseek_key or os.environ.get("DEEPSEEK_API_KEY", "").strip()
-        if not deepseek_key:
-            logger.warning("DEEPSEEK_API_KEY missing — running in dry_run mode")
-            dry_run = True
+    backend_config = None
+    if backend_url:
+        backend_config = BackendAnswerSourceConfig(
+            base_url=backend_url,
+            endpoint=backend_endpoint,
+            api_key_env=backend_api_key_env,
+            timeout=backend_timeout,
+            transport=backend_transport,
+        )
+
+    explicit_deepseek_key = (deepseek_key or "").strip()
+    evaluator_requested = enable_evaluator or bool(explicit_deepseek_key)
+    evaluator_key = ""
+    if evaluator_requested and not dry_run:
+        evaluator_key = explicit_deepseek_key or os.environ.get("DEEPSEEK_API_KEY", "").strip()
+        if not evaluator_key:
+            logger.warning("DeepSeek evaluator enabled but DEEPSEEK_API_KEY is missing")
 
     rows: list[dict[str, Any]] = []
     per_domain: dict[str, dict[str, int]] = {}
 
     for domain, q in iter_queries(golden):
         qid = q["id"]
-        answer = answers.get(qid, "")
+        source_error = None
+        answer_source = "none"
+        answer = ""
+
+        if not dry_run and qid in answers:
+            answer = str(answers.get(qid) or "")
+            answer_source = "answers_file" if answers_loaded_from_file else "supplied_answers"
+        elif not dry_run and backend_config is not None:
+            source_result = fetch_backend_answer(
+                query_id=qid,
+                query=q["query"],
+                config=backend_config,
+            )
+            answer = source_result.answer
+            answer_source = source_result.answer_source
+            source_error = source_result.source_error
+
         if dry_run:
             grade = {
                 "hit": False,
@@ -166,6 +324,15 @@ def run_cep(
                 "contradiction": False,
                 "notes": "dry_run",
                 "evaluator_error": "dry_run",
+            }
+        elif source_error:
+            grade = {
+                "hit": False,
+                "facts_covered": 0,
+                "facts_total": len(q["required_facts"]),
+                "contradiction": False,
+                "notes": f"source error: {source_error}",
+                "evaluator_error": None,
             }
         elif not answer:
             grade = {
@@ -176,10 +343,28 @@ def run_cep(
                 "notes": "no answer provided",
                 "evaluator_error": None,
             }
+        elif not evaluator_requested:
+            grade = {
+                "hit": False,
+                "facts_covered": 0,
+                "facts_total": len(q["required_facts"]),
+                "contradiction": False,
+                "notes": "evaluator_disabled",
+                "evaluator_error": "evaluator_disabled",
+            }
+        elif not evaluator_key:
+            grade = {
+                "hit": False,
+                "facts_covered": 0,
+                "facts_total": len(q["required_facts"]),
+                "contradiction": False,
+                "notes": "missing DeepSeek API key",
+                "evaluator_error": "missing_deepseek_key",
+            }
         else:
             grade = grade_with_deepseek(
                 q["query"], answer, q["required_facts"],
-                api_key=deepseek_key,  # type: ignore[arg-type]
+                api_key=evaluator_key,
             )
 
         rows.append({
@@ -187,12 +372,15 @@ def run_cep(
             "id": qid,
             "tier": q.get("tier", 2),
             "query": q["query"],
+            "answer_source": answer_source,
             "answer_excerpt": (answer[:200] + "...") if len(answer) > 200 else answer,
+            "source_error": source_error,
             "hit": grade["hit"],
             "facts_covered": grade["facts_covered"],
             "facts_total": grade["facts_total"],
             "contradiction": grade["contradiction"],
             "notes": grade["notes"],
+            "evaluator_error": grade.get("evaluator_error"),
         })
 
         bucket = per_domain.setdefault(domain, {"total": 0, "hit": 0})
@@ -208,6 +396,9 @@ def run_cep(
         "total": total,
         "hits": hits,
         "hit_rate": (hits / total) if total else 0.0,
+        "source_errors": sum(1 for row in rows if row["source_error"]),
+        "evaluator_errors": sum(1 for row in rows if row["evaluator_error"]),
+        "evaluator_enabled": evaluator_requested and not dry_run,
         "per_domain": {
             d: {
                 "total": b["total"],
@@ -223,8 +414,9 @@ def run_cep(
         report_path.parent.mkdir(parents=True, exist_ok=True)
         with report_path.open("w", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()) if rows else [
-                "domain", "id", "tier", "query", "answer_excerpt",
-                "hit", "facts_covered", "facts_total", "contradiction", "notes",
+                "domain", "id", "tier", "query", "answer_source", "answer_excerpt",
+                "source_error", "hit", "facts_covered", "facts_total",
+                "contradiction", "notes", "evaluator_error",
             ])
             writer.writeheader()
             writer.writerows(rows)
@@ -245,6 +437,34 @@ def main() -> None:
         "--answers-file", help="JSON file mapping query_id → answer text"
     )
     parser.add_argument(
+        "--backend-url",
+        help="Base URL for live/shadow backend answer collection",
+    )
+    parser.add_argument(
+        "--endpoint",
+        "--backend-endpoint",
+        dest="backend_endpoint",
+        default="/api/agentic-rag/query",
+        help="Backend POST endpoint for answer collection",
+    )
+    parser.add_argument(
+        "--api-key-env",
+        "--backend-api-key-env",
+        dest="backend_api_key_env",
+        help="Env var containing backend API key; sent as bearer and x-api-key",
+    )
+    parser.add_argument(
+        "--backend-timeout",
+        type=float,
+        default=30.0,
+        help="Per-query backend HTTP timeout in seconds",
+    )
+    parser.add_argument(
+        "--enable-evaluator",
+        action="store_true",
+        help="Enable paid DeepSeek evaluator calls. Disabled by default.",
+    )
+    parser.add_argument(
         "--report",
         help="CSV report path (default /tmp/cep-report-YYYY-MM-DD.csv)",
     )
@@ -263,6 +483,11 @@ def main() -> None:
         answers_file=Path(args.answers_file) if args.answers_file else None,
         dry_run=args.dry_run,
         report_path=report,
+        enable_evaluator=args.enable_evaluator,
+        backend_url=args.backend_url,
+        backend_endpoint=args.backend_endpoint,
+        backend_api_key_env=args.backend_api_key_env,
+        backend_timeout=args.backend_timeout,
     )
 
     # Compact summary to stdout — cron-friendly
@@ -272,6 +497,9 @@ def main() -> None:
         "total": summary["total"],
         "hits": summary["hits"],
         "hit_rate": round(summary["hit_rate"], 3),
+        "source_errors": summary["source_errors"],
+        "evaluator_errors": summary["evaluator_errors"],
+        "evaluator_enabled": summary["evaluator_enabled"],
         "per_domain": {
             d: round(b["hit_rate"], 3)
             for d, b in summary["per_domain"].items()
@@ -279,8 +507,8 @@ def main() -> None:
         "report": str(report),
     }, indent=2))
 
-    # Exit nonzero if hit rate < 0.8 (so cron + sentinel can alert)
-    sys.exit(0 if summary["hit_rate"] >= 0.8 or args.dry_run else 1)
+    # Exit nonzero on low graded hit rate only when paid evaluation was explicit.
+    sys.exit(0 if summary["hit_rate"] >= 0.8 or args.dry_run or not args.enable_evaluator else 1)
 
 
 if __name__ == "__main__":

--- a/apps/evaluator/cep/test_run_cep.py
+++ b/apps/evaluator/cep/test_run_cep.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
+import httpx
 
 from apps.evaluator.cep import run_cep
 
@@ -58,13 +58,55 @@ def test_run_cep_dry_run_returns_zero_hits(tmp_path):
 
 def test_run_cep_no_answers_marks_all_miss(tmp_path):
     report = tmp_path / "report.csv"
-    # No answers map, no DeepSeek key → falls through to dry_run-like behavior
+    # No answers map, no evaluator enabled → all misses without paid calls.
     summary = run_cep.run_cep(
         GOLDEN_PATH, answers={}, dry_run=False,
-        deepseek_key="",  # explicit empty triggers dry_run promotion
         report_path=report,
     )
     assert summary["hits"] == 0
+
+
+def test_run_cep_dry_run_does_not_call_backend_or_evaluator(tmp_path):
+    """Dry-run stays fully local even if a backend URL is configured."""
+    report = tmp_path / "report.csv"
+
+    def fail_backend(request):
+        raise AssertionError(f"backend should not be called in dry-run: {request.url}")
+
+    with patch.object(run_cep, "grade_with_deepseek") as grade:
+        summary = run_cep.run_cep(
+            GOLDEN_PATH,
+            dry_run=True,
+            report_path=report,
+            backend_url="https://rag.example.test",
+            backend_transport=httpx.MockTransport(fail_backend),
+        )
+
+    grade.assert_not_called()
+    assert summary["total"] == 50
+    assert summary["source_errors"] == 0
+    assert {row["evaluator_error"] for row in summary["rows"]} == {"dry_run"}
+
+
+def test_run_cep_answers_file_remains_backward_compatible(tmp_path):
+    """The existing JSON answer map path remains a valid answer source."""
+    answers_path = tmp_path / "answers.json"
+    report = tmp_path / "report.csv"
+    answers_path.write_text(json.dumps({"imm-01": "KITAS E23 is valid for one year."}))
+
+    with patch.object(run_cep, "grade_with_deepseek") as grade:
+        summary = run_cep.run_cep(
+            GOLDEN_PATH,
+            answers_file=answers_path,
+            report_path=report,
+        )
+
+    grade.assert_not_called()
+    first = summary["rows"][0]
+    assert first["id"] == "imm-01"
+    assert first["answer_source"] == "answers_file"
+    assert first["answer_excerpt"] == "KITAS E23 is valid for one year."
+    assert first["evaluator_error"] == "evaluator_disabled"
 
 
 # ── grading ────────────────────────────────────────────────────────────────
@@ -110,3 +152,112 @@ def test_run_cep_with_supplied_answers_uses_evaluator(tmp_path):
     assert summary["hit_rate"] == 1.0
     for domain_summary in summary["per_domain"].values():
         assert domain_summary["hit_rate"] == 1.0
+
+
+def test_run_cep_backend_answer_source_success(tmp_path, monkeypatch):
+    """Backend mode collects answers through a thin HTTP client."""
+    report = tmp_path / "report.csv"
+    monkeypatch.setenv("CEP_BACKEND_KEY", "test-backend-key")
+
+    def handler(request):
+        assert request.url == httpx.URL("https://rag.example.test/api/agentic-rag/query")
+        assert request.headers["authorization"] == "Bearer test-backend-key"
+        assert request.headers["x-api-key"] == "test-backend-key"
+        payload = json.loads(request.content)
+        assert payload["user_id"] == "cep_eval"
+        return httpx.Response(200, json={"answer": f"backend answer: {payload['query']}"})
+
+    def fake_grade(query, answer, required_facts, *, api_key, timeout=60):
+        return {
+            "hit": True,
+            "facts_covered": len(required_facts),
+            "facts_total": len(required_facts),
+            "contradiction": False,
+            "notes": "fake-grader",
+            "evaluator_error": None,
+        }
+
+    with patch.object(run_cep, "grade_with_deepseek", side_effect=fake_grade) as grade:
+        summary = run_cep.run_cep(
+            GOLDEN_PATH,
+            backend_url="https://rag.example.test",
+            backend_endpoint="/api/agentic-rag/query",
+            backend_api_key_env="CEP_BACKEND_KEY",
+            backend_transport=httpx.MockTransport(handler),
+            deepseek_key="fake-key",
+            enable_evaluator=True,
+            report_path=report,
+        )
+
+    assert grade.call_count == 50
+    assert summary["hits"] == 50
+    assert summary["source_errors"] == 0
+    assert summary["rows"][0]["answer_source"] == "backend"
+    assert summary["rows"][0]["source_error"] is None
+
+
+def test_run_cep_backend_failure_is_per_query_and_skips_evaluator(tmp_path):
+    """A backend error records source_error for that row without stopping CEP."""
+    report = tmp_path / "report.csv"
+    calls = {"backend": 0}
+
+    def handler(request):
+        calls["backend"] += 1
+        if calls["backend"] == 1:
+            return httpx.Response(503, text="backend unavailable")
+        payload = json.loads(request.content)
+        return httpx.Response(200, json={"answer": f"answer for {payload['query']}"})
+
+    def fake_grade(query, answer, required_facts, *, api_key, timeout=60):
+        return {
+            "hit": True,
+            "facts_covered": len(required_facts),
+            "facts_total": len(required_facts),
+            "contradiction": False,
+            "notes": "fake-grader",
+            "evaluator_error": None,
+        }
+
+    with patch.object(run_cep, "grade_with_deepseek", side_effect=fake_grade) as grade:
+        summary = run_cep.run_cep(
+            GOLDEN_PATH,
+            backend_url="https://rag.example.test",
+            backend_transport=httpx.MockTransport(handler),
+            deepseek_key="fake-key",
+            enable_evaluator=True,
+            report_path=report,
+        )
+
+    assert calls["backend"] == 50
+    assert grade.call_count == 49
+    assert summary["total"] == 50
+    assert summary["hits"] == 49
+    assert summary["source_errors"] == 1
+    assert summary["rows"][0]["source_error"].startswith("HTTP 503")
+    assert summary["rows"][0]["evaluator_error"] is None
+
+
+def test_run_cep_does_not_call_paid_evaluator_without_explicit_enable(
+    tmp_path, monkeypatch
+):
+    """An env key alone is not enough to spend evaluator budget."""
+    report = tmp_path / "report.csv"
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "real-looking-env-key")
+
+    answers = {
+        q["id"]: f"answer for {q['id']}"
+        for _, q in run_cep.iter_queries(run_cep.load_golden(GOLDEN_PATH))
+    }
+
+    with patch.object(run_cep, "grade_with_deepseek") as grade:
+        summary = run_cep.run_cep(
+            GOLDEN_PATH,
+            answers=answers,
+            dry_run=False,
+            report_path=report,
+        )
+
+    grade.assert_not_called()
+    assert summary["hits"] == 0
+    assert summary["evaluator_errors"] == 50
+    assert {row["evaluator_error"] for row in summary["rows"]} == {"evaluator_disabled"}


### PR DESCRIPTION
## Scope
- Adds backend HTTP answer-source mode to CEP evaluator.
- Keeps answers-file mode.
- Gates paid evaluator calls behind explicit CLI flag.
- Avoids backend imports to keep evaluator decoupled.

## Verification
- `/Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m pytest apps/evaluator/cep/test_run_cep.py -q` -> 13 passed
- `/Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m ruff check apps/evaluator/cep/run_cep.py apps/evaluator/cep/test_run_cep.py` -> passed
- CLI dry-run generated `/tmp/cep-worker-b-dry-run.csv`
