### PR TITLE
feat(ops): add live orchestrator map

### DIFF
--- a/research/operations/2026-06-04-codex-orchestrator-map.md
+++ b/research/operations/2026-06-04-codex-orchestrator-map.md
@@ -114,3 +114,19 @@ High priority, frontend/MCP:
 - Ops lane: prove CRM Guardian/WA/doc-intake runtime from logs before changing
   worker automation.
 - M5 lane: resolve Olympus/db safety work before changing light process exposure.
+
+## 2026-06-05 Reusable Live Mapper
+
+The manual map is now backed by `scripts/ops/orchestrator_live_map.py`, a
+read-only CLI that gathers:
+
+- `git worktree list --porcelain` for active isolated lanes.
+- `gh pr list` for open remote branches and likely ownership.
+- local process signals for Claude, Codex, Gemini, FlowKit, WA, and backend
+  runtimes.
+- high-signal incomplete markers in operative source roots.
+
+It derives no-touch lanes first, then proposes candidate workstreams only when
+the component area is not already owned by an open PR, active worktree, or live
+runtime signal. This keeps the orchestration map reusable without relying on a
+single stale report snapshot.

--- a/scripts/ops/orchestrator_live_map.py
+++ b/scripts/ops/orchestrator_live_map.py
@@ -1,0 +1,661 @@
+#!/usr/bin/env python3
+"""Read-only live map for Nuzantara agent orchestration.
+
+The mapper turns the ad-hoc "who is working on what?" audit into a repeatable
+artifact. It gathers active git worktrees, open PRs, relevant local processes,
+and high-signal incomplete-code markers, then derives no-touch lanes and safe
+candidate workstreams.
+
+It is intentionally read-only: no branch switching, no cleanup, no process
+signals, and no writes unless --output is explicitly provided.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+DEFAULT_SCAN_ROOTS = (
+    "apps/backend-rag/backend",
+    "apps/mouth",
+    "apps/admin-dashboard",
+    "apps/web",
+    "apps/webapp",
+    "apps/nuzantara-mcp",
+    "scripts",
+)
+SKIP_DIRS = {
+    ".git",
+    ".next",
+    ".pytest_cache",
+    ".venv",
+    "__pycache__",
+    "node_modules",
+    "dist",
+    "build",
+    "coverage",
+    "tests",
+    "__tests__",
+    "e2e",
+}
+SOURCE_SUFFIXES = {
+    ".py",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".cjs",
+    ".sh",
+    ".md",
+}
+MAX_SCAN_BYTES = 512_000
+
+MARKER_PATTERNS: tuple[tuple[str, str, str], ...] = (
+    ("not_implemented_error", r"\bNotImplementedError\b", "high"),
+    ("http_501", r"\bstatus_code\s*=\s*501\b|\bHTTP_501\b|\b501\b.*not implemented", "high"),
+    ("mock_result", r"\b(mock|placeholder|stub)\b.{0,80}\b(result|response|data)\b", "medium"),
+    ("returns_empty_placeholder", r"\breturn\s+(\[\]|\{\})\b.{0,80}\b(placeholder|stub|mock)\b", "medium"),
+    ("todo", r"\b(TODO|FIXME)\b", "low"),
+    ("not_implemented_text", r"\bnot implemented\b", "medium"),
+    ("placeholder_text", r"\bplaceholder\b|\bstub\b", "medium"),
+)
+
+LANE_KEYWORDS: tuple[tuple[str, str], ...] = (
+    ("wr2", "wr2"),
+    ("wr3", "wr3"),
+    ("flowkit", "flowkit"),
+    ("wa-mirror", "wa"),
+    ("wacorpus", "wa"),
+    ("wa-corpus", "wa"),
+    ("whatsapp", "wa"),
+    ("doc-intake", "doc-intake"),
+    ("document-intake", "doc-intake"),
+    ("olympus", "olympus"),
+    ("router", "backend-router"),
+    ("backend-rag", "backend-rag"),
+    ("apps/mouth", "mouth"),
+    ("mouth", "mouth"),
+    ("palette", "mouth"),
+    ("messagebubble", "mouth"),
+    ("imagegenmodal", "mouth"),
+    ("observatory", "observatory"),
+    ("s13", "s13"),
+    ("translation-drift", "translation"),
+    ("crm_guardian", "crm-guardian"),
+    ("crm-guardian", "crm-guardian"),
+    ("workspace-event", "workspace-event-bridge"),
+    ("intake", "doc-intake"),
+)
+
+PROCESS_KEYWORDS: tuple[tuple[str, str], ...] = (
+    ("claude", "claude"),
+    ("codex", "codex"),
+    ("gemini", "gemini"),
+    ("flowkit", "flowkit"),
+    ("wa-mirror", "wa"),
+    ("openclaw_whatsapp", "wa"),
+    ("crm_guardian", "crm-guardian"),
+    ("workspace-event", "workspace-event-bridge"),
+    ("uvicorn", "backend-runtime"),
+    ("next dev", "frontend-runtime"),
+)
+
+AREA_BLOCK_ALIASES: dict[str, set[str]] = {
+    "backend-rag": {"backend-rag", "backend-router", "backend-service"},
+    "backend-router": {"backend-router"},
+    "wa": {"wa"},
+    "wr2": {"wr2"},
+    "wr3": {"wr3"},
+    "doc-intake": {"doc-intake"},
+    "olympus": {"olympus"},
+    "flowkit": {"flowkit", "wr2", "wr3"},
+    "s13": {"s13"},
+}
+
+
+@dataclass(frozen=True)
+class WorktreeInfo:
+    path: str
+    head: str | None = None
+    branch: str | None = None
+    detached: bool = False
+    lane: str | None = None
+    task_id: str | None = None
+
+
+@dataclass(frozen=True)
+class PullRequestInfo:
+    number: int
+    title: str
+    head_ref: str
+    base_ref: str
+    state: str
+    is_draft: bool
+    merge_state_status: str | None
+    updated_at: str | None
+    author: str | None
+    lane: str | None = None
+
+
+@dataclass(frozen=True)
+class ProcessSignal:
+    pid: int | None
+    category: str
+    command: str
+
+
+@dataclass(frozen=True)
+class ComponentFinding:
+    component_id: str
+    area: str
+    path: str
+    line: int
+    marker: str
+    severity: str
+    evidence: str
+
+
+@dataclass(frozen=True)
+class NoTouchLane:
+    lane: str
+    reason: str
+    source: str
+    reference: str
+
+
+@dataclass(frozen=True)
+class CandidateWorkstream:
+    lane: str
+    task_id: str
+    area: str
+    finding_count: int
+    top_severity: str
+    sample_paths: list[str]
+    rationale: str
+
+
+@dataclass(frozen=True)
+class OrchestratorMap:
+    generated_at: str
+    repo_root: str
+    current_branch: str | None
+    worktrees: list[WorktreeInfo] = field(default_factory=list)
+    pull_requests: list[PullRequestInfo] = field(default_factory=list)
+    process_signals: list[ProcessSignal] = field(default_factory=list)
+    findings: list[ComponentFinding] = field(default_factory=list)
+    no_touch_lanes: list[NoTouchLane] = field(default_factory=list)
+    candidate_workstreams: list[CandidateWorkstream] = field(default_factory=list)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _run_command(args: Sequence[str], cwd: Path, timeout_s: int = 15) -> str:
+    try:
+        proc = subprocess.run(
+            list(args),
+            cwd=cwd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout
+
+
+def _infer_lane(text: str) -> str | None:
+    lowered = text.lower()
+    for needle, lane in LANE_KEYWORDS:
+        if needle in lowered:
+            return lane
+    return None
+
+
+def _parse_branch_lane(branch: str | None) -> tuple[str | None, str | None]:
+    if not branch:
+        return None, None
+    parts = branch.split("/")
+    if len(parts) >= 4 and parts[0] == "agent":
+        return parts[2], parts[3]
+    lane = _infer_lane(branch)
+    return lane, None
+
+
+def parse_worktree_porcelain(text: str) -> list[WorktreeInfo]:
+    worktrees: list[WorktreeInfo] = []
+    current: dict[str, str] = {}
+
+    def flush() -> None:
+        if not current.get("worktree"):
+            return
+        branch_ref = current.get("branch")
+        branch = branch_ref.removeprefix("refs/heads/") if branch_ref else None
+        lane, task_id = _parse_branch_lane(branch)
+        worktrees.append(
+            WorktreeInfo(
+                path=current["worktree"],
+                head=current.get("HEAD"),
+                branch=branch,
+                detached="detached" in current,
+                lane=lane or _infer_lane(current["worktree"]),
+                task_id=task_id,
+            )
+        )
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            flush()
+            current = {}
+            continue
+        key, _, value = line.partition(" ")
+        current[key] = value
+    flush()
+    return worktrees
+
+
+def parse_pr_json(text: str) -> list[PullRequestInfo]:
+    if not text.strip():
+        return []
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(data, list):
+        return []
+
+    prs: list[PullRequestInfo] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        author = item.get("author")
+        if isinstance(author, dict):
+            author_login = author.get("login")
+        else:
+            author_login = None
+        number = item.get("number")
+        if not isinstance(number, int):
+            continue
+        head_ref = str(item.get("headRefName") or "")
+        prs.append(
+            PullRequestInfo(
+                number=number,
+                title=str(item.get("title") or ""),
+                head_ref=head_ref,
+                base_ref=str(item.get("baseRefName") or ""),
+                state=str(item.get("state") or ""),
+                is_draft=bool(item.get("isDraft")),
+                merge_state_status=item.get("mergeStateStatus"),
+                updated_at=item.get("updatedAt"),
+                author=author_login,
+                lane=_infer_lane(head_ref + " " + str(item.get("title") or "")),
+            )
+        )
+    return prs
+
+
+def parse_ps_aux(text: str) -> list[ProcessSignal]:
+    signals: list[ProcessSignal] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        category = _infer_process_category(line)
+        if category is None:
+            continue
+        parts = line.split(None, 10)
+        pid: int | None = None
+        if len(parts) > 1:
+            try:
+                pid = int(parts[1])
+            except ValueError:
+                pid = None
+        command = parts[10] if len(parts) > 10 else line
+        signals.append(ProcessSignal(pid=pid, category=category, command=command))
+    return signals
+
+
+def _infer_process_category(line: str) -> str | None:
+    lowered = line.lower()
+    for needle, label in PROCESS_KEYWORDS:
+        if needle == "flowkit":
+            # Avoid false positives from Apple's WorkflowKit framework.
+            if "/flowkit/" in lowered or "flowkit/venv" in lowered:
+                return label
+            continue
+        if needle in lowered:
+            return label
+    return None
+
+
+def component_area(path: str) -> str:
+    normalized = path.replace(os.sep, "/")
+    if normalized.startswith("apps/backend-rag/"):
+        if "/routers/" in normalized or "router_registration" in normalized:
+            return "backend-router"
+        if "/services/" in normalized:
+            return "backend-service"
+        return "backend-rag"
+    if normalized.startswith("apps/mouth/"):
+        return "mouth"
+    if normalized.startswith("apps/admin-dashboard/"):
+        return "admin-dashboard"
+    if normalized.startswith("apps/webapp/"):
+        return "webapp"
+    if normalized.startswith("apps/web/"):
+        return "web"
+    if normalized.startswith("apps/nuzantara-mcp/"):
+        return "mcp"
+    if normalized.startswith("scripts/wr2"):
+        return "wr2"
+    if normalized.startswith("scripts/wr3"):
+        return "wr3"
+    if "whatsapp" in normalized or "wa_" in normalized or "wa-" in normalized:
+        return "wa"
+    if normalized.startswith("scripts/"):
+        return "ops-script"
+    return normalized.split("/", 1)[0] if "/" in normalized else "repo"
+
+
+def _iter_scan_files(repo_root: Path, scan_roots: Iterable[str]) -> Iterable[Path]:
+    for rel_root in scan_roots:
+        root = repo_root / rel_root
+        if not root.exists():
+            continue
+        if root.is_file():
+            yield root
+            continue
+        for path in root.rglob("*"):
+            if not path.is_file():
+                continue
+            if any(part in SKIP_DIRS for part in path.parts):
+                continue
+            if path.suffix not in SOURCE_SUFFIXES:
+                continue
+            try:
+                if path.stat().st_size > MAX_SCAN_BYTES:
+                    continue
+            except OSError:
+                continue
+            yield path
+
+
+def scan_incomplete_markers(
+    repo_root: Path,
+    scan_roots: Iterable[str] = DEFAULT_SCAN_ROOTS,
+    *,
+    limit: int = 200,
+    per_area_limit: int = 30,
+) -> list[ComponentFinding]:
+    compiled = [(name, re.compile(pattern, re.IGNORECASE), severity) for name, pattern, severity in MARKER_PATTERNS]
+    findings: list[ComponentFinding] = []
+    seen: set[tuple[str, int, str]] = set()
+    area_counts: dict[str, int] = {}
+
+    for path in _iter_scan_files(repo_root, scan_roots):
+        try:
+            lines = path.read_text(errors="replace").splitlines()
+        except OSError:
+            continue
+        rel_path = path.relative_to(repo_root).as_posix()
+        area = component_area(rel_path)
+        if area_counts.get(area, 0) >= per_area_limit:
+            continue
+        for line_no, line in enumerate(lines, start=1):
+            stripped = line.strip()
+            if not stripped or stripped.startswith("# noqa"):
+                continue
+            for marker, regex, severity in compiled:
+                if not regex.search(stripped):
+                    continue
+                key = (rel_path, line_no, marker)
+                if key in seen:
+                    continue
+                seen.add(key)
+                findings.append(
+                    ComponentFinding(
+                        component_id=area,
+                        area=area,
+                        path=rel_path,
+                        line=line_no,
+                        marker=marker,
+                        severity=severity,
+                        evidence=stripped[:180],
+                    )
+                )
+                area_counts[area] = area_counts.get(area, 0) + 1
+                break
+            if len(findings) >= limit:
+                return findings
+            if area_counts.get(area, 0) >= per_area_limit:
+                break
+    return findings
+
+
+def derive_no_touch_lanes(
+    worktrees: Sequence[WorktreeInfo],
+    prs: Sequence[PullRequestInfo],
+    processes: Sequence[ProcessSignal],
+) -> list[NoTouchLane]:
+    lanes: dict[tuple[str, str, str], NoTouchLane] = {}
+
+    def add(lane: str | None, reason: str, source: str, reference: str) -> None:
+        if not lane:
+            return
+        key = (lane, source, reference)
+        lanes[key] = NoTouchLane(lane=lane, reason=reason, source=source, reference=reference)
+
+    for wt in worktrees:
+        if wt.lane:
+            add(wt.lane, "active git worktree exists", "worktree", wt.branch or wt.path)
+
+    for pr in prs:
+        if pr.state.upper() == "OPEN":
+            add(pr.lane, f"open PR #{pr.number}: {pr.title}", "pull_request", pr.head_ref)
+            if pr.lane == "backend-router":
+                add("backend-rag", f"open PR #{pr.number} touches router wiring", "pull_request", pr.head_ref)
+
+    process_seen: set[str] = set()
+    for proc in processes:
+        if proc.category in process_seen:
+            continue
+        process_seen.add(proc.category)
+        add(proc.category, "local process is running", "process", proc.command[:120])
+
+    return sorted(lanes.values(), key=lambda item: (item.lane, item.source, item.reference))
+
+
+def _severity_rank(severity: str) -> int:
+    return {"high": 3, "medium": 2, "low": 1}.get(severity, 0)
+
+
+def derive_candidate_workstreams(
+    findings: Sequence[ComponentFinding],
+    no_touch_lanes: Sequence[NoTouchLane],
+    *,
+    max_candidates: int = 8,
+) -> list[CandidateWorkstream]:
+    blocked_lanes = {lane.lane for lane in no_touch_lanes}
+    blocked_areas = set(blocked_lanes)
+    for lane in blocked_lanes:
+        blocked_areas.update(AREA_BLOCK_ALIASES.get(lane, set()))
+    grouped: dict[str, list[ComponentFinding]] = {}
+    for finding in findings:
+        if finding.area in blocked_areas or finding.component_id in blocked_areas:
+            continue
+        grouped.setdefault(finding.area, []).append(finding)
+
+    candidates: list[CandidateWorkstream] = []
+    for area, area_findings in grouped.items():
+        sorted_findings = sorted(
+            area_findings,
+            key=lambda item: (-_severity_rank(item.severity), item.path, item.line),
+        )
+        top = sorted_findings[0]
+        task_slug = re.sub(r"[^a-z0-9]+", "-", area.lower()).strip("-")[:40] or "component"
+        sample_paths = []
+        for finding in sorted_findings:
+            if finding.path not in sample_paths:
+                sample_paths.append(finding.path)
+            if len(sample_paths) >= 3:
+                break
+        candidates.append(
+            CandidateWorkstream(
+                lane="ops" if area == "ops-script" else area,
+                task_id=f"audit-{task_slug}-incomplete",
+                area=area,
+                finding_count=len(area_findings),
+                top_severity=top.severity,
+                sample_paths=sample_paths,
+                rationale="Incomplete markers found and no active no-touch lane currently owns this area.",
+            )
+        )
+    return sorted(
+        candidates,
+        key=lambda item: (-_severity_rank(item.top_severity), -item.finding_count, item.area),
+    )[:max_candidates]
+
+
+def collect_live_map(
+    repo_root: Path,
+    *,
+    scan_roots: Iterable[str] = DEFAULT_SCAN_ROOTS,
+    finding_limit: int = 200,
+    per_area_limit: int = 30,
+) -> OrchestratorMap:
+    repo_root = repo_root.resolve()
+    branch = _run_command(["git", "rev-parse", "--abbrev-ref", "HEAD"], repo_root).strip() or None
+    worktrees = parse_worktree_porcelain(_run_command(["git", "worktree", "list", "--porcelain"], repo_root))
+    pr_json = _run_command(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--limit",
+            "100",
+            "--json",
+            "number,title,headRefName,baseRefName,state,isDraft,mergeStateStatus,updatedAt,author",
+        ],
+        repo_root,
+        timeout_s=30,
+    )
+    prs = parse_pr_json(pr_json)
+    ps_text = _run_command(["ps", "aux"], repo_root)
+    processes = parse_ps_aux(ps_text)
+    findings = scan_incomplete_markers(repo_root, scan_roots, limit=finding_limit, per_area_limit=per_area_limit)
+    no_touch = derive_no_touch_lanes(worktrees, prs, processes)
+    candidates = derive_candidate_workstreams(findings, no_touch)
+    return OrchestratorMap(
+        generated_at=_utc_now(),
+        repo_root=str(repo_root),
+        current_branch=branch,
+        worktrees=worktrees,
+        pull_requests=prs,
+        process_signals=processes,
+        findings=findings,
+        no_touch_lanes=no_touch,
+        candidate_workstreams=candidates,
+    )
+
+
+def render_markdown(report: OrchestratorMap) -> str:
+    lines = [
+        f"# Nuzantara Orchestrator Live Map - {report.generated_at}",
+        "",
+        f"- Repo: `{report.repo_root}`",
+        f"- Branch: `{report.current_branch or 'unknown'}`",
+        f"- Worktrees: {len(report.worktrees)}",
+        f"- Open PRs observed: {len([pr for pr in report.pull_requests if pr.state.upper() == 'OPEN'])}",
+        f"- Process signals: {len(report.process_signals)}",
+        f"- Incomplete markers: {len(report.findings)}",
+        "",
+        "## No-Touch Lanes",
+    ]
+    if report.no_touch_lanes:
+        for lane in report.no_touch_lanes:
+            lines.append(f"- `{lane.lane}` ({lane.source}): {lane.reason} -> `{lane.reference}`")
+    else:
+        lines.append("- None detected.")
+
+    lines.extend(["", "## Candidate Workstreams"])
+    if report.candidate_workstreams:
+        for candidate in report.candidate_workstreams:
+            paths = ", ".join(f"`{path}`" for path in candidate.sample_paths)
+            lines.append(
+                f"- `{candidate.lane}` / `{candidate.task_id}`: {candidate.finding_count} "
+                f"markers, top severity `{candidate.top_severity}`. {paths}"
+            )
+    else:
+        lines.append("- No safe candidates detected outside no-touch lanes.")
+
+    lines.extend(["", "## High-Severity Findings"])
+    high = [finding for finding in report.findings if finding.severity == "high"][:25]
+    if high:
+        for finding in high:
+            lines.append(
+                f"- `{finding.area}` `{finding.path}:{finding.line}` "
+                f"{finding.marker}: {finding.evidence}"
+            )
+    else:
+        lines.append("- None in scanned scope.")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def to_json(report: OrchestratorMap) -> str:
+    return json.dumps(asdict(report), indent=2, sort_keys=True)
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate a read-only Nuzantara agent orchestration map.")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd(), help="Repository root to inspect.")
+    parser.add_argument("--format", choices=("json", "markdown"), default="markdown")
+    parser.add_argument("--output", type=Path, help="Optional output file. Stdout is used when omitted.")
+    parser.add_argument(
+        "--scan-root",
+        action="append",
+        dest="scan_roots",
+        help="Relative path to scan for incomplete markers. Can be repeated.",
+    )
+    parser.add_argument("--finding-limit", type=int, default=200)
+    parser.add_argument("--per-area-limit", type=int, default=30)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    scan_roots = args.scan_roots or list(DEFAULT_SCAN_ROOTS)
+    report = collect_live_map(
+        args.repo_root,
+        scan_roots=scan_roots,
+        finding_limit=args.finding_limit,
+        per_area_limit=args.per_area_limit,
+    )
+    rendered = to_json(report) if args.format == "json" else render_markdown(report)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+        if not rendered.endswith("\n"):
+            sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_orchestrator_live_map.py
+++ b/scripts/tests/test_orchestrator_live_map.py
@@ -1,0 +1,194 @@
+"""Tests for scripts/ops/orchestrator_live_map.py."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "ops" / "orchestrator_live_map.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("orchestrator_live_map_under_test", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+olm = _load_module()
+
+
+def test_parse_worktree_porcelain_extracts_agent_lane_and_task() -> None:
+    text = """worktree /repo
+HEAD abc
+branch refs/heads/main
+
+worktree /repo/.worktrees/ops-live-map
+HEAD def
+branch refs/heads/agent/nuzantara/ops/live-map
+
+worktree /repo/.worktrees/wr2-active
+HEAD 123
+detached
+"""
+    worktrees = olm.parse_worktree_porcelain(text)
+    assert len(worktrees) == 3
+    assert worktrees[1].branch == "agent/nuzantara/ops/live-map"
+    assert worktrees[1].lane == "ops"
+    assert worktrees[1].task_id == "live-map"
+    assert worktrees[2].detached is True
+    assert worktrees[2].lane == "wr2"
+
+
+def test_parse_pr_json_infers_lanes() -> None:
+    payload = [
+        {
+            "number": 1124,
+            "title": "feat(routers): wire orphan routers",
+            "headRefName": "agent/air-m5/backend-rag/wire-orphan-routers",
+            "baseRefName": "main",
+            "state": "OPEN",
+            "isDraft": False,
+            "mergeStateStatus": "DIRTY",
+            "updatedAt": "2026-06-04T16:24:39Z",
+            "author": {"login": "Balizero1987"},
+        },
+        {
+            "number": 1125,
+            "title": "fix(wr2): autopsy remediation",
+            "headRefName": "agent/nuzantara/wr2/autopsy-fixes",
+            "baseRefName": "main",
+            "state": "OPEN",
+            "isDraft": False,
+            "mergeStateStatus": "UNKNOWN",
+            "updatedAt": "2026-06-04T16:23:20Z",
+            "author": {"login": "Balizero1987"},
+        },
+        {
+            "number": 1116,
+            "title": "Palette: MessageBubble UX and Accessibility Improvements",
+            "headRefName": "palette/message-bubble-ux-a11y",
+            "baseRefName": "main",
+            "state": "OPEN",
+            "isDraft": False,
+            "mergeStateStatus": "UNKNOWN",
+            "updatedAt": "2026-06-04T02:51:35Z",
+            "author": {"login": "Balizero1987"},
+        },
+    ]
+    prs = olm.parse_pr_json(json.dumps(payload))
+    assert [pr.lane for pr in prs] == ["backend-router", "wr2", "mouth"]
+
+
+def test_derive_no_touch_lanes_uses_prs_worktrees_and_processes() -> None:
+    worktrees = [
+        olm.WorktreeInfo(path="/repo/.worktrees/doc-intake-dossier", branch="agent/pro/research/doc-intake-dossier", lane="doc-intake"),
+    ]
+    prs = [
+        olm.PullRequestInfo(
+            number=1124,
+            title="feat(routers): wire orphan routers",
+            head_ref="agent/air-m5/backend-rag/wire-orphan-routers",
+            base_ref="main",
+            state="OPEN",
+            is_draft=False,
+            merge_state_status="DIRTY",
+            updated_at=None,
+            author="Balizero1987",
+            lane="backend-router",
+        )
+    ]
+    processes = [
+        olm.ProcessSignal(pid=100, category="flowkit", command="/Users/nuzantara/flowkit/venv/bin/python"),
+        olm.ProcessSignal(pid=101, category="flowkit", command="/Users/nuzantara/flowkit/venv/bin/python -m agent.main"),
+    ]
+    lanes = olm.derive_no_touch_lanes(worktrees, prs, processes)
+    lane_names = {lane.lane for lane in lanes}
+    assert lane_names == {"backend-rag", "backend-router", "doc-intake", "flowkit"}
+    assert len([lane for lane in lanes if lane.lane == "flowkit"]) == 1
+
+
+def test_parse_ps_aux_ignores_apple_workflowkit_false_positive() -> None:
+    text = (
+        "user 10 0.0 0.0 /System/Library/PrivateFrameworks/WorkflowKit.framework/XPCServices/ShortcutsViewService\n"
+        "user 11 0.0 0.0 /Users/nuzantara/flowkit/venv/bin/python -m agent.main\n"
+    )
+    signals = olm.parse_ps_aux(text)
+    assert [(signal.pid, signal.category) for signal in signals] == [(11, "flowkit")]
+
+
+def test_flowkit_no_touch_blocks_wr3_candidates() -> None:
+    findings = [
+        olm.ComponentFinding(
+            component_id="wr3",
+            area="wr3",
+            path="scripts/wr3_flowkit_client.py",
+            line=1,
+            marker="placeholder_text",
+            severity="medium",
+            evidence="placeholder",
+        ),
+        olm.ComponentFinding(
+            component_id="admin-dashboard",
+            area="admin-dashboard",
+            path="apps/admin-dashboard/app/legal/page.tsx",
+            line=1,
+            marker="placeholder_text",
+            severity="medium",
+            evidence="placeholder",
+        ),
+    ]
+    no_touch = [olm.NoTouchLane(lane="flowkit", reason="running", source="process", reference="flowkit")]
+    candidates = olm.derive_candidate_workstreams(findings, no_touch)
+    assert [candidate.area for candidate in candidates] == ["admin-dashboard"]
+
+
+def test_scan_incomplete_markers_and_candidates_skip_no_touch(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    backend = repo / "apps" / "backend-rag" / "backend" / "app" / "routers"
+    mouth = repo / "apps" / "mouth"
+    backend.mkdir(parents=True)
+    mouth.mkdir(parents=True)
+    (backend / "intel.py").write_text(
+        "from fastapi import HTTPException\n"
+        "async def revalidate():\n"
+        "    raise HTTPException(status_code=501, detail='not implemented')\n"
+    )
+    (mouth / "settings.tsx").write_text("export const value = 'placeholder result';\n")
+
+    findings = olm.scan_incomplete_markers(repo, ["apps/backend-rag/backend", "apps/mouth"], limit=20)
+    assert {finding.area for finding in findings} == {"backend-router", "mouth"}
+    no_touch = [olm.NoTouchLane(lane="backend-rag", reason="active PR", source="test", reference="pr")]
+    candidates = olm.derive_candidate_workstreams(findings, no_touch)
+    assert [candidate.area for candidate in candidates] == ["mouth"]
+    assert candidates[0].task_id == "audit-mouth-incomplete"
+
+
+def test_render_markdown_includes_no_touch_and_candidates() -> None:
+    report = olm.OrchestratorMap(
+        generated_at="2026-06-04T16:00:00Z",
+        repo_root="/repo",
+        current_branch="agent/nuzantara/ops/live-map",
+        no_touch_lanes=[
+            olm.NoTouchLane(lane="wr2", reason="active git worktree exists", source="worktree", reference="agent/wr2")
+        ],
+        candidate_workstreams=[
+            olm.CandidateWorkstream(
+                lane="mouth",
+                task_id="audit-mouth-incomplete",
+                area="mouth",
+                finding_count=2,
+                top_severity="medium",
+                sample_paths=["apps/mouth/settings.tsx"],
+                rationale="test",
+            )
+        ],
+    )
+    rendered = olm.render_markdown(report)
+    assert "## No-Touch Lanes" in rendered
+    assert "`wr2`" in rendered
+    assert "`audit-mouth-incomplete`" in rendered


### PR DESCRIPTION
## Summary
- add a read-only live orchestrator mapper for worktrees, open PRs, process signals, and incomplete component markers
- derive no-touch lanes before suggesting candidate workstreams
- update the existing orchestrator report with the reusable mapper handoff

## Verification
- PYTHONPATH=. pytest scripts/tests/test_orchestrator_live_map.py -q
- ruff check scripts/ops/orchestrator_live_map.py scripts/tests/test_orchestrator_live_map.py
- python scripts/ops/orchestrator_live_map.py --format json --scan-root apps/admin-dashboard --finding-limit 20 --per-area-limit 10
- python scripts/docs_sync.py --check