### PR TITLE
fix(wr2): saliency-placement is SOFT when contrast passes (unblock legible slides)

### DIFF
--- a/apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py
@@ -381,6 +381,68 @@ def test_legibility_levers_constant():
     assert _LEGIBILITY_LEVERS == {"scrim_opacity", "text_stroke", "shrink_font", "grow_font"}
 
 
+# ── saliency-placement is SOFT when contrast passes (2026-06-12 SCAR: a busy
+#    background band blocked a legible slide forever — busyness measured on the
+#    raw hero ignores the scrim, and the reposition remedy is disabled) ─────────
+
+
+def _mk_png(tmp):
+    p = Path(tmp) / "iter.png"
+    p.write_bytes(b"PNG")
+    return p
+
+
+def test_legibility_busy_band_is_soft_when_contrast_passes(monkeypatch, tmp_path):
+    """Hero text on a busier-than-calmest band but with PASSING contrast must NOT
+    fail the gate — the text is legible, scrim mitigates the busy bg, and the
+    only real remedy (reposition) is disabled. The note is still surfaced."""
+    from wr2_html_renderer import designer_loop as dl
+
+    monkeypatch.setattr(dl, "text_region_contrast", lambda *a, **k: 12.6)  # ≫ AAA 7.0
+    monkeypatch.setattr(dl, "calmest_band", lambda *a, **k: (0, [0.00, 0.02, 0.05]))
+    hero = tmp_path / "hero.jpg"
+    hero.write_bytes(b"JPG")
+
+    c = dl.critic_legibility(_mk_png(tmp_path), {"headline": "H"}, is_hero=True, hero_path=hero)
+
+    assert c.passed is True
+    assert any("busier than calmest" in i for i in c.issues)  # note still visible
+    assert not c.levers  # nothing to pull — contrast is fine, reposition disabled
+
+
+def test_legibility_busy_band_is_hard_when_contrast_fails(monkeypatch, tmp_path):
+    """If contrast ALSO fails, the busy-band note is part of the hard problem and
+    the in-place remedy ladder (scrim+stroke) is proposed; gate fails."""
+    from wr2_html_renderer import designer_loop as dl
+
+    monkeypatch.setattr(dl, "text_region_contrast", lambda *a, **k: 3.0)  # < AAA 7.0
+    monkeypatch.setattr(dl, "calmest_band", lambda *a, **k: (0, [0.00, 0.02, 0.05]))
+    hero = tmp_path / "hero.jpg"
+    hero.write_bytes(b"JPG")
+
+    c = dl.critic_legibility(_mk_png(tmp_path), {"headline": "H"}, is_hero=True, hero_path=hero)
+
+    assert c.passed is False
+    assert any("contrast" in i for i in c.issues)
+    assert any(lev["lever"] == "scrim_opacity" for lev in c.levers)
+
+
+def test_legibility_calm_band_passes_clean(monkeypatch, tmp_path):
+    """Calm bottom band + good contrast → pass, no issues, no levers."""
+    from wr2_html_renderer import designer_loop as dl
+
+    monkeypatch.setattr(dl, "text_region_contrast", lambda *a, **k: 13.0)
+    monkeypatch.setattr(dl, "calmest_band", lambda *a, **k: (2, [0.05, 0.04, 0.01]))
+    hero = tmp_path / "hero.jpg"
+    hero.write_bytes(b"JPG")
+
+    c = dl.critic_legibility(_mk_png(tmp_path), {"headline": "H"}, is_hero=True, hero_path=hero)
+
+    assert c.passed is True
+    assert c.issues == []
+    assert c.levers == []
+
+
 @pytest.mark.asyncio
 async def test_designer_loop_legibility_lever_not_killed_by_brand_reject(monkeypatch):
     """FIX#3: when the brand verifier rejects for a NON-legibility reason but the

--- a/scripts/wr2_html_renderer/designer_loop.py
+++ b/scripts/wr2_html_renderer/designer_loop.py
@@ -363,38 +363,61 @@ def critic_legibility(
     On flat-background (non-hero) slides, contrast is usually fine (white on
     antracite = 13.4); this mostly guards hero slides.
     """
-    issues: list[str] = []
+    # `passed` is decided by HARD issues only (measured contrast — the direct
+    # legibility signal). Saliency-placement is a SOFT note: see why below.
+    hard_issues: list[str] = []
+    soft_issues: list[str] = []
     levers: list[dict[str, Any]] = []
 
     contrast = text_region_contrast(png_path, text_box, fg_rgb)
     if contrast < CONTRAST_FLOOR:
-        issues.append(f"text contrast {contrast:.1f} < AAA {CONTRAST_FLOOR:.0f}")
+        hard_issues.append(f"text contrast {contrast:.1f} < AAA {CONTRAST_FLOOR:.0f}")
         # remedy ladder
         levers.append({"lever": "scrim_opacity", "delta": +0.15, "reason": f"contrast {contrast:.1f}"})
         levers.append({"lever": "text_stroke", "weight": "increase", "reason": "fallback legibility"})
 
     # saliency placement — only meaningful for hero slides with a photo.
     # We DETECT "text sits on the busiest band" but do NOT try to fix it by
-    # repositioning the text (that broke the cover in E2E 2026-06-07). Instead
-    # the remedy is stronger scrim/stroke (keep text where the template put it
-    # but make it survive the busy region); if that's already maxed, it's a
-    # composition problem → rerender signal, not a CSS nudge.
+    # repositioning the text (that broke the cover in E2E 2026-06-07).
+    #
+    # Crucially, busyness is measured on the RAW hero image, BEFORE the scrim
+    # CSS overlay is composited — so stronger scrim does NOT lower the measured
+    # busyness, and the only real remedy (text_anchor reposition) is disabled.
+    # If this were a HARD gate it would loop to render_failed with no applicable
+    # fix even when the text is perfectly legible (2026-06-12 SCAR: slide 3 of
+    # draft 3e2c2923 — contrast ~12.6 ≫ AAA floor 7.0, yet blocked forever).
+    # So: when contrast PASSES, the text IS legible and a busy background band
+    # is a SOFT composition note (logged, visible, never blocking). It only
+    # reinforces the lever ladder when contrast ALSO failed (then it's HARD).
     if is_hero and hero_path and hero_path.is_file():
         best_band, busyness = calmest_band(hero_path, n_bands=3)
         bottom_band = len(busyness) - 1
         if busyness[bottom_band] > min(busyness) * 1.5 and best_band != bottom_band:
-            issues.append(
+            note = (
                 f"text band (bottom, busyness {busyness[bottom_band]:.2f}) is busier "
                 f"than calmest band {best_band} ({busyness[best_band]:.2f})"
             )
-            # remedy IN PLACE: a heavier scrim + stroke so text survives the busy
-            # bottom (no repositioning). Only add if not already proposed above.
-            if not any(lev.get("lever") == "scrim_opacity" for lev in levers):
-                levers.append({"lever": "scrim_opacity", "delta": +0.2, "reason": "text over busy band — darken in place"})
-            if not any(lev.get("lever") == "text_stroke" for lev in levers):
-                levers.append({"lever": "text_stroke", "reason": "text over busy band — outline in place"})
+            if hard_issues:
+                # contrast already failed → this is part of the hard problem;
+                # reinforce the in-place remedy ladder (no repositioning).
+                hard_issues.append(note)
+                if not any(lev.get("lever") == "scrim_opacity" for lev in levers):
+                    levers.append({"lever": "scrim_opacity", "delta": +0.2, "reason": "text over busy band — darken in place"})
+                if not any(lev.get("lever") == "text_stroke" for lev in levers):
+                    levers.append({"lever": "text_stroke", "reason": "text over busy band — outline in place"})
+            else:
+                # contrast PASSES → text is legible → busy background is a soft
+                # composition note (scrim mitigates it at render time; the
+                # measure can't see the scrim, and reposition is disabled).
+                soft_issues.append(note + " (composition note — text legible, scrim mitigates)")
 
-    return Critique(tier="legibility", passed=not issues, issues=issues, levers=levers, score=min(contrast / 21.0, 1.0))
+    return Critique(
+        tier="legibility",
+        passed=not hard_issues,
+        issues=hard_issues + soft_issues,
+        levers=levers,
+        score=min(contrast / 21.0, 1.0),
+    )
 
 
 def critic_ocr(


### PR DESCRIPTION
## SCAR (2026-06-12, draft 3e2c2923 slide 3 — the last blocker to first M1-green)

`critic_legibility` HARD-failed a slide whose text was **perfectly legible** (contrast ~12.6, far above the AAA floor of 7.0), solely because the bottom text band sat on a busier-than-calmest region of the hero photo. The gate could **never** be satisfied:

- busyness is measured on the **raw hero image, before** the scrim CSS overlay is composited → the `scrim_opacity` lever the loop kept pulling never lowered the measured busyness;
- the only real remedy — repositioning text to the calmest band (`text_anchor`) — was **removed 2026-06-07** (broke the cover layout).

So a busy background band was an **unsatisfiable HARD gate**, looping straight to `render_failed` even on a legible slide. (This is why E2E after the 429 fix advanced to slide 3 and stuck there with identical critiques across all 3 retries.)

## Fix

Split the two signals in `critic_legibility`:
- **contrast** (the direct, measured legibility signal) → stays **HARD**.
- **saliency-placement** → when contrast PASSES, a busy background band is a **SOFT composition note**: surfaced in `issues` (logged, visible) but no longer flips `passed`. It only reinforces the in-place scrim/stroke ladder when contrast ALSO failed.

Not loosening legibility: the measured contrast gate is untouched; we stop blocking on a background **proxy** whose only fix is disabled and which the mitigating scrim is invisible to.

## Tests

TDD, **RED verified by stashing the fix** (`assert False is True`): 3 new tests — soft-when-contrast-passes, hard-when-contrast-fails, calm-band-clean. Suite `test_wr2_html_render_apply.py` **95/95**.

Last known blocker to first M1-green (P-1 follow-up, Antonello GO 2026-06-11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)