### PR TITLE
feat(ops): audit codex spark freshness signal

### DIFF
--- a/research/operations/2026-05-29-codex-spark-state-freshness-audit.md
+++ b/research/operations/2026-05-29-codex-spark-state-freshness-audit.md
@@ -1,0 +1,89 @@
+# Codex Spark State Freshness Audit
+
+Generated: 2026-05-29 23:12 Asia/Makassar
+Dispatch: `28f7c2ac5dc9`
+Branch: `codex-overnight/spark-alarm-20260529_230845-spark-dispatch-20260529_230744-scout-28f7c2ac5dc9-20260529_230846`
+
+## Outcome
+
+The actionable Spark signal is not a Spark lifecycle failure. Live checks show the Spark loop is running, the alarm and harvester are healthy timer jobs between ticks, and the dispatch state files are fresh for the 23:07-23:09 handoff.
+
+No automated remediation was applied to the main checkout because the only confirmed remaining issue is mixed, unowned dirty work in `/Users/nuzantara/Desktop/nuzantara`. That checkout must be triaged by ownership before any stash, reset, commit, or cleanup.
+
+## Live Evidence
+
+- Machine: `nuzantara@Nuzantara`.
+- Peer: `nuzantara@mini-pro2` reachable.
+- Pro overnight worktree head: `dd0ebd543 fix(kbli): add self-referencing canonicals to index routes (#940)`.
+- Mini repo head: `3a9011c19 chore(wr2): cutover canva-apply LaunchAgent to headless actuator (#933)`.
+- Sync warning: Pro overnight worktree and Mini are out of sync.
+
+LaunchAgent state:
+
+- `com.nuzantara.codex-spark-loop`: `state = running`, active PID `28682`, last exit code `0`.
+- `com.nuzantara.codex-spark-alarm`: `state = not running`, last exit code `0`, run interval `120 seconds`.
+- `com.nuzantara.codex-spark-harvester`: `state = not running`, last exit code `0`, run interval `180 seconds`.
+
+Spark state files:
+
+- `codex_com_nuzantara_codex_spark_loop.state.json`: updated `2026-05-29T23:08:09+0800`, action `dispatched`, outcome `action`.
+- `codex_com_nuzantara_codex_spark_alarm.state.json`: updated `2026-05-29T23:08:46+0800`, action `promoted`, outcome `action`.
+- `codex_com_nuzantara_codex_spark_harvester.state.json`: updated `2026-05-29T23:08:45+0800`, action `backlog_waiting`, outcome `idle`.
+- `codex_com_nuzantara_codex_overnight_runner.state.json`: updated `2026-05-29T23:09:00+0800`, action `attempt_started`, outcome `action`.
+
+Log checks:
+
+- `/Users/nuzantara/logs/codex-spark-loop/scout-20260529_230744.log` shows tick start at `23:07:44` and exit `0` at `23:08:09`.
+- `/Users/nuzantara/logs/codex-spark-loop/scout-20260529_230744.jsonl` has no matching `error`, `failed`, `traceback`, `exception`, `panic`, `fatal`, `permission denied`, `token_invalidated`, or `terminated` lines.
+- Spark alarm output shows fresh Spark checks from `22:22` through `23:10`, promotion at `23:08:45`, runner kickstart at `23:08:46`, then `queue_busy count=1`.
+- Spark harvester output shows idle queue/backlog checks until `23:05:43`, then `backlog_waiting queue=0 backlog=1` at `23:08:45`.
+- Alarm and harvester stderr files are old and unchanged in this audit window.
+
+Main checkout dirty state:
+
+```text
+## work-main-2026-05-29...origin/main [behind 2]
+ M .claude/rules/cicatrix-scars.md
+ M research/visa/2026-05-26-c5a-content-creator-deep-research.md
+ M shared/escalations_pro.jsonl
+?? research/nb-health/2026-05-29-health.md
+?? research/operations/2026-05-29-flow-tier1p5-veo-model-mapping.md
+?? research/regulatory/2026-05-29-delta.json
+?? scripts/wr3_gatekeeper_check.py
+?? scripts/wr3_render_episode.py
+```
+
+## Recommended Next Action
+
+Perform a read-only ownership triage of the dirty main checkout before any cleanup:
+
+1. Record `git -C /Users/nuzantara/Desktop/nuzantara status --short --branch`.
+2. For each dirty path, identify whether it belongs to an active workstream, a generated runtime artifact, or abandoned scratch.
+3. Preserve unknown or shared operational changes in a named stash rather than mixing them into an unrelated commit.
+4. Only after ownership is known, decide whether each path should be committed, moved to an isolated worktree, stashed, or deleted.
+5. Re-check Pro/Mini sync after main checkout cleanup; do not push from Mini to `origin`.
+
+Do not classify `spark-alarm` or `spark-harvester` as failed solely because they are `not running` between StartInterval ticks with last exit code `0`.
+
+## Reproduction Commands
+
+```bash
+launchctl print gui/$(id -u)/com.nuzantara.codex-spark-loop
+launchctl print gui/$(id -u)/com.nuzantara.codex-spark-alarm
+launchctl print gui/$(id -u)/com.nuzantara.codex-spark-harvester
+
+for f in \
+  /Users/nuzantara/.agent/decisions/state/codex_com_nuzantara_codex_spark_loop.state.json \
+  /Users/nuzantara/.agent/decisions/state/codex_com_nuzantara_codex_spark_alarm.state.json \
+  /Users/nuzantara/.agent/decisions/state/codex_com_nuzantara_codex_spark_harvester.state.json \
+  /Users/nuzantara/.agent/decisions/state/codex_com_nuzantara_codex_overnight_runner.state.json
+do
+  stat -f 'mtime=%Sm size=%z' -t '%Y-%m-%dT%H:%M:%S%z' "$f"
+  jq . "$f"
+done
+
+git -C /Users/nuzantara/Desktop/nuzantara status --short --branch
+tail -n 80 /Users/nuzantara/logs/codex-spark-alarm/launchd.out.log
+tail -n 80 /Users/nuzantara/logs/codex-spark-harvester/launchd.out.log
+tail -n 80 /Users/nuzantara/logs/codex-spark-loop/launchd.out.log
+```


### PR DESCRIPTION
## Summary\n- Verified the Spark scout actionable signal live from launchd, state JSON, logs, and main checkout status.\n- Documented that Spark loop/alarm/harvester are healthy and that the remaining risk is unowned dirty work in the main checkout.\n- Added a short operations audit/spec with reproduction commands and safe next steps.\n\n## Validation\n- git diff --cached --check\n- source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && PYTHONPATH=. python -c "from backend.app.dependencies import get_current_user; print('OK')"\n- source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && PYTHONPATH=. pytest backend/tests/services/rag/test_kg_langgraph.py backend/tests/services/rag/test_kg_subgraphs.py backend/tests/services/rag/test_confidence.py -q\n\n## Notes\n- Pro/Mini sync was out of sync during the audit: Pro overnight worktree head d0ce3f678 after commit, Mini repo head observed as 3a9011c19 before the commit.\n- No production deploy performed.