### PR TITLE
fix(deps): pin react+react-dom 19.2.6 via root overrides (unblock main)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -704,24 +704,12 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "apps/admin-dashboard/node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
       }
     },
     "apps/admin-dashboard/node_modules/rimraf": {
@@ -761,15 +749,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "apps/admin-dashboard/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
       }
     },
     "apps/admin-dashboard/node_modules/std-env": {
@@ -1007,15 +986,15 @@
         "date-fns": "^4.1.0",
         "dompurify": "^3.4.0",
         "framer-motion": "^12.36.0",
-        "googleapis": "^171.1.0",
+        "googleapis": "^172.0.0",
         "gray-matter": "^4.0.3",
         "lucide-react": "^0.556.0",
         "next": "^16.2.5",
         "next-mdx-remote": "^6.0.0",
         "next-themes": "^0.4.6",
-        "react": "19.2.4",
+        "react": "19.2.6",
         "react-countup": "^6.5.3",
-        "react-dom": "19.2.4",
+        "react-dom": "19.2.6",
         "react-markdown": "^10.1.0",
         "recharts": "^3.8.1",
         "remark-gfm": "^4.0.1",
@@ -1035,7 +1014,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
-        "@types/node": "25.0.9",
+        "@types/node": "25.9.1",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/uuid": "^10.0.0",
@@ -1121,13 +1100,13 @@
       }
     },
     "apps/mouth/node_modules/@types/node": {
-      "version": "25.0.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.9.tgz",
-      "integrity": "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "apps/mouth/node_modules/ajv": {
@@ -1333,9 +1312,9 @@
       }
     },
     "apps/mouth/node_modules/googleapis": {
-      "version": "171.4.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-171.4.0.tgz",
-      "integrity": "sha512-xybFL2SmmUgIifgsbsRQYRdNrSAYwxWZDmkZTGjUIaRnX5jPqR8el/cEvo6rCqh7iaZx6MfEPS/lrDgZ0bymkg==",
+      "version": "172.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-172.0.0.tgz",
+      "integrity": "sha512-cF1m/nwfu9JP+JtR6j2nkQKnhu0z45eUVsWCVeooU8EIvBiPQqbfgAuJsTggCYEpbWJNwq2WS+aigaBC/sriIw==",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^10.2.0",
@@ -1443,6 +1422,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "apps/mouth/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
     },
     "apps/mouth/node_modules/zod": {
       "version": "4.4.3",
@@ -27724,10 +27710,11 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -27745,15 +27732,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-is": {
@@ -28672,7 +28660,8 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/schema-utils": {
       "version": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,9 @@
     "next": ">=16.2.5",
     "dompurify": ">=3.4.0",
     "qs": ">=6.15.2",
-    "brace-expansion": ">=5.0.6"
+    "brace-expansion": ">=5.0.6",
+    "react": "19.2.6",
+    "react-dom": "19.2.6"
   },
   "overrides": {
     "path-to-regexp": "^8.0.0",
@@ -166,6 +168,8 @@
     "postcss": ">=8.5.10",
     "fast-uri": ">=3.1.2",
     "ip-address": ">=10.2.0",
-    "qs": ">=6.15.2"
+    "qs": ">=6.15.2",
+    "react": "19.2.6",
+    "react-dom": "19.2.6"
   }
 }


### PR DESCRIPTION
Hotfix for RED main: #863 react/react-dom bump caused a root hoist mismatch (react 19.2.6 / react-dom 19.2.4) breaking mouth process page tests 40/40. Pin both to 19.2.6 in root overrides+resolutions. Verified 40/40 green locally.