### PR TITLE
fix(wr2): reconcile fact-checked Canva drafts

### DIFF
--- a/scripts/tests/test_wr2_canva_reconcile.py
+++ b/scripts/tests/test_wr2_canva_reconcile.py
@@ -1,0 +1,67 @@
+"""Unit tests for scripts/wr2_canva_reconcile.py.
+
+The reconciler exists for late Canva Desktop completions: the skill can write
+carousel_canva.json after the Python worker timed out. It must therefore match
+the same pre-render statuses that canva-apply consumes, including the
+fact-checked state `drafts_imaged_checked`.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+RECONCILE_PATH = SCRIPTS_DIR / "wr2_canva_reconcile.py"
+
+
+@pytest.fixture
+def reconcile_mod():
+    """Load wr2_canva_reconcile fresh from scripts/."""
+    sys.modules.pop("wr2_canva_reconcile", None)
+    spec = importlib.util.spec_from_file_location("wr2_canva_reconcile", RECONCILE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["wr2_canva_reconcile"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_fetch_unfinished_includes_fact_checked_status(reconcile_mod):
+    """Late Canva output for `drafts_imaged_checked` must be discoverable."""
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[])
+
+    asyncio.run(reconcile_mod._fetch_unfinished(conn))
+
+    sql = conn.fetch.call_args[0][0]
+    assert "drafts_imaged" in sql
+    assert "drafts" in sql
+    assert "drafts_imaged_facted" in sql
+    assert "drafts_imaged_checked" in sql
+
+
+def test_apply_update_allows_fact_checked_status(reconcile_mod):
+    """The UPDATE guard must allow the same statuses as the SELECT."""
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value="UPDATE 1")
+
+    asyncio.run(
+        reconcile_mod._apply_update(
+            conn,
+            uuid.uuid4(),
+            "DAHITEST123",
+            "https://www.canva.com/design/DAHITEST123/edit",
+            "https://www.canva.com/design/DAHITEST123/view",
+        )
+    )
+
+    sql = conn.execute.call_args[0][0]
+    assert "drafts_imaged" in sql
+    assert "drafts" in sql
+    assert "drafts_imaged_facted" in sql
+    assert "drafts_imaged_checked" in sql

--- a/scripts/wr2_canva_reconcile.py
+++ b/scripts/wr2_canva_reconcile.py
@@ -13,8 +13,9 @@ Symptom (observed 2026-05-10 03:48 WITA on draft de69f035):
   still NULL.
 - Operator has to UPDATE manually (which is what happened tonight).
 
-This script reconciles. Default mode: scan all drafts in
-`drafts_imaged` / `drafts` status, check the latest
+This script reconciles. Default mode: scan all pre-render drafts consumed
+by canva-apply (`drafts`, `drafts_imaged`, `drafts_imaged_facted`,
+`drafts_imaged_checked`), check the latest
 `carousel_canva.json` for a matching topic, UPDATE if confirmed.
 
 Usage:
@@ -80,7 +81,12 @@ async def _fetch_unfinished(conn: asyncpg.Connection) -> list[asyncpg.Record]:
         """
         SELECT id, topic, status, canva_design_id
           FROM war_room_drafts
-         WHERE status IN ('drafts_imaged', 'drafts')
+         WHERE status IN (
+             'drafts_imaged',
+             'drafts',
+             'drafts_imaged_facted',
+             'drafts_imaged_checked'
+         )
            AND canva_edit_url IS NULL
          ORDER BY created_at DESC
          LIMIT 20
@@ -105,7 +111,12 @@ async def _apply_update(
                status           = 'rendered',
                updated_at       = NOW()
          WHERE id = $1
-           AND status IN ('drafts_imaged', 'drafts')
+           AND status IN (
+               'drafts_imaged',
+               'drafts',
+               'drafts_imaged_facted',
+               'drafts_imaged_checked'
+           )
         """,
         draft_id,
         design_id,


### PR DESCRIPTION
## Summary
- Allow wr2_canva_reconcile.py to match the same pre-render statuses consumed by canva-apply, including drafts_imaged_facted and drafts_imaged_checked.
- Add unit coverage so late Canva Desktop completions for fact-checked drafts remain reconcilable.

## Test plan
- PYTHONPATH=. pytest scripts/tests/test_wr2_canva_reconcile.py -q
- git diff --check