### PR TITLE
fix(security): F01 sweep — silence httpx/httpcore Telegram-token logging in remaining scripts

### DIFF
--- a/scripts/bz_content_broadcaster.py
+++ b/scripts/bz_content_broadcaster.py
@@ -22,6 +22,10 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s [%(levelname)s] %(message)s')
+# Silence httpx/httpcore INFO logs — httpx at INFO logs the full request URL,
+# which leaks the Telegram bot token in api.telegram.org/bot<token>/... calls (F01).
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("httpcore").setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 # Paths

--- a/scripts/codex_tri_llm_review.py
+++ b/scripts/codex_tri_llm_review.py
@@ -64,6 +64,10 @@ LOG_DIR.mkdir(parents=True, exist_ok=True)
 
 LOG_FORMAT = "%(asctime)s [%(levelname)s] %(message)s"
 logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+# Silence httpx/httpcore INFO logs — httpx at INFO logs the full request URL,
+# which leaks the Telegram bot token in api.telegram.org/bot<token>/... calls (F01).
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("httpcore").setLevel(logging.WARNING)
 logger = logging.getLogger("tri-llm-review")
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/scripts/wr2_html_render_apply.py
+++ b/scripts/wr2_html_render_apply.py
@@ -57,8 +57,9 @@ from backend.services.canva_renderer_v2 import _pg  # noqa: E402
 from wr2_html_renderer.claude_vision import VisionTransient  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
-# Silence httpx INFO logs that would otherwise leak the Telegram bot token in the request URL
+# Silence httpx/httpcore INFO logs that would otherwise leak the Telegram bot token in the request URL
 logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("httpcore").setLevel(logging.WARNING)
 logger = logging.getLogger("wr2_html_apply")
 
 MAX_DRAFTS_PER_RUN = 1


### PR DESCRIPTION
## Scope

Surgical completion of the two active secret-leak findings from the Fable audit 2026-06-11 (F01 + F02). Re-verified both on disk before editing: **the primary fixes for both already landed in PR #1271** (`98ad94386`). This PR closes the F01 *sweep* residuals that #1271 did not cover.

## F01 — Telegram bot token leaked into logs by httpx INFO logging

httpx at INFO level logs the full request URL (`HTTP Request: POST https://api.telegram.org/bot<TOKEN>/sendMessage ...`), so any script with `logging.basicConfig(level=INFO)` + an httpx Telegram call writes the bot token into its log file on every alert.

Fixed in this PR (each gets `logging.getLogger("httpx").setLevel(logging.WARNING)` + same for `httpcore`, immediately after `basicConfig`):

- `scripts/wr2_html_render_apply.py` — httpx was already silenced by #1271; added the missing `httpcore` silencing (defense-in-depth).
- `scripts/codex_tri_llm_review.py` — **was actively leaking**: `httpx.Client` posts to the bot-token URL, `basicConfig(level=INFO)` at L66, no silencing → token written to `~/logs/tri-llm-review/` on every panel notify.
- `scripts/bz_content_broadcaster.py` — **was actively leaking**: `httpx.post` to bot-token URL, `basicConfig(level=INFO)` at L24, no silencing.

Sweep evidence (`scripts/`, `.venv` excluded): 36 Python scripts reference `api.telegram.org`. All others are NOT in the leak class:
- urllib-based Telegram calls (urllib never logs URLs): `wr2_image_generator.py`, `wr2_topic_selector.py`, `wa_media_pull_worker.py`, `intel-lake-outbox-drain.py`, `sota_fase0_final_check.py`, `wr2_canva_garbage_collector.py`, `wr2_daily_metrics.py`, and the rest.
- `federation_orchestrator.py` uses httpx + bot-token URL but configures **no logging at all** (no root handler → httpx INFO records are dropped; lastResort emits WARNING+ only). Not strictly affected; noted as a future defense-in-depth candidate.
- Zero `requests`-library Telegram callers found.

No token value appears anywhere in this diff or in the commit message.

## F02 — Google OAuth client_secret hardcoded in `apps/backend-rag/scripts/bulk_populate_clients.py`

**Already fully fixed by PR #1271** — re-verified on disk this session: both credential sets (the `get_drive_access_token` refresh path L151-152 AND the module-level rclone constants L188-190) now read from env vars (`GOOGLE_OAUTH_CLIENT_ID`/`GOOGLE_OAUTH_CLIENT_SECRET`, `GOOGLE_OAUTH_CLIENT_ID_RCLONE`/`GOOGLE_OAUTH_CLIENT_SECRET_RCLONE`/`GOOGLE_OAUTH_REFRESH_TOKEN`). `grep -nE "GOCSPX"` matches only placeholder text in rotation comments. **No code change needed — skipped.**

## ⚠️ Operator action still required

**Rotate the Telegram bot token (BotFather) and the Google OAuth client_secret (Cloud Console) — both values were exposed in logs/git history; this PR stops future leaks only.** Specifically:
- Telegram bot token: appeared in `~/logs/wr2-html-apply.log` (pre-#1271) AND in `~/logs/tri-llm-review/` + broadcaster logs (until this PR merges).
- Both `GOCSPX-*` client secrets: were committed in plaintext in git history (pre-#1271). Rotation does not happen automatically from either PR.

## Verification

- `python3 -m py_compile` clean on all 3 edited files.
- Pre-push gate: full backend suite **14687 passed, 847 skipped** (local PG17 CI-parity gate).
- Diff is 10 insertions / 1 deletion across 3 files; no behavior change beyond logger levels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)