### PR TITLE
fix(test): import TYPE_CHECKING in legal ingestion test

### DIFF
--- a/apps/backend-rag/backend/tests/unit/services/ingestion/test_legal_ingestion_service.py
+++ b/apps/backend-rag/backend/tests/unit/services/ingestion/test_legal_ingestion_service.py
@@ -7,6 +7,7 @@ _ensure_drive_folder_exists, _get_kg_extractor, detect_legal_document.
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -20,7 +21,7 @@ os.environ.setdefault("OPENAI_API_KEY", "test_key")
 os.environ.setdefault("GOOGLE_API_KEY", "test_key")
 
 
-def _build_service():
+def _build_service() -> LegalIngestionService:
     """Build LegalIngestionService with all heavy dependencies mocked."""
     with patch("backend.services.ingestion.legal_ingestion_service.LegalCleaner") as mc, \
          patch("backend.services.ingestion.legal_ingestion_service.LegalMetadataExtractor") as mme, \


### PR DESCRIPTION
## Summary
- fix backend CI collection by importing TYPE_CHECKING in legal ingestion service tests
- annotate _build_service so the type-only import is used and ruff remains green

## Test plan
- cd apps/backend-rag && source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && ruff check backend/tests/unit/services/ingestion/test_legal_ingestion_service.py
- cd apps/backend-rag && source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && PYTHONPATH=. python -m pytest backend/tests/unit/services/ingestion/test_legal_ingestion_service.py -q