### PR TITLE
feat(wa-mirror): v2 strict E.164 + @lid parsing + additive schema (steps 1-2 of 8)

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/185_wa_mirror_v2_lid_session_history_ocr.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/185_wa_mirror_v2_lid_session_history_ocr.sql
@@ -1,0 +1,164 @@
+-- migration 185_wa_mirror_v2_lid_session_history_ocr
+-- wa-mirror v2 architecture: LID resolution map, session-flap audit trail,
+-- OCR worker queue, and FTS-ready trigram index for the intelligence layer.
+--
+-- Purely additive. All ALTER TABLE statements use ADD COLUMN IF NOT EXISTS;
+-- all CREATE statements use IF NOT EXISTS. Safe to re-apply.
+--
+-- Context (verified 2026-05-19 against production `nuzantara_rag`):
+-- - whatsapp_message_context: 15,209 rows, 0% client_id match because
+--   counterpart_phone was synthesised wrong for @lid identifiers (WhatsApp
+--   privacy-shielded contacts, rolled out late 2024).
+-- - whatsapp_team_sessions: 4,545 rows of which 4,538 status='revoked' from
+--   the reconnect-flap loop (Sahira alone has 1,116 rows). UPSERT on a
+--   single state row was needed but lost the audit trail; the new
+--   whatsapp_session_history table is the append-only ledger, current state
+--   reads via the whatsapp_current_sessions view.
+-- - OCR: 66 media files downloaded, 0 processed. Worker queue lives in
+--   whatsapp_message_context.ocr_status (pending / done / error).
+-- - FTS: GIN trgm index on message_text enables the daily-digest cron to
+--   surface KITAS / E33G / PT PMA mentions without a vector DB.
+--
+-- Squawk: ADD COLUMN with no DEFAULT on non-empty table is fast in PG 11+
+-- (catalog-only metadata change). pg_trgm extension is shipped with PG 14+
+-- on Fly.io's nuzantara-postgres v0.1.0.
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- ───────────────────────────────────────────────────────────────────────
+-- 1. whatsapp_lid_phone_map — LID resolution, per (team_member, LID) pair.
+--    LID is NOT globally unique: WhatsApp assigns a different LID to the
+--    same counterpart per linked-device pairing. Composite PK enforces.
+-- ───────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS whatsapp_lid_phone_map (
+    team_member_phone   VARCHAR(32) NOT NULL,
+    lid                 VARCHAR(64) NOT NULL,
+    jid_phone           VARCHAR(32),                -- canonical E.164 once resolved; NULL while unresolved
+    pushname            TEXT,                       -- counterpart's display name as broadcast by WhatsApp
+    source              VARCHAR(32) NOT NULL DEFAULT 'contacts_upsert',
+                                                    -- 'contacts_upsert' | 'manual' | 'message_signal' | 'on_whatsapp_query'
+    first_seen          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_seen           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    resolved_at         TIMESTAMPTZ,                -- when jid_phone first became non-NULL
+    PRIMARY KEY (team_member_phone, lid)
+);
+
+CREATE INDEX IF NOT EXISTS idx_lid_map_jid_phone
+    ON whatsapp_lid_phone_map (jid_phone)
+    WHERE jid_phone IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_lid_map_unresolved
+    ON whatsapp_lid_phone_map (last_seen DESC)
+    WHERE jid_phone IS NULL;
+
+-- ───────────────────────────────────────────────────────────────────────
+-- 2. whatsapp_session_history — append-only flap ledger.
+--    The pre-v2 design UPSERTed whatsapp_team_sessions on every state
+--    change, losing the flap history. Sahira's 1,116 'revoked' rows were
+--    an accidental ledger; we now make it intentional.
+-- ───────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS whatsapp_session_history (
+    id                     BIGSERIAL PRIMARY KEY,
+    team_member_email      VARCHAR(255) NOT NULL,
+    team_member_phone      VARCHAR(32),
+    team_member_name       VARCHAR(255),
+    session_label          VARCHAR(255),
+    transition             VARCHAR(32) NOT NULL,
+                                                    -- 'opened' | 'connected' | 'disconnected' | 'revoked' | 'heartbeat'
+    reason                 TEXT,                    -- disconnect reason code (loggedOut / connectionLost / restartRequired / …)
+    messages_logged_delta  INTEGER NOT NULL DEFAULT 0,
+    messages_filtered_delta INTEGER NOT NULL DEFAULT 0,
+    metadata               JSONB NOT NULL DEFAULT '{}'::jsonb,
+    occurred_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_history_team_recent
+    ON whatsapp_session_history (team_member_phone, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_session_history_transition_recent
+    ON whatsapp_session_history (transition, occurred_at DESC);
+
+-- Current state projection: latest row per team_member_phone wins.
+CREATE OR REPLACE VIEW whatsapp_current_sessions AS
+SELECT DISTINCT ON (team_member_phone)
+       team_member_phone,
+       team_member_email,
+       team_member_name,
+       session_label,
+       transition       AS current_status,
+       reason           AS last_reason,
+       occurred_at      AS last_seen_at,
+       metadata
+  FROM whatsapp_session_history
+ WHERE team_member_phone IS NOT NULL
+ ORDER BY team_member_phone, occurred_at DESC;
+
+-- ───────────────────────────────────────────────────────────────────────
+-- 3. whatsapp_message_context additive columns
+-- ───────────────────────────────────────────────────────────────────────
+
+-- LID storage: separate from counterpart_phone so the message row stays
+-- intact when only the LID is known. The Python consumer joins against
+-- whatsapp_lid_phone_map to attribute messages once the LID is resolved.
+ALTER TABLE whatsapp_message_context
+    ADD COLUMN IF NOT EXISTS counterpart_lid VARCHAR(64);
+
+-- OCR worker queue. Worker SELECTs … WHERE ocr_status='pending' AND
+-- media_stored_path IS NOT NULL FOR UPDATE SKIP LOCKED.
+ALTER TABLE whatsapp_message_context
+    ADD COLUMN IF NOT EXISTS ocr_status VARCHAR(16) NOT NULL DEFAULT 'pending';
+
+ALTER TABLE whatsapp_message_context
+    ADD COLUMN IF NOT EXISTS ocr_engine VARCHAR(32);
+    -- 'tesseract' | 'qwen2.5vl' | 'manual' once worker processes a row
+
+ALTER TABLE whatsapp_message_context
+    ADD COLUMN IF NOT EXISTS ocr_completed_at TIMESTAMPTZ;
+
+-- Flag for the storico repair script (step 4): rows with corrupted
+-- counterpart_phone (LENGTH >= 15) get counterpart_phone=NULL +
+-- counterpart_lid populated + needs_lid_resolve=true so the consumer
+-- knows the LID resolver should re-attempt attribution.
+ALTER TABLE whatsapp_message_context
+    ADD COLUMN IF NOT EXISTS needs_lid_resolve BOOLEAN NOT NULL DEFAULT false;
+
+-- ───────────────────────────────────────────────────────────────────────
+-- 4. Indexes
+-- ───────────────────────────────────────────────────────────────────────
+
+-- OCR worker queue scan (small index: only pending rows with media)
+CREATE INDEX IF NOT EXISTS idx_wmc_ocr_pending
+    ON whatsapp_message_context (id)
+    WHERE ocr_status = 'pending' AND media_stored_path IS NOT NULL;
+
+-- LID resolver scan
+CREATE INDEX IF NOT EXISTS idx_wmc_lid_unresolved
+    ON whatsapp_message_context (counterpart_lid, team_member_phone)
+    WHERE counterpart_lid IS NOT NULL AND client_id IS NULL;
+
+-- FTS trigram index for cross-conversation search (KITAS, E33G, PT PMA…)
+-- pg_trgm GIN allows ILIKE '%kitas%' to use the index instead of seq scan.
+-- Scoped to message_text (already populated) and limited by a partial
+-- predicate to avoid indexing the 14,860 NULL/empty rows.
+CREATE INDEX IF NOT EXISTS idx_wmc_message_text_trgm
+    ON whatsapp_message_context USING GIN (message_text gin_trgm_ops)
+    WHERE message_text IS NOT NULL AND LENGTH(message_text) > 0;
+
+-- === ROLLBACK ===
+DROP INDEX IF EXISTS idx_wmc_message_text_trgm;
+DROP INDEX IF EXISTS idx_wmc_lid_unresolved;
+DROP INDEX IF EXISTS idx_wmc_ocr_pending;
+ALTER TABLE whatsapp_message_context DROP COLUMN IF EXISTS needs_lid_resolve;
+ALTER TABLE whatsapp_message_context DROP COLUMN IF EXISTS ocr_completed_at;
+ALTER TABLE whatsapp_message_context DROP COLUMN IF EXISTS ocr_engine;
+ALTER TABLE whatsapp_message_context DROP COLUMN IF EXISTS ocr_status;
+ALTER TABLE whatsapp_message_context DROP COLUMN IF EXISTS counterpart_lid;
+DROP VIEW IF EXISTS whatsapp_current_sessions;
+DROP INDEX IF EXISTS idx_session_history_transition_recent;
+DROP INDEX IF EXISTS idx_session_history_team_recent;
+DROP TABLE IF EXISTS whatsapp_session_history;
+DROP INDEX IF EXISTS idx_lid_map_unresolved;
+DROP INDEX IF EXISTS idx_lid_map_jid_phone;
+DROP TABLE IF EXISTS whatsapp_lid_phone_map;

--- a/apps/wa-mirror/bridge/filters.ts
+++ b/apps/wa-mirror/bridge/filters.ts
@@ -1,46 +1,123 @@
 // filters.ts — JID helpers and legacy match classifier.
 //
-// Current capture policy is store-everything for one-to-one chats. No CRM
-// match means prospect/client_id=NULL, not a dropped message. Groups and
-// malformed JIDs remain out of scope.
+// WhatsApp ships two distinct JID server tags relevant to wa-mirror:
+//   1. `@s.whatsapp.net` / `@c.us` — the user part is the actual phone
+//      number (E.164 digits, no `+`).
+//   2. `@lid` — Linked Identity Device, an anonymous identifier rolled
+//      out late 2024 for privacy-shielded contacts. The user part is
+//      NOT a phone number; it is a random 15-16-digit string.
+//
+// Pre-2026-05-19 the bridge only handled (1) and silently turned (2)
+// into fake E.164 by prepending `62`. That broke 70% of inbound match
+// in production (the `+62…17-18 digit` rows in whatsapp_message_context).
+// v2 separates the two surfaces via `parseJid()`.
 
 import { findClientByPhone } from "./pg.js";
+import { normalizePhone } from "./phone.js";
+
+export type JidKind = "phone" | "lid" | "group" | "broadcast" | "empty";
+
+export type ParsedJid = {
+  /** Always populated. */
+  kind: JidKind;
+  /** Canonical E.164 (with `+`) when kind === "phone", else "". */
+  phone: string;
+  /** The LID identifier (digits only) when kind === "lid", else "". */
+  lid: string;
+  /** Raw server tag stripped of leading "@" — for diagnostics. */
+  server: string;
+};
+
+const GROUP_SERVER = "g.us";
+const BROADCAST_SERVER = "broadcast";
+const NEWSLETTER_SERVER = "newsletter";
+const LID_SERVER = "lid";
+const PHONE_SERVERS = new Set(["s.whatsapp.net", "c.us"]);
+
+/**
+ * Parse a Baileys JID into a typed shape. Returns kind="empty" for any
+ * non-string / missing input. Never throws.
+ */
+export function parseJid(jid: string | null | undefined): ParsedJid {
+  const empty: ParsedJid = { kind: "empty", phone: "", lid: "", server: "" };
+  if (!jid || typeof jid !== "string") return empty;
+
+  const sepIdx = jid.indexOf("@");
+  if (sepIdx < 0) return empty;
+
+  const server = jid.slice(sepIdx + 1);
+  const userCombined = jid.slice(0, sepIdx);
+  // strip `:<device>` multi-device suffix and `_<agent>` (rare)
+  const beforeDevice = userCombined.split(":")[0] ?? "";
+  const user = beforeDevice.split("_")[0] ?? "";
+
+  if (server === GROUP_SERVER) {
+    return { kind: "group", phone: "", lid: "", server };
+  }
+  if (server === BROADCAST_SERVER || server === NEWSLETTER_SERVER) {
+    return { kind: "broadcast", phone: "", lid: "", server };
+  }
+
+  if (server === LID_SERVER) {
+    const lid = user.replace(/[^\d]/g, "");
+    if (lid.length === 0) return empty;
+    return { kind: "lid", phone: "", lid, server };
+  }
+
+  if (PHONE_SERVERS.has(server)) {
+    // `user` here is a bare phone (no `+`). normalizePhone will:
+    // (a) validate via libphonenumber (rejects garbage),
+    // (b) emit canonical E.164 with `+`.
+    // We prepend `+` so libphonenumber treats it as international (the
+    // user part of @s.whatsapp.net ALWAYS includes country code).
+    const digits = user.replace(/[^\d]/g, "");
+    if (digits.length === 0) return empty;
+    const e164 = normalizePhone(`+${digits}`);
+    if (!e164) return empty;
+    return { kind: "phone", phone: e164, lid: "", server };
+  }
+
+  return empty;
+}
+
+/**
+ * Legacy: extract a digit-only phone string from a Baileys JID.
+ *
+ * v1 behaviour preserved for callers that still expect a string: returns
+ * "" for groups/broadcasts/LIDs/malformed; returns digit-only E.164 for
+ * phone JIDs. LIDs return "" — callers that need the LID must use
+ * `parseJid()` instead.
+ *
+ * NOTE: this is a STRICTER contract than the pre-v2 version. Previously
+ * LIDs slipped through as fake phone numbers. Callers that need to keep
+ * the LID separate MUST migrate to `parseJid()`.
+ */
+export function jidToPhone(jid: string | null | undefined): string {
+  const parsed = parseJid(jid);
+  if (parsed.kind !== "phone") return "";
+  return parsed.phone.replace(/[^\d]/g, "");
+}
 
 export type FilterDecision = {
   mirror: boolean;
   clientId: number | null;
-  reason: "client_match" | "no_client_match" | "self_message" | "empty_jid";
+  reason:
+    | "client_match"
+    | "no_client_match"
+    | "self_message"
+    | "empty_jid"
+    | "lid_unresolved";
   counterpartNormalized: string;
+  counterpartLid: string;
 };
-
-/**
- * Extract a normalized phone number from a Baileys JID.
- *
- * Baileys JID formats we care about:
- *   <country><number>@s.whatsapp.net  — direct chat (1-to-1)
- *   <country><number>@c.us            — older format, same meaning
- *   <number>@g.us                     — group (we filter these out entirely)
- *   <number>:<device>@s.whatsapp.net  — multi-device suffix
- *
- * Returns digit-only string (e.g. "628123456789") or empty string when the
- * JID is a group or unparseable. Groups are NEVER mirrored.
- */
-export function jidToPhone(jid: string | null | undefined): string {
-  if (!jid) return "";
-  // Reject groups outright — group chats are out of v1 scope.
-  if (jid.endsWith("@g.us")) return "";
-  // Strip device suffix and JID server.
-  const beforeServer = jid.split("@")[0] ?? "";
-  const beforeDevice = beforeServer.split(":")[0] ?? "";
-  return beforeDevice.replace(/[^\d]/g, "");
-}
 
 /**
  * Legacy classifier retained for callers that want CRM match metadata.
  *
- * A no-client match is still mirrorable: the message is a prospect/lead and
- * must be stored with client_id=NULL. Only empty JIDs and self-messages are
- * non-mirrorable.
+ * Behaviour for LID JIDs (kind === "lid"): we cannot do CRM matching
+ * because we don't know the real phone yet. The message is still
+ * mirrorable — the caller is expected to populate `counterpart_lid` and
+ * let the async resolver (whatsapp_lid_phone_map) attribute later.
  *
  * Self-messages (team member writing notes to themselves) are dropped.
  */
@@ -48,36 +125,49 @@ export async function shouldMirror(opts: {
   counterpartJid: string | null;
   teamMemberPhone: string;
 }): Promise<FilterDecision> {
-  const counterpart = jidToPhone(opts.counterpartJid);
-  if (counterpart.length === 0) {
+  const parsed = parseJid(opts.counterpartJid);
+  if (
+    parsed.kind === "empty" ||
+    parsed.kind === "group" ||
+    parsed.kind === "broadcast"
+  ) {
     return {
       mirror: false,
       clientId: null,
       reason: "empty_jid",
       counterpartNormalized: "",
+      counterpartLid: "",
     };
   }
-  if (counterpart === opts.teamMemberPhone.replace(/[^\d]/g, "")) {
+
+  if (parsed.kind === "lid") {
+    return {
+      mirror: true,
+      clientId: null,
+      reason: "lid_unresolved",
+      counterpartNormalized: "",
+      counterpartLid: parsed.lid,
+    };
+  }
+
+  // parsed.kind === "phone"
+  const counterpartDigits = parsed.phone.replace(/[^\d]/g, "");
+  const teamDigits = opts.teamMemberPhone.replace(/[^\d]/g, "");
+  if (counterpartDigits === teamDigits) {
     return {
       mirror: false,
       clientId: null,
       reason: "self_message",
-      counterpartNormalized: counterpart,
+      counterpartNormalized: parsed.phone,
+      counterpartLid: "",
     };
   }
-  const clientId = await findClientByPhone(counterpart);
-  if (clientId === null) {
-    return {
-      mirror: true,
-      clientId: null,
-      reason: "no_client_match",
-      counterpartNormalized: counterpart,
-    };
-  }
+  const clientId = await findClientByPhone(parsed.phone);
   return {
     mirror: true,
     clientId,
-    reason: "client_match",
-    counterpartNormalized: counterpart,
+    reason: clientId === null ? "no_client_match" : "client_match",
+    counterpartNormalized: parsed.phone,
+    counterpartLid: "",
   };
 }

--- a/apps/wa-mirror/bridge/phone.ts
+++ b/apps/wa-mirror/bridge/phone.ts
@@ -1,51 +1,92 @@
-const INDONESIA_COUNTRY_CODE = "62";
+// phone.ts — strict E.164 normalisation via libphonenumber-js.
+//
+// Replaces the regex-based heuristic (pre-2026-05-19) which had two
+// production bugs verified empirically against `whatsapp_message_context`
+// (15,209 rows, 0% client match):
+//
+// 1. Truncation: leading-zero strip ate an internal digit on rare carrier
+//    formats — `+6282134547725` (12 nat'l digits) became `+628213454725`
+//    (11 nat'l digits) in `whatsapp_team_sessions`, breaking team-side
+//    matching for Adit / Vino / Damar.
+//
+// 2. False country-code injection on WhatsApp `@lid` (Linked Identity
+//    Device) identifiers. A LID like `224112131756075` is not a phone
+//    number; the old code blindly prepended `62` and produced fake
+//    E.164 strings (`+62224112131756075`, 17-18 digits) for 70% of
+//    inbound messages, making client-side matching impossible.
+//
+// Contract for v2:
+// - normalizePhone() ALWAYS returns a valid E.164 string (with `+`) or
+//   an empty string. Indonesia is the default region for ambiguous inputs
+//   that lack a country code (e.g. `0812…` / `812…`).
+// - International numbers (`+39…`, `+61…`, `+966…`) are preserved
+//   unchanged when they already carry a `+`.
+// - LID strings MUST be filtered upstream by `filters.ts::parseJid`;
+//   this module does not attempt to detect them. If a caller passes a
+//   LID by mistake, libphonenumber rejects it as invalid and we return
+//   "" — fail-safe, no fake match.
 
-/**
- * Normalize WhatsApp/CRM phone values into canonical E.164.
- *
- * Bali Zero numbers are Indonesia-first for this bridge. Common CRM and WA
- * variants all converge to +62...:
- * - 08xxx
- * - 628xxx
- * - +628xxx
- * - 00628xxx
- */
+import {
+  parsePhoneNumberFromString,
+  type CountryCode,
+} from "libphonenumber-js";
+
+const INDONESIA: CountryCode = "ID";
+
+function looksInternational(raw: string): boolean {
+  const trimmed = raw.trimStart();
+  if (trimmed.startsWith("+")) return true;
+  // `00` international-dial prefix → treat as +CC
+  if (trimmed.startsWith("00")) return true;
+  return false;
+}
+
 export function normalizePhone(raw: string | null | undefined): string {
-  const digitsOnly = (raw ?? "").replace(/[^\d]/g, "");
-  if (digitsOnly.length === 0) return "";
+  if (!raw) return "";
+  const cleaned = String(raw).trim();
+  if (cleaned.length === 0) return "";
 
-  let digits = digitsOnly;
-  if (digits.startsWith("00")) {
-    digits = digits.slice(2);
-  }
+  // Convert `00CCxxx` to `+CCxxx` so libphonenumber sees the international form.
+  const withPlus = cleaned.startsWith("00") ? `+${cleaned.slice(2)}` : cleaned;
 
-  while (digits.startsWith("0")) {
-    digits = digits.slice(1);
-  }
+  // If the input carries an explicit country prefix, parse without a default
+  // region — libphonenumber uses whatever country the `+CC` indicates
+  // (Italy `+39`, Australia `+61`, Saudi `+966`, etc.). This is what kills
+  // the cross-country last-N-digit collision class.
+  const parsed = looksInternational(withPlus)
+    ? parsePhoneNumberFromString(withPlus)
+    : parsePhoneNumberFromString(withPlus, INDONESIA);
 
-  if (!digits.startsWith(INDONESIA_COUNTRY_CODE)) {
-    digits = `${INDONESIA_COUNTRY_CODE}${digits}`;
-  }
-
-  return digits.length > INDONESIA_COUNTRY_CODE.length ? `+${digits}` : "";
+  if (!parsed || !parsed.isValid()) return "";
+  return parsed.number; // canonical E.164 with leading `+`
 }
 
 export function phoneDigits(raw: string | null | undefined): string {
   return normalizePhone(raw).replace(/[^\d]/g, "");
 }
 
+/**
+ * Variants emitted for legacy CRM lookups where rows may be stored in
+ * mixed formats (`+6281…`, `6281…`, `0812…`). The canonical E.164 form
+ * is always first so callers can prefer it.
+ *
+ * Non-Indonesian numbers only emit the canonical E.164 + digit-only form —
+ * there is no "local 0-prefix" equivalent for arbitrary countries.
+ */
 export function phoneSearchVariants(raw: string | null | undefined): string[] {
   const canonical = normalizePhone(raw);
   if (!canonical) return [];
 
   const digits = canonical.replace(/[^\d]/g, "");
-  const local =
-    digits.startsWith(INDONESIA_COUNTRY_CODE) &&
-    digits.length > INDONESIA_COUNTRY_CODE.length
-      ? `0${digits.slice(INDONESIA_COUNTRY_CODE.length)}`
-      : digits;
+  const variants = [canonical, digits];
 
-  return Array.from(new Set([canonical, digits, local]));
+  // Indonesia-only: emit the local `0xxx` form so we still match legacy
+  // CRM rows that were typed as `08123…` without country code.
+  if (digits.startsWith("62") && digits.length > 2) {
+    variants.push(`0${digits.slice(2)}`);
+  }
+
+  return Array.from(new Set(variants));
 }
 
 export function phonePathSegment(raw: string): string {

--- a/apps/wa-mirror/package.json
+++ b/apps/wa-mirror/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@whiskeysockets/baileys": "6.7.21",
     "dotenv": "^16.4.5",
+    "libphonenumber-js": "^1.13.2",
     "pg": "^8.13.0",
     "pino": "^9.5.0",
     "qrcode": "^1.5.4",

--- a/apps/wa-mirror/tests/filters.test.ts
+++ b/apps/wa-mirror/tests/filters.test.ts
@@ -1,60 +1,119 @@
-// filters.test.ts — unit tests for the wa-mirror privacy gate.
+// filters.test.ts — unit tests for the wa-mirror JID parser.
 //
-// jidToPhone() is load-bearing for the PRIVACY_CONTRACT_TEAM.md commitment:
-// it MUST return "" for any group JID (@g.us) so group chats never reach the
-// mirror path, and it MUST normalise direct-chat JIDs to a digit-only string
-// so the clients-table lookup in shouldMirror() can match.
-//
-// shouldMirror() itself touches Postgres (findClientByPhone), so it is out of
-// scope for this pure-function test file — the jidToPhone behaviour it
-// depends on is what we pin here.
+// parseJid() must distinguish (1) real phone JIDs (@s.whatsapp.net / @c.us),
+// (2) LID identifiers (@lid, WhatsApp privacy-shielded anonymous IDs rolled
+// out late 2024), (3) groups (@g.us, dropped from mirror), and (4) malformed
+// input. The pre-v2 bridge collapsed (2) into fake phone numbers; the LID
+// branch here is the regression fence for that bug.
 
 import { describe, expect, it } from "vitest";
 
-import { jidToPhone } from "../bridge/filters.js";
+import { jidToPhone, parseJid } from "../bridge/filters.js";
 
-describe("jidToPhone — group rejection (privacy contract)", () => {
-  it("returns empty string for any @g.us group JID", () => {
-    expect(jidToPhone("120363012345678901@g.us")).toBe("");
-    expect(jidToPhone("0@g.us")).toBe("");
+describe("parseJid — phone server (@s.whatsapp.net / @c.us)", () => {
+  it("returns kind='phone' and canonical E.164 for standard JID", () => {
+    expect(parseJid("628123456789@s.whatsapp.net")).toEqual({
+      kind: "phone",
+      phone: "+628123456789",
+      lid: "",
+      server: "s.whatsapp.net",
+    });
   });
 
-  it("rejects group JIDs even if they contain a phone-like prefix", () => {
-    // A group id can be all-digits; the @g.us suffix is the only signal.
-    expect(jidToPhone("628123456789@g.us")).toBe("");
+  it("handles the legacy @c.us server tag", () => {
+    expect(parseJid("628123456789@c.us")).toMatchObject({
+      kind: "phone",
+      phone: "+628123456789",
+      server: "c.us",
+    });
+  });
+
+  it("strips the :<device> multi-device suffix", () => {
+    expect(parseJid("628213107363:1@s.whatsapp.net")).toMatchObject({
+      kind: "phone",
+      phone: "+628213107363",
+    });
+    expect(parseJid("628213107363:42@s.whatsapp.net")).toMatchObject({
+      kind: "phone",
+      phone: "+628213107363",
+    });
+  });
+
+  it("preserves international numbers (Italian +39)", () => {
+    expect(parseJid("393398745516@s.whatsapp.net")).toMatchObject({
+      kind: "phone",
+      phone: "+393398745516",
+    });
+  });
+
+  it("returns kind='empty' when the JID user has no digits", () => {
+    expect(parseJid("@s.whatsapp.net")).toMatchObject({ kind: "empty" });
   });
 });
 
-describe("jidToPhone — direct chat normalisation", () => {
-  it("extracts digits from a standard @s.whatsapp.net JID", () => {
-    expect(jidToPhone("628123456789@s.whatsapp.net")).toBe("628123456789");
+describe("parseJid — @lid (privacy-shielded identifiers)", () => {
+  it("returns kind='lid' and preserves the raw LID identifier, NO phone synthesis", () => {
+    expect(parseJid("224112131756075@lid")).toEqual({
+      kind: "lid",
+      phone: "",
+      lid: "224112131756075",
+      server: "lid",
+    });
   });
 
-  it("extracts digits from the legacy @c.us JID", () => {
-    expect(jidToPhone("628123456789@c.us")).toBe("628123456789");
+  it("never injects +62 into a LID identifier (regression for the +62NNNNNNNNNNNNN bug)", () => {
+    const cases = [
+      "224112131756075@lid",
+      "179065826877524@lid",
+      "187840445030654@lid",
+      "224971225866242@lid",
+    ];
+    for (const jid of cases) {
+      const out = parseJid(jid);
+      expect(out.kind).toBe("lid");
+      expect(out.phone).toBe("");
+      expect(out.lid).not.toMatch(/^\+62/);
+    }
+  });
+});
+
+describe("parseJid — group / broadcast / newsletter (must NOT be mirrored)", () => {
+  it("returns kind='group' for @g.us regardless of digit content", () => {
+    expect(parseJid("120363012345678901@g.us")).toMatchObject({
+      kind: "group",
+    });
+    expect(parseJid("628123456789@g.us")).toMatchObject({ kind: "group" });
   });
 
-  it("strips the multi-device :<device> suffix", () => {
-    // This is the exact shape Baileys reported for zero@balizero.com:
-    //   628213107363:1@s.whatsapp.net
+  it("returns kind='broadcast' for status / broadcast / newsletter", () => {
+    expect(parseJid("status@broadcast")).toMatchObject({ kind: "broadcast" });
+    expect(parseJid("0@broadcast")).toMatchObject({ kind: "broadcast" });
+    expect(parseJid("xxx@newsletter")).toMatchObject({ kind: "broadcast" });
+  });
+});
+
+describe("parseJid — empty / malformed", () => {
+  it("returns kind='empty' for null / undefined / empty / no-@", () => {
+    expect(parseJid(null)).toMatchObject({ kind: "empty" });
+    expect(parseJid(undefined)).toMatchObject({ kind: "empty" });
+    expect(parseJid("")).toMatchObject({ kind: "empty" });
+    expect(parseJid("no-at-sign-here")).toMatchObject({ kind: "empty" });
+  });
+});
+
+describe("jidToPhone (legacy) — STRICTER post-v2 contract", () => {
+  it("returns digits for phone JIDs", () => {
     expect(jidToPhone("628213107363:1@s.whatsapp.net")).toBe("628213107363");
-    expect(jidToPhone("628123456789:42@s.whatsapp.net")).toBe("628123456789");
   });
 
-  it("strips any non-digit characters defensively", () => {
-    expect(jidToPhone("+62 812-3456-789@s.whatsapp.net")).toBe("628123456789");
-  });
-});
-
-describe("jidToPhone — empty / malformed input", () => {
-  it("returns empty string for null/undefined/empty", () => {
-    expect(jidToPhone(null)).toBe("");
-    expect(jidToPhone(undefined)).toBe("");
-    expect(jidToPhone("")).toBe("");
+  it("returns '' for @lid (BREAKING change from v1 — callers must migrate to parseJid)", () => {
+    expect(jidToPhone("224112131756075@lid")).toBe("");
   });
 
-  it("returns empty string when there are no digits at all", () => {
-    expect(jidToPhone("@s.whatsapp.net")).toBe("");
+  it("returns '' for groups, broadcasts, malformed", () => {
+    expect(jidToPhone("120363012345678901@g.us")).toBe("");
     expect(jidToPhone("status@broadcast")).toBe("");
+    expect(jidToPhone(null)).toBe("");
+    expect(jidToPhone("")).toBe("");
   });
 });

--- a/apps/wa-mirror/tests/phone.test.ts
+++ b/apps/wa-mirror/tests/phone.test.ts
@@ -2,30 +2,101 @@ import { describe, expect, it } from "vitest";
 
 import { normalizePhone, phoneSearchVariants } from "../bridge/phone.js";
 
-describe("normalizePhone", () => {
-  it("normalizes Indonesian local 08xxx numbers to canonical E.164", () => {
+describe("normalizePhone — Indonesian numbers", () => {
+  it("normalises 0812 local form to canonical E.164 (11-digit national)", () => {
     expect(normalizePhone("0812 3456-7890")).toBe("+6281234567890");
   });
 
-  it("normalizes 628xxx numbers to canonical E.164", () => {
+  it("normalises 628xxx without `+` to canonical E.164", () => {
     expect(normalizePhone("6281234567890")).toBe("+6281234567890");
   });
 
-  it("keeps +628xxx numbers canonical after stripping separators", () => {
+  it("keeps +628xxx canonical after stripping separators", () => {
     expect(normalizePhone("+62 812-3456-7890")).toBe("+6281234567890");
   });
 
-  it("normalizes over-zero-prefixed variants to the same canonical value", () => {
+  it("normalises the 00 international-dial prefix", () => {
     expect(normalizePhone("0062 812 3456 7890")).toBe("+6281234567890");
+  });
+
+  it("preserves Adit's 12-national-digit number without truncation (regression for the +6282134547725 → +628213454725 bug)", () => {
+    expect(normalizePhone("+6282134547725")).toBe("+6282134547725");
+    expect(normalizePhone("6282134547725")).toBe("+6282134547725");
+  });
+
+  it("preserves all 8 Bali Zero team numbers verbatim", () => {
+    const team = [
+      "+6282134547725", // Adit
+      "+6282134547727", // Vino
+      "+6282134547723", // Sahira
+      "+6282326357501", // Krisna
+      "+6281339468856", // Surya
+      "+6282134547721", // Ari
+      "+6282134547726", // Damar
+      "+62881038467246", // Asya
+    ];
+    for (const n of team) expect(normalizePhone(n)).toBe(n);
+  });
+});
+
+describe("normalizePhone — international numbers", () => {
+  it("preserves Italian +39 numbers", () => {
+    expect(normalizePhone("+393398745516")).toBe("+393398745516");
+  });
+
+  it("preserves Australian +61 numbers", () => {
+    expect(normalizePhone("+61401877755")).toBe("+61401877755");
+  });
+
+  it("preserves Saudi +966 numbers", () => {
+    expect(normalizePhone("+966566272811")).toBe("+966566272811");
+  });
+
+  it("preserves Irish +353 numbers", () => {
+    expect(normalizePhone("+353894477906")).toBe("+353894477906");
+  });
+});
+
+describe("normalizePhone — fail-safe (no fake country code on garbage)", () => {
+  it("rejects WhatsApp LID identifiers (NOT phones) without injecting +62 (regression for the @lid 17-18 digit bug)", () => {
+    // Pre-v2: `224112131756075` → `+62224112131756075` (fake 18-digit E.164).
+    // Post-v2: libphonenumber rejects → "" (empty, fail-safe).
+    expect(normalizePhone("224112131756075")).toBe("");
+    expect(normalizePhone("179065826877524")).toBe("");
+    expect(normalizePhone("280650426929268")).toBe("");
+  });
+
+  it("returns empty string for null / undefined / empty", () => {
+    expect(normalizePhone(null)).toBe("");
+    expect(normalizePhone(undefined)).toBe("");
+    expect(normalizePhone("")).toBe("");
+    expect(normalizePhone("   ")).toBe("");
+  });
+
+  it("returns empty string for clearly invalid digit strings", () => {
+    expect(normalizePhone("abc")).toBe("");
+    expect(normalizePhone("1")).toBe("");
   });
 });
 
 describe("phoneSearchVariants", () => {
-  it("emits canonical, digit-only, and local variants for DB matching", () => {
+  it("emits canonical, digit-only, and local Indonesia variants for legacy CRM rows", () => {
     expect(phoneSearchVariants("0812 3456 7890")).toEqual([
       "+6281234567890",
       "6281234567890",
       "081234567890",
     ]);
+  });
+
+  it("emits only canonical + digit-only for non-Indonesia numbers", () => {
+    expect(phoneSearchVariants("+393398745516")).toEqual([
+      "+393398745516",
+      "393398745516",
+    ]);
+  });
+
+  it("returns empty array on invalid input", () => {
+    expect(phoneSearchVariants("224112131756075")).toEqual([]);
+    expect(phoneSearchVariants(null)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

wa-mirror v2 architecture — steps 1 and 2 of a 8-step critical path to fix the production reality verified 2026-05-19:

- 15,209 messages captured by wa-mirror, **0% client_id match** (root cause: WhatsApp `@lid` privacy-shielded identifiers introduced late 2024)
- 4,538 `revoked` rows in `whatsapp_team_sessions` from the reconnect-flap loop (Sahira alone: 1,116 rows)
- 66 media files downloaded, 0 OCR processed
- 3/8 Bali Zero team members connected with **wrong** stored phone (one digit truncated by the old `normalizePhone` regex hack)

Multi-LLM design panel (Gemini 3.1 Pro v1 → red-team Gemini → synthesis Gemini) consolidated in commit message.

### Step 1 — `phone.ts` + `filters.ts` rewrite

- Replace regex heuristic with `libphonenumber-js` (Indonesia default region, parses international `+39/+61/+966/…` correctly).
- New typed `parseJid()` → `{kind: 'phone'|'lid'|'group'|'broadcast'|'empty', phone, lid, server}`.
- `@lid` identifiers ALWAYS return `kind='lid'` with the raw LID preserved — NEVER synthesised into fake `+62NNNNNNN` E.164.
- `jidToPhone()` (legacy) is **stricter**: LID returns `""`. Breaking from v1; callers needing the LID must migrate to `parseJid()`.
- Test coverage: 44/44 vitest pass (16 phone + 13 filters + 12 session + 3 message-capture). Regression fences for the `+6282134547725 → +628213454725` truncation bug and the `224112131756075@lid → +62224112131756075` LID injection bug.
- `tsc` build clean. `libphonenumber-js@^1.13.2` added.

### Step 2 — Migration v185 (additive, reversible)

- `whatsapp_lid_phone_map` — LID resolution, composite PK `(team_member_phone, lid)`. LID is per-pair (team_member × counterpart), NOT globally unique — this is load-bearing (see panel red-team finding 1).
- `whatsapp_session_history` — append-only flap ledger. View `whatsapp_current_sessions` projects current state via `DISTINCT ON (team_member_phone)`. Preserves the audit trail destroyed by the pre-v2 UPSERT-on-state design.
- `whatsapp_message_context` additive columns: `counterpart_lid`, `ocr_status`, `ocr_engine`, `ocr_completed_at`, `needs_lid_resolve`.
- Indexes: GIN `pg_trgm` on `message_text` (FTS for KITAS / PT PMA / E33G cross-conversation search), partial OCR queue index, partial LID resolver index. `pg_trgm` extension declared.
- Validated UP + ROLLBACK + UP idempotency on Mini PG against the live 15,209-row table; no data loss.

## Test plan

- [x] Vitest 44/44 pass (phone + filters + session + message-capture)
- [x] `tsc` build clean (apps/wa-mirror)
- [x] Migration 185 UP applied OK on Mini PG (production-like schema, 15,209 rows preserved)
- [x] Migration 185 ROLLBACK clean — all 5 new columns + 2 new tables + view + 3 indexes removed
- [x] Migration 185 UP idempotent (re-applied after ROLLBACK with no errors)
- [ ] CI: E2E + MCP tests (auto-run on PR)
- [ ] Squawk migration-lint (auto-run on PR for `migrations_v2/*.sql`)

## Next (separate PRs, sequential — do NOT parallelise)

3. Update daemon: `session.ts` listens `contacts.upsert` → upsert `whatsapp_lid_phone_map`; `markConnected`/`markDisconnected` INSERT into `whatsapp_session_history`; Redis-throttle Telegram alerts (1/h per team member).
4. Repair script `repair_wa_message_phones.py`: 15,209-row backfill from `raw_baileys_event::jsonb->'key'->>'remoteJid'`. Idempotent, batched.
5. Consumer `_core.py::_log_whatsapp_message_interaction`: exact-match `clients.phone` via E.164, fallback JOIN `whatsapp_lid_phone_map` when only LID is known.
6. OCR worker `wa_ocr_worker.py`: PG `SKIP LOCKED` queue, Tesseract → `qwen2.5vl:7b` Ollama fallback for scanned/handwritten. Local, sovrano (Antonello decision 2026-05-19).
7. Daily digest `wa_daily_digest.py`: 19:00 WITA Telegram → msg/team last 24h, top 5 prospect non-CRM, notable OCR hits.
8. Re-onboard 8 team with verified phone numbers (Adit `+6282134547725`, Vino `+6282134547727`, Sahira `+6282134547723`, Krisna `+6282326357501`, Surya `+6281339468856`, Ari `+6282134547721`, Damar `+6282134547726`, Asya `+62881038467246`).

Cf memory `decision_wa-mirror_design_finale_multi_llm_consolidato_2026_05_19`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)