### PR TITLE
feat(wa-dashboard): M1.3 frontend scaffolding — Next.js 16 + SSE live stream

### DIFF
--- a/apps/wa-dashboard/.gitignore
+++ b/apps/wa-dashboard/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+.next/
+out/
+dist/
+build/
+*.log
+.env*.local
+.DS_Store
+next-env.d.ts

--- a/apps/wa-dashboard/README.md
+++ b/apps/wa-dashboard/README.md
@@ -1,0 +1,49 @@
+# wa-dashboard
+
+Local-only Next.js 16 app for the Bali Zero team WhatsApp inbox.
+
+**M1 scope**: read-only SSE live stream of all team WA messages, RBAC-filtered server-side.
+
+## Stack
+- Next.js 16 + React 19 + Tailwind v4
+- SSE via native EventSource → `/api/v1/wa-dashboard/stream`
+- Zustand store (1000-message rolling buffer)
+- react-virtuoso virtualized list
+
+## Dev
+
+```bash
+cd apps/wa-dashboard
+npm install
+WA_DASHBOARD_BACKEND_URL=http://localhost:8080 npm run dev
+# open http://localhost:3030
+```
+
+For production backend:
+
+```bash
+WA_DASHBOARD_BACKEND_URL=https://nuzantara-rag.fly.dev npm run dev
+```
+
+Auth: cookie-based JWT from `nuzantara-rag` backend. Browser must already
+have a valid session (login via main app first).
+
+## Architecture
+
+```
+EventSource(/api/v1/wa-dashboard/stream)
+  ├─ open      → status=open
+  ├─ wa_message → useInboxStore.pushMessage()
+  ├─ keepalive  → no-op
+  └─ error      → reconnect with exponential backoff + jitter
+```
+
+`Last-Event-ID` header is auto-managed by the browser EventSource API —
+on reconnect, missed messages are replayed via the backend
+`fetch_replay()` query (devils-advocate v3 fix #11).
+
+## What's NOT here (M1 scope boundary)
+- No outbound (POST /send is M3, gated on UU PDP compliance docs)
+- No thread/conversation grouping (M2 routers)
+- No search, no attention queue, no Web Components fancy chat bubbles
+- No tests (manual smoke for M1)

--- a/apps/wa-dashboard/next.config.ts
+++ b/apps/wa-dashboard/next.config.ts
@@ -1,0 +1,17 @@
+import type { NextConfig } from "next";
+
+const config: NextConfig = {
+  reactStrictMode: true,
+  async rewrites() {
+    const backend =
+      process.env.WA_DASHBOARD_BACKEND_URL || "http://localhost:8080";
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${backend}/api/:path*`,
+      },
+    ];
+  },
+};
+
+export default config;

--- a/apps/wa-dashboard/package.json
+++ b/apps/wa-dashboard/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "wa-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Local-only Bali Zero team WhatsApp inbox dashboard (M1 read-only)",
+  "scripts": {
+    "dev": "next dev --port 3030",
+    "build": "next build",
+    "start": "next start --port 3030",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.62.7",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.469.0",
+    "next": "^16.2.5",
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
+    "react-virtuoso": "^4.12.3",
+    "tailwind-merge": "^2.5.5",
+    "zustand": "^5.0.2"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4",
+    "@types/node": "^22",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "tailwindcss": "^4",
+    "typescript": "^5.7"
+  }
+}

--- a/apps/wa-dashboard/postcss.config.mjs
+++ b/apps/wa-dashboard/postcss.config.mjs
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};

--- a/apps/wa-dashboard/src/app/globals.css
+++ b/apps/wa-dashboard/src/app/globals.css
@@ -1,0 +1,28 @@
+@import "tailwindcss";
+
+@theme {
+  --color-bg: #0a0a0a;
+  --color-surface: #141414;
+  --color-surface-2: #1a1a1a;
+  --color-border: #262626;
+  --color-text: #e5e5e5;
+  --color-text-muted: #737373;
+  --color-accent: #facc15;
+  --color-incoming: #1e3a8a;
+  --color-outgoing: #14532d;
+}
+
+:root {
+  color-scheme: dark;
+}
+
+html,
+body {
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    sans-serif;
+}

--- a/apps/wa-dashboard/src/app/layout.tsx
+++ b/apps/wa-dashboard/src/app/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import "./globals.css";
+import { QueryProvider } from "./providers";
+
+export const metadata: Metadata = {
+  title: "Bali Zero — WA Team Inbox",
+  description: "Local-only team WhatsApp dashboard (read-only M1)",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <QueryProvider>{children}</QueryProvider>
+      </body>
+    </html>
+  );
+}

--- a/apps/wa-dashboard/src/app/page.tsx
+++ b/apps/wa-dashboard/src/app/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useWaSse } from "@/hooks/use-wa-sse";
+import { InboxStream } from "@/components/InboxStream";
+import { StreamStatus } from "@/components/StreamStatus";
+import { useInboxStore } from "@/lib/store";
+
+export default function HomePage() {
+  useWaSse();
+  const messageCount = useInboxStore((s) => s.messages.length);
+
+  return (
+    <main className="h-screen flex flex-col bg-neutral-950">
+      <header className="border-b border-neutral-800 px-6 py-3 flex items-center justify-between">
+        <div>
+          <h1 className="text-base font-semibold text-neutral-100">
+            Bali Zero — Team WA Inbox
+          </h1>
+          <p className="text-xs text-neutral-500">
+            Local read-only mirror · M1 · {messageCount} message
+            {messageCount === 1 ? "" : "s"}
+          </p>
+        </div>
+        <StreamStatus />
+      </header>
+      <InboxStream />
+    </main>
+  );
+}

--- a/apps/wa-dashboard/src/app/providers.tsx
+++ b/apps/wa-dashboard/src/app/providers.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
+
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  const [client] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: { staleTime: 30_000, refetchOnWindowFocus: false },
+        },
+      }),
+  );
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}

--- a/apps/wa-dashboard/src/components/InboxStream.tsx
+++ b/apps/wa-dashboard/src/components/InboxStream.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useInboxStore } from "@/lib/store";
+import { Virtuoso } from "react-virtuoso";
+import { MessageRow } from "./MessageRow";
+
+export function InboxStream() {
+  const messages = useInboxStore((s) => s.messages);
+  if (messages.length === 0) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-neutral-500 text-sm">
+        Waiting for live messages...
+      </div>
+    );
+  }
+  return (
+    <Virtuoso
+      data={messages}
+      itemContent={(_, message) => <MessageRow message={message} />}
+      followOutput="smooth"
+      atBottomThreshold={120}
+      className="flex-1"
+    />
+  );
+}

--- a/apps/wa-dashboard/src/components/MessageRow.tsx
+++ b/apps/wa-dashboard/src/components/MessageRow.tsx
@@ -1,0 +1,76 @@
+import type { WaMessage } from "@/types/wa-message";
+import { cn } from "@/lib/cn";
+import {
+  ArrowDownLeft,
+  ArrowUpRight,
+  Users,
+  AlertTriangle,
+} from "lucide-react";
+
+interface Props {
+  message: WaMessage;
+}
+
+export function MessageRow({ message }: Props) {
+  const isIncoming = message.direction === "incoming";
+  const isGroup = message.chat_type === "group";
+  const Arrow = isIncoming ? ArrowDownLeft : ArrowUpRight;
+  const date = message.message_date ? new Date(message.message_date) : null;
+
+  return (
+    <div
+      className={cn(
+        "px-4 py-3 border-b border-neutral-800 hover:bg-neutral-900/40 transition-colors",
+        isIncoming
+          ? "border-l-2 border-l-blue-700"
+          : "border-l-2 border-l-emerald-700",
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <Arrow
+          className={cn(
+            "h-4 w-4 mt-1 flex-shrink-0",
+            isIncoming ? "text-blue-400" : "text-emerald-400",
+          )}
+        />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 text-xs text-neutral-500 mb-1">
+            {isGroup && <Users className="h-3 w-3" />}
+            <span className="font-mono">
+              {message.counterpart_phone ?? "?"}
+            </span>
+            <span>→</span>
+            <span className="font-mono">
+              {message.team_member_phone ?? "?"}
+            </span>
+            {message.attention_priority !== null &&
+              message.attention_priority > 0 && (
+                <span className="ml-auto flex items-center gap-1 text-amber-400">
+                  <AlertTriangle className="h-3 w-3" />P
+                  {message.attention_priority}
+                </span>
+              )}
+            {date && (
+              <span className="ml-auto tabular-nums">
+                {date.toLocaleTimeString("it-IT")}
+              </span>
+            )}
+          </div>
+          <div className="text-sm text-neutral-200 whitespace-pre-wrap break-words">
+            {message.body || (
+              <span className="text-neutral-500 italic">(no body)</span>
+            )}
+          </div>
+          {message.media_type && (
+            <div className="text-xs text-neutral-500 mt-1">
+              [media: {message.media_type}]
+            </div>
+          )}
+        </div>
+        <div className="text-xs text-neutral-600 font-mono tabular-nums">
+          #{message.id}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/wa-dashboard/src/components/StreamStatus.tsx
+++ b/apps/wa-dashboard/src/components/StreamStatus.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useInboxStore } from "@/lib/store";
+import { Circle, AlertCircle, Loader2 } from "lucide-react";
+import { cn } from "@/lib/cn";
+
+const STATUS_COLOR: Record<string, string> = {
+  idle: "text-neutral-500",
+  connecting: "text-yellow-400",
+  open: "text-emerald-400",
+  error: "text-red-400",
+  closed: "text-neutral-600",
+};
+
+export function StreamStatus() {
+  const { status, lastEventId, errorCount } = useInboxStore((s) => s.stream);
+  const color = STATUS_COLOR[status] ?? "text-neutral-500";
+  const Icon =
+    status === "connecting"
+      ? Loader2
+      : status === "error"
+        ? AlertCircle
+        : Circle;
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <Icon
+        className={cn(
+          "h-3 w-3",
+          color,
+          status === "connecting" && "animate-spin",
+        )}
+        fill={status === "open" ? "currentColor" : "none"}
+      />
+      <span className={color}>SSE {status}</span>
+      <span className="text-neutral-500">| last_event_id={lastEventId}</span>
+      {errorCount > 0 && (
+        <span className="text-red-400">| errors={errorCount}</span>
+      )}
+    </div>
+  );
+}

--- a/apps/wa-dashboard/src/hooks/use-wa-sse.ts
+++ b/apps/wa-dashboard/src/hooks/use-wa-sse.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useInboxStore } from "@/lib/store";
+import type { WaMessage } from "@/types/wa-message";
+
+const STREAM_URL = "/api/v1/wa-dashboard/stream";
+const RECONNECT_BASE_MS = 1000;
+const RECONNECT_MAX_MS = 30_000;
+
+/**
+ * Connects to the backend SSE stream and pushes incoming wa_message events
+ * into the Zustand inbox store. Uses native EventSource (browser handles
+ * Last-Event-ID header automatically on reconnect — devils-advocate v3 fix #11).
+ */
+export function useWaSse() {
+  const setStatus = useInboxStore((s) => s.setStreamStatus);
+  const pushMessage = useInboxStore((s) => s.pushMessage);
+  const incrementError = useInboxStore((s) => s.incrementError);
+  const esRef = useRef<EventSource | null>(null);
+  const reconnectMsRef = useRef(RECONNECT_BASE_MS);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const connect = () => {
+      if (cancelled) return;
+      setStatus("connecting");
+      const es = new EventSource(STREAM_URL, { withCredentials: true });
+      esRef.current = es;
+
+      es.addEventListener("open", () => {
+        setStatus("open");
+        reconnectMsRef.current = RECONNECT_BASE_MS;
+      });
+
+      es.addEventListener("wa_message", (ev: MessageEvent<string>) => {
+        try {
+          const msg = JSON.parse(ev.data) as WaMessage;
+          pushMessage(msg);
+        } catch {
+          incrementError();
+        }
+      });
+
+      es.addEventListener("keepalive", () => {
+        // No-op — just confirms the socket is alive.
+      });
+
+      es.addEventListener("error", () => {
+        setStatus("error");
+        incrementError();
+        es.close();
+        esRef.current = null;
+        // Exponential backoff with jitter
+        const delay = Math.min(
+          reconnectMsRef.current + Math.random() * 500,
+          RECONNECT_MAX_MS,
+        );
+        reconnectMsRef.current = Math.min(
+          reconnectMsRef.current * 2,
+          RECONNECT_MAX_MS,
+        );
+        timerRef.current = setTimeout(connect, delay);
+      });
+    };
+
+    connect();
+
+    return () => {
+      cancelled = true;
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (esRef.current) {
+        esRef.current.close();
+        esRef.current = null;
+      }
+      setStatus("closed");
+    };
+  }, [setStatus, pushMessage, incrementError]);
+}

--- a/apps/wa-dashboard/src/lib/cn.ts
+++ b/apps/wa-dashboard/src/lib/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/apps/wa-dashboard/src/lib/store.ts
+++ b/apps/wa-dashboard/src/lib/store.ts
@@ -1,0 +1,52 @@
+import { create } from "zustand";
+import type { WaMessage, SseStreamState } from "@/types/wa-message";
+
+interface InboxStore {
+  messages: WaMessage[];
+  stream: SseStreamState;
+  pushMessage: (m: WaMessage) => void;
+  pushBatch: (batch: WaMessage[]) => void;
+  setStreamStatus: (status: SseStreamState["status"]) => void;
+  setLastEventId: (id: number) => void;
+  incrementError: () => void;
+  clear: () => void;
+}
+
+const MAX_BUFFER = 1000;
+
+export const useInboxStore = create<InboxStore>((set) => ({
+  messages: [],
+  stream: { status: "idle", lastEventId: 0, errorCount: 0 },
+  pushMessage: (m) =>
+    set((s) => ({
+      messages: [...s.messages.slice(-(MAX_BUFFER - 1)), m],
+      stream: {
+        ...s.stream,
+        lastEventId: Math.max(s.stream.lastEventId, m.id),
+      },
+    })),
+  pushBatch: (batch) =>
+    set((s) => {
+      const next = [...s.messages, ...batch].slice(-MAX_BUFFER);
+      const maxId = batch.reduce(
+        (acc, m) => Math.max(acc, m.id),
+        s.stream.lastEventId,
+      );
+      return { messages: next, stream: { ...s.stream, lastEventId: maxId } };
+    }),
+  setStreamStatus: (status) =>
+    set((s) => ({ stream: { ...s.stream, status } })),
+  setLastEventId: (id) =>
+    set((s) => ({
+      stream: { ...s.stream, lastEventId: Math.max(s.stream.lastEventId, id) },
+    })),
+  incrementError: () =>
+    set((s) => ({
+      stream: { ...s.stream, errorCount: s.stream.errorCount + 1 },
+    })),
+  clear: () =>
+    set({
+      messages: [],
+      stream: { status: "idle", lastEventId: 0, errorCount: 0 },
+    }),
+}));

--- a/apps/wa-dashboard/src/types/wa-message.ts
+++ b/apps/wa-dashboard/src/types/wa-message.ts
@@ -1,0 +1,20 @@
+export interface WaMessage {
+  id: number;
+  direction: "incoming" | "outgoing";
+  team_member_phone: string | null;
+  counterpart_phone: string | null;
+  chat_type: "dm" | "group";
+  group_jid: string | null;
+  body: string;
+  message_date: string | null;
+  media_type: string | null;
+  attention_priority: number | null;
+  client_id: number | null;
+  practice_id: number | null;
+}
+
+export interface SseStreamState {
+  status: "idle" | "connecting" | "open" | "error" | "closed";
+  lastEventId: number;
+  errorCount: number;
+}

--- a/apps/wa-dashboard/tsconfig.json
+++ b/apps/wa-dashboard/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/wa-dashboard/tsconfig.json
+++ b/apps/wa-dashboard/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -11,11 +15,27 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
-    "plugins": [{ "name": "next" }],
-    "paths": { "@/*": ["./src/*"] }
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary

M1.3 closes the M1 read-only milestone for the local-only Bali Zero team WhatsApp inbox webapp. Next.js 16 frontend consuming the SSE backend shipped in #826.

**Supersedes #830** (clean cherry-pick from `origin/main`, no parallel-work conflicts).

### Scope (read-only M1)
- `GET /api/v1/wa-dashboard/stream` SSE consumer with auto Last-Event-ID replay
- Live message list (1000-msg rolling buffer, virtualized scroll)
- Per-message direction + group + attention-priority indicators
- SSE connection status pill (idle/connecting/open/error/closed + error counter)

### Stack
- Next.js 16 + React 19 + Tailwind v4 (matches `apps/mouth`)
- Native `EventSource` API — browser auto-manages `Last-Event-ID` (devils-advocate v3 fix #11)
- Zustand store + react-virtuoso virtualization
- TanStack Query ready for M2 REST endpoints
- Dark theme, port 3030, JWT cookie auth

### File layout (16 files, 549 lines)
```
apps/wa-dashboard/
├── package.json, tsconfig.json, next.config.ts, postcss.config.mjs
├── README.md, .gitignore
└── src/
    ├── app/{layout,page,providers,globals.css}
    ├── components/{InboxStream,MessageRow,StreamStatus}
    ├── hooks/use-wa-sse.ts
    ├── lib/{store,cn}
    └── types/wa-message.ts
```

### Verification (local)
- ✅ `npm install` — 55 packages in 19s
- ✅ `npm run typecheck` — 0 errors
- ✅ `npm run build` — Compiled in 1278ms, 3 static pages
- Manual dev smoke pending (requires JWT cookie from main app)

### What's NOT here
- M2 routers REST (`/threads`, `/messages`, `/search`, `/attention`)
- M3 outbound POST `/send` — gated on UU PDP compliance
- No tests (manual smoke for M1; M2 introduces vitest)

## Test plan
- [x] `npm install` clean
- [x] `npm run typecheck` 0 errors
- [x] `npm run build` clean
- [ ] `npm run dev` → page renders, SSE connects, status pill goes `open`
- [ ] Verify 401 fallback when no JWT cookie present
- [ ] Send a test WA message → appears live in stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)