### PR TITLE
feat(seo): add /business internal link from LatestNews section

### DIFF
--- a/apps/mouth/src/app/v2/_components/LatestNews.tsx
+++ b/apps/mouth/src/app/v2/_components/LatestNews.tsx
@@ -167,6 +167,22 @@ export function LatestNews({
           );
         })}
       </div>
+
+      <div className="flex justify-center mt-10">
+        <a
+          href="/business"
+          className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-[13px] font-semibold transition-all hover:-translate-y-0.5"
+          style={{
+            background: "color-mix(in srgb, #f59e0b 10%, transparent)",
+            border: "1px solid color-mix(in srgb, #f59e0b 30%, transparent)",
+            color: "#f59e0b",
+            textDecoration: "none",
+          }}
+        >
+          View all Business articles
+          <ArrowUpRight size={14} strokeWidth={2} />
+        </a>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Insight
119 /business/ articles flagged "discovered not indexed" in GSC since April 2026.
Homepage had zero crawlable links to /business/ category page —
Google had no strong internal signal to prioritize crawling this cluster.

## Studio
SEO Internal Linking — crawl budget optimization

## Source / Reference
GSC Coverage Report — 2 June 2026
153 EN articles in /business/ MDX directory
Homepage v2 grep: 0 results for /business/ href

## Methodology
Audit homepage internal linking → identify zero /business/ links →
add crawlable entry point from highest-authority page (homepage) to /business/ cluster.

## Raw Observations
- Nav "Business" href="#kbli" — anchor only, not a crawlable link to /business/
- LatestNews articles prop fed from getAllArticles() — no business filter
- No dedicated /business/ hub page exists
- 153 EN articles in MDX, 119 stuck at "discovered not indexed"

## Reasoning Path
Google already knows these URLs exist (discovered state).
Missing signal: no internal link from a high-authority page.
Homepage is the highest PageRank source — adding one link here
gives Googlebot a clear crawl path to the entire /business/ cluster.

## Risk / Implication
Low risk. UI addition only — 16 lines inserted before closing </section>.
No logic changes, no data changes, no existing links modified.
Styled with existing business accent (#f59e0b) for visual consistency.

## Recommendation
Merge after CI green.

## Next Action
1. After merge: request manual indexing via GSC URL Inspection
   for top 5 priority /business/ articles.
2. Monitor GSC Coverage: "discovered not indexed" count for /business/
   should decrease within 2-4 weeks.
3. Consider adding /business/ links from /services/ and /kbli/ hub pages
   in a follow-up PR for stronger signal.