### PR TITLE
chore(security): gitignore WhatsApp Baileys session-credential dumps (Law 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -311,6 +311,13 @@ research/**/*-guidance.pdf
 # (force-added there by plist_snapshot_dr.sh); ignored on every working branch.
 infra/launchagents/_snapshot-live/
 
+# WhatsApp/Baileys session credentials + sync-key dumps (OSINT secrets, Symbiosis Law 2).
+# A git stash captured 3041 such files (session-quarantine); this blocks any re-leak.
+apps/wa-mirror/historical/
+**/session-quarantine-*/
+**/baileys_auth*/
+**/creds.json
+
 # ========================================
 # SECURITY FIXES (2026-01-11)
 # ========================================


### PR DESCRIPTION
## Cosa
Aggiunge copertura `.gitignore` per i dump di credenziali WhatsApp/Baileys (session-quarantine), che NON erano protetti.

## Perché ora
Durante la pulizia stash è emerso che uno stash (`voa-pr-rebase-pre-main`, 2026-05-27) ha catturato **3041 file** sotto `apps/wa-mirror/historical/session-quarantine-*/` = credenziali sessione + sync-key Baileys. Sono **secret OSINT** (Symbiosis Law 2: i dati non lasciano il Pro). Il path NON era coperto da alcun pattern (solo `scripts/data/*_creds.json` esisteva) → se quello stash venisse estratto/applicato finirebbero su git.

Complemento del fix #920 (leak wa-corpus, blocco subito sopra nel `.gitignore`).

## Pattern aggiunti
```
apps/wa-mirror/historical/
**/session-quarantine-*/
**/baileys_auth*/
**/creds.json
```

## Verificato
- Tutti i path target ora `git check-ignore`'d (5/5).
- Zero `creds.json` attualmente tracciati → nessun untrack accidentale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)