### PR TITLE
fix(kita): drop dead Team Performance columns + wire Clienti/Processi KPIs (P0.2)

### DIFF
--- a/apps/backend-rag/backend/app/routers/dashboard_summary.py
+++ b/apps/backend-rag/backend/app/routers/dashboard_summary.py
@@ -171,6 +171,25 @@ async def _get_revenue_stats(db_pool: asyncpg.Pool) -> dict:
         }
 
 
+async def _get_total_clients(db_pool: asyncpg.Pool) -> int:
+    """
+    Total registered clients for the admin KPI bar.
+
+    Uses the SAME definition as /api/crm/clients/stats/overview (the source of
+    the /clients page total): every non-soft-deleted client, regardless of
+    status. NOT the /api/dashboard/stats definition (status = 'active'), which
+    yields a different number and would make the KPI disagree with /clients.
+    """
+    try:
+        async with db_pool.acquire() as conn:
+            return (
+                await conn.fetchval("SELECT COUNT(*) FROM clients WHERE deleted_at IS NULL") or 0
+            )
+    except Exception as e:
+        logger.warning("Failed to get total clients: %s", e)
+        return 0
+
+
 async def _calculate_revenue_growth(db_pool: asyncpg.Pool) -> float:
     """
     Calculate revenue growth percentage (current month vs previous month).
@@ -281,6 +300,7 @@ async def get_dashboard_summary(
                         {"total_revenue": 0, "paid_revenue": 0, "outstanding_revenue": 0},
                     ),
                     _with_timeout(_calculate_revenue_growth(db_pool), 0.0),
+                    _with_timeout(_get_total_clients(db_pool), 0),
                 ],
             )
 
@@ -310,6 +330,7 @@ async def get_dashboard_summary(
             else {"total_revenue": 0, "paid_revenue": 0, "outstanding_revenue": 0}
         )
         revenue_growth = results[7] if is_admin and not isinstance(results[7], Exception) else 0.0
+        total_clients = results[8] if is_admin and not isinstance(results[8], Exception) else 0
 
         # Check system health
         has_failures = any(isinstance(result, Exception) for result in results[:5])
@@ -416,6 +437,11 @@ async def get_dashboard_summary(
         if is_admin:
             response["revenue"] = revenue_stats
             response["revenue_growth"] = revenue_growth
+            # KPI bar counts — total_clients matches the /clients page source
+            # (crm_clients stats/overview: deleted_at IS NULL); total_practices
+            # comes from the practice stats already fetched above.
+            response["total_clients"] = total_clients
+            response["total_practices"] = practice_stats.get("total_practices", 0)
 
         return response
 

--- a/apps/backend-rag/backend/tests/unit/routers/test_dashboard_summary.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_dashboard_summary.py
@@ -202,6 +202,44 @@ class TestGetRevenueStats:
         assert result["total_revenue"] == 0
 
 
+# ── _get_total_clients ──────────────────────────────────────────────────────
+
+
+class TestGetTotalClients:
+    @pytest.mark.asyncio
+    async def test_returns_count(self):
+        from backend.app.routers.dashboard_summary import _get_total_clients
+
+        mock_conn = AsyncMock()
+        mock_conn.fetchval = AsyncMock(return_value=1481)
+        mock_pool = _make_pool(mock_conn)
+
+        assert await _get_total_clients(mock_pool) == 1481
+        # Same source as /clients: non-soft-deleted, NOT status='active'
+        sql = mock_conn.fetchval.call_args.args[0]
+        assert "deleted_at IS NULL" in sql
+        assert "status" not in sql
+
+    @pytest.mark.asyncio
+    async def test_none_returns_zero(self):
+        from backend.app.routers.dashboard_summary import _get_total_clients
+
+        mock_conn = AsyncMock()
+        mock_conn.fetchval = AsyncMock(return_value=None)
+        mock_pool = _make_pool(mock_conn)
+
+        assert await _get_total_clients(mock_pool) == 0
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_zero(self):
+        from backend.app.routers.dashboard_summary import _get_total_clients
+
+        mock_pool = MagicMock()
+        mock_pool.acquire.side_effect = Exception("fail")
+
+        assert await _get_total_clients(mock_pool) == 0
+
+
 # ── _calculate_revenue_growth ───────────────────────────────────────────────
 
 

--- a/apps/mouth/src/components/dashboard/TeamActivityPanel.tsx
+++ b/apps/mouth/src/components/dashboard/TeamActivityPanel.tsx
@@ -5,30 +5,21 @@ import {
   Users,
   Briefcase,
   Clock,
-  MessageCircle,
-  Mail,
-  BookOpen,
   Star,
-  Zap,
   TrendingUp,
   CheckCircle2,
   DollarSign,
 } from "lucide-react";
 
+// Only metrics with a live data source are rendered. Chat convos/messages,
+// emails in/out and KB views/downloads were zero for every member (their
+// source tables are dead or stale — P0.2 audit 2026-06-11) and were removed.
 export interface TeamMemberStats {
   email: string;
   name: string;
   role: string;
-  department: string;
-  conversations: number;
-  messages: number;
   days_worked: number;
   crm_actions: number;
-  emails_sent: number;
-  emails_received: number;
-  kb_views: number;
-  kb_downloads: number;
-  last_activity: string | null;
   // Practice stats (joined via client.assigned_to)
   practices_completed?: number;
   practices_active?: number;
@@ -36,11 +27,7 @@ export interface TeamMemberStats {
 }
 
 export interface TeamOverview {
-  total_conversations: number;
-  total_messages: number;
-  total_team_members: number;
   active_today: number;
-  messages_today: number;
 }
 
 interface Props {
@@ -255,7 +242,7 @@ function Cell({
   );
 }
 
-const COLS = "190px 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr";
+const COLS = "190px 1fr 1fr 1fr 1fr";
 
 export function TeamActivityPanel({ members, overview, isLoading }: Props) {
   const safeMembers = Array.isArray(members) ? members : [];
@@ -267,20 +254,8 @@ export function TeamActivityPanel({ members, overview, isLoading }: Props) {
 
   const maxima = React.useMemo(
     () => ({
-      conversations: Math.max(
-        ...filteredMembers.map((m) => m.conversations),
-        1,
-      ),
-      messages: Math.max(...filteredMembers.map((m) => m.messages), 1),
       days_worked: Math.max(...filteredMembers.map((m) => m.days_worked), 1),
       crm_actions: Math.max(...filteredMembers.map((m) => m.crm_actions), 1),
-      emails_sent: Math.max(...filteredMembers.map((m) => m.emails_sent), 1),
-      emails_received: Math.max(
-        ...filteredMembers.map((m) => m.emails_received),
-        1,
-      ),
-      kb_views: Math.max(...filteredMembers.map((m) => m.kb_views), 1),
-      kb_downloads: Math.max(...filteredMembers.map((m) => m.kb_downloads), 1),
       practices_completed: Math.max(
         ...filteredMembers.map((m) => m.practices_completed ?? 0),
         1,
@@ -324,9 +299,6 @@ export function TeamActivityPanel({ members, overview, isLoading }: Props) {
               />
               {overview.active_today} online
             </span>
-            <span>
-              {overview.total_messages.toLocaleString("en-US")} total messages
-            </span>
             <span>{filteredMembers.length} members</span>
           </div>
         )}
@@ -347,14 +319,8 @@ export function TeamActivityPanel({ members, overview, isLoading }: Props) {
           </span>
         </div>
         {[
-          { icon: MessageCircle, label: "Convos" },
-          { icon: Zap, label: "Messages" },
           { icon: Clock, label: "Days" },
           { icon: Briefcase, label: "CRM" },
-          { icon: Mail, label: "Emails Out" },
-          { icon: Mail, label: "Emails In" },
-          { icon: BookOpen, label: "KB Views" },
-          { icon: BookOpen, label: "KB DL" },
           { icon: CheckCircle2, label: "Done" },
           { icon: DollarSign, label: "Revenue" },
         ].map(({ icon: Icon, label }) => (
@@ -443,17 +409,7 @@ export function TeamActivityPanel({ members, overview, isLoading }: Props) {
                     </div>
                   </div>
 
-                  {/* 9 metric cells */}
-                  <Cell
-                    value={m.conversations}
-                    max={maxima.conversations}
-                    accent={palette.accent}
-                  />
-                  <Cell
-                    value={m.messages}
-                    max={maxima.messages}
-                    accent={palette.accent}
-                  />
+                  {/* 4 metric cells */}
                   <Cell
                     value={m.days_worked}
                     max={maxima.days_worked}
@@ -462,26 +418,6 @@ export function TeamActivityPanel({ members, overview, isLoading }: Props) {
                   <Cell
                     value={m.crm_actions}
                     max={maxima.crm_actions}
-                    accent={palette.accent}
-                  />
-                  <Cell
-                    value={m.emails_sent}
-                    max={maxima.emails_sent}
-                    accent={palette.accent}
-                  />
-                  <Cell
-                    value={m.emails_received}
-                    max={maxima.emails_received}
-                    accent={palette.accent}
-                  />
-                  <Cell
-                    value={m.kb_views}
-                    max={maxima.kb_views}
-                    accent={palette.accent}
-                  />
-                  <Cell
-                    value={m.kb_downloads}
-                    max={maxima.kb_downloads}
                     accent={palette.accent}
                   />
                   <Cell

--- a/apps/mouth/src/components/dashboard/__tests__/TeamActivityPanel.test.tsx
+++ b/apps/mouth/src/components/dashboard/__tests__/TeamActivityPanel.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TeamActivityPanel, type TeamMemberStats } from "../TeamActivityPanel";
+
+const member = (over: Partial<TeamMemberStats> = {}): TeamMemberStats => ({
+  email: "ari.firda@balizero.com",
+  name: "Ari Firda",
+  role: "consultant",
+  days_worked: 18,
+  crm_actions: 72,
+  practices_completed: 5,
+  practices_active: 3,
+  practices_revenue: 45_000_000,
+  ...over,
+});
+
+describe("TeamActivityPanel", () => {
+  it("renders only the live metric columns", () => {
+    render(
+      <TeamActivityPanel
+        members={[member()]}
+        overview={{ active_today: 2 }}
+        isLoading={false}
+      />,
+    );
+    for (const label of ["Member", "Days", "CRM", "Done", "Revenue"]) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it("does not render the dead always-zero columns (P0.2)", () => {
+    render(
+      <TeamActivityPanel
+        members={[member()]}
+        overview={{ active_today: 2 }}
+        isLoading={false}
+      />,
+    );
+    for (const dead of [
+      "Convos",
+      "Messages",
+      "Emails Out",
+      "Emails In",
+      "KB Views",
+      "KB DL",
+    ]) {
+      expect(screen.queryByText(dead)).not.toBeInTheDocument();
+    }
+    expect(screen.queryByText(/total messages/i)).not.toBeInTheDocument();
+  });
+
+  it("renders member values and revenue", () => {
+    render(
+      <TeamActivityPanel
+        members={[member()]}
+        overview={{ active_today: 1 }}
+        isLoading={false}
+      />,
+    );
+    expect(screen.getByText("Ari Firda")).toBeInTheDocument();
+    expect(screen.getByText("18")).toBeInTheDocument();
+    expect(screen.getByText("72")).toBeInTheDocument();
+    expect(screen.getByText("Rp 45M")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when there are no members", () => {
+    render(
+      <TeamActivityPanel members={[]} overview={null} isLoading={false} />,
+    );
+    expect(screen.getByText("No team data")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

PR 1 of the kita.balizero.com UI/UX audit (`research/operations/2026-06-11-kita-uiux-audit.md`, finding **P0.2** — dead metrics erode trust in the whole dashboard).

### 1. Team Performance: remove the 6 always-zero columns

The dashboard panel rendered 11 columns; 6 were zero for **every** member. Confirmed on **prod data** (read-only `fly ssh` + asyncpg, 2026-06-12) before touching anything:

| Column(s) | Source | Prod evidence |
|---|---|---|
| Convos, Messages | `v_messages` JOIN `team_members` on email | **0 matches all-time** (only 2 distinct chat users ever) |
| Emails Out/In | `email_activity_log` (written only by Zoho integration) | 13 rows ever, last write **2026-01-27** |
| KB Views, KB DL | `knowledge_activity_log` | 244 rows, last write **2026-03-07**, **zero** frontend call sites for the logging endpoint |

Live columns kept: Days (`team_timesheet`, 4.184 rows/30d), CRM (`activity_log`, 1.129 rows/30d), Done + Revenue (practice-stats). Also dropped the chat-wide "total messages" header stat (same dead family). Backend `/team-stats` untouched — the `/admin/team-activity` deep-dive page keeps its own full-detail view.

### 2. KPI "Clienti"/"Processi" always empty

`useDashboardData.ts:112-113` reads `total_clients`/`total_practices` from `/api/dashboard/summary`, but the endpoint **never returned those keys** (typed optional in `dashboard.api.ts:62-63`, never populated) → both KPIs rendered "—" while `/clients` showed 1.481.

Fix: the summary endpoint now returns both for admins. `total_clients` uses the **same definition as the /clients page total** (`crm_clients` stats/overview: `deleted_at IS NULL` = 1481 on prod). **Source mismatch documented**: the pre-existing `/api/dashboard/stats` counts `status='active'` (= 1145) — deliberately NOT used, it would disagree with /clients. `total_practices` reuses the practice-stats already fetched in the same call (zero extra queries).

## LOC delta

- `TeamActivityPanel.tsx`: **-66** lines
- `dashboard_summary.py`: +26 (helper + wiring + source-parity comment)
- **Production net: -40** (audit constraint: net ≤ 0 ✓)

## Gates

- Backend: `pytest backend/tests/unit/routers/test_dashboard_summary.py` → **25/25** (3 new for `_get_total_clients`, incl. assertion that the SQL matches the /clients source)
- Frontend: vitest **8/8** (new `TeamActivityPanel.test.tsx` locks dead columns out + dashboard page suite), `tsc --noEmit` clean
- Note: local `eslint` crashes pre-existing on M5 toolchain (`scopeManager.addGlobals`, reproduced on untouched files) — CI lint is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)