### PR TITLE
fix(crm): guard missing whatsapp_enrichment import so router collects (main CI red)

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_clients.py
+++ b/apps/backend-rag/backend/app/routers/crm_clients.py
@@ -27,9 +27,20 @@ from backend.core.cache import cached, invalidate_cache
 from backend.db.repositories.client_repository import ClientRepository
 from backend.services.common.background import spawn
 from backend.services.crm.client_service import ClientService
-from backend.services.crm.whatsapp_enrichment import fetch_client_whatsapp_enrichments
 
 logger = get_logger(__name__)
+
+try:
+    # Optional dependency: the WhatsApp-enrichment read service is not present in
+    # every deployment. Import it lazily-guarded so this router still imports
+    # (and pytest can collect it) when the module is absent. The single endpoint
+    # that uses it (`GET /{client_id}/whatsapp-enrichments`) then fails loudly
+    # with 501 instead of crashing the whole module at import time.
+    from backend.services.crm.whatsapp_enrichment import (  # type: ignore[import-not-found]
+        fetch_client_whatsapp_enrichments,
+    )
+except ImportError:  # pragma: no cover - exercised only when the module is absent
+    fetch_client_whatsapp_enrichments = None  # type: ignore[assignment]
 
 router = APIRouter(prefix="/api/crm/clients", tags=["crm-clients"])
 
@@ -836,6 +847,13 @@ async def get_client_whatsapp_enrichments(
     This endpoint intentionally omits source hashes, dedupe keys, and raw
     WhatsApp evidence. It is for internal CRM/workspace surfaces only.
     """
+    if fetch_client_whatsapp_enrichments is None:
+        # The optional WhatsApp-enrichment read service is not installed in this
+        # deployment. Fail explicitly rather than raising an opaque NameError.
+        raise HTTPException(
+            status_code=501,
+            detail="WhatsApp enrichment service is not available in this deployment.",
+        )
     try:
         async with db_pool.acquire() as conn:
             await verify_client_access(client_id, current_user, conn, allow_assigned=True)


### PR DESCRIPTION
## Problem

`main` is functionally broken for CI. `apps/backend-rag/backend/app/routers/crm_clients.py:30` had a top-level import:

```python
from backend.services.crm.whatsapp_enrichment import fetch_client_whatsapp_enrichments
```

The module `whatsapp_enrichment.py` **never existed in any commit on any branch** (empty `git log --all` for that path; `fetch_client_whatsapp_enrichments` is referenced but never defined anywhere). Every pytest run that collects this router crashed with `ModuleNotFoundError` at import time → `Backend Tests (Python)` red on `main` and on every PR branched from it.

## Fix (minimal)

Wrap the import in `try/except ImportError`. When the module is absent, `fetch_client_whatsapp_enrichments` becomes `None`, the router still imports (pytest collects it), and the single endpoint that uses it (`GET /api/crm/clients/{client_id}/whatsapp-enrichments`) raises a clean `HTTPException(501)` instead of an opaque `NameError`.

- Runtime behavior is **unchanged** when the module is genuinely missing: the endpoint was already non-functional (it would have crashed on any call). Now it fails loudly and explicitly.
- If the real module is later added, the import path is preferred automatically — no further change needed.

## Verification

```
$ PYTHONPATH=. python -c "from backend.app.routers import crm_clients; print('import OK')"
import OK   (stub active: True)

$ PYTHONPATH=. pytest backend/tests/routers/test_crm_clients.py --collect-only -q
13 tests collected in 0.45s    # was ModuleNotFoundError
```

## Notes

- A complete fix (actually implementing the WhatsApp-enrichment read service so the endpoint works) is out of scope and needs review — this PR only unblocks CI by making the router collectible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)