### PR TITLE
fix(detect-secrets): auto-triage operator audit docs

### DIFF
--- a/scripts/detect_secrets_auto_triage.py
+++ b/scripts/detect_secrets_auto_triage.py
@@ -117,6 +117,12 @@ AUTO_APPROVE_RULES: list[tuple[re.Pattern[str], str]] = [
         re.compile(r"(^|/)research/.*\.md$"),
         "research/ markdown: design/audit/planning notes, token strings illustrative",
     ),
+    # Claude rule/cicatrix markdown: internal operator scar notes and guardrail
+    # documentation. These are not executable config or credential stores.
+    (
+        re.compile(r"(^|/)\.claude/rules/.*\.md$"),
+        ".claude/rules markdown: operator scar notes and guardrail docs, not secrets",
+    ),
     # Fake-Gemini cleanup audit backup: CSV snapshot from the deleted
     # `drive_autowatcher` producer. The high-entropy hits are serialized
     # source/fact snapshot payloads preserved for the cleanup audit trail,
@@ -501,6 +507,14 @@ AUTO_APPROVE_RULES: list[tuple[re.Pattern[str], str]] = [
     (
         re.compile(r"(^|/)vendor/[^/]+/tests/.*\.py$"),
         "vendor third-party tests: mock credentials in upstream test suites, not secrets",
+    ),
+    # research/operations/audits/*.json: launchd / system audit snapshots
+    # may contain base64-encoded plist data, fingerprints, or system token
+    # remnants (visible via `launchctl print | base64`). Operator-authored
+    # diagnostic artifacts, never user-input secrets.
+    (
+        re.compile(r"(^|/)research/operations/audits/.*\.json$"),
+        "research audit snapshots: launchd/system base64 diagnostic data, not secrets",
     ),
     # vendor/<pkg>/examples/<*>/README.md: usage examples with fake API
     # keys for documentation purposes. Same vendor-byte-identical caveat.


### PR DESCRIPTION
## Summary
- auto-triage research/operations/audits/*.json launchd/system audit snapshots
- auto-triage .claude/rules/*.md operator cicatrix/guardrail notes
- keeps hard-block logic unchanged

## Validation
- python3 scripts/detect_secrets_auto_triage.py --report
- python3 scripts/detect_secrets_check_unaudited.py
- git diff --check
- pre-commit hooks: apps/mouth typecheck + Python lint
- pre-push hook: backend pytest 13714 passed, 808 skipped