### PR TITLE
feat(nlm-expander): enrich proposal + auto-create empty NB

### DIFF
--- a/apps/mata-garuda/mata_garuda/agents/nlm_expander_agent.py
+++ b/apps/mata-garuda/mata_garuda/agents/nlm_expander_agent.py
@@ -7,14 +7,29 @@ last 30 days but isn't mapped to an NLM notebook in
 NB-INTEL-{X} be created. Also flags mapped notebooks that appear stale
 (no fed entries in KB for 30+ days).
 
-CRITICAL: L2 autonomy — this agent PROPOSES, does NOT create. A human
-(Zero) decides via Telegram reply.
+Each proposal is enriched with the top public titles + URLs that compose
+the domain (volume signal for Zero). ONLY public titles/URLs are surfaced
+— NEVER raw OSINT body/content (Symbiosis Law 2).
+
+AUTO-CREATE (L2+): when a domain crosses the HIGH threshold
+(``AUTO_CREATE_THRESHOLD`` items/30d) the agent auto-creates an EMPTY NB
+container via ``nlm notebook create`` (CLI subprocess), with a KB-backed
+cooldown so the same domain is never auto-created twice. It NEVER feeds
+sources into the new NB (auto-feed would push raw OSINT to the cloud —
+forbidden by Law 2) and NEVER merges/deletes notebooks. Population is
+manual / left to the feeder.
+
+CRITICAL: below AUTO_CREATE_THRESHOLD this agent only PROPOSES — a human
+(Zero) decides via Telegram reply. The auto-create container is empty by
+design and still requires human/feeder population.
 
 Layer 4 Analista.
 """
 from __future__ import annotations
 
 import logging
+import re
+import subprocess
 from collections import Counter
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -33,8 +48,12 @@ logger = logging.getLogger("mata_garuda.agents.nlm_expander")
 
 GENOME_FILE = str(Path(__file__).parent / "nlm_expander_agent_GENOME.md")
 
-DEFAULT_PROPOSAL_THRESHOLD = 50  # items in 30d → proposal-worthy
+DEFAULT_PROPOSAL_THRESHOLD = 50   # items in 30d → proposal-worthy
 DEFAULT_STALE_DAYS = 30           # NB unused for this many days → stale flag
+AUTO_CREATE_THRESHOLD = 100       # items in 30d → auto-create EMPTY NB container
+TOP_ITEMS_PER_DOMAIN = 3          # public titles+URLs surfaced per proposal
+NB_CREATE_STATUS = "nb_created"   # KB type used as auto-create cooldown marker
+NB_CREATE_AGENT = "nlm_expander_agent"  # KB agent for cooldown lookups
 
 
 def _parse_ts(data: dict[str, str]) -> datetime | None:
@@ -128,12 +147,131 @@ def find_stale_notebooks(
     return stale
 
 
+def top_public_items_for_domain(
+    items: list[dict[str, Any]],
+    domain: str,
+    now: datetime | None = None,
+    limit: int = TOP_ITEMS_PER_DOMAIN,
+) -> list[tuple[str, str]]:
+    """Return up to ``limit`` (title, url) pairs for ``domain`` over the
+    last 30 days.
+
+    SYMBIOSIS Law 2: only PUBLIC fields (``title`` + ``url``) are read —
+    NEVER ``content``/body or any raw OSINT field. ``items`` are the same
+    {id, data} rows produced by ``_xrevrange`` (newest-first), so we keep
+    that ordering as the "top" signal and de-duplicate on URL.
+    """
+    now = now or datetime.now(timezone.utc)
+    horizon = now - timedelta(days=30)
+    out: list[tuple[str, str]] = []
+    seen_urls: set[str] = set()
+    for it in items:
+        data = it.get("data") or {}
+        ts = _parse_ts(data)
+        if ts is not None and ts < horizon:
+            continue
+        item_domain = (data.get("domain") or data.get("topic") or "").strip()
+        if item_domain != domain:
+            continue
+        # ONLY public fields — title + url. Never data.get("content").
+        title = (data.get("title") or "(untitled)").strip()[:160]
+        url = (data.get("url") or "").strip()
+        dedup_key = url or title
+        if dedup_key in seen_urls:
+            continue
+        seen_urls.add(dedup_key)
+        out.append((title, url))
+        if len(out) >= limit:
+            break
+    return out
+
+
+def _domain_to_nb_title(domain: str) -> str:
+    """Derive a stable, human-readable NB title from a domain slug."""
+    pretty = re.sub(r"[_\-]+", " ", domain).strip().title()
+    return f"NB-INTEL {pretty}"
+
+
+def domain_recently_auto_created(
+    kb: KnowledgeBase,
+    domain: str,
+    cooldown_days: int = 30,
+    now: datetime | None = None,
+) -> bool:
+    """Return True if ``domain`` already has a recent auto-create / proposal
+    marker in the KB (anti-spam cooldown).
+
+    Matches any `nb_created` OR `proposal` entry whose ``source`` is the
+    domain slug, created within ``cooldown_days``. Prevents auto-creating the
+    same NB container twice. Best-effort: any DB error → treat as NOT recent
+    (favour surfacing over silent skip, but never hard-fail the run)."""
+    now = now or datetime.now(timezone.utc)
+    try:
+        cursor = kb._conn.execute(
+            "SELECT 1 FROM knowledge "
+            "WHERE agent = ? AND type IN (?, ?) AND source = ? "
+            "AND created_at > datetime('now', ?) LIMIT 1",
+            (
+                NB_CREATE_AGENT,
+                NB_CREATE_STATUS,
+                "proposal",
+                domain,
+                f"-{cooldown_days} days",
+            ),
+        )
+        return cursor.fetchone() is not None
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning(f"[nlm_expander] cooldown lookup failed for {domain}: {e}")
+        return False
+
+
+def _create_empty_notebook(title: str, dry_run: bool = False) -> tuple[bool, str]:
+    """Create an EMPTY NB container via the `nlm notebook create` CLI.
+
+    CLI-only (mata-garuda never imports the NLM SDK). Returns
+    ``(ok, uuid_or_message)``. In ``dry_run`` no subprocess is invoked.
+
+    Does NOT feed any source (auto-feed would leak raw OSINT to cloud —
+    Law 2) and does NOT merge/delete notebooks.
+    """
+    if dry_run:
+        logger.info(f"[nlm_expander] dry_run: would create empty NB '{title}'")
+        return True, "(dry-run)"
+    try:
+        result = subprocess.run(
+            ["nlm", "notebook", "create", title],
+            capture_output=True, text=True, timeout=60,
+        )
+        if result.returncode == 0:
+            out = (result.stdout or "").strip()
+            # Best-effort UUID extraction from CLI stdout.
+            m = re.search(
+                r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+                r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+                out,
+            )
+            uuid = m.group(0) if m else (out[:80] or "(unknown-uuid)")
+            return True, uuid
+        return False, (result.stderr or "")[:200]
+    except FileNotFoundError:
+        return False, "nlm CLI not found"
+    except subprocess.TimeoutExpired:
+        return False, "nlm notebook create timeout (60s)"
+    except Exception as e:  # pragma: no cover - defensive
+        return False, f"nlm notebook create failed: {e}"
+
+
 def build_proposal_message(
     candidates: list[tuple[str, int]],
     stale: list[str],
     now: datetime | None = None,
+    *,
+    items: list[dict[str, Any]] | None = None,
+    auto_created: list[dict[str, str]] | None = None,
 ) -> str:
     now = now or datetime.now(timezone.utc)
+    items = items or []
+    auto_created = auto_created or []
     lines = [
         f"🧭 NLM EXPANDER — {now.strftime('%Y-%m-%d')}",
         "",
@@ -142,15 +280,32 @@ def build_proposal_message(
         lines.append("**Propongo nuovi notebook:**")
         for domain, n in candidates:
             lines.append(f"• `{domain}` — {n} item/30gg (non mappato)")
+            # Volume signal: ONLY public titles + URLs (Law 2 — no body).
+            top = top_public_items_for_domain(items, domain, now=now)
+            for title, url in top:
+                if url:
+                    lines.append(f"    – {title} — {url}")
+                else:
+                    lines.append(f"    – {title}")
         lines.append("")
         lines.append("Rispondi `y <domain>` per approvare la creazione, `n <domain>` per ignorare.")
+    if auto_created:
+        lines.append("")
+        for nb in auto_created:
+            lines.append(
+                f"✅ Auto-creato NB vuoto: {nb.get('title', '?')} "
+                f"({nb.get('uuid', '?')}) — va popolato manualmente / dal feeder"
+            )
     if stale:
         lines.append("")
         lines.append(f"**NB stali (>{DEFAULT_STALE_DAYS}gg senza feed):** {', '.join(stale)}")
-    if not candidates and not stale:
+    if not candidates and not stale and not auto_created:
         lines.append("Niente da proporre — coverage stabile, feed attivo.")
     lines.append("")
-    lines.append("_L2 autonomy: solo proposte. Non creo NB senza tua approvazione._")
+    lines.append(
+        "_L2 autonomy: proposte + auto-create solo contenitore vuoto "
+        "(>=100 item/30gg). Mai feed/merge/delete. NB creati vanno popolati._"
+    )
     return "\n".join(lines)
 
 
@@ -161,11 +316,16 @@ def run_nlm_expander(
     dry_run: bool = False,
     max_stream_items: int = 2000,
     proposal_threshold: int = DEFAULT_PROPOSAL_THRESHOLD,
+    auto_create_threshold: int = AUTO_CREATE_THRESHOLD,
 ) -> dict:
     """Scan enriched stream for unmapped high-volume domains and stale NBs.
 
-    Returns stats: {counts, candidates, stale, tg_ok, dry_run}.
-    Never creates notebooks (L2 autonomy — Zero decides).
+    For domains over ``proposal_threshold`` → propose (with top public
+    titles+URLs). For domains over ``auto_create_threshold`` AND not under
+    cooldown → auto-create an EMPTY NB container via `nlm notebook create`.
+
+    Returns stats: {domains_seen, candidates, stale, auto_created, tg_ok,
+    dry_run, sent}. NEVER feeds sources, NEVER merges/deletes notebooks.
     """
     now = now or datetime.now(timezone.utc)
     own_kb = False
@@ -179,10 +339,49 @@ def run_nlm_expander(
         candidates = find_proposal_candidates(counts, threshold=proposal_threshold)
         stale = find_stale_notebooks(kb, now=now)
 
-        should_send = bool(candidates or stale)
+        # B) Auto-create EMPTY NB container for very-high-volume domains,
+        # gated by cooldown so the same domain is never created twice.
+        auto_created: list[dict[str, str]] = []
+        for domain, n in candidates:
+            if n < auto_create_threshold:
+                continue
+            if domain_recently_auto_created(kb, domain, now=now):
+                logger.info(
+                    f"[nlm_expander] skip auto-create '{domain}' "
+                    f"({n} item) — cooldown active"
+                )
+                continue
+            title = _domain_to_nb_title(domain)
+            ok, uuid = _create_empty_notebook(title, dry_run=dry_run)
+            if not ok:
+                logger.warning(
+                    f"[nlm_expander] auto-create failed for '{domain}': {uuid}"
+                )
+                continue
+            auto_created.append({"domain": domain, "title": title, "uuid": uuid})
+            logger.info(
+                f"[nlm_expander] auto-created empty NB '{title}' ({uuid}) "
+                f"for domain '{domain}' ({n} item/30gg, dry_run={dry_run})"
+            )
+            # Log to KB as cooldown marker (source = domain slug for lookup).
+            if not dry_run:
+                try:
+                    kb.store(
+                        NB_CREATE_AGENT, NB_CREATE_STATUS,
+                        f"auto-created empty NB '{title}' ({uuid}) for "
+                        f"domain '{domain}' ({n} item/30gg)",
+                        domain, 0.8,
+                    )
+                except Exception as e:
+                    logger.warning(f"[nlm_expander] kb.store(nb_created) failed: {e}")
+
+        should_send = bool(candidates or stale or auto_created)
         tg_ok = True
         if should_send:
-            msg = build_proposal_message(candidates, stale, now=now)
+            msg = build_proposal_message(
+                candidates, stale, now=now,
+                items=items, auto_created=auto_created,
+            )
             tg_ok = _send_telegram(msg, dry_run=dry_run)
             if not dry_run:
                 try:
@@ -197,6 +396,7 @@ def run_nlm_expander(
             "domains_seen": len(counts),
             "candidates": [{"domain": d, "count": n} for d, n in candidates],
             "stale": stale,
+            "auto_created": auto_created,
             "tg_ok": tg_ok,
             "dry_run": dry_run,
             "sent": should_send,

--- a/apps/mata-garuda/tests/test_nlm_expander_agent.py
+++ b/apps/mata-garuda/tests/test_nlm_expander_agent.py
@@ -135,18 +135,126 @@ class TestRunner:
         m_run.assert_not_called()
         kb.close()
 
-    def test_never_creates_notebooks(self, tmp_path):
-        """L2 hard boundary: no nlm CLI subprocess calls happen."""
+    def test_no_auto_create_below_high_threshold(self, tmp_path):
+        """Below AUTO_CREATE_THRESHOLD the agent only proposes — no NB created."""
         kb = KnowledgeBase(db_path=tmp_path / "db.db")
         kb.store("nlm_feeder", "nlm_fed", "nlm_fed https://x", "https://x", 1.0)
-        items = [_item("bignew") for _ in range(120)]
+        # 60 items: over proposal (50), under auto-create (100)
+        items = [_item("midvol") for _ in range(60)]
         with patch.object(nea, "_xrevrange", return_value=items), \
              patch.object(nea, "_send_telegram", return_value=True), \
              patch("subprocess.run") as m_run:
-            nea.run_nlm_expander(kb=kb, now=NOW, proposal_threshold=50)
-        # No subprocess run at all from within the agent (TG mocked)
+            stats = nea.run_nlm_expander(kb=kb, now=NOW, proposal_threshold=50)
+        assert stats["auto_created"] == []
         for call in m_run.call_args_list:
             args = call.args[0] if call.args else []
             assert "nlm" not in args[:1], \
-                f"L2 violation: NLM CLI invoked with {args}"
+                f"unexpected NLM CLI invoke under threshold: {args}"
         kb.close()
+
+
+class TestAutoCreate:
+    def _run(self, kb, items, m_run, *, dry_run=False):
+        m_run.return_value.returncode = 0
+        m_run.return_value.stdout = (
+            "Created notebook 12345678-1234-1234-1234-123456789abc"
+        )
+        m_run.return_value.stderr = ""
+        with patch.object(nea, "_xrevrange", return_value=items), \
+             patch.object(nea, "_send_telegram", return_value=True):
+            return nea.run_nlm_expander(
+                kb=kb, now=NOW, proposal_threshold=50, dry_run=dry_run,
+            )
+
+    def test_auto_creates_empty_nb_above_high_threshold(self, tmp_path):
+        kb = KnowledgeBase(db_path=tmp_path / "db.db")
+        kb.store("nlm_feeder", "nlm_fed", "nlm_fed https://x", "https://x", 1.0)
+        items = [_item("bignew") for _ in range(120)]
+        with patch("subprocess.run") as m_run:
+            stats = self._run(kb, items, m_run)
+        assert len(stats["auto_created"]) == 1
+        assert stats["auto_created"][0]["domain"] == "bignew"
+        assert stats["auto_created"][0]["uuid"] == \
+            "12345678-1234-1234-1234-123456789abc"
+        # Exactly one nlm CLI call, and it is `notebook create` — NEVER a feed.
+        nlm_calls = [
+            c.args[0] for c in m_run.call_args_list
+            if c.args and c.args[0][:1] == ["nlm"]
+        ]
+        assert len(nlm_calls) == 1
+        assert nlm_calls[0][:3] == ["nlm", "notebook", "create"]
+        kb.close()
+
+    def test_no_auto_feed_or_merge_or_delete(self, tmp_path):
+        """Law 2: only `notebook create` allowed — no source add / merge / delete."""
+        kb = KnowledgeBase(db_path=tmp_path / "db.db")
+        kb.store("nlm_feeder", "nlm_fed", "nlm_fed https://x", "https://x", 1.0)
+        items = [_item("bignew") for _ in range(120)]
+        with patch("subprocess.run") as m_run:
+            self._run(kb, items, m_run)
+        forbidden = {"source", "merge", "delete", "rm"}
+        for c in m_run.call_args_list:
+            args = c.args[0] if c.args else []
+            if args[:1] == ["nlm"]:
+                assert not (set(args) & forbidden), \
+                    f"L2 violation: forbidden NLM op {args}"
+        kb.close()
+
+    def test_cooldown_prevents_double_create(self, tmp_path):
+        kb = KnowledgeBase(db_path=tmp_path / "db.db")
+        kb.store("nlm_feeder", "nlm_fed", "nlm_fed https://x", "https://x", 1.0)
+        items = [_item("bignew") for _ in range(120)]
+        with patch("subprocess.run") as m_run:
+            first = self._run(kb, items, m_run)
+            second = self._run(kb, items, m_run)
+        assert len(first["auto_created"]) == 1
+        # Cooldown marker stored by first run blocks the second.
+        assert second["auto_created"] == []
+        kb.close()
+
+    def test_dry_run_does_not_create(self, tmp_path):
+        kb = KnowledgeBase(db_path=tmp_path / "db.db")
+        kb.store("nlm_feeder", "nlm_fed", "nlm_fed https://x", "https://x", 1.0)
+        items = [_item("bignew") for _ in range(120)]
+        with patch("subprocess.run") as m_run:
+            stats = self._run(kb, items, m_run, dry_run=True)
+        # dry_run still reports the would-create entry...
+        assert len(stats["auto_created"]) == 1
+        assert stats["auto_created"][0]["uuid"] == "(dry-run)"
+        # ...but NO real subprocess invocation happened.
+        m_run.assert_not_called()
+        kb.close()
+
+
+class TestTopPublicItems:
+    def test_only_title_and_url_no_body(self):
+        items = [{
+            "id": "20260414090000-0",
+            "data": {
+                "domain": "newdom",
+                "title": "Public Headline",
+                "url": "https://example.com/a",
+                "content": "SECRET OSINT BODY",
+                "normalized_at": (NOW - timedelta(days=2)).isoformat(),
+            },
+        }]
+        out = nea.top_public_items_for_domain(items, "newdom", now=NOW)
+        assert out == [("Public Headline", "https://example.com/a")]
+
+    def test_proposal_message_includes_public_url_not_body(self):
+        items = [{
+            "id": "20260414090000-0",
+            "data": {
+                "domain": "newdom",
+                "title": "Public Headline",
+                "url": "https://example.com/a",
+                "content": "SECRET OSINT BODY",
+                "normalized_at": (NOW - timedelta(days=2)).isoformat(),
+            },
+        }]
+        msg = nea.build_proposal_message(
+            [("newdom", 120)], [], now=NOW, items=items,
+        )
+        assert "https://example.com/a" in msg
+        assert "Public Headline" in msg
+        assert "SECRET OSINT BODY" not in msg


### PR DESCRIPTION
## Summary

Two upgrades to the weekly **nlm-expander** agent (MATA GARUDA), both git-tracked in `apps/mata-garuda`:

1. **Enriched Telegram proposal** — each proposed domain now lists its top-3 public titles + URLs and the volume count, so the proposal is actionable at a glance.
2. **Auto-create empty NB on high threshold** — when a domain exceeds `AUTO_CREATE_THRESHOLD` (100 items / 30d) and is not in cooldown, the agent creates the **empty** NB container via `nlm notebook create` (reversible) and logs it to the KB.

## OSINT / Symbiosis constraints respected

- **Public-only in proposal**: only public URLs/titles surface — never OSINT body content (Symbiosis Law 2).
- **No auto-feed**: the auto-created NB stays empty; the agent never pushes OSINT content to cloud.
- **No merge / no delete**: auto-create is the only mutating action, and it is reversible.
- **GENOME untouched**.

## Tests

20/20 pass, including 6 new cases: auto-create, cooldown, dry-run, no-feed / no-merge / no-delete, and public-url-only.

🤖 Generated with Claude Code