### PR TITLE
feat(broker): enforce agent worktree TTL — auto-cleanup + orphan detection + CI gate (W62)

### DIFF
--- a/.github/workflows/broker-hygiene.yml
+++ b/.github/workflows/broker-hygiene.yml
@@ -1,0 +1,60 @@
+name: Agent worktree broker hygiene
+
+# W62 ANTIBODY #3 — gate the agent worktree broker at PR time.
+#
+# Two things run here, both pure-stdlib (no backend deps):
+#   1. The broker's own unit tests (scripts/tests/test_agent_start.py) — these
+#      were previously orphaned from CI (NO workflow collected them).
+#   2. tests/integration/test_no_stale_worktrees.py — fails the PR if the
+#      checked-out .worktrees/ contains a worktree older than 24h, AND covers
+#      the find_stale_worktrees detector logic.
+#
+# The live-checkout guard is safe to be strict: CI runs on a fresh
+# actions/checkout with no live agent session, so there are no false positives.
+#
+# References:
+#   - cicatrix-scars.md "W62 — Agent worktree broker TTL=60min violated 34×"
+#   - docs/runbooks/agent-worktree-broker.md
+
+on:
+  pull_request:
+    paths:
+      - "scripts/agent_start.py"
+      - "scripts/agent_worktree_cleanup_cron.sh"
+      - "scripts/tests/test_agent_start.py"
+      - "tests/integration/test_no_stale_worktrees.py"
+      - "infra/launchagents/com.nuzantara.agent-worktree-cleanup.daily.plist.example"
+      - "infra/launchagents/install_agent_worktree_cleanup.sh"
+      - "docs/runbooks/agent-worktree-broker.md"
+      - ".worktrees/**"
+      - ".github/workflows/broker-hygiene.yml"
+  push:
+    branches: [main]
+    paths:
+      - "scripts/agent_start.py"
+      - "scripts/agent_worktree_cleanup_cron.sh"
+      - ".worktrees/**"
+
+concurrency:
+  group: broker-hygiene-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  broker-hygiene:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install pytest
+        run: pip install --quiet pytest
+
+      - name: Broker unit tests
+        run: python -m pytest scripts/tests/test_agent_start.py -q
+
+      - name: No stale worktrees (24h orphan guard)
+        run: python -m pytest tests/integration/test_no_stale_worktrees.py -q

--- a/docs/runbooks/agent-worktree-broker.md
+++ b/docs/runbooks/agent-worktree-broker.md
@@ -41,11 +41,48 @@ WIP=yes significa file uncommitted (tracked o untracked) presenti.
 
 ```bash
 python scripts/agent_start.py --cleanup
+# skip <id> (recent activity <10min) — live session, will reap when idle
 # WARN: skip <id> (WIP). Commit or stash inside <path>, then re-run --cleanup.
 # removed expired worktree <id> (<path>)
 ```
 
-WIP-safe: skippa worktree dirty con WARN. Forza con `--force`.
+Due guard proteggono un worktree expired dal drop:
+
+- **WIP-safe** — worktree con modifiche non committate → skip con WARN, exit 1 (operator deve committare/stashare). Forza con `--force`.
+- **skip-recent** (W62) — worktree con attività filesystem negli ultimi 10min = sessione viva → skip silenzioso, exit 0 (al prossimo tick, quando idle, verrà preso). Soglia configurabile con `--skip-recent-min N` (0 disabilita). `--force` bypassa anche questo.
+
+### Auto-cleanup (cron) — W62 ANTIBODY #1
+
+`--cleanup` NON è più solo manuale. Il LaunchAgent `com.nuzantara.agent-worktree-cleanup.daily` lo invoca ogni giorno alle 08:15 WITA via `scripts/agent_worktree_cleanup_cron.sh`.
+
+```bash
+# install (Pro):
+bash infra/launchagents/install_agent_worktree_cleanup.sh
+# verify:
+launchctl print gui/$(id -u)/com.nuzantara.agent-worktree-cleanup.daily | grep -E 'state|runs'
+# log:
+tail -f ~/logs/agent-worktree-cleanup.log
+# uninstall:
+bash infra/launchagents/install_agent_worktree_cleanup.sh --uninstall
+```
+
+GOTCHA: il cron usa SEMPRE il main checkout (`~/Desktop/nuzantara/scripts/agent_start.py`). Il broker risolve `WORKTREES_DIR` da `parents[1]` dello script — invocarlo da un worktree scansiona `.worktrees/<wt>/.worktrees/` (inesistente) → no-op silenzioso.
+
+### Orphan detection — W62 ANTIBODY #2
+
+`--list` flagga `ORPHAN` ogni worktree più vecchio di 2× il suo TTL e stampa un sommario WARN finale:
+
+```bash
+python scripts/agent_start.py --list
+# ... ORPHAN ...
+# WARN: 2 orphan worktree(s) detected (age > 2× TTL) — review then run --cleanup or --release.
+```
+
+Un orphan non viene rimosso da `--list` (read-only): è un segnale. Usa `--cleanup` (se idle+clean) o `--release <id>`.
+
+### CI hygiene gate — W62 ANTIBODY #3
+
+`tests/integration/test_no_stale_worktrees.py` fallisce in CI (workflow `broker-hygiene.yml`) se il checkout contiene un worktree più vecchio di 24h (cap assoluto, indipendente dal TTL per-task). Lo stesso workflow gira anche `scripts/tests/test_agent_start.py` (prima orfano da CI). Se rompe una PR: `--list` per ispezionare, poi `--cleanup`/`--release`.
 
 ### Tear down esplicito a fine task
 
@@ -111,5 +148,20 @@ OGNI sessione agent dispatch (subagent dispatch, cron-spawned `claude`, parallel
 2. `cd` nel path stampato da `WORKTREE_READY`
 3. Lavorare lì. Mai `git stash` / `git checkout` nel main checkout.
 4. Quando finito: commit + push + `--release <task-id>` (oppure lascia che `--cleanup` lo prenda al prossimo cron tick).
+
+## Broker-aware spawn convention (W62 ANTIBODY #4)
+
+Il TTL da solo non basta: nessun consumer lo applicava. La hygiene è ora a 3 livelli, in ordine di affidabilità decrescente:
+
+1. **Release esplicito (preferito)** — l'orchestratore/agent chiama `--release <task-id>` a fine task. Tear-down immediato, branch cancellato se merged. È l'unico path che pulisce _subito_.
+2. **Cron reaper (rete di sicurezza)** — `com.nuzantara.agent-worktree-cleanup.daily` reape i worktree idle+clean+expired senza intervento. Copre il caso "l'agent è morto senza release". Non tocca WIP né sessioni vive (skip-recent).
+3. **CI gate (backstop finale)** — `broker-hygiene.yml` impedisce che un orphan >24h si fossilizzi: la PR fallisce finché il `.worktrees/` non è pulito.
+
+Regole per chi dispatcha worktree (orchestratore o script):
+
+- Un worktree è **effimero**: o lo rilasci tu, o lo reapa il cron. Mai trattarlo come storage persistente.
+- Se hai WIP da preservare oltre la sessione: **committa su un branch dedicato e pusha** PRIMA di lasciare il worktree. Né il cron né `--cleanup` rimuovono WIP, ma un worktree con WIP eterno è debito che blocca il CI gate.
+- I subagent spawnati via Agent tool girano sotto `.claude/worktrees/agent-<id>/` (path diverso, auto-pulito dall'harness). Questo broker governa SOLO il path user-facing `.worktrees/` usato da spawn manuali o scriptati.
+- Convenzione TTL: usa `--ttl-min` realistico per la durata attesa. Il cron reaper rispetta il TTL per-task; il CI gate impone comunque il cap assoluto di 24h.
 
 Il main checkout `~/Desktop/nuzantara` è riservato all'operator interactive + cicatrix hotfix.

--- a/infra/launchagents/com.nuzantara.agent-worktree-cleanup.daily.plist.example
+++ b/infra/launchagents/com.nuzantara.agent-worktree-cleanup.daily.plist.example
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Agent worktree broker reaper — daily 08:15 WITA (W62 ANTIBODY #1).
+Runbook: docs/runbooks/agent-worktree-broker.md §Auto-cleanup
+
+Invokes scripts/agent_start.py --cleanup (WIP-safe + skip-recent safe) so
+abandoned worktrees no longer accumulate into a storm. Scheduled 15min after
+the WR2 worktree-gc (00:00 UTC) to avoid two GC passes racing on .worktrees/.
+
+Install (Pro):
+    cp infra/launchagents/com.nuzantara.agent-worktree-cleanup.daily.plist.example \
+       ~/Library/LaunchAgents/com.nuzantara.agent-worktree-cleanup.daily.plist
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.nuzantara.agent-worktree-cleanup.daily.plist
+  (or: bash infra/launchagents/install_agent_worktree_cleanup.sh)
+
+Kill switch (without removing plist):
+    launchctl setenv AGENT_BROKER_ENABLED false
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.nuzantara.agent-worktree-cleanup.daily</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/nuzantara/Desktop/nuzantara/scripts/agent_worktree_cleanup_cron.sh</string>
+    </array>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>0</integer>
+        <key>Minute</key>
+        <integer>15</integer>
+    </dict>
+    <!-- 00:15 UTC = 08:15 WITA (15min after WR2 worktree-gc at 00:00) -->
+
+    <key>WorkingDirectory</key>
+    <string>/Users/nuzantara/Desktop/nuzantara</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>AGENT_BROKER_ENABLED</key>
+        <string>true</string>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/agent-worktree-cleanup.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/agent-worktree-cleanup.error.log</string>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>KeepAlive</key>
+    <false/>
+</dict>
+</plist>

--- a/infra/launchagents/install_agent_worktree_cleanup.sh
+++ b/infra/launchagents/install_agent_worktree_cleanup.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# install_agent_worktree_cleanup.sh — W62 ANTIBODY #1
+#
+# Install (or reload) the daily LaunchAgent that reaps abandoned agent
+# worktrees via scripts/agent_start.py --cleanup (WIP-safe + skip-recent safe).
+#
+# Usage:
+#   bash infra/launchagents/install_agent_worktree_cleanup.sh
+#   bash infra/launchagents/install_agent_worktree_cleanup.sh --uninstall
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLIST_SRC_DIR="$REPO_ROOT/infra/launchagents"
+PLIST_DEST_DIR="$HOME/Library/LaunchAgents"
+LOG_DIR="$HOME/logs"
+UID_VAL="$(id -u)"
+
+LABEL="com.nuzantara.agent-worktree-cleanup.daily"
+SRC="$PLIST_SRC_DIR/$LABEL.plist.example"
+DEST="$PLIST_DEST_DIR/$LABEL.plist"
+
+MODE="${1:-install}"
+
+mkdir -p "$PLIST_DEST_DIR" "$LOG_DIR"
+
+bootout() {
+    if launchctl print "gui/$UID_VAL/$LABEL" >/dev/null 2>&1; then
+        echo "[install] booting out $LABEL"
+        launchctl bootout "gui/$UID_VAL/$LABEL" 2>&1 | grep -v "Boot-out failed" || true
+    fi
+}
+
+case "$MODE" in
+    install)
+        if [[ ! -f "$SRC" ]]; then
+            echo "[install] FATAL: source plist missing: $SRC" >&2
+            exit 1
+        fi
+        if [[ -f "$DEST" ]]; then
+            bak="$DEST.pre-install-$(date +%Y%m%d-%H%M%S)"
+            chmod u+w "$DEST" 2>/dev/null || true
+            cp "$DEST" "$bak"
+            echo "[install] backed up existing → $bak"
+        fi
+        bootout
+        # Copy + mode 0444 per VADEMECUM hardening (no secrets in this plist).
+        cp "$SRC" "$DEST"
+        chmod 0444 "$DEST"
+        if ! plutil -lint "$DEST" >/dev/null 2>&1; then
+            echo "[install] FATAL: $DEST plutil lint failed"
+            plutil -lint "$DEST"
+            exit 1
+        fi
+        echo "[install] bootstrapping $LABEL"
+        launchctl bootstrap "gui/$UID_VAL" "$DEST"
+        echo "[install] done. Verify: launchctl print gui/$UID_VAL/$LABEL | grep -E 'state|runs'"
+        ;;
+    --uninstall)
+        bootout
+        if [[ -f "$DEST" ]]; then
+            chmod u+w "$DEST" 2>/dev/null || true
+            rm -f "$DEST"
+            echo "[install] removed $DEST"
+        fi
+        ;;
+    *)
+        echo "Usage: $0 [install|--uninstall]" >&2
+        exit 2
+        ;;
+esac

--- a/research/operations/S4-broker-FROZEN.json
+++ b/research/operations/S4-broker-FROZEN.json
@@ -1,0 +1,145 @@
+{
+  "session": "S4-worktree-broker-enforcement",
+  "date": "2026-06-02",
+  "orchestrator": "claude-opus-4-8",
+  "lane": "infra",
+  "task_id": "s4-broker",
+  "branch": "agent/nuzantara/infra/s4-broker",
+  "base_head": "e66ccd018",
+  "cicatrix": "W62 — Agent worktree broker TTL=60min violated 34× (no auto-cleanup)",
+  "mission": "Make the worktree-per-session broker (scripts/agent_start.py) self-enforcing: TTL was advisory (--cleanup opt-in, no cron, subagents never --release). Result was a worktree storm + sibling-race surface growth + risk of WIP loss.",
+
+  "wip_rescue": {
+    "passo_1_critical": "Inspected all 11 stale worktrees BEFORE any cleanup.",
+    "verdict": {
+      "real_wip_found": 1,
+      "details": [
+        {
+          "worktree": "codex-autofix-ci-runtime",
+          "wip": "scripts/root_guard.py +2 lines (army-prompts whitelist), staged",
+          "fate": "Sibling codex-autofix CI runtime committed it on its own mid-session (commit eecbd1c1f, observed live via reflog HEAD@{0}). Preserved on dedicated rescue branch.",
+          "rescue_branch": "rescue/s4-root-guard-army-prompts-wip",
+          "pushed_to_origin": true,
+          "origin_sha": "eecbd1c1ff75707253fa7d438af7c6b429ec4716"
+        }
+      ],
+      "subsumed_fossils": [
+        {
+          "worktree": "infra-wa-army-launcher",
+          "untracked": [
+            "scripts/wa_army_launcher.sh (6555B)",
+            "scripts/wa_army_watcher.sh",
+            "army-prompts/ (3 SPEC files)"
+          ],
+          "verdict": "SAFE — superseded by feature branch commit 531680763 (launcher hardened 6555B→7783B with OAuth token + headless -p; watcher byte-identical; army-prompts 3 SPEC→21 final). No WIP lost."
+        }
+      ],
+      "metadata_only_safe": [
+        "audit-quote-redteam-2026-05-31",
+        "backend-rag-crm-guardian-observability-hardening",
+        "backend-rag-openclaw-kbli-whatsapp-guard",
+        "codex-coverage-improver-runtime (detached HEAD, clean)",
+        "infra-claude-hooks-pathaware",
+        "infra-gitignore-wa-session-quarantine",
+        "infra-venv-rebuild-script",
+        "ops-autonomous-lab-scaffold"
+      ]
+    },
+    "loss": "ZERO — no git stash without -u was ever run; the one real WIP is committed + pushed.",
+    "note": "Cleanup of the stale worktrees themselves was NOT performed by this session (out of scope: this PR ships the enforcement mechanism; the daily cron will reap them once installed)."
+  },
+
+  "antibodies_shipped": {
+    "1_launchagent_cleanup_daily": {
+      "what": "Daily reaper invoking scripts/agent_start.py --cleanup (WIP-safe + skip-recent safe).",
+      "files": [
+        "infra/launchagents/com.nuzantara.agent-worktree-cleanup.daily.plist.example",
+        "scripts/agent_worktree_cleanup_cron.sh",
+        "infra/launchagents/install_agent_worktree_cleanup.sh"
+      ],
+      "schedule": "00:15 UTC (08:15 WITA), 15min after WR2 worktree-gc to avoid GC race",
+      "skip_recent_guard": "New: cmd_cleanup skips a TTL-expired-but-clean worktree touched <10min ago (live session). Signal = max(mtime) over worktree dir + .git. Silent skip (exit 0), NOT a WIP failure. Configurable --skip-recent-min N (0 disables). --force bypasses.",
+      "gotcha": "Cron hardcodes the MAIN checkout path; broker resolves WORKTREES_DIR from parents[1] so running from a worktree would scan .worktrees/<wt>/.worktrees/ (nonexistent) and no-op."
+    },
+    "2_orphan_detection_list": {
+      "what": "--list flags ORPHAN for any worktree older than 2× its TTL + prints WARN summary footer.",
+      "file": "scripts/agent_start.py (cmd_list, _is_orphan)",
+      "signal": "created_at (broker canonical age axis, NOT filesystem mtime). Malformed timestamps (age<0) excluded from orphan classification.",
+      "live_smoke": "Verified on real .worktrees/: 6 ORPHAN flagged correctly, fresh s4-broker (11.9min/180 TTL) NOT flagged."
+    },
+    "3_ci_stale_worktree_test": {
+      "what": "tests/integration/test_no_stale_worktrees.py fails CI if any worktree >24h old. Plus broker-hygiene.yml workflow that also runs the previously-CI-orphaned scripts/tests/test_agent_start.py.",
+      "files": [
+        "tests/integration/test_no_stale_worktrees.py",
+        ".github/workflows/broker-hygiene.yml"
+      ],
+      "signal": "created_at primary (24h absolute cap, independent of per-task TTL) + dir-mtime fallback for metadata-less dirs (catches non-broker orphans).",
+      "shared_impl": "find_stale_worktrees() added to agent_start.py so the live guard and --cleanup reason about the same detector (no drift).",
+      "gap_closed": "AUDIT FINDING: no CI workflow previously collected the top-level tests/ tree or scripts/tests/ — the broker's own unit tests never gated any PR. broker-hygiene.yml fixes this."
+    },
+    "4_broker_aware_spawn_convention": {
+      "what": "Documented 3-tier hygiene: explicit --release (preferred) → cron reaper (safety net) → CI gate (final backstop).",
+      "file": "docs/runbooks/agent-worktree-broker.md (+54 lines: auto-cleanup, orphan detection, CI gate, spawn convention)"
+    }
+  },
+
+  "latent_bug_fixed": {
+    "what": ".env.worktree (broker-generated by W59 PR #899, 2026-05-27) was NOT in the WIP ignore-list, so EVERY freshly created worktree read as dirty → cleanup could never reap a clean worktree, and two pre-existing tests were already failing on HEAD.",
+    "fix": "BROKER_GENERATED_FILES frozenset = {.agent-task.json, .env.worktree}; _worktree_has_wip ignores both.",
+    "impact": "Restores the WIP-safe cleanup path to actually function for clean worktrees. This was a silent contributor to the W62 storm (clean worktrees were never auto-eligible)."
+  },
+
+  "tests": {
+    "total": 35,
+    "passing": 35,
+    "files": [
+      "scripts/tests/test_agent_start.py (29)",
+      "tests/integration/test_no_stale_worktrees.py (6)"
+    ],
+    "new_tests": [
+      "test_cleanup_skips_recently_active_expired_clean_worktree",
+      "test_cleanup_removes_expired_clean_idle_worktree",
+      "test_cleanup_skip_recent_disabled_with_zero",
+      "test_list_warns_on_orphan_worktree",
+      "test_list_no_orphan_when_within_2x_ttl",
+      "test_detector_flags_worktree_older_than_24h",
+      "test_detector_ignores_fresh_worktree",
+      "test_detector_uses_created_at_not_dir_mtime",
+      "test_detector_falls_back_to_dir_mtime_without_metadata",
+      "test_detector_empty_when_no_worktrees_dir",
+      "test_no_stale_worktrees_in_checkout"
+    ],
+    "tdd": "RED-first verified (4 new broker tests failed before implementation), GREEN after.",
+    "verification": {
+      "bash_n": "cron wrapper + install script: OK",
+      "plutil_lint": "plist: OK",
+      "python_parse": "agent_start.py: OK"
+    }
+  },
+
+  "method": {
+    "worktree_isolation": "agent_start.py --lane infra --task-id s4-broker (this session ran in its own isolated worktree)",
+    "fan_out_audit": "2 parallel general-purpose audit agents (ANTIBODY #1 launchagent convention; ANTIBODY #2+#3 list/CI signal choice)",
+    "adversarial": "Codex GPT-5.5 read-only spalla on the staged diff (race/fail-open/cron-mask/CI-bypass/.env.worktree-shadow)"
+  },
+
+  "adversarial_fixes_applied": {
+    "summary": "Codex found 0 P1, 3 P2, 3 P3. 5 fixed, 1 accepted-as-residual.",
+    "P2_wip_before_recent": "FIXED — cmd_cleanup now checks WIP BEFORE recent-activity, so a recent+dirty worktree exits 1 with WARN instead of being silently swallowed as a live session. Test: test_cleanup_recent_AND_dirty_reports_wip_not_silent_skip.",
+    "P2_liveness_gitdir": "FIXED (partial) — liveness probe now also stats the real linked-worktree gitdir HEAD (not just the .git pointer). index deliberately excluded (git status rewrites its mtime → false-active). Lock/lease left as future work; accepted heuristic + 24h CI cap as hard ceiling.",
+    "P2_env_worktree_shadow": "ACCEPTED RESIDUAL (low) — .env.worktree is broker-generated and only ever untracked; an agent overwriting it with secret WIP is an edge case. Documented in code comment; the 24h CI cap still catches a worktree that never gets released.",
+    "P3_ci_strict_missing_metadata": "FIXED — find_stale_worktrees(strict_missing_metadata=True) used by the CI guard reports any metadata-less worktree as unmanaged (no lax dir-mtime escape). Test: test_detector_strict_flags_fresh_metadata_less_dir.",
+    "P3_heartbeat_mask_rc": "FIXED — every organism_heartbeat call in the cron wrapper guarded with || true so it cannot mask the broker RC under set -e.",
+    "P3_workflow_path_filter": "FIXED — broker-hygiene.yml paths now include the cron wrapper, plist, install script, and runbook."
+  },
+
+  "needs_operator": [
+    "Install the cron: bash infra/launchagents/install_agent_worktree_cleanup.sh (ships as .plist.example, NOT auto-bootstrapped).",
+    "Optionally reap the 6 existing ORPHAN worktrees now (--cleanup will skip the WIP ones; --release for the rest).",
+    "Branch protection: broker-hygiene.yml must be added as a required check if PR-time enforcement is desired."
+  ],
+
+  "files_changed": 8,
+  "insertions": 713,
+  "deletions": 10
+}

--- a/scripts/agent_start.py
+++ b/scripts/agent_start.py
@@ -55,6 +55,9 @@ from typing import Iterable
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKTREES_DIR = REPO_ROOT / ".worktrees"
 TASK_METADATA_FILENAME = ".agent-task.json"
+# Broker-generated files that must NOT count as user WIP (otherwise every
+# freshly created worktree reads as dirty and is never cleanup-eligible).
+BROKER_GENERATED_FILES = frozenset({".agent-task.json", ".env.worktree"})
 
 # Lanes documented in CLAUDE.md + research synthesis.
 # This is an ALLOW-list for create; --list/--cleanup/--release accept any lane
@@ -94,6 +97,16 @@ LOG_DIR = Path.home() / "logs"
 LOG_FILE = LOG_DIR / "agent-broker.log"
 
 KILL_SWITCH_ENV = "AGENT_BROKER_ENABLED"
+
+# W62 ANTIBODY #1: cleanup must not reap a TTL-expired-but-clean worktree that
+# is still being actively worked on. A worktree touched more recently than this
+# threshold is treated as a live session and skipped (override with --force or
+# skip_recent_minutes=0).
+RECENT_ACTIVITY_MINUTES = 10
+
+# W62 ANTIBODY #2/#3: a worktree older than this multiple of its TTL is a
+# suspected orphan (surfaced by --list, gated by the CI hygiene test).
+ORPHAN_TTL_MULTIPLE = 2
 
 
 # ---------------------------------------------------------------------------
@@ -449,8 +462,8 @@ def _worktree_has_wip(worktree: Path) -> bool:
     if proc.returncode != 0:
         # If git can't read the worktree (corrupt) treat as WIP to be safe.
         return True
-    # Ignore the metadata file itself when computing WIP, otherwise every
-    # freshly created worktree would report dirty.
+    # Ignore broker-generated files (.agent-task.json, .env.worktree) when
+    # computing WIP, otherwise every freshly created worktree reports dirty.
     relevant = []
     for line in proc.stdout.splitlines():
         # Porcelain v1: first 2 cols are status, then a space, then path.
@@ -459,10 +472,127 @@ def _worktree_has_wip(worktree: Path) -> bool:
         path = line[3:].strip()
         # Strip "->" rename targets.
         path = path.split(" -> ")[-1].strip().strip('"')
-        if path == TASK_METADATA_FILENAME:
+        if path in BROKER_GENERATED_FILES:
             continue
         relevant.append(line)
     return bool(relevant)
+
+
+def _worktree_recently_active(
+    worktree: Path, *, threshold_minutes: int = RECENT_ACTIVITY_MINUTES
+) -> bool:
+    """True if the worktree shows filesystem activity within threshold_minutes.
+
+    Distinct from age (created_at): this is a *liveness* probe so cleanup never
+    reaps a worktree whose TTL clock expired while a session was still working
+    in it (W62 ANTIBODY #1). Signal = newest mtime among the worktree dir, its
+    `.git` pointer, and the REAL gitdir HEAD (the linked-worktree gitdir is
+    under REPO_ROOT/.git/worktrees/<name>/; HEAD is bumped by commit/checkout —
+    codex P2: the `.git` pointer alone is not enough for linked worktrees).
+
+    NB: the gitdir `index` is deliberately NOT probed — `git status` (run by the
+    WIP check that precedes this guard) rewrites the index mtime, so it would
+    read as "active" on every cleanup pass. HEAD is stable under read-only
+    status, so it tracks genuine commit/checkout activity only.
+
+    This is a best-effort liveness heuristic, NOT a security control: an
+    adversary could `touch` a path to keep an orphan alive. Its only job is to
+    avoid reaping a genuinely active session; the 24h CI cap (find_stale_
+    worktrees) is the hard ceiling no heuristic can opt out of.
+    """
+    if threshold_minutes <= 0:
+        return False
+    cutoff = time.time() - threshold_minutes * 60
+    probes = [worktree, worktree / ".git"]
+    real_gitdir = _resolve_worktree_gitdir(worktree)
+    if real_gitdir is not None:
+        probes.append(real_gitdir / "HEAD")
+    try:
+        return any(p.exists() and p.stat().st_mtime > cutoff for p in probes)
+    except OSError:
+        return True
+
+
+def _resolve_worktree_gitdir(worktree: Path) -> Path | None:
+    """Resolve the real gitdir of a linked worktree (REPO_ROOT/.git/worktrees/
+    <name>). For a linked worktree, `worktree/.git` is a file
+    `gitdir: <abs-path>`; return that path. Returns None on any error."""
+    git_pointer = worktree / ".git"
+    try:
+        if git_pointer.is_file():
+            text = git_pointer.read_text(encoding="utf-8").strip()
+            if text.startswith("gitdir:"):
+                return Path(text.split(":", 1)[1].strip())
+        elif git_pointer.is_dir():
+            return git_pointer
+    except OSError:
+        return None
+    return None
+
+
+def _is_orphan(meta: "TaskMetadata", *, now: datetime | None = None) -> bool:
+    """True if age exceeds ORPHAN_TTL_MULTIPLE × ttl. Malformed timestamps
+    (age_minutes == -1.0) are NOT orphans — operator must inspect them."""
+    age = meta.age_minutes(now=now)
+    if age < 0:
+        return False
+    return age > ORPHAN_TTL_MULTIPLE * meta.ttl_minutes
+
+
+# Hard ceiling (W62 ANTIBODY #3): no worktree should survive this long. Enforced
+# at PR-time by tests/integration/test_no_stale_worktrees.py. Independent of any
+# per-task TTL — a runaway TTL cannot opt out of the absolute cap.
+STALE_WORKTREE_MAX_AGE_MINUTES = 24 * 60
+
+
+def find_stale_worktrees(
+    worktrees_dir: Path | None = None,
+    *,
+    max_age_minutes: int = STALE_WORKTREE_MAX_AGE_MINUTES,
+    strict_missing_metadata: bool = False,
+    now: datetime | None = None,
+) -> list[tuple[str, float]]:
+    """Return [(name, age_minutes)] for worktrees older than max_age_minutes.
+
+    Age signal (W62 audit decision): primary is the broker's own `created_at`
+    metadata (the canonical age axis used by --list/--cleanup).
+
+    For a worktree dir WITHOUT a valid `.agent-task.json`:
+      - strict_missing_metadata=False (default): fall back to directory mtime so
+        non-broker orphans are still caught when they happen to be old.
+      - strict_missing_metadata=True (CI gate): an unmanaged/malformed worktree
+        is ALWAYS reported (age = +inf), because a fresh-but-untracked dir under
+        .worktrees/ has a recent mtime and would slip past a 24h mtime check
+        (codex P3 false-negative). At PR time there is no live session, so any
+        metadata-less worktree is a defect to fix.
+    """
+    worktrees_dir = worktrees_dir if worktrees_dir is not None else WORKTREES_DIR
+    if not worktrees_dir.is_dir():
+        return []
+    now = now or datetime.now(timezone.utc)
+    now_ts = now.timestamp()
+    stale: list[tuple[str, float]] = []
+    for entry in sorted(worktrees_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        meta_path = entry / TASK_METADATA_FILENAME
+        managed = False
+        age = -1.0
+        if meta_path.is_file():
+            try:
+                meta = TaskMetadata.from_path(meta_path)
+                age = meta.age_minutes(now=now)
+                managed = age >= 0
+            except (OSError, json.JSONDecodeError, KeyError, ValueError):
+                managed = False
+        if not managed:
+            if strict_missing_metadata:
+                stale.append((entry.name, float("inf")))
+                continue
+            age = max(0.0, (now_ts - entry.stat().st_mtime) / 60.0)
+        if age > max_age_minutes:
+            stale.append((entry.name, age))
+    return stale
 
 
 def cmd_list() -> int:
@@ -472,18 +602,30 @@ def cmd_list() -> int:
         return 0
     print(
         f"{'TASK':<24} {'LANE':<14} {'HOST':<14} "
-        f"{'AGE_MIN':>8} {'TTL':>5} {'WIP':<4} BRANCH"
+        f"{'AGE_MIN':>8} {'TTL':>5} {'WIP':<4} {'ORPHAN':<7} BRANCH"
     )
     now = datetime.now(timezone.utc)
+    orphan_count = 0
     for meta in rows:
         wt = Path(meta.worktree_path) if meta.worktree_path else _worktree_path(
             meta.lane, meta.task_id
         )
         wip_flag = "yes" if wt.is_dir() and _worktree_has_wip(wt) else "no"
         age = meta.age_minutes(now=now)
+        orphan = _is_orphan(meta, now=now)
+        if orphan:
+            orphan_count += 1
+        orphan_flag = "ORPHAN" if orphan else ""
         print(
             f"{meta.task_id:<24} {meta.lane:<14} {meta.host:<14} "
-            f"{age:>8.1f} {meta.ttl_minutes:>5d} {wip_flag:<4} {meta.branch}"
+            f"{age:>8.1f} {meta.ttl_minutes:>5d} {wip_flag:<4} "
+            f"{orphan_flag:<7} {meta.branch}"
+        )
+    if orphan_count:
+        print(
+            f"\nWARN: {orphan_count} orphan worktree(s) detected "
+            f"(age > {ORPHAN_TTL_MULTIPLE}× TTL) — review then run "
+            "--cleanup or --release."
         )
     return 0
 
@@ -493,12 +635,25 @@ def cmd_list() -> int:
 # ---------------------------------------------------------------------------
 
 
-def cmd_cleanup(*, force: bool = False) -> int:
+def cmd_cleanup(
+    *, force: bool = False, skip_recent_minutes: int = RECENT_ACTIVITY_MINUTES
+) -> int:
     """Remove expired worktrees. WIP-safe: emits WARNING and skips if dirty.
 
-    Pass force=True to override the WIP guard (operator escape hatch).
+    Two guards protect a worktree from being reaped even when its TTL clock
+    expired. Order matters — WIP is checked FIRST so a worktree that is BOTH
+    recently-touched AND dirty still surfaces as a WIP failure (never silently
+    swallowed as a "live session"):
+      1. WIP guard — uncommitted changes present (tracked or untracked). This
+         is a *failure* to clean (the operator must commit/stash) → exit 1.
+      2. Recent-activity guard (W62 ANTIBODY #1) — applied only to CLEAN
+         worktrees: filesystem activity within skip_recent_minutes marks a live
+         session. This is *not* a failure; the next tick reaps it once idle.
+
+    Pass force=True to override BOTH guards (operator escape hatch).
+    skip_recent_minutes=0 disables only the recent-activity guard.
     Returns 0 if every expired worktree was removed cleanly OR no work
-    needed; 1 if at least one removal was skipped/errored.
+    needed; 1 if at least one removal was skipped for WIP / errored.
     """
     if _kill_switch_active():
         raise SystemExit(
@@ -518,6 +673,9 @@ def cmd_cleanup(*, force: bool = False) -> int:
         wt = Path(meta.worktree_path) if meta.worktree_path else _worktree_path(
             meta.lane, meta.task_id
         )
+        # WIP guard FIRST: a dirty worktree is always a failure to clean,
+        # even if it was touched recently (codex P2: recent+dirty must not
+        # exit 0 silently).
         if wt.is_dir() and _worktree_has_wip(wt) and not force:
             logger.warning(
                 "cleanup skip %s — uncommitted WIP present (use --force)",
@@ -528,6 +686,23 @@ def cmd_cleanup(*, force: bool = False) -> int:
                 f"Commit or stash inside {wt}, then re-run --cleanup."
             )
             issues += 1
+            continue
+        # Recent-activity guard SECOND, on clean worktrees only: a live session
+        # that simply outran its TTL clock — keep it, reap when idle.
+        if (
+            wt.is_dir()
+            and not force
+            and _worktree_recently_active(wt, threshold_minutes=skip_recent_minutes)
+        ):
+            logger.info(
+                "cleanup skip %s — recent activity (<%dmin), likely live session",
+                meta.task_id,
+                skip_recent_minutes,
+            )
+            print(
+                f"skip {meta.task_id} (recent activity <{skip_recent_minutes}min) "
+                "— live session, will reap when idle"
+            )
             continue
         try:
             _remove_worktree(wt, meta.branch, delete_branch=False)
@@ -678,6 +853,15 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="With --cleanup/--release: override WIP and merged-status guards",
     )
+    p.add_argument(
+        "--skip-recent-min",
+        type=int,
+        default=RECENT_ACTIVITY_MINUTES,
+        help=(
+            "With --cleanup: skip worktrees with filesystem activity in the last "
+            f"N minutes (default: {RECENT_ACTIVITY_MINUTES}; 0 disables the guard)"
+        ),
+    )
     return p
 
 
@@ -699,7 +883,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.list:
         return cmd_list()
     if args.cleanup:
-        return cmd_cleanup(force=args.force)
+        return cmd_cleanup(force=args.force, skip_recent_minutes=args.skip_recent_min)
     if args.release:
         return cmd_release(args.release, force=args.force)
 

--- a/scripts/agent_worktree_cleanup_cron.sh
+++ b/scripts/agent_worktree_cleanup_cron.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# agent_worktree_cleanup_cron.sh — periodic reaper for the agent worktree broker.
+#
+# W62 ANTIBODY #1: scripts/agent_start.py --cleanup is WIP-safe and skip-recent
+# safe, but it is OPT-IN — nothing invoked it on a schedule, so abandoned
+# worktrees accumulated for days (worktree storm, sibling-race surface growth).
+# This wrapper is driven by com.nuzantara.agent-worktree-cleanup.daily.plist.
+#
+# Guards (all enforced inside agent_start.py --cleanup):
+#   - WIP-safe   : a worktree with uncommitted changes is NEVER removed.
+#   - skip-recent: a worktree touched in the last 10min (live session) is kept.
+#   - kill switch: AGENT_BROKER_ENABLED=false aborts cleanly.
+#
+# GOTCHA (W62 audit): the broker resolves WORKTREES_DIR from the script's own
+# location (parents[1]). It MUST run from the MAIN checkout, never a worktree
+# copy, or it would scan .worktrees/<wt>/.worktrees/ (nonexistent) and no-op.
+#
+# Exit codes: 0 = clean (or live-session skips only); 1 = a WIP worktree was
+# skipped (operator must commit/stash); 2 = broker disabled / env missing.
+
+set -euo pipefail
+
+# Hardcoded MAIN checkout — do NOT derive from $0 (this wrapper may itself be
+# invoked from a worktree copy). The broker path below is the canonical one.
+REPO_ROOT="${HOME}/Desktop/nuzantara"
+BROKER="${REPO_ROOT}/scripts/agent_start.py"
+
+LOG_DIR="${HOME}/logs"
+mkdir -p "$LOG_DIR"
+LOG="${LOG_DIR}/agent-worktree-cleanup.log"
+
+log() {
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" | tee -a "$LOG"
+}
+
+# Heartbeat helper (no-op fallback if not present).
+# shellcheck disable=SC1091
+if ! source "${REPO_ROOT}/scripts/lib/heartbeat.sh" 2>/dev/null; then
+    organism_heartbeat() { :; }
+fi
+
+if [ ! -f "$BROKER" ]; then
+    log "ERROR: broker not found at $BROKER"
+    organism_heartbeat "pro.agent_worktree_cleanup" "fail" "broker missing"
+    exit 2
+fi
+
+PYTHON="$(command -v python3 || true)"
+if [ -z "$PYTHON" ]; then
+    log "ERROR: python3 not on PATH ($PATH)"
+    organism_heartbeat "pro.agent_worktree_cleanup" "fail" "python3 missing"
+    exit 2
+fi
+
+log "running broker --cleanup (repo=$REPO_ROOT)"
+set +e
+OUTPUT="$(cd "$REPO_ROOT" && "$PYTHON" "$BROKER" --cleanup 2>&1)"
+RC=$?
+set -e
+
+echo "$OUTPUT" | tee -a "$LOG"
+
+# Heartbeat must never mask the broker's real RC under set -e (codex P3):
+# guard every call with || true and exit on the captured $RC.
+case "$RC" in
+    0) organism_heartbeat "pro.agent_worktree_cleanup" "ok" "clean" || true ;;
+    1) organism_heartbeat "pro.agent_worktree_cleanup" "warn" "WIP worktree skipped" || true ;;
+    *) organism_heartbeat "pro.agent_worktree_cleanup" "fail" "exit $RC" || true ;;
+esac
+
+log "done (exit $RC)"
+exit "$RC"

--- a/scripts/tests/test_agent_start.py
+++ b/scripts/tests/test_agent_start.py
@@ -20,6 +20,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -225,10 +226,58 @@ def _backdate_metadata(worktree: Path, mod, minutes: int) -> None:
     meta_path.write_text(json.dumps(data, indent=2, sort_keys=True))
 
 
+def _commit_in_worktree(worktree: Path, mod, rel_path: str, msg: str) -> None:
+    """Stage + commit a file inside the worktree so it reads as CLEAN."""
+    env = dict(os.environ)
+    env.update(
+        GIT_AUTHOR_NAME="Test",
+        GIT_AUTHOR_EMAIL="test@example.com",
+        GIT_COMMITTER_NAME="Test",
+        GIT_COMMITTER_EMAIL="test@example.com",
+    )
+    for args in (["add", rel_path], ["commit", "-m", msg]):
+        subprocess.run(
+            ["git", *args], cwd=worktree, check=True,
+            capture_output=True, text=True, env=env,
+        )
+
+
+def _backdate_worktree_mtime(worktree: Path, minutes: int) -> None:
+    """Push every file's mtime back so the worktree reads as idle (no recent
+    activity). Covers both the worktree tree AND the linked-worktree gitdir
+    (REPO_ROOT/.git/worktrees/<name>/index|HEAD), since the liveness probe
+    inspects the real gitdir too."""
+    past = time.time() - minutes * 60
+
+    def _back(p: Path) -> None:
+        try:
+            os.utime(p, (past, past))
+        except OSError:
+            pass
+
+    for path in worktree.rglob("*"):
+        _back(path)
+    _back(worktree)
+    # Linked-worktree real gitdir (resolve `.git` file pointer).
+    git_pointer = worktree / ".git"
+    try:
+        if git_pointer.is_file():
+            text = git_pointer.read_text().strip()
+            if text.startswith("gitdir:"):
+                gitdir = Path(text.split(":", 1)[1].strip())
+                for name in ("index", "HEAD"):
+                    _back(gitdir / name)
+                _back(gitdir)
+        _back(git_pointer)
+    except OSError:
+        pass
+
+
 def test_cleanup_removes_expired_clean_worktree(fake_repo, capsys):
     mod, repo = fake_repo
     wt = mod.cmd_create("wr2", "expired-001", ttl_minutes=5)
     _backdate_metadata(wt, mod, minutes=120)
+    _backdate_worktree_mtime(wt, minutes=120)  # idle, not a live session
     rc = mod.cmd_cleanup()
     assert rc == 0
     assert not wt.exists()
@@ -241,6 +290,7 @@ def test_cleanup_skips_wip_with_warning(fake_repo, capsys):
     wt = mod.cmd_create("wr2", "wip-keep", ttl_minutes=5)
     _backdate_metadata(wt, mod, minutes=120)
     (wt / "wip.txt").write_text("not committed\n")
+    _backdate_worktree_mtime(wt, minutes=120)  # idle clock, but real WIP present
     rc = mod.cmd_cleanup()
     assert rc == 1  # signals at least one skip
     assert wt.exists()  # WIP-safe
@@ -265,6 +315,105 @@ def test_cleanup_leaves_fresh_worktrees_alone(fake_repo):
     rc = mod.cmd_cleanup()
     assert rc == 0
     assert wt.exists()
+
+
+# ---------------------------------------------------------------------------
+# cleanup — skip-recent guard (W62 ANTIBODY #1)
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_skips_recently_active_expired_clean_worktree(fake_repo, capsys):
+    """A clean, TTL-expired worktree that was touched <10min ago is an ACTIVE
+    session — cleanup must NOT drop it (W62: avoid killing a live session that
+    simply outran its TTL clock)."""
+    mod, _ = fake_repo
+    wt = mod.cmd_create("wr2", "active-001", ttl_minutes=5)
+    _backdate_metadata(wt, mod, minutes=120)  # expired by the clock
+    # Simulate live activity: a freshly written tracked file (recent mtime),
+    # but committed so the worktree is CLEAN (no WIP).
+    work_file = wt / "live.txt"
+    work_file.write_text("active session output\n")
+    _commit_in_worktree(wt, mod, "live.txt", "active work")
+    rc = mod.cmd_cleanup()
+    assert rc == 0  # not an error — just skipped a live session
+    assert wt.exists()  # preserved because recently active
+    out = capsys.readouterr().out
+    assert "active-001" in out
+    assert "recent" in out.lower() or "active" in out.lower()
+
+
+def test_cleanup_removes_expired_clean_idle_worktree(fake_repo):
+    """An expired, clean worktree with NO recent activity (mtime old) is a true
+    orphan — cleanup removes it."""
+    mod, _ = fake_repo
+    wt = mod.cmd_create("wr2", "idle-001", ttl_minutes=5)
+    _backdate_metadata(wt, mod, minutes=120)
+    _backdate_worktree_mtime(wt, minutes=120)
+    rc = mod.cmd_cleanup()
+    assert rc == 0
+    assert not wt.exists()
+
+
+def test_cleanup_recent_AND_dirty_reports_wip_not_silent_skip(fake_repo, capsys):
+    """A worktree that is BOTH recently active AND dirty must surface as a WIP
+    failure (exit 1), never be silently swallowed as a live session (codex P2:
+    WIP guard runs before the recent-activity guard)."""
+    mod, _ = fake_repo
+    wt = mod.cmd_create("wr2", "recent-dirty", ttl_minutes=5)
+    _backdate_metadata(wt, mod, minutes=120)  # expired
+    (wt / "uncommitted.txt").write_text("real WIP\n")  # dirty + fresh mtime
+    rc = mod.cmd_cleanup()
+    assert rc == 1  # WIP failure, NOT a silent exit-0 skip
+    assert wt.exists()
+    out = capsys.readouterr().out
+    assert "recent-dirty" in out
+    assert "WIP" in out
+
+
+def test_cleanup_skip_recent_disabled_with_zero(fake_repo):
+    """skip_recent_minutes=0 disables the recent-activity guard (operator
+    escape for a forced sweep of even just-touched worktrees)."""
+    mod, _ = fake_repo
+    wt = mod.cmd_create("wr2", "recent-002", ttl_minutes=5)
+    _backdate_metadata(wt, mod, minutes=120)
+    (wt / "fresh.txt").write_text("just now\n")
+    _commit_in_worktree(wt, mod, "fresh.txt", "fresh")
+    rc = mod.cmd_cleanup(skip_recent_minutes=0)
+    assert rc == 0
+    assert not wt.exists()
+
+
+# ---------------------------------------------------------------------------
+# list — orphan detection (W62 ANTIBODY #2)
+# ---------------------------------------------------------------------------
+
+
+def test_list_warns_on_orphan_worktree(fake_repo, capsys):
+    """A worktree older than 2× its TTL is flagged ORPHAN with a summary line."""
+    mod, _ = fake_repo
+    wt = mod.cmd_create("wr2", "orphan-001", ttl_minutes=30)
+    _backdate_metadata(wt, mod, minutes=120)  # 120 > 2*30 = 60 → orphan
+    rc = mod.cmd_list()
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "orphan-001" in out
+    assert "ORPHAN" in out
+    assert "1 orphan" in out.lower() or "orphan worktree" in out.lower()
+
+
+def test_list_no_orphan_when_within_2x_ttl(fake_repo, capsys):
+    """A worktree past TTL but under 2× TTL is NOT yet an orphan."""
+    mod, _ = fake_repo
+    wt = mod.cmd_create("wr2", "young-001", ttl_minutes=30)
+    _backdate_metadata(wt, mod, minutes=45)  # 30 < 45 < 60 → not orphan
+    rc = mod.cmd_list()
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "young-001" in out
+    # "ORPHAN" appears in the header column; assert the data row is NOT flagged.
+    data_row = next(line for line in out.splitlines() if "young-001" in line)
+    assert "ORPHAN" not in data_row
+    assert "orphan worktree" not in out.lower()
 
 
 def test_cleanup_blocked_by_kill_switch(fake_repo, monkeypatch):

--- a/tests/integration/test_no_stale_worktrees.py
+++ b/tests/integration/test_no_stale_worktrees.py
@@ -1,0 +1,159 @@
+"""W62 ANTIBODY #3 — CI hygiene gate for the agent worktree broker.
+
+Two responsibilities:
+
+1. **Live guard** — fail the PR if the real `.worktrees/` tree in this checkout
+   contains a worktree older than 24h (a true orphan the broker never reaped).
+   Runs against the repo root, on a fresh CI checkout where no live agent
+   session exists, so strictness yields no false positives.
+
+2. **Detector unit tests** — exercise `find_stale_worktrees` against a synthetic
+   `.worktrees/` so the threshold logic (created_at primary, dir-mtime fallback)
+   is covered independently of whatever happens to be on disk.
+
+The detector lives in `scripts/agent_start.py` so test and the live guard share
+one implementation (no drift between what CI checks and what `--cleanup` reaps).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "agent_start.py"
+
+
+def _load_broker(worktrees_dir: Path):
+    spec = importlib.util.spec_from_file_location("agent_start_ci", SCRIPT_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    import sys
+
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    mod.REPO_ROOT = worktrees_dir.parent
+    mod.WORKTREES_DIR = worktrees_dir
+    return mod
+
+
+def _write_metadata(wt: Path, *, created_minutes_ago: int, ttl: int = 60) -> None:
+    wt.mkdir(parents=True, exist_ok=True)
+    created = datetime.now(timezone.utc) - timedelta(minutes=created_minutes_ago)
+    (wt / ".agent-task.json").write_text(
+        json.dumps(
+            {
+                "task_id": wt.name,
+                "lane": "infra",
+                "branch": f"agent/test/infra/{wt.name}",
+                "host": "test",
+                "created_at": created.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "ttl_minutes": ttl,
+                "pid": 0,
+                "base_branch": "main",
+                "worktree_path": str(wt),
+            }
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Detector unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_detector_flags_worktree_older_than_24h(tmp_path):
+    wtd = tmp_path / ".worktrees"
+    mod = _load_broker(wtd)
+    _write_metadata(wtd / "infra-old", created_minutes_ago=25 * 60)
+    stale = mod.find_stale_worktrees(wtd)
+    assert [name for name, _ in stale] == ["infra-old"]
+
+
+def test_detector_ignores_fresh_worktree(tmp_path):
+    wtd = tmp_path / ".worktrees"
+    mod = _load_broker(wtd)
+    _write_metadata(wtd / "infra-fresh", created_minutes_ago=30)
+    assert mod.find_stale_worktrees(wtd) == []
+
+
+def test_detector_uses_created_at_not_dir_mtime(tmp_path):
+    """A dir whose mtime is recent (active edits) but whose created_at is >24h
+    old IS stale — created_at is the authoritative age axis."""
+    wtd = tmp_path / ".worktrees"
+    mod = _load_broker(wtd)
+    wt = wtd / "infra-touched"
+    _write_metadata(wt, created_minutes_ago=25 * 60)
+    # Bump dir mtime to "now" — must NOT rescue it from stale.
+    os.utime(wt, None)
+    stale = mod.find_stale_worktrees(wtd)
+    assert "infra-touched" in [name for name, _ in stale]
+
+
+def test_detector_falls_back_to_dir_mtime_without_metadata(tmp_path):
+    """A worktree dir with NO .agent-task.json (not broker-created) is judged by
+    dir mtime so non-broker orphans are still caught."""
+    wtd = tmp_path / ".worktrees"
+    mod = _load_broker(wtd)
+    wt = wtd / "rogue-no-meta"
+    wt.mkdir(parents=True)
+    old = time.time() - 25 * 60 * 60
+    os.utime(wt, (old, old))
+    stale = mod.find_stale_worktrees(wtd)
+    assert "rogue-no-meta" in [name for name, _ in stale]
+
+
+def test_detector_strict_flags_fresh_metadata_less_dir(tmp_path):
+    """strict_missing_metadata=True (CI gate): a metadata-less worktree is
+    reported even if its dir mtime is brand new (codex P3 false-negative)."""
+    wtd = tmp_path / ".worktrees"
+    mod = _load_broker(wtd)
+    wt = wtd / "fresh-no-meta"
+    wt.mkdir(parents=True)
+    os.utime(wt, None)  # mtime = now
+    # Lax mode: NOT stale (fresh mtime). Strict mode: stale (unmanaged).
+    assert mod.find_stale_worktrees(wtd) == []
+    strict = mod.find_stale_worktrees(wtd, strict_missing_metadata=True)
+    assert [name for name, _ in strict] == ["fresh-no-meta"]
+    assert strict[0][1] == float("inf")
+
+
+def test_detector_empty_when_no_worktrees_dir(tmp_path):
+    mod = _load_broker(tmp_path / ".worktrees")
+    assert mod.find_stale_worktrees(tmp_path / ".worktrees") == []
+
+
+# ---------------------------------------------------------------------------
+# Live guard against the real checkout
+# ---------------------------------------------------------------------------
+
+
+def test_no_stale_worktrees_in_checkout():
+    """Hard gate: the live .worktrees/ must contain no worktree older than 24h.
+
+    If this fails, an orphan survived the broker. Fix by:
+      python scripts/agent_start.py --list      # inspect (ORPHAN-flagged)
+      python scripts/agent_start.py --cleanup   # reap idle expired worktrees
+      python scripts/agent_start.py --release <task-id>   # tear down one
+    """
+    mod = _load_broker(REPO_ROOT / ".worktrees")
+    # strict: at PR time a metadata-less worktree under .worktrees/ is a defect,
+    # not something to excuse via a (recent) dir mtime.
+    stale = mod.find_stale_worktrees(
+        REPO_ROOT / ".worktrees", strict_missing_metadata=True
+    )
+    if stale:
+        listing = "\n".join(
+            f"  - {name}: {('unmanaged' if age == float('inf') else f'{age/60:.1f}h old')}"
+            for name, age in stale
+        )
+        pytest.fail(
+            "Stale worktree(s) older than 24h detected (W62 orphan guard):\n"
+            f"{listing}\n"
+            "Run: python scripts/agent_start.py --cleanup  (or --release <id>)"
+        )


### PR DESCRIPTION
## What & why

Closes cicatrix **W62** — the agent worktree broker (`scripts/agent_start.py`) had `TTL=60min` but it was **advisory**: `--cleanup` was opt-in, no cron ran it, and subagents never `--release`. Result: a worktree storm, growing sibling-race surface, and WIP-loss risk (danger zone "untracked-files-lost" W-family).

## Four ANTIBODY shipped

| # | ANTIBODY | Files |
|---|---|---|
| 1 | **Auto-cleanup cron** — daily `--cleanup`, WIP-safe + new skip-recent guard (live session <10min kept) | `infra/launchagents/com.nuzantara.agent-worktree-cleanup.daily.plist.example`, `scripts/agent_worktree_cleanup_cron.sh`, `infra/launchagents/install_agent_worktree_cleanup.sh` |
| 2 | **Orphan detection** in `--list` — flags `ORPHAN` >2×TTL + WARN footer | `scripts/agent_start.py` (`cmd_list`, `_is_orphan`) |
| 3 | **CI gate** — fail PR on worktree >24h; also runs the previously CI-orphaned broker unit tests | `tests/integration/test_no_stale_worktrees.py`, `.github/workflows/broker-hygiene.yml`, `find_stale_worktrees()` |
| 4 | **Broker-aware spawn convention** — 3-tier hygiene documented | `docs/runbooks/agent-worktree-broker.md` |

## Latent bug also fixed

`.env.worktree` (broker-generated by W59) wasn't in the WIP ignore-list → **every fresh worktree read as dirty** and could never be auto-reaped. A silent contributor to the storm. `BROKER_GENERATED_FILES` now covers it.

## WIP rescue (PASSO 1)

Inspected all 11 stale worktrees **before** any cleanup. The one with real WIP (`root_guard` army-prompts whitelist) was committed by a sibling mid-session and preserved on `rescue/s4-root-guard-army-prompts-wip` (pushed to origin). **Zero loss.** The other 10 were metadata-only or fossils subsumed by `531680763`.

## Verification

- **37/37 tests pass** (TDD: RED-first verified). New: skip-recent guard, recent+dirty→WARN, orphan detection, 24h CI detector + strict-missing-metadata.
- `plutil -lint` plist OK · `bash -n` wrappers OK · live smoke on real tree (6 ORPHAN flagged, strict mode flags unmanaged codex worktrees).
- **Adversarial**: Codex GPT-5.5 → 0 P1 / 3 P2 / 3 P3 → **5 fixed** (WIP-before-recent ordering, gitdir HEAD probe, CI strict-missing-metadata, heartbeat `|| true`, workflow path filter), 1 accepted as low residual.

## Needs operator

- Install cron: `bash infra/launchagents/install_agent_worktree_cleanup.sh` (ships as `.plist.example`, not auto-bootstrapped).
- Optionally reap the existing ORPHAN worktrees now.
- Add `broker-hygiene.yml` as a required check for PR-time enforcement.

FROZEN: `research/operations/S4-broker-FROZEN.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)