### PR TITLE
fix(ui): mobile nav drawer below 768px viewport

### DIFF
--- a/apps/mouth/src/app/v2/_components/MobileNav.tsx
+++ b/apps/mouth/src/app/v2/_components/MobileNav.tsx
@@ -19,10 +19,13 @@ export function MobileNav({ items }: MobileNavProps) {
 
   return (
     <>
+      {/* Hamburger button — flex-shrink-0 prevents compression at 390px */}
       <button
         onClick={() => setOpen(true)}
         aria-label="Open menu"
-        className="md:hidden inline-flex items-center justify-center w-10 h-10 rounded-lg"
+        aria-expanded={open}
+        aria-controls="mobile-nav-drawer"
+        className="md:hidden inline-flex items-center justify-center flex-shrink-0 w-10 h-10 rounded-lg"
         style={{
           color: "#ffffff",
           background: "rgba(255,255,255,0.06)",
@@ -32,75 +35,110 @@ export function MobileNav({ items }: MobileNavProps) {
         <Menu size={22} strokeWidth={2.2} />
       </button>
 
+      {/* Backdrop tap-to-close — rendered beneath the drawer panel */}
       {open && (
         <div
-          className="md:hidden fixed inset-0 z-[400] flex flex-col"
+          aria-hidden="true"
+          onClick={() => setOpen(false)}
           style={{
-            background: "color-mix(in srgb, var(--surface-base) 96%, #000)",
-            backdropFilter: "blur(12px)",
+            position: "fixed",
+            inset: 0,
+            zIndex: 398,
+            background: "rgba(0,0,0,0.45)",
           }}
-        >
-          <div
-            className="flex items-center justify-end px-5 h-14"
-            style={{ borderBottom: "1px solid var(--nav-border)" }}
-          >
-            <button
-              onClick={() => setOpen(false)}
-              aria-label="Close menu"
-              className="inline-flex items-center justify-center w-9 h-9 rounded-md"
-              style={{ color: "var(--text-primary)" }}
-            >
-              <X size={22} strokeWidth={2} />
-            </button>
-          </div>
-
-          <ul className="flex flex-col gap-1 list-none p-5 m-0">
-            {items.map((item) => (
-              <li key={item.href}>
-                <a
-                  href={item.href}
-                  onClick={() => setOpen(false)}
-                  className="block px-4 py-3 rounded-xl text-[18px] font-semibold"
-                  style={{
-                    color: "var(--text-primary)",
-                    background:
-                      "color-mix(in srgb, var(--accent-funnel) 6%, transparent)",
-                    border:
-                      "1px solid color-mix(in srgb, var(--accent-funnel) 14%, transparent)",
-                  }}
-                >
-                  {item.label}
-                </a>
-              </li>
-            ))}
-          </ul>
-
-          <div className="mt-auto p-5 flex flex-col gap-3">
-            <a
-              href="#top"
-              onClick={() => setOpen(false)}
-              className="block text-center px-5 py-3 rounded-xl text-[14px] font-semibold"
-              style={{
-                background: "var(--accent-funnel)",
-                color: "var(--text-on-accent)",
-              }}
-            >
-              Get Started
-            </a>
-            <a
-              href="/login"
-              onClick={() => setOpen(false)}
-              className="block text-center px-5 py-3 rounded-xl text-[13px] font-semibold"
-              style={{
-                border: "1px solid var(--border-default)",
-                color: "var(--text-secondary)",
-              }}
-            >
-              Login
-            </a>
-          </div>
-        </div>
+        />
       )}
+
+      {/* Drawer panel — slides in from the left */}
+      <div
+        id="mobile-nav-drawer"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Navigation menu"
+        className="md:hidden fixed inset-y-0 left-0 z-[399] flex flex-col w-[min(80vw,320px)]"
+        style={{
+          background: "color-mix(in srgb, var(--surface-base) 97%, #000)",
+          borderRight: "1px solid var(--nav-border)",
+          backdropFilter: "blur(16px)",
+          WebkitBackdropFilter: "blur(16px)",
+          transform: open ? "translateX(0)" : "translateX(-100%)",
+          transition: "transform 0.26s cubic-bezier(0.4, 0, 0.2, 1)",
+          willChange: "transform",
+          overflowY: "auto",
+        }}
+      >
+        {/* Header row with close button */}
+        <div
+          className="flex items-center justify-between px-5 h-14 flex-shrink-0"
+          style={{ borderBottom: "1px solid var(--nav-border)" }}
+        >
+          <span
+            className="text-[11px] font-bold uppercase tracking-widest"
+            style={{ color: "var(--text-tertiary)" }}
+          >
+            Menu
+          </span>
+          <button
+            onClick={() => setOpen(false)}
+            aria-label="Close menu"
+            className="inline-flex items-center justify-center w-9 h-9 rounded-md"
+            style={{ color: "var(--text-primary)" }}
+          >
+            <X size={22} strokeWidth={2} />
+          </button>
+        </div>
+
+        {/* Nav links */}
+        <ul className="flex flex-col gap-1 list-none p-5 m-0 flex-1">
+          {items.map((item) => (
+            <li key={item.href}>
+              <a
+                href={item.href}
+                onClick={() => setOpen(false)}
+                className="block px-4 py-3 rounded-xl text-[18px] font-semibold"
+                style={{
+                  color: "var(--text-primary)",
+                  background:
+                    "color-mix(in srgb, var(--accent-funnel) 6%, transparent)",
+                  border:
+                    "1px solid color-mix(in srgb, var(--accent-funnel) 14%, transparent)",
+                  textDecoration: "none",
+                }}
+              >
+                {item.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+
+        {/* Footer CTAs */}
+        <div className="p-5 flex flex-col gap-3 flex-shrink-0">
+          <a
+            href="#top"
+            onClick={() => setOpen(false)}
+            className="block text-center px-5 py-3 rounded-xl text-[14px] font-semibold"
+            style={{
+              background: "var(--accent-funnel)",
+              color: "var(--text-on-accent)",
+              textDecoration: "none",
+            }}
+          >
+            Get Started
+          </a>
+          <a
+            href="/login"
+            onClick={() => setOpen(false)}
+            className="block text-center px-5 py-3 rounded-xl text-[13px] font-semibold"
+            style={{
+              border: "1px solid var(--border-default)",
+              color: "var(--text-secondary)",
+              textDecoration: "none",
+            }}
+          >
+            Login
+          </a>
+        </div>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Insight

Mobile nav breaks at 390px viewport. Hamburger button gets compressed out of the flex container because it lacks `flex-shrink-0`, and the drawer uses conditional mount (`{open && ...}`) which prevents CSS slide-in transitions.

## Studio

Refactored MobileNav.tsx: hamburger button locked with `flex-shrink-0`, drawer always rendered with `translateX(-100%)` when closed enabling smooth CSS transition, separate backdrop overlay for tap-to-close UX, and drawer width capped at `min(80vw, 320px)`.

## Source / Reference

- V2 Verde task: hamburger/drawer mobile < 768px
- NavShell (packages/core) read-only — fix scoped entirely to MobileNav.tsx in apps/mouth/
- Root cause confirmed: BZLogo variant='full' + missing flex-shrink-0 = hamburger compression at 390px

## Methodology

- Read NavShell, MobileNav, page.tsx before any edit
- Identified flex layout collision between logo mr-auto and slotAfter ml-auto at 390px
- Chose Approach A: fix CSS/logic on existing MobileNav structure (not rebuild)

## Raw Observations

- MobileNav had useState toggle but missing flex-shrink-0 on trigger button
- Drawer used conditional mount — blocks CSS translateX transition
- No backdrop overlay for tap-outside-to-close
- Files changed: 1 | 99 insertions | 61 deletions

## Reasoning Path

Always-rendered drawer with translateX(-100%)/translateX(0) is standard mobile drawer pattern. Separate backdrop div at z-398 handles tap-to-close without coupling to drawer z-index.

## Risk / Implication

Low risk.
- Single file change in apps/mouth/ only
- NavShell (packages/core) untouched
- No analytics changes
- No backend changes
- No package-lock.json staged

## Recommendation

Merge after CI green. Test on 390px viewport in DevTools mobile emulation.

## Next Action

Post-merge: verify drawer slide-in on iPhone 14 viewport. All 5 Verde tasks complete — V1 + V4 + V2 merged, V3 + V5 confirmed no-op.