### PR TITLE
fix(infra): harden WR2 watchdog launchagent recovery

### DIFF
--- a/infra/launchagents/com.balizero.nuzantara.log-size-watchdog.plist
+++ b/infra/launchagents/com.balizero.nuzantara.log-size-watchdog.plist
@@ -34,16 +34,15 @@
     <string>com.balizero.nuzantara.log-size-watchdog</string>
 
     <!--
-      Script path: nuzantara-deploy worktree (pinned to origin/main via
-      wr2-deploy-pull cron). Same pattern as wr2-script-wrapper.sh —
-      prevents branch-hijack from breaking the watchdog. After this PR
-      merges to main, the next wr2-deploy-pull (~1h) will publish the
-      script to the deploy worktree automatically.
+      Prefer the nuzantara-deploy worktree when present, but fall back to
+      the main repo path. This watchdog should not crash-loop with exit 127
+      when the deploy worktree itself is missing.
     -->
     <key>ProgramArguments</key>
     <array>
       <string>/bin/bash</string>
-      <string>/Users/nuzantara/Desktop/nuzantara-deploy/scripts/log_size_watchdog.sh</string>
+      <string>-lc</string>
+      <string>if [[ -x /Users/nuzantara/Desktop/nuzantara-deploy/scripts/log_size_watchdog.sh ]]; then exec /Users/nuzantara/Desktop/nuzantara-deploy/scripts/log_size_watchdog.sh; fi; exec /Users/nuzantara/Desktop/nuzantara/scripts/log_size_watchdog.sh</string>
     </array>
 
     <key>StartInterval</key>

--- a/infra/launchagents/com.balizero.wr2.plist-watchdog.plist
+++ b/infra/launchagents/com.balizero.wr2.plist-watchdog.plist
@@ -18,7 +18,8 @@
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/bash</string>
-		<string>/Users/nuzantara/Desktop/nuzantara-deploy/scripts/wr2_plist_watchdog.sh</string>
+		<string>-lc</string>
+		<string>if [[ -x /Users/nuzantara/Desktop/nuzantara-deploy/scripts/wr2_plist_watchdog.sh ]]; then export WR2_REPO_ROOT=/Users/nuzantara/Desktop/nuzantara-deploy; exec /Users/nuzantara/Desktop/nuzantara-deploy/scripts/wr2_plist_watchdog.sh; fi; export WR2_REPO_ROOT=/Users/nuzantara/Desktop/nuzantara; exec /Users/nuzantara/Desktop/nuzantara/scripts/wr2_plist_watchdog.sh</string>
 	</array>
 	<key>StartInterval</key>
 	<integer>900</integer>

--- a/scripts/wr2_plist_watchdog.sh
+++ b/scripts/wr2_plist_watchdog.sh
@@ -49,6 +49,12 @@ _telegram() {
         >/dev/null 2>&1 || true
 }
 
+_plist_label() {
+    local plist="$1"
+    plutil -extract Label raw -o - "${plist}" 2>/dev/null \
+        || /usr/libexec/PlistBuddy -c "Print :Label" "${plist}" 2>/dev/null
+}
+
 if [[ ! -d "${SOURCE_DIR}" ]]; then
     echo "[wr2-plist-watchdog] source dir missing: ${SOURCE_DIR}" >&2
     exit 0
@@ -59,16 +65,21 @@ fi
 # write their own watchdog if they need one.
 shopt -s nullglob
 for source_plist in "${SOURCE_DIR}"/com.balizero.wr2.*.plist; do
-    label="$(basename "${source_plist}" .plist)"
-    target_plist="${TARGET_DIR}/${label}.plist"
+    plist_name="$(basename "${source_plist}" .plist)"
+    target_plist="${TARGET_DIR}/${plist_name}.plist"
+    label="$(_plist_label "${source_plist}")"
+    if [[ -z "${label}" ]]; then
+        ERRORS+=("${plist_name} (source plist missing Label)")
+        continue
+    fi
 
     if [[ ! -f "${target_plist}" ]]; then
-        echo "[wr2-plist-watchdog] ${label}: missing on disk, restoring..."
+        echo "[wr2-plist-watchdog] ${label}: missing on disk, restoring ${plist_name}.plist..."
         if cp "${source_plist}" "${target_plist}" 2>/dev/null && chmod 0444 "${target_plist}" 2>/dev/null; then
             if launchctl bootstrap "${DOMAIN}" "${target_plist}" 2>/dev/null; then
-                RECOVERIES+=("${label} (restored from git + bootstrapped)")
+                RECOVERIES+=("${label} (${plist_name}.plist restored from git + bootstrapped)")
             else
-                ERRORS+=("${label} (file restored, bootstrap failed)")
+                ERRORS+=("${label} (${plist_name}.plist restored, bootstrap failed)")
             fi
         else
             ERRORS+=("${label} (could not write to ${target_plist})")
@@ -80,9 +91,9 @@ for source_plist in "${SOURCE_DIR}"/com.balizero.wr2.*.plist; do
     if ! launchctl print "${DOMAIN}/${label}" >/dev/null 2>&1; then
         echo "[wr2-plist-watchdog] ${label}: file present but not loaded, bootstrapping..."
         if launchctl bootstrap "${DOMAIN}" "${target_plist}" 2>/dev/null; then
-            RECOVERIES+=("${label} (bootstrapped, file was already present)")
+            RECOVERIES+=("${label} (${plist_name}.plist bootstrapped, file was already present)")
         else
-            ERRORS+=("${label} (bootstrap failed; file present, launchctl unloaded)")
+            ERRORS+=("${label} (${plist_name}.plist bootstrap failed; file present, launchctl unloaded)")
         fi
     fi
 done

--- a/tests/lint/test_wr2_plist_watchdog_labels.sh
+++ b/tests/lint/test_wr2_plist_watchdog_labels.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Validate wr2_plist_watchdog.sh uses the plist Label key, not the filename.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WATCHDOG="$REPO_ROOT/scripts/wr2_plist_watchdog.sh"
+
+TMP="$(mktemp -d -t wr2_plist_watchdog_labels.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+export HOME="$TMP/home"
+export WR2_REPO_ROOT="$TMP/repo"
+mkdir -p "$HOME/Library/LaunchAgents" "$WR2_REPO_ROOT/infra/launchagents" "$TMP/bin"
+
+CALLS="$TMP/launchctl.calls"
+cat > "$TMP/bin/launchctl" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "$LAUNCHCTL_CALLS"
+if [[ "${1:-}" == "print" ]]; then
+  case "${2:-}" in
+    */com.balizero.wr2.canva-token-watchdog|*/com.balizero.wr2.canva-lease-watchdog)
+      exit 0
+      ;;
+    *)
+      exit 9
+      ;;
+  esac
+fi
+if [[ "${1:-}" == "bootstrap" ]]; then
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$TMP/bin/launchctl"
+
+export PATH="$TMP/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+export LAUNCHCTL_CALLS="$CALLS"
+
+write_plist() {
+  local path="$1" label="$2"
+  cat > "$path" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${label}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/echo</string>
+    <string>ok</string>
+  </array>
+</dict>
+</plist>
+EOF
+}
+
+write_plist \
+  "$WR2_REPO_ROOT/infra/launchagents/com.balizero.wr2.canva-token-watchdog.daily.plist" \
+  "com.balizero.wr2.canva-token-watchdog"
+write_plist \
+  "$WR2_REPO_ROOT/infra/launchagents/com.balizero.wr2.canva-lease-watchdog.10min.plist" \
+  "com.balizero.wr2.canva-lease-watchdog"
+
+cp "$WR2_REPO_ROOT/infra/launchagents/"*.plist "$HOME/Library/LaunchAgents/"
+
+"$WATCHDOG" >/tmp/wr2_plist_watchdog_labels.out 2>/tmp/wr2_plist_watchdog_labels.err
+
+if grep -q 'canva-token-watchdog.daily' "$CALLS"; then
+  echo "FAIL: launchctl was called with filename-derived token label" >&2
+  cat "$CALLS" >&2
+  exit 1
+fi
+
+if grep -q 'canva-lease-watchdog.10min' "$CALLS"; then
+  echo "FAIL: launchctl was called with filename-derived lease label" >&2
+  cat "$CALLS" >&2
+  exit 1
+fi
+
+grep -q 'com.balizero.wr2.canva-token-watchdog' "$CALLS"
+grep -q 'com.balizero.wr2.canva-lease-watchdog' "$CALLS"
+
+echo "PASS: wr2 plist watchdog uses Label keys for launchctl checks"


### PR DESCRIPTION
## Summary
- harden the two watchdog LaunchAgent plists against missing nuzantara-deploy script paths
- fix wr2_plist_watchdog.sh to read the plist Label key instead of deriving labels from filenames
- add a regression test for filename suffixes like .daily and .10min whose internal LaunchAgent labels differ

## Verification
- plutil -lint infra/launchagents/com.balizero.nuzantara.log-size-watchdog.plist infra/launchagents/com.balizero.wr2.plist-watchdog.plist
- bash -n scripts/wr2_plist_watchdog.sh scripts/log_size_watchdog.sh tests/lint/test_wr2_plist_watchdog_labels.sh
- bash tests/lint/test_wr2_plist_watchdog_labels.sh
- WR2_REPO_ROOT=$PWD bash scripts/wr2_plist_watchdog.sh -> exit 0
- cd apps/backend-rag && source .venv/bin/activate && PYTHONPATH=. python -c "from backend.app.dependencies import get_current_user; print('OK')"
- cd apps/backend-rag && source .venv/bin/activate && PYTHONPATH=. pytest backend/tests/services/rag/test_kg_langgraph.py backend/tests/services/rag/test_kg_subgraphs.py backend/tests/services/rag/test_confidence.py -q (91 passed)

## Runtime note
The live LaunchAgent status improved from the Spark-reported exit 127 to: log-size watchdog last exit 0, wr2 plist watchdog last exit 1. The remaining live exit 1 is because the installed job still resolves ~/Desktop/nuzantara-deploy to /Users/nuzantara/Desktop/nuzantara/.worktrees/backend-rag-crm-guardian-audit, which contains the old watchdog script. I did not mutate that separate worktree or the deploy symlink in this PR.