### PR TITLE
fix(logging): render database operation message

### DIFF
--- a/apps/backend-rag/backend/app/utils/logging_utils.py
+++ b/apps/backend-rag/backend/app/utils/logging_utils.py
@@ -182,7 +182,7 @@ def log_database_operation(
     if duration_ms is not None:
         extra["duration_ms"] = duration_ms
 
-    logger.debug("%s %s", operation, table, extra=extra)
+    logger.debug(f"{operation} {table}", extra=extra)
 
 
 @contextmanager


### PR DESCRIPTION
## Summary
- render database operation log messages before calling logger.debug
- keeps structured logging context unchanged
- fixes the next logging_utils backend CI failure exposed after #739

## Verification
- PYTHONPATH=. python -m pytest backend/tests/unit/app/utils/test_logging_utils.py -q
- PYTHONPATH=. ruff check backend/app/utils/logging_utils.py