### PR TITLE
fix(nav): increase navigation font size

### DIFF
--- a/apps/mouth/src/app/v2/_components/HomeSearchButton.tsx
+++ b/apps/mouth/src/app/v2/_components/HomeSearchButton.tsx
@@ -28,7 +28,7 @@ export function HomeSearchButton() {
       <button
         onClick={() => setOpen(true)}
         aria-label="Search articles"
-        className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md text-[11px] font-semibold uppercase tracking-wide transition-colors hover:opacity-90"
+        className="inline-flex items-center gap-2 px-3 py-2 rounded-md text-[13px] font-semibold uppercase tracking-wide transition-colors hover:opacity-90"
         style={{
           background: "rgba(255,255,255,0.06)",
           border: "1px solid rgba(255,255,255,0.12)",

--- a/apps/mouth/src/app/v2/_components/NavWhatsAppCTA.tsx
+++ b/apps/mouth/src/app/v2/_components/NavWhatsAppCTA.tsx
@@ -16,7 +16,7 @@ export function NavWhatsAppCTA() {
           payload: { trigger: "nav" },
         })
       }
-      className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-md text-[11px] font-semibold uppercase tracking-wide"
+      className="inline-flex items-center gap-1.5 px-4 py-2 rounded-md text-[13px] font-semibold uppercase tracking-wide"
       style={{
         background: "var(--accent-funnel)",
         color: "var(--text-on-accent)",

--- a/apps/mouth/src/app/v2/_components/TopicPills.tsx
+++ b/apps/mouth/src/app/v2/_components/TopicPills.tsx
@@ -43,7 +43,7 @@ export function TopicPills() {
             <a
               key={t.label}
               href={t.href}
-              className="inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-[11.5px] font-semibold transition-all"
+              className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-full text-[13px] font-semibold transition-all"
               style={{
                 background: `color-mix(in srgb, ${t.accent} 10%, transparent)`,
                 border: `1px solid color-mix(in srgb, ${t.accent} 28%, transparent)`,

--- a/apps/mouth/src/app/v2/page.tsx
+++ b/apps/mouth/src/app/v2/page.tsx
@@ -72,7 +72,7 @@ export default async function HomeV2() {
           <>
             <a
               href="https://kita.balizero.com/"
-              className="px-4 py-1.5 rounded-md text-[11px] font-semibold uppercase tracking-wide"
+              className="px-4 py-2 rounded-md text-[13px] font-semibold uppercase tracking-wide"
               style={{
                 background: "transparent",
                 color: "var(--text-secondary)",


### PR DESCRIPTION
# Insight

Homepage v2 navigation/action controls were visually too small for readability and light touch comfort.

# Studio

## Source / Reference

* V1 Verde task: Nav font 11.5px → 13px + touch target
* repo grep scan for small nav/action text
* targeted review of homepage v2 navigation-related components

## Methodology

Compared small typography usage across homepage v2 and limited the change to actual navigation/action controls only.

Scope was intentionally constrained to:

* Login nav action
* WhatsApp nav CTA
* Homepage search action
* Topic pill navigation links

Excluded unrelated `text-[11px]` usages such as:

* footer labels
* section labels
* social proof microcopy
* news cards
* workspace/admin components

## Raw Observations

Changed 4 files only:

* `apps/mouth/src/app/v2/page.tsx`
* `apps/mouth/src/app/v2/_components/NavWhatsAppCTA.tsx`
* `apps/mouth/src/app/v2/_components/HomeSearchButton.tsx`
* `apps/mouth/src/app/v2/_components/TopicPills.tsx`

Diff summary:

* 4 files changed
* 4 insertions
* 4 deletions

Specific changes:

* `text-[11px]` → `text-[13px]`
* `text-[11.5px]` → `text-[13px]`
* `py-1.5` → `py-2`

Inner micro-labels were intentionally left untouched:

* WhatsApp CTA second-line micro label
* Search button `<kbd>` shortcut label

## Reasoning Path

The goal was not a visual redesign.

The change improves navigation readability and touch comfort while keeping the current homepage layout, hierarchy, and styling system intact.

This is intentionally a small frontend-only patch before moving to the higher-risk mobile drawer work.

## Risk / Implication

Low risk.

Potential visual impact:

* nav actions may become slightly taller
* topic pills may occupy slightly more vertical space

Mitigation:

* only 4 one-line class changes
* no layout logic changed
* no analytics logic changed
* no WhatsApp link logic changed
* no package/core/backend changes

## Checks

Local checks:

* pre-commit checks passed
* typecheck passed
* lint was blocked locally by existing ESLint runtime/tooling error:

`TypeError: scopeManager.addGlobals is not a function`

No package files were changed.

## Guardrails Confirmed

* no backend changes
* no `.env` changes
* no Fly.io changes
* no DB schema changes
* no `packages/core` changes
* no `package-lock.json` changes
* existing untracked KBLI audit file was not included

# Recommendation

Merge after CI is green.

This should be treated as a safe V1 readability/touch-target improvement before starting V2 mobile drawer work.

# Next Action

After this PR is open and CI is running, proceed to V2:

* inspect `NavShell`
* inspect current mobile nav behavior below 768px
* implement hamburger/drawer fix in a separate branch:

`sancho/fix-mobile-nav-drawer`
