### PR TITLE
chore(gitignore): ignore .codex/ (Codex CLI local config)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,9 @@ google_credentials.json
 
 # AI/dev tooling (local state)
 .cursor/
+# Codex CLI local config: MCP server map + hooks carrying absolute /Users
+# paths and Keychain/secret references — machine-local, never versioned.
+.codex/
 .libs/
 **/.claude/settings.local.json
 **/.claude/locks/


### PR DESCRIPTION
`.codex/` holds Codex CLI's local MCP server map + PostToolUse hooks with absolute `/Users/balizero` paths and Keychain/secret references — machine-local tooling state (same class as the already-ignored `.cursor/`/`.claude/`). Without this rule it shows untracked in `git status` and trips the stop-verify dirty-worktree gate. File stays on disk for Codex; just stops polluting the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)