### PR TITLE
fix(db): grant Olympus residual runtime privileges

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/211_olympus_residual_runtime_grants.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/211_olympus_residual_runtime_grants.sql
@@ -1,0 +1,299 @@
+-- 211_olympus_residual_runtime_grants.sql
+-- Runtime grants for residual Olympus Guardian maintenance tasks.
+--
+-- Live symptoms fixed by this migration:
+-- - sequence repair scan denied SELECT on query_clusters and x_monitored_tweets
+-- - expired persistent session cleanup denied DELETE on persistent_sessions
+--
+-- Keep this guarded for CI/local databases. In production, fail with precise
+-- remediation if the deploying role cannot apply the required owner grants.
+
+DO $grant_block$
+DECLARE
+    runtime_role constant text := 'backend_rag_v2';
+    object_name text;
+    object_reg regclass;
+    sequence_name text;
+    sequence_reg regclass;
+    read_objects text[] := ARRAY[
+        'public.query_clusters',
+        'public.x_monitored_tweets'
+    ];
+    write_objects text[] := ARRAY[
+        'public.persistent_sessions'
+    ];
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = runtime_role) THEN
+        RETURN;
+    END IF;
+
+    IF NOT has_schema_privilege(runtime_role, 'public', 'USAGE') THEN
+        BEGIN
+            GRANT USAGE ON SCHEMA public TO backend_rag_v2;
+        EXCEPTION
+            WHEN insufficient_privilege THEN
+                RAISE WARNING
+                    'manual grant required: GRANT USAGE ON SCHEMA public TO %',
+                    runtime_role;
+        END;
+    END IF;
+
+    IF NOT has_schema_privilege(runtime_role, 'public', 'USAGE') THEN
+        RAISE EXCEPTION
+            'backend_rag_v2 is missing USAGE on schema public; apply manual grant with an owner/admin role';
+    END IF;
+
+    FOREACH object_name IN ARRAY read_objects LOOP
+        object_reg := to_regclass(object_name);
+
+        IF object_reg IS NULL THEN
+            CONTINUE;
+        END IF;
+
+        IF NOT has_table_privilege(runtime_role, object_reg, 'SELECT') THEN
+            BEGIN
+                EXECUTE format(
+                    'GRANT SELECT ON TABLE %s TO %I',
+                    object_reg,
+                    runtime_role
+                );
+            EXCEPTION
+                WHEN insufficient_privilege THEN
+                    RAISE WARNING
+                        'manual grant required: GRANT SELECT ON TABLE % TO %',
+                        object_name,
+                        runtime_role;
+            END;
+        END IF;
+
+        IF NOT has_table_privilege(runtime_role, object_reg, 'SELECT') THEN
+            RAISE EXCEPTION
+                'backend_rag_v2 is missing SELECT on %; apply manual grant with an owner/admin role',
+                object_name;
+        END IF;
+
+        sequence_name := pg_get_serial_sequence(object_name, 'id');
+
+        IF sequence_name IS NOT NULL THEN
+            sequence_reg := to_regclass(sequence_name);
+
+            IF sequence_reg IS NOT NULL
+                AND NOT (
+                    has_sequence_privilege(runtime_role, sequence_reg, 'USAGE')
+                    AND has_sequence_privilege(runtime_role, sequence_reg, 'SELECT')
+                    AND has_sequence_privilege(runtime_role, sequence_reg, 'UPDATE')
+                ) THEN
+                BEGIN
+                    EXECUTE format(
+                        'GRANT USAGE, SELECT, UPDATE ON SEQUENCE %s TO %I',
+                        sequence_reg,
+                        runtime_role
+                    );
+                EXCEPTION
+                    WHEN insufficient_privilege THEN
+                        RAISE WARNING
+                            'manual grant required: GRANT USAGE, SELECT, UPDATE ON SEQUENCE % TO %',
+                            sequence_name,
+                            runtime_role;
+                END;
+            END IF;
+
+            IF sequence_reg IS NOT NULL
+                AND NOT has_sequence_privilege(runtime_role, sequence_reg, 'USAGE') THEN
+                RAISE EXCEPTION
+                    'backend_rag_v2 is missing USAGE on sequence %; apply manual grant with an owner/admin role',
+                    sequence_name;
+            END IF;
+
+            IF sequence_reg IS NOT NULL
+                AND NOT has_sequence_privilege(runtime_role, sequence_reg, 'SELECT') THEN
+                RAISE EXCEPTION
+                    'backend_rag_v2 is missing SELECT on sequence %; apply manual grant with an owner/admin role',
+                    sequence_name;
+            END IF;
+
+            IF sequence_reg IS NOT NULL
+                AND NOT has_sequence_privilege(runtime_role, sequence_reg, 'UPDATE') THEN
+                RAISE EXCEPTION
+                    'backend_rag_v2 is missing UPDATE on sequence %; apply manual grant with an owner/admin role',
+                    sequence_name;
+            END IF;
+        END IF;
+    END LOOP;
+
+    FOREACH object_name IN ARRAY write_objects LOOP
+        object_reg := to_regclass(object_name);
+
+        IF object_reg IS NULL THEN
+            CONTINUE;
+        END IF;
+
+        IF NOT (
+            has_table_privilege(runtime_role, object_reg, 'SELECT')
+            AND has_table_privilege(runtime_role, object_reg, 'INSERT')
+            AND has_table_privilege(runtime_role, object_reg, 'UPDATE')
+            AND has_table_privilege(runtime_role, object_reg, 'DELETE')
+        ) THEN
+            BEGIN
+                EXECUTE format(
+                    'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE %s TO %I',
+                    object_reg,
+                    runtime_role
+                );
+            EXCEPTION
+                WHEN insufficient_privilege THEN
+                    RAISE WARNING
+                        'manual grant required: GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE % TO %',
+                        object_name,
+                        runtime_role;
+            END;
+        END IF;
+
+        IF NOT has_table_privilege(runtime_role, object_reg, 'SELECT') THEN
+            RAISE EXCEPTION
+                'backend_rag_v2 is missing SELECT on %; apply manual grant with an owner/admin role',
+                object_name;
+        END IF;
+
+        IF NOT has_table_privilege(runtime_role, object_reg, 'INSERT') THEN
+            RAISE EXCEPTION
+                'backend_rag_v2 is missing INSERT on %; apply manual grant with an owner/admin role',
+                object_name;
+        END IF;
+
+        IF NOT has_table_privilege(runtime_role, object_reg, 'UPDATE') THEN
+            RAISE EXCEPTION
+                'backend_rag_v2 is missing UPDATE on %; apply manual grant with an owner/admin role',
+                object_name;
+        END IF;
+
+        IF NOT has_table_privilege(runtime_role, object_reg, 'DELETE') THEN
+            RAISE EXCEPTION
+                'backend_rag_v2 is missing DELETE on %; apply manual grant with an owner/admin role',
+                object_name;
+        END IF;
+
+        sequence_name := pg_get_serial_sequence(object_name, 'id');
+
+        IF sequence_name IS NOT NULL THEN
+            sequence_reg := to_regclass(sequence_name);
+
+            IF sequence_reg IS NOT NULL
+                AND NOT (
+                    has_sequence_privilege(runtime_role, sequence_reg, 'USAGE')
+                    AND has_sequence_privilege(runtime_role, sequence_reg, 'SELECT')
+                    AND has_sequence_privilege(runtime_role, sequence_reg, 'UPDATE')
+                ) THEN
+                BEGIN
+                    EXECUTE format(
+                        'GRANT USAGE, SELECT, UPDATE ON SEQUENCE %s TO %I',
+                        sequence_reg,
+                        runtime_role
+                    );
+                EXCEPTION
+                    WHEN insufficient_privilege THEN
+                        RAISE WARNING
+                            'manual grant required: GRANT USAGE, SELECT, UPDATE ON SEQUENCE % TO %',
+                            sequence_name,
+                            runtime_role;
+                END;
+            END IF;
+
+            IF sequence_reg IS NOT NULL
+                AND NOT has_sequence_privilege(runtime_role, sequence_reg, 'USAGE') THEN
+                RAISE EXCEPTION
+                    'backend_rag_v2 is missing USAGE on sequence %; apply manual grant with an owner/admin role',
+                    sequence_name;
+            END IF;
+
+            IF sequence_reg IS NOT NULL
+                AND NOT has_sequence_privilege(runtime_role, sequence_reg, 'SELECT') THEN
+                RAISE EXCEPTION
+                    'backend_rag_v2 is missing SELECT on sequence %; apply manual grant with an owner/admin role',
+                    sequence_name;
+            END IF;
+
+            IF sequence_reg IS NOT NULL
+                AND NOT has_sequence_privilege(runtime_role, sequence_reg, 'UPDATE') THEN
+                RAISE EXCEPTION
+                    'backend_rag_v2 is missing UPDATE on sequence %; apply manual grant with an owner/admin role',
+                    sequence_name;
+            END IF;
+        END IF;
+    END LOOP;
+END
+$grant_block$;
+
+-- === ROLLBACK ===
+DO $revoke_block$
+DECLARE
+    runtime_role text := 'backend_rag_v2';
+    object_name text;
+    object_reg regclass;
+    sequence_name text;
+    sequence_reg regclass;
+    read_objects text[] := ARRAY[
+        'public.query_clusters',
+        'public.x_monitored_tweets'
+    ];
+    write_objects text[] := ARRAY[
+        'public.persistent_sessions'
+    ];
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = runtime_role) THEN
+        RETURN;
+    END IF;
+
+    FOREACH object_name IN ARRAY read_objects LOOP
+        object_reg := to_regclass(object_name);
+
+        IF object_reg IS NOT NULL THEN
+            EXECUTE format(
+                'REVOKE SELECT ON TABLE %s FROM %I',
+                object_reg,
+                runtime_role
+            );
+        END IF;
+
+        sequence_name := pg_get_serial_sequence(object_name, 'id');
+
+        IF sequence_name IS NOT NULL THEN
+            sequence_reg := to_regclass(sequence_name);
+
+            IF sequence_reg IS NOT NULL THEN
+                EXECUTE format(
+                    'REVOKE USAGE, SELECT, UPDATE ON SEQUENCE %s FROM %I',
+                    sequence_reg,
+                    runtime_role
+                );
+            END IF;
+        END IF;
+    END LOOP;
+
+    FOREACH object_name IN ARRAY write_objects LOOP
+        object_reg := to_regclass(object_name);
+
+        IF object_reg IS NOT NULL THEN
+            EXECUTE format(
+                'REVOKE SELECT, INSERT, UPDATE, DELETE ON TABLE %s FROM %I',
+                object_reg,
+                runtime_role
+            );
+        END IF;
+
+        sequence_name := pg_get_serial_sequence(object_name, 'id');
+
+        IF sequence_name IS NOT NULL THEN
+            sequence_reg := to_regclass(sequence_name);
+
+            IF sequence_reg IS NOT NULL THEN
+                EXECUTE format(
+                    'REVOKE USAGE, SELECT, UPDATE ON SEQUENCE %s FROM %I',
+                    sequence_reg,
+                    runtime_role
+                );
+            END IF;
+        END IF;
+    END LOOP;
+END
+$revoke_block$;

--- a/apps/backend-rag/backend/tests/db/test_migration_211_olympus_residual_runtime_grants.py
+++ b/apps/backend-rag/backend/tests/db/test_migration_211_olympus_residual_runtime_grants.py
@@ -1,0 +1,93 @@
+"""Contract tests for migration 211 Olympus residual runtime grants."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.db.migration_manager import _extract_rollback_sql
+
+MIGRATION_FILE = (
+    Path(__file__).resolve().parents[2]
+    / "db"
+    / "migrations_v2"
+    / "211_olympus_residual_runtime_grants.sql"
+)
+
+READ_TABLES = ("public.query_clusters", "public.x_monitored_tweets")
+WRITE_TABLE = "public.persistent_sessions"
+
+
+def _forward(sql: str) -> str:
+    """Return the forward section applied by the migration runner."""
+    return sql.split("-- === ROLLBACK ===", maxsplit=1)[0]
+
+
+def test_migration_211_file_exists() -> None:
+    assert MIGRATION_FILE.exists()
+
+
+def test_migration_211_has_rollback_marker() -> None:
+    sql = MIGRATION_FILE.read_text()
+
+    assert "-- === ROLLBACK ===" in sql
+    assert _extract_rollback_sql(sql) is not None
+
+
+def test_migration_211_targets_runtime_role_conditionally() -> None:
+    forward = _forward(MIGRATION_FILE.read_text())
+
+    assert "runtime_role constant text := 'backend_rag_v2'" in forward
+    assert "pg_roles WHERE rolname = runtime_role" in forward
+    assert "GRANT USAGE ON SCHEMA public TO backend_rag_v2" in forward
+
+
+def test_migration_211_targets_live_olympus_residuals() -> None:
+    sql = MIGRATION_FILE.read_text()
+
+    for table in READ_TABLES:
+        assert table in sql
+    assert WRITE_TABLE in sql
+
+
+def test_migration_211_grants_read_tables_for_sequence_repair() -> None:
+    forward = _forward(MIGRATION_FILE.read_text())
+
+    assert "read_objects text[] := ARRAY[" in forward
+    assert "GRANT SELECT ON TABLE" in forward
+    assert "has_table_privilege(runtime_role, object_reg, 'SELECT')" in forward
+
+
+def test_migration_211_grants_write_table_for_session_cleanup() -> None:
+    forward = _forward(MIGRATION_FILE.read_text())
+
+    assert "write_objects text[] := ARRAY[" in forward
+    assert "GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE" in forward
+    assert "has_table_privilege(runtime_role, object_reg, 'DELETE')" in forward
+
+
+def test_migration_211_grants_sequence_update_for_repair() -> None:
+    forward = _forward(MIGRATION_FILE.read_text())
+
+    assert "pg_get_serial_sequence(object_name, 'id')" in forward
+    assert "GRANT USAGE, SELECT, UPDATE ON SEQUENCE" in forward
+    assert "has_sequence_privilege(runtime_role, sequence_reg, 'UPDATE')" in forward
+
+
+def test_migration_211_fails_loudly_when_manual_grants_remain() -> None:
+    forward = _forward(MIGRATION_FILE.read_text())
+
+    assert "manual grant required: GRANT SELECT ON TABLE" in forward
+    assert (
+        "manual grant required: GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE"
+        in forward
+    )
+    assert "apply manual grant with an owner/admin role" in forward
+
+
+def test_migration_211_rollback_revokes_same_grants() -> None:
+    rollback = _extract_rollback_sql(MIGRATION_FILE.read_text())
+
+    assert rollback is not None
+    assert "REVOKE SELECT ON TABLE" in rollback
+    assert "REVOKE SELECT, INSERT, UPDATE, DELETE ON TABLE" in rollback
+    assert "REVOKE USAGE, SELECT, UPDATE ON SEQUENCE" in rollback

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`289 routers · 582 services · 990 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`289 routers · 582 services · 991 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary
- add migration 211 for residual Olympus runtime grants observed in Fly logs
- grants read access for sequence repair on `query_clusters` and `x_monitored_tweets`
- grants DML access for expired session cleanup on `persistent_sessions`
- adds contract tests for rollback marker, guarded role behavior, table grants, sequence grants, and manual-remediation messages

## Production note
Manual owner/admin grants were applied before this PR so the release command can pass if migration 211 is picked up by the fresh image.

## Verification
- `git diff --check`
- `cd apps/backend-rag && . .venv/bin/activate && ruff check backend/tests/db/test_migration_211_olympus_residual_runtime_grants.py`
- `cd apps/backend-rag && . .venv/bin/activate && PYTHONPATH=. pytest backend/tests/db/test_migration_211_olympus_residual_runtime_grants.py backend/tests/db/test_migration_uniqueness.py -q`
- pre-commit hooks passed, including migration uniqueness/rollback, frontend typecheck, Python lint, FastAPI import chain
