### PR TITLE
fix(channels): silent-failure sweep — IG raise_for_status + telegram/router/webhook logging (F07,F39,F40,F43)

### DIFF
--- a/apps/backend-rag/backend/channels/instagram/adapter.py
+++ b/apps/backend-rag/backend/channels/instagram/adapter.py
@@ -12,6 +12,11 @@ from backend.channels.instagram.formatter import InstagramMessageFormatter
 
 logger = logging.getLogger(__name__)
 
+# Single source of truth for the Meta Graph API version used by this adapter.
+# F07 follow-up: send and mark-seen previously drifted (v22.0 vs v18.0) because
+# the version was inlined per-URL. Bump here, never per-call-site.
+GRAPH_API_VERSION = "v22.0"
+
 
 class InstagramChannelAdapter(BaseChannel):
     """Instagram Business API adapter."""
@@ -98,7 +103,7 @@ class InstagramChannelAdapter(BaseChannel):
             )
 
         account_id = self.instagram_config.instagram_account_id
-        url = f"https://graph.instagram.com/v22.0/{account_id}/messages"
+        url = f"https://graph.instagram.com/{GRAPH_API_VERSION}/{account_id}/messages"
         payload = {"recipient": {"id": channel_id}, "message": {"text": formatted_text}}
         headers = {"Authorization": f"Bearer {self.instagram_config.access_token}"}
 
@@ -108,7 +113,7 @@ class InstagramChannelAdapter(BaseChannel):
             logger.info("✅ Sent Instagram message to %s", channel_id)
 
             # Mark message as seen to prevent read-receipt webhook loops
-            seen_url = "https://graph.facebook.com/v22.0/me/messages"
+            seen_url = f"https://graph.facebook.com/{GRAPH_API_VERSION}/me/messages"
             seen_payload = {
                 "recipient": {"id": channel_id},
                 "sender_action": "mark_seen",

--- a/apps/backend-rag/backend/tests/unit/channels/test_instagram_adapter.py
+++ b/apps/backend-rag/backend/tests/unit/channels/test_instagram_adapter.py
@@ -21,7 +21,7 @@ os.environ.setdefault("OPENAI_API_KEY", "test_key")
 os.environ.setdefault("GOOGLE_API_KEY", "test_key")
 
 from backend.channels.base import ChannelResponse
-from backend.channels.instagram.adapter import InstagramChannelAdapter
+from backend.channels.instagram.adapter import GRAPH_API_VERSION, InstagramChannelAdapter
 from backend.channels.instagram.config import InstagramChannelConfig
 from backend.channels.instagram.formatter import InstagramMessageFormatter
 
@@ -260,6 +260,66 @@ class TestInstagramAdapter:
 
         # mark_seen must NOT have been called — exception propagated before it
         assert adapter.client.post.call_count == 1
+
+    async def test_send_response_meta_400_raises_via_real_transport(
+        self,
+        adapter: InstagramChannelAdapter,
+        simple_response: ChannelResponse,
+    ) -> None:
+        """F07 (MockTransport): a real httpx 400 from Meta must raise, not log success.
+
+        Unlike test_send_response_raises_on_meta_4xx (which mocks the response
+        object), this drives the REAL httpx client/response path via
+        MockTransport — so it fails if the adapter ever stops calling
+        raise_for_status() on the actual response.
+        """
+        requests_seen: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests_seen.append(request)
+            return httpx.Response(
+                400,
+                json={"error": {"message": "Invalid OAuth access token", "code": 190}},
+            )
+
+        adapter.client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        try:
+            with pytest.raises(httpx.HTTPStatusError):
+                await adapter.send_response("9876543210", simple_response)
+        finally:
+            await adapter.close()
+
+        # Exactly one request: the send failed, mark_seen must NOT have fired
+        assert len(requests_seen) == 1
+        assert GRAPH_API_VERSION in str(requests_seen[0].url)
+
+    async def test_send_response_meta_200_success_via_real_transport(
+        self,
+        adapter: InstagramChannelAdapter,
+        simple_response: ChannelResponse,
+    ) -> None:
+        """F07 (MockTransport): a real 200 completes the full path — send + mark_seen.
+
+        Both calls must hit the SAME Graph API version (module constant), the
+        previous drift was send=v22.0 vs mark-seen=v18.0.
+        """
+        requests_seen: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests_seen.append(request)
+            return httpx.Response(200, json={"message_id": "m_ok"})
+
+        adapter.client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        try:
+            await adapter.send_response("9876543210", simple_response)
+        finally:
+            await adapter.close()
+
+        # Send + mark_seen both happened, both on the unified API version
+        assert len(requests_seen) == 2
+        assert f"/{GRAPH_API_VERSION}/" in str(requests_seen[0].url)
+        assert f"/{GRAPH_API_VERSION}/" in str(requests_seen[1].url)
+        assert b"mark_seen" in requests_seen[1].content
 
     async def test_send_status_update_noop(
         self,


### PR DESCRIPTION
## Summary

Surgical sweep of the channel silent-failure cluster from the Fable-5 audit 2026-06-11 (F07, F39, F40, F43). **Re-verification on disk found 4/4 findings already fixed on main** — this PR ships only the two F07 residuals from the audit spec.

### Re-verification results (per finding)

| Finding | Status on disk | Fixed by |
|---|---|---|
| F07 (P1) IG send no status check | **already fixed** — `raise_for_status()` at `channels/instagram/adapter.py:107`, exception re-raised to `send_response_safe()` DLQ path | PR #1270 (`d7e477e36`) |
| F07 bis — Graph API version drift v22/v18 | versions aligned at v22.0 by #1270, **but as two inline literals** → residual shipped here | this PR |
| F39 (P3) telegram stream_response swallow | **already fixed** — guarded error-edit + `send_response_safe` fallback at `channels/telegram/adapter.py:356-387` | PR #1290 (`951d58bb2`) |
| F40 (P3) router persist DEBUG log | **already fixed** — WARNING + `_persist_failures` counter, channel/client ids, no message content | PR #1290 |
| F43 (P3) twitter/instagram_chat get_database swallow | **already fixed** — WARNING in both `app/routers/twitter.py` and `app/routers/instagram_chat.py` (note: files live under `app/routers/`, not `channels/`) | PR #1290 |

### Changes in this PR (F07 residuals)

- **`GRAPH_API_VERSION` module constant** in `channels/instagram/adapter.py`, used by both the send URL and the mark-seen URL — single source of truth so the versions cannot silently drift again (the original bug was send=v22.0 vs mark-seen=v18.0).
- **Two `httpx.MockTransport` regression tests** (the #1270 test mocks the response object's `raise_for_status`; these drive the REAL httpx client/response path):
  - `test_send_response_meta_400_raises_via_real_transport` — real 400 → `HTTPStatusError` raised, mark_seen NOT fired (1 request).
  - `test_send_response_meta_200_success_via_real_transport` — real 200 → send + mark_seen both complete, both on the unified `GRAPH_API_VERSION`.

### Tests

- 122/122 `backend/tests/channels/` + IG adapter unit tests green
- 447 passed on `-k "instagram or adapter"` sweep
- Full pre-push gate: **14689 passed, 847 skipped** (local PG17 CI-parity)
- ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)