### PR TITLE
feat(wr2): IG-feedback queue writer — close the metrics loop (STRATO 1)

### DIFF
--- a/apps/backend-rag/backend/tests/unit/scripts/test_wr2_queue_writer.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_wr2_queue_writer.py
@@ -1,0 +1,244 @@
+"""Unit tests for scripts/wr2_queue_writer.py — the WR2 IG-feedback queue writer.
+
+Loaded via importlib (the module lives in repo-root scripts/, not an importable
+package). Covers the pure matching/normalization logic and the atomic
+mark_published orchestration, including the scraper-compatibility contract and
+every refuse-to-write branch (the anti-fragility guarantees for the WhatsApp
+channel: never write on an ambiguous/absent/conflicting match).
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# ── Load the module from repo-root scripts/ ────────────────────────────────
+_REPO_ROOT = Path(__file__).resolve().parents[6]
+_MODULE_PATH = _REPO_ROOT / "scripts" / "wr2_queue_writer.py"
+_spec = importlib.util.spec_from_file_location("wr2_queue_writer", _MODULE_PATH)
+qw = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = qw
+_spec.loader.exec_module(qw)
+
+
+# ── Fixtures: the two historical queue schemas ─────────────────────────────
+
+
+def _old_schema_item(item_id="kep71-spt-extension-test6-FIRSTPROD"):
+    """43-item 'first-prod' schema: item_id/topic, em as truthy dict, no ig_url key."""
+    return {
+        "item_id": item_id,
+        "topic": "KEP-71/PJ/2026 SPT Tahunan Badan extension",
+        "state": "applied_ready_for_damar",
+        "engagement_metrics": {"likes": None, "saves": None, "reach": None, "comments": None},
+        "domain": "tax",
+    }
+
+
+def _new_schema_item(item_id="some-draft-slug"):
+    """Newer drafts schema: id/topic_slug, ig_url key present (null), em None."""
+    return {
+        "id": item_id,
+        "topic_slug": item_id,
+        "state": "drafted",
+        "instagram_post_url": None,
+        "instagram_published_at": None,
+        "engagement_metrics": None,
+        "state_history": [{"state": "drafted", "at": "2026-05-01T00:00:00+00:00"}],
+    }
+
+
+@pytest.fixture
+def queue_file(tmp_path):
+    """Write a small heterogeneous queue to a temp file, return its Path."""
+    items = [
+        _old_schema_item("alpha-FIRSTPROD"),
+        _old_schema_item("beta-FIRSTPROD"),
+        _new_schema_item("gamma-draft"),
+    ]
+    p = tmp_path / "human-review-queue.json"
+    p.write_text(json.dumps(items, indent=2))
+    return p
+
+
+VALID_URL = "https://www.instagram.com/p/Cabc123_-/"
+
+
+# ── compute_ref_code / normalize ───────────────────────────────────────────
+
+
+def test_compute_ref_code_deterministic_and_format():
+    a = qw.compute_ref_code("alpha-FIRSTPROD")
+    b = qw.compute_ref_code("alpha-FIRSTPROD")
+    assert a == b
+    assert a.startswith("WR2-")
+    assert len(a) == len("WR2-") + 6
+    assert a[4:].isalnum() and a[4:].isupper()
+    # different ids -> different codes
+    assert qw.compute_ref_code("beta-FIRSTPROD") != a
+
+
+def test_normalize_ref_code_tolerates_missing_prefix_and_case():
+    code = qw.compute_ref_code("alpha-FIRSTPROD")  # e.g. WR2-AB12CD
+    hex_only = code[len("WR2-"):]
+    assert qw.normalize_ref_code(hex_only.lower()) == code
+    assert qw.normalize_ref_code(f"  {code.lower()} ") == code
+
+
+# ── item_id_of / topic_of across schemas ───────────────────────────────────
+
+
+def test_item_id_of_handles_both_schemas():
+    assert qw.item_id_of(_old_schema_item("x")) == "x"
+    assert qw.item_id_of(_new_schema_item("y")) == "y"
+    assert qw.item_id_of({}) is None
+
+
+def test_topic_of_handles_both_schemas():
+    assert qw.topic_of(_old_schema_item()) .startswith("KEP-71")
+    assert qw.topic_of(_new_schema_item("gamma-draft")) == "gamma-draft"
+
+
+# ── validate_ig_url ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("url", [
+    "https://www.instagram.com/p/Cabc123_-/",
+    "https://instagram.com/reel/Xyz789/",
+    "http://instagram.com/tv/Abc/",
+    "https://www.instagram.com/p/Cabc123/?igshid=foo",
+])
+def test_validate_ig_url_accepts_real_permalinks(url):
+    assert qw.validate_ig_url(url) is True
+
+
+@pytest.mark.parametrize("url", [
+    "https://instagram.com/balizero0",          # profile, not a post
+    "https://example.com/p/abc/",               # wrong host
+    "not a url",
+    "",
+    "https://www.instagram.com/",
+])
+def test_validate_ig_url_rejects_non_permalinks(url):
+    assert qw.validate_ig_url(url) is False
+
+
+# ── find_by_ref_code ───────────────────────────────────────────────────────
+
+
+def test_find_by_ref_code_exact_match():
+    items = [_old_schema_item("alpha-FIRSTPROD"), _old_schema_item("beta-FIRSTPROD")]
+    ref = qw.compute_ref_code("beta-FIRSTPROD")
+    idx, item = qw.find_by_ref_code(items, ref)
+    assert idx == 1
+    assert qw.item_id_of(item) == "beta-FIRSTPROD"
+
+
+def test_find_by_ref_code_miss_returns_none():
+    items = [_old_schema_item("alpha-FIRSTPROD")]
+    idx, item = qw.find_by_ref_code(items, "WR2-000000")
+    assert idx is None and item is None
+
+
+# ── apply_publish — the scraper-compatibility contract ─────────────────────
+
+
+def test_apply_publish_normalizes_to_scraper_shape():
+    item = _old_schema_item()
+    out = qw.apply_publish(item, VALID_URL, "2026-06-12T10:00:00+00:00")
+    # scraper requires: state published, em FALSY, ig_url + published_at set
+    assert out["state"] == "published"
+    assert out["instagram_post_url"] == VALID_URL
+    assert out["instagram_published_at"] == "2026-06-12T10:00:00+00:00"
+    assert not out["engagement_metrics"]  # the truthy-dict bug is cleared to None
+    assert out["damar_action"] == "published"
+    # input not mutated (pure)
+    assert item["state"] == "applied_ready_for_damar"
+    assert item["engagement_metrics"] == {"likes": None, "saves": None, "reach": None, "comments": None}
+
+
+def test_apply_publish_appends_state_history_when_present():
+    item = _new_schema_item()
+    out = qw.apply_publish(item, VALID_URL, "2026-06-12T10:00:00+00:00")
+    assert out["state_history"][-1]["state"] == "published"
+    assert len(out["state_history"]) == len(item["state_history"]) + 1
+
+
+# ── mark_published — end to end + every refuse-to-write branch ─────────────
+
+
+def test_mark_published_happy_path_writes_atomically(queue_file):
+    ref = qw.compute_ref_code("alpha-FIRSTPROD")
+    res = qw.mark_published(queue_file, ref, VALID_URL, published_at="2026-06-12T10:00:00+00:00")
+    assert res.status == "published" and res.ok is True
+    assert res.item_id == "alpha-FIRSTPROD"
+    # persisted + scraper-compatible
+    items = json.loads(queue_file.read_text())
+    alpha = next(i for i in items if qw.item_id_of(i) == "alpha-FIRSTPROD")
+    assert alpha["state"] == "published"
+    assert alpha["instagram_post_url"] == VALID_URL
+    assert not alpha["engagement_metrics"]
+    # OTHER items untouched
+    beta = next(i for i in items if qw.item_id_of(i) == "beta-FIRSTPROD")
+    assert beta["state"] == "applied_ready_for_damar"
+
+
+def test_mark_published_idempotent_same_url(queue_file):
+    ref = qw.compute_ref_code("alpha-FIRSTPROD")
+    qw.mark_published(queue_file, ref, VALID_URL, published_at="2026-06-12T10:00:00+00:00")
+    res2 = qw.mark_published(queue_file, ref, VALID_URL)
+    assert res2.status == "already_published" and res2.ok is True
+
+
+def test_mark_published_conflict_different_url_refuses(queue_file):
+    ref = qw.compute_ref_code("alpha-FIRSTPROD")
+    qw.mark_published(queue_file, ref, VALID_URL, published_at="2026-06-12T10:00:00+00:00")
+    other = "https://www.instagram.com/p/DIFFERENT99/"
+    res = qw.mark_published(queue_file, ref, other)
+    assert res.status == "conflict" and res.ok is False
+    # original url preserved, not overwritten
+    items = json.loads(queue_file.read_text())
+    alpha = next(i for i in items if qw.item_id_of(i) == "alpha-FIRSTPROD")
+    assert alpha["instagram_post_url"] == VALID_URL
+
+
+def test_mark_published_not_found_no_write(queue_file):
+    before = queue_file.read_text()
+    res = qw.mark_published(queue_file, "WR2-000000", VALID_URL)
+    assert res.status == "not_found" and res.ok is False
+    assert queue_file.read_text() == before  # untouched
+
+
+def test_mark_published_invalid_url_no_write(queue_file):
+    before = queue_file.read_text()
+    ref = qw.compute_ref_code("alpha-FIRSTPROD")
+    res = qw.mark_published(queue_file, ref, "https://example.com/not-ig")
+    assert res.status == "invalid_url" and res.ok is False
+    assert queue_file.read_text() == before
+
+
+def test_mark_published_wrong_state_no_write(queue_file):
+    before = queue_file.read_text()
+    ref = qw.compute_ref_code("gamma-draft")  # state=drafted, not publishable
+    res = qw.mark_published(queue_file, ref, VALID_URL)
+    assert res.status == "wrong_state" and res.ok is False
+    assert queue_file.read_text() == before
+
+
+# ── write_queue_atomic preserves structure ────────────────────────────────
+
+
+def test_write_queue_atomic_roundtrip(tmp_path):
+    items = [_old_schema_item("a"), _new_schema_item("b")]
+    p = tmp_path / "q.json"
+    qw.write_queue_atomic(p, items)
+    assert json.loads(p.read_text()) == items
+
+
+def test_load_queue_tolerates_items_wrapper(tmp_path):
+    p = tmp_path / "q.json"
+    p.write_text(json.dumps({"items": [_old_schema_item("a")]}))
+    loaded = qw.load_queue(p)
+    assert isinstance(loaded, list) and qw.item_id_of(loaded[0]) == "a"

--- a/scripts/wr2_queue_writer.py
+++ b/scripts/wr2_queue_writer.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""WR2 publish-feedback writer — close the IG-metrics feedback loop.
+
+The WR2 carousel pipeline leaves caroselli in `human-review-queue.json` with
+state `applied_ready_for_damar`. Damar then publishes them to Instagram BY HAND
+(Law 5 — Zero/Damar publish manually, no autonomous IG API). Until now there was
+no way to feed the published IG URL back into the queue, so the IG-metrics
+scraper (`~/.claude/skills/bali-zero-brand/_ig-metrics-scraper.py`) had nothing
+to scrape and the weekly analyst stayed blocked on "insufficient data".
+
+This module is the missing writer. It is the COMMON core for every feedback
+channel (manual CLI now, WhatsApp ingest in STRATO 2): given a short, stable
+`ref_code` and an IG post URL, it finds the matching queue item and normalizes
+it to the exact shape the scraper consumes:
+
+    state                  -> "published"
+    instagram_post_url     -> <url>
+    instagram_published_at -> <iso utc>
+    engagement_metrics     -> None        (cleared; a dict of Nones is TRUTHY and
+                                           the scraper SKIPS truthy em — verified
+                                           against _ig-metrics-scraper.py:46)
+    damar_action           -> "published"
+    damar_action_at        -> <iso utc>
+
+Ref-code design (anti-fragility for the WhatsApp channel): the code is a pure
+deterministic function of the item id (`WR2-` + 6 hex of sha1). No extra state to
+keep in sync, and Damar can be told the exact code to quote back. Matching is
+EXACT on the ref-code — never fuzzy, never "the only pending one". The writer
+NEVER writes on an ambiguous/absent match: it returns a structured outcome the
+caller routes to a human-disambiguation queue instead.
+
+The queue is heterogeneous (two historical schemas coexist): the 43 ready items
+use `item_id`/`topic`, the newer drafts use `id`/`topic_slug`. `item_id_of`
+handles both.
+
+CLI:
+    python scripts/wr2_queue_writer.py list-ready
+    python scripts/wr2_queue_writer.py ref-code <item_id>
+    python scripts/wr2_queue_writer.py mark-published <ref_code> <ig_url> [--at ISO]
+
+Side-effect free functions (pure, unit-tested) are separated from the two I/O
+functions (`load_queue`, `write_queue_atomic`) so the matching/normalization
+logic is testable without touching disk.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+# ── Constants ──────────────────────────────────────────────────────────────
+
+DEFAULT_QUEUE_PATH = (
+    Path.home() / "Desktop/nuzantara/apps/war-room/output/queue/human-review-queue.json"
+)
+
+# States from which an item may legitimately transition to `published`.
+PUBLISHABLE_STATES = ("applied_ready_for_damar", "approved", "reviewed")
+PUBLISHED_STATES = ("published", "published_with_edits")
+
+REF_CODE_PREFIX = "WR2-"
+REF_CODE_HEX_LEN = 6
+
+# IG post / reel URL. Accepts optional www, trailing slash, query string.
+_IG_URL_RE = re.compile(
+    r"^https?://(?:www\.)?instagram\.com/(?:p|reel|tv)/[A-Za-z0-9_-]+/?(?:\?\S*)?$"
+)
+
+
+# ── Pure functions (no I/O) ────────────────────────────────────────────────
+
+
+def item_id_of(item: dict[str, Any]) -> Optional[str]:
+    """Return the canonical id of a queue item, across both historical schemas.
+
+    Old (ready_for_damar) schema uses `item_id`; newer drafts use `id`.
+    """
+    return item.get("item_id") or item.get("id")
+
+
+def topic_of(item: dict[str, Any]) -> str:
+    """Human label for an item, across both schemas (best-effort)."""
+    return item.get("topic") or item.get("topic_slug") or "(no topic)"
+
+
+def compute_ref_code(item_id: str) -> str:
+    """Deterministic short ref-code for an item id.
+
+    `WR2-` + first 6 uppercase hex of sha1(item_id). Stable across runs, no
+    stored state. Collisions are detectable at list-ready time.
+    """
+    digest = hashlib.sha1(item_id.encode("utf-8")).hexdigest()
+    return f"{REF_CODE_PREFIX}{digest[:REF_CODE_HEX_LEN].upper()}"
+
+
+def normalize_ref_code(raw: str) -> str:
+    """Canonicalize a user-supplied ref-code for exact comparison.
+
+    Uppercases, strips whitespace, and tolerates a missing `WR2-` prefix
+    (Damar might type just the 6 hex). Does NOT validate length.
+    """
+    s = raw.strip().upper()
+    if not s.startswith(REF_CODE_PREFIX) and re.fullmatch(r"[0-9A-F]{1,}", s):
+        s = REF_CODE_PREFIX + s
+    return s
+
+
+def validate_ig_url(url: str) -> bool:
+    """True iff `url` looks like a real instagram post/reel/tv permalink."""
+    return bool(_IG_URL_RE.match(url.strip()))
+
+
+def find_by_ref_code(
+    items: list[dict[str, Any]], ref_code: str
+) -> tuple[Optional[int], Optional[dict[str, Any]]]:
+    """Return (index, item) of the unique item whose ref-code matches, else (None, None).
+
+    Exact, case-insensitive match on the ref-code derived from the item id.
+    """
+    target = normalize_ref_code(ref_code)
+    for idx, item in enumerate(items):
+        iid = item_id_of(item)
+        if iid and compute_ref_code(iid) == target:
+            return idx, item
+    return None, None
+
+
+def apply_publish(
+    item: dict[str, Any], ig_url: str, published_at_iso: str
+) -> dict[str, Any]:
+    """Return a COPY of `item` normalized to the scraper-consumable published shape.
+
+    Pure: does not mutate the input. Clears `engagement_metrics` to None so the
+    scraper (which skips truthy em) will pick the item up after the 24h window.
+    """
+    updated = dict(item)
+    updated["state"] = "published"
+    updated["instagram_post_url"] = ig_url.strip()
+    updated["instagram_published_at"] = published_at_iso
+    updated["engagement_metrics"] = None
+    updated["damar_action"] = "published"
+    updated["damar_action_at"] = published_at_iso
+    # Append to state_history if the item tracks one (newer schema); leave absent otherwise.
+    history = updated.get("state_history")
+    if isinstance(history, list):
+        updated["state_history"] = history + [
+            {"state": "published", "at": published_at_iso, "via": "wr2_queue_writer"}
+        ]
+    return updated
+
+
+# ── Outcome type ───────────────────────────────────────────────────────────
+
+
+@dataclass
+class PublishResult:
+    """Structured outcome of mark_published. `ok` distinguishes success from no-op/error."""
+
+    status: str  # published | already_published | conflict | not_found | invalid_url | wrong_state
+    ok: bool
+    ref_code: str
+    item_id: Optional[str] = None
+    detail: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "ok": self.ok,
+            "ref_code": self.ref_code,
+            "item_id": self.item_id,
+            "detail": self.detail,
+        }
+
+
+# ── I/O functions ──────────────────────────────────────────────────────────
+
+
+def load_queue(path: Path) -> list[dict[str, Any]]:
+    """Load the queue list. Raises FileNotFoundError if absent (caller decides)."""
+    data = json.loads(Path(path).read_text())
+    if isinstance(data, dict):  # tolerate {"items": [...]} wrapper
+        data = data.get("items", [])
+    if not isinstance(data, list):
+        raise ValueError(f"queue at {path} is not a list")
+    return data
+
+
+def write_queue_atomic(path: Path, items: list[dict[str, Any]]) -> None:
+    """Write the queue list atomically (tmp file in same dir + os.replace)."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".queue-", suffix=".json")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(items, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+        os.replace(tmp, path)  # atomic on POSIX
+    except Exception:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
+
+
+# ── Orchestration ──────────────────────────────────────────────────────────
+
+
+def mark_published(
+    path: Path,
+    ref_code: str,
+    ig_url: str,
+    published_at: Optional[str] = None,
+    now: Optional[datetime] = None,
+) -> PublishResult:
+    """Find the item by ref-code and mark it published with the IG URL.
+
+    Idempotent and safe:
+      * not_found     — no item matches the ref-code  -> NO write
+      * invalid_url   — url is not an instagram permalink -> NO write
+      * already_published — already published with the SAME url -> NO write (success no-op)
+      * conflict      — already published with a DIFFERENT url -> NO write (needs human)
+      * wrong_state   — item exists but is not in a publishable state -> NO write
+      * published     — applied + written atomically -> WRITE
+    """
+    ref = normalize_ref_code(ref_code)
+
+    if not validate_ig_url(ig_url):
+        return PublishResult("invalid_url", False, ref, detail=f"not an IG permalink: {ig_url!r}")
+
+    items = load_queue(path)
+    idx, item = find_by_ref_code(items, ref)
+    if item is None:
+        return PublishResult("not_found", False, ref, detail="no queue item matches this ref-code")
+
+    iid = item_id_of(item)
+    state = item.get("state")
+    existing_url = (item.get("instagram_post_url") or "").strip()
+    new_url = ig_url.strip()
+
+    if state in PUBLISHED_STATES:
+        if existing_url == new_url:
+            return PublishResult("already_published", True, ref, iid, "no-op: same URL already recorded")
+        return PublishResult(
+            "conflict", False, ref, iid,
+            f"already published with a different URL ({existing_url!r}); refusing to overwrite",
+        )
+
+    if state not in PUBLISHABLE_STATES:
+        return PublishResult(
+            "wrong_state", False, ref, iid,
+            f"state {state!r} is not publishable (expected one of {PUBLISHABLE_STATES})",
+        )
+
+    published_iso = published_at or (now or datetime.now(timezone.utc)).isoformat()
+    items[idx] = apply_publish(item, new_url, published_iso)
+    write_queue_atomic(path, items)
+    return PublishResult("published", True, ref, iid, f"published at {published_iso}")
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+
+def _resolve_queue_path(arg: Optional[str]) -> Path:
+    if arg:
+        return Path(arg)
+    env = os.environ.get("WR2_QUEUE_PATH")
+    return Path(env) if env else DEFAULT_QUEUE_PATH
+
+
+def _cmd_list_ready(args: argparse.Namespace) -> int:
+    path = _resolve_queue_path(args.queue)
+    items = load_queue(path)
+    seen: dict[str, str] = {}
+    rows = []
+    for item in items:
+        state = item.get("state")
+        if not args.all and state not in PUBLISHABLE_STATES:
+            continue
+        iid = item_id_of(item)
+        if not iid:
+            continue
+        ref = compute_ref_code(iid)
+        collision = " ⚠️COLLISION" if ref in seen and seen[ref] != iid else ""
+        seen[ref] = iid
+        rows.append((ref, state, iid, topic_of(item), collision))
+    if not rows:
+        print("(no items)")
+        return 0
+    print(f"{'REF-CODE':<12} {'STATE':<24} {'ITEM_ID':<40} TOPIC")
+    for ref, state, iid, topic, coll in rows:
+        print(f"{ref:<12} {state:<24} {iid:<40} {topic[:50]}{coll}")
+    print(f"\n{len(rows)} item(s).")
+    return 0
+
+
+def _cmd_ref_code(args: argparse.Namespace) -> int:
+    print(compute_ref_code(args.item_id))
+    return 0
+
+
+def _cmd_mark_published(args: argparse.Namespace) -> int:
+    path = _resolve_queue_path(args.queue)
+    result = mark_published(path, args.ref_code, args.ig_url, published_at=args.at)
+    print(json.dumps(result.as_dict(), ensure_ascii=False))
+    return 0 if result.ok else 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="WR2 publish-feedback queue writer")
+    p.add_argument("--queue", help="path to human-review-queue.json (default: env WR2_QUEUE_PATH or standard)")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    lr = sub.add_parser("list-ready", help="list items awaiting publish with their ref-code")
+    lr.add_argument("--all", action="store_true", help="show all items, not only publishable")
+    lr.set_defaults(func=_cmd_list_ready)
+
+    rc = sub.add_parser("ref-code", help="print the ref-code for a given item id")
+    rc.add_argument("item_id")
+    rc.set_defaults(func=_cmd_ref_code)
+
+    mp = sub.add_parser("mark-published", help="mark an item published with its IG URL")
+    mp.add_argument("ref_code")
+    mp.add_argument("ig_url")
+    mp.add_argument("--at", help="ISO timestamp of publication (default: now UTC)")
+    mp.set_defaults(func=_cmd_mark_published)
+    return p
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Cosa

Chiude l'anello di feedback IG-metrics della pipeline WR2. **STRATO 1**: il *writer* riutilizzabile della queue — il pezzo comune a ogni canale (CLI manuale ora, WhatsApp in STRATO 2).

## Perché

Il loop era **bloccato a monte**: 43 caroselli in `applied_ready_for_damar`, **0** `published`. Damar pubblica su IG a mano (Law 5 — nessuna API IG autonoma) ma non c'era modo di rimandare l'URL nella queue → lo scraper IG non aveva nulla da raschiare → l'analista settimanale fermo su "insufficient data".

## Come

`scripts/wr2_queue_writer.py`: dato un **ref-code deterministico** (`WR2-` + 6 hex di sha1(item_id)) + un URL IG, trova l'item e lo normalizza **esattamente** alla forma che lo scraper consuma (verificato vs `_ig-metrics-scraper.py:43-52`):

| campo | valore |
|---|---|
| `state` | `published` |
| `instagram_post_url` | `<url>` |
| `instagram_published_at` | `<iso utc>` |
| `engagement_metrics` | `None` ⚠️ |

⚠️ Un dict-di-None è **truthy** e lo scraper salta gli item con `engagement_metrics` truthy — bug latente nei 43 item first-prod, azzerato qui.

### Anti-fragilità (decisione panel sul canale WhatsApp)
Match **esatto** sul ref-code, mai fuzzy, mai "l'unico in attesa". Ogni caso ambiguo/assente/conflittuale ritorna un esito strutturato e **non scrive nulla**:
`not_found` · `invalid_url` · `already_published` (no-op) · `conflict` · `wrong_state`.

Gestisce la queue **eterogenea** (43 item vecchi `item_id`/`topic` + 23 draft nuovi `id`/`topic_slug`). Scrittura atomica (tmp + `os.replace`). Funzioni pure separate dall'I/O.

### CLI
\`\`\`
wr2_queue_writer.py list-ready                      # ref-code + topic per item
wr2_queue_writer.py ref-code <item_id>
wr2_queue_writer.py mark-published <ref> <ig_url> [--at ISO]
\`\`\`

## Verifica

- **25/25** unit test (`test_wr2_queue_writer.py`), ruff clean.
- **Fire-test su copia della queue live**: dopo `mark-published`, la *select* propria dello scraper ritorna `True` per l'item → **loop chiuso**. Idempotente su stesso URL; rifiuta conflict/not_found/invalid/wrong_state. Queue di produzione **intatta**.
- `list-ready` sulla queue reale: 44 item, **0 collisioni** di ref-code.

## Prossimo (STRATO 2, PR separata)

Canale WhatsApp inbound: Damar → numero business Meta → webhook → signal Postgres → consumer Pro che chiama `mark_published` + notifica outbound del ref-code. **wa-mirror deliberatamente NON usato** (OSINT-scoped, Law 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)