### PR TITLE
ci(contract): schemathesis on /openapi.json (non-blocking)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -1,0 +1,169 @@
+name: Contract Tests (Schemathesis)
+
+# Property-based contract testing of the FastAPI /openapi.json spec.
+# Catches the bug class from PR #422 → #423 → #424 (3 hotfix chain 2026-05-02):
+# unit tests green, production 404 because router not included or middleware
+# blocks. Schemathesis fuzzes every endpoint defined in /openapi.json with
+# Hypothesis-generated payloads and reports schema/contract violations.
+#
+# Mode: ASGI-direct (--app=backend.app.main:app). No HTTP server, no
+# external services. The app boots in degraded mode (PG/Redis/Qdrant
+# unreachable → app.state.startup_failed=True per P0-1), but the
+# /openapi.json schema is fully populated at import time, which is what
+# Schemathesis needs.
+#
+# Status: NON-BLOCKING (continue-on-error: true). Promotion criteria to
+# required check is documented in apps/backend-rag/docs/contract-testing.md.
+# See finding #3 of the audit modernization 2026-05-18.
+
+on:
+  pull_request:
+    paths:
+      - "apps/backend-rag/**"
+      - ".github/workflows/contract-tests.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: contract-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract-tests:
+    name: Schemathesis on /openapi.json
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 20
+
+    env:
+      # ----- Minimal env to allow the FastAPI app to import in degraded mode -----
+      # All external services point at unreachable/sqlite stubs. The startup
+      # path is designed to degrade (P0-1, no RuntimeError raise) so the app
+      # mounts routers and exposes /openapi.json even when nothing is wired.
+      DATABASE_URL: "sqlite:///:memory:"
+      ASYNC_DATABASE_URL: "sqlite+aiosqlite:///:memory:"
+      REDIS_URL: "redis://127.0.0.1:6379/0"
+      QDRANT_URL: "http://127.0.0.1:6333"
+      QDRANT_API_KEY: "test-not-real"
+      OPENAI_API_KEY: "sk-test-not-real-do-not-use"
+      JWT_SECRET: "test-jwt-secret-for-contract-tests-only-not-prod"
+      # Skip side-effects on import
+      SKIP_SENTRY_INIT: "1"
+      SENTRY_TRACES_SAMPLE_RATE: "0.0"
+      # Langfuse dormant (no keys = no-op)
+      LANGFUSE_ENABLED: "false"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            apps/backend-rag/requirements.txt
+            apps/backend-rag/requirements-test.txt
+
+      - name: Install backend dependencies
+        working-directory: apps/backend-rag
+        run: |
+          python -m pip install --upgrade pip
+          # Install runtime deps (best-effort: some heavy ML deps may be skipped
+          # locally; the app import only needs FastAPI + Pydantic + a handful
+          # of stdlib-adjacent libs to expose /openapi.json).
+          pip install -r requirements.txt
+          # cell-core is declared as -e ../../packages/cell-core
+          # (already in requirements.txt). No extra install needed.
+
+      - name: Install Schemathesis
+        run: |
+          # Pin range: 3.36+ has ASGI loader fixes; <4.0 to avoid breaking-change
+          # surprises before we promote to blocking.
+          pip install 'schemathesis>=3.36.0,<4.0' 'hypothesis>=6.100,<7.0'
+
+      - name: Smoke-import FastAPI app
+        working-directory: apps/backend-rag
+        env:
+          PYTHONPATH: "."
+        run: |
+          # Sanity check: the app must be importable even with all external
+          # services unreachable. If this fails, Schemathesis would fail with
+          # an opaque module-load error.
+          python -c "from backend.app.main import app; print(f'✅ App imported. Routes: {len(app.routes)}')"
+
+      - name: Dump OpenAPI schema for artifact
+        working-directory: apps/backend-rag
+        env:
+          PYTHONPATH: "."
+        run: |
+          python -c "
+          import json
+          from backend.app.main import app
+          schema = app.openapi()
+          with open('openapi-snapshot.json', 'w') as f:
+              json.dump(schema, f, indent=2, sort_keys=True)
+          paths = len(schema.get('paths', {}))
+          ops = sum(len(v) for v in schema.get('paths', {}).values())
+          print(f'✅ OpenAPI schema: {paths} paths, {ops} operations')
+          "
+
+      - name: Run Schemathesis (ASGI direct mode)
+        working-directory: apps/backend-rag
+        env:
+          PYTHONPATH: "."
+        run: |
+          mkdir -p schemathesis-report
+          # ASGI loader: no HTTP, no live server. Schemathesis introspects the
+          # FastAPI app object directly and fuzzes routes with Hypothesis
+          # payloads. Stateful=off because OpenAPI links are not yet wired
+          # across routers (re-enable once we have at least one chain defined).
+          # Auth: a dummy Bearer placates middleware that routes by header
+          # presence (the JWT itself will not validate — that surfaces as 401,
+          # which is a valid contract response and won't fail Schemathesis
+          # unless the OpenAPI spec doesn't declare it).
+          schemathesis run \
+            --app=backend.app.main:app \
+            --checks=all \
+            --hypothesis-max-examples=10 \
+            --hypothesis-deadline=10000 \
+            --request-timeout=30000 \
+            --workers=2 \
+            --validate-schema=true \
+            --stateful=none \
+            --hypothesis-suppress-health-check=filter_too_much,data_too_large,too_slow \
+            -H "Authorization: Bearer ci-contract-test-dummy-token" \
+            --show-errors-tracebacks \
+            --junit-xml=schemathesis-report/junit.xml \
+            / 2>&1 | tee schemathesis-report/run.log
+          # Note: positional URI argument "/" is required even in --app mode
+          # (Schemathesis API quirk). The actual base URL is derived from the
+          # ASGI app.
+
+      - name: Upload Schemathesis report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: schemathesis-report-${{ github.event.pull_request.number || github.run_id }}
+          path: |
+            apps/backend-rag/schemathesis-report/
+            apps/backend-rag/openapi-snapshot.json
+          retention-days: 14
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Contract Tests (Schemathesis)"
+            echo ""
+            echo "Mode: **non-blocking** — see \`apps/backend-rag/docs/contract-testing.md\` for promotion criteria."
+            echo ""
+            if [ -f apps/backend-rag/schemathesis-report/run.log ]; then
+              echo "### Run summary"
+              echo '```'
+              tail -40 apps/backend-rag/schemathesis-report/run.log || true
+              echo '```'
+            fi
+            echo ""
+            echo "Full report uploaded as artifact: \`schemathesis-report-${{ github.event.pull_request.number || github.run_id }}\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/apps/backend-rag/docs/contract-testing.md
+++ b/apps/backend-rag/docs/contract-testing.md
@@ -1,0 +1,131 @@
+# Contract Testing (Schemathesis)
+
+> Finding #3 of the modernization audit 2026-05-18. Shipped non-blocking
+> in PR `ci/schemathesis-contract-tests-2026-05-18` to baseline the
+> failure surface without blocking unrelated PRs.
+
+## What it does
+
+[Schemathesis](https://schemathesis.readthedocs.io/) is a property-based
+contract testing tool. Given the FastAPI `/openapi.json` spec, it
+generates Hypothesis payloads for every operation and asserts the
+response conforms to the declared schema (status code, content-type,
+body shape, response headers). It also runs a configurable set of
+`--checks=all` (e.g. `status_code_conformance`,
+`response_schema_conformance`, `not_a_server_error`, `content_type_conformance`).
+
+The check runs in **ASGI-direct mode** (`--app=backend.app.main:app`),
+i.e. the FastAPI app is loaded as a Python object and called via the
+ASGI protocol — no live HTTP server, no external services required. The
+app boots in degraded mode (`app.state.startup_failed=True`); endpoints
+that exercise DB/Redis/Qdrant respond with 5xx, but `/openapi.json` is
+fully populated because routes are registered at import time.
+
+## Why we need it
+
+The scar from 2026-05-02 (PR #422 → #423 → #424, 3 hotfix chained):
+unit tests green, production endpoint returned 404 because the router
+was added to `router_manifest.py` but never imported by
+`router_registration.py`. Another shape of the same scar: a router was
+included but its path was missing from `PUBLIC_ENDPOINTS`, so
+`HybridAuthMiddleware` blocked unauthenticated `/health` requests with
+401 in prod despite a green unit suite.
+
+Schemathesis catches both classes at PR-check time:
+
+- A 404 on a path that the spec declares as `200|4xx` fails
+  `status_code_conformance`.
+- A 401 on a path the spec declares as `200` without a `401` response
+  fails the same check.
+
+## Reproduce locally
+
+```bash
+cd apps/backend-rag
+source .venv/bin/activate
+pip install 'schemathesis>=3.36.0,<4.0'
+
+# ASGI mode — no live server needed
+PYTHONPATH=. schemathesis run \
+  --app=backend.app.main:app \
+  --checks=all \
+  --hypothesis-max-examples=10 \
+  --stateful=none \
+  -H "Authorization: Bearer dummy" \
+  /
+```
+
+Drop `--hypothesis-max-examples=10` for a faster smoke run (default is
+100 examples per operation = much slower).
+
+To debug a single failing operation:
+
+```bash
+PYTHONPATH=. schemathesis run \
+  --app=backend.app.main:app \
+  --include-path "/api/channels/{name}/health" \
+  --hypothesis-max-examples=50 \
+  /
+```
+
+## Interpret the report
+
+The CI job uploads `schemathesis-report/` as a workflow artifact. Two
+artifacts inside:
+
+- `run.log` — full Schemathesis stdout with per-operation result
+  (`P` pass, `F` fail, `E` error). Failed operations include the
+  minimal Hypothesis-shrunk payload that triggered the failure.
+- `junit.xml` — machine-readable JUnit report. Can be wired into a
+  GitHub Check annotation later.
+
+A typical failure entry:
+
+```
+F GET /api/channels/{name}/health
+    response_schema_conformance: response body does not match the schema
+    in /components/responses/HealthResponse (missing required key `status`).
+    Repro: schemathesis replay <hash>
+```
+
+False positives to ignore:
+
+- **5xx on endpoints that need DB/Qdrant/Redis.** In degraded mode the
+  service is unreachable; the endpoint returns 503 or 500, which fails
+  `not_a_server_error`. Suppress per-operation via OpenAPI extension
+  `x-schemathesis-skip: true` if the endpoint cannot be tested without
+  a real backend. **Do NOT blanket-disable the check** — that's the
+  whole point.
+- **Hypothesis timeouts on endpoints that wrap LLM calls.** Already
+  handled by `--hypothesis-deadline=10000` + `too_slow` suppression.
+
+## Promote to required (blocking) check
+
+Promotion criteria (all three must hold):
+
+1. **Two consecutive weeks** of contract-tests runs on `main` with zero
+   genuine failures (only false positives that have been documented
+   and suppressed).
+2. **No flaky runs.** If Hypothesis seeds need pinning to stabilize,
+   pin them and document why.
+3. **Triage owner identified.** Someone on the team commits to looking
+   at the report within 1 business day of a failure.
+
+Once green, remove `continue-on-error: true` from
+`.github/workflows/contract-tests.yml` and add the job name to the
+`Required status checks` list in the GitHub branch protection rules
+for `main`.
+
+## Future scope
+
+- **Stateful tests** (`--stateful=links`) once we wire OpenAPI `links`
+  on at least one chain (e.g. `POST /api/clients` → `GET
+/api/clients/{id}`). Catches contract violations that only surface
+  across multiple requests.
+- **Auth profile.** Currently a dummy Bearer token. Could be upgraded
+  to a real JWT minted with the test `JWT_SECRET` so endpoints that
+  validate the token (not just its presence) actually exercise the
+  authenticated path.
+- **Coverage delta.** Schemathesis reports operation coverage; a
+  follow-up PR could fail the build if coverage regresses below a
+  threshold.


### PR DESCRIPTION
## Summary

- New CI workflow `.github/workflows/contract-tests.yml` runs [Schemathesis](https://schemathesis.readthedocs.io/) on the FastAPI `/openapi.json` spec for every PR touching `apps/backend-rag/**`. Fuzzes every operation with Hypothesis-generated payloads (max 10 examples/op) and asserts schema/contract conformance (`status_code_conformance`, `response_schema_conformance`, `not_a_server_error`, `content_type_conformance`).
- ASGI-direct mode (`--app=backend.app.main:app`) — no live HTTP server, no external services. The app boots in degraded mode (`app.state.startup_failed=True` per P0-1 antibody) but `/openapi.json` is fully populated because routes register at import time.
- New doc `apps/backend-rag/docs/contract-testing.md` covers local reproduction, report interpretation, and the promotion criteria to required check.

## Why

Audit modernization finding #3 (2026-05-18). Targets the scar from 2026-05-02 (PR #422 → #423 → #424, 3 hotfix chained on the same `channel_health` router): unit tests green, prod returned 404 because router added to `router_manifest.py` but never imported by `router_registration.py`. Schemathesis exercises the actual mounted route table — a missing `include_router` call would surface immediately as `status_code_conformance` failure at PR-check time.

## Non-blocking on purpose

`continue-on-error: true` while we baseline the failure surface. The job runs, the report is uploaded as artifact, but failures do not block merge. This avoids weaponizing a noisy new check against unrelated PRs.

**Promotion criteria** (all three must hold to flip to required):
1. Two consecutive weeks on `main` with zero genuine failures (false positives documented and suppressed via `x-schemathesis-skip`).
2. No flaky runs.
3. Triage owner identified with a 1-business-day SLA.

Then drop `continue-on-error: true` and add the job to `Required status checks` in branch protection for `main`.

## Test plan

- [ ] Verify the workflow triggers on this PR (paths filter matches `apps/backend-rag/docs/contract-testing.md`).
- [ ] Inspect the uploaded artifact `schemathesis-report-<pr#>` for `run.log` + `junit.xml` + `openapi-snapshot.json`.
- [ ] Confirm the import smoke check passes (`backend.app.main:app` loads in degraded mode with all env stubs).
- [ ] Confirm Schemathesis emits a real per-operation report (not just a transport error).
- [ ] Catalog any genuine failures vs false positives in the run summary on the Actions tab.

## Files

- `.github/workflows/contract-tests.yml` (new, 134 lines)
- `apps/backend-rag/docs/contract-testing.md` (new, 131 lines)

No app code touched. No new test-only endpoint added. `schemathesis` is installed only inside the CI job (not in `requirements-prod.txt` or `requirements-test.txt`).