### PR TITLE
fix(nlm): align notebook uuid references

### DIFF
--- a/apps/backend-rag/backend/kb/legal/employment-ip-2026-04-25/00-INDEX.md
+++ b/apps/backend-rag/backend/kb/legal/employment-ip-2026-04-25/00-INDEX.md
@@ -2,7 +2,7 @@
 title: Employment & IP Defense — Indonesian PKWT Contracts (Master Index)
 domain: company
 subdomain: employment_law_ip_protection
-notebook: NB-3 (Company & Licensing) — UUID 933509f9-1561-403d-bd44-4a7a67a36df2
+notebook: NB-3 (Company & Licensing) — UUID 045f3cdb-ef62-488c-90ba-82594928b671
 collection: legal_unified_hybrid_hybrid
 generated_at: 2026-04-25
 generator: Exa Research Pro (exa-research-pro model, $1.56)

--- a/apps/backend-rag/backend/tests/core/test_nlm_shadow_chunk.py
+++ b/apps/backend-rag/backend/tests/core/test_nlm_shadow_chunk.py
@@ -12,7 +12,7 @@ def test_minimal_construction():
     c = NLMShadowChunk(
         chunk_id="nlm_shadow_NB-3_20260425_001",
         claim_text="PT PMA minimum capital is IDR 10 billion under PP 28/2025.",
-        nb_id="933509f9-1561-403d-bd44-4a7a67a36df2",
+        nb_id="045f3cdb-ef62-488c-90ba-82594928b671",
         nb_label="company",
         extraction_run_id="run-001",
     )

--- a/apps/backend-rag/backend/tests/services/ingestion/test_legal_full_worker.py
+++ b/apps/backend-rag/backend/tests/services/ingestion/test_legal_full_worker.py
@@ -30,7 +30,7 @@ def test_resolve_nb_target_invalid_override_falls_back():
 
 def test_resolve_nb_notebook_id():
     nb_id = resolve_nb_notebook_id("NB-3")
-    assert nb_id == "933509f9-1561-403d-bd44-4a7a67a36df2"
+    assert nb_id == "045f3cdb-ef62-488c-90ba-82594928b671"
 
 
 def test_resolve_nb_notebook_id_unknown():

--- a/apps/backend-rag/backend/tests/services/oracle/test_nlm_notebook_registry_freshness.py
+++ b/apps/backend-rag/backend/tests/services/oracle/test_nlm_notebook_registry_freshness.py
@@ -11,8 +11,6 @@ import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-import pytest
-
 from backend.services.oracle import nlm_notebook_registry as reg
 
 
@@ -107,7 +105,7 @@ def test_resolve_notebook_returns_none_when_stale_and_gated(tmp_path, monkeypatc
     old = (datetime.now(tz=timezone.utc) - timedelta(hours=48)).isoformat()
     _write_state(state, {
         # Use the actual NB-2 UUID from registry
-        "cff93ab0-813a-42f2-a8de-36987e724271": {
+        "271c7159-0c32-49a1-bda8-803c8e0993a6": {
             "last": {"started_at": old, "status": "ok", "uuid": "x"},
         }
     })
@@ -125,7 +123,7 @@ def test_resolve_notebook_returns_nb_when_fresh_and_gated(tmp_path, monkeypatch)
     state = tmp_path / "state.json"
     now = datetime.now(tz=timezone.utc).isoformat()
     _write_state(state, {
-        "cff93ab0-813a-42f2-a8de-36987e724271": {
+        "271c7159-0c32-49a1-bda8-803c8e0993a6": {
             "last": {"started_at": now, "status": "ok", "uuid": "fresh"},
         }
     })

--- a/apps/backend-rag/backend/tests/services/oracle/test_nlm_orchestrator.py
+++ b/apps/backend-rag/backend/tests/services/oracle/test_nlm_orchestrator.py
@@ -175,13 +175,13 @@ class TestNLMOrchestrator:
 # ── Sprint 1a golden tests: extended routing via NLM_EXTENDED_ROUTING ────────
 
 # The 5 notebooks that were orphaned on the backend side before Sprint 1a.
-NB_5_PROPERTY = "d9438180-5e63-4e2a-a473-6061101f6a8d"
-NB_6_OPERATIONS = "85207af3-352f-4554-8d2a-18f42cc541ba"
-NB_7_EDITORIAL = "f51ab8a0-50d0-49f1-a64f-ebc131fed7b8"
-NB_8_LIFESTYLE = "4fd8cd0f-93f1-4e43-9c9e-86c0d581852c"
-NB_10_TEAM = "f0307c2c-9220-4160-93c8-f4a6ef4a3b65"
+NB_5_PROPERTY = "93314ad3-177e-4d2f-956b-fe4be3e47697"
+NB_6_OPERATIONS = "7fbf37ed-e290-491a-98f5-677d6371ad62"
+NB_7_EDITORIAL = "42687fcb-87fc-40b1-8af8-8a2ff91f9c4c"
+NB_8_LIFESTYLE = "aa9ac5d7-5090-46c7-9d09-89cec4ba13de"
+NB_10_TEAM = "b319f1b3-74a1-415f-b8c0-c0626b008f29"
 # And the legacy-fallback used before the fix.
-NB_3_COMPANY = "933509f9-1561-403d-bd44-4a7a67a36df2"
+NB_3_COMPANY = "045f3cdb-ef62-488c-90ba-82594928b671"
 
 
 class TestExtendedRoutingFlag:
@@ -238,7 +238,7 @@ class TestExtendedRoutingFlag:
         monkeypatch.delenv("NLM_EXTENDED_ROUTING", raising=False)
         orch = self._make_orch()
         assert orch._resolve_notebooks("visa", is_cross_domain=False) == [
-            "cff93ab0-813a-42f2-a8de-36987e724271"
+            "271c7159-0c32-49a1-bda8-803c8e0993a6"
         ]
         assert orch._resolve_notebooks("tax", is_cross_domain=False) == [
             "d4b2eedb-9863-4a1a-81ff-a11b0b45d853"
@@ -284,7 +284,7 @@ class TestExtendedRoutingFlag:
         monkeypatch.setenv("NLM_EXTENDED_ROUTING", "yes")
         orch = self._make_orch()
         assert orch._resolve_notebooks("visa", is_cross_domain=False) == [
-            "cff93ab0-813a-42f2-a8de-36987e724271"
+            "271c7159-0c32-49a1-bda8-803c8e0993a6"
         ]
         assert orch._resolve_notebooks("tax", is_cross_domain=False) == [
             "d4b2eedb-9863-4a1a-81ff-a11b0b45d853"

--- a/apps/backend-rag/scripts/golden_answers_questions.yaml
+++ b/apps/backend-rag/scripts/golden_answers_questions.yaml
@@ -9,7 +9,7 @@ questions:
   # ─── VISA DOMAIN (NB-2) ───
   - question: "What are the requirements for a B211A social/cultural visa?"
     domain: visa
-    nb_id: "cff93ab0-813a-42f2-a8de-36987e724271"
+    nb_id: "271c7159-0c32-49a1-bda8-803c8e0993a6"
     aliases:
       - "B211A visa requirements"
       - "B211 social budaya"
@@ -19,7 +19,7 @@ questions:
 
   - question: "What is the difference between Golden Visa and Second Home Visa in Indonesia?"
     domain: visa
-    nb_id: "cff93ab0-813a-42f2-a8de-36987e724271"
+    nb_id: "271c7159-0c32-49a1-bda8-803c8e0993a6"
     aliases:
       - "golden visa vs second home"
       - "compare golden visa retirement visa"
@@ -27,7 +27,7 @@ questions:
 
   - question: "What are the requirements for the Golden Visa in Indonesia?"
     domain: visa
-    nb_id: "cff93ab0-813a-42f2-a8de-36987e724271"
+    nb_id: "271c7159-0c32-49a1-bda8-803c8e0993a6"
     aliases:
       - "golden visa requirements"
       - "golden visa Indonesia"
@@ -36,7 +36,7 @@ questions:
 
   - question: "What is a Digital Nomad Visa in Indonesia and how do I apply?"
     domain: visa
-    nb_id: "cff93ab0-813a-42f2-a8de-36987e724271"
+    nb_id: "271c7159-0c32-49a1-bda8-803c8e0993a6"
     aliases:
       - "digital nomad visa Bali"
       - "remote worker visa Indonesia"
@@ -45,7 +45,7 @@ questions:
 
   - question: "What are the requirements for a Working KITAS in Indonesia?"
     domain: visa
-    nb_id: "cff93ab0-813a-42f2-a8de-36987e724271"
+    nb_id: "271c7159-0c32-49a1-bda8-803c8e0993a6"
     aliases:
       - "KITAS work permit"
       - "working visa Bali"
@@ -55,7 +55,7 @@ questions:
 
   - question: "What is the Second Home Visa E33 and who qualifies?"
     domain: visa
-    nb_id: "cff93ab0-813a-42f2-a8de-36987e724271"
+    nb_id: "271c7159-0c32-49a1-bda8-803c8e0993a6"
     aliases:
       - "second home visa"
       - "E33 visa"
@@ -65,7 +65,7 @@ questions:
 
   - question: "What is the Investor KITAS E28A and what are the investment requirements?"
     domain: visa
-    nb_id: "cff93ab0-813a-42f2-a8de-36987e724271"
+    nb_id: "271c7159-0c32-49a1-bda8-803c8e0993a6"
     aliases:
       - "investor KITAS"
       - "E28A visa"
@@ -74,7 +74,7 @@ questions:
 
   - question: "How do I extend my visit visa in Bali?"
     domain: visa
-    nb_id: "cff93ab0-813a-42f2-a8de-36987e724271"
+    nb_id: "271c7159-0c32-49a1-bda8-803c8e0993a6"
     aliases:
       - "visa extension Bali"
       - "perpanjangan visa"
@@ -83,7 +83,7 @@ questions:
 
   - question: "What happens if my visa expires in Indonesia? What are the penalties?"
     domain: visa
-    nb_id: "cff93ab0-813a-42f2-a8de-36987e724271"
+    nb_id: "271c7159-0c32-49a1-bda8-803c8e0993a6"
     aliases:
       - "overstay penalty Indonesia"
       - "visa expired Bali"
@@ -92,7 +92,7 @@ questions:
 
   - question: "What documents do I need for an offshore KITAS application?"
     domain: visa
-    nb_id: "cff93ab0-813a-42f2-a8de-36987e724271"
+    nb_id: "271c7159-0c32-49a1-bda8-803c8e0993a6"
     aliases:
       - "offshore KITAS documents"
       - "KITAS offshore application"
@@ -101,7 +101,7 @@ questions:
 
   - question: "What is the difference between KITAS and KITAP?"
     domain: visa
-    nb_id: "cff93ab0-813a-42f2-a8de-36987e724271"
+    nb_id: "271c7159-0c32-49a1-bda8-803c8e0993a6"
     aliases:
       - "KITAS vs KITAP"
       - "temporary vs permanent stay"
@@ -109,7 +109,7 @@ questions:
 
   - question: "What is the E-VOA (Electronic Visa on Arrival) and how does it work?"
     domain: visa
-    nb_id: "cff93ab0-813a-42f2-a8de-36987e724271"
+    nb_id: "271c7159-0c32-49a1-bda8-803c8e0993a6"
     aliases:
       - "E-VOA Indonesia"
       - "visa on arrival Bali"
@@ -173,7 +173,7 @@ questions:
   # ─── COMPANY DOMAIN (NB-3/NB-6) ───
   - question: "How do I set up a PT PMA company in Bali as a foreigner?"
     domain: company
-    nb_id: "85207af3-352f-4554-8d2a-18f42cc541ba"
+    nb_id: "045f3cdb-ef62-488c-90ba-82594928b671"
     aliases:
       - "PT PMA setup"
       - "company formation Bali"
@@ -182,7 +182,7 @@ questions:
 
   - question: "What is the minimum capital requirement for a PT PMA?"
     domain: company
-    nb_id: "85207af3-352f-4554-8d2a-18f42cc541ba"
+    nb_id: "045f3cdb-ef62-488c-90ba-82594928b671"
     aliases:
       - "PT PMA modal"
       - "minimum investment PT PMA"
@@ -191,7 +191,7 @@ questions:
 
   - question: "What KBLI codes do I need for a restaurant in Bali?"
     domain: company
-    nb_id: "85207af3-352f-4554-8d2a-18f42cc541ba"
+    nb_id: "045f3cdb-ef62-488c-90ba-82594928b671"
     aliases:
       - "KBLI restaurant"
       - "KBLI 56101"
@@ -201,7 +201,7 @@ questions:
 
   - question: "How does the OSS (Online Single Submission) system work for business licensing?"
     domain: company
-    nb_id: "85207af3-352f-4554-8d2a-18f42cc541ba"
+    nb_id: "045f3cdb-ef62-488c-90ba-82594928b671"
     aliases:
       - "OSS RBA"
       - "perizinan berusaha"
@@ -210,7 +210,7 @@ questions:
 
   - question: "What is the difference between PT PMA and PT PMDN?"
     domain: company
-    nb_id: "85207af3-352f-4554-8d2a-18f42cc541ba"
+    nb_id: "045f3cdb-ef62-488c-90ba-82594928b671"
     aliases:
       - "PMA vs PMDN"
       - "foreign vs local company Indonesia"
@@ -218,7 +218,7 @@ questions:
 
   - question: "What are the steps to get a NIB (Nomor Induk Berusaha)?"
     domain: company
-    nb_id: "85207af3-352f-4554-8d2a-18f42cc541ba"
+    nb_id: "045f3cdb-ef62-488c-90ba-82594928b671"
     aliases:
       - "NIB registration"
       - "nomor induk berusaha"
@@ -227,7 +227,7 @@ questions:
   # ─── PROPERTY DOMAIN (NB-5) ───
   - question: "Can a foreigner buy property in Bali? What are the options?"
     domain: property
-    nb_id: "d9438180-5e63-4e2a-a473-6061101f6a8d"
+    nb_id: "93314ad3-177e-4d2f-956b-fe4be3e47697"
     aliases:
       - "foreigner buy property Bali"
       - "hak pakai WNA"
@@ -236,7 +236,7 @@ questions:
 
   - question: "What is Hak Pakai and how does it work for foreigners?"
     domain: property
-    nb_id: "d9438180-5e63-4e2a-a473-6061101f6a8d"
+    nb_id: "93314ad3-177e-4d2f-956b-fe4be3e47697"
     aliases:
       - "hak pakai"
       - "right to use Indonesia"
@@ -245,7 +245,7 @@ questions:
 
   - question: "What taxes apply to property transactions in Indonesia?"
     domain: property
-    nb_id: "d9438180-5e63-4e2a-a473-6061101f6a8d"
+    nb_id: "93314ad3-177e-4d2f-956b-fe4be3e47697"
     aliases:
       - "property tax Indonesia"
       - "BPHTB"
@@ -254,7 +254,7 @@ questions:
 
   - question: "What is the process for transferring property ownership to a foreigner in Indonesia?"
     domain: property
-    nb_id: "d9438180-5e63-4e2a-a473-6061101f6a8d"
+    nb_id: "93314ad3-177e-4d2f-956b-fe4be3e47697"
     aliases:
       - "property transfer foreigner"
       - "pelepasan hak"

--- a/apps/backend-rag/scripts/nlm_claims_extractor.py
+++ b/apps/backend-rag/scripts/nlm_claims_extractor.py
@@ -8,7 +8,7 @@ Usage:
     cd apps/backend-rag
     source venv/bin/activate
     OPENAI_API_KEY=... PYTHONPATH=. python scripts/nlm_claims_extractor.py \
-        --notebook 933509f9-1561-403d-bd44-4a7a67a36df2 --domain company
+        --notebook 045f3cdb-ef62-488c-90ba-82594928b671 --domain company
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- align stale NotebookLM UUID references with the migrated zero@balizero.com registry
- update affected NLM tests, golden-answer notebook ids, and operator docs/examples

## Verification
- source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && PYTHONPATH=. python -m pytest backend/tests/services/ingestion/test_legal_full_worker.py backend/tests/services/oracle/test_nlm_orchestrator.py backend/tests/services/oracle/test_nlm_notebook_registry_freshness.py backend/tests/core/test_nlm_shadow_chunk.py -q
- source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && cd apps/backend-rag && PYTHONPATH=. python -m ruff check backend/tests/services/ingestion/test_legal_full_worker.py backend/tests/services/oracle/test_nlm_orchestrator.py backend/tests/services/oracle/test_nlm_notebook_registry_freshness.py backend/tests/core/test_nlm_shadow_chunk.py scripts/nlm_claims_extractor.py
- source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && cd apps/backend-rag && PYTHONPATH=. python -c "from backend.app.dependencies import get_current_user; print('OK')"
- npm run typecheck -w apps/mouth
- python YAML parse check: 28 golden-answer questions