### PR TITLE
🎨 Palette: Enhance accessibility and localization for chat citations

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2026-04-30 - [Shared Locale Hook for Chat Micro-frontend]
 **Learning:** In applications where certain routes (like `/chat`) are architecturally isolated from the main `I18nProvider`, duplicating locale-detection logic across components leads to inconsistencies and maintenance overhead. Consolidating this into a shared `useChatLocale` hook that synchronizes with `localStorage` ensures a unified language experience across all chat-specific components.
 **Action:** Use a shared `useChatLocale` hook for any components in the chat interface that require multi-language support (Tool Indicators, Badges, Panels).
+
+## 2026-05-02 - [Interactive Citation and Verification States]
+**Learning:** For components that toggle supplemental information (like citations or verification details), synchronizing the visual state (rotating chevrons) with accessibility attributes (`aria-expanded`) and providing clear localized context is essential. Using a container-level focus indicator (`.focus-ring`) on the trigger button improves navigation for keyboard users without adding visual clutter.
+**Action:** Always pair `aria-expanded` with CSS transitions for height/opacity on collapsible panels. Ensure localized labels are consistent across related components (e.g., Badge vs Panel).

--- a/apps/mouth/src/components/chat/MessageBubble.tsx
+++ b/apps/mouth/src/components/chat/MessageBubble.tsx
@@ -542,6 +542,7 @@ function MessageBubbleComponent({
                 <TeamVerificationBadge
                   status={message.metadata.nlm_status}
                   domainLabel={message.metadata.nlm_domain_label}
+                  isExpanded={showCitations}
                   onToggleCitations={() => setShowCitations((prev) => !prev)}
                 />
               )}

--- a/apps/mouth/src/components/chat/NLMCitationPanel.test.tsx
+++ b/apps/mouth/src/components/chat/NLMCitationPanel.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { NLMCitationPanel } from "./NLMCitationPanel";
+
+// Mock useChatLocale
+vi.mock("@/hooks/useChatLocale", () => ({
+  useChatLocale: vi.fn(() => "en"),
+}));
+
+import { useChatLocale } from "@/hooks/useChatLocale";
+
+describe("NLMCitationPanel", () => {
+  const mockCitations = [
+    {
+      source_file: "test_file.pdf",
+      section: "Section 1",
+      excerpt: "Test excerpt",
+      page: 1,
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders localized title in English", () => {
+    vi.mocked(useChatLocale).mockReturnValue("en");
+    render(
+      <NLMCitationPanel
+        citations={mockCitations}
+        domainLabel="Legal"
+        expanded={false}
+        onToggle={() => {}}
+      />
+    );
+    expect(screen.getByText(/Official Sources — Legal/i)).toBeDefined();
+  });
+
+  it("renders localized title in Italian", () => {
+    vi.mocked(useChatLocale).mockReturnValue("it");
+    render(
+      <NLMCitationPanel
+        citations={mockCitations}
+        domainLabel="Legal"
+        expanded={false}
+        onToggle={() => {}}
+      />
+    );
+    expect(screen.getByText(/Fonti ufficiali — Legal/i)).toBeDefined();
+  });
+
+  it("calls onToggle when header is clicked", () => {
+    const onToggle = vi.fn();
+    render(
+      <NLMCitationPanel
+        citations={mockCitations}
+        domainLabel="Legal"
+        expanded={false}
+        onToggle={onToggle}
+      />
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(onToggle).toHaveBeenCalled();
+  });
+
+  it("has correct aria-expanded attribute", () => {
+    const { rerender } = render(
+      <NLMCitationPanel
+        citations={mockCitations}
+        domainLabel="Legal"
+        expanded={false}
+        onToggle={() => {}}
+      />
+    );
+    expect(screen.getByRole("button").getAttribute("aria-expanded")).toBe("false");
+
+    rerender(
+      <NLMCitationPanel
+        citations={mockCitations}
+        domainLabel="Legal"
+        expanded={true}
+        onToggle={() => {}}
+      />
+    );
+    expect(screen.getByRole("button").getAttribute("aria-expanded")).toBe("true");
+  });
+});

--- a/apps/mouth/src/components/chat/NLMCitationPanel.tsx
+++ b/apps/mouth/src/components/chat/NLMCitationPanel.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import React from "react";
-import { BookOpen, ChevronDown, ChevronUp, FileText } from "lucide-react";
+import { BookOpen, ChevronDown, FileText } from "lucide-react";
+import { useChatLocale } from "@/hooks/useChatLocale";
 
 interface NLMCitation {
   source_file: string;
@@ -17,12 +18,23 @@ interface NLMCitationPanelProps {
   onToggle: () => void;
 }
 
+const LABELS: Record<string, string> = {
+  en: "Official Sources",
+  it: "Fonti ufficiali",
+  id: "Sumber Resmi",
+  fr: "Sources officielles",
+  ru: "Официальные источники",
+};
+
 export const NLMCitationPanel: React.FC<NLMCitationPanelProps> = ({
   citations,
   domainLabel,
   expanded,
   onToggle,
 }) => {
+  const locale = useChatLocale();
+  const title = LABELS[locale] || LABELS.en;
+
   return (
     <div className="mt-3 rounded-lg border-l-2 border-amber-600 overflow-hidden">
       {/* Header — always visible, toggles expand */}
@@ -34,10 +46,15 @@ export const NLMCitationPanel: React.FC<NLMCitationPanelProps> = ({
       >
         <div className="flex items-center gap-2 text-xs font-medium text-amber-600">
           <BookOpen size={14} />
-          <span>Fonti ufficiali — {domainLabel}</span>
+          <span>
+            {title} — {domainLabel}
+          </span>
         </div>
         <div className="text-zinc-400">
-          {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+          <ChevronDown
+            size={14}
+            className={`transition-transform duration-200 ${expanded ? "rotate-180" : ""}`}
+          />
         </div>
       </button>
 

--- a/apps/mouth/src/components/chat/TeamVerificationBadge.test.tsx
+++ b/apps/mouth/src/components/chat/TeamVerificationBadge.test.tsx
@@ -36,4 +36,27 @@ describe("TeamVerificationBadge", () => {
     render(<TeamVerificationBadge status="verified" domainLabel="Imigrasi" />);
     expect(screen.getByText(/Diverifikasi oleh tim Imigrasi/i)).toBeDefined();
   });
+
+  it("applies aria-expanded based on isExpanded prop", () => {
+    const { rerender } = render(
+      <TeamVerificationBadge
+        status="verified"
+        domainLabel="Legal"
+        onToggleCitations={() => {}}
+        isExpanded={false}
+      />
+    );
+    const button = screen.getByRole("button");
+    expect(button.getAttribute("aria-expanded")).toBe("false");
+
+    rerender(
+      <TeamVerificationBadge
+        status="verified"
+        domainLabel="Legal"
+        onToggleCitations={() => {}}
+        isExpanded={true}
+      />
+    );
+    expect(button.getAttribute("aria-expanded")).toBe("true");
+  });
 });

--- a/apps/mouth/src/components/chat/TeamVerificationBadge.tsx
+++ b/apps/mouth/src/components/chat/TeamVerificationBadge.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { BadgeCheck } from "lucide-react";
+import { BadgeCheck, ChevronDown } from "lucide-react";
 import { useChatLocale } from "@/hooks/useChatLocale";
 
 export type VerificationStatus = "verified" | "consulting" | "not_needed";
@@ -7,15 +7,16 @@ export type VerificationStatus = "verified" | "consulting" | "not_needed";
 interface TeamVerificationBadgeProps {
   status?: VerificationStatus;
   domainLabel?: string;
+  isExpanded?: boolean;
   onToggleCitations?: () => void;
 }
 
 const LABELS: Record<string, (domain: string) => string> = {
   en: (d) => `Our ${d} specialists are verifying`,
-  it: (d) => `Verificato dal team ${d}`,
-  id: (d) => `Diverifikasi oleh tim ${d}`,
-  fr: (d) => `Vérifié par l'équipe ${d}`,
-  ru: (d) => `Подтверждено командой ${d}`,
+  it: (d) => `I nostri specialisti ${d} stanno verificando`,
+  id: (d) => `Spesialis ${d} kami sedang memverifikasi`,
+  fr: (d) => `Nos spécialistes ${d} vérifient`,
+  ru: (d) => `Наши специалисты по ${d} проверяют`,
 };
 
 const VERIFIED_LABELS: Record<string, (domain: string) => string> = {
@@ -29,6 +30,7 @@ const VERIFIED_LABELS: Record<string, (domain: string) => string> = {
 export const TeamVerificationBadge: React.FC<TeamVerificationBadgeProps> = ({
   status = "verified",
   domainLabel = "Legal",
+  isExpanded = false,
   onToggleCitations,
 }) => {
   const locale = useChatLocale();
@@ -50,11 +52,16 @@ export const TeamVerificationBadge: React.FC<TeamVerificationBadgeProps> = ({
       <button
         type="button"
         onClick={onToggleCitations}
-        className={`${baseClassName} hover:text-accent transition-colors cursor-pointer`}
-        aria-label={label}
+        className={`${baseClassName} hover:text-accent transition-colors cursor-pointer focus-ring rounded px-1 -ml-1`}
+        aria-expanded={isExpanded}
       >
         <BadgeCheck size={12} className="shrink-0" aria-hidden="true" />
         <span>{label}</span>
+        <ChevronDown
+          size={10}
+          className={`shrink-0 transition-transform duration-200 ${isExpanded ? "rotate-180" : ""}`}
+          aria-hidden="true"
+        />
       </button>
     );
   }
@@ -62,7 +69,7 @@ export const TeamVerificationBadge: React.FC<TeamVerificationBadgeProps> = ({
   return (
     <div className={baseClassName}>
       <BadgeCheck size={12} className="shrink-0" aria-hidden="true" />
-      <span aria-label={label}>{label}</span>
+      <span>{label}</span>
     </div>
   );
 };


### PR DESCRIPTION
This PR implements micro-UX and accessibility improvements for the chat interface in `apps/mouth`.

### 💡 What
- **TeamVerificationBadge**: Converted from a static indicator to an interactive toggle (when applicable) with proper `aria-expanded` state, a rotating chevron icon, and consistent keyboard focus styles using `.focus-ring`.
- **NLMCitationPanel**: Replaced hardcoded Italian strings with localized labels using the shared `useChatLocale` hook. Added `aria-expanded` to the trigger and synchronized it with a rotating chevron.
- **MessageBubble**: Orchestrated state between the verification badge and the citation panel to ensure a seamless toggle experience.

### 🎯 Why
- Users needed clearer visual feedback that the verification badge was linked to the citations below.
- Non-English/Italian users were seeing hardcoded "Fonti ufficiali" strings.
- Keyboard users lacked a visible focus indicator on the verification toggle.

### ♿ Accessibility
- Synchronized `aria-expanded` with UI state.
- Added `.focus-ring` for keyboard visibility.
- Removed redundant `aria-label` attributes where the text content was already sufficient.
- Ensured non-submit buttons have `type="button"`.

### ✅ Verification
- Ran Vitest unit tests: `pnpm --filter mouth exec vitest run src/components/chat/NLMCitationPanel.test.tsx src/components/chat/TeamVerificationBadge.test.tsx` (Passed).
- Visual verification performed via Playwright screenshots in the chat environment.

---
*PR created automatically by Jules for task [14534222696964918584](https://jules.google.com/task/14534222696964918584) started by @Balizero1987*