### PR TITLE
fix(evoskill): cache tree_hash includes .evoskill/task.md (stale-replay bug)

### DIFF
--- a/vendor/evoskill/src/cache/run_cache.py
+++ b/vendor/evoskill/src/cache/run_cache.py
@@ -4,6 +4,7 @@ Program-aware run caching for agent evaluations.
 Cache invalidates automatically when behavior-affecting files change:
 - .claude/skills/** (skill definitions)
 - src/agent_profiles/base_agent/prompt.txt (prompt text)
+- .evoskill/task.md (task description / prompt)
 
 Excludes metadata files like .claude/program.yaml to avoid unnecessary
 cache invalidation when only scores or timestamps change.
@@ -89,6 +90,7 @@ class RunCache:
         Only hashes files that actually affect agent behavior:
         - .claude/skills/** - skill definitions
         - src/agent_profiles/base_agent/prompt.txt - prompt text
+        - .evoskill/task.md - task description / prompt
 
         Excludes metadata files like .claude/program.yaml which contain
         mutable fields (score, created_at) that don't affect behavior.
@@ -101,6 +103,7 @@ class RunCache:
         behavior_paths = [
             (".claude/skills", "**/*"),  # All skill files
             ("src/agent_profiles/base_agent", "prompt.txt"),  # Prompt text
+            (".evoskill", "task.md"),  # Task description / output contract (production system prompt)
         ]
 
         content_hashes = []


### PR DESCRIPTION
## Summary

`RunCache._get_tree_hash()` (`vendor/evoskill/src/cache/run_cache.py`) hashed only
`.claude/skills/**/*` and `src/agent_profiles/base_agent/prompt.txt` as
behavior-affecting paths. It **excluded** `.evoskill/task.md`, which **is** the
production system prompt (loaded via `cfg.task_description`).

Because `task.md` was not part of the cache key, editing it did **not** invalidate
the LLM cache. The #1070 athlete-schema fix lives in `task.md`, so after that edit
the run path replayed the **pre-fix** `{issue, resolution}` answers and scored
**0.0 on every sample (4 consecutive 0.0% runs)** while a cache-bypassing manual
eval of the same fix scored **1.00**.

## Fix

Add one tuple to `behavior_paths`:

```python
behavior_paths = [
    (".claude/skills", "**/*"),  # All skill files
    ("src/agent_profiles/base_agent", "prompt.txt"),  # Prompt text
    (".evoskill", "task.md"),  # Task description / output contract (production system prompt)
]
```

`self.config.cwd == project_root`, so `.evoskill/task.md` resolves correctly with
the existing loop. Docstrings (module + method) updated to list the third
behavior file. One file, three additive lines.

## Verification

Empirical test with `CacheConfig(cwd=temp_root)` containing a real
`.evoskill/task.md`, a 1-char edit to `task.md`, recompute, then revert:

**Patched (this branch):**
```
tree_hash BEFORE task.md edit: 3da0fa89a39a4d63d17a9af82476f8e157c20e877cd2376325451ffa9c833ea9
tree_hash AFTER  task.md edit: 8e5dbe95926d2e6e4f65a768df134358215d6a2b53dab2a7aa6ce9b8d67be502
tree_hash AFTER  revert     : 3da0fa89a39a4d63d17a9af82476f8e157c20e877cd2376325451ffa9c833ea9
PASS: task.md edits now invalidate the tree_hash (h1!=h2) and revert restores it (h1==h3)
```

**Unpatched (origin/main, negative control):**
```
UNPATCHED tree_hash BEFORE task.md edit: 3b3c62d06efc1af6ae8fa5505cd4cb82048918b88aaf4851e1d0e00432c23498
UNPATCHED tree_hash AFTER  task.md edit: 3b3c62d06efc1af6ae8fa5505cd4cb82048918b88aaf4851e1d0e00432c23498
CONFIRMED BUG: unpatched tree_hash IGNORES task.md (h1==h2) -> stale-replay
```

The patched hash responds to `task.md` edits; the unpatched hash does not.

## Context

Blocker #8 of the agent-library evolution loop saga (after #1042 env, #1045 YAML,
#1047 guard+prune, #1050 scorer, #1070 athlete schema).
