### PR TITLE
fix(infra): per-attempt watchdog for nuz_db_refresh DUMP_MODE=fly-ssh (19-min hang)

### DIFF
--- a/scripts/nuz_db_refresh.sh
+++ b/scripts/nuz_db_refresh.sh
@@ -39,7 +39,9 @@
 #         PROXY_WAIT (default 25 — seconds to wait for a local proxy before pro fallback),
 #         NUZ_APP_DB (override the clients-table DB probe), FLY_PG_PORT (default 5433 —
 #         in-container postgres TCP port), FLY_PGDUMP/FLY_PSQL (default /usr/lib/postgresql/17/bin/*),
-#         FLY_SSH_RETRIES (default 4 — stream retries for the flaky tunnel).
+#         FLY_SSH_RETRIES (default 4 — stream retries for the flaky tunnel),
+#         FLY_SSH_TIMEOUT (default 300 — per-attempt wall-clock watchdog; the tunnel can HANG a
+#         single fly-ssh attempt for ~19min, so each attempt is SIGKILLed past this).
 
 set -euo pipefail
 
@@ -310,18 +312,30 @@ fi
 REMOTE
 )"
 
-    local attempt rc
+    # Per-attempt wall-clock watchdog: the Fly tunnel can HANG an individual `fly ssh console`
+    # mid-stream indefinitely (19-min hang observed 2026-06-12), not just fail fast — a single
+    # stuck attempt would blow the whole retry budget. macOS /bin/bash has no `timeout(1)`, so we
+    # run the console in the background and a watchdog SIGKILLs it after FLY_SSH_TIMEOUT seconds.
+    local FLY_SSH_TIMEOUT="${FLY_SSH_TIMEOUT:-300}"  # 5 min — generous for a ~15M dump, < the 19m hang
+    local attempt rc child wd
     for attempt in $(seq 1 "$FLY_SSH_RETRIES"); do
-        log "fly-ssh mode: dump attempt $attempt/$FLY_SSH_RETRIES (streaming -Fc over ssh-console) ..."
+        log "fly-ssh mode: dump attempt $attempt/$FLY_SSH_RETRIES (streaming -Fc, ${FLY_SSH_TIMEOUT}s watchdog) ..."
         # stdin = ONLY the RO password (consumed by the script's `read`). The script runs via
         # `-C` (bash -c <script>), so a partial/raced handshake can't echo the password as a
         # command — stdin is data, not the script source. stdout = the -Fc dump → $DUMP_FILE.
-        if printf '%s\n' "$RO_PASS" \
+        printf '%s\n' "$RO_PASS" \
             | fly ssh console -a "$FLY_PG_APP" --machine "$MACHINE" --pty=false \
-                -C "/bin/bash -c $(_shq "$remote_script")" >"$DUMP_FILE" 2>/tmp/flyssh.err; then
-            rc=0
-        else
-            rc=$?
+                -C "/bin/bash -c $(_shq "$remote_script")" >"$DUMP_FILE" 2>/tmp/flyssh.err &
+        child=$!
+        # Watchdog: after the timeout, hard-kill the (likely-hung) console child.
+        ( sleep "$FLY_SSH_TIMEOUT"; kill -9 "$child" 2>/dev/null ) &
+        wd=$!
+        if wait "$child"; then rc=0; else rc=$?; fi
+        # Stop the watchdog if the attempt finished on its own.
+        kill "$wd" 2>/dev/null; wait "$wd" 2>/dev/null || true
+        # rc 137 = SIGKILL by the watchdog (timed-out hang) → treat as a retryable failure.
+        if [ "$rc" -eq 137 ]; then
+            log "fly-ssh mode: attempt $attempt HUNG > ${FLY_SSH_TIMEOUT}s — watchdog killed it (tunnel stall)"
         fi
         # Permission error = STOP (never retry into a role escalation, W38)
         if grep -q 'FLYSSH-PERM' /tmp/flyssh.err 2>/dev/null; then


### PR DESCRIPTION
## What
Adds a per-attempt wall-clock watchdog to `dump_fly_ssh()` in `scripts/nuz_db_refresh.sh`.

## Why
Follow-up of #1372. The AC4 empirical run surfaced that the Fly tunnel can **HANG** an individual `fly ssh console` mid-stream **indefinitely** (19-min hang observed), not just fail fast — so a single stuck attempt blew the whole 4× retry budget and wedged the run.

## How
macOS `/bin/bash` has no `timeout(1)`, so each attempt now runs the console in the background with a watchdog that `kill -9`s it after `FLY_SSH_TIMEOUT` seconds (default **300** — generous for a ~15M dump, well under the observed hang). `rc 137` (SIGKILL) is treated as a **retryable** failure → the next attempt gets a fresh tunnel.

## Validation
- `bash -n` clean.
- Watchdog self-test: a 20s "hung" child is killed at the 3s test timeout (`rc=137`, elapsed 3s not 20s); a fast child finishes `rc=0` with the watchdog cancelled.

## Note
AC4 itself (the actual prod snapshot) is **still gated on a stable M5→Fly tunnel** — an infra flake, not this code. This PR just stops one hung attempt from stalling the whole run, so a future retry has a better shot at catching a good window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)