### PR TITLE
fix(seo): optimize meta descriptions for 7 high-traffic tax articles

### DIFF
--- a/apps/mouth/src/content/articles/tax/annual-tax-return-guide.mdx
+++ b/apps/mouth/src/content/articles/tax/annual-tax-return-guide.mdx
@@ -2,7 +2,7 @@
 title: "Annual Tax Return (SPT) Guide for Expats in Indonesia 2026"
 slug: "annual-tax-return-guide"
 description: "How to file your annual tax return (SPT Tahunan) as a foreigner in Indonesia. Step-by-step guide, deadlines, and common mistakes."
-excerpt: "Every tax resident must file SPT by March 31. Here's how to do it correctly."
+excerpt: "Indonesia annual tax return (SPT Tahunan) guide for expats and PT PMA. Filing deadline March 31, required documents, CoreTax walkthrough, and late penalty avoidance."
 category: "tax"
 coverImage: "/static/insights/tax/spt-filing.jpg"
 

--- a/apps/mouth/src/content/articles/tax/corporate-income-tax.mdx
+++ b/apps/mouth/src/content/articles/tax/corporate-income-tax.mdx
@@ -2,7 +2,7 @@
 title: "Corporate Income Tax Indonesia 2026: Complete Guide"
 slug: "corporate-income-tax"
 description: "Corporate income tax (CIT) in Indonesia. Tax rates, deductions, and compliance requirements for PT PMA and local companies."
-excerpt: "Understanding corporate tax is essential for business in Indonesia. Here's the complete guide."
+excerpt: "Indonesia corporate income tax rate is 22% for PT PMA. Complete guide to PPh Badan obligations, deductible expenses, PPh 25 installments, and annual SPT Tahunan filing."
 category: "tax"
 coverImage: "/static/insights/tax/corporate-tax.jpg"
 

--- a/apps/mouth/src/content/articles/tax/npwp-foreigners-guide.mdx
+++ b/apps/mouth/src/content/articles/tax/npwp-foreigners-guide.mdx
@@ -2,7 +2,7 @@
 title: "NPWP for Foreigners in Indonesia: How to Register (2026)"
 slug: "npwp-foreigners-guide"
 description: "Indonesia's tax ID is mandatory for banking, property, and business. Get your NPWP in 1-3 days with an active KITAS. Requirements, process, and what happens without it."
-excerpt: "NPWP is essential for foreigners in Indonesia. Here's how to get yours and why it matters."
+excerpt: "How to get NPWP as a foreigner in Indonesia: required documents, Coretax online registration, KITAS holders vs tourists, and consequences of not registering."
 category: "tax"
 coverImage: "/static/insights/tax/npwp-card.jpg"
 

--- a/apps/mouth/src/content/articles/tax/pph-21-expat-guide.mdx
+++ b/apps/mouth/src/content/articles/tax/pph-21-expat-guide.mdx
@@ -2,7 +2,7 @@
 title: "PPh 21 for Expats in Indonesia 2026: Income Tax Rates, Calculation & Payslip"
 slug: "pph-21-expat-guide"
 description: "PPh 21 is Indonesia's income tax withheld from salaries. Expat guide: progressive rates 5-35%, PTKP allowances, TER simplified method, and how your employer calculates withholding."
-excerpt: "Working in Indonesia? Here's how PPh 21 income tax works and what to expect on your payslip."
+excerpt: "PPh 21 income tax in Indonesia: progressive rates 5-35% for expats and employees. Monthly withholding, PTKP exemptions IDR 54M, year-end reconciliation, and payslip breakdown."
 category: "tax"
 coverImage: "/static/insights/tax/pph-21.jpg"
 

--- a/apps/mouth/src/content/articles/tax/tax-calendar-indonesia.mdx
+++ b/apps/mouth/src/content/articles/tax/tax-calendar-indonesia.mdx
@@ -2,7 +2,7 @@
 title: "Indonesia Tax Calendar 2026: Every Deadline for Individuals & Businesses"
 slug: "tax-calendar-indonesia"
 description: "Complete 2026 tax calendar for Indonesia. Monthly PPh, annual SPT, VAT, and PBB deadlines for individuals, expats, and PT PMA. Never miss a filing date again."
-excerpt: "Never miss a tax deadline. Here's the complete Indonesia tax calendar for 2026."
+excerpt: "Complete Indonesia tax calendar 2026: PPh 21 by 20th, PPN by 31st, SPT Tahunan March 31, PPh 25 by 15th. All deadlines, penalty amounts, and CoreTax submission tips."
 category: "tax"
 coverImage: "/static/insights/tax/tax-calendar.jpg"
 

--- a/apps/mouth/src/content/articles/tax/vat-ppn-guide.mdx
+++ b/apps/mouth/src/content/articles/tax/vat-ppn-guide.mdx
@@ -2,7 +2,7 @@
 title: "VAT (PPN) Indonesia 2026: 12% Rate, Registration & Compliance Guide"
 slug: "vat-ppn-guide"
 description: "Indonesia raised VAT to 12% in January 2025. Guide to PPN registration thresholds (IDR 4.8B), e-Faktur invoicing, monthly SPT, and what PT PMA owners need to know in 2026."
-excerpt: "Understanding Indonesian VAT (PPN) is essential for business compliance. Here's everything you need to know."
+excerpt: "Indonesia PPN (VAT) guide: 12% standard rate from 2026, PKP registration threshold IDR 4.8B, e-Faktur invoicing, monthly reporting by 31st, and input tax credit rules."
 category: "tax"
 coverImage: "/static/insights/tax/vat-ppn.jpg"
 

--- a/apps/mouth/src/content/articles/tax/withholding-tax-guide.mdx
+++ b/apps/mouth/src/content/articles/tax/withholding-tax-guide.mdx
@@ -2,7 +2,7 @@
 title: "Withholding Tax Indonesia 2026: Complete PPh Guide"
 slug: "withholding-tax-guide"
 description: "Indonesian withholding taxes explained. PPh 21, PPh 23, PPh 26, PPh 4(2), and compliance requirements for businesses."
-excerpt: "Withholding taxes are a key part of Indonesian taxation. Here's what every business needs to know."
+excerpt: "Indonesia withholding tax guide: PPh 21 salaries, PPh 23 domestic services 2-15%, PPh 26 foreign payments 20%, PPh 4(2) final tax. Rates, deadlines, and e-Bupot reporting."
 category: "tax"
 coverImage: "/static/insights/tax/withholding-tax.jpg"
 


### PR DESCRIPTION
## Summary
Batch update: 7 tax articles had generic/too-short excerpts that rendered as weak meta descriptions in Google search results.

## Studio Layer

**Insight:** Tax cluster audit (21 Mei 2026) identified 7 high-traffic articles with excerpts lacking keywords, specifics, or transactional intent.

**Evidence:** Before/after comparison:
- annual-tax-return-guide: "Every tax resident must file SPT by March 31." → keyword-rich with CoreTax + penalty mention
- corporate-income-tax: "Understanding corporate tax is essential..." → now includes 22% rate + PPh Badan
- npwp-foreigners-guide: "NPWP is essential for foreigners..." → now includes documents + Coretax + KITAS
- pph-21-expat-guide: "Working in Indonesia?..." → now includes 5-35% rates + PTKP IDR 54M
- tax-calendar-indonesia: "Never miss a tax deadline..." → now includes specific deadlines per tax type
- vat-ppn-guide: "Understanding Indonesian VAT..." → now includes 12% rate + IDR 4.8B threshold
- withholding-tax-guide: "Withholding taxes are a key part..." → now includes PPh 21/23/26 rates

**Reasoning:** Excerpt field renders as <meta name="description"> — confirmed via DevTools audit. Generic excerpts reduce CTR in organic search results.

**Risk:** Minimal — 7 MDX content files, no component changes, no layout changes.

**Recommendation:** Merge and monitor GSC CTR for these 7 pages over 30 days.

**Next Action:** Post-merge verify via view-source on each page. Track CTR in GSC after 2-4 weeks.

## Files Changed
7 MDX files — excerpt field only.