### PR TITLE
fix(mouth): de-index phantom article pages — notFound() on missing slug (MYTHOS D12)

### DIFF
--- a/apps/mouth/e2e/article-404.spec.ts
+++ b/apps/mouth/e2e/article-404.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect, type APIRequestContext } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * D12 soft-404 guard (MYTHOS B1).
+ *
+ * Before the fix, /[category]/[slug] rendered a phantom article page for ANY
+ * garbage slug — the slug title-cased into <title>, indexable, an infinite
+ * crawlable thin-content surface.
+ *
+ * After the fix the page (and its generateMetadata) call notFound().
+ *
+ * NOTE on status codes: this route streams (loading.tsx boundaries exist in
+ * the (blog), [category] and [slug] segments), so the HTTP status is
+ * committed as 200 BEFORE any page code runs — a true 404 status is
+ * architecturally unavailable here. Verified empirically 2026-06-10: even the
+ * long-standing isStaticFilePath notFound() returns 200 on this route. What
+ * Next.js guarantees instead: the streamed payload carries
+ * <meta name="robots" content="noindex"> plus the 404 boundary UI, which
+ * keeps phantom URLs out of search indexes. These tests pin that contract,
+ * and also accept a true 404 status (if the streaming topology ever changes,
+ * they must not break).
+ *
+ * The describe title contains "page Page" so the CI E2E job
+ * (--grep "page Page" in .github/workflows/tests.yml) actually runs it.
+ */
+
+const ARTICLES_DIR = path.join(__dirname, "..", "src", "content", "articles");
+
+function firstMdxSlug(folder: string): string | null {
+  const dir = path.join(ARTICLES_DIR, folder);
+  if (!fs.existsSync(dir)) return null;
+  // Real article files only: non-empty kebab slug + ".mdx". Excludes locale
+  // variants (slug.id.mdx) and degenerate strays (a literal ".mdx" exists).
+  const file = fs
+    .readdirSync(dir)
+    .sort()
+    .find((f) => /^[a-z0-9][a-z0-9-]*\.mdx$/i.test(f));
+  return file ? file.replace(/\.mdx$/, "") : null;
+}
+
+/**
+ * A nonexistent article URL must never be an indexable phantom page:
+ * either a true HTTP 404, or a streamed 200 carrying a noindex robots meta
+ * and no fabricated title derived from the slug.
+ */
+async function expectNotIndexablePhantom(
+  request: APIRequestContext,
+  url: string,
+  phantomTitleFragment: string,
+): Promise<void> {
+  const response = await request.get(url, { timeout: 90_000 });
+  const status = response.status();
+
+  if (status === 404) return; // true 404 — strictly better, accept
+
+  expect(status).toBe(200);
+  const body = await response.text();
+  expect(body).toContain('name="robots" content="noindex"');
+  expect(body).not.toContain(phantomTitleFragment);
+}
+
+test.describe("article 404 page Page", () => {
+  test.describe.configure({ timeout: 120_000 });
+
+  test("unknown slug under a real category is not an indexable phantom", async ({
+    request,
+  }) => {
+    await expectNotIndexablePhantom(
+      request,
+      "/taxes/totally-nonexistent-slug-xyz-9999",
+      // the old soft-404 fabricated this via title-casing the slug
+      "Totally Nonexistent",
+    );
+  });
+
+  test("unknown slug under an unknown category is not an indexable phantom", async ({
+    request,
+  }) => {
+    await expectNotIndexablePhantom(
+      request,
+      "/foobar/this-page-does-not-exist-42",
+      "This Page Does Not Exist",
+    );
+  });
+
+  test("real article still renders with 200 and no noindex", async ({
+    request,
+  }) => {
+    const slug = firstMdxSlug("immigration");
+    test.skip(!slug, "no immigration MDX articles on disk");
+
+    const response = await request.get(`/visas/${slug}`, { timeout: 90_000 });
+    expect(response.status()).toBe(200);
+
+    const body = await response.text();
+    expect(body).not.toContain('name="robots" content="noindex"');
+  });
+});

--- a/apps/mouth/src/app/(blog)/[category]/[slug]/page.tsx
+++ b/apps/mouth/src/app/(blog)/[category]/[slug]/page.tsx
@@ -99,13 +99,18 @@ export async function generateMetadata({
       {},
       err instanceof Error ? err : new Error(String(err)),
     );
+
+    // Genuine lookup error (distinct from "article missing"): keep the page
+    // renderable but never indexable under invented metadata.
+    return {
+      title: "Bali Zero",
+      robots: { index: false, follow: false },
+    };
   }
 
-  // Fallback metadata
-  return {
-    title: `${slug.replace(/-/g, " ").replace(/\b\w/g, (l) => l.toUpperCase())} | Bali Zero`,
-    description: `Learn about ${slug.replace(/-/g, " ")} in Indonesia. Expert guides from Bali Zero.`,
-  };
+  // Article does not exist: render the 404 boundary. Title-casing the slug
+  // here used to fabricate a phantom 200 page for ANY url (soft-404, D12).
+  notFound();
 }
 
 // Category labels for breadcrumbs
@@ -147,6 +152,13 @@ export default async function ArticlePage({ params, searchParams }: PageProps) {
   const article = lang
     ? await getArticleByLocale(category, slug, lang)
     : await getArticleBySlug(category, slug);
+
+  // No article in backend NOR local MDX: hard 404 (D12 soft-404 fix).
+  // getArticleBySlug/getArticleByLocale return null both for "not found";
+  // backend outages degrade to the MDX-on-disk fallback before reaching here.
+  if (!article) {
+    notFound();
+  }
 
   const breadcrumbItems = [
     { name: "Home", url: "/" },


### PR DESCRIPTION
## What

Closes MYTHOS defect **D12** (soft-404): any garbage slug under `/[category]/[slug]` rendered an HTTP 200 page with a **phantom title fabricated by title-casing the slug** (`generateMetadata` fallback) — an infinite, crawlable, *indexable* thin-content surface. Verified live pre-fix: `/tax/anything-test` → 200, `/taxes/totally-nonexistent-slug-xyz-9999` → 200 with invented metadata.

## Changes (2 files)

- `apps/mouth/src/app/(blog)/[category]/[slug]/page.tsx`
  - `ArticlePage`: hard `notFound()` when the article resolves null. Both fetchers return null only when backend **and** local-MDX miss; backend outages degrade to MDX-on-disk before reaching the guard (no false 404s on outage — verified in `articles.ts` fetcher semantics).
  - `generateMetadata`: `notFound()` instead of fabricating slug-derived metadata. Genuine lookup errors (near-impossible: fetchers swallow internally) return minimal `noindex` metadata.
- `apps/mouth/e2e/article-404.spec.ts` (new Playwright guard) — describe title contains `page Page` so the CI `--grep "page Page"` filter **actually runs it** in the required E2E check (esistere ≠ armato).

## Status-code caveat (important, empirically verified)

This route **streams** (`loading.tsx` boundaries in `(blog)`, `[category]` and `[slug]` segments), so the HTTP status is committed as 200 **before any page code runs**. A true 404 status is architecturally unavailable here — proven by the discriminating experiment: even the long-standing `isStaticFilePath` `notFound()` (pre-existing code) returns 200 on this route. An `htmlLimitedBots` blocking-metadata experiment also did not change the status (tried, reverted — Law 7, no demonstrated benefit).

The **enforceable contract** (what Next.js guarantees and the guard pins):
- garbage slug → streamed payload carries `<meta name="robots" content="noindex">` + the 404 boundary UI, and **never** the phantom title → search engines drop/never index these URLs;
- real article → 200, real title, **no** noindex.

A true-404 would require removing the whole `loading.tsx` chain for the blog group (UX regression on every blog page) or `dynamicParams=false` (breaks the approve→deploy publish window). Both rejected; documented in the spec header for future readers.

## Verification (all empirical, local dev server on the branch)

| Check | Result |
|---|---|
| `/taxes/totally-nonexistent-slug-xyz-9999` | noindex meta + 404 UI, no phantom title ✅ |
| `/foobar/this-page-does-not-exist-42` (garbage category too) | noindex meta + 404 UI ✅ |
| Real article `/visas/10-bandara-…` | 200, real `<title>`, zero noindex ✅ |
| `tsc --noEmit` | exit 0, zero errors ✅ |
| `npx playwright test e2e/article-404.spec.ts --project=chromium` | **3/3 passed** ✅ |

## §6 enforceable checks

- **Route-inventory diff**: zero routes added/removed — behavior-only change inside the existing `[category]/[slug]` route.
- **Playwright guard**: new spec runs in the required `E2E Tests (Playwright)` check (title matches the CI grep).
- **Rollback**: single revert of this commit restores prior behavior; no data, config, or schema touched.

## Side-findings (not fixed here, for the ledger)

1. `apps/mouth/src/content/articles/immigration/` contains degenerate stray files literally named `.mdx` and `.id.mdx` (empty slug) — junk from some pipeline; harmless but should be cleaned.
2. The category-alias duplicate surface remains: a real slug renders under ANY category path (backend fetch ignores the category segment); mitigated by the canonical tag pointing at `article.category`. Candidate for a later redirect-to-canonical-category pass.

Part of MYTHOS Round 1, Stage B / B1 measurement foundation (Phase-0 ground-state + Stage-A decision pack: PR #1256).

🤖 Generated with [Claude Code](https://claude.com/claude-code)