### PR TITLE
fix(crm-guardian): normalize Indonesian role names from akta OCR to English enum

### DIFF
--- a/apps/backend-rag/backend/services/crm_guardian/schemas.py
+++ b/apps/backend-rag/backend/services/crm_guardian/schemas.py
@@ -151,6 +151,35 @@ class Shareholder(BaseModel):
             raise ValueError(f"percentage must be in [0,100], got {v}")
         return v
 
+    # Phase 1.5 hotfix 2026-05-18 (queue id 47, client 484 Gergely Gal): OCR
+    # extracts akta in Bahasa Indonesia, so Gemini occasionally emits raw
+    # Indonesian role names ("DIREKTUR", "KOMISARIS", "PEMEGANG SAHAM",
+    # "PENDIRI") that fail the English enum. Normalize before enum validation
+    # rather than asking the LLM to retry — the rest of the extraction is
+    # correct, only the role label is i18n.
+    @field_validator("role", mode="before")
+    @classmethod
+    def _normalize_role(cls, v: str | None) -> str | None:
+        if v is None or not isinstance(v, str):
+            return v
+        stripped = v.strip().rstrip(".").upper()
+        ID_TO_EN = {
+            "DIREKTUR": "Director",
+            "DIREKTUR UTAMA": "Director",
+            "DIR": "Director",
+            "KOMISARIS": "Commissioner",
+            "KOMISARIS UTAMA": "Commissioner",
+            "KOM": "Commissioner",
+            "PEMEGANG SAHAM": "Shareholder",
+            "PEMEGANGSAHAM": "Shareholder",
+            "PENDIRI": "Founder",
+            "FOUNDER": "Founder",
+            "DIRECTOR": "Director",
+            "COMMISSIONER": "Commissioner",
+            "SHAREHOLDER": "Shareholder",
+        }
+        return ID_TO_EN.get(stripped, v)  # pass-through unknowns → enum will raise
+
 
 class PropertyAsset(BaseModel):
     """Real estate / villa / lease — Bali-specific."""

--- a/apps/backend-rag/backend/tests/unit/services/crm_guardian/test_schemas_v2.py
+++ b/apps/backend-rag/backend/tests/unit/services/crm_guardian/test_schemas_v2.py
@@ -200,3 +200,42 @@ class TestL1ClientSummaryV2:
                 source_file_fingerprint="x",
                 extraction_confidence=-0.1,
             )
+
+class TestShareholderRoleNormalizer:
+    """Phase 1.5 hotfix 2026-05-18: Indonesian role names from akta OCR
+    should normalize to the English enum before validation."""
+
+    def test_indonesian_direktur_normalized(self) -> None:
+        from backend.services.crm_guardian.schemas import Shareholder
+        s = Shareholder(name="Gergely Gal", role="DIREKTUR", percentage=100.0)
+        assert s.role == "Director"
+
+    def test_indonesian_komisaris_lowercase_normalized(self) -> None:
+        from backend.services.crm_guardian.schemas import Shareholder
+        s = Shareholder(name="Test", role="Komisaris")
+        assert s.role == "Commissioner"
+
+    def test_indonesian_pemegang_saham_normalized(self) -> None:
+        from backend.services.crm_guardian.schemas import Shareholder
+        s = Shareholder(name="Test", role="PEMEGANG SAHAM")
+        assert s.role == "Shareholder"
+
+    def test_indonesian_pendiri_normalized(self) -> None:
+        from backend.services.crm_guardian.schemas import Shareholder
+        s = Shareholder(name="Test", role="PENDIRI")
+        assert s.role == "Founder"
+
+    def test_english_canonical_passthrough(self) -> None:
+        from backend.services.crm_guardian.schemas import Shareholder
+        s = Shareholder(name="Test", role="Director")
+        assert s.role == "Director"
+
+    def test_unknown_role_still_rejected(self) -> None:
+        from backend.services.crm_guardian.schemas import Shareholder
+        with pytest.raises(ValidationError):
+            Shareholder(name="Test", role="INVENTED_ROLE")
+
+    def test_none_role_preserved(self) -> None:
+        from backend.services.crm_guardian.schemas import Shareholder
+        s = Shareholder(name="Test", role=None)
+        assert s.role is None


### PR DESCRIPTION
## Summary

Phase 1.5 bulk active-linked (PR #718) hit pydantic `ValidationError` on **client 484 (Gergely Gal)**: Gemini emitted `role="DIREKTUR"` from akta OCR content, schema enum requires `Director`. Worker correctly marked the queue row as `error`; the rest of the extraction was valid.

This hotfix adds a pre-enum `field_validator` (mode="before") on `Shareholder.role` that maps Bahasa Indonesia role names to canonical English:

| Indonesian input | Normalized output |
|---|---|
| `DIREKTUR` / `Direktur` / `Dir` | `Director` |
| `KOMISARIS` / `Komisaris` / `Kom` | `Commissioner` |
| `PEMEGANG SAHAM` / `pemegangsaham` | `Shareholder` |
| `PENDIRI` / `Founder` | `Founder` |
| `Director` / `Commissioner` (canonical) | pass-through unchanged |
| Unknown values | pass-through → enum rejects (no silent garbage) |

## Why this matters

The bulk active-linked pipeline (724 client queue) was processing ~25 client/h. Without this fix, every Indonesian akta will fail pydantic parsing → wasted Gemini CLI call + retry needed. Akta in Bahasa Indonesia is the COMMON case in Bali Zero CRM, not the exception.

## Test plan

- [x] 7 new tests in `TestShareholderRoleNormalizer` covering DIREKTUR/Komisaris/PEMEGANG SAHAM/PENDIRI/English pass-through/unknown rejection/None preservation
- [x] All 99 existing crm_guardian tests still passing
- [x] **Total: 106/106 passed** (`PYTHONPATH=. pytest backend/tests/unit/services/crm_guardian/ -q`)
- [x] Import chain validation (pre-commit hook ✓)

## Operational impact

- Worker rilegge `schemas.py` al prossimo subprocess call → **no restart needed**
- Queue id 47 (client 484 Gergely Gal) already retried to `pending` → will succeed on next tick post-merge
- Bulk pipeline continues uninterrupted

## Discovery context

Discovered during live bulk processing 2026-05-18 07:13 WITA. Logged in queue row 47 last_error: `pydantic validation: 2 validation errors for L1ClientSummary / shareholders.0.role / Input should be 'Director', 'Commissioner', 'Shareholder' or 'Founder' [type=literal_error, input_value='DIREKTUR']`.

Related: PR #718 (Phase 1.5 OCR layer base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)