### PR TITLE
feat(fase0): arm governance-liveness H24 + verify_mcp_integrity guardian (W69 BUCO #2)

### DIFF
--- a/.claude/rules/cicatrix-scars.md
+++ b/.claude/rules/cicatrix-scars.md
@@ -573,3 +573,48 @@ _Discovered: 2026-06-09 06:54 WITA da M5 (thin-client), audit indipendente post-
 **GOTCHA**: **Nessuno dei 2 buchi è armabile da M5** — entrambi richiedono una sessione SUL Pro (coerente con la nota-pending lasciata dal sibling). `hot-zone-pr-gate` è **GIÀ flipped a enforcing 2026-06-07**: gli step `CODEOWNERS self-mod check` + `Replay lint_migration_numbers` sono `continue-on-error: false` (= bloccano); gli step `Redis lease` + `LaunchAgent notice` restano `continue-on-error: true` ma è **monitor-by-design** (i runner effimeri non hanno Redis né LaunchAgent), **NON disarmo accidentale** — non confonderli con il buco #1.
 
 **Reference**: audit in worktree isolato `.worktrees/ops-fase0-armament-audit` allineato a `origin/main` 8bab25ba5. Branch sibling `agent/air-m5/fase0-instrumentation-rearm` (locale, 2 commit `verify_mcp_integrity.sh` + W67-sentinel) **MAI toccato**. Required-checks letti via `gh api repos/Balizero1987/Teman2/branches/main/protection/required_status_checks`. Family: W64 (`esistere ≠ armato`, asyncpg sibling-fix), il verdetto eserciti `2026-06-07-sota-9-spec-armies-verdict.md §4c` rischio-max "decadimento entropico inosservabile / esiste-ma-disarmato". Fix → sessione-Pro dedicata.
+
+---
+
+### ⚠️ W70 (P2, renumber of m5-branch W67): sentinel + meta-watchdog OK but 39 jobs DLQ-terminal (21 in 24h), healing=0 — common cause = Air-decommissioned path-drift in backup scripts + sentinel captures no real stderr (blind autopilot) (2026-06-09)
+
+_Discovered: 2026-06-09 ~04:45 WITA during FASE-0 instrumentation re-arm (read-only audit from M5 via ssh pro) · Severity: P2 · Status: **DIAGNOSED — fix deferred to a dedicated Pro session**. Renumbered from the m5-branch's "W67" because W67 was independently taken on main by the wa-mirror reconnect-storm scar (2026-06-07); two different scars, same number → this DLQ one becomes W70._
+
+**TRAUMA**: FASE-0 re-arm went hunting for "disarmed guardians" (per the 9-spec armies verdict). The verdict said `sentinel_meta_watchdog` was "esiste ma non gira" — FALSE: `launchctl list` on Pro shows `com.nuzantara.sentinel-meta-watchdog` LOADED, `LastExitStatus=0`, state file fresh. The watchdog WORKS. But verifying it surfaced the real wound: `sentinel_status.json` reports `jobs_circuit_terminal=38 dlq_terminal=38 healing_actions_24h=0`. The true source `~/.agent/decisions/dlq.json` → **39 entries, all status=TERMINAL**, age **21 ≤1d / 12 2-7d / 6 8-30d**. NOT stale legacy noise — CORE infra jobs dying NOW: `fly_pg_backup`, `qdrant_snapshot`, `fly_qdrant_backup`, `rag_canary`, `garuda_indexer`, `knowledge_graph_builder`, `nlm_nb1_daily_refresh`, `post_publish_poller`, etc. The fleet sheds jobs into terminal-DLQ and **nobody resuscitates them** (`healing_actions_24h=0`).
+
+Two compounding root causes (found by EXECUTING the real scripts, which the sentinel does not):
+1. **Air-decommissioned path-drift (W50/W51/W52 family)**: `qdrant_snapshot` + `fly_qdrant_backup` fail with `/Users/nuzantara/Projects/nuzantara/.../.env not found` — the **Air checkout path decommissioned 2026-05-05**. Live path is `~/Desktop/nuzantara`. Hardcoded dead-machine path.
+2. **`fly_pg_backup` runs but produces a 0-byte dump**: `pg_dump` inside the Fly primary returns empty, silent.
+
+**META-problem (load-bearing)**: the sentinel's `log_tail` captures only the retry-wrapper summary ("exit 1 after 3 attempts"), NOT the job's real stderr. So every terminal entry has `classification={type:UNKNOWN, confidence:0.0}` → the autopilot retries blind 10× → gives up → TERMINAL. Observability exists (we KNOW 39 died) but is BLIND on WHY — the exact "instrumentation disarmed" thesis made concrete.
+
+**ANTIBODY (DIAGNOSED, NOT executed — highest-leverage = #3):**
+1. grep `~/scripts/*backup*.sh` + `*snapshot*.sh` for `Projects/nuzantara` → repoint to `~/Desktop/nuzantara` (resuscitates the qdrant pair + several of the 21).
+2. Fix `fly_pg_backup` 0-byte dump (Fly-side pg_dump empty; cf. W38 role demotion in flight).
+3. Make the sentinel capture REAL stderr in `log_tail` (not the retry-summary) — re-arms the WHOLE auto-heal loop.
+4. Resolve `com.nuzantara.sentinel` one-shot-vs-daemon mismatch (RunAtLoad, no StartInterval → one-shot the watchdog tamps every ~1h, W55-masked slow crash-loop).
+
+**GOTCHA**: monitor-alive ≠ fleet-healthy — read `dlq.json` / `jobs_circuit_terminal` + `healing_actions_24h`, not just "is the sentinel running". `log_tail="exit 1 after 3 attempts"` is a false friend (zero diagnostic signal). The Air decommission (2026-05-05) keeps spawning path-drift scars 35 days later — no sweep ever grepped all scripts for `Projects/nuzantara`. Family: W50/W51/W52 (Air-path drift), W55 (cooldown masks slow failure).
+
+**Reference**: `~/.agent/decisions/dlq.json` (39 terminal), `sentinel_status.json`, `~/scripts/nuzantara-sentinel.py` (log_tail handling). Origin: m5 branch `agent/air-m5/fase0-instrumentation-rearm` commit d6ae97e33. Pending: triage 39 DLQ + 3 fixes on a dedicated Pro session.
+
+---
+
+### ✅ W71: FASE-0 governance-liveness ARMED H24 on Pro (W69 BUCO #2 closed) + verify_mcp_integrity.sh shipped-but-untested glyph bug caught (2026-06-09)
+
+_Discovered/Fixed: 2026-06-09 ~08:00-08:30 WITA, dedicated Pro session closing W69 · Severity: P2 → RESOLVED for BUCO #2; BUCO #1 + cost_breaker-ledger deferred · Status: **ARMED (2/3 live) + PR**_
+
+**TRAUMA**: W69 found the FASE-0 governance layer running only per-PR in CI, never H24. Arming it surfaced THREE latent wounds, each an instance of W64 (`esistere ≠ armato`):
+1. **`verify_the_verifiers.json` permanently MISSING on Pro** — the P1 §4 meta-verifier had NO Pro cron, so its alive-signal never existed, which ALSO blinded `cost_breaker_deadman.sh` (it observes that file). At first deadman boot it correctly alerted `verify_the_verifiers=MISSING`.
+2. **`verify_mcp_integrity.sh` (m5 branch) shipped-but-never-run** — it counted the WRONG checkmark glyph (`✓` U+2713) while `claude mcp list` emits `✔` (U+2714) → `connected` parsed as **0** despite ~12 truly connected; and `failed>0 → RED` pinned it perma-RED on chronically-unconfigured optional plugin MCP servers (slack/asana/pagerduty/github-copilot). A guardian that exists, runs, and lies.
+3. **`cost_breaker.py` CLI cannot read the real ledger from the Pro** — its `_check_all` path reads ONLY the JSONL fallback (`${LLM_COST_JSONL_ROOT:-/data}`), but the real ledger is Fly Postgres `llm_cost_events`; on the Pro every provider returns UNKNOWN → fail-closed DEGRADE-log every tick. (G4 fail-closed is CORRECT; it just isn't governing real spend.)
+
+**ANTIBODY (SHIPPED + live-verified):**
+- 3 LaunchAgents authored (`infra/launchagents/com.nuzantara.{verify-the-verifiers,mcp-integrity,cost-breaker-deadman}.plist`) + idempotent installer `install_fase0_governance.sh` (runtime home = deploy worktree; graceful-SKIP a label whose script is absent; `/bin/bash` 3.2-compatible — NO `declare -A`, a `case()` function). 2 armed live (verify-the-verifiers + deadman); mcp-integrity SKIPs until this PR merges + the deploy worktree syncs the fixed script.
+- `verify_mcp_integrity.sh` fixed: glyph `✔|✓`; RED only on failures INCREASING vs a baseline (pre-existing optional-plugin failures tolerated, captured first-run); + a per-tick alive-signal `mcp_integrity.json` (the m5 version wrote only the frozen baseline, useless for staleness).
+- `cost_breaker_deadman.sh` OBSERVED_FILES extended with `mcp_integrity.json` → closes the W69 §G5 mutual-watch (deadman now watches all three governance signals).
+- GATES (live on Pro): verify-the-verifiers `runs≥1`, `verify_the_verifiers.json` now FRESH; deadman exit 0 on fresh signals (zero false alarm) + FORCE_ALERT emits a SELF-TEST Telegram; cost_breaker proven UNKNOWN→DEGRADE, over-budget $25/$20→STOP, known-low→ALLOW; verify_mcp_integrity now YELLOW (was false-RED) with `connected=12`.
+
+**GOTCHA**: arming ≠ value — a cron that runs but reads the wrong glyph / a missing ledger is W64 theater; RUN the guardian and read its verdict before trusting the green light. macOS `/bin/bash` is 3.2 — `declare -A` raises "invalid arithmetic operator" (it failed silently here until run with `/bin/bash` explicitly; `which bash` was 3.2 too). The deadman's first-boot `MISSING` alert is a one-time transient (the signal persists on disk after first write). DEFERRED (not this session): cost_breaker.py real-ledger bridge (Fly PG → Pro), BUCO #1 (P* required-status-checks), and the 2 disarmed claude_hook gates verify_the_verifiers surfaced (`seam_verify` hook file missing, `guardrails_static` not registered in settings.json).
+
+**Reference**: PR (FASE-0 instrumentation rearm) branch `agent/nuzantara/infra/fase0-governance-rearm`. Live state: `~/.agent/decisions/state/{verify_the_verifiers,mcp_integrity,cost_breaker_deadman}.json`. Family: W69 (parent audit), W70 (sibling DLQ), W64 (esistere ≠ armato), W50/W51/W52 (deploy-worktree as runtime home).

--- a/infra/launchagents/com.nuzantara.cost-breaker-deadman.plist
+++ b/infra/launchagents/com.nuzantara.cost-breaker-deadman.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.nuzantara.cost-breaker-deadman</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/nuzantara/Desktop/nuzantara-deploy/scripts/cost_breaker_deadman.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>600</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/fase0-cost-breaker-deadman.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/fase0-cost-breaker-deadman.err.log</string>
+</dict>
+</plist>

--- a/infra/launchagents/com.nuzantara.mcp-integrity.plist
+++ b/infra/launchagents/com.nuzantara.mcp-integrity.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.nuzantara.mcp-integrity</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <key>PATH</key>
+        <string>/Users/nuzantara/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/nuzantara/Desktop/nuzantara-deploy/scripts/verify_mcp_integrity.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>900</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/fase0-mcp-integrity.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/fase0-mcp-integrity.err.log</string>
+</dict>
+</plist>

--- a/infra/launchagents/com.nuzantara.verify-the-verifiers.plist
+++ b/infra/launchagents/com.nuzantara.verify-the-verifiers.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.nuzantara.verify-the-verifiers</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/homebrew/bin/python3</string>
+        <string>/Users/nuzantara/Desktop/nuzantara-deploy/scripts/verify_the_verifiers.py</string>
+        <string>--scope</string>
+        <string>all</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>600</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/fase0-verify-the-verifiers.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/fase0-verify-the-verifiers.err.log</string>
+</dict>
+</plist>

--- a/infra/launchagents/install_fase0_governance.sh
+++ b/infra/launchagents/install_fase0_governance.sh
@@ -1,24 +1,29 @@
 #!/bin/bash
-# install_fase0_governance.sh — FASE-0 armament rearm (W69 BUCO #2)
+# install_fase0_governance.sh — FASE-0 armament rearm (W69 BUCO #2 + W67 mutual-watch)
 #
 # Arms the H24 governance-liveness layer on Pro/Mini that W69 found disarmed
-# (running only per-PR in CI, never H24):
+# (running only per-PR in CI, never H24). Three LaunchAgents, StartInterval-based
+# (KeepAlive false), NO secrets in any plist (the deadman sources its own token):
 #
-#   com.nuzantara.verify-the-verifiers   — runs scripts/verify_the_verifiers.py
-#       every 600s. SILENT writer (no Telegram): emits the alive-signal
-#       ~/.agent/decisions/state/verify_the_verifiers.json AND renders disarmed
-#       safety gates OBSERVABLE (disarmed_ids in the payload). This is the meta-
-#       verifier (P1 §4) running H24, not just per-PR.
-#   com.nuzantara.cost-breaker-deadman   — runs scripts/cost_breaker_deadman.sh
-#       every 600s. The G5 dead-man's switch: the SECOND observer that alerts
-#       (Telegram, cooldown-throttled) if verify_the_verifiers.json OR
-#       sentinel_meta_watchdog.json goes stale beyond 1800s — i.e. governance
-#       has gone mute. Sources its own secrets from ~/.nuzantara-secrets.env.
+#   com.nuzantara.verify-the-verifiers (600s) -> verify_the_verifiers.py --scope all
+#       Silent writer: emits verify_the_verifiers.json AND renders disarmed
+#       safety gates observable (disarmed_ids). The P1 §4 meta-verifier, H24.
+#   com.nuzantara.mcp-integrity (900s)         -> verify_mcp_integrity.sh
+#       MCP reachability guardian: emits mcp_integrity.json + a drift baseline.
+#       RED only on a NEW failure vs baseline (read-only; never restarts).
+#   com.nuzantara.cost-breaker-deadman (600s)  -> cost_breaker_deadman.sh
+#       The G5 second observer: alerts (Telegram, cooldown) if ANY of the three
+#       alive-signals above goes stale > 1800s — i.e. governance went mute.
 #
-# RUNTIME HOME = the deploy worktree (~/Desktop/nuzantara-deploy), which is the
-# stable, deploy-puller-refreshed checkout that actually carries the FASE-0
-# scripts (the main checkout was on an older branch missing them — see W69).
-# The plists hardcode that path; this installer only copies+bootstraps them.
+# Signal-writers are installed BEFORE the deadman so their signals exist when it
+# first runs. RUNTIME HOME = the deploy worktree (~/Desktop/nuzantara-deploy),
+# the deploy-puller-refreshed checkout that carries the FASE-0 scripts (the main
+# checkout was on an older branch missing them — see W69).
+#
+# GRACEFUL: a label whose runtime script is not yet present (e.g. mcp-integrity
+# before this PR has merged + the deploy worktree has synced) is SKIPPED with a
+# warning, not a hard failure — re-run post-merge to arm it (W64: never ship a
+# cron that no-ops; refuse to install one whose script is absent).
 #
 # Usage:
 #   bash infra/launchagents/install_fase0_governance.sh
@@ -37,10 +42,23 @@ UID_VAL="$(id -u)"
 # The runtime checkout the plists point at. Must carry the FASE-0 scripts.
 RUNTIME_ROOT="$HOME/Desktop/nuzantara-deploy"
 
+# Install order: signal-writers first, the deadman (watcher) last.
 LABELS=(
     "com.nuzantara.verify-the-verifiers"
+    "com.nuzantara.mcp-integrity"
     "com.nuzantara.cost-breaker-deadman"
 )
+# Each label's runtime script — install is SKIPPED if it is absent. A case()
+# function, NOT a `declare -A` associative array: macOS /bin/bash is 3.2 and
+# associative arrays are bash 4+ only (they raise "invalid arithmetic operator").
+runtime_for() {
+    case "$1" in
+        com.nuzantara.verify-the-verifiers) echo "$RUNTIME_ROOT/scripts/verify_the_verifiers.py" ;;
+        com.nuzantara.mcp-integrity)        echo "$RUNTIME_ROOT/scripts/verify_mcp_integrity.sh" ;;
+        com.nuzantara.cost-breaker-deadman) echo "$RUNTIME_ROOT/scripts/cost_breaker_deadman.sh" ;;
+        *) echo "" ;;
+    esac
+}
 
 MODE="${1:-install}"
 
@@ -54,32 +72,21 @@ bootout() {
     fi
 }
 
-preflight() {
-    # The plists are useless if the runtime scripts they reference are absent.
-    # Fail LOUD here rather than ship a cron that no-ops forever (W64).
-    local missing=0
-    for s in \
-        "$RUNTIME_ROOT/scripts/verify_the_verifiers.py" \
-        "$RUNTIME_ROOT/scripts/cost_breaker_deadman.sh"; do
-        if [[ ! -f "$s" ]]; then
-            echo "[install] FATAL: runtime script missing: $s" >&2
-            echo "[install]   The plists point at $RUNTIME_ROOT — make sure it" >&2
-            echo "[install]   is checked out at a ref that carries the FASE-0 scripts." >&2
-            missing=1
-        fi
-    done
-    [[ "$missing" == "0" ]] || exit 1
-}
-
 case "$MODE" in
     install)
-        preflight
+        installed=0
         for label in "${LABELS[@]}"; do
             src="$PLIST_SRC_DIR/$label.plist"
             dest="$PLIST_DEST_DIR/$label.plist"
+            runtime="$(runtime_for "$label")"
             if [[ ! -f "$src" ]]; then
                 echo "[install] FATAL: source plist missing: $src" >&2
                 exit 1
+            fi
+            if [[ ! -f "$runtime" ]]; then
+                echo "[install] SKIP $label — runtime script absent: $runtime"
+                echo "[install]   (re-run after this PR merges + the deploy worktree syncs)"
+                continue
             fi
             if [[ -f "$dest" ]]; then
                 bak="$dest.pre-install-$(date +%Y%m%d-%H%M%S)"
@@ -89,8 +96,7 @@ case "$MODE" in
                 echo "[install] backed up existing → $bak"
             fi
             bootout "$label"
-            # Copy + mode 0444 per VADEMECUM hardening (NO secrets in these
-            # plists — the deadman sources its token at runtime).
+            # Copy + mode 0444 per VADEMECUM hardening (NO secrets in these plists).
             cp "$src" "$dest"
             chmod 0444 "$dest"
             if ! plutil -lint "$dest" >/dev/null 2>&1; then
@@ -100,8 +106,13 @@ case "$MODE" in
             fi
             echo "[install] bootstrapping $label"
             launchctl bootstrap "gui/$UID_VAL" "$dest"
+            installed=$((installed + 1))
         done
-        echo "[install] done. Verify with: bash $0 --verify"
+        if [[ "$installed" == "0" ]]; then
+            echo "[install] FATAL: nothing installed — no runtime script present at $RUNTIME_ROOT/scripts" >&2
+            exit 1
+        fi
+        echo "[install] done ($installed agent(s)). Verify with: bash $0 --verify"
         ;;
     --uninstall)
         for label in "${LABELS[@]}"; do
@@ -121,8 +132,8 @@ case "$MODE" in
             launchctl print "gui/$UID_VAL/$label" 2>/dev/null \
                 | grep -E "state =|runs =|last exit code" || echo "  NOT LOADED"
         done
-        echo "--- alive signals ---"
-        for f in verify_the_verifiers.json sentinel_meta_watchdog.json cost_breaker_deadman.json; do
+        echo "--- alive signals (deadman observes the first 3) ---"
+        for f in verify_the_verifiers.json sentinel_meta_watchdog.json mcp_integrity.json cost_breaker_deadman.json; do
             if [[ -f "$STATE_DIR/$f" ]]; then
                 age=$(( $(date +%s) - $(stat -f %m "$STATE_DIR/$f") ))
                 echo "  $f  age=${age}s"

--- a/infra/launchagents/install_fase0_governance.sh
+++ b/infra/launchagents/install_fase0_governance.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# install_fase0_governance.sh — FASE-0 armament rearm (W69 BUCO #2)
+#
+# Arms the H24 governance-liveness layer on Pro/Mini that W69 found disarmed
+# (running only per-PR in CI, never H24):
+#
+#   com.nuzantara.verify-the-verifiers   — runs scripts/verify_the_verifiers.py
+#       every 600s. SILENT writer (no Telegram): emits the alive-signal
+#       ~/.agent/decisions/state/verify_the_verifiers.json AND renders disarmed
+#       safety gates OBSERVABLE (disarmed_ids in the payload). This is the meta-
+#       verifier (P1 §4) running H24, not just per-PR.
+#   com.nuzantara.cost-breaker-deadman   — runs scripts/cost_breaker_deadman.sh
+#       every 600s. The G5 dead-man's switch: the SECOND observer that alerts
+#       (Telegram, cooldown-throttled) if verify_the_verifiers.json OR
+#       sentinel_meta_watchdog.json goes stale beyond 1800s — i.e. governance
+#       has gone mute. Sources its own secrets from ~/.nuzantara-secrets.env.
+#
+# RUNTIME HOME = the deploy worktree (~/Desktop/nuzantara-deploy), which is the
+# stable, deploy-puller-refreshed checkout that actually carries the FASE-0
+# scripts (the main checkout was on an older branch missing them — see W69).
+# The plists hardcode that path; this installer only copies+bootstraps them.
+#
+# Usage:
+#   bash infra/launchagents/install_fase0_governance.sh
+#   bash infra/launchagents/install_fase0_governance.sh --uninstall
+#   bash infra/launchagents/install_fase0_governance.sh --verify
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLIST_SRC_DIR="$REPO_ROOT/infra/launchagents"
+PLIST_DEST_DIR="$HOME/Library/LaunchAgents"
+LOG_DIR="$HOME/logs"
+STATE_DIR="$HOME/.agent/decisions/state"
+UID_VAL="$(id -u)"
+
+# The runtime checkout the plists point at. Must carry the FASE-0 scripts.
+RUNTIME_ROOT="$HOME/Desktop/nuzantara-deploy"
+
+LABELS=(
+    "com.nuzantara.verify-the-verifiers"
+    "com.nuzantara.cost-breaker-deadman"
+)
+
+MODE="${1:-install}"
+
+mkdir -p "$PLIST_DEST_DIR" "$LOG_DIR" "$STATE_DIR"
+
+bootout() {
+    local label="$1"
+    if launchctl print "gui/$UID_VAL/$label" >/dev/null 2>&1; then
+        echo "[install] booting out $label"
+        launchctl bootout "gui/$UID_VAL/$label" 2>&1 | grep -v "Boot-out failed" || true
+    fi
+}
+
+preflight() {
+    # The plists are useless if the runtime scripts they reference are absent.
+    # Fail LOUD here rather than ship a cron that no-ops forever (W64).
+    local missing=0
+    for s in \
+        "$RUNTIME_ROOT/scripts/verify_the_verifiers.py" \
+        "$RUNTIME_ROOT/scripts/cost_breaker_deadman.sh"; do
+        if [[ ! -f "$s" ]]; then
+            echo "[install] FATAL: runtime script missing: $s" >&2
+            echo "[install]   The plists point at $RUNTIME_ROOT — make sure it" >&2
+            echo "[install]   is checked out at a ref that carries the FASE-0 scripts." >&2
+            missing=1
+        fi
+    done
+    [[ "$missing" == "0" ]] || exit 1
+}
+
+case "$MODE" in
+    install)
+        preflight
+        for label in "${LABELS[@]}"; do
+            src="$PLIST_SRC_DIR/$label.plist"
+            dest="$PLIST_DEST_DIR/$label.plist"
+            if [[ ! -f "$src" ]]; then
+                echo "[install] FATAL: source plist missing: $src" >&2
+                exit 1
+            fi
+            if [[ -f "$dest" ]]; then
+                bak="$dest.pre-install-$(date +%Y%m%d-%H%M%S)"
+                chmod u+w "$dest" 2>/dev/null || true
+                cp "$dest" "$bak"
+                chmod 0444 "$bak" 2>/dev/null || true
+                echo "[install] backed up existing → $bak"
+            fi
+            bootout "$label"
+            # Copy + mode 0444 per VADEMECUM hardening (NO secrets in these
+            # plists — the deadman sources its token at runtime).
+            cp "$src" "$dest"
+            chmod 0444 "$dest"
+            if ! plutil -lint "$dest" >/dev/null 2>&1; then
+                echo "[install] FATAL: $dest plutil lint failed" >&2
+                plutil -lint "$dest"
+                exit 1
+            fi
+            echo "[install] bootstrapping $label"
+            launchctl bootstrap "gui/$UID_VAL" "$dest"
+        done
+        echo "[install] done. Verify with: bash $0 --verify"
+        ;;
+    --uninstall)
+        for label in "${LABELS[@]}"; do
+            bootout "$label"
+            dest="$PLIST_DEST_DIR/$label.plist"
+            if [[ -f "$dest" ]]; then
+                chmod u+w "$dest" 2>/dev/null || true
+                rm -f "$dest"
+                echo "[install] removed $dest"
+            fi
+        done
+        echo "[install] uninstalled."
+        ;;
+    --verify)
+        for label in "${LABELS[@]}"; do
+            echo "--- $label ---"
+            launchctl print "gui/$UID_VAL/$label" 2>/dev/null \
+                | grep -E "state =|runs =|last exit code" || echo "  NOT LOADED"
+        done
+        echo "--- alive signals ---"
+        for f in verify_the_verifiers.json sentinel_meta_watchdog.json cost_breaker_deadman.json; do
+            if [[ -f "$STATE_DIR/$f" ]]; then
+                age=$(( $(date +%s) - $(stat -f %m "$STATE_DIR/$f") ))
+                echo "  $f  age=${age}s"
+            else
+                echo "  $f  MISSING"
+            fi
+        done
+        ;;
+    *)
+        echo "Usage: $0 [install|--uninstall|--verify]" >&2
+        exit 2
+        ;;
+esac

--- a/research/operations/specs/2026-06-09-fase0-buco1-pstar-required-checks.md
+++ b/research/operations/specs/2026-06-09-fase0-buco1-pstar-required-checks.md
@@ -1,0 +1,146 @@
+---
+date: 2026-06-09
+domain: operations
+client_case: none
+sources:
+  - W69 cicatrix (.claude/rules/cicatrix-scars.md)
+  - gh api repos/Balizero1987/Teman2/branches/main/protection/required_status_checks (live read 2026-06-09)
+  - .github/workflows/verify-the-verifiers.yml, p1s2-mutation-incremental.yml
+  - .github/CODEOWNERS
+---
+
+# FASE-0 BUCO #1 — make the P* workflows required-status-checks (sequenced, NOT executed)
+
+> **Status: NOT EXECUTED this session — deliberately deferred.** Closing BUCO #1
+> autonomously is blocked by two structural gates (below). This spec captures the
+> empirical ground truth + the exact safe sequence so the next executor (operator
+> or a follow-up session WITH Antonello's CODEOWNERS approval) can run it without
+> tripping the pending-forever trap.
+
+## Why it could not be done autonomously this session
+
+1. **CODEOWNERS TIER-1 anti-injection** — `/.github/workflows/ @Balizero1987`
+   (`.github/CODEOWNERS:27`). Every edit to a workflow file (needed for the
+   skip→success sentinel) requires Antonello's review; it is NOT self-mergeable
+   by an agent, by design. `verify-the-verifiers.yml` is additionally
+   tamper-evident (sha256 `.github/verify-the-verifiers.sha256` + the workflow
+   lists itself in its own `paths:`).
+2. **The PUT must come AFTER the sentinel is on `main` + green-stable** (W69
+   trap #1). The sentinel-workflow edits must be merged + observed reporting
+   `success` on a path-miss PR BEFORE any `required_status_checks` PUT. That
+   merge + multi-run confirmation cannot complete inside one session.
+
+Doing the PUT before the sentinel is on main = the exact pending-forever trap
+(`verify-the-verifiers` / `p1s2` are `paths:`-filtered → they do not run on a PR
+that does not touch their paths → a required check that never runs blocks EVERY
+such PR). Confirmed live: PR #1199 does NOT trigger `verify-the-verifiers` (its
+paths are untouched) — had it been required, #1199 would be stuck pending.
+
+## Empirical ground truth (live 2026-06-09)
+
+**Current required_status_checks (strict=true) — PRESERVE ALL 9 in any PUT:**
+```
+E2E Tests (Playwright)
+MCP Server Tests
+Detect Secrets
+Backend Tests (Python)
+Bandit Python Security
+CodeQL Analysis (python)
+CodeQL Analysis (javascript)
+root-guard
+Frontend Tests (Next.js) (mouth, true)
+```
+
+**Green-stability of the 2 candidates on main:**
+- `verify-the-verifiers.yml` — 5/5 `success` (last 2026-06-07). ✅ stable.
+- `p1s2-mutation-incremental.yml` — `success` (2026-06-07). ✅ stable.
+- NOT candidates (W69): `p6-federation-parallelize` (FAILURE on main),
+  `p7`/`p8`/`p3`/`hot-zone` (NO-RUNS). Do NOT make these required yet.
+
+**Both candidates are `pull_request: paths:`-filtered** → the trap applies to both.
+
+## Step 1 — skip→success sentinel (separate the TRIGGER from the WORK)
+
+For EACH of the 2 candidate workflows, change the top-level trigger so the
+workflow ALWAYS runs on `pull_request`, and gate the expensive WORK on a
+path-check step. The job NAME (= the required-check context) stays identical, and
+a path-miss PR still ends the job `success`.
+
+Pattern (apply to `verify-the-verifiers.yml` and `p1s2-mutation-incremental.yml`):
+```yaml
+on:
+  pull_request:            # NO top-level paths: — always trigger
+  push:
+    branches: [main]
+    paths: [ ...keep the existing push paths... ]
+
+jobs:
+  verify-the-verifiers:    # ← keep the SAME job name (= the required context)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with: { fetch-depth: 0 }
+      - name: Did relevant paths change?
+        id: relevant
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          if git diff --name-only "$base"...HEAD | grep -qE \
+            '^(scripts/verify_the_verifiers\.py|scripts/verify_the_verifiers_gates\.yaml|\.github/verify-the-verifiers\.sha256|\.github/workflows/verify-the-verifiers\.yml|\.github/workflows/hot-zone-pr-gate\.yml|scripts/tests/test_verify_the_verifiers\.py)$'; then
+            echo "run=true"  >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::no relevant paths changed — sentinel success"
+          fi
+      # every real step below gains:  if: steps.relevant.outputs.run == 'true'
+```
+Notes:
+- `verify-the-verifiers.yml` is tamper-evident — this edit needs Antonello's
+  CODEOWNERS review AND must not alter the protected `.py`/sha256 (it doesn't;
+  only the workflow YAML changes). Confirm the sha256 step still passes.
+- Prefer the explicit `git diff` gate over `dorny/paths-filter` to avoid adding a
+  third-party action to a TIER-1 anti-injection file.
+
+## Step 2 — merge + confirm green-stable on main
+
+After Antonello approves + the sentinel PR merges:
+```
+gh run list --workflow verify-the-verifiers.yml --branch main -L 5 --json conclusion
+gh run list --workflow p1s2-mutation-incremental.yml --branch main -L 5 --json conclusion
+```
+Then open a throwaway markdown-only PR and confirm BOTH checks report `success`
+(NOT skipped, NOT pending) on it. Only proceed if so.
+
+## Step 3 — PUT required (preserve the 9, ADD the 2)
+
+Get the EXACT check-context names first (job display names) from a recent PR's
+check list — likely `verify-the-verifiers` and the p1s2 job name. Then:
+```
+# READ current, then PUT current+2 (NEVER overwrite blindly):
+gh api repos/Balizero1987/Teman2/branches/main/protection/required_status_checks \
+  > /tmp/req.json
+python3 - <<'PY'
+import json
+d=json.load(open('/tmp/req.json'))
+ctx=set(d['contexts'])
+ctx.update(['verify-the-verifiers','<exact p1s2 context name>'])
+json.dump({'strict':d['strict'],'contexts':sorted(ctx)}, open('/tmp/req-new.json','w'))
+PY
+gh api -X PUT repos/Balizero1987/Teman2/branches/main/protection/required_status_checks \
+  --input /tmp/req-new.json
+```
+
+## Step 4 — GATE (falsifiable) + rollback
+
+Open a markdown-only canary PR. It MUST NOT be stuck pending-forever; both new
+checks must report `success` (sentinel path-miss). If it hangs pending → the
+sentinel did not take → **ROLLBACK immediately**:
+```
+gh api -X PUT repos/Balizero1987/Teman2/branches/main/protection/required_status_checks \
+  --input /tmp/req.json   # the original 9-context snapshot
+```
+The PUT is fully reversible in one command; the blast radius (PRs can't merge)
+is caught by the canary and undone by the rollback.
+
+## Out of scope (still)
+p6/p7/p8/p3/hot-zone are NOT required-safe (failing or never-run). Re-evaluate
+each only after it is green-stable on main with its own sentinel.

--- a/scripts/cost_breaker_deadman.sh
+++ b/scripts/cost_breaker_deadman.sh
@@ -45,9 +45,11 @@ STATE_DIR="$HOME/.agent/decisions/state"
 # thresholds (≈2× the expected emit interval — generous, only fire on a true
 # stall, not a slow tick). verify_the_verifiers + sentinel_meta_watchdog both
 # emit on cron cadences in the 10-15min range, so 1800s (30min) is a safe 2×.
+# mcp_integrity emits every 900s (com.nuzantara.mcp-integrity) — same 2× safety.
 OBSERVED_FILES=(
     "$STATE_DIR/verify_the_verifiers.json"
     "$STATE_DIR/sentinel_meta_watchdog.json"
+    "$STATE_DIR/mcp_integrity.json"
 )
 CRITICAL_THRESHOLD_SEC="${COST_BREAKER_DEADMAN_THRESHOLD_SEC:-1800}"  # 30 min
 COOLDOWN_SEC=3600                                                     # 1 h

--- a/scripts/verify_mcp_integrity.sh
+++ b/scripts/verify_mcp_integrity.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# verify_mcp_integrity.sh — MCP server reachability + integrity baseline check.
+#
+# FASE-0 instrumentation re-arm (2026-06-09). This guardian was a cicatrix
+# candidate ("MISSING — re-author or recover from Mini", zero-point-recovery
+# 2026-05-28) and is referenced by the `mcp-health` agent spec as its core tool,
+# but was never written. This is the first real implementation.
+#
+# WHAT IT DOES (read-only diagnose — NEVER restarts, NEVER mutates):
+#   1. Count MCP servers declared in .mcp.json (config baseline).
+#   2. Run `claude mcp list`, parse per-server state:
+#        ✓ Connected | ⏸ Pending approval | ✗ Failed | (unknown)
+#   3. Compare connected/total against a saved baseline; flag drift.
+#   4. Emit a verdict line (GREEN/YELLOW/RED) + optional Telegram alert.
+#
+# State baseline: ~/.agent/decisions/state/mcp_integrity_baseline.json
+#   - First run writes the baseline (current connected+declared counts).
+#   - Later runs compare; --update rewrites it deliberately.
+#
+# Exit codes: 0 = GREEN/YELLOW (informational), 2 = RED (a server FAILED, or
+# connected count dropped below baseline floor). RED is the only blocking signal.
+#
+# Why this is NOT a SPOF: short-lived (list → parse → compare → exit), cannot
+# hang (claude mcp list has its own internal timeout), and if it crashes the
+# next scheduled tick runs fresh.
+#
+# Usage:
+#   verify_mcp_integrity.sh              # check against baseline
+#   verify_mcp_integrity.sh --update     # rewrite baseline to current state
+#   verify_mcp_integrity.sh --json       # machine-readable output
+#
+# Kill switch: env MCP_INTEGRITY_OFF=1 → exits 0 immediately.
+
+set -uo pipefail
+
+# --- Configuration ---------------------------------------------------------
+
+REPO_ROOT="${NUZ_REPO_ROOT:-$HOME/Desktop/nuzantara}"
+MCP_CONFIG="$REPO_ROOT/.mcp.json"
+STATE_DIR="$HOME/.agent/decisions/state"
+BASELINE_FILE="$STATE_DIR/mcp_integrity_baseline.json"
+LOG_FILE="$HOME/logs/verify-mcp-integrity.log"
+DRIFT_PCT=10                 # flag YELLOW if connected count drifts > this %
+
+UPDATE_BASELINE=0
+JSON_OUT=0
+for arg in "$@"; do
+    case "$arg" in
+        --update) UPDATE_BASELINE=1 ;;
+        --json)   JSON_OUT=1 ;;
+    esac
+done
+
+# --- Kill switch ------------------------------------------------------------
+
+if [[ "${MCP_INTEGRITY_OFF:-0}" == "1" ]]; then
+    echo "[mcp-integrity] OFF (MCP_INTEGRITY_OFF=1) — skipping"
+    exit 0
+fi
+
+mkdir -p "$STATE_DIR" "$(dirname "$LOG_FILE")" 2>/dev/null || true
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" >> "$LOG_FILE" 2>/dev/null || true; }
+
+# --- 1. Declared count from .mcp.json --------------------------------------
+
+if [[ ! -f "$MCP_CONFIG" ]]; then
+    echo "[mcp-integrity] RED: .mcp.json not found at $MCP_CONFIG"
+    log "RED: .mcp.json missing"
+    exit 2
+fi
+
+declared=$(python3 -c "
+import json, sys
+try:
+    d = json.load(open('$MCP_CONFIG'))
+    s = d.get('mcpServers', d.get('servers', {}))
+    print(len(s))
+except Exception:
+    print(0)
+")
+
+# --- 2. Live reachability via `claude mcp list` ----------------------------
+# We strip ANSI, then count state glyphs. claude mcp list has its own timeout;
+# we guard with a background+wait fallback (macOS has no `timeout`).
+
+raw=$(unset ANTHROPIC_API_KEY; claude mcp list 2>&1)
+clean=$(printf '%s' "$raw" | sed -E 's/\x1b\[[0-9;]*[a-zA-Z]//g')
+
+connected=$(printf '%s\n' "$clean" | grep -cE '✔ Connected|✓ Connected' || true)
+pending=$(printf '%s\n' "$clean" | grep -c '⏸ Pending approval' || true)
+failed=$(printf '%s\n' "$clean" | grep -cE '✗ Failed|✗ Failed to connect|✘' || true)
+warnings=$(printf '%s\n' "$clean" | grep -c '\[Warning\]' || true)
+
+# reachable = connected + pending (pending = config-valid, just needs approval;
+# NOT a failure). failed = the real problem.
+reachable=$((connected + pending))
+
+# --- 3. Compare against baseline -------------------------------------------
+
+baseline_connected=""
+baseline_declared=""
+baseline_failed=""
+if [[ -f "$BASELINE_FILE" ]]; then
+    baseline_connected=$(python3 -c "import json;print(json.load(open('$BASELINE_FILE')).get('reachable',''))" 2>/dev/null || echo "")
+    baseline_declared=$(python3 -c "import json;print(json.load(open('$BASELINE_FILE')).get('declared',''))" 2>/dev/null || echo "")
+    baseline_failed=$(python3 -c "import json;print(json.load(open('$BASELINE_FILE')).get('failed',''))" 2>/dev/null || echo "")
+fi
+
+verdict="GREEN"
+reason=""
+
+# RED only on a NEW failure vs baseline (a server that used to be reachable went
+# down) — NOT on any failure: optional/plugin MCP servers (slack/asana/pagerduty/
+# github-copilot/…) are chronically unconfigured and would pin RED forever (W64:
+# armed-but-wrong = noise). First run captures the current failure count as the
+# tolerated baseline.
+if [[ -n "$baseline_failed" && "$failed" -gt "$baseline_failed" ]]; then
+    verdict="RED"
+    reason="MCP failures INCREASED vs baseline ($baseline_failed → $failed)"
+elif [[ -z "$baseline_failed" && "$failed" -gt 0 ]]; then
+    verdict="YELLOW"
+    reason="$failed pre-existing MCP failure(s) captured in baseline (optional/plugin servers)"
+elif [[ -n "$baseline_connected" && "$reachable" -lt "$baseline_connected" ]]; then
+    # connected dropped vs baseline → could be a regression
+    drop=$((baseline_connected - reachable))
+    floor=$(( baseline_connected - (baseline_connected * DRIFT_PCT / 100) ))
+    if [[ "$reachable" -lt "$floor" ]]; then
+        verdict="RED"
+        reason="reachable dropped $drop below ${DRIFT_PCT}% floor ($reachable < baseline $baseline_connected)"
+    else
+        verdict="YELLOW"
+        reason="reachable dropped $drop within tolerance ($reachable vs baseline $baseline_connected)"
+    fi
+elif [[ -n "$baseline_declared" && "$declared" != "$baseline_declared" ]]; then
+    verdict="YELLOW"
+    reason="declared MCP count changed ($baseline_declared → $declared)"
+elif [[ "$warnings" -gt 0 ]]; then
+    verdict="YELLOW"
+    reason="$warnings config warning(s) (missing env vars)"
+fi
+
+# --- 4. Output + baseline write --------------------------------------------
+
+if [[ "$UPDATE_BASELINE" == "1" || ! -f "$BASELINE_FILE" ]]; then
+    python3 -c "
+import json
+json.dump({'declared': $declared, 'reachable': $reachable,
+           'connected': $connected, 'pending': $pending, 'failed': $failed,
+           'ts': '$(date -u +%Y-%m-%dT%H:%M:%SZ)'},
+          open('$BASELINE_FILE','w'), indent=2)
+"
+    if [[ "$UPDATE_BASELINE" == "1" ]]; then
+        echo "[mcp-integrity] baseline updated: declared=$declared reachable=$reachable"
+        # Deliberate baseline write is not a health check — never block on it.
+        exit 0
+    fi
+fi
+
+if [[ "$JSON_OUT" == "1" ]]; then
+    python3 -c "
+import json
+print(json.dumps({'verdict':'$verdict','reason':'''$reason''',
+  'declared':$declared,'reachable':$reachable,'connected':$connected,
+  'pending':$pending,'failed':$failed,'warnings':$warnings,
+  'baseline_reachable':'$baseline_connected','baseline_declared':'$baseline_declared'}))
+"
+else
+    echo "[mcp-integrity] $verdict — declared=$declared connected=$connected pending=$pending failed=$failed warnings=$warnings${reason:+ | $reason}"
+fi
+
+log "$verdict declared=$declared connected=$connected pending=$pending failed=$failed warnings=$warnings ${reason}"
+
+# Per-tick alive-signal (fresh ts EVERY run, distinct from the frozen baseline)
+# so the dead-man's switch (cost_breaker_deadman.sh) can detect when THIS
+# guardian itself goes mute — closing the FASE-0 mutual-watch loop (W69 §G5).
+python3 -c "
+import json
+json.dump({'ts': '$(date -u +%Y-%m-%dT%H:%M:%SZ)', 'verdict': '$verdict',
+           'declared': $declared, 'reachable': $reachable, 'failed': $failed,
+           '_writer': 'verify_mcp_integrity'},
+          open('$STATE_DIR/mcp_integrity.json','w'), indent=2)
+" 2>/dev/null || true
+
+[[ "$verdict" == "RED" ]] && exit 2
+exit 0


### PR DESCRIPTION
## What

Closes **W69 BUCO #2** (FASE-0 governance running only per-PR in CI, never H24) and wires the `verify_mcp_integrity` guardian, fixing the bugs that made it W64 theater.

### LaunchAgents (governance-liveness H24)
- `com.nuzantara.verify-the-verifiers` (600s) — runs the P1 §4 meta-verifier `verify_the_verifiers.py --scope all`; silent writer of `verify_the_verifiers.json` + renders disarmed gates observable.
- `com.nuzantara.mcp-integrity` (900s) — MCP reachability guardian; emits `mcp_integrity.json` + drift baseline.
- `com.nuzantara.cost-breaker-deadman` (600s) — G5 second observer; alerts (Telegram, cooldown) if any of the three alive-signals goes stale > 1800s.
- `install_fase0_governance.sh` — idempotent, `/bin/bash` 3.2-compatible (`case()` map, NOT `declare -A`), graceful-SKIP for a label whose runtime script is absent.

### verify_mcp_integrity.sh fixes (was shipped-but-never-run on m5 branch)
- glyph `✓`→`✔|✓` (connected was always 0; live now 12).
- RED only on failures **increasing** vs baseline (optional/plugin servers no longer pin perma-RED; live verdict YELLOW).
- per-tick alive-signal `mcp_integrity.json` (m5 wrote only the frozen baseline).

### deadman mutual-watch
- `OBSERVED_FILES += mcp_integrity.json` → closes the W69 §G5 loop.

### cicatrix
- **W70** — renumber of the m5-branch "W67" DLQ/blind-autopilot scar (W67 was taken on main by the wa-mirror reconnect-storm scar).
- **W71** — this FASE-0 arming session + the glyph/ledger/disarmed-gate findings.

## Live verification (on Pro)
- launchctl: verify-the-verifiers + cost-breaker-deadman active; `verify_the_verifiers.json` now FRESH (was permanently MISSING).
- deadman: exit 0 on fresh signals (no false alarm); `FORCE_ALERT=1` emits a SELF-TEST-labelled Telegram.
- cost_breaker: UNKNOWN→DEGRADE, over-budget \$25/\$20→STOP (choice [D]/[P]/[C]), known-low→ALLOW — G4 fail-closed proven (never ALLOW on unknown/over-budget).
- verify_mcp_integrity: YELLOW (was false-RED), connected=12.

## Runtime home
The plists point at `~/Desktop/nuzantara-deploy` (the deploy-puller-refreshed checkout that carries the FASE-0 scripts; the main checkout was on an older branch missing them). `mcp-integrity` arms (graceful-skip clears) once this PR merges and the deploy worktree syncs the fixed script — re-run the installer post-merge.

## Deferred (NOT in this PR)
- `cost_breaker.py` periodic CLI — its CLI reads only the JSONL ledger; the real ledger is Fly Postgres `llm_cost_events`, unreachable from the Pro CLI path. Needs a Fly→Pro ledger bridge (else it only fail-closed DEGRADE-logs every tick).
- **W69 BUCO #1** (P* required-status-checks) — separate, more delicate (skip→success sentinel before any PUT).
- 2 disarmed claude_hook gates surfaced by verify_the_verifiers: `seam_verify` hook file missing, `guardrails_static` not registered in settings.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)