### PR TITLE
feat(autonomous-lab): add Pro runtime worker

### DIFF
--- a/.github/workflows/hot-zone-pr-gate.yml
+++ b/.github/workflows/hot-zone-pr-gate.yml
@@ -64,7 +64,8 @@ jobs:
 
       # ---------------------------------------------------------------------
       # Step 1 — Checkout base SHA (NOT branch HEAD; anti pull_request_target trap)
-      # Fetch enough history for `git diff base...head` to enumerate changed files.
+      # Fetch only the base endpoint; the diff step fetches the PR head separately.
+      # git diff base head only needs both endpoint trees, not full repo history.
       # ---------------------------------------------------------------------
       - name: Checkout base ref
         if: steps.kill_switch.outputs.disabled != 'true'
@@ -73,7 +74,7 @@ jobs:
           # For merge_group: github.event.merge_group.base_sha (latest base)
           # For pull_request: github.event.pull_request.base.sha
           ref: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
-          fetch-depth: 0
+          fetch-depth: 1
 
       # ---------------------------------------------------------------------
       # Step 2 — Enumerate changed files (PR diff)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 324 routers · 605 services
+- Backend: FastAPI · 324 routers · 606 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 28 · Packages: 6

--- a/apps/backend-rag/backend/services/autonomous_lab/__init__.py
+++ b/apps/backend-rag/backend/services/autonomous_lab/__init__.py
@@ -43,6 +43,16 @@ from backend.services.autonomous_lab.reviewer import (
     LabReviewFinding,
     review_lab_run,
 )
+from backend.services.autonomous_lab.runtime_worker import (
+    LabRunStateStore,
+    LabWorkerConfig,
+    LabWorkerStatus,
+    LabWorkerTickResult,
+    VerificationCommandResult,
+    default_worker_id,
+    execute_command_plan,
+    run_worker_once,
+)
 from backend.services.autonomous_lab.state_store import (
     AutonomousLabStateStore,
     LabEventType,
@@ -84,9 +94,13 @@ __all__ = [
     "LabRun",
     "LabRunQueueItem",
     "LabRunRecord",
+    "LabRunStateStore",
     "LabRunStatus",
     "LabRuntimePlacement",
     "LabSafetyGate",
+    "LabWorkerConfig",
+    "LabWorkerStatus",
+    "LabWorkerTickResult",
     "MaterialSourceType",
     "MetaWorkflowStage",
     "NormalizedMaterial",
@@ -99,6 +113,7 @@ __all__ = [
     "ReviewFinding",
     "SimulationPlan",
     "SotaGovernancePiece",
+    "VerificationCommandResult",
     "assert_outbox_consumer_allowed",
     "assert_receipt_persistable",
     "assert_run_queue_item_persistable",
@@ -106,6 +121,9 @@ __all__ = [
     "current_runtime_placement",
     "default_operational_plan",
     "default_pipeline",
+    "default_worker_id",
+    "execute_command_plan",
     "resolve_runtime_placement",
     "review_lab_run",
+    "run_worker_once",
 ]

--- a/apps/backend-rag/backend/services/autonomous_lab/operational_plan.py
+++ b/apps/backend-rag/backend/services/autonomous_lab/operational_plan.py
@@ -148,14 +148,10 @@ class LabOperationalPlan:
     def to_receipt(self) -> dict[str, Any]:
         return {
             "version": self.version,
-            "governance_pieces": [
-                piece.to_receipt() for piece in self.governance_pieces
-            ],
+            "governance_pieces": [piece.to_receipt() for piece in self.governance_pieces],
             "meta_workflow": [stage.to_receipt() for stage in self.meta_workflow],
             "anchor_jobs": [component.to_receipt() for component in self.anchor_jobs],
-            "missing_components": [
-                component.to_receipt() for component in self.missing_components
-            ],
+            "missing_components": [component.to_receipt() for component in self.missing_components],
             "work_packages": [package.to_receipt() for package in self.work_packages],
             "missing_component_keys": self.missing_component_keys,
             "parallelizable_component_keys": self.parallelizable_component_keys,
@@ -280,10 +276,10 @@ MISSING_V1_COMPONENTS: tuple[LabControlPlaneComponent, ...] = (
     LabControlPlaneComponent(
         key="verification_runner",
         agent_role="verification_runner",
-        responsibility="run allowlisted tests, lint, metrics, and failure analysis",
-        output="verification report",
+        responsibility="claim Pro-only queue work and run allowlisted verification",
+        output="owner-scoped worker transition and receipt-safe verification report",
         gate="empirical_result_recorded",
-        state=ComponentState.PLANNED,
+        state=ComponentState.CONTRACTED,
         depends_on=("worktree_experiment_runner",),
         parallel_group="execution",
     ),

--- a/apps/backend-rag/backend/services/autonomous_lab/runtime_worker.py
+++ b/apps/backend-rag/backend/services/autonomous_lab/runtime_worker.py
@@ -1,0 +1,440 @@
+"""Pro-only runtime worker for Autonomous Lab queue items.
+
+The v1 Lab control plane can enqueue durable work from Air/Mini/Pro, but only
+the Pro may claim and execute run work. This module activates the verification
+runner slice without starting an H24 daemon or enabling promotion/deploy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import time
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Protocol
+
+from backend.services.autonomous_lab.command_policy import (
+    CommandExecutionPlan,
+    plan_for_allowlisted_command,
+    refusal_reason,
+    verification_commands_for_paths,
+)
+from backend.services.autonomous_lab.receipt_safety import (
+    receipt_safe_evidence,
+    safe_sha256_fingerprint,
+)
+from backend.services.autonomous_lab.state_store import (
+    AsyncConnection,
+    AutonomousLabStateStore,
+    LabMachineRole,
+    LabRunRecord,
+)
+
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 120
+DEFAULT_MAX_VERIFICATION_COMMANDS = 12
+
+
+class LabWorkerStatus(str, Enum):
+    """High-level outcome for one queue worker tick."""
+
+    IDLE = "idle"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    REFUSED = "refused"
+    MARK_FAILED = "mark_failed"
+
+
+@dataclass(frozen=True)
+class VerificationCommandResult:
+    """Receipt-safe result for one planned verification command."""
+
+    command: str
+    allowed: bool
+    executed: bool
+    returncode: int | None
+    duration_ms: int = 0
+    refusal: str | None = None
+    stdout_chars: int = 0
+    stderr_chars: int = 0
+    stdout_fingerprint: str | None = None
+    stderr_fingerprint: str | None = None
+
+    @property
+    def failed(self) -> bool:
+        """Return True when this command blocks the run."""
+        return (not self.allowed) or (self.executed and self.returncode != 0)
+
+    def to_receipt(self) -> dict[str, Any]:
+        """Return a DB-safe command receipt without raw output."""
+        return {
+            "command": self.command,
+            "allowed": self.allowed,
+            "executed": self.executed,
+            "returncode": self.returncode,
+            "duration_ms": self.duration_ms,
+            "refusal": self.refusal,
+            "stdout_chars": self.stdout_chars,
+            "stderr_chars": self.stderr_chars,
+            "stdout_fingerprint": self.stdout_fingerprint,
+            "stderr_fingerprint": self.stderr_fingerprint,
+        }
+
+
+@dataclass(frozen=True)
+class LabWorkerConfig:
+    """Bounded execution policy for one Pro worker tick."""
+
+    worker_id: str
+    repo_root: Path
+    backend_root: Path
+    execute_verification: bool
+    command_timeout_seconds: int = DEFAULT_COMMAND_TIMEOUT_SECONDS
+    max_verification_commands: int = DEFAULT_MAX_VERIFICATION_COMMANDS
+
+
+@dataclass(frozen=True)
+class LabWorkerTickResult:
+    """Receipt-safe outcome for one worker tick."""
+
+    status: LabWorkerStatus
+    worker_id: str
+    run_id: str | None = None
+    claimed: bool = False
+    marked: bool = False
+    commands: tuple[VerificationCommandResult, ...] = ()
+    message: str = ""
+    placement: LabMachineRole = LabMachineRole.PRO_RUNTIME
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def ok(self) -> bool:
+        """Return True for non-error tick outcomes."""
+        return self.status in {LabWorkerStatus.IDLE, LabWorkerStatus.SUCCEEDED}
+
+    def to_receipt(self) -> dict[str, Any]:
+        """Return a durable receipt without raw command output."""
+        return {
+            "ok": self.ok,
+            "status": self.status.value,
+            "worker_id": self.worker_id,
+            "run_id": self.run_id,
+            "claimed": self.claimed,
+            "marked": self.marked,
+            "placement": self.placement.value,
+            "message": receipt_safe_evidence(self.message, force_fingerprint=True)
+            if self.message
+            else "",
+            "commands": [command.to_receipt() for command in self.commands],
+            "metadata": dict(self.metadata),
+        }
+
+
+class LabRunStateStore(Protocol):
+    """State-store subset used by the runtime worker."""
+
+    placement: Any
+
+    async def claim_next_run(
+        self,
+        conn: AsyncConnection,
+        *,
+        worker_id: str,
+        machine_role: LabMachineRole | str | None = None,
+    ) -> LabRunRecord | None: ...
+
+    async def heartbeat_run(
+        self,
+        conn: AsyncConnection,
+        *,
+        run_id: str,
+        worker_id: str,
+    ) -> bool: ...
+
+    async def mark_run_succeeded(
+        self,
+        conn: AsyncConnection,
+        *,
+        run_id: str,
+        worker_id: str,
+        summary: Mapping[str, Any] | None = None,
+    ) -> bool: ...
+
+    async def mark_run_failed(
+        self,
+        conn: AsyncConnection,
+        *,
+        run_id: str,
+        worker_id: str,
+        error: str,
+    ) -> bool: ...
+
+
+CommandExecutor = Callable[[CommandExecutionPlan], Awaitable[VerificationCommandResult]]
+
+
+async def run_worker_once(
+    conn: AsyncConnection,
+    *,
+    config: LabWorkerConfig,
+    store: LabRunStateStore | None = None,
+    executor: CommandExecutor | None = None,
+) -> LabWorkerTickResult:
+    """Claim one pending run and execute its allowlisted verification plan."""
+    state_store = store or AutonomousLabStateStore()
+    role = LabMachineRole.PRO_RUNTIME
+    run = await state_store.claim_next_run(
+        conn,
+        worker_id=config.worker_id,
+        machine_role=role,
+    )
+    if run is None:
+        return LabWorkerTickResult(
+            status=LabWorkerStatus.IDLE,
+            worker_id=config.worker_id,
+            claimed=False,
+            placement=role,
+            message="no pending autonomous lab run",
+        )
+
+    await state_store.heartbeat_run(conn, run_id=run.run_id, worker_id=config.worker_id)
+    commands = _verification_commands_for_run(run, config)
+    if isinstance(commands, str):
+        return await _fail_claimed_run(
+            conn,
+            state_store=state_store,
+            config=config,
+            run=run,
+            status=LabWorkerStatus.REFUSED,
+            commands=(),
+            message=commands,
+        )
+
+    planned = _plan_commands(commands, config)
+    if any(not result.allowed for result in planned):
+        return await _fail_claimed_run(
+            conn,
+            state_store=state_store,
+            config=config,
+            run=run,
+            status=LabWorkerStatus.REFUSED,
+            commands=tuple(planned),
+            message="verification command refused by Autonomous Lab command policy",
+        )
+
+    if not config.execute_verification:
+        return await _fail_claimed_run(
+            conn,
+            state_store=state_store,
+            config=config,
+            run=run,
+            status=LabWorkerStatus.REFUSED,
+            commands=tuple(planned),
+            message="verification execution disabled for runtime worker invocation",
+        )
+
+    command_executor = executor or (
+        lambda plan: execute_command_plan(
+            plan,
+            timeout_seconds=config.command_timeout_seconds,
+        )
+    )
+    results = tuple([await command_executor(plan) for plan in _plans_only(commands, config)])
+    failed = [result for result in results if result.failed]
+    if failed:
+        return await _fail_claimed_run(
+            conn,
+            state_store=state_store,
+            config=config,
+            run=run,
+            status=LabWorkerStatus.FAILED,
+            commands=results,
+            message="one or more Autonomous Lab verification commands failed",
+        )
+
+    summary = {
+        "result": "verification_passed",
+        "command_count": len(results),
+        "target_path_count": len(run.target_paths),
+        "commands": [result.to_receipt() for result in results],
+    }
+    marked = await state_store.mark_run_succeeded(
+        conn,
+        run_id=run.run_id,
+        worker_id=config.worker_id,
+        summary=summary,
+    )
+    return LabWorkerTickResult(
+        status=LabWorkerStatus.SUCCEEDED if marked else LabWorkerStatus.MARK_FAILED,
+        worker_id=config.worker_id,
+        run_id=run.run_id,
+        claimed=True,
+        marked=marked,
+        commands=results,
+        placement=role,
+        message="autonomous lab verification succeeded"
+        if marked
+        else "verification passed but success transition missed owner scope",
+        metadata={"target_path_count": len(run.target_paths)},
+    )
+
+
+async def execute_command_plan(
+    plan: CommandExecutionPlan,
+    *,
+    timeout_seconds: int = DEFAULT_COMMAND_TIMEOUT_SECONDS,
+) -> VerificationCommandResult:
+    """Execute one allowlisted command plan without shell expansion."""
+    started = time.monotonic()
+    proc = await asyncio.create_subprocess_exec(
+        *plan.argv,
+        cwd=str(plan.cwd),
+        env=plan.env,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout_raw, stderr_raw = await asyncio.wait_for(
+            proc.communicate(),
+            timeout=timeout_seconds,
+        )
+        returncode = proc.returncode
+        refusal = None
+    except asyncio.TimeoutError:
+        proc.kill()
+        stdout_raw, stderr_raw = await proc.communicate()
+        returncode = 124
+        refusal = "timeout"
+
+    stdout_text = stdout_raw.decode("utf-8", errors="replace")
+    stderr_text = stderr_raw.decode("utf-8", errors="replace")
+    return VerificationCommandResult(
+        command=plan.command,
+        allowed=True,
+        executed=True,
+        returncode=returncode,
+        duration_ms=int((time.monotonic() - started) * 1000),
+        refusal=refusal,
+        stdout_chars=len(stdout_text),
+        stderr_chars=len(stderr_text),
+        stdout_fingerprint=_fingerprint_or_none(stdout_text),
+        stderr_fingerprint=_fingerprint_or_none(stderr_text),
+    )
+
+
+def default_worker_id(prefix: str = "autonomous-lab-worker") -> str:
+    """Return a stable, low-cardinality worker id for the current process."""
+    hostname = socket.gethostname().replace(".", "-")
+    return f"{prefix}:{hostname}"
+
+
+def _verification_commands_for_run(
+    run: LabRunRecord,
+    config: LabWorkerConfig,
+) -> list[str] | str:
+    commands = verification_commands_for_paths(list(run.target_paths))
+    if len(commands) > config.max_verification_commands:
+        return "verification command count exceeds Autonomous Lab worker bound"
+    return commands
+
+
+def _plan_commands(
+    commands: list[str],
+    config: LabWorkerConfig,
+) -> list[VerificationCommandResult]:
+    results: list[VerificationCommandResult] = []
+    for command in commands:
+        plan = plan_for_allowlisted_command(
+            command,
+            repo_root=config.repo_root,
+            backend_root=config.backend_root,
+        )
+        if plan is None:
+            results.append(
+                VerificationCommandResult(
+                    command=command,
+                    allowed=False,
+                    executed=False,
+                    returncode=None,
+                    refusal=refusal_reason(command),
+                )
+            )
+            continue
+        results.append(
+            VerificationCommandResult(
+                command=command,
+                allowed=True,
+                executed=False,
+                returncode=None,
+            )
+        )
+    return results
+
+
+def _plans_only(
+    commands: list[str],
+    config: LabWorkerConfig,
+) -> list[CommandExecutionPlan]:
+    plans: list[CommandExecutionPlan] = []
+    for command in commands:
+        plan = plan_for_allowlisted_command(
+            command,
+            repo_root=config.repo_root,
+            backend_root=config.backend_root,
+        )
+        if plan is None:
+            raise ValueError(f"unexpected refused command after policy preflight: {command}")
+        plans.append(plan)
+    return plans
+
+
+async def _fail_claimed_run(
+    conn: AsyncConnection,
+    *,
+    state_store: LabRunStateStore,
+    config: LabWorkerConfig,
+    run: LabRunRecord,
+    status: LabWorkerStatus,
+    commands: tuple[VerificationCommandResult, ...],
+    message: str,
+) -> LabWorkerTickResult:
+    marked = await state_store.mark_run_failed(
+        conn,
+        run_id=run.run_id,
+        worker_id=config.worker_id,
+        error=message,
+    )
+    return LabWorkerTickResult(
+        status=status if marked else LabWorkerStatus.MARK_FAILED,
+        worker_id=config.worker_id,
+        run_id=run.run_id,
+        claimed=True,
+        marked=marked,
+        commands=commands,
+        placement=LabMachineRole.PRO_RUNTIME,
+        message=message if marked else "failed run transition missed owner scope",
+        metadata={"target_path_count": len(run.target_paths)},
+    )
+
+
+def _fingerprint_or_none(value: str) -> str | None:
+    if not value:
+        return None
+    return safe_sha256_fingerprint(value)
+
+
+__all__ = [
+    "DEFAULT_COMMAND_TIMEOUT_SECONDS",
+    "DEFAULT_MAX_VERIFICATION_COMMANDS",
+    "CommandExecutor",
+    "LabRunStateStore",
+    "LabWorkerConfig",
+    "LabWorkerStatus",
+    "LabWorkerTickResult",
+    "VerificationCommandResult",
+    "default_worker_id",
+    "execute_command_plan",
+    "run_worker_once",
+]

--- a/apps/backend-rag/backend/tests/unit/services/autonomous_lab/test_runtime_worker.py
+++ b/apps/backend-rag/backend/tests/unit/services/autonomous_lab/test_runtime_worker.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from backend.services.autonomous_lab.command_policy import CommandExecutionPlan
+from backend.services.autonomous_lab.receipt_safety import safe_sha256_fingerprint
+from backend.services.autonomous_lab.runtime_worker import (
+    LabWorkerConfig,
+    LabWorkerStatus,
+    VerificationCommandResult,
+    run_worker_once,
+)
+from backend.services.autonomous_lab.state_store import (
+    AsyncConnection,
+    AutonomousLabStateStore,
+    LabMachineRole,
+    LabRunRecord,
+    LabRunStatus,
+    resolve_runtime_placement,
+)
+
+
+class FakeConn:
+    pass
+
+
+class FakeAsyncConnection:
+    def __init__(self) -> None:
+        self.fetchrow_calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    async def fetchrow(self, query: str, *args: Any) -> Any:
+        self.fetchrow_calls.append((query, args))
+        return {"updated_count": 1, "event_id": 123}
+
+    async def fetch(self, query: str, *args: Any) -> list[Any]:
+        raise AssertionError("fetch not expected")
+
+    async def execute(self, query: str, *args: Any) -> str:
+        raise AssertionError("execute not expected")
+
+
+class FakeStore:
+    def __init__(self, run: LabRunRecord | None, *, transition_updates: bool = True) -> None:
+        self.run = run
+        self.transition_updates = transition_updates
+        self.placement = resolve_runtime_placement("Nuzantara", "nuzantara")
+        self.claims: list[tuple[str, LabMachineRole | str | None]] = []
+        self.heartbeats: list[tuple[str, str]] = []
+        self.succeeded: list[dict[str, Any]] = []
+        self.failed: list[dict[str, Any]] = []
+
+    async def claim_next_run(
+        self,
+        conn: AsyncConnection,
+        *,
+        worker_id: str,
+        machine_role: LabMachineRole | str | None = None,
+    ) -> LabRunRecord | None:
+        self.claims.append((worker_id, machine_role))
+        return self.run
+
+    async def heartbeat_run(
+        self,
+        conn: AsyncConnection,
+        *,
+        run_id: str,
+        worker_id: str,
+    ) -> bool:
+        self.heartbeats.append((run_id, worker_id))
+        return self.transition_updates
+
+    async def mark_run_succeeded(
+        self,
+        conn: AsyncConnection,
+        *,
+        run_id: str,
+        worker_id: str,
+        summary: dict[str, Any] | None = None,
+    ) -> bool:
+        self.succeeded.append({"run_id": run_id, "worker_id": worker_id, "summary": summary or {}})
+        return self.transition_updates
+
+    async def mark_run_failed(
+        self,
+        conn: AsyncConnection,
+        *,
+        run_id: str,
+        worker_id: str,
+        error: str,
+    ) -> bool:
+        self.failed.append({"run_id": run_id, "worker_id": worker_id, "error": error})
+        return self.transition_updates
+
+
+def _run_record(target_paths: tuple[str, ...]) -> LabRunRecord:
+    return LabRunRecord(
+        run_id="runtime-worker-test",
+        idempotency_key="runtime-worker-test:v1",
+        status=LabRunStatus.RUNNING,
+        objective="evidence_fingerprint:sha256:1111-2222; chars:20",
+        receipt={"run_id": "runtime-worker-test", "blocked": False},
+        target_paths=target_paths,
+        metadata={"lane": "ops"},
+        priority=10,
+        attempts=1,
+        max_attempts=3,
+        inserted=False,
+    )
+
+
+def _config(*, execute_verification: bool = True) -> LabWorkerConfig:
+    repo_root = Path(__file__).resolve().parents[7]
+    return LabWorkerConfig(
+        worker_id="worker-test",
+        repo_root=repo_root,
+        backend_root=repo_root / "apps" / "backend-rag",
+        execute_verification=execute_verification,
+    )
+
+
+@pytest.mark.asyncio
+async def test_worker_idle_when_no_pending_run() -> None:
+    store = FakeStore(None)
+
+    result = await run_worker_once(FakeConn(), config=_config(), store=store)
+
+    assert result.status == LabWorkerStatus.IDLE
+    assert result.ok is True
+    assert result.claimed is False
+    assert store.claims == [("worker-test", LabMachineRole.PRO_RUNTIME)]
+    assert store.succeeded == []
+    assert store.failed == []
+
+
+@pytest.mark.asyncio
+async def test_worker_refuses_non_allowlisted_verification_without_execution() -> None:
+    store = FakeStore(_run_record(("apps/mouth/src/lib/api/crm/crm.api.ts",)))
+    executor_called = False
+
+    async def executor(_plan: CommandExecutionPlan) -> VerificationCommandResult:
+        nonlocal executor_called
+        executor_called = True
+        raise AssertionError("refused command must not reach executor")
+
+    result = await run_worker_once(
+        FakeConn(),
+        config=_config(),
+        store=store,
+        executor=executor,
+    )
+
+    assert result.status == LabWorkerStatus.REFUSED
+    assert result.ok is False
+    assert executor_called is False
+    assert store.succeeded == []
+    assert (
+        store.failed[0]["error"] == "verification command refused by Autonomous Lab command policy"
+    )
+    assert result.commands[0].command == "cd apps/mouth && npm run lint"
+    assert result.commands[0].refusal == "command_not_allowlisted"
+
+
+@pytest.mark.asyncio
+async def test_worker_requires_execution_enabled_after_claim() -> None:
+    store = FakeStore(
+        _run_record(("apps/backend-rag/backend/services/autonomous_lab/runtime_worker.py",))
+    )
+
+    result = await run_worker_once(
+        FakeConn(), config=_config(execute_verification=False), store=store
+    )
+
+    assert result.status == LabWorkerStatus.REFUSED
+    assert (
+        store.failed[0]["error"] == "verification execution disabled for runtime worker invocation"
+    )
+    assert store.succeeded == []
+
+
+@pytest.mark.asyncio
+async def test_worker_executes_allowlisted_commands_and_marks_success() -> None:
+    store = FakeStore(
+        _run_record(("apps/backend-rag/backend/services/autonomous_lab/runtime_worker.py",))
+    )
+    executed: list[list[str]] = []
+    raw_stdout = "RAW_STDOUT_VALUE_MUST_NOT_LEAK"
+
+    async def executor(plan: CommandExecutionPlan) -> VerificationCommandResult:
+        executed.append(plan.argv)
+        return VerificationCommandResult(
+            command=plan.command,
+            allowed=True,
+            executed=True,
+            returncode=0,
+            stdout_chars=len(raw_stdout),
+            stdout_fingerprint=safe_sha256_fingerprint(raw_stdout),
+        )
+
+    result = await run_worker_once(
+        FakeConn(),
+        config=_config(),
+        store=store,
+        executor=executor,
+    )
+
+    receipt = result.to_receipt()
+
+    assert result.status == LabWorkerStatus.SUCCEEDED
+    assert result.ok is True
+    assert len(executed) == 1
+    assert store.failed == []
+    assert store.succeeded[0]["summary"]["result"] == "verification_passed"
+    assert raw_stdout not in str(receipt)
+    assert "stdout_fingerprint" in str(receipt)
+
+
+@pytest.mark.asyncio
+async def test_worker_marks_failed_when_allowlisted_command_fails() -> None:
+    store = FakeStore(
+        _run_record(("apps/backend-rag/backend/services/autonomous_lab/runtime_worker.py",))
+    )
+
+    async def executor(plan: CommandExecutionPlan) -> VerificationCommandResult:
+        return VerificationCommandResult(
+            command=plan.command,
+            allowed=True,
+            executed=True,
+            returncode=1,
+            stderr_chars=12,
+            stderr_fingerprint=safe_sha256_fingerprint("test failed"),
+        )
+
+    result = await run_worker_once(
+        FakeConn(),
+        config=_config(),
+        store=store,
+        executor=executor,
+    )
+
+    assert result.status == LabWorkerStatus.FAILED
+    assert result.ok is False
+    assert store.succeeded == []
+    assert store.failed[0]["error"] == "one or more Autonomous Lab verification commands failed"
+
+
+@pytest.mark.asyncio
+async def test_real_store_accepts_worker_success_summary_without_raw_output() -> None:
+    raw_stdout = "RAW_STDOUT_VALUE_MUST_NOT_LEAK"
+    conn = FakeAsyncConnection()
+    with patch(
+        "backend.services.autonomous_lab.state_store.current_runtime_placement",
+        return_value=resolve_runtime_placement("Nuzantara", "nuzantara"),
+    ):
+        store = AutonomousLabStateStore()
+
+    marked = await store.mark_run_succeeded(
+        conn,
+        run_id="runtime-worker-test",
+        worker_id="worker-test",
+        summary={
+            "result": "verification_passed",
+            "command_count": 1,
+            "commands": [
+                VerificationCommandResult(
+                    command=(
+                        "cd apps/backend-rag && PYTHONPATH=. "
+                        "pytest backend/tests/unit/services/autonomous_lab -q"
+                    ),
+                    allowed=True,
+                    executed=True,
+                    returncode=0,
+                    stdout_chars=len(raw_stdout),
+                    stdout_fingerprint=safe_sha256_fingerprint(raw_stdout),
+                ).to_receipt()
+            ],
+        },
+    )
+
+    payload = str(conn.fetchrow_calls[0][1])
+
+    assert marked is True
+    assert raw_stdout not in payload
+    assert "RAW_STDOUT_VALUE_MUST_NOT_LEAK" not in payload
+    assert "evidence_fingerprint:sha256:" in payload

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`324 routers · 605 services · 1022 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`324 routers · 606 services · 1024 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/docs/runbooks/autonomous-lab-runtime-placement.md
+++ b/docs/runbooks/autonomous-lab-runtime-placement.md
@@ -66,6 +66,33 @@ Outbox:
 - Do not wire deploy, merge, push, or Google Workspace writes into the Lab
   without an explicit operator gate.
 
+## Pro Worker Activation Slice
+
+`scripts/autonomous_lab_worker.py` is a bounded Pro-only queue worker. It claims
+at most one pending `autonomous_lab_runs` item per iteration, maps target paths
+to the shared command allowlist, executes verification without a shell, and then
+marks the run `succeeded` or retryable/failed through owner-scoped state-store
+transitions.
+
+From Pro only:
+
+```bash
+cd ~/Desktop/nuzantara
+source apps/backend-rag/.venv/bin/activate
+DATABASE_URL="$DATABASE_URL_LOCAL" \
+  python scripts/autonomous_lab_worker.py --execute-verification --iterations 1
+```
+
+From Air-M5, use dry-run only:
+
+```bash
+python scripts/autonomous_lab_worker.py --dry-run
+```
+
+The worker intentionally does not create a worktree experiment, merge, deploy,
+push, write Google Workspace files, or start a persistent scheduler. H24
+scheduling remains gated by `scheduler_daemon`.
+
 ## Local Verification
 
 From the worktree:
@@ -75,7 +102,7 @@ cd apps/backend-rag
 source .venv/bin/activate
 PYTHONPATH=. pytest backend/tests/unit/services/autonomous_lab -q
 PYTHONPATH=. pytest backend/tests/migrations/test_migration_124_autonomous_lab_runtime.py -q
-ruff check backend/services/autonomous_lab backend/migrations/migration_124_autonomous_lab_runtime.py
+ruff check backend/services/autonomous_lab backend/migrations/migration_124_autonomous_lab_runtime.py ../../scripts/autonomous_lab_worker.py
 ```
 
 These checks are intentionally Air-safe: they use fake async connections and do

--- a/scripts/autonomous_lab_worker.py
+++ b/scripts/autonomous_lab_worker.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Run one bounded Pro-only Autonomous Lab worker tick."""
+# ruff: noqa: E402
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACKEND_ROOT = REPO_ROOT / "apps" / "backend-rag"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from backend.services.autonomous_lab import (
+    AutonomousLabStateStore,
+    LabWorkerConfig,
+    LabWorkerStatus,
+    current_runtime_placement,
+    default_worker_id,
+    run_worker_once,
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--database-url",
+        default=os.environ.get("DATABASE_URL"),
+        help="Postgres URL. Defaults to DATABASE_URL.",
+    )
+    parser.add_argument(
+        "--worker-id",
+        default=default_worker_id(),
+        help="Stable worker id used for owner-scoped run transitions.",
+    )
+    parser.add_argument(
+        "--execute-verification",
+        action="store_true",
+        help="Execute allowlisted verification commands. Required for DB mutation.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print placement/configuration only. Does not connect to Postgres.",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=1,
+        help="Number of bounded worker ticks to run. Default 1.",
+    )
+    parser.add_argument(
+        "--poll-interval-sec",
+        type=float,
+        default=5.0,
+        help="Sleep interval between idle iterations.",
+    )
+    parser.add_argument(
+        "--command-timeout-sec",
+        type=int,
+        default=120,
+        help="Per-command timeout for allowlisted verification commands.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    args = parse_args(argv)
+    try:
+        return asyncio.run(_main_async(args))
+    except KeyboardInterrupt:
+        _dump({"ok": False, "status": "interrupted"})
+        return 130
+    except Exception as exc:
+        _dump({"ok": False, "status": "crashed", "error_type": type(exc).__name__})
+        return 1
+
+
+async def _main_async(args: argparse.Namespace) -> int:
+    placement = current_runtime_placement()
+    base_payload: dict[str, Any] = {
+        "placement": placement.to_receipt(),
+        "worker_id": args.worker_id,
+        "execute_verification": bool(args.execute_verification),
+        "iterations": max(args.iterations, 1),
+    }
+    if args.dry_run:
+        _dump({"ok": True, "status": "dry_run", **base_payload})
+        return 0
+    if not placement.can_claim_runs:
+        _dump(
+            {
+                "ok": False,
+                "status": "placement_refused",
+                "reason": "Autonomous Lab run workers must execute on Pro runtime",
+                **base_payload,
+            }
+        )
+        return 2
+    if not args.execute_verification:
+        _dump(
+            {
+                "ok": False,
+                "status": "verification_disabled",
+                "reason": "--execute-verification is required for worker DB mutation",
+                **base_payload,
+            }
+        )
+        return 2
+    if not args.database_url:
+        _dump({"ok": False, "status": "missing_database_url", **base_payload})
+        return 2
+
+    asyncpg = _import_asyncpg()
+    conn = await asyncpg.connect(args.database_url)
+    results: list[dict[str, Any]] = []
+    try:
+        store = AutonomousLabStateStore()
+        config = LabWorkerConfig(
+            worker_id=args.worker_id,
+            repo_root=REPO_ROOT,
+            backend_root=BACKEND_ROOT,
+            execute_verification=True,
+            command_timeout_seconds=args.command_timeout_sec,
+        )
+        for index in range(max(args.iterations, 1)):
+            result = await run_worker_once(conn, config=config, store=store)
+            results.append(result.to_receipt())
+            if result.status != LabWorkerStatus.IDLE or index == args.iterations - 1:
+                continue
+            await asyncio.sleep(max(args.poll_interval_sec, 0.0))
+    finally:
+        await conn.close()
+
+    ok = all(result.get("ok") is True for result in results)
+    _dump({"ok": ok, "status": "complete" if ok else "failed", **base_payload, "results": results})
+    return _exit_code(results)
+
+
+def _import_asyncpg() -> Any:
+    try:
+        import asyncpg  # type: ignore
+
+        return asyncpg
+    except ImportError as exc:
+        raise RuntimeError(
+            "asyncpg not installed in active venv. Activate apps/backend-rag/.venv."
+        ) from exc
+
+
+def _exit_code(results: list[dict[str, Any]]) -> int:
+    statuses = {str(result.get("status")) for result in results}
+    if not results or statuses <= {LabWorkerStatus.IDLE.value, LabWorkerStatus.SUCCEEDED.value}:
+        return 0
+    if LabWorkerStatus.REFUSED.value in statuses:
+        return 3
+    if LabWorkerStatus.MARK_FAILED.value in statuses:
+        return 4
+    return 1
+
+
+def _dump(payload: dict[str, Any]) -> None:
+    json.dump(payload, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a bounded Pro-only Autonomous Lab worker that claims queued runs and executes only allowlisted verification commands without a shell
- add an Air/Pro placement-guarded CLI for dry-run and one-shot worker execution
- mark `verification_runner` as contracted and document the activation path while keeping the H24 scheduler gated
- refresh generated README and AI onboarding counters for the added service and test

## Tests
- `source .venv/bin/activate && ruff check backend/services/autonomous_lab backend/tests/unit/services/autonomous_lab/test_runtime_worker.py ../../scripts/autonomous_lab_worker.py`
- `source .venv/bin/activate && PYTHONPATH=. pytest backend/tests/unit/services/autonomous_lab -q`
- `source .venv/bin/activate && PYTHONPATH=. pytest backend/tests/migrations/test_migration_124_autonomous_lab_runtime.py -q`
- `source apps/backend-rag/.venv/bin/activate && python scripts/autonomous_lab_worker.py --dry-run`
- `source apps/backend-rag/.venv/bin/activate && python scripts/autonomous_lab_worker.py --execute-verification; test $? -eq 2`
- pre-commit hooks passed on the final amended commit
- pre-push broad Python suite was attempted: 14111 passed, 870 skipped, 3 failed, 138 errors from local Air `::1:5432` Postgres unavailability; hook continued and passed

## Runtime placement
- Air-M5 remains cockpit only
- Pro is the only machine allowed to claim and execute Lab runs
- no deploy, merge, push, worktree experiment, or scheduler daemon is enabled by this PR