### PR TITLE
perf(vercel): path-aware ignoreCommand — cut Vercel build-CPU cost (~85% fewer mouth builds)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,5 @@
   "outputDirectory": "apps/mouth/.next",
   "framework": "nextjs",
   "installCommand": "npm install",
-  "ignoreCommand": "exit 1"
+  "ignoreCommand": "if [ -z \"$VERCEL_GIT_PREVIOUS_SHA\" ]; then exit 1; fi; git diff --quiet $VERCEL_GIT_PREVIOUS_SHA HEAD -- apps/mouth && git diff --quiet $VERCEL_GIT_PREVIOUS_SHA HEAD -- packages && git diff --quiet $VERCEL_GIT_PREVIOUS_SHA HEAD -- package.json && git diff --quiet $VERCEL_GIT_PREVIOUS_SHA HEAD -- package-lock.json && git diff --quiet $VERCEL_GIT_PREVIOUS_SHA HEAD -- vercel.json"
 }


### PR DESCRIPTION
## Problema
Vercel ci costa **\$124/mese**, di cui **\$119 (96%)** sono **Build CPU Minutes** (919 ore/mese). Diagnosi empirica via Vercel MCP sul team `nuzantara-2026`:

| Causa | Impatto |
|---|---|
| **`ignoreCommand: "exit 1"`** nel root `vercel.json` = forza-builda-sempre (exit ≠0 = build) | `mouth` ribuilda su **ogni** commit di **ogni** branch, anche backend-Python / docs / scripts / CI-auto-fix che non toccano il frontend |
| Progetto **`nuzantara`** duplicato | builda **ogni commit identico a `mouth`** (SHA a 30ms di distanza), **zero domini di produzione** → +50% build sprecate |

Finestra reale ~16h: **20 build mouth + 20 build nuzantara** = ~60 build/giorno.

## Cosa fa questa PR (lato repo)
Sostituisce `exit 1` con un **ignore step path-aware**: builda solo se cambia il frontend o le sue dipendenze — `apps/mouth`, `packages` (mouth importa `@balizero/core` 56×), `package.json`, `package-lock.json`, `vercel.json`. Tutto il resto (backend, docs, scripts, infra, research) → **skip**.

**Validato sugli ultimi 40 commit di main: SKIP=34 / BUILD=6** (~85% build mouth in meno). I 6 BUILD sono esattamente i commit frontend/dipendenze — **zero falsi-skip**.

### Note implementative (load-bearing — NON "semplificare")
- Confronta **`VERCEL_GIT_PREVIOUS_SHA`** (ultimo commit *deployato*), non `HEAD^` → un batch-push il cui cambio frontend non è il commit-tip builda comunque.
- Fallback primo-deploy (`exit 1`) + fail-safe su errore git (exit 128) → **entrambi buildano**.
- Catena `&&` di **pathspec singoli**, NON un singolo `git diff` multi-pathspec: `git diff A <merge> -- p1 p2` attiva il **combined-diff** di git e **sopprime erroneamente** i file identici a un parent del merge (verificato: scartava il merge dell'articolo PP-20 → blog stale).

Verificato end-to-end via `sh -c` sulla **stringa letterale** con SHA reali: backend→SKIP, merge-articolo→BUILD, prev-vuoto→BUILD, prev-errato→BUILD.

## Cosa NON fa questa PR (azioni dashboard owner — vedi sotto)
1. **Spegnere/eliminare il progetto `nuzantara`** (duplicato, nessun dominio prod) → **−50% immediato**. Dashboard-only.
2. (Opz.) Limitare preview deploy sui branch `agent/*` e `codex/auto-fix-ci-*`.

## Risk / rollback
1 riga in `vercel.json`. Rollback = ripristina `"ignoreCommand": "exit 1"`. Pre-commit verde (incl. typecheck mouth). Production deploy resta su push a `main` invariato; il primo build post-merge tocca `vercel.json` → builda (auto-valida).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>