### PR TITLE
content(tax): reusable MDX template + SEO checklist for tax cluster

### DIFF
--- a/apps/mouth/docs/content-templates/TAX-ARTICLE-CHECKLIST.md
+++ b/apps/mouth/docs/content-templates/TAX-ARTICLE-CHECKLIST.md
@@ -1,0 +1,55 @@
+# Tax Article SEO Checklist
+
+Pre-commit checklist sebelum push artikel baru di cluster tax.
+
+## Frontmatter
+
+- [ ] `title` 50-65 chars, primary keyword di awal, year 2026 included
+- [ ] `description` 150-160 chars, ada primary keyword + action verb
+- [ ] `category` = "tax" (BUKAN "tax-legal" atau category lain)
+- [ ] `canonicalUrl` pakai `/tax/[slug]` (BUKAN `/tax-legal/`)
+- [ ] `updatedAt` dan `publishedAt` real date
+- [ ] `seoTitle` 50-60 chars
+- [ ] `seoDescription` 150-160 chars
+- [ ] `relatedArticles` = 5 sibling dari cluster yang sama
+- [ ] `image` path: `/og/tax/[slug].png`
+
+## Structure
+
+- [ ] Import block setelah frontmatter:
+  - [ ] `HeaderWhatsAppCTA`
+  - [ ] `ArticleClusterCTA`
+  - [ ] `KeyTakeaway`
+- [ ] H1 muncul TEPAT setelah import (SEO critical — jangan lewat)
+- [ ] `<KeyTakeaway>` TL;DR setelah H1
+- [ ] `<HeaderWhatsAppCTA />` setelah TL;DR (above the fold)
+- [ ] Minimum 4 H2 sections
+- [ ] `<ArticleClusterCTA slug="..." />` di tengah artikel
+- [ ] FAQ section dengan minimum 5 long-tail questions
+- [ ] CTA footer "Get Help With [TOPIC]"
+- [ ] `<HeaderWhatsAppCTA />` di footer
+
+## Content Integrity
+
+- [ ] Hanya gunakan verified regulatory facts (cek NB-4 verification list)
+- [ ] Tidak hardcode phone/email/WA URL
+- [ ] Internal links pakai `/tax/[slug]` path
+- [ ] Minimum 1 tabel dengan rate/scenario comparison
+- [ ] Minimum 3 scenario examples
+- [ ] Regulation citation jelas (KEP, PMK, UU referenced eksplisit)
+
+## Technical
+
+- [ ] File path: `apps/mouth/src/content/articles/tax/[slug].mdx`
+- [ ] Slug: kebab-case, descriptive, contains primary keyword
+- [ ] `npx tsc --noEmit` clean
+- [ ] `npx prettier --write [file]` applied
+- [ ] No `console.log` atau debug statements
+- [ ] No leftover `[BRACKETS]` placeholders
+
+## Pre-Commit
+
+- [ ] Branch naming: `feat/c[X]-[topic]-[YYYY-MM-DD]`
+- [ ] Commit format: `content(tax): [description]`
+- [ ] Pre-commit hooks pass (husky)
+- [ ] PR description: cluster, target GSC position, key claims, regulatory references

--- a/apps/mouth/docs/content-templates/tax-article.template.mdx
+++ b/apps/mouth/docs/content-templates/tax-article.template.mdx
@@ -1,0 +1,128 @@
+---
+# ============================================================================
+# TAX ARTICLE TEMPLATE — Bali Zero Content Cluster
+# ============================================================================
+# Cara pakai:
+#   1. Copy file ke apps/mouth/src/content/articles/tax/[slug].mdx
+#   2. Replace SEMUA placeholder [BRACKETS]
+#   3. Verifikasi pakai TAX-ARTICLE-CHECKLIST.md sebelum commit
+#   4. Run: npx prettier --write apps/mouth/src/content/articles/tax/[slug].mdx
+# ============================================================================
+title: "[TOPIC]: [HOOK/BENEFIT] — Bali Zero Guide 2026"
+description: "[BRIEF DESCRIPTION 150-160 CHARS — start dengan key fact, end dengan action verb]"
+category: "tax"
+updatedAt: "2026-MM-DD"
+publishedAt: "2026-MM-DD"
+canonicalUrl: "https://balizero.com/tax/[slug]"
+seoTitle: "[SHORTER TITLE 50-60 CHARS] | Bali Zero 2026"
+seoDescription: "[META DESCRIPTION 150-160 CHARS — include primary keyword + CTA hint]"
+author: "Bali Zero"
+image: "/og/tax/[slug].png"
+relatedArticles:
+  - "[sibling-slug-1]"
+  - "[sibling-slug-2]"
+  - "[sibling-slug-3]"
+  - "[sibling-slug-4]"
+  - "[sibling-slug-5]"
+---
+
+import { HeaderWhatsAppCTA } from "@/components/blog/HeaderWhatsAppCTA";
+import { ArticleClusterCTA } from "@/components/blog/ArticleClusterCTA";
+import { KeyTakeaway } from "@/components/blog/interactive";
+
+# [H1 — PRIMARY KEYWORD + BENEFIT — 50-65 CHARS]
+
+<KeyTakeaway>
+  **TL;DR:** [3-5 sentences merangkum key points artikel — buat reader yang scan 5 detik]
+
+- Key point 1: [verified fact dengan regulation reference]
+- Key point 2: [actionable insight untuk reader's situation]
+- Key point 3: [practical scenario atau common mistake]
+  </KeyTakeaway>
+
+<HeaderWhatsAppCTA />
+
+## [H2 — MAIN CONCEPT / DEFINITION]
+
+[Buka dengan definisi: apa itu, untuk siapa, kapan berlaku. 2-3 paragraf.]
+
+[Include verified regulation reference: "Per KEP-71/PJ/2026..." atau "PMK-XX/2026..."]
+
+## [H2 — HOW IT WORKS / CALCULATION / PROCESS]
+
+[Step-by-step atau rule breakdown. Pakai tabel untuk compare rate/scenario.]
+
+| Scenario | Rate / Treatment | Reference    |
+| -------- | ---------------- | ------------ |
+| [Case 1] | [X%]             | [Regulation] |
+| [Case 2] | [Y%]             | [Regulation] |
+| [Case 3] | [Z%]             | [Regulation] |
+
+## [H2 — WHO QUALIFIES / WHO MUST COMPLY]
+
+[Kriteria yes/no untuk typical reader profiles.]
+
+**Typical readers:**
+
+- Foreign individual investors dengan PT PMA
+- Expat employees di Bali
+- Property owners yang rent villa
+- [Adjust per topic]
+
+## [H2 — KEY DEADLINES & FILING REQUIREMENTS]
+
+[Timeline praktis. Bullet untuk clarity.]
+
+- **[Filing type 1]**: [Deadline]
+- **[Filing type 2]**: [Deadline]
+- **Penalty late filing**: [Formula atau amount]
+
+## [H2 — SCENARIOS]
+
+### Scenario 1: [Common case]
+
+[Story-style: profil, action, tax treatment, kalkulasi, kesimpulan.]
+
+### Scenario 2: [Edge case]
+
+[Struktur sama.]
+
+### Scenario 3: [Optimization case]
+
+[Struktur sama.]
+
+## [H2 — Tax Optimization / Common Mistakes]
+
+[Practical do's & don'ts. Mengurangi kebingungan & inbound call generic.]
+
+<ArticleClusterCTA slug="[this-article-slug]" />
+
+## Frequently Asked Questions
+
+### [Long-tail keyword question 1]?
+
+[Answer 2-3 sentences. Avoid jargon. Cite regulation kalau applicable.]
+
+### [Long-tail keyword question 2]?
+
+[Answer.]
+
+### [Long-tail keyword question 3]?
+
+[Answer.]
+
+### [Long-tail keyword question 4]?
+
+[Answer.]
+
+### [Long-tail keyword question 5]?
+
+[Answer.]
+
+## Get Help With [TOPIC]
+
+[2-3 sentences kapan reader butuh advisor profesional. Lower friction ke CTA.]
+
+If you are unsure how this applies to your situation — individual taxpayer, PT PMA director, or property owner — or need help with monthly and annual filings, speak with a Bali Zero tax advisor directly.
+
+<HeaderWhatsAppCTA />


### PR DESCRIPTION
## Summary

Adds reusable MDX template for tax cluster articles + pre-commit SEO checklist.

## Coverage

Template covers upcoming clusters:
- **C2** — NPWP / Coretax
- **C3** — Tax Incentives (allowance + holiday)
- **C6** — PPN / VAT 12% increase 2026

Existing C1 (tax-residency) and C4 (rental-income-tax) follow same patterns, can be retrofitted later if needed.

## Files

- `apps/mouth/docs/content-templates/tax-article.template.mdx` — drop-in template
- `apps/mouth/docs/content-templates/TAX-ARTICLE-CHECKLIST.md` — pre-commit SEO checklist

## Expected Impact

- ~2-3 hours saved per article on C2/C3/C6 build-out
- Consistent SEO patterns (H1, TL;DR, CTAs, ArticleClusterCTA placement)
- Standardized frontmatter (canonicalUrl, category, relatedArticles)
- 5-section FAQ skeleton enforces long-tail keyword coverage

## Review

**Non-blocking** — template ini scaffolding, tidak mengubah artikel existing. Bisa di-merge kapanpun. Mohon arahan jika ada section yang perlu disesuaikan dengan brand voice Bali Zero.

## Test Plan

Will be validated when applied to first C2 (NPWP) article — pending NB-4 verification for Coretax effective dates.