### PR TITLE
ci: reduce runner-queue fan-out (path-scope 4 non-required workflows + drop check_suite meta-trigger)

### DIFF
--- a/.github/workflows/auto-merge-whitelist.yml
+++ b/.github/workflows/auto-merge-whitelist.yml
@@ -13,21 +13,27 @@
 
 name: Auto-merge whitelist
 
+# 2026-06-12 CI fan-out reduction: dropped the `check_suite: [completed]`
+# trigger. It fired a job on EVERY check-suite completion of EVERY PR (~20% of
+# all runner traffic measured during the merge-storm) only to re-evaluate
+# arming. Arming is already covered by pull_request_target opened/synchronize
+# for the whitelisted automation branches, and once auto-merge is armed GitHub
+# completes it when checks pass — no re-trigger needed. The merge-train now
+# owns ongoing PR advancement. Revert = re-add the two lines if dependabot/
+# docs-sync PRs stop auto-arming.
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review, labeled]
-  check_suite:
-    types: [completed]
 
 permissions:
-  contents: write          # required for gh pr merge --auto
-  pull-requests: write     # enable auto-merge
+  contents: write # required for gh pr merge --auto
+  pull-requests: write # enable auto-merge
   checks: read
 
 jobs:
   evaluate:
     name: Evaluate auto-merge eligibility
-    if: github.event.pull_request.draft == false || github.event_name == 'check_suite'
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (read-only for diff inspection)

--- a/.github/workflows/catD-backend-data-invariants.yml
+++ b/.github/workflows/catD-backend-data-invariants.yml
@@ -31,11 +31,23 @@ name: catD-backend-data-invariants
 # it proves stable + zero false-positive (W69 BUCO #1: arming a check as
 # required without a skip→success sentinel can pend-forever / block innocents).
 
+# Path-scoped (2026-06-12 CI fan-out reduction): this guardian only inspects
+# backend-rag data invariants (embedding dim, reachability test), so a PR that
+# touches no backend code has nothing for it to check. NON-REQUIRED, so a
+# non-matching PR simply doesn't run it — no pending-forever (W69 BUCO #1 only
+# bites REQUIRED checks placed behind a path filter without a skip→success
+# sentinel).
 on:
   pull_request:
+    paths:
+      - "apps/backend-rag/**"
+      - ".github/workflows/catD-backend-data-invariants.yml"
   push:
     branches:
       - main
+    paths:
+      - "apps/backend-rag/**"
+      - ".github/workflows/catD-backend-data-invariants.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/catE-sovereignty-lint.yml
+++ b/.github/workflows/catE-sovereignty-lint.yml
@@ -27,11 +27,25 @@ name: catE-sovereignty-lint
 # it proves stable + zero false-positive (W69 BUCO #1 lesson: arming a check as
 # required without a skip→success sentinel can pend-forever / block innocents).
 
+# Path-scoped (2026-06-12 CI fan-out reduction): every check here inspects
+# Python source (paid-Anthropic ban, Law-5 wr3 publish lint) or .env perms, so
+# a docs/content-only PR (.mdx/.md/.json) has nothing for it to scan — scoping
+# to those paths loses zero coverage. NON-REQUIRED, so a non-matching PR just
+# skips it (no pending-forever; W69 BUCO #1 only bites REQUIRED path-filtered
+# checks lacking a skip→success sentinel).
 on:
   pull_request:
+    paths:
+      - "**.py"
+      - "**/.env*"
+      - ".github/workflows/catE-sovereignty-lint.yml"
   push:
     branches:
       - main
+    paths:
+      - "**.py"
+      - "**/.env*"
+      - ".github/workflows/catE-sovereignty-lint.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,10 +1,28 @@
 name: SAST — Bandit + ESLint Security
 
+# Path-scoped (2026-06-12 CI fan-out reduction): SAST only has work to do on
+# source changes. A docs/content-only PR has no .py/.js/.ts to scan. NOT a
+# required check (the required "Bandit Python Security" comes from security.yml,
+# not this "Bandit SAST (Python)"), so a non-matching PR simply skips it.
 on:
   pull_request:
     branches: [main]
+    paths:
+      - "**.py"
+      - "**.js"
+      - "**.jsx"
+      - "**.ts"
+      - "**.tsx"
+      - ".github/workflows/semgrep.yml"
   push:
     branches: [main]
+    paths:
+      - "**.py"
+      - "**.js"
+      - "**.jsx"
+      - "**.ts"
+      - "**.tsx"
+      - ".github/workflows/semgrep.yml"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,12 +1,29 @@
 name: SonarQube Analysis
 
+# Path-scoped (2026-06-12 CI fan-out reduction): advisory code-quality scan
+# (continue-on-error) — no value on docs/content-only PRs. NON-REQUIRED, so a
+# non-matching PR just skips it.
 on:
   push:
     branches:
       - main
       - develop
+    paths:
+      - "**.py"
+      - "**.js"
+      - "**.jsx"
+      - "**.ts"
+      - "**.tsx"
+      - ".github/workflows/sonarqube.yml"
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - "**.py"
+      - "**.js"
+      - "**.jsx"
+      - "**.ts"
+      - "**.tsx"
+      - ".github/workflows/sonarqube.yml"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Why

You asked why GitHub CI is so slow. Measured it during the merge-storm: **jobs run in <1 min but sit ~20 min in queue** — the runner pool is saturated, not slow. Two amplifiers:
1. **~19 workflows fire per PR push** (GitHub queues per *job*, so each is a runner slot)
2. **`auto-merge-whitelist` fired on every `check_suite` completion** = ~20% of all runner traffic, pure meta-noise

GitHub queues per JOB, so the fix that actually frees runners is to **not start work that has nothing to do** — not to merge workflow files (same job count).

## What

All 5 touched workflows are **NON-REQUIRED** (verified against branch protection's 18 required contexts), so path-scoping them **cannot pend-forever** — W69 BUCO #1 only bites *required* path-filtered checks lacking a skip→success sentinel. The required suites are **untouched**.

| Workflow | Change | Rationale |
|---|---|---|
| catD-backend-data-invariants | scope `apps/backend-rag/**` | only checks backend embedding-dim + reachability |
| catE-sovereignty-lint | scope `**.py` + `**/.env*` | every check inspects Python or .env perms — zero coverage lost |
| semgrep (Bandit SAST + ESLint) | scope source extensions | SAST has no work on docs PRs |
| sonarqube (advisory) | scope source extensions | continue-on-error, no value on content PRs |
| auto-merge-whitelist | drop `check_suite:[completed]` | arming is covered by `pull_request_target` opened/synchronize; merge-train now owns ongoing advancement |

**Net effect:** a content/docs-only PR (frequent — .mdx articles) now skips 4 workflows and stops re-triggering the auto-merge evaluator on every check_suite completion.

## Verification

- `actionlint` clean (rc=0). The 3 shellcheck/expression warnings are **pre-existing** on the untouched `Resolve PR context` step (incl. an untrusted `head.ref` in an inline script — flagged for a separate hardening PR, out of scope here).
- All 5 files parse; required check names (asyncpg-lint, root-guard, Bandit Python Security, Detect Secrets, …) are produced by files I did **not** touch.
- Revert is trivial: each change is local to one workflow's `on:` block.

## Not done here (deliberate)

Consolidating the *required* sentinel gates (P1/P3/P6/P7/P8/P9 + asyncpg-lint + root-guard) into a single multi-step job would free ~7 more runners/PR but requires an **atomic branch-protection update** (rename N required checks → 1) — best done in a low-traffic window with the merge-train in enforcing mode as guard, not mid-storm. Documented as the next phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)