### PR TITLE
feat(infra): memory-sync hub-and-spoke → Air-M5 + M5 study (atomic)

### DIFF
--- a/infra/sync-daemons/README.md
+++ b/infra/sync-daemons/README.md
@@ -1,0 +1,25 @@
+# sync-daemons (reference copies — audit trail)
+
+⚠️ **Queste sono COPIE REFERENCE, non l'origine eseguibile.**
+
+I daemon di sync memoria vivono in `~/scripts/mini-setup/` (HOME, non versionato) e sono
+invocati dai LaunchAgent (`com.nuzantara.memory-sync-bidirectional` ogni 5min). Questa dir
+nel repo esiste solo per **audit trail** — mitiga il rischio HOME-fork drift documentato
+nelle cicatrici W50/W51/W52 (due sistemi credono di avere world-state diverso, drift silenzioso).
+
+Se modifichi il daemon: la fonte di verità resta `~/scripts/mini-setup/`. Aggiorna QUI la
+copia reference dopo ogni modifica, per tenere l'audit trail allineato.
+
+## memory-sync-bidirectional.sh
+
+Hub-and-spoke (Opzione A, hub=Pro). UN daemon sul Pro sincronizza la memoria L1
+(`~/.claude/projects/<user>/memory/*.md`) verso 2 spoke:
+- **Mini-Pro2** (user nuzantara, `/Users/nuzantara/...`)
+- **Air-M5** (user balizero, `/Users/balizero/...`, ramo `sync_m5()` aggiunto 2026-06-01)
+
+Ogni ramo è 2-way Pro↔spoke, conflict-aware (md5+mtime, delta<60s = conflict → backup+skip),
+fail-soft (uno spoke giù non abortisce l'altro), lock unico Pro (`/tmp/memory-sync.lock`).
+
+Kill switch ramo M5: `M5_SYNC_ENABLED=false` nell'env.
+Dettaglio decisione: memory `decision_m5_air_fleet_join_2026_05_31.md`.
+Studio topologia: `research/operations/2026-05-31-m5-memory-integrity-topology-STUDY.md`.

--- a/infra/sync-daemons/memory-sync-bidirectional.sh
+++ b/infra/sync-daemons/memory-sync-bidirectional.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+# Bidirectional memory sync Pro <-> Mini <-> Air-M5 (hub-and-spoke, hub=Pro) with conflict detection
+# Cron: */5 * * * * /Users/nuzantara/scripts/mini-setup/memory-sync-bidirectional.sh >> ~/logs/memory-sync.log 2>&1
+# Hub-and-spoke (Opzione A, 2026-06-01): UN solo daemon sul Pro cicla Mini E M5.
+#   Mini e M5 NON si parlano direttamente — ogni ramo è 2-way Pro<->spoke, lock unico.
+# NB: 'set -e' RIMOSSO 2026-06-01 — con 2 spoke un fallimento di uno (es. M5 in sleep)
+#     NON deve abortire l'altro. Ogni ramo è fail-soft individualmente.
+
+LOG_FILE="$HOME/logs/memory-sync.log"
+MEM_PRO="$HOME/.claude/projects/-Users-nuzantara/memory"
+MEM_MINI_USER="nuzantara"
+MEM_MINI_PATH="/Users/nuzantara/.claude/projects/-Users-nuzantara/memory"
+LOCK_FILE="/tmp/memory-sync.lock"
+CONFLICT_DIR="$HOME/.claude/memory-conflicts"
+
+# --- Air-M5 spoke (added 2026-06-01) ---
+# M5 = user balizero, path memory diverso, SSH richiede IdentitiesOnly+IdentityAgent=none.
+M5_ENABLED="${M5_SYNC_ENABLED:-true}"   # kill switch: M5_SYNC_ENABLED=false
+M5_IP="192.168.0.20"
+M5_TS="100.87.146.107"                  # tailscale fallback
+M5_USER="balizero"
+MEM_M5_PATH="/Users/balizero/.claude/projects/-Users-balizero/memory"
+M5_SSH_OPTS="-o ConnectTimeout=5 -o IdentitiesOnly=yes -o IdentityAgent=none -o BatchMode=yes -i $HOME/.ssh/id_ed25519"
+
+mkdir -p "$(dirname $LOG_FILE)" "$CONFLICT_DIR"
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+# Lock to prevent concurrent runs
+if [ -f "$LOCK_FILE" ]; then
+  PID=$(cat "$LOCK_FILE")
+  if kill -0 "$PID" 2>/dev/null; then
+    log "Already running (PID $PID), skipping"
+    exit 0
+  fi
+fi
+echo $$ > "$LOCK_FILE"
+trap "rm -f $LOCK_FILE" EXIT
+
+log "=== Memory sync run (hub=Pro, spoke=Mini+M5) ==="
+
+# Check Mini reachable — try LAN first, fallback to Tailscale
+MINI_HOST="mini"
+MINI_OK=1
+if ! ssh -o ConnectTimeout=5 -o BatchMode=yes mini "echo OK" &>/dev/null; then
+  if ssh -o ConnectTimeout=5 -o BatchMode=yes mini-remote "echo OK" &>/dev/null; then
+    MINI_HOST="mini-remote"
+    log "Mini reachable via Tailscale (LAN unavailable)"
+  else
+    log "Mini unreachable (LAN+Tailscale), skip Mini branch (M5 branch still runs)"
+    MINI_OK=0
+  fi
+fi
+
+if [ "$MINI_OK" = "1" ]; then
+
+# Step 1: Get file lists with checksums on both sides
+log "Fetching Pro file checksums + mtime..."
+PRO_LIST=$(cd "$MEM_PRO" && find . -type f -name "*.md" -exec md5 -q {} \; -exec stat -f "%m" {} \; -print | paste - - - | sort)
+
+log "Fetching Mini file checksums + mtime..."
+MINI_LIST=$(ssh "$MINI_HOST" "cd $MEM_MINI_PATH 2>/dev/null && find . -type f -name '*.md' -exec md5 -q {} \\; -exec stat -f '%m' {} \\; -print | paste - - - | sort" 2>/dev/null || echo "")
+
+# Step 2: Find conflicts (md5 differ AND mtime delta < 60s = simultaneous edit)
+# If md5 differs but mtime delta >= 60s, mtime newer wins (rsync --update handles).
+log "Detecting conflicts (md5 differ + mtime delta <60s)..."
+CONFLICTS=$(comm -12 \
+  <(echo "$PRO_LIST" | awk '{print $3}') \
+  <(echo "$MINI_LIST" | awk '{print $3}') | while read f; do
+    PRO_HASH=$(echo "$PRO_LIST" | grep " $f$" | awk '{print $1}')
+    PRO_MTIME=$(echo "$PRO_LIST" | grep " $f$" | awk '{print $2}')
+    MINI_HASH=$(echo "$MINI_LIST" | grep " $f$" | awk '{print $1}')
+    MINI_MTIME=$(echo "$MINI_LIST" | grep " $f$" | awk '{print $2}')
+    if [ "$PRO_HASH" != "$MINI_HASH" ]; then
+      DELTA=$(( PRO_MTIME > MINI_MTIME ? PRO_MTIME - MINI_MTIME : MINI_MTIME - PRO_MTIME ))
+      if [ "$DELTA" -lt 60 ]; then
+        echo "$f"
+      fi
+    fi
+  done)
+
+if [ -n "$CONFLICTS" ]; then
+  log "⚠ Conflicts detected:"
+  echo "$CONFLICTS" | while read f; do
+    log "  CONFLICT: $f"
+    # Save both versions for manual review
+    BACKUP_NAME="$(basename $f)-conflict-$(date +%Y%m%d_%H%M%S)"
+    cp "$MEM_PRO/$f" "$CONFLICT_DIR/PRO-$BACKUP_NAME" 2>/dev/null
+    ssh "$MINI_HOST" "cat $MEM_MINI_PATH/$f" > "$CONFLICT_DIR/MINI-$BACKUP_NAME" 2>/dev/null
+    log "    Backup saved: $CONFLICT_DIR/{PRO,MINI}-$BACKUP_NAME"
+  done
+  log "⚠ Skipping conflicting files. Resolve manually then re-run."
+fi
+
+# Step 3: Sync NON-conflicting files
+# Strategy: newest mtime wins (rsync --update is approximate; we use timestamp)
+
+log "Pro → Mini (newer files only, skip conflicts)..."
+EXCLUDE_ARGS=""
+if [ -n "$CONFLICTS" ]; then
+  while read f; do
+    EXCLUDE_ARGS="$EXCLUDE_ARGS --exclude=$f"
+  done <<< "$CONFLICTS"
+fi
+rsync -avz --update $EXCLUDE_ARGS \
+  "$MEM_PRO/" "$MINI_HOST:$MEM_MINI_PATH/" 2>&1 | tail -5
+
+log "Mini → Pro (newer files only, skip conflicts)..."
+rsync -avz --update $EXCLUDE_ARGS \
+  "$MINI_HOST:$MEM_MINI_PATH/" "$MEM_PRO/" 2>&1 | tail -5
+
+# Step 4: Verify
+PRO_COUNT=$(ls "$MEM_PRO"/*.md 2>/dev/null | wc -l | tr -d ' ')
+MINI_COUNT=$(ssh "$MINI_HOST" "ls $MEM_MINI_PATH/*.md 2>/dev/null | wc -l")
+
+log "Mini branch done: Pro=$PRO_COUNT files, Mini=$MINI_COUNT files"
+fi  # end Mini branch (MINI_OK)
+
+# ─────────────────────────────────────────────────────────────
+# Air-M5 SPOKE — fail-soft, isolato dal ramo Mini (hub-and-spoke)
+# ─────────────────────────────────────────────────────────────
+sync_m5() {
+  [ "$M5_ENABLED" != "true" ] && { log "M5 spoke disabled (M5_SYNC_ENABLED=false)"; return 0; }
+
+  # reachability: LAN IP first, tailscale fallback
+  local M5H="$M5_IP"
+  if ! ssh $M5_SSH_OPTS "$M5_USER@$M5_IP" "echo OK" &>/dev/null; then
+    if ssh $M5_SSH_OPTS "$M5_USER@$M5_TS" "echo OK" &>/dev/null; then
+      M5H="$M5_TS"; log "M5 reachable via Tailscale (LAN unavailable)"
+    else
+      log "M5 unreachable (LAN+Tailscale), skip M5 branch"; return 0
+    fi
+  fi
+
+  log "M5 branch: Pro <-> Air-M5 ($M5H)"
+  local PRO_L M5_L M5_CONFLICTS
+  PRO_L=$(cd "$MEM_PRO" && find . -type f -name "*.md" -exec md5 -q {} \; -exec stat -f "%m" {} \; -print | paste - - - | sort)
+  M5_L=$(ssh $M5_SSH_OPTS "$M5_USER@$M5H" "cd $MEM_M5_PATH 2>/dev/null && find . -type f -name '*.md' -exec md5 -q {} \\; -exec stat -f '%m' {} \\; -print | paste - - - | sort" 2>/dev/null || echo "")
+
+  # conflict detection (md5 differ + mtime delta <60s)
+  M5_CONFLICTS=$(comm -12 \
+    <(echo "$PRO_L" | awk '{print $3}') \
+    <(echo "$M5_L" | awk '{print $3}') | while read f; do
+      local ph pm mh mm
+      ph=$(echo "$PRO_L" | grep " $f$" | awk '{print $1}'); pm=$(echo "$PRO_L" | grep " $f$" | awk '{print $2}')
+      mh=$(echo "$M5_L"  | grep " $f$" | awk '{print $1}'); mm=$(echo "$M5_L"  | grep " $f$" | awk '{print $2}')
+      if [ "$ph" != "$mh" ]; then
+        local d=$(( pm > mm ? pm - mm : mm - pm ))
+        [ "$d" -lt 60 ] && echo "$f"
+      fi
+    done)
+
+  local EXC=""
+  if [ -n "$M5_CONFLICTS" ]; then
+    log "⚠ M5 conflicts (saved for manual review):"
+    echo "$M5_CONFLICTS" | while read f; do
+      log "  CONFLICT: $f"
+      local bn="$(basename $f)-m5conflict-$(date +%Y%m%d_%H%M%S)"
+      cp "$MEM_PRO/$f" "$CONFLICT_DIR/PRO-$bn" 2>/dev/null
+      ssh $M5_SSH_OPTS "$M5_USER@$M5H" "cat $MEM_M5_PATH/$f" > "$CONFLICT_DIR/M5-$bn" 2>/dev/null
+    done
+    while read f; do EXC="$EXC --exclude=$f"; done <<< "$M5_CONFLICTS"
+  fi
+
+  log "Pro → M5 (newer only)..."
+  rsync -avz --update $EXC -e "ssh $M5_SSH_OPTS" "$MEM_PRO/" "$M5_USER@$M5H:$MEM_M5_PATH/" 2>&1 | tail -3
+  log "M5 → Pro (newer only)..."
+  rsync -avz --update $EXC -e "ssh $M5_SSH_OPTS" "$M5_USER@$M5H:$MEM_M5_PATH/" "$MEM_PRO/" 2>&1 | tail -3
+
+  local M5_COUNT
+  M5_COUNT=$(ssh $M5_SSH_OPTS "$M5_USER@$M5H" "ls $MEM_M5_PATH/*.md 2>/dev/null | wc -l")
+  log "M5 branch done: Pro=$(ls "$MEM_PRO"/*.md 2>/dev/null | wc -l | tr -d ' ') files, M5=$(echo $M5_COUNT | tr -d ' ') files"
+}
+
+sync_m5
+
+log "=== Done (hub-and-spoke) ==="

--- a/research/operations/2026-05-31-m5-memory-integrity-topology-STUDY.md
+++ b/research/operations/2026-05-31-m5-memory-integrity-topology-STUDY.md
@@ -1,0 +1,155 @@
+---
+date: 2026-05-31
+domain: operations
+client_case: false
+sources:
+  - "empirical: ls/stat/md5/readlink su ~/.claude/projects/{-Users-nuzantara,-Users-nuzantara-Desktop-nuzantara}/memory"
+  - "code: ~/scripts/mini-setup/memory-sync-bidirectional.sh"
+  - "code: ~/scripts/mini-setup/claude-config-sync.sh"
+  - "code: ~/scripts/nuz-sync/nuz-sync-check.sh"
+  - "memory: reference_pro_mini_sync_daemons.md"
+  - "memory: discovery_memory_sync_lan_tailscale_fallback.md"
+  - "~/.ssh/config (alias mini/pro, 'air' libero)"
+status: IMPLEMENTED 2026-06-01 — Opzione A hub-and-spoke attiva (ramo M5 nel daemon, dry-run verificato). Vedi memory decision_m5_air_fleet_join_2026_05_31 §HUB-DAEMON.
+---
+
+# M5 memory-integrity study — topologia a 3 nodi (Pro / Mini / Air-M5)
+
+> ⚠️ RUOLO CORRETTO 2026-06-01 (l'header originale qui sotto aveva il ruolo INVERTITO): Air-M5 = macchina PRINCIPALE di Antonello (dev+ricerca) ma LEGGERA, modello THIN-CLIENT (lavori su M5, esegui pesante su Pro/Mini via ssh). Pro = workhorse pesante. NON il contrario. La decisione autoritativa è in memory decision_m5_air_fleet_join_2026_05_31; questo studio resta valido per la topologia di sync (Opzione A), non per il ruolo.
+>
+> [storico, ruolo invertito] Decisione Antonello 2026-05-31: ruolo M5 = posto di sviluppo interactive di Antonello + automazioni PESANTI (Pro sgravato dal dev; Mini = automazioni leggere + lunghe/costanti). Macchina "solo dev, niente policy office-block". memory.db = fresco per-macchina. Sync continuo: STUDIARE PRIMA, zero daemon ora.
+
+## 0. Cosa intendiamo per "integrità di Claude"
+
+Non è UN file. Sono **4 layer distinti**, con criticità e meccaniche di sync diverse:
+
+| Layer                    | Cosa                                                              | Path                                          | Size   | Sync oggi (Pro↔Mini)                                   | Criticità identità                               |
+| ------------------------ | ----------------------------------------------------------------- | --------------------------------------------- | ------ | ------------------------------------------------------ | ------------------------------------------------ |
+| **L1 Memory MD**         | 378 `.md` — MEMORY\*.md, decisioni, lessons, cicatrici, reference | `~/.claude/projects/-Users-nuzantara/memory/` | 4.2 MB | ✅ bidirezionale 5min, conflict-aware, **NO --delete** | **MASSIMA — è il "chi sei"**                     |
+| **L2 memory.db (MOS)**   | SQLite FTS5: `mem query`, storia sessioni, entità, importance     | `~/.claude/memory.db` (+`-shm`/`-wal`)        | 39 MB  | ❌ ESCLUSO by design (stato per-sessione)              | Media — storia FTS, NON ricostruibile 1:1 dai MD |
+| **L3 Config/skill/hook** | `skills/`, `scripts/`, `hooks/`, `CLAUDE.md`                      | `~/.claude/`                                  | —      | ✅ bidirezionale 1h, lista esclusioni lunga            | Alta — _come_ pensi/agisci                       |
+| **L4 OAuth MAX**         | token Claude in macOS Keychain                                    | Keychain `Claude Code-credentials`            | —      | ❌ Keychain non sincronizzabile                        | Accesso, non identità — `/login` lo rigenera     |
+
+**Empirical 2026-05-31**: il path `-Users-nuzantara-Desktop-nuzantara/memory` (quello che il SessionStart hook carica) è un **symlink** → `-Users-nuzantara/memory` (il target del sync). md5 MEMORY.md identico, 378 file su entrambi. ⟹ il sync esistente opera GIÀ sulla memoria viva. Nessuna divergenza dei due path. (Trappola evitata: se l'M5 sincronizzasse solo `-Desktop-nuzantara` senza ricreare il symlink, erediterebbe una dir vuota o stale.)
+
+## 1. Il problema vero: bootstrap ≠ sync continuo
+
+Sono **due problemi separati**, spesso confusi:
+
+- **Bootstrap (one-shot)**: come l'M5 nasce con la memoria-identità completa, da zero. Avviene UNA volta.
+- **Sync continuo (steady-state)**: come la memoria resta coerente tra 3 nodi mentre Antonello lavora su Pro o M5. Avviene per sempre.
+
+Il rischio per l'integrità sta quasi tutto nel **bootstrap fatto male** + nel **conflict-model a 3 nodi** (oggi scritto per 2).
+
+## 2. Trappola strutturale: il conflict-model è 2-node, l'M5 lo rende 3-node
+
+`memory-sync-bidirectional.sh` oggi:
+
+- confronta md5+mtime tra Pro e Mini
+- md5 differ + Δmtime ≥60s → **newer wins** (rsync --update)
+- md5 differ + Δmtime <60s → **conflict** → backup entrambe in `~/.claude/memory-conflicts/` + skip
+- **NESSUN `--delete`**: un file cancellato su un nodo RIVIVE dall'altro al next sync (zombie-resurrection). Già noto in `reference_pro_mini_sync_daemons.md`.
+
+Con 3 nodi questo modello si ROMPE in 3 modi:
+
+1. **Finestra di collisione triplicata**: oggi il daemon è installato SOLO sul Pro e fa Pro↔Mini. Se aggiungo lo stesso daemon sull'M5 che fa M5↔Pro (o M5↔Mini), due daemon scrivono sugli stessi file. Il lock (`/tmp/memory-sync.lock`) è **per-macchina, non distribuito** → Pro e M5 possono fare rsync sullo stesso target Pro contemporaneamente.
+
+2. **Conflict-detection cieca al terzo nodo**: lo script confronta solo 2 liste (PRO_LIST, MINI_LIST). Un edit su M5 + un edit su Mini dello stesso file non vengono mai confrontati direttamente — passano per il Pro in due cicli separati, e il "newer wins" può silenziosamente scartare l'edit di Mini se Pro fa prima il sync con M5.
+
+3. **Zombie cross-node amplificato**: senza `--delete`, un file cancellato su M5 rivive da Pro, poi da Mini. La cancellazione diventa quasi impossibile da propagare.
+
+## 3. Tre topologie candidate
+
+### Opzione A — HUB-AND-SPOKE (Pro = hub, M5 e Mini = spoke) ⭐ RACCOMANDATA
+
+```
+        Pro (HUB / source-of-truth memoria)
+       /   \
+   Mini     Air-M5
+```
+
+- UN SOLO daemon di sync vive sul **Pro**, che fa Pro↔Mini E Pro↔M5 (sequenziale, sotto lo stesso lock).
+- M5 e Mini **non** parlano direttamente: ogni modifica transita per il Pro.
+- Conflict-detection resta 2-way per ramo (Pro↔M5, Pro↔Mini), che è esattamente ciò per cui lo script è scritto.
+- Lock unico sul Pro → niente rsync concorrenti sullo stesso target.
+- **Pro = source of truth** anche se non è più la macchina di dev: è la macchina H24-ish più stabile e già hub di tutto il resto (CRM tokens, secrets-source).
+- **Costo**: M5↔Mini ha latenza 2× (deve passare per Pro, due cicli da 5min = max 10min). Irrilevante per file MD.
+- **Pro DEVE essere acceso** perché il sync funzioni. Se Pro è spento, M5 e Mini divergono finché Pro non torna. Accettabile: Pro è il nodo più stabile.
+
+### Opzione B — MESH (ogni nodo parla con ogni nodo)
+
+```
+   Pro ─── Mini
+     \     /
+     Air-M5
+```
+
+- 3 daemon, 3 rami (Pro↔Mini, Pro↔M5, Mini↔M5).
+- Massima resilienza (qualsiasi nodo down, gli altri 2 restano coerenti).
+- **MA**: richiede riscrivere conflict-resolution per N-way (3 liste, vector-clock o last-writer-wins con tie-break deterministico). Lock distribuito necessario. Zombie-resurrection da risolvere con tombstone. **Alto rischio integrità durante la transizione** — è il modo per romperti, non preservarti.
+- Scartata salvo necessità reale di resilienza Pro-down.
+
+### Opzione C — M5 PULL-ONLY bootstrap + git come spina dorsale
+
+```
+   Pro/Mini ──(memoria via git branch dedicato)──> Air-M5
+```
+
+- La memoria-identità (L1) viene versionata in un branch git dedicato (`memory/snapshot`) e l'M5 fa `git pull`. Push esplicito quando Antonello vuole propagare.
+- Pro: massima auditabilità (ogni cambio memoria = commit), zero conflict silenziosi (git li forza espliciti), gira anche con nodi spenti (async).
+- Contro: meno ergonomico (push manuale), e la memoria contiene path/contenuti che oggi NON sono nel repo git (sono in `~/.claude/`, fuori da `~/Desktop/nuzantara`). Servirebbe un repo git separato per la memoria.
+- Interessante come **canale di bootstrap** anche se lo steady-state resta A.
+
+## 4. memory.db (L2) — decisione presa: fresco per-macchina
+
+Antonello 2026-05-31: **DB fresco per-macchina** (come Pro e Mini già fanno).
+
+- M5 parte con memory.db vuoto, cresce con le SUE sessioni.
+- `mem query` sull'M5 troverà i fatti **ri-indicizzando i 378 .md** (che SONO sincronizzati), non la storia-sessioni del Pro.
+- **Azione bootstrap necessaria**: verificare che esista un re-index dei .md → memory.db all'avvio M5 (il `mem` CLI deve poter popolare FTS dai .md). Da confermare empiricamente sull'M5 reale.
+- Zero rischio corruzione SQLite cross-machine (mai copiato a freddo, mai in rsync concorrente). ✅ scelta giusta.
+
+## 5. Piano bootstrap M5 (quando la macchina sarà accesa e nominata)
+
+Ordine, ognuno verificabile:
+
+1. **Rinomina** host → `Air-M5` (`scutil --set HostName/LocalHostName/ComputerName Air-M5`), user `nuzantara`.
+2. **Tailnet**: join tailnet balizero. Aggiungere a `~/.ssh/config` su tutti i nodi: `Host air` → HostName `<tailscale-ip-M5>`. Verificare `ssh air "echo OK"` da Pro e `ssh pro`/`ssh mini` da M5.
+3. **L4 OAuth**: `/login` interactive sull'M5 (slot MAX disponibili: antonellosiano + kaiser). Keychain locale.
+4. **L1 bootstrap one-shot**: `rsync -avz pro:~/.claude/projects/-Users-nuzantara/memory/ ~/.claude/projects/-Users-nuzantara/memory/` + **ricreare il symlink** `-Users-nuzantara-Desktop-nuzantara/memory -> ../-Users-nuzantara/memory` (CRITICO — senza, SessionStart carica dir sbagliata).
+5. **L3 bootstrap one-shot**: rsync di `skills/`, `scripts/`, `hooks/`, `CLAUDE.md` con la stessa lista-esclusioni di claude-config-sync.
+6. **L2**: lasciare memory.db assente; primo `mem` lo crea + re-index dai .md. Verificare `mem recent` ritorna i fatti.
+7. **SessionStart hook**: verificare che il machine-check riconosca `Air-M5` (oggi nuz-sync-check.sh ha un case `Nuzantara`/`mini-pro2` → aggiungere `Air-M5|air*) NODE="Air" REPO=...`).
+8. **Steady-state (Opzione A)**: installare sul **Pro** l'estensione hub-and-spoke del daemon memory-sync che cicla anche su `air`. NON installare daemon di sync sull'M5. Aggiornare lock per essere ramo-aware.
+
+## 6. Checklist integrità (da spuntare a bootstrap finito)
+
+- [ ] `md5 MEMORY.md` su M5 == Pro (identità trasferita 1:1)
+- [ ] file count `.md` su M5 == 378 (o il valore Pro al momento del bootstrap)
+- [ ] symlink `-Desktop-nuzantara/memory` presente e risolve a `-Users-nuzantara/memory`
+- [ ] `mem recent` su M5 ritorna fatti (re-index OK)
+- [ ] SessionStart hook su M5 logga `Machine: nuzantara@Air-M5` (non un fallback)
+- [ ] `ssh air`/`ssh pro`/`ssh mini` reciproci OK (mesh SSH per il sync)
+- [ ] daemon hub Pro logga un ramo `air` riuscito in `~/logs/memory-sync.log`
+- [ ] NESSUN daemon di sync attivo sull'M5 (`launchctl list | grep -i sync` → vuoto sul lato M5, per evitare doppio-writer)
+- [ ] conflict dir `~/.claude/memory-conflicts/` vuota dopo 1h di steady-state
+
+## 7. Rischi residui e mitigazioni
+
+| Rischio                                            | Mitigazione                                                                                                                                 |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Doppio-writer (daemon su Pro+M5 sullo stesso file) | Opzione A: daemon SOLO su Pro. Lock unico.                                                                                                  |
+| Edit M5+Mini stesso file <60s                      | Hub-and-spoke serializza via Pro → il secondo ramo vede già l'edit del primo. Resta finestra <5min ma 2-way per ramo.                       |
+| Zombie-resurrection (no --delete)                  | Invariato dal sistema attuale. Tombstone = enhancement futuro, non blocca M5. Documentare: cancellazioni memoria = manuali su tutti i nodi. |
+| Pro spento → M5/Mini divergono                     | Accettato. Pro è il nodo più stabile. Reconvergono al ritorno di Pro (newer-wins).                                                          |
+| memory.db copiato a freddo                         | EVITATO — scelta "fresco per-macchina".                                                                                                     |
+| symlink dimenticato a bootstrap                    | Step 4 esplicito + checklist §6. È la trappola n.1.                                                                                         |
+
+## 8. Cosa NON faccio finché non approvi
+
+- Nessun `scutil --set` (macchina non ancora accesa/in mano).
+- Nessun daemon installato (né Pro né M5).
+- Nessun patch a CLAUDE.md / memory (registro solo la decisione di studio).
+- Nessun rsync verso M5 (non esiste ancora in tailnet).
+
+**Prossimo gate**: Antonello sceglie topologia (A/B/C) → solo allora preparo gli script di bootstrap + l'estensione hub del daemon, su branch feature, con i 4-LLM panel se tocca codice di sync (è shared-state → preflight L2).


### PR DESCRIPTION
## Cosa
Branch atomico (2 commit) che isola SOLO lo stream Air-M5 dal precedente #995 multi-stream.

- `infra/sync-daemons/memory-sync-bidirectional.sh` + `README.md` — reference copy del daemon esteso col ramo `sync_m5()` (fail-soft, path-aware /Users/balizero, conflict-aware md5+mtime, LAN 192.168.0.20 + tailscale 100.87.146.107 fallback). Kill switch `M5_SYNC_ENABLED=false`. Sorgente eseguibile in ~/scripts/mini-setup (HOME, non versionato); questa è copia audit-trail anti HOME-fork drift (W50/51/52). Verificato IDENTICAL alla sorgente.
- `research/operations/2026-05-31-m5-memory-integrity-topology-STUDY.md` — fix header ruolo thin-client LIGHT (era invertito) + status IMPLEMENTED.

## Verifica live
Daemon hub-and-spoke girato 2026-06-01 09:03: Pro/Mini/M5 = 383/383/383 .md allineati. LaunchAgent exit 0.

## Sostituisce #995
#995 mescolava 5 stream (M5 + NextDNS impl + 6 commit audit duplicati su #987/#989/#992 + 4 rider) → conflitto cicatrix sweep-vs-sweep. Questo branch parte da origin/main fresco: zero conflitti, atomico. #995 va chiusa.

L2 Autonomous Ops. Additivo, kill-switch presente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)