### PR TITLE
feat(intake): /reject terminal endpoint (queue-management, not flag-gated)

### DIFF
--- a/apps/backend-rag/backend/app/routers/intake_review.py
+++ b/apps/backend-rag/backend/app/routers/intake_review.py
@@ -46,11 +46,6 @@ router = APIRouter(prefix="/api/intake/review", tags=["intake-review"])
 # How long a single reviewer holds a proposal before it becomes reclaimable.
 CLAIM_TTL_MINUTES = 15
 
-# FASE 5C writer endpoints are not active yet — surfaced as explicit 501.
-_WRITER_DISABLED_DETAIL = (
-    "FASE 5C — writer non ancora attivo. approve/reject/commit scrivono il CRM "
-    "e sono dietro feature-flag (INTAKE_WRITER_ENABLED). Non implementato in 5A."
-)
 
 
 # --------------------------------------------------------------------------- #
@@ -497,7 +492,50 @@ async def release_review(
 
 
 # --------------------------------------------------------------------------- #
-# FASE 5C stubs — writer not active in 5A
+# Shared claim/lease guard (P0#5) — used by approve AND reject
+# --------------------------------------------------------------------------- #
+async def _require_active_claim(
+    prop: asyncpg.Record,
+    *,
+    admin: bool,
+    user_email: str,
+    claim_token: str | None,
+) -> None:
+    """Raise unless the caller holds the active, unexpired claim on ``prop``.
+
+    P0#5: the proposal must be ``review_claimed`` with a non-expired lease; a
+    non-admin must own the lease AND present the matching ``claim_token`` UUID.
+    Admins bypass the owner/token checks but NOT the status/expiry checks.
+
+    The caller must have already ``SELECT ... FOR UPDATE``'d ``prop`` (so this is a
+    pure in-memory check on the locked row). Mirrors the original inline guard in
+    ``approve_review`` exactly — extracted so ``reject_review`` enforces the
+    identical rule without drift.
+    """
+    now = datetime.now(timezone.utc)
+    if prop["status"] != "review_claimed":
+        raise HTTPException(
+            status_code=409,
+            detail=f"Proposal must be review_claimed (status={prop['status']}).",
+        )
+    lease_exp = prop["lease_expires_at"]
+    if lease_exp is None or lease_exp < now:
+        raise HTTPException(status_code=409, detail="Claim lease expired - re-claim first.")
+    if not admin:
+        if (prop["lease_owner"] or "").lower().strip() != user_email:
+            raise HTTPException(status_code=403, detail="You do not hold this claim.")
+        if claim_token is None:
+            raise HTTPException(status_code=400, detail="claim_token required.")
+        try:
+            tok = uuid.UUID(str(claim_token))
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail="Invalid claim_token.") from exc
+        if prop["claim_token"] != tok:
+            raise HTTPException(status_code=403, detail="claim_token does not match active claim.")
+
+
+# --------------------------------------------------------------------------- #
+# approve (dry-run 5B / real commit 5C) + reject (terminal, queue-management)
 # --------------------------------------------------------------------------- #
 @router.post("/{proposal_id}/approve")
 async def approve_review(
@@ -531,8 +569,6 @@ async def approve_review(
     override_practice_id = body.get("practice_id")
     final_fields = body.get("final_fields") if isinstance(body.get("final_fields"), dict) else None
 
-    now = datetime.now(timezone.utc)
-
     async with pool.acquire() as conn:
         async with conn.transaction():
             prop = await conn.fetchrow(
@@ -549,26 +585,10 @@ async def approve_review(
             if prop is None:
                 raise HTTPException(status_code=404, detail="Proposal not found")
 
-            # P0#5 — claim/lease enforcement.
-            if prop["status"] != "review_claimed":
-                raise HTTPException(
-                    status_code=409,
-                    detail=f"Proposal must be review_claimed to approve (status={prop['status']}).",
-                )
-            lease_exp = prop["lease_expires_at"]
-            if lease_exp is None or lease_exp < now:
-                raise HTTPException(status_code=409, detail="Claim lease expired - re-claim first.")
-            if not admin:
-                if (prop["lease_owner"] or "").lower().strip() != user_email:
-                    raise HTTPException(status_code=403, detail="You do not hold this claim.")
-                if claim_token is None:
-                    raise HTTPException(status_code=400, detail="claim_token required.")
-                try:
-                    tok = uuid.UUID(str(claim_token))
-                except ValueError as exc:
-                    raise HTTPException(status_code=400, detail="Invalid claim_token.") from exc
-                if prop["claim_token"] != tok:
-                    raise HTTPException(status_code=403, detail="claim_token does not match active claim.")
+            # P0#5 — claim/lease enforcement (shared with reject).
+            await _require_active_claim(
+                prop, admin=admin, user_email=user_email, claim_token=claim_token,
+            )
 
             plan = await intake_writer.plan_commit(
                 prop,
@@ -605,13 +625,81 @@ async def approve_review(
     }
 
 
-@router.post("/{proposal_id}/reject", status_code=501)
-async def reject_review_stub(
+@router.post("/{proposal_id}/reject")
+async def reject_review(
     proposal_id: int = Path(..., ge=1),
+    body: dict[str, Any] = Body(default_factory=dict),
     user: dict[str, Any] = Depends(get_current_user),
+    pool: asyncpg.Pool = Depends(get_database_pool),
 ) -> dict[str, Any]:
-    """Stub — terminal/dead-state write, lives in FASE 5C."""
-    raise HTTPException(status_code=501, detail=_WRITER_DISABLED_DETAIL)
+    """Reject a proposal — terminal transition ``review_claimed`` → ``rejected``.
+
+    This is a **queue-management** operation: it writes ONLY the proposal status +
+    clears the lease. It touches NO CRM data (no ``documents``, no ``practices``),
+    so — unlike ``approve`` — it is NOT gated by ``INTAKE_WRITER_ENABLED``: reviewers
+    must be able to dispose of garbage/NO_MATCH proposals in every phase (5B and 5C),
+    exactly like ``claim``/``release`` (which are also un-gated).
+
+    P0#5: identical claim/lease enforcement as ``approve`` (shared helper). No
+    ``intake_commit_audit`` row is written — that table is the CRM-commit forensic
+    log; a rejection is fully recorded by the proposal's own terminal ``status``
+    (and its lease history). Idempotent under concurrency / re-reject: the
+    ``status='review_claimed'`` guard makes a second reject a 409 no-op, never a
+    double-write.
+
+    body: {claim_token?, reason?}  — ``reason`` is logged (truncated), not persisted.
+    """
+    admin = is_crm_admin(user)
+    user_email = (user.get("email") or "").lower().strip()
+    claim_token = body.get("claim_token")
+    reason = body.get("reason")
+
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            prop = await conn.fetchrow(
+                """
+                SELECT id, status, lease_owner, lease_expires_at, claim_token
+                FROM document_routing_proposal
+                WHERE id = $1
+                FOR UPDATE
+                """,
+                proposal_id,
+            )
+            if prop is None:
+                raise HTTPException(status_code=404, detail="Proposal not found")
+
+            await _require_active_claim(
+                prop, admin=admin, user_email=user_email, claim_token=claim_token,
+            )
+
+            # Terminal transition + lease clear. Reuse the release_review lease-clear
+            # UPDATE but set status='rejected' (terminal per chk_rp_status), NOT
+            # 'review_pending'. The status='review_claimed' guard makes a concurrent
+            # loser / re-reject a no-op (RETURNING NULL → 409 below).
+            updated = await conn.fetchrow(
+                """
+                UPDATE document_routing_proposal
+                   SET status = 'rejected',
+                       lease_owner = NULL,
+                       lease_expires_at = NULL,
+                       claim_token = NULL,
+                       claimed_at = NULL
+                 WHERE id = $1 AND status = 'review_claimed'
+                RETURNING id
+                """,
+                proposal_id,
+            )
+
+    if updated is None:
+        # Lost the race or already terminal (the guard above passed at SELECT time
+        # but the row changed) — surface as conflict.
+        raise HTTPException(status_code=409, detail="Proposal no longer review_claimed.")
+
+    logger.info(
+        "intake.review.rejected proposal=%s reviewer=%s admin=%s reason=%s",
+        proposal_id, user_email, admin, (reason or "")[:200],
+    )
+    return {"proposal_id": proposal_id, "status": "rejected"}
 
 
 # --------------------------------------------------------------------------- #

--- a/apps/backend-rag/backend/tests/routers/test_intake_review.py
+++ b/apps/backend-rag/backend/tests/routers/test_intake_review.py
@@ -262,12 +262,125 @@ async def test_release_wrong_token_409(pool, seed):
                        params={"claim_token": tok})
 
 
-async def test_reject_stub_501(pool, seed):
-    """reject is still a FASE 5C stub (terminal CRM-affecting write)."""
+async def _proposal_status(pool: asyncpg.Pool, pid: int) -> str:
+    async with pool.acquire() as conn:
+        return await conn.fetchval(
+            "SELECT status FROM document_routing_proposal WHERE id=$1", pid)
+
+
+async def test_reject_transitions_to_rejected(pool, seed):
+    """Admin claim → reject → proposal terminal 'rejected', lease cleared."""
+    pid = seed["p_owner"]
+    app = _make_app(pool, ADMIN)
+    async with _client(app) as cl:
+        rc = await cl.post(f"/api/intake/review/{pid}/claim")
+        assert rc.status_code == 200, rc.text
+        rr = await cl.post(
+            f"/api/intake/review/{pid}/reject",
+            json={"claim_token": rc.json()["claim_token"], "reason": "garbage scan"},
+        )
+    assert rr.status_code == 200, rr.text
+    assert rr.json()["status"] == "rejected"
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT status, lease_owner, lease_expires_at, claim_token, claimed_at "
+            "FROM document_routing_proposal WHERE id=$1", pid)
+    assert row["status"] == "rejected"
+    assert row["lease_owner"] is None
+    assert row["lease_expires_at"] is None
+    assert row["claim_token"] is None
+    assert row["claimed_at"] is None
+
+
+async def test_reject_clears_lease_not_reclaimable(pool, seed):
+    """After reject the proposal is terminal — claim must 409 (not review_pending)."""
+    pid = seed["p_nomatch"]
+    app = _make_app(pool, ADMIN)
+    async with _client(app) as cl:
+        rc = await cl.post(f"/api/intake/review/{pid}/claim")
+        await cl.post(f"/api/intake/review/{pid}/reject",
+                      json={"claim_token": rc.json()["claim_token"]})
+        # terminal 'rejected' is not 'review_pending' → claim's WHERE no longer matches
+        rcl = await cl.post(f"/api/intake/review/{pid}/claim")
+    assert rcl.status_code == 409, rcl.text
+    assert await _proposal_status(pool, pid) == "rejected"
+
+
+async def test_reject_requires_claim_409(pool, seed):
+    """reject on an UNCLAIMED (review_pending) proposal → 409 (must be review_claimed)."""
     app = _make_app(pool, ADMIN)
     async with _client(app) as cl:
         rr = await cl.post(f"/api/intake/review/{seed['p_owner']}/reject")
-    assert rr.status_code == 501 and "5C" in rr.json()["detail"]
+    assert rr.status_code == 409, rr.text
+    assert await _proposal_status(pool, seed["p_owner"]) == "review_pending"
+
+
+async def test_reject_non_admin_token_enforcement(pool, seed):
+    """Non-admin must hold the lease + present the matching token (P0#5)."""
+    pid = seed["p_owner"]  # assigned_to TEAM_OWNER → owner has access
+    owner_app = _make_app(pool, TEAM_OWNER)
+    async with _client(owner_app) as cl:
+        rc = await cl.post(f"/api/intake/review/{pid}/claim")
+        assert rc.status_code == 200, rc.text
+        token = rc.json()["claim_token"]
+        # no token → 400
+        no_tok = await cl.post(f"/api/intake/review/{pid}/reject", json={})
+        assert no_tok.status_code == 400, no_tok.text
+        # wrong token → 403
+        wrong = await cl.post(f"/api/intake/review/{pid}/reject",
+                              json={"claim_token": str(uuid.uuid4())})
+        assert wrong.status_code == 403, wrong.text
+        # correct token → 200
+        ok = await cl.post(f"/api/intake/review/{pid}/reject",
+                           json={"claim_token": token})
+        assert ok.status_code == 200, ok.text
+    assert await _proposal_status(pool, pid) == "rejected"
+
+
+async def test_reject_idempotent_noop(pool, seed):
+    """Re-reject an already-rejected proposal → 409, status stays rejected."""
+    pid = seed["p_other"]
+    app = _make_app(pool, ADMIN)
+    async with _client(app) as cl:
+        rc = await cl.post(f"/api/intake/review/{pid}/claim")
+        r1 = await cl.post(f"/api/intake/review/{pid}/reject",
+                           json={"claim_token": rc.json()["claim_token"]})
+        assert r1.status_code == 200, r1.text
+        # second reject — proposal is terminal, not review_claimed → 409
+        r2 = await cl.post(f"/api/intake/review/{pid}/reject", json={})
+    assert r2.status_code == 409, r2.text
+    assert await _proposal_status(pool, pid) == "rejected"
+
+
+async def test_reject_writes_no_crm_rows(pool, seed):
+    """A full claim→reject mutates NO clients/practices and writes NO audit row."""
+    before = await _crm_counts(pool)
+    pid = seed["p_owner"]
+    app = _make_app(pool, ADMIN)
+    async with _client(app) as cl:
+        rc = await cl.post(f"/api/intake/review/{pid}/claim")
+        rr = await cl.post(f"/api/intake/review/{pid}/reject",
+                           json={"claim_token": rc.json()["claim_token"]})
+    assert rr.status_code == 200, rr.text
+    after = await _crm_counts(pool)
+    assert after == before, f"CRM mutated by reject! {before} -> {after}"
+    async with pool.acquire() as conn:
+        n_audit = await conn.fetchval(
+            "SELECT count(*) FROM intake_commit_audit WHERE proposal_id=$1", pid)
+    assert n_audit == 0, "reject wrote an intake_commit_audit row (should write none)"
+
+
+async def test_reject_not_flag_gated(pool, seed, monkeypatch):
+    """reject works with INTAKE_WRITER_ENABLED OFF — it is a queue-management op."""
+    monkeypatch.delenv("INTAKE_WRITER_ENABLED", raising=False)
+    pid = seed["p_nomatch"]
+    app = _make_app(pool, ADMIN)
+    async with _client(app) as cl:
+        rc = await cl.post(f"/api/intake/review/{pid}/claim")
+        rr = await cl.post(f"/api/intake/review/{pid}/reject",
+                           json={"claim_token": rc.json()["claim_token"]})
+    assert rr.status_code == 200, rr.text
+    assert rr.json()["status"] == "rejected"
 
 
 async def test_approve_requires_claim_409(pool, seed):


### PR DESCRIPTION
## What

Replaces the FASE 5C `/reject` `501` stub (`intake_review.py`) with the real terminal transition `review_claimed → rejected`. Reviewers can now dispose of garbage / NO_MATCH proposals — in **both** 5B and 5C (it is not gated by the writer flag).

## Design (operator-confirmed 2026-06-06)

- **NOT flag-gated.** `/reject` writes ONLY the proposal status + clears the lease — no `documents`/`practices` (no CRM PII). It is a queue-management op like `claim`/`release` (also un-gated), not a CRM write like `approve`. Gating it would let junk proposals pile up as undisposable `review_claimed` rows until go-live.
- **No `intake_commit_audit` row.** That table is the CRM-commit forensic log (`doc_id`/`practice_id`/`plan`-shaped). A rejection is fully recorded by the proposal's own terminal `status='rejected'` + lease history. Keeps the Stage-3 go-live observation query (`failed`/`blocked` = anomaly) clean.
- **No migration.** `'rejected'` is already in `chk_rp_status` (mig 212); `chk_ica_outcome` untouched.

## Implementation

- Extracted the P0#5 claim/lease guard from `approve_review` into module-level `_require_active_claim(...)` — approve now calls it (byte-identical), reject enforces the identical rule without drift.
- `reject_review`: `SELECT ... FOR UPDATE` → `_require_active_claim` → `UPDATE ... SET status='rejected'` + clear lease `WHERE status='review_claimed'` (guarded → concurrent loser / re-reject = 409 no-op). Body `{claim_token?, reason?}`; `reason` logged (truncated), not persisted.
- Removed now-orphan `_WRITER_DISABLED_DETAIL`.

## Verification

`backend/tests/routers/test_intake_review.py` + `test_intake_writer.py` → **29 passed, 0 failed** on real `nuzantara_dev` (Pro), **not skipped**. 7 new reject tests (transitions / clears-lease-not-reclaimable / requires-claim-409 / non-admin-token 400-403-200 / idempotent-noop / writes-no-crm-rows incl. 0 audit rows / not-flag-gated) + the refactored approve + the 11 writer-suite tests (regression intact). Removed `test_reject_stub_501`.

Part of the FASE 5C go-live (writer #1145 merged). Runbook update is a separate PR (#1144).

🤖 Generated with [Claude Code](https://claude.com/claude-code)