### PR TITLE
fix(tests): isolate legal ingestion test env

### DIFF
--- a/apps/backend-rag/backend/prompts/zantara_core_v2.py
+++ b/apps/backend-rag/backend/prompts/zantara_core_v2.py
@@ -23,10 +23,12 @@ from backend.prompts.business_rules_i18n import all_languages_for
 from backend.prompts.zantara_core import (
     CITATION_RULES,  # already multilingual at the source level
     CLOSING_PHRASES,  # already lang-aware (delegates to model)
+    CREATOR_PERSONA,  # noqa: F401 - re-exported for v2/v3 compatibility
     KNOWLEDGE_GOVERNANCE,  # XML structural, no IT-only phrases
     LANGUAGE_PROTOCOL,  # the protocol itself; reused verbatim
     SYSTEM_INSTRUCTIONS,  # XML structural, no IT-only phrases
-    )
+    TEAM_PERSONA,  # noqa: F401 - re-exported for v2/v3 compatibility
+)
 
 
 # Helper: render a {lang: phrase} dict as a 3-line model instruction so the

--- a/apps/backend-rag/backend/tests/conftest.py
+++ b/apps/backend-rag/backend/tests/conftest.py
@@ -23,6 +23,9 @@ os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/tes
 os.environ.setdefault("QDRANT_URL", "http://localhost:6333")
 os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
 os.environ.setdefault("ENVIRONMENT", "test")
+# Unit tests run with localhost Qdrant while developer shells may export a
+# different cloud QDRANT_URL; keep the production ingest guard explicit.
+os.environ["LEGAL_INGEST_ALLOW_QDRANT_ENV_OVERRIDE"] = "1"
 os.environ.setdefault("WHATSAPP_VERIFY_TOKEN", "test_whatsapp_verify_token")
 os.environ.setdefault("INSTAGRAM_VERIFY_TOKEN", "test_instagram_verify_token")
 os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123456:test_token")


### PR DESCRIPTION
## Summary
- make backend test env explicit for legal ingestion Qdrant override so developer shell QDRANT_URL does not trip the production ingest guard
- restore zantara_core_v2 CREATOR_PERSONA/TEAM_PERSONA re-exports required by zantara_core_v3 compatibility tests

## Verification
- cd apps/backend-rag && source .venv/bin/activate && ruff check backend/tests/conftest.py backend/prompts/zantara_core_v2.py
- cd apps/backend-rag && source .venv/bin/activate && PYTHONPATH=. pytest backend/tests/unit/cli/test_ingestion_cli.py backend/tests/unit/services/ingestion/test_legal_ingestion_service.py backend/tests/unit/services/ingestion/test_legal_ingest_integrity.py backend/tests/unit/test_zantara_core_v3.py -q --tb=short
- cd apps/backend-rag && source .venv/bin/activate && PYTHONPATH=. pytest backend/tests/ -q --tb=short
- git push pre-push hook: 13624 passed, 808 skipped, 95 warnings

## Notes
- prompt text was not changed; zantara_core_v2 only restores compatibility imports
- warnings are pre-existing async/mock warnings and are not failures
- peer machine was unreachable during local verification, so cross-machine sync is not confirmed
