### PR TITLE
fix(intake): review RBAC by received_by (own-chat axis), not client assigned_to

### DIFF
--- a/apps/backend-rag/backend/app/routers/intake_review.py
+++ b/apps/backend-rag/backend/app/routers/intake_review.py
@@ -14,9 +14,16 @@ It is the SAFE half of FASE 5:
 INVARIANTS (06-fase5-hitl-writer-design + CLAUDE.md):
   * ZERO CRM write. Reads clients/practices ONLY to show candidates. Writes ONLY
     document_routing_proposal (claim/release).
-  * RBAC (§6e, P0#4): admins (zero@/asya@/antonellosiano@) see everything; a team
-    member sees ONLY proposals whose resolved candidate client is assigned to them.
-    Proposals with no resolved client (NO_MATCH / AMBIGUOUS) → admin-only.
+  * RBAC (§6e, P0#4): the axis is OWN-CHAT, not client-assignment. Admins
+    (zero@/asya@/antonellosiano@ — is_crm_admin) see the ENTIRE queue (every
+    worker's docs, every decision) for supervision. A non-admin sees ONLY rows
+    whose `intake_queue.received_by` (the receiving employee's email, set by the
+    wa-mirror sweeper) equals the caller's email. This INCLUDES that worker's own
+    NO_MATCH / AMBIGUOUS / null-decision docs — "it's my chat" takes PRECEDENCE
+    over the client-resolution gate, so the receiver (not an admin) reviews them.
+    Docs with `received_by IS NULL` (the shared business-line `whatsapp-live:*`
+    feeds + Drive-sourced docs) are admin-only: a NULL received_by never equals a
+    non-admin's email, so the `received_by = :email` filter excludes them naturally.
   * claim_token (P0#5): claim mints an opaque token; FASE 5C mutations must present
     it. release verifies it to avoid a stale reviewer stealing another's claim.
   * Atomic claim: UPDATE ... WHERE status='review_pending' RETURNING. Concurrent
@@ -141,9 +148,10 @@ async def list_review_queue(
 ) -> dict[str, Any]:
     """List proposals awaiting review, filtered by the caller's RBAC scope.
 
-    Admins see everything. Team members see only proposals whose resolved
-    candidate client is assigned to them; proposals with no resolved client
-    (NO_MATCH / AMBIGUOUS) are admin-only.
+    Admins see the entire queue. A non-admin sees ONLY rows from their own chats
+    (`intake_queue.received_by == caller`), including their own NO_MATCH /
+    AMBIGUOUS docs. NULL-received_by docs (shared business line + Drive) are
+    admin-only.
     """
     admin = is_crm_admin(user)
     user_email = (user.get("email") or "").lower().strip()
@@ -164,16 +172,20 @@ async def list_review_queue(
                 p.lease_expires_at,
                 p.created_at,
                 q.source,
+                q.received_by,
                 q.status        AS queue_status,
                 q.stage_output
             FROM document_routing_proposal p
             JOIN intake_queue q ON q.id = p.queue_id
             WHERE p.status = $1
               AND ($2::text IS NULL OR q.source = $2)
+              AND ($3::boolean OR q.received_by = $4)
             ORDER BY p.created_at ASC, p.id ASC
             """,
             status,
             source,
+            admin,
+            user_email,
         )
 
         items: list[dict[str, Any]] = []
@@ -190,14 +202,10 @@ async def list_review_queue(
             candidate_ids = _candidate_client_ids(entity_resolution)
             candidates = await _load_candidate_clients(conn, candidate_ids)
 
-            # RBAC: non-admins only see items assigned to them.
-            if not admin:
-                assigned_set = {
-                    (c.get("assigned_to") or "").lower().strip() for c in candidates
-                }
-                # No resolved client → admin-only. Resolved but not assigned to me → hide.
-                if not candidates or user_email not in assigned_set:
-                    continue
+            # RBAC: the own-chat gate (received_by) is enforced in the SQL WHERE
+            # above — non-admins see ONLY their received docs (incl. NO_MATCH /
+            # AMBIGUOUS); NULL received_by never matches a non-admin's email, so
+            # the shared business-line + Drive docs stay admin-only.
 
             items.append(
                 {
@@ -207,6 +215,7 @@ async def list_review_queue(
                     "status": row["status"],
                     "routing_key": row["routing_key"],
                     "source": row["source"],
+                    "received_by": row["received_by"],
                     "queue_status": row["queue_status"],
                     "decision": row_decision,
                     "doc_type": routing.get("doc_type") or stage_output.get("doc_type"),
@@ -222,8 +231,9 @@ async def list_review_queue(
                 }
             )
 
-    # Pagination AFTER RBAC filtering (the WHERE can't express assigned-to-me
-    # without joining a noisy JSON path; the in-app filter is the safe option).
+    # Pagination AFTER the in-app `decision` filter (the RBAC own-chat gate is
+    # already applied in the SQL WHERE; `decision` lives in a JSONB path so it is
+    # filtered in Python, hence the post-fetch slice).
     total = len(items)
     page = items[offset : offset + limit]
     return {"total": total, "limit": limit, "offset": offset, "items": page}
@@ -259,6 +269,7 @@ async def get_review_detail(
                 p.created_at,
                 q.source,
                 q.source_ref,
+                q.received_by,
                 q.status        AS queue_status,
                 q.blob_path,
                 q.stage_output
@@ -271,6 +282,15 @@ async def get_review_detail(
         if row is None:
             raise HTTPException(status_code=404, detail="Proposal not found")
 
+        # RBAC (own-chat axis): a non-admin may open a proposal ONLY if it came
+        # from their own chat (intake_queue.received_by == caller). NULL
+        # received_by (shared business line + Drive) never matches → admin-only.
+        if not admin:
+            received_by = (row["received_by"] or "").lower().strip()
+            if received_by != user_email:
+                # Hide existence from non-authorised team members.
+                raise HTTPException(status_code=403, detail="Not authorised for this proposal")
+
         entity_resolution = _as_dict(row["entity_resolution"])
         routing = _as_dict(row["routing"])
         commit_gate = _as_dict(row["commit_gate"])
@@ -278,12 +298,6 @@ async def get_review_detail(
 
         candidate_ids = _candidate_client_ids(entity_resolution)
         candidates = await _load_candidate_clients(conn, candidate_ids)
-
-        if not admin:
-            assigned_set = {(c.get("assigned_to") or "").lower().strip() for c in candidates}
-            if not candidates or user_email not in assigned_set:
-                # Hide existence from non-authorised team members.
-                raise HTTPException(status_code=403, detail="Not authorised for this proposal")
 
         # OCR text per page (if FASE-3 stored it in stage_output) — for human review.
         ocr = stage_output.get("ocr") if isinstance(stage_output, dict) else None
@@ -297,6 +311,7 @@ async def get_review_detail(
             "routing_key": row["routing_key"],
             "source": row["source"],
             "source_ref": row["source_ref"],
+            "received_by": row["received_by"],
             "queue_status": row["queue_status"],
             "blob_path": row["blob_path"],
             "decision": entity_resolution.get("decision"),
@@ -337,18 +352,24 @@ async def claim_review(
     expires = now + timedelta(minutes=CLAIM_TTL_MINUTES)
 
     async with pool.acquire() as conn:
-        # RBAC gate up-front (cheap read of the candidate scope).
+        # RBAC gate up-front (own-chat axis): a non-admin may claim ONLY a
+        # proposal that came from their own chat (intake_queue.received_by ==
+        # caller). NULL received_by (shared business line + Drive) never matches
+        # → admin-only.
         if not admin:
             prop = await conn.fetchrow(
-                "SELECT entity_resolution FROM document_routing_proposal WHERE id = $1",
+                """
+                SELECT q.received_by
+                FROM document_routing_proposal p
+                JOIN intake_queue q ON q.id = p.queue_id
+                WHERE p.id = $1
+                """,
                 proposal_id,
             )
             if prop is None:
                 raise HTTPException(status_code=404, detail="Proposal not found")
-            candidate_ids = _candidate_client_ids(_as_dict(prop["entity_resolution"]))
-            candidates = await _load_candidate_clients(conn, candidate_ids)
-            assigned_set = {(c.get("assigned_to") or "").lower().strip() for c in candidates}
-            if not candidates or user_email not in assigned_set:
+            received_by = (prop["received_by"] or "").lower().strip()
+            if received_by != user_email:
                 raise HTTPException(status_code=403, detail="Not authorised for this proposal")
 
         # Atomic claim: only steal a claim that is unclaimed OR expired.

--- a/apps/backend-rag/backend/tests/routers/test_intake_review.py
+++ b/apps/backend-rag/backend/tests/routers/test_intake_review.py
@@ -73,7 +73,9 @@ async def seed(pool: asyncpg.Pool) -> AsyncIterator[dict]:
         )
         created["clients"] += [cid_owner, cid_other]
 
-        async def mk_proposal(entity_resolution: dict, source: str = "drive") -> int:
+        async def mk_proposal(
+            entity_resolution: dict, source: str = "drive", received_by: str | None = None
+        ) -> int:
             bh = uuid.uuid4().hex + uuid.uuid4().hex  # 64-char
             inst = await conn.fetchval(
                 """INSERT INTO document_instances (blob_hash, pipeline_version, blob_path, first_source)
@@ -85,12 +87,12 @@ async def seed(pool: asyncpg.Pool) -> AsyncIterator[dict]:
             qid = await conn.fetchval(
                 """INSERT INTO intake_queue
                    (instance_id, source, source_ref, blob_path, blob_hash, pipeline_version,
-                    status, stage_output, intake_key)
-                   VALUES ($1,$2,$3,$4,$5,$6,'done',$7::jsonb,$8) RETURNING id""",
+                    status, stage_output, intake_key, received_by)
+                   VALUES ($1,$2,$3,$4,$5,$6,'done',$7::jsonb,$8,$9) RETURNING id""",
                 inst, source, f"{tag}-ref", f"/tmp/{tag}.pdf", bh[:64], PIPELINE,
                 json.dumps({"ocr": {"pages": [{"page": 1, "text": "NPWP 09.x"}]},
                             "doc_type": "npwp"}),
-                ikey,
+                ikey, received_by,
             )
             created["queues"].append(qid)
             pid = await conn.fetchval(
@@ -109,18 +111,32 @@ async def seed(pool: asyncpg.Pool) -> AsyncIterator[dict]:
             created["proposals"].append(pid)
             return pid
 
+        # RBAC axis is OWN-CHAT (intake_queue.received_by), NOT the client's
+        # assigned_to. Seed received_by independently of the resolved candidate:
+        #   p_owner   → received_by=OWNER  (owner sees)
+        #   p_other   → received_by=OTHER  (owner does NOT see)
+        #   p_nomatch → received_by=OWNER  (NO_MATCH but OWNER's chat → owner sees)
+        #   p_null    → received_by=NULL   (shared business line + Drive → admin-only)
         p_owner = await mk_proposal(
             {"decision": "AUTO_ATTACH", "score": 0.95,
-             "candidates": [{"client_id": cid_owner, "score": 0.95}]})
+             "candidates": [{"client_id": cid_owner, "score": 0.95}]},
+            received_by=TEAM_OWNER["email"])
         p_other = await mk_proposal(
             {"decision": "LINK_CANDIDATE", "score": 0.80,
-             "candidates": [{"client_id": cid_other, "score": 0.80}]})
-        p_nomatch = await mk_proposal({"decision": "NO_MATCH", "candidates": []})
+             "candidates": [{"client_id": cid_other, "score": 0.80}]},
+            received_by=TEAM_OTHER["email"])
+        p_nomatch = await mk_proposal(
+            {"decision": "NO_MATCH", "candidates": []},
+            received_by=TEAM_OWNER["email"])
+        p_null = await mk_proposal(
+            {"decision": "NO_MATCH", "candidates": []},
+            received_by=None)
 
     yield {
         "tag": tag,
         "cid_owner": cid_owner, "cid_other": cid_other,
         "p_owner": p_owner, "p_other": p_other, "p_nomatch": p_nomatch,
+        "p_null": p_null,
         "created": created,
     }
 
@@ -158,24 +174,31 @@ async def _crm_counts(pool: asyncpg.Pool) -> tuple[int, int]:
 
 # --------------------------------------------------------------------------- #
 async def test_queue_admin_sees_all(pool, seed):
+    """Admin sees the ENTIRE queue — every worker's docs, incl. NULL-received_by."""
     app = _make_app(pool, ADMIN)
     async with _client(app) as cl:
         r = await cl.get("/api/intake/review/queue", params={"source": "drive", "limit": 200})
     assert r.status_code == 200, r.text
     ids = {it["proposal_id"] for it in r.json()["items"]}
-    assert {seed["p_owner"], seed["p_other"], seed["p_nomatch"]} <= ids
+    assert {seed["p_owner"], seed["p_other"], seed["p_nomatch"], seed["p_null"]} <= ids
 
 
 async def test_queue_team_rbac_filter(pool, seed):
-    """Owner sees only their assigned proposal; not other's, not NO_MATCH."""
+    """Own-chat axis: owner sees ONLY rows they received (incl. their NO_MATCH).
+
+    received_by=OWNER → p_owner + p_nomatch visible.
+    received_by=OTHER → p_other hidden.
+    received_by=NULL  → p_null hidden (admin-only shared/Drive docs).
+    """
     app = _make_app(pool, TEAM_OWNER)
     async with _client(app) as cl:
         r = await cl.get("/api/intake/review/queue", params={"limit": 200})
     assert r.status_code == 200, r.text
     ids = {it["proposal_id"] for it in r.json()["items"]}
     assert seed["p_owner"] in ids
-    assert seed["p_other"] not in ids
-    assert seed["p_nomatch"] not in ids
+    assert seed["p_nomatch"] in ids  # NO_MATCH from OWNER's own chat → now visible
+    assert seed["p_other"] not in ids  # another worker's chat
+    assert seed["p_null"] not in ids  # NULL received_by → admin-only
 
 
 async def test_queue_decision_filter(pool, seed):
@@ -202,11 +225,56 @@ async def test_detail_admin(pool, seed):
 
 
 async def test_detail_rbac_forbidden(pool, seed):
-    """Team user with no access → 403 on detail."""
+    """Non-admin who did NOT receive the doc → 403 (p_owner is OWNER's chat)."""
     app = _make_app(pool, TEAM_OTHER)
     async with _client(app) as cl:
         r = await cl.get(f"/api/intake/review/{seed['p_owner']}")
     assert r.status_code == 403, r.text
+
+
+async def test_detail_own_chat_nomatch_allowed(pool, seed):
+    """Non-admin CAN open a doc from their own chat — even a NO_MATCH one."""
+    app = _make_app(pool, TEAM_OWNER)
+    async with _client(app) as cl:
+        r = await cl.get(f"/api/intake/review/{seed['p_nomatch']}")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["decision"] == "NO_MATCH"
+    assert (body["received_by"] or "").lower() == TEAM_OWNER["email"]
+
+
+async def test_detail_null_received_by_admin_only(pool, seed):
+    """A NULL-received_by doc (shared business line / Drive) is admin-only."""
+    team_app = _make_app(pool, TEAM_OWNER)
+    async with _client(team_app) as cl:
+        r = await cl.get(f"/api/intake/review/{seed['p_null']}")
+    assert r.status_code == 403, r.text
+    admin_app = _make_app(pool, ADMIN)
+    async with _client(admin_app) as cl2:
+        r2 = await cl2.get(f"/api/intake/review/{seed['p_null']}")
+    assert r2.status_code == 200, r2.text
+
+
+async def test_claim_rbac_own_chat(pool, seed):
+    """Non-admin claim is gated by own-chat (received_by), not assigned_to.
+
+    OWNER can claim p_nomatch (their NO_MATCH chat); OWNER cannot claim p_other
+    (another worker's chat) nor p_null (NULL received_by → admin-only) → 403.
+    """
+    owner_app = _make_app(pool, TEAM_OWNER)
+    async with _client(owner_app) as cl:
+        # other worker's doc → 403, never reaches the atomic claim
+        r_other = await cl.post(f"/api/intake/review/{seed['p_other']}/claim")
+        assert r_other.status_code == 403, r_other.text
+        # NULL received_by → admin-only → 403
+        r_null = await cl.post(f"/api/intake/review/{seed['p_null']}/claim")
+        assert r_null.status_code == 403, r_null.text
+        # own NO_MATCH chat → claimable
+        r_ok = await cl.post(f"/api/intake/review/{seed['p_nomatch']}/claim")
+        assert r_ok.status_code == 200, r_ok.text
+        # cleanup: release so teardown deletes cleanly
+        await cl.post(f"/api/intake/review/{seed['p_nomatch']}/release",
+                      params={"claim_token": r_ok.json()["claim_token"]})
 
 
 async def test_claim_release_and_race(pool, seed):


### PR DESCRIPTION
## The rule

The document-review gate forces **every worker** to do review, and each worker must see the documents that came from **their own chats**. The RBAC axis is now **own-chat (`intake_queue.received_by`)**, not the CRM client's `assigned_to`.

- **admin** (`is_crm_admin` -> zero@/asya@/antonellosiano@/admin@): sees the **ENTIRE** queue (all workers' docs, all decisions) for supervision. **Unchanged**.
- **non-admin**: sees ONLY rows where `intake_queue.received_by == user_email` (lowercased). This **INCLUDES** their own `NO_MATCH` / `AMBIGUOUS` / null-decision docs - "it's my chat" takes precedence over the client-resolution gate. The receiver (not an admin) reviews them.
- **`received_by IS NULL`** docs (the shared business-line `whatsapp-live:*` feeds + Drive-sourced docs) stay **admin-only** - a NULL `received_by` never equals a non-admin's email, so the `received_by = :email` filter excludes them naturally (no special-casing).

## Before / after

The old filter used the CRM client's `assigned_to`, which (a) hid every `NO_MATCH`/`AMBIGUOUS` doc behind admin-only, and (b) showed **adit@balizero.com 0 of his 12 received docs** (no resolved client was assigned to him). After this change adit sees **12 of 12**.

## The 3 endpoints touched

- **`GET /queue` (list):** pushed the gate into SQL - `AND (IS_ADMIN OR q.received_by = EMAIL)` (partial index `idx_iq_received_by_pending` on `(received_by, status)` supports it). Removed the old `assigned_to` hiding AND the *no-resolved-client -> admin-only* hide. `q.received_by` now selected + surfaced per item.
- **`GET /{proposal_id}` (detail):** replaced the `assigned_to` check with `received_by == caller` (JOIN `intake_queue`), else 403.
- **`POST /{proposal_id}/claim`:** same `received_by == caller` gate, else 403.

`approve`/`reject`/`release` are left as-is - they gate on the `claim_token` (`_require_active_claim`), reachable only after a successful claim, which now requires the `received_by` match. No independent `assigned_to` check existed in them.

## Tests

`backend/tests/routers/test_intake_review.py` updated to the new axis (ran against real local `nuzantara_dev`): seed now sets `received_by` per proposal (+ a NULL-received_by proposal). New/updated cases: non-admin sees a doc they received incl. `NO_MATCH`; does NOT see another worker's doc; does NOT see a NULL-received_by doc; admin sees all; claim/detail own-chat gate. **21 passed.** Import smoke OK.

NULL-received_by docs (shared business line + Drive) remain admin-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
