### PR TITLE
feat(pages): add careers + press stub pages

### DIFF
--- a/apps/mouth/src/app/v2/company/careers/page.tsx
+++ b/apps/mouth/src/app/v2/company/careers/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from "next";
+import { NavShell } from "@balizero/core/components/NavShell";
+import { BZLogo } from "@balizero/core/components/BZLogo";
+import { Footer } from "../../_components/Footer";
+
+export const metadata: Metadata = {
+  title: "Careers — Bali Zero",
+  description:
+    "Join the team building the infrastructure for foreigners to thrive in Bali.",
+  robots: { index: false, follow: false },
+};
+
+export default function CareersPage() {
+  return (
+    <div
+      style={{
+        background: "var(--surface-base)",
+        color: "var(--text-primary)",
+        minHeight: "100vh",
+      }}
+    >
+      <NavShell
+        logo={<BZLogo variant="full" size={36} />}
+        items={[{ label: "Home", href: "/v2" }]}
+        actions={null}
+      />
+
+      <main className="max-w-3xl mx-auto px-6 md:px-10 pt-28 pb-20">
+        <div
+          className="text-[10px] font-semibold uppercase tracking-[0.2em] mb-4"
+          style={{ color: "var(--text-tertiary)" }}
+        >
+          Company · Careers
+        </div>
+
+        <h1
+          className="font-black tracking-tight mb-6"
+          style={{ fontSize: "clamp(28px, 4vw, 44px)", lineHeight: 1.1 }}
+        >
+          Work at Bali Zero
+        </h1>
+
+        <p
+          className="text-[17px] leading-relaxed mb-10"
+          style={{ color: "var(--text-secondary)" }}
+        >
+          We&apos;re building the infrastructure for foreigners to thrive in
+          Bali — visas, companies, tax, property. The team doing this work is
+          small, expert, and on fire. We&apos;ll post open roles here when the
+          time is right.
+        </p>
+
+        <div
+          className="rounded-lg px-6 py-5"
+          style={{
+            background: "var(--surface-raised)",
+            border: "1px solid var(--border-subtle)",
+          }}
+        >
+          <p
+            className="text-[13px] leading-relaxed"
+            style={{ color: "var(--text-tertiary)" }}
+          >
+            In the meantime — if you think you belong here, reach out directly
+            via WhatsApp. Tell us what you do and why Bali Zero.
+          </p>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/apps/mouth/src/app/v2/company/press/page.tsx
+++ b/apps/mouth/src/app/v2/company/press/page.tsx
@@ -1,0 +1,75 @@
+import type { Metadata } from "next";
+import { NavShell } from "@balizero/core/components/NavShell";
+import { BZLogo } from "@balizero/core/components/BZLogo";
+import { Footer } from "../../_components/Footer";
+
+export const metadata: Metadata = {
+  title: "Press — Bali Zero",
+  description:
+    "Media enquiries and press resources for Bali Zero — Indonesia's leading expat services firm.",
+  robots: { index: false, follow: false },
+};
+
+export default function PressPage() {
+  return (
+    <div
+      style={{
+        background: "var(--surface-base)",
+        color: "var(--text-primary)",
+        minHeight: "100vh",
+      }}
+    >
+      <NavShell
+        logo={<BZLogo variant="full" size={36} />}
+        items={[{ label: "Home", href: "/v2" }]}
+        actions={null}
+      />
+
+      <main className="max-w-3xl mx-auto px-6 md:px-10 pt-28 pb-20">
+        <div
+          className="text-[10px] font-semibold uppercase tracking-[0.2em] mb-4"
+          style={{ color: "var(--text-tertiary)" }}
+        >
+          Company · Press
+        </div>
+
+        <h1
+          className="font-black tracking-tight mb-6"
+          style={{ fontSize: "clamp(28px, 4vw, 44px)", lineHeight: 1.1 }}
+        >
+          Press &amp; Media
+        </h1>
+
+        <p
+          className="text-[17px] leading-relaxed mb-10"
+          style={{ color: "var(--text-secondary)" }}
+        >
+          If you&apos;re covering Indonesian visa law, foreign business
+          ownership, PT PMA, or the expat ecosystem in Bali — we&apos;re a
+          primary source. Antonello and the team are available for comment,
+          background, and on-record interviews.
+        </p>
+
+        <div
+          className="rounded-lg px-6 py-5"
+          style={{
+            background: "var(--surface-raised)",
+            border: "1px solid var(--border-subtle)",
+          }}
+        >
+          <p
+            className="text-[11px] font-semibold uppercase tracking-[0.15em] mb-2"
+            style={{ color: "var(--text-tertiary)" }}
+          >
+            Press enquiries
+          </p>
+          <p className="text-[15px]" style={{ color: "var(--text-secondary)" }}>
+            Reach us via WhatsApp or email — we respond within one business day.
+          </p>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Insight
Footer links /v2/company/careers and /v2/company/press were previously dead-ends (404). Two stub pages were created to eliminate broken links at B2B due-diligence touchpoints.

## Studio
apps/mouth only — 2 new files, zero packages/core touch.

## Source
UX Audit 8 Jun 2026 · PR #1205 footer fix · Antonello GO via Telegram 10 Jun 2026.

## Methodology
Layout identical to /v2/terms/page.tsx. robots noindex — stub, not ready for indexing.

## Raw Observations
Footer COMPANY array post-PR #1205 links to /v2/company/careers and /v2/company/press

Both routes do not yet exist → 404 for every visitor who clicks

## Reasoning Path
Stub pages with brand-aligned coming-soon copy are better than 404. robots noindex prevents premature indexing. Zero analytics change, zero new dependencies.

## Risk
LOW. 2 new files, apps/mouth only, no shared component changes.

## Implication
Footer credibility restored. Dead links eliminated.

## Recommendation
Self-merge after 9/9 CI is green.

## Next Action
Nav contrast fix → sancho/fix-nav-contrast (packages/core, requires Antonello review).