### PR TITLE
fix(wa-bridge): guard family over/under-match sweep + REGULATORY_FACTS expiry (F05/F06/F11-F14/F36-F38)

### DIFF
--- a/apps/backend-rag/backend/tests/unit/scripts/test_openclaw_whatsapp_bridge_script.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_openclaw_whatsapp_bridge_script.py
@@ -557,6 +557,80 @@ def test_nominee_guard_still_fires_on_real_nominee_with_atas_nama() -> None:
 
 
 # ---------------------------------------------------------------------------
+# F06 hardening (2026-06-13): "'s name" / "atas nama" are WEAK tokens — they
+# need an asset/proxy co-occurrence and never fire in booking/tiket/rekening
+# naming contexts. Both polarities per the W73 matrix convention.
+# ---------------------------------------------------------------------------
+
+def test_nominee_guard_does_not_fire_on_booking_atas_nama() -> None:
+    """A hotel-booking request 'atas nama saya' is reservation NAMING, not a
+    nominee asset-holding request — it was clobbered with the illegal-nominee
+    canonical before the hardening."""
+    correct = (
+        "Ya, kami bisa bantu booking hotel atas nama Anda. Kirim tanggal "
+        "check-in dan nama lengkap sesuai paspor."
+    )
+    assert bridge._is_nominee_intent("bisa booking hotel atas nama saya?") is False
+    assert (
+        bridge._guard_nominee_reply("Bisa booking hotel atas nama saya?", correct, "id")
+        == correct
+    )
+
+
+def test_nominee_guard_does_not_fire_on_rekening_atas_nama() -> None:
+    """A bank-transfer question about a 'rekening atas nama istri' is account
+    NAMING — the proxy word ('istri') alone must not turn it into nominee
+    intent."""
+    correct = (
+        "Bisa, transfer ke rekening atas nama istri Anda diterima selama "
+        "datanya cocok dengan data pembayaran."
+    )
+    assert (
+        bridge._is_nominee_intent("bisa transfer ke rekening atas nama istri saya?")
+        is False
+    )
+    assert (
+        bridge._guard_nominee_reply(
+            "Bisa transfer ke rekening atas nama istri saya?", correct, "id"
+        )
+        == correct
+    )
+
+
+def test_nominee_guard_does_not_fire_on_plain_possessive_name() -> None:
+    """"'s name" with NO asset/proxy co-occurrence (e.g. asking for the
+    notary's name) is everyday possessive English, not nominee intent."""
+    message = "Can you confirm the notary's name for tomorrow's appointment?"
+    correct = (
+        "The notary for your appointment is confirmed for 10am; the team will "
+        "send the full name and office address shortly."
+    )
+    assert bridge._is_nominee_intent(bridge._normalize_text(message)) is False
+    assert bridge._guard_nominee_reply(message, correct, "en") == correct
+
+
+def test_nominee_guard_still_fires_on_weak_name_with_asset() -> None:
+    """Clobber polarity: "'s name" WITH an asset + proxy co-occurrence is a
+    genuine nominee request — a soft 'usually fine' answer must be replaced
+    with the illegality canonical."""
+    unsafe = "Yes, that is a common approach and usually fine in practice."
+    guarded = bridge._guard_nominee_reply(
+        "Can we put the villa certificate in my wife's name?", unsafe, "en"
+    )
+    assert guarded != unsafe
+    assert "illegal" in guarded.lower()
+
+
+def test_nominee_intent_compositional_beats_admin_token() -> None:
+    """A genuine compositional nominee request must fire even when the message
+    incidentally contains an administrative token (the old exclusion-first
+    ordering returned False here)."""
+    assert bridge._is_nominee_intent(
+        "my indonesian friend will hold the land title for me, then send me the invoice"
+    )
+
+
+# ---------------------------------------------------------------------------
 # F13: villa⊂village in _is_villa_kbli_query and _guard_villa_kbli_reply
 # ---------------------------------------------------------------------------
 

--- a/scripts/openclaw_whatsapp_bridge.py
+++ b/scripts/openclaw_whatsapp_bridge.py
@@ -1286,21 +1286,27 @@ _NOMINEE_DIRECT_TERMS = (
     "under their name",
     "in his name",
     "in her name",
-    # NOTE: "'s name" and "atas nama" are kept here but _is_nominee_intent
-    # applies an exclusion check for company/invoice contexts (F06 2026-06-11):
-    # "change my company's name" and "faktur atas nama PT saya" must NOT fire.
-    "'s name",  # "in my friend's name", "in her husband's name", etc.
-    "atas nama",
     "pinjam nama",
     "pakai nama",
     "prestanome",
     "intestare",
     "intesta a",
 )
+# Weak name-tokens (F06 hardening 2026-06-13): "'s name" / "atas nama" appear in
+# everyday administrative sentences ("the notary's name", "booking atas nama
+# saya"), so ALONE they are not nominee intent. They fire only when the message
+# also carries an asset or proxy co-occurrence, and never in an
+# administrative-naming context (_NOMINEE_FALSE_POSITIVE_TERMS below).
+_NOMINEE_WEAK_NAME_TERMS = (
+    "'s name",  # "in my friend's name", "in her husband's name", etc.
+    "atas nama",
+)
 # Contexts that look like nominee trigger terms but are NOT nominee intent.
 # "company's name" / "company name" → corporate name change (not land holding).
 # "atas nama PT" → invoice / document issued in the name of a company.
 # "faktur" / "invoice" / "ubah nama" (change name) → administrative, not holding.
+# booking / tiket / rekening (F06 hardening) → reservation, ticket, or bank
+# account NAMING ("booking hotel atas nama saya"), not asset holding.
 _NOMINEE_FALSE_POSITIVE_TERMS = (
     "company name",
     "company's name",
@@ -1318,12 +1324,35 @@ _NOMINEE_FALSE_POSITIVE_TERMS = (
     "atas nama pt",
     "atas nama cv",
     "atas nama perusahaan",
+    "booking",
+    "reservation",
+    "reservasi",
+    "ticket",
+    "tiket",
+    "rekening",
+    "bank account",
 )
 # Compositional fallback: "<someone Indonesian/a friend> hold(s) the <asset> for me".
 # Phrase lists are too brittle ("hold the title for me" missed "hold the land title
 # for me"), so detect the verb + an asset noun + a for-me / friend signal instead.
 _NOMINEE_HOLD_VERBS = ("hold ", "holds ", "holding ", "keep ", "register ", "put it in")
-_NOMINEE_ASSET_TERMS = ("title", "land", "property", "house", "villa", "certificate", "shares")
+_NOMINEE_ASSET_TERMS = (
+    "title",
+    "land",
+    "property",
+    "house",
+    "villa",
+    "certificate",
+    "shares",
+    # Indonesian / Italian asset nouns so "atas nama" co-occurrence works in
+    # the languages where it is actually used (F06 hardening).
+    "tanah",
+    "sertifikat",
+    "saham",
+    "rumah",
+    "properti",
+    "terreno",
+)
 _NOMINEE_PROXY_SIGNALS = (
     "for me",
     "for us",
@@ -1340,18 +1369,28 @@ _NOMINEE_PROXY_SIGNALS = (
 
 
 def _is_nominee_intent(normalized_message: str) -> bool:
-    # Bail early for known false-positive contexts (F06 2026-06-11):
-    # company name changes ("Can I change my company's name?") and invoice
-    # language ("bisa buat faktur atas nama PT saya?") share trigger tokens
-    # with nominee requests but are unrelated.
-    if _contains_any(normalized_message, _NOMINEE_FALSE_POSITIVE_TERMS):
-        return False
+    # STRONG signals fire regardless of administrative context: the explicit
+    # nominee vocabulary, or the compositional verb+asset+proxy pattern
+    # ("my Indonesian friend can hold the land title for me").
     if _contains_any(normalized_message, _NOMINEE_DIRECT_TERMS):
         return True
-    return (
+    if (
         _contains_any(normalized_message, _NOMINEE_HOLD_VERBS)
         and _contains_any(normalized_message, _NOMINEE_ASSET_TERMS)
         and _contains_any(normalized_message, _NOMINEE_PROXY_SIGNALS)
+    ):
+        return True
+    # WEAK name-tokens ("'s name" / "atas nama") — F06 2026-06-11 + hardening
+    # 2026-06-13. First bail in administrative-naming contexts (company name
+    # change, faktur/invoice, booking/tiket/rekening naming); then require an
+    # asset or proxy co-occurrence, so "the notary's name" / "booking hotel
+    # atas nama saya" never read as nominee requests while "the villa
+    # certificate in my wife's name" still does.
+    if _contains_any(normalized_message, _NOMINEE_FALSE_POSITIVE_TERMS):
+        return False
+    return _contains_any(normalized_message, _NOMINEE_WEAK_NAME_TERMS) and (
+        _contains_any(normalized_message, _NOMINEE_ASSET_TERMS)
+        or _contains_any(normalized_message, _NOMINEE_PROXY_SIGNALS)
     )
 _DEFINITIONAL_TERMS = (
     "what is",


### PR DESCRIPTION
## Audit re-verification (2026-06-11 Fable audit, 9 defects)

Per the W68/W72/W73 discipline, every file:line from the 2-day-old audit was re-verified on disk before editing. **8 of 9 defects were already fixed on main** by PRs #1272, #1273, #1288, #1291 (+F12 by the content-gated hak-milik guard) — each verified in source AND covered by both-polarity tests + the `GUARD_MATRIX` meta-gate (baseline: 97 passed).

| Defect | Status | Before → After |
|---|---|---|
| F05 property_zoning bare-substring (`lease⊂please`, `villa⊂village`) | **already fixed** (#1273) | word-boundary on both term sets; W68 lease-duration bailout intact |
| F06 nominee `"'s name"`/`"atas nama"` over-match | **partially fixed** (#1273) → **completed here** | see below |
| F11 LKPM "1-15 April" hardcoded time-bomb | **already fixed** (#1288) | `_LKPM_PUBLISHED_WINDOW` SSOT + `valid_until` + stale-markers-only degrade + monkeypatch expiry tests |
| F12 hak_milik length-only gate (short wrong reply passed) | **already fixed** | `_hak_milik_asserts_foreigner_can_own` negative-gating; length kept as secondary net |
| F13 `villa⊂village` in `_is_villa_kbli_query` + reply guard | **already fixed** (#1273) | `_contains_any_word` at both sites |
| F14 b211 escape markers (`old⊂holders`, `lama⊂selama`) | **already fixed** (#1272) | word-boundary escape markers |
| F36 tax risk-intent substrings (`late⊂translate`, `fine⊂define`, `owe⊂lower`) | **already fixed** (#1272) | `_contains_any_word` on `_RISK_INTENT_TERMS` |
| F37 document_status `"is approved"` matches conditionals | **already fixed** (#1272) | conditional look-behind regex (`once/when/after/if/until … is approved` passes) |
| F38 kbli_label `\b\d{5}\b` matches postcodes/amounts | **already fixed** (#1272) | KBLI-context required in the MESSAGE before prefixing |

## The one residual fixed in this PR (F06 hardening)

`"'s name"` and `"atas nama"` were still **unconditional** direct triggers. Reproduced live before fixing — all three got the "this is illegal" nominee canonical:

- "Bisa booking hotel atas nama saya?" (hotel booking) → clobbered
- "Bisa transfer ke rekening atas nama istri saya?" (bank transfer) → clobbered
- "Can you confirm the notary's name for tomorrow's appointment?" → clobbered

Fix (negative-gating, W73 convention):
- `"'s name"`/`"atas nama"` moved to a **weak-token tier**: fire only with an asset OR proxy co-occurrence in the message
- `_NOMINEE_FALSE_POSITIVE_TERMS` += booking/reservation/reservasi/ticket/tiket/rekening/bank-account (administrative NAMING contexts, per the audit spec)
- `_NOMINEE_ASSET_TERMS` += ID/IT asset nouns (tanah/sertifikat/saham/rumah/properti/terreno) so co-occurrence works in the languages where "atas nama" occurs
- `_is_nominee_intent` reordered **strong-first**: a genuine compositional nominee request now fires even when the message incidentally contains an administrative token

Both polarities verified live post-fix: "villa certificate in my wife's name" and "tanah atas nama teman" still clobber with the illegality canonical.

## Tests

- 97 → **102 passed** (5 new both-polarity regression tests)
- `test_guard_matrix_covers_every_guard_both_polarities` meta-gate green
- Pre-push full backend suite passed (local PG CI-parity gate)

## Note for ops

The live bridge runs the HOME-fork copy `~/.openclaw/bin/openclaw_whatsapp_bridge.py` (W50/W51/W52 family). After merge, sync the HOME copy and `launchctl kickstart -k gui/501/com.nuzantara.openclaw-whatsapp-bridge` — not done here (scope: repo files only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)