### PR TITLE
feat(intake): worker orchestrator claim/lease/retry/DLQ (FASE 2)

### DIFF
--- a/apps/backend-rag/backend/services/intake/intake-worker-run.sh
+++ b/apps/backend-rag/backend/services/intake/intake-worker-run.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# com.nuzantara.intake-worker runner — FASE 2.
+#
+# Activates the backend-rag venv and runs the intake worker's OWN internal
+# claim->process->sleep loop (backend.services.intake.worker:main). The worker
+# loops forever on its own cadence; launchd KeepAlive is ONLY for respawn on a
+# hard crash, NOT for driving the cycle (anti retry-storm). On DB-connection
+# retry-exhaust the worker exits 0 so launchd respawns it slowly via
+# ThrottleInterval instead of flapping.
+#
+# Single-instance via flock so two launchd ticks can never overlap workers
+# (the queue is exactly-once via SKIP LOCKED regardless, but flock avoids
+# pointless duplicate processes).
+set -euo pipefail
+
+REPO_ROOT="${INTAKE_REPO_ROOT:-/Users/nuzantara/Desktop/nuzantara}"
+BACKEND="${REPO_ROOT}/apps/backend-rag"
+LOCKFILE="/tmp/com.nuzantara.intake-worker.lock"
+
+exec 9>"${LOCKFILE}"
+if ! flock -n 9; then
+    echo "[intake-worker] another instance holds the lock; exiting 0" >&2
+    exit 0
+fi
+
+cd "${BACKEND}"
+# shellcheck disable=SC1091
+source .venv/bin/activate
+export PYTHONPATH="${BACKEND}"
+exec python -m backend.services.intake.worker

--- a/apps/backend-rag/backend/services/intake/worker.py
+++ b/apps/backend-rag/backend/services/intake/worker.py
@@ -1,0 +1,489 @@
+"""Unified document-intake worker orchestrator (FASE 2).
+
+Forks the SKIP-LOCKED claim/lease/heartbeat/retry/DLQ pattern from
+`backend.services.workflow.queue` and adapts it to the unified `intake_queue`
+(migration 206). PII stays 100% local (Law 2 / UU-PDP): no cloud LLM, no OCR
+here (that's FASE 3) — the per-stage handlers are STUB passthroughs that emit
+an `intake_stage_metrics` row and advance the job's status.
+
+Stage machine (all stub, all claimable statuses per idx_iq_claimable):
+
+    pending --classify--> processing --ocr--> ocr --extract--> classified
+        --validate--> extracted --route--> done
+
+Each claim advances EXACTLY ONE stage, then re-enqueues the row (next_visible_at
+= now) so a sibling worker can pick up the next stage. Terminal states:
+  - 'done'  : routed through all stub stages.
+  - 'dead'  : retry budget exhausted (attempts >= max_attempts). TERMINAL —
+              a 'dead' job is NEVER claimable again (W61 anti-storm: terminal
+              stays terminal, no re-add to the claimable set).
+
+Reuses the caller's persistent asyncpg pool (Golden Rule #10). ZERO CRM writes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import re
+import socket
+from dataclasses import dataclass
+from typing import Awaitable, Callable
+
+import asyncpg
+
+logger = logging.getLogger("zantara.intake.worker")
+
+# --- Claimable status set (mirrors idx_iq_claimable in migration 206). ---
+CLAIMABLE_STATUSES: tuple[str, ...] = (
+    "pending",
+    "processing",
+    "ocr",
+    "classified",
+    "extracted",
+)
+
+# --- Stub stage machine: status -> (stage_name, next_status). ---
+# Ordered passthrough; terminal next_status='done' is NOT claimable.
+STAGE_TRANSITIONS: dict[str, tuple[str, str]] = {
+    "pending": ("classify", "processing"),
+    "processing": ("ocr", "ocr"),
+    "ocr": ("extract", "classified"),
+    "classified": ("validate", "extracted"),
+    "extracted": ("route", "done"),
+}
+
+# --- Defaults (overridable via env / constructor for tests). ---
+DEFAULT_LEASE_TTL_SECONDS = 900  # 15 min — must exceed slowest stub stage.
+DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 120  # 2 min, like workflow/queue.
+DEFAULT_POLL_INTERVAL_SECONDS = 2
+DEFAULT_BASE_BACKOFF_SECONDS = 2.0  # exponential: base * 2**(attempts-1).
+DEFAULT_MAX_BACKOFF_SECONDS = 600.0
+
+# Number of consecutive DB-connection failures before the worker exits 0
+# (anti-storm: let launchd respawn slowly via ThrottleInterval, do not flap).
+DB_FAILURE_EXIT_THRESHOLD = 10
+
+# --- PII masking for last_error (Law 2). Never persist raw doc content. ---
+_PII_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\b\d{16}\b"), "[KTP/CARD]"),  # 16-digit KTP / card.
+    (re.compile(r"\b[A-Z]\d{7,8}\b"), "[PASSPORT]"),  # passport-ish.
+    (re.compile(r"\b[\w.+-]+@[\w-]+\.[\w.-]+\b"), "[EMAIL]"),
+    (re.compile(r"\b\+?\d[\d\s().-]{8,}\d\b"), "[PHONE]"),
+)
+
+
+def mask_pii(text: str, *, max_len: int = 1000) -> str:
+    """Best-effort PII redaction for error strings persisted to last_error."""
+    masked = text
+    for pattern, repl in _PII_PATTERNS:
+        masked = pattern.sub(repl, masked)
+    return masked[:max_len]
+
+
+# Alert hook: pluggable so the worker never hard-couples to a cloud channel.
+# Default logs locally only (Law 2). Production can inject a Telegram callable.
+AlertFn = Callable[[str], Awaitable[None]]
+
+
+async def _default_alert(message: str) -> None:
+    logger.error("INTAKE-ALERT %s", message)
+
+
+@dataclass
+class WorkerConfig:
+    lease_ttl_seconds: int = DEFAULT_LEASE_TTL_SECONDS
+    heartbeat_interval_seconds: float = DEFAULT_HEARTBEAT_INTERVAL_SECONDS
+    poll_interval_seconds: float = DEFAULT_POLL_INTERVAL_SECONDS
+    base_backoff_seconds: float = DEFAULT_BASE_BACKOFF_SECONDS
+    max_backoff_seconds: float = DEFAULT_MAX_BACKOFF_SECONDS
+
+    @classmethod
+    def from_env(cls) -> "WorkerConfig":
+        return cls(
+            lease_ttl_seconds=int(
+                os.getenv("INTAKE_LEASE_TTL_SECONDS", DEFAULT_LEASE_TTL_SECONDS)
+            ),
+            heartbeat_interval_seconds=float(
+                os.getenv(
+                    "INTAKE_HEARTBEAT_INTERVAL_SECONDS",
+                    DEFAULT_HEARTBEAT_INTERVAL_SECONDS,
+                )
+            ),
+            poll_interval_seconds=float(
+                os.getenv("INTAKE_POLL_INTERVAL_SECONDS", DEFAULT_POLL_INTERVAL_SECONDS)
+            ),
+            base_backoff_seconds=float(
+                os.getenv("INTAKE_BASE_BACKOFF_SECONDS", DEFAULT_BASE_BACKOFF_SECONDS)
+            ),
+            max_backoff_seconds=float(
+                os.getenv("INTAKE_MAX_BACKOFF_SECONDS", DEFAULT_MAX_BACKOFF_SECONDS)
+            ),
+        )
+
+
+def make_worker_id() -> str:
+    """Stable-ish per-process worker identity for lease_owner."""
+    return f"{socket.gethostname()}:{os.getpid()}"
+
+
+# --- Stub stage handler. Override via StageRunner for tests (poison-pill). ---
+StageHandler = Callable[[dict, str], Awaitable[dict]]
+
+
+async def _stub_stage(job: dict, stage: str) -> dict:
+    """STUB passthrough stage: no OCR, no LLM. Returns a fixture dict.
+
+    The returned dict is merged into stage_output[stage]. FASE 3 replaces this
+    with real OCR/classify/extract/validate/route handlers.
+    """
+    return {"stub": True, "stage": stage, "queue_id": job["id"]}
+
+
+class IntakeWorker:
+    """Single-process intake worker: claim -> run one stub stage -> advance."""
+
+    def __init__(
+        self,
+        pool: asyncpg.Pool,
+        *,
+        config: WorkerConfig | None = None,
+        worker_id: str | None = None,
+        stage_handler: StageHandler | None = None,
+        alert_fn: AlertFn | None = None,
+    ) -> None:
+        self.pool = pool
+        self.config = config or WorkerConfig()
+        self.worker_id = worker_id or make_worker_id()
+        self.stage_handler = stage_handler or _stub_stage
+        self.alert_fn = alert_fn or _default_alert
+        self._stop = asyncio.Event()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    async def _heartbeat(self, job_id: int) -> None:
+        """Extend the lease while a stage runs (only if WE still own it)."""
+        async with self.pool.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE intake_queue
+                SET lease_expires_at = now() + make_interval(secs => $2)
+                WHERE id = $1 AND lease_owner = $3 AND status = 'processing'
+                """,
+                job_id,
+                self.config.lease_ttl_seconds,
+                self.worker_id,
+            )
+
+    async def _record_metric(
+        self,
+        conn: asyncpg.Connection,
+        queue_id: int,
+        stage: str,
+        latency_ms: int,
+        ok: bool,
+    ) -> None:
+        await conn.execute(
+            """
+            INSERT INTO intake_stage_metrics
+                (queue_id, stage, latency_ms, confidence, model, ok)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            """,
+            queue_id,
+            stage,
+            latency_ms,
+            1.0 if ok else 0.0,
+            "stub-passthrough",
+            ok,
+        )
+
+    async def _advance(
+        self,
+        job_id: int,
+        next_status: str,
+        stage: str,
+        stage_payload: dict,
+    ) -> None:
+        """On stage success: release lease, set next_status, re-enqueue.
+
+        next_status='done' is terminal-success and NOT in the claimable set,
+        so the row stops circulating. attempts is left as-is (success path).
+        stage_output is merged (jsonb || ) so prior stages' output is kept.
+        """
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute(
+                    """
+                    UPDATE intake_queue
+                    SET status           = $2,
+                        stage            = $3,
+                        lease_owner      = NULL,
+                        lease_expires_at = NULL,
+                        next_visible_at  = now(),
+                        stage_output     = stage_output || $4::jsonb
+                    WHERE id = $1 AND lease_owner = $5
+                    """,
+                    job_id,
+                    next_status,
+                    stage,
+                    json.dumps({stage: stage_payload}),
+                    self.worker_id,
+                )
+
+    async def _fail(
+        self,
+        job_id: int,
+        stage: str,
+        attempts: int,
+        max_attempts: int,
+        error: str,
+    ) -> bool:
+        """On stage failure: bump attempts; retry with backoff OR go 'dead'.
+
+        Returns True iff the job was moved to terminal 'dead' (alert needed).
+
+        W61 anti-storm: 'dead' is terminal and NOT claimable. We only ever
+        write 'dead' here; a dead row is never re-added to the claimable set.
+        Exponential backoff on retry: base * 2**(attempts-1), capped.
+        """
+        new_attempts = attempts + 1
+        masked = mask_pii(error)
+
+        if new_attempts >= max_attempts:
+            async with self.pool.acquire() as conn:
+                await conn.execute(
+                    """
+                    UPDATE intake_queue
+                    SET status           = 'dead',
+                        stage            = $2,
+                        attempts         = $3,
+                        last_error       = $4,
+                        lease_owner      = NULL,
+                        lease_expires_at = NULL
+                    WHERE id = $1 AND lease_owner = $5
+                    """,
+                    job_id,
+                    stage,
+                    new_attempts,
+                    masked,
+                    self.worker_id,
+                )
+            return True
+
+        backoff = min(
+            self.config.base_backoff_seconds * (2 ** (new_attempts - 1)),
+            self.config.max_backoff_seconds,
+        )
+        # Re-enqueue at the SAME claimable status the job had before this stage,
+        # so it retries the failed stage. We stored the inbound status as 'stage'
+        # context; simplest correct choice: put it back to the status that maps
+        # to this stage. We reverse-map stage -> inbound status.
+        inbound_status = _STAGE_TO_INBOUND_STATUS[stage]
+        async with self.pool.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE intake_queue
+                SET status           = $2,
+                    stage            = $3,
+                    attempts         = $4,
+                    last_error       = $5,
+                    lease_owner      = NULL,
+                    lease_expires_at = NULL,
+                    next_visible_at  = now() + make_interval(secs => $6)
+                WHERE id = $1 AND lease_owner = $7
+                """,
+                job_id,
+                inbound_status,
+                stage,
+                new_attempts,
+                masked,
+                float(backoff),
+                self.worker_id,
+            )
+        return False
+
+    async def _process_one(self, job: dict) -> None:
+        """Run exactly one stub stage for a claimed job."""
+        job_id = job["id"]
+        # _claim_with_inbound flipped status to 'processing' but carried out the
+        # PRE-claim status, which tells us which stage to run.
+        inbound = job["_inbound_status"]
+        if inbound not in STAGE_TRANSITIONS:
+            logger.warning("job %s inbound status %s has no stage; skipping", job_id, inbound)
+            return
+        stage, next_status = STAGE_TRANSITIONS[inbound]
+
+        hb_task = asyncio.create_task(self._heartbeat_loop(job_id))
+        loop = asyncio.get_event_loop()
+        t0 = loop.time()
+        try:
+            payload = await self.stage_handler(job, stage)
+            latency_ms = int((loop.time() - t0) * 1000)
+            async with self.pool.acquire() as conn:
+                await self._record_metric(conn, job_id, stage, latency_ms, ok=True)
+            await self._advance(job_id, next_status, stage, payload)
+            logger.info(
+                "job %s stage=%s ok %s->%s (%dms)",
+                job_id, stage, inbound, next_status, latency_ms,
+            )
+        except Exception as exc:  # noqa: BLE001 — stage handler may raise anything.
+            latency_ms = int((loop.time() - t0) * 1000)
+            try:
+                async with self.pool.acquire() as conn:
+                    await self._record_metric(conn, job_id, stage, latency_ms, ok=False)
+            except Exception:  # metric write must never mask the real failure.
+                logger.exception("metric write failed for job %s", job_id)
+            went_dead = await self._fail(
+                job_id, stage, job["attempts"], job["max_attempts"], repr(exc)
+            )
+            if went_dead:
+                await self.alert_fn(
+                    f"intake job {job_id} DEAD at stage={stage} "
+                    f"after {job['attempts'] + 1} attempts (poison-pill)"
+                )
+                logger.error("job %s -> DEAD stage=%s", job_id, stage)
+            else:
+                logger.warning("job %s stage=%s failed, will retry", job_id, stage)
+        finally:
+            hb_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await hb_task
+
+    async def _heartbeat_loop(self, job_id: int) -> None:
+        while True:
+            await asyncio.sleep(self.config.heartbeat_interval_seconds)
+            try:
+                await self._heartbeat(job_id)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("heartbeat failed job %s: %s", job_id, exc)
+
+    async def run_once(self) -> bool:
+        """Claim and process at most one job. Returns True if work was done.
+
+        The claim is a single atomic UPDATE...FROM(CTE with FOR UPDATE SKIP
+        LOCKED) statement — auto-committed, so no explicit transaction needed
+        to guarantee exactly-once acquisition across concurrent workers.
+        """
+        async with self.pool.acquire() as conn:
+            job = await self._claim_with_inbound(conn)
+        if job is None:
+            return False
+        await self._process_one(job)
+        return True
+
+    async def _claim_with_inbound(self, conn: asyncpg.Connection) -> dict | None:
+        """Claim one job, returning the PRE-claim (inbound) status too.
+
+        The CTE selects the row (capturing its current status as inbound),
+        then the UPDATE flips it to 'processing'. We RETURNING the post-update
+        row but carry the inbound status out of the CTE.
+        """
+        ttl = self.config.lease_ttl_seconds
+        row = await conn.fetchrow(
+            f"""
+            WITH claimed AS (
+                SELECT id, status AS inbound_status
+                FROM intake_queue
+                WHERE status = ANY($1::text[])
+                  AND next_visible_at <= now()
+                  AND (lease_owner IS NULL OR lease_expires_at < now())
+                ORDER BY next_visible_at, id
+                LIMIT 1
+                FOR UPDATE SKIP LOCKED
+            )
+            UPDATE intake_queue q
+            SET lease_owner      = $2,
+                lease_expires_at = now() + make_interval(secs => $3),
+                status           = 'processing'
+            FROM claimed
+            WHERE q.id = claimed.id
+            RETURNING q.id, q.attempts, q.max_attempts, q.source,
+                      q.source_ref, claimed.inbound_status
+            """,
+            list(CLAIMABLE_STATUSES),
+            self.worker_id,
+            ttl,
+        )
+        if row is None:
+            return None
+        job = dict(row)
+        job["_inbound_status"] = job.pop("inbound_status")
+        return job
+
+    async def run_forever(self) -> None:
+        """Internal claim->process->sleep loop. Owns its own cadence.
+
+        Does NOT rely on launchd KeepAlive for the cycle (anti-storm): KeepAlive
+        is only for respawn-on-crash. We loop here until stopped or the DB is
+        unreachable past DB_FAILURE_EXIT_THRESHOLD (then exit 0, no flap).
+        """
+        logger.info("intake worker %s started", self.worker_id)
+        db_failures = 0
+        while not self._stop.is_set():
+            try:
+                did_work = await self.run_once()
+                db_failures = 0
+                if not did_work:
+                    await self._sleep_or_stop(self.config.poll_interval_seconds)
+            except (asyncpg.PostgresError, asyncpg.InterfaceError, OSError) as exc:
+                db_failures += 1
+                logger.error(
+                    "DB error (%d/%d): %s",
+                    db_failures, DB_FAILURE_EXIT_THRESHOLD, exc,
+                )
+                if db_failures >= DB_FAILURE_EXIT_THRESHOLD:
+                    logger.error("DB unreachable; exiting 0 to let launchd respawn slowly")
+                    return
+                await self._sleep_or_stop(self.config.poll_interval_seconds)
+            except asyncio.CancelledError:
+                logger.info("intake worker %s cancelled", self.worker_id)
+                raise
+            except Exception:  # noqa: BLE001
+                logger.exception("unexpected worker loop error")
+                await self._sleep_or_stop(self.config.poll_interval_seconds)
+        logger.info("intake worker %s stopped", self.worker_id)
+
+    async def _sleep_or_stop(self, seconds: float) -> None:
+        try:
+            await asyncio.wait_for(self._stop.wait(), timeout=seconds)
+        except asyncio.TimeoutError:
+            pass
+
+
+# Reverse map stage -> inbound claimable status (for retry re-enqueue).
+_STAGE_TO_INBOUND_STATUS: dict[str, str] = {
+    stage: inbound for inbound, (stage, _next) in STAGE_TRANSITIONS.items()
+}
+
+
+async def _build_pool() -> asyncpg.Pool:
+    """Build the asyncpg pool from DATABASE_URL (LOCAL nuzantara_dev only)."""
+    dsn = os.getenv(
+        "INTAKE_DATABASE_URL",
+        os.getenv(
+            "DATABASE_URL",
+            "postgresql://nuzantara@127.0.0.1:5432/nuzantara_dev",
+        ),
+    )
+    return await asyncpg.create_pool(dsn, min_size=1, max_size=4)
+
+
+async def main() -> None:
+    logging.basicConfig(
+        level=os.getenv("INTAKE_LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    pool = await _build_pool()
+    worker = IntakeWorker(pool, config=WorkerConfig.from_env())
+    try:
+        await worker.run_forever()
+    finally:
+        await pool.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/apps/backend-rag/backend/tests/services/intake/test_intake_worker.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_intake_worker.py
@@ -1,0 +1,283 @@
+"""Integration tests for the intake worker orchestrator (FASE 2).
+
+Runs against the LOCAL nuzantara_dev DB (same default as test_intake_enqueue).
+Each test enqueues its own jobs via the FASE 1 enqueue() core (unique blobs ->
+unique intake_key), runs real IntakeWorker instances against them, then cleans
+up by blob_hash. Short lease TTLs (2-3s) keep the reclaim test fast.
+
+Covered:
+  - exactly-once: 2 concurrent workers, 100 jobs -> each reaches 'done' exactly
+    once, no double-claim (SKIP LOCKED).
+  - kill -9 reclaim: a worker dies mid-job (lease held) -> after lease_ttl the
+    job is re-claimable and completes; 0 jobs lost.
+  - poison-pill: a stage that always raises -> job ends 'dead' after
+    max_attempts, alert fired, no infinite loop.
+  - attempts>max -> dead terminal transition.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from backend.services.intake.enqueue import enqueue
+from backend.services.intake.worker import (
+    IntakeWorker,
+    WorkerConfig,
+    STAGE_TRANSITIONS,
+)
+
+_DB_URL = os.environ.get(
+    "TEST_DATABASE_URL",
+    "postgresql://nuzantara@localhost:5432/nuzantara_dev",
+)
+
+# Number of stub stages from 'pending' to 'done'.
+_N_STAGES = len(STAGE_TRANSITIONS)
+
+
+@pytest_asyncio.fixture
+async def pool():
+    p = await asyncpg.create_pool(_DB_URL, min_size=2, max_size=12)
+    try:
+        yield p
+    finally:
+        await p.close()
+
+
+async def _make_jobs(pool: asyncpg.Pool, tmp_path, n: int, tag: str) -> list[int]:
+    """Enqueue n unique jobs; return their queue ids. Unique blob per job."""
+    qids: list[int] = []
+    for i in range(n):
+        f = tmp_path / f"{tag}-{i}.bin"
+        f.write_bytes(f"{tag}-{i}-{uuid.uuid4()}".encode())
+        res = await enqueue(
+            pool,
+            source="drive",
+            source_ref=f"test/{tag}/{uuid.uuid4()}",
+            blob_path=str(f),
+        )
+        qids.append(res.queue_id)
+    return qids
+
+
+async def _cleanup(pool: asyncpg.Pool, qids: list[int]) -> None:
+    if not qids:
+        return
+    async with pool.acquire() as conn:
+        await conn.execute("DELETE FROM intake_stage_metrics WHERE queue_id = ANY($1)", qids)
+        rows = await conn.fetch(
+            "SELECT id, instance_id FROM intake_queue WHERE id = ANY($1)", qids
+        )
+        await conn.execute("DELETE FROM intake_queue WHERE id = ANY($1)", qids)
+        inst_ids = list({r["instance_id"] for r in rows})
+        if inst_ids:
+            # Only delete instances no longer referenced.
+            await conn.execute(
+                """DELETE FROM document_instances di WHERE di.id = ANY($1)
+                   AND NOT EXISTS (SELECT 1 FROM intake_queue q WHERE q.instance_id = di.id)""",
+                inst_ids,
+            )
+
+
+async def _statuses(pool: asyncpg.Pool, qids: list[int]) -> dict[str, int]:
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT status, count(*) c FROM intake_queue WHERE id = ANY($1) GROUP BY status",
+            qids,
+        )
+    return {r["status"]: r["c"] for r in rows}
+
+
+async def _drive_to_done(workers, qids, pool, timeout=60.0):
+    """Run workers cooperatively until all qids are 'done'/'dead' or timeout."""
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    # Each worker keeps calling run_once until no work, then we re-check.
+    async def drain(w):
+        while loop.time() < deadline:
+            did = await w.run_once()
+            if not did:
+                # check if everything terminal
+                st = await _statuses(pool, qids)
+                if (st.get("done", 0) + st.get("dead", 0)) == len(qids):
+                    return
+                await asyncio.sleep(0.05)
+    await asyncio.gather(*(drain(w) for w in workers))
+
+
+@pytest.mark.asyncio
+async def test_exactly_once_two_workers_100_jobs(pool, tmp_path):
+    """100 jobs, 2 concurrent workers -> each job done exactly once.
+
+    Exactly-once is proven by: (a) every job ends 'done', and (b) the number of
+    successful 'route' (final-stage) metrics equals the number of jobs (no job
+    completed twice), and (c) each job has exactly _N_STAGES ok metrics.
+    """
+    n = 100
+    qids = await _make_jobs(pool, tmp_path, n, "eo")
+    try:
+        cfg = WorkerConfig(lease_ttl_seconds=30, heartbeat_interval_seconds=999,
+                           poll_interval_seconds=0.01)
+        w1 = IntakeWorker(pool, config=cfg, worker_id="w1")
+        w2 = IntakeWorker(pool, config=cfg, worker_id="w2")
+        await _drive_to_done([w1, w2], qids, pool, timeout=90.0)
+
+        st = await _statuses(pool, qids)
+        assert st.get("done", 0) == n, f"not all done: {st}"
+
+        async with pool.acquire() as conn:
+            # Each stage's final 'route' metric should appear exactly once/job.
+            route_ok = await conn.fetchval(
+                "SELECT count(*) FROM intake_stage_metrics WHERE queue_id = ANY($1) "
+                "AND stage='route' AND ok = true", qids,
+            )
+            total_ok = await conn.fetchval(
+                "SELECT count(*) FROM intake_stage_metrics WHERE queue_id = ANY($1) "
+                "AND ok = true", qids,
+            )
+        assert route_ok == n, f"route_ok={route_ok} != {n} (double-processing!)"
+        assert total_ok == n * _N_STAGES, f"total_ok={total_ok} != {n * _N_STAGES}"
+        print(f"\n[exactly-once] {n} jobs, 2 workers -> done={st.get('done')}, "
+              f"route_ok={route_ok}, total_ok={total_ok} (expect {n}/{n*_N_STAGES})")
+    finally:
+        await _cleanup(pool, qids)
+
+
+@pytest.mark.asyncio
+async def test_kill9_reclaim_no_job_lost(pool, tmp_path):
+    """A worker holds a lease then 'dies'; after lease_ttl the job is reclaimed.
+
+    Simulate kill -9 by claiming a job, NOT releasing it, then dropping the
+    worker. A second worker must reclaim it after lease_expires_at < now() and
+    drive it to done.
+    """
+    qids = await _make_jobs(pool, tmp_path, 1, "kr")
+    qid = qids[0]
+    try:
+        lease_ttl = 2  # seconds
+        cfg = WorkerConfig(lease_ttl_seconds=lease_ttl, heartbeat_interval_seconds=999,
+                           poll_interval_seconds=0.05)
+        dead_worker = IntakeWorker(pool, config=cfg, worker_id="dead")
+
+        # Claim (takes lease, flips to 'processing') but DO NOT process -> sim crash.
+        async with pool.acquire() as conn:
+            job = await dead_worker._claim_with_inbound(conn)
+        assert job is not None and job["id"] == qid
+
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT status, lease_owner, lease_expires_at > now() AS leased "
+                "FROM intake_queue WHERE id=$1", qid)
+        assert row["status"] == "processing"
+        assert row["lease_owner"] == "dead"
+        assert row["leased"] is True
+        print(f"\n[reclaim] job {qid} claimed by dead worker, lease held: {dict(row)}")
+
+        # Live worker tries immediately -> must NOT be able to claim (lease valid).
+        live = IntakeWorker(pool, config=cfg, worker_id="live", )
+        async with pool.acquire() as conn:
+            stolen = await live._claim_with_inbound(conn)
+        assert stolen is None, "lease not respected: live worker stole a held job"
+        print(f"[reclaim] live worker correctly BLOCKED while lease valid")
+
+        # Wait out the lease, then the live worker reclaims + completes.
+        await asyncio.sleep(lease_ttl + 0.5)
+        await _drive_to_done([live], qids, pool, timeout=30.0)
+
+        st = await _statuses(pool, qids)
+        assert st.get("done", 0) == 1, f"job lost / not reclaimed: {st}"
+        print(f"[reclaim] after lease expiry, live worker reclaimed -> {st}")
+    finally:
+        await _cleanup(pool, qids)
+
+
+@pytest.mark.asyncio
+async def test_poison_pill_goes_dead_with_alert(pool, tmp_path):
+    """A job whose first stage always crashes -> 'dead' after max_attempts.
+
+    Verifies: terminal 'dead', attempts == max_attempts, alert fired once,
+    last_error is PII-masked, and NO infinite loop (bounded run_once calls).
+    """
+    qids = await _make_jobs(pool, tmp_path, 1, "poison")
+    qid = qids[0]
+    try:
+        # max_attempts default 5 in schema; short backoff so it's fast.
+        cfg = WorkerConfig(lease_ttl_seconds=30, heartbeat_interval_seconds=999,
+                           poll_interval_seconds=0.01, base_backoff_seconds=0.05,
+                           max_backoff_seconds=0.2)
+        alerts: list[str] = []
+
+        async def capture_alert(msg: str) -> None:
+            alerts.append(msg)
+
+        w = IntakeWorker(pool, config=cfg, worker_id="poison-w",
+                         alert_fn=capture_alert)
+        # Inject a stage handler that always crashes.
+        async def crash(job, stage):  # noqa: ANN001
+            raise RuntimeError(
+                "poison stage=%s leak test@x.com KTP 1234567890123456" % stage
+            )
+        w.stage_handler = crash
+
+        # Drive with a hard cap on iterations to prove NO infinite loop.
+        max_iters = 200
+        iters = 0
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + 30
+        while iters < max_iters and loop.time() < deadline:
+            iters += 1
+            did = await w.run_once()
+            if not did:
+                st = await _statuses(pool, qids)
+                if st.get("dead", 0) == 1:
+                    break
+                await asyncio.sleep(0.02)
+
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT status, attempts, max_attempts, last_error FROM intake_queue WHERE id=$1",
+                qid)
+        st = await _statuses(pool, qids)
+        assert st.get("dead", 0) == 1, f"poison did not go dead: {st}"
+        assert row["attempts"] == row["max_attempts"], f"attempts={row['attempts']}"
+        assert len(alerts) == 1, f"expected 1 alert, got {len(alerts)}: {alerts}"
+        # PII masked in persisted error.
+        assert "test@x.com" not in row["last_error"], row["last_error"]
+        assert "1234567890123456" not in row["last_error"], row["last_error"]
+        assert "[EMAIL]" in row["last_error"] and "[KTP/CARD]" in row["last_error"]
+        assert iters < max_iters, "ran to iter cap -> suspected infinite loop"
+        print(f"\n[poison] dead after attempts={row['attempts']}/{row['max_attempts']}, "
+              f"iters={iters}, alerts={len(alerts)}, last_error={row['last_error']!r}")
+    finally:
+        await _cleanup(pool, qids)
+
+
+@pytest.mark.asyncio
+async def test_attempts_over_max_is_terminal_dead(pool, tmp_path):
+    """A 'dead' job is terminal: it is NOT in the claimable set (W61)."""
+    qids = await _make_jobs(pool, tmp_path, 1, "term")
+    qid = qids[0]
+    try:
+        # Force the row to dead directly, then assert no worker can claim it.
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE intake_queue SET status='dead', attempts=max_attempts, "
+                "next_visible_at=now() WHERE id=$1", qid)
+        cfg = WorkerConfig(lease_ttl_seconds=30, poll_interval_seconds=0.01)
+        w = IntakeWorker(pool, config=cfg, worker_id="term-w")
+        async with pool.acquire() as conn:
+            claimed = await w._claim_with_inbound(conn)
+        # claimed could be another test's row only if ids overlap; assert it's not ours.
+        assert claimed is None or claimed["id"] != qid, \
+            f"DEAD job was claimable (W61 violation): {claimed}"
+        st = await _statuses(pool, qids)
+        assert st.get("dead", 0) == 1
+        print(f"\n[dead-terminal] job {qid} status=dead, never re-claimed -> {st}")
+    finally:
+        await _cleanup(pool, qids)

--- a/infra/launchagents/com.nuzantara.intake-worker.plist
+++ b/infra/launchagents/com.nuzantara.intake-worker.plist
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.nuzantara.intake-worker — Unified document-intake worker (FASE 2).
+
+  Drives the intake_queue (migration 206) stub stage machine. The worker has
+  its OWN internal claim->process->sleep loop (backend.services.intake.worker:
+  main); launchd KeepAlive here is ONLY a respawn-on-crash backstop, NOT the
+  cycle driver — this is the anti retry-storm pattern (cicatrix 2026-05-31).
+
+  Anti-storm guarantees:
+    - KeepAlive=true  : respawn ONLY if the process dies (crash recovery).
+    - ThrottleInterval=30 : launchd waits >=30s between respawns -> a crash
+      loop cannot flap the machine.
+    - The runner exits 0 on DB retry-exhaust (worker.DB_FAILURE_EXIT_THRESHOLD)
+      so a transient DB outage does NOT count as a crash; launchd respawns it
+      slowly instead of hammering.
+    - flock single-instance in the runner: overlapping launchd ticks never
+      spawn duplicate workers.
+    - W61 (DLQ re-add storm): a 'dead' job is TERMINAL and never re-enters the
+      claimable set, so dead-lettering cannot create a respawn storm.
+
+  PII (Law 2 / UU-PDP): worker talks ONLY to the LOCAL nuzantara_dev DB; no
+  cloud, no OCR/LLM (FASE 3). last_error is PII-masked before persistence.
+
+  Logs go to ~/logs (NOT /tmp — survives reboot, cicatrix P0-3).
+
+  Install (operator — NOT auto-installed):
+    cp infra/launchagents/com.nuzantara.intake-worker.plist ~/Library/LaunchAgents/
+    chmod 0444 ~/Library/LaunchAgents/com.nuzantara.intake-worker.plist
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.nuzantara.intake-worker.plist
+  Uninstall:
+    launchctl bootout gui/$(id -u)/com.nuzantara.intake-worker
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.nuzantara.intake-worker</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/nuzantara/Desktop/nuzantara/apps/backend-rag/backend/services/intake/intake-worker-run.sh</string>
+    </array>
+
+    <!-- Long-lived daemon: the worker loops internally. RunAtLoad starts it
+         once; KeepAlive respawns it ONLY if it dies. NO StartInterval — we do
+         NOT want launchd to re-trigger the cycle (anti-storm). -->
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+
+    <!-- Anti retry-storm: >=30s between respawns. A crash loop is throttled,
+         not allowed to flap the machine (cicatrix verified 2026-05-31). -->
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <!-- Background priority; never starve interactive dev work. -->
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>Nice</key>
+    <integer>5</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/intake-worker.launchd.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/intake-worker.launchd.err.log</string>
+
+    <!-- VADEMECUM §11: complete EnvironmentVariables (no implicit shell env). -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <key>PATH</key>
+        <string>/Users/nuzantara/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>INTAKE_REPO_ROOT</key>
+        <string>/Users/nuzantara/Desktop/nuzantara</string>
+        <!-- LOCAL DB only (Law 2). Override here, never hardcode in code. -->
+        <key>INTAKE_DATABASE_URL</key>
+        <string>postgresql://nuzantara@127.0.0.1:5432/nuzantara_dev</string>
+        <key>INTAKE_LEASE_TTL_SECONDS</key>
+        <string>900</string>
+        <key>INTAKE_POLL_INTERVAL_SECONDS</key>
+        <string>2</string>
+        <key>INTAKE_LOG_LEVEL</key>
+        <string>INFO</string>
+        <key>PYTHONUNBUFFERED</key>
+        <string>1</string>
+    </dict>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/nuzantara/Desktop/nuzantara/apps/backend-rag</string>
+</dict>
+</plist>


### PR DESCRIPTION
## FASE 2 — Worker orchestrator (coda → done, stadi STUB)

Cuore concorrente del sistema document-intake. Claim exactly-once + lease + retry budget + DLQ. **Stadi sono stub passthrough** (nessun OCR/LLM ancora — quello è FASE 3).

> Base = branch FASE 1 (#1107). Mergeare #1107 PRIMA di questa.

### Cosa fa
- Claim atomico `UPDATE ... FOR UPDATE SKIP LOCKED` → status=processing + lease. Reclaim lease scaduto (worker morto non blocca > TTL).
- Heartbeat estende lease durante lo stadio. Retry exponential backoff; attempts≥max → `dead` + alert. last_error PII-masked.
- LaunchAgent `com.nuzantara.intake-worker` generato (NON installato).

### Difese da cicatrici
- **W61**: `dead` è terminale, mai re-claimabile.
- **Anti retry-storm**: loop interno proprio, KeepAlive solo respawn-crash + ThrottleInterval=30, exit-0 su DB down, log in ~/logs.
- Golden Rule #10: riusa pool asyncpg esistente.

### Test (4 PASS su nuzantara_dev, output reale)
- exactly-once 100 job / 2 worker → done=100, no doppio-claim
- kill-9 reclaim → job ri-claimato dopo TTL, 0 persi
- poison-pill → dead dopo 5 tentativi, 1 alert, last_error mascherato, no loop
- dead terminale → mai re-claimato

### Nota onesta
LaunchAgent lint-OK ma non provato sotto launchctl bootstrap reale. Exactly-once provato via conteggio metriche, non race adversarial forzata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)