### PR TITLE
fix(seo): add missing name and image to service page microdata schema

### DIFF
--- a/apps/mouth/src/app/(blog)/services/[slug]/page.tsx
+++ b/apps/mouth/src/app/(blog)/services/[slug]/page.tsx
@@ -207,6 +207,12 @@ export default async function ServiceDetailPage({
                       itemScope
                       itemType={`https://schema.org/${serviceType}`}
                     >
+                      <dt>Name</dt>
+                      <dd itemProp="name">{service.name}</dd>
+                      <dt>Image</dt>
+                      <dd itemProp="image">
+                        {baseUrl}/static/balizero-logo-clean.png
+                      </dd>
                       <dt>Service Type</dt>
                       <dd itemProp="serviceType">{service.name}</dd>
                       <dt>Processing Time</dt>


### PR DESCRIPTION
## Summary
Adds missing required microdata properties (`name` and `image`) to the
LocalBusiness/ProfessionalService schema block in the service detail page.
Fixes "Unnamed item" INVALID status on Google Rich Results Test for all
/services/[slug] pages.

## Studio Layer

**Insight**
All /services/[slug] pages (tax, visa, property, company) had invalid
LocalBusiness microdata — missing 2 required fields causing Google to
mark schema as INVALID and ineligible for rich results.

**Evidence**
Rich Results Test on /services/tax: "Local businesses — 3 items detected,
some are invalid." Item 1 "Unnamed item" showed 2 critical errors:
Missing field "name" + Missing field "image". Detected via schema audit
20 May 2026.

**Reasoning**
The <dl itemScope> block in page.tsx generated microdata without name/image.
Google's LocalBusiness schema requires both fields to be eligible for
rich results. Fix is 4 lines, dynamic ({service.name}), applies to all
service slugs automatically.

**Risk**
Low. Change is additive only — 4 lines added inside an sr-only block.
Zero UI impact. No JS, no client component changes. Affects all
/services/[slug] routes (visa, tax, property, company) — all benefit.

**Recommendation**
Merge after Vercel preview confirms no regression. Re-test via Rich
Results Test post-deploy to verify "Unnamed item" → named item (valid).

**Next Action**
Post-merge: re-run Rich Results Test on /services/tax → confirm
LocalBusiness Item 1 shows service name (not "Unnamed") with valid status.