### PR TITLE
fix(crm): include company-level autowatcher dossiers

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -46,6 +46,8 @@ jobs:
       QDRANT_API_KEY: "test-not-real"
       OPENAI_API_KEY: "sk-test-not-real-do-not-use"
       JWT_SECRET: "test-jwt-secret-for-contract-tests-only-not-prod"
+      JWT_SECRET_KEY: "test-jwt-secret-key-for-contract-tests-min-32-chars"
+      API_KEYS: "test-contract-api-key-1,test-contract-api-key-2"
       # Skip side-effects on import
       SKIP_SENTRY_INIT: "1"
       SENTRY_TRACES_SAMPLE_RATE: "0.0"

--- a/apps/backend-rag/backend/services/crm/drive_autowatcher_service.py
+++ b/apps/backend-rag/backend/services/crm/drive_autowatcher_service.py
@@ -46,7 +46,7 @@ class DriveEvidenceDocument:
 
 @dataclass(frozen=True)
 class CompanyDriveEvidence:
-    """Person-first evidence bundle for one linked company."""
+    """Evidence bundle for one company, optionally anchored to active people."""
 
     company_id: int
     company_name: str
@@ -200,7 +200,6 @@ def build_workspace_ai_snapshot_payload(
 def _facts_from_evidence(
     evidence: CompanyDriveEvidence,
 ) -> list[TaxCompanyPilotWorkspaceAiFact]:
-    people = _human_join(evidence.people, fallback="the linked person")
     groups = _document_group_counts(evidence.documents)
     missing = _missing_groups(groups, evidence.kg_edge_count)
 
@@ -209,11 +208,18 @@ def _facts_from_evidence(
         f"indexed source document{'s' if len(evidence.documents) != 1 else ''} across "
         f"{_coverage_sentence(groups)}."
     )
-    person_detail = (
-        f"Start from {people}; then read {evidence.company_name} through the confirmed "
-        "CRM relationship, connecting roles, residency, and tax ownership before any "
-        "client-facing use."
-    )
+    if evidence.people:
+        people = _human_join(evidence.people, fallback="the linked person")
+        person_detail = (
+            f"Start from {people}; then read {evidence.company_name} through the confirmed "
+            "CRM relationship, connecting roles, residency, and tax ownership before any "
+            "client-facing use."
+        )
+    else:
+        person_detail = (
+            f"Read {evidence.company_name} as a company-level dossier. Link active "
+            "individual profiles before person-first publication."
+        )
     compliance_detail = (
         f"The tax posture is visible at evidence level: {_coverage_sentence(groups)}. "
         f"Tax owner: {evidence.tax_owner}. Treat this as an internal consultant reading, "
@@ -291,8 +297,10 @@ def _evidence_from_rows(rows: list[Any]) -> list[CompanyDriveEvidence]:
                 "kg_edge_count": 0,
             },
         )
-        bucket["client_ids"].add(int(data["client_id"]))
-        _append_unique(bucket["people"], str(data["client_name"]))
+        if data.get("client_id") is not None:
+            bucket["client_ids"].add(int(data["client_id"]))
+        if data.get("client_name"):
+            _append_unique(bucket["people"], str(data["client_name"]))
         if data.get("tax_owner"):
             _append_unique(bucket["tax_owners"], str(data["tax_owner"]))
         if data.get("file_id"):
@@ -472,6 +480,23 @@ WITH linked_people AS (
     WHERE cl.deleted_at IS NULL
       AND ($1::int IS NULL OR cl.id = $1::int)
 ),
+company_document_scope AS (
+    SELECT
+        co.id AS company_id,
+        co.company_name
+    FROM companies co
+    JOIN company_documents cd ON cd.company_id = co.id
+    WHERE $1::int IS NULL
+      AND cd.google_drive_file_id IS NOT NULL
+      AND cd.google_drive_file_id <> ''
+      AND COALESCE(cd.status, 'active') <> 'deleted'
+      AND COALESCE(co.status, 'active') <> 'deleted'
+      AND NOT EXISTS (
+          SELECT 1
+          FROM linked_people lp
+          WHERE lp.company_id = co.id
+      )
+),
 company_scope AS (
     SELECT
         base.company_id,
@@ -499,6 +524,13 @@ company_scope AS (
         WHERE cd.google_drive_file_id IS NOT NULL
           AND cd.google_drive_file_id <> ''
           AND COALESCE(cd.status, 'active') <> 'deleted'
+
+        UNION
+
+        SELECT
+            cds.company_id,
+            cds.company_name
+        FROM company_document_scope cds
     ) base
     LEFT JOIN crm_workspace_ai_snapshots snap
         ON snap.company_id = base.company_id
@@ -557,6 +589,36 @@ evidence_rows AS (
     WHERE cd.google_drive_file_id IS NOT NULL
       AND cd.google_drive_file_id <> ''
       AND COALESCE(cd.status, 'active') <> 'deleted'
+
+    UNION ALL
+
+    SELECT
+        scope.company_id,
+        scope.company_name,
+        NULL::int AS client_id,
+        NULL::text AS client_name,
+        ''::text AS tax_owner,
+        cd.google_drive_file_id AS file_id,
+        cd.file_name,
+        cd.document_type,
+        COALESCE(cd.document_subtype, 'company') AS document_category,
+        NULL::text AS ocr_status,
+        kg.entity_id IS NOT NULL AS has_kg_node,
+        kg.entity_id AS kg_entity_id
+    FROM company_scope scope
+    JOIN company_documents cd ON cd.company_id = scope.company_id
+    LEFT JOIN crm_kg_nodes kg
+        ON kg.file_id = cd.google_drive_file_id
+        AND kg.entity_type = 'crm_document'
+        AND kg.deleted_at IS NULL
+    WHERE cd.google_drive_file_id IS NOT NULL
+      AND cd.google_drive_file_id <> ''
+      AND COALESCE(cd.status, 'active') <> 'deleted'
+      AND NOT EXISTS (
+          SELECT 1
+          FROM linked_people lp
+          WHERE lp.company_id = scope.company_id
+      )
 ),
 kg_counts AS (
     SELECT

--- a/apps/backend-rag/backend/tests/services/crm/test_drive_autowatcher_service.py
+++ b/apps/backend-rag/backend/tests/services/crm/test_drive_autowatcher_service.py
@@ -308,6 +308,50 @@ def test_story_draft_payload_frames_consultant_narrative_and_prompts() -> None:
     assert "drive.google.com" not in all_details
 
 
+def test_story_draft_payload_handles_company_level_dossier_without_active_people() -> None:
+    from backend.services.crm.drive_autowatcher_service import (
+        CompanyDriveEvidence,
+        DriveEvidenceDocument,
+        build_workspace_ai_snapshot_payload,
+    )
+
+    payload = build_workspace_ai_snapshot_payload(
+        CompanyDriveEvidence(
+            company_id=3317,
+            company_name="PT Bali Budu Group",
+            client_ids=[],
+            people=[],
+            tax_owner="Unassigned",
+            documents=[
+                DriveEvidenceDocument(
+                    file_id="profile",
+                    file_name="Profil Perseroan.pdf",
+                    document_type="company_profile",
+                    document_category="company",
+                    ocr_status="completed",
+                    has_kg_node=True,
+                ),
+                DriveEvidenceDocument(
+                    file_id="lease",
+                    file_name="PERJANJIAN SEWA MENYEWA - PT Bali Budu Group.pdf",
+                    document_type="lease",
+                    document_category="company",
+                    ocr_status="skipped",
+                    has_kg_node=False,
+                ),
+            ],
+            kg_edge_count=0,
+        )
+    )
+
+    details_by_category = {fact.category: fact.detail for fact in payload.facts}
+    assert payload.client_id is None
+    assert "company-level dossier" in details_by_category["person"]
+    assert "active individual profiles" in details_by_category["person"]
+    assert "the linked person" not in details_by_category["person"]
+    assert "confirmed CRM relationship" not in details_by_category["person"]
+
+
 def test_evidence_query_prioritizes_companies_without_autowatcher_drafts() -> None:
     from backend.services.crm import drive_autowatcher_service
 
@@ -318,6 +362,8 @@ def test_evidence_query_prioritizes_companies_without_autowatcher_drafts() -> No
     assert "ORDER BY has_autowatcher_snapshot ASC" in sql
     assert "company_documents" in sql
     assert "google_drive_file_id" in sql
+    assert "company_document_scope" in sql
+    assert "NULL::int AS client_id" in sql
 
 
 def test_evidence_rows_dedupe_company_documents_across_linked_people() -> None:
@@ -360,3 +406,35 @@ def test_evidence_rows_dedupe_company_documents_across_linked_people() -> None:
     assert evidence[0].client_ids == [146, 176]
     assert evidence[0].people == ["Michele Porinelli", "Francesca rizzo"]
     assert [document.file_id for document in evidence[0].documents] == ["company-drive-file"]
+
+
+def test_evidence_rows_support_company_level_documents_without_active_people() -> None:
+    from backend.services.crm.drive_autowatcher_service import _evidence_from_rows
+
+    evidence = _evidence_from_rows(
+        [
+            {
+                "company_id": 3317,
+                "company_name": "PT Bali Budu Group",
+                "client_id": None,
+                "client_name": None,
+                "tax_owner": None,
+                "file_id": "bali-budu-profile",
+                "file_name": "Profil Perseroan.pdf",
+                "document_type": "company_profile",
+                "document_category": "company",
+                "ocr_status": "completed",
+                "has_kg_node": True,
+                "kg_edge_count": 0,
+            }
+        ]
+    )
+
+    assert len(evidence) == 1
+    assert evidence[0].company_id == 3317
+    assert evidence[0].client_ids == []
+    assert evidence[0].people == []
+    assert evidence[0].tax_owner == "Unassigned"
+    assert [document.file_id for document in evidence[0].documents] == [
+        "bali-budu-profile"
+    ]


### PR DESCRIPTION
## Summary
- include active company documents even when no active linked person exists
- generate a company-level consultant narrative frame instead of pretending there is a linked person
- keep approved/story payloads client-safe: no raw Drive URLs, no person leak, client_id remains null when unknown

## Verification
- PYTHONPATH=. python -m pytest backend/tests/services/crm/test_drive_autowatcher_service.py -q
- PYTHONPATH=. python -m pytest backend/tests/services/crm/test_drive_autowatcher_service.py backend/tests/services/crm/test_workspace_ai_snapshots.py -q
- PYTHONPATH=. python -m pytest backend/tests/services/rag/test_kg_langgraph.py backend/tests/services/rag/test_kg_subgraphs.py backend/tests/services/rag/test_confidence.py -q
- PYTHONPATH=. ruff check backend/services/crm/drive_autowatcher_service.py backend/tests/services/crm/test_drive_autowatcher_service.py
- python -c "from backend.app.dependencies import get_current_user; print('OK')"
- live read-only DB probe via localhost:15432 confirmed PT Bali Budu Group appears as company-level evidence candidate with 7 docs