### PR TITLE
fix(docker): whitelist requirements*.lock.txt in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,8 @@
 !apps/backend-rag/training-data/
 !apps/backend-rag/requirements-prod.txt
 !apps/backend-rag/requirements.txt
+!apps/backend-rag/requirements-prod.lock.txt
+!apps/backend-rag/requirements.lock.txt
 !apps/backend-rag/Dockerfile
 !apps/backend-rag/*.py
 


### PR DESCRIPTION
## Summary
Fix Fly deploy fail post-PR #777 (uv migration). 

## Root cause
Root `.dockerignore` uses whitelist approach. PR #777 added `requirements.lock.txt` + `requirements-prod.lock.txt` but never added them to the whitelist → Docker build context excluded them silently → `uv pip install -r requirements-prod.lock.txt` failed inside builder stage with `File not found`.

## Fix
2-line addition to `.dockerignore` whitelist.

## Test plan
- [x] `git diff HEAD -- .dockerignore` shows +2 lines
- [ ] Fly deploy success on merge (the real test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>