### PR TITLE
chore(mouth): safe-fix pair — dead funnel event + /tax legacy redirect

### DIFF
--- a/apps/mouth/next.config.ts
+++ b/apps/mouth/next.config.ts
@@ -233,6 +233,12 @@ const nextConfig: NextConfig = {
         destination: "/taxes/:slug*",
         permanent: true,
       },
+      { source: "/tax", destination: "/taxes", permanent: true },
+      {
+        source: "/tax/:slug*",
+        destination: "/taxes/:slug*",
+        permanent: true,
+      },
       { source: "/lifestyle", destination: "/living", permanent: true },
       {
         source: "/lifestyle/:slug*",

--- a/packages/core/analytics/funnel-view.ts
+++ b/packages/core/analytics/funnel-view.ts
@@ -32,7 +32,6 @@ export const FUNNEL_EVENTS = [
   "property_cta_clicked",
   "property_chat_question",
   "property_whatsapp_cta",
-  "property_cta_click",
   "property_consult_click",
   "property_search_submit",
   "property_suggestion_click",


### PR DESCRIPTION
## Lane: `ungated-safe-fix` (MYTHOS charter §6 — brand-neutral, non-structural pure wins)

Two atomic commits, both found during MYTHOS Phase 0 (PR #1256):

1. **`chore(analytics)`: remove dead `property_cta_click`** from `FUNNEL_EVENTS` (D5). Evidence: zero call sites in `apps/mouth` (all property CTAs fire `property_cta_clicked` — `analytics.ts:413/430/437`); the backend allowlist (`routers/analytics.py` `ALLOWED_EVENTS`) never accepted it, so any firing client was already silently dropped. `tsc --noEmit` green = proof of no hidden consumer.

2. **`fix(seo)`: 308 `/tax` + `/tax/:slug*` → `/taxes/*`**. The blog category map normalizes `tax→taxes` at render, so `/tax/<slug>` serves duplicate content with 200 (verified live: `/tax/indonesia-umkm-tax-reforms-pp-20-2026` → 200; GA4 shows real sessions). Every other legacy alias (lifestyle/tech/tax-legal/bali_news/digital-nomad/immigration) already has this redirect — `tax` was the only one missing. `/tax-calendar` is a distinct path segment, unaffected.

**Explicitly NOT in this PR** (bigger blast radius, queued with tests in Stage-B B1): D11 — backend accepts only 11/32 funnel events (dashboard blind to 21); D12 — soft-404: any garbage slug under any category renders 200 (needs `notFound()` + dedicated Playwright guard).

cc @Subhi — your perimeter; shout if `d1-funnel-tracking` (orphan branch, no merge base) overlaps anything here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)