### PR TITLE
fix(tokens): nav text-tertiary 0.65 → 0.80 WCAG AA 4.5:1 compliant

### DIFF
--- a/packages/core/tokens/themes/editorial.css
+++ b/packages/core/tokens/themes/editorial.css
@@ -28,7 +28,7 @@
 
   --text-primary: rgba(255, 255, 255, 0.96);
   --text-secondary: rgba(255, 255, 255, 0.68);
-  --text-tertiary: rgba(255, 255, 255, 0.65);
+  --text-tertiary: rgba(255, 255, 255, 0.80);
   --text-on-accent: #ffffff;
 
   --border-subtle: rgba(255, 255, 255, 0.06);


### PR DESCRIPTION
Follow-up to #1257. WCAG AA requires minimum 4.5:1 contrast ratio — 0.80 meets the threshold, 0.65 does not. Single token change. packages/core — needs Antonello review.