### PR TITLE
fix(cell+organism): empirical audit + Cell daemon resurrection 2026-05-21

### DIFF
--- a/.claude/rules/cicatrix-scars.md
+++ b/.claude/rules/cicatrix-scars.md
@@ -5,6 +5,63 @@ Each entry has TRAUMA (what went wrong), ANTIBODY (how it's now protected), and 
 
 ---
 
+### ⚠️ STRUCTURAL: `apps/cell/.env` unquoted multi-token value silent-aborts `launch_cell.sh` under `set -e` (2026-05-22)
+
+_Discovered: 2026-05-22 00:00 WITA during Cell daemon resurrection (worktree audit-cell-genoma-organism-2026-05-21) · Severity: P1 · Status: **RESOLVED** (quote-fix applied + Python normalizer; reproducible via audit installer)_
+
+**TRAUMA:** Cell core daemon (`com.cell.organism`) had been silent since 2026-05-16 08:01 WITA (5.5 giorni). Audit phase concluded the cause was "plist not installed in `~/Library/LaunchAgents/`". Re-bootstrap via `apps/cell/scripts/install_cell_daemon.sh` succeeded the install step but daemon entered `spawn scheduled` + `last exit code = 1` immediately. `/tmp/cell.stderr.log` revealed `bash: /Users/nuzantara/Desktop/nuzantara/apps/cell/.env: line 5: fm2_lJP...,fm2_lJP...: No such file or directory`.
+
+Root cause: `FLY_API_TOKEN=FlyV1 fm2_xxx==,fm2_yyy==` in `.env` had:
+- Space between `FlyV1` and the first token segment → `set -a; source .env` assigns `FLY_API_TOKEN=FlyV1`, then tries to **execute** `fm2_xxx==,fm2_yyy==` as a command;
+- `,` in middle of the token → bash interprets `fm2_xxx==,fm2_yyy==` as a path (the `/` inside the base64-ish content) → "no such file or directory";
+- `launch_cell.sh` has `set -euo pipefail` → ANY error in `source` aborts the entire wrapper with exit 1 → launchd marks daemon failed, retries, same crash → loop;
+- Earlier interactive dry-run during audit Phase 5 used the SAME `set -a; source .env; set +a` but the parent shell had **no** `set -e`, so it survived the same error (only printed the warning and assigned the truncated value). This created a **FALSE POSITIVE empirical signal** that "the code works manually" — it doesn't, when invoked under launchd's strict-mode wrapper.
+
+Hidden for 5.5 days because:
+1. The daemon was never re-installed after being uninstalled (date unknown — likely 2026-04-29 plist-corruption episode or post-handoff cleanup);
+2. `cell-observatory` collector kept showing "no new cell pulses" but the symptom was attributed to missing daemon, not to `.env` parsing;
+3. The historic plist (still in `~/p0-3-recovery/plist_reconstructed/`) bypassed this by inlining env vars in the plist `EnvironmentVariables` dict — which is exactly the P0 secret-leak posture we want to avoid.
+
+**ANTIBODY (shipped):**
+
+1. **Quote-fix `.env` line 5**: backup at `apps/cell/.env.pre-quote-fix-2026-05-21`, line rewritten as `FLY_API_TOKEN="FlyV1 fm2_xxx==,fm2_yyy=="`. Verified via `bash -c 'set -euo pipefail; set -a; source apps/cell/.env; set +a; echo ${#FLY_API_TOKEN}'` returns 687 (full token length).
+2. **Python normalizer** (one-shot, ad-hoc): iterates lines, detects values containing `[\s,;|&<>(){}*?\\]`, wraps with double quotes after escaping any embedded `"`. Lives inline in the bootstrap session for now — could be promoted to `apps/cell/scripts/validate_env.py` if recurring.
+3. **Daemon empirical verification**: `Pulse #1 complete. Health: green` at 23:58:44, `Pulse #2 complete. Health: green` at 23:59:56, PID 48494 stable. Cell SelfModel age=56d pulses=39911 actions=20217 resumed from EpisodicMemory.
+
+**GOTCHA:**
+
+- Phase 5 of the audit (interactive dry-run from `set -a; source .env`) returned green INFO logs and made the "code works" claim plausible. The bug only manifests when invoked from a wrapper that uses `set -e`. **Generalize**: dry-running env-loading code WITHOUT `set -e` does not prove launchd behavior. Always test under the same shell flags as production wrapper (`bash -c 'set -euo pipefail; ./launch_cell.sh' </dev/null`).
+- `.env` line was added by someone manually copying the FLY token output of `fly auth token` — that command emits the token with a leading `FlyV1 ` prefix (space-separated). The token format itself is the issue.
+- `apps/cell/.env.example` does NOT include `FLY_API_TOKEN` (audited 2026-05-22). Future onboarding will hit the same trap. Consider adding `FLY_API_TOKEN="FlyV1 <token>"` to `.env.example` with explicit quoting demonstration.
+- This scar is adjacent to but DIFFERENT from the 2026-05-21 P0 password leak: that one is about secrets-in-tracked-files, this one is about whitespace handling in untracked secrets. Same `.env`, different failure mode.
+
+**Reference**: bootstrap session log = `/tmp/cell.stderr.log` (initial crash trace), worktree `audit-cell-genoma-organism-2026-05-21` audit report (this commit's body).
+
+---
+
+### ℹ️ INFO: Cell pulse → `cell_pulse_observed` PG channel emit gated by `CELL_OBSERVATORY_EMIT=true` (2026-05-22)
+
+_Discovered: 2026-05-22 00:05 WITA during Cell daemon resurrection · Severity: INFO (by design, not a bug) · Status: behavior documented_
+
+**TRAUMA:** Not really a trauma — by design. After Cell daemon was successfully resurrected (cicatrix above), the empirical check on `~/.cell-observatory/observatory.db` showed `count(*) WHERE cell_id='cell' AND pulse_timestamp > NOW() - 5min = 0` despite the daemon emitting `Pulse #1` and `Pulse #2` green internally. The pulse loop runs fine; the bridge to PG `cell_pulse_observed` channel is conditional on env var `CELL_OBSERVATORY_EMIT=true` (gate in `apps/cell/cell/core/pulse.py:803` and `packages/cell-core/...`).
+
+Without the flag: Cell pulses internally, sensors fire, cortex thinks, actions taken — but no row in `events_outbox` channel `cell_pulse_observed`, no row in `pulse_events` SQLite. Observability gap, not a functional gap.
+
+**Historic context**: `~/.cell-observatory/observatory.db` shows `cell_id='cell'` pulses from 2026-05-02 to 2026-05-16 (~14925 rows). Someone HAD set `CELL_OBSERVATORY_EMIT=true` historically. It was removed (silently — `.env` does not contain the variable now) at some point coincident with the daemon being uninstalled.
+
+**ANTIBODY (deferred):**
+
+- Decision pending operator (Antonello): set `CELL_OBSERVATORY_EMIT=true` in `apps/cell/.env` to restore historical observability? Cost: 1 row per pulse in `events_outbox` (~1380/day, persistent table) + 1 row in SQLite + Redis stream bytes. Benefit: dashboard continuity, anomaly detection, weekly Cell health reports.
+- If yes: add line to `.env`, `launchctl bootout + bootstrap` to pick up new env. Verify with `sqlite3 ~/.cell-observatory/observatory.db "SELECT count(*) FROM pulse_events WHERE cell_id='cell' AND pulse_timestamp/1000 > strftime('%s','now') - 600"` within 5 min.
+- Mention also in `apps/cell/launchagent/README.md` resurrection section so the variable is not lost on future re-bootstraps.
+
+**GOTCHA:**
+
+- This is a "silent observability gap" — daemon is technically healthy, dashboards just don't see it. Easy to miss in audits because `launchctl print` shows `state = running`, no exit codes, no crash logs.
+- The 14925 historic rows from before 2026-05-16 are NOT regenerated retroactively when the flag is re-enabled; they remain frozen as snapshot. Trend continuity gap is permanent unless backfill is scripted.
+
+---
+
 ### 🚨 P0 SECURITY: Postgres prod password `backend_rag_v2` hardcoded in 32 files repo public — 5 months exposure (2026-05-21)
 
 _Discovered: 2026-05-21 ~05:00 WITA during PR #802 admin-override review · Severity: **P0** · Status: **OPEN — awaiting rotation decision by Antonello**_

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ See [`INDEX.md`](INDEX.md) for the full atlas including packages, tessuti dati, 
 ### Tech Stack
 
 <!-- DOCSYNC:BACKEND_STATS_START -->
-- **Backend:** Python 3.11+, FastAPI, 271 routers, 564 services, 957 test files
+- **Backend:** Python 3.11+, FastAPI, 271 routers, 565 services, 958 test files
 <!-- DOCSYNC:BACKEND_STATS_END -->
 - **Frontend:** Next.js, TypeScript, Tailwind CSS
 - **Databases:** PostgreSQL (relational), Qdrant (vector), Redis (cache)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 271 routers · 564 services
+- Backend: FastAPI · 271 routers · 565 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 24 · Packages: 5

--- a/apps/cell/com.cell.organism.plist
+++ b/apps/cell/com.cell.organism.plist
@@ -16,8 +16,8 @@
     <key>KeepAlive</key>
     <true/>
     <key>StandardOutPath</key>
-    <string>/tmp/cell.stdout.log</string>
+    <string>/Users/nuzantara/logs/cell/organism.stdout.log</string>
     <key>StandardErrorPath</key>
-    <string>/tmp/cell.stderr.log</string>
+    <string>/Users/nuzantara/logs/cell/organism.stderr.log</string>
 </dict>
 </plist>

--- a/apps/cell/launchagent/README.md
+++ b/apps/cell/launchagent/README.md
@@ -7,6 +7,43 @@
 This directory stores the canonical source for plist files; operators copy
 them into `~/Library/LaunchAgents/` and chmod them read-only.
 
+## cell.organism (Cell core daemon) — RESURRECTION 2026-05-21
+
+The Cell core daemon plist source is at `apps/cell/com.cell.organism.plist`
+(parent dir, not this directory — historical layout).
+
+**Status as of 2026-05-21**: NOT installed in `~/Library/LaunchAgents/`.
+Cell core stopped pulsing on 2026-05-16 08:01 WITA. Empirical evidence in
+`~/.cell-observatory/observatory.db` (`cell_id='cell'` last_pulse).
+
+**Operator install steps** (run from clean checkout of `nuzantara` main):
+
+```bash
+# 1. Preconditions
+ls apps/cell/.env                    # secrets in CELL_*, GOOGLE_API_KEY, etc.
+ls apps/cell/.venv/bin/python        # virtualenv exists
+ls apps/cell/com.cell.organism.plist # plist source
+
+# 2. Run installer (idempotent)
+bash apps/cell/scripts/install_cell_daemon.sh
+
+# 3. Verify pulses resume within 5min
+sleep 60
+sqlite3 ~/.cell-observatory/observatory.db \
+  "SELECT max(pulse_timestamp) FROM pulse_events WHERE cell_id='cell';"
+```
+
+**Warning re P0 secret leak 2026-05-21**: `apps/cell/.env` currently contains
+the `backend_rag_v2` Postgres password that is the subject of the P0
+incident (`cicatrix-scars.md` head entry). If/when that password is rotated,
+`apps/cell/.env` MUST be updated BEFORE re-launching the daemon (or the
+daemon will crash-loop on `CELL_DATABASE_URL` auth failure).
+
+The reconstructed plist at `~/p0-3-recovery/plist_reconstructed/com.cell.organism.plist`
+contains the same leaked secrets inline; do NOT use that file as install
+source. The repo-tracked `apps/cell/com.cell.organism.plist` sources
+secrets from `.env` (out-of-tree) — this is the correct posture.
+
 ## skills-bridge-consumer (TICKET G.3)
 
 Cron-invoked shim that pulls `cell:skills` Redis stream entries from

--- a/apps/cell/requirements.txt
+++ b/apps/cell/requirements.txt
@@ -8,5 +8,6 @@ faiss-cpu>=1.9.0
 numpy>=1.26.0
 pydantic>=2.0.0
 pydantic-settings>=2.0.0
+pyyaml>=6.0
 pytest>=8.0.0
 pytest-asyncio>=0.24.0

--- a/apps/cell/scripts/install_cell_daemon.sh
+++ b/apps/cell/scripts/install_cell_daemon.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# install_cell_daemon.sh — operator-run installer for com.cell.organism
+#
+# Per cicatrix-scars.md 2026-04-29 antibody pattern, this script is the
+# canonical way to bootstrap the Cell core daemon. Run from a clean
+# checkout of nuzantara main repo.
+#
+# Idempotent: safe to re-run.
+set -euo pipefail
+
+REPO_ROOT="/Users/nuzantara/Desktop/nuzantara"
+CELL_DIR="$REPO_ROOT/apps/cell"
+SRC_PLIST="$CELL_DIR/com.cell.organism.plist"
+DST_PLIST="$HOME/Library/LaunchAgents/com.cell.organism.plist"
+LABEL="com.cell.organism"
+LOG_DIR="$HOME/logs/cell"
+
+echo "==> Cell daemon installer"
+echo "    Source plist: $SRC_PLIST"
+echo "    Target plist: $DST_PLIST"
+
+# Preconditions
+[ -f "$SRC_PLIST" ] || { echo "FATAL: missing $SRC_PLIST" >&2; exit 1; }
+[ -f "$CELL_DIR/.env" ] || { echo "FATAL: missing $CELL_DIR/.env (create from .env.example)" >&2; exit 1; }
+[ -x "$CELL_DIR/.venv/bin/python" ] || { echo "FATAL: missing $CELL_DIR/.venv (run pip install -r requirements.txt)" >&2; exit 1; }
+[ -x "$CELL_DIR/scripts/launch_cell.sh" ] || { echo "FATAL: missing launch_cell.sh" >&2; exit 1; }
+
+# Log dir
+mkdir -p "$LOG_DIR"
+
+# Validate plist schema
+plutil -lint "$SRC_PLIST" >/dev/null || { echo "FATAL: $SRC_PLIST plist is malformed" >&2; exit 1; }
+
+# If already loaded, bootout first (idempotent)
+if launchctl print "gui/$(id -u)/$LABEL" >/dev/null 2>&1; then
+    echo "==> Found existing $LABEL — bootout first"
+    # Make writable if previously chmod'd 0444
+    chmod u+w "$DST_PLIST" 2>/dev/null || true
+    launchctl bootout "gui/$(id -u)" "$DST_PLIST" 2>/dev/null || true
+fi
+
+# Copy + chmod read-only (scar 2026-04-29 antibody)
+install -m 0444 "$SRC_PLIST" "$DST_PLIST"
+echo "==> Installed $DST_PLIST (mode 0444)"
+
+# Bootstrap
+launchctl bootstrap "gui/$(id -u)" "$DST_PLIST"
+echo "==> Bootstrap OK"
+
+# Wait + verify
+sleep 3
+if launchctl print "gui/$(id -u)/$LABEL" 2>&1 | grep -q "state = running"; then
+    echo "==> $LABEL is RUNNING"
+    echo "==> Logs:"
+    echo "      tail -f $LOG_DIR/organism.stdout.log"
+    echo "      tail -f $LOG_DIR/organism.stderr.log"
+else
+    echo "==> WARN: $LABEL not in 'running' state — inspect logs:" >&2
+    launchctl print "gui/$(id -u)/$LABEL" 2>&1 | grep -E "state =|last exit" | head -5 >&2
+    exit 2
+fi

--- a/apps/cell/tests/test_pulse_with_cortex.py
+++ b/apps/cell/tests/test_pulse_with_cortex.py
@@ -125,14 +125,23 @@ class TestPulseWithCortex:
 
     @pytest.mark.asyncio
     async def test_during_idle_not_called_when_yellow(self) -> None:
-        """During idle hook is NOT called when health is YELLOW."""
+        """During idle hook is NOT called when health is YELLOW.
+
+        After P0-0 fix (commit 2a3256758) HTTP 5xx classifies as RED, not
+        YELLOW. To exercise the YELLOW path we use a 200 response with
+        body.status='degraded' — see classify_http_status() in pulse.py.
+        """
         dna = MagicMock()
         dna.verify_integrity = MagicMock(return_value=True)
         safety = AsyncMock()
         safety.check = AsyncMock(return_value=MagicMock(can_proceed=True))
         health = AsyncMock()
         health.read = AsyncMock(return_value=MagicMock(
-            reachable=True, status_code=500, response_time_seconds=0.2, error=None,
+            reachable=True,
+            status_code=200,
+            body={"status": "degraded"},
+            response_time_seconds=0.2,
+            error=None,
         ))
         cortex = AsyncMock()
         cortex.before_reasoning = AsyncMock(return_value="")

--- a/apps/organism/README.md
+++ b/apps/organism/README.md
@@ -6,7 +6,8 @@ See `docs/superpowers/specs/2026-04-22-autonomic-organism-design.md` for full de
 
 ## Innervation Genoma (`organism/organs_registry.yaml`)
 
-Single source of truth for the ~149 organi nervosi. Spec:
+Single source of truth for the 120 organi nervosi (snapshot 2026-05-21:
+107 `pro_launchd` + 9 `fly_machine` + 4 `mini_launchd`). Spec:
 `docs/innervation-2026-04-29/07_innervation_protocol.md` §2.
 
 > **Renamed 2026-05-08 (IG-3):** the file `genome.yaml` is now

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`271 routers · 564 services · 957 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`271 routers · 565 services · 958 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary

Empirical audit of Cell, genoma (`organs_registry.yaml`) and Organism layers.
Detected and fixed the Cell core daemon being offline for 5.5 days.

**Daemon now running**: PID 48494, Pulse #1+#2 green, SelfModel resumed from
age=56d pulses=39911 actions=20217.

## What works (verified empirical, not docs)

- Genoma validator + checksum HALT-on-mismatch enforcement
- Organism supervisor daemon + actuator framework (262/262 tests pass)
- EventBus PG outbox + `cell_pulse_observed` channel (15124 historic events)
- Cell-observatory collector + SQLite mirror
- Cell core code (DB tables, DNA loader, PatternIndex, Cortex, SLOW layer, sensors, effectors) — 453/453 tests pass

## What was broken

| Layer | Issue | Fix |
|---|---|---|
| Cell core daemon | Plist not in `~/Library/LaunchAgents/`, silent 5.5d since 2026-05-16 08:01 WITA | New `install_cell_daemon.sh` installer, bootstrapped, running |
| `.env` parse | `FLY_API_TOKEN=FlyV1 fm2_xxx==,fm2_yyy==` unquoted -> bash `source` aborts under `set -e` | Quote-fix applied, backup at `.env.pre-quote-fix-2026-05-21` |
| Test stale | `test_during_idle_not_called_when_yellow` aspetta YELLOW per HTTP 500, ma P0-0 fix (2a3256758) classifica >=500 come RED | Rewired to `status_code=200, body.status=degraded` |
| Cell venv | `tests/test_genome_aggregator_sensor.py` missing `yaml` | Added `pyyaml>=6.0` to requirements |
| Plist logs | `/tmp/cell.{stdout,stderr}.log` lost on reboot (scar 2026-04-29) | Changed to `~/logs/cell/organism.{stdout,stderr}.log` (effective on next re-bootstrap from this branch) |
| `README.md` drift | "~149 organi" mismatch with 120 actual | Updated to 120 (107 pro_launchd + 9 fly_machine + 4 mini_launchd) |

## New cicatrix entries (this branch)

1. P1 STRUCTURAL: `apps/cell/.env` unquoted multi-token value silent-aborts `launch_cell.sh` under `set -e` -- false positive in audit Phase 5 dry-run because parent shell lacked `set -e`. Generalizable lesson: dry-running env-loading code without `set -e` does not prove launchd behavior.
2. INFO: Cell pulse -> `cell_pulse_observed` PG channel emit gated by `CELL_OBSERVATORY_EMIT=true`. Daemon runs clean but silent on observability bridge until operator decides whether to re-enable.

## What's NOT in this PR (decisione operativa pending)

- Bootstrap `pro.claude_max_watcher` daemon (plist source exists in `docs/infra/launchagents/`, never installed)
- Set `CELL_OBSERVATORY_EMIT=true` in `.env` to restore historical observability (1380 rows/day to `events_outbox`)
- Resolve P0 secret leak (`backend_rag_v2` Postgres password -- separate scar 2026-05-21, OPEN)

## Test plan

- [x] `apps/cell/.venv/bin/python -m pytest apps/cell/tests/` -> 453/453 pass
- [x] `apps/backend-rag/.venv/bin/python -m pytest apps/organism/tests/` -> 262/262 pass, 1 skipped
- [x] `python -m organism.tools.validate_organs_registry apps/organism/organism/organs_registry.yaml` -> valid
- [x] `bash apps/cell/scripts/install_cell_daemon.sh` -> daemon running on Pro
- [x] `launchctl print gui/$(id -u)/com.cell.organism` -> `state = running`, never exited
- [x] `/tmp/cell.stderr.log` shows `Pulse #1 complete. Health: green`, `Pulse #2 complete. Health: green`
- [ ] After merge: re-run installer to upgrade log path from `/tmp/` to `~/logs/cell/`
- [ ] After merge + operator decision: `CELL_OBSERVATORY_EMIT=true` to restore observability bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)