### PR TITLE
fix(security): migrate 3 paid-Anthropic call sites to Max-plan OAuth/CLI

### DIFF
--- a/apps/backend-rag/process_batches_2_3.py
+++ b/apps/backend-rag/process_batches_2_3.py
@@ -7,12 +7,12 @@ from typing import Any
 
 import httpx
 import pdfplumber
-from anthropic import AsyncAnthropic
 
 # Add backend to path
 sys.path.append("/Users/nuzantara/Desktop/nuzantara/apps/backend-rag")
 
 # Nuzantara imports
+from backend.llm.claude_oauth_client import complete_async
 from backend.services.integrations.drive.drive_auth import DriveAuthManager
 
 # Configure logging
@@ -31,7 +31,6 @@ BATCH_3 = [{'company_id': 2526, 'name': 'PT Unity Land Development', 'drive_file
 class BatchProcessor:
     def __init__(self):
         self.http_client = httpx.AsyncClient(timeout=60.0)
-        self.anthropic = AsyncAnthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
         self.drive_auth = DriveAuthManager(db_pool=None, http_client=self.http_client)
 
     async def get_token(self):
@@ -106,12 +105,12 @@ TEXT:
         max_retries = 3
         for attempt in range(max_retries):
             try:
-                response = await self.anthropic.messages.create(
-                    model="claude-3-5-sonnet-20241022",
-                    max_tokens=2048,
-                    messages=[{"role": "user", "content": prompt}]
+                response = await complete_async(
+                    prompt,
+                    model="claude-sonnet-4-6",
+                    endpoint="batch_company_parser",
                 )
-                content = response.content[0].text
+                content = response.text
                 if "```json" in content:
                     content = content.split("```json")[1].split("```")[0].strip()
                 elif "```" in content:
@@ -161,8 +160,5 @@ TEXT:
         await self.run_batch(BATCH_3, os.path.join(RESULTS_DIR, "batch_3_results.json"))
 
 if __name__ == "__main__":
-    if not os.environ.get("ANTHROPIC_API_KEY"):
-        logger.error("Missing ANTHROPIC_API_KEY")
-        sys.exit(1)
     processor = BatchProcessor()
     asyncio.run(processor.run())

--- a/apps/backend-rag/scripts/claims_extractor.py
+++ b/apps/backend-rag/scripts/claims_extractor.py
@@ -16,13 +16,13 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import os
 import re
-import sys
 from pathlib import Path
 from typing import Any
 
 from dotenv import load_dotenv
+
+from backend.llm.claude_oauth_client import complete_async
 
 load_dotenv(Path(__file__).resolve().parents[1] / ".env", override=False)
 
@@ -125,21 +125,22 @@ async def extract_claims_from_file(
     source_path: Path,
     instrument_id: str,
     domain: str,
-    anthropic_api_key: str,
 ) -> list[dict[str, Any]]:
-    """Extract claims from a source file using Claude Haiku 4.5."""
-    import anthropic
+    """Extract claims from a source file using Claude Haiku 4.5 (OAuth/CLI).
 
+    Uses the Max-plan OAuth path (``claude`` CLI via
+    ``backend.llm.claude_oauth_client``) — never ``ANTHROPIC_API_KEY``
+    (CLAUDE.md §5 / Golden Rule #13).
+    """
     source_text = source_path.read_text(encoding="utf-8")
     prompt = build_extraction_prompt(source_text, instrument_id, domain)
 
-    client = anthropic.AsyncAnthropic(api_key=anthropic_api_key)
-    response = await client.messages.create(
+    response = await complete_async(
+        prompt,
         model="claude-haiku-4-5-20251001",
-        max_tokens=4096,
-        messages=[{"role": "user", "content": prompt}],
+        endpoint="claims_extractor",
     )
-    raw = response.content[0].text
+    raw = response.text
     claims = parse_claims_response(raw)
     logger.info("Extracted %d raw claims from %s", len(claims), instrument_id)
     return claims
@@ -153,11 +154,6 @@ def main() -> None:
     parser.add_argument("--instrument-id", required=True, help="e.g. UU-6-2011")
     args = parser.parse_args()
 
-    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
-    if not api_key:
-        print("ERROR: ANTHROPIC_API_KEY not set", file=sys.stderr)  # noqa: T201
-        sys.exit(1)
-
     import asyncio
     source_path = Path(args.source)
     output_path = Path(__file__).parent / "claims_db" / f"{args.domain}_claims_db.json"
@@ -165,12 +161,12 @@ def main() -> None:
     start_idx = len(existing) + 1
 
     new_claims = asyncio.run(
-        extract_claims_from_file(source_path, args.instrument_id, args.domain, api_key)
+        extract_claims_from_file(source_path, args.instrument_id, args.domain)
     )
     stamped = stamp_claims(new_claims, args.domain, start_idx)
     all_claims = existing + stamped
     save_claims_db(all_claims, output_path)
-    print(f"Added {len(stamped)} new claims. Total: {len(all_claims)}")  # noqa: T201
+    print(f"Added {len(stamped)} new claims. Total: {len(all_claims)}")
 
 
 if __name__ == "__main__":

--- a/apps/bali-intel-scraper/backend/services/ai_engine.py
+++ b/apps/bali-intel-scraper/backend/services/ai_engine.py
@@ -187,35 +187,38 @@ class AIBatchProcessor:
         )
 
     async def _call_anthropic(self, request: AIRequest) -> AIResponse:
-        """Call Anthropic API."""
-        import anthropic
+        """Call Claude via Max-plan OAuth (``claude`` CLI), never the paid API.
+
+        CLAUDE.md §5 / Golden Rule #13: ``ANTHROPIC_API_KEY`` is banned.
+        The OAuth CLI has no separate system slot, no token metadata and no
+        max_tokens/temperature knobs — so the system prompt is inlined and
+        usage is estimated (``len // 4``, industry rule-of-thumb).
+        """
+        from backend.services.claude_oauth import complete_oauth
 
         await limit_ai_request("anthropic")
 
-        client = anthropic.AsyncAnthropic(api_key=settings.ai.anthropic_api_key)
+        # settings.ai.anthropic_model defaults to a legacy slug the CLI
+        # rejects (claude-3-opus-20240229); force a current default unless
+        # the caller passes an explicit model.
+        model = request.model or "claude-sonnet-4-6"
+        prompt = f"{self._get_system_prompt(request.task_type)}\n\n{request.content}"
 
         start_time = asyncio.get_event_loop().time()
-
-        response = await client.messages.create(
-            model=request.model or settings.ai.anthropic_model,
-            max_tokens=request.max_tokens,
-            temperature=request.temperature,
-            system=self._get_system_prompt(request.task_type),
-            messages=[{"role": "user", "content": request.content}],
-        )
-
+        text = await complete_oauth(prompt, model=model)
         latency = (asyncio.get_event_loop().time() - start_time) * 1000
 
+        prompt_tokens = max(1, len(prompt) // 4)
+        completion_tokens = max(1, len(text) // 4)
         return AIResponse(
-            content=response.content[0].text,
+            content=text,
             usage={
-                "prompt_tokens": response.usage.input_tokens,
-                "completion_tokens": response.usage.output_tokens,
-                "total_tokens": response.usage.input_tokens
-                + response.usage.output_tokens,
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": prompt_tokens + completion_tokens,
             },
-            model=response.model,
-            finish_reason=response.stop_reason,
+            model=model,
+            finish_reason="stop",
             latency_ms=latency,
         )
 

--- a/apps/bali-intel-scraper/backend/services/claude_oauth.py
+++ b/apps/bali-intel-scraper/backend/services/claude_oauth.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 import shutil
 from pathlib import Path
 from typing import Final
@@ -31,6 +32,21 @@ _CLI_CANDIDATES: Final[tuple[Path, ...]] = (
     Path.home() / ".npm-global/bin" / "claude",
     Path("/usr/local/bin/claude"),
 )
+# Pure text-completion never needs tools. Block the destructive/exfil ones
+# defense-in-depth so an OSINT-content prompt-injection (the prompt is built
+# from scraped, untrusted text) can never reach a tool — replaces the unsafe
+# `--permission-mode bypassPermissions` the reference client still carries.
+_DISALLOWED_TOOLS: Final[tuple[str, ...]] = (
+    "Bash",
+    "Edit",
+    "Write",
+    "WebFetch",
+    "WebSearch",
+    "NotebookEdit",
+)
+# Model slug allowlist-by-shape: forwarded to `--model`, so reject anything
+# that isn't a plain slug (blocks argv/flag smuggling via the model field).
+_MODEL_RE: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{1,63}$")
 
 
 class ClaudeOAuthError(RuntimeError):
@@ -75,11 +91,17 @@ async def complete_oauth(
     """
     if not prompt:
         raise ValueError("prompt must be non-empty")
+    if model is not None and not _MODEL_RE.match(model):
+        raise ValueError(f"invalid model slug: {model!r}")
 
-    cmd: list[str] = [_resolve_cli(), "-p", "--permission-mode", "bypassPermissions"]
+    # No bypassPermissions: tools are explicitly disallowed and the default
+    # permission mode fails-closed on any tool the model still attempts.
+    cmd: list[str] = [_resolve_cli(), "-p", "--disallowedTools", *_DISALLOWED_TOOLS]
     if model:
         cmd.extend(["--model", model])
-    cmd.append(prompt)
+    # `--` sentinel: the untrusted prompt that follows is an operand, never a
+    # flag (argv/flag-smuggling guard).
+    cmd.extend(["--", prompt])
 
     try:
         proc = await asyncio.create_subprocess_exec(

--- a/apps/bali-intel-scraper/backend/services/claude_oauth.py
+++ b/apps/bali-intel-scraper/backend/services/claude_oauth.py
@@ -1,0 +1,114 @@
+"""Claude via Max-plan OAuth (subprocess to ``claude -p``).
+
+Local, self-contained substitute for the banned paid path
+``anthropic.AsyncAnthropic(api_key=...)`` (CLAUDE.md §5 / Golden Rule #13).
+``bali-intel-scraper`` is a separate app and cannot import
+``backend.llm.claude_oauth_client`` from ``backend-rag`` — this is a
+minimal mirror of that module's contract (one-shot prompt -> text, no
+streaming, no tool-use), which is exactly what ``ai_engine`` needs.
+
+The ``claude`` CLI reads ``CLAUDE_CODE_OAUTH_TOKEN`` from the environment
+(or the macOS keychain when unset). ``ANTHROPIC_API_KEY`` is stripped
+unconditionally so the CLI can never silently fall back to the paid key.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+from pathlib import Path
+from typing import Final
+
+from backend.core.logger import get_logger
+
+logger = get_logger(__name__, component="claude_oauth")
+
+DEFAULT_TIMEOUT_S: Final[int] = 120
+_CLI_CANDIDATES: Final[tuple[Path, ...]] = (
+    Path("/opt/homebrew/bin/claude"),
+    Path.home() / ".local/bin" / "claude",
+    Path.home() / ".npm-global/bin" / "claude",
+    Path("/usr/local/bin/claude"),
+)
+
+
+class ClaudeOAuthError(RuntimeError):
+    """Raised when the ``claude`` CLI fails or returns empty output."""
+
+
+def _resolve_cli() -> str:
+    resolved = shutil.which("claude")
+    if resolved:
+        return resolved
+    for candidate in _CLI_CANDIDATES:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    return "claude"
+
+
+def _build_env() -> dict[str, str]:
+    env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+    token = os.getenv("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
+    if token:
+        env["CLAUDE_CODE_OAUTH_TOKEN"] = token
+    return env
+
+
+async def complete_oauth(
+    prompt: str,
+    *,
+    model: str | None = None,
+    timeout_s: int = DEFAULT_TIMEOUT_S,
+) -> str:
+    """Run ``claude -p`` and return the text completion.
+
+    Args:
+        prompt: The full prompt (any system framing must be inlined — the
+            CLI has no separate system-prompt slot).
+        model: Optional CLI model slug (e.g. ``claude-sonnet-4-6``).
+        timeout_s: Wall-clock timeout for the subprocess.
+
+    Raises:
+        ClaudeOAuthError: missing binary, non-zero exit, timeout, or empty
+            output.
+    """
+    if not prompt:
+        raise ValueError("prompt must be non-empty")
+
+    cmd: list[str] = [_resolve_cli(), "-p", "--permission-mode", "bypassPermissions"]
+    if model:
+        cmd.extend(["--model", model])
+    cmd.append(prompt)
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            env=_build_env(),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError as exc:
+        raise ClaudeOAuthError(
+            "`claude` CLI not found in PATH. Install: https://claude.ai/code",
+        ) from exc
+
+    try:
+        stdout_b, stderr_b = await asyncio.wait_for(
+            proc.communicate(), timeout=timeout_s
+        )
+    except asyncio.TimeoutError as exc:
+        proc.kill()
+        raise ClaudeOAuthError(f"claude CLI timeout after {timeout_s}s") from exc
+
+    output = (stdout_b.decode(errors="replace") or "").strip()
+    stderr = (stderr_b.decode(errors="replace") or "").strip()
+
+    if proc.returncode != 0:
+        raise ClaudeOAuthError(
+            f"claude CLI exit={proc.returncode} stderr={stderr[:200]}"
+        )
+    if not output:
+        raise ClaudeOAuthError("claude CLI returned empty output (quota/rate?)")
+
+    return output


### PR DESCRIPTION
## Cosa
Chiude uno dei 2 P0 dell'audit guardian-of-guardians (2026-06-11): i **3 siti che istanziano il client Anthropic a pagamento** (`anthropic.AsyncAnthropic(api_key=...)`), vietato da CLAUDE.md §5 / Golden Rule #13 perché duplica l'abbonamento Claude MAX flat con costo per-token. Migrati tutti al path sanzionato (OAuth via `claude` CLI). Decisione operatore: "migrali tutti e 3 ora".

| File | App | Prima | Dopo |
|---|---|---|---|
| `scripts/claims_extractor.py` | backend-rag | `AsyncAnthropic(api_key=…)` Haiku | `claude_oauth_client.complete_async` |
| `process_batches_2_3.py` | backend-rag | `AsyncAnthropic(api_key=…)` + slug morto `claude-3-5-sonnet-20241022` | `complete_async` + `claude-sonnet-4-6` |
| `services/ai_engine.py` | bali-intel-scraper | `anthropic.AsyncAnthropic(api_key=…)` | helper locale `claude_oauth.complete_oauth` |

Tutti e 3 facevano lo stesso one-shot `prompt → text` (zero streaming/tool-use) → mappano puliti sul client OAuth.

`bali-intel-scraper` è un'app separata (non può importare `backend-rag`) → nuovo helper minimale `apps/bali-intel-scraper/backend/services/claude_oauth.py` che rispecchia il contratto CLI-subprocess.

## Hardening (da automated commit-review)
Il nuovo helper aveva ereditato il pattern del client di riferimento; corretto:
- **[HIGH]** rimosso `--permission-mode bypassPermissions` (il prompt è costruito da contenuto OSINT scrapato untrusted → mai dare accesso a tool). Sostituito con `--disallowedTools Bash Edit Write WebFetch WebSearch NotebookEdit`; default-mode fail-closed.
- **[MED]** sentinel `--` prima del prompt untrusted + allowlist-by-shape sul `model` (anti argv/flag-smuggling).

## Verifica
- ruff clean sui file backend-rag; `claude_oauth.py` clean
- 7/7 test `test_claims_extractor`; import chain risolve `complete_async`
- **smoke test LIVE**: l'argv esatto (`-p --disallowedTools … -- "<prompt>"`) ritorna completion pulita
- `grep` finale: zero `Anthropic(api_key=` nei 3 file
- pre-push full suite: 14532 passed (1 fail ambientale `test_live_kbli` = QDRANT env non settato in locale, non-bloccante, non regressione)

## Follow-up noti (NON in questo PR)
- `backend/llm/claude_oauth_client.py` (client di riferimento) porta lo **stesso** `bypassPermissions` + no-sentinel → hardening dedicato (file caldo, molti consumer).
- `catE-paid-anthropic-baseline.txt` (PR #1306): dopo merge di entrambi, il baseline (3 siti noti) diventa 0 → aggiornare a vuoto. Il lint non si rompe (live<baseline = PASS).

Relativo: PR #1306 (audit drift-lints), audit `research/operations/2026-06-11-guardian-of-guardians.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)