### PR TITLE
fix(agent-library): EvoSkill default SDK deepseek (Phase 1 hotfix)

### DIFF
--- a/vendor/evoskill/src/harness/sdk_config.py
+++ b/vendor/evoskill/src/harness/sdk_config.py
@@ -11,9 +11,23 @@ from typing import Literal
 SDKType = Literal["claude", "opencode", "codex", "goose", "openhands", "deepseek"]
 
 # Global SDK selection (can be overridden via CLI arguments).
-# Default remains "claude" for upstream compatibility — Bali Zero
-# evolver.toml explicitly sets "deepseek" before any .run() call.
-_current_sdk: SDKType = "claude"
+#
+# Phase 1 post-merge hotfix 2026-05-19: default was "claude" for
+# upstream compatibility, BUT several agent_profiles modules call
+# `build_options()` at MODULE-LOAD TIME (e.g., proposer.py:35
+# `proposer_options = get_proposer_options()` → build_options(...) →
+# `if sdk == "claude": raise ImportError(...)` from harness/utils.py
+# Phase 0 strip). This crashed `uv run evoskill run` on first
+# import — verified by the kickstart smoke run at 13:12:48 WITA
+# 2026-05-19. evolver.toml `[harness] name="deepseek"` is read by
+# load_config() AFTER the agent_profiles import chain completed,
+# too late to influence the module-load build_options() calls.
+#
+# Fix: default to "deepseek" so module-load build_options() calls
+# route to the sanctioned executor instead of the stripped claude
+# stub. CLI `--harness` flag or evolver.toml still override at run
+# time for any future scenario where a different SDK is needed.
+_current_sdk: SDKType = "deepseek"
 
 _VALID_SDKS = ("claude", "opencode", "codex", "goose", "openhands", "deepseek")
 


### PR DESCRIPTION
## Summary

LaunchAgent kickstart smoke 2026-05-19 13:12 WITA (PR #753 Phase 1
post-merge) failed with ImportError raised at module-load time:

\`\`\`
src/agent_profiles/proposer/proposer.py:35
  proposer_options = get_proposer_options()
src/agent_profiles/proposer/proposer.py:26
  return build_options(...)  # uses default SDK
src/harness/utils.py:77 (Phase 0 strip)
  if sdk == "claude":
      raise ImportError("Claude SDK disabled per CLAUDE.md hard rule")
\`\`\`

## Root cause

agent_profiles modules call \`build_options()\` at MODULE-LOAD time during
\`from src.agent_profiles.base_agent.base_agent import ...\` in
\`src/cli/commands/run.py:306\`. \`evolver.toml [harness] name="deepseek"\`
is read by \`load_config()\` AFTER the import chain completes — too
late to override \`_current_sdk\`.

The Phase 0 strip raised ImportError for \`sdk == "claude"\` precisely
to fail-loud, but it crashes the entire import chain rather than just
the executor invocation path.

## Fix

\`src/harness/sdk_config.py:\` change \`_current_sdk: SDKType = "claude"\`
to \`"deepseek"\`. Default routes to the sanctioned executor; explicit
\`set_sdk("claude")\` or \`evolver.toml harness.name\` override still works.

## Verification

- \`from src.agent_profiles.proposer import proposer_options\` succeeds locally
- 99/99 Phase 1 tests PASS (35 redactor + 21 deepseek + 20 evidence + 23 entailment)
- No regression on the loud-raise contract: explicit \`set_sdk("claude")\` then \`build_options()\` still raises ImportError

Telegram alert from kickstart failure was correctly received (message_id 45422, chat 1125336968 Zero) — fail-loud + alert path works end-to-end.

## Test plan

- [ ] Pull branch + run \`pytest scripts/test_*.py\` (99/99 PASS)
- [ ] Run \`uv run --directory vendor/evoskill python -c 'from src.agent_profiles.proposer import proposer_options'\` (no ImportError)
- [ ] Re-kickstart LaunchAgent post-merge: \`launchctl kickstart -k gui/\$(id -u)/com.balizero.agent-library-evolver.weekly\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)