### PR TITLE
ci(p6): add httpx to test deps so federation_orchestrator import resolves (F25)

### DIFF
--- a/.github/workflows/p6-federation-parallelize.yml
+++ b/.github/workflows/p6-federation-parallelize.yml
@@ -50,7 +50,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install test deps (pytest)
-        run: pip install pytest
+        run: pip install pytest httpx
 
       - name: P6 falsifiable gates (G1-G5 + default-serial invariant)
         # scripts/ on path for the pure sibling module; apps/backend-rag on path


### PR DESCRIPTION
## What
Audit **F25**: `p6-federation-parallelize` failed twice with `ModuleNotFoundError: No module named 'httpx'`.

Root cause: the workflow installs only `pytest`, but `scripts/federation_orchestrator.py:36` has an unconditional top-level `import httpx`; the test imports the orchestrator → 4 orchestrator tests fail at import (20/24 passed).

## Fix
One line: `pip install pytest` → `pip install pytest httpx`.

## Note
This re-greens p6. It is a **prerequisite** before p6 can be promoted to a required status check (W69 BUCO #1 — the skip-sentinel pattern is still needed separately before any promotion, per the audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)