### PR TITLE
feat(crm): add workspace AI review loop

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_intelligence.py
+++ b/apps/backend-rag/backend/app/routers/crm_intelligence.py
@@ -1,9 +1,9 @@
 """Team-only CRM intelligence endpoints."""
 
-from typing import Annotated
+from typing import Annotated, Literal
 
 import asyncpg
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from backend.app.dependencies import get_database_pool, require_team_member
 from backend.services.crm.evidence_dossier import build_evidence_dossiers
@@ -11,7 +11,9 @@ from backend.services.crm.tax_company_pilot import TaxCompanyPilotMap
 from backend.services.crm.workspace_ai_snapshots import (
     WorkspaceAiSnapshotCreate,
     WorkspaceAiSnapshotResponse,
+    approve_workspace_ai_snapshot,
     create_workspace_ai_snapshot,
+    fetch_workspace_ai_review_queue,
 )
 
 router = APIRouter(prefix="/api/crm/intelligence", tags=["crm-intelligence"])
@@ -49,3 +51,39 @@ async def create_workspace_ai_snapshot_draft(
         payload,
         created_by=created_by,
     )
+
+
+@router.get("/workspace-ai-snapshots/review", response_model=list[WorkspaceAiSnapshotResponse])
+async def review_workspace_ai_snapshots(
+    status: Literal["draft", "approved", "rejected"] = "draft",
+    limit: Annotated[int, Query(ge=1, le=100)] = 25,
+    pool: asyncpg.Pool = Depends(get_database_pool),
+    _current_user: dict = Depends(require_team_member),
+) -> list[WorkspaceAiSnapshotResponse]:
+    """Return Workspace AI snapshots awaiting team review."""
+    return await fetch_workspace_ai_review_queue(
+        pool,
+        status=status,
+        limit=limit,
+    )
+
+
+@router.post("/workspace-ai-snapshots/{snapshot_id}/approve", response_model=WorkspaceAiSnapshotResponse)
+async def approve_workspace_ai_snapshot_draft(
+    snapshot_id: str,
+    pool: asyncpg.Pool = Depends(get_database_pool),
+    current_user: dict = Depends(require_team_member),
+) -> WorkspaceAiSnapshotResponse:
+    """Approve a draft Workspace AI snapshot for Business Story use."""
+    approved_by = current_user.get("email") if isinstance(current_user, dict) else None
+    try:
+        return await approve_workspace_ai_snapshot(
+            pool,
+            snapshot_id=snapshot_id,
+            approved_by=approved_by,
+        )
+    except LookupError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail="Workspace AI snapshot not found or not in draft status.",
+        ) from exc

--- a/apps/backend-rag/backend/services/crm/workspace_ai_snapshots.py
+++ b/apps/backend-rag/backend/services/crm/workspace_ai_snapshots.py
@@ -89,6 +89,41 @@ async def create_workspace_ai_snapshot(
             created_by,
         )
 
+    return _response_from_row(row)
+
+
+async def fetch_workspace_ai_review_queue(
+    pool: asyncpg.Pool,
+    *,
+    status: Literal["draft", "approved", "rejected"] = "draft",
+    limit: int = 25,
+) -> list[WorkspaceAiSnapshotResponse]:
+    """Return Workspace AI snapshots for the team review inbox."""
+    safe_limit = max(1, min(int(limit), 100))
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(_REVIEW_QUEUE_SQL, status, safe_limit)
+
+    return [_response_from_row(row) for row in rows]
+
+
+async def approve_workspace_ai_snapshot(
+    pool: asyncpg.Pool,
+    *,
+    snapshot_id: str,
+    approved_by: str | None,
+) -> WorkspaceAiSnapshotResponse:
+    """Approve one draft Workspace AI snapshot for Business Story use."""
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(_APPROVE_SQL, snapshot_id, approved_by)
+
+    if row is None:
+        raise LookupError("workspace_ai_snapshot_not_found_or_not_draft")
+
+    return _response_from_row(row)
+
+
+def _response_from_row(row: Any) -> WorkspaceAiSnapshotResponse:
+    approved_at = row["approved_at"]
     return WorkspaceAiSnapshotResponse(
         id=str(row["id"]),
         company_id=row["company_id"],
@@ -102,7 +137,7 @@ async def create_workspace_ai_snapshot(
         status=row["status"],
         created_by=row["created_by"],
         approved_by=row["approved_by"],
-        approved_at=row["approved_at"].isoformat() if row["approved_at"] else None,
+        approved_at=approved_at.isoformat() if approved_at else None,
         created_at=row["created_at"].isoformat(),
     )
 
@@ -160,6 +195,56 @@ INSERT INTO crm_workspace_ai_snapshots (
     facts,
     created_by
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9)
+RETURNING
+    id,
+    company_id,
+    client_id,
+    company_name,
+    provider,
+    notebook_id,
+    note_id,
+    source_file_ids,
+    facts,
+    status,
+    created_by,
+    approved_by,
+    approved_at,
+    created_at
+"""
+
+
+_REVIEW_QUEUE_SQL = """
+SELECT
+    id,
+    company_id,
+    client_id,
+    company_name,
+    provider,
+    notebook_id,
+    note_id,
+    source_file_ids,
+    facts,
+    status,
+    created_by,
+    approved_by,
+    approved_at,
+    created_at
+FROM crm_workspace_ai_snapshots
+WHERE status = $1
+ORDER BY created_at DESC
+LIMIT $2
+"""
+
+
+_APPROVE_SQL = """
+UPDATE crm_workspace_ai_snapshots
+SET
+    status = 'approved',
+    approved_by = $2,
+    approved_at = NOW(),
+    updated_at = NOW()
+WHERE id = $1::uuid
+  AND status = 'draft'
 RETURNING
     id,
     company_id,

--- a/apps/backend-rag/backend/tests/services/crm/test_workspace_ai_snapshots.py
+++ b/apps/backend-rag/backend/tests/services/crm/test_workspace_ai_snapshots.py
@@ -11,7 +11,9 @@ import pytest
 from backend.services.crm.tax_company_pilot import TaxCompanyPilotWorkspaceAiFact
 from backend.services.crm.workspace_ai_snapshots import (
     WorkspaceAiSnapshotCreate,
+    approve_workspace_ai_snapshot,
     create_workspace_ai_snapshot,
+    fetch_workspace_ai_review_queue,
 )
 
 
@@ -37,9 +39,20 @@ class _FakePool:
 class _FakeConn:
     def __init__(self) -> None:
         self.args: tuple[Any, ...] | None = None
+        self.fetch_args: tuple[Any, ...] | None = None
+        self.approve_args: tuple[Any, ...] | None = None
 
     async def fetchrow(self, _query: str, *args: Any) -> dict[str, Any]:
         self.args = args
+        if args and str(args[0]) == "snapshot-approve":
+            self.approve_args = args
+            return _snapshot_row(
+                snapshot_id=args[0],
+                status="approved",
+                approved_by=args[1],
+                approved_at=datetime(2026, 5, 13, tzinfo=timezone.utc),
+            )
+
         facts_arg = args[7]
         assert isinstance(facts_arg, str)
         return {
@@ -58,6 +71,45 @@ class _FakeConn:
             "approved_at": None,
             "created_at": datetime(2026, 5, 12, tzinfo=timezone.utc),
         }
+
+    async def fetch(self, _query: str, *args: Any) -> list[dict[str, Any]]:
+        self.fetch_args = args
+        return [_snapshot_row(snapshot_id="snapshot-draft", status=args[0])]
+
+
+def _snapshot_row(
+    *,
+    snapshot_id: str,
+    status: str,
+    approved_by: str | None = None,
+    approved_at: datetime | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": snapshot_id,
+        "company_id": 7,
+        "client_id": 3,
+        "company_name": "OCEAN CLOTHES AND SHOES PT",
+        "provider": "gemini",
+        "notebook_id": None,
+        "note_id": "crm-drive-autowatcher:v1:7:test",
+        "source_file_ids": ["drive-file-1"],
+        "facts": json.dumps(
+            [
+                {
+                    "category": "identity",
+                    "label": "Company evidence",
+                    "detail": "Company source documents are indexed for review.",
+                    "source_file_ids": ["drive-file-1"],
+                    "confidence": "medium",
+                }
+            ]
+        ),
+        "status": status,
+        "created_by": "crm-drive-autowatcher",
+        "approved_by": approved_by,
+        "approved_at": approved_at,
+        "created_at": datetime(2026, 5, 12, tzinfo=timezone.utc),
+    }
 
 
 @pytest.mark.asyncio
@@ -91,3 +143,35 @@ async def test_create_workspace_ai_snapshot_serializes_facts_for_jsonb() -> None
     assert response.facts[0].category == "identity"
     assert pool.conn.args is not None
     assert json.loads(pool.conn.args[7])[0]["category"] == "identity"
+
+
+@pytest.mark.asyncio
+async def test_fetch_workspace_ai_review_queue_returns_draft_snapshots() -> None:
+    pool = _FakePool()
+
+    result = await fetch_workspace_ai_review_queue(
+        pool,  # type: ignore[arg-type]
+        status="draft",
+        limit=10,
+    )
+
+    assert result[0].id == "snapshot-draft"
+    assert result[0].status == "draft"
+    assert result[0].facts[0].label == "Company evidence"
+    assert pool.conn.fetch_args == ("draft", 10)
+
+
+@pytest.mark.asyncio
+async def test_approve_workspace_ai_snapshot_marks_draft_approved() -> None:
+    pool = _FakePool()
+
+    result = await approve_workspace_ai_snapshot(
+        pool,  # type: ignore[arg-type]
+        snapshot_id="snapshot-approve",
+        approved_by="team@balizero.com",
+    )
+
+    assert result.status == "approved"
+    assert result.approved_by == "team@balizero.com"
+    assert result.approved_at == "2026-05-13T00:00:00+00:00"
+    assert pool.conn.approve_args == ("snapshot-approve", "team@balizero.com")

--- a/apps/backend-rag/backend/tests/unit/routers/test_crm_intelligence.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_crm_intelligence.py
@@ -86,3 +86,72 @@ async def test_create_workspace_ai_snapshot_draft_uses_team_actor() -> None:
     assert result == response
     create_snapshot.assert_awaited_once()
     assert create_snapshot.await_args.kwargs["created_by"] == "team@balizero.com"
+
+
+@pytest.mark.asyncio
+async def test_review_workspace_ai_snapshots_returns_draft_queue() -> None:
+    from backend.app.routers.crm_intelligence import review_workspace_ai_snapshots
+    from backend.services.crm.workspace_ai_snapshots import WorkspaceAiSnapshotResponse
+
+    response = WorkspaceAiSnapshotResponse(
+        id="snapshot-draft",
+        company_id=7,
+        client_id=None,
+        company_name="OCEAN CLOTHES AND SHOES PT",
+        provider="gemini",
+        facts=[],
+        status="draft",
+        created_by="crm-drive-autowatcher",
+        created_at="2026-05-12T15:45:00+00:00",
+    )
+
+    with patch(
+        "backend.app.routers.crm_intelligence.fetch_workspace_ai_review_queue",
+        new=AsyncMock(return_value=[response]),
+    ) as fetch_queue:
+        result = await review_workspace_ai_snapshots(
+            status="draft",
+            limit=25,
+            pool=MagicMock(),
+            _current_user={"email": "team@balizero.com", "role": "team"},
+        )
+
+    assert result == [response]
+    fetch_queue.assert_awaited_once()
+    assert fetch_queue.await_args.kwargs["status"] == "draft"
+    assert fetch_queue.await_args.kwargs["limit"] == 25
+
+
+@pytest.mark.asyncio
+async def test_approve_workspace_ai_snapshot_uses_team_actor() -> None:
+    from backend.app.routers.crm_intelligence import approve_workspace_ai_snapshot_draft
+    from backend.services.crm.workspace_ai_snapshots import WorkspaceAiSnapshotResponse
+
+    response = WorkspaceAiSnapshotResponse(
+        id="snapshot-1",
+        company_id=7,
+        client_id=None,
+        company_name="OCEAN CLOTHES AND SHOES PT",
+        provider="gemini",
+        facts=[],
+        status="approved",
+        created_by="crm-drive-autowatcher",
+        approved_by="team@balizero.com",
+        approved_at="2026-05-13T15:45:00+00:00",
+        created_at="2026-05-12T15:45:00+00:00",
+    )
+
+    with patch(
+        "backend.app.routers.crm_intelligence.approve_workspace_ai_snapshot",
+        new=AsyncMock(return_value=response),
+    ) as approve_snapshot:
+        result = await approve_workspace_ai_snapshot_draft(
+            "snapshot-1",
+            pool=MagicMock(),
+            current_user={"email": "team@balizero.com", "role": "team"},
+        )
+
+    assert result == response
+    approve_snapshot.assert_awaited_once()
+    assert approve_snapshot.await_args.kwargs["snapshot_id"] == "snapshot-1"
+    assert approve_snapshot.await_args.kwargs["approved_by"] == "team@balizero.com"

--- a/apps/mouth/src/app/(workspace)/clients/tax-pilot/page.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/tax-pilot/page.tsx
@@ -1,20 +1,44 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
 import { TaxCompanyPilotWorkspace } from "@/components/crm/TaxCompanyPilotWorkspace";
 import { api } from "@/lib/api";
-import type { TaxCompanyPilotMap } from "@/lib/api/crm/crm.types";
+import type {
+  TaxCompanyPilotMap,
+  WorkspaceAiSnapshotReviewItem,
+} from "@/lib/api/crm/crm.types";
 
 export default function TaxCompanyPilotPage() {
+  const queryClient = useQueryClient();
   const { data, isLoading, error } = useQuery<TaxCompanyPilotMap[]>({
     queryKey: ["crm-evidence-dossiers", "ocean", "bimala"],
     queryFn: async () =>
       api.crm.getEvidenceDossiers({
         companies: ["ocean", "bimala"],
         limit: 2,
-      }),
+    }),
     staleTime: 5 * 60_000,
+  });
+  const reviewQueue = useQuery<WorkspaceAiSnapshotReviewItem[]>({
+    queryKey: ["crm-workspace-ai-review", "draft"],
+    queryFn: async () =>
+      api.crm.getWorkspaceAiReviewQueue({ status: "draft", limit: 25 }),
+    staleTime: 60_000,
+  });
+  const approveSnapshot = useMutation({
+    mutationFn: (snapshotId: string) =>
+      api.crm.approveWorkspaceAiSnapshot(snapshotId),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["crm-workspace-ai-review"],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["crm-evidence-dossiers"],
+        }),
+      ]);
+    },
   });
 
   if (isLoading) {
@@ -36,5 +60,13 @@ export default function TaxCompanyPilotPage() {
     );
   }
 
-  return <TaxCompanyPilotWorkspace maps={data} />;
+  return (
+    <TaxCompanyPilotWorkspace
+      maps={data}
+      reviewSnapshots={reviewQueue.data ?? []}
+      reviewLoading={reviewQueue.isLoading}
+      approvingSnapshotId={approveSnapshot.variables ?? null}
+      onApproveSnapshot={(snapshotId) => approveSnapshot.mutate(snapshotId)}
+    />
+  );
 }

--- a/apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.test.tsx
+++ b/apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TaxCompanyPilotWorkspace } from "./TaxCompanyPilotWorkspace";
 import type { TaxCompanyPilotMap } from "@/lib/api/crm/crm.types";
@@ -281,5 +281,54 @@ describe("TaxCompanyPilotWorkspace", () => {
     expect(consoleError.mock.calls.flat().join("\n")).not.toContain(
       "Encountered two children with the same key",
     );
+  });
+
+  it("renders Workspace AI draft review queue with approve action", () => {
+    const onApproveSnapshot = vi.fn();
+
+    render(
+      <TaxCompanyPilotWorkspace
+        maps={[oceanMap]}
+        reviewSnapshots={[
+          {
+            id: "snapshot-draft",
+            company_id: 7,
+            client_id: null,
+            company_name: "OCEAN CLOTHES AND SHOES PT",
+            provider: "gemini",
+            source_file_ids: ["drive-file-1"],
+            facts: [
+              {
+                category: "identity",
+                label: "Company evidence",
+                detail: "Company source documents are indexed for review.",
+                source_file_ids: ["drive-file-1"],
+                confidence: "medium",
+              },
+            ],
+            status: "draft",
+            created_by: "crm-drive-autowatcher",
+            approved_by: null,
+            approved_at: null,
+            created_at: "2026-05-12T15:45:00+00:00",
+          },
+        ]}
+        onApproveSnapshot={onApproveSnapshot}
+      />,
+    );
+
+    expect(screen.getByText("Workspace AI review")).toBeInTheDocument();
+    expect(screen.getByText("1 draft")).toBeInTheDocument();
+    expect(
+      screen.getByText("Company source documents are indexed for review."),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Approve Workspace AI draft for OCEAN CLOTHES AND SHOES PT",
+      }),
+    );
+
+    expect(onApproveSnapshot).toHaveBeenCalledWith("snapshot-draft");
   });
 });

--- a/apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.tsx
+++ b/apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.tsx
@@ -19,6 +19,7 @@ import type {
   TaxCompanyPilotMap,
   TaxCompanyPilotNextAction,
   TaxCompanyPilotPersonDossier,
+  WorkspaceAiSnapshotReviewItem,
 } from "@/lib/api/crm/crm.types";
 
 const severityClass: Record<TaxCompanyPilotGap["severity"], string> = {
@@ -455,10 +456,95 @@ function CompanyPilotPanel({ map }: { map: TaxCompanyPilotMap }) {
   );
 }
 
+function WorkspaceAiReviewPanel({
+  snapshots,
+  loading = false,
+  approvingSnapshotId = null,
+  onApproveSnapshot,
+}: {
+  snapshots: WorkspaceAiSnapshotReviewItem[];
+  loading?: boolean;
+  approvingSnapshotId?: string | null;
+  onApproveSnapshot?: (snapshotId: string) => void;
+}) {
+  if (!loading && snapshots.length === 0) return null;
+
+  const draftCount = snapshots.filter(
+    (snapshot) => snapshot.status === "draft",
+  ).length;
+
+  return (
+    <section className="mb-5 border-b border-slate-200 pb-5">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-sm font-semibold text-slate-950">
+          <Sparkles size={16} />
+          Workspace AI review
+        </div>
+        <span className="rounded bg-white px-2.5 py-1 text-xs font-medium text-slate-600 ring-1 ring-slate-200">
+          {loading
+            ? "Checking drafts"
+            : `${draftCount} draft${draftCount === 1 ? "" : "s"}`}
+        </span>
+      </div>
+      {snapshots.length > 0 && (
+        <div className="grid gap-3 lg:grid-cols-2">
+          {snapshots.slice(0, 6).map((snapshot) => {
+            const firstFact = snapshot.facts[0];
+            const isApproving = approvingSnapshotId === snapshot.id;
+            return (
+              <article
+                key={snapshot.id}
+                className="rounded-lg border border-slate-200 bg-white p-3 shadow-sm"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-semibold text-slate-950">
+                      {snapshot.company_name}
+                    </p>
+                    <p className="mt-1 text-xs uppercase text-slate-500">
+                      {snapshot.provider} · {snapshot.status}
+                    </p>
+                  </div>
+                  {snapshot.status === "draft" && (
+                    <button
+                      type="button"
+                      aria-label={`Approve Workspace AI draft for ${snapshot.company_name}`}
+                      disabled={!onApproveSnapshot || isApproving}
+                      onClick={() => onApproveSnapshot?.(snapshot.id)}
+                      className="inline-flex items-center gap-1.5 rounded-md bg-emerald-700 px-2.5 py-1.5 text-xs font-semibold text-white hover:bg-emerald-800 disabled:cursor-not-allowed disabled:bg-slate-300"
+                    >
+                      <ShieldCheck size={13} />
+                      {isApproving ? "Approving" : "Approve"}
+                    </button>
+                  )}
+                </div>
+                {firstFact && (
+                  <div className="mt-3 border-l-2 border-emerald-600 bg-emerald-50 px-3 py-2 text-sm text-emerald-950">
+                    <p className="font-medium">{firstFact.label}</p>
+                    <p className="mt-1 leading-5">{firstFact.detail}</p>
+                  </div>
+                )}
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}
+
 export function TaxCompanyPilotWorkspace({
   maps,
+  reviewSnapshots = [],
+  reviewLoading = false,
+  approvingSnapshotId = null,
+  onApproveSnapshot,
 }: {
   maps: TaxCompanyPilotMap[];
+  reviewSnapshots?: WorkspaceAiSnapshotReviewItem[];
+  reviewLoading?: boolean;
+  approvingSnapshotId?: string | null;
+  onApproveSnapshot?: (snapshotId: string) => void;
 }) {
   const totalPeople = maps.reduce((sum, map) => sum + map.persons.length, 0);
   const totalDocuments = maps.reduce(
@@ -517,6 +603,12 @@ export function TaxCompanyPilotWorkspace({
           </div>
         </div>
       </header>
+      <WorkspaceAiReviewPanel
+        snapshots={reviewSnapshots}
+        loading={reviewLoading}
+        approvingSnapshotId={approvingSnapshotId}
+        onApproveSnapshot={onApproveSnapshot}
+      />
       <div className="grid gap-4 xl:grid-cols-2">
         {maps.map((map, index) => (
           <CompanyPilotPanel

--- a/apps/mouth/src/lib/api/crm/crm.api.test.ts
+++ b/apps/mouth/src/lib/api/crm/crm.api.test.ts
@@ -151,6 +151,64 @@ describe("CrmApi", () => {
     });
   });
 
+  describe("workspace AI review", () => {
+    it("should fetch workspace AI draft review queue", async () => {
+      const mockQueue = [
+        {
+          id: "snapshot-draft",
+          company_id: 7,
+          client_id: null,
+          company_name: "OCEAN CLOTHES AND SHOES PT",
+          provider: "gemini",
+          source_file_ids: [],
+          facts: [],
+          status: "draft",
+          created_by: "crm-drive-autowatcher",
+          approved_by: null,
+          approved_at: null,
+          created_at: "2026-05-12T15:45:00+00:00",
+        },
+      ];
+      mockClient.request.mockResolvedValue(mockQueue);
+
+      const result = await crmApi.getWorkspaceAiReviewQueue({
+        status: "draft",
+        limit: 25,
+      });
+
+      expect(mockClient.request).toHaveBeenCalledWith(
+        "/api/crm/intelligence/workspace-ai-snapshots/review?status=draft&limit=25",
+      );
+      expect(result).toEqual(mockQueue);
+    });
+
+    it("should approve a workspace AI draft", async () => {
+      const mockApproved = {
+        id: "snapshot-draft",
+        company_id: 7,
+        client_id: null,
+        company_name: "OCEAN CLOTHES AND SHOES PT",
+        provider: "gemini",
+        source_file_ids: [],
+        facts: [],
+        status: "approved",
+        created_by: "crm-drive-autowatcher",
+        approved_by: "team@balizero.com",
+        approved_at: "2026-05-13T15:45:00+00:00",
+        created_at: "2026-05-12T15:45:00+00:00",
+      };
+      mockClient.request.mockResolvedValue(mockApproved);
+
+      const result = await crmApi.approveWorkspaceAiSnapshot("snapshot-draft");
+
+      expect(mockClient.request).toHaveBeenCalledWith(
+        "/api/crm/intelligence/workspace-ai-snapshots/snapshot-draft/approve",
+        { method: "POST" },
+      );
+      expect(result).toEqual(mockApproved);
+    });
+  });
+
   describe("markInteractionRead", () => {
     it("should mark interaction as read", async () => {
       const mockResponse = {

--- a/apps/mouth/src/lib/api/crm/crm.api.ts
+++ b/apps/mouth/src/lib/api/crm/crm.api.ts
@@ -26,6 +26,8 @@ import type {
   TaxCompanyPilotKey,
   TaxCompanyPilotMap,
   AiSummaryResponse,
+  WorkspaceAiSnapshotReviewItem,
+  WorkspaceAiSnapshotReviewStatus,
 } from "./crm.types";
 import type {
   RequiredDocument,
@@ -224,6 +226,30 @@ export class CrmApi {
     queryParams.append("limit", limit.toString());
     return this.client.request<TaxCompanyPilotMap[]>(
       `/api/crm/intelligence/evidence-dossiers?${queryParams.toString()}`,
+    );
+  }
+
+  async getWorkspaceAiReviewQueue({
+    status = "draft",
+    limit = 25,
+  }: {
+    status?: WorkspaceAiSnapshotReviewStatus;
+    limit?: number;
+  } = {}): Promise<WorkspaceAiSnapshotReviewItem[]> {
+    const queryParams = new URLSearchParams();
+    queryParams.append("status", status);
+    queryParams.append("limit", limit.toString());
+    return this.client.request<WorkspaceAiSnapshotReviewItem[]>(
+      `/api/crm/intelligence/workspace-ai-snapshots/review?${queryParams.toString()}`,
+    );
+  }
+
+  async approveWorkspaceAiSnapshot(
+    snapshotId: string,
+  ): Promise<WorkspaceAiSnapshotReviewItem> {
+    return this.client.request<WorkspaceAiSnapshotReviewItem>(
+      `/api/crm/intelligence/workspace-ai-snapshots/${encodeURIComponent(snapshotId)}/approve`,
+      { method: "POST" },
     );
   }
 

--- a/apps/mouth/src/lib/api/crm/crm.schemas.ts
+++ b/apps/mouth/src/lib/api/crm/crm.schemas.ts
@@ -32,7 +32,10 @@ export const leadSourceEnum = z.enum([
 // Practice type codes are now loaded dynamically from the backend catalog
 // (69 services across 9 categories). Validate as non-empty string.
 export const practiceTypeCodeEnum = z
-  .string()
+  .string({
+    required_error: "Service type is required",
+    invalid_type_error: "Service type is required",
+  })
   .min(1, "Service type is required");
 
 export const practiceStatusEnum = z.enum([
@@ -162,7 +165,12 @@ export type CreateClientOutput = z.output<typeof createClientSchema>;
 
 export const createPracticeSchema = z
   .object({
-    client_id: z.number().positive("Invalid client ID"),
+    client_id: z
+      .number({
+        required_error: "Client is required",
+        invalid_type_error: "Client is required",
+      })
+      .positive("Invalid client ID"),
     practice_type_code: practiceTypeCodeEnum,
     status: practiceStatusEnum.default("inquiry"),
     priority: practicePriorityEnum.default("normal"),

--- a/apps/mouth/src/lib/api/crm/crm.types.ts
+++ b/apps/mouth/src/lib/api/crm/crm.types.ts
@@ -142,6 +142,25 @@ export interface TaxCompanyPilotWorkspaceAiSnapshot {
   created_at?: string | null;
 }
 
+export type WorkspaceAiSnapshotReviewStatus = "draft" | "approved" | "rejected";
+
+export interface WorkspaceAiSnapshotReviewItem {
+  id: string;
+  company_id?: number | null;
+  client_id?: number | null;
+  company_name: string;
+  provider: "notebooklm" | "gemini" | "manual";
+  notebook_id?: string | null;
+  note_id?: string | null;
+  source_file_ids: string[];
+  facts: TaxCompanyPilotWorkspaceAiFact[];
+  status: WorkspaceAiSnapshotReviewStatus;
+  created_by?: string | null;
+  approved_by?: string | null;
+  approved_at?: string | null;
+  created_at: string;
+}
+
 export interface TaxCompanyPilotEvidenceStory {
   person_name: string;
   company_name: string;


### PR DESCRIPTION
## Summary

- Adds backend CRM Workspace AI snapshot review queue and approve endpoint.
- Adds frontend review panel on the tax pilot workspace to approve draft insights.
- Wires CRM API types, schemas, client helpers, and focused tests.

## Verification

- `PYTHONPATH=. python -m pytest backend/tests/services/crm/test_workspace_ai_snapshots.py backend/tests/unit/routers/test_crm_intelligence.py backend/tests/unit/services/crm/test_evidence_dossier.py -q`
- `PYTHONPATH=. python -m ruff check backend/app/routers/crm_intelligence.py backend/services/crm/workspace_ai_snapshots.py backend/tests/services/crm/test_workspace_ai_snapshots.py backend/tests/unit/routers/test_crm_intelligence.py`
- `PYTHONPATH=. python -c "from backend.app.dependencies import get_current_user; print('OK')"`
- `npm run test -- src/lib/api/crm/crm.api.test.ts src/components/crm/TaxCompanyPilotWorkspace.test.tsx --run`
- `npm run typecheck`
