### PR TITLE
feat(rag): allow tax_genius as secondary ingest target

### DIFF
--- a/apps/backend-rag/backend/scripts/ingest_pwc_pocket_tax_book_2026.py
+++ b/apps/backend-rag/backend/scripts/ingest_pwc_pocket_tax_book_2026.py
@@ -1,0 +1,82 @@
+"""
+One-shot ingest of PwC Indonesian Pocket Tax Book 2026 into tax_genius_hybrid.
+
+Uses the same legal-ingestion pipeline (BM25 + dense 1536 + flat payload +
+hierarchical indexer) but targets the tax canonical collection. Authority
+tier secondary so query-time filters can prefer UU/PMK primary over PwC
+secondary on high-stakes regulatory questions.
+
+Run:
+    cd apps/backend-rag
+    source .venv/bin/activate
+    PYTHONPATH=. python backend/scripts/ingest_pwc_pocket_tax_book_2026.py
+"""
+
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+)
+logger = logging.getLogger("pwc_ingest")
+
+
+PDF_PATH = "/Users/nuzantara/Desktop/pocket-tax-book-2026.pdf"
+SOURCE_TAG = "pwc_pocket_tax_book_2026"
+TIGRIS_URL = (
+    "https://fly.storage.tigris.dev/nuzantara-warroom-images/tax/"
+    "pwc-pocket-tax-book-2026.pdf"
+)
+
+
+async def main() -> int:
+    if not Path(PDF_PATH).exists():
+        logger.error("PDF missing at %s", PDF_PATH)
+        return 1
+
+    os.environ["LEGAL_INGEST_ALLOW_QDRANT_ENV_OVERRIDE"] = "1"
+
+    from backend.app.models import TierLevel
+    from backend.services.ingestion.legal_ingestion_service import (
+        LegalIngestionService,
+        validate_legal_ingest_result,
+    )
+
+    service = LegalIngestionService(collection_name="tax_genius")
+
+    result = await service.ingest_legal_document(
+        file_path=PDF_PATH,
+        title="PwC Indonesian Pocket Tax Book 2026",
+        tier_override=TierLevel.S,
+        collection_name="tax_genius",
+        skip_pricing=True,
+        category="tax_guide_secondary",
+        document_id=SOURCE_TAG,
+    )
+
+    if not result.get("success"):
+        logger.error("Ingestion failed: %s", result.get("error"))
+        logger.error("Full result: %s", result)
+        return 1
+
+    try:
+        validate_legal_ingest_result(result)
+    except Exception as exc:
+        logger.error("Integrity validation failed: %s", exc)
+        return 1
+
+    logger.info("✅ Ingest complete")
+    logger.info("   collection      : %s", result.get("collection"))
+    logger.info("   chunks created  : %s", result.get("chunks_created"))
+    logger.info("   chunks upserted : %s", result.get("chunks_upserted"))
+    logger.info("   document_id     : %s", SOURCE_TAG)
+    logger.info("   tigris url      : %s", TIGRIS_URL)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/apps/backend-rag/backend/services/ingestion/legal_ingestion_service.py
+++ b/apps/backend-rag/backend/services/ingestion/legal_ingestion_service.py
@@ -32,6 +32,11 @@ logger = logging.getLogger(__name__)
 LEGAL_CANONICAL_COLLECTION = "legal_unified"
 LEGAL_ENV_OVERRIDE_FLAG = "LEGAL_INGEST_ALLOW_QDRANT_ENV_OVERRIDE"
 
+ALLOWED_CANONICAL_COLLECTIONS = frozenset({
+    LEGAL_CANONICAL_COLLECTION,
+    "tax_genius",
+})
+
 
 class LegalIngestIntegrityError(RuntimeError):
     """Raised when legal/regulatory ingestion would write to an unsafe target."""
@@ -128,10 +133,11 @@ def validate_legal_ingest_preflight(preflight: LegalIngestPreflight) -> None:
         )
 
     canonical_target = canonicalize_collection_name(preflight.resolved_collection)
-    if canonical_target != LEGAL_CANONICAL_COLLECTION:
+    if canonical_target not in ALLOWED_CANONICAL_COLLECTIONS:
         raise LegalIngestIntegrityError(
-            "Legal ingestion target collection must resolve to "
-            f"{LEGAL_CANONICAL_COLLECTION!r}; requested={preflight.requested_collection!r} "
+            "Legal ingestion target collection must resolve to one of "
+            f"{sorted(ALLOWED_CANONICAL_COLLECTIONS)!r}; "
+            f"requested={preflight.requested_collection!r} "
             f"resolved={preflight.resolved_collection!r}"
         )
 

--- a/apps/backend-rag/backend/tests/unit/services/ingestion/test_legal_ingest_integrity.py
+++ b/apps/backend-rag/backend/tests/unit/services/ingestion/test_legal_ingest_integrity.py
@@ -50,7 +50,7 @@ def test_preflight_allows_explicit_process_env_override() -> None:
 
 
 def test_preflight_rejects_wrong_target_collection() -> None:
-    """Legal/regulatory ingestion must only target the legal collection family."""
+    """Legal/regulatory ingestion must only target the allowed collection family."""
     from backend.services.ingestion.legal_ingestion_service import (
         LegalIngestIntegrityError,
         LegalIngestPreflight,
@@ -69,6 +69,37 @@ def test_preflight_rejects_wrong_target_collection() -> None:
 
     with pytest.raises(LegalIngestIntegrityError, match="target collection"):
         validate_legal_ingest_preflight(preflight)
+
+
+def test_preflight_accepts_tax_genius_canonical() -> None:
+    """tax_genius is an allowed secondary-authority target (PwC, Big-4 guides, OECD reports)."""
+    from backend.services.ingestion.legal_ingestion_service import (
+        LegalIngestPreflight,
+        validate_legal_ingest_preflight,
+    )
+
+    preflight = LegalIngestPreflight(
+        configured_qdrant_url="http://localhost:6333",
+        process_qdrant_url="http://localhost:6333",
+        env_file_qdrant_url="http://localhost:6333",
+        requested_collection="tax_genius",
+        resolved_collection="tax_genius_hybrid",
+        allow_process_env_override=False,
+        environment="development",
+    )
+
+    validate_legal_ingest_preflight(preflight)
+
+
+def test_allowed_canonical_collections_contains_legal_and_tax() -> None:
+    """Whitelist must include legal_unified (primary) and tax_genius (secondary)."""
+    from backend.services.ingestion.legal_ingestion_service import (
+        ALLOWED_CANONICAL_COLLECTIONS,
+        LEGAL_CANONICAL_COLLECTION,
+    )
+
+    assert LEGAL_CANONICAL_COLLECTION in ALLOWED_CANONICAL_COLLECTIONS
+    assert "tax_genius" in ALLOWED_CANONICAL_COLLECTIONS
 
 
 def test_validate_legal_ingest_result_rejects_failed_service_result() -> None:

--- a/research/tax/2026-05-18-pwc-pocket-tax-book-2026.md
+++ b/research/tax/2026-05-18-pwc-pocket-tax-book-2026.md
@@ -1,0 +1,184 @@
+---
+date: 2026-05-18
+domain: tax
+client_case: ground-truth tax 2026 — annual reference for all Bali Zero tax/compliance practice
+sources: 1
+authority_tier: secondary
+publisher: PwC Indonesia
+original_pdf: ~/Desktop/pocket-tax-book-2026.pdf
+tigris_url: https://fly.storage.tigris.dev/nuzantara-warroom-images/tax/pwc-pocket-tax-book-2026.pdf
+qdrant_collection: tax_genius_hybrid
+qdrant_source_tag: pwc_pocket_tax_book_2026
+qdrant_status: PARKED — write 403, replay when key available
+nb_target: NB-4 d4b2eedb-9863-4a1a-81ff-a11b0b45d853 (antonellosiano@gmail.com account)
+nb_source_id: 97a3cead-4a01-40b0-a381-1eb38c060458
+nb_public_link: https://notebooklm.google.com/notebook/d4b2eedb-9863-4a1a-81ff-a11b0b45d853
+pages: 122
+---
+
+# PwC Indonesian Pocket Tax Book 2026 — capture for Bali Zero
+
+## TL;DR (5 punti)
+
+1. **CIT rates**: flat 22% standard · 19% public companies (40% listing + conditions) · 50% discount for small enterprises (turnover ≤ IDR 50bn) on proportional taxable income up to IDR 4.8bn · **Final Tax 0.5% of turnover** for micro enterprises (gross turnover ≤ IDR 4.8bn).
+2. **PIT progressive 2026**: 5% (≤ IDR 60M) · 15% (60M–250M) · 25% (250M–500M) · 30% (500M–5bn) · **35% (> IDR 5bn)** — 5-bracket structure unchanged from 2024 reform.
+3. **VAT e-commerce**: foreign sellers/marketplaces appointed VAT Collector if transaction value > IDR 600M/year OR IDR 50M/month, OR platform access > 12,000 users/12mo OR 1,000 users/month.
+4. **Carbon Tax**: rate at least max(domestic carbon credit price, IDR 30/kg CO2e) — cap-and-trade mechanism, NOT fully implemented yet (emissions YES, carbon-content-goods NO).
+5. **MLI/Pillar Two**: GloBE rules issued 31 Dec 2024. **IIR effective 1 Jan 2025**, **UTPR effective 1 Jan 2026**, QDMTT from 1 Jan 2025. STTR MLI signed 19 Sep 2024 (29 treaties).
+
+## Section index (122 pp)
+
+| Section                                           | Page |
+| ------------------------------------------------- | ---- |
+| Corporate Income Tax                              | 1    |
+| Individual Income Tax                             | 17   |
+| Withholding taxes (Art 21/22/4(2)/23/26)          | 26   |
+| International tax agreements (DTA/TIEA/MLI/FATCA) | 36   |
+| Value Added Tax                                   | 48   |
+| Luxury-goods Sales Tax                            | 65   |
+| Carbon Tax                                        | 67   |
+| Customs and Excise                                | 69   |
+| Tax concessions (special projects/zones)          | 74   |
+| Regional Taxes (Land & Building, BPHTB)           | 89   |
+| Stamp Duty                                        | 96   |
+| Tax payments and tax return filing                | 97   |
+| Accounting for tax                                | 102  |
+| Tax audits and assessments                        | 104  |
+| Tax collection (distress warrant)                 | 110  |
+| Tax dispute resolution                            | 112  |
+| Contacts                                          | 116  |
+
+## Numeri-chiave per practice Bali Zero
+
+### Corporate Income Tax (CIT)
+
+| Regime                          | Rate             | Threshold                                                                  |
+| ------------------------------- | ---------------- | -------------------------------------------------------------------------- |
+| Standard                        | 22%              | All resident corps + PE foreign companies                                  |
+| Public company discount         | 19%              | 40% min listing + other conditions                                         |
+| Small enterprise (50% discount) | 11% effective    | Annual turnover ≤ IDR 50bn (applies proportionally on portion ≤ IDR 4.8bn) |
+| Micro (Final Tax)               | 0.5% of turnover | Annual gross turnover ≤ IDR 4.8bn                                          |
+
+### PIT 2026 (resident individuals)
+
+| Taxable income bracket      | Rate |
+| --------------------------- | ---- |
+| ≤ IDR 60,000,000            | 5%   |
+| 60,000,000 – 250,000,000    | 15%  |
+| 250,000,000 – 500,000,000   | 25%  |
+| 500,000,000 – 5,000,000,000 | 30%  |
+| > IDR 5,000,000,000         | 35%  |
+
+Severance pay concessional (if within 2 years): Nil ≤ 50M · 5% (50M–100M) · scaled above.
+
+### BPJS / Social Security (employer + employee)
+
+| Coverage                | Employer                  | Employee | Cap base         |
+| ----------------------- | ------------------------- | -------- | ---------------- |
+| Unemployment (JKP)      | Reallocated from JKK + JK | —        | —                |
+| Old age (JHT)           | 3.7%                      | 2%       | —                |
+| Health (BPJS Kesehatan) | 4%                        | 1%       | IDR 12M/month    |
+| Pension (JP)            | 2%                        | 1%       | Updated annually |
+
+**Tapera (housing savings, mandatory)**: 0.5% employer + 2.5% employee · freelancer 3% income · deadline registrazione private sector entro **19 May 2027**.
+
+### VAT thresholds & e-commerce
+
+- PKP threshold: turnover > IDR 4.8bn/year
+- VAT e-commerce trigger: > IDR 600M/year OR > IDR 50M/month OR > 12k users/12mo OR > 1k users/month
+- LST range: 10%–95% (legal cap 200%) — luxury residences 20%, motor vehicles full range
+
+### Carbon Tax
+
+- Base: at least max(domestic carbon credit price, IDR 30/kg CO2e)
+- Status: emission cap-and-trade YES, carbon-content goods purchase NOT YET implemented
+
+### Land & Building transfer
+
+- **PPh transfer rights** (seller): 2.5% gross transfer value (1% for simple-house/apartment developers) — FINAL tax
+- **BPHTB acquisition duty** (buyer): max 5% of NPOP (higher of market or NJOP), non-taxable threshold ≥ IDR 80M (inheritance from IDR 300M)
+
+### Stamp duty
+
+- Flat **IDR 10,000** on most documents (agreements, notarial deeds, securities, money docs > IDR 5M)
+
+### Annual filing deadlines
+
+| Tax         | Payment                                           | Return filing                     |
+| ----------- | ------------------------------------------------- | --------------------------------- |
+| CIT         | End 4th month after book year-end (before filing) | End 4th month after book year-end |
+| PIT         | End 3rd month after year-end (before filing)      | End 3rd month after year-end      |
+| PBB         | 6 months from SPPT receipt                        | N/A                               |
+| Monthly WHT | Day 15 of following month                         | Day 20 of following month         |
+| VAT/LST     | Before filing (end of month after)                | End of month after                |
+
+Late payment surcharge: MoF Interest Rate + part-month counts as full month, max 24 months.
+
+## International framework
+
+- **Tax treaties (DTA)**: extensive network, MLI ratified 13 Nov 2019, in force 1 Aug 2020, **60 treaties covered** by Convention (per 27 Nov 2023)
+- **TIEA**: San Marino (pending), Bermuda, Guernsey, Isle of Man, Jersey, Bahamas
+- **MAAC Convention**: signed/ratified 2014; CRS + Crypto-Asset Reporting + CbC Report active
+- **FATCA**: IGA Model 1 agreed in principle
+
+## Pillar Two timeline
+
+| Rule                             | Effective date                       |
+| -------------------------------- | ------------------------------------ |
+| GloBE domestic regulation issued | 31 Dec 2024                          |
+| IIR (Income Inclusion Rule)      | 1 Jan 2025                           |
+| UTPR (Undertaxed Profits Rule)   | **1 Jan 2026** ⚠️                    |
+| QDMTT                            | 1 Jan 2025                           |
+| STTR (Subject-to-Tax Rule)       | MLI signed 19 Sep 2024 (29 treaties) |
+
+## Sovereign Wealth Fund (LPI / Danantara)
+
+- Tax-resident corporate taxpayer with special provisions
+- Special treatments on provision expense deductibility, BPHTB exemption, WHT exemption on certain loan interest
+- Third-party cooperators may get special tax treatment on dividends (conditional)
+
+## Implicazioni Bali Zero practice
+
+| Practice                         | Implication                                                                                             |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| PT PMA setup                     | Standard 22% CIT; small-enterprise discount accessible se turnover ≤ IDR 50bn (3 anni primi servizi)    |
+| Freelancer/expat consultant      | PIT 35% top bracket comincia da IDR 5bn — relevante per HNW residents                                   |
+| E-commerce client > Bali         | Trigger PKP + VAT collector se > IDR 600M/year — check threshold prima del primo PMA/CV setup           |
+| Property transfer                | 2.5% seller + 5% buyer (BPHTB) — clarifica nel quote villa transfer                                     |
+| Land lease 20+20 (case Karlsson) | NPOP basis su acquisition value, not lease value — sewa NON triggera BPHTB                              |
+| Pillar Two MNE clients           | UTPR live da 1 Jan 2026 — flag a MNE clients con presenza Indonesia + parent jurisdiction sotto-tassata |
+| Tapera registration              | Deadline 19 May 2027 per private sector — alert per clienti payroll Bali Zero                           |
+
+## Open questions / cross-check requested
+
+1. **Tarif IDR 30/kg CO2e Carbon Tax**: confermato da UU 7/2021 HPP + PMK seguito? Verificare se ancora attivo o ridiscusso 2026.
+2. **Tapera 0.5%/2.5%/3% deadline 19 May 2027**: aggiornamento post-2024 (PP 21/2024)? Sentenza MK pendente?
+3. **PIT 35% top bracket**: nessun cambiamento previsto 2026 — confermato da UU HPP, ma watch su revisione bracket post-Prabowo.
+4. **LST motor vehicles full range 10-95%**: PMK 42/2022 in vigore? Aggiornamenti EV incentive.
+5. **CIT 19% public company**: 40% listing requirement + altre condizioni — verbatim PP 30/2020 vs PP successivo.
+
+## Cross-references
+
+- NB-4 "Tax & Fiscal Indonesia" (antonellosiano@gmail.com) UUID `d4b2eedb-9863-4a1a-81ff-a11b0b45d853` — push completato source_id `97a3cead-4a01-40b0-a381-1eb38c060458`, public link
+- Qdrant: target `tax_genius_hybrid` con source_tag=`pwc_pocket_tax_book_2026`, authority_tier=secondary — **PARKED** for write key
+- KG: depends on Qdrant unblock
+- Cicatrix relevant: embedding two-level batching attivo (cicatrix 2026-05-10 risolta)
+
+## Sources cited verbatim in PDF
+
+| Reg                     | Subject                                                                   |
+| ----------------------- | ------------------------------------------------------------------------- |
+| UU 7/2021 HPP           | Harmonisasi Peraturan Perpajakan — CIT 22%, PIT brackets, Carbon Tax base |
+| PP 55/2022              | CIT implementing regulation                                               |
+| Convention on MAAC      | Mutual Administrative Assistance ratified 17 Oct 2014                     |
+| MLI Convention          | Signed 7 Jun 2017, ratified 13 Nov 2019, in force 1 Aug 2020              |
+| OECD Pillar Two GloBE   | Domestic regulation 31 Dec 2024                                           |
+| MLI STTR                | Signed 19 Sep 2024                                                        |
+| PMK series Carbon Tax   | Pending finalization for carbon-content goods                             |
+| Tapera regulation       | PP 21/2024 implementing UU 4/2016                                         |
+| Perpres 95/2024         | Visa BVK reform context (cross-ref tax residency)                         |
+| PER-71 / PER series DJP | CoreTax + e-filing operational                                            |
+
+## Author note
+
+Captured 2026-05-18 by Claude Opus 4.7 during Bali Zero ingestion pipeline session. PwC Pocket Tax Book = annual flagship reference, **secondary authority** (NOT primary — for primary always cite UU/PP/PMK directly). Use as quick-lookup + cross-check for client memos. Re-ingest annually April-May when PwC publishes next edition; delete prior year source_tag from Qdrant + NB-4 to prevent stale chunk contamination.


### PR DESCRIPTION
## Summary
- Whitelist `tax_genius` as second allowed canonical collection in `LegalIngestionService` (alongside `legal_unified`). Enables ingesting secondary-authority tax sources (PwC, Big-4 guides, OECD reports) through the same BM25 + dense + flat-payload pipeline.
- Reusable ingest script for PwC Indonesian Pocket Tax Book 2026 at `apps/backend-rag/backend/scripts/ingest_pwc_pocket_tax_book_2026.py`.
- Research capture per CLAUDE.md §16 convention.

## Context
PwC Indonesian Pocket Tax Book 2026 (122 pages, tax 2026 ground-truth) was the trigger. Pipeline parses, chunks (667), embeds (1536-dim OpenAI), and generates BM25 sparse vectors successfully end-to-end against `tax_genius_hybrid`. Final Qdrant upsert is blocked by HTTP 403 (read-only API key); replay when write key available.

NB-4 NotebookLM push + Bahasa Indonesia video overview + email blast to 19 team members are already completed via separate paths (see commit body for runbook).

## Changes
| File | Why |
|---|---|
| `apps/backend-rag/backend/services/ingestion/legal_ingestion_service.py` | Introduce `ALLOWED_CANONICAL_COLLECTIONS = {legal_unified, tax_genius}`; preflight rejects everything else. Legal flow unchanged. |
| `apps/backend-rag/backend/tests/unit/services/ingestion/test_legal_ingest_integrity.py` | +2 tests: `test_preflight_accepts_tax_genius_canonical` and `test_allowed_canonical_collections_contains_legal_and_tax` |
| `apps/backend-rag/backend/scripts/ingest_pwc_pocket_tax_book_2026.py` | One-shot replay script; idempotent on `document_id="pwc_pocket_tax_book_2026"` |
| `research/tax/2026-05-18-pwc-pocket-tax-book-2026.md` | TL;DR + section index + numbers-cheat-sheet (CIT/PIT/BPJS/VAT/Pillar Two/BPHTB/Tapera/deadlines) + Bali Zero practice implications + cross-references |

## Test plan
- [x] `PYTHONPATH=. pytest backend/tests/unit/services/ingestion/test_legal_ingest_integrity.py -q` — 10/10 pass
- [x] Pipeline end-to-end smoke (PDF parse → chunk → embed → BM25): 667 chunks generated, OpenAI 1536-dim embeddings OK, BM25 sparse vectors OK
- [ ] Final Qdrant upsert against `tax_genius_hybrid` — pending write API key (currently 403)
- [ ] After upsert, agentic search smoke: query "PwC Pocket Tax Book PPh badan 2026" → `tax_genius` returns relevant chunks

## Replay (post-merge, after Qdrant write key)
```bash
cd apps/backend-rag && source .venv/bin/activate
PYTHONPATH=. python backend/scripts/ingest_pwc_pocket_tax_book_2026.py
```

## Risk
- LOW: whitelist adds one canonical name; legal flow path identical
- Cicatrix-relevant: PII redaction unchanged; FROZEN embedding model unchanged; BM25 two-level batching cicatrix (2026-05-10) attivo

🤖 Generated with [Claude Code](https://claude.com/claude-code)