### PR TITLE
fix(routing): revive dead Haiku Layer-2 — ClaudeOAuthClient never existed

### DIFF
--- a/apps/backend-rag/backend/services/routing/surface_router.py
+++ b/apps/backend-rag/backend/services/routing/surface_router.py
@@ -401,17 +401,19 @@ class SurfaceRouter:
     async def _classify_with_haiku(self, query: str) -> SurfaceDecision | None:
         """Classify with Claude Haiku. Returns None on any failure."""
         try:
-            from backend.llm.claude_oauth_client import ClaudeOAuthClient
+            from backend.llm.claude_oauth_client import complete_async
 
-            client = ClaudeOAuthClient(
-                model="claude-haiku-4-5-20251001", timeout_s=int(HAIKU_TIMEOUT_S)
-            )
             prompt = f"{_HAIKU_SYSTEM}\n\nUser query: {query}"
-            text = await asyncio.wait_for(
-                asyncio.get_event_loop().run_in_executor(None, lambda: client.complete(prompt)),
+            response = await asyncio.wait_for(
+                complete_async(
+                    prompt,
+                    model="claude-haiku-4-5-20251001",
+                    timeout_s=int(HAIKU_TIMEOUT_S),
+                    endpoint="surface_router.haiku",
+                ),
                 timeout=HAIKU_TIMEOUT_S,
             )
-            data = json.loads(text.strip())
+            data = json.loads(response.text.strip())
             domain: str = data.get("domain", "visa")
             haiku_confidence: float = float(data.get("confidence", 0.5))
 


### PR DESCRIPTION
## What

`SurfaceRouter._classify_with_haiku` (Layer-2 of the surface router) imported and instantiated `ClaudeOAuthClient(...)` from `backend.llm.claude_oauth_client` — **but that class never existed**. The module only exposes the functions `complete` / `complete_async` plus the `ClaudeOAuthResponse` / `ClaudeOAuthError` / `ClaudeOAuthNotAvailable` types.

Result: every invocation raised `ImportError`, swallowed by the generic `except Exception` → returned `None` → the router **silently degraded to Layer-1**. The Haiku path has been dead since the day it was written.

## Fix

Call the native async `complete_async()` directly:

```python
from backend.llm.claude_oauth_client import complete_async

prompt = f"{_HAIKU_SYSTEM}\n\nUser query: {query}"
response = await asyncio.wait_for(
    complete_async(
        prompt,
        model="claude-haiku-4-5-20251001",
        timeout_s=int(HAIKU_TIMEOUT_S),
        endpoint="surface_router.haiku",
    ),
    timeout=HAIKU_TIMEOUT_S,
)
data = json.loads(response.text.strip())
```

This also removes the redundant `run_in_executor` + `lambda` wrapper (`complete_async` is already a coroutine) and reads `response.text` instead of a bare string. Everything else in the method is untouched (`domain_surface_map`, `_make_decision`, the `TimeoutError`/`asyncio.TimeoutError` re-raise, the `except Exception → None`).

## ⚠️ This RE-ACTIVATES a dormant path in production (Fly)

The Layer-2 Haiku call has been a no-op since it was written; this PR makes it actually fire.

- **Worst case is unchanged**: timeout / CLI-absent → `except` → `None` → Layer-1. There is a **double timeout** by design — `complete_async`'s internal per-attempt cap **plus** the outer `asyncio.wait_for(timeout=HAIKU_TIMEOUT_S)`.
- **Good case now does real Haiku routing** instead of silently falling through to keyword Layer-1.

### Dependency / caveat

This PR depends on **#1340** (the `claude_oauth_client` hardening that makes this previously-untrusted path safe to invoke). #1340 also documents the **hang-on-Fly-non-TTY** caveat for the CLI subprocess — mitigated here by the wrapping `asyncio.wait_for` timeout (and the client's own per-attempt cap).

## Tests

- `python -m py_compile` ✅
- `ruff check` ✅ (All checks passed)
- import chain ✅ (`from backend.services.routing.surface_router import SurfaceRouter`)
- `pytest backend/tests/services/routing/test_surface_router.py` + search-service + kg-fast-path → **55 passed**

No test needed updating: the existing tests mock at the `_classify_with_haiku` **method boundary** (`@patch(...SurfaceRouter._classify_with_haiku...)`), and nothing anywhere referenced the dead `ClaudeOAuthClient` class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)