### PR TITLE
feat(agent-lease): Redis Option B flock fallback on Redis-down

### DIFF
--- a/scripts/agent_lease.py
+++ b/scripts/agent_lease.py
@@ -31,6 +31,8 @@ Kill-switch env: AGENT_LEASE_ENFORCEMENT=false → check always exits 0.
 from __future__ import annotations
 
 import argparse
+import fcntl
+import hashlib
 import json
 import logging
 import os
@@ -70,6 +72,15 @@ AUDIT_PATH = Path(os.path.expanduser("~/.agent/leases.jsonl"))
 KEY_PREFIX = "agent_lock:"
 DEFAULT_TTL_S = 300
 DEFAULT_LANE = "default"
+
+# Option B (2026-05-29): when Redis is unreachable, `check` falls back to a
+# local flock advisory lock so a same-machine race on the SAME path inside the
+# same commit window produces a visible WARN. The flock is held ONLY for the
+# lifetime of the short check subprocess, so it can never deadlock a commit.
+# This is observability defense-in-depth, NOT a hard serializer (cross-node
+# Pro/Mini races are not covered). HARD constraint preserved: this path always
+# returns exit 0 (never blocks on Redis outage).
+FALLBACK_LOCK_DIR = Path(os.path.expanduser("~/.agent/lease-fallback"))
 
 
 # ── Exceptions ────────────────────────────────────────────────────────────────
@@ -150,6 +161,65 @@ def build_key(resource: str) -> str:
     if resource.startswith(KEY_PREFIX):
         return resource
     return f"{KEY_PREFIX}{resource}"
+
+
+def _fallback_lock_path(path: str) -> Path:
+    """Map a resource path to its flock file under FALLBACK_LOCK_DIR.
+
+    The resource path contains '/', so we hash it for a flat lock filename.
+    """
+    digest = hashlib.sha256(path.encode("utf-8")).hexdigest()[:32]
+    return FALLBACK_LOCK_DIR / f"{digest}.lock"
+
+
+def flock_fallback_check(path: str, *, task_id: Optional[str] = None) -> bool:
+    """Option B: best-effort same-machine advisory lock used when Redis is down.
+
+    Tries a NON-blocking exclusive flock on a per-path lock file. Returns:
+      - True  → lock acquired cleanly (no same-machine contention seen).
+      - False → another local process holds it RIGHT NOW (visible WARN logged).
+
+    The HARD constraint is preserved by the CALLER, which always returns exit 0
+    regardless of this result — this is an observability signal, not a gate.
+    The flock is released as soon as the fd is closed (i.e. when the short
+    `check` subprocess exits), so it can never deadlock a commit. We also fold
+    in a `degraded=true` audit record so a daily report can surface how often
+    the Redis-down fallback path was taken.
+    """
+    _audit("check-degraded", path=path, task_id=task_id, degraded=True,
+           backend="flock-fallback")
+    try:
+        FALLBACK_LOCK_DIR.mkdir(parents=True, exist_ok=True)
+        lock_path = _fallback_lock_path(path)
+        # Open (create) the lock file; keep the fd open for the subprocess life.
+        fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+    except OSError as e:  # pragma: no cover — fs error, never block
+        LOG.warning("flock fallback unavailable (%s) — passing through", e)
+        return True
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        # Acquired. Stamp the holder for human debugging. Intentionally do NOT
+        # close fd here so the lock survives until process exit.
+        try:
+            os.ftruncate(fd, 0)
+            os.write(fd, json.dumps({
+                "task_id": task_id or "",
+                "pid": os.getpid(),
+                "host": socket.gethostname(),
+                "ts": time.time(),
+            }, separators=(",", ":")).encode("utf-8"))
+        except OSError:
+            pass
+        return True
+    except (OSError, BlockingIOError):
+        # Held by another local process right now — coarse same-machine race.
+        os.close(fd)
+        LOG.warning(
+            "LEASE FALLBACK CONTENTION: another local process is checking the "
+            "same path '%s' while Redis is down (this is an observability "
+            "WARN, the commit is NOT blocked)", path,
+        )
+        return False
 
 
 def _audit(event: str, **fields) -> None:
@@ -484,7 +554,13 @@ def _cmd_check(args) -> int:
     try:
         lease = AgentLease()
     except RedisUnavailable as e:
-        LOG.warning("Redis unavailable — passing through (no enforcement): %s", e)
+        # Option B (2026-05-29): Redis down → flock fallback (same-machine
+        # observability) + degraded audit line. HARD constraint preserved:
+        # we ALWAYS return 0 here — flock contention only emits a WARN, it
+        # never blocks the commit (the flock itself is non-blocking and is
+        # released at subprocess exit).
+        LOG.warning("Redis unavailable — flock fallback (no hard enforcement): %s", e)
+        flock_fallback_check(args.path, task_id=our_task_id)
         return 0
     try:
         blocking, holder = lease.check_path(args.path, our_task_id=our_task_id)

--- a/scripts/tests/test_agent_lease.py
+++ b/scripts/tests/test_agent_lease.py
@@ -218,9 +218,11 @@ def test_cli_check_kill_switch_disables_enforcement(monkeypatch, mod, capsys):
     assert rc == 0
 
 
-def test_cli_check_redis_down_passes_through(monkeypatch, mod):
+def test_cli_check_redis_down_passes_through(monkeypatch, mod, tmp_path):
     """Force AgentLease() to raise RedisUnavailable → check exits 0 (degraded)."""
     monkeypatch.setenv("AGENT_LEASE_ENFORCEMENT", "true")
+    monkeypatch.setattr(mod, "FALLBACK_LOCK_DIR", tmp_path / "lease-fallback")
+    monkeypatch.setattr(mod, "AUDIT_PATH", tmp_path / "leases.jsonl")
 
     class _Boom:
         def __init__(self, *a, **k):
@@ -229,6 +231,71 @@ def test_cli_check_redis_down_passes_through(monkeypatch, mod):
     monkeypatch.setattr(mod, "AgentLease", _Boom)
     rc = mod.main(["check", "apps/anything.py"])
     assert rc == 0
+
+
+# ── Option B: flock fallback when Redis is down ───────────────────────────────
+
+def test_flock_fallback_acquires_when_free(monkeypatch, mod, tmp_path):
+    """First caller on a free path gets the flock cleanly (returns True)."""
+    monkeypatch.setattr(mod, "FALLBACK_LOCK_DIR", tmp_path / "lease-fallback")
+    monkeypatch.setattr(mod, "AUDIT_PATH", tmp_path / "leases.jsonl")
+    assert mod.flock_fallback_check("apps/foo.py", task_id="task-A") is True
+    # A lock file must now exist under the fallback dir.
+    locks = list((tmp_path / "lease-fallback").glob("*.lock"))
+    assert len(locks) == 1
+
+
+def test_flock_fallback_detects_contention(monkeypatch, mod, tmp_path):
+    """A second process holding the SAME path's flock → returns False (WARN)."""
+    monkeypatch.setattr(mod, "FALLBACK_LOCK_DIR", tmp_path / "lease-fallback")
+    monkeypatch.setattr(mod, "AUDIT_PATH", tmp_path / "leases.jsonl")
+    path = "infra/launchagents/foo.sh"
+    lock_file = mod._fallback_lock_path(path)
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+    # Simulate another local process holding the lock.
+    import fcntl as _fcntl
+    fd = os.open(str(lock_file), os.O_CREAT | os.O_RDWR, 0o600)
+    _fcntl.flock(fd, _fcntl.LOCK_EX | _fcntl.LOCK_NB)
+    try:
+        assert mod.flock_fallback_check(path, task_id="task-B") is False
+    finally:
+        _fcntl.flock(fd, _fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def test_flock_fallback_writes_degraded_audit(monkeypatch, mod, tmp_path):
+    """The fallback path must emit a degraded=true audit record (Option C fold-in)."""
+    monkeypatch.setattr(mod, "FALLBACK_LOCK_DIR", tmp_path / "lease-fallback")
+    audit = tmp_path / "leases.jsonl"
+    monkeypatch.setattr(mod, "AUDIT_PATH", audit)
+    mod.flock_fallback_check("apps/bar.py", task_id="task-C")
+    lines = audit.read_text().splitlines()
+    degraded = [json.loads(l) for l in lines if json.loads(l).get("degraded")]
+    assert any(
+        r["event"] == "check-degraded" and r["backend"] == "flock-fallback"
+        for r in degraded
+    )
+
+
+def test_cli_check_redis_down_takes_flock_fallback(monkeypatch, mod, tmp_path):
+    """Redis down → _cmd_check exits 0 AND a degraded audit line is written."""
+    monkeypatch.setenv("AGENT_LEASE_ENFORCEMENT", "true")
+    monkeypatch.setattr(mod, "FALLBACK_LOCK_DIR", tmp_path / "lease-fallback")
+    audit = tmp_path / "leases.jsonl"
+    monkeypatch.setattr(mod, "AUDIT_PATH", audit)
+
+    class _Boom:
+        def __init__(self, *a, **k):
+            raise mod.RedisUnavailable("simulated outage")
+
+    monkeypatch.setattr(mod, "AgentLease", _Boom)
+    rc = mod.main(["check", "infra/launchagents/x.sh"])
+    assert rc == 0  # HARD constraint: never block on Redis outage
+    assert audit.exists()
+    assert any(
+        json.loads(l).get("event") == "check-degraded"
+        for l in audit.read_text().splitlines()
+    )
 
 
 def _patch_agent_lease_ctor(monkeypatch, mod, fake_client):


### PR DESCRIPTION
## Summary
- When Redis is unreachable, `agent-lease check` (the pre-commit hot-zone gate) used to `return 0` (bare pass-through). The lease system silently disappeared exactly during the high-activity windows most likely to race.
- **Option B** (operator-endorsed 2026-05-29): on Redis-down, fall back to a per-path **non-blocking `flock`** advisory lock under `~/.agent/lease-fallback/<sha>.lock`. A second LOCAL process checking the SAME path in the same commit window sees the flock held → emits a visible WARN (coarse same-machine contention signal).
- Folds in **Option C** audit: a `degraded=true` / `event=check-degraded` record is written to `~/.agent/leases.jsonl` on every fallback, so a daily report can surface how often Redis was down during hot-zone commits.

## HARD constraint preserved
This path **always** returns exit 0. The flock is non-blocking and released at subprocess exit → it can never deadlock a commit. It is observability defense-in-depth, **NOT** a hard serializer. Cross-node Pro/Mini races are out of scope (rarer; most fan-out is single-machine).

## Changes
- `scripts/agent_lease.py`: + `fcntl`/`hashlib` imports, `FALLBACK_LOCK_DIR`, `_fallback_lock_path()`, `flock_fallback_check()`, wired into the `except RedisUnavailable` branch of `_cmd_check`.
- `scripts/tests/test_agent_lease.py`: 4 new tests (acquire-when-free, contention-detect, degraded-audit, cli-redis-down-takes-fallback).

## Test plan
- [x] 40/41 pass in worktree. My 4 new flock-fallback tests all pass.
- [x] The 1 failure (`test_cli_check_blocks_when_held_by_other`) is **pre-existing on baseline HEAD** `ad8928019` — verified via `git show HEAD`. It exercises the Redis-UP fakeredis monkeypatch path, unrelated to this change. Left untouched to keep this hot-zone PR atomic.

Reference: `research/operations/2026-05-29-redis-lease-fail-closed-escalation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)