### PR TITLE
feat(ops): Dropbox→Drive intake — copy-only rclone cron + Telegram digest

### DIFF
--- a/docs/runbooks/dropbox-intake.md
+++ b/docs/runbooks/dropbox-intake.md
@@ -1,0 +1,87 @@
+# Dropbox → Google Drive Intake
+
+Every file that lands in the Bali Zero Dropbox (`data.bayusantero@gmail.com`) is
+copied to Google Drive (`antonellosiano@gmail.com`) under `Dropbox-Intake/`,
+mirroring the original folder structure.
+
+**Invariant (operator decision 2026-06-12): COPY ONLY.** Dropbox is never
+emptied — no `move`, no `sync` (which deletes), no `purge`. Drive accumulates.
+
+## Architecture
+
+```
+Dropbox (data.bayusantero@gmail.com)
+   │  rclone copy — incremental, idempotent, bwlimit 4M
+   │  LaunchAgent com.balizero.dropbox-intake on Pro, every 10 min
+   ▼
+Drive antonellosiano@gmail.com → Dropbox-Intake/  (mirrored structure)
+   ├── Telegram digest when ≥1 new file copied
+   └── Telegram alert (1h cooldown) when a run fails or remotes are missing
+```
+
+- No state to maintain: `rclone copy` compares src/dst (size+modtime) each run
+  and copies only the delta. A missed run self-heals on the next tick.
+- A single-instance lock lets long runs (e.g. the first ~527 GiB backfill)
+  continue while later cron ticks exit 0.
+- State JSON for the sentinel: `~/.agent/decisions/state/dropbox_intake.last.json`.
+- Run logs: `~/.cache/dropbox-intake/` (last 100 kept), summary in `latest.log`.
+
+## Components
+
+| Piece       | Repo source                                            | Deployed at (Pro)                  |
+| ----------- | ------------------------------------------------------ | ---------------------------------- |
+| Sync script | `scripts/dropbox_intake_sync.sh`                       | `~/scripts/dropbox-intake-sync.sh` |
+| LaunchAgent | `infra/launchagents/com.balizero.dropbox-intake.plist` | `~/Library/LaunchAgents/`          |
+| Installer   | `infra/launchagents/install_dropbox_intake.sh`         | run on Pro                         |
+
+The repo is the source of truth; after editing, re-run the installer on the Pro
+(HOME-fork discipline, scar family W50/W51/W52).
+
+## rclone remotes (prereq)
+
+`~/.config/rclone/rclone.conf` on the Pro (must be **0600**) holds two remotes:
+
+- `gdrive` — Google Drive OAuth as antonellosiano@gmail.com (`type = drive`,
+  `scope = drive`). Shared with `nuzantara-drive-sync.sh` and the
+  `gdrive-*-backup.sh` family.
+- `dropbox-bayu` — Dropbox OAuth as data.bayusantero@gmail.com (`type = dropbox`).
+
+### Re-auth (token expired/revoked)
+
+On any machine with a browser (rclone installed):
+
+```bash
+rclone authorize "drive"     # login antonellosiano@gmail.com
+rclone authorize "dropbox"   # login data.bayusantero@gmail.com
+```
+
+Paste the resulting `token = {...}` JSON into the matching section of
+`~/.config/rclone/rclone.conf` on the Pro. Never paste tokens into chat
+transcripts or commit them.
+
+## Operations
+
+```bash
+# Kill switch (set in plist env, then bootout/bootstrap — or just bootout):
+launchctl bootout gui/$(id -u)/com.balizero.dropbox-intake
+
+# Manual run (respects the lock):
+bash ~/scripts/dropbox-intake-sync.sh
+
+# Status:
+cat ~/.agent/decisions/state/dropbox_intake.last.json
+tail -20 ~/.cache/dropbox-intake/latest.log
+```
+
+Tunables (env): `DROPBOX_INTAKE_ENABLED`, `DROPBOX_INTAKE_SRC`,
+`DROPBOX_INTAKE_DST`, `DROPBOX_INTAKE_BWLIMIT` (default `4M` ≈ 32 Mbit/s).
+
+## Troubleshooting
+
+- **"remote not configured" alert** → the rclone config was wiped (it happened
+  2026-05-25, silently breaking the Drive mirror + backups for 18 days) or the
+  token was revoked → re-auth as above.
+- **Run fails with Drive upload-limit** → `--drive-stop-on-upload-limit` halted
+  at Google's 750 GB/day cap; the next tick resumes where it left off.
+- **No digest but files were added** → check `latest.log`; the digest fires only
+  at the END of a run — during the initial backfill that can be a day+.

--- a/infra/launchagents/com.balizero.dropbox-intake.plist
+++ b/infra/launchagents/com.balizero.dropbox-intake.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.balizero.dropbox-intake</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>DROPBOX_INTAKE_ENABLED</key>
+        <string>true</string>
+    </dict>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__HOME__/scripts/dropbox-intake-sync.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>600</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>__HOME__/logs/dropbox-intake.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>__HOME__/logs/dropbox-intake.err.log</string>
+</dict>
+</plist>

--- a/infra/launchagents/install_dropbox_intake.sh
+++ b/infra/launchagents/install_dropbox_intake.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# install_dropbox_intake.sh — idempotent installer for the Dropbox→Drive intake cron.
+# Run ON the target machine (Pro). Re-run after every change to script/plist.
+# Prereq: rclone remotes 'dropbox-bayu' + 'gdrive' in ~/.config/rclone/rclone.conf (0600).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_SRC="$REPO_ROOT/scripts/dropbox_intake_sync.sh"
+PLIST_SRC="$REPO_ROOT/infra/launchagents/com.balizero.dropbox-intake.plist"
+LABEL="com.balizero.dropbox-intake"
+PLIST_DST="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+[ -f "$SCRIPT_SRC" ] || { echo "SKIP: $SCRIPT_SRC missing"; exit 0; }
+[ -f "$PLIST_SRC" ] || { echo "SKIP: $PLIST_SRC missing"; exit 0; }
+
+mkdir -p "$HOME/scripts" "$HOME/logs"
+install -m 0755 "$SCRIPT_SRC" "$HOME/scripts/dropbox-intake-sync.sh"
+
+# No secrets in the plist by design (scar 2026-04-29 plist-secret-leak).
+sed "s|__HOME__|$HOME|g" "$PLIST_SRC" > "$PLIST_DST"
+chmod 0644 "$PLIST_DST"
+plutil -lint "$PLIST_DST"
+
+launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST_DST"
+launchctl kickstart "gui/$(id -u)/$LABEL"
+
+echo "OK: $LABEL installed + kickstarted (script: ~/scripts/dropbox-intake-sync.sh)"

--- a/scripts/dropbox_intake_sync.sh
+++ b/scripts/dropbox_intake_sync.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# dropbox-intake-sync.sh — Dropbox → Google Drive intake. COPY ONLY: never move,
+# never delete. Dropbox is never emptied (operator decision 2026-06-12).
+#
+# Src: dropbox-bayu:           (Dropbox, data.bayusantero@gmail.com)
+# Dst: gdrive:Dropbox-Intake/  (Google Drive, antonellosiano@gmail.com)
+#
+# Runtime: Pro, LaunchAgent com.balizero.dropbox-intake every 10 min.
+# A single-instance lock self-paces long runs (first backfill ~527 GiB):
+# while a run is alive, later ticks exit 0 immediately.
+#
+# Source of truth: scripts/dropbox_intake_sync.sh (repo). After edits, re-run
+# infra/launchagents/install_dropbox_intake.sh on the Pro (HOME-fork discipline,
+# scar family W50/W51/W52).
+#
+# Kill switch: DROPBOX_INTAKE_ENABLED=false (plist env or shell).
+set -uo pipefail
+
+ENABLED="${DROPBOX_INTAKE_ENABLED:-true}"
+SRC="${DROPBOX_INTAKE_SRC:-dropbox-bayu:}"
+DST="${DROPBOX_INTAKE_DST:-gdrive:Dropbox-Intake}"
+BWLIMIT="${DROPBOX_INTAKE_BWLIMIT:-4M}"
+LOG_DIR="${HOME}/.cache/dropbox-intake"
+STATE_DIR="${HOME}/.agent/decisions/state"
+STATE_FILE="${STATE_DIR}/dropbox_intake.last.json"
+LOCK_FILE="${LOG_DIR}/.lock"
+RUN_LOG="${LOG_DIR}/run-$(date +%Y%m%d-%H%M%S).log"
+LATEST="${LOG_DIR}/latest.log"
+SECRETS_FILE="${HOME}/.nuzantara-secrets.env"
+TELEGRAM_CHAT_ID="${TELEGRAM_CHAT_ID:-1125336968}"
+ALERT_COOLDOWN_S=3600
+
+mkdir -p "$LOG_DIR" "$STATE_DIR"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [dropbox-intake] $*" >> "$LATEST"; }
+
+if [ "$ENABLED" != "true" ]; then
+  log "disabled via DROPBOX_INTAKE_ENABLED — exit 0"
+  exit 0
+fi
+
+# Single-instance lock (a long backfill run keeps it; later cron ticks skip).
+if [ -f "$LOCK_FILE" ]; then
+  PID=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
+  if [ -n "$PID" ] && ps -p "$PID" >/dev/null 2>&1; then
+    log "another run alive (PID $PID) — exit 0"
+    exit 0
+  fi
+fi
+echo $$ > "$LOCK_FILE"
+trap 'rm -f "$LOCK_FILE"' EXIT
+
+telegram() {
+  # Token lives ONLY in the 0600 secrets file — never in plist, never logged.
+  local text="$1"
+  [ -f "$SECRETS_FILE" ] || return 0
+  # shellcheck disable=SC1090
+  set -a; source "$SECRETS_FILE" >/dev/null 2>&1; set +a
+  [ -n "${TELEGRAM_BOT_TOKEN:-}" ] || return 0
+  curl -sS --max-time 20 \
+    "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+    -d "chat_id=${TELEGRAM_CHAT_ID}" \
+    --data-urlencode "text=${text}" >/dev/null 2>&1 || log "telegram post failed"
+}
+
+alert_once() {
+  # Failure alert with 1h cooldown — alert on breakage, don't spam (W55/W70).
+  local text="$1" now last
+  now=$(date +%s)
+  last=$(cat "${LOG_DIR}/.last_alert" 2>/dev/null || echo 0)
+  if [ $((now - last)) -ge "$ALERT_COOLDOWN_S" ]; then
+    telegram "$text"
+    echo "$now" > "${LOG_DIR}/.last_alert"
+  else
+    log "alert suppressed (cooldown): $text"
+  fi
+}
+
+# Pre-flight: both remotes must exist, else skip quietly + one deduped alert.
+REMOTES=$(rclone listremotes 2>/dev/null || echo "")
+for r in "${SRC%%:*}" "${DST%%:*}"; do
+  if ! echo "$REMOTES" | grep -q "^${r}:$"; then
+    log "remote '$r' not configured — exit 0"
+    alert_once "⚠️ dropbox-intake: remote rclone '$r' non configurato su $(hostname -s) — flow fermo (rifare rclone authorize, vedi docs/runbooks/dropbox-intake.md)"
+    exit 0
+  fi
+done
+
+START=$(date +%s)
+log "run start: $SRC -> $DST (bwlimit=$BWLIMIT) log=$RUN_LOG"
+
+rclone copy "$SRC" "$DST" \
+  --log-level INFO --log-file "$RUN_LOG" \
+  --transfers 4 --checkers 8 \
+  --fast-list \
+  --bwlimit "$BWLIMIT" \
+  --drive-stop-on-upload-limit \
+  --exclude ".DS_Store" --exclude "/.dropbox.cache/**"
+RC=$?
+ELAPSED=$(( $(date +%s) - START ))
+
+COPIED=$(grep -c ": Copied (new)" "$RUN_LOG" 2>/dev/null || true)
+REPLACED=$(grep -c ": Copied (replaced existing)" "$RUN_LOG" 2>/dev/null || true)
+COPIED="${COPIED:-0}"
+REPLACED="${REPLACED:-0}"
+
+if [ "$RC" -ne 0 ]; then
+  log "FAIL rc=$RC copied=$COPIED replaced=$REPLACED elapsed=${ELAPSED}s"
+  alert_once "🔴 dropbox-intake FAILED (exit $RC) su $(hostname -s) — copied=$COPIED elapsed=${ELAPSED}s. Log: ~/.cache/dropbox-intake/"
+else
+  log "ok: copied=$COPIED replaced=$REPLACED elapsed=${ELAPSED}s"
+  TOTAL=$(( COPIED + REPLACED ))
+  if [ "$TOTAL" -gt 0 ]; then
+    NAMES=$(grep -E ": Copied \((new|replaced existing)\)" "$RUN_LOG" \
+      | sed -E 's/^.*INFO[[:space:]]*:[[:space:]]*//; s/: Copied.*$//' | head -10)
+    MSG="📥 Dropbox-Intake: ${COPIED} nuovi file → Drive/Dropbox-Intake"
+    [ "$REPLACED" -gt 0 ] && MSG="${MSG} (+${REPLACED} aggiornati)"
+    MSG="${MSG}
+${NAMES}"
+    EXTRA=$(( TOTAL - 10 ))
+    [ "$EXTRA" -gt 0 ] && MSG="${MSG}
+… +${EXTRA} altri"
+    telegram "$MSG"
+  fi
+fi
+
+printf '{"job":"dropbox_intake","ts":%s,"status":"%s","copied":%s,"replaced":%s,"elapsed":%s,"host":"%s"}\n' \
+  "$(date +%s)" "$([ "$RC" -eq 0 ] && echo ok || echo fail)" "$COPIED" "$REPLACED" "$ELAPSED" "$(hostname -s)" \
+  > "$STATE_FILE"
+
+# Keep last 100 run logs.
+ls -t "${LOG_DIR}"/run-*.log 2>/dev/null | tail -n +101 | xargs rm -f 2>/dev/null || true
+
+exit "$RC"


### PR DESCRIPTION
## Summary
- New automated flow: every file landing in the Bali Zero Dropbox (`data.bayusantero@gmail.com`) is **copied** to Google Drive (`antonellosiano@gmail.com`) under `Dropbox-Intake/`, mirroring the folder structure.
- **COPY ONLY invariant** (operator decision 2026-06-12): Dropbox is never emptied — no move/sync/purge, Drive accumulates.
- Pieces: sync script (rclone copy, single-instance lock, bwlimit 4M, Telegram digest on new files + cooldown-deduped failure alert, sentinel state JSON), LaunchAgent plist (10 min, NO KeepAlive — cron not daemon per scar W67; `__HOME__` placeholder per W50-family; zero secrets in plist per scar 2026-04-29), idempotent installer, runbook.

## Already live (L2)
Deployed on Pro 2026-06-12 and verified:
- E2E selftest PASS: file written to Dropbox → copied to Drive in 17s (`copied=1`, state JSON ok, Telegram digest sent).
- LaunchAgent `com.balizero.dropbox-intake` armed (`state=running, runs=1`) — initial ~527 GiB backfill in progress under the lock.
- Side effect of the same OAuth re-auth: the `gdrive` rclone remote (wiped 2026-05-25) is restored → un-breaks `nuzantara-drive-sync.sh` (was CRITICAL every 12h for 18 days) and the `gdrive-*-backup.sh` 04:00 family.

## Test plan
- [x] `bash -n` + `plutil -lint` green
- [x] E2E selftest on Pro (Dropbox → Drive, 17s)
- [x] LaunchAgent armed and running
- [ ] CI required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)