### PR TITLE
fix(intake): review UX — authenticated blob preview + homonym disambiguation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 321 routers · 605 services
+- Backend: FastAPI · 321 routers · 606 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 28 · Packages: 6

--- a/apps/backend-rag/backend/app/routers/intake_review.py
+++ b/apps/backend-rag/backend/app/routers/intake_review.py
@@ -235,19 +235,28 @@ def _ocr_pages(stage_output: dict[str, Any]) -> list[dict[str, Any]] | None:
 async def _load_candidate_clients(
     conn: asyncpg.Connection, client_ids: list[int]
 ) -> list[dict[str, Any]]:
-    """READ-ONLY lookup of candidate clients (id, name, assigned_to)."""
+    """READ-ONLY lookup of candidate clients, with the disambiguators a human
+    needs to tell homonyms apart (phone/email/nationality — the "tanti Walter"
+    problem: 10 clients named Walter, distinguishable only by phone)."""
     if not client_ids:
         return []
     rows = await conn.fetch(
         """
-        SELECT id, full_name, assigned_to
+        SELECT id, full_name, assigned_to, email, phone, nationality
         FROM clients
         WHERE id = ANY($1::bigint[]) AND deleted_at IS NULL
         """,
         client_ids,
     )
     return [
-        {"client_id": r["id"], "full_name": r["full_name"], "assigned_to": r["assigned_to"]}
+        {
+            "client_id": r["id"],
+            "full_name": r["full_name"],
+            "assigned_to": r["assigned_to"],
+            "email": r["email"],
+            "phone": r["phone"],
+            "nationality": r["nationality"],
+        }
         for r in rows
     ]
 
@@ -371,23 +380,27 @@ async def search_clients(
     user: dict[str, Any] = Depends(get_current_user),
     pool: asyncpg.Pool = Depends(get_database_pool),
 ) -> dict[str, Any]:
-    """Name-lookup over local CRM clients for the review destination picker.
+    """Name/phone/email lookup over local CRM clients for the destination picker.
 
-    Deliberately MINIMAL projection (id, full_name, assigned_to) — this is a
-    routing affordance, not client access: a reviewer redirecting a NO_MATCH
-    document must be able to find ANY client by name (the doc's subject is
-    rarely one of their own assigned clients). pg_trgm-ranked, ILIKE-gated.
-    READ-ONLY. PII boundary unchanged: runs on the Pro reader, local DB only.
+    Projection includes the HUMAN DISAMBIGUATORS (phone/email/nationality):
+    the CRM holds many homonyms (10 bare "Walter"s) distinguishable only by
+    contact data — a name-only list forces blind guessing. Phone matching
+    activates when the query carries >=5 digits. This is a routing affordance,
+    not client access: a reviewer redirecting a NO_MATCH document must find ANY
+    client. pg_trgm-ranked, ILIKE-gated. READ-ONLY, Pro reader, local DB only.
     """
     needle = q.strip()
     async with pool.acquire() as conn:
         rows = await conn.fetch(
             """
-            SELECT id, full_name, assigned_to,
+            SELECT id, full_name, assigned_to, email, phone, nationality,
                    similarity(full_name, $1) AS sim
             FROM clients
             WHERE deleted_at IS NULL
-              AND full_name ILIKE '%' || $1 || '%'
+              AND (full_name ILIKE '%' || $1 || '%'
+                   OR phone LIKE '%' || regexp_replace($1, '[^0-9+]', '', 'g') || '%'
+                       AND length(regexp_replace($1, '[^0-9]', '', 'g')) >= 5
+                   OR email ILIKE '%' || $1 || '%')
             ORDER BY sim DESC, full_name ASC
             LIMIT $2
             """,
@@ -400,6 +413,9 @@ async def search_clients(
                 "client_id": r["id"],
                 "full_name": r["full_name"],
                 "assigned_to": r["assigned_to"],
+                "email": r["email"],
+                "phone": r["phone"],
+                "nationality": r["nationality"],
                 "score": round(float(r["sim"] or 0.0), 4),
             }
             for r in rows

--- a/apps/mouth/src/app/(workspace)/review/page.tsx
+++ b/apps/mouth/src/app/(workspace)/review/page.tsx
@@ -33,6 +33,18 @@ interface EntityCandidate {
   client_id: number;
   full_name: string;
   assigned_to?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  nationality?: string | null;
+}
+
+/** "Walter · +39 339… · IT" — the human disambiguators for homonym-heavy CRM. */
+function clientMeta(c: {
+  phone?: string | null;
+  email?: string | null;
+  nationality?: string | null;
+}): string {
+  return [c.phone, c.email, c.nationality].filter(Boolean).join(" · ");
 }
 
 interface ProposalSummary {
@@ -82,6 +94,9 @@ interface ClientSearchItem {
   client_id: number;
   full_name: string;
   assigned_to?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  nationality?: string | null;
   score: number;
 }
 
@@ -363,7 +378,51 @@ export default function ReviewPage() {
     return `${selectedClient.full_name} → ${practiceLabel}`;
   }, [selectedClient, selectedPractice]);
 
-  const blobUrl = detail ? `/api/intake/review/${detail.proposal_id}/blob` : "";
+  // Authenticated blob preview: an <iframe>/<img> request cannot carry the
+  // Bearer header, so a direct src 401s ("Connessione negata"). Fetch the
+  // blob WITH the token, then preview via a local object URL.
+  const [blobUrl, setBlobUrl] = useState<string>("");
+  useEffect(() => {
+    if (!detail) {
+      setBlobUrl("");
+      return;
+    }
+    let revoked: string | null = null;
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = api.getToken();
+        const res = await fetch(
+          `/api/intake/review/${detail.proposal_id}/blob`,
+          {
+            headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+            credentials: "include",
+          },
+        );
+        if (!res.ok) throw new Error(`blob HTTP ${res.status}`);
+        const blob = await res.blob();
+        if (cancelled) return;
+        revoked = URL.createObjectURL(blob);
+        setBlobUrl(revoked);
+        setPreviewFailed(false);
+      } catch (e) {
+        logger.warn("blob preview fetch failed", {
+          component: "ReviewPage",
+          action: "blobFetch",
+          metadata: { proposalId: detail.proposal_id, error: String(e) },
+        });
+        if (!cancelled) {
+          setBlobUrl("");
+          setPreviewFailed(true);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (revoked) URL.revokeObjectURL(revoked);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [detail?.proposal_id]);
   const mime = detail?.mime_type ?? "";
   const isImage = mime.startsWith("image/");
   const isPdf = mime === "application/pdf";
@@ -509,7 +568,19 @@ export default function ReviewPage() {
             <div className="grid gap-5 md:grid-cols-2">
               {/* ── LEFT: the exact document ──────────────────────────── */}
               <div>
-                {!previewFailed && isImage && (
+                {!previewFailed && !blobUrl && (isImage || isPdf) && (
+                  <div
+                    className="flex w-full items-center justify-center rounded-md border text-xs"
+                    style={{
+                      borderColor: "var(--bz-border)",
+                      color: "var(--bz-text-3)",
+                      height: "60vh",
+                    }}
+                  >
+                    Loading document…
+                  </div>
+                )}
+                {!previewFailed && blobUrl && isImage && (
                   // eslint-disable-next-line @next/next/no-img-element
                   <img
                     src={blobUrl}
@@ -522,7 +593,7 @@ export default function ReviewPage() {
                     onError={() => setPreviewFailed(true)}
                   />
                 )}
-                {!previewFailed && isPdf && (
+                {!previewFailed && blobUrl && isPdf && (
                   <iframe
                     src={blobUrl}
                     title="document preview"
@@ -646,13 +717,23 @@ export default function ReviewPage() {
                               );
                             }}
                           />
-                          <span>{c.full_name}</span>
+                          <span className="min-w-0">
+                            {c.full_name}
+                            {clientMeta(c) && (
+                              <span
+                                className="block truncate text-xs"
+                                style={{ color: "var(--bz-text-3)" }}
+                              >
+                                {clientMeta(c)}
+                              </span>
+                            )}
+                          </span>
                           {c.assigned_to && (
                             <span
-                              className="text-xs"
+                              className="ml-auto text-xs"
                               style={{ color: "var(--bz-text-3)" }}
                             >
-                              · {c.assigned_to}
+                              {c.assigned_to}
                             </span>
                           )}
                         </label>
@@ -675,7 +756,7 @@ export default function ReviewPage() {
                       background: "var(--bz-surface)",
                       color: "var(--bz-text-1)",
                     }}
-                    placeholder="Search another client by name…"
+                    placeholder="Search client by name, phone or email…"
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
                   />
@@ -695,22 +776,34 @@ export default function ReviewPage() {
                                 client_id: r.client_id,
                                 full_name: r.full_name,
                                 assigned_to: r.assigned_to,
+                                email: r.email,
+                                phone: r.phone,
+                                nationality: r.nationality,
                               });
                               setSelectedPracticeId("");
                               setSearch("");
                               setSearchResults([]);
                             }}
                           >
-                            {r.full_name}
-                            {r.assigned_to ? (
+                            <span className="flex items-baseline justify-between gap-2">
+                              <span>{r.full_name}</span>
+                              {r.assigned_to ? (
+                                <span
+                                  className="text-xs"
+                                  style={{ color: "var(--bz-text-3)" }}
+                                >
+                                  {r.assigned_to}
+                                </span>
+                              ) : null}
+                            </span>
+                            {clientMeta(r) && (
                               <span
-                                className="text-xs"
+                                className="block truncate text-xs"
                                 style={{ color: "var(--bz-text-3)" }}
                               >
-                                {" "}
-                                · {r.assigned_to}
+                                {clientMeta(r)}
                               </span>
-                            ) : null}
+                            )}
                           </button>
                         </li>
                       ))}

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`321 routers · 605 services · 1026 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`321 routers · 606 services · 1028 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Why

These commits were STRANDED on PR #1315's head branch (`agent/air-m5/intake/crm-drive-push`): they were pushed onto the branch right as its auto-merge fired, so the squash that landed on main (ef923887e) does not contain them. Verified absent from main before re-landing (anti-hallucination check): `createObjectURL` 0 hits in `apps/mouth/src/app/(workspace)/review/page.tsx`, `regexp_replace` 0 hits in `apps/backend-rag/backend/app/routers/intake_review.py` on `origin/main`. The other two branch commits (b849cc06c candidate-shape fix, 23bd1d957 FASE 5D crm_push) ARE content-wise in main and are NOT re-landed here.

## What

Cherry-picked from the old branch (oldest-first):

- `74a895c5b` → docs: regenerate DOCSYNC counters. Conflict on the counter blocks (main's counters had moved) resolved by re-running `python scripts/docs_sync.py` against the current tree — authoritative regen, now 321 routers · 606 services · 1028 tests.
- `40f7bac51` → fix(intake): review UX (applied clean, no conflict). Two live-QA blockers found while reviewing as Sahira:
  1. **Blob preview 401** — an `<iframe>`/`<img>` `src` cannot carry the Bearer header, so the authenticated `/blob` endpoint refused the connection. The review page now fetches the blob WITH `api.getToken()` Authorization (+ `credentials:"include"`), previews via `URL.createObjectURL` (revoked on cleanup), with a "Loading document…" placeholder and a `previewFailed` error state.
  2. **Homonym disambiguation ("tanti Walter")** — candidates + search returned bare names, indistinguishable across 10 clients named "Walter". `search_clients` and `_load_candidate_clients` now project email/phone/nationality; the search query also matches phone fragments (digits-only `regexp_replace`, ≥5-digit guard) and email ILIKE. UI rows render `name · phone · email · nationality` in both the candidate radio list and the search dropdown; placeholder updated to "Search client by name, phone or email…".

## Validation

- `ruff check backend/app/routers/intake_review.py` → All checks passed
- `python -c "import ast; ast.parse(...)"` on the router → OK
- `apps/mouth`: `npx tsc --noEmit` → exit 0 (also green in pre-commit hook)
- `scripts/docs_sync.py` re-run → counters stable, no further drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)