### PR TITLE
docs(migration): correct mig 217 header — DDL applies on Fly, only DATA is local-only

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/217_intake_commit_audit.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/217_intake_commit_audit.sql
@@ -1,4 +1,4 @@
--- 217_intake_commit_audit.sql — FASE 5B/5C CRM-writer audit + idempotency (LOCAL Pro DB only)
+-- 217_intake_commit_audit.sql — FASE 5B/5C CRM-writer audit + idempotency (DDL, no data)
 -- Adds the two persistence primitives the document-intake CRM writer needs:
 --   1. intake_commit_audit            — forensic trace of EVERY commit attempt
 --                                        (committed / dry_run / failed / rolled_back).
@@ -16,7 +16,15 @@
 --
 -- READ-ONLY w.r.t. the CRM in 5B: the new \`documents\` columns are only WRITTEN by the
 -- real (5C) commit path, gated by INTAKE_WRITER_ENABLED (default OFF).
--- PII 100% locale (Law 2 / UU-PDP): MAI applicare su Fly. Solo nuzantara_dev @127.0.0.1:5432.
+-- DDL-vs-DATA boundary (Law 2 / UU-PDP): this migration is SCHEMA ONLY — an empty
+-- `intake_commit_audit` table + two nullable `documents` columns. The numbered-migration
+-- runner (migration_manager.discover_migrations) applies every migrations_v2/*.sql by
+-- number on EVERY DB it runs against (local AND Fly), so this schema IS present on Fly —
+-- a `-- comment` cannot gate the runner. That is fine: zero PII is written by the schema.
+-- What is PII-local-only is the DATA: the 5C writer (gated by INTAKE_WRITER_ENABLED,
+-- default OFF) must only ever write rows here against nuzantara_dev @127.0.0.1, never Fly.
+-- (Earlier header said "MAI applicare su Fly" — that was wrong about the DDL; corrected
+--  2026-06-06 after empirical verify that 217 is in _schema_versions on Fly, table empty.)
 -- === FORWARD ===
 
 -- A. Idempotency + provenance columns on documents (nullable: legacy rows untouched).


### PR DESCRIPTION
Migration 217's header claimed `PII 100% locale ... MAI applicare su Fly`. That's empirically false: the numbered-migration runner globs `migrations_v2/*.sql` and applies every file by number on every DB — a `-- comment` can't gate it. Verified post-#1137 deploy: 217 is in `_schema_versions` on Fly, `intake_commit_audit` table present + EMPTY, `documents.intake_*` columns nullable.

The real boundary is **DDL-vs-DATA**: the schema (empty table, nullable cols) is harmless on Fly (zero PII). What stays local-only is the **data** the 5C writer would write (`INTAKE_WRITER_ENABLED`, default OFF). Header rewritten to say that.

Comment-only change — no DDL, no runtime, no rollback impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)