### PR TITLE
fix(wa-dashboard): register SSE router in router_registration.py — empirical 404 on prod

### DIFF
--- a/apps/backend-rag/backend/app/setup/router_registration.py
+++ b/apps/backend-rag/backend/app/setup/router_registration.py
@@ -129,6 +129,7 @@ def include_routers(api: FastAPI) -> None:
         visa_check,  # [4APPS] Homepage Visa Check app (Clock + Match branches)
         visa_oracle,
         voice,
+        wa_dashboard_stream,
         wa_mirror_messages,
         webhooks,
         websocket,
@@ -285,6 +286,7 @@ def include_routers(api: FastAPI) -> None:
         whatsapp_conversations.router,
     )  # Omnichannel WhatsApp conversations API (dashboard only)
     api.include_router(wa_mirror_messages.router)  # Read-only wa-mirror CRM timeline API
+    api.include_router(wa_dashboard_stream.router)  # WA Team Inbox SSE live stream (M1 read-only)
     api.include_router(instagram_chat.router)  # Instagram DM auto-reply via RAG
     api.include_router(instagram_chat.webhook_router)  # [NEW] Instagram webhook
     api.include_router(intel_lake.router)  # Intel Lake Wave 1 ingest (mig 168)
@@ -498,6 +500,7 @@ def include_light_routers(api: FastAPI) -> None:
         twitter,  # RE-ENABLED 2026-04-29 (P0-6 zero-crash audit) — CRC was actually working
         visa_check,  # [4APPS] Homepage Visa Check app (Clock + Match branches)
         visa_oracle,
+        wa_dashboard_stream,
         wa_mirror_messages,
         webhooks,
         websocket,
@@ -604,6 +607,7 @@ def include_light_routers(api: FastAPI) -> None:
     api.include_router(twitter.webhook_router)  # P0-6 re-enabled 2026-04-29
     api.include_router(whatsapp_conversations.router)
     api.include_router(wa_mirror_messages.router)  # /api/wa/messages read-only mirror timeline
+    api.include_router(wa_dashboard_stream.router)  # WA Team Inbox SSE live stream (M1 read-only)
     api.include_router(instagram_chat.router)
     api.include_router(instagram_chat.webhook_router)
     api.include_router(webhooks.router)


### PR DESCRIPTION
## Problem (empirical)

After PR #826 (M1.2 backend) merged + deployed, the SSE endpoint returns 404 on prod even though the router file is deployed and imports cleanly:

\`\`\`bash
$ curl https://nuzantara-rag.fly.dev/api/v1/wa-dashboard/stream
{\"detail\":\"Authentication required\"}  # middleware blocks first

$ curl -H \"X-Debug-Key: zantara-debug-2024\" https://nuzantara-rag.fly.dev/api/v1/wa-dashboard/stream
{\"detail\":\"Not Found\"}  # route actually missing in FastAPI

$ fly ssh console -C 'ls /app/backend/app/routers/wa_dashboard_stream.py'
/app/backend/app/routers/wa_dashboard_stream.py  # file deployed

$ fly ssh ... 'python -c \"from backend.app.routers.wa_dashboard_stream import router; print(router.routes)\"'
[Route('/api/v1/wa-dashboard/stream'), Route('/api/v1/wa-dashboard/stream/health')]  # routes exist

$ /openapi.json grep wa-dashboard
0 paths  # NOT registered at runtime
\`\`\`

## Root cause

PR #826 added \`wa_dashboard_stream\` to \`ROUTER_MANIFEST\` (router_manifest.py:325-329) but the runtime FastAPI registration in \`router_registration.py\` uses **explicit \`api.include_router()\` calls**, not the manifest. The manifest is documentation; the explicit list is authoritative.

This is identical to cicatrix scar **2026-05-02 PRs #54/#55/#60** — same regression class. The manifest exists precisely to make this mistake structurally impossible, but the parity test \`test_module_router_imports\` only validates that manifest entries CAN be imported, not that they ARE actually wired in registration.

## Fix

4 edits to \`router_registration.py\`:
- \`include_routers()\` (line 132 + 288): add \`wa_dashboard_stream\` to import + \`api.include_router(wa_dashboard_stream.router)\`
- \`include_light_routers()\` (line 503 + 609): same in api/prod path

## Verification

- ✅ Import chain locale clean (\`from backend.app.routers.wa_dashboard_stream import router\`)
- ✅ Pre-commit hooks pass (import chain anti-rogue-AI check)

## Effect

Frontend dashboard (PR #831, https://localhost:3030) was already rendering correctly:
- Header \"Bali Zero — Team WA Inbox\" ✓
- SSE EventSource connecting ✓
- After this fix: EventSource will reach the stream endpoint → pass through auth check → start receiving messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)