### PR TITLE
feat(crm-guardian): Phase 1.6 tax-dept federation — 3rd cross-folder source

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/182_companies_tax_dept_folder.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/182_companies_tax_dept_folder.sql
@@ -1,0 +1,83 @@
+-- ============================================================
+-- 182_companies_tax_dept_folder.sql
+-- CRM-Guardian Phase 1.6 — tax-dept folder linkage
+--
+-- The Bali Zero tax department maintains a SHARED Drive structure
+-- (`Members/<TeamMember>/<COMPANY_NAME>/`) holding SPT/PPN/PPh/LKPM
+-- documents that are NOT in the cliente canonical folder NOR in the
+-- linked company's `companies.google_drive_folder_id`.
+--
+-- Discovery script `crm_guardian_tax_dept_discovery.py` ran 2026-05-18
+-- and matched 20 tax-dept company folders to existing `companies` rows
+-- via 3-tier fuzzy match (T3 Levenshtein <= 3 on normalized names).
+-- This migration adds the column the worker reads as its 3rd source
+-- alongside cliente root + companies.google_drive_folder_id.
+--
+-- After the writer script applies (separate PR), the worker will
+-- include tax-dept folder content automatically: same aggregation,
+-- same OCR cache, same prompt — just one more `source_folder_id` in
+-- the inventory.
+--
+-- Depends on:
+--   181_crm_guardian_file_content_cache.sql (Phase 1.5 OCR cache base)
+-- Decision memo:
+--   research/crm-guardian/2026-05-18-phase-1.5-ocr-layer-plan.md
+--   (Phase 1.6 section to be added; see MOS decision 2026-05-18)
+-- ============================================================
+
+ALTER TABLE companies
+    ADD COLUMN IF NOT EXISTS tax_dept_folder_id TEXT;
+
+COMMENT ON COLUMN companies.tax_dept_folder_id IS
+  'Phase 1.6 (2026-05-18): Drive folder ID inside Members/<TeamMember>/<COMPANY>/ '
+  'in the tax department shared Drive. NULL when the company has no tax-dept '
+  'entry (most companies). Populated by scripts/crm_guardian_tax_dept_apply.py '
+  'from a discovery report. Worker reads it as 3rd cross-folder source.';
+
+CREATE INDEX IF NOT EXISTS ix_companies_tax_dept_folder
+    ON companies (tax_dept_folder_id)
+    WHERE tax_dept_folder_id IS NOT NULL;
+
+-- Audit
+INSERT INTO crm_guardian_events (
+    invariant_id, action, target_type, target_id, client_id,
+    before_state, after_state, status, dry_run
+)
+VALUES (
+    'I10_summary_l1',
+    'enable_phase1.6_tax_dept_folder_column',
+    'system',
+    'companies.tax_dept_folder_id',
+    NULL,
+    jsonb_build_object('column_exists', false),
+    jsonb_build_object(
+        'column_exists', true,
+        'migration', '182_companies_tax_dept_folder',
+        'note', 'Phase 1.6 schema extension. Writer apply step + worker patch follow.'
+    ),
+    'success',
+    false
+);
+
+-- === ROLLBACK ===
+-- Drop the column. tax-dept folder data, if populated, is lost — recoverable
+-- by re-running the discovery script and writer.
+
+DROP INDEX IF EXISTS ix_companies_tax_dept_folder;
+ALTER TABLE companies DROP COLUMN IF EXISTS tax_dept_folder_id;
+
+INSERT INTO crm_guardian_events (
+    invariant_id, action, target_type, target_id, client_id,
+    before_state, after_state, status, dry_run
+)
+VALUES (
+    'I10_summary_l1',
+    'disable_phase1.6_tax_dept_folder_column',
+    'system',
+    'companies.tax_dept_folder_id',
+    NULL,
+    jsonb_build_object('column_exists', true),
+    jsonb_build_object('column_exists', false, 'migration', '182_companies_tax_dept_folder', 'rolled_back', true),
+    'success',
+    false
+);

--- a/scripts/crm_guardian_gemini_cli_worker.py
+++ b/scripts/crm_guardian_gemini_cli_worker.py
@@ -157,7 +157,15 @@ async def fetch_client(conn, client_id: int) -> dict[str, Any] | None:
 
 
 async def fetch_linked_companies(conn, client_id: int) -> list[dict[str, Any]]:
-    """Active company links for this client with their Drive folder ID."""
+    """Active company links for this client with their Drive folder ID(s).
+
+    Phase 1.5 (2026-05-18): also returns `tax_dept_folder_id` (migration 182,
+    populated by scripts/crm_guardian_tax_dept_apply.py). The tax-dept folder
+    is the Bali Zero shared 'Members/<TeamMember>/<COMPANY>/' Drive area
+    that holds SPT/PPN/PPh/LKPM filings outside the cliente canonical folder.
+    Worker treats it as a 3rd source in aggregate_cross_folder_files when
+    populated (NULL on most companies = same behavior as before).
+    """
     rows = await conn.fetch(
         """
         SELECT
@@ -165,12 +173,13 @@ async def fetch_linked_companies(conn, client_id: int) -> list[dict[str, Any]]:
             ccl.role,
             ccl.is_primary,
             c.company_name,
-            c.google_drive_folder_id
+            c.google_drive_folder_id,
+            c.tax_dept_folder_id
         FROM client_company_links ccl
         JOIN companies c ON c.id = ccl.company_id
         WHERE ccl.client_id = $1
           AND ccl.status = 'active'
-          AND c.google_drive_folder_id IS NOT NULL
+          AND (c.google_drive_folder_id IS NOT NULL OR c.tax_dept_folder_id IS NOT NULL)
         ORDER BY ccl.is_primary DESC, ccl.id ASC
         """,
         client_id,
@@ -290,20 +299,43 @@ async def aggregate_cross_folder_files(
 
     for company in linked_companies:
         cf_id = company.get("google_drive_folder_id")
-        if not cf_id:
-            continue
-        try:
-            cf_files = await list_drive_files(drive_service, cf_id)
-            for f in cf_files:
-                f["source_folder_id"] = cf_id
-            flat_files.extend(cf_files)
-            folder_id_to_name[cf_id] = company.get("company_name") or cf_id
-        except Exception as e:
-            LOG.warning(
-                "company folder %s (%s) aggregation failed: %s",
-                cf_id, company.get("company_name"), e,
-            )
-            continue
+        if cf_id:
+            try:
+                cf_files = await list_drive_files(drive_service, cf_id)
+                for f in cf_files:
+                    f["source_folder_id"] = cf_id
+                flat_files.extend(cf_files)
+                folder_id_to_name[cf_id] = company.get("company_name") or cf_id
+            except Exception as e:
+                LOG.warning(
+                    "company folder %s (%s) aggregation failed: %s",
+                    cf_id, company.get("company_name"), e,
+                )
+
+        # Phase 1.6 (2026-05-18): third source — tax department shared folder
+        # (Members/<TeamMember>/<COMPANY>/) populated via migration 182 +
+        # scripts/crm_guardian_tax_dept_apply.py. Holds SPT/PPN/PPh/LKPM that
+        # don't live in the cliente canonical folder nor the company corporate
+        # folder.
+        tax_id = company.get("tax_dept_folder_id")
+        if tax_id:
+            try:
+                tax_files = await list_drive_files(drive_service, tax_id)
+                for f in tax_files:
+                    f["source_folder_id"] = tax_id
+                flat_files.extend(tax_files)
+                folder_id_to_name[tax_id] = (
+                    f"{company.get('company_name') or 'unknown'} (Tax Dept)"
+                )
+                LOG.info(
+                    "tax-dept folder for company %s: +%d files",
+                    company.get("company_name"), len(tax_files),
+                )
+            except Exception as e:
+                LOG.warning(
+                    "tax-dept folder %s (%s) aggregation failed: %s",
+                    tax_id, company.get("company_name"), e,
+                )
 
     return flat_files, folder_id_to_name
 

--- a/scripts/crm_guardian_tax_dept_apply.py
+++ b/scripts/crm_guardian_tax_dept_apply.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Tax Department Federator — APPLY (writes companies.tax_dept_folder_id).
+
+Reads a discovery report JSON produced by
+`crm_guardian_tax_dept_discovery.py` and populates the
+`companies.tax_dept_folder_id` column for matched entries.
+
+Behavior:
+  - Only writes when the column is currently NULL OR --force is passed
+  - Skips matches with edit_distance > MAX_EDIT_DISTANCE (default 3)
+  - Optionally restricts to a specific match tier
+  - Idempotent: re-running with same report = no-op
+
+Side effect (cascade):
+  After apply, the next crm_guardian_gemini_cli_worker tick processes
+  the affected client and the worker's fetch_linked_companies extension
+  (Phase 1.6 patch) reads tax_dept_folder_id as a 3rd source folder.
+
+Usage:
+    # Dry-run preview (read-only):
+    python scripts/crm_guardian_tax_dept_apply.py --report <latest> --dry-run
+
+    # Apply (writes companies.tax_dept_folder_id):
+    python scripts/crm_guardian_tax_dept_apply.py --report <latest>
+
+    # Force overwrite existing values:
+    python scripts/crm_guardian_tax_dept_apply.py --report <latest> --force
+
+If --report is omitted, uses the most recent discovery JSON in
+~/.crm_guardian/tax_dept_discovery_*.json
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BACKEND_RAG = REPO_ROOT / "apps" / "backend-rag"
+sys.path.insert(0, str(BACKEND_RAG))
+
+import asyncpg
+
+LOG = logging.getLogger("tax_dept_apply")
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+
+REPORTS_DIR = Path.home() / ".crm_guardian"
+MAX_EDIT_DISTANCE_ACCEPTED = 3
+
+
+def _resolve_db_url() -> str:
+    secrets = Path.home() / ".nuzantara-secrets.env"
+    for line in secrets.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("DATABASE_URL_LOCAL="):
+            return stripped.split("=", 1)[1].strip('"').strip("'")
+    raise RuntimeError("DATABASE_URL_LOCAL not found")
+
+
+def _find_latest_report() -> Path:
+    candidates = sorted(
+        REPORTS_DIR.glob("tax_dept_discovery_*.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    if not candidates:
+        raise RuntimeError(f"No discovery report found in {REPORTS_DIR}")
+    return candidates[0]
+
+
+async def apply_report(
+    report_path: Path,
+    *,
+    dry_run: bool,
+    force: bool,
+    accepted_tiers: set[str],
+    max_distance: int,
+) -> dict[str, Any]:
+    report = json.loads(report_path.read_text())
+    matches = report.get("matched", [])
+    LOG.info(
+        "loaded %d matched entries from %s (run %s)",
+        len(matches),
+        report_path.name,
+        report.get("started_at", "?"),
+    )
+
+    db_url = _resolve_db_url()
+    conn = await asyncpg.connect(db_url)
+
+    counters = {
+        "inserted": 0,
+        "already_set_same": 0,
+        "overwritten": 0,
+        "skipped_already_set_different": 0,
+        "skipped_tier": 0,
+        "skipped_distance": 0,
+        "skipped_no_clients": 0,
+        "errors": 0,
+    }
+    actions: list[dict[str, Any]] = []
+
+    try:
+        for m in matches:
+            tier = m.get("match_tier")
+            dist = m.get("edit_distance") or 0
+            company_id = m.get("matched_company_id")
+            company_name = m.get("matched_company_name")
+            folder_id = m.get("company_folder_id")
+            folder_name = m.get("company_folder_name")
+            clients_count = m.get("linked_clients_count", 0)
+
+            if tier not in accepted_tiers:
+                counters["skipped_tier"] += 1
+                actions.append({"action": "skip_tier", "company_id": company_id, "tier": tier})
+                continue
+            if dist > max_distance:
+                counters["skipped_distance"] += 1
+                actions.append({"action": "skip_distance", "company_id": company_id, "distance": dist})
+                continue
+            if clients_count == 0:
+                counters["skipped_no_clients"] += 1
+                actions.append({
+                    "action": "skip_no_clients",
+                    "company_id": company_id,
+                    "company_name": company_name,
+                    "folder_name": folder_name,
+                })
+                continue
+
+            # Read current value
+            row = await conn.fetchrow(
+                "SELECT tax_dept_folder_id FROM companies WHERE id=$1",
+                company_id,
+            )
+            if row is None:
+                LOG.warning("company_id %s not found in DB", company_id)
+                counters["errors"] += 1
+                continue
+            current = row["tax_dept_folder_id"]
+
+            if current == folder_id:
+                counters["already_set_same"] += 1
+                actions.append({
+                    "action": "already_set_same",
+                    "company_id": company_id,
+                    "folder_id": folder_id,
+                })
+                continue
+            if current is not None and not force:
+                counters["skipped_already_set_different"] += 1
+                actions.append({
+                    "action": "skip_already_set_different",
+                    "company_id": company_id,
+                    "current": current,
+                    "would_set": folder_id,
+                })
+                continue
+
+            if dry_run:
+                action_label = "would_overwrite" if current is not None else "would_insert"
+                if current is not None:
+                    counters["overwritten"] += 1
+                else:
+                    counters["inserted"] += 1
+                actions.append({
+                    "action": action_label,
+                    "company_id": company_id,
+                    "company_name": company_name,
+                    "folder_name": folder_name,
+                    "folder_id": folder_id,
+                    "previous": current,
+                    "clients_count": clients_count,
+                })
+                continue
+
+            # Real write
+            await conn.execute(
+                "UPDATE companies SET tax_dept_folder_id=$1 WHERE id=$2",
+                folder_id,
+                company_id,
+            )
+            if current is None:
+                counters["inserted"] += 1
+                actions.append({
+                    "action": "inserted",
+                    "company_id": company_id,
+                    "company_name": company_name,
+                    "folder_id": folder_id,
+                    "clients_count": clients_count,
+                })
+                LOG.info(
+                    "  INSERT company_id=%s '%s' → tax_dept_folder_id=%s (clients=%d)",
+                    company_id, company_name, folder_id, clients_count,
+                )
+            else:
+                counters["overwritten"] += 1
+                actions.append({
+                    "action": "overwritten",
+                    "company_id": company_id,
+                    "previous": current,
+                    "folder_id": folder_id,
+                })
+                LOG.info(
+                    "  OVERWRITE company_id=%s '%s' (was %s → now %s)",
+                    company_id, company_name, current, folder_id,
+                )
+    finally:
+        await conn.close()
+
+    return {
+        "report_path": str(report_path),
+        "executed_at": datetime.now(timezone.utc).isoformat(),
+        "dry_run": dry_run,
+        "force": force,
+        "accepted_tiers": sorted(accepted_tiers),
+        "max_distance": max_distance,
+        "counters": counters,
+        "actions": actions,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--report", type=Path, default=None,
+                    help="Discovery report JSON (default: most recent in ~/.crm_guardian/)")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Preview only — no DB writes")
+    ap.add_argument("--force", action="store_true",
+                    help="Overwrite existing tax_dept_folder_id values")
+    ap.add_argument("--tier", action="append", default=None,
+                    help="Accept only these tiers (default: T1_exact + T2_normalized + T3_fuzzy)")
+    ap.add_argument("--max-distance", type=int, default=MAX_EDIT_DISTANCE_ACCEPTED,
+                    help="Max Levenshtein distance for T3 matches (default 3)")
+    args = ap.parse_args()
+
+    report_path = args.report or _find_latest_report()
+    accepted_tiers = set(args.tier) if args.tier else {"T1_exact", "T2_normalized", "T3_fuzzy"}
+
+    audit = asyncio.run(apply_report(
+        report_path=report_path,
+        dry_run=args.dry_run,
+        force=args.force,
+        accepted_tiers=accepted_tiers,
+        max_distance=args.max_distance,
+    ))
+
+    # Write audit log
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = REPORTS_DIR / f"tax_dept_apply_{ts}.json"
+    out.write_text(json.dumps(audit, indent=2, default=str))
+
+    cnt = audit["counters"]
+    print()
+    print(f"  Tax-dept apply — {audit['executed_at']}")
+    print(f"  -------------------------------------")
+    print(f"  report             : {Path(audit['report_path']).name}")
+    print(f"  dry_run            : {audit['dry_run']}")
+    print(f"  force              : {audit['force']}")
+    print(f"  accepted_tiers     : {audit['accepted_tiers']}")
+    print(f"  max_distance       : {audit['max_distance']}")
+    print()
+    print(f"  inserted                       : {cnt['inserted']}")
+    print(f"  overwritten                    : {cnt['overwritten']}")
+    print(f"  already_set_same               : {cnt['already_set_same']}")
+    print(f"  skipped_already_set_different  : {cnt['skipped_already_set_different']}")
+    print(f"  skipped_tier                   : {cnt['skipped_tier']}")
+    print(f"  skipped_distance               : {cnt['skipped_distance']}")
+    print(f"  skipped_no_clients             : {cnt['skipped_no_clients']}")
+    print(f"  errors                         : {cnt['errors']}")
+    print()
+    print(f"  audit              : {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/crm_guardian_tax_dept_discovery.py
+++ b/scripts/crm_guardian_tax_dept_discovery.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""Tax Department Federator — DISCOVERY (read-only).
+
+Walks the Bali Zero tax-dept Drive structure:
+  Members/<TeamMember>/[shortcut→]<TeamMember>/<COMPANY_NAME>/...
+
+For each <COMPANY_NAME> folder found, attempts a 3-tier match against
+the `companies` table:
+
+  T1. exact `companies.company_name` match (case-insensitive trim)
+  T2. normalized match (strip "PT", uppercase, drop punctuation)
+  T3. Levenshtein distance <= 3 fuzzy match
+
+For matched companies, resolves linked clients via
+`client_company_links.status='active'`.
+
+Output:
+  ~/.crm_guardian/tax_dept_discovery_<ts>.json    — full structured report
+  stdout                                          — terse human summary
+
+NO Drive writes. NO DB writes. Pure read + report.
+
+Run once via `python scripts/crm_guardian_tax_dept_discovery.py`. The
+follow-up writer script (separate file) will consume the matched_company
+ids from this report.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BACKEND_RAG = REPO_ROOT / "apps" / "backend-rag"
+sys.path.insert(0, str(BACKEND_RAG))
+
+import asyncpg
+from backend.services.crm_guardian.base import build_drive_service
+
+LOG = logging.getLogger("tax_dept_discovery")
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+
+TAX_DEPT_ROOT = "1QkFxr9rwtyIxIf7XaVNi6ehmxIMrWO2S"
+SHORTCUT_MIME = "application/vnd.google-apps.shortcut"
+FOLDER_MIME = "application/vnd.google-apps.folder"
+
+OUT_DIR = Path.home() / ".crm_guardian"
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_db_url() -> str:
+    secrets = Path.home() / ".nuzantara-secrets.env"
+    for line in secrets.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("DATABASE_URL_LOCAL="):
+            return stripped.split("=", 1)[1].strip('"').strip("'")
+    raise RuntimeError("DATABASE_URL_LOCAL not found")
+
+
+async def fetch_all_companies(conn) -> list[dict[str, Any]]:
+    rows = await conn.fetch(
+        """
+        SELECT id, company_name, google_drive_folder_id, npwp_company
+        FROM companies
+        """
+    )
+    return [dict(r) for r in rows]
+
+
+async def fetch_clients_for_company(conn, company_id: int) -> list[dict[str, Any]]:
+    rows = await conn.fetch(
+        """
+        SELECT c.id, c.full_name, c.google_drive_folder_id, ccl.role, ccl.is_primary
+        FROM client_company_links ccl
+        JOIN clients c ON c.id = ccl.client_id
+        WHERE ccl.company_id = $1 AND ccl.status = 'active'
+        ORDER BY ccl.is_primary DESC, c.id ASC
+        """,
+        company_id,
+    )
+    return [dict(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Drive walkers
+# ---------------------------------------------------------------------------
+
+def list_children(drive, folder_id: str) -> list[dict[str, Any]]:
+    """Page through direct children of a Drive folder."""
+    out: list[dict[str, Any]] = []
+    page_token: str | None = None
+    while True:
+        resp = drive.files().list(
+            q=f"'{folder_id}' in parents and trashed=false",
+            fields=(
+                "nextPageToken, files(id,name,mimeType,size,modifiedTime,"
+                "shortcutDetails)"
+            ),
+            pageSize=200,
+            pageToken=page_token,
+            supportsAllDrives=True,
+            includeItemsFromAllDrives=True,
+        ).execute()
+        out.extend(resp.get("files", []))
+        page_token = resp.get("nextPageToken")
+        if not page_token:
+            break
+    return out
+
+
+def resolve_shortcut(drive, file_meta: dict[str, Any]) -> tuple[str, str] | None:
+    """Return (target_id, target_mime) for a shortcut, or None."""
+    details = file_meta.get("shortcutDetails") or {}
+    target_id = details.get("targetId")
+    target_mime = details.get("targetMimeType")
+    if not target_id:
+        return None
+    return target_id, target_mime or ""
+
+
+def walk_tax_dept(drive) -> list[dict[str, Any]]:
+    """Walk Members/<TeamMember>/[shortcut→]<TeamMember>/<COMPANY>/...
+
+    Returns flat list of {team_member, company_folder_id, company_folder_name,
+                          file_count, sample_filenames[]}.
+    """
+    findings: list[dict[str, Any]] = []
+    members = list_children(drive, TAX_DEPT_ROOT)
+    LOG.info("tax-dept root has %d team-member entries", len(members))
+
+    for member in members:
+        if member["mimeType"] != FOLDER_MIME:
+            continue
+        team_member_name = member["name"]
+        team_member_folder_id = member["id"]
+        LOG.info("scanning team member: %s", team_member_name)
+
+        # Each member folder may have shortcuts that point to their actual
+        # working folder OR direct subfolders (companies)
+        level1 = list_children(drive, team_member_folder_id)
+        target_folder_ids: list[tuple[str, str]] = []  # (id, source_label)
+
+        for entry in level1:
+            if entry["mimeType"] == SHORTCUT_MIME:
+                resolved = resolve_shortcut(drive, entry)
+                if resolved and resolved[1] == FOLDER_MIME:
+                    target_folder_ids.append((resolved[0], f"{team_member_name} (via shortcut '{entry['name']}')"))
+            elif entry["mimeType"] == FOLDER_MIME:
+                target_folder_ids.append((entry["id"], f"{team_member_name} (direct)"))
+
+        if not target_folder_ids:
+            LOG.info("  %s: empty (no shortcuts or subfolders)", team_member_name)
+            continue
+
+        for working_folder_id, source_label in target_folder_ids:
+            companies = list_children(drive, working_folder_id)
+            company_folders = [c for c in companies if c["mimeType"] == FOLDER_MIME]
+            LOG.info("  %s → %d company folders", source_label, len(company_folders))
+
+            for company in company_folders:
+                cf_id = company["id"]
+                cf_name = company["name"]
+                # Sample files inside the company folder (depth 1 only for discovery)
+                inner = list_children(drive, cf_id)
+                files = [f for f in inner if f["mimeType"] != FOLDER_MIME]
+                subdirs = [f for f in inner if f["mimeType"] == FOLDER_MIME]
+                findings.append({
+                    "team_member": team_member_name,
+                    "source_label": source_label,
+                    "company_folder_id": cf_id,
+                    "company_folder_name": cf_name,
+                    "files_at_root": len(files),
+                    "subdirs_at_root": len(subdirs),
+                    "sample_filenames": [f["name"] for f in files[:5]],
+                    "sample_subdirs": [f["name"] for f in subdirs[:5]],
+                })
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Company name matching
+# ---------------------------------------------------------------------------
+
+_PT_PREFIX_RE = re.compile(r"^\s*(PT[\.\s]+|PT\b)\s*", re.IGNORECASE)
+_PUNCT_RE = re.compile(r"[^\w\s]")
+_MULTISPACE_RE = re.compile(r"\s+")
+
+
+def normalize_company_name(s: str) -> str:
+    """Lowercase, strip PT prefix, drop punctuation, collapse spaces."""
+    s = s or ""
+    s = _PT_PREFIX_RE.sub("", s)
+    s = _PUNCT_RE.sub(" ", s)
+    s = _MULTISPACE_RE.sub(" ", s).strip().lower()
+    return s
+
+
+def levenshtein(a: str, b: str) -> int:
+    """Iterative Levenshtein distance — small ints, no DP overhead."""
+    if a == b:
+        return 0
+    if len(a) > len(b):
+        a, b = b, a
+    if not a:
+        return len(b)
+    prev = list(range(len(a) + 1))
+    for i, cb in enumerate(b, 1):
+        cur = [i]
+        for j, ca in enumerate(a, 1):
+            cost = 0 if ca == cb else 1
+            cur.append(min(cur[-1] + 1, prev[j] + 1, prev[j - 1] + cost))
+        prev = cur
+    return prev[-1]
+
+
+def match_company(
+    folder_name: str,
+    companies: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """3-tier match: exact → normalized → fuzzy (Levenshtein <= 3)."""
+    if not folder_name:
+        return None
+
+    fnorm = normalize_company_name(folder_name)
+    if not fnorm:
+        return None
+
+    # Tier 1: exact case-insensitive
+    for c in companies:
+        if (c["company_name"] or "").strip().lower() == folder_name.strip().lower():
+            return {"company": c, "tier": "T1_exact", "score": 1.0}
+
+    # Tier 2: normalized match
+    for c in companies:
+        cnorm = normalize_company_name(c["company_name"])
+        if cnorm and cnorm == fnorm:
+            return {"company": c, "tier": "T2_normalized", "score": 0.95}
+
+    # Tier 3: fuzzy on normalized form, Levenshtein <= 3, length >= 6 chars
+    best = None
+    best_dist = 99
+    for c in companies:
+        cnorm = normalize_company_name(c["company_name"])
+        if not cnorm or len(cnorm) < 6:
+            continue
+        d = levenshtein(fnorm, cnorm)
+        if d < best_dist:
+            best_dist = d
+            best = c
+    if best is not None and best_dist <= 3:
+        return {
+            "company": best,
+            "tier": "T3_fuzzy",
+            "score": 1.0 - (best_dist / max(len(fnorm), 1)),
+            "edit_distance": best_dist,
+        }
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+async def run_discovery() -> dict[str, Any]:
+    started = datetime.now(timezone.utc)
+    drive = build_drive_service(prefer_user_oauth=True)
+    findings = walk_tax_dept(drive)
+    LOG.info("walked tax-dept → %d company folders found", len(findings))
+
+    conn = await asyncpg.connect(_resolve_db_url())
+    try:
+        companies = await fetch_all_companies(conn)
+        LOG.info("loaded %d companies from DB", len(companies))
+
+        matched: list[dict[str, Any]] = []
+        unmatched: list[dict[str, Any]] = []
+
+        for f in findings:
+            result = match_company(f["company_folder_name"], companies)
+            if result is None:
+                unmatched.append(f)
+                continue
+            client_rows = await fetch_clients_for_company(conn, result["company"]["id"])
+            matched.append({
+                **f,
+                "matched_company_id": result["company"]["id"],
+                "matched_company_name": result["company"]["company_name"],
+                "matched_company_npwp": result["company"]["npwp_company"],
+                "match_tier": result["tier"],
+                "match_score": result["score"],
+                "edit_distance": result.get("edit_distance"),
+                "linked_clients": [
+                    {"id": r["id"], "full_name": r["full_name"], "role": r["role"], "is_primary": r["is_primary"]}
+                    for r in client_rows
+                ],
+                "linked_clients_count": len(client_rows),
+            })
+    finally:
+        await conn.close()
+
+    # Stats by tier
+    by_tier: dict[str, int] = {}
+    by_team: dict[str, int] = {}
+    for m in matched:
+        by_tier[m["match_tier"]] = by_tier.get(m["match_tier"], 0) + 1
+        by_team[m["team_member"]] = by_team.get(m["team_member"], 0) + 1
+
+    total_clients_reached = len({
+        c["id"]
+        for m in matched
+        for c in m["linked_clients"]
+    })
+
+    report = {
+        "started_at": started.isoformat(),
+        "finished_at": datetime.now(timezone.utc).isoformat(),
+        "tax_dept_root_folder": TAX_DEPT_ROOT,
+        "totals": {
+            "company_folders_found": len(findings),
+            "matched": len(matched),
+            "unmatched": len(unmatched),
+            "unique_clients_reached": total_clients_reached,
+        },
+        "by_match_tier": by_tier,
+        "by_team_member": by_team,
+        "matched": matched,
+        "unmatched": unmatched,
+    }
+    return report
+
+
+def main() -> int:
+    report = asyncio.run(run_discovery())
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out_path = OUT_DIR / f"tax_dept_discovery_{ts}.json"
+    out_path.write_text(json.dumps(report, indent=2, default=str))
+
+    t = report["totals"]
+    print()
+    print(f"  Tax-dept discovery — {report['started_at']}")
+    print(f"  -----------------------------------------")
+    print(f"  company folders found    : {t['company_folders_found']}")
+    print(f"  matched to companies     : {t['matched']}")
+    print(f"  unmatched                : {t['unmatched']}")
+    print(f"  unique CRM clients       : {t['unique_clients_reached']}")
+    print()
+    print(f"  Match tier breakdown:")
+    for tier, n in sorted(report["by_match_tier"].items()):
+        print(f"    {tier:<18} {n:>4}")
+    print()
+    print(f"  Per-team-member:")
+    for tm, n in sorted(report["by_team_member"].items(), key=lambda x: -x[1]):
+        print(f"    {tm:<20} {n:>4}")
+    print()
+    print(f"  Report saved: {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/crm_guardian_tax_dept_discovery.py
+++ b/scripts/crm_guardian_tax_dept_discovery.py
@@ -50,7 +50,7 @@ logging.basicConfig(
     datefmt="%H:%M:%S",
 )
 
-TAX_DEPT_ROOT = "1QkFxr9rwtyIxIf7XaVNi6ehmxIMrWO2S"
+TAX_DEPT_ROOT = "1QkFxr9rwtyIxIf7XaVNi6ehmxIMrWO2S"  # pragma: allowlist secret  # noqa: E501 — Google Drive folder ID, not a credential
 SHORTCUT_MIME = "application/vnd.google-apps.shortcut"
 FOLDER_MIME = "application/vnd.google-apps.folder"
 


### PR DESCRIPTION
## Summary

Phase 1.5 worker reads cliente Drive root + linked-company Drive folder as 2 sources. The Bali Zero tax department maintains a **SHARED Drive structure** (`Members/<TeamMember>/<COMPANY_NAME>/`) holding SPT/PPN/PPh/LKPM filings that are NOT in either source. Without this, `tax_records[]` and `lkpm_history[]` stay empty even for clients with active tax filings.

This adds tax-dept as the **3rd source** via a single new column on the companies table — no schema change to the L1 v3 contract.

## What ships

1. **Migration 182** `companies.tax_dept_folder_id TEXT` — soft NULL (most companies don't have a tax-dept entry). Partial index on populated rows. Audit event in `crm_guardian_events`.

2. **`scripts/crm_guardian_tax_dept_discovery.py`** (read-only) — walks `Members/<TeamMember>/[shortcut→]<TeamMember>/<COMPANY>/*` and matches each `<COMPANY>` folder against `companies.company_name` with 3-tier fallback:
   - **T1** exact case-insensitive
   - **T2** normalized (strip PT prefix, drop punctuation, lowercase)
   - **T3** fuzzy Levenshtein ≤ 3 on normalized form

   Outputs `~/.crm_guardian/tax_dept_discovery_<ts>.json`.

3. **`scripts/crm_guardian_tax_dept_apply.py`** — writer that consumes a discovery report and populates `companies.tax_dept_folder_id`. Idempotent, skips entries with no active linked clients, `--dry-run` + `--force` flags.

4. **Worker patch** (`scripts/crm_guardian_gemini_cli_worker.py`):
   - `fetch_linked_companies` SELECT includes `c.tax_dept_folder_id` + accepts companies that have ONLY tax-dept folder
   - `aggregate_cross_folder_files` iterates the new field as 3rd source per company, labels files `<company_name> (Tax Dept)` in the inventory
   - OCR cache works unchanged (file_id keyed)
   - INFO log emits `tax-dept folder for company <X>: +N files` for grep-ability

## Empirical discovery run 2026-05-18 (37 tax-dept folders found)

| Tier | Match count |
|---|---|
| T1 exact | 0 |
| T2 normalized | 0 |
| **T3 fuzzy** | **20** (all of them — PT prefix vs suffix pattern) |
| Unmatched | 17 (companies not in DB, team personal folders, admin folders like BPJS forms) |

- Apply step inserted **18 rows** (2 skipped: no active linked clients)
- **20 unique CRM clients impacted** (19 already pending in queue, 1 re-enqueued)

## Test plan
- [x] 106/106 tests passed (`PYTHONPATH=. pytest backend/tests/unit/services/crm_guardian/ -q`)
- [x] Migration 182 already applied to local Fly PG proxy + registered in `schema_migrations`
- [x] Discovery script smoke ran successfully (37 folders, 20 matches)
- [x] Apply script smoke ran successfully (18 inserts, audit JSON saved)
- [x] Worker import OK after patch
- [x] Empirical: 18 `companies.tax_dept_folder_id` populated

## Operational follow-ups (future, not in this PR)
- Daily cron 04:30 WITA for `discovery → apply` to pick up new tax-dept folders
- Manual cleanup of the 17 unmatched (DB out-of-sync vs team naming)

🤖 Generated with [Claude Code](https://claude.com/claude-code)