### PR TITLE
fix(crm-guardian): align test with Wave 1 extra=ignore flip (unblock main CI)

### DIFF
--- a/apps/backend-rag/backend/tests/unit/services/crm_guardian/test_schemas_v2.py
+++ b/apps/backend-rag/backend/tests/unit/services/crm_guardian/test_schemas_v2.py
@@ -131,17 +131,25 @@ class TestL1ClientSummaryV2:
         assert "narrative_id" not in dump
         assert "narrative_en" in dump
 
-    def test_narrative_id_rejected_as_extra_field(self) -> None:
-        """Trying to pass narrative_id should fail (extra='forbid')."""
-        with pytest.raises(ValidationError):
-            L1ClientSummary(
-                client_id=1,
-                generated_at="2026-05-16T10:00:00Z",
-                source_folder_id="folder_abc",
-                source_file_count=0,
-                source_file_fingerprint="deadbeef",
-                narrative_id="should-be-rejected",  # type: ignore[call-arg]
-            )
+    def test_narrative_id_silently_dropped_as_extra_field(self) -> None:
+        """Passing narrative_id is silently dropped after Wave 1 flip to extra='ignore'.
+
+        2026-05-23 Wave 1 (commit ce61e4d6a): L1ClientSummary root flipped
+        extra='forbid' → 'ignore' to survive Gemini struct-shift under high
+        payload (5/5 fail empirical on re-enqueue cohort 06:54 WITA). Trade-off
+        documented in schemas.py:316-323. Test updated from rejection to
+        silent-drop assertion.
+        """
+        summary = L1ClientSummary(
+            client_id=1,
+            generated_at="2026-05-16T10:00:00Z",
+            source_folder_id="folder_abc",
+            source_file_count=0,
+            source_file_fingerprint="deadbeef",
+            narrative_id="should-be-silently-dropped",  # type: ignore[call-arg]
+        )
+        dump = summary.model_dump()
+        assert "narrative_id" not in dump
 
     def test_cross_folder_summary_roundtrip(self) -> None:
         """Worker writes L1 cross-folder → roundtrip through JSONB serialization."""


### PR DESCRIPTION
## Summary

Main CI `Tests & Coverage` is **RED on every commit since Wave 1** (commit `ce61e4d6a`, 2026-05-23 07:02 WITA). Root cause: `test_narrative_id_rejected_as_extra_field` asserts `ValidationError` on extra fields, but Wave 1 flipped `L1ClientSummary.model_config = ConfigDict(extra="ignore")` — extras are now silently dropped, not rejected.

This test was missed in Wave 1 commit scope. Test updated to assert the intended Wave 1 behavior (silent drop), aligned with documented trade-off at `apps/backend-rag/backend/services/crm_guardian/schemas.py:316-323`.

## Verification

Empirical local PASS:
```
cd apps/backend-rag
PYTHONPATH=. .venv/bin/python -m pytest backend/tests/unit/services/crm_guardian/test_schemas_v2.py::TestL1ClientSummaryV2::test_narrative_id_silently_dropped_as_extra_field -v
→ 1 passed in 0.14s
```

## Impact

Unblocks ALL open PR currently failing Backend Tests due to inherited main:
- PR #829 (pg-proxy Perl prefix)
- PR #823 (Mata-Garuda W1→W21 hardening)
- All future PR merging main with Wave 1 commit

## Test plan

- [ ] CI Backend Tests (Python) → PASS on this branch
- [ ] Post-merge: re-trigger PR #829 + #823 → Backend Tests should pass
- [ ] No regression on other CRM-Guardian schema tests (16 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)