### PR TITLE
refactor(kita): dashboard action above the fold, news below (P0.1)

### DIFF
--- a/apps/mouth/src/app/(workspace)/dashboard/__tests__/page.test.tsx
+++ b/apps/mouth/src/app/(workspace)/dashboard/__tests__/page.test.tsx
@@ -51,6 +51,9 @@ vi.mock("next/link", () => ({
     href: string;
   }) => <a href={href}>{children}</a>,
 }));
+vi.mock("@/components/workspace/HeroLiveWindow", () => ({
+  HeroLiveWindow: () => <div data-testid="hero-live-window">Hero</div>,
+}));
 
 // Mock dashboard components
 vi.mock("@/components/dashboard", () => ({
@@ -299,5 +302,20 @@ describe("DashboardPage - Unit Tests", () => {
     await waitFor(() => {
       expect(screen.getByTestId("zantara-portal-card")).toBeInTheDocument();
     });
+  });
+
+  it("renders the metric bar before the hero news window (P0.1)", async () => {
+    render(<DashboardPage />, { wrapper: createWrapper() });
+
+    // "My Cases" is the first metric-bar KPI for a non-zero user.
+    const metricLabel = await screen.findByText("My Cases");
+    const hero = screen.getByTestId("hero-live-window");
+
+    // The hero (news) must FOLLOW the metric bar in DOM order — action
+    // above the fold, news below (audit P0.1).
+    expect(
+      metricLabel.compareDocumentPosition(hero) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 });

--- a/apps/mouth/src/app/(workspace)/dashboard/page.tsx
+++ b/apps/mouth/src/app/(workspace)/dashboard/page.tsx
@@ -472,13 +472,13 @@ export default function DashboardPage() {
   if (isLoading) {
     return (
       <div className="p-2.5 space-y-2">
-        <div className="h-[240px] rounded-xl bg-white/[0.025] animate-pulse" />
         <div className="h-12 rounded-xl bg-white/[0.025] animate-pulse" />
         <div className="grid grid-cols-4 gap-2">
           <div className="col-span-3 h-[220px] rounded-xl bg-white/[0.025] animate-pulse" />
           <div className="h-[220px] rounded-xl bg-white/[0.025] animate-pulse" />
         </div>
         <div className="h-[320px] rounded-xl bg-white/[0.025] animate-pulse" />
+        <div className="h-[240px] rounded-xl bg-white/[0.025] animate-pulse" />
       </div>
     );
   }
@@ -579,9 +579,6 @@ export default function DashboardPage() {
     <DashboardErrorBoundary>
       <div className="relative dash-liquid-bg">
         <div className="p-2.5 space-y-2">
-          {/* ROW 0: Hero */}
-          <HeroLiveWindow />
-
           {/* ROW 1: Zantara AI portal */}
           <ZantaraPortalCard />
 
@@ -760,6 +757,9 @@ export default function DashboardPage() {
               <RoleWidget role={role} userId={user?.email ?? ""} />
             </div>
           </div>
+
+          {/* ROW 5: Hero news — below the operational rows (audit P0.1: action above the fold) */}
+          <HeroLiveWindow />
         </div>
       </div>
     </DashboardErrorBoundary>


### PR DESCRIPTION
## Summary

Implements finding **P0.1** of the kita.balizero.com UI/UX audit
(`research/operations/2026-06-11-kita-uiux-audit.md`): the dashboard buried the
operational signal under a full-width news hero. An operator opens the console to see
what needs action now, not to read news.

**Row order before → after** (`apps/mouth/src/app/(workspace)/dashboard/page.tsx`):

| Before | After |
|---|---|
| HeroLiveWindow (news carousel, 420px) | ZantaraPortalCard |
| ZantaraPortalCard | IntakeReviewBanner ("N documents waiting for your review") |
| IntakeReviewBanner | Metric bar (KPIs) |
| Metric bar (KPIs) | TeamActivityPanel |
| TeamActivityPanel | Pipeline + Intel + LiveActivity grid |
| Pipeline + Intel + LiveActivity grid | HeroLiveWindow (news, bottom row) |

Pure JSX reordering — no redesign, no new components, no styling changes. The loading
skeleton is mirrored to the new order (one block moved).

## Test

Added one DOM-order regression test to the existing
`apps/mouth/src/app/(workspace)/dashboard/__tests__/page.test.tsx`:
`renders the metric bar before the hero news window (P0.1)` — asserts via
`compareDocumentPosition` that the hero FOLLOWS the metric bar. Verified falsifiable:
the test fails against the old layout (checked by stashing the page change).

- Page suite: 5/5 passed
- `vitest run src/components/dashboard src/app`: 25 files, 224 tests, all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)