### PR TITLE
fix(crm-guardian): bound OCR preprocessing latency

### DIFF
--- a/apps/backend-rag/backend/services/crm_guardian/ocr.py
+++ b/apps/backend-rag/backend/services/crm_guardian/ocr.py
@@ -338,6 +338,10 @@ async def _tesseract_ocr_png(png_bytes: bytes) -> tuple[str, float]:
             proc.communicate(input=png_bytes),
             timeout=TESSERACT_TIMEOUT_SECONDS,
         )
+    except asyncio.CancelledError:
+        proc.kill()
+        await proc.wait()
+        raise
     except asyncio.TimeoutError:
         proc.kill()
         await proc.wait()

--- a/apps/backend-rag/backend/tests/unit/services/crm_guardian/test_cli_worker_helpers.py
+++ b/apps/backend-rag/backend/tests/unit/services/crm_guardian/test_cli_worker_helpers.py
@@ -15,6 +15,7 @@ test_worker_helpers.py and re-imported here only for sanity.
 
 from __future__ import annotations
 
+import asyncio
 import importlib.util
 import subprocess
 import sys
@@ -257,6 +258,96 @@ class TestFileContentSnippetsBlock:
         assert "# Snippets skipped_by_prompt_budget: 1" in block
         assert "# Snippet text chars rendered: 8/8" in block
         assert "prompt_truncated=true" in block
+
+
+# ---------------------------------------------------------------------------
+# enrich_files_with_ocr
+# ---------------------------------------------------------------------------
+
+
+class TestOcrEnrichmentBudgets:
+    def test_default_fresh_ocr_budget_matches_rendered_snippets(self, worker) -> None:
+        assert worker.OCR_MAX_FILES_PER_CLIENT == 8
+        assert worker.CONTENT_SNIPPET_MAX_FILES == 8
+        assert worker.OCR_MAX_SECONDS_PER_CLIENT > 0
+        assert worker.OCR_MAX_SECONDS_PER_FILE > 0
+
+    @pytest.mark.asyncio
+    async def test_fresh_ocr_budget_caps_extraction_work(
+        self,
+        worker,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        files = [
+            {"id": "f1", "name": "passport-a.pdf", "mimeType": "application/pdf"},
+            {"id": "f2", "name": "passport-b.pdf", "mimeType": "application/pdf"},
+            {"id": "f3", "name": "passport-c.pdf", "mimeType": "application/pdf"},
+        ]
+        extraction = worker.ExtractionResult(
+            text="passport text",
+            extractor="pdfminer",
+            confidence=None,
+            page_count=1,
+            duration_ms=1,
+            truncated=False,
+        )
+
+        extract = AsyncMock(return_value=extraction)
+        download = AsyncMock(return_value=b"%PDF")
+        upsert = AsyncMock()
+
+        monkeypatch.setattr(worker, "get_cached_content", AsyncMock(return_value=None))
+        monkeypatch.setattr(worker, "download_drive_file_bytes", download)
+        monkeypatch.setattr(worker, "extract_file_content", extract)
+        monkeypatch.setattr(worker, "upsert_cache_row", upsert)
+
+        enriched = await worker.enrich_files_with_ocr(
+            object(),
+            object(),
+            files,
+            object(),
+            budget=2,
+            max_seconds_per_client=999,
+            max_seconds_per_file=999,
+        )
+
+        assert extract.await_count == 2
+        assert download.await_count == 2
+        assert upsert.await_count == 2
+        assert set(enriched) == {"f1", "f2"}
+        assert [f["inferred_doc_type"] for f in files] == ["passport", "passport", "passport"]
+
+    @pytest.mark.asyncio
+    async def test_fresh_ocr_file_timeout_records_skipped_cache_row(
+        self,
+        worker,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        async def slow_extract(**_kwargs):
+            await asyncio.sleep(0.05)
+
+        files = [{"id": "f1", "name": "passport.pdf", "mimeType": "application/pdf"}]
+        upsert = AsyncMock()
+
+        monkeypatch.setattr(worker, "get_cached_content", AsyncMock(return_value=None))
+        monkeypatch.setattr(worker, "download_drive_file_bytes", AsyncMock(return_value=b"%PDF"))
+        monkeypatch.setattr(worker, "extract_file_content", slow_extract)
+        monkeypatch.setattr(worker, "upsert_cache_row", upsert)
+
+        enriched = await worker.enrich_files_with_ocr(
+            object(),
+            object(),
+            files,
+            object(),
+            budget=1,
+            max_seconds_per_client=999,
+            max_seconds_per_file=0.01,
+        )
+
+        assert enriched == {}
+        result = upsert.await_args.kwargs["result"]
+        assert result.extractor == "skipped"
+        assert result.notes == "file_timeout_after_0.01s"
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/crm_guardian_gemini_cli_worker.py
+++ b/scripts/crm_guardian_gemini_cli_worker.py
@@ -58,6 +58,7 @@ import re
 import signal
 import subprocess
 import sys
+import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -102,10 +103,13 @@ GEMINI_TIMEOUT_SECONDS = int(os.getenv("CRM_GUARDIAN_GEMINI_TIMEOUT_SECONDS", "9
 GEMINI_DEFAULT_MODEL: str | None = None  # agy uses CLI default model — does NOT support `-m` flag (prints help instead)
 STALE_RUNNING_SECONDS = int(os.getenv("CRM_GUARDIAN_STALE_RUNNING_SECONDS", "900"))
 
-# Phase 1.5 OCR budget per client. Tesseract is fast but akta scans can spike
-# latency; we cap how many priority files we OCR in a single client run.
-# Excess files fall through as metadata-only (extractor='skipped').
-OCR_MAX_FILES_PER_CLIENT = 30
+# Phase 1.5 OCR budget per client. Fresh OCR is capped to the number of
+# snippets we can actually render, with timeboxes to keep huge Drive folders
+# from spending many minutes before the LLM call. Cache hits still render when
+# available because they are cheap and deterministic.
+OCR_MAX_FILES_PER_CLIENT = int(os.getenv("CRM_GUARDIAN_OCR_MAX_FILES_PER_CLIENT", "8"))
+OCR_MAX_SECONDS_PER_CLIENT = float(os.getenv("CRM_GUARDIAN_OCR_MAX_SECONDS_PER_CLIENT", "240"))
+OCR_MAX_SECONDS_PER_FILE = float(os.getenv("CRM_GUARDIAN_OCR_MAX_SECONDS_PER_FILE", "75"))
 
 # Prompt budget guards. Fresh extraction is capped above, but cache hits and
 # very large Drive folders can otherwise render unbounded prompt sections.
@@ -519,6 +523,8 @@ async def enrich_files_with_ocr(
     health: OcrHealth,
     *,
     budget: int = OCR_MAX_FILES_PER_CLIENT,
+    max_seconds_per_client: float = OCR_MAX_SECONDS_PER_CLIENT,
+    max_seconds_per_file: float = OCR_MAX_SECONDS_PER_FILE,
 ) -> dict[str, ExtractionResult]:
     """Extract text content for priority files, using the OCR cache when possible.
 
@@ -534,15 +540,28 @@ async def enrich_files_with_ocr(
     by (file_id, modified_time_ms). Cache hit → reconstruct ExtractionResult
     from the row. Cache miss → download bytes, extract, upsert row.
 
-    Budget cap: at most `budget` fresh extractions per client. Excess priority
-    files fall through to metadata-only. Cache hits do NOT count toward budget.
+    Budget cap: at most `budget` fresh extractions per client and at most
+    `max_seconds_per_client` seconds of OCR work. Excess priority files fall
+    through to metadata-only. Cache hits do NOT count toward either budget.
     """
     enriched: dict[str, ExtractionResult] = {}
     fresh_extractions = 0
+    cache_hits = 0
+    skipped_fresh_budget = 0
+    skipped_time_budget = 0
+    fresh_budget_logged = False
+    time_budget_logged = False
+    started_monotonic = time.monotonic()
 
     for f in flat_files:
-        doc_type = infer_doc_type_from_filename(f.get("name"))
-        f["inferred_doc_type"] = doc_type
+        f["inferred_doc_type"] = infer_doc_type_from_filename(f.get("name"))
+
+    priority_files = sum(
+        1 for f in flat_files if f.get("inferred_doc_type") in PRIORITY_DOC_TYPES
+    )
+
+    for f in flat_files:
+        doc_type = f.get("inferred_doc_type")
 
         if doc_type not in PRIORITY_DOC_TYPES:
             continue
@@ -554,6 +573,7 @@ async def enrich_files_with_ocr(
         cached = await get_cached_content(conn, file_id, modtime_ms)
         if cached:
             if cached["text_content"]:
+                cache_hits += 1
                 enriched[file_id] = ExtractionResult(
                     text=cached["text_content"],
                     extractor=cached["extractor"],
@@ -567,10 +587,21 @@ async def enrich_files_with_ocr(
 
         # Budget guard for FRESH extractions
         if fresh_extractions >= budget:
-            LOG.info(
-                "ocr budget %d reached for this client, skipping further priority files",
-                budget,
-            )
+            skipped_fresh_budget += 1
+            if not fresh_budget_logged:
+                LOG.info("ocr fresh-file budget %d reached, metadata-only for remaining priority files", budget)
+                fresh_budget_logged = True
+            continue
+
+        elapsed_seconds = time.monotonic() - started_monotonic
+        if elapsed_seconds >= max_seconds_per_client:
+            skipped_time_budget += 1
+            if not time_budget_logged:
+                LOG.info(
+                    "ocr time budget %.1fs reached, metadata-only for remaining priority files",
+                    max_seconds_per_client,
+                )
+                time_budget_logged = True
             continue
 
         # Cache miss → fetch bytes + extract
@@ -578,12 +609,39 @@ async def enrich_files_with_ocr(
         if file_bytes is None:
             continue
 
-        result = await extract_file_content(
-            file_bytes=file_bytes,
-            mime_type=f.get("mimeType", ""),
-            doc_type=doc_type,
-            health=health,
-        )
+        remaining_client_seconds = max_seconds_per_client - (time.monotonic() - started_monotonic)
+        if remaining_client_seconds <= 0:
+            skipped_time_budget += 1
+            if not time_budget_logged:
+                LOG.info(
+                    "ocr time budget %.1fs reached after download, skipping extraction",
+                    max_seconds_per_client,
+                )
+                time_budget_logged = True
+            continue
+
+        file_timeout = min(max_seconds_per_file, remaining_client_seconds)
+        extraction_started = time.monotonic()
+        try:
+            result = await asyncio.wait_for(
+                extract_file_content(
+                    file_bytes=file_bytes,
+                    mime_type=f.get("mimeType", ""),
+                    doc_type=doc_type,
+                    health=health,
+                ),
+                timeout=file_timeout,
+            )
+        except asyncio.TimeoutError:
+            result = ExtractionResult(
+                text="",
+                extractor="skipped",
+                confidence=None,
+                page_count=None,
+                duration_ms=int((time.monotonic() - extraction_started) * 1000),
+                truncated=False,
+                notes=f"file_timeout_after_{file_timeout:g}s",
+            )
         fresh_extractions += 1
 
         if result.extractor != "skipped" and result.text:
@@ -598,13 +656,19 @@ async def enrich_files_with_ocr(
         except Exception as e:
             LOG.warning("ocr cache upsert failed for %s: %s", file_id, e)
 
-    if fresh_extractions or enriched:
+    if priority_files or fresh_extractions or enriched:
         LOG.info(
-            "ocr enrichment: priority_files=%d fresh_ocr=%d cache_hits=%d snippets=%d",
-            sum(1 for f in flat_files if f.get("inferred_doc_type") in PRIORITY_DOC_TYPES),
+            (
+                "ocr enrichment: priority_files=%d fresh_ocr=%d cache_hits=%d "
+                "snippets=%d skipped_fresh_budget=%d skipped_time_budget=%d elapsed_ms=%d"
+            ),
+            priority_files,
             fresh_extractions,
-            len(enriched) - fresh_extractions if len(enriched) >= fresh_extractions else 0,
+            cache_hits,
             len(enriched),
+            skipped_fresh_budget,
+            skipped_time_budget,
+            int((time.monotonic() - started_monotonic) * 1000),
         )
     return enriched
 


### PR DESCRIPTION
## Summary
- cap fresh OCR to rendered snippet budget by default
- add per-client and per-file OCR timeboxes before agy prompt assembly
- make Tesseract cancellation kill subprocesses safely

## Tests
- .venv/bin/python -m pytest backend/tests/unit/services/crm_guardian/test_cli_worker_helpers.py -q
- .venv/bin/ruff check ../../scripts/crm_guardian_gemini_cli_worker.py backend/services/crm_guardian/ocr.py backend/tests/unit/services/crm_guardian/test_cli_worker_helpers.py
- git diff --check