### PR TITLE
feat(seo): add missing internal links to tax hub + resolve 183-day cannibalization

### DIFF
--- a/apps/mouth/src/content/articles/business/indonesias-183-day-tax-residency-rule-what-expats-get-wrong-in-2026.mdx
+++ b/apps/mouth/src/content/articles/business/indonesias-183-day-tax-residency-rule-what-expats-get-wrong-in-2026.mdx
@@ -83,6 +83,8 @@ The good news is that with proper planning, the 183-day rule is entirely managea
   ]}
 />
 
+For a complete overview of Indonesian tax residency rules including the dual-test and implications for different visa types, see our [Tax Residency in Indonesia guide](/insights/tax/tax-residency-indonesia).
+
 ---
 
 <AskZantara

--- a/apps/mouth/src/content/articles/tax/indonesia-tax-guide-for-foreigners.mdx
+++ b/apps/mouth/src/content/articles/tax/indonesia-tax-guide-for-foreigners.mdx
@@ -1074,6 +1074,9 @@ Indonesian tax can be complex, especially for foreigners with multiple income so
 - [Tax Treaties: Avoiding Double Taxation](/insights/tax-legal/tax-treaties-explained)
 - [Corporate Tax in Indonesia](/insights/tax-legal/corporate-tax-indonesia)
 - [Freelancer Taxes in Indonesia](/insights/tax-legal/freelancer-taxes-indonesia)
+- [Tax Residency in Indonesia: The 183-Day Rule Explained](/insights/tax/tax-residency-indonesia)
+- [Rental Income Tax Indonesia 2026: 10% PPh Final for Villas & Property](/insights/tax/rental-income-tax-indonesia)
+- [Withholding Tax Indonesia 2026: Complete PPh Guide](/insights/tax/withholding-tax-guide)
 
 ---
 


### PR DESCRIPTION
## Summary
Adds 3 missing internal links to the tax cluster hub article and 
resolves keyword cannibalization between two overlapping tax 
residency articles.

## Studio Layer

**Insight**
Tax hub (indonesia-tax-guide-for-foreigners.mdx) was missing links 
to 3 key cluster articles — weakening PageRank flow to tax spoke 
pages and leaving two articles competing for the same keyword.

**Evidence**
Hub audit (20 May 2026): 5 existing links, missing tax-residency, 
rental-income-tax, and withholding-tax cluster articles. 
Cannibalization: business/183-day article (80%+ overlap) competing 
with tax/tax-residency-indonesia.mdx for "tax residency indonesia" 
keyword.

**Reasoning**
Hub-and-spoke internal linking strengthens topical authority. 
Missing links = Google cannot determine hierarchy. Cross-link from 
183-day article signals canonical source to Google, reducing 
competition between two overlapping articles.

**Risk**
Zero. Additive MDX changes only — no component or logic changes. 
No UI impact.

**Recommendation**
Merge after confirming URL paths resolve correctly in staging. 
Verify /insights/tax/tax-residency-indonesia and 
/insights/tax/rental-income-tax-indonesia return 200 after deploy.

**Next Action**
Post-merge: check GSC for internal link coverage improvements 
on tax cluster pages within 2-3 weeks.