### PR TITLE
chore(deps): isolate openai-stack into its own dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,25 @@ updates:
       - dependency-name: "sentence-transformers"
         update-types: ["version-update:semver-major"]
     groups:
+      # OpenAI-stack packages isolated into their own group so a breaking bump
+      # (openai/langchain-openai sit near the frozen embedding path:
+      # text-embedding-3-small / 1536-dim / 93,283 vectors, CLAUDE.md sec.9)
+      # only fails a small, individually-mergeable PR instead of the whole
+      # batch. Both groups still receive minor+patch — nothing is ignored.
+      # (see closed PR #935: 60-pkg group failed 4 required checks as a unit)
+      openai-stack:
+        patterns:
+          - "openai"
+          - "langchain*"
+          - "tiktoken"
+        update-types:
+          - "minor"
+          - "patch"
       minor-and-patch:
+        exclude-patterns:
+          - "openai"
+          - "langchain*"
+          - "tiktoken"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Why

Closed PR #935 was a dependabot `minor-and-patch` group bumping **60 backend packages at once**. It failed 4 of its own required checks (Backend Tests, E2E, Schemathesis, SonarQube) — PR-specific, not environmental (baseline PRs #926/#950 pass those same 4 checks). A grouped bump can't be partially merged, so one breaking package took down the whole batch; #935 was closed so dependabot regroups into smaller, mergeable chunks.

The pip block in `.github/dependabot.yml` had **no isolation** for `openai` / `langchain-openai`, which sit near the frozen embedding invariant (`text-embedding-3-small` / 1536-dim / 93,283 vectors, CLAUDE.md §9). Bundling them with ~58 other packages means any future breakage there keeps blocking the entire batch.

## What

Split `openai` / `langchain*` / `tiktoken` into a dedicated `openai-stack` dependabot group and `exclude-patterns` them from `minor-and-patch`, in the pip ecosystem block only.

- Both groups still receive **minor + patch** updates — **nothing is ignored**.
- A breakage in the OpenAI stack now only fails a **small, individually-mergeable PR** instead of the entire dependency batch.
- Only `.github/dependabot.yml` touched — no code changes. YAML validated (both pip groups, preserved torch/sentence-transformers ignore rules, untouched npm + github-actions blocks); prettier-clean.

## Note re: #935

The `openai 2.37->2.38` / `langchain-openai 1.2.1->1.2.2` bumps themselves were safe w.r.t. the frozen embedding invariant (no `text-embedding-3-small`/1536/`tiktoken` change in that diff) — they just need to arrive via a green, isolated PR going forward, which this config enables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)