### PR TITLE
fix(wr2): vision 429 rate-limit is transient, never burns the render breaker

### DIFF
--- a/apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py
@@ -82,6 +82,134 @@ def test_vision_critic_fail_closed_when_required(monkeypatch):
     assert any("vision" in i.lower() for i in c.issues)
 
 
+# ── 429 rate-limit resilience (2026-06-12: a transient quota window masqueraded
+#    as "vision unavailable" and burned 3 attempts → render_failed on a healthy
+#    draft) ──────────────────────────────────────────────────────────────────
+
+
+def _fake_proc(returncode=0, stdout="", stderr=""):
+    from types import SimpleNamespace
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_run_claude_json_raises_on_429_envelope(monkeypatch):
+    """A CLI error envelope with api_error_status==429 (even rc!=0) is a transient
+    rate-limit, distinct from a real outage — must raise VisionRateLimited."""
+    import json as _json
+
+    from wr2_html_renderer import claude_vision
+
+    envelope = _json.dumps({"is_error": True, "api_error_status": 429,
+                            "result": "You've hit your session limit · resets 2:40am"})
+    monkeypatch.setattr(claude_vision.subprocess, "run",
+                        lambda *a, **k: _fake_proc(returncode=1, stdout=envelope))
+    with pytest.raises(claude_vision.VisionRateLimited):
+        claude_vision._run_claude_json("p", {"type": "object"})
+
+
+def test_run_claude_json_raises_on_session_limit_text(monkeypatch):
+    from wr2_html_renderer import claude_vision
+
+    monkeypatch.setattr(claude_vision.subprocess, "run",
+                        lambda *a, **k: _fake_proc(returncode=1, stderr="Error: session limit reached"))
+    with pytest.raises(claude_vision.VisionRateLimited):
+        claude_vision._run_claude_json("p", {"type": "object"})
+
+
+def test_run_claude_json_genuine_failure_returns_none_not_raise(monkeypatch):
+    """A real non-429 failure (rc!=0, no limit text) stays the None/unavailable
+    path — must NOT be reclassified as rate-limit."""
+    from wr2_html_renderer import claude_vision
+
+    monkeypatch.setattr(claude_vision.subprocess, "run",
+                        lambda *a, **k: _fake_proc(returncode=1, stderr="boom: chromium crashed"))
+    assert claude_vision._run_claude_json("p", {"type": "object"}) is None
+
+
+def test_run_claude_json_pins_vision_model(monkeypatch):
+    """Default pins claude-sonnet-4-6; WR2_VISION_MODEL overrides. (No --model
+    before = CLI default, heavier → 120s timeouts + quota burn.)"""
+    import json as _json
+
+    from wr2_html_renderer import claude_vision
+
+    captured = {}
+
+    def _capture(cmd, *a, **k):
+        captured["cmd"] = cmd
+        return _fake_proc(returncode=0, stdout=_json.dumps({"structured_output": {"ok": True}}))
+
+    monkeypatch.setattr(claude_vision.subprocess, "run", _capture)
+    monkeypatch.delenv("WR2_VISION_MODEL", raising=False)
+    claude_vision._run_claude_json("p", {"type": "object"})
+    assert "--model" in captured["cmd"]
+    assert "claude-sonnet-4-6" in captured["cmd"]
+
+    monkeypatch.setenv("WR2_VISION_MODEL", "claude-opus-4-8")
+    claude_vision._run_claude_json("p", {"type": "object"})
+    assert "claude-opus-4-8" in captured["cmd"]
+
+
+def test_design_critic_propagates_rate_limit_not_fail_closed(monkeypatch):
+    """When the runner signals rate-limit, the critic must propagate it (the
+    apply-worker treats it as transient), NOT collapse to the fail-closed
+    'unavailable' Critique that the circuit breaker would burn an attempt on."""
+    from wr2_html_renderer import claude_vision
+
+    def _raise(*a, **k):
+        raise claude_vision.VisionRateLimited("429")
+
+    monkeypatch.setattr(claude_vision, "_run_claude_json", _raise)
+    monkeypatch.setenv("WR2_VISION_REQUIRED", "1")
+    png = Path(tempfile.mkdtemp()) / "x.png"
+    png.write_bytes(b"PNG")
+    with pytest.raises(claude_vision.VisionRateLimited):
+        claude_vision.claude_design_critic(png, {}, {})
+
+
+@pytest.mark.asyncio
+async def test_apply_one_rate_limit_does_not_burn_attempt(monkeypatch):
+    """INVARIANT: a 429 during render releases the lease back to
+    drafts_imaged_checked WITHOUT writing _html_attempts and WITHOUT
+    render_failed — the draft is retried next tick, no attempt consumed."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    import scripts.wr2_html_render_apply as html
+
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    conn.fetchval = AsyncMock(return_value=0)
+    conn.close = AsyncMock()
+    monkeypatch.setattr(html.asyncpg, "connect", AsyncMock(return_value=conn))
+    monkeypatch.setattr(
+        html._pg, "acquire_html_lease_and_fetch",
+        AsyncMock(return_value={"slides_json": {"slides": [{"headline": "H"}]}}),
+    )
+    monkeypatch.setattr(html, "_heartbeat_loop", AsyncMock())
+    monkeypatch.setattr(html, "_normalize_heroes", lambda slides, *a, **k: slides)
+
+    class _Srv:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+    monkeypatch.setattr(html, "_HeroServer", lambda *a, **k: _Srv())
+    monkeypatch.setattr(
+        html, "_render_carousel",
+        AsyncMock(side_effect=html.VisionRateLimited("429 session limit")),
+    )
+    monkeypatch.setenv("WR2_VISION_REQUIRED", "1")
+
+    import uuid as _uuid
+    did = _uuid.uuid4()
+    result = await html._apply_one("postgres://x", did, "owner-1")
+
+    assert result.startswith("rate_limited")
+    # the release UPDATE must NOT touch the attempt counter and must NOT fail it
+    sqls = " ".join(str(c.args[0]) for c in conn.execute.call_args_list)
+    assert "_html_attempts" not in sqls
+    assert "render_failed" not in sqls
+    assert "drafts_imaged_checked" in sqls
+
+
 @pytest.mark.asyncio
 async def test_designer_loop_converges_default_no_vision(monkeypatch):
     import base64

--- a/scripts/wr2_html_render_apply.py
+++ b/scripts/wr2_html_render_apply.py
@@ -54,6 +54,7 @@ sys.path.insert(0, str(_REPO / "scripts"))
 import asyncpg  # noqa: E402
 
 from backend.services.canva_renderer_v2 import _pg  # noqa: E402
+from wr2_html_renderer.claude_vision import VisionRateLimited  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 # Silence httpx INFO logs that would otherwise leak the Telegram bot token in the request URL
@@ -436,6 +437,23 @@ async def _apply_one(pool_conn_dsn: str, draft_id: uuid.UUID, owner: str) -> str
                     f"Re-open by having them text +62 821-3465-159, then re-enqueue."
                 )
             return f"rendered report={report}"
+        except VisionRateLimited as exc:
+            # transient quota window (HTTP 429) — NOT a draft defect. Release the
+            # lease WITHOUT touching _html_attempts so the circuit breaker is not
+            # burned; the draft returns to the queue and renders next tick once
+            # quota recovers. (Pre-fix this 429 masqueraded as "vision
+            # unavailable" and killed healthy drafts in 3 attempts.)
+            await main_conn.execute(
+                """
+                UPDATE war_room_drafts
+                   SET status='drafts_imaged_checked', lease_owner=NULL,
+                       lease_acquired_at=NULL, lease_heartbeat_at=NULL, updated_at=NOW()
+                 WHERE id=$1 AND lease_owner=$2 AND status='rendering'
+                """,
+                draft_id, owner,
+            )
+            logger.warning("draft %s vision rate-limited (429) — transient, no attempt burned: %s", draft_id, exc)
+            return f"rate_limited:{exc}"
         except RuntimeError as exc:
             # transient render/Drive failure -> back to queue unless attempts exhausted
             attempts = await main_conn.fetchval(
@@ -539,6 +557,7 @@ async def run(dry_run: bool = False, draft_id: str | None = None) -> int:
 
     processed = 0
     successes = 0
+    rate_limited_halt = False
     for loop_n in range(max_loops):
         if draft_id:
             ids = [uuid.UUID(draft_id)] if loop_n == 0 else []
@@ -570,8 +589,17 @@ async def run(dry_run: bool = False, draft_id: str | None = None) -> int:
                 logger.info("draft %s -> %s", did, result)
                 if result.startswith("rendered") or result == "shadow_done":
                     successes += 1
+                elif result.startswith("rate_limited"):
+                    # quota is exhausted account-wide — further drafts this run
+                    # would hit the same 429. Stop draining; the draft stays
+                    # queued (no attempt burned) and renders on a later tick.
+                    logger.warning("drain-loop halting early: vision quota rate-limited")
+                    rate_limited_halt = True
+                    break
             except Exception:
                 logger.exception("draft %s crashed", did)
+        if draft_id or rate_limited_halt:
+            break
         if draft_id:
             break
     return 0 if successes == processed else 1

--- a/scripts/wr2_html_renderer/claude_vision.py
+++ b/scripts/wr2_html_renderer/claude_vision.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -32,6 +33,34 @@ from typing import Any
 from .designer_loop import Critique
 
 logger = logging.getLogger("wr2.claude_vision")
+
+
+class VisionRateLimited(Exception):
+    """The vision call hit a transient quota/rate-limit (HTTP 429 / session
+    limit) — NOT a real outage and NOT a defect of the slide. Distinct from the
+    `None`-return "unavailable" path: a rate-limit is recoverable next tick, so
+    the apply-worker must release the draft WITHOUT burning a circuit-breaker
+    attempt. Deliberately NOT a subclass of RuntimeError so the apply-worker's
+    generic `except RuntimeError` (transient render failure, which DOES burn an
+    attempt) cannot swallow it."""
+
+
+# A 429 surfaces either as a JSON envelope with api_error_status==429 / is_error
+# + a session-limit message, or (older CLI paths) as rc!=0 with the limit text
+# on stdout/stderr. Match the human text conservatively.
+_RATE_LIMIT_RE = re.compile(r"session limit|rate.?limit|usage limit", re.IGNORECASE)
+
+
+def _detect_rate_limit(envelope: dict[str, Any] | None, combined_text: str, returncode: int) -> bool:
+    if isinstance(envelope, dict):
+        if envelope.get("api_error_status") == 429:
+            return True
+        if envelope.get("is_error") and _RATE_LIMIT_RE.search(str(envelope.get("result", ""))):
+            return True
+    # only trust the loose text match when the call actually failed
+    if returncode != 0 and _RATE_LIMIT_RE.search(combined_text):
+        return True
+    return False
 
 # The lever vocabulary the critic may return — kept in sync with
 # designer_loop._apply_levers so the loop can act on them.
@@ -121,8 +150,13 @@ def _run_claude_json(prompt: str, schema: dict[str, Any], *, timeout_s: int = 12
     """
     env = dict(os.environ)
     env.pop("ANTHROPIC_API_KEY", None)
+    # Pin the vision model (default sonnet: vision-capable + solid editorial
+    # judgment, lighter/cheaper than opus so it neither burns the MAX-plan quota
+    # window nor trips the 120s timeout). Configurable without a code change.
+    model = os.environ.get("WR2_VISION_MODEL", "claude-sonnet-4-6")
     cmd = [
         _CLAUDE_BIN, "--print",
+        "--model", model,
         "--output-format", "json",
         "--json-schema", json.dumps(schema),
         prompt,
@@ -132,15 +166,28 @@ def _run_claude_json(prompt: str, schema: dict[str, Any], *, timeout_s: int = 12
     except subprocess.TimeoutExpired:
         logger.warning("claude vision call timed out after %ss", timeout_s)
         return None
+    # Parse the stdout envelope up front so a 429 can be told apart from a real
+    # failure even when the CLI exits rc!=0 (it emits the error as JSON on stdout
+    # and a non-zero code with empty stderr).
+    out = proc.stdout.strip()
+    envelope: dict[str, Any] | None = None
+    if out:
+        try:
+            parsed = json.loads(out)
+            if isinstance(parsed, dict):
+                envelope = parsed
+        except json.JSONDecodeError:
+            envelope = None
+    if _detect_rate_limit(envelope, (proc.stdout or "") + (proc.stderr or ""), proc.returncode):
+        raise VisionRateLimited(
+            f"claude vision rate-limited (429/session limit): {str(envelope.get('result', ''))[:160] if envelope else proc.stderr[:160]}"
+        )
     if proc.returncode != 0:
         logger.warning("claude vision call failed rc=%s err=%s", proc.returncode, proc.stderr[:300])
         return None
-    out = proc.stdout.strip()
     if not out:
         return None
-    try:
-        envelope = json.loads(out)
-    except json.JSONDecodeError:
+    if envelope is None:
         logger.warning("claude vision: stdout not JSON: %s", out[:200])
         return None
     # CLI json envelope (verified 2026-06-07): when --json-schema is used the


### PR DESCRIPTION
## Post-mortem (2026-06-12, via the #1300 HARD-reject observability)

The env-file OAuth token hit a **429 session limit** mid-render. The `claude` CLI emitted a JSON error envelope (`api_error_status=429`) and exited **rc=1 with empty stderr**. `claude_vision._run_claude_json` mapped *any* `rc!=0` to `None`; `claude_design_critic` mapped `None` to the fail-closed `"vision unavailable"` Critique; the apply-worker circuit breaker burned all 3 `_html_attempts` → **`render_failed` on a healthy draft, on the cover slide**, before the body slides were even reached. This is why draft `3e2c2923` never converged tonight — not a design defect, a transient quota window killing the draft.

## Fixes

1. **`claude_vision`** — detect 429/session-limit (envelope `api_error_status==429`, or `rc!=0` + limit text) and `raise VisionRateLimited`. Deliberately **NOT** a `RuntimeError` subclass, so the worker's generic `except RuntimeError` (real transient render failure, which *does* burn an attempt) can't swallow it. Genuine non-429 failures still return `None` (unavailable, unchanged).
2. **`claude_vision`** — pin `--model` (default `claude-sonnet-4-6`, override `WR2_VISION_MODEL`). No `--model` before meant the heavy CLI default → the 120s timeouts + excess quota burn.
3. **`wr2_html_render_apply`** — `except VisionRateLimited` *before* the RuntimeError handler releases the lease back to `drafts_imaged_checked` **without** touching `_html_attempts` and **without** `render_failed`; the drain loop halts early (quota is account-wide). The draft renders next tick once quota recovers.

## Tests

TDD, RED first: 6 new tests, including the invariant **"a rate-limited render leaves `_html_attempts` unchanged and status not `render_failed`"**. Suite `test_wr2_html_render_apply.py` **92/92**.

Part of P-1 follow-up convergence work (Antonello GO 2026-06-11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)