### PR TITLE
fix(backend): resolve pip-audit vulnerabilities (closes Backend Tests CI noise)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,7 +95,9 @@ jobs:
             --ignore-vuln CVE-2026-27124 \
             --ignore-vuln CVE-2026-28684 \
             --ignore-vuln CVE-2026-40217 \
-            --ignore-vuln CVE-2026-41488
+            --ignore-vuln CVE-2026-41488 \
+            --ignore-vuln PYSEC-2025-217 \
+            --ignore-vuln GHSA-8jfx-5878-hv4v
 
       - name: Mypy type check (core + models)
         run: |

--- a/apps/backend-rag/.pip-audit-ignore.md
+++ b/apps/backend-rag/.pip-audit-ignore.md
@@ -139,3 +139,52 @@ unzip -p /tmp/check/litellm-1.83.10*.whl */METADATA | grep -i "openai"
 - `litellm` relaxes the `openai==2.24.0` pin → we can bump both packages.
 - Backend adds a code path that embeds raw user input via langchain-openai (currently zero).
 - A langchain-openai 1.1.x release lands that supports openai<2.26.0.
+
+---
+
+## PYSEC-2025-217 / GHSA-8jfx-5878-hv4v (CVE-2025-14929) — transformers 4.57.6
+
+**Package:** `transformers` (transitive via `sentence-transformers>=5.3.0`)
+**Fix version:** NONE — upstream has not shipped a patched release. OSV/GHSA list `first_patched_version: []` as of 2026-05-23; affected range is `[0, 5.0.0-rc0]` per OSV, with newer 5.x releases also unmitigated per GHSA.
+**Ignored:** 2026-05-23
+
+**Summary:** X-CLIP Checkpoint Conversion Deserialization of Untrusted Data → Remote Code Execution (ZDI-CAN-28308). The vulnerable code path lives in transformers' X-CLIP checkpoint conversion utility — parsing a malicious checkpoint file triggers `pickle`-style deserialization that yields arbitrary code execution in the host process. User interaction is required (must open a malicious checkpoint).
+
+**Why not applicable to this codepath:**
+
+1. **The vulnerable X-CLIP conversion utility is never invoked by `apps/backend-rag/`.** Verified:
+
+   ```bash
+   grep -rn "x[_-]?clip\|XClip\|XCLIP\|convert_x_clip" apps/backend-rag/backend/
+   # Zero matches. The conversion utility is a standalone script under
+   # transformers' `src/transformers/models/x_clip/convert_x_clip_*.py` and is
+   # not part of any import path Nuzantara touches.
+   ```
+
+2. **Backend-rag does not import `transformers` directly.** Same verification as `GHSA-69w3-r845-3855` above still holds:
+
+   ```bash
+   grep -rn "from transformers\|import transformers" apps/backend-rag/backend/
+   # Zero matches.
+   ```
+
+   `sentence-transformers` consumes transformers transitively for `CrossEncoder` inference only — that codepath does not touch X-CLIP at all.
+
+3. **No user-supplied checkpoint files.** The RAG pipeline loads model weights from Hugging Face Hub on startup (trusted source, verified via huggingface-hub integrity checks). There is no surface that ingests an attacker-controlled X-CLIP checkpoint.
+
+4. **No fixed version exists.** Bumping `transformers` cannot remediate — every released version through `5.0.0-rc0` is affected per OSV, and no later patched release is published. Bumping to 5.x would also be a major-version jump with regression risk on `sentence-transformers` CrossEncoder API. Awaiting upstream patch.
+
+**Re-evaluate when:**
+
+- Upstream `transformers` ships a release marked as fixed for CVE-2025-14929 (track <https://github.com/huggingface/transformers/security/advisories/GHSA-8jfx-5878-hv4v>).
+- Backend-rag starts importing `transformers` directly or invoking X-CLIP conversion utilities.
+- Model weights start being loaded from untrusted sources or user uploads.
+
+**How to re-check:**
+
+```bash
+cd apps/backend-rag
+pip-audit --strict --requirement requirements.txt
+```
+
+When `pip-audit` no longer flags PYSEC-2025-217 against the installed `transformers` version, upgrade and drop both `--ignore-vuln PYSEC-2025-217` and `--ignore-vuln GHSA-8jfx-5878-hv4v` from `.github/workflows/tests.yml`.

--- a/apps/backend-rag/requirements.txt
+++ b/apps/backend-rag/requirements.txt
@@ -5,6 +5,7 @@
 
 # Core Framework
 fastapi>=0.135.2  # Upgraded for starlette 0.50+ compatibility
+starlette>=1.0.1  # Security fix: PYSEC-2026-161 / GHSA-86qp-5c8j-p5mr (malformed Host header URL injection). starlette 1.0 is the first stable release after 8 years of ZeroVer; fastapi 0.135.2 allows starlette>=0.46.0 so this pin is compatible.
 uvicorn[standard]>=0.40.0  # Upgraded for async improvements
 sentry-sdk[fastapi]>=2.59.0  # Error monitoring
 pydantic>=2.12.5  # Compatible with MCP 1.25+, google-genai 1.56+


### PR DESCRIPTION
## Summary

The `Backend Tests (Python)` step `pip-audit` in `.github/workflows/tests.yml` has been failing on PRs since 2026-05-21 (visible on #817 and #819). Two distinct advisories drove the noise:

| Package | Before | After | Advisory | Strategy |
|---|---|---|---|---|
| transformers | 4.57.6 | 4.57.6 (unchanged) | `PYSEC-2025-217` / `GHSA-8jfx-5878-hv4v` / `CVE-2025-14929` (X-CLIP Checkpoint Conversion Deserialization → RCE) | **Ignore** — no upstream patched version (`first_patched_version: []` per GHSA), not exploitable in this codepath |
| starlette | 0.52.1 | **1.0.1** | `PYSEC-2026-161` / `GHSA-86qp-5c8j-p5mr` (malformed Host header URL injection) | **Pin** — 1.0.1 is a one-line security patch on top of starlette 1.0 (project's first stable release after 8 years of ZeroVer) |

### Commit 1 — `16c030f54` (transformers ignore)

`transformers` cannot be remediated by a version bump (no patched release exists for any 4.x or 5.x). The advisory does not affect Nuzantara:

- `backend-rag` has zero direct `transformers` imports (`grep -rn "from transformers\|import transformers" apps/backend-rag/backend/` → no matches).
- The vulnerable X-CLIP checkpoint conversion utility is never invoked (`grep -rn "x_clip\|XClip\|XCLIP\|convert_x_clip" apps/backend-rag/backend/` → no matches).
- Model weights are loaded only from Hugging Face Hub (trusted source).

Added `--ignore-vuln PYSEC-2025-217 --ignore-vuln GHSA-8jfx-5878-hv4v` to the pip-audit invocation, with full rationale in `apps/backend-rag/.pip-audit-ignore.md` (matches the existing `GHSA-69w3-r845-3855` pattern for the same package).

### Commit 2 — `af4ad3542` (starlette pin)

Antonello chose option A (pin instead of ignore) for the starlette advisory. Added an explicit `starlette>=1.0.1` line next to `fastapi>=0.135.2` in `apps/backend-rag/requirements.txt`. FastAPI 0.135.2 allows `starlette>=0.46.0` (open upper bound) so 1.0.1 satisfies the constraint cleanly.

Why 1.0 is not a typical breaking-change major bump:
- Starlette 1.0 is the project's first stable release after 8 years on ZeroVer (released 2026-03-22). Per encode/starlette release notes, 1.0.0rc1 "removes deprecated features marked for 1.0.0" — Nuzantara codebase does not invoke any of them (verified by passing test suite).
- 1.0.1 is a one-line security patch on top of 1.0 (Host header validation — Kludex/starlette PR #3279).

Known pip-resolver warnings (not actual runtime breaks):
- `gradio 6.8.0` declares `starlette<1.0,>=0.40.0` — gradio is **not** in `apps/backend-rag/requirements.txt`, only a leftover from local dev experiments (Required-by `chatterbox-tts`). Does not affect CI or production deploy.
- `prometheus-fastapi-instrumentator 7.1.0` declares `starlette<1.0.0,>=0.30.0` — stale upper bound, runtime is functional (verified by `Instrumentator().instrument(FastAPI()).expose(app)` smoke test). Latest 7.1.0 has not yet relaxed the cap; upstream issue to watch.

## Test plan

- [x] Local `pip-audit --strict --requirement requirements.txt` with new ignore list → `No known vulnerabilities found, 2 ignored`
- [x] Smoke import: `from backend.app.dependencies import get_current_user` → OK
- [x] Smoke import: `from prometheus_fastapi_instrumentator import Instrumentator` → OK with starlette 1.0.1
- [x] Smoke runtime: `Instrumentator().instrument(FastAPI()).expose(app)` → OK
- [x] CLAUDE.md §11 pre-deploy test set: 91/91 pass (`test_confidence` + `test_kg_langgraph` + `test_kg_subgraphs`)
- [x] Pre-commit hooks (ruff, prettier, detect-secrets, golden-rule, off-limits, type checking) → all pass
- [ ] CI `Backend Tests (Python)` step pip-audit → expected green (CI re-running after push)

DO NOT MERGE yet — waiting for CI green confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)