### PR TITLE
refactor(kita): one UI language for operator chrome — string dictionary (P1.3)

### DIFF
--- a/apps/mouth/src/app/(workspace)/analytics/funnel/page.tsx
+++ b/apps/mouth/src/app/(workspace)/analytics/funnel/page.tsx
@@ -6,6 +6,7 @@ import {
   analyticsApi,
   type FunnelViewResponse,
 } from "@/lib/api/workspace/analytics.api";
+import { STRINGS } from "@/lib/strings";
 
 const FunnelChart = dynamic(
   () => import("@/components/analytics/FunnelChart"),
@@ -84,10 +85,10 @@ export default function FunnelAnalyticsPage() {
       </header>
 
       {loading ? (
-        <p>Caricamento…</p>
+        <p>{STRINGS.common.loading}</p>
       ) : error ? (
         <p role="alert" style={{ color: "var(--color-danger, #dc2626)" }}>
-          Errore: {error}
+          {STRINGS.common.errorPrefix}: {error}
         </p>
       ) : (
         <>
@@ -99,15 +100,15 @@ export default function FunnelAnalyticsPage() {
             }}
           >
             <Kpi
-              label="Sessioni totali"
+              label={STRINGS.funnel.totalSessionsLabel}
               value={totals.sessions.toLocaleString()}
             />
             <Kpi
-              label="Conversioni"
+              label={STRINGS.funnel.conversionsLabel}
               value={totals.conversions.toLocaleString()}
             />
             <Kpi
-              label="Tasso conversione"
+              label={STRINGS.funnel.conversionRateLabel}
               value={`${totals.rate.toFixed(2)}%`}
             />
           </div>
@@ -122,11 +123,11 @@ export default function FunnelAnalyticsPage() {
             }}
           >
             <h2 style={{ margin: "0 0 12px", fontSize: 16 }}>
-              Sessioni vs conversioni per funnel
+              {STRINGS.funnel.chartTitle}
             </h2>
             {merged.length === 0 ? (
               <p style={{ color: "var(--color-text-secondary, #9ca3af)" }}>
-                Nessun dato disponibile.
+                {STRINGS.common.noData}
               </p>
             ) : (
               <FunnelChart data={merged} />

--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/OracleChat.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/OracleChat.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
+import { STRINGS } from "@/lib/strings";
 
 interface Citation {
   source_id: string;
@@ -27,10 +28,10 @@ interface OracleChatProps {
 }
 
 const QUICK_PROMPTS = [
-  { label: "Riassumi il profilo completo", icon: "📋" },
-  { label: "Stato visti e scadenze", icon: "🛂" },
-  { label: "Situazione fiscale e LKPM", icon: "💰" },
-  { label: "Documenti mancanti o in scadenza", icon: "📄" },
+  { label: STRINGS.oracle.promptSummarizeProfile, icon: "📋" },
+  { label: STRINGS.oracle.promptVisaStatus, icon: "🛂" },
+  { label: STRINGS.oracle.promptTaxLkpm, icon: "💰" },
+  { label: STRINGS.oracle.promptMissingDocs, icon: "📄" },
 ] as const;
 
 export function OracleChat({ clientId }: OracleChatProps) {
@@ -100,7 +101,7 @@ export function OracleChat({ clientId }: OracleChatProps) {
         <div className="flex items-center gap-2">
           <MessageCircle className="h-4 w-4 text-amber-400" />
           <h3 className="text-sm font-semibold text-gray-100">
-            🔮 Chiedi all&apos;Oracle
+            {STRINGS.oracle.header}
           </h3>
         </div>
         {isOpen ? (
@@ -135,7 +136,7 @@ export function OracleChat({ clientId }: OracleChatProps) {
               type="text"
               value={question}
               onChange={(e) => setQuestion(e.target.value)}
-              placeholder="Fai una domanda sul cliente…"
+              placeholder={STRINGS.oracle.inputPlaceholder}
               disabled={loading}
               className="flex-1 rounded-lg border border-gray-700/50 bg-gray-900/60 px-3 py-2 text-sm text-gray-200 placeholder-gray-500 outline-none transition-colors focus:border-amber-500/50 focus:ring-1 focus:ring-amber-500/20 disabled:opacity-50"
             />
@@ -143,7 +144,7 @@ export function OracleChat({ clientId }: OracleChatProps) {
               type="submit"
               disabled={loading || !question.trim()}
               className="flex items-center justify-center rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-amber-300 transition-colors hover:bg-amber-500/20 disabled:opacity-40 disabled:cursor-not-allowed"
-              title="Invia domanda"
+              title={STRINGS.oracle.sendTitle}
             >
               {loading ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
@@ -157,7 +158,7 @@ export function OracleChat({ clientId }: OracleChatProps) {
           {loading && (
             <div className="flex items-center gap-2 text-sm text-gray-400">
               <Loader2 className="h-4 w-4 animate-spin text-amber-400" />
-              <span>Consultando l&apos;Oracle…</span>
+              <span>{STRINGS.oracle.consulting}</span>
             </div>
           )}
 
@@ -165,7 +166,7 @@ export function OracleChat({ clientId }: OracleChatProps) {
           {error && (
             <div className="rounded-lg border border-red-700/40 bg-red-950/20 p-3">
               <div className="text-sm font-medium text-red-400">
-                Errore nella richiesta
+                {STRINGS.oracle.requestError}
               </div>
               <div className="mt-1 text-xs text-red-300/70">{error}</div>
             </div>
@@ -186,7 +187,10 @@ export function OracleChat({ clientId }: OracleChatProps) {
                 <div className="space-y-2">
                   <div className="flex items-center gap-1.5 text-xs font-medium text-gray-400">
                     <BookOpen className="h-3 w-3" />
-                    <span>Fonti ({response.citations.length})</span>
+                    <span>
+                      {STRINGS.oracle.sourcesLabel} ({response.citations.length}
+                      )
+                    </span>
                   </div>
                   <div className="flex flex-wrap gap-1.5">
                     {response.citations.map((cit, idx) => (

--- a/apps/mouth/src/app/(workspace)/clients/page.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/page.tsx
@@ -32,7 +32,9 @@ const PrimeNexusLayout = dynamic(
   () => import("@/components/maps/prime/PrimeNexusLayout"),
   {
     ssr: false,
-    loading: () => <div style={{ padding: 24 }}>Caricamento mappa…</div>,
+    loading: () => (
+      <div style={{ padding: 24 }}>{STRINGS.common.loadingMap}</div>
+    ),
   },
 );
 import { useAutoAnimate } from "@formkit/auto-animate/react";
@@ -56,6 +58,7 @@ import { useCrmClients, useCrmStats } from "@/hooks";
 import { useTeamMemberOptions } from "@/hooks/useTeamMembers";
 import { useQuery } from "@tanstack/react-query";
 import { logger } from "@/lib/logger";
+import { STRINGS } from "@/lib/strings";
 
 // Status badge styling
 const STATUS_STYLES: Record<string, { bg: string; text: string }> = {
@@ -1312,7 +1315,7 @@ function ClientsListContent() {
 /**
  * Main page component with error boundary
  */
-export default function ClientiPage() {
+export default function ClientsPage() {
   return (
     <CRMErrorBoundary section="Clients">
       <ClientsListContent />

--- a/apps/mouth/src/app/(workspace)/dashboard/page.tsx
+++ b/apps/mouth/src/app/(workspace)/dashboard/page.tsx
@@ -30,6 +30,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { normalizeDashboardRole } from "@/lib/dashboard-role";
 import type { LiveActivityEvent } from "@/types/dashboard-role.types";
 import { logger } from "@/lib/logger";
+import { STRINGS } from "@/lib/strings";
 import { api } from "@/lib/api";
 import { formatIDRCompact } from "@balizero/core/utils";
 import { RefreshCw } from "lucide-react";
@@ -513,7 +514,9 @@ export default function DashboardPage() {
             ? formatIDRCompact(revenue.total_revenue)
             : "—",
           sub: revenue?.paid_revenue
-            ? `${formatIDRCompact(revenue.paid_revenue)} incassato`
+            ? STRINGS.dashboard.collectedSub(
+                formatIDRCompact(revenue.paid_revenue),
+              )
             : "—",
           accent: "#9880d8",
         },
@@ -522,28 +525,34 @@ export default function DashboardPage() {
           value: revenue?.outstanding_revenue
             ? formatIDRCompact(revenue.outstanding_revenue)
             : "—",
-          sub: "da incassare",
+          sub: STRINGS.dashboard.outstandingSub,
           accent: "#d4845a",
         },
         {
-          label: "Clienti",
+          label: STRINGS.dashboard.clientsLabel,
           value:
             totalClients != null ? totalClients.toLocaleString("en-US") : "—",
-          sub: "registrati",
+          sub: STRINGS.dashboard.clientsSub,
           accent: "#4a8ec4",
           href: "/clients",
         },
         {
-          label: "Processi",
+          label: STRINGS.dashboard.casesLabel,
           value: totalPractices != null ? totalPractices : "—",
-          sub: `${stats.activeCases} attivi · ${stats.criticalDeadlines} critici`,
+          sub: STRINGS.dashboard.casesSub(
+            stats.activeCases,
+            stats.criticalDeadlines,
+          ),
           accent: "#5cb88a",
           href: "/process",
         },
         {
-          label: "Fatture",
+          label: STRINGS.dashboard.invoicesLabel,
           value: stats.pendingInvoices > 0 ? stats.pendingInvoices : "✓",
-          sub: stats.pendingInvoices > 0 ? "in attesa" : "tutte pagate",
+          sub:
+            stats.pendingInvoices > 0
+              ? STRINGS.dashboard.invoicesPendingSub
+              : STRINGS.dashboard.invoicesPaidSub,
           accent: "#b89a40",
         },
       ]

--- a/apps/mouth/src/app/(workspace)/intelligence/article-composer/page.tsx
+++ b/apps/mouth/src/app/(workspace)/intelligence/article-composer/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/lib/api/articles.api";
 import { useToast } from "@/components/ui/toast";
 import { logger } from "@/lib/logger";
+import { STRINGS } from "@/lib/strings";
 import { AutoResizeTextarea } from "@/components/ui/auto-resize-textarea";
 import { renderMiniMarkdown, fileToBase64 } from "@/lib/utils";
 import { safeMiniMarkdown } from "@/lib/utils/safe-html";
@@ -428,7 +429,7 @@ export default function ArticleComposerPage() {
               <input
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
-                placeholder="Es. New KITAS Rules..."
+                placeholder={STRINGS.articleComposer.titlePlaceholder}
                 className={inputClass}
                 style={getInputStyle("title")}
                 onFocus={() => setFocusedInput("title")}
@@ -447,7 +448,7 @@ export default function ArticleComposerPage() {
               <AutoResizeTextarea
                 value={content}
                 onChange={(e) => setContent(e.target.value)}
-                placeholder="Incolla contenuto..."
+                placeholder={STRINGS.articleComposer.contentPlaceholder}
                 className={`${inputClass} min-h-[140px] resize-none`}
                 style={getInputStyle("content")}
                 onFocus={() => setFocusedInput("content")}

--- a/apps/mouth/src/lib/strings.test.ts
+++ b/apps/mouth/src/lib/strings.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { STRINGS } from "./strings";
+
+const SRC_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+/** Operator surfaces normalized by P1.3 (kita UI/UX audit 2026-06-11). */
+const OPERATOR_SURFACES = [
+  "app/(workspace)/intelligence/article-composer/page.tsx",
+  "app/(workspace)/dashboard/page.tsx",
+  "app/(workspace)/analytics/funnel/page.tsx",
+  "app/(workspace)/clients/page.tsx",
+  "app/(workspace)/clients/[id]/components/OracleChat.tsx",
+];
+
+/**
+ * Italian microcopy that used to be hardcoded in the surfaces above.
+ * Chosen to be precise enough not to false-positive on English text
+ * (e.g. bare "registrati" would match English "registration").
+ */
+const ITALIAN_MARKERS = [
+  "Incolla",
+  "Es. New",
+  "Caricamento",
+  "Errore",
+  "Nessun dato",
+  '"Clienti"',
+  '"Processi"',
+  '"Fatture"',
+  "incassato",
+  "da incassare",
+  '"registrati"',
+  "attivi",
+  "in attesa",
+  "tutte pagate",
+  "Chiedi all",
+  "Fai una domanda",
+  "Invia domanda",
+  "Consultando",
+  "Fonti (",
+  "Riassumi",
+  "scadenze",
+];
+
+describe("operator UI strings dictionary (P1.3 — one UI language)", () => {
+  it("dictionary values are English (no Italian microcopy)", () => {
+    const values: string[] = [
+      STRINGS.dashboard.collectedSub("Rp 1M"),
+      STRINGS.dashboard.casesSub(3, 1),
+    ];
+    const walk = (node: object) => {
+      for (const value of Object.values(node)) {
+        if (typeof value === "string") values.push(value);
+        else if (typeof value === "object" && value !== null) walk(value);
+      }
+    };
+    walk(STRINGS);
+
+    for (const value of values) {
+      for (const marker of ITALIAN_MARKERS) {
+        expect(value, `dictionary value "${value}"`).not.toContain(
+          marker.replaceAll('"', ""),
+        );
+      }
+    }
+  });
+
+  it("normalized operator surfaces use the dictionary and carry no hardcoded Italian", () => {
+    for (const surface of OPERATOR_SURFACES) {
+      const source = readFileSync(path.join(SRC_ROOT, surface), "utf-8");
+
+      expect(source, `${surface} should import the strings dictionary`).toMatch(
+        /import \{ STRINGS \} from ["']@\/lib\/strings["'];/,
+      );
+
+      for (const marker of ITALIAN_MARKERS) {
+        expect(
+          source,
+          `${surface} should not contain "${marker}"`,
+        ).not.toContain(marker);
+      }
+    }
+  });
+
+  it("article composer renders placeholders from the dictionary", () => {
+    const source = readFileSync(
+      path.join(
+        SRC_ROOT,
+        "app/(workspace)/intelligence/article-composer/page.tsx",
+      ),
+      "utf-8",
+    );
+    expect(source).toContain(
+      "placeholder={STRINGS.articleComposer.titlePlaceholder}",
+    );
+    expect(source).toContain(
+      "placeholder={STRINGS.articleComposer.contentPlaceholder}",
+    );
+  });
+});

--- a/apps/mouth/src/lib/strings.ts
+++ b/apps/mouth/src/lib/strings.ts
@@ -1,0 +1,53 @@
+/**
+ * Operator UI chrome strings — kita workspace.
+ *
+ * ONE UI language for operator-facing chrome: ENGLISH
+ * (kita UI/UX audit 2026-06-11, finding P1.3 — mixed EN/IT microcopy).
+ *
+ * Keep operator-facing literals that risk language drift here so the whole
+ * surface stays greppable from a single file. This is NOT an i18n framework:
+ * client-facing pages (blog / portal / marketing) use `@/i18n` and stay
+ * multilingual by design — do not move their copy here.
+ */
+export const STRINGS = {
+  common: {
+    loading: "Loading…",
+    loadingMap: "Loading map…",
+    errorPrefix: "Error",
+    noData: "No data available.",
+  },
+  articleComposer: {
+    titlePlaceholder: "e.g. New KITAS Rules...",
+    contentPlaceholder: "Paste raw content...",
+  },
+  dashboard: {
+    collectedSub: (amount: string) => `${amount} collected`,
+    outstandingSub: "to collect",
+    clientsLabel: "Clients",
+    clientsSub: "registered",
+    casesLabel: "Cases",
+    casesSub: (active: number, critical: number) =>
+      `${active} active · ${critical} critical`,
+    invoicesLabel: "Invoices",
+    invoicesPendingSub: "pending",
+    invoicesPaidSub: "all paid",
+  },
+  funnel: {
+    totalSessionsLabel: "Total sessions",
+    conversionsLabel: "Conversions",
+    conversionRateLabel: "Conversion rate",
+    chartTitle: "Sessions vs conversions per funnel",
+  },
+  oracle: {
+    header: "🔮 Ask the Oracle",
+    promptSummarizeProfile: "Summarize the full profile",
+    promptVisaStatus: "Visa status and deadlines",
+    promptTaxLkpm: "Tax and LKPM situation",
+    promptMissingDocs: "Missing or expiring documents",
+    inputPlaceholder: "Ask a question about this client…",
+    sendTitle: "Send question",
+    consulting: "Consulting the Oracle…",
+    requestError: "Request failed",
+    sourcesLabel: "Sources",
+  },
+} as const;

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`321 routers · 607 services · 1034 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`321 routers · 607 services · 1035 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary

Implements **P1.3** of the kita UI/UX audit (`research/operations/2026-06-11-kita-uiux-audit.md`): operator-facing workspace chrome mixed English and Italian microcopy in the same screens. All confirmed mixed-language surfaces are normalized to **English** (the kita operator-chrome convention) via a minimal typed string dictionary (`apps/mouth/src/lib/strings.ts`) so future language drift stays greppable from one file.

**Not an i18n framework**: the existing `@/i18n` (locale-switching) stays untouched for client-facing pages, which remain multilingual by design. The dictionary is a flat `as const` object, fixed English, operator chrome only. No new deps. `packages/core` untouched (`brand_api_gen.py --check` → fresh).

## Surfaces normalized (all under `app/(workspace)`)

| Surface | Before → After (samples) |
|---|---|
| `intelligence/article-composer` | `Es. New KITAS Rules...` → `e.g. New KITAS Rules...` · `Incolla contenuto...` → `Paste raw content...` |
| `dashboard` (admin KPI row) | `Clienti/Processi/Fatture` → `Clients/Cases/Invoices` · `da incassare` → `to collect` · `N attivi · M critici` → `N active · M critical` · `in attesa`/`tutte pagate` → `pending`/`all paid` · `… incassato` → `… collected` |
| `analytics/funnel` | `Caricamento…` → `Loading…` · `Errore:` → `Error:` · `Sessioni totali/Conversioni/Tasso conversione` → `Total sessions/Conversions/Conversion rate` · `Nessun dato disponibile.` → `No data available.` |
| `clients` | `Caricamento mappa…` → `Loading map…` (+ `ClientiPage` → `ClientsPage` identifier rename) |
| `clients/[id]/OracleChat` | `🔮 Chiedi all'Oracle` → `🔮 Ask the Oracle` · 4 quick prompts EN · `Fai una domanda sul cliente…` → `Ask a question about this client…` · `Invia domanda` → `Send question` · `Consultando l'Oracle…` → `Consulting the Oracle…` · `Errore nella richiesta` → `Request failed` · `Fonti` → `Sources` |

~24 strings across 5 files. Out of scope by design: marketing/blog/client-portal routes (bilingual by design), `/dream` (outside workspace), `schema.d.ts` (generated).

## Tests

- New `apps/mouth/src/lib/strings.test.ts` (3 tests): dictionary values are English; the 5 normalized surfaces import the dictionary and carry **no hardcoded Italian** (grep-style markers, chosen to avoid English false-positives); composer renders dictionary placeholders.
- Full `apps/mouth` vitest suite: **1650 passed**. `tsc --noEmit`: clean. Prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)