### PR TITLE
🎨 Palette: standardize language in Thinking Indicator

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -42,3 +42,8 @@
 
 **Learning:** Small utility widgets that contain text inputs (like FeedbackWidget) often feel "heavy" when they use standard textareas with fixed heights and internal scrollbars. Utilizing the project's standard AutoResizeTextarea component ensures a fluid, consistent input experience across all interface layers. Additionally, secondary widgets must strictly adhere to semantic labeling (htmlFor/id) and ARIA dialog roles to ensure they are not overlooked by screen reader users.
 **Action:** Consistently use AutoResizeTextarea for multi-line inputs in all UI layers. Always associate labels with inputs using semantic IDs and apply aria-labelledby to dialog containers.
+
+## 2026-05-20 - [Consistency in Dynamic AI Status Messages]
+
+**Learning:** Surfacing internal system names (like database collections) or hardcoded localized verbs in dynamic AI reasoning indicators creates a disjointed experience if the rest of the interface is English-first.
+**Action:** Always map internal tool/database identifiers to user-friendly English strings for reasoning indicators, while maintaining personality-driven elements (like interjections) where appropriate for the brand voice.

--- a/apps/mouth/src/components/chat/thinking/constants.tsx
+++ b/apps/mouth/src/components/chat/thinking/constants.tsx
@@ -16,14 +16,14 @@ import { ThinkingPhrase } from "./types";
 
 // Collection display names for user-friendly messages
 export const COLLECTION_NAMES: Record<string, string> = {
-  visa_oracle: "documenti visti",
-  legal_unified: "normativa legale",
-  tax_genius: "regolamenti fiscali",
-  kbli_2025_final: "codici KBLI",
-  balizero_news: "aggiornamenti normativi",
-  bali_zero_pricing_hybrid: "listino prezzi",
-  training_conversations_hybrid: "conversazioni precedenti",
-  immigration_circulars: "circolari immigrazione",
+  visa_oracle: "visa documents",
+  legal_unified: "legal regulations",
+  tax_genius: "tax regulations",
+  kbli_2025_final: "KBLI codes",
+  balizero_news: "regulatory updates",
+  bali_zero_pricing_hybrid: "price list",
+  training_conversations_hybrid: "previous conversations",
+  immigration_circulars: "immigration circulars",
 };
 
 // Map tool names to icons

--- a/apps/mouth/src/components/chat/thinking/utils.ts
+++ b/apps/mouth/src/components/chat/thinking/utils.ts
@@ -16,37 +16,37 @@ export function getDynamicToolMessage(
   switch (toolName) {
     case "vector_search": {
       if (collection && COLLECTION_NAMES[collection]) {
-        return `Cerco "${shortQuery}" in ${COLLECTION_NAMES[collection]}...`;
+        return `Searching for "${shortQuery}" in ${COLLECTION_NAMES[collection]}...`;
       }
-      return `Cerco "${shortQuery}" nella knowledge base...`;
+      return `Searching for "${shortQuery}" in knowledge base...`;
     }
     case "knowledge_graph_search": {
       const entity =
         typeof args?.entity_name === "string" ? args.entity_name : query;
-      return `Esploro connessioni per "${entity}"...`;
+      return `Exploring connections for "${entity}"...`;
     }
     case "calculator": {
       const expr = typeof args?.expression === "string" ? args.expression : "";
-      return `Calcolo: ${expr.slice(0, 30)}${expr.length > 30 ? "..." : ""}`;
+      return `Calculating: ${expr.slice(0, 30)}${expr.length > 30 ? "..." : ""}`;
     }
     case "get_pricing": {
       const service =
-        typeof args?.service_name === "string" ? args.service_name : "servizio";
-      return `Recupero prezzo per "${service}"...`;
+        typeof args?.service_name === "string" ? args.service_name : "service";
+      return `Fetching price for "${service}"...`;
     }
     case "team_knowledge":
     case "search_team_member":
     case "get_team_members_list": {
-      return "Consulto il team Bali Zero...";
+      return "Consulting Bali Zero team...";
     }
     case "web_search": {
-      return `Cerco sul web: "${shortQuery}"...`;
+      return `Searching the web: "${shortQuery}"...`;
     }
     case "generate_image": {
-      return "Genero immagine...";
+      return "Generating image...";
     }
     default:
-      return `Elaboro con ${toolName}...`;
+      return `Processing with ${toolName}...`;
   }
 }
 


### PR DESCRIPTION
I have refactored the hardcoded Italian strings in the `ThinkingIndicator` component within the `apps/mouth` chat application. 

### 💡 What:
- Translated database collection display names (e.g., "documenti visti" -> "visa documents") in `constants.tsx`.
- Translated tool status verbs (e.g., "Cerco" -> "Searching for") in the `getDynamicToolMessage` utility.

### 🎯 Why:
The codebase is primarily English, but several system-level status messages in the "Thinking" state were hardcoded in Italian. This created a disjointed user experience where the main interface was English but the reasoning steps switched languages unexpectedly.

### ♿ Accessibility:
- Ensures consistent language for screen reader users consuming the AI's step-by-step reasoning.

### ✅ Verification:
- Verified with a dedicated unit test suite (ran during development).
- Visually verified using a Playwright script in a temporary route to confirm the English strings appear correctly in the UI.
- All changes are under the 50-line limit for core UI logic.

---
*PR created automatically by Jules for task [572965853536701740](https://jules.google.com/task/572965853536701740) started by @Balizero1987*