### PR TITLE
fix(whatsapp-review): block generic /approve, enforce match-aware endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ See [`INDEX.md`](INDEX.md) for the full atlas including packages, tessuti dati, 
 ### Tech Stack
 
 <!-- DOCSYNC:BACKEND_STATS_START -->
-- **Backend:** Python 3.11+, FastAPI, 271 routers, 564 services, 957 test files
+- **Backend:** Python 3.11+, FastAPI, 273 routers, 565 services, 959 test files
 <!-- DOCSYNC:BACKEND_STATS_END -->
 - **Frontend:** Next.js, TypeScript, Tailwind CSS
 - **Databases:** PostgreSQL (relational), Qdrant (vector), Redis (cache)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 271 routers · 564 services
+- Backend: FastAPI · 273 routers · 565 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 24 · Packages: 5

--- a/apps/backend-rag/backend/app/routers/whatsapp_export_review.py
+++ b/apps/backend-rag/backend/app/routers/whatsapp_export_review.py
@@ -1101,25 +1101,15 @@ async def approve_review_item(
             )
             return ReviewActionResponse(id=entity_id, status="completed", action="approve")
         if resource == "contacts":
-            await _update_contact_review(
-                conn,
-                contact_id=entity_id,
-                review_status="approved",
-                approved_client_id=None,
-                current_user=current_user,
-                note=payload.reason,
+            raise HTTPException(
+                status_code=400,
+                detail="Use /contacts/{id}/approve-match with approved_client_id",
             )
-            return ReviewActionResponse(id=entity_id, status="approved", action="approve")
         if resource == "documents":
-            await _update_document_review(
-                conn,
-                document_id=entity_id,
-                review_status="approved",
-                approved_document_id=None,
-                current_user=current_user,
-                note=payload.reason,
+            raise HTTPException(
+                status_code=400,
+                detail="Use /documents/{id}/approve-link for document approvals",
             )
-            return ReviewActionResponse(id=entity_id, status="approved", action="approve")
         await _update_message_review(
             conn,
             message_id=entity_id,

--- a/apps/backend-rag/backend/tests/unit/routers/test_whatsapp_export_review.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_whatsapp_export_review.py
@@ -372,3 +372,47 @@ def test_message_helper_uses_excerpt_not_body() -> None:
     payload = item.model_dump()
     assert "body" not in payload
     assert len(payload["body_excerpt"]) <= 240
+
+
+def test_generic_approve_blocks_contacts_without_explicit_match(
+    admin_user: dict[str, str],
+) -> None:
+    conn = FakeConn(
+        existing_tables={
+            "whatsapp_export_contacts_staging",
+            "whatsapp_export_review_actions",
+        }
+    )
+    client = make_client(admin_user, conn)
+
+    response = client.post(
+        "/api/whatsapp-export/contacts/44/approve",
+        json={"reason": "looks fine"},
+    )
+
+    assert response.status_code == 400
+    assert "approve-match" in response.json()["detail"]
+    executed_sql = "\n".join(query for query, _args in conn.executed)
+    assert "UPDATE whatsapp_export_contacts_staging" not in executed_sql
+
+
+def test_generic_approve_blocks_documents_without_explicit_link(
+    admin_user: dict[str, str],
+) -> None:
+    conn = FakeConn(
+        existing_tables={
+            "whatsapp_export_documents_staging",
+            "whatsapp_export_review_actions",
+        }
+    )
+    client = make_client(admin_user, conn)
+
+    response = client.post(
+        "/api/whatsapp-export/documents/77/approve",
+        json={"reason": "looks fine"},
+    )
+
+    assert response.status_code == 400
+    assert "approve-link" in response.json()["detail"]
+    executed_sql = "\n".join(query for query, _args in conn.executed)
+    assert "UPDATE whatsapp_export_documents_staging" not in executed_sql

--- a/apps/mouth/src/app/(workspace)/whatsapp/export-review/page.tsx
+++ b/apps/mouth/src/app/(workspace)/whatsapp/export-review/page.tsx
@@ -14,12 +14,7 @@ import {
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from "@/components/ui/tabs";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   approveWhatsAppExportReview,
   getWhatsAppExportYopoCase,
@@ -83,23 +78,41 @@ function formatConfidence(value?: number | null): string {
   return `${Math.round(normalized)}%`;
 }
 
-function statusVariant(status?: string | null): "default" | "secondary" | "destructive" | "outline" {
+function statusVariant(
+  status?: string | null,
+): "default" | "secondary" | "destructive" | "outline" {
   if (status === "approved" || status === "completed") return "default";
-  if (status === "rejected" || status === "failed" || status === "archived") return "destructive";
-  if (status === "pending" || status === "reviewing" || status === "parsed") return "secondary";
+  if (status === "rejected" || status === "failed" || status === "archived")
+    return "destructive";
+  if (status === "pending" || status === "reviewing" || status === "parsed")
+    return "secondary";
   return "outline";
 }
 
-function countValue(counts: WhatsAppExportCounts | null | undefined, key: keyof WhatsAppExportCounts): number {
+function countValue(
+  counts: WhatsAppExportCounts | null | undefined,
+  key: keyof WhatsAppExportCounts,
+): number {
   return counts?.[key] ?? 0;
 }
 
-function aggregateCounts(batches: WhatsAppExportReviewBatch[]): Required<WhatsAppExportCounts> {
+function aggregateCounts(
+  batches: WhatsAppExportReviewBatch[],
+): Required<WhatsAppExportCounts> {
   return batches.reduce(
     (total, batch) => ({
-      contacts: total.contacts + countValue(batch.counts, "contacts") + (batch.total_contacts ?? 0),
-      documents: total.documents + countValue(batch.counts, "documents") + (batch.total_documents ?? 0),
-      messages: total.messages + countValue(batch.counts, "messages") + (batch.total_messages ?? 0),
+      contacts:
+        total.contacts +
+        countValue(batch.counts, "contacts") +
+        (batch.total_contacts ?? 0),
+      documents:
+        total.documents +
+        countValue(batch.counts, "documents") +
+        (batch.total_documents ?? 0),
+      messages:
+        total.messages +
+        countValue(batch.counts, "messages") +
+        (batch.total_messages ?? 0),
       yopo_cases: total.yopo_cases + countValue(batch.counts, "yopo_cases"),
       pending: total.pending + countValue(batch.counts, "pending"),
       approved: total.approved + countValue(batch.counts, "approved"),
@@ -130,7 +143,9 @@ export default function WhatsAppExportReviewPage() {
   const [actionKey, setActionKey] = useState<string | null>(null);
 
   const selectedBatch = useMemo(
-    () => batches.find((batch) => String(batch.id) === selectedBatchId) ?? batches[0],
+    () =>
+      batches.find((batch) => String(batch.id) === selectedBatchId) ??
+      batches[0],
     [batches, selectedBatchId],
   );
 
@@ -178,17 +193,22 @@ export default function WhatsAppExportReviewPage() {
   }, [loadReview]);
 
   const handleAction = async (
-    kind: WhatsAppExportReviewKind,
-    id: string | number,
+    kind: "contacts" | "documents",
+    item: WhatsAppExportReviewItem,
     action: "approve" | "reject",
   ): Promise<void> => {
-    const key = `${kind}:${id}:${action}`;
+    const key = `${kind}:${item.id}:${action}`;
     setActionKey(key);
     try {
       if (action === "approve") {
-        await approveWhatsAppExportReview({ kind, id });
+        await approveWhatsAppExportReview({
+          kind,
+          id: item.id,
+          approvedClientId: item.suggested_client_id,
+          approvedPracticeId: item.suggested_practice_id,
+        });
       } else {
-        await rejectWhatsAppExportReview({ kind, id });
+        await rejectWhatsAppExportReview({ kind, id: item.id });
       }
       await loadReview();
     } catch (nextError) {
@@ -210,11 +230,14 @@ export default function WhatsAppExportReviewPage() {
             <div>
               <div className="flex items-center gap-2">
                 <ShieldCheck className="h-5 w-5 text-[var(--accent)]" />
-                <h1 className="text-xl font-semibold">WhatsApp Export Review</h1>
+                <h1 className="text-xl font-semibold">
+                  WhatsApp Export Review
+                </h1>
                 <Badge variant="outline">Internal</Badge>
               </div>
               <p className="mt-1 text-sm text-[var(--foreground-muted)]">
-                Staged contacts, document hints, and YOPO candidates awaiting review.
+                Staged contacts, document hints, and YOPO candidates awaiting
+                review.
               </p>
             </div>
             <div className="flex flex-wrap items-center gap-2">
@@ -229,7 +252,9 @@ export default function WhatsAppExportReviewPage() {
                 onClick={loadReview}
                 disabled={isLoading}
               >
-                <RefreshCw className={cn("h-4 w-4", isLoading && "animate-spin")} />
+                <RefreshCw
+                  className={cn("h-4 w-4", isLoading && "animate-spin")}
+                />
                 Refresh
               </Button>
             </div>
@@ -247,7 +272,11 @@ export default function WhatsAppExportReviewPage() {
           <div className="border-b border-[var(--border)] px-5 py-3">
             <TabsList className="h-9 bg-[var(--background-secondary)]">
               {REVIEW_TABS.map((tab) => (
-                <TabsTrigger key={tab.value} value={tab.value} className="h-7 text-xs">
+                <TabsTrigger
+                  key={tab.value}
+                  value={tab.value}
+                  className="h-7 text-xs"
+                >
                   {tab.label}
                 </TabsTrigger>
               ))}
@@ -295,9 +324,7 @@ export default function WhatsAppExportReviewPage() {
                     actionKey={actionKey}
                     onAction={handleAction}
                   />
-                  <YopoPanel
-                    yopoCase={yopoCase}
-                  />
+                  <YopoPanel yopoCase={yopoCase} />
                 </TabsContent>
               </>
             )}
@@ -358,8 +385,14 @@ function Overview({
         {selectedBatch ? (
           <div className="mt-4 space-y-3 text-sm">
             <SafeField label="Source" value={selectedBatch.source_label} />
-            <SafeField label="File" value={sanitizeBasename(selectedBatch.source_basename)} />
-            <SafeField label="Confidence" value={formatConfidence(selectedBatch.confidence)} />
+            <SafeField
+              label="File"
+              value={sanitizeBasename(selectedBatch.source_basename)}
+            />
+            <SafeField
+              label="Confidence"
+              value={formatConfidence(selectedBatch.confidence)}
+            />
             <div className="flex items-center justify-between gap-3">
               <span className="text-[var(--foreground-muted)]">Status</span>
               <Badge variant={statusVariant(selectedBatch.review_status)}>
@@ -401,8 +434,8 @@ function ReviewTable({
   items: WhatsAppExportReviewItem[];
   actionKey: string | null;
   onAction: (
-    kind: WhatsAppExportReviewKind,
-    id: string | number,
+    kind: "contacts" | "documents",
+    item: WhatsAppExportReviewItem,
     action: "approve" | "reject",
   ) => Promise<void>;
 }) {
@@ -436,29 +469,43 @@ function ReviewTable({
             </thead>
             <tbody>
               {items.map((item) => (
-                <tr key={item.id} className="border-b border-[var(--border)]/70">
+                <tr
+                  key={item.id}
+                  className="border-b border-[var(--border)]/70"
+                >
                   <td className="px-4 py-3">
-                    <div className="font-medium">{sanitizeText(item.source_label)}</div>
+                    <div className="font-medium">
+                      {sanitizeText(item.source_label)}
+                    </div>
                     <div className="text-[var(--foreground-muted)]">
                       {sanitizeBasename(item.source_basename)}
                     </div>
                   </td>
-                  <td className="px-4 py-3 font-mono">{sanitizePhone(item.masked_phone)}</td>
+                  <td className="px-4 py-3 font-mono">
+                    {sanitizePhone(item.masked_phone)}
+                  </td>
                   <td className="px-4 py-3">
                     {sanitizeText(item.display_name ?? item.body_excerpt)}
                   </td>
                   <td className="px-4 py-3">
-                    {sanitizeText(item.suggested_client ?? item.suggested_client_id)}
+                    {sanitizeText(
+                      item.suggested_client ?? item.suggested_client_id,
+                    )}
                   </td>
                   <td className="px-4 py-3">
-                    {sanitizeText(item.suggested_practice ?? item.suggested_practice_id)}
+                    {sanitizeText(
+                      item.suggested_practice ?? item.suggested_practice_id,
+                    )}
                   </td>
                   <td className="px-4 py-3">
                     {formatConfidence(item.confidence)}
                   </td>
                   <td className="max-w-[220px] px-4 py-3">
                     <ReasonList
-                      reasons={item.reasons ?? (item.body_excerpt ? [item.body_excerpt] : [])}
+                      reasons={
+                        item.reasons ??
+                        (item.body_excerpt ? [item.body_excerpt] : [])
+                      }
                       compact
                     />
                   </td>
@@ -470,7 +517,7 @@ function ReviewTable({
                   <td className="px-4 py-3">
                     <ActionButtons
                       kind={kind}
-                      id={item.id}
+                      item={item}
                       actionKey={actionKey}
                       onAction={onAction}
                     />
@@ -497,14 +544,30 @@ function YopoPanel({ yopoCase }: { yopoCase: WhatsAppExportYopoCase | null }) {
       </div>
       {yopoCase ? (
         <div className="grid gap-3 lg:grid-cols-3">
-          <SafeField label="Contacts" value={String(yopoCase.recap?.contact_count ?? contacts.length)} />
-          <SafeField label="Documents" value={String(yopoCase.recap?.document_count ?? documents.length)} />
-          <SafeField label="Messages" value={String(yopoCase.recap?.message_count ?? messages.length)} />
-          <SafeField label="Status" value={yopoCase.recap?.review_status ?? "pending"} />
+          <SafeField
+            label="Contacts"
+            value={String(yopoCase.recap?.contact_count ?? contacts.length)}
+          />
+          <SafeField
+            label="Documents"
+            value={String(yopoCase.recap?.document_count ?? documents.length)}
+          />
+          <SafeField
+            label="Messages"
+            value={String(yopoCase.recap?.message_count ?? messages.length)}
+          />
+          <SafeField
+            label="Status"
+            value={yopoCase.recap?.review_status ?? "pending"}
+          />
           <SafeField label="Lead contact" value={contacts[0]?.display_name} />
-          <SafeField label="Lead document" value={documents[0]?.display_name ?? documents[0]?.source_basename} />
+          <SafeField
+            label="Lead document"
+            value={documents[0]?.display_name ?? documents[0]?.source_basename}
+          />
           <div className="lg:col-span-3 rounded-md border border-[var(--border)] p-3 text-xs text-[var(--foreground-muted)]">
-            Review contacts, documents, and message signals in their tabs before approving individual rows.
+            Review contacts, documents, and message signals in their tabs before
+            approving individual rows.
           </div>
         </div>
       ) : (
@@ -518,7 +581,9 @@ function SafeField({ label, value }: { label: string; value: unknown }) {
   return (
     <div className="flex items-center justify-between gap-3 rounded-md border border-[var(--border)] p-3">
       <span className="text-xs text-[var(--foreground-muted)]">{label}</span>
-      <span className="max-w-[220px] truncate text-right text-sm">{sanitizeText(value)}</span>
+      <span className="max-w-[220px] truncate text-right text-sm">
+        {sanitizeText(value)}
+      </span>
     </div>
   );
 }
@@ -539,10 +604,18 @@ function ReasonList({
   reasons?: string[] | null;
   compact?: boolean;
 }) {
-  const safeReasons = (reasons ?? []).slice(0, compact ? 2 : 4).map((reason) => sanitizeText(reason));
-  if (safeReasons.length === 0) return <span className="text-[var(--foreground-muted)]">—</span>;
+  const safeReasons = (reasons ?? [])
+    .slice(0, compact ? 2 : 4)
+    .map((reason) => sanitizeText(reason));
+  if (safeReasons.length === 0)
+    return <span className="text-[var(--foreground-muted)]">—</span>;
   return (
-    <ul className={cn("space-y-1 text-xs text-[var(--foreground-muted)]", compact && "truncate")}>
+    <ul
+      className={cn(
+        "space-y-1 text-xs text-[var(--foreground-muted)]",
+        compact && "truncate",
+      )}
+    >
       {safeReasons.map((reason, index) => (
         <li key={`${reason}-${index}`} className="truncate">
           {reason}
@@ -554,36 +627,46 @@ function ReasonList({
 
 function ActionButtons({
   kind,
-  id,
+  item,
   actionKey,
   onAction,
 }: {
   kind: WhatsAppExportReviewKind;
-  id: string | number;
+  item: WhatsAppExportReviewItem;
   actionKey: string | null;
   onAction: (
-    kind: WhatsAppExportReviewKind,
-    id: string | number,
+    kind: "contacts" | "documents",
+    item: WhatsAppExportReviewItem,
     action: "approve" | "reject",
   ) => Promise<void>;
 }) {
-  const approveKey = `${kind}:${id}:approve`;
-  const rejectKey = `${kind}:${id}:reject`;
+  if (kind !== "contacts" && kind !== "documents") {
+    return <span className="text-[var(--foreground-muted)]">—</span>;
+  }
+
+  const approveKey = `${kind}:${item.id}:approve`;
+  const rejectKey = `${kind}:${item.id}:reject`;
+  const approveDisabled =
+    Boolean(actionKey) || (kind === "contacts" && !item.suggested_client_id);
   return (
     <div className="flex justify-end gap-2">
       <Button
         size="sm"
         variant="outline"
-        onClick={() => onAction(kind, id, "approve")}
-        disabled={Boolean(actionKey)}
+        onClick={() => onAction(kind, item, "approve")}
+        disabled={approveDisabled}
         aria-label="Approve review item"
       >
-        {actionKey === approveKey ? <Loader2 className="animate-spin" /> : <Check />}
+        {actionKey === approveKey ? (
+          <Loader2 className="animate-spin" />
+        ) : (
+          <Check />
+        )}
       </Button>
       <Button
         size="sm"
         variant="outline"
-        onClick={() => onAction(kind, id, "reject")}
+        onClick={() => onAction(kind, item, "reject")}
         disabled={Boolean(actionKey)}
         aria-label="Reject review item"
       >
@@ -610,12 +693,20 @@ function EmptyState({ label }: { label: string }) {
   );
 }
 
-function ErrorState({ message, onRetry }: { message: string; onRetry: () => void }) {
+function ErrorState({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
   return (
     <div className="mx-5 mt-4 flex items-center justify-between gap-3 rounded-md border border-[var(--warning)]/40 bg-[var(--warning)]/10 px-4 py-3 text-sm">
       <div className="flex min-w-0 items-center gap-2">
         <AlertTriangle className="h-4 w-4 shrink-0 text-[var(--warning)]" />
-        <span className="truncate text-[var(--foreground)]">{sanitizeText(message)}</span>
+        <span className="truncate text-[var(--foreground)]">
+          {sanitizeText(message)}
+        </span>
       </div>
       <Button size="sm" variant="outline" onClick={onRetry}>
         Retry

--- a/apps/mouth/src/lib/api/whatsapp-export-review.ts
+++ b/apps/mouth/src/lib/api/whatsapp-export-review.ts
@@ -22,7 +22,6 @@ export interface WhatsAppExportCounts {
 
 export interface WhatsAppExportReviewBatch {
   id: string;
-  label?: string | null;
   source_label?: string | null;
   source_basename?: string | null;
   review_status?: WhatsAppExportReviewStatus | null;
@@ -43,16 +42,12 @@ export interface WhatsAppExportReviewItem {
   source_basename?: string | null;
   masked_phone?: string | null;
   display_name?: string | null;
-  title?: string | null;
   suggested_client?: string | null;
   suggested_client_id?: string | null;
   suggested_practice?: string | null;
   suggested_practice_id?: string | null;
-  matched_practice_id?: string | null;
   confidence?: number | null;
-  match_confidence?: number | null;
   reasons?: string[] | null;
-  match_reasons?: string[] | null;
   review_status?: WhatsAppExportReviewStatus | null;
   counts?: WhatsAppExportCounts | null;
   body_excerpt?: string | null;
@@ -78,7 +73,8 @@ export type WhatsAppExportReviewKind =
   | "batches"
   | "contacts"
   | "documents"
-  | "messages";
+  | "messages"
+  | "yopo-case";
 
 export interface WhatsAppExportListParams {
   batchId?: string;
@@ -88,8 +84,10 @@ export interface WhatsAppExportListParams {
 }
 
 export interface WhatsAppExportActionParams {
-  kind: WhatsAppExportReviewKind;
-  id: string | number;
+  kind: "contacts" | "documents";
+  id: string;
+  approvedClientId?: string | null;
+  approvedPracticeId?: string | null;
   reason?: string;
 }
 
@@ -243,9 +241,9 @@ async function requestJson<T>(
 export async function listWhatsAppExportBatches(
   params: WhatsAppExportListParams = {},
 ): Promise<WhatsAppExportReviewBatch[]> {
-  const payload = await requestJson<BackendBatch[] | ListEnvelope<BackendBatch>>(
-    `/batches${buildQuery(params)}`,
-  );
+  const payload = await requestJson<
+    BackendBatch[] | ListEnvelope<BackendBatch>
+  >(`/batches${buildQuery(params)}`);
   return asList(payload).map(mapBatch);
 }
 
@@ -300,16 +298,44 @@ export async function listWhatsAppExportYopoCase(
 export async function approveWhatsAppExportReview(
   params: WhatsAppExportActionParams,
 ): Promise<void> {
-  await requestJson(`/${params.kind}/${encodeURIComponent(String(params.id))}/approve`, {
-    method: "POST",
-    body: JSON.stringify({ reason: params.reason }),
-  });
+  if (params.kind === "contacts") {
+    if (!params.approvedClientId) {
+      throw new Error("Contact approval requires a suggested client.");
+    }
+    await requestJson(
+      `/contacts/${encodeURIComponent(params.id)}/approve-match`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          approved_client_id: Number(params.approvedClientId),
+          note: params.reason,
+        }),
+      },
+    );
+    return;
+  }
+
+  await requestJson(
+    `/documents/${encodeURIComponent(params.id)}/approve-link`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        approved_client_id: params.approvedClientId
+          ? Number(params.approvedClientId)
+          : undefined,
+        approved_practice_id: params.approvedPracticeId
+          ? Number(params.approvedPracticeId)
+          : undefined,
+        note: params.reason,
+      }),
+    },
+  );
 }
 
 export async function rejectWhatsAppExportReview(
   params: WhatsAppExportActionParams,
 ): Promise<void> {
-  await requestJson(`/${params.kind}/${encodeURIComponent(String(params.id))}/reject`, {
+  await requestJson(`/${params.kind}/${encodeURIComponent(params.id)}/reject`, {
     method: "POST",
     body: JSON.stringify({ reason: params.reason }),
   });

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`271 routers · 564 services · 957 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`273 routers · 565 services · 959 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/scripts/whatsapp_export_backfill/import_staging.py
+++ b/scripts/whatsapp_export_backfill/import_staging.py
@@ -1,10 +1,31 @@
+"""WhatsApp export staging importer.
+
+Reads JSONL produced by parse_exports.py and INSERTs records into:
+- whatsapp_export_batches
+- whatsapp_export_documents_staging
+- whatsapp_export_messages_staging
+
+Idempotent: ON CONFLICT DO NOTHING via UNIQUE constraints.
+NEVER writes to clients/practices — staging only.
+"""
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import logging
+import os
+import re
 import sys
 from pathlib import Path
 from typing import Any
+
+import psycopg2
+from psycopg2.extras import Json
+
+logger = logging.getLogger("whatsapp_export_backfill.import_staging")
+
+_MSG_INDEX_RE = re.compile(r":(\d+)$")
 
 
 def summarize_jsonl(path: str | Path) -> dict[str, int]:
@@ -19,16 +40,195 @@ def summarize_jsonl(path: str | Path) -> dict[str, int]:
     return counts
 
 
+def _compute_source_hash(batch: dict[str, Any]) -> str:
+    payload = f"{batch.get('export_root', '')}|{batch.get('chat_path', '')}|{batch.get('batch_id', '')}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _msg_index(message_id: str | None) -> int | None:
+    if not message_id:
+        return None
+    match = _MSG_INDEX_RE.search(message_id)
+    return int(match.group(1)) if match else None
+
+
+def _excerpt(body: str | None, limit: int = 240) -> str | None:
+    if not body:
+        return None
+    body = body.strip()
+    return body[:limit] + ("…" if len(body) > limit else "")
+
+
+def import_jsonl(
+    jsonl_path: Path,
+    conn: Any,
+    *,
+    created_by: str = "import_staging.py",
+) -> dict[str, int]:
+    """Idempotent import. Returns counts of inserted rows."""
+    records: list[dict[str, Any]] = []
+    with jsonl_path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            if not line.strip():
+                continue
+            records.append(json.loads(line))
+
+    batch_records = [r for r in records if r.get("record_type") == "batch"]
+    if len(batch_records) != 1:
+        raise ValueError(f"expected exactly 1 batch record, found {len(batch_records)}")
+    batch = batch_records[0]
+
+    documents = [r for r in records if r.get("record_type") == "document"]
+    messages = [r for r in records if r.get("record_type") == "message"]
+
+    source_hash = _compute_source_hash(batch)
+    inserted = {"batch": 0, "document": 0, "message": 0}
+
+    with conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO whatsapp_export_batches
+                    (source_root, source_label, source_hash, chat_title,
+                     canonical_chat_path, status, metadata, created_by)
+                VALUES (%s, %s, %s, %s, %s, 'parsed', %s, %s)
+                ON CONFLICT (source_hash) DO NOTHING
+                RETURNING id
+                """,
+                (
+                    batch.get("export_root"),
+                    batch.get("batch_id"),
+                    source_hash,
+                    batch.get("batch_id"),
+                    batch.get("chat_path"),
+                    Json(
+                        {
+                            "message_count": batch.get("message_count"),
+                            "parser_record_count": len(records),
+                        }
+                    ),
+                    created_by,
+                ),
+            )
+            row = cur.fetchone()
+            if row is not None:
+                batch_pk = row[0]
+                inserted["batch"] = 1
+            else:
+                cur.execute(
+                    "SELECT id FROM whatsapp_export_batches WHERE source_hash = %s",
+                    (source_hash,),
+                )
+                batch_pk = cur.fetchone()[0]
+
+            for doc in documents:
+                source_relpath = doc.get("source_path")
+                if not source_relpath:
+                    logger.warning("doc missing source_path, skipped: %s", doc.get("filename"))
+                    continue
+                cur.execute(
+                    """
+                    INSERT INTO whatsapp_export_documents_staging
+                        (batch_id, source_relpath, file_name, file_ext,
+                         file_size_bytes, sha256, document_category,
+                         match_reasons, contains_sensitive_data, review_status)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, '[]'::jsonb, true, 'pending')
+                    ON CONFLICT (batch_id, source_relpath) DO NOTHING
+                    """,
+                    (
+                        batch_pk,
+                        source_relpath,
+                        doc.get("filename_nfc") or doc.get("filename"),
+                        Path(doc.get("filename") or "").suffix.lstrip(".").lower() or None,
+                        doc.get("size_bytes"),
+                        doc.get("sha256"),
+                        doc.get("category") or "unknown",
+                    ),
+                )
+                if cur.rowcount == 1:
+                    inserted["document"] += 1
+
+            for msg in messages:
+                idx = _msg_index(msg.get("message_id"))
+                if idx is None:
+                    logger.warning("msg missing index, skipped: %s", msg.get("message_id"))
+                    continue
+                attachments = msg.get("attachments") or []
+                cur.execute(
+                    """
+                    INSERT INTO whatsapp_export_messages_staging
+                        (batch_id, source_relpath, message_index, message_date,
+                         sender_display_name, body, body_excerpt,
+                         has_attachments, attachment_relpaths, review_status)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, 'pending')
+                    ON CONFLICT (batch_id, source_relpath, message_index) DO NOTHING
+                    """,
+                    (
+                        batch_pk,
+                        batch.get("chat_path") or "_chat.txt",
+                        idx,
+                        msg.get("timestamp"),
+                        msg.get("sender"),
+                        msg.get("body"),
+                        _excerpt(msg.get("body")),
+                        bool(attachments),
+                        Json(attachments),
+                    ),
+                )
+                if cur.rowcount == 1:
+                    inserted["message"] += 1
+
+    return inserted
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Dry-run skeleton for future WhatsApp export staging imports."
+        description="Import parsed WhatsApp export JSONL into staging tables (idempotent)."
     )
     parser.add_argument("jsonl_path", type=Path)
-    parser.add_argument("--dry-run", action="store_true", default=True)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print summary only, no DB writes (default behavior preserved).",
+    )
+    parser.add_argument(
+        "--database-url",
+        default=os.environ.get("DATABASE_URL"),
+        help="Postgres DSN (defaults to $DATABASE_URL).",
+    )
+    parser.add_argument("--created-by", default="import_staging.py")
     args = parser.parse_args(argv)
 
     counts = summarize_jsonl(args.jsonl_path)
-    sys.stdout.write(json.dumps({"dry_run": True, "counts": counts}, sort_keys=True) + "\n")
+
+    if args.dry_run or not args.database_url:
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "dry_run": True,
+                    "counts": counts,
+                    "reason": "no_database_url" if not args.database_url else "explicit_dry_run",
+                },
+                sort_keys=True,
+            )
+            + "\n"
+        )
+        return 0
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    conn = psycopg2.connect(args.database_url)
+    try:
+        inserted = import_jsonl(args.jsonl_path, conn, created_by=args.created_by)
+    finally:
+        conn.close()
+
+    sys.stdout.write(
+        json.dumps(
+            {"dry_run": False, "counts": counts, "inserted": inserted},
+            sort_keys=True,
+        )
+        + "\n"
+    )
     return 0
 
 

--- a/scripts/whatsapp_export_backfill/tests/test_import_staging.py
+++ b/scripts/whatsapp_export_backfill/tests/test_import_staging.py
@@ -1,0 +1,127 @@
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from scripts.whatsapp_export_backfill.import_staging import (
+    _compute_source_hash,
+    _excerpt,
+    _msg_index,
+    import_jsonl,
+    summarize_jsonl,
+)
+
+
+def test_compute_source_hash_stable() -> None:
+    batch = {
+        "export_root": "/Users/x/Desktop/WhatsApp Chat - YOPO",
+        "chat_path": "_chat.txt",
+        "batch_id": "WhatsApp Chat - YOPO",
+    }
+    h1 = _compute_source_hash(batch)
+    h2 = _compute_source_hash(batch)
+    assert h1 == h2
+    assert len(h1) == 64
+
+    batch2 = {**batch, "batch_id": "WhatsApp Chat - OTHER"}
+    assert _compute_source_hash(batch2) != h1
+
+
+def test_msg_index_parses_zero_padded_suffix() -> None:
+    assert _msg_index("WhatsApp Chat - YOPO company:000001") == 1
+    assert _msg_index("WhatsApp Chat - YOPO company:000012") == 12
+    assert _msg_index("malformed") is None
+    assert _msg_index(None) is None
+
+
+def test_excerpt_truncates_and_appends_ellipsis() -> None:
+    short = "Hello"
+    assert _excerpt(short) == "Hello"
+
+    long = "x" * 500
+    out = _excerpt(long, limit=240)
+    assert out is not None
+    assert len(out) == 241  # 240 + ellipsis
+    assert out.endswith("…")
+
+    assert _excerpt(None) is None
+    assert _excerpt("") is None
+
+
+def test_summarize_jsonl_counts(tmp_path: Path) -> None:
+    path = tmp_path / "sample.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps({"record_type": "batch"}),
+                json.dumps({"record_type": "document"}),
+                json.dumps({"record_type": "document"}),
+                json.dumps({"record_type": "message"}),
+                "",
+            ]
+        )
+    )
+    counts = summarize_jsonl(path)
+    assert counts == {"batch": 1, "document": 2, "message": 1}
+
+
+def test_import_jsonl_inserts_with_mock_conn(tmp_path: Path) -> None:
+    path = tmp_path / "sample.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "record_type": "batch",
+                        "batch_id": "WhatsApp Chat - YOPO",
+                        "export_root": "/tmp/x",
+                        "chat_path": "_chat.txt",
+                        "message_count": 1,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "record_type": "document",
+                        "batch_id": "WhatsApp Chat - YOPO",
+                        "filename": "a.pdf",
+                        "filename_nfc": "a.pdf",
+                        "source_path": "a.pdf",
+                        "category": "unknown",
+                        "size_bytes": 100,
+                        "sha256": "deadbeef",
+                        "mime_type": "application/pdf",
+                        "message_id": "WhatsApp Chat - YOPO:000001",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "record_type": "message",
+                        "batch_id": "WhatsApp Chat - YOPO",
+                        "message_id": "WhatsApp Chat - YOPO:000001",
+                        "timestamp": "2026-05-15T10:00:00",
+                        "sender": "Makar",
+                        "body": "Hello",
+                        "attachments": ["a.pdf"],
+                    }
+                ),
+            ]
+        )
+    )
+
+    cur = MagicMock()
+    # First INSERT batch returns id=42; subsequent inserts return rowcount=1
+    cur.fetchone.return_value = (42,)
+    cur.rowcount = 1
+
+    conn = MagicMock()
+    # Make context managers return the mocks
+    conn.__enter__.return_value = conn
+    conn.cursor.return_value.__enter__.return_value = cur
+
+    counts = import_jsonl(path, conn)
+    assert counts == {"batch": 1, "document": 1, "message": 1}
+
+    # Verify exactly 3 INSERTs executed (batch, doc, msg) — batch upsert path uses RETURNING
+    insert_calls = [
+        c for c in cur.execute.call_args_list if "INSERT" in c.args[0].upper()
+    ]
+    assert len(insert_calls) == 3


### PR DESCRIPTION
## Summary

**Stacks on PR #815.** Security follow-up that closes a blanket-approval hole the base branch leaves open.

The base branch's `POST /api/whatsapp-export/{contacts|documents}/{id}/approve` calls `_update_*_review` with `approved_client_id=None` — a reviewer can mark a contact "approved" without ever committing to which CRM client it actually matches. The same router already exposes `/approve-match` (contacts) and `/approve-link` (documents) which require explicit IDs.

This PR makes the generic paths reject with HTTP 400 + redirect message, and rewires the frontend to use the match-aware endpoints.

## Origin

These changes were applied by Codex session `019e4ad9-5483-7740-bd20-94b89fa1a800` but isolated into 3 stashes during cleanup of PR #815, then deferred. Review concluded the divergence is the real fix, not noise.

## Backend

`apps/backend-rag/backend/app/routers/whatsapp_export_review.py`:
- `approve_review_item` contacts branch → `raise HTTPException(400, "Use /contacts/{id}/approve-match with approved_client_id")`
- `approve_review_item` documents branch → `raise HTTPException(400, "Use /documents/{id}/approve-link for document approvals")`
- Batches and messages unchanged.

`apps/backend-rag/backend/tests/unit/routers/test_whatsapp_export_review.py`:
- New `test_generic_approve_blocks_contacts_without_explicit_match` — asserts 400 + no UPDATE SQL
- New `test_generic_approve_blocks_documents_without_explicit_link` — asserts 400 + no UPDATE SQL

## Frontend (apps/mouth)

`src/lib/api/whatsapp-export-review.ts`:
- `approveWhatsAppExportReview` switches on `params.kind`, POSTs to `/contacts/{id}/approve-match` or `/documents/{id}/approve-link`
- Contact approval throws client-side if `approvedClientId` missing (defense-in-depth)
- `WhatsAppExportReviewKind` adds `"yopo-case"` union member

`src/app/(workspace)/whatsapp/export-review/page.tsx`:
- `handleAction` signature: `(kind, item, action)` instead of `(kind, id, action)` so the wrapper has match context
- `ActionButtons` disables Approve when `kind === "contacts" && !item.suggested_client_id`

## Test plan

- [x] `pytest backend/tests/unit/routers/test_whatsapp_export_review.py -q` → **11 passed** (9 original + 2 new guards)
- [x] `npm run typecheck` → exit 0
- [x] Prettier check on staged files → clean
- [x] Pre-commit hooks pass (import chain + ruff + format)

## Merge order

1. Merge PR #815 (`cleanup/whatsapp-export-backfill-20260521` → `main`)
2. Rebase this branch onto `main`
3. Merge this PR → `main`

Or merge this directly into PR #815's branch first, then ship as one fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-authored with GPT-5.5 Codex (session 019e4ad9 — original stash contents)