### PR TITLE
feat(crm): S7 yield mining — revenue signals over 1,450 actionable clients (draft, PII-safe)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -755,3 +755,7 @@ apps/backend-rag/scripts/output/*campaign*.csv
 **/dq_clients*.csv
 **/dq_orphan_clients*.csv
 research/nb-health/nb-inventory-live.json
+
+# S7 yield: local PII drafts staging (NEVER commit — UU PDP)
+s7-yield-drafts-local/
+research/crm/*-drafts-local/

--- a/research/crm/S7-yield-FROZEN.json
+++ b/research/crm/S7-yield-FROZEN.json
@@ -1,0 +1,116 @@
+{
+  "session": "S7-crm-yield-mining",
+  "generated_at_utc": "2026-06-02T15:47:00Z",
+  "machine": "Pro (Nuzantara)",
+  "privacy": {
+    "law": "SYMBIOSIS Law 2 + UU PDP (Indonesian GDPR)",
+    "rule": "This file contains ONLY aggregate counts and internal team-owner routing. ZERO client PII (no names, passport, phone, email, client_ids). Per-client PII lives only in the gitignored local staging dir ~/.nuzantara-staging/s7-yield/ and was drafted exclusively by LOCAL Ollama qwen3.5:9b. No client data ever reached a cloud LLM.",
+    "drafting_llm": "ollama qwen3.5:9b (local, localhost:11434)",
+    "outreach": "DRAFT ONLY — nothing sent. Ops team reviews and sends manually (SYMBIOSIS Law 5)."
+  },
+  "universe": {
+    "gross_clients_rows": 11702,
+    "actionable_not_deleted": 1450,
+    "archived_or_deleted_imports": 10252,
+    "note": "The headline '11.699 clienti' is the gross import count; the revenue-actionable universe is the 1,450 non-deleted clients (10,252 rows are soft-deleted legacy imports).",
+    "status_breakdown": { "prospect": 646, "active": 638, "lead": 153, "inactive": 13 },
+    "client_type_breakdown": { "individual": 1419, "company": 28, "Corporate": 3 },
+    "practices_total": 444,
+    "practices_date_span": "2026-01-21 .. 2026-06-01",
+    "clients_with_any_practice": 344,
+    "clients_with_paid_practice": 352,
+    "total_quoted_pipeline_value_idr": 4012800000,
+    "clients_whatsapp_linked": 665
+  },
+  "data_coverage_caveats": [
+    "last_interaction_date populated for only 338/1450 clients — recency signals are partial.",
+    "client_preferences.language essentially empty (1448 null) — draft language inferred from nationality.",
+    "practices table only spans ~4.5 months (Jan-Jun 2026) — NO practice-age dormancy exists yet; classic 'dormant high-value (6mo+)' segment is genuinely 0, not a bug.",
+    "practice next_renewal_date / expiry_date have 0 rows due within 90d — renewal pipeline is driven by clients/visa expiry columns via client_expiry_alerts_view, not by practices."
+  ],
+  "segments": [
+    {
+      "id": "S1",
+      "label": "Visa/KITAS renewal pipeline (permit expiring 0-90d)",
+      "distinct_clients": 61,
+      "priority": "P0 — time-sensitive, highest conversion",
+      "pitch_type": "renewal + KITAP eligibility check",
+      "expiry_buckets": { "d0_30": 18, "d31_60": 21, "d61_90": 28 },
+      "owner_routing_doc_level": { "ari.firda": 28, "surya": 12, "adit": 10, "krisna": 9, "sahira": 5, "vino": 2, "damar": 1 }
+    },
+    {
+      "id": "S2",
+      "label": "Expired-permit win-back (visa/kitas/e-visa already expired)",
+      "distinct_clients": 67,
+      "priority": "P0 — overstay/penalty risk, urgent recovery",
+      "pitch_type": "re-activation before penalties accrue",
+      "owner_routing_doc_level": { "adit": 12, "vino": 11, "krisna": 11, "sahira": 11, "ari.firda": 9, "surya": 8, "damar": 4, "dea": 3, "rina": 1 }
+    },
+    {
+      "id": "S3",
+      "label": "Passport expiring 0-180d (blocks future visa work)",
+      "distinct_clients": 9,
+      "priority": "P2 — proactive, unblocks downstream visa revenue",
+      "pitch_type": "early passport renewal advisory"
+    },
+    {
+      "id": "S4",
+      "label": "Active client, no contact 120d+ (relationship health / re-engagement)",
+      "distinct_clients": 403,
+      "priority": "P1 — large re-engagement pool among 638 active clients",
+      "pitch_type": "check-in + needs discovery",
+      "owner_routing_client_level": { "krisna": 76, "adit": 68, "ari.firda": 59, "vino": 49, "sahira": 37, "damar": 32, "surya": 30, "dea": 24, "unassigned": 18, "ruslana": 8, "rina": 1, "ari": 1 }
+    },
+    {
+      "id": "S5",
+      "label": "Corporate (NPWP/NIB on file) with ZERO practice (tax & compliance expansion)",
+      "distinct_clients": 286,
+      "priority": "P1 — high-LTV: monthly tax retainer, LKPM, SPT, bookkeeping",
+      "pitch_type": "monthly tax & compliance retainer"
+    },
+    {
+      "id": "S6",
+      "label": "WhatsApp-warm (message <60d) with no practice (warm conversion)",
+      "distinct_clients": 30,
+      "priority": "P1 — warm intent, no commitment yet",
+      "pitch_type": "convert enquiry to concrete service plan"
+    },
+    {
+      "id": "S7",
+      "label": "Unconverted prospects/leads (status prospect|lead, no practice)",
+      "distinct_clients": 712,
+      "priority": "P3 — large top-of-funnel; nurture, not 1:1 pitch (ops bandwidth)",
+      "pitch_type": "nurture sequence / qualification (NOT in weekly cap-20 drafting)"
+    },
+    {
+      "id": "S8",
+      "label": "Repeat buyers (2+ paid practices) — loyalty/premium tier",
+      "distinct_clients": 47,
+      "priority": "P2 — proven payers, upsell to retainer/priority",
+      "pitch_type": "priority/retainer arrangement"
+    }
+  ],
+  "language_distribution_top": {
+    "Italian": 275, "English_proxy": 281, "Indonesian": 102, "Spanish": 77,
+    "Russian_Ukrainian": 114, "French": 61, "German": 51, "Dutch": 23, "null": 177,
+    "note": "English_proxy aggregates Australian/British/American/etc. RU/UA clients drafted in English as lingua franca. Italian is the single largest nationality (owner is Italian)."
+  },
+  "weekly_recommendation": {
+    "drafting_cap": 20,
+    "priority_order": ["S1", "S2", "S6", "S5", "S8", "S4", "S3"],
+    "excluded_from_1to1_drafting": ["S7"],
+    "rationale": "Cap 20/week per ops bandwidth (yield-optimizer rule 4). Lead with the two P0 time-sensitive expiry segments (S1+S2 = 128 clients), then warm/expansion. S7 (712 leads) is a nurture-funnel concern, not weekly 1:1 drafting."
+  },
+  "estimated_opportunity": {
+    "basis": "Illustrative only — no per-client value modelling (CRM lifetime_value sparse).",
+    "p0_time_sensitive_clients": 128,
+    "tax_expansion_clients": 286,
+    "comment": "S1+S2 (128) are renewal/recovery with near-certain need. S5 (286 corporate w/o practice) is the largest untapped recurring-revenue pool (monthly tax retainers)."
+  },
+  "reproducibility": {
+    "segment_sql": "scripts/s7_yield_draft_local.py (SEGMENTS dict — each segment has canonical SQL)",
+    "spec": "research/crm/S7-yield-signals-spec.md",
+    "db_role": "nuzantara_readonly (read-only) via pg-proxy localhost:15432, db nuzantara_rag",
+    "expiry_source_view": "client_expiry_alerts_view"
+  }
+}

--- a/research/crm/S7-yield-signals-spec.md
+++ b/research/crm/S7-yield-signals-spec.md
@@ -1,0 +1,92 @@
+---
+date: 2026-06-02
+domain: crm
+client_case: false
+sources:
+  - postgres nuzantara_rag (read-only role nuzantara_readonly)
+  - ~/.claude/agents/yield-optimizer.md (existing weekly agent)
+  - client_expiry_alerts_view, clients, practices, whatsapp_contacts, client_segments
+---
+
+# S7 — CRM Yield Signals Spec (revenue-signal extension of `yield-optimizer`)
+
+Extends the existing **`yield-optimizer`** agent (weekly, Sunday 04:00 WITA) with a
+concrete, schema-accurate set of revenue signals over the **1,450 actionable
+clients** (the non-deleted slice of the 11,702 gross rows). The original agent
+referenced a `crm_clients` table and columns (`engagement_score`,
+`total_spend_ytd`, `kitap_expiry_date`) that **do not exist** in production. This
+spec maps each opportunity rule to the **real** schema and to a reproducible SQL
+query (implemented in `scripts/s7_yield_draft_local.py`).
+
+## Privacy contract (HARD — UU PDP / SYMBIOSIS Law 2)
+
+- Segment **counts and team-owner routing** are public/aggregate → live in
+  `research/crm/S7-yield-FROZEN.json` (committed).
+- Per-client **PII** (names, expiry dates, contact) is read by a **read-only**
+  Postgres role and drafted **only by local Ollama `qwen3.5:9b`**. Drafts land in
+  the gitignored local staging dir `~/.nuzantara-staging/s7-yield/`. **Never**
+  committed, **never** sent to a cloud LLM, **never** printed to stdout (logs
+  carry `client_id` only).
+- **Nothing is sent.** Drafts are for the ops team to review and send manually
+  (SYMBIOSIS Law 5).
+
+## Data-coverage caveats (drive the rule design)
+
+| Field | Coverage | Consequence |
+|---|---|---|
+| `clients.last_interaction_date` | 338 / 1450 | Recency is partial; S4 treats NULL as "no recent contact". |
+| `client_preferences.language` | 2 / 1450 | Draft language **inferred from `nationality`**. |
+| `practices` date span | 2026-01-21 .. 2026-06-01 (~4.5mo) | **No practice-age dormancy exists** → classic "dormant 6mo+" segment = 0 (real, not a bug). |
+| `practices.next_renewal_date` / `expiry_date` due ≤90d | 0 rows | Renewal pipeline driven by **`client_expiry_alerts_view`**, not by practices. |
+
+## Revenue segments (canonical)
+
+All counts are **distinct clients**, `deleted_at IS NULL`, as of 2026-06-02.
+
+| ID | Signal | Trigger (real schema) | Clients | Priority | Pitch |
+|----|--------|-----------------------|--------:|----------|-------|
+| **S1** | Renewal pipeline | `client_expiry_alerts_view`: visa/kitas/e-visa expiring `0..90d` | **61** | P0 | Renewal + KITAP eligibility check |
+| **S2** | Expired win-back | same view, `days_until_expiry < 0` | **67** | P0 | Re-activate before penalties |
+| **S3** | Passport pre-block | same view, `document_type='passport'`, `0..180d` | **9** | P2 | Early passport renewal |
+| **S4** | Active, no-contact | `status='active'` AND `last_interaction_date` NULL or `< now()-120d` | **403** | P1 | Check-in / needs discovery |
+| **S5** | Corporate expansion | (`npwp` OR `nib` not null) AND **no practice** | **286** | P1 | Monthly tax & compliance retainer |
+| **S6** | WhatsApp-warm | linked WA contact `last_message_at < 60d` AND no practice | **30** | P1 | Convert enquiry → service plan |
+| **S7** | Unconverted leads | `status IN (prospect,lead)` AND no practice | **712** | P3 | Nurture funnel (NOT weekly 1:1) |
+| **S8** | Repeat buyers | `>=2` paid practices | **47** | P2 | Priority/retainer upsell |
+
+**Replaces** the old agent's R1–R6 (KITAS, KITAP-eligible, business-pivot,
+tax-expansion, dormant-high-value, engagement-spike). Mapping: R1→S1, R5→(S2+S4),
+R4→S5, R6→S6/S8; R2/R3 deferred (no `kitap_expiry_date` / SHGB columns yet).
+
+## Weekly execution (cap 20/week, ops bandwidth)
+
+Priority order: **S1 → S2 → S6 → S5 → S8 → S4 → S3**. S7 (712 leads) is a
+top-of-funnel **nurture** concern, excluded from weekly 1:1 drafting.
+
+```bash
+# PII-safe local drafting (Pro only; Ollama must be up — no cloud fallback)
+python scripts/s7_yield_draft_local.py --segment S1 --limit 20   # one segment
+python scripts/s7_yield_draft_local.py --all --limit 5           # spread across all
+python scripts/s7_yield_draft_local.py --segment S1 --dry-run    # list only, no Ollama
+```
+
+Drafts: `~/.nuzantara-staging/s7-yield/<SEG>-<ts>-drafts.md` (40–80 words, no
+emoji, no buzzwords, language per nationality). Pilot 2026-06-02 produced S1
+(54/65/57 words) and S5 (65/57/57 words) — all in-spec.
+
+## Owner routing (S1 renewal + S4 re-engagement)
+
+S1 (doc-level): ari.firda 28 · surya 12 · adit 10 · krisna 9 · sahira 5 · vino 2 · damar 1.
+S4 (client-level): krisna 76 · adit 68 · ari.firda 59 · vino 49 · sahira 37 · damar 32 · surya 30 · dea 24 · (unassigned 18) · ruslana 8.
+
+## Failure modes
+
+- **Ollama down** → STOP, no cloud fallback (privacy). Script exits non-zero.
+- **DB unreachable** → STOP (read-only role via pg-proxy 15432).
+- **Draft out of spec** (length/language) → ops re-prompts or skips that row.
+
+## Reference
+
+- FROZEN aggregates: `research/crm/S7-yield-FROZEN.json`
+- Drafter + canonical SQL: `scripts/s7_yield_draft_local.py`
+- Existing agent: `~/.claude/agents/yield-optimizer.md` (column refs corrected to match this spec)

--- a/scripts/s7_yield_draft_local.py
+++ b/scripts/s7_yield_draft_local.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""S7 CRM Yield — PII-safe local pitch drafter.
+
+Connects the 1,450 active-universe CRM clients to revenue signals and drafts
+WhatsApp outreach pitches *entirely on-machine*. Reads client PII (names,
+expiry dates, nationality, contact) directly from the read-only Postgres role
+and feeds it to a LOCAL Ollama model. NOTHING with PII ever leaves the machine.
+
+HARD PRIVACY CONTRACT (UU PDP / SYMBIOSIS Law 2):
+  - DB access: read-only role `nuzantara_readonly` via pg-proxy localhost:15432.
+  - Drafting LLM: Ollama qwen3.5:9b LOCAL only. NEVER OpenAI/Anthropic/Gemini.
+  - PII (names, passport, phone) is written ONLY to a local staging dir under
+    $HOME (gitignored, outside the repo tree). It is NEVER printed to stdout
+    and NEVER committed.
+  - stdout/logs carry ONLY client_id + aggregate counts (the privacy log rule).
+  - This script SENDS NOTHING. It produces drafts for the ops team to review
+    and send manually (SYMBIOSIS Law 5).
+
+Usage:
+  python scripts/s7_yield_draft_local.py --segment S1 --limit 10
+  python scripts/s7_yield_draft_local.py --all --limit 5        # all segments
+  python scripts/s7_yield_draft_local.py --segment S1 --dry-run  # no Ollama, list only
+
+Exit codes: 0 ok · 2 Ollama down · 3 DB unreachable · 4 bad args
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+# --- config ---------------------------------------------------------------
+PSQL = os.environ.get("PSQL_BIN", "/opt/homebrew/bin/psql")
+DSN = "postgresql://nuzantara_readonly@127.0.0.1:15432/nuzantara_rag?sslmode=disable"
+KEYCHAIN_SERVICE = "nuzantara-postgres-readonly"
+OLLAMA_URL = "http://localhost:11434/api/generate"
+OLLAMA_MODEL = os.environ.get("S7_OLLAMA_MODEL", "qwen3.5:9b")
+STAGING = Path(os.environ.get("S7_STAGING", str(Path.home() / ".nuzantara-staging" / "s7-yield")))
+
+# Segment SQL. Each returns the per-client fields the drafter needs.
+# assigned_to is an internal Bali Zero team email (NOT client PII).
+SEGMENTS: dict[str, dict] = {
+    "S1": {
+        "label": "Visa/KITAS renewal pipeline (expiring 0-90d)",
+        "pitch": "renewal of their expiring permit (and KITAP eligibility check if applicable)",
+        "sql": """
+            SELECT DISTINCT c.id, c.full_name, c.nationality, c.assigned_to,
+                   v.document_type, v.days_until_expiry, v.expiry_date
+            FROM clients c
+            JOIN client_expiry_alerts_view v ON v.client_id = c.id
+            WHERE c.deleted_at IS NULL
+              AND v.document_type IN ('visa','kitas','e-visa','e_visa','telex_visa')
+              AND v.days_until_expiry BETWEEN 0 AND 90
+            ORDER BY v.days_until_expiry ASC
+        """,
+    },
+    "S2": {
+        "label": "Expired-permit win-back (visa/kitas already expired)",
+        "pitch": "re-activating their lapsed permit before penalties accrue",
+        "sql": """
+            SELECT DISTINCT c.id, c.full_name, c.nationality, c.assigned_to,
+                   v.document_type, v.days_until_expiry, v.expiry_date
+            FROM clients c
+            JOIN client_expiry_alerts_view v ON v.client_id = c.id
+            WHERE c.deleted_at IS NULL
+              AND v.document_type IN ('visa','kitas','e-visa','e_visa','telex_visa')
+              AND v.days_until_expiry < 0
+            ORDER BY v.days_until_expiry DESC
+        """,
+    },
+    "S3": {
+        "label": "Passport expiring 0-180d (blocks future visa work)",
+        "pitch": "renewing their passport early so upcoming visa work is not blocked",
+        "sql": """
+            SELECT DISTINCT c.id, c.full_name, c.nationality, c.assigned_to,
+                   v.document_type, v.days_until_expiry, v.expiry_date
+            FROM clients c
+            JOIN client_expiry_alerts_view v ON v.client_id = c.id
+            WHERE c.deleted_at IS NULL AND v.document_type='passport'
+              AND v.days_until_expiry BETWEEN 0 AND 180
+            ORDER BY v.days_until_expiry ASC
+        """,
+    },
+    "S4": {
+        "label": "Active client, no contact 120d+ (relationship health)",
+        "pitch": "a quick check-in on their current status and any pending needs",
+        "sql": """
+            SELECT c.id, c.full_name, c.nationality, c.assigned_to,
+                   'last_contact' AS document_type, NULL::int AS days_until_expiry,
+                   c.last_interaction_date::date AS expiry_date
+            FROM clients c
+            WHERE c.deleted_at IS NULL AND c.status='active'
+              AND (c.last_interaction_date IS NULL OR c.last_interaction_date < now()-interval '120 days')
+            ORDER BY c.last_interaction_date ASC NULLS FIRST
+        """,
+    },
+    "S5": {
+        "label": "Corporate (NPWP/NIB) with zero practice (tax/compliance expansion)",
+        "pitch": "a monthly tax & compliance retainer for their Indonesian company (LKPM, SPT, bookkeeping)",
+        "sql": """
+            SELECT c.id, c.full_name, c.nationality, c.assigned_to,
+                   'corporate' AS document_type, NULL::int AS days_until_expiry, NULL::date AS expiry_date
+            FROM clients c
+            LEFT JOIN practices p ON p.client_id=c.id
+            WHERE c.deleted_at IS NULL AND (c.npwp IS NOT NULL OR c.nib IS NOT NULL) AND p.id IS NULL
+            ORDER BY c.created_at DESC
+        """,
+    },
+    "S6": {
+        "label": "WhatsApp-warm (msg <60d) with no practice (warm conversion)",
+        "pitch": "turning their recent enquiry into a concrete service plan",
+        "sql": """
+            SELECT c.id, c.full_name, c.nationality, c.assigned_to,
+                   'wa_warm' AS document_type, NULL::int AS days_until_expiry, max(w.last_message_at)::date AS expiry_date
+            FROM clients c
+            JOIN whatsapp_contacts w ON w.phone_normalized=c.phone_normalized
+            LEFT JOIN practices p ON p.client_id=c.id
+            WHERE c.deleted_at IS NULL AND p.id IS NULL AND w.last_message_at >= now()-interval '60 days'
+            GROUP BY c.id, c.full_name, c.nationality, c.assigned_to
+            ORDER BY max(w.last_message_at) DESC
+        """,
+    },
+    "S8": {
+        "label": "Repeat buyers (2+ paid practices) — loyalty/premium",
+        "pitch": "a priority/retainer arrangement reflecting their repeat business with us",
+        "sql": """
+            SELECT c.id, c.full_name, c.nationality, c.assigned_to,
+                   'repeat' AS document_type,
+                   count(*) FILTER (WHERE lower(coalesce(p.payment_status,''))='paid') AS days_until_expiry,
+                   NULL::date AS expiry_date
+            FROM clients c JOIN practices p ON p.client_id=c.id
+            WHERE c.deleted_at IS NULL
+            GROUP BY c.id, c.full_name, c.nationality, c.assigned_to
+            HAVING count(*) FILTER (WHERE lower(coalesce(p.payment_status,''))='paid') >= 2
+            ORDER BY 6 DESC
+        """,
+    },
+}
+
+
+def lang_for(nationality: str | None) -> str:
+    """Infer draft language from nationality (language pref column is unpopulated)."""
+    n = (nationality or "").strip().lower()
+    if any(k in n for k in ("indonesia", "indonesian", "wni")):
+        return "Indonesian (Bahasa Indonesia)"
+    if any(k in n for k in ("ital", "italiana")):
+        return "Italian"
+    if any(k in n for k in ("españ", "espan", "spanish", "esp")):
+        return "Spanish"
+    if any(k in n for k in ("franç", "franc", "french", "fra")):
+        return "French"
+    if any(k in n for k in ("deutsch", "german", "deu")):
+        return "German"
+    if any(k in n for k in ("russ", "ukrain", "ukr")):
+        return "English"  # safe lingua franca for RU/UA expat clients
+    return "English"
+
+
+def get_pgpassword() -> str:
+    out = subprocess.run(
+        ["security", "find-generic-password", "-s", KEYCHAIN_SERVICE, "-w"],
+        capture_output=True, text=True,
+    )
+    if out.returncode != 0 or not out.stdout.strip():
+        sys.exit("[S7] FATAL: readonly Keychain creds missing (nuzantara-postgres-readonly)")
+    return out.stdout.strip()
+
+
+def fetch_rows(sql: str, pgpass: str, limit: int) -> list[dict]:
+    env = dict(os.environ, PGPASSWORD=pgpass)
+    full = f"COPY (SELECT row_to_json(t) FROM ({sql.strip().rstrip(';')} LIMIT {int(limit)}) t) TO STDOUT"
+    proc = subprocess.run([PSQL, DSN, "-tA", "-c", full], capture_output=True, text=True, env=env)
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr)
+        sys.exit(3)
+    rows = []
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if line:
+            rows.append(json.loads(line))
+    return rows
+
+
+def ollama_up() -> bool:
+    try:
+        urllib.request.urlopen("http://localhost:11434/api/tags", timeout=3).read()
+        return True
+    except Exception:
+        return False
+
+
+def draft_pitch(name: str, nationality: str, language: str, seg_pitch: str,
+                doc_type: str, days: int | None, expiry) -> str:
+    fact = ""
+    if doc_type in ("visa", "kitas", "e-visa", "e_visa", "telex_visa") and days is not None:
+        fact = f"Their {doc_type.upper()} expires in {days} days ({expiry})."
+    elif doc_type == "passport" and days is not None:
+        fact = f"Their passport expires in {days} days ({expiry})."
+    elif doc_type == "repeat":
+        fact = f"They have completed {days} paid services with Bali Zero."
+    elif doc_type == "corporate":
+        fact = "They have an Indonesian company (NPWP/NIB on file) but no active service with us."
+    prompt = (
+        f"You are a Bali Zero account executive writing a WhatsApp message to a client.\n"
+        f"Client first name: {name}. Write in {language}.\n"
+        f"Context: {fact}\n"
+        f"Goal: invite them to discuss {seg_pitch}.\n"
+        f"Rules: 40-80 words. Warm but professional. NO marketing buzzwords, NO emoji, "
+        f"NO 'exciting opportunity'. Reference the specific fact above. End with a concrete "
+        f"next step (a suggested 20-30 min call this week). Output ONLY the message text.\n/no_think"
+    )
+    body = json.dumps({"model": OLLAMA_MODEL, "prompt": prompt, "stream": False,
+                       "think": False, "options": {"temperature": 0.4}}).encode()
+    req = urllib.request.Request(OLLAMA_URL, data=body, headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=180) as r:
+        resp = json.loads(r.read())
+    txt = (resp.get("response") or "").strip()
+    # qwen may wrap in <think>...</think>; strip if present
+    if "</think>" in txt:
+        txt = txt.split("</think>", 1)[1].strip()
+    return txt
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--segment", choices=list(SEGMENTS))
+    ap.add_argument("--all", action="store_true")
+    ap.add_argument("--limit", type=int, default=10)
+    ap.add_argument("--dry-run", action="store_true", help="list opportunities, skip Ollama")
+    args = ap.parse_args()
+    if not args.segment and not args.all:
+        ap.error("pass --segment <S#> or --all")
+
+    if not args.dry_run and not ollama_up():
+        sys.exit("[S7] FATAL: Ollama down — NO cloud fallback (UU PDP). Aborting.")
+
+    pgpass = get_pgpassword()
+    STAGING.mkdir(parents=True, exist_ok=True)
+    targets = list(SEGMENTS) if args.all else [args.segment]
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    summary = {}
+
+    for seg in targets:
+        meta = SEGMENTS[seg]
+        rows = fetch_rows(meta["sql"], pgpass, args.limit)
+        drafted = 0
+        out_path = STAGING / f"{seg}-{ts}-drafts.md"
+        with out_path.open("w") as f:
+            f.write(f"# S7 Yield drafts — {seg}: {meta['label']}\n")
+            f.write(f"_Generated {ts} · LOCAL Ollama {OLLAMA_MODEL} · DRAFT ONLY (do not auto-send)_\n\n")
+            for row in rows:
+                cid = row["id"]
+                name = (row.get("full_name") or "there").split()[0]
+                nat = row.get("nationality")
+                lang = lang_for(nat)
+                f.write(f"## client_id={cid} · owner={row.get('assigned_to') or '(unassigned)'} · lang={lang}\n")
+                if args.dry_run:
+                    f.write(f"- {row.get('document_type')} days={row.get('days_until_expiry')} expiry={row.get('expiry_date')}\n\n")
+                else:
+                    try:
+                        pitch = draft_pitch(name, nat or "", lang, meta["pitch"],
+                                            row.get("document_type"), row.get("days_until_expiry"),
+                                            row.get("expiry_date"))
+                        f.write(f"**Pitch ({lang})**:\n> {pitch}\n\n")
+                        drafted += 1
+                    except Exception as e:  # noqa: BLE001
+                        f.write(f"_draft failed: {type(e).__name__}_\n\n")
+                # privacy log: client_id ONLY, never name
+                print(f"[S7] {seg} client_id={cid} drafted={not args.dry_run}")
+        summary[seg] = {"pulled": len(rows), "drafted": drafted, "file": str(out_path)}
+        print(f"[S7] {seg}: pulled={len(rows)} drafted={drafted} -> {out_path}")
+
+    print("[S7] SUMMARY " + json.dumps(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## S7 — CRM Yield Mining (ONDA 2, Pro/Ollama, PII-safe)

Connects the CRM (11,702 gross rows → **1,450 actionable** non-deleted clients) to **revenue signals** and extends the weekly `yield-optimizer` agent. The legacy agent referenced a non-existent `crm_clients` table + columns (`engagement_score`, `total_spend_ytd`, `kitap_expiry_date`); this PR maps every rule to the **real** schema (`clients`, `practices`, `client_expiry_alerts_view`) with reproducible SQL.

### Revenue segments (distinct non-deleted clients, 2026-06-02)
| Seg | Signal | Clients | Pri |
|---|---|--:|---|
| S1 | Visa/KITAS renewal 0–90d | **61** | P0 |
| S2 | Expired-permit win-back | **67** | P0 |
| S3 | Passport <180d (pre-block) | 9 | P2 |
| S4 | Active, no-contact 120d+ | **403** | P1 |
| S5 | Corporate (NPWP/NIB) no practice — tax expansion | **286** | P1 |
| S6 | WhatsApp-warm <60d, no practice | 30 | P1 |
| S7 | Unconverted leads (nurture, not 1:1) | 712 | P3 |
| S8 | Repeat buyers (2+ paid) | 47 | P2 |

Headline finding: **S1+S2 = 128 time-sensitive permit clients** (renewal/recovery, near-certain need) + **S5 = 286 corporate clients with NPWP/NIB but zero service** (largest untapped recurring-revenue pool: monthly tax retainers). Total quoted pipeline to date: IDR 4.01B across 444 practices.

### PII contract (UU PDP / SYMBIOSIS Law 2) — verifiable
- Committed files carry **only aggregate counts + internal team-owner routing**. Zero client names/passport/phone/email/IDs.
- Per-client PII read via **read-only** Postgres role → drafted by **LOCAL Ollama qwen3.5:9b** → written to gitignored `~/.nuzantara-staging/s7-yield/`. **No client data ever reached a cloud LLM** (incl. me — I only ran aggregate COUNT queries). Logs carry `client_id` only.
- **DRAFT ONLY** — nothing sent. Ops team reviews + sends manually (Law 5).

### Pilot (local Ollama, 2026-06-02)
S1 drafts: 54/65/57 words · S5 drafts: 65/57/57 words — all in spec (40–80 words, no emoji, no buzzwords, language inferred from nationality).

### Data caveats (documented in FROZEN)
- `practices` only spans ~4.5mo (Jan–Jun 2026) → **no practice-age dormancy exists** (classic "dormant 6mo+" = 0, real not bug).
- `last_interaction_date` sparse (338/1450); `client_preferences.language` empty → language from nationality.

### Files
- `research/crm/S7-yield-FROZEN.json` — aggregate segments + routing (no PII)
- `research/crm/S7-yield-signals-spec.md` — extended ruleset + caveats + weekly cap-20 plan
- `scripts/s7_yield_draft_local.py` — PII-safe local drafter (readonly PG → Ollama → local staging)
- Also patched live `~/.claude/agents/yield-optimizer.md` (global, not in repo) to correct broken column refs and point at this spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)