### PR TITLE
fix(kbli): bust stale 56301 explanation cache

### DIFF
--- a/apps/backend-rag/backend/app/routers/kbli_notebook_chat.py
+++ b/apps/backend-rag/backend/app/routers/kbli_notebook_chat.py
@@ -291,8 +291,8 @@ async def _generate_kbli_explanation_gemini(
 
 
 @cached(
-    ttl=43200, prefix="kbli_explain_v25",
-)  # Cache explanations for 12 hours (v25: 96100 risk scale-dependent: Rendah Mikro-Menengah / Tinggi Besar; all sector 96 PMA=TERBUKA)
+    ttl=43200, prefix="kbli_explain_v26",
+)  # Cache explanations for 12 hours (v26: 56301 PMA status corrected to TERBUKA)
 async def _generate_kbli_explanation(
     query: str, results: list[KBLISearchResult], parent_docs: dict[str, str] = None,
 ) -> str:

--- a/apps/backend-rag/backend/prompts/zantara_core_v2.py
+++ b/apps/backend-rag/backend/prompts/zantara_core_v2.py
@@ -23,9 +23,11 @@ from backend.prompts.business_rules_i18n import all_languages_for
 from backend.prompts.zantara_core import (
     CITATION_RULES,  # already multilingual at the source level
     CLOSING_PHRASES,  # already lang-aware (delegates to model)
+    CREATOR_PERSONA,  # backward-compatible re-export for v3/import consumers
     KNOWLEDGE_GOVERNANCE,  # XML structural, no IT-only phrases
     LANGUAGE_PROTOCOL,  # the protocol itself; reused verbatim
     SYSTEM_INSTRUCTIONS,  # XML structural, no IT-only phrases
+    TEAM_PERSONA,  # backward-compatible re-export for v3/import consumers
     )
 
 


### PR DESCRIPTION
## Summary\n- bump the KBLI explanation cache prefix from v25 to v26 so production stops serving stale pre-fix 56301 answers\n- restore v2 prompt compatibility exports required by zantara_core_v3 import tests\n\n## Why\nPR #725 corrected the source for KBLI 56301, but live browser QA still received cached answers saying PMA TERTUTUP. This PR invalidates that explanation cache namespace.\n\n## Test plan\n- cd apps/backend-rag && source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && PYTHONPATH=. pytest backend/tests/unit/test_zantara_core_v3.py backend/tests/unit/routers/test_kbli_notebook_chat.py backend/tests/unit/routers/test_kbli_notebook_chat_coverage.py -q\n\n## Live browser QA\n- continuous log: /tmp/zantara-live-loop-2026-05-18.jsonl\n- expected current prod before this deploy: 56301 fails with cached TERTUTUP answer\n- expected after deploy: 56301 answers should stop containing TERTUTUP/PMA cannot hold