### PR TITLE
fix(evoskill): frontier reads scores from nested-repo program.yaml (git show :./path)

### DIFF
--- a/vendor/evoskill/src/registry/manager.py
+++ b/vendor/evoskill/src/registry/manager.py
@@ -7,6 +7,7 @@ Each program is stored as a git branch with:
 """
 
 import json
+import logging
 import random
 import subprocess
 from pathlib import Path
@@ -15,6 +16,8 @@ from typing import Any
 import yaml
 
 from .models import ProgramConfig
+
+logger = logging.getLogger(__name__)
 
 
 class ProgramManagerError(RuntimeError):
@@ -338,7 +341,11 @@ class ProgramManager:
                 score = config.get_score()
                 if score is not None:
                     scored.append((name, score, index))
-            except Exception:
+            except subprocess.CalledProcessError:
+                # Branch or program.yaml genuinely absent: skip this member.
+                continue
+            except Exception as e:  # noqa: BLE001 - keep loop resilient, but surface
+                logger.warning("frontier score read failed for %s: %s", name, e)
                 continue
         scored.sort(key=lambda item: (item[1], item[2]), reverse=True)
         return [(name, score) for name, score, _ in scored]
@@ -488,7 +495,7 @@ class ProgramManager:
 
     def _read_config_from_branch(self, branch: str) -> ProgramConfig:
         """Read program config from a specific branch without checking out."""
-        result = self._run_git(["show", f"{branch}:{self.PROGRAM_FILE}"])
+        result = self._run_git(["show", f"{branch}:./{self.PROGRAM_FILE}"])
         data = yaml.safe_load(result.stdout)
         return ProgramConfig.model_validate(data)
 


### PR DESCRIPTION
## Bug #9 — frontier always reads empty, loop can never promote a winner

`git show <rev>:<path>` resolves `<path>` from the **repo root**, not the cwd. The evoskill run dir (`agent-library`) is a **subdir** of the repo, so `program.yaml` is committed at `agent-library/.claude/program.yaml`, while `PROGRAM_FILE` is the cwd-relative `.claude/program.yaml`.

So `_read_config_from_branch` ran `git show {branch}:.claude/program.yaml` → **exit 128**:

```
fatal: path 'agent-library/.claude/program.yaml' exists, but not '.claude/program.yaml'
hint: Did you mean 'program/base:agent-library/.claude/program.yaml' aka 'program/base:./.claude/program.yaml'?
```

`get_frontier_with_scores` swallowed it in a bare `except Exception: continue` → returned `[]` → `best_score=0.0`, `best_program="base"` on **every** run. The loop could never promote a winning mutation even though scores ARE persisted on disk.

## The fix (two parts, 9 insertions / 2 deletions, manager.py only)

**Part A (load-bearing)** — use git's documented cwd-relative pathspec `:./path`, the same assumption every other method already makes:

```python
-        result = self._run_git(["show", f"{branch}:{self.PROGRAM_FILE}"])
+        result = self._run_git(["show", f"{branch}:./{self.PROGRAM_FILE}"])
```

**Part B** — narrow the swallowing `except`: keep `CalledProcessError` (branch/file truly absent) silent, but `logger.warning(...)` on any unexpected exception. Loop stays resilient (still `continue`); failures are no longer invisible.

## Empirical verification (against the deploy worktree's real git history)

Deploy repo root `~/Desktop/nuzantara-deploy`, run dir `agent-library`, branches `program/base..iter-skill-10`. Running `get_frontier_with_scores()` through the FIXED manager (loaded from this branch's worktree, asserted via `__file__`):

```
get_frontier_with_scores() -> [('iter-skill-8', 1.0), ('iter-skill-7', 1.0),
  ('iter-skill-5', 1.0), ('iter-skill-3', 1.0), ('iter-skill-2', 1.0),
  ('iter-skill-10', 1.0), ('base', 1.0), ('iter-skill-1', 0.8)]   # len 8
get_best_from_frontier() -> iter-skill-8        # was None / "base" before
_read_config_from_branch('program/base').get_score() -> 1.0   # was exit 128
```

Before the fix the same calls returned `[]` / `None`. This proves the loop can now read persisted scores and thus promote a winning mutation.

## Saga context

Blocker **#9** of the agent-library evolution loop saga (after #1042 env-drift / #1045 YAML / #1047 guard+prune / #1050 / #1070 / cache #1073).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
