### PR TITLE
fix(backend-rag): bound 3 background loops to 2 PG-pool slots (god-test S12 / FIX-1)

### DIFF
--- a/apps/backend-rag/backend/services/analytics/attendance_monitor.py
+++ b/apps/backend-rag/backend/services/analytics/attendance_monitor.py
@@ -28,6 +28,7 @@ from zoneinfo import ZoneInfo
 import httpx
 
 from backend.app.utils.logging_utils import get_logger
+from backend.services.common.background import get_bg_pool_semaphore
 
 if TYPE_CHECKING:
     import asyncpg
@@ -365,19 +366,23 @@ class AttendanceMonitor:
         while self._running:
             iteration += 1
             try:
-                # PANOPTICON: Clock-in reminder at 09:15 WITA
-                now_bali = datetime.now(BALI_TZ)
-                if (
-                    now_bali.hour == CLOCKIN_REMINDER_HOUR
-                    and now_bali.minute >= CLOCKIN_REMINDER_MINUTE
-                    and now_bali.minute < CLOCKIN_REMINDER_MINUTE + 15
-                    and now_bali.weekday() < 5  # Mon-Fri only
-                ):
-                    if not getattr(self, "_reminder_sent_date", None) == now_bali.date():
-                        await self.send_clockin_reminder()
-                        self._reminder_sent_date = now_bali.date()
+                # Bound concurrent background-loop pool access (see
+                # backend.services.common.background — god-test S12 / FIX-1
+                # cicatrix 2026-05-24).
+                async with get_bg_pool_semaphore():
+                    # PANOPTICON: Clock-in reminder at 09:15 WITA
+                    now_bali = datetime.now(BALI_TZ)
+                    if (
+                        now_bali.hour == CLOCKIN_REMINDER_HOUR
+                        and now_bali.minute >= CLOCKIN_REMINDER_MINUTE
+                        and now_bali.minute < CLOCKIN_REMINDER_MINUTE + 15
+                        and now_bali.weekday() < 5  # Mon-Fri only
+                    ):
+                        if not getattr(self, "_reminder_sent_date", None) == now_bali.date():
+                            await self.send_clockin_reminder()
+                            self._reminder_sent_date = now_bali.date()
 
-                counters = await self.run_escalation_scan()
+                    counters = await self.run_escalation_scan()
                 logger.info(
                     "AttendanceMonitor._escalation_loop: heartbeat iter=%d pid=%d counters=%s",
                     iteration,

--- a/apps/backend-rag/backend/services/analytics/team_timesheet_service.py
+++ b/apps/backend-rag/backend/services/analytics/team_timesheet_service.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
     from backend.services.analytics.attendance_monitor import AttendanceMonitor
 
-from backend.services.common.background import spawn
+from backend.services.common.background import get_bg_pool_semaphore, spawn
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +74,11 @@ class TeamTimesheetService:
         """Background loop checking for expired sessions every 5 minutes"""
         while self.running:
             try:
-                await self._process_auto_logout()
+                # Bound concurrent background-loop pool access (see
+                # backend.services.common.background — god-test S12 / FIX-1
+                # cicatrix 2026-05-24).
+                async with get_bg_pool_semaphore():
+                    await self._process_auto_logout()
             except Exception as e:
                 logger.error("❌ Auto-logout check failed: %s", e)
 

--- a/apps/backend-rag/backend/services/common/background.py
+++ b/apps/backend-rag/backend/services/common/background.py
@@ -63,4 +63,37 @@ def _on_done(task: asyncio.Task[Any]) -> None:
         )
 
 
-__all__ = ["spawn"]
+# ---------------------------------------------------------------------------
+# Background-loop pool concurrency guard
+# ---------------------------------------------------------------------------
+#
+# Shared semaphore that bounds concurrent PG-pool acquisitions performed by
+# long-running background loops (NOT request handlers). The default DB pool
+# has ``max_size=10`` (see ``backend.app.setup.service_initializer``); three
+# unsynchronised loops (olympus heartbeat, team-timesheet auto-logout,
+# attendance escalation) can otherwise align with a request burst and
+# exhaust the pool, deadlocking the FastAPI event loop (god-test S12, FIX-1
+# cicatrix 2026-05-24).
+#
+# Limit of 2 concurrent loops leaves at least 8 pool slots for request
+# handlers under worst-case alignment.
+
+BG_LOOP_POOL_CONCURRENCY: int = 2
+
+_bg_pool_semaphore: asyncio.Semaphore | None = None
+
+
+def get_bg_pool_semaphore() -> asyncio.Semaphore:
+    """Return the process-wide semaphore bounding background-loop pool access.
+
+    Lazily constructed on first call so it binds to the running event loop
+    rather than to import-time (which would raise on Python 3.10+ if no
+    loop is yet running).
+    """
+    global _bg_pool_semaphore
+    if _bg_pool_semaphore is None:
+        _bg_pool_semaphore = asyncio.Semaphore(BG_LOOP_POOL_CONCURRENCY)
+    return _bg_pool_semaphore
+
+
+__all__ = ["BG_LOOP_POOL_CONCURRENCY", "get_bg_pool_semaphore", "spawn"]

--- a/apps/backend-rag/backend/services/olympus/guardian.py
+++ b/apps/backend-rag/backend/services/olympus/guardian.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import asyncpg
 
+from backend.services.common.background import get_bg_pool_semaphore
 from backend.services.olympus.alerts import OlympusAlerts
 from backend.services.olympus.heartbeat import Heartbeat
 from backend.services.olympus.insights import InsightsCollector
@@ -97,7 +98,11 @@ class OlympusGuardian:
     async def _heartbeat_loop(self) -> None:
         while self._running:
             try:
-                await self.run_heartbeat_once()
+                # Bound concurrent background-loop pool access (see
+                # backend.services.common.background — god-test S12 / FIX-1
+                # cicatrix 2026-05-24).
+                async with get_bg_pool_semaphore():
+                    await self.run_heartbeat_once()
             except Exception:
                 logger.exception("Heartbeat cycle failed")
             await asyncio.sleep(self._get_heartbeat_interval())

--- a/apps/backend-rag/backend/tests/unit/services/common/test_background.py
+++ b/apps/backend-rag/backend/tests/unit/services/common/test_background.py
@@ -146,3 +146,67 @@ async def test_inflight_cleared_after_all_done():
     await asyncio.gather(*tasks)
     await asyncio.sleep(0)
     assert len(background._inflight) == 0
+
+
+# ---------------------------------------------------------------------------
+# Background-loop pool concurrency guard (god-test S12 / FIX-1 2026-05-24)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _reset_bg_semaphore():
+    """Reset the module-level lazy semaphore between tests so each test
+    binds its own loop instance."""
+    background._bg_pool_semaphore = None
+    yield
+    background._bg_pool_semaphore = None
+
+
+@pytest.mark.asyncio
+async def test_get_bg_pool_semaphore_returns_singleton(_reset_bg_semaphore):
+    sem1 = background.get_bg_pool_semaphore()
+    sem2 = background.get_bg_pool_semaphore()
+    assert sem1 is sem2
+    assert isinstance(sem1, asyncio.Semaphore)
+
+
+@pytest.mark.asyncio
+async def test_bg_pool_semaphore_bounds_concurrency_to_two(_reset_bg_semaphore):
+    """Three concurrent loops must serialize so at most 2 hold the semaphore
+    at any instant — this is the actual guarantee that prevents pool exhaust."""
+    sem = background.get_bg_pool_semaphore()
+    in_flight = 0
+    peak = 0
+    lock = asyncio.Lock()
+    release = asyncio.Event()
+    entered = [asyncio.Event() for _ in range(3)]
+
+    async def loop_body(idx: int):
+        nonlocal in_flight, peak
+        async with sem:
+            async with lock:
+                in_flight += 1
+                peak = max(peak, in_flight)
+            entered[idx].set()
+            await release.wait()
+            async with lock:
+                in_flight -= 1
+
+    tasks = [asyncio.create_task(loop_body(i)) for i in range(3)]
+    # Wait until exactly 2 have entered
+    await asyncio.wait_for(
+        asyncio.gather(entered[0].wait(), entered[1].wait()), timeout=1.0,
+    )
+    # Third must still be blocked on the semaphore
+    assert not entered[2].is_set()
+    assert peak == 2
+    release.set()
+    await asyncio.gather(*tasks)
+    assert peak == 2
+
+
+def test_bg_loop_pool_concurrency_constant_is_two():
+    """Hardcoded contract: 2 background loops max, leaving ≥8 of 10 pool
+    slots for request handlers. Changing this constant changes safety
+    margins — keep the test as a tripwire."""
+    assert background.BG_LOOP_POOL_CONCURRENCY == 2


### PR DESCRIPTION
## Root cause

Three background loops in the FastAPI api process all acquire connections from the shared `asyncpg` pool (`max_size=10`, see `backend.app.setup.service_initializer:497`) without coordinating among themselves:

| File | Loop |
|---|---|
| `apps/backend-rag/backend/services/olympus/guardian.py:97` | `_heartbeat_loop` |
| `apps/backend-rag/backend/services/analytics/team_timesheet_service.py:73` | `_auto_logout_loop` |
| `apps/backend-rag/backend/services/analytics/attendance_monitor.py:345` | `_escalation_loop` |

Under request load, simultaneous loop ticks could pile up against request handlers and exhaust the pool, deadlocking the Fly api machine (observed `pool=0/1`, full event-loop stall — god-test S12 / FIX-1 cicatrix 2026-05-24).

## Fix

Introduce a lazy module-level `asyncio.Semaphore(2)` in `backend.services.common.background` and gate the DB-hitting body of each loop with `async with get_bg_pool_semaphore():`. At most two background loops may hold pool connections concurrently → at least 8 of 10 slots remain available for request handlers under worst-case alignment.

### Surgical scope (karpathy discipline)

- `backend/services/common/background.py` — `BG_LOOP_POOL_CONCURRENCY=2` constant + lazy `get_bg_pool_semaphore()` (singleton bound to running loop, avoids import-time loop assertion on Python 3.10+).
- `backend/services/olympus/guardian.py` — wrap `_heartbeat_loop` work only.
- `backend/services/analytics/team_timesheet_service.py` — wrap `_auto_logout_loop` work only.
- `backend/services/analytics/attendance_monitor.py` — wrap `_escalation_loop` work only (covers both `send_clockin_reminder()` and `run_escalation_scan()`).
- `backend/tests/unit/services/common/test_background.py` — 3 new tests.

### Untouched on purpose

- `guardian._pulse_loop`, `attendance._daily_digest_loop` — NOT in the failing-loop set listed in the brief; adding them blindly would expand scope.
- Request handlers — bypass the semaphore (only loops are gated).

## Test plan

- [x] Unit tests (existing): `pytest backend/tests/services/{analytics,olympus}/ backend/tests/unit/services/{analytics,olympus,common}/` → **207 passed in 0.74s** (196 prior + 11 incl. 3 new). Zero regression.
- [x] Empirical concurrency cap (`test_bg_pool_semaphore_bounds_concurrency_to_two`): spawn 3 loop bodies, observe peak in-flight = 2, third blocks until release.
- [x] Singleton identity guarantee (`test_get_bg_pool_semaphore_returns_singleton`).
- [x] Tripwire on constant change (`test_bg_loop_pool_concurrency_constant_is_two`).
- [x] Pre-push hook full backend suite: **13719 passed, 808 skipped** in 193s.
- [ ] Post-merge smoke: deploy to Fly, run god-test S12 under request burst, confirm `pool` no longer reaches 0/1 with all three loops active.

## Cicatrix reference

- **2026-05-24 FIX-1 / god-test S12** — Fly api machine deadlock pool=0/1 during simultaneous background tick + request burst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)