### PR TITLE
fix(agent-library): robust evolver guard (combined EXIT trap) + program/* prune

### DIFF
--- a/scripts/agent-library-evolver-run.sh
+++ b/scripts/agent-library-evolver-run.sh
@@ -89,7 +89,9 @@ _restore_deploy_branch() {
             ;;
     esac
 }
-trap _restore_deploy_branch EXIT
+# NOTE: do NOT register a standalone EXIT trap here — bash allows only
+# one EXIT trap and the advisory-lock trap (acquire_lock) would overwrite
+# it. _restore_deploy_branch is invoked from the combined trap below.
 
 # ─── CLI parsing ─────────────────────────────────────────────────────
 
@@ -267,7 +269,12 @@ acquire_lock() {
         log "advisory lock acquired (key=${PG_LOCK_KEY})"
         # Best-effort release on EXIT (Bash trap)
         # shellcheck disable=SC2064
-        trap "psql '${DATABASE_URL}' -c 'SELECT pg_advisory_unlock(${PG_LOCK_KEY});' >/dev/null 2>&1 || true" EXIT
+        # Combined EXIT trap: release the advisory lock AND restore deploy/main
+        # (bash keeps only ONE EXIT trap, so both actions must live here — a
+        # separate `trap _restore_deploy_branch EXIT` would silently overwrite
+        # this one, S13-P6b regression discovered 2026-06-02).
+        # shellcheck disable=SC2064
+        trap "psql '${DATABASE_URL}' -c 'SELECT pg_advisory_unlock(${PG_LOCK_KEY});' >/dev/null 2>&1 || true; _restore_deploy_branch" EXIT
         return 0
     fi
     log "another run holds the advisory lock (key=${PG_LOCK_KEY}) — exiting"
@@ -364,6 +371,17 @@ if [[ ! -f "${EVOSKILL_CONFIG}" ]]; then
 fi
 
 run_evoskill() {
+    # S13-P6b (2026-06-02): evoskill creates program/* branches inside REPO_ROOT
+    # and leaves them; a prior run's branches make this run's `git checkout -b
+    # program/iter-skill-N` fail (exit 128, already-exists). Prune them first.
+    # Safe: program/* are evoskill-only artifacts, never pushed, regenerated each
+    # run. The base is recreated clean by the fixed writer.
+    if git -C "${REPO_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        for _pb in $(git -C "${REPO_ROOT}" branch --list 'program/*' --format='%(refname:short)' 2>/dev/null); do
+            git -C "${REPO_ROOT}" branch -D "${_pb}" >/dev/null 2>&1 \
+                && log "pruned stale evoskill branch ${_pb}" || true
+        done
+    fi
     log "invoking uv run evoskill run --config ${EVOSKILL_CONFIG}"
     # Codex panel R5 BLOCKING #2 fix: evoskill CLI does NOT support
     # `--output-telemetry`. Cost is reported via the post-run RunReport


### PR DESCRIPTION
## Problem

Follow-up to #1045. Two residual defects in the evolver↔repo integration, both
discovered by a real prod run:

1. **Guard never fired.** #1045 added `_restore_deploy_branch` via
   `trap ... EXIT` at the top of the script. But `acquire_lock()` later registers
   a second `trap ... EXIT` for the advisory-lock release. **Bash keeps only one
   EXIT trap** → the lock trap silently overwrote the guard → a prod run left the
   deploy worktree parked on `program/iter-skill-10` (next `wr2-deploy-pull` would
   break on the wrong-branch gate).

2. **program/\* branch accumulation.** evoskill creates one `program/*` branch per
   iteration inside `REPO_ROOT` and leaves them. The next run's
   `git checkout -b program/iter-skill-N` then fails with **exit 128**
   (already-exists), FATAL-ing the entire run.

## Fix

1. Merge both actions into the single advisory-lock EXIT trap:
   `... pg_advisory_unlock ...; _restore_deploy_branch`. Standalone guard trap
   removed. `_restore_deploy_branch` now always runs on exit.
2. Prune stale `program/*` branches at the start of `run_evoskill()` before
   invoking evoskill. Safe — they are evoskill-only artifacts, never pushed,
   regenerated each run.

## Verification (real run on Pro, patched worktree)

| Check | Result |
|---|---|
| iterations | **10/10, exit 0**, $0.11 |
| `exit status 128` | **0** (prune works) |
| guard executed on exit | **yes** — logged the restore attempt (WARN only in the test worktree because `deploy/main` is checked out in the prod worktree; in prod `REPO_ROOT` IS the `deploy/main` worktree so the checkout succeeds) |

## Known follow-ups (NOT in this PR)

- **#5** DeepSeek LLM scorer returns `''` → `could not parse response as float` →
  0 proposals. Loop runs but evolves nothing until fixed.
- **Structural**: isolate evoskill git-ops to a dedicated registry repo. The guard
  + prune here are belt-and-suspenders until that refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
