### PR TITLE
fix(golden-rule-10): preserve exempt marker after ruff-format

### DIFF
--- a/apps/backend-rag/backend/services/integrations/team_drive_service.py
+++ b/apps/backend-rag/backend/services/integrations/team_drive_service.py
@@ -29,9 +29,10 @@ class TeamDriveService:
 
         # 1. Ottimizzazione HTTP: Client asincrono condiviso per reuse delle connessioni.
         limits = httpx.Limits(max_keepalive_connections=20, max_connections=100)
-        self.http_client = httpx.AsyncClient(
+        # golden-rule-10-exempt: process-wide singleton, close() wired in app_factory.lifespan via app.state.team_drive_service
+        self.http_client = httpx.AsyncClient(  # golden-rule-10-exempt
             limits=limits, timeout=30.0
-        )  # golden-rule-10-exempt: process-wide singleton, close() wired in app_factory.lifespan via app.state.team_drive_service
+        )
 
         # 2. Inizializzazione dei sottomoduli (Dependency Injection interna)
         self.audit = DriveAuditLogger()


### PR DESCRIPTION
## Summary
Fix `Backend Tests (Python)` + `Detect Golden Rule` CI fails on `main` (post-#752 ruff-format sweep).

## Root cause
PR #752 ran `ruff format` on 1350 files. The exempt comment on `team_drive_service.py:32` was on the **closing-paren line** of the multi-line `httpx.AsyncClient(...)` call. The test `test_no_httpx_violators_outside_http_files` checks for the `# golden-rule-10-exempt` marker **only on the line containing `httpx.AsyncClient(`**.

Result: test sees a "bare" instantiation and fails with `VIOLATION_INSTANCE_INIT`.

## Fix
3 LOC change: keep the human-readable rationale on the preceding line AND add a short `# golden-rule-10-exempt` tag on the instantiation line itself.

## Verification
- ✅ `pytest backend/tests/app/setup/test_no_httpx_violators.py -q` → 1/1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>