### PR TITLE
feat(observability): orjson + ORJSONResponse default

### DIFF
--- a/apps/backend-rag/backend/app/main_api.py
+++ b/apps/backend-rag/backend/app/main_api.py
@@ -71,6 +71,7 @@ async def lifespan_light(app: FastAPI):
 
 def create_api_app() -> FastAPI:
     from fastapi import HTTPException
+    from fastapi.responses import ORJSONResponse
     from starlette.exceptions import HTTPException as StarletteHTTPException
 
     from backend.app.core.config import settings
@@ -92,6 +93,7 @@ def create_api_app() -> FastAPI:
         lifespan=lifespan_light,
         docs_url="/docs" if getattr(settings, "ENVIRONMENT", "production") != "production" else None,
         redoc_url=None,
+        default_response_class=ORJSONResponse,  # 3-10× faster JSON serialization (audit modernization 2026-05-18)
     )
 
     api.add_exception_handler(HTTPException, http_exception_handler)

--- a/apps/backend-rag/backend/app/main_rag.py
+++ b/apps/backend-rag/backend/app/main_rag.py
@@ -25,6 +25,7 @@ logger = logging.getLogger("zantara.backend")
 
 def create_rag_app() -> FastAPI:
     from fastapi import FastAPI, HTTPException
+    from fastapi.responses import ORJSONResponse
     from starlette.exceptions import HTTPException as StarletteHTTPException
 
     from backend.app.core.config import settings
@@ -47,6 +48,7 @@ def create_rag_app() -> FastAPI:
         lifespan=lifespan_full,
         docs_url="/docs" if getattr(settings, "ENVIRONMENT", "production") != "production" else None,
         redoc_url=None,
+        default_response_class=ORJSONResponse,  # 3-10× faster JSON serialization (audit modernization 2026-05-18)
     )
 
     rag.add_exception_handler(HTTPException, http_exception_handler)

--- a/apps/backend-rag/backend/app/services/crm/audit_logger.py
+++ b/apps/backend-rag/backend/app/services/crm/audit_logger.py
@@ -5,11 +5,11 @@ Tracks all state changes with user attribution and timestamps
 
 import functools
 import inspect
-import json
 from datetime import datetime, timezone
 from typing import Any
 
 import asyncpg
+import orjson
 
 from backend.app.utils.logging_utils import get_logger
 
@@ -82,10 +82,11 @@ class CRMAuditLogger:
                     entity_id,
                     change_type,
                     user_email,
-                    json.dumps(old_state, default=str),
-                    json.dumps(new_state, default=str),
-                    json.dumps(changes, default=str),
-                    json.dumps(metadata or {}, default=str),
+                    # orjson 3-10× faster; .decode() because CRM audit columns are TEXT not JSONB
+                    orjson.dumps(old_state, default=str).decode(),
+                    orjson.dumps(new_state, default=str).decode(),
+                    orjson.dumps(changes, default=str).decode(),
+                    orjson.dumps(metadata or {}, default=str).decode(),
                     datetime.now(tz=timezone.utc),
                 )
 

--- a/apps/backend-rag/backend/app/setup/app_factory.py
+++ b/apps/backend-rag/backend/app/setup/app_factory.py
@@ -17,6 +17,7 @@ import time
 from contextlib import asynccontextmanager, suppress
 
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import ORJSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from backend.app.core.config import settings
@@ -629,6 +630,7 @@ def create_app() -> FastAPI:
         openapi_url=f"{settings.API_V1_STR}/openapi.json",
         debug=settings.log_level == "DEBUG",  # Environment-based debug mode
         lifespan=lifespan,  # Modern lifespan API (replaces @app.on_event)
+        default_response_class=ORJSONResponse,  # 3-10× faster JSON serialization (audit modernization 2026-05-18)
     )
 
     # Register global exception handlers (MUST be before middleware to catch all exceptions)

--- a/apps/backend-rag/backend/middleware/pii_scanner.py
+++ b/apps/backend-rag/backend/middleware/pii_scanner.py
@@ -12,6 +12,7 @@ import json
 import logging
 from typing import Any
 
+import orjson
 from presidio_analyzer import AnalyzerEngine, Pattern, PatternRecognizer
 from presidio_anonymizer import AnonymizerEngine
 
@@ -253,7 +254,7 @@ class PIIScannerMiddleware:
         redacted_body = raw_body
         if "application/json" in content_type and raw_body:
             try:
-                payload = json.loads(raw_body)
+                payload = orjson.loads(raw_body)
                 total_redacted = 0
                 all_patterns: list[str] = []
                 for field in self._REDACT_FIELDS:
@@ -286,7 +287,8 @@ class PIIScannerMiddleware:
                             user_hash=hash_subject(subject),
                         ),
                     )
-                redacted_body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+                # orjson.dumps returns bytes already (UTF-8, non-ASCII passthrough) — no .encode() needed
+                redacted_body = orjson.dumps(payload)
             except (json.JSONDecodeError, UnicodeDecodeError) as exc:
                 # UU PDP audit: an agentic endpoint declared JSON but returned
                 # an unparsable body. Pass-through is safe (no redaction can

--- a/apps/backend-rag/backend/services/events/event_bus.py
+++ b/apps/backend-rag/backend/services/events/event_bus.py
@@ -36,6 +36,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 import asyncpg
+import orjson
 
 logger = logging.getLogger(__name__)
 
@@ -286,7 +287,8 @@ class EventBus:
         # Lightweight size warning preserved from phase 1 — outbox.publish
         # re-serialises with _outbox_id injected, so we flag the raw size
         # before it grows further.
-        payload_str = json.dumps(payload, default=str)
+        # orjson 3-10× faster; .decode() because downstream loggers expect str
+        payload_str = orjson.dumps(payload, default=str).decode()
         if len(payload_str) > 7500:
             logger.warning(
                 f"EventBus: PG payload for '{channel}' is {len(payload_str)} bytes "
@@ -413,7 +415,8 @@ class EventBus:
                         payload: dict[str, Any], _ch: str = pg_channel
                     ) -> None:
                         await self._handle_pg_event(
-                            _ch, json.dumps(payload, default=str)
+                            # orjson 3-10× faster; .decode() because _handle_pg_event expects str
+                            _ch, orjson.dumps(payload, default=str).decode()
                         )
 
                     try:

--- a/apps/backend-rag/requirements-prod.txt
+++ b/apps/backend-rag/requirements-prod.txt
@@ -108,6 +108,7 @@ scikit-learn>=1.3.0  # Required for GoldenAnswerService cosine similarity
 # - pandas (large, optional for this app)
 # Force rebuild 2026-02-13_00:12:41
 python-json-logger>=2.0.0
+orjson>=3.10.0  # 3-10× faster JSON serialization (FastAPI default response, hot path: pii_scanner, audit_logger, event_bus)
 aiosmtplib>=3.0.0
 apscheduler==3.11.2
 

--- a/apps/backend-rag/requirements.txt
+++ b/apps/backend-rag/requirements.txt
@@ -167,6 +167,7 @@ mcp>=1.25.0  # Upgraded for pydantic 2.12+ compatibility
 # (GHSA-5h2m-4q8j-pqpj), CVE-2025-66416 (GHSA-rcfx-77hg-w2wv), command
 # injection variants, reflected XSS callback page.
 python-json-logger>=2.0.0
+orjson>=3.10.0  # 3-10× faster JSON serialization (FastAPI default response, hot path: pii_scanner, audit_logger, event_bus)
 
 # Security & HTTP
 certifi>=2026.2.25  # Updated 2026-03-14: SSL certificates updated Feb 2026


### PR DESCRIPTION
## Summary

Drop-in **3-10× faster JSON serialization** for FastAPI responses + hottest internal serializers. Finding #1 of audit modernization 2026-05-18: 553 stdlib `json.dumps` + 291 `json.loads` but **0 orjson imports** across `apps/backend-rag/backend/`.

- Pin `orjson>=3.10.0` in `requirements{,-prod}.txt`
- Set `default_response_class=ORJSONResponse` on all 3 FastAPI() constructors (`app_factory.py`, `main_api.py`, `main_rag.py`)  every JSON response on every route now serialized by orjson without route-level changes
- Hot-path swap (3 files): `pii_scanner.py` (UU PDP middleware), `audit_logger.py` (every CRM state change), `event_bus.py` (every cross-process PG NOTIFY)

## Files changed

| File | Lines | Purpose |
|---|---|---|
| `requirements.txt` | +1 | pin orjson |
| `requirements-prod.txt` | +1 | pin orjson (prod) |
| `backend/app/setup/app_factory.py` | +2 | ORJSONResponse default (full RAG) |
| `backend/app/main_api.py` | +2 | ORJSONResponse default (api worker) |
| `backend/app/main_rag.py` | +2 | ORJSONResponse default (rag worker) |
| `backend/middleware/pii_scanner.py` | +3/-2 | orjson.loads + orjson.dumps |
| `backend/app/services/crm/audit_logger.py` | +5/-5 | 4x orjson.dumps + remove unused `import json` |
| `backend/services/events/event_bus.py` | +5/-2 | 2x orjson.dumps in PG event path |

Total: **+23/-9** across 8 files.

## Compatibility

- `orjson.JSONDecodeError` is a subclass of `json.JSONDecodeError`  existing `except` clauses still catch
- `default=str` (datetime/UUID fallback) is identical kwarg in orjson
- orjson always outputs UTF-8 bytes, non-ASCII passthrough  equivalent to `ensure_ascii=False` on stdlib
- In `audit_logger.py` + `event_bus.py` we add `.decode()` because the downstream consumers (asyncpg TEXT columns / size-logger str path) expect `str`, not bytes
- In `pii_scanner.py` line 289 we drop `.encode()` because orjson.dumps already returns bytes
- 88 migration scripts NOT touched (CLI tools, stdlib json fine)
- Test files NOT touched

## Out of scope (deferred)

- 549 remaining `json.dumps` callsites  swap opportunistically when touching the file
- 290 remaining `json.loads`  same policy
- Type-narrow `dict[str, Any]`  TypedDict on hot-path payloads
- `orjson.OPT_SERIALIZE_NUMPY` for KG embedding paths (out of audit scope #1)

## Test plan

- [x] `python -c "from backend.app.dependencies import get_current_user; print('OK')"` returns OK
- [x] `PYTHONPATH=. pytest backend/tests/services/rag/test_confidence.py -q` 24/24 passed
- [x] All 6 modified Python files parse via `ast.parse`
- [x] All 8 files pass `ruff` pre-commit gate (lint + import-order)
- [x] `npm run typecheck -w apps/mouth` green (no frontend impact)
- [ ] CI: pre-deploy-gate (import chain + core tests)
- [ ] CI: full pytest backend/tests
- [ ] Post-deploy: `/health` returns 200 on `nuzantara-rag` after rolling deploy
- [ ] Post-deploy: PII scanner integration test still redacts NPWP/passport correctly

## Gotcha encountered

The task spec referenced `audit_logger.py:335` and `pii_scanner.py:289`, but only line 289 was correct; `audit_logger` has its 4 `json.dumps` at lines 85-88 (file is only 390 lines total). Used actual locations, not spec ones.

The `event_bus.py` import-order initially broke ruff (`orjson` between stdlib `logging` and `time`)  fixed by placing orjson with other third-party (`asyncpg`) below the stdlib block.