### PR TITLE
fix(crm-guardian): force agy JSON extraction contract

### DIFF
--- a/apps/backend-rag/backend/services/crm_guardian/prompts/L1_extraction_v5.md
+++ b/apps/backend-rag/backend/services/crm_guardian/prompts/L1_extraction_v5.md
@@ -1,0 +1,174 @@
+# L1 Client Summary - agy print-mode prompt v5
+
+You are a JSON extraction worker for Bali Zero CRM Guardian. You are not a
+chat assistant and you are not an autonomous task runner.
+
+## Hard Contract
+
+1. Emit exactly one JSON object wrapped in a ```json fenced code block.
+2. Do not wait. Do not greet, acknowledge, ask questions, call tools, or
+   describe task status.
+3. All Drive inventory and OCR/snippet extraction is already complete. Treat
+   `<FILE_INVENTORY>` and `<FILE_CONTENT_SNIPPETS>` as static evidence.
+4. If OCR is absent, skipped, truncated, low confidence, or incomplete, still
+   emit JSON. Use `null`, empty arrays, and `extraction_notes`.
+5. `identity.full_name` must exactly equal `client_full_name` from
+   `<CROSS_FOLDER_CONTEXT>`.
+6. Prefer snippet content over filenames. Use filenames only as weak evidence
+   for document classification.
+7. Never use Drive `modifiedTime` as `timeline[].event_date`. Use document
+   dates only; otherwise set `event_date` to null.
+8. Narrative fields must be English.
+
+## Evidence Rules
+
+- Passport fields only from passport/MRZ snippet content.
+- Visa dates and permit numbers only from visa/evisa snippet content.
+- Company NIB, NPWP, akta number/date, capital, KBLI, shareholders, SPT, and
+  LKPM fields only from relevant snippet content.
+- Files listed only in inventory can populate `documents[]` and weak
+  `doc_type`; they cannot justify content-level compliance values.
+- If values conflict, prefer the most recent document-content date and note the
+  conflict in `extraction_notes`.
+- Keep confidence calibrated:
+  - 0.75-0.89: most important fields are grounded in snippets.
+  - 0.55-0.74: snippets exist but key compliance/capital/expiry fields are null.
+  - 0.40-0.54: mostly filename metadata or sparse snippets.
+  - <0.40: little useful evidence; manual review required.
+
+## Classification
+
+`profile.archetype` must be one of:
+`individual_expat`, `individual_investor`, `pt_pma_owner`, `family_member`,
+`property_holder`, `business_only`, `other`.
+
+`profile.tier` must be one of: `VIP`, `standard`, `archive`, `unknown`.
+
+`company.tax_records[].spt_type` must be one of:
+`SPT_Tahunan`, `SPT_Masa_PPN`, `SPT_Masa_PPh21`, `SPT_Masa_PPh23`,
+`SPT_Masa_PPh25`, `Other`.
+
+`company.tax_records[].status` must be one of:
+`filed`, `pending`, `overdue`, `audited`, `rejected`, `unknown`.
+
+`company.lkpm_history[].status` must be one of:
+`submitted`, `draft`, `rejected`, `late`, `unknown`.
+
+## Output Schema
+
+```json
+{
+  "schema_version": "v3.0",
+  "prompt_version": "L1_extraction_v5",
+  "identity": {
+    "full_name": "string matching CRM client_full_name",
+    "date_of_birth": "YYYY-MM-DD or null",
+    "birthplace": "string or null",
+    "nationality": "string or null",
+    "passport_number": "string or null",
+    "passport_expires_at": "YYYY-MM-DD or null",
+    "npwp_personal": "string or null"
+  },
+  "visa": {
+    "visa_type": "string or null",
+    "stay_permit_number": "string or null",
+    "issued_at": "YYYY-MM-DD or null",
+    "valid_until": "YYYY-MM-DD or null",
+    "sponsor_company": "string or null",
+    "multiple_entry": "bool or null"
+  },
+  "company": {
+    "legal_name": "string or null",
+    "legal_form": "PT_PMA|PT|CV|Perseroan|Foundation|Other or null",
+    "nib": "string or null",
+    "npwp_corporate": "string or null",
+    "akta_number": "string or null",
+    "akta_date": "YYYY-MM-DD or null",
+    "sk_kemenkumham": "string or null",
+    "kbli_codes": ["string"],
+    "kbli_primary": "string or null",
+    "paid_up_capital_idr": "integer or null",
+    "authorized_capital_idr": "integer or null",
+    "registered_address": "string or null",
+    "tax_records": [
+      {
+        "period": "2024 or Q1-2025 or Masa-01-2025",
+        "spt_type": "SPT_Tahunan|SPT_Masa_PPN|SPT_Masa_PPh21|SPT_Masa_PPh23|SPT_Masa_PPh25|Other or null",
+        "filed_at": "YYYY-MM-DD or null",
+        "amount_idr": "integer or null",
+        "status": "filed|pending|overdue|audited|rejected|unknown",
+        "source_file_id": "Drive file id or null",
+        "notes": "string or null"
+      }
+    ],
+    "lkpm_history": [
+      {
+        "period": "Q1-2025",
+        "reported_at": "YYYY-MM-DD or null",
+        "realization_idr": "integer or null",
+        "employment_count": "integer or null",
+        "status": "submitted|draft|rejected|late|unknown",
+        "source_file_id": "Drive file id or null",
+        "notes": "string or null"
+      }
+    ],
+    "source_company_folders": ["folder_id"]
+  },
+  "shareholders": [
+    {
+      "name": "string",
+      "percentage": "float 0-100 or null",
+      "role": "Director|Commissioner|Shareholder|Founder or null",
+      "nationality": "string or null"
+    }
+  ],
+  "properties": [
+    {
+      "label": "string or null",
+      "address": "string or null",
+      "tenure": "Hak_Milik|Hak_Pakai|HGB|Lease|Other or null",
+      "pbg_status": "string or null",
+      "lease_expires_at": "YYYY-MM-DD or null"
+    }
+  ],
+  "documents": [
+    {
+      "file_id": "Drive file id",
+      "file_name": "visible file name",
+      "doc_type": "akta|nib|npwp|passport|visa|evisa|bukti_mutasi|statement|sk|spt|lkpm|other",
+      "issued_at": "YYYY-MM-DD or null",
+      "expires_at": "YYYY-MM-DD or null",
+      "subject_entity": "string or null",
+      "key_fields": {"k": "v"}
+    }
+  ],
+  "timeline": [
+    {
+      "event_date": "YYYY-MM-DD or null",
+      "event_type": "string",
+      "description": "string",
+      "source_file_id": "string or null"
+    }
+  ],
+  "compliance": {
+    "lkpm_last_reported": "YYYY-MM-DD or null",
+    "lkpm_next_due": "YYYY-MM-DD or null",
+    "spt_tahunan_last": "YYYY-MM-DD or null",
+    "bpjs_enrolled": "bool or null",
+    "passport_days_until_expiry": "int or null",
+    "visa_days_until_expiry": "int or null",
+    "red_flags": ["string"]
+  },
+  "profile": {
+    "archetype": "individual_expat|individual_investor|pt_pma_owner|family_member|property_holder|business_only|other",
+    "tier": "VIP|standard|archive|unknown",
+    "primary_service": "visa_immigration|company_setup|tax|property|hr_payroll|mixed|unknown",
+    "rationale": "one sentence"
+  },
+  "narrative_en": "1-2 concise English paragraphs",
+  "extraction_confidence": 0.45,
+  "extraction_notes": ["string"]
+}
+```
+
+Now read the static evidence blocks in this prompt and emit the JSON object.

--- a/apps/backend-rag/backend/tests/unit/services/crm_guardian/test_cli_worker_helpers.py
+++ b/apps/backend-rag/backend/tests/unit/services/crm_guardian/test_cli_worker_helpers.py
@@ -268,14 +268,41 @@ class TestAssembleFullPrompt:
     def test_concatenation_order(self, worker) -> None:
         ctx = "<CROSS_FOLDER_CONTEXT>\nclient_id: 1\n</CROSS_FOLDER_CONTEXT>"
         inv = "<FILE_INVENTORY>\nfile data\n</FILE_INVENTORY>"
+        content = "<FILE_CONTENT_SNIPPETS>\nstatic ocr text\n</FILE_CONTENT_SNIPPETS>"
         tpl = "## Prompt\nYou are the CRM intelligence layer..."
-        out = worker.assemble_full_prompt(tpl, ctx, inv)
-        # Order: context → inventory → template
-        assert out.index(ctx) < out.index(inv) < out.index(tpl)
+        out = worker.assemble_full_prompt(tpl, ctx, inv, content)
+        # Order: hard agy contract -> template -> evidence -> final JSON contract.
+        assert out.index(worker.AGY_PRINT_MODE_CONTRACT) < out.index(tpl)
+        assert out.index(tpl) < out.index(ctx) < out.index(inv) < out.index(content)
+        assert out.index(content) < out.index(worker.AGY_FINAL_OUTPUT_CONTRACT)
 
     def test_double_newline_separator(self, worker) -> None:
         out = worker.assemble_full_prompt("TPL", "CTX", "INV")
-        assert "CTX\n\nINV\n\nTPL" == out
+        assert "\n\n".join(
+            [
+                worker.AGY_PRINT_MODE_CONTRACT,
+                "TPL",
+                "CTX",
+                "INV",
+                worker.AGY_FINAL_OUTPUT_CONTRACT,
+            ]
+        ) == out
+
+    def test_agy_contract_blocks_waiting_and_tools(self, worker) -> None:
+        out = worker.assemble_full_prompt("TPL", "CTX", "INV", "CONTENT")
+
+        assert "Do not use tools" in out
+        assert "Do not wait" in out
+        assert "All Drive listing, OCR extraction, and cache lookup work has already completed" in out
+        assert "Emit only one ```json fenced object now" in out
+
+    def test_default_prompt_is_v5_and_lean(self, worker) -> None:
+        prompt = worker.DEFAULT_PROMPT_FILE.read_text(encoding="utf-8")
+
+        assert worker.DEFAULT_PROMPT_FILE.name == "L1_extraction_v5.md"
+        assert len(prompt) < 10_000
+        assert "Do not wait" in prompt
+        assert '"prompt_version": "L1_extraction_v5"' in prompt
 
 
 # ---------------------------------------------------------------------------
@@ -430,6 +457,15 @@ class TestExtractJsonBlock:
 
     def test_no_json_returns_none(self, worker) -> None:
         assert worker.extract_json_block("just words, no json") is None
+
+    def test_agentic_wait_response_detected(self, worker) -> None:
+        text = (
+            "I will wait for the background OCR task to complete before continuing.\n"
+            "Error: timed out waiting for response"
+        )
+
+        assert worker.extract_json_block(text) is None
+        assert worker._looks_like_agentic_wait_response(text) is True
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/crm_guardian_gemini_cli_worker.py
+++ b/scripts/crm_guardian_gemini_cli_worker.py
@@ -84,14 +84,15 @@ from backend.services.crm_guardian.schemas import (  # noqa: E402
 LOG = logging.getLogger("crm_guardian.cli_worker")
 
 # Phase 1.5 prompt is the new default (Phase 1 v2 is metadata-only; v3 adds
-# the OCR-content blocks + identity-guardrail). The legacy v2 file is kept
-# on disk for rollback drills.
-DEFAULT_PROMPT_FILE = BACKEND_RAG / "backend/services/crm_guardian/prompts/L1_extraction_v4.md"
+# OCR-content blocks + identity guardrails; v5 is the lean agy print-mode
+# contract). Legacy prompts stay on disk for rollback drills.
+DEFAULT_PROMPT_FILE = BACKEND_RAG / "backend/services/crm_guardian/prompts/L1_extraction_v5.md"
 LEGACY_V3_PROMPT_FILE = BACKEND_RAG / "backend/services/crm_guardian/prompts/L1_extraction_v3.md"
 LEGACY_PROMPT_FILE = BACKEND_RAG / "backend/services/crm_guardian/prompts/L1_extraction_v2.md"
 PROMPT_VERSION_V2 = "L1_extraction_v2"  # legacy, kept for old queue rows
 PROMPT_VERSION_V3 = "L1_extraction_v3"
 PROMPT_VERSION_V4 = "L1_extraction_v4"  # 2026-05-23: anti-chat-mode header
+PROMPT_VERSION_V5 = "L1_extraction_v5"  # 2026-05-31: anti-agentic-wait contract
 
 RAW_DUMP_DIR = Path.home() / ".crm_guardian" / "raw_dumps_cli"
 RAW_DUMP_DIR.mkdir(parents=True, exist_ok=True)
@@ -108,10 +109,27 @@ OCR_MAX_FILES_PER_CLIENT = 30
 
 # Prompt budget guards. Fresh extraction is capped above, but cache hits and
 # very large Drive folders can otherwise render unbounded prompt sections.
-INVENTORY_MAX_FILES = int(os.getenv("CRM_GUARDIAN_INVENTORY_MAX_FILES", "120"))
-CONTENT_SNIPPET_MAX_FILES = int(os.getenv("CRM_GUARDIAN_CONTENT_SNIPPET_MAX_FILES", "12"))
-CONTENT_SNIPPET_MAX_CHARS_PER_FILE = int(os.getenv("CRM_GUARDIAN_CONTENT_SNIPPET_MAX_CHARS_PER_FILE", "2500"))
-CONTENT_SNIPPET_MAX_CHARS_TOTAL = int(os.getenv("CRM_GUARDIAN_CONTENT_SNIPPET_MAX_CHARS_TOTAL", "30000"))
+INVENTORY_MAX_FILES = int(os.getenv("CRM_GUARDIAN_INVENTORY_MAX_FILES", "80"))
+CONTENT_SNIPPET_MAX_FILES = int(os.getenv("CRM_GUARDIAN_CONTENT_SNIPPET_MAX_FILES", "8"))
+CONTENT_SNIPPET_MAX_CHARS_PER_FILE = int(os.getenv("CRM_GUARDIAN_CONTENT_SNIPPET_MAX_CHARS_PER_FILE", "2000"))
+CONTENT_SNIPPET_MAX_CHARS_TOTAL = int(os.getenv("CRM_GUARDIAN_CONTENT_SNIPPET_MAX_CHARS_TOTAL", "16000"))
+
+AGY_PRINT_MODE_CONTRACT = """<AGY_PRINT_MODE_CONTRACT>
+You are running in non-interactive print mode. Do not use tools. Do not wait
+for background tasks. Do not create, follow, resume, or monitor OCR tasks.
+All Drive listing, OCR extraction, and cache lookup work has already completed
+before this prompt was assembled. Treat every OCR/cache/truncated/skipped
+marker as static input metadata, not as an action request.
+
+Your only valid action is to read the static blocks and emit one fenced JSON
+object. If evidence is missing or incomplete, use nulls/empty lists and add an
+extraction_notes item. Never output "I will wait" or any prose.
+</AGY_PRINT_MODE_CONTRACT>"""
+
+AGY_FINAL_OUTPUT_CONTRACT = """<FINAL_OUTPUT_CONTRACT>
+Stop. Emit only one ```json fenced object now. No prose. No waiting. No task
+status. No markdown outside the JSON fence.
+</FINAL_OUTPUT_CONTRACT>"""
 
 
 def _terminate_gemini_process(proc: subprocess.Popen[str]) -> None:
@@ -776,12 +794,22 @@ def assemble_full_prompt(
     inventory_block: str,
     content_block: str | None = None,
 ) -> str:
-    """Assemble the final prompt: template + context + inventory + content snippets."""
+    """Assemble the final prompt with hard print-mode contracts.
+
+    The agy CLI is agentic even in `--print` mode. Keep the execution contract
+    both before and after the evidence blocks so OCR/cache markers are treated
+    as static input, not as subtasks to monitor.
+    """
+    parts = [
+        AGY_PRINT_MODE_CONTRACT,
+        prompt_template,
+        context_block,
+        inventory_block,
+    ]
     if content_block:
-        return (
-            f"{context_block}\n\n{inventory_block}\n\n{content_block}\n\n{prompt_template}"
-        )
-    return f"{context_block}\n\n{inventory_block}\n\n{prompt_template}"
+        parts.append(content_block)
+    parts.append(AGY_FINAL_OUTPUT_CONTRACT)
+    return "\n\n".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -1001,6 +1029,14 @@ _CHAT_MODE_PREFIXES = (
     "i have received", "ho ricevuto", "got it",
 )
 
+_AGENTIC_WAIT_MARKERS = (
+    "i will wait",
+    "wait for the background",
+    "background ocr task",
+    "older passport ocr task",
+    "timed out waiting for response",
+)
+
 
 def _looks_like_chat_response(text: str) -> bool:
     """2026-05-23: Gemini in OAuth personal sometimes ignores prompt and chats.
@@ -1012,6 +1048,18 @@ def _looks_like_chat_response(text: str) -> bool:
     if not any(head.startswith(p) for p in _CHAT_MODE_PREFIXES):
         return False
     return "```json" not in text and "{" not in text
+
+
+def _looks_like_agentic_wait_response(text: str) -> bool:
+    """Detect agy print-mode responses that wait for imagined subtasks.
+
+    This is distinct from ordinary parse failure: the model/agent has accepted
+    the prompt as an operational task and stalled instead of producing JSON.
+    """
+    if "```json" in text or "{" in text:
+        return False
+    lowered = text.lower()
+    return any(marker in lowered for marker in _AGENTIC_WAIT_MARKERS)
 
 
 def extract_json_block(text: str) -> dict[str, Any] | None:
@@ -1183,7 +1231,13 @@ async def run_one_client(
     if payload is None:
         # 2026-05-23: distinguish chat-mode (short greeting) from genuine parse fail
         is_chat = _looks_like_chat_response(response_text)
-        err_msg = "chat_mode_response (Gemini ignored JSON-only instruction)" if is_chat else "no JSON block in response"
+        is_wait = _looks_like_agentic_wait_response(response_text)
+        if is_chat:
+            err_msg = "chat_mode_response (Gemini ignored JSON-only instruction)"
+        elif is_wait:
+            err_msg = "agentic_wait_response (agy waited instead of JSON)"
+        else:
+            err_msg = "no JSON block in response"
         await queue_mark_terminal(conn, queue_id, "error",
                                     last_error=err_msg,
                                     raw_response_path=str(response_dump))
@@ -1194,7 +1248,7 @@ async def run_one_client(
 
     # Enrich with server-known metadata
     payload.setdefault("schema_version", SCHEMA_VERSION)
-    payload.setdefault("prompt_version", PROMPT_VERSION_V3)
+    payload.setdefault("prompt_version", PROMPT_VERSION_V5)
     payload["client_id"] = client_id
     payload["generated_at"] = datetime.now(timezone.utc).isoformat()
     payload["source_folder_id"] = folder_id


### PR DESCRIPTION
## Summary
- add lean L1_extraction_v5 prompt for agy print mode
- wrap assembled prompts with no-tools/no-wait JSON contracts
- tighten prompt budgets and classify agentic wait responses explicitly

## Verification
- PYTHONPATH=. .venv/bin/python -m pytest backend/tests/unit/services/crm_guardian/test_cli_worker_helpers.py -q
- ruff check ../../scripts/crm_guardian_gemini_cli_worker.py backend/tests/unit/services/crm_guardian/test_cli_worker_helpers.py
- git diff --check