### PR TITLE
fix(intake): proxy /api/intake/review to RAG process (was 404 on kita)

### DIFF
--- a/apps/backend-rag/backend/app/rag_proxy.py
+++ b/apps/backend-rag/backend/app/rag_proxy.py
@@ -32,6 +32,8 @@ HEAVY_PREFIXES = (
     "/api/crm/clients",
     "/api/crm/companies",
     "/api/crm/practices",
+    # Pro-local HITL doc-review queue (Law 2 PII) — proxy to RAG like /api/crm/*
+    "/api/intake/review",
     "/api/dashboard",
     "/api/ingest",
     "/api/intel",


### PR DESCRIPTION
## Bug

`GET /api/intake/review/queue` returned **404** from kita.balizero.com, locking out the document reviewer (adit).

## Root cause

The `intake_review` router (prefix `/api/intake/review`, `apps/backend-rag/backend/app/routers/intake_review.py`) is mounted only on the **Fly RAG process** — because it serves the Pro-local HITL document-review queue holding **PII** (KTP / passport / akta intake docs). Per Symbiosis **Law 2**, that data stays on the Pro/RAG side.

The public Fly **API process** forwards Pro-local routes to RAG via the `HEAVY_PREFIXES` allow-list in `apps/backend-rag/backend/app/rag_proxy.py`. `/api/intake/review` was **missing** from that list, so the API process 404d instead of proxying. The exact same mechanism already works for `/api/crm/*` (also Pro-local PII).

## Fix (one line)

Added `"/api/intake/review"` to `HEAVY_PREFIXES`, grouped with the `/api/crm/*` Pro-local PII prefixes.

```diff
     "/api/crm/practices",
+    # Pro-local HITL doc-review queue (Law 2 PII) -- proxy to RAG like /api/crm/*
+    "/api/intake/review",
```

The **specific** prefix is used (not the broad `/api/intake`). Matching is `path.startswith()`, so `/api/intake/review` does NOT capture `/api/intake/gate`, which MUST stay on the API process for the login gate. Verified: `is_heavy_route("/api/intake/gate") is False`, `is_heavy_route("/api/intake/review/queue") is True`.

## PII safety

Data never leaves the Pro. The Fly API process only **relays** the request to the RAG process where the intake data lives. No PII is moved or exposed to any LLM.

## Verification

- Import smoke: `"/api/intake/review" in rag_proxy.HEAVY_PREFIXES` OK; gate not captured OK
- `pytest -k "rag_proxy or heavy_prefix or intake_review"` -> **18 passed** (router tests). No existing test enumerates `HEAVY_PREFIXES`, so no prefix-list test to extend; a brittle new one was not invented.

There is currently **1 `review_pending`** document on the Pro waiting for the reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
