### PR TITLE
fix(db): renumber WR3 eventbus migration

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/183_wr3_eventbus_channels.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/183_wr3_eventbus_channels.sql
@@ -1,4 +1,4 @@
--- 182_wr3_eventbus_channels.sql
+-- 183_wr3_eventbus_channels.sql
 --
 -- WR3 Video Production Room eventbus channels.
 --

--- a/apps/backend-rag/backend/tests/services/events/test_wr3_outbox_explicit_ack.py
+++ b/apps/backend-rag/backend/tests/services/events/test_wr3_outbox_explicit_ack.py
@@ -1,6 +1,6 @@
 """WR3 supervisor explicit-ack contract test.
 
-Migration 182 closes EventBus Phase 3 pending (cicatrix-scars.md): the
+Migration 183 closes EventBus Phase 3 pending (cicatrix-scars.md): the
 universal `replay_unconsumed()` in services/events/outbox.py auto-acks on
 dispatch return, which is unsafe for a video pipeline where ffmpeg can
 crash mid-render. WR3 supervisor must implement EXPLICIT per-handler ack


### PR DESCRIPTION
## Summary
- renumber WR3 eventbus SQL migration from 182 to 183 because production already has canonical migration_number 182 for companies tax department folder
- update the WR3 explicit-ack test docstring to match the new migration number

## Verification
- PYTHONPATH=. /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m pytest backend/tests/services/events/test_wr3_outbox_explicit_ack.py backend/tests/db/test_migration_uniqueness.py -q
- duplicate migration number shell check returned migration_numbers_unique=1
- live DB read-only probe confirmed migration_number 183 is not present in schema_migrations or _schema_versions