### PR TITLE
fix(blog): apply cleanExcerpt() to MDX frontmatter excerpt path in articles.ts

### DIFF
--- a/apps/mouth/src/lib/blog/articles.ts
+++ b/apps/mouth/src/lib/blog/articles.ts
@@ -385,7 +385,7 @@ async function getMdxArticleBySlug(
     slug: frontmatter.slug || slug,
     title: frontmatter.title || "Untitled",
     subtitle: frontmatter.subtitle,
-    excerpt: frontmatter.excerpt || "",
+    excerpt: cleanExcerpt(frontmatter.excerpt || ""),
     content: content,
     coverImage:
       frontmatter.coverImage ||
@@ -506,7 +506,7 @@ export async function getArticleByLocale(
         slug: frontmatter.slug || slug,
         title: frontmatter.title || "Untitled",
         subtitle: frontmatter.subtitle,
-        excerpt: frontmatter.excerpt || "",
+        excerpt: cleanExcerpt(frontmatter.excerpt || ""),
         content,
         coverImage:
           frontmatter.coverImage ||


### PR DESCRIPTION
# Insight
cleanExcerpt() was applied to API-sourced articles but skipped 
for MDX frontmatter articles — causing raw markdown to render 
visibly in LatestNews excerpt previews (## headings, **bold**, links).

# Studio

## Source / Reference
- File: apps/mouth/src/lib/blog/articles.ts
- Renderer: apps/mouth/src/app/v2/_components/LatestNews.tsx line 162
- cleanExcerpt() defined at line 76, applied at lines 155 and 184
- Missing application: lines 388 and 509

## Methodology
1. Identified raw {a.excerpt} render in LatestNews.tsx
2. Traced excerpt source to articles.ts
3. Found two code paths: API (lines 155/184 — uses cleanExcerpt) 
   vs MDX frontmatter (lines 388/509 — raw string)
4. Applied cleanExcerpt() to both missing lines
5. Verified with grep — both instances confirmed wrapped
6. TSC pass via Husky pre-commit hook

## Raw Observations
- Line 388: excerpt: frontmatter.excerpt || ""
- Line 509: excerpt: frontmatter.excerpt || ""
- Both now: excerpt: cleanExcerpt(frontmatter.excerpt || "")
- cleanExcerpt() strips: ## headings, **bold**, *italic*, 
  [link](url), `code`
- 1 file changed, 2 insertions, 2 deletions

## Reasoning Path
Two article data sources (API vs MDX) had inconsistent excerpt 
sanitization. The fix applies the existing function uniformly 
across both paths — no new logic introduced.

## Risk / Implication
- Risk: None — cleanExcerpt() already battle-tested on API path
- Implication: All excerpt previews render clean plain text 
  regardless of source

# Recommendation
Merge independently. No dependency on other PRs.

# Next Action
After merge: spot-check /v2 LatestNews section — confirm 
no raw markdown visible in article preview cards.