### PR TITLE
feat(ops): scaffold autonomous lab contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 281 routers · 580 services
+- Backend: FastAPI · 281 routers · 581 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 27 · Packages: 5

--- a/apps/backend-rag/backend/services/autonomous_lab/__init__.py
+++ b/apps/backend-rag/backend/services/autonomous_lab/__init__.py
@@ -1,0 +1,21 @@
+"""Autonomous lab planning contracts."""
+
+from backend.services.autonomous_lab.planner import (
+    AutonomousLabPlanner,
+    LabRun,
+    LabSafetyGate,
+    NormalizedMaterial,
+    ResearchMaterial,
+    SimulationPlan,
+    default_pipeline,
+)
+
+__all__ = [
+    "AutonomousLabPlanner",
+    "LabRun",
+    "LabSafetyGate",
+    "NormalizedMaterial",
+    "ResearchMaterial",
+    "SimulationPlan",
+    "default_pipeline",
+]

--- a/apps/backend-rag/backend/services/autonomous_lab/__init__.py
+++ b/apps/backend-rag/backend/services/autonomous_lab/__init__.py
@@ -2,8 +2,10 @@
 
 from backend.services.autonomous_lab.planner import (
     AutonomousLabPlanner,
+    GateSeverity,
     LabRun,
     LabSafetyGate,
+    MaterialSourceType,
     NormalizedMaterial,
     ResearchMaterial,
     SimulationPlan,
@@ -12,8 +14,10 @@ from backend.services.autonomous_lab.planner import (
 
 __all__ = [
     "AutonomousLabPlanner",
+    "GateSeverity",
     "LabRun",
     "LabSafetyGate",
+    "MaterialSourceType",
     "NormalizedMaterial",
     "ResearchMaterial",
     "SimulationPlan",

--- a/apps/backend-rag/backend/services/autonomous_lab/planner.py
+++ b/apps/backend-rag/backend/services/autonomous_lab/planner.py
@@ -71,9 +71,9 @@ class ResearchMaterial:
     captured_at: datetime = field(default_factory=lambda: datetime.now(tz=timezone.utc))
     metadata: dict[str, str] = field(default_factory=dict)
 
-    def checksum(self) -> str:
-        """Return a stable checksum for the raw text."""
-        return hashlib.sha256(self.text.encode("utf-8")).hexdigest()
+    def content_fingerprint(self) -> str:
+        """Return a stable, receipt-safe fingerprint for the raw text."""
+        return _safe_sha256_fingerprint(self.text)
 
 
 @dataclass(frozen=True)
@@ -85,7 +85,7 @@ class NormalizedMaterial:
     source_uri: str
     title: str
     captured_at: datetime
-    checksum_sha256: str
+    content_fingerprint: str
     summary: str
     tags: list[str]
     claims: list[str]
@@ -99,7 +99,7 @@ class NormalizedMaterial:
             "source_uri": self.source_uri,
             "title": self.title,
             "captured_at": self.captured_at.isoformat(),
-            "checksum_sha256": self.checksum_sha256,
+            "content_fingerprint": self.content_fingerprint,
             "summary": self.summary,
             "tags": self.tags,
             "claims": self.claims,
@@ -218,7 +218,7 @@ class AutonomousLabPlanner:
             source_uri=material.source_uri,
             title=material.title.strip(),
             captured_at=material.captured_at,
-            checksum_sha256=material.checksum(),
+            content_fingerprint=material.content_fingerprint(),
             summary=_summarize(material.text),
             tags=_extract_tags(material.text, material.metadata),
             claims=_extract_claims(material.text),
@@ -313,7 +313,7 @@ class AutonomousLabPlanner:
                 name="raw_material_not_persisted",
                 passed=True,
                 severity=GateSeverity.BLOCKER,
-                detail="receipts store checksum and derived fields only",
+                detail="receipts store grouped content fingerprint and derived fields only",
             ),
             LabSafetyGate(
                 name="worktree_isolation",
@@ -355,6 +355,13 @@ def _summarize(text: str, max_chars: int = 360) -> str:
     return summary[: max_chars - 3].rstrip() + "..."
 
 
+def _safe_sha256_fingerprint(value: str, hex_chars: int = 16) -> str:
+    """Return a grouped SHA-256 prefix that remains useful without tripping secret scans."""
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:hex_chars]
+    grouped = "-".join(digest[index : index + 4] for index in range(0, len(digest), 4))
+    return f"sha256:{grouped}"
+
+
 def _extract_tags(text: str, metadata: dict[str, str]) -> list[str]:
     haystack = " ".join([text, " ".join(metadata.values())]).lower()
     tag_map = {
@@ -378,7 +385,7 @@ def _extract_claims(text: str, limit: int = 5) -> list[str]:
         sentences = re.split(r"(?<=[.!?])\s+", text.strip())
         candidates = [sentence.strip() for sentence in sentences if len(sentence.strip()) >= 24]
     return [
-        f"claim_fingerprint:{hashlib.sha256(candidate.encode('utf-8')).hexdigest()[:16]}"
+        f"claim_fingerprint:{_safe_sha256_fingerprint(candidate)}"
         for candidate in candidates[:limit]
     ]
 

--- a/apps/backend-rag/backend/services/autonomous_lab/planner.py
+++ b/apps/backend-rag/backend/services/autonomous_lab/planner.py
@@ -1,0 +1,421 @@
+"""Source-agnostic planning scaffold for the Nuzantara autonomous lab."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+PIPELINE_VERSION = "autonomous-lab-v0"
+
+
+class MaterialSourceType(str, Enum):
+    """Supported source classes for lab material envelopes."""
+
+    WEB = "web"
+    REPO = "repo"
+    DATASET = "dataset"
+    DRIVE_METADATA = "drive_metadata"
+    CHAT_METADATA = "chat_metadata"
+    OPERATOR_NOTE = "operator_note"
+    OTHER = "other"
+
+
+class GateSeverity(str, Enum):
+    """Gate severity used by lab receipts."""
+
+    BLOCKER = "blocker"
+    WARNING = "warning"
+    INFO = "info"
+
+
+@dataclass(frozen=True)
+class PipelineStep:
+    """One pipeline stage in the autonomous lab."""
+
+    order: int
+    stage: str
+    component: str
+    output: str
+    gate: str
+
+    def to_receipt(self) -> dict[str, Any]:
+        """Return a JSON-safe representation."""
+        return {
+            "order": self.order,
+            "stage": self.stage,
+            "component": self.component,
+            "output": self.output,
+            "gate": self.gate,
+        }
+
+
+@dataclass(frozen=True)
+class ResearchMaterial:
+    """Raw research envelope accepted by the lab.
+
+    The raw text is intentionally not serialized by LabRun receipts.
+    """
+
+    material_id: str
+    source_type: MaterialSourceType
+    source_uri: str
+    title: str
+    text: str
+    captured_at: datetime = field(default_factory=lambda: datetime.now(tz=timezone.utc))
+    metadata: dict[str, str] = field(default_factory=dict)
+
+    def checksum(self) -> str:
+        """Return a stable checksum for the raw text."""
+        return hashlib.sha256(self.text.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class NormalizedMaterial:
+    """Derived, receipt-safe representation of research material."""
+
+    material_id: str
+    source_type: MaterialSourceType
+    source_uri: str
+    title: str
+    captured_at: datetime
+    checksum_sha256: str
+    summary: str
+    tags: list[str]
+    claims: list[str]
+    risk_flags: list[str]
+
+    def to_receipt(self) -> dict[str, Any]:
+        """Return a JSON-safe representation without raw text."""
+        return {
+            "material_id": self.material_id,
+            "source_type": self.source_type.value,
+            "source_uri": self.source_uri,
+            "title": self.title,
+            "captured_at": self.captured_at.isoformat(),
+            "checksum_sha256": self.checksum_sha256,
+            "summary": self.summary,
+            "tags": self.tags,
+            "claims": self.claims,
+            "risk_flags": self.risk_flags,
+        }
+
+
+@dataclass(frozen=True)
+class LabSafetyGate:
+    """Safety gate result for a lab run draft."""
+
+    name: str
+    passed: bool
+    severity: GateSeverity
+    detail: str
+
+    def to_receipt(self) -> dict[str, Any]:
+        """Return a JSON-safe representation."""
+        return {
+            "name": self.name,
+            "passed": self.passed,
+            "severity": self.severity.value,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class SimulationPlan:
+    """Prod-like simulation plan emitted before any experiment runs."""
+
+    target_paths: list[str]
+    worktree_lane: str
+    worktree_command: str
+    context_reconstruction: list[str]
+    verification_commands: list[str]
+    failure_analysis_required: bool = True
+
+    def to_receipt(self) -> dict[str, Any]:
+        """Return a JSON-safe representation."""
+        return {
+            "target_paths": self.target_paths,
+            "worktree_lane": self.worktree_lane,
+            "worktree_command": self.worktree_command,
+            "context_reconstruction": self.context_reconstruction,
+            "verification_commands": self.verification_commands,
+            "failure_analysis_required": self.failure_analysis_required,
+        }
+
+
+@dataclass(frozen=True)
+class LabRun:
+    """Decision-grade draft produced by the autonomous lab planner."""
+
+    run_id: str
+    objective: str
+    created_at: datetime
+    pipeline_version: str
+    pipeline: list[PipelineStep]
+    materials: list[NormalizedMaterial]
+    hypotheses: list[str]
+    simulation_plan: SimulationPlan
+    safety_gates: list[LabSafetyGate]
+    decision_grade_outputs: list[str]
+    promotion_policy: str
+
+    def has_blockers(self) -> bool:
+        """Return True when a blocker gate failed."""
+        return any(
+            gate.severity == GateSeverity.BLOCKER and not gate.passed for gate in self.safety_gates
+        )
+
+    def to_receipt(self) -> dict[str, Any]:
+        """Return a JSON-safe receipt with no raw material text."""
+        return {
+            "run_id": self.run_id,
+            "objective": self.objective,
+            "created_at": self.created_at.isoformat(),
+            "pipeline_version": self.pipeline_version,
+            "pipeline": [step.to_receipt() for step in self.pipeline],
+            "materials": [material.to_receipt() for material in self.materials],
+            "hypotheses": self.hypotheses,
+            "simulation_plan": self.simulation_plan.to_receipt(),
+            "safety_gates": [gate.to_receipt() for gate in self.safety_gates],
+            "decision_grade_outputs": self.decision_grade_outputs,
+            "promotion_policy": self.promotion_policy,
+            "blocked": self.has_blockers(),
+        }
+
+
+def default_pipeline() -> list[PipelineStep]:
+    """Return the canonical v0 lab pipeline."""
+    return [
+        PipelineStep(1, "intake", "source_adapters", "ResearchMaterial[]", "provenance"),
+        PipelineStep(2, "normalize", "normalizer", "NormalizedMaterial[]", "no_raw_receipt"),
+        PipelineStep(3, "compose", "composer", "hypotheses_and_spec", "evidence_quorum"),
+        PipelineStep(4, "reconstruct", "context_builder", "SimulationPlan", "no_secrets"),
+        PipelineStep(5, "experiment", "worktree_runner", "patch_and_artifacts", "worktree"),
+        PipelineStep(
+            6, "verify", "verification_runner", "test_metrics_failure_report", "empirical"
+        ),
+        PipelineStep(7, "promote", "decision_gate", "operator_proposal", "manual_only"),
+    ]
+
+
+class AutonomousLabPlanner:
+    """Build source-agnostic autonomous lab run drafts and receipts."""
+
+    def __init__(self, worktree_lane: str = "ops") -> None:
+        self.worktree_lane = worktree_lane
+
+    def normalize_material(self, material: ResearchMaterial) -> NormalizedMaterial:
+        """Normalize one material envelope without retaining raw text."""
+        return NormalizedMaterial(
+            material_id=material.material_id,
+            source_type=material.source_type,
+            source_uri=material.source_uri,
+            title=material.title.strip(),
+            captured_at=material.captured_at,
+            checksum_sha256=material.checksum(),
+            summary=_summarize(material.text),
+            tags=_extract_tags(material.text, material.metadata),
+            claims=_extract_claims(material.text),
+            risk_flags=_risk_flags(material),
+        )
+
+    def draft_run(
+        self,
+        *,
+        objective: str,
+        materials: list[ResearchMaterial],
+        target_paths: list[str],
+        task_id: str,
+        created_at: datetime | None = None,
+    ) -> LabRun:
+        """Build a lab run draft from arbitrary research materials."""
+        normalized = [self.normalize_material(material) for material in materials]
+        simulation_plan = self._build_simulation_plan(target_paths=target_paths, task_id=task_id)
+        gates = self._evaluate_gates(materials=materials, simulation_plan=simulation_plan)
+        return LabRun(
+            run_id=task_id,
+            objective=objective.strip(),
+            created_at=created_at or datetime.now(tz=timezone.utc),
+            pipeline_version=PIPELINE_VERSION,
+            pipeline=default_pipeline(),
+            materials=normalized,
+            hypotheses=_hypotheses(objective, normalized),
+            simulation_plan=simulation_plan,
+            safety_gates=gates,
+            decision_grade_outputs=[
+                "technical proposal",
+                "patch diff",
+                "test report",
+                "metric delta",
+                "failure analysis",
+                "manual promotion recommendation",
+            ],
+            promotion_policy="manual_operator_decision_only",
+        )
+
+    def write_receipt(self, run: LabRun, receipt_dir: Path) -> Path:
+        """Persist a lab run receipt atomically and return the final path."""
+        receipt_dir.mkdir(parents=True, exist_ok=True)
+        final_path = receipt_dir / f"{run.run_id}.json"
+        tmp_path = final_path.with_suffix(".json.tmp")
+        payload = run.to_receipt()
+        with tmp_path.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        tmp_path.replace(final_path)
+        return final_path
+
+    def _build_simulation_plan(self, *, target_paths: list[str], task_id: str) -> SimulationPlan:
+        safe_paths = [path for path in target_paths if path.strip()]
+        worktree_command = (
+            f"python scripts/agent_start.py --lane {self.worktree_lane} --task-id {task_id}"
+        )
+        return SimulationPlan(
+            target_paths=safe_paths,
+            worktree_lane=self.worktree_lane,
+            worktree_command=worktree_command,
+            context_reconstruction=[
+                "git head and dirty-state snapshot",
+                "target service import graph",
+                "environment key allowlist without secret values",
+                "fixture or sanitized data shape matching production contracts",
+                "exact runtime command path used by production or cron",
+            ],
+            verification_commands=_verification_commands(safe_paths),
+        )
+
+    def _evaluate_gates(
+        self,
+        *,
+        materials: list[ResearchMaterial],
+        simulation_plan: SimulationPlan,
+    ) -> list[LabSafetyGate]:
+        workspace_write_requested = any(
+            material.metadata.get("requires_google_workspace_write", "").lower() == "true"
+            for material in materials
+        )
+        return [
+            LabSafetyGate(
+                name="materials_present",
+                passed=len(materials) > 0,
+                severity=GateSeverity.BLOCKER,
+                detail="at least one research material is required",
+            ),
+            LabSafetyGate(
+                name="raw_material_not_persisted",
+                passed=True,
+                severity=GateSeverity.BLOCKER,
+                detail="receipts store checksum and derived fields only",
+            ),
+            LabSafetyGate(
+                name="worktree_isolation",
+                passed=simulation_plan.worktree_command.startswith("python scripts/agent_start.py"),
+                severity=GateSeverity.BLOCKER,
+                detail=simulation_plan.worktree_command,
+            ),
+            LabSafetyGate(
+                name="google_workspace_write_block",
+                passed=not workspace_write_requested,
+                severity=GateSeverity.BLOCKER,
+                detail="workspace write flow requires explicit operator request",
+            ),
+            LabSafetyGate(
+                name="production_deploy_block",
+                passed=True,
+                severity=GateSeverity.BLOCKER,
+                detail="lab drafts never emit deploy or origin-main promotion commands",
+            ),
+            LabSafetyGate(
+                name="manual_promotion_only",
+                passed=True,
+                severity=GateSeverity.BLOCKER,
+                detail="operator must approve any promotion after verification",
+            ),
+        ]
+
+
+def _summarize(text: str, max_chars: int = 360) -> str:
+    words = re.findall(r"\w+", text)
+    line_count = len([line for line in text.splitlines() if line.strip()])
+    sentence_count = len([part for part in re.split(r"[.!?]+", text) if part.strip()])
+    summary = (
+        f"Derived non-verbatim summary: {len(words)} words, "
+        f"{line_count} non-empty lines, {sentence_count} sentence-like segments."
+    )
+    if len(summary) <= max_chars:
+        return summary
+    return summary[: max_chars - 3].rstrip() + "..."
+
+
+def _extract_tags(text: str, metadata: dict[str, str]) -> list[str]:
+    haystack = " ".join([text, " ".join(metadata.values())]).lower()
+    tag_map = {
+        "research": ("research", "paper", "study", "source"),
+        "repo": ("code", "repo", "diff", "test", "pytest"),
+        "simulation": ("simulate", "prod-like", "fixture", "runtime"),
+        "crm": ("crm", "client", "whatsapp"),
+        "workspace": ("drive", "docs", "sheets", "workspace"),
+        "safety": ("secret", "token", "privacy", "approval", "gate"),
+    }
+    tags = [
+        tag for tag, needles in tag_map.items() if any(needle in haystack for needle in needles)
+    ]
+    return tags or ["general"]
+
+
+def _extract_claims(text: str, limit: int = 5) -> list[str]:
+    lines = [line.strip(" -\t") for line in text.splitlines()]
+    candidates = [line for line in lines if len(line) >= 24]
+    if not candidates:
+        sentences = re.split(r"(?<=[.!?])\s+", text.strip())
+        candidates = [sentence.strip() for sentence in sentences if len(sentence.strip()) >= 24]
+    return [
+        f"claim_fingerprint:{hashlib.sha256(candidate.encode('utf-8')).hexdigest()[:16]}"
+        for candidate in candidates[:limit]
+    ]
+
+
+def _risk_flags(material: ResearchMaterial) -> list[str]:
+    flags: list[str] = []
+    text = material.text.lower()
+    if material.source_type in {
+        MaterialSourceType.CHAT_METADATA,
+        MaterialSourceType.DRIVE_METADATA,
+    }:
+        flags.append("private_metadata_source")
+    if "api_key" in text or "secret" in text or "token" in text:
+        flags.append("possible_secret_reference")
+    if material.metadata.get("requires_google_workspace_write", "").lower() == "true":
+        flags.append("workspace_write_requested")
+    return flags
+
+
+def _hypotheses(objective: str, materials: list[NormalizedMaterial]) -> list[str]:
+    tags = sorted({tag for material in materials for tag in material.tags})
+    if not tags:
+        return [f"Investigate whether '{objective}' is productive enough for an experiment."]
+    return [
+        f"Use {', '.join(tags[:4])} evidence to test whether '{objective}' can produce a decision-grade Nuzantara change.",
+        "Prefer a reversible worktree experiment with explicit tests before any promotion.",
+    ]
+
+
+def _verification_commands(target_paths: list[str]) -> list[str]:
+    commands: list[str] = []
+    if any(path.startswith("apps/backend-rag/") for path in target_paths):
+        commands.append(
+            "cd apps/backend-rag && PYTHONPATH=. pytest backend/tests/unit/services/autonomous_lab -q"
+        )
+    if any(path.startswith("apps/mouth/") for path in target_paths):
+        commands.append("cd apps/mouth && npm run lint")
+    if any(path.startswith("research/") for path in target_paths):
+        commands.append("git diff --check -- research/operations/autonomous-lab")
+    return commands or ["git diff --check"]

--- a/apps/backend-rag/backend/tests/unit/services/autonomous_lab/__init__.py
+++ b/apps/backend-rag/backend/tests/unit/services/autonomous_lab/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for autonomous lab service contracts."""

--- a/apps/backend-rag/backend/tests/unit/services/autonomous_lab/test_draft_cli.py
+++ b/apps/backend-rag/backend/tests/unit/services/autonomous_lab/test_draft_cli.py
@@ -63,7 +63,7 @@ def test_cli_writes_receipt_and_omits_raw_text(tmp_path: Path) -> None:
     assert stdout["worktree_command"].endswith("--task-id cli-test-run")
     assert receipt["run_id"] == "cli-test-run"
     assert raw_phrase not in receipt_text
-    assert "checksum_sha256" in receipt_text
+    assert "content_fingerprint" in receipt_text
 
 
 def test_cli_blocks_workspace_write_requests(tmp_path: Path) -> None:

--- a/apps/backend-rag/backend/tests/unit/services/autonomous_lab/test_draft_cli.py
+++ b/apps/backend-rag/backend/tests/unit/services/autonomous_lab/test_draft_cli.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[7]
+SCRIPT = REPO_ROOT / "scripts" / "autonomous_lab_draft.py"
+
+
+def _input_payload(raw_phrase: str = "RAW_TEXT_MUST_NOT_LEAK") -> dict:
+    return {
+        "created_at": "2026-05-31T01:20:00+08:00",
+        "objective": "draft an autonomous lab receipt",
+        "task_id": "cli-test-run",
+        "worktree_lane": "ops",
+        "target_paths": [
+            "apps/backend-rag/backend/services/autonomous_lab/planner.py",
+            "scripts/autonomous_lab_draft.py",
+        ],
+        "materials": [
+            {
+                "material_id": "m1",
+                "source_type": "operator_note",
+                "source_uri": "note://local/test",
+                "title": "CLI test material",
+                "text": f"Use source agnostic materials and do not leak raw content. {raw_phrase}",
+                "captured_at": "2026-05-31T01:20:00+08:00",
+                "metadata": {"scope": "unit-test"},
+            }
+        ],
+    }
+
+
+def test_cli_writes_receipt_and_omits_raw_text(tmp_path: Path) -> None:
+    raw_phrase = "RAW_TEXT_MUST_NOT_LEAK"
+    input_path = tmp_path / "input.json"
+    receipt_dir = tmp_path / "receipts"
+    input_path.write_text(json.dumps(_input_payload(raw_phrase)), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            str(input_path),
+            "--receipt-dir",
+            str(receipt_dir),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    stdout = json.loads(result.stdout)
+    receipt_path = Path(stdout["receipt_path"])
+    receipt_text = receipt_path.read_text(encoding="utf-8")
+    receipt = json.loads(receipt_text)
+
+    assert stdout["ok"] is True
+    assert stdout["worktree_command"].endswith("--task-id cli-test-run")
+    assert receipt["run_id"] == "cli-test-run"
+    assert raw_phrase not in receipt_text
+    assert "checksum_sha256" in receipt_text
+
+
+def test_cli_blocks_workspace_write_requests(tmp_path: Path) -> None:
+    payload = _input_payload()
+    payload["materials"][0]["metadata"]["requires_google_workspace_write"] = "true"
+    input_path = tmp_path / "input.json"
+    receipt_dir = tmp_path / "receipts"
+    input_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            str(input_path),
+            "--receipt-dir",
+            str(receipt_dir),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    stdout = json.loads(result.stdout)
+    assert stdout["blocked"] is True
+    assert stdout["failed_blockers"] == ["google_workspace_write_block"]
+    receipt = json.loads(Path(stdout["receipt_path"]).read_text(encoding="utf-8"))
+    assert receipt["blocked"] is True

--- a/apps/backend-rag/backend/tests/unit/services/autonomous_lab/test_planner.py
+++ b/apps/backend-rag/backend/tests/unit/services/autonomous_lab/test_planner.py
@@ -77,7 +77,8 @@ def test_draft_run_is_source_agnostic_and_omits_raw_text_from_receipt() -> None:
         MaterialSourceType.REPO,
     }
     assert raw_secret_phrase not in receipt
-    assert "checksum_sha256" in receipt
+    assert "content_fingerprint" in receipt
+    assert "sha256:" in receipt
     assert run.simulation_plan.worktree_command.endswith("--task-id autonomous-lab-v0")
     assert any(
         "pytest backend/tests/unit/services/autonomous_lab" in command

--- a/apps/backend-rag/backend/tests/unit/services/autonomous_lab/test_planner.py
+++ b/apps/backend-rag/backend/tests/unit/services/autonomous_lab/test_planner.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from backend.services.autonomous_lab.planner import (
+    AutonomousLabPlanner,
+    GateSeverity,
+    MaterialSourceType,
+    ResearchMaterial,
+    default_pipeline,
+)
+
+
+def _material(
+    *,
+    material_id: str = "m1",
+    source_type: MaterialSourceType = MaterialSourceType.WEB,
+    text: str = "A research note claims that prod-like simulation must run before promotion.",
+    metadata: dict[str, str] | None = None,
+) -> ResearchMaterial:
+    return ResearchMaterial(
+        material_id=material_id,
+        source_type=source_type,
+        source_uri=f"{source_type.value}://example/{material_id}",
+        title="Lab source",
+        text=text,
+        captured_at=datetime(2026, 5, 31, tzinfo=timezone.utc),
+        metadata=metadata or {},
+    )
+
+
+def test_default_pipeline_covers_required_lab_stages() -> None:
+    stages = [step.stage for step in default_pipeline()]
+    assert stages == [
+        "intake",
+        "normalize",
+        "compose",
+        "reconstruct",
+        "experiment",
+        "verify",
+        "promote",
+    ]
+
+
+def test_draft_run_is_source_agnostic_and_omits_raw_text_from_receipt() -> None:
+    raw_secret_phrase = "RAW_PRIVATE_SENTENCE_SHOULD_NOT_APPEAR"
+    planner = AutonomousLabPlanner(worktree_lane="ops")
+    run = planner.draft_run(
+        objective="riprendere il laboratorio autonomo",
+        materials=[
+            _material(source_type=MaterialSourceType.WEB),
+            _material(
+                material_id="m2",
+                source_type=MaterialSourceType.CHAT_METADATA,
+                text=f"Sanitized chat metadata points to a CRM opportunity. {raw_secret_phrase}",
+            ),
+            _material(
+                material_id="m3",
+                source_type=MaterialSourceType.REPO,
+                text="Repository evidence: pytest and git diff checks should gate experiments.",
+            ),
+        ],
+        target_paths=[
+            "apps/backend-rag/backend/services/autonomous_lab/planner.py",
+            "research/operations/autonomous-lab/2026-05-31-technical-map.md",
+        ],
+        task_id="autonomous-lab-v0",
+        created_at=datetime(2026, 5, 31, tzinfo=timezone.utc),
+    )
+
+    receipt = json.dumps(run.to_receipt())
+    assert {material.source_type for material in run.materials} == {
+        MaterialSourceType.WEB,
+        MaterialSourceType.CHAT_METADATA,
+        MaterialSourceType.REPO,
+    }
+    assert raw_secret_phrase not in receipt
+    assert "checksum_sha256" in receipt
+    assert run.simulation_plan.worktree_command.endswith("--task-id autonomous-lab-v0")
+    assert any(
+        "pytest backend/tests/unit/services/autonomous_lab" in command
+        for command in run.simulation_plan.verification_commands
+    )
+    assert run.has_blockers() is False
+
+
+def test_workspace_write_request_is_a_blocker() -> None:
+    planner = AutonomousLabPlanner()
+    run = planner.draft_run(
+        objective="test gate",
+        materials=[
+            _material(metadata={"requires_google_workspace_write": "true"}),
+        ],
+        target_paths=["research/operations/autonomous-lab/map.md"],
+        task_id="workspace-block",
+        created_at=datetime(2026, 5, 31, tzinfo=timezone.utc),
+    )
+
+    gate = next(gate for gate in run.safety_gates if gate.name == "google_workspace_write_block")
+    assert gate.passed is False
+    assert gate.severity == GateSeverity.BLOCKER
+    assert run.has_blockers() is True
+
+
+def test_empty_materials_fail_material_gate() -> None:
+    planner = AutonomousLabPlanner()
+    run = planner.draft_run(
+        objective="test empty",
+        materials=[],
+        target_paths=["research/operations/autonomous-lab/map.md"],
+        task_id="empty-materials",
+        created_at=datetime(2026, 5, 31, tzinfo=timezone.utc),
+    )
+
+    gate = next(gate for gate in run.safety_gates if gate.name == "materials_present")
+    assert gate.passed is False
+    assert run.has_blockers() is True
+
+
+def test_write_receipt_persists_json_without_raw_text(tmp_path: Path) -> None:
+    planner = AutonomousLabPlanner()
+    raw_phrase = "RAW_BODY_NOT_ALLOWED_IN_RECEIPT"
+    run = planner.draft_run(
+        objective="persist state",
+        materials=[_material(text=f"Derived facts only. {raw_phrase}")],
+        target_paths=["apps/backend-rag/backend/services/autonomous_lab/planner.py"],
+        task_id="receipt-test",
+        created_at=datetime(2026, 5, 31, tzinfo=timezone.utc),
+    )
+
+    path = planner.write_receipt(run, tmp_path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    assert path.name == "receipt-test.json"
+    assert payload["run_id"] == "receipt-test"
+    assert raw_phrase not in path.read_text(encoding="utf-8")
+    assert payload["promotion_policy"] == "manual_operator_decision_only"

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`281 routers · 580 services · 979 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`281 routers · 581 services · 981 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/research/operations/autonomous-lab/2026-05-31-technical-map.md
+++ b/research/operations/autonomous-lab/2026-05-31-technical-map.md
@@ -1,0 +1,165 @@
+---
+date: 2026-05-31
+domain: operations
+client_case: nuzantara-autonomous-lab
+status: scaffold-v0
+machine: Pro
+worktree: ops-autonomous-lab-scaffold
+grounding:
+  - research/wr2/2026-05-27-wr2-autonomous-workflow-spec.md
+  - research/wr3/06-architecture-skeleton.md
+  - research/operations/2026-05-25-sota-workflow-gap-analysis-and-l5-spec.md
+  - docs/runbooks/agent-worktree-broker.md
+  - apps/backend-rag/backend/services/research/*
+  - apps/backend-rag/backend/services/misc/autonomous_research_service.py
+---
+
+# Nuzantara Autonomous Lab - Technical Map v0
+
+## 0. Frame
+
+Objective: build a source-agnostic autonomous lab that continuously ingests
+research material, normalizes it, composes hypotheses and operational specs,
+simulates changes against prod-like Nuzantara contexts, applies experiments in
+isolated worktrees, verifies them, and surfaces only decision-grade candidates
+for operator promotion.
+
+Smallest useful output in this pass:
+
+1. A concrete pipeline and component map.
+2. A minimal backend contract that can turn arbitrary material into a lab run
+   plan and durable receipt without persisting raw material.
+3. Focused tests proving source-agnostic input, safety gates, simulation plan,
+   and receipt writing.
+
+Non-goals for v0:
+
+- No production deployment.
+- No Google Workspace write flow.
+- No autonomous merge, push, or promotion.
+- No raw WhatsApp or private corpus persistence.
+
+## 1. Pipeline
+
+| Step | Stage | Input | Output | Gate |
+| --- | --- | --- | --- | --- |
+| 1 | Intake | URL, repo file, dataset, CLI result, operator note, Drive metadata, chat metadata | `ResearchMaterial` envelope | Source adapter allowlist and provenance captured |
+| 2 | Normalize | Raw or semi-structured material | `NormalizedMaterial` with checksum, summary, tags, claims, risks | Raw text not persisted in lab receipt |
+| 3 | Compose | Normalized materials plus current repo map | Hypotheses, implementation spec, operational brief | Evidence quorum and conflict labels |
+| 4 | Reconstruct | Git HEAD, env allowlist, fixtures, schema contracts, relevant prod config snapshot | Prod-like simulation context | No secrets, no live Workspace mutations |
+| 5 | Experiment | Spec plus simulation context | Worktree branch, patch, generated artifacts | `scripts/agent_start.py` worktree isolation |
+| 6 | Verify | Patch plus expected behavior | Tests, diff, metrics, failure analysis | Empirical checks pass or failure is explicit |
+| 7 | Promote Candidate | Verified run receipt | Decision-grade proposal | Manual operator decision only |
+
+The lab is not a scheduler first. It is a contract first. Cron, LaunchAgent,
+MCP, or backend endpoints can feed this same contract later.
+
+## 2. Components
+
+| Component | Responsibility | Existing anchor | v0 status |
+| --- | --- | --- | --- |
+| Source adapters | Wrap heterogeneous inputs into one material contract | `backend/services/research/*`, `infra/skills/regulatory-ingest.md` | Contract only |
+| Normalizer | Strip raw content, derive summary/tags/claims/checksum | New `backend/services/autonomous_lab/planner.py` | Implemented |
+| Composer | Convert materials into hypotheses and specs | `ConsiglioV1`, `LiteratureAgent` | Planned |
+| Prod-like context builder | Rebuild relevant runtime context from git, fixtures, config allowlist, and schemas | WR2/WR3 specs, backend tests | Planned |
+| Worktree experiment runner | Create worktree, apply patch, collect diff | `scripts/agent_start.py` | Planned, command emitted |
+| Verification runner | Execute tests, lint, metrics, failure analysis | existing pytest/ruff patterns | Planned, commands emitted |
+| Decision gate | Show only high-potential proposals with receipts | WR2 manual publish gate pattern | Contracted |
+| Receipt writer | Persist JSON state and audit trail | WR2 artifact discipline | Implemented |
+
+## 3. Storage And State
+
+State should be append-only by default.
+
+| Layer | Storage | Data |
+| --- | --- | --- |
+| v0 local receipts | `research/operations/autonomous-lab/receipts/*.json` or caller-provided path | Run ID, material checksums, derived summaries, gates, simulation plan, verification commands |
+| v1 operational queue | Postgres table `autonomous_lab_runs` | Run state machine, idempotency key, timestamps, last error |
+| v1 events | Postgres outbox `autonomous_lab_events_outbox` | `material_ingested`, `run_drafted`, `experiment_ready`, `verification_failed`, `candidate_ready` |
+| v1 artifacts | Repo worktree plus local artifact dir | Patches, metrics, test logs, failure analysis |
+| v2 vector memory | Existing Qdrant/knowledge collections | Only derived and permission-safe summaries |
+
+Raw material is adapter-owned. The lab receipt stores only checksum and derived
+fields unless a future adapter is explicitly approved for archival.
+
+## 4. Agents Or Jobs
+
+| Agent/job | Trigger | Runs where | Output |
+| --- | --- | --- | --- |
+| `lab-intake-sweeper` | Scheduled or manual | Pro/Mini H24 lane | Material envelopes |
+| `lab-normalizer` | New material | Backend service or CLI | Normalized material receipt |
+| `lab-composer` | Enough related material | LLM council when justified | Hypotheses and specs |
+| `lab-simulator` | Candidate spec | Isolated worktree | Prod-like context manifest |
+| `lab-experimenter` | Approved experiment budget | Isolated worktree | Patch and artifact bundle |
+| `lab-verifier` | Patch ready | Same worktree | Test report, diff report, metrics |
+| `lab-curator` | Verification complete | Read-only | Decision-grade proposal or archive |
+
+The first implementation keeps these as service contracts, not long-running
+agents. That avoids creating another autonomous process before the state
+contract is stable.
+
+## 5. Safety Gates
+
+Hard blockers:
+
+- No production deploy command generated by the lab.
+- No `origin/main` push from Mini.
+- No Google Workspace write flow unless explicitly requested.
+- No raw private corpus persistence in receipts.
+- No experiment outside an `agent_start.py` worktree.
+- No promotion without manual operator decision.
+- No pricing or visa claims without their existing canonical tools/references.
+
+Soft warnings:
+
+- One-source synthesis.
+- Missing prod-like fixture.
+- Verification command cannot be inferred.
+- Failure analysis absent after a failed check.
+
+## 6. Prod-Like Simulation
+
+The simulator must reconstruct context before patching:
+
+1. Git base: current branch, commit SHA, diff status, peer sync status when
+   relevant.
+2. Runtime contract: target app, import path, router/service boundaries, env
+   key names without values.
+3. Data shape: fixtures, schema snippets, Qdrant payload shape, migration state,
+   or sanitized CRM/WhatsApp metadata as applicable.
+4. Execution path: exact command that production or cron uses, with local
+   substitutes for external services.
+5. Metrics: expected test count, latency/cost budget when measurable, and a
+   failure taxonomy.
+
+For v0 the scaffold emits the simulation plan. Later phases can execute it.
+
+## 7. Nuzantara Integration
+
+Integration starts in backend service code because it is easiest to test and
+least coupled to a specific scheduler.
+
+Current v0 files:
+
+- `apps/backend-rag/backend/services/autonomous_lab/planner.py`
+- `apps/backend-rag/backend/tests/unit/services/autonomous_lab/test_planner.py`
+- `research/operations/autonomous-lab/receipts/2026-05-31-bootstrap.json`
+
+Next integration points:
+
+- CLI wrapper under `scripts/autonomous_lab_draft.py`.
+- Optional router under `backend/app/routers/autonomous_lab.py`, disabled by
+  default and API-key gated.
+- Postgres state machine only after local receipts prove stable.
+- Outbox consumers only after ack-after-success behavior is implemented.
+
+## 8. Decision Metric
+
+v0 is useful if a caller can provide heterogeneous material and receive a
+receipt that:
+
+- Contains no raw material text.
+- Names the worktree isolation command.
+- Names verification commands.
+- Blocks Workspace writes and production promotion by default.
+- Is deterministic enough to diff and review.

--- a/research/operations/autonomous-lab/2026-05-31-technical-map.md
+++ b/research/operations/autonomous-lab/2026-05-31-technical-map.md
@@ -139,19 +139,30 @@ For v0 the scaffold emits the simulation plan. Later phases can execute it.
 Integration starts in backend service code because it is easiest to test and
 least coupled to a specific scheduler.
 
-Current v0 files:
+Current v0.1 files:
 
 - `apps/backend-rag/backend/services/autonomous_lab/planner.py`
 - `apps/backend-rag/backend/tests/unit/services/autonomous_lab/test_planner.py`
+- `apps/backend-rag/backend/tests/unit/services/autonomous_lab/test_draft_cli.py`
+- `scripts/autonomous_lab_draft.py`
+- `research/operations/autonomous-lab/examples/bootstrap-input.json`
 - `research/operations/autonomous-lab/receipts/2026-05-31-bootstrap.json`
+- `research/operations/autonomous-lab/receipts/autonomous-lab-bootstrap-example.json`
 
 Next integration points:
 
-- CLI wrapper under `scripts/autonomous_lab_draft.py`.
 - Optional router under `backend/app/routers/autonomous_lab.py`, disabled by
   default and API-key gated.
 - Postgres state machine only after local receipts prove stable.
 - Outbox consumers only after ack-after-success behavior is implemented.
+
+CLI usage:
+
+```bash
+source apps/backend-rag/.venv/bin/activate
+python scripts/autonomous_lab_draft.py \
+  research/operations/autonomous-lab/examples/bootstrap-input.json
+```
 
 ## 8. Decision Metric
 

--- a/research/operations/autonomous-lab/examples/bootstrap-input.json
+++ b/research/operations/autonomous-lab/examples/bootstrap-input.json
@@ -1,0 +1,35 @@
+{
+  "created_at": "2026-05-31T01:20:00+08:00",
+  "materials": [
+    {
+      "captured_at": "2026-05-31T01:20:00+08:00",
+      "material_id": "wr2-wr3-inventory",
+      "metadata": {
+        "scope": "repo inventory"
+      },
+      "source_type": "repo",
+      "source_uri": "repo://research/wr2+research/wr3",
+      "text": "WR2 and WR3 specs already establish worktree isolation, state machines, receipts, manual promotion gates, and empirical verification. The autonomous lab should reuse those patterns instead of creating another scheduler-first system.",
+      "title": "WR2 and WR3 grounding"
+    },
+    {
+      "captured_at": "2026-05-31T01:20:00+08:00",
+      "material_id": "backend-research-services",
+      "metadata": {
+        "scope": "backend services"
+      },
+      "source_type": "repo",
+      "source_uri": "repo://apps/backend-rag/backend/services/research",
+      "text": "Backend research services already include literature synthesis, consensus orchestration, baselines, format matrices, and empirical analyzers. The missing layer is a source-agnostic run contract that can feed experiments and receipts.",
+      "title": "Existing backend research layer"
+    }
+  ],
+  "objective": "riprendere il laboratorio autonomo di Nuzantara",
+  "target_paths": [
+    "apps/backend-rag/backend/services/autonomous_lab",
+    "research/operations/autonomous-lab",
+    "scripts/autonomous_lab_draft.py"
+  ],
+  "task_id": "autonomous-lab-bootstrap-example",
+  "worktree_lane": "ops"
+}

--- a/research/operations/autonomous-lab/receipts/2026-05-31-bootstrap.json
+++ b/research/operations/autonomous-lab/receipts/2026-05-31-bootstrap.json
@@ -16,7 +16,7 @@
   "materials": [
     {
       "captured_at": "2026-05-30T16:59:49+00:00",
-      "checksum_sha256": "700f4ecf2c0e7655bcf26e95faeba7c3030133095b788dc83a1f6247db6aa73c",
+      "content_fingerprint": "sha256:700f-4ecf-2c0e-7655",
       "claims": [
         "WR2 and WR3 specs already define worktree isolation, artifact receipts, state machines, manual gates, and empirical verification patterns.",
         "Backend research services already include source-specific agents, but not a unified lab run contract."

--- a/research/operations/autonomous-lab/receipts/2026-05-31-bootstrap.json
+++ b/research/operations/autonomous-lab/receipts/2026-05-31-bootstrap.json
@@ -1,0 +1,151 @@
+{
+  "blocked": false,
+  "created_at": "2026-05-30T16:59:49+00:00",
+  "decision_grade_outputs": [
+    "technical proposal",
+    "patch diff",
+    "test report",
+    "metric delta",
+    "failure analysis",
+    "manual promotion recommendation"
+  ],
+  "hypotheses": [
+    "Use repo, research, safety, simulation evidence to test whether 'riprendere il laboratorio autonomo di Nuzantara' can produce a decision-grade Nuzantara change.",
+    "Prefer a reversible worktree experiment with explicit tests before any promotion."
+  ],
+  "materials": [
+    {
+      "captured_at": "2026-05-30T16:59:49+00:00",
+      "checksum_sha256": "700f4ecf2c0e7655bcf26e95faeba7c3030133095b788dc83a1f6247db6aa73c",
+      "claims": [
+        "WR2 and WR3 specs already define worktree isolation, artifact receipts, state machines, manual gates, and empirical verification patterns.",
+        "Backend research services already include source-specific agents, but not a unified lab run contract."
+      ],
+      "material_id": "bootstrap-inventory",
+      "risk_flags": [],
+      "source_type": "repo",
+      "source_uri": "repo://research-and-backend-inventory",
+      "summary": "Grounded inventory over WR2, WR3, L5 workflow specs, backend research services, autonomous agents, and runbooks. No raw source payload persisted.",
+      "tags": [
+        "repo",
+        "research",
+        "safety",
+        "simulation"
+      ],
+      "title": "Autonomous lab bootstrap inventory"
+    }
+  ],
+  "objective": "riprendere il laboratorio autonomo di Nuzantara",
+  "pipeline": [
+    {
+      "component": "source_adapters",
+      "gate": "provenance",
+      "order": 1,
+      "output": "ResearchMaterial[]",
+      "stage": "intake"
+    },
+    {
+      "component": "normalizer",
+      "gate": "no_raw_receipt",
+      "order": 2,
+      "output": "NormalizedMaterial[]",
+      "stage": "normalize"
+    },
+    {
+      "component": "composer",
+      "gate": "evidence_quorum",
+      "order": 3,
+      "output": "hypotheses_and_spec",
+      "stage": "compose"
+    },
+    {
+      "component": "context_builder",
+      "gate": "no_secrets",
+      "order": 4,
+      "output": "SimulationPlan",
+      "stage": "reconstruct"
+    },
+    {
+      "component": "worktree_runner",
+      "gate": "worktree",
+      "order": 5,
+      "output": "patch_and_artifacts",
+      "stage": "experiment"
+    },
+    {
+      "component": "verification_runner",
+      "gate": "empirical",
+      "order": 6,
+      "output": "test_metrics_failure_report",
+      "stage": "verify"
+    },
+    {
+      "component": "decision_gate",
+      "gate": "manual_only",
+      "order": 7,
+      "output": "operator_proposal",
+      "stage": "promote"
+    }
+  ],
+  "pipeline_version": "autonomous-lab-v0",
+  "promotion_policy": "manual_operator_decision_only",
+  "run_id": "2026-05-31-bootstrap",
+  "safety_gates": [
+    {
+      "detail": "at least one research material is required",
+      "name": "materials_present",
+      "passed": true,
+      "severity": "blocker"
+    },
+    {
+      "detail": "receipts store checksum and derived fields only",
+      "name": "raw_material_not_persisted",
+      "passed": true,
+      "severity": "blocker"
+    },
+    {
+      "detail": "python scripts/agent_start.py --lane ops --task-id autonomous-lab-scaffold",
+      "name": "worktree_isolation",
+      "passed": true,
+      "severity": "blocker"
+    },
+    {
+      "detail": "workspace write flow requires explicit operator request",
+      "name": "google_workspace_write_block",
+      "passed": true,
+      "severity": "blocker"
+    },
+    {
+      "detail": "lab drafts never emit deploy or origin-main promotion commands",
+      "name": "production_deploy_block",
+      "passed": true,
+      "severity": "blocker"
+    },
+    {
+      "detail": "operator must approve any promotion after verification",
+      "name": "manual_promotion_only",
+      "passed": true,
+      "severity": "blocker"
+    }
+  ],
+  "simulation_plan": {
+    "context_reconstruction": [
+      "git head and dirty-state snapshot",
+      "target service import graph",
+      "environment key allowlist without secret values",
+      "fixture or sanitized data shape matching production contracts",
+      "exact runtime command path used by production or cron"
+    ],
+    "failure_analysis_required": true,
+    "target_paths": [
+      "apps/backend-rag/backend/services/autonomous_lab",
+      "research/operations/autonomous-lab"
+    ],
+    "verification_commands": [
+      "cd apps/backend-rag && PYTHONPATH=. pytest backend/tests/unit/services/autonomous_lab -q",
+      "git diff --check -- research/operations/autonomous-lab"
+    ],
+    "worktree_command": "python scripts/agent_start.py --lane ops --task-id autonomous-lab-scaffold",
+    "worktree_lane": "ops"
+  }
+}

--- a/research/operations/autonomous-lab/receipts/autonomous-lab-bootstrap-example.json
+++ b/research/operations/autonomous-lab/receipts/autonomous-lab-bootstrap-example.json
@@ -1,0 +1,165 @@
+{
+  "blocked": false,
+  "created_at": "2026-05-31T01:20:00+08:00",
+  "decision_grade_outputs": [
+    "technical proposal",
+    "patch diff",
+    "test report",
+    "metric delta",
+    "failure analysis",
+    "manual promotion recommendation"
+  ],
+  "hypotheses": [
+    "Use repo, research, safety evidence to test whether 'riprendere il laboratorio autonomo di Nuzantara' can produce a decision-grade Nuzantara change.",
+    "Prefer a reversible worktree experiment with explicit tests before any promotion."
+  ],
+  "materials": [
+    {
+      "captured_at": "2026-05-31T01:20:00+08:00",
+      "checksum_sha256": "cba7fc5e41b0f78c94cf105845dd0446b53ead40e3bd8bf6688941632950616b",
+      "claims": [
+        "claim_fingerprint:cba7fc5e41b0f78c"
+      ],
+      "material_id": "wr2-wr3-inventory",
+      "risk_flags": [],
+      "source_type": "repo",
+      "source_uri": "repo://research/wr2+research/wr3",
+      "summary": "Derived non-verbatim summary: 31 words, 1 non-empty lines, 2 sentence-like segments.",
+      "tags": [
+        "repo",
+        "safety"
+      ],
+      "title": "WR2 and WR3 grounding"
+    },
+    {
+      "captured_at": "2026-05-31T01:20:00+08:00",
+      "checksum_sha256": "3460ffb7791b04c96d3ad092d441eed72b0c867446e3897f5929169676cc8539",
+      "claims": [
+        "claim_fingerprint:3460ffb7791b04c9"
+      ],
+      "material_id": "backend-research-services",
+      "risk_flags": [],
+      "source_type": "repo",
+      "source_uri": "repo://apps/backend-rag/backend/services/research",
+      "summary": "Derived non-verbatim summary: 30 words, 1 non-empty lines, 2 sentence-like segments.",
+      "tags": [
+        "research"
+      ],
+      "title": "Existing backend research layer"
+    }
+  ],
+  "objective": "riprendere il laboratorio autonomo di Nuzantara",
+  "pipeline": [
+    {
+      "component": "source_adapters",
+      "gate": "provenance",
+      "order": 1,
+      "output": "ResearchMaterial[]",
+      "stage": "intake"
+    },
+    {
+      "component": "normalizer",
+      "gate": "no_raw_receipt",
+      "order": 2,
+      "output": "NormalizedMaterial[]",
+      "stage": "normalize"
+    },
+    {
+      "component": "composer",
+      "gate": "evidence_quorum",
+      "order": 3,
+      "output": "hypotheses_and_spec",
+      "stage": "compose"
+    },
+    {
+      "component": "context_builder",
+      "gate": "no_secrets",
+      "order": 4,
+      "output": "SimulationPlan",
+      "stage": "reconstruct"
+    },
+    {
+      "component": "worktree_runner",
+      "gate": "worktree",
+      "order": 5,
+      "output": "patch_and_artifacts",
+      "stage": "experiment"
+    },
+    {
+      "component": "verification_runner",
+      "gate": "empirical",
+      "order": 6,
+      "output": "test_metrics_failure_report",
+      "stage": "verify"
+    },
+    {
+      "component": "decision_gate",
+      "gate": "manual_only",
+      "order": 7,
+      "output": "operator_proposal",
+      "stage": "promote"
+    }
+  ],
+  "pipeline_version": "autonomous-lab-v0",
+  "promotion_policy": "manual_operator_decision_only",
+  "run_id": "autonomous-lab-bootstrap-example",
+  "safety_gates": [
+    {
+      "detail": "at least one research material is required",
+      "name": "materials_present",
+      "passed": true,
+      "severity": "blocker"
+    },
+    {
+      "detail": "receipts store checksum and derived fields only",
+      "name": "raw_material_not_persisted",
+      "passed": true,
+      "severity": "blocker"
+    },
+    {
+      "detail": "python scripts/agent_start.py --lane ops --task-id autonomous-lab-bootstrap-example",
+      "name": "worktree_isolation",
+      "passed": true,
+      "severity": "blocker"
+    },
+    {
+      "detail": "workspace write flow requires explicit operator request",
+      "name": "google_workspace_write_block",
+      "passed": true,
+      "severity": "blocker"
+    },
+    {
+      "detail": "lab drafts never emit deploy or origin-main promotion commands",
+      "name": "production_deploy_block",
+      "passed": true,
+      "severity": "blocker"
+    },
+    {
+      "detail": "operator must approve any promotion after verification",
+      "name": "manual_promotion_only",
+      "passed": true,
+      "severity": "blocker"
+    }
+  ],
+  "simulation_plan": {
+    "context_reconstruction": [
+      "git head and dirty-state snapshot",
+      "target service import graph",
+      "environment key allowlist without secret values",
+      "fixture or sanitized data shape matching production contracts",
+      "exact runtime command path used by production or cron"
+    ],
+    "failure_analysis_required": true,
+    "target_paths": [
+      "apps/backend-rag/backend/services/autonomous_lab",
+      "research/operations/autonomous-lab",
+      "scripts/autonomous_lab_draft.py"
+    ],
+    "verification_commands": [
+      "cd apps/backend-rag && PYTHONPATH=. pytest backend/tests/unit/services/autonomous_lab -q",
+      "git diff --check -- research/operations/autonomous-lab"
+    ],
+    "worktree_command": "python scripts/agent_start.py --lane ops --task-id autonomous-lab-bootstrap-example",
+    "worktree_lane": "ops"
+  }
+}

--- a/research/operations/autonomous-lab/receipts/autonomous-lab-bootstrap-example.json
+++ b/research/operations/autonomous-lab/receipts/autonomous-lab-bootstrap-example.json
@@ -16,10 +16,10 @@
   "materials": [
     {
       "captured_at": "2026-05-31T01:20:00+08:00",
-      "checksum_sha256": "cba7fc5e41b0f78c94cf105845dd0446b53ead40e3bd8bf6688941632950616b",
       "claims": [
-        "claim_fingerprint:cba7fc5e41b0f78c"
+        "claim_fingerprint:sha256:cba7-fc5e-41b0-f78c"
       ],
+      "content_fingerprint": "sha256:cba7-fc5e-41b0-f78c",
       "material_id": "wr2-wr3-inventory",
       "risk_flags": [],
       "source_type": "repo",
@@ -33,10 +33,10 @@
     },
     {
       "captured_at": "2026-05-31T01:20:00+08:00",
-      "checksum_sha256": "3460ffb7791b04c96d3ad092d441eed72b0c867446e3897f5929169676cc8539",
       "claims": [
-        "claim_fingerprint:3460ffb7791b04c9"
+        "claim_fingerprint:sha256:3460-ffb7-791b-04c9"
       ],
+      "content_fingerprint": "sha256:3460-ffb7-791b-04c9",
       "material_id": "backend-research-services",
       "risk_flags": [],
       "source_type": "repo",
@@ -111,7 +111,7 @@
       "severity": "blocker"
     },
     {
-      "detail": "receipts store checksum and derived fields only",
+      "detail": "receipts store grouped content fingerprint and derived fields only",
       "name": "raw_material_not_persisted",
       "passed": true,
       "severity": "blocker"

--- a/scripts/autonomous_lab_draft.py
+++ b/scripts/autonomous_lab_draft.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Draft an autonomous lab run receipt from a source-agnostic JSON input."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACKEND_ROOT = REPO_ROOT / "apps" / "backend-rag"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from backend.services.autonomous_lab import (  # noqa: E402
+    AutonomousLabPlanner,
+    MaterialSourceType,
+    ResearchMaterial,
+)
+
+DEFAULT_RECEIPT_DIR = REPO_ROOT / "research" / "operations" / "autonomous-lab" / "receipts"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "input",
+        type=Path,
+        help="Path to the autonomous lab draft input JSON.",
+    )
+    parser.add_argument(
+        "--receipt-dir",
+        type=Path,
+        default=DEFAULT_RECEIPT_DIR,
+        help="Directory where the receipt JSON is written.",
+    )
+    parser.add_argument(
+        "--allow-blocked",
+        action="store_true",
+        help="Return 0 even if blocker gates fail. The blocked receipt is still written.",
+    )
+    return parser.parse_args(argv)
+
+
+def load_input(path: Path) -> dict[str, Any]:
+    """Load and validate the top-level input JSON object."""
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError("input JSON must be an object")
+    return payload
+
+
+def material_from_payload(payload: dict[str, Any]) -> ResearchMaterial:
+    """Build a ResearchMaterial from one input material object."""
+    required = ("material_id", "source_type", "source_uri", "title", "text")
+    missing = [key for key in required if key not in payload]
+    if missing:
+        raise ValueError(f"material missing required keys: {', '.join(missing)}")
+
+    source_type = MaterialSourceType(str(payload["source_type"]))
+    metadata_raw = payload.get("metadata", {})
+    if not isinstance(metadata_raw, dict):
+        raise ValueError("material metadata must be an object when provided")
+    metadata = {str(key): str(value) for key, value in metadata_raw.items()}
+
+    captured_at = _parse_datetime(payload.get("captured_at"))
+    return ResearchMaterial(
+        material_id=str(payload["material_id"]),
+        source_type=source_type,
+        source_uri=str(payload["source_uri"]),
+        title=str(payload["title"]),
+        text=str(payload["text"]),
+        captured_at=captured_at,
+        metadata=metadata,
+    )
+
+
+def build_run(payload: dict[str, Any]) -> tuple[AutonomousLabPlanner, Any]:
+    """Build the lab run from input payload."""
+    objective = str(payload.get("objective", "")).strip()
+    task_id = str(payload.get("task_id", "")).strip()
+    if not objective:
+        raise ValueError("objective is required")
+    if not task_id:
+        raise ValueError("task_id is required")
+
+    materials_raw = payload.get("materials", [])
+    if not isinstance(materials_raw, list):
+        raise ValueError("materials must be a list")
+    materials = [material_from_payload(item) for item in materials_raw]
+
+    target_paths_raw = payload.get("target_paths", [])
+    if not isinstance(target_paths_raw, list):
+        raise ValueError("target_paths must be a list")
+    target_paths = [str(path) for path in target_paths_raw]
+
+    worktree_lane = str(payload.get("worktree_lane", "ops")).strip() or "ops"
+    planner = AutonomousLabPlanner(worktree_lane=worktree_lane)
+    run = planner.draft_run(
+        objective=objective,
+        materials=materials,
+        target_paths=target_paths,
+        task_id=task_id,
+        created_at=_parse_datetime(payload.get("created_at")),
+    )
+    return planner, run
+
+
+def summarize_result(receipt_path: Path, run: Any) -> dict[str, Any]:
+    """Return a small JSON summary for stdout."""
+    failed_blockers = [
+        gate.name
+        for gate in run.safety_gates
+        if gate.severity.value == "blocker" and not gate.passed
+    ]
+    return {
+        "ok": not failed_blockers,
+        "blocked": bool(failed_blockers),
+        "failed_blockers": failed_blockers,
+        "receipt_path": str(receipt_path),
+        "run_id": run.run_id,
+        "verification_commands": run.simulation_plan.verification_commands,
+        "worktree_command": run.simulation_plan.worktree_command,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    args = parse_args(argv)
+    payload = load_input(args.input)
+    planner, run = build_run(payload)
+    receipt_path = planner.write_receipt(run, args.receipt_dir)
+    summary = summarize_result(receipt_path, run)
+    json.dump(summary, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    if summary["blocked"] and not args.allow_blocked:
+        return 2
+    return 0
+
+
+def _parse_datetime(value: Any) -> datetime:
+    if value is None:
+        return datetime.now().astimezone()
+    if not isinstance(value, str):
+        raise ValueError("datetime fields must be ISO-8601 strings")
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add the autonomous lab technical map and local receipts
- add source-agnostic backend planning contracts that normalize research material without persisting raw text
- add `scripts/autonomous_lab_draft.py` to generate lab receipts from JSON input
- add a versioned bootstrap example and CLI-generated receipt

## Safety
- no production deploy commands
- no Google Workspace write flow
- manual promotion only
- worktree command emitted via `scripts/agent_start.py`
- blocked exit code for explicit Workspace write requests

## Verification
- `ruff format --check backend/services/autonomous_lab backend/tests/unit/services/autonomous_lab ../../scripts/autonomous_lab_draft.py`
- `ruff check backend/services/autonomous_lab backend/tests/unit/services/autonomous_lab ../../scripts/autonomous_lab_draft.py`
- `PYTHONPATH=. pytest backend/tests/unit/services/autonomous_lab -q` (7 passed)
- `git diff --check`
- `python scripts/autonomous_lab_draft.py research/operations/autonomous-lab/examples/bootstrap-input.json --receipt-dir research/operations/autonomous-lab/receipts`
