### PR TITLE
fix(backend): restore router runtime parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 289 routers · 582 services
+- Backend: FastAPI · 314 routers · 593 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 28 · Packages: 5

--- a/apps/backend-rag/backend/app/routers/compliance_alerts.py
+++ b/apps/backend-rag/backend/app/routers/compliance_alerts.py
@@ -119,24 +119,20 @@ async def post_retrain(
     """Manually trigger threshold autotune (admin only, honors kill-switch).
 
     Args:
-        body: {dry_run, category?}. dry_run is accepted but not yet enforced
-              at the service layer (reserved for future).
+        body: {dry_run, category?}. dry_run previews threshold changes without
+              persisting them.
         user: Authenticated user dict.
         pool: DB connection pool.
 
     Returns:
-        {changed: [...], reason: "applied"|"no_change"|"autotune_disabled"}
+        {changed: [...], reason: "applied"|"dry_run"|"no_change"|"autotune_disabled"}
     """
     _require_admin(user)
     fb = AlertFeedback(db_pool=pool)
-    result: dict[str, Any] = await fb.retrain(category=body.category if body.category else None)
-    if body.dry_run:
-        logger.warning(
-            "dry_run=true requested but not implemented at service layer; "
-            "thresholds were actually updated",
-        )
-        result["dry_run_not_implemented"] = True
-    return result
+    return await fb.retrain(
+        category=body.category if body.category else None,
+        dry_run=body.dry_run,
+    )
 
 
 @router.get("")

--- a/apps/backend-rag/backend/app/routers/war_room_dashboard.py
+++ b/apps/backend-rag/backend/app/routers/war_room_dashboard.py
@@ -11,22 +11,25 @@ from __future__ import annotations
 from typing import Any, Literal
 
 import asyncpg
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
-from backend.app.dependencies import get_database_pool
+from backend.app.dependencies import get_current_user, get_database_pool
+from backend.app.utils.crm_utils import is_crm_admin
 from backend.app.utils.logging_utils import get_logger
 from backend.services.war_room.dashboard_service import DashboardService
 from backend.services.war_room.repository import WarRoomRepository
 
 logger = get_logger(__name__)
 
-router = APIRouter(
-    prefix="/api/war-room/metrics",
-    tags=["war-room-metrics"],
-)
-
-
 # ── Helpers ───────────────────────────────────────────────────
+
+
+async def _require_admin(
+    current_user: dict[str, Any] = Depends(get_current_user),
+) -> dict[str, Any]:
+    if not is_crm_admin(current_user):
+        raise HTTPException(status_code=403, detail="Admin access required")
+    return current_user
 
 
 def _service(pool: asyncpg.Pool) -> DashboardService:
@@ -34,6 +37,13 @@ def _service(pool: asyncpg.Pool) -> DashboardService:
 
 
 DaysParam = Literal[14, 30, 90]
+
+
+router = APIRouter(
+    prefix="/api/war-room/metrics",
+    tags=["war-room-metrics"],
+    dependencies=[Depends(_require_admin)],
+)
 
 
 # ── Endpoints ─────────────────────────────────────────────────

--- a/apps/backend-rag/backend/app/setup/router_registration.py
+++ b/apps/backend-rag/backend/app/setup/router_registration.py
@@ -42,6 +42,7 @@ def include_routers(api: FastAPI) -> None:
         channel_health,  # [HEARTBEAT] Sprint 1.B 2026-05-02 — Cell-side bridge
         channels,  # Channel health, DLQ, unified conversations
         collective_memory,
+        compliance_alerts,
         conversations,
         crm_analytics,  # [NEW] CRM Analytics dashboard
         crm_clients,
@@ -82,6 +83,7 @@ def include_routers(api: FastAPI) -> None:
         ingest,
         instagram_chat,
         intel_lake,
+        intel_observability,
         kbli_notebook,
         kbli_notebook_chat,
         kg_agentic,
@@ -104,6 +106,7 @@ def include_routers(api: FastAPI) -> None:
         omnichannel,  # [NEW] Unified inbox for cross-channel conversations
         oracle_ingest,
         oracle_universal,
+        partners,  # [PARTNERS] CRM Partners module v1 (PR #141 + follow-ups)
         performance,
         portal,
         portal_admin,
@@ -113,14 +116,15 @@ def include_routers(api: FastAPI) -> None:
         portal_family,
         portal_invite,
         portal_matters,
-        portal_notifications,
         portal_notification_prefs,
+        portal_notifications,
         portal_process_timeline,
         portal_taxes,
         portal_visa,
         prime,
         prime_v2,  # [PRIME NEXUS] Layered geospatial intelligence API
         query_analytics,
+        research_control,
         session,
         sheets,
         skill,  # [SKILL] Skill Registry — canonical procedures (Sprint 5.2 W3-4)
@@ -139,12 +143,14 @@ def include_routers(api: FastAPI) -> None:
         wa_dashboard_stream,
         wa_inbox,  # /api/wa-inbox/* WA Meta Inbox console (scoped key auth)
         wa_mirror_messages,
+        war_room_dashboard,
         webhooks,
         websocket,
         whatsapp_chat,
         whatsapp_conversations,
         workflow_analytics,
         workflow_queue,
+        workspace_analytics,
         workspace_inbox,  # /api/workspace/inbox unified team feed (wa-mirror, telegram, email)
         zoho_email,
     )
@@ -209,6 +215,7 @@ def include_routers(api: FastAPI) -> None:
     api.include_router(crm_tax_pilot.router)
     api.include_router(crm_analytics.router)  # [NEW] CRM Analytics dashboard
     api.include_router(crm_portal_integration.router)  # Team ↔ Portal integration
+    api.include_router(partners.router)  # [PARTNERS] /api/partners/* — CRM Partners module
 
     # Channel system + Omnichannel router (unified inbox)
     api.include_router(channel_health.router)  # /api/channels/{name}/health Cell heartbeat bridge
@@ -248,10 +255,16 @@ def include_routers(api: FastAPI) -> None:
     api.include_router(portal_visa.router)
 
     # Compliance routers
+    api.include_router(compliance_alerts.router)
     api.include_router(lkpm.router)  # LKPM Investment Activity Reports
 
     # Analytics routers (Admin/reporting)
     api.include_router(analytics.router)
+    api.include_router(war_room_dashboard.router)
+    api.include_router(workspace_analytics.router)
+
+    # SOTA research controls (kill-switch guarded)
+    api.include_router(research_control.router)
 
     # Ingestion routers
     api.include_router(ingest.router)
@@ -304,6 +317,7 @@ def include_routers(api: FastAPI) -> None:
     api.include_router(instagram_chat.router)  # Instagram DM auto-reply via RAG
     api.include_router(instagram_chat.webhook_router)  # [NEW] Instagram webhook
     api.include_router(intel_lake.router)  # Intel Lake Wave 1 ingest (mig 168)
+    api.include_router(intel_observability.router)  # Intel Lake + WR2 pipeline health
     api.include_router(webhooks.router)  # External webhooks (OpenClaw, etc.)
     api.include_router(
         messaging_identity.router,
@@ -323,15 +337,25 @@ def include_routers(api: FastAPI) -> None:
         admin_drive_health,
         admin_drive_refresh,
         admin_drive_setup,
+        admin_email_health,
+        admin_pii,
+        admin_rate_limit,
+        admin_self_healing,
         admin_zoho_auth,
+        llm_costs,
     )
 
     api.include_router(admin_crm_kg.router)
     api.include_router(admin_drive_auth.router)
     api.include_router(admin_drive_health.router)
+    api.include_router(admin_email_health.router)
+    api.include_router(admin_pii.router)
+    api.include_router(admin_rate_limit.router)
     api.include_router(admin_drive_refresh.router)
     api.include_router(admin_drive_setup.router)
+    api.include_router(admin_self_healing.router)
     api.include_router(admin_zoho_auth.router)
+    api.include_router(llm_costs.router)
 
     # Blog routers
     api.include_router(newsletter.router)
@@ -437,8 +461,12 @@ def include_light_routers(api: FastAPI) -> None:
         admin_drive_health,
         admin_drive_refresh,
         admin_drive_setup,
+        admin_email_health,
         admin_logs,
+        admin_pii,
         admin_practice_auto_create,
+        admin_rate_limit,
+        admin_self_healing,
         admin_team_activity,
         admin_zoho_auth,
         analytics,
@@ -449,6 +477,7 @@ def include_light_routers(api: FastAPI) -> None:
         cell_status,
         channel_health,  # [HEARTBEAT] Sprint 1.B 2026-05-02 — Cell-side bridge
         channels,  # Channel health, DLQ, unified conversations
+        compliance_alerts,
         crm_analytics,
         crm_clients_documents,
         crm_company,
@@ -479,9 +508,11 @@ def include_light_routers(api: FastAPI) -> None:
         image_generation,
         instagram_chat,
         intel_lake,
+        intel_observability,
         knowledge_activity,
         lead_capture,  # [4APPS] POST /api/lead/capture — homepage → WhatsApp handoff
         lkpm,
+        llm_costs,
         media,
         messaging_identity,
         metabolic_health,  # [METABOLIC] SYMBIOSIS Pillar 7 read-only metrics (PR #60)
@@ -499,14 +530,15 @@ def include_light_routers(api: FastAPI) -> None:
         portal_family,
         portal_invite,
         portal_matters,
-        portal_notifications,
         portal_notification_prefs,
+        portal_notifications,
         portal_process_timeline,
         portal_taxes,
         portal_visa,
         prime,
         prime_v2,
         query_analytics,
+        research_control,
         session,
         sheets,
         skill,  # [SKILL] Skill Registry — canonical procedures (PR #55)
@@ -514,7 +546,7 @@ def include_light_routers(api: FastAPI) -> None:
         team_activity,
         team_analytics,
         team_drive,
-        team_members,
+        # team_members,  # DISABLED: duplicates team.py /members endpoint (audit 2026-04-03)
         telegram,
         telegram_webhook,
         twitter,  # RE-ENABLED 2026-04-29 (P0-6 zero-crash audit) — CRC was actually working
@@ -524,12 +556,14 @@ def include_light_routers(api: FastAPI) -> None:
         wa_dashboard_stream,
         wa_inbox,  # /api/wa-inbox/* WA Meta Inbox console (scoped key auth)
         wa_mirror_messages,
+        war_room_dashboard,
         webhooks,
         websocket,
         whatsapp_chat,
         whatsapp_conversations,
         workflow_analytics,
         workflow_queue,
+        workspace_analytics,
         workspace_inbox,  # /api/workspace/inbox unified team feed
         zoho_email,
     )
@@ -616,10 +650,16 @@ def include_light_routers(api: FastAPI) -> None:
     api.include_router(portal_visa.router)
 
     # Compliance routers
+    api.include_router(compliance_alerts.router)
     api.include_router(lkpm.router)
 
     # Analytics routers
     api.include_router(analytics.router)
+    api.include_router(war_room_dashboard.router)
+    api.include_router(workspace_analytics.router)
+
+    # SOTA research controls (kill-switch guarded)
+    api.include_router(research_control.router)
 
     # Preview router (for Telegram article previews)
     from backend.app.routers import preview
@@ -656,9 +696,14 @@ def include_light_routers(api: FastAPI) -> None:
     api.include_router(admin_crm_kg.router)
     api.include_router(admin_drive_auth.router)
     api.include_router(admin_drive_health.router)
+    api.include_router(admin_email_health.router)
+    api.include_router(admin_pii.router)
+    api.include_router(admin_rate_limit.router)
     api.include_router(admin_drive_refresh.router)
     api.include_router(admin_drive_setup.router)
+    api.include_router(admin_self_healing.router)
     api.include_router(admin_zoho_auth.router)
+    api.include_router(llm_costs.router)
 
     # Blog routers (light)
     api.include_router(newsletter.router)
@@ -674,7 +719,7 @@ def include_light_routers(api: FastAPI) -> None:
     api.include_router(team.router)
     api.include_router(team_activity.router)
     api.include_router(team_analytics.router)
-    api.include_router(team_members.router)
+    # api.include_router(team_members.router)  # DISABLED: duplicates team.py (audit 2026-04-03)
 
     # Media router
     api.include_router(media.router)
@@ -684,6 +729,7 @@ def include_light_routers(api: FastAPI) -> None:
 
     # Intel Lake — Wave 1 (mig 168) unified intel pipeline ingest endpoint
     api.include_router(intel_lake.router)
+    api.include_router(intel_observability.router)
 
     # Query Analytics router
     api.include_router(query_analytics.router)
@@ -743,6 +789,8 @@ def include_heavy_routers(api: FastAPI) -> None:
     from backend.app.modules.identity.router import router as identity_router
     from backend.app.modules.knowledge.router import router as knowledge_router
     from backend.app.routers import (
+        admin_rate_limit,
+        admin_self_healing,
         agent,
         agentic_rag,
         agents,
@@ -766,6 +814,8 @@ def include_heavy_routers(api: FastAPI) -> None:
         ingest,
         intel,
         intel_analytics,
+        intel_lake,
+        intel_observability,
         intel_scraper,
         kbli_notebook,
         kbli_notebook_chat,
@@ -787,6 +837,8 @@ def include_heavy_routers(api: FastAPI) -> None:
     # Health endpoints (required for Fly.io process health checks)
     api.include_router(health.router)
     api.include_router(handlers.router)
+    api.include_router(admin_rate_limit.router)
+    api.include_router(admin_self_healing.router)
 
     # Agent routers
     api.include_router(agent.router)
@@ -827,6 +879,8 @@ def include_heavy_routers(api: FastAPI) -> None:
     api.include_router(intel.router)
     api.include_router(intel_scraper.router)
     api.include_router(intel_analytics.router)
+    api.include_router(intel_lake.router)
+    api.include_router(intel_observability.router)
 
     from backend.app.core.config import settings
 

--- a/apps/backend-rag/backend/services/compliance/alert_feedback.py
+++ b/apps/backend-rag/backend/services/compliance/alert_feedback.py
@@ -83,16 +83,22 @@ class AlertFeedback:
 
     # ── Public API ──────────────────────────────────────────────────────
 
-    async def retrain(self, *, category: str | None = None) -> dict[str, Any]:
+    async def retrain(
+        self,
+        *,
+        category: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
         """Run one autotune cycle.
 
         Args:
             category: If given, only retrain this category; else all.
+            dry_run: If True, compute proposed changes without persisting them.
 
         Returns:
             Dict with keys:
               changed: list of {category, old, new, precision, sample_size}
-              reason:  "applied" | "no_change" | "autotune_disabled"
+              reason:  "applied" | "dry_run" | "no_change" | "autotune_disabled"
         """
         enabled = await self._exec(
             "fetchval",
@@ -140,7 +146,8 @@ class AlertFeedback:
                 new_threshold = max(THRESHOLD_MIN, current - 1)
 
             if new_threshold != current:
-                await self._apply_change(cat, current, new_threshold, p, denom)
+                if not dry_run:
+                    await self._apply_change(cat, current, new_threshold, p, denom)
                 changes.append(
                     ThresholdChange(
                         category=cat,
@@ -151,7 +158,11 @@ class AlertFeedback:
                     )
                 )
 
-        return {
+        reason = "no_change"
+        if changes:
+            reason = "dry_run" if dry_run else "applied"
+
+        result: dict[str, Any] = {
             "changed": [
                 {
                     "category": c.category,
@@ -162,8 +173,11 @@ class AlertFeedback:
                 }
                 for c in changes
             ],
-            "reason": "applied" if changes else "no_change",
+            "reason": reason,
         }
+        if dry_run:
+            result["dry_run"] = True
+        return result
 
     async def _apply_change(
         self,

--- a/apps/backend-rag/backend/tests/services/compliance/test_alert_feedback.py
+++ b/apps/backend-rag/backend/tests/services/compliance/test_alert_feedback.py
@@ -125,6 +125,31 @@ async def test_low_precision_widens_threshold(
 
 
 @pytest.mark.asyncio
+async def test_dry_run_reports_change_without_updating_threshold(
+    db_tx: asyncpg.Connection, sample_client: dict
+) -> None:
+    """dry_run previews threshold movement without persisting it."""
+    await _enable_autotune(db_tx)
+    await db_tx.execute(
+        "INSERT INTO system_settings (key, value) VALUES "
+        "('compliance_alert_threshold_urgent_visa_expiry','7') "
+        "ON CONFLICT (key) DO UPDATE SET value='7'",
+    )
+    await _seed_outcomes(db_tx, sample_client["id"], "visa_expiry", acted=5, dismissed=20)
+
+    fb = AlertFeedback(connection=db_tx)
+    result = await fb.retrain(dry_run=True)
+
+    new = await db_tx.fetchval(
+        "SELECT value FROM system_settings WHERE key='compliance_alert_threshold_urgent_visa_expiry'",
+    )
+    assert int(new) == 7
+    assert result["reason"] == "dry_run"
+    assert result["dry_run"] is True
+    assert ("visa_expiry", 7, 8) in [(c["category"], c["old"], c["new"]) for c in result["changed"]]
+
+
+@pytest.mark.asyncio
 async def test_high_precision_tightens_threshold(
     db_tx: asyncpg.Connection, sample_client: dict
 ) -> None:

--- a/apps/backend-rag/backend/tests/setup/test_router_registration_parity.py
+++ b/apps/backend-rag/backend/tests/setup/test_router_registration_parity.py
@@ -30,6 +30,7 @@ Cicatrix ref: .claude/rules/cicatrix-scars.md "Test infrastructure mock
 
 from __future__ import annotations
 
+import ast
 import inspect
 import re
 
@@ -53,6 +54,40 @@ def _extract_function_body(source: str, fn_name: str) -> str:
     if next_match:
         return source[start : start + 1 + next_match.start()]
     return source[start:]
+
+
+def _included_router_pairs(fn_name: str) -> set[tuple[str, str]]:
+    """Return (module, router_attr) pairs passed to api.include_router()."""
+    tree = ast.parse(_read_registration_source())
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == fn_name
+    )
+
+    imported_modules: dict[str, str] = {}
+    for node in ast.walk(function):
+        if isinstance(node, ast.ImportFrom) and node.module == "backend.app.routers":
+            for alias in node.names:
+                imported_modules[alias.asname or alias.name] = alias.name
+
+    pairs: set[tuple[str, str]] = set()
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        if not isinstance(node.func, ast.Attribute) or node.func.attr != "include_router":
+            continue
+
+        router_arg = node.args[0]
+        if not isinstance(router_arg, ast.Attribute) or not isinstance(
+            router_arg.value, ast.Name
+        ):
+            continue
+
+        module_name = imported_modules.get(router_arg.value.id, router_arg.value.id)
+        pairs.add((module_name, router_arg.attr))
+
+    return pairs
 
 
 class TestChannelHealthRegression:
@@ -212,4 +247,45 @@ class TestPortalManifestRegistrationParity:
         assert not missing_light, (
             f"portal_* routers in manifest but NOT in include_light_routers(): "
             f"{missing_light} — would 404 in main_api production. (ONDA-3 S11 P0 scar.)"
+        )
+
+
+class TestManifestApiRuntimeCoverage:
+    """Regression guard for manifest-only API routers.
+
+    Manifest entries with process_groups containing `api` are explicitly
+    registered in both runtime functions. Import-path module routers are
+    intentionally excluded because they mount through local aliases. Olympus is
+    the one documented light-process exception: router_registration.py keeps its
+    internal admin surface full-only.
+    """
+
+    LIGHT_PROCESS_EXCEPTIONS: frozenset[tuple[str, str]] = frozenset(
+        {("olympus", "internal_router")}
+    )
+
+    def _api_manifest_pairs(self) -> set[tuple[str, str]]:
+        return {
+            (entry.name, entry.attr)
+            for entry in ROUTER_MANIFEST
+            if "api" in entry.process_groups and entry.import_path is None
+        }
+
+    def test_api_manifest_entries_registered_in_full_and_light(self) -> None:
+        expected_full = self._api_manifest_pairs()
+        expected_light = expected_full - self.LIGHT_PROCESS_EXCEPTIONS
+
+        in_full = _included_router_pairs("include_routers")
+        in_light = _included_router_pairs("include_light_routers")
+
+        missing_full = sorted(expected_full - in_full)
+        missing_light = sorted(expected_light - in_light)
+
+        assert not missing_full, (
+            "_API/_BOTH manifest routers missing from include_routers(): "
+            f"{missing_full}"
+        )
+        assert not missing_light, (
+            "_API/_BOTH manifest routers missing from include_light_routers(): "
+            f"{missing_light}"
         )

--- a/apps/backend-rag/backend/tests/unit/routers/test_war_room_dashboard_router.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_war_room_dashboard_router.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.app.dependencies import get_current_user, get_database_pool
+from backend.app.routers.war_room_dashboard import router
+
+
+def test_war_room_metrics_requires_admin_user() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: {
+        "email": "viewer@example.com",
+        "role": "team",
+    }
+    app.dependency_overrides[get_database_pool] = lambda: object()
+
+    try:
+        response = TestClient(app).get("/api/war-room/metrics/timeline")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Admin access required"}

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`289 routers · 582 services · 991 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`314 routers · 593 services · 998 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/research/operations/2026-06-04-codex-orchestrator-map.md
+++ b/research/operations/2026-06-04-codex-orchestrator-map.md
@@ -1,0 +1,116 @@
+# Codex Orchestrator Map - 2026-06-04
+
+Scope: map non-operative or partially operative surfaces, identify active
+parallel lanes, and close one non-overlapping backend fix through tests.
+
+## Machine and Sync
+
+- Local machine: Pro, `nuzantara@Nuzantara`.
+- `mini` SSH alias was unreachable during this session.
+- `m5` / Air-M5 was reachable in a prior check but was not at the same repo
+  head as this Pro worktree.
+- Main checkout was busy and dirty on branch `fix/backup-fly-proxy-2026-06-03`.
+- Codex mutation worktree: `.worktrees/ops-codex-orchestrator-map`.
+
+## Active No-Touch Lanes
+
+- Main checkout: occupied by Claude/Codex desktop flows; do not mutate there.
+- WR2/WR3/FlowKit/media lanes: active or likely active; avoid asset/prompt/video
+  automation unless explicitly assigned.
+- WA, wa-mirror, OpenClaw, doc-intake, corpus, and CRM Guardian runtime lanes:
+  active or scheduled; inspect live logs before changing worker behavior.
+- M5 lanes include S1 events outbox, Olympus/db safety envelope, organism/world
+  scan, golden visa/docs work. Avoid Olympus light-process registration changes
+  until that lane resolves.
+
+## Subagent Reuse
+
+- Singer: backend/router/runtime audit. Confirmed manifest-vs-registration drift,
+  `team_members` duplicate registration, compliance dry-run risk, Naga/intel/
+  autonomous stubs, scheduler migrations, and legal KG OOM disable.
+- Noether: frontend/MCP audit. Confirmed stale `apps/webapp` scope, unwired
+  `apps/web`, admin war-room navigation gap, mouth frontend metrics no-op,
+  streaming resume backlog, settings placeholders, E2E skips, MCP mock-only
+  coverage and live-gated ops.
+- Hooke: ops ownership audit. Confirmed main checkout occupancy, active local
+  sessions, M5 divergence, and safe backend setup files for this worktree.
+
+## Closed In This Worktree
+
+- Registered manifest-declared API routers that were not mounted at runtime:
+  `admin_email_health`, `admin_pii`, `admin_rate_limit`,
+  `admin_self_healing`, `compliance_alerts`, `intel_observability`,
+  `llm_costs`, `partners`, `research_control`, `war_room_dashboard`,
+  and `workspace_analytics`.
+- Registered RAG/BOTH routers in the heavy process where missing:
+  `admin_rate_limit`, `admin_self_healing`, `intel_lake`,
+  and `intel_observability`.
+- Left `olympus.internal_router` full-only for light process because local
+  comments and active M5 Olympus work mark it as internal/admin ownership.
+- Removed the stale light registration for `team_members.router`; `team.py`
+  remains the canonical `/api/team/members` router.
+- Added AST-based parity coverage so future `_API/_BOTH` manifest entries must
+  appear in full and light runtime registration, and `_RAG` entries are audited
+  in an independent local check.
+- Hardened `/api/war-room/metrics/*` with CRM admin auth before exposing it.
+- Made compliance alert retrain `dry_run` non-mutating and covered it with a DB
+  test before exposing the router.
+
+## Verified
+
+- `PYTHONPATH=. pytest backend/tests/setup/test_router_registration_parity.py backend/tests/setup/test_router_manifest.py backend/tests/unit/routers/test_war_room_dashboard_router.py backend/tests/services/compliance/test_alert_feedback.py -q`
+  - Result: 33 passed.
+- `PYTHONPATH=. pytest backend/tests/app/routers/test_compliance_alerts_router.py -q`
+  - Result: 8 passed.
+- `ruff check` on touched backend files.
+  - Result: all checks passed.
+- `python -c "from backend.app.dependencies import get_current_user; print('OK')"`
+  - Result: OK.
+- Independent AST audit:
+  - `missing_full_api []`
+  - `missing_light_api []`
+  - `missing_heavy_rag []`
+  - `registered_without_manifest []`
+- Runtime registration smoke:
+  - `full: 758 routes`
+  - `light: 572 routes`
+  - `heavy: 250 routes`
+
+## Remaining Non-Operative / Partial Surfaces
+
+High priority, backend:
+
+- `autonomous_execution` and `services/rag/autonomous_executor.py`: feature flag
+  is documented but not wired; execution remains POC/simulated.
+- `naga.py`: session lookup and claims search are stubs or v1.1 placeholders.
+- `intel.py` staging revalidate endpoint returns 501.
+- `oracle_universal.py`: accepts fields that are logged/dropped instead of
+  passed through to service.
+- `whatsapp_onboarding_detector.py`: onboarding chain trigger returns mock
+  result instead of invoking MCP.
+- Trend Hunter adapters: XAI, Reddit, and Google Trends adapters return empty
+  placeholder results.
+- Legal ingestion KG extraction: intentionally disabled on Fly due 2GB OOM;
+  only consider Pro/offline proof.
+- Autonomous scheduler: several jobs intentionally migrated to Air/Pro cron or
+  disabled due Fly auto-stop/self-call issues.
+
+High priority, frontend/MCP:
+
+- `apps/webapp` is stale scope; actual satellite appears to be `apps/web`, but
+  `apps/web` is not a root workspace and imports `@nuzantara/ts-schemas`.
+- Admin war-room metrics page exists but is not linked from admin sidebar.
+- Mouth frontend metrics collection skips `/api/metrics/frontend` because the
+  endpoint is not implemented.
+- Chat streaming retry/resume is documented as incomplete.
+- Settings integrations and user management contain local-state placeholders.
+- MCP chains/browser/advanced ops have strong mock coverage but live operation
+  remains opt-in and environment gated.
+
+## Suggested Next Assignments
+
+- Backend lane: Naga/intel/autonomous stubs, one feature per worktree.
+- Frontend lane: `apps/web` workspace wiring and admin war-room discoverability.
+- Ops lane: prove CRM Guardian/WA/doc-intake runtime from logs before changing
+  worker automation.
+- M5 lane: resolve Olympus/db safety work before changing light process exposure.


### PR DESCRIPTION
## Summary
- register manifest-declared API/BOTH routers in full and light runtime paths, and RAG/BOTH routers in heavy runtime paths
- remove stale light registration for disabled duplicate `team_members` router
- harden war-room metrics with CRM admin auth before exposing it
- make compliance alert retrain `dry_run` non-mutating before exposing that router
- add AST parity coverage and orchestration map report

## Verification
- `PYTHONPATH=. pytest backend/tests/setup/test_router_registration_parity.py backend/tests/setup/test_router_manifest.py backend/tests/unit/routers/test_war_room_dashboard_router.py backend/tests/services/compliance/test_alert_feedback.py -q` (33 passed)
- `PYTHONPATH=. pytest backend/tests/app/routers/test_compliance_alerts_router.py -q` (8 passed)
- `ruff check` on touched backend files
- dependency import smoke: `from backend.app.dependencies import get_current_user`
- independent AST audit: no missing full/light/heavy registrations and no registered router outside manifest
- runtime registration smoke: full 758 routes, light 572 routes, heavy 250 routes