### PR TITLE
fix(redact): P2 confine-PII — close 2 verified bugs in _redact_pii.py (FASE-2)

### DIFF
--- a/scripts/_redact_pii.py
+++ b/scripts/_redact_pii.py
@@ -64,6 +64,17 @@ class RedactionError(RuntimeError):
     """Raised when the redactor refuses to produce output (fail-closed)."""
 
 
+class DynamicNameLoadError(RedactionError):
+    """Raised when dynamic CRM names were EXPECTED but Postgres was unreachable.
+
+    P2 §7.1 BUG #1 fix: distinguishes "PG legitimately out of scope" (env unset →
+    return [] and degrade) from "PG expected but down" (env set + connection/query
+    failed). The latter is a fail-OPEN trap — it would silently skip redacting
+    CRM names and forward un-redacted text to the cloud. When the caller requires
+    dynamic names, this exception forces fail-CLOSED instead.
+    """
+
+
 @dataclass
 class GateConfig:
     min_remaining_chars: int = 100
@@ -189,18 +200,31 @@ def _apply_dynamic_rule(
     # ("Sofia Mueller" before "Sofia").
     escaped.sort(key=len, reverse=True)
     pattern = r"\b(?:" + "|".join(escaped) + r")\b"
-    compiled = re.compile(pattern)
+    # P2 §7.1 BUG #2 fix: case-insensitive. CRM names arrive title-cased from
+    # Postgres ("Budi Santoso") but appear lowercased in WhatsApp text
+    # ("budi santoso"). Without re.IGNORECASE the lowercase form BYPASSED the
+    # filter and the name leaked to the cloud. The static passes carry their own
+    # (?i) inline in the YAML where needed; this dynamic alternation is built at
+    # runtime from re.escape'd names, so the flag must be set here.
+    compiled = re.compile(pattern, re.IGNORECASE)
     return compiled.sub(rule["replace"], text)
 
 
 def _load_pg_names(query: str, pg_url: str | None = None) -> list[str]:
-    """Load a single column from PG. Returns empty list if PG unreachable.
+    """Load a single column from PG.
 
-    Phase 1 design: the redactor is fail-closed on rule-application
-    errors but DEGRADES gracefully when PG is unavailable (LaunchAgent
-    may run before postgresql@18 is started). Empty list → dynamic
-    rule no-ops with a warning. Operator MUST verify PG was reachable
-    by checking the run telemetry.
+    P2 §7.1 BUG #1 fix — two distinct outcomes (NOT one silent []):
+
+    - **PG out of scope** (no DATABASE_URL/PGURL env, no explicit pg_url):
+      return [] and degrade. This is legitimate — the redactor may run where
+      PG is intentionally absent (LaunchAgent before postgresql@18; the P3
+      egress-proxy with REDACT_PG_DISABLED). The static NPWP/KTP/passport
+      passes still run.
+    - **PG expected but unreachable** (env/pg_url set, but psql missing /
+      timeout / connection / query failure): raise DynamicNameLoadError.
+      Previously this returned [] and PROCEEDED → CRM names silently NOT
+      redacted → fail-OPEN masquerading as fail-closed. The caller decides
+      whether to fail-CLOSED (see Redactor.load_default require_dynamic_names).
     """
     # Read DATABASE_URL (canonical name used by wrapper + secrets template),
     # PGURL as legacy fallback. Mismatch was caught by Codex panel R5
@@ -210,7 +234,7 @@ def _load_pg_names(query: str, pg_url: str | None = None) -> list[str]:
     pg_url = pg_url or os.environ.get("DATABASE_URL") or os.environ.get("PGURL")
     if not pg_url:
         logger.warning(
-            "DATABASE_URL/PGURL env not set — skipping dynamic name load."
+            "DATABASE_URL/PGURL env not set — PG out of scope, skipping dynamic name load."
         )
         return []
     try:
@@ -221,16 +245,17 @@ def _load_pg_names(query: str, pg_url: str | None = None) -> list[str]:
             timeout=10,
             check=False,
         )
-    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
-        logger.warning("psql unavailable for dynamic name load: %s", e)
-        return []
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        # PG was EXPECTED (url set) but psql is missing or timed out → fail-CLOSED signal.
+        raise DynamicNameLoadError(
+            f"dynamic CRM-name load expected (pg_url set) but psql unavailable: {e}"
+        ) from e
     if result.returncode != 0:
-        logger.warning(
-            "psql query failed (rc=%d): %s",
-            result.returncode,
-            result.stderr.strip(),
+        # PG was EXPECTED but the query failed (DB down, auth, missing table) → fail-CLOSED signal.
+        raise DynamicNameLoadError(
+            f"dynamic CRM-name load expected (pg_url set) but psql query failed "
+            f"(rc={result.returncode}): {result.stderr.strip()}"
         )
-        return []
     return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
 
@@ -259,19 +284,47 @@ class Redactor:
                     self._compiled[rid] = compiled
 
     @classmethod
-    def load_default(cls, pg_url: str | None = None) -> "Redactor":
-        """Load config from the canonical path + populate runtime names."""
+    def load_default(
+        cls, pg_url: str | None = None, require_dynamic_names: bool = False
+    ) -> "Redactor":
+        """Load config from the canonical path + populate runtime names.
+
+        P2 §7.1 BUG #1 fix — `require_dynamic_names` controls the PG-down posture:
+
+        - **False** (default, backward-compatible): PG out of scope (env unset) →
+          dynamic names empty, static passes still run. PG EXPECTED-but-down →
+          still raises DynamicNameLoadError (a set DATABASE_URL means PG was
+          meant to be reachable; silently skipping CRM-name redaction is the
+          fail-OPEN trap). Out-of-scope PG no longer masquerades as a working
+          dynamic pass.
+        - **True**: PG MUST be reachable AND yield names. Any DynamicNameLoadError
+          OR a no-pg-url situation → fail-CLOSED. Use this on the cloud-egress
+          path where un-redacted CRM names leaving the machine is unacceptable.
+        """
         config = load_config()
-        runtime_names = {
-            "__DYNAMIC_CRM_CLIENT_NAMES__": _load_pg_names(
-                "SELECT full_name FROM clients WHERE full_name IS NOT NULL;",
-                pg_url=pg_url,
-            ),
-            "__DYNAMIC_CRM_COMPANY_NAMES__": _load_pg_names(
-                "SELECT name FROM companies WHERE name IS NOT NULL;",
-                pg_url=pg_url,
-            ),
-        }
+        try:
+            runtime_names = {
+                "__DYNAMIC_CRM_CLIENT_NAMES__": _load_pg_names(
+                    "SELECT full_name FROM clients WHERE full_name IS NOT NULL;",
+                    pg_url=pg_url,
+                ),
+                "__DYNAMIC_CRM_COMPANY_NAMES__": _load_pg_names(
+                    "SELECT name FROM companies WHERE name IS NOT NULL;",
+                    pg_url=pg_url,
+                ),
+            }
+        except DynamicNameLoadError:
+            # PG was expected but unreachable. ALWAYS fail-closed here — proceeding
+            # would forward un-redacted CRM names. (require_dynamic_names only
+            # tightens further, below, for the env-unset case.)
+            raise
+
+        if require_dynamic_names and not any(runtime_names.values()):
+            raise DynamicNameLoadError(
+                "require_dynamic_names=True but 0 CRM names loaded "
+                "(PG out of scope or both tables empty) — fail-CLOSED on the "
+                "cloud-egress path to avoid leaking un-redacted CRM names."
+            )
         return cls(config=config, runtime_names=runtime_names)
 
     def _apply_pass(

--- a/scripts/test_redact_pii.py
+++ b/scripts/test_redact_pii.py
@@ -19,7 +19,6 @@ Run:
 
 from __future__ import annotations
 
-import re
 import sys
 from pathlib import Path
 
@@ -28,9 +27,11 @@ import pytest
 SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR.parent))
 
-from scripts._redact_pii import (
+from scripts._redact_pii import (  # noqa: E402  (sys.path.insert must precede this local import)
+    DynamicNameLoadError,
     Redactor,
     RedactionError,
+    _load_pg_names,
     load_config,
 )
 
@@ -386,3 +387,87 @@ def test_kura_kura_btid_dossier_redacted(redactor_no_dynamic):
     assert "[INTERNAL-DOSSIER-REDACTED]" in out
     assert "Padding line 1" in out, "unrelated content before must survive"
     assert "Padding line 4" in out, "unrelated content after must survive"
+
+
+# ─── P2 §7.1 BUG FIXES (FASE-2 confine-PII) ──────────────────────────
+
+
+def test_p2_bug2_lowercase_crm_name_redacted(redactor_with_names):
+    """P2 §7.1 BUG #2: CRM names arrive title-cased from PG but appear
+    LOWERCASE in WhatsApp text. Without re.IGNORECASE the lowercase form
+    bypassed pass4 and leaked to the cloud. Fix = re.IGNORECASE on the
+    dynamic alternation.
+    """
+    # "Sofia Mueller" is in the fixture's CRM names — feed it lowercase.
+    text = (
+        "Padding to keep the gate happy with enough surviving content here. "
+        + "z" * 150
+        + " the client sofia mueller asked about her visa extension today please."
+    )
+    out = redactor_with_names.redact(text)
+    assert "sofia mueller" not in out.lower(), (
+        "lowercase CRM name leaked — re.IGNORECASE regression (P2 BUG #2)"
+    )
+
+
+def test_p2_bug2_mixed_case_crm_name_redacted(redactor_with_names):
+    """Mixed/odd casing ('SoFiA MuElLeR') must also be caught."""
+    text = (
+        "Padding content to satisfy min_remaining_chars gate comfortably here. "
+        + "w" * 150
+        + " note: SoFiA MuElLeR is the registered client for this matter."
+    )
+    out = redactor_with_names.redact(text)
+    assert "mueller" not in out.lower(), "mixed-case CRM name leaked (P2 BUG #2)"
+
+
+def test_p2_bug1_pg_unset_degrades_no_raise(monkeypatch):
+    """P2 §7.1 BUG #1: PG out of scope (no env, no pg_url) → return [],
+    degrade gracefully. This is the legitimate case (LaunchAgent before PG,
+    P3 egress-proxy with REDACT_PG_DISABLED). Must NOT raise.
+    """
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("PGURL", raising=False)
+    assert _load_pg_names("SELECT 1", pg_url=None) == []
+
+
+def test_p2_bug1_pg_expected_but_down_raises(monkeypatch):
+    """P2 §7.1 BUG #1: PG EXPECTED (pg_url set) but unreachable → raise
+    DynamicNameLoadError. Previously returned [] and PROCEEDED = fail-OPEN
+    (CRM names silently NOT redacted, then forwarded to cloud).
+    """
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("PGURL", raising=False)
+    with pytest.raises(DynamicNameLoadError):
+        # Dead port → psql connection refused (or psql missing → also raises).
+        _load_pg_names(
+            "SELECT full_name FROM clients",
+            pg_url="postgresql://x:x@127.0.0.1:5999/nope",
+        )
+
+
+def test_p2_bug1_load_default_fail_closed_when_pg_down(monkeypatch):
+    """load_default() must fail-CLOSED (raise) when DATABASE_URL is set but
+    Postgres is down — never silently build a redactor with no CRM names.
+    """
+    monkeypatch.setenv("DATABASE_URL", "postgresql://x:x@127.0.0.1:5999/nope")
+    with pytest.raises(DynamicNameLoadError):
+        Redactor.load_default()
+
+
+def test_p2_bug1_require_dynamic_names_fail_closed_when_env_unset(monkeypatch):
+    """On the cloud-egress path, require_dynamic_names=True must fail-CLOSED
+    even when PG is merely out of scope (env unset) — because forwarding text
+    that COULD contain un-redacted CRM names is unacceptable there.
+    """
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("PGURL", raising=False)
+    with pytest.raises(DynamicNameLoadError):
+        Redactor.load_default(require_dynamic_names=True)
+
+
+def test_p2_dynamic_name_load_error_is_redaction_error():
+    """DynamicNameLoadError must subclass RedactionError so existing callers
+    that catch RedactionError (e.g. _cli_main) fail-closed automatically.
+    """
+    assert issubclass(DynamicNameLoadError, RedactionError)


### PR DESCRIPTION
## FASE-2 of the SOTA meta-dev-loop

Spec: `research/operations/specs/P2-router-confine-pii.md` §7.1. Builds on FASE-1 (#1170, already merged) — `_redact_pii.py` is now mounted at the P3 egress chokepoint, so these bugs are **load-bearing** for the network confine-PII boundary. The spec mandates fixing them FIRST.

### Two verified bugs closed
**BUG #1 — fail-OPEN masquerading as fail-closed** (`_load_pg_names`): when `DATABASE_URL` was set but Postgres was unreachable, it returned `[]` + warning and **proceeded** → CRM client/company names silently NOT redacted, forwarded to the cloud. Fix distinguishes:
- PG **out of scope** (no env/pg_url) → `[]`, degrade (legitimate: LaunchAgent pre-PG; P3 proxy with `REDACT_PG_DISABLED`).
- PG **expected but down** (env/pg_url set, psql missing/timeout/connection/query fail) → raise new `DynamicNameLoadError` (⊂ `RedactionError` → existing catchers incl. `_cli_main` fail-closed automatically).
- `load_default()` re-raises on PG-expected-but-down + gains `require_dynamic_names=True` for the cloud-egress path.

**BUG #2 — case-sensitivity** (`_apply_dynamic_rule`): dynamic CRM-name alternation compiled WITHOUT `re.IGNORECASE`. Names arrive title-cased from PG (\"Budi Santoso\") but lowercase in WhatsApp (\"budi santoso\") → lowercase BYPASSED the filter and leaked. Fix: `re.IGNORECASE` on the runtime alternation.

**BUG #3 — leak via repo-read**: NOT in this file — already closed by the FASE-1 sandbox (P3). Dependency P2→P3 confirmed.

### Verification
- 7 new falsifiable tests (lowercase/mixed-case redaction; PG-unset degrades; PG-down raises; load_default fail-closed; require_dynamic_names; subclass invariant).
- Full suite **42/42 green** (35 prior + 7 new), zero regressions.
- ruff clean.

Note: the test commit was made with the documented `PII_GATE_ENFORCEMENT=false` allowlist — `test_redact_pii.py` is BY DESIGN the file that tests NPWP/KTP/passport redaction, every \"PII\" string in it is synthetic fixture data (invented numbers, fictional names). No real client PII committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)