### PR TITLE
fix(backend-rag): grant team/admin runtime DB reads

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/207_team_admin_runtime_grants.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/207_team_admin_runtime_grants.sql
@@ -1,0 +1,84 @@
+-- 207_team_admin_runtime_grants.sql
+-- Runtime read grants for team/admin dashboard endpoints.
+--
+-- Live symptom fixed by this migration:
+-- - /api/admin/team-activity/overview denied SELECT on conversations
+-- - /api/admin/team-activity/team-stats reads v_messages and activity rollups
+-- - /api/team/my-status denied SELECT on team_online_status
+--
+-- The objects are historical/prod-owned in some environments, so every grant is
+-- guarded with to_regclass(). The runtime role is absent in CI test databases,
+-- so the whole migration is guarded on pg_roles.
+
+DO $grant_block$
+DECLARE
+    runtime_role text := 'backend_rag_v2';
+    object_name text;
+    object_reg regclass;
+    read_objects text[] := ARRAY[
+        'public.conversations',
+        'public.v_messages',
+        'public.team_online_status',
+        'public.daily_work_hours',
+        'public.weekly_work_summary',
+        'public.monthly_work_summary',
+        'public.team_timesheet',
+        'public.team_members',
+        'public.activity_log',
+        'public.email_activity_log',
+        'public.knowledge_activity_log',
+        'public.kg_nodes',
+        'public.kg_edges'
+    ];
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = runtime_role) THEN
+        RETURN;
+    END IF;
+
+    GRANT USAGE ON SCHEMA public TO backend_rag_v2;
+
+    FOREACH object_name IN ARRAY read_objects LOOP
+        object_reg := to_regclass(object_name);
+
+        IF object_reg IS NOT NULL THEN
+            EXECUTE format('GRANT SELECT ON TABLE %s TO %I', object_reg, runtime_role);
+        END IF;
+    END LOOP;
+END
+$grant_block$;
+
+-- === ROLLBACK ===
+DO $revoke_block$
+DECLARE
+    runtime_role text := 'backend_rag_v2';
+    object_name text;
+    object_reg regclass;
+    read_objects text[] := ARRAY[
+        'public.conversations',
+        'public.v_messages',
+        'public.team_online_status',
+        'public.daily_work_hours',
+        'public.weekly_work_summary',
+        'public.monthly_work_summary',
+        'public.team_timesheet',
+        'public.team_members',
+        'public.activity_log',
+        'public.email_activity_log',
+        'public.knowledge_activity_log',
+        'public.kg_nodes',
+        'public.kg_edges'
+    ];
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = runtime_role) THEN
+        RETURN;
+    END IF;
+
+    FOREACH object_name IN ARRAY read_objects LOOP
+        object_reg := to_regclass(object_name);
+
+        IF object_reg IS NOT NULL THEN
+            EXECUTE format('REVOKE SELECT ON TABLE %s FROM %I', object_reg, runtime_role);
+        END IF;
+    END LOOP;
+END
+$revoke_block$;

--- a/apps/backend-rag/backend/tests/db/test_migration_207_team_admin_runtime_grants.py
+++ b/apps/backend-rag/backend/tests/db/test_migration_207_team_admin_runtime_grants.py
@@ -1,0 +1,101 @@
+"""Contract tests for migration 207 team/admin runtime grants.
+
+The migration fixes live permission denials on team/admin endpoints without
+assuming every historical table or view exists in local/CI databases.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.db.migration_manager import _extract_rollback_sql
+
+MIGRATION_FILE = (
+    Path(__file__).resolve().parents[2]
+    / "db"
+    / "migrations_v2"
+    / "207_team_admin_runtime_grants.sql"
+)
+
+LIVE_ERROR_OBJECTS = (
+    "public.conversations",
+    "public.team_online_status",
+)
+
+TEAM_STATUS_OBJECTS = (
+    "public.daily_work_hours",
+    "public.weekly_work_summary",
+    "public.monthly_work_summary",
+)
+
+ADMIN_TEAM_ACTIVITY_OBJECTS = (
+    "public.v_messages",
+    "public.team_timesheet",
+    "public.team_members",
+    "public.activity_log",
+    "public.email_activity_log",
+    "public.knowledge_activity_log",
+    "public.kg_nodes",
+    "public.kg_edges",
+)
+
+
+def _forward(sql: str) -> str:
+    """Return the forward section applied by the migration runner."""
+    return sql.split("-- === ROLLBACK ===", maxsplit=1)[0]
+
+
+def test_migration_207_file_exists() -> None:
+    assert MIGRATION_FILE.exists()
+
+
+def test_migration_207_has_rollback_marker() -> None:
+    sql = MIGRATION_FILE.read_text()
+
+    assert "-- === ROLLBACK ===" in sql
+    assert _extract_rollback_sql(sql) is not None
+
+
+def test_migration_207_targets_runtime_role_conditionally() -> None:
+    forward = _forward(MIGRATION_FILE.read_text())
+
+    assert "runtime_role text := 'backend_rag_v2'" in forward
+    assert "pg_roles WHERE rolname = runtime_role" in forward
+    assert "GRANT USAGE ON SCHEMA public TO backend_rag_v2" in forward
+
+
+def test_migration_207_is_safe_when_historical_objects_are_missing() -> None:
+    forward = _forward(MIGRATION_FILE.read_text())
+
+    assert "to_regclass(object_name)" in forward
+    assert "IF object_reg IS NOT NULL" in forward
+
+
+def test_migration_207_grants_live_error_objects() -> None:
+    forward = _forward(MIGRATION_FILE.read_text())
+
+    for object_name in LIVE_ERROR_OBJECTS:
+        assert object_name in forward
+
+
+def test_migration_207_grants_team_status_dependencies() -> None:
+    forward = _forward(MIGRATION_FILE.read_text())
+
+    for object_name in TEAM_STATUS_OBJECTS:
+        assert object_name in forward
+
+
+def test_migration_207_grants_admin_team_activity_dependencies() -> None:
+    forward = _forward(MIGRATION_FILE.read_text())
+
+    for object_name in ADMIN_TEAM_ACTIVITY_OBJECTS:
+        assert object_name in forward
+
+
+def test_migration_207_rollback_revokes_same_select_grants() -> None:
+    rollback = _extract_rollback_sql(MIGRATION_FILE.read_text())
+
+    assert rollback is not None
+    assert "REVOKE SELECT ON TABLE" in rollback
+    for object_name in LIVE_ERROR_OBJECTS + TEAM_STATUS_OBJECTS + ADMIN_TEAM_ACTIVITY_OBJECTS:
+        assert object_name in rollback


### PR DESCRIPTION
## Summary
- add migration 207 to grant backend_rag_v2 read access for team/admin dashboard objects
- guard grants with pg_roles and to_regclass for CI/local compatibility
- add DB migration contract tests for live error objects and rollback extraction

## Verification
- PYTHONPATH=. pytest backend/tests/db/test_migration_207_team_admin_runtime_grants.py backend/tests/db/test_migration_uniqueness.py backend/tests/db/test_migration_rollback_extraction.py -q
- PYTHONPATH=. pytest backend/tests/services/analytics/test_team_timesheet_svc.py tests/unit/routers/test_team_activity_router.py -q
- PYTHONPATH=. pytest backend/tests/unit/routers/test_admin_team_activity.py -q
- ruff check backend/tests/db/test_migration_207_team_admin_runtime_grants.py
- local Pro dev Postgres transaction smoke: forward + rollback of migration 207, transaction rolled back