### PR TITLE
fix(evoskill): inject "json" marker for response_format=json_object (Phase 1.1D)

### DIFF
--- a/scripts/test_deepseek_executor.py
+++ b/scripts/test_deepseek_executor.py
@@ -25,6 +25,7 @@ Run:
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import sys
 from pathlib import Path
@@ -400,6 +401,93 @@ def test_build_response_format_with_schema():
 def test_build_response_format_no_schema():
     assert _build_response_format(None) is None
     assert _build_response_format({}) is None
+
+
+# ─── Phase 1.1D fix: DeepSeek json-mode requires "json" in prompt ────
+
+
+def _capture_transport():
+    """MockTransport that captures every outgoing request body."""
+    captured = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8")) if request.content else {}
+        captured.append(body)
+        # Return a minimal valid response so execute_query completes
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "id": "captured",
+                "model": "deepseek-v4-pro",
+                "choices": [{"message": {"content": "{}"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+            },
+        )
+
+    return httpx.MockTransport(handler), captured
+
+
+@pytest.mark.asyncio
+async def test_json_marker_injected_when_schema_set_and_system_lacks_json(
+    monkeypatch, set_api_key
+):
+    """Schema requested + system has no 'json' word → marker prepended."""
+    transport, captured = _capture_transport()
+    _patch_async_client(monkeypatch, transport)
+    options = {
+        "model": "deepseek-v4-pro",
+        "system": "You answer questions about the weather.",
+        "schema": {"type": "object", "properties": {"answer": {"type": "string"}}},
+    }
+    await execute_query(options, "What is the weather?")
+    assert len(captured) == 1
+    body = captured[0]
+    assert body.get("response_format") == {"type": "json_object"}
+    messages = body["messages"]
+    # System message should now contain "json" (case insensitive)
+    sys_msgs = [m for m in messages if m.get("role") == "system"]
+    assert any("json" in (m.get("content") or "").lower() for m in sys_msgs), (
+        f"Expected 'json' in some system message, got: {sys_msgs}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_json_marker_NOT_injected_when_system_already_has_json(
+    monkeypatch, set_api_key
+):
+    """System already mentions JSON → no duplicate marker added."""
+    transport, captured = _capture_transport()
+    _patch_async_client(monkeypatch, transport)
+    options = {
+        "model": "deepseek-v4-pro",
+        "system": "Reply in JSON format only.",
+        "schema": {"type": "object"},
+    }
+    await execute_query(options, "test")
+    assert len(captured) == 1
+    messages = captured[0]["messages"]
+    sys_msgs = [m for m in messages if m.get("role") == "system"]
+    # The original system message is unchanged (no marker prepended)
+    assert sys_msgs[0]["content"] == "Reply in JSON format only."
+
+
+@pytest.mark.asyncio
+async def test_no_marker_when_no_schema(monkeypatch, set_api_key):
+    """No schema → no response_format → no marker injected."""
+    transport, captured = _capture_transport()
+    _patch_async_client(monkeypatch, transport)
+    options = {
+        "model": "deepseek-v4-pro",
+        "system": "You answer freely.",
+        # schema absent
+    }
+    await execute_query(options, "test")
+    body = captured[0]
+    assert "response_format" not in body
+    sys_msgs = [m for m in body["messages"] if m.get("role") == "system"]
+    # Original system message untouched (no JSON marker)
+    assert sys_msgs[0]["content"] == "You answer freely."
 
 
 # ─── Integration: execute_query + parse_response together ────────────

--- a/vendor/evoskill/src/harness/deepseek/executor.py
+++ b/vendor/evoskill/src/harness/deepseek/executor.py
@@ -248,6 +248,32 @@ async def execute_query(options: dict[str, Any], query: str) -> list[Any]:
     response_format = _build_response_format(options.get("schema"))
     if response_format is not None:
         payload["response_format"] = response_format
+        # Phase 1.1D fix (2026-05-19 smoke #6): DeepSeek API rejects
+        # `response_format: {"type": "json_object"}` with HTTP 400 if
+        # the prompt does NOT contain the substring "json" (case
+        # insensitive). EvoSkill's system prompts are generic agent
+        # task descriptions that may not include the literal word.
+        # We unconditionally prepend a JSON-mode marker to the system
+        # message — the marker is informative ("Respond in JSON.") and
+        # cheap (~5 tokens), and it satisfies DeepSeek's guard.
+        #
+        # Verified failure mode pre-fix:
+        #   DeepSeek API 400 (non-retryable): "Prompt must contain
+        #   the word 'json' in some form to use 'response_format' of
+        #   type 'json_object'."
+        messages = payload["messages"]
+        has_json_word = any(
+            "json" in (m.get("content") or "").lower() for m in messages
+        )
+        if not has_json_word:
+            json_marker = "Respond in JSON format matching the requested schema."
+            # Prepend to system message if present, else inject a new one
+            if messages and messages[0].get("role") == "system":
+                messages[0]["content"] = (
+                    json_marker + "\n\n" + messages[0]["content"]
+                )
+            else:
+                messages.insert(0, {"role": "system", "content": json_marker})
 
     # `reasoning_effort` is a DeepSeek V4 Pro extension (low/high/max).
     # We forward it conditionally; if the API doesn't recognise it on a


### PR DESCRIPTION
## Summary

Phase 1.1D — fixes runtime bug #4 caught by smoke #6 (2026-05-19): DeepSeek API
returns HTTP 400 (`Prompt must contain word 'json'`) when
`response_format: {"type":"json_object"}` is set but the prompt does not contain
the substring "json". EvoSkill's proposer/critic prompts built from
`options["schema"]` did not propagate the constraint into the messages — every
json-mode call to DeepSeek failed.

## Fix

In `vendor/evoskill/src/harness/deepseek/executor.py`, after building
`response_format` from `options["schema"]`, scan all messages
case-insensitive. If "json" is absent:

- prepend `"Respond in JSON format matching the requested schema."` to the first
  system message (concatenated with `\n\n`)
- or insert a new system message at position 0 if none exists

Marker is idempotent: NOT injected when the prompt already mentions JSON, and
NOT injected when no schema is set.

## Tests

3 new tests in `scripts/test_deepseek_executor.py`:
- `test_json_marker_injected_when_schema_set_and_system_lacks_json` — happy path
- `test_json_marker_NOT_injected_when_system_already_has_json` — idempotency
- `test_no_marker_when_no_schema` — no false positives

New `_capture_transport()` helper records the actual httpx request payload via
MockTransport, so tests can assert on the wire-level `messages[0].content`.

**Full regression: 116/116 PASS** across deepseek_executor, evidence_lint,
entailment_check, redact_pii, call_llm_deepseek suites.

## Bug discovery cadence

Smoke iterations have caught one new runtime bug each round, all missed by the
6-round panel review (Codex/Gemini/DeepSeek/NB-1):

| # | Bug | Fix PR |
|---|-----|--------|
| 1 | Module-load ImportError (SDK default = "claude") | #773 |
| 2 | Pre-commit hook blocks evoskill `git commit` | #778 |
| 3 | psql connection failure conflated with lock-held | #779 |
| 4 | `stratified_split` ZeroDivisionError (1-row-per-category) | #780 |
| 5 | DeepSeek json-mode 400 (missing "json" word) | **THIS PR** |

Reconfirms cicatrix lesson (2026-05-13): *empirical smoke > panel review for
runtime/integration issues*.

## Test plan

- [x] `pytest scripts/test_deepseek_executor.py` — 24/24 PASS (21 existing + 3 new)
- [x] Full Phase 1 suite — 116/116 PASS
- [x] Pre-commit hooks green (prettier + typecheck + ruff + golden-rule)
- [ ] Post-merge: re-bootstrap LaunchAgent + smoke #7 (verify Bug #5 program.yaml is cascade of #4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)