### PR TITLE
feat(scripts): visa nomenclature audit + news retag tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -679,3 +679,6 @@ docs/codex-reviews/
 # Mini-Pro2 venv aside (transient backup during venv recreations)
 apps/backend-rag/.venv.mini-aside-*/
 apps/mouth/scripts/output/
+
+# Generated artifacts from analysis scripts
+apps/mouth/scripts/output/

--- a/apps/mouth/scripts/identify-skip-slugs.ts
+++ b/apps/mouth/scripts/identify-skip-slugs.ts
@@ -1,0 +1,603 @@
+/**
+ * identify-skip-slugs.ts
+ *
+ * Read-only heuristic script — reads the visa nomenclature audit JSON and
+ * detects which articles are "context-aware": they reference legacy visa codes
+ * (B211A, C312) intentionally, within a historical/educational context.
+ *
+ * Context-aware articles should be added to the SKIP_SLUGS allowlist so the
+ * transform script leaves them untouched.
+ *
+ * THIS SCRIPT NEVER MODIFIES ANY FILE.
+ *
+ * Run with:
+ *   npx ts-node apps/mouth/scripts/identify-skip-slugs.ts
+ *
+ * Input  : research/marketing/2026-05-08-visa-nomenclature-audit.json
+ * Output : research/marketing/2026-05-11-skip-slugs-candidates.json
+ */
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+// ---------------------------------------------------------------------------
+// Configuration — paths
+// ---------------------------------------------------------------------------
+
+/** Monorepo root (two levels up from apps/mouth/scripts/) */
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MONOREPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+
+/** Input: audit produced by audit-outdated-visa-codes.ts */
+const INPUT_FILE = path.join(
+  MONOREPO_ROOT,
+  "research",
+  "marketing",
+  "2026-05-08-visa-nomenclature-audit.json",
+);
+
+/** Output: skip-slug candidates for the SKIP_SLUGS allowlist */
+const OUTPUT_FILE = path.join(
+  MONOREPO_ROOT,
+  "research",
+  "marketing",
+  "2026-05-11-skip-slugs-candidates.json",
+);
+
+// ---------------------------------------------------------------------------
+// Heuristic phrase lists — Family 1: migration_keyword
+// ---------------------------------------------------------------------------
+
+/**
+ * Phrases that indicate the article explicitly acknowledges the legacy code
+ * as superseded by a regulation change.
+ * Checked against the full article body (case-insensitive).
+ */
+const MIGRATION_KEYWORD_PHRASES: string[] = [
+  "permenkumham 22/2023",
+  "permenkumham no. 22 tahun 2023",
+  "digantikan oleh",
+  "digantikan dengan",
+  "replaced by",
+  "superseded by",
+  "now known as",
+  "formerly known as",
+  "historical reference",
+  "untuk referensi historis",
+];
+
+// ---------------------------------------------------------------------------
+// Heuristic phrase lists — Family 2: date_context
+// ---------------------------------------------------------------------------
+
+/**
+ * Temporal anchor words/phrases. The heuristic checks whether a legacy visa
+ * code (B211A or C312) appears within 10 words of any of these tokens.
+ * Checked case-insensitively on the tokenised article body.
+ */
+const DATE_CONTEXT_ANCHORS: string[] = [
+  "2023",
+  "before 2023",
+  "pre-2023",
+  "dulu",
+  "sebelumnya",
+  "sampai 2023",
+  "until 2023",
+];
+
+// ---------------------------------------------------------------------------
+// Heuristic phrase lists — Family 3: tutorial_signal
+// ---------------------------------------------------------------------------
+
+/**
+ * Phrases checked against the article title (from frontmatter "title:" field
+ * or first H1 line starting with "# ").
+ * Checked case-insensitively.
+ */
+const TUTORIAL_SIGNAL_PHRASES: string[] = [
+  "evolution",
+  "history",
+  "timeline",
+  "changes from",
+  "from b211a to",
+  "from b211a to c1",
+  "migrasi",
+  "perubahan kode",
+  "regulatory shift",
+];
+
+// ---------------------------------------------------------------------------
+// Legacy visa codes to detect proximity for date_context
+// ---------------------------------------------------------------------------
+
+const LEGACY_CODES = ["B211A", "C312"] as const;
+type LegacyCode = (typeof LEGACY_CODES)[number];
+
+// ---------------------------------------------------------------------------
+// Heuristic family names and their priority ordering
+// ---------------------------------------------------------------------------
+
+type HeuristicFamily = "migration_keyword" | "date_context" | "tutorial_signal";
+
+/**
+ * Priority order for selecting the "strongest" family when an article matches
+ * multiple families. Lower index = higher priority.
+ */
+const FAMILY_PRIORITY: HeuristicFamily[] = [
+  "migration_keyword",
+  "tutorial_signal",
+  "date_context",
+];
+
+// ---------------------------------------------------------------------------
+// Types for input audit JSON
+// ---------------------------------------------------------------------------
+
+interface AuditEntry {
+  slug: string;
+  // NOTE: the audit JSON does not include a "filepath" field.
+  // The absolute path is derived from the slug at runtime.
+  codes_found: string[];
+  has_migration_note: boolean;
+  suggested_replacement: string;
+}
+
+// ---------------------------------------------------------------------------
+// Types for output JSON
+// ---------------------------------------------------------------------------
+
+type Lang = "en" | "id" | "it" | "fr" | "ru";
+
+interface SkipCandidate {
+  slug: string;
+  lang: Lang;
+  reason: string;
+  matched_phrase: string;
+  surrounding_snippet: string;
+  heuristic_family: HeuristicFamily;
+}
+
+interface OutputReport {
+  generated_at: string;
+  total_processed: number;
+  skip_count: number;
+  flag_count: number;
+  heuristic_breakdown: Record<HeuristicFamily, number>;
+  candidates: SkipCandidate[];
+}
+
+// ---------------------------------------------------------------------------
+// Helper: detect language from filepath suffix
+// ---------------------------------------------------------------------------
+
+/**
+ * Derives the article language from the MDX filename suffix.
+ *   foo.id.mdx  → "id"
+ *   foo.it.mdx  → "it"
+ *   foo.fr.mdx  → "fr"
+ *   foo.ru.mdx  → "ru"
+ *   foo.mdx     → "en"  (no lang suffix = default English)
+ */
+function detectLang(filepath: string): Lang {
+  const basename = path.basename(filepath);
+  // Match the optional language code immediately before ".mdx"
+  const match = basename.match(/\.([a-z]{2})\.mdx$/);
+  if (!match) return "en";
+  const code = match[1];
+  if (code === "id" || code === "it" || code === "fr" || code === "ru") {
+    return code;
+  }
+  // Unknown suffix → treat as English
+  return "en";
+}
+
+// ---------------------------------------------------------------------------
+// Helper: resolve absolute disk path from article slug
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the absolute MDX file path from the article slug.
+ *
+ * The audit JSON only contains a "slug" field (no "filepath").
+ * Pattern:
+ *   slug     → "business/bkpm-regulation-5-2025-fdi.fr"
+ *   filepath → "<MONOREPO_ROOT>/apps/mouth/src/content/articles/business/bkpm-regulation-5-2025-fdi.fr.mdx"
+ */
+function resolveFilePath(slug: string): string {
+  return path.join(
+    MONOREPO_ROOT,
+    "apps",
+    "mouth",
+    "src",
+    "content",
+    "articles",
+    slug + ".mdx",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helper: extract article title from raw MDX content
+// ---------------------------------------------------------------------------
+
+/**
+ * Looks for:
+ *   1. A "title:" key inside the frontmatter block (between "---" delimiters).
+ *   2. The first Markdown H1 line (starting with "# ").
+ * Returns an empty string if neither is found.
+ */
+function extractTitle(content: string): string {
+  const lines = content.split("\n");
+  let inFrontmatter = false;
+  let frontmatterClosed = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Detect frontmatter boundaries
+    if (trimmed === "---") {
+      if (!inFrontmatter && !frontmatterClosed) {
+        inFrontmatter = true;
+        continue;
+      }
+      if (inFrontmatter) {
+        inFrontmatter = false;
+        frontmatterClosed = true;
+        continue;
+      }
+    }
+
+    // Inside frontmatter: look for "title:" key
+    if (inFrontmatter) {
+      const titleMatch = trimmed.match(/^title\s*:\s*["']?(.+?)["']?\s*$/i);
+      if (titleMatch) return titleMatch[1];
+    }
+
+    // Outside frontmatter: look for first H1
+    if (frontmatterClosed && trimmed.startsWith("# ")) {
+      return trimmed.slice(2).trim();
+    }
+  }
+
+  return "";
+}
+
+// ---------------------------------------------------------------------------
+// Helper: extract surrounding snippet (±1 sentence) around a phrase
+// ---------------------------------------------------------------------------
+
+/**
+ * Finds the position of `phrase` in `content` (case-insensitive) and returns
+ * a snippet of ±1 sentence around it.
+ *
+ * Strategy:
+ *   - Locate the phrase within the lowercased content.
+ *   - Walk backwards to find the previous sentence boundary (". ", "! ", "? ").
+ *   - Walk forwards to find the next sentence boundary.
+ *   - Cap total snippet length at 400 characters.
+ */
+function extractSnippet(content: string, phrase: string): string {
+  const lower = content.toLowerCase();
+  const phrasePos = lower.indexOf(phrase.toLowerCase());
+  if (phrasePos === -1) return "";
+
+  const MAX_SNIPPET = 400;
+  // Walk back to find sentence start
+  let start = phrasePos;
+  while (start > 0) {
+    const prev = content[start - 1];
+    if ((prev === "." || prev === "!" || prev === "?") && start < phrasePos) {
+      break;
+    }
+    start--;
+    // Limit how far back we walk
+    if (phrasePos - start > MAX_SNIPPET / 2) break;
+  }
+
+  // Walk forward to find sentence end (two sentences after match)
+  const phraseEnd = phrasePos + phrase.length;
+  let end = phraseEnd;
+  let sentenceCount = 0;
+  while (end < content.length && sentenceCount < 2) {
+    const ch = content[end];
+    if (ch === "." || ch === "!" || ch === "?") sentenceCount++;
+    end++;
+    if (end - phrasePos > MAX_SNIPPET) break;
+  }
+
+  return content.slice(start, end).replace(/\s+/g, " ").trim();
+}
+
+// ---------------------------------------------------------------------------
+// Family 1 check: migration_keyword
+// ---------------------------------------------------------------------------
+
+interface HeuristicMatch {
+  matched: boolean;
+  phrase: string;
+  snippet: string;
+}
+
+/**
+ * Checks whether the article body contains any migration_keyword phrase.
+ * Returns the first matching phrase and a surrounding snippet.
+ */
+function checkMigrationKeyword(content: string): HeuristicMatch {
+  const lower = content.toLowerCase();
+  for (const phrase of MIGRATION_KEYWORD_PHRASES) {
+    if (lower.includes(phrase.toLowerCase())) {
+      return {
+        matched: true,
+        phrase,
+        snippet: extractSnippet(content, phrase),
+      };
+    }
+  }
+  return { matched: false, phrase: "", snippet: "" };
+}
+
+// ---------------------------------------------------------------------------
+// Family 2 check: date_context
+// ---------------------------------------------------------------------------
+
+/**
+ * Tokenises the body into words and checks whether a legacy visa code
+ * (B211A or C312) appears within 10 words of any DATE_CONTEXT_ANCHOR.
+ *
+ * Returns the matched anchor phrase and the raw matched phrase
+ * (code + anchor or anchor + code) for the report.
+ */
+function checkDateContext(content: string): HeuristicMatch {
+  // Normalise: lowercase, split on whitespace
+  const words = content.toLowerCase().split(/\s+/);
+
+  for (let i = 0; i < words.length; i++) {
+    const word = words[i];
+
+    // Check if this position is a legacy code token
+    const isCode = LEGACY_CODES.some((code) =>
+      word.includes(code.toLowerCase()),
+    );
+    if (!isCode) continue;
+
+    // Examine a window of ±10 words around the code position
+    const windowStart = Math.max(0, i - 10);
+    const windowEnd = Math.min(words.length - 1, i + 10);
+    const windowTokens = words.slice(windowStart, windowEnd + 1);
+
+    for (const anchor of DATE_CONTEXT_ANCHORS) {
+      const anchorWords = anchor.toLowerCase().split(/\s+/);
+      // Check if the anchor phrase appears in the window
+      for (let j = 0; j <= windowTokens.length - anchorWords.length; j++) {
+        const slice = windowTokens.slice(j, j + anchorWords.length);
+        if (slice.join(" ") === anchorWords.join(" ")) {
+          // Reconstruct a human-readable matched phrase
+          const codeToken = LEGACY_CODES.find((c) =>
+            word.includes(c.toLowerCase()),
+          )!;
+          const matchedPhrase = `${codeToken} near "${anchor}"`;
+          return {
+            matched: true,
+            phrase: matchedPhrase,
+            snippet: extractSnippet(content, anchor),
+          };
+        }
+      }
+    }
+  }
+
+  return { matched: false, phrase: "", snippet: "" };
+}
+
+// ---------------------------------------------------------------------------
+// Family 3 check: tutorial_signal
+// ---------------------------------------------------------------------------
+
+/**
+ * Checks whether the article title (extracted from frontmatter or first H1)
+ * contains any tutorial_signal phrase (case-insensitive).
+ */
+function checkTutorialSignal(content: string): HeuristicMatch {
+  const title = extractTitle(content).toLowerCase();
+  if (!title) return { matched: false, phrase: "", snippet: "" };
+
+  for (const phrase of TUTORIAL_SIGNAL_PHRASES) {
+    if (title.includes(phrase.toLowerCase())) {
+      return {
+        matched: true,
+        phrase,
+        // Snippet is the full title line, as the signal is in the title itself
+        snippet: `Title: "${extractTitle(content)}"`,
+      };
+    }
+  }
+
+  return { matched: false, phrase: "", snippet: "" };
+}
+
+// ---------------------------------------------------------------------------
+// Core: run all 3 heuristic families and select strongest
+// ---------------------------------------------------------------------------
+
+interface ArticleResult {
+  isContextAware: boolean;
+  family: HeuristicFamily | null;
+  matchedPhrase: string;
+  snippet: string;
+}
+
+/**
+ * Runs all three heuristic families against the article content.
+ * All families are always evaluated (additive).
+ * If multiple match, the highest-priority family wins.
+ * Priority: migration_keyword > tutorial_signal > date_context.
+ */
+function analyseArticle(content: string): ArticleResult {
+  const results: Partial<Record<HeuristicFamily, HeuristicMatch>> = {
+    migration_keyword: checkMigrationKeyword(content),
+    tutorial_signal: checkTutorialSignal(content),
+    date_context: checkDateContext(content),
+  };
+
+  // Select strongest matching family according to FAMILY_PRIORITY order
+  for (const family of FAMILY_PRIORITY) {
+    const result = results[family];
+    if (result?.matched) {
+      return {
+        isContextAware: true,
+        family,
+        matchedPhrase: result.phrase,
+        snippet: result.snippet,
+      };
+    }
+  }
+
+  return {
+    isContextAware: false,
+    family: null,
+    matchedPhrase: "",
+    snippet: "",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build human-readable "reason" field from family + phrase
+// ---------------------------------------------------------------------------
+
+/**
+ * Generates a short, readable explanation for why an article is classified
+ * as context-aware, based on the matched heuristic family.
+ */
+function buildReason(family: HeuristicFamily, phrase: string): string {
+  switch (family) {
+    case "migration_keyword":
+      return `Article explicitly references the regulatory change (matched: "${phrase}")`;
+    case "date_context":
+      return `Legacy code appears in temporal context (${phrase})`;
+    case "tutorial_signal":
+      return `Article title signals historical/educational intent (matched: "${phrase}")`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  // ------------------------------------------------------------------
+  // 1. Load input audit JSON
+  // ------------------------------------------------------------------
+  if (!fs.existsSync(INPUT_FILE)) {
+    console.error(`[ERROR] Input file not found: ${INPUT_FILE}`);
+    console.error(
+      "        Run audit-outdated-visa-codes.ts first to generate it.",
+    );
+    process.exit(1);
+  }
+
+  const rawInput = fs.readFileSync(INPUT_FILE, "utf-8");
+  const auditEntries: AuditEntry[] = JSON.parse(rawInput);
+
+  // ------------------------------------------------------------------
+  // 2. Initialise counters
+  // ------------------------------------------------------------------
+  let skipCount = 0;
+  let flagCount = 0;
+  let notFoundCount = 0;
+  const breakdown: Record<HeuristicFamily, number> = {
+    migration_keyword: 0,
+    date_context: 0,
+    tutorial_signal: 0,
+  };
+  const candidates: SkipCandidate[] = [];
+
+  // ------------------------------------------------------------------
+  // 3. Process each audit entry
+  // ------------------------------------------------------------------
+  for (const entry of auditEntries) {
+    // Build the absolute path from the slug — entry.filepath does not exist in the JSON
+    const absPath = resolveFilePath(entry.slug);
+
+    // Guard: file must exist on disk
+    if (!fs.existsSync(absPath)) {
+      console.warn(`[WARN] File not found on disk: ${absPath}`);
+      notFoundCount++;
+      continue;
+    }
+
+    // Read MDX as plain text — no parser needed
+    let content: string;
+    try {
+      content = fs.readFileSync(absPath, "utf-8");
+    } catch (err) {
+      console.warn(`[WARN] Could not read file: ${absPath} — ${String(err)}`);
+      notFoundCount++;
+      continue;
+    }
+
+    // Run heuristic analysis
+    const result = analyseArticle(content);
+
+    if (result.isContextAware && result.family) {
+      // Context-aware: add to candidates list
+      skipCount++;
+      breakdown[result.family]++;
+
+      // Detect language from the slug suffix (e.g. "foo.fr" → "fr")
+      const lang = detectLang(entry.slug);
+      candidates.push({
+        slug: entry.slug,
+        lang,
+        reason: buildReason(result.family, result.matchedPhrase),
+        matched_phrase: result.matchedPhrase,
+        surrounding_snippet: result.snippet,
+        heuristic_family: result.family,
+      });
+
+      console.log(
+        `[SKIP]  ${entry.slug} | family: ${result.family} | phrase: "${result.matchedPhrase}"`,
+      );
+    } else {
+      // Not context-aware: needs a migration note
+      flagCount++;
+      console.log(`[FLAG]  ${entry.slug} | no match`);
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // 4. Print summary to console
+  // ------------------------------------------------------------------
+  const total = auditEntries.length;
+  console.log("\n─────────────────────────────────────────────");
+  console.log(`Total processed           : ${total}`);
+  console.log(`Context-aware (SKIP)      : ${skipCount}`);
+  console.log(`  - migration_keyword     : ${breakdown.migration_keyword}`);
+  console.log(`  - date_context          : ${breakdown.date_context}`);
+  console.log(`  - tutorial_signal       : ${breakdown.tutorial_signal}`);
+  console.log(`Needs migration note      : ${flagCount}`);
+  console.log(`File not found on disk    : ${notFoundCount}`);
+  console.log("─────────────────────────────────────────────");
+
+  // ------------------------------------------------------------------
+  // 5. Write output JSON
+  // ------------------------------------------------------------------
+  const report: OutputReport = {
+    generated_at: new Date().toISOString(),
+    total_processed: total,
+    skip_count: skipCount,
+    flag_count: flagCount,
+    heuristic_breakdown: breakdown,
+    candidates,
+  };
+
+  const outputDir = path.dirname(OUTPUT_FILE);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+
+  fs.writeFileSync(OUTPUT_FILE, JSON.stringify(report, null, 2), "utf-8");
+  console.log(`\nOutput saved to: ${OUTPUT_FILE}`);
+}
+
+main();

--- a/apps/mouth/scripts/retag-news.ts
+++ b/apps/mouth/scripts/retag-news.ts
@@ -1,0 +1,290 @@
+/**
+ * retag-news.ts
+ *
+ * Scans immigration, business, and tax-legal article folders.
+ * If the slug OR the frontmatter title matches a "news" keyword and the file
+ * does NOT already have category: "news", inserts that field.
+ *
+ * Run with:
+ *   npx ts-node scripts/retag-news.ts
+ *   npx tsx   scripts/retag-news.ts
+ *
+ * Set DRY_RUN = false to apply actual writes.
+ */
+
+import fs from "fs";
+import path from "path";
+
+// ---------------------------------------------------------------------------
+// Config — flip to false to write files
+// ---------------------------------------------------------------------------
+
+const DRY_RUN = false;
+
+// ---------------------------------------------------------------------------
+// Directories to scan (relative to apps/mouth/)
+// ---------------------------------------------------------------------------
+
+const MOUTH_ROOT = path.resolve(__dirname, "..");
+
+const SCAN_DIRS = [
+  path.join(MOUTH_ROOT, "src", "content", "articles", "immigration"),
+  path.join(MOUTH_ROOT, "src", "content", "articles", "business"),
+  path.join(MOUTH_ROOT, "src", "content", "articles", "tax-legal"),
+];
+
+// ---------------------------------------------------------------------------
+// News keyword lists
+// ---------------------------------------------------------------------------
+
+/**
+ * Keywords checked against the SLUG (hyphen-separated, lowercase).
+ * Year/date patterns are intentionally excluded — too broad for evergreen articles.
+ */
+const SLUG_KEYWORDS = [
+  "news",
+  "update",
+  "alert",
+  "announces",
+  "reshuffle",
+  "arrives",
+  "launches",
+  "breaking",
+  "latest",
+  "new-regulation",
+  "new-rule",
+  "amendment",
+  "circular",
+  "decree",
+  "enacted",
+  "effective-",
+  "deports",
+  "arrests",
+  "raids",
+  "bans",
+  "halts",
+  "confirms",
+  "approves",
+  "rejects",
+  "expels",
+];
+
+/**
+ * Keywords checked against the frontmatter TITLE field (natural language,
+ * may contain spaces — matched case-insensitively as substrings).
+ */
+const TITLE_KEYWORDS = [
+  "news",
+  "update",
+  "alert",
+  "announces",
+  "reshuffle",
+  "arrives",
+  "launches",
+  "breaking",
+  "latest",
+  "new regulation",
+  "new rule",
+  "amendment",
+  "circular",
+  "decree",
+  "enacted",
+  "effective",
+  "deports",
+  "arrests",
+  "raids",
+  "bans",
+  "halts",
+  "confirms",
+  "approves",
+  "rejects",
+  "expels",
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Recursively collect all .mdx files under a directory. */
+function collectMdx(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const results: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectMdx(full));
+    } else if (entry.isFile() && entry.name.endsWith(".mdx")) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+/** Extract the bare slug from a file path (filename without .mdx). */
+function slugFromPath(filePath: string): string {
+  return path.basename(filePath, ".mdx");
+}
+
+/**
+ * Extract the raw value of the `title:` field from the frontmatter block.
+ * Returns an empty string if not found.
+ */
+function extractTitle(content: string): string {
+  const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!fmMatch) return "";
+  // Match: title: "Some Title" or title: Some Title (quoted or unquoted)
+  const titleLine = fmMatch[1]
+    .split(/\r?\n/)
+    .find((l) => /^\s*title\s*:/i.test(l));
+  if (!titleLine) return "";
+  return titleLine
+    .replace(/^\s*title\s*:\s*/i, "") // strip the key
+    .replace(/^"|"$/g, "") // strip surrounding double quotes
+    .replace(/^'|'$/g, "") // strip surrounding single quotes
+    .trim();
+}
+
+/**
+ * Check the slug against SLUG_KEYWORDS.
+ * Returns the first matching keyword, or null if none match.
+ */
+function slugMatchKeyword(slug: string): string | null {
+  const lower = slug.toLowerCase();
+  return SLUG_KEYWORDS.find((kw) => lower.includes(kw)) ?? null;
+}
+
+/**
+ * Check the title against TITLE_KEYWORDS.
+ * Returns the first matching keyword, or null if none match.
+ */
+function titleMatchKeyword(title: string): string | null {
+  const lower = title.toLowerCase();
+  return TITLE_KEYWORDS.find((kw) => lower.includes(kw)) ?? null;
+}
+
+/**
+ * Returns true when the raw frontmatter block already contains
+ * a `category: "news"` (or `category: news`) field.
+ * Only looks inside the first --- ... --- block.
+ */
+function hasNewsCategory(content: string): boolean {
+  const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!fmMatch) return false;
+  const fm = fmMatch[1];
+  // Match both quoted and unquoted variants
+  return /^\s*category\s*:\s*["']?news["']?\s*$/im.test(fm);
+}
+
+/**
+ * Insert `category: "news"` after the first frontmatter field.
+ *
+ * Strategy:
+ *  1. Locate the opening ---.
+ *  2. Find the first non-empty line inside the frontmatter block.
+ *  3. Insert category: "news" on the very next line.
+ *
+ * This preserves all other content byte-for-byte.
+ */
+function insertNewsCategory(content: string): string {
+  // Match: "---\n" + everything up to closing "---"
+  const fmRegex = /^(---\r?\n)([\s\S]*?)(\r?\n---)/;
+  const match = content.match(fmRegex);
+  if (!match) return content; // No frontmatter found — skip
+
+  const opener = match[1]; // "---\n"
+  const fmBody = match[2]; // raw frontmatter lines
+  const closer = match[3]; // "\n---"
+
+  // Split frontmatter into individual lines
+  const lines = fmBody.split(/\r?\n/);
+
+  // Find the index of the first non-empty line (= first real field)
+  const firstFieldIdx = lines.findIndex((l) => l.trim() !== "");
+
+  if (firstFieldIdx === -1) {
+    // Frontmatter is empty — just prepend the field
+    const newFm = `category: "news"\n${fmBody}`;
+    return content.replace(fmRegex, `${opener}${newFm}${closer}`);
+  }
+
+  // Insert category: "news" right after the first field line
+  lines.splice(firstFieldIdx + 1, 0, `category: "news"`);
+  const newFm = lines.join("\n");
+  return content.replace(fmRegex, `${opener}${newFm}${closer}`);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  if (DRY_RUN) {
+    console.log("=== DRY RUN MODE — no files will be written ===\n");
+  }
+
+  // Collect every .mdx file across all target directories
+  const allFiles: string[] = SCAN_DIRS.flatMap(collectMdx);
+
+  let totalMatched = 0;
+  let totalSkipped = 0; // already had category: news
+  let totalUpdated = 0;
+  let dryRunPrinted = 0; // counter for the first-10 preview
+
+  for (const filePath of allFiles) {
+    const slug = slugFromPath(filePath);
+    const content = fs.readFileSync(filePath, "utf-8");
+    const title = extractTitle(content);
+
+    // Step 1 — check slug OR title against their respective keyword lists
+    const slugHit = slugMatchKeyword(slug);
+    const titleHit = titleMatchKeyword(title);
+    if (!slugHit && !titleHit) continue;
+    totalMatched++;
+
+    // Step 2 — skip if category: news already present
+    if (hasNewsCategory(content)) {
+      totalSkipped++;
+      continue;
+    }
+
+    // Step 3 — apply or preview
+    if (DRY_RUN) {
+      if (dryRunPrinted < 10) {
+        console.log(`[WOULD UPDATE] ${path.relative(MOUTH_ROOT, filePath)}`);
+        console.log(`  slug    : ${slug}`);
+        console.log(`  title   : ${title || "(no title field)"}`);
+
+        // Show whether the trigger came from slug, title, or both
+        const triggers: string[] = [];
+        if (slugHit) triggers.push(`slug:"${slugHit}"`);
+        if (titleHit) triggers.push(`title:"${titleHit}"`);
+        console.log(`  matched : ${triggers.join(", ")}`);
+        console.log();
+        dryRunPrinted++;
+      }
+      totalUpdated++; // count "would update" in dry run
+    } else {
+      // Live mode — write the modified content back
+      const updated = insertNewsCategory(content);
+      fs.writeFileSync(filePath, updated, "utf-8");
+      totalUpdated++;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Summary
+  // ---------------------------------------------------------------------------
+  const label = DRY_RUN ? "Would update" : "Updated";
+
+  console.log("=== retag-news Summary ===");
+  console.log(`Total files scanned               : ${allFiles.length}`);
+  console.log(`Total matched (news pattern)      : ${totalMatched}`);
+  console.log(`Already had category: news (skip) : ${totalSkipped}`);
+  console.log(`${label.padEnd(33)}: ${totalUpdated}`);
+
+  if (DRY_RUN) {
+    console.log("\nSet DRY_RUN = false and re-run to apply changes.");
+  }
+}
+
+main();

--- a/research/marketing/2026-05-11-skip-slugs-candidates.json
+++ b/research/marketing/2026-05-11-skip-slugs-candidates.json
@@ -1,0 +1,109 @@
+{
+  "generated_at": "2026-05-12T02:22:55.198Z",
+  "total_processed": 220,
+  "skip_count": 12,
+  "flag_count": 208,
+  "heuristic_breakdown": {
+    "migration_keyword": 1,
+    "date_context": 0,
+    "tutorial_signal": 11
+  },
+  "candidates": [
+    {
+      "slug": "immigration/constitutional-clash-bank-statements",
+      "lang": "en",
+      "reason": "Article explicitly references the regulatory change (matched: \"replaced by\")",
+      "matched_phrase": "replaced by",
+      "surrounding_snippet": "- Replaced by stricter enforcement of existing deportation laws - Focus shifts to \"behavior\" not \"wealth\" - No new regulations published - Business as usual --- ## PRECEDENTS: Koster's Track Record Governor Koster has a history of bold announcements that evolve significantly before implementation: | Announcement | Outcome | | ---------------------- | ----------",
+      "heuristic_family": "migration_keyword"
+    },
+    {
+      "slug": "immigration/e25b-director-kitas-guide.fr",
+      "lang": "en",
+      "reason": "Article title signals historical/educational intent (matched: \"timeline\")",
+      "matched_phrase": "timeline",
+      "surrounding_snippet": "Title: \"E25B Director KITAS 2026: Requirements, Costs, Timeline, and Complete Application Guide\"",
+      "heuristic_family": "tutorial_signal"
+    },
+    {
+      "slug": "immigration/e25b-director-kitas-guide.id",
+      "lang": "en",
+      "reason": "Article title signals historical/educational intent (matched: \"timeline\")",
+      "matched_phrase": "timeline",
+      "surrounding_snippet": "Title: \"E25B Director KITAS 2026: Persyaratan, Biaya, Timeline, dan Panduan Aplikasi Lengkap\"",
+      "heuristic_family": "tutorial_signal"
+    },
+    {
+      "slug": "immigration/e25b-director-kitas-guide.it",
+      "lang": "en",
+      "reason": "Article title signals historical/educational intent (matched: \"timeline\")",
+      "matched_phrase": "timeline",
+      "surrounding_snippet": "Title: \"E25B Director KITAS 2026: Requisiti, Costi, Timeline e Guida Completa all'Applicazione\"",
+      "heuristic_family": "tutorial_signal"
+    },
+    {
+      "slug": "immigration/e25b-director-kitas-guide",
+      "lang": "en",
+      "reason": "Article title signals historical/educational intent (matched: \"timeline\")",
+      "matched_phrase": "timeline",
+      "surrounding_snippet": "Title: \"E25B Director KITAS 2026: Requirements, Costs, Timeline, and Complete Application Guide\"",
+      "heuristic_family": "tutorial_signal"
+    },
+    {
+      "slug": "immigration/e25b-director-kitas-guide.ru",
+      "lang": "en",
+      "reason": "Article title signals historical/educational intent (matched: \"timeline\")",
+      "matched_phrase": "timeline",
+      "surrounding_snippet": "Title: \"E25B Director KITAS 2026: Requirements, Costs, Timeline, and Complete Application Guide\"",
+      "heuristic_family": "tutorial_signal"
+    },
+    {
+      "slug": "immigration/immigration-checks-documents-carry-indonesia.id",
+      "lang": "en",
+      "reason": "Article title signals historical/educational intent (matched: \"migrasi\")",
+      "matched_phrase": "migrasi",
+      "surrounding_snippet": "Title: \"Pemeriksaan Imigrasi dan Dokumen yang Wajib Dibawa di Indonesia 2026: Panduan Lengkap\"",
+      "heuristic_family": "tutorial_signal"
+    },
+    {
+      "slug": "immigration/indonesia-visa-timeline-comparison.fr",
+      "lang": "en",
+      "reason": "Article title signals historical/educational intent (matched: \"timeline\")",
+      "matched_phrase": "timeline",
+      "surrounding_snippet": "Title: \"Indonesia Visa Processing Times 2026: Side-by-Side Timeline Comparison of Every Visa Type\"",
+      "heuristic_family": "tutorial_signal"
+    },
+    {
+      "slug": "immigration/indonesia-visa-timeline-comparison.id",
+      "lang": "en",
+      "reason": "Article title signals historical/educational intent (matched: \"timeline\")",
+      "matched_phrase": "timeline",
+      "surrounding_snippet": "Title: \"Waktu Pemrosesan Visa Indonesia 2026: Perbandingan Timeline Berdampingan untuk Setiap Jenis Visa\"",
+      "heuristic_family": "tutorial_signal"
+    },
+    {
+      "slug": "immigration/indonesia-visa-timeline-comparison.it",
+      "lang": "en",
+      "reason": "Article title signals historical/educational intent (matched: \"timeline\")",
+      "matched_phrase": "timeline",
+      "surrounding_snippet": "Title: \"Tempi di Elaborazione Visto Indonesia 2026: Confronto Affiancato delle Timeline per Ogni Tipo di Visto\"",
+      "heuristic_family": "tutorial_signal"
+    },
+    {
+      "slug": "immigration/indonesia-visa-timeline-comparison",
+      "lang": "en",
+      "reason": "Article title signals historical/educational intent (matched: \"timeline\")",
+      "matched_phrase": "timeline",
+      "surrounding_snippet": "Title: \"Indonesia Visa Processing Times 2026: Side-by-Side Timeline Comparison of Every Visa Type\"",
+      "heuristic_family": "tutorial_signal"
+    },
+    {
+      "slug": "immigration/indonesia-visa-timeline-comparison.ru",
+      "lang": "en",
+      "reason": "Article title signals historical/educational intent (matched: \"timeline\")",
+      "matched_phrase": "timeline",
+      "surrounding_snippet": "Title: \"Indonesia Visa Processing Times 2026: Side-by-Side Timeline Comparison of Every Visa Type\"",
+      "heuristic_family": "tutorial_signal"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a content audit toolkit from the May 8–11 SEO cleanup cycle.

## Files

* `apps/mouth/scripts/identify-skip-slugs.ts` — read-only heuristic to detect context-aware articles (legacy visa codes B211A, C312)
* `apps/mouth/scripts/retag-news.ts` — auto-inserts `category: "news"` for news-flavored articles (`DRY_RUN` defaults to `false`)
* `research/marketing/2026-05-11-skip-slugs-candidates.json` — audit output: 220 processed, 12 skipped, 208 flagged
* `.gitignore` — excludes `apps/mouth/scripts/output/` (artifact folder)

## Context

Utility tools for visa nomenclature audits related to the March 26, 2026 immigration regulation changes (C1/C2 visa retirement and E33G introduction).

## How to Use

```bash
# Step 1: Generate audit data (separate script, not included in this PR)

# Step 2: Identify articles to skip (included in this PR)
npx ts-node apps/mouth/scripts/identify-skip-slugs.ts

# Step 3: Apply news retag
# Recommended: set DRY_RUN=true first for preview
npx ts-node apps/mouth/scripts/retag-news.ts
```

## Safety

* `identify-skip-slugs.ts` **never modifies files** (read-only heuristic)
* `retag-news.ts` includes a `DRY_RUN` flag — recommended to run with `DRY_RUN=true` first for preview

## Review

**Non-blocking** — utility tooling only, does not modify existing published articles.
