### PR TITLE
feat(wr2): Damar WhatsApp publish consumer — IG-feedback loop STRATO 2

### DIFF
--- a/apps/backend-rag/backend/tests/unit/scripts/test_wr2_damar_publish_consumer.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_wr2_damar_publish_consumer.py
@@ -1,0 +1,185 @@
+"""Unit tests for scripts/wr2_damar_publish_consumer.py — STRATO 2.
+
+Tests the pure parser and batch-processing logic with an injected mark_fn — no
+Postgres, no queue file, no asyncpg. Covers the real-message shapes (Italian
+PUBBLICATO with double-B, English PUBLISHED, noise, malformed) and the
+cursor/unmatched accounting that protects the loop from silently dropping or
+mis-applying a signal.
+"""
+
+import importlib.util
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ── Load the module from repo-root scripts/ ────────────────────────────────
+_REPO_ROOT = Path(__file__).resolve().parents[6]
+_MODULE_PATH = _REPO_ROOT / "scripts" / "wr2_damar_publish_consumer.py"
+_spec = importlib.util.spec_from_file_location("wr2_damar_publish_consumer", _MODULE_PATH)
+dc = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = dc
+_spec.loader.exec_module(dc)
+
+# A real ref-code (sha1-derived) for one of the live items, computed via STRATO 1.
+REAL_REF = dc._qw.compute_ref_code("pg-3fc8cb52-1778433536")  # e.g. WR2-A8274F
+HEX = REAL_REF[len("WR2-"):]
+URL = "https://www.instagram.com/p/Cabc123_-/"
+
+
+# ── parse_publish_command ──────────────────────────────────────────────────
+
+
+def test_parse_italian_pubblicato_double_b():
+    # "PUBBLICATO" has a double B — the regex must still match it.
+    ref, url = dc.parse_publish_command(f"PUBBLICATO {REAL_REF} {URL}")
+    assert ref == REAL_REF and url == URL
+
+
+def test_parse_english_published():
+    ref, url = dc.parse_publish_command(f"Published {REAL_REF}: {URL}")
+    assert ref == REAL_REF and url == URL
+
+
+def test_parse_tolerates_missing_prefix_and_lowercase():
+    ref, url = dc.parse_publish_command(f"pubblicato {HEX.lower()} {URL}")
+    assert ref == REAL_REF and url == URL
+
+
+def test_parse_tolerates_extra_text_and_newlines():
+    msg = f"Ciao! Ho PUBBLICATO il carosello {REAL_REF}\nlink: {URL}\ngrazie"
+    ref, url = dc.parse_publish_command(msg)
+    assert ref == REAL_REF and url == URL
+
+
+def test_parse_reel_url():
+    reel = "https://instagram.com/reel/Xyz789/"
+    ref, url = dc.parse_publish_command(f"PUBBLICATO {REAL_REF} {reel}")
+    assert url == reel
+
+
+def test_parse_rejects_plain_client_message():
+    assert dc.parse_publish_command("Hi, how much is a KITAS?") is None
+
+
+def test_parse_rejects_command_without_url():
+    assert dc.parse_publish_command(f"PUBBLICATO {REAL_REF} done") is None
+
+
+def test_parse_rejects_non_instagram_url():
+    assert dc.parse_publish_command(f"PUBBLICATO {REAL_REF} https://example.com/p/abc/") is None
+
+
+def test_parse_rejects_command_without_refcode():
+    assert dc.parse_publish_command(f"PUBBLICATO {URL}") is None
+
+
+def test_parse_none_and_empty():
+    assert dc.parse_publish_command("") is None
+    assert dc.parse_publish_command(None) is None
+
+
+# ── Fake mark_fn ───────────────────────────────────────────────────────────
+
+
+class _FakeResult:
+    def __init__(self, status, detail=""):
+        self.status = status
+        self.detail = detail
+
+
+def _recording_mark(status="published"):
+    calls = []
+
+    def mark_fn(ref, url, published_at):
+        calls.append((ref, url, published_at))
+        return _FakeResult(status)
+
+    mark_fn.calls = calls
+    return mark_fn
+
+
+# ── process_message ────────────────────────────────────────────────────────
+
+
+def test_process_message_command_calls_mark_once():
+    mark = _recording_mark("published")
+    when = datetime(2026, 6, 12, 8, 0, tzinfo=timezone.utc)
+    out = dc.process_message({"id": 7, "text": f"PUBBLICATO {REAL_REF} {URL}", "message_date": when}, mark)
+    assert out.parsed and out.status == "published"
+    assert out.ref_code == REAL_REF and out.ig_url == URL
+    assert len(mark.calls) == 1
+    # message_date passed through as iso utc
+    assert mark.calls[0][2] == when.isoformat()
+
+
+def test_process_message_noise_does_not_call_mark():
+    mark = _recording_mark()
+    out = dc.process_message({"id": 9, "text": "what's my visa status?", "message_date": None}, mark)
+    assert out.parsed is False and out.status == "not_a_command"
+    assert mark.calls == []
+
+
+def test_process_message_naive_datetime_handled():
+    mark = _recording_mark()
+    naive = datetime(2026, 6, 12, 8, 0)  # no tzinfo
+    out = dc.process_message({"id": 3, "text": f"PUBBLICATO {REAL_REF} {URL}", "message_date": naive}, mark)
+    assert out.parsed
+    assert len(mark.calls) == 1  # did not raise on naive dt
+
+
+# ── process_batch ──────────────────────────────────────────────────────────
+
+
+def test_process_batch_advances_cursor_to_max_id():
+    mark = _recording_mark("published")
+    msgs = [
+        {"id": 10, "text": f"PUBBLICATO {REAL_REF} {URL}", "message_date": None},
+        {"id": 12, "text": "random client noise", "message_date": None},
+    ]
+    report = dc.process_batch(msgs, mark, cursor_before=5)
+    assert report.cursor_after == 12  # advances past noise too (not re-scanned forever)
+    assert report.published == 1
+    assert len(mark.calls) == 1
+
+
+def test_process_batch_unmatched_collects_failed_applies():
+    mark = _recording_mark("not_found")  # ref didn't resolve
+    msgs = [{"id": 20, "text": f"PUBBLICATO {REAL_REF} {URL}", "message_date": None}]
+    report = dc.process_batch(msgs, mark, cursor_before=0)
+    assert report.published == 0
+    assert len(report.unmatched) == 1
+    assert report.unmatched[0].status == "not_found"
+
+
+def test_process_batch_already_published_is_not_unmatched():
+    mark = _recording_mark("already_published")
+    msgs = [{"id": 21, "text": f"PUBBLICATO {REAL_REF} {URL}", "message_date": None}]
+    report = dc.process_batch(msgs, mark, cursor_before=0)
+    assert report.unmatched == []  # idempotent no-op is success, not a human-needed case
+
+
+def test_process_batch_empty_keeps_cursor():
+    report = dc.process_batch([], _recording_mark(), cursor_before=42)
+    assert report.cursor_after == 42 and report.outcomes == []
+
+
+# ── cursor persistence ─────────────────────────────────────────────────────
+
+
+def test_cursor_roundtrip(tmp_path):
+    p = tmp_path / "cursor.json"
+    assert dc.load_cursor(p) == 0  # absent -> 0
+    dc.save_cursor(p, 123)
+    assert dc.load_cursor(p) == 123
+
+
+def test_append_unmatched_writes_jsonl(tmp_path):
+    import json
+    p = tmp_path / "unmatched.jsonl"
+    out = dc.MessageOutcome(row_id=5, parsed=True, status="conflict", ref_code=REAL_REF, ig_url=URL, detail="x")
+    dc.append_unmatched(p, out)
+    dc.append_unmatched(p, out)
+    lines = p.read_text().strip().splitlines()
+    assert len(lines) == 2
+    rec = json.loads(lines[0])
+    assert rec["status"] == "conflict" and rec["ref_code"] == REAL_REF

--- a/docs/runbooks/wr2-ig-feedback-loop.md
+++ b/docs/runbooks/wr2-ig-feedback-loop.md
@@ -1,0 +1,148 @@
+# Runbook — WR2 IG-metrics feedback loop (Damar → published)
+
+Closes the loop between "Damar publishes a WR2 carosello on Instagram by hand"
+and "the IG-metrics scraper has a published item with a URL to scrape". Before
+this, 43 caroselli sat at `applied_ready_for_damar`, `0` were `published`, and
+the weekly IG analyst stayed blocked on "insufficient data".
+
+Two strati:
+
+- **STRATO 1** — `scripts/wr2_queue_writer.py`: the reusable writer. Given a
+  deterministic `ref_code` + IG URL, advances the matching queue item to
+  `published` in the exact shape the scraper consumes. Usable standalone (manual
+  CLI) — closes the loop even without WhatsApp.
+- **STRATO 2** — `scripts/wr2_damar_publish_consumer.py` + LaunchAgent: polls
+  the local wa-mirror Postgres for Damar's WhatsApp messages and drives STRATO 1
+  automatically.
+
+Everything is Pro-local (wa-mirror → local Postgres → `human-review-queue.json`).
+No PII leaves the machine (Law 2). wa-mirror is the source by Zero's decision;
+the only field acted on is a public IG URL.
+
+---
+
+## How Damar uses it
+
+After publishing a carosello on Instagram, Damar sends ONE WhatsApp message from
+his number (+628213454726) — wording is flexible, three things must appear:
+
+```
+PUBBLICATO WR2-A8274F https://instagram.com/p/XYZ
+```
+
+- a publish word (`PUBBLICATO` / `Published`),
+- the **ref-code** of the carosello (`WR2-XXXXXX`),
+- the **Instagram post URL**.
+
+Word order, extra text, emoji and newlines are tolerated. A bad/missing ref-code
+is NEVER mis-applied — it lands in the unmatched queue (below).
+
+### Where does the ref-code come from?
+
+Each carosello has a stable ref-code = `WR2-` + 6 hex of sha1(item_id). List the
+pending ones with their codes:
+
+```bash
+python scripts/wr2_queue_writer.py list-ready
+```
+
+> STRATO 2b (not yet built): auto-notify Damar with the ref-code when a carosello
+> reaches `applied_ready_for_damar`. Until then, send him the code from
+> `list-ready` (or via the `applied_ready_for_damar` handoff).
+
+---
+
+## Manual operation (STRATO 1 — works today, no setup)
+
+```bash
+# find the ref-code
+python scripts/wr2_queue_writer.py list-ready
+
+# mark one published (after Damar publishes)
+python scripts/wr2_queue_writer.py mark-published WR2-A8274F https://instagram.com/p/XYZ
+# -> {"status":"published","ok":true,...}
+```
+
+Idempotent: re-running with the same URL is a no-op (`already_published`); a
+different URL is refused (`conflict`); an unknown ref-code is `not_found`; a
+non-IG URL is `invalid_url` — none of these write.
+
+The scraper picks the item up on its next daily run, ≥24h after `published_at`.
+
+---
+
+## Automatic operation (STRATO 2 — requires activation)
+
+### One-time activation (operator — Antonello)
+
+STRATO 2 is **dormant** until these manual steps (each touches an off-limits /
+hot-zone surface, deliberately left to the operator):
+
+1. **Add Damar to wa-mirror** so his messages are captured. Edit
+   `apps/wa-mirror/.env` (OFF-LIMITS for the agent): add `+628213454726` to
+   `WA_MIRROR_ACCOUNTS`, his name to `WA_MIRROR_ACCOUNT_NAMES`, his email to
+   `WA_MIRROR_ACCOUNT_EMAILS`. Then Damar scans the QR once
+   (`bash ~/scripts/wa-mirror-launcher/start-one.sh damar --qr`).
+
+   > NOTE (Law 2): mirroring Damar's number captures his WhatsApp conversations
+   > into the OSINT-scoped store. This is Zero's explicit choice for this channel.
+   > The consumer reads ONLY Damar's rows and acts ONLY on the publish-command
+   > pattern; it never forwards message content anywhere.
+
+2. **Dry-run the consumer once** (no writes) to confirm DB reachability + parsing:
+
+   ```bash
+   set -a; . apps/wa-mirror/.env; set +a
+   apps/backend-rag/.venv/bin/python scripts/wr2_damar_publish_consumer.py --once --dry-run
+   ```
+
+3. **Install the LaunchAgent** (polls every 5 min):
+   ```bash
+   cp infra/launchagents/com.nuzantara.wr2-damar-publish-consumer.plist ~/Library/LaunchAgents/
+   launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.nuzantara.wr2-damar-publish-consumer.plist
+   launchctl kickstart -k gui/$(id -u)/com.nuzantara.wr2-damar-publish-consumer
+   ```
+
+### Kill switch
+
+```bash
+echo '{"enabled": false}' > ~/.agent/wr2-damar-consumer.config   # pause (read live each tick)
+launchctl bootout gui/$(id -u)/com.nuzantara.wr2-damar-publish-consumer   # full stop
+```
+
+### Disambiguation queue
+
+Parsed-but-unresolved commands (wrong ref-code, conflict, etc.) are appended to
+`~/.agent/state/wr2_damar_unmatched.jsonl` and the run exits non-zero. Inspect:
+
+```bash
+tail ~/.agent/state/wr2_damar_unmatched.jsonl
+```
+
+Resolve by hand with the right ref-code via `mark-published`.
+
+### State files
+
+- cursor: `~/.agent/state/wr2_damar_consumer.json` (last processed row id)
+- unmatched: `~/.agent/state/wr2_damar_unmatched.jsonl`
+- log: `~/logs/wr2-damar-publish-consumer.log`
+
+---
+
+## Guarantees
+
+- **Exact ref-code match** — never fuzzy, never "the only pending one".
+- **Never writes on uncertainty** — not_found / conflict / invalid / wrong_state
+  all write nothing.
+- **Idempotent** — cursor + STRATO 1 no-op/conflict make re-runs safe.
+- **Scraper-compatible output** — `engagement_metrics` is cleared to `None`
+  (a dict-of-Nones is truthy and the scraper skips truthy em — a latent bug in
+  the 43 first-prod items, fixed by the writer).
+
+## Tests
+
+```bash
+apps/backend-rag/.venv/bin/python -m pytest \
+  apps/backend-rag/backend/tests/unit/scripts/test_wr2_queue_writer.py \
+  apps/backend-rag/backend/tests/unit/scripts/test_wr2_damar_publish_consumer.py -q
+```

--- a/infra/launchagents/com.nuzantara.wr2-damar-publish-consumer.plist
+++ b/infra/launchagents/com.nuzantara.wr2-damar-publish-consumer.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.nuzantara.wr2-damar-publish-consumer</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>/Users/nuzantara/Desktop/nuzantara/scripts/wr2_damar_publish_consumer_run.sh</string>
+	</array>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>/Users/nuzantara</string>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+		<key>WR2_CONSUMER_REPO_ROOT</key>
+		<string>/Users/nuzantara/Desktop/nuzantara</string>
+	</dict>
+	<key>StandardOutPath</key>
+	<string>/Users/nuzantara/logs/wr2-damar-publish-consumer.launchd.out.log</string>
+	<key>StandardErrorPath</key>
+	<string>/Users/nuzantara/logs/wr2-damar-publish-consumer.launchd.err.log</string>
+	<!-- Poll every 5 min. NO KeepAlive: this is a one-shot poller, not a daemon
+	     (W67: KeepAlive + one-shot = SIGTERM crash-loop). RunAtLoad for an
+	     immediate first pass on (re)load. -->
+	<key>StartInterval</key>
+	<integer>300</integer>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>ThrottleInterval</key>
+	<integer>60</integer>
+</dict>
+</plist>

--- a/scripts/wr2_damar_publish_consumer.py
+++ b/scripts/wr2_damar_publish_consumer.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""WR2 Damar publish consumer — STRATO 2 of the IG-metrics feedback loop.
+
+Damar publishes WR2 caroselli to Instagram by hand (Law 5). To feed the IG URL
+back into the queue WITHOUT a web form or a new Fly webhook, he simply sends a
+WhatsApp message from his own number (+628213454726, mirrored by wa-mirror):
+
+    PUBBLICATO WR2-A8274F https://instagram.com/p/XYZ
+
+wa-mirror captures that message into the LOCAL Postgres table
+`whatsapp_message_context` (localhost:15432/nuzantara_rag — same DB the backend
+uses, NOT Fly). This consumer polls that table for new messages from Damar,
+parses `ref_code + ig_url`, and calls `mark_published` (STRATO 1,
+scripts/wr2_queue_writer.py) to advance the matching queue item to `published`.
+
+Everything is Pro-local: wa-mirror (source) → local Postgres (transport) →
+human-review-queue.json (sink) all live on the Pro. No PII leaves the machine
+(Law 2): the consumer reads only the team-member channel and the only field it
+acts on is a public IG URL.
+
+Anti-fragility (inherited from STRATO 1): EXACT ref-code match. Any message that
+does not parse, or whose ref-code does not resolve, is appended to an
+"unmatched" JSONL for human disambiguation and NEVER silently dropped or
+mis-applied.
+
+Idempotency: a persistent cursor (last processed row id) + STRATO 1's own
+idempotent `mark_published` (already_published no-op, conflict refusal) make
+re-runs safe.
+
+Column contract verified against the runtime reader
+(app/routers/wa_mirror_messages.py:106-119): text lives in `body` with a legacy
+fallback to `message_text` (COALESCE), sender is `team_member_phone`, ordering
+by `id`.
+
+CLI:
+    wr2_damar_publish_consumer.py --once            # one polling pass (default)
+    wr2_damar_publish_consumer.py --once --dry-run  # parse + report, write nothing
+    wr2_damar_publish_consumer.py --phone +62...    # override Damar's number
+
+The DB DSN is read from env `WA_MIRROR_DATABASE_URL` (same var wa-mirror uses).
+NEVER hard-code the DSN — it carries a password (Golden Rule #6).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+# ── Import STRATO 1 (sibling module in scripts/) ───────────────────────────
+_THIS_DIR = Path(__file__).resolve().parent
+_WRITER_PATH = _THIS_DIR / "wr2_queue_writer.py"
+_spec = importlib.util.spec_from_file_location("wr2_queue_writer", _WRITER_PATH)
+_qw = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = _qw
+_spec.loader.exec_module(_qw)
+
+# ── Constants ──────────────────────────────────────────────────────────────
+
+DAMAR_PHONE_DEFAULT = "+628213454726"  # roster: apps/wa-mirror/tests/phone.test.ts
+DEFAULT_CURSOR_PATH = Path.home() / ".agent/state/wr2_damar_consumer.json"
+DEFAULT_UNMATCHED_PATH = Path.home() / ".agent/state/wr2_damar_unmatched.jsonl"
+DSN_ENV = "WA_MIRROR_DATABASE_URL"
+
+# A publish command must carry THREE independent signals (matched separately so
+# arbitrary surrounding text / word order is tolerated):
+#   1. a "publish" intent word — PUBBLICATO (it, double-B), PUBLISHED, PUBLISH (en)
+#   2. an instagram permalink
+#   3. a ref-code — preferred `WR2-<6hex>`; fallback a bare 6-hex token
+_PUB_WORD_RE = re.compile(r"\bpub\w*", re.IGNORECASE)
+_IG_URL_RE = re.compile(
+    r"https?://(?:www\.)?instagram\.com/(?:p|reel|tv)/[A-Za-z0-9_-]+/?(?:\?\S*)?",
+    re.IGNORECASE,
+)
+_REF_PREFIXED_RE = re.compile(r"\bwr2-([0-9a-f]{6})\b", re.IGNORECASE)
+_REF_BARE_RE = re.compile(r"\b([0-9a-f]{6})\b", re.IGNORECASE)
+
+
+# ── Pure parsing ───────────────────────────────────────────────────────────
+
+
+def parse_publish_command(text: str) -> Optional[tuple[str, str]]:
+    """Parse `PUBBLICATO <ref> <ig_url>` from a free-text message.
+
+    Returns (ref_code_normalized, ig_url) or None if the message is not a
+    well-formed publish command. Tolerant of word order, extra text, newlines
+    and casing. The ref-code is preferred with its `WR2-` prefix; a bare 6-hex
+    token is accepted as a fallback (searched AFTER excising the URL, so hex
+    inside an IG shortcode is never mistaken for the ref-code). A bad ref-code
+    still resolves to `not_found` downstream and writes nothing — fail-safe.
+    """
+    if not text:
+        return None
+    if not _PUB_WORD_RE.search(text):
+        return None
+    url_m = _IG_URL_RE.search(text)
+    if not url_m:
+        return None
+    url = url_m.group(0).strip()
+    if not _qw.validate_ig_url(url):
+        return None
+    ref_m = _REF_PREFIXED_RE.search(text)
+    if ref_m:
+        ref_hex = ref_m.group(1)
+    else:
+        text_wo_url = text.replace(url_m.group(0), " ")
+        bare = _REF_BARE_RE.search(text_wo_url)
+        if not bare:
+            return None
+        ref_hex = bare.group(1)
+    return _qw.normalize_ref_code(ref_hex), url
+
+
+# ── Result types ───────────────────────────────────────────────────────────
+
+
+@dataclass
+class MessageOutcome:
+    """Outcome of processing one captured message."""
+
+    row_id: int
+    parsed: bool
+    status: str  # not_a_command | <PublishResult.status>
+    ref_code: Optional[str] = None
+    ig_url: Optional[str] = None
+    detail: str = ""
+
+
+@dataclass
+class BatchReport:
+    cursor_before: int
+    cursor_after: int
+    outcomes: list[MessageOutcome] = field(default_factory=list)
+
+    @property
+    def published(self) -> int:
+        return sum(1 for o in self.outcomes if o.status == "published")
+
+    @property
+    def unmatched(self) -> list[MessageOutcome]:
+        # Parsed-but-failed-to-apply OR not a command at all (latter is benign noise).
+        return [o for o in self.outcomes if o.parsed and o.status not in ("published", "already_published")]
+
+
+# ── Pure batch processing (mark_fn injected → testable without DB/queue) ───
+
+
+def process_message(
+    msg: dict[str, Any],
+    mark_fn: Callable[[str, str, Optional[str]], Any],
+) -> MessageOutcome:
+    """Process one captured message dict {id, text, message_date}.
+
+    `mark_fn(ref_code, ig_url, published_at_iso) -> PublishResult-like` is
+    injected. Returns a MessageOutcome. Never raises on a malformed message.
+    """
+    row_id = int(msg["id"])
+    text = msg.get("text") or ""
+    parsed = parse_publish_command(text)
+    if parsed is None:
+        return MessageOutcome(row_id=row_id, parsed=False, status="not_a_command")
+    ref, url = parsed
+    published_at = msg.get("message_date")
+    if isinstance(published_at, datetime):
+        published_at = published_at.astimezone(timezone.utc).isoformat()
+    result = mark_fn(ref, url, published_at)
+    return MessageOutcome(
+        row_id=row_id,
+        parsed=True,
+        status=getattr(result, "status", "unknown"),
+        ref_code=ref,
+        ig_url=url,
+        detail=getattr(result, "detail", ""),
+    )
+
+
+def process_batch(
+    messages: list[dict[str, Any]],
+    mark_fn: Callable[[str, str, Optional[str]], Any],
+    cursor_before: int,
+) -> BatchReport:
+    """Process a batch of messages ordered by id ascending. Cursor advances to
+    the max processed id (even for non-commands, so benign noise is not
+    re-scanned forever)."""
+    report = BatchReport(cursor_before=cursor_before, cursor_after=cursor_before)
+    for msg in messages:
+        outcome = process_message(msg, mark_fn)
+        report.outcomes.append(outcome)
+        report.cursor_after = max(report.cursor_after, outcome.row_id)
+    return report
+
+
+# ── Cursor + unmatched persistence (I/O) ───────────────────────────────────
+
+
+def load_cursor(path: Path) -> int:
+    try:
+        return int(json.loads(Path(path).read_text()).get("last_id", 0))
+    except (FileNotFoundError, ValueError, json.JSONDecodeError):
+        return 0
+
+
+def save_cursor(path: Path, last_id: int) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"last_id": int(last_id), "updated_at": datetime.now(timezone.utc).isoformat()}))
+
+
+def append_unmatched(path: Path, outcome: MessageOutcome) -> None:
+    """Append a parsed-but-unresolved command for human disambiguation."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a") as f:
+        f.write(json.dumps({
+            "row_id": outcome.row_id,
+            "status": outcome.status,
+            "ref_code": outcome.ref_code,
+            "ig_url": outcome.ig_url,
+            "detail": outcome.detail,
+            "at": datetime.now(timezone.utc).isoformat(),
+        }, ensure_ascii=False) + "\n")
+
+
+# ── DB fetch (asyncpg) ─────────────────────────────────────────────────────
+
+_FETCH_SQL = """
+    SELECT id,
+           COALESCE(NULLIF(body, ''), message_text, '') AS text,
+           message_date
+      FROM whatsapp_message_context
+     WHERE team_member_phone = $1
+       AND id > $2
+       AND COALESCE(NULLIF(body, ''), message_text, '') ~* 'publ'
+     ORDER BY id ASC
+     LIMIT 200
+"""
+
+
+async def fetch_new_messages(dsn: str, phone: str, after_id: int) -> list[dict[str, Any]]:
+    """Fetch new wa-mirror messages from `phone` after `after_id`. Read-only."""
+    import asyncpg  # local import: only needed at runtime, keeps unit tests dep-free
+
+    conn = await asyncpg.connect(dsn.replace("?sslmode=disable", ""), timeout=10)
+    try:
+        rows = await conn.fetch(_FETCH_SQL, phone, after_id)
+        return [{"id": r["id"], "text": r["text"], "message_date": r["message_date"]} for r in rows]
+    finally:
+        await conn.close()
+
+
+# ── Orchestration ──────────────────────────────────────────────────────────
+
+
+async def run_once(
+    *,
+    dsn: str,
+    phone: str,
+    queue_path: Path,
+    cursor_path: Path,
+    unmatched_path: Path,
+    dry_run: bool,
+    log: Callable[[str], None] = print,
+) -> BatchReport:
+    cursor = load_cursor(cursor_path)
+    messages = await fetch_new_messages(dsn, phone, cursor)
+    log(f"[wr2-damar-consumer] phone={phone} cursor={cursor} fetched={len(messages)} dry_run={dry_run}")
+
+    def mark_fn(ref: str, url: str, published_at: Optional[str]):
+        if dry_run:
+            return _qw.PublishResult("dry_run", True, ref, detail="dry-run: would mark published")
+        return _qw.mark_published(queue_path, ref, url, published_at=published_at)
+
+    report = process_batch(messages, mark_fn, cursor)
+
+    for o in report.outcomes:
+        if o.parsed:
+            log(f"  row={o.row_id} {o.status} ref={o.ref_code} url={o.ig_url} — {o.detail}")
+        if o.parsed and o.status not in ("published", "already_published", "dry_run") and not dry_run:
+            append_unmatched(unmatched_path, o)
+
+    if not dry_run and report.cursor_after > report.cursor_before:
+        save_cursor(cursor_path, report.cursor_after)
+
+    log(f"[wr2-damar-consumer] published={report.published} unmatched={len(report.unmatched)} "
+        f"cursor->{report.cursor_after}")
+    return report
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+
+def _resolve_queue_path(arg: Optional[str]) -> Path:
+    if arg:
+        return Path(arg)
+    env = os.environ.get("WR2_QUEUE_PATH")
+    return Path(env) if env else _qw.DEFAULT_QUEUE_PATH
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    p = argparse.ArgumentParser(description="WR2 Damar publish consumer (STRATO 2)")
+    p.add_argument("--once", action="store_true", help="run one polling pass (default behavior)")
+    p.add_argument("--dry-run", action="store_true", help="parse + report, write nothing")
+    p.add_argument("--phone", default=DAMAR_PHONE_DEFAULT, help="Damar's mirrored number")
+    p.add_argument("--queue", help="queue path (default env WR2_QUEUE_PATH or standard)")
+    p.add_argument("--cursor", default=str(DEFAULT_CURSOR_PATH))
+    p.add_argument("--unmatched", default=str(DEFAULT_UNMATCHED_PATH))
+    args = p.parse_args(argv)
+
+    dsn = os.environ.get(DSN_ENV)
+    if not dsn:
+        print(f"FATAL: env {DSN_ENV} not set (the wa-mirror Postgres DSN). Refusing to run.", file=sys.stderr)
+        return 2
+
+    report = asyncio.run(run_once(
+        dsn=dsn,
+        phone=args.phone,
+        queue_path=_resolve_queue_path(args.queue),
+        cursor_path=Path(args.cursor),
+        unmatched_path=Path(args.unmatched),
+        dry_run=args.dry_run,
+    ))
+    # Non-zero exit if there are parsed-but-unresolved commands needing a human.
+    return 0 if not report.unmatched else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wr2_damar_publish_consumer_run.sh
+++ b/scripts/wr2_damar_publish_consumer_run.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# WR2 Damar publish consumer — LaunchAgent wrapper (STRATO 2).
+#
+# Polls the local wa-mirror Postgres for Damar's `PUBBLICATO WR2-XXX <url>`
+# messages and advances the matching queue item to `published` via STRATO 1.
+#
+# Cron: every 5 min via com.nuzantara.wr2-damar-publish-consumer.plist
+#       (StartInterval, NO KeepAlive — W67: KeepAlive + one-shot = crash-loop).
+#
+# Requires:
+#   * env WA_MIRROR_DATABASE_URL (the wa-mirror local Postgres DSN) — sourced
+#     from apps/wa-mirror/.env below; NEVER hard-coded (Golden Rule #6).
+#   * backend venv (asyncpg).
+#
+# Exit codes: 0 = clean (incl. nothing to do); 1 = parsed-but-unresolved
+# command(s) need human disambiguation (see ~/.agent/state/wr2_damar_unmatched.jsonl).
+
+set -uo pipefail
+
+REPO_ROOT="${WR2_CONSUMER_REPO_ROOT:-$HOME/Desktop/nuzantara}"
+LOGDIR="${HOME}/logs"
+mkdir -p "$LOGDIR"
+LOG="$LOGDIR/wr2-damar-publish-consumer.log"
+
+echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] wr2-damar-publish-consumer starting" >> "$LOG"
+
+# Kill switch (read live each tick).
+CONFIG="${HOME}/.agent/wr2-damar-consumer.config"
+if [ -f "$CONFIG" ]; then
+  if grep -q '"enabled"[[:space:]]*:[[:space:]]*false' "$CONFIG" 2>/dev/null; then
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] disabled via config — skip" >> "$LOG"
+    exit 0
+  fi
+fi
+
+# DSN from the wa-mirror env (carries a password — do not echo it).
+WA_ENV="$REPO_ROOT/apps/wa-mirror/.env"
+if [ -f "$WA_ENV" ]; then
+  # shellcheck disable=SC1090
+  set -a; . "$WA_ENV"; set +a
+fi
+if [ -z "${WA_MIRROR_DATABASE_URL:-}" ]; then
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] FATAL: WA_MIRROR_DATABASE_URL unset — abort" >> "$LOG"
+  exit 2
+fi
+export WA_MIRROR_DATABASE_URL
+
+VENV="$REPO_ROOT/apps/backend-rag/.venv/bin/python"
+if [ ! -x "$VENV" ]; then
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] FATAL: backend venv missing at $VENV — abort" >> "$LOG"
+  exit 2
+fi
+
+"$VENV" "$REPO_ROOT/scripts/wr2_damar_publish_consumer.py" --once >> "$LOG" 2>&1
+RC=$?
+echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] wr2-damar-publish-consumer done rc=$RC" >> "$LOG"
+exit $RC


### PR DESCRIPTION
## Cosa

**STRATO 2** dell'anello di feedback IG-metrics: automatizza il rientro dell'URL IG nella queue via WhatsApp (canale scelto da Zero). STRATO 1 (#1352, merged) chiudeva il loop a mano; questo lo guida da WhatsApp.

## Flusso

Damar pubblica un carosello su IG a mano, poi manda **un** messaggio WhatsApp dal suo numero (+628213454726, mirrorato da wa-mirror):

```
PUBBLICATO WR2-A8274F https://instagram.com/p/XYZ
```

`scripts/wr2_damar_publish_consumer.py` fa polling del **Postgres locale** di wa-mirror (`localhost:15432/nuzantara_rag` — **NON** Fly) per i messaggi di Damar, parsa ref-code + URL, e chiama `mark_published` (STRATO 1). Tutto **Pro-locale** (wa-mirror → PG locale → `human-review-queue.json`); nessuna PII lascia la macchina (Law 2) — l'unico campo su cui agisce è un URL IG pubblico.

**Perché wa-mirror e non il webhook Meta**: la queue è Pro-locale → niente split Fly↔Pro, niente migration, niente webhook. Contratto colonne verificato vs il reader runtime (`wa_mirror_messages.py:106-119`).

## Robustezza

- Parser su **tre segnali indipendenti** (publish-word + URL IG + ref-code): tollera ordine parole / testo extra / emoji / newline. "PUBBLICATO" ha la doppia B → regex `pub\w*`, non `publ`.
- Ref-code: preferito `WR2-<6hex>`; fallback hex-only cercato **dopo** aver tolto l'URL (così l'hex nello shortcode IG non viene scambiato per il codice).
- **Match esatto** (STRATO 1). Parsed-ma-irrisolto (`not_found`/`conflict`/`invalid`/`wrong_state`) → `~/.agent/state/wr2_damar_unmatched.jsonl`, **mai** mis-applicato, exit non-zero.
- Cursore persistente + `mark_published` idempotente → re-run sicuri.
- DSN da env `WA_MIRROR_DATABASE_URL`, mai hardcoded (Golden Rule #6).

## Verifica

- **44/44** test (25 STRATO 1 + 19 STRATO 2), ruff clean.
- Parser testato: italiano doppia-B, inglese, rifiuto noise cliente, contabilità cursore/unmatched — zero dipendenze DB.
- **Smoke d'integrazione** STRATO 1+2 su copia queue: messaggio italiano realistico (emoji+testo extra) → item `published` → la *select* dello scraper ritorna `True`.

## ⚠️ Attivazione (operatore — non fatta dall'agente)

STRATO 2 è **dormiente** finché non attivi (ogni passo tocca off-limits/hot-zone):
1. Aggiungi Damar a `apps/wa-mirror/.env` (off-limits per l'agente) + Damar scansiona QR.
2. Dry-run del consumer (`--dry-run`).
3. `launchctl bootstrap` del LaunchAgent (polling 5 min).

Runbook completo: `docs/runbooks/wr2-ig-feedback-loop.md`. Kill switch: `~/.agent/wr2-damar-consumer.config {"enabled": false}`. STRATO 1 (CLI manuale) funziona già da ora.

**Non costruito (STRATO 2b)**: auto-notifica a Damar del ref-code quando un carosello entra in `applied_ready_for_damar` (per ora: mandagli l'output di `list-ready`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)