### PR TITLE
fix(db): reconcile migration 182 tracking ledger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ See [`INDEX.md`](INDEX.md) for the full atlas including packages, tessuti dati, 
 ### Tech Stack
 
 <!-- DOCSYNC:BACKEND_STATS_START -->
-- **Backend:** Python 3.11+, FastAPI, 269 routers, 565 services, 954 test files
+- **Backend:** Python 3.11+, FastAPI, 269 routers, 565 services, 955 test files
 <!-- DOCSYNC:BACKEND_STATS_END -->
 - **Frontend:** Next.js, TypeScript, Tailwind CSS
 - **Databases:** PostgreSQL (relational), Qdrant (vector), Redis (cache)

--- a/apps/backend-rag/backend/db/migrations_v2/184_reconcile_182_tracking_divergence.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/184_reconcile_182_tracking_divergence.sql
@@ -1,0 +1,48 @@
+-- 184_reconcile_182_tracking_divergence.sql
+--
+-- Production had migration_number 182 recorded in the canonical
+-- schema_migrations table as 182_companies_tax_dept_folder, but missing from
+-- the legacy _schema_versions table used by the release runner. That makes
+-- backend.db.schema_audit fail with tracking_divergence_canonical_only after
+-- otherwise-successful deploy migrations.
+--
+-- This migration reconciles only the tracking ledger. It does not change any
+-- application tables.
+
+SET lock_timeout = '5s';
+SET statement_timeout = '30s';
+
+INSERT INTO _schema_versions (
+    migration_name,
+    migration_number,
+    executed_at,
+    checksum,
+    description,
+    execution_time_ms,
+    rollback_sql,
+    applied_by
+)
+SELECT
+    sm.migration_name,
+    sm.migration_number,
+    COALESCE(sm.executed_at, NOW()),
+    sm.checksum,
+    COALESCE(
+        sm.description,
+        'Backfilled from schema_migrations by 184_reconcile_182_tracking_divergence'
+    ),
+    sm.execution_time_ms,
+    sm.rollback_sql,
+    'migration-184-ledger-reconcile'
+FROM schema_migrations sm
+WHERE sm.migration_number = 182
+  AND NOT EXISTS (
+      SELECT 1
+      FROM _schema_versions sv
+      WHERE sv.migration_number = 182
+  )
+ON CONFLICT (migration_name) DO NOTHING;
+
+-- === ROLLBACK ===
+-- Intentionally no-op. Removing the backfilled 182 tracking row would recreate
+-- the production schema_audit failure that this migration fixes.

--- a/apps/backend-rag/backend/tests/db/test_migration_184.py
+++ b/apps/backend-rag/backend/tests/db/test_migration_184.py
@@ -1,0 +1,56 @@
+"""Verify migration 184 only reconciles the migration tracking ledger."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+MIGRATION_FILE = (
+    Path(__file__).resolve().parents[2]
+    / "db"
+    / "migrations_v2"
+    / "184_reconcile_182_tracking_divergence.sql"
+)
+
+
+def _sections() -> tuple[str, str]:
+    sql = MIGRATION_FILE.read_text(encoding="utf-8")
+    forward, rollback = sql.split("-- === ROLLBACK ===", maxsplit=1)
+    return forward, rollback
+
+
+def _executable_lines(sql: str) -> str:
+    return "\n".join(line for line in sql.splitlines() if not line.lstrip().startswith("--"))
+
+
+def test_migration_file_exists() -> None:
+    assert MIGRATION_FILE.exists(), f"Migration file missing: {MIGRATION_FILE}"
+
+
+def test_forward_backfills_legacy_tracking_from_canonical_row() -> None:
+    forward, _rollback = _sections()
+
+    assert "INSERT INTO _schema_versions" in forward
+    assert "FROM schema_migrations sm" in forward
+    assert "WHERE sm.migration_number = 182" in forward
+    assert "WHERE sv.migration_number = 182" in forward
+    assert "migration-184-ledger-reconcile" in forward
+    assert "ON CONFLICT (migration_name) DO NOTHING" in forward
+
+
+def test_forward_does_not_touch_application_tables() -> None:
+    forward, _rollback = _sections()
+    executable = _executable_lines(forward)
+
+    assert "clients" not in executable
+    assert "companies" not in executable
+    assert "company_documents" not in executable
+    assert "DROP " not in executable.upper()
+    assert "DELETE " not in executable.upper()
+
+
+def test_rollback_is_intentionally_noop() -> None:
+    _forward, rollback = _sections()
+
+    assert "Intentionally no-op" in rollback
+    assert "DELETE " not in rollback.upper()
+    assert "DROP " not in rollback.upper()

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`269 routers · 565 services · 954 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`269 routers · 565 services · 955 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary
- add migration 184 to backfill the missing _schema_versions row for canonical migration_number 182
- add a focused test proving the migration only touches migration tracking tables

## Context
The Fly release command now applies migration 183 successfully, but schema_audit fails because schema_migrations contains 182_companies_tax_dept_folder while _schema_versions is missing migration_number 182.

## Verification
- PYTHONPATH=. /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m pytest backend/tests/db/test_migration_184.py backend/tests/db/test_migration_uniqueness.py -q
- migration_numbers_unique=1
- migration_184_forward_valid=1