### PR TITLE
feat(wr2): topic_type_log — persist + enforce anti-sameness (autopsy P-4)

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/206_wr2_topic_type_log.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/206_wr2_topic_type_log.sql
@@ -1,0 +1,37 @@
+-- 206_wr2_topic_type_log.sql
+-- WR2 anti-sameness (constitution Art 10.6): persist one row per rendered
+-- carousel so the draft generator can enforce "same-domain carousels must
+-- differ in register AND image-mode" instead of treating it as aspirational.
+--
+-- Written at the `rendered` transition (the real terminal status in Pipeline B;
+-- there is NO software publish-to-IG event -- Damar publishes manually from the
+-- Canva design). published_at/deleted_at are nullable and added now (zero cost)
+-- so a future "count only published / prune rejected" semantic switch needs no
+-- new migration.
+-- === FORWARD ===
+CREATE TABLE IF NOT EXISTS topic_type_log (
+    id              BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    draft_id        UUID NOT NULL,
+    domain          TEXT NOT NULL,         -- visa|tax|property|regulatory|health|brand|unknown
+    register        TEXT,                  -- the 7-tone register
+    dominant_mode   TEXT,                  -- one of the 9 image-style modes (or 'mixed'/'unknown')
+    layout_family   TEXT,                  -- derived from archetype/slides (nullable)
+    archetype       TEXT,                  -- nullable (from slides_json if present)
+    topic           TEXT,                  -- denormalized for human inspection
+    rendered_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    published_at    TIMESTAMPTZ,           -- NULL until a real publish signal exists (panel B)
+    deleted_at      TIMESTAMPTZ            -- soft-delete to prune Damar-rejected rows (panel B)
+);
+
+-- idempotency: one row per draft (re-render must not duplicate)
+CREATE UNIQUE INDEX IF NOT EXISTS ux_topic_type_log_draft_id ON topic_type_log (draft_id);
+
+-- the hot query: last-N by domain, newest first
+CREATE INDEX IF NOT EXISTS ix_topic_type_log_domain_time ON topic_type_log (domain, rendered_at DESC);
+
+COMMENT ON TABLE topic_type_log IS 'WR2 anti-sameness ledger (constitution Art 10.6). One row per carousel at status=rendered: domain + dominant register + dominant image-mode + layout_family. Consumed by wr2_draft_generator.fetch_recent_same_domain to steer/reject monotonous same-domain carousels. Best-effort write -- never gates the render path.';
+
+-- === ROLLBACK ===
+DROP INDEX IF EXISTS ix_topic_type_log_domain_time;
+DROP INDEX IF EXISTS ux_topic_type_log_draft_id;
+DROP TABLE IF EXISTS topic_type_log;

--- a/apps/backend-rag/backend/db/migrations_v2/216_wr2_topic_type_log.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/216_wr2_topic_type_log.sql
@@ -1,4 +1,4 @@
--- 206_wr2_topic_type_log.sql
+-- 216_wr2_topic_type_log.sql
 -- WR2 anti-sameness (constitution Art 10.6): persist one row per rendered
 -- carousel so the draft generator can enforce "same-domain carousels must
 -- differ in register AND image-mode" instead of treating it as aspirational.

--- a/scripts/test_wr2_topic_type.py
+++ b/scripts/test_wr2_topic_type.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Tests for wr2_topic_type derivation helpers + the image_mode normalise survival.
+
+Run (from scripts/, with the backend venv active):
+    PYTHONPATH=<repo>/apps/backend-rag:<repo>/scripts \
+        python -m pytest test_wr2_topic_type.py -q
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# scripts/ on path so the sibling pure module imports regardless of cwd.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import wr2_topic_type as tt  # noqa: E402
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# derive_domain
+# ─────────────────────────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "topic,expected",
+    [
+        ("New KITAS rules for sham investors", "visa"),
+        ("E33G Golden Visa explained", "visa"),
+        ("Digital nomad visa Indonesia", "visa"),
+        ("Coretax and the new PPN rate", "tax"),
+        ("How PPh 21 withholding works", "tax"),
+        ("NPWP for foreign founders", "tax"),
+        ("Hak Pakai land rights for foreigners", "property"),
+        ("Nominee villa ownership risks", "property"),
+        ("Leasehold vs freehold in Bali", "property"),
+        ("Permenaker labor changes 2025", "regulatory"),
+        ("KBLI codes for a PT PMA", "regulatory"),
+        ("LKPM reporting obligations", "regulatory"),
+        ("BPJS Kesehatan for expats", "health"),  # must beat the regulatory bucket
+        ("Layanan kesehatan di Bali", "health"),
+        ("Bali Zero: our story so far", "brand"),
+    ],
+)
+def test_derive_domain_buckets(topic: str, expected: str) -> None:
+    assert tt.derive_domain(topic) == expected
+
+
+@pytest.mark.parametrize(
+    "topic",
+    ["Bali sunset photography", "A random unrelated headline", "", "   "],
+)
+def test_derive_domain_unknown(topic: str) -> None:
+    assert tt.derive_domain(topic) == "unknown"
+
+
+def test_derive_domain_none_and_nonstr() -> None:
+    assert tt.derive_domain(None) == "unknown"
+    assert tt.derive_domain(12345) == "unknown"  # type: ignore[arg-type]
+
+
+def test_derive_domain_case_insensitive() -> None:
+    assert tt.derive_domain("KITAS RULES") == "visa"
+    assert tt.derive_domain("kitas rules") == "visa"
+
+
+def test_derive_domain_regulatory_bpjs_specificity() -> None:
+    # bare "BPJS" with no "kesehatan" should NOT be claimed as health by accident,
+    # and the labor-specific token routes to regulatory.
+    assert tt.derive_domain("BPJS Ketenagakerjaan contributions") == "regulatory"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# derive_dominant_mode
+# ─────────────────────────────────────────────────────────────────────────
+def test_dominant_mode_simple_majority() -> None:
+    slides = {
+        "slides": [
+            {"image_mode": "desk-document"},
+            {"image_mode": "desk-document"},
+            {"image_mode": "event-photo"},
+        ]
+    }
+    assert tt.derive_dominant_mode(slides) == "desk-document"
+
+
+def test_dominant_mode_case_normalised() -> None:
+    slides = {"slides": [{"image_mode": "Desk-Document"}, {"image_mode": "desk-document"}]}
+    assert tt.derive_dominant_mode(slides) == "desk-document"
+
+
+def test_dominant_mode_tie_is_unknown() -> None:
+    slides = {"slides": [{"image_mode": "a"}, {"image_mode": "b"}]}
+    assert tt.derive_dominant_mode(slides) == "unknown"
+
+
+def test_dominant_mode_empty_is_unknown() -> None:
+    assert tt.derive_dominant_mode({"slides": []}) == "unknown"
+    assert tt.derive_dominant_mode({}) == "unknown"
+    assert tt.derive_dominant_mode(None) == "unknown"
+
+
+def test_dominant_mode_no_mode_field_is_unknown() -> None:
+    slides = {"slides": [{"headline": "x"}, {"headline": "y"}]}
+    assert tt.derive_dominant_mode(slides) == "unknown"
+
+
+def test_dominant_mode_malformed_string_is_unknown() -> None:
+    assert tt.derive_dominant_mode("{not valid json") == "unknown"
+    assert tt.derive_dominant_mode("[1,2,3") == "unknown"
+
+
+def test_dominant_mode_accepts_json_string() -> None:
+    raw = json.dumps({"slides": [{"image_mode": "cultural-photo"}, {"image_mode": "cultural-photo"}]})
+    assert tt.derive_dominant_mode(raw) == "cultural-photo"
+
+
+def test_dominant_mode_accepts_bare_list() -> None:
+    slides = [{"image_mode": "calendar-photo"}, {"image_mode": "calendar-photo"}]
+    assert tt.derive_dominant_mode(slides) == "calendar-photo"
+
+
+def test_dominant_mode_alt_field_name() -> None:
+    slides = {"slides": [{"image_style_mode": "data-visualization"}, {"image_style_mode": "data-visualization"}]}
+    assert tt.derive_dominant_mode(slides) == "data-visualization"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# distinct_mode_count
+# ─────────────────────────────────────────────────────────────────────────
+def test_distinct_mode_count() -> None:
+    slides = {
+        "slides": [
+            {"image_mode": "desk-document"},
+            {"image_mode": "event-photo"},
+            {"image_mode": "desk-document"},
+            {"image_mode": "cultural-photo"},
+        ]
+    }
+    assert tt.distinct_mode_count(slides) == 3
+
+
+def test_distinct_mode_count_malformed() -> None:
+    assert tt.distinct_mode_count("garbage") == 0
+    assert tt.distinct_mode_count({"slides": []}) == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# derive_layout_family / extract_archetype
+# ─────────────────────────────────────────────────────────────────────────
+def test_layout_family_from_per_slide() -> None:
+    slides = {
+        "slides": [
+            {"layout_family": "Grid"},
+            {"layout_family": "grid"},
+            {"layout_family": "stack"},
+        ]
+    }
+    assert tt.derive_layout_family(slides) == "grid"
+
+
+def test_layout_family_falls_back_to_archetype() -> None:
+    slides = {"archetype": "Timeline", "slides": [{"headline": "x"}]}
+    assert tt.derive_layout_family(slides) == "timeline"
+
+
+def test_layout_family_none_when_absent() -> None:
+    assert tt.derive_layout_family({"slides": [{"headline": "x"}]}) is None
+    assert tt.derive_layout_family("garbage") is None
+
+
+def test_extract_archetype() -> None:
+    assert tt.extract_archetype({"archetype": "Manifesto"}) == "manifesto"
+    assert tt.extract_archetype({"slides": []}) is None
+    assert tt.extract_archetype("garbage") is None
+    assert tt.extract_archetype(None) is None
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Collision logic (the anti-sameness rule: differ in EITHER register OR mode)
+# ─────────────────────────────────────────────────────────────────────────
+def test_collision_matches_both_is_collision() -> None:
+    assert tt.is_same_combo("analitico", "desk-document", "analitico", "desk-document") is True
+
+
+def test_collision_differs_in_mode_is_ok() -> None:
+    assert tt.is_same_combo("analitico", "desk-document", "analitico", "event-photo") is False
+
+
+def test_collision_differs_in_register_is_ok() -> None:
+    assert tt.is_same_combo("analitico", "desk-document", "tecnico", "desk-document") is False
+
+
+def test_collision_unknown_mode_falls_back_to_register_only() -> None:
+    # mode unknown on one side -> register-only comparison -> same register collides
+    assert tt.is_same_combo("analitico", "unknown", "analitico", "desk-document") is True
+    assert tt.is_same_combo("analitico", "unknown", "tecnico", "desk-document") is False
+
+
+def test_collision_unknown_mode_both_sides() -> None:
+    assert tt.is_same_combo("analitico", "unknown", "analitico", "unknown") is True
+
+
+def test_collision_register_none_never_collides() -> None:
+    assert tt.is_same_combo(None, "desk-document", "analitico", "desk-document") is False
+    assert tt.is_same_combo("analitico", "desk-document", None, "desk-document") is False
+
+
+def test_collides_with_recent_empty_history_is_ok() -> None:
+    assert tt.collides_with_recent("analitico", "desk-document", []) is False
+
+
+def test_collides_with_recent_hit_on_second() -> None:
+    recent = [
+        {"register": "tecnico", "dominant_mode": "event-photo"},
+        {"register": "analitico", "dominant_mode": "desk-document"},
+    ]
+    assert tt.collides_with_recent("analitico", "desk-document", recent) is True
+
+
+def test_collides_with_recent_no_hit() -> None:
+    recent = [
+        {"register": "tecnico", "dominant_mode": "event-photo"},
+        {"register": "poetico", "dominant_mode": "cultural-photo"},
+    ]
+    assert tt.collides_with_recent("analitico", "desk-document", recent) is False
+
+
+def test_collides_with_recent_differs_in_mode_only_is_ok() -> None:
+    # same register as a recent row, but different mode -> allowed (differ-in-either)
+    recent = [{"register": "analitico", "dominant_mode": "event-photo"}]
+    assert tt.collides_with_recent("analitico", "desk-document", recent) is False
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# image_mode survives _normalise_slides (panel-critical, §3.0)
+# ─────────────────────────────────────────────────────────────────────────
+def _make_parsed(extra_first: dict) -> dict:
+    first = {
+        "slide_number": 1,
+        "is_cover": True,
+        "is_hero_image": True,
+        "headline": "H",
+        "body": "B",
+        "image_prompt": "P",
+    }
+    first.update(extra_first)
+    rest = [
+        {
+            "slide_number": n,
+            "is_hero_image": False,
+            "headline": f"h{n}",
+            "body": "b",
+            "image_prompt": "p",
+        }
+        for n in range(2, 12)
+    ]
+    return {"register": "analitico", "slides": [first] + rest}
+
+
+def test_normalise_image_mode_survives_lowercased() -> None:
+    import wr2_draft_generator as g
+
+    register, slides = g._normalise_slides(_make_parsed({"image_mode": "Desk-Document"}))
+    assert register == "analitico"
+    assert slides[0]["image_mode"] == "desk-document"
+
+
+def test_normalise_image_mode_absent_is_none() -> None:
+    import wr2_draft_generator as g
+
+    _register, slides = g._normalise_slides(_make_parsed({}))
+    # absent on slide 1
+    assert slides[0]["image_mode"] is None
+    # present (as a key) on every slide
+    assert all("image_mode" in s for s in slides)
+
+
+def test_normalise_image_mode_blank_is_none() -> None:
+    import wr2_draft_generator as g
+
+    _register, slides = g._normalise_slides(_make_parsed({"image_mode": "   "}))
+    assert slides[0]["image_mode"] is None
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/scripts/wr2_canva_desktop_apply.py
+++ b/scripts/wr2_canva_desktop_apply.py
@@ -197,6 +197,10 @@ async def _persist_result(
     design_id: str,
     edit_url: str,
     view_url: str | None,
+    *,
+    topic: str | None = None,
+    slides_json: object | None = None,
+    register: str | None = None,
 ) -> None:
     await conn.execute(
         """
@@ -213,6 +217,65 @@ async def _persist_result(
         design_id,
         edit_url,
         view_url,
+    )
+    # P-4 (constitution Art 10.6): write one anti-sameness ledger row per
+    # rendered carousel. Best-effort + savepoint-isolated so a logging failure
+    # can NEVER abort the status='rendered' update above. Covers BOTH call paths
+    # (headless + desktop) because both go through _persist_result.
+    try:
+        async with conn.transaction():  # savepoint — isolates the insert
+            await _log_topic_type(
+                conn, draft_id, topic, slides_json, register
+            )
+    except Exception as exc:  # noqa: BLE001 — observability, never fail the render
+        logger.warning("topic_type_log write failed for %s: %s", draft_id, exc)
+
+
+async def _log_topic_type(
+    conn: asyncpg.Connection,
+    draft_id: UUID,
+    topic: str | None,
+    slides_json: object | None,
+    register: str | None,
+) -> None:
+    """Derive (domain, dominant_mode, layout_family, archetype) and INSERT one
+    row into topic_type_log, idempotent on draft_id.
+
+    If topic/slides_json/register were not threaded in by the caller, fall back
+    to a single SELECT on war_room_drafts (best-effort logging tolerates the
+    extra query). Pure-derivation lives in wr2_topic_type.
+    """
+    import wr2_topic_type as tt  # local import: keep module import side-effect-free
+
+    if topic is None or slides_json is None or register is None:
+        rec = await conn.fetchrow(
+            "SELECT topic, register, slides_json FROM war_room_drafts WHERE id = $1",
+            draft_id,
+        )
+        if rec is not None:
+            topic = topic if topic is not None else rec["topic"]
+            register = register if register is not None else rec["register"]
+            slides_json = slides_json if slides_json is not None else rec["slides_json"]
+
+    domain = tt.derive_domain(topic)
+    dominant_mode = tt.derive_dominant_mode(slides_json)
+    layout_family = tt.derive_layout_family(slides_json)
+    archetype = tt.extract_archetype(slides_json)
+
+    await conn.execute(
+        """
+        INSERT INTO topic_type_log
+            (draft_id, domain, register, dominant_mode, layout_family, archetype, topic)
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
+        ON CONFLICT (draft_id) DO NOTHING
+        """,
+        draft_id,
+        domain,
+        register,
+        dominant_mode,
+        layout_family,
+        archetype,
+        topic,
     )
 
 
@@ -437,7 +500,10 @@ async def _apply_one(conn: asyncpg.Connection, row: asyncpg.Record) -> bool:
             )
             return False
         design_id, edit_url, view_url = result
-        await _persist_result(conn, draft_id, design_id, edit_url, view_url)
+        await _persist_result(
+            conn, draft_id, design_id, edit_url, view_url,
+            topic=topic, slides_json=slides_json, register=tone,
+        )
         _send_telegram(
             "WR2 Canva carousel ready (headless)\n"
             f"Topic: {topic[:100]}\n"
@@ -564,7 +630,10 @@ async def _apply_one(conn: asyncpg.Connection, row: asyncpg.Record) -> bool:
         return False
 
     design_id, edit_url, view_url = result
-    await _persist_result(conn, draft_id, design_id, edit_url, view_url)
+    await _persist_result(
+        conn, draft_id, design_id, edit_url, view_url,
+        topic=topic, slides_json=slides_json, register=tone,
+    )
     duration = time.time() - started_at
     logger.info(
         "Draft %s rendered — design=%s edit=%s duration=%.0fs",

--- a/scripts/wr2_draft_generator.py
+++ b/scripts/wr2_draft_generator.py
@@ -32,9 +32,13 @@ from typing import Any
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "apps" / "backend-rag"))
+# scripts/ on path so the pure topic-type helpers (sibling module) import
+# regardless of cwd (launchd runs with an arbitrary working directory).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import asyncpg  # noqa: E402
 
+import wr2_topic_type as tt  # noqa: E402  (pure, side-effect-free)
 from backend.llm.claude_oauth_client import (  # noqa: E402
     ClaudeOAuthError,
     ClaudeOAuthNotAvailable,
@@ -169,6 +173,22 @@ same-domain carousels looking identical):
 - "bleached-daylight": open, hopeful, resolution, "the way out"
 Non-hero slides do not need it.
 
+IMAGE MODE (per hero slide — the SCENE TYPE, drives anti-sameness):
+Each `is_hero_image: true` slide MUST include an `image_mode` field naming the
+KIND of scene. Pick the ONE mode that matches what the photo depicts, and VARY
+it across the slides (two same-domain carousels must not repeat the same dominant
+mode — the brand forbids monotony). Choose from EXACTLY these 9 modes:
+- "desk-document": papers, forms, a desk, a document close enough to read
+- "event-photo": a real moment/scene with people doing something
+- "architecture-or-texture": buildings, surfaces, materials, no people
+- "provocation-photo": a tense or confrontational image that unsettles
+- "human-silhouette": a person shown as shape/shadow, anonymous, no face
+- "object-comparison": two or more objects set against each other
+- "calendar-photo": dates, deadlines, time made visible
+- "data-visualization": a chart, graph, map, or numbers as the image
+- "cultural-photo": Indonesian/Balinese culture, ritual, place, daily life
+Use the slug verbatim (e.g. "desk-document"). Non-hero slides may omit it.
+
 HERO IMAGE SELECTION (MANDATORY):
 You MUST mark exactly 4 slides as `is_hero_image: true`:
 - Slide 1 (cover) — ALWAYS hero
@@ -241,7 +261,8 @@ Structure:
       "headline": "...",
       "subhead": "...",
       "body": "...",
-      "image_prompt": "editorial scene, 1-2 sentences"
+      "image_prompt": "editorial scene, 1-2 sentences",
+      "image_mode": "desk-document"
     },
     {
       "slide_number": 2,
@@ -259,7 +280,8 @@ Structure:
       "is_cover": false,
       "is_hero_image": true,
       "headline": "Where this leaves you",
-      "body": "One clear consequence, then one concrete next step. Reach Bali Zero when the deadline is yours, not theirs."
+      "body": "One clear consequence, then one concrete next step. Reach Bali Zero when the deadline is yours, not theirs.",
+      "image_mode": "human-silhouette"
     }
   ]
 }
@@ -268,6 +290,10 @@ REPEAT (MUST OBEY): every slide object MUST include the `is_hero_image` field
 (true or false). Slide 1 hero=true, slide 11 hero=true, plus exactly 2 more
 slides hero=true at narrative turning points = 4 hero slides total per
 carousel. The other 7 slides have is_hero_image=false. THIS IS NON-NEGOTIABLE.
+
+ALSO MANDATORY: every is_hero_image=true slide MUST carry an `image_mode` (one
+of the 9 slugs above), and the 4 hero slides should use at least 3 DISTINCT
+modes — do not paint all four with the same scene type.
 """
 
 
@@ -362,6 +388,7 @@ def _build_draft_prompt(
     source_url: str,
     enrichment: dict[str, Any] | None = None,
     live_reasons: list[str] | None = None,
+    avoid_steer: str = "",
 ) -> str:
     """Build the slide-composition prompt.
 
@@ -385,7 +412,7 @@ def _build_draft_prompt(
         # Legacy path: truncated summary. Always available as fallback.
         body = summary[:3500]
 
-    return f"""{SYSTEM_INSTRUCTIONS}
+    return f"""{SYSTEM_INSTRUCTIONS}{avoid_steer}
 
 ---
 
@@ -425,10 +452,12 @@ async def claude_compose_slides(
     source_url: str,
     enrichment: dict[str, Any] | None = None,
     live_reasons: list[str] | None = None,
+    avoid_steer: str = "",
 ) -> dict[str, Any]:
     prompt = _build_draft_prompt(
         topic, summary, source_url,
         enrichment=enrichment, live_reasons=live_reasons,
+        avoid_steer=avoid_steer,
     )
     logger.info("Calling Claude OAuth for slide composition (prompt %d chars)", len(prompt))
     t0 = time.perf_counter()
@@ -727,6 +756,11 @@ def _normalise_slides(parsed: dict[str, Any]) -> tuple[str, list[dict[str, Any]]
         # store whatever the model gave (or None) without hard-validating here.
         tonal = raw.get("tonal_palette")
         tonal = tonal.strip().lower() if isinstance(tonal, str) and tonal.strip() else None
+        # image_mode (2026-06-05, P-4): per-hero scene-mode (constitution Art 5.8,
+        # 9 modes) consumed by topic_type_log.derive_dominant_mode for the
+        # anti-sameness ledger. Whitelisted here like tonal_palette — without
+        # this line the field is stripped at persistence. Lowercased hint; no
+        # hard validation (unknown values just don't constrain downstream).
         slide = {
             "slide_number": i,
             "slide_type": raw.get("slide_type", "body"),
@@ -737,6 +771,7 @@ def _normalise_slides(parsed: dict[str, Any]) -> tuple[str, list[dict[str, Any]]
             "body": (raw.get("body") or "").strip()[:500],
             "image_prompt": (raw.get("image_prompt") or "").strip()[:600],
             "tonal_palette": tonal,
+            "image_mode": (raw.get("image_mode") or "").strip().lower() or None,
             "image_url": None,  # filled later for cover only
         }
         normalised.append(slide)
@@ -783,6 +818,56 @@ async def _fetch_briefed_drafts(conn: asyncpg.Connection, limit: int) -> list[as
          LIMIT $1
         """,
         limit,
+    )
+
+
+async def fetch_recent_same_domain(
+    conn: asyncpg.Connection, domain: str, limit: int = 2
+) -> list[dict[str, Any]]:
+    """Last-N rendered carousels in this domain, newest first (P-4, Art 10.6).
+
+    Returns a list of {"register", "dominant_mode"} dicts for the anti-sameness
+    steer/reject. Best-effort: any error (e.g. the topic_type_log table not yet
+    migrated on this DB) returns [] so generation is never blocked. The "unknown"
+    domain bucket is never queried (it must not cross-constrain unrelated topics).
+    """
+    if not domain or domain == tt.UNKNOWN:
+        return []
+    try:
+        rows = await conn.fetch(
+            """
+            SELECT register, dominant_mode
+              FROM topic_type_log
+             WHERE domain = $1
+               AND deleted_at IS NULL
+             ORDER BY rendered_at DESC
+             LIMIT $2
+            """,
+            domain,
+            limit,
+        )
+    except Exception as exc:  # noqa: BLE001 — table may not exist yet; never block
+        logger.warning("fetch_recent_same_domain(%s) failed: %s", domain, exc)
+        return []
+    return [{"register": r["register"], "dominant_mode": r["dominant_mode"]} for r in rows]
+
+
+def _build_avoid_steer(recent: list[dict[str, Any]]) -> str:
+    """Render the recent same-domain (register, mode) combos as a soft-steer
+    block to append to the generation prompt. Empty list -> empty string."""
+    if not recent:
+        return ""
+    combos = ", ".join(
+        f"(register={r.get('register') or '?'}, image-mode={r.get('dominant_mode') or '?'})"
+        for r in recent
+    )
+    return (
+        "\n\nANTI-SAMENESS (constitution Art 10.6 — MUST OBEY): the last "
+        "same-domain carousels we published used these (register, image-mode) "
+        f"combinations: {combos}. Your carousel MUST DIFFER in EITHER the "
+        "register OR the dominant image-mode from each of them — do not reuse "
+        "the same pairing. Prefer a fresh register and a different dominant "
+        "scene-mode so two same-domain carousels never look alike."
     )
 
 
@@ -851,27 +936,87 @@ async def _process_one(conn: asyncpg.Connection, row: asyncpg.Record) -> bool:
         bool(enrichment), brief.get("live_news_score"),
     )
 
-    try:
-        parsed = await claude_compose_slides(
-            topic=topic, summary=summary, source_url=source_url,
-            enrichment=enrichment, live_reasons=live_reasons,
-        )
-    except (ClaudeOAuthError, ClaudeOAuthNotAvailable) as e:
-        logger.error("Claude OAuth failed: %s", e)
-        await _mark_rejected(conn, draft_id, f"claude_failed: {e}")
-        _send_telegram(f"WR2 draft_generator Claude failed\ndraft {draft_id}\n{str(e)[:200]}")
-        return False
-    except (json.JSONDecodeError, ValueError) as e:
-        logger.error("Claude output parse failed: %s", e)
-        await _mark_rejected(conn, draft_id, f"parse_error: {e}")
-        return False
+    # ── P-4 anti-sameness (constitution Art 10.6) ──────────────────────────
+    # Soft steer (ALWAYS ON): derive the prospective domain from the topic,
+    # look up the last-2 rendered same-domain carousels, and tell the model to
+    # vary register/image-mode away from them. The HARD reject loop below only
+    # engages when WR2_ANTIMONOTONE_ENFORCE=true (default OFF) — it ships
+    # dormant-but-safe so it can be turned on after topic_type_log fills with
+    # real data. The "unknown" domain bucket is never constrained.
+    prospective_domain = tt.derive_domain(topic)
+    recent = await fetch_recent_same_domain(conn, prospective_domain, limit=2)
+    avoid_steer = _build_avoid_steer(recent)
+    enforce = os.environ.get("WR2_ANTIMONOTONE_ENFORCE", "false").lower() == "true"
+    max_regen = 2  # => up to 3 total generation attempts
 
-    try:
-        register, slides = _normalise_slides(parsed)
-    except ValueError as e:
-        logger.error("Normalisation failed: %s", e)
-        await _mark_rejected(conn, draft_id, f"normalise_error: {e}")
-        return False
+    parsed: dict[str, Any] | None = None
+    register = ""
+    slides: list[dict[str, Any]] = []
+    for attempt in range(max_regen + 1):
+        try:
+            parsed = await claude_compose_slides(
+                topic=topic, summary=summary, source_url=source_url,
+                enrichment=enrichment, live_reasons=live_reasons,
+                avoid_steer=avoid_steer,
+            )
+        except (ClaudeOAuthError, ClaudeOAuthNotAvailable) as e:
+            logger.error("Claude OAuth failed: %s", e)
+            await _mark_rejected(conn, draft_id, f"claude_failed: {e}")
+            _send_telegram(f"WR2 draft_generator Claude failed\ndraft {draft_id}\n{str(e)[:200]}")
+            return False
+        except (json.JSONDecodeError, ValueError) as e:
+            logger.error("Claude output parse failed: %s", e)
+            await _mark_rejected(conn, draft_id, f"parse_error: {e}")
+            return False
+
+        try:
+            register, slides = _normalise_slides(parsed)
+        except ValueError as e:
+            logger.error("Normalisation failed: %s", e)
+            await _mark_rejected(conn, draft_id, f"normalise_error: {e}")
+            return False
+
+        # Derived signature of THIS draft for the anti-sameness check.
+        slides_envelope = {"slides": slides}
+        dominant_mode = tt.derive_dominant_mode(slides_envelope)
+
+        if (
+            not enforce
+            or prospective_domain == tt.UNKNOWN
+            or not tt.collides_with_recent(register, dominant_mode, recent)
+        ):
+            break  # accepted (enforcement off, unknown domain, or no collision)
+
+        if attempt < max_regen:
+            logger.warning(
+                "Anti-sameness collision (domain=%s register=%s mode=%s) vs recent "
+                "%s — regenerating (attempt %d/%d).",
+                prospective_domain, register, dominant_mode, recent,
+                attempt + 1, max_regen,
+            )
+            # Strengthen the steer on retry so the model does not repeat itself.
+            avoid_steer = _build_avoid_steer(recent) + (
+                "\n\nYour PREVIOUS attempt repeated a forbidden combination. "
+                f"Do NOT use register={register!r} with image-mode={dominant_mode!r} "
+                "again. Change at least one of them."
+            )
+        else:
+            logger.warning(
+                "Anti-sameness collision persisted after %d retries "
+                "(domain=%s register=%s mode=%s) — proceeding anyway (WARN).",
+                max_regen, prospective_domain, register, dominant_mode,
+            )
+
+    assert parsed is not None  # loop always sets parsed or returns
+
+    # Intra-carousel variety WARN (autopsy): a single carousel should use >=3
+    # distinct image-modes. Becomes meaningful now that §3.0 emits image_mode.
+    n_distinct = tt.distinct_mode_count({"slides": slides})
+    if n_distinct < 3:
+        logger.warning(
+            "Draft %s has only %d distinct image-modes (<3) — monotone carousel.",
+            draft_id, n_distinct,
+        )
 
     logger.info(
         "Slides composed: register=%s count=%d cover_prompt=%r",

--- a/scripts/wr2_topic_type.py
+++ b/scripts/wr2_topic_type.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""WR2 topic-type derivation helpers (pure, defensive, no I/O).
+
+These functions turn a carousel's `topic` text and `slides_json` into the
+columns of `topic_type_log` (migration 206). They are consumed by:
+  - wr2_canva_desktop_apply._log_topic_type  (write at status='rendered')
+  - wr2_draft_generator.fetch_recent_same_domain / the anti-sameness steer
+
+Design contract (constitution Art 5.7 domain, Art 5.8 image-mode, Art 10.6
+anti-sameness):
+  * derive_domain(topic)            -> str          (never raises; "unknown" fallback)
+  * derive_dominant_mode(slides)    -> str          (never raises; "unknown" fallback)
+  * derive_layout_family(slides)    -> str | None   (never raises)
+  * extract_archetype(slides)       -> str | None   (never raises)
+
+EVERY function is defensive: it accepts a dict OR a JSON string OR garbage and
+NEVER raises. A logging table must never break the render path (best-effort
+write per plan §3.3). When in doubt the answer is "unknown" / None.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from collections import Counter
+from typing import Any
+
+logger = logging.getLogger("wr2.topic_type")
+
+# ── Domain keyword map (constitution Art 5.7: visa, tax, property, regulatory,
+# health, brand). Case-insensitive, Indonesian + English keywords. Order does
+# not matter for correctness — first-match-wins on the iteration below, but the
+# buckets are disjoint enough in practice that ordering is not load-bearing. ──
+#
+# A coarse keyword classifier by design (plan risk #5): a misclassification only
+# weakens the anti-monotony steer, it never corrupts data. A real classifier is
+# a documented v2 follow-up.
+#
+# ORDER IS LOAD-BEARING: derive_domain returns the FIRST bucket whose keyword
+# hits, so more-specific buckets must precede the ones with broad/ambiguous
+# tokens. In particular `health` is checked BEFORE `regulatory` because
+# "BPJS Kesehatan" (a health topic) would otherwise be claimed by a bare "bpjs"
+# regulatory token — so regulatory carries only the labor-specific
+# "bpjs ketenagakerjaan", never bare "bpjs". (Verified empirically: without
+# this ordering "BPJS Kesehatan for expats" misclassified as regulatory.)
+_DOMAIN_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "visa": (
+        "visa", "visto", "kitas", "kitap", "e28a", "e28b", "e33g", "voa",
+        "b211", "c312", "c313", "c314", "c316", "c317", "c318", "c319", "c320",
+        "permit", "stay permit", "izin tinggal", "rkptka", "imta", "dkptka",
+        "second home", "golden visa", "retirement visa", "digital nomad",
+    ),
+    "tax": (
+        "tax", "pajak", "ppn", "pph", "npwp", "vat", "fiscal", "fiskal",
+        "spt", "coretax", "withholding", "income tax", "bea", "djp",
+        "tax amnesty", "transfer pricing", " pbb",
+    ),
+    "property": (
+        "property", "properti", "tanah", "rumah", "villa", "land",
+        "hak pakai", "hak guna", "hgb", "shm", "sertifikat", "nominee",
+        "leasehold", "freehold", "real estate", "zoning", "imb", "pbg",
+        "right to use", "right of use",
+    ),
+    "health": (
+        "health", "kesehatan", "bpjs kesehatan", "medical", "rumah sakit",
+        "hospital", "clinic", "klinik", "insurance health", "asuransi kesehatan",
+        "vaccine", "vaksin", "puskesmas",
+    ),
+    "regulatory": (
+        "permenaker", "permenkumham", "labor", "tenaga kerja",
+        "bpjs ketenagakerjaan", "regulasi", "regulation", "peraturan",
+        "omnibus", "oss", "nib", "kbli", "compliance", "lkpm", "bkpm",
+        "pp ", "pp no", "permen", "uu ", "perppu", "decree", "ministerial",
+        "license", "izin usaha", "company", "pt pma", "perusahaan",
+        "incorporation",
+    ),
+    "brand": (
+        "bali zero", "balizero", "our story", "behind the scenes", "team",
+        "anniversary", "we built", "manifesto",
+    ),
+}
+
+# The image-mode taxonomy (constitution Art 5.8, 9 modes). We do NOT invent
+# modes — derive_dominant_mode only counts what the slides actually carry, and
+# this set is informational (lets callers sanity-check / future-validate).
+VALID_IMAGE_MODES: frozenset[str] = frozenset(
+    {
+        "desk-document",
+        "event-photo",
+        "architecture-or-texture",
+        "provocation-photo",
+        "human-silhouette",
+        "object-comparison",
+        "calendar-photo",
+        "data-visualization",
+        "cultural-photo",
+    }
+)
+
+UNKNOWN = "unknown"
+
+
+def _coerce_to_dict(slides_json: Any) -> dict[str, Any] | list[Any] | None:
+    """Best-effort coerce slides_json into a dict/list. Never raises.
+
+    Accepts:
+      * a dict (already parsed) -> returned as-is
+      * a list (the bare slides array) -> returned as-is
+      * a JSON string -> parsed; returns the result or None on failure
+      * anything else / malformed -> None
+    """
+    if slides_json is None:
+        return None
+    if isinstance(slides_json, (dict, list)):
+        return slides_json
+    if isinstance(slides_json, (str, bytes, bytearray)):
+        try:
+            parsed = json.loads(slides_json)
+        except (ValueError, TypeError):
+            return None
+        if isinstance(parsed, (dict, list)):
+            return parsed
+        return None
+    return None
+
+
+def _extract_slide_list(slides_json: Any) -> list[dict[str, Any]]:
+    """Return the list of per-slide dicts from any slides_json shape. Never raises.
+
+    Handles the canonical {"slides": [...]} envelope as well as a bare [...]
+    list. Non-dict slide entries are dropped (defensive).
+    """
+    data = _coerce_to_dict(slides_json)
+    if data is None:
+        return []
+    if isinstance(data, dict):
+        slides = data.get("slides")
+    else:  # already a list
+        slides = data
+    if not isinstance(slides, list):
+        return []
+    return [s for s in slides if isinstance(s, dict)]
+
+
+def derive_domain(topic: str | None) -> str:
+    """Map a topic string to a domain bucket via keyword match. Never raises.
+
+    Case-insensitive, matches Indonesian + English keywords. Returns the first
+    domain whose keyword set hits; "unknown" if nothing matches or topic is
+    empty/None/non-string.
+    """
+    if not isinstance(topic, str) or not topic.strip():
+        return UNKNOWN
+    haystack = topic.lower()
+    for domain, keywords in _DOMAIN_KEYWORDS.items():
+        for kw in keywords:
+            if kw in haystack:
+                return domain
+    return UNKNOWN
+
+
+def _slide_mode(slide: dict[str, Any]) -> str | None:
+    """Read a slide's image-mode from whichever field it carries. Never raises.
+
+    Tolerates both `image_mode` (the field §3.0 adds) and the alt name
+    `image_style_mode`. Returns a normalised lowercase string, or None when the
+    slide has no usable mode.
+    """
+    for key in ("image_mode", "image_style_mode"):
+        val = slide.get(key)
+        if isinstance(val, str) and val.strip():
+            return val.strip().lower()
+    return None
+
+
+def derive_dominant_mode(slides_json: Any) -> str:
+    """Most-frequent per-slide image-mode across the carousel. Never raises.
+
+    Counts only what the slides carry (we do not invent modes). Returns:
+      * the single most-frequent mode when there is a unique winner
+      * "unknown" on a tie, on an empty/absent set, or on malformed input
+    """
+    slides = _extract_slide_list(slides_json)
+    if not slides:
+        return UNKNOWN
+    modes = [m for m in (_slide_mode(s) for s in slides) if m]
+    if not modes:
+        return UNKNOWN
+    counts = Counter(modes)
+    most_common = counts.most_common()
+    # Tie at the top -> ambiguous -> unknown (do not pick arbitrarily).
+    if len(most_common) > 1 and most_common[0][1] == most_common[1][1]:
+        return UNKNOWN
+    return most_common[0][0]
+
+
+def distinct_mode_count(slides_json: Any) -> int:
+    """Number of distinct image-modes present in the carousel. Never raises.
+
+    Used by the intra-carousel >=3-distinct-modes WARN (plan §3.5).
+    """
+    slides = _extract_slide_list(slides_json)
+    modes = {m for m in (_slide_mode(s) for s in slides) if m}
+    return len(modes)
+
+
+def derive_layout_family(slides_json: Any) -> str | None:
+    """Most-frequent per-slide layout field, else top-level archetype, else None.
+
+    Never raises. Reads a per-slide `layout_family` / `layout` field if the
+    slides carry one; falls back to the top-level archetype; else None.
+    """
+    slides = _extract_slide_list(slides_json)
+    layouts: list[str] = []
+    for s in slides:
+        for key in ("layout_family", "layout"):
+            val = s.get(key)
+            if isinstance(val, str) and val.strip():
+                layouts.append(val.strip().lower())
+                break
+    if layouts:
+        counts = Counter(layouts)
+        return counts.most_common(1)[0][0]
+    return extract_archetype(slides_json)
+
+
+def extract_archetype(slides_json: Any) -> str | None:
+    """Top-level `archetype` from slides_json if present, else None. Never raises."""
+    data = _coerce_to_dict(slides_json)
+    if isinstance(data, dict):
+        val = data.get("archetype")
+        if isinstance(val, str) and val.strip():
+            return val.strip().lower()
+    return None
+
+
+def is_same_combo(
+    register_a: str | None,
+    mode_a: str | None,
+    register_b: str | None,
+    mode_b: str | None,
+) -> bool:
+    """True when two (register, image-mode) combos count as "the same" per Art 10.6.
+
+    The anti-sameness rule (plan §3.5, panel-corrected): a new carousel is
+    allowed if it DIFFERS IN EITHER register OR image-mode. So two combos are
+    "the same" (a collision worth rejecting) only when they match in BOTH
+    register AND mode.
+
+    Mode comparison is SKIPPED when dominant_mode is "unknown" on EITHER side
+    (until §3.0 fills modes, this degrades to register-only). When mode is
+    skipped, a collision requires only the registers to match.
+    """
+    reg_a = (register_a or "").strip().lower() or None
+    reg_b = (register_b or "").strip().lower() or None
+    md_a = (mode_a or "").strip().lower() or None
+    md_b = (mode_b or "").strip().lower() or None
+
+    # Registers must match for any collision.
+    if reg_a is None or reg_b is None or reg_a != reg_b:
+        return False
+
+    # Registers match. Now the mode axis.
+    mode_known = (
+        md_a is not None
+        and md_b is not None
+        and md_a != UNKNOWN
+        and md_b != UNKNOWN
+    )
+    if not mode_known:
+        # Mode unknown on at least one side -> register-only comparison.
+        # Registers already matched -> collision.
+        return True
+    # Both modes known: collision only if modes ALSO match (differ-in-either rule).
+    return md_a == md_b
+
+
+def collides_with_recent(
+    register: str | None,
+    dominant_mode: str | None,
+    recent: list[dict[str, Any]],
+) -> bool:
+    """True if (register, mode) collides with EITHER of the recent same-domain rows.
+
+    `recent` is the output of fetch_recent_same_domain: a list of dicts with
+    keys `register` and `dominant_mode`. Empty list -> no collision (cold-start
+    safe). Never raises.
+    """
+    if not recent:
+        return False
+    for row in recent:
+        try:
+            r_reg = row.get("register")
+            r_mode = row.get("dominant_mode")
+        except AttributeError:
+            continue
+        if is_same_combo(register, dominant_mode, r_reg, r_mode):
+            return True
+    return False


### PR DESCRIPTION
## What

Implements **P-4** from the WR2 autopsy: a Postgres `topic_type_log` table written at `status='rendered'`, plus the derivation + lookup + steer that make constitution **Art 10.6** ("two same-domain carousels must differ in register AND image-mode") *enforceable* instead of aspirational.

Plan (4-LLM-reviewed, rev 2) followed as contract: `/tmp/P4-topic-type-log-plan.md` (synthesised from `research/operations/2026-06-04-wr2-autopsy-report.md`).

## Why

The autopsy found the anti-sameness rule was aspirational: nothing recorded what each rendered carousel *was* (domain / register / dominant image-mode), so the generator couldn't avoid repeating itself. Worse, the panel found the feature was **DOA as first drafted** because `image_mode` did not exist in the producer at all — so the "dominant mode" axis would have been `unknown` 100% of the time.

## The 4-LLM panel findings + how addressed

1. **CRITICAL — `image_mode` absent from the generator** (both DeepSeek + Codex). → Added it as a GATING PREREQ (§3.0): emitted in `SYSTEM_INSTRUCTIONS` + the JSON examples + reinforced in the MUST-OBEY block, and whitelisted in `_normalise_slides` (mirrors the existing `tonal_palette` pattern) so it survives to `slides_json`. **Verified empirically**: `"Desk-Document"` → `"desk-document"`, absent/blank → `None`, key present on every slide.
2. **HIGH — "differ in BOTH" + mode-always-unknown → dead letter.** → Collision rule is now **differ in EITHER register OR image-mode** (a collision requires matching BOTH).
3. **HIGH — writing at `rendered` logs Damar-rejected carousels too.** → DDL carries nullable `published_at` + `deleted_at` now (zero cost) so the future publish-semantics switch is a 1-line query change, no new migration.
4. **MEDIUM — "unknown" domain cross-constrains unrelated topics.** → `domain=="unknown"` is **exempt** from the hard reject and never queried in the lookup (soft-steer only).
5. **Codex — transaction premise wrong.** `_persist_result` is a bare `conn.execute` called from TWO paths. → The log write is folded INTO `_persist_result` (single site, covers both headless + desktop), AFTER the status update, in a `conn.transaction()` savepoint, try/except WARN-only.
6. **Codex — rollback needs the literal marker.** → Migration uses `-- === ROLLBACK ===` with executable `DROP INDEX`/`DROP TABLE` (the runner `migration_base.split_migration_sql` stores + executes it; the forward apply excludes it — verified).

Also corrected two autopsy hallucinations (verified on Pro): there is no pre-existing `topic_type_log` anywhere in the codebase (building from zero), and there is **no software publish-to-IG event** — `rendered` is the real terminal status in Pipeline B (Damar publishes manually), so the row is written there.

## Shipped ON vs gated

- **ON:** migration, `image_mode` emit+persist, write-at-rendered (best-effort), the soft steer (recent same-domain combos injected into the prompt), the intra-carousel ≥3-distinct-modes **WARN**.
- **Behind `WR2_ANTIMONOTONE_ENFORCE` (default OFF):** the hard reject+regenerate loop (max 2 retries, then WARN-and-proceed). Ships dormant-but-safe so it can be turned on after `topic_type_log` accumulates real data. The lookup + soft steer give immediate value with zero starvation risk.

## Tests

- `scripts/test_wr2_topic_type.py` — **50 tests, all pass**: every domain bucket + unknown + case-insensitivity + the BPJS-Kesehatan-beats-regulatory ordering edge; dominant-mode frequency/tie/empty/malformed-string/json-string/bare-list/alt-field-name; layout-family + archetype; the full collision matrix (match-both→reject, differ-in-either→ok, unknown-mode→register-only, empty-history→ok); and `image_mode` normalise survival.
- No regression: existing `scripts/test_wr2_autopsy_fixes.py` (29 tests, incl. the `tonal_palette` passthrough) still green.

## Migration

`206_wr2_topic_type_log.sql`. Smoke-tested against a throwaway schema (forward → table + 2 named indexes exist; `ON CONFLICT (draft_id)` double-INSERT idempotent = 1 row; forward re-apply idempotent; rollback drops the table → `to_regclass` None). Squawk-safe: `CREATE TABLE/INDEX IF NOT EXISTS` on a brand-new empty table, no `ALTER`, no backfill, no lock on `war_room_drafts`.

## Deferred (out of scope)

A real publish-to-IG signal; a domain classifier beyond keyword matching; making the ≥3-distinct-modes check a hard block; Pipeline A orchestrator resurrection (that's P-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
