### PR TITLE
feat(evolver): world-scan — learn failure patterns from the outside world

### DIFF
--- a/agent-library/scar_replay/test_world_scan_translate.py
+++ b/agent-library/scar_replay/test_world_scan_translate.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Test the world-scan translator's deterministic grade WITHOUT network.
+
+The whole anti-"plausible-wisdom" firewall lives in _grade(): an LLM saying
+"ADOPT" is not enough — the draft must contain the structural ingredients of a
+real executable probe. These tests pin that gate.
+"""
+from __future__ import annotations
+
+import world_scan_translate as wt
+
+
+def _good_dict():
+    return {
+        "applicable": True,
+        "expressible": True,
+        "family": "stale_lock_not_released",
+        "incident_summary": (
+            "A cron job acquires a file lock then crashes before releasing it; "
+            "the next run blocks forever waiting on the orphaned lock."
+        ),
+        "contract": (
+            "The antibody receives LOCK_PATH and MAX_AGE_SECONDS; it must ensure "
+            "a lock older than MAX_AGE_SECONDS is treated as stale and reclaimed."
+        ),
+        "fixture_sketch": (
+            "mktemp -d; create LOCK_PATH with an mtime 2h in the past via touch -t; "
+            "run the job's lock-acquire step under the antibody."
+        ),
+        "assertion_sketch": (
+            "after the antibody runs, exit code is 0 and the job proceeded "
+            "(grep the run-log for 'acquired'); the stale lock file was removed."
+        ),
+        "baseline_fails_rationale": (
+            "without the antibody the acquire blocks/aborts; exit code != 0."
+        ),
+    }
+
+
+def test_good_pattern_is_adopt():
+    cat, ok, reasons = wt._grade(_good_dict())
+    assert cat == "ADOPT", f"a fully-specified executable probe must be ADOPT, reasons={reasons}"
+    assert ok is True
+    assert reasons == []
+
+
+def test_not_applicable_is_reject():
+    d = _good_dict()
+    d["applicable"] = False
+    cat, ok, reasons = wt._grade(d)
+    assert cat == "REJECT" and ok is False
+
+
+def test_not_expressible_is_observe():
+    d = _good_dict()
+    d["expressible"] = False
+    cat, ok, reasons = wt._grade(d)
+    assert cat == "OBSERVE", "a real-but-unsandboxable failure class is OBSERVE, not ADOPT"
+    assert ok is False
+
+
+def test_assertion_that_defers_to_llm_is_not_adopt():
+    d = _good_dict()
+    d["assertion_sketch"] = "an LLM reviews whether the output looks correct and reasonable"
+    cat, ok, reasons = wt._grade(d)
+    assert ok is False, "an assertion that defers to an LLM judgment must NOT be executable"
+    assert cat == "OBSERVE"
+    assert any("judgment" in r for r in reasons)
+
+
+def test_assertion_without_executable_markers_is_not_adopt():
+    d = _good_dict()
+    d["assertion_sketch"] = "the system behaves better afterwards"  # vague, no markers
+    cat, ok, reasons = wt._grade(d)
+    assert ok is False
+    assert any("executable markers" in r for r in reasons)
+
+
+def test_thin_fixture_is_not_adopt():
+    d = _good_dict()
+    d["fixture_sketch"] = "do stuff"  # too short
+    cat, ok, reasons = wt._grade(d)
+    assert ok is False
+    assert any("fixture_sketch too thin" in r for r in reasons)
+
+
+def test_bad_family_id_flagged():
+    d = _good_dict()
+    d["family"] = "Stale Lock!"  # not snake_case
+    cat, ok, reasons = wt._grade(d)
+    assert ok is False
+    assert any("family id not snake_case" in r for r in reasons)
+
+
+def test_render_does_not_crash_and_shows_category():
+    draft = wt.translate_pattern.__wrapped__ if hasattr(wt.translate_pattern, "__wrapped__") else None
+    # build a DraftProbe directly to test rendering
+    d = wt.DraftProbe(pattern_title="Test pattern", category="ADOPT", family="x_y_z",
+                      incident_summary="s", contract="c", fixture_sketch="f",
+                      assertion_sketch="exit code 0", baseline_fails_rationale="b",
+                      executable=True)
+    md = wt.render_draft_md(d)
+    assert "ADOPT" in md and "Test pattern" in md
+    assert "scar_probes.py" in md  # the human-promotion instruction is present
+
+
+def test_extract_json_tolerates_fences():
+    assert wt._extract_json('```json\n{"a": 1}\n```') == {"a": 1}
+    assert wt._extract_json('prose before {"b": 2} prose after') == {"b": 2}
+    assert wt._extract_json("no json here") is None
+
+
+def _main() -> int:
+    fails = []
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            print(f"FAIL {t.__name__}: {e}")
+            fails.append(t.__name__)
+        except Exception as e:  # noqa
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+            fails.append(t.__name__)
+    print(f"\n{len(tests)-len(fails)}/{len(tests)} passed")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/agent-library/scar_replay/world-scan-agent.md
+++ b/agent-library/scar_replay/world-scan-agent.md
@@ -1,0 +1,93 @@
+---
+name: world-scan
+description: Weekly external-novelty scout for the agent-library evolver. Researches public SRE / security / autonomous-agent failure patterns, translates each into a DRAFT executable replay-probe (baseline-fails fault-injection test), runs it through a deterministic executability gate, and stages ADOPT candidates for human promotion into scar_probes.py. NEVER auto-merges. Use when the evolver should learn from the outside world, not only from its own scars.
+tools: Read, Write, Bash, WebSearch, WebFetch
+model: claude-opus-4-8
+---
+
+# world-scan — the evolver's window onto the outside world
+
+The scar-replay harness (`agent-library/scar_replay/`) makes the evolver learn from its
+**own** past — every cicatrix scar becomes a deterministic replay-probe whose baseline fails
+by construction, and the LLM must generate an _executable_ antibody that survives the
+original fault plus hidden variants. That is **inward** learning.
+
+`world-scan` is the **outward** half: once a week it asks _"what failure modes has the rest of
+the engineering world discovered that we haven't been bitten by yet?"_ — and tries to turn the
+good ones into probes **before** they become our next incident.
+
+It is a deliberate, reuse-first fork of `wr2-external-bench` (the brand bench that ingests SOTA
+editorial references → DeepSeek extract → synth → devils-advocate gate → `_proposed/` → human
+commit). Same skeleton, different domain and different acceptance test.
+
+## The non-negotiable: external wisdom enters as CODE, never as prose
+
+The council that designed this (3-LLM, unanimous 2026-06-04) flagged one trap above all: a
+"world best-practices digest" degrades into plausible-sounding advice that quietly bloats the
+system and is never falsifiable. The firewall against that is absolute:
+
+> An external pattern earns **ADOPT** only if it can be expressed as a deterministic replay-probe
+> whose baseline **fails** and whose assertion is a **local executable check** (exit code / file
+> state / branch / process / lock) — _never_ an LLM or human judgment.
+
+If the pattern is real but cannot be sandboxed deterministically → **OBSERVE** (worth watching,
+not yet a probe). If it does not apply to our stack → **REJECT**. The gate (`_grade()` in
+`world_scan_translate.py`) is **deterministic Python**, run _on top of_ the LLM verdict: the LLM
+saying "ADOPT" is necessary but **not sufficient**. This is the same anti-overfit principle as the
+harness's scoring-is-local-executable rule.
+
+## Pipeline (5 phases)
+
+1. **INGEST** — web search the last ~30 days of public engineering write-ups: SRE / reliability
+   (toil, retries, idempotency, locking, queues), chaos engineering & fault injection, autonomous-
+   agent / LLM-agent failure modes (loops, drift, tool misuse, runaway state), CI/CD & git-worktree /
+   deploy hazards. Prefer concrete incident reports & postmortems; reject listicles.
+2. **EXTRACT** — distill 6–12 _distinct, concrete, testable_ failure mechanics into strict JSON
+   (`title`, `text`, `source`). Vague/cultural advice is dropped here.
+3. **TRANSLATE** — `world_scan_translate.py` sends each pattern to DeepSeek (`deepseek-v4-pro`)
+   with a strict contract: produce the SPEC of a probe (incident_summary / contract /
+   fixture_sketch / assertion_sketch / baseline_fails_rationale) or honestly declare it
+   non-expressible. **No PII ever leaves the machine** — patterns are generic engineering
+   know-how, not client data (Law 2 clean).
+4. **GATE** — the deterministic `_grade()` firewall: field-substance thresholds + executable-marker
+   regex + judgment-deferral anti-markers + snake_case family check → ADOPT / OBSERVE / REJECT.
+5. **STAGE + NOTIFY** — write all drafts to
+   `research/operations/_proposed/<YYYY-Www>-world-scan-probes.md` (ADOPT first), Telegram a one-line
+   summary to Antonello. **Stop there.** A human reads the ADOPT drafts and, for the good ones,
+   writes a real `Probe` in `scar_probes.py` (fixture + assertion as code) and commits it. The loop
+   that _promotes_ is a human; world-scan only _proposes_.
+
+## Boundaries (load-bearing)
+
+- **Never auto-merge / never write into `scar_probes.py`.** Output is a staged proposal only (Law 5
+  — alert/act on the human only where judgment is irreducible; promoting a new live probe is exactly
+  that).
+- **Never send PII to any cloud LLM.** This scans the public engineering world; the inputs are
+  generic failure mechanics. Client KTP/passport/NPWP/OSINT never appear here (Law 2).
+- **OAuth-only for Claude** (ingest agent shells out to the `claude` CLI with MAX-plan quota; the
+  Anthropic SDK / `ANTHROPIC_API_KEY` are banned). DeepSeek (`deepseek-v4-pro`, ~$0.01/q) is the
+  sanctioned paid path for the non-PII translate step.
+- **Worktree isolation.** The runner refuses to execute from inside the shared `nuzantara-deploy`
+  worktree (same hard-guard as `scar-replay-run.sh`) to avoid the deploy-drift scar family
+  (W50/W52/2026-05-25/2026-06-03).
+- **Idempotent.** One scan per ISO week; re-running is a no-op unless the staging file is deleted.
+- **Graceful degradation.** If ingest produces nothing, or translation fails, it Telegrams the human
+  and exits non-zero — it does **not** stage an empty or fabricated file (Law 4).
+
+## How it grows
+
+- A new external failure-class the world discovers → ingest surfaces it → if expressible, it lands
+  as an ADOPT draft → a human promotes it → the harness now has one more probe → the evolver is
+  measurably stronger on a class of failure **we never had to suffer first**.
+- The translator's `_grade()` thresholds are tunable as we learn what separates a real probe-spec
+  from plausible mush. Tighten when noise rises; loosen only with evidence.
+
+## Run
+
+```bash
+# manual induction (no cron wait):
+bash agent-library/scar_replay/world-scan-run.sh
+# scheduled: weekly LaunchAgent, low-traffic window. Cost ~$0.05/week.
+```
+
+Output: `research/operations/_proposed/<week>-world-scan-probes.md` + Telegram summary.

--- a/agent-library/scar_replay/world-scan-run.sh
+++ b/agent-library/scar_replay/world-scan-run.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+# world-scan-run.sh — weekly external failure-pattern scan for the evolver.
+#
+# Reuse-first (2026-06-04): forked from ~/scripts/wr2-external-bench-run.sh.
+# ~80% reused (multi-LLM ingest+extract via a Claude agent, DeepSeek translate
+# via world_scan_translate.py, devils-advocate-style gate built into the
+# translator's deterministic grade, _proposed/ staging, Telegram). The only NEW
+# code is world_scan_translate.py (pattern -> draft executable probe).
+#
+# Pipeline:
+#   1. INGEST+EXTRACT (Claude Opus agent w/ web search): scan SRE/security/
+#      agent-failure sources -> JSON list of failure patterns.
+#   2. TRANSLATE (world_scan_translate.py + DeepSeek): each pattern -> draft probe
+#      with a DETERMINISTIC executability gate (ADOPT/OBSERVE/REJECT).
+#   3. STAGE: write drafts to research/operations/_proposed/<date>-world-scan.md.
+#   4. NOTIFY: Telegram summary to Antonello. NEVER auto-merge; human promotes
+#      an ADOPT draft into scar_probes.py by hand.
+#
+# Cron: weekly (1st-of-week guard inside). Schedule via LaunchAgent.
+# Cost: ~$0.05/week (Gemini/Claude OAuth + DeepSeek translate calls).
+
+set -euo pipefail
+
+LOGDIR="${HOME}/logs"; mkdir -p "$LOGDIR"
+LOG="$LOGDIR/world-scan.log"
+ERR="$LOGDIR/world-scan.err.log"
+
+HARNESS_DIR="${SCAR_REPLAY_DIR:-${HOME}/Desktop/nuzantara-deploy/agent-library/scar_replay}"
+REPO_ROOT="${WORLD_SCAN_REPO_ROOT:-${HOME}/Desktop/nuzantara-deploy}"
+WEEK_TAG="$(date +%Y-W%V)"
+PROPOSED_DIR="${REPO_ROOT}/research/operations/_proposed"
+OUTPUT_FILE="${PROPOSED_DIR}/${WEEK_TAG}-world-scan-probes.md"
+PATTERNS_JSON="/tmp/world-scan-patterns-${WEEK_TAG}.json"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" >> "$LOG"; }
+
+# telegram_alert: reused verbatim from scar-replay-run.sh (#1090). Resolves token
+# + chat id from sanctioned vaults; tolerates OWNER vs APPROVAL chat-id naming
+# drift; suppresses silently if creds unresolved (Law 4 — never block on outage).
+telegram_alert() {
+  local msg="$1"
+  local tok="${TELEGRAM_BOT_TOKEN:-}"
+  local chat="${TELEGRAM_OWNER_CHAT_ID:-${TELEGRAM_APPROVAL_CHAT_ID:-}}"
+  if [[ -z "${tok}" || -z "${chat}" ]]; then
+    for f in "${HOME}/.nuzantara-secrets.env" "${HOME}/.openclaw/workspace/.env.master"; do
+      [[ -f "$f" ]] || continue
+      [[ -z "${tok}"  ]] && tok="$(grep -m1 -E '^TELEGRAM_BOT_TOKEN=' "$f" 2>/dev/null | cut -d= -f2- | tr -d '"')"
+      [[ -z "${chat}" ]] && chat="$(grep -m1 -E '^TELEGRAM_(OWNER|APPROVAL)_CHAT_ID=' "$f" 2>/dev/null | cut -d= -f2- | tr -d '"')"
+    done
+  fi
+  if [[ -z "${tok}" || -z "${chat}" ]]; then
+    log "WARN: telegram creds unresolved — human-alert suppressed: ${msg}"
+    return 0
+  fi
+  curl -sS --max-time 20 -X POST "https://api.telegram.org/bot${tok}/sendMessage" \
+    -d "chat_id=${chat}" -d "text=${msg}" >/dev/null 2>&1 || true
+}
+
+log "world-scan starting (week=${WEEK_TAG}, out=${OUTPUT_FILE})"
+
+# --- idempotence: one scan per week ---
+if [ -s "$OUTPUT_FILE" ]; then
+  log "skip: ${OUTPUT_FILE} already exists ($(wc -l < "$OUTPUT_FILE") lines). Delete to re-run."
+  exit 0
+fi
+
+# --- worktree-isolation guard (same discipline as scar-replay-run.sh): never
+#     run from inside the shared deploy worktree ---
+case "$(pwd -P)/" in
+  "${REPO_ROOT}/"*) log "REFUSE: cwd inside shared deploy worktree; aborting."; exit 0 ;;
+esac
+
+# --- secrets: DEEPSEEK_API_KEY (with vault drift fallback) + telegram ---
+DS_KEY="${DEEPSEEK_API_KEY:-}"
+if [ -z "$DS_KEY" ]; then
+  for f in "${HOME}/.nuzantara-secrets.env" "${HOME}/.openclaw/workspace/.env.master"; do
+    [ -f "$f" ] || continue
+    line=$(grep -m1 -E '^DEEPSEEK_API_KEY=' "$f" 2>/dev/null || true)
+    [ -n "$line" ] && { DS_KEY="${line#DEEPSEEK_API_KEY=}"; DS_KEY="${DS_KEY%\"}"; DS_KEY="${DS_KEY#\"}"; break; }
+  done
+fi
+if [ -z "$DS_KEY" ]; then
+  log "FATAL: DEEPSEEK_API_KEY not found in any vault — cannot translate. Aborting."
+  exit 2
+fi
+export DEEPSEEK_API_KEY="$DS_KEY"
+
+mkdir -p "$PROPOSED_DIR"
+
+# --- Step 1: INGEST + EXTRACT via Claude Opus agent (OAuth-only, web search) ---
+# Reuse of the wr2-external-bench invocation shape. The agent does the web
+# research and emits a strict JSON array of failure patterns to PATTERNS_JSON.
+INGEST_PROMPT="You are world-scan, the evolver's external research scout.
+
+Research the LAST ~30 days of public best-practices and post-mortems on:
+  - SRE / reliability engineering (toil, retries, idempotency, locking, queues)
+  - chaos engineering & fault injection
+  - autonomous-agent / LLM-agent failure modes (loops, drift, tool misuse, state)
+  - CI/CD & git-worktree / deploy hazards
+Use web search. Prefer concrete engineering write-ups (incident reports, SRE
+books/blogs, postmortems), NOT listicles.
+
+Extract 6-12 DISTINCT failure patterns relevant to a self-improving ops agent
+that runs local git worktrees, LaunchAgent cron, shell scripts, Postgres.
+
+Write ONLY a strict JSON array to ${PATTERNS_JSON}, each item:
+  {\"title\": \"...\", \"text\": \"2-4 sentence description of the failure mode and why it bites\", \"source\": \"url or outlet\"}
+No prose around the JSON. Reject vague/cultural advice — only concrete, testable failure mechanics."
+
+CLAUDE_BIN="${HOME}/.local/bin/claude"; [ -x "$CLAUDE_BIN" ] || CLAUDE_BIN="/opt/homebrew/bin/claude"
+
+log "step1: ingest+extract via claude opus (web search)"
+timeout 1800 "$CLAUDE_BIN" -p \
+  --model claude-opus-4-8 \
+  --permission-mode bypassPermissions \
+  "$INGEST_PROMPT" >> "$LOG" 2>> "$ERR" || log "WARN: ingest agent exit=$?"
+
+if [ ! -s "$PATTERNS_JSON" ]; then
+  log "FATAL: no patterns JSON produced at ${PATTERNS_JSON}. Aborting."
+  # Telegram: this needs a human (ingest produced nothing).
+  telegram_alert "⚠️ world-scan ${WEEK_TAG}: ingest produced no patterns. Check ${ERR}."
+  exit 3
+fi
+log "step1 done: $(wc -c < "$PATTERNS_JSON") bytes of patterns"
+
+# --- Step 2+3: TRANSLATE each pattern + STAGE drafts ---
+log "step2: translate patterns -> draft probes (DeepSeek + deterministic gate)"
+PYTHONPATH="${HARNESS_DIR}" python3 - "$PATTERNS_JSON" "$OUTPUT_FILE" "$WEEK_TAG" <<'PYEOF' >> "$LOG" 2>> "$ERR"
+import json, sys, os, datetime
+sys.path.insert(0, os.environ["PYTHONPATH"])
+import world_scan_translate as wt
+
+patterns_path, out_path, week = sys.argv[1], sys.argv[2], sys.argv[3]
+key = os.environ["DEEPSEEK_API_KEY"]
+patterns = json.load(open(patterns_path))
+if not isinstance(patterns, list):
+    print("patterns JSON is not a list — abort"); sys.exit(4)
+
+drafts = []
+for p in patterns:
+    title = (p.get("title") or "untitled").strip()
+    text = (p.get("text") or "") + "\nSource: " + (p.get("source") or "")
+    d = wt.translate_pattern(key, title, text)
+    d.source_refs = p.get("source") or title
+    drafts.append(d)
+
+adopt = [d for d in drafts if d.category == "ADOPT"]
+observe = [d for d in drafts if d.category == "OBSERVE"]
+reject = [d for d in drafts if d.category == "REJECT"]
+
+header = (
+    f"# World-Scan draft probes — {week}\n\n"
+    f"> Auto-generated by world-scan (reuse-first fork of wr2-external-bench). "
+    f"These are DRAFT replay-probes proposed from external failure patterns. "
+    f"**Nothing here is live.** A human promotes an ADOPT draft into "
+    f"`agent-library/scar_replay/scar_probes.py` by hand (fixture + assertion as "
+    f"code) and commits it. Never auto-merged (Law 5).\n\n"
+    f"**Summary:** {len(adopt)} ADOPT · {len(observe)} OBSERVE · {len(reject)} REJECT "
+    f"(of {len(drafts)} patterns scanned).\n\n---\n\n"
+)
+body = "".join(wt.render_draft_md(d) for d in (adopt + observe + reject))
+open(out_path, "w").write(header + body)
+print(f"WORLD_SCAN_SUMMARY adopt={len(adopt)} observe={len(observe)} reject={len(reject)} total={len(drafts)}")
+PYEOF
+
+if [ ! -s "$OUTPUT_FILE" ]; then
+  log "FATAL: translation produced no output file. Check ${ERR}."
+  telegram_alert "⚠️ world-scan ${WEEK_TAG}: translation failed. Check ${ERR}."
+  exit 5
+fi
+
+SUMMARY=$(grep -h "WORLD_SCAN_SUMMARY" "$LOG" | tail -1 || echo "summary unavailable")
+log "step3 done: ${OUTPUT_FILE} ($(wc -l < "$OUTPUT_FILE") lines) — ${SUMMARY}"
+
+# --- Step 4: notify (human reviews; never auto-merge) ---
+telegram_alert "🌐 world-scan ${WEEK_TAG} done. ${SUMMARY}. Draft probes staged at research/operations/_proposed/${WEEK_TAG}-world-scan-probes.md — review & promote ADOPT drafts by hand."
+log "DONE world-scan ${WEEK_TAG}"
+exit 0

--- a/agent-library/scar_replay/world_scan_translate.py
+++ b/agent-library/scar_replay/world_scan_translate.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""
+world_scan_translate.py — the ONE new piece of the world-scan.
+
+Reuse-first audit (2026-06-04): ~80% of the world-scan already exists in-house
+(wr2-external-bench runner, devils-advocate gate, ai-dispatch cascade, _proposed/
+convention). The only genuinely new code is THIS: the translator that turns an
+external failure-pattern (e.g. "chaos engineering: inject network latency to test
+timeout handling") into a DRAFT replay-probe for scar_probes.py — a deterministic
+fault-injection test where the baseline FAILS.
+
+Anti-overfit / anti-"plausible-wisdom" firewall (council 2026-06-04, unanimous):
+external best-practices DO NOT enter the harness as prose. A pattern only earns
+ADOPT if it can be expressed as an EXECUTABLE probe whose baseline fails. If the
+LLM can't articulate a concrete fixture (precondition + fault + assertion), it is
+OBSERVE (worth watching, not yet a probe) — never silently promoted.
+
+This module:
+  1. Sends each extracted pattern to DeepSeek with a strict translation contract.
+  2. Applies DETERMINISTIC executability checks on top of the LLM verdict (the LLM
+     proposing "ADOPT" is necessary but NOT sufficient — the draft must contain the
+     structural ingredients of a real probe).
+  3. Emits a draft-probe markdown block + a category (ADOPT / OBSERVE / REJECT).
+
+It does NOT write into scar_probes.py and does NOT auto-merge. Output is staged for
+human review (Law 5 — the human decides what becomes a real probe).
+
+Provenance (reuse-first §7):
+  - DeepSeek curl shape: adapted from ~/scripts/eventbus/devils_advocate_runner.py
+    (model deepseek-v4-pro, reasoning_effort high) — NOT the stale deepseek-reasoner
+    in the devils-advocate.md spec.
+  - cascade/quota-detection: pattern from ~/scripts/claude-cascade.sh.
+  License: in-house (Nuzantara repo). No third-party code copied.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import subprocess
+from dataclasses import dataclass, field
+from typing import Optional
+
+logger = logging.getLogger("world_scan_translate")
+
+_DEEPSEEK_URL = "https://api.deepseek.com/v1/chat/completions"
+_DEEPSEEK_MODEL = "deepseek-v4-pro"  # NOT deepseek-reasoner (deprecated, silent flash)
+
+
+# --------------------------------------------------------------------------- #
+# Data model                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class DraftProbe:
+    pattern_title: str
+    category: str = "REJECT"          # ADOPT | OBSERVE | REJECT
+    family: str = ""                  # snake_case family id for scar_probes.py
+    incident_summary: str = ""        # what the candidate LLM would see (no fix)
+    contract: str = ""                # what an antibody must guarantee
+    fixture_sketch: str = ""          # how to build the pre-error state + inject the fault
+    assertion_sketch: str = ""        # the executable, local check (NOT an LLM judgment)
+    baseline_fails_rationale: str = ""# WHY the baseline fails by construction (headroom)
+    source_refs: str = ""             # where this pattern came from
+    executable: bool = False          # deterministic gate: does it have all probe ingredients?
+    reasons: list[str] = field(default_factory=list)
+
+
+# --------------------------------------------------------------------------- #
+# DeepSeek translation call (reuse of the devils_advocate curl shape)          #
+# --------------------------------------------------------------------------- #
+
+_TRANSLATE_SYSTEM = (
+    "You convert an external software-failure pattern into the SPEC of a "
+    "deterministic replay-probe for a self-improving ops agent. A replay-probe "
+    "is a test that: (1) builds a minimal pre-error state in an ephemeral "
+    "sandbox, (2) injects the exact fault, (3) asserts a LOCAL, EXECUTABLE "
+    "outcome (exit code / file state / process state) — never an LLM judgment. "
+    "The probe's BASELINE (no guard applied) must FAIL by construction. "
+    "If the pattern CANNOT be expressed as a concrete deterministic fixture "
+    "(e.g. it's a vague cultural/process recommendation, or needs real external "
+    "infrastructure that can't be sandboxed), say so honestly — do NOT invent a "
+    "fake fixture. Output STRICT JSON only."
+)
+
+_TRANSLATE_USER_TMPL = (
+    "EXTERNAL FAILURE PATTERN:\n{pattern}\n\n"
+    "Our agent operates on: local git worktrees, LaunchAgent cron jobs, shell "
+    "scripts, Postgres via asyncpg, secrets in env vaults, file-based state. "
+    "Probes must be reproducible in an ephemeral mktemp sandbox with NO network "
+    "and NO paid services.\n\n"
+    "Produce STRICT JSON with these keys:\n"
+    '  "applicable": true|false   (is this failure class even relevant to our stack?)\n'
+    '  "expressible": true|false  (can it be a deterministic sandbox fixture? be honest)\n'
+    '  "family": "snake_case_id"\n'
+    '  "incident_summary": "what went wrong, plain prose, NO fix, NO variant list"\n'
+    '  "contract": "what env vars an antibody receives + what it must guarantee"\n'
+    '  "fixture_sketch": "concrete steps to build pre-error state + inject the fault in bash/python"\n'
+    '  "assertion_sketch": "the exact LOCAL executable check (exit code / file / branch / process)"\n'
+    '  "baseline_fails_rationale": "why the baseline (no guard) fails by construction"\n'
+    "Return ONLY the JSON object."
+)
+
+
+def _call_deepseek(api_key: str, pattern: str, timeout: int = 180) -> Optional[dict]:
+    body = {
+        "model": _DEEPSEEK_MODEL,
+        "messages": [
+            {"role": "system", "content": _TRANSLATE_SYSTEM},
+            {"role": "user", "content": _TRANSLATE_USER_TMPL.format(pattern=pattern[:2000])},
+        ],
+        "temperature": 0,
+        "seed": 42,
+        "max_tokens": 4000,
+        "reasoning_effort": "high",
+    }
+    try:
+        proc = subprocess.run(
+            ["curl", "-sf", "-X", "POST", _DEEPSEEK_URL,
+             "-H", f"Authorization: Bearer {api_key}",
+             "-H", "Content-Type: application/json",
+             "-d", json.dumps(body)],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("translate: deepseek call failed (%s)", exc)
+        return None
+    if proc.returncode != 0:
+        logger.warning("translate: deepseek rc=%s: %s", proc.returncode, (proc.stderr or "")[:160])
+        return None
+    try:
+        resp = json.loads(proc.stdout)
+        content = resp["choices"][0]["message"]["content"] or ""
+    except (json.JSONDecodeError, KeyError, IndexError, TypeError) as exc:
+        logger.warning("translate: bad deepseek response shape (%s)", exc)
+        return None
+    return _extract_json(content)
+
+
+def _extract_json(text: str) -> Optional[dict]:
+    """Pull the JSON object out of the model's reply (tolerates fences/prose)."""
+    text = text.strip()
+    # strip ```json fences
+    m = re.search(r"```(?:json)?\s*\n(.*?)\n```", text, re.DOTALL)
+    if m:
+        text = m.group(1).strip()
+    # find the outermost {...}
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        return None
+    try:
+        return json.loads(text[start:end + 1])
+    except json.JSONDecodeError:
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic executability gate (the firewall — LLM verdict is NOT enough)  #
+# --------------------------------------------------------------------------- #
+
+# A draft is ADOPT-eligible only if the model returned ALL of these as non-empty
+# and substantive. Anything vague/missing => OBSERVE (or REJECT if not applicable).
+_MIN_FIELD_CHARS = {
+    "fixture_sketch": 40,
+    "assertion_sketch": 25,
+    "baseline_fails_rationale": 25,
+    "incident_summary": 40,
+    "contract": 40,
+}
+
+# Heuristic markers that an assertion is genuinely LOCAL+EXECUTABLE, not a judgment.
+_EXECUTABLE_MARKERS = re.compile(
+    r"exit code|exit status|returncode|\$\?|rev-parse|HEAD|file exists|"
+    r"\bgrep\b|\bdiff\b|process|pid|lock|state|stdout|stderr|"
+    r"=\s*0|!=\s*0|non-zero|unchanged|present|absent",
+    re.IGNORECASE,
+)
+# Anti-markers: an "assertion" that defers to an LLM/human is NOT a valid gate.
+_JUDGMENT_MARKERS = re.compile(
+    r"\bLLM\b|model judges|looks correct|seems|reasonable|review by|ask the|"
+    r"human decides|subjectiv",
+    re.IGNORECASE,
+)
+
+
+def _grade(d: dict) -> tuple[str, bool, list[str]]:
+    """Deterministic grade on top of the LLM's self-report. Returns
+    (category, executable, reasons)."""
+    reasons: list[str] = []
+    if not d.get("applicable", False):
+        return "REJECT", False, ["not applicable to our stack (LLM)"]
+    if not d.get("expressible", False):
+        reasons.append("LLM says not expressible as a deterministic fixture")
+        return "OBSERVE", False, reasons
+
+    # field-substance checks
+    for fld, need in _MIN_FIELD_CHARS.items():
+        val = (d.get(fld) or "").strip()
+        if len(val) < need:
+            reasons.append(f"{fld} too thin ({len(val)}<{need} chars)")
+
+    assertion = (d.get("assertion_sketch") or "")
+    if _JUDGMENT_MARKERS.search(assertion):
+        reasons.append("assertion defers to LLM/human judgment (not a local gate)")
+    if not _EXECUTABLE_MARKERS.search(assertion):
+        reasons.append("assertion lacks executable markers (exit code/file/branch/process)")
+
+    fam = (d.get("family") or "").strip()
+    if not re.fullmatch(r"[a-z][a-z0-9_]{2,40}", fam):
+        reasons.append(f"family id not snake_case usable: {fam!r}")
+
+    executable = len(reasons) == 0
+    category = "ADOPT" if executable else "OBSERVE"
+    return category, executable, reasons
+
+
+def translate_pattern(api_key: str, pattern_title: str, pattern_text: str) -> DraftProbe:
+    """Translate one external failure pattern into a DRAFT probe + category."""
+    draft = DraftProbe(pattern_title=pattern_title, source_refs=pattern_title)
+    d = _call_deepseek(api_key, pattern_text)
+    if d is None:
+        draft.category = "REJECT"
+        draft.reasons = ["translation call failed (no JSON)"]
+        return draft
+
+    draft.family = (d.get("family") or "").strip()
+    draft.incident_summary = (d.get("incident_summary") or "").strip()
+    draft.contract = (d.get("contract") or "").strip()
+    draft.fixture_sketch = (d.get("fixture_sketch") or "").strip()
+    draft.assertion_sketch = (d.get("assertion_sketch") or "").strip()
+    draft.baseline_fails_rationale = (d.get("baseline_fails_rationale") or "").strip()
+
+    draft.category, draft.executable, draft.reasons = _grade(d)
+    return draft
+
+
+# --------------------------------------------------------------------------- #
+# Markdown rendering for the _proposed/ staging file (human review)            #
+# --------------------------------------------------------------------------- #
+
+
+def render_draft_md(draft: DraftProbe) -> str:
+    badge = {"ADOPT": "✅ ADOPT", "OBSERVE": "👁 OBSERVE", "REJECT": "✗ REJECT"}.get(
+        draft.category, draft.category
+    )
+    lines = [
+        f"### {badge} — {draft.pattern_title}",
+        "",
+        f"- **family**: `{draft.family or '(none)'}`",
+        f"- **executable** (deterministic gate): {'yes' if draft.executable else 'NO'}",
+    ]
+    if draft.reasons:
+        lines.append(f"- **gate notes**: {'; '.join(draft.reasons)}")
+    lines += [
+        f"- **source**: {draft.source_refs}",
+        "",
+        "**incident_summary** (what the antibody-author would see):",
+        f"> {draft.incident_summary or '(empty)'}",
+        "",
+        "**contract** (what an antibody must guarantee):",
+        f"> {draft.contract or '(empty)'}",
+        "",
+        "**fixture_sketch** (build pre-error state + inject fault):",
+        "```",
+        draft.fixture_sketch or "(empty)",
+        "```",
+        "**assertion_sketch** (LOCAL executable check — never an LLM judgment):",
+        "```",
+        draft.assertion_sketch or "(empty)",
+        "```",
+        f"**why baseline fails (headroom)**: {draft.baseline_fails_rationale or '(empty)'}",
+        "",
+        "_To promote: a human turns an ADOPT draft into a real `Probe` in "
+        "`scar_probes.py` (with the fixture + assertion as code) and commits it. "
+        "Never auto-merged._",
+        "",
+        "---",
+        "",
+    ]
+    return "\n".join(lines)


### PR DESCRIPTION
## What
Adds **world-scan**, the outward half of the scar-replay evolver harness. While the harness learns from our OWN cicatrix scars (inward), world-scan learns from the engineering world OUTSIDE: a weekly scout that researches public SRE / security / autonomous-agent failure patterns and turns the expressible ones into DRAFT replay-probes for human review.

## The firewall (why this is safe, not noise)
External wisdom enters as **code, never prose**. A pattern earns ADOPT only if it can be a deterministic replay-probe whose baseline FAILS and whose assertion is a LOCAL executable check (exit code / file / branch / process) — never an LLM/human judgment. The gate (`_grade()`) is deterministic Python run ON TOP of the LLM verdict: the LLM saying "ADOPT" is necessary but not sufficient. Real-but-unsandboxable -> OBSERVE. Not-applicable -> REJECT.

## Reuse-first
~80% forked from `wr2-external-bench` (ingest+extract, `_proposed/` staging, Telegram, gate shape). The one genuinely new piece is `world_scan_translate.py`.

## Tests
- `test_world_scan_translate.py`: **9/9** pinning the deterministic gate.
- Verified end-to-end against real DeepSeek: an "orphaned lockfile" pattern produced a clean ADOPT draft-probe (baseline exits 1 by construction; assertion = exit 0 + work_done exists + stale lock reclaimed).

## Boundaries
- **Never auto-merges** / never writes into `scar_probes.py` — output is a staged proposal; a human promotes ADOPT drafts (Law 5).
- **No PII to cloud** — scans generic public engineering know-how only (Law 2).
- OAuth-only for Claude (ingest via CLI); DeepSeek for the non-PII translate step.
- Worktree-isolation guard; idempotent per ISO week; graceful degradation (Law 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)