### PR TITLE
fix(analytics): emit property_whatsapp_cta in trackPropertyWACTA

### DIFF
--- a/apps/mouth/src/lib/analytics.ts
+++ b/apps/mouth/src/lib/analytics.ts
@@ -453,14 +453,14 @@ export function trackPropertyChatQuestion(articleSlug: string): void {
   });
 }
 
-/** Track property WA CTA click (placeholder for property_chat_question) */
+/** Track property WhatsApp CTA click */
 export function trackPropertyWACTA(): void {
-  sendGA4Event("property_chat_question", {
+  sendGA4Event("property_whatsapp_cta", {
     event_category: "Property",
     cta_type: "whatsapp",
   });
-  trackEvent("property_chat_question", { cta_type: "whatsapp" });
-  void trackFunnelEvent("property_chat_question", {
+  trackEvent("property_whatsapp_cta", { cta_type: "whatsapp" });
+  void trackFunnelEvent("property_whatsapp_cta", {
     sessionId: getOrCreateSessionId(),
     payload: { cta_type: "whatsapp" },
   });


### PR DESCRIPTION
## fix(analytics): emit property_whatsapp_cta in trackPropertyWACTA

`trackPropertyWACTA()` fires `property_chat_question` instead of `property_whatsapp_cta` in all three dispatches (GA4, internal CRM, backend funnel). Renames event name to the correct registry entry. Single-file, 4-line change.

### Studio Layer

**Insight**
Property WA CTA clicks (non-header surface) currently attribute to `property_chat_question` bucket instead of `property_whatsapp_cta`. Two metrics contaminated: chat questions inflated, WhatsApp CTA undercounted on property funnel.

**Evidence**
- `apps/mouth/src/lib/analytics.ts:455–467` — function name + JSDoc says WA, but all 3 dispatches (GA4, CRM, funnel-event) emit `property_chat_question`. Original JSDoc `"placeholder for property_chat_question"` confirms ini legacy placeholder yang tidak pernah di-rename.
- `packages/core/analytics/funnel-view.ts:32` — `property_whatsapp_cta` registered, emitted via `HeaderWhatsAppCTA.tsx`.
- `apps/mouth/src/components/funnel/HeaderWhatsAppCTA.test.tsx:30` — parametrized test confirms `property_whatsapp_cta` is the correct registry key for property WA surface.
- Caller: 1 production usage at `apps/mouth/src/components/funnel/PropertyEligibilityBody.tsx:366`. No signature change needed.

**Reasoning**
Mismatch is a pure naming bug, not architectural. Header WA CTA already emits correct event via `HeaderWhatsAppCTA.tsx`. The non-header function `trackPropertyWACTA` should follow the same convention. Registry entry exists, no new event added. TypeScript-safe.

**Risk**
- Backward compat: any GA4 funnels or CRM rules keyed on `property_chat_question` for Property surface will see a small drop in volume after merge → notify Antonello to review CRM/GA4 dashboards.
- Historical data: pre-merge clicks remain logged under wrong bucket, no retroactive fix possible.
- Caller blast: 1 file (`PropertyEligibilityBody.tsx`), no signature change → zero downstream code impact.

**Recommendation**
Merge after CI green. Smoke test on staging post-merge.

**Next Action**
1. CI green → merge.
2. Post-merge smoke test on staging: click Property WA CTA → DevTools Network → verify `/api/analytics/funnel-event` payload `event = "property_whatsapp_cta"` + GA4 real-time event matches.
3. Notify Antonello about the attribution shift so CRM/GA4 dashboards keyed on `property_chat_question` for Property surface can be reviewed.
4. Optional follow-up (separate PR): add unit test asserting `trackPropertyWACTA` emits correct event name — prevent regression.