### PR TITLE
feat(hook): W59 BRANCH_EXPECTED sibling-race guard in .husky/pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -153,6 +153,35 @@ if [ -n "$PY_FILES" ]; then
     cd ../..
 fi
 
+# ── W59 SIBLING-RACE BRANCH-TARGETING GUARD (cicatrix 2026-05-27) ────────────
+# Prevents the W59 branch-hijack class where a sibling Claude/Codex session
+# changes HEAD between `git add` and `git commit`, causing the commit to land
+# on the wrong branch silently. ANTIBODY (W59 cicatrix section 4).
+#
+# Usage (opt-in, in atomic git sequences):
+#   BRANCH_EXPECTED=feat/foo git add X && git commit -m "..."
+#
+# Behavior:
+#   - If BRANCH_EXPECTED unset → skip (backward-compat, no-op for legacy callers)
+#   - If BRANCH_EXPECTED set + HEAD branch mismatches → exit 2 with diagnostic
+#   - Kill switch: BRANCH_EXPECTED_ENFORCEMENT=false bypasses check
+#
+# Latency: <5ms (1 git symbolic-ref call). Zero impact when env unset.
+
+if [ -n "${BRANCH_EXPECTED:-}" ] && [ "${BRANCH_EXPECTED_ENFORCEMENT:-true}" != "false" ]; then
+    CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "DETACHED")
+    if [ "$CURRENT_BRANCH" != "$BRANCH_EXPECTED" ]; then
+        echo "❌ [W59-guard] BRANCH MISMATCH:"
+        echo "    expected: $BRANCH_EXPECTED"
+        echo "    current:  $CURRENT_BRANCH"
+        echo "    Sibling session may have moved HEAD. Investigate via:"
+        echo "      ps aux | grep -E 'claude|codex' | wc -l"
+        echo "      git reflog -5"
+        echo "    Override (skip guard): BRANCH_EXPECTED_ENFORCEMENT=false"
+        exit 2
+    fi
+fi
+
 # ── ANTI-ROGUE-AI GATES ───────────────────────────────────────────────────────
 # Prevents Gemini/Windsurf/Cursor from silently breaking the import chain
 # or modifying OFF-LIMITS files. History: 5+ production crashes (feb-mar 2026).


### PR DESCRIPTION
## Summary
- Adds opt-in W59 BRANCH_EXPECTED guard to \`.husky/pre-commit\` (29 LOC)
- Prevents the W59 sibling-race branch-hijack class documented 2026-05-27 03:18-03:37 WITA (cicatrix-scars.md W59 section, ANTIBODY point 4)
- W57 lesson was incomplete: \`&&\`-chained \`git add+commit\` protects from staging-race (sibling re-stage) but NOT from HEAD-race (sibling changes HEAD between Read and Bash)

## Why
W59 incident 2026-05-27 ~03:18 WITA: sibling Claude/Codex session checked out new branch \`feat/voa-pricing-and-process-2026-05-27\` from HEAD of my branch \`feat/wr2-c5a-pilot-and-p1-structural-fixes-2026-05-26\`. Between my Read and Bash \`git add && git commit\`, HEAD moved silently. Commit \`a96b9f3d0\` landed on wrong branch, push said \"Everything up-to-date\" because targeted ref was unchanged.

Recovery: \`git reset --soft HEAD~1\` + atomic single-Bash commit. Costly cleanup avoided only by accepting commit-with-wrong-files \`033a83c3c\` containing both my fix + sibling's diff.

## Behavior
\`\`\`bash
# Opt-in usage (no impact on legacy callers):
BRANCH_EXPECTED=feat/foo git add X && git commit -m \"...\"

# Mismatch → exit 2 + diagnostic:
[W59-guard] BRANCH MISMATCH:
    expected: feat/foo
    current:  feat/voa-pricing-...
    Sibling session may have moved HEAD. Investigate via:
      ps aux | grep -E 'claude|codex' | wc -l
      git reflog -5
    Override (skip guard): BRANCH_EXPECTED_ENFORCEMENT=false
\`\`\`

## Test plan (4/4 PASS local)
- [x] \`BRANCH_EXPECTED\` unset → no-op pass
- [x] \`BRANCH_EXPECTED\` matches → pass
- [x] \`BRANCH_EXPECTED\` mismatches → exit 2 with diagnostic
- [x] \`BRANCH_EXPECTED_ENFORCEMENT=false\` bypass on mismatch → pass
- [x] Self-applied: this commit itself shipped with W59 guard enabled (HEAD = expected)
- [x] 13790/13790 unit tests PASS (pre-push hook)

## Family
- W57 RESOLVED (staging-race) + W59 NEW (HEAD-race) closes the sibling-race class trio
- Latency: <5ms when env unset (1 \`git symbolic-ref\` call)
- Kill switch: \`BRANCH_EXPECTED_ENFORCEMENT=false\` per-invocation bypass

## Adoption path
1. Merge this PR (hook becomes available)
2. Update CLAUDE.md §git discipline to recommend BRANCH_EXPECTED for atomic sequences
3. Optional: bake into \`scripts/agent_start.py\` automatic env-export at worktree spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)