### PR TITLE
feat(intake): approve delivers to client Drive folder + Fly CRM (FASE 5D)

### DIFF
--- a/apps/backend-rag/backend/app/intake_review_reader.py
+++ b/apps/backend-rag/backend/app/intake_review_reader.py
@@ -138,6 +138,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     try:
         yield
     finally:
+        # The reader is the process that actually runs the CRM pusher in
+        # production (the Fly-mounted router is bypassed by the proxy) — close
+        # its persistent httpx client here, not just in the app factory.
+        from backend.services.intake import crm_push
+
+        await crm_push.close_client()
         await pool.close()
         app.state.db_pool = None
         logger.info("intake_review_reader: db pool closed")

--- a/apps/backend-rag/backend/app/routers/intake_review.py
+++ b/apps/backend-rag/backend/app/routers/intake_review.py
@@ -106,19 +106,27 @@ async def _require_own_chat_or_admin(
 # --------------------------------------------------------------------------- #
 # Candidate-client extraction (read-only helper)
 # --------------------------------------------------------------------------- #
-def _candidate_client_ids(entity_resolution: dict[str, Any]) -> list[int]:
+def _candidate_client_ids(
+    entity_resolution: dict[str, Any], routing: dict[str, Any] | None = None
+) -> list[int]:
     """Best-effort extraction of candidate client ids from the FASE-4 blob.
 
     FASE 4's entity_resolution shape is still settling; be tolerant. Recognised
     shapes:
       {"candidates": [{"client_id": 412, ...}, ...]}
+      {"candidates": [{"id": 412, "table": "clients", ...}, ...]}   <- LIVE shape
       {"client_id": 412}
       {"resolved_client_id": 412}
+    plus the routing blob's resolved target ({"client_id": 412}) as fallback.
+
+    The ``id``+``table`` variant is what the production resolver actually
+    writes (every live proposal sampled 2026-06-11 used it) — recognising only
+    ``client_id`` left entity_candidates empty and the UI radio list dead.
     Returns a de-duplicated list of ints (empty if nothing resolvable).
     """
     ids: list[int] = []
     if not isinstance(entity_resolution, dict):
-        return ids
+        entity_resolution = {}
 
     for key in ("resolved_client_id", "client_id"):
         val = entity_resolution.get(key)
@@ -128,8 +136,15 @@ def _candidate_client_ids(entity_resolution: dict[str, Any]) -> list[int]:
     candidates = entity_resolution.get("candidates")
     if isinstance(candidates, list):
         for cand in candidates:
-            if isinstance(cand, dict) and isinstance(cand.get("client_id"), int):
+            if not isinstance(cand, dict):
+                continue
+            if isinstance(cand.get("client_id"), int):
                 ids.append(cand["client_id"])
+            elif isinstance(cand.get("id"), int) and cand.get("table") in (None, "clients"):
+                ids.append(cand["id"])
+
+    if isinstance(routing, dict) and isinstance(routing.get("client_id"), int):
+        ids.append(routing["client_id"])
 
     # de-dup preserving order
     seen: set[int] = set()
@@ -304,7 +319,7 @@ async def list_review_queue(
             if decision is not None and row_decision != decision:
                 continue
 
-            candidate_ids = _candidate_client_ids(entity_resolution)
+            candidate_ids = _candidate_client_ids(entity_resolution, routing)
             candidates = await _load_candidate_clients(conn, candidate_ids)
 
             # RBAC: the own-chat gate (received_by) is enforced in the SQL WHERE
@@ -538,7 +553,7 @@ async def get_review_detail(
         commit_gate = _as_dict(row["commit_gate"])
         stage_output = _as_dict(row["stage_output"])
 
-        candidate_ids = _candidate_client_ids(entity_resolution)
+        candidate_ids = _candidate_client_ids(entity_resolution, routing)
         candidates = await _load_candidate_clients(conn, candidate_ids)
 
         # OCR text per page — for human review. The current pipeline runs OCR

--- a/apps/backend-rag/backend/app/routers/intake_review.py
+++ b/apps/backend-rag/backend/app/routers/intake_review.py
@@ -41,11 +41,12 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import asyncpg
-from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request
 from fastapi.responses import FileResponse
 
 from backend.app.dependencies import get_current_user, get_database_pool
 from backend.app.utils.crm_utils import is_crm_admin
+from backend.services.intake import crm_push as intake_crm_push
 from backend.services.intake import writer as intake_writer
 
 logger = logging.getLogger(__name__)
@@ -807,10 +808,148 @@ async def _require_active_claim(
 
 
 # --------------------------------------------------------------------------- #
+# Post-commit Pro→Fly CRM delivery (Drive folder + Fly documents row)
+# --------------------------------------------------------------------------- #
+async def _deliver_committed_to_crm(
+    *,
+    pool: asyncpg.Pool,
+    request: Request,
+    queue_id: int | None,
+    plan: intake_writer.CommitPlan,
+    result: intake_writer.CommitResult,
+) -> dict[str, Any]:
+    """Best-effort delivery of a COMMITTED document to the Fly CRM.
+
+    Runs AFTER the local commit transaction succeeded (the local Pro Postgres
+    commit stays the source of truth for the approve outcome). Reuses the Fly
+    base64 upload endpoint, authenticated with the reviewer's own bearer JWT
+    (forwarded by the Fly proxy on the incoming request). On success the LOCAL
+    ``documents`` row is enriched with the Drive file_id/file_url; either way
+    the push status is appended to the ``intake_commit_audit.plan`` jsonb of
+    this commit's audit row. NEVER raises — a failed delivery leaves the
+    approve outcome 'committed' and surfaces {status, detail} to the caller.
+    """
+    import json as _json
+
+    if not intake_crm_push.push_enabled():
+        return {"status": "disabled"}
+
+    # Reviewer's bearer JWT — reused for the Pro→Fly call (same RBAC actor).
+    auth_header = request.headers.get("authorization") or ""
+    bearer = auth_header[7:].strip() if auth_header.lower().startswith("bearer ") else None
+
+    blob_path: str | None = None
+    mime_type: str | None = None
+    already: asyncpg.Record | None = None
+    async with pool.acquire() as conn:
+        if queue_id is not None:
+            qrow = await conn.fetchrow(
+                """
+                SELECT q.blob_path, di.mime_type
+                FROM intake_queue q
+                LEFT JOIN document_instances di ON di.id = q.instance_id
+                WHERE q.id = $1
+                """,
+                queue_id,
+            )
+            if qrow is not None:
+                blob_path = qrow["blob_path"]
+                mime_type = qrow["mime_type"]
+        # Idempotent re-approve guard: if the local row already carries a Drive
+        # file (previous successful push, or Drive-sourced intake), do NOT
+        # upload again — that would duplicate the file in the client's folder.
+        if result.doc_id is not None:
+            already = await conn.fetchrow(
+                "SELECT file_id, file_url FROM documents WHERE id = $1", result.doc_id
+            )
+
+    payload = plan.payload
+    if already is not None and (already["file_id"] or already["file_url"]):
+        push = intake_crm_push.CrmPushResult(
+            ok=False,
+            status="already_delivered",
+            file_id=already["file_id"],
+            file_url=already["file_url"],
+            detail="local documents row already has a Drive file — skipping re-upload",
+        )
+    elif not blob_path:
+        push = intake_crm_push.CrmPushResult(
+            ok=False, status="missing_blob", detail="no blob_path on intake_queue row"
+        )
+    else:
+        push = await intake_crm_push.push_committed_document(
+            bearer_token=bearer,
+            client_id=int(plan.client_id),  # type: ignore[arg-type]  # committed ⇒ non-None
+            practice_id=plan.practice_id,
+            document_type=payload.get("document_type") or "unknown",
+            document_category=payload.get("document_category"),
+            file_name=payload.get("file_name") or os.path.basename(blob_path),
+            blob_path=blob_path,
+            mime_type=mime_type,
+            expiry_date=payload.get("expiry_date"),
+            notes=payload.get("notes"),
+        )
+
+    crm_info: dict[str, Any] = {
+        "status": push.status,
+        "fly_doc_id": push.fly_doc_id,
+        "file_url": push.file_url,
+    }
+    if push.detail:
+        crm_info["detail"] = push.detail
+
+    # Post-delivery bookkeeping (best-effort, outside the commit TX by design).
+    try:
+        async with pool.acquire() as conn:
+            if push.ok and result.doc_id is not None:
+                await conn.execute(
+                    """
+                    UPDATE documents
+                       SET file_id = COALESCE($2, file_id),
+                           file_url = COALESCE($3, file_url),
+                           google_drive_file_url = COALESCE($3, google_drive_file_url),
+                           storage_type = 'google_drive',
+                           updated_at = NOW()
+                     WHERE id = $1
+                    """,
+                    result.doc_id,
+                    push.file_id,
+                    push.file_url,
+                )
+            if result.audit_id is not None:
+                await conn.execute(
+                    """
+                    UPDATE intake_commit_audit
+                       SET plan = COALESCE(plan, '{}'::jsonb) || $2::jsonb
+                     WHERE id = $1
+                    """,
+                    result.audit_id,
+                    _json.dumps({"crm_push": crm_info}),
+                )
+    except (asyncpg.PostgresError, asyncpg.InterfaceError, OSError) as exc:
+        logger.error(
+            "intake.review.crm_push.bookkeeping_failed proposal=%s err=%s",
+            plan.proposal_id,
+            exc,
+        )
+
+    if not push.ok and push.status not in ("disabled", "already_delivered"):
+        logger.warning(
+            "intake.review.crm_push.failed proposal=%s doc=%s status=%s detail=%s",
+            plan.proposal_id,
+            result.doc_id,
+            push.status,
+            push.detail,
+        )
+    return crm_info
+
+
+# --------------------------------------------------------------------------- #
 # approve (dry-run 5B / real commit 5C) + reject (terminal, queue-management)
 # --------------------------------------------------------------------------- #
 @router.post("/{proposal_id}/approve")
 async def approve_review(
+    request: Request,
     proposal_id: int = Path(..., ge=1),
     body: dict[str, Any] = Body(default_factory=dict),
     user: dict[str, Any] = Depends(get_current_user),
@@ -887,11 +1026,24 @@ async def approve_review(
     # review_claimed (P0#9).
     advanced = result.outcome == "committed"
     response_status = "routed" if advanced else "review_claimed"
+
+    # Pro→Fly CRM delivery — ONLY after a REAL committed write (never dry-run,
+    # never blocked). The local commit above is final regardless of delivery.
+    crm_push_info: dict[str, Any] | None = None
+    if advanced and not result.dry_run:
+        crm_push_info = await _deliver_committed_to_crm(
+            pool=pool,
+            request=request,
+            queue_id=prop["queue_id"],
+            plan=plan,
+            result=result,
+        )
+
     logger.info(
         "intake.review.approve proposal=%s reviewer=%s dry_run=%s outcome=%s status=%s",
         proposal_id, user_email, result.dry_run, result.outcome, response_status,
     )
-    return {
+    response: dict[str, Any] = {
         "proposal_id": proposal_id,
         "dry_run": result.dry_run,
         "status": response_status,
@@ -899,6 +1051,9 @@ async def approve_review(
         "would_commit": plan.to_dict(),
         "result": result.to_dict(),
     }
+    if crm_push_info is not None:
+        response["crm_push"] = crm_push_info
+    return response
 
 
 @router.post("/{proposal_id}/reject")

--- a/apps/backend-rag/backend/app/setup/app_factory.py
+++ b/apps/backend-rag/backend/app/setup/app_factory.py
@@ -366,6 +366,14 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.debug("Checkpointer close skipped: %s", e)
 
+    # Close the intake→CRM push HTTP client (Golden Rule 10 — persistent client)
+    try:
+        from backend.services.intake.crm_push import close_client as close_crm_push_client
+
+        await close_crm_push_client()
+    except Exception as e:
+        logger.debug("CRM push client close skipped: %s", e)
+
     # NOTE: WebSocket Redis Listener, Compliance Monitor, and Autonomous Scheduler
     # shutdown removed — _init_background_services() is disabled (omnichannel stabilization).
     # Re-add shutdown code when _init_background_services() is re-enabled.

--- a/apps/backend-rag/backend/services/intake/crm_push.py
+++ b/apps/backend-rag/backend/services/intake/crm_push.py
@@ -1,0 +1,249 @@
+"""Pro→Fly CRM delivery for committed intake documents.
+
+When a reviewer APPROVES an intake proposal with the writer armed, the local
+(Pro Postgres) commit is the source of truth for the approve outcome. This
+module is the best-effort DELIVERY leg that runs AFTER that commit: it pushes
+the original blob to the existing Fly base64 upload endpoint
+(``POST /api/crm/clients/{client_id}/documents/upload`` —
+``crm_enhanced_documents.upload_document_base64``), which resolves/creates the
+client's Google Drive folder, uploads the file, INSERTs the canonical
+``documents`` row on the Fly Postgres (the CRM kita reads) and dispatches OCR.
+
+PII note: the blob transits Pro→Fly→Google Drive. That is the CRM's sanctioned
+storage path — identical to a manual upload from the kita frontend — so this
+does not widen the PII surface beyond what every manual document upload
+already does (Law 2: the intake REVIEW data itself stays on the Pro; only the
+approved document travels, authenticated with the reviewer's own JWT).
+
+Failure policy: :func:`push_committed_document` NEVER raises for delivery
+failures — it always returns a :class:`CrmPushResult`. The caller treats the
+local commit as final and surfaces the push status in the approve response +
+audit trail.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+import os
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://nuzantara-rag.fly.dev"
+DEFAULT_MAX_MB = 9.0  # raw bytes; base64 inflates ~33% against the endpoint's ~10MB class limit
+_REQUEST_TIMEOUT_SECONDS = 60.0
+
+# Google Drive webViewLink → file id (best-effort: the Fly endpoint's response
+# carries only document_id + file_url, not the bare Drive file id).
+_DRIVE_FILE_ID_RE = re.compile(r"/d/([A-Za-z0-9_-]{10,})")
+
+
+def push_enabled() -> bool:
+    """Kill-switch — ``INTAKE_CRM_PUSH_ENABLED`` (default ON)."""
+    return os.environ.get("INTAKE_CRM_PUSH_ENABLED", "1").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
+def _push_base_url() -> str:
+    return os.environ.get("INTAKE_CRM_PUSH_BASE_URL", "").strip() or DEFAULT_BASE_URL
+
+
+def _max_push_bytes() -> int:
+    """Raw-blob size guard in bytes (env ``INTAKE_CRM_PUSH_MAX_MB``, default 9 MB)."""
+    raw = os.environ.get("INTAKE_CRM_PUSH_MAX_MB", "").strip()
+    try:
+        mb = float(raw) if raw else DEFAULT_MAX_MB
+    except ValueError:
+        mb = DEFAULT_MAX_MB
+    return int(mb * 1024 * 1024)
+
+
+# --------------------------------------------------------------------------- #
+# Persistent HTTP client (Golden Rule 10) — lazy module singleton.
+# --------------------------------------------------------------------------- #
+_client: httpx.AsyncClient | None = None
+
+
+def _get_client() -> httpx.AsyncClient:
+    global _client
+    if _client is None or _client.is_closed:
+        _client = httpx.AsyncClient(timeout=httpx.Timeout(_REQUEST_TIMEOUT_SECONDS))
+    return _client
+
+
+async def close_client() -> None:
+    """Close the module HTTP client (called from the app lifespan shutdown)."""
+    global _client
+    if _client is not None and not _client.is_closed:
+        await _client.aclose()
+    _client = None
+
+
+@dataclass
+class CrmPushResult:
+    """Outcome of one Pro→Fly document delivery attempt."""
+
+    ok: bool
+    status: str  # pushed | too_large | denied_rbac | rejected | server_error |
+    #              unreachable | no_token | missing_blob | error
+    fly_doc_id: int | None = None
+    file_id: str | None = None
+    file_url: str | None = None
+    detail: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _parse_drive_file_id(file_url: str | None) -> str | None:
+    if not file_url:
+        return None
+    m = _DRIVE_FILE_ID_RE.search(file_url)
+    return m.group(1) if m else None
+
+
+async def push_committed_document(
+    *,
+    bearer_token: str | None,
+    client_id: int,
+    file_name: str,
+    document_type: str,
+    blob_path: str,
+    practice_id: int | None = None,
+    document_category: str | None = None,
+    mime_type: str | None = None,
+    expiry_date: str | None = None,
+    notes: str | None = None,
+    family_member_id: int | None = None,
+    base_url: str | None = None,
+) -> CrmPushResult:
+    """Deliver one committed intake blob to the Fly CRM upload endpoint.
+
+    Matches ``DocumentUploadBase64`` (crm_enhanced_documents.py) exactly:
+    ``file`` (base64), ``file_name``, ``document_type`` + the optional
+    ``mime_type`` / ``notes`` / ``document_category`` / ``expiry_date`` /
+    ``family_member_id`` / ``practice_id``. Fields the endpoint does not
+    accept (e.g. extracted_fields) are deliberately NOT sent.
+
+    Auth: the reviewer's own ``Authorization: Bearer <jwt>`` — the Fly endpoint
+    enforces ``get_current_user`` + ``verify_client_access(write=True)``.
+
+    Retry: ONE retry on transient failures (connect/read errors, 5xx).
+    401/403 → ``denied_rbac`` (no retry). Other 4xx → ``rejected``.
+    NEVER raises for delivery failures — always returns a CrmPushResult.
+    """
+    if not bearer_token:
+        return CrmPushResult(ok=False, status="no_token", detail="no bearer token on request")
+
+    path = Path(blob_path)
+    try:
+        raw = await asyncio.to_thread(path.read_bytes)
+    except (FileNotFoundError, IsADirectoryError, PermissionError, OSError) as exc:
+        return CrmPushResult(
+            ok=False, status="missing_blob", detail=f"{type(exc).__name__}: {exc}"
+        )
+
+    max_bytes = _max_push_bytes()
+    if len(raw) > max_bytes:
+        return CrmPushResult(
+            ok=False,
+            status="too_large",
+            detail=f"blob {len(raw)} bytes exceeds limit {max_bytes} bytes",
+        )
+
+    payload: dict[str, Any] = {
+        "file": base64.b64encode(raw).decode("ascii"),
+        "file_name": file_name,
+        "document_type": document_type,
+    }
+    optional_fields: dict[str, Any] = {
+        "mime_type": mime_type,
+        "notes": notes,
+        "document_category": document_category,
+        "expiry_date": expiry_date,
+        "family_member_id": family_member_id,
+        "practice_id": practice_id,
+    }
+    payload.update({key: value for key, value in optional_fields.items() if value is not None})
+
+    url = f"{(base_url or _push_base_url()).rstrip('/')}/api/crm/clients/{client_id}/documents/upload"
+    headers = {"Authorization": f"Bearer {bearer_token}"}
+    client = _get_client()
+
+    try:
+        last_detail: str | None = None
+        for attempt in (0, 1):
+            try:
+                resp = await client.post(url, json=payload, headers=headers)
+            except (httpx.TimeoutException, httpx.TransportError) as exc:
+                last_detail = f"{type(exc).__name__}: {exc}"
+                if attempt == 0:
+                    logger.warning(
+                        "intake.crm_push.transient client=%s err=%s — retrying once",
+                        client_id,
+                        last_detail,
+                    )
+                    continue
+                return CrmPushResult(ok=False, status="unreachable", detail=last_detail)
+
+            if resp.status_code in (401, 403):
+                return CrmPushResult(
+                    ok=False,
+                    status="denied_rbac",
+                    detail=f"HTTP {resp.status_code}: {resp.text[:200]}",
+                )
+            if resp.status_code >= 500:
+                last_detail = f"HTTP {resp.status_code}: {resp.text[:200]}"
+                if attempt == 0:
+                    logger.warning(
+                        "intake.crm_push.5xx client=%s detail=%s — retrying once",
+                        client_id,
+                        last_detail,
+                    )
+                    continue
+                return CrmPushResult(ok=False, status="server_error", detail=last_detail)
+            if resp.status_code >= 400:
+                return CrmPushResult(
+                    ok=False,
+                    status="rejected",
+                    detail=f"HTTP {resp.status_code}: {resp.text[:200]}",
+                )
+
+            # 2xx — response shape: {"success", "document_id", "file_url", ...}
+            try:
+                data = resp.json()
+            except ValueError:
+                data = {}
+            if not isinstance(data, dict):
+                data = {}
+            fly_doc_id = data.get("document_id")
+            file_url = data.get("file_url")
+            logger.info(
+                "intake.crm_push.pushed client=%s fly_doc=%s file_url=%s",
+                client_id,
+                fly_doc_id,
+                bool(file_url),
+            )
+            return CrmPushResult(
+                ok=True,
+                status="pushed",
+                fly_doc_id=int(fly_doc_id) if fly_doc_id is not None else None,
+                file_id=_parse_drive_file_id(file_url),
+                file_url=file_url,
+            )
+        # Unreachable: the loop always returns. Defensive fallthrough.
+        return CrmPushResult(ok=False, status="error", detail=last_detail or "exhausted retries")
+    except Exception as exc:  # delivery must never break the approve
+        logger.exception("intake.crm_push.unexpected client=%s", client_id)
+        return CrmPushResult(ok=False, status="error", detail=f"{type(exc).__name__}: {exc}")

--- a/apps/backend-rag/backend/tests/routers/test_intake_review.py
+++ b/apps/backend-rag/backend/tests/routers/test_intake_review.py
@@ -125,8 +125,12 @@ async def seed(pool: asyncpg.Pool) -> AsyncIterator[dict]:
              "candidates": [{"client_id": cid_owner, "score": 0.95}]},
             received_by=TEAM_OWNER["email"])
         p_other = await mk_proposal(
+            # LIVE resolver shape (routing.py): {"table","id","name"} — NOT
+            # "client_id". Regression for the dead radio-list bug: the reader
+            # must resolve this shape into entity_candidates.
             {"decision": "LINK_CANDIDATE", "score": 0.80,
-             "candidates": [{"client_id": cid_other, "score": 0.80}]},
+             "candidates": [{"table": "clients", "id": cid_other,
+                             "name": f"{tag}-other", "score": 0.80}]},
             received_by=TEAM_OTHER["email"])
         p_nomatch = await mk_proposal(
             {"decision": "NO_MATCH", "candidates": []},
@@ -823,3 +827,54 @@ async def test_approve_practice_explicit_archive_only(pool, seed, monkeypatch):
     op_tables = [op["table"] for op in plan["ops"]]
     assert "documents" in op_tables  # the archive (document UPSERT) is planned
     assert "practices.documents[]" not in op_tables  # NO practice-attach op
+
+
+async def test_entity_candidates_resolve_live_resolver_shape(pool, seed):
+    """The radio-list regression: candidates written as {"table","id","name"}
+    (the shape the production resolver in routing.py ACTUALLY writes — every
+    live proposal sampled 2026-06-11 used it) must resolve into a populated
+    entity_candidates list. The reader previously recognised only "client_id"
+    → entity_candidates was always [] and the UI's proposed-client radio list
+    was dead code; the only resolvable proposals were test-seeded ones."""
+    app = _make_app(pool, ADMIN)
+    async with _client(app) as cl:
+        # p_other was seeded with the LIVE shape (id+table, no client_id).
+        r = await cl.get(f"/api/intake/review/{seed['p_other']}")
+        assert r.status_code == 200, r.text
+        cands = r.json()["entity_candidates"]
+        assert len(cands) == 1, f"live-shape candidate not resolved: {cands}"
+        assert cands[0]["client_id"] == seed["cid_other"]
+        assert cands[0]["full_name"] == f"{seed['tag']}-other"
+
+        # p_owner keeps the legacy "client_id" shape — both must work.
+        r = await cl.get(f"/api/intake/review/{seed['p_owner']}")
+        assert r.status_code == 200, r.text
+        cands = r.json()["entity_candidates"]
+        assert len(cands) == 1
+        assert cands[0]["client_id"] == seed["cid_owner"]
+
+
+async def test_candidate_ids_routing_fallback_and_companies_excluded(pool, seed):
+    """routing.client_id is a valid fallback source; companies-table candidate
+    ids must NOT be looked up in the clients table (id collision hazard)."""
+    pid = seed["p_nomatch"]  # seeded with zero candidates
+    async with pool.acquire() as conn:
+        # companies candidate (must be ignored) + routing resolved client.
+        await conn.execute(
+            "UPDATE document_routing_proposal SET "
+            "entity_resolution = entity_resolution || "
+            "  jsonb_build_object('candidates', jsonb_build_array("
+            "    jsonb_build_object('table','companies','id',$2::int,'name','co'))), "
+            "routing = routing || jsonb_build_object('client_id', $3::int) "
+            "WHERE id=$1",
+            pid, seed["cid_other"], seed["cid_owner"])
+
+    app = _make_app(pool, ADMIN)
+    async with _client(app) as cl:
+        r = await cl.get(f"/api/intake/review/{pid}")
+        assert r.status_code == 200, r.text
+        cands = r.json()["entity_candidates"]
+        ids = [c["client_id"] for c in cands]
+        assert seed["cid_owner"] in ids, f"routing.client_id fallback missing: {cands}"
+        assert seed["cid_other"] not in ids, (
+            f"companies-table id leaked into clients lookup: {cands}")

--- a/apps/backend-rag/backend/tests/routers/test_intake_review.py
+++ b/apps/backend-rag/backend/tests/routers/test_intake_review.py
@@ -643,6 +643,39 @@ async def test_approve_dry_run_after_claim(pool, seed):
     assert after == before
 
 
+async def test_approve_dry_run_never_calls_crm_pusher(pool, seed, monkeypatch):
+    """Dry-run approve (writer OFF) must NOT call the Pro→Fly CRM pusher.
+
+    The Fly delivery leg runs ONLY after a REAL committed write. A sentinel
+    replaces push_committed_document: any call fails the test. The dry-run
+    response also must NOT carry a crm_push key (response unchanged vs 5B).
+    """
+    monkeypatch.delenv("INTAKE_WRITER_ENABLED", raising=False)
+    calls: list[dict] = []
+
+    async def _sentinel(**kwargs):
+        calls.append(kwargs)
+        raise AssertionError("CRM pusher must not be called on a dry-run approve")
+
+    from backend.services.intake import crm_push
+    monkeypatch.setattr(crm_push, "push_committed_document", _sentinel)
+
+    app = _make_app(pool, ADMIN)
+    pid = seed["p_owner"]
+    async with _client(app) as cl:
+        rc = await cl.post(f"/api/intake/review/{pid}/claim")
+        assert rc.status_code == 200, rc.text
+        ra = await cl.post(
+            f"/api/intake/review/{pid}/approve",
+            json={"claim_token": rc.json()["claim_token"]},
+        )
+    assert ra.status_code == 200, ra.text
+    body = ra.json()
+    assert body["dry_run"] is True
+    assert "crm_push" not in body
+    assert calls == []
+
+
 async def test_zero_crm_write(pool, seed):
     """Full exercise of every endpoint must NOT mutate clients/practices."""
     before = await _crm_counts(pool)

--- a/apps/backend-rag/backend/tests/services/intake/test_crm_push.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_crm_push.py
@@ -1,0 +1,237 @@
+"""Unit tests for the Pro→Fly CRM delivery module (backend.services.intake.crm_push).
+
+NO database, NO network: HTTP is faked via httpx.MockTransport injected into
+the module's persistent client. Asserts the request matches the REAL Fly
+endpoint contract (path /api/crm/clients/{id}/documents/upload + the
+DocumentUploadBase64 field names) and the response parsing
+({"success", "document_id", "file_url"}).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import AsyncIterator, Callable
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from backend.services.intake import crm_push
+
+pytestmark = pytest.mark.asyncio
+
+CLIENT_ID = 77
+BLOB_BYTES = b"%PDF-1.4 fake intake blob bytes"
+DRIVE_FILE_ID = "1AbC2dEfG3hIjK4LmNoP"
+DRIVE_URL = f"https://drive.google.com/file/d/{DRIVE_FILE_ID}/view?usp=drivesdk"
+
+
+@pytest.fixture
+def blob(tmp_path: Path) -> Path:
+    p = tmp_path / "passport-scan.pdf"
+    p.write_bytes(BLOB_BYTES)
+    return p
+
+
+@pytest_asyncio.fixture
+async def mock_client() -> AsyncIterator[Callable[..., list[httpx.Request]]]:
+    """Install a MockTransport-backed client into the module; restore after.
+
+    Usage: ``requests = mock_client(handler)`` — returns the (live) list of
+    captured requests; the handler decides each response.
+    """
+    captured: list[httpx.Request] = []
+    saved = crm_push._client
+
+    def install(handler: Callable[[httpx.Request], httpx.Response]) -> list[httpx.Request]:
+        def _wrapped(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return handler(request)
+
+        crm_push._client = httpx.AsyncClient(transport=httpx.MockTransport(_wrapped))
+        return captured
+
+    yield install
+
+    if crm_push._client is not None and not crm_push._client.is_closed:
+        await crm_push._client.aclose()
+    crm_push._client = saved
+
+
+def _push_kwargs(blob: Path, **overrides: object) -> dict:
+    kwargs: dict = {
+        "bearer_token": "jwt-token-abc",
+        "client_id": CLIENT_ID,
+        "file_name": "passport-scan.pdf",
+        "document_type": "passport",
+        "blob_path": str(blob),
+        "practice_id": 12,
+        "document_category": "immigration",
+        "mime_type": "application/pdf",
+        "notes": "intake:wa-123",
+        "base_url": "http://fly.test",
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+# --------------------------------------------------------------------------- #
+async def test_success_parses_doc_id_file_url_and_drive_file_id(mock_client, blob):
+    """200 → ok=True, document_id/file_url parsed, Drive file id extracted."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "success": True,
+                "document_id": 321,
+                "file_url": DRIVE_URL,
+                "ocr_triggered": True,
+                "company_document_id": None,
+            },
+        )
+
+    requests = mock_client(handler)
+    result = await crm_push.push_committed_document(**_push_kwargs(blob))
+
+    assert result.ok is True
+    assert result.status == "pushed"
+    assert result.fly_doc_id == 321
+    assert result.file_url == DRIVE_URL
+    assert result.file_id == DRIVE_FILE_ID
+
+    # Exactly one request, against the REAL endpoint path, with the reviewer JWT.
+    assert len(requests) == 1
+    req = requests[0]
+    assert req.url.path == f"/api/crm/clients/{CLIENT_ID}/documents/upload"
+    assert req.headers["authorization"] == "Bearer jwt-token-abc"
+
+    # Body matches DocumentUploadBase64 field names exactly.
+    body = json.loads(req.content)
+    assert base64.b64decode(body["file"]) == BLOB_BYTES
+    assert body["file_name"] == "passport-scan.pdf"
+    assert body["document_type"] == "passport"
+    assert body["document_category"] == "immigration"
+    assert body["mime_type"] == "application/pdf"
+    assert body["notes"] == "intake:wa-123"
+    assert body["practice_id"] == 12
+    # Fields the endpoint does NOT accept must not be sent.
+    assert "extracted_fields" not in body
+    # None optionals are dropped, not sent as null.
+    assert "expiry_date" not in body
+    assert "family_member_id" not in body
+
+
+async def test_403_denied_rbac_no_retry(mock_client, blob):
+    requests = mock_client(lambda r: httpx.Response(403, json={"detail": "nope"}))
+    result = await crm_push.push_committed_document(**_push_kwargs(blob))
+
+    assert result.ok is False
+    assert result.status == "denied_rbac"
+    assert "403" in (result.detail or "")
+    assert len(requests) == 1  # no retry on auth failures
+
+
+async def test_401_denied_rbac_no_retry(mock_client, blob):
+    requests = mock_client(lambda r: httpx.Response(401, json={"detail": "expired"}))
+    result = await crm_push.push_committed_document(**_push_kwargs(blob))
+
+    assert result.ok is False
+    assert result.status == "denied_rbac"
+    assert len(requests) == 1
+
+
+async def test_other_4xx_rejected_no_retry(mock_client, blob):
+    requests = mock_client(lambda r: httpx.Response(400, json={"detail": "Invalid base64"}))
+    result = await crm_push.push_committed_document(**_push_kwargs(blob))
+
+    assert result.ok is False
+    assert result.status == "rejected"
+    assert len(requests) == 1
+
+
+async def test_500_then_200_retried_ok(mock_client, blob):
+    responses = iter(
+        [
+            httpx.Response(500, text="upstream burp"),
+            httpx.Response(200, json={"success": True, "document_id": 9, "file_url": DRIVE_URL}),
+        ]
+    )
+    requests = mock_client(lambda r: next(responses))
+    result = await crm_push.push_committed_document(**_push_kwargs(blob))
+
+    assert result.ok is True
+    assert result.status == "pushed"
+    assert result.fly_doc_id == 9
+    assert len(requests) == 2  # one retry
+
+
+async def test_500_twice_server_error(mock_client, blob):
+    requests = mock_client(lambda r: httpx.Response(500, text="dead"))
+    result = await crm_push.push_committed_document(**_push_kwargs(blob))
+
+    assert result.ok is False
+    assert result.status == "server_error"
+    assert len(requests) == 2
+
+
+async def test_connect_error_twice_unreachable(mock_client, blob):
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    requests = mock_client(handler)
+    result = await crm_push.push_committed_document(**_push_kwargs(blob))
+
+    assert result.ok is False
+    assert result.status == "unreachable"
+    assert "ConnectError" in (result.detail or "")
+    assert len(requests) == 2  # initial + ONE retry
+
+
+async def test_oversize_blob_too_large_without_http_call(mock_client, blob, monkeypatch):
+    monkeypatch.setenv("INTAKE_CRM_PUSH_MAX_MB", "0.00001")  # ~10 bytes
+    requests = mock_client(lambda r: httpx.Response(200, json={"success": True}))
+    result = await crm_push.push_committed_document(**_push_kwargs(blob))
+
+    assert result.ok is False
+    assert result.status == "too_large"
+    assert requests == []  # size guard fires BEFORE any HTTP
+
+
+async def test_missing_blob_no_http_call(mock_client, tmp_path):
+    requests = mock_client(lambda r: httpx.Response(200, json={"success": True}))
+    result = await crm_push.push_committed_document(
+        **_push_kwargs(tmp_path / "ghost.pdf")
+    )
+
+    assert result.ok is False
+    assert result.status == "missing_blob"
+    assert requests == []
+
+
+async def test_no_token_no_http_call(mock_client, blob):
+    requests = mock_client(lambda r: httpx.Response(200, json={"success": True}))
+    result = await crm_push.push_committed_document(**_push_kwargs(blob, bearer_token=None))
+
+    assert result.ok is False
+    assert result.status == "no_token"
+    assert requests == []
+
+
+def test_push_enabled_default_and_kill_switch(monkeypatch):
+    monkeypatch.delenv("INTAKE_CRM_PUSH_ENABLED", raising=False)
+    assert crm_push.push_enabled() is True
+    monkeypatch.setenv("INTAKE_CRM_PUSH_ENABLED", "0")
+    assert crm_push.push_enabled() is False
+    monkeypatch.setenv("INTAKE_CRM_PUSH_ENABLED", "false")
+    assert crm_push.push_enabled() is False
+    monkeypatch.setenv("INTAKE_CRM_PUSH_ENABLED", "1")
+    assert crm_push.push_enabled() is True
+
+
+def test_parse_drive_file_id():
+    assert crm_push._parse_drive_file_id(DRIVE_URL) == DRIVE_FILE_ID
+    assert crm_push._parse_drive_file_id(None) is None
+    assert crm_push._parse_drive_file_id("https://example.com/no-drive") is None


### PR DESCRIPTION
Closes the last gap in the intake flow per Antonello's directive: *"voglio il documento/file al suo posto perfetto su Drive, e nel suo posto perfetto su kita."*

**Before**: approve committed the documents row to the Pro-LOCAL Postgres only (Law 2 pipeline). Fly Postgres (18.5k docs, what kita's client profile reads) got **zero** intake docs; no Drive upload (`file_url` NULL).

**Now**: after the local commit succeeds, the Pro reader pushes the blob to the **existing** Fly upload endpoint (`POST /api/crm/clients/{id}/documents/upload`) with the reviewer's own bearer JWT. That endpoint already does the perfect placement: client Drive folder (auto-created `{id}_{name}` under the right root), category subfolders (`01_Immigration`, `03_Tax`, …), visa rotation (Actual→Previous), `documents` row on Fly → visible in the kita client profile + practice view, OCR dispatch.

Design:
- Local commit stays the approve gate; the push is best-effort delivery with typed statuses (`pushed/too_large/denied_rbac/rejected/server_error/unreachable`), 1 retry on transient, never raises.
- Reviewer's own JWT → Fly re-enforces `verify_client_access(write=True)`, `uploaded_by` = the real human.
- `already_delivered` guard: idempotent re-approve / Drive-sourced docs never duplicate files.
- Local row enriched with `file_id`/`file_url` on success; push status appended to the commit's audit jsonb.
- Kill-switch `INTAKE_CRM_PUSH_ENABLED`; size guard `INTAKE_CRM_PUSH_MAX_MB` (default 9MB raw, b64 inflation vs endpoint limits).
- Dry-run path byte-identical.

**Tests**: 46/46 on the Pro against real `nuzantara_dev` (34 DB-backed router + 12 MockTransport unit). Fire-test with synthetic client planned post-merge (incl. Drive file cleanup).

**Post-merge (Pro)**: deploy worktree pull + `launchctl kickstart -k gui/501/com.nuzantara.intake-review-reader`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)