### PR TITLE
docs(ops): document Spark scout git stall remediation

### DIFF
--- a/research/operations/2026-05-28-spark-scout-git-stall-remediation.md
+++ b/research/operations/2026-05-28-spark-scout-git-stall-remediation.md
@@ -1,0 +1,69 @@
+# Spark Scout Git Stall Remediation - 2026-05-28
+
+Dispatch key: `b1eff125d047`
+Branch: `codex-overnight/spark-alarm-20260528_213547-spark-dispatch-20260528_213450-scout-b1eff125d047-20260528_213547`
+Main checkout inspected: `/Users/nuzantara/Desktop/nuzantara`
+
+## Live Findings
+
+- Host: `nuzantara@Nuzantara` (Pro).
+- Peer: `mini-pro2` reachable, but Pro/Mini heads were out of sync at session start:
+  - Pro/worktree: `98720c5c5 docs(research): SOTA 4-LLM synthesis (wave 2026-05-24 audit trail) (#855)`
+  - Mini: `0a7ef76c5 fix(wa-mirror): restore direct ingest on Baileys rc13`
+- Spark lifecycle assertion was current: `com.nuzantara.codex-spark-loop` was `state = running` with PID `1022`.
+- Codex state files were present under `/Users/nuzantara/.agent/decisions/state/`.
+- Main checkout was detached at `98720c5c56eb8e11147415b384493f6c1d061d9d`.
+- Main checkout had an unresolved merge conflict:
+  - `UU .claude/rules/cicatrix-scars.md`
+- Main checkout also had staged deletions plus matching untracked files for:
+  - `research/operations/2026-05-25-wa-corpus-monetization-tri-llm-synthesis.md`
+  - `research/personal/wa-corpus/**`
+
+## Safe Remediation Already Applied
+
+The `wa-corpus` churn was not a content rewrite. Before touching the index, each staged-deleted file was compared against the working-tree file at the same path:
+
+- compared files: 35
+- byte-identical to `HEAD`: 35
+- changed files: 0
+- missing files: 0
+
+Because the files were byte-identical, the staged deletions were index-only churn. The intervention unstaged only those paths:
+
+```bash
+git -C /Users/nuzantara/Desktop/nuzantara restore --staged -- \
+  research/personal/wa-corpus \
+  research/operations/2026-05-25-wa-corpus-monetization-tri-llm-synthesis.md
+```
+
+Post-remediation main checkout status:
+
+```text
+## HEAD (no branch)
+UU .claude/rules/cicatrix-scars.md
+```
+
+No content in `research/personal/wa-corpus` was changed by this remediation.
+
+## Remaining Conflict
+
+`.claude/rules/cicatrix-scars.md` still needs a semantic merge. The conflict is not safe to resolve with a blind ours/theirs choice:
+
+- stage 2 contains W61, W60, W62, W63, W58, W57, and newer structural scars.
+- stage 3 contains W61, W60, W62, W63 plus the archived CRM Guardian and W55-W48 material.
+- the working file conflict markers show one hunk where W58/W57 exist only on one side and another hunk where older archived material exists only on the other side.
+
+Recommended resolution:
+
+1. Keep the common W61/W60/W62/W63 entries once.
+2. Preserve W58 and W57 from stage 2.
+3. Preserve the CRM Guardian and W55-W48 archived material from stage 3.
+4. Remove conflict markers.
+5. Verify with:
+
+```bash
+git -C /Users/nuzantara/Desktop/nuzantara diff --check -- .claude/rules/cicatrix-scars.md
+git -C /Users/nuzantara/Desktop/nuzantara status --short --branch
+```
+
+Because the main checkout is detached and shared, commit the final conflict resolution only after moving it onto an owned branch or after the operator confirms that this detached merge is the intended active integration state.


### PR DESCRIPTION
## Summary
- verified the Spark scout signal live on Pro
- safely unstaged 35 byte-identical wa-corpus/research staged deletions in the main checkout
- documented the remaining cicatrix conflict handoff and why it should preserve both sides

## Validation
- git diff --check HEAD
- backend import chain: `from backend.app.dependencies import get_current_user` -> OK
- `PYTHONPATH=. pytest backend/tests/services/rag/test_kg_langgraph.py backend/tests/services/rag/test_kg_subgraphs.py backend/tests/services/rag/test_confidence.py -q` -> 91 passed, 1 warning

## Remaining local state
- /Users/nuzantara/Desktop/nuzantara still has `UU .claude/rules/cicatrix-scars.md`
- Pro/Mini heads were out of sync at session start