### PR TITLE
feat(infra): version worktree-isolation hooks + make them path-aware (Pro+M5)

### DIFF
--- a/infra/claude-hooks/README.md
+++ b/infra/claude-hooks/README.md
@@ -1,0 +1,56 @@
+# claude-hooks (reference copies — audit trail)
+
+⚠️ **Queste sono COPIE REFERENCE, non l'origine eseguibile.**
+
+I PreToolUse hook worktree-isolation vivono in `~/.claude/hooks/` (HOME, non
+versionato) e sono invocati dal harness Claude Code prima di ogni `Bash`/`Write`.
+Questa dir nel repo esiste solo per **audit trail** + **diff Pro-vs-M5** — mitiga il
+rischio HOME-fork drift documentato nelle cicatrici W50/W51/W52 (due macchine
+credono di avere world-state diverso, drift silenzioso).
+
+Se modifichi un hook: la fonte di verità resta `~/.claude/hooks/`. Aggiorna QUI la
+copia reference dopo ogni modifica (e su entrambe le macchine Pro+M5), per tenere
+l'audit trail allineato. Verifica drift con:
+
+```bash
+shasum -a 256 ~/.claude/hooks/worktree_isolation.py infra/claude-hooks/worktree_isolation.py
+```
+
+## worktree_isolation.py — PreToolUse(Bash)
+
+Blocca git op mutanti (`checkout|switch|stash|reset|merge|rebase|pull`,
+`commit -a/-am/--all`, `add -A/-a/--all/.`) quando il target effettivo è il main
+checkout. Permette: read-only (`status|log|diff`), `git -C <worktree> ...`,
+`commit -m` (no -a), `push`, op fuori dal repo.
+
+## worktree_file_write_check.py — PreToolUse(Edit|Write|MultiEdit)
+
+Blocca scritture file sotto il main checkout ma fuori da ogni worktree registrato
+(copre il pattern Write-orphan che la sola enforcement Bash non intercetta).
+
+## Path-aware (2026-06-01)
+
+Entrambi derivano `REPO_ROOT` a runtime (non più hardcoded `/Users/nuzantara/...`),
+così girano identici su Pro (`/Users/nuzantara/Desktop/nuzantara`) e Air-M5
+(`/Users/balizero/Desktop/nuzantara`). Ordine di derivazione in `_derive_repo_root()`:
+
+1. env `NUZ_REPO_ROOT` (override esplicito)
+2. parent di `git rev-parse --git-common-dir`, **solo se** il root ha la firma
+   `scripts/agent_start.py` (guard contro cwd dentro un altro repo, es. `~/.claude`)
+3. fallback `~/Desktop/nuzantara`
+
+## Kill switch
+
+`AGENT_WORKTREE_ENFORCEMENT=false` (env var) disarma entrambi gli hook.
+Su Pro al 2026-06-01 è `false` in `~/.claude/settings.json` (single-operator
+interactive). Su M5 è armato (`true`) per il caso multi-agente "8 finestre × N
+agenti che committano". Decisione: memory `session_2026_06_01_m5_worktree_hooks_fix.md`.
+
+## Test regressione regex
+
+```bash
+python3 infra/claude-hooks/test_block_regex.py
+```
+
+Valida i 20 casi block/allow del `BLOCKED_SUBCMD_RE` (incl. il guard contro falsi
+positivi tipo `git commit -m "add a feature"`). Eseguilo dopo ogni modifica alla regex.

--- a/infra/claude-hooks/test_block_regex.py
+++ b/infra/claude-hooks/test_block_regex.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Regression test for worktree_isolation BLOCKED_SUBCMD_RE.
+
+Imports the regex from the reference copy in this dir and asserts the
+block/allow contract. Run after any edit to the regex:
+
+    python3 infra/claude-hooks/test_block_regex.py
+
+Exit 0 = all pass, exit 1 = at least one mismatch.
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+
+
+def _load_regex():
+    spec = importlib.util.spec_from_file_location(
+        "wi", str(HERE / "worktree_isolation.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.BLOCKED_SUBCMD_RE
+
+
+CASES = {
+    # must BLOCK
+    "git commit -a": True,
+    'git commit -am "x"': True,
+    'git commit -a -m "x"': True,
+    'git commit --all -m "x"': True,
+    "git add .": True,
+    "git add -A": True,
+    "git add --all": True,
+    "git checkout main": True,
+    "git stash": True,
+    "git reset --hard": True,
+    # must ALLOW
+    'git commit -m "x"': False,
+    'git commit -m "add a feature"': False,
+    'git commit -m "amend the docs"': False,
+    "git commit --amend": False,
+    "git add path/to/file.py": False,
+    "git add src/main.py README.md": False,
+    "git status": False,
+    "git log --oneline": False,
+    "git diff HEAD": False,
+    "git push origin feature": False,
+}
+
+
+def main() -> int:
+    rx = _load_regex()
+    fails = 0
+    for cmd, expect in CASES.items():
+        got = bool(rx.search(cmd))
+        if got != expect:
+            fails += 1
+            print(f"  [FAIL] block={got!s:5} expect={expect!s:5}  {cmd}")
+    if fails:
+        print(f"\n=== {fails} FAIL ===")
+        return 1
+    print(f"=== ALL {len(CASES)} PASS ===")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infra/claude-hooks/worktree_file_write_check.py
+++ b/infra/claude-hooks/worktree_file_write_check.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""PreToolUse hook (Edit|Write|MultiEdit) — block file writes to main checkout.
+
+L5.1 SOTA wave 2026-05-25 — Codex unique amendment (P0).
+
+Closes the critical gap: L5.1 worktree_isolation.py covers ONLY Bash git ops.
+But the empirical motivation cited in L5.1 §1 (`kg_bridge.py` orphan in main)
+was created via Write tool, not git command. Bash-only enforcement is
+incomplete against the very pattern it claims to prevent.
+
+This hook blocks Edit/Write/MultiEdit file_path that resolves under
+REPO_ROOT but NOT under any allowed worktree.
+
+Escape: AGENT_WORKTREE_ENFORCEMENT=false (env var, NOT inline cmd prefix).
+
+Exit code 2 + stderr = block tool call.
+Exit code 0 + no stderr = allow.
+
+Reference: research/operations/specs/L5.1-panel-synthesis-2026-05-25.md §"CRITICAL NEW FINDING".
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+import subprocess as _sp
+
+
+def _is_nuzantara_root(root: str) -> bool:
+    """Repo signature: only the nuzantara checkout carries scripts/agent_start.py."""
+    return os.path.isfile(os.path.join(root, "scripts", "agent_start.py"))
+
+
+def _derive_repo_root() -> str:
+    """Machine-agnostic main-checkout root (Pro /Users/nuzantara, M5 /Users/balizero).
+
+    git-common-dir derivation is correct ONLY when cwd is inside the nuzantara
+    repo. When the session cwd sits in a DIFFERENT git repo (e.g. ~/.claude),
+    it would silently resolve there and disarm the brake. The signature guard
+    rejects any derived root that lacks scripts/agent_start.py.
+    """
+    home_default = f"{os.path.expanduser('~')}/Desktop/nuzantara"
+    # 1) honor explicit override
+    _env = os.environ.get("NUZ_REPO_ROOT")
+    if _env:
+        return _env.rstrip("/")
+    # 2) main checkout = parent of git common dir (only if it is the nuzantara repo)
+    try:
+        cd = _sp.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            cwd=os.getcwd(), capture_output=True, text=True, timeout=3,
+        )
+        if cd.returncode == 0 and cd.stdout.strip():
+            common = cd.stdout.strip()
+            root = common[:-5] if common.endswith("/.git") else os.path.dirname(common)
+            if _is_nuzantara_root(root):
+                return root
+    except Exception:
+        pass
+    # 3) fallback to home-based guess (works on both machines)
+    return home_default
+
+
+REPO_ROOT = _derive_repo_root()
+BLOCK_COUNT_FILE = "/tmp/nuz_l5_1_blocks"
+PROBE_LOG = pathlib.Path.home() / ".claude" / "l5_1_hook_probe.jsonl"
+
+
+def _kill_switch_active() -> bool:
+    val = os.environ.get("AGENT_WORKTREE_ENFORCEMENT", "true").strip().lower()
+    return val in {"false", "0", "no", "off", "disabled"}
+
+
+def _git_worktree_list() -> list[pathlib.Path]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", REPO_ROOT, "worktree", "list", "--porcelain"],
+            capture_output=True, text=True, timeout=2,
+        )
+        if result.returncode != 0:
+            return []
+        return [
+            pathlib.Path(line.removeprefix("worktree ").strip()).resolve()
+            for line in result.stdout.splitlines() if line.startswith("worktree ")
+        ]
+    except Exception:
+        return []
+
+
+def _is_path_under_allowed_worktree(path_real: pathlib.Path) -> bool:
+    """True if path is under an allowed worktree (NOT under main checkout root directly)."""
+    repo_real = pathlib.Path(REPO_ROOT).resolve()
+
+    worktrees = _git_worktree_list()
+    allowed_worktrees = [w for w in worktrees if w != repo_real]
+
+    _base = re.escape(os.path.dirname(REPO_ROOT))
+    external_patterns = [
+        re.compile(r"^" + _base + r"/nuzantara-deploy$"),
+        re.compile(r"^" + _base + r"/nuzantara-wa-dashboard-[a-z0-9-]+$"),
+        re.compile(r"^" + _base + r"/nuzantara-[a-z0-9-]+-2026-\d{2}-\d{2}$"),
+    ]
+
+    # Check external worktree convention by walking parents
+    for parent in [path_real, *path_real.parents]:
+        for pattern in external_patterns:
+            if pattern.match(str(parent)):
+                return True
+
+    # Check discovered worktrees
+    for allowed_wt in allowed_worktrees:
+        try:
+            if path_real == allowed_wt or path_real.is_relative_to(allowed_wt):
+                return True
+        except AttributeError:
+            try:
+                path_real.relative_to(allowed_wt)
+                return True
+            except ValueError:
+                pass
+
+    return False
+
+
+def _probe_log(payload: dict, file_path: str, decision: str):
+    try:
+        PROBE_LOG.parent.mkdir(parents=True, exist_ok=True)
+        with PROBE_LOG.open("a") as f:
+            json.dump({
+                "tool_name": payload.get("tool_name", ""),
+                "file_path": file_path[:200],
+                "decision": decision,
+                "pid": os.getpid(),
+                "ppid": os.getppid(),
+            }, f)
+            f.write("\n")
+    except Exception:
+        pass
+
+
+def _increment_block_counter():
+    try:
+        bc = pathlib.Path(BLOCK_COUNT_FILE)
+        n = int(bc.read_text().strip()) if bc.exists() else 0
+        bc.write_text(str(n + 1))
+    except Exception:
+        pass
+
+
+def main():
+    if _kill_switch_active():
+        sys.exit(0)
+
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+
+    tool_name = payload.get("tool_name", "")
+    if tool_name not in {"Edit", "Write", "MultiEdit"}:
+        sys.exit(0)
+
+    file_path = payload.get("tool_input", {}).get("file_path", "")
+    if not file_path:
+        sys.exit(0)
+
+    try:
+        fp_real = pathlib.Path(file_path).resolve()
+    except Exception:
+        sys.exit(0)
+
+    repo_real = pathlib.Path(REPO_ROOT).resolve()
+
+    # Quick exit: file outside repo entirely (e.g. ~/.claude/, /tmp/, etc) → allow
+    try:
+        is_under_repo = fp_real.is_relative_to(repo_real)
+    except AttributeError:
+        try:
+            fp_real.relative_to(repo_real)
+            is_under_repo = True
+        except ValueError:
+            is_under_repo = False
+
+    if not is_under_repo:
+        _probe_log(payload, file_path, "allow_outside_repo")
+        sys.exit(0)
+
+    # File is under REPO_ROOT. Is it under an allowed worktree?
+    if _is_path_under_allowed_worktree(fp_real):
+        _probe_log(payload, file_path, "allow_worktree")
+        sys.exit(0)
+
+    # File is under main checkout (REPO_ROOT but not in worktree). BLOCK.
+    _increment_block_counter()
+    _probe_log(payload, file_path, "block")
+
+    sys.stderr.write(
+        f"WORKTREE ISOLATION VIOLATION (file write to main)\n"
+        f"  tool: {tool_name}\n"
+        f"  file_path: {file_path}\n"
+        f"  resolved: {fp_real}\n\n"
+        f"Reason: writing to main checkout would race with other AI agents.\n"
+        f"This is the exact pattern that produced 32+ sibling-orphan stash in 24h.\n\n"
+        f"Resolution:\n"
+        f"  1. Create dedicated worktree:\n"
+        f"     python scripts/agent_start.py --lane <lane> --task-id <task-id>\n"
+        f"  2. Rewrite file_path to use worktree absolute path:\n"
+        f"     {REPO_ROOT}/.worktrees/<lane>-<task-id>/<rest>\n\n"
+        f"Emergency escape: AGENT_WORKTREE_ENFORCEMENT=false\n\n"
+        f"See: docs/runbooks/agent-worktree-broker.md\n"
+    )
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/claude-hooks/worktree_isolation.py
+++ b/infra/claude-hooks/worktree_isolation.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""PreToolUse hook (Bash) — block dangerous git ops in main checkout.
+
+L5.1 SOTA wave 2026-05-25. Closes Gap G1 (adoption enforcement) from
+research/operations/2026-05-25-sota-workflow-gap-analysis-and-l5-spec.md.
+
+Post-4-LLM-panel amendments (research/operations/specs/L5.1-panel-synthesis-2026-05-25.md):
+- A1: Path canonicalization via os.path.realpath() + Path.is_relative_to()
+- A3: Parse `git -C <path>` and `cd <path> && git` for effective target
+- A4: Removed transcript marker bypass (env-only escape)
+- A5: Probe-mode logging for empirical sub-agent inheritance test
+- A6: Cached alive-agent count (zero subprocess on hot path)
+
+Blocked patterns (only when effective git target is REPO_ROOT):
+- git checkout / switch (branch op)
+- git stash (sibling-orphan creator)
+- git reset --hard
+- git merge / rebase / pull
+- git commit -a / git add -A / git add .
+
+Allow:
+- git status/log/diff/show/branch -l/worktree list (read-only)
+- git -C <worktree> ... where <worktree> resolves under allowed
+- git add <specific-file>
+- git commit -m "..." (no -a)
+- git push <branch>
+
+Escape: AGENT_WORKTREE_ENFORCEMENT=false (env var set in session, NOT inline cmd prefix).
+
+Exit code 2 + stderr = block tool call.
+Exit code 0 + no stderr = allow.
+
+Reference cicatrix: 2026-04-29 #1+#2, W50/W51/W52, 32+ sibling-orphan-2026-05-25.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+import subprocess as _sp
+
+
+def _is_nuzantara_root(root: str) -> bool:
+    """Repo signature: only the nuzantara checkout carries scripts/agent_start.py."""
+    return os.path.isfile(os.path.join(root, "scripts", "agent_start.py"))
+
+
+def _derive_repo_root() -> str:
+    """Machine-agnostic main-checkout root (Pro /Users/nuzantara, M5 /Users/balizero).
+
+    git-common-dir derivation is correct ONLY when cwd is inside the nuzantara
+    repo. When the session cwd sits in a DIFFERENT git repo (e.g. ~/.claude),
+    it would silently resolve there and disarm the brake. The signature guard
+    rejects any derived root that lacks scripts/agent_start.py.
+    """
+    home_default = f"{os.path.expanduser('~')}/Desktop/nuzantara"
+    # 1) honor explicit override
+    _env = os.environ.get("NUZ_REPO_ROOT")
+    if _env:
+        return _env.rstrip("/")
+    # 2) main checkout = parent of git common dir (only if it is the nuzantara repo)
+    try:
+        cd = _sp.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            cwd=os.getcwd(), capture_output=True, text=True, timeout=3,
+        )
+        if cd.returncode == 0 and cd.stdout.strip():
+            common = cd.stdout.strip()
+            root = common[:-5] if common.endswith("/.git") else os.path.dirname(common)
+            if _is_nuzantara_root(root):
+                return root
+    except Exception:
+        pass
+    # 3) fallback to home-based guess (works on both machines)
+    return home_default
+
+
+REPO_ROOT = _derive_repo_root()
+
+# Blocked git subcommands.
+BLOCKED_SUBCMD_RE = re.compile(
+    r"\bgit\s+(?:-c\s+\S+\s+)*"  # optional -c key=val flags
+    r"(?:-C\s+\S+\s+)?"  # optional -C path
+    r"(checkout|switch|stash|reset|merge|rebase|pull)\b"
+    r"|\bgit\s+commit\s+(?:[^\s]+\s+)*(?:-[A-Za-z]*a|--all\b)"  # commit -a / -am / -a -m / --all
+    r"|\bgit\s+add\s+(?:-A|-a|--all|\.)"  # add -A / add -a / add --all / add .
+)
+
+# Extract `git -C <path>` target.
+GIT_C_RE = re.compile(r"\bgit\s+(?:-c\s+\S+\s+)*-C\s+(\S+)")
+
+# Extract `cd <path> && git ...` target.
+CD_GIT_RE = re.compile(r"\bcd\s+(\S+)\s*(?:&&|;)\s*git\b")
+
+ALIVE_COUNT_CACHE = "/tmp/nuz_alive_count"
+BLOCK_COUNT_FILE = "/tmp/nuz_l5_1_blocks"
+PROBE_LOG = pathlib.Path.home() / ".claude" / "l5_1_hook_probe.jsonl"
+
+
+def _kill_switch_active() -> bool:
+    val = os.environ.get("AGENT_WORKTREE_ENFORCEMENT", "true").strip().lower()
+    return val in {"false", "0", "no", "off", "disabled"}
+
+
+def _git_worktree_list() -> list[pathlib.Path]:
+    """Parse `git worktree list --porcelain` for current worktree paths.
+
+    Best-effort: empty list on error (defaults to only main).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", REPO_ROOT, "worktree", "list", "--porcelain"],
+            capture_output=True, text=True, timeout=2,
+        )
+        if result.returncode != 0:
+            return []
+        worktrees = []
+        for line in result.stdout.splitlines():
+            if line.startswith("worktree "):
+                p = line.removeprefix("worktree ").strip()
+                try:
+                    worktrees.append(pathlib.Path(p).resolve())
+                except Exception:
+                    pass
+        return worktrees
+    except Exception:
+        return []
+
+
+def _is_path_in_allowed_worktree(path_str: str) -> bool:
+    """True if path resolves under an allowed worktree (NOT main checkout)."""
+    if not path_str:
+        return False
+    try:
+        path_real = pathlib.Path(path_str).resolve()
+    except Exception:
+        return False
+
+    repo_real = pathlib.Path(REPO_ROOT).resolve()
+
+    # Exactly main checkout → NOT allowed
+    if path_real == repo_real:
+        return False
+
+    # Get all worktrees from git
+    worktrees = _git_worktree_list()
+    # Filter out main checkout itself
+    allowed = [w for w in worktrees if w != repo_real]
+
+    # Also accept external worktree convention paths
+    _base = re.escape(os.path.dirname(REPO_ROOT))
+    external_patterns = [
+        re.compile(r"^" + _base + r"/nuzantara-deploy$"),
+        re.compile(r"^" + _base + r"/nuzantara-wa-dashboard-[a-z0-9-]+$"),
+        re.compile(r"^" + _base + r"/nuzantara-[a-z0-9-]+-2026-\d{2}-\d{2}$"),
+    ]
+
+    path_str_real = str(path_real)
+    for pattern in external_patterns:
+        # Check if path_real OR any parent matches
+        for parent in [path_real, *path_real.parents]:
+            if pattern.match(str(parent)):
+                return True
+
+    # is_relative_to check against discovered worktrees
+    for allowed_wt in allowed:
+        try:
+            if path_real == allowed_wt or path_real.is_relative_to(allowed_wt):
+                return True
+        except AttributeError:
+            # Python <3.9 fallback
+            try:
+                path_real.relative_to(allowed_wt)
+                return True
+            except ValueError:
+                pass
+
+    return False
+
+
+def _effective_git_target(cmd: str, default_cwd: str) -> str:
+    """Determine the effective working dir for git command.
+
+    Priority: `git -C <path>` > `cd <path> && git` > default cwd.
+    """
+    m = GIT_C_RE.search(cmd)
+    if m:
+        return m.group(1)
+    m = CD_GIT_RE.search(cmd)
+    if m:
+        return m.group(1)
+    return default_cwd
+
+
+def _n_alive_cached() -> int:
+    try:
+        return int(pathlib.Path(ALIVE_COUNT_CACHE).read_text().strip())
+    except Exception:
+        return -1
+
+
+def _increment_block_counter():
+    try:
+        bc = pathlib.Path(BLOCK_COUNT_FILE)
+        n = int(bc.read_text().strip()) if bc.exists() else 0
+        bc.write_text(str(n + 1))
+    except Exception:
+        pass
+
+
+def _probe_log(payload: dict, decision: str):
+    """A5: probe-mode logging for empirical sub-agent inheritance test."""
+    try:
+        PROBE_LOG.parent.mkdir(parents=True, exist_ok=True)
+        with PROBE_LOG.open("a") as f:
+            json.dump({
+                "tool_name": payload.get("tool_name", ""),
+                "cwd": payload.get("cwd", ""),
+                "cmd": payload.get("tool_input", {}).get("command", "")[:200],
+                "decision": decision,
+                "pid": os.getpid(),
+                "ppid": os.getppid(),
+            }, f)
+            f.write("\n")
+    except Exception:
+        pass
+
+
+def main():
+    if _kill_switch_active():
+        sys.exit(0)
+
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+
+    if payload.get("tool_name") != "Bash":
+        sys.exit(0)
+
+    cmd = payload.get("tool_input", {}).get("command", "")
+    cwd = payload.get("cwd", "")
+
+    # Quick exit: cmd doesn't look git-mutating
+    if "git" not in cmd:
+        sys.exit(0)
+
+    if not BLOCKED_SUBCMD_RE.search(cmd):
+        sys.exit(0)
+
+    # Compute effective target
+    target = _effective_git_target(cmd, cwd)
+
+    # If effective target is in an allowed worktree → permit
+    if _is_path_in_allowed_worktree(target):
+        _probe_log(payload, "allow_worktree")
+        sys.exit(0)
+
+    # If target is NOT REPO_ROOT and we can't classify → permit (defense conservative)
+    target_real = pathlib.Path(target).resolve() if target else pathlib.Path(REPO_ROOT)
+    repo_real = pathlib.Path(REPO_ROOT).resolve()
+    if target_real != repo_real:
+        _probe_log(payload, "allow_external")
+        sys.exit(0)
+
+    # Block.
+    _increment_block_counter()
+    _probe_log(payload, "block")
+
+    n_alive = _n_alive_cached()
+    n_alive_str = f"{n_alive}" if n_alive >= 0 else "?"
+
+    sys.stderr.write(
+        f"WORKTREE ISOLATION VIOLATION (Bash git op in main)\n"
+        f"  cwd: {cwd}\n"
+        f"  effective target: {target_real}\n"
+        f"  command: {cmd[:200]}\n"
+        f"  alive AI processes: {n_alive_str}\n\n"
+        f"Reason: this git op in main checkout would race with other agents.\n\n"
+        f"Resolution:\n"
+        f"  1. Create dedicated worktree:\n"
+        f"     python scripts/agent_start.py --lane <lane> --task-id <task-id>\n"
+        f"     cd <output-path>\n"
+        f"  2. Then retry the git op there (use 'git -C <path> ...' since Bash resets cwd).\n\n"
+        f"Emergency escape: AGENT_WORKTREE_ENFORCEMENT=false (env var set in shell)\n\n"
+        f"See: docs/runbooks/agent-worktree-broker.md\n"
+    )
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Cosa

I 2 PreToolUse hook worktree-isolation (`worktree_isolation.py`, `worktree_file_write_check.py`) vivevano solo in `~/.claude/hooks/` con `REPO_ROOT` hardcoded a `/Users/nuzantara/Desktop/nuzantara`. Due problemi:

1. **Rotti su Air-M5** (`/Users/balizero/...`) — il path hardcoded paralizzava Claude su M5, freno di fatto disarmato.
2. **Non versionati** → HOME-fork drift risk (cicatrix W50/W51/W52).
3. **2 buchi regex preesistenti** (anche sul Pro): `git commit -am` / `--all` e `git add .` / `--all` sfuggivano al blocco.

## Fix (applicato a `~/.claude/hooks/` su Pro E M5 — ora sha256-identici)

- `_derive_repo_root()`: `NUZ_REPO_ROOT` override → parent di `git rev-parse --git-common-dir` (con **signature-guard** `scripts/agent_start.py`, così una sessione con cwd dentro un altro repo tipo `~/.claude` non disarma silenziosamente il freno) → fallback `~/Desktop/nuzantara`.
- Regex external-worktree generalizzate via `os.path.dirname(REPO_ROOT)`.
- `BLOCKED_SUBCMD_RE` chiude i 2 buchi; `commit -m "..."` (anche con "a"/"amend" nel messaggio) e `commit --amend` restano permessi.

## Questa dir = reference copy

`infra/claude-hooks/` è **audit trail + diff Pro-vs-M5**, NON l'origine eseguibile (resta `~/.claude/hooks/`). Stesso pattern di `infra/sync-daemons/`. README documenta il workflow di sync/verify. `test_block_regex.py` valida i 20 casi block/allow contro la copia reference.

## Verificato

- 9/9 scenari E2E: BLOCK su main (`commit -am`, `add .`, `checkout`, Write) / ALLOW in worktree registrato (via `-C` e file_path) / read-only passa / `commit -m` passa / Write fuori repo passa.
- 20/20 regex regression, su **entrambe** Pro e M5.
- `REPO_ROOT` deriva corretto da ogni cwd testato (repo nuzantara, `~/.claude`, `/tmp`) + override.

## Nota operativa

Kill switch `AGENT_WORKTREE_ENFORCEMENT=false`. Su Pro è attualmente `false` in `settings.json` (single-operator interactive) → i freni riparati sono **dormienti** sul Pro finché Antonello decide il riarmo. Su M5 sono **armati** (`true`) per il caso multi-agente "8 finestre × N agenti che committano".

🤖 Generated with [Claude Code](https://claude.com/claude-code)