### PR TITLE
fix(intake): resolve LIVE candidate shape {table,id,name} — dead radio-list

### DIFF
--- a/apps/backend-rag/backend/app/routers/intake_review.py
+++ b/apps/backend-rag/backend/app/routers/intake_review.py
@@ -106,19 +106,27 @@ async def _require_own_chat_or_admin(
 # --------------------------------------------------------------------------- #
 # Candidate-client extraction (read-only helper)
 # --------------------------------------------------------------------------- #
-def _candidate_client_ids(entity_resolution: dict[str, Any]) -> list[int]:
+def _candidate_client_ids(
+    entity_resolution: dict[str, Any], routing: dict[str, Any] | None = None
+) -> list[int]:
     """Best-effort extraction of candidate client ids from the FASE-4 blob.
 
     FASE 4's entity_resolution shape is still settling; be tolerant. Recognised
     shapes:
       {"candidates": [{"client_id": 412, ...}, ...]}
+      {"candidates": [{"id": 412, "table": "clients", ...}, ...]}   <- LIVE shape
       {"client_id": 412}
       {"resolved_client_id": 412}
+    plus the routing blob's resolved target ({"client_id": 412}) as fallback.
+
+    The ``id``+``table`` variant is what the production resolver actually
+    writes (every live proposal sampled 2026-06-11 used it) — recognising only
+    ``client_id`` left entity_candidates empty and the UI radio list dead.
     Returns a de-duplicated list of ints (empty if nothing resolvable).
     """
     ids: list[int] = []
     if not isinstance(entity_resolution, dict):
-        return ids
+        entity_resolution = {}
 
     for key in ("resolved_client_id", "client_id"):
         val = entity_resolution.get(key)
@@ -128,8 +136,15 @@ def _candidate_client_ids(entity_resolution: dict[str, Any]) -> list[int]:
     candidates = entity_resolution.get("candidates")
     if isinstance(candidates, list):
         for cand in candidates:
-            if isinstance(cand, dict) and isinstance(cand.get("client_id"), int):
+            if not isinstance(cand, dict):
+                continue
+            if isinstance(cand.get("client_id"), int):
                 ids.append(cand["client_id"])
+            elif isinstance(cand.get("id"), int) and cand.get("table") in (None, "clients"):
+                ids.append(cand["id"])
+
+    if isinstance(routing, dict) and isinstance(routing.get("client_id"), int):
+        ids.append(routing["client_id"])
 
     # de-dup preserving order
     seen: set[int] = set()
@@ -304,7 +319,7 @@ async def list_review_queue(
             if decision is not None and row_decision != decision:
                 continue
 
-            candidate_ids = _candidate_client_ids(entity_resolution)
+            candidate_ids = _candidate_client_ids(entity_resolution, routing)
             candidates = await _load_candidate_clients(conn, candidate_ids)
 
             # RBAC: the own-chat gate (received_by) is enforced in the SQL WHERE
@@ -538,7 +553,7 @@ async def get_review_detail(
         commit_gate = _as_dict(row["commit_gate"])
         stage_output = _as_dict(row["stage_output"])
 
-        candidate_ids = _candidate_client_ids(entity_resolution)
+        candidate_ids = _candidate_client_ids(entity_resolution, routing)
         candidates = await _load_candidate_clients(conn, candidate_ids)
 
         # OCR text per page — for human review. The current pipeline runs OCR

--- a/apps/backend-rag/backend/tests/routers/test_intake_review.py
+++ b/apps/backend-rag/backend/tests/routers/test_intake_review.py
@@ -125,8 +125,12 @@ async def seed(pool: asyncpg.Pool) -> AsyncIterator[dict]:
              "candidates": [{"client_id": cid_owner, "score": 0.95}]},
             received_by=TEAM_OWNER["email"])
         p_other = await mk_proposal(
+            # LIVE resolver shape (routing.py): {"table","id","name"} — NOT
+            # "client_id". Regression for the dead radio-list bug: the reader
+            # must resolve this shape into entity_candidates.
             {"decision": "LINK_CANDIDATE", "score": 0.80,
-             "candidates": [{"client_id": cid_other, "score": 0.80}]},
+             "candidates": [{"table": "clients", "id": cid_other,
+                             "name": f"{tag}-other", "score": 0.80}]},
             received_by=TEAM_OTHER["email"])
         p_nomatch = await mk_proposal(
             {"decision": "NO_MATCH", "candidates": []},
@@ -823,3 +827,54 @@ async def test_approve_practice_explicit_archive_only(pool, seed, monkeypatch):
     op_tables = [op["table"] for op in plan["ops"]]
     assert "documents" in op_tables  # the archive (document UPSERT) is planned
     assert "practices.documents[]" not in op_tables  # NO practice-attach op
+
+
+async def test_entity_candidates_resolve_live_resolver_shape(pool, seed):
+    """The radio-list regression: candidates written as {"table","id","name"}
+    (the shape the production resolver in routing.py ACTUALLY writes — every
+    live proposal sampled 2026-06-11 used it) must resolve into a populated
+    entity_candidates list. The reader previously recognised only "client_id"
+    → entity_candidates was always [] and the UI's proposed-client radio list
+    was dead code; the only resolvable proposals were test-seeded ones."""
+    app = _make_app(pool, ADMIN)
+    async with _client(app) as cl:
+        # p_other was seeded with the LIVE shape (id+table, no client_id).
+        r = await cl.get(f"/api/intake/review/{seed['p_other']}")
+        assert r.status_code == 200, r.text
+        cands = r.json()["entity_candidates"]
+        assert len(cands) == 1, f"live-shape candidate not resolved: {cands}"
+        assert cands[0]["client_id"] == seed["cid_other"]
+        assert cands[0]["full_name"] == f"{seed['tag']}-other"
+
+        # p_owner keeps the legacy "client_id" shape — both must work.
+        r = await cl.get(f"/api/intake/review/{seed['p_owner']}")
+        assert r.status_code == 200, r.text
+        cands = r.json()["entity_candidates"]
+        assert len(cands) == 1
+        assert cands[0]["client_id"] == seed["cid_owner"]
+
+
+async def test_candidate_ids_routing_fallback_and_companies_excluded(pool, seed):
+    """routing.client_id is a valid fallback source; companies-table candidate
+    ids must NOT be looked up in the clients table (id collision hazard)."""
+    pid = seed["p_nomatch"]  # seeded with zero candidates
+    async with pool.acquire() as conn:
+        # companies candidate (must be ignored) + routing resolved client.
+        await conn.execute(
+            "UPDATE document_routing_proposal SET "
+            "entity_resolution = entity_resolution || "
+            "  jsonb_build_object('candidates', jsonb_build_array("
+            "    jsonb_build_object('table','companies','id',$2::int,'name','co'))), "
+            "routing = routing || jsonb_build_object('client_id', $3::int) "
+            "WHERE id=$1",
+            pid, seed["cid_other"], seed["cid_owner"])
+
+    app = _make_app(pool, ADMIN)
+    async with _client(app) as cl:
+        r = await cl.get(f"/api/intake/review/{pid}")
+        assert r.status_code == 200, r.text
+        cands = r.json()["entity_candidates"]
+        ids = [c["client_id"] for c in cands]
+        assert seed["cid_owner"] in ids, f"routing.client_id fallback missing: {cands}"
+        assert seed["cid_other"] not in ids, (
+            f"companies-table id leaked into clients lookup: {cands}")


### PR DESCRIPTION
Follow-up to #1299, found by authenticated QA as a real team member (adit) right after the rollout.

**Bug**: `entity_candidates` was ALWAYS `[]` — the reader's `_candidate_client_ids` only recognised `"client_id"`, but the production resolver (`routing.py`) writes `{"table":"clients","id":…,"name":…}` (every live proposal sampled 2026-06-11 uses this shape). The UI's proposed-client radio list was dead code; reviewers fell back to manual search even on a 0.99 passport-number AUTO_ATTACH.

**Fix**:
- accept `{"id","table"}` candidates — clients table only (`table:"companies"` ids must NOT be looked up in the clients table)
- `routing.client_id` as fallback source (both call sites)
- seed `p_other` with the LIVE shape so the real contract is pinned (mock≠production scar class: the suite was green because the seed spoke the reader's own dialect)
- 2 regression tests (live shape + legacy shape both resolve; companies excluded; routing fallback)

**Verified**: 33/33 `test_intake_review.py` on the Pro against real `nuzantara_dev`.

**Post-merge**: deploy worktree pull + `launchctl kickstart -k gui/501/com.nuzantara.intake-review-reader`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)