### PR TITLE
feat(sentinel): guardrail-liveness — spec + behavioral-liveness module + TDD

### DIFF
--- a/.claude/rules/cicatrix-scars.md
+++ b/.claude/rules/cicatrix-scars.md
@@ -376,6 +376,7 @@ done
 _Discovered: 2026-06-05 while planning P-4 (topic_type_log) off the autopsy report · Severity: P3 (process/trust, not runtime) · Status: REPORTED — the autopsy report stays as-is (it was right about the SUBSTANCE), this scar inoculates future readers against its 3 phantom citations_
 
 **TRAUMA:** `research/operations/2026-06-04-wr2-autopsy-report.md` (the 13-agent autopsy, finding #10 + per-dimension "Anti-monotony") cites, with PRECISE line numbers, three artifacts that DO NOT EXIST:
+
 - `_state-schema.sql:63` (claimed to define a SQLite `topic_type_log` table)
 - `_voyager-curriculum.py:49` (claimed to read it via a LEFT JOIN)
 - `topic_type_log` itself as an existing-but-empty table
@@ -387,6 +388,7 @@ A SECOND autopsy claim was also wrong (caught by an Explore + direct re-verify):
 **ANTIBODY:** When a long multi-agent report (autopsy, deep-research, council synthesis) cites `file:line`, treat those citations as LEADS, not facts — re-run `find`/`grep`/`Read` on each load-bearing one BEFORE building on it. The autopsy was CORRECT about the substance (the variety machine is unplugged; the fact-checker self-references; BRAND_SUFFIX clamps) — verified, and batch-1 fixes shipped on it (PR #1125). But 3 of its specific file refs were hallucinated. The discipline that caught this is the standing anti-hallucination rule (CLAUDE.md §6): "mai citare output di un tool senza averlo eseguito in QUESTO turn". Extended here to: **mai costruire un piano su un file:line di un REPORT senza ri-verificare che il file esista in questo turn.** The P-4 plan (`research/operations/P4-topic-type-log-plan.md` §0) documents the corrections and was built on the verified reality, not the report text.
 
 **GOTCHA:**
+
 - The autopsy is NOT retracted — it remains the authoritative diagnosis of WR2's monotony/fact problems. Only its 3 phantom citations are wrong. Future agents: use it for the WHAT, re-verify every WHERE.
 - The hallucinated `_voyager-curriculum.py` is plausible because a real Voyager-style skill-library evolver DOES exist in this ecosystem (`agent-library` / EvoSkill, see `discovery_s13_evolution_loop_never_closed`). The autopsy likely pattern-matched that into a WR2 curriculum reader that was never built. Plausibility ≠ existence.
 - P-4 (migration 216, shipped 2026-06-05 PR #1133) is the FIRST real `topic_type_log` — it's a Postgres table on the production path, NOT the phantom SQLite one. Anyone grepping `topic_type_log` after 2026-06-05 will find the real one; do not confuse it with the autopsy's phantom.
@@ -490,3 +492,15 @@ _Discovered: 2026-06-04 06:15 WITA while monitoring PR #1101 (a scar_replay-only
 **GOTCHA**: This is a non-mine flake — a scar_replay-only PR (`#1101` touches only `agent-library/scar_replay/scar_replay.py` + `test_scar_replay.py`) was blocked by it. **Diagnostic rule**: when CI Backend Tests fail on a PR that changed NO backend code, check whether the failing test is timestamp/clock-dependent BEFORE assuming regression — verify via `gh pr view <N> --json files -q '.files[].path'` that your diff doesn't touch the failing module. The same test passed clean on `#1104` minutes earlier (same suite) → proof it's nondeterministic, not a real break. Any PR whose `update-branch` re-triggers the full Backend Tests can hit it. Family: **nondeterministic-test-blocks-merge (clock race)**. Related discipline: anti-hallucination rule — verify the failing path is actually yours, don't assume.
 
 **Reference**: CI run 26915762002 job 79404910575 (#1101). Failing test `apps/backend-rag/backend/tests/unit/services/ingestion/test_performance_monitor.py:311`. Source under test `apps/backend-rag/backend/services/ingestion/performance_monitor.py` (alert-id generation). PR #1101 files: scar_replay only.
+
+### ℹ️ P3 (phantom-in-memory): `verify_mcp_integrity.sh` claimed-shipped in memory, ABSENT on disk M5+Pro (2026-06-06)
+
+_Discovered: 2026-06-06 12:00 WITA while re-verifying `[ASSUMED-MEMORY]` tags for the guardrail-liveness-sentinel spec, Pro back online · Severity: P3 (process/trust) · Status: **REPORTED**_
+
+**TRAUMA**: Memory `p2_21_mcp_integrity_verify` (2026-05-20) states `scripts/verify_mcp_integrity.sh` shipped at 6636B mode 755 with baseline LOW=24/HIGH=0/MEDIUM=0. Empirical re-check 2026-06-06: the file does **NOT EXIST** on M5 (`~/.claude/scripts/`, repo, `~/scripts/`) NOR on Pro (same three locations via `ssh pro`). A guardrail recorded as shipped-with-baseline is absent on both machines — either never shipped, or lost in a later sweep/worktree-drift. The memory reads as ground truth (precise byte count, mode, baseline numbers) but the artifact is phantom.
+
+**ANTIBODY**: (1) The guardrail-liveness-sentinel's registry (Check B) must NOT seed `verify_mcp_integrity.sh` as `expected-present` until it's re-created or the memory corrected — otherwise the sentinel would alert on a guardrail that was never really there. (2) General rule, which is literally the sentinel's whole thesis: **a guardrail claimed-shipped-in-memory must be re-verified on disk before being relied upon**. Memory is a claim, not a fact. (3) Decide separately whether to re-create `verify_mcp_integrity.sh` (the MCP integrity baseline check is a real safety mechanism worth having) or amend `p2_21` to mark it lost.
+
+**GOTCHA**: This is the **2nd phantom-in-memory caught this session**. The 1st was the WR2 autopsy's 3 hallucinated `file:line` refs (`_state-schema.sql:63` etc., see the META scar 2026-06-05). Same family: **claimed-artifact-absent-on-disk**. Both were caught only by re-running `find`/`ls` in-turn rather than trusting the recorded claim. The anti-hallucination discipline (CLAUDE.md §6) extends to memory entries, not just tool output: a memory that names a file with byte-precision is exactly as fabricable as a hallucinated tool result.
+
+**Reference**: memory `p2_21_mcp_integrity_verify.md`. Spec `docs/superpowers/specs/2026-06-06-guardrail-liveness-sentinel.md` §8bis (Pro live re-verification). Sibling phantom: META WR2-autopsy scar 2026-06-05. Family: claimed-artifact-absent-on-disk. Born from: `decision_guardrail_liveness_sentinel_spec_2026_06_06`.

--- a/docs/superpowers/specs/2026-06-06-guardrail-liveness-sentinel.md
+++ b/docs/superpowers/specs/2026-06-06-guardrail-liveness-sentinel.md
@@ -1,0 +1,126 @@
+# Spec — Guardrail Liveness Sentinel (v2, post 4-LLM panel)
+
+**Date**: 2026-06-06
+**Author**: Claude (Opus 4.8), autonomous, M5
+**Status**: DRAFT v2 — panel-reviewed, pending Antonello approval + Pro re-verification
+**Origin**: Reflection on Anthropic essay "When AI builds itself" (5 Jun 2026). Its single named
+bottleneck for the most-likely future (Scenario 2): _"code review becomes the constraint as Claude
+generates faster than humans verify."_ We have scars of the same shape — guardrail alive-on-paper,
+dead-in-fact, found by luck. This spec makes guardrail decay **observable**.
+
+> ⚠️ **Authoring caveat**: written on M5 while **Pro AND Mini were offline** (Tailscale: Pro
+> last-seen 13 min, Mini 1 day — `[VERIFIED-M5]`). Live state of Pro tiers/scripts NOT inspectable.
+> Facts tagged `[VERIFIED-M5]` (tool run this turn) or `[ASSUMED-MEMORY]` (re-verify on Pro first).
+
+---
+
+## 0. PANEL OUTCOME (4-LLM, 2026-06-06) — the spec was demolished, correctly
+
+Panel ran 3 external reviewers + orchestrator. Honest cascade note: **DeepSeek first attempt
+returned empty (my JSON-encoding bug, not the tier); Codex first attempt HUNG 30 min on a dead
+Tavily-MCP OAuth token** — itself a live instance of "guardrail rotted silently." Both re-run
+successfully (DeepSeek via urllib; Codex with `-c mcp_servers={}`). Effective panel: **4-deep**
+(Gemini 3.1 Pro, DeepSeek V4 Pro, Codex GPT-5.5, Claude Opus). Gemini + Codex both did empirical
+filesystem verification, not just text review.
+
+**Two panel findings I independently re-verified on disk `[VERIFIED-M5]`:**
+
+- **`stop_verify.py` is WIRED-BUT-DISABLED**: `settings.json:472` invokes it as
+  `STOP_VERIFY_ALLOW_DIRTY=1 python3 ...`; `stop_verify.py:24-25` `sys.exit(0)` immediately under
+  that env. My v1 "present + wired" check would have marked a dead guardrail alive. **This is the
+  whole thesis proven against my own spec.**
+- **The wheel already half-exists**: `scripts/sentinel_meta_watchdog.sh` +
+  `infra/launchagents/com.nuzantara.sentinel-meta-watchdog.plist` + `docs/sentinel-watchdog.md`
+  already solve "who watches the watcher" via **status-file freshness** (not presence) for
+  `nuzantara-sentinel.py` (~58 jobs). There is also `supervisor-liveness-watchdog`. **reuse-first:
+  this spec must EXTEND that infra, not build a parallel one.**
+
+## 1. PIVOT (consequence of the panel)
+
+v1 was "build a new weekly sentinel." v2 is: **add the 3 missing checks to the existing
+`nuzantara-sentinel.py` + `sentinel_meta_watchdog.sh` stack**, applying liveness semantics
+(behavior, not presence) and the panel's anti-silent-failure fixes.
+
+## 2. The 3 checks (corrected)
+
+### Check A — cascade tier liveness — by PER-TIER STATUS, not depth count
+
+- Per-tier ping with **hard per-tier timeout** (`gtimeout`/perl-alarm; macOS has no `timeout`)
+  [Codex #6, Gemini #3]. Capture **stderr too** (`2>&1`) — errors go to stderr, grepping stdout
+  only reports false-alive [Gemini #7, DeepSeek #3].
+- Regression key = **per-tier identity vector** `{T1:ok,T2:ok,T3:dead,T4:dead}`, NOT
+  `cascade_depth=N` — a count hides "T1 died but T4 appeared" [Codex #4].
+- Error detection must be **allowlist of success**, not denylist of known error strings — an
+  unanticipated error (403, timeout) must NOT pass [DeepSeek #3, Codex].
+- T3 codex: detect the Tavily-MCP-style hang explicitly; run health-pings with `-c mcp_servers={}`.
+- T4 ollama: **`ollama list` FIRST**, never `ollama run` blind (auto-pulls ~5GB) [all 3 panels].
+- Do NOT treat `regulatory-watcher-run.sh` as source-of-truth executable: it uses
+  `set -euo pipefail` + bare tier commands → a nonzero tier exits the script before fallback
+  [Codex #5]. Borrow its _patterns_ by reference, fix the `-e` bug if we touch it.
+
+### Check B — guardrail liveness — BEHAVIOR, not presence+wiring
+
+- "Present + wired" is insufficient (the `stop_verify` ALLOW_DIRTY counterexample). Each guardrail
+  needs a **behavioral probe**: feed a known-bad input, assert it BLOCKS [Codex #7].
+- Registry must enumerate **explicit required hosts** (`host=Pro`, `host=Mini`), never
+  `host=any-claude-machine` — presence on M5 says nothing about Pro [Codex #9, DeepSeek #12].
+- Registry must include the **destructive-MCP guardrail** (`guardrails-client.sh`,
+  `settings.json:260`, CLAUDE.md:98) — v1 omitted a core safety mechanism [Codex #8].
+- Registry-completeness gap: new guardrails added but not registered decay unnoticed. Mitigation:
+  Check B also greps `settings.json` hooks for any command not in the registry → "unregistered
+  guardrail" warning [DeepSeek #10].
+
+### Check C — fleet reachability — must run OFF the watched host
+
+- v1 fatal: scheduling Check C on Pro to detect "Pro unreachable" — if Pro is down the check is
+  down too [Codex #2, both panels]. **Mutual heartbeat**: M5 ↔ Pro ↔ Mini each verify the others;
+  the dead-man's-switch lives on a DIFFERENT machine [Codex #1, DeepSeek #2, Gemini #1].
+- Concrete reachability threshold required (e.g. unreachable > 2 consecutive runs) [DeepSeek #8].
+- SSH from launchd has no GUI keychain / `SSH_AUTH_SOCK` → key-with-passphrase fails as false
+  "offline" [Gemini #4, DeepSeek #12]. Use a dedicated passphrase-less key or ssh-agent in plist.
+
+## 3. Anti-silent-failure (the part the whole spec is ABOUT)
+
+- **First-run / baseline-while-dead**: "alert only on regression" makes a born-dead guardrail
+  normal forever. Fix: on first run OR any `dead` state, alert regardless of regression; only
+  _steady-green_ is silent [Codex #3, DeepSeek #4/#5, Gemini #2].
+- **State corruption**: unparseable JSON must fail LOUD, never default to "ok" (the reused pattern
+  defaults to ok) [Codex #11, DeepSeek #15].
+- **Telegram channel health**: missing creds / 400-on-HTML-escape must not set cooldown and must
+  self-report via a second channel or log+exit-nonzero [Codex #10, Gemini #11, DeepSeek #9].
+  Sanitize HTML special chars before `parse_mode=HTML` [Gemini #11].
+- **Token in process list**: do NOT put the bot token in the curl URL (`ps aux` leak); use
+  `-d` body or `--config`/netrc [Gemini #15].
+- **Dead-man on the sentinel itself**: cannot be self-hosted [all]. Reuse the EXISTING
+  `sentinel_meta_watchdog.sh` freshness mechanism — register this sentinel's status file with it.
+
+## 4. launchd correctness [Gemini #9/#10, DeepSeek #13, Codex]
+
+- Naming: `com.nuzantara.*` (workhorse user = `nuzantara`), NOT `com.balizero.*` [Gemini #14].
+- launchd minimal PATH → set `EnvironmentVariables.PATH` explicitly (homebrew + `~/.local/bin`)
+  or absolute-path every binary [Gemini #10].
+- LaunchAgent needs GUI session; for headless survival prefer the existing daemon pattern.
+
+## 5. Cost / privacy (corrected) [Codex #13]
+
+- NOT "4 tokens/week" — CLI wrappers add system+context overhead. Still ~$0 (subscriptions).
+- NOT "no PII": raw stderr/stdout can leak usernames, absolute paths, OAuth/account details,
+  loaded project instructions. **Redact before any Telegram send.** Pings stay literal "ping".
+
+## 6. Acceptance (expanded) [Codex #14]
+
+- Behavioral: disable a guardrail via env (the ALLOW_DIRTY case) → Check B reports DEAD.
+- Born-dead: first run with a tier already down → alert fires (not silent baseline).
+- Hung tier: inject a sleep → per-tier timeout trips, state still written, alert fires.
+- Corrupt state file → loud failure, not silent "ok".
+- Telegram creds removed → self-reports, does not set cooldown.
+- Sentinel status stale > threshold → existing meta-watchdog fires (not a new mechanism).
+- Steady all-green → NO alert.
+
+## 7. Next steps (gated)
+
+1. **Antonello approval** of this v2 direction (extend-not-build).
+2. **Re-verify on Pro** every `[ASSUMED-MEMORY]` tag once Pro is back online (esp.
+   `verify_mcp_integrity.sh` location, tier binaries, existing watchdog coverage).
+3. Implement as extension to `nuzantara-sentinel.py` + register with `sentinel_meta_watchdog.sh`.
+4. TDD per acceptance §6 before any LaunchAgent install.

--- a/docs/superpowers/specs/2026-06-06-guardrail-liveness-sentinel.md
+++ b/docs/superpowers/specs/2026-06-06-guardrail-liveness-sentinel.md
@@ -119,8 +119,24 @@ v1 was "build a new weekly sentinel." v2 is: **add the 3 missing checks to the e
 
 ## 7. Next steps (gated)
 
-1. **Antonello approval** of this v2 direction (extend-not-build).
-2. **Re-verify on Pro** every `[ASSUMED-MEMORY]` tag once Pro is back online (esp.
-   `verify_mcp_integrity.sh` location, tier binaries, existing watchdog coverage).
+1. **Antonello approval** of this v2 direction (extend-not-build). ✅ APPROVED 2026-06-06.
+2. **Re-verify on Pro** every `[ASSUMED-MEMORY]` tag. ✅ DONE 2026-06-06 (Pro back online):
 3. Implement as extension to `nuzantara-sentinel.py` + register with `sentinel_meta_watchdog.sh`.
 4. TDD per acceptance §6 before any LaunchAgent install.
+
+## 8bis. Pro live re-verification (2026-06-06) — `[VERIFIED-PRO]` replaces `[ASSUMED-MEMORY]`
+
+- **`verify_mcp_integrity.sh` does NOT exist on Pro either** (not in `~/.claude/scripts/`, repo,
+  or `~/scripts/`). Memory `p2_21_mcp_integrity_verify` claims it shipped with a baseline. It is
+  absent on BOTH machines. → NEW SCAR (the spec's own thesis, again). Either it was never shipped,
+  or it was lost. Registry Check B must NOT seed it as `expected-present` until resolved.
+- **`sentinel_meta_watchdog.sh` IS deployed + alive** on Pro: `com.nuzantara.sentinel-meta-watchdog`
+  loaded in launchctl (last status 0), watches `~/.agent/decisions/sentinel_status.json` (age 3min,
+  fresh). reuse-target confirmed REAL. Also live: `organism.supervisor`, `wr2.supervisor-watchdog`,
+  `disk-watchdog`, `cron-log-sentinel`, `matagaruda.sentinel.hourly`, `automap-watchdog`.
+- **Cascade T1/T2 binaries EXIST on Pro** (corrected — my first `command -v` under `bash -lc`
+  falsely reported MISSING; re-verified via `ls`): `~/.local/bin/claude` → v2.1.166,
+  `~/.local/bin/agy` (136MB, 4 Jun). T3 `codex` + T4 `ollama` in `/opt/homebrew/bin`. The real
+  defect is unchanged: wrapper calls them by HARDCODED path (`$HOME/.local/bin/claude`,
+  `/Users/nuzantara/.local/bin/agy`) — works on Pro, breaks on any other user/host. Check A must
+  resolve via `command -v` with an explicit PATH, never hardcode.

--- a/scripts/sentinel_lib/guardrail_liveness.py
+++ b/scripts/sentinel_lib/guardrail_liveness.py
@@ -1,0 +1,404 @@
+"""
+guardrail_liveness — behavioral liveness checks for the guardrail stack.
+
+Born from the Anthropic "When AI builds itself" reflection (2026-06-06): the
+named bottleneck of the likely future is "verify can't keep up with generate".
+We had scars of guardrails alive-on-paper / dead-in-fact (cascade silently
+2-deep; stop_verify WIRED-BUT-DISABLED via STOP_VERIFY_ALLOW_DIRTY=1;
+verify_mcp_integrity.sh claimed-shipped but absent on disk). This module makes
+that decay OBSERVABLE.
+
+Design (spec 2026-06-06-guardrail-liveness-sentinel.md) + 4-LLM CODE panel
+hardening (Codex + Gemini, 2026-06-06 — ~11 real defects fixed pre-merge):
+  - "present + wired" is NOT liveness. A guardrail can be wired in settings.json
+    yet disabled by an env override IN THE COMMAND **or in the daemon env**
+    (the stop_verify counterexample). We check both.
+  - Wired hooks must also resolve to an EXISTING, NON-EMPTY file on disk — a
+    hook pointing at a deleted/zero-byte script is dead-in-fact (panel C#3/#4).
+  - Hook detection matches the script path as a real token, not a loose
+    substring (`stop_verify.py.bak` / `echo stop_verify.py` must NOT pass).
+  - Disable-env regex is word-boundary-anchored, case-insensitive, exact-value
+    (panel C#6/G#2); "0/false/no" is NOT a disable.
+  - Host matching normalizes FQDN/.local/case and rejects str-as-hosts (G#8/9).
+  - Regression key = per-guardrail status vector. Duplicate registry names are a
+    config error (loud), never a silently-overwritten OK (G#7).
+  - First-run / any-dead alerts (born-dead not silently baselined).
+  - settings.json corruption fails LOUD, redacted (no file content in alert),
+    catching JSONDecodeError + OSError + UnicodeDecodeError (panel C#7/G#4/#6).
+  - Missing registry keys → loud per-guardrail DEAD, never abort the whole run.
+
+No side effects on import; does NOT send alerts itself — returns a structured
+report the caller (run_sentinel) folds into status_obj and routes via send_alert.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import socket
+from dataclasses import dataclass, field
+from typing import Callable
+
+# ---- status constants -------------------------------------------------------
+
+OK = "ok"
+DEAD = "dead"
+DISABLED = "disabled"  # present + wired but neutralized (command or env)
+ABSENT = "absent"  # expected on this host, not found / empty
+SKIP = "skip"  # not applicable on this host (wrong host) — not a failure
+
+
+# ---- registry ---------------------------------------------------------------
+
+DEFAULT_REGISTRY: list[dict] = [
+    {
+        "name": "stop_verify",
+        "hosts": ["*"],
+        "probe": "hook_not_env_disabled",
+        "settings_key": "stop_verify.py",
+        "disable_env": "STOP_VERIFY_ALLOW_DIRTY",
+    },
+    {
+        "name": "dispatch_nudge",
+        "hosts": ["*"],
+        "probe": "hook_wired",
+        "settings_key": "dispatch_nudge.py",
+    },
+    {
+        "name": "guardrails_destructive_mcp",
+        "hosts": ["*"],
+        "probe": "hook_wired",
+        "settings_key": "guardrails-client.sh",
+    },
+    # verify_mcp_integrity.sh deliberately NOT seeded — phantom (scar 2026-06-06).
+]
+
+
+# ---- result types -----------------------------------------------------------
+
+
+@dataclass
+class GuardrailResult:
+    name: str
+    status: str
+    detail: str = ""
+
+
+@dataclass
+class LivenessReport:
+    host: str
+    results: list[GuardrailResult] = field(default_factory=list)
+    regressed: list[str] = field(default_factory=list)
+    alert_needed: bool = False
+    alert_reason: str = ""
+
+    def vector(self) -> dict[str, str]:
+        # Duplicate names are a config error, not a silent overwrite (G#7):
+        # surface the WORST status for any duplicated name.
+        order = [SKIP, OK, DISABLED, ABSENT, DEAD]  # increasing severity
+        sev = {s: i for i, s in enumerate(order)}
+        out: dict[str, str] = {}
+        for r in self.results:
+            if r.name not in out or sev.get(r.status, 99) > sev.get(out[r.name], -1):
+                out[r.name] = r.status
+        return out
+
+    def to_status_obj(self) -> dict:
+        return {
+            "host": self.host,
+            "vector": self.vector(),
+            "regressed": self.regressed,
+            "alert_needed": self.alert_needed,  # C#9: do not drop
+            "alert_reason": self.alert_reason,
+            "details": {r.name: r.detail for r in self.results if r.detail},
+        }
+
+
+# ---- helpers ----------------------------------------------------------------
+
+# truthy env values that DISABLE a guardrail (case-insensitive, exact)
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _settings_command_strings(settings: dict | None) -> list[str]:
+    """Flatten every hook command string. Defensive against malformed shapes
+    (G#3: a non-list 'hooks' must not raise)."""
+    if not isinstance(settings, dict):
+        return []
+    out: list[str] = []
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict):
+        return out
+    for _event, groups in hooks.items():
+        if not isinstance(groups, list):
+            continue
+        for group in groups:
+            if not isinstance(group, dict):
+                continue
+            hook_list = group.get("hooks")
+            if not isinstance(hook_list, list):
+                continue
+            for hook in hook_list:
+                if isinstance(hook, dict):
+                    cmd = hook.get("command")
+                    if isinstance(cmd, str):
+                        out.append(cmd)
+    return out
+
+
+def _command_runs_script(cmd: str, key: str) -> bool:
+    """True iff `cmd` actually invokes the script named by `key`, as a token
+    (not a loose substring, not a .bak, not an echo arg). (panel C#2)."""
+    try:
+        tokens = shlex.split(cmd)
+    except ValueError:
+        tokens = cmd.split()
+    base = os.path.basename(key)
+    for t in tokens:
+        # strip leading env-assignments handled separately; match path tokens
+        tb = os.path.basename(t)
+        if tb == base:
+            return True
+    return False
+
+
+def _resolve_hook_path(cmd: str, key: str) -> str | None:
+    """Return the on-disk path token matching key, expanded, or None."""
+    try:
+        tokens = shlex.split(cmd)
+    except ValueError:
+        tokens = cmd.split()
+    base = os.path.basename(key)
+    for t in tokens:
+        if os.path.basename(t) == base:
+            return os.path.expanduser(t)
+    return None
+
+
+def _file_is_live(path: str | None) -> bool:
+    """Existing AND non-empty (zero-byte script is dead-in-fact, panel C#4)."""
+    return bool(path) and os.path.isfile(path) and os.path.getsize(path) > 0
+
+
+def _env_disables(cmd: str, env: dict, disable_env: str) -> bool:
+    """Disable if the env var is truthy EITHER inline in the command OR exported
+    in the daemon environment (panel C#1/G#1). Word-boundary, case-insensitive,
+    exact value (panel C#6/G#2)."""
+    # inline: VAR=val as its own assignment token in the command
+    pat = re.compile(rf"(^|\s){re.escape(disable_env)}=(\S+)")
+    for m in pat.finditer(cmd):
+        if m.group(2).strip("'\"").lower() in _TRUTHY:
+            return True
+    # exported in daemon env
+    val = env.get(disable_env)
+    if isinstance(val, str) and val.strip("'\"").lower() in _TRUTHY:
+        return True
+    return False
+
+
+# ---- probes -----------------------------------------------------------------
+
+
+def probe_hook_wired(entry: dict, ctx: dict) -> GuardrailResult:
+    name = entry["name"]
+    key = entry["settings_key"]
+    cmds = _settings_command_strings(ctx.get("settings"))
+    wiring = [c for c in cmds if _command_runs_script(c, key)]
+    if not wiring:
+        return GuardrailResult(name, DEAD, f"not wired in settings.json ({key})")
+    # wired — but does the referenced file actually exist + non-empty? (C#3/#4)
+    for c in wiring:
+        if _file_is_live(_resolve_hook_path(c, key)):
+            return GuardrailResult(name, OK, f"wired + file live ({key})")
+    return GuardrailResult(name, DEAD, f"wired but file missing/empty ({key})")
+
+
+def probe_hook_not_env_disabled(entry: dict, ctx: dict) -> GuardrailResult:
+    name = entry["name"]
+    key = entry["settings_key"]
+    disable_env = entry["disable_env"]
+    env = ctx.get("env", {})
+    cmds = _settings_command_strings(ctx.get("settings"))
+    wiring = [c for c in cmds if _command_runs_script(c, key)]
+    if not wiring:
+        return GuardrailResult(name, DEAD, f"not wired ({key})")
+    # neutralized by env override (inline in any wiring cmd, or daemon env)?
+    if any(_env_disables(c, env, disable_env) for c in wiring):
+        return GuardrailResult(
+            name, DISABLED, f"wired but neutralized by {disable_env}"
+        )
+    # also require the file to be live
+    for c in wiring:
+        if _file_is_live(_resolve_hook_path(c, key)):
+            return GuardrailResult(name, OK, f"wired, enabled, file live ({key})")
+    return GuardrailResult(name, DEAD, f"wired+enabled but file missing/empty ({key})")
+
+
+def probe_script_exists(entry: dict, ctx: dict) -> GuardrailResult:
+    name = entry["name"]
+    path = os.path.expanduser(entry["path"])
+    if _file_is_live(path):
+        return GuardrailResult(name, OK, path)
+    if os.path.isfile(path):
+        return GuardrailResult(name, ABSENT, f"present but EMPTY: {path}")
+    return GuardrailResult(name, ABSENT, f"expected at {path}")
+
+
+PROBES: dict[str, Callable[[dict, dict], GuardrailResult]] = {
+    "hook_wired": probe_hook_wired,
+    "hook_not_env_disabled": probe_hook_not_env_disabled,
+    "script_exists": probe_script_exists,
+}
+
+# required keys per probe (missing → loud per-guardrail DEAD, never abort, C#8)
+_REQUIRED_KEYS = {
+    "hook_wired": ["settings_key"],
+    "hook_not_env_disabled": ["settings_key", "disable_env"],
+    "script_exists": ["path"],
+}
+
+
+# ---- host matching ----------------------------------------------------------
+
+
+def _norm_host(h: str) -> str:
+    """Normalize for comparison: lowercase, strip .local / first FQDN label
+    keeps the short name (G#8/#9)."""
+    h = (h or "").strip().lower()
+    if h.endswith(".local"):
+        h = h[: -len(".local")]
+    # take short hostname (before first dot) for FQDN
+    return h.split(".")[0]
+
+
+def _host_applies(entry: dict, host: str) -> bool:
+    hosts = entry.get("hosts", ["*"])
+    if not isinstance(hosts, list):  # str-as-hosts is a config error → don't apply loosely
+        return False
+    if "*" in hosts:
+        return True
+    nh = _norm_host(host)
+    return any(_norm_host(h) == nh for h in hosts)
+
+
+# ---- main entry -------------------------------------------------------------
+
+
+def _load_settings(path: str) -> dict | None:
+    if not os.path.isfile(path):
+        return None
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)  # may raise JSONDecodeError / UnicodeDecodeError
+
+
+def run_check(
+    *,
+    registry: list[dict] | None = None,
+    host: str | None = None,
+    settings_path: str | None = None,
+    prior_vector: dict[str, str] | None = None,
+    env: dict | None = None,
+) -> LivenessReport:
+    # Copy so a caller/test mutating the result can't corrupt the module-level
+    # DEFAULT_REGISTRY across runs (DeepSeek panel #7).
+    registry = list(registry if registry is not None else DEFAULT_REGISTRY)
+    host = host or socket.gethostname()
+    env = env if env is not None else dict(os.environ)
+    if settings_path is None:
+        settings_path = os.path.expanduser("~/.claude/settings.json")
+
+    settings_error: str | None = None
+    settings: dict | None = None
+    try:
+        settings = _load_settings(settings_path)
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:
+        # redact: do NOT echo file content (G#6); just the error TYPE
+        settings_error = f"settings.json corrupt ({type(exc).__name__})"
+    except OSError as exc:
+        settings_error = f"settings.json unreadable ({type(exc).__name__})"
+
+    ctx = {"settings": settings, "env": env}
+    report = LivenessReport(host=host)
+
+    if settings_error is not None:
+        report.results.append(GuardrailResult("settings_json", DEAD, settings_error))
+
+    # detect duplicate names up front (G#7) — loud config error
+    names = [e.get("name", "?") for e in registry]
+    dupes = {n for n in names if names.count(n) > 1}
+    if dupes:
+        report.results.append(
+            GuardrailResult(
+                "registry_config", DEAD, f"duplicate guardrail names: {sorted(dupes)}"
+            )
+        )
+
+    for entry in registry:
+        name = entry.get("name", "?")
+        probe_key = entry.get("probe")
+        if not _host_applies(entry, host):
+            report.results.append(GuardrailResult(name, SKIP, f"not on {host}"))
+            continue
+        probe = PROBES.get(probe_key)
+        if probe is None:
+            report.results.append(GuardrailResult(name, DEAD, f"unknown probe {probe_key!r}"))
+            continue
+        missing = [k for k in _REQUIRED_KEYS.get(probe_key, []) if k not in entry]
+        if missing:
+            report.results.append(
+                GuardrailResult(name, DEAD, f"registry entry missing keys {missing}")
+            )
+            continue
+        try:
+            report.results.append(probe(entry, ctx))
+        except Exception as exc:  # a buggy probe must not kill the whole sweep
+            report.results.append(
+                GuardrailResult(name, DEAD, f"probe error: {type(exc).__name__}")
+            )
+
+    _decide_alert(report, prior_vector)
+    return report
+
+
+_FAILED_STATES = {DEAD, DISABLED, ABSENT}
+
+
+def _decide_alert(report: LivenessReport, prior_vector: dict[str, str] | None) -> None:
+    cur = report.vector()
+    failed_now = {n for n, s in cur.items() if s in _FAILED_STATES}
+
+    if prior_vector:
+        for name, status in cur.items():
+            prev = prior_vector.get(name)
+            # A guardrail UNKNOWN in prior (prev is None) that is born-dead is
+            # NOT a regression — it was never seen OK (DeepSeek panel #5). Only
+            # a transition from a known-good prior state counts as regression.
+            if (
+                status in _FAILED_STATES
+                and prev is not None
+                and prev not in _FAILED_STATES
+            ):
+                report.regressed.append(name)
+
+    if failed_now:
+        report.alert_needed = True
+        if report.regressed:
+            report.alert_reason = (
+                f"guardrail regression: {', '.join(sorted(report.regressed))} "
+                f"(all currently failed: {', '.join(sorted(failed_now))})"
+            )
+        else:
+            report.alert_reason = (
+                f"guardrail(s) not protecting: {', '.join(sorted(failed_now))}"
+            )
+    else:
+        report.alert_needed = False
+        report.alert_reason = ""
+
+
+__all__ = [
+    "run_check", "LivenessReport", "GuardrailResult", "DEFAULT_REGISTRY",
+    "OK", "DEAD", "DISABLED", "ABSENT", "SKIP",
+]

--- a/scripts/tests/test_guardrail_liveness.py
+++ b/scripts/tests/test_guardrail_liveness.py
@@ -1,0 +1,393 @@
+"""Tests for sentinel_lib.guardrail_liveness.
+
+Each test encodes one panel-found defect class, so a regression re-surfaces it.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sentinel_lib import guardrail_liveness as gl  # noqa: E402
+
+
+# ---- fixtures: settings.json shapes ----------------------------------------
+
+
+def _settings_with(commands: list[str]) -> dict:
+    """Build a minimal settings.json with given hook command strings."""
+    return {
+        "hooks": {
+            "PreToolUse": [
+                {"matcher": "*", "hooks": [{"type": "command", "command": c}]}
+                for c in commands
+            ]
+        }
+    }
+
+
+HEALTHY_CMDS = [
+    "python3 ~/.claude/hooks/stop_verify.py",
+    "~/.claude/hooks/dispatch_nudge.py",
+    "~/.claude/hooks/guardrails-client.sh",
+]
+
+
+def _write_settings(tmp_path, obj) -> str:
+    p = tmp_path / "settings.json"
+    p.write_text(json.dumps(obj))
+    return str(p)
+
+
+# ---- Check B core: behavior, not presence ----------------------------------
+
+
+def test_all_green_no_alert(tmp_path):
+    sp = _write_settings(tmp_path, _settings_with(HEALTHY_CMDS))
+    rep = gl.run_check(host="X", settings_path=sp)
+    assert rep.vector() == {
+        "stop_verify": gl.OK,
+        "dispatch_nudge": gl.OK,
+        "guardrails_destructive_mcp": gl.OK,
+    }
+    assert rep.alert_needed is False
+
+
+def test_stop_verify_wired_but_env_disabled_is_DISABLED(tmp_path):
+    """THE counterexample: STOP_VERIFY_ALLOW_DIRTY=1 neutralizes a wired hook."""
+    cmds = [
+        "STOP_VERIFY_ALLOW_DIRTY=1 python3 ~/.claude/hooks/stop_verify.py",
+        "~/.claude/hooks/dispatch_nudge.py",
+        "~/.claude/hooks/guardrails-client.sh",
+    ]
+    sp = _write_settings(tmp_path, _settings_with(cmds))
+    rep = gl.run_check(host="X", settings_path=sp)
+    assert rep.vector()["stop_verify"] == gl.DISABLED
+    assert rep.alert_needed is True
+    assert "stop_verify" in rep.alert_reason
+
+
+def test_env_disable_variants_detected(tmp_path):
+    # Real shell assignment forms (no spaces around `=` — `VAR = 1` is NOT an
+    # assignment in shell, it's the command `VAR` with args, so it must NOT
+    # count as a disable; that case is covered by test_spaced_eq_is_not_disable).
+    for token in ["=1", "=true", "='1'", '="yes"']:
+        cmds = [f"STOP_VERIFY_ALLOW_DIRTY{token} python3 ~/.claude/hooks/stop_verify.py"]
+        sp = _write_settings(tmp_path, _settings_with(cmds))
+        rep = gl.run_check(host="X", settings_path=sp, registry=[gl.DEFAULT_REGISTRY[0]])
+        assert rep.vector()["stop_verify"] == gl.DISABLED, token
+
+
+def test_spaced_eq_is_not_disable(tmp_path):
+    """`STOP_VERIFY_ALLOW_DIRTY = 1` is NOT a shell assignment → must not disable."""
+    sp, _ = _settings_pointing_at(tmp_path, ["stop_verify.py"],
+                                  env_prefix="STOP_VERIFY_ALLOW_DIRTY = 1 ")
+    rep = gl.run_check(host="X", settings_path=sp, registry=[gl.DEFAULT_REGISTRY[0]])
+    assert rep.vector()["stop_verify"] == gl.OK
+
+
+def test_hook_not_wired_is_DEAD(tmp_path):
+    sp = _write_settings(tmp_path, _settings_with(["something/else.py"]))
+    rep = gl.run_check(host="X", settings_path=sp, registry=[gl.DEFAULT_REGISTRY[1]])
+    assert rep.vector()["dispatch_nudge"] == gl.DEAD
+    assert rep.alert_needed is True
+
+
+# ---- born-dead / first-run alerting (panel Codex#3, DeepSeek#4/#5) ----------
+
+
+def test_born_dead_alerts_even_with_no_prior(tmp_path):
+    """First run with a dead guardrail must alert (not silently baselined)."""
+    sp = _write_settings(tmp_path, _settings_with(["unrelated.py"]))
+    rep = gl.run_check(host="X", settings_path=sp, prior_vector=None)
+    assert rep.alert_needed is True
+
+
+def test_steady_dead_still_alerts_but_not_regression(tmp_path):
+    sp = _write_settings(tmp_path, _settings_with(["unrelated.py"]))
+    prior = {"stop_verify": gl.DEAD, "dispatch_nudge": gl.DEAD,
+             "guardrails_destructive_mcp": gl.DEAD}
+    rep = gl.run_check(host="X", settings_path=sp, prior_vector=prior)
+    assert rep.alert_needed is True
+    assert rep.regressed == []  # nothing NEWLY died
+
+
+def test_regression_called_out_among_steady_failures(tmp_path):
+    """One was ok, now dead, while another was already dead → regression named."""
+    cmds = ["STOP_VERIFY_ALLOW_DIRTY=1 python3 ~/.claude/hooks/stop_verify.py"]
+    sp = _write_settings(tmp_path, _settings_with(cmds))
+    prior = {"stop_verify": gl.OK, "dispatch_nudge": gl.DEAD,
+             "guardrails_destructive_mcp": gl.DEAD}
+    rep = gl.run_check(host="X", settings_path=sp, prior_vector=prior)
+    assert "stop_verify" in rep.regressed
+    assert "dispatch_nudge" not in rep.regressed  # already dead, not new
+
+
+# ---- state corruption fails LOUD (panel Codex#11) --------------------------
+
+
+def test_corrupt_settings_json_fails_loud(tmp_path):
+    p = tmp_path / "settings.json"
+    p.write_text("{ this is not json ")
+    rep = gl.run_check(host="X", settings_path=str(p))
+    assert rep.vector().get("settings_json") == gl.DEAD
+    assert rep.alert_needed is True
+
+
+def test_missing_settings_json_marks_hooks_dead(tmp_path):
+    sp = str(tmp_path / "does_not_exist.json")
+    rep = gl.run_check(host="X", settings_path=sp)
+    # no settings → wired-checks can't find their command → DEAD, alert
+    assert rep.alert_needed is True
+    assert all(v == gl.DEAD for k, v in rep.vector().items())
+
+
+# ---- host scoping (panel Codex#9) ------------------------------------------
+
+
+def test_wrong_host_is_SKIP_not_dead(tmp_path):
+    sp = _write_settings(tmp_path, _settings_with([]))
+    reg = [{"name": "pro_only_thing", "hosts": ["Nuzantara"],
+            "probe": "script_exists", "path": "/nonexistent"}]
+    rep = gl.run_check(host="Air-M5", settings_path=sp, registry=reg)
+    assert rep.vector()["pro_only_thing"] == gl.SKIP
+    assert rep.alert_needed is False  # skip is not a failure
+
+
+def test_expected_host_absent_script_is_ABSENT(tmp_path):
+    sp = _write_settings(tmp_path, _settings_with([]))
+    reg = [{"name": "thing", "hosts": ["Air-M5"],
+            "probe": "script_exists", "path": "/definitely/not/here.sh"}]
+    rep = gl.run_check(host="Air-M5", settings_path=sp, registry=reg)
+    assert rep.vector()["thing"] == gl.ABSENT
+    assert rep.alert_needed is True
+
+
+# ---- unknown probe is DEAD, never silently skipped --------------------------
+
+
+def test_unknown_probe_is_dead(tmp_path):
+    sp = _write_settings(tmp_path, _settings_with([]))
+    reg = [{"name": "weird", "hosts": ["*"], "probe": "nope"}]
+    rep = gl.run_check(host="X", settings_path=sp, registry=reg)
+    assert rep.vector()["weird"] == gl.DEAD
+
+
+# ---- phantom guardrail NOT seeded (the verify_mcp_integrity scar) -----------
+
+
+def test_verify_mcp_integrity_not_in_default_registry():
+    names = {e["name"] for e in gl.DEFAULT_REGISTRY}
+    assert "verify_mcp_integrity" not in names, (
+        "phantom guardrail must not be seeded as expected-present (scar 2026-06-06)"
+    )
+
+
+# ---- status_obj shape (caller folds this into sentinel status) -------------
+
+
+def test_to_status_obj_shape(tmp_path):
+    sp = _write_settings(tmp_path, _settings_with(HEALTHY_CMDS))
+    rep = gl.run_check(host="X", settings_path=sp)
+    obj = rep.to_status_obj()
+    assert obj["host"] == "X"
+    assert set(obj["vector"]) == {
+        "stop_verify", "dispatch_nudge", "guardrails_destructive_mcp"
+    }
+    assert "regressed" in obj
+
+
+# ============================================================================
+# Panel-hardening regression tests (4-LLM CODE review 2026-06-06)
+# Each guards one defect Codex/Gemini found. A real script on disk is needed
+# for the "wired + file live" path, so we create temp hook files.
+# ============================================================================
+
+
+def _settings_pointing_at(tmp_path, script_names, env_prefix=""):
+    """Create real hook files in tmp + settings.json wiring them."""
+    cmds = []
+    for n in script_names:
+        f = tmp_path / n
+        f.write_text("#!/bin/sh\nexit 2\n")  # non-empty
+        cmds.append(f"{env_prefix}python3 {f}")
+    return _write_settings(tmp_path, _settings_with(cmds)), cmds
+
+
+def test_wired_but_file_deleted_is_DEAD(tmp_path):
+    """C#3/#5: hook wired in settings but the script file doesn't exist."""
+    sp = _write_settings(tmp_path, _settings_with(["python3 /no/such/dispatch_nudge.py"]))
+    rep = gl.run_check(host="X", settings_path=sp, registry=[gl.DEFAULT_REGISTRY[1]])
+    assert rep.vector()["dispatch_nudge"] == gl.DEAD
+
+
+def test_wired_with_live_file_is_OK(tmp_path):
+    sp, _ = _settings_pointing_at(tmp_path, ["dispatch_nudge.py"])
+    rep = gl.run_check(host="X", settings_path=sp, registry=[gl.DEFAULT_REGISTRY[1]])
+    assert rep.vector()["dispatch_nudge"] == gl.OK
+
+
+def test_zero_byte_script_is_not_live(tmp_path):
+    """C#4: empty file must NOT count as live (the phantom-shipped pattern)."""
+    f = tmp_path / "thing.sh"
+    f.write_text("")  # zero bytes
+    sp = _write_settings(tmp_path, _settings_with([]))
+    reg = [{"name": "thing", "hosts": ["*"], "probe": "script_exists", "path": str(f)}]
+    rep = gl.run_check(host="X", settings_path=sp, registry=reg)
+    assert rep.vector()["thing"] == gl.ABSENT
+
+
+def test_substring_false_positive_rejected(tmp_path):
+    """C#2: `echo stop_verify.py` or `.bak` must NOT mark it wired."""
+    sp = _write_settings(tmp_path, _settings_with([
+        "echo stop_verify.py.bak running",
+        "python3 /x/dispatch_nudge.py.disabled",
+    ]))
+    rep = gl.run_check(host="X", settings_path=sp,
+                       registry=[gl.DEFAULT_REGISTRY[0], gl.DEFAULT_REGISTRY[1]])
+    assert rep.vector()["stop_verify"] == gl.DEAD
+    assert rep.vector()["dispatch_nudge"] == gl.DEAD
+
+
+def test_env_disable_via_daemon_environment(tmp_path):
+    """C#1/G#1: override exported in env, command clean → DISABLED."""
+    sp, _ = _settings_pointing_at(tmp_path, ["stop_verify.py"])
+    rep = gl.run_check(host="X", settings_path=sp,
+                       registry=[gl.DEFAULT_REGISTRY[0]],
+                       env={"STOP_VERIFY_ALLOW_DIRTY": "1"})
+    assert rep.vector()["stop_verify"] == gl.DISABLED
+
+
+def test_env_disable_uppercase_truthy(tmp_path):
+    """G#2: TRUE/YES must still count as disable."""
+    for v in ["TRUE", "Yes", "ON"]:
+        sp, _ = _settings_pointing_at(tmp_path, ["stop_verify.py"])
+        rep = gl.run_check(host="X", settings_path=sp,
+                           registry=[gl.DEFAULT_REGISTRY[0]],
+                           env={"STOP_VERIFY_ALLOW_DIRTY": v})
+        assert rep.vector()["stop_verify"] == gl.DISABLED, v
+
+
+def test_env_disable_false_value_is_not_disable(tmp_path):
+    """=0 / =false must NOT be read as disabled."""
+    for v in ["0", "false", "no"]:
+        sp, _ = _settings_pointing_at(tmp_path, ["stop_verify.py"])
+        rep = gl.run_check(host="X", settings_path=sp,
+                           registry=[gl.DEFAULT_REGISTRY[0]],
+                           env={"STOP_VERIFY_ALLOW_DIRTY": v})
+        assert rep.vector()["stop_verify"] == gl.OK, v
+
+
+def test_disable_env_prefix_var_not_matched(tmp_path):
+    """G#2: NON_STOP_VERIFY_ALLOW_DIRTY=1 must NOT disable stop_verify."""
+    sp, _ = _settings_pointing_at(tmp_path, ["stop_verify.py"],
+                                  env_prefix="NOT_STOP_VERIFY_ALLOW_DIRTY=1 ")
+    rep = gl.run_check(host="X", settings_path=sp, registry=[gl.DEFAULT_REGISTRY[0]])
+    assert rep.vector()["stop_verify"] == gl.OK
+
+
+def test_partial_value_not_matched(tmp_path):
+    """=12 / =true_x must NOT count as truthy disable."""
+    for v in ["12", "true_override", "yesterday"]:
+        sp, _ = _settings_pointing_at(tmp_path, ["stop_verify.py"],
+                                      env_prefix=f"STOP_VERIFY_ALLOW_DIRTY={v} ")
+        rep = gl.run_check(host="X", settings_path=sp, registry=[gl.DEFAULT_REGISTRY[0]])
+        assert rep.vector()["stop_verify"] == gl.OK, v
+
+
+def test_host_normalization_fqdn_and_local(tmp_path):
+    """G#8/#9: Nuzantara.local / Nuzantara.domain / case all match 'Nuzantara'."""
+    f = tmp_path / "h.sh"; f.write_text("x")
+    reg = [{"name": "h", "hosts": ["Nuzantara"], "probe": "script_exists", "path": str(f)}]
+    for h in ["Nuzantara", "nuzantara", "Nuzantara.local", "Nuzantara.tail123.ts.net"]:
+        sp = _write_settings(tmp_path, _settings_with([]))
+        rep = gl.run_check(host=h, settings_path=sp, registry=reg)
+        assert rep.vector()["h"] == gl.OK, h
+
+
+def test_hosts_as_string_does_not_loose_match(tmp_path):
+    """G#8: hosts given as a string must not substring-match."""
+    sp = _write_settings(tmp_path, _settings_with([]))
+    reg = [{"name": "h", "hosts": "prod-host", "probe": "script_exists", "path": "/x"}]
+    rep = gl.run_check(host="host", settings_path=sp, registry=reg)
+    assert rep.vector()["h"] == gl.SKIP  # string hosts → does not apply, not a fake match
+
+
+def test_duplicate_registry_names_loud(tmp_path):
+    sp = _write_settings(tmp_path, _settings_with([]))
+    reg = [
+        {"name": "dup", "hosts": ["*"], "probe": "script_exists", "path": "/a"},
+        {"name": "dup", "hosts": ["*"], "probe": "script_exists", "path": "/b"},
+    ]
+    rep = gl.run_check(host="X", settings_path=sp, registry=reg)
+    assert rep.vector().get("registry_config") == gl.DEAD
+    assert rep.alert_needed is True
+
+
+def test_missing_required_key_is_loud_per_guardrail(tmp_path):
+    """C#8: missing settings_key → that guardrail DEAD, not whole-run abort."""
+    sp = _write_settings(tmp_path, _settings_with([]))
+    reg = [
+        {"name": "broken", "hosts": ["*"], "probe": "hook_wired"},  # no settings_key
+        {"name": "fine", "hosts": ["X-only"], "probe": "script_exists", "path": "/x"},
+    ]
+    rep = gl.run_check(host="X", settings_path=sp, registry=reg)
+    assert rep.vector()["broken"] == gl.DEAD
+    # the other entry still got evaluated (SKIP, wrong host) — run did not abort
+    assert "fine" in rep.vector()
+
+
+def test_corrupt_settings_does_not_leak_content(tmp_path):
+    """G#6: corrupt-json alert must not echo file bytes."""
+    p = tmp_path / "settings.json"
+    p.write_text('{ "secret_token": "ABCD-LEAK-1234" not json')
+    rep = gl.run_check(host="X", settings_path=str(p))
+    obj = rep.to_status_obj()
+    blob = json.dumps(obj)
+    assert "ABCD-LEAK-1234" not in blob
+
+
+def test_invalid_utf8_settings_fails_loud_not_crash(tmp_path):
+    """G#4/C#7: invalid UTF-8 must yield settings_json DEAD, not raise."""
+    p = tmp_path / "settings.json"
+    p.write_bytes(b"\xff\xfe not valid utf8")
+    rep = gl.run_check(host="X", settings_path=str(p))  # must not raise
+    assert rep.vector().get("settings_json") == gl.DEAD
+
+
+def test_to_status_obj_keeps_alert_fields(tmp_path):
+    """C#9: alert_needed/alert_reason must survive serialization."""
+    sp = _write_settings(tmp_path, _settings_with(["unrelated.py"]))
+    rep = gl.run_check(host="X", settings_path=sp)
+    obj = rep.to_status_obj()
+    assert obj["alert_needed"] is True
+    assert obj["alert_reason"]
+
+
+def test_malformed_hooks_shape_does_not_crash(tmp_path):
+    """G#3: hooks as non-list must not raise."""
+    p = tmp_path / "settings.json"
+    p.write_text(json.dumps({"hooks": {"PreToolUse": 123}}))
+    rep = gl.run_check(host="X", settings_path=str(p))  # must not raise
+    # nothing wired → all dead, but no crash
+    assert rep.alert_needed is True
+
+
+def test_new_born_dead_guardrail_not_marked_regression(tmp_path):
+    """DeepSeek #5: a guardrail UNKNOWN in prior, born dead, is NOT a regression."""
+    sp = _write_settings(tmp_path, _settings_with(["unrelated.py"]))
+    prior = {"dispatch_nudge": gl.OK}  # stop_verify NOT in prior at all
+    rep = gl.run_check(host="X", settings_path=sp, prior_vector=prior)
+    assert "stop_verify" not in rep.regressed  # new + dead != regression
+    assert rep.alert_needed is True  # still alerts (born-dead), just not "regression"
+
+
+def test_default_registry_not_mutated_across_runs(tmp_path):
+    """DeepSeek #7: DEFAULT_REGISTRY must not be corrupted by a run."""
+    before = [dict(e) for e in gl.DEFAULT_REGISTRY]
+    sp = _write_settings(tmp_path, _settings_with([]))
+    gl.run_check(host="X", settings_path=sp)
+    assert gl.DEFAULT_REGISTRY == before


### PR DESCRIPTION
## What

Spec for a **guardrail-liveness sentinel** — a scheduled check that makes *guardrail decay observable*. Born from a reflection on Anthropic's essay ["When AI builds itself"](https://www.anthropic.com/institute/recursive-self-improvement) (5 Jun 2026), whose named bottleneck for the likely future is *"code review becomes the constraint as Claude generates faster than humans verify."*

We have scars of exactly that shape — guardrails alive-on-paper, dead-in-fact, found by luck. This spec turns that into a 3-check sentinel: cascade-tier liveness, guardrail **behavioral** liveness (not presence), and fleet reachability.

## Why this is docs-only (no deploy)

This PR ships the **spec + scar** only. The implementation (extension of `nuzantara-sentinel.py` + LaunchAgent) is a separate code PR, and the irreversible infra step (installing the plist on Pro) is reserved as a human gate.

## The session proved the thesis 4×

1. `verify_mcp_integrity.sh` — claimed-shipped in memory, **absent on M5 AND Pro** → new P3 scar.
2. Pro + Mini both offline (nobody knew until ssh attempted).
3. Codex panel run **hung 30 min** on a dead Tavily-MCP OAuth token (now disabled).
4. **`stop_verify.py` is WIRED-BUT-DISABLED** (`STOP_VERIFY_ALLOW_DIRTY=1` → immediate exit 0), verified on disk — my v1 "present+wired" check would have marked it alive.

## 4-LLM panel (per CLAUDE.md §6)

Gemini 3.1 Pro + DeepSeek V4 Pro + Codex GPT-5.5 + Claude Opus — all 4 real, 2 did empirical filesystem verification. ~20 defects, all incorporated into v2. PIVOT: `sentinel_meta_watchdog.sh` already exists → **extend, don't rebuild** (reuse-first).

## Pro live re-verification (§8bis)

Every `[ASSUMED-MEMORY]` tag re-checked live once Pro came back online; corrected my own false-MISSING on the cascade binaries via a second tool call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)