### PR TITLE
fix(agent-library): Phase 1.1B — acquire_lock graceful degrade on psql failure

### DIFF
--- a/scripts/agent-library-evolver-run.sh
+++ b/scripts/agent-library-evolver-run.sh
@@ -200,16 +200,38 @@ acquire_lock() {
         log "WARN: psql not on PATH — skipping advisory lock"
         return 0
     fi
-    local got
-    got="$(psql "${DATABASE_URL}" -At -c "SELECT pg_try_advisory_lock(${PG_LOCK_KEY});" 2>>"${LOG_FILE}" || echo "")"
-    if [[ "${got}" != "t" ]]; then
-        log "another run holds the advisory lock (key=${PG_LOCK_KEY}) — exiting"
-        exit 3
+    # Phase 1.1 fix B (2026-05-19 smoke #4 discovery): we must
+    # distinguish three psql outcomes — only one of them means
+    # "another run holds the lock":
+    #
+    #   1. psql exit 0, output "t"  → lock acquired, proceed
+    #   2. psql exit 0, output "f"  → another run holds, exit 3
+    #   3. psql exit non-zero       → connection failure (e.g.
+    #      DATABASE_URL points to Fly flycast hostname not reachable
+    #      from outside Fly net), degrade gracefully per Symbiosis
+    #      Law 4 — log warning + skip lock + continue. Treating
+    #      connection failure as "lock held" would block every
+    #      Sunday run forever if the operator's DATABASE_URL is
+    #      misconfigured. Better to lose single-flight protection
+    #      than to silently never run.
+    local got rc
+    set +e
+    got="$(psql "${DATABASE_URL}" -At -c "SELECT pg_try_advisory_lock(${PG_LOCK_KEY});" 2>>"${LOG_FILE}")"
+    rc=$?
+    set -e
+    if [[ "${rc}" -ne 0 ]]; then
+        log "WARN: psql connection to DATABASE_URL failed (rc=${rc}) — skipping advisory lock (single-flight degraded, see ${LOG_FILE})"
+        return 0
     fi
-    log "advisory lock acquired (key=${PG_LOCK_KEY})"
-    # Best-effort release on EXIT (Bash trap)
-    # shellcheck disable=SC2064
-    trap "psql '${DATABASE_URL}' -c 'SELECT pg_advisory_unlock(${PG_LOCK_KEY});' >/dev/null 2>&1 || true" EXIT
+    if [[ "${got}" == "t" ]]; then
+        log "advisory lock acquired (key=${PG_LOCK_KEY})"
+        # Best-effort release on EXIT (Bash trap)
+        # shellcheck disable=SC2064
+        trap "psql '${DATABASE_URL}' -c 'SELECT pg_advisory_unlock(${PG_LOCK_KEY});' >/dev/null 2>&1 || true" EXIT
+        return 0
+    fi
+    log "another run holds the advisory lock (key=${PG_LOCK_KEY}) — exiting"
+    exit 3
 }
 acquire_lock
 


### PR DESCRIPTION
## Summary

LaunchAgent smoke #3/#4 (2026-05-19 18:10/18:12 WITA, post PR #778 git-hook bypass) failed with exit 3 "lock held" but `pg_locks` showed 0 active locks. Empirical trace via evolver.log:

\`\`\`
psql: errore: could not translate host name "nuzantara-postgres.flycast"
to address: nodename nor servname provided, or not known
\`\`\`

Operator's `DATABASE_URL` points at Fly internal hostname (correct for backend-rag, wrong for local LaunchAgent). psql exits non-zero, stdout empty, wrapper interpreted as "lock held" → exit 3.

## Fix

`acquire_lock()` now distinguishes 3 outcomes:

| psql rc | output | Action |
|---|---|---|
| 0 | "t" | lock acquired, proceed |
| 0 | "f" | real conflict, exit 3 |
| non-zero | (any) | connection failure, **degrade gracefully** (warn + skip lock + continue) per Symbiosis Law 4 |

Previously outcome 3 was conflated with outcome 2, blocking every Sunday run if DATABASE_URL is misconfigured. Losing single-flight on a single run is better than silent crash-loop weekly.

## Verification

- `bash -n` syntax OK
- 99/99 Phase 1 unit tests PASS (no regression)
- Telemetry log confirms actual psql failure was flycast resolver error, NOT real lock conflict

## Phase 2 worthy follow-up

Introduce `EVOLVER_DATABASE_URL` separate env var pointing at local `nuzantara_dev` to avoid this entirely. Tracked for Phase 2.

## Cicatrix lesson (4th time)

Empirical smoke > panel review for runtime issues. Code reads OK in isolation; the DATABASE_URL/psql interaction only surfaces under launchd with operator's real secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)