### PR TITLE
feat(crm): approve consultant workspace stories

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_intelligence.py
+++ b/apps/backend-rag/backend/app/routers/crm_intelligence.py
@@ -85,7 +85,7 @@ async def auto_approve_workspace_ai_snapshot_drafts(
     pool: asyncpg.Pool = Depends(get_database_pool),
     _current_user: dict = Depends(require_team_member),
 ) -> WorkspaceAiAutoApproveResult:
-    """Dry-run or apply policy auto-approval for safe Workspace AI drafts."""
+    """Dry-run or apply policy auto-approval for reviewed Workspace AI stories."""
     return await auto_approve_workspace_ai_snapshots(
         pool,
         limit=payload.limit,
@@ -93,7 +93,9 @@ async def auto_approve_workspace_ai_snapshot_drafts(
     )
 
 
-@router.post("/workspace-ai-snapshots/{snapshot_id}/approve", response_model=WorkspaceAiSnapshotResponse)
+@router.post(
+    "/workspace-ai-snapshots/{snapshot_id}/approve", response_model=WorkspaceAiSnapshotResponse
+)
 async def approve_workspace_ai_snapshot_draft(
     snapshot_id: str,
     pool: asyncpg.Pool = Depends(get_database_pool),

--- a/apps/backend-rag/backend/services/crm/drive_autowatcher_service.py
+++ b/apps/backend-rag/backend/services/crm/drive_autowatcher_service.py
@@ -205,23 +205,32 @@ def _facts_from_evidence(
     missing = _missing_groups(groups, evidence.kg_edge_count)
 
     identity_detail = (
-        f"{evidence.company_name} has {len(evidence.documents)} indexed source "
-        f"document{'s' if len(evidence.documents) != 1 else ''} in the CRM workspace."
+        f"{evidence.company_name} is an operational dossier with {len(evidence.documents)} "
+        f"indexed source document{'s' if len(evidence.documents) != 1 else ''} across "
+        f"{_coverage_sentence(groups)}."
     )
     person_detail = (
-        f"Start from {people}; then open {evidence.company_name} through the confirmed CRM relationship."
+        f"Start from {people}; then read {evidence.company_name} through the confirmed "
+        "CRM relationship, connecting roles, residency, and tax ownership before any "
+        "client-facing use."
     )
     compliance_detail = (
-        f"Evidence currently covers {_coverage_sentence(groups)}. "
-        f"Tax owner: {evidence.tax_owner}."
+        f"The tax posture is visible at evidence level: {_coverage_sentence(groups)}. "
+        f"Tax owner: {evidence.tax_owner}. Treat this as an internal consultant reading, "
+        "not a compliance certification."
     )
     gap_detail = (
-        "Missing or weak evidence: " + ", ".join(missing) + "."
+        "Document review gaps to keep visible: " + ", ".join(missing) + "."
         if missing
-        else "Company, tax, person, and relationship evidence are all present for team review."
+        else (
+            "Document review gaps: no company, tax, person, or relationship document "
+            "gaps are visible in the indexed evidence."
+        )
     )
     next_action_detail = (
-        "Review this draft, confirm the roles and source documents, then approve it for the Business Story."
+        "Consultant prompts: review LKPM or capital reporting, investor visa role "
+        "alignment, property or operating permits, and the monthly tax workflow before "
+        "the story becomes client-facing."
     )
 
     return [
@@ -229,7 +238,9 @@ def _facts_from_evidence(
             category="identity",
             label="Company evidence",
             detail=_clean_detail(identity_detail),
-            source_file_ids=_source_ids_for_groups(evidence.documents, ("company", "tax", "person")),
+            source_file_ids=_source_ids_for_groups(
+                evidence.documents, ("company", "tax", "person")
+            ),
             confidence=_confidence_for(evidence.documents, evidence.kg_edge_count),
         ),
         TaxCompanyPilotWorkspaceAiFact(
@@ -383,11 +394,7 @@ def _source_ids_for_groups(
     documents: list[DriveEvidenceDocument],
     groups: tuple[str, ...],
 ) -> list[str]:
-    return [
-        document.file_id
-        for document in documents
-        if _document_group(document) in groups
-    ][:12]
+    return [document.file_id for document in documents if _document_group(document) in groups][:12]
 
 
 def _ordered_file_ids(documents: list[DriveEvidenceDocument]) -> list[str]:
@@ -437,7 +444,11 @@ def _human_join(items: list[str], *, fallback: str) -> str:
 
 def _clean_detail(value: str) -> str:
     no_urls = re.sub(r"https?://\S+", "[internal source]", value)
-    return no_urls.replace("Drive", "source").replace("OCR", "document reading").replace("KG", "relationship")
+    return (
+        no_urls.replace("Drive", "source")
+        .replace("OCR", "document reading")
+        .replace("KG", "relationship")
+    )
 
 
 def _append_unique(items: list[str], value: str) -> None:

--- a/apps/backend-rag/backend/services/crm/workspace_ai_snapshots.py
+++ b/apps/backend-rag/backend/services/crm/workspace_ai_snapshots.py
@@ -21,10 +21,12 @@ from backend.services.crm.tax_company_pilot import (
 
 logger = logging.getLogger(__name__)
 
-AUTO_APPROVE_POLICY_VERSION = "workspace-ai-v1-factual-structural"
+AUTO_APPROVE_POLICY_VERSION = "workspace-ai-v2-consultant-narrative"
 _AUTO_APPROVE_SYSTEM_ACTOR = f"system:auto-approve:{AUTO_APPROVE_POLICY_VERSION}"
-_AUTO_APPROVE_FACT_CATEGORIES = frozenset({"identity", "person", "gap"})
-_AUTO_APPROVE_BLOCKED_CATEGORIES = frozenset({"compliance", "next_action"})
+_AUTO_APPROVE_FACT_CATEGORIES = frozenset(
+    {"identity", "person", "compliance", "gap", "next_action"}
+)
+_CONSULTANT_NARRATIVE_CATEGORIES = frozenset({"compliance", "next_action"})
 _RAW_DRIVE_REFERENCE_MARKERS = (
     "drive.google.com",
     "docs.google.com",
@@ -39,12 +41,43 @@ _DOCUMENT_GAP_PATTERN = re.compile(
     r"\b(document|record|file|npwp|nib|akta|profile|folder)\b",
     re.IGNORECASE,
 )
-_INTERPRETIVE_OR_SENSITIVE_PATTERN = re.compile(
+_CREDENTIAL_OR_PORTAL_SECRET_PATTERN = re.compile(
     r"\b("
-    r"advice|advise|recommend|recommendation|should|must|legal opinion|"
-    r"liable|liability|penalty|sanction|strategy|suspicion|suspected|fraud|"
-    r"tax return|tax payable|vat|pph|profit|revenue|income|price|pricing|"
-    r"fee|invoice|paid|unpaid|debt|balance"
+    r"efin|password|passcode|otp|credential|credentials|username|login|"
+    r"tax portal|djp/coretax|coretax access|portal access|accessed via|"
+    r"npwp ending|individual accounts|personal tax oversight"
+    r")\b|[\w.+-]+@(?:gmail|yahoo|hotmail|outlook)\.[\w.-]+",
+    re.IGNORECASE,
+)
+_BACKSTAGE_SOURCE_REFERENCE_PATTERN = re.compile(
+    r"\b(sources?|source files?)\s*:|"
+    r"\b(file_id|folder_id|transaction_history)\b|"
+    r"\.(?:pdf|jpe?g|png|xlsx?|csv)\b",
+    re.IGNORECASE,
+)
+_ABSOLUTE_COMPLIANCE_PATTERN = re.compile(
+    r"\b("
+    r"fully compliant|compliant with all|legal and regulatory excellence|"
+    r"no compliance risk|no legal risk|no risk|guaranteed|legally safe|"
+    r"cleared by (?:the )?tax office|free of liabilities"
+    r")\b",
+    re.IGNORECASE,
+)
+_SENSITIVE_FINANCIAL_AMOUNT_PATTERN = re.compile(
+    r"\b(?:pph|ppn|vat|tax|pajak|omzet|withholding|salary|salaries|"
+    r"revenue|income|profit|loss|debt|balance|invoice|fee|royalty)"
+    r"\b.{0,80}\b(?:rp|idr)\s*\d|"
+    r"\b(?:rp|idr)\s*\d.{0,80}\b(?:pph|ppn|vat|tax|pajak|omzet|"
+    r"withholding|salary|salaries|revenue|income|profit|loss|debt|"
+    r"balance|invoice|fee|royalty)\b",
+    re.IGNORECASE | re.DOTALL,
+)
+_UNSAFE_ADVICE_PATTERN = re.compile(
+    r"\b(?:client|company|director|commissioner|shareholder|they|you)\s+"
+    r"(?:should|must|need to|required to|has to)\b|"
+    r"\b("
+    r"amended tax return|legal opinion|liable|liability|penalty|sanction|"
+    r"suspicion|suspected|fraud"
     r")\b",
     re.IGNORECASE,
 )
@@ -191,9 +224,7 @@ def evaluate_workspace_ai_auto_approve_snapshot(
     for fact in snapshot.facts:
         category = str(fact.category)
         text = _normalise_fact_text(fact)
-        if category in _AUTO_APPROVE_BLOCKED_CATEGORIES:
-            blocked_reasons.append(f"blocked_category:{category}")
-        elif category not in _AUTO_APPROVE_FACT_CATEGORIES:
+        if category not in _AUTO_APPROVE_FACT_CATEGORIES:
             blocked_reasons.append(f"unknown_category:{category}")
         elif category == "gap" and not _is_document_gap_fact(text):
             blocked_reasons.append("gap_not_document_inventory")
@@ -202,17 +233,34 @@ def evaluate_workspace_ai_auto_approve_snapshot(
             blocked_reasons.append("missing_explicit_evidence")
         if _contains_raw_drive_reference(text):
             blocked_reasons.append("raw_drive_reference")
-        if _contains_interpretive_or_sensitive_claim(text):
-            blocked_reasons.append("interpretive_or_sensitive_claim")
+        if _contains_credential_or_portal_secret(text):
+            blocked_reasons.append("credential_or_portal_secret")
+        if _contains_backstage_source_reference(text):
+            blocked_reasons.append("backstage_source_reference")
+        if _contains_absolute_compliance_claim(text):
+            blocked_reasons.append("absolute_compliance_claim")
+        if _contains_sensitive_financial_amount(text):
+            blocked_reasons.append("sensitive_financial_amount")
+        if _contains_unsafe_advice_claim(text):
+            blocked_reasons.append("unsafe_advice_claim")
 
     unique_blocked_reasons = list(dict.fromkeys(blocked_reasons))
     eligible = len(unique_blocked_reasons) == 0
+    has_consultant_narrative = any(
+        str(fact.category) in _CONSULTANT_NARRATIVE_CATEGORIES for fact in snapshot.facts
+    )
     return WorkspaceAiAutoApproveDecision(
         snapshot_id=snapshot.id,
         company_id=snapshot.company_id,
         company_name=snapshot.company_name,
         eligible=eligible,
-        reason="factual_structural_snapshot" if eligible else "policy_blocked",
+        reason=(
+            "consultant_narrative_snapshot"
+            if eligible and has_consultant_narrative
+            else "factual_structural_snapshot"
+            if eligible
+            else "policy_blocked"
+        ),
         blocked_reasons=unique_blocked_reasons,
         fact_count=len(snapshot.facts),
     )
@@ -340,8 +388,24 @@ def _contains_raw_drive_reference(text: str) -> bool:
     return any(marker in lower_text for marker in _RAW_DRIVE_REFERENCE_MARKERS)
 
 
-def _contains_interpretive_or_sensitive_claim(text: str) -> bool:
-    return bool(_INTERPRETIVE_OR_SENSITIVE_PATTERN.search(text))
+def _contains_credential_or_portal_secret(text: str) -> bool:
+    return bool(_CREDENTIAL_OR_PORTAL_SECRET_PATTERN.search(text))
+
+
+def _contains_backstage_source_reference(text: str) -> bool:
+    return bool(_BACKSTAGE_SOURCE_REFERENCE_PATTERN.search(text))
+
+
+def _contains_absolute_compliance_claim(text: str) -> bool:
+    return bool(_ABSOLUTE_COMPLIANCE_PATTERN.search(text))
+
+
+def _contains_sensitive_financial_amount(text: str) -> bool:
+    return bool(_SENSITIVE_FINANCIAL_AMOUNT_PATTERN.search(text))
+
+
+def _contains_unsafe_advice_claim(text: str) -> bool:
+    return bool(_UNSAFE_ADVICE_PATTERN.search(text))
 
 
 _LATEST_BY_COMPANY_SQL = """

--- a/apps/backend-rag/backend/tests/services/crm/test_drive_autowatcher_service.py
+++ b/apps/backend-rag/backend/tests/services/crm/test_drive_autowatcher_service.py
@@ -36,18 +36,22 @@ async def test_autowatcher_dry_run_previews_story_drafts_without_writes() -> Non
         )
     ]
 
-    with patch(
-        "backend.services.crm.drive_autowatcher_service.run_crm_drive_backfill",
-        new_callable=AsyncMock,
-        return_value={"processed": 1, "ocr_dispatched": 0, "kg_linked": 1},
-    ), patch(
-        "backend.services.crm.drive_autowatcher_service.fetch_drive_evidence_for_story_drafts",
-        new_callable=AsyncMock,
-        return_value=evidence,
-    ), patch(
-        "backend.services.crm.drive_autowatcher_service.create_workspace_ai_snapshot",
-        new_callable=AsyncMock,
-    ) as create_snapshot:
+    with (
+        patch(
+            "backend.services.crm.drive_autowatcher_service.run_crm_drive_backfill",
+            new_callable=AsyncMock,
+            return_value={"processed": 1, "ocr_dispatched": 0, "kg_linked": 1},
+        ),
+        patch(
+            "backend.services.crm.drive_autowatcher_service.fetch_drive_evidence_for_story_drafts",
+            new_callable=AsyncMock,
+            return_value=evidence,
+        ),
+        patch(
+            "backend.services.crm.drive_autowatcher_service.create_workspace_ai_snapshot",
+            new_callable=AsyncMock,
+        ) as create_snapshot,
+    ):
         result = await run_crm_drive_autowatch(
             object(),
             limit=5,
@@ -101,23 +105,28 @@ async def test_autowatcher_creates_only_new_draft_snapshots() -> None:
         )
     ]
 
-    with patch(
-        "backend.services.crm.drive_autowatcher_service.run_crm_drive_backfill",
-        new_callable=AsyncMock,
-        return_value={"processed": 2, "ocr_dispatched": 1, "kg_linked": 2},
-    ), patch(
-        "backend.services.crm.drive_autowatcher_service.fetch_drive_evidence_for_story_drafts",
-        new_callable=AsyncMock,
-        return_value=evidence,
-    ), patch(
-        "backend.services.crm.drive_autowatcher_service.workspace_ai_snapshot_exists",
-        new_callable=AsyncMock,
-        return_value=False,
-    ), patch(
-        "backend.services.crm.drive_autowatcher_service.create_workspace_ai_snapshot",
-        new_callable=AsyncMock,
-        return_value=object(),
-    ) as create_snapshot:
+    with (
+        patch(
+            "backend.services.crm.drive_autowatcher_service.run_crm_drive_backfill",
+            new_callable=AsyncMock,
+            return_value={"processed": 2, "ocr_dispatched": 1, "kg_linked": 2},
+        ),
+        patch(
+            "backend.services.crm.drive_autowatcher_service.fetch_drive_evidence_for_story_drafts",
+            new_callable=AsyncMock,
+            return_value=evidence,
+        ),
+        patch(
+            "backend.services.crm.drive_autowatcher_service.workspace_ai_snapshot_exists",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "backend.services.crm.drive_autowatcher_service.create_workspace_ai_snapshot",
+            new_callable=AsyncMock,
+            return_value=object(),
+        ) as create_snapshot,
+    ):
         result = await run_crm_drive_autowatch(
             object(),
             limit=5,
@@ -173,22 +182,27 @@ async def test_autowatcher_skips_existing_snapshot_fingerprint() -> None:
         )
     ]
 
-    with patch(
-        "backend.services.crm.drive_autowatcher_service.run_crm_drive_backfill",
-        new_callable=AsyncMock,
-        return_value={"processed": 0},
-    ), patch(
-        "backend.services.crm.drive_autowatcher_service.fetch_drive_evidence_for_story_drafts",
-        new_callable=AsyncMock,
-        return_value=evidence,
-    ), patch(
-        "backend.services.crm.drive_autowatcher_service.workspace_ai_snapshot_exists",
-        new_callable=AsyncMock,
-        return_value=True,
-    ), patch(
-        "backend.services.crm.drive_autowatcher_service.create_workspace_ai_snapshot",
-        new_callable=AsyncMock,
-    ) as create_snapshot:
+    with (
+        patch(
+            "backend.services.crm.drive_autowatcher_service.run_crm_drive_backfill",
+            new_callable=AsyncMock,
+            return_value={"processed": 0},
+        ),
+        patch(
+            "backend.services.crm.drive_autowatcher_service.fetch_drive_evidence_for_story_drafts",
+            new_callable=AsyncMock,
+            return_value=evidence,
+        ),
+        patch(
+            "backend.services.crm.drive_autowatcher_service.workspace_ai_snapshot_exists",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "backend.services.crm.drive_autowatcher_service.create_workspace_ai_snapshot",
+            new_callable=AsyncMock,
+        ) as create_snapshot,
+    ):
         result = await run_crm_drive_autowatch(
             object(),
             dry_run=False,
@@ -233,7 +247,65 @@ def test_story_draft_payload_uses_human_language_and_no_drive_links() -> None:
     assert "OCR" not in details
     assert "drive.google.com" not in details
     assert "Maria Rossi" in details
-    assert payload.facts[-1].detail.startswith("Review this draft")
+    assert payload.facts[-1].detail.startswith("Consultant prompts:")
+
+
+def test_story_draft_payload_frames_consultant_narrative_and_prompts() -> None:
+    from backend.services.crm.drive_autowatcher_service import (
+        CompanyDriveEvidence,
+        DriveEvidenceDocument,
+        build_workspace_ai_snapshot_payload,
+    )
+
+    payload = build_workspace_ai_snapshot_payload(
+        CompanyDriveEvidence(
+            company_id=11,
+            company_name="PT BIMALA INVESTMENTS BALI",
+            client_ids=[101, 102],
+            people=["Gianluca Morelli", "Giulia Del Giudice"],
+            tax_owner="Dewa Ayu",
+            documents=[
+                DriveEvidenceDocument(
+                    file_id="akta",
+                    file_name="Akta Pendirian.pdf",
+                    document_type="akta",
+                    document_category="company",
+                    ocr_status="completed",
+                    has_kg_node=True,
+                ),
+                DriveEvidenceDocument(
+                    file_id="itas",
+                    file_name="ITAS E28A Investor.pdf",
+                    document_type="itas",
+                    document_category="person",
+                    ocr_status="completed",
+                    has_kg_node=True,
+                ),
+                DriveEvidenceDocument(
+                    file_id="spt",
+                    file_name="SPT 2025.pdf",
+                    document_type="spt",
+                    document_category="tax",
+                    ocr_status="completed",
+                    has_kg_node=True,
+                ),
+            ],
+            kg_edge_count=3,
+        )
+    )
+
+    details_by_category = {fact.category: fact.detail for fact in payload.facts}
+    all_details = " ".join(details_by_category.values())
+    assert "operational dossier" in details_by_category["identity"]
+    assert "Gianluca Morelli and Giulia Del Giudice" in details_by_category["person"]
+    assert "tax posture" in details_by_category["compliance"]
+    assert "Consultant prompts:" in details_by_category["next_action"]
+    assert "investor visa role alignment" in details_by_category["next_action"]
+    assert "LKPM or capital reporting" in details_by_category["next_action"]
+    assert "monthly tax workflow" in details_by_category["next_action"]
+    assert "KG" not in all_details
+    assert "OCR" not in all_details
+    assert "drive.google.com" not in all_details
 
 
 def test_evidence_query_prioritizes_companies_without_autowatcher_drafts() -> None:

--- a/apps/backend-rag/backend/tests/services/crm/test_workspace_ai_snapshots.py
+++ b/apps/backend-rag/backend/tests/services/crm/test_workspace_ai_snapshots.py
@@ -232,6 +232,74 @@ def test_auto_approve_policy_allows_factual_structural_snapshot() -> None:
     assert decision.blocked_reasons == []
 
 
+def test_auto_approve_policy_allows_guarded_consultant_narrative_snapshot() -> None:
+    snapshot = _snapshot_response(
+        facts=[
+            TaxCompanyPilotWorkspaceAiFact(
+                category="identity",
+                label="Foundation narrative",
+                detail=(
+                    "PT Bimala Investments Bali began as a PMA company in Badung with "
+                    "foundational capital of Rp 25,000,000,000 and a real estate, "
+                    "hospitality, commerce, and digital trade scope."
+                ),
+                source_file_ids=["akta", "nib"],
+                confidence="confirmed",
+            ),
+            TaxCompanyPilotWorkspaceAiFact(
+                category="person",
+                label="Leadership and residency",
+                detail=(
+                    "Gianluca Morelli is the Director with 60 percent ownership, "
+                    "Giulia Del Giudice is the Commissioner with 40 percent ownership, "
+                    "and both investor ITAS records support the long-term Bali presence."
+                ),
+                source_file_ids=["profile", "itas-gianluca", "itas-giulia"],
+                confidence="confirmed",
+            ),
+            TaxCompanyPilotWorkspaceAiFact(
+                category="compliance",
+                label="Tax posture",
+                detail=(
+                    "The tax story moves from a 2024 setup year filed as Nihil into "
+                    "active 2025-2026 reporting, with PPh 21, PPh 23, and PKP readiness "
+                    "as consultant watchpoints rather than client-facing conclusions."
+                ),
+                source_file_ids=["spt-2024", "rekap-2026"],
+                confidence="high",
+            ),
+            TaxCompanyPilotWorkspaceAiFact(
+                category="gap",
+                label="Document review gaps",
+                detail=(
+                    "Document review gaps to keep visible: LKPM or capital reporting, "
+                    "updated property due diligence files, and role evidence for each "
+                    "investment or visa decision."
+                ),
+                source_file_ids=["travel", "profile"],
+                confidence="medium",
+            ),
+            TaxCompanyPilotWorkspaceAiFact(
+                category="next_action",
+                label="Consultant prompts",
+                detail=(
+                    "Consultant prompts: align investor visa roles with the company "
+                    "structure, review LKPM capital reporting, and prepare the monthly "
+                    "tax workflow before the story becomes client-facing."
+                ),
+                source_file_ids=["profile", "rekap-2026"],
+                confidence="medium",
+            ),
+        ]
+    )
+
+    decision = evaluate_workspace_ai_auto_approve_snapshot(snapshot)
+
+    assert decision.eligible is True
+    assert decision.reason == "consultant_narrative_snapshot"
+    assert decision.blocked_reasons == []
+
+
 @pytest.mark.parametrize(
     ("fact", "expected_reason"),
     [
@@ -243,7 +311,7 @@ def test_auto_approve_policy_allows_factual_structural_snapshot() -> None:
                 source_file_ids=["drive-file-1"],
                 confidence="confirmed",
             ),
-            "blocked_category:compliance",
+            "unsafe_advice_claim",
         ),
         (
             TaxCompanyPilotWorkspaceAiFact(
@@ -274,6 +342,53 @@ def test_auto_approve_policy_blocks_risky_or_weak_snapshots(
     snapshot = _snapshot_response(
         facts=[fact],
         source_file_ids=[] if expected_reason == "missing_explicit_evidence" else None,
+    )
+
+    decision = evaluate_workspace_ai_auto_approve_snapshot(snapshot)
+
+    assert decision.eligible is False
+    assert expected_reason in decision.blocked_reasons
+
+
+@pytest.mark.parametrize(
+    ("detail", "expected_reason"),
+    [
+        (
+            "DJP/Coretax is accessed via ptbimalainvetmentbali.tax@gmail.com with EFIN 7473573914.",
+            "credential_or_portal_secret",
+        ),
+        (
+            "The company stands as proof of legal and regulatory excellence with no compliance risk.",
+            "absolute_compliance_claim",
+        ),
+        (
+            "PPh Final for February is Rp 213,954 and PPh Final for March is Rp 200,553.",
+            "sensitive_financial_amount",
+        ),
+        (
+            "Sources: Akta Pendirian.pdf, NPWP.pdf, transaction_history_permata_paging-2.pdf.",
+            "backstage_source_reference",
+        ),
+        (
+            "Client should file an amended tax return next month.",
+            "unsafe_advice_claim",
+        ),
+    ],
+)
+def test_auto_approve_policy_blocks_sensitive_consultant_narrative_details(
+    detail: str,
+    expected_reason: str,
+) -> None:
+    snapshot = _snapshot_response(
+        facts=[
+            TaxCompanyPilotWorkspaceAiFact(
+                category="compliance",
+                label="Sensitive detail",
+                detail=detail,
+                source_file_ids=["drive-file-1"],
+                confidence="confirmed",
+            )
+        ]
     )
 
     decision = evaluate_workspace_ai_auto_approve_snapshot(snapshot)

--- a/apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.test.tsx
+++ b/apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.test.tsx
@@ -314,7 +314,7 @@ describe("TaxCompanyPilotWorkspace", () => {
           },
         ]}
         autoApproveResult={{
-          policy_version: "workspace-ai-v1-factual-structural",
+          policy_version: "workspace-ai-v2-consultant-narrative",
           dry_run: true,
           evaluated: 1,
           eligible_count: 1,
@@ -330,7 +330,7 @@ describe("TaxCompanyPilotWorkspace", () => {
 
     expect(screen.getByText("Workspace AI review")).toBeInTheDocument();
     expect(screen.getByText("1 draft")).toBeInTheDocument();
-    expect(screen.getByText("1 safe · 0 held")).toBeInTheDocument();
+    expect(screen.getByText("1 ready · 0 held")).toBeInTheDocument();
     expect(
       screen.getByText("Company source documents are indexed for review."),
     ).toBeInTheDocument();
@@ -343,8 +343,8 @@ describe("TaxCompanyPilotWorkspace", () => {
 
     expect(onApproveSnapshot).toHaveBeenCalledWith("snapshot-draft");
 
-    fireEvent.click(screen.getByRole("button", { name: "Check safe" }));
-    fireEvent.click(screen.getByRole("button", { name: "Approve safe" }));
+    fireEvent.click(screen.getByRole("button", { name: "Check stories" }));
+    fireEvent.click(screen.getByRole("button", { name: "Approve stories" }));
 
     expect(onAutoApproveDryRun).toHaveBeenCalledOnce();
     expect(onAutoApproveApply).toHaveBeenCalledOnce();

--- a/apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.tsx
+++ b/apps/mouth/src/components/crm/TaxCompanyPilotWorkspace.tsx
@@ -493,7 +493,7 @@ function WorkspaceAiReviewPanel({
           {autoApproveResult && (
             <span className="rounded bg-emerald-50 px-2.5 py-1 text-xs font-medium text-emerald-800 ring-1 ring-emerald-200">
               {autoApproveResult.dry_run
-                ? `${autoApproveResult.eligible_count} safe · ${autoApproveResult.blocked_count} held`
+                ? `${autoApproveResult.eligible_count} ready · ${autoApproveResult.blocked_count} held`
                 : `${autoApproveResult.approved_count} approved · ${autoApproveResult.blocked_count} held`}
             </span>
           )}
@@ -504,7 +504,7 @@ function WorkspaceAiReviewPanel({
             className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-300"
           >
             <Sparkles size={13} />
-            Check safe
+            Check stories
           </button>
           <button
             type="button"
@@ -513,7 +513,7 @@ function WorkspaceAiReviewPanel({
             className="inline-flex items-center gap-1.5 rounded-md bg-emerald-700 px-2.5 py-1.5 text-xs font-semibold text-white hover:bg-emerald-800 disabled:cursor-not-allowed disabled:bg-slate-300"
           >
             <ShieldCheck size={13} />
-            Approve safe
+            Approve stories
           </button>
           <span className="rounded bg-white px-2.5 py-1 text-xs font-medium text-slate-600 ring-1 ring-slate-200">
             {loading


### PR DESCRIPTION
## Summary\n- upgrade Workspace AI auto-approve policy to consultant narrative v2\n- allow guarded Business Story lines for tax posture, visa/company alignment, LKPM/capital prompts, and next actions\n- block credentials, raw/backstage source references, absolute compliance claims, exact sensitive financial/tax amounts, and unsafe advice\n- make CRM autowatcher draft stories more human/consultant-oriented and update the review UI copy from safe to stories\n\n## Verification\n- RED first: new consultant narrative policy and autowatcher prompt tests failed before implementation\n- cd apps/backend-rag && source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && ruff check backend/app/routers/crm_intelligence.py backend/services/crm/workspace_ai_snapshots.py backend/services/crm/drive_autowatcher_service.py backend/tests/services/crm/test_workspace_ai_snapshots.py backend/tests/services/crm/test_drive_autowatcher_service.py backend/tests/unit/routers/test_crm_intelligence.py\n- cd apps/backend-rag && source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && PYTHONPATH=. python -m pytest backend/tests/services/crm/test_workspace_ai_snapshots.py backend/tests/services/crm/test_drive_autowatcher_service.py backend/tests/unit/routers/test_crm_intelligence.py -q\n- cd apps/backend-rag && source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && python -c "from backend.app.dependencies import get_current_user; print('OK')"\n- cd apps/backend-rag && source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && PYTHONPATH=. python -m pytest backend/tests/services/rag/test_kg_langgraph.py backend/tests/services/rag/test_kg_subgraphs.py backend/tests/services/rag/test_confidence.py -q\n- cd apps/mouth && npm test -- --run src/components/crm/TaxCompanyPilotWorkspace.test.tsx\n- cd apps/mouth && npm run typecheck -- --pretty false\n- cd apps/mouth && npm run build\n- git diff --check