### PR TITLE
fix(logging): render endpoint call message

### DIFF
--- a/apps/backend-rag/backend/app/utils/logging_utils.py
+++ b/apps/backend-rag/backend/app/utils/logging_utils.py
@@ -71,7 +71,7 @@ def log_endpoint_call(
     if user_email:
         extra["user_email"] = user_email
 
-    logger.info("%s %s", method, endpoint, extra=extra)
+    logger.info(f"{method} {endpoint}", extra=extra)
 
 
 def log_success(


### PR DESCRIPTION
## Summary
- render endpoint call log messages before passing them to logger.info
- keeps structured context unchanged
- fixes backend CI failure in test_log_endpoint_call_basic seen after PR #737

## Verification
- PYTHONPATH=. python -m pytest backend/tests/unit/app/utils/test_logging_utils.py::TestLogEndpointCall::test_log_endpoint_call_basic backend/tests/unit/app/utils/test_logging_utils.py::TestLogEndpointCall::test_log_endpoint_call_different_methods -q
- PYTHONPATH=. ruff check backend/app/utils/logging_utils.py