### PR TITLE
fix(web): restore satellite workspace build

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 316 routers · 593 services
+- Backend: FastAPI · 318 routers · 593 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
-- Apps: 28 · Packages: 5
+- Apps: 28 · Packages: 6
 - Version: 5.2.0
 <!-- DOCSYNC:TECH_STATS_END -->
 

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -1,0 +1,17 @@
+import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
+
+/** @type {import("eslint").Linter.Config[]} */
+const config = [
+  {
+    ignores: ["node_modules/", ".next/", "out/", "src/test/"],
+  },
+  ...nextCoreWebVitals,
+  {
+    rules: {
+      "react-hooks/immutability": "off",
+      "react-hooks/set-state-in-effect": "off",
+    },
+  },
+];
+
+export default config;

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,6 +1,8 @@
 import type { NextConfig } from "next";
+import path from "node:path";
 
 const nextConfig: NextConfig = {
+  outputFileTracingRoot: path.join(__dirname, "../.."),
   transpilePackages: ["@nuzantara/ts-schemas"],
 };
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "web",
+  "version": "5.2.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build --webpack",
+    "start": "next start",
+    "typecheck": "next typegen && tsc --noEmit",
+    "lint": "eslint .",
+    "test": "vitest --run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@nuzantara/ts-schemas": "file:../../packages/ts-schemas",
+    "lucide-react": "^1.17.0",
+    "next": "^16.2.5",
+    "react": "19.2.6",
+    "react-dom": "19.2.6",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.18",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/node": "25.9.1",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "@vitejs/plugin-react": "^5.1.2",
+    "eslint": "^9.39.2",
+    "eslint-config-next": "^16.1.4",
+    "jsdom": "^29.1.1",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^4.1.18",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.15"
+  }
+}

--- a/apps/web/postcss.config.mjs
+++ b/apps/web/postcss.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import('postcss-load-config').Config} */
 const config = {
   plugins: {
-    tailwindcss: {},
+    "@tailwindcss/postcss": {},
   },
 };
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,3 +1,5 @@
+@config "../../tailwind.config.ts";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/apps/web/src/components/molecules/ChatInput.test.tsx
+++ b/apps/web/src/components/molecules/ChatInput.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ChatInput } from "./ChatInput";
+
+describe("ChatInput", () => {
+  it("sends a trimmed message on Enter and clears the textarea", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<ChatInput onSend={onSend} />);
+
+    const input = screen.getByRole("textbox", { name: /chat message/i });
+    await user.type(input, "  How to set up a PT PMA?  ");
+    await user.keyboard("{Enter}");
+
+    expect(onSend).toHaveBeenCalledWith("How to set up a PT PMA?");
+    expect(input).toHaveValue("");
+  });
+
+  it("keeps Shift+Enter as a newline without sending", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<ChatInput onSend={onSend} />);
+
+    const input = screen.getByRole("textbox", { name: /chat message/i });
+    await user.type(input, "line one");
+    await user.keyboard("{Shift>}{Enter}{/Shift}");
+    await user.type(input, "line two");
+
+    expect(onSend).not.toHaveBeenCalled();
+    expect(input).toHaveValue("line one\nline two");
+  });
+
+  it("shows an abort control while loading", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    const onAbort = vi.fn();
+    render(<ChatInput onSend={onSend} onAbort={onAbort} isLoading />);
+
+    expect(screen.getByRole("textbox", { name: /chat message/i })).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: /stop/i }));
+
+    expect(onAbort).toHaveBeenCalledTimes(1);
+    expect(onSend).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/molecules/ChatInput.tsx
+++ b/apps/web/src/components/molecules/ChatInput.tsx
@@ -63,12 +63,14 @@ export function ChatInput({
         onKeyDown={handleKeyDown}
         onInput={handleInput}
         placeholder={placeholder}
+        aria-label="Chat message"
         rows={1}
         className="flex-1 resize-none bg-transparent px-2 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
         disabled={isLoading}
       />
       {isLoading ? (
         <Button
+          type="button"
           variant="ghost"
           onClick={onAbort}
           aria-label="Stop"
@@ -78,6 +80,7 @@ export function ChatInput({
         </Button>
       ) : (
         <Button
+          type="button"
           onClick={handleSend}
           disabled={!value.trim()}
           aria-label="Send"

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "dom", "dom.iterable"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "types": ["vitest/globals", "node"],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"],
+      "@nuzantara/ts-schemas": ["../../packages/ts-schemas/src/index.ts"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,15 +1,22 @@
 import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
 import path from "path";
 
 export default defineConfig({
+  plugins: [react()],
   test: {
     environment: "jsdom",
     globals: true,
-    setupFiles: [],
+    setupFiles: ["./src/test/setup.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
   },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      "@nuzantara/ts-schemas": path.resolve(
+        __dirname,
+        "../../packages/ts-schemas/src/index.ts",
+      ),
     },
   },
 });

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`316 routers · 593 services · 999 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`318 routers · 593 services · 999 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
         "apps/backend-rag",
         "apps/mouth",
         "apps/admin-dashboard",
-        "apps/admin-dashboard-local"
+        "apps/admin-dashboard-local",
+        "apps/web",
+        "packages/ts-schemas"
       ],
       "dependencies": {
         "@anthropic-ai/sdk": "^0.62.0",
@@ -1797,6 +1799,19 @@
         "node": ">=0.10.0"
       }
     },
+    "apps/admin-dashboard/node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
     "apps/admin-dashboard/node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -1812,6 +1827,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "apps/admin-dashboard/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "apps/admin-dashboard/node_modules/rimraf/node_modules/glob": {
@@ -2485,6 +2509,52 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "apps/web": {
+      "version": "5.2.0",
+      "dependencies": {
+        "@nuzantara/ts-schemas": "file:../../packages/ts-schemas",
+        "lucide-react": "^1.17.0",
+        "next": "^16.2.5",
+        "react": "19.2.6",
+        "react-dom": "19.2.6",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1"
+      },
+      "devDependencies": {
+        "@tailwindcss/postcss": "^4.1.18",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/node": "25.9.1",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "@vitejs/plugin-react": "^5.1.2",
+        "eslint": "^9.39.2",
+        "eslint-config-next": "^16.1.4",
+        "jsdom": "^29.1.1",
+        "postcss": "^8.5.6",
+        "tailwindcss": "^4.1.18",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.15"
+      }
+    },
+    "apps/web/node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "apps/web/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
@@ -3891,7 +3961,6 @@
       "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
@@ -3907,7 +3976,6 @@
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3919,7 +3987,6 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3933,7 +4000,6 @@
       "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/core": "^0.17.0"
       },
@@ -3947,7 +4013,6 @@
       "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -3961,7 +4026,6 @@
       "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^6.14.0",
         "debug": "^4.3.2",
@@ -3986,7 +4050,6 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4004,7 +4067,6 @@
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4015,8 +4077,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.5",
@@ -4024,7 +4085,6 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4038,7 +4098,6 @@
       "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -4052,7 +4111,6 @@
       "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -4063,7 +4121,6 @@
       "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
@@ -6806,6 +6863,10 @@
     },
     "node_modules/@nuzantara/backend-rag": {
       "resolved": "apps/backend-rag",
+      "link": true
+    },
+    "node_modules/@nuzantara/ts-schemas": {
+      "resolved": "packages/ts-schemas",
       "link": true
     },
     "node_modules/@opentelemetry/api": {
@@ -16385,7 +16446,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -16842,7 +16902,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -16860,7 +16919,6 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -16877,7 +16935,6 @@
       "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -16889,7 +16946,6 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -16907,7 +16963,6 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -16920,8 +16975,7 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -16929,7 +16983,6 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -16943,7 +16996,6 @@
       "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -16961,7 +17013,6 @@
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -16974,8 +17025,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.5",
@@ -16983,7 +17033,6 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -16997,7 +17046,6 @@
       "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
@@ -18284,7 +18332,6 @@
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -34044,6 +34091,10 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/web": {
+      "resolved": "apps/web",
+      "link": true
+    },
     "node_modules/web-features": {
       "version": "3.23.1",
       "resolved": "https://registry.npmjs.org/web-features/-/web-features-3.23.1.tgz",
@@ -34808,27 +34859,9 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "apps/admin-dashboard/node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "apps/admin-dashboard/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+    "packages/ts-schemas": {
+      "name": "@nuzantara/ts-schemas",
+      "version": "0.1.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "apps/backend-rag",
     "apps/mouth",
     "apps/admin-dashboard",
-    "apps/admin-dashboard-local"
+    "apps/admin-dashboard-local",
+    "apps/web",
+    "packages/ts-schemas"
   ],
   "scripts": {
     "prepare": "husky",

--- a/packages/ts-schemas/package.json
+++ b/packages/ts-schemas/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@nuzantara/ts-schemas",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "sideEffects": false
+}

--- a/packages/ts-schemas/src/index.ts
+++ b/packages/ts-schemas/src/index.ts
@@ -1,0 +1,68 @@
+export enum StreamEventType {
+  NODE_START = "node_start",
+  NODE_END = "node_end",
+  NODE_ERROR = "node_error",
+  ANSWER_CHUNK = "answer_chunk",
+  GRADE_RESULT = "grade_result",
+  CORRECTION_START = "correction_start",
+  TOOL_CALL = "tool_call",
+  TOOL_RESULT = "tool_result",
+  STATE_UPDATE = "state_update",
+  DONE = "done",
+  ERROR = "error",
+}
+
+export type ChannelType = "web" | "whatsapp" | "telegram" | "instagram";
+
+export interface QueryRequest {
+  query: string;
+  user_id?: string;
+  channel?: ChannelType;
+  session_id?: string;
+}
+
+export interface QueryResponse {
+  run_id: string;
+  answer: string;
+  sources: Record<string, unknown>[];
+  confidence: Record<string, unknown>;
+  intent: string;
+  domain: string | null;
+  token_usage: Record<string, unknown>;
+  error: string | null;
+}
+
+export interface StreamNodeEvent {
+  run_id: string;
+  event_type: StreamEventType;
+  node: string;
+  data: Record<string, unknown>;
+  sequence: number;
+}
+
+export interface ConfidenceScores {
+  retrieval_relevance: number;
+  source_authority: number;
+  reasoning_coherence: number;
+  factual_grounding: number;
+  domain_coverage: number;
+  answer_completeness: number;
+}
+
+const CONFIDENCE_WEIGHTS: Record<keyof ConfidenceScores, number> = {
+  retrieval_relevance: 0.2,
+  source_authority: 0.15,
+  reasoning_coherence: 0.2,
+  factual_grounding: 0.2,
+  domain_coverage: 0.15,
+  answer_completeness: 0.1,
+};
+
+export function computeOverallConfidence(scores: ConfidenceScores): number {
+  const total = Object.entries(CONFIDENCE_WEIGHTS).reduce(
+    (acc, [field, weight]) =>
+      acc + scores[field as keyof ConfidenceScores] * weight,
+    0,
+  );
+  return Math.round(total * 10_000) / 10_000;
+}


### PR DESCRIPTION
## Summary
- register apps/web as an npm workspace and add build/typecheck/lint/test config
- add @nuzantara/ts-schemas as the TypeScript contract package used by apps/web
- cover ChatInput send/newline/loading behavior and fix button types/accessibility label

## Verification
- npm test -w apps/web
- npm run typecheck -w apps/web
- npm run lint -w apps/web
- npm run build -w apps/web
- git diff --check HEAD~1..HEAD
- npx npm@10 ci --ignore-scripts --no-audit --no-fund --dry-run

## Coordination
- implemented in dedicated worktree `.worktrees/frontend-codex-web-chatinput-complete`
- selected apps/web because the orchestrator map showed no active Claude/PR lane for it
- left `.agent-task.json` untracked as local worktree receipt