### PR TITLE
fix(migrations): mig 192 IF EXISTS guard for bridge_outbox (closes CI Backend Tests)

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/192_bridge_outbox_jsonb_double_encoding_repair.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/192_bridge_outbox_jsonb_double_encoding_repair.sql
@@ -36,10 +36,29 @@
 -- rollout window, old-code instances may still write new double-encoded
 -- rows. A second manual run after full rollout is safe.
 
+-- Defensive guard: `bridge_outbox` is created by legacy migration 107
+-- (`apps/backend-rag/backend/migrations/migration_107_bridge_outbox.py`)
+-- which lives in the legacy .py system and is NOT auto-discovered by the
+-- v2 runner (`migration_manager.py:discover_migrations` globs only
+-- `migrations_v2/*.sql`). Mig 107 was applied manually on prod pre-
+-- 2026-04-18 (table exists in production), but fresh CI Postgres does
+-- NOT have it. Without this guard, `UPDATE bridge_outbox …` aborts the
+-- entire migration run with `relation "bridge_outbox" does not exist`
+-- and the suite stops at mig 192 forever. The IF NOT EXISTS check makes
+-- this migration a no-op when the table is absent — repair will run
+-- when (if) mig 107 is promoted to v2 (separate ticket).
 DO $$
 DECLARE
     n_repaired bigint;
 BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+         WHERE table_schema = 'public' AND table_name = 'bridge_outbox'
+    ) THEN
+        RAISE NOTICE 'm192 jsonb repair: bridge_outbox absent — skipping (legacy mig 107 not yet promoted to v2)';
+        RETURN;
+    END IF;
+
     UPDATE bridge_outbox
        SET payload = (payload #>> '{}')::jsonb
      WHERE jsonb_typeof(payload) = 'string'


### PR DESCRIPTION
## Summary

Mig 192 (`192_bridge_outbox_jsonb_double_encoding_repair.sql`) is a data-repair migration that assumes `bridge_outbox` table exists. On prod this is true (legacy `migration_107_bridge_outbox.py` applied manually pre-2026-04-18). On fresh CI Postgres the table is missing — v2 runner globs only `migrations_v2/*.sql` and never discovers legacy `.py` migrations.

**Symptom unmasked by PR #824**: pip-audit was previously short-circuiting Backend Tests workflow; now the job advances and fails on mig 192 with `relation "bridge_outbox" does not exist`, aborting the entire suite.

## Fix

Wrap the repair body in defensive guard:

```sql
IF NOT EXISTS (
    SELECT 1 FROM information_schema.tables
     WHERE table_schema = 'public' AND table_name = 'bridge_outbox'
) THEN
    RAISE NOTICE 'm192 jsonb repair: bridge_outbox absent — skipping ...';
    RETURN;
END IF;
```

| Scenario | Pre-fix | Post-fix |
|---|---|---|
| Prod (table EXISTS) | UPDATE runs + RAISE NOTICE | identical (UPDATE runs + RAISE NOTICE) |
| CI fresh (table ABSENT) | `UndefinedTableError` aborts suite | RAISE NOTICE skip, suite continues |

## Empirical verification

Via asyncpg tx rollback (both scenarios within one transaction, rolled back so prod untouched):

```
=== Scenario A: table EXISTS ===
PASS: migration 192 runs without error on existing bridge_outbox

=== Scenario B: table ABSENT (CI-like) ===
PASS: migration 192 IF EXISTS guard skips cleanly on absent bridge_outbox
```

## Follow-up (out of scope)

The structural gap remains: legacy `migration_107_bridge_outbox.py` should be promoted to `migrations_v2/107_bridge_outbox.sql` so the v2 runner discovers it. Documented in this migration's comment block as separate ticket.

## Test plan

- [x] Pre-commit hooks PASS (ruff, prettier, detect-secrets, golden-rule, off-limits, FastAPI import chain)
- [x] Empirical: both scenarios verified via asyncpg tx rollback
- [ ] CI: Backend Tests "Apply database migrations" step should now PASS (was failing on mig 192)
- [ ] CI: all 4 required checks (E2E, MCP, Frontend, Detect Secrets) still PASS

## Refs

- PR #824 (smasked this bug)
- Cicatrix scar 2026-05-22 family: overbroad-regex anti-pattern (`SQL_DESTRUCTIVE_IN_CONTENT` guardrails-static.py was blocking this exact fix until earlier today's diff-aware patch landed in `~/.claude/hooks/guardrails-static.py` + daemon)
- Investigation: agent `a6881a89d8679c1f2` (background agent identified root cause)

🤖 Generated with [Claude Code](https://claude.com/claude-code)