### PR TITLE
feat(cc-setup): Law-2 egress guards + fleet-health DR (self-audit)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -299,6 +299,17 @@ env.production
 # Existing *.local patterns did NOT cover .local.tsv / .local.jsonl; this closes the leak.
 *.local.*
 research/personal/wa-corpus/
+# Client-PII research artifacts (named-client cases must NEVER reach cloud GitHub/Vercel).
+# Added 2026-06-05 after cc-setup self-audit found research/visa/clients/ un-ignored
+# holding a real client file (marc-buckner) one `git add -A` away from the cloud.
+research/*/clients/
+research/**/*-case.md
+research/**/*-guidance.html
+research/**/*-guidance.pdf
+
+# plist-snapshot DR mirror — lives ONLY on the chore/plist-snapshot-dr branch
+# (force-added there by plist_snapshot_dr.sh); ignored on every working branch.
+infra/launchagents/_snapshot-live/
 
 # ========================================
 # SECURITY FIXES (2026-01-11)
@@ -719,3 +730,4 @@ apps/mouth/scripts/output/
 # deploy worktree ff-only pull when untracked. Root-anchored so it does NOT
 # match vendor/evoskill/src/cache/ (tracked).
 /cache/
+apps/evaluator/.rag-eval-prod.env

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,34 @@
 echo "🔍 Running pre-commit hooks..."
 
+# ── OSINT / CLIENT-PII SOVEREIGNTY GATE (Symbiosis Law 2) ────────────────────
+# Added 2026-06-05 (cc-setup self-audit → research/operations/2026-06-05-claude-code-setup-self-audit.md).
+# HARD-BLOCKS committing named-client PII / OSINT research artifacts that
+# .gitignore may not catch. The repo Vercel-auto-deploys on push to main, so a
+# `git add -A` during sibling-race WIP churn would push client PII to the cloud
+# — a direct Law 2 breach (the audit found research/visa/clients/ un-ignored
+# holding a real client file, one `git add -A` from the cloud). First gate so it
+# fails fast before any other check. TDD: 12/12 incl. 2 false-positive guards.
+# Kill switch (sanitized/approved artifact ONLY): PII_GATE_ENFORCEMENT=false
+if [ "${PII_GATE_ENFORCEMENT:-true}" != "false" ]; then
+    PII_PATH_REGEX='(^|/)research/[^/]+/clients/|(^|/)[^/]*-case\.md$|(^|/)[^/]*-guidance\.(html|pdf)$|(^|/)DOSSIER_[^/]*\.md$|(^|/)OSINT-Nexus/'
+    PII_NUM='\b(npwp|nik|ktp)\b[[:space:]:#=.]*[0-9][0-9.\-]{5,}'
+    PII_PASS='passport[[:space:]]*(no\.?|number|#|:)[[:space:]:#=]*[A-Za-z0-9]{6,}'
+    PII_STAGED=$(git diff --cached --name-only --diff-filter=d | grep -EI "$PII_PATH_REGEX" || true)
+    PII_CONTENT=""
+    for f in $(git diff --cached --name-only --diff-filter=d | grep -Evi '\.(png|jpg|jpeg|pdf|gif|webp|zip|gz|bin)$' || true); do
+        git show ":$f" 2>/dev/null | grep -Eiq "$PII_NUM|$PII_PASS" && PII_CONTENT="$PII_CONTENT $f"
+    done
+    if [ -n "$PII_STAGED" ] || [ -n "$PII_CONTENT" ]; then
+        echo "❌ [Law-2 PII gate] BLOCKED: staged path/content looks like OSINT/client-PII:"
+        [ -n "$PII_STAGED" ] && echo "$PII_STAGED" | sed 's/^/    path: /'
+        [ -n "$PII_CONTENT" ] && echo "$PII_CONTENT" | tr ' ' '\n' | sed '/^$/d;s/^/    pii-content: /'
+        echo "   Symbiosis Law 2: OSINT/client data NEVER reaches cloud GitHub/Vercel."
+        echo "   Fix: add the path to .gitignore (sovereignty section) or move it out of the tree."
+        echo "   Allowlist (sanitized/published artifact ONLY): PII_GATE_ENFORCEMENT=false git commit ..."
+        exit 1
+    fi
+fi
+
 # ── Redis Lease Registry hot-zone check (SOTA wave 2026-05-24) ──────────────
 # Closes cicatrix family W40/W50/W51/W52 (concurrent agent sessions mutating
 # shared hot-zone paths: LaunchAgent wrappers, migrations_v2/*.sql, sentinel

--- a/infra/launchagents/chronic_failure_digest.py
+++ b/infra/launchagents/chronic_failure_digest.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+# chronic_failure_digest.py — weekly chronic-failure digest (W55 suppression-family fix)
+#
+# WHY THIS EXISTS
+#   `~/scripts/audit-launchd-daily.sh` alerts ONLY on a *delta* (new-since-yesterday
+#   unhealthy plists / hot-1h errors). A job that has been red for many consecutive
+#   days produces ZERO delta after day 1, so it silently drops off the daily radar
+#   — the exact W55 "suppression after first alert" failure family that masked the
+#   2026-05-25 evolver/deploy-puller 32h drift and the 6 stale ops worktrees (W62).
+#
+#   This digest is the COMPLEMENT: it re-reads the last N daily JSON snapshots,
+#   computes per-job CONSECUTIVE-day red streaks, cross-references the
+#   circuit-breaker registry (OPEN) + the dead-letter queue (TERMINAL), and emits
+#   ONE weekly Telegram message listing every job red for >= THRESHOLD days.
+#
+# READ-ONLY · NO LLM · PURE AGGREGATION.
+#   Reads:
+#     ~/logs/audit-launchd-daily-snapshots/YYYY-MM-DD.json   (audit snapshots)
+#     ~/.agent/decisions/circuit_breakers.json               (breaker registry)
+#     ~/.agent/decisions/dlq.json                            (dead-letter queue)
+#   Writes: nothing but its own stdout (launchd log) + one Telegram POST.
+#
+# Invoked by com.nuzantara.chronic-failure-digest.weekly.plist (Mon 08:30 WITA).
+#
+# Env knobs (all optional):
+#   CHRONIC_DIGEST_ENABLED   "true"/"false"  — kill switch (default true)
+#   CHRONIC_DIGEST_THRESHOLD int             — min consecutive red days (default 3)
+#   CHRONIC_DIGEST_WINDOW    int             — # of recent snapshots to scan (default 8)
+#   SNAPSHOT_DIR             path            — override snapshots dir (tests)
+#   STATE_DIR               path            — override ~/.agent/decisions (tests)
+#   TELEGRAM_BOT_TOKEN / TELEGRAM_OWNER_CHAT_ID — sourced by the .sh wrapper
+#   CHRONIC_DIGEST_DRY_RUN   "1"             — print digest, do NOT POST to Telegram
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+HOME = Path(os.environ.get("HOME", str(Path.home())))
+SNAPSHOT_DIR = Path(
+    os.environ.get("SNAPSHOT_DIR", HOME / "logs" / "audit-launchd-daily-snapshots")
+)
+STATE_DIR = Path(os.environ.get("STATE_DIR", HOME / ".agent" / "decisions"))
+CIRCUIT_BREAKERS = STATE_DIR / "circuit_breakers.json"
+DLQ = STATE_DIR / "dlq.json"
+
+THRESHOLD = int(os.environ.get("CHRONIC_DIGEST_THRESHOLD", "3"))
+WINDOW = int(os.environ.get("CHRONIC_DIGEST_WINDOW", "8"))
+DRY_RUN = os.environ.get("CHRONIC_DIGEST_DRY_RUN", "") in ("1", "true", "yes")
+
+# Breaker states that count as "still tripped" (defense-in-depth: anything not
+# explicitly healthy). CLOSED == healthy; everything else is a signal.
+BREAKER_TRIPPED_STATES = {"OPEN", "HALF_OPEN", "TERMINAL"}
+# DLQ statuses that count as a permanently-abandoned job.
+DLQ_DEAD_STATES = {"TERMINAL"}
+
+
+def log(msg: str) -> None:
+    print(f"[chronic-failure-digest] {msg}", flush=True)
+
+
+def load_json(path: Path):
+    try:
+        with path.open() as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return None
+    except Exception as e:  # noqa: BLE001 — corrupt file must not crash a watchdog
+        log(f"WARN: could not parse {path}: {e}")
+        return None
+
+
+def recent_snapshots(window: int) -> list[tuple[str, dict]]:
+    """Return up to `window` most-recent snapshots, OLDEST→NEWEST.
+
+    Each item is (date_str, parsed_json). Date is the file stem (YYYY-MM-DD),
+    which sorts lexicographically == chronologically.
+    """
+    if not SNAPSHOT_DIR.is_dir():
+        return []
+    files = sorted(SNAPSHOT_DIR.glob("*.json"))  # chronological by name
+    files = files[-window:]  # keep the most recent `window`
+    out: list[tuple[str, dict]] = []
+    for fp in files:
+        data = load_json(fp)
+        if isinstance(data, dict) and isinstance(data.get("rows"), list):
+            out.append((fp.stem, data))
+    return out
+
+
+# Diagnosis prefixes that constitute a genuine FAILED / NOT-LOADED / STALE
+# *operational* failure (vs. a config-shape smell). A diagnosis string looks like
+# "NONZERO_EXIT=1" / "STALE(last_activity=...)" / "NEVER_FIRED_OR_NOT_LOADED" /
+# "DEGRADING_RECENT=2 ...". We match on the leading token.
+FAILURE_DIAG_PREFIXES = (
+    "NONZERO_EXIT",
+    "NEVER_FIRED_OR_NOT_LOADED",
+    "STALE",
+    "DEGRADING_RECENT",
+)
+# A config smell the daily audit also flags as unhealthy, but which is NOT a
+# runtime FAILED/NOT-LOADED state. Reporting these chronically would just relist
+# the static plist-shape backlog every week — exactly the noise this digest must
+# avoid. A row that is unhealthy ONLY for this reason is not "red" here.
+CONFIG_SMELL_PREFIXES = (
+    "USES_LC_ANTIPATTERN",
+    "HISTORICAL_ERRORS",
+    "HIGH_NOISE",
+)
+
+
+def row_is_red(row: dict) -> bool:
+    """A job is RED for a day if the audit marked it FAILED / NOT-LOADED / STALE.
+
+    The daily audit's `healthy: false` is the entry gate (it folds STALE /
+    NONZERO_EXIT / NEVER_FIRED_OR_NOT_LOADED *and* config smells like
+    USES_LC_ANTIPATTERN into one boolean). For a *chronic-failure* digest we then
+    narrow to genuine operational failure signals and exclude rows that are
+    unhealthy ONLY for a static config smell — otherwise the weekly digest would
+    relist the whole plist-shape backlog (~15 lc-antipattern plists) every week
+    and bury the real chronic failures it exists to surface.
+
+    Red iff: not healthy AND (
+        a real recent stderr error  OR  a non-zero/IO/config exit code
+        OR  a failure-class diagnosis (NONZERO_EXIT / NOT_LOADED / STALE / DEGRADING)
+    ).
+    """
+    if row.get("healthy") is not False:
+        return False
+    # Real runtime stderr in the last 24h is unambiguous failure.
+    if int(row.get("stderr_real_recent_24h", 0) or 0) > 0:
+        return True
+    if int(row.get("stderr_real_hot_1h", 0) or 0) > 0:
+        return True
+    # Non-zero exit (sysexits like 74/75/78, or plain 1/2). "0" and the
+    # placeholders "(never exited)" / "—" / None are not failures here.
+    le = row.get("last_exit")
+    if isinstance(le, int) and le != 0:
+        return True
+    if isinstance(le, str) and le not in ("0", "(never exited)", "—", "None", ""):
+        return True
+    # Diagnosis-based failure (covers NOT-LOADED, STALE, DEGRADING even when the
+    # process left no stderr — e.g. a job that simply never fired / went stale).
+    diag = row.get("diagnosis") or []
+    has_failure = any(
+        str(d).startswith(FAILURE_DIAG_PREFIXES) for d in diag
+    )
+    return has_failure
+
+
+def last_error_line(row: dict) -> str:
+    """Best one-line error summary for a red job from a single snapshot row."""
+    sample = row.get("stderr_sample") or []
+    if sample:
+        # last non-empty line of the captured traceback/stderr tail
+        for line in reversed(sample):
+            line = (line or "").strip()
+            if line:
+                return line
+    diag = row.get("diagnosis") or []
+    if diag:
+        return "; ".join(str(d) for d in diag)
+    le = row.get("last_exit")
+    if le not in (None, "0", 0):
+        return f"last_exit={le}"
+    return "(no error line captured)"
+
+
+def compute_streaks(
+    snapshots: list[tuple[str, dict]],
+) -> dict[str, dict]:
+    """Consecutive red-day streak per job, anchored at the MOST RECENT snapshot.
+
+    We only report jobs that are red in the newest snapshot (an actively-broken
+    job), then count backwards how many consecutive prior days it was also red.
+    A healthy day OR an absence (job not in that day's snapshot) breaks the streak.
+    """
+    if not snapshots:
+        return {}
+
+    # Index each day's rows by label for O(1) lookup. Use `label` (stable id);
+    # fall back to `plist` when a row lacks a label.
+    def key(row: dict) -> str:
+        return row.get("label") or row.get("plist") or "(unknown)"
+
+    by_day: list[dict[str, dict]] = []
+    for _date, data in snapshots:
+        by_day.append({key(r): r for r in data["rows"]})
+
+    newest_date, newest_data = snapshots[-1]
+    newest_rows = by_day[-1]
+
+    results: dict[str, dict] = {}
+    for jk, newest_row in newest_rows.items():
+        if not row_is_red(newest_row):
+            continue
+        # Walk backwards from newest day, counting the unbroken red streak.
+        streak = 0
+        for day_rows in reversed(by_day):
+            r = day_rows.get(jk)
+            if r is not None and row_is_red(r):
+                streak += 1
+            else:
+                break  # healthy day or absent → streak ends
+        results[jk] = {
+            "label": jk,
+            "plist": newest_row.get("plist", jk),
+            "streak": streak,
+            "since_date": snapshots[-streak][0] if streak <= len(snapshots) else newest_date,
+            "diagnosis": newest_row.get("diagnosis") or [],
+            "last_error": last_error_line(newest_row),
+            "loaded": newest_row.get("loaded"),
+            "last_exit": newest_row.get("last_exit"),
+        }
+    return results
+
+
+def load_breakers() -> dict[str, str]:
+    """Map job-name → tripped breaker state (only non-CLOSED breakers)."""
+    data = load_json(CIRCUIT_BREAKERS)
+    out: dict[str, str] = {}
+    if isinstance(data, dict):
+        for name, rec in data.items():
+            if isinstance(rec, dict):
+                state = str(rec.get("state", "")).upper()
+                if state in BREAKER_TRIPPED_STATES:
+                    out[name] = state
+    return out
+
+
+def load_dlq_terminal() -> dict[str, str]:
+    """Map job-name → DLQ status for TERMINAL (permanently abandoned) jobs."""
+    data = load_json(DLQ)
+    out: dict[str, str] = {}
+    queue = []
+    if isinstance(data, dict):
+        queue = data.get("queue") or []
+    elif isinstance(data, list):
+        queue = data
+    for entry in queue:
+        if not isinstance(entry, dict):
+            continue
+        status = str(entry.get("status", "")).upper()
+        if status in DLQ_DEAD_STATES:
+            job = entry.get("job")
+            if job:
+                out[str(job)] = status
+    return out
+
+
+def _norm(s: str) -> str:
+    """Loosely normalise a label/plist/job-name for cross-source matching.
+
+    Snapshots use plist labels like 'com.balizero.fly-pg-backup'; the breaker /
+    DLQ registries use short names like 'fly_pg_backup'. Normalise both to a bag
+    of alnum tokens so we can substring-match the short name inside the label.
+    """
+    return s.lower().replace(".", " ").replace("-", " ").replace("_", " ").strip()
+
+
+def cross_ref(job_label: str, plist: str, registry: dict[str, str]) -> str | None:
+    """Return the registry state if any registry key matches this job, else None."""
+    hay = f"{_norm(job_label)} {_norm(plist)}"
+    hay_tokens = set(hay.split())
+    for name, state in registry.items():
+        ntoks = set(_norm(name).split())
+        if ntoks and ntoks.issubset(hay_tokens):
+            return state
+        # also allow the compact form to appear as a contiguous substring
+        if _norm(name).replace(" ", "") in hay.replace(" ", ""):
+            return state
+    return None
+
+
+def build_digest(threshold: int, window: int):
+    snapshots = recent_snapshots(window)
+    if not snapshots:
+        log(f"no snapshots found under {SNAPSHOT_DIR}; nothing to do")
+        return None, []
+
+    streaks = compute_streaks(snapshots)
+    breakers = load_breakers()
+    dlq_terminal = load_dlq_terminal()
+
+    chronic = [v for v in streaks.values() if v["streak"] >= threshold]
+    chronic.sort(key=lambda x: -x["streak"])
+
+    span = f"{snapshots[0][0]}..{snapshots[-1][0]} ({len(snapshots)} snapshots)"
+
+    if not chronic:
+        log(f"clean: 0 jobs red >= {threshold} consecutive days over {span}")
+        return None, []
+
+    lines = []
+    lines.append("\U0001F4C9 *Chronic failure digest (weekly)*")
+    lines.append(f"Window: {span} · threshold: >= {threshold} consecutive red days")
+    lines.append("")
+    for item in chronic:
+        tags = []
+        bstate = cross_ref(item["label"], item["plist"], breakers)
+        if bstate:
+            tags.append(f"breaker={bstate}")
+        dstate = cross_ref(item["label"], item["plist"], dlq_terminal)
+        if dstate:
+            tags.append(f"dlq={dstate}")
+        tag_str = f" [{', '.join(tags)}]" if tags else ""
+        err = item["last_error"]
+        if len(err) > 200:
+            err = err[:197] + "..."
+        lines.append(
+            f"• *{item['plist']}* — RED {item['streak']}d "
+            f"(since {item['since_date']}){tag_str}\n"
+            f"  ↳ {err}"
+        )
+    lines.append("")
+    lines.append(
+        f"_{len(chronic)} chronic job(s). Complements the daily delta audit "
+        f"(this catches steady-state red the daily alert suppresses — W55 family)._"
+    )
+    return "\n".join(lines), chronic
+
+
+def send_telegram(message: str) -> bool:
+    token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+    chat = os.environ.get("TELEGRAM_OWNER_CHAT_ID", "")
+    if not token or not chat:
+        log("WARN: TELEGRAM_BOT_TOKEN/TELEGRAM_OWNER_CHAT_ID missing; skipping POST")
+        return False
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    payload = urllib.parse.urlencode(
+        {"chat_id": chat, "text": message, "parse_mode": "Markdown"}
+    ).encode()
+    try:
+        req = urllib.request.Request(url, data=payload, method="POST")
+        with urllib.request.urlopen(req, timeout=15) as resp:  # noqa: S310
+            ok = 200 <= resp.status < 300
+        log(f"telegram POST status ok={ok} chat={chat}")
+        return ok
+    except Exception as e:  # noqa: BLE001 — alert delivery must never crash the cron
+        log(f"WARN: telegram POST failed: {e}")
+        return False
+
+
+def main() -> int:
+    if os.environ.get("CHRONIC_DIGEST_ENABLED", "true").lower() in ("0", "false", "no"):
+        log("disabled via CHRONIC_DIGEST_ENABLED; exiting 0")
+        return 0
+
+    message, chronic = build_digest(THRESHOLD, WINDOW)
+    if not message:
+        return 0  # clean week or no data — stay silent (digest, not heartbeat)
+
+    log(f"{len(chronic)} chronic job(s) >= {THRESHOLD}d red")
+    print(message)  # always emit to launchd stdout log for audit trail
+
+    if DRY_RUN:
+        log("dry-run: not sending Telegram")
+        return 0
+
+    send_telegram(message)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infra/launchagents/chronic_failure_digest.sh
+++ b/infra/launchagents/chronic_failure_digest.sh
@@ -1,0 +1,33 @@
+#!/bin/zsh
+# chronic_failure_digest.sh — wrapper for the weekly chronic-failure digest.
+#
+# Sources Telegram secrets the same way ~/scripts/audit-launchd-daily.sh does
+# (from ~/.nuzantara-secrets.env), then runs the pure-aggregation Python digest.
+# Invoked by com.nuzantara.chronic-failure-digest.weekly.plist (Mon 08:30 WITA).
+#
+# READ-ONLY: reads daily audit snapshots + circuit_breakers.json + dlq.json,
+# emits ONE Telegram digest of jobs red >= THRESHOLD consecutive days. No LLM,
+# no mutation of any state file. Complements the daily delta-only audit
+# (closes the W55 suppression gap where steady-state red drops off the radar).
+
+set -uo pipefail
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+REPO_ROOT="${REPO_ROOT:-/Users/nuzantara/Desktop/nuzantara}"
+DIGEST_SCRIPT="$REPO_ROOT/infra/launchagents/chronic_failure_digest.py"
+
+# Source Telegram secrets (TELEGRAM_BOT_TOKEN / TELEGRAM_OWNER_CHAT_ID).
+if [[ -f "$HOME/.nuzantara-secrets.env" ]]; then
+    # shellcheck disable=SC1091
+    set -a; source "$HOME/.nuzantara-secrets.env"; set +a
+fi
+
+# Sensible default chat id matches the rest of the fleet (Zero's owner chat).
+export TELEGRAM_OWNER_CHAT_ID="${TELEGRAM_OWNER_CHAT_ID:-1125336968}"
+
+if [[ ! -f "$DIGEST_SCRIPT" ]]; then
+    echo "[chronic-failure-digest] FATAL: $DIGEST_SCRIPT missing" >&2
+    exit 66
+fi
+
+exec python3 "$DIGEST_SCRIPT"

--- a/infra/launchagents/com.nuzantara.chronic-failure-digest.weekly.plist
+++ b/infra/launchagents/com.nuzantara.chronic-failure-digest.weekly.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.nuzantara.chronic-failure-digest.weekly</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/zsh</string>
+        <string>/Users/nuzantara/Desktop/nuzantara/infra/launchagents/chronic_failure_digest.sh</string>
+    </array>
+
+    <!-- Monday 08:30 WITA (every week) — 30min after the branch-cleanup weekly,
+         so the operator gets the chronic-failure digest in the same Monday batch.
+         Reads the last N daily audit snapshots; the daily audit runs 02:00. -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key>
+        <integer>1</integer>
+        <key>Hour</key>
+        <integer>8</integer>
+        <key>Minute</key>
+        <integer>30</integer>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>KeepAlive</key>
+    <false/>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <key>REPO_ROOT</key>
+        <string>/Users/nuzantara/Desktop/nuzantara</string>
+        <key>CHRONIC_DIGEST_ENABLED</key>
+        <string>true</string>
+        <!-- Min consecutive RED days before a job is reported (default 3). -->
+        <key>CHRONIC_DIGEST_THRESHOLD</key>
+        <string>3</string>
+        <!-- Number of recent daily snapshots to scan (default 8 = ~1 week + 1). -->
+        <key>CHRONIC_DIGEST_WINDOW</key>
+        <string>8</string>
+    </dict>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/nuzantara/Desktop/nuzantara</string>
+
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/chronic-failure-digest.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/chronic-failure-digest.error.log</string>
+</dict>
+</plist>

--- a/infra/launchagents/com.nuzantara.plist-snapshot.daily.plist
+++ b/infra/launchagents/com.nuzantara.plist-snapshot.daily.plist
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Daily disaster-recovery snapshot of live LaunchAgent plists (Pro).
+Cicatrix lineage: 2026-04-29 "Unknown agent overwrites loaded LaunchAgent plist
+files" (51/54 truncated, no git copy to restore from) + W65 plist-secret leak.
+
+Runs scripts/../infra/launchagents/plist_snapshot_dr.sh:
+  - mirrors loaded com.{nuzantara,balizero,cell,matagaruda}.* plists into
+    infra/launchagents/_snapshot-live/ with all secret-like values REDACTED,
+  - plutil-lints + independently grep-verifies no secret survived,
+  - commits the redacted mirror to branch chore/plist-snapshot-dr,
+  - Telegram delta line per changed plist.
+
+Schedule: daily 03:30 WITA (19:30 UTC prev day) on Pro — 30min after the
+log-prune (03:00) so it snapshots a quiet, settled LaunchAgents dir.
+
+Install (Pro):
+    bash infra/launchagents/install_plist_snapshot.sh
+  (or manually:)
+    cp infra/launchagents/com.nuzantara.plist-snapshot.daily.plist \
+       ~/Library/LaunchAgents/com.nuzantara.plist-snapshot.daily.plist
+    launchctl bootstrap gui/$(id -u) \
+       ~/Library/LaunchAgents/com.nuzantara.plist-snapshot.daily.plist
+
+Kill switch (without removing plist):
+    launchctl setenv PLIST_SNAPSHOT_ENABLED false
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.nuzantara.plist-snapshot.daily</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/nuzantara/Desktop/nuzantara/infra/launchagents/plist_snapshot_dr.sh</string>
+    </array>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>19</integer>
+        <key>Minute</key>
+        <integer>30</integer>
+    </dict>
+    <!-- 19:30 UTC = 03:30 WITA (30min after com.nuzantara.log-prune.daily) -->
+
+    <key>WorkingDirectory</key>
+    <string>/Users/nuzantara/Desktop/nuzantara</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PLIST_SNAPSHOT_ENABLED</key>
+        <string>true</string>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/plist-snapshot.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/plist-snapshot.error.log</string>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>KeepAlive</key>
+    <false/>
+</dict>
+</plist>

--- a/infra/launchagents/install_chronic_failure_digest.sh
+++ b/infra/launchagents/install_chronic_failure_digest.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# install_chronic_failure_digest.sh
+#
+# Install (or reload) the weekly chronic-failure digest LaunchAgent.
+# Complements ~/scripts/audit-launchd-daily.sh: the daily audit alerts only on a
+# *delta* (new-since-yesterday), so a job red for many consecutive days drops off
+# the radar after day 1 (W55 suppression family). This digest re-reads the last N
+# daily JSON snapshots, computes per-job consecutive-red streaks, cross-references
+# circuit_breakers.json + dlq.json, and emits ONE weekly Telegram digest.
+#
+# Usage:
+#   bash infra/launchagents/install_chronic_failure_digest.sh
+#   bash infra/launchagents/install_chronic_failure_digest.sh --uninstall
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLIST_SRC_DIR="$REPO_ROOT/infra/launchagents"
+PLIST_DEST_DIR="$HOME/Library/LaunchAgents"
+LOG_DIR="$HOME/logs"
+UID_VAL="$(id -u)"
+
+LABEL="com.nuzantara.chronic-failure-digest.weekly"
+
+MODE="${1:-install}"
+
+mkdir -p "$PLIST_DEST_DIR" "$LOG_DIR"
+
+bootout() {
+    local label="$1"
+    if launchctl print "gui/$UID_VAL/$label" >/dev/null 2>&1; then
+        echo "[install_chronic_failure_digest] booting out $label"
+        launchctl bootout "gui/$UID_VAL/$label" 2>&1 | grep -v "Boot-out failed" || true
+    fi
+}
+
+bootstrap() {
+    local label="$1"
+    local plist="$PLIST_DEST_DIR/$label.plist"
+    if [[ ! -f "$plist" ]]; then
+        echo "[install_chronic_failure_digest] WARN: $plist missing"
+        return 1
+    fi
+    if ! plutil -lint "$plist" >/dev/null 2>&1; then
+        echo "[install_chronic_failure_digest] FATAL: $plist plutil lint failed"
+        plutil -lint "$plist"
+        return 1
+    fi
+    echo "[install_chronic_failure_digest] bootstrapping $label"
+    launchctl bootstrap "gui/$UID_VAL" "$plist"
+}
+
+case "$MODE" in
+    install)
+        src="$PLIST_SRC_DIR/$LABEL.plist"
+        dest="$PLIST_DEST_DIR/$LABEL.plist"
+        wrapper="$PLIST_SRC_DIR/chronic_failure_digest.sh"
+        digest="$PLIST_SRC_DIR/chronic_failure_digest.py"
+
+        if [[ ! -f "$src" ]]; then
+            echo "[install_chronic_failure_digest] FATAL: source plist missing: $src" >&2
+            exit 1
+        fi
+        if [[ ! -f "$wrapper" || ! -f "$digest" ]]; then
+            echo "[install_chronic_failure_digest] FATAL: digest scripts missing in $PLIST_SRC_DIR" >&2
+            exit 1
+        fi
+
+        # Ensure the runner scripts are executable.
+        chmod +x "$wrapper" "$digest" 2>/dev/null || true
+
+        # Backup existing dest plist if present.
+        if [[ -f "$dest" ]]; then
+            bak="$dest.pre-install-$(date +%Y%m%d-%H%M%S)"
+            chmod u+w "$dest" 2>/dev/null || true
+            cp "$dest" "$bak"
+            chmod 0400 "$bak" 2>/dev/null || true   # hardening: backups not world-readable (W65)
+            echo "[install_chronic_failure_digest] backed up existing → $bak"
+        fi
+
+        bootout "$LABEL"
+        cp "$src" "$dest"
+        chmod 0644 "$dest"
+        echo "[install_chronic_failure_digest] copied $src → $dest"
+
+        bootstrap "$LABEL"
+        launchctl print "gui/$UID_VAL/$LABEL" 2>/dev/null \
+            | grep -E "state|last exit code|program" | head -5 \
+            || echo "[install_chronic_failure_digest] WARN: $LABEL not visible after bootstrap"
+        echo ""
+        echo "[install_chronic_failure_digest] install complete."
+        echo "Schedule: Monday 08:30 WITA (weekly)."
+        echo "Logs:"
+        echo "  - $LOG_DIR/chronic-failure-digest.log"
+        echo "  - $LOG_DIR/chronic-failure-digest.error.log"
+        echo "Smoke test (no Telegram POST):"
+        echo "  CHRONIC_DIGEST_DRY_RUN=1 python3 $digest"
+        ;;
+    --uninstall|uninstall)
+        bootout "$LABEL"
+        dest="$PLIST_DEST_DIR/$LABEL.plist"
+        if [[ -f "$dest" ]]; then
+            chmod u+w "$dest" 2>/dev/null || true
+            rm -f "$dest"
+            echo "[install_chronic_failure_digest] removed $dest"
+        fi
+        echo "[install_chronic_failure_digest] uninstall complete."
+        ;;
+    *)
+        echo "Usage: $0 [install|--uninstall]" >&2
+        exit 64
+        ;;
+esac
+
+exit 0

--- a/infra/launchagents/install_plist_snapshot.sh
+++ b/infra/launchagents/install_plist_snapshot.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# install_plist_snapshot.sh — plist disaster-recovery snapshot installer.
+#
+# Installs (or reloads) the daily LaunchAgent that mirrors every loaded
+# com.{nuzantara,balizero,cell,matagaruda}.* plist into
+# infra/launchagents/_snapshot-live/ with secrets REDACTED, lint+grep-verified,
+# and committed to a dedicated DR branch.
+#
+# Cicatrix lineage: 2026-04-29 plist-truncation P0 (51/54 lost, no git copy) +
+# W65 plist-secret leak. This installer DOES NOT run the snapshot — it only
+# bootstraps the cron. The script itself is the deliverable.
+#
+# Usage:
+#   bash infra/launchagents/install_plist_snapshot.sh
+#   bash infra/launchagents/install_plist_snapshot.sh --uninstall
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLIST_SRC_DIR="$REPO_ROOT/infra/launchagents"
+PLIST_DEST_DIR="$HOME/Library/LaunchAgents"
+LOG_DIR="$HOME/logs"
+UID_VAL="$(id -u)"
+
+LABEL="com.nuzantara.plist-snapshot.daily"
+SRC="$PLIST_SRC_DIR/$LABEL.plist"
+DEST="$PLIST_DEST_DIR/$LABEL.plist"
+SNAPSHOT_SH="$PLIST_SRC_DIR/plist_snapshot_dr.sh"
+
+MODE="${1:-install}"
+
+mkdir -p "$PLIST_DEST_DIR" "$LOG_DIR"
+
+bootout() {
+    if launchctl print "gui/$UID_VAL/$LABEL" >/dev/null 2>&1; then
+        echo "[install] booting out $LABEL"
+        launchctl bootout "gui/$UID_VAL/$LABEL" 2>&1 | grep -v "Boot-out failed" || true
+    fi
+}
+
+case "$MODE" in
+    install)
+        if [[ ! -f "$SRC" ]]; then
+            echo "[install] FATAL: source plist missing: $SRC" >&2
+            exit 1
+        fi
+        # The snapshot script must be present + executable before bootstrap.
+        if [[ ! -f "$SNAPSHOT_SH" ]]; then
+            echo "[install] FATAL: snapshot script missing: $SNAPSHOT_SH" >&2
+            exit 1
+        fi
+        chmod 0755 "$SNAPSHOT_SH"
+        echo "[install] chmod 0755 $SNAPSHOT_SH"
+
+        # Backup existing dest if any.
+        if [[ -f "$DEST" ]]; then
+            bak="$DEST.pre-install-$(date +%Y%m%d-%H%M%S)"
+            chmod u+w "$DEST" 2>/dev/null || true
+            cp "$DEST" "$bak"
+            # The backup carries no secret (this plist has none), but harden it
+            # anyway per W65 ("hardening leaked its own backup").
+            chmod 0644 "$bak"
+            echo "[install] backed up existing → $bak"
+        fi
+
+        bootout
+
+        # Copy + mode 0644 (no secrets in THIS plist; the snapshot it produces
+        # is redacted, so no secret ever lands on disk world-readable).
+        cp "$SRC" "$DEST"
+        chmod 0644 "$DEST"
+        echo "[install] copied $SRC → $DEST"
+
+        if ! plutil -lint "$DEST" >/dev/null 2>&1; then
+            echo "[install] FATAL: $DEST plutil lint failed"
+            plutil -lint "$DEST"
+            exit 1
+        fi
+
+        echo "[install] bootstrapping $LABEL"
+        launchctl bootstrap "gui/$UID_VAL" "$DEST"
+
+        launchctl print "gui/$UID_VAL/$LABEL" 2>/dev/null \
+            | grep -E "state|last exit code|program" | head -5 \
+            || echo "[install] WARN: $LABEL not visible after bootstrap"
+
+        echo ""
+        echo "[install] install complete."
+        echo "Logs:"
+        echo "  - $LOG_DIR/plist-snapshot.log"
+        echo "  - $LOG_DIR/plist-snapshot.error.log"
+        echo ""
+        echo "Smoke test (no git, redaction + lint + leak-verify only):"
+        echo "  PLIST_SNAPSHOT_DRY_RUN=true bash $SNAPSHOT_SH"
+        echo ""
+        echo "Kill switch:"
+        echo "  launchctl setenv PLIST_SNAPSHOT_ENABLED false"
+        ;;
+    --uninstall|uninstall)
+        bootout
+        if [[ -f "$DEST" ]]; then
+            chmod u+w "$DEST" 2>/dev/null || true
+            rm -f "$DEST"
+            echo "[install] removed $DEST"
+        fi
+        echo "[install] uninstall complete."
+        ;;
+    *)
+        echo "Usage: $0 [install|--uninstall]" >&2
+        exit 64
+        ;;
+esac
+
+exit 0

--- a/infra/launchagents/plist_snapshot_dr.sh
+++ b/infra/launchagents/plist_snapshot_dr.sh
@@ -107,7 +107,7 @@ REDACTED = "REDACTED"
 # Value-based redaction (defense layer 2): a VALUE that looks like a secret is
 # redacted regardless of its key name. Closes the gap where keys like
 # WA_DASHBOARD_DATABASE_URL / *_REDIS_URL (end in URL, not TOKEN/KEY) carry an
-# inline password (postgres://u:pass@h). Specific shapes only — NOT bare hex
+# inline password (postgres://u:pass@h). Specific shapes only — NOT bare hex  # pragma: allowlist secret
 # (would over-redact git shas). Sub-redacts only the secret span, preserving the
 # rest (host/command) for DR usefulness.
 VALUE_SECRET_RE = re.compile(

--- a/infra/launchagents/plist_snapshot_dr.sh
+++ b/infra/launchagents/plist_snapshot_dr.sh
@@ -1,0 +1,352 @@
+#!/bin/bash
+# plist_snapshot_dr.sh — daily disaster-recovery snapshot of live LaunchAgent plists.
+#
+# WHY (cicatrix lineage):
+#   - 2026-04-29 "Unknown agent overwrites loaded LaunchAgent plist files" P0:
+#     51/54 plist truncated on disk; only launchd's cached boot config saved us.
+#     A reboot would have lost 51 services. We had NO git copy to restore from.
+#   - 2026-04-29 "53 LaunchAgents, only 13% KeepAlive" + secrets leaked 0644.
+#   - W65 (2026-06-02): a hardening backup leaked a 64-hex API key world-readable.
+#   This script keeps a REDACTED, git-tracked mirror of every loaded plist so a
+#   future corruption/loss event is recoverable from version control — WITHOUT
+#   ever committing a live secret (Symbiosis Law 2 + the no-secret-in-git rule).
+#
+# WHAT IT DOES:
+#   1. Copies every loaded com.{nuzantara,balizero,cell,matagaruda}.* plist from
+#      ~/Library/LaunchAgents into infra/launchagents/_snapshot-live/.
+#   2. BEFORE writing each, REDACTS secret values: any <key> whose name matches
+#      the secret pattern has its following <string>VALUE</string> replaced with
+#      <string>REDACTED</string>. Done structurally (plistlib) AND textually
+#      (line scan) — defense in depth.
+#   3. Validates every output file with `plutil -lint`.
+#   4. HARD-VERIFIES the snapshot: an independent grep over _snapshot-live/ that
+#      ABORTS the commit if any secret-shaped value survived redaction. No secret
+#      may ever reach git. (Anti-hallucination rule #2: verify with a second,
+#      independent pass — never trust the redactor's own report.)
+#   5. git add + commit on a dedicated branch (this script runs as cron later).
+#   6. Emits a Telegram delta line per plist that differs from the previous
+#      snapshot, reusing the repo's _telegram() pattern (wr2_plist_watchdog.sh).
+#
+# Designed to be invoked from com.nuzantara.plist-snapshot.daily.plist, OR
+# manually. Idempotent. Safe to run unconditionally.
+#
+#   Kill switch:  PLIST_SNAPSHOT_ENABLED=false (env or `launchctl setenv`)
+#   Dry run:      PLIST_SNAPSHOT_DRY_RUN=true   (redact + lint + verify, NO git)
+#
+# Usage:
+#   bash infra/launchagents/plist_snapshot_dr.sh
+#   PLIST_SNAPSHOT_DRY_RUN=true bash infra/launchagents/plist_snapshot_dr.sh
+
+set -uo pipefail
+
+# ── Kill switch ────────────────────────────────────────────────────────────
+if [[ "${PLIST_SNAPSHOT_ENABLED:-true}" == "false" ]]; then
+    echo "[plist-snapshot] disabled via PLIST_SNAPSHOT_ENABLED=false — exit 0"
+    exit 0
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SRC_DIR="${HOME}/Library/LaunchAgents"
+SNAP_DIR="${REPO_ROOT}/infra/launchagents/_snapshot-live"
+LOG_DIR="${HOME}/logs"
+SECRETS_FILE="${HOME}/.nuzantara-secrets.env"
+BRANCH="chore/plist-snapshot-dr"
+DRY_RUN="${PLIST_SNAPSHOT_DRY_RUN:-false}"
+
+# Secret-key regex (anchored, case-insensitive). A <key> name matching this →
+# its following <string> value is replaced with REDACTED.
+SECRET_KEY_RE='(^|.*_)(API_KEY|TOKEN|KEY|SECRET|PASSWORD)$|^TELEGRAM_.*|^FLY_API_TOKEN$'
+
+mkdir -p "${SNAP_DIR}" "${LOG_DIR}"
+
+# Pull TELEGRAM_BOT_TOKEN / chat id from the secrets file (not committed).
+if [[ -f "${SECRETS_FILE}" ]]; then
+    # shellcheck disable=SC1090
+    set -a
+    source "${SECRETS_FILE}"
+    set +a
+fi
+
+# ── Telegram helper (reused from wr2_plist_watchdog.sh) ──────────────────────
+_telegram() {
+    local text="$1"
+    local token="${TELEGRAM_BOT_TOKEN:-}"
+    local chat="${TELEGRAM_OWNER_CHAT_ID:-1125336968}"
+    if [[ -z "${token}" ]]; then
+        return 0
+    fi
+    curl -fsS -m 10 \
+        --data-urlencode "chat_id=${chat}" \
+        --data-urlencode "text=${text}" \
+        "https://api.telegram.org/bot${token}/sendMessage" \
+        >/dev/null 2>&1 || true
+}
+
+NOW_ISO="$(date -u +%FT%TZ)"
+echo "[plist-snapshot] ${NOW_ISO} start (repo=${REPO_ROOT})"
+
+if [[ ! -d "${SRC_DIR}" ]]; then
+    echo "[plist-snapshot] FATAL: source dir missing: ${SRC_DIR}" >&2
+    exit 1
+fi
+
+# ── 1+2+3: copy + redact + lint each loaded plist ────────────────────────────
+# The heavy lifting (XML-aware redaction + lint + delta) is done in Python:
+# bash regex over plist XML is fragile and the W65 scar is precisely a botched
+# redaction. Python returns a machine-readable summary on stdout.
+REDACT_SUMMARY="$(
+SECRET_KEY_RE="${SECRET_KEY_RE}" SRC_DIR="${SRC_DIR}" SNAP_DIR="${SNAP_DIR}" \
+python3 - <<'PY'
+import os, re, glob, plistlib, subprocess, sys
+
+SRC_DIR  = os.environ["SRC_DIR"]
+SNAP_DIR = os.environ["SNAP_DIR"]
+SECRET_RE = re.compile(os.environ["SECRET_KEY_RE"], re.IGNORECASE)
+REDACTED = "REDACTED"
+
+# Value-based redaction (defense layer 2): a VALUE that looks like a secret is
+# redacted regardless of its key name. Closes the gap where keys like
+# WA_DASHBOARD_DATABASE_URL / *_REDIS_URL (end in URL, not TOKEN/KEY) carry an
+# inline password (postgres://u:pass@h). Specific shapes only — NOT bare hex
+# (would over-redact git shas). Sub-redacts only the secret span, preserving the
+# rest (host/command) for DR usefulness.
+VALUE_SECRET_RE = re.compile(
+    r"://[^:/\s]+:[^@\s]{3,}@"                 # user:password@ in any URI
+    r"|\b[0-9]{6,}:[A-Za-z0-9_-]{30,}\b"      # telegram bot token
+    r"|\bghp_[A-Za-z0-9]{20,}\b|\bgithub_pat_[A-Za-z0-9_]{30,}\b"  # GitHub PAT
+    r"|FlyV1\s+[A-Za-z0-9_=-]{10,}|\bfm2_[A-Za-z0-9_=-]{10,}\b"    # Fly tokens
+    r"|\bxox[baprs]-[A-Za-z0-9-]{10,}\b"      # Slack
+    r"|\bsk-[A-Za-z0-9]{20,}\b"               # OpenAI-style
+    r"|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{6,}",  # JWT
+)
+
+PREFIXES = ("com.nuzantara.", "com.balizero.", "com.cell.", "com.matagaruda.")
+
+def is_loaded(label: str) -> bool:
+    # Only snapshot plists launchd actually knows about (the 2026-04-29 producer
+    # only touched loaded services; an unloaded canary on disk is noise).
+    uid = os.getuid()
+    r = subprocess.run(
+        ["launchctl", "print", f"gui/{uid}/{label}"],
+        capture_output=True,
+    )
+    return r.returncode == 0
+
+def redact_obj(obj):
+    """Walk parsed plist; redact a value whose KEY matches SECRET_RE (whole value)
+    OR whose string content matches VALUE_SECRET_RE (secret span only). The latter
+    also covers secrets sitting inline in a ProgramArguments list."""
+    if isinstance(obj, dict):
+        out = {}
+        for k, v in obj.items():
+            if isinstance(k, str) and SECRET_RE.search(k) and isinstance(v, (str, int, float, bytes)):
+                out[k] = REDACTED
+            else:
+                out[k] = redact_obj(v)
+        return out
+    if isinstance(obj, list):
+        return [redact_obj(x) for x in obj]
+    if isinstance(obj, str):
+        return VALUE_SECRET_RE.sub(REDACTED, obj)
+    return obj
+
+def redact_text_fallback(xml: str) -> str:
+    """Textual defense-in-depth: <key>SECRET</key>\\n<string>v</string> →
+    <string>REDACTED</string>. Catches keys the structured pass can't reach
+    (e.g. inside an inline shell <string> ProgramArguments block)."""
+    def repl(m):
+        keyname = m.group("k")
+        if SECRET_RE.search(keyname):
+            return f"<key>{m.group('k')}</key>{m.group('gap')}<string>{REDACTED}</string>"
+        return m.group(0)
+    pat = re.compile(
+        r"<key>(?P<k>[^<]+)</key>(?P<gap>\s*)<string>(?P<v>.*?)</string>",
+        re.DOTALL,
+    )
+    out = pat.sub(repl, xml)
+    # Value-based layer: redact any secret-shaped span anywhere (covers inline
+    # ProgramArguments secrets the key-adjacent pattern cannot reach).
+    out = VALUE_SECRET_RE.sub(REDACTED, out)
+    return out
+
+results = []   # (label, status, changed_vs_prev)
+errors  = []
+
+candidates = []
+for pref in PREFIXES:
+    candidates.extend(glob.glob(os.path.join(SRC_DIR, pref + "*.plist")))
+# Exclude .bak* and non-plist siblings; glob already restricts to *.plist.
+candidates = sorted(set(candidates))
+
+for src in candidates:
+    base = os.path.basename(src)            # com.x.y.plist
+    label = base[:-len(".plist")]
+    if not is_loaded(label):
+        results.append((label, "SKIP_UNLOADED", False))
+        continue
+
+    dest = os.path.join(SNAP_DIR, base)
+    try:
+        with open(src, "rb") as fh:
+            raw = fh.read()
+        parsed = plistlib.loads(raw)
+        red = redact_obj(parsed)
+        # Re-serialize from the redacted structure (canonical), then apply the
+        # textual fallback to mop up any inline-script secrets.
+        xml = plistlib.dumps(red, fmt=plistlib.FMT_XML).decode("utf-8")
+        xml = redact_text_fallback(xml)
+    except Exception as e:          # noqa: BLE001
+        # Unparseable plist: fall back to pure-text redaction of the raw bytes
+        # so a corrupt-but-readable file still gets a redacted snapshot.
+        try:
+            xml = redact_text_fallback(raw.decode("utf-8", "replace"))
+            results_note = f"PARSE_FALLBACK({type(e).__name__})"
+        except Exception as e2:      # noqa: BLE001
+            errors.append(f"{label}: unreadable ({e2})")
+            continue
+    else:
+        results_note = "OK"
+
+    # delta vs previous snapshot (content compare, ignoring nothing — XML is
+    # canonical from plistlib so formatting noise is stable across runs).
+    changed = True
+    if os.path.exists(dest):
+        with open(dest, "r", encoding="utf-8") as fh:
+            changed = (fh.read() != xml)
+
+    with open(dest, "w", encoding="utf-8") as fh:
+        fh.write(xml)
+
+    # plutil -lint the OUTPUT (must stay valid plist after redaction).
+    lint = subprocess.run(["plutil", "-lint", dest], capture_output=True)
+    if lint.returncode != 0:
+        errors.append(f"{label}: plutil lint failed after redaction")
+        continue
+
+    results.append((label, results_note, changed))
+
+# Emit machine-readable summary for the bash caller.
+print("SNAPSHOTTED=" + str(sum(1 for _, s, _ in results if s in ("OK", "PARSE_FALLBACK") or s.startswith("PARSE_FALLBACK"))))
+print("SKIPPED=" + str(sum(1 for _, s, _ in results if s == "SKIP_UNLOADED")))
+print("CHANGED=" + str(sum(1 for _, _, c in results if c)))
+for label, status, changed in results:
+    if status == "SKIP_UNLOADED":
+        continue
+    mark = "Δ" if changed else "="
+    print(f"DELTA\t{mark}\t{label}\t{status}")
+for e in errors:
+    print(f"ERROR\t{e}")
+sys.exit(2 if errors else 0)
+PY
+)"
+REDACT_RC=$?
+
+echo "${REDACT_SUMMARY}"
+
+if [[ ${REDACT_RC} -ne 0 ]]; then
+    msg="🚨 plist-snapshot: redaction/lint ERRORS @ ${NOW_ISO}"$'\n'"$(echo "${REDACT_SUMMARY}" | grep '^ERROR' | head -20)"
+    echo "${msg}" >&2
+    _telegram "${msg}"
+    # Do NOT commit a snapshot that failed lint — abort before git.
+    exit 1
+fi
+
+# ── 4: HARD secret-leak verification (independent of the redactor) ───────────
+# The redactor said it's clean. Trust nothing — re-scan the OUTPUT directory for
+# any secret-shaped value that is NOT the literal REDACTED. If even one survives,
+# ABORT before git. (W65 lesson: even an adversarial verifier hallucinates; the
+# only safe check is your own independent grep.)
+#
+# Heuristic leak signatures: long hex (>=24), JWT-ish, AAAA: bot tokens,
+# fly tokens (FlyV1/fm2_), GitHub PATs (ghp_/github_pat_), sk-/xoxb- style keys.
+LEAK_HITS="$(
+grep -rInaE '(<string>[A-Fa-f0-9]{24,}</string>)|(<string>[0-9]{6,}:[A-Za-z0-9_-]{30,}</string>)|(ghp_[A-Za-z0-9]{20,})|(github_pat_[A-Za-z0-9_]{30,})|(FlyV1 )|(fm2_)|(xox[baprs]-[A-Za-z0-9-]{10,})|(sk-[A-Za-z0-9]{20,})|(eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.)|(://[^:/<[:space:]]+:[^@<[:space:]]{3,}@)' \
+    "${SNAP_DIR}" 2>/dev/null \
+    | grep -vF '>REDACTED<' \
+    || true
+)"
+
+if [[ -n "${LEAK_HITS}" ]]; then
+    # Quarantine: do NOT commit. Wipe the freshly-written snapshot so a leak
+    # can't sit on disk world-readable either (W65 residue pattern).
+    msg="🚨🚨 plist-snapshot ABORTED: secret survived redaction @ ${NOW_ISO}"$'\n'"$(echo "${LEAK_HITS}" | sed -E 's#(<string>).*(</string>)#\1<LEAKED-VALUE-NOT-LOGGED>\2#g' | head -10)"
+    echo "${msg}" >&2
+    _telegram "🚨🚨 plist-snapshot ABORTED: secret survived redaction @ ${NOW_ISO} — see ${LOG_DIR}/plist-snapshot.error.log (value NOT logged)"
+    exit 3
+fi
+echo "[plist-snapshot] secret-leak verification PASS (0 unredacted secrets in ${SNAP_DIR})"
+
+# Tighten perms on the snapshot dir (defense in depth; redacted but still).
+chmod 0644 "${SNAP_DIR}"/*.plist 2>/dev/null || true
+
+CHANGED_N="$(echo "${REDACT_SUMMARY}" | sed -n 's/^CHANGED=//p')"
+SNAP_N="$(echo "${REDACT_SUMMARY}" | sed -n 's/^SNAPSHOTTED=//p')"
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+    echo "[plist-snapshot] DRY RUN — no git. snapshotted=${SNAP_N} changed=${CHANGED_N}"
+    exit 0
+fi
+
+# ── 5: commit snapshot to a dedicated DR branch WITHOUT touching HEAD ─────────
+# Anti sibling-race (cicatrix W50/W51/W52 + untracked-loss-on-branch-switch
+# 2026-04-29): a cron MUST NOT `git checkout`/`git stash` on the shared worktree
+# — that changes HEAD under a live operator session and can drop untracked files.
+# We commit via a temp index + commit-tree + update-ref: HEAD and the working
+# tree are NEVER touched; only refs/heads/${BRANCH} advances. Push left to operator.
+cd "${REPO_ROOT}" || { echo "[plist-snapshot] FATAL: cannot cd ${REPO_ROOT}" >&2; exit 1; }
+
+TMP_INDEX="$(mktemp "${TMPDIR:-/tmp}/plist-snap-index.XXXXXX")"
+rm -f "${TMP_INDEX}"   # mktemp's empty 0-byte file is NOT a valid git index; let git create it fresh
+trap 'rm -f "${TMP_INDEX}"' EXIT
+
+if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+    PARENT="$(git rev-parse "refs/heads/${BRANCH}")"
+    GIT_INDEX_FILE="${TMP_INDEX}" git read-tree "${PARENT}" 2>/dev/null || true
+else
+    PARENT=""
+fi
+
+# Stage ONLY the snapshot dir into the TEMP index (operator's index untouched).
+# -f because _snapshot-live/ is gitignored on working branches (it belongs ONLY
+# on the DR branch, force-added here).
+GIT_INDEX_FILE="${TMP_INDEX}" git add -f -- "infra/launchagents/_snapshot-live/"
+TREE="$(GIT_INDEX_FILE="${TMP_INDEX}" git write-tree)"
+
+if [[ -n "${PARENT}" && "${TREE}" == "$(git rev-parse "${PARENT}^{tree}" 2>/dev/null)" ]]; then
+    echo "[plist-snapshot] no plist changes since last snapshot — nothing to commit."
+    exit 0
+fi
+
+COMMIT_MSG="chore(dr): plist live snapshot ${NOW_ISO} (${CHANGED_N} changed, redacted)
+
+Daily disaster-recovery snapshot of loaded LaunchAgent plists, secrets redacted.
+snapshotted=${SNAP_N} changed=${CHANGED_N}
+Source: ~/Library/LaunchAgents/com.{nuzantara,balizero,cell,matagaruda}.*
+Redaction + independent secret-leak verification PASSED before commit.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+
+if [[ -n "${PARENT}" ]]; then
+    COMMIT="$(printf '%s' "${COMMIT_MSG}" | git commit-tree "${TREE}" -p "${PARENT}")"
+else
+    COMMIT="$(printf '%s' "${COMMIT_MSG}" | git commit-tree "${TREE}")"
+fi
+if [[ -z "${COMMIT}" ]]; then
+    echo "[plist-snapshot] FATAL: git commit-tree returned empty (tree=${TREE})" >&2
+    exit 1
+fi
+git update-ref "refs/heads/${BRANCH}" "${COMMIT}" ${PARENT:+"${PARENT}"}
+echo "[plist-snapshot] committed ${COMMIT:0:9} → ${BRANCH} (HEAD/working-tree untouched)"
+
+# ── 6: Telegram delta line ───────────────────────────────────────────────────
+if [[ -n "${CHANGED_N}" && "${CHANGED_N}" != "0" ]]; then
+    DELTA_LINES="$(echo "${REDACT_SUMMARY}" | awk -F'\t' '$1=="DELTA" && $2=="Δ" {print "  • "$3}' | head -20)"
+    msg="🗂 plist-snapshot DR @ ${NOW_ISO}"$'\n'"${CHANGED_N} plist changed vs yesterday (committed to ${BRANCH}):"$'\n'"${DELTA_LINES}"
+    echo "${msg}"
+    _telegram "${msg}"
+else
+    echo "[plist-snapshot] committed; 0 deltas vs previous snapshot (timestamp-only)."
+fi
+
+echo "[plist-snapshot] done @ $(date -u +%FT%TZ)"
+exit 0

--- a/research/operations/2026-06-05-claude-code-setup-self-audit.md
+++ b/research/operations/2026-06-05-claude-code-setup-self-audit.md
@@ -1,0 +1,96 @@
+---
+date: 2026-06-05
+domain: operations
+client_case: none
+sources:
+  - cc-setup-self-audit workflow (18 agents, 147 inventory items, 12 verified recs) — run wf_bbaf62f1-f80
+  - Empirical re-verification (git check-ignore, lsof :5432, wc -c MEMORY.md, launchctl plist count)
+  - anthropics/claude-plugins-official — claude-code-setup plugin (read-only recommender, baseline)
+  - .claude/rules/cicatrix-scars.md (W64, W65, 2026-04-29 plist-secret, 2026-06-02 503 split-brain)
+---
+
+# Claude Code setup — self-audit (replica del plugin `claude-code-setup`, calibrato anti-duplicato)
+
+## Contesto
+
+Il plugin ufficiale Anthropic `claude-code-setup@claude-plugins-official` è un **raccomandatore read-only**:
+scansiona il repo e suggerisce hook/skill/MCP/subagent/command/automazioni mancanti. È già installato dal
+2026-03-02 ma **non abilitato**. Per un setup vanilla è utile; per Nuzantara (setup iper-avanzato: 147 item già
+esistenti) il valore sta tutto nell'**anti-duplicato**. Questo audit lo replica con un workflow multi-agente:
+6 scanner inventory in parallelo → gap-scan per categoria → verify adversariale (refute) per categoria → sintesi.
+
+## Inventory baseline (cosa esiste GIÀ — 147 item)
+
+| Categoria      | #     | Coverage                                                                                                                                                                                                                                            |
+| -------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| hooks          | 36    | Eccezionalmente profonda. Lifecycle completo + guardrails daemon fail-closed + worktree-isolation + stop_verify. **Trap**: `.git/hooks/` legacy INERTI (core.hooksPath→.husky); `.pre-commit-config.yaml` non wired. Rischio = sprawl, non assenza. |
+| mcp-servers    | 17    | Molto ricca (6 first-party + postgres-ro + github + ga4 + ocr). Overlap (github MCP vs gh, ocr-tesseract vs qwen2.5vl). Cloud connectors = superficie egress Law 2.                                                                                 |
+| subagents      | 43    | Matura (WR2=8, WR3=13, ops cluster, reviewer). Tutti **user-scoped** (`.claude/agents/` di progetto VUOTO).                                                                                                                                         |
+| skills         | 29    | 15 custom + 250+ da plugin. Sbilanciata: archivi `_archive-*` hanno ritirato db-migration/crm/vector-search senza rimpiazzo.                                                                                                                        |
+| slash-commands | 13    | 6 custom (/verify /scar /resume /dispatch-stat /subhi /codex-second-opinion) + 7 da plugin. Tarati sui pain noti.                                                                                                                                   |
+| automations    | 9→213 | Dominante. **217 plist live vs 77 tracked** in git. AUTOMATIONS_REFERENCE = 213 job, 25 failed, 10 TERMINAL, 10 DLQ. Gap = HEALTH non assenza.                                                                                                      |
+
+## 12 raccomandazioni verificate → 6 bisogni distinti
+
+**Insight dell'orchestratore (non visibile ai sub-agent per-categoria)**: 3 categorie hanno proposto lo STESSO
+bisogno in forma diversa. I 12 finding collassano in **6 bisogni**, 2 dei quali con 3 forme alternative
+(scegline UNA, non implementarle tutte).
+
+### 🔴 CLUSTER A — Law 2 / OSINT enforcement (FINDING #1: hard-rule top-line con ZERO backstop oggi)
+
+La sovranità OSINT (Law 2) è una hard-constraint top-line **senza alcun hook che la enforci**. L'unica
+consapevolezza è `mos_capture_post_tool.py` che LABELS ma non blocca. Due superfici **complementari**:
+
+- **A1 — hook MCP cloud-egress block** (estende `guardrails-static.py`): BLOCK (exit 2) quando un cloud-write
+  MCP tool (`google-workspace docs/gmail/drive`, `claude_ai Canva/Drive/Gmail`, `notebooklm source_add`,
+  `github push`) riceve payload che matcha SENSITIVE_PATHS/PII già definiti. Riusa plumbing esistente. **P1, effort medium.**
+- **A2 — pre-commit path-gate** (Husky): HARD-BLOCK commit di `research/*/clients/`, `*-case.md`, DOSSIER\_\*, contenuto PII. **P1, effort low.**
+- ✅ **Mitigazione immediata GIÀ APPLICATA (2026-06-05)**: aggiunti pattern `research/*/clients/`, `research/**/*-case.md`,
+  `*-guidance.{html,pdf}` a `.gitignore`. Verificato: `research/visa/clients/` (file Marc Buckner reale, untracked) ora IGNORED.
+  Rischio era LATENTE (un `git add -A` dal cloud Vercel), non breach avvenuta.
+
+### 🟠 CLUSTER B — MEMORY.md overflow (BROKEN ADESSO: 39.629 byte = 1.6x il limite 24.440, troncamento silenzioso)
+
+Verificato live questa sessione (anche nel system-reminder di SessionStart). Il MOS carica un index TRONCATO →
+memorie importance≥7 silenziosamente non caricate. `mem` CLI non ha trim/compact/archive. **3 forme proposte — scegline 1:**
+
+- B-cmd — **/mem-trim** (command, on-demand, operator y/n) — _consigliato: più pragmatico_. P1.
+- B-skill — memory-index-curator (skill). P1.
+- B-agent — mos-curator (subagent, **declassato a P2**: `alzheimer-hook.sh` già alerta su >25600 byte; net-new = solo per-line >200char + orphan-detection tra 424 topic file).
+
+### 🟠 CLUSTER C — Fly split-brain / deploy-desync (scar 2x in un giorno il 2026-06-02)
+
+`/health=200` maschera un rag worker morto; un deploy CI non force-boota una macchina autostop crash-loopata.
+`nuzantara-deploy` skill controlla solo `/health` → avrebbe PASSATO durante l'outage. **Bonus**: la skill ha pure
+il build-context SBAGLIATO (`cd apps/backend-rag` invece di repo-root). **3 forme — scegline 1:**
+
+- C-skill — **fly-split-brain-verify** (skill) — _consigliato: si innesta in nuzantara-deploy e corregge il bug build-context_. P1.
+- C-cmd — /fly-desync (command, triage on-demand). P1.
+- C-agent — deploy-desync-triage (subagent). P1.
+
+### 🟡 CLUSTER D — Fleet health (2 complementari, entrambi P1 low)
+
+- **D1 — plist snapshot DR**: LaunchAgent daily che esporta i 217 plist live in git (XML secret-redatto). Il P0 cicatrix
+  2026-04-29 (51 plist truncati, recovery solo da `launchctl print` effimero) sarebbe stato "git checkout". 217 live vs 77 tracked.
+- **D2 — chronic-failure digest**: digest settimanale "red-for-N-days" sui job. `audit-launchd-daily.sh` è DELTA-only
+  → un job rosso da >1 giorno diventa invisibile (famiglia W55 suppression).
+
+### 🟢 CLUSTER E — quick wins indipendenti (P1 low)
+
+- **E1 — /escalations**: triage HIGH-first di `shared/escalations_pro.jsonl` (24 entry, tutte dlq NORMAL ripetute) +
+  `~/.agent/decisions/claude_tasks/` (507 file, 4 HIGH). Ritual CLAUDE.md §2/§14 mandato ma non automatizzato.
+- **E2 — postgres-nuzantara-local MCP**: read-only sul Postgres LOCALE `127.0.0.1:5432/nuzantara_dev` (corpus WhatsApp
+  OSINT live, 26.755 righe). L'MCP esistente punta al Fly cloud frozen pre-cutover → il corpus live NON ha MCP surface oggi.
+
+## Sequenza consigliata
+
+1. ✅ `.gitignore` PII (fatto). 2. A2 pre-commit gate (low, chiude la stessa superficie permanentemente).
+2. B-cmd /mem-trim (broken adesso). 4. C-skill fly-split-brain-verify. 5. E1+E2 quick wins. 6. D1+D2 fleet health.
+3. A1 hook MCP-egress (effort medium, ma è l'enforcement vero di Law 2). mos-curator/forme duplicate: SKIP.
+
+## Nota metodologica
+
+0 raccomandazioni droppate su 12 NON è consenso cieco: i `verify_reason` contengono verifiche empiriche reali
+(lettura `guardrails-static.py`, `git check-ignore`, `lsof :5432`, lettura `nuzantara-deploy/SKILL.md`), e il verifier
+ha declassato mos-curator P1→P2. I gap-scanner hanno prodotto poche rec già molto mirate (con `not_duplicate_because`
+forte), confermate dal verify. Finding di sicurezza ri-verificati indipendentemente dall'orchestratore (cicatrix W65 GOTCHA).


### PR DESCRIPTION
## What
Ships the claude-code-setup self-audit deliverables (originally stacked on the fix-backup branch; here cherry-picked **clean onto main**, isolated to just these 10 files):

- `.husky/pre-commit` — PII/egress (Law-2) gate
- `infra/launchagents/plist_snapshot_dr.sh` — daily plist snapshot + secret redaction (DR)
- `infra/launchagents/chronic_failure_digest.{py,sh}` — weekly chronic-failure digest
- install scripts + LaunchAgent plists for both
- `research/operations/2026-06-05-claude-code-setup-self-audit.md` — the audit writeup
- `.gitignore` — ignore `apps/evaluator/.rag-eval-prod.env` (union-merged with main's `/cache/` rule)

## Verification (originating session c95d7eed)
TDD egress gate (A1), `bash -n` / `py ast.parse` syntax, daemon kickstart, dry-run D1 (redaction + independent leak-check) + D2 (15 real snapshots, no Telegram). Additive only (+1254/-0).

## Note
The local `~/.claude/hooks/guardrails-static.py` + daemon parity edits from the same audit are HOME-fork files (outside the repo) and are not part of this PR.