### PR TITLE
docs(config): Pro/Air → Pro/Mini topology + Codex best-config audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,41 +9,41 @@ Two machines exist on the local network:
 | Machine | User             | Hostname      | Role                       |
 | ------- | ---------------- | ------------- | -------------------------- |
 | **Pro** | `nuzantara`      | `Nuzantara`   | Development (48GB, M4 Pro) |
-| **Air** | `antonellosiano` | `Nuzantara-9` | Server H24 (16GB, M4)      |
+| **Mini** | `nuzantara`     | `mini-pro2`   | Server H24 / automation    |
 
 **At every session start, run this check:**
 
 ```bash
 echo "Machine: $(whoami)@$(hostname)" && \
-OTHER=$(if [ "$(whoami)" = "nuzantara" ]; then echo "air"; else echo "pro"; fi) && \
-ssh -o ConnectTimeout=3 $OTHER 'echo "Peer: $(whoami)@$(hostname)"' 2>/dev/null || echo "Peer: UNREACHABLE" && \
+HOST=$(hostname | tr '[:upper:]' '[:lower:]') && \
+case "$HOST" in nuzantara) OTHER=mini ;; mini-pro2) OTHER=pro ;; *) OTHER="" ;; esac && \
+if [ -z "$OTHER" ]; then echo "Peer: UNKNOWN_HOST($HOST)"; else ssh -o ConnectTimeout=3 $OTHER 'echo "Peer: $(whoami)@$(hostname)"' 2>/dev/null || echo "Peer: UNREACHABLE"; fi && \
 LOCAL_HEAD=$(git log --oneline -1 2>/dev/null) && \
-REMOTE_HEAD=$(ssh -o ConnectTimeout=3 $OTHER 'cd ~/Desktop/projects/nuzantara 2>/dev/null || cd ~/Desktop/nuzantara 2>/dev/null; git log --oneline -1' 2>/dev/null) && \
-if [ "$LOCAL_HEAD" = "$REMOTE_HEAD" ]; then echo "Git sync: OK ($LOCAL_HEAD)"; else echo "Git sync: OUT OF SYNC! Local=$LOCAL_HEAD Remote=$REMOTE_HEAD"; fi
+REMOTE_HEAD=$(if [ -n "$OTHER" ]; then ssh -o ConnectTimeout=3 $OTHER 'cd ~/Desktop/nuzantara 2>/dev/null || cd ~/Desktop/projects/nuzantara 2>/dev/null; git log --oneline -1' 2>/dev/null; fi) && \
+if [ -z "$OTHER" ]; then echo "Git sync: UNKNOWN (unrecognized host: $HOST)"; elif [ "$LOCAL_HEAD" = "$REMOTE_HEAD" ]; then echo "Git sync: OK ($LOCAL_HEAD)"; else echo "Git sync: OUT OF SYNC! Local=$LOCAL_HEAD Remote=$REMOTE_HEAD"; fi
 ```
 
 This tells you:
 
-- `whoami` = `nuzantara` → you are on **Pro**
-- `whoami` = `antonellosiano` → you are on **Air**
+- `hostname` = `Nuzantara` → you are on **Pro**
+- `hostname` = `mini-pro2` → you are on **Mini**
 - Whether the other machine is reachable via SSH
 - Whether both repos are on the same commit
 
-**Always prefix your first response with which machine you're on**, e.g. "[Pro]" or "[Air]".
+**Always prefix your first response with which machine you're on**, e.g. "[Pro]" or "[Mini]".
 If the peer is unreachable or out of sync, **warn the user immediately**.
 
-**SSH between machines:** `ssh air` (from Pro) / `ssh pro` (from Air) — uses mDNS, works on any WiFi.
-See `docs/PRO_AIR_CONNECTION.md` for full details.
+**SSH between machines:** `ssh mini` (from Pro) / `ssh pro` (from Mini). Prefer the SSH aliases because Tailscale is more reliable than mDNS across subnets. Trust the live command above and `~/.ssh/config` before legacy connection docs.
 
-### Git Sync Architecture (updated 2026-03-28)
+### Git Sync Architecture (updated 2026-05-21)
 
-Both machines work on `main` branch only. Sync is **automatic** via husky post-commit hooks:
+Both machines work on `main` branch only. Sync must be verified live at session start; do not infer parity from previous runs or from hook intent.
 
-- **Pro commits** → Air auto-pulls (`git pull pro main --ff-only`)
-- **Air commits** → Air auto-pushes to Pro (`git push pro main`)
+- **Pro commits** → Mini should fast-forward from Pro when sync hooks run.
+- **Mini commits** → Pro should fast-forward from Mini when sync hooks run.
 - **GitHub** is updated by Pro only via `git push origin main`
 
-**Never** create an `air` branch. **Never** push from Air to `origin`. Log: `~/.openclaw/logs/git-sync.log`.
+**Never** create machine-specific peer branches such as `air` or `mini`; this branch rule is separate from legacy filenames like `shared/escalations_air.jsonl`. **Never** push from Mini to `origin` unless explicitly requested. Log: `~/.openclaw/logs/git-sync.log`.
 
 ---
 
@@ -117,7 +117,7 @@ Both machines work on `main` branch only. Sync is **automatic** via husky post-c
 
 ```bash
 # Activate virtualenv
-source venv/bin/activate  # or: . venv/bin/activate
+source .venv/bin/activate  # or: . .venv/bin/activate
 
 # Run backend locally
 cd apps/backend-rag
@@ -181,7 +181,7 @@ apps/backend-rag/
 │   ├── llm/              # LLM clients (Gemini, Ollama, OpenRouter)
 │   └── migrations/       # Alembic (up to 060)
 ├── tests/                # 419 test files
-├── .venv/                # ⚠️ ALWAYS .venv on Pro, venv on Air
+├── .venv/                # ⚠️ ALWAYS .venv on Pro and Mini
 └── fly.toml
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,19 +9,20 @@
 | Machine | User             | Hostname      | Role                            |
 | ------- | ---------------- | ------------- | ------------------------------- |
 | **Pro** | `nuzantara`      | `Nuzantara`   | Server H24 + Dev (48GB, M4 Pro) |
-| **Air** | `antonellosiano` | `Nuzantara-9` | Server H24 (16GB, M4)           |
+| **Mini** | `nuzantara`     | `mini-pro2`   | Server H24 + automation         |
 
 **At every session start, run:**
 
 ```bash
 echo "Machine: $(whoami)@$(hostname)" && \
-OTHER=$(if [ "$(whoami)" = "nuzantara" ]; then echo "air"; else echo "pro"; fi) && \
-ssh -o ConnectTimeout=3 $OTHER 'echo "Peer: $(whoami)@$(hostname)"' 2>/dev/null || echo "Peer: UNREACHABLE"
+HOST=$(hostname | tr '[:upper:]' '[:lower:]') && \
+case "$HOST" in nuzantara) OTHER=mini ;; mini-pro2) OTHER=pro ;; *) OTHER="" ;; esac && \
+if [ -z "$OTHER" ]; then echo "Peer: UNKNOWN_HOST($HOST)"; else ssh -o ConnectTimeout=3 $OTHER 'echo "Peer: $(whoami)@$(hostname)"' 2>/dev/null || echo "Peer: UNREACHABLE"; fi
 ```
 
-- `whoami` = `nuzantara` → **Pro** · `whoami` = `antonellosiano` → **Air**
-- Always prefix first response with "[Pro]" or "[Air]"
-- SSH: `ssh air` / `ssh pro` (mDNS). Details: `docs/PRO_AIR_CONNECTION.md`
+- `hostname` = `Nuzantara` → **Pro** · `hostname` = `mini-pro2` → **Mini**
+- Always prefix first response with "[Pro]" or "[Mini]"
+- SSH: `ssh mini` / `ssh pro` via Tailscale aliases. mDNS is not assumed reliable across subnets.
 
 ---
 
@@ -407,8 +408,8 @@ reference: [`docs/oss-injections-2026-04-26.md`](docs/oss-injections-2026-04-26.
 
 ### Federation Protocol
 
-- Escalation: Air → `shared/escalations.json` → Pro reads at session start
-- Git sync: post-commit hook. Pro→Air auto-pull. Air→Pro push. GitHub: only Pro→origin.
+- Escalation: Mini/Pro per-machine JSONL files under `shared/` until the legacy `air` filename is retired.
+- Git sync: verify live at session start. Pro↔Mini may be hook-assisted, but parity is never presumed. GitHub: only Pro→origin unless explicitly directed.
 - CLAUDE.md: IDENTICAL on both — git-tracked
 
 ## 13. Anthropic API — Quick Reference
@@ -437,11 +438,10 @@ thinking={"type": "adaptive"}, output_config={"effort": "medium"}  # NOT budget_
 
 ### Virtualenv
 
-- **Air:** `venv` (NOT `.venv`) — `apps/backend-rag/venv/bin/python`
-- **Pro:** `.venv` — verify with `ls apps/backend-rag/ | grep venv`
-- **pip on Air:** `/Users/antonellosiano/.pyenv/shims/python3 -m pip`
+- **Pro and Mini:** `.venv` — verify with `ls apps/backend-rag/ | grep venv`
+- Never use system Python for backend work.
 
-### Drive Polling (Air only)
+### Drive Polling (Mini/Pro local automation only)
 
 - Cron every 5min (`scripts/drive_poll_cron.sh`). **NOT on Fly.io** (auto_stop loses page_token)
 - `page_token` in `system_settings` table — loss = full re-scan
@@ -525,7 +525,7 @@ Reference: [`docs/oss-injections-2026-04-26.md`](docs/oss-injections-2026-04-26.
 
 Company ✅ · Visa ✅ · Property ✅ · Tax ✅
 
-### Cron Air
+### Cron Mini
 
 | Job               | Schedule     | Script                               |
 | ----------------- | ------------ | ------------------------------------ |

--- a/INDEX.md
+++ b/INDEX.md
@@ -7,16 +7,16 @@
 
 ## Cosa cerchi?
 
-| Bisogno                                       | Dove guardare                                                      | Come                                          |
-| --------------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------- |
-| Perché fare X?                                | [SYMBIOSIS.md](SYMBIOSIS.md)                                       | Filosofia, "prima di toccare"                 |
-| Come fare X?                                  | [VADEMECUM.md](VADEMECUM.md)                                       | Checklist operativa per ogni tipo di elemento |
-| Dove vive X?                                  | Questa pagina, sezione "Organi" sotto                              | Mappa statica top-level                       |
-| Metriche live (count routers/servizi/vector)? | [CLAUDE.md](CLAUDE.md) §Tech Stack                                 | Auto-sincronizzate via `docs_sync.py`         |
-| Dettagli tecnici di un'app?                   | `apps/<nome>/README.md` o `apps/<nome>/CLAUDE.md`                  | File locali all'app                           |
-| Quando X è stato fatto?                       | `git log` + MOS (`~/.claude/scripts/mem query "X"`)                | Git + memoria persistente                     |
-| Policy AI dispatch / federazione?             | [docs/AI_DISPATCH_REFERENCE.md](docs/AI_DISPATCH_REFERENCE.md)     | Dispatch, fallback, timeout                   |
-| Cicatrici / bug ricorrenti?                   | [.claude/rules/cicatrix-scars.md](.claude/rules/cicatrix-scars.md) | Trauma + antibody per file chiave             |
+| Bisogno                                       | Dove guardare                                                      | Come                                                 |
+| --------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------- |
+| Perché fare X?                                | [SYMBIOSIS.md](SYMBIOSIS.md)                                       | Filosofia, "prima di toccare"                        |
+| Come fare X?                                  | [VADEMECUM.md](VADEMECUM.md)                                       | Checklist operativa per ogni tipo di elemento        |
+| Dove vive X?                                  | Questa pagina, sezione "Organi" sotto                              | Mappa statica top-level                              |
+| Metriche live (count routers/servizi/vector)? | [CLAUDE.md](CLAUDE.md) §Tech Stack                                 | Auto-sincronizzate via `docs_sync.py`                |
+| Dettagli tecnici di un'app?                   | `apps/<nome>/README.md` o `apps/<nome>/CLAUDE.md`                  | File locali all'app                                  |
+| Quando X è stato fatto?                       | `git log` + MOS (`~/.claude/scripts/mem query "X"`)                | Git + memoria persistente                            |
+| Policy AI dispatch / federazione?             | [docs/AI_DISPATCH_REFERENCE.md](docs/AI_DISPATCH_REFERENCE.md)     | Dispatch, fallback, timeout                          |
+| Cicatrici / bug ricorrenti?                   | [.claude/rules/cicatrix-scars.md](.claude/rules/cicatrix-scars.md) | Trauma + antibody per file chiave                    |
 | Stato della documentazione (live/stale)?      | [docs/DOCS_INVENTORY.md](docs/DOCS_INVENTORY.md)                   | Auto-generato, refresh settimanale via docs-guardian |
 
 ## Organi principali (top of mind)
@@ -37,7 +37,7 @@
 ### Intelligence
 
 - **`apps/evaluator/`** — Core Guardian V3/V5 (auto-calibration), NLM deep research (10 pipelines NB-1..10).
-- **`apps/federation/`** — A2A protocol multi-agent. Pro↔Air.
+- **`apps/federation/`** — A2A protocol multi-agent. Pro↔Mini.
 - **`packages/core/`** — BZ design tokens, BZLogo, libraries condivise.
 
 ### MCP
@@ -74,7 +74,7 @@ Tabelle core: `articles`, `kg_nodes`/`kg_edges` (108K/242K), `garuda_index`/`gar
 ### Filesystem state
 
 - `~/.agent/decisions/` — agent state, DLQ, escalation
-- `shared/escalations_pro.jsonl`, `shared/escalations_air.jsonl` — federation bus
+- `shared/escalations_pro.jsonl`, `shared/escalations_air.jsonl` — federation bus (`air` filename is legacy until scripts are migrated)
 - `apps/evaluator/nlm_deep_research/*_state.json` — NB pipelines state
 
 ### GitHub
@@ -89,15 +89,15 @@ Tabelle core: `articles`, `kg_nodes`/`kg_edges` (108K/242K), `garuda_index`/`gar
 - **02:10-02:50 WITA** NLM NB-2..10 pipeline (Mon-Sat)
 - **21:30/22:00 WITA** gap_scanner + freshness_monitor
 - **every 3h** Core Guardian
-- **every 5min** log-anomaly-detector, drive-poll (Air), sentinel
+- **every 5min** log-anomaly-detector, drive-poll (local automation host), sentinel
 - **Dettagli completi:** `docs/AUTOMATIONS_REFERENCE.md` + `scripts/automation_catalog.json`
 
 ## Machine & env
 
 - **Pro** (`nuzantara@Nuzantara`, M4 Pro 48GB): Dev + Server H24. Venv `.venv` in `apps/backend-rag/`.
-- **Air** (`antonellosiano@Nuzantara-9`, M4 16GB): Server H24. Venv `venv` (non `.venv`).
-- SSH: `ssh pro` / `ssh air` via mDNS.
-- Git sync: post-commit hook Pro→Air auto-pull. GitHub: only Pro→origin.
+- **Mini** (`nuzantara@mini-pro2`): Server H24 + automation. Venv `.venv` in `apps/backend-rag/`.
+- SSH: `ssh pro` / `ssh mini` via Tailscale aliases. mDNS is not assumed reliable across subnets.
+- Git sync: verify live at session start. GitHub: only Pro→origin unless explicitly directed.
 
 ## 5 Libri sacri — 5 funzioni cognitive
 

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -17,12 +17,13 @@
 
 ```bash
 echo "Machine: $(whoami)@$(hostname)" && \
-OTHER=$(if [ "$(whoami)" = "nuzantara" ]; then echo "air"; else echo "pro"; fi) && \
-ssh -o ConnectTimeout=3 $OTHER 'echo "Peer: $(whoami)@$(hostname)"' 2>/dev/null || echo "Peer: UNREACHABLE"
+HOST=$(hostname | tr '[:upper:]' '[:lower:]') && \
+case "$HOST" in nuzantara) OTHER=mini ;; mini-pro2) OTHER=pro ;; *) OTHER="" ;; esac && \
+if [ -z "$OTHER" ]; then echo "Peer: UNKNOWN_HOST($HOST)"; else ssh -o ConnectTimeout=3 $OTHER 'echo "Peer: $(whoami)@$(hostname)"' 2>/dev/null || echo "Peer: UNREACHABLE"; fi
 ```
 
-- `nuzantara@Nuzantara` → **Pro** (48GB, dev) | `antonellosiano@Nuzantara-9` → **Air** (16GB, server H24)
-- Always prefix first response with **[Pro]** or **[Air]**
+- `nuzantara@Nuzantara` → **Pro** (48GB, dev) | `nuzantara@mini-pro2` → **Mini** (server H24 + automation)
+- Always prefix first response with **[Pro]** or **[Mini]**
 
 **2. Verify backend works:**
 

--- a/research/crm/2026-05-21-timing-qwen3.5_9b.json
+++ b/research/crm/2026-05-21-timing-qwen3.5_9b.json
@@ -1,0 +1,243 @@
+{
+  "model": "qwen3.5:9b",
+  "results": [
+    {
+      "client_id": 11801,
+      "display_name": "Anaya Ashamaya",
+      "msg_count": 56,
+      "elapsed_s": 80.32,
+      "ok": true
+    },
+    {
+      "client_id": 11800,
+      "display_name": "Gerard",
+      "msg_count": 45,
+      "elapsed_s": 54.06,
+      "ok": true
+    },
+    {
+      "client_id": 11802,
+      "display_name": "Lead +628133946856",
+      "msg_count": 40,
+      "elapsed_s": 85.77,
+      "ok": true
+    },
+    {
+      "client_id": 2877,
+      "display_name": "Bu Ayu",
+      "msg_count": 36,
+      "elapsed_s": 180.04,
+      "ok": false
+    },
+    {
+      "client_id": 11798,
+      "display_name": "Irma K\u00fclaviir",
+      "msg_count": 35,
+      "elapsed_s": 148.72,
+      "ok": true
+    },
+    {
+      "client_id": 11677,
+      "display_name": "Asraf Guy Baruch",
+      "msg_count": 31,
+      "elapsed_s": 147.44,
+      "ok": true
+    },
+    {
+      "client_id": 2175,
+      "display_name": "Lia Bayu",
+      "msg_count": 34,
+      "elapsed_s": 125.3,
+      "ok": true
+    },
+    {
+      "client_id": 11799,
+      "display_name": "Sindy Kirks",
+      "msg_count": 22,
+      "elapsed_s": 107.6,
+      "ok": true
+    },
+    {
+      "client_id": 1526,
+      "display_name": "Adi Bayu Santero",
+      "msg_count": 19,
+      "elapsed_s": 105.79,
+      "ok": true
+    },
+    {
+      "client_id": 3571,
+      "display_name": "Cristian",
+      "msg_count": 18,
+      "elapsed_s": 84.76,
+      "ok": true
+    },
+    {
+      "client_id": 4703,
+      "display_name": "Davide Bisognini",
+      "msg_count": 17,
+      "elapsed_s": 63.75,
+      "ok": true
+    },
+    {
+      "client_id": 11814,
+      "display_name": "Lead +628213454723",
+      "msg_count": 17,
+      "elapsed_s": 37.86,
+      "ok": true
+    },
+    {
+      "client_id": 11803,
+      "display_name": "Jonathan",
+      "msg_count": 11,
+      "elapsed_s": 51.46,
+      "ok": true
+    },
+    {
+      "client_id": 2539,
+      "display_name": "Stefano Caradonna",
+      "msg_count": 11,
+      "elapsed_s": 132.65,
+      "ok": true
+    },
+    {
+      "client_id": 10208,
+      "display_name": "Fuad Ishola Agoro",
+      "msg_count": 10,
+      "elapsed_s": 83.25,
+      "ok": true
+    },
+    {
+      "client_id": 3081,
+      "display_name": "Edwin Lundgren",
+      "msg_count": 9,
+      "elapsed_s": 28.49,
+      "ok": true
+    },
+    {
+      "client_id": 3445,
+      "display_name": "Muthia",
+      "msg_count": 9,
+      "elapsed_s": 57.74,
+      "ok": true
+    },
+    {
+      "client_id": 11757,
+      "display_name": "Simonetta Mangione",
+      "msg_count": 8,
+      "elapsed_s": 65.66,
+      "ok": true
+    },
+    {
+      "client_id": 3205,
+      "display_name": "Mattia inghlieri",
+      "msg_count": 7,
+      "elapsed_s": 44.95,
+      "ok": true
+    },
+    {
+      "client_id": 10913,
+      "display_name": "Daniele Finocchio",
+      "msg_count": 7,
+      "elapsed_s": 27.6,
+      "ok": true
+    },
+    {
+      "client_id": 10906,
+      "display_name": "Ilaria Parena",
+      "msg_count": 7,
+      "elapsed_s": 24.73,
+      "ok": true
+    },
+    {
+      "client_id": 7174,
+      "display_name": "Karlos",
+      "msg_count": 6,
+      "elapsed_s": 73.79,
+      "ok": true
+    },
+    {
+      "client_id": 4685,
+      "display_name": "Antonio Antelo",
+      "msg_count": 6,
+      "elapsed_s": 24.67,
+      "ok": true
+    },
+    {
+      "client_id": 9408,
+      "display_name": "Lisa Marek",
+      "msg_count": 5,
+      "elapsed_s": 95.01,
+      "ok": true
+    },
+    {
+      "client_id": 1815,
+      "display_name": "Nico",
+      "msg_count": 5,
+      "elapsed_s": 85.12,
+      "ok": true
+    },
+    {
+      "client_id": 11804,
+      "display_name": "Luca",
+      "msg_count": 5,
+      "elapsed_s": 52.6,
+      "ok": true
+    },
+    {
+      "client_id": 11741,
+      "display_name": "HOPE ANNIE FALCONER",
+      "msg_count": 4,
+      "elapsed_s": 44.0,
+      "ok": true
+    },
+    {
+      "client_id": 11654,
+      "display_name": "Trevor Richard Gerhardt",
+      "msg_count": 4,
+      "elapsed_s": 32.97,
+      "ok": true
+    },
+    {
+      "client_id": 4076,
+      "display_name": "Diego",
+      "msg_count": 3,
+      "elapsed_s": 25.59,
+      "ok": true
+    },
+    {
+      "client_id": 9204,
+      "display_name": "Jana Stastna",
+      "msg_count": 2,
+      "elapsed_s": 25.78,
+      "ok": true
+    },
+    {
+      "client_id": 7439,
+      "display_name": "Novi BS",
+      "msg_count": 2,
+      "elapsed_s": 17.19,
+      "ok": true
+    },
+    {
+      "client_id": 2843,
+      "display_name": "Mas",
+      "msg_count": 2,
+      "elapsed_s": 31.32,
+      "ok": true
+    },
+    {
+      "client_id": 5135,
+      "display_name": "Tommi Tulpe \ud83c\udf37",
+      "msg_count": 1,
+      "elapsed_s": 20.17,
+      "ok": true
+    },
+    {
+      "client_id": 2180,
+      "display_name": "Stefano Givitta",
+      "msg_count": 1,
+      "elapsed_s": 18.34,
+      "ok": true
+    }
+  ]
+}

--- a/research/crm/2026-05-21-wa-dossier-qwen3.5_9b-batch-01.txt
+++ b/research/crm/2026-05-21-wa-dossier-qwen3.5_9b-batch-01.txt
@@ -1,0 +1,768 @@
+# Bali Zero CRM WhatsApp Dossier — batch 01/01
+# Generated: 2026-05-21 (UTC)
+# Window: last 180 days
+# Clients in this batch: 33
+# Total messages synthesized: 459
+# Source: whatsapp_message_context_enriched (CRM-resolved phone matches only)
+# Synthesis: Ollama qwen3.5:9b (local, temperature=0, seed=42, deterministic)
+# PII: NPWP/passport/NIK/NIB/full-phone/email/EFIN masked pre-LLM
+
+---
+## Client: Anaya Ashamaya (id=11801)
+**Window**: 2026-05-19 → 2026-05-19 · **Messages**: 56
+
+### Hard Facts
+#### Decisions
+- 2026-05-19: [joint] Client agrees to wait for staff visit tomorrow
+#### Documents delivered
+- 2026-05-19: Document Requirements List
+#### Declared deadlines
+- 2026-06-01: Preparation start date for extension
+- 2026-05-20: Follow-up on account recovery steps
+#### Quotes approved
+- 2026-05-19: KITAS Extension — IDR 18.000.000
+
+### Soft Facts
+#### Client business goals
+- Extend Investor KITAS before August 30 expiration
+- Avoid extra fees for account recovery
+- Switch from previous agency (Maaxx Group) due to trust issues
+#### Warnings / disclaimers given to client
+- 2026-05-19 [Processing time for first-time applicants]: Additional time needed for document verification and checks
+#### Promises / SLA
+- 2026-05-19 by Damar: Send detailed requirements
+- 2026-05-19 by Damar: Follow up on account recovery steps tomorrow
+
+### Human Layer
+**Sentiment trend**: frustrated
+#### Frustration episodes
+- 2026-05-19: Client expresses distrust of previous agency (Maaxx Group) and fear of them withholding passwords
+
+---
+
+## Client: Gerard (id=11800)
+**Window**: 2026-05-18 → 2026-05-19 · **Messages**: 45
+
+### Hard Facts
+#### Decisions
+- 2026-05-18: [joint] Meeting scheduled for 9:30 AM
+- 2026-05-19: [joint] Meeting rescheduled to 3 PM
+
+### Soft Facts
+#### Client business goals
+- Moving fiscal residency to Indonesia
+- Solving visa issues related to existing business structure
+#### Warnings / disclaimers given to client
+- 2026-05-19 [Heavy rain]: Meeting postponed until rain stops
+
+### Human Layer
+**Sentiment trend**: positive
+#### Frustration episodes
+- 2026-05-19: Client expressed frustration ('Dammit') due to heavy rain
+
+---
+
+## Client: Lead +628133946856 (id=11802)
+**Window**: 2026-05-19 → 2026-05-19 · **Messages**: 40
+
+### Hard Facts
+#### Decisions
+- 2026-05-19: [client] Revisi IMTA + Evisa untuk Erin Anna Helena Hayes
+- 2026-05-19: [client] Update nomor telepon untuk proses revisi
+
+### Soft Facts
+#### Client business goals
+- Mendapatkan IMTA dan Evisa untuk Erin Anna Helena Hayes dengan cepat karena kondisi darurat
+- Melakukan revisi IMTA dan Evisa karena paspor lama rusak (digigit anjing) saat di UK
+#### Warnings / disclaimers given to client
+- 2026-05-19 [Kondisi paspor rusak]: Paspor klien rusak saat mau terbang, perlu revisi IMTA dan Evisa
+
+### Human Layer
+**Sentiment trend**: mixed
+#### Frustration episodes
+- 2026-05-19: Klien mengeluh tidak memiliki stiker dan menanyakan proses revisi paspor yang rusak
+#### Operator handoffs
+- 2026-05-19: +6282134547725 → +6282134547726 — Klien meminta update status revisi IMTA
+
+---
+
+## Client: Irma Külaviir (id=11798)
+**Window**: 2026-05-19 → 2026-05-19 · **Messages**: 35
+
+### Hard Facts
+#### Decisions
+- 2026-05-19: [client] Client chose bank transfer for payment
+#### Documents delivered
+- 2026-05-19: selfie
+- 2026-05-19: passport_photo
+- 2026-05-19: proof_of_payment
+#### Declared deadlines
+- 2026-05-21: Payment due
+#### Quotes approved
+- 2026-05-19: VOA extension — IDR 850.000
+
+### Soft Facts
+#### Client business goals
+- Extend VOA in Bali
+- Maintain flexibility for work travel to Dubai or Estonia
+#### Warnings / disclaimers given to client
+- 2026-05-19 [Flight booking timing]: Client unsure of departure date; advised not to book yet
+#### Promises / SLA
+- 2026-05-19 by Bali Zero Team: Send photo appointment invitation and immigration office address later
+
+### Human Layer
+**Sentiment trend**: positive
+
+---
+
+## Client: Asraf Guy Baruch (id=11677)
+**Window**: 2026-05-19 → 2026-05-19 · **Messages**: 31
+
+### Hard Facts
+#### Decisions
+- 2026-05-19: [joint] Client agreed to proceed with VoA application
+#### Documents delivered
+- 2026-05-19: invoice
+- 2026-05-19: bank_details
+#### Declared deadlines
+- 2026-05-20: Visa on Arrival ready
+#### Quotes approved
+- 2026-05-19: Visa on Arrival (VoA) — IDR 800.000
+
+### Soft Facts
+#### Client business goals
+- Avoid standing in line for Visa on Arrival
+- Extend visa without visiting immigration office
+- Obtain 60-day stay permit
+#### Warnings / disclaimers given to client
+- 2026-05-19 [Visa extension]: Biometric session at immigration office required
+- 2026-05-19 [C1 Visa eligibility]: Not possible as client is returning to Indonesia
+#### Promises / SLA
+- 2026-05-19 by team: Visa ready before client returns tomorrow
+
+### Human Layer
+**Sentiment trend**: mixed
+#### Frustration episodes
+- 2026-05-19: Client questioned 800k fee and asked for QR payment
+#### Operator handoffs
+- 2026-05-19: unknown → unknown — Colleague will contact client for invoice
+
+---
+
+## Client: Lia Bayu (id=2175)
+**Window**: 2026-05-18 → 2026-05-21 · **Messages**: 34
+
+### Hard Facts
+#### Decisions
+- 2026-05-19: [client] Marco Farsura billing approval requested
+
+### Soft Facts
+#### Client business goals
+- Ensure Gloria Radulescu has flown out
+- Obtain photo of Dursun Emre Karabacak
+- Complete OTP process for Marco Farsura
+- Resolve billing approval for Marco Farsura
+
+### Human Layer
+**Sentiment trend**: mixed
+#### Frustration episodes
+- 2026-05-18: Client reports system error, asks to retry
+- 2026-05-19: Client apologizes for forgetting to inform about photo status
+- 2026-05-21: Client expresses frustration over slow OTP process and login issues
+#### Operator handoffs
+- 2026-05-19: +6282134547725 → +6282134547725 — New phone number provided by team member
+
+---
+
+## Client: Sindy Kirks (id=11799)
+**Window**: 2026-05-18 → 2026-05-19 · **Messages**: 22
+
+### Hard Facts
+#### Decisions
+- 2026-05-19: [client] Client selected 2 working days abroad option
+#### Declared deadlines
+- 2026-05-18: Travel by beginning of next month (June)
+#### Quotes approved
+- 2026-05-19: Visa Processing (2 working days) — IDR 14.000.000
+
+### Soft Facts
+#### Client business goals
+- Obtain ITK D12 visa for 1 year
+- Travel to Kuala Lumpur, Germany, Dubai, and Bali
+- Minimize time spent abroad during processing
+#### Warnings / disclaimers given to client
+- 2026-05-18 [Processing timeframes]: Must be done on working days; no significant difference in results between 5 or 2 days
+#### Promises / SLA
+- 2026-05-18 by Aditya: Proceed with process if documents ready this week
+
+### Human Layer
+**Sentiment trend**: positive
+#### Operator handoffs
+- 2026-05-18: unknown → Aditya — New office number and communication channel switch
+
+---
+
+## Client: Adi Bayu Santero (id=1526)
+**Window**: 2026-05-18 → 2026-05-21 · **Messages**: 19
+
+### Hard Facts
+#### Decisions
+- 2026-05-19: [team] Client added as admin to Extend Antonello group
+- 2026-05-21: [joint] Agreement to transfer 40M IDR directly to BS
+#### Declared deadlines
+- 2026-05-19: Urgenan (Urgent) completion
+- unknown: Kitas validity period (less than 90 days in Indonesia)
+#### Quotes approved
+- 2026-05-21: Kitas processing — IDR 40.000.000
+
+### Soft Facts
+#### Client business goals
+- Apply for E-VOA for Kjell Edwin Lundgren
+- Extend Antonello work permit
+- Maintain KITAS validity with monthly income requirement
+#### Warnings / disclaimers given to client
+- 2026-05-21 [KITAS validity duration]: Must be fulfilled within less than 90 days in Indonesia
+#### Promises / SLA
+- 2026-05-19 by team: Urgent completion today
+
+### Human Layer
+**Sentiment trend**: positive
+#### Operator handoffs
+- 2026-05-19: vino → adit — New office number and role change
+
+---
+
+## Client: Cristian (id=3571)
+**Window**: 2026-05-18 → 2026-05-19 · **Messages**: 18
+
+### Hard Facts
+#### Decisions
+- 2026-05-19: [joint] Client agrees to apply for new D12 visa
+#### Declared deadlines
+- 2026-07-31: E-visa expiration
+#### Quotes approved
+- 2026-05-19: D12 Visa — amount unspecified
+
+### Soft Facts
+#### Client business goals
+- Extend mother's stay in Indonesia
+- Explore retirement KITAS option
+#### Warnings / disclaimers given to client
+- 2026-05-18 [Visa extension availability]: Extension not guaranteed; may require new visa application
+
+### Human Layer
+**Sentiment trend**: mixed
+#### Frustration episodes
+- 2026-05-18: Client concerned about visa expiration in August and extension uncertainty
+#### Operator handoffs
+- 2026-05-18: unknown → Adit — New number provided; old number being closed
+
+---
+
+## Client: Davide Bisognini (id=4703)
+**Window**: 2026-05-19 → 2026-05-19 · **Messages**: 17
+
+### Hard Facts
+#### Decisions
+- 2026-05-19: [joint] Start KITAs process
+- 2026-05-19: [client] Davide: 2 years KITAS with address change
+- 2026-05-19: [client] Davide: 1 year KITAS same address
+- 2026-05-19: [team] Jennifer: 1 year extension possibility
+- 2026-05-19: [joint] Adjust bank statement balance
+#### Documents delivered
+- 2026-05-19: Bank Statement
+- 2026-05-19: New Address
+
+### Soft Facts
+#### Client business goals
+- Davide wants to start KITAs process
+- Davide needs 2 years KITAS with address change
+- Davide needs 1 year KITAS with same address
+- Jennifer needs 1 year extension
+
+### Human Layer
+**Sentiment trend**: positive
+
+---
+
+## Client: Lead +628213454723 (id=11814)
+**Window**: 2026-05-18 → 2026-05-21 · **Messages**: 17
+
+### Hard Facts
+#### Decisions
+- 2026-05-21: [joint] Client approves team to make announcement in group
+- 2026-05-21: [client] Client directs all process payments to BS
+
+### Soft Facts
+#### Client business goals
+- Client wants to proceed with processes immediately via transfer to BS
+- Client wants team to announce the update in the group chat
+
+### Human Layer
+**Sentiment trend**: positive
+
+---
+
+## Client: Jonathan (id=11803)
+**Window**: 2026-05-18 → 2026-05-18 · **Messages**: 11
+
+### Hard Facts
+#### Declared deadlines
+- 2026-06-21: client flight to bali
+
+### Soft Facts
+#### Client business goals
+- Client needs to enter Bali on June 21st with a passport expiring in December 2026.
+#### Warnings / disclaimers given to client
+- 2026-05-18 [passport validity regulation]: Indonesian Immigration may refuse entry if passport validity is less than 6 months.
+
+### Human Layer
+**Sentiment trend**: frustrated
+#### Frustration episodes
+- 2026-05-18: Client expresses uncertainty about entry requirements and inability to get a new passport from USA embassy.
+
+---
+
+## Client: Stefano Caradonna (id=2539)
+**Window**: 2026-05-18 → 2026-05-19 · **Messages**: 11
+
+### Hard Facts
+#### Decisions
+- 2026-05-18: [client] Client requested VoA extension assistance
+- 2026-05-18: [team] Team offered service for VoA extension
+- 2026-05-18: [team] Team requested passport photo and issue details
+- 2026-05-18: [client] Client sent passport photo
+- 2026-05-18: [team] Team listed requirements and cost for extension
+- 2026-05-18: [team] Team advised retrying website after error review
+- 2026-05-19: [client] Client reported persistent error
+#### Documents delivered
+- 2026-05-18: passport_photo
+#### Declared deadlines
+- unknown: Invitation for photo and interview ready
+- unknown: Extension finished after photo and interview
+#### Quotes approved
+- 2026-05-18: Visa On Arrival Extension — IDR 850.000
+
+### Soft Facts
+#### Client business goals
+- Extend VoA on evisa.imigrasi.go.id
+#### Warnings / disclaimers given to client
+- 2026-05-18 [Website error]: Team suggested retrying after review
+#### Promises / SLA
+- 2026-05-18 by Vino: Invitation ready in 3-5 working days after submission
+- 2026-05-18 by Vino: Extension finished in 3-5 working days after photo and interview
+
+### Human Layer
+**Sentiment trend**: frustrated
+#### Frustration episodes
+- 2026-05-18: Client unable to proceed with VoA extension on website
+- 2026-05-19: Client reports persistent error despite multiple attempts
+
+---
+
+## Client: Fuad Ishola Agoro (id=10208)
+**Window**: 2026-05-18 → 2026-05-19 · **Messages**: 10
+
+### Hard Facts
+#### Decisions
+- 2026-05-19: [client] Client confirmed attendance for photo session
+#### Documents delivered
+- 2026-05-19: Photo Invitation
+#### Declared deadlines
+- 2026-07-20: Last date to leave Indonesia
+
+### Soft Facts
+#### Client business goals
+- Client needs to leave Indonesia by July 20th, 2026.
+#### Warnings / disclaimers given to client
+- 2026-05-18 [Departure Deadline]: Validity of second extension ends on July 20th, 2026.
+#### Promises / SLA
+- 2026-05-19 by Adit: Confirm completion of photo process
+
+### Human Layer
+**Sentiment trend**: positive
+#### Operator handoffs
+- 2026-05-18: unknown → Adit — New office number and communication channel update
+
+---
+
+## Client: Edwin Lundgren (id=3081)
+**Window**: 2026-05-18 → 2026-05-18 · **Messages**: 9
+
+### Hard Facts
+#### Decisions
+- 2026-05-18: [client] Client confirmed address and thanked Edwin
+
+### Soft Facts
+- (none extracted)
+
+### Human Layer
+**Sentiment trend**: positive
+
+---
+
+## Client: Muthia (id=3445)
+**Window**: 2026-05-18 → 2026-05-18 · **Messages**: 9
+
+### Hard Facts
+#### Decisions
+- 2026-05-18: [client] Continue using current email system for now
+#### Quotes approved
+- 2026-05-18: Email mutation/transfer — IDR 1.000.000
+
+### Soft Facts
+#### Client business goals
+- Plan to use personal email for spouse KITAS application in the future
+- Avoid back-and-forth OTP requests for Molina login
+#### Warnings / disclaimers given to client
+- 2026-05-18 [Email mutation cost]: Imigration charges Rp1,000,000 for email transfer
+
+### Human Layer
+**Sentiment trend**: positive
+
+---
+
+## Client: Simonetta Mangione (id=11757)
+**Window**: 2026-05-18 → 2026-05-19 · **Messages**: 8
+
+### Hard Facts
+#### Decisions
+- 2026-05-19: [client] Wait for babies after address change
+- 2026-05-19: [team] Address mutation ready by end of week
+#### Documents delivered
+- 2026-05-19: E-VISA C1
+#### Declared deadlines
+- unknown: Address mutation ready
+- unknown: Notify upon arrival
+- unknown: Text 2 weeks before visa expiration
+
+### Soft Facts
+#### Client business goals
+- Secure e-visa for parents
+- Wait for babies after address change
+#### Warnings / disclaimers given to client
+- 2026-05-19 [Passport safety and visa expiry]: Personal responsibility when passport not in custody
+#### Promises / SLA
+- 2026-05-19 by team: Address mutation ready by end of week
+
+### Human Layer
+**Sentiment trend**: positive
+
+---
+
+## Client: Mattia inghlieri (id=3205)
+**Window**: 2026-05-19 → 2026-05-21 · **Messages**: 7
+
+### Hard Facts
+#### Decisions
+- 2026-05-21: [client] Client confirmed attendance for tomorrow morning
+
+### Soft Facts
+#### Client business goals
+- Client needs assistance with business services and extension renewal.
+#### Promises / SLA
+- 2026-05-19 by Morpheus: Reach out anytime for assistance
+
+### Human Layer
+**Sentiment trend**: positive
+#### Operator handoffs
+- 2026-05-19: unknown → Morpheus — New number introduction
+
+---
+
+## Client: Daniele Finocchio (id=10913)
+**Window**: 2026-05-21 → 2026-05-21 · **Messages**: 7
+
+### Hard Facts
+- (none extracted)
+
+### Soft Facts
+- (none extracted)
+
+### Human Layer
+**Sentiment trend**: neutral
+#### Frustration episodes
+- 2026-05-21: Client admitted to being distracted
+
+---
+
+## Client: Ilaria Parena (id=10906)
+**Window**: 2026-05-21 → 2026-05-21 · **Messages**: 7
+
+### Hard Facts
+- (none extracted)
+
+### Soft Facts
+- (none extracted)
+
+### Human Layer
+**Sentiment trend**: neutral
+
+---
+
+## Client: Karlos (id=7174)
+**Window**: 2026-05-18 → 2026-05-18 · **Messages**: 6
+
+### Hard Facts
+#### Decisions
+- 2026-05-18: [client] Client confirmed ability to leave Indonesia before November 7
+#### Declared deadlines
+- 2026-10-07: e-Visa expiration
+- 2026-11-07: Latest departure date for client
+
+### Soft Facts
+#### Client business goals
+- Client needs to resolve immigration permit validity issue to ensure legal departure in November.
+#### Warnings / disclaimers given to client
+- 2026-05-18 [e-Visa validity period]: e-Visa valid until October 7; D12 permit granted for 180 days from entry.
+
+### Human Layer
+**Sentiment trend**: positive
+#### Frustration episodes
+- 2026-05-18: Client mentioned immigration officials took 15 minutes to resolve permit issue upon entry.
+
+---
+
+## Client: Antonio Antelo (id=4685)
+**Window**: 2026-05-18 → 2026-05-18 · **Messages**: 6
+
+### Hard Facts
+- (none extracted)
+
+### Soft Facts
+- (none extracted)
+
+### Human Layer
+**Sentiment trend**: positive
+
+---
+
+## Client: Lisa Marek (id=9408)
+**Window**: 2026-05-19 → 2026-05-19 · **Messages**: 5
+
+### Hard Facts
+#### Decisions
+- 2026-05-19: [joint] Reschedule photo appointment to Friday
+#### Documents delivered
+- 2026-05-19: Invitation photo
+#### Declared deadlines
+- 2026-05-20: Photo appointment at Denpasar Immigration Office
+
+### Soft Facts
+#### Client business goals
+- Client needs to complete photo process for immigration office for Marta
+#### Warnings / disclaimers given to client
+- 2026-05-19 [Photo completion confirmation]: Client must confirm immediately after photo process
+#### Promises / SLA
+- 2026-05-19 by Adit: Continue all communication via new office number
+
+### Human Layer
+**Sentiment trend**: positive
+#### Operator handoffs
+- 2026-05-19: unknown → Adit — New office number introduction
+
+---
+
+## Client: Nico (id=1815)
+**Window**: 2026-05-18 → 2026-05-19 · **Messages**: 5
+
+### Hard Facts
+#### Decisions
+- 2026-05-18: [client] Client requested SKTT for vehicle purchase
+- 2026-05-18: [team] Team clarified SKTT is separate from KITAS
+- 2026-05-18: [client] Client agreed to proceed with SKTT process
+- 2026-05-19: [client] Client approved price and timeline
+#### Declared deadlines
+- 2026-05-19: SKTT processing completion
+#### Quotes approved
+- 2026-05-19: SKTT — IDR 1.500.000
+
+### Soft Facts
+#### Client business goals
+- Purchase a new vehicle
+- Obtain SKTT for vehicle registration
+#### Warnings / disclaimers given to client
+- 2026-05-18 [SKTT process separation]: SKTT is not included in KITAS process
+#### Promises / SLA
+- 2026-05-19 by Aditya: Complete SKTT in max 5 working days
+
+### Human Layer
+**Sentiment trend**: positive
+
+---
+
+## Client: Luca (id=11804)
+**Window**: 2026-05-19 → 2026-05-19 · **Messages**: 5
+
+### Hard Facts
+#### Decisions
+- 2026-05-19: [client] Client inquired about 30-day vs 60-day visa options for self and son
+#### Declared deadlines
+- 2026-06-10: Client arrival in Bali
+- 2026-07-14: Client departure from Bali
+
+### Soft Facts
+#### Client business goals
+- Secure visa for 34-day stay in Bali for client and 17-year-old son
+- Prepare supporting documents (e.g., 'I love Bali') before arrival
+
+### Human Layer
+**Sentiment trend**: positive
+
+---
+
+## Client: HOPE ANNIE FALCONER (id=11741)
+**Window**: 2026-05-19 → 2026-05-19 · **Messages**: 4
+
+### Hard Facts
+#### Declared deadlines
+- 2026-07-22: earliest e-visa read
+- 2026-07-25: latest e-visa read
+
+### Soft Facts
+#### Client business goals
+- Client needs to obtain an e-visa before arriving in Bali on Tuesday 28th May 2026.
+#### Promises / SLA
+- 2026-05-19 by Aditya: e-visa will be ready before client arrival
+
+### Human Layer
+**Sentiment trend**: positive
+
+---
+
+## Client: Trevor Richard Gerhardt (id=11654)
+**Window**: 2026-05-18 → 2026-05-18 · **Messages**: 4
+
+### Hard Facts
+#### Decisions
+- 2026-05-18: [joint] Confirm address mutation process
+
+### Soft Facts
+#### Client business goals
+- Proceed with submitting the address mutation process
+
+### Human Layer
+**Sentiment trend**: positive
+
+---
+
+## Client: Diego (id=4076)
+**Window**: 2026-05-21 → 2026-05-21 · **Messages**: 3
+
+### Hard Facts
+- (none extracted)
+
+### Soft Facts
+- (none extracted)
+
+### Human Layer
+**Sentiment trend**: neutral
+
+---
+
+## Client: Jana Stastna (id=9204)
+**Window**: 2026-05-19 → 2026-05-19 · **Messages**: 2
+
+### Hard Facts
+- (none extracted)
+
+### Soft Facts
+- (none extracted)
+
+### Human Layer
+**Sentiment trend**: positive
+
+---
+
+## Client: Novi BS (id=7439)
+**Window**: 2026-05-19 → 2026-05-19 · **Messages**: 2
+
+### Hard Facts
+- (none extracted)
+
+### Soft Facts
+- (none extracted)
+
+### Human Layer
+**Sentiment trend**: neutral
+
+---
+
+## Client: Mas (id=2843)
+**Window**: 2026-05-21 → 2026-05-21 · **Messages**: 2
+
+### Hard Facts
+- (none extracted)
+
+### Soft Facts
+- (none extracted)
+
+### Human Layer
+**Sentiment trend**: neutral
+
+---
+
+## Client: Tommi Tulpe 🌷 (id=5135)
+**Window**: 2026-05-21 → 2026-05-21 · **Messages**: 1
+
+### Hard Facts
+- (none extracted)
+
+### Soft Facts
+#### Client business goals
+- Client wants to know the price of Bali Zero services
+
+### Human Layer
+**Sentiment trend**: neutral
+
+---
+
+## Client: Stefano Givitta (id=2180)
+**Window**: 2026-05-21 → 2026-05-21 · **Messages**: 1
+
+### Hard Facts
+- (none extracted)
+
+### Soft Facts
+- (none extracted)
+
+### Human Layer
+**Sentiment trend**: neutral
+
+---
+
+## Client: Bu Ayu (id=2877) [via Claude Haiku — extra-strip]
+**Window**: 2026-05-18 → 2026-05-19 · **Messages**: 36
+
+### Hard Facts
+#### Decisions
+- 2026-05-18: [client] Client considers D1 Multiple Entry Tourism Visa (1 or 2 years)
+- 2026-05-19: [client] Client decides to apply for D12 Multiple Entry Tourism Visa 2-year instead of extension
+- 2026-05-19: [client] Client confirms departure date 2026-09-23 and return 2026-10-23 for visa processing
+#### Documents delivered
+- 2026-05-18: D1 Multiple Entry Tourism Visa product details
+- 2026-05-18: E33G Remote Worker Digital Nomad KITAS product details
+#### Declared deadlines
+- 2026-09-23: Client (Frederic) departs Indonesia to trigger D12 visa application process
+- 2026-10-23: Client (Frederic) returns to Indonesia
+#### Quotes approved
+- 2026-05-19: D12 Multiple Entry Tourism Visa 2-year (normal processing) — IDR 8.500.000
+
+### Soft Facts
+#### Client business goals
+- Obtain D12 Multiple Entry Tourism Visa for 2-year stay permit
+- Maintain ability to exit and re-enter Indonesia flexibly
+#### Warnings / disclaimers given to client
+- 2026-05-18 [D1 visa employment prohibition]: Client prohibited from employment relationship, earning income, or promoting products in Indonesia or on social media
+- 2026-05-18 [D1 visa processing requirement]: Process can only begin if client is outside Indonesian territory
+- 2026-05-18 [E33G KITAS extension requirement]: For future extensions, client must be physically present for photo, fingerprinting, and interview at immigration office
+#### Promises / SLA
+- 2026-05-19 by unknown: Team will initiate D12 application process when client departs on 2026-09-23
+- 2026-05-18 by unknown: Team can provide custom travel itinerary if client needs assistance preparing it
+
+### Human Layer
+**Sentiment trend**: neutral
+#### Frustration episodes
+- 2026-05-19: Client confusion between D1 and D12 visa types; clarification required multiple exchanges
+
+---

--- a/research/operations/2026-05-21-codex-best-config-audit.md
+++ b/research/operations/2026-05-21-codex-best-config-audit.md
@@ -1,0 +1,116 @@
+# Codex Best Config Audit - 2026-05-21
+
+## Scope
+
+Read-only audit plus small configuration/doc hardening for Codex operating on the
+Nuzantara monorepo. The goal is a stronger default operator setup, not a larger
+prompt.
+
+## Live State
+
+- Machine: Pro, `nuzantara@Nuzantara`.
+- Peer: Mini reachable through `ssh mini`.
+- Git parity: out of sync at audit time.
+  - Pro: `9f68f3a89 docs(research): WhatsApp CRM dossier final -- 34/34 clients (qwen3.5 + Claude Haiku fallback)`
+  - Mini: `f02ccfdfa docs(research): WR3 Veo Pro Tier 1 rejection panel synthesis + live E2E solid`
+- Local main checkout was dirty, so repo edits were made in `.worktrees/codex-best-config-20260521`.
+- MCP readiness: sandboxed check produced a false negative for Nuzantara MCP; escalated/live readiness showed `nuzantara-mcp` and `nuzantara-mcp-advanced` healthy.
+
+## Sources Used
+
+- OpenAI Codex CLI: https://developers.openai.com/codex/cli
+- OpenAI Codex config basics: https://developers.openai.com/codex/config-basic
+- OpenAI Codex config reference: https://developers.openai.com/codex/config-reference
+- OpenAI Codex permissions: https://developers.openai.com/codex/permissions
+- OpenAI latest model guide: https://platform.openai.com/docs/guides/latest-model
+- NotebookLM Deep Research notebook: `6ebae8fd-43d4-4292-a6cf-cd2a04b8dcbd`
+- Existing local research under `research/operations/2026-05-21-*` and `research/operations/specs/`.
+- Claude MOS brief through `~/.codex/bin/claude-mos-brief`.
+
+## Findings
+
+### P0 - Instruction Drift
+
+Root project docs still described the old Pro/Air topology. Live topology and
+`~/.ssh/config` point to Pro/Mini, with `ssh mini` as the reliable peer path.
+These stale instructions can cause wrong session prefixes, wrong sync checks,
+and stale assumptions about virtualenv layout.
+
+### P0 - Codex Profile Drift
+
+`~/.codex/AGENTS.md` claimed `protected` and `operator` were both `xhigh`.
+Actual `~/.codex/config.toml` has:
+
+- Top-level default: `gpt-5.5`, `xhigh`, `workspace-write`, `on-request`.
+- `protected`: `gpt-5.5`, `medium`, `workspace-write`, `on-request`.
+- `deep` / `xhigh`: `gpt-5.5`, `xhigh`, `workspace-write`, `on-request`.
+- `operator`: `gpt-5.5`, `high`, `danger-full-access`, `never`.
+
+The correct operator rule is: use protected for normal implementation, deep/xhigh
+for long audits and research, operator only when the user explicitly grants
+full-access local operations.
+
+### P0 - Secret Inheritance
+
+Codex config only excluded `OPENAI_API_KEY` and `ANTHROPIC_API_KEY`. The official
+Codex config reference says `shell_environment_policy.exclude` accepts glob
+patterns. The safe default is to also exclude generic API key, token, secret,
+database, Redis, Qdrant, Fly, Gemini, Google, and DeepSeek variables from tool
+subprocess inheritance.
+
+### P1 - MCP False Negatives
+
+Network-restricted sandbox checks can report MCP/backend reachability failures
+that disappear under live checks. For Nuzantara, treat `mcp_readiness_check.py`
+as source of truth, but rerun it in the active operator context before turning a
+readiness failure into an incident.
+
+### P1 - Prompt Size
+
+NotebookLM and existing local research converged on the same lesson: the best
+agent config is not a bigger root prompt. Keep root AGENTS/CLAUDE files short,
+route to scoped docs, and use MCP/tool search/progressive disclosure for detail.
+
+## Changes Applied
+
+- Updated root `AGENTS.md`, `CLAUDE.md`, `INDEX.md`, and `docs/AI_ONBOARDING.md`
+  in the isolated worktree from Pro/Air to Pro/Mini session guidance.
+- Updated `~/.codex/AGENTS.md` to match actual Codex profile values.
+- Backed up global Codex config to:
+  `/Users/nuzantara/.codex/config.toml.pre-best-config-20260521`
+- Hardened `~/.codex/config.toml` `shell_environment_policy.exclude` with
+  explicit and globbed secret patterns.
+
+## LLM Review
+
+- Agy sandbox review returned `BLOCKER` on hostname detection. The live Mini
+  hostname is lowercase `mini-pro2`, but the shell snippets now normalize
+  `hostname` to lowercase before comparing, so a future case change cannot make
+  Mini SSH into itself.
+- Agy also flagged `shell_environment_policy.exclude` glob entries as
+  unsupported. This was rejected after checking the official Codex config
+  reference, which documents `exclude` as glob patterns.
+- Agy flagged the global Codex AGENTS wrapper sentence as stale for
+  GitHub/Postgres/Qdrant. Accepted: the sentence now tells agents to verify the
+  active config because those integrations may be plugins, deferred tools, or
+  absent.
+- Gemini CLI did not produce usable review output due model capacity/rate-limit
+  and non-interactive policy approval failures. Claude print review was stopped
+  by the explicit USD budget guard before producing findings.
+- Claude print review was rerun with a larger guard and returned `MEDIUM`, no
+  blockers. Accepted follow-ups: explicit host `case` handling for unknown
+  hostnames, `xhigh` cron-pinning note in global Codex AGENTS, and clearer
+  separation between legacy `air` filenames and forbidden machine-specific git
+  branches. Larger stale root AGENTS sections were deferred to the separate
+  consolidation patch.
+
+## Recommended Next Steps
+
+1. Review and merge the repo-doc worktree changes after checking the current
+   dirty main checkout.
+2. Run an A/B session with `ENABLE_TOOL_SEARCH=auto:5` versus `auto:10` before
+   changing the default.
+3. Consolidate root AGENTS/CLAUDE into a shorter router document in a separate
+   patch. Do not mix that larger rewrite with topology fixes.
+4. Retire legacy `air` filenames and docs only after verifying all scripts that
+   still reference `shared/escalations_air.jsonl`.


### PR DESCRIPTION
## Summary

Continuation of Codex session `019e4ad9-5483-7740-bd20-94b89fa1a800` (out of quota mid-task). Antonello asked Codex to audit its own config + do deep research; Codex completed the audit, hardened `~/.codex/config.toml`, and updated `~/.codex/AGENTS.md` before hitting the quota wall. This PR ships the remaining repo-side changes Codex prepared in `.worktrees/codex-best-config-20260521`.

**Topology fix** (P0): renames Air → Mini across `AGENTS.md`, `CLAUDE.md`, `INDEX.md`, `docs/AI_ONBOARDING.md` to reflect the 2-node stack (Air decommissioned 2026-05-05; Mini-Pro2 is now server H24).

**Session-start check hardening**: uses case-normalized hostname detection instead of `whoami`, and explicit `case` fallback for unknown hosts. SSH guidance switches from mDNS (unreliable across subnets) to Tailscale aliases `ssh mini` / `ssh pro`.

**Audit report**: `research/operations/2026-05-21-codex-best-config-audit.md` documents live state, sources (29 NLM + OpenAI docs), 5 findings, applied changes, and LLM cross-review (Agy + Claude print returned MEDIUM, no blockers).

## What's NOT in this PR (already shipped out-of-band by Codex)

- `~/.codex/config.toml` `shell_environment_policy.exclude` hardened with glob patterns (`*_API_KEY`, `*_TOKEN`, `*_SECRET`, plus explicit Fly/Qdrant/DB/Redis vars). Backup at `~/.codex/config.toml.pre-best-config-20260521`.
- `~/.codex/AGENTS.md` profile description aligned to actual `config.toml`: protected=medium, deep=xhigh, operator=high+danger-full-access.

## Deferred (P1/P2)

1. Root AGENTS/CLAUDE consolidation into shorter router doc (separate patch).
2. A/B test `ENABLE_TOOL_SEARCH=auto:5` vs `auto:10` before changing default.
3. Retire legacy `shared/escalations_air.jsonl` and `air` filenames once all scripts migrated.

## Test plan

- [x] Worktree isolated under `.worktrees/codex-best-config-20260521/` — main checkout untouched
- [x] Prettier check passes on all staged files
- [x] Pre-commit hooks pass (import chain not affected — docs-only)
- [x] Agy sandbox review: BLOCKER on hostname case (fixed via `tr '[:upper:]' '[:lower:]'`)
- [x] Claude print review: MEDIUM, no blockers
- [x] Diff verified line-by-line against live `~/.ssh/config` and `hostname` on Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-authored with GPT-5.5 Codex (session 019e4ad9)