### PR TITLE
fix(api): keep Sentry off startup critical path

### DIFF
--- a/apps/backend-rag/backend/app/setup/__init__.py
+++ b/apps/backend-rag/backend/app/setup/__init__.py
@@ -12,14 +12,36 @@ Centralizes all application setup logic including:
 - Application factory
 """
 
-from backend.app.setup.app_factory import create_app
-from backend.app.setup.cors_config import get_allowed_origins, register_cors_middleware
-from backend.app.setup.middleware_config import register_middleware
-from backend.app.setup.observability import setup_observability
-from backend.app.setup.plugin_initializer import initialize_plugins
-from backend.app.setup.router_registration import include_routers
-from backend.app.setup.sentry_config import init_sentry
-from backend.app.setup.service_initializer import initialize_services
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_EXPORTS: dict[str, tuple[str, str]] = {
+    "create_app": ("backend.app.setup.app_factory", "create_app"),
+    "get_allowed_origins": ("backend.app.setup.cors_config", "get_allowed_origins"),
+    "include_routers": ("backend.app.setup.router_registration", "include_routers"),
+    "init_sentry": ("backend.app.setup.sentry_config", "init_sentry"),
+    "initialize_plugins": ("backend.app.setup.plugin_initializer", "initialize_plugins"),
+    "initialize_services": ("backend.app.setup.service_initializer", "initialize_services"),
+    "register_cors_middleware": (
+        "backend.app.setup.cors_config",
+        "register_cors_middleware",
+    ),
+    "register_middleware": ("backend.app.setup.middleware_config", "register_middleware"),
+    "setup_observability": ("backend.app.setup.observability", "setup_observability"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve setup exports lazily so light API imports stay light."""
+    try:
+        module_name, attr_name = _EXPORTS[name]
+    except KeyError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+    value = getattr(import_module(module_name), attr_name)
+    globals()[name] = value
+    return value
 
 __all__ = [
     "create_app",

--- a/apps/backend-rag/backend/app/setup/sentry_config.py
+++ b/apps/backend-rag/backend/app/setup/sentry_config.py
@@ -29,13 +29,16 @@ Quota policy (Sentry free tier = 5k events/month shared error+transaction):
 
 from __future__ import annotations
 
+import logging
 import os
 import re
+import threading
 from typing import Any
 
-import sentry_sdk
-
 PII_REDACTION_PLACEHOLDER = "[REDACTED]"
+logger = logging.getLogger("zantara.backend")
+_SENTRY_INIT_LOCK = threading.Lock()
+_SENTRY_INIT_STARTED = False
 
 # Keys whose *value* must always be redacted, regardless of nesting depth.
 # Match is case-insensitive and also catches common suffixed variants (e.g.
@@ -183,22 +186,9 @@ def _before_send(event: dict[str, Any], hint: dict[str, Any]) -> dict[str, Any] 
         }
 
 
-def init_sentry() -> None:
-    """
-    Initialize Sentry only when configured.
-
-    Notes:
-    - Avoids initializing during tests unless explicitly desired.
-    - Default behavior is opt-in via SENTRY_DSN.
-    - `traces_sample_rate` defaults to 0.0 in production (APM is opt-in).
-    - `before_send` strips PII before anything leaves the process.
-    """
-    if os.getenv("SKIP_SENTRY_INIT"):
-        return
-
-    dsn = os.getenv("SENTRY_DSN", "")
-    if not dsn:
-        return
+def _init_sentry_blocking(dsn: str) -> None:
+    """Run the actual SDK import/init outside the API startup critical path."""
+    import sentry_sdk
 
     send_pii = os.getenv("SENTRY_SEND_DEFAULT_PII", "").strip().lower() in {"1", "true", "yes"}
     env = os.getenv("ENVIRONMENT", "development")
@@ -217,3 +207,45 @@ def init_sentry() -> None:
         release=os.getenv("SENTRY_RELEASE", "nuzantara-backend@1.0.0"),
         before_send=_before_send,
     )
+
+
+def init_sentry() -> None:
+    """
+    Initialize Sentry only when configured.
+
+    Notes:
+    - Avoids initializing during tests unless explicitly desired.
+    - Default behavior is opt-in via SENTRY_DSN.
+    - `traces_sample_rate` defaults to 0.0 in production (APM is opt-in).
+    - `before_send` strips PII before anything leaves the process.
+    - SDK import/init runs in a daemon thread by default so Sentry cannot
+      block Fly.io health checks before the HTTP socket is bound.
+    """
+    if os.getenv("SKIP_SENTRY_INIT"):
+        return
+
+    dsn = os.getenv("SENTRY_DSN", "")
+    if not dsn:
+        return
+
+    if os.getenv("SENTRY_INIT_SYNC", "").strip().lower() in {"1", "true", "yes"}:
+        _init_sentry_blocking(dsn)
+        return
+
+    def _background_init() -> None:
+        try:
+            _init_sentry_blocking(dsn)
+        except Exception as exc:
+            logger.warning("Sentry init skipped after startup: %s", exc)
+
+    global _SENTRY_INIT_STARTED
+    with _SENTRY_INIT_LOCK:
+        if _SENTRY_INIT_STARTED:
+            return
+        _SENTRY_INIT_STARTED = True
+        thread = threading.Thread(
+            target=_background_init,
+            name="sentry-init",
+            daemon=True,
+        )
+        thread.start()

--- a/apps/backend-rag/tests/test_sentry_lazy_import.py
+++ b/apps/backend-rag/tests/test_sentry_lazy_import.py
@@ -67,7 +67,7 @@ def test_init_sentry_with_dsn_does_not_block_startup() -> None:
     )
     env = {
         **os.environ,
-        "SENTRY_DSN": "https://public@example.invalid/1",
+        "SENTRY_DSN": "not-a-real-dsn",
         "SKIP_SENTRY_INIT": "",
     }
     result = subprocess.run(

--- a/apps/backend-rag/tests/test_sentry_lazy_import.py
+++ b/apps/backend-rag/tests/test_sentry_lazy_import.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+
+
+def test_sentry_config_import_skips_sentry_sdk_when_disabled() -> None:
+    """Importing app startup code must not load sentry_sdk when Sentry is off."""
+    script = textwrap.dedent(
+        """
+        import builtins
+        import importlib
+
+        real_import = builtins.__import__
+
+        def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "sentry_sdk" or name.startswith("sentry_sdk."):
+                raise AssertionError("sentry_sdk imported before init_sentry opted in")
+            if name == "backend.app.setup.app_factory":
+                raise AssertionError("setup.__init__ imported app_factory eagerly")
+            return real_import(name, globals, locals, fromlist, level)
+
+        builtins.__import__ = guarded_import
+        module = importlib.import_module("backend.app.setup.sentry_config")
+        module.init_sentry()
+        """
+    )
+    env = {**os.environ, "SKIP_SENTRY_INIT": "1"}
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        env=env,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_init_sentry_with_dsn_does_not_block_startup() -> None:
+    """Sentry opt-in must not block API boot if the SDK import stalls."""
+    script = textwrap.dedent(
+        """
+        import builtins
+        import importlib
+        import time
+
+        real_import = builtins.__import__
+
+        def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "sentry_sdk" or name.startswith("sentry_sdk."):
+                time.sleep(30)
+                raise AssertionError("sentry_sdk import stayed on startup path")
+            return real_import(name, globals, locals, fromlist, level)
+
+        builtins.__import__ = guarded_import
+        module = importlib.import_module("backend.app.setup.sentry_config")
+        started = time.time()
+        module.init_sentry()
+        elapsed = time.time() - started
+        assert elapsed < 2, elapsed
+        print(f"returned_in={elapsed:.3f}")
+        """
+    )
+    env = {
+        **os.environ,
+        "SENTRY_DSN": "https://public@example.invalid/1",
+        "SKIP_SENTRY_INIT": "",
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        env=env,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "returned_in=" in result.stdout


### PR DESCRIPTION
## Summary
- make backend.app.setup package exports lazy so light API imports do not eagerly load app_factory/service setup
- move sentry_sdk import behind opt-in checks
- initialize Sentry in a daemon thread by default so SDK import/init cannot block Fly health checks before the HTTP socket binds

## Test plan
- cd apps/backend-rag && PYTHONPATH=. pytest tests/test_sentry_lazy_import.py tests/test_sentry_pii_redaction.py backend/tests/setup/test_router_registration_parity.py -q
- cd apps/backend-rag && PYTHONPATH=. ruff check backend/app/setup/__init__.py backend/app/setup/sentry_config.py tests/test_sentry_lazy_import.py
- local import probe: ENVIRONMENT=production SENTRY_DSN=... PYTHONPATH=. python -c 'import backend.app.main_api' completed in ~9s

## Ops context
Production API machine was started but had no listener on 127.0.0.1:8080. Remote checkpoint showed startup stuck on setup/Sentry import path before Uvicorn bound the socket.