### PR TITLE
feat(wa-meta-inbox): wire outbox scheduler — enable SEND (human-send v1)

### DIFF
--- a/apps/backend-rag/backend/app/main_api.py
+++ b/apps/backend-rag/backend/app/main_api.py
@@ -22,6 +22,50 @@ init_sentry()
 logger = logging.getLogger("zantara.backend")
 
 
+async def _wa_bot_generate_not_implemented(_thread: object) -> str:
+    """v1 bot generator: not wired yet (human-send-only scope).
+
+    The WA Meta inbox v1 ships SEND for operator-typed replies only. Bot
+    auto-reply (RAG generation) is a follow-up PR. A ``needs_generation`` row
+    should not exist in v1 (the webhook only enqueues bot replies when the bot
+    path is active), but if one does, this raises and the outbox worker marks
+    it failed/retry — it is NEVER left orphaned (worker has a guard around
+    bot_generate_fn). See docs/superpowers/specs/2026-06-04-wa-outbox-scheduler.md.
+    """
+    raise NotImplementedError("wa-inbox bot auto-reply not enabled in v1")
+
+
+async def _run_wa_outbox_scheduler(app: FastAPI) -> None:
+    """Drain the wa_outbox send-queue by calling process_outbox_once in a loop.
+
+    Hosted on the 'api' process group (always-on, single-worker) so exactly one
+    scheduler runs. Tight-loops while draining (status == 'sent'), backs off to
+    WA_OUTBOX_POLL_SECONDS when idle. Never crashes the app: per-tick exceptions
+    are logged and the loop continues after a backoff.
+    """
+    from backend.services.integrations.wa_outbox_worker import process_outbox_once
+    from backend.services.integrations.whatsapp_service import whatsapp_service
+
+    interval = float(os.getenv("WA_OUTBOX_POLL_SECONDS", "3"))
+    pool = app.state.db_pool
+    logger.info("✅ WA outbox scheduler started (poll=%ss)", interval)
+    while True:
+        try:
+            status = await process_outbox_once(
+                pool, whatsapp_service, _wa_bot_generate_not_implemented
+            )
+            # Drain fast while sending, but always yield the loop (sleep(0)
+            # would not starve asyncio, but a tiny throttle is safer under a
+            # full queue per panel 2026-06-04). Back off fully when idle.
+            await asyncio.sleep(0.1 if status == "sent" else interval)
+        except asyncio.CancelledError:
+            logger.info("🛑 WA outbox scheduler cancelled")
+            raise
+        except Exception:
+            logger.exception("WA outbox scheduler tick failed; backing off")
+            await asyncio.sleep(interval)
+
+
 @asynccontextmanager
 async def lifespan_light(app: FastAPI):
     """
@@ -44,9 +88,11 @@ async def lifespan_light(app: FastAPI):
         # Background workers kill switch — see service_initializer.py note (2026-04-12 incident)
         if os.getenv("DISABLE_BACKGROUND_WORKERS") == "1":
             logger.warning(
-                "⚠️ DISABLE_BACKGROUND_WORKERS=1 — skipping Notification Scheduler",
+                "⚠️ DISABLE_BACKGROUND_WORKERS=1 — skipping Notification Scheduler "
+                "+ WA outbox scheduler",
             )
             app.state.notification_scheduler = None
+            app.state._wa_outbox_scheduler_task = None
         else:
             try:
                 from backend.app.modules.notifications.scheduler import init_scheduler
@@ -56,13 +102,35 @@ async def lifespan_light(app: FastAPI):
             except Exception as e:
                 logger.warning("⚠️ Notification Scheduler failed: %s", e)
 
+            # WA Meta inbox outbox scheduler — spawned HERE (not in the outer
+            # lifespan) because app.state.db_pool is only set above, inside this
+            # background init task; an outer-lifespan task could start with
+            # db_pool=None (panel race-fix 2026-06-04). Guard on a real pool.
+            if getattr(app.state, "db_pool", None) is not None:
+                app.state._wa_outbox_scheduler_task = asyncio.create_task(
+                    _run_wa_outbox_scheduler(app)
+                )
+            else:
+                app.state._wa_outbox_scheduler_task = None
+                logger.warning(
+                    "⚠️ WA outbox scheduler NOT started — db_pool unavailable",
+                )
+
     init_task = asyncio.create_task(_background_light_init())
     app.state._init_task = init_task
 
     yield
 
-    # Shutdown: close DB pool and proxy client
+    # Shutdown: cancel the WA outbox scheduler BEFORE closing the pool it uses.
     logger.info("🛑 [API PROCESS] Shutting down...")
+    wa_task = getattr(app.state, "_wa_outbox_scheduler_task", None)
+    if wa_task is not None:
+        wa_task.cancel()
+        try:
+            await wa_task
+        except (asyncio.CancelledError, Exception):
+            pass
+
     db_pool = getattr(app.state, "db_pool", None)
     if db_pool:
         await db_pool.close()

--- a/apps/backend-rag/backend/services/integrations/wa_outbox_worker.py
+++ b/apps/backend-rag/backend/services/integrations/wa_outbox_worker.py
@@ -227,7 +227,68 @@ async def process_outbox_once(
             await conn.execute(
                 "UPDATE wa_outbox SET status = 'generating' WHERE id = $1", outbox_id
             )
-            body_text = await bot_generate_fn(thread)
+            # bot_generate_fn may raise (transient RAG error, or — in the
+            # human-send-only v1 — a NotImplementedError sentinel). Without this
+            # guard the exception bubbles to the scheduler and the row is left
+            # ORPHANED in 'generating' (reclaim only resets 'claimed' rows), so
+            # it is never retried nor surfaced. Mirror the send retry/backoff
+            # policy: retry with backoff up to MAX_ATTEMPTS, then mark failed.
+            try:
+                body_text = await bot_generate_fn(thread)
+            except Exception as gen_exc:
+                attempts += 1
+                if attempts >= MAX_ATTEMPTS:
+                    await conn.execute(
+                        "UPDATE wa_outbox SET status = 'failed', attempts = $2 WHERE id = $1",
+                        outbox_id,
+                        attempts,
+                    )
+                    await conn.execute(
+                        """
+                        UPDATE meta_inbox_messages
+                        SET status = 'failed', error = $2
+                        WHERE id = $1
+                        """,
+                        message_id,
+                        f"bot_generate_failed_after_{attempts}_attempts: {gen_exc}",
+                    )
+                    logger.error(
+                        "wa_outbox: bot generation failed permanently "
+                        "(outbox=%s thread=%s): %s",
+                        outbox_id,
+                        thread_id,
+                        gen_exc,
+                    )
+                    return "failed"
+
+                backoff = RETRY_BACKOFF_BASE_SECONDS * (2 ** (attempts - 1))
+                await conn.execute(
+                    """
+                    UPDATE wa_outbox
+                    SET status = 'pending', attempts = $2,
+                        next_retry_at = NOW() + ($3 * INTERVAL '1 second'),
+                        claim_token = NULL, claimed_at = NULL, claim_expires_at = NULL
+                    WHERE id = $1
+                    """,
+                    outbox_id,
+                    attempts,
+                    backoff,
+                )
+                await conn.execute(
+                    "UPDATE meta_inbox_messages SET status = 'queued' WHERE id = $1",
+                    message_id,
+                )
+                logger.warning(
+                    "wa_outbox: bot generation failed (attempt %d/%d), retry in %ds "
+                    "(outbox=%s): %s",
+                    attempts,
+                    MAX_ATTEMPTS,
+                    backoff,
+                    outbox_id,
+                    gen_exc,
+                )
+                return "retry"
+
             await conn.execute(
                 "UPDATE meta_inbox_messages SET body = $2 WHERE id = $1",
                 message_id,

--- a/apps/backend-rag/backend/tests/unit/services/test_wa_outbox_scheduler.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_wa_outbox_scheduler.py
@@ -1,0 +1,125 @@
+"""Tests for the WA Meta Inbox outbox scheduler loop (main_api).
+
+Covers the panel-2026-06-04 fixes:
+  - cadence: sleep ~0.1s after 'sent' (drain fast), full interval after 'idle'.
+  - resilience: a raised exception in a tick is logged and the loop continues.
+  - cancellation: the loop exits cleanly on CancelledError (shutdown path).
+  - v1 sentinel bot generator raises NotImplementedError (human-send-only).
+
+The loop is driven against a fake app whose state.db_pool is a sentinel, with
+process_outbox_once monkeypatched to a scripted sequence of statuses. We cap
+iterations by cancelling the task after the scripted statuses are consumed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from backend.app import main_api
+
+
+@pytest.mark.asyncio
+async def test_v1_bot_generator_raises_not_implemented() -> None:
+    with pytest.raises(NotImplementedError):
+        await main_api._wa_bot_generate_not_implemented(object())
+
+
+@pytest.mark.asyncio
+async def test_scheduler_cadence_sent_then_idle(monkeypatch: pytest.MonkeyPatch) -> None:
+    statuses = ["sent", "sent", "idle"]
+    calls: list[Any] = []
+    sleeps: list[float] = []
+
+    async def fake_process(pool, wa, botfn) -> str:
+        calls.append((pool, wa, botfn))
+        if statuses:
+            return statuses.pop(0)
+        raise asyncio.CancelledError  # stop the loop deterministically
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(main_api, "process_outbox_once", fake_process, raising=False)
+    # patch the symbol the loop imports locally
+    import backend.services.integrations.wa_outbox_worker as worker_mod
+
+    monkeypatch.setattr(worker_mod, "process_outbox_once", fake_process)
+    monkeypatch.setattr(main_api.asyncio, "sleep", fake_sleep)
+    monkeypatch.setenv("WA_OUTBOX_POLL_SECONDS", "3")
+
+    app = SimpleNamespace(state=SimpleNamespace(db_pool=object()))
+
+    with pytest.raises(asyncio.CancelledError):
+        await main_api._run_wa_outbox_scheduler(app)
+
+    # 3 productive ticks happened (sent, sent, idle) before the cancel tick
+    assert len(calls) == 4
+    # cadence: 0.1 after each 'sent', full interval (3.0) after 'idle'
+    assert sleeps[0] == pytest.approx(0.1)
+    assert sleeps[1] == pytest.approx(0.1)
+    assert sleeps[2] == pytest.approx(3.0)
+    # the bot generator passed through is the v1 sentinel
+    assert calls[0][2] is main_api._wa_bot_generate_not_implemented
+
+
+@pytest.mark.asyncio
+async def test_scheduler_survives_tick_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    seq = ["boom", "idle"]
+    ticks = 0
+    sleeps: list[float] = []
+
+    async def fake_process(pool, wa, botfn) -> str:
+        nonlocal ticks
+        ticks += 1
+        if not seq:
+            raise asyncio.CancelledError
+        item = seq.pop(0)
+        if item == "boom":
+            raise RuntimeError("transient tick failure")
+        return item
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    import backend.services.integrations.wa_outbox_worker as worker_mod
+
+    monkeypatch.setattr(worker_mod, "process_outbox_once", fake_process)
+    monkeypatch.setattr(main_api.asyncio, "sleep", fake_sleep)
+
+    app = SimpleNamespace(state=SimpleNamespace(db_pool=object()))
+
+    with pytest.raises(asyncio.CancelledError):
+        await main_api._run_wa_outbox_scheduler(app)
+
+    # tick 1 raised RuntimeError (logged, backed off), tick 2 idle, tick 3 cancel
+    assert ticks == 3
+    # after the exception the loop backed off by the full interval (default 3.0)
+    assert sleeps[0] == pytest.approx(3.0)
+
+
+@pytest.mark.asyncio
+async def test_scheduler_cancels_cleanly(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_process(pool, wa, botfn) -> str:
+        return "idle"
+
+    _real_sleep = asyncio.sleep  # capture BEFORE patching to avoid recursion
+
+    async def fast_sleep(seconds: float) -> None:
+        await _real_sleep(0)  # yield so cancellation can be delivered
+
+    import backend.services.integrations.wa_outbox_worker as worker_mod
+
+    monkeypatch.setattr(worker_mod, "process_outbox_once", fake_process)
+    monkeypatch.setattr(main_api.asyncio, "sleep", fast_sleep)
+
+    app = SimpleNamespace(state=SimpleNamespace(db_pool=object()))
+    task = asyncio.create_task(main_api._run_wa_outbox_scheduler(app))
+    await asyncio.sleep(0)  # let it run a few ticks
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert task.cancelled()

--- a/apps/backend-rag/backend/tests/unit/services/test_wa_outbox_worker.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_wa_outbox_worker.py
@@ -236,6 +236,79 @@ async def test_send_failure_retries_with_backoff() -> None:
 
 
 @pytest.mark.asyncio
+async def test_bot_generate_failure_retries_not_orphaned() -> None:
+    # Panel 2026-06-04 (Codex): a raising bot_generate_fn must NOT leave the row
+    # orphaned in 'generating' — it must retry with backoff (the v1 sentinel
+    # raises NotImplementedError, and a transient RAG error in B must retry too).
+    conn = ScriptedConn(
+        fetchrow_results=[
+            {
+                "id": 6,
+                "thread_id": 7,
+                "message_id": 600,
+                "needs_generation": True,
+                "attempts": 0,
+            },
+            # thread load → human NOT handling, so the bot path proceeds
+            {
+                "thread_id": 7,
+                "counterpart_phone": "628111",
+                "human_handling": False,
+                "last_customer_at": "x",
+            },
+        ]
+    )
+    pool = _make_pool(conn)
+    svc = _wa_service()
+
+    async def _bot_raises(_thread: Any) -> str:
+        raise NotImplementedError("bot not wired in v1")
+
+    result = await process_outbox_once(pool, svc, _bot_raises)
+
+    assert result == "retry"
+    svc.send_message.assert_not_awaited()
+    # row went back to pending (NOT left in 'generating') + attempts incremented
+    retry_updates = conn.sql_with_args("status = 'pending'")
+    assert retry_updates, "bot-gen failure must re-queue, never orphan in generating"
+    assert any("next_retry_at" in s for s, _ in retry_updates)
+    assert any(1 in a for _, a in retry_updates)  # attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_bot_generate_failure_terminal_after_max_attempts() -> None:
+    conn = ScriptedConn(
+        fetchrow_results=[
+            {
+                "id": 7,
+                "thread_id": 7,
+                "message_id": 700,
+                "needs_generation": True,
+                "attempts": wa_outbox_worker.MAX_ATTEMPTS - 1,
+            },
+            {
+                "thread_id": 7,
+                "counterpart_phone": "628111",
+                "human_handling": False,
+                "last_customer_at": "x",
+            },
+        ]
+    )
+    pool = _make_pool(conn)
+    svc = _wa_service()
+
+    async def _bot_raises(_thread: Any) -> str:
+        raise NotImplementedError("bot not wired in v1")
+
+    result = await process_outbox_once(pool, svc, _bot_raises)
+
+    assert result == "failed"
+    svc.send_message.assert_not_awaited()
+    assert conn.sql_contains("UPDATE wa_outbox SET status = 'failed', attempts")
+    assert any("bot_generate_failed_after_" in str(a) for _, a in conn.executed)
+
+
+@pytest.mark.asyncio
 async def test_send_failure_terminal_after_max_attempts() -> None:
     conn = ScriptedConn(
         fetchrow_results=[

--- a/docs/superpowers/specs/2026-06-04-wa-outbox-scheduler.md
+++ b/docs/superpowers/specs/2026-06-04-wa-outbox-scheduler.md
@@ -1,0 +1,103 @@
+# WA Meta Inbox — outbox scheduler (enable SEND)
+
+> Date: 2026-06-04 · Domain: backend · Depends on: wa-meta-inbox backend (PR #1081, live)
+
+## Problem
+
+The backend captures + reads Meta WhatsApp threads, and `wa_outbox` rows are
+enqueued (by the human-send endpoint `POST /threads/{id}/send` and, later, by
+the bot path). But `process_outbox_once()` is never called by anything — the
+scheduler loop was intentionally left as a TODO. So **nothing is sent**: rows
+sit `pending` forever. This wires the loop so SEND works.
+
+## Verified facts
+
+| Fact | Value |
+|---|---|
+| Unit of work | `process_outbox_once(pool, whatsapp_service, bot_generate_fn) -> str` |
+| Returns | `idle / sent / aborted_human / window_closed / retry / failed` |
+| `whatsapp_service` | singleton `backend.services.integrations.whatsapp_service.whatsapp_service`, has `async send_message(phone, text, reply_to_message_id=None)` |
+| `api` process group | always-on (`auto_stop='off'`, `min_machines_running=1`), single-worker (fly.toml comment: 2 workers duplicate background loops → keep single) |
+| `rag` process group | no `[[services]]` block; not guaranteed always-on |
+| Existing bg-loop host | `main_api.py::lifespan_light` already runs Notification Scheduler in an `asyncio.create_task`, gated by `DISABLE_BACKGROUND_WORKERS` |
+| Existing bg-loop precedent | `app_factory.py::lifespan` (full/rag) runs `run_worker`, `legal_run_worker` |
+| claim lease | `wa_outbox.claim_expires_at`, `FOR UPDATE SKIP LOCKED` → double-worker is safe (no double-send) but wasteful |
+
+## Design
+
+### Host: `lifespan_light` on the `api` process group
+
+Add the scheduler as an `asyncio.create_task` in `main_api.py::lifespan_light`,
+inside the existing `DISABLE_BACKGROUND_WORKERS` else-block, right after the
+Notification Scheduler. Rationale:
+- `api` is the only always-on, single-worker group → exactly one loop, never
+  stopped, no double-worker waste.
+- `lifespan_light` already owns `app.state.db_pool` and one bg loop — same
+  pattern, same shutdown path.
+- The webhook that enqueues also runs on `api` → producer + consumer co-located.
+
+### The loop
+
+```python
+async def _run_wa_outbox_scheduler(pool, bot_generate_fn) -> None:
+    from backend.services.integrations.whatsapp_service import whatsapp_service
+    from backend.services.integrations.wa_outbox_worker import process_outbox_once
+    interval = float(os.getenv("WA_OUTBOX_POLL_SECONDS", "3"))
+    while True:
+        try:
+            status = await process_outbox_once(pool, whatsapp_service, bot_generate_fn)
+            # tight loop while draining, back off when idle
+            await asyncio.sleep(0 if status == "sent" else interval)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("wa-outbox scheduler tick failed")
+            await asyncio.sleep(interval)
+```
+
+Cancelled cleanly on shutdown (store task on `app.state`, cancel in the
+shutdown half of the lifespan — mirror the existing worker tasks).
+
+### bot_generate_fn — v1 scope decision (panel must settle)
+
+`process_outbox_once` only calls `bot_generate_fn` for rows with
+`needs_generation = true`. Human-typed sends (`POST /threads/{id}/send`) carry
+the text already (`needs_generation = false`) and never invoke it.
+
+- **Option A — human-send only (v1):** pass a `bot_generate_fn` that raises
+  `NotImplementedError`. The operator-typed sends work end-to-end immediately
+  (this is the "prepare + monitor before publishing the number" need). Bot
+  auto-reply stays off until a later PR wires the RAG orchestrator. Smallest,
+  safest, ships the SEND the operator actually asked for. A bot row, if any
+  somehow gets enqueued, would error → `retry`/`failed`, never a wrong send.
+- **Option B — bot auto-reply now:** `bot_generate_fn` calls the RAG worker
+  (HTTP `RAG_WORKER_URL` from the `api` machine, since RAG lives on the `rag`
+  group). More moving parts, needs prompt/persona wiring + the human-in-the-loop
+  `human_handling` interplay re-verified live. Larger surface, more risk.
+
+Recommendation in the spec: **A** for this PR (matches the stated need —
+prepare/monitor + human reply before publication), B as a follow-up.
+
+## Kill switch & ops
+
+- `DISABLE_BACKGROUND_WORKERS=1` already disables it (shared with other loops).
+- `WA_OUTBOX_POLL_SECONDS` (default 3) tunes cadence.
+- Loop logs each non-idle status at INFO; exceptions at EXCEPTION (never crashes
+  the app — the lifespan task swallows and backs off).
+
+## Test plan
+
+1. Unit: a fake pool/whatsapp_service driving `_run_wa_outbox_scheduler` for N
+   ticks — asserts it calls `process_outbox_once`, sleeps 0 after `sent`,
+   `interval` after `idle`, and survives a raised exception (logs, continues).
+2. Unit: cancellation — task cancels cleanly on shutdown.
+3. Existing `test_wa_outbox_worker.py` (21 tests) still green (worker unit
+   unchanged).
+4. Live (post-deploy): enqueue a human send via `POST /threads/{id}/send` from
+   the local UI → observe `wa_outbox` row go `pending → done`, `meta_inbox_messages`
+   status `sending → sent`, message delivered on WhatsApp.
+
+## Rollback
+
+Additive: the loop is one task gated by an env var. Revert = unset/disable or
+revert the diff. No schema, no data change.


### PR DESCRIPTION
## Why

The wa-meta-inbox backend (#1081) captured + read Meta WhatsApp threads and enqueued `wa_outbox` rows, but `process_outbox_once()` was never called — **nothing was sent**. This wires the drain loop so operator-typed replies actually go out (the "prepare + monitor + reply BEFORE publishing +62 821-3465-159" need).

## What

- **Scheduler loop** in `main_api.py` `lifespan_light` on the **`api`** process group — the only always-on, single-worker group, already owning `app.state.db_pool` + the producer webhook. Exactly one scheduler, no double-lease waste.
- Drains fast while sending (`sleep(0.1)` after `sent`), backs off to `WA_OUTBOX_POLL_SECONDS` (default 3) when idle. Gated by `DISABLE_BACKGROUND_WORKERS`. Cancelled cleanly before pool close.
- **v1 scope: human-send only.** `bot_generate_fn` is a sentinel raising `NotImplementedError`; bot auto-reply (RAG wiring) is a follow-up PR.

## 4-LLM panel (DeepSeek + Codex + Gemini — all APPROVE-WITH-CHANGES)

| Fix | Source | Applied |
|---|---|---|
| Startup race | all 3 | `db_pool` is set inside the background `_background_light_init` task → scheduler spawned THERE (after `initialize_services_light`) with a not-None guard. Never starts on a `None` pool. |
| **Poison row** | Codex (verified on real code) | `wa_outbox_worker` awaited `bot_generate_fn` with **no try/except** → a raise left the row orphaned in `generating` (reclaim only resets `claimed`). Now wrapped with the same retry/backoff→failed policy as send. |
| Hot loop | Codex + Gemini | `sleep(0.1)` after `sent` (yield), full interval when idle. |

## Tests

4 scheduler (cadence sent→idle, exception-resilience, clean-cancel, v1-sentinel) + 2 worker (bot-gen failure re-queues / terminal after MAX_ATTEMPTS). **12/12 green**; `main_api` assembles (547 routes, scheduler fn present); dep-import smoke OK.

## Deploy note

Ships on the `api` process group (always-on). After merge + deploy, the loop starts automatically. Live verification: enqueue a human send via the local UI `POST /threads/{id}/send` → `wa_outbox` row `pending → done`, `meta_inbox_messages` `sending → sent`, message delivered on WhatsApp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)