### PR TITLE
fix(kbli): add self-referencing canonicals to index routes

### DIFF
--- a/apps/mouth/src/app/kbli/page.tsx
+++ b/apps/mouth/src/app/kbli/page.tsx
@@ -17,6 +17,9 @@ export const metadata: Metadata = {
       "The definitive guide to Indonesia's KBLI 2025 business classification. 1,563 codes, PMA rules, and AI-powered analysis.",
     type: "website",
   },
+  alternates: {
+    canonical: "https://balizero.com/kbli",
+  },
 };
 
 export default async function KBLIHomePage({

--- a/apps/mouth/src/app/kbli/sectors/page.tsx
+++ b/apps/mouth/src/app/kbli/sectors/page.tsx
@@ -7,6 +7,9 @@ export const metadata: Metadata = {
   title: "KBLI 2025 Sectors — Browse All Business Categories",
   description:
     "Browse all 22 KBLI 2025 business sectors. Indonesia's complete business classification system with PMA rules and licensing requirements.",
+  alternates: {
+    canonical: "https://balizero.com/kbli/sectors",
+  },
 };
 
 export default function SectorsPage() {


### PR DESCRIPTION
## Title

fix(kbli): add self-referencing canonicals to index routes

## Summary

Adds explicit self-referencing canonical URLs to KBLI index routes:

* `/kbli`
* `/kbli/sectors`

This strengthens canonical ownership signals for search engines and reduces the risk of query-string variants being selected as canonical URLs.

## Changes

* Added canonical metadata to `apps/mouth/src/app/kbli/page.tsx`
* Added canonical metadata to `apps/mouth/src/app/kbli/sectors/page.tsx`

No routing, rendering, analytics, ISR, or data-fetching logic was modified.

## Verification

* `npm run typecheck` ✅
* `npm run build -w apps/mouth` ✅
* Static generation completed successfully
* No TypeScript errors
* No prerender errors

## Risk

Very low.

Metadata-only change affecting two index routes.

---

### Studio Layer

**Insight:** KBLI index routes lacked explicit self-referencing canonicals.

**Evidence:** KBLI indexability audit identified missing canonical tags on `/kbli` and `/kbli/sectors`.

**Reasoning:** Explicit canonicals improve URL ownership signals and reduce crawl ambiguity without changing application behavior.

**Risk:** Extremely low. Metadata-only change with no impact on rendering, analytics, routing, or ISR.

**Recommendation:** Verify rendered `<link rel="canonical">` tags on both routes after deployment.

**Next Action:** Review KBLI index coverage in GSC before considering any changes to the current ISR strategy (`generateStaticParams` scope).
