### PR TITLE
feat(wr2): facts-block body structurer — label/value stack + source line (designer-loop convergence)

### DIFF
--- a/apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py
@@ -2263,3 +2263,237 @@ async def test_render_carousel_reject_cites_critiques_and_dumps_history(monkeypa
     payload = _json.loads(dumps[0].read_text())
     assert payload["draft_id"] == "draft-test"
     assert payload["history"] == hist
+
+
+# ── facts-block body structurer (designer-loop convergence, 2026-06-12) ──────
+# Diagnosis: draft 3e2c2923 slide 2 HARD-rejected every iteration because the
+# body renders as ONE monolithic uppercase-bold paragraph; the vision critic's
+# only lever is `rerender` (structural) which no CSS lever can perform → the
+# loop can never converge. The fix is a deterministic body structurer in the
+# COMPOSER: label/value stack + separated subordinate source line + yellow
+# accent on the lead value. Conservative: non-parsing bodies render
+# byte-identical to the legacy paragraph path; cover slides untouched.
+
+_FACTS_BODY = (
+    "NEW FEE: IDR 3,500,000. OLD FEE: IDR 2,000,000. REGULATION: PMK 47/2026. "
+    "EFFECTIVE: 1 JUNE 2026. [SOURCE: KEMENKEU, 24 APR 2026]"
+)
+_FACTS_BODY_NO_SOURCE = (
+    "NEW FEE: IDR 3,500,000. OLD FEE: IDR 2,000,000. REGULATION: PMK 47/2026. "
+    "EFFECTIVE: 1 JUNE 2026."
+)
+
+
+def test_split_source_line_extracts_trailing_source():
+    """_split_source_line extracts a trailing [SOURCE: …] verbatim (brackets
+    stripped) and returns the body without it."""
+    from wr2_html_renderer.composer import _split_source_line
+
+    body, src = _split_source_line(_FACTS_BODY)
+    assert body == _FACTS_BODY_NO_SOURCE
+    assert src == "SOURCE: KEMENKEU, 24 APR 2026"
+
+
+def test_split_source_line_fonte_and_case_insensitive():
+    from wr2_html_renderer.composer import _split_source_line
+
+    body, src = _split_source_line("BODY TEXT. [Fonte: Kemenkeu, 24 Apr 2026]")
+    assert body == "BODY TEXT."
+    assert src == "Fonte: Kemenkeu, 24 Apr 2026"
+    body, src = _split_source_line("BODY TEXT. [source: imigrasi]")
+    assert body == "BODY TEXT."
+    assert src == "source: imigrasi"
+
+
+def test_split_source_line_no_source_returns_none():
+    from wr2_html_renderer.composer import _split_source_line
+
+    plain = "A NORMAL BODY WITH NO ATTRIBUTION AT ALL."
+    assert _split_source_line(plain) == (plain, None)
+    # a NON-trailing bracket segment is content, not attribution — untouched
+    mid = "[SOURCE: X] FOLLOWED BY MORE TEXT."
+    assert _split_source_line(mid) == (mid, None)
+
+
+def test_parse_fact_pairs_parses_facts_body():
+    """The exact 3e2c2923 slide-2 style body (source-stripped) parses into
+    ordered label/value pairs."""
+    from wr2_html_renderer.composer import _parse_fact_pairs
+
+    pairs = _parse_fact_pairs(_FACTS_BODY_NO_SOURCE)
+    assert pairs == [
+        ("NEW FEE", "IDR 3,500,000"),
+        ("OLD FEE", "IDR 2,000,000"),
+        ("REGULATION", "PMK 47/2026"),
+        ("EFFECTIVE", "1 JUNE 2026"),
+    ]
+
+
+def test_parse_fact_pairs_none_for_prose():
+    """Conservative fallback: anything that is not a clean ≥2-pair chain of
+    `LABEL: value. ` segments returns None (legacy paragraph rendering)."""
+    from wr2_html_renderer.composer import _parse_fact_pairs
+
+    # narrative sentence with one colon → single segment → None
+    assert _parse_fact_pairs(
+        "THE MINISTRY CONFIRMED: FEES WILL RISE SHARPLY IN JUNE 2026."
+    ) is None
+    # plain prose, no colon at all
+    assert _parse_fact_pairs(
+        "YOUR KITAP STAYS VALID. THE RENEWAL WINDOW MOVED TO MARCH."
+    ) is None
+    # mixed: one fact segment + one narrative segment → whole-or-nothing → None
+    assert _parse_fact_pairs(
+        "NEW FEE: IDR 3,500,000. THIS IS WHY IT MATTERS FOR YOUR VISA."
+    ) is None
+    # label longer than 4 words → None
+    assert _parse_fact_pairs(
+        "WHAT YOU NEED TO KNOW NOW: EVERYTHING. ALSO THIS OTHER THING HERE: MORE."
+    ) is None
+    # empty / whitespace
+    assert _parse_fact_pairs("") is None
+    assert _parse_fact_pairs("   ") is None
+
+
+_BODY_SLIDE_HTML = (
+    "<html><head></head><body>"
+    '<div class="text-panel" data-zone-type="text">'
+    '<div class="heading">{{heading}}</div>'
+    '<div class="body">{{body}}</div>'
+    "</div></body></html>"
+)
+
+
+def test_fill_placeholders_facts_body_renders_label_value_stack():
+    """A facts body renders as a label/value stack: one row per pair, the
+    source line present OUTSIDE the rows, yellow accent on the FIRST value
+    only (the lead fact), facts CSS injected."""
+    from wr2_html_renderer.composer import _fill_placeholders
+
+    out = _fill_placeholders(
+        _BODY_SLIDE_HTML,
+        {"headline": "VISA FEE UPDATE", "body": _FACTS_BODY},
+        hero_filename=None,
+        cover_family=False,
+    )
+    # 4 label/value rows
+    assert out.count('class="fact-row"') == 4
+    assert '<div class="fact-label">NEW FEE</div>' in out
+    assert '<div class="fact-label">EFFECTIVE</div>' in out
+    # yellow accent on the FIRST value only
+    assert out.count("fact-value-lead") >= 1
+    assert '<div class="fact-value fact-value-lead">IDR 3,500,000</div>' in out
+    assert '<div class="fact-value">IDR 2,000,000</div>' in out
+    assert '<div class="fact-value">PMK 47/2026</div>' in out
+    assert 'fact-value-lead">IDR 2,000,000' not in out
+    # source line present, OUTSIDE the rows, brackets stripped
+    assert '<div class="fact-source">SOURCE: KEMENKEU, 24 APR 2026</div>' in out
+    assert "[SOURCE" not in out
+    last_row = out.rfind('class="fact-row"')
+    assert out.find('class="fact-source"') > last_row
+    # facts CSS injected, accent from the existing brand token (no invented hex)
+    assert 'data-facts-block="1"' in out
+    assert "var(--color-accent-yellow)" in out
+    # the dead-void fix: the text stack centers vertically in its zone
+    assert "justify-content:center" in out
+    assert "{{body}}" not in out
+
+
+def test_fill_placeholders_facts_body_without_source_still_stacks():
+    from wr2_html_renderer.composer import _fill_placeholders
+
+    out = _fill_placeholders(
+        _BODY_SLIDE_HTML,
+        {"headline": "VISA FEE UPDATE", "body": _FACTS_BODY_NO_SOURCE},
+        hero_filename=None,
+        cover_family=False,
+    )
+    assert out.count('class="fact-row"') == 4
+    assert 'class="fact-source"' not in out
+
+
+def test_fill_placeholders_non_parsing_body_byte_identical():
+    """Regression: a body that does NOT parse as fact pairs renders EXACTLY as
+    before the change — placeholder substituted verbatim, no facts markup, no
+    injected facts CSS."""
+    from wr2_html_renderer.composer import _fill_placeholders
+
+    prose = "YOUR KITAP STAYS VALID. THE RENEWAL WINDOW MOVED TO MARCH."
+    out = _fill_placeholders(
+        _BODY_SLIDE_HTML,
+        {"headline": "SHORT TITLE", "body": prose},
+        hero_filename=None,
+        cover_family=False,
+    )
+    # pre-change snapshot semantics: plain placeholder substitution only
+    expected = _BODY_SLIDE_HTML.replace("{{heading}}", "SHORT TITLE").replace(
+        "{{body}}", prose
+    )
+    assert out == expected
+    assert "fact-row" not in out
+    assert "data-facts-block" not in out
+
+
+def test_fill_placeholders_cover_family_facts_body_untouched():
+    """Cover slides are COMPLETELY untouched by the facts structurer — even a
+    body that would parse as pairs renders as the legacy paragraph."""
+    from wr2_html_renderer.composer import _fill_placeholders
+
+    out = _fill_placeholders(
+        _BODY_SLIDE_HTML,
+        {"headline": "FEE", "body": _FACTS_BODY},
+        hero_filename=None,
+        cover_family=True,
+    )
+    assert "fact-row" not in out
+    assert "data-facts-block" not in out
+    expected = _BODY_SLIDE_HTML.replace("{{heading}}", "FEE").replace(
+        "{{body}}", _FACTS_BODY
+    )
+    assert out == expected
+
+
+def test_materialize_body_slide_facts_stack_and_centering():
+    """materialize_slide_html on a NON-cover body slide with a facts body emits
+    the stack + the vertical-centering CSS (dead-void critique) into the HTML
+    file the renderer consumes."""
+    import asyncio
+    import tempfile
+    from pathlib import Path
+    from unittest.mock import patch
+
+    BODY_SKELETON = """<!doctype html>
+<html><head><link rel="stylesheet" href="../_base.css"></head>
+<body>
+  <div class="text-panel" data-zone-type="text">
+    <div class="subheading">{{subheading}}</div>
+    <div class="heading">{{heading}}</div>
+    <div class="body">{{body}}</div>
+  </div>
+</body></html>"""
+
+    slide = {
+        "slide_number": 2,
+        "slide_type": "facts",
+        "headline": "THE NUMBERS",
+        "subhead": "PMK 47/2026",
+        "body": _FACTS_BODY,
+    }
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        slides_dir = Path(tmpdir) / "slides"
+        slides_dir.mkdir()
+        with patch(
+            "wr2_html_renderer.composer._extract_skeleton", return_value=BODY_SKELETON
+        ):
+            from wr2_html_renderer.composer import materialize_slide_html
+
+            html_path, expect_hero = asyncio.run(
+                materialize_slide_html(slide, slides_dir, index=2, total=6)
+            )
+        html = html_path.read_text()
+        assert html.count('class="fact-row"') == 4
+        assert '<div class="fact-source">SOURCE: KEMENKEU, 24 APR 2026</div>' in html
+        assert "justify-content:center" in html
+        assert "var(--color-accent-yellow)" in html
+        assert "[SOURCE" not in html

--- a/scripts/wr2_html_renderer/composer.py
+++ b/scripts/wr2_html_renderer/composer.py
@@ -679,6 +679,132 @@ def _wrap_headline_sentence_aware(
     return "<br>".join(out_lines), floor_px
 
 
+# ── facts-block body structurer (designer-loop convergence, 2026-06-12) ─────
+# Diagnosis (draft 3e2c2923 slide 2, HARD-reject history 2026-06-11): a "facts"
+# body like "NEW FEE: IDR 3,500,000. OLD FEE: IDR 2,000,000. REGULATION: PMK
+# 47/2026. EFFECTIVE: 1 JUNE 2026. [SOURCE: KEMENKEU, 24 APR 2026]" rendered as
+# ONE monolithic uppercase-bold paragraph. The vision critic HARD-rejects it
+# every iteration (no internal hierarchy, the key number doesn't pop, the
+# [SOURCE:…] attribution glued into the paragraph, the text block floats in
+# dead voids) and its only proposed lever is `rerender` — a structural
+# recomposition that no CSS lever can perform, so the designer loop can NEVER
+# converge on these slides. The fix lives HERE in the composer: detect the
+# label/value structure at compose time and render it as a proper stack.
+# CONSERVATIVE by contract (W68/W72/W73 discipline — never clobber a correct
+# rendering): a body that does not parse as fact pairs renders byte-identical
+# to the legacy paragraph path, and cover slides are completely untouched.
+
+# Trailing `[SOURCE: …]` / `[FONTE: …]` attribution (case-insensitive). Only a
+# TRAILING bracket segment is attribution — a mid-body bracket is content.
+_SOURCE_LINE_RE = re.compile(
+    r"\s*\[\s*((?:SOURCE|FONTE)\s*:\s*[^\]]+?)\s*\]\s*\.?\s*$",
+    re.IGNORECASE,
+)
+
+# A fact segment is `LABEL: value` — label 1-4 words with no internal period
+# (the [^.:] class enforces it), value non-empty.
+_FACT_SEGMENT_RE = re.compile(r"^([^.:]+):\s*(.+)$")
+_FACT_LABEL_MAX_WORDS = 4
+
+# Stack styling, brand-token-pure: label = small muted uppercase, value =
+# larger high-contrast extrabold, lead value (the key number) = the existing
+# brand yellow accent token, source line = subordinate (smaller, reduced
+# opacity, NOT uppercase-bold). `.text-panel{justify-content:center}` centers
+# the whole text stack vertically in its zone (the dead-void critique) — the
+# skeleton's .text-panel is already a flex column, so this is positioning-inert
+# for every other element. Selectors are defensive descendants of the
+# skeleton's .body slot; unused selectors are inert (same approach as levers).
+_FACTS_BLOCK_CSS = (
+    "\n<style data-facts-block=\"1\">\n"
+    ".text-panel{justify-content:center;}\n"
+    ".fact-row{margin-bottom:var(--spacing-list-gap);}\n"
+    ".fact-label{font-size:var(--font-size-body-md);color:var(--color-text-muted);"
+    "font-weight:var(--font-weight-bold);letter-spacing:var(--letter-spacing-title);"
+    "line-height:var(--line-height-snug);}\n"
+    ".fact-value{font-size:var(--font-size-subheadline);color:var(--color-text-white);"
+    "font-weight:var(--font-weight-extrabold);line-height:var(--line-height-snug);}\n"
+    ".fact-value-lead{color:var(--color-accent-yellow);}\n"
+    ".fact-source{margin-top:var(--spacing-section-gap);"
+    "font-size:calc(var(--font-size-body-md) * 0.8);color:var(--color-text-muted);"
+    "font-weight:400;text-transform:none;opacity:0.7;}\n"
+    "</style>\n"
+)
+
+
+def _split_source_line(body: str) -> tuple[str, str | None]:
+    """Extract a trailing `[SOURCE: …]` / `[FONTE: …]` attribution from a body.
+
+    Returns (body_without_source, source_text). source_text keeps the label +
+    citation verbatim (brackets stripped) — e.g. "SOURCE: KEMENKEU, 24 APR
+    2026" — so the attribution renders untouched on its own subordinate line.
+    A body with no trailing source returns (body, None).
+    """
+    m = _SOURCE_LINE_RE.search(body)
+    if not m:
+        return body, None
+    return body[: m.start()].rstrip(), m.group(1).strip()
+
+
+def _parse_fact_pairs(body: str) -> list[tuple[str, str]] | None:
+    """Heuristic LABEL/value parser for "facts" slide bodies.
+
+    Returns the ordered pairs ONLY when the whole (source-stripped) body is a
+    chain of ≥2 `LABEL: value` segments separated by `. ` — label 1-4 words
+    with no internal period, value non-empty. ANY segment that doesn't fit the
+    shape (narrative prose, a single colon-clause, a >4-word label) returns
+    None and the caller falls back to the legacy paragraph rendering
+    UNCHANGED. When in doubt: None — this MUST stay conservative.
+    """
+    text = (body or "").strip()
+    if not text:
+        return None
+    # Split AFTER a period followed by whitespace; each segment keeps its
+    # terminal period (stripped from the value below). Periods inside tokens
+    # (e.g. Indonesian "3.500.000") are not followed by a space → safe.
+    segments = [s.strip() for s in re.split(r"(?<=\.)\s+", text) if s.strip()]
+    if len(segments) < 2:
+        return None
+    pairs: list[tuple[str, str]] = []
+    for seg in segments:
+        m = _FACT_SEGMENT_RE.match(seg)
+        if not m:
+            return None
+        label = m.group(1).strip()
+        value = m.group(2).strip()
+        if value.endswith("."):
+            value = value[:-1].rstrip()  # the segment terminator, not content
+        if not label or not value:
+            return None
+        if len(label.split()) > _FACT_LABEL_MAX_WORDS:
+            return None
+        pairs.append((label, value))
+    return pairs
+
+
+def _facts_block_html(pairs: list[tuple[str, str]], source_text: str | None) -> str:
+    """Render parsed fact pairs as a label/value stack + optional source line.
+
+    Each row = small muted uppercase label + larger high-contrast value; the
+    FIRST row's value (the lead fact, e.g. the new fee) carries the brand
+    yellow accent so the key number pops. The source line sits OUTSIDE the
+    rows, at the bottom of the stack, as a subordinate attribution. Plain
+    string markup (no escaping) — consistent with _fill_placeholders, which
+    substitutes via str.replace.
+    """
+    rows: list[str] = []
+    for i, (label, value) in enumerate(pairs):
+        lead = " fact-value-lead" if i == 0 else ""
+        rows.append(
+            '<div class="fact-row">'
+            f'<div class="fact-label">{label}</div>'
+            f'<div class="fact-value{lead}">{value}</div>'
+            "</div>"
+        )
+    if source_text:
+        rows.append(f'<div class="fact-source">{source_text}</div>')
+    return "\n".join(rows)
+
+
 def _fill_placeholders(
     html: str,
     slide: dict[str, Any],
@@ -724,6 +850,20 @@ def _fill_placeholders(
     body = (slide.get("body") or slide.get("body_text") or "").strip()
     reg = (slide.get("regulation_code") or slide.get("primary_regulation_code") or "").strip()
 
+    # Facts-block body structurer (NON-cover slides only): when the body parses
+    # as a chain of LABEL: value facts, render it as a label/value stack with a
+    # separated subordinate source line instead of one monolithic paragraph.
+    # When it does NOT parse (or on a cover), body_html stays the verbatim body
+    # and NO facts CSS is injected → byte-identical to the legacy rendering.
+    body_html = body
+    facts_block = False
+    if body and not cover_family:
+        body_wo_source, source_text = _split_source_line(body)
+        pairs = _parse_fact_pairs(body_wo_source)
+        if pairs:
+            body_html = _facts_block_html(pairs, source_text)
+            facts_block = True
+
     # {{#if regulation_code}} ... {{/if}}
     if reg:
         html = re.sub(r"\{\{#if regulation_code\}\}(.*?)\{\{/if\}\}", r"\1", html, flags=re.DOTALL)
@@ -737,7 +877,7 @@ def _fill_placeholders(
         "{{heading}}": headline,
         "{{subheading}}": subhead,
         "{{subhead}}": subhead,
-        "{{body}}": body,
+        "{{body}}": body_html,
         "{{regulation_code}}": reg,
         "{{statement}}": statement,
     }
@@ -768,6 +908,16 @@ def _fill_placeholders(
             html = html.replace("</body>", font_css + "</body>", 1)
         else:
             html = html + font_css
+
+    # Inject the facts-block styles ONLY when the stack was rendered, so a
+    # non-parsing body stays byte-identical to the legacy paragraph output.
+    if facts_block:
+        if "</head>" in html:
+            html = html.replace("</head>", _FACTS_BLOCK_CSS + "</head>", 1)
+        elif "</body>" in html:
+            html = html.replace("</body>", _FACTS_BLOCK_CSS + "</body>", 1)
+        else:
+            html = html + _FACTS_BLOCK_CSS
 
     return html
 


### PR DESCRIPTION
## Diagnosis (via the HARD-reject observability from #1300)

Draft `3e2c2923` slide 2 history (`~/logs/wr2-html-debug/20260611T163038Z-…`): a "facts" body renders as ONE monolithic uppercase-bold paragraph (`NEW FEE: … OLD FEE: … REGULATION: … [SOURCE: …]`). The vision critic HARD-rejects **every iteration** — no internal hierarchy (wants label/value pairs), key number doesn't pop (no brand accent), `[SOURCE: …]` glued into the paragraph, dead voids above/below — and its only proposed lever is `rerender`, a structural recomposition **no CSS lever can perform**. The designer loop can never converge on these slides; this is why 0/3 drafts rendered tonight with identical critiques.

## Fix (composer-side, deterministic)

- `_split_source_line`: extracts a trailing `[SOURCE: …]`/`[FONTE: …]` into a separate subordinate source line.
- `_parse_fact_pairs`: conservative heuristic — body of ≥2 `LABEL: value.` segments → label/value pairs; anything ambiguous returns None and renders **byte-identical to today** (regression-tested).
- Facts stack rendering: muted uppercase labels + high-contrast values, brand yellow accent on the FIRST value only (the lead fact), block vertically centered.
- Cover slides completely untouched.

## Tests

TDD, RED verified first. Suite `test_wr2_html_render_apply.py`: **86 passed** (was 76). Regression test proves non-parsing bodies render identical markup to before.

E2E gate after merge: deploy pull + reset draft `3e2c2923` + re-render — the designer loop itself is the final judge (M1).

Part of P-1 follow-up (Antonello GO 2026-06-11). Subagent died on a 529 mid-flow; commit verified independently (tests re-run from clean state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)