### PR TITLE
fix(whatsapp): guard villa KBLI mapping replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 281 routers · 579 services
+- Backend: FastAPI · 281 routers · 580 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 27 · Packages: 5

--- a/apps/backend-rag/backend/app/routers/whatsapp_chat.py
+++ b/apps/backend-rag/backend/app/routers/whatsapp_chat.py
@@ -33,6 +33,7 @@ from backend.services.integrations.whatsapp_triage_service import (
     TriageDecision,
     whatsapp_triage_service,
 )
+from backend.services.whatsapp_kbli_guard import sanitize_whatsapp_kbli_reply
 from backend.services.whatsapp_onboarding_detector import get_onboarding_detector
 
 logger = logging.getLogger(__name__)
@@ -366,6 +367,21 @@ async def process_whatsapp_message(
             )
 
             if openclaw_response:
+                guarded_openclaw_response = sanitize_whatsapp_kbli_reply(
+                    message_text=message_text,
+                    reply=openclaw_response,
+                    detected_language=ctx.get("detected_language"),
+                )
+                if guarded_openclaw_response.corrected:
+                    logger.warning(
+                        "WhatsApp KBLI guard corrected OpenClaw reply "
+                        "(phone=%s message_id=%s reason=%s)",
+                        phone,
+                        message_id,
+                        guarded_openclaw_response.reason,
+                    )
+                openclaw_response = guarded_openclaw_response.reply
+
                 chunks = whatsapp_service.chunk_message(openclaw_response, max_length=4000)
 
                 for i, chunk in enumerate(chunks):
@@ -478,6 +494,21 @@ async def process_whatsapp_message(
             if needs_escalation:
                 # Remove the marker before sending to client
                 response_text = response_text.replace("[ESCALATE]", "").strip()
+
+            guarded_response = sanitize_whatsapp_kbli_reply(
+                message_text=message_text,
+                reply=response_text,
+                detected_language=ctx.get("detected_language"),
+            )
+            if guarded_response.corrected:
+                logger.warning(
+                    "WhatsApp KBLI guard corrected fallback RAG reply "
+                    "(phone=%s message_id=%s reason=%s)",
+                    phone,
+                    message_id,
+                    guarded_response.reason,
+                )
+            response_text = guarded_response.reply
 
             # Split into chunks if too long for WhatsApp
             chunks = whatsapp_service.chunk_message(response_text, max_length=4000)

--- a/apps/backend-rag/backend/prompts/zantara_core.py
+++ b/apps/backend-rag/backend/prompts/zantara_core.py
@@ -128,6 +128,14 @@ TOOL_USAGE_POLICY: str = """\
 - When clients need to explore multiple codes or compare options → Suggest: "You can explore all KBLI 2025 codes interactively at https://balizero.com/kbli"
 - The Navigator has: full-text search, PMA status filters, risk category info, and detailed descriptions for all 9,612 codes
 
+**RULE 5: VILLA/AIRBNB 55193 VS 55203 MAPPING**
+- For villa/Airbnb/accommodation-short-stay questions, do NOT treat 55193 and 55203 as two equal current choices.
+- `55193` = KBLI 2020 / PP28 source code for Vila in the migration mapping.
+- `55203` = KBLI 2025 code for `AKTIVITAS VILA`; use this as the primary 2025 direction for villas operated as short-stay accommodation.
+- If the company manages villas owned by third parties for a management fee, also check `55901` (`AKTIVITAS JASA MANAJEMEN AKOMODASI`).
+- If the model is accommodation intermediation/platform/booking, check `55400` (`AKTIVITAS JASA INTERMEDIASI AKOMODASI`).
+- If a client asks "55193 or 55203?", answer that 55193 maps to 55203 in KBLI 2025, then explain that final code still depends on operating model, lease/ownership, zoning, and OSS/NIB.
+
 **Keywords that trigger vector_search(collection="kbli_2025_final"):**
 "kbli", "codice kbli", "kode kbli", "classificazione", "classification", "klasifikasi",
 "attività permesse", "permitted activities", "kegiatan usaha", "business activity",

--- a/apps/backend-rag/backend/services/whatsapp_kbli_guard.py
+++ b/apps/backend-rag/backend/services/whatsapp_kbli_guard.py
@@ -1,0 +1,221 @@
+"""Deterministic WhatsApp guardrails for high-risk KBLI villa answers."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+_KBLI_CODE_RE = re.compile(r"\b\d{5}\b")
+_UNRELATED_OFF_TOPIC_CODES = frozenset(
+    {
+        "20113",
+        "20291",
+        "43224",
+        "52322",
+        "59201",
+        "61106",
+        "65201",
+    }
+)
+_VILLA_TERMS = (
+    "airbnb",
+    "akomodasi",
+    "alloggio",
+    "booking",
+    "holiday rental",
+    "otel",
+    "ota",
+    "rent",
+    "rental",
+    "sewa",
+    "short stay",
+    "short-term",
+    "villa",
+    "vila",
+    "ville",
+)
+_KBLI_TERMS = ("kbli", "code", "codes", "codice", "codici", "kode")
+_COMPARE_TERMS = (
+    "beda",
+    "compare",
+    "difference",
+    "differenza",
+    "mana",
+    "qual",
+    "quale",
+    "vs",
+)
+_MAPPING_TERMS = (
+    "2020",
+    "2025",
+    "legacy",
+    "mappa",
+    "mappato",
+    "mapped",
+    "mapping",
+    "pp28",
+    "renumber",
+    "rinumer",
+    "source",
+    "sorgente",
+    "vecchio",
+)
+
+
+@dataclass(frozen=True)
+class KbliGuardResult:
+    """Result of a deterministic KBLI WhatsApp response check."""
+
+    reply: str
+    corrected: bool
+    reason: str | None = None
+
+
+def _normalize(value: str) -> str:
+    return (
+        value.casefold()
+        .replace("\u2018", "'")
+        .replace("\u2019", "'")
+        .replace("\u201c", '"')
+        .replace("\u201d", '"')
+        .replace("\u2013", "-")
+        .replace("\u2014", "-")
+    )
+
+
+def _contains_any(value: str, terms: tuple[str, ...]) -> bool:
+    return any(term in value for term in terms)
+
+
+def _codes_in(value: str) -> set[str]:
+    return set(_KBLI_CODE_RE.findall(value))
+
+
+def is_villa_kbli_query(message_text: str) -> bool:
+    """Return True for villa/Airbnb KBLI questions that need strict handling."""
+    normalized = _normalize(message_text)
+    codes = _codes_in(normalized)
+
+    if {"55193", "55203"}.issubset(codes):
+        return True
+
+    if (codes & {"55193", "55203"}) and _contains_any(normalized, _COMPARE_TERMS):
+        return True
+
+    if _contains_any(normalized, _KBLI_TERMS) and _contains_any(normalized, _VILLA_TERMS):
+        return True
+
+    if (codes & {"55193", "55203", "55901", "55400"}) and _contains_any(
+        normalized,
+        _VILLA_TERMS,
+    ):
+        return True
+
+    return False
+
+
+def _language_for(message_text: str, detected_language: str | None) -> str:
+    language = (detected_language or "").casefold()
+    if language.startswith(("it", "id", "en")):
+        return language[:2]
+
+    normalized = _normalize(message_text)
+    if any(term in normalized for term in ("quanto", "differenza", "codice", "ville")):
+        return "it"
+    if any(term in normalized for term in ("berapa", "kode", "mana", "sewa", "vila")):
+        return "id"
+    return "en"
+
+
+def _villa_kbli_answer(language: str) -> str:
+    if language == "id":
+        return (
+            "Perbedaannya begini:\n\n"
+            "55203 - AKTIVITAS VILA: kode KBLI 2025 yang dipakai sebagai arah utama "
+            "untuk villa/Airbnb jika perusahaan mengoperasikan villa sebagai akomodasi "
+            "jangka pendek.\n\n"
+            "55193: bukan kode villa 2025 yang dipilih terpisah. Di dataset kami, ini "
+            "kode sumber KBLI 2020/PP28 yang dipetakan ke 55203 di KBLI 2025.\n\n"
+            "Kalau hanya mengelola villa milik pihak ketiga dengan management fee, cek "
+            "55901. Kalau modelnya platform/intermediasi akomodasi, cek 55400. Finalnya "
+            "tetap perlu diverifikasi dari model bisnis, lease/ownership, zoning, dan OSS/NIB."
+        )
+
+    if language == "en":
+        return (
+            "The practical difference is:\n\n"
+            "55203 - AKTIVITAS VILA: the KBLI 2025 code to check first for villas/Airbnb "
+            "when the company operates the villa as short-stay accommodation.\n\n"
+            "55193: not a separate current villa code to choose in KBLI 2025. In our "
+            "dataset it is the KBLI 2020/PP28 source code that maps to 55203 in KBLI 2025.\n\n"
+            "If you manage third-party villas for a management fee, check 55901. If the "
+            "model is accommodation intermediation/platform/booking, check 55400. The final "
+            "code still depends on the operating model, lease/ownership, zoning, and OSS/NIB."
+        )
+
+    return (
+        "La differenza pratica e' questa:\n\n"
+        "55203 - AKTIVITAS VILA: e' il codice KBLI 2025 da verificare per ville/Airbnb "
+        "quando la societa' opera la villa come alloggio breve.\n\n"
+        "55193: non e' un secondo codice villa 2025 da scegliere. Nel nostro dataset e' "
+        "il codice sorgente KBLI 2020/PP28 che mappa a 55203 nel KBLI 2025.\n\n"
+        "Se invece gestisci ville di terzi con management fee, va verificato 55901. Se il "
+        "modello e' piattaforma/intermediazione/prenotazione accommodation, va verificato "
+        "55400. Il codice finale dipende comunque da modello operativo, lease/ownership, "
+        "zoning e OSS/NIB."
+    )
+
+
+def _reply_explains_55193_55203_mapping(reply: str) -> bool:
+    normalized = _normalize(reply)
+    codes = _codes_in(normalized)
+    return (
+        {"55193", "55203"}.issubset(codes)
+        and _contains_any(normalized, _MAPPING_TERMS)
+        and ("villa" in normalized or "vila" in normalized)
+    )
+
+
+def _reply_needs_villa_kbli_correction(message_text: str, reply: str) -> str | None:
+    if not is_villa_kbli_query(message_text):
+        return None
+
+    normalized_reply = _normalize(reply)
+    reply_codes = _codes_in(normalized_reply)
+    message_codes = _codes_in(_normalize(message_text))
+
+    off_topic_codes = sorted(reply_codes & _UNRELATED_OFF_TOPIC_CODES)
+    if off_topic_codes:
+        return "off_topic_kbli_codes:" + ",".join(off_topic_codes)
+
+    if {"55193", "55203"}.issubset(message_codes) and not _reply_explains_55193_55203_mapping(
+        reply,
+    ):
+        return "missing_55193_to_55203_mapping"
+
+    if "55193" in reply_codes and not _reply_explains_55193_55203_mapping(reply):
+        return "legacy_55193_without_2025_mapping"
+
+    if _contains_any(_normalize(message_text), _VILLA_TERMS) and "55203" not in reply_codes:
+        return "villa_query_without_55203"
+
+    return None
+
+
+def sanitize_whatsapp_kbli_reply(
+    *,
+    message_text: str,
+    reply: str,
+    detected_language: str | None = None,
+) -> KbliGuardResult:
+    """Replace unsafe villa KBLI replies with a canonical client-safe answer."""
+    reason = _reply_needs_villa_kbli_correction(message_text, reply)
+    if reason is None:
+        return KbliGuardResult(reply=reply, corrected=False)
+
+    language = _language_for(message_text, detected_language)
+    return KbliGuardResult(
+        reply=_villa_kbli_answer(language),
+        corrected=True,
+        reason=reason,
+    )

--- a/apps/backend-rag/backend/tests/unit/routers/test_whatsapp_chat_coverage.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_whatsapp_chat_coverage.py
@@ -706,6 +706,73 @@ async def test_process_whatsapp_message_onboarding_triggered():
 
 
 @pytest.mark.asyncio
+async def test_process_whatsapp_message_corrects_openclaw_villa_kbli_reply():
+    """OpenClaw replies are guarded before WhatsApp delivery."""
+    from backend.app.routers.whatsapp_chat import process_whatsapp_message
+    from backend.services.integrations.whatsapp_triage_service import TriageDecision
+
+    mock_request = MagicMock()
+    mock_triage_service = MagicMock()
+    mock_triage_service.is_allowed.return_value = True
+    mock_triage_service.should_escalate = AsyncMock(
+        return_value=(TriageDecision.BOT_CAN_HANDLE, "business_query")
+    )
+
+    mock_wa_service = MagicMock()
+    mock_wa_service.mark_message_read = AsyncMock()
+    mock_wa_service.send_message = AsyncMock()
+    mock_wa_service.chunk_message.side_effect = lambda text, max_length: [text]
+
+    mock_onboarding = MagicMock()
+    mock_onboarding.detect_and_trigger = AsyncMock(return_value=None)
+
+    context = {
+        "_wa_user_id": "whatsapp_6281234567890",
+        "_session_id": "wa_session_6281234567890",
+        "_existing_row_id": None,
+        "client_name": "Test Client",
+        "client_profile": {"detected_language": "it"},
+        "conversation_history": [],
+        "detected_language": "it",
+        "is_first_message": False,
+        "time_of_day": "afternoon",
+    }
+
+    with (
+        patch("backend.app.routers.whatsapp_chat.whatsapp_service", mock_wa_service),
+        patch("backend.app.routers.whatsapp_chat.whatsapp_triage_service", mock_triage_service),
+        patch(
+            "backend.app.routers.whatsapp_chat.get_onboarding_detector",
+            return_value=mock_onboarding,
+        ),
+        patch(
+            "backend.services.whatsapp_context_builder.build_context",
+            new=AsyncMock(return_value=context),
+        ),
+        patch(
+            "backend.app.routers.whatsapp_chat.ask_openclaw_whatsapp",
+            new=AsyncMock(return_value="55193 - Aktivitas Vila: usa questo per Airbnb."),
+        ),
+        patch("backend.app.routers.whatsapp_chat.notify_zero_conversation_log", new=AsyncMock()),
+        patch("backend.app.routers.whatsapp_chat._save_conversation", new=AsyncMock()),
+        patch("backend.app.routers.whatsapp_chat._get_db_pool", return_value=None),
+    ):
+        await process_whatsapp_message(
+            phone="6281234567890",
+            message_text="ma 55193 o 55203?",
+            sender_name="Test Client",
+            message_id="msg_kbli_guard",
+            request=mock_request,
+        )
+
+    sent_text = mock_wa_service.send_message.call_args.kwargs["text"]
+    assert "55203" in sent_text
+    assert "55193" in sent_text
+    assert "KBLI 2020/PP28" in sent_text
+    assert "usa questo per Airbnb" not in sent_text
+
+
+@pytest.mark.asyncio
 async def test_save_conversation_inserts_messages_as_jsonb_array_text():
     """New WhatsApp conversations should store messages as parseable JSONB arrays."""
     from backend.app.routers.whatsapp_chat import _save_conversation

--- a/apps/backend-rag/backend/tests/unit/scripts/test_openclaw_whatsapp_bridge_script.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_openclaw_whatsapp_bridge_script.py
@@ -100,6 +100,49 @@ def test_build_prompt_marks_kbli_followup_from_recent_context() -> None:
     assert any("nuzantara-mcp.search_kbli" in rule for rule in prompt["tool_mandates"])
 
 
+def test_build_prompt_includes_villa_55193_to_55203_mapping_rule() -> None:
+    body = bridge.BridgeRequest(
+        phone="+62 812-345",
+        sender_name="Client",
+        message_id="wamid.villa",
+        text="ma per ville Airbnb e' 55193 o 55203?",
+        context={"detected_language": "it"},
+    )
+
+    prompt = json.loads(bridge._build_prompt(body))
+    contract = "\n".join(prompt["knowledge_tool_contract"])
+
+    assert "55193" in contract
+    assert "55203" in contract
+    assert "KBLI 2020/PP28" in contract
+    assert "KBLI 2025" in contract
+    assert "55901" in contract
+    assert "55400" in contract
+    assert "AC/ventilation" in contract
+
+
+def test_bridge_guard_corrects_bad_villa_55193_reply() -> None:
+    guarded = bridge._guard_villa_kbli_reply(
+        "ma per ville Airbnb e' 55193 o 55203?",
+        "55193 - Aktivitas Vila: usa questo codice per Airbnb.",
+        "it",
+    )
+
+    assert "55203" in guarded
+    assert "55193" in guarded
+    assert "KBLI 2020/PP28" in guarded
+    assert "usa questo codice" not in guarded
+
+
+def test_bridge_guard_keeps_grounded_villa_mapping_reply() -> None:
+    reply = (
+        "55193 era il codice KBLI 2020/PP28 sorgente; nel mapping KBLI 2025 "
+        "mappa a 55203 - AKTIVITAS VILA."
+    )
+
+    assert bridge._guard_villa_kbli_reply("Differenza 55193 vs 55203", reply, "it") == reply
+
+
 def test_run_script_uses_installed_bridge_app_dir() -> None:
     repo_root = Path(__file__).resolve().parents[6]
     script = (repo_root / "scripts" / "run_openclaw_whatsapp_bridge.sh").read_text(

--- a/apps/backend-rag/backend/tests/unit/services/test_whatsapp_kbli_guard.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_whatsapp_kbli_guard.py
@@ -1,0 +1,87 @@
+"""Tests for deterministic WhatsApp KBLI response guardrails."""
+
+from __future__ import annotations
+
+from backend.services.whatsapp_kbli_guard import (
+    is_villa_kbli_query,
+    sanitize_whatsapp_kbli_reply,
+)
+
+
+def test_detects_direct_55193_vs_55203_question() -> None:
+    assert is_villa_kbli_query("ma 55193 o 55203?") is True
+    assert is_villa_kbli_query("Differenza 55193 vs 55203") is True
+
+
+def test_corrects_legacy_55193_answer_without_mapping() -> None:
+    result = sanitize_whatsapp_kbli_reply(
+        message_text="ma 55193 o 55203?",
+        reply="55193 - Aktivitas Vila: se fai Airbnb usa questo codice.",
+        detected_language="it",
+    )
+
+    assert result.corrected is True
+    assert result.reason == "missing_55193_to_55203_mapping"
+    assert "55193" in result.reply
+    assert "55203" in result.reply
+    assert "KBLI 2020/PP28" in result.reply
+    assert "KBLI 2025" in result.reply
+
+
+def test_corrects_off_topic_kbli_codes_for_villa_query() -> None:
+    result = sanitize_whatsapp_kbli_reply(
+        message_text="che codici kbli servono per fittare ville su Airbnb?",
+        reply=(
+            "1. KBLI 43224 - Installazione di Condizionamento e Ventilazione.\n"
+            "2. KBLI 65201 - Riassicurazione Convenzionale."
+        ),
+        detected_language="it",
+    )
+
+    assert result.corrected is True
+    assert result.reason == "off_topic_kbli_codes:43224,65201"
+    assert "43224" not in result.reply
+    assert "65201" not in result.reply
+    assert "55203" in result.reply
+
+
+def test_keeps_precise_55193_to_55203_mapping_reply() -> None:
+    reply = (
+        "55193 e' il codice KBLI 2020/PP28 sorgente per Vila; nel KBLI 2025 "
+        "mappa a 55203 - Aktivitas Vila."
+    )
+
+    result = sanitize_whatsapp_kbli_reply(
+        message_text="Differenza 55193 vs 55203",
+        reply=reply,
+        detected_language="it",
+    )
+
+    assert result.corrected is False
+    assert result.reply == reply
+
+
+def test_ignores_unrelated_non_kbli_message() -> None:
+    reply = "Una nuova PT PMA con Bali Zero parte da 20.000.000 IDR."
+
+    result = sanitize_whatsapp_kbli_reply(
+        message_text="quanto costa una pma?",
+        reply=reply,
+        detected_language="it",
+    )
+
+    assert result.corrected is False
+    assert result.reply == reply
+
+
+def test_indonesian_villa_management_answer_mentions_management_and_platform_codes() -> None:
+    result = sanitize_whatsapp_kbli_reply(
+        message_text="Kode KBLI untuk manajemen vila Airbnb pihak ketiga apa?",
+        reply="Untuk villa bisa cek kode real estate dulu.",
+        detected_language="id",
+    )
+
+    assert result.corrected is True
+    assert "55203" in result.reply
+    assert "55901" in result.reply
+    assert "55400" in result.reply

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`281 routers · 579 services · 977 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`281 routers · 580 services · 978 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/scripts/openclaw_whatsapp_bridge.py
+++ b/scripts/openclaw_whatsapp_bridge.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 from typing import Any
 
 from fastapi import FastAPI, Header, HTTPException, Request
@@ -33,6 +34,50 @@ class BridgeRequest(BaseModel):
 
 
 app = FastAPI(title="OpenClaw WhatsApp Reply Bridge", redoc_url=None)
+
+_KBLI_CODE_RE = re.compile(r"\b\d{5}\b")
+_VILLA_KBLI_CODES = frozenset({"55193", "55203", "55901", "55400"})
+_UNRELATED_VILLA_CODES = frozenset(
+    {"20113", "20291", "43224", "52322", "59201", "61106", "65201"}
+)
+_VILLA_TERMS = (
+    "airbnb",
+    "akomodasi",
+    "alloggio",
+    "booking",
+    "ota",
+    "rent",
+    "rental",
+    "sewa",
+    "short stay",
+    "short-stay",
+    "villa",
+    "vila",
+    "ville",
+)
+_KBLI_TERMS = ("kbli", "code", "codes", "codice", "codici", "kode")
+_COMPARE_TERMS = (
+    "beda",
+    "compare",
+    "difference",
+    "differenza",
+    "mana",
+    "qual",
+    "quale",
+    "vs",
+)
+_MAPPING_TERMS = (
+    "2020",
+    "2025",
+    "mappa",
+    "mapped",
+    "mapping",
+    "pp28",
+    "rinumer",
+    "source",
+    "sorgente",
+    "vecchio",
+)
 
 
 def _tool_mandates(text: str, context: dict[str, Any] | None = None) -> list[str]:
@@ -93,6 +138,126 @@ def _tool_mandates(text: str, context: dict[str, Any] | None = None) -> list[str
     return mandates
 
 
+def _normalize_text(value: str) -> str:
+    return (
+        value.casefold()
+        .replace("\u2018", "'")
+        .replace("\u2019", "'")
+        .replace("\u201c", '"')
+        .replace("\u201d", '"')
+        .replace("\u2013", "-")
+        .replace("\u2014", "-")
+    )
+
+
+def _contains_any(value: str, terms: tuple[str, ...]) -> bool:
+    return any(term in value for term in terms)
+
+
+def _kbli_codes(value: str) -> set[str]:
+    return set(_KBLI_CODE_RE.findall(value))
+
+
+def _is_villa_kbli_query(message_text: str) -> bool:
+    normalized = _normalize_text(message_text)
+    codes = _kbli_codes(normalized)
+
+    if {"55193", "55203"}.issubset(codes):
+        return True
+    if (codes & {"55193", "55203"}) and _contains_any(normalized, _COMPARE_TERMS):
+        return True
+    if _contains_any(normalized, _KBLI_TERMS) and _contains_any(normalized, _VILLA_TERMS):
+        return True
+    return bool(codes & _VILLA_KBLI_CODES and _contains_any(normalized, _VILLA_TERMS))
+
+
+def _reply_explains_villa_mapping(reply: str) -> bool:
+    normalized = _normalize_text(reply)
+    codes = _kbli_codes(normalized)
+    return (
+        {"55193", "55203"}.issubset(codes)
+        and _contains_any(normalized, _MAPPING_TERMS)
+        and ("villa" in normalized or "vila" in normalized)
+    )
+
+
+def _villa_answer_language(message_text: str, detected_language: Any) -> str:
+    language = str(detected_language or "").casefold()
+    if language.startswith(("it", "id", "en")):
+        return language[:2]
+
+    normalized = _normalize_text(message_text)
+    if any(term in normalized for term in ("quanto", "differenza", "codice", "ville")):
+        return "it"
+    if any(term in normalized for term in ("berapa", "kode", "mana", "sewa", "vila")):
+        return "id"
+    return "en"
+
+
+def _canonical_villa_kbli_answer(language: str) -> str:
+    if language == "id":
+        return (
+            "Perbedaannya: 55203 - AKTIVITAS VILA adalah kode KBLI 2025 yang "
+            "dicek utama untuk villa/Airbnb jika perusahaan mengoperasikan villa "
+            "sebagai akomodasi short stay. 55193 bukan pilihan villa 2025 terpisah; "
+            "itu kode sumber KBLI 2020/PP28 yang dipetakan ke 55203. Jika hanya "
+            "mengelola villa pihak ketiga dengan management fee, cek 55901. Jika "
+            "modelnya platform/intermediasi booking akomodasi, cek 55400. Finalnya "
+            "tetap perlu diverifikasi dari model bisnis, lease/ownership, zoning, "
+            "dan OSS/NIB."
+        )
+    if language == "en":
+        return (
+            "The difference: 55203 - AKTIVITAS VILA is the KBLI 2025 code to check "
+            "first for villas/Airbnb when the company operates the villa as short-stay "
+            "accommodation. 55193 is not a separate current villa code in KBLI 2025; "
+            "it is the KBLI 2020/PP28 source code that maps to 55203. If you manage "
+            "third-party villas for a management fee, check 55901. If the model is "
+            "accommodation platform/intermediation/booking, check 55400. Final code "
+            "still depends on operating model, lease/ownership, zoning, and OSS/NIB."
+        )
+    return (
+        "La differenza: 55203 - AKTIVITAS VILA e' il codice KBLI 2025 da verificare "
+        "per ville/Airbnb quando la societa' opera la villa come alloggio breve. "
+        "55193 non e' un secondo codice villa 2025: e' il codice sorgente KBLI "
+        "2020/PP28 che mappa a 55203 nel KBLI 2025. Se gestisci ville di terzi con "
+        "management fee, verifica 55901. Se il modello e' piattaforma/intermediazione/"
+        "booking accommodation, verifica 55400. Il codice finale dipende da modello "
+        "operativo, lease/ownership, zoning e OSS/NIB."
+    )
+
+
+def _guard_villa_kbli_reply(
+    message_text: str,
+    reply: str,
+    detected_language: Any = None,
+) -> str:
+    if not _is_villa_kbli_query(message_text):
+        return reply
+
+    normalized_reply = _normalize_text(reply)
+    reply_codes = _kbli_codes(normalized_reply)
+    if reply_codes & _UNRELATED_VILLA_CODES:
+        return _canonical_villa_kbli_answer(
+            _villa_answer_language(message_text, detected_language)
+        )
+    if "55193" in reply_codes and not _reply_explains_villa_mapping(reply):
+        return _canonical_villa_kbli_answer(
+            _villa_answer_language(message_text, detected_language)
+        )
+    if {"55193", "55203"}.issubset(
+        _kbli_codes(_normalize_text(message_text))
+    ) and not _reply_explains_villa_mapping(reply):
+        return _canonical_villa_kbli_answer(
+            _villa_answer_language(message_text, detected_language)
+        )
+    if _contains_any(_normalize_text(message_text), _VILLA_TERMS) and "55203" not in reply_codes:
+        return _canonical_villa_kbli_answer(
+            _villa_answer_language(message_text, detected_language)
+        )
+    return reply
+
+
 def _expected_secret() -> str:
     secret = os.getenv("WHATSAPP_OPENCLAW_BRIDGE_SECRET") or os.getenv("OPENCLAW_WEBHOOK_SECRET", "")
     if not secret:
@@ -135,6 +300,7 @@ def _build_prompt(body: BridgeRequest) -> str:
         "knowledge_tool_contract": [
             "Use available Bali Zero knowledge, KBLI, visa, pricing, CRM, and compliance tools silently when relevant.",
             "For KBLI or company setup questions, call nuzantara-mcp.search_kbli before naming a KBLI code or likely activity direction.",
+            "For villa/Airbnb short-stay KBLI questions, explain that 55193 is the KBLI 2020/PP28 source code that maps to 55203 in KBLI 2025; 55203 is the current KBLI 2025 AKTIVITAS VILA direction. For third-party villa or accommodation management fee, check 55901. For accommodation intermediation, platform, or booking, check 55400. Never answer villa/Airbnb questions with unrelated KBLI codes such as AC/ventilation, insurance, adhesives, sound recording, flight permits, or IPTV.",
             "For food import, wholesale, distribution, or other broad KBLI matches, do not list speculative code numbers; describe the direction and say the team will verify the exact KBLI against the product and licensing requirements.",
             "For visa, immigration, and work-stay questions, call a lightweight internal Nuzantara tool such as nuzantara-mcp.list_visa_types or nuzantara-mcp.search_intel before answering; use nuzantara-mcp.ask_legal only when a legal interpretation is truly needed.",
             "For remote work on a tourist visa or VOA, do not state categorical immigration or tax conclusions unless the retrieved tool output explicitly supports them; otherwise say Bali Zero should verify the current visa direction with the immigration team.",
@@ -267,6 +433,11 @@ async def reply(
             body.message_id,
             body.model,
             body.thinking,
+        )
+        response_text = _guard_villa_kbli_reply(
+            body.text,
+            response_text,
+            body.context.get("detected_language") if body.context else None,
         )
     except Exception as exc:
         raise HTTPException(status_code=502, detail=f"OpenClaw failed: {exc}") from exc

--- a/scripts/openclaw_whatsapp_eval_cases.json
+++ b/scripts/openclaw_whatsapp_eval_cases.json
@@ -498,6 +498,42 @@
       "repair_hint": "Indonesian tax follow-up failed: use history, stay Indonesian, and verify tax penalties before certainty."
     },
     {
+      "id": "italian_villa_kbli_55193_vs_55203",
+      "category": "kbli_kb",
+      "message": "ma per ville Airbnb e' 55193 o 55203? spiegami la differenza",
+      "context": {
+        "detected_language": "it",
+        "is_first_message": false,
+        "conversation_history": [
+          {
+            "role": "user",
+            "text": "vorrei fittare ville su Airbnb"
+          },
+          {
+            "role": "assistant",
+            "text": "Per ville/Airbnb bisogna verificare il KBLI accommodation corretto."
+          }
+        ]
+      },
+      "must_contain_all": ["55193", "55203"],
+      "must_contain_any": ["2020", "PP28", "mappa", "mapping", "sorgente"],
+      "must_not_contain_any": [
+        "43224",
+        "65201",
+        "20291",
+        "61106",
+        "ventilazione",
+        "riassicurazione",
+        "openclaw",
+        "system prompt"
+      ],
+      "max_words": 135,
+      "plain_text": true,
+      "required_tool_any": ["nuzantara-mcp.search_kbli", "postgres-nuzantara.query"],
+      "max_tool_errors": 0,
+      "repair_hint": "Villa KBLI probe failed: explain 55193 as KBLI 2020/PP28 source mapped to 55203 in KBLI 2025; do not return unrelated KBLI codes."
+    },
+    {
       "id": "pricing_multi_service_quote",
       "category": "pricing_tool_safety",
       "message": "Can you quote PT PMA setup plus investor KITAS plus monthly tax support as one package?",


### PR DESCRIPTION
## Summary
- add deterministic WhatsApp KBLI guard for villa/Airbnb questions
- teach Zantara that 55193 is the KBLI 2020/PP28 source code mapped to 55203 in KBLI 2025
- guard OpenClaw bridge and WhatsApp router replies against unrelated KBLI codes
- add eval coverage for Italian 55193 vs 55203 WhatsApp flow

## Verification
- ruff check targeted WhatsApp/KBLI files
- PYTHONPATH=. pytest backend/tests/unit/scripts/test_openclaw_whatsapp_bridge_script.py backend/tests/unit/routers/test_whatsapp_chat_coverage.py backend/tests/unit/services/test_whatsapp_kbli_guard.py backend/tests/unit/scripts/test_openclaw_whatsapp_eval_script.py -q
- full local pre-push Python suite: 13889 passed, 809 skipped
- live OpenClaw WhatsApp eval italian_villa_kbli_55193_vs_55203: 1/1 passed

## Runtime
- updated and restarted local com.nuzantara.openclaw-whatsapp-bridge
- health check OK on 127.0.0.1:8789
