### PR TITLE
fix(email): error_message='' diagnostic helper + httpx timeout 60s (W57) + fastapi pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ nuzantara/
 - Backend: FastAPI · 277 routers · 576 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
-- Apps: 26 · Packages: 5
+- Apps: 27 · Packages: 5
 - Version: 5.2.0
 <!-- DOCSYNC:TECH_STATS_END -->
 

--- a/apps/backend-rag/backend/app/services/internal_email.py
+++ b/apps/backend-rag/backend/app/services/internal_email.py
@@ -39,6 +39,7 @@ import os
 from typing import TYPE_CHECKING
 
 from backend.services.notifications.email_audit import (
+    format_send_error,
     is_critical,
     log_email_attempt,
     notify_email_failure_critical,
@@ -143,10 +144,11 @@ async def send_internal_email(
                 provider="brevo",
             )
     except Exception as e:
+        err_msg = format_send_error(e)
         logger.warning(
             "Internal email failed (context=%s): %s",
             log_context or "",
-            e,
+            err_msg,
         )
         if audit_enabled:
             await record_email_result(
@@ -154,7 +156,7 @@ async def send_internal_email(
                 row_id,
                 status="failed",
                 provider="brevo",
-                error_message=str(e),
+                error_message=err_msg,
             )
             if is_critical(email_type):  # type: ignore[arg-type]
                 notify_email_failure_critical(
@@ -162,7 +164,7 @@ async def send_internal_email(
                     to_email=to,
                     subject=subject,
                     practice_id=practice_id,
-                    error=str(e),
+                    error=err_msg,
                 )
         if raise_on_failure:
             raise

--- a/apps/backend-rag/backend/services/crm/completed_process_service.py
+++ b/apps/backend-rag/backend/services/crm/completed_process_service.py
@@ -17,6 +17,7 @@ from backend.services.common.cache import cache_invalidating
 from backend.services.integrations.drive_folder_service import DriveFolderService
 from backend.services.integrations.zoho_email_service import ZohoEmailService
 from backend.services.notifications.email_audit import (
+    format_send_error,
     log_email_attempt,
     notify_email_failure_critical,
     record_email_result,
@@ -415,7 +416,7 @@ P.S. Save our contact info for future needs—we're always here to help! 😊
             return
         except Exception as brevo_error:
             logger.warning("Brevo failed for %s, trying Zoho: %s", to_email, brevo_error)
-            brevo_err_msg = str(brevo_error)
+            brevo_err_msg = format_send_error(brevo_error)
 
         # 2) Zoho fallback
         try:
@@ -434,7 +435,7 @@ P.S. Save our contact info for future needs—we're always here to help! 😊
             )
             return
         except Exception as zoho_error:
-            combined_err = f"brevo: {brevo_err_msg} | zoho: {zoho_error}"
+            combined_err = f"brevo: {brevo_err_msg} | zoho: {format_send_error(zoho_error)}"
             logger.error(
                 "Both Brevo and Zoho failed for %s: %s",
                 to_email,

--- a/apps/backend-rag/backend/services/crm/waiting_documents_service.py
+++ b/apps/backend-rag/backend/services/crm/waiting_documents_service.py
@@ -16,6 +16,7 @@ from backend.services.common.cache import cache_invalidating
 from backend.services.crm.welcome.welcome_templates import PRACTICE_DOCUMENT_CHECKLISTS
 from backend.services.integrations.zoho_email_service import ZohoEmailService
 from backend.services.notifications.email_audit import (
+    format_send_error,
     log_email_attempt,
     notify_email_failure_critical,
     record_email_result,
@@ -301,8 +302,8 @@ Zantara — Bali Zero Team
             )
             return
         except Exception as brevo_error:
-            logger.warning("Brevo failed for %s, trying Zoho: %s", to_email, brevo_error)
-            brevo_err_msg = str(brevo_error)
+            brevo_err_msg = format_send_error(brevo_error)
+            logger.warning("Brevo failed for %s, trying Zoho: %s", to_email, brevo_err_msg)
 
         # 2) Zoho fallback — wrapped so that a double-failure is observable.
         try:
@@ -321,7 +322,7 @@ Zantara — Bali Zero Team
             )
             return
         except Exception as zoho_error:
-            combined_err = f"brevo: {brevo_err_msg} | zoho: {zoho_error}"
+            combined_err = f"brevo: {brevo_err_msg} | zoho: {format_send_error(zoho_error)}"
             logger.error(
                 "Both Brevo and Zoho failed for %s: %s",
                 to_email,

--- a/apps/backend-rag/backend/services/crm/welcome/welcome_email_service.py
+++ b/apps/backend-rag/backend/services/crm/welcome/welcome_email_service.py
@@ -31,6 +31,7 @@ from backend.app.core.config import settings
 from backend.services.crm.birthday_notifier_service import NATIONALITY_LANGUAGE_MAP
 from backend.services.crm.welcome.welcome_templates import WELCOME_EMAIL_SUBJECT
 from backend.services.notifications.email_audit import (
+    format_send_error,
     log_email_attempt,
     notify_email_failure_critical,
     record_email_result,
@@ -276,7 +277,7 @@ async def _send_client_welcome_impl(client_id: int, db_pool: asyncpg.Pool) -> No
         if status_code != 200:
             send_error = f"status={status_code} body={resp.text[:200]}"
     except Exception as e:
-        send_error = f"exception: {e}"
+        send_error = f"exception: {format_send_error(e)}"
 
     if send_error is None:
         async with db_pool.acquire() as conn:

--- a/apps/backend-rag/backend/services/invoicing/invoice_service.py
+++ b/apps/backend-rag/backend/services/invoicing/invoice_service.py
@@ -23,6 +23,7 @@ from backend.app.utils.logging_utils import get_logger
 from backend.services.integrations.service_account_drive_service import ServiceAccountDriveService
 from backend.services.invoicing.invoice_generator import InvoiceGenerator
 from backend.services.notifications.email_audit import (
+    format_send_error,
     log_email_attempt,
     notify_email_failure_critical,
     record_email_result,
@@ -174,9 +175,7 @@ class InvoiceAutomationService:
                     )
                     logger.info(f"Invoice email sent to client {client_data['email']}")
                 except Exception as email_error:
-                    err_msg = str(email_error)
-                    if isinstance(email_error, httpx.HTTPStatusError):
-                        err_msg = f"status={email_error.response.status_code} {err_msg}"
+                    err_msg = format_send_error(email_error)
                     logger.warning(
                         f"Failed to send invoice email to {client_data['email']}: {err_msg}",
                     )

--- a/apps/backend-rag/backend/services/notifications/email_audit.py
+++ b/apps/backend-rag/backend/services/notifications/email_audit.py
@@ -240,3 +240,33 @@ def notify_email_failure_critical(
 def is_critical(email_type: str) -> bool:
     """Return True iff a failure of ``email_type`` should page immediately."""
     return email_type in CRITICAL_EMAIL_TYPES
+
+
+def format_send_error(exc: BaseException) -> str:
+    """Return a non-empty diagnostic string for ``exc``.
+
+    Some httpx low-level exceptions (``RemoteProtocolError``,
+    ``ConnectError`` with no message, transient SSL drops) carry
+    ``str(exc) == ''``. Persisting an empty ``error_message`` in
+    ``email_send_log`` makes the failure undiagnosable from the
+    dashboard. This helper falls back through ``str`` →
+    HTTPStatusError-aware status+text → ``repr`` → class name so
+    the field always holds at least the exception type.
+    """
+    msg = str(exc).strip()
+    try:
+        import httpx  # local import — keep email_audit dep-light
+        if isinstance(exc, httpx.HTTPStatusError):
+            resp = exc.response
+            body = (resp.text or "").strip()[:500]
+            status_line = f"HTTP {resp.status_code} from {resp.request.url}"
+            return f"{status_line}: {body}" if body else status_line
+    except Exception:
+        # diagnostic helper must never raise
+        pass
+    if msg:
+        return msg
+    r = repr(exc).strip()
+    if r and r != "Exception()":
+        return r
+    return type(exc).__name__ or "UnknownError"

--- a/apps/backend-rag/backend/services/notifications/email_health_monitor.py
+++ b/apps/backend-rag/backend/services/notifications/email_health_monitor.py
@@ -170,7 +170,8 @@ class EmailHealthMonitor:
             )
             resp.raise_for_status()
         except Exception as e:
-            err_msg = str(e)
+            from backend.services.notifications.email_audit import format_send_error
+            err_msg = format_send_error(e)
 
         async with self.db_pool.acquire() as conn:
             if err_msg is None:

--- a/apps/backend-rag/backend/services/notifications/email_http.py
+++ b/apps/backend-rag/backend/services/notifications/email_http.py
@@ -27,7 +27,7 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
-_EMAIL_HTTPX_TIMEOUT = 30.0
+_EMAIL_HTTPX_TIMEOUT = 60.0
 
 # Module-level singleton. Reset if the app process is reloaded (e.g.
 # FastAPI dev autoreload) since the client is bound to a now-dead loop.

--- a/apps/backend-rag/backend/tests/unit/services/notifications/test_email_audit.py
+++ b/apps/backend-rag/backend/tests/unit/services/notifications/test_email_audit.py
@@ -15,6 +15,7 @@ import pytest
 
 from backend.services.notifications.email_audit import (
     CRITICAL_EMAIL_TYPES,
+    format_send_error,
     is_critical,
     log_email_attempt,
     notify_email_failure_critical,
@@ -282,3 +283,76 @@ def test_is_critical_membership():
     assert is_critical("cron_visa") is False
     assert is_critical("") is False
     assert is_critical("random_string") is False
+
+
+# ---------------------------------------------------------------------------
+# format_send_error — anti-empty-error_message guard (W57 2026-05-26)
+# ---------------------------------------------------------------------------
+
+
+def test_format_send_error_plain_exception_with_message():
+    assert format_send_error(ValueError("boom")) == "boom"
+
+
+def test_format_send_error_empty_str_falls_back_to_repr():
+    class Silent(Exception):
+        def __str__(self):  # noqa: D401 — fixture
+            return ""
+
+    out = format_send_error(Silent())
+    assert "Silent" in out  # repr() is "Silent()", class name preserved
+
+
+def test_format_send_error_empty_str_and_empty_repr_falls_back_to_classname():
+    class Whisper(Exception):
+        def __str__(self):
+            return ""
+
+        def __repr__(self):
+            return ""
+
+    assert format_send_error(Whisper()) == "Whisper"
+
+
+def test_format_send_error_httpx_status_error_includes_status_and_body():
+    import httpx
+
+    req = httpx.Request("POST", "https://brevo.example/send")
+    resp = httpx.Response(400, request=req, content=b'{"error":"invalid recipient"}')
+    try:
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        out = format_send_error(e)
+    assert "HTTP 400" in out
+    assert "brevo.example" in out
+    assert "invalid recipient" in out
+
+
+def test_format_send_error_httpx_status_error_empty_body():
+    import httpx
+
+    req = httpx.Request("POST", "https://brevo.example/send")
+    resp = httpx.Response(503, request=req, content=b"")
+    try:
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        out = format_send_error(e)
+    assert "HTTP 503" in out
+    assert "brevo.example" in out
+
+
+def test_format_send_error_never_returns_empty_string():
+    """Anti-regression guard: caller writes result to email_send_log,
+    empty-string error_message is undiagnosable from the dashboard."""
+
+    class Bare(Exception):
+        def __str__(self):
+            return ""
+
+    for exc in [
+        ValueError("x"),
+        Bare(),
+        ConnectionResetError(),
+        TimeoutError(),
+    ]:
+        assert format_send_error(exc) != ""


### PR DESCRIPTION
## Summary
Two unrelated fixes bundled in this branch (per Antonello multi-fix PR direction):

### Fix 1 — email error_message=''  / stale_sending (W57, 2026-05-26)
Email digest 2026-05-26 surfaced **8 failures across 5 critical categories** (hr_bonus, invoice_client, waiting_docs_client, waiting_docs_team, welcome) last 24h. Triage via `email_send_log` identified **2 root-cause clusters**:

**Cluster A — `stale_sending` (6 rows, provider=unknown, IDs 1205-1210):**
- httpx timeout 30s insufficient for Brevo p99 → bumped to **60s** in `email_http.py`
- Spread 04:55-07:09 UTC, NOT a single Brevo outage event
- `check_stale_sendings()` flipped them after 10min stuck on `sending`

**Cluster B — provider=brevo with `error_message=''` (2 rows, IDs 1201/1202 Darren Jonk):**
- `_retry_single` did `err_msg = str(e)` — some httpx low-level exceptions (`RemoteProtocolError`, `ConnectError` with no message, transient SSL drops) carry `str(exc) == ''`
- Empty `error_message` in dashboard = undiagnosable failure
- **Fix**: new `format_send_error(exc)` helper in `email_audit.py` with 4-layer fallback:
  1. `str(exc).strip()` if non-empty
  2. `HTTPStatusError` → `HTTP {code} from {url}: {body[:500]}`
  3. `repr(exc)` if non-empty
  4. `type(exc).__name__` as last resort
- Anti-empty-string test asserts non-empty return for `ValueError`, bare `Exception` subclass, `ConnectionResetError`, `TimeoutError`
- Wired into 6 call sites: `email_health_monitor._retry_single`, `internal_email.send_internal_email`, `waiting_documents_service` (Brevo+Zoho legs), `completed_process_service` (both legs), `invoice_service`, `welcome_email_service`

**Tests**: 6 new unit tests + 48/48 PASS in `backend/tests/unit/services/notifications`.

**8 backlog rows** have `retry_after = 2026-05-26 08:50-08:57 UTC` → drain naturally at next cron tick post-09:00 UTC. No manual force-retry.

### Fix 2 — FastAPI MAL-2026-4750 pin (pre-existing commit bf644bce1)
Pin `fastapi != 0.136.3` to avoid supply-chain malware (separate commit, already in branch).

## Test plan
- [x] `backend/tests/unit/services/notifications/` — 48/48 PASS (incl. 6 new format_send_error tests)
- [x] Import chain validation (`format_send_error` exported, all 6 caller modules import OK)
- [x] Pre-commit: ruff + mypy + import chain ✅
- [x] Pre-push: full backend suite **13749 PASS** / 4 pre-existing CRM partners failures (UniqueViolation+Deadlock+UndefinedTable on `partner_commissions` — NOT related to this PR, test DB isolation issue)
- [ ] Post-deploy: monitor `email_send_log` for next 24h, expect zero rows with `error_message=''` on `provider=brevo` failures
- [ ] Post-deploy: verify httpx timeout 60s does NOT increase tail latency on `/api/notifications/send-email`

🤖 Generated with [Claude Code](https://claude.com/claude-code)