### PR TITLE
fix(seo): optimize meta descriptions for 7 tax articles batch 2

### DIFF
--- a/apps/mouth/src/content/articles/tax/double-taxation-treaties.mdx
+++ b/apps/mouth/src/content/articles/tax/double-taxation-treaties.mdx
@@ -2,7 +2,7 @@
 title: "Double Taxation Treaties Indonesia 2026: Complete Guide"
 slug: "double-taxation-treaties"
 description: "Indonesia's double taxation agreements explained. How tax treaties work and benefits for foreign investors and expats."
-excerpt: "Avoid paying tax twice on the same income. Here's how Indonesia's tax treaties work."
+excerpt: "Indonesia has tax treaties with 70+ countries including Australia, UK, Singapore, and Netherlands. How P3B agreements reduce withholding rates and avoid double taxation."
 category: "tax"
 coverImage: "/static/insights/tax/double-taxation.jpg"
 

--- a/apps/mouth/src/content/articles/tax/freelancer-tax-guide.mdx
+++ b/apps/mouth/src/content/articles/tax/freelancer-tax-guide.mdx
@@ -2,7 +2,7 @@
 title: "Freelancer Taxes in Indonesia 2026"
 slug: "freelancer-tax-guide"
 description: "Tax guide for freelancers in Indonesia. How to calculate, report, and pay taxes on freelance income. Domestic and international clients."
-excerpt: "Freelancing in Indonesia? Here's how your taxes work and what you need to know."
+excerpt: "Freelancers in Indonesia pay tax under norma penghitungan or actual cost. Guide to NPWP registration, PPh 21 withholding, deemed profit rates, and SPT 1770 annual filing."
 category: "tax"
 coverImage: "/static/insights/tax/freelancer-tax.jpg"
 

--- a/apps/mouth/src/content/articles/tax/indonesia-tax-guide-for-foreigners.mdx
+++ b/apps/mouth/src/content/articles/tax/indonesia-tax-guide-for-foreigners.mdx
@@ -2,7 +2,7 @@
 title: "Indonesia Tax Guide for Foreigners 2026"
 slug: "indonesia-tax-guide-for-foreigners"
 description: "Complete guide to Indonesian taxation for expatriates and foreign investors. Understand tax residency, income tax rates, reporting requirements, and how to stay compliant."
-excerpt: "Navigate Indonesia's tax system with confidence. From determining your residency status to filing annual returns, this guide covers everything foreigners need to know."
+excerpt: "Complete Indonesia tax guide for foreigners 2026: residency rules, PPh 21 rates 5-35%, NPWP registration, tax treaties, annual SPT filing, and expat tax planning strategies."
 category: "tax"
 coverImage: "/static/insights/tax/indonesia-tax-guide.jpg"
 

--- a/apps/mouth/src/content/articles/tax/tax-audit-indonesia.mdx
+++ b/apps/mouth/src/content/articles/tax/tax-audit-indonesia.mdx
@@ -2,7 +2,7 @@
 title: "Tax Audit Indonesia 2026: What Businesses Need to Know"
 slug: "tax-audit-indonesia"
 description: "Understanding tax audits in Indonesia. How audits work, preparation, common triggers, and how to handle DJP examinations."
-excerpt: "Facing a tax audit? Here's what to expect and how to prepare."
+excerpt: "DJP tax audit in Indonesia: what triggers pemeriksaan, audit types office vs field, document checklist, typical timeline 3-6 months, and how to respond to objections."
 category: "tax"
 coverImage: "/static/insights/tax/tax-audit.jpg"
 

--- a/apps/mouth/src/content/articles/tax/tax-incentives-indonesia.mdx
+++ b/apps/mouth/src/content/articles/tax/tax-incentives-indonesia.mdx
@@ -2,7 +2,7 @@
 title: "Indonesia Tax Incentives 2026: Tax Holiday, Allowance & Pioneer List"
 slug: "tax-incentives-indonesia"
 description: "100% corporate tax exemption for up to 20 years. Indonesia's tax holiday, tax allowance, super deduction, and KEK benefits explained for investors and PT PMA owners."
-excerpt: "Indonesia offers significant tax incentives for investors. Here's what's available."
+excerpt: "Indonesia tax incentives for investors: tax holiday 0% CIT up to 20 years, tax allowance 30% deduction, super deduction R&D 250%, and special economic zone benefits."
 category: "tax"
 coverImage: "/static/insights/tax/tax-incentives.jpg"
 

--- a/apps/mouth/src/content/articles/tax/tax-planning-expats.mdx
+++ b/apps/mouth/src/content/articles/tax/tax-planning-expats.mdx
@@ -2,7 +2,7 @@
 title: "Tax Planning for Expats Indonesia 2026: Strategies Guide"
 slug: "tax-planning-expats"
 description: "Tax planning strategies for expats in Indonesia. Optimize your tax position while staying compliant."
-excerpt: "Smart tax planning can save you money. Here's how expats can optimize their tax position in Indonesia."
+excerpt: "Indonesia tax planning for expats: PTKP optimization, foreign income exemption PMK 18/2021, treaty benefits, residency timing strategy, and PT PMA ownership structures."
 category: "tax"
 coverImage: "/static/insights/tax/tax-planning.jpg"
 

--- a/apps/mouth/src/content/articles/tax/tax-treaties-explained.mdx
+++ b/apps/mouth/src/content/articles/tax/tax-treaties-explained.mdx
@@ -2,7 +2,7 @@
 title: "Tax Treaties: Avoiding Double Taxation in Indonesia 2026"
 slug: "tax-treaties-explained"
 description: "How Indonesia's tax treaties work to prevent double taxation. Claiming treaty benefits, reduced rates, and which countries have agreements."
-excerpt: "Don't pay tax twice on the same income. Here's how tax treaties protect you."
+excerpt: "Indonesia tax treaty network explained: how P3B agreements reduce withholding on dividends 10-15%, interest 10%, and royalties 10-15% vs domestic rates."
 category: "tax"
 coverImage: "/static/insights/tax/tax-treaties.jpg"
 


### PR DESCRIPTION
## Summary
Batch update: 7 tax articles had generic/too-short excerpts rendering as weak meta descriptions.

## Studio Layer

**Insight:** Tax cluster audit (21 Mei 2026) identified 7 remaining articles with excerpts lacking keywords, specifics, or transactional intent.

**Evidence:** Before/after:
- double-taxation-treaties: "Avoid paying tax twice..." → now includes 70+ countries + P3B specifics
- freelancer-tax-guide: "Freelancing in Indonesia?..." → now includes norma penghitungan + SPT 1770
- indonesia-tax-guide-for-foreigners: "Navigate Indonesia's tax system..." → now includes 5-35% rates + 2026
- tax-audit-indonesia: "Facing a tax audit?..." → now includes pemeriksaan + 3-6 month timeline
- tax-incentives-indonesia: "Indonesia offers significant tax incentives..." → now includes 0% CIT + R&D 250%
- tax-planning-expats: "Smart tax planning can save you money..." → now includes PMK 18/2021 + PT PMA
- tax-treaties-explained: "Don't pay tax twice..." → now includes specific withholding rates 10-15%

**Reasoning:** Excerpt field renders as <meta name="description"> — confirmed via DevTools audit. Generic excerpts reduce CTR in organic search results.

**Risk:** Minimal — 7 MDX content files, no component changes. Note: tax-incentives-indonesia required Python fix due to & character in R&D conflicting with sed special character handling.

**Recommendation:** Merge and monitor GSC CTR over 30 days.

**Next Action:** Post-merge verify via view-source on each page.

## Files Changed
7 MDX files — excerpt field only.