### PR TITLE
fix(agent-library): evoskill YAML round-trip + return-to-branch guard

### DIFF
--- a/scripts/agent-library-evolver-run.sh
+++ b/scripts/agent-library-evolver-run.sh
@@ -66,6 +66,31 @@ RUN_TS="$(date +%Y-%m-%dT%H:%M:%S%z)"
 RUN_TELEMETRY_DIR="${TELEMETRY_DIR}/${RUN_DATE}"
 DRY_RUN="0"
 
+# ─── S13-P6b (2026-06-02): return-to-branch guard ────────────────────
+# evoskill (vendor/evoskill ProgramManager) does native git checkout of
+# program/* branches INSIDE REPO_ROOT and can leave the worktree parked
+# on a program/* branch when it exits (incl. on FATAL). In production
+# REPO_ROOT is the deploy worktree pinned to deploy/main; a left-over
+# program/* checkout breaks the next wr2-deploy-pull (wrong-branch gate).
+# This trap restores deploy/main on EXIT, but ONLY when (a) REPO_ROOT is
+# a git tree and (b) it was left on a program/* branch — so it never
+# touches a feature/test worktree on its own branch.
+_restore_deploy_branch() {
+    git -C "${REPO_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+    local cur
+    cur="$(git -C "${REPO_ROOT}" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+    case "${cur}" in
+        program/*)
+            if git -C "${REPO_ROOT}" rev-parse --verify --quiet deploy/main >/dev/null 2>&1; then
+                git -C "${REPO_ROOT}" checkout deploy/main >/dev/null 2>&1 \
+                    && log "return-to-branch guard: restored deploy/main (was ${cur})" \
+                    || log "WARN: return-to-branch guard failed to restore deploy/main from ${cur}"
+            fi
+            ;;
+    esac
+}
+trap _restore_deploy_branch EXIT
+
 # ─── CLI parsing ─────────────────────────────────────────────────────
 
 usage() {

--- a/vendor/evoskill/src/registry/manager.py
+++ b/vendor/evoskill/src/registry/manager.py
@@ -468,7 +468,16 @@ class ProgramManager:
         config_path = self.cwd / self.PROGRAM_FILE
         config_path.parent.mkdir(parents=True, exist_ok=True)
         with open(config_path, "w") as f:
-            yaml.dump(config.model_dump(), f, default_flow_style=False, sort_keys=False)
+            # mode="json" serializes nested Path/datetime values in the
+            # metadata dict to plain str so yaml.safe_load can round-trip
+            # them on read (avoids !!python/object/apply:pathlib.PosixPath
+            # tags that safe_load rejects). Fixes evoskill FATAL since 2026-05-24.
+            yaml.safe_dump(
+                config.model_dump(mode="json"),
+                f,
+                default_flow_style=False,
+                sort_keys=False,
+            )
 
     def _read_config(self) -> ProgramConfig:
         """Read program config from YAML file."""


### PR DESCRIPTION
## Problem

After the S13-P6 env fix (#1042) let the agent-library evolver pass secrets validation,
the next real run revealed evoskill itself was FATAL on every invocation since 2026-05-24
(this was the true 24-May blocker, not the psql WARN). Two distinct defects:

1. **YAML round-trip corruption.** `vendor/evoskill` `manager.py` `_write_config` did
   `yaml.dump(config.model_dump())`. `model_dump()` left the `project_root` value (a
   `PosixPath`, stored inside the `metadata: dict[str, Any]`) as a Path object, which
   `yaml.dump` serialized as `!!python/object/apply:pathlib.PosixPath`. The reader
   (`_read_config`, `yaml.safe_load`) rejects that tag → `ConstructorError` → crash before
   any work. The corrupt `program.yaml` was committed on a `program/base` branch (2026-05-24),
   so every run re-read it and died.

2. **Worktree-park.** evoskill does native `git checkout` of `program/*` branches inside
   `REPO_ROOT`. In prod `REPO_ROOT` is the deploy worktree pinned to `deploy/main`; evoskill
   left it parked on `program/base`, which would break the next `wr2-deploy-pull`
   (wrong-branch gate).

## Fix

1. `manager.py` `_write_config`: `yaml.safe_dump(config.model_dump(mode="json"), ...)`.
   `mode="json"` serializes nested Path/datetime to plain str so `safe_load` round-trips.
2. `agent-library-evolver-run.sh`: return-to-branch EXIT trap that restores `deploy/main`
   **only** when the worktree was left on a `program/*` branch (never touches a feature/test
   worktree).

Operational cleanup (done on Pro, outside this diff): deleted the corrupt arcaic
`program/base` branch (backed up as tag `backup/program-base-corrupt-2026-05-24`) so evoskill
recreates it cleanly via the fixed writer.

## Verification (real run on Pro)

| Check | Result |
|---|---|
| `bash -n` | OK |
| Real evolver run (budget $1) | reached **10/10 iterations, exit 0**, cost **$0.10** |
| ConstructorError / PosixPath crash | **gone** — loop ran end-to-end first time since 2026-05-19 |
| program/base recreation | clean via fixed writer (safe_load round-trips) |

## Known follow-up (NOT in this PR — separate task)

The DeepSeek LLM scorer returns an empty string → `could not parse response as float` →
all scores `0.0000` → `Frontier: []` → **0 proposals promoted**. The loop now *runs* but
produces no useful proposals until the scorer parse is fixed. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
