### PR TITLE
fix(intel-lake): Phase F.4 — point NB-PROBE-SANDBOX UUID to zero-profile NB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ See [`INDEX.md`](INDEX.md) for the full atlas including packages, tessuti dati, 
 ### Tech Stack
 
 <!-- DOCSYNC:BACKEND_STATS_START -->
-- **Backend:** Python 3.11+, FastAPI, 269 routers, 564 services, 954 test files
+- **Backend:** Python 3.11+, FastAPI, 269 routers, 564 services, 957 test files
 <!-- DOCSYNC:BACKEND_STATS_END -->
 - **Frontend:** Next.js, TypeScript, Tailwind CSS
 - **Databases:** PostgreSQL (relational), Qdrant (vector), Redis (cache)

--- a/apps/backend-rag/backend/services/intel/intel_lake_router.py
+++ b/apps/backend-rag/backend/services/intel/intel_lake_router.py
@@ -60,7 +60,7 @@ NB_INTEL_AI_RESEARCH = "d48c4933-4d93-4d1e-8753-23b88145ba78"
 # Matching rule: source_domain == "probe-sandbox.example.test" (RFC 2606 .test
 # TLD never resolves on the public internet — only probe scripts use it).
 # Migration 187 CHECK constraint enforces canonical_url prefix at INSERT.
-NB_PROBE_SANDBOX = "7e6ae978-136c-4c96-bed5-9fab6f39176f"
+NB_PROBE_SANDBOX = "1e33e107-4064-48cd-b09d-f7f0a52b31ea"
 
 
 # ─── Routing rules (closed-set, applied top-to-bottom; first match wins) ────

--- a/apps/backend-rag/backend/tests/integration/test_intel_lake_e2e_probe_smoke.py
+++ b/apps/backend-rag/backend/tests/integration/test_intel_lake_e2e_probe_smoke.py
@@ -43,7 +43,7 @@ def test_probe_fixture_schema_stable(probe_module):
 
 
 def test_probe_constants(probe_module):
-    assert probe_module.NB_SANDBOX_UUID == "7e6ae978-136c-4c96-bed5-9fab6f39176f"
+    assert probe_module.NB_SANDBOX_UUID == "1e33e107-4064-48cd-b09d-f7f0a52b31ea"
     assert probe_module.PROBE_PRODUCER.startswith("probe-sandbox-")
 
 

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`269 routers · 564 services · 954 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`269 routers · 564 services · 957 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/scripts/probes/intel_lake_e2e_probe.py
+++ b/scripts/probes/intel_lake_e2e_probe.py
@@ -3,7 +3,8 @@
 Drives a single fixture observation through every layer of the Intel Lake
 pipeline and asserts each hop. Probe data is hard-isolated via migration
 187 (is_probe_sandbox boolean + CHECK constraint) and NB-PROBE-SANDBOX-2026-05
-NotebookLM notebook UUID 7e6ae978-136c-4c96-bed5-9fab6f39176f.
+NotebookLM notebook UUID 1e33e107-4064-48cd-b09d-f7f0a52b31ea (profile=zero,
+recreated 2026-05-20 Phase F.4 after pusher profile-mismatch discovery).
 
 Pipeline hops verified:
     1. POST /api/intel/lake/observations-batch  → outbox row inserted
@@ -47,7 +48,7 @@ import httpx
 logger = logging.getLogger("intel-lake.probe")
 
 PROBE_PRODUCER = f"probe-sandbox-{time.strftime('%Y-%m-%d')}"
-NB_SANDBOX_UUID = "7e6ae978-136c-4c96-bed5-9fab6f39176f"
+NB_SANDBOX_UUID = "1e33e107-4064-48cd-b09d-f7f0a52b31ea"
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Phase F.4 closes the last gap in Intel Lake e2e probe pipeline, discovered during live hop4 enforcement.

The original NB-PROBE-SANDBOX (UUID `7e6ae978-...`) was created on the **default nlm profile** (`antonellosiano@gmail.com` — Bali Zero personal account, 60-NB stack), but `intel-lake-nb-pusher-cron.sh` hardcodes `--profile zero` (`zero@balizero.com`). NLM CLI returns "Could not add url source" indistinguishable from a network error when the NB doesn't exist on the active profile.

Fix: new NB created on profile=zero with UUID `1e33e107-4064-48cd-b09d-f7f0a52b31ea`, all references updated.

## Verified live (2026-05-20 05:53 WITA)

- Router classified probe URL → `routing_targets.nb_uuids=[1e33e107...]`
- Pusher `push_id=2996 item=e9ab9f41 nb=1e33e107`
- `push_method=text` via envelope fallback (RFC 2606 `.test` TLD intentionally unreachable for URL push)
- NLM source `[PROBE-SANDBOX] e2e fixture 179382c455bd` confirmed in NB at +6s
- `intel_item_nb_pushes.status='pushed'`, `pushed_at=2026-05-19 21:53:40 UTC`

## Side fix (Pro-local, not in repo)

`/Users/nuzantara/scripts/intel-lake-nb-pusher-standalone.py::_classify_nlm_error` now matches `could not add url source` / `check the url is accessible` → returns `network` so text fallback fires on unreachable URLs.

## Test plan
- [x] Unit tests `TestClassifySandbox` still pass (5/5)
- [x] Live e2e: router→pusher→NLM end-to-end with new UUID
- [x] DB `intel_item_nb_pushes` row `status=pushed`
- [x] NLM source listed in NB-PROBE-SANDBOX

🤖 Generated with [Claude Code](https://claude.com/claude-code)