### PR TITLE
feat(wr2): IG profile harvester — auto-collect Zero's own posts (IG-feedback STRATO 4)

### DIFF
--- a/apps/backend-rag/backend/tests/unit/scripts/test_wr2_ig_profile_harvester.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_wr2_ig_profile_harvester.py
@@ -1,0 +1,74 @@
+"""Unit tests for scripts/wr2_ig_profile_harvester.py — STRATO 4 (pure helpers).
+
+The browser I/O (login/collect) is not unit-tested (needs a live Instagram
+session); the load-bearing pure logic is `normalize_post_urls`, which turns the
+raw grid hrefs into unique canonical permalinks — tested here.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[6]
+_MODULE_PATH = _REPO_ROOT / "scripts" / "wr2_ig_profile_harvester.py"
+_spec = importlib.util.spec_from_file_location("wr2_ig_profile_harvester", _MODULE_PATH)
+hv = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = hv
+_spec.loader.exec_module(hv)
+
+
+def test_normalize_keeps_only_posts_and_reels():
+    hrefs = [
+        "https://www.instagram.com/p/ABC123/",
+        "https://www.instagram.com/reel/DEF456/",
+        "https://www.instagram.com/balizero0/",          # profile -> dropped
+        "https://www.instagram.com/explore/tags/bali/",  # explore -> dropped
+        "https://www.instagram.com/p/ABC123/liked_by/",  # same post, sub-route -> dedup
+    ]
+    out = hv.normalize_post_urls(hrefs)
+    assert out == [
+        "https://www.instagram.com/p/ABC123/",
+        "https://www.instagram.com/reel/DEF456/",
+    ]
+
+
+def test_normalize_dedups_by_shortcode_preserving_order():
+    hrefs = [
+        "https://www.instagram.com/p/AAA/",
+        "https://www.instagram.com/p/BBB/",
+        "https://www.instagram.com/p/AAA/",  # dup
+        "https://www.instagram.com/p/CCC/",
+    ]
+    out = hv.normalize_post_urls(hrefs)
+    assert out == [
+        "https://www.instagram.com/p/AAA/",
+        "https://www.instagram.com/p/BBB/",
+        "https://www.instagram.com/p/CCC/",
+    ]
+
+
+def test_normalize_canonicalizes_messy_urls():
+    hrefs = [
+        "https://instagram.com/p/XYZ?igshid=foo",   # no www, query -> canonical
+        "http://www.instagram.com/reel/QQQ/",        # http -> https
+    ]
+    out = hv.normalize_post_urls(hrefs)
+    assert out == [
+        "https://www.instagram.com/p/XYZ/",
+        "https://www.instagram.com/reel/QQQ/",
+    ]
+
+
+def test_normalize_empty_and_garbage():
+    assert hv.normalize_post_urls([]) == []
+    assert hv.normalize_post_urls(["", None, "https://example.com/p/x/"]) == []
+
+
+def test_normalized_urls_pass_writer_validation():
+    # every URL the harvester emits must be accepted by STRATO 1's validator,
+    # else ingest-external would reject them.
+    out = hv.normalize_post_urls([
+        "https://www.instagram.com/p/ABC123/",
+        "https://instagram.com/reel/DEF456?x=1",
+    ])
+    assert out and all(hv._qw.validate_ig_url(u) for u in out)

--- a/docs/runbooks/wr2-ig-feedback-loop.md
+++ b/docs/runbooks/wr2-ig-feedback-loop.md
@@ -101,10 +101,47 @@ python scripts/wr2_queue_writer.py ingest-external https://instagram.com/p/XYZ \
 - Idempotent on the URL: re-ingesting the same post is a no-op
   (`already_present`). A non-IG URL is `invalid_url` and writes nothing.
 
-> To bulk-register Zero's own back-catalogue, run `ingest-external` once per URL
-> (the account is login-walled, so the URLs are pasted by hand or exported from
-> Meta Business Suite — there is no logged-in scraping session on the Pro). The
-> scraper then collects engagement for them on its next ≥24h run.
+> To bulk-register Zero's own back-catalogue by hand, run `ingest-external` once
+> per URL. To do it automatically instead, use STRATO 4 below.
+
+---
+
+## Auto-harvest Zero's own posts (STRATO 4 — Playwright)
+
+Instead of pasting URLs by hand, `scripts/wr2_ig_profile_harvester.py` logs into
+@balizero0 with a persistent Playwright profile, scrolls the grid, collects
+every post URL, and feeds them to STRATO 3. The same profile
+(`~/.chrome-cdp-profile/balizero0-ig`) is what `_ig-metrics-scraper.py` uses, so
+the one-time login also unblocks that scraper.
+
+### One-time login (operator — Zero)
+
+Opens a real browser window; log in to @balizero0 ONCE. The script detects login
+automatically (polling, no Enter needed) and saves the session.
+
+```bash
+apps/backend-rag/.venv/bin/python scripts/wr2_ig_profile_harvester.py login
+```
+
+### Harvest
+
+```bash
+# preview the URLs it finds (writes nothing)
+apps/backend-rag/.venv/bin/python scripts/wr2_ig_profile_harvester.py harvest --collect-only
+
+# collect + register them all via ingest-external (idempotent)
+apps/backend-rag/.venv/bin/python scripts/wr2_ig_profile_harvester.py harvest --ingest
+```
+
+- `harvest` runs headless (reuses the saved profile); if the session expired it
+  says so — re-run `login`.
+- Scrolls until the grid stops yielding new posts (3 stable rounds) or
+  `--max-scrolls` (default 60). Dedups by shortcode, canonicalizes to
+  `https://www.instagram.com/p|reel/<code>/`.
+- `--ingest` is idempotent: re-running only adds posts not already registered.
+
+> Law 2: reads only public @balizero0 post URLs — no client PII. The login
+> session is a Bali Zero account, stored locally in the persistent profile.
 
 ---
 

--- a/scripts/wr2_ig_profile_harvester.py
+++ b/scripts/wr2_ig_profile_harvester.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""WR2 IG profile harvester — STRATO 4 of the IG-metrics feedback loop.
+
+Auto-extracts the URLs of posts published BY HAND on @balizero0 (Zero's own
+back-catalogue) so they don't have to be pasted one by one. Feeds them to
+STRATO 3 `ingest_external_post`, which mints scraper-consumable `published`
+items; the IG-metrics scraper then collects their engagement.
+
+The @balizero0 account is login-walled and there is no logged-in scraping
+session on the Pro, so this uses a PERSISTENT Playwright profile
+(~/.chrome-cdp-profile/balizero0-ig — the SAME profile the existing
+_ig-metrics-scraper.py uses, so a login here also unblocks that scraper). Two
+commands:
+
+    login    — open a headful browser, let Zero log in to Instagram ONCE; the
+               session is saved into the persistent profile. Run by the operator.
+    harvest  — reuse the saved profile, scroll @balizero0, collect every post
+               shortcode, and (with --ingest) register them via STRATO 3.
+
+Login detection is by polling (no stdin needed): the script watches the page
+until the login form disappears, then saves and exits — so it can be launched
+with `!` from the Claude prompt or from a terminal.
+
+Law 2: these are PUBLIC Instagram posts of Bali Zero; only public post URLs are
+read. No client PII. The harvest acts only on the account's own grid.
+
+CLI:
+    wr2_ig_profile_harvester.py login                  [--handle balizero0]
+    wr2_ig_profile_harvester.py harvest --collect-only [--handle balizero0] [--max-scrolls N]
+    wr2_ig_profile_harvester.py harvest --ingest       [--handle balizero0]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Optional
+
+# ── Import STRATO 3 (sibling module in scripts/) ───────────────────────────
+_THIS_DIR = Path(__file__).resolve().parent
+_WRITER_PATH = _THIS_DIR / "wr2_queue_writer.py"
+_spec = importlib.util.spec_from_file_location("wr2_queue_writer", _WRITER_PATH)
+_qw = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = _qw
+_spec.loader.exec_module(_qw)
+
+IG_CHROME_PROFILE = Path.home() / ".chrome-cdp-profile/balizero0-ig"
+DEFAULT_HANDLE = "balizero0"
+LOGIN_POLL_TIMEOUT_S = 300
+LOGIN_POLL_INTERVAL_S = 3
+SCROLL_SETTLE_MS = 1800
+DEFAULT_MAX_SCROLLS = 60
+
+
+# ── Pure helpers (no I/O, unit-tested) ─────────────────────────────────────
+
+
+def normalize_post_urls(hrefs: list[str], handle: Optional[str] = None) -> list[str]:
+    """From a list of hrefs scraped off the grid, return unique canonical IG
+    post/reel permalinks, order-preserving.
+
+    - keeps only /p/<code>/ and /reel/<code>/ (drops /tv/ stories, /explore/,
+      profile links, etc.)
+    - canonicalizes to https://www.instagram.com/p|reel/<code>/
+    - dedups by shortcode (a post can appear multiple times in the DOM)
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for href in hrefs:
+        if not href:
+            continue
+        code = _qw.extract_ig_shortcode(href)
+        if not code or code in seen:
+            continue
+        # determine kind from the path
+        kind = "reel" if "/reel/" in href else "p"
+        seen.add(code)
+        out.append(f"https://www.instagram.com/{kind}/{code}/")
+    return out
+
+
+# ── Browser I/O ────────────────────────────────────────────────────────────
+
+
+async def _is_logged_in(page) -> bool:
+    """Best-effort: logged in when no username login field is present and we are
+    not on an /accounts/login route."""
+    try:
+        if "/accounts/login" in page.url:
+            return False
+        has_login = await page.evaluate(
+            "() => !!document.querySelector('input[name=\"username\"]')"
+        )
+        return not has_login
+    except Exception:
+        return False
+
+
+async def do_login(handle: str) -> int:
+    """Open a headful browser on Instagram and wait (polling) until Zero logs in.
+    Saves the session into the persistent profile. Returns 0 on success."""
+    from playwright.async_api import async_playwright
+
+    IG_CHROME_PROFILE.parent.mkdir(parents=True, exist_ok=True)
+    print(f"[harvester] opening Instagram for login — profile: {IG_CHROME_PROFILE}")
+    print("[harvester] >>> LOG IN to @balizero0 in the window that opens. "
+          "This script detects login automatically and saves the session.")
+    async with async_playwright() as p:
+        ctx = await p.chromium.launch_persistent_context(
+            user_data_dir=str(IG_CHROME_PROFILE), headless=False
+        )
+        page = ctx.pages[0] if ctx.pages else await ctx.new_page()
+        await page.goto("https://www.instagram.com/accounts/login/", wait_until="domcontentloaded")
+        waited = 0
+        while waited < LOGIN_POLL_TIMEOUT_S:
+            if await _is_logged_in(page):
+                print(f"[harvester] login detected after ~{waited}s — session saved. You can close the window.")
+                await page.wait_for_timeout(2000)
+                await ctx.close()
+                return 0
+            await page.wait_for_timeout(LOGIN_POLL_INTERVAL_S * 1000)
+            waited += LOGIN_POLL_INTERVAL_S
+        print(f"[harvester] timed out after {LOGIN_POLL_TIMEOUT_S}s without detecting login.", file=sys.stderr)
+        await ctx.close()
+        return 1
+
+
+async def collect_post_urls(handle: str, max_scrolls: int) -> list[str]:
+    """Reuse the saved profile, scroll the @handle grid, return unique post URLs."""
+    from playwright.async_api import async_playwright
+
+    if not IG_CHROME_PROFILE.exists():
+        print(f"[harvester] profile missing at {IG_CHROME_PROFILE} — run `login` first.", file=sys.stderr)
+        return []
+
+    async with async_playwright() as p:
+        ctx = await p.chromium.launch_persistent_context(
+            user_data_dir=str(IG_CHROME_PROFILE), headless=True
+        )
+        page = ctx.pages[0] if ctx.pages else await ctx.new_page()
+        await page.goto(f"https://www.instagram.com/{handle}/", wait_until="domcontentloaded")
+        await page.wait_for_timeout(SCROLL_SETTLE_MS)
+
+        if not await _is_logged_in(page):
+            print("[harvester] not logged in (session expired?) — re-run `login`.", file=sys.stderr)
+            await ctx.close()
+            return []
+
+        all_hrefs: list[str] = []
+        stable_rounds = 0
+        prev_count = 0
+        for _ in range(max_scrolls):
+            hrefs = await page.evaluate(
+                "() => Array.from(document.querySelectorAll('a[href*=\"/p/\"], a[href*=\"/reel/\"]')).map(a => a.href)"
+            )
+            all_hrefs.extend(hrefs)
+            unique = normalize_post_urls(all_hrefs, handle)
+            if len(unique) == prev_count:
+                stable_rounds += 1
+                if stable_rounds >= 3:  # grid exhausted (no new posts after 3 scrolls)
+                    break
+            else:
+                stable_rounds = 0
+            prev_count = len(unique)
+            await page.evaluate("() => window.scrollBy(0, document.body.scrollHeight)")
+            await page.wait_for_timeout(SCROLL_SETTLE_MS)
+
+        await ctx.close()
+        return normalize_post_urls(all_hrefs, handle)
+
+
+# ── Orchestration ──────────────────────────────────────────────────────────
+
+
+def _resolve_queue_path() -> Path:
+    import os
+    env = os.environ.get("WR2_QUEUE_PATH")
+    return Path(env) if env else _qw.DEFAULT_QUEUE_PATH
+
+
+def _cmd_login(args: argparse.Namespace) -> int:
+    return asyncio.run(do_login(args.handle))
+
+
+def _cmd_harvest(args: argparse.Namespace) -> int:
+    urls = asyncio.run(collect_post_urls(args.handle, args.max_scrolls))
+    if not urls:
+        print("[harvester] no post URLs collected.")
+        return 1
+    print(f"[harvester] collected {len(urls)} unique post URL(s) from @{args.handle}:")
+    for u in urls:
+        print(f"  {u}")
+    if args.collect_only:
+        return 0
+    if args.ingest:
+        queue_path = _resolve_queue_path()
+        ingested = already = failed = 0
+        for u in urls:
+            res = _qw.ingest_external_post(queue_path, u)
+            if res.status == "ingested":
+                ingested += 1
+            elif res.status == "already_present":
+                already += 1
+            else:
+                failed += 1
+                print(f"  ! {u} -> {res.status}: {res.detail}", file=sys.stderr)
+        print(f"[harvester] ingest: {ingested} new, {already} already present, {failed} failed.")
+        return 0 if failed == 0 else 1
+    print("[harvester] (dry: pass --ingest to register, or --collect-only to suppress this hint)")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="WR2 IG profile harvester (STRATO 4)")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    lg = sub.add_parser("login", help="one-time interactive login (headful), saves the IG session")
+    lg.add_argument("--handle", default=DEFAULT_HANDLE)
+    lg.set_defaults(func=_cmd_login)
+
+    hv = sub.add_parser("harvest", help="scroll the profile grid and collect post URLs")
+    hv.add_argument("--handle", default=DEFAULT_HANDLE)
+    hv.add_argument("--max-scrolls", type=int, default=DEFAULT_MAX_SCROLLS)
+    g = hv.add_mutually_exclusive_group()
+    g.add_argument("--collect-only", action="store_true", help="print URLs only, do not register")
+    g.add_argument("--ingest", action="store_true", help="register collected URLs via STRATO 3 ingest-external")
+    hv.set_defaults(func=_cmd_harvest)
+    return p
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Cosa

STRATO 4 del loop IG-metrics: elimina l'incolla-a-mano dello STRATO 3. Lo script logga UNA volta su @balizero0 con profilo Playwright persistente, scorre la griglia del profilo, raccoglie tutti gli URL dei post, e li passa a STRATO 3 ingest-external.

Il profilo (`~/.chrome-cdp-profile/balizero0-ig`) è lo STESSO che `_ig-metrics-scraper.py` si aspetta → il login una-tantum sblocca anche quello scraper.

## Comandi

```
wr2_ig_profile_harvester.py login                  # headful, operatore logga 1 volta
wr2_ig_profile_harvester.py harvest --collect-only # preview URL (no write)
wr2_ig_profile_harvester.py harvest --ingest       # registra via STRATO 3
```

- **login**: rilevamento via polling (no stdin) → lanciabile con `!`; osserva finché il form di login sparisce, salva la sessione, esce.
- **harvest**: headless, scrolla finché la griglia non dà più post nuovi (3 round stabili) o `--max-scrolls` (60); dedup per shortcode, canonicalizza a `https://www.instagram.com/p|reel/<code>/`. `--ingest` idempotente (STRATO 3 already_present no-op).

## Verifica

- Helper puro `normalize_post_urls` (hrefs griglia → permalink canonici unici, order-preserving, scarta profile/explore/sub-route) unit-testato + contract test che ogni URL emesso passa `validate_ig_url` di STRATO 1. **5 test**, ruff clean, CLI smoke OK.
- Browser I/O (login/scroll) richiede sessione IG viva → operator-run, non unit-testato.

## Uso (operatore)

1. `login` una volta (apre browser, Zero logga su @balizero0).
2. `harvest --collect-only` per vedere cosa trova.
3. `harvest --ingest` per registrare tutto → scraper raccoglie metriche.

Law 2: legge solo URL pubblici dei post @balizero0, nessuna PII cliente. Sezione runbook STRATO 4 aggiunta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)