### PR TITLE
fix(codex): skip stale autofix ci branches

### DIFF
--- a/scripts/codex/codex-nightly-autofix-ci.sh
+++ b/scripts/codex/codex-nightly-autofix-ci.sh
@@ -214,12 +214,6 @@ gh run view "$RUN_ID" --repo "$REPO_SLUG" --log-failed > "$RUN_LOG_FILE" 2>&1 ||
     exit 1
 }
 
-# Mark this run as attempted only after a real fix attempt can start. Log-fetch
-# failures are blocked observations, not daily-cap-consuming fix attempts.
-echo "${RUN_ID} ${NOW_EPOCH} ${BRANCH} ${WORKFLOW_NAME}" >> "$STATE_FILE"
-echo $((ATTEMPTS_TODAY + 1)) > "$COUNT_FILE"
-codex_state action attempt_started "Fetched logs for run $RUN_ID; launching Codex" "$FIX_BRANCH" "$REPO_ROOT"
-
 # Truncate logs to last 8000 chars (focus on actual failure)
 TAIL_LOGS=$(tail -c 8000 "$RUN_LOG_FILE")
 
@@ -259,15 +253,32 @@ restore_stash() {
 # Combined with mkdir-mutex trap above
 trap 'restore_stash; rm -f "$LOCK_DIR/pid"; rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
 
-git fetch origin "$BRANCH" 2>&1 | head -5
+if ! git fetch origin "$BRANCH" 2>&1 | head -5; then
+    log "Cannot fetch $BRANCH (likely deleted). Skipping without consuming daily cap."
+    echo "${RUN_ID} ${NOW_EPOCH} ${BRANCH} ${WORKFLOW_NAME}" >> "$STATE_FILE"
+    codex_state skipped stale_branch "Branch $BRANCH not fetchable; cap not consumed" "$FIX_BRANCH" "$REPO_ROOT"
+    notify "⚠️ Codex autofix: branch $BRANCH not fetchable"
+    git checkout main 2>&1 | head -2 || true
+    restore_stash
+    exit 0
+fi
 git checkout "$BRANCH" 2>&1 | head -3 || {
-    log "Cannot checkout $BRANCH (likely deleted). Skipping."
+    log "Cannot checkout $BRANCH (likely deleted). Skipping without consuming daily cap."
+    echo "${RUN_ID} ${NOW_EPOCH} ${BRANCH} ${WORKFLOW_NAME}" >> "$STATE_FILE"
+    codex_state skipped stale_branch "Branch $BRANCH not checkoutable; cap not consumed" "$FIX_BRANCH" "$REPO_ROOT"
     notify "⚠️ Codex autofix: branch $BRANCH not checkoutable"
     git checkout main 2>&1 | head -2 || true
     restore_stash
     exit 0
 }
 git reset --hard "$SHA" 2>&1 | head -3
+
+# Mark this run as attempted only after checkout/reset succeeds and a real
+# Codex fix attempt can start. Log-fetch and stale-branch failures are blocked
+# observations, not daily-cap-consuming fix attempts.
+echo "${RUN_ID} ${NOW_EPOCH} ${BRANCH} ${WORKFLOW_NAME}" >> "$STATE_FILE"
+echo $((ATTEMPTS_TODAY + 1)) > "$COUNT_FILE"
+codex_state action attempt_started "Fetched logs and checked out run $RUN_ID; launching Codex" "$FIX_BRANCH" "$REPO_ROOT"
 
 # ───────────────────────────────────────────────────────────────
 # Run Codex autofix


### PR DESCRIPTION
## Summary
- handle deleted/missing autofix target branches as clean skips instead of launchd exit 128
- move daily-cap consumption until after checkout/reset succeeds and Codex can actually start
- keep stale branch run IDs cooldown-recorded so the hourly job does not retry the same deleted branch loop

## Verification
- `bash -n scripts/codex/codex-nightly-autofix-ci.sh`
- temp-repo stale branch simulation with real run log fetch: exits 0, records state, does not increment daily cap
- `source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && cd apps/backend-rag && PYTHONPATH=. python -c "from backend.app.dependencies import get_current_user; print('OK')"`
- `source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && cd apps/backend-rag && PYTHONPATH=. pytest backend/tests/services/rag/test_kg_langgraph.py backend/tests/services/rag/test_kg_subgraphs.py backend/tests/services/rag/test_confidence.py -q` (91 passed)

## Notes
- No production deploy.
- Main checkout has unrelated untracked `research/...` local snapshot files; this PR leaves them untouched.