### PR TITLE
fix(repomap): make build_repomap.sh work under launchd

### DIFF
--- a/scripts/build_repomap.sh
+++ b/scripts/build_repomap.sh
@@ -16,6 +16,11 @@
 
 set -uo pipefail
 
+# Prepend homebrew bin so command -v ctags resolves to universal-ctags, not BSD /usr/bin/ctags
+# (launchd default env passes PATH=/usr/bin:/bin:/usr/sbin:/sbin even when plist sets PATH —
+#  see W50/W51/W52 cicatrix family deploy-path coordination)
+export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH:-/usr/bin:/bin}"
+
 # === Kill-switch ===
 if [[ "${REPOMAP_ENABLED:-true}" == "false" ]]; then
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] repomap disabled via REPOMAP_ENABLED=false" >&2
@@ -90,14 +95,24 @@ build_with_aider() {
 
 build_with_ctags() {
     local ctags_bin
-    ctags_bin="$(command -v ctags 2>/dev/null || true)"
+    # Try homebrew path first explicitly (launchd PATH override unreliable)
+    if [[ -x /opt/homebrew/bin/ctags ]]; then
+        ctags_bin=/opt/homebrew/bin/ctags
+    else
+        ctags_bin="$(command -v ctags 2>/dev/null || true)"
+    fi
     if [[ -z "$ctags_bin" ]]; then
         return 1
     fi
-    # Verify universal-ctags (json support)
-    if ! "$ctags_bin" --help 2>&1 | grep -q "json"; then
-        echo "$LOG_PREFIX WARN: ctags lacks json support (need universal-ctags)" >&2
-        return 1
+    # Under launchd, ctags --help/--version output can be truncated by stderr buffering.
+    # Trust that the binary path is universal-ctags if it exists at /opt/homebrew/bin/ctags
+    # (homebrew formula 'universal-ctags' is the only ctags published there).
+    # For non-homebrew paths, fall back to --output-format=json probe which has predictable output.
+    if [[ "$ctags_bin" != "/opt/homebrew/bin/ctags" ]]; then
+        if ! "$ctags_bin" --output-format=json /dev/null >/dev/null 2>&1; then
+            echo "$LOG_PREFIX WARN: ctags lacks json support (need universal-ctags)" >&2
+            return 1
+        fi
     fi
     echo "$LOG_PREFIX strategy=ctags ($ctags_bin) — fallback"
 


### PR DESCRIPTION
## Summary

Repomap cron `com.nuzantara.repomap.15min` was silently failing — `~/.nuzantara-repomap.txt` never generated, SessionStart `repomap-inject` hook had nothing to inject (~50 wasted tool calls/session for codebase exploration).

Two root causes both rooted in launchd sandbox quirks:

1. **PATH shadowing**: launchd 'default environment' PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) shadowed the EnvironmentVariables PATH set in the plist. `command -v ctags` resolved to BSD `/usr/bin/ctags` which lacks `--output-format=json`. Fix: explicit `export PATH=/opt/homebrew/bin:...` in the script itself.

2. **`ctags --help` truncation**: under launchd stdio buffering, `/opt/homebrew/bin/ctags --help` returned only the first line (1 line vs 247 in normal shell), so `grep -q json` returned false even though the binary IS universal-ctags. Fix: trust the homebrew path (the formula `universal-ctags` is the only ctags published there); for other paths fall back to `--output-format=json /dev/null` probe.

Sister cicatrix family: W50/W51/W52 deploy-path coordination — launchd env / sandbox surprises consistently undermine repo CI signal.

## Empirical verification

```
$ launchctl kickstart -k gui/501/com.nuzantara.repomap.15min
$ sleep 8 && stat -f "%Sm size=%z" ~/.nuzantara-repomap.txt
May 26 11:35:49 2026 size=184311

$ tail -3 ~/logs/repomap.log
[2026-05-26 11:35:45] [build_repomap] start ...
[2026-05-26 11:35:45] [build_repomap] strategy=ctags (/opt/homebrew/bin/ctags) — fallback
[2026-05-26 11:35:45] [build_repomap] done strategy=ctags bytes=184311 lines=968
```

## Test plan

- [x] `launchctl kickstart -k` produces `~/.nuzantara-repomap.txt` (>1KB, ctags JSON parsed)
- [x] No `WARN: ctags lacks json support` in `~/logs/repomap.error.log` post-fix
- [x] Pre-push pytest suite passes (13744 passed, 808 skipped)
- [ ] Next SessionStart auto-injects repo map (verifiable on next Claude Code session start)

🤖 Generated with [Claude Code](https://claude.com/claude-code)