### PR TITLE
feat(rag): R5 Phase 5 — KG fast-path wiring in OrchestratorCore

### DIFF
--- a/apps/backend-rag/backend/app/deps/orchestrator.py
+++ b/apps/backend-rag/backend/app/deps/orchestrator.py
@@ -57,4 +57,10 @@ async def get_orchestrator(request: Request) -> Any:
             specialized_service_router=specialized_router,
         )
 
+        # R5 Phase 5: inject SurfaceRouter for KG fast-path
+        surface_router = getattr(request.app.state, "surface_router", None)
+        if surface_router and hasattr(_agentic_rag_orchestrator, "core"):
+            _agentic_rag_orchestrator.core._surface_router = surface_router
+            logger.info("✅ [R5 Phase 5] SurfaceRouter injected into OrchestratorCore (main singleton)")
+
     return _agentic_rag_orchestrator

--- a/apps/backend-rag/backend/app/setup/service_initializer.py
+++ b/apps/backend-rag/backend/app/setup/service_initializer.py
@@ -1054,6 +1054,12 @@ async def initialize_channel_router(
             )
             logger.info(f"✅ Fallback orchestrator created with {len(tools)} tools")
 
+            # R5 Phase 5: inject SurfaceRouter into OrchestratorCore for KG fast-path
+            surface_router = getattr(app.state, "surface_router", None)
+            if surface_router and hasattr(orchestrator, "core"):
+                orchestrator.core._surface_router = surface_router
+                logger.info("✅ [R5 Phase 5] SurfaceRouter injected into OrchestratorCore")
+
             # Eagerly initialize async components (MemoryOrchestrator, KG LangGraph)
             # to avoid first-query latency spike
             try:

--- a/apps/backend-rag/backend/services/rag/agentic/orchestrator_core.py
+++ b/apps/backend-rag/backend/services/rag/agentic/orchestrator_core.py
@@ -178,6 +178,11 @@ class OrchestratorCore:
             except Exception as e:
                 logger.warning(f"⚠️ [Phase 6] MultiAgentCoordinator init skipped: {e}")
 
+        # R5 Phase 5: SurfaceRouter KG fast-path
+        # Post-init injectable (service_initializer sets core._surface_router = surface_router).
+        # None = shadow mode: KG routing disabled, falls through to ReAct loop.
+        self._surface_router: Any = None
+
     async def check_faq_cache(
         self,
         query: str,
@@ -597,6 +602,82 @@ class OrchestratorCore:
         except Exception as e:
             logger.warning(f"Failed to track workflow analytics: {e}")
 
+    # ------------------------------------------------------------------
+    # R5 Phase 5: KG fast-path
+    # ------------------------------------------------------------------
+
+    async def _try_kg_fast_path(
+        self,
+        query: str,
+        user_context: dict[str, Any],
+        extracted_entities: dict[str, Any],
+        start_time: float,
+    ) -> CoreResult | None:
+        """Route to KGLangGraphOrchestrator when SurfaceRouter decides KG surface.
+
+        Returns CoreResult on KG hit, None to fall through to the standard ReAct loop.
+        Failures degrade gracefully (return None) per Symbiosis Law 4.
+        """
+        if self._surface_router is None or self.kg_langgraph_orchestrator is None:
+            return None
+
+        try:
+            decision = self._surface_router.decide(query)
+        except Exception as exc:
+            logger.warning("⚠️ [R5 KG] SurfaceRouter.decide failed: %s", exc)
+            return None
+
+        if not decision.is_kg_surface:
+            return None
+
+        logger.info(
+            "🔀 [R5 KG] Fast-path activated: surface=kg, confidence=%.2f",
+            decision.confidence,
+        )
+
+        try:
+            if not hasattr(self.kg_langgraph_orchestrator, "app") or self.kg_langgraph_orchestrator.app is None:
+                await self.kg_langgraph_orchestrator.initialize()
+
+            kg_result = await self.kg_langgraph_orchestrator.query(
+                query=query,
+                user_context=user_context,
+            )
+        except Exception as exc:
+            logger.warning("⚠️ [R5 KG] KGLangGraphOrchestrator.query failed: %s — falling through to ReAct", exc)
+            return None
+
+        if not kg_result:
+            return None
+
+        answer_parts: list[str] = []
+        if kg_result.get("workflow"):
+            answer_parts.append(self._format_workflow_for_prompt(kg_result["workflow"]))
+        if kg_result.get("reasoning"):
+            answer_parts.append(str(kg_result["reasoning"]))
+        answer = "\n\n".join(answer_parts) or "Nessuna entità trovata nel Knowledge Graph."
+
+        sources = [
+            {
+                "type": "kg",
+                "source": "neo4j_knowledge_graph",
+                "domain": "kg",
+                "surface": "kg",
+            }
+        ]
+        if kg_result.get("evidence"):
+            for ev in kg_result["evidence"]:
+                sources.append({"type": "kg", "source": "neo4j_kg_entity", **ev})
+
+        return CoreResult(
+            answer=answer,
+            sources=sources,
+            model_used="kg_langgraph",
+            entities=extracted_entities,
+            timings={"total": time.time() - start_time, "kg_fast_path": time.time() - start_time},
+            tools_called=["kg_langgraph"],
+        )
+
     @traceable(run_type="chain", name="ReAct Loop", tags=["nuzantara", "react"])
     async def execute_react_loop(
         self,
@@ -818,6 +899,17 @@ class OrchestratorCore:
                     timings={"total": time.time() - start_time},
                     tools_called=[ssr_result.get("category", "specialized_service")],
                 )
+
+        # 3b.6. R5 Phase 5: KG fast-path — entity/relationship queries bypass Qdrant ReAct loop
+        kg_fast_result = await self._try_kg_fast_path(
+            query=query,
+            user_context=user_context,
+            extracted_entities=extracted_entities,
+            start_time=start_time,
+        )
+        if kg_fast_result:
+            logger.info("✅ [R5 KG] Fast-path returned answer (skipping ReAct loop)")
+            return kg_fast_result
 
         # 3c. NLM Speculative Fire — launch in parallel with the rest of the pipeline.
         # Placed AFTER all early-return gates/cache checks to avoid task leaks.

--- a/apps/backend-rag/backend/tests/services/rag/agentic/test_kg_fast_path.py
+++ b/apps/backend-rag/backend/tests/services/rag/agentic/test_kg_fast_path.py
@@ -1,0 +1,250 @@
+"""TDD test suite — R5 Phase 5: KG fast-path in OrchestratorCore.
+
+When SurfaceDecision.is_kg_surface=True, process_query_core must:
+1. Call kg_langgraph_orchestrator.query() directly (bypass Qdrant ReAct loop)
+2. Return CoreResult with model_used="kg_langgraph" + surface="kg"
+3. Gracefully degrade (return None fast-path) when kg_orchestrator is None
+4. Gracefully degrade when kg_orchestrator.query() raises
+5. Not enter the ReAct loop for KG queries
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.services.rag.agentic.schema import CoreResult
+from backend.services.routing.surface_router import Surface, SurfaceDecision
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_kg_decision() -> SurfaceDecision:
+    return SurfaceDecision(
+        surface=Surface.KG,
+        primary_collection="",
+        collections=[],
+        domain="kg",
+        confidence=0.88,
+        layer_used=1,
+        is_local_only=False,
+        latency_ms=0.5,
+        is_kg_surface=True,
+    )
+
+
+def _make_qdrant_decision() -> SurfaceDecision:
+    return SurfaceDecision(
+        surface=Surface.QDRANT_VISA,
+        primary_collection="visa_oracle",
+        collections=["visa_oracle"],
+        domain="visa",
+        confidence=0.90,
+        layer_used=1,
+        is_local_only=False,
+        latency_ms=0.5,
+        is_kg_surface=False,
+    )
+
+
+def _make_kg_orchestrator_result() -> dict:
+    return {
+        "workflow": {
+            "type": "entity_resolution",
+            "name": "Company Director Lookup",
+            "steps": [{"step": 1, "action": "Resolve entity from Neo4j"}],
+            "source": "neo4j",
+            "confidence": 0.85,
+        },
+        "evidence": [{"entity": "John Doe", "role": "Director"}],
+        "reasoning": "Found 1 matching entity in KG.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. KG fast-path integration — _try_kg_fast_path method
+# ---------------------------------------------------------------------------
+
+class TestKGFastPath:
+    """Tests for OrchestratorCore._try_kg_fast_path (internal helper)."""
+
+    @pytest.fixture()
+    def mock_kg_orchestrator(self):
+        m = AsyncMock()
+        m.app = MagicMock()  # simulate initialized orchestrator
+        m.query = AsyncMock(return_value=_make_kg_orchestrator_result())
+        return m
+
+    @pytest.mark.asyncio
+    async def test_kg_fast_path_returns_core_result(self, mock_kg_orchestrator):
+        """_try_kg_fast_path returns CoreResult when kg_orchestrator is available."""
+
+        core = _make_minimal_core(kg_langgraph_orchestrator=mock_kg_orchestrator)
+        core._surface_router = MagicMock()
+        core._surface_router.decide.return_value = _make_kg_decision()
+
+        result = await core._try_kg_fast_path(
+            query="chi è il direttore di PT Bali XYZ?",
+            user_context={},
+            extracted_entities={},
+            start_time=0.0,
+        )
+
+        assert result is not None
+        assert isinstance(result, CoreResult)
+        assert result.model_used == "kg_langgraph"
+
+    @pytest.mark.asyncio
+    async def test_kg_fast_path_returns_none_when_no_orchestrator(self):
+        """_try_kg_fast_path returns None when kg_langgraph_orchestrator is None."""
+
+        core = _make_minimal_core(kg_langgraph_orchestrator=None)
+        core._surface_router = MagicMock()
+        core._surface_router.decide.return_value = _make_kg_decision()
+
+        result = await core._try_kg_fast_path(
+            query="struttura societaria azienda",
+            user_context={},
+            extracted_entities={},
+            start_time=0.0,
+        )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_kg_fast_path_returns_none_when_not_kg_surface(self, mock_kg_orchestrator):
+        """_try_kg_fast_path returns None for Qdrant surfaces (is_kg_surface=False)."""
+
+        core = _make_minimal_core(kg_langgraph_orchestrator=mock_kg_orchestrator)
+        core._surface_router = MagicMock()
+        core._surface_router.decide.return_value = _make_qdrant_decision()
+
+        result = await core._try_kg_fast_path(
+            query="KITAS renewal requirements",
+            user_context={},
+            extracted_entities={},
+            start_time=0.0,
+        )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_kg_fast_path_returns_none_when_no_surface_router(self, mock_kg_orchestrator):
+        """_try_kg_fast_path returns None gracefully when surface_router is None."""
+
+        core = _make_minimal_core(kg_langgraph_orchestrator=mock_kg_orchestrator)
+        core._surface_router = None
+
+        result = await core._try_kg_fast_path(
+            query="entity relationship query",
+            user_context={},
+            extracted_entities={},
+            start_time=0.0,
+        )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_kg_fast_path_degrades_on_kg_error(self, mock_kg_orchestrator):
+        """_try_kg_fast_path returns None (graceful degrade) when kg_orchestrator.query raises."""
+        mock_kg_orchestrator.query.side_effect = RuntimeError("Neo4j connection failed")
+
+
+        core = _make_minimal_core(kg_langgraph_orchestrator=mock_kg_orchestrator)
+        core._surface_router = MagicMock()
+        core._surface_router.decide.return_value = _make_kg_decision()
+
+        result = await core._try_kg_fast_path(
+            query="organigramma aziendale",
+            user_context={},
+            extracted_entities={},
+            start_time=0.0,
+        )
+
+        assert result is None  # graceful degrade → caller falls through to ReAct
+
+    @pytest.mark.asyncio
+    async def test_kg_fast_path_calls_initialize_when_app_is_none(self, mock_kg_orchestrator):
+        """_try_kg_fast_path calls kg_orchestrator.initialize() when app is None."""
+        mock_kg_orchestrator.app = None  # not yet initialized
+        mock_kg_orchestrator.initialize = AsyncMock()
+
+
+        core = _make_minimal_core(kg_langgraph_orchestrator=mock_kg_orchestrator)
+        core._surface_router = MagicMock()
+        core._surface_router.decide.return_value = _make_kg_decision()
+
+        await core._try_kg_fast_path(
+            query="who is the company director?",
+            user_context={},
+            extracted_entities={},
+            start_time=0.0,
+        )
+
+        mock_kg_orchestrator.initialize.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_kg_fast_path_sources_contain_surface_kg(self, mock_kg_orchestrator):
+        """CoreResult sources from KG fast-path include source_type 'kg'."""
+
+        core = _make_minimal_core(kg_langgraph_orchestrator=mock_kg_orchestrator)
+        core._surface_router = MagicMock()
+        core._surface_router.decide.return_value = _make_kg_decision()
+
+        result = await core._try_kg_fast_path(
+            query="chi è il fondatore?",
+            user_context={},
+            extracted_entities={},
+            start_time=0.0,
+        )
+
+        assert result is not None
+        assert any(s.get("type") == "kg" for s in result.sources)
+
+
+# ---------------------------------------------------------------------------
+# 2. OrchestratorCore._surface_router attribute
+# ---------------------------------------------------------------------------
+
+class TestOrchestratorCoreSurfaceRouterAttr:
+    def test_core_has_surface_router_attr(self):
+        """OrchestratorCore must expose _surface_router attribute (default None)."""
+        core = _make_minimal_core()
+        assert hasattr(core, "_surface_router")
+
+    def test_surface_router_defaults_to_none(self):
+        """_surface_router defaults to None when not provided."""
+        core = _make_minimal_core()
+        assert core._surface_router is None
+
+    def test_surface_router_can_be_set_post_init(self):
+        """_surface_router can be injected post-init (pattern used by service_initializer)."""
+        from backend.services.routing.surface_router import SurfaceRouter
+        core = _make_minimal_core()
+        router = SurfaceRouter()
+        core._surface_router = router
+        assert core._surface_router is router
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+def _make_minimal_core(kg_langgraph_orchestrator=None):
+    """Build a minimal OrchestratorCore with all dependencies mocked."""
+    from backend.services.rag.agentic.orchestrator_core import OrchestratorCore
+
+    return OrchestratorCore(
+        llm_gateway=MagicMock(),
+        reasoning_engine=MagicMock(),
+        prompt_builder=MagicMock(),
+        query_gates=MagicMock(),
+        memory_handler=MagicMock(),
+        context_window_manager=MagicMock(),
+        entity_extractor=MagicMock(),
+        kg_retrieval=None,
+        semantic_cache=None,
+        kg_langgraph_orchestrator=kg_langgraph_orchestrator,
+    )


### PR DESCRIPTION
## Summary

- `OrchestratorCore._try_kg_fast_path()`: when `SurfaceDecision.is_kg_surface=True`, calls `KGLangGraphOrchestrator.query()` directly, bypassing the Qdrant ReAct loop entirely (step 3b.6 in `process_query_core`)
- `_surface_router: Any = None` post-init injectable attribute on `OrchestratorCore`
- Injection in 2 sites: fallback orchestrator in `service_initializer.py` + main singleton in `app/deps/orchestrator.py`
- Graceful degradation on ALL failures → returns `None` → falls through to ReAct loop (Symbiosis Law 4)
- `CoreResult` from fast-path: `model_used="kg_langgraph"`, `sources=[{"type": "kg", ...}]`
- Feature-flagged via `ENABLE_KG_LANGGRAPH` env var (default `"false"`) — no-op until flag is set

## Test plan

- [x] `test_kg_fast_path.py` — 10/10 TDD tests green
- [x] Import chain OK
- [x] Ruff lint clean
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)