### PR TITLE
fix(intake): ocr_vision role -> qwen2.5vl:7b — dead qwen3-vl primary poisons OCR

### DIFF
--- a/MODEL_TOPOLOGY.json
+++ b/MODEL_TOPOLOGY.json
@@ -35,7 +35,7 @@
     "translation": "gemma3:27b",
     "kg_json": "gemma4:26b",
     "vision": "qwen2.5vl:7b",
-    "ocr_vision": "qwen3-vl:8b",
+    "ocr_vision": "qwen2.5vl:7b",
     "intake_extraction": "aisingapore/Qwen-SEA-LION-v4-32B-IT:q4_k_m",
     "reasoning": "deepseek-r1:32b",
     "fast": "qwen3.5:9b",


### PR DESCRIPTION
## Problem

The 2026-06-12 intake backlog run poisoned **782/812** `review_pending` proposals with empty OCR (<30 chars).

Root cause (two compounding failures):

1. **Dead primary**: the `qwen3-vl:8b` OCR primary always fails empty — documented in `classify.py`'s 2026-06-04 note. Every page paid a doomed first call.
2. **Dual model-swap thrash**: under batch load, alternating `qwen3-vl:8b` ↔ `qwen2.5vl:7b` per page drove Ollama into 500s, so the `qwen2.5vl:7b` fallback failed too → empty OCR persisted as "successful" proposals.

## Fix

One line in `MODEL_TOPOLOGY.json`: route the `ocr_vision` role straight to `qwen2.5vl:7b` (read by `backend/services/intake/model_roles.py` from `INTAKE_REPO_ROOT`). A single model removes both the model-swap thrash and the dead primary call. `qwen2.5vl:7b` is the project's invariant vision/OCR model (CLAUDE.md §9).

## Rollout plan

1. Merge → on the Pro: `cd ~/Desktop/nuzantara-deploy && git pull --ff-only origin main`
2. GATE: `python3 -c "import json; print(json.load(open('MODEL_TOPOLOGY.json'))['roles']['ocr_vision'])"` → must print `qwen2.5vl:7b`
3. `launchctl kickstart -k gui/501/com.nuzantara.intake-worker`
4. Reprocess the poisoned backlog: `scripts/intake_reprocess_backlog.py --reprocess --pipeline-version v2.2-ocrfix` (dry-run gate ~782 rows, then `--apply`)
5. Verify cure: sample first jobs completed under `v2.2-ocrfix` — OCR text lengths must be mostly >100 chars, per-job duration honest (~60-180s)

## Follow-ups (not in this PR)

- Raise `TransientStageError` when BOTH OCR calls error (instead of persisting an empty-OCR proposal as success)
- `doc_type` / `decision` filters in the intake review UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)