### PR TITLE
fix(wr2): give fact-checker real source coverage from brief_json

### DIFF
--- a/scripts/tests/test_wr2_fact_checker.py
+++ b/scripts/tests/test_wr2_fact_checker.py
@@ -236,6 +236,7 @@ def _make_facted_row(draft_id: uuid.UUID, claims: list[dict], source: str) -> di
         "register": "pedagogico",
         "slides_json": {"slides": [{"index": 1, "title": "X", "body": source}]},
         "research_json": {"text": source},
+        "brief_json": {"article_summary": source},
         "council_debate_json": None,
         "fact_check_json": {"claims": claims, "extracted_at": "2026-05-08T00:00:00+00:00"},
     }
@@ -282,6 +283,7 @@ def test_process_one_draft_handles_string_blobs(fc):
         "register": "pedagogico",
         "slides_json": json.dumps({"slides": [{"index": 1, "title": "X", "body": "PP 28/2025"}]}),
         "research_json": json.dumps({"text": "PP 28/2025"}),
+        "brief_json": json.dumps({"article_summary": "PP 28/2025"}),
         "council_debate_json": None,
         "fact_check_json": json.dumps({"claims": [{"claim": "PP 28/2025", "slide_index": 1, "type": "law"}]}),
     }
@@ -343,3 +345,56 @@ def test_uses_claude_oauth_client_not_anthropic_sdk():
             if node.module and node.module.endswith("claude_oauth_client"):
                 used_oauth_client = True
     assert used_oauth_client
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Regression: research_json is systemically NULL in production; the actual
+# research lives in brief_json (article_summary / article_body_full /
+# enrichment). The checker must include brief_json in its source corpus or it
+# false-flags headline numbers the slides omit for editorial brevity.
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_extract_source_text_includes_brief_json(fc):
+    """A figure present only in brief_json must land in the source corpus."""
+    text = fc._extract_source_text(
+        research_json=None,
+        council_debate_json=None,
+        slides=[{"title": "Pajak", "body": "Aturan baru berlaku"}],
+        brief_json={
+            "article_summary": "Target setoran pajak Rp 52 triliun tahun ini.",
+            "enrichment": {"the_facts": "Angka 2.500 unit terdampak."},
+        },
+    )
+    assert "52" in text
+    assert "2.500" in text
+
+
+def test_process_one_draft_verifies_number_only_in_brief_json(fc):
+    """Headline number 52 lives only in brief_json (research_json NULL, slides
+    omit it). Before the fix this was a false 'contradicted' → fact_check_failed.
+    After the fix the checker verifies it against brief_json."""
+    draft_id = uuid.uuid4()
+    row = {
+        "id": draft_id,
+        "topic": "Pajak",
+        "register": "pedagogico",
+        # Slides deliberately omit the headline number (editorial brevity).
+        "slides_json": {"slides": [{"index": 1, "title": "Pajak", "body": "Setoran pajak meningkat tahun ini."}]},
+        # research_json systemically NULL in production.
+        "research_json": None,
+        # The real research the article was derived from.
+        "brief_json": {"article_summary": "Target setoran pajak Rp 52 triliun tahun ini."},
+        "council_debate_json": None,
+        "fact_check_json": {
+            "claims": [
+                {"claim": "target Rp 52 triliun", "slide_index": 1, "type": "number", "context": ""},
+            ],
+        },
+    }
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    ok = asyncio.run(fc._process_one_draft(conn, row, llm_enabled=False))
+    assert ok is True
+    args = conn.execute.call_args[0]
+    assert args[3] == "pass"  # not "fail"
+    assert args[4] == "drafts_imaged_checked"  # not "fact_check_failed"

--- a/scripts/wr2_fact_checker.py
+++ b/scripts/wr2_fact_checker.py
@@ -152,16 +152,25 @@ def _log_telemetry(record: dict) -> None:
 # ─────────────────────────────────────────────────────────────────────────
 
 def _extract_source_text(
-    research_json: Any, council_debate_json: Any, slides: list[dict[str, Any]]
+    research_json: Any,
+    council_debate_json: Any,
+    slides: list[dict[str, Any]],
+    brief_json: Any = None,
 ) -> str:
     """Concatenate all available source-text the draft was derived from.
 
-    research_json (from topic-selector + draft-generator) is the primary
-    truth. council_debate_json captures the LLM panel's reasoning; useful
-    for paraphrase matches. Slide bodies are last-resort fallback.
+    brief_json (from the topic-selector) is the ACTUAL research the draft
+    generator consumed: article_summary, article_body_full, source_url and
+    the structured `enrichment` object (the_facts / bali_zero_take /
+    in_practice / next_steps / faq). research_json is a separate column the
+    production pipeline never populates (only probes/smoke tests do), so
+    without brief_json the checker has almost no source corpus and
+    false-flags headline numbers the slides omit for editorial brevity.
+    council_debate_json captures the LLM panel's reasoning; useful for
+    paraphrase matches. Slide bodies are last-resort fallback.
     """
     parts: list[str] = []
-    for blob in (research_json, council_debate_json):
+    for blob in (research_json, brief_json, council_debate_json):
         if blob is None:
             continue
         if isinstance(blob, str):
@@ -374,7 +383,7 @@ async def _fetch_ready_drafts(conn: asyncpg.Connection, limit: int) -> list[asyn
     return await conn.fetch(
         """
         SELECT id, topic, register, slides_json, research_json,
-               council_debate_json, fact_check_json
+               brief_json, council_debate_json, fact_check_json
           FROM war_room_drafts
          WHERE status = 'drafts_imaged_facted'
            AND fact_check_json IS NOT NULL
@@ -475,6 +484,12 @@ async def _process_one_draft(
             council = json.loads(council)
         except json.JSONDecodeError:
             pass
+    brief = row.get("brief_json")
+    if isinstance(brief, str):
+        try:
+            brief = json.loads(brief)
+        except json.JSONDecodeError:
+            pass
     slides_blob = row["slides_json"]
     if isinstance(slides_blob, str):
         try:
@@ -487,7 +502,7 @@ async def _process_one_draft(
         else slides_blob
     ) or []
 
-    source_text = _extract_source_text(research, council, slides)
+    source_text = _extract_source_text(research, council, slides, brief_json=brief)
     source_laws = _find_law_citations(source_text)
 
     t0 = time.time()


### PR DESCRIPTION
## Problem (systemic)

`war_room_drafts.research_json` is **NULL on every production draft** — 52 drafts in the DB, only 1 non-NULL (a probe/smoke fixture). The fact-checker (`scripts/wr2_fact_checker.py`) builds its source corpus from `research_json` + `council_debate_json` + slide bodies, then verifies number/law/quote tokens against it. With `research_json` empty and `council_debate_json` carrying only metadata in production (`register_reason`, `cover_url`, `composed_at`), the corpus collapses to the slide bodies. Strong headline figures that the slides omit for editorial brevity (e.g. "Rp 52 triliun") then have **no source text** → false `contradicted` → `fact_check_failed`, blocking the carousel.

## Diagnosis (data flow traced)

- **Who writes `research_json`?** Nobody in production. The topic-selector INSERTs `(topic, register, status, brief_json)`; the draft-generator only UPDATEs `slides_json` + `council_debate_json`. `repository.patch_json(research_json=...)` exists but is called **only from probes/smoke tests**.
- **Where the real research lives:** `brief_json`. The topic-selector populates it with `article_summary`, `article_body_full`, `source_url` and the structured `enrichment` object (`the_facts` / `bali_zero_take` / `in_practice` / `next_steps` / `faq`, 1400–2000 words). The draft-generator consumes exactly this `brief_json` to compose the slides — so it IS the research that informed the article.
- So the research is **captured-but-unread**, not missing: it sits in `brief_json`, which the checker never looked at.

## Fix (option B — root-cause, no weakening)

Include `brief_json` in the checker's source corpus:
- `_extract_source_text()` now also concatenates `brief_json`.
- `_fetch_ready_drafts()` selects `brief_json`.
- the per-draft loop parses it and passes it through (`row.get("brief_json")` — tolerant so existing dict fixtures don't `KeyError`).

The checker now verifies claims against the **same research that produced the article**. It does **not** make the checker pass anything it can't verify — a figure absent from `brief_json` is still flagged.

## Verification

Empirical before/after on a real rendered draft (`28bffc4b`, `research_json` NULL), importing the patched `_extract_source_text` from this branch:

| | corpus chars | verifiable number-tokens |
|---|---|---|
| before | 2553 | 23 |
| after | 5391 | **47** (+24) |

Newly covered figures include `5,000`, `2,500`, `135.5`, `28.5`, `2023`, `2011`.

Tests: **31 pass** (29 existing + 2 regression). The new tests prove a headline number present **only** in `brief_json` now verifies → `pass` / `drafts_imaged_checked` instead of the prior false `fail` / `fact_check_failed`.

## Safety

No DB writes, no secrets, no schema change. Existing drafts' data untouched. Surgical edit to one script + its test file (`+77 / -7`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
