### PR TITLE
chore(security): remove hardcoded Tigris creds from fly-qdrant-backup.sh

### DIFF
--- a/scripts/fly-qdrant-backup.sh
+++ b/scripts/fly-qdrant-backup.sh
@@ -25,8 +25,8 @@ fi
 # Tigris credentials (same as pg backup)
 TIGRIS_ENDPOINT="https://fly.storage.tigris.dev"
 TIGRIS_BUCKET="nuzantara-backups"
-TIGRIS_KEY="${AWS_ACCESS_KEY_ID:-tid_sZQYyrgouAXAdQDuvsfPlLIIUMMvEDNhfMWmzCdeouELsPMn_U}"
-TIGRIS_SECRET="${AWS_SECRET_ACCESS_KEY:-tsec_5knItu7FoHkkv2P5qaEMSRdHxXDNb6ZD0+mgDfLsLF-lLntRwDUgrH4qmzhJX+3OI4XYTc}"
+TIGRIS_KEY="${AWS_ACCESS_KEY_ID:?Missing AWS_ACCESS_KEY_ID - source ~/.nuzantara-secrets.env; Tigris creds are not hardcoded, rotate via Fly Tigris dashboard}"
+TIGRIS_SECRET="${AWS_SECRET_ACCESS_KEY:?Missing AWS_SECRET_ACCESS_KEY - source ~/.nuzantara-secrets.env}"
 
 # Telegram alert (optional)
 TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN:-}"


### PR DESCRIPTION
## What
Removes the only plaintext copy of the Tigris access key (`tid_…`/`tsec_…`), which lived as a shell default fallback in `scripts/fly-qdrant-backup.sh:28-29`. Replaced with a `:?` hard-fail.

## Why it's safe
Investigation confirmed the cron runs the **HOME copy** (`~/scripts/fly-qdrant-backup.sh`), which already sources `~/.nuzantara-secrets.env` and has no literal. This repo file is **dead code at runtime** — removing the fallback breaks no scheduled job.

## Scope / honesty
This stops *new* exposure (committed source + Drive mirror). It does **NOT** invalidate the already-exposed key — that needs a new key generated in the **Fly Tigris dashboard**, then propagated to `~/.nuzantara-secrets.env` + Fly app secrets (`nuzantara-rag`, `nuzantara-postgres`) + GH secrets `TIGRIS_ACCESS_KEY_ID/SECRET`. Tracked as the remaining rotation step.

Discovered during the restore-drill loop closure (#1146).