### PR TITLE
fix(security): harden claude_oauth_client argv — drop bypassPermissions + sentinel + model allowlist

### DIFF
--- a/apps/backend-rag/backend/llm/claude_oauth_client.py
+++ b/apps/backend-rag/backend/llm/claude_oauth_client.py
@@ -80,6 +80,25 @@ CLAUDE_CLI_CANDIDATES: Final[tuple[Path, ...]] = (
     Path.home() / ".npm-global/bin" / "claude",
     Path("/usr/local/bin/claude"),
 )
+# Model slug allowlist-by-shape: the value is forwarded to ``--model``, so
+# reject anything that isn't a plain ``claude-*`` slug (blocks argv/flag
+# smuggling via the model field). All current call-site slugs pass:
+# ``claude-sonnet-4-6``, ``claude-haiku-4-5``, ``claude-haiku-4-5-20251001``.
+_ALLOWED_MODEL_RE: Final[re.Pattern[str]] = re.compile(
+    r"^claude-[A-Za-z0-9][A-Za-z0-9._-]{1,63}$"
+)
+# Pure text-completion never needs tools. Block the destructive/exfil ones
+# defense-in-depth so an untrusted prompt (e.g. a raw user query routed
+# through ``surface_router``) can never reach a tool — replaces the unsafe
+# ``--permission-mode bypassPermissions`` this client used to carry.
+_DISALLOWED_TOOLS: Final[tuple[str, ...]] = (
+    "Bash",
+    "Edit",
+    "Write",
+    "WebFetch",
+    "WebSearch",
+    "NotebookEdit",
+)
 
 
 class ClaudeOAuthError(RuntimeError):
@@ -228,14 +247,21 @@ async def complete_async(
     claude_cli = _resolve_claude_cli()
 
     for attempt, (token, label) in enumerate(tokens, start=1):
+        # No bypassPermissions: tools are explicitly disallowed and the
+        # default permission mode fails-closed on any tool the model still
+        # attempts. The `--` sentinel guarantees the (possibly untrusted)
+        # prompt is parsed as an operand, never as a flag.
         cmd: list[str] = [
             claude_cli,
             "-p",
-            "--permission-mode",
-            "bypassPermissions",
+            "--disallowedTools",
+            *_DISALLOWED_TOOLS,
         ]
         if model:
+            if not _ALLOWED_MODEL_RE.match(model):
+                raise ValueError(f"model not allowed: {model!r}")
             cmd.extend(["--model", model])
+        cmd.append("--")
         cmd.append(prompt)
 
         env = _build_env(token)

--- a/apps/backend-rag/backend/tests/unit/llm/test_claude_oauth_client.py
+++ b/apps/backend-rag/backend/tests/unit/llm/test_claude_oauth_client.py
@@ -199,6 +199,48 @@ async def test_complete_async_cli_missing(
         await mod.complete_async("ping")
 
 
+@pytest.mark.asyncio
+async def test_complete_async_argv_is_hardened(
+    monkeypatch: pytest.MonkeyPatch,
+    clear_oauth_env: None,
+) -> None:
+    """The built argv must drop bypassPermissions, end with a ``--`` sentinel
+    immediately before the prompt, and reject non-allowlisted model slugs."""
+    from backend.llm import claude_oauth_client as mod
+
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_1", "tok1")
+
+    captured: dict[str, Any] = {}
+
+    async def fake_create(*args: Any, **kwargs: Any) -> Any:
+        captured["cmd"] = list(args)
+        return _fake_proc(stdout=b"ok", returncode=0)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create)
+
+    # (iv) a valid, allowlisted slug passes and reaches the subprocess.
+    resp = await mod.complete_async("untrusted prompt", model="claude-sonnet-4-6")
+    assert resp.text == "ok"
+
+    cmd = captured["cmd"]
+    # (i) the dangerous permission bypass is gone.
+    assert "bypassPermissions" not in cmd
+    assert "--permission-mode" not in cmd
+    # tools are explicitly disallowed instead.
+    assert "--disallowedTools" in cmd
+    # (ii) the `--` sentinel is present and sits immediately before the prompt.
+    assert "--" in cmd
+    assert cmd[-2] == "--"
+    assert cmd[-1] == "untrusted prompt"
+    # the model slug was forwarded.
+    assert "--model" in cmd
+    assert "claude-sonnet-4-6" in cmd
+
+    # (iii) a non-allowlisted model (flag-shaped) raises before any subprocess.
+    with pytest.raises(ValueError):
+        await mod.complete_async("ping", model="--evil-flag")
+
+
 def test_module_imports_without_anthropic_sdk() -> None:
     """Integrity test: the OAuth client must not import the Anthropic SDK.
 


### PR DESCRIPTION
## What

Hardens the argv that `complete_async()` builds for the `claude -p` subprocess in `apps/backend-rag/backend/llm/claude_oauth_client.py`, matching the already-hardened sibling helper `apps/bali-intel-scraper/backend/services/claude_oauth.py`.

### Before
```python
cmd = [claude_cli, "-p", "--permission-mode", "bypassPermissions"]
if model:
    cmd.extend(["--model", model])
cmd.append(prompt)
```
Problems:
- **[HIGH]** `bypassPermissions` on input that can be **untrusted**. `surface_router._classify_with_haiku` routes the raw user query into this client, so a prompt-injection could have reached any tool the CLI exposes.
- **[MED]** `prompt` as the last bare argv with no `--` sentinel → flag-smuggling.
- No validation of `model` before it is forwarded to `--model`.

### After
```python
cmd = [claude_cli, "-p", "--disallowedTools", *_DISALLOWED_TOOLS]  # Bash Edit Write WebFetch WebSearch NotebookEdit
if model:
    if not _ALLOWED_MODEL_RE.match(model):
        raise ValueError(f"model not allowed: {model!r}")
    cmd.extend(["--model", model])
cmd.append("--")
cmd.append(prompt)
```
- Drops `bypassPermissions`; explicitly disallows the destructive/exfil tools (fail-closed — pure text-completion never needs tools).
- Adds `--` sentinel immediately before the prompt operand.
- Allowlists the model slug by shape: `_ALLOWED_MODEL_RE = ^claude-[A-Za-z0-9][A-Za-z0-9._-]{1,63}$`. All current call-site slugs pass (`claude-sonnet-4-6`, `claude-haiku-4-5`, `claude-haiku-4-5-20251001`).

**Untouched (load-bearing):** `_collect_tokens` + 3-token fallback, rate-limit/empty/exit logic, OTEL span (`_start_claude_cli_span`/`_span_set`), `_record_claude_oauth_call` + finally + cost ledger, `_build_env` (ANTHROPIC_API_KEY strip), `_resolve_claude_cli`, keychain sentinel.

## Test
New `test_complete_async_argv_is_hardened` captures the built `cmd` from the subprocess fake and asserts: (i) no `bypassPermissions`/`--permission-mode`; (ii) `--` present and immediately before the prompt; (iii) a flag-shaped model (`--evil-flag`) raises `ValueError` before any subprocess; (iv) a valid slug (`claude-sonnet-4-6`) passes and is forwarded. The 9 pre-existing tests mock subprocess but do not inspect argv → unaffected.

Local verification (worktree `.worktrees/oauth-harden`, backend-rag venv):
- `python -m py_compile` → OK (client + test)
- `ruff check` → All checks passed!
- `pytest .../test_claude_oauth_client.py -q` → **10 passed**

Committed with all pre-commit hooks green (no `--no-verify`). The hook's FastAPI import-chain check self-skipped (`asyncpg` absent in the worktree venv) — code-unrelated.

---

## ⚠️ Escalation to Antonello — NOT fixed in this PR

### 1. 🐛 `surface_router.py:404` references a class that does not exist
`backend/services/routing/surface_router.py:404-407` does:
```python
from backend.llm.claude_oauth_client import ClaudeOAuthClient
client = ClaudeOAuthClient(model="claude-haiku-4-5-20251001", timeout_s=int(HAIKU_TIMEOUT_S))
```
But `claude_oauth_client` exports **no `ClaudeOAuthClient` class** — only the functions `complete_async`/`complete` plus the `ClaudeOAuthResponse`/error dataclasses. So this import raises `ImportError` at runtime. It is inside a broad `try/except` at line 402 that returns `None` on any failure → the **Haiku Layer-2 classifier has been dead since it was written**, silently degrading to Layer-1 heuristics on every call. Decide: repair (needs a thin `ClaudeOAuthClient` wrapper class around `complete_async`, with a sync `.complete()` shim) or remove the dead Layer-2 path. This hardening PR deliberately does not touch it.

### 2. ⚠️ permission-mode change is untested on Fly (non-TTY)
The switch from `--permission-mode bypassPermissions` to `--disallowedTools …` changes how the `claude` CLI negotiates permissions. The CLI has a known **hang in non-TTY containers** (this is exactly why `article_composer` was migrated off the CLI to DeepSeek). This PR was validated only locally with a mocked subprocess — **it has NOT been smoke-tested on a Fly `nuzantara-rag` container**. Before flipping any traffic onto this path on Fly, run a one-shot non-interactive smoke (`claude -p --disallowedTools … -- "ping"`) inside the container and confirm it returns rather than hangs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)