### PR TITLE
fix(backend-rag): make team admin grants runtime safe

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/207_team_admin_runtime_grants.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/207_team_admin_runtime_grants.sql
@@ -9,10 +9,15 @@
 -- The objects are historical/prod-owned in some environments, so every grant is
 -- guarded with to_regclass(). The runtime role is absent in CI test databases,
 -- so the whole migration is guarded on pg_roles.
+--
+-- In production this migration is executed by the runtime role. That role can
+-- verify its existing privileges, but cannot grant privileges on objects owned
+-- by other roles. If owner-level grants are still missing, fail with a precise
+-- manual-remediation message instead of a raw PostgreSQL permission error.
 
 DO $grant_block$
 DECLARE
-    runtime_role text := 'backend_rag_v2';
+    runtime_role constant text := 'backend_rag_v2';
     object_name text;
     object_reg regclass;
     read_objects text[] := ARRAY[
@@ -35,13 +40,45 @@ BEGIN
         RETURN;
     END IF;
 
-    GRANT USAGE ON SCHEMA public TO backend_rag_v2;
+    IF NOT has_schema_privilege(runtime_role, 'public', 'USAGE') THEN
+        BEGIN
+            GRANT USAGE ON SCHEMA public TO backend_rag_v2;
+        EXCEPTION
+            WHEN insufficient_privilege THEN
+                RAISE WARNING
+                    'manual grant required: GRANT USAGE ON SCHEMA public TO %',
+                    runtime_role;
+        END;
+    END IF;
+
+    IF NOT has_schema_privilege(runtime_role, 'public', 'USAGE') THEN
+        RAISE EXCEPTION
+            'backend_rag_v2 is missing USAGE on schema public; apply manual grant with an owner/admin role';
+    END IF;
 
     FOREACH object_name IN ARRAY read_objects LOOP
         object_reg := to_regclass(object_name);
 
-        IF object_reg IS NOT NULL THEN
-            EXECUTE format('GRANT SELECT ON TABLE %s TO %I', object_reg, runtime_role);
+        IF object_reg IS NULL THEN
+            CONTINUE;
+        END IF;
+
+        IF NOT has_table_privilege(runtime_role, object_reg, 'SELECT') THEN
+            BEGIN
+                EXECUTE format('GRANT SELECT ON TABLE %s TO %I', object_reg, runtime_role);
+            EXCEPTION
+                WHEN insufficient_privilege THEN
+                    RAISE WARNING
+                        'manual grant required: GRANT SELECT ON TABLE % TO %',
+                        object_name,
+                        runtime_role;
+            END;
+        END IF;
+
+        IF NOT has_table_privilege(runtime_role, object_reg, 'SELECT') THEN
+            RAISE EXCEPTION
+                'backend_rag_v2 is missing SELECT on %; apply manual grant with an owner/admin role',
+                object_name;
         END IF;
     END LOOP;
 END

--- a/apps/backend-rag/backend/tests/db/test_migration_207_team_admin_runtime_grants.py
+++ b/apps/backend-rag/backend/tests/db/test_migration_207_team_admin_runtime_grants.py
@@ -59,7 +59,7 @@ def test_migration_207_has_rollback_marker() -> None:
 def test_migration_207_targets_runtime_role_conditionally() -> None:
     forward = _forward(MIGRATION_FILE.read_text())
 
-    assert "runtime_role text := 'backend_rag_v2'" in forward
+    assert "runtime_role constant text := 'backend_rag_v2'" in forward
     assert "pg_roles WHERE rolname = runtime_role" in forward
     assert "GRANT USAGE ON SCHEMA public TO backend_rag_v2" in forward
 
@@ -68,7 +68,19 @@ def test_migration_207_is_safe_when_historical_objects_are_missing() -> None:
     forward = _forward(MIGRATION_FILE.read_text())
 
     assert "to_regclass(object_name)" in forward
-    assert "IF object_reg IS NOT NULL" in forward
+    assert "IF object_reg IS NULL THEN" in forward
+    assert "CONTINUE;" in forward
+
+
+def test_migration_207_checks_existing_privileges_before_granting() -> None:
+    forward = _forward(MIGRATION_FILE.read_text())
+
+    assert "has_schema_privilege(runtime_role, 'public', 'USAGE')" in forward
+    assert "has_table_privilege(runtime_role, object_reg, 'SELECT')" in forward
+    assert "WHEN insufficient_privilege THEN" in forward
+    assert "manual grant required: GRANT USAGE ON SCHEMA public" in forward
+    assert "manual grant required: GRANT SELECT ON TABLE" in forward
+    assert "apply manual grant with an owner/admin role" in forward
 
 
 def test_migration_207_grants_live_error_objects() -> None:


### PR DESCRIPTION
## Summary
- make migration 207 safe when the Fly release command runs as the runtime role
- skip grants when privileges are already present, and emit explicit manual-grant remediation when they are missing
- update contract tests for privilege checks and missing historical objects

## Verification
- `PYTHONPATH=. pytest backend/tests/db/test_migration_207_team_admin_runtime_grants.py backend/tests/db/test_migration_uniqueness.py backend/tests/db/test_migration_rollback_extraction.py -q` -> 19 passed
- `ruff check backend/tests/db/test_migration_207_team_admin_runtime_grants.py` -> pass
- asyncpg transactional smoke on `nuzantara_dev`: forward twice, privilege checks for `conversations`, `v_messages`, `team_online_status`, rollback, transaction rollback -> ok
- `pytest tests/unit/routers/test_team_activity_router.py -q` -> 59 passed
- `pytest backend/tests/unit/routers/test_admin_team_activity.py -q` -> 29 passed

## Note
The combined team/admin router run currently has 2 legacy allowlist failures only when both files are collected together; both files pass independently and this PR only changes the SQL migration contract.