### PR TITLE
chore(wr2): cutover canva-apply LaunchAgent to headless actuator

### DIFF
--- a/infra/launchagents/com.balizero.wr2.canva-apply.plist
+++ b/infra/launchagents/com.balizero.wr2.canva-apply.plist
@@ -12,6 +12,10 @@
 		<string>/Users/nuzantara/Desktop/nuzantara-deploy</string>
 		<key>WR2_OUTPUT_ROOT</key>
 		<string>/Users/nuzantara/Desktop/nuzantara/apps/war-room/output/canva</string>
+		<key>WR2_CANVA_ACTUATOR</key>
+		<string>headless</string>
+		<key>WR2_HEADLESS_TIMEOUT_SEC</key>
+		<string>900</string>
 	</dict>
 	<key>Label</key>
 	<string>com.balizero.wr2.canva-apply</string>


### PR DESCRIPTION
## Summary
- Follow-up to #929 (headless Canva actuator). Flips the production `com.balizero.wr2.canva-apply` LaunchAgent from the AppleScript-GUI path to the new headless `claude -p` actuator.
- Adds two env vars to `infra/launchagents/com.balizero.wr2.canva-apply.plist`:
  - `WR2_CANVA_ACTUATOR=headless` — selects the headless dispatch branch in `scripts/wr2_canva_desktop_apply.py`
  - `WR2_HEADLESS_TIMEOUT_SEC=900` — wall-clock cap for the headless subprocess
- The installed plist (`~/Library/LaunchAgents/...`) has already been patched + `launchctl bootstrap`-reloaded; `launchctl print` confirms all three env vars live (`WR2_CANVA_ACTUATOR`, `WR2_HEADLESS_TIMEOUT_SEC`, `WR2_OUTPUT_ROOT`).

## Why a separate PR
The plist commit was authored after #929 merged; this keeps the repo's `infra/launchagents/` copy in sync with the now-live installed plist.

## Test plan
- [x] `plutil -lint` OK on both repo and installed plist.
- [x] `launchctl bootout` + `bootstrap` reload succeeded; env vars verified via `launchctl print`.
- [ ] Next scheduled canva-apply run executes via headless actuator (desktop AppleScript fallback remains intact if `WR2_CANVA_ACTUATOR` unset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)