### PR TITLE
feat(wr2): every carousel slide gets its own image — 6-8 slides, all hero (option A)

### DIFF
--- a/scripts/test_wr2_topic_type.py
+++ b/scripts/test_wr2_topic_type.py
@@ -253,7 +253,7 @@ def _make_parsed(extra_first: dict) -> dict:
             "body": "b",
             "image_prompt": "p",
         }
-        for n in range(2, 12)
+        for n in range(2, 9)
     ]
     return {"register": "analitico", "slides": [first] + rest}
 

--- a/scripts/tests/test_wr2_all_hero_slides.py
+++ b/scripts/tests/test_wr2_all_hero_slides.py
@@ -1,0 +1,127 @@
+"""
+Locks down the 2026-06-12 Antonello decision (option A): every WR2 carousel
+slide carries its own generated image — 6-8 slides, 6-8 images, flexible.
+
+Three contract points:
+  1. wr2_draft_generator._normalise_slides forces is_hero_image=True on EVERY
+     slide (cover, bodies, CTA closer) regardless of what the model returned.
+  2. composer._fill_placeholders fills statement-bomb's
+     {{statement_html_with_emphasis_span}} (previously NEVER filled -> raw
+     mustache shipped to the renderer on every CTA slide).
+  3. composer._hero_bg_to_img fallback inject (layouts with no .hero div,
+     i.e. statement-bomb) must NOT paint the image OVER the text: content is
+     raised above the img and a legibility scrim sits between them.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+SCRIPTS_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from wr2_draft_generator import _normalise_slides  # noqa: E402
+from wr2_html_renderer.composer import (  # noqa: E402
+    _fill_placeholders,
+    _hero_bg_to_img,
+    map_slide_to_family,
+)
+
+
+def _raw_slide(n: int, *, hero: bool = False, **extra) -> dict:
+    s = {
+        "slide_number": n,
+        "slide_type": "body",
+        "is_cover": n == 1,
+        "is_hero_image": hero,
+        "headline": f"Headline {n}",
+        "subhead": f"Sub {n}",
+        "body": f"Body {n}",
+        "image_prompt": f"editorial scene {n}",
+    }
+    s.update(extra)
+    return s
+
+
+def _parsed(num_slides: int, heroes: set[int] | None = None) -> dict:
+    heroes = heroes or set()
+    return {
+        "register": "analitico",
+        "slides": [_raw_slide(i, hero=i in heroes) for i in range(1, num_slides + 1)],
+    }
+
+
+def test_all_slides_forced_hero_even_when_model_marks_none() -> None:
+    _, slides = _normalise_slides(_parsed(7))
+    assert len(slides) == 7
+    assert all(s["is_hero_image"] for s in slides)
+
+
+def test_all_slides_hero_on_short_and_long_carousels() -> None:
+    for n in (6, 8):
+        _, slides = _normalise_slides(_parsed(n, heroes={1, 3}))
+        assert all(s["is_hero_image"] for s in slides), f"n={n}"
+
+
+def test_cover_flags_preserved() -> None:
+    _, slides = _normalise_slides(_parsed(6))
+    assert slides[0]["is_cover"] is True
+    assert all(not s["is_cover"] for s in slides[1:])
+
+
+STATEMENT_SKELETON = (
+    "<html><head><style>.emphasis{color:yellow}</style></head><body>"
+    '<div class="statement">{{statement_html_with_emphasis_span}}</div>'
+    "</body></html>"
+)
+
+
+def test_statement_emphasis_placeholder_filled_from_headline() -> None:
+    slide = {"headline": "Where this leaves you", "body": ""}
+    html = _fill_placeholders(STATEMENT_SKELETON, slide, hero_filename=None)
+    assert "{{statement_html_with_emphasis_span}}" not in html
+    assert "Where this leaves" in html
+    assert '<span class="emphasis">you</span>' in html
+
+
+def test_statement_emphasis_escapes_html() -> None:
+    slide = {"headline": "A <b>risky</b> & bold move", "body": ""}
+    html = _fill_placeholders(STATEMENT_SKELETON, slide, hero_filename=None)
+    assert "<b>" not in html
+    assert "&amp;" in html
+
+
+NO_HERO_DIV_SKELETON = (
+    "<html><head><style>body{background:#000}</style></head><body>"
+    '<div class="statement">BIG WORDS</div>'
+    "</body></html>"
+)
+
+
+def test_fallback_inject_adds_img_scrim_and_raises_content() -> None:
+    html = _hero_bg_to_img(NO_HERO_DIV_SKELETON, "slide-08-hero.jpg")
+    assert 'src="slide-08-hero.jpg"' in html
+    assert "hero-scrim" in html
+    assert "z-index" in html
+
+
+def test_hero_div_path_unchanged() -> None:
+    skeleton = (
+        "<html><head><style>"
+        ".hero{background-image:url('{{image_url}}');}"
+        "</style></head><body>"
+        '<div class="hero" data-zone-type="hero-photo"></div>'
+        "</body></html>"
+    )
+    html = _hero_bg_to_img(skeleton, "h.jpg")
+    assert '<img class="hero" src="h.jpg"' in html
+    assert "hero-scrim" not in html
+
+
+def test_routing_cover_mid_cta_with_all_hero() -> None:
+    _, slides = _normalise_slides(_parsed(7))
+    total = len(slides)
+    fams = [map_slide_to_family(s, i, total) for i, s in enumerate(slides, start=1)]
+    assert fams[0] == "cover-photo"
+    assert fams[-1] == "statement-bomb"
+    assert all(f == "photo-headline-yellow-sub" for f in fams[1:-1])

--- a/scripts/tests/test_wr2_draft_generator_enriched_prompt.py
+++ b/scripts/tests/test_wr2_draft_generator_enriched_prompt.py
@@ -364,7 +364,7 @@ def test_normalise_slides_caps_subhead_field() -> None:
     """End-to-end through _normalise_slides: a long cover subhead is capped
     on the 'subhead' field of the persisted slide dict."""
     slides_in = []
-    for i in range(1, 12):
+    for i in range(1, 9):
         slides_in.append({
             "slide_number": i,
             "slide_type": "cover" if i == 1 else "body",

--- a/scripts/wr2_draft_generator.py
+++ b/scripts/wr2_draft_generator.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""WR2 Draft Generator — Claude writes 11 English slides, Imagen generates cover only.
+"""WR2 Draft Generator — Claude writes 6-8 English slides, every slide gets a generated image.
 
 Daily cron (05:15 WITA): picks drafts with status='briefed', calls Claude
-OAuth to compose the 11-slide JSON (English content, register in the 7
-Council tones), runs Imagen 4 Ultra for the cover only (body slides keep
-image_url=None and carry image_prompt for manual generation by the team),
+OAuth to compose the 6-8 slide JSON (English content, register in the 7
+Council tones; every slide is is_hero_image=true per the 2026-06-12
+decision), runs Imagen 4 Ultra for the cover only (body slides keep
+image_url=None and carry image_prompt for downstream generation),
 uploads the cover to Tigris, persists slides_json to the draft and flips
 status to 'drafts'.
 
@@ -139,7 +140,7 @@ SYSTEM_INSTRUCTIONS = """You are the Draft Composer of War Room 2.0 for Bali Zer
 
 Bali Zero is an Indonesian business-services agency serving international expats, foreign investors, digital nomads and retirees — primarily English-speaking, from ~50 countries. The Italian community is one slice among many; never default to Italian.
 
-GOAL: produce the 11-slide structure of an Instagram carousel that reads like a NARRATIVE (Wired/The Atlantic editorial), not a legal brief.
+GOAL: produce the 6-8 slide structure (flexible: pick the count the story needs) of an Instagram carousel that reads like a NARRATIVE (Wired/The Atlantic editorial), not a legal brief.
 
 TONE REGISTERS (pick ONE of the 7 based on content):
 - rituale (ritual): symbolic events, cultural anniversaries, turning points
@@ -158,12 +159,12 @@ HARD RULES:
 - Headlines max 60 characters
 - Body max 280 characters
 - Slide 1 = cover (is_cover: true, is_hero_image: true ALWAYS)
-- Slide 11 = CTA to Bali Zero
+- LAST slide = CTA to Bali Zero
 - Every slide must include image_prompt: editorial scene in Wired/Bloomberg style, NO stock photos, NO handshakes, NO passport close-ups
 
-TONAL PALETTE (per hero slide — drives the photographic look, fights monotony):
-Each `is_hero_image: true` slide MUST include a `tonal_palette` field. Pick ONE
-that fits the slide's mood; do NOT use the same palette for every hero slide,
+TONAL PALETTE (per slide — drives the photographic look, fights monotony):
+EVERY slide MUST include a `tonal_palette` field (all slides are hero). Pick ONE
+that fits the slide's mood; do NOT use the same palette for every slide,
 and vary it across carousels on the same topic (the brand forbids two
 same-domain carousels looking identical):
 - "warm-ochre": warm, intimate, document/interior mood (the house style)
@@ -171,10 +172,9 @@ same-domain carousels looking identical):
 - "monochrome": stark, archival, historical, high-gravity
 - "high-contrast": tense, confrontational, urgent
 - "bleached-daylight": open, hopeful, resolution, "the way out"
-Non-hero slides do not need it.
 
-IMAGE MODE (per hero slide — the SCENE TYPE, drives anti-sameness):
-Each `is_hero_image: true` slide MUST include an `image_mode` field naming the
+IMAGE MODE (per slide — the SCENE TYPE, drives anti-sameness):
+EVERY slide MUST include an `image_mode` field naming the
 KIND of scene. Pick the ONE mode that matches what the photo depicts, and VARY
 it across the slides (two same-domain carousels must not repeat the same dominant
 mode — the brand forbids monotony). Choose from EXACTLY these 9 modes:
@@ -187,21 +187,15 @@ mode — the brand forbids monotony). Choose from EXACTLY these 9 modes:
 - "calendar-photo": dates, deadlines, time made visible
 - "data-visualization": a chart, graph, map, or numbers as the image
 - "cultural-photo": Indonesian/Balinese culture, ritual, place, daily life
-Use the slug verbatim (e.g. "desk-document"). Non-hero slides may omit it.
+Use the slug verbatim (e.g. "desk-document").
 
-HERO IMAGE SELECTION (MANDATORY):
-You MUST mark exactly 4 slides as `is_hero_image: true`:
-- Slide 1 (cover) — ALWAYS hero
-- Slide 11 (CTA closer) — ALWAYS hero
-- 2 mid-carousel slides at NARRATIVE TURNING POINTS — pick the slides that
-  open a new beat (e.g. "the shift", "the stakes", "fiction vs substance"),
-  not the ones that list facts or numbers.
-
-The remaining 7 slides have `is_hero_image: false` — they keep the
-template's tipografia layout without an image. Hero slides get a
-full-bleed photo as background; non-hero slides are clean text-on-color.
-
-Output exactly 4 slides with `is_hero_image: true`. Not 3, not 5.
+HERO IMAGE SELECTION (MANDATORY — decision 2026-06-12, option A):
+EVERY slide is `is_hero_image: true` — cover, bodies AND the CTA closer.
+Each slide gets its own generated full-bleed photo as background; there
+are NO text-only slides. Therefore EVERY slide MUST carry `image_prompt`,
+`tonal_palette` AND `image_mode`. Vary the image_mode across the slides:
+NEVER let one mode dominate the whole carousel — use at least 4 of the 9
+modes across the 6-8 slides.
 
 STORYTELLING DIRECTIVES (overrides any default factual mode):
 
@@ -242,11 +236,11 @@ STORYTELLING DIRECTIVES (overrides any default factual mode):
    quoted phrase, or a concrete scene. Then introduce the law later if
    needed.
 
-7. Bali Zero "take" slides (typically slide 2 and slide 11): write as
+7. Bali Zero "take" slides (typically slide 2 and the last slide): write as
    first-person editorial voice ("Our read:", "What we are seeing:"),
    NOT as a third-party legal summary.
 
-8. The "What This Means For You" type closer (slide 11): SHORT, DIRECT,
+8. The "What This Means For You" type closer (the last slide): SHORT, DIRECT,
    action-oriented. Two sentences max. Ends with the Bali Zero CTA.
 
 9. The cover "subhead" MUST be 1-6 words maximum — a short tag/category/
@@ -277,32 +271,35 @@ Structure:
       "slide_number": 2,
       "slide_type": "take",
       "is_cover": false,
-      "is_hero_image": false,
+      "is_hero_image": true,
       "headline": "Our read: ...",
       "body": "...",
-      "image_prompt": "editorial scene, 1-2 sentences"
+      "image_prompt": "editorial scene, 1-2 sentences",
+      "tonal_palette": "cool-teal",
+      "image_mode": "event-photo"
     },
-    // ... 7 more slides — 2 of them at narrative turning points must have is_hero_image: true ...
+    // ... 4 more slides, ALL is_hero_image: true ...
     {
-      "slide_number": 11,
+      "slide_number": 7,
       "slide_type": "cta",
       "is_cover": false,
       "is_hero_image": true,
       "headline": "Where this leaves you",
       "body": "One clear consequence, then one concrete next step. Reach Bali Zero when the deadline is yours, not theirs.",
+      "image_prompt": "editorial scene, 1-2 sentences",
+      "tonal_palette": "bleached-daylight",
       "image_mode": "human-silhouette"
     }
   ]
 }
 
-REPEAT (MUST OBEY): every slide object MUST include the `is_hero_image` field
-(true or false). Slide 1 hero=true, slide 11 hero=true, plus exactly 2 more
-slides hero=true at narrative turning points = 4 hero slides total per
-carousel. The other 7 slides have is_hero_image=false. THIS IS NON-NEGOTIABLE.
+REPEAT (MUST OBEY): EVERY slide object MUST have `is_hero_image: true` — no
+exceptions, no text-only slides. Every slide MUST carry `image_prompt`,
+`tonal_palette` and `image_mode`. THIS IS NON-NEGOTIABLE.
 
-ALSO MANDATORY: every is_hero_image=true slide MUST carry an `image_mode` (one
-of the 9 slugs above), and the 4 hero slides should use at least 3 DISTINCT
-modes — do not paint all four with the same scene type.
+ALSO MANDATORY: vary the `image_mode` (one of the 9 slugs above) across the
+slides — use at least 4 DISTINCT modes per carousel; never let one scene type
+dominate the whole carousel.
 """
 
 
@@ -437,7 +434,7 @@ Content:
 
 ---
 
-Produce the full 11-slide JSON NOW. English content. No text outside the JSON object.
+Produce the full 6-8 slide JSON NOW. English content. No text outside the JSON object.
 """
 
 
@@ -786,8 +783,8 @@ def _normalise_slides(parsed: dict[str, Any]) -> tuple[str, list[dict[str, Any]]
         )
 
     slides = parsed.get("slides") or []
-    if len(slides) < 6 or len(slides) > 11:
-        raise ValueError(f"Expected 6-11 slides, got {len(slides)}")
+    if len(slides) < 6 or len(slides) > 8:
+        raise ValueError(f"Expected 6-8 slides, got {len(slides)}")
 
     normalised: list[dict[str, Any]] = []
     for i, raw in enumerate(slides, start=1):
@@ -819,27 +816,14 @@ def _normalise_slides(parsed: dict[str, Any]) -> tuple[str, list[dict[str, Any]]
 
     if normalised:
         normalised[0]["is_cover"] = True
-        # Slide 1 is ALWAYS hero (cover image). Force-set even if Claude omitted it.
-        normalised[0]["is_hero_image"] = True
         for s in normalised[1:]:
             s["is_cover"] = False
-        # Slide 11 (last, the CTA closer) is ALWAYS hero too.
-        if len(normalised) >= 11:
-            normalised[10]["is_hero_image"] = True
-
-    # Defensive: if Claude produced 0 hero slides (ignoring the prompt),
-    # auto-promote a sensible mid-carousel default so image-generator has
-    # work to do. Pick slides at narrative-turning-point positions.
-    hero_count = sum(1 for s in normalised if s.get("is_hero_image"))
-    if hero_count < 2 and len(normalised) >= 11:
-        # Force-promote slides 3 and 6 (typical turning points) if no
-        # other hero was selected. This is a fallback, not the desired path.
-        normalised[2]["is_hero_image"] = True   # slide 3
-        normalised[5]["is_hero_image"] = True   # slide 6
-        logger.warning(
-            "Claude returned %d hero slides (need >=2 mid). Auto-promoted slides 3 and 6.",
-            hero_count,
-        )
+        # Decisione Antonello 2026-06-12 (option A): EVERY slide carries its
+        # own generated image — force is_hero_image=True on all slides (cover,
+        # bodies, CTA closer) regardless of what the model returned. This
+        # eliminates text-only slides routed to photo layouts without a photo.
+        for s in normalised:
+            s["is_hero_image"] = True
 
     return register, normalised
 

--- a/scripts/wr2_html_renderer/composer.py
+++ b/scripts/wr2_html_renderer/composer.py
@@ -31,6 +31,7 @@ import json
 import logging
 import re
 from dataclasses import dataclass
+from html import escape as _html_escape
 from pathlib import Path
 from typing import Any
 
@@ -186,12 +187,21 @@ def _hero_bg_to_img(html: str, hero_filename: str) -> str:
         return html
 
     # Fallback: no <div class="hero"> — inject a positioned <img> after <body>.
+    # The image must NOT paint OVER the slide text (statement-bomb etc.): the
+    # existing content is raised above the img (z-index:1) and a legibility
+    # scrim (.hero-scrim) sits between image and text.
     hero_img_css = (
         "\n.hero-img{position:absolute;inset:0;width:100%;height:100%;"
         "object-fit:cover;z-index:0;}\n"
+        ".hero-scrim{position:absolute;inset:0;"
+        "background:rgba(10,10,10,0.55);z-index:0;}\n"
+        "body > *:not(.hero-img):not(.hero-scrim){position:relative;z-index:1;}\n"
     )
     html = html.replace("</style>", hero_img_css + "</style>", 1)
-    img_tag = f'<img class="hero-img" src="{hero_filename}" alt="" data-zone-type="hero-photo">'
+    img_tag = (
+        f'<img class="hero-img" src="{hero_filename}" alt="" data-zone-type="hero-photo">'
+        '<div class="hero-scrim"></div>'
+    )
     html = re.sub(r"(<body[^>]*>)", r"\1\n  " + img_tag, html, count=1)
     return html
 
@@ -873,6 +883,21 @@ def _fill_placeholders(
     # statement-bomb uses {{statement}}; map from headline/body
     statement = (slide.get("statement") or headline or body).strip()
 
+    # statement-bomb's richer placeholder {{statement_html_with_emphasis_span}}
+    # was previously NEVER filled — the raw mustache shipped to the renderer on
+    # every CTA slide. Build it from the statement: HTML-escape the text, then
+    # wrap the LAST word in <span class="emphasis"> (the skeleton's accent).
+    statement_emphasis_html = ""
+    if statement:
+        words = _html_escape(statement).split()
+        if len(words) > 1:
+            statement_emphasis_html = (
+                " ".join(words[:-1])
+                + f' <span class="emphasis">{words[-1]}</span>'
+            )
+        else:
+            statement_emphasis_html = f'<span class="emphasis">{words[0]}</span>'
+
     replacements = {
         "{{heading}}": headline,
         "{{subheading}}": subhead,
@@ -880,6 +905,7 @@ def _fill_placeholders(
         "{{body}}": body_html,
         "{{regulation_code}}": reg,
         "{{statement}}": statement,
+        "{{statement_html_with_emphasis_span}}": statement_emphasis_html,
     }
     for k, v in replacements.items():
         html = html.replace(k, v)


### PR DESCRIPTION
## What

Antonello decision 2026-06-12 (option A): WR2 carousels become **6-8 slides (flexible), every slide with its own generated full-bleed photo** (`is_hero_image: true` on all).

This removes the text-only body slides that `map_slide_to_family` routed to `photo-headline-yellow-sub` with no image — the anthracite void that made every draft fail the critic gate (STRATO 8, the architectural root of the M1 block).

## Changes

- **`wr2_draft_generator.py`**: prompt rewritten to the 6-8/all-hero contract (`image_prompt` + `tonal_palette` + `image_mode` mandatory on every slide, ≥4 distinct modes per carousel); `_normalise_slides` force-sets `is_hero_image=True` on every slide; slide-count validator 6-8.
- **`composer.py`**: fills statement-bomb's `{{statement_html_with_emphasis_span}}` (was NEVER filled — raw mustache shipped on every CTA slide); last word wrapped in the emphasis span, HTML-escaped.
- **`composer.py`**: `_hero_bg_to_img` fallback inject (layouts with no `.hero` div, e.g. statement-bomb) no longer paints the image OVER the text — content raised to z-index:1 + rgba(10,10,10,.55) legibility scrim.
- **Tests**: new `test_wr2_all_hero_slides.py` (8 cases, TDD red→green); existing fixtures updated 11→8 slides, assertions unchanged.

## Verification

- New suite 8/8 green; related WR2 set 132 passed; backend consumers 122 passed.
- Full `scripts/tests/`: 737 passed; the 6 failed + 4 errors are pre-existing and identical on merge-base (verified empirically).

Downstream is count-agnostic (image generator iterates `hero_slides`, render apply iterates slides) — verified by grep + read this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)