### PR TITLE
fix(analytics): accept all 32 funnel-view events + cross-stack parity guard (MYTHOS D11)

### DIFF
--- a/apps/backend-rag/backend/app/routers/analytics.py
+++ b/apps/backend-rag/backend/app/routers/analytics.py
@@ -3,7 +3,7 @@ Analytics API Router
 Exposes historical analytics endpoints and unified dashboard for founder consumption.
 
 Endpoints:
-- POST /api/analytics/funnel-event           - Ingest funnel event (public, 11 whitelisted events)
+- POST /api/analytics/funnel-event           - Ingest funnel event (public, allowlisted — parity with funnel-view.ts)
 - GET /api/analytics/dashboard               - Unified analytics dashboard (cached)
 - GET /api/analytics/completion-rates
 - GET /api/analytics/response-times
@@ -41,22 +41,51 @@ router = APIRouter(prefix="/api/analytics", tags=["analytics"])
 # F-19: Funnel event ingest (public — no auth required)
 # ---------------------------------------------------------------------------
 
+# Kept in strict parity with packages/core/analytics/funnel-view.ts
+# (FUNNEL_EVENTS) — enforced by tests/app/routers/test_analytics_funnel_parity.py.
+# MYTHOS D11: this list used to cover 14 of the 32 emitted events; the other
+# 18 were silently dropped with {"ok": False, "reason": "unknown_event"}.
 ALLOWED_EVENTS: frozenset[str] = frozenset(
     {
+        # --- Visa Oracle ---
         "visa_quiz_completed",
         "visa_result_viewed",
         "visa_chat_question",
         "visa_whatsapp_cta",
         "visa_calling_block",
+        # --- Home CTAs ---
+        "home_whatsapp_cta",
+        # --- Funnel home-block CTAs ---
+        "visa_cta_click",
+        "visa_consult_click",
+        "visa_search_submit",
+        "visa_suggestion_click",
+        # --- KBLI Navigator ---
         "kbli_code_viewed",
         "kbli_search",
         "kbli_chat_question",
         "kbli_whatsapp_cta",
+        "kbli_cta_click",
+        "kbli_consult_click",
+        "kbli_search_submit",
+        "kbli_suggestion_click",
+        # --- Tax Intelligence ---
         "tax_dashboard_viewed",
         "tax_whatsapp_cta",
+        "tax_cta_click",
+        "tax_consult_click",
+        "tax_search_submit",
+        "tax_suggestion_click",
+        # --- Property Map ---
         "property_cta_clicked",
         "property_chat_question",
         "property_whatsapp_cta",
+        "property_consult_click",
+        "property_search_submit",
+        "property_suggestion_click",
+        # --- Hero Section CTAs ---
+        "hero_cta_book_call",
+        "hero_cta_read_dispatch",
     }
 )
 

--- a/apps/backend-rag/backend/tests/app/routers/test_analytics.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_analytics.py
@@ -92,25 +92,19 @@ async def test_funnel_event_rejects_short_session_id() -> None:
 
 
 @pytest.mark.asyncio
-async def test_funnel_event_all_eleven_allowed() -> None:
-    """Verify all 11 whitelisted events are accepted."""
+async def test_funnel_event_every_allowlisted_event_accepted() -> None:
+    """Every event in ALLOWED_EVENTS is accepted end-to-end.
+
+    Driven directly off the router's allowlist (not a hardcoded copy) so it
+    cannot drift; cross-stack parity with funnel-view.ts is enforced by
+    test_analytics_funnel_parity.py.
+    """
+    from backend.app.routers.analytics import ALLOWED_EVENTS
+
     app = make_app()
-    allowed = [
-        "visa_quiz_completed",
-        "visa_result_viewed",
-        "visa_chat_question",
-        "visa_whatsapp_cta",
-        "visa_calling_block",
-        "kbli_code_viewed",
-        "kbli_search",
-        "kbli_chat_question",
-        "tax_dashboard_viewed",
-        "property_cta_clicked",
-        "property_chat_question",
-    ]
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
-        for event in allowed:
+        for event in sorted(ALLOWED_EVENTS):
             r = await c.post(
                 "/api/analytics/funnel-event",
                 json={

--- a/apps/backend-rag/backend/tests/app/routers/test_analytics_funnel_parity.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_analytics_funnel_parity.py
@@ -1,0 +1,61 @@
+"""Cross-stack parity guard: ALLOWED_EVENTS == FUNNEL_EVENTS (funnel-view.ts).
+
+MYTHOS defect D11: the backend allowlist covered 14 of the 32 events emitted
+by packages/core/analytics/funnel-view.ts — the other 18 were silently dropped
+({"ok": False, "reason": "unknown_event"}), so most funnel CTAs never reached
+funnel_sessions. This test pins set EQUALITY in both directions: any event
+added or removed on one side without the other fails CI.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from backend.app.routers.analytics import ALLOWED_EVENTS
+
+
+def _repo_root() -> Path:
+    """Walk up from this file until the monorepo root (has packages/core)."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "packages" / "core").is_dir():
+            return parent
+    raise AssertionError(f"monorepo root with packages/core not found above {here}")
+
+
+FUNNEL_VIEW_TS = _repo_root() / "packages" / "core" / "analytics" / "funnel-view.ts"
+
+
+def _frontend_events() -> list[str]:
+    source = FUNNEL_VIEW_TS.read_text(encoding="utf-8")
+    match = re.search(
+        r"export const FUNNEL_EVENTS\s*=\s*\[(.*?)\]\s*as const",
+        source,
+        re.DOTALL,
+    )
+    assert match, f"FUNNEL_EVENTS array not found in {FUNNEL_VIEW_TS}"
+    return re.findall(r'"([a-z0-9_]+)"', match.group(1))
+
+
+def test_funnel_view_ts_exists() -> None:
+    assert FUNNEL_VIEW_TS.is_file(), f"missing {FUNNEL_VIEW_TS}"
+
+
+def test_frontend_has_no_duplicate_events() -> None:
+    events = _frontend_events()
+    assert len(events) == len(set(events)), "duplicate entries in FUNNEL_EVENTS"
+
+
+def test_backend_allowlist_matches_frontend_funnel_events() -> None:
+    frontend = set(_frontend_events())
+    missing_in_backend = frontend - ALLOWED_EVENTS
+    stale_in_backend = ALLOWED_EVENTS - frontend
+    assert not missing_in_backend, (
+        "events emitted by funnel-view.ts but DROPPED by the backend "
+        f"allowlist: {sorted(missing_in_backend)}"
+    )
+    assert not stale_in_backend, (
+        "events accepted by the backend but no longer emitted by "
+        f"funnel-view.ts: {sorted(stale_in_backend)}"
+    )

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`324 routers · 605 services · 1023 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`324 routers · 605 services · 1024 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## What

Closes MYTHOS defect **D11**: the public funnel-event ingest (`POST /api/analytics/funnel-event`) allowlisted only **14 of the 32 events** emitted by `packages/core/analytics/funnel-view.ts`. The other 18 — `home_whatsapp_cta`, all sixteen funnel home-block CTAs (`*_cta_click`, `*_consult_click`, `*_search_submit`, `*_suggestion_click`), `hero_cta_book_call`, `hero_cta_read_dispatch` — were silently dropped with `{"ok": False, "reason": "unknown_event"}` (no 4xx, no client-side error). Most public-funnel CTA signal never reached `funnel_sessions`: the measurement foundation for balizero.com was structurally blind on home/hero/CTA interactions.

Three layers of drift, zero enforcement: the module docstring claimed "11 whitelisted events", the frozenset held 14, the frontend emitted 32 — and a test (`test_funnel_event_all_eleven_allowed`) pinned a hardcoded copy of the stale 11.

## Changes (3 files)

- `backend/app/routers/analytics.py` — `ALLOWED_EVENTS` is now the full 32-event set, grouped to mirror `funnel-view.ts`; docstring fixed.
- `backend/tests/app/routers/test_analytics_funnel_parity.py` (**new, the antibody**) — parses `FUNNEL_EVENTS` out of `funnel-view.ts` and pins **set equality in both directions**: an event added on the frontend without backend acceptance fails CI (drop detection), and a stale backend event no longer emitted fails CI too. Esistere ≠ armato: the guard runs inside the required `Backend Tests (Python)` check, no path-filter.
- `backend/tests/app/routers/test_analytics.py` — the drift-prone hardcoded 11-event test replaced by a loop driven directly off `ALLOWED_EVENTS`.

## Verification

- 7/7 targeted tests green (4 router + 3 parity) against the real venv.
- Full pre-commit backend suite green (commit hook, exit 0).
- No schema change, no endpoint change, no auth change — the ingest path and its "never block UX" contract are untouched; previously-dropped events now follow the existing UPDATE path.

## Known residual (documented, out of scope)

**Accepted ≠ persisted**: the ingest is an `UPDATE funnel_sessions ...` — it writes only if a `funnel_sessions` row exists for the `session_id` (created by the funnel router's upsert). Whether the homepage/hero surfaces bootstrap a funnel session is a separate frontend wiring check, queued in the MYTHOS B1 ledger. This PR fixes the first gate (acceptance); the session-bootstrap audit is the second.

## Rollback

Single revert — additive allowlist + tests only.

Part of MYTHOS Round 1, Stage B / B1 measurement foundation (Phase-0: PR #1256 · D12: PR #1260, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)