### PR TITLE
feat(articles): ID/IT translations for OJK online-lenders watchlist article

### DIFF
--- a/apps/mouth/src/content/articles/business_regulations/ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms.id.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms.id.mdx
@@ -1,0 +1,90 @@
+---
+title: "OJK Puts 8 Online Lenders on Watchlist, License Revocation Looms"
+slug: "ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms"
+excerpt: "## Facts  Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online lending platforms—colloquially known as 'pinjol,' short for pinjaman online—onto its special supervision list, according to a repor"
+coverImage: "/static/news/news_20260608_173755_ec8588d0_cover.png"
+coverImageAlt: "OJK Puts 8 Online Lenders on Watchlist, License Revocation Looms"
+category: "business_regulations"
+tags: ["business_regulations", "puts", "online"]
+publishedAt: "2026-06-09"
+author:
+  name: "Exa: suara.com"
+  avatar: /static/zantara-avatar.png
+trending: false
+featured: false
+readingTime: 3
+difficulty: "intermediate"
+seoTitle: "OJK Puts 8 Online Lenders on Watchlist, License Revocation..."
+seoDescription: "## Facts  Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online..."
+aiGenerated: true
+aiConfidenceScore: 0.85
+aiOptimization:
+  answerSnippet: "## Facts  Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online lending platforms—colloquially known as 'pinjol,' short for pinjaman online—onto its special supervision list, according to a repor"
+  primaryQuestion: "What does OJK Puts 8 Online Lenders on Watchlist, License Revocation Looms mean for expats in Bali?"
+
+locale: "id"
+---
+## TL;DR
+
+<InfoCard
+  title="Quick Summary"
+  items={[
+    { label: "Should I Worry?", value: "Depends" },
+    { label: "Risk Level", value: "Medium" },
+    { label: "Who's Affected", value: "Expats and investors in Indonesia" },
+    { label: "When", value: "Check article for specific dates" },
+  ]}
+/>
+
+**Otoritas Jasa Keuangan (OJK) Indonesia, regulator layanan keuangan terpadu negara tersebut, telah memasukkan delapan platform pinjaman online (P2P) ke dalam daftar pengawasan khusus**,
+
+---
+
+## The Facts
+
+Otoritas Jasa Keuangan (OJK) Indonesia, regulator layanan keuangan terpadu negara tersebut, telah memasukkan delapan platform pinjaman online (P2P)—yang secara umum dikenal sebagai 'pinjol', singkatan dari pinjaman online—ke dalam daftar pengawasan khusus, menurut laporan dari Suara.com. Penunjukan ini menandakan bahwa regulator telah menemukan kegagalan kepatuhan material pada operator-operator ini dan siap untuk mencabut izin usaha mereka jika tindakan perbaikan tidak diambil dalam jangka waktu remediasi yang ditentukan.
+
+Pengawasan khusus (pengawasan khusus) adalah status regulasi formal yang ditingkatkan dalam kerangka kerja OJK, berbeda dari pemantauan rutin. Biasanya dipicu oleh pelanggaran yang meliputi penyangga modal yang tidak memadai, kegagalan untuk memenuhi ambang batas ekuitas minimum, pelanggaran berulang terhadap aturan perlindungan peminjam, kegagalan tata kelola data, atau ketidakmampuan untuk menunjukkan manajemen risiko yang sehat. Platform yang ditempatkan dalam kategori ini dapat diidentifikasi secara publik, yang merupakan kewajiban komersial yang signifikan—peminjam dan pemberi pinjaman dapat menarik diri, mempercepat tekanan likuiditas apa pun.
+
+Sektor pinjaman P2P di Indonesia diatur terutama oleh peraturan OJK tentang layanan pinjaman berbasis teknologi. OJK memelihara daftar resmi platform berlisensi, yang saat ini dikelola bersama dengan Asosiasi Fintech Pendanaan Bersama Indonesia (AFPI), organisasi pengaturan mandiri sektor tersebut. Setiap platform yang dihapus dari daftar tersebut kehilangan hak hukum untuk memfasilitasi pinjaman, dan buku pinjaman yang ada menghadapi prosedur penyelesaian yang tidak pasti.
+
+OJK secara progresif memperketat pengawasan terhadap ruang pinjaman fintech menyusul gelombang keluhan konsumen, praktik penagihan predator, dan kebangkrutan di tahun-tahun sebelumnya. Regulator telah mencabut puluhan izin sejak 2022, mengurangi sektor tersebut dari lebih seratus operator terdaftar menjadi kohort yang secara teoritis lebih kuat. Delapan platform yang disebutkan dalam putaran saat ini mewakili kelanjutan dari upaya konsolidasi tersebut.
+
+Nama-nama dari delapan platform tersebut belum dikonfirmasi secara independen pada saat publikasi. OJK biasanya mengungkapkan keputusan pengawasan khusus melalui situs web resminya dan siaran pers berkala, dan kohort saat ini diperkirakan akan secara resmi terdaftar di sana. Platform di bawah pengawasan khusus umumnya diberi jangka waktu tertentu—seringkali 30 hingga 90 hari—untuk memperbaiki kekurangan yang teridentifikasi sebelum regulator melanjutkan pencabutan izin.
+
+---
+
+## Bali Zero Take
+
+### The Hidden Insight
+
+Gelombang penegakan OJK terbaru ini adalah pengingat bahwa sektor pinjaman fintech Indonesia masih dalam proses perombakan regulasi yang aktif, bukan pasar yang matang dan stabil. Bagi klien kami, risiko utama adalah dua kali lipat: 
+
+### Our Analysis
+
+paparan keuangan langsung sebagai pemberi pinjaman di salah satu dari delapan platform yang ditandai, dan risiko tidak langsung bagi mereka yang memegang ekuitas atau utang dalam usaha fintech Indonesia tanpa uji tuntas yang memadai terhadap status regulasi.
+
+### Our Advice
+
+Kami secara konsisten menasihati investor asing yang mempertimbangkan ruang pinjaman P2P Indonesia—baik sebagai pemberi pinjaman ritel maupun sebagai pemegang saham PT PMA di perusahaan fintech—untuk memverifikasi status registrasi OJK sebelum berkomitmen pada modal, dan untuk meninjau status tersebut setiap triwulan. Daftar pantauan OJK adalah informasi publik; tidak ada alasan untuk tidak memeriksanya. Penunjukan pengawasan khusus jarang terjadi tanpa tanda-tanda peringatan sebelumnya: volume pencairan yang menurun, perselisihan keanggotaan AFPI, atau korespondensi regulasi yang seharusnya diungkapkan oleh tim manajemen yang kompeten.
+
+Bagi klien yang sudah terpapar pada salah satu platform yang ditandai, prioritas segera adalah memahami komposisi buku pinjaman mereka dan jangka waktu remediasi platform tersebut. Menunggu pengumuman pencabutan izin sebelum bertindak adalah strategi yang kalah.
+
+---
+
+## Next Steps
+
+<Checklist
+  title="Action Items"
+  items={[
+    { text: "For Expats", subItems: ["Review the article for specific actions"] },
+    { text: "For Investors", subItems: ["Pertama, periksa daftar publik OJK (ojk.go.id/fintech) untuk mengonfirmasi apakah ada platform yang Anda gunakan muncul di daftar pengawasan khusus saat ini. Lakukan ini hari ini—jangan menunggu media arus utama menerbitkan daftar lengkap.\n\nJika Anda memegang saldo pemberi pinjaman pada platform yang ditandai, tinjau jatuh tempo pinjaman Anda yang belum terselesaikan dan nilai risiko likuiditas. Pertimbangkan untuk tidak menginvestasikan kembali pokok pinjaman saat pinjaman jatuh tempo sampai status platform diselesaikan.\n\nUntuk pemegang saham PT PMA fintech, komisioner analisis kesenjangan kepatuhan terhadap peraturan P2P OJK saat ini sebelum rapat dewan direksi berikutnya. Jika platform Anda ada dalam daftar pantauan, libatkan OJK secara langsung melalui penasihat hukum dalam minggu pertama dari jangka waktu remediasi—penundaan ditafsirkan sebagai ketidakpedulian.\n\nHubungi Bali Zero untuk pemeriksaan status regulasi entitas fintech Indonesia mana pun sebelum berinvestasi atau memperluas operasi."] },
+  ]}
+/>
+
+---
+
+<AskZantara
+  question="Have questions about this topic?"
+  placeholder="Ask Zantara AI for personalized advice..."
+/>

--- a/apps/mouth/src/content/articles/business_regulations/ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms.it.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms.it.mdx
@@ -1,0 +1,90 @@
+---
+title: "OJK Puts 8 Online Lenders on Watchlist, License Revocation Looms"
+slug: "ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms"
+excerpt: "## Facts  Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online lending platforms—colloquially known as 'pinjol,' short for pinjaman online—onto its special supervision list, according to a repor"
+coverImage: "/static/news/news_20260608_173755_ec8588d0_cover.png"
+coverImageAlt: "OJK Puts 8 Online Lenders on Watchlist, License Revocation Looms"
+category: "business_regulations"
+tags: ["business_regulations", "puts", "online"]
+publishedAt: "2026-06-09"
+author:
+  name: "Exa: suara.com"
+  avatar: /static/zantara-avatar.png
+trending: false
+featured: false
+readingTime: 3
+difficulty: "intermediate"
+seoTitle: "OJK Puts 8 Online Lenders on Watchlist, License Revocation..."
+seoDescription: "## Facts  Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online..."
+aiGenerated: true
+aiConfidenceScore: 0.85
+aiOptimization:
+  answerSnippet: "## Facts  Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online lending platforms—colloquially known as 'pinjol,' short for pinjaman online—onto its special supervision list, according to a repor"
+  primaryQuestion: "What does OJK Puts 8 Online Lenders on Watchlist, License Revocation Looms mean for expats in Bali?"
+
+locale: "it"
+---
+## TL;DR
+
+<InfoCard
+  title="Quick Summary"
+  items={[
+    { label: "Should I Worry?", value: "Depends" },
+    { label: "Risk Level", value: "Medium" },
+    { label: "Who's Affected", value: "Expats and investors in Indonesia" },
+    { label: "When", value: "Check article for specific dates" },
+  ]}
+/>
+
+**L'Otoritas Jasa Keuangan (OJK) indonesiana, l'organo di regolamentazione integrata dei servizi finanziari del paese, ha inserito otto piattaforme di prestito online peer-to-peer (P2P)**
+
+---
+
+## The Facts
+
+L'Otoritas Jasa Keuangan (OJK) indonesiana, l'organo di regolamentazione integrata dei servizi finanziari del paese, ha inserito otto piattaforme di prestito online peer-to-peer (P2P) – comunemente note come 'pinjol', abbreviazione di pinjaman online – nella sua lista di supervisione speciale, secondo un rapporto di Suara.com. La designazione segnala che il regolatore ha riscontrato gravi inadempienze in questi operatori ed è pronto a revocare le loro licenze commerciali se non vengono intraprese azioni correttive entro un periodo di sanatoria definito.
+
+La supervisione speciale (pengawasan khusus) è uno stato normativo formale ed esacerbato nel quadro dell'OJK, distinto dal monitoraggio di routine. È tipicamente innescata da violazioni che includono buffer di capitale inadeguati, mancato rispetto delle soglie minime di capitale proprio, violazioni persistenti delle regole sulla protezione dei mutuatari, fallimenti nella governance dei dati o incapacità di dimostrare una sana gestione del rischio. Le piattaforme inserite in questa categoria sono pubblicamente identificabili, il che costituisce di per sé una significativa responsabilità commerciale: mutuatari e finanziatori possono ritirare i fondi, accelerando qualsiasi stress di liquidità.
+
+Il settore dei prestiti P2P in Indonesia è regolato principalmente dalle normative dell'OJK sui servizi di prestito basati sulla tecnologia. L'OJK mantiene un registro ufficiale delle piattaforme autorizzate, attualmente gestito in coordinamento con l'Asosiasi Fintech Pendanaan Bersama Indonesia (AFPI), l'organizzazione di autoregolamentazione del settore. Qualsiasi piattaforma rimossa da tale registro perde il diritto legale di intermediare prestiti e i libri prestiti esistenti affrontano procedure di risoluzione incerte.
+
+L'OJK ha progressivamente rafforzato la supervisione dello spazio dei prestiti fintech a seguito di un'ondata di reclami dei consumatori, pratiche di riscossione predatori e insolvenze negli anni precedenti. Il regolatore ha revocato dozzine di licenze dal 2022, riducendo il settore da oltre cento operatori registrati a una coorte significativamente più piccola, teoricamente più solida. Le otto piattaforme nominate nell'attuale round rappresentano una continuazione di questa spinta alla consolidazione.
+
+I nomi delle otto piattaforme non sono stati confermati in modo indipendente al momento della pubblicazione. L'OJK divulga tipicamente le decisioni di supervisione speciale attraverso il suo sito web ufficiale e comunicati stampa periodici, e si prevede che la corrente coorte sarà formalmente elencata lì. Alle piattaforme sottoposte a supervisione speciale viene generalmente concesso un periodo definito – spesso da 30 a 90 giorni – per sanare le carenze identificate prima che il regolatore proceda alla cancellazione della licenza.
+
+---
+
+## Bali Zero Take
+
+### The Hidden Insight
+
+Questa ultima ondata di applicazione dell'OJK è un promemoria del fatto che il settore dei prestiti fintech indonesiani rimane in una fase di riassetto normativo attivo, non un mercato maturo e stabile. Per i nostri clienti, il rischio chiave è duplice:
+
+### Our Analysis
+
+esposizione finanziaria diretta come finanziatore su una qualsiasi delle otto piattaforme segnalate e rischio indiretto per coloro che detengono partecipazioni azionarie o debiti in imprese fintech indonesiane senza un'adeguata due diligence sulla regolamentazione.
+
+### Our Advice
+
+Consigliamo costantemente agli investitori stranieri che prendono in considerazione lo spazio dei prestiti P2P indonesiani – sia come finanziatori al dettaglio che come azionisti PT PMA in società fintech – di verificare lo stato di registrazione dell'OJK prima di impegnare capitali e di rivederlo trimestralmente. La lista di controllo dell'OJK è un'informazione pubblica; non c'è scusa per non controllarla. Le designazioni di supervisione speciale raramente arrivano senza segnali di avvertimento precedenti: volumi di erogazione in calo, controversie sulla membership AFPI o corrispondenza normativa che i team di gestione competenti avrebbero dovuto divulgare.
+
+Per i clienti già esposti a una delle piattaforme segnalate, la priorità immediata è comprendere la composizione del loro libro prestiti e la tempistica di sanatoria della piattaforma. Aspettare un annuncio di revoca della licenza prima di agire è una strategia perdente.
+
+---
+
+## Next Steps
+
+<Checklist
+  title="Action Items"
+  items={[
+    { text: "For Expats", subItems: ["Review the article for specific actions"] },
+    { text: "For Investors", subItems: ["Innanzitutto, controlla il registro pubblico dell'OJK (ojk.go.id/fintech) per confermare se una qualsiasi piattaforma che utilizzi appare nell'attuale lista di supervisione speciale. Fallo oggi – non aspettare che i media tradizionali pubblichino l'elenco completo.\n\nSe detieni saldi di finanziatori su una piattaforma segnalata, rivedi le scadenze dei tuoi prestiti in sospeso e valuta il rischio di liquidità. Considera di non reinvestire il capitale principale quando i prestiti scadono fino a quando lo stato della piattaforma non sarà risolto.\n\nPer gli azionisti PT PMA fintech, commissiona un'analisi dei gap di conformità rispetto alle attuali normative OJK P2P prima della tua prossima riunione del consiglio di amministrazione. Se la tua piattaforma è nella lista di controllo, coinvolgi direttamente l'OJK tramite un consulente legale entro la prima settimana del periodo di sanatoria – il ritardo viene interpretato come disimpegno.\n\nContatta Bali Zero per un controllo dello stato normativo di qualsiasi entità fintech indonesiana prima di investire o espandere le operazioni."] },
+  ]}
+/>
+
+---
+
+<AskZantara
+  question="Have questions about this topic?"
+  placeholder="Ask Zantara AI for personalized advice..."
+/>


### PR DESCRIPTION
## What
Adds the Indonesian (ID) and Italian (IT) translations for the business-regulations
article `ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms`.

The English base article is already on `main`; only the ID/IT translations were
missing. Generated by the translation pipeline, salvaged from trunk untracked
during the catch-all-branch cleanup follow-up.

## Verification
- Branched clean off fresh `origin/main` (incl. #1243) — 2 new files, +180.
- `git ls-tree origin/main` confirmed base `.mdx` exists, ID/IT absent.
- Frontmatter validated (title/slug/excerpt/coverImage present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)