### PR TITLE
feat(mouth/chat): TeamVerificationBadge expandable + NLMCitationPanel localized (PR #835 UI subset)

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,23 +1,34 @@
 ## 2026-04-25 - [Semantic Lists and Sibling Interactive Elements]
+
 **Learning:** Using generic `div` wrappers with `onClick` for lists of interactive items makes them inaccessible to keyboard and screen reader users. Refactoring to semantic `<ul>`, `<li>`, and `<button>` elements provides immediate a11y benefits. Additionally, nesting interactive elements (like a delete button inside a clickable container) is invalid HTML and requires fragile event propagation logic; refactoring them to sibling buttons within a list item is a cleaner, more robust pattern.
 **Action:** Always use `<ul>` and `<li>` for collections of items. Ensure interactive items are semantic `<button>` or `<a>` tags. Use sibling structures instead of nesting for multiple actions on a single item.
 
 ## 2026-04-25 - [Keyboard Visibility for Actions]
+
 **Learning:** Actions that only appear on hover (e.g., a "Delete" button) are inaccessible to keyboard-only users unless they are also triggered by focus.
 **Action:** Use Tailwind's `group-focus-within:opacity-100` (or similar focus-based classes) alongside `group-hover:opacity-100` to ensure secondary actions become visible when a user tabs through a list.
 
 ## 2026-04-25 - [Interactive Menu Dismissal Patterns]
+
 **Learning:** For interactive popover menus (like attachment or user menus), users expect to dismiss them using the 'Escape' key or by clicking outside. Implementing this requires a `useEffect` hook combined with a `useRef` on the menu container to detect click targets and event listener cleanup.
 **Action:** Always implement 'Escape' and click-outside dismissal for ephemeral UI menus. Use a local `useEffect` to manage these global event listeners.
 
 ## 2026-04-26 - [Descriptive Action Labels and Explicit Button Types]
+
 **Learning:** Generic action labels like "Delete" in lists are ambiguous for screen reader users. Including the item's title in the `aria-label` (e.g., "Delete conversation: [Title]") provides crucial context. Additionally, omitting `type="button"` on non-submit buttons can lead to accidental form submissions and inconsistent browser behavior.
 **Action:** Always include identifying information in `aria-label` for repetitive actions in lists. Consistently apply `type="button"` to all interactive elements that are not meant to submit a form.
 
 ## 2026-04-28 - [Consistent Focus Indicators with focus-ring Utility]
+
 **Learning:** In highly customized dark UIs, default browser focus outlines are often invisible or clash with the aesthetic. Providing a dedicated `.focus-ring` utility class using `focus-visible` ensures that keyboard users have clear, brand-consistent navigation cues without affecting mouse users.
 **Action:** Apply `.focus-ring` to all interactive elements that do not have a robust built-in focus state.
 
 ## 2026-04-30 - [Shared Locale Hook for Chat Micro-frontend]
+
 **Learning:** In applications where certain routes (like `/chat`) are architecturally isolated from the main `I18nProvider`, duplicating locale-detection logic across components leads to inconsistencies and maintenance overhead. Consolidating this into a shared `useChatLocale` hook that synchronizes with `localStorage` ensures a unified language experience across all chat-specific components.
 **Action:** Use a shared `useChatLocale` hook for any components in the chat interface that require multi-language support (Tool Indicators, Badges, Panels).
+
+## 2026-05-18 - [Stateful Indicators and Localized Panels]
+
+**Learning:** Collapsible panels and toggle buttons should provide clear visual feedback for their state. Using a rotating chevron icon synchronized with the 'aria-expanded' attribute ensures both visual and assistive technology users understand the component's state. Additionally, hardcoded strings in a multi-language app should always be refactored to use the shared localization hooks.
+**Action:** Always include a rotating chevron for toggles. Synchronize 'aria-expanded' with the UI state. Use 'useChatLocale' for all UI text in the chat interface.

--- a/apps/mouth/src/components/chat/MessageBubble.tsx
+++ b/apps/mouth/src/components/chat/MessageBubble.tsx
@@ -543,6 +543,7 @@ function MessageBubbleComponent({
                   status={message.metadata.nlm_status}
                   domainLabel={message.metadata.nlm_domain_label}
                   onToggleCitations={() => setShowCitations((prev) => !prev)}
+                  isExpanded={showCitations}
                 />
               )}
 

--- a/apps/mouth/src/components/chat/NLMCitationPanel.tsx
+++ b/apps/mouth/src/components/chat/NLMCitationPanel.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import React from "react";
-import { BookOpen, ChevronDown, ChevronUp, FileText } from "lucide-react";
+import { BookOpen, ChevronDown, FileText } from "lucide-react";
+import { useChatLocale } from "@/hooks/useChatLocale";
 
 interface NLMCitation {
   source_file: string;
@@ -17,12 +18,23 @@ interface NLMCitationPanelProps {
   onToggle: () => void;
 }
 
+const LABELS: Record<string, string> = {
+  en: "Official Sources",
+  it: "Fonti ufficiali",
+  id: "Sumber Resmi",
+  fr: "Sources officielles",
+  ru: "Официальные источники",
+};
+
 export const NLMCitationPanel: React.FC<NLMCitationPanelProps> = ({
   citations,
   domainLabel,
   expanded,
   onToggle,
 }) => {
+  const locale = useChatLocale();
+  const labelPrefix = LABELS[locale] || LABELS.en;
+
   return (
     <div className="mt-3 rounded-lg border-l-2 border-amber-600 overflow-hidden">
       {/* Header — always visible, toggles expand */}
@@ -33,11 +45,17 @@ export const NLMCitationPanel: React.FC<NLMCitationPanelProps> = ({
         className="w-full flex items-center justify-between gap-2 px-3 py-2 bg-zinc-900/50 hover:bg-zinc-900/70 transition-colors text-left focus-ring"
       >
         <div className="flex items-center gap-2 text-xs font-medium text-amber-600">
-          <BookOpen size={14} />
-          <span>Fonti ufficiali — {domainLabel}</span>
+          <BookOpen size={14} aria-hidden="true" />
+          <span>
+            {labelPrefix} — {domainLabel}
+          </span>
         </div>
         <div className="text-zinc-400">
-          {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+          <ChevronDown
+            size={14}
+            className={`transition-transform duration-200 ${expanded ? "rotate-180" : ""}`}
+            aria-hidden="true"
+          />
         </div>
       </button>
 
@@ -53,7 +71,7 @@ export const NLMCitationPanel: React.FC<NLMCitationPanelProps> = ({
           {citations.map((citation, idx) => (
             <div key={idx} className="flex gap-2.5">
               <div className="flex-shrink-0 mt-0.5 text-amber-600/60">
-                <FileText size={12} />
+                <FileText size={12} aria-hidden="true" />
               </div>
               <div className="min-w-0 space-y-0.5">
                 <p className="text-xs font-medium text-zinc-300 truncate">

--- a/apps/mouth/src/components/chat/TeamVerificationBadge.tsx
+++ b/apps/mouth/src/components/chat/TeamVerificationBadge.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { BadgeCheck } from "lucide-react";
+import { BadgeCheck, ChevronDown } from "lucide-react";
 import { useChatLocale } from "@/hooks/useChatLocale";
 
 export type VerificationStatus = "verified" | "consulting" | "not_needed";
@@ -8,6 +8,7 @@ interface TeamVerificationBadgeProps {
   status?: VerificationStatus;
   domainLabel?: string;
   onToggleCitations?: () => void;
+  isExpanded?: boolean;
 }
 
 const LABELS: Record<string, (domain: string) => string> = {
@@ -30,6 +31,7 @@ export const TeamVerificationBadge: React.FC<TeamVerificationBadgeProps> = ({
   status = "verified",
   domainLabel = "Legal",
   onToggleCitations,
+  isExpanded = false,
 }) => {
   const locale = useChatLocale();
 
@@ -50,11 +52,17 @@ export const TeamVerificationBadge: React.FC<TeamVerificationBadgeProps> = ({
       <button
         type="button"
         onClick={onToggleCitations}
-        className={`${baseClassName} hover:text-accent transition-colors cursor-pointer`}
+        className={`${baseClassName} hover:text-accent transition-colors cursor-pointer focus-ring rounded px-1 -mx-1`}
         aria-label={label}
+        aria-expanded={isExpanded}
       >
         <BadgeCheck size={12} className="shrink-0" aria-hidden="true" />
         <span>{label}</span>
+        <ChevronDown
+          size={10}
+          className={`shrink-0 transition-transform duration-200 ${isExpanded ? "rotate-180" : ""}`}
+          aria-hidden="true"
+        />
       </button>
     );
   }


### PR DESCRIPTION
## Summary

UI subset of original PR #835 cherry-picked after schema/test parts conflicted with #838 (already shipped silent-drop strategy on main).

UI changes:
- TeamVerificationBadge: rotating ChevronDown + aria-expanded state
- NLMCitationPanel: 38-line localized strings + visual state
- MessageBubble: 1-line pass isExpanded prop
- palette.md: 2026-05-18 lesson on Stateful Indicators

Dropped from #835: schemas.py _reject_removed_fields validator (conflicts with #838's silent-drop already on main) + test_schemas_v2 changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)