### PR TITLE
feat(wr2): P-2a code scaffold — per-archetype Canva master selection

### DIFF
--- a/apps/backend-rag/backend/services/canva_renderer/pending_builder.py
+++ b/apps/backend-rag/backend/services/canva_renderer/pending_builder.py
@@ -90,6 +90,46 @@ def _sanitize_slide_text(text: str) -> str:
 # shadow validation (the skill auto-reconciled but warned the default was stale).
 # The renderer clamps to MAX_SLIDES_TEMPLATE (11).
 TEMPLATE_DESIGN_ID = "DAHJSqJOIO8"
+
+# P-2a (2026-06-05): per-archetype master templates. The autopsy
+# (research/operations/2026-06-04-wr2-autopsy-report.md, W66 spec) found every
+# live carousel is a text-swap of the SINGLE gray master above, so structural
+# sameness is guaranteed by construction. This map lets build_canva_pending pick
+# a distinct master per archetype.
+#
+# CODE-ONLY scaffolding: the four non-default IDs below are PLACEHOLDERS. The
+# real Canva masters are a manual design task (duplicate DAHJSqJOIO8, vary the
+# background / grid, keep the antracite/white/yellow palette per Art 2 + 14.4) +
+# operator sign-off. Until a real design ID replaces a placeholder, that
+# archetype falls back to TEMPLATE_DESIGN_ID via select_template_design_id() --
+# so behaviour is IDENTICAL to today until both (a) a caller passes an archetype
+# AND (b) that archetype has a non-placeholder ID. The archetype names match the
+# layout families already declared in bali-zero-brand/tokens.json.
+_PLACEHOLDER_PREFIX = "PLACEHOLDER-"
+TEMPLATE_DESIGN_IDS: dict[str, str] = {
+    "default": TEMPLATE_DESIGN_ID,
+    "swiss-grid-asymmetry": _PLACEHOLDER_PREFIX + "swiss-grid-asymmetry",
+    "stat-card-hero": _PLACEHOLDER_PREFIX + "stat-card-hero",
+    "thin-red-rule-divider": _PLACEHOLDER_PREFIX + "thin-red-rule-divider",
+    "monospace-evidence-block": _PLACEHOLDER_PREFIX + "monospace-evidence-block",
+}
+
+
+def select_template_design_id(archetype: str | None) -> str:
+    """Resolve the Canva master design ID for an archetype.
+
+    Falls back to the default master (TEMPLATE_DESIGN_ID) when archetype is None,
+    unknown, or still backed by a placeholder ID. This keeps the live path
+    byte-identical to pre-P-2a behaviour until a real Canva master is recorded
+    AND a caller actually passes the matching archetype.
+    """
+    if not archetype:
+        return TEMPLATE_DESIGN_ID
+    candidate = TEMPLATE_DESIGN_IDS.get(archetype)
+    if not candidate or candidate.startswith(_PLACEHOLDER_PREFIX):
+        return TEMPLATE_DESIGN_ID
+    return candidate
+
 CAROUSEL_FOLDER_ID = "FAHEwkTYduI"
 
 # Legibility Armor gradient overlay — 4:5 PNG with strong dark at top (heading
@@ -289,6 +329,7 @@ def build_canva_pending(
     topic: str,
     tone: str,
     slides: list[dict[str, Any]],
+    archetype: str | None = None,
 ) -> dict[str, Any]:
     """Build the full canva_pending.json payload from WR2 draft data.
 
@@ -325,7 +366,8 @@ def build_canva_pending(
     hero_slides_used = [s["slide_number"] for s in effective_slides if s.get("is_hero_image")]
 
     return {
-        "template_design_id": TEMPLATE_DESIGN_ID,
+        "template_design_id": select_template_design_id(archetype),
+        "archetype": archetype,
         "folder_id": CAROUSEL_FOLDER_ID,
         "design_id": None,
         "design_url": None,

--- a/apps/backend-rag/backend/tests/unit/services/canva_renderer/test_pending_builder.py
+++ b/apps/backend-rag/backend/tests/unit/services/canva_renderer/test_pending_builder.py
@@ -16,7 +16,9 @@ from backend.services.canva_renderer.pending_builder import (
     CAROUSEL_FOLDER_ID,
     MAX_SLIDES_TEMPLATE,
     TEMPLATE_DESIGN_ID,
+    TEMPLATE_DESIGN_IDS,
     build_canva_pending,
+    select_template_design_id,
     slides_to_operations,
 )
 
@@ -250,3 +252,63 @@ class TestBuildCanvaPending:
         slides = [{"slide_number": i, "headline": f"s{i}"} for i in range(1, 15)]
         with pytest.raises(ValueError, match="cannot exceed 13 slides"):
             build_canva_pending(topic="x", tone="pedagogico", slides=slides)
+
+
+class TestArchetypeTemplateSelection:
+    """P-2a: per-archetype master selection. The four non-default IDs are
+    placeholders for now, so every archetype MUST still fall back to the live
+    default master until a real Canva design ID is recorded. These tests pin
+    that fallback contract + the additive payload field."""
+
+    def test_default_map_points_at_live_master(self) -> None:
+        assert TEMPLATE_DESIGN_IDS["default"] == TEMPLATE_DESIGN_ID
+
+    def test_none_archetype_falls_back_to_default(self) -> None:
+        assert select_template_design_id(None) == TEMPLATE_DESIGN_ID
+
+    def test_unknown_archetype_falls_back_to_default(self) -> None:
+        assert select_template_design_id("no-such-archetype") == TEMPLATE_DESIGN_ID
+
+    def test_placeholder_archetype_falls_back_to_default(self) -> None:
+        # All four non-default entries are placeholders today -> all fall back.
+        for key in (
+            "swiss-grid-asymmetry",
+            "stat-card-hero",
+            "thin-red-rule-divider",
+            "monospace-evidence-block",
+        ):
+            assert select_template_design_id(key) == TEMPLATE_DESIGN_ID, key
+
+    def test_real_id_is_returned_when_no_longer_placeholder(self) -> None:
+        # Simulate an operator wiring a real Canva master for one archetype.
+        import backend.services.canva_renderer.pending_builder as pb
+
+        original = dict(pb.TEMPLATE_DESIGN_IDS)
+        try:
+            pb.TEMPLATE_DESIGN_IDS["stat-card-hero"] = "DAHrealmaster"
+            assert pb.select_template_design_id("stat-card-hero") == "DAHrealmaster"
+            # other placeholders still fall back
+            assert pb.select_template_design_id("swiss-grid-asymmetry") == TEMPLATE_DESIGN_ID
+        finally:
+            pb.TEMPLATE_DESIGN_IDS.clear()
+            pb.TEMPLATE_DESIGN_IDS.update(original)
+
+    def test_build_payload_default_archetype_unchanged(self) -> None:
+        # No archetype passed (the only production call site today) -> identical
+        # template_design_id as before P-2a.
+        payload = build_canva_pending(
+            topic="x", tone="pedagogico", slides=_slides_fixture()
+        )
+        assert payload["template_design_id"] == TEMPLATE_DESIGN_ID
+        assert payload["archetype"] is None
+
+    def test_build_payload_placeholder_archetype_still_default(self) -> None:
+        payload = build_canva_pending(
+            topic="x",
+            tone="pedagogico",
+            slides=_slides_fixture(),
+            archetype="swiss-grid-asymmetry",
+        )
+        # placeholder -> falls back, but the chosen archetype is still recorded
+        assert payload["template_design_id"] == TEMPLATE_DESIGN_ID
+        assert payload["archetype"] == "swiss-grid-asymmetry"


### PR DESCRIPTION
## What

Code-only slice of **P-2a** from the WR2 autopsy deferred spec (W66). Adds the machinery to select a distinct Canva master template per *archetype*, instead of text-swapping the single gray master (`DAHJSqJOIO8`) for every carousel — which the 13-agent autopsy identified as a structural cause of carousel sameness.

## Changes (`pending_builder.py`)

- `TEMPLATE_DESIGN_IDS: dict[archetype, str]` — `default` + the 4 layout families already named in `bali-zero-brand/tokens.json` (`swiss-grid-asymmetry`, `stat-card-hero`, `thin-red-rule-divider`, `monospace-evidence-block`).
- `select_template_design_id(archetype)` — resolves the master, **falls back to the live default** for `None` / unknown / placeholder.
- `build_canva_pending()` gains optional `archetype: str | None = None`; records the chosen archetype in the payload.

## Why this is non-breaking

- The 4 non-default IDs are **placeholders** (`PLACEHOLDER-*`). The real Canva masters are a manual design task + operator sign-off (still deferred, per spec).
- `select_template_design_id` returns the **live default** for every placeholder → the publishing path is **byte-identical to today** until (a) a caller passes an archetype AND (b) that archetype has a real ID.
- The only production caller (`wr2_canva_desktop_apply.py`) passes **no** archetype → unchanged.
- Placeholder strings can never reach Canva `get-design` or the `pg_try_advisory_lock` key (selector never returns them).

## Tests

20 pass in `test_pending_builder.py` (13 existing + 7 new pinning the fallback contract + additive `archetype` payload field).

## Out of scope (still deferred, operator-gated)

- Building the actual Canva master designs (manual).
- Wiring `archetype` selection into the live draft path = **P-1 Route 1A** (needs 4-LLM panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)