### PR TITLE
feat(analytics): MYTHOS B1 measurement foundation — cross-stack parity, book_*/app_* reconcile, hostname capture, PII scrub

### DIFF
--- a/apps/backend-rag/backend/app/routers/analytics.py
+++ b/apps/backend-rag/backend/app/routers/analytics.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import time
 from datetime import date, datetime, timedelta, timezone
 from typing import Any
@@ -42,10 +43,14 @@ router = APIRouter(prefix="/api/analytics", tags=["analytics"])
 # ---------------------------------------------------------------------------
 
 # Kept in strict parity with packages/core/analytics/funnel-view.ts
-# (FUNNEL_EVENTS) — enforced by tests/app/routers/test_analytics_funnel_parity.py.
+# (FUNNEL_EVENTS) and packages/core/analytics/funnel-app.ts (APP_EVENTS) —
+# ALLOWED_EVENTS == FUNNEL_EVENTS ∪ APP_EVENTS, enforced bidirectionally by
+# tests/app/routers/test_analytics_funnel_parity.py.
 # MYTHOS D11: this list used to cover 14 of the 32 emitted events; the other
 # 18 were silently dropped with {"ok": False, "reason": "unknown_event"}.
-ALLOWED_EVENTS: frozenset[str] = frozenset(
+# MYTHOS B1 (IA-8): book_* scaffolding (the /book flow ships in B4) + the
+# app_* tool-funnel taxonomy reconciled into the single backend allowlist.
+FUNNEL_PAGE_EVENTS: frozenset[str] = frozenset(
     {
         # --- Visa Oracle ---
         "visa_quiz_completed",
@@ -77,6 +82,8 @@ ALLOWED_EVENTS: frozenset[str] = frozenset(
         "tax_search_submit",
         "tax_suggestion_click",
         # --- Property Map ---
+        # MYTHOS D5: "property_cta_clicked" is the single canonical property
+        # CTA-click event; there is deliberately NO "property_cta_click".
         "property_cta_clicked",
         "property_chat_question",
         "property_whatsapp_cta",
@@ -86,14 +93,76 @@ ALLOWED_EVENTS: frozenset[str] = frozenset(
         # --- Hero Section CTAs ---
         "hero_cta_book_call",
         "hero_cta_read_dispatch",
+        # --- Booked Consultation (MYTHOS IA-3 scaffolding, emission in B4) ---
+        "book_viewed",
+        "book_form_started",
+        "book_form_submitted",
+        "book_call_confirmed",
     }
 )
+
+FUNNEL_APP_EVENTS: frozenset[str] = frozenset(
+    {
+        "app_viewed",
+        "app_branch_selected",
+        "app_form_started",
+        "app_form_submitted",
+        "app_wizard_step_completed",
+        "app_wizard_abandoned",
+        "app_result_viewed",
+        "app_cta_clicked",
+        "app_whatsapp_handoff",
+        "app_share_clicked",
+        "app_pdf_downloaded",
+        "app_email_subscribed",
+    }
+)
+
+ALLOWED_EVENTS: frozenset[str] = FUNNEL_PAGE_EVENTS | FUNNEL_APP_EVENTS
+
+# ---------------------------------------------------------------------------
+# MYTHOS §6 guardrail: PII scrub on funnel payloads before storage.
+# Scrub, don't drop — fail-safe for data, fail-closed for PII.
+# ---------------------------------------------------------------------------
+
+_PII_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+# Phone-like: optional +, digit, 6+ of digits/spaces/().-, ending on a digit
+# (e.g. "+62 812 3456 7890") — anchoring the end on a digit keeps trailing
+# whitespace/punctuation out of the redaction.
+_PII_PHONE_RE = re.compile(r"\+?\d[\d\s().-]{6,}\d")
+_PII_REDACTED = "[redacted]"
+
+
+def _scrub_pii_string(value: str) -> str:
+    """Redact email and phone-like substrings; leave the rest intact."""
+    # Email first: an address's digit run could otherwise partially match the
+    # phone pattern and leave a recognizable fragment behind.
+    value = _PII_EMAIL_RE.sub(_PII_REDACTED, value)
+    return _PII_PHONE_RE.sub(_PII_REDACTED, value)
+
+
+def scrub_pii(value: Any) -> Any:
+    """Recursively scrub PII (emails, phone-like numbers) from payload values.
+
+    Strings are scrubbed in place (substring redaction, not dropped);
+    dicts/lists are walked; every other type passes through unchanged.
+    """
+    if isinstance(value, str):
+        return _scrub_pii_string(value)
+    if isinstance(value, dict):
+        return {k: scrub_pii(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [scrub_pii(v) for v in value]
+    return value
 
 
 class FunnelEvent(BaseModel):
     session_id: str = Field(min_length=32, max_length=64)
     event: str
-    payload: dict = Field(default_factory=dict)
+    payload: dict[str, Any] = Field(default_factory=dict)
+    # MYTHOS D3/D9 foundation: emitting hostname (window.location.hostname),
+    # so denominators can be scoped to public hostnames (B2 reads this).
+    hostname: str | None = Field(default=None, max_length=253)
 
 
 @router.post("/funnel-event")
@@ -103,23 +172,29 @@ async def ingest_funnel_event(
 ) -> dict[str, Any]:
     """
     Ingest a funnel analytics event. Never blocks the UX: unknown events
-    return ok=False instead of raising an error.
+    return ok=False instead of raising an error. Payload values are
+    PII-scrubbed (MYTHOS §6 guardrail) before storage.
     """
     if req.event not in ALLOWED_EVENTS:
         return {"ok": False, "reason": "unknown_event"}
+    scrubbed_payload = scrub_pii(req.payload)
     async with pool.acquire() as conn:
         await conn.execute(
             """
             UPDATE funnel_sessions
             SET step_state = step_state || jsonb_build_object(
                     'last_event', $2::text,
-                    'last_event_at', to_jsonb(NOW())
+                    'last_event_at', to_jsonb(NOW()),
+                    'last_event_payload', $3::jsonb,
+                    'last_hostname', $4::text
                 ),
                 last_touched_at = NOW()
             WHERE session_id = $1
             """,
             req.session_id,
             req.event,
+            json.dumps(scrubbed_payload),
+            req.hostname,
         )
     return {"ok": True}
 

--- a/apps/backend-rag/backend/tests/app/routers/test_analytics.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_analytics.py
@@ -1,7 +1,14 @@
-"""Tests for /api/analytics/funnel-event (F-19)."""
+"""Tests for /api/analytics/funnel-event (F-19 + MYTHOS B1).
+
+Covers: allowlist acceptance/rejection (data-driven off ALLOWED_EVENTS),
+session-id validation, hostname capture (D3/D9 foundation) and the §6
+PII-scrub guardrail (payload values redacted before storage).
+"""
 
 from __future__ import annotations
 
+import json
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -9,11 +16,17 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from backend.app.deps.database import get_database_pool
-from backend.app.routers.analytics import router
+from backend.app.routers.analytics import router, scrub_pii
+
+SESSION_ID = "55555555-5555-5555-8555-555555555555"
 
 
-def make_app() -> FastAPI:
-    """Build a minimal FastAPI app with a mocked DB pool — no real DB required."""
+def make_app() -> tuple[FastAPI, AsyncMock]:
+    """Build a minimal FastAPI app with a mocked DB pool — no real DB required.
+
+    Returns the app AND the mocked connection so tests can assert on what
+    actually gets persisted (PII scrub, hostname).
+    """
     app = FastAPI()
     app.include_router(router)
 
@@ -29,66 +42,68 @@ def make_app() -> FastAPI:
     mock_pool = MagicMock()
     mock_pool.acquire = MagicMock(return_value=mock_cm)
 
-    async def fake_pool():
+    async def fake_pool() -> MagicMock:
         return mock_pool
 
     app.dependency_overrides[get_database_pool] = fake_pool
-    return app
+    return app, mock_conn
+
+
+async def _post_event(
+    app: FastAPI, body: dict[str, Any]
+) -> tuple[int, dict[str, Any]]:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.post("/api/analytics/funnel-event", json=body)
+        return r.status_code, r.json()
 
 
 @pytest.mark.asyncio
 async def test_funnel_event_whitelisted() -> None:
     """Whitelisted event is accepted and returns ok=True."""
-    app = make_app()
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as c:
-        r = await c.post(
-            "/api/analytics/funnel-event",
-            json={
-                "session_id": "33333333-3333-4333-8333-333333333333",
-                "event": "kbli_code_viewed",
-                "payload": {"code": "47111"},
-            },
-        )
-        assert r.status_code == 200, r.text
-        assert r.json()["ok"] is True
+    app, _ = make_app()
+    status, payload = await _post_event(
+        app,
+        {
+            "session_id": "33333333-3333-4333-8333-333333333333",
+            "event": "kbli_code_viewed",
+            "payload": {"code": "47111"},
+        },
+    )
+    assert status == 200
+    assert payload["ok"] is True
 
 
 @pytest.mark.asyncio
 async def test_funnel_event_unknown_rejected() -> None:
     """Unknown event returns ok=False (not 422) — analytics never blocks UX."""
-    app = make_app()
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as c:
-        r = await c.post(
-            "/api/analytics/funnel-event",
-            json={
-                "session_id": "44444444-4444-4444-8444-444444444444",
-                "event": "not_in_whitelist",
-                "payload": {},
-            },
-        )
-        # Controller + implementer spec: unknown event returns ok=False
-        # (not 422) — so analytics "never blocks UX".
-        assert r.status_code == 200
-        assert r.json().get("ok") is False
+    app, mock_conn = make_app()
+    status, payload = await _post_event(
+        app,
+        {
+            "session_id": "44444444-4444-4444-8444-444444444444",
+            "event": "not_in_whitelist",
+            "payload": {},
+        },
+    )
+    # Controller + implementer spec: unknown event returns ok=False
+    # (not 422) — so analytics "never blocks UX".
+    assert status == 200
+    assert payload.get("ok") is False
+    # Fail-closed: nothing reaches storage for an unknown event,
+    # even if the payload contained PII.
+    mock_conn.execute.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_funnel_event_rejects_short_session_id() -> None:
     """Pydantic validation: session_id shorter than 32 chars → 422."""
-    app = make_app()
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as c:
-        r = await c.post(
-            "/api/analytics/funnel-event",
-            json={
-                "session_id": "tooshort",
-                "event": "kbli_search",
-                "payload": {},
-            },
-        )
-        assert r.status_code == 422
+    app, _ = make_app()
+    status, _ = await _post_event(
+        app,
+        {"session_id": "tooshort", "event": "kbli_search", "payload": {}},
+    )
+    assert status == 422
 
 
 @pytest.mark.asyncio
@@ -96,22 +111,122 @@ async def test_funnel_event_every_allowlisted_event_accepted() -> None:
     """Every event in ALLOWED_EVENTS is accepted end-to-end.
 
     Driven directly off the router's allowlist (not a hardcoded copy) so it
-    cannot drift; cross-stack parity with funnel-view.ts is enforced by
-    test_analytics_funnel_parity.py.
+    cannot drift; cross-stack parity with funnel-view.ts + funnel-app.ts is
+    enforced by test_analytics_funnel_parity.py.
     """
     from backend.app.routers.analytics import ALLOWED_EVENTS
 
-    app = make_app()
+    app, _ = make_app()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         for event in sorted(ALLOWED_EVENTS):
             r = await c.post(
                 "/api/analytics/funnel-event",
-                json={
-                    "session_id": "55555555-5555-5555-8555-555555555555",
-                    "event": event,
-                    "payload": {},
-                },
+                json={"session_id": SESSION_ID, "event": event, "payload": {}},
             )
             assert r.status_code == 200, f"Event {event!r} failed: {r.text}"
             assert r.json()["ok"] is True, f"Event {event!r} returned ok=False"
+
+
+# ---------------------------------------------------------------------------
+# MYTHOS D3/D9 foundation: hostname capture
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_funnel_event_persists_hostname() -> None:
+    """The emitting hostname is accepted and passed through to storage."""
+    app, mock_conn = make_app()
+    status, payload = await _post_event(
+        app,
+        {
+            "session_id": SESSION_ID,
+            "event": "visa_quiz_completed",
+            "payload": {"purpose": "business"},
+            "hostname": "balizero.com",
+        },
+    )
+    assert status == 200
+    assert payload["ok"] is True
+    mock_conn.execute.assert_awaited_once()
+    args = mock_conn.execute.await_args.args
+    # Positional SQL params: ($1 session_id, $2 event, $3 payload, $4 hostname)
+    assert args[1] == SESSION_ID
+    assert args[2] == "visa_quiz_completed"
+    assert args[4] == "balizero.com"
+
+
+@pytest.mark.asyncio
+async def test_funnel_event_hostname_optional() -> None:
+    """Events without a hostname (SSR / legacy emitters) are still accepted."""
+    app, mock_conn = make_app()
+    status, payload = await _post_event(
+        app,
+        {"session_id": SESSION_ID, "event": "kbli_search", "payload": {}},
+    )
+    assert status == 200
+    assert payload["ok"] is True
+    args = mock_conn.execute.await_args.args
+    assert args[4] is None
+
+
+# ---------------------------------------------------------------------------
+# MYTHOS §6 guardrail: PII scrub (scrub, don't drop)
+# ---------------------------------------------------------------------------
+
+
+def test_scrub_pii_redacts_email_and_phone() -> None:
+    """Email + phone-like values are redacted; surrounding text survives."""
+    payload = {
+        "note": "reach me at fake_user@example.com please",
+        "phone": "+62 812 3456 7890",
+        "nested": {"messages": ["call +1 (555) 123-4567 tomorrow"]},
+    }
+    out = scrub_pii(payload)
+    assert out["note"] == "reach me at [redacted] please"
+    assert out["phone"] == "[redacted]"
+    assert out["nested"]["messages"][0] == "call [redacted] tomorrow"
+    dumped = json.dumps(out)
+    assert "fake_user@example.com" not in dumped
+    assert "3456" not in dumped
+
+
+def test_scrub_pii_leaves_clean_payload_unchanged() -> None:
+    """Non-PII strings, numbers, bools and short codes pass through intact."""
+    payload = {
+        "kbli_code": "47111",
+        "top_visa": "C1 Tourism",
+        "note": "leasehold 25 years",
+        "visa_count": 3,
+        "lat": -8.65,
+        "active": True,
+        "none": None,
+    }
+    assert scrub_pii(payload) == payload
+
+
+@pytest.mark.asyncio
+async def test_funnel_event_payload_pii_scrubbed_before_storage() -> None:
+    """A payload arriving with email/phone is STORED redacted (scrub ≠ drop)."""
+    app, mock_conn = make_app()
+    status, payload = await _post_event(
+        app,
+        {
+            "session_id": SESSION_ID,
+            "event": "visa_whatsapp_cta",
+            "payload": {
+                "action": "clicked",
+                "contact": "fake_user@example.com",
+                "phone": "+62 812 3456 7890",
+            },
+        },
+    )
+    assert status == 200
+    assert payload["ok"] is True
+    args = mock_conn.execute.await_args.args
+    stored = json.loads(args[3])
+    # Scrubbed, not dropped: keys survive, PII values are redacted.
+    assert stored["action"] == "clicked"
+    assert stored["contact"] == "[redacted]"
+    assert stored["phone"] == "[redacted]"
+    assert "fake_user@example.com" not in args[3]

--- a/apps/backend-rag/backend/tests/app/routers/test_analytics_funnel_parity.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_analytics_funnel_parity.py
@@ -1,10 +1,15 @@
-"""Cross-stack parity guard: ALLOWED_EVENTS == FUNNEL_EVENTS (funnel-view.ts).
+"""Cross-stack parity guard: ALLOWED_EVENTS == FUNNEL_EVENTS ∪ APP_EVENTS.
 
 MYTHOS defect D11: the backend allowlist covered 14 of the 32 events emitted
 by packages/core/analytics/funnel-view.ts — the other 18 were silently dropped
 ({"ok": False, "reason": "unknown_event"}), so most funnel CTAs never reached
-funnel_sessions. This test pins set EQUALITY in both directions: any event
-added or removed on one side without the other fails CI.
+funnel_sessions.
+
+MYTHOS B1 (IA-8) extends the guard to the app_* tool-funnel taxonomy
+(packages/core/analytics/funnel-app.ts, APP_EVENTS): the backend allowlist is
+now the UNION of both frontend consts. This test pins set EQUALITY in both
+directions — any event added or removed on one side without the other fails
+CI — and pins the two frontend taxonomies as disjoint.
 """
 
 from __future__ import annotations
@@ -12,7 +17,11 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from backend.app.routers.analytics import ALLOWED_EVENTS
+from backend.app.routers.analytics import (
+    ALLOWED_EVENTS,
+    FUNNEL_APP_EVENTS,
+    FUNNEL_PAGE_EVENTS,
+)
 
 
 def _repo_root() -> Path:
@@ -24,33 +33,56 @@ def _repo_root() -> Path:
     raise AssertionError(f"monorepo root with packages/core not found above {here}")
 
 
-FUNNEL_VIEW_TS = _repo_root() / "packages" / "core" / "analytics" / "funnel-view.ts"
+_ANALYTICS_DIR = _repo_root() / "packages" / "core" / "analytics"
+FUNNEL_VIEW_TS = _ANALYTICS_DIR / "funnel-view.ts"
+FUNNEL_APP_TS = _ANALYTICS_DIR / "funnel-app.ts"
 
 
-def _frontend_events() -> list[str]:
-    source = FUNNEL_VIEW_TS.read_text(encoding="utf-8")
+def _extract_const_events(source_path: Path, const_name: str) -> list[str]:
+    """Extract event-name string literals from `export const <NAME> = [...] as const`."""
+    source = source_path.read_text(encoding="utf-8")
     match = re.search(
-        r"export const FUNNEL_EVENTS\s*=\s*\[(.*?)\]\s*as const",
+        rf"export const {const_name}\s*=\s*\[(.*?)\]\s*as const",
         source,
         re.DOTALL,
     )
-    assert match, f"FUNNEL_EVENTS array not found in {FUNNEL_VIEW_TS}"
-    return re.findall(r'"([a-z0-9_]+)"', match.group(1))
+    assert match, f"{const_name} array not found in {source_path}"
+    # Strip // comments first — event names quoted inside comments (e.g. the
+    # MYTHOS D5 note) must not leak into the extracted list.
+    block = re.sub(r"//[^\n]*", "", match.group(1))
+    return re.findall(r'"([a-z0-9_]+)"', block)
 
 
-def test_funnel_view_ts_exists() -> None:
+def _frontend_funnel_events() -> list[str]:
+    return _extract_const_events(FUNNEL_VIEW_TS, "FUNNEL_EVENTS")
+
+
+def _frontend_app_events() -> list[str]:
+    return _extract_const_events(FUNNEL_APP_TS, "APP_EVENTS")
+
+
+def test_funnel_source_files_exist() -> None:
     assert FUNNEL_VIEW_TS.is_file(), f"missing {FUNNEL_VIEW_TS}"
+    assert FUNNEL_APP_TS.is_file(), f"missing {FUNNEL_APP_TS}"
 
 
 def test_frontend_has_no_duplicate_events() -> None:
-    events = _frontend_events()
-    assert len(events) == len(set(events)), "duplicate entries in FUNNEL_EVENTS"
+    funnel = _frontend_funnel_events()
+    assert len(funnel) == len(set(funnel)), "duplicate entries in FUNNEL_EVENTS"
+    app = _frontend_app_events()
+    assert len(app) == len(set(app)), "duplicate entries in APP_EVENTS"
 
 
-def test_backend_allowlist_matches_frontend_funnel_events() -> None:
-    frontend = set(_frontend_events())
-    missing_in_backend = frontend - ALLOWED_EVENTS
-    stale_in_backend = ALLOWED_EVENTS - frontend
+def test_frontend_taxonomies_are_disjoint() -> None:
+    """Page-funnel and tool-funnel consts must never share an event name."""
+    overlap = set(_frontend_funnel_events()) & set(_frontend_app_events())
+    assert not overlap, f"events in BOTH FUNNEL_EVENTS and APP_EVENTS: {sorted(overlap)}"
+
+
+def test_backend_page_events_match_funnel_view() -> None:
+    frontend = set(_frontend_funnel_events())
+    missing_in_backend = frontend - FUNNEL_PAGE_EVENTS
+    stale_in_backend = FUNNEL_PAGE_EVENTS - frontend
     assert not missing_in_backend, (
         "events emitted by funnel-view.ts but DROPPED by the backend "
         f"allowlist: {sorted(missing_in_backend)}"
@@ -58,4 +90,31 @@ def test_backend_allowlist_matches_frontend_funnel_events() -> None:
     assert not stale_in_backend, (
         "events accepted by the backend but no longer emitted by "
         f"funnel-view.ts: {sorted(stale_in_backend)}"
+    )
+
+
+def test_backend_app_events_match_funnel_app() -> None:
+    frontend = set(_frontend_app_events())
+    missing_in_backend = frontend - FUNNEL_APP_EVENTS
+    stale_in_backend = FUNNEL_APP_EVENTS - frontend
+    assert not missing_in_backend, (
+        "events emitted by funnel-app.ts but DROPPED by the backend "
+        f"allowlist: {sorted(missing_in_backend)}"
+    )
+    assert not stale_in_backend, (
+        "events accepted by the backend but no longer emitted by "
+        f"funnel-app.ts: {sorted(stale_in_backend)}"
+    )
+
+
+def test_backend_allowlist_is_exactly_the_frontend_union() -> None:
+    """ALLOWED_EVENTS == extracted(FUNNEL_EVENTS) ∪ extracted(APP_EVENTS), exactly."""
+    union = set(_frontend_funnel_events()) | set(_frontend_app_events())
+    missing_in_backend = union - ALLOWED_EVENTS
+    stale_in_backend = ALLOWED_EVENTS - union
+    assert not missing_in_backend, (
+        f"frontend events DROPPED by the backend allowlist: {sorted(missing_in_backend)}"
+    )
+    assert not stale_in_backend, (
+        f"backend-only events with no frontend source: {sorted(stale_in_backend)}"
     )

--- a/apps/mouth/src/app/(marketing)/FunnelCTAs.tsx
+++ b/apps/mouth/src/app/(marketing)/FunnelCTAs.tsx
@@ -1,14 +1,37 @@
 "use client";
 
-const funnels = [
+import type { ReactNode } from "react";
+import { trackFunnelCTA } from "@/lib/analytics";
+
+type FunnelKey = "visa" | "kbli" | "tax" | "property";
+
+const funnels: Array<{
+  title: string;
+  funnel: FunnelKey;
+  description: string;
+  href: string;
+  accent: string;
+  accentGlow: string;
+  icon: ReactNode;
+}> = [
   {
     title: "Visa Oracle",
+    funnel: "visa",
     description: "Find your best visa path in 60 seconds",
     href: "https://visa.balizero.com",
     accent: "#2E6FD4",
     accentGlow: "rgba(46, 111, 212, 0.15)",
     icon: (
-      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <svg
+        width="28"
+        height="28"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
         <path d="M6 2L3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z" />
         <line x1="3" y1="6" x2="21" y2="6" />
         <path d="M16 10a4 4 0 0 1-8 0" />
@@ -17,12 +40,22 @@ const funnels = [
   },
   {
     title: "KBLI Navigator",
+    funnel: "kbli",
     description: "Decode 1,563 Indonesian business codes",
     href: "/kbli",
     accent: "#d4845a",
     accentGlow: "rgba(212, 132, 90, 0.15)",
     icon: (
-      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <svg
+        width="28"
+        height="28"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
         <ellipse cx="12" cy="5" rx="9" ry="3" />
         <path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3" />
         <path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5" />
@@ -31,12 +64,22 @@ const funnels = [
   },
   {
     title: "Tax & Compliance",
+    funnel: "tax",
     description: "Personal and corporate tax services",
     href: "/contact?service=tax",
     accent: "#D4A853",
     accentGlow: "rgba(212, 168, 83, 0.15)",
     icon: (
-      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <svg
+        width="28"
+        height="28"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
         <rect x="4" y="2" width="16" height="20" rx="2" />
         <line x1="8" y1="6" x2="16" y2="6" />
         <line x1="8" y1="10" x2="16" y2="10" />
@@ -46,12 +89,22 @@ const funnels = [
   },
   {
     title: "Property",
+    funnel: "property",
     description: "Leasehold, freehold & investment guidance",
     href: "/property",
     accent: "#d4845a",
     accentGlow: "rgba(212, 132, 90, 0.15)",
     icon: (
-      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <svg
+        width="28"
+        height="28"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
         <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
         <polyline points="9 22 9 12 15 12 15 22" />
       </svg>
@@ -59,14 +112,13 @@ const funnels = [
   },
 ];
 
-function trackClick(funnel: string) {
-  if (typeof window !== "undefined" && "gtag" in window) {
-    (window as unknown as { gtag: (...args: unknown[]) => void }).gtag(
-      "event",
-      "funnel_cta_click",
-      { funnel },
-    );
-  }
+// MYTHOS B1: this used to fire a raw gtag "funnel_cta_click" — an event that
+// is not in FUNNEL_EVENTS/ALLOWED_EVENTS, so it never reached the funnel
+// store. Each card now dispatches the canonical allowlisted per-funnel
+// "<funnel>_cta_click" via the tracked helper (GA4 + CRM bus + funnel store);
+// the source payload preserves where the click came from.
+function trackClick(funnel: FunnelKey): void {
+  trackFunnelCTA(funnel, "cta_click", { source: "intelligence_tools" });
 }
 
 export function FunnelCTAs() {
@@ -117,7 +169,7 @@ export function FunnelCTAs() {
           <a
             key={f.title}
             href={f.href}
-            onClick={() => trackClick(f.title.toLowerCase().replace(/\s+/g, "-"))}
+            onClick={() => trackClick(f.funnel)}
             style={{
               display: "flex",
               flexDirection: "column",
@@ -194,7 +246,16 @@ export function FunnelCTAs() {
               }}
             >
               Explore
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
                 <path d="M5 12h14" />
                 <path d="m12 5 7 7-7 7" />
               </svg>

--- a/apps/mouth/src/lib/analytics.test.ts
+++ b/apps/mouth/src/lib/analytics.test.ts
@@ -172,4 +172,35 @@ describe("analytics", () => {
       lng: 115.22,
     });
   });
+
+  it("canonicalizes property cta_click onto property_cta_clicked (MYTHOS D5)", async () => {
+    const gtag = vi.fn();
+    (window as typeof window & { gtag?: typeof gtag }).gtag = gtag;
+    const { trackFunnelCTA } = await loadAnalytics();
+
+    trackFunnelCTA("property", "cta_click", { source: "home_grid" });
+    trackFunnelCTA("visa", "cta_click");
+
+    // Property: the grid name "property_cta_click" was never allowlisted —
+    // the canonical event with GA4 history is "property_cta_clicked".
+    expect(gtag).toHaveBeenCalledWith("event", "property_cta_clicked", {
+      event_category: "FunnelCTA",
+      funnel: "property",
+      source: "home_grid",
+    });
+    expect(trackFunnelEventMock).toHaveBeenCalledWith("property_cta_clicked", {
+      sessionId: "core-session-id",
+      payload: { funnel: "property", source: "home_grid" },
+    });
+    // The other three funnels keep the grid-derived "<funnel>_cta_click".
+    expect(gtag).toHaveBeenCalledWith("event", "visa_cta_click", {
+      event_category: "FunnelCTA",
+      funnel: "visa",
+    });
+    expect(gtag).not.toHaveBeenCalledWith(
+      "event",
+      "property_cta_click",
+      expect.anything(),
+    );
+  });
 });

--- a/apps/mouth/src/lib/analytics.ts
+++ b/apps/mouth/src/lib/analytics.ts
@@ -405,39 +405,34 @@ export function trackTaxDashboardViewed(
 
 // --- Property ---
 
+/** Single dispatch path for property CTA clicks (MYTHOS D5 consolidation).
+ * "property_cta_clicked" is the canonical event name; the typed `cta_type`
+ * payload param disambiguates the surface (article CTA, map analyze, …). */
+function dispatchPropertyCTAClicked(
+  payload: Record<string, string | number> & { cta_type: string },
+): void {
+  sendGA4Event("property_cta_clicked", {
+    event_category: "Property",
+    ...payload,
+  });
+  trackEvent("property_cta_clicked", payload);
+  void trackFunnelEvent("property_cta_clicked", {
+    sessionId: getOrCreateSessionId(),
+    payload,
+  });
+}
+
 /** Track property article-page CTA interaction (article slug + CTA type) */
 export function trackPropertyArticleCTA(
   articleSlug: string,
   ctaType: string,
 ): void {
-  sendGA4Event("property_cta_clicked", {
-    event_category: "Property",
-    article_slug: articleSlug,
-    cta_type: ctaType,
-  });
-  trackEvent("property_cta_clicked", {
-    article_slug: articleSlug,
-    cta_type: ctaType,
-  });
-  void trackFunnelEvent("property_cta_clicked", {
-    sessionId: getOrCreateSessionId(),
-    payload: { article_slug: articleSlug, cta_type: ctaType },
-  });
+  dispatchPropertyCTAClicked({ article_slug: articleSlug, cta_type: ctaType });
 }
 
 /** Track property analyze button clicked */
 export function trackPropertyAnalyzeCTA(lat: number, lng: number): void {
-  sendGA4Event("property_cta_clicked", {
-    event_category: "Property",
-    cta_type: "analyze",
-    lat,
-    lng,
-  });
-  trackEvent("property_cta_clicked", { cta_type: "analyze", lat, lng });
-  void trackFunnelEvent("property_cta_clicked", {
-    sessionId: getOrCreateSessionId(),
-    payload: { cta_type: "analyze", lat, lng },
-  });
+  dispatchPropertyCTAClicked({ cta_type: "analyze", lat, lng });
 }
 
 /** Track AskZantara question on property article */
@@ -489,13 +484,21 @@ export function trackFunnelCTA(
   action: FunnelCTAAction,
   extra?: Record<string, string | number | boolean>,
 ): void {
-  // Event name: e.g. "visa_cta_click", "kbli_search_submit"
-  const eventName = `${funnel}_${action}` as const;
+  // Event name: e.g. "visa_cta_click", "kbli_search_submit".
+  // MYTHOS D5: property's canonical CTA-click event is "property_cta_clicked"
+  // (pre-existing GA4 history). The grid-derived "property_cta_click" was
+  // never in FUNNEL_EVENTS/ALLOWED_EVENTS, so the backend silently dropped
+  // every property home-block CTA click — canonicalize here instead.
+  const eventName =
+    funnel === "property" && action === "cta_click"
+      ? "property_cta_clicked"
+      : `${funnel}_${action}`;
   const params = { event_category: "FunnelCTA", funnel, ...extra };
   sendGA4Event(eventName, params);
   trackEvent(eventName, { funnel, ...extra });
   void trackFunnelEvent(
-    // Cast is safe: all 16 combinations are in FUNNEL_EVENTS
+    // Cast is safe: every name constructed above is in FUNNEL_EVENTS
+    // (guarded by test_analytics_funnel_parity.py + funnel-view.test.ts).
     eventName as Parameters<typeof trackFunnelEvent>[0],
     { sessionId: getOrCreateSessionId(), payload: { funnel, ...extra } },
   );

--- a/packages/core/analytics/funnel-app.test.ts
+++ b/packages/core/analytics/funnel-app.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  APP_EVENTS,
+  emitFunnelAppEvent,
+  createFunnelAppTracker,
+  type FunnelAppEvent,
+} from "./funnel-app";
+
+describe("funnel-app", () => {
+  beforeEach(() => {
+    vi.stubGlobal("gtag", vi.fn());
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+    document.cookie = "bz_session=; Max-Age=0; path=/";
+  });
+
+  it("POSTs session_id (≥32 chars), hostname and the event to the backend", async () => {
+    await emitFunnelAppEvent({ type: "app_viewed", app: "visa_clock" });
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/analytics/funnel-event",
+      expect.objectContaining({ method: "POST" }),
+    );
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string);
+    // The backend FunnelEvent model requires session_id (min 32 chars):
+    // without it every app_* POST was a silent 422.
+    expect(typeof body.session_id).toBe("string");
+    expect(body.session_id.length).toBeGreaterThanOrEqual(32);
+    expect(body.hostname).toBe(window.location.hostname); // D3/D9
+    expect(body.event).toBe("app_viewed");
+    expect(body.payload).toMatchObject({
+      type: "app_viewed",
+      app: "visa_clock",
+    });
+  });
+
+  it("suppresses the network POST in local mode but keeps gtag", async () => {
+    await emitFunnelAppEvent(
+      { type: "app_pdf_downloaded", app: "tax_gap" },
+      { local: true },
+    );
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    const gtag = globalThis.gtag as unknown as ReturnType<typeof vi.fn>;
+    expect(gtag).toHaveBeenCalledWith(
+      "event",
+      "app_pdf_downloaded",
+      expect.any(Object),
+    );
+  });
+
+  it("APP_EVENTS is the exact event-name source of truth for the tracker", async () => {
+    // No duplicates, snake_case naming — mirrors funnel-view.test.ts.
+    expect(new Set(APP_EVENTS).size).toBe(APP_EVENTS.length);
+    for (const event of APP_EVENTS) {
+      expect(event).toMatch(/^app(?:_[a-z0-9]+)+$/);
+    }
+
+    // Every tracker helper emits an event whose type is in APP_EVENTS.
+    const tracker = createFunnelAppTracker("kbli_decoder");
+    await tracker.viewed();
+    await tracker.branchSelected("pma");
+    await tracker.formStarted("sector");
+    await tracker.formSubmitted(["sector"]);
+    await tracker.wizardStep(1, 3);
+    await tracker.wizardAbandoned(2);
+    await tracker.resultViewed("abc123");
+    await tracker.ctaClicked("Talk to us", "/contact");
+    await tracker.whatsappHandoff("lead-1");
+    await tracker.shareClicked("copy");
+    await tracker.pdfDownloaded();
+    await tracker.emailSubscribed("exit_intent");
+
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    const emitted = fetchMock.mock.calls.map(
+      ([, init]) =>
+        (JSON.parse((init as RequestInit).body as string) as { event: string })
+          .event,
+    );
+    expect(emitted).toHaveLength(APP_EVENTS.length);
+    expect(new Set(emitted)).toEqual(
+      new Set(APP_EVENTS as readonly FunnelAppEvent["type"][]),
+    );
+  });
+});

--- a/packages/core/analytics/funnel-app.ts
+++ b/packages/core/analytics/funnel-app.ts
@@ -6,6 +6,8 @@
  * endpoint + GA4 gtag, so dashboards unify automatically.
  */
 
+import { getOrCreateSessionId } from "../auth";
+
 export type FunnelAppName =
   | "visa_clock"
   | "visa_match"
@@ -13,6 +15,26 @@ export type FunnelAppName =
   | "kbli_builder"
   | "tax_gap"
   | "zoning_check";
+
+/** Finite source-of-truth list of app_* event names (MYTHOS IA-8 app_*
+ * reconciliation). The backend allowlist mirrors FUNNEL_EVENTS ∪ APP_EVENTS —
+ * enforced by test_analytics_funnel_parity.py, which parses this const. */
+export const APP_EVENTS = [
+  "app_viewed",
+  "app_branch_selected",
+  "app_form_started",
+  "app_form_submitted",
+  "app_wizard_step_completed",
+  "app_wizard_abandoned",
+  "app_result_viewed",
+  "app_cta_clicked",
+  "app_whatsapp_handoff",
+  "app_share_clicked",
+  "app_pdf_downloaded",
+  "app_email_subscribed",
+] as const satisfies readonly string[];
+
+export type AppEventType = (typeof APP_EVENTS)[number];
 
 export type FunnelAppEvent =
   | { type: "app_viewed"; app: FunnelAppName }
@@ -62,6 +84,17 @@ export type FunnelAppEvent =
       trigger_type: string;
     };
 
+/** Compile-time parity proof: resolves to `true` only when APP_EVENTS exactly
+ * covers FunnelAppEvent["type"] in BOTH directions. Adding a union variant
+ * without listing it in APP_EVENTS (or vice versa) fails `tsc`. */
+export type AppEventsExactlyCoverUnion =
+  Exclude<FunnelAppEvent["type"], AppEventType> extends never
+    ? Exclude<AppEventType, FunnelAppEvent["type"]> extends never
+      ? true
+      : never
+    : never;
+export const APP_EVENTS_COVER_UNION: AppEventsExactlyCoverUnion = true;
+
 interface EmitOptions {
   /** Suppress network POST, keep only gtag (for dev / testing). */
   local?: boolean;
@@ -84,12 +117,23 @@ export async function emitFunnelAppEvent(
     globalThis.gtag("event", event.type, event);
   }
   if (opts.local) return;
+  // MYTHOS D3/D9 foundation: capture the emitting hostname (SSR-safe).
+  const hostname =
+    typeof window !== "undefined" ? window.location.hostname : undefined;
   try {
     await fetch(ENDPOINT, {
       method: "POST",
       credentials: "include",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ event: event.type, payload: event }),
+      // session_id is REQUIRED by the backend FunnelEvent model (min 32
+      // chars) — without it every app_* POST 422s and the "dashboards unify
+      // automatically" promise in the module docstring was silently false.
+      body: JSON.stringify({
+        session_id: getOrCreateSessionId(),
+        event: event.type,
+        payload: event,
+        ...(hostname ? { hostname } : {}),
+      }),
       keepalive: true,
     });
   } catch {

--- a/packages/core/analytics/funnel-view.test.ts
+++ b/packages/core/analytics/funnel-view.test.ts
@@ -28,6 +28,21 @@ describe("funnel-view", () => {
     );
   });
 
+  it("captures the emitting hostname in the backend POST (D3/D9)", async () => {
+    await trackFunnelEvent("kbli_code_viewed", {
+      sessionId: "abc",
+      payload: { code: "47111" },
+    });
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string);
+    // jsdom default location is http://localhost — what matters is that the
+    // field is present and mirrors window.location.hostname.
+    expect(body.hostname).toBe(window.location.hostname);
+    expect(body.session_id).toBe("abc");
+    expect(body.event).toBe("kbli_code_viewed");
+  });
+
   it("whitelist derives from the FUNNEL_EVENTS source — no hardcoded count", () => {
     // Representative events (one per funnel) that must always exist.
     // Containment is asserted per-event off this array — never off a magic number.
@@ -36,6 +51,7 @@ describe("funnel-view", () => {
       "kbli_code_viewed",
       "tax_dashboard_viewed",
       "property_cta_clicked",
+      "book_viewed", // MYTHOS IA-3 scaffolding (emission ships in B4)
     ];
     for (const event of representative) {
       expect(FUNNEL_EVENTS).toContain(event);

--- a/packages/core/analytics/funnel-view.ts
+++ b/packages/core/analytics/funnel-view.ts
@@ -29,6 +29,9 @@ export const FUNNEL_EVENTS = [
   "tax_search_submit",
   "tax_suggestion_click",
   // --- Property Map ---
+  // NOTE (MYTHOS D5): "property_cta_clicked" is the single canonical property
+  // CTA-click event (kept for GA4 continuity). The funnel home-block dispatcher
+  // maps property + cta_click onto it — there is NO separate "property_cta_click".
   "property_cta_clicked",
   "property_chat_question",
   "property_whatsapp_cta",
@@ -38,6 +41,14 @@ export const FUNNEL_EVENTS = [
   // --- Hero Section CTAs ---
   "hero_cta_book_call",
   "hero_cta_read_dispatch",
+  // --- Booked Consultation (MYTHOS IA-3 scaffolding) ---
+  // The /book consultation flow ships in B4; these events are allowlisted
+  // ahead of it so measurement is ready on day one. NO emission sites yet —
+  // the existing /book route is an editorial book reader, unrelated.
+  "book_viewed",
+  "book_form_started",
+  "book_form_submitted",
+  "book_call_confirmed",
 ] as const;
 
 export type FunnelEventName = (typeof FUNNEL_EVENTS)[number];
@@ -56,10 +67,16 @@ export async function trackFunnelEvent(
   name: FunnelEventName,
   args: TrackArgs,
 ): Promise<void> {
+  // MYTHOS D3/D9 foundation: capture the emitting hostname so the backend can
+  // scope denominators to public hostnames (GA4 mixes 7 hostnames + localhost).
+  // SSR-safe: omitted entirely outside the browser.
+  const hostname =
+    typeof window !== "undefined" ? window.location.hostname : undefined;
   const body = {
     session_id: args.sessionId,
     event: name,
     payload: args.payload ?? {},
+    ...(hostname ? { hostname } : {}),
   };
   if (typeof globalThis.gtag === "function") {
     // GA4 cannot serialize nested objects — stringify payload so it arrives

--- a/packages/core/analytics/index.ts
+++ b/packages/core/analytics/index.ts
@@ -1,1 +1,6 @@
+// Single source-of-truth module for both funnel taxonomies (MYTHOS IA-8):
+// page-funnel events (FUNNEL_EVENTS) and tool-funnel events (APP_EVENTS)
+// stay separate consts but are exported together so consumers and the
+// cross-stack parity test cover the union.
 export * from "./funnel-view";
+export * from "./funnel-app";


### PR DESCRIPTION
## MYTHOS Stage-B slice B1 — measurement foundation

Per the Stage-A decision pack (`research/operations/2026-06-10-mythos-stage-a-decision-pack.md`, §4 roadmap "B1 Measurement foundation (events cleanup, `book_*`, hostname convention, PII-scrub test)" + IA-3/IA-8), approved gate #1256 (GO PIENO). Built on fresh `origin/main` including #1274.

### Deliverables

**1. Cross-stack parity test (P0)** — `test_analytics_funnel_parity.py` turned out to ALREADY exist on main (shipped by #1261, contrary to the brief's "verified missing 3×" — it landed after the brief was written). Extended it to the union contract: `extracted(FUNNEL_EVENTS) ∪ extracted(APP_EVENTS) == ALLOWED_EVENTS` exactly (bidirectional), plus per-side guards (`FUNNEL_PAGE_EVENTS` vs funnel-view.ts, `FUNNEL_APP_EVENTS` vs funnel-app.ts), taxonomy disjointness, and duplicate-free checks. Extractor now strips `//` comments so event names quoted in code comments can't leak into the parsed list.

**2. `test_analytics.py` modernization** — the hardcoded 11-event list was already replaced by a data-driven loop over `ALLOWED_EVENTS` (#1261). Kept; added hostname + PII-scrub coverage, `make_app()` now exposes the mocked connection so tests assert on what is actually persisted, and the unknown-event test now also asserts nothing reaches storage. No stale "11 whitelisted events" docstrings found in `analytics.py` (the historical D11 note is accurate and kept).

**3. `book_*` scaffolding (IA-3)** — the pack says "events `book_*` added to FUNNEL_EVENTS" without naming them, so the brief's defaults apply: `book_viewed`, `book_form_started`, `book_form_submitted`, `book_call_confirmed`. Added to `FUNNEL_EVENTS` + backend allowlist. **Scaffolding only — NO emission sites**; the `/book` consultation flow ships in B4 (the existing `/book` route is an editorial book reader, unrelated). `funnel-view.test.ts` derived assertions pass automatically; `book_viewed` added to its representative list.

**4. `app_*` reconciliation (IA-8 / D6)** — funnel-app.ts events were a finite discriminated union but had no runtime const: materialized `APP_EVENTS` (12 names) with a compile-time bidirectional parity proof (`AppEventsExactlyCoverUnion` — `tsc` fails if the union and the const drift). The two frontend consts stay separate (page-funnel vs tool-funnel) but are exported from the single source-of-truth module `packages/core/analytics/index.ts`. Backend: `ALLOWED_EVENTS = FUNNEL_PAGE_EVENTS | FUNNEL_APP_EVENTS` = **48 events**. Bonus fix found during grounding: `emitFunnelAppEvent` POSTed **without `session_id`**, which the backend Pydantic model requires (min 32 chars) — every `app_*` POST was silently 422ing, so the module's "dashboards unify automatically" docstring was false. It now sends the shared `bz_session` UUID via `getOrCreateSessionId()`.

**5. Stray gtag fix** — `FunnelCTAs.tsx` fired raw gtag `funnel_cta_click` (never allowlisted, never reached the backend). Now routes through `trackFunnelCTA(funnel, "cta_click", { source: "intelligence_tools" })` → canonical allowlisted `<funnel>_cta_click` events, no data loss. Note: this component is currently only imported by `page.v1-backup.tsx` (not a routable page), so it's dormant on the live site — fixed anyway so any revival is correct by construction.

**6. D5 duplication** — the pack's D5 is **NOT** the brief's hypothesis (article-vs-analyze dual-emit). Pack verbatim (Phase-0 D-ledger): "`property_cta_clicked` vs `property_cta_click` duplicate event". Live wound confirmed: the funnel home-block grid (`FunnelFeature.tsx` → `track("cta_click")`) emitted `property_cta_click`, which was in neither `FUNNEL_EVENTS` nor `ALLOWED_EVENTS` → **every property home-block CTA click was silently dropped by the backend** (and the `trackFunnelCTA` cast comment "all 16 combinations are in FUNNEL_EVENTS" was false). Fix: canonicalized on `property_cta_clicked` (the name with GA4 history); `trackFunnelCTA` maps property+cta_click onto it. Additionally consolidated `trackPropertyArticleCTA`/`trackPropertyAnalyzeCTA` into one dispatch path (`dispatchPropertyCTAClicked`, typed `cta_type` param) — behavior-identical, zero callsite churn — which also covers the brief's hypothesized duplication.

**7. Hostname capture (D3/D9 foundation)** — both shared frontend dispatch paths (`trackFunnelEvent`, `emitFunnelAppEvent`) now attach `window.location.hostname` (SSR-safe, omitted server-side). Backend `FunnelEvent` accepts `hostname` (optional, max 253) and persists `last_hostname` + the scrubbed `last_event_payload` into `funnel_sessions.step_state` — JSON field, **no schema change** (slice kept thin per brief). **No engaged-organic denominator aggregator exists in code today** (verified — `workspace_analytics.py` only counts sessions per funnel; the D9 analysis was manual GA4) → capture+persist now, hostname-scoped denominator queries land in B2.

**8. PII-scrub guardrail (§6)** — `scrub_pii()` recursively redacts email + phone-like substrings in payload string values to `"[redacted]"` before storage. Scrub-don't-drop: surrounding text and keys survive (fail-safe for data, fail-closed for PII). Phone pattern anchored to end on a digit so trailing whitespace isn't swallowed. Unit tests: email/phone payload arrives → **stored** redacted; clean payload byte-identical; unknown event still rejected before any storage. Note: prior to this PR the payload was received and discarded (only `last_event` was stored) — the scrub gate is in place from the very first byte persisted.

### Pack-letter divergences (per brief instruction)
- **Charter §6 is not on disk** — the pack references "MYTHOS CHARTER v2 §6" guardrails but the charter file does not exist in the repo. Implemented the pack's own operationalization of §6 for B1: "PII-scrub test + event allowlist" (IA-8) — both shipped here.
- **D9 is not in the Phase-0 D-ledger** (which has D1–D8); it is defined in `2026-06-10-mythos-gsc-demand-90d.md`: bot/monitor Direct traffic inflates the baseline → adopt *engaged sessions, hostname-scoped* as the scoreboard denominator. This PR ships the hostname capture that denominator needs; the scoping query is B2.
- **Brief vs reality**: parity test + data-driven test_analytics.py already existed (#1261); D5 is the `*_clicked`/`*_click` naming dup, not the dual-helper emit (both addressed).

### Measurement tier / rollback
- Tier: instrumentation-only — no user-facing behavior change, no PricingTool/price surface touched.
- Rollback: revert this single squash commit. `book_*` events have zero emitters; `last_event_payload`/`last_hostname` are additive JSON keys in `step_state`.

### Verification
- `packages/core`: vitest **71/71** (24 files) — incl. new `funnel-app.test.ts` (session_id ≥32, hostname, APP_EVENTS coverage) and extended `funnel-view.test.ts` (hostname POST, book_viewed representative; #1274's derived assertions NOT regressed).
- `apps/mouth`: vitest **1619/1619** (181 files) · `tsc --noEmit` exit 0 — incl. new D5 canonicalization test.
- backend: `pytest test_analytics.py test_analytics_funnel_parity.py` → **15/15** (9 + 6).
- Preflight: `./scripts/ai-dispatch.sh preflight-l1` confirmed NOT INSTALLED (P5 scar — backend deleted by repo cleanup, wrapper survives); proceeded as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)