### PR TITLE
fix(crm-guardian): harden cli worker validation

### DIFF
--- a/apps/backend-rag/backend/services/crm_guardian/schemas.py
+++ b/apps/backend-rag/backend/services/crm_guardian/schemas.py
@@ -31,6 +31,7 @@ under prompts/.
 
 from __future__ import annotations
 
+import json
 from datetime import date
 from typing import Literal
 
@@ -223,6 +224,32 @@ class PropertyAsset(BaseModel):
     lease_expires_at: date | None = None
 
 
+def _stringify_key_field_value(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (bool, int, float)):
+        return str(value)
+    if isinstance(value, list):
+        scalar_values: list[str] = []
+        for item in value:
+            if item is None:
+                continue
+            if isinstance(item, (dict, list, tuple, set)):
+                return _json_dump_key_field(value)
+            text = str(item).strip()
+            if text:
+                scalar_values.append(text)
+        return ", ".join(scalar_values)
+    return _json_dump_key_field(value)
+
+
+def _json_dump_key_field(value: object) -> str:
+    try:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+    except TypeError:
+        return json.dumps(value, ensure_ascii=False, default=str)
+
+
 class DocumentRef(BaseModel):
     """Reference to a source file inside the client's canonical folder."""
 
@@ -237,6 +264,27 @@ class DocumentRef(BaseModel):
     expires_at: date | None = None
     subject_entity: str | None = None
     key_fields: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("key_fields", mode="before")
+    @classmethod
+    def _coerce_key_fields(cls, v: object) -> dict[str, str]:
+        # Gemini often emits source-field facts as numbers or string lists
+        # (amounts, KBLI codes). Preserve the fact but keep the downstream
+        # contract stable as dict[str, str].
+        if v is None:
+            return {}
+        if not isinstance(v, dict):
+            return {}
+
+        normalized: dict[str, str] = {}
+        for raw_key, raw_value in v.items():
+            if raw_key is None or raw_value is None:
+                continue
+            key = str(raw_key).strip()
+            if not key:
+                continue
+            normalized[key] = _stringify_key_field_value(raw_value)
+        return normalized
 
 
 class Timeline(BaseModel):

--- a/apps/backend-rag/backend/tests/unit/services/crm_guardian/test_cli_worker_helpers.py
+++ b/apps/backend-rag/backend/tests/unit/services/crm_guardian/test_cli_worker_helpers.py
@@ -647,10 +647,16 @@ class TestMainOperationalState:
         import backend.services.crm_guardian.base as guardian_base
 
         bump = AsyncMock()
+        drive_modes: list[bool] = []
+
+        def fake_build_drive_service(prefer_user_oauth: bool) -> object:
+            drive_modes.append(prefer_user_oauth)
+            return object()
+
         monkeypatch.setattr(worker, "_resolve_db_url", lambda: "postgresql://test/db")
         monkeypatch.setattr(asyncpg, "connect", AsyncMock(return_value=fake_conn))
         monkeypatch.setattr(guardian_base, "bump_circuit_breaker", bump)
-        monkeypatch.setattr(guardian_base, "build_drive_service", lambda prefer_user_oauth: object())
+        monkeypatch.setattr(guardian_base, "build_drive_service", fake_build_drive_service)
         monkeypatch.setattr(
             worker,
             "run_one_client",
@@ -670,6 +676,7 @@ class TestMainOperationalState:
         exit_code = await worker.main()
 
         assert exit_code == 0
+        assert drive_modes == [False]
         assert bump.await_args_list[0].args == (fake_conn, "I10b_summary_queue", True, None)
         assert bump.await_args_list[1].args == (fake_conn, "I10_summary_l1", True, None)
         fake_conn.close.assert_awaited_once()

--- a/apps/backend-rag/backend/tests/unit/services/crm_guardian/test_schemas_v2.py
+++ b/apps/backend-rag/backend/tests/unit/services/crm_guardian/test_schemas_v2.py
@@ -21,6 +21,7 @@ from pydantic import ValidationError
 from backend.services.crm_guardian.schemas import (
     SCHEMA_VERSION,
     Company,
+    DocumentRef,
     L1ClientSummary,
     LkpmRecord,
     TaxRecord,
@@ -115,6 +116,36 @@ class TestCompanyV2Extension:
         assert len(c.tax_records) == 1
         assert len(c.lkpm_history) == 1
         assert c.source_company_folders == ["folder_id_1", "folder_id_2"]
+
+
+class TestDocumentRef:
+    def test_key_fields_normalizes_scalar_and_list_values(self) -> None:
+        doc = DocumentRef(
+            file_id="drive_file",
+            file_name="permit.pdf",
+            doc_type="nib",
+            key_fields={
+                "realization_idr": 1_500_000_000,
+                "kbli_codes": ["68111", "55120"],
+                "active": True,
+            },
+        )
+
+        assert doc.key_fields == {
+            "realization_idr": "1500000000",
+            "kbli_codes": "68111, 55120",
+            "active": "True",
+        }
+
+    def test_key_fields_preserves_nested_values_as_json_string(self) -> None:
+        doc = DocumentRef(
+            file_id="drive_file",
+            file_name="akta.pdf",
+            doc_type="akta",
+            key_fields={"shareholders": [{"name": "A", "pct": 60}]},
+        )
+
+        assert doc.key_fields == {"shareholders": '[{"name": "A", "pct": 60}]'}
 
 
 class TestL1ClientSummaryV2:

--- a/scripts/crm_guardian_gemini_cli_worker.py
+++ b/scripts/crm_guardian_gemini_cli_worker.py
@@ -84,6 +84,14 @@ from backend.services.crm_guardian.schemas import (  # noqa: E402
 
 LOG = logging.getLogger("crm_guardian.cli_worker")
 
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 # Phase 1.5 prompt is the new default (Phase 1 v2 is metadata-only; v3 adds
 # OCR-content blocks + identity guardrails; v5 is the lean agy print-mode
 # contract). Legacy prompts stay on disk for rollback drills.
@@ -102,6 +110,7 @@ GEMINI_CLI = "/Users/nuzantara/.local/bin/agy"  # agy CLI v1.0.0 (Antigravity), 
 GEMINI_TIMEOUT_SECONDS = int(os.getenv("CRM_GUARDIAN_GEMINI_TIMEOUT_SECONDS", "900"))
 GEMINI_DEFAULT_MODEL: str | None = None  # agy uses CLI default model — does NOT support `-m` flag (prints help instead)
 STALE_RUNNING_SECONDS = int(os.getenv("CRM_GUARDIAN_STALE_RUNNING_SECONDS", "900"))
+DRIVE_PREFER_USER_OAUTH = _env_bool("CRM_GUARDIAN_DRIVE_PREFER_USER_OAUTH", False)
 
 # Phase 1.5 OCR budget per client. Fresh OCR is capped to the number of
 # snippets we can actually render, with timeboxes to keep huge Drive folders
@@ -1452,7 +1461,11 @@ async def main() -> int:
                 targets, args.dry_run, args.model or "default")
 
     try:
-        drive_service = build_drive_service(prefer_user_oauth=True)
+        LOG.info(
+            "Drive auth mode: %s",
+            "user_oauth" if DRIVE_PREFER_USER_OAUTH else "service_account",
+        )
+        drive_service = build_drive_service(prefer_user_oauth=DRIVE_PREFER_USER_OAUTH)
     except Exception as e:
         await bump_circuit_breaker(
             conn,


### PR DESCRIPTION
## Summary
- default the CRM Guardian CLI Drive client to service-account auth unless explicitly overridden
- normalize document key_fields scalar/list/nested values to the stable dict[str, str] contract
- add regression tests for key_fields coercion and Drive auth mode

## Tests
- apps/backend-rag/.venv/bin/python -m pytest apps/backend-rag/backend/tests/unit/services/crm_guardian/test_schemas_v2.py apps/backend-rag/backend/tests/unit/services/crm_guardian/test_cli_worker_helpers.py -q
- apps/backend-rag/.venv/bin/python -m ruff check scripts/crm_guardian_gemini_cli_worker.py apps/backend-rag/backend/services/crm_guardian/schemas.py apps/backend-rag/backend/tests/unit/services/crm_guardian/test_cli_worker_helpers.py apps/backend-rag/backend/tests/unit/services/crm_guardian/test_schemas_v2.py