### PR TITLE
feat(seo): 301 redirect tax-for-freelancers-indonesia-2026 → freelancer-tax-guide (all locales)

### DIFF
--- a/apps/mouth/next.config.ts
+++ b/apps/mouth/next.config.ts
@@ -209,17 +209,17 @@ const nextConfig: NextConfig = {
       // SEO redirect: freelancer tax guide (2026-05-28)
       {
         source: "/tax-for-freelancers-indonesia-2026",
-        destination: "/freelancer-tax-guide",
+        destination: "/taxes/freelancer-tax-guide",
         permanent: true,
       },
       {
         source: "/id/tax-for-freelancers-indonesia-2026",
-        destination: "/id/freelancer-tax-guide",
+        destination: "/id/taxes/freelancer-tax-guide",
         permanent: true,
       },
       {
         source: "/it/tax-for-freelancers-indonesia-2026",
-        destination: "/it/freelancer-tax-guide",
+        destination: "/it/taxes/freelancer-tax-guide",
         permanent: true,
       },
       {

--- a/apps/mouth/next.config.ts
+++ b/apps/mouth/next.config.ts
@@ -206,6 +206,22 @@ const nextConfig: NextConfig = {
     return [
       // Category renames (2026-03-23) — keep for 12+ months
       { source: "/immigration", destination: "/visas", permanent: true },
+      // SEO redirect: freelancer tax guide (2026-05-28)
+      {
+        source: "/tax-for-freelancers-indonesia-2026",
+        destination: "/freelancer-tax-guide",
+        permanent: true,
+      },
+      {
+        source: "/id/tax-for-freelancers-indonesia-2026",
+        destination: "/id/freelancer-tax-guide",
+        permanent: true,
+      },
+      {
+        source: "/it/tax-for-freelancers-indonesia-2026",
+        destination: "/it/freelancer-tax-guide",
+        permanent: true,
+      },
       {
         source: "/immigration/:slug*",
         destination: "/visas/:slug*",


### PR DESCRIPTION
## Summary
301 redirect: `tax-for-freelancers-indonesia-2026` → `taxes/freelancer-tax-guide` (all locale variants)

## Changes
- `apps/mouth/next.config.ts` — 3 redirect rules added (default, /id/, /it/)

---

## Studio Layer

**Insight:** Two URLs targeting identical freelancer tax content created keyword cannibalization risk and split link equity across the same topic cluster.

**Evidence:** Antonello confirmed canonical decision: `tax-for-freelancers-indonesia-2026` → 301 → `freelancer-tax-guide` as evergreen slug. Locale variants (.id, .it) handled explicitly due to no i18n config in next.config.

**Reasoning:** Permanent 301 consolidates crawl budget, passes full link equity to evergreen slug, and eliminates duplicate indexing risk in the tax cluster.

**Risk:** Low — single file change, additive only, no existing rules modified, all pre-commit hooks passed.

**Recommendation:** Merge after review. No backend dependency.

**Next Action:** Monitor Google Search Console for deindex of old URL within 2–4 weeks post-merge.