### PR TITLE
fix(workspace-inbox): cl.name → cl.full_name (39d silent HTTP 500)

### DIFF
--- a/apps/backend-rag/backend/app/routers/workspace_inbox.py
+++ b/apps/backend-rag/backend/app/routers/workspace_inbox.py
@@ -60,7 +60,7 @@ async def feed(
                m.content,
                m.created_at,
                m.client_id,
-               cl.name AS client_name,
+               cl.full_name AS client_name,
                cl.email AS client_email
         FROM conversation_messages m
         LEFT JOIN clients cl ON cl.id = m.client_id

--- a/apps/backend-rag/backend/tests/app/routers/test_workspace_inbox_schema.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_workspace_inbox_schema.py
@@ -1,0 +1,101 @@
+"""Schema regression guard for workspace_inbox.
+
+Prior bug (2026-05-26): SQL used `cl.name` but `clients` table has
+`full_name` (no `name` column). Produced `column cl.name does not exist`
+silent 500 on /api/workspace/inbox, blocking redirect post-login for ALL
+team users. Bug survived 39 days (2026-04-17 → 2026-05-26) because no
+test exercised the real SQL string against the live schema.
+
+This test inspects the router source as text and asserts only valid column
+references against `clients` table — no DB needed.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROUTER_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "app"
+    / "routers"
+    / "workspace_inbox.py"
+)
+
+VALID_CLIENTS_COLUMNS = {
+    "id",
+    "uuid",
+    "full_name",
+    "email",
+    "phone",
+    "whatsapp",
+    "nationality",
+    "passport_number",
+    "assigned_to",
+    "status",
+    "tags",
+    "metadata",
+    "created_at",
+    "updated_at",
+    "deleted_at",
+    "client_type",
+    "first_contact_date",
+    "last_interaction_date",
+    "address",
+    "notes",
+    "custom_fields",
+    "avatar_url",
+    "google_drive_folder_id",
+    "date_of_birth",
+    "passport_expiry",
+    "company_name",
+    "lead_source",
+    "service_interest",
+    "gender",
+    "birthplace",
+    "phone_normalized",
+    "tax_id",
+    "npwp",
+    "nib",
+    "current_visa_type",
+    "current_visa_sponsor",
+    "visa_expiry_date",
+    "kitas_expiry_date",
+    "ai_summary",
+    "drive_folder_id",
+    "drive_folder_url",
+    "strategic_recap",
+}
+
+
+def test_workspace_inbox_uses_only_valid_clients_columns() -> None:
+    """Every cl.<col> reference must match an actual clients column."""
+    source = ROUTER_PATH.read_text()
+
+    # Find every `cl.<identifier>` reference in the file (the JOINed clients alias)
+    references = set(re.findall(r"\bcl\.([a-z_][a-z0-9_]*)", source))
+
+    invalid = references - VALID_CLIENTS_COLUMNS
+    assert not invalid, (
+        f"workspace_inbox.py references invalid clients columns: {invalid}. "
+        f"Valid set (excerpt): full_name, email, id, assigned_to. "
+        f"This is the 2026-05-26 cl.name → cl.full_name class of bug."
+    )
+
+
+def test_workspace_inbox_does_not_reference_dropped_name_column() -> None:
+    """Explicit regression guard for the 2026-05-26 bug."""
+    source = ROUTER_PATH.read_text()
+    assert "cl.name" not in source, (
+        "workspace_inbox.py uses `cl.name` but clients table has `full_name`, "
+        "not `name`. This was the 2026-04-17 → 2026-05-26 silent 500 bug."
+    )
+
+
+def test_workspace_inbox_selects_client_name_alias() -> None:
+    """The client_name alias must be present in the SELECT (frontend uses it)."""
+    source = ROUTER_PATH.read_text()
+    assert "AS client_name" in source, (
+        "workspace_inbox.py must SELECT client_name alias — frontend AiSummaryCard "
+        "consumes this field. Removing it breaks the inbox UI silently."
+    )

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`277 routers · 576 services · 963 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`277 routers · 576 services · 964 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary

- Fix `column cl.name does not exist` HTTP 500 on `/api/workspace/inbox` (broken since 2026-04-17)
- Add schema regression test that exercises router source text vs actual `clients` schema (3/3 PASS)

## Discovery

Subhi reported `/login` HTTP 500 at 10:30 WITA 2026-05-26. Login was actually fine (last successful login 10:21 WITA confirmed in `auth_audit_log`). The 500 was on `/api/workspace/inbox?limit=100` called by the post-login `/inbox` redirect — blocking the inbox UI for all team users.

## Root cause

`apps/backend-rag/backend/app/routers/workspace_inbox.py:63` selected `cl.name AS client_name` but the `clients` table only has `full_name`. Bug introduced 2026-04-17 by commit `524fe9f40` ("feat(kita): inbox-first default + omnichannel feed API"), survived 39 days because no test exercised the real SQL against the live schema.

## Empirical verification

| Check | Before | After |
|---|---|---|
| `SELECT cl.name FROM clients cl` | ❌ column does not exist | n/a |
| `SELECT cl.full_name FROM clients cl` | ✅ 200 OK | ✅ 200 OK |
| `workspace_inbox.py` line 63 | `cl.name` | `cl.full_name` |
| Fly log `cl.name` errors | 2026-05-26 02:31:38 UTC | (expected: zero post-deploy) |

## Test plan

- [x] Schema regression test 3/3 PASS in 0.02s (`backend/tests/app/routers/test_workspace_inbox_schema.py`)
- [x] Import chain: `python -c "from backend.app.dependencies import get_current_user; from backend.app.routers import workspace_inbox"` → OK
- [x] Pre-push hook: 13747 tests pass / 808 skip (no regression)
- [ ] Post-deploy: `curl https://nuzantara-rag.fly.dev/api/workspace/inbox` returns 200 with valid auth (or 401 unauth) — NOT 500
- [ ] Post-deploy: zero `column cl.name does not exist` in fly logs within 1 hour

## Reference

- Cicatrix family: schema drift in router SQL (cf. 2026-04-19 migration runner SCAR — same lesson "reproduce on real call path")
- Test pattern: lightweight parsing-based guard (no DB dep), runs in CI as fast unit test
- Originating user report: Subhi message 2026-05-26 10:30 WITA

🤖 Generated with [Claude Code](https://claude.com/claude-code)