### PR TITLE
feat(content): W1P1 FB post rental income tax 10% — copy draft

### DIFF
--- a/research/marketing/fb-post-rental-income-tax.md
+++ b/research/marketing/fb-post-rental-income-tax.md
@@ -1,0 +1,95 @@
+# W1 Post 1 — FB Post Copy Draft
+
+**Date:** 22 May 2026
+**Platform:** Facebook + Instagram
+**Format:** Carousel (10 slides) — visuals ready from Damar
+**Cluster:** C2 — Tax Compliance
+**Topic:** Rental Income Tax 10% — Bali 2026
+**Posting window:** 19:00–21:00 WITA
+**Status:** Draft — pending Antonello sign-off
+
+---
+
+## FACEBOOK CAPTION
+
+🏠 Renting out property in Bali?
+
+The 10% tax is just the starting point.
+
+What most property owners don't know:
+
+→ Tax is calculated on gross rental income —
+operating costs, maintenance, and agency fees
+cannot be deducted
+→ If your tenant is an individual, you pay
+and report the tax yourself — not the tenant
+→ If your villa runs on Airbnb or OTA platforms
+with daily services, your entire tax
+classification changes
+
+Swipe to understand the rules — before
+the tax authority does it for you.
+
+#rentalincome #indonesiatax #propertybali
+#ptpma #baliexpats #villabali #propertyinvestment
+
+> No outbound link in post body.
+> Link to article in first comment only if needed.
+
+---
+
+## CAROUSEL SLIDES REFERENCE
+
+Visuals + slide copy final from Damar.
+File: Copy_of_DAHJEkWpkzY.pdf (10 slides)
+
+Slide breakdown:
+
+1. Cover — Bali 2026: The Rental Income Tax Crackdown
+2. The 10% Tax Foundation
+3. No Deductions Allowed (gross rental basis)
+4. The Responsibility Split (corporate vs individual tenant)
+5. The Airbnb Myth (OTA + hospitality reclassification)
+6. Rental vs Hospitality (business structure definition)
+7. Tax Tracking in the Digital Age
+8. The Nominee & Banking Illusion
+9. The Cost of Bad Bookkeeping
+10. CTA — Bali Zero
+
+---
+
+## KEY FIGURES (for Antonello verification)
+
+1. Rate: 10% final — calculated on gross rental amount
+2. Tax base: gross only — no deductions (operating costs,
+   maintenance, agency fees cannot reduce tax base)
+3. Responsibility: corporate tenant withholds & remits;
+   individual tenant = owner pays and reports directly
+4. Reclassification trigger: OTA + daily guests +
+   services (housekeeping, reception, breakfast)
+   → PB1 + corporate taxes + tourism licensing
+
+---
+
+## NOTES FOR ANTONELLO
+
+Sign-off needed on:
+
+- [ ] Caption: tone compliance — no marketing fluff,
+      taboo notes check, bilingual lexicon review
+- [ ] Regulatory basis: no explicit PP/PMK reference
+      in slides — please verify against NB-7,
+      confirm regulation current for 2026
+- [ ] Slide 10 CTA: "Build your legacy" +
+      "Immigration and Investment Architects"
+      — flag for brand cortex review
+
+---
+
+## NOTES FOR DAMAR
+
+- Carousel visuals final ✅
+- Caption above for Facebook/Instagram post body
+- No outbound link in post — article link in
+  first comment only if needed
+- Posting window: 19:00–21:00 WITA, 22 May 2026


### PR DESCRIPTION
## Summary
Facebook carousel copy draft for W1 Post 1 — Rental Income Tax 10%.
Carousel visuals already final from Damar (10 slides, PDF).
Review needed on caption only.

---

## Studio Layer

**Insight**
Carousel from Damar is complete with slide copy baked in.
Only missing piece was the Facebook post caption.
Topic confirmed as Rental Income Tax 10% after discovery
that 183-day Tax Residency (PR #768) was already posted.

**Evidence**
- Carousel: Copy_of_DAHJEkWpkzY.pdf (10 slides, final)
- Key figures: 10% final on gross rental, no deductions,
  responsibility split, OTA reclassification trigger
- Replaces PR #768 (wrong topic for W1P1)

**Reasoning**
Publish 22 May (Friday) catches weekend search spike
for tax + property queries per W1 calendar rhythm.

**Risk**
- No explicit PP/PMK reference in carousel slides
  — needs NB-7 verification before publish
- Slide 10 CTA language ("Build your legacy") may
  need brand cortex adjustment

**Recommendation**
Sign-off on caption. Regulatory basis and CTA language
deferred to Antonello judgment post NB-7 check.

**Next Action**
Antonello review ≤30 min → sign-off →
publish 19:00–21:00 WITA 22 May 2026.