### PR TITLE
fix(kbli): correct 56301 PMA status

### DIFF
--- a/apps/backend-rag/backend/app/routers/kbli_notebook_chat.py
+++ b/apps/backend-rag/backend/app/routers/kbli_notebook_chat.py
@@ -101,7 +101,7 @@ KBLI_MASTER_PROMPT = (
     "'graphic design/desain grafis/logo design/branding' = aktivitas desain grafis/komunikasi visual (KBLI 74192), "
     "'interior design/desain interior' = aktivitas desain interior (KBLI 74191), "
     "'fashion design/desain mode/desain tekstil' = aktivitas desain tekstil mode dan garmen (KBLI 74113), "
-    "'bar/wine bar/cocktail bar/beach club' = aktivitas bar (KBLI 56301, PMA TERTUTUP — foreigners CANNOT own a bar), "
+    "'bar/wine bar/cocktail bar/beach club' = aktivitas bar (KBLI 56301, PMA TERBUKA — alcohol service still requires SKPL/PB-UMKU and local licensing), "
     "'salon/hair salon/barbershop/pangkas rambut/hair studio' = aktivitas penataan dan pangkas rambut (KBLI 96210), "
     "'beauty salon/nail studio/nail art/eyelash extension/brow studio/wax studio/make-up artist/MUA/perawatan kecantikan' = aktivitas perawatan kecantikan (KBLI 96220), "
     "'spa/day spa/wellness/spa harian/sauna/steam bath/pemandian uap/solarium' = aktivitas SPA harian sauna dan pemandian uap (KBLI 96230), "
@@ -423,8 +423,8 @@ KNOWN_KBLI_CODES: dict[str, dict] = {
     "56301": {
         "title": "AKTIVITAS BAR",
         "description": "Bar activities serving alcoholic and non-alcoholic beverages for on-premises consumption. Includes cocktail bars, wine bars, and other licensed drinking establishments.",
-        "pma_status": "TERTUTUP",
-        "risk_category": "Verify at OSS",
+        "pma_status": "TERBUKA",
+        "risk_category": "Menengah Tinggi",
     },
     "47690": {
         "title": "PERDAGANGAN ECERAN KHUSUS BARANG KESENIAN DAN REKREASI YTDL",

--- a/apps/backend-rag/backend/tests/unit/routers/test_kbli_notebook_chat.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_kbli_notebook_chat.py
@@ -446,6 +446,21 @@ def test_known_kbli_codes_structure():
         assert "risk_category" in data
 
 
+def test_known_kbli_56301_uses_canonical_pma_status():
+    from backend.app.routers.kbli_notebook_chat import KNOWN_KBLI_CODES
+
+    assert KNOWN_KBLI_CODES["56301"]["title"] == "AKTIVITAS BAR"
+    assert KNOWN_KBLI_CODES["56301"]["pma_status"] == "TERBUKA"
+
+
+def test_master_prompt_does_not_override_56301_as_closed_to_pma():
+    from backend.app.routers.kbli_notebook_chat import KBLI_MASTER_PROMPT
+
+    prompt = KBLI_MASTER_PROMPT.format(lang="English")
+    assert "KBLI 56301, PMA TERTUTUP" not in prompt
+    assert "foreigners CANNOT own a bar" not in prompt
+
+
 def test_non_business_keywords_list():
     from backend.app.routers.kbli_notebook_chat import NON_BUSINESS_KEYWORDS
 


### PR DESCRIPTION
## Summary\n- correct the KBLI notebook router override for 56301 from PMA TERTUTUP to TERBUKA\n- align risk category with canonical KBLI data: Menengah Tinggi\n- add regression tests so the prompt/manual code table cannot re-close 56301 silently\n\n## Test plan\n- cd apps/backend-rag && source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && PYTHONPATH=. pytest backend/tests/unit/routers/test_kbli_notebook_chat.py::test_known_kbli_56301_uses_canonical_pma_status backend/tests/unit/routers/test_kbli_notebook_chat.py::test_master_prompt_does_not_override_56301_as_closed_to_pma -q\n- cd apps/backend-rag && source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && PYTHONPATH=. pytest backend/tests/unit/routers/test_kbli_notebook_chat.py backend/tests/unit/routers/test_kbli_notebook_chat_coverage.py -q\n- cd apps/backend-rag && source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && PYTHONPATH=. python -c "from backend.app.dependencies import get_current_user; print('OK')"\n\n## Live browser QA\n- production currently still fails the 56301 checks until this PR is deployed; live loop log: /tmp/zantara-live-loop-2026-05-18.jsonl