### PR TITLE
chore(intel-lake): enable hop4 enforcement in e2e probe LaunchAgent (Phase F.5)

### DIFF
--- a/infra/launchagents/com.balizero.intel-lake.e2e-probe.6h.plist
+++ b/infra/launchagents/com.balizero.intel-lake.e2e-probe.6h.plist
@@ -10,7 +10,7 @@
         <key>HOME</key>
         <string>/Users/nuzantara</string>
         <key>PATH</key>
-        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>/opt/homebrew/opt/postgresql@17/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     </dict>
 
     <key>ProgramArguments</key>

--- a/research/operations/2026-05-20-probe-sandbox-setup.md
+++ b/research/operations/2026-05-20-probe-sandbox-setup.md
@@ -15,12 +15,12 @@ storage layer.
 
 ## Sandbox tenants
 
-| Layer            | Tenant identifier                      | Notes                                                                                             |
-| ---------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| NotebookLM       | NB-PROBE-SANDBOX-2026-05               | UUID `7e6ae978-136c-4c96-bed5-9fab6f39176f` (created via `mcp__notebooklm-mcp__notebook_create`). |
-| PG `intel_items` | `producer_name LIKE 'probe-sandbox-%'` | Migration 187 adds `is_probe_sandbox BOOLEAN` + CHECK constraint hard barrier.                    |
-| Canva            | Folder `wr2-probe-sandbox` (TBD)       | Separate from production folder `FAHEwkTYduI`. `canva-apply --target-folder` flag.                |
-| Telegram         | `TELEGRAM_PROBE_CHAT_ID` (TBD)         | Probe failures route here — never owner chat (`TELEGRAM_OWNER_CHAT_ID=1125336968`).               |
+| Layer            | Tenant identifier                      | Notes                                                                                                                                                                                                                                                                                                                                                                            |
+| ---------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| NotebookLM       | NB-PROBE-SANDBOX-2026-05               | UUID `1e33e107-4064-48cd-b09d-f7f0a52b31ea` (re-created 2026-05-20 Phase F.4 via `nlm notebook create --profile zero`). The original `7e6ae978-...` was on the default nlm profile (`antonellosiano@gmail.com`); the pusher cron hardcodes `--profile zero` (`zero@balizero.com`), so the NB was invisible to the pusher and writes failed with `Could not add url/file source`. |
+| PG `intel_items` | `producer_name LIKE 'probe-sandbox-%'` | Migration 187 adds `is_probe_sandbox BOOLEAN` + CHECK constraint hard barrier.                                                                                                                                                                                                                                                                                                   |
+| Canva            | Folder `wr2-probe-sandbox` (TBD)       | Separate from production folder `FAHEwkTYduI`. `canva-apply --target-folder` flag.                                                                                                                                                                                                                                                                                               |
+| Telegram         | `TELEGRAM_PROBE_CHAT_ID` (TBD)         | Probe failures route here — never owner chat (`TELEGRAM_OWNER_CHAT_ID=1125336968`).                                                                                                                                                                                                                                                                                              |
 
 ## Cleanup invariants
 
@@ -39,14 +39,14 @@ WHERE topic LIKE '[PROBE-SANDBOX-%' AND created_at < now() - interval '24h';
 ```
 
 NotebookLM sandbox NB can be deleted wholesale via
-`mcp__notebooklm-mcp__notebook_delete(notebook_id='7e6ae978-...')` if state
+`mcp__notebooklm-mcp__notebook_delete(notebook_id='1e33e107-...')` if state
 drifts. Canva sandbox folder: trash all designs in folder via Canva UI.
 
 ## Verification (read-only)
 
 ```bash
 # NB sandbox exists + 0 sources (fresh)
-mcp__notebooklm-mcp__notebook_describe(notebook_id='7e6ae978-136c-4c96-bed5-9fab6f39176f')
+mcp__notebooklm-mcp__notebook_describe(notebook_id='1e33e107-4064-48cd-b09d-f7f0a52b31ea')
 # Expected: source_count=0
 ```
 


### PR DESCRIPTION
## Summary

Phase F.5 closes the LaunchAgent activation gap for Intel Lake e2e probe.

### Changes
- Plist PATH now includes \`/opt/homebrew/opt/postgresql@17/bin\` so wrapper's \`psql\` call to write \`system_settings.probe_intel_lake_last_pass\` on PROBE PASS actually resolves (previously emitted \`WARN system_settings update failed (non-fatal)\` every run).
- Wrapper script (Pro-local) now sets \`INTEL_LAKE_PROBE_CHECK_NB_PUSH=1\` before invoking probe → hop4 enforced on every cron tick. Safe to enable now that Phase F.1 added the sandbox routing rule and Phase F.4 fixed the NB profile mismatch.
- Wrapper DSN-rewrite bug fixed (Pro-local): nested bash subs produced \`@localhost:15432:5432/...\` double-port. Replaced with single Python regex sub.

### Live verified (2026-05-20 07:27 WITA via launchctl kickstart)
- hop1 PASS item_id=a8e4de11
- hop2 PASS outbox 17957
- hop2.5 PASS sandbox flag
- hop3 PASS routing_status=nb-intel
- hop4 PASS nb_uuid=1e33e107 pushed_at=23:27:11 — enforced via env flag
- hop5 PASS cleanup
- PROBE END rc=0
- system_settings.probe_intel_lake_last_pass = 2026-05-19T23:27:14Z

### Schedule
Every 6h: 00:30 / 06:30 / 12:30 / 18:30 WITA. Failures alert TELEGRAM_PROBE_CHAT_ID (fallback OWNER_CHAT_ID) with 30min debounce.

## Test plan
- [x] launchctl bootstrap loads plist
- [x] Manual kickstart runs full pipeline through hop4
- [x] psql resolves in cron PATH
- [x] system_settings update on PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)