### PR TITLE
fix(test): update log_endpoint_call test for lazy-eval logging

### DIFF
--- a/apps/backend-rag/backend/tests/unit/app/utils/test_logging_utils.py
+++ b/apps/backend-rag/backend/tests/unit/app/utils/test_logging_utils.py
@@ -71,9 +71,10 @@ class TestLogEndpointCall:
         log_endpoint_call(logger, "/api/test", "GET")
 
         logger.info.assert_called_once()
-        call_args = logger.info.call_args[0][0]
-        assert "/api/test" in call_args
-        assert "GET" in call_args
+        call_args = logger.info.call_args[0]
+        rendered = call_args[0] % call_args[1:] if len(call_args) > 1 else call_args[0]
+        assert "/api/test" in rendered
+        assert "GET" in rendered
 
     def test_log_endpoint_call_with_user(self):
         """Test endpoint call logging with user email"""


### PR DESCRIPTION
## Summary
Fix Backend Tests CI failure introduced by #731 (ruff G004 lazy-eval logging sweep).

`log_endpoint_call` now uses `logger.info("%s %s", path, method)` with separate args. The previous test assertion read only `call_args[0][0]` (template `"%s %s"`) and missed the interpolated values.

## Fix
Render the full message via `%` substitution before assertion (3 LOC change).

## Test plan
- [x] `pytest backend/tests/unit/app/utils/test_logging_utils.py -q` → 23/23 passed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>