### PR TITLE
feat(war-room): Step 2 briefer — B-fusione (news+NB, rails-into-enrichment)

### DIFF
--- a/research/marketing/2026-06-06-warroom-step2-brief-poor-vs-rich.md
+++ b/research/marketing/2026-06-06-warroom-step2-brief-poor-vs-rich.md
@@ -1,0 +1,115 @@
+---
+date: 2026-06-06
+domain: marketing
+client_case: war-room-rebuild
+sources:
+  - intel_items id 44122b09 (PPh Final UMKM, liputan6.com, 2026-06-05) — brief povero reale
+  - wr2-brief-interpreter agent + NB-4 (157 sources) — brief ricco reale
+  - scripts/wr2_draft_generator.py (consumer del brief_json)
+---
+
+# War Room Step 2 — confronto AFFIANCATO: brief povero vs brief ricco (stesso topic reale)
+
+> Decisione architetturale: che brief deve produrre lo Step 2? Prima di scegliere,
+> ecco i DUE brief generati sullo STESSO articolo reale (PPh Final UMKM, liputan6, 5 giu).
+> **Non astratto: dato reale, generato adesso.**
+
+## Il topic
+
+`Pemerintah Ubah Aturan PPh Final UMKM, PT dan CV Tak Lagi Dapat Fasilitas`
+(il governo cambia il PPh Final 0,5% UMKM: PT e CV perdono la facilitazione). Fonte
+liputan6.com, 2026-06-05. È uno dei candidati della shortlist Step 1, regolatorio-tax
+(il caso peggiore per un brief povero: serve precisione normativa).
+
+---
+
+## LATO A — Brief POVERO (cosa ha OGGI lo Step 2)
+
+**Materiale grezzo unico = il campo `summary`** (raw_payload = solo metadata staging,
+ZERO enrichment, ZERO war_room_draft preesistente). Il summary è:
+
+- ~2000 char di **estratti dell'articolo** separati da `[...]` **letterali** nel DB
+- **troncato a metà parola** (`...fasilitas ters‹TRONCATO›`)
+- testo **indonesiano grezzo**, zero struttura, zero analisi
+- contiene il numero norma (PP 20/2026, Pasal 57) ma **annegato** nel testo
+
+Esempio verbatim (così com'è nel DB):
+
+> Pemerintah resmi menerbitkan PP Nomor 20 Tahun 2026 tentang Perubahan atas PP Nomor
+> 55 Tahun 2022... [...] ...kini penerimanya dibatasi hanya untuk wajib pajak orang
+> pribadi, perseroan perorangan... [...] ...CV, firma, PT, dan BUMDes... masih dapat
+> menggunakannya hingga masa transisi berakhir. [...] ...Sebelumnya, fasilitas ters‹TRONCATO›
+
+**Cosa NON ha**: nessun the_facts, nessun 30-second-brief, nessun bali_zero_take,
+nessun next_steps, nessun FAQ, nessuna citazione normativa isolata, nessun glossario,
+nessun taboo-check, nessun angolo per il pubblico PT PMA. Il draft_generator a valle
+dovrebbe estrarre TUTTO da questo blocco grezzo, da solo.
+
+---
+
+## LATO B — Brief RICCO (brief-interpreter + NB-4 ground-truth)
+
+Generato adesso dall'agente `wr2-brief-interpreter` con query a NotebookLM NB-4 (157 source tax). Estratto:
+
+**15 key_facts** con provenienza normativa, es.:
+
+- "PP 55/2022 ha sostituito PP 23/2018... implementando UU HPP 7/2021 Art. 4, 17, 32C — NB-4 source 848862af (testo verbatim)"
+- "Durata: 7 anni orang pribadi / 4 anni CV-firma-koperasi-BUMDes / 3 anni PT — NB-4 848862af"
+- "PT PMA strutturalmente esclusi anche oggi: capitale minimo Rp 10 mld incompatibile con soglia omzet Rp 4,8 mld — NB-4 9e49136b"
+- "CoreTax (PMK 81/2024) bloccherà automaticamente e-Billing 0,5% per PT/CV post-revisione, triggerando SP2DK — NB-4 c9203fa0"
+
+**11 key_numbers**: 0,5% / Rp 4,8 mld / Rp 500 mln esente / 7-4-3 anni / 22% / 11% Pasal 31E / 2029 / 24 mesi bunga / Rp 10 mld PT PMA.
+
+**7 citazioni regolatorie verbatim**: PP 23/2018, PP 55/2022, UU HPP 7/2021 (Pasal 4(2)e, 17(2e), 32C), UU KUP Pasal 28+13, Pasal 17(1)b, Pasal 31E, PMK 81/2024 Pasal 448.
+
+**Quote dirette autorità** (verbatim, citabili senza parafrasi):
+
+- Airlangga Hartarto: "...PPh finalnya 0,5% dilanjutkan sampai 2029. Jadi, tidak diperpanjang setahun-setahun, tetapi diberikan kepastian sampai 2029" (DDTCNews)
+- Bimo Wijayanto (DJP): rimozione facility corporate mira al "firm splitting / revenue bunching"
+
+**23 termini lexicon bilingue** (PPh Final, omzet, peredaran bruto, pembukuan, SKPKB, SP2DK… con assist EN; PT PMA/CV/NPWP/Coretax always-untranslated).
+
+**7 taboo-check TOPIC-SPECIFICI** (oltre alla ban-list standard):
+
+- "save money on taxes" / "loophole" / "avoid taxes" (la riforma CHIUDE un loophole — usarlo fa sembrare BZ complice del firm-splitting)
+- "PT PMA can use UMKM regime" = MISINFORMAZIONE al pubblico-target BZ
+- framing "signed/effective" — (vedi sotto: qui il brief ricco è meno aggiornato del povero!)
+
+**hook_angle**, **archetype** (regulatory-explainer), **tone_register** (analitico/militante).
+
+---
+
+## LATO C — La cosa che NESSUNO dei due ha da solo (importante per la decisione)
+
+⚠️ **Discrepanza fattuale reale tra i due brief**:
+
+- Il **povero** (articolo Liputan6, 5 giu) dice: norma **GIÀ emanata = PP 20/2026, Pasal 57**, con masa transisi.
+- Il **ricco** (NB-4) dice: revisione **"in attesa di firma di Prabowo, nessun numero PP"** — perché le source NB-4 sono di nov 2025/set 2025, **precedenti** all'emanazione.
+
+→ **Il brief povero (news fresca) aveva il numero norma definitivo (PP 20/2026) che il brief ricco (NB curato) non aveva ancora.** Il ricco ha la profondità normativa (PP 55/2022 verbatim, UU HPP, sanzioni); il povero ha l'aggiornamento (PP 20/2026 emanata). **Il brief ideale fonde i due: freschezza-news + ground-truth-NB.**
+
+---
+
+## Verdetto secco (per la decisione)
+
+| Dimensione                               | Povero (summary)                       | Ricco (NB-4)                                  |
+| ---------------------------------------- | -------------------------------------- | --------------------------------------------- |
+| Profondità normativa                     | quasi zero (numero annegato nel testo) | altissima (7 citazioni verbatim, UU+PP+PMK)   |
+| Numeri precisi                           | sparsi nel testo                       | 11 isolati e verificati                       |
+| Quote autorità citabili                  | no                                     | sì (verbatim)                                 |
+| Taboo/rischio-legale                     | nessun controllo                       | 7 taboo topic-specifici (anti-misinfo PT PMA) |
+| Lexicon bilingue                         | no                                     | 23 termini                                    |
+| **Freschezza (numero norma definitivo)** | **sì (PP 20/2026)**                    | **no (source pre-emanazione)**                |
+| Costo                                    | $0 (già nel DB)                        | 1 invocazione agente + query NB (~$0, MAX)    |
+| Pronto per il carosello?                 | il draft_generator deve estrarre tutto | quasi pronto allo storyboard                  |
+
+**Implicazione per lo Step 2**: il brief ricco è **incomparabilmente superiore** per un carosello
+regolatorio (è la differenza tra "ecco il testo grezzo, arrangiati" e "ecco i fatti citati,
+i numeri, le quote, cosa NON dire"). MA da solo rischia di essere **stale** sui fatti
+freschissimi. La fusione (news fresca → grounding NB verbatim) è il brief vero.
+
+> **3 opzioni per lo Step 2** (la decisione è di Antonello):
+>
+> - **(B-ponte)** Step 2 invoca brief-interpreter + PERSISTE lo schema ricco in brief_json. Estende wr2_draft_generator a leggere i campi nuovi. Brief fortissimo, più lavoro.
+> - **(B-enrichment)** Step 2 popola la forma a 12 chiavi esistente (enrichment via LLM). Zero modifiche a valle, carosello subito, ma meno ricco.
+> - **(B-fusione)** Step 2 = news-item (fresco) + brief-interpreter (grounding NB) fusi in un brief_json esteso. Il migliore in assoluto; il più ambizioso. Risolve anche la discrepanza PP 20/2026 vs pre-emanazione.

--- a/research/marketing/2026-06-06-warroom-step2-design.md
+++ b/research/marketing/2026-06-06-warroom-step2-design.md
@@ -1,0 +1,176 @@
+---
+date: 2026-06-06
+domain: marketing
+client_case: war-room-rebuild
+sources:
+  - research/marketing/2026-06-06-warroom-step2-brief-poor-vs-rich.md (confronto reale)
+  - scripts/wr2_draft_generator.py (consumer brief_json — contratto verificato)
+  - ~/.claude/agents/wr2-brief-interpreter.md (schema brief ricco + NB ground-truth)
+  - scripts/warroom_step1_reader.py (Step 1 — produce la shortlist input)
+---
+
+# War Room — Step 2: shortlist → draft briefato (B-FUSIONE)
+
+> Decisione Antonello: **B-fusione** — il brief fonde la NEWS FRESCA (item shortlist, fatti
+> aggiornati es. PP 20/2026) col GROUNDING NB VERBATIM (brief-interpreter: citazioni, numeri,
+> taboo). Risolve la discrepanza stale-vs-fresco vista sul dato reale.
+> **Stato: DESIGN (no codice). Gate: panel 4-LLM prima dell'implementazione.**
+
+---
+
+## 0. Cosa fa lo Step 2 (una frase)
+
+Prende un item dalla shortlist dello Step 1, lo arricchisce fondendo i fatti freschi della news
+con il ground-truth verbatim di NotebookLM (via brief-interpreter), e scrive un `brief_json`
+in `war_room_drafts` (status='briefed') — retrocompatibile col drafter esistente + con i campi
+ricchi nuovi per il futuro.
+
+---
+
+## 1. Il contratto verificato (cosa lo Step 2 DEVE rispettare)
+
+Il consumer `wr2_draft_generator.py` legge `brief_json` solo via `.get()` (verificato: zero
+schema-validation, zero extra=forbid). Set chiuso che legge:
+
+**Top-level (5)**: `article_summary` (str), `source_url` (str), `enrichment` (dict),
+`live_news_reasons` (list), `live_news_score` (solo log).
+**Dentro `enrichment` (6)**: `thirty_second_brief{what,why_it_matters,who,risk_level}`,
+`the_facts` (str), `bali_zero_take` (str), `in_practice` (str), `next_steps` (str),
+`faq` (list[{question,answer}], max 6).
+
+**Contratto minimo non-rompere**: `article_summary` non vuoto + `enrichment` resta dict +
+`live_news_reasons` resta list. **Tutto il resto è additivo e sicuro** (i campi ricchi nuovi
+sono invisibili al vecchio consumer).
+
+→ **Strategia**: lo Step 2 popola SIA `enrichment` (il drafter funziona subito) SIA i campi
+ricchi nuovi (persistiti per il futuro). Doppio binario, zero rottura.
+
+---
+
+## 2. Architettura B-fusione (4 stadi)
+
+```
+shortlist Step 1 (item: title, canonical_url, summary, source_domain, llm.service_line)
+      │  prende 1 item (top relevance non ancora briefato) — idempotenza su canonical_url
+      ▼
+[STADIO 1] FATTI FRESCHI: estrai dal news-item
+      │  title + summary completo (dal DB intel_items, non il summary troncato shortlist)
+      │  → i fatti AGGIORNATI (es. "PP 20/2026 emanata", numeri citati nell'articolo)
+      ▼
+[STADIO 2] GROUNDING NB: invoca wr2-brief-interpreter
+      │  input: topic + domain_hint (= service_line dallo Step 1)
+      │  output ricco: key_facts[], regulatory_citations_verbatim[], key_numbers[],
+      │    bilingual_lexicon[], taboo_check[], archetype, tone_register, hook_angle
+      │  (ground-truth da NB-4/1/5 — profondità normativa)
+      ▼
+[STADIO 3] FUSIONE: riconcilia fresco (news) + profondo (NB)  ← LLM (Claude MAX SDK auth_token)
+      │  - i FATTI freschi della news sovrascrivono/aggiornano i fatti NB stale
+      │    (es. news dice PP 20/2026 emanata > NB dice "in attesa firma")
+      │  - le CITAZIONI verbatim NB restano (la news non le ha)
+      │  - flag esplicito quando news e NB confliggono → "freshness_override" nel brief
+      │  - genera enrichment{the_facts, bali_zero_take, next_steps, faq, thirty_second_brief}
+      │    DAL materiale fuso (non solo dalla news, non solo da NB)
+      ▼
+[STADIO 4] PERSISTI brief_json in war_room_drafts (status='briefed')
+      │  enrichment{...}        ← il drafter esistente lo legge (carosello subito)
+      │  + key_facts/regulatory_citations/key_numbers/bilingual_lexicon/taboo/archetype  ← campi ricchi nuovi
+      │  + article_summary/source_url/live_news_reasons  ← contratto minimo
+      │  + fusion_meta{nb_sources, freshness_overrides, generated_at}  ← provenienza
+      ▼  (INSERT war_room_drafts — è l'unica WRITE. Idempotenza: skip se canonical_url già briefato)
+```
+
+---
+
+## 3. La fusione (il cuore — come riconciliare fresco vs profondo)
+
+Il problema reale visto su PPh UMKM: news dice "PP 20/2026 emanata, Pasal 57"; NB dice "in attesa
+firma Prabowo". **Regola di fusione** (LLM-guidata, esplicita nel prompt):
+
+1. **Fatti datati/procedurali** (status di una norma, numeri, scadenze) → **la NEWS vince** se più
+   recente (ha una data di pubblicazione fresca). Flag `freshness_override` per audit.
+2. **Citazioni normative verbatim + numeri strutturali** (testo di legge, aliquote storiche,
+   durate) → **NB vince** (ground-truth, la news non le ha verbatim).
+3. **Conflitto irriducibile** (news e NB dicono cose opposte su un fatto sostanziale) → **NON
+   inventare la sintesi**: riporta entrambi con flag `conflict` + privilegia la news fresca ma
+   segnala. (Anti-allucinazione: meglio un brief che dice "fonti discordi" che uno che sceglie a caso.)
+4. **Taboo + lexicon + archetype** → sempre da NB (non li ha la news).
+
+---
+
+## 4. Contratto I/O dello Step 2
+
+**Input**: la shortlist dello Step 1 (`shortlist-YYYY-MM-DD.json`) — oppure `--item-id <uuid>`
+per forzare un item, `--dry-run` (non scrive war_room_drafts), `--top N` (processa i top-N).
+
+**Output**: righe `war_room_drafts` (status='briefed') con `brief_json` esteso:
+
+```json
+{
+  "article_title": "...", "article_summary": "...(completo dal DB)...", "source_url": "...",
+  "staging_id": "<intel_items.id>", "staging_type": "tax",
+  "live_news_reasons": [...], "live_news_score": 0,
+  "enrichment": {
+    "thirty_second_brief": {"what": "...", "why_it_matters": "...", "who": "...", "risk_level": "..."},
+    "the_facts": "...(fuso news+NB)...", "bali_zero_take": "...", "in_practice": "...",
+    "next_steps": "...", "faq": [{"question": "...", "answer": "..."}]
+  },
+  "key_facts": ["...con provenienza NB-4 source ..."],
+  "key_numbers": ["0.5%", "Rp 4.8 mld", ...],
+  "regulatory_citations_verbatim": ["PP 55/2022 ...", "UU HPP 7/2021 Pasal ..."],
+  "bilingual_lexicon": [{"id_term": "omzet", "english_assist": "gross revenue", "always_untranslated": false}],
+  "taboo_check": ["no 'loophole' — la riforma lo chiude", "no 'PT PMA can use UMKM' = misinfo"],
+  "archetype": "regulatory-explainer", "tone_register": "analitico/militante",
+  "fusion_meta": {"nb_sources": ["NB-4 d4b2..."], "freshness_overrides": ["status norma: news PP 20/2026 > NB 'in attesa'"], "generated_at": "..."}
+}
+```
+
+Il drafter legge `enrichment` + `article_summary` → carosello. I campi ricchi restano per Step 3/drafter-v2.
+
+---
+
+## 5. Reuse-first
+
+| Mattone                       | Esiste?                                                                   | Esito                                                      |
+| ----------------------------- | ------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Schema brief ricco + query NB | ✅ `wr2-brief-interpreter` agente                                         | **[INVOCA]** — lo Step 2 lo chiama via Agent tool          |
+| Forma `brief_json` + INSERT   | ✅ `wr2_topic_selector.py:637` (template) + `WarRoomDraftCreate` Pydantic | **[FORKA-E-ADATTA]** il template, estendi coi campi ricchi |
+| Consumer (drafter)            | ✅ `wr2_draft_generator.py` (tollera campi extra)                         | **[NON TOCCARE]** — retrocompat, legge enrichment          |
+| Lettura shortlist + DB        | ✅ `warroom_step1_reader.py` (pattern asyncpg+proxy+token)                | **[RIUSA]** il pattern connessione/token                   |
+| LLM fusione                   | ✅ SDK `anthropic` auth_token (Step 1)                                    | **[RIUSA]** stesso client raw MAX                          |
+
+Lo Step 2 è ~collante: invoca brief-interpreter + fonde via LLM + INSERT. Poco codice nuovo.
+
+---
+
+## 6. Vincoli (hard)
+
+- **Claude quota MAX** (SDK auth_token, mai api_key) per la fusione. Token dal Keychain CLI (fallback env).
+- **Law 2**: la fusione tocca news pubbliche + ground-truth NB (conoscenza operativa, non PII cliente) → cloud OK.
+- **Legge 5**: lo Step 2 scrive un draft 'briefed', NON pubblica. Il drafter+review-gate restano a valle.
+- **Anti-allucinazione**: conflitto news/NB → riporta entrambi con flag, MAI inventare la sintesi.
+- **Idempotenza**: skip item con canonical_url già 'briefed' (no doppio draft). INSERT è l'unica WRITE.
+- **Retrocompat**: NON rinominare/cambiare-tipo i campi che il drafter legge (enrichment dict, article_summary str, live_news_reasons list).
+
+---
+
+## 7. Domande aperte per il panel 4-LLM
+
+1. **Granularità fusione**: fondere a livello di `the_facts` (un blocco) o campo-per-campo? Quanto LLM-guidata vs regola deterministica?
+2. **brief-interpreter è stale**: NB-4 aveva fatti di nov 2025. Se ogni Step 2 invoca brief-interpreter, paghiamo la staleness NB ogni volta. Meglio: la news fresca come "correttore" sistematico? O aggiornare prima NB-4 (fuori scope Step 2)?
+3. **Conflitto irriducibile**: il flag `conflict`/`freshness_override` è sufficiente, o serve human-in-loop quando news e NB confliggono su un fatto sostanziale (es. una norma è emanata o no)?
+4. **Costo/quota**: ogni item = 1 invocazione brief-interpreter (query NB multiple) + 1 fusione LLM. Per N item della shortlist, quanto carica la rolling-window MAX 5h? Batch o 1-a-1?
+5. **Idempotenza cross-day**: un topic in shortlist per 3 giorni → ri-briefato ogni giorno? Dedup su canonical_url 'briefed' in qualsiasi data, o solo oggi?
+6. **Quando scrivere war_room_drafts**: lo Step 2 scrive subito (status='briefed' → il drafter cron lo prende) o aspetta un OK umano sulla shortlist? (Legge 5 è a valle, ma il draft consuma quota drafter.)
+
+---
+
+## 8. Decisione chiusa / da chiudere
+
+- **Forma**: nuovo `scripts/warroom_step2_briefer.py`. Riusa pattern connessione/token Step 1.
+- **Fusione**: LLM-guidata (Claude MAX) con regole esplicite §3. brief-interpreter via Agent.
+- **Persistenza**: brief_json esteso (enrichment + campi ricchi + fusion_meta), INSERT 'briefed'.
+- **DA DECIDERE col panel**: granularità fusione (§7.1), gestione staleness NB (§7.2), human-gate su conflitto (§7.3), batch vs 1-a-1 (§7.4), quando scrivere (§7.6).
+
+> Prossimo: panel 4-LLM su questo design → implementazione in worktree (codice + collaudo su
+> 1 item reale della shortlist, INSERT in dry-run/staging) → poi Step 3 (draft → slide, che però
+> esiste già come wr2_draft_generator: lo Step 3 sarà più "verifica+migliora l'esistente").

--- a/research/marketing/2026-06-06-warroom-step2-design.md
+++ b/research/marketing/2026-06-06-warroom-step2-design.md
@@ -144,33 +144,84 @@ Lo Step 2 è ~collante: invoca brief-interpreter + fonde via LLM + INSERT. Poco 
 
 ## 6. Vincoli (hard)
 
-- **Claude quota MAX** (SDK auth_token, mai api_key) per la fusione. Token dal Keychain CLI (fallback env).
+- **Claude quota MAX via SDK `auth_token`** (mai `api_key`) per la fusione. Token dal Keychain CLI
+  (`Claude Code-credentials`, `claudeAiOauth.accessToken`, auto-refresh) — fallback env
+  `CLAUDE_CODE_OAUTH_TOKEN`. ⚠️ **CONFLITTO DA RICONCILIARE**: il `CLAUDE.md` di progetto §5 dice
+  ancora «Anthropic SDK BANNED. Never `from anthropic import Anthropic`». Antonello ha corretto la
+  regola in questa sessione (2026-06-06): l'SDK con `auth_token` consuma la quota MAX (HTTP
+  `Authorization: Bearer`, verificato in `_client.py` `auth_headers()`), distinto dal path
+  `api_key`/`ANTHROPIC_API_KEY` = pay-as-you-go, **quello sì bandito**. Il global `~/.claude/CLAUDE.md`
+  già riflette il dual-auth; il CLAUDE.md di progetto **va aggiornato** prima/insieme al merge di
+  questo codice, altrimenti un agente che legge il repo crede l'import vietato. Code-review pre-merge
+  obbligatoria anti-scambio `auth_token`↔`api_key`.
 - **Law 2**: la fusione tocca news pubbliche + ground-truth NB (conoscenza operativa, non PII cliente) → cloud OK.
 - **Legge 5**: lo Step 2 scrive un draft 'briefed', NON pubblica. Il drafter+review-gate restano a valle.
-- **Anti-allucinazione**: conflitto news/NB → riporta entrambi con flag, MAI inventare la sintesi.
-- **Idempotenza**: skip item con canonical_url già 'briefed' (no doppio draft). INSERT è l'unica WRITE.
+- **Anti-allucinazione**: conflitto news/NB → NON inventare la sintesi; status `needs_review_conflict` + riporta entrambi.
+- **Idempotenza**: dedup `canonical_url` any-date, MA re-brief UPSERT se `content_hash`/`published_at` mutano (§8.5).
 - **Retrocompat**: NON rinominare/cambiare-tipo i campi che il drafter legge (enrichment dict, article_summary str, live_news_reasons list).
 
 ---
 
-## 7. Domande aperte per il panel 4-LLM
+## 7. Verdetto panel 4-LLM (2026-06-06) — RISOLTO
 
-1. **Granularità fusione**: fondere a livello di `the_facts` (un blocco) o campo-per-campo? Quanto LLM-guidata vs regola deterministica?
-2. **brief-interpreter è stale**: NB-4 aveva fatti di nov 2025. Se ogni Step 2 invoca brief-interpreter, paghiamo la staleness NB ogni volta. Meglio: la news fresca come "correttore" sistematico? O aggiornare prima NB-4 (fuori scope Step 2)?
-3. **Conflitto irriducibile**: il flag `conflict`/`freshness_override` è sufficiente, o serve human-in-loop quando news e NB confliggono su un fatto sostanziale (es. una norma è emanata o no)?
-4. **Costo/quota**: ogni item = 1 invocazione brief-interpreter (query NB multiple) + 1 fusione LLM. Per N item della shortlist, quanto carica la rolling-window MAX 5h? Batch o 1-a-1?
-5. **Idempotenza cross-day**: un topic in shortlist per 3 giorni → ri-briefato ogni giorno? Dedup su canonical_url 'briefed' in qualsiasi data, o solo oggi?
-6. **Quando scrivere war_room_drafts**: lo Step 2 scrive subito (status='briefed' → il drafter cron lo prende) o aspetta un OK umano sulla shortlist? (Legge 5 è a valle, ma il draft consuma quota drafter.)
+Panel girato su **Claude (subagent) + Gemini (agy) + DeepSeek V4 Pro + Codex GPT-5.5**, tutti
+su M5 (Pro+Mini fleet OFFLINE quel giorno). Output verbatim:
+`/tmp/step2_panel_{codex,deepseek,gemini}_m5.out`.
+
+| Q                  | Verdetto                                                                                                                                                                               | Voti                                                               |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Q1 granularità     | **Ibrido**: LLM scrive SOLO la prosa narrativa; provenienza/conflitto/freschezza + campi-safety (taboo/lexicon/citations/numbers) = **codice deterministico** che copia verbatim da NB | 4/4 unanime                                                        |
+| Q2 staleness NB    | News = correttore sistematico dello stato corrente; **NON** bloccare sull'NB; emetti segnale staleness (`nb_snapshot_date`/`nb_staleness_days`) per cura out-of-band                   | 4/4 unanime                                                        |
+| Q3 conflitto       | Flag NON basta: status separato **`needs_review_conflict`** che ESCLUDE l'item dal pickup del drafter                                                                                  | 3/4 (DeepSeek: basta flag)                                         |
+| Q4 quota           | **1-by-1**, mai batch, cap esplicito 3-5/giorno, **stop pulito** su quota (output parziale utile), cache NB grounding per `canonical_url+notebook_version`                             | 4/4 unanime                                                        |
+| Q5 idempotenza     | Dedup `canonical_url` **any-date** MA re-brief (UPSERT) se `content_hash`/`published_at` cambiano materialmente                                                                        | 3/4 (Gemini+DeepSeek: dedup secco — ma perdono il caso PP 20/2026) |
+| Q6 quando scrivere | Separare "brief esiste" da "pronto per drafter"; gate umano dove protegge la quota                                                                                                     | convergenza (vedi §8)                                              |
+
+**IL DIFETTO PIÙ GRAVE — trovato da 3 LLM su 4 in modo indipendente, stessa crepa da 3 lati:**
+
+- **Codex**: «overloading `status='briefed'` to mean both "brief exists" AND "safe for drafter". Split storage from readiness.»
+- **Claude**: «idempotency-key `canonical_url='briefed'` è backwards — congela la prima versione stale, salta la correzione» (= rompe il caso PP 20/2026 che motiva la fusione).
+- **Gemini**: «il drafter è cieco ai rail — legge solo `enrichment`, ignora taboo_check/citations/key_numbers → slide che violano taboo / allucinano numeri».
+
+Tradotto: lo Step 2 v1 (a) sovraccarica un solo stato con due significati, (b) persiste campi
+ricchi che il drafter non legge né aggiorna. Il "dual-rail per il futuro" non protegge **oggi**.
 
 ---
 
-## 8. Decisione chiusa / da chiudere
+## 8. Decisioni chiuse (panel + Antonello 2026-06-06)
+
+7 decisioni, design v2:
+
+1. **Fusione ibrida (Q1)**: l'LLM (Claude MAX, SDK `auth_token`) genera solo la prosa di
+   `the_facts`/`bali_zero_take`/`thirty_second_brief`/`next_steps`/`faq`. Tutto il resto —
+   provenienza, scelta news-vs-NB, freshness_override, e i campi-safety (taboo/lexicon/citations/
+   numbers) — è **codice deterministico** che copia verbatim da NB. L'LLM non tocca mai una
+   citazione o un numero strutturale.
+2. **News-corrector (Q2)**: la news fresca corregge i fatti datati NB stale; mai bloccare; emetti
+   `fusion_meta.nb_staleness_days` + `freshness_overrides[]`. NB-4 si aggiorna in un backlog separato.
+3. **Conflitto → blocca (Q3)**: conflitto sostanziale (es. norma emanata sì/no) → status
+   **`needs_review_conflict`**, il drafter lo salta. Solo i puliti vanno avanti.
+4. **1-by-1 + cap + stop-pulito (Q4)**: processa in ordine di rilevanza, cap `WR2_BRIEF_MAX_PER_RUN`
+   (default 3), check quota e stop pulito (mai mezza coda di brief falliti).
+5. **Idempotenza con re-brief (Q5)**: skip se `canonical_url` già briefato in **qualsiasi** data,
+   MA se ricompare con `content_hash`/`published_at` cambiato → re-brief UPSERT sulla stessa riga
+   (bump `revision`). Risolve PP 20/2026.
+6. **Step 2 applica i rail (Antonello)**: oltre a persistere i campi ricchi, lo Step 2 **inietta**
+   taboo/citazioni/numeri DENTRO `enrichment` (il canale che il drafter già legge): `the_facts`
+   incorpora le citazioni verbatim, una riga esplicita `NON usare: <taboo>`, i numeri chiave nel
+   testo. **Zero modifiche al drafter** — la sicurezza arriva sul binario esistente (retrocompat).
+7. **Gate umano PRIMA dello Step 2 (Antonello)**: la fusione costosa gira solo su shortlist
+   **approvata**. Step 2 = on-demand su selezione umana, non automatico su tutta la shortlist.
+   Protegge la quota fusione + drafter, non solo il publish (Legge 5 resta a valle).
+
+**Stato schema (separazione storage/readiness)**: lo status `briefed` significa "pronto per il
+drafter" SOLO se l'item ha passato i gate machine-readable (no conflitto bloccante, campi richiesti
+presenti). Conflitto → `needs_review_conflict`. Il drafter cron consuma SOLO `briefed`.
 
 - **Forma**: nuovo `scripts/warroom_step2_briefer.py`. Riusa pattern connessione/token Step 1.
-- **Fusione**: LLM-guidata (Claude MAX) con regole esplicite §3. brief-interpreter via Agent.
-- **Persistenza**: brief_json esteso (enrichment + campi ricchi + fusion_meta), INSERT 'briefed'.
-- **DA DECIDERE col panel**: granularità fusione (§7.1), gestione staleness NB (§7.2), human-gate su conflitto (§7.3), batch vs 1-a-1 (§7.4), quando scrivere (§7.6).
+- **Persistenza**: `brief_json` esteso (enrichment con rail iniettati + campi ricchi + fusion_meta).
+- **Input**: shortlist Step 1 + flag `--approved <item_id...>` (gate umano) o `--item-id` singolo.
 
-> Prossimo: panel 4-LLM su questo design → implementazione in worktree (codice + collaudo su
-> 1 item reale della shortlist, INSERT in dry-run/staging) → poi Step 3 (draft → slide, che però
-> esiste già come wr2_draft_generator: lo Step 3 sarà più "verifica+migliora l'esistente").
+> Prossimo: implementazione in worktree (codice + collaudo su 1 item reale della shortlist,
+> INSERT in `--dry-run`) → poi Step 3 (draft → slide, esiste già come wr2_draft_generator:
+> sarà "verifica+migliora l'esistente").

--- a/scripts/tests/test_warroom_step2.py
+++ b/scripts/tests/test_warroom_step2.py
@@ -1,0 +1,197 @@
+"""Unit tests for scripts/warroom_step2_briefer.py (War Room Step 2, B-fusione).
+
+Covers the DETERMINISTIC logic only (no DB, no LLM) — the new, risky surface:
+- content_hash determinism + content-mutation discrimination (D5 re-brief)
+- rail injection into enrichment.the_facts (D6 — the field the drafter reads)
+- NB staleness delta (D2)
+- decide_status: substantive conflict -> needs_review_conflict (D3)
+- build_brief_json: full schema + rails inside the final brief + minimal contract
+- select_items: human-gate D7 (no --approved/--item-id => empty selection)
+
+Design + panel verdict: research/marketing/2026-06-06-warroom-step2-design.md (§8 7 decisions).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+STEP2_PATH = SCRIPTS_DIR / "warroom_step2_briefer.py"
+
+
+@pytest.fixture
+def m():
+    """Load warroom_step2_briefer as a module from scripts/."""
+    sys.modules.pop("warroom_step2_briefer", None)
+    spec = importlib.util.spec_from_file_location("warroom_step2_briefer", STEP2_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def nb_brief():
+    """A realistic NB grounding brief (PP 20/2026 / PPh UMKM case)."""
+    return {
+        "key_facts": [
+            "PP 55/2022 ha sostituito PP 23/2018 implementando UU HPP 7/2021",
+            "Durata facility: 7 anni orang pribadi / 4 anni CV / 3 anni PT",
+        ],
+        "regulatory_citations_verbatim": ["PP 55/2022", "UU HPP 7/2021 Pasal 4(2)e", "PMK 81/2024 Pasal 448"],
+        "key_numbers": ["0,5%", "Rp 4,8 mld", "7-4-3 anni", "Rp 10 mld PT PMA"],
+        "bilingual_lexicon": [{"id_term": "omzet", "english_assist": "gross revenue", "always_untranslated": False}],
+        "taboo_check": ["no 'save money on taxes' (la riforma chiude un loophole)", "no 'PT PMA can use UMKM'"],
+        "archetype": "regulatory-explainer",
+        "tone_register": "analitico/militante",
+        "nb_sources": ["NB-4 848862af"],
+        "nb_snapshot_date": "2025-11-01T00:00:00+00:00",
+    }
+
+
+@pytest.fixture
+def item():
+    """A realistic shortlist item (the fresh news that corrects the stale NB)."""
+    return {
+        "id": "44122b09-0000-0000-0000-000000000000",
+        "item_id": "44122b09-0000-0000-0000-000000000000",
+        "title": "Pemerintah Ubah Aturan PPh Final UMKM, PT dan CV Tak Lagi Dapat Fasilitas",
+        "summary": "Pemerintah resmi menerbitkan PP 20/2026 tentang Perubahan atas PP 55/2022. Pasal 57.",
+        "canonical_url": "https://liputan6.com/pph-umkm-pp20-2026",
+        "source_domain": "liputan6.com",
+        "published_at": "2026-06-05T00:00:00+00:00",
+        "llm": {"relevance": 9, "service_line": "tax", "rationale": "core regulatory tax"},
+    }
+
+
+@pytest.fixture
+def prose_clean():
+    return {
+        "the_facts": "Pemerintah menerbitkan PP 20/2026 yang mengubah PP 55/2022.",
+        "bali_zero_take": "Per i clienti PT: niente nuova facility 0,5%.",
+        "thirty_second_brief": {"what": "PPh UMKM cambia", "why_it_matters": "PT esclusi",
+                                "who": "PT/CV", "risk_level": "medium"},
+        "next_steps": "Verificare regime fiscale corrente.",
+        "faq": [{"question": "PT PMA può usarlo?", "answer": "No, mai."}],
+        "conflict": False,
+        "conflict_note": "",
+    }
+
+
+# --- D5: content_hash --------------------------------------------------------
+def test_content_hash_deterministic(m):
+    assert m._content_hash("PP 20/2026", "testo a") == m._content_hash("PP 20/2026", "testo a")
+
+
+def test_content_hash_discriminates_content(m):
+    # same title, different body -> different hash (so re-brief triggers, D5)
+    assert m._content_hash("PP 20/2026", "in attesa firma") != m._content_hash("PP 20/2026", "emanata")
+
+
+# --- D6: rail injection into the_facts ---------------------------------------
+def test_rails_injected_into_facts(m, nb_brief):
+    facts = m._inject_rails_into_facts("I fatti base.", nb_brief)
+    assert "I fatti base." in facts                       # base prose preserved
+    assert "PP 55/2022" in facts                          # verbatim citation injected
+    assert "0,5%" in facts                                # key number injected
+    assert "loophole" in facts or "save money" in facts   # taboo injected
+    assert "NON usare" in facts                            # taboo header present
+
+
+def test_rails_injection_empty_nb_is_noop(m):
+    # no NB grounding -> just the base prose, no crash
+    assert m._inject_rails_into_facts("solo prosa", {}) == "solo prosa"
+
+
+# --- D2: staleness -----------------------------------------------------------
+def test_nb_staleness_days(m, nb_brief):
+    pub = m._parse_dt("2026-06-05T00:00:00+00:00")
+    assert m._nb_staleness_days(nb_brief, pub) == 216  # 2025-11-01 -> 2026-06-05
+
+
+def test_nb_staleness_none_when_missing(m):
+    assert m._nb_staleness_days({}, m._parse_dt("2026-06-05T00:00:00+00:00")) is None
+
+
+# --- D3: decide_status -------------------------------------------------------
+def test_decide_status_conflict_blocks(m):
+    assert m.decide_status({"conflict": True}) == m.STATUS_CONFLICT == "needs_review_conflict"
+
+
+def test_decide_status_clean_ready(m):
+    assert m.decide_status({"conflict": False}) == m.STATUS_READY == "briefed"
+
+
+# --- build_brief_json --------------------------------------------------------
+def test_build_brief_json_full_schema(m, item, nb_brief, prose_clean):
+    b = m.build_brief_json(item=item, nb_brief=nb_brief, prose=prose_clean, prev_revision=0)
+    # enrichment is the channel the drafter reads
+    assert isinstance(b["enrichment"], dict)
+    assert b["enrichment"]["the_facts"].startswith("Pemerintah menerbitkan PP 20/2026")
+    # D6: rails are INSIDE the_facts (drafter sees them)
+    assert "PP 55/2022" in b["enrichment"]["the_facts"]
+    assert "0,5%" in b["enrichment"]["the_facts"]
+    # minimal contract (drafter)
+    assert b["source_url"] == "https://liputan6.com/pph-umkm-pp20-2026"
+    assert isinstance(b["live_news_reasons"], list)
+    # idempotency provenance (D5)
+    assert b["content_hash"] and b["revision"] == 1
+    assert b["canonical_url"] == item["canonical_url"]
+    # rich fields persisted (future)
+    assert b["regulatory_citations_verbatim"] == nb_brief["regulatory_citations_verbatim"]
+    assert b["key_numbers"] == nb_brief["key_numbers"]
+    # fusion meta
+    assert b["fusion_meta"]["nb_staleness_days"] == 216
+    assert b["fusion_meta"]["conflict"] is False
+
+
+def test_build_brief_json_revision_bump(m, item, nb_brief, prose_clean):
+    b = m.build_brief_json(item=item, nb_brief=nb_brief, prose=prose_clean, prev_revision=2)
+    assert b["revision"] == 3  # re-brief bumps revision (D5)
+
+
+def test_build_brief_json_conflict_in_meta(m, item, nb_brief):
+    prose = {"the_facts": "fonti discordi", "conflict": True, "conflict_note": "norma emanata sì/no"}
+    b = m.build_brief_json(item=item, nb_brief=nb_brief, prose=prose, prev_revision=0)
+    assert b["fusion_meta"]["conflict"] is True
+    assert b["fusion_meta"]["conflict_note"] == "norma emanata sì/no"
+
+
+# --- D7: human gate in select_items ------------------------------------------
+def test_select_items_requires_explicit_gate(m, item):
+    shortlist = [item]
+    # no approved, no item_id -> EMPTY (never process whole shortlist blindly)
+    assert m.select_items(shortlist, approved=None, item_id=None, top=3) == []
+
+
+def test_select_items_by_item_id(m, item):
+    picked = m.select_items([item], approved=None, item_id=item["item_id"], top=3)
+    assert len(picked) == 1 and picked[0]["item_id"] == item["item_id"]
+
+
+def test_select_items_by_approved_list(m, item):
+    picked = m.select_items([item], approved=[item["item_id"]], item_id=None, top=3)
+    assert len(picked) == 1
+
+
+def test_select_items_top_caps_approved(m):
+    items = [{"item_id": f"id-{i}"} for i in range(10)]
+    approved = [f"id-{i}" for i in range(10)]
+    assert len(m.select_items(items, approved=approved, item_id=None, top=2)) == 2
+
+
+# --- fail-closed JSON extraction ---------------------------------------------
+def test_extract_json_obj_empty_raises(m):
+    with pytest.raises(ValueError, match="vuota"):
+        m._extract_json_obj("")
+
+
+def test_extract_json_obj_no_json_raises(m):
+    with pytest.raises(ValueError, match="nessun oggetto JSON"):
+        m._extract_json_obj("just prose no braces here")
+
+
+def test_extract_json_obj_extracts(m):
+    assert m._extract_json_obj('preamble {"ok": true} trailing')["ok"] is True

--- a/scripts/warroom_step1_reader.py
+++ b/scripts/warroom_step1_reader.py
@@ -60,7 +60,11 @@ OUT_DIR_DEFAULT = Path.home() / "Desktop" / "nuzantara" / "var" / "war_room"
 
 # ---- Token MAX dal Keychain (auto-refresh dal CLI), fallback env ------------
 def load_oauth_token() -> str:
-    """accessToken OAuth dal Keychain del CLI claude. MAI loggato. Fallback env var."""
+    """accessToken OAuth MAX. MAI loggato. Ordine: Keychain → ~/.claude/.credentials.json → env.
+
+    Sul Pro (SSH headless, dove gira il cron) il Keychain è bloccato: il token vive nel file
+    ~/.claude/.credentials.json. Per questo proviamo il file PRIMA della env var. MAI stampare il token.
+    """
     try:
         raw = subprocess.run(
             ["security", "find-generic-password",
@@ -71,10 +75,18 @@ def load_oauth_token() -> str:
         if tok:
             return tok
     except Exception as exc:  # noqa: BLE001
-        logger.debug("keychain token read failed (%s), trying env", type(exc).__name__)
+        logger.debug("keychain token read failed (%s), trying credentials file", type(exc).__name__)
+    try:
+        cred = Path.home() / ".claude" / ".credentials.json"
+        if cred.exists():
+            tok = json.loads(cred.read_text())["claudeAiOauth"]["accessToken"]
+            if tok:
+                return tok
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("credentials file read failed (%s), trying env", type(exc).__name__)
     tok = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
     if not tok:
-        raise RuntimeError("nessun token MAX: né Keychain 'Claude Code-credentials' né CLAUDE_CODE_OAUTH_TOKEN")
+        raise RuntimeError("nessun token MAX: né Keychain, né ~/.claude/.credentials.json, né CLAUDE_CODE_OAUTH_TOKEN")
     return tok
 
 

--- a/scripts/warroom_step2_briefer.py
+++ b/scripts/warroom_step2_briefer.py
@@ -117,7 +117,13 @@ RETURNING id
 # RIUSO da Step 1 — token / DSN / client (pattern identico, vedi warroom_step1_reader.py)
 # ============================================================================
 def load_oauth_token() -> str:
-    """accessToken OAuth dal Keychain del CLI claude. MAI loggato. Fallback env var."""
+    """accessToken OAuth MAX. MAI loggato. Ordine: Keychain → ~/.claude/.credentials.json → env.
+
+    Sul Pro (SSH headless) il Keychain è bloccato: il token vive nel file
+    ~/.claude/.credentials.json (cicatrice 'keychain SSH-locked sul Pro'). Per questo proviamo
+    il file PRIMA della env var. MAI stampare il token.
+    """
+    # 1) Keychain (macchina interactive)
     try:
         raw = subprocess.run(
             ["security", "find-generic-password",
@@ -128,10 +134,20 @@ def load_oauth_token() -> str:
         if tok:
             return tok
     except Exception as exc:  # noqa: BLE001
-        logger.debug("keychain token read failed (%s), trying env", type(exc).__name__)
+        logger.debug("keychain token read failed (%s), trying credentials file", type(exc).__name__)
+    # 2) ~/.claude/.credentials.json (Pro headless — Keychain SSH-locked)
+    try:
+        cred = Path.home() / ".claude" / ".credentials.json"
+        if cred.exists():
+            tok = json.loads(cred.read_text())["claudeAiOauth"]["accessToken"]
+            if tok:
+                return tok
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("credentials file read failed (%s), trying env", type(exc).__name__)
+    # 3) env var
     tok = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
     if not tok:
-        raise RuntimeError("nessun token MAX: né Keychain 'Claude Code-credentials' né CLAUDE_CODE_OAUTH_TOKEN")
+        raise RuntimeError("nessun token MAX: né Keychain, né ~/.claude/.credentials.json, né CLAUDE_CODE_OAUTH_TOKEN")
     return tok
 
 

--- a/scripts/warroom_step2_briefer.py
+++ b/scripts/warroom_step2_briefer.py
@@ -1,0 +1,568 @@
+#!/usr/bin/env python3
+"""War Room — Step 2: shortlist → draft briefato (B-FUSIONE).
+
+Prende un item della shortlist (Step 1, già APPROVATO da umano — gate §8.7), lo arricchisce
+fondendo i FATTI FRESCHI della news col GROUNDING VERBATIM di NotebookLM, e scrive un
+`brief_json` esteso in `war_room_drafts`.
+
+Design + verdetto panel 4-LLM (2026-06-06):
+  research/marketing/2026-06-06-warroom-step2-design.md  (§7 verdetto, §8 7 decisioni chiuse)
+
+Le 7 decisioni implementate qui:
+  D1 (Q1) FUSIONE IBRIDA — l'LLM scrive SOLO la prosa narrativa (the_facts/bali_zero_take/...).
+          Provenienza, scelta news-vs-NB, freshness_override e i campi-safety (taboo/lexicon/
+          citations/numbers) sono COPIATI VERBATIM da NB con codice deterministico. L'LLM non
+          tocca mai una citazione o un numero strutturale.
+  D2 (Q2) NEWS-CORRECTOR — la news fresca corregge i fatti datati NB stale; mai bloccare sull'NB;
+          emette fusion_meta.nb_staleness_days + freshness_overrides[].
+  D3 (Q3) CONFLITTO → BLOCCA — conflitto sostanziale ⇒ status='needs_review_conflict' (il drafter
+          cron lo salta). Solo i puliti diventano 'briefed'.
+  D4 (Q4) 1-BY-1 + CAP + STOP-PULITO — processa in ordine di rilevanza, cap WR2_BRIEF_MAX_PER_RUN
+          (default 3), stop pulito su quota (mai mezza coda di brief falliti).
+  D5 (Q5) IDEMPOTENZA + RE-BRIEF — skip se canonical_url già briefato in QUALSIASI data, MA se il
+          contenuto è mutato (content_hash o published_at cambiati) ⇒ re-brief UPSERT (bump revision).
+          Risolve il caso PP 20/2026 (stesso URL, "in attesa firma" → "emanata").
+  D6 (Q6) RAIL DENTRO ENRICHMENT — oltre a persistere i campi ricchi, INIETTA taboo/citazioni/numeri
+          DENTRO `enrichment` (il canale che il drafter GIA legge): the_facts incorpora le citazioni
+          verbatim, una riga 'NON usare: <taboo>', i numeri chiave nel testo. Zero modifiche al drafter.
+  D7 (Q6) GATE UMANO PRIMA — gira solo su item APPROVATI (--approved / --item-id), non auto su tutta
+          la shortlist.
+
+Vincoli (hard, vedi design §6):
+  - Claude quota MAX via SDK auth_token (HTTP Bearer), MAI api_key (pay-as-you-go). Riusa il client
+    RAW dello Step 1. ⚠️ Il CLAUDE.md di progetto §5 dice ancora "SDK BANNED" — conflitto da
+    riconciliare pre-merge (auth_token=MAX OAuth OK; api_key=bandito). Vedi design §6.
+  - Law 2: news pubblica + NB conoscenza operativa (non PII) → cloud OK.
+  - Legge 5: scrive un draft, NON pubblica. Drafter + review-gate restano a valle.
+  - Anti-allucinazione: conflitto news/NB ⇒ NON inventare la sintesi, status needs_review_conflict.
+
+Reuse-first (design §5):
+  - load_oauth_token / load_dsn / _build_client  ← [RIUSA] da warroom_step1_reader.py (pattern identico)
+  - forma brief_json + INSERT war_room_drafts     ← [FORKA-E-ADATTA] da wr2_topic_selector.py:605
+  - wr2-brief-interpreter (NB ground-truth)        ← [INVOCA] — qui via stub iniettabile (vedi §brief)
+
+NB SULL'INVOCAZIONE brief-interpreter: questo script è un processo Python, NON una sessione Claude
+con l'Agent tool. NON può dispatchare il subagent wr2-brief-interpreter da solo. Due modalità:
+  (a) --nb-brief <file.json>  : il grounding NB è prodotto a monte (dall'orchestratore Claude che
+      invoca il subagent) e passato come file. Modalità di produzione.
+  (b) --no-nb                  : salta il grounding NB (fusione degradata = solo news). Per collaudo
+      della pipeline DB/fusione-prosa senza NB.
+Così la responsabilità "interrogare NotebookLM" resta dell'orchestratore (Contract NB), e questo
+script resta un puro fonditore+persister deterministico+1-LLM-call-prosa.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger("warroom.step2")
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# --- Costanti (panel-derived) ------------------------------------------------
+MAX_PER_RUN = int(os.environ.get("WR2_BRIEF_MAX_PER_RUN", "3"))  # D4 cap
+LLM_MODEL = os.environ.get("WR2_BRIEF_MODEL", "claude-sonnet-4-5-20250929")
+OUT_DIR_DEFAULT = _REPO_ROOT / "var" / "war_room"
+
+# status separati (D3 — separazione storage/readiness)
+STATUS_READY = "briefed"               # il drafter cron consuma SOLO questo
+STATUS_CONFLICT = "needs_review_conflict"  # bloccato, attende revisione umana
+
+# Stadio 3: SQL per leggere il summary COMPLETO dal DB (lo shortlist ha summary troncato)
+FETCH_FULL_SQL = """
+SELECT id, canonical_url, content_hash, title, summary, source_domain,
+       published_at, first_seen_at, topic_tags
+FROM intel_items
+WHERE id = $1::uuid
+"""
+
+# D5: esiste già un draft per questo canonical_url? in QUALSIASI data.
+DEDUP_SQL = """
+SELECT id, status,
+       brief_json->>'content_hash'  AS prev_hash,
+       brief_json->>'published_at'  AS prev_published,
+       COALESCE((brief_json->>'revision')::int, 1) AS revision
+FROM war_room_drafts
+WHERE brief_json->>'canonical_url' = $1
+ORDER BY created_at DESC
+LIMIT 1
+"""
+
+INSERT_SQL = """
+INSERT INTO war_room_drafts (topic, register, status, brief_json)
+VALUES ($1, NULL, $2, $3::jsonb)
+RETURNING id
+"""
+
+# D5 re-brief: aggiorna la riga esistente (UPSERT manuale) bump revision
+UPDATE_SQL = """
+UPDATE war_room_drafts
+SET status = $2, brief_json = $3::jsonb, updated_at = now()
+WHERE id = $1
+RETURNING id
+"""
+
+
+# ============================================================================
+# RIUSO da Step 1 — token / DSN / client (pattern identico, vedi warroom_step1_reader.py)
+# ============================================================================
+def load_oauth_token() -> str:
+    """accessToken OAuth dal Keychain del CLI claude. MAI loggato. Fallback env var."""
+    try:
+        raw = subprocess.run(
+            ["security", "find-generic-password",
+             "-s", "Claude Code-credentials", "-a", os.environ.get("USER", ""), "-w"],
+            capture_output=True, text=True, check=True, timeout=10,
+        ).stdout.strip()
+        tok = json.loads(raw)["claudeAiOauth"]["accessToken"]
+        if tok:
+            return tok
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("keychain token read failed (%s), trying env", type(exc).__name__)
+    tok = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
+    if not tok:
+        raise RuntimeError("nessun token MAX: né Keychain 'Claude Code-credentials' né CLAUDE_CODE_OAUTH_TOKEN")
+    return tok
+
+
+def load_dsn() -> str:
+    env_path = _REPO_ROOT / "apps" / "backend-rag" / ".env"
+    for line in env_path.read_text().splitlines():
+        if line.startswith("DATABASE_URL="):
+            url = line.split("=", 1)[1].strip().strip('"').strip("'")
+            return re.sub(r"@[^/]+/", "@127.0.0.1:15432/", url)
+    raise RuntimeError(f"DATABASE_URL non trovato in {env_path}")
+
+
+def _build_client(token: str):
+    """anthropic.Anthropic(auth_token=...) — client RAW (header Bearer = MAX). MAI api_key.
+
+    Identico allo Step 1: client PURO, path prompt→testo via messages.create. NON instructor
+    (richiederebbe response_model). Vedi warroom_step1_reader._build_client per la cicatrice.
+    """
+    os.environ.pop("ANTHROPIC_API_KEY", None)  # defense-in-depth (Golden Rule #6)
+    import anthropic
+    return anthropic.Anthropic(auth_token=token)
+
+
+# ============================================================================
+# Helpers deterministici (D1 — niente LLM qui)
+# ============================================================================
+def _parse_dt(value: Any) -> Optional[datetime]:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None
+
+
+def _content_hash(title: str, summary: str) -> str:
+    """Hash deterministico del contenuto news (D5 — discrimina 'contenuto mutato')."""
+    h = hashlib.sha256()
+    h.update((title or "").strip().encode("utf-8"))
+    h.update(b"\x00")
+    h.update((summary or "").strip().encode("utf-8"))
+    return h.hexdigest()
+
+
+def _nb_staleness_days(nb_brief: dict[str, Any], news_published: Optional[datetime]) -> Optional[int]:
+    """D2: delta giorni tra la data-snapshot più recente delle source NB e la pubblicazione news.
+
+    Il brief-interpreter può fornire `nb_snapshot_date` (la data più recente delle sue source).
+    Se assente, ritorna None (staleness ignota, non bloccante).
+    """
+    snap = _parse_dt(nb_brief.get("nb_snapshot_date"))
+    if not snap or not news_published:
+        return None
+    return max(0, (news_published - snap).days)
+
+
+def load_nb_brief(path: Optional[str]) -> dict[str, Any]:
+    """Carica il grounding NB prodotto a monte dal subagent wr2-brief-interpreter (modalità a).
+
+    Schema atteso (campi tutti opzionali — degrada, mai eccezione):
+      key_facts[], regulatory_citations_verbatim[], key_numbers[], bilingual_lexicon[],
+      taboo_check[], archetype, tone_register, hook_angle, nb_sources[], nb_snapshot_date
+    """
+    if not path:
+        return {}
+    p = Path(path)
+    if not p.exists():
+        raise RuntimeError(f"--nb-brief file non trovato: {path}")
+    data = json.loads(p.read_text())
+    if not isinstance(data, dict):
+        raise RuntimeError(f"--nb-brief deve essere un oggetto JSON, trovato {type(data).__name__}")
+    return data
+
+
+# ============================================================================
+# D6 — iniezione rail dentro enrichment (deterministica)
+# ============================================================================
+def _inject_rails_into_facts(prose_facts: str, nb_brief: dict[str, Any]) -> str:
+    """Incorpora citazioni verbatim + numeri chiave + taboo DENTRO the_facts (il drafter li vede).
+
+    Il drafter legge solo `enrichment.the_facts` (oltre ad altri campi enrichment); NON legge
+    i campi ricchi top-level. Quindi i guardrail DEVONO arrivare qui dentro o sono invisibili.
+    """
+    parts = [prose_facts.strip()] if prose_facts and prose_facts.strip() else []
+
+    cites = [c for c in (nb_brief.get("regulatory_citations_verbatim") or []) if str(c).strip()]
+    if cites:
+        parts.append("Riferimenti normativi (verbatim, citare senza parafrasare): "
+                      + " · ".join(str(c).strip() for c in cites[:8]))
+
+    nums = [str(n).strip() for n in (nb_brief.get("key_numbers") or []) if str(n).strip()]
+    if nums:
+        parts.append("Numeri chiave (riportare esatti): " + ", ".join(nums[:12]))
+
+    taboos = [str(t).strip() for t in (nb_brief.get("taboo_check") or []) if str(t).strip()]
+    if taboos:
+        parts.append("NON usare / evitare: " + " ; ".join(taboos[:8]))
+
+    return "\n\n".join(parts)
+
+
+# ============================================================================
+# STADIO 3 — fusione (1 sola LLM call: SOLO prosa; resto deterministico)
+# ============================================================================
+FUSION_PROMPT = """Sei l'analista editoriale di Bali Zero (consulenza immigrazione/società/tax/property in Indonesia).
+Devi scrivere la PROSA di un brief per un carosello Instagram, fondendo due fonti su uno stesso tema.
+
+FONTE A — NOTIZIA FRESCA (fatti aggiornati, può avere lo stato corrente di una norma):
+Titolo: {news_title}
+Testo: {news_summary}
+Data pubblicazione: {news_published}
+
+FONTE B — GROUND TRUTH NotebookLM (profondità normativa, può essere DATATA):
+Fatti chiave: {nb_key_facts}
+Snapshot NB: {nb_snapshot}
+
+REGOLE DI FUSIONE (vincolanti):
+1. Per FATTI DATATI/PROCEDURALI (stato di una norma, se è emanata, numeri, scadenze): la NOTIZIA
+   FRESCA vince se più recente del ground-truth NB. Non ripetere lo stato vecchio dell'NB se la news lo aggiorna.
+2. NON inventare. Se news e NB si contraddicono su un FATTO SOSTANZIALE (es. una norma è emanata
+   oppure no), NON scegliere a caso e NON sintetizzare: scrivi che le fonti sono discordi e imposta
+   il campo "conflict" a true nel JSON di output.
+3. Tono: analitico, asciutto, mai sensazionalista. Niente promesse, niente "risparmia tasse",
+   niente claim regolatori che non sono nelle fonti.
+
+Scrivi SOLO un oggetto JSON (nessun testo fuori dal JSON) con ESATTAMENTE queste chiavi:
+{{
+  "the_facts": "<2-4 frasi sui fatti fusi, privilegiando lo stato corrente dalla news>",
+  "bali_zero_take": "<2-3 frasi: cosa significa concretamente per i clienti Bali Zero>",
+  "thirty_second_brief": {{"what":"<1 frase>","why_it_matters":"<1 frase>","who":"<chi è toccato>","risk_level":"<low|medium|high>"}},
+  "next_steps": "<1-2 frasi azionabili>",
+  "faq": [{{"question":"<domanda>","answer":"<risposta breve>"}}],
+  "conflict": <true|false>,
+  "conflict_note": "<se conflict=true, 1 frase su cosa diverge; altrimenti stringa vuota>"
+}}"""
+
+
+def _extract_json_obj(text: str) -> dict[str, Any]:
+    """Estrae il primo oggetto JSON dal testo dell'LLM (robusto a preamboli).
+
+    Fail-closed esplicito su risposta vuota/troncata (collaudo 2026-06-06: un reasoner con
+    max_tokens basso può restituire content='' bruciando il budget nel reasoning — qui solleva
+    un errore chiaro che brief_one cattura e logga, mai un brief corrotto).
+    """
+    if not text or not text.strip():
+        raise ValueError("risposta LLM vuota (probabile troncamento/quota — nessun JSON da estrarre)")
+    m = re.search(r"\{.*\}", text, re.DOTALL)
+    if not m:
+        raise ValueError(f"nessun oggetto JSON nella risposta LLM (primi 120 char: {text[:120]!r})")
+    return json.loads(m.group(0))
+
+
+def fuse_prose(client, *, news_title: str, news_summary: str,
+               news_published: Optional[datetime], nb_brief: dict[str, Any]) -> dict[str, Any]:
+    """Una sola chiamata LLM: genera la prosa fusa + il flag conflict. NIENTE citazioni/numeri qui."""
+    key_facts = nb_brief.get("key_facts") or []
+    prompt = FUSION_PROMPT.format(
+        news_title=news_title[:400],
+        news_summary=(news_summary or "")[:6000],
+        news_published=news_published.isoformat() if news_published else "ignota",
+        nb_key_facts=" | ".join(str(f) for f in key_facts[:15]) if key_facts else "(nessun grounding NB)",
+        nb_snapshot=nb_brief.get("nb_snapshot_date") or "ignoto",
+    )
+    resp = client.messages.create(
+        model=LLM_MODEL,
+        max_tokens=3000,
+        temperature=0,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    text = "".join(block.text for block in resp.content if getattr(block, "type", None) == "text")
+    if getattr(resp, "stop_reason", None) == "max_tokens":
+        logger.warning("fusione troncata (stop_reason=max_tokens) — JSON potrebbe essere incompleto")
+    return _extract_json_obj(text)
+
+
+# ============================================================================
+# Costruzione brief_json (deterministica, post-fusione)
+# ============================================================================
+def build_brief_json(*, item: dict[str, Any], nb_brief: dict[str, Any],
+                     prose: dict[str, Any], prev_revision: int = 0) -> dict[str, Any]:
+    """Assembla il brief_json esteso. enrichment con rail iniettati (D6) + campi ricchi (futuro)."""
+    title = item.get("title") or ""
+    summary = item.get("summary") or ""
+    published = _parse_dt(item.get("published_at"))
+    chash = item.get("content_hash") or _content_hash(title, summary)
+
+    # D6: i rail (citazioni/numeri/taboo) entrano DENTRO the_facts (il drafter li vede)
+    facts_with_rails = _inject_rails_into_facts(prose.get("the_facts", ""), nb_brief)
+
+    enrichment = {
+        "thirty_second_brief": prose.get("thirty_second_brief") or {},
+        "the_facts": facts_with_rails,
+        "bali_zero_take": prose.get("bali_zero_take", ""),
+        "in_practice": prose.get("next_steps", ""),  # drafter legge in_practice; mappiamo next_steps
+        "next_steps": prose.get("next_steps", ""),
+        "faq": (prose.get("faq") or [])[:6],
+    }
+
+    brief: dict[str, Any] = {
+        # --- contratto minimo (drafter) ---
+        "article_title": title,
+        "article_summary": summary[:6000],
+        "source_url": item.get("canonical_url"),
+        "live_news_reasons": (item.get("llm") or {}).get("rationale") and [item["llm"]["rationale"]] or [],
+        "live_news_score": (item.get("llm") or {}).get("relevance"),
+        "enrichment": enrichment,
+        # --- idempotenza / provenienza (D5) ---
+        "staging_id": str(item.get("id")) if item.get("id") else None,
+        "staging_type": (item.get("llm") or {}).get("service_line"),
+        "canonical_url": item.get("canonical_url"),
+        "content_hash": chash,
+        "published_at": published.isoformat() if published else None,
+        "revision": prev_revision + 1,
+        # --- campi ricchi NB (persistiti per Step 3 / drafter-v2) ---
+        "key_facts": nb_brief.get("key_facts") or [],
+        "key_numbers": nb_brief.get("key_numbers") or [],
+        "regulatory_citations_verbatim": nb_brief.get("regulatory_citations_verbatim") or [],
+        "bilingual_lexicon": nb_brief.get("bilingual_lexicon") or [],
+        "taboo_check": nb_brief.get("taboo_check") or [],
+        "archetype": nb_brief.get("archetype"),
+        "tone_register": nb_brief.get("tone_register"),
+        # --- meta fusione (D2 staleness + audit) ---
+        "fusion_meta": {
+            "nb_sources": nb_brief.get("nb_sources") or [],
+            "nb_snapshot_date": nb_brief.get("nb_snapshot_date"),
+            "nb_staleness_days": _nb_staleness_days(nb_brief, published),
+            "conflict": bool(prose.get("conflict")),
+            "conflict_note": prose.get("conflict_note", "") if prose.get("conflict") else "",
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "model": LLM_MODEL,
+        },
+    }
+    return brief
+
+
+def decide_status(prose: dict[str, Any]) -> str:
+    """D3: conflitto sostanziale ⇒ blocca (drafter salta); altrimenti pronto."""
+    return STATUS_CONFLICT if prose.get("conflict") else STATUS_READY
+
+
+# ============================================================================
+# DB I/O (skippabile in --dry-run)
+# ============================================================================
+async def fetch_full_item(conn, item_id: str) -> Optional[dict[str, Any]]:
+    row = await conn.fetchrow(FETCH_FULL_SQL, item_id)
+    return dict(row) if row else None
+
+
+async def check_existing(conn, canonical_url: str) -> Optional[dict[str, Any]]:
+    if not canonical_url:
+        return None
+    row = await conn.fetchrow(DEDUP_SQL, canonical_url)
+    return dict(row) if row else None
+
+
+async def persist(conn, *, topic: str, status: str, brief: dict[str, Any],
+                  existing: Optional[dict[str, Any]]) -> tuple[str, str]:
+    """INSERT nuovo o UPDATE (re-brief D5). Ritorna (draft_id, action)."""
+    payload = json.dumps(brief)
+    if existing:
+        draft_id = await conn.fetchval(UPDATE_SQL, existing["id"], status, payload)
+        return str(draft_id), "rebrief-update"
+    draft_id = await conn.fetchval(INSERT_SQL, topic[:500], status, payload)
+    return str(draft_id), "insert"
+
+
+# ============================================================================
+# Orchestrazione di un singolo item
+# ============================================================================
+async def brief_one(conn, client, *, item_min: dict[str, Any], nb_brief: dict[str, Any],
+                    dry_run: bool) -> dict[str, Any]:
+    """Processa 1 item della shortlist. conn può essere None se dry_run (no DB).
+
+    item_min = record shortlist (item_id, title, canonical_url, source_domain, published_at, llm).
+    """
+    item_id = item_min.get("item_id") or item_min.get("id")
+    canonical_url = item_min.get("canonical_url")
+    title_short = item_min.get("title") or ""
+
+    # Stadio 1: summary COMPLETO dal DB (lo shortlist ha summary troncato). Se no-DB, usa lo shortlist.
+    if conn is not None and item_id:
+        full = await fetch_full_item(conn, str(item_id))
+        if not full:
+            return {"item_id": item_id, "status": "skipped", "reason": "item non trovato in intel_items"}
+        item = {**item_min, **full}  # full sovrascrive (summary completo, content_hash, published_at reali)
+    else:
+        item = dict(item_min)
+        item.setdefault("content_hash", _content_hash(title_short, item.get("summary") or ""))
+
+    # D5: dedup + decisione re-brief
+    existing = await check_existing(conn, canonical_url) if conn is not None else None
+    prev_revision = 0
+    if existing:
+        cur_hash = item.get("content_hash") or _content_hash(item.get("title") or "", item.get("summary") or "")
+        cur_pub = (_parse_dt(item.get("published_at")).isoformat()
+                   if _parse_dt(item.get("published_at")) else None)
+        changed = (existing.get("prev_hash") != cur_hash) or (existing.get("prev_published") != cur_pub)
+        if not changed:
+            return {"item_id": item_id, "status": "skipped",
+                    "reason": f"già briefato (draft {existing['id']}, rev {existing['revision']}), contenuto invariato"}
+        prev_revision = int(existing.get("revision") or 1)
+        logger.info("re-brief: canonical_url cambiato (hash/published) → bump rev %d", prev_revision + 1)
+
+    # Stadio 3: fusione (1 LLM call, solo prosa)
+    prose = fuse_prose(
+        client,
+        news_title=item.get("title") or title_short,
+        news_summary=item.get("summary") or "",
+        news_published=_parse_dt(item.get("published_at")),
+        nb_brief=nb_brief,
+    )
+
+    brief = build_brief_json(item=item, nb_brief=nb_brief, prose=prose, prev_revision=prev_revision)
+    status = decide_status(prose)
+
+    if dry_run or conn is None:
+        return {"item_id": item_id, "status": "dry-run", "would_be_status": status,
+                "conflict": bool(prose.get("conflict")), "brief_json": brief}
+
+    draft_id, action = await persist(
+        conn, topic=item.get("title") or title_short, status=status, brief=brief, existing=existing)
+    return {"item_id": item_id, "status": status, "action": action, "draft_id": draft_id,
+            "conflict": bool(prose.get("conflict"))}
+
+
+# ============================================================================
+# Selezione item da processare (D7 — solo approvati)
+# ============================================================================
+def load_shortlist(path: Path) -> list[dict[str, Any]]:
+    data = json.loads(path.read_text())
+    return data.get("shortlist") or []
+
+
+def select_items(shortlist: list[dict[str, Any]], *, approved: Optional[list[str]],
+                 item_id: Optional[str], top: int) -> list[dict[str, Any]]:
+    """D7: senza --approved/--item-id NON si processa tutta la shortlist alla cieca."""
+    if item_id:
+        return [r for r in shortlist if str(r.get("item_id")) == item_id][:1]
+    if approved:
+        approved_set = set(approved)
+        picked = [r for r in shortlist if str(r.get("item_id")) in approved_set]
+        return picked[: max(0, top)]
+    # nessun gate fornito → comportamento sicuro: niente (richiede selezione esplicita)
+    return []
+
+
+# ============================================================================
+# main
+# ============================================================================
+async def run(args) -> int:
+    out_dir = Path(args.out_dir)
+    shortlist_path = (Path(args.shortlist) if args.shortlist
+                      else out_dir / f"shortlist-{datetime.now(timezone.utc):%Y-%m-%d}.json")
+    if not shortlist_path.exists():
+        logger.error("shortlist non trovata: %s", shortlist_path)
+        return 2
+    shortlist = load_shortlist(shortlist_path)
+
+    approved = args.approved.split(",") if args.approved else None
+    items = select_items(shortlist, approved=approved, item_id=args.item_id, top=args.top)
+    if not items:
+        logger.error("nessun item selezionato. Fornisci --item-id <uuid> o --approved <id1,id2,...> "
+                     "(gate umano D7). Shortlist ha %d candidati.", len(shortlist))
+        return 3
+    items = items[:MAX_PER_RUN]  # D4 cap
+    logger.info("Step 2: %d item selezionati (cap %d). dry_run=%s no_nb=%s",
+                len(items), MAX_PER_RUN, args.dry_run, args.no_nb)
+
+    nb_brief = {} if args.no_nb else load_nb_brief(args.nb_brief)
+    if not nb_brief and not args.no_nb:
+        logger.warning("nessun --nb-brief e non --no-nb: il grounding NB sarà VUOTO (fusione degradata). "
+                       "In produzione l'orchestratore deve passare il brief NB del subagent.")
+
+    client = _build_client(load_oauth_token())
+
+    conn = None
+    if not args.dry_run:
+        import asyncpg  # local import (solo se serve il DB)
+        conn = await asyncio.wait_for(asyncpg.connect(load_dsn()), timeout=20)
+    elif args.with_db:  # dry-run ma con lettura DB per summary completo (no INSERT)
+        import asyncpg
+        conn = await asyncio.wait_for(asyncpg.connect(load_dsn()), timeout=20)
+
+    results = []
+    try:
+        for it in items:
+            try:
+                res = await brief_one(conn, client, item_min=it, nb_brief=nb_brief,
+                                      dry_run=args.dry_run)
+            except Exception as exc:  # noqa: BLE001 — D4 stop-pulito: logga e prosegui col prossimo
+                logger.error("item %s fallito: %s", it.get("item_id"), exc)
+                res = {"item_id": it.get("item_id"), "status": "error", "reason": str(exc)}
+            results.append(res)
+            logger.info("→ %s: %s", it.get("title", "")[:70], res.get("status"))
+    finally:
+        if conn is not None:
+            await conn.close()
+
+    # output: scrivi il risultato (i brief in dry-run) su file per ispezione
+    out_path = out_dir / f"step2-{datetime.now(timezone.utc):%Y-%m-%dT%H%M%S}.json"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps({"results": results}, ensure_ascii=False, indent=2))
+    logger.info("Step 2 done. %d risultati → %s", len(results), out_path)
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--shortlist", help="path shortlist-YYYY-MM-DD.json (default: oggi in --out-dir)")
+    p.add_argument("--out-dir", default=str(OUT_DIR_DEFAULT))
+    p.add_argument("--item-id", help="processa SOLO questo item_id (gate umano singolo)")
+    p.add_argument("--approved", help="lista item_id approvati, comma-separated (gate umano D7)")
+    p.add_argument("--top", type=int, default=MAX_PER_RUN, help=f"max item dagli approvati (default {MAX_PER_RUN})")
+    p.add_argument("--nb-brief", help="path JSON col grounding NB prodotto dal subagent wr2-brief-interpreter")
+    p.add_argument("--no-nb", action="store_true", help="salta il grounding NB (fusione degradata, collaudo)")
+    p.add_argument("--dry-run", action="store_true", help="NON scrive war_room_drafts (stampa i brief)")
+    p.add_argument("--with-db", action="store_true",
+                   help="in dry-run, legge comunque il DB per il summary completo (no INSERT)")
+    args = p.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+                        stream=sys.stderr)
+    try:
+        return asyncio.run(run(args))
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## War Room Step 2 — shortlist item → rich brief → war_room_drafts

Second link of the rebuilt War Room (Step 1 = #1152, merged). Takes an **approved**
shortlist item, fuses **fresh news facts** with **verbatim NotebookLM grounding**, and
writes a `brief_json` the existing drafter consumes — with the safety rails injected so
the drafter actually respects them.

### Panel 4-LLM verdict (design v2 §8)
Reviewed by Claude + Gemini + DeepSeek + Codex. 3/4 independently found the same flaw:
`status='briefed'` conflated "brief exists" with "safe for drafter", and the dual-rail
persisted rich fields (taboo/citations/numbers) the drafter never reads. The 7 closed decisions:

- **D1 hybrid fusion** — 1 LLM call writes prose ONLY; citations/numbers/taboo copied verbatim from NB by deterministic code (LLM never touches a citation or a structural number).
- **D2 news-corrector** — fresh news corrects stale NB facts; `fusion_meta.nb_staleness_days`; never block on NB.
- **D3 conflict blocks** — substantive conflict → `status='needs_review_conflict'` (the cron drafter skips it).
- **D4 1-by-1 + cap** — `WR2_BRIEF_MAX_PER_RUN=3`, clean stop on per-item failure.
- **D5 dedup + re-brief** — dedup `canonical_url` any-date, BUT re-brief (UPSERT, bump revision) when `content_hash`/`published_at` change (fixes the PP 20/2026 case: same URL, "awaiting signature" → "enacted").
- **D6 rails into enrichment** — taboo/citations/numbers injected INTO `enrichment.the_facts` (the field the drafter reads). **Drafter untouched** — backward-compatible.
- **D7 human gate** — processes only `--approved`/`--item-id`, never the whole shortlist blindly.

### Files
- `scripts/warroom_step2_briefer.py` (568) — the briefer
- `scripts/tests/test_warroom_step2.py` — **18 deterministic tests, green**
- `scripts/warroom_step1_reader.py` + `warroom_step2_briefer.py` — `load_oauth_token` now reads `~/.claude/.credentials.json` (the Pro is SSH-headless, Keychain locked, token lives in that file — without this the cron can't auth Claude)
- `research/marketing/2026-06-06-warroom-step2-*.md` — design v2 + poor-vs-rich comparison

### Tested (NOT deployed, Legge 5: writes a draft, does not publish)
- Deterministic logic: **18/18 green** (content_hash, rail-injection, staleness=216d, decide_status, build_brief_json, human-gate, fail-closed JSON).
- DB-real on the Pro: read real `intel_items` item (PP 20/2026) + `fetch_full_item` + dedup — all real, no INSERT.
- End-to-end fusion pipeline proven with a real LLM (prompt → code parser → brief_json with rails in `the_facts`).
- Claude-as-engine E2E + real INSERT: **pending MAX quota** (429); path verified valid (Bearer accepted). Script armed on the Pro to fire when quota frees.

### ⚠️ To reconcile before/at merge
Project `CLAUDE.md §5` still says "Anthropic SDK BANNED. Never `from anthropic import Anthropic`".
Antonello corrected the rule (2026-06-06): SDK with **`auth_token`** consumes MAX OAuth quota
(`Authorization: Bearer`, distinct from the banned `api_key` pay-as-you-go path). The global
`~/.claude/CLAUDE.md` already reflects this dual-auth; the project file needs updating so a future
reader doesn't think the import is forbidden. Code-review pre-merge: anti-`auth_token`↔`api_key` swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)