### PR TITLE
feat(crm): add Workspace AI policy auto-approve

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ See [`INDEX.md`](INDEX.md) for the full atlas including packages, tessuti dati, 
 ### Tech Stack
 
 <!-- DOCSYNC:BACKEND_STATS_START -->
-- **Backend:** Python 3.11+, FastAPI, 269 routers, 564 services, 952 test files
+- **Backend:** Python 3.11+, FastAPI, 269 routers, 565 services, 953 test files
 <!-- DOCSYNC:BACKEND_STATS_END -->
 - **Frontend:** Next.js, TypeScript, Tailwind CSS
 - **Databases:** PostgreSQL (relational), Qdrant (vector), Redis (cache)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 269 routers · 564 services
+- Backend: FastAPI · 269 routers · 565 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 24 · Packages: 5

--- a/apps/backend-rag/backend/app/routers/crm_intelligence.py
+++ b/apps/backend-rag/backend/app/routers/crm_intelligence.py
@@ -4,19 +4,27 @@ from typing import Annotated, Literal
 
 import asyncpg
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
 
 from backend.app.dependencies import get_database_pool, require_team_member
 from backend.services.crm.evidence_dossier import build_evidence_dossiers
 from backend.services.crm.tax_company_pilot import TaxCompanyPilotMap
 from backend.services.crm.workspace_ai_snapshots import (
+    WorkspaceAiAutoApproveResult,
     WorkspaceAiSnapshotCreate,
     WorkspaceAiSnapshotResponse,
     approve_workspace_ai_snapshot,
+    auto_approve_workspace_ai_snapshots,
     create_workspace_ai_snapshot,
     fetch_workspace_ai_review_queue,
 )
 
 router = APIRouter(prefix="/api/crm/intelligence", tags=["crm-intelligence"])
+
+
+class WorkspaceAiAutoApproveRequest(BaseModel):
+    dry_run: bool = True
+    limit: int = Field(default=25, ge=1, le=100)
 
 
 @router.get("/evidence-dossiers", response_model=list[TaxCompanyPilotMap])
@@ -65,6 +73,23 @@ async def review_workspace_ai_snapshots(
         pool,
         status=status,
         limit=limit,
+    )
+
+
+@router.post(
+    "/workspace-ai-snapshots/auto-approve",
+    response_model=WorkspaceAiAutoApproveResult,
+)
+async def auto_approve_workspace_ai_snapshot_drafts(
+    payload: WorkspaceAiAutoApproveRequest,
+    pool: asyncpg.Pool = Depends(get_database_pool),
+    _current_user: dict = Depends(require_team_member),
+) -> WorkspaceAiAutoApproveResult:
+    """Dry-run or apply policy auto-approval for safe Workspace AI drafts."""
+    return await auto_approve_workspace_ai_snapshots(
+        pool,
+        limit=payload.limit,
+        dry_run=payload.dry_run,
     )
 
 

--- a/apps/backend-rag/backend/services/crm/workspace_ai_snapshots.py
+++ b/apps/backend-rag/backend/services/crm/workspace_ai_snapshots.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Any, Literal
 
 import asyncpg
@@ -19,6 +20,34 @@ from backend.services.crm.tax_company_pilot import (
 )
 
 logger = logging.getLogger(__name__)
+
+AUTO_APPROVE_POLICY_VERSION = "workspace-ai-v1-factual-structural"
+_AUTO_APPROVE_SYSTEM_ACTOR = f"system:auto-approve:{AUTO_APPROVE_POLICY_VERSION}"
+_AUTO_APPROVE_FACT_CATEGORIES = frozenset({"identity", "person", "gap"})
+_AUTO_APPROVE_BLOCKED_CATEGORIES = frozenset({"compliance", "next_action"})
+_RAW_DRIVE_REFERENCE_MARKERS = (
+    "drive.google.com",
+    "docs.google.com",
+    "/file/d/",
+    "/folders/",
+    "open?id=",
+)
+_DOCUMENT_GAP_PATTERN = re.compile(
+    r"\b(document|record|file|npwp|nib|akta|profile|folder)\b.*"
+    r"\b(missing|required|needed|absent|not found|not indexed|gap)\b|"
+    r"\b(missing|required|needed|absent|not found|not indexed|gap)\b.*"
+    r"\b(document|record|file|npwp|nib|akta|profile|folder)\b",
+    re.IGNORECASE,
+)
+_INTERPRETIVE_OR_SENSITIVE_PATTERN = re.compile(
+    r"\b("
+    r"advice|advise|recommend|recommendation|should|must|legal opinion|"
+    r"liable|liability|penalty|sanction|strategy|suspicion|suspected|fraud|"
+    r"tax return|tax payable|vat|pph|profit|revenue|income|price|pricing|"
+    r"fee|invoice|paid|unpaid|debt|balance"
+    r")\b",
+    re.IGNORECASE,
+)
 
 
 class WorkspaceAiSnapshotCreate(BaseModel):
@@ -39,6 +68,28 @@ class WorkspaceAiSnapshotResponse(WorkspaceAiSnapshotCreate):
     approved_by: str | None = None
     approved_at: str | None = None
     created_at: str
+
+
+class WorkspaceAiAutoApproveDecision(BaseModel):
+    snapshot_id: str
+    company_id: int | None = None
+    company_name: str
+    policy_version: str = AUTO_APPROVE_POLICY_VERSION
+    eligible: bool
+    approved: bool = False
+    reason: str
+    blocked_reasons: list[str] = Field(default_factory=list)
+    fact_count: int
+
+
+class WorkspaceAiAutoApproveResult(BaseModel):
+    policy_version: str = AUTO_APPROVE_POLICY_VERSION
+    dry_run: bool
+    evaluated: int
+    eligible_count: int
+    blocked_count: int
+    approved_count: int
+    decisions: list[WorkspaceAiAutoApproveDecision]
 
 
 async def fetch_latest_workspace_ai_snapshots(
@@ -122,6 +173,111 @@ async def approve_workspace_ai_snapshot(
     return _response_from_row(row)
 
 
+def evaluate_workspace_ai_auto_approve_snapshot(
+    snapshot: WorkspaceAiSnapshotResponse,
+) -> WorkspaceAiAutoApproveDecision:
+    """Decide whether a draft snapshot is safe for policy auto-approval.
+
+    The policy is intentionally type/evidence based. Model confidence is not a
+    gate because factual CRM inventory should pass even when the model labels it
+    low confidence, while recommendations must remain human-reviewed.
+    """
+    blocked_reasons: list[str] = []
+    if snapshot.status != "draft":
+        blocked_reasons.append(f"status_not_draft:{snapshot.status}")
+    if not snapshot.facts:
+        blocked_reasons.append("missing_facts")
+
+    for fact in snapshot.facts:
+        category = str(fact.category)
+        text = _normalise_fact_text(fact)
+        if category in _AUTO_APPROVE_BLOCKED_CATEGORIES:
+            blocked_reasons.append(f"blocked_category:{category}")
+        elif category not in _AUTO_APPROVE_FACT_CATEGORIES:
+            blocked_reasons.append(f"unknown_category:{category}")
+        elif category == "gap" and not _is_document_gap_fact(text):
+            blocked_reasons.append("gap_not_document_inventory")
+
+        if not (fact.source_file_ids or snapshot.source_file_ids):
+            blocked_reasons.append("missing_explicit_evidence")
+        if _contains_raw_drive_reference(text):
+            blocked_reasons.append("raw_drive_reference")
+        if _contains_interpretive_or_sensitive_claim(text):
+            blocked_reasons.append("interpretive_or_sensitive_claim")
+
+    unique_blocked_reasons = list(dict.fromkeys(blocked_reasons))
+    eligible = len(unique_blocked_reasons) == 0
+    return WorkspaceAiAutoApproveDecision(
+        snapshot_id=snapshot.id,
+        company_id=snapshot.company_id,
+        company_name=snapshot.company_name,
+        eligible=eligible,
+        reason="factual_structural_snapshot" if eligible else "policy_blocked",
+        blocked_reasons=unique_blocked_reasons,
+        fact_count=len(snapshot.facts),
+    )
+
+
+async def auto_approve_workspace_ai_snapshots(
+    pool: asyncpg.Pool,
+    *,
+    limit: int = 25,
+    dry_run: bool = True,
+    approved_by: str | None = None,
+) -> WorkspaceAiAutoApproveResult:
+    """Evaluate draft snapshots and optionally approve policy-safe rows."""
+    snapshots = await fetch_workspace_ai_review_queue(
+        pool,
+        status="draft",
+        limit=limit,
+    )
+    actor = approved_by or _AUTO_APPROVE_SYSTEM_ACTOR
+    decisions: list[WorkspaceAiAutoApproveDecision] = []
+    approved_count = 0
+
+    for snapshot in snapshots:
+        decision = evaluate_workspace_ai_auto_approve_snapshot(snapshot)
+        if decision.eligible and not dry_run:
+            try:
+                await approve_workspace_ai_snapshot(
+                    pool,
+                    snapshot_id=snapshot.id,
+                    approved_by=actor,
+                )
+            except LookupError:
+                logger.warning(
+                    "Workspace AI snapshot auto-approval skipped because row is no longer draft",
+                    extra={
+                        "snapshot_id": snapshot.id,
+                        "policy_version": AUTO_APPROVE_POLICY_VERSION,
+                    },
+                )
+                decision = decision.model_copy(
+                    update={
+                        "eligible": False,
+                        "reason": "approval_failed",
+                        "blocked_reasons": [
+                            *decision.blocked_reasons,
+                            "approval_failed:not_draft",
+                        ],
+                    }
+                )
+            else:
+                approved_count += 1
+                decision = decision.model_copy(update={"approved": True})
+        decisions.append(decision)
+
+    eligible_count = sum(1 for decision in decisions if decision.eligible)
+    return WorkspaceAiAutoApproveResult(
+        dry_run=dry_run,
+        evaluated=len(decisions),
+        eligible_count=eligible_count,
+        blocked_count=len(decisions) - eligible_count,
+        approved_count=approved_count,
+        decisions=decisions,
+    )
+
+
 def _response_from_row(row: Any) -> WorkspaceAiSnapshotResponse:
     approved_at = row["approved_at"]
     return WorkspaceAiSnapshotResponse(
@@ -163,6 +319,29 @@ def _facts_from_db_value(value: Any) -> list[TaxCompanyPilotWorkspaceAiFact]:
         return []
     parsed = json.loads(value) if isinstance(value, str) else value
     return [TaxCompanyPilotWorkspaceAiFact.model_validate(fact) for fact in parsed]
+
+
+def _normalise_fact_text(fact: TaxCompanyPilotWorkspaceAiFact) -> str:
+    return " ".join(
+        [
+            fact.category,
+            fact.label,
+            fact.detail,
+        ]
+    ).strip()
+
+
+def _is_document_gap_fact(text: str) -> bool:
+    return bool(_DOCUMENT_GAP_PATTERN.search(text))
+
+
+def _contains_raw_drive_reference(text: str) -> bool:
+    lower_text = text.lower()
+    return any(marker in lower_text for marker in _RAW_DRIVE_REFERENCE_MARKERS)
+
+
+def _contains_interpretive_or_sensitive_claim(text: str) -> bool:
+    return bool(_INTERPRETIVE_OR_SENSITIVE_PATTERN.search(text))
 
 
 _LATEST_BY_COMPANY_SQL = """

--- a/apps/backend-rag/backend/tests/services/crm/test_workspace_ai_snapshots.py
+++ b/apps/backend-rag/backend/tests/services/crm/test_workspace_ai_snapshots.py
@@ -10,9 +10,13 @@ import pytest
 
 from backend.services.crm.tax_company_pilot import TaxCompanyPilotWorkspaceAiFact
 from backend.services.crm.workspace_ai_snapshots import (
+    AUTO_APPROVE_POLICY_VERSION,
     WorkspaceAiSnapshotCreate,
+    WorkspaceAiSnapshotResponse,
     approve_workspace_ai_snapshot,
+    auto_approve_workspace_ai_snapshots,
     create_workspace_ai_snapshot,
+    evaluate_workspace_ai_auto_approve_snapshot,
     fetch_workspace_ai_review_queue,
 )
 
@@ -29,23 +33,26 @@ class _FakeAcquire:
 
 
 class _FakePool:
-    def __init__(self) -> None:
-        self.conn = _FakeConn()
+    def __init__(self, *, review_rows: list[dict[str, Any]] | None = None) -> None:
+        self.conn = _FakeConn(review_rows=review_rows)
 
     def acquire(self) -> _FakeAcquire:
         return _FakeAcquire(self.conn)
 
 
 class _FakeConn:
-    def __init__(self) -> None:
+    def __init__(self, *, review_rows: list[dict[str, Any]] | None = None) -> None:
         self.args: tuple[Any, ...] | None = None
         self.fetch_args: tuple[Any, ...] | None = None
         self.approve_args: tuple[Any, ...] | None = None
+        self.approved_ids: list[str] = []
+        self._review_rows = review_rows
 
     async def fetchrow(self, _query: str, *args: Any) -> dict[str, Any]:
         self.args = args
-        if args and str(args[0]) == "snapshot-approve":
+        if "UPDATE crm_workspace_ai_snapshots" in _query:
             self.approve_args = args
+            self.approved_ids.append(str(args[0]))
             return _snapshot_row(
                 snapshot_id=args[0],
                 status="approved",
@@ -74,6 +81,8 @@ class _FakeConn:
 
     async def fetch(self, _query: str, *args: Any) -> list[dict[str, Any]]:
         self.fetch_args = args
+        if self._review_rows is not None:
+            return self._review_rows
         return [_snapshot_row(snapshot_id="snapshot-draft", status=args[0])]
 
 
@@ -83,7 +92,10 @@ def _snapshot_row(
     status: str,
     approved_by: str | None = None,
     approved_at: datetime | None = None,
+    facts: list[dict[str, Any]] | None = None,
+    source_file_ids: list[str] | None = None,
 ) -> dict[str, Any]:
+    safe_source_file_ids = source_file_ids or ["drive-file-1"]
     return {
         "id": snapshot_id,
         "company_id": 7,
@@ -92,14 +104,15 @@ def _snapshot_row(
         "provider": "gemini",
         "notebook_id": None,
         "note_id": "crm-drive-autowatcher:v1:7:test",
-        "source_file_ids": ["drive-file-1"],
+        "source_file_ids": safe_source_file_ids,
         "facts": json.dumps(
-            [
+            facts
+            or [
                 {
                     "category": "identity",
                     "label": "Company evidence",
                     "detail": "Company source documents are indexed for review.",
-                    "source_file_ids": ["drive-file-1"],
+                    "source_file_ids": safe_source_file_ids,
                     "confidence": "medium",
                 }
             ]
@@ -175,3 +188,178 @@ async def test_approve_workspace_ai_snapshot_marks_draft_approved() -> None:
     assert result.approved_by == "team@balizero.com"
     assert result.approved_at == "2026-05-13T00:00:00+00:00"
     assert pool.conn.approve_args == ("snapshot-approve", "team@balizero.com")
+
+
+def _snapshot_response(
+    *,
+    facts: list[TaxCompanyPilotWorkspaceAiFact],
+    snapshot_id: str = "snapshot-policy",
+    source_file_ids: list[str] | None = None,
+) -> WorkspaceAiSnapshotResponse:
+    return WorkspaceAiSnapshotResponse(
+        id=snapshot_id,
+        company_id=7,
+        client_id=3,
+        company_name="OCEAN CLOTHES AND SHOES PT",
+        provider="gemini",
+        note_id="crm-drive-autowatcher:v1:7:test",
+        source_file_ids=["drive-file-1"] if source_file_ids is None else source_file_ids,
+        facts=facts,
+        status="draft",
+        created_by="crm-drive-autowatcher",
+        created_at="2026-05-12T00:00:00+00:00",
+    )
+
+
+def test_auto_approve_policy_allows_factual_structural_snapshot() -> None:
+    snapshot = _snapshot_response(
+        facts=[
+            TaxCompanyPilotWorkspaceAiFact(
+                category="identity",
+                label="Company document inventory",
+                detail="NPWP company document is present in indexed source evidence.",
+                source_file_ids=["drive-file-1"],
+                confidence="low",
+            )
+        ]
+    )
+
+    decision = evaluate_workspace_ai_auto_approve_snapshot(snapshot)
+
+    assert decision.eligible is True
+    assert decision.policy_version == AUTO_APPROVE_POLICY_VERSION
+    assert decision.reason == "factual_structural_snapshot"
+    assert decision.blocked_reasons == []
+
+
+@pytest.mark.parametrize(
+    ("fact", "expected_reason"),
+    [
+        (
+            TaxCompanyPilotWorkspaceAiFact(
+                category="compliance",
+                label="Tax recommendation",
+                detail="Client should file an amended tax return next month.",
+                source_file_ids=["drive-file-1"],
+                confidence="confirmed",
+            ),
+            "blocked_category:compliance",
+        ),
+        (
+            TaxCompanyPilotWorkspaceAiFact(
+                category="identity",
+                label="Raw Drive source",
+                detail="Evidence is visible at https://drive.google.com/file/d/raw-id/view.",
+                source_file_ids=["drive-file-1"],
+                confidence="confirmed",
+            ),
+            "raw_drive_reference",
+        ),
+        (
+            TaxCompanyPilotWorkspaceAiFact(
+                category="identity",
+                label="Company profile",
+                detail="Profile document is indexed.",
+                source_file_ids=[],
+                confidence="confirmed",
+            ),
+            "missing_explicit_evidence",
+        ),
+    ],
+)
+def test_auto_approve_policy_blocks_risky_or_weak_snapshots(
+    fact: TaxCompanyPilotWorkspaceAiFact,
+    expected_reason: str,
+) -> None:
+    snapshot = _snapshot_response(
+        facts=[fact],
+        source_file_ids=[] if expected_reason == "missing_explicit_evidence" else None,
+    )
+
+    decision = evaluate_workspace_ai_auto_approve_snapshot(snapshot)
+
+    assert decision.eligible is False
+    assert expected_reason in decision.blocked_reasons
+
+
+@pytest.mark.asyncio
+async def test_auto_approve_workspace_ai_snapshots_dry_run_does_not_update() -> None:
+    pool = _FakePool(
+        review_rows=[
+            _snapshot_row(
+                snapshot_id="safe-snapshot",
+                status="draft",
+                facts=[
+                    {
+                        "category": "identity",
+                        "label": "Company document inventory",
+                        "detail": "NPWP company document is present in indexed source evidence.",
+                        "source_file_ids": ["drive-file-1"],
+                        "confidence": "low",
+                    }
+                ],
+            ),
+            _snapshot_row(
+                snapshot_id="blocked-snapshot",
+                status="draft",
+                facts=[
+                    {
+                        "category": "next_action",
+                        "label": "Tax next action",
+                        "detail": "Client should submit a tax correction.",
+                        "source_file_ids": ["drive-file-2"],
+                        "confidence": "confirmed",
+                    }
+                ],
+                source_file_ids=["drive-file-2"],
+            ),
+        ]
+    )
+
+    result = await auto_approve_workspace_ai_snapshots(
+        pool,  # type: ignore[arg-type]
+        limit=10,
+        dry_run=True,
+    )
+
+    assert result.dry_run is True
+    assert result.evaluated == 2
+    assert result.eligible_count == 1
+    assert result.blocked_count == 1
+    assert result.approved_count == 0
+    assert pool.conn.approved_ids == []
+
+
+@pytest.mark.asyncio
+async def test_auto_approve_workspace_ai_snapshots_apply_reuses_approve_path() -> None:
+    pool = _FakePool(
+        review_rows=[
+            _snapshot_row(
+                snapshot_id="safe-snapshot",
+                status="draft",
+                facts=[
+                    {
+                        "category": "identity",
+                        "label": "Company document inventory",
+                        "detail": "NPWP company document is present in indexed source evidence.",
+                        "source_file_ids": ["drive-file-1"],
+                        "confidence": "low",
+                    }
+                ],
+            )
+        ]
+    )
+
+    result = await auto_approve_workspace_ai_snapshots(
+        pool,  # type: ignore[arg-type]
+        limit=10,
+        dry_run=False,
+    )
+
+    expected_actor = f"system:auto-approve:{AUTO_APPROVE_POLICY_VERSION}"
+    assert result.dry_run is False
+    assert result.evaluated == 1
+    assert result.approved_count == 1
+    assert result.decisions[0].approved is True
+    assert pool.conn.approved_ids == ["safe-snapshot"]
+    assert pool.conn.approve_args == ("safe-snapshot", expected_actor)

--- a/apps/backend-rag/backend/tests/unit/routers/test_crm_intelligence.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_crm_intelligence.py
@@ -155,3 +155,40 @@ async def test_approve_workspace_ai_snapshot_uses_team_actor() -> None:
     approve_snapshot.assert_awaited_once()
     assert approve_snapshot.await_args.kwargs["snapshot_id"] == "snapshot-1"
     assert approve_snapshot.await_args.kwargs["approved_by"] == "team@balizero.com"
+
+
+@pytest.mark.asyncio
+async def test_auto_approve_workspace_ai_snapshots_uses_policy_service() -> None:
+    from backend.app.routers.crm_intelligence import (
+        WorkspaceAiAutoApproveRequest,
+        auto_approve_workspace_ai_snapshot_drafts,
+    )
+    from backend.services.crm.workspace_ai_snapshots import (
+        AUTO_APPROVE_POLICY_VERSION,
+        WorkspaceAiAutoApproveResult,
+    )
+
+    response = WorkspaceAiAutoApproveResult(
+        dry_run=False,
+        evaluated=2,
+        eligible_count=1,
+        blocked_count=1,
+        approved_count=1,
+        decisions=[],
+    )
+
+    with patch(
+        "backend.app.routers.crm_intelligence.auto_approve_workspace_ai_snapshots",
+        new=AsyncMock(return_value=response),
+    ) as auto_approve:
+        result = await auto_approve_workspace_ai_snapshot_drafts(
+            WorkspaceAiAutoApproveRequest(dry_run=False, limit=10),
+            pool=MagicMock(),
+            _current_user={"email": "team@balizero.com", "role": "team"},
+        )
+
+    assert result == response
+    assert result.policy_version == AUTO_APPROVE_POLICY_VERSION
+    auto_approve.assert_awaited_once()
+    assert auto_approve.await_args.kwargs["dry_run"] is False
+    assert auto_approve.await_args.kwargs["limit"] == 10

--- a/apps/mouth/src/app/(workspace)/clients/tax-pilot/page.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/tax-pilot/page.tsx
@@ -2,22 +2,26 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
+import { useState } from "react";
 import { TaxCompanyPilotWorkspace } from "@/components/crm/TaxCompanyPilotWorkspace";
 import { api } from "@/lib/api";
 import type {
   TaxCompanyPilotMap,
+  WorkspaceAiAutoApproveResult,
   WorkspaceAiSnapshotReviewItem,
 } from "@/lib/api/crm/crm.types";
 
 export default function TaxCompanyPilotPage() {
   const queryClient = useQueryClient();
+  const [autoApproveResult, setAutoApproveResult] =
+    useState<WorkspaceAiAutoApproveResult | null>(null);
   const { data, isLoading, error } = useQuery<TaxCompanyPilotMap[]>({
     queryKey: ["crm-evidence-dossiers", "ocean", "bimala"],
     queryFn: async () =>
       api.crm.getEvidenceDossiers({
         companies: ["ocean", "bimala"],
         limit: 2,
-    }),
+      }),
     staleTime: 5 * 60_000,
   });
   const reviewQueue = useQuery<WorkspaceAiSnapshotReviewItem[]>({
@@ -38,6 +42,23 @@ export default function TaxCompanyPilotPage() {
           queryKey: ["crm-evidence-dossiers"],
         }),
       ]);
+    },
+  });
+  const autoApproveSnapshots = useMutation({
+    mutationFn: ({ dryRun }: { dryRun: boolean }) =>
+      api.crm.autoApproveWorkspaceAiSnapshots({ dryRun, limit: 25 }),
+    onSuccess: async (result, variables) => {
+      setAutoApproveResult(result);
+      if (!variables.dryRun) {
+        await Promise.all([
+          queryClient.invalidateQueries({
+            queryKey: ["crm-workspace-ai-review"],
+          }),
+          queryClient.invalidateQueries({
+            queryKey: ["crm-evidence-dossiers"],
+          }),
+        ]);
+      }
     },
   });
 
@@ -66,7 +87,11 @@ export default function TaxCompanyPilotPage() {
       reviewSnapshots={reviewQueue.data ?? []}
       reviewLoading={reviewQueue.isLoading}
       approvingSnapshotId={approveSnapshot.variables ?? null}
+      autoApproveResult={autoApproveResult}
+      autoApproving={autoApproveSnapshots.isPending}
       onApproveSnapshot={(snapshotId) => approveSnapshot.mutate(snapshotId)}
+      onAutoApproveDryRun={() => autoApproveSnapshots.mutate({ dryRun: true })}
+      onAutoApproveApply={() => autoApproveSnapshots.mutate({ dryRun: false })}
     />
   );
 }

--- a/apps/mouth/src/app/(workspace)/layout.tsx
+++ b/apps/mouth/src/app/(workspace)/layout.tsx
@@ -10,7 +10,6 @@ import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
 import { ErrorBoundary } from "@/components/optimization";
 import { CellWidget } from "@/components/cell/CellWidget";
-import { ZantaraWidget } from "@/components/workspace/ZantaraWidget";
 import { WorkspaceAssistant } from "@/components/workspace/WorkspaceAssistant";
 import { KitaCommandPalette } from "@/components/workspace/KitaCommandPalette";
 import { I18nProvider } from "@/i18n";
@@ -37,7 +36,6 @@ export default function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
   const mobileSidebarRef = useRef<HTMLDivElement | null>(null);
   const mobileMenuToggleRef = useRef<HTMLButtonElement | null>(null);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-  const [isZantaraOpen, setIsZantaraOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [user, setUser] = useState({
     name: "",
@@ -165,18 +163,6 @@ export default function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
 
   // isOnline status is now managed server-side (PANOPTICON)
 
-  // Cmd+J shortcut — toggle Zantara widget
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === "j") {
-        e.preventDefault();
-        setIsZantaraOpen((p) => !p);
-      }
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, []);
-
   // Handle logout
   const handleLogout = async () => {
     try {
@@ -277,8 +263,6 @@ export default function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
               unreadWhatsApp={0}
               onLogout={handleLogout}
               ariaLabel="Primary"
-              onZantaraToggle={() => setIsZantaraOpen((p) => !p)}
-              isZantaraOpen={isZantaraOpen}
             />
           </div>
 
@@ -302,8 +286,6 @@ export default function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
                   unreadWhatsApp={0}
                   onLogout={handleLogout}
                   ariaLabel="Primary (mobile)"
-                  onZantaraToggle={() => setIsZantaraOpen((p) => !p)}
-                  isZantaraOpen={isZantaraOpen}
                 />
               </div>
             </>
@@ -346,10 +328,7 @@ export default function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
           </div>
         </div>
         {!isTerminalPage && <CellWidget />}
-        <ZantaraWidget
-          open={isZantaraOpen}
-          onClose={() => setIsZantaraOpen(false)}
-        />
+        {!isTerminalPage && <WorkspaceAssistant />}
         <KitaCommandPalette />
       </ToastProvider>
     </I18nProvider>

--- a/apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.test.tsx
+++ b/apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.test.tsx
@@ -228,9 +228,7 @@ describe("TaxCompanyPilotWorkspace", () => {
     expect(screen.getByText("DEA")).toBeInTheDocument();
     expect(screen.getByText("Dewa Ayu")).toBeInTheDocument();
     expect(screen.getAllByText("Natan Kleimonov").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Giulia Del Giudice").length).toBeGreaterThan(
-      0,
-    );
+    expect(screen.getAllByText("Giulia Del Giudice").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Giorgia Emidio").length).toBeGreaterThan(0);
     expect(
       screen.getAllByText("Confirm the company role from registry documents."),
@@ -285,6 +283,8 @@ describe("TaxCompanyPilotWorkspace", () => {
 
   it("renders Workspace AI draft review queue with approve action", () => {
     const onApproveSnapshot = vi.fn();
+    const onAutoApproveDryRun = vi.fn();
+    const onAutoApproveApply = vi.fn();
 
     render(
       <TaxCompanyPilotWorkspace
@@ -313,12 +313,24 @@ describe("TaxCompanyPilotWorkspace", () => {
             created_at: "2026-05-12T15:45:00+00:00",
           },
         ]}
+        autoApproveResult={{
+          policy_version: "workspace-ai-v1-factual-structural",
+          dry_run: true,
+          evaluated: 1,
+          eligible_count: 1,
+          blocked_count: 0,
+          approved_count: 0,
+          decisions: [],
+        }}
         onApproveSnapshot={onApproveSnapshot}
+        onAutoApproveDryRun={onAutoApproveDryRun}
+        onAutoApproveApply={onAutoApproveApply}
       />,
     );
 
     expect(screen.getByText("Workspace AI review")).toBeInTheDocument();
     expect(screen.getByText("1 draft")).toBeInTheDocument();
+    expect(screen.getByText("1 safe · 0 held")).toBeInTheDocument();
     expect(
       screen.getByText("Company source documents are indexed for review."),
     ).toBeInTheDocument();
@@ -330,5 +342,11 @@ describe("TaxCompanyPilotWorkspace", () => {
     );
 
     expect(onApproveSnapshot).toHaveBeenCalledWith("snapshot-draft");
+
+    fireEvent.click(screen.getByRole("button", { name: "Check safe" }));
+    fireEvent.click(screen.getByRole("button", { name: "Approve safe" }));
+
+    expect(onAutoApproveDryRun).toHaveBeenCalledOnce();
+    expect(onAutoApproveApply).toHaveBeenCalledOnce();
   });
 });

--- a/apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.tsx
+++ b/apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.tsx
@@ -19,6 +19,7 @@ import type {
   TaxCompanyPilotMap,
   TaxCompanyPilotNextAction,
   TaxCompanyPilotPersonDossier,
+  WorkspaceAiAutoApproveResult,
   WorkspaceAiSnapshotReviewItem,
 } from "@/lib/api/crm/crm.types";
 
@@ -460,12 +461,20 @@ function WorkspaceAiReviewPanel({
   snapshots,
   loading = false,
   approvingSnapshotId = null,
+  autoApproveResult = null,
+  autoApproving = false,
   onApproveSnapshot,
+  onAutoApproveDryRun,
+  onAutoApproveApply,
 }: {
   snapshots: WorkspaceAiSnapshotReviewItem[];
   loading?: boolean;
   approvingSnapshotId?: string | null;
+  autoApproveResult?: WorkspaceAiAutoApproveResult | null;
+  autoApproving?: boolean;
   onApproveSnapshot?: (snapshotId: string) => void;
+  onAutoApproveDryRun?: () => void;
+  onAutoApproveApply?: () => void;
 }) {
   if (!loading && snapshots.length === 0) return null;
 
@@ -480,11 +489,38 @@ function WorkspaceAiReviewPanel({
           <Sparkles size={16} />
           Workspace AI review
         </div>
-        <span className="rounded bg-white px-2.5 py-1 text-xs font-medium text-slate-600 ring-1 ring-slate-200">
-          {loading
-            ? "Checking drafts"
-            : `${draftCount} draft${draftCount === 1 ? "" : "s"}`}
-        </span>
+        <div className="flex flex-wrap items-center gap-2">
+          {autoApproveResult && (
+            <span className="rounded bg-emerald-50 px-2.5 py-1 text-xs font-medium text-emerald-800 ring-1 ring-emerald-200">
+              {autoApproveResult.dry_run
+                ? `${autoApproveResult.eligible_count} safe · ${autoApproveResult.blocked_count} held`
+                : `${autoApproveResult.approved_count} approved · ${autoApproveResult.blocked_count} held`}
+            </span>
+          )}
+          <button
+            type="button"
+            disabled={!onAutoApproveDryRun || autoApproving}
+            onClick={() => onAutoApproveDryRun?.()}
+            className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-300"
+          >
+            <Sparkles size={13} />
+            Check safe
+          </button>
+          <button
+            type="button"
+            disabled={!onAutoApproveApply || autoApproving}
+            onClick={() => onAutoApproveApply?.()}
+            className="inline-flex items-center gap-1.5 rounded-md bg-emerald-700 px-2.5 py-1.5 text-xs font-semibold text-white hover:bg-emerald-800 disabled:cursor-not-allowed disabled:bg-slate-300"
+          >
+            <ShieldCheck size={13} />
+            Approve safe
+          </button>
+          <span className="rounded bg-white px-2.5 py-1 text-xs font-medium text-slate-600 ring-1 ring-slate-200">
+            {loading
+              ? "Checking drafts"
+              : `${draftCount} draft${draftCount === 1 ? "" : "s"}`}
+          </span>
+        </div>
       </div>
       {snapshots.length > 0 && (
         <div className="grid gap-3 lg:grid-cols-2">
@@ -538,13 +574,21 @@ export function TaxCompanyPilotWorkspace({
   reviewSnapshots = [],
   reviewLoading = false,
   approvingSnapshotId = null,
+  autoApproveResult = null,
+  autoApproving = false,
   onApproveSnapshot,
+  onAutoApproveDryRun,
+  onAutoApproveApply,
 }: {
   maps: TaxCompanyPilotMap[];
   reviewSnapshots?: WorkspaceAiSnapshotReviewItem[];
   reviewLoading?: boolean;
   approvingSnapshotId?: string | null;
+  autoApproveResult?: WorkspaceAiAutoApproveResult | null;
+  autoApproving?: boolean;
   onApproveSnapshot?: (snapshotId: string) => void;
+  onAutoApproveDryRun?: () => void;
+  onAutoApproveApply?: () => void;
 }) {
   const totalPeople = maps.reduce((sum, map) => sum + map.persons.length, 0);
   const totalDocuments = maps.reduce(
@@ -607,7 +651,11 @@ export function TaxCompanyPilotWorkspace({
         snapshots={reviewSnapshots}
         loading={reviewLoading}
         approvingSnapshotId={approvingSnapshotId}
+        autoApproveResult={autoApproveResult}
+        autoApproving={autoApproving}
         onApproveSnapshot={onApproveSnapshot}
+        onAutoApproveDryRun={onAutoApproveDryRun}
+        onAutoApproveApply={onAutoApproveApply}
       />
       <div className="grid gap-4 xl:grid-cols-2">
         {maps.map((map, index) => (

--- a/apps/mouth/src/lib/api/crm/crm.api.test.ts
+++ b/apps/mouth/src/lib/api/crm/crm.api.test.ts
@@ -207,6 +207,45 @@ describe("CrmApi", () => {
       );
       expect(result).toEqual(mockApproved);
     });
+
+    it("should run workspace AI auto-approve policy", async () => {
+      const mockResult = {
+        policy_version: "workspace-ai-v1-factual-structural",
+        dry_run: true,
+        evaluated: 2,
+        eligible_count: 1,
+        blocked_count: 1,
+        approved_count: 0,
+        decisions: [
+          {
+            snapshot_id: "snapshot-safe",
+            company_id: 7,
+            company_name: "OCEAN CLOTHES AND SHOES PT",
+            policy_version: "workspace-ai-v1-factual-structural",
+            eligible: true,
+            approved: false,
+            reason: "factual_structural_snapshot",
+            blocked_reasons: [],
+            fact_count: 1,
+          },
+        ],
+      };
+      mockClient.request.mockResolvedValue(mockResult);
+
+      const result = await crmApi.autoApproveWorkspaceAiSnapshots({
+        dryRun: true,
+        limit: 25,
+      });
+
+      expect(mockClient.request).toHaveBeenCalledWith(
+        "/api/crm/intelligence/workspace-ai-snapshots/auto-approve",
+        {
+          method: "POST",
+          body: JSON.stringify({ dry_run: true, limit: 25 }),
+        },
+      );
+      expect(result).toEqual(mockResult);
+    });
   });
 
   describe("markInteractionRead", () => {

--- a/apps/mouth/src/lib/api/crm/crm.api.ts
+++ b/apps/mouth/src/lib/api/crm/crm.api.ts
@@ -26,6 +26,7 @@ import type {
   TaxCompanyPilotKey,
   TaxCompanyPilotMap,
   AiSummaryResponse,
+  WorkspaceAiAutoApproveResult,
   WorkspaceAiSnapshotReviewItem,
   WorkspaceAiSnapshotReviewStatus,
 } from "./crm.types";
@@ -250,6 +251,22 @@ export class CrmApi {
     return this.client.request<WorkspaceAiSnapshotReviewItem>(
       `/api/crm/intelligence/workspace-ai-snapshots/${encodeURIComponent(snapshotId)}/approve`,
       { method: "POST" },
+    );
+  }
+
+  async autoApproveWorkspaceAiSnapshots({
+    dryRun = true,
+    limit = 25,
+  }: {
+    dryRun?: boolean;
+    limit?: number;
+  } = {}): Promise<WorkspaceAiAutoApproveResult> {
+    return this.client.request<WorkspaceAiAutoApproveResult>(
+      "/api/crm/intelligence/workspace-ai-snapshots/auto-approve",
+      {
+        method: "POST",
+        body: JSON.stringify({ dry_run: dryRun, limit }),
+      },
     );
   }
 

--- a/apps/mouth/src/lib/api/crm/crm.types.ts
+++ b/apps/mouth/src/lib/api/crm/crm.types.ts
@@ -161,6 +161,28 @@ export interface WorkspaceAiSnapshotReviewItem {
   created_at: string;
 }
 
+export interface WorkspaceAiAutoApproveDecision {
+  snapshot_id: string;
+  company_id?: number | null;
+  company_name: string;
+  policy_version: string;
+  eligible: boolean;
+  approved: boolean;
+  reason: string;
+  blocked_reasons: string[];
+  fact_count: number;
+}
+
+export interface WorkspaceAiAutoApproveResult {
+  policy_version: string;
+  dry_run: boolean;
+  evaluated: number;
+  eligible_count: number;
+  blocked_count: number;
+  approved_count: number;
+  decisions: WorkspaceAiAutoApproveDecision[];
+}
+
 export interface TaxCompanyPilotEvidenceStory {
   person_name: string;
   company_name: string;

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`269 routers · 564 services · 952 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`269 routers · 565 services · 953 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary
- add a Workspace AI auto-approve policy for factual structural snapshots only
- expose a team-only dry-run/apply endpoint and wire it into the tax pilot review panel
- keep legal/tax/visa recommendations, raw Drive links, weak evidence, and next actions in manual review
- fix stale workspace assistant wiring so frontend typecheck/build pass

## Test plan
- cd apps/backend-rag && source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && PYTHONPATH=. python -m pytest backend/tests/services/crm/test_workspace_ai_snapshots.py backend/tests/unit/routers/test_crm_intelligence.py -q
- cd apps/backend-rag && source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && ruff check backend/services/crm/workspace_ai_snapshots.py backend/app/routers/crm_intelligence.py backend/tests/services/crm/test_workspace_ai_snapshots.py backend/tests/unit/routers/test_crm_intelligence.py
- cd apps/backend-rag && source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && PYTHONPATH=. python -m pytest backend/tests/services/rag/test_kg_langgraph.py backend/tests/services/rag/test_kg_subgraphs.py backend/tests/services/rag/test_confidence.py -q
- cd apps/mouth && npm test -- --run src/lib/api/crm/crm.api.test.ts src/components/crm/TaxCompanyPilotWorkspace.test.tsx
- cd apps/mouth && npm run typecheck -- --pretty false
- cd apps/mouth && npm run build