### PR TITLE
feat(mouth): Garuda UI redesign — ZantaraWidget + AppSidebar + nav cleanup

### DIFF
--- a/apps/mouth/src/app/(blog)/layout.tsx
+++ b/apps/mouth/src/app/(blog)/layout.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import Link from "next/link";
-import { NavShell, BZLogo, WhatsAppFAB } from "@balizero/core";
+import { NavShell, BZLogo } from "@balizero/core";
 import { ZantaraFAB } from "@/app/v2/_components/ZantaraFAB";
 import { Footer } from "@/app/v2/_components/Footer";
 import { I18nProvider } from "@/i18n";
@@ -52,7 +52,6 @@ export default function BlogLayout({ children }: { children: ReactNode }) {
         <main className="flex-1 pt-14">{children}</main>
         <Footer />
         <ZantaraFAB />
-        <WhatsAppFAB />
       </div>
     </I18nProvider>
   );

--- a/apps/mouth/src/app/(workspace)/layout.tsx
+++ b/apps/mouth/src/app/(workspace)/layout.tsx
@@ -10,7 +10,7 @@ import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
 import { ErrorBoundary } from "@/components/optimization";
 import { CellWidget } from "@/components/cell/CellWidget";
-import { WorkspaceAssistant } from "@/components/workspace/WorkspaceAssistant";
+import { ZantaraWidget } from "@/components/workspace/ZantaraWidget";
 import { KitaCommandPalette } from "@/components/workspace/KitaCommandPalette";
 import { I18nProvider } from "@/i18n";
 import { routeTitles } from "@/types/navigation";
@@ -36,6 +36,7 @@ export default function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
   const mobileSidebarRef = useRef<HTMLDivElement | null>(null);
   const mobileMenuToggleRef = useRef<HTMLButtonElement | null>(null);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [isZantaraOpen, setIsZantaraOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [user, setUser] = useState({
     name: "",
@@ -163,6 +164,18 @@ export default function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
 
   // isOnline status is now managed server-side (PANOPTICON)
 
+  // Cmd+J shortcut — toggle Zantara widget
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "j") {
+        e.preventDefault();
+        setIsZantaraOpen((p) => !p);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
   // Handle logout
   const handleLogout = async () => {
     try {
@@ -234,7 +247,8 @@ export default function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
         id="main-content"
         aria-busy="true"
         aria-live="polite"
-        className="min-h-screen flex items-center justify-center bg-transparent"
+        className="min-h-screen flex items-center justify-center"
+        style={{ background: "var(--bz-base, #0f1419)" }}
       >
         <div className="flex flex-col items-center gap-4">
           <div
@@ -255,7 +269,10 @@ export default function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
         <a href="#main-content" className="bz-skip-link">
           Skip to main content
         </a>
-        <div className="min-h-screen bg-transparent">
+        <div
+          className="min-h-screen"
+          style={{ background: "var(--bz-base, #0f1419)" }}
+        >
           {/* Desktop Sidebar — labelled landmark so AT can list it */}
           <div className="hidden md:block">
             <AppSidebar
@@ -263,6 +280,8 @@ export default function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
               unreadWhatsApp={0}
               onLogout={handleLogout}
               ariaLabel="Primary"
+              onZantaraToggle={() => setIsZantaraOpen((p) => !p)}
+              isZantaraOpen={isZantaraOpen}
             />
           </div>
 
@@ -286,6 +305,8 @@ export default function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
                   unreadWhatsApp={0}
                   onLogout={handleLogout}
                   ariaLabel="Primary (mobile)"
+                  onZantaraToggle={() => setIsZantaraOpen((p) => !p)}
+                  isZantaraOpen={isZantaraOpen}
                 />
               </div>
             </>
@@ -328,7 +349,10 @@ export default function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
           </div>
         </div>
         {!isTerminalPage && <CellWidget />}
-        {!isTerminalPage && <WorkspaceAssistant />}
+        <ZantaraWidget
+          open={isZantaraOpen}
+          onClose={() => setIsZantaraOpen(false)}
+        />
         <KitaCommandPalette />
       </ToastProvider>
     </I18nProvider>

--- a/apps/mouth/src/app/globals.css
+++ b/apps/mouth/src/app/globals.css
@@ -596,7 +596,11 @@ main,
   }
 
   .glass-panel-deep {
-    @apply bg-black/40 backdrop-blur-xl border border-white/5 shadow-[0_8px_32px_rgba(0,0,0,0.4)];
+    background: var(--bz-elevated, #1b222b);
+    backdrop-filter: blur(20px) saturate(1.2);
+    -webkit-backdrop-filter: blur(20px) saturate(1.2);
+    border-right: 1px solid var(--bz-border, rgba(255, 255, 255, 0.05));
+    box-shadow: 4px 0 24px rgba(0, 0, 0, 0.35);
   }
 
   .glass-card-warm {

--- a/apps/mouth/src/app/globals.css
+++ b/apps/mouth/src/app/globals.css
@@ -256,20 +256,20 @@
   --accent: var(--kbli-accent);
   --accent-hover: var(--kbli-accent-hover);
 
-  /* Warm Depth tokens (Legacy) */
-  --bz-base: #1d273b;
-  --bz-elevated: #243047;
-  --bz-surface: #2a3655;
-  --bz-card: #2a3655;
-  --bz-card-hover: #2f3d5e;
+  /* GARUDA — Proposal 3 (2026-05-18) */
+  --bz-base: #0f1419;
+  --bz-elevated: #1b222b;
+  --bz-surface: #28313d;
+  --bz-card: #2e3847;
+  --bz-card-hover: #35414f;
   --bz-accent: #d4845a;
   --bz-accent-hover: #bf7350;
   --bz-accent-warm: #c9a96e;
   --bz-accent-cool: #5e7fb5;
 
   /* God Tier Anthracite Tokens */
-  --anthracite-base: #1d273b;
-  --anthracite-elevated: #243047;
+  --anthracite-base: #0f1419;
+  --anthracite-elevated: #1b222b;
 
   /* Cinematic Border Tokens */
   --glass-highlight: rgba(255, 255, 255, 0.12);
@@ -290,17 +290,18 @@
   --neon-cyan: #06b6d4;
   --bz-copper: #d4845a;
 
-  /* Sidebar */
-  --sidebar-active-bg: rgba(212, 132, 90, 0.08);
-  --sidebar-active-border: rgba(212, 132, 90, 0.3);
+  /* Sidebar — GARUDA pill active */
+  --sidebar-active-bg: #d4845a;
+  --sidebar-active-border: transparent;
+  --sidebar-pill-radius: 12px;
 
   --bz-text-1: #edeae4;
-  --bz-text-2: #8c8884;
-  --bz-text-3: #575350;
-  --bz-border: rgba(255, 255, 255, 0.055);
+  --bz-text-2: #8a8f9a;
+  --bz-text-3: #545c6a;
+  --bz-border: rgba(255, 255, 255, 0.05);
   --bz-border-hover: rgba(255, 255, 255, 0.1);
   --bz-border-accent: rgba(201, 169, 110, 0.18);
-  --bz-green: #4db87a;
+  --bz-green: #3ecf8e;
   --bz-red: #d95f5a;
   --bz-amber: #d4923a;
   --success: #4db87a;
@@ -371,32 +372,52 @@ body {
   }
 }
 
-/* Subtle ambient gradients — God Tier Anthracite */
+/* Subtle ambient gradients — GARUDA */
 body::before {
   content: "";
   position: fixed;
   inset: -25vh -25vw;
   background:
     radial-gradient(
-      circle at 15% 30%,
-      rgba(59, 130, 246, 0.04) 0%,
-      transparent 40%
+      ellipse 60% 40% at 50% 0%,
+      rgba(212, 132, 90, 0.035) 0%,
+      transparent 55%
     ),
-    /* Blue */
     radial-gradient(
-        circle at 85% 70%,
-        rgba(139, 92, 246, 0.03) 0%,
-        transparent 50%
-      ),
-    /* Purple */
+      circle at 10% 60%,
+      rgba(30, 58, 90, 0.06) 0%,
+      transparent 45%
+    ),
     radial-gradient(
-        circle at 50% 10%,
-        rgba(212, 132, 90, 0.02) 0%,
-        transparent 40%
-      ); /* Copper top */
+      circle at 90% 40%,
+      rgba(15, 35, 60, 0.05) 0%,
+      transparent 40%
+    );
   pointer-events: none;
   z-index: 0;
   mix-blend-mode: color-dodge;
+}
+
+/* GARUDA KPI animations */
+@keyframes kpi-impact {
+  0% {
+    transform: scale(1);
+  }
+  40% {
+    transform: scale(1.14);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+.kpi-impact {
+  animation: kpi-impact 320ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+.garuda-kpi-bar {
+  height: 3px;
+  background: var(--bz-accent);
+  border-radius: 0 0 2px 2px;
+  transition: width 600ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 /* Noise texture overlay */

--- a/apps/mouth/src/app/layout.tsx
+++ b/apps/mouth/src/app/layout.tsx
@@ -12,7 +12,6 @@ import { QueryProvider } from "@/components/providers/QueryProvider";
 import { ErrorBoundary } from "@/components/optimization";
 import { WebVitalsMonitor } from "@/components/providers/WebVitalsMonitor";
 import { ThemeProvider } from "@balizero/core/components/ThemeProvider";
-import { WhatsAppFAB } from "@balizero/core/components/WhatsAppFAB";
 import { inter } from "@balizero/core/fonts/inter";
 import { cormorant } from "@balizero/core/fonts/cormorant";
 import { LazyToaster } from "@/components/providers/LazyToaster";
@@ -244,8 +243,6 @@ export default function RootLayout({
             >
               {children}
             </ErrorBoundary>
-            {/* Persistent WhatsApp FAB — visible on every page */}
-            <WhatsAppFAB />
           </ThemeProvider>
           <LazyToaster />
         </QueryProvider>

--- a/apps/mouth/src/components/workspace/AppSidebar.tsx
+++ b/apps/mouth/src/components/workspace/AppSidebar.tsx
@@ -1,9 +1,9 @@
-'use client';
+"use client";
 
-import React from 'react';
-import Link from 'next/link';
-import Image from 'next/image';
-import { usePathname } from 'next/navigation';
+import React from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { usePathname } from "next/navigation";
 import {
   Home,
   Inbox,
@@ -28,9 +28,15 @@ import {
   Banknote,
   Terminal,
   Handshake,
-} from 'lucide-react';
-import { navigation, portalNavigation, NavSection, NavItem } from '@/types/navigation';
-import { cn } from '@/lib/utils';
+  BotMessageSquare,
+} from "lucide-react";
+import {
+  navigation,
+  portalNavigation,
+  NavSection,
+  NavItem,
+} from "@/types/navigation";
+import { cn } from "@/lib/utils";
 
 // Icon mapping
 const iconMap: Record<string, React.ElementType> = {
@@ -55,6 +61,7 @@ const iconMap: Record<string, React.ElementType> = {
   Banknote,
   Terminal,
   Handshake,
+  BotMessageSquare,
 };
 
 interface AppSidebarProps {
@@ -72,6 +79,8 @@ interface AppSidebarProps {
   navigationConfig?: NavSection[];
   isPortal?: boolean;
   ariaLabel?: string;
+  onZantaraToggle?: () => void;
+  isZantaraOpen?: boolean;
 }
 
 export function AppSidebar({
@@ -80,14 +89,16 @@ export function AppSidebar({
   onLogout,
   navigationConfig,
   isPortal = false,
-  ariaLabel = 'Primary',
+  ariaLabel = "Primary",
+  onZantaraToggle,
+  isZantaraOpen = false,
 }: AppSidebarProps) {
   const pathname = usePathname();
   const nav = navigationConfig || navigation;
 
   const isActive = (href: string) => {
     if (!pathname) return false;
-    if (href === '/dashboard' || href === '/portal') {
+    if (href === "/dashboard" || href === "/portal") {
       return pathname === href;
     }
     return pathname.startsWith(href);
@@ -96,32 +107,45 @@ export function AppSidebar({
   const renderNavItem = (item: NavItem) => {
     const Icon = iconMap[item.icon] || Home;
     const active = isActive(item.href);
-    const badge = item.href === '/whatsapp' ? unreadWhatsApp : item.badge;
+    const badge = item.href === "/whatsapp" ? unreadWhatsApp : item.badge;
 
+    // GARUDA active: copper pill fill + white text, rounded-[12px]
     const sharedClassName = cn(
-      'flex items-center gap-2.5 px-2.5 py-[7px] rounded-[8px] mb-[2px] text-[11.5px] font-medium uppercase tracking-[0.5px] transition-all group',
-      active ? 'font-semibold' : 'hover:bg-[rgba(255,255,255,0.05)] hover:text-[var(--bz-text-1)]'
+      "flex items-center gap-2.5 px-2.5 py-[7px] rounded-[12px] mb-[2px] text-[11.5px] font-medium uppercase tracking-[0.5px] transition-all group",
+      active
+        ? "font-semibold"
+        : "hover:bg-[rgba(255,255,255,0.04)] hover:text-[var(--bz-text-1)]",
     );
     const sharedStyle = active
-      ? { background: 'rgba(212,132,90,0.12)', color: 'var(--bz-accent)' }
-      : { color: 'var(--bz-text-2)' };
+      ? { background: "var(--bz-accent)", color: "#fff" }
+      : { color: "var(--bz-text-2)" };
 
     const sharedContent = (
       <>
-        <Icon size={15} className="flex-shrink-0" style={{ opacity: active ? 1 : 0.7 }} />
+        <Icon
+          size={15}
+          className="flex-shrink-0"
+          style={{ opacity: active ? 1 : 0.65 }}
+        />
         <span className="flex-1 leading-relaxed">{item.title}</span>
         {item.external && (
-          <ExternalLink size={9} style={{ color: 'var(--bz-text-3)', opacity: 0.5 }} />
+          <ExternalLink
+            size={9}
+            style={{
+              color: active ? "rgba(255,255,255,0.5)" : "var(--bz-text-3)",
+              opacity: 0.5,
+            }}
+          />
         )}
         {badge && badge > 0 && (
           <span
             className="text-[8px] font-bold px-1.5 py-0.5 rounded-full"
             style={{
-              background: 'rgba(212,132,90,0.18)',
-              color: 'var(--bz-accent)',
+              background: "rgba(212,132,90,0.18)",
+              color: "var(--bz-accent)",
             }}
           >
-            {badge > 99 ? '99+' : badge}
+            {badge > 99 ? "99+" : badge}
           </span>
         )}
       </>
@@ -143,7 +167,12 @@ export function AppSidebar({
     }
 
     return (
-      <Link key={item.href} href={item.href} className={sharedClassName} style={sharedStyle}>
+      <Link
+        key={item.href}
+        href={item.href}
+        className={sharedClassName}
+        style={sharedStyle}
+      >
         {sharedContent}
       </Link>
     );
@@ -152,11 +181,10 @@ export function AppSidebar({
   const renderNavSection = (section: NavSection, index: number) => (
     <div key={index}>
       {section.title && (
-        // bz-text-2 (#8c8884 → ~5.0:1 on glass-panel-deep) without opacity
-        // multiplier — keeps the muted look while satisfying WCAG AA 4.5:1.
+        // More muted section headers — "structure felt not seen"
         <div
-          className="text-[8.5px] font-bold uppercase tracking-[1.2px] px-2.5 pt-4 pb-1.5"
-          style={{ color: 'var(--bz-text-2)' }}
+          className="text-[8px] font-semibold uppercase tracking-[1.2px] px-2.5 pt-4 pb-1.5"
+          style={{ color: "var(--bz-text-3)" }}
         >
           {section.title}
         </div>
@@ -171,17 +199,17 @@ export function AppSidebar({
       aria-label={ariaLabel}
       className="fixed left-0 top-0 z-40 h-screen flex flex-col border-r transition-all duration-300 glass-panel-deep"
       style={{
-        width: 'var(--bz-sidebar-width, 216px)',
-        borderColor: 'var(--bz-border)',
+        width: "var(--bz-sidebar-width, 216px)",
+        borderColor: "var(--bz-border)",
       }}
     >
-      {/* Logo Header — Centered, 2x scale */}
+      {/* Logo Header */}
       <div
         className="border-b flex items-center justify-center py-4 px-3"
-        style={{ borderColor: 'var(--bz-border)' }}
+        style={{ borderColor: "var(--bz-border)" }}
       >
         <Link
-          href={isPortal ? '/portal' : '/dashboard'}
+          href={isPortal ? "/portal" : "/dashboard"}
           aria-label="Bali Zero — workspace home"
           className="flex items-center justify-center transition-opacity hover:opacity-80"
         >
@@ -202,8 +230,40 @@ export function AppSidebar({
       </nav>
 
       {/* User Profile Footer */}
-      <div className="border-t p-2.5" style={{ borderColor: 'var(--bz-border)' }}>
-        <div className="flex items-center gap-2.5 px-1.5 py-1.5 rounded-lg hover:bg-[rgba(255,255,255,0.05)] cursor-pointer transition-colors">
+      <div
+        className="border-t p-2.5"
+        style={{ borderColor: "var(--bz-border)" }}
+      >
+        {/* Zantara toggle button */}
+        {onZantaraToggle && (
+          <button
+            onClick={onZantaraToggle}
+            className="flex items-center gap-2.5 w-full px-2.5 py-[7px] rounded-[12px] mb-1.5 text-[11.5px] font-medium uppercase tracking-[0.5px] transition-all"
+            style={{
+              color: isZantaraOpen ? "#fff" : "var(--bz-text-2)",
+              background: isZantaraOpen ? "var(--bz-accent)" : "transparent",
+            }}
+            aria-label="Toggle Zantara AI"
+          >
+            <BotMessageSquare
+              size={15}
+              className="flex-shrink-0"
+              style={{ opacity: isZantaraOpen ? 1 : 0.65 }}
+            />
+            <span className="flex-1 leading-relaxed text-left">Zantara</span>
+            <span
+              className="text-[8px] font-medium"
+              style={{
+                opacity: 0.5,
+                color: isZantaraOpen ? "#fff" : "var(--bz-text-3)",
+              }}
+            >
+              ⌘J
+            </span>
+          </button>
+        )}
+
+        <div className="flex items-center gap-2.5 px-1.5 py-1.5 rounded-lg hover:bg-[rgba(255,255,255,0.04)] cursor-pointer transition-colors">
           <div className="relative flex-shrink-0">
             {user.avatar ? (
               <Image
@@ -217,41 +277,50 @@ export function AppSidebar({
               <div
                 className="w-[28px] h-[28px] rounded-[8px] flex items-center justify-center text-[10px] font-bold text-white"
                 style={{
-                  background: 'linear-gradient(135deg, #c9a96e 0%, #d4845a 100%)',
+                  background:
+                    "linear-gradient(135deg, #c9a96e 0%, #d4845a 100%)",
                 }}
               >
-                {user.name?.[0]?.toUpperCase() || 'U'}
+                {user.name?.[0]?.toUpperCase() || "U"}
               </div>
             )}
           </div>
           <div className="flex-1 min-w-0">
             <div
               className="text-[11.5px] font-semibold uppercase tracking-[0.3px] truncate"
-              style={{ color: 'var(--bz-text-1)' }}
+              style={{ color: "var(--bz-text-1)" }}
             >
               {user.name}
             </div>
             <div
               className="text-[9.5px] uppercase tracking-[0.5px]"
-              style={{ color: 'var(--bz-text-2)' }}
+              style={{ color: "var(--bz-text-2)" }}
             >
-              {isPortal ? 'Client Portal' : user.role || user.team || 'Team'}
+              {isPortal ? "Client Portal" : user.role || user.team || "Team"}
             </div>
           </div>
           <div
             className="w-[7px] h-[7px] rounded-full flex-shrink-0"
             style={{
-              background: user.isOnline ? 'var(--bz-green)' : 'var(--bz-text-3)',
-              boxShadow: user.isOnline ? '0 0 6px rgba(77,184,122,0.45)' : 'none',
+              background: user.isOnline
+                ? "var(--bz-green)"
+                : "var(--bz-text-3)",
+              boxShadow: user.isOnline
+                ? "0 0 6px rgba(62,207,142,0.45)"
+                : "none",
             }}
           />
         </div>
         <button
           onClick={onLogout}
           className="flex items-center gap-2 w-full mt-1 px-2.5 py-1.5 text-[10px] font-medium uppercase tracking-[0.5px] rounded-lg transition-colors"
-          style={{ color: 'var(--bz-text-2)' }}
-          onMouseEnter={(e) => (e.currentTarget.style.color = 'var(--bz-text-1)')}
-          onMouseLeave={(e) => (e.currentTarget.style.color = 'var(--bz-text-2)')}
+          style={{ color: "var(--bz-text-2)" }}
+          onMouseEnter={(e) =>
+            (e.currentTarget.style.color = "var(--bz-text-1)")
+          }
+          onMouseLeave={(e) =>
+            (e.currentTarget.style.color = "var(--bz-text-2)")
+          }
         >
           <LogOut size={13} />
           <span>Logout</span>

--- a/apps/mouth/src/components/workspace/ZantaraWidget.tsx
+++ b/apps/mouth/src/components/workspace/ZantaraWidget.tsx
@@ -1,0 +1,363 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { X, Send, Loader2, SquareArrowOutUpRight } from "lucide-react";
+import dynamic from "next/dynamic";
+import { api } from "@/lib/api";
+import { sendChat } from "@/lib/gateway";
+import { TERMINAL_HANDOFF_KEY } from "@/components/terminal/types";
+
+const ReactMarkdown = dynamic(() => import("react-markdown"), { ssr: false });
+
+interface ChatMsg {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  isStreaming?: boolean;
+}
+
+interface ZantaraWidgetProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const genId = () => `z_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+
+export function ZantaraWidget({ open, onClose }: ZantaraWidgetProps) {
+  const pathname = usePathname();
+  const [messages, setMessages] = useState<ChatMsg[]>([]);
+  const [input, setInput] = useState("");
+  const [isStreaming, setIsStreaming] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  useEffect(() => {
+    if (open) setTimeout(() => inputRef.current?.focus(), 100);
+  }, [open]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && open) onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
+  const send = useCallback(async () => {
+    const text = input.trim();
+    if (!text || isStreaming) return;
+
+    setInput("");
+
+    const userMsg: ChatMsg = { id: genId(), role: "user", content: text };
+    const assistantMsg: ChatMsg = {
+      id: genId(),
+      role: "assistant",
+      content: "",
+      isStreaming: true,
+    };
+
+    setMessages((prev) => [...prev, userMsg, assistantMsg]);
+    setIsStreaming(true);
+
+    try {
+      const profile = api.getUserProfile();
+      const sessionId = profile?.id || "workspace-user";
+      const history = messages
+        .filter((m) => !m.isStreaming)
+        .map((m) => ({ role: m.role, content: m.content }));
+
+      const response = await sendChat({
+        query: text,
+        session_id: sessionId,
+        conversation_history: history,
+        workspace_page: pathname || undefined,
+      });
+
+      if (!response || !response.body) throw new Error("No response body");
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let accumulated = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        const chunk = decoder.decode(value, { stream: true });
+        const lines = chunk.split("\n");
+
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue;
+          const data = line.slice(6).trim();
+          if (data === "[DONE]") continue;
+
+          try {
+            const parsed = JSON.parse(data);
+            if (parsed.type === "token" && typeof parsed.data === "string") {
+              accumulated += parsed.data;
+              setMessages((prev) => {
+                const last = prev[prev.length - 1];
+                if (last?.role !== "assistant") return prev;
+                return [
+                  ...prev.slice(0, -1),
+                  { ...last, content: accumulated },
+                ];
+              });
+            } else if (parsed.type === "terminal_handoff" && parsed.data) {
+              try {
+                sessionStorage.setItem(
+                  TERMINAL_HANDOFF_KEY,
+                  JSON.stringify(parsed.data),
+                );
+              } catch {
+                // ignore storage errors
+              }
+            }
+          } catch {
+            // skip unparseable lines
+          }
+        }
+      }
+
+      setMessages((prev) => {
+        const last = prev[prev.length - 1];
+        if (last?.role !== "assistant") return prev;
+        return [
+          ...prev.slice(0, -1),
+          {
+            ...last,
+            content: accumulated || "Sorry, I couldn't respond. Try again!",
+            isStreaming: false,
+          },
+        ];
+      });
+    } catch {
+      setMessages((prev) => {
+        const last = prev[prev.length - 1];
+        if (last?.role !== "assistant") return prev;
+        return [
+          ...prev.slice(0, -1),
+          {
+            ...last,
+            content: "Connection issue. Please try again.",
+            isStreaming: false,
+          },
+        ];
+      });
+    } finally {
+      setIsStreaming(false);
+    }
+  }, [input, isStreaming, messages]);
+
+  if (!open) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-[60] bg-black/30 backdrop-blur-[2px]"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Panel */}
+      <div
+        className="fixed top-[10vh] right-0 z-[61] h-[80vh] w-[40vw] min-w-[340px] max-w-[640px] flex flex-col rounded-l-2xl overflow-hidden shadow-2xl"
+        style={{
+          background: "rgba(10,10,16,0.72)",
+          backdropFilter: "blur(28px) saturate(1.4)",
+          WebkitBackdropFilter: "blur(28px) saturate(1.4)",
+          border: "1px solid rgba(255,255,255,0.07)",
+          borderRight: "none",
+        }}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Zantara AI Assistant"
+      >
+        {/* Header */}
+        <div
+          className="flex items-center justify-between px-5 py-4 border-b"
+          style={{ borderColor: "rgba(255,255,255,0.07)" }}
+        >
+          <div className="flex items-center gap-3">
+            <Image
+              src="/static/balizero-logo-clean.png"
+              alt="Zantara"
+              width={28}
+              height={28}
+              className="rounded-full"
+            />
+            <div>
+              <p
+                className="text-[12px] font-semibold uppercase tracking-[0.5px]"
+                style={{ color: "var(--bz-text-1)" }}
+              >
+                Zantara
+              </p>
+              <p
+                className="text-[9px] uppercase tracking-[0.5px]"
+                style={{ color: "var(--bz-text-3)" }}
+              >
+                AI Assistant · Cmd+J
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Link
+              href="/terminal"
+              onClick={onClose}
+              className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-[10px] font-medium uppercase tracking-[0.4px] transition-colors hover:bg-white/05"
+              style={{ color: "var(--bz-text-3)" }}
+            >
+              <SquareArrowOutUpRight size={10} />
+              <span>Full Terminal</span>
+            </Link>
+            <button
+              onClick={onClose}
+              className="p-1.5 rounded-lg transition-colors hover:bg-white/05"
+              style={{ color: "var(--bz-text-3)" }}
+              aria-label="Close Zantara"
+            >
+              <X size={14} />
+            </button>
+          </div>
+        </div>
+
+        {/* Messages */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+          {messages.length === 0 && (
+            <div className="flex flex-col items-center justify-center h-full gap-3 text-center">
+              <p
+                className="text-[12px] font-medium"
+                style={{ color: "var(--bz-text-2)" }}
+              >
+                Ask Zantara anything about clients, cases, regulations…
+              </p>
+              <p className="text-[10px]" style={{ color: "var(--bz-text-3)" }}>
+                Cmd+J to toggle · Esc to close
+              </p>
+            </div>
+          )}
+          {messages.map((msg) => (
+            <div
+              key={msg.id}
+              className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
+            >
+              <div
+                className={`
+                  max-w-[85%] rounded-2xl px-4 py-3 text-[12.5px] leading-relaxed
+                  ${msg.role === "user" ? "" : ""}
+                  ${msg.isStreaming && !msg.content ? "animate-pulse" : ""}
+                `}
+                style={
+                  msg.role === "user"
+                    ? {
+                        background: "var(--bz-accent)",
+                        color: "#fff",
+                      }
+                    : {
+                        background: "rgba(255,255,255,0.05)",
+                        color: "var(--bz-text-1)",
+                        border: "1px solid rgba(255,255,255,0.06)",
+                      }
+                }
+              >
+                {msg.role === "user" ? (
+                  <p className="whitespace-pre-wrap">{msg.content}</p>
+                ) : msg.content ? (
+                  <div className="prose prose-invert prose-xs max-w-none prose-p:my-0.5 prose-headings:my-1 prose-ul:my-0.5 prose-li:my-0">
+                    <ReactMarkdown>{msg.content}</ReactMarkdown>
+                  </div>
+                ) : (
+                  <div className="flex gap-1 py-0.5">
+                    <span
+                      className="w-1.5 h-1.5 rounded-full animate-bounce"
+                      style={{
+                        background: "var(--bz-text-3)",
+                        animationDelay: "0ms",
+                      }}
+                    />
+                    <span
+                      className="w-1.5 h-1.5 rounded-full animate-bounce"
+                      style={{
+                        background: "var(--bz-text-3)",
+                        animationDelay: "150ms",
+                      }}
+                    />
+                    <span
+                      className="w-1.5 h-1.5 rounded-full animate-bounce"
+                      style={{
+                        background: "var(--bz-text-3)",
+                        animationDelay: "300ms",
+                      }}
+                    />
+                  </div>
+                )}
+                {msg.isStreaming && msg.content && (
+                  <span
+                    className="inline-block w-1 h-3.5 animate-pulse ml-0.5 align-text-bottom"
+                    style={{ background: "var(--bz-text-3)" }}
+                  />
+                )}
+              </div>
+            </div>
+          ))}
+          <div ref={bottomRef} />
+        </div>
+
+        {/* Input */}
+        <div
+          className="border-t px-4 py-3.5"
+          style={{ borderColor: "rgba(255,255,255,0.07)" }}
+        >
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              send();
+            }}
+            className="flex items-center gap-2.5"
+          >
+            <input
+              ref={inputRef}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="Ask anything…"
+              aria-label="Ask Zantara"
+              className="flex-1 rounded-xl px-4 py-2.5 text-[12.5px] focus:outline-none transition-all"
+              style={{
+                background: "rgba(255,255,255,0.05)",
+                border: "1px solid rgba(255,255,255,0.08)",
+                color: "var(--bz-text-1)",
+              }}
+              disabled={isStreaming}
+            />
+            <button
+              type="submit"
+              disabled={!input.trim() || isStreaming}
+              className="p-2.5 rounded-xl transition-all disabled:opacity-30"
+              style={{
+                background: "var(--bz-accent)",
+                color: "#fff",
+              }}
+              aria-label="Send message"
+            >
+              {isStreaming ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <Send size={14} />
+              )}
+            </button>
+          </form>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/mouth/src/types/navigation.ts
+++ b/apps/mouth/src/types/navigation.ts
@@ -37,16 +37,8 @@ export const navigation: NavSection[] = [
   {
     // Block 1: Core
     items: [
-      { title: "Inbox", href: "/inbox", icon: "Inbox" },
       { title: "Dashboard", href: "/dashboard", icon: "Home" },
-      { title: "Zantara Terminal", href: "/terminal", icon: "Terminal" },
       { title: "Intelligence Center", href: "/intelligence", icon: "Activity" },
-      {
-        title: "Zantara Public",
-        href: "https://zantara.balizero.com",
-        icon: "MessageSquare",
-        external: true,
-      },
     ],
   },
   {
@@ -55,8 +47,13 @@ export const navigation: NavSection[] = [
     items: [
       { title: "Clients", href: "/clients", icon: "Users" },
       { title: "Process", href: "/process", icon: "FolderKanban" },
-      { title: "Partners", href: "/partners", icon: "Handshake" },
       { title: "HR / Payroll", href: "/hr", icon: "Banknote" },
+    ],
+  },
+  {
+    title: "Kita-Space",
+    // Block 3: Collaborative
+    items: [
       { title: "LKPM", href: "/lkpm", icon: "ClipboardCheck" },
       {
         title: "Documents",
@@ -64,12 +61,7 @@ export const navigation: NavSection[] = [
         icon: "FolderOpen",
         external: true,
       },
-    ],
-  },
-  {
-    title: "Kita-Space",
-    // Block 3: Collaborative
-    items: [
+      { title: "Partners", href: "/partners", icon: "Handshake" },
       {
         title: "Email",
         href: "https://mail.balizero.com",
@@ -128,13 +120,11 @@ export const portalNavigation: NavSection[] = [
 
 // Route titles for breadcrumbs and page titles
 export const routeTitles: Record<string, string> = {
-  "/inbox": "Inbox",
   "/dashboard": "Dashboard",
   "/intelligence": "Intelligence Center",
   "/intelligence/visa-oracle": "Visa Oracle",
   "/intelligence/news-room": "News Room",
   "/intelligence/system-pulse": "System Pulse",
-  "/terminal": "Zantara Terminal",
   "/chat": "Zantara AI",
   "/whatsapp": "WhatsApp",
   "/clients": "Clients",


### PR DESCRIPTION
## Summary

- Garuda design system Proposal 3 (Sharp · Architectural · Power-Forward): copper pill active state, near-black blue-ish base (#0f1419), muted section headers
- **Restores `ZantaraWidget.tsx`** (363 LOC) that was missing from `origin/main` — `(workspace)/layout.tsx` imported it but file did not exist (build-broken state, TS2307 on workspace pages). Removes `WorkspaceAssistant` import + render in favor of ZantaraWidget.
- 80%h × 40%w glassmorphism panel slide-in, Cmd+J toggle, connected to `sendChat` gateway + TERMINAL_HANDOFF_KEY handoff
- Nav cleanup: removed Inbox/Zantara Terminal/Zantara Public; moved LKPM/Documents/Partners into Kita-Space section
- WhatsApp FAB removed from root + blog layouts

Carve-out of original commit `74ac43649` from `feat/kita-ui-refactor-2026-05-18` (mouth/ files only). The 2 WR3 backend files that were accidentally bundled via sibling-session drift ship separately in PR for `feat/wr3-eventbus-channels-2026-05-18`.

## Context — why this PR reverts PR #723 behavior

- PR #718 (2026-05-18 03:01) merged `(workspace)/layout.tsx` importing `ZantaraWidget` but file `ZantaraWidget.tsx` was NEVER committed → main broken since then
- PR #723 (2026-05-18 05:36) "fixed" by removing ZantaraWidget imports and reverting render to `<WorkspaceAssistant />`
- This PR is the **correct fix**: introduces the missing `ZantaraWidget.tsx`, restores its import + render, removes the now-superseded `WorkspaceAssistant`. Confirmed with Antonello: ZantaraWidget is the intended Garuda redesign widget.

## Test plan

- [ ] CI: typecheck + lint pass
- [ ] Vercel preview deploy → manual QA: `/dashboard` workspace renders without TS2307; Cmd+J toggles widget; backdrop click + Esc close; backdrop blur 28px visible
- [ ] Mobile: AppSidebar mobile overlay shows Zantara toggle button in footer
- [ ] Verify no WhatsApp FAB on `/blog/*` or root pages
- [ ] Send a test message through widget → streaming response + lipsync indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)