### PR TITLE
fix(govern): cost-ledger DSN -> 127.0.0.1 (fly PG proxy IPv4-only)

### DIFF
--- a/scripts/cost_ledger_export.py
+++ b/scripts/cost_ledger_export.py
@@ -75,7 +75,7 @@ _KEYCHAIN_ACCOUNT: str = "nuzantara_readonly"
 # The local read-only proxy the postgres-nuzantara MCP uses (Fly PG, read-only
 # role). The password is injected from the Keychain — never in this string.
 _DEFAULT_DSN_TEMPLATE: str = (
-    "postgresql://nuzantara_readonly:{password}@localhost:15432/"
+    "postgresql://nuzantara_readonly:{password}@127.0.0.1:15432/"
     "nuzantara_rag?sslmode=disable"
 )
 


### PR DESCRIPTION
Fixes intermittent `cost-ledger-export` cron exit 1 (`Connect call failed ('::1', 15432)`). The fly PG proxy binds 127.0.0.1 only; forcing the IPv4 literal in the DSN template removes the localhost→::1 flakiness. One-line change to `_DEFAULT_DSN_TEMPLATE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)