### PR TITLE
fix(seo): optimize meta description for tax-residency-indonesia article

### DIFF
--- a/apps/mouth/src/content/articles/tax/tax-residency-indonesia.mdx
+++ b/apps/mouth/src/content/articles/tax/tax-residency-indonesia.mdx
@@ -2,7 +2,7 @@
 title: "Tax Residency in Indonesia: The 183-Day Rule and What Most Expats Get Wrong"
 slug: "tax-residency-indonesia"
 description: "Indonesia's tax residency rules go beyond the 183-day threshold. Learn the dual-test, what it means for PT PMA owners, KITAS holders, and digital nomads on E33G."
-excerpt: "183 days is not the only trigger. Here's how Indonesia really determines tax residency — and what that means for your compliance."
+excerpt: "Indonesia tax residency explained for expats: beyond the 183-day rule. How domicile, intention, and KITAS status affect your worldwide income tax liability."
 category: "tax"
 coverImage: "/static/insights/tax/tax-calendar.jpg"
 publishedAt: "2026-05-15"


### PR DESCRIPTION
## Summary
Update excerpt field in tax-residency-indonesia.mdx to improve meta description SEO quality.

## Studio Layer

**Insight:** Meta description audit (21 Mei 2026) identified /insights/tax/tax-residency-indonesia as the only tax cluster article with a suboptimal meta description — conversational tone but missing explicit keywords.

**Evidence:** Previous excerpt: "183 days is not the only trigger. Here's how Indonesia really determines tax residency..." — no keyword "expat", "KITAS", or "Indonesia tax residency" in first 60 chars.

**Reasoning:** The excerpt field is what renders as <meta name="description"> on this page (confirmed via DevTools). seo.description field exists but is not rendering — separate issue, not in scope.

**Risk:** Minimal — 1 field changed in 1 MDX file. No component changes, no layout changes.

**Recommendation:** Deploy and verify via view-source after merge.

**Next Action:** Post-merge: confirm new meta description live via view-source → Cmd+F → "description".

## Files Changed
- `apps/mouth/src/content/articles/tax/tax-residency-indonesia.mdx` — excerpt updated