### PR TITLE
feat(ops): map remote orchestrator lanes

### DIFF
--- a/research/operations/2026-06-04-codex-orchestrator-map.md
+++ b/research/operations/2026-06-04-codex-orchestrator-map.md
@@ -130,3 +130,22 @@ It derives no-touch lanes first, then proposes candidate workstreams only when
 the component area is not already owned by an open PR, active worktree, or live
 runtime signal. This keeps the orchestration map reusable without relying on a
 single stale report snapshot.
+
+## 2026-06-05 Multi-Machine Extension
+
+The live mapper can now include read-only remote observations before deriving
+safe candidate workstreams:
+
+```bash
+python scripts/ops/orchestrator_live_map.py --include-m5 --format markdown
+python scripts/ops/orchestrator_live_map.py --remote m5 --format json
+python scripts/ops/orchestrator_live_map.py --remote air=air:/Users/balizero/Desktop/nuzantara
+```
+
+Remote collection is intentionally narrow: `ssh`, `git -C <repo> worktree list
+--porcelain`, repo head metadata, and `ps aux`. It does not run remote cleanup,
+does not send process signals, and does not call `gh` remotely. Remote
+worktrees and process signals are tagged with their source machine, but their
+lanes block local candidate generation globally. That is the operational rule
+needed to avoid Codex and Claude Code working on the same feature from Pro and
+Air-M5 at the same time.

--- a/scripts/ops/orchestrator_live_map.py
+++ b/scripts/ops/orchestrator_live_map.py
@@ -9,12 +9,14 @@ candidate workstreams.
 It is intentionally read-only: no branch switching, no cleanup, no process
 signals, and no writes unless --output is explicitly provided.
 """
+
 from __future__ import annotations
 
 import argparse
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 from dataclasses import asdict, dataclass, field
@@ -61,9 +63,21 @@ MAX_SCAN_BYTES = 512_000
 
 MARKER_PATTERNS: tuple[tuple[str, str, str], ...] = (
     ("not_implemented_error", r"\bNotImplementedError\b", "high"),
-    ("http_501", r"\bstatus_code\s*=\s*501\b|\bHTTP_501\b|\b501\b.*not implemented", "high"),
-    ("mock_result", r"\b(mock|placeholder|stub)\b.{0,80}\b(result|response|data)\b", "medium"),
-    ("returns_empty_placeholder", r"\breturn\s+(\[\]|\{\})\b.{0,80}\b(placeholder|stub|mock)\b", "medium"),
+    (
+        "http_501",
+        r"\bstatus_code\s*=\s*501\b|\bHTTP_501\b|\b501\b.*not implemented",
+        "high",
+    ),
+    (
+        "mock_result",
+        r"\b(mock|placeholder|stub)\b.{0,80}\b(result|response|data)\b",
+        "medium",
+    ),
+    (
+        "returns_empty_placeholder",
+        r"\breturn\s+(\[\]|\{\})\b.{0,80}\b(placeholder|stub|mock)\b",
+        "medium",
+    ),
     ("todo", r"\b(TODO|FIXME)\b", "low"),
     ("not_implemented_text", r"\bnot implemented\b", "medium"),
     ("placeholder_text", r"\bplaceholder\b|\bstub\b", "medium"),
@@ -121,6 +135,31 @@ AREA_BLOCK_ALIASES: dict[str, set[str]] = {
     "s13": {"s13"},
 }
 
+DEFAULT_REMOTE_TARGETS: dict[str, tuple[str, str]] = {
+    "m5": ("m5", "/Users/balizero/Desktop/nuzantara"),
+    "air": ("air", "/Users/balizero/Desktop/nuzantara"),
+}
+
+
+@dataclass(frozen=True)
+class RemoteTarget:
+    name: str
+    host: str
+    repo_root: str
+
+
+@dataclass(frozen=True)
+class MachineStatus:
+    name: str
+    host: str | None
+    repo_root: str
+    reachable: bool
+    current_branch: str | None = None
+    head: str | None = None
+    origin_main: str | None = None
+    identity: str | None = None
+    error: str | None = None
+
 
 @dataclass(frozen=True)
 class WorktreeInfo:
@@ -130,6 +169,7 @@ class WorktreeInfo:
     detached: bool = False
     lane: str | None = None
     task_id: str | None = None
+    machine: str = "local"
 
 
 @dataclass(frozen=True)
@@ -144,6 +184,7 @@ class PullRequestInfo:
     updated_at: str | None
     author: str | None
     lane: str | None = None
+    machine: str | None = None
 
 
 @dataclass(frozen=True)
@@ -151,6 +192,7 @@ class ProcessSignal:
     pid: int | None
     category: str
     command: str
+    machine: str = "local"
 
 
 @dataclass(frozen=True)
@@ -170,6 +212,7 @@ class NoTouchLane:
     reason: str
     source: str
     reference: str
+    machine: str = "local"
 
 
 @dataclass(frozen=True)
@@ -188,6 +231,7 @@ class OrchestratorMap:
     generated_at: str
     repo_root: str
     current_branch: str | None
+    machines: list[MachineStatus] = field(default_factory=list)
     worktrees: list[WorktreeInfo] = field(default_factory=list)
     pull_requests: list[PullRequestInfo] = field(default_factory=list)
     process_signals: list[ProcessSignal] = field(default_factory=list)
@@ -217,11 +261,91 @@ def _run_command(args: Sequence[str], cwd: Path, timeout_s: int = 15) -> str:
     return proc.stdout
 
 
+def _run_ssh_command(
+    target: RemoteTarget, command: str, timeout_s: int = 15
+) -> tuple[str, str]:
+    try:
+        proc = subprocess.run(
+            [
+                "ssh",
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ConnectTimeout=5",
+                target.host,
+                command,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+    except OSError as exc:
+        return "", str(exc)
+    except subprocess.TimeoutExpired:
+        return "", f"timeout after {timeout_s}s"
+    if proc.returncode != 0:
+        return "", proc.stderr.strip() or f"ssh exited {proc.returncode}"
+    return proc.stdout, ""
+
+
+def _first_line(text: str) -> str | None:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return None
+
+
+def parse_remote_target(spec: str) -> RemoteTarget:
+    trimmed = spec.strip()
+    if not trimmed:
+        raise ValueError("remote target cannot be empty")
+    if trimmed in DEFAULT_REMOTE_TARGETS:
+        host, repo_root = DEFAULT_REMOTE_TARGETS[trimmed]
+        return RemoteTarget(name=trimmed, host=host, repo_root=repo_root)
+
+    if "=" in trimmed:
+        name, rest = trimmed.split("=", 1)
+        name = name.strip()
+        rest = rest.strip()
+    else:
+        rest = trimmed
+        name = rest.split(":", 1)[0].strip()
+
+    if ":" not in rest:
+        raise ValueError(
+            f"remote target must be name=host:/repo/path or host:/repo/path: {spec}"
+        )
+    host, repo_root = rest.split(":", 1)
+    host = host.strip()
+    repo_root = repo_root.strip()
+    if not name or not host or not repo_root:
+        raise ValueError(
+            f"remote target must include name, host, and repo path: {spec}"
+        )
+    return RemoteTarget(name=name, host=host, repo_root=repo_root)
+
+
 def _infer_lane(text: str) -> str | None:
     lowered = text.lower()
     for needle, lane in LANE_KEYWORDS:
         if needle in lowered:
             return lane
+    return None
+
+
+def _infer_machine(text: str) -> str | None:
+    lowered = text.lower()
+    if (
+        "air-m5" in lowered
+        or "air_m5" in lowered
+        or "agent/m5/" in lowered
+        or "agent/air/" in lowered
+    ):
+        return "m5"
+    if "agent/pro/" in lowered or "agent/nuzantara/" in lowered:
+        return "pro"
     return None
 
 
@@ -235,7 +359,9 @@ def _parse_branch_lane(branch: str | None) -> tuple[str | None, str | None]:
     return lane, None
 
 
-def parse_worktree_porcelain(text: str) -> list[WorktreeInfo]:
+def parse_worktree_porcelain(
+    text: str, *, machine: str = "local"
+) -> list[WorktreeInfo]:
     worktrees: list[WorktreeInfo] = []
     current: dict[str, str] = {}
 
@@ -253,6 +379,7 @@ def parse_worktree_porcelain(text: str) -> list[WorktreeInfo]:
                 detached="detached" in current,
                 lane=lane or _infer_lane(current["worktree"]),
                 task_id=task_id,
+                machine=machine,
             )
         )
 
@@ -303,12 +430,13 @@ def parse_pr_json(text: str) -> list[PullRequestInfo]:
                 updated_at=item.get("updatedAt"),
                 author=author_login,
                 lane=_infer_lane(head_ref + " " + str(item.get("title") or "")),
+                machine=_infer_machine(head_ref + " " + str(item.get("title") or "")),
             )
         )
     return prs
 
 
-def parse_ps_aux(text: str) -> list[ProcessSignal]:
+def parse_ps_aux(text: str, *, machine: str = "local") -> list[ProcessSignal]:
     signals: list[ProcessSignal] = []
     for raw_line in text.splitlines():
         line = raw_line.strip()
@@ -325,7 +453,9 @@ def parse_ps_aux(text: str) -> list[ProcessSignal]:
             except ValueError:
                 pid = None
         command = parts[10] if len(parts) > 10 else line
-        signals.append(ProcessSignal(pid=pid, category=category, command=command))
+        signals.append(
+            ProcessSignal(pid=pid, category=category, command=command, machine=machine)
+        )
     return signals
 
 
@@ -340,6 +470,93 @@ def _infer_process_category(line: str) -> str | None:
         if needle in lowered:
             return label
     return None
+
+
+def collect_local_machine_status(repo_root: Path) -> MachineStatus:
+    whoami = _first_line(_run_command(["whoami"], repo_root))
+    hostname = _first_line(_run_command(["hostname"], repo_root))
+    branch = _first_line(
+        _run_command(["git", "rev-parse", "--abbrev-ref", "HEAD"], repo_root)
+    )
+    head = _first_line(_run_command(["git", "rev-parse", "--short", "HEAD"], repo_root))
+    origin_main = _first_line(
+        _run_command(["git", "rev-parse", "--short", "origin/main"], repo_root)
+    )
+    identity = f"{whoami}@{hostname}" if whoami and hostname else None
+    return MachineStatus(
+        name="local",
+        host=hostname,
+        repo_root=str(repo_root),
+        reachable=True,
+        current_branch=branch,
+        head=head,
+        origin_main=origin_main,
+        identity=identity,
+    )
+
+
+def _parse_status_lines(text: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in text.splitlines():
+        key, separator, value = line.partition("=")
+        if separator and key:
+            values[key.strip()] = value.strip()
+    return values
+
+
+def collect_remote_machine(
+    target: RemoteTarget,
+) -> tuple[MachineStatus, list[WorktreeInfo], list[ProcessSignal]]:
+    quoted_repo = shlex.quote(target.repo_root)
+    status_command = (
+        'printf "identity=%s@%s\\n" "$(whoami)" "$(hostname)"; '
+        f"if git -C {quoted_repo} rev-parse --git-dir >/dev/null 2>&1; then "
+        f'printf "branch="; git -C {quoted_repo} rev-parse --abbrev-ref HEAD 2>/dev/null || true; '
+        f'printf "head="; git -C {quoted_repo} rev-parse --short HEAD 2>/dev/null || true; '
+        f'printf "origin_main="; git -C {quoted_repo} rev-parse --short origin/main 2>/dev/null || true; '
+        'else printf "error=repo_not_available\\n"; fi'
+    )
+    status_text, status_error = _run_ssh_command(target, status_command, timeout_s=15)
+    if status_error:
+        return (
+            MachineStatus(
+                name=target.name,
+                host=target.host,
+                repo_root=target.repo_root,
+                reachable=False,
+                error=status_error,
+            ),
+            [],
+            [],
+        )
+
+    status_values = _parse_status_lines(status_text)
+    status = MachineStatus(
+        name=target.name,
+        host=target.host,
+        repo_root=target.repo_root,
+        reachable=True,
+        current_branch=status_values.get("branch") or None,
+        head=status_values.get("head") or None,
+        origin_main=status_values.get("origin_main") or None,
+        identity=status_values.get("identity") or None,
+        error=status_values.get("error") or None,
+    )
+
+    if status.error:
+        return status, [], []
+
+    worktree_text, _ = _run_ssh_command(
+        target,
+        f"git -C {quoted_repo} worktree list --porcelain 2>/dev/null || true",
+        timeout_s=20,
+    )
+    ps_text, _ = _run_ssh_command(target, "ps aux 2>/dev/null || true", timeout_s=20)
+    return (
+        status,
+        parse_worktree_porcelain(worktree_text, machine=target.name),
+        parse_ps_aux(ps_text, machine=target.name),
+    )
 
 
 def component_area(path: str) -> str:
@@ -401,7 +618,10 @@ def scan_incomplete_markers(
     limit: int = 200,
     per_area_limit: int = 30,
 ) -> list[ComponentFinding]:
-    compiled = [(name, re.compile(pattern, re.IGNORECASE), severity) for name, pattern, severity in MARKER_PATTERNS]
+    compiled = [
+        (name, re.compile(pattern, re.IGNORECASE), severity)
+        for name, pattern, severity in MARKER_PATTERNS
+    ]
     findings: list[ComponentFinding] = []
     seen: set[tuple[str, int, str]] = set()
     area_counts: dict[str, int] = {}
@@ -451,32 +671,74 @@ def derive_no_touch_lanes(
     prs: Sequence[PullRequestInfo],
     processes: Sequence[ProcessSignal],
 ) -> list[NoTouchLane]:
-    lanes: dict[tuple[str, str, str], NoTouchLane] = {}
+    lanes: dict[tuple[str, str, str, str], NoTouchLane] = {}
 
-    def add(lane: str | None, reason: str, source: str, reference: str) -> None:
+    def add(
+        lane: str | None,
+        reason: str,
+        source: str,
+        reference: str,
+        *,
+        machine: str = "local",
+    ) -> None:
         if not lane:
             return
-        key = (lane, source, reference)
-        lanes[key] = NoTouchLane(lane=lane, reason=reason, source=source, reference=reference)
+        key = (lane, source, reference, machine)
+        lanes[key] = NoTouchLane(
+            lane=lane,
+            reason=reason,
+            source=source,
+            reference=reference,
+            machine=machine,
+        )
 
     for wt in worktrees:
         if wt.lane:
-            add(wt.lane, "active git worktree exists", "worktree", wt.branch or wt.path)
+            add(
+                wt.lane,
+                "active git worktree exists",
+                "worktree",
+                wt.branch or wt.path,
+                machine=wt.machine,
+            )
 
     for pr in prs:
         if pr.state.upper() == "OPEN":
-            add(pr.lane, f"open PR #{pr.number}: {pr.title}", "pull_request", pr.head_ref)
+            machine = pr.machine or "github"
+            add(
+                pr.lane,
+                f"open PR #{pr.number}: {pr.title}",
+                "pull_request",
+                pr.head_ref,
+                machine=machine,
+            )
             if pr.lane == "backend-router":
-                add("backend-rag", f"open PR #{pr.number} touches router wiring", "pull_request", pr.head_ref)
+                add(
+                    "backend-rag",
+                    f"open PR #{pr.number} touches router wiring",
+                    "pull_request",
+                    pr.head_ref,
+                    machine=machine,
+                )
 
-    process_seen: set[str] = set()
+    process_seen: set[tuple[str, str]] = set()
     for proc in processes:
-        if proc.category in process_seen:
+        process_key = (proc.machine, proc.category)
+        if process_key in process_seen:
             continue
-        process_seen.add(proc.category)
-        add(proc.category, "local process is running", "process", proc.command[:120])
+        process_seen.add(process_key)
+        add(
+            proc.category,
+            f"process is running on {proc.machine}",
+            "process",
+            proc.command[:120],
+            machine=proc.machine,
+        )
 
-    return sorted(lanes.values(), key=lambda item: (item.lane, item.source, item.reference))
+    return sorted(
+        lanes.values(),
+        key=lambda item: (item.lane, item.machine, item.source, item.reference),
+    )
 
 
 def _severity_rank(severity: str) -> int:
@@ -506,7 +768,9 @@ def derive_candidate_workstreams(
             key=lambda item: (-_severity_rank(item.severity), item.path, item.line),
         )
         top = sorted_findings[0]
-        task_slug = re.sub(r"[^a-z0-9]+", "-", area.lower()).strip("-")[:40] or "component"
+        task_slug = (
+            re.sub(r"[^a-z0-9]+", "-", area.lower()).strip("-")[:40] or "component"
+        )
         sample_paths = []
         for finding in sorted_findings:
             if finding.path not in sample_paths:
@@ -526,7 +790,11 @@ def derive_candidate_workstreams(
         )
     return sorted(
         candidates,
-        key=lambda item: (-_severity_rank(item.top_severity), -item.finding_count, item.area),
+        key=lambda item: (
+            -_severity_rank(item.top_severity),
+            -item.finding_count,
+            item.area,
+        ),
     )[:max_candidates]
 
 
@@ -536,10 +804,17 @@ def collect_live_map(
     scan_roots: Iterable[str] = DEFAULT_SCAN_ROOTS,
     finding_limit: int = 200,
     per_area_limit: int = 30,
+    remote_targets: Sequence[RemoteTarget] = (),
 ) -> OrchestratorMap:
     repo_root = repo_root.resolve()
-    branch = _run_command(["git", "rev-parse", "--abbrev-ref", "HEAD"], repo_root).strip() or None
-    worktrees = parse_worktree_porcelain(_run_command(["git", "worktree", "list", "--porcelain"], repo_root))
+    branch = (
+        _run_command(["git", "rev-parse", "--abbrev-ref", "HEAD"], repo_root).strip()
+        or None
+    )
+    machines = [collect_local_machine_status(repo_root)]
+    worktrees = parse_worktree_porcelain(
+        _run_command(["git", "worktree", "list", "--porcelain"], repo_root)
+    )
     pr_json = _run_command(
         [
             "gh",
@@ -556,13 +831,21 @@ def collect_live_map(
     prs = parse_pr_json(pr_json)
     ps_text = _run_command(["ps", "aux"], repo_root)
     processes = parse_ps_aux(ps_text)
-    findings = scan_incomplete_markers(repo_root, scan_roots, limit=finding_limit, per_area_limit=per_area_limit)
+    for target in remote_targets:
+        status, remote_worktrees, remote_processes = collect_remote_machine(target)
+        machines.append(status)
+        worktrees.extend(remote_worktrees)
+        processes.extend(remote_processes)
+    findings = scan_incomplete_markers(
+        repo_root, scan_roots, limit=finding_limit, per_area_limit=per_area_limit
+    )
     no_touch = derive_no_touch_lanes(worktrees, prs, processes)
     candidates = derive_candidate_workstreams(findings, no_touch)
     return OrchestratorMap(
         generated_at=_utc_now(),
         repo_root=str(repo_root),
         current_branch=branch,
+        machines=machines,
         worktrees=worktrees,
         pull_requests=prs,
         process_signals=processes,
@@ -583,11 +866,37 @@ def render_markdown(report: OrchestratorMap) -> str:
         f"- Process signals: {len(report.process_signals)}",
         f"- Incomplete markers: {len(report.findings)}",
         "",
-        "## No-Touch Lanes",
+        "## Machines",
     ]
+    if report.machines:
+        for machine in report.machines:
+            state = "reachable" if machine.reachable else "unreachable"
+            details = [
+                f"identity=`{machine.identity or 'unknown'}`",
+                f"branch=`{machine.current_branch or 'unknown'}`",
+                f"head=`{machine.head or 'unknown'}`",
+                f"origin/main=`{machine.origin_main or 'unknown'}`",
+            ]
+            if machine.error:
+                details.append(f"error=`{machine.error}`")
+            lines.append(
+                f"- `{machine.name}` via `{machine.host or 'local'}`: {state}; "
+                + "; ".join(details)
+            )
+    else:
+        lines.append("- None observed.")
+
+    lines.extend(
+        [
+            "",
+            "## No-Touch Lanes",
+        ]
+    )
     if report.no_touch_lanes:
         for lane in report.no_touch_lanes:
-            lines.append(f"- `{lane.lane}` ({lane.source}): {lane.reason} -> `{lane.reference}`")
+            lines.append(
+                f"- [{lane.machine}] `{lane.lane}` ({lane.source}): {lane.reason} -> `{lane.reference}`"
+            )
     else:
         lines.append("- None detected.")
 
@@ -622,10 +931,16 @@ def to_json(report: OrchestratorMap) -> str:
 
 
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Generate a read-only Nuzantara agent orchestration map.")
-    parser.add_argument("--repo-root", type=Path, default=Path.cwd(), help="Repository root to inspect.")
+    parser = argparse.ArgumentParser(
+        description="Generate a read-only Nuzantara agent orchestration map."
+    )
+    parser.add_argument(
+        "--repo-root", type=Path, default=Path.cwd(), help="Repository root to inspect."
+    )
     parser.add_argument("--format", choices=("json", "markdown"), default="markdown")
-    parser.add_argument("--output", type=Path, help="Optional output file. Stdout is used when omitted.")
+    parser.add_argument(
+        "--output", type=Path, help="Optional output file. Stdout is used when omitted."
+    )
     parser.add_argument(
         "--scan-root",
         action="append",
@@ -634,17 +949,35 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     )
     parser.add_argument("--finding-limit", type=int, default=200)
     parser.add_argument("--per-area-limit", type=int, default=30)
+    parser.add_argument(
+        "--remote",
+        action="append",
+        dest="remote_specs",
+        help="Remote target as name=host:/abs/repo/path, host:/abs/repo/path, or default key m5/air.",
+    )
+    parser.add_argument(
+        "--include-m5", action="store_true", help="Shortcut for --remote m5."
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     scan_roots = args.scan_roots or list(DEFAULT_SCAN_ROOTS)
+    remote_specs = list(args.remote_specs or [])
+    if args.include_m5:
+        remote_specs.append("m5")
+    try:
+        remote_targets = [parse_remote_target(spec) for spec in remote_specs]
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
     report = collect_live_map(
         args.repo_root,
         scan_roots=scan_roots,
         finding_limit=args.finding_limit,
         per_area_limit=args.per_area_limit,
+        remote_targets=remote_targets,
     )
     rendered = to_json(report) if args.format == "json" else render_markdown(report)
     if args.output:

--- a/scripts/tests/test_orchestrator_live_map.py
+++ b/scripts/tests/test_orchestrator_live_map.py
@@ -1,4 +1,5 @@
 """Tests for scripts/ops/orchestrator_live_map.py."""
+
 from __future__ import annotations
 
 import importlib.util
@@ -11,7 +12,9 @@ SCRIPT_PATH = Path(__file__).resolve().parents[1] / "ops" / "orchestrator_live_m
 
 
 def _load_module():
-    spec = importlib.util.spec_from_file_location("orchestrator_live_map_under_test", SCRIPT_PATH)
+    spec = importlib.util.spec_from_file_location(
+        "orchestrator_live_map_under_test", SCRIPT_PATH
+    )
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
@@ -42,6 +45,30 @@ detached
     assert worktrees[1].task_id == "live-map"
     assert worktrees[2].detached is True
     assert worktrees[2].lane == "wr2"
+
+
+def test_parse_remote_target_supports_default_and_explicit() -> None:
+    default = olm.parse_remote_target("m5")
+    assert default.name == "m5"
+    assert default.host == "m5"
+    assert default.repo_root == "/Users/balizero/Desktop/nuzantara"
+
+    explicit = olm.parse_remote_target(
+        "staging=mini:/Users/nuzantara/Desktop/nuzantara"
+    )
+    assert explicit.name == "staging"
+    assert explicit.host == "mini"
+    assert explicit.repo_root == "/Users/nuzantara/Desktop/nuzantara"
+
+
+def test_parse_worktree_porcelain_tags_machine() -> None:
+    text = """worktree /repo/.worktrees/backend-rag-wire-orphan-routers
+HEAD abc
+branch refs/heads/agent/air-m5/backend-rag/wire-orphan-routers
+"""
+    worktrees = olm.parse_worktree_porcelain(text, machine="m5")
+    assert worktrees[0].machine == "m5"
+    assert worktrees[0].lane == "backend-rag"
 
 
 def test_parse_pr_json_infers_lanes() -> None:
@@ -82,11 +109,16 @@ def test_parse_pr_json_infers_lanes() -> None:
     ]
     prs = olm.parse_pr_json(json.dumps(payload))
     assert [pr.lane for pr in prs] == ["backend-router", "wr2", "mouth"]
+    assert [pr.machine for pr in prs] == ["m5", "pro", None]
 
 
 def test_derive_no_touch_lanes_uses_prs_worktrees_and_processes() -> None:
     worktrees = [
-        olm.WorktreeInfo(path="/repo/.worktrees/doc-intake-dossier", branch="agent/pro/research/doc-intake-dossier", lane="doc-intake"),
+        olm.WorktreeInfo(
+            path="/repo/.worktrees/doc-intake-dossier",
+            branch="agent/pro/research/doc-intake-dossier",
+            lane="doc-intake",
+        ),
     ]
     prs = [
         olm.PullRequestInfo(
@@ -103,8 +135,16 @@ def test_derive_no_touch_lanes_uses_prs_worktrees_and_processes() -> None:
         )
     ]
     processes = [
-        olm.ProcessSignal(pid=100, category="flowkit", command="/Users/nuzantara/flowkit/venv/bin/python"),
-        olm.ProcessSignal(pid=101, category="flowkit", command="/Users/nuzantara/flowkit/venv/bin/python -m agent.main"),
+        olm.ProcessSignal(
+            pid=100,
+            category="flowkit",
+            command="/Users/nuzantara/flowkit/venv/bin/python",
+        ),
+        olm.ProcessSignal(
+            pid=101,
+            category="flowkit",
+            command="/Users/nuzantara/flowkit/venv/bin/python -m agent.main",
+        ),
     ]
     lanes = olm.derive_no_touch_lanes(worktrees, prs, processes)
     lane_names = {lane.lane for lane in lanes}
@@ -142,9 +182,37 @@ def test_flowkit_no_touch_blocks_wr3_candidates() -> None:
             evidence="placeholder",
         ),
     ]
-    no_touch = [olm.NoTouchLane(lane="flowkit", reason="running", source="process", reference="flowkit")]
+    no_touch = [
+        olm.NoTouchLane(
+            lane="flowkit", reason="running", source="process", reference="flowkit"
+        )
+    ]
     candidates = olm.derive_candidate_workstreams(findings, no_touch)
     assert [candidate.area for candidate in candidates] == ["admin-dashboard"]
+
+
+def test_remote_no_touch_blocks_local_candidate() -> None:
+    findings = [
+        olm.ComponentFinding(
+            component_id="backend-rag",
+            area="backend-rag",
+            path="apps/backend-rag/backend/services/naga.py",
+            line=1,
+            marker="placeholder_text",
+            severity="medium",
+            evidence="placeholder",
+        )
+    ]
+    no_touch = [
+        olm.NoTouchLane(
+            lane="backend-rag",
+            reason="active remote worktree exists",
+            source="worktree",
+            reference="agent/air-m5/backend-rag/wire-orphan-routers",
+            machine="m5",
+        )
+    ]
+    assert olm.derive_candidate_workstreams(findings, no_touch) == []
 
 
 def test_scan_incomplete_markers_and_candidates_skip_no_touch(tmp_path: Path) -> None:
@@ -160,9 +228,15 @@ def test_scan_incomplete_markers_and_candidates_skip_no_touch(tmp_path: Path) ->
     )
     (mouth / "settings.tsx").write_text("export const value = 'placeholder result';\n")
 
-    findings = olm.scan_incomplete_markers(repo, ["apps/backend-rag/backend", "apps/mouth"], limit=20)
+    findings = olm.scan_incomplete_markers(
+        repo, ["apps/backend-rag/backend", "apps/mouth"], limit=20
+    )
     assert {finding.area for finding in findings} == {"backend-router", "mouth"}
-    no_touch = [olm.NoTouchLane(lane="backend-rag", reason="active PR", source="test", reference="pr")]
+    no_touch = [
+        olm.NoTouchLane(
+            lane="backend-rag", reason="active PR", source="test", reference="pr"
+        )
+    ]
     candidates = olm.derive_candidate_workstreams(findings, no_touch)
     assert [candidate.area for candidate in candidates] == ["mouth"]
     assert candidates[0].task_id == "audit-mouth-incomplete"
@@ -173,8 +247,26 @@ def test_render_markdown_includes_no_touch_and_candidates() -> None:
         generated_at="2026-06-04T16:00:00Z",
         repo_root="/repo",
         current_branch="agent/nuzantara/ops/live-map",
+        machines=[
+            olm.MachineStatus(
+                name="m5",
+                host="m5",
+                repo_root="/Users/balizero/Desktop/nuzantara",
+                reachable=True,
+                current_branch="HEAD",
+                head="40b28a2",
+                origin_main="36fb513",
+                identity="balizero@Air-M5",
+            )
+        ],
         no_touch_lanes=[
-            olm.NoTouchLane(lane="wr2", reason="active git worktree exists", source="worktree", reference="agent/wr2")
+            olm.NoTouchLane(
+                lane="wr2",
+                reason="active git worktree exists",
+                source="worktree",
+                reference="agent/wr2",
+                machine="m5",
+            )
         ],
         candidate_workstreams=[
             olm.CandidateWorkstream(
@@ -189,6 +281,9 @@ def test_render_markdown_includes_no_touch_and_candidates() -> None:
         ],
     )
     rendered = olm.render_markdown(report)
+    assert "## Machines" in rendered
+    assert "`m5` via `m5`" in rendered
     assert "## No-Touch Lanes" in rendered
+    assert "[m5]" in rendered
     assert "`wr2`" in rendered
     assert "`audit-mouth-incomplete`" in rendered


### PR DESCRIPTION
## Summary
- add read-only remote machine targets to the orchestrator live map
- tag worktrees/processes/no-touch lanes by source machine
- make M5/Air-M5 lanes block local candidate generation to avoid agent overlap

## Verification
- PYTHONPATH=. pytest scripts/tests/test_orchestrator_live_map.py -q
- ruff check scripts/ops/orchestrator_live_map.py scripts/tests/test_orchestrator_live_map.py
- ruff format --check scripts/ops/orchestrator_live_map.py scripts/tests/test_orchestrator_live_map.py
- python scripts/ops/orchestrator_live_map.py --include-m5 --format markdown --finding-limit 20 --per-area-limit 10
- python scripts/docs_sync.py --check