### PR TITLE
fix(crm): redact phone in upsert-by-phone log (CodeQL HIGH PII)

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_clients.py
+++ b/apps/backend-rag/backend/app/routers/crm_clients.py
@@ -1147,10 +1147,11 @@ async def upsert_client_by_phone(
         logger.warning("upsert-by-phone: cache invalidation failed: %s", exc)
 
     if result.get("matched_count", 0) > 1:
+        # Do NOT log the phone (PII / UU PDP + log-injection: it's user-supplied).
+        # client_id + matched_count are non-PII DB integers and fully identify the row.
         logger.warning(
-            "upsert-by-phone: phone %s matched %s rows (shared number) — acted on id=%s; "
+            "upsert-by-phone: %s clients share a phone (acted on id=%s) — "
             "review for possible duplicate-client merge",
-            phone,
             result["matched_count"],
             result["client_id"],
         )


### PR DESCRIPTION
Follow-up to #1150. CodeQL flagged a **HIGH** (clear-text logging of sensitive information) + **MEDIUM** (log injection) at the shared-phone warning in `crm_clients.py` — it logged the raw user-supplied `phone_normalized` (PII / UU PDP scope).

Fix: drop the phone from the log line; `client_id` + `matched_count` (non-PII DB integers) fully identify the row for audit. Resolves both alerts.

The endpoint is flag-gated **OFF** (`WA_MIRROR_CRM_WRITE_ENABLED` default false) — this lands before activation, so no PII is ever logged in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)