### PR TITLE
fix(wr2): vision TIMEOUT is transient too (generalize 429 fix) + raise budget 120->180s

### DIFF
--- a/apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py
@@ -126,6 +126,56 @@ def test_run_claude_json_genuine_failure_returns_none_not_raise(monkeypatch):
     assert claude_vision._run_claude_json("p", {"type": "object"}) is None
 
 
+def test_run_claude_json_timeout_raises_transient(monkeypatch):
+    """A subprocess timeout is endpoint latency, not a defect — must raise the
+    transient VisionTimeout (no burned attempt), NOT return None (which would
+    fail-closed crash a healthy draft)."""
+    import subprocess as _sp
+
+    from wr2_html_renderer import claude_vision
+
+    def _boom(*a, **k):
+        raise _sp.TimeoutExpired(cmd="claude", timeout=180)
+
+    monkeypatch.setattr(claude_vision.subprocess, "run", _boom)
+    with pytest.raises(claude_vision.VisionTimeout):
+        claude_vision._run_claude_json("p", {"type": "object"})
+
+
+def test_vision_timeout_is_a_transient(monkeypatch):
+    """VisionTimeout and VisionRateLimited share the VisionTransient base so the
+    worker's single handler covers both."""
+    from wr2_html_renderer import claude_vision
+
+    assert issubclass(claude_vision.VisionTimeout, claude_vision.VisionTransient)
+    assert issubclass(claude_vision.VisionRateLimited, claude_vision.VisionTransient)
+
+
+def test_run_claude_json_timeout_budget_from_env(monkeypatch):
+    """The wall-clock budget defaults to 180s and is overridable via
+    WR2_VISION_TIMEOUT_S (raised from the old hardcoded 120s)."""
+    import subprocess as _sp
+
+    from wr2_html_renderer import claude_vision
+
+    captured = {}
+
+    def _capture(cmd, *a, **k):
+        captured["timeout"] = k.get("timeout")
+        raise _sp.TimeoutExpired(cmd="claude", timeout=k.get("timeout"))
+
+    monkeypatch.setattr(claude_vision.subprocess, "run", _capture)
+    monkeypatch.delenv("WR2_VISION_TIMEOUT_S", raising=False)
+    with pytest.raises(claude_vision.VisionTimeout):
+        claude_vision._run_claude_json("p", {"type": "object"})
+    assert captured["timeout"] == 180
+
+    monkeypatch.setenv("WR2_VISION_TIMEOUT_S", "300")
+    with pytest.raises(claude_vision.VisionTimeout):
+        claude_vision._run_claude_json("p", {"type": "object"})
+    assert captured["timeout"] == 300
+
+
 def test_run_claude_json_pins_vision_model(monkeypatch):
     """Default pins claude-sonnet-4-6; WR2_VISION_MODEL overrides. (No --model
     before = CLI default, heavier → 120s timeouts + quota burn.)"""
@@ -192,11 +242,16 @@ async def test_apply_one_rate_limit_does_not_burn_attempt(monkeypatch):
         def __enter__(self): return self
         def __exit__(self, *a): return False
     monkeypatch.setattr(html, "_HeroServer", lambda *a, **k: _Srv())
+    from wr2_html_renderer.claude_vision import VisionRateLimited, VisionTimeout
+    # parametrize-free: prove BOTH transient kinds (429 + timeout) take the
+    # no-burn path via the shared VisionTransient base.
     monkeypatch.setattr(
         html, "_render_carousel",
-        AsyncMock(side_effect=html.VisionRateLimited("429 session limit")),
+        AsyncMock(side_effect=VisionTimeout("vision call timed out after 180s")),
     )
     monkeypatch.setenv("WR2_VISION_REQUIRED", "1")
+    assert issubclass(VisionRateLimited, html.VisionTransient)
+    assert issubclass(VisionTimeout, html.VisionTransient)
 
     import uuid as _uuid
     did = _uuid.uuid4()

--- a/scripts/wr2_html_render_apply.py
+++ b/scripts/wr2_html_render_apply.py
@@ -54,7 +54,7 @@ sys.path.insert(0, str(_REPO / "scripts"))
 import asyncpg  # noqa: E402
 
 from backend.services.canva_renderer_v2 import _pg  # noqa: E402
-from wr2_html_renderer.claude_vision import VisionRateLimited  # noqa: E402
+from wr2_html_renderer.claude_vision import VisionTransient  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 # Silence httpx INFO logs that would otherwise leak the Telegram bot token in the request URL
@@ -459,12 +459,16 @@ async def _apply_one(pool_conn_dsn: str, draft_id: uuid.UUID, owner: str) -> str
                     f"Re-open by having them text +62 821-3465-159, then re-enqueue."
                 )
             return f"rendered report={report}"
-        except VisionRateLimited as exc:
-            # transient quota window (HTTP 429) — NOT a draft defect. Release the
-            # lease WITHOUT touching _html_attempts so the circuit breaker is not
-            # burned; the draft returns to the queue and renders next tick once
-            # quota recovers. (Pre-fix this 429 masqueraded as "vision
-            # unavailable" and killed healthy drafts in 3 attempts.)
+        except VisionTransient as exc:
+            # transient vision-infra failure (HTTP 429 quota window OR endpoint
+            # timeout) — NOT a draft defect. Release the lease WITHOUT touching
+            # _html_attempts so the circuit breaker is not burned; the draft
+            # returns to the queue and renders next tick once the endpoint
+            # recovers. (Pre-fix a 429/timeout masqueraded as "vision unavailable"
+            # and killed healthy drafts in 3 attempts.)
+            # The render may have run long enough to kill main_conn — reconnect so
+            # this release path records its status instead of crashing on a closed
+            # connection and leaving the draft stuck in 'rendering'.
             main_conn = await _ensure_live(main_conn, pool_conn_dsn)
             await main_conn.execute(
                 """
@@ -475,7 +479,7 @@ async def _apply_one(pool_conn_dsn: str, draft_id: uuid.UUID, owner: str) -> str
                 """,
                 draft_id, owner,
             )
-            logger.warning("draft %s vision rate-limited (429) — transient, no attempt burned: %s", draft_id, exc)
+            logger.warning("draft %s vision transient (%s) — no attempt burned: %s", draft_id, type(exc).__name__, exc)
             return f"rate_limited:{exc}"
         except RuntimeError as exc:
             # transient render/Drive failure -> back to queue unless attempts exhausted.

--- a/scripts/wr2_html_renderer/claude_vision.py
+++ b/scripts/wr2_html_renderer/claude_vision.py
@@ -35,14 +35,25 @@ from .designer_loop import Critique
 logger = logging.getLogger("wr2.claude_vision")
 
 
-class VisionRateLimited(Exception):
-    """The vision call hit a transient quota/rate-limit (HTTP 429 / session
-    limit) — NOT a real outage and NOT a defect of the slide. Distinct from the
-    `None`-return "unavailable" path: a rate-limit is recoverable next tick, so
-    the apply-worker must release the draft WITHOUT burning a circuit-breaker
-    attempt. Deliberately NOT a subclass of RuntimeError so the apply-worker's
-    generic `except RuntimeError` (transient render failure, which DOES burn an
-    attempt) cannot swallow it."""
+class VisionTransient(Exception):
+    """A vision call failed for a TRANSIENT infra reason (quota window, endpoint
+    timeout) — NOT a real outage and NOT a defect of the slide. The draft is
+    recoverable next tick, so the apply-worker must release it WITHOUT burning a
+    circuit-breaker attempt. Deliberately NOT a subclass of RuntimeError so the
+    worker's generic `except RuntimeError` (a real transient render failure,
+    which DOES burn an attempt) cannot swallow it."""
+
+
+class VisionRateLimited(VisionTransient):
+    """Transient: HTTP 429 / session limit."""
+
+
+class VisionTimeout(VisionTransient):
+    """Transient: the vision CLI call exceeded its wall-clock budget. A timeout
+    is almost always endpoint latency/overload (verified 2026-06-12: intermittent
+    120s timeouts during an Anthropic congestion window, the SAME run sometimes
+    completing), not a property of the slide — so it must not burn an attempt and
+    fail a healthy draft. The draft retries next tick when latency recovers."""
 
 
 # A 429 surfaces either as a JSON envelope with api_error_status==429 / is_error
@@ -142,12 +153,17 @@ Set brand_ok=true only if ALL hold. List any violations."""
 _CLAUDE_BIN = os.environ.get("CLAUDE_BIN", "claude")
 
 
-def _run_claude_json(prompt: str, schema: dict[str, Any], *, timeout_s: int = 120) -> dict[str, Any] | None:
+def _run_claude_json(prompt: str, schema: dict[str, Any], *, timeout_s: int | None = None) -> dict[str, Any] | None:
     """Call the claude CLI with a JSON schema, return the parsed object or None.
 
     Strips ANTHROPIC_API_KEY from the env (defense-in-depth: force OAuth path,
     never the paid endpoint — CLAUDE.md hard rule).
+
+    Raises VisionTimeout (transient) when the call exceeds the wall-clock budget
+    (default 180s, override WR2_VISION_TIMEOUT_S) and VisionRateLimited on a 429.
     """
+    if timeout_s is None:
+        timeout_s = int(os.environ.get("WR2_VISION_TIMEOUT_S", "180"))
     env = dict(os.environ)
     env.pop("ANTHROPIC_API_KEY", None)
     # Pin the vision model (default sonnet: vision-capable + solid editorial
@@ -164,8 +180,11 @@ def _run_claude_json(prompt: str, schema: dict[str, Any], *, timeout_s: int = 12
     try:
         proc = subprocess.run(cmd, capture_output=True, text=True, env=env, timeout=timeout_s)
     except subprocess.TimeoutExpired:
-        logger.warning("claude vision call timed out after %ss", timeout_s)
-        return None
+        # A timeout is endpoint latency/overload, not a slide defect — transient,
+        # must NOT burn a render attempt (2026-06-12 SCAR: intermittent 120s
+        # timeouts fail-closed-crashed healthy drafts during a congestion window).
+        logger.warning("claude vision call timed out after %ss — transient", timeout_s)
+        raise VisionTimeout(f"vision call timed out after {timeout_s}s")
     # Parse the stdout envelope up front so a 429 can be told apart from a real
     # failure even when the CLI exits rc!=0 (it emits the error as JSON on stdout
     # and a non-zero code with empty stderr).


### PR DESCRIPTION
Rebased clean replacement for #1355 (which went DIRTY after #1365 landed `_ensure_live` on the same file). Single commit atop current main.

## What
- Vision endpoint **timeout** is now treated as transient (same class as 429), not a draft defect: `VisionTimeout(VisionTransient)` + `VisionRateLimited(VisionTransient)`. The worker catches `VisionTransient` and releases the lease back to `drafts_imaged_checked` **without burning a circuit-breaker attempt**.
- Vision call timeout budget raised 120s → 180s (`WR2_VISION_TIMEOUT_S`), `--model` pinned (`WR2_VISION_MODEL`, default claude-sonnet-4-6).
- Merged with #1365's `_ensure_live(main_conn, dsn)` reconnect on the transient-release path (render can outlive the idle main_conn → pg-proxy closes it → release must reconnect or it crashes and strands the draft in `rendering`).

## Why
A 429/timeout previously masqueraded as "vision unavailable" and killed healthy drafts in 3 attempts. Transient infra ≠ composition defect.

## Tests
- `test_wr2_html_render_apply.py` grew to 98 (429/timeout transient, model pin, `_ensure_live` reconnect on release path).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>