### PR TITLE
feat(mouth/portal): PortalNotifications accessibility + loading states (PR #805 UI subset)

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -32,3 +32,8 @@
 
 **Learning:** Collapsible panels and toggle buttons should provide clear visual feedback for their state. Using a rotating chevron icon synchronized with the 'aria-expanded' attribute ensures both visual and assistive technology users understand the component's state. Additionally, hardcoded strings in a multi-language app should always be refactored to use the shared localization hooks.
 **Action:** Always include a rotating chevron for toggles. Synchronize 'aria-expanded' with the UI state. Use 'useChatLocale' for all UI text in the chat interface.
+
+## 2026-05-18 - [Loading States and Interaction Feedback in Portal]
+
+**Learning:** Asynchronous actions in the client portal (like marking notifications as read) lacked visual feedback, leading to a "dead" feel during network latency. Providing immediate feedback via spinning icons and disabling buttons during mutations significantly improves the perceived responsiveness and prevents duplicate requests.
+**Action:** Always expose and utilize mutation pending states from hooks to provide visual feedback and disable interactive elements during async operations.

--- a/apps/mouth/src/components/portal/PortalNotifications.tsx
+++ b/apps/mouth/src/components/portal/PortalNotifications.tsx
@@ -61,10 +61,14 @@ export function PortalNotificationsList({
   notifications,
   onMarkRead,
   onMarkAllRead,
+  isMarkingRead,
+  isMarkingAllRead,
 }: {
   notifications: PortalNotification[];
   onMarkRead: (id: number) => void;
   onMarkAllRead: () => void;
+  isMarkingRead?: boolean;
+  isMarkingAllRead?: boolean;
 }) {
   const unread = notifications.filter((n) => !n.read);
 
@@ -78,11 +82,15 @@ export function PortalNotificationsList({
         <span className="text-sm font-semibold">Notifications</span>
         {unread.length > 0 && (
           <button
+            type="button"
             onClick={onMarkAllRead}
-            className="text-xs flex items-center gap-1 transition-opacity hover:opacity-80"
+            disabled={isMarkingAllRead}
+            className="text-xs flex items-center gap-1 transition-opacity hover:opacity-80 focus-ring rounded disabled:opacity-40 disabled:cursor-not-allowed"
             style={{ color: "var(--bz-accent-warm)" }}
           >
-            <CheckCheck className="w-3 h-3" />
+            <CheckCheck
+              className={`w-3 h-3 ${isMarkingAllRead ? "animate-spin" : ""}`}
+            />
             Mark all read
           </button>
         )}
@@ -150,8 +158,10 @@ export function PortalNotificationsList({
               </div>
               {!notif.read && (
                 <button
+                  type="button"
                   onClick={() => onMarkRead(notif.id)}
-                  className="p-1 rounded-md mt-0.5 flex-shrink-0 transition-opacity hover:opacity-80"
+                  disabled={isMarkingRead}
+                  className="p-1 rounded-md mt-0.5 flex-shrink-0 transition-opacity hover:opacity-80 focus-ring disabled:opacity-40 disabled:cursor-not-allowed"
                   style={{ color: "var(--bz-accent-warm)" }}
                   aria-label="Mark as read"
                 >
@@ -167,8 +177,14 @@ export function PortalNotificationsList({
 }
 
 export function PortalNotificationsPopover() {
-  const { notifications, unreadCount, markRead, markAllRead } =
-    usePortalNotifications();
+  const {
+    notifications,
+    unreadCount,
+    markRead,
+    markAllRead,
+    isMarkingRead,
+    isMarkingAllRead,
+  } = usePortalNotifications();
   const [isOpen, setIsOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -197,8 +213,9 @@ export function PortalNotificationsPopover() {
   return (
     <div className="relative" ref={ref}>
       <button
+        type="button"
         onClick={() => setIsOpen(!isOpen)}
-        className="relative p-2 rounded-lg transition-colors hover:bg-white/[0.05]"
+        className="relative p-2 rounded-lg transition-colors hover:bg-white/[0.05] focus-ring"
         aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ""}`}
       >
         <Bell className="w-5 h-5" style={{ color: "var(--bz-text-2)" }} />
@@ -218,6 +235,8 @@ export function PortalNotificationsPopover() {
             notifications={notifications}
             onMarkRead={(id) => markRead(id)}
             onMarkAllRead={() => markAllRead()}
+            isMarkingRead={isMarkingRead}
+            isMarkingAllRead={isMarkingAllRead}
           />
         </div>
       )}

--- a/apps/mouth/src/hooks/usePortalNotifications.ts
+++ b/apps/mouth/src/hooks/usePortalNotifications.ts
@@ -28,6 +28,8 @@ export function usePortalNotifications() {
     notifications: query.data?.notifications ?? [],
     unreadCount: query.data?.unread_count ?? 0,
     isLoading: query.isLoading,
+    isMarkingRead: markRead.isPending,
+    isMarkingAllRead: markAllRead.isPending,
     markRead: markRead.mutate,
     markAllRead: markAllRead.mutate,
   };


### PR DESCRIPTION
Cherry-pick UI subset of PR #805 — dropped tests.yml + pip-audit-ignore.md changes (main has tighter security gate post-W39).

UI improvements: loading states (isMarkingRead/isMarkingAllRead), type='button', focus-ring, disabled styling, animate-spin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)