### PR TITLE
fix(ops): re-arm blind heal-loop (W70) — capture real stderr + heal=0 alert + dlq requeue

### DIFF
--- a/scripts/cron-wrapper.sh
+++ b/scripts/cron-wrapper.sh
@@ -166,17 +166,48 @@ printf '{"job":"%s","status":"%s","exit_code":%d,"attempts":%d,"duration_s":%d,"
 # the Cell flags them all as failed (false-positive flood since 2026-04-13).
 LAST_ERROR_PAYLOAD=""
 if [ "$STATUS" = "failed" ]; then
+    # W70 fix 2026-06-12: capture the REAL stderr so the DLQ classifier stops
+    # heal-looping blind. The pre-W70 path (F08 2026-06-11) used
+    #   tr '"' "'" | tr '\n' '|'
+    # which only neutralised double-quotes and newlines — a job whose output
+    # contained a backslash (Windows path, Python traceback repr, regex), a
+    # tab, a carriage return, or any other control char produced INVALID JSON.
+    # That broke the sentinel .last.json parse, which silently zeroes the
+    # classifier signal — the exact blind-loop W70 is about.
+    #
+    # Fix: build a one-line human summary, then JSON-escape the last ~2000
+    # chars of $OUTPUT with python3's json.dumps (handles ", \, \n, \t, \r and
+    # all control chars correctly). json.dumps returns a fully-quoted JSON
+    # string value, so we substitute it verbatim as the field value.
     if [ $EXIT_CODE -eq 124 ]; then
-        # F08 fix 2026-06-11: include actual output so DLQ classifier gets real signal
-        _output_tail=$(echo "$OUTPUT" | tail -50 | tr '"' "'" | tr '\n' '|' | head -c 2000)
-        LAST_ERROR_PAYLOAD=",\"last_error\":\"timeout after ${TIMEOUT}s | ${_output_tail}\""
+        _err_summary="timeout after ${TIMEOUT}s"
     else
-        # F08 fix 2026-06-11: was "exit N after M attempts" (BLIND); now includes last
-        # 50 lines of stdout+stderr so autopilot classifier gets real signal. JSON-safe:
-        # double-quotes->single-quotes, newlines->|, capped at 2000 chars.
-        _output_tail=$(echo "$OUTPUT" | tail -50 | tr '"' "'" | tr '\n' '|' | head -c 2000)
-        LAST_ERROR_PAYLOAD=",\"last_error\":\"exit ${EXIT_CODE} after ${ATTEMPT} attempts | ${_output_tail}\""
+        _err_summary="exit ${EXIT_CODE} after ${ATTEMPT} attempts"
     fi
+
+    # Tail to last 50 lines then cap at 2000 chars — keep the most recent signal.
+    _output_tail=$(printf '%s' "$OUTPUT" | tail -50 | tail -c 2000)
+
+    _last_error_json=""
+    if [ -n "$_output_tail" ]; then
+        # Compose "<summary> | <real stderr>" and let python emit a safe JSON
+        # string (quotes included). SUMMARY and TAIL passed via argv to avoid
+        # any shell re-quoting of the captured output.
+        if command -v python3 &>/dev/null; then
+            _last_error_json=$(SUMMARY="$_err_summary" TAIL="$_output_tail" \
+                python3 -c 'import json,os;print(json.dumps((os.environ["SUMMARY"]+" | "+os.environ["TAIL"])[:2000]))' 2>/dev/null || echo "")
+        fi
+        if [ -z "$_last_error_json" ]; then
+            # python3 absent or failed — degrade to the legacy tr-escape so the
+            # field is still (mostly) JSON-safe. Never leave last_error unset.
+            _legacy_tail=$(printf '%s' "$_output_tail" | tr '"' "'" | tr '\n' '|' | tr -d '\r\t\\')
+            _last_error_json="\"${_err_summary} | ${_legacy_tail}\""
+        fi
+    else
+        # $OUTPUT empty (e.g. job killed before any output) — summary fallback.
+        _last_error_json="\"${_err_summary}\""
+    fi
+    LAST_ERROR_PAYLOAD=",\"last_error\":${_last_error_json}"
 fi
 printf '{"job":"%s","ts":%d,"status":"%s","host":"%s","source":"cron-wrapper","duration_ms":%d%s}\n' \
     "$SENTINEL_JOB_KEY" "$END_TS" "$STATUS" "$HOSTNAME_SHORT" "$((DURATION * 1000))" "$LAST_ERROR_PAYLOAD" \

--- a/scripts/dlq_autopilot.py
+++ b/scripts/dlq_autopilot.py
@@ -744,6 +744,59 @@ def run_autopilot() -> None:
         release_lock(fd)
 
 
+def requeue_terminal(job_id: str) -> int:
+    """W70 (2026-06-12): re-arm a TERMINAL DLQ entry for one more diagnostic pass.
+
+    Twin of `clear`, but instead of removing the entry it resets it to a
+    non-terminal, fresh state so process_entry() will actually reason about it
+    again on the next autopilot tick:
+      - status: TERMINAL -> active (key removed; absence == active)
+      - autopilot_attempts: -> 0 (so the max-attempts guard doesn't re-TERMINAL it)
+      - first_abandoned_at: -> removed (clean re-entry timestamp on next abandon)
+
+    This is the manual companion to Fix #1 (cron-wrapper now captures real
+    stderr): requeue lets a job that went TERMINAL while error_summary was BLIND
+    get a real diagnostic pass now that the signal is meaningful.
+
+    Does NOT touch the W61 preserve-terminal logic on the add/process path —
+    this is an explicit operator-driven requeue only. Same atomic tmp+replace
+    (save_dlq) and the same dlq_autopilot.lock as the autopilot itself, so a
+    concurrent autopilot tick can't interleave a half-written queue.
+
+    Returns 0 on success, 1 if no matching TERMINAL entry, 2 if lock busy.
+    """
+    fd = acquire_lock()
+    if fd is None:
+        print("Could not acquire lock (autopilot running?) — try again shortly")
+        return 2
+    try:
+        queue = load_dlq()
+        matched = 0
+        for entry in queue:
+            if entry.get("job") == job_id and entry.get("status") == "TERMINAL":
+                entry.pop("status", None)          # absence == active (non-terminal)
+                entry["autopilot_attempts"] = 0    # fresh attempt budget
+                entry.pop("first_abandoned_at", None)
+                entry["requeued_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+                entry["requeued_by"] = "operator"
+                matched += 1
+        if matched == 0:
+            print(f"No TERMINAL entry found for '{job_id}' in DLQ")
+            return 1
+        save_dlq(queue)
+        print(
+            f"Requeued {matched} TERMINAL entry/entries for '{job_id}' "
+            f"(status cleared, autopilot_attempts=0) — will get a diagnostic pass next tick"
+        )
+        logger.info(
+            f"dlq_requeue_manual: {job_id} re-armed from TERMINAL by operator "
+            f"({matched} entry/entries)"
+        )
+        return 0
+    finally:
+        release_lock(fd)
+
+
 if __name__ == "__main__":
     import sys
     if len(sys.argv) >= 3 and sys.argv[1] == "clear":
@@ -758,5 +811,7 @@ if __name__ == "__main__":
             save_dlq(queue)
             print(f"Cleared TERMINAL entry for '{job_id}' from DLQ ({before - after} removed)")
             logger.info(f"dlq_clear_manual: {job_id} removed from DLQ by operator")
+    elif len(sys.argv) >= 3 and sys.argv[1] == "requeue":
+        sys.exit(requeue_terminal(sys.argv[2]))
     else:
         run_autopilot()

--- a/scripts/nuzantara-sentinel.py
+++ b/scripts/nuzantara-sentinel.py
@@ -786,6 +786,81 @@ def _infer_files(job_id: str, error_text: str) -> list:
 SENTINEL_STATUS_FILE = os.path.expanduser("~/.agent/decisions/sentinel_status.json")
 MAX_RUN_DURATION_S = 240  # D1.7: abort if single run exceeds 4 minutes
 
+# W70 (2026-06-12): blind heal-loop detector. When dlq_terminal > 0 (jobs are
+# parked dead) but healing_actions_24h == 0 (sentinel did NOTHING to heal them)
+# for several consecutive cycles, the heal-loop is effectively dead and nobody
+# is told. Persist a consecutive-cycle counter next to sentinel_status.json and
+# fire ONE Telegram alert once it crosses the threshold.
+BLIND_LOOP_STATE_FILE = os.path.expanduser("~/.agent/decisions/blind_loop_counter.json")
+BLIND_LOOP_ALERT_CYCLES = int(os.getenv("SENTINEL_BLIND_LOOP_CYCLES", "3"))
+
+
+def _check_blind_heal_loop(status_obj: dict) -> None:
+    """W70: alert when the heal-loop is parked-but-idle for N cycles.
+
+    Condition: dlq_terminal > 0 AND healing_actions_24h == 0. Each cycle that
+    matches increments a persisted counter; the first non-matching cycle resets
+    it. On crossing BLIND_LOOP_ALERT_CYCLES we send ONE Telegram alert (gated by
+    the existing per-job escalation cooldown so it can't storm). Never raises —
+    a counter/IO miss must not break the sentinel run.
+    """
+    try:
+        dlq_terminal = status_obj.get("dlq_terminal", 0) or 0
+        healing_24h = status_obj.get("healing_actions_24h", 0) or 0
+        is_blind = dlq_terminal > 0 and healing_24h == 0
+
+        # Load + update the persisted consecutive-cycle counter.
+        try:
+            counter = json.loads(open(BLIND_LOOP_STATE_FILE).read())
+        except (FileNotFoundError, json.JSONDecodeError):
+            counter = {}
+        consecutive = int(counter.get("consecutive_blind_cycles", 0)) if is_blind else 0
+        if is_blind:
+            consecutive += 1
+        new_state = {
+            "consecutive_blind_cycles": consecutive,
+            "last_ts": time.time(),
+            "dlq_terminal": dlq_terminal,
+            "healing_actions_24h": healing_24h,
+            "_writer": "sentinel",
+        }
+        try:
+            os.makedirs(os.path.dirname(BLIND_LOOP_STATE_FILE), exist_ok=True)
+            _tmp = BLIND_LOOP_STATE_FILE + ".tmp"
+            with open(_tmp, "w") as f:
+                json.dump(new_state, f, indent=2)
+            os.replace(_tmp, BLIND_LOOP_STATE_FILE)
+        except OSError as _e:
+            logger.warning(f"W70 blind-loop: failed to persist counter ({_e})")
+
+        if is_blind and consecutive >= BLIND_LOOP_ALERT_CYCLES:
+            cooldown_key = "blind_heal_loop"
+            if check_escalation_cooldown(cooldown_key):
+                logger.info(
+                    f"W70 blind-loop: {consecutive} consecutive blind cycles "
+                    f"(dlq_terminal={dlq_terminal}, heal=0) — alert on cooldown, suppressed"
+                )
+                return
+            msg = (
+                f"BLIND HEAL-LOOP: {dlq_terminal} TERMINAL job(s) parked in DLQ "
+                f"but ZERO healing actions for {consecutive} consecutive sentinel "
+                f"cycles. The heal-loop is idle — these jobs will never recover "
+                f"on their own. Run: dlq requeue <job_id> after fixing root cause."
+            )
+            if send_alert(msg, level="CRITICAL"):
+                mark_escalation_sent(cooldown_key)
+            logger.warning(
+                f"W70 blind-loop alert fired: dlq_terminal={dlq_terminal}, "
+                f"consecutive={consecutive}"
+            )
+        elif is_blind:
+            logger.info(
+                f"W70 blind-loop: {consecutive}/{BLIND_LOOP_ALERT_CYCLES} blind "
+                f"cycle(s) (dlq_terminal={dlq_terminal}, heal=0)"
+            )
+    except Exception as _e:  # defensive: never break the sentinel run
+        logger.warning(f"W70 blind-loop check failed: {_e}")
+
 
 def run_sentinel() -> None:
     # D0.6: HEALING_DISABLED file flag — safer than env var (works in LaunchAgent)
@@ -940,6 +1015,9 @@ def run_sentinel() -> None:
     os.makedirs(os.path.dirname(SENTINEL_STATUS_FILE), exist_ok=True)
     with open(SENTINEL_STATUS_FILE, "w") as f:
         json.dump(status_obj, f, indent=2)
+
+    # W70: detect a parked-but-idle heal-loop and alert if it persists.
+    _check_blind_heal_loop(status_obj)
 
     logger.info(f"=== Sentinel done: {log_entry['jobs_checked']} checked, "
                 f"{log_entry['healthy']} healthy, {log_entry['escalated']} escalated, "


### PR DESCRIPTION
## What & why

The **W70 blind heal-loop**: when a cron job fails, `cron-wrapper.sh` parks it for the DLQ classifier, but (1) the classifier was reasoning over a summary string instead of the real stderr, (2) when the heal-loop went fully idle nobody was alerted, and (3) there was no manual way to re-arm a job that went TERMINAL while the signal was blind. Three repo-side fixes — **no runtime mutation in this PR** (manual ops listed below).

### Fix #1 — `scripts/cron-wrapper.sh`: capture the REAL stderr in `last_error`
The prior F08 path (2026-06-11) already tail'd `$OUTPUT`, but escaped it with only `tr '"' "'" | tr '\n' '|'`. A backslash (Windows path / Python traceback repr / regex), tab, carriage-return, or any control char in the job output produced **invalid JSON**, which broke the sentinel `.last.json` parse and silently zeroed the classifier signal — the blind loop itself.

Now the last ~2000 chars of `$OUTPUT` are JSON-escaped via `python3 json.dumps` (correctly handles `"`, `\`, `\n`, `\t`, `\r` and all control/unicode chars). The `exit N`/`timeout` summary is kept as the prefix **and** as the fallback when `$OUTPUT` is empty or `python3` is unavailable (degrades to the legacy `tr` escape, never leaves `last_error` unset).
- `bash -n scripts/cron-wrapper.sh` → 0
- Verified valid JSON on a hostile payload (backslashes / quotes / newlines / tabs / CR / `\x01` control / unicode).

### Fix #2 — `scripts/nuzantara-sentinel.py`: alert when the heal-loop is parked-but-idle
New `_check_blind_heal_loop()` fires **one** Telegram alert (reusing the existing `sentinel_lib.alerter.send_alert` + per-job escalation cooldown — no new sender invented) when `dlq_terminal > 0 AND healing_actions_24h == 0` persists for **≥N consecutive cycles** (`N = SENTINEL_BLIND_LOOP_CYCLES`, default **3**). The consecutive-cycle counter persists in `~/.agent/decisions/blind_loop_counter.json` (atomic tmp+replace) beside `sentinel_status.json`; a healthy cycle resets it to 0. Defensive: never raises, never breaks the sentinel run.

> Note on file mapping: the task map named `sentinel-aggregate.py`, but that file is the organ-heartbeat aggregator and has no `dlq_terminal`/`healing_actions_24h`. The real heal-loop aggregator that writes `sentinel_status.json` is `nuzantara-sentinel.py` (confirmed via `grep -rl 'healing_actions_24h'`). Fix #2 landed there.

### Fix #3 — `scripts/dlq_autopilot.py`: new `dlq requeue <job_id>` command
Twin of the existing `clear`. Instead of removing a TERMINAL entry it **re-arms** it: drops `status`, resets `autopilot_attempts=0`, drops `first_abandoned_at`, stamps `requeued_at`/`requeued_by`. So old jobs that went TERMINAL while their `error_summary` was blind get a real diagnostic pass now that Fix #1 makes the signal meaningful. Uses the same `dlq_autopilot.lock` + atomic `save_dlq` (tmp+replace) as the autopilot. Does **NOT** touch the W61 preserve-terminal logic on the add/process path — explicit operator-driven requeue only. Exit codes: 0 ok / 1 no-match / 2 lock-busy.

## Verification
- `bash -n scripts/cron-wrapper.sh` → 0
- `python3 -m py_compile scripts/dlq_autopilot.py scripts/nuzantara-sentinel.py` → 0
- `ruff check` clean — the single `E402` in `dlq_autopilot.py` is **pre-existing on origin/main** (line 47 lazy import, untouched), not introduced here. `nuzantara-sentinel.py` ruff: all checks passed.
- `scripts/tests` sentinel + dlq suite: **92 passed**. The one `test_format_schedule` failure is **pre-existing on main** (missing `_format_schedule` attr in `generate_automations_reference.py`, a file this PR does not touch).
- Isolated functional tests (temp fixtures, no real data): requeue resets correctly + leaves non-matching jobs untouched + correct exit codes; blind-loop helper increments per cycle, fires exactly one alert at the threshold, resets on a healthy cycle.

## Manual ops post-merge (supervised, NOT in this PR)
These are runtime actions on cron/data, deliberately excluded from the PR. To be run by a human after merge:

1. **Backup + requeue the 30 TERMINAL jobs** (so they get a real diagnostic pass with the new stderr):
   ```
   cp ~/.agent/decisions/dlq.json ~/.agent/decisions/dlq.json.bak-$(date +%Y%m%d-%H%M%S)
   # then for each TERMINAL job_id:
   python3 scripts/dlq_autopilot.py requeue <job_id>
   ```
2. **Repoint the ~5 `~/scripts/*.sh` wrappers** that still point at `Projects/nuzantara` (Air-era path) to `Desktop/nuzantara`:
   `qdrant_snapshot`, `nb_agents_daily_dr`, `nextdns_weekly_digest`, `login_healthcheck`, `fly_cost_alert`. (These currently invoke a stale checkout, so cron-wrapper's new escaping wouldn't apply until repointed.)
3. **Evaluate the DLQ alert mute** in the plist: today `DLQ_TELEGRAM_MUTE=1` also suppresses escalation alerts. Consider flipping `DLQ_TELEGRAM_MUTE=1→0` so the Fix #2 heal=0 alert (and TERMINAL escalations) actually reach Telegram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)