### PR TITLE
fix(funnel): jsonb double-encode in lead_capture + migration 223 clients.lead_metadata

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/223_clients_lead_metadata.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/223_clients_lead_metadata.sql
@@ -1,0 +1,20 @@
+-- 223_clients_lead_metadata.sql
+--
+-- The lead_intent_matcher cron (scripts/lead_intent_matcher.py) writes the
+-- content-funnel attribution payload (lead_intent_id, source_app, context,
+-- utm, matched_at) to clients.lead_metadata on every match. The matcher was
+-- designed against this column (see also migration 118 first_touch_at) but
+-- the column itself never got a migration — first real match would crash
+-- with UndefinedColumnError (found 2026-06-11 while arming the cron).
+--
+-- Additive, idempotent, no backfill needed (NULL = no attribution yet).
+
+ALTER TABLE clients ADD COLUMN IF NOT EXISTS lead_metadata JSONB;
+
+COMMENT ON COLUMN clients.lead_metadata IS
+    'Content-funnel attribution written by lead_intent_matcher on match: '
+    '{lead_intent_id, source_app, context, utm, matched_at}. NULL until the '
+    'client is matched to a lead_intents row.';
+
+-- === ROLLBACK ===
+ALTER TABLE clients DROP COLUMN IF EXISTS lead_metadata;

--- a/apps/backend-rag/backend/services/lead_capture/repository.py
+++ b/apps/backend-rag/backend/services/lead_capture/repository.py
@@ -84,8 +84,13 @@ class LeadIntentRepository:
                 """,
                 intent_id,
                 source.value,
-                json.dumps(context),
-                json.dumps(utm) if utm is not None else None,
+                # Pass dicts raw: the app pool registers a jsonb codec with
+                # encoder=json.dumps (PR #494, app/core/database.py). Calling
+                # json.dumps here double-encodes and stores a jsonb STRING
+                # instead of an object (bug found 2026-06-11 by running the
+                # matcher against a live row).
+                context,
+                utm,
                 fingerprint,
                 whatsapp_url,
                 now,

--- a/apps/backend-rag/backend/tests/services/lead_capture/test_matcher.py
+++ b/apps/backend-rag/backend/tests/services/lead_capture/test_matcher.py
@@ -38,6 +38,36 @@ class TestPhoneNormalise:
         assert m.normalise_phone(None) is None
 
 
+class TestParseJsonb:
+    """jsonb columns read through the matcher's codec-less pool.
+
+    Regression for the 2026-06-11 crash: rows INSERTed while the repository
+    json.dumps-ed on top of the app pool's jsonb codec (PR #494) hold a
+    jsonb STRING — _pick_match then exploded on str.get()."""
+
+    def test_dict_passthrough(self):
+        assert m.parse_jsonb({"slug": "x"}, {}) == {"slug": "x"}
+
+    def test_plain_json_text(self):
+        assert m.parse_jsonb('{"slug": "x"}', {}) == {"slug": "x"}
+
+    def test_double_encoded_json_text(self):
+        assert m.parse_jsonb('"{\\"slug\\": \\"verify-filo1\\"}"', {}) == {
+            "slug": "verify-filo1"
+        }
+
+    def test_none_and_null_text_fall_back_to_default(self):
+        assert m.parse_jsonb(None, {}) == {}
+        assert m.parse_jsonb("null", {}) == {}
+        assert m.parse_jsonb(None, None) is None
+
+    def test_invalid_json_falls_back_to_default(self):
+        assert m.parse_jsonb("{not json", {}) == {}
+
+    def test_non_dict_json_falls_back_to_default(self):
+        assert m.parse_jsonb("[1, 2]", {}) == {}
+
+
 class TestPickMatch:
     def _intent(self, *, phone: str | None = None, minutes_ago: int = 2):
         created = datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)

--- a/scripts/lead_intent_matcher.py
+++ b/scripts/lead_intent_matcher.py
@@ -62,6 +62,29 @@ _FETCH_LOOKBACK = timedelta(minutes=35)  # small buffer for cron drift
 _PHONE_RE = re.compile(r"[^\d]")
 
 
+def parse_jsonb(value: Any, default: Any) -> Any:
+    """Decode a jsonb column read through a codec-less asyncpg pool.
+
+    Handles three shapes seen in prod `lead_intents`:
+    - dict/None (pool with codec, or already decoded) → as-is
+    - JSON text ('{"slug": ...}') → one json.loads
+    - double-encoded JSON text ('"{\\"slug\\": ...}"', rows written while the
+      repository json.dumps-ed on top of the pool codec, pre-fix 2026-06-11)
+      → two json.loads
+    Anything else (or invalid JSON) → `default`.
+    """
+    for _ in range(2):
+        if not isinstance(value, str):
+            break
+        try:
+            value = json.loads(value or "null")
+        except ValueError:
+            return default
+    if value is None:
+        return default
+    return value if isinstance(value, dict) else default
+
+
 def normalise_phone(raw: str | None) -> str | None:
     """Reduce a phone number to digits only. Also strip Indonesia leading 0
     and replace a leading 62 with '' so '+62 812' matches '0812'."""
@@ -129,8 +152,8 @@ async def _fetch_unmatched_intents(conn: asyncpg.Connection) -> list[dict[str, A
         {
             "id": r["id"],
             "source": r["source"],
-            "context": r["context"] if isinstance(r["context"], dict) else json.loads(r["context"] or "{}"),
-            "utm": r["utm"] if isinstance(r["utm"], (dict, type(None))) else json.loads(r["utm"] or "null"),
+            "context": parse_jsonb(r["context"], {}),
+            "utm": parse_jsonb(r["utm"], None),
             "fingerprint": r["fingerprint"],
             "created_at": r["created_at"],
         }


### PR DESCRIPTION
## Why

Arming the lead-intent-matcher cron (follow-up of #1276) and running it against the live DB surfaced two latent defects that only execution could reveal:

1. **jsonb double-encode**: PR #494 registered a jsonb codec (`encoder=json.dumps`) on the app pool. The lead_capture repository — dormant since before #494 because of the 401 — still `json.dumps`-ed its jsonb params, so every row written post-#1276 stores `context` as a jsonb **string** (April-era rows are objects). The matcher crashed on `str.get()` at its first-ever execution.
2. **`clients.lead_metadata` never existed**: `_record_match` UPDATEs it on every match, but the column never got a migration (sibling of m118 `first_touch_at`). First real match → `UndefinedColumnError`.

## What

- `repository.py`: pass dicts raw — the pool codec encodes (house convention post-#494)
- `lead_intent_matcher.py`: `parse_jsonb()` tolerates dict / JSON text / legacy double-encoded text → existing bad rows still match
- migration `223_clients_lead_metadata.sql`: additive `ADD COLUMN IF NOT EXISTS`, with ROLLBACK section
- 6 new unit tests (lead_capture suite 26/26 green)

## Verified live

Wrapper run against prod DB with the fixed script: `rc=0`, `{intents_seen: 1, matched: 0, skipped: 1}` — the double-encoded probe row parses and is correctly skipped (no WhatsApp client to match).

Note: the installed cron (`com.nuzantara.lead-intent-matcher`, every 5 min from the deploy worktree) logs rc=1 until this merges and the hourly deploy-puller picks it up — self-heals, log-only, no alert spam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)