### PR TITLE
fix(crm-guardian): bound file inventory prompt

### DIFF
--- a/apps/backend-rag/backend/tests/unit/services/crm_guardian/test_cli_worker_helpers.py
+++ b/apps/backend-rag/backend/tests/unit/services/crm_guardian/test_cli_worker_helpers.py
@@ -129,6 +129,66 @@ class TestFileInventoryBlock:
         block = worker.build_file_inventory_block([], {})
         assert "source_folder | file_id | name | mimeType | size_bytes | modifiedTime" in block
 
+    def test_inventory_prompt_budget_prioritizes_ocr_and_doc_type(
+        self,
+        worker,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        files = [
+            {
+                "id": "old_plain",
+                "name": "meeting-notes-2020.pdf",
+                "mimeType": "application/pdf",
+                "modifiedTime": "2020-01-01T00:00:00Z",
+                "source_folder_id": "f",
+            },
+            {
+                "id": "new_plain",
+                "name": "meeting-notes-2026.pdf",
+                "mimeType": "application/pdf",
+                "modifiedTime": "2026-01-01T00:00:00Z",
+                "source_folder_id": "f",
+            },
+            {
+                "id": "priority_doc",
+                "name": "passport.pdf",
+                "mimeType": "application/pdf",
+                "modifiedTime": "2021-01-01T00:00:00Z",
+                "source_folder_id": "f",
+            },
+            {
+                "id": "ocr_doc",
+                "name": "random-scan.pdf",
+                "mimeType": "application/pdf",
+                "modifiedTime": "2019-01-01T00:00:00Z",
+                "source_folder_id": "f",
+            },
+        ]
+        ocr_results = {
+            "ocr_doc": worker.ExtractionResult(
+                text="ocr text",
+                extractor="pdfminer",
+                confidence=0.9,
+                page_count=1,
+                duration_ms=1,
+                truncated=False,
+            )
+        }
+
+        monkeypatch.setattr(worker, "INVENTORY_MAX_FILES", 3)
+
+        block = worker.build_file_inventory_block(files, {"f": "Folder"}, ocr_results)
+
+        assert "ocr_doc" in block
+        assert "priority_doc" in block
+        assert "new_plain" in block
+        assert "old_plain" not in block
+        assert block.index("ocr_doc") < block.index("priority_doc") < block.index("new_plain")
+        assert "priority_doc | passport.pdf | application/pdf |  | 2021-01-01T00:00:00Z | passport" in block
+        assert "# Total files: 4" in block
+        assert "# Files rendered: 3" in block
+        assert "# Files skipped_by_prompt_budget: 1" in block
+
 
 # ---------------------------------------------------------------------------
 # build_file_content_snippets_block

--- a/scripts/crm_guardian_gemini_cli_worker.py
+++ b/scripts/crm_guardian_gemini_cli_worker.py
@@ -106,12 +106,12 @@ STALE_RUNNING_SECONDS = int(os.getenv("CRM_GUARDIAN_STALE_RUNNING_SECONDS", "900
 # Excess files fall through as metadata-only (extractor='skipped').
 OCR_MAX_FILES_PER_CLIENT = 30
 
-# Prompt budget guard for cached OCR content. Fresh extraction is capped above,
-# but cache hits can otherwise render every historical priority document into
-# one prompt. Keep the LLM input bounded while preserving full file inventory.
-CONTENT_SNIPPET_MAX_FILES = int(os.getenv("CRM_GUARDIAN_CONTENT_SNIPPET_MAX_FILES", "20"))
-CONTENT_SNIPPET_MAX_CHARS_PER_FILE = int(os.getenv("CRM_GUARDIAN_CONTENT_SNIPPET_MAX_CHARS_PER_FILE", "4000"))
-CONTENT_SNIPPET_MAX_CHARS_TOTAL = int(os.getenv("CRM_GUARDIAN_CONTENT_SNIPPET_MAX_CHARS_TOTAL", "60000"))
+# Prompt budget guards. Fresh extraction is capped above, but cache hits and
+# very large Drive folders can otherwise render unbounded prompt sections.
+INVENTORY_MAX_FILES = int(os.getenv("CRM_GUARDIAN_INVENTORY_MAX_FILES", "120"))
+CONTENT_SNIPPET_MAX_FILES = int(os.getenv("CRM_GUARDIAN_CONTENT_SNIPPET_MAX_FILES", "12"))
+CONTENT_SNIPPET_MAX_CHARS_PER_FILE = int(os.getenv("CRM_GUARDIAN_CONTENT_SNIPPET_MAX_CHARS_PER_FILE", "2500"))
+CONTENT_SNIPPET_MAX_CHARS_TOTAL = int(os.getenv("CRM_GUARDIAN_CONTENT_SNIPPET_MAX_CHARS_TOTAL", "30000"))
 
 
 def _terminate_gemini_process(proc: subprocess.Popen[str]) -> None:
@@ -632,26 +632,71 @@ def build_cross_folder_context_block(
 def build_file_inventory_block(
     flat_files: list[dict[str, Any]],
     folder_id_to_name: dict[str, str],
-    _ocr_results: dict[str, ExtractionResult] | None = None,
+    ocr_results: dict[str, ExtractionResult] | None = None,
 ) -> str:
     """Render <FILE_INVENTORY> block exposing file metadata to Gemini.
 
     Each row also tags the inferred doc_type (passport/akta/nib/...) so the
     model can prioritise the right files when extracting compliance fields.
+    The rendered table is budgeted because some Drive roots contain thousands
+    of historical files; fingerprinting still uses the complete file list.
     """
+    ocr_results = ocr_results or {}
+
+    def _doc_type(file_row: dict[str, Any]) -> str:
+        return (
+            file_row.get("inferred_doc_type")
+            or infer_doc_type_from_filename(file_row.get("name"))
+            or "-"
+        )
+
+    def _ranked_file(item: tuple[int, dict[str, Any]]) -> tuple[int, int, str, str, int]:
+        index, file_row = item
+        fid = str(file_row.get("id", ""))
+        doc_type = _doc_type(file_row)
+        if fid in ocr_results:
+            rank = 0
+        elif doc_type in PRIORITY_DOC_TYPES:
+            rank = 1
+        elif doc_type != "-":
+            rank = 2
+        else:
+            rank = 3
+        return (
+            rank,
+            -_drive_modified_time_ms(file_row.get("modifiedTime")),
+            str(file_row.get("source_folder_id", "")),
+            fid,
+            index,
+        )
+
+    ranked_files = [
+        file_row
+        for _, file_row in sorted(enumerate(flat_files), key=_ranked_file)
+    ]
+    rendered_files = ranked_files[:INVENTORY_MAX_FILES]
+    skipped_by_budget = max(0, len(flat_files) - len(rendered_files))
+
     lines = ["<FILE_INVENTORY>"]
     lines.append(
         "# Format: source_folder | file_id | name | mimeType | size_bytes | modifiedTime | inferred_doc_type"
     )
-    for f in flat_files:
+    if skipped_by_budget:
+        lines.append(
+            "# Inventory is priority-sorted: OCR-backed docs, inferred compliance docs, "
+            "then newest remaining files."
+        )
+    for f in rendered_files:
         src = folder_id_to_name.get(f.get("source_folder_id", ""), "?")
         size = f.get("size", "")
-        doc_type = f.get("inferred_doc_type") or "-"
+        doc_type = _doc_type(f)
         lines.append(
             f"{src} | {f['id']} | {f.get('name', '?')} | "
             f"{f.get('mimeType', '?')} | {size} | {f.get('modifiedTime', '?')} | {doc_type}"
         )
     lines.append(f"# Total files: {len(flat_files)}")
+    lines.append(f"# Files rendered: {len(rendered_files)}")
+    lines.append(f"# Files skipped_by_prompt_budget: {skipped_by_budget}")
     lines.append("</FILE_INVENTORY>")
     return "\n".join(lines)
 


### PR DESCRIPTION
## Summary
- cap rendered CRM Guardian file inventory rows with an env override
- prioritize OCR-backed docs, inferred compliance docs, then newest remaining files
- lower default OCR snippet prompt budget to keep agy JSON output reliable
- add test coverage for inventory budget markers and prioritization

## Verification
- PYTHONPATH=. pytest backend/tests/unit/services/crm_guardian/test_cli_worker_helpers.py -q
- ruff check ../../scripts/crm_guardian_gemini_cli_worker.py backend/tests/unit/services/crm_guardian/test_cli_worker_helpers.py
- git diff --check