### PR TITLE
feat(enforcement): guardrails cd+rm bypass fix + universal worktree GC

### DIFF
--- a/research/operations/2026-05-29-guardrails-realpath-bypass-patch7.md
+++ b/research/operations/2026-05-29-guardrails-realpath-bypass-patch7.md
@@ -1,0 +1,103 @@
+# Guardrails `cd`+`rm` / absolute-`$HOME` Bypass — Patch 7
+
+_2026-05-29 WITA · branch `fix/guardrails-realpath-bypass-2026-05-29`_
+
+## Executive Summary
+
+The guardrails destructive-command evaluator (the PreToolUse hook that blocks
+`rm -rf` against protected roots) could be bypassed by **changing directory
+first and then issuing a relative `rm -rf`**, e.g.:
+
+```bash
+cd ~/Projects && rm -rf nuzantara
+```
+
+The pre-Patch-7 matcher only inspected the literal `rm` argument. Because
+`nuzantara` is a *relative* path, it did not match the protected-root patterns
+(`~`, `$HOME`, `/Users/nuzantara`, `/`), so the destructive command was
+**ALLOWED**. The effective target after the `cd` was a protected directory.
+
+Two adjacent argument forms were also under-covered:
+
+- **Quoted / braced `$HOME`**: `rm -rf "$HOME"`, `rm -rf ${HOME}`,
+  `rm -rf ${HOME}/Projects`.
+- **Pre-expanded absolute home**: `rm -rf /Users/nuzantara`,
+  `rm -rf /Users/nuzantara/Desktop` (the shell had already expanded `~`/`$HOME`
+  before the string reached the matcher).
+
+## Patch 7 (what changed)
+
+Patch 7 hardens the static evaluator so it:
+
+1. **Resolves the effective target of a `cd <dir> && rm -rf <rel>` chain** — when
+   a command does `cd` into a protected root (`~`, `$HOME`, `${HOME}`,
+   `/Users/nuzantara`, `/`) and then `rm -rf` a relative path (joined by `&&`
+   *or* `;`), it now BLOCKS.
+2. **Normalizes quoted/braced `$HOME`** (`"$HOME"`, `${HOME}`, `${HOME}/...`) to
+   the protected-home form before matching.
+3. **Treats pre-expanded absolute home paths** (`/Users/nuzantara`,
+   `/Users/nuzantara/...`) as protected.
+
+Legacy Patch-6 protections are preserved (`rm -rf /`, `rm -rf $HOME`,
+`rm -rf ~`, `rm -rf ~/something`), and legitimate operations are still ALLOWED
+with no new false positives (`rm -rf /tmp/...`, relative `rm -rf node_modules`,
+`rm -f` of a single home file, `cd /tmp/work && rm -rf build`, `cd` + non-`rm`).
+
+### Files changed by Patch 7 (NOT in this repo)
+
+The hook logic is **user-global infrastructure** under `~/.claude/`, which is
+gitignored and cannot be committed to this repo. Patch 7 was applied directly to
+those two files on the operator machine:
+
+| File | Role |
+|---|---|
+| `~/.claude/hooks/guardrails-static.py` | PreToolUse static evaluator (the synchronous BLOCK path) |
+| `~/.claude/daemons/guardrails.py` | Guardrails daemon (the resident matcher) |
+
+Because those live outside the repo, the only artifact that *can* be captured in
+version control is the **regression test** — which is the point of this commit:
+the test pins the contract so a future edit to the user-global hook that
+re-introduces the bypass is caught.
+
+## Regression test (the committed artifact)
+
+`scripts/tests/test_guardrails_patch7_cd_rm_bypass.py` drives the **real hook**
+as a subprocess with crafted Bash payloads and asserts BLOCK on every bypass
+form plus ALLOW on legitimate ops. 24 cases:
+
+- 12 new Patch-7 bypasses that MUST now BLOCK (the `cd`+`rm` chain in `&&` and
+  `;` forms, quoted/braced `$HOME`, pre-expanded absolute home).
+- 4 legacy Patch-6 cases that MUST still BLOCK.
+- 8 legitimate ops that MUST still be ALLOWED (false-positive guards).
+
+### Running it
+
+```bash
+python3 scripts/tests/test_guardrails_patch7_cd_rm_bypass.py
+# → 24/24 passed   (exit 0)
+```
+
+The test resolves the hook at `~/.claude/hooks/guardrails-static.py` by default.
+Override the path on a different machine/CI with:
+
+```bash
+GUARDRAILS_STATIC_HOOK=/path/to/guardrails-static.py \
+  python3 scripts/tests/test_guardrails_patch7_cd_rm_bypass.py
+```
+
+If the hook is **absent** (e.g. fresh checkout / CI without the user-global
+`~/.claude` tree), the test prints `SKIP:` and exits 0 rather than failing —
+the hook is operator infra, not a repo dependency.
+
+## Gotchas
+
+- **The hook is the SSOT, the test is the witness.** Editing
+  `~/.claude/hooks/guardrails-static.py` does not change anything in this repo;
+  re-run this test after any future edit to confirm the contract still holds.
+- **PreToolUse hooks need a Claude Code session restart to take effect** — an
+  in-session edit of the hook will not change the live BLOCK behavior until the
+  session restarts. The subprocess test bypasses that (it execs the file
+  directly), so it reflects on-disk hook state immediately.
+- **Skip-on-missing is intentional.** A hard failure on machines without
+  `~/.claude` would make the suite non-portable; the env-override exists so CI
+  can still opt in by pointing at a copy of the hook.

--- a/scripts/tests/test_guardrails_patch7_cd_rm_bypass.py
+++ b/scripts/tests/test_guardrails_patch7_cd_rm_bypass.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Patch 7 regression test: cd+rm bypass + quoted/absolute $HOME.
+Runs the static evaluator as a subprocess (real hook path) with crafted
+Bash payloads. Asserts BLOCK on the new bypass forms + ALLOW on legit ops.
+"""
+import json
+import os
+import subprocess
+import sys
+
+# The hook lives in the user-global ~/.claude tree (gitignored, NOT in this repo).
+# Override with GUARDRAILS_STATIC_HOOK for a different machine/CI path.
+HOOK = os.environ.get(
+    "GUARDRAILS_STATIC_HOOK",
+    os.path.expanduser("~/.claude/hooks/guardrails-static.py"),
+)
+
+
+def run(command: str) -> str:
+    payload = {"tool_name": "Bash", "tool_input": {"command": command}}
+    p = subprocess.run(
+        [sys.executable, HOOK],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return p.stdout.strip()
+
+
+# (command, expected_prefix)  — BLOCK or ALLOW
+CASES = [
+    # --- NEW Patch-7 bypasses that MUST now BLOCK ---
+    ("cd ~/Projects && rm -rf nuzantara", "BLOCK"),                 # the real 2026-05-28 bypass
+    ("cd ~ && rm -rf .git", "BLOCK"),                               # cd home + rm relative
+    ("cd $HOME && rm -rf Teman2", "BLOCK"),
+    ("cd ${HOME} && rm -rf something", "BLOCK"),
+    ("cd /Users/nuzantara && rm -rf x", "BLOCK"),
+    ("cd / && rm -rf etc", "BLOCK"),
+    ("cd ~/Projects ; rm -rf nuzantara", "BLOCK"),                  # semicolon variant
+    ('rm -rf "$HOME"', "BLOCK"),                                    # quoted $HOME
+    ("rm -rf ${HOME}", "BLOCK"),                                    # braced $HOME
+    ("rm -rf ${HOME}/Projects", "BLOCK"),
+    ("rm -rf /Users/nuzantara", "BLOCK"),                           # pre-expanded absolute home
+    ("rm -rf /Users/nuzantara/Desktop", "BLOCK"),
+
+    # --- legacy Patch-6 cases that must STILL block ---
+    ("rm -rf /", "BLOCK"),
+    ("rm -rf $HOME", "BLOCK"),
+    ("rm -rf ~", "BLOCK"),
+    ("rm -rf ~/something", "BLOCK"),
+
+    # --- legit ops that must STILL be ALLOWED (no false positives) ---
+    ("rm -rf /tmp/scratch-dir", "ALLOW"),                          # /tmp is fine
+    ("rm -rf .worktrees/dead-lane", "ALLOW"),                      # relative non-cd
+    ("rm -f ~/.claude/state/operator-presence.flag", "ALLOW"),    # rm -f (non-recursive) home file
+    ("rm -rf node_modules", "ALLOW"),                             # plain relative
+    ("cd /tmp/work && rm -rf build", "ALLOW"),                    # cd into NON-protected then rm
+    ("cd apps/mouth && npm run build", "ALLOW"),                  # cd + non-rm
+    ("ls -la ~/Projects", "ALLOW"),                              # not an rm at all
+    ("git status", "ALLOW"),
+]
+
+
+def main() -> int:
+    if not os.path.exists(HOOK):
+        # Hook is user-global infra, not shipped in the repo. On a machine/CI
+        # without it, skip rather than fail (exit 0). Set GUARDRAILS_STATIC_HOOK
+        # to point at the hook to actually run the regression.
+        print(f"SKIP: guardrails hook not found at {HOOK} (user-global infra)")
+        return 0
+    fails = 0
+    for cmd, want in CASES:
+        got = run(cmd)
+        ok = got.startswith(want)
+        if not ok:
+            fails += 1
+            print(f"FAIL  want={want:5} got={got!r:40} cmd={cmd!r}")
+        else:
+            print(f"ok    {want:5} :: {cmd}")
+    print(f"\n{len(CASES) - fails}/{len(CASES)} passed")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_worktree_gc_universal.py
+++ b/scripts/tests/test_worktree_gc_universal.py
@@ -1,0 +1,171 @@
+"""Unit tests for scripts/worktree_gc_universal.py.
+
+Tests the pure logic functions WITHOUT touching real worktrees. The module is
+a script (not an importable package member), so it is loaded by path via
+``importlib.util``. Git is mocked by monkeypatching ``_run_git``; the real
+helper returns a ``subprocess.CompletedProcess`` whose ``.stdout`` callers read,
+so the fakes return a small stand-in with a ``stdout`` attribute.
+"""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent
+SPEC_PATH = SCRIPT_DIR / "worktree_gc_universal.py"
+
+_spec = importlib.util.spec_from_file_location("worktree_gc_universal", SPEC_PATH)
+gc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gc)
+
+
+class _FakeProc:
+    """Stand-in for subprocess.CompletedProcess (only .stdout is consumed)."""
+
+    def __init__(self, stdout: str):
+        self.stdout = stdout
+        self.returncode = 0
+
+
+# ---------------------------------------------------------------------------
+# _slug  (signature: _slug(path: str) -> str)
+# ---------------------------------------------------------------------------
+
+
+class TestSlug:
+    def test_basic_path_becomes_safe_filename(self):
+        slug = gc._slug("/Users/nuz/Desktop/nuzantara/.worktrees/ops-foo")
+        assert "/" not in slug
+        assert slug == "Users_nuz_Desktop_nuzantara_.worktrees_ops-foo"
+
+    def test_trailing_slash_stripped(self):
+        slug = gc._slug("/tmp/lane/")
+        assert not slug.endswith("_")
+        assert slug == "tmp_lane"
+
+    def test_truncated_to_80_chars(self):
+        long = "/" + "a" * 200
+        assert len(gc._slug(long)) <= 80
+
+
+# ---------------------------------------------------------------------------
+# _kill_switch_active  (env WORKTREE_GC_ENABLED)
+# ---------------------------------------------------------------------------
+
+
+class TestKillSwitch:
+    def test_false_disables(self, monkeypatch):
+        monkeypatch.setenv(gc.KILL_SWITCH_ENV, "false")
+        assert gc._kill_switch_active() is True
+
+    def test_zero_disables(self, monkeypatch):
+        monkeypatch.setenv(gc.KILL_SWITCH_ENV, "0")
+        assert gc._kill_switch_active() is True
+
+    def test_unset_is_enabled(self, monkeypatch):
+        # Default value is "true" -> not in the disabled set -> active.
+        monkeypatch.delenv(gc.KILL_SWITCH_ENV, raising=False)
+        assert gc._kill_switch_active() is False
+
+    def test_true_is_enabled(self, monkeypatch):
+        monkeypatch.setenv(gc.KILL_SWITCH_ENV, "true")
+        assert gc._kill_switch_active() is False
+
+
+# ---------------------------------------------------------------------------
+# _list_worktrees  (parses `git worktree list --porcelain`)
+# ---------------------------------------------------------------------------
+
+
+SAMPLE_PORCELAIN = """\
+worktree /Users/nuz/Desktop/nuzantara
+HEAD a26da9e96aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+branch refs/heads/main
+
+worktree /Users/nuz/Desktop/nuzantara/.worktrees/ops-foo
+HEAD 1111111111111111111111111111111111111111
+branch refs/heads/feat/ops-foo
+
+worktree /Users/nuz/Desktop/nuzantara/.worktrees/detached-lane
+HEAD 2222222222222222222222222222222222222222
+detached
+
+worktree /Users/nuz/Desktop/nuzantara/.bare
+bare
+"""
+
+
+class TestListWorktrees:
+    def _entries(self, monkeypatch):
+        monkeypatch.setattr(
+            gc, "_run_git", lambda *a, **k: _FakeProc(SAMPLE_PORCELAIN)
+        )
+        return gc._list_worktrees()
+
+    def test_counts_all_entries(self, monkeypatch):
+        assert len(self._entries(monkeypatch)) == 4
+
+    def test_branch_field_strips_refs_heads(self, monkeypatch):
+        main = self._entries(monkeypatch)[0]
+        assert main["branch"] == "main"
+        assert main["detached"] is False
+        assert main["bare"] is False
+        assert main["head"] == "a26da9e96aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+    def test_detached_flag(self, monkeypatch):
+        det = self._entries(monkeypatch)[2]
+        assert det["detached"] is True
+        assert det["branch"] is None
+
+    def test_bare_flag(self, monkeypatch):
+        bare = self._entries(monkeypatch)[3]
+        assert bare["bare"] is True
+
+    def test_empty_input(self, monkeypatch):
+        monkeypatch.setattr(gc, "_run_git", lambda *a, **k: _FakeProc(""))
+        assert gc._list_worktrees() == []
+
+
+# ---------------------------------------------------------------------------
+# _has_real_dirty
+# ---------------------------------------------------------------------------
+
+
+class TestHasRealDirty:
+    def test_clean_tree_is_not_dirty(self, monkeypatch):
+        monkeypatch.setattr(gc, "_run_git", lambda *a, **k: _FakeProc(""))
+        assert gc._has_real_dirty(Path("/tmp/wt")) is False
+
+    def test_formatting_noise_is_not_dirty(self, monkeypatch):
+        # status non-empty but whitespace-insensitive diff empty -> noise.
+        def fake(args, **k):
+            if args[0] == "status":
+                return _FakeProc(" M scripts/foo.py")
+            if args[0] == "diff":
+                return _FakeProc("")  # --ignore-all-space yields nothing
+            return _FakeProc("")
+
+        monkeypatch.setattr(gc, "_run_git", fake)
+        assert gc._has_real_dirty(Path("/tmp/wt")) is False
+
+    def test_untracked_is_dirty(self, monkeypatch):
+        def fake(args, **k):
+            if args[0] == "status":
+                return _FakeProc("?? scripts/new_file.py")
+            return _FakeProc("")
+
+        monkeypatch.setattr(gc, "_run_git", fake)
+        assert gc._has_real_dirty(Path("/tmp/wt")) is True
+
+    def test_real_tracked_change_is_dirty(self, monkeypatch):
+        def fake(args, **k):
+            if args[0] == "status":
+                return _FakeProc(" M scripts/foo.py")
+            if args[0] == "diff":
+                return _FakeProc(
+                    "diff --git a/scripts/foo.py b/scripts/foo.py\n+real change"
+                )
+            return _FakeProc("")
+
+        monkeypatch.setattr(gc, "_run_git", fake)
+        assert gc._has_real_dirty(Path("/tmp/wt")) is True

--- a/scripts/worktree_gc_universal.py
+++ b/scripts/worktree_gc_universal.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Universal worktree GC — covers ALL git worktrees, not just broker/WR2 lanes.
+
+Closes the gap between the two existing GCs (cicatrix W62/W63 + 3-LLM panel
+2026-05-29):
+  - scripts/agent_start.py --cleanup  → only worktrees with .agent-task.json,
+    filtered by metadata TTL. Orphans/manual/nested/<tmp> worktrees invisible.
+  - scripts/wr2_worktree_gc.py        → only wr2-run-* prefix, by mtime.
+
+This script enumerates `git worktree list --porcelain` so EVERY worktree is in
+scope. For each candidate it applies the panel's safety model:
+
+  1. NEVER touch the main checkout or known long-lived worktrees (allowlist).
+  2. Age gate: skip if mtime < MIN_AGE_MIN (active session).
+  3. Dirty classification: `git status --porcelain` AND a whitespace-insensitive
+     diff. Pure formatting noise (Prettier/Black reflow) is NOT real work
+     (W62: the 6 orphans were all formatting-only). Real dirty → QUARANTINE.
+  4. Quarantine before removal: if a worktree has real uncommitted work OR is on
+     a detached HEAD with commits, stash it onto refs/agent-quarantine/<slug>
+     so nothing is lost, THEN remove. Never blind-delete dirty work.
+  5. Unpushed-commit gate: if the branch has commits not on origin, do NOT
+     remove — report for operator (a branch may be mid-PR).
+  6. `git worktree prune` at the end → clears phantom admin entries for /tmp
+     worktrees deleted on reboot (Pattern 7).
+  7. dry-run by DEFAULT; --apply required to remove.
+  8. Loop-bug alarm: WARN if it would remove > MAX_REMOVE_ALARM in one run.
+
+Kill switch: WORKTREE_GC_ENABLED=false → no-op exit 0.
+Run: python scripts/worktree_gc_universal.py [--apply] [--quiet]
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+logger = logging.getLogger("worktree_gc_universal")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKTREES_DIR = REPO_ROOT / ".worktrees"
+STATE_FILENAME = ".agent-task.json"
+KILL_SWITCH_ENV = "WORKTREE_GC_ENABLED"
+
+MIN_AGE_MIN = 15          # skip worktrees touched in the last 15 min (active)
+DEFAULT_MAX_AGE_HOURS = 24
+MAX_REMOVE_ALARM = 5      # WARN if a single run removes more than this
+QUARANTINE_REF_PREFIX = "refs/agent-quarantine"
+
+# Worktrees that must NEVER be GC'd, regardless of age/state.
+# Matched by resolved absolute path.
+ALLOWLIST_PATHS = {
+    str(REPO_ROOT),
+    str(Path.home() / "Desktop" / "nuzantara-deploy"),
+    str(Path.home() / "Desktop" / "nuzantara-crm-guardian-drive"),
+}
+
+
+def _run_git(args, *, cwd=None, check=True):
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd or REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def _kill_switch_active() -> bool:
+    return os.environ.get(KILL_SWITCH_ENV, "true").strip().lower() in (
+        "false", "0", "no", "off", "disabled",
+    )
+
+
+def _list_worktrees() -> list[dict]:
+    """Parse `git worktree list --porcelain` into dicts.
+
+    Each: {path, head, branch (or None), detached (bool), bare (bool)}.
+    """
+    out = _run_git(["worktree", "list", "--porcelain"], check=True).stdout
+    entries: list[dict] = []
+    cur: dict = {}
+    for line in out.splitlines():
+        if not line.strip():
+            if cur:
+                entries.append(cur)
+                cur = {}
+            continue
+        if line.startswith("worktree "):
+            cur = {"path": line[len("worktree "):], "branch": None,
+                   "detached": False, "bare": False, "head": None}
+        elif line.startswith("HEAD "):
+            cur["head"] = line[len("HEAD "):]
+        elif line.startswith("branch "):
+            cur["branch"] = line[len("branch "):].replace("refs/heads/", "")
+        elif line.strip() == "detached":
+            cur["detached"] = True
+        elif line.strip() == "bare":
+            cur["bare"] = True
+    if cur:
+        entries.append(cur)
+    return entries
+
+
+def _mtime_age_seconds(path: Path) -> float | None:
+    """Newest mtime among path + path/.git (the broker bumps the latter).
+
+    Returns None if the path doesn't exist (phantom /tmp entry)."""
+    try:
+        m = path.stat().st_mtime
+    except OSError:
+        return None
+    gitp = path / ".git"
+    try:
+        m = max(m, gitp.stat().st_mtime)
+    except OSError:
+        pass
+    return time.time() - m
+
+
+def _has_real_dirty(worktree: Path) -> bool:
+    """True if the worktree has NON-formatting uncommitted changes.
+
+    A pure whitespace/formatting reflow (Prettier/Black) is NOT real work
+    (cicatrix W62). We detect that by diffing with --ignore-all-space: if the
+    porcelain status is non-empty BUT the whitespace-insensitive diff is empty,
+    it's formatting noise → not real dirty.
+    Unreadable/corrupt → True (safer to keep).
+    """
+    try:
+        status = _run_git(["status", "--porcelain"], cwd=worktree, check=True).stdout
+    except subprocess.CalledProcessError as exc:
+        logger.warning("status failed in %s: %s — treating as dirty", worktree, exc)
+        return True
+    lines = [
+        ln for ln in status.splitlines()
+        if ln.strip() and not ln.strip().endswith(STATE_FILENAME)
+    ]
+    if not lines:
+        return False
+    # Untracked files (??) are always real work — diff can't see them.
+    if any(ln.startswith("??") for ln in lines):
+        return True
+    # Tracked changes: check if they survive whitespace-insensitivity.
+    try:
+        diff = _run_git(
+            ["diff", "--ignore-all-space", "--ignore-blank-lines"],
+            cwd=worktree, check=True,
+        ).stdout
+    except subprocess.CalledProcessError:
+        return True
+    return bool(diff.strip())
+
+
+def _unpushed_commits(worktree: Path, branch: str | None) -> int:
+    """Count commits on this worktree's HEAD not present on origin/main.
+
+    Conservative: any error → return 1 (treat as has-unpushed, keep it).
+    """
+    try:
+        # Use origin/main as the canonical upstream baseline.
+        out = _run_git(
+            ["rev-list", "--count", "origin/main..HEAD"],
+            cwd=worktree, check=True,
+        ).stdout.strip()
+        return int(out or "0")
+    except (subprocess.CalledProcessError, ValueError):
+        return 1
+
+
+def _quarantine(worktree: Path, slug: str, *, apply: bool) -> bool:
+    """Create a quarantine ref capturing the worktree's current tree+untracked.
+
+    Uses `git stash create` (produces a commit object without touching the
+    stash stack) then writes it to refs/agent-quarantine/<slug>. Returns True
+    on success (or dry-run). Best-effort: failure → False (caller keeps wt).
+    """
+    ref = f"{QUARANTINE_REF_PREFIX}/{slug}"
+    if not apply:
+        logger.info("[dry-run] would quarantine %s -> %s", worktree, ref)
+        return True
+    try:
+        # stash create captures tracked changes; add -u-equivalent by staging
+        # untracked first into the index of a temp — simplest robust path:
+        # `git stash create` does NOT include untracked, so we snapshot via
+        # a throwaway commit of `git add -A` is invasive. Instead capture a
+        # patch artifact AND a stash-create commit for tracked changes.
+        _run_git(["add", "-A"], cwd=worktree, check=False)
+        created = _run_git(["stash", "create", f"quarantine {slug}"],
+                           cwd=worktree, check=False)
+        sha = created.stdout.strip()
+        if sha:
+            _run_git(["update-ref", ref, sha], check=False)
+            logger.info("quarantined %s -> %s (%s)", worktree, ref, sha[:10])
+        # Also drop a patch artifact under .agent-receipts/ for human-readable
+        # recovery even if the ref is later pruned.
+        receipts = REPO_ROOT / ".agent-receipts"
+        receipts.mkdir(exist_ok=True)
+        patch = _run_git(["diff", "HEAD"], cwd=worktree, check=False).stdout
+        (receipts / f"quarantine-{slug}.patch").write_text(patch)
+        # Reset the index we just staged so removal is clean.
+        _run_git(["reset"], cwd=worktree, check=False)
+        return True
+    except Exception as exc:  # noqa: BLE001 — best-effort, never crash GC
+        logger.warning("quarantine failed for %s: %s", worktree, exc)
+        return False
+
+
+def _remove(worktree: Path, *, apply: bool) -> bool:
+    if not apply:
+        logger.info("[dry-run] would remove worktree %s", worktree)
+        return True
+    try:
+        _run_git(["worktree", "remove", "--force", str(worktree)], check=True)
+        logger.info("removed worktree %s", worktree)
+        return True
+    except subprocess.CalledProcessError as exc:
+        logger.error("remove failed %s: %s", worktree, (exc.stderr or "").strip())
+        return False
+
+
+def _slug(path: str) -> str:
+    return path.rstrip("/").replace("/", "_").lstrip("_")[:80]
+
+
+def gc(*, apply: bool, max_age_hours: float) -> int:
+    if _kill_switch_active():
+        logger.info("%s=false — GC disabled, no-op", KILL_SWITCH_ENV)
+        return 0
+
+    entries = _list_worktrees()
+    # In dry-run these count what WOULD happen; in apply they count what DID.
+    removed = 0
+    quarantined = 0
+    kept_unpushed = 0
+    kept_active = 0
+    pruned_phantom = 0
+    verb = "would " if not apply else ""
+
+    for e in entries:
+        path_str = e["path"]
+        path = Path(path_str)
+
+        if e.get("bare"):
+            continue
+        if path_str in ALLOWLIST_PATHS or str(path.resolve()) in ALLOWLIST_PATHS:
+            continue
+
+        age = _mtime_age_seconds(path)
+        if age is None:
+            # Phantom: registered but dir gone (reboot-cleared /tmp). Prune.
+            logger.info("phantom worktree (dir missing): %s", path_str)
+            pruned_phantom += 1
+            continue
+
+        if age < MIN_AGE_MIN * 60:
+            kept_active += 1
+            continue
+
+        if age < max_age_hours * 3600:
+            # Not old enough yet.
+            continue
+
+        slug = _slug(path_str)
+        real_dirty = _has_real_dirty(path)
+        unpushed = _unpushed_commits(path, e.get("branch"))
+
+        # Detached HEAD with commits OR real dirty work → quarantine first.
+        needs_quarantine = real_dirty or (e.get("detached") and unpushed > 0)
+
+        if unpushed > 0 and not e.get("detached"):
+            # Branch with unpushed commits — may be mid-PR. Keep + report.
+            logger.warning(
+                "KEEP %s — branch '%s' has %d unpushed commit(s); not GC'd "
+                "(operator review)", path_str, e.get("branch"), unpushed,
+            )
+            kept_unpushed += 1
+            continue
+
+        if needs_quarantine:
+            if not _quarantine(path, slug, apply=apply):
+                logger.warning("KEEP %s — quarantine failed, refusing to remove",
+                               path_str)
+                continue
+            quarantined += 1
+
+        if _remove(path, apply=apply):
+            removed += 1
+            logger.info("%sremove counted: %s (total %d)", verb, path_str, removed)
+
+    # Always prune phantom admin entries (cheap, safe, fixes /tmp reboot bug).
+    if apply:
+        _run_git(["worktree", "prune"], check=False)
+
+    if removed > MAX_REMOVE_ALARM:
+        logger.warning(
+            "[ALARM] universal worktree GC removed %d worktrees in one run — "
+            "investigate possible loop bug", removed,
+        )
+
+    logger.info(
+        "done: removed=%d quarantined=%d kept_unpushed=%d kept_active=%d "
+        "phantom=%d apply=%s",
+        removed, quarantined, kept_unpushed, kept_active, pruned_phantom, apply,
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true",
+                        help="actually remove (default: dry-run report only)")
+    parser.add_argument("--max-age-hours", type=float,
+                        default=float(os.environ.get("WORKTREE_GC_MAX_AGE_HOURS",
+                                                      DEFAULT_MAX_AGE_HOURS)))
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.WARNING if args.quiet else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        stream=sys.stdout,
+    )
+    return gc(apply=args.apply, max_age_hours=args.max_age_hours)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Two enforcement-hardening fixes from the 3-LLM panel review of recurring worktree/branch/cleanup failure-patterns (`research/operations/2026-05-29-worktree-failure-patterns-3llm-panel.md`):

1. **Guardrails `cd`+`rm` bypass fix (Pattern 6/4).** The home-wipe guard only matched when the `rm` *target* was literally `/`, `$HOME`, or `~`. `cd ~/Projects && rm -rf nuzantara` slipped through (empirically used 3× during the 2026-05-28 cleanup). Added 2 patterns to `BLOCK_PATTERNS` (mirrored in both `~/.claude/hooks/guardrails-static.py` and `~/.claude/daemons/guardrails.py` — out-of-repo, not in this diff): block `cd <protected> && rm -rf <anything>`, and block quoted/braced `$HOME` + pre-expanded `/Users/<user>` paths. This PR carries the **regression test** (the hooks themselves live in `~/.claude/`).

2. **Universal worktree GC (Pattern 1/2/7/8).** Closes the gap between `agent_start.py --cleanup` (broker-tagged only) and `wr2_worktree_gc.py` (wr2-run-* only): orphan/manual/nested/detached-HEAD/`/tmp` worktrees fell through both (cicatrix W62/W63). New `scripts/worktree_gc_universal.py` enumerates `git worktree list --porcelain` so every worktree is in scope, with panel-recommended safety: allowlist core worktrees, skip <15min (active), whitespace-insensitive dirty-classification (formatting noise ≠ real work), quarantine-before-remove (`refs/agent-quarantine/` + `.agent-receipts/*.patch`), keep+report unpushed-branch commits, `git worktree prune` for `/tmp` phantoms, **dry-run by default**.

## Test plan
- [x] Guardrails regression: 24/24 (incl. boundary `cd /tmp/work && rm` = ALLOW, `cd / && rm` = BLOCK; zero false positives on legit ops)
- [x] Worktree GC unit tests: 16/16 (`_slug`, kill-switch, porcelain parse, dirty-classification)
- [x] GC dry-run smoke: side-effect-free (worktrees 7/0/0, identical before/after, kill switch no-op)
- [ ] LaunchAgent `com.nuzantara.worktree-gc-universal.daily` ships **report-only** (no `--apply`) for 48h validation before enforcing (plist written + linted, NOT activated — operator decides)

## Not in this PR (operator decision pending)
- Redis write-lock fail-closed (Pattern 9) — contradicts a documented HARD constraint in `agent_lease.py`; escalated separately per Symbiosis Law 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)