### PR TITLE
feat(ops): recover GDrive scanner/dedup/register scripts (orphaned on nextdns branch)

### DIFF
--- a/apps/backend-rag/scripts/analyze_duplicates.py
+++ b/apps/backend-rag/scripts/analyze_duplicates.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+import re
+from collections import Counter
+
+
+def analyze_report(report_path):
+    print(f"Reading report from {report_path}...")
+    with open(report_path, encoding="utf-8") as f:
+        content = f.read()
+
+    blocks = content.split("----------------------------------\n")
+    # The first block contains the header, skip it.
+    # The last block might be empty, skip it.
+    records = []
+
+    # Regex to parse record details
+    client_re = re.compile(r"Client:\s+(\d+)\s+-\s+(.+)")
+    path_re = re.compile(r"\s+Percorso Fisico:\s+(.+)")
+    file_re = re.compile(r"\s+File:\s+(.+)")
+    size_re = re.compile(r"\s+Dimensione:\s+(\d+)\s+bytes")
+    id_re = re.compile(r"\s+Google Drive ID:\s+(\S+)")
+
+    for block in blocks:
+        block = block.strip()
+        if not block or "REPORT DI SCANSIONE" in block:
+            continue
+
+        client_match = client_re.search(block)
+        path_match = path_re.search(block)
+        file_match = file_re.search(block)
+        size_match = size_re.search(block)
+        id_match = id_re.search(block)
+
+        if client_match and file_match and id_match:
+            records.append(
+                {
+                    "client_id": int(client_match.group(1)),
+                    "client_name": client_match.group(2).strip(),
+                    "subfolder": path_match.group(1).strip() if path_match else "Root",
+                    "file_name": file_match.group(1).strip(),
+                    "file_size": int(size_match.group(1)) if size_match else 0,
+                    "file_id": id_match.group(1).strip(),
+                }
+            )
+
+    total_records = len(records)
+    print(f"Parsed {total_records} records.")
+
+    # 1. Check duplicate Google Drive IDs
+    drive_ids = [r["file_id"] for r in records]
+    drive_id_counts = Counter(drive_ids)
+    duplicate_drive_ids = {id_: count for id_, count in drive_id_counts.items() if count > 1}
+
+    # 2. Check duplicate filenames per client (exact same name + size for the same client)
+    client_file_keys = [(r["client_id"], r["file_name"], r["file_size"]) for r in records]
+    client_file_counts = Counter(client_file_keys)
+    duplicate_client_files = {k: count for k, count in client_file_counts.items() if count > 1}
+
+    # 3. Check duplicate filenames + sizes globally (same filename + same size across different clients)
+    global_file_keys = [(r["file_name"], r["file_size"]) for r in records]
+    global_file_counts = Counter(global_file_keys)
+    duplicate_global_files = {k: count for k, count in global_file_counts.items() if count > 1}
+
+    # 4. Check duplicate filenames globally regardless of size
+    global_name_counts = Counter([r["file_name"] for r in records])
+    most_common_names = global_name_counts.most_common(15)
+
+    print("\n=== RESULTS ===")
+    print(f"Total Discovered Files: {total_records}")
+    print(f"Unique Google Drive IDs: {len(drive_id_counts)}")
+    print(
+        f"Duplicate Google Drive IDs (same file ID listed multiple times): {len(duplicate_drive_ids)}"
+    )
+    print(
+        f"Duplicate Filename+Size for the SAME client: {len(duplicate_client_files)} cases (totaling {sum(duplicate_client_files.values())} files)"
+    )
+    print(
+        f"Duplicate Filename+Size GLOBALLY (across different clients): {len(duplicate_global_files)} patterns"
+    )
+
+    print("\n--- Most Common Filenames (Top 15) ---")
+    for name, count in most_common_names:
+        print(f"  - '{name}': {count} occurrences")
+
+    # Print details of a few duplicate cases per client
+    if duplicate_client_files:
+        print("\n--- Examples of Duplicates for the Same Client (Top 5) ---")
+        sorted_dup_clients = sorted(
+            duplicate_client_files.items(), key=lambda x: x[1], reverse=True
+        )
+        for (client_id, name, size), count in sorted_dup_clients[:5]:
+            client_name = next(r["client_name"] for r in records if r["client_id"] == client_id)
+            print(
+                f"  Client {client_id} ({client_name}): '{name}' ({size} bytes) appears {count} times"
+            )
+
+
+import os
+
+if __name__ == "__main__":
+    report_path = os.path.expanduser("~/Desktop/nuzantara_drive_scan_report.txt")
+    analyze_report(report_path)

--- a/apps/backend-rag/scripts/deduplicate_report.py
+++ b/apps/backend-rag/scripts/deduplicate_report.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+import re
+import time
+
+
+def deduplicate_report(input_path, output_path):
+    print(f"Reading raw report from {input_path}...")
+    with open(input_path, encoding="utf-8") as f:
+        content = f.read()
+
+    blocks = content.split("----------------------------------\n")
+    records = []
+
+    # Regex to parse record details
+    client_re = re.compile(r"Client:\s+(\d+)\s+-\s+(.+)")
+    path_re = re.compile(r"\s+Percorso Fisico:\s+(.+)")
+    file_re = re.compile(r"\s+File:\s+(.+)")
+    size_re = re.compile(r"\s+Dimensione:\s+(\d+)\s+bytes")
+    id_re = re.compile(r"\s+Google Drive ID:\s+(\S+)")
+
+    for block in blocks:
+        block = block.strip()
+        if not block or "REPORT DI SCANSIONE" in block:
+            continue
+
+        client_match = client_re.search(block)
+        path_match = path_re.search(block)
+        file_match = file_re.search(block)
+        size_match = size_re.search(block)
+        id_match = id_re.search(block)
+
+        if client_match and file_match and id_match:
+            records.append(
+                {
+                    "client_id": int(client_match.group(1)),
+                    "client_name": client_match.group(2).strip(),
+                    "subfolder": path_match.group(1).strip() if path_match else "Root",
+                    "file_name": file_match.group(1).strip(),
+                    "file_size": int(size_match.group(1)) if size_match else 0,
+                    "file_id": id_match.group(1).strip(),
+                }
+            )
+
+    total_raw = len(records)
+
+    # 1. Deduplicate by Google Drive ID
+    seen_ids = set()
+    dedup_id_records = []
+    for r in records:
+        if r["file_id"] not in seen_ids:
+            seen_ids.add(r["file_id"])
+            dedup_id_records.append(r)
+
+    total_after_id = len(dedup_id_records)
+
+    # 2. Deduplicate by Filename + Size per Client
+    seen_client_files = set()
+    final_records = []
+    for r in dedup_id_records:
+        key = (r["client_id"], r["file_name"], r["file_size"])
+        if key not in seen_client_files:
+            seen_client_files.add(key)
+            final_records.append(r)
+
+    total_final = len(final_records)
+
+    print("Deduplication summary:")
+    print(f"  Raw records: {total_raw}")
+    print(
+        f"  After unique Drive ID filter: {total_after_id} (removed {total_raw - total_after_id} ID duplicates)"
+    )
+    print(
+        f"  After Client Filename+Size filter: {total_final} (removed {total_after_id - total_final} name+size duplicates for same client)"
+    )
+    print(f"  Total duplicates removed: {total_raw - total_final}")
+
+    # Write deduped report
+    with open(output_path, "w", encoding="utf-8") as rf:
+        rf.write("=================================================================\n")
+        rf.write(" REPORT DI SCANSIONE GOOGLE DRIVE PROFONDO - DE-DUPLICATO \n")
+        rf.write("=================================================================\n\n")
+        rf.write(f"Data Report: {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
+        rf.write(f"File totali analizzati (grezzi): {total_raw}\n")
+        rf.write(f"File totali dopo de-duplicazione: {total_final}\n")
+        rf.write(
+            f"Duplicati rimossi (ID identici o stesso Nome+Dimensione per client): {total_raw - total_final}\n\n"
+        )
+
+        if final_records:
+            rf.write("Dettaglio dei file orfani trovati (De-duplicati):\n")
+            rf.write("----------------------------------\n")
+            for file in final_records:
+                rf.write(f"Client: {file['client_id']} - {file['client_name']}\n")
+                rf.write(f"  Percorso Fisico: {file['subfolder']}\n")
+                rf.write(f"  File: {file['file_name']}\n")
+                rf.write(f"  Dimensione: {file['file_size']} bytes\n")
+                rf.write(f"  Google Drive ID: {file['file_id']}\n")
+                rf.write("  Stato nel DB: MANCANTE\n")
+                rf.write("----------------------------------\n")
+        else:
+            rf.write("Ottimo! Nessun file orfano trovato.\n")
+
+    print(f"Deduped report written successfully to {output_path}!")
+
+
+import os
+
+if __name__ == "__main__":
+    deduplicate_report(
+        os.path.expanduser("~/Desktop/nuzantara_drive_scan_report.txt"),
+        os.path.expanduser("~/Desktop/nuzantara_drive_scan_report_deduped.txt"),
+    )

--- a/apps/backend-rag/scripts/register_drive_documents.py
+++ b/apps/backend-rag/scripts/register_drive_documents.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""
+Nuzantara GDrive Document Registerer
+-----------------------------------
+Parses the de-duplicated scan report and inserts the missing documents into
+the PostgreSQL `documents` table, marking their ocr_status as 'pending'.
+"""
+
+import argparse
+import asyncio
+import logging
+import os
+import re
+import sys
+from typing import Any
+
+import asyncpg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(asctime)s] %(levelname)s %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+logger = logging.getLogger("register_documents")
+
+from pathlib import Path
+
+base_path = Path(__file__).resolve().parent.parent
+sys.path.append(str(base_path))
+import dotenv
+
+dotenv.load_dotenv(str(base_path / ".env"))
+
+from backend.services.crm.documents import auto_categorize_document
+from backend.services.crm.drive_poll_service import _infer_document_type
+
+
+def parse_report(report_path: str) -> list[dict[str, Any]]:
+    logger.info(f"Parsing report from {report_path}...")
+    if not os.path.exists(report_path):
+        logger.error(f"Report path {report_path} does not exist!")
+        sys.exit(1)
+
+    with open(report_path, encoding="utf-8") as f:
+        content = f.read()
+
+    blocks = content.split("----------------------------------\n")
+    records = []
+
+    client_re = re.compile(r"Client:\s+(\d+)\s+-\s+(.+)")
+    path_re = re.compile(r"\s+Percorso Fisico:\s+(.+)")
+    file_re = re.compile(r"\s+File:\s+(.+)")
+    size_re = re.compile(r"\s+Dimensione:\s+(\d+)\s+bytes")
+    id_re = re.compile(r"\s+Google Drive ID:\s+(\S+)")
+
+    for block in blocks:
+        block = block.strip()
+        if not block or "REPORT DI SCANSIONE" in block:
+            continue
+
+        client_match = client_re.search(block)
+        path_match = path_re.search(block)
+        file_match = file_re.search(block)
+        size_match = size_re.search(block)
+        id_match = id_re.search(block)
+
+        if client_match and file_match and id_match:
+            records.append(
+                {
+                    "client_id": int(client_match.group(1)),
+                    "client_name": client_match.group(2).strip(),
+                    "subfolder": path_match.group(1).strip() if path_match else "Root",
+                    "file_name": file_match.group(1).strip(),
+                    "file_size": int(size_match.group(1)) if size_match else 0,
+                    "file_id": id_match.group(1).strip(),
+                }
+            )
+
+    logger.info(f"Successfully parsed {len(records)} records from report.")
+    return records
+
+
+async def main():
+    parser = argparse.ArgumentParser(
+        description="Register discovered Google Drive documents into database."
+    )
+    parser.add_argument(
+        "--execute", action="store_true", help="Execute database insertions (default is dry-run)"
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None, help="Limit number of records to process"
+    )
+    args = parser.parse_args()
+
+    report_path = os.path.expanduser("~/Desktop/nuzantara_drive_scan_report_deduped.txt")
+    records = parse_report(report_path)
+
+    if args.limit:
+        records = records[: args.limit]
+        logger.info(f"Limiting to first {args.limit} records.")
+
+    if not records:
+        logger.info("No records found to process.")
+        return
+
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        logger.error("DATABASE_URL env var is missing")
+        sys.exit(1)
+
+    logger.info("Connecting to database...")
+    db_pool = await asyncpg.create_pool(db_url, min_size=1, max_size=5)
+
+    try:
+        # Pre-process all records to infer type, category, subfolder, and URL
+        logger.info("Auto-categorizing and inferring document types...")
+        processed_data = []
+        unique_clients = set()
+
+        for r in records:
+            file_name = r["file_name"]
+            folder_name = r["subfolder"]
+            file_id = r["file_id"]
+            client_id = r["client_id"]
+
+            # 1. Infer category and type
+            cat_result = auto_categorize_document(file_name)
+            doc_category = cat_result["document_category"]
+
+            # Folder hint upgrade (just like in drive_poll_service.py)
+            if doc_category == "other" and folder_name:
+                folder_lower = folder_name.lower()
+                if (
+                    folder_lower in ("01_immigration", "actual visa", "previous visa")
+                    or "immigration" in folder_lower
+                ):
+                    doc_category = "immigration"
+
+            doc_type = _infer_document_type(file_name, folder_name)
+
+            # 2. Check Actual Visa / Previous Visa subfolder
+            subfolder_value = None
+            parent_name_lower = folder_name.lower() if folder_name else ""
+            if parent_name_lower in ("actual visa", "previous visa"):
+                subfolder_value = (
+                    "Actual Visa" if "actual" in parent_name_lower else "Previous Visa"
+                )
+                doc_category = "immigration"
+
+            # 3. Size in KB
+            file_size_kb = r["file_size"] // 1024
+
+            # 4. Construct google drive URL
+            drive_url = f"https://drive.google.com/file/d/{file_id}/view?usp=drivesdk"
+
+            processed_data.append(
+                (
+                    client_id,
+                    doc_type,
+                    doc_category,
+                    file_name,
+                    file_id,
+                    drive_url,
+                    file_size_kb,
+                    subfolder_value,
+                )
+            )
+            unique_clients.add(client_id)
+
+        if not args.execute:
+            logger.info("=== DRY RUN MODE ===")
+            logger.info(f"Total documents to register: {len(processed_data)}")
+            logger.info(f"Total affected clients: {len(unique_clients)}")
+            logger.info("Example of insertions:")
+            for i, p in enumerate(processed_data[:5]):
+                logger.info(
+                    f"  Doc {i + 1}: Client: {p[0]}, Type: {p[1]}, Cat: {p[2]}, File: {p[3]}, ID: {p[4]}, Subfolder: {p[7]}"
+                )
+            logger.info("Use --execute flag to perform the actual database write.")
+            return
+
+        logger.info("=== EXECUTION MODE ===")
+        logger.info(f"Registering {len(processed_data)} documents...")
+
+        # Batch insert documents in chunks of 500
+        chunk_size = 500
+        inserted_count = 0
+
+        async with db_pool.acquire() as conn:
+            async with conn.transaction():
+                # We do this inside a single transaction
+                for i in range(0, len(processed_data), chunk_size):
+                    chunk = processed_data[i : i + chunk_size]
+
+                    # Insert query
+                    # Wait, is there a unique constraint on file_id in the database?
+                    # Let's write standard inserts or catch duplicate errors, or check constraint.
+                    # To be safe, we can do it one-by-one or check if file_id already exists.
+                    # Since we pre-filtered in scan_drive_fast against the current list of file_ids,
+                    # conflict should not happen, but we can do try-except per insert or use a safe insert.
+                    # Let's run a bulk executemany, but wait, executemany is very fast.
+                    # Let's check if there is a unique index on file_id.
+                    # If there's no unique constraint on file_id, ON CONFLICT (file_id) will error.
+                    # Let's just execute standard inserts but skip duplicate file_ids we already loaded.
+                    # To be 100% safe, let's run individual inserts or check if there is a constraint.
+                    # Actually, if we pre-fetched all file_ids from the database and only processed missing ones,
+                    # we should not have conflicts. Let's just do bulk executemany without ON CONFLICT,
+                    # or write a try-catch chunk processing.
+
+                    # Let's check if documents has a constraint or just insert.
+                    # Let's do executemany:
+                    try:
+                        await conn.executemany(
+                            """
+                            INSERT INTO documents (
+                                client_id, document_type, document_category, file_name, file_id,
+                                google_drive_file_url, file_size_kb, subfolder,
+                                status, storage_type, ocr_status, created_at, updated_at
+                            ) VALUES (
+                                $1, $2, $3, $4, $5, $6, $7, $8,
+                                'active', 'google_drive', 'pending', NOW(), NOW()
+                            )
+                        """,
+                            chunk,
+                        )
+                        inserted_count += len(chunk)
+                    except Exception as e:
+                        logger.error(
+                            f"Error inserting chunk {i // chunk_size}: {e}. Retrying chunk individually..."
+                        )
+                        # If a chunk fails, insert rows individually to skip duplicates
+                        for row in chunk:
+                            try:
+                                await conn.execute(
+                                    """
+                                    INSERT INTO documents (
+                                        client_id, document_type, document_category, file_name, file_id,
+                                        google_drive_file_url, file_size_kb, subfolder,
+                                        status, storage_type, ocr_status, created_at, updated_at
+                                    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'active', 'google_drive', 'pending', NOW(), NOW())
+                                """,
+                                    *row,
+                                )
+                                inserted_count += 1
+                            except Exception as row_err:
+                                # Safe skip
+                                logger.warning(
+                                    f"Failed to insert single file {row[3]} (ID: {row[4]}): {row_err}"
+                                )
+
+                    logger.info(f"Inserted {inserted_count}/{len(processed_data)} documents...")
+
+                # Update affected clients updated_at
+                logger.info(f"Touching updated_at for {len(unique_clients)} clients...")
+                client_ids_list = list(unique_clients)
+                await conn.execute(
+                    """
+                    UPDATE clients
+                    SET updated_at = NOW()
+                    WHERE id = ANY($1::int[])
+                """,
+                    client_ids_list,
+                )
+
+        logger.info(f"Successfully registered {inserted_count} documents in PostgreSQL database.")
+
+    finally:
+        await db_pool.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/apps/backend-rag/scripts/scan_drive_fast.py
+++ b/apps/backend-rag/scripts/scan_drive_fast.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""
+Nuzantara Fast Google Drive Scanner
+----------------------------------
+Performs a deep, recursive scan starting from the physical root folders
+of all active clients in the database (1,408 clients) in parallel.
+
+Uses independent connection pools per worker task to avoid SSL failures.
+"""
+
+import asyncio
+import logging
+import os
+import sys
+import time
+from typing import Any
+
+import asyncpg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(asctime)s] %(levelname)s %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+logger = logging.getLogger("scan_drive_fast")
+
+from pathlib import Path
+
+base_path = Path(__file__).resolve().parent.parent
+
+# Dynamic environment bootstrapping
+SECRETS_SA_PATH = str(base_path.parent / ".secrets/nuzantara-google-drive-sa.json")
+if os.path.exists(SECRETS_SA_PATH):
+    with open(SECRETS_SA_PATH) as f:
+        os.environ["GOOGLE_CREDENTIALS_JSON"] = f.read()
+else:
+    logger.error(f"Credentials not found at {SECRETS_SA_PATH}")
+    sys.exit(1)
+
+os.environ["GDRIVE_INDIVIDUALS_FOLDER_ID"] = "1mNi2FkhZqP9inJH2Y1taXLCgS95UkYk4"
+os.environ["GDRIVE_COMPANIES_FOLDER_ID"] = "1rLlr2G7TdNUmmvQ_xN9pZQLbPrDFjUsW"
+os.environ["GOOGLE_DRIVE_ROOT_FOLDER_ID"] = "1mNi2FkhZqP9inJH2Y1taXLCgS95UkYk4"
+
+sys.path.append(str(base_path))
+import dotenv
+
+dotenv.load_dotenv(str(base_path / ".env"))
+
+from backend.services.integrations.service_account_drive_service import ServiceAccountDriveService
+
+
+# Async-safe Rate Limiter
+class AsyncRateLimiter:
+    def __init__(self, rate: int, period: float = 1.0):
+        self.rate = rate
+        self.period = period
+        self.allowance = float(rate)
+        self.last_check = asyncio.get_event_loop().time()
+        self.lock = asyncio.Lock()
+
+    async def wait(self):
+        async with self.lock:
+            current = asyncio.get_event_loop().time()
+            time_passed = current - self.last_check
+            self.last_check = current
+            self.allowance += time_passed * (self.rate / self.period)
+            if self.allowance > self.rate:
+                self.allowance = float(self.rate)
+
+            if self.allowance < 1.0:
+                sleep_time = (1.0 - self.allowance) * (self.period / self.rate)
+                await asyncio.sleep(sleep_time)
+                self.allowance = 0.0
+            else:
+                self.allowance -= 1.0
+
+
+# 60 calls/sec is extremely fast and safe (Google allows up to 200/sec)
+limiter = AsyncRateLimiter(rate=60, period=1.0)
+
+
+async def list_folder_contents_async(
+    drive: ServiceAccountDriveService, folder_id: str
+) -> list[dict[str, Any]]:
+    """List files and folders inside a folder sequentially with retries."""
+    items = []
+    page_token = None
+    query = f"'{folder_id}' in parents and trashed=false"
+    max_retries = 3
+
+    while True:
+        success = False
+        for attempt in range(max_retries):
+            try:
+                await limiter.wait()
+                request = drive.service.files().list(
+                    q=query,
+                    fields="nextPageToken, files(id, name, mimeType, size)",
+                    pageSize=1000,
+                    pageToken=page_token,
+                    supportsAllDrives=True,
+                    includeItemsFromAllDrives=True,
+                )
+                result = await asyncio.to_thread(request.execute)
+                items.extend(result.get("files", []))
+                page_token = result.get("nextPageToken")
+                success = True
+                break
+            except Exception as e:
+                backoff = (attempt + 1) * 2.0
+                logger.warning(
+                    f"Error listing folder {folder_id} (attempt {attempt + 1}/{max_retries}): {e}. Retrying in {backoff}s..."
+                )
+                await asyncio.sleep(backoff)
+
+        if not success:
+            logger.error(f"Failed to list folder {folder_id} after {max_retries} attempts.")
+            break
+
+        if not page_token:
+            break
+
+    return items
+
+
+async def scan_folder_recursive(
+    drive: ServiceAccountDriveService,
+    folder_id: str,
+    client_id: int,
+    client_name: str,
+    path: str,
+    existing_file_ids: set[str],
+    orphans: list[dict[str, Any]],
+):
+    """Recursively scan a GDrive folder and add missing files to orphans."""
+    contents = await list_folder_contents_async(drive, folder_id)
+
+    for item in contents:
+        item_id = item["id"]
+        item_name = item["name"]
+        mime_type = item.get("mimeType", "")
+
+        if mime_type == "application/vnd.google-apps.folder":
+            sub_path = f"{path}/{item_name}" if path else item_name
+            await scan_folder_recursive(
+                drive, item_id, client_id, client_name, sub_path, existing_file_ids, orphans
+            )
+        else:
+            if mime_type.startswith("video/") or mime_type.startswith("audio/"):
+                continue
+
+            file_size = int(item.get("size", 0))
+            if item_id not in existing_file_ids:
+                orphans.append(
+                    {
+                        "client_id": client_id,
+                        "client_name": client_name,
+                        "subfolder": path or "Root",
+                        "file_name": item_name,
+                        "file_id": item_id,
+                        "file_size": file_size,
+                        "mime_type": mime_type,
+                    }
+                )
+
+
+async def worker(
+    worker_id: int,
+    queue: asyncio.Queue,
+    existing_file_ids: set[str],
+    all_discovered_files: list[dict[str, Any]],
+    progress: dict[str, int],
+):
+    """Worker task that processes clients from the queue using its own Drive service instance."""
+    # Instantiate service specific to this worker to avoid shared connection SSL errors!
+    drive = ServiceAccountDriveService()
+
+    while True:
+        try:
+            client = queue.get_nowait()
+        except asyncio.QueueEmpty:
+            break
+
+        client_id = client["id"]
+        client_name = client["full_name"]
+        root_folder_id = client["google_drive_folder_id"]
+
+        progress["scanned"] += 1
+        curr_scanned = progress["scanned"]
+        curr_total = progress["total"]
+
+        if curr_scanned % 20 == 0 or curr_scanned == curr_total:
+            logger.info(f"Progress: [{curr_scanned}/{curr_total}] clients processed...")
+
+        try:
+            client_orphans = []
+            await scan_folder_recursive(
+                drive=drive,
+                folder_id=root_folder_id,
+                client_id=client_id,
+                client_name=client_name,
+                path="",
+                existing_file_ids=existing_file_ids,
+                orphans=client_orphans,
+            )
+            if client_orphans:
+                all_discovered_files.extend(client_orphans)
+                logger.info(
+                    f"  Worker {worker_id}: Client {client_id} ({client_name}) - Found {len(client_orphans)} new files!"
+                )
+        except Exception as e:
+            logger.error(
+                f"  Worker {worker_id}: Failed to scan client {client_id} ({client_name}) root folder {root_folder_id}: {e}"
+            )
+        finally:
+            queue.task_done()
+
+
+async def main():
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        logger.error("DATABASE_URL env var is missing")
+        sys.exit(1)
+
+    db_pool = await asyncpg.create_pool(db_url, min_size=1, max_size=2)
+
+    try:
+        async with db_pool.acquire() as conn:
+            # 1. Pre-fetch all existing file IDs from DB (O(1) matching)
+            logger.info("Pre-fetching existing file IDs from database...")
+            rows = await conn.fetch("SELECT file_id FROM documents WHERE file_id IS NOT NULL")
+            existing_file_ids = {r["file_id"] for r in rows}
+            logger.info(f"Loaded {len(existing_file_ids)} file IDs from DB")
+
+            # 2. Fetch all active clients with non-null folder IDs
+            logger.info("Fetching active clients with folders...")
+            clients_query = """
+                SELECT id, full_name, google_drive_folder_id
+                FROM clients
+                WHERE google_drive_folder_id IS NOT NULL AND deleted_at IS NULL
+                ORDER BY id
+            """
+            active_clients = await conn.fetch(clients_query)
+            logger.info(
+                f"Found {len(active_clients)} active clients with Google Drive folders to scan"
+            )
+
+            # 3. Queue setup
+            queue = asyncio.Queue()
+            for c in active_clients:
+                queue.put_nowait(dict(c))
+
+            progress = {"scanned": 0, "total": len(active_clients)}
+            all_discovered_files = []
+
+            # 4. Launch concurrent workers
+            num_workers = 25
+            logger.info(f"Launching {num_workers} concurrent workers for deep scan...")
+
+            workers = [
+                asyncio.create_task(
+                    worker(i, queue, existing_file_ids, all_discovered_files, progress)
+                )
+                for i in range(num_workers)
+            ]
+
+            await asyncio.gather(*workers)
+            await queue.join()
+
+            # 5. Write Report to Desktop
+            report_path = "/Users/nuzantara/Desktop/nuzantara_drive_scan_report.txt"
+            logger.info(f"Writing report to {report_path}...")
+
+            # Sort files by client_id and subfolder path for readability
+            all_discovered_files.sort(
+                key=lambda x: (x["client_id"], x["subfolder"], x["file_name"])
+            )
+
+            with open(report_path, "w") as rf:
+                rf.write("=================================================================\n")
+                rf.write(
+                    " REPORT DI SCANSIONE GOOGLE DRIVE PROFONDO - FILE NON ANCORA TRASCRITTI \n"
+                )
+                rf.write("=================================================================\n\n")
+                rf.write(f"Data Scansione: {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
+                rf.write(f"Clienti attivi scansionati ricorsivamente: {len(active_clients)}\n")
+                rf.write(
+                    f"File totali scoperti non presenti nel database: {len(all_discovered_files)}\n\n"
+                )
+
+                if all_discovered_files:
+                    rf.write("Dettaglio dei file orfani trovati:\n")
+                    rf.write("----------------------------------\n")
+                    for file in all_discovered_files:
+                        rf.write(f"Client: {file['client_id']} - {file['client_name']}\n")
+                        rf.write(f"  Percorso Fisico: {file['subfolder']}\n")
+                        rf.write(f"  File: {file['file_name']}\n")
+                        rf.write(f"  Dimensione: {file['file_size']} bytes\n")
+                        rf.write(f"  Google Drive ID: {file['file_id']}\n")
+                        rf.write("  Stato nel DB: MANCANTE\n")
+                        rf.write("----------------------------------\n")
+                else:
+                    rf.write(
+                        "Ottimo! Tutti i file presenti ricorsivamente su Google Drive sono già registrati e indicizzati nel database.\n"
+                    )
+
+            logger.info(f"Report written successfully to {report_path}. Done!")
+    finally:
+        await db_pool.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## What

Recovers 4 standalone GDrive operations scripts (cherry-pick of `e63e94988`) that were orphaned on `feat/nextdns-tamper-detect-2026-05-31` — a branch whose nextdns/tamper-detect feature already landed on main (#997) and whose M5 routing docs are on main too, leaving these 4 scripts as the only unmerged, unique content (799 LOC, nowhere else in history).

- `apps/backend-rag/scripts/scan_drive_fast.py` (313 LOC) — parallel GDrive scanning
- `apps/backend-rag/scripts/register_drive_documents.py` (272 LOC) — DB registration of Drive docs
- `apps/backend-rag/scripts/deduplicate_report.py` (112 LOC)
- `apps/backend-rag/scripts/analyze_duplicates.py` (102 LOC)

## Why

A read-only branch-triage (2026-06-12) found these 4 scripts exist on no other branch and in no other commit across `--all` history. Rather than delete the stale nextdns branch and lose them, this PR cherry-picks just the additive script commit onto a clean branch off `main`.

## Safety

- **Additive only** — cherry-pick is 799 insertions, 0 deletions/modifications. No collateral changes.
- **Standalone** — zero imports/LaunchAgent/cron references to these scripts on main; they are run-by-hand utilities, no import-chain risk.
- All 4 compile (`py_compile` clean), no hardcoded secrets (grep clean).

Once merged, `feat/nextdns-tamper-detect-2026-05-31` can be safely deleted (its remaining content is all on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)