### PR TITLE
fix(evolver): return-to-branch guard restores deploy/main from ANY branch, not only program/*

### DIFF
--- a/scripts/agent-library-evolver-run.sh
+++ b/scripts/agent-library-evolver-run.sh
@@ -68,26 +68,31 @@ DRY_RUN="0"
 
 # ─── S13-P6b (2026-06-02): return-to-branch guard ────────────────────
 # evoskill (vendor/evoskill ProgramManager) does native git checkout of
-# program/* branches INSIDE REPO_ROOT and can leave the worktree parked
-# on a program/* branch when it exits (incl. on FATAL). In production
-# REPO_ROOT is the deploy worktree pinned to deploy/main; a left-over
-# program/* checkout breaks the next wr2-deploy-pull (wrong-branch gate).
-# This trap restores deploy/main on EXIT, but ONLY when (a) REPO_ROOT is
-# a git tree and (b) it was left on a program/* branch — so it never
-# touches a feature/test worktree on its own branch.
+# branches INSIDE REPO_ROOT and can leave the worktree parked on the
+# wrong branch when it exits (incl. on FATAL). It checks out program/*
+# branches AND, between programs, pre-existing agent/* branches
+# (e.g. agent/nuzantara/backend-rag/crm-guardian-audit). In production
+# REPO_ROOT is the deploy worktree pinned to deploy/main; ANY left-over
+# non-deploy/main checkout breaks the next wr2-deploy-pull (wrong-branch
+# gate) — observed twice on 2026-06-03, manual restore both times.
+# S13-#11 (2026-06-03): broaden the restore to fire whenever HEAD is on
+# any branch other than deploy/main (not only program/*), guarded by a
+# clean-tree check so we never clobber uncommitted tracked work in a
+# feature/test worktree. Untracked files (cache/) are fine.
 _restore_deploy_branch() {
     git -C "${REPO_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
     local cur
-    cur="$(git -C "${REPO_ROOT}" rev-parse --abbrev-ref HEAD 2>/dev/null)"
-    case "${cur}" in
-        program/*)
-            if git -C "${REPO_ROOT}" rev-parse --verify --quiet deploy/main >/dev/null 2>&1; then
-                git -C "${REPO_ROOT}" checkout deploy/main >/dev/null 2>&1 \
-                    && log "return-to-branch guard: restored deploy/main (was ${cur})" \
-                    || log "WARN: return-to-branch guard failed to restore deploy/main from ${cur}"
-            fi
-            ;;
-    esac
+    cur="$(git -C "${REPO_ROOT}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo )"
+    if [[ -n "${cur}" && "${cur}" != "deploy/main" ]] \
+        && git -C "${REPO_ROOT}" show-ref --verify --quiet refs/heads/deploy/main; then
+        if git -C "${REPO_ROOT}" diff --quiet && git -C "${REPO_ROOT}" diff --cached --quiet; then
+            git -C "${REPO_ROOT}" checkout deploy/main >/dev/null 2>&1 \
+                && log "return-to-branch guard: restored deploy/main (was ${cur})" \
+                || log "WARN: return-to-branch guard failed to restore deploy/main from ${cur}"
+        else
+            log "WARN: return-to-branch guard: uncommitted tracked changes, NOT switching from ${cur}"
+        fi
+    fi
 }
 # NOTE: do NOT register a standalone EXIT trap here — bash allows only
 # one EXIT trap and the advisory-lock trap (acquire_lock) would overwrite


### PR DESCRIPTION
## Problem (S13 blocker #11, prod-safety, recurring)

`scripts/agent-library-evolver-run.sh` has a `_restore_deploy_branch` function fired from the combined EXIT trap, meant to leave the production deploy worktree on `deploy/main` after every run. But it only restored when HEAD was on a `program/*` branch.

evoskill, between iterations, does a native `git checkout` of a **pre-existing** branch (`agent/nuzantara/backend-rag/crm-guardian-audit`) inside `REPO_ROOT`. At EXIT the worktree HEAD is on THAT branch, not `program/*` → the `case program/*)` falls through → guard is a no-op → the production worktree is left on the wrong branch. **Observed twice on 2026-06-03, manual restore both times.** The cron reads this worktree, so the next `wr2-deploy-pull` hits the wrong-branch gate.

## Fix

Broaden `_restore_deploy_branch` to checkout `deploy/main` whenever HEAD is on **any** branch other than `deploy/main` (and `deploy/main` exists locally), not only `program/*`. Guarded by a clean-tree check (`git diff --quiet && git diff --cached --quiet`) so uncommitted **tracked** work is never clobbered; untracked files (`cache/`) are fine.

Unchanged / preserved:
- The **single combined** advisory-unlock + restore EXIT trap (bash keeps only one EXIT trap).
- The `program/*` **prune** at run start.

## Verification

- `bash -n` → SYNTAX_OK
- Isolation test (throwaway repo, branches `deploy/main` + `agent/foo`): HEAD `agent/foo` → after guard → `deploy/main`, logged `restored deploy/main (was agent/foo)`. Old code was a no-op in this exact scenario.
- Clean-tree safety test: dirty tracked tree on `agent/foo` → guard logs WARN and does NOT switch (HEAD stays `agent/foo`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
