### PR TITLE
fix(portal): register 3 orphaned portal routers (P0 — 404 in prod)

### DIFF
--- a/apps/backend-rag/backend/app/setup/router_registration.py
+++ b/apps/backend-rag/backend/app/setup/router_registration.py
@@ -108,10 +108,13 @@ def include_routers(api: FastAPI) -> None:
         portal,
         portal_admin,
         portal_billing,
+        portal_dashboard,
         portal_drive,
+        portal_family,
         portal_invite,
         portal_matters,
         portal_notifications,
+        portal_notification_prefs,
         portal_process_timeline,
         portal_taxes,
         portal_visa,
@@ -232,10 +235,13 @@ def include_routers(api: FastAPI) -> None:
     api.include_router(portal.router)
     api.include_router(portal_admin.router)  # superuser impersonation support
     api.include_router(portal_billing.router)
+    api.include_router(portal_dashboard.router)  # P0 fix: was orphaned (manifest-only) → 404
     api.include_router(portal_drive.router)
+    api.include_router(portal_family.router)  # P0 fix: was orphaned (manifest-only) → 404
     api.include_router(portal_invite.router)
     api.include_router(portal_matters.router)
     api.include_router(portal_notifications.router)
+    api.include_router(portal_notification_prefs.router)  # P0 fix: was orphaned (manifest-only) → 404
     api.include_router(portal_process_timeline.router)
     api.include_router(portal_taxes.router)
     api.include_router(portal_visa.router)
@@ -486,10 +492,13 @@ def include_light_routers(api: FastAPI) -> None:
         portal,
         portal_admin,
         portal_billing,
+        portal_dashboard,
         portal_drive,
+        portal_family,
         portal_invite,
         portal_matters,
         portal_notifications,
+        portal_notification_prefs,
         portal_process_timeline,
         portal_taxes,
         portal_visa,
@@ -592,10 +601,13 @@ def include_light_routers(api: FastAPI) -> None:
     api.include_router(portal.router)
     api.include_router(portal_admin.router)  # superuser impersonation support
     api.include_router(portal_billing.router)
+    api.include_router(portal_dashboard.router)  # P0 fix: was orphaned (manifest-only) → 404
     api.include_router(portal_drive.router)
+    api.include_router(portal_family.router)  # P0 fix: was orphaned (manifest-only) → 404
     api.include_router(portal_invite.router)
     api.include_router(portal_matters.router)
     api.include_router(portal_notifications.router)
+    api.include_router(portal_notification_prefs.router)  # P0 fix: was orphaned (manifest-only) → 404
     api.include_router(portal_process_timeline.router)
     api.include_router(portal_taxes.router)
     api.include_router(portal_visa.router)

--- a/apps/backend-rag/backend/tests/setup/test_router_registration_parity.py
+++ b/apps/backend-rag/backend/tests/setup/test_router_registration_parity.py
@@ -164,3 +164,52 @@ class TestIncludeFunctionsParity:
             f"would silently 404 in main_api production. Add explicit "
             f"`api.include_router(<name>.router)` in include_light_routers()."
         )
+
+
+class TestPortalManifestRegistrationParity:
+    """Every `portal_*` manifest entry MUST be registered in BOTH include
+    functions — the exact class of the ONDA-3 S11 P0 scar (#1055 audit).
+
+    Unlike the general "manifest entry implies include_router" check (which
+    is out of scope because some routers mount via app_factory and would
+    false-positive), the portal_* family is fully explicit-registration:
+    all 13 portal routers are wired by hand in include_routers() +
+    include_light_routers(). This test is therefore false-positive-free for
+    that family.
+
+    Scar: portal_dashboard / portal_family / portal_notification_prefs were
+    in ROUTER_MANIFEST but never include_router()'d → 404 in production on
+    the client portal Family page, Notification settings, and dashboard
+    summary + iCal export. Same drift class as channel_health (#422→#424).
+    """
+
+    def _portal_manifest_names(self) -> set[str]:
+        from backend.app.setup.router_manifest import _API, _BOTH
+
+        return {
+            e.name
+            for e in ROUTER_MANIFEST
+            if e.name.startswith("portal_") and e.process_groups in (_API, _BOTH)
+        }
+
+    def test_every_portal_router_in_both_include_functions(self):
+        source = _read_registration_source()
+        body_main = _extract_function_body(source, "include_routers")
+        body_light = _extract_function_body(source, "include_light_routers")
+
+        pat = re.compile(r"include_router\s*\(\s*(\w+)\.router")
+        in_main = set(pat.findall(body_main))
+        in_light = set(pat.findall(body_light))
+
+        portal = self._portal_manifest_names()
+        missing_main = sorted(portal - in_main)
+        missing_light = sorted(portal - in_light)
+
+        assert not missing_main, (
+            f"portal_* routers in manifest but NOT in include_routers(): "
+            f"{missing_main} — would 404 in production. (ONDA-3 S11 P0 scar.)"
+        )
+        assert not missing_light, (
+            f"portal_* routers in manifest but NOT in include_light_routers(): "
+            f"{missing_light} — would 404 in main_api production. (ONDA-3 S11 P0 scar.)"
+        )


### PR DESCRIPTION
## P0 — broken in production now

`portal_dashboard`, `portal_family`, `portal_notification_prefs` are in `router_manifest.py` but were never `include_router()`'d → **404 in prod** on the client portal Family page, Notification settings, and dashboard summary + iCal export. Found by the ONDA-3 S11 audit (#1055).

Same drift class as the channel_health scar (Sprint 1.B #422→#424).

## Fix
- Explicit import + `include_router()` for all 3 in **both** `include_routers()` and `include_light_routers()`.
- **Verified**: `include_light_routers()` now mounts all 13 `portal_*` manifest routers (0 missing); the 3 prefixes register correctly.

## Regression guard
- New `TestPortalManifestRegistrationParity`: every `portal_*` manifest entry must be registered in both include functions. The pre-existing parity test only checked main↔light *symmetry*, so a router missing from **both** slipped through.
- **Negative-tested**: removing one registration makes the new test fail with the exact missing-router name. Full file: 7/7 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)