### PR TITLE
feat(wr2): ingest-external — register hand-published IG posts (IG-feedback STRATO 3)

### DIFF
--- a/apps/backend-rag/backend/tests/unit/scripts/test_wr2_queue_writer.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_wr2_queue_writer.py
@@ -242,3 +242,83 @@ def test_load_queue_tolerates_items_wrapper(tmp_path):
     p.write_text(json.dumps({"items": [_old_schema_item("a")]}))
     loaded = qw.load_queue(p)
     assert isinstance(loaded, list) and qw.item_id_of(loaded[0]) == "a"
+
+
+# ── extract_ig_shortcode / build_external_item ─────────────────────────────
+
+
+@pytest.mark.parametrize("url,code", [
+    ("https://www.instagram.com/p/Cabc123_-/", "Cabc123_-"),
+    ("https://instagram.com/reel/Xyz789/", "Xyz789"),
+    ("http://instagram.com/tv/Abc/?igshid=x", "Abc"),
+])
+def test_extract_ig_shortcode(url, code):
+    assert qw.extract_ig_shortcode(url) == code
+
+
+def test_extract_ig_shortcode_none_on_profile():
+    assert qw.extract_ig_shortcode("https://instagram.com/balizero0") is None
+
+
+def test_build_external_item_scraper_shape():
+    it = qw.build_external_item(VALID_URL, "2026-06-10T00:00:00+00:00", topic="My post")
+    assert it["item_id"] == "ig-Cabc123_-"
+    assert it["state"] == "published"
+    assert it["instagram_post_url"] == VALID_URL
+    assert it["instagram_published_at"] == "2026-06-10T00:00:00+00:00"
+    assert not it["engagement_metrics"]
+    assert it["external"] is True and it["source"] == "manual_external"
+    assert it["topic"] == "My post"
+
+
+def test_build_external_item_auto_topic():
+    it = qw.build_external_item(VALID_URL, "2026-06-10T00:00:00+00:00")
+    assert "Cabc123_-" in it["topic"]
+
+
+# ── ingest_external_post — orchestration ───────────────────────────────────
+
+
+def test_ingest_external_mints_published_item(queue_file):
+    before = len(json.loads(queue_file.read_text()))
+    res = qw.ingest_external_post(queue_file, VALID_URL, topic="Zero's post")
+    assert res.status == "ingested" and res.ok is True
+    items = json.loads(queue_file.read_text())
+    assert len(items) == before + 1
+    new = next(i for i in items if qw.item_id_of(i) == "ig-Cabc123_-")
+    assert new["state"] == "published" and new["instagram_post_url"] == VALID_URL
+    assert new["topic"] == "Zero's post"
+
+
+def test_ingest_external_default_published_at_is_scraper_eligible(queue_file):
+    # Default published_at must be >24h in the past so the scraper picks it up now.
+    from datetime import datetime, timezone
+    qw.ingest_external_post(queue_file, VALID_URL)
+    items = json.loads(queue_file.read_text())
+    new = next(i for i in items if qw.item_id_of(i) == "ig-Cabc123_-")
+    pub = datetime.fromisoformat(new["instagram_published_at"])
+    age_hours = (datetime.now(timezone.utc) - pub).total_seconds() / 3600
+    assert age_hours >= 24
+
+
+def test_ingest_external_idempotent_same_url(queue_file):
+    qw.ingest_external_post(queue_file, VALID_URL)
+    n_after_first = len(json.loads(queue_file.read_text()))
+    res = qw.ingest_external_post(queue_file, VALID_URL)
+    assert res.status == "already_present" and res.ok is True
+    assert len(json.loads(queue_file.read_text())) == n_after_first  # no duplicate
+
+
+def test_ingest_external_invalid_url_no_write(queue_file):
+    before = queue_file.read_text()
+    res = qw.ingest_external_post(queue_file, "https://example.com/p/x")
+    assert res.status == "invalid_url" and res.ok is False
+    assert queue_file.read_text() == before
+
+
+def test_ingest_external_explicit_date(queue_file):
+    res = qw.ingest_external_post(queue_file, VALID_URL, published_at="2026-05-01T12:00:00+00:00")
+    assert res.ok
+    items = json.loads(queue_file.read_text())
+    new = next(i for i in items if qw.item_id_of(i) == "ig-Cabc123_-")
+    assert new["instagram_published_at"] == "2026-05-01T12:00:00+00:00"

--- a/docs/runbooks/wr2-ig-feedback-loop.md
+++ b/docs/runbooks/wr2-ig-feedback-loop.md
@@ -71,6 +71,35 @@ The scraper picks the item up on its next daily run, ≥24h after `published_at`
 
 ---
 
+## Externally-published posts (STRATO 3 — posts NOT from the WR2 pipeline)
+
+For IG posts published BY HAND (e.g. by Zero) that never went through the WR2
+pipeline, there is no queue item to advance — so mint a fresh `published` item
+directly from the URL:
+
+```bash
+python scripts/wr2_queue_writer.py ingest-external https://instagram.com/p/XYZ \
+  --topic "What the post is about" \
+  --at 2026-05-20T00:00:00+00:00      # real publication date (optional)
+```
+
+- `--topic` is optional (auto-labelled from the shortcode if omitted).
+- `--at` is the real publication date. **If omitted it defaults to 25h ago**, so
+  the post is IMMEDIATELY eligible for the scraper (these posts are already live;
+  we are not waiting for a fresh-publish window).
+- The minted item id is `ig-<shortcode>`, `external: true`,
+  `source: "manual_external"` — the IG analyst can tell it apart from real WR2
+  caroselli (it lacks the archetype/domain/audience attributes).
+- Idempotent on the URL: re-ingesting the same post is a no-op
+  (`already_present`). A non-IG URL is `invalid_url` and writes nothing.
+
+> To bulk-register Zero's own back-catalogue, run `ingest-external` once per URL
+> (the account is login-walled, so the URLs are pasted by hand or exported from
+> Meta Business Suite — there is no logged-in scraping session on the Pro). The
+> scraper then collects engagement for them on its next ≥24h run.
+
+---
+
 ## Automatic operation (STRATO 2 — requires activation)
 
 ### One-time activation (operator — Antonello)

--- a/scripts/wr2_queue_writer.py
+++ b/scripts/wr2_queue_writer.py
@@ -53,7 +53,7 @@ import re
 import sys
 import tempfile
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional
 
@@ -117,6 +117,46 @@ def normalize_ref_code(raw: str) -> str:
 def validate_ig_url(url: str) -> bool:
     """True iff `url` looks like a real instagram post/reel/tv permalink."""
     return bool(_IG_URL_RE.match(url.strip()))
+
+
+_IG_SHORTCODE_RE = re.compile(
+    r"instagram\.com/(?:p|reel|tv)/([A-Za-z0-9_-]+)", re.IGNORECASE
+)
+
+
+def extract_ig_shortcode(url: str) -> Optional[str]:
+    """Return the IG shortcode (the /p/<code>/ segment) of a permalink, else None."""
+    m = _IG_SHORTCODE_RE.search(url.strip())
+    return m.group(1) if m else None
+
+
+def build_external_item(
+    ig_url: str, published_at_iso: str, topic: Optional[str] = None
+) -> dict[str, Any]:
+    """Build a fresh, published queue item for an EXTERNALLY-published IG post.
+
+    Used for posts published by hand (e.g. by Zero) that never went through the
+    WR2 pipeline — there is no pre-existing queue item to advance, so we mint
+    one already in the scraper-consumable `published` shape. The id is
+    `ig-<shortcode>` (deterministic from the URL → idempotent). `external=True`
+    and `source="manual_external"` flag it so the IG analyst knows it lacks the
+    full WR2 attributes (archetype/domain/audience).
+    """
+    url = ig_url.strip()
+    shortcode = extract_ig_shortcode(url) or hashlib.sha1(url.encode()).hexdigest()[:8]
+    return {
+        "item_id": f"ig-{shortcode}",
+        "topic": topic or f"(external IG post {shortcode})",
+        "state": "published",
+        "instagram_post_url": url,
+        "instagram_published_at": published_at_iso,
+        "engagement_metrics": None,
+        "damar_action": "published",
+        "damar_action_at": published_at_iso,
+        "external": True,
+        "source": "manual_external",
+        "created_at": published_at_iso,
+    }
 
 
 def find_by_ref_code(
@@ -265,6 +305,52 @@ def mark_published(
     return PublishResult("published", True, ref, iid, f"published at {published_iso}")
 
 
+def ingest_external_post(
+    path: Path,
+    ig_url: str,
+    topic: Optional[str] = None,
+    published_at: Optional[str] = None,
+    now: Optional[datetime] = None,
+) -> PublishResult:
+    """Register an externally-published IG post (no pre-existing queue item).
+
+    For posts published by hand (e.g. by Zero) that bypassed the WR2 pipeline.
+    Mints a fresh `published` item (id `ig-<shortcode>`) so the scraper collects
+    its metrics. Idempotent on the IG URL: re-ingesting the same post is a no-op.
+
+    Default `published_at` is 25h in the past so the post is IMMEDIATELY eligible
+    for the scraper (which skips items <24h old) — these posts are already live,
+    we are not waiting for a fresh-publish window. Pass `--at` with the real
+    publication date when known.
+
+    Returns PublishResult with ref_code = compute_ref_code of the minted id.
+      * invalid_url     — not an IG permalink -> NO write
+      * already_present — a published item with the SAME url already exists -> no-op
+      * ingested        — minted + written atomically -> WRITE
+    """
+    url = ig_url.strip()
+    if not validate_ig_url(url):
+        return PublishResult("invalid_url", False, "", detail=f"not an IG permalink: {ig_url!r}")
+
+    items = load_queue(path)
+    for existing in items:
+        if (existing.get("instagram_post_url") or "").strip() == url:
+            iid = item_id_of(existing)
+            return PublishResult(
+                "already_present", True, compute_ref_code(iid or url), iid,
+                "no-op: this IG URL is already registered",
+            )
+
+    published_iso = published_at or (
+        (now or datetime.now(timezone.utc)) - timedelta(hours=25)
+    ).isoformat()
+    new_item = build_external_item(url, published_iso, topic=topic)
+    items.append(new_item)
+    write_queue_atomic(path, items)
+    iid = new_item["item_id"]
+    return PublishResult("ingested", True, compute_ref_code(iid), iid, f"registered external post {iid}")
+
+
 # ── CLI ────────────────────────────────────────────────────────────────────
 
 
@@ -313,6 +399,13 @@ def _cmd_mark_published(args: argparse.Namespace) -> int:
     return 0 if result.ok else 1
 
 
+def _cmd_ingest_external(args: argparse.Namespace) -> int:
+    path = _resolve_queue_path(args.queue)
+    result = ingest_external_post(path, args.ig_url, topic=args.topic, published_at=args.at)
+    print(json.dumps(result.as_dict(), ensure_ascii=False))
+    return 0 if result.ok else 1
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description="WR2 publish-feedback queue writer")
     p.add_argument("--queue", help="path to human-review-queue.json (default: env WR2_QUEUE_PATH or standard)")
@@ -331,6 +424,15 @@ def build_parser() -> argparse.ArgumentParser:
     mp.add_argument("ig_url")
     mp.add_argument("--at", help="ISO timestamp of publication (default: now UTC)")
     mp.set_defaults(func=_cmd_mark_published)
+
+    ie = sub.add_parser(
+        "ingest-external",
+        help="register an externally-published IG post (no pre-existing queue item)",
+    )
+    ie.add_argument("ig_url")
+    ie.add_argument("--topic", help="human label for the post (default: auto from shortcode)")
+    ie.add_argument("--at", help="ISO publication date (default: 25h ago, so it's immediately scraper-eligible)")
+    ie.set_defaults(func=_cmd_ingest_external)
     return p
 
 


### PR DESCRIPTION
## Cosa

STRATO 3 del loop IG-metrics: registra i post Instagram pubblicati A MANO da Zero su @balizero0 (fuori dalla pipeline WR2) così che lo scraper ne raccolga le metriche.

## Perché

I 44 caroselli della pipeline non sono mai andati online; i post che Zero ha pubblicato a mano NON hanno un item-queue da avanzare (STRATO 1 `mark-published` richiede un item esistente). Serviva creare l'item da zero a partire dall'URL.

## Come

```
wr2_queue_writer.py ingest-external <ig_url> [--topic ...] [--at ISO]
```

Conia un item `published` (id `ig-<shortcode>`, `external=true`, `source=manual_external`) nella forma esatta che lo scraper consuma. I flag `external`/`source` segnalano all'analista che manca degli attributi WR2 (archetype/domain/audience).

- Default `published_at` = 25h fa → **subito** eleggibile per lo scraper (che salta gli item <24h; questi post sono già online, niente finestra da aspettare). `--at` per la data reale.
- Idempotente sull'URL (`already_present` no-op, niente duplicati); URL non-IG → `invalid_url`, non scrive.

## Verifica

- 11 nuovi test, **36/36** nella suite del writer, ruff clean.
- Fire-test su copia queue: ingest → item esterno `published` → la select dello scraper ritorna True a 25h d'età.

## Uso (back-catalogue di Zero)

L'account @balizero0 è dietro login-wall senza sessione loggata sul Pro → gli URL si incollano a mano o si esportano da Meta Business Suite, un `ingest-external` per URL. Sezione runbook STRATO 3 aggiunta in `docs/runbooks/wr2-ig-feedback-loop.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)