### PR TITLE
fix(analytics): emit gtag consent default=granted before GA loads (GA4 0-events root cause)

### DIFF
--- a/apps/mouth/src/app/layout.tsx
+++ b/apps/mouth/src/app/layout.tsx
@@ -256,7 +256,19 @@ export default function RootLayout({
           }}
         />
         {process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID && (
-          <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID} />
+          <>
+            {/* Consent Mode v2 default — MUST load BEFORE gtag.js (which @next/third-parties
+                injects with strategy="afterInteractive"). Without this, Google Tag defaults
+                analytics_storage to "denied" on first hit → /g/collect arrives with gcs=G100
+                and GA4 silently drops the event from reports/Realtime. Empirically verified
+                2026-05-21: property 505466833 had 1 event in 94 days because every hit was
+                consent-denied. Strategy: analytics_storage=granted by legitimate interest
+                (analytics-only, no PII, no ad cookies), ad_* stay denied for GDPR/UU-PDP. */}
+            <Script id="gtag-consent-default" strategy="beforeInteractive">
+              {`window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});`}
+            </Script>
+            <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID} />
+          </>
         )}
       </body>
     </html>


### PR DESCRIPTION
## Summary

**Empirical root cause for GA4 property 505466833 reporting 0 events despite hits firing correctly.**

- balizero.com loads `@next/third-parties/google` `<GoogleAnalytics>` which injects gtag.js with `strategy="afterInteractive"`
- No `gtag('consent', 'default', ...)` is emitted anywhere in the codebase
- No cookie banner exists  
- Without explicit consent default, Google Tag falls back to safety default `denied` for all storage categories
- Result: every `/g/collect?tid=G-S3H2M6VXWT` arrives with `gcs=G100` + `npa=1`. GA4 receives hits server-side but drops them from reports/Realtime per Consent Mode v2 semantics
- **Property 505466833 received 1 event in 94 days** (verified via Data API v1beta `runReport` 2026-02-17 → today)
- Stream UI in GA4 admin even shows "Data collection isn't active for your website"

## Fix

Inject a `<Script id="gtag-consent-default" strategy="beforeInteractive">` that runs BEFORE gtag.js loads, calling `gtag('consent', 'default', { analytics_storage: 'granted', ad_*: 'denied' })`.

## Rationale for `analytics_storage=granted` by default (no cookie banner)

- Legitimate interest (GDPR art. 6(1)(f) / UU PDP art. 20(1)(d)) for first-party analytics with no PII, no ad cookies, no cross-site tracking
- All ad-* signals stay `denied` for safety
- Future cookie banner can call `gtag('consent', 'update', ...)` to downgrade `analytics_storage` to `denied` on opt-out — non-breaking

## Empirical verification (recipe for Subhi post-deploy)

```bash
# 1. Playwright probe — gcs should flip from G100 to G111/G110
node /tmp/ga-probe-deep.js   # script in conversation 2026-05-21

# 2. GA4 Realtime should populate within 15-60s of first real visitor
# Subhi: open analytics.google.com → property 505466833 → Reports → Realtime
# In separate tab: visit https://balizero.com/
# Expected: 1 active user within 60s

# 3. Reports populate within 24-48h
```

## Test plan

- [x] Local `npm run typecheck` clean
- [x] Pre-commit hooks pass (prettier, typecheck, import chain)
- [ ] Vercel preview deploy renders
- [ ] Playwright post-deploy probe shows `gcs=G111`
- [ ] GA4 Realtime populates with test visit
- [ ] No regression in PageSpeed (Script `beforeInteractive` is < 200 bytes inline)