### PR TITLE
fix(war-room): Step 3 enables enriched prompt by default — closes Step 2→3 link

### DIFF
--- a/scripts/wr2_draft_generator.py
+++ b/scripts/wr2_draft_generator.py
@@ -394,15 +394,16 @@ def _build_draft_prompt(
 
     PR-1 §C: when an enrichment object is available we hand Claude the full
     structured brief (1400-2000 words across the_facts, bali_zero_take,
-    in_practice, next_steps, faq) instead of a truncated paragraph. This
-    is gated by WR2_USE_FULL_ENRICHED_PROMPT so the legacy path stays
-    available for back-compat / rollback.
+    in_practice, next_steps, faq) instead of a truncated paragraph. This is
+    the default path (WR2_USE_FULL_ENRICHED_PROMPT defaults to "true"); set
+    WR2_USE_FULL_ENRICHED_PROMPT=false to opt out and force the legacy path
+    for back-compat / rollback.
 
     Falls back to summary[:3500] when:
-      - WR2_USE_FULL_ENRICHED_PROMPT != "true" (legacy mode), OR
+      - WR2_USE_FULL_ENRICHED_PROMPT == "false" (legacy opt-out), OR
       - enrichment dict is empty / missing all expected fields.
     """
-    use_full_enriched = os.environ.get("WR2_USE_FULL_ENRICHED_PROMPT", "false").lower() == "true"
+    use_full_enriched = os.environ.get("WR2_USE_FULL_ENRICHED_PROMPT", "true").lower() == "true"
 
     body = ""
     if use_full_enriched and enrichment:


### PR DESCRIPTION
## Closes the rebuilt War Room chain

The third link. Step 3 (`wr2_draft_generator.py`) gated the rich enriched-prompt path behind
`WR2_USE_FULL_ENRICHED_PROMPT`, **default `"false"`**. The flag is unset in production, so the
default won → Step 3 **ignored the `enrichment` object** (Step 2's fused brief + injected rails:
verbatim citations, exact numbers, taboo) and fell back to the legacy `summary[:3500]` raw
truncated path — **throwing away all of Step 2's work** (exactly the "brief povero" the
poor-vs-rich comparison rejected).

### The one-line fix
`os.environ.get("WR2_USE_FULL_ENRICHED_PROMPT", "false")` → `"true"`. Opt-out with
`WR2_USE_FULL_ENRICHED_PROMPT=false` to revert. Legacy summary path stays as fallback when
`enrichment` is empty.

### Verified before flipping (per Antonello: test before enabling a prod-cron path)
`_build_enriched_brief` was exercised on the **real Step 2 brief** (PP 20/2026, fused by
`warroom_step2_briefer`): the generated prompt body (2100 chars, section-tagged) carries —
- verbatim citations: `PP 55/2022 · UU HPP 7/2021 Pasal 4(2)e · PMK 81/2024 Pasal 448`
- exact numbers: `0,5%, Rp 4,8 mld, 7-4-3 anni, Rp 10 mld PT PMA`
- the taboo line: `NON usare / evitare: no 'save money on taxes'...`

all reaching Claude's slide-composition prompt. The path is sound; the flag was the only
disconnected link.

### The full chain now connects
```
Step 1 (warroom_step1_reader)  → intel_items → LLM shortlist
Step 2 (warroom_step2_briefer) → brief_json with rails injected into enrichment.the_facts
Step 3 (wr2_draft_generator)   → reads enrichment (THIS FIX) → claude-opus-4-7 → slides_json
```
Step 3 already filters `status='briefed'` only, so Step 2's `needs_review_conflict` drafts are
correctly skipped (verified). claude-opus-4-7 via OAuth (not api_key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)