### PR TITLE
fix(evoskill): Telegram alert parse_mode breaks on special chars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -423,6 +423,8 @@ agent-library/.evoskill/logs/
 agent-library/.evoskill/skills/
 agent-library/.evoskill/prompts/
 agent-library/.evoskill/state.json
+agent-library/.evoskill/loop_checkpoint.json
+agent-library/.evoskill/feedback_history.md
 
 service_roi_calculator.py
 service_zone_finder.py

--- a/scripts/agent-library-evolver-run.sh
+++ b/scripts/agent-library-evolver-run.sh
@@ -156,7 +156,6 @@ import json, sys
 print(json.dumps({
     'chat_id': '${TELEGRAM_OWNER_CHAT_ID}',
     'text': sys.argv[1],
-    'parse_mode': 'Markdown'
 }))
 " "${msg}")"
     curl -sS -X POST \


### PR DESCRIPTION
## Summary

Smoke #10 (2026-05-19) end-to-end success — 10/10 iterations, $0.0992/$1.00 budget,
exit 0 — caught a non-blocking issue: the final Telegram alert returned HTTP 400
`Bad Request: can't parse entities: Can't find end of the entity starting at
byte offset 47`.

Root cause: `telegram_alert()` sends payload with `parse_mode: 'Markdown'`, but
the message text contains `$0.0992` and `_` in log paths — both Markdown special
chars without escaping. Server-side parser rejects, alert silently drops.

## Fix

Drop `parse_mode` from the payload. Plain text is sufficient for ops alerts
and immune to user-content escaping issues. Telegram renders raw text fine
(line breaks, ASCII art, paths) without any markdown formatting.

Also extend `.gitignore` for two EvoSkill runtime artifacts that appeared
during smoke #10:
- `agent-library/.evoskill/loop_checkpoint.json` (loop resume state)
- `agent-library/.evoskill/feedback_history.md` (iter feedback log)

These join the existing `.evoskill/state.json`, `frontier/`, `reports/`,
`logs/`, `skills/`, `prompts/` rules — all runtime, not source-controlled.

## Verification

End-to-end smoke #10 passed:
- 10/10 iterations completed
- Total cost $0.0992 (8% margin to budget)
- Best program: base (no proposals beat baseline)
- `DONE (proposals_passed=0) — exit 0` ✅
- Only Telegram render failed (this fix)

## Test plan

- [x] Wrapper smoke #10 = exit 0
- [ ] Next smoke: Telegram alert delivers (plain text rendered)
- [ ] No accidental commit of loop_checkpoint.json / feedback_history.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)