### PR TITLE
fix(wr2): catch asyncpg.InterfaceError in canva lease watchdog (W64)

### DIFF
--- a/scripts/wr2_canva_lease_watchdog.py
+++ b/scripts/wr2_canva_lease_watchdog.py
@@ -37,7 +37,7 @@ async def _connect_with_retry(dsn: str) -> asyncpg.Connection | None:
     for attempt in range(1, MAX_RETRIES + 1):
         try:
             return await asyncpg.connect(dsn, timeout=CONNECT_TIMEOUT_SEC)
-        except (asyncio.TimeoutError, OSError, asyncpg.PostgresError) as e:
+        except (asyncio.TimeoutError, OSError, asyncpg.PostgresError, asyncpg.InterfaceError) as e:
             if attempt == MAX_RETRIES:
                 logger.warning(
                     "connect exhausted %d retries (last error: %s: %s); skipping tick",


### PR DESCRIPTION
Closes scar **W64** (reopened by S15 ONDA-1 symbiosis audit).

`scripts/wr2_canva_lease_watchdog.py:40` connect-retry caught `asyncpg.PostgresError` but not its sibling `asyncpg.InterfaceError` (raised on connection loss). A watchdog tick could crash instead of skipping. One-line fix to the except tuple.

- Verified by `scripts/lint_asyncpg_except_completeness.py` → green (no violations).
- Branch rebased on fresh origin/main (not the stale 40-behind base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)