### PR TITLE
fix(wr2): canva-desktop-apply accepts drafts_imaged_checked status

### DIFF
--- a/scripts/wr2_canva_desktop_apply.py
+++ b/scripts/wr2_canva_desktop_apply.py
@@ -147,14 +147,19 @@ async def _kill_switch_enabled(conn: asyncpg.Connection) -> bool:
 async def _fetch_ready_drafts(conn: asyncpg.Connection, limit: int) -> list[asyncpg.Record]:
     # WR2 pipeline: topic → briefed → (draft_generator) → drafts →
     # (image_generator) → drafts_imaged → (canva_apply) → published.
-    # Accept both 'drafts_imaged' (normal) and 'drafts' (legacy/fallback when
-    # image_generator is disabled) so the pipeline keeps flowing even if
-    # the image step is skipped.
+    # Accept 'drafts_imaged' (normal), 'drafts' (legacy/fallback when
+    # image_generator is disabled), 'drafts_imaged_facted' (post fact-extractor),
+    # and 'drafts_imaged_checked' (post fact-checker — supervisor routes this
+    # status to canva-apply per wr2_supervisor.py:97). The supervisor's
+    # routing table is the source of truth; this query must accept any
+    # status the supervisor will route here. Bug fix 2026-05-20: previously
+    # drafts that passed fact-checker were stuck because the query only
+    # matched 'drafts_imaged' / 'drafts'.
     return await conn.fetch(
         """
         SELECT id, topic, register AS tone, slides_json
           FROM war_room_drafts
-         WHERE status IN ('drafts_imaged', 'drafts')
+         WHERE status IN ('drafts_imaged', 'drafts', 'drafts_imaged_facted', 'drafts_imaged_checked')
            AND canva_edit_url IS NULL
          ORDER BY created_at ASC
          LIMIT $1
@@ -526,7 +531,7 @@ async def _fetch_one_by_id(
         SELECT id, topic, register AS tone, slides_json
           FROM war_room_drafts
          WHERE id = $1::uuid
-           AND status IN ('drafts_imaged', 'drafts')
+           AND status IN ('drafts_imaged', 'drafts', 'drafts_imaged_facted', 'drafts_imaged_checked')
            AND canva_edit_url IS NULL
         """,
         draft_id,


### PR DESCRIPTION
## Root cause

Routing mismatch between supervisor and canva-desktop-apply.

- Supervisor: `drafts_imaged_checked → canva-apply` (wr2_supervisor.py:97)
- canva-desktop-apply._fetch_ready_drafts(): `status IN ('drafts_imaged', 'drafts')` only

Drafts that passed fact-checker were stuck at `drafts_imaged_checked` — every cron tick logged 'no drafts ready'.

## Empirical 2026-05-20

2 retry drafts (2f21e709, 98805a61):
- 09:07 image-gen → drafts_imaged
- 09:07 canva-apply kickstarted, wrote canva_pending.json
- 09:07-09 fact-checker promoted to drafts_imaged_facted → drafts_imaged_checked
- 09:42 canva-apply re-kickstart found 'no drafts ready'
- Stuck at drafts_imaged_checked, canva_design_id NULL

## Fix

Both queries (`_fetch_ready_drafts` + `_fetch_one_by_id`) now match:
`drafts_imaged | drafts | drafts_imaged_facted | drafts_imaged_checked`

🤖 Generated with [Claude Code](https://claude.com/claude-code)