### PR TITLE
feat(phase-f): sandbox routing rule for NB-PROBE-SANDBOX

### DIFF
--- a/apps/backend-rag/backend/services/intel/intel_lake_router.py
+++ b/apps/backend-rag/backend/services/intel/intel_lake_router.py
@@ -55,6 +55,13 @@ NB_INTEL_REGULATION = "80821295-703f-40ab-a32a-f0307e43ae2a"
 NB_INTEL_PRESS = "caec5b82-287c-464f-844f-02e2c8f04c21"
 NB_INTEL_AI_RESEARCH = "d48c4933-4d93-4d1e-8753-23b88145ba78"
 
+# ─── NB-PROBE-SANDBOX (Phase F, 2026-05-20) ─────────────────────────────────
+# Dedicated NotebookLM for synthetic e2e probes. Never NB-INTEL family.
+# Matching rule: source_domain == "probe-sandbox.example.test" (RFC 2606 .test
+# TLD never resolves on the public internet — only probe scripts use it).
+# Migration 187 CHECK constraint enforces canonical_url prefix at INSERT.
+NB_PROBE_SANDBOX = "7e6ae978-136c-4c96-bed5-9fab6f39176f"
+
 
 # ─── Routing rules (closed-set, applied top-to-bottom; first match wins) ────
 
@@ -155,6 +162,18 @@ _PRESS_REGULATORY_PATTERNS = tuple(
 
 
 _RULES: list[tuple[re.Pattern[str], str, dict[str, Any], str]] = [
+    # ─── Sandbox probe (Phase F, 2026-05-20) ────────────────────────────────
+    # Match EXACT RFC 2606 .test domain — never the public internet.
+    # First rule so probes are routed before any other classification.
+    # Uses ^...$ anchors via fullmatch semantics (pattern.match anchors at
+    # start; explicit $ anchors at end) to prevent prefix attacks like
+    # "probe-sandbox.example.test.evil.com".
+    (
+        re.compile(r"probe-sandbox\.example\.test$"),
+        "nb-intel",
+        {"nb_uuids": [NB_PROBE_SANDBOX]},
+        "probe_sandbox",
+    ),
     # Immigration (visa, KITAS, KITAP) → NB-INTEL-Immigration
     (
         re.compile(

--- a/apps/backend-rag/backend/tests/unit/services/intel/test_intel_lake_router.py
+++ b/apps/backend-rag/backend/tests/unit/services/intel/test_intel_lake_router.py
@@ -13,6 +13,7 @@ from backend.services.intel.intel_lake_router import (
     NB_INTEL_PRESS,
     NB_INTEL_REGULATION,
     NB_INTEL_TAX,
+    NB_PROBE_SANDBOX,
     IntelLakeRouter,
     _press_content_gate,
     backfill_needs_review,
@@ -94,6 +95,47 @@ class _PaginatedBackfillPool:
     @asynccontextmanager
     async def acquire(self) -> Any:
         yield self.conn
+
+
+class TestClassifySandbox:
+    """Phase F 2026-05-20: sandbox routing rule must short-circuit before
+    any production rule, and only match the exact RFC 2606 .test host."""
+
+    def test_sandbox_exact_host_routes_to_nb_probe_sandbox(self) -> None:
+        d = _make_router()._classify("probe-sandbox.example.test")
+        assert d["status"] == "nb-intel"
+        assert d["targets"]["nb_uuids"] == [NB_PROBE_SANDBOX]
+        assert d["rule"] == "probe_sandbox"
+
+    def test_sandbox_with_url_still_matches(self) -> None:
+        d = _make_router()._classify(
+            "probe-sandbox.example.test",
+            canonical_url="https://probe-sandbox.example.test/probe-abc123",
+        )
+        assert d["status"] == "nb-intel"
+        assert d["targets"]["nb_uuids"] == [NB_PROBE_SANDBOX]
+
+    def test_sandbox_substring_in_real_domain_does_NOT_match(self) -> None:
+        """A real producer URL containing the substring must NOT match."""
+        d = _make_router()._classify("probe-sandbox-attack.kompas.com")
+        # Falls through to press_general rule, not sandbox
+        assert d["rule"] != "probe_sandbox"
+        # Should route to NB-PROBE-SANDBOX UUID nowhere in the targets
+        if "nb_uuids" in d.get("targets", {}):
+            assert NB_PROBE_SANDBOX not in d["targets"]["nb_uuids"]
+
+    def test_sandbox_prefix_attack_does_NOT_match(self) -> None:
+        """Domain like 'probe-sandbox.example.test.evil.com' must NOT match."""
+        d = _make_router()._classify("probe-sandbox.example.test.evil.com")
+        # Anchored regex with $ prevents this attack
+        assert d["rule"] != "probe_sandbox"
+
+    def test_sandbox_does_not_collide_with_real_test_domains(self) -> None:
+        """A different .test host must not accidentally match."""
+        d = _make_router()._classify("other-sandbox.example.test")
+        assert d["rule"] != "probe_sandbox"
+        # Falls through to needs_review (no other rule matches .test)
+        assert d["status"] == "needs_review"
 
 
 class TestClassifyImmigration:


### PR DESCRIPTION
## Summary

Phase F closes the loop on Phase C/D probe infrastructure. The synthetic Intel Lake e2e probe previously skipped hop4 (nb-push validation) because no routing rule targeted the sandbox NB. This PR adds that rule.

## Routing rule details

- Match exact host \`probe-sandbox.example.test\` (RFC 2606 .test TLD — never resolves on public internet, so no real producer can match).
- Anchored regex with \`\$\` prevents prefix-attack like \`probe-sandbox.example.test.evil.com\`.
- Placed FIRST in \`_RULES\` so it short-circuits before any production rule.
- Routes to \`NB_PROBE_SANDBOX\` UUID \`7e6ae978-136c-4c96-bed5-9fab6f39176f\`.

## Test plan

- [x] 5 new unit tests added — all PASS:
  - exact host routes to NB-PROBE-SANDBOX
  - with canonical_url still matches
  - substring in real domain (\`probe-sandbox-attack.kompas.com\`) does NOT match
  - prefix-attack (\`probe-sandbox.example.test.evil.com\`) does NOT match
  - other .test host (\`other-sandbox.example.test\`) does NOT collide
- [x] 55/55 unit tests in test_intel_lake_router.py PASS
- [x] JSON SSOT (\`~/scripts/intel-lake-routing-rules.json\`) updated to version 3
- [ ] Post-merge: deploy + run probe with \`INTEL_LAKE_PROBE_CHECK_NB_PUSH=1\` to verify hop4 PASSES live

## Context

Plan: \`~/.claude/plans/vectorized-tinkering-moon.md\`

Phase A audit + Phase B-D shipped via #790-#794 (already merged). Phase F is the deferred routing rule needed to close hop4 enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)