### PR TITLE
fix(db): reconcile ghost migration 182 in _schema_versions (unblocks Fly deploy)

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/184_reconcile_ghost_182_schema_versions.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/184_reconcile_ghost_182_schema_versions.sql
@@ -1,0 +1,61 @@
+-- 184_reconcile_ghost_182_schema_versions.sql
+--
+-- Reconcile cross-table divergence introduced by ghost migration 182.
+--
+-- TIMELINE:
+--   * PR #722 (DRAFT, feat/wr3-room-genesis, 2026-05-17 21:18) authored a
+--     `182_wr3_eventbus_channels.sql` migration. Someone applied it manually
+--     on Fly Postgres for testing, registering migration_number=182 in
+--     `schema_migrations` BUT NOT in `_schema_versions`. The DRAFT was
+--     never merged.
+--   * PR #735 (mergeato 2026-05-18 01:37) carved out the same migration
+--     under the same number `182_wr3_eventbus_channels.sql`. Release
+--     command on Fly tried to INSERT migration_number=182 → UniqueViolation
+--     against schema_migrations (mig 165 uq_schema_migrations_migration_number).
+--   * PR #741 (mergeato 2026-05-18 02:18) renamed the file 182→183 to
+--     avoid the apply-time conflict. Mig 183 applied successfully (27ms).
+--   * Post-deploy schema_audit STILL FAILS with
+--     `tracking_divergence_canonical_only: {"only_in_canonical": [182]}`
+--     because the ghost row in schema_migrations remains, and
+--     _schema_versions never received a row for 182.
+--
+-- FIX STRATEGY:
+--   Insert a TOMBSTONE row in `_schema_versions` for migration_number=182
+--   so schema_audit sees both tables in sync. Do NOT touch schema_migrations
+--   (the ghost row is harmless once the divergence is reconciled — both
+--   tables agree that 182 is "applied"). Idempotent via ON CONFLICT.
+--
+--   Why migration_name = '182_ghost_pre_renumber_to_183'? Because
+--   _schema_versions.migration_name has UNIQUE constraint. The name is
+--   self-documenting and prevents accidental collision with the (never
+--   used) name '182_wr3_eventbus_channels' from PR #722. The actual WR3
+--   eventbus channel migration lives at migration_number=183 (file
+--   183_wr3_eventbus_channels.sql) via PR #741.
+--
+-- AUTONOMOUS_OPS rule compliance: this is a NEW migration applied via
+-- the runner (the canonical path), NOT a manual `fly ssh console` DDL/DML
+-- write to either tracking table. The rule "do not write to either table
+-- directly outside the runner" is honored.
+--
+-- Squawk lint: INSERT statement with ON CONFLICT DO NOTHING is safe. No
+-- DDL in forward path.
+
+INSERT INTO _schema_versions
+    (migration_name, migration_number, checksum, description, execution_time_ms, rollback_sql, applied_by)
+VALUES
+    (
+        '182_ghost_pre_renumber_to_183',
+        182,
+        'GHOST_TOMBSTONE_NO_DDL_APPLIED',
+        'Tombstone row to reconcile schema_migrations ghost migration 182. See migration 184 header for full context.',
+        0,
+        '-- ROLLBACK by mig 184 itself: DELETE FROM _schema_versions WHERE migration_name = ''182_ghost_pre_renumber_to_183''',
+        'mig_184_reconcile'
+    )
+ON CONFLICT (migration_name) DO NOTHING;
+
+-- === ROLLBACK ===
+-- Tombstone removal: if mig 184 is rolled back, schema_audit will resume
+-- flagging divergence_canonical_only:[182] until the schema_migrations
+-- ghost is cleaned up by an out-of-band operation.
+DELETE FROM _schema_versions WHERE migration_name = '182_ghost_pre_renumber_to_183';


### PR DESCRIPTION
## P0 — Fly backend deploy blocked since 01:37 WITA

All deploys to Fly since PR #735 merge fail with `schema_audit` error:

\`\`\`
[ERROR] tracking_divergence_canonical_only
  1 migration(s) recorded in schema_migrations but missing from _schema_versions
  details: {"only_in_canonical": [182]}
\`\`\`

5 consecutive failures: runs 26008447236, 26008765206, 26008936986, 26009154942, 26010028276 (this last one was post PR #741 renumber).

## Root cause (3-PR timeline)

| Time | Event |
|---|---|
| 2026-05-17 21:18 | PR #722 (DRAFT \`feat/wr3-room-genesis\`) authored \`182_wr3_eventbus_channels.sql\`. Someone applied it manually on Fly Postgres for testing — registered \`migration_number=182\` in \`schema_migrations\` only. DRAFT never merged. |
| 2026-05-18 01:37 | PR #735 (carve-out from same source) merged → release_command fails INSERT migration 182 → UniqueViolation on \`uq_schema_migrations_migration_number\` (mig 165 constraint). |
| 2026-05-18 02:18 | PR #741 renamed file 182→183 → mig 183 applied cleanly (27ms), but \`schema_audit\` still flags ghost 182 in \`schema_migrations\` vs missing in \`_schema_versions\`. |

## Fix

Migration 184 inserts a TOMBSTONE row into \`_schema_versions\` for \`migration_number=182\` via the canonical runner path. After applying:
- \`schema_migrations\` has 182 (ghost) + 183 (real WR3 helper)
- \`_schema_versions\` has 182 (tombstone) + 183 (real WR3 helper)
- \`schema_audit\` finds zero divergence

\`migration_name='182_ghost_pre_renumber_to_183'\` is self-documenting and avoids collision with the never-used \`182_wr3_eventbus_channels\` name from PR #722.

## Why NOT a manual \`fly ssh console\` DELETE / INSERT

\`AUTONOMOUS_OPS.md\` rule: "do not write to either tracking table directly outside the runner". This fix is a NEW migration applied via the runner = canonical path. Rule honored.

## Pre-flight

- [x] Squawk lint: 0 issues 🎉
- [x] ROLLBACK marker present (\`-- === ROLLBACK ===\`)
- [x] Idempotent (\`ON CONFLICT (migration_name) DO NOTHING\`)
- [x] Pre-commit import-chain + golden-rules + secrets all pass

## Test plan

- [ ] CI Squawk lint pass on migration 184
- [ ] Fly deploy run-migrations (pre-deploy, OLD image): "No pending migrations" (184 not in image yet — expected)
- [ ] Fly deploy rolling deploy (NEW image release_command): applies 184 → \`_schema_versions\` gains row 182 → \`schema_audit\` exit 0 → deploy succeeds
- [ ] Post-deploy: \`curl https://nuzantara-rag.fly.dev/health\` returns 200 + new release version > v100-qdrant
- [ ] Post-deploy: \`curl POST https://kita.balizero.com/api/auth/login\` returns 200 with valid JWT

## Follow-up (separate PR, NOT this one)

The legacy \`_schema_versions\` vs canonical \`schema_migrations\` dual-table tracking is being unified (per cicatrix archive \`EventBus phase 3\` reference). This PR keeps the divergence-reconciliation strategy because the unification work is out of scope for this emergency unblock.

Cicatrix-worthy lesson: any DRAFT branch that pushes test migrations to Fly Postgres via \`fly ssh console\` MUST clean up its tracking rows before letting the file enter \`origin/main\` under the same number. Pattern: DRAFT testing on prod DB without rollback is structural footgun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)