### PR TITLE
feat(docker): BuildKit cache mounts on 4 Dockerfile

### DIFF
--- a/apps/backend-rag/Dockerfile
+++ b/apps/backend-rag/Dockerfile
@@ -1,8 +1,16 @@
+# syntax=docker/dockerfile:1.7
 # ZANTARA RAG Backend — Fly.io Deployment (OPTIMIZED FOR <8GB)
 # Multi-stage build. Python 3.11 + FastAPI + Qdrant + Sentence Transformers.
 #
 # BUILD CONTEXT: monorepo root (set by `flyctl deploy --dockerfile apps/backend-rag/Dockerfile --config apps/backend-rag/fly.toml` in .github/workflows/fly-deploy.yml).
 # Local: `docker build -f apps/backend-rag/Dockerfile -t rag-test .` FROM repo root, not from apps/backend-rag/.
+#
+# BuildKit cache mounts (added 2026-05-18): pip cache mounted at /root/.cache/pip
+# (default pip user-cache for root). Cache persists across builds, drastically
+# reducing rebuild time for ML deps (torch + transformers + sentence-transformers).
+# `--no-cache-dir` flag is REMOVED — it instructs pip to NOT write to its cache,
+# which is counterproductive with cache mounts. The `--user` install target
+# (/root/.local) is separate from the pip cache (/root/.cache/pip).
 
 # ========================================
 # Stage 1: Build Stage
@@ -34,7 +42,8 @@ COPY apps/backend-rag /app/apps/backend-rag
 # Install Python dependencies (skip Playwright browsers to save ~500MB)
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 WORKDIR /app/apps/backend-rag
-RUN pip install --no-cache-dir --user -r requirements-prod.txt \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    pip install --user -r requirements-prod.txt \
     && find /root/.local -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true \
     && find /root/.local -type f -name "*.pyc" -delete \
     && find /root/.local -type f -name "*.pyo" -delete

--- a/apps/bali-intel-scraper/Dockerfile
+++ b/apps/bali-intel-scraper/Dockerfile
@@ -1,4 +1,9 @@
+# syntax=docker/dockerfile:1.7
 # Multi-stage build for Bali Intel Scraper
+#
+# BuildKit cache mount (added 2026-05-18): pip cache at /root/.cache/pip
+# persists across builds. `--no-cache-dir` removed (counterproductive with
+# cache mounts — it tells pip not to write to the cache we now persist).
 
 # Stage 1: Builder
 FROM python:3.11-slim as builder
@@ -17,8 +22,9 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 # Install dependencies
 COPY requirements.txt .
-RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    pip install --upgrade pip && \
+    pip install -r requirements.txt
 
 # Download NLTK data
 RUN python -c "import nltk; nltk.download('punkt'); nltk.download('stopwords')"

--- a/apps/mouth/Dockerfile
+++ b/apps/mouth/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1.7
 
 # ============================================
 # Stage 1: Dependencies
@@ -13,7 +13,12 @@ RUN apk add --no-cache libc6-compat
 COPY package.json ./
 
 # Install dependencies (using npm install for monorepo compatibility)
-RUN npm install --legacy-peer-deps --ignore-scripts
+# BuildKit cache mount (added 2026-05-18): persists npm cache (/root/.npm)
+# across builds. --prefer-offline tells npm to use cached tarballs first
+# (synergy with the cache mount). Keep --legacy-peer-deps + --ignore-scripts
+# (existing monorepo compat behavior, unchanged).
+RUN --mount=type=cache,target=/root/.npm,sharing=locked \
+    npm install --legacy-peer-deps --ignore-scripts --prefer-offline
 
 # ============================================
 # Stage 2: Builder

--- a/scripts/exporters/.dockerignore
+++ b/scripts/exporters/.dockerignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+.venv/
+venv/
+.git/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+*.egg-info/
+.DS_Store

--- a/scripts/exporters/Dockerfile
+++ b/scripts/exporters/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 FROM python:3.12-slim
 WORKDIR /app
 COPY cron_exporter.py .


### PR DESCRIPTION
## Summary
Wave 2 modernization #8 (audit 2026-05-18). Adds BuildKit cache mounts to all 4 Dockerfile to cut CI build time substantially (-40-60% expected on backend-rag where ML deps dominate).

## Changes
- **`apps/backend-rag/Dockerfile`** (biggest impact): `pip install --user -r requirements-prod.txt` now wrapped with `--mount=type=cache,target=/root/.cache/pip,sharing=locked`. Drops `--no-cache-dir`.
- **`apps/bali-intel-scraper/Dockerfile`**: same pattern, both pip steps wrapped.
- **`apps/mouth/Dockerfile`**: `npm install --legacy-peer-deps --ignore-scripts --prefer-offline` wrapped with `--mount=type=cache,target=/root/.npm,sharing=locked`.
- **`scripts/exporters/Dockerfile`**: `# syntax=docker/dockerfile:1.7` header for consistency (no pip install present).
- **`scripts/exporters/.dockerignore`**: created (was missing per audit).

All 4 Dockerfile now declare `# syntax=docker/dockerfile:1.7`.

## Notes
- Cache mounts persist across builds (per-Dockerfile-per-step semantics).
- `--no-cache-dir` removed where present — counterproductive with persistent cache.
- Multi-stage builds preserved, USER non-root preserved, build context (monorepo root) unchanged.
- Fly.io uses BuildKit by default, no workflow changes needed.

## Test plan
- [ ] Fly deploy successful (auto via `fly-deploy.yml`)
- [ ] Backend-rag deploy time noticeably reduced on 2nd build vs 1st (cold cache)
- [ ] Mouth `npm ci` time reduced on 2nd build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>