### PR TITLE
feat(infra): agent worktree broker — SOTA L1 (worktree-per-session enforcement)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,12 @@
 - First-response prefix: `[Pro]` or `[Mini]`.
 - **Air decommissioned 2026-05-05** — handed off to Ari/Bali Zero. Historical references in code/scripts are archaeology, NOT active.
 
+## Agent Worktree Discipline (2026-05-24)
+
+OGNI agent session (subagent dispatch / cron-spawned claude / parallel Claude Code window) DEVE girare sotto `.worktrees/<lane>-<task-id>/` creato via `scripts/agent_start.py`. Il main checkout `~/Desktop/nuzantara` resta read-only per agent — riservato a operator interactive + cicatrix hotfix.
+
+Quick start: `python scripts/agent_start.py --lane <X> --task-id <Y>` → cd output path → spawn agent. Kill switch `AGENT_BROKER_ENABLED=false`. Runbook: `docs/runbooks/agent-worktree-broker.md`. SOTA panel reference: `research/operations/2026-05-24-sota-multi-agent-repo-architecture-synthesis.md`.
+
 ## 2. Behavior & Autonomous Ops
 
 **DO NOT ask the user to write code.** Act first, ask if blocked. Use `Edit`/`Write`/`Bash` without asking permission.

--- a/docs/runbooks/agent-worktree-broker.md
+++ b/docs/runbooks/agent-worktree-broker.md
@@ -1,0 +1,115 @@
+# Runbook — Agent Worktree Broker
+
+> SOTA L1 2026-05-24. Reference: `research/operations/2026-05-24-sota-multi-agent-repo-architecture-synthesis.md`.
+
+## Cosa fa
+
+`scripts/agent_start.py` crea un git worktree isolato per ogni sessione agent (subagent, cron-spawned `claude`, parallel Claude Code window). Risolve la cicatrix 2026-04-29 (incident #1+#2: `git stash` / `git checkout` da sibling che distrugge WIP altrui) e i 17 stash orphan accumulati 2026-05-23.
+
+Invariante (4/4 panel SOTA): due sessioni non condividono mai lo stesso working tree.
+
+## Come usarlo
+
+### Creare un worktree per una nuova task
+
+```bash
+python scripts/agent_start.py --lane wr2 --task-id render-cleanup --ttl-min 60
+# stdout: WORKTREE_READY /Users/nuzantara/Desktop/nuzantara/.worktrees/wr2-render-cleanup
+cd /Users/nuzantara/Desktop/nuzantara/.worktrees/wr2-render-cleanup
+# spawn claude qui (NON nel main checkout)
+```
+
+Effetti:
+
+- Branch nuovo `agent/<hostname>/<lane>/<task-id>` (es. `agent/nuzantara/wr2/render-cleanup`) creato da `--base-branch` (default `main`).
+- Worktree montato sotto `.worktrees/<lane>-<task-id>/`.
+- Symlink env-safe: `apps/backend-rag/.venv`, `apps/backend-rag/.env`, `node_modules/` puntano al main checkout (read-only intent — non modificarli).
+- `.agent-task.json` con metadata (task_id / lane / branch / host / created_at / ttl_minutes / pid / base_branch / worktree_path).
+- Log su `~/logs/agent-broker.log` (rotation 1MB x 5).
+
+### Vedere worktree attivi
+
+```bash
+python scripts/agent_start.py --list
+# TASK              LANE   HOST       AGE_MIN  TTL  WIP  BRANCH
+# render-cleanup    wr2    nuzantara     12.3   60  yes  agent/nuzantara/wr2/render-cleanup
+```
+
+WIP=yes significa file uncommitted (tracked o untracked) presenti.
+
+### Cleanup worktree TTL-expired
+
+```bash
+python scripts/agent_start.py --cleanup
+# WARN: skip <id> (WIP). Commit or stash inside <path>, then re-run --cleanup.
+# removed expired worktree <id> (<path>)
+```
+
+WIP-safe: skippa worktree dirty con WARN. Forza con `--force`.
+
+### Tear down esplicito a fine task
+
+```bash
+python scripts/agent_start.py --release render-cleanup
+# released render-cleanup (branch agent/nuzantara/wr2/render-cleanup deleted)
+```
+
+Il branch viene cancellato SOLO se merged in `base_branch`. Forza con `--force` (es. branch abbandonato senza merge).
+
+### Kill switch (lesson W33)
+
+```bash
+export AGENT_BROKER_ENABLED=false
+python scripts/agent_start.py --lane wr2 --task-id ...
+# ERROR: broker disabled (AGENT_BROKER_ENABLED=false)...
+```
+
+Disabilita create/cleanup/release. `--list` resta abilitato per osservabilità.
+
+## Lane riconosciute
+
+`wr2`, `wr3`, `infra`, `docs`, `db`, `cicatrix-fix`, `mouth` (Subhi reserved), `intel`, `cell`, `organism`, `mata-garuda`, `backend-rag`, `frontend`, `ops`. Lane nuove → aggiungere a `KNOWN_LANES` in `scripts/agent_start.py` o usare `--allow-unknown-lane` una tantum.
+
+## Troubleshooting top 5
+
+### 1. `ERROR: branch '...' already exists`
+
+Un task-id precedente ha lasciato il branch in giro (worktree rimosso ma branch no).
+
+```bash
+git branch -D agent/<host>/<lane>/<task-id>
+# poi ri-eseguire il create
+```
+
+### 2. `ERROR: worktree already exists at .worktrees/<lane>-<id>`
+
+Già attivo. Verifica con `--list`; se l'altra sessione non sta più lavorando, usa `--release <task-id>`.
+
+### 3. Cleanup non rimuove un worktree expired
+
+`--cleanup` skippa worktree con WIP per evitare la cicatrix 2026-04-29 #2. Soluzioni:
+
+- entrare nel worktree, `git add -A && git commit -m "WIP" && git push`, poi `--release <id>`
+- oppure (operator escape) `python scripts/agent_start.py --cleanup --force`
+
+### 4. `release` rifiuta "branch not merged"
+
+Comportamento corretto: protegge dal perdere lavoro non-merged. Soluzioni:
+
+- aprire PR, mergiare, poi `--release <id>`
+- oppure `--release <id> --force` se il branch è davvero abbandonato
+
+### 5. Symlink mancanti dentro il worktree
+
+Il broker crea symlink solo se il target esiste in main. Se `apps/backend-rag/.venv` non è creato, il symlink viene skippato. Crea il venv nel main checkout una volta, poi ricrea il worktree.
+
+## Per Claude (agent) — quick start
+
+OGNI sessione agent dispatch (subagent dispatch, cron-spawned `claude`, parallel Claude Code window) DEVE:
+
+1. `python scripts/agent_start.py --lane <X> --task-id <Y>`
+2. `cd` nel path stampato da `WORKTREE_READY`
+3. Lavorare lì. Mai `git stash` / `git checkout` nel main checkout.
+4. Quando finito: commit + push + `--release <task-id>` (oppure lascia che `--cleanup` lo prenda al prossimo cron tick).
+
+Il main checkout `~/Desktop/nuzantara` è riservato all'operator interactive + cicatrix hotfix.

--- a/scripts/agent_start.py
+++ b/scripts/agent_start.py
@@ -1,0 +1,710 @@
+#!/usr/bin/env python3
+"""SOTA L1 (2026-05-24) — Agent Worktree Broker.
+
+Closes the sibling-collision class documented in cicatrix incidents
+2026-04-29 #1 + #2 (untracked file loss when sibling automation switches
+branches mid-session) and the 17 stash orphans accumulated 2026-05-23.
+
+Convergence 4/4 from the 4-LLM panel (Gemini 3.1 / GPT-5.5 codex /
+DeepSeek V4 Pro / Claude Opus 4.7) on the invariant:
+
+    ∀ w₁,w₂ : session(w₁) ∧ session(w₂)
+    ⇒ working_tree(w₁) ∩ working_tree(w₂) = ∅
+
+Reference: research/operations/2026-05-24-sota-multi-agent-repo-architecture-synthesis.md
+
+Each agent session (subagent dispatch / cron-spawned claude / parallel
+Claude Code window) MUST run inside a dedicated worktree under
+`<REPO_ROOT>/.worktrees/<LANE>-<TASK_ID>/`. The main checkout is
+reserved for operator interactive use + cicatrix hotfixes.
+
+Subcommands:
+    --lane / --task-id      Create a new worktree (default action).
+    --list                  Show active worktrees + age + WIP indicator.
+    --cleanup               Remove worktrees whose TTL expired (WIP-safe).
+    --release <task-id>     Tear down a specific worktree + branch.
+
+Kill switch:
+    AGENT_BROKER_ENABLED=false   Disables every create/cleanup/release op
+                                  (lesson W33). --list stays available.
+
+Logs:
+    ~/logs/agent-broker.log     Rotating (RotatingFileHandler 1MB x 5).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import logging.handlers
+import os
+import re
+import socket
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKTREES_DIR = REPO_ROOT / ".worktrees"
+TASK_METADATA_FILENAME = ".agent-task.json"
+
+# Lanes documented in CLAUDE.md + research synthesis.
+# This is an ALLOW-list for create; --list/--cleanup/--release accept any lane
+# that already has a metadata file on disk (forward-compat for new lanes).
+KNOWN_LANES: set[str] = {
+    "wr2",
+    "wr3",
+    "infra",
+    "docs",
+    "db",
+    "cicatrix-fix",
+    "mouth",  # reserved for Subhi per CLAUDE.md §12
+    "intel",
+    "cell",
+    "organism",
+    "mata-garuda",
+    "backend-rag",
+    "frontend",
+    "ops",
+}
+
+# Lane / task-id validation: lowercase, digits, dash. No slashes (would break
+# the branch ref and the directory path).
+ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9\-]{0,63}$")
+
+# Symlinks created from main checkout into the new worktree (env-safe).
+# Targets are relative paths inside the repo. If the target does not exist in
+# main, the symlink is skipped silently — the agent will still get a working
+# worktree, just without that helper artifact.
+SYMLINK_TARGETS: tuple[tuple[str, str], ...] = (
+    ("apps/backend-rag/.venv", "apps/backend-rag/.venv"),
+    ("apps/backend-rag/.env", "apps/backend-rag/.env"),
+    ("node_modules", "node_modules"),
+)
+
+LOG_DIR = Path.home() / "logs"
+LOG_FILE = LOG_DIR / "agent-broker.log"
+
+KILL_SWITCH_ENV = "AGENT_BROKER_ENABLED"
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+
+def _init_logger() -> logging.Logger:
+    logger = logging.getLogger("agent_broker")
+    if logger.handlers:
+        return logger
+    logger.setLevel(logging.INFO)
+
+    fmt = logging.Formatter(
+        "%(asctime)s %(levelname)s agent_broker[%(process)d] %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S%z",
+    )
+
+    # File handler with rotation (best-effort — failure must not crash the CLI).
+    try:
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
+        fh = logging.handlers.RotatingFileHandler(
+            LOG_FILE, maxBytes=1_048_576, backupCount=5, encoding="utf-8"
+        )
+        fh.setFormatter(fmt)
+        logger.addHandler(fh)
+    except OSError:
+        pass
+
+    sh = logging.StreamHandler(sys.stderr)
+    sh.setLevel(logging.WARNING)
+    sh.setFormatter(fmt)
+    logger.addHandler(sh)
+    return logger
+
+
+logger = _init_logger()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _kill_switch_active() -> bool:
+    """True if the broker is disabled via env var (lesson W33)."""
+    val = os.environ.get(KILL_SWITCH_ENV, "").strip().lower()
+    return val in {"false", "0", "no", "off", "disabled"}
+
+
+def _hostname_short() -> str:
+    """Return the short hostname (first dotted segment), lowercased.
+
+    The hostname is reused as a branch-path segment, so we lowercase + strip
+    anything outside [a-z0-9-].
+    """
+    raw = socket.gethostname().split(".")[0].lower()
+    cleaned = re.sub(r"[^a-z0-9-]", "-", raw).strip("-")
+    return cleaned or "unknown-host"
+
+
+def _validate_id(label: str, value: str) -> None:
+    if not ID_PATTERN.match(value):
+        raise SystemExit(
+            f"ERROR: invalid {label} '{value}' — must match {ID_PATTERN.pattern}"
+        )
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso(ts: str) -> datetime:
+    # Accept both `...Z` and `...+00:00`.
+    if ts.endswith("Z"):
+        ts = ts[:-1] + "+00:00"
+    return datetime.fromisoformat(ts)
+
+
+def _run_git(
+    args: list[str],
+    *,
+    cwd: Path | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Thin wrapper around `git ...` that captures output.
+
+    Returns the CompletedProcess. When check=True (default) raises
+    CalledProcessError with stderr piped into the exception for diagnosis.
+    """
+    cmd = ["git", *args]
+    cwd = cwd or REPO_ROOT
+    logger.debug("git: %s (cwd=%s)", " ".join(cmd), cwd)
+    proc = subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if check and proc.returncode != 0:
+        raise subprocess.CalledProcessError(
+            proc.returncode, cmd, proc.stdout, proc.stderr
+        )
+    return proc
+
+
+def _branch_name(host: str, lane: str, task_id: str) -> str:
+    return f"agent/{host}/{lane}/{task_id}"
+
+
+def _worktree_path(lane: str, task_id: str) -> Path:
+    return WORKTREES_DIR / f"{lane}-{task_id}"
+
+
+# ---------------------------------------------------------------------------
+# Metadata dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TaskMetadata:
+    task_id: str
+    lane: str
+    branch: str
+    host: str
+    created_at: str
+    ttl_minutes: int
+    pid: int
+    base_branch: str
+    worktree_path: str
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "task_id": self.task_id,
+                "lane": self.lane,
+                "branch": self.branch,
+                "host": self.host,
+                "created_at": self.created_at,
+                "ttl_minutes": self.ttl_minutes,
+                "pid": self.pid,
+                "base_branch": self.base_branch,
+                "worktree_path": self.worktree_path,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+
+    @classmethod
+    def from_path(cls, path: Path) -> "TaskMetadata":
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return cls(
+            task_id=data["task_id"],
+            lane=data["lane"],
+            branch=data["branch"],
+            host=data["host"],
+            created_at=data["created_at"],
+            ttl_minutes=int(data["ttl_minutes"]),
+            pid=int(data["pid"]),
+            base_branch=data.get("base_branch", "main"),
+            worktree_path=data.get("worktree_path", ""),
+        )
+
+    def is_expired(self, *, now: datetime | None = None) -> bool:
+        now = now or datetime.now(timezone.utc)
+        try:
+            created = _parse_iso(self.created_at)
+        except ValueError:
+            return False  # malformed timestamp → operator must intervene
+        age_minutes = (now - created).total_seconds() / 60.0
+        return age_minutes > self.ttl_minutes
+
+    def age_minutes(self, *, now: datetime | None = None) -> float:
+        now = now or datetime.now(timezone.utc)
+        try:
+            created = _parse_iso(self.created_at)
+        except ValueError:
+            return -1.0
+        return (now - created).total_seconds() / 60.0
+
+
+# ---------------------------------------------------------------------------
+# Symlink helper
+# ---------------------------------------------------------------------------
+
+
+def _create_symlinks(worktree: Path) -> list[str]:
+    """Create env-safe symlinks from main checkout into the new worktree.
+
+    Returns the list of relative symlink targets actually created (skips any
+    target that does not exist in main, plus any that would clobber an existing
+    file/dir in the worktree).
+    """
+    created: list[str] = []
+    for source_rel, dest_rel in SYMLINK_TARGETS:
+        source = REPO_ROOT / source_rel
+        dest = worktree / dest_rel
+        if not source.exists():
+            logger.debug("symlink skip (no source): %s", source_rel)
+            continue
+        if dest.exists() or dest.is_symlink():
+            logger.debug("symlink skip (dest exists): %s", dest_rel)
+            continue
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            os.symlink(source, dest)
+            created.append(dest_rel)
+        except OSError as exc:
+            logger.warning("symlink failed %s -> %s: %s", dest_rel, source, exc)
+    return created
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: create
+# ---------------------------------------------------------------------------
+
+
+def cmd_create(
+    lane: str,
+    task_id: str,
+    *,
+    ttl_minutes: int = 60,
+    base_branch: str = "main",
+    allow_unknown_lane: bool = False,
+) -> Path:
+    """Create a new worktree + branch + metadata.
+
+    Returns the absolute path to the new worktree.
+
+    Raises SystemExit on validation or git error so the CLI exits non-zero.
+    """
+    if _kill_switch_active():
+        raise SystemExit(
+            f"ERROR: broker disabled ({KILL_SWITCH_ENV}=false). "
+            "Unset or set to 'true' to re-enable."
+        )
+
+    _validate_id("lane", lane)
+    _validate_id("task-id", task_id)
+
+    if lane not in KNOWN_LANES and not allow_unknown_lane:
+        known = ", ".join(sorted(KNOWN_LANES))
+        raise SystemExit(
+            f"ERROR: unknown lane '{lane}'. Known: {known}.\n"
+            f"Pass --allow-unknown-lane to override."
+        )
+
+    if ttl_minutes <= 0:
+        raise SystemExit("ERROR: --ttl-min must be > 0")
+
+    host = _hostname_short()
+    branch = _branch_name(host, lane, task_id)
+    worktree = _worktree_path(lane, task_id)
+
+    if worktree.exists():
+        raise SystemExit(
+            f"ERROR: worktree already exists at {worktree}. "
+            f"Use --release {task_id} first or pick a different task-id."
+        )
+
+    # Pre-flight: branch must not already exist (worktree add -b would fail
+    # with a less-clear error otherwise).
+    existing_branches = _run_git(["branch", "--list", branch]).stdout.strip()
+    if existing_branches:
+        raise SystemExit(
+            f"ERROR: branch '{branch}' already exists. "
+            "Choose a different task-id or delete the stale branch."
+        )
+
+    WORKTREES_DIR.mkdir(parents=True, exist_ok=True)
+
+    logger.info(
+        "creating worktree lane=%s task_id=%s branch=%s base=%s ttl_min=%d",
+        lane,
+        task_id,
+        branch,
+        base_branch,
+        ttl_minutes,
+    )
+
+    try:
+        _run_git(["worktree", "add", "-b", branch, str(worktree), base_branch])
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        raise SystemExit(f"ERROR: git worktree add failed: {stderr}") from exc
+
+    symlinks = _create_symlinks(worktree)
+
+    metadata = TaskMetadata(
+        task_id=task_id,
+        lane=lane,
+        branch=branch,
+        host=host,
+        created_at=_utc_now_iso(),
+        ttl_minutes=ttl_minutes,
+        pid=os.getpid(),
+        base_branch=base_branch,
+        worktree_path=str(worktree),
+    )
+    (worktree / TASK_METADATA_FILENAME).write_text(
+        metadata.to_json(), encoding="utf-8"
+    )
+
+    logger.info(
+        "worktree ready path=%s symlinks=%s", worktree, ",".join(symlinks) or "(none)"
+    )
+    return worktree
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: list
+# ---------------------------------------------------------------------------
+
+
+def _iter_metadata(worktrees_dir: Path | None = None) -> Iterable[TaskMetadata]:
+    # Resolve at call-time (not import-time) so test fixtures that patch
+    # the module-level WORKTREES_DIR after import take effect.
+    worktrees_dir = worktrees_dir if worktrees_dir is not None else WORKTREES_DIR
+    if not worktrees_dir.is_dir():
+        return []
+    out: list[TaskMetadata] = []
+    for entry in sorted(worktrees_dir.iterdir()):
+        meta_path = entry / TASK_METADATA_FILENAME
+        if not meta_path.is_file():
+            continue
+        try:
+            out.append(TaskMetadata.from_path(meta_path))
+        except (OSError, json.JSONDecodeError, KeyError) as exc:
+            logger.warning("skip malformed metadata at %s: %s", meta_path, exc)
+    return out
+
+
+def _worktree_has_wip(worktree: Path) -> bool:
+    """True if the worktree has uncommitted changes (tracked or untracked)."""
+    proc = _run_git(
+        ["status", "--porcelain"], cwd=worktree, check=False
+    )
+    if proc.returncode != 0:
+        # If git can't read the worktree (corrupt) treat as WIP to be safe.
+        return True
+    # Ignore the metadata file itself when computing WIP, otherwise every
+    # freshly created worktree would report dirty.
+    relevant = []
+    for line in proc.stdout.splitlines():
+        # Porcelain v1: first 2 cols are status, then a space, then path.
+        if len(line) < 4:
+            continue
+        path = line[3:].strip()
+        # Strip "->" rename targets.
+        path = path.split(" -> ")[-1].strip().strip('"')
+        if path == TASK_METADATA_FILENAME:
+            continue
+        relevant.append(line)
+    return bool(relevant)
+
+
+def cmd_list() -> int:
+    rows = list(_iter_metadata())
+    if not rows:
+        print("(no active worktrees under .worktrees/)")
+        return 0
+    print(
+        f"{'TASK':<24} {'LANE':<14} {'HOST':<14} "
+        f"{'AGE_MIN':>8} {'TTL':>5} {'WIP':<4} BRANCH"
+    )
+    now = datetime.now(timezone.utc)
+    for meta in rows:
+        wt = Path(meta.worktree_path) if meta.worktree_path else _worktree_path(
+            meta.lane, meta.task_id
+        )
+        wip_flag = "yes" if wt.is_dir() and _worktree_has_wip(wt) else "no"
+        age = meta.age_minutes(now=now)
+        print(
+            f"{meta.task_id:<24} {meta.lane:<14} {meta.host:<14} "
+            f"{age:>8.1f} {meta.ttl_minutes:>5d} {wip_flag:<4} {meta.branch}"
+        )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: cleanup
+# ---------------------------------------------------------------------------
+
+
+def cmd_cleanup(*, force: bool = False) -> int:
+    """Remove expired worktrees. WIP-safe: emits WARNING and skips if dirty.
+
+    Pass force=True to override the WIP guard (operator escape hatch).
+    Returns 0 if every expired worktree was removed cleanly OR no work
+    needed; 1 if at least one removal was skipped/errored.
+    """
+    if _kill_switch_active():
+        raise SystemExit(
+            f"ERROR: broker disabled ({KILL_SWITCH_ENV}=false). Unset to cleanup."
+        )
+
+    rows = list(_iter_metadata())
+    if not rows:
+        print("(nothing to cleanup)")
+        return 0
+
+    now = datetime.now(timezone.utc)
+    issues = 0
+    for meta in rows:
+        if not meta.is_expired(now=now):
+            continue
+        wt = Path(meta.worktree_path) if meta.worktree_path else _worktree_path(
+            meta.lane, meta.task_id
+        )
+        if wt.is_dir() and _worktree_has_wip(wt) and not force:
+            logger.warning(
+                "cleanup skip %s — uncommitted WIP present (use --force)",
+                meta.task_id,
+            )
+            print(
+                f"WARN: skip {meta.task_id} (WIP). "
+                f"Commit or stash inside {wt}, then re-run --cleanup."
+            )
+            issues += 1
+            continue
+        try:
+            _remove_worktree(wt, meta.branch, delete_branch=False)
+            print(f"removed expired worktree {meta.task_id} ({wt})")
+        except subprocess.CalledProcessError as exc:
+            issues += 1
+            logger.error(
+                "cleanup failed %s: %s", meta.task_id, (exc.stderr or "").strip()
+            )
+            print(f"ERROR: cleanup failed for {meta.task_id}: {exc.stderr}")
+    return 0 if issues == 0 else 1
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: release
+# ---------------------------------------------------------------------------
+
+
+def _branch_is_merged(branch: str, base: str = "main") -> bool:
+    """True if every commit on branch is reachable from base."""
+    proc = _run_git(
+        ["rev-list", "--count", f"{base}..{branch}"], check=False
+    )
+    if proc.returncode != 0:
+        return False
+    try:
+        return int(proc.stdout.strip()) == 0
+    except ValueError:
+        return False
+
+
+def _remove_worktree(worktree: Path, branch: str, *, delete_branch: bool) -> None:
+    """Remove worktree via `git worktree remove` and optionally delete branch."""
+    _run_git(["worktree", "remove", "--force", str(worktree)])
+    if delete_branch:
+        # -D allows deleting branches not merged into HEAD (we already verified
+        # merged-into-base separately).
+        _run_git(["branch", "-D", branch])
+
+
+def cmd_release(task_id: str, *, force: bool = False) -> int:
+    """Tear down a worktree by task-id. Branch deleted only if merged into base.
+
+    With --force, the branch is deleted unconditionally (operator escape).
+    """
+    if _kill_switch_active():
+        raise SystemExit(
+            f"ERROR: broker disabled ({KILL_SWITCH_ENV}=false). Unset to release."
+        )
+
+    _validate_id("task-id", task_id)
+    matches = [m for m in _iter_metadata() if m.task_id == task_id]
+    if not matches:
+        raise SystemExit(f"ERROR: no worktree metadata for task-id '{task_id}'")
+    if len(matches) > 1:
+        raise SystemExit(
+            f"ERROR: multiple worktrees for task-id '{task_id}' — "
+            "pass full path manually"
+        )
+    meta = matches[0]
+    wt = Path(meta.worktree_path) if meta.worktree_path else _worktree_path(
+        meta.lane, meta.task_id
+    )
+    base = meta.base_branch or "main"
+
+    if wt.is_dir() and _worktree_has_wip(wt) and not force:
+        raise SystemExit(
+            f"ERROR: worktree {wt} has uncommitted WIP. "
+            "Commit, push, or pass --force."
+        )
+
+    merged = _branch_is_merged(meta.branch, base=base)
+    if not merged and not force:
+        raise SystemExit(
+            f"ERROR: branch {meta.branch} not merged into {base}. "
+            "Open a PR + merge it, or pass --force to delete unconditionally."
+        )
+
+    try:
+        _remove_worktree(wt, meta.branch, delete_branch=True)
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        raise SystemExit(f"ERROR: release failed: {stderr}") from exc
+
+    logger.info("released worktree task_id=%s branch=%s", task_id, meta.branch)
+    print(f"released {task_id} (branch {meta.branch} deleted)")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="agent-start",
+        description=(
+            "Agent Worktree Broker — enforces worktree-per-session for every "
+            "concurrent Claude / subagent / cron session."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  agent-start --lane wr2 --task-id render-cleanup\n"
+            "  agent-start --list\n"
+            "  agent-start --cleanup\n"
+            "  agent-start --release render-cleanup\n"
+        ),
+    )
+    # Operations (mutually exclusive at the group-of-flags level).
+    p.add_argument("--lane", help="Lane identifier (e.g. wr2, infra, docs)")
+    p.add_argument("--task-id", help="Task id (short slug, ticket id, uuid)")
+    p.add_argument(
+        "--ttl-min",
+        type=int,
+        default=60,
+        help="TTL in minutes after which cleanup may reclaim (default: 60)",
+    )
+    p.add_argument(
+        "--base-branch",
+        default="main",
+        help="Base branch to fork from (default: main)",
+    )
+    p.add_argument(
+        "--allow-unknown-lane",
+        action="store_true",
+        help="Permit creating a worktree with a lane not in the known list",
+    )
+
+    p.add_argument(
+        "--list",
+        action="store_true",
+        help="List active worktrees with age + WIP indicator",
+    )
+    p.add_argument(
+        "--cleanup",
+        action="store_true",
+        help="Remove worktrees whose TTL has expired (WIP-safe)",
+    )
+    p.add_argument(
+        "--release",
+        metavar="TASK_ID",
+        help="Tear down a specific worktree + branch (branch must be merged)",
+    )
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="With --cleanup/--release: override WIP and merged-status guards",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    # Dispatch (subcommand flags are mutually exclusive at the semantic level).
+    operations = sum(
+        [bool(args.list), bool(args.cleanup), bool(args.release), bool(args.lane)]
+    )
+    if operations == 0:
+        parser.print_help()
+        return 2
+    if operations > 1:
+        print("ERROR: choose exactly one of --lane/--list/--cleanup/--release")
+        return 2
+
+    if args.list:
+        return cmd_list()
+    if args.cleanup:
+        return cmd_cleanup(force=args.force)
+    if args.release:
+        return cmd_release(args.release, force=args.force)
+
+    # Default: create.
+    if not args.lane or not args.task_id:
+        print("ERROR: --lane AND --task-id are both required to create a worktree")
+        return 2
+
+    worktree = cmd_create(
+        args.lane,
+        args.task_id,
+        ttl_minutes=args.ttl_min,
+        base_branch=args.base_branch,
+        allow_unknown_lane=args.allow_unknown_lane,
+    )
+    # Single-line stdout contract for shell-glue:
+    print(f"WORKTREE_READY {worktree}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_agent_start.py
+++ b/scripts/tests/test_agent_start.py
@@ -1,0 +1,378 @@
+"""SOTA L1 (2026-05-24) — tests for scripts/agent_start.py (Worktree Broker).
+
+Coverage matrix:
+- create worktree happy path (branch + metadata + symlinks + stdout contract)
+- list shows entries with WIP detection
+- cleanup skips worktree with uncommitted WIP and emits WARN
+- cleanup removes worktree past TTL when clean
+- release fails gracefully when branch is not merged into base
+- release succeeds when branch is merged
+- kill-switch (AGENT_BROKER_ENABLED=false) blocks create/cleanup/release but not list
+- input validation rejects malformed lane / task-id
+
+Tests use a temporary git repo + temporary HOME via monkeypatch, so they never
+touch the real ~/Desktop/nuzantara checkout or ~/logs/.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "agent_start.py"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _load_module(repo_root: Path):
+    """Reload agent_start under a fresh REPO_ROOT (overrides module constants)."""
+    spec = importlib.util.spec_from_file_location("agent_start_under_test", SCRIPT_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    # Register before exec_module so dataclass __module__ lookups succeed
+    # (the @dataclass decorator does sys.modules[cls.__module__] in 3.11).
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    mod.REPO_ROOT = repo_root
+    mod.WORKTREES_DIR = repo_root / ".worktrees"
+    return mod
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """Redirect HOME so log handler init writes inside tmp."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("AGENT_BROKER_ENABLED", raising=False)
+    return home
+
+
+@pytest.fixture
+def fake_repo(tmp_path, fake_home, monkeypatch):
+    """Create a fresh git repo with a main branch + 1 commit, return module + path."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    # git init + commit (need identity for the commit to work).
+    env = dict(os.environ)
+    env["GIT_AUTHOR_NAME"] = "Test"
+    env["GIT_AUTHOR_EMAIL"] = "test@example.com"
+    env["GIT_COMMITTER_NAME"] = "Test"
+    env["GIT_COMMITTER_EMAIL"] = "test@example.com"
+
+    def git(*args):
+        return subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    git("init", "-b", "main")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "Test")
+    (repo / "README.md").write_text("seed\n")
+    git("add", "README.md")
+    git("commit", "-m", "seed")
+
+    mod = _load_module(repo)
+    # Patch the module's subprocess git wrapper cwd default to point at our repo.
+    return mod, repo
+
+
+# ---------------------------------------------------------------------------
+# create
+# ---------------------------------------------------------------------------
+
+
+def test_create_happy_path_writes_metadata_and_branch(fake_repo):
+    mod, repo = fake_repo
+    out = mod.cmd_create("wr2", "happy-001", ttl_minutes=30)
+    assert out.is_dir()
+    assert out == repo / ".worktrees" / "wr2-happy-001"
+
+    meta_path = out / mod.TASK_METADATA_FILENAME
+    assert meta_path.is_file()
+    data = json.loads(meta_path.read_text())
+    assert data["task_id"] == "happy-001"
+    assert data["lane"] == "wr2"
+    assert data["branch"].endswith("/wr2/happy-001")
+    assert data["branch"].startswith("agent/")
+    assert data["ttl_minutes"] == 30
+    assert data["base_branch"] == "main"
+
+    # Branch exists.
+    branches = subprocess.run(
+        ["git", "branch", "--list"], cwd=repo, capture_output=True, text=True
+    ).stdout
+    assert data["branch"] in branches
+
+
+def test_create_symlinks_only_when_targets_exist(fake_repo):
+    mod, repo = fake_repo
+    # Create one of the SYMLINK_TARGETS in main so the symlink is exercised.
+    (repo / "apps" / "backend-rag").mkdir(parents=True)
+    (repo / "apps" / "backend-rag" / ".env").write_text("FAKE=1\n")
+    out = mod.cmd_create("infra", "sym-test")
+    link = out / "apps" / "backend-rag" / ".env"
+    assert link.is_symlink()
+    # Resolves back to source.
+    assert link.resolve() == (repo / "apps" / "backend-rag" / ".env").resolve()
+    # Non-existent target (node_modules) is silently skipped (no broken link).
+    assert not (out / "node_modules").exists()
+
+
+def test_create_rejects_unknown_lane_by_default(fake_repo):
+    mod, _ = fake_repo
+    with pytest.raises(SystemExit) as exc:
+        mod.cmd_create("notreal", "x")
+    assert "unknown lane" in str(exc.value).lower()
+
+
+def test_create_allows_unknown_lane_when_flagged(fake_repo):
+    mod, _ = fake_repo
+    out = mod.cmd_create("notreal", "x", allow_unknown_lane=True)
+    assert out.is_dir()
+
+
+def test_create_rejects_invalid_chars_in_task_id(fake_repo):
+    mod, _ = fake_repo
+    with pytest.raises(SystemExit):
+        mod.cmd_create("wr2", "BAD/SLASH")
+    with pytest.raises(SystemExit):
+        mod.cmd_create("wr2", "_underscore")
+    with pytest.raises(SystemExit):
+        mod.cmd_create("wr2", "")
+
+
+def test_create_refuses_duplicate_task_id(fake_repo):
+    mod, _ = fake_repo
+    mod.cmd_create("wr2", "dup-001")
+    with pytest.raises(SystemExit) as exc:
+        mod.cmd_create("wr2", "dup-001")
+    assert "already exists" in str(exc.value).lower()
+
+
+def test_create_blocked_by_kill_switch(fake_repo, monkeypatch):
+    mod, _ = fake_repo
+    monkeypatch.setenv("AGENT_BROKER_ENABLED", "false")
+    with pytest.raises(SystemExit) as exc:
+        mod.cmd_create("wr2", "killed")
+    assert "disabled" in str(exc.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+def test_list_empty(fake_repo, capsys):
+    mod, _ = fake_repo
+    rc = mod.cmd_list()
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "no active worktrees" in out.lower()
+
+
+def test_list_shows_created_entries(fake_repo, capsys):
+    mod, _ = fake_repo
+    mod.cmd_create("wr2", "list-001")
+    mod.cmd_create("infra", "list-002")
+    rc = mod.cmd_list()
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "list-001" in out
+    assert "list-002" in out
+    assert "wr2" in out
+    assert "infra" in out
+    # Fresh worktree has only the metadata file (filtered) → WIP=no.
+    assert "no" in out
+
+
+def test_list_flags_wip(fake_repo, capsys):
+    mod, _ = fake_repo
+    out = mod.cmd_create("wr2", "wip-001")
+    (out / "dirty.txt").write_text("uncommitted\n")
+    mod.cmd_list()
+    captured = capsys.readouterr().out
+    assert "wip-001" in captured
+    assert "yes" in captured  # WIP column
+
+
+# ---------------------------------------------------------------------------
+# cleanup
+# ---------------------------------------------------------------------------
+
+
+def _backdate_metadata(worktree: Path, mod, minutes: int) -> None:
+    """Rewrite created_at to push the worktree past TTL."""
+    meta_path = worktree / mod.TASK_METADATA_FILENAME
+    data = json.loads(meta_path.read_text())
+    backdated = datetime.now(timezone.utc) - timedelta(minutes=minutes)
+    data["created_at"] = backdated.strftime("%Y-%m-%dT%H:%M:%SZ")
+    meta_path.write_text(json.dumps(data, indent=2, sort_keys=True))
+
+
+def test_cleanup_removes_expired_clean_worktree(fake_repo, capsys):
+    mod, repo = fake_repo
+    wt = mod.cmd_create("wr2", "expired-001", ttl_minutes=5)
+    _backdate_metadata(wt, mod, minutes=120)
+    rc = mod.cmd_cleanup()
+    assert rc == 0
+    assert not wt.exists()
+    out = capsys.readouterr().out
+    assert "expired-001" in out
+
+
+def test_cleanup_skips_wip_with_warning(fake_repo, capsys):
+    mod, _ = fake_repo
+    wt = mod.cmd_create("wr2", "wip-keep", ttl_minutes=5)
+    _backdate_metadata(wt, mod, minutes=120)
+    (wt / "wip.txt").write_text("not committed\n")
+    rc = mod.cmd_cleanup()
+    assert rc == 1  # signals at least one skip
+    assert wt.exists()  # WIP-safe
+    out = capsys.readouterr().out
+    assert "wip-keep" in out
+    assert "WIP" in out or "wip" in out.lower()
+
+
+def test_cleanup_force_removes_wip(fake_repo):
+    mod, _ = fake_repo
+    wt = mod.cmd_create("wr2", "wip-force", ttl_minutes=5)
+    _backdate_metadata(wt, mod, minutes=120)
+    (wt / "wip.txt").write_text("not committed\n")
+    rc = mod.cmd_cleanup(force=True)
+    assert rc == 0
+    assert not wt.exists()
+
+
+def test_cleanup_leaves_fresh_worktrees_alone(fake_repo):
+    mod, _ = fake_repo
+    wt = mod.cmd_create("wr2", "fresh-001", ttl_minutes=60)
+    rc = mod.cmd_cleanup()
+    assert rc == 0
+    assert wt.exists()
+
+
+def test_cleanup_blocked_by_kill_switch(fake_repo, monkeypatch):
+    mod, _ = fake_repo
+    monkeypatch.setenv("AGENT_BROKER_ENABLED", "0")
+    with pytest.raises(SystemExit):
+        mod.cmd_cleanup()
+
+
+# ---------------------------------------------------------------------------
+# release
+# ---------------------------------------------------------------------------
+
+
+def test_release_fails_when_branch_not_merged(fake_repo):
+    mod, repo = fake_repo
+    wt = mod.cmd_create("wr2", "rel-001")
+    # Add a commit on the new branch so it diverges from main.
+    (wt / "new.txt").write_text("on branch\n")
+    subprocess.run(["git", "add", "new.txt"], cwd=wt, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@e", "-c", "user.name=T", "commit", "-m", "div"],
+        cwd=wt,
+        check=True,
+    )
+    with pytest.raises(SystemExit) as exc:
+        mod.cmd_release("rel-001")
+    msg = str(exc.value).lower()
+    assert "not merged" in msg
+    assert wt.exists()  # untouched
+
+
+def test_release_succeeds_when_branch_merged(fake_repo):
+    mod, repo = fake_repo
+    wt = mod.cmd_create("wr2", "rel-002")
+    # No new commits → branch is already at HEAD of main → considered merged.
+    rc = mod.cmd_release("rel-002")
+    assert rc == 0
+    assert not wt.exists()
+
+
+def test_release_force_overrides_unmerged(fake_repo):
+    mod, _ = fake_repo
+    wt = mod.cmd_create("wr2", "rel-force")
+    (wt / "new.txt").write_text("on branch\n")
+    subprocess.run(["git", "add", "new.txt"], cwd=wt, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@e", "-c", "user.name=T", "commit", "-m", "div"],
+        cwd=wt,
+        check=True,
+    )
+    rc = mod.cmd_release("rel-force", force=True)
+    assert rc == 0
+    assert not wt.exists()
+
+
+def test_release_unknown_task_errors(fake_repo):
+    mod, _ = fake_repo
+    with pytest.raises(SystemExit) as exc:
+        mod.cmd_release("does-not-exist")
+    assert "no worktree metadata" in str(exc.value).lower()
+
+
+def test_release_blocked_by_kill_switch(fake_repo, monkeypatch):
+    mod, _ = fake_repo
+    mod.cmd_create("wr2", "rel-killed")
+    monkeypatch.setenv("AGENT_BROKER_ENABLED", "off")
+    with pytest.raises(SystemExit):
+        mod.cmd_release("rel-killed")
+
+
+# ---------------------------------------------------------------------------
+# kill-switch + list still works
+# ---------------------------------------------------------------------------
+
+
+def test_list_works_under_kill_switch(fake_repo, monkeypatch, capsys):
+    """--list is observational, must keep working when broker is disabled."""
+    mod, _ = fake_repo
+    mod.cmd_create("wr2", "ks-list")
+    monkeypatch.setenv("AGENT_BROKER_ENABLED", "false")
+    rc = mod.cmd_list()
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "ks-list" in out
+
+
+# ---------------------------------------------------------------------------
+# Smoke: main() CLI entry
+# ---------------------------------------------------------------------------
+
+
+def test_main_create_writes_worktree_ready_line(fake_repo, capsys):
+    mod, _ = fake_repo
+    rc = mod.main(["--lane", "wr2", "--task-id", "main-smoke"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert out.startswith("WORKTREE_READY ")
+    assert "wr2-main-smoke" in out
+
+
+def test_main_missing_args_returns_nonzero(fake_repo, capsys):
+    mod, _ = fake_repo
+    rc = mod.main([])
+    assert rc != 0
+
+
+def test_main_conflicting_ops_rejected(fake_repo, capsys):
+    mod, _ = fake_repo
+    rc = mod.main(["--list", "--cleanup"])
+    assert rc != 0


### PR DESCRIPTION
## Summary

Implements **Worktree Broker** (`scripts/agent_start.py`) — convergence 4/4 from the 2026-05-24 SOTA panel as L1 (top priority, ship in 1 week).

Closes the sibling-collision class documented in cicatrix incidents 2026-04-29 #1+#2 (untracked file loss when sibling automation switches branches mid-session — `git stash` without `-u` silently drops untracked files; `git checkout` from a parallel Claude session wipes WIP). 17 stash orphans accumulated 2026-05-23 are evidence the cicatrix pattern is still active.

Reference: `research/operations/2026-05-24-sota-multi-agent-repo-architecture-synthesis.md`

**Invariant enforced** (DeepSeek formalization):

    ∀ w₁,w₂ : session(w₁) ∧ session(w₂)
    ⇒ working_tree(w₁) ∩ working_tree(w₂) = ∅

## Before / After

| Aspect | Before (cicatrix-prone) | After (this PR) |
|---|---|---|
| Workspace for parallel agent sessions | Same `~/Desktop/nuzantara` checkout | Dedicated `.worktrees/<lane>-<task-id>/` per session |
| Branch convention | Ad-hoc `feat/...` collisions | `agent/<host>/<lane>/<task-id>` namespaced |
| Untracked file loss on sibling checkout | Recurring (2 incidents 2026-04-29, ~17 stash orphans 2026-05-23) | Impossible (sibling has its own worktree) |
| WIP commit cadence | "every 10min" defensive pattern (cicatrix 2026-04-29) | Optional — worktree isolation removes urgency |
| Operator escape | None | `AGENT_BROKER_ENABLED=false` kill switch (W33 lesson) |
| Stale worktree cleanup | Manual `git worktree remove` | `--cleanup` (WIP-safe) + `--release` (merged-only) |

## Files

- `scripts/agent_start.py` — CLI (argparse, 4 subcommands)
- `scripts/tests/test_agent_start.py` — 24 unit tests
- `docs/runbooks/agent-worktree-broker.md` — runbook (creation / list / cleanup / release / troubleshooting top-5)
- `CLAUDE.md` — Section 1 update: Agent Worktree Discipline

## CLI surface

```bash
# Create (default action)
python scripts/agent_start.py --lane wr2 --task-id render-cleanup --ttl-min 60
# → WORKTREE_READY /Users/nuzantara/Desktop/nuzantara/.worktrees/wr2-render-cleanup

# Observe
python scripts/agent_start.py --list

# Reclaim
python scripts/agent_start.py --cleanup           # WIP-safe; --force overrides
python scripts/agent_start.py --release <task-id> # merged-only; --force overrides
```

Lanes whitelisted: `wr2`, `wr3`, `infra`, `docs`, `db`, `cicatrix-fix`, `mouth`, `intel`, `cell`, `organism`, `mata-garuda`, `backend-rag`, `frontend`, `ops`. New lanes: extend `KNOWN_LANES` or pass `--allow-unknown-lane`.

## Smoke test transcript (live on this repo)

```
$ python scripts/agent_start.py --lane infra --task-id broker-smoke-test --ttl-min 5
WORKTREE_READY /Users/nuzantara/Desktop/nuzantara/.worktrees/infra-broker-smoke-test

$ python scripts/agent_start.py --list
TASK                     LANE           HOST            AGE_MIN   TTL WIP  BRANCH
broker-smoke-test        infra          nuzantara           0.1     5 no   agent/nuzantara/infra/broker-smoke-test

$ ls -la .worktrees/infra-broker-smoke-test/apps/backend-rag/.env
lrwxr-xr-x  1 nuzantara staff 56 ... .env -> /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.env

$ ls -la .worktrees/infra-broker-smoke-test/node_modules
lrwxr-xr-x  1 nuzantara staff 47 ... node_modules -> /Users/nuzantara/Desktop/nuzantara/node_modules

$ cat .worktrees/infra-broker-smoke-test/.agent-task.json
{
  "base_branch": "main",
  "branch": "agent/nuzantara/infra/broker-smoke-test",
  "created_at": "2026-05-24T11:06:09Z",
  "host": "nuzantara",
  "lane": "infra",
  "pid": 72019,
  "task_id": "broker-smoke-test",
  "ttl_minutes": 5,
  "worktree_path": "/Users/nuzantara/Desktop/nuzantara/.worktrees/infra-broker-smoke-test"
}

$ python scripts/agent_start.py --release broker-smoke-test
released broker-smoke-test (branch agent/nuzantara/infra/broker-smoke-test deleted)
```

## Test plan

- [x] `pytest scripts/tests/test_agent_start.py` → 24/24 PASS in 5.08s (no flakes across 3 runs)
- [x] Coverage: happy path, symlinks created when target exists, unknown-lane rejection + override, invalid task-id chars, duplicate task-id, kill-switch blocks create/cleanup/release, list works under kill-switch, WIP detection in list output, cleanup skips dirty + warns, cleanup `--force` overrides, cleanup leaves fresh worktrees alone, release rejects unmerged branch, release succeeds when merged, `--force` overrides, conflicting CLI ops rejected
- [x] Live smoke on repo: create + list + symlinks + release (transcript above)
- [ ] Reviewer: validate runbook top-5 troubleshooting against own habits
- [ ] Reviewer: confirm lane whitelist aligns with current LaunchAgent topology

## Constraints honored

- Uses only `git worktree` built-in (no Sapling/Graphite install)
- No `--no-verify`, no `--amend` (pre-commit hook + pre-push test suite both ran clean — 13716 tests passed)
- Kill switch `AGENT_BROKER_ENABLED=false` (lesson W33)
- Log rotation `~/logs/agent-broker.log` (RotatingFileHandler 1MB x 5)
- Symlinks env-safe (read-only intent on `.venv`, `.env`, `node_modules`)

## Notes for reviewer

This PR was authored *during* a live cicatrix demonstration: sibling agent sessions switched my working tree to their branches mid-session 3 separate times during commit prep. Each time I recovered without losing the work because the new files were untracked (they travel with the working tree, not the branch). This is exactly the scenario the broker eliminates — once adopted, none of those interruptions could happen because each session would be in its own `.worktrees/<lane>-<id>/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)