### PR TITLE
fix(ui): add flex-wrap to footer legal links for mobile

### DIFF
--- a/apps/mouth/src/app/v2/_components/Footer.tsx
+++ b/apps/mouth/src/app/v2/_components/Footer.tsx
@@ -141,7 +141,7 @@ export function Footer() {
           >
             © 2026 Bali Zero. All rights reserved.
           </span>
-          <div className="flex items-center gap-5">
+          <div className="flex items-center gap-x-5 gap-y-2 flex-wrap justify-end">
             <a
               href="/v2/privacy"
               className="text-[11px]"


### PR DESCRIPTION
# Insight

Footer legal links are truncated on mobile devices (390px width) because the container does not use `flex-wrap`. As a result, the "Cookie Policy" link is not visible and cannot be accessed.

# Studio Layer

## Source / Reference

* File: `apps/mouth/src/app/v2/_components/Footer.tsx` (line 144)
* Confirmed during UI audit on June 1, 2026 (390px mobile viewport)

## Methodology

1. Identified the absence of `flex-wrap` on the legal links container
2. Applied a single `className` update with no logic changes
3. Verified all pre-push hooks passed successfully

## Raw Observations

* **Before:** `className="flex items-center gap-5"`
* **After:** `className="flex items-center gap-x-5 gap-y-2 flex-wrap justify-end"`
* 1 file changed, 1 line modified

## Reasoning

Adding `flex-wrap` allows legal links to flow onto a second line when horizontal space is limited. `gap-x-5` preserves the existing horizontal spacing, while `gap-y-2` provides adequate vertical spacing when wrapping occurs.

## Risk / Impact

* **Risk:** None. Tailwind utility classes only; no TypeScript, logic, or behavioral changes.
* **Impact:** All three legal links remain fully visible and clickable on mobile devices.

# Recommendation

Merge as an independent, low-risk UI fix.

# Next Action

Perform a visual spot check of the `/v2` footer on a 390px iPhone viewport after deployment.
