### PR TITLE
fix(crm): restore zod schema build compatibility

### DIFF
--- a/apps/mouth/src/lib/api/crm/crm.schemas.ts
+++ b/apps/mouth/src/lib/api/crm/crm.schemas.ts
@@ -32,10 +32,7 @@ export const leadSourceEnum = z.enum([
 // Practice type codes are now loaded dynamically from the backend catalog
 // (69 services across 9 categories). Validate as non-empty string.
 export const practiceTypeCodeEnum = z
-  .string({
-    required_error: "Service type is required",
-    invalid_type_error: "Service type is required",
-  })
+  .string()
   .min(1, "Service type is required");
 
 export const practiceStatusEnum = z.enum([
@@ -165,12 +162,7 @@ export type CreateClientOutput = z.output<typeof createClientSchema>;
 
 export const createPracticeSchema = z
   .object({
-    client_id: z
-      .number({
-        required_error: "Client is required",
-        invalid_type_error: "Client is required",
-      })
-      .positive("Invalid client ID"),
+    client_id: z.number().positive("Invalid client ID"),
     practice_type_code: practiceTypeCodeEnum,
     status: practiceStatusEnum.default("inquiry"),
     priority: practicePriorityEnum.default("normal"),


### PR DESCRIPTION
## Summary

- Restores Zod schema calls in `crm.schemas.ts` to the production-compatible form.
- Fixes Vercel `next build` failures caused by unsupported `required_error` / `invalid_type_error` options.

## Verification

- `npm run typecheck`
- `npm run test -- src/lib/api/crm/crm.api.test.ts src/components/crm/TaxCompanyPilotWorkspace.test.tsx --run`
- `npm run build`
