### PR TITLE
docs(agents): tell Codex where Claude's MOS memory lives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -609,3 +609,20 @@ tools = [{"name": "kbli_search", "eager_input_streaming": True, ...}]
 | Routing / classificazione | `claude-haiku-4-5-20251001` | $1/$5 MTok, velocissimo                      |
 | Task critici              | `claude-opus-4-6`           | 128K output, effort=max                      |
 | Spiegazioni KBLI          | `claude-haiku-4-5-20251001` | Già configurato in kbli_notebook.py          |
+
+---
+
+## 16. Memory (MOS) — dove leggere la conoscenza di progetto
+
+La memoria di progetto (decisioni, scoperte, fatti, lessons) vive come file Markdown qui:
+
+- **Pro**: `~/.claude/projects/-Users-nuzantara-Desktop-nuzantara/memory/*.md` (388+ file)
+- **Air-M5**: `~/.claude/projects/-Users-balizero-Desktop-nuzantara/memory/*.md` (sincronizzati dal Pro via hub-daemon)
+- **Indice**: `MEMORY.md` nella stessa dir — leggi questo PRIMA per orientarti (1 riga per memory).
+
+Per interrogarla:
+
+- Comando `mem query "<termine>"` (FTS5 sul DB `memory.db`). Su **Pro** funziona diretto. Su **Air-M5** `mem` usa SSH-al-Pro per il DB ricco, con fallback grep sui `.md` locali se il Pro è irraggiungibile.
+- In alternativa (sempre disponibile, zero dipendenze): leggi i `.md` direttamente col path sopra, o `grep -rl "<termine>" <memory-dir>/*.md`.
+
+Codex NON carica la memory in automatico (a differenza di Claude che ha i SessionStart hook): leggi `MEMORY.md` + i `.md` rilevanti col path quando ti serve contesto storico del progetto.


### PR DESCRIPTION
## What

Adds a concise `## 16. Memory (MOS)` reference section to `AGENTS.md` (the instruction file Codex reads), pointing to where Claude's project memory lives.

## Why

Codex had no pointer to Claude's Memory Operating System. The project memory — 388 `.md` files of decisions, discoveries, facts, and lessons — lives under `~/.claude/projects/-Users-<user>-Desktop-nuzantara/memory/`, but `AGENTS.md` never said so. Unlike Claude (which auto-loads memory via SessionStart hooks), Codex loads nothing automatically, so it was effectively blind to the project's historical context.

Now `AGENTS.md` (read by Codex on both Pro and M5) gives it:
- the **path** (Pro `-Users-nuzantara-...`, Air-M5 `-Users-balizero-...`, hub-synced)
- the **`MEMORY.md` index** to read first
- the **`mem query`** command (FTS5 on `memory.db`, SSH-to-Pro fallback on M5)
- a **`grep` fallback** (zero-dependency, always works)

## Scope

Single-file, additive (17 lines appended as a reference section). No existing content changed. Path verified empirically: `ls ~/.claude/projects/` -> project-id `-Users-nuzantara-Desktop-nuzantara`, 388 `.md` files, `MEMORY.md` present.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)