### PR TITLE
feat(intake): wire Drive as second intake source — scoped drain + folder-name routing signal (m227)

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/227_intake_queue_source_path.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/227_intake_queue_source_path.sql
@@ -1,0 +1,28 @@
+-- Migration 227: intake_queue.source_path — WHERE the blob came from (entity signal).
+--
+-- Drive-intake wiring (smistamento CRM). The Dropbox→Drive copy job mirrors the
+-- Dropbox folder structure under Drive/Dropbox-Intake/, and those folders are
+-- named after clients/practices ("BUDI SANTOSO", "Jane Doe", ...). The transport
+-- layer therefore KNOWS the likely subject of every blob — exactly like m225's
+-- sender_phone knows who sent a WhatsApp document. Persisting the path relative
+-- to the watched root ("<Client Name>/passport.jpg") lets FASE-4 routing
+-- fuzzy-match the first segment against clients.full_name / companies.
+-- company_name (a ~0.85 signal — folders are human-typed and can hold a whole
+-- family's documents, so it ranks BELOW the phone signal and never auto-attaches
+-- alone).
+--
+-- Pure additive nullable column. NULL stays valid for whatsapp/zoho sources.
+--
+-- On the Pro apply manually like 212-226:
+--   psql postgresql://nuzantara@127.0.0.1:5432/nuzantara_dev \
+--     -f apps/backend-rag/backend/db/migrations_v2/227_intake_queue_source_path.sql
+-- === FORWARD ===
+
+ALTER TABLE intake_queue
+    ADD COLUMN IF NOT EXISTS source_path TEXT;
+
+COMMENT ON COLUMN intake_queue.source_path IS
+    'Blob path relative to the watched Drive root (e.g. "<Client Name>/passport.jpg", migration 227). First segment is the folder-name entity signal for FASE-4 routing. NULL for sources without a folder (whatsapp/zoho).';
+
+-- === ROLLBACK ===
+-- ALTER TABLE intake_queue DROP COLUMN IF EXISTS source_path;

--- a/apps/backend-rag/backend/services/intake/drive_adapter.py
+++ b/apps/backend-rag/backend/services/intake/drive_adapter.py
@@ -1,15 +1,22 @@
-"""Drive intake adapter (FASE 1B).
+"""Drive intake adapter (FASE 1B, scoped + path-aware since m227).
 
 Forks the blob-enumeration logic of the existing Drive poller
 (`backend/services/crm/drive_poll_service.py` + `ServiceAccountDriveService.
 list_changes_since`) but does NOT process/route into CRM — it downloads each
 changed file to a local intake blob dir and calls enqueue().
 
+Scope (m227): the adapter REQUIRES ``INTAKE_DRIVE_SCOPE_FOLDER_ID`` (the Drive
+folder id of the watched root, e.g. Dropbox-Intake/). The Drive changes API is
+account-wide — without the scope filter this adapter would ingest the codebase
+mirror, the nightly backups and every other Drive write. Files whose ancestor
+chain does not reach the scope folder are skipped. The ancestor walk also yields
+the path RELATIVE to the scope root ("<Client Name>/passport.jpg"), persisted as
+``intake_queue.source_path`` — the folder-name entity signal for FASE-4 routing.
+
 ZERO CRM writes. PII stays local: blobs are written under INTAKE_BLOB_ROOT on
-the Pro, never shipped to cloud LLMs here. Cursor reuses the existing
-`system_settings` key `drive_poll_page_token` (read-only fork — this adapter
-advances its OWN cursor key `intake_drive_page_token` so it does not fight the
-production poller).
+the Pro, never shipped to cloud LLMs here. Cursor: this adapter advances its
+OWN ``system_settings`` key ``intake_drive_page_token`` so it does not fight
+the production poller (``drive_poll_page_token``).
 """
 
 from __future__ import annotations
@@ -17,6 +24,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
+from typing import Any
 
 import asyncpg
 
@@ -27,6 +35,10 @@ logger = logging.getLogger(__name__)
 _SOURCE = "drive"
 _CURSOR_KEY = "intake_drive_page_token"
 
+# Drive folder id of the watched root (e.g. Dropbox-Intake/). REQUIRED —
+# fail-safe: without it the adapter refuses to ingest anything.
+_SCOPE_ENV = "INTAKE_DRIVE_SCOPE_FOLDER_ID"
+
 # Local blob landing dir (PII stays on the Pro). Override via env.
 _BLOB_ROOT = Path(
     os.environ.get("INTAKE_BLOB_ROOT", os.path.expanduser("~/.nuzantara/intake-blobs"))
@@ -34,6 +46,9 @@ _BLOB_ROOT = Path(
 
 # Drive native/Google-Doc mime types we skip (no binary blob to hash).
 _GOOGLE_NATIVE_PREFIX = "application/vnd.google-apps"
+
+# Max parent-chain hops before declaring a file out of scope (defensive cap).
+_MAX_ANCESTOR_DEPTH = 12
 
 
 def _local_blob_path(file_id: str, file_name: str) -> Path:
@@ -63,20 +78,67 @@ async def _download_file(drive_service, file_id: str, dest: Path) -> int:
     return len(data)
 
 
+async def _folder_meta(drive_service, folder_id: str) -> dict[str, Any]:
+    """files.get for one ancestor folder (id, name, parents)."""
+    import asyncio
+
+    def _blocking_get() -> dict[str, Any]:
+        return (
+            drive_service.service.files()
+            .get(fileId=folder_id, fields="id, name, parents", supportsAllDrives=True)
+            .execute()
+        )
+
+    return await asyncio.to_thread(_blocking_get)
+
+
+async def _resolve_relative_dir(
+    drive_service,
+    parents: list[str] | None,
+    scope_id: str,
+    cache: dict[str, dict[str, Any]],
+) -> str | None:
+    """Walk the parent chain up to the scope folder.
+
+    Returns the folder path RELATIVE to the scope root ("" for a direct child,
+    "A/B" for nested), or None when the chain never reaches ``scope_id``
+    (= out of scope). ``cache`` memoizes folder lookups within one drain tick.
+    """
+    cur = (parents or [None])[0]
+    segments: list[str] = []
+    depth = 0
+    while cur and depth < _MAX_ANCESTOR_DEPTH:
+        if cur == scope_id:
+            return "/".join(reversed(segments))
+        meta = cache.get(cur)
+        if meta is None:
+            try:
+                meta = await _folder_meta(drive_service, cur)
+            except Exception as exc:
+                logger.warning("drain_drive: ancestor walk failed at %s (%s)", cur, exc)
+                return None
+            cache[cur] = meta
+        segments.append(meta.get("name") or cur)
+        cur = (meta.get("parents") or [None])[0]
+        depth += 1
+    return None
+
+
 async def drain_drive(
     pool: asyncpg.Pool,
     *,
     drive_service=None,
     limit: int = 500,
 ) -> dict[str, int]:
-    """Enumerate Drive changes since the intake cursor, enqueue new blobs.
+    """Enumerate Drive changes since the intake cursor, enqueue in-scope blobs.
 
     `drive_service` is a ServiceAccountDriveService instance; if None, this
     adapter attempts to build one and degrades gracefully (WARN + return zeros)
-    if Drive is not configured/reachable (Law 4).
+    if Drive is not configured/reachable (Law 4). ``INTAKE_DRIVE_SCOPE_FOLDER_ID``
+    must point at the watched root folder, else the drain refuses to run.
 
     Returns counters: {changes, enqueued_new, already_present, skipped_native,
-    skipped_removed, errors}.
+    skipped_removed, skipped_out_of_scope, errors}.
     """
     counters = {
         "changes": 0,
@@ -84,8 +146,17 @@ async def drain_drive(
         "already_present": 0,
         "skipped_native": 0,
         "skipped_removed": 0,
+        "skipped_out_of_scope": 0,
         "errors": 0,
     }
+
+    scope_id = os.environ.get(_SCOPE_ENV, "").strip()
+    if not scope_id:
+        logger.warning(
+            "drain_drive: %s not set — refusing to ingest the whole Drive "
+            "(fail-safe), skipping", _SCOPE_ENV,
+        )
+        return counters
 
     if drive_service is None:
         try:
@@ -94,7 +165,7 @@ async def drain_drive(
             )
 
             drive_service = ServiceAccountDriveService()
-        except Exception as exc:  # noqa: BLE001 — graceful degradation (Law 4)
+        except Exception as exc:
             logger.warning("drain_drive: Drive service unavailable, skipping (%s)", exc)
             return counters
 
@@ -117,12 +188,14 @@ async def drain_drive(
         if not page_token:
             page_token = await drive_service.get_start_page_token()
         result = await drive_service.list_changes_since(page_token)
-    except Exception as exc:  # noqa: BLE001 — graceful degradation (Law 4)
+    except Exception as exc:
         logger.warning("drain_drive: Drive enumeration failed, skipping (%s)", exc)
         return counters
 
     changes = result.get("changes", [])[:limit]
     counters["changes"] = len(changes)
+
+    folder_cache: dict[str, dict[str, Any]] = {}
 
     for change in changes:
         if change.get("removed"):
@@ -136,10 +209,21 @@ async def drain_drive(
         mime_type = file_meta.get("mimeType", "")
         if mime_type.startswith(_GOOGLE_NATIVE_PREFIX):
             # Google-native docs have no downloadable binary blob to hash.
+            # (Folders are google-apps.folder → also skipped here.)
             counters["skipped_native"] += 1
             continue
 
+        # Scope filter (m227): only files whose ancestor chain reaches the
+        # watched root are ingested; the walk yields the relative folder path.
+        rel_dir = await _resolve_relative_dir(
+            drive_service, file_meta.get("parents"), scope_id, folder_cache
+        )
+        if rel_dir is None:
+            counters["skipped_out_of_scope"] += 1
+            continue
+
         file_name = file_meta.get("name", file_id)
+        source_path = f"{rel_dir}/{file_name}" if rel_dir else file_name
         dest = _local_blob_path(file_id, file_name)
         try:
             byte_size = await _download_file(drive_service, file_id, dest)
@@ -150,8 +234,9 @@ async def drain_drive(
                 blob_path=dest,
                 mime_type=mime_type or None,
                 byte_size=byte_size,
+                source_path=source_path,
             )
-        except Exception:  # noqa: BLE001 — adapter must not crash the drain loop
+        except Exception:
             logger.exception("drain_drive enqueue failed for file_id=%s", file_id)
             counters["errors"] += 1
             continue

--- a/apps/backend-rag/backend/services/intake/enqueue.py
+++ b/apps/backend-rag/backend/services/intake/enqueue.py
@@ -79,6 +79,7 @@ async def enqueue(
     byte_size: int | None = None,
     received_by: str | None = None,
     sender_phone: str | None = None,
+    source_path: str | None = None,
     pipeline_version: str = PIPELINE_VERSION,
 ) -> EnqueueResult:
     """Idempotently register a blob and enqueue it for processing.
@@ -145,19 +146,22 @@ async def enqueue(
             #    document (live-WhatsApp path only; NULL for drive/zoho/export).
             #    sender_phone (m225) records WHO SENT it (raw transport value;
             #    routing normalizes + matches it against clients.phone_normalized).
+            #    source_path (m227) records WHERE the blob came from relative to
+            #    the watched Drive root (folder name = client-name signal; NULL
+            #    for whatsapp/zoho).
             queue_id = await conn.fetchval(
                 """
                 INSERT INTO intake_queue
                     (instance_id, source, source_ref, blob_path, blob_hash,
                      text_hash, phash, client_id_hint, received_by, sender_phone,
-                     pipeline_version, intake_key)
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+                     source_path, pipeline_version, intake_key)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
                 ON CONFLICT (intake_key) DO NOTHING
                 RETURNING id
                 """,
                 instance_id, source, source_ref, blob_path_str, blob_hash,
                 text_hash, phash, client_id_hint, received_by, sender_phone,
-                pipeline_version, intake_key,
+                source_path, pipeline_version, intake_key,
             )
             was_new = queue_id is not None
             if queue_id is None:

--- a/apps/backend-rag/backend/services/intake/routing.py
+++ b/apps/backend-rag/backend/services/intake/routing.py
@@ -13,7 +13,7 @@ cloud, zero third-party endpoints.
 
 Reuse (reuse-first discipline)
 ------------------------------
-* ``backend.services.crm.client_core.validate_passport`` — passport normaliser
+* ``backend.services.crm.client_core.validate_passport`` — passport-number normaliser
   (upper-case + format guard), reused so the document identifier is normalised
   the same way the CRM stores/validates it.
 * The pg_trgm ``%`` / ``similarity()`` fuzzy-name + ambiguity-margin cascade is
@@ -76,6 +76,12 @@ CONF_STRONG_EXACT = 0.99
 CONF_PHONE_MATCH = 0.90
 # Boost applied when sender phone AND fuzzy name agree on the same client.
 PHONE_NAME_AGREE_BOOST = 0.05
+
+# Folder-name match (m227). Drive-intake blobs arrive under a per-client folder
+# (Dropbox-Intake/<Client Name>/...): the transport layer knows WHICH FOLDER the
+# blob came from, like the phone knows who sent it. Human-typed and shared-folder
+# prone → slightly below the phone signal and NEVER auto-attach alone.
+CONF_FOLDER_MATCH = 0.85
 
 # Doc-types whose subject is a PERSON (match against ``clients``) vs a COMPANY
 # (match against ``companies``). canonical_doc_type() upstream already maps
@@ -325,6 +331,58 @@ async def _match_sender_phone(
     ]
 
 
+def _clean_folder_segment(value: Any) -> str | None:
+    """Normalise the first path segment of ``source_path`` into a name to match.
+
+    Real Dropbox folders carry human decorations — ``###PERPANJANGAN KITAS
+    JOHN DOE###``, ``@arsip Cetak (2027)`` — so strip non-name punctuation and
+    parenthetical suffixes, collapse whitespace, reject <3 chars.
+    """
+    if value is None:
+        return None
+    seg = str(value).split("/", 1)[0]
+    seg = re.sub(r"\([^)]*\)", " ", seg)        # drop parenthetical suffixes
+    seg = re.sub(r"[#@_*\[\]{}!]+", " ", seg)   # drop decoration characters
+    seg = re.sub(r"\s+", " ", seg).strip()
+    if len(seg) < 3:
+        return None
+    return seg
+
+
+async def _match_folder_name(
+    conn: asyncpg.Connection, source_path: str | None
+) -> list[dict[str, Any]]:
+    """Folder-name match (m227): first ``source_path`` segment vs CRM names.
+
+    Fuzzy (pg_trgm) against ``clients.full_name`` AND ``companies.company_name``;
+    only a similarity >= FUZZY_APPLY_THRESHOLD counts as a transport hint (a weak
+    folder sim is noise — unlike the OCR-name fuzzy, which has its own review
+    band). One clear winner → a single CONF_FOLDER_MATCH candidate; top-2 inside
+    the ambiguity margin → both returned so the decision matrix degrades to
+    AMBIGUOUS rather than guessing.
+    """
+    name = _clean_folder_segment(source_path)
+    if not name:
+        return []
+    merged = await _match_fuzzy_name(conn, "clients", "full_name", name)
+    merged += await _match_fuzzy_name(conn, "companies", "company_name", name)
+    usable = [c for c in merged if c["score"] >= FUZZY_APPLY_THRESHOLD]
+    usable.sort(key=lambda c: c["score"], reverse=True)
+    if not usable:
+        return []
+
+    def _as_hint(c: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "table": c["table"], "id": c["id"], "name": c["name"],
+            "method": "folder_name", "score": CONF_FOLDER_MATCH,
+            "matched_value": name, "basis": "folder", "folder_sim": c["score"],
+        }
+
+    if len(usable) >= 2 and usable[0]["score"] - usable[1]["score"] < AMBIGUITY_MARGIN:
+        return [_as_hint(usable[0]), _as_hint(usable[1])]
+    return [_as_hint(usable[0])]
+
+
 async def _match_fuzzy_name(
     conn: asyncpg.Connection, table: str, name_col: str, name: str
 ) -> list[dict[str, Any]]:
@@ -360,17 +418,24 @@ def _classify_decision(
     fuzzy: list[dict[str, Any]],
     phone: list[dict[str, Any]] | None = None,
 ) -> tuple[str, list[dict[str, Any]], dict[str, Any]]:
-    """Apply the C4 decision matrix to strong + phone + fuzzy candidate lists.
+    """Apply the C4 decision matrix to strong + transport-hint + fuzzy lists.
 
-    Precedence: strong document identifiers > sender-phone exact match (m225)
-    > fuzzy name. The phone signal NEVER yields AUTO_ATTACH on its own (a phone
-    can be shared by spouse/agent): alone it is a LINK_CANDIDATE; agreeing with
-    the top fuzzy name it is a boosted LINK_CANDIDATE; disagreeing, BOTH are
-    surfaced for review; shared by >1 client it degrades to AMBIGUOUS.
+    ``phone`` carries the transport-layer hint candidates — sender-phone (m225)
+    or folder-name (m227); each candidate self-describes via its ``basis`` key.
+    Precedence: strong document identifiers > transport hint > fuzzy name. The
+    hint NEVER yields AUTO_ATTACH on its own (a phone can be shared by
+    spouse/agent; a folder can hold a family's documents): alone it is a
+    LINK_CANDIDATE; agreeing with the top fuzzy name it is a boosted
+    LINK_CANDIDATE; disagreeing, BOTH are surfaced for review; matching >1 row
+    it degrades to AMBIGUOUS.
 
     Returns ``(decision, candidates, reason)``.
     """
     phone = list(phone or [])
+    hint_label = (
+        "folder name" if phone and phone[0].get("basis") == "folder" else "sender phone"
+    )
+    hint_score_key = "folder_score" if hint_label == "folder name" else "phone_score"
 
     # De-dup strong candidates by (table, id).
     seen: set[tuple[str, int]] = set()
@@ -397,37 +462,37 @@ def _classify_decision(
     usable = [c for c in fuzzy if c["score"] >= FUZZY_REVIEW_LOW]
     usable.sort(key=lambda c: c["score"], reverse=True)
 
-    # 2) Sender-phone signal (no strong identifier resolved).
+    # 2) Transport-hint signal — sender phone / folder name (no strong id).
     if phone:
         if len(phone) > 1:
             return DECISION_AMBIGUOUS, phone, {
-                "reason": f"{len(phone)} clients share the sender phone",
+                "reason": f"{len(phone)} clients share the {hint_label}",
             }
         pc = phone[0]
         if usable:
             top_f = usable[0]
             if top_f["table"] == pc["table"] and top_f["id"] == pc["id"]:
-                # Phone + name agree on the same client → boosted candidate.
+                # Hint + name agree on the same client → boosted candidate.
                 boosted = dict(pc)
                 boosted["score"] = round(
                     min(CONF_STRONG_EXACT - 0.01, pc["score"] + PHONE_NAME_AGREE_BOOST), 4
                 )
                 boosted["method"] = f"{pc['method']}+{top_f['method']}"
                 return DECISION_LINK_CANDIDATE, [boosted], {
-                    "reason": "sender phone and fuzzy name agree on the same client",
-                    "phone_score": pc["score"], "name_sim": top_f["score"],
+                    "reason": f"{hint_label} and fuzzy name agree on the same client",
+                    hint_score_key: pc["score"], "name_sim": top_f["score"],
                 }
-            # Phone and name point at DIFFERENT rows → surface both for review.
+            # Hint and name point at DIFFERENT rows → surface both for review.
             return DECISION_LINK_CANDIDATE, [pc, top_f], {
-                "reason": "sender phone and fuzzy name disagree — review both",
-                "phone_score": pc["score"], "name_sim": top_f["score"],
+                "reason": f"{hint_label} and fuzzy name disagree — review both",
+                hint_score_key: pc["score"], "name_sim": top_f["score"],
             }
         return DECISION_LINK_CANDIDATE, [pc], {
-            "reason": "sender phone exact match (no strong identifier, no fuzzy name)",
-            "phone_score": pc["score"],
+            "reason": f"{hint_label} match (no strong identifier, no fuzzy name)",
+            hint_score_key: pc["score"],
         }
 
-    # 3) No strong identifier, no phone → fuzzy name candidates only.
+    # 3) No strong identifier, no transport hint → fuzzy name candidates only.
     if not usable:
         return DECISION_NO_MATCH, [], {"reason": "no strong identifier, no fuzzy name >= 0.40"}
 
@@ -461,12 +526,16 @@ async def resolve_entity(
     pool: asyncpg.Pool | asyncpg.Connection,
     *,
     sender_phone: str | None = None,
+    source_path: str | None = None,
 ) -> dict[str, Any]:
     """Resolve the document subject against existing CRM rows (READ-ONLY).
 
     ``sender_phone`` (m225) is the raw transport-layer sender number; it is
     consulted only when no strong document identifier matched, as a
     high-confidence (~0.90) person hint — see :func:`_classify_decision`.
+    ``source_path`` (m227) is the Drive-intake folder path relative to the
+    watched root (``<Client Name>/file.pdf``); its first segment is consulted
+    only when neither a strong identifier nor the phone resolved (~0.85 hint).
 
     Returns a dict::
 
@@ -513,6 +582,14 @@ async def resolve_entity(
             phone = await _match_sender_phone(conn, sender_phone)
             if phone and subject_kind == "unknown":
                 subject_kind = "person"
+
+        # Folder-name signal (m227) — Drive intake knows WHICH FOLDER the blob
+        # arrived in (Dropbox-Intake/<Client Name>/...). Consulted only when
+        # neither a strong identifier nor the sender phone resolved.
+        if not strong and not phone and source_path:
+            phone = await _match_folder_name(conn, source_path)
+            if phone and subject_kind == "unknown":
+                subject_kind = "person" if phone[0]["table"] == "clients" else "company"
 
         # Fuzzy name fallback (only matters when no strong identifier resolved).
         if not strong:
@@ -631,6 +708,7 @@ async def build_routing_proposal(
     doc_index: int = 0,
     pipeline_version: str = PIPELINE_VERSION_DEFAULT,
     sender_phone: str | None = None,
+    source_path: str | None = None,
 ) -> dict[str, Any]:
     """Build (but do NOT persist) the routing proposal payload.
 
@@ -638,7 +716,10 @@ async def build_routing_proposal(
     into ``document_routing_proposal``.
     """
     async def _run(conn: asyncpg.Connection) -> dict[str, Any]:
-        entity = await resolve_entity(extracted, doc_type, conn, sender_phone=sender_phone)
+        entity = await resolve_entity(
+            extracted, doc_type, conn,
+            sender_phone=sender_phone, source_path=source_path,
+        )
         target = await _resolve_routing_target(conn, entity)
 
         decision = entity["decision"]
@@ -771,10 +852,12 @@ async def route_stage(job: dict, stage: str, pool: asyncpg.Pool) -> dict:  # noq
         # reach _make_routing_key, else the old routing_key collides and
         # ON CONFLICT silently drops the fresh proposal.
         qrow = await conn.fetchrow(
-            "SELECT sender_phone, pipeline_version FROM intake_queue WHERE id = $1",
+            "SELECT sender_phone, source_path, pipeline_version"
+            " FROM intake_queue WHERE id = $1",
             queue_id,
         )
         sender_phone = job.get("sender_phone") or (qrow["sender_phone"] if qrow else None)
+        source_path = job.get("source_path") or (qrow["source_path"] if qrow else None)
         pipeline_version = (
             job.get("pipeline_version")
             or (qrow["pipeline_version"] if qrow else None)
@@ -785,6 +868,7 @@ async def route_stage(job: dict, stage: str, pool: asyncpg.Pool) -> dict:  # noq
             queue_id, fields, doc_type, conn,
             pipeline_version=pipeline_version,
             sender_phone=sender_phone,
+            source_path=source_path,
         )
 
         proposal_id = await conn.fetchval(

--- a/apps/backend-rag/backend/tests/services/intake/test_intake_drive_adapter.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_intake_drive_adapter.py
@@ -1,0 +1,172 @@
+"""Unit tests for the scoped Drive intake adapter (drain_drive, m227).
+
+PURE unit (no Postgres, no Drive): pool/conn faked, Drive API + download +
+enqueue monkeypatched. Locked behaviours:
+
+  * fail-safe: INTAKE_DRIVE_SCOPE_FOLDER_ID missing -> zero ingestion (the
+    changes API is account-wide; unscoped would swallow the codebase mirror).
+  * in-scope file -> enqueued with source='drive' + source_path relative to
+    the scope root (folder-name signal for FASE-4 routing).
+  * out-of-scope file (ancestor chain never reaches the scope id) -> skipped.
+  * direct child of the scope root -> source_path is the bare file name.
+  * google-native mime (incl. folders) -> skipped, no download.
+  * cursor: new_page_token persisted via system_settings upsert.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from backend.services.intake import drive_adapter as da
+from backend.services.intake.enqueue import EnqueueResult
+
+
+class FakeConn:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        return None  # no stored cursor
+
+    async def execute(self, query: str, *args: Any) -> str:
+        self.executed.append((query, args))
+        return "INSERT 0 1"
+
+
+class FakePool:
+    def __init__(self) -> None:
+        self.conn = FakeConn()
+
+    def acquire(self) -> Any:
+        conn = self.conn
+
+        class _Ctx:
+            async def __aenter__(self) -> FakeConn:
+                return conn
+
+            async def __aexit__(self, *exc: Any) -> bool:
+                return False
+
+        return _Ctx()
+
+
+class FakeDriveService:
+    """Stands in for ServiceAccountDriveService (changes API only)."""
+
+    def __init__(self, changes: list[dict[str, Any]], folders: dict[str, dict[str, Any]]) -> None:
+        self._changes = changes
+        self.folders = folders  # folder_id -> {id, name, parents}
+
+    async def get_start_page_token(self) -> str:
+        return "tok1"
+
+    async def list_changes_since(self, page_token: str) -> dict[str, Any]:
+        return {"changes": self._changes, "new_page_token": "tok2"}
+
+
+def _patch_io(monkeypatch: pytest.MonkeyPatch, svc: FakeDriveService) -> list[dict[str, Any]]:
+    """Patch download + folder lookup + enqueue; return the enqueue-call log."""
+    calls: list[dict[str, Any]] = []
+
+    async def _fake_download(drive_service: Any, file_id: str, dest: Any) -> int:
+        return 123
+
+    async def _fake_folder_meta(drive_service: Any, folder_id: str) -> dict[str, Any]:
+        meta = svc.folders.get(folder_id)
+        if meta is None:
+            raise FileNotFoundError(folder_id)
+        return meta
+
+    async def _fake_enqueue(pool: Any, **kwargs: Any) -> EnqueueResult:
+        calls.append(kwargs)
+        return EnqueueResult(instance_id=1, queue_id=len(calls), was_new=True)
+
+    monkeypatch.setattr(da, "_download_file", _fake_download)
+    monkeypatch.setattr(da, "_folder_meta", _fake_folder_meta)
+    monkeypatch.setattr(da, "enqueue", _fake_enqueue)
+    return calls
+
+
+def _change(file_id: str, name: str, parents: list[str], mime: str = "application/pdf") -> dict:
+    return {"fileId": file_id, "removed": False,
+            "file": {"id": file_id, "name": name, "mimeType": mime, "parents": parents}}
+
+
+@pytest.mark.asyncio
+async def test_no_scope_env_refuses_to_ingest(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("INTAKE_DRIVE_SCOPE_FOLDER_ID", raising=False)
+    svc = FakeDriveService([_change("f1", "passport.jpg", ["A"])], {})
+    calls = _patch_io(monkeypatch, svc)
+    counters = await da.drain_drive(FakePool(), drive_service=svc)
+    assert counters["changes"] == 0
+    assert counters["enqueued_new"] == 0
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_in_scope_file_enqueued_with_source_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INTAKE_DRIVE_SCOPE_FOLDER_ID", "SCOPE")
+    svc = FakeDriveService(
+        [_change("f1", "passport.jpg", ["folderA"])],
+        {"folderA": {"id": "folderA", "name": "BUDI", "parents": ["SCOPE"]}},
+    )
+    calls = _patch_io(monkeypatch, svc)
+    counters = await da.drain_drive(FakePool(), drive_service=svc)
+    assert counters["enqueued_new"] == 1
+    assert counters["skipped_out_of_scope"] == 0
+    assert calls[0]["source"] == "drive"
+    assert calls[0]["source_ref"] == "drive:f1"
+    assert calls[0]["source_path"] == "BUDI/passport.jpg"
+
+
+@pytest.mark.asyncio
+async def test_direct_child_of_scope_has_bare_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INTAKE_DRIVE_SCOPE_FOLDER_ID", "SCOPE")
+    svc = FakeDriveService([_change("f2", "loose.pdf", ["SCOPE"])], {})
+    calls = _patch_io(monkeypatch, svc)
+    counters = await da.drain_drive(FakePool(), drive_service=svc)
+    assert counters["enqueued_new"] == 1
+    assert calls[0]["source_path"] == "loose.pdf"
+
+
+@pytest.mark.asyncio
+async def test_out_of_scope_file_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INTAKE_DRIVE_SCOPE_FOLDER_ID", "SCOPE")
+    svc = FakeDriveService(
+        [_change("f3", "repo-file.py", ["folderB"])],
+        {
+            "folderB": {"id": "folderB", "name": "repo", "parents": ["ROOT"]},
+            "ROOT": {"id": "ROOT", "name": "My Drive", "parents": []},
+        },
+    )
+    calls = _patch_io(monkeypatch, svc)
+    counters = await da.drain_drive(FakePool(), drive_service=svc)
+    assert counters["skipped_out_of_scope"] == 1
+    assert counters["enqueued_new"] == 0
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_google_native_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INTAKE_DRIVE_SCOPE_FOLDER_ID", "SCOPE")
+    svc = FakeDriveService(
+        [_change("d1", "BUDI", ["SCOPE"], mime="application/vnd.google-apps.folder")],
+        {},
+    )
+    calls = _patch_io(monkeypatch, svc)
+    counters = await da.drain_drive(FakePool(), drive_service=svc)
+    assert counters["skipped_native"] == 1
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_cursor_advanced_after_drain(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INTAKE_DRIVE_SCOPE_FOLDER_ID", "SCOPE")
+    svc = FakeDriveService([_change("f4", "x.pdf", ["SCOPE"])], {})
+    _patch_io(monkeypatch, svc)
+    pool = FakePool()
+    await da.drain_drive(pool, drive_service=svc)
+    upserts = [q for q, _ in pool.conn.executed if "system_settings" in q]
+    assert len(upserts) == 1

--- a/apps/backend-rag/backend/tests/services/intake/test_intake_routing_folder.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_intake_routing_folder.py
@@ -1,0 +1,264 @@
+"""Unit tests for the FASE-4 folder-name entity signal (m227, Drive intake).
+
+PURE unit (no Postgres): the asyncpg pool/connection is faked, so these run on
+any machine/CI. Mirrors test_intake_routing_phone.py (m225) — the folder signal
+rides the same transport-hint slot in the decision matrix.
+
+Locked behaviours:
+  * _clean_folder_segment: decoration stripping, parenthetical suffixes,
+    first-segment-only, <3 chars rejected.
+  * _match_folder_name: only sim >= FUZZY_APPLY_THRESHOLD counts; one clear
+    winner -> single CONF_FOLDER_MATCH hint; top-2 within the ambiguity margin
+    -> both returned (AMBIGUOUS downstream).
+  * _classify_decision: folder hint NEVER auto-attaches; agree=boost,
+    disagree=both surfaced, >1 match=AMBIGUOUS; reason strings say
+    "folder name" (phone strings unchanged — covered by the m225 suite).
+  * resolve_entity wiring: folder consulted ONLY when no strong identifier and
+    no sender-phone resolved.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from backend.services.intake import routing as rt
+
+# ---------------------------------------------------------------------------
+# _clean_folder_segment
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("BUDI/passport.jpg", "BUDI"),
+        ("Jane Doe/kitas/scan.pdf", "Jane Doe"),
+        ("###PERPANJANGAN KITAS JOHN DOE###/doc.pdf", "PERPANJANGAN KITAS JOHN DOE"),
+        ("@arsip Cetak (2027)/x.pdf", "arsip Cetak"),
+        ("file-at-root.pdf", "file-at-root.pdf"),
+        ("ab/x.pdf", None),  # <3 chars after cleaning
+        ("###/x.pdf", None),  # decorations only
+        ("", None),
+        (None, None),
+    ],
+)
+def test_clean_folder_segment(raw: str | None, expected: str | None) -> None:
+    assert rt._clean_folder_segment(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# _classify_decision — folder-hint slotting (pure)
+# ---------------------------------------------------------------------------
+
+def _strong(cid: int = 1) -> dict[str, Any]:
+    return {"table": "clients", "id": cid, "name": "Strong Match",
+            "method": "passport_number", "score": rt.CONF_STRONG_EXACT,
+            "matched_value": "ZZ123"}
+
+
+def _folder(cid: int = 2, table: str = "clients") -> dict[str, Any]:
+    return {"table": table, "id": cid, "name": "Folder Match",
+            "method": "folder_name", "score": rt.CONF_FOLDER_MATCH,
+            "matched_value": "BUDI", "basis": "folder", "folder_sim": 0.82}
+
+
+def _fuzzy(cid: int, sim: float) -> dict[str, Any]:
+    return {"table": "clients", "id": cid, "name": "Fuzzy Match",
+            "method": "fuzzy_full_name", "score": sim, "matched_value": "Fuzzy"}
+
+
+def test_folder_only_is_link_candidate_never_auto() -> None:
+    decision, cands, reason = rt._classify_decision([], [], [_folder()])
+    assert decision == rt.DECISION_LINK_CANDIDATE
+    assert len(cands) == 1
+    assert cands[0]["method"] == "folder_name"
+    assert cands[0]["score"] == rt.CONF_FOLDER_MATCH
+    assert "folder name" in reason["reason"]
+    assert "folder_score" in reason
+
+
+def test_strong_identifier_ignores_folder() -> None:
+    decision, cands, _ = rt._classify_decision([_strong(1)], [], [_folder(2)])
+    assert decision == rt.DECISION_AUTO_ATTACH
+    assert cands == [_strong(1)]
+
+
+def test_folder_and_fuzzy_agree_boosts() -> None:
+    decision, cands, reason = rt._classify_decision(
+        [], [_fuzzy(2, 0.82)], [_folder(2)]
+    )
+    assert decision == rt.DECISION_LINK_CANDIDATE
+    assert len(cands) == 1
+    assert cands[0]["id"] == 2
+    assert cands[0]["score"] == pytest.approx(
+        rt.CONF_FOLDER_MATCH + rt.PHONE_NAME_AGREE_BOOST
+    )
+    assert cands[0]["score"] < rt.CONF_STRONG_EXACT
+    assert cands[0]["method"] == "folder_name+fuzzy_full_name"
+    assert "folder name" in reason["reason"]
+
+
+def test_folder_and_fuzzy_disagree_surfaces_both() -> None:
+    decision, cands, reason = rt._classify_decision(
+        [], [_fuzzy(9, 0.85)], [_folder(2)]
+    )
+    assert decision == rt.DECISION_LINK_CANDIDATE
+    assert [c["id"] for c in cands] == [2, 9]  # folder candidate first
+    assert "disagree" in reason["reason"]
+
+
+def test_shared_folder_is_ambiguous() -> None:
+    decision, cands, reason = rt._classify_decision(
+        [], [], [_folder(2), _folder(3)]
+    )
+    assert decision == rt.DECISION_AMBIGUOUS
+    assert len(cands) == 2
+    assert "share the folder name" in reason["reason"]
+
+
+# ---------------------------------------------------------------------------
+# _match_folder_name — candidate selection (monkeypatched fuzzy)
+# ---------------------------------------------------------------------------
+
+def _patch_fuzzy(monkeypatch: pytest.MonkeyPatch, per_table: dict[str, list[dict]]) -> None:
+    async def _fake_fuzzy(conn: Any, table: str, name_col: str, name: str) -> list[dict]:
+        return [dict(c) for c in per_table.get(table, [])]
+
+    monkeypatch.setattr(rt, "_match_fuzzy_name", _fake_fuzzy)
+
+
+@pytest.mark.asyncio
+async def test_match_folder_name_single_winner(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_fuzzy(monkeypatch, {
+        "clients": [{"table": "clients", "id": 7, "name": "Budi Santoso",
+                     "method": "fuzzy_full_name", "score": 0.86, "matched_value": "BUDI"}],
+        "companies": [],
+    })
+    out = await rt._match_folder_name(None, "BUDI/passport.jpg")
+    assert len(out) == 1
+    assert out[0]["method"] == "folder_name"
+    assert out[0]["score"] == rt.CONF_FOLDER_MATCH
+    assert out[0]["basis"] == "folder"
+    assert out[0]["folder_sim"] == 0.86
+
+
+@pytest.mark.asyncio
+async def test_match_folder_name_weak_sim_is_noise(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_fuzzy(monkeypatch, {
+        "clients": [{"table": "clients", "id": 7, "name": "Someone Else",
+                     "method": "fuzzy_full_name", "score": 0.55, "matched_value": "BUDI"}],
+        "companies": [],
+    })
+    assert await rt._match_folder_name(None, "BUDI/passport.jpg") == []
+
+
+@pytest.mark.asyncio
+async def test_match_folder_name_homonyms_return_both(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_fuzzy(monkeypatch, {
+        "clients": [{"table": "clients", "id": 7, "name": "Budi W",
+                     "method": "fuzzy_full_name", "score": 0.80, "matched_value": "BUDI"}],
+        "companies": [{"table": "companies", "id": 4, "name": "PT Budi",
+                       "method": "fuzzy_company_name", "score": 0.78, "matched_value": "BUDI"}],
+    })
+    out = await rt._match_folder_name(None, "BUDI/doc.pdf")
+    assert len(out) == 2  # within ambiguity margin -> AMBIGUOUS downstream
+
+
+@pytest.mark.asyncio
+async def test_match_folder_name_no_path() -> None:
+    assert await rt._match_folder_name(None, None) == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_entity wiring — fake pool/conn (no PG)
+# ---------------------------------------------------------------------------
+
+class FakeConn:
+    """asyncpg.Connection stand-in: dispatches fetch() on query text + table."""
+
+    def __init__(
+        self,
+        passport_rows: list[dict[str, Any]] | None = None,
+        phone_rows: list[dict[str, Any]] | None = None,
+        client_fuzzy_rows: list[dict[str, Any]] | None = None,
+        company_fuzzy_rows: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.passport_rows = passport_rows or []
+        self.phone_rows = phone_rows or []
+        self.client_fuzzy_rows = client_fuzzy_rows or []
+        self.company_fuzzy_rows = company_fuzzy_rows or []
+        self.queries: list[str] = []
+
+    async def fetch(self, query: str, *args: Any) -> list[dict[str, Any]]:
+        self.queries.append(query)
+        if "passport_number" in query:
+            return self.passport_rows
+        if "phone_normalized" in query:
+            return self.phone_rows
+        if "similarity" in query and "FROM clients" in query:
+            return self.client_fuzzy_rows
+        if "similarity" in query and "FROM companies" in query:
+            return self.company_fuzzy_rows
+        return []
+
+
+class FakePool:
+    def __init__(self, conn: FakeConn) -> None:
+        self._conn = conn
+
+    def acquire(self) -> Any:
+        conn = self._conn
+
+        class _Ctx:
+            async def __aenter__(self) -> FakeConn:
+                return conn
+
+            async def __aexit__(self, *exc: Any) -> bool:
+                return False
+
+        return _Ctx()
+
+
+@pytest.mark.asyncio
+async def test_resolve_entity_folder_match_no_strong_no_phone() -> None:
+    conn = FakeConn(client_fuzzy_rows=[{"id": 7, "name": "Budi Santoso", "sim": 0.84}])
+    out = await rt.resolve_entity(
+        {}, "unknown", FakePool(conn), source_path="BUDI/passport.jpg"
+    )
+    assert out["decision"] == rt.DECISION_LINK_CANDIDATE
+    assert out["subject_kind"] == "person"
+    cand = out["candidates"][0]
+    assert (cand["table"], cand["id"], cand["method"]) == ("clients", 7, "folder_name")
+    assert cand["score"] == rt.CONF_FOLDER_MATCH
+
+
+@pytest.mark.asyncio
+async def test_resolve_entity_strong_id_skips_folder_query() -> None:
+    conn = FakeConn(
+        passport_rows=[{"id": 7, "full_name": "Alice Strong"}],
+        client_fuzzy_rows=[{"id": 9, "name": "Budi Santoso", "sim": 0.84}],
+    )
+    out = await rt.resolve_entity(
+        {"passport_no": {"value": "ZZ9988770"}}, "passport",
+        FakePool(conn), source_path="BUDI/passport.jpg",
+    )
+    assert out["decision"] == rt.DECISION_AUTO_ATTACH
+    assert not any("similarity" in q for q in conn.queries)
+
+
+@pytest.mark.asyncio
+async def test_resolve_entity_phone_wins_over_folder() -> None:
+    conn = FakeConn(
+        phone_rows=[{"id": 42, "full_name": "Wira Phone"}],
+        client_fuzzy_rows=[{"id": 7, "name": "Budi Santoso", "sim": 0.84}],
+    )
+    out = await rt.resolve_entity(
+        {}, "unknown", FakePool(conn),
+        sender_phone="08123456789", source_path="BUDI/passport.jpg",
+    )
+    assert out["decision"] == rt.DECISION_LINK_CANDIDATE
+    assert out["candidates"][0]["method"] == "sender_phone"
+    # Folder fuzzy never queried: phone resolved first.
+    assert not any("similarity" in q for q in conn.queries)

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`321 routers · 606 services · 1034 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`321 routers · 606 services · 1031 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`321 routers · 606 services · 1031 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`321 routers · 606 services · 1034 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/infra/launchagents/com.balizero.drive-intake-drain.plist
+++ b/infra/launchagents/com.balizero.drive-intake-drain.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.balizero.drive-intake-drain</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>INTAKE_DRIVE_SCOPE_FOLDER_ID</key>
+        <string>__SCOPE_FOLDER_ID__</string>
+    </dict>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__VENV_PYTHON__</string>
+        <string>__REPO_ROOT__/scripts/drive_intake_drain.py</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>600</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>__HOME__/logs/drive-intake-drain.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>__HOME__/logs/drive-intake-drain.err.log</string>
+</dict>
+</plist>

--- a/infra/launchagents/install_drive_intake.sh
+++ b/infra/launchagents/install_drive_intake.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# install_drive_intake.sh <scope-folder-id> — installer for the Drive→intake drain cron.
+#
+# Run ON the Pro, AFTER the Dropbox backfill has completed (arming during the
+# backfill would flood intake_queue with the historical corpus). The first run
+# seeds the changes cursor at "now" → only files added from arming onward are
+# ingested (historical smistamento happens via targeted campaigns, not here).
+#
+# <scope-folder-id> = Drive folder id of Dropbox-Intake/ — find it with:
+#   rclone lsf gdrive: --dirs-only --format "ip" | grep Dropbox-Intake
+set -euo pipefail
+
+SCOPE_ID="${1:-}"
+[ -n "$SCOPE_ID" ] || { echo "usage: $0 <scope-folder-id>"; exit 2; }
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLIST_SRC="$REPO_ROOT/infra/launchagents/com.balizero.drive-intake-drain.plist"
+SCRIPT="$REPO_ROOT/scripts/drive_intake_drain.py"
+VENV_PYTHON="$REPO_ROOT/apps/backend-rag/.venv/bin/python"
+LABEL="com.balizero.drive-intake-drain"
+PLIST_DST="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+[ -f "$PLIST_SRC" ] || { echo "SKIP: $PLIST_SRC missing"; exit 0; }
+[ -f "$SCRIPT" ] || { echo "SKIP: $SCRIPT missing"; exit 0; }
+[ -x "$VENV_PYTHON" ] || { echo "SKIP: venv python missing at $VENV_PYTHON"; exit 0; }
+
+mkdir -p "$HOME/logs"
+
+# No secrets in the plist by design (scar 2026-04-29) — the folder id is an
+# identifier, not a credential.
+sed -e "s|__HOME__|$HOME|g" \
+    -e "s|__REPO_ROOT__|$REPO_ROOT|g" \
+    -e "s|__VENV_PYTHON__|$VENV_PYTHON|g" \
+    -e "s|__SCOPE_FOLDER_ID__|$SCOPE_ID|g" \
+    "$PLIST_SRC" > "$PLIST_DST"
+chmod 0644 "$PLIST_DST"
+plutil -lint "$PLIST_DST"
+
+launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST_DST"
+launchctl kickstart "gui/$(id -u)/$LABEL"
+
+echo "OK: $LABEL installed + kickstarted (scope=$SCOPE_ID, repo=$REPO_ROOT)"

--- a/scripts/drive_intake_drain.py
+++ b/scripts/drive_intake_drain.py
@@ -1,0 +1,68 @@
+"""Drive-intake drain caller — cron entrypoint that arms drain_drive (FASE 1B).
+
+Runs ON the Pro (LaunchAgent com.balizero.drive-intake-drain, every 10 min):
+connects to the LOCAL intake Postgres and drains Drive changes scoped to
+INTAKE_DRIVE_SCOPE_FOLDER_ID (the Dropbox-Intake/ folder id) into intake_queue.
+Mirrors scripts/wa_media_pull_worker.py (same DB, same sovereign-local stance).
+ZERO CRM writes — enqueue only; the worker + FASE-5 review do the rest.
+
+Env:
+- LOCAL_DATABASE_URL            (default postgresql://nuzantara@127.0.0.1:5432/nuzantara_dev)
+- INTAKE_DRIVE_SCOPE_FOLDER_ID  (REQUIRED by the adapter — fail-safe skip if missing)
+- INTAKE_DRIVE_DRAIN_LIMIT      (default 200 changes per tick)
+
+State JSON for the sentinel family: ~/.agent/decisions/state/drive_intake_drain.last.json
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "apps" / "backend-rag"))
+
+import asyncpg  # noqa: E402
+
+from backend.services.intake.drive_adapter import drain_drive  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+logger = logging.getLogger("drive_intake_drain")
+
+STATE_FILE = Path.home() / ".agent" / "decisions" / "state" / "drive_intake_drain.last.json"
+
+
+async def main() -> int:
+    db_url = os.getenv(
+        "LOCAL_DATABASE_URL", "postgresql://nuzantara@127.0.0.1:5432/nuzantara_dev"
+    )
+    limit = int(os.getenv("INTAKE_DRIVE_DRAIN_LIMIT", "200"))
+
+    started = time.time()
+    pool = await asyncpg.create_pool(dsn=db_url, min_size=1, max_size=2)
+    try:
+        counters = await drain_drive(pool, limit=limit)
+    finally:
+        await pool.close()
+
+    elapsed = round(time.time() - started, 1)
+    state = {
+        "job": "drive_intake_drain",
+        "ts": int(time.time()),
+        "status": "ok" if counters.get("errors", 0) == 0 else "partial",
+        "elapsed": elapsed,
+        **counters,
+    }
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    STATE_FILE.write_text(json.dumps(state) + "\n")
+    logger.info("drain tick done: %s", state)
+    return 0 if counters.get("errors", 0) == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))


### PR DESCRIPTION
## What

Smistamento CRM for the Dropbox→Drive copy flow (#1357): files landing in `Drive/Dropbox-Intake/` now enter the intake v2 pipeline, carrying their folder path as a routing signal.

## Pieces

1. **`drive_adapter.py` — scoped drain.** `drain_drive()` now REQUIRES `INTAKE_DRIVE_SCOPE_FOLDER_ID` (fail-safe: the Drive changes API is account-wide — unscoped it would ingest the codebase mirror + nightly backups). A memoized ancestor walk (depth ≤12) both filters to the watched root AND yields the path relative to it, passed to `enqueue()` as `source_path`. New counter `skipped_out_of_scope`.

2. **m227** — additive nullable `intake_queue.source_path` (twin of m225 `sender_phone`). Apply manually on Pro `nuzantara_dev` like 212-226:
   ```
   psql postgresql://nuzantara@127.0.0.1:5432/nuzantara_dev -f apps/backend-rag/backend/db/migrations_v2/227_intake_queue_source_path.sql
   ```

3. **`routing.py` — folder-name entity signal** (`CONF_FOLDER_MATCH = 0.85`). First path segment cleaned (`_clean_folder_segment`: strips decorations/parentheticals, rejects <3 chars) and fuzzy-matched vs `clients.full_name` / `companies.company_name` (pg_trgm, only sim ≥0.70 counts). Rides the m225 transport-hint slot in the decision matrix: consulted ONLY when no strong identifier and no sender-phone; **never auto-attaches alone**; agree=boost, disagree=both surfaced, homonyms→AMBIGUOUS. All m225 reason-string contracts preserved.

4. **Pro caller cron (NOT armed)** — `scripts/drive_intake_drain.py` + `infra/launchagents/com.balizero.drive-intake-drain.plist` (10min, `__HOME__` placeholders, no secrets) + `install_drive_intake.sh <scope-folder-id>`. **Install AFTER the 527GiB Dropbox backfill completes** so the changes-API cursor seeds past historical files (~170s/job OCR would take months on backlog).

## Safety

- Writer stays dry-run (`INTAKE_WRITER_ENABLED` untouched) — proposals land in kita/review only.
- PII stays local: blobs under `INTAKE_BLOB_ROOT` on the Pro, OCR via local qwen2.5vl (Law 2).
- Tests use fictional names only.

## Tests

26 new pure-unit tests (no PG/Drive needed): folder-signal selection/slotting/wiring + scoped drain (fail-safe, in/out-of-scope, native-mime skip, cursor upsert). m225 phone suite untouched. **46/46 green**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
