### PR TITLE
docs(visa): S9 client-case dossiers — Marc Buckner + Paco Pak

### DIFF
--- a/research/visa/clients/2026-06-03-marc-buckner-S9-dossier.md
+++ b/research/visa/clients/2026-06-03-marc-buckner-S9-dossier.md
@@ -1,0 +1,92 @@
+---
+date: 2026-06-03
+domain: visa
+session: ONDA-3 S9 client-case-dossier
+client_case: marc-buckner-content-creator-3mo-bali
+status: DRAFT — NEEDS-ANTONELLO (income proof + foreign-employer-contract structure + barter-deal disclosure pending)
+pricing_source: bali_zero_official_prices_2026.json (version 2026.1, effective 2026-01-01) via PricingTool source-of-truth
+devils_advocate: PASS-after-fix (Codex flagged NEEDS-FIX x3, 2 accolti + fix applicati, see section Devils-Advocate)
+eligibility_source: research/visa/2026-05-31-marc-buckner-c5a-e33g-barter-case.md (NB-2 Kepmen M.IP-08.GR.01.01/2025 verbatim + 7 web sources convergent)
+author: S9 orchestrator (Claude Opus 4.8) — eligibility from S6/Marc-case ground truth, cost from PricingTool
+---
+
+# Dossier cliente — Marc Buckner (Content Creator, 3 mesi Bali)
+
+> **STATUS: BOZZA — NON SEND-READY.** Eligibility verde e cost da PricingTool verde, ma due input cliente mancanti bloccano la quote finale: (1) prova reddito estero >= USD 60k/anno, (2) natura dei deal con hotel (barter informale vs contrattualizzabile via entita estera). Vedi sezione Documenti mancanti.
+
+## 1. Profilo cliente
+
+- **Nome**: Marc Buckner (IG @marcbuckner)
+- **Nazionalita**: Sudafricana (WNA)
+- **Audience**: 2M+ follower — travel/lifestyle/fitness/motivation/technology/animals
+- **Soggiorno**: ~3 mesi Bali, giugno–settembre 2026 (hotel + ville)
+- **Reddito**: brand partnership sudafricane + internazionali (fonte estera)
+- **Lead**: arrivato tramite influencer contatto di Antonello (Meta Business Suite)
+
+## 2. Eligibility (ground-truth NB-2, Kepmen M.IP-08.GR.01.01/2025 verbatim)
+
+| Visto | Eleggibile per Marc | Verdetto |
+|---|---|---|
+| **E33G Remote Worker KITAS** | Si — copre SOLO la creazione di contenuti pagata dall'estero, no sponsor | UNICA VIA SENSATA per la GAMBA reddito-estero (vedi caveat contratto sotto) |
+| **C5A** (content creator) | Definito legalmente MA non selezionabile sul portale evisa (Data Belum Tersedia 11+ mesi); vieta barter ("atau sejenisnya") | NON OPERATIVO — non vendere (panel 3-LLM 2026-05-28: WAIT) |
+| **C7/C7C** (arti/cultura) | NO — copre performance/chef-demo, non travel/lifestyle | categoria sbagliata |
+| **E23** (lavoro sponsorizzato) | Tecnicamente si se hotel fa da sponsor (RPTKA + DKP-TKA) | economicamente assurdo per 3 mesi |
+| **E28A** (investor PT PMA) | Si ma modal IDR 10 mld + capital lock 12 mesi | fuori scope 3 mesi |
+
+**Requisiti E33G**: reddito >= **USD 60.000/anno** da fonte estera + saldo **USD 2.000** + **contratto con datore di lavoro estero** + assicurazione. NO sponsor. Validita 1 anno (estendibile, max 2). Apply online evisa.
+
+**CAVEAT BLOCCANTE — gate "contratto datore estero" per un creator autonomo** (devils-advocate finding, S9): E33G e' costruito attorno a un *remote worker* con un *employment contract* presso un'azienda estera. Marc e' un creator **autonomo** (brand partnership multiple, non un singolo datore). Va verificato come la sua struttura reddituale soddisfa il requisito "contratto datore estero": (a) tramite la sua entita/societa estera che lo "impiega", oppure (b) contratti di servizio con i brand documentabili come rapporto di lavoro estero. Se nessuna delle due regge, l'E33G NON e' automaticamente concedibile e va rivalutata la struttura (es. PT PMA self-sponsor, fuori scope 3 mesi). **Questo e' un secondo blocco oltre alla soglia reddito — non solo "income + barter docs".**
+
+**Vincolo critico barter** (NB-2 source_id 09d6e396, RESTRIZIONI CRITICHE verbatim): E33G VIETA di lavorare per aziende indonesiane e generare reddito da fonti locali. Il barter "camera-per-promo" con hotel di Bali = lavoro non autorizzato indipendentemente dal pagamento in natura ("atau sejenisnya" copre il compenso in natura). La triangolazione estera (hotel paga la societa SA) riduce ma NON elimina il rischio — NB-2 declina di dichiararla sicura (zona grigia ad alto rischio per profilo 2M follower).
+
+**Enforcement context**: Operasi Dharma Dewata (lanciata 15 apr 2026): 62 WNA fermati in ~20 giorni, target esplicito influencer/content creator, ban re-entry 5y/10y/a-vita. Profilo Marc = target diretto Tim Pora.
+
+## 3. Cost — PricingTool (Bali Zero Official Prices 2026, version 2026.1)
+
+> Prezzi da `bali_zero_official_prices_2026.json` (source-of-truth dichiarata in `pricing_service.py:4,30-31`). NESSUN prezzo da DeepSeek o user-input.
+
+| Voce | Configurazione | Prezzo Bali Zero (IDR) |
+|---|---|---|
+| **E33G Remote Worker KITAS** | Offshore (apply da fuori IDN, raccomandato per nuovo ingresso) | **13.000.000** |
+| E33G Remote Worker KITAS | Altus/Onshore (se gia in Indonesia) | 14.000.000 |
+| E33G Remote Worker — Extend | (non rilevante per singolo soggiorno 3 mesi) | 10.000.000 |
+
+**Quote raccomandata**: E33G Offshore = **IDR 13.000.000** (fee servizio Bali Zero, listino pacchetto 2026). Per 3 mesi NON serve extend.
+
+Costo verde MA quote non send-ready finche income docs non confermano la soglia USD 60k (vedi sezione 5).
+
+## 4. Timeline
+
+- **E33G Offshore**: apply online evisa → approvazione e-VITAS → ingresso → conversione KITAS onshore. Avviare la pratica PRIMA dell'ingresso (offshore) per non entrare con visto turistico e dover convertire onshore (piu caro: 14M). Il listino 2026 non pubblica SLA esplicito; per urgenza esistono pacchetti Urgent 1-3 giorni a parte.
+- **Finestra cliente**: giugno–settembre 2026.
+
+## 5. Risk + documenti mancanti (BLOCCANTI per send)
+
+| Rischio | Mitigazione |
+|---|---|
+| **Barter hotel = lavoro non autorizzato** | Tenere TUTTI i deal hotel FUORI Indonesia: contrattualizzare + pagare l'entita estera di Marc. MAI barter locale informale. |
+| **Profilo alto = target Dharma Dewata** | E33G corretto + zero attivita locale visibile in pagamento-natura. |
+| **Soglia reddito non provata** | Richiedere prova reddito estero >= USD 60k/anno (brand contract / payslip / Payoneer 3-6 mesi). |
+| **Saldo non provato** | Richiedere conferma saldo USD 2.000. |
+
+**Documenti da richiedere a Marc (pre-quote send)**:
+1. Prova reddito da fonte non-indonesiana (>= USD 60k/anno).
+2. Conferma saldo USD 2.000.
+3. **Struttura contrattuale del rapporto di lavoro estero** (entita/societa che lo impiega O contratti brand documentabili) — necessaria per soddisfare il gate "contratto datore estero" E33G per un creator autonomo.
+4. Quadro deal hotel: barter informale o contrattualizzabile via entita estera?
+
+## 6. Deliverable
+
+- Questo dossier (`research/visa/clients/2026-06-03-marc-buckner-S9-dossier.md`).
+- Documento cliente brand A4 gia esistente: `2026-05-31-marc-buckner-visa-guidance.pdf` (2 pagine).
+- Quote E33G IDR 13.000.000 — da finalizzare a documenti ricevuti.
+
+## Devils-Advocate (gate pre-output)
+
+Prima passata Codex read-only: **NEEDS-FIX** (3 finding). Adjudicazione + fix applicati:
+
+1. *"E33G framing troppo netto come soluzione del caso intero"* — ACCOLTO: tabella eligibility e verdetto ora chiariscono che E33G copre SOLO la gamba reddito-estero, non il barter ne risolve l'intero caso.
+2. *"gate contratto-datore-estero non trattato come blocco"* — ACCOLTO (finding piu importante): aggiunto CAVEAT BLOCCANTE — Marc e' un creator autonomo, il requisito "contratto datore estero" E33G va verificato e puo non essere automatico. Aggiunto come doc mancante #3.
+3. *"triangolazione hotel-estero troppo pulita"* — PARZIALE: il testo gia diceva "riduce ma NON elimina... zona grigia ad alto rischio". Lasciato com'e (gia conforme alla source NB-2 che declina di dichiararla sicura).
+
+**Verdetto post-fix: PASS** (con 2 blocchi NEEDS-ANTONELLO espliciti: soglia reddito + struttura contrattuale datore estero). Cost esclusivamente da PricingTool; C5A escluso come non-operativo; nessun KBLI richiesto (caso visa puro). Math n/a per questo caso.

--- a/research/visa/clients/2026-06-03-paco-pak-S9-dossier.md
+++ b/research/visa/clients/2026-06-03-paco-pak-S9-dossier.md
@@ -1,0 +1,87 @@
+---
+date: 2026-06-03
+domain: property
+session: ONDA-3 S9 client-case-dossier
+client_case: paco-pak-seseh-shophouse-lease
+status: DRAFT — NEEDS-ANTONELLO (legal-service quote = "Contact for quote" in listino; HIGH cures unresolved)
+pricing_source: bali_zero_official_prices_2026.json (version 2026.1) via PricingTool source-of-truth
+devils_advocate: PASS (Codex read-only adversarial pass + DeepSeek v4-pro math verification)
+eligibility_source: research/property/paco-pak-due-diligence-2026-05-22.html (DD memo) + research/property/2026-06-02-foreign-property-rights-hak-pakai-hgb-leasehold.md (S6 NB-5 ground truth)
+math_verification: DeepSeek v4-pro (model verified, NOT reasoner alias) — lease escalation 2-scenario
+author: S9 orchestrator (Claude Opus 4.8)
+---
+
+# Dossier cliente — Paco Pak / Seseh Shophouse Lease
+
+> **STATUS: BOZZA — NON SEND-READY.** Verdetto DD esistente = "Hold / cure first" (4 rischi HIGH aperti). Il costo del servizio legale Bali Zero per questo caso e' "Depend (Contact for quote)" nel listino 2026 → quote NON auto-generabile, marcata NEEDS-ANTONELLO. La due diligence sottostante e' completa.
+
+## 1. Profilo cliente / oggetto
+
+- **Cliente**: Paco Pak (tenant nel draft: Michele Cangiano)
+- **Oggetto**: lease 10 anni (1 apr 2026 – 31 mar 2036) di 2 unita shophouse + ~60 m2 terreno retrostante
+- **Localita**: Jalan Raya Seseh, Munggu, Mengwi, Badung
+- **Titolo**: Hak Milik No. 22030509.1.03453, NIB 22030509.02627, area 935 m2, owner **Pura Puseh Desa Adat Munggu**
+- **Firmatario First Party**: I Made Suwinda, S.Pd. (NON l'owner BPN)
+- **Rent base**: IDR 260.000.000/anno (240M shophouse + 20M terreno), +7% escalation, totale tabella contratto IDR 2.943.156.000
+
+## 2. Eligibility / struttura legale (ground-truth S6 NB-5 + DD memo)
+
+Questo e' un **leasehold (Hak Sewa, PP 44/1994)** — la struttura piu accessibile per WNA (solo passaporto, no KITAS, no BPN, no soglia investimento) ma anche **la piu rischiosa** (protezione = solo il contratto notarile PPAT, nessuna registrazione BPN).
+
+| Aspetto | Stato | Ground-truth |
+|---|---|---|
+| WNA puo prendere leasehold commerciale | Si | S6: Hak Sewa, qualsiasi WNA, uso commerciale se da contratto |
+| Durata 10 anni | OK | Sotto i 30 anni → nessun rifiuto PPAT atteso |
+| Uso commerciale (shophouse) | **A RISCHIO** | BPN dice "sawah"; RDTR appare zona agricola/food-crop |
+| Autorita a concedere il lease | **A RISCHIO** | Owner BPN = Pura/Desa Adat; firmatario = individuo |
+
+**Vincolo zoning critico (S6 NB-5)**: costruire/operare strutture commerciali in **Zona Pertanian (P1 sawah / P2)** = divieto assoluto, demolizione forzata + pidana (Perda Bali 4/2026 criminalizza conversione sawah→commerciale, protegge subak UNESCO). Precedente: 21 lug 2025 demolizioni Bingin Beach. Il caso Paco Pak tocca esattamente questo rischio (BPN "sebidang tanah sawah").
+
+## 3. Risk register (dalla DD memo — 4 HIGH bloccanti)
+
+| Rischio | Finding | Cura richiesta |
+|---|---|---|
+| **HIGH — Owner/signatory mismatch** | BPN owner = Pura Puseh Desa Adat Munggu; firma = I Made Suwinda | Catena autorita formale: delibera Pura/Desa Adat, lettera nomina, procura, KTP/NPWP, conferma PPAT che il firmatario puo concedere lease commerciale 10 anni |
+| **HIGH — Zoning/use uncertainty** | BPN "sawah"; RDTR appare agricolo/food-crop | KRK/PKKPR/RDTR ufficiale per NIB/NOP esatto + conferma scritta uso commerciale ammesso (DPMPTSP/PUPR Badung) |
+| **HIGH — Building legality missing** | Nessun PBG/IMB, SLF, dettaglio tassa edilizia | Richiedere PBG/IMB, SLF, as-built, approvazione uso/funzione, permessi ristrutturazione |
+| **HIGH — Lease object not tied to title** | Lease cita 2 unita + 60 m2 ma non allega plot plan rilevato dentro i 935 m2 | Allegare site plan firmato con confini, misure, accesso, parcheggio, utilities, allocazione terreno retrostante |
+| MEDIUM — Payment schedule ambiguity | "7% increase" ambiguo (annuale vs block) | Riscrivere Art. 3 con tabella datata, periodo esatto, late fee, trattamento fiscale |
+| MEDIUM — Template blanks / dispute forum | Dati parti + Tribunale incompleti nel template | Completare identita parti, indirizzi, lingua, foro |
+| MEDIUM — Assignment/sublease restriction | Art. 5 vieta cessione/sublease senza consenso scritto | Aggiungere clausola cessione controllata |
+| MEDIUM — No operational rights detail | Solo "lawful business use" | Aggiungere permitted-use schedule + obblighi cooperazione licenze |
+
+## 4. Math — verifica escalation (DeepSeek v4-pro, modello verificato)
+
+Discrepanza Art. 3 quantificata. Base IDR 260M/anno, 10 anni, "7% increase":
+
+- **Scenario A (7% compound annuale)**: IDR 260M × (1.07^10 − 1)/0.07 = **IDR 3.592.276.470**
+- **Scenario B (7% per payment-block, come da tabella contratto)**: 260M + 3×278.2M + 3×297.674M + 3×318.511M = **IDR 2.943.155.000** (contratto dichiara 2.943.156.000 — delta 1.000 IDR arrotondamento)
+- **Differenza A − B**: **IDR 649.121.470**
+
+Sanity check manuale orchestratore: 1.07^10 ≈ 1.9672, fattore geom ≈ 13.817, ×260M ≈ 3.592 mld → concorda con DeepSeek. La tabella contratto segue lo Scenario B (block-based). **Il contratto e' aritmeticamente coerente sotto interpretazione block**, ma la clausola va resa esplicita per evitare contestazione downstream (potenziale esposizione +649M se un tribunale leggesse "annuale").
+
+## 5. Cost — PricingTool (Bali Zero Official Prices 2026)
+
+> Da `bali_zero_official_prices_2026.json`. NESSUN prezzo inventato.
+
+| Voce listino | Prezzo (IDR) | Nota |
+|---|---|---|
+| **Legal Real Estate / lease DD** | listino company_services: "Akta Perubahan" e simili **"Depend (Contact for quote)"** | Il servizio legale/DD su misura NON ha prezzo fisso a listino → quote richiede input Bali Zero |
+| Voci ancillari potenzialmente rilevanti (se il cliente procede) | — | NPWPD Registration 2.500.000; NPWP Personal + Coretax 1.000.000 (se Paco apre struttura fiscale locale) |
+
+**Cost status: NEEDS-ANTONELLO.** Il listino 2026 NON contiene un prezzo fisso per la due-diligence/contract-review immobiliare su misura ("Contact for quote"). Coerente con la prassi: la DD legale e' a preventivo. NON invento una cifra (sarebbe esattamente lo STRUCT-1 / lo "[OPINIONE - SPECULATIVE pricing]" che il caso C5A mostra come anti-pattern).
+
+## 6. Timeline
+
+- **Pre-firma (cure)**: 4 HIGH da risolvere con documenti originali + conferma PPAT/legale. Tempi dipendono da reattivita Pura/Desa Adat + DPMPTSP/PUPR Badung (zoning KRK/PKKPR puo richiedere settimane).
+- **Istruzione immediata (dalla DD memo)**: NESSUN pagamento del deposito IDR 5.000.000, NESSUNA firma, NESSUNA ristrutturazione, NESSUN lancio pubblico finche i HIGH non sono curati con documenti originali.
+
+## 7. Deliverable
+
+- Questo dossier (`research/visa/clients/2026-06-03-paco-pak-S9-dossier.md`).
+- DD memo brand A4 gia esistente: `research/property/paco-pak-due-diligence-2026-05-22.html`.
+- Cure-list (4 HIGH + 4 MEDIUM) sopra = checklist operativa per l'account exec.
+
+## Devils-Advocate (gate pre-output)
+
+Verdetto: **PASS**. Codex read-only adversarial + DeepSeek math + auto-critica. Controlli: (1) zoning sawah→commerciale correttamente flaggato come potenziale pidana (Perda Bali 4/2026); (2) struttura leasehold/Hak Sewa correttamente identificata (NON Hak Milik nominee — owner e' Desa Adat, non un nominee straniero); (3) math escalation verificato 2-scenario, delta 649M coerente con DD memo; (4) cost NON inventato — marcato "Contact for quote" come da listino reale; (5) nessun KBLI allucinato. Residuo legittimo: caso intrinsecamente "Hold/cure" — il dossier riflette lo stato reale, non un difetto del dossier.

--- a/research/visa/clients/S9-cases-FROZEN.json
+++ b/research/visa/clients/S9-cases-FROZEN.json
@@ -1,0 +1,74 @@
+{
+  "session": "ONDA-3 S9 client-case-dossier",
+  "date": "2026-06-03",
+  "orchestrator": "Claude Opus 4.8 (1M context), thin-client M5 -> ssh pro worktree .worktrees/docs-s9-client-cases",
+  "pricing_tool": {
+    "status": "GREEN",
+    "source_of_truth": "apps/backend-rag/backend/data/bali_zero_official_prices_2026.json (version 2026.1, effective 2026-01-01)",
+    "binding_proof": "apps/backend-rag/backend/services/pricing/pricing_service.py lines 4,30-31 declare this JSON as authoritative source-of-truth",
+    "rbac_blocked": false,
+    "note": "Prices read directly from the PricingTool source JSON. NO price from DeepSeek, NO user-input, NO speculation. STRUCT-1 anti-pattern (speculative pricing seen in C5A files as '[OPINIONE - SPECULATIVE pricing]') explicitly avoided."
+  },
+  "math_engine": {
+    "model": "deepseek-v4-pro",
+    "note": "Explicit deepseek-v4-pro used (NOT deprecated deepseek-reasoner alias which silently returns flash). Model field verified in API response. Cross-checked by Codex node re-derivation + manual orchestrator sanity check."
+  },
+  "devils_advocate": {
+    "spalla": "Codex GPT-5.5 (codex exec --sandbox read-only), health-check PONG exit 0 pre-run",
+    "method": "adversarial pass hunting legal error / miscalc / missing regulation / hallucinated KBLI / contradiction; orchestrator adjudicated findings against ground-truth source (not blind obedience)"
+  },
+  "cases": [
+    {
+      "id": "marc-buckner-content-creator-3mo-bali",
+      "domain": "visa",
+      "client": "Marc Buckner (IG @marcbuckner), Sudafricano, content creator 2M+ follower, 3 mesi Bali giu-set 2026",
+      "dossier": "research/visa/clients/2026-06-03-marc-buckner-S9-dossier.md",
+      "eligibility": {
+        "recommended": "E33G Remote Worker KITAS (copre SOLO la gamba reddito-estero)",
+        "rejected": ["C5A (non operativo, portale Data Belum Tersedia)", "C7/C7C (categoria sbagliata)", "E23/E28A (economicamente fuori scope per 3 mesi)"],
+        "source": "research/visa/2026-05-31-marc-buckner-c5a-e33g-barter-case.md (NB-2 Kepmen M.IP-08.GR.01.01/2025 verbatim + 7 web sources)"
+      },
+      "cost_status": "GREEN (PricingTool) ma quote NON send-ready",
+      "cost": "E33G Remote Worker Offshore = IDR 13.000.000 (Altus/Onshore 14.000.000) — bali_zero_official_prices_2026.json kitas_permits",
+      "math": "n/a (caso visa puro, nessun calcolo richiesto)",
+      "devils_advocate_verdict": "PASS-after-fix",
+      "devils_advocate_findings_resolved": [
+        "ACCOLTO: chiarito che E33G copre SOLO reddito-estero, non l'intero caso ne il barter",
+        "ACCOLTO (key): aggiunto CAVEAT BLOCCANTE gate 'contratto datore estero' per creator autonomo — secondo blocco oltre soglia reddito",
+        "PARZIALE: triangolazione gia marcata 'zona grigia alto rischio', conforme a NB-2"
+      ],
+      "send_ready": false,
+      "blockers": ["prova reddito estero >= USD 60k/anno", "struttura contratto datore estero (creator autonomo)", "disclosure natura deal hotel (barter vs contrattualizzabile)"]
+    },
+    {
+      "id": "paco-pak-seseh-shophouse-lease",
+      "domain": "property",
+      "client": "Paco Pak (tenant: Michele Cangiano), lease 10 anni 2 shophouse + 60m2, Jalan Raya Seseh, Munggu, Badung",
+      "dossier": "research/visa/clients/2026-06-03-paco-pak-S9-dossier.md",
+      "eligibility": {
+        "structure": "Leasehold / Hak Sewa (PP 44/1994) — solo passaporto, no BPN, protezione = contratto PPAT",
+        "critical_risks": ["zoning sawah/agricolo vs uso commerciale (Perda Bali 4/2026 criminalizza conversione, demolizione forzata)", "owner BPN = Pura/Desa Adat vs firmatario individuo (autorita a concedere)"],
+        "source": "research/property/paco-pak-due-diligence-2026-05-22.html + research/property/2026-06-02-foreign-property-rights-hak-pakai-hgb-leasehold.md (S6 NB-5)"
+      },
+      "cost_status": "NEEDS-ANTONELLO",
+      "cost": "Legal/DD real-estate su misura = 'Depend (Contact for quote)' nel listino 2026 → NESSUNA cifra inventata. Voci ancillari a listino se cliente procede: NPWPD 2.500.000, NPWP+Coretax 1.000.000.",
+      "math": {
+        "verified_by": "deepseek-v4-pro + Codex node re-derivation",
+        "scenario_A_compound_annual_7pct": "IDR 3.592.276.470",
+        "scenario_B_block_based_contract_table": "IDR 2.943.155.000 (contratto dichiara 2.943.156.000, delta 1.000 arrotondamento)",
+        "difference_A_minus_B": "IDR 649.121.470",
+        "finding": "contratto coerente sotto interpretazione block; clausola va resa esplicita per evitare esposizione +649M"
+      },
+      "devils_advocate_verdict": "PASS",
+      "devils_advocate_findings_resolved": ["NONE"],
+      "send_ready": false,
+      "blockers": ["4 cure HIGH aperti (owner/signatory, zoning, building legality, lease-object-to-title)", "quote legale a preventivo (Contact for quote)"]
+    }
+  ],
+  "summary": {
+    "dossiers_produced": 2,
+    "send_ready": 0,
+    "all_draft_needs_antonello": true,
+    "reason": "Vincolo S9 rispettato: quote NON send-ready senza PricingTool-verde + devils-advocate-PASS. Marc: PricingTool verde + DA PASS ma 3 blockers cliente. Paco: DA PASS ma cost=Contact-for-quote + 4 cure HIGH."
+  }
+}


### PR DESCRIPTION
## ONDA-3 S9 — client-case-dossier

Two complete client-case dossiers for active Bali Zero cases, built with structural guards against the known `client-case-quote-generator` scars (STRUCT-1: no PricingTool; STRUCT-2: deprecated `deepseek-reasoner` alias).

### Cases (2)

**1. Marc Buckner** (visa — content creator, 3 months Bali)
- Eligibility: **E33G Remote Worker KITAS** (covers only the foreign-income leg), from NB-2 Kepmen M.IP-08.GR.01.01/2025 verbatim. C5A rejected (non-operational portal), C7/E23/E28A out of scope.
- Cost: **IDR 13.000.000** (E33G Offshore) from `bali_zero_official_prices_2026.json` — PricingTool source-of-truth. No invented figure.
- Devils-advocate (Codex): flagged NEEDS-FIX x3 → 2 accepted (E33G scope clarified; **foreign-employer-contract gate** added for self-employed creator). **Verdict: PASS-after-fix.**
- `send_ready: false` — 3 client blockers (income proof, contract structure, hotel-deal disclosure).

**2. Paco Pak / Michele Cangiano** (property — Seseh shophouse lease DD)
- Eligibility: **leasehold / Hak Sewa (PP 44/1994)**; critical zoning-sawah risk (Perda Bali 4/2026 criminalizes conversion) + owner/signatory authority gap. From S6 NB-5 ground truth.
- Math: lease escalation verified via **`deepseek-v4-pro`** (explicit model, NOT the reasoner alias) + Codex re-derivation: block-based IDR 2.943bn vs compound IDR 3.592bn, delta **IDR 649M**.
- Cost: **"Contact for quote"** per the 2026 listino (bespoke legal DD has no fixed price) → marked NEEDS-ANTONELLO. **No invented figure.**
- Devils-advocate (Codex): **Verdict: PASS** (NONE).
- `send_ready: false` — 4 HIGH cures open + quote on request.

### Guards honored
- **PricingTool: GREEN** — prices read only from `bali_zero_official_prices_2026.json` (declared source-of-truth in `pricing_service.py`). Zero prices from DeepSeek/user-input/speculation.
- **Math: `deepseek-v4-pro` explicit** (no silent-flash downgrade).
- **Devils-advocate gate: mandatory**, run via Codex `--sandbox read-only`, findings adjudicated against ground-truth (not blind obedience).
- Both dossiers DRAFT/NEEDS-ANTONELLO per S9 constraint: not send-ready without PricingTool-green + devils-advocate-PASS + client docs.

Index: `research/visa/clients/S9-cases-FROZEN.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)