### PR TITLE
feat(ops): HOME-bridge sync antibody — verify ~/.openclaw bridge == origin/main (W50/W51/W52)

### DIFF
--- a/docs/runbooks/home-bridge-sync.md
+++ b/docs/runbooks/home-bridge-sync.md
@@ -1,0 +1,107 @@
+# HOME-bridge sync antibody
+
+**Script:** `scripts/verify_home_bridge_sync.sh`
+**Scar family:** W50 / W51 / W52
+**LaunchAgent watched:** `com.nuzantara.openclaw-whatsapp-bridge`
+
+## The invariant
+
+The **live** WhatsApp bridge does **not** run from the git checkout. It runs from
+a HOME copy that is **not** git-tracked:
+
+```
+~/.openclaw/bin/openclaw_whatsapp_bridge.py     <- PROD (live, hand-patched historically)
+scripts/openclaw_whatsapp_bridge.py             <- tracked source of truth (origin/main)
+```
+
+These two must be byte-identical. Nothing enforced that, so they drifted in
+silence (the W50/W51/W52 scar): a fix that touches only `scripts/` is invisible
+to prod until HOME is re-copied; a hand-patch on HOME never lands in git.
+
+This is dangerous because the WhatsApp **safety guards** (property-zoning /
+nominee / villa — commits F05 / F06 / F13) live in this file. Drift means prod
+either runs **without** the guards the repo thinks are deployed, or runs guards
+**different** from what the repo says is shipped — and until this antibody, both
+were undetectable.
+
+## What the antibody does
+
+1. `git hash-object ~/.openclaw/bin/openclaw_whatsapp_bridge.py` (live HOME blob).
+2. `git fetch origin main` then `git rev-parse origin/main:scripts/openclaw_whatsapp_bridge.py` (ground-truth blob).
+   **origin/main is ground truth — deliberately NOT the local checkout**, which
+   can be stale by dozens of commits.
+3. Hashes match → exit 0, logs `HOME bridge in sync with origin/main`.
+4. Hashes diverge → exit 1, prints both hashes + a diff line-count summary, and
+   fires a Telegram `⚠️ HOME bridge DRIFT vs origin/main` alert (if creds are
+   configured, same secret-sourcing pattern as the other sentinel scripts).
+5. HOME copy absent (e.g. on Mini, no bridge installed) → exit 0 with a WARN.
+   That is a non-event, not a drift.
+
+Kill switch: `HOME_BRIDGE_SYNC_OFF=1`.
+Self-test of the alert path: `FORCE_ALERT=1 bash scripts/verify_home_bridge_sync.sh`.
+
+## How to run it
+
+```bash
+cd ~/Desktop/nuzantara
+bash scripts/verify_home_bridge_sync.sh ; echo "exit=$?"
+```
+
+Exit `0` = in sync (or no HOME copy on this machine). Exit `1` = DRIFT.
+
+## What to do on DRIFT
+
+Resolution is **one-directional: origin/main → HOME, NEVER the reverse.**
+The HOME copy is a deployment artifact; the repo is the source of truth. If
+someone hand-patched HOME and that patch is genuinely wanted, it must first be
+committed to `scripts/openclaw_whatsapp_bridge.py` via a normal PR, land on
+origin/main, and only then be re-deployed to HOME.
+
+To re-deploy origin/main → HOME:
+
+```bash
+cd ~/Desktop/nuzantara
+git fetch origin main
+# materialise the ground-truth blob straight into the live HOME path:
+git show origin/main:scripts/openclaw_whatsapp_bridge.py > ~/.openclaw/bin/openclaw_whatsapp_bridge.py
+chmod +x ~/.openclaw/bin/openclaw_whatsapp_bridge.py
+
+# restart the bridge so prod picks up the new file:
+launchctl kickstart -k "gui/$(id -u)/com.nuzantara.openclaw-whatsapp-bridge"
+# (or: launchctl unload + load the plist if kickstart is unavailable)
+
+# re-verify:
+bash scripts/verify_home_bridge_sync.sh ; echo "exit=$?"   # expect exit=0
+```
+
+**Never** copy HOME → repo to "fix" a drift. That launders an unreviewed
+hand-patch (possibly one that weakens a safety guard) into the source of truth.
+
+## Scheduling (operator step — NOT installed by this change)
+
+This change deliberately does **not** install a LaunchAgent (local infra is an
+operator decision). Recommended: run every ~30 min via launchd. Sketch:
+
+```xml
+<!-- ~/Library/LaunchAgents/com.nuzantara.home-bridge-sync.plist -->
+<key>Label</key><string>com.nuzantara.home-bridge-sync</string>
+<key>ProgramArguments</key>
+<array>
+  <string>/bin/bash</string>
+  <string>/Users/nuzantara/Desktop/nuzantara/scripts/verify_home_bridge_sync.sh</string>
+</array>
+<key>StartInterval</key><integer>1800</integer>   <!-- 30 min -->
+<key>RunAtLoad</key><true/>
+```
+
+The script already self-hardens for launchd: minimal `PATH`, absolute `git`
+path, secrets sourced from `~/.nuzantara-secrets.env`.
+
+## Note: stale local checkout (separate issue)
+
+As of writing, the **local checkout** of the bridge can differ from both HOME and
+origin/main — the checkout has been observed ~85 commits behind origin/main with
+dirty files. That is a _separate_ hygiene problem (the antibody intentionally
+compares against `origin/main`, not the checkout, precisely so a stale checkout
+cannot produce a false DRIFT). Pulling the local checkout up to origin/main is
+tracked separately and is not required for this antibody to be correct.

--- a/scripts/verify_home_bridge_sync.sh
+++ b/scripts/verify_home_bridge_sync.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# verify_home_bridge_sync.sh — HOME-bridge sync antibody (cicatrix family W50/W51/W52).
+#
+# THE INVARIANT THIS GUARDS
+# -------------------------
+# The LIVE WhatsApp bridge does NOT run from the git checkout. It runs from a
+# HOME copy:
+#       ~/.openclaw/bin/openclaw_whatsapp_bridge.py     (prod, NOT git-tracked)
+# launched by LaunchAgent  com.nuzantara.openclaw-whatsapp-bridge.
+# The git-tracked source of truth is:
+#       scripts/openclaw_whatsapp_bridge.py             (on origin/main)
+#
+# The two are supposed to be byte-identical. But nothing enforced that — they can
+# diverge IN SILENCE. This bit us (the W50/W51/W52 scar family): a fix that
+# touches only scripts/ is INVISIBLE to prod until someone re-copies it into HOME;
+# and conversely a hand-patch applied to the HOME copy never lands in git, so the
+# repo's "source of truth" is a lie.
+#
+# The danger is doubled because the WhatsApp safety guards
+# (property-zoning / nominee / villa — commits F05 / F06 / F13) live in this file.
+# If HOME drifts from tracked, then either:
+#   - prod runs WITHOUT the guards the repo thinks are deployed, OR
+#   - prod runs guards DIFFERENT from what the repo says is shipped.
+# Both are dangerous, and both were until now completely undetectable.
+#
+# THIS SCRIPT is the antibody: it compares the git blob hash of the live HOME
+# copy against the blob hash of scripts/openclaw_whatsapp_bridge.py ON ORIGIN/MAIN
+# (origin/main is ground truth — deliberately NOT the local checkout, which can be
+# stale by dozens of commits). If they match → healthy. If they diverge → exit 1,
+# print both hashes + a diff summary, and (if Telegram creds are configured, same
+# pattern as the other sentinel scripts) fire a DRIFT alert.
+#
+# DRIFT RESOLUTION IS ONE-DIRECTIONAL: origin/main -> HOME, NEVER the reverse.
+# See docs/runbooks/home-bridge-sync.md.
+#
+# Usage:
+#   verify_home_bridge_sync.sh           # check; exit 0 = sync, 1 = DRIFT, 0+WARN = no HOME copy
+#   FORCE_ALERT=1 verify_home_bridge_sync.sh   # exercise the Telegram path (self-test)
+#
+# Kill switch: env HOME_BRIDGE_SYNC_OFF=1 → exits 0 immediately.
+#
+# Scheduling: meant to run via launchd ~every 30min. The plist is an OPERATOR
+# step (this script does NOT install it) — see the runbook.
+
+set -uo pipefail
+
+# --- Kill switch -----------------------------------------------------------
+
+if [[ "${HOME_BRIDGE_SYNC_OFF:-0}" == "1" ]]; then
+    echo "verify_home_bridge_sync: disabled via HOME_BRIDGE_SYNC_OFF=1" >&2
+    exit 0
+fi
+
+# --- launchd robustness: minimal PATH, absolute tool paths -----------------
+# launchd hands us a bare environment. Resolve git with an absolute path and a
+# sane PATH so the script behaves identically under cron/launchd and an
+# interactive shell.
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:${PATH:-}"
+
+GIT_BIN="/usr/bin/git"
+[[ -x "$GIT_BIN" ]] || GIT_BIN="$(command -v git || echo git)"
+
+# --- Configuration ---------------------------------------------------------
+
+REPO_ROOT="${NUZ_REPO_ROOT:-$HOME/Desktop/nuzantara}"
+HOME_BRIDGE="$HOME/.openclaw/bin/openclaw_whatsapp_bridge.py"
+TRACKED_PATH="scripts/openclaw_whatsapp_bridge.py"
+GROUND_TRUTH_REF="origin/main"
+
+LOG_FILE="$HOME/logs/home-bridge-sync.log"
+
+# Source secrets (TELEGRAM_BOT_TOKEN + chat id). NEVER hardcode the token.
+# Same pattern as scripts/cost_breaker_deadman.sh / disk_watchdog.sh.
+if [[ -f "$HOME/.nuzantara-secrets.env" ]]; then
+    set -a
+    # shellcheck disable=SC1091
+    source "$HOME/.nuzantara-secrets.env"
+    set +a
+fi
+TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN:-${BALIZEROBOT_TOKEN:-}}"
+TELEGRAM_CHAT_ID="${TELEGRAM_OWNER_CHAT_ID:-${TELEGRAM_ADMIN_CHAT_ID:-${TELEGRAM_CHAT_ID:-1125336968}}}"
+
+# --- Helpers ---------------------------------------------------------------
+
+mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
+
+log() {
+    local msg
+    msg="[$(date '+%Y-%m-%dT%H:%M:%S%z')] $*"
+    echo "$msg"
+    echo "$msg" >>"$LOG_FILE" 2>/dev/null || true
+}
+
+tg_alert() {
+    local text="$1"
+    if [[ -z "$TELEGRAM_BOT_TOKEN" || -z "$TELEGRAM_CHAT_ID" ]]; then
+        log "telegram: missing creds (token or chat_id), skipping alert"
+        return 1
+    fi
+    curl -sS -m 10 -X POST \
+        "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+        -d "chat_id=${TELEGRAM_CHAT_ID}" \
+        -d "text=${text}" \
+        -d "parse_mode=HTML" \
+        -o /dev/null \
+        || log "telegram: post failed"
+}
+
+# --- Main ------------------------------------------------------------------
+
+main() {
+    if [[ ! -d "$REPO_ROOT/.git" && ! -f "$REPO_ROOT/.git" ]]; then
+        log "ERROR: repo root not a git repo: $REPO_ROOT"
+        exit 1
+    fi
+
+    # Case: HOME copy absent → this machine simply has no bridge installed
+    # (e.g. Mini). That is NOT a drift — it is a non-event. Warn and pass.
+    if [[ ! -f "$HOME_BRIDGE" ]]; then
+        log "WARN: HOME bridge not present ($HOME_BRIDGE) — no bridge installed on this machine, nothing to sync"
+        exit 0
+    fi
+
+    # Hash of the LIVE HOME copy (git blob hash — same algo git uses, so it is
+    # directly comparable to a tracked blob hash).
+    local home_hash
+    home_hash="$("$GIT_BIN" hash-object "$HOME_BRIDGE" 2>/dev/null)"
+    if [[ -z "$home_hash" ]]; then
+        log "ERROR: could not hash HOME bridge ($HOME_BRIDGE)"
+        exit 1
+    fi
+
+    # Ground-truth blob hash from origin/main (NOT the local checkout). Refresh
+    # the remote ref first so we compare against what is actually on origin/main,
+    # not a stale fetch. Failure to fetch is non-fatal — fall back to the cached
+    # remote-tracking ref (better a slightly stale ground truth than none).
+    "$GIT_BIN" -C "$REPO_ROOT" fetch origin main --quiet 2>/dev/null \
+        || log "WARN: 'git fetch origin main' failed — comparing against cached $GROUND_TRUTH_REF ref"
+
+    local tracked_hash
+    tracked_hash="$("$GIT_BIN" -C "$REPO_ROOT" rev-parse "${GROUND_TRUTH_REF}:${TRACKED_PATH}" 2>/dev/null)"
+    if [[ -z "$tracked_hash" ]]; then
+        log "ERROR: could not resolve ${GROUND_TRUTH_REF}:${TRACKED_PATH} — is origin/main fetched?"
+        exit 1
+    fi
+
+    # --- Verdict -----------------------------------------------------------
+
+    if [[ "$home_hash" == "$tracked_hash" && "${FORCE_ALERT:-0}" != "1" ]]; then
+        log "OK: HOME bridge in sync with ${GROUND_TRUTH_REF} (blob ${home_hash})"
+        exit 0
+    fi
+
+    # DRIFT (or forced self-test). Compute a diff summary against the tracked
+    # blob. We materialise the origin/main blob to a temp file and diff line
+    # counts — purely informational, never mutating either side.
+    local tmp diff_summary="(diff unavailable)"
+    tmp="$(mktemp -t home_bridge_truth.XXXXXX 2>/dev/null || echo "")"
+    if [[ -n "$tmp" ]] && "$GIT_BIN" -C "$REPO_ROOT" cat-file blob "$tracked_hash" >"$tmp" 2>/dev/null; then
+        # diff exit code is 1 when files differ; capture changed-line count.
+        local added removed
+        added="$(diff "$tmp" "$HOME_BRIDGE" 2>/dev/null | grep -c '^>' || true)"
+        removed="$(diff "$tmp" "$HOME_BRIDGE" 2>/dev/null | grep -c '^<' || true)"
+        diff_summary="HOME has ${added} line(s) not in ${GROUND_TRUTH_REF}, missing ${removed} line(s) present in ${GROUND_TRUTH_REF}"
+        rm -f "$tmp"
+    fi
+
+    if [[ "${FORCE_ALERT:-0}" == "1" && "$home_hash" == "$tracked_hash" ]]; then
+        log "SELF-TEST (FORCE_ALERT=1): hashes actually MATCH (${home_hash}); exercising alert path only"
+    fi
+
+    log "DRIFT: HOME bridge != ${GROUND_TRUTH_REF}"
+    log "  HOME blob    : ${home_hash}  ($HOME_BRIDGE)"
+    log "  origin/main  : ${tracked_hash}  (${TRACKED_PATH})"
+    log "  diff         : ${diff_summary}"
+    log "  RESOLUTION   : re-copy ${GROUND_TRUTH_REF}:${TRACKED_PATH} -> HOME, then restart LaunchAgent com.nuzantara.openclaw-whatsapp-bridge (NEVER the reverse). See docs/runbooks/home-bridge-sync.md"
+
+    tg_alert "⚠️ HOME bridge DRIFT vs origin/main
+HOME blob: <code>${home_hash}</code>
+origin/main: <code>${tracked_hash}</code>
+${diff_summary}
+Fix: re-copy origin/main:${TRACKED_PATH} → HOME + restart LaunchAgent (runbook: home-bridge-sync.md). NEVER copy HOME→repo."
+
+    exit 1
+}
+
+main "$@"


### PR DESCRIPTION
## The invariant (cicatrix W50/W51/W52)

The **live** WhatsApp bridge does NOT run from the git checkout. It runs from a non-git-tracked HOME copy:

- `~/.openclaw/bin/openclaw_whatsapp_bridge.py` — PROD (live, hand-patched historically), launched by LaunchAgent `com.nuzantara.openclaw-whatsapp-bridge`
- `scripts/openclaw_whatsapp_bridge.py` — tracked source of truth (origin/main)

These two are supposed to be byte-identical, but **nothing enforced it** — they can drift in silence (the W50/W51/W52 scar family). A fix that touches only `scripts/` is invisible to prod until HOME is re-copied; a hand-patch on HOME never lands in git.

This is doubly dangerous because the WhatsApp **safety guards** (property-zoning / nominee / villa — commits F05/F06/F13) live in this file. Drift means prod either runs **without** the guards the repo thinks are deployed, or runs guards **different** from what the repo says is shipped — and until now, both were undetectable.

## The antibody

`scripts/verify_home_bridge_sync.sh`:

1. `git hash-object` of the live HOME copy.
2. Blob hash of `origin/main:scripts/openclaw_whatsapp_bridge.py` (origin/main is ground truth — **deliberately NOT the local checkout**, which can be dozens of commits stale).
3. Match → exit 0, logs `HOME bridge in sync with origin/main`.
4. Diverge → exit 1, prints both hashes + a diff line-count summary, and fires a Telegram `⚠️ HOME bridge DRIFT vs origin/main` alert (reuses the exact secret-sourcing + curl pattern from `cost_breaker_deadman.sh` / `disk_watchdog.sh`).
5. HOME copy absent (e.g. Mini, no bridge installed) → exit 0 with WARN (non-event, not a drift).
6. launchd-hardened: minimal PATH, absolute git path. Kill switch `HOME_BRIDGE_SYNC_OFF=1`. Self-test `FORCE_ALERT=1`.

`docs/runbooks/home-bridge-sync.md` documents the invariant and the **one-directional** fix: origin/main → HOME + restart the LaunchAgent, NEVER HOME → repo (that would launder an unreviewed hand-patch into the source of truth).

## Real run output (today)

```
$ bash scripts/verify_home_bridge_sync.sh ; echo "exit=$?"
OK: HOME bridge in sync with origin/main (blob d132057958d2e5113279b13fd838079040640656)
exit=0
```

**In sync today: YES.** HOME blob `d132057958d2e5113279b13fd838079040640656` == `origin/main:scripts/openclaw_whatsapp_bridge.py`. Verified: `shellcheck` clean, `bash -n` OK, `FORCE_ALERT=1` exercises the diff+alert path without crashing.

## Manual follow-ups (out of scope for this PR)

- **Schedule** via LaunchAgent every 30 min (operator step — this PR installs no plist; sketch in the runbook).
- **Evaluate `git pull` of the local checkout**: as of today the local checkout is ~85 commits behind origin/main with 32 dirty files. The antibody intentionally compares against `origin/main` (not the checkout) precisely so a stale checkout cannot produce a false DRIFT — so this is a **separate** hygiene task, not a blocker here.

Worked in an isolated worktree off `origin/main`. No `--no-verify` used. No LaunchAgent installed. The live HOME bridge was never touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)