### PR TITLE
fix(wr2): reconnect main_conn before terminal write (render outlives idle conn)

### DIFF
--- a/apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py
@@ -210,6 +210,106 @@ async def test_apply_one_rate_limit_does_not_burn_attempt(monkeypatch):
     assert "drafts_imaged_checked" in sqls
 
 
+# ── connection-resilience: the ~15 min render kills the idle main_conn; the
+#    terminal write must reconnect (2026-06-12 SCAR: drafts stuck 'rendering'
+#    forever because the post-render write crashed on a closed connection) ──────
+
+
+@pytest.mark.asyncio
+async def test_ensure_live_reconnects_when_closed(monkeypatch):
+    from unittest.mock import AsyncMock, MagicMock
+
+    import scripts.wr2_html_render_apply as html
+
+    dead = MagicMock()
+    dead.is_closed = MagicMock(return_value=True)
+    fresh = MagicMock()
+    connect = AsyncMock(return_value=fresh)
+    monkeypatch.setattr(html.asyncpg, "connect", connect)
+
+    out = await html._ensure_live(dead, "postgres://x")
+
+    assert out is fresh
+    connect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ensure_live_keeps_open_connection(monkeypatch):
+    from unittest.mock import AsyncMock, MagicMock
+
+    import scripts.wr2_html_render_apply as html
+
+    live = MagicMock()
+    live.is_closed = MagicMock(return_value=False)
+    connect = AsyncMock()
+    monkeypatch.setattr(html.asyncpg, "connect", connect)
+
+    out = await html._ensure_live(live, "postgres://x")
+
+    assert out is live
+    connect.assert_not_awaited()  # no needless reconnect on a healthy conn
+
+
+@pytest.mark.asyncio
+async def test_apply_one_reconnects_before_terminal_write(monkeypatch):
+    """INVARIANT: if main_conn died during the long render, the success path
+    reconnects so the carousel reaches status='rendered' instead of crashing on
+    a closed connection (which left it stuck in 'rendering')."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    import scripts.wr2_html_render_apply as html
+
+    dead = MagicMock(name="dead")
+    dead.is_closed = MagicMock(return_value=True)   # closed by the proxy mid-render
+    dead.execute = AsyncMock()
+    dead.fetchval = AsyncMock(return_value=0)
+    dead.close = AsyncMock()
+    fresh = MagicMock(name="fresh")
+    fresh.is_closed = MagicMock(return_value=False)
+    fresh.execute = AsyncMock()
+    fresh.fetchval = AsyncMock(return_value=0)
+    fresh.close = AsyncMock()
+
+    # first two connects (main_conn, hb_conn) → dead; any reconnect → fresh
+    conns = [dead, dead, fresh, fresh]
+    monkeypatch.setattr(html.asyncpg, "connect", AsyncMock(side_effect=conns))
+    monkeypatch.setattr(
+        html._pg, "acquire_html_lease_and_fetch",
+        AsyncMock(return_value={"slides_json": {"slides": [{"headline": "H"}]}}),
+    )
+    monkeypatch.setattr(html, "_heartbeat_loop", AsyncMock())
+    monkeypatch.setattr(html, "_normalize_heroes", lambda slides, *a, **k: slides)
+
+    class _Srv:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+    monkeypatch.setattr(html, "_HeroServer", lambda *a, **k: _Srv())
+
+    # render "succeeds": produce a PNG path the worker will glob
+    async def _fake_render(draft_id, slides, work, vision_required):
+        d = work / "carousel" / "slides"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "01.png").write_bytes(b"PNG")
+        return d
+    monkeypatch.setattr(html, "_render_carousel", _fake_render)
+    monkeypatch.setattr(html, "_drive_upload_carousel", AsyncMock(return_value="https://drive/x"))
+    monkeypatch.setattr(
+        html._pg, "persist_html_result_and_enqueue_notifications",
+        AsyncMock(return_value={}),
+    )
+    monkeypatch.setattr(html, "_log_ledger_best_effort", AsyncMock())
+    monkeypatch.delenv("WR2_VISION_REQUIRED", raising=False)
+    monkeypatch.delenv("WR2_HTML_SHADOW", raising=False)
+
+    import uuid as _uuid
+    persist = html._pg.persist_html_result_and_enqueue_notifications
+    result = await html._apply_one("postgres://x", _uuid.uuid4(), "owner-1")
+
+    assert result.startswith("rendered")
+    # the persist (terminal write) ran on the RECONNECTED conn, not the dead one
+    assert persist.await_args.args[0] is fresh
+
+
 @pytest.mark.asyncio
 async def test_designer_loop_converges_default_no_vision(monkeypatch):
     import base64

--- a/scripts/wr2_html_render_apply.py
+++ b/scripts/wr2_html_render_apply.py
@@ -359,6 +359,23 @@ async def _log_ledger_best_effort(conn: "asyncpg.Connection", draft_id: uuid.UUI
         logger.warning("topic_type_log write failed for %s: %s", draft_id, exc)
 
 
+async def _ensure_live(conn: "asyncpg.Connection", dsn: str) -> "asyncpg.Connection":
+    """Return a live connection: if `conn` was closed while idle, reconnect.
+
+    The render of a full carousel takes ~13-16 min, during which main_conn sits
+    idle between the lease-acquire and the terminal write. The pg-proxy closes
+    idle connections, so the post-render write (success OR failure path) hit
+    `asyncpg.InterfaceError: connection is closed` and crashed before recording
+    a terminal status — leaving the draft stuck in 'rendering' forever (2026-06-12
+    SCAR). The heartbeat survives only because its own conn pings every 60s.
+    Reconnect right before each post-render write.
+    """
+    if conn.is_closed():
+        logger.warning("main_conn closed during long render — reconnecting for terminal write")
+        return await asyncpg.connect(dsn, timeout=10)
+    return conn
+
+
 # ── apply one draft ──────────────────────────────────────────────────────────────
 async def _apply_one(pool_conn_dsn: str, draft_id: uuid.UUID, owner: str) -> str:
     """Full lifecycle for one draft. Uses a dedicated connection for the heartbeat so it
@@ -406,6 +423,11 @@ async def _apply_one(pool_conn_dsn: str, draft_id: uuid.UUID, owner: str) -> str
             if stop.is_set():
                 raise RuntimeError("lease_lost_before_drive")
 
+            # the render just took ~15 min — main_conn may have been closed idle
+            # by the pg-proxy; reconnect before the terminal write so a converged
+            # carousel actually reaches status='rendered' (2026-06-12 SCAR).
+            main_conn = await _ensure_live(main_conn, pool_conn_dsn)
+
             web = await _drive_upload_carousel(str(draft_id), png_paths, shadow)
 
             if shadow:
@@ -443,6 +465,7 @@ async def _apply_one(pool_conn_dsn: str, draft_id: uuid.UUID, owner: str) -> str
             # burned; the draft returns to the queue and renders next tick once
             # quota recovers. (Pre-fix this 429 masqueraded as "vision
             # unavailable" and killed healthy drafts in 3 attempts.)
+            main_conn = await _ensure_live(main_conn, pool_conn_dsn)
             await main_conn.execute(
                 """
                 UPDATE war_room_drafts
@@ -455,7 +478,11 @@ async def _apply_one(pool_conn_dsn: str, draft_id: uuid.UUID, owner: str) -> str
             logger.warning("draft %s vision rate-limited (429) — transient, no attempt burned: %s", draft_id, exc)
             return f"rate_limited:{exc}"
         except RuntimeError as exc:
-            # transient render/Drive failure -> back to queue unless attempts exhausted
+            # transient render/Drive failure -> back to queue unless attempts exhausted.
+            # The render may have run long enough to kill main_conn — reconnect so
+            # this failure path records its terminal status instead of crashing on
+            # a closed connection and leaving the draft stuck in 'rendering'.
+            main_conn = await _ensure_live(main_conn, pool_conn_dsn)
             attempts = await main_conn.fetchval(
                 "SELECT COALESCE((slides_json->>'_html_attempts')::int, 0) FROM war_room_drafts WHERE id=$1",
                 draft_id,


### PR DESCRIPTION
## SCAR (2026-06-12) — THE structural blocker to the first M1-green

A full carousel render takes ~13-16 min. During it, `main_conn` sits **idle** between lease-acquire and the terminal status write. The pg-proxy closes idle connections, so the post-render write — success (`persist → 'rendered'`) OR failure (`fetchval _html_attempts`) — hit `asyncpg.InterfaceError: connection is closed` and **crashed before recording any terminal status**. The draft was left stuck in `'rendering'` forever (the heartbeat conn survives because it pings every 60s; `main_conn` does not).

Net effect: **even a fully converged carousel never reached `status='rendered'`** — observed twice in tonight's E2E (05:08, 05:15).

## Fix

`_ensure_live(conn, dsn)` reconnects if the connection was closed, called right before each post-render write:
- success path (before drive upload + `persist`)
- `RuntimeError` failure path (before the attempt read/write)
- vision-transient release path

A healthy connection is reused untouched (no needless reconnect).

## Tests

TDD, **RED verified by stashing**: 3 tests — reconnect-when-closed, keep-open-when-live, and the `_apply_one` invariant *"the terminal persist runs on the reconnected conn"*. Suite `test_wr2_html_render_apply.py` **98/98**.

Already hot-applied to the live deploy worktree (surgical, identical to main otherwise) so the in-flight render benefits immediately; this PR is the durable git source.

Pushing WR2 to its first end-to-end render (P-1, Antonello GO 2026-06-11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)