### PR TITLE
feat(connectome): machine-readable edge census (352 edges) + verify_connectome verifier

### DIFF
--- a/docs/connectome/README.md
+++ b/docs/connectome/README.md
@@ -1,0 +1,63 @@
+# Connectome — the empirical map of Nuzantara's arteries
+
+> INDEX.md maps the **organs** (apps, packages, services). This directory maps the
+> **edges** — every producer→consumer artery: PG LISTEN/NOTIFY channels, queues and
+> their drainers, the launchd fleet on all machines, GitHub workflows and what they
+> gate, file-sync daemons, HOME-fork double-files, webhooks, Claude hooks, MCP servers.
+>
+> Why it exists: the recurring disease class of this organism is **edges dying
+> silently** (scars W55, W62, W64, W67, W70, W71 — orphan listeners, green crons that
+> do nothing, suppressed alerts, drifted deployed copies). Organs get audited; edges
+> only got discovered when they bled. This census + verifier closes that gap.
+
+## Layout
+
+- `edges/*.yaml` — one file per domain, censused 2026-06-13 by an 8-agent read-only
+  fan-out, every load-bearing claim re-verified on disk in-session. Each edge:
+  `id, kind, machine, producer, consumer, status, notes` + optional `probe`.
+- `scripts/verify_connectome.py` — re-walks the probes and reports
+  **REGRESSED** (declared healthy, now failing — the alarm), **RECOVERED**
+  (census stale — update it), CONFIRMED / STATIC / SKIPPED.
+
+Companion narrative: `research/operations/2026-06-13-organism-connectome-fable5.md`
+(the same-day TAC by a sibling session — diagnosis prose, disease ranking). This
+directory is the machine-readable counterpart meant to STAY true over time.
+
+## Status vocabulary
+
+| status | meaning |
+|---|---|
+| ALIVE / ARMED / GATING / SCHEDULED_ALIVE / IDENTICAL | healthy at census |
+| LOOPING | W67 signature: KeepAlive + crash respawn |
+| DEAD / RED | persistent failure on schedule |
+| STALE | runs but its work item ages (blocked sync, undrained queue) |
+| ORPHAN_PRODUCER / ORPHAN_CONSUMER | one side of the edge does not exist |
+| DISARMED | exists, loaded, no trigger |
+| LYING_BY_PRESENCE | on disk, looks installed, not loaded |
+| NEUTRALIZED | wired but a kill-switch/missing backend makes it a no-op |
+| BY_DESIGN_OFF | deliberately off, with a documented decision |
+| UNKNOWN | could not verify (e.g. machine unreachable) — never guessed |
+
+## Running the verifier
+
+```bash
+cd ~/Desktop/nuzantara
+apps/backend-rag/.venv/bin/python scripts/verify_connectome.py            # local + ssh probes
+apps/backend-rag/.venv/bin/python scripts/verify_connectome.py --no-ssh   # local only
+apps/backend-rag/.venv/bin/python scripts/verify_connectome.py --json /tmp/connectome.json
+```
+
+Exit 1 ⇔ at least one REGRESSED edge. Designed for a future cron (NOT installed —
+new cron requires operator authorization per AUTONOMOUS_OPS); recommended cadence:
+daily on Pro, weekly on M5.
+
+## Maintenance rules
+
+1. **New automation ⇒ new edge.** Any new LaunchAgent, workflow, queue, webhook or
+   sync daemon gets an entry here in the same PR (same spirit as
+   `scripts/automation_catalog.json`, but edge-centric and probe-backed).
+2. **RECOVERED verdicts mean the census is stale** — update the edge's `status`,
+   don't ignore them.
+3. Statuses are census-time observations, not promises. The probe is the truth.
+4. Census refresh: re-run the 8-domain fan-out quarterly or after major surgery
+   (machine decommission, pipeline cutover).

--- a/docs/connectome/edges/gh-workflows.yaml
+++ b/docs/connectome/edges/gh-workflows.yaml
@@ -1,0 +1,356 @@
+# Connectome — GitHub Actions edges (Balizero1987/Teman2)
+# Census: 2026-06-13. Required contexts on main at census: 18.
+# GATING = produces a required status check. RUN_ONLY = runs, doesn't block.
+domain: gh-workflows
+census_date: "2026-06-13"
+edges:
+  # ── GATING (merge-blocking) ──
+  - {
+      id: tests.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: GATING,
+      consumer: "4 required contexts: Backend/MCP/Frontend/E2E",
+    }
+  - id: security.yml
+    kind: gh_workflow
+    machine: github
+    status: GATING
+    consumer: "Detect Secrets + Bandit + CodeQL py/js (required)"
+    notes: "ANOMALY A1 at census: required job 'Bandit Python Security' ran bandit with '|| true' — toothless twin required while toothed twin (semgrep.yml) advisory. Fix dispatched 2026-06-13"
+  - {
+      id: hot-zone-pr-gate.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: GATING,
+      consumer: "Hot-zone enforcement (CODEOWNERS self-mod + migration replay blocking; redis-lease + launchagent steps monitor-by-design)",
+      notes: "kill-switch var L5_2_SERVER_ENFORCEMENT_ENABLED does not exist (404) → active; var-write = silent disarm vector",
+    }
+  - {
+      id: verify-the-verifiers.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: GATING,
+      notes: "sentinel skip→success pattern (W69-safe); sha256 integrity teeth real",
+    }
+  - {
+      id: p1s2-mutation-incremental.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: GATING,
+    }
+  - {
+      id: p3-sandbox-gates.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: GATING,
+      notes: "static job blocks; runtime job monitor-by-design (runner can't reach Pro)",
+    }
+  - {
+      id: p6-federation-parallelize.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: GATING,
+      notes: "W69 red ×2 HEALED — last 3 green",
+    }
+  - {
+      id: p7-lesson-harvester.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: GATING,
+    }
+  - { id: p8-brand-api.yml, kind: gh_workflow, machine: github, status: GATING }
+  - {
+      id: p9-cost-breaker.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: GATING,
+      notes: "CI layer; H24 runtime twin = Pro cost-breaker-deadman (complementary)",
+    }
+  - {
+      id: asyncpg-lint.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: GATING,
+      notes: "W64/W35 deferral CLOSED — required since 2026-06-11/12",
+    }
+  - { id: root-guard.yml, kind: gh_workflow, machine: github, status: GATING }
+  # ── deploy edge ──
+  - {
+      id: fly-deploy.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: RUN_ONLY,
+      consumer: "Fly prod deploy + health + auto-rollback + Telegram",
+      notes: "success ≠ machine running (autostop 503-scar caveat)",
+    }
+  # ── RUN_ONLY PR gates (alive, not required) ──
+  - {
+      id: auto-merge-whitelist.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: RUN_ONLY,
+    }
+  - {
+      id: broker-hygiene.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: RUN_ONLY,
+      notes: "dormant 11d — paths rarely touched",
+    }
+  - {
+      id: catA-channel-count-pin.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: RUN_ONLY,
+    }
+  - {
+      id: catB-daemon-cron-xor.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: RUN_ONLY,
+      notes: "W67 crash-loop guard for versioned plists",
+    }
+  - {
+      id: catC-canary-tautology-lint.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: RUN_ONLY,
+    }
+  - {
+      id: catD-backend-data-invariants.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: RUN_ONLY,
+    }
+  - {
+      id: catE-sovereignty-lint.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: RUN_ONLY,
+    }
+  - {
+      id: catF-wa-bridge-drift.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: RUN_ONLY,
+      notes: "guard-chain + HOME-fork drift notice (W50/W68/W73 family)",
+    }
+  - {
+      id: contract-tests.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: NEUTRALIZED,
+      notes: "job-level continue-on-error:true — DOCUMENTED advisory with promotion criteria",
+    }
+  - {
+      id: docs-guardian.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: RED,
+      notes: "6/6 failures at census; regen fix dispatched 2026-06-13",
+    }
+  - {
+      id: docs-sync.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: RED,
+      notes: "DOCSYNC STALE on main 6/6; regen fix dispatched 2026-06-13",
+    }
+  - {
+      id: intel-router-tests.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: RUN_ONLY,
+      notes: "dormant 24d (<30d threshold)",
+    }
+  - { id: lighthouse.yml, kind: gh_workflow, machine: github, status: RUN_ONLY }
+  - {
+      id: lint-cross-import.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: RUN_ONLY,
+    }
+  - {
+      id: lint-golden-rule-10.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: RUN_ONLY,
+    }
+  - {
+      id: lint-i18n-providers.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: RUN_ONLY,
+    }
+  - {
+      id: lint-migration-numbers.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: RUN_ONLY,
+      notes: "double-covered inside hot-zone gate (deliberate, W40)",
+    }
+  - {
+      id: lint-migration-rollback.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: RUN_ONLY,
+    }
+  - {
+      id: migration-lint.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: RUN_ONLY,
+      notes: "Squawk (PR #306)",
+    }
+  - { id: sbom.yml, kind: gh_workflow, machine: github, status: RUN_ONLY }
+  - {
+      id: semgrep.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: RUN_ONLY,
+      notes: "despite the name = Bandit+ESLint WITH teeth (sys.exit 1 on HIGH/CRITICAL) — the toothed twin of security.yml's required job",
+    }
+  - {
+      id: sonarqube.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: NEUTRALIZED,
+      notes: "self-documented advisory",
+    }
+  - {
+      id: symbiosis-lint.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: RUN_ONLY,
+    }
+  - {
+      id: vercel-build-guard.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: RUN_ONLY,
+      notes: "notify-only",
+    }
+  - {
+      id: wr2-master-template-guard.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: RUN_ONLY,
+      notes: "Canva path retired by HTML cutover — decommission-review candidate",
+    }
+  # ── SCHEDULED (cron twins of local jobs flagged in notes) ──
+  - {
+      id: cron-cert-monitor.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: SCHEDULED_ALIVE,
+      producer: "daily 23:00 UTC",
+    }
+  - {
+      id: cron-drive-poll.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: SCHEDULED_ALIVE,
+      producer: "*/5min",
+      notes: "potential ACTIVE_ACTIVE with Pro drive intake watcher when armed (#1364, ~14/06)",
+    }
+  - {
+      id: cron-fly-cost-alert.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: SCHEDULED_ALIVE,
+      producer: "Mon 01:00 UTC",
+      notes: "complementary to Pro cost-breaker (different ledgers)",
+    }
+  - {
+      id: cron-fly-restart-detector.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: SCHEDULED_ALIVE,
+      producer: "*/15min",
+      notes: "503-scar antibody; verify it force-starts not just alerts (behavior unaudited)",
+    }
+  - {
+      id: cron-fly-watcher.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: SCHEDULED_ALIVE,
+      producer: "*/15min",
+      notes: "overlaps restart-detector cadence — consolidation candidate",
+    }
+  - {
+      id: cron-notifiers-all.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: SCHEDULED_ALIVE,
+      producer: "daily 16:00 UTC",
+    }
+  - {
+      id: cron-notifiers-birthday.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: SCHEDULED_ALIVE,
+      producer: "daily 16:05 UTC",
+    }
+  - {
+      id: cron-notifiers-email-health.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: SCHEDULED_ALIVE,
+      producer: "*/30min",
+    }
+  - {
+      id: cron-notifiers-lkpm-deadlines.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: SCHEDULED_ALIVE,
+      producer: "daily 15:00 UTC",
+      notes: "functional overlap with compliance-deadline-sentinel (different channels)",
+    }
+  - {
+      id: cron-notifiers-welcome-pending.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: SCHEDULED_ALIVE,
+      producer: "*/15min",
+    }
+  - {
+      id: cron-practice-auto-create.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: SCHEDULED_ALIVE,
+      producer: "daily 23:30 UTC",
+    }
+  - {
+      id: cron-sentry-quota-check.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: SCHEDULED_ALIVE,
+      producer: "daily 01:00 UTC",
+    }
+  - {
+      id: fly-secrets-check.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: SCHEDULED_ALIVE,
+      producer: "Mon 09:00 UTC",
+    }
+  - id: restore-drill.yml
+    kind: gh_workflow
+    machine: github
+    status: RED
+    producer: "monthly d1 04:00 UTC"
+    notes: "last SCHEDULED run (2026-06-01) FAILED, rescued by manual dispatch 06-05; with W70 local fly_pg_backup 0-byte history, backup-verify lane failed on BOTH sides. Next unattended proof 2026-07-01"
+  - {
+      id: sprint2-w1-verify.yml,
+      kind: gh_workflow,
+      machine: github,
+      status: SCHEDULED_DEAD,
+      producer: "yearly May 10 (one-shot zombie)",
+      notes: "removal dispatched 2026-06-13",
+    }
+anomalies:
+  - "A1: required Bandit check toothless ('|| true') while toothed twin advisory — fix in flight"
+  - "A4: 7 cron workflows exit-0 silently if Telegram secrets missing — alert-path soft-neutralization (W55 family)"
+  - "A6: hot-zone kill-switch is a nonexistent repo var — variable-write = silent disarm; add var-audit to verify-the-verifiers"
+  - "restore-drill scheduled failure + W70 = backup lane needs its 2026-07-01 unattended proof"

--- a/docs/connectome/edges/hooks-mcp.yaml
+++ b/docs/connectome/edges/hooks-mcp.yaml
@@ -1,0 +1,243 @@
+# Connectome — Claude Code hooks + MCP servers + pre-commit chain (the agent layer's own nerves)
+# Census: 2026-06-13, M5 + Pro (via ssh).
+domain: hooks-mcp
+census_date: "2026-06-13"
+edges:
+  # ── M5 hooks ──
+  - id: hook-m5-guardrails-client
+    kind: claude_hook
+    machine: m5
+    status: ARMED
+    notes: "DEGRADED: Tier-1 daemon ABSENT on M5 (no socket/launchd job; Pro has it) → every PreToolUse pays Tier-2 static fallback. Fail-closed Tier-3 intact"
+  - id: hook-m5-worktree-isolation
+    kind: claude_hook
+    machine: m5
+    status: NEUTRALIZED
+    notes: "AGENT_WORKTREE_ENFORCEMENT=false live in ~/.zshrc:39 since 2026-06-07 'temp: dirty-rescue' — 6+ days stale; Pro runs =true. BOTH worktree hooks off on the PRIMARY dev machine"
+    probe:
+      {
+        type: cmd,
+        cmd: "! grep -q 'AGENT_WORKTREE_ENFORCEMENT=false' ~/.zshrc",
+      }
+  - {
+      id: hook-m5-worktree-file-write-check,
+      kind: claude_hook,
+      machine: m5,
+      status: NEUTRALIZED,
+      notes: "same kill-switch",
+    }
+  - {
+      id: hook-m5-block-heavy-brew,
+      kind: claude_hook,
+      machine: m5,
+      status: ARMED,
+    }
+  - {
+      id: hook-m5-orchestrate-gate,
+      kind: claude_hook,
+      machine: m5,
+      status: ARMED,
+    }
+  - {
+      id: hook-m5-stadio-zero-nudge,
+      kind: claude_hook,
+      machine: m5,
+      status: ARMED,
+    }
+  - {
+      id: hook-m5-stop-verify,
+      kind: claude_hook,
+      machine: m5,
+      status: ARMED,
+      notes: "STOP_VERIFY_ALLOW_DIRTY absent — re-armed",
+    }
+  - {
+      id: hook-m5-seam-verify,
+      kind: claude_hook,
+      machine: m5,
+      status: ARMED,
+      notes: "PR #1237 wired",
+    }
+  - {
+      id: hook-m5-sessionstart-cluster,
+      kind: claude_hook,
+      machine: m5,
+      status: ARMED,
+      notes: "18/18 script targets exist+exec",
+    }
+  - {
+      id: hook-m5-statusline,
+      kind: claude_hook,
+      machine: m5,
+      status: DEAD,
+      notes: "registered but ~/.claude/statusline.sh MISSING on M5 (Pro has it) — cosmetic sync gap",
+      probe: { type: file_exists, path: "~/.claude/statusline.sh" },
+    }
+  - {
+      id: hook-m5-guardrails-static,
+      kind: claude_hook,
+      machine: m5,
+      status: ARMED,
+      notes: "W71 'not registered' is NOT exists-unwired — consumed as Tier-2 by guardrails-client.sh; on M5 it IS the effective evaluator",
+    }
+  - {
+      id: hook-project-codex-spalla,
+      kind: claude_hook,
+      machine: m5,
+      status: ARMED,
+      notes: "repo .claude/settings.json PostToolUse",
+    }
+  # ── Pro hooks ──
+  - {
+      id: hook-pro-registrations,
+      kind: claude_hook,
+      machine: pro,
+      status: ARMED,
+      notes: "mirrors M5 minus m5_block_heavy_brew; 12/12 script targets + pyenv interpreter verified",
+    }
+  - {
+      id: hook-pro-guardrails-daemon,
+      kind: claude_hook,
+      machine: pro,
+      status: ARMED,
+      notes: "Tier-1 daemon ALIVE (socket fresh)",
+    }
+  - {
+      id: hook-pro-worktree-enforcement,
+      kind: claude_hook,
+      machine: pro,
+      status: ARMED,
+      notes: "settings env =true explicit",
+    }
+  # ── M5 MCP servers ──
+  - {
+      id: mcp-m5-ga4-analytics,
+      kind: mcp_server,
+      machine: m5,
+      status: ARMED,
+      probe:
+        {
+          type: cmd,
+          cmd: "$HOME/Desktop/nuzantara/.mcp-servers/ga4-analytics/.venv/bin/python3 -c 'print(1)'",
+        },
+    }
+  - {
+      id: mcp-m5-ocr-tesseract,
+      kind: mcp_server,
+      machine: m5,
+      status: ARMED,
+      probe:
+        {
+          type: cmd,
+          cmd: "$HOME/Desktop/nuzantara/.mcp-servers/ocr/.venv/bin/python3 -c 'print(1)'",
+        },
+    }
+  - {
+      id: mcp-m5-nuzantara-mcp,
+      kind: mcp_server,
+      machine: m5,
+      status: ARMED,
+      notes: "LANGSMITH_API_KEY absent by design (optional)",
+      probe:
+        {
+          type: cmd,
+          cmd: "$HOME/Desktop/nuzantara/apps/nuzantara-mcp/.venv/bin/python3 -c 'print(1)'",
+        },
+    }
+  - {
+      id: mcp-m5-nuzantara-mcp-advanced,
+      kind: mcp_server,
+      machine: m5,
+      status: ARMED,
+      probe:
+        {
+          type: cmd,
+          cmd: "$HOME/Desktop/nuzantara/apps/nuzantara-mcp-advanced/.venv/bin/python3 -c 'print(1)'",
+        },
+    }
+  - {
+      id: mcp-m5-nuzantara-browser,
+      kind: mcp_server,
+      machine: m5,
+      status: ARMED,
+      notes: "all 5 venvs NATIVE post 2026-06-09 fix — dead-symlink class healed",
+      probe:
+        {
+          type: cmd,
+          cmd: "$HOME/Desktop/nuzantara/apps/nuzantara-mcp-browser/.venv/bin/python3 -c 'print(1)'",
+        },
+    }
+  - {
+      id: mcp-m5-notebooklm,
+      kind: mcp_server,
+      machine: m5,
+      status: ARMED,
+      probe: { type: file_exists, path: "~/.local/bin/notebooklm-mcp" },
+    }
+  - { id: mcp-m5-github, kind: mcp_server, machine: m5, status: ARMED }
+  - {
+      id: mcp-m5-playwright,
+      kind: mcp_server,
+      machine: m5,
+      status: ARMED,
+      notes: "use-gated by convention (claude-in-chrome default)",
+    }
+  - {
+      id: mcp-m5-postgres-nuzantara,
+      kind: mcp_server,
+      machine: m5,
+      status: UNKNOWN,
+      notes: "schema loads but :15432 tunnel + keychain liveness at query time unverified (audit F33)",
+    }
+  - {
+      id: mcp-m5-exa,
+      kind: mcp_server,
+      machine: m5,
+      status: ARMED,
+      notes: "API key cleartext in ~/.claude.json URL — secret-hygiene note",
+    }
+  # ── pre-commit chain (M5) ──
+  - {
+      id: precommit-pii-law2-gate,
+      kind: precommit_gate,
+      machine: m5,
+      status: ARMED,
+      notes: "first hard gate, pure-shell",
+    }
+  - {
+      id: precommit-cicatrix-auto-archive,
+      kind: precommit_gate,
+      machine: m5,
+      status: ARMED,
+    }
+  - id: precommit-redis-lease-check
+    kind: precommit_gate
+    machine: m5
+    status: NEUTRALIZED
+    notes: "backend ABSENT on M5 (no redis-cli, :6379 closed) → designed pass-through. Hot-zone commits from M5 have zero lease protection; Pro redis PONG (armed there)"
+  - {
+      id: precommit-migration-lints,
+      kind: precommit_gate,
+      machine: m5,
+      status: ARMED,
+    }
+  - {
+      id: precommit-reward-hacking-lint,
+      kind: precommit_gate,
+      machine: m5,
+      status: ARMED,
+      notes: "only gate with NO kill-switch by design",
+    }
+  - {
+      id: precommit-anti-rogue-gates,
+      kind: precommit_gate,
+      machine: m5,
+      status: ARMED,
+      notes: "OFF-LIMITS block + FastAPI import smoke",
+    }
+anomalies:
+  - "P1: AGENT_WORKTREE_ENFORCEMENT=false in M5 ~/.zshrc since 06-07 ('temp') — worktree discipline OFF on primary dev machine (remove the line; takes effect on new shells)"
+  - "P2: guardrails Tier-1 daemon absent on M5 (Pro/M5 asymmetry nobody decided)"
+  - "P2: redis lease backend absent on M5 → hot-zone lease gate pass-through"
+  - "P3: statusline.sh missing on M5 (cosmetic)"
+  - "SECURITY note from census itself: a census subagent cat'd ~/.zshenv and leaked CLAUDE_CODE_OAUTH_TOKEN into its transcript (2026-06-03 scar class) — rotation recommended; future censuses grep with patterns, never cat env files"

--- a/docs/connectome/edges/http-webhooks.yaml
+++ b/docs/connectome/edges/http-webhooks.yaml
@@ -1,0 +1,176 @@
+# Connectome — inbound webhooks + outbound HTTP edges (the boundary with the outside world)
+# Census: 2026-06-13 (repo-level reads; no live external probes).
+domain: http-webhooks
+census_date: "2026-06-13"
+edges:
+  # ── inbound ──
+  - {
+      id: webhook-telegram-in,
+      kind: http_webhook,
+      direction: in,
+      machine: fly,
+      status: ALIVE,
+      consumer: "routers/telegram_webhook.py:245 (update_id dedup, ack-first, intel+fad callbacks)",
+    }
+  - id: webhook-whatsapp-in
+    kind: http_webhook
+    direction: in
+    machine: fly
+    status: ALIVE
+    consumer: "channels/whatsapp/adapter.py:74 via ChannelRouter"
+    notes: "Meta X-Hub-Signature verification NOT visible in adapter — verify it lives in middleware/base class, else forged-event surface (census open question)"
+  - {
+      id: webhook-instagram-in,
+      kind: http_webhook,
+      direction: in,
+      machine: fly,
+      status: ALIVE,
+      consumer: "channels/instagram/adapter.py:50 (is_echo + account_id double-check)",
+    }
+  - {
+      id: webhook-openclaw-crm-logging,
+      kind: http_webhook,
+      direction: in,
+      machine: fly,
+      status: ALIVE,
+      consumer: "routers/webhooks.py:44 (HMAC X-OpenClaw-Signature enforced)",
+    }
+  - {
+      id: web-sse-chat,
+      kind: http_webhook,
+      direction: in,
+      machine: fly,
+      status: ALIVE,
+      consumer: "channels/web/adapter.py:150 stream_response (auth via get_current_user)",
+      notes: "send_response is a documented no-op (F41) — router must always use stream path",
+    }
+  # ── outbound: Meta ──
+  - {
+      id: out-whatsapp-graph,
+      kind: http_webhook,
+      direction: out,
+      machine: fly,
+      status: ALIVE,
+      consumer: "graph.facebook.com v22.0 (raise_for_status + DLQ path)",
+    }
+  - {
+      id: out-instagram-graph,
+      kind: http_webhook,
+      direction: out,
+      machine: fly,
+      status: ALIVE,
+      consumer: "graph.instagram.com v22.0",
+      notes: "raise_for_status present since #1270; GRAPH_API_VERSION constant since #1377 — audit F07 fully closed",
+    }
+  # ── outbound: Telegram (the big sender family — 25+ files) ──
+  - id: out-telegram-bot-api
+    kind: http_webhook
+    direction: out
+    machine: fly
+    status: ALIVE
+    producer: "25+ backend files (adapter, bot_service, federation notifier, canva _telegram, drive_poll, attendance, sota m13, wa_copilot, owner_cashout, review, optimizations DLQ)"
+    consumer: "api.telegram.org (token in URL path — Telegram protocol requirement)"
+    notes: "leak surface = LOGGING the URL, not the URL itself (Bearer header NOT supported by Telegram). F01 sweep (#1271+#1378) silenced httpx/httpcore in the leaking scripts; backend services use urllib (never logs URLs) or guarded httpx. Any NEW Telegram sender must silence its HTTP client logger"
+  # ── outbound: email ──
+  - {
+      id: out-brevo-email,
+      kind: http_webhook,
+      direction: out,
+      machine: fly,
+      status: ALIVE,
+      consumer: "api.brevo.com/v3/smtp/email (fallback chain Brevo→SendGrid→Resend)",
+      notes: "hardcoded rule: from=zantara@balizero.com",
+    }
+  # ── outbound: LLM + data ──
+  - {
+      id: out-openai-embeddings,
+      kind: http_webhook,
+      direction: out,
+      machine: fly,
+      status: ALIVE,
+      consumer: "text-embedding-3-small 1536d FROZEN (300k token batch discipline)",
+    }
+  - {
+      id: out-deepseek-api,
+      kind: http_webhook,
+      direction: out,
+      machine: fly,
+      status: ALIVE,
+      consumer: "api.deepseek.com (deepseek-v4-pro/flash explicit; legacy aliases = silent flash downgrade TRAP)",
+    }
+  - {
+      id: out-gemini-genai,
+      kind: http_webhook,
+      direction: out,
+      machine: fly,
+      status: ALIVE,
+      consumer: "Gemini 2.5 Flash primary RAG + 2.0 fallback",
+    }
+  - {
+      id: out-qdrant-cloud,
+      kind: http_webhook,
+      direction: out,
+      machine: fly,
+      status: ALIVE,
+      consumer: "Qdrant Cloud (flat payloads only)",
+    }
+  - {
+      id: out-google-drive,
+      kind: http_webhook,
+      direction: out,
+      machine: fly,
+      status: ALIVE,
+      consumer: "Drive v3 (OAuth token table, 90d expiry, watchdog 7d-before)",
+    }
+  - {
+      id: out-gsc-indexing,
+      kind: http_webhook,
+      direction: out,
+      machine: pro,
+      status: ALIVE,
+      consumer: "GSC Indexing API (service account)",
+    }
+  - {
+      id: out-ga4,
+      kind: http_webhook,
+      direction: out,
+      machine: fly,
+      status: ALIVE,
+      consumer: "GA4 reporting (service account)",
+    }
+  - {
+      id: out-notebooklm-mcp,
+      kind: http_webhook,
+      direction: out,
+      machine: pro,
+      status: ALIVE,
+      consumer: "NotebookLM via MCP (oracle shadow retrieval + drive backup)",
+    }
+  # ── internal Fly edges ──
+  - id: fly-api-to-rag-internal
+    kind: http_webhook
+    direction: internal
+    machine: fly
+    status: ALIVE
+    consumer: "rag.process.nuzantara-rag.internal:8080 (IPv6 ::, no Fly proxy)"
+    notes: "F27 census note: experience/skill/metabolic_health manifest-declared API-only but included in heavy → potential SQLite split-brain for internal callers (open, audit F27)"
+  - {
+      id: fly-postgres-internal,
+      kind: http_webhook,
+      direction: internal,
+      machine: fly,
+      status: ALIVE,
+      consumer: "nuzantara-postgres (advisory-lock migrations, repmgr HA)",
+    }
+  - {
+      id: fly-redis-optional,
+      kind: http_webhook,
+      direction: internal,
+      machine: fly,
+      status: UNKNOWN,
+      notes: "conditional on REDIS_URL; graceful degradation",
+    }
+anomalies:
+  - "WA/IG webhook signature verification not located in adapters — confirm middleware or close the forged-event hole"
+  - "F27 router parity inverse direction still open (manifest vs include_heavy_routers)"
+  - "F41 web send_response no-op: enforced only by convention — assertion in DLQ retry path recommended"

--- a/docs/connectome/edges/launchd-m5-mini.yaml
+++ b/docs/connectome/edges/launchd-m5-mini.yaml
@@ -1,0 +1,113 @@
+# Connectome — scheduled automation on M5 (primary dev) + Mini-Pro2 (H24 server) + fleet ssh links
+# Census: 2026-06-13. Mini was UNREACHABLE at census (both Tailscale and LAN) — whole section UNKNOWN.
+domain: launchd-m5-mini
+census_date: "2026-06-13"
+edges:
+  - {
+      id: com.balizero.caffeinate,
+      kind: launchd,
+      machine: m5,
+      status: ALIVE,
+      consumer: "/usr/bin/caffeinate -i -m -s",
+    }
+  - id: com.nuzantara.agent-worktree-cleanup.daily-m5
+    kind: launchd
+    machine: m5
+    status: DEAD
+    consumer: "scripts/agent_worktree_cleanup_cron.sh (exists, exec)"
+    notes: "exit 126 EVERY run — macOS TCC: launchd bash lacks Desktop access ('Operation not permitted'). W62 reaper green on ZERO machines (Pro twin exit 1 too)"
+    probe:
+      {
+        type: cmd,
+        cmd: "launchctl list | grep -F com.nuzantara.agent-worktree-cleanup.daily",
+      }
+  - id: com.balizero.nlm-autodownload
+    kind: launchd
+    machine: m5
+    status: BY_DESIGN_OFF
+    notes: "self-unloads after artifacts land on Desktop (log-proven 6×) — not a wound"
+  - {
+      id: homebrew.mxcl.postgresql-17,
+      kind: launchd,
+      machine: m5,
+      status: ALIVE,
+      consumer: "PG17 local (PR #1349)",
+      probe:
+        {
+          type: cmd,
+          cmd: "pg_isready -q -h 127.0.0.1 -p 5432 || /opt/homebrew/opt/postgresql@17/bin/pg_isready -q",
+        },
+    }
+  - id: m5-crontab
+    kind: cron
+    machine: m5
+    status: BY_DESIGN_OFF
+    notes: "no crontab for balizero — all M5 scheduling is launchd (expected)"
+  - id: m5-path-drift-meta
+    kind: meta_check
+    machine: m5
+    status: ALIVE
+    notes: "0 hits for /Users/nuzantara/ across M5 plists+target scripts — 2026-06-09 path-drift fix held"
+    probe:
+      {
+        type: cmd,
+        cmd: "! grep -l '/Users/nuzantara/' ~/Library/LaunchAgents/*.plist 2>/dev/null",
+      }
+  - id: repomap-m5
+    kind: file_sync
+    machine: m5
+    status: DEAD
+    producer: "(never installed)"
+    consumer: "SessionStart repomap inject"
+    notes: "~/.nuzantara-repomap.txt ENOENT on the PRIMARY dev machine — every session pays ~50 extra exploration calls"
+    probe:
+      { type: file_age_max_h, path: "~/.nuzantara-repomap.txt", max_age_h: 1 }
+  # ── fleet ssh links ──
+  - id: m5-tailscale-control-plane
+    kind: ssh_link
+    machine: m5
+    status: DEGRADED
+    notes: "census-time: no network map from coordination server; client/daemon version skew (half-applied update). Fleet survives on LAN mDNS only"
+    probe:
+      {
+        type: cmd,
+        cmd: "/opt/homebrew/bin/tailscale status >/dev/null 2>&1 && ! /opt/homebrew/bin/tailscale status 2>&1 | grep -q 'Unable to connect'",
+      }
+  - id: m5-to-pro-lan
+    kind: ssh_link
+    machine: m5
+    status: ALIVE
+    consumer: "ssh pro-lan (Nuzantara.local)"
+    probe: { type: cmd, cmd: "ssh -o ConnectTimeout=8 pro-lan true" }
+  - id: pro-to-mini
+    kind: ssh_link
+    machine: pro
+    status: DEAD
+    notes: "census-time: timeout on BOTH Tailscale 100.93.236.6 AND LAN 192.168.110.44, ping 100% loss → Mini powered off/asleep ≥1d. H24 server dark with NO alert = monitoring gap"
+    probe:
+      {
+        type: cmd,
+        via: "ssh:pro-lan",
+        cmd: "ssh -o ConnectTimeout=5 mini true",
+      }
+  # ── Mini (all UNKNOWN at census — re-census on wake) ──
+  - id: mini-launchd-fleet
+    kind: launchd
+    machine: mini
+    status: UNKNOWN
+    notes: "unreachable; includes GSC indexing sweep 06:00 WITA + Ollama batch + heavy crons — all silently not running while Mini is down"
+  - id: mini-wa-mirror-bootout
+    kind: launchd
+    machine: mini
+    status: UNKNOWN
+    notes: "W67c bootout re-verification BLOCKED — on wake: launchctl print gui/501/com.balizero.wa-mirror must be 'not found' + print-disabled lists it"
+  - id: dup-gsc-indexing-pro-mini
+    kind: launchd
+    machine: mini
+    status: UNKNOWN
+    notes: "Pro com.nuzantara.daily-indexing-sweep loaded TODAY; memory places GSC sweep on Mini → ACTIVE_ACTIVE candidate pending Mini wake (W67c class)"
+anomalies:
+  - "P1: Mini-Pro2 (H24 server) unreachable ≥1d on all routes — no guardian alerted; every Mini cron silently stopped"
+  - "P2: W62 worktree reaper runs green on ZERO machines (M5 TCC exit 126, Pro exit 1)"
+  - "P2: M5 Tailscale control-plane degraded + version skew — fleet on LAN-only"
+  - "P3: repomap never installed on M5 (primary dev machine)"

--- a/docs/connectome/edges/launchd-pro.yaml
+++ b/docs/connectome/edges/launchd-pro.yaml
@@ -1,0 +1,1298 @@
+# Connectome — LaunchAgent fleet on Pro (nuzantara@Nuzantara)
+# Census: 2026-06-13 00:30 WITA · 180 plists on disk, 173 loaded, 0 lint failures.
+# kind=launchd edges get an automatic liveness probe (launchctl label check via ssh:pro-lan).
+# Statuses are census-time. LOOPING = W67 signature (KeepAlive + crash respawn).
+domain: launchd-pro
+census_date: "2026-06-13"
+edges:
+  # ── LOOPING (P1 at census: redis-timeout crash-loop, ~1 respawn/31s) ──
+  - {
+      id: com.balizero.meta-dispatcher,
+      kind: launchd,
+      machine: pro,
+      status: LOOPING,
+      consumer: "~/scripts/eventbus/meta_dispatcher.py",
+      notes: "834 runs/7h, redis TimeoutError — ROOT CAUSE (sibling TAC 2026-06-13): they target the MINI's redis 100.93.236.6:6379 and Mini is off. Fix = wake Mini, not touch daemons",
+    }
+  - {
+      id: com.balizero.intel-dedup-gateway,
+      kind: launchd,
+      machine: pro,
+      status: LOOPING,
+      consumer: "~/scripts/eventbus/intel_dedup_gateway.py",
+      notes: "same redis-timeout loop",
+    }
+  - {
+      id: com.balizero.research-sentinel,
+      kind: launchd,
+      machine: pro,
+      status: LOOPING,
+      consumer: "~/scripts/eventbus/research_sentinel.py",
+      notes: "same",
+    }
+  - {
+      id: com.balizero.observatory,
+      kind: launchd,
+      machine: pro,
+      status: LOOPING,
+      consumer: "~/agents/.observatory/observatory.py",
+      notes: "same",
+    }
+  # ── DEAD (persistent bad exit on schedule) ──
+  - {
+      id: com.balizero.wr2.deploy-puller,
+      kind: launchd,
+      machine: pro,
+      status: DEAD,
+      consumer: "~/scripts/wr2-deploy-pull.sh (hourly)",
+      notes: "worktree dirty → refuses pull; alerts cooldown-suppressed (W55 replay); healing in flight 2026-06-13",
+    }
+  - {
+      id: com.nuzantara.codex-spark-alarm,
+      kind: launchd,
+      machine: pro,
+      status: DEAD,
+      consumer: "codex/spark-alarm.sh (120s)",
+      notes: "208 failed runs",
+    }
+  - {
+      id: com.balizero.wr2.plist-watchdog,
+      kind: launchd,
+      machine: pro,
+      status: DEAD,
+      consumer: "wr2_plist_watchdog.sh (900s)",
+      notes: "the WR2 plist guardian itself failing every 15min",
+    }
+  - {
+      id: com.balizero.wr2.sla-worker,
+      kind: launchd,
+      machine: pro,
+      status: DEAD,
+      consumer: "wr2-cron-wrapper.sh sla_worker_cli (1800s)",
+    }
+  - {
+      id: com.nuzantara.codex-autofix-ci,
+      kind: launchd,
+      machine: pro,
+      status: DEAD,
+      consumer: "codex/nightly-autofix-ci.sh (hourly :15)",
+    }
+  # ── UNKNOWN (failed only run since boot — recheck after next fire) ──
+  - {
+      id: com.balizero.wr2.hardening,
+      kind: launchd,
+      machine: pro,
+      status: UNKNOWN,
+      consumer: "wr2-hardening-chain.sh (6h)",
+      notes: "exit 1 on only run",
+    }
+  - {
+      id: com.balizero.wr2.measurer,
+      kind: launchd,
+      machine: pro,
+      status: UNKNOWN,
+      consumer: "wr2-cron-wrapper.sh measurer (6h)",
+      notes: "exit 2 on only run",
+    }
+  - {
+      id: com.balizero.intel-radar-daily-digest,
+      kind: launchd,
+      machine: pro,
+      status: UNKNOWN,
+      consumer: "intel_radar_daily_digest.py (18:00)",
+    }
+  - {
+      id: com.nuzantara.agent-worktree-cleanup.daily,
+      kind: launchd,
+      machine: pro,
+      status: UNKNOWN,
+      consumer: "agent_worktree_cleanup_cron.sh (00:15)",
+      notes: "W62 antibody — exit 1 tonight; M5 twin DEAD on TCC → reaper green on ZERO machines",
+    }
+  # ── LYING_BY_PRESENCE (on disk, NOT loaded, no disable-override) ──
+  - {
+      id: com.nuzantara.pg-organism-bridge-watchdog,
+      kind: launchd,
+      machine: pro,
+      status: LYING_BY_PRESENCE,
+      consumer: "pg-organism-bridge-watchdog.sh",
+      notes: "unarmed watchdog while watched daemon IS live",
+      probe:
+        {
+          type: cmd,
+          via: "ssh:pro-lan",
+          cmd: "launchctl list | grep -F com.nuzantara.pg-organism-bridge-watchdog || true; test -f ~/Library/LaunchAgents/com.nuzantara.pg-organism-bridge-watchdog.plist",
+        },
+    }
+  - {
+      id: com.balizero.agent-library-evolver.daily,
+      kind: launchd,
+      machine: pro,
+      status: LYING_BY_PRESENCE,
+      consumer: "scar-replay-run.sh",
+      notes: "unloaded; matches W74-F18 suspend reco but no recorded decision",
+    }
+  - {
+      id: com.balizero.agent-library-evolver.weekly,
+      kind: launchd,
+      machine: pro,
+      status: LYING_BY_PRESENCE,
+      consumer: "agent-library-evolver-run.sh",
+    }
+  - {
+      id: com.balizero.wr3.reflexion.weekly,
+      kind: launchd,
+      machine: pro,
+      status: LYING_BY_PRESENCE,
+      consumer: "wr3/_reflexion-synthesis.py (816B stub)",
+      notes: "the W74-F21 cron-theater is now UNLOADED — stub still on disk",
+    }
+  # ── BY_DESIGN_OFF (unloaded deliberately — documented decisions) ──
+  - {
+      id: com.balizero.wr2.queue-server,
+      kind: launchd,
+      machine: pro,
+      status: BY_DESIGN_OFF,
+      notes: "Damar standby 2026-06-12",
+    }
+  - {
+      id: com.balizero.wr2.canva-renderer,
+      kind: launchd,
+      machine: pro,
+      status: BY_DESIGN_OFF,
+      notes: "HTML cutover PR #1236",
+    }
+  - {
+      id: com.balizero.wr2.canva-apply,
+      kind: launchd,
+      machine: pro,
+      status: BY_DESIGN_OFF,
+      notes: "HTML cutover",
+    }
+  # ── DISARMED (loaded, no trigger — on-demand kickstart targets) ──
+  - {
+      id: com.balizero.sota.m13-collect,
+      kind: launchd,
+      machine: pro,
+      status: DISARMED,
+      notes: "no interval/calendar/KA/WatchPaths",
+    }
+  - {
+      id: com.balizero.wr2.draft-generator,
+      kind: launchd,
+      machine: pro,
+      status: DISARMED,
+      notes: "kickstart target of WR2 pipeline (by design)",
+    }
+  - {
+      id: com.balizero.wr2.fact-checker,
+      kind: launchd,
+      machine: pro,
+      status: DISARMED,
+    }
+  - {
+      id: com.balizero.wr2.fact-extractor,
+      kind: launchd,
+      machine: pro,
+      status: DISARMED,
+    }
+  - {
+      id: com.balizero.wr2.image-generator,
+      kind: launchd,
+      machine: pro,
+      status: DISARMED,
+      notes: "no fallback schedule if supervisor dead (audit F50)",
+    }
+  # ── ALIVE: long-lived daemons (KeepAlive, PID stable at census) ──
+  - {
+      id: com.balizero.guardrails-daemon,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      consumer: "~/.claude/daemons/guardrails.py",
+    }
+  - {
+      id: com.balizero.nlm-bridge,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      consumer: "uvicorn :18790",
+    }
+  - {
+      id: com.nuzantara.pg-organism-bridge,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      consumer: "scripts/pg-to-organism-bridge.py",
+    }
+  - {
+      id: com.nuzantara.intake-review-reader,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+    }
+  - {
+      id: com.balizero.post-publish-webhook,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+    }
+  - {
+      id: com.nuzantara.organism.supervisor,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+    }
+  - {
+      id: com.balizero.wa-mirror-launcher,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      notes: "post-W67 real supervisor",
+    }
+  - {
+      id: com.nuzantara.intake-worker,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+    }
+  - {
+      id: com.nuzantara.openclaw-whatsapp-bridge,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      notes: "prior instance SIGTERM (restart), current healthy",
+    }
+  - {
+      id: com.nuzantara.openclaw-whatsapp-tunnel,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+    }
+  - {
+      id: com.balizero.cron-log-sentinel,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      notes: "only eventbus daemon NOT redis-looping — verify not internally wedged",
+    }
+  - {
+      id: com.nuzantara.automap-server,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+    }
+  - {
+      id: com.nuzantara.automap-telegram,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+    }
+  - {
+      id: com.balizero.wa-meta-inbox,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+    }
+  - {
+      id: com.nuzantara.codex-spark-loop,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+    }
+  - { id: com.balizero.wa-viewer, kind: launchd, machine: pro, status: ALIVE }
+  - {
+      id: com.balizero.wa-dashboard-m1,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+    }
+  - {
+      id: com.nuzantara.heartbeat-bridge,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+    }
+  - {
+      id: com.nuzantara.prime-tunnel,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+    }
+  - {
+      id: com.nuzantara.cloudflared-intake-review,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+    }
+  - {
+      id: com.balizero.observatory-server,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+    }
+  - {
+      id: com.balizero.qdrant.daemon,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+    }
+  - {
+      id: com.balizero.profile-monitor-wrapper,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+    }
+  - {
+      id: com.balizero.wr2.pg-proxy,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+    }
+  - {
+      id: com.nuzantara.organism.control-panel,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      consumer: "uvicorn organism.control_panel :1819",
+    }
+  - {
+      id: com.cell.organism,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      notes: "2 restarts since boot on exit 1 — slow-churn watch",
+    }
+  - {
+      id: com.nuzantara.federation-alert-dispatcher,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+    }
+  - {
+      id: com.balizero.wr2.supervisor,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      notes: "exit-74 history (EX_IOERR = missing DATABASE_URL_LOCAL at boot)",
+    }
+  - {
+      id: com.balizero.wr2.supervisor-watchdog,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      notes: "same exit-74 history",
+    }
+  - {
+      id: com.balizero.wr3.supervisor,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      notes: "process alive ≠ episodes produced (0 in 14d, W74)",
+    }
+  # ── ALIVE: interval crons ──
+  - {
+      id: com.nuzantara.zombie-hunter,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "60s",
+    }
+  - {
+      id: com.balizero.intel-lake.outbox-drain.minute,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "60s",
+    }
+  - {
+      id: com.balizero.observatory-export,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "60s",
+    }
+  - {
+      id: com.nuzantara.codex-spark-harvester,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "180s",
+    }
+  - {
+      id: com.nuzantara.merge-train,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "180s",
+    }
+  - {
+      id: com.balizero.crm-guardian-cli-worker,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "300s",
+    }
+  - {
+      id: com.balizero.intel-lake-router.5min,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "300s",
+    }
+  - {
+      id: com.balizero.wa-mirror-attention-classifier,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "300s",
+    }
+  - {
+      id: com.balizero.wa-mirror-auto-promote,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "300s",
+    }
+  - {
+      id: com.balizero.post-publish-poller,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "300s",
+      notes: "loaded+green BUT its queue has 79 failed undrained (see queues.yaml)",
+    }
+  - {
+      id: com.nuzantara.wa-media-pull,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "300s",
+    }
+  - {
+      id: com.nuzantara.wa-mirror-intake-sweeper,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "300s",
+    }
+  - {
+      id: com.nuzantara.wa-mirror-session-janitor,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "300s",
+    }
+  - {
+      id: com.nuzantara.sentinel-aggregate,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "300s",
+    }
+  - {
+      id: com.nuzantara.launchagent-state-bridge,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "300s",
+      notes: "was LOOPING in 2026-06-11 guardian audit — now interval-based, healed",
+    }
+  - {
+      id: com.nuzantara.lead-intent-matcher,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "300s",
+    }
+  - {
+      id: com.nuzantara.login-healthcheck,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "300s",
+    }
+  - {
+      id: com.nuzantara.intake-gate-count-pusher,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "300s",
+    }
+  - {
+      id: com.nuzantara.openclaw-children-watchdog,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "300s",
+    }
+  - {
+      id: com.nuzantara.memory-sync-bidirectional,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "300s",
+      notes: "daemon green but BOTH spokes skipped 100/100 runs (M5 IP drift + Mini down) — see sync-forks.yaml",
+    }
+  - {
+      id: com.balizero.wa-mirror-attention-realtime,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "600s",
+    }
+  - {
+      id: com.balizero.dropbox-intake,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "600s",
+      notes: "527GiB backfill in flight",
+    }
+  - {
+      id: com.nuzantara.cost-breaker-deadman,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "600s",
+      notes: "W71 governance",
+    }
+  - {
+      id: com.nuzantara.review-gate,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "600s",
+    }
+  - {
+      id: com.nuzantara.sentinel,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "600s",
+      notes: "W70 #4 one-shot-vs-daemon RESOLVED (StartInterval=600)",
+    }
+  - {
+      id: com.nuzantara.sentinel-meta-watchdog,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "600s",
+    }
+  - {
+      id: com.nuzantara.supervisor-liveness-watchdog,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "600s",
+    }
+  - {
+      id: com.nuzantara.verify-the-verifiers,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "600s",
+      notes: "W71 meta-verifier H24",
+    }
+  - {
+      id: com.nuzantara.cpu-monitor,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "600s",
+    }
+  - {
+      id: com.nuzantara.disk-monitor,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "600s",
+    }
+  - {
+      id: com.nuzantara.automap-watchdog,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "600s",
+    }
+  - {
+      id: com.balizero.wr2.canva-lease-watchdog,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "600s",
+      notes: "W64 lint target — runtime green",
+    }
+  - {
+      id: com.balizero.wr2.pg-queue-sync,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "600s",
+    }
+  - {
+      id: com.balizero.wr2.html-apply,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "600s",
+      notes: "the LIVE HTML renderer lane",
+    }
+  - {
+      id: com.balizero.mos-plus.compression,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "600s",
+    }
+  - {
+      id: com.nuzantara.fly-restart-loop-detector,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "900s",
+    }
+  - {
+      id: com.nuzantara.repomap.15min,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "900s",
+    }
+  - {
+      id: com.nuzantara.mcp-integrity,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "900s",
+      notes: "W71 glyph fix live",
+    }
+  - {
+      id: com.balizero.intel-lake-nb-pusher.15min,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "900s",
+    }
+  - {
+      id: com.balizero.mos-plus.qdrant-indexer,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "1800s",
+    }
+  - {
+      id: com.nuzantara.cost-ledger-export,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "1800s",
+    }
+  - {
+      id: com.nuzantara.dlq-autopilot,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "1800s",
+    }
+  - {
+      id: com.nuzantara.claude-config-sync,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "3600s",
+    }
+  - {
+      id: com.nuzantara.claude-max-usage-watcher,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "3600s",
+    }
+  - {
+      id: com.nuzantara.nb-intel-delta-watcher.hourly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "3600s",
+    }
+  - {
+      id: com.balizero.nuzantara.log-size-watchdog,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "3600s",
+    }
+  - {
+      id: com.nuzantara.cost-breaker,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "3600s",
+      notes: "W69 BUCO#2 closed",
+    }
+  - {
+      id: com.balizero.wa-mirror-strategic-recap,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "10800s",
+    }
+  - {
+      id: com.balizero.wr2.trend-hunter,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "7200s",
+    }
+  - {
+      id: com.balizero.intel-lake.shadow-validate.6h,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "21600s",
+    }
+  - {
+      id: com.balizero.wr2.canva-oauth-watchdog,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "21600s",
+    }
+  - {
+      id: com.nuzantara.launchd-env-loader,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "43200s",
+    }
+  # ── ALIVE: calendar crons (WITA schedule in producer) ──
+  - {
+      id: com.balizero.intel.nightly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 1:00",
+    }
+  - {
+      id: com.nuzantara.daily-indexing-sweep,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 1:00",
+      notes: "guardian-audit 10.7k-runs crash-loop NO LONGER present (calendar-only now)",
+    }
+  - {
+      id: com.balizero.audit-launchd.daily,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 2:00",
+    }
+  - {
+      id: com.nuzantara.nb-mitochondrial-monitor.daily,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 2:30",
+    }
+  - {
+      id: com.balizero.wr2.reflexion.weekly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "Sun 2:30",
+      notes: "the REAL 314-line impl (WR3 twin unloaded)",
+    }
+  - {
+      id: com.balizero.wr2.voyager.weekly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "Sun 2:00",
+      notes: "_voyager-curriculum.py NOW EXISTS — do not confuse with the 2026-06-05 phantom-citation scar",
+    }
+  - {
+      id: com.nuzantara.openclaw-logrotate,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 3:00",
+    }
+  - {
+      id: com.balizero.wr2.learner-nightly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 3:00",
+    }
+  - {
+      id: com.balizero.wr2.ig-scraper.daily,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 3:00",
+    }
+  - {
+      id: com.nuzantara.codex-coverage-improver,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 3:00",
+    }
+  - {
+      id: com.balizero.wa-lid-refresh,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 3:15",
+      notes: "depends on wa-mirror :7790 up",
+    }
+  - {
+      id: com.nuzantara.outbox-prune.daily,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 3:15",
+    }
+  - {
+      id: com.balizero.domain-mesh.foundations.daily,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 4:00",
+    }
+  - {
+      id: com.balizero.nb-curator.daily,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 4:00",
+    }
+  - {
+      id: com.nuzantara.archive-empty-sessions.daily,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 4:00",
+    }
+  - {
+      id: com.balizero.wr2.e2e-probe.daily,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 4:00",
+    }
+  - {
+      id: com.balizero.wr2.connector,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 4:00",
+    }
+  - {
+      id: com.balizero.wr2.dossier-compiler,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 4:30",
+    }
+  - {
+      id: com.nuzantara.secrets-sync-mini,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 4:30",
+      notes: "Mini down at census — verify behavior on Mini return",
+    }
+  - {
+      id: com.balizero.wr2.topic-selector,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 5:10",
+    }
+  - {
+      id: com.balizero.bz-daily-visual-pipeline,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 5:30",
+    }
+  - {
+      id: com.balizero.setup-team.daily,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 6:00",
+    }
+  - {
+      id: com.balizero.wr2.daily-metrics,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 6:00",
+    }
+  - {
+      id: com.balizero.nuzantara-drive-sync,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "6:00+18:00",
+    }
+  - {
+      id: com.nuzantara.codex-research-actor,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 6:00",
+    }
+  - {
+      id: com.balizero.regulatory-watcher.daily,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 7:00",
+    }
+  - {
+      id: com.nuzantara.codex-openclaw-analysis,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 7:15",
+    }
+  - {
+      id: com.balizero.renewal-alerts,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 8:00",
+    }
+  - {
+      id: com.nuzantara.cost-advisor-daily-cap,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 8:00",
+    }
+  - {
+      id: com.nuzantara.openclaw.guardian-board,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 8:30",
+    }
+  - {
+      id: com.balizero.client-value-predictor,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 9:00",
+    }
+  - {
+      id: com.balizero.l5-2-phase2b-trigger,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 9:00",
+    }
+  - {
+      id: com.balizero.sota.m13-checkpoint,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 9:00",
+    }
+  - {
+      id: com.balizero.wr2.canva-token-watchdog,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 9:00",
+    }
+  - {
+      id: com.balizero.nuzantara.disk-watchdog,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 9:00",
+    }
+  - {
+      id: com.balizero.wa-mirror-attention-digest,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 18:00",
+    }
+  - {
+      id: com.balizero.seo-cell.daily,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 19:30",
+    }
+  - {
+      id: com.nuzantara.plist-snapshot.daily,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 19:30",
+    }
+  - {
+      id: com.nuzantara.codex-overnight-feeder,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 21:30",
+    }
+  - {
+      id: com.nuzantara.codex-overnight-runner,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 22:00",
+    }
+  - {
+      id: com.nuzantara.automations-reference,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 23:15",
+    }
+  - {
+      id: com.cell.metabolic-rollup,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 23:45",
+    }
+  - {
+      id: com.balizero.translate.hourly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "hourly :30",
+      notes: "translate-hourly.log 83MB — rotation candidate",
+    }
+  - {
+      id: com.nuzantara.organism.scheduled-tick,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "hourly :00",
+    }
+  - {
+      id: com.nuzantara.skills-bridge-consumer,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "192-entry calendar 06:00-21:55/5min",
+      notes: "W65 family",
+    }
+  - {
+      id: com.balizero.intel-lake.e2e-probe.6h,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "0:30/6:30/12:30/18:30",
+    }
+  - {
+      id: com.balizero.cicatrix-rotation.monthly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "d1 4:00",
+    }
+  - {
+      id: com.balizero.sota.m13-monthly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "d1 4:30",
+    }
+  - {
+      id: com.balizero.wr3.editorial-bench.monthly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "d1 7:00",
+    }
+  - {
+      id: com.balizero.competitor-monitor.monthly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "d1 9:00",
+    }
+  - {
+      id: com.balizero.seo-cell.28d-check,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "d29 4:00",
+      notes: "skips February",
+    }
+  - {
+      id: com.balizero.wr2.worktree-gc.daily,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 0:00",
+      notes: "plistlib strict-parse fails, plutil OK — bites python plist tooling",
+    }
+  - {
+      id: com.nuzantara.worktree-gc-universal.daily,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "daily 0:30",
+      notes: "same plistlib edge",
+    }
+  - {
+      id: com.nuzantara.branch-cleanup.weekly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "Mon 8:00",
+    }
+  - {
+      id: com.balizero.curiosity.weekly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "Sun 20:00",
+    }
+  - {
+      id: com.balizero.wr2.oracle,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "Sun 22:30",
+    }
+  - {
+      id: com.balizero.wr2.strategos,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "Sun 22:00",
+    }
+  - {
+      id: com.balizero.sota.m13-weekly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "Sun 6:00",
+    }
+  - {
+      id: com.balizero.yield-optimizer.weekly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "Sun 4:00",
+    }
+  - {
+      id: com.balizero.codex-spalla-calibrate,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "Sun 6:00",
+    }
+  - {
+      id: com.balizero.nextdns-tamper-detect.weekly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "Mon 1:00",
+    }
+  - {
+      id: com.balizero.competitor-signal-router.weekly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "Mon 6:30",
+    }
+  - {
+      id: com.balizero.wr2.ig-metrics-analyst.weekly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "Mon 6:07",
+    }
+  - {
+      id: com.nuzantara.cost-advisor-weekly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "Mon 7:00",
+    }
+  - {
+      id: com.nuzantara.gh-auth-healthcheck.weekly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "Mon 7:00",
+    }
+  - {
+      id: com.nuzantara.chronic-failure-digest.weekly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "Mon 8:30",
+    }
+  - {
+      id: com.balizero.fly-cost-alert.weekly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "Mon 9:00",
+    }
+  - {
+      id: com.nuzantara.vector-reindex-check,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "Mon 9:00",
+    }
+  - {
+      id: com.balizero.wr2.canva-gc.weekly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "Mon 4:30",
+      notes: "Canva GC scheduled though renderer unloaded — harmless residue",
+    }
+  - {
+      id: com.nuzantara.outbox-prune.weekly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "Sun 4:30",
+    }
+  - {
+      id: com.balizero.wr2.external-bench.monthly,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "Mon 7:00 (weekday=1 — runs WEEKLY despite name)",
+    }
+  - {
+      id: com.balizero.wr2.newsletter,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "Mon 9:00",
+    }
+  - {
+      id: com.balizero.claude-settings-watcher,
+      kind: launchd,
+      machine: pro,
+      status: ALIVE,
+      producer: "WatchPaths ~/.claude/settings.json",
+    }
+anomalies:
+  - "P1: 4 eventbus daemons crash-looping on redis TimeoutError ~7h (meta-dispatcher, intel-dedup-gateway, research-sentinel, observatory) — redis-cli on localhost WORKS, so their connection target/env is wrong"
+  - "P1: wr2.deploy-puller DEAD + alert-suppressed (W55 replay) — remediation dispatched 2026-06-13"
+  - "P2: wr2.plist-watchdog DEAD 28×15min — WR2 self-heal layer dark while deploy-puller also dark"
+  - "P2: pg-organism-bridge-watchdog LYING_BY_PRESENCE — unarmed watchdog over a live daemon"
+  - "P3: supervisors wr2/wr2-watchdog/wr3 exit-74 churn (DATABASE_URL_LOCAL transient at boot)"
+  - "P4: external-bench 'monthly' actually weekly; 4 plists fail strict plistlib; translate log 83MB"

--- a/docs/connectome/edges/pg-channels.yaml
+++ b/docs/connectome/edges/pg-channels.yaml
@@ -1,0 +1,170 @@
+# Connectome — Postgres LISTEN/NOTIFY channels + EventBus outbox event-types
+# Census: 2026-06-13 (8-agent fan-out, every claim re-verified on disk that session)
+# Producer/consumer refs are file:line at census time — re-grep before building on them.
+domain: pg-channels
+census_date: "2026-06-13"
+edges:
+  - id: practice-status-changed
+    kind: pg_channel
+    producer: "migrations_v2/146 trigger notify_practice_change"
+    consumer: "services/events/handlers/_core.py:168 + crm/practice_status_listener.py:156"
+    machine: fly
+    status: ALIVE
+  - id: client-changed
+    kind: pg_channel
+    producer: "migrations_v2/146 trigger notify_client_change"
+    consumer: "services/events/handlers/_core.py:89"
+    machine: fly
+    status: ALIVE
+    notes: "554 unconsumed outbox rows (largest orphan residue — see queues.yaml events-outbox-fly)"
+  - id: compliance-alert
+    kind: pg_channel
+    producer: "migrations_v2/146 trigger notify_compliance_alert"
+    consumer: "_core.py:256 + compliance_handlers.py"
+    machine: fly
+    status: ALIVE
+  - id: lkpm-ingest-completed
+    kind: pg_channel
+    producer: "imperative outbox.publish (scripts)"
+    consumer: "crm_hgt_handlers.py on_lkpm_ingest_completed"
+    machine: fly
+    status: ALIVE
+  - id: war-room-event
+    kind: pg_channel
+    producer: "migrations_v2/146 triggers on war_room_drafts/posts"
+    consumer: "webhook_processor.py:90 + pg-to-organism-bridge.py:64"
+    machine: fly
+    status: ALIVE
+  - id: wa-message-inserted
+    kind: pg_channel
+    producer: "migrations_v2/193 trigger on whatsapp_message_context"
+    consumer: "routers/wa_dashboard_stream.py:145 (SSE)"
+    machine: fly
+    status: ALIVE
+  - id: intel-event
+    kind: pg_channel
+    producer: "migrations_v2/146 triggers trend_signals/research_dossiers"
+    consumer: "dossier_fanout/subscriber.py + bridge"
+    machine: fly
+    status: ALIVE
+  - id: cognitive-event
+    kind: pg_channel
+    producer: "migrations_v2/146 triggers (theses/anomaly/briefs/ultra_moves)"
+    consumer: "EventBus dispatch + pg-to-organism-bridge.py:66"
+    machine: fly
+    status: ALIVE
+  - id: partner-commission-changed
+    kind: pg_channel
+    producer: "crm/partners/events.py _publish_changed"
+    consumer: "crm/partners/events.py register_partner_handlers"
+    machine: fly
+    status: ALIVE
+  - id: federation-alert
+    kind: pg_channel
+    producer: "12+ alert producers (cell, compliance-ops, WR2 supervisor, monitors)"
+    consumer: "federation_alerts/daemon.py:55 (direct LISTEN, NOT via EventBus)"
+    machine: pro
+    status: ALIVE
+    notes: "duplicate-listener pattern: PG_CHANNEL_MAP entry exists but EventBus does not consume — daemon owns it"
+  - id: cell-pulse-observed
+    kind: pg_channel
+    producer: "cell-core/observatory.py emit_pulse_observed"
+    consumer: "cell-observatory-collector/collector.py:128"
+    machine: pro
+    status: ALIVE
+    notes: "393 unconsumed outbox rows accumulate (bridge consumes via LISTEN, outbox replay never acks)"
+  - id: cell-pulse-sustained-red
+    kind: pg_channel
+    producer: "cell-core/observatory.py emit_sustained_red (W57)"
+    consumer: "pg-to-organism-bridge.py:73 only — NO EventBus subscriber"
+    machine: pro
+    status: ORPHAN_CONSUMER
+    notes: "52 unconsumed rows; event_bus.py:108-114 comment documents the missing subscriber"
+  - id: measurer-event
+    kind: pg_channel
+    producer: "migrations_v2/152 trigger post_metrics_history/m13_retrain_log"
+    consumer: "M14 learner"
+    machine: fly
+    status: ALIVE
+  - id: crm-welcome-completed
+    kind: pg_channel
+    producer: "migrations_v2/153 trigger crm_welcome_runs"
+    consumer: "analytics/retention consumers"
+    machine: fly
+    status: ALIVE
+  - id: whatsapp-message-received
+    kind: pg_channel
+    producer: "wa-mirror explicit publish"
+    consumer: "_core.py:326 on_whatsapp_message_received"
+    machine: fly
+    status: ALIVE
+  - id: mata-garuda-asset-provenance
+    kind: pg_channel
+    producer: "migrations_v2/155 trigger asset_provenance"
+    consumer: "war_room/asset_invalidated_subscriber.py"
+    machine: fly
+    status: ALIVE
+  - id: intel-lake-event
+    kind: pg_channel
+    producer: "migrations_v2/168 trigger intel_items INSERT"
+    consumer: "intel/intel_lake_router.py"
+    machine: fly
+    status: ALIVE
+    notes: "24 unconsumed outbox rows"
+  - id: wr2-status-change
+    kind: pg_channel
+    producer: "migrations_v2/164 trigger war_room_drafts status UPDATE"
+    consumer: "scripts/wr2_supervisor.py (bespoke listener + own outbox replay)"
+    machine: pro
+    status: ALIVE
+    notes: "NOT in PG_CHANNEL_MAP by design"
+  - id: wr3-episode-lifecycle
+    kind: pg_channel
+    producer: "scripts/wr3_supervisor.py publish_wr3_event (migration 183) — 6 channels: brief_requested/pre_render_ready/gate_passed/assembly_ready/critic_verdict/staged"
+    consumer: "scripts/wr3_supervisor.py _listen_loop"
+    machine: pro
+    status: ALIVE
+    notes: "self-loop orchestration; supervisor process alive but 0 episodes in 14d (armed-but-inactive, W74)"
+  - id: pg-to-organism-bridge
+    kind: pg_channel
+    producer: "18 channels above"
+    consumer: "scripts/pg-to-organism-bridge.py CHANNELS (l.59-78) -> organism Redis stream + JSONL mirror"
+    machine: pro
+    status: ALIVE
+    probe:
+      {
+        type: launchd_label,
+        label: com.nuzantara.pg-organism-bridge,
+        via: "ssh:pro-lan",
+      }
+  - id: whatsapp-media-pending
+    kind: outbox_event
+    producer: "routers/bridge.py (Fly webhook, metadata-only Law 2)"
+    consumer: "scripts/wa_media_pull_worker.py (Pro cron, ACK-after-local-enqueue)"
+    machine: fly
+    status: ALIVE
+    notes: "outbox-only pattern, deliberately NOT in PG_CHANNEL_MAP; ~0 backlog at census"
+  - id: crm-bridge-outbox-events
+    kind: outbox_event
+    producer: "_core.py:125-143 insert_outbox_event (crm.client_created etc.)"
+    consumer: "Pro-side bridge consumer (cross-environment by design)"
+    machine: fly
+    status: ALIVE
+  - id: wr2-carousel-events-outbox
+    kind: outbox_event
+    producer: "war_room/wr2_outbox_consumer.py (migration 199 bespoke table)"
+    consumer: "wr2_damar_publish_consumer.py / wr2_fact_checker.py"
+    machine: pro
+    status: ALIVE
+    notes: "damar publish consumer DEAD since Damar standby 2026-06-12 (see queues.yaml)"
+  - id: autonomous-lab-events-outbox
+    kind: outbox_event
+    producer: "migrations_v2/124 autonomous_lab_events_outbox"
+    consumer: "Autonomous Lab runtime (ack-after-success)"
+    machine: fly
+    status: ALIVE
+anomalies:
+  - "DIVERGENCE with sibling TAC report (research/operations/2026-06-13-organism-connectome-fable5.md): it counts 27 channels in PG_CHANNEL_MAP and flags 5 producer-without-EventBus-consumer (war_room_event, cognitive_event, federation_alert, measurer_event, crm_welcome_completed); this census found bespoke/direct listeners for some of those. Two verifiers disagree → resolve with verify_connectome probes, do not trust either blindly"
+  - "cell_pulse_sustained_red: ORPHAN_CONSUMER — EventBus subscriber never written (52 rows, growing)"
+  - "topic_ready channel: census found ZERO grep hits in current tree — pipeline-A dispatcher removed since the 2026-06-11 audit (F17 superseded by deletion)"
+  - "federation_alert: PG_CHANNEL_MAP entry unused by EventBus (daemon does direct LISTEN) — either remove from map or add fan-in"

--- a/docs/connectome/edges/queues.yaml
+++ b/docs/connectome/edges/queues.yaml
@@ -1,0 +1,144 @@
+# Connectome — queues, buffers, dead-letter stores (producer → queue → drainer)
+# Census: 2026-06-13. Depths/ages are census-time snapshots, not invariants.
+domain: queues
+census_date: "2026-06-13"
+edges:
+  - id: dlq-json-pro
+    kind: queue
+    producer: "scripts/nuzantara-sentinel.py add_to_dlq (heal-failure path)"
+    consumer: "scripts/dlq_autopilot.py (com.nuzantara.dlq-autopilot 30min); TERMINAL rows = human requeue only"
+    machine: pro
+    status: ALIVE
+    depth_at_census: "33 (31 TERMINAL) — REGREW from 0 on 2026-06-09 in 4 days"
+    probe:
+      {
+        type: cmd,
+        via: "ssh:pro-lan",
+        cmd: 'python3 -c "import json;d=json.load(open(''/Users/nuzantara/.agent/decisions/dlq.json''));q=[e for e in d.get(''queue'',[]) if e.get(''status'')==''TERMINAL''];import sys;sys.exit(0 if len(q)<40 else 1)"',
+      }
+    notes: "META-cause W70 #3 still open: log_tail='exit 1 after 3 attempts', classification UNKNOWN → autopilot blind"
+  - id: claude-tasks-escalation-dir
+    kind: queue
+    producer: "dlq_autopilot.py:430 escalate_to_claude_code"
+    consumer: "HUMAN convention (CLAUDE.md §14) — no automated drainer"
+    machine: pro
+    status: ORPHAN_CONSUMER
+    depth_at_census: "840 files, oldest ~18d"
+    notes: "producer is a 30-min cron loop, consumer is a human — structurally divergent"
+  - id: escalations-pro-jsonl
+    kind: queue
+    producer: "sentinel_lib/escalations.py write_escalation"
+    consumer: "dlq_autopilot cooldown consult + metabolic_rollup + suppressed_digest"
+    machine: pro
+    status: STALE
+    depth_at_census: "19 lines, ALL status=pending forever (no resolution lifecycle)"
+  - id: events-outbox-fly
+    kind: queue
+    producer: "services/events/outbox.py publish + migration-146 triggers"
+    consumer: "EventBus replay (ack-after-dispatch); prune crons daily/weekly (consumed-only)"
+    machine: fly
+    status: ALIVE
+    depth_at_census: "41,499 total; 1,351 unconsumed (client_changed 554, cell_pulse_observed 393, inbound_webhook_queued 188, practice_changed 113, sustained_red 52); oldest unconsumed 32d"
+    notes: "orphan-channel rows never pruned — event_bus.py:112 admits unmapped channels stay unconsumed forever"
+  - id: intake-queue-local
+    kind: queue
+    producer: "wa_media_pull_worker + drive_intake_drain + wa_mirror_intake_sweeper + dropbox intake"
+    consumer: "services/intake/worker.py (com.nuzantara.intake-worker, v2 lease-only claim, SKIP-LOCKED)"
+    machine: pro
+    status: STALE
+    depth_at_census: "pending=179, ocr_done=740 (stuck 9d at extract stage), review_pending=6, done=767"
+    notes: "lease discipline clean (0 processing-stuck) — mid-pipeline silt at the EXTRACT stage is the wound"
+  - id: post-publish-queue-fly
+    kind: queue
+    producer: "routers/news.py:33 + routers/intel.py:568"
+    consumer: "post_publish_poller.py (300s) + post_publish_webhook.py (daemon)"
+    machine: fly
+    status: STALE
+    depth_at_census: "failed=79 undrained, processing=1 STUCK 46 DAYS, done=33"
+    notes: "nothing requeues failed except manual re-publish; poller also has 47+45 claude_tasks escalations"
+  - id: redis-garuda-raw
+    kind: redis_stream
+    producer: "mata_garuda agents (intel_scraper_bridge, reddit_listener, lhkpn, exa, tavily)"
+    consumer: "groups: nexus-bridge (lag 0) · normalizer (lag 858, NO process exists)"
+    machine: pro
+    status: ORPHAN_CONSUMER
+    depth_at_census: "XLEN 3655; producers SILENT 22d (last entry 2026-05-21)"
+    notes: "pipeline semi-decommissioned toward Intel Lake; groups never removed"
+  - id: redis-garuda-enriched
+    kind: redis_stream
+    producer: "mata_garuda enrichment chain"
+    consumer: "classifier/kg_linker/ner lag 0 ALIVE · nlm_feeder lag 3144 STALE · scorer lag 3036 NO PROCESS"
+    machine: pro
+    status: ORPHAN_CONSUMER
+    depth_at_census: "XLEN 4539"
+    notes: "watchdogs consumer-lag.check + redis-split-brain.check BOTH exit 1 — blind watchers"
+  - id: redis-nexus-gaps
+    kind: redis_stream
+    producer: "gap-detector (twice daily)"
+    consumer: "workers/gap_consumer.py (acks ONLY on success)"
+    machine: pro
+    status: STALE
+    depth_at_census: "XLEN 1149, PEL 1097 delivered-never-ACKed (95%)"
+    notes: "consumer runs exit 0 but acks almost nothing — silent per-item failure"
+  - id: redis-nexus-tasks
+    kind: redis_stream
+    producer: "mata_garuda autonomy task_tools"
+    consumer: "nexus-autonomy-workers (lag 0)"
+    machine: pro
+    status: ALIVE
+    notes: "2032 churned consumer names in group — cosmetic debt"
+  - id: redis-bridge-inbound
+    kind: redis_stream
+    producer: "mata-garuda/bridge/nerve.py:346 XADD"
+    consumer: "nerve.py xreadgroup — group NEVER CREATED (zero groups)"
+    machine: pro
+    status: ORPHAN_PRODUCER
+    depth_at_census: "151 entries nobody reads; producer also quiet 19d"
+  - id: redis-cell-skills
+    kind: redis_stream
+    producer: "cell organism skill events"
+    consumer: "hgt_ai-intel-sentinel lag 0 ALIVE · sentinel-1 entries-read 0 (dead group)"
+    machine: pro
+    status: ALIVE
+  - id: redis-agent-lock-leases
+    kind: buffer
+    producer: "scripts/agent_start.py + pre-commit lease hook (TTL+heartbeat)"
+    consumer: "TTL expiry"
+    machine: pro
+    status: ALIVE
+    depth_at_census: "0 active leases"
+  - id: wa-outbox-fly
+    kind: queue
+    producer: "wa_inbox.py / whatsapp_chat.py send-intents"
+    consumer: "_run_wa_outbox_scheduler in main_api.py:38-65 (in-app loop, poll 3s, SKIP-LOCKED, 24h window)"
+    machine: fly
+    status: ALIVE
+    depth_at_census: "done=3, failed=33 terminal (no requeue path)"
+  - id: partner-email-outbox-fly
+    kind: queue
+    producer: "crm/partners/repository.py:453 insert_email_outbox"
+    consumer: "emails.py:328 flush_outbox — NO cron/endpoint invokes it"
+    machine: fly
+    status: ORPHAN_CONSUMER
+    depth_at_census: "1 pending for 53 days"
+  - id: wr2-damar-publish-feedback
+    kind: queue
+    producer: "Damar WA 'PUBBLICATO WR2-<ref>' → wa-mirror → whatsapp_message_context"
+    consumer: "scripts/wr2_damar_publish_consumer.py → mark_published"
+    machine: pro
+    status: BY_DESIGN_OFF
+    notes: "Damar standby 2026-06-12 — consumer disabled deliberately"
+  - id: bridge-outbox-local
+    kind: queue
+    producer: "services/bridge/outbox.py (Pro/Mini sync)"
+    consumer: "replay_outbox_throttled family"
+    machine: pro
+    status: ALIVE
+    depth_at_census: "0 rows"
+anomalies:
+  - "nexus:gaps PEL 1097/1149 unacked + both its watchdogs exit 1 — blind watchers over a sick stream"
+  - "DLQ TERMINAL regrowth 0→31 in 4 days post-W70-drain; healing_actions_24h=0 — heal loop still blind (stderr capture never shipped)"
+  - "claude_tasks/ 840 files — automated producer vs human consumer"
+  - "intake ocr_done=740 stuck 9d at extract stage"
+  - "post_publish failed=79 + 1 processing stuck 46d"
+  - "cross-cutting: every drainer-of-last-resort is either a human convention or a failing watchdog (W64 'esistere ≠ armato' on the queue layer)"

--- a/docs/connectome/edges/sync-forks.yaml
+++ b/docs/connectome/edges/sync-forks.yaml
@@ -1,0 +1,125 @@
+# Connectome — file-sync arteries + HOME-fork double-files (W50/W51/W52/W68 disease class)
+# Census: 2026-06-13. md5 values are census-time; the md5_pair probes re-verify drift.
+domain: sync-forks
+census_date: "2026-06-13"
+edges:
+  - id: memory-sync-bidirectional
+    kind: file_sync
+    producer: "Pro hub ~/.claude/projects/-Users-nuzantara/memory"
+    consumer: "Mini + M5 spokes (5min)"
+    machine: pro
+    status: STALE
+    notes: "daemon green but 100/100 runs skipped both spokes: script hardcodes M5_IP=192.168.0.16 vs live .19 (DHCP drift) + Mini down. Last M5 sync 06-12 13:22"
+  - id: nuz-sync-air
+    kind: file_sync
+    machine: pro
+    status: DEAD
+    notes: "Air decommissioned 2026-05-05 — expected retirement, scripts remain as archaeology (last run 05-04)"
+  - id: drive-codebase-mirror
+    kind: file_sync
+    producer: "Pro repo+brand+memory"
+    consumer: "gdrive:nuzantara-codebase (rclone, 06:00+18:00)"
+    machine: pro
+    status: ALIVE
+    probe:
+      {
+        type: cmd,
+        via: "ssh:pro-lan",
+        cmd: "find ~/.cache/nuzantara-drive-sync -name 'sync-*.log' -mtime -1 | grep -q .",
+      }
+  - id: dropbox-drive-intake
+    kind: file_sync
+    producer: "dropbox data.bayusantero@"
+    consumer: "gdrive:Dropbox-Intake (rclone copy-only, 10min)"
+    machine: pro
+    status: ALIVE
+    notes: "527GiB backfill in flight at census (~50%)"
+  - id: wr2-deploy-puller-sync
+    kind: file_sync
+    producer: "origin/main"
+    consumer: "Pro ~/Desktop/nuzantara-deploy (hourly pull)"
+    machine: pro
+    status: STALE
+    notes: "census: dirty=1 + 17 behind + alerts suppressed (W55 replay #3). Sibling session realigned ~00:41 06-13; verify"
+    probe:
+      {
+        type: cmd,
+        via: "ssh:pro-lan",
+        cmd: 'cd ~/Desktop/nuzantara-deploy && test -z "$(git status --porcelain)" && git fetch -q origin && test "$(git rev-list --count HEAD..origin/main)" -lt 5',
+      }
+  - id: repomap-pro
+    kind: file_sync
+    machine: pro
+    status: ALIVE
+    probe:
+      {
+        type: file_age_max_h,
+        via: "ssh:pro-lan",
+        path: "~/.nuzantara-repomap.txt",
+        max_age_h: 1,
+      }
+    notes: "PR #1376 (sibling) fixed 188kB webpack noise → ~40kB real signatures"
+  # ── HOME-forks (copy_a = deployed/HOME, copy_b = repo/main) ──
+  - id: fork-openclaw-whatsapp-bridge
+    kind: home_fork
+    machine: pro
+    status: IDENTICAL
+    notes: "deployed Pro HOME copy == origin/main HEAD (md5 09ec1366) — W73 double-patch discipline HELD. Pro repo checkout copy is stale but that checkout is itself 131 behind (see anomaly)"
+    probe:
+      {
+        type: cmd,
+        via: "ssh:pro-lan",
+        cmd: 'test "$(md5 -q ~/.openclaw/bin/openclaw_whatsapp_bridge.py)" = "$(cd ~/Desktop/nuzantara-deploy && git show origin/main:scripts/openclaw_whatsapp_bridge.py | md5 -q)"',
+      }
+  - id: fork-fly-pg-backup
+    kind: home_fork
+    machine: pro
+    status: IDENTICAL
+    probe:
+      {
+        type: cmd,
+        via: "ssh:pro-lan",
+        cmd: 'test "$(md5 -q ~/scripts/fly-pg-backup.sh)" = "$(cd ~/Desktop/nuzantara-deploy && git show origin/main:scripts/fly-pg-backup.sh | md5 -q)"',
+      }
+  - id: fork-fly-qdrant-backup
+    kind: home_fork
+    machine: pro
+    status: DRIFTED
+    notes: "HOME copy Apr 6 (2+ months stale, likely dead Air path) vs repo current — the cron runs the OLD file. Refresh HOME from repo (wave-2)"
+    probe:
+      {
+        type: cmd,
+        via: "ssh:pro-lan",
+        cmd: 'test "$(md5 -q ~/scripts/fly-qdrant-backup.sh)" = "$(cd ~/Desktop/nuzantara-deploy && git show origin/main:scripts/fly-qdrant-backup.sh | md5 -q)"',
+      }
+  - id: fork-wr2-deploy-pull
+    kind: home_fork
+    machine: pro
+    status: DRIFTED
+    notes: "HOME NEWER (Jun 7, uncommitted) than main — production hourly puller logic unversioned. Adopt into repo"
+  - id: fork-fly-backup
+    kind: home_fork
+    machine: pro
+    status: DRIFTED
+    notes: "HOME (May 27) ≠ repo infra/scripts/fly-backup.sh (main)"
+  - id: fork-nextdns-weekly-digest
+    kind: home_fork
+    machine: pro
+    status: DRIFTED
+    notes: "HOME newer (May 16), uncommitted"
+  - id: untracked-single-copies
+    kind: home_fork
+    machine: pro
+    status: UNKNOWN
+    notes: "production scripts existing ONLY in HOME, unversioned: qdrant-snapshot.sh (carries F09 fix), regulatory-watcher-run.sh (canonical cascade impl), wa-mirror-launcher trio. A Pro rebuild loses them — version them"
+  - id: fork-launchagent-plists
+    kind: home_fork
+    machine: pro
+    status: DRIFTED
+    notes: "136/215 live Pro plists NOT versioned in infra/launchagents/ (the installed-by-hand set); 79 overlap pairs not md5-diffed yet (next census pass)"
+anomalies:
+  - "P1: Pro MAIN checkout 131 commits behind origin/main + divergent local commit e2b355f45 + 33 dirty files — untrustworthy as reference, violates main-checkout-read-only discipline"
+  - "P2: fly-qdrant-backup deployed copy 2+ months stale (W70 backup-death class)"
+  - "P2: wr2-deploy-pull.sh production logic uncommitted (HOME newer than main)"
+  - "P2: 136/215 live plists unversioned — Pro not rebuildable from repo"
+  - "P3: memory-sync M5_IP hardcoded → DHCP drift broke the spoke"

--- a/scripts/verify_connectome.py
+++ b/scripts/verify_connectome.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""verify_connectome.py — re-walk the declared system arteries and detect silent edge death.
+
+The connectome (docs/connectome/edges/*.yaml) is the empirical census of every
+producer→consumer edge in the Nuzantara organism (PG channels, queues, launchd
+fleet, GH workflows, sync daemons, HOME-forks, webhooks, hooks, MCP servers).
+This verifier re-probes the edges that carry a runnable probe and reports drift
+against the declared status — the antibody for the recurring disease class
+"edges die silently" (W55/W62/W64/W67/W70/W71 family).
+
+Classification per edge:
+  CONFIRMED   probe outcome matches declared status
+  REGRESSED   declared healthy (ALIVE/ARMED/GATING/...) but probe FAILED  ← the alarm
+  RECOVERED   declared dead-ish but probe PASSED (census is stale — update it)
+  STATIC      no probe declared/derivable (documentation-only edge)
+  SKIPPED     probe targets an unreachable machine
+
+Probe spec (optional per edge):
+  probe:
+    type: cmd | file_exists | file_age_max_h | grep | launchd_label | md5_pair
+    via: local | ssh:<host>          # default local
+    # type=cmd:           cmd: "...", expect_regex: "..." (optional)
+    # type=file_exists:   path: "~/..."
+    # type=file_age_max_h: path: "~/...", max_age_h: 26
+    # type=grep:          path: "...", pattern: "..."
+    # type=launchd_label: label defaults to edge id; bad_exit_ok: false
+    # type=md5_pair:      path_a: "...", path_b: "..." (DRIFTED edges: pass = still drifted? no:
+    #                     pass = files identical; declare expected: identical|drifted)
+
+Kind-default probes (when no explicit probe):
+  kind=launchd on the current/reachable machine → launchd_label(id)
+
+Usage:
+  apps/backend-rag/.venv/bin/python scripts/verify_connectome.py [--json out.json]
+      [--edges-dir docs/connectome/edges] [--only-kind launchd] [--machine auto]
+      [--no-ssh]
+
+Exit codes: 0 = no REGRESSED · 1 = at least one REGRESSED · 2 = loader error.
+
+Healthy-declared statuses: ALIVE, ARMED, GATING, SCHEDULED_ALIVE, IDENTICAL,
+ALIVE-ACTIVE, ALIVE (mechanism), RUN_ONLY. Everything else counts as dead-ish
+for RECOVERED detection. Substring match on the first token before whitespace.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import hashlib
+import json
+import logging
+import os
+import re
+import shlex
+import socket
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("verify_connectome")
+
+HEALTHY_PREFIXES = (
+    "ALIVE",
+    "ARMED",
+    "GATING",
+    "SCHEDULED_ALIVE",
+    "IDENTICAL",
+    "RUN_ONLY",
+    "OK",
+)
+
+SSH_HOSTS: dict[str, str] = {
+    # logical machine -> ssh alias (LAN-first: Tailscale degrades silently)
+    "pro": "pro-lan",
+}
+
+PROBE_TIMEOUT_S = 30
+
+
+def detect_machine() -> str:
+    user = getpass.getuser()
+    host = socket.gethostname().lower()
+    if user == "balizero":
+        return "m5"
+    if "mini" in host:
+        return "mini"
+    if user == "nuzantara":
+        return "pro"
+    return "unknown"
+
+
+def is_healthy(declared: str) -> bool:
+    head = (declared or "").strip().upper()
+    return any(head.startswith(p) for p in HEALTHY_PREFIXES)
+
+
+@dataclass
+class ProbeResult:
+    ok: bool
+    detail: str = ""
+
+
+@dataclass
+class EdgeReport:
+    edge_id: str
+    kind: str
+    machine: str
+    declared: str
+    verdict: str
+    detail: str = ""
+    source_file: str = ""
+
+
+def _run(cmd: str, via: str, no_ssh: bool) -> ProbeResult:
+    if via.startswith("ssh:"):
+        if no_ssh:
+            return ProbeResult(False, "ssh disabled (--no-ssh)")
+        host = via.split(":", 1)[1]
+        full = ["ssh", "-o", "ConnectTimeout=8", host, cmd]
+    else:
+        full = ["/bin/bash", "-lc", cmd]
+    try:
+        proc = subprocess.run(
+            full, capture_output=True, text=True, timeout=PROBE_TIMEOUT_S
+        )
+    except subprocess.TimeoutExpired:
+        return ProbeResult(False, f"timeout {PROBE_TIMEOUT_S}s")
+    except OSError as exc:
+        return ProbeResult(False, f"spawn error: {exc}")
+    out = (proc.stdout or "") + (proc.stderr or "")
+    return ProbeResult(proc.returncode == 0, out.strip()[:300])
+
+
+def _expand(path: str, via: str) -> str:
+    # ~ expansion must happen on the TARGET machine for ssh probes
+    return os.path.expanduser(path) if via == "local" else path
+
+
+def run_probe(edge: dict[str, Any], no_ssh: bool, this_machine: str) -> ProbeResult | None:
+    """Return ProbeResult, or None if the edge has no runnable probe."""
+    probe = edge.get("probe")
+    kind = edge.get("kind", "")
+    machine = str(edge.get("machine", "")).lower()
+
+    # Kind-default probe: launchd label liveness
+    if probe is None and kind == "launchd":
+        label = edge.get("id", "")
+        if not label.startswith("com."):
+            return None
+        probe = {"type": "launchd_label", "label": label}
+        if machine and machine != this_machine:
+            if machine in SSH_HOSTS:
+                probe["via"] = f"ssh:{SSH_HOSTS[machine]}"
+            else:
+                return ProbeResult(False, f"machine {machine} unreachable (no ssh map)")
+
+    if probe is None:
+        return None
+
+    via = probe.get("via", "local")
+    ptype = probe.get("type", "cmd")
+
+    if ptype == "cmd":
+        res = _run(probe["cmd"], via, no_ssh)
+        if res.ok and probe.get("expect_regex"):
+            if not re.search(probe["expect_regex"], res.detail, re.MULTILINE):
+                return ProbeResult(False, f"regex miss: {res.detail[:120]}")
+        return res
+
+    if ptype == "file_exists":
+        path = probe["path"]
+        if via == "local":
+            ok = Path(_expand(path, via)).exists()
+            return ProbeResult(ok, path if ok else f"ENOENT {path}")
+        return _run(f"test -e {shlex.quote(path)}", via, no_ssh)
+
+    if ptype == "file_age_max_h":
+        path, max_h = probe["path"], float(probe.get("max_age_h", 26))
+        if via == "local":
+            p = Path(_expand(path, via))
+            if not p.exists():
+                return ProbeResult(False, f"ENOENT {path}")
+            age_h = (time.time() - p.stat().st_mtime) / 3600
+            return ProbeResult(age_h <= max_h, f"age {age_h:.1f}h (max {max_h}h)")
+        cmd = (
+            f'python3 -c "import os,time,sys;'
+            f"p={path!r};"
+            f's=os.stat(os.path.expanduser(p));'
+            f'a=(time.time()-s.st_mtime)/3600;'
+            f'print(f\'age {{a:.1f}}h\');'
+            f'sys.exit(0 if a<={max_h} else 1)"'
+        )
+        return _run(cmd, via, no_ssh)
+
+    if ptype == "grep":
+        path, pattern = probe["path"], probe["pattern"]
+        return _run(f"grep -qE {shlex.quote(pattern)} {shlex.quote(path)}", via, no_ssh)
+
+    if ptype == "launchd_label":
+        label = probe.get("label", edge.get("id", ""))
+        res = _run(f"launchctl list | grep -F {shlex.quote(label)}", via, no_ssh)
+        if not res.ok:
+            return ProbeResult(False, f"label not loaded: {label}")
+        if not probe.get("bad_exit_ok", True):
+            # column 2 of launchctl list = last exit status
+            m = re.search(r"^\S+\s+(-?\d+)\s", res.detail)
+            if m and m.group(1) not in ("0", "-"):
+                return ProbeResult(False, f"last exit {m.group(1)}")
+        return res
+
+    if ptype == "md5_pair":
+        pa, pb = probe["path_a"], probe["path_b"]
+        expected = probe.get("expected", "identical")
+
+        def _md5(path: str, pvia: str) -> str | None:
+            if pvia == "local":
+                fp = Path(_expand(path, "local"))
+                if not fp.exists():
+                    return None
+                return hashlib.md5(fp.read_bytes()).hexdigest()
+            r = _run(f"md5 -q {shlex.quote(path)}", pvia, no_ssh)
+            return r.detail.split()[0] if r.ok and r.detail else None
+
+        via_a, via_b = probe.get("via_a", via), probe.get("via_b", via)
+        ha, hb = _md5(pa, via_a), _md5(pb, via_b)
+        if ha is None or hb is None:
+            return ProbeResult(False, f"missing copy a={ha is not None} b={hb is not None}")
+        same = ha == hb
+        ok = same if expected == "identical" else not same
+        return ProbeResult(ok, "identical" if same else f"DRIFT {ha[:8]}≠{hb[:8]}")
+
+    return ProbeResult(False, f"unknown probe type {ptype}")
+
+
+def load_edges(edges_dir: Path) -> list[tuple[dict[str, Any], str]]:
+    try:
+        import yaml  # type: ignore[import-untyped]
+    except ImportError:
+        logger.error("PyYAML required — run under apps/backend-rag/.venv")
+        sys.exit(2)
+    out: list[tuple[dict[str, Any], str]] = []
+    for f in sorted(edges_dir.glob("*.yaml")):
+        try:
+            doc = yaml.safe_load(f.read_text()) or {}
+        except yaml.YAMLError as exc:
+            logger.error("YAML parse failure in %s: %s", f.name, exc)
+            sys.exit(2)
+        for edge in doc.get("edges", []):
+            if isinstance(edge, dict) and edge.get("id"):
+                out.append((edge, f.name))
+    return out
+
+
+def ssh_reachable(no_ssh: bool) -> set[str]:
+    if no_ssh:
+        return set()
+    reachable = set()
+    for machine, alias in SSH_HOSTS.items():
+        r = _run("true", f"ssh:{alias}", no_ssh=False)
+        if r.ok:
+            reachable.add(machine)
+    return reachable
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--edges-dir", default="docs/connectome/edges")
+    parser.add_argument("--json", dest="json_out", default=None)
+    parser.add_argument("--only-kind", default=None)
+    parser.add_argument("--machine", default="auto")
+    parser.add_argument("--no-ssh", action="store_true")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(message)s",
+    )
+
+    this_machine = detect_machine() if args.machine == "auto" else args.machine
+    edges_dir = Path(args.edges_dir)
+    if not edges_dir.is_dir():
+        logger.error("edges dir not found: %s", edges_dir)
+        return 2
+
+    edges = load_edges(edges_dir)
+    reachable = ssh_reachable(args.no_ssh)
+    logger.info(
+        "machine=%s edges=%d ssh_reachable=%s", this_machine, len(edges), sorted(reachable)
+    )
+
+    reports: list[EdgeReport] = []
+    for edge, src in edges:
+        if args.only_kind and edge.get("kind") != args.only_kind:
+            continue
+        declared = str(edge.get("status", "UNKNOWN"))
+        machine = str(edge.get("machine", "")).lower()
+
+        # Skip probes that need an unreachable remote machine
+        needs_remote = machine not in ("", this_machine, "github", "cloud", "fly")
+        if needs_remote and machine not in reachable and machine != this_machine:
+            probe = edge.get("probe")
+            derivable = probe is not None or edge.get("kind") == "launchd"
+            if derivable:
+                reports.append(
+                    EdgeReport(edge["id"], edge.get("kind", ""), machine, declared,
+                               "SKIPPED", f"{machine} unreachable", src)
+                )
+                continue
+
+        result = run_probe(edge, args.no_ssh, this_machine)
+        if result is None:
+            reports.append(
+                EdgeReport(edge["id"], edge.get("kind", ""), machine, declared,
+                           "STATIC", "", src)
+            )
+            continue
+
+        healthy = is_healthy(declared)
+        if result.ok and healthy:
+            verdict = "CONFIRMED"
+        elif result.ok and not healthy:
+            verdict = "RECOVERED"
+        elif not result.ok and healthy:
+            verdict = "REGRESSED"
+        else:
+            verdict = "CONFIRMED"  # declared dead, still dead
+        reports.append(
+            EdgeReport(edge["id"], edge.get("kind", ""), machine, declared,
+                       verdict, result.detail, src)
+        )
+
+    counts: dict[str, int] = {}
+    for r in reports:
+        counts[r.verdict] = counts.get(r.verdict, 0) + 1
+
+    regressed = [r for r in reports if r.verdict == "REGRESSED"]
+    recovered = [r for r in reports if r.verdict == "RECOVERED"]
+
+    logger.info("verdicts: %s", counts)
+    for r in regressed:
+        logger.warning("REGRESSED %-50s [%s/%s] %s", r.edge_id, r.kind, r.machine, r.detail)
+    for r in recovered:
+        logger.info("RECOVERED %-50s [%s/%s] — update census status", r.edge_id, r.kind, r.machine)
+
+    if args.json_out:
+        payload = {
+            "ts": time.time(),
+            "machine": this_machine,
+            "counts": counts,
+            "reports": [r.__dict__ for r in reports],
+        }
+        Path(args.json_out).write_text(json.dumps(payload, indent=1))
+        logger.info("json written: %s", args.json_out)
+
+    return 1 if regressed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Operazione Connettoma — the map of the arteries

INDEX.md maps the organs; nothing mapped the **edges**. The recurring disease class of this organism is *edges dying silently* (W55 suppressed alerts, W62 stale worktrees, W64 esiste-ma-disarmato, W67 active-active orphans, W70 path-drift backups, W71 lying guardians). This PR ships the empirical edge map + the guardian that keeps it true.

### What's in
- **`docs/connectome/edges/*.yaml`** — 352 edges across 7 domains (PG channels/EventBus, queues+drainers, launchd Pro fleet 180 plists, M5+Mini+ssh links, 54 GH workflows, sync daemons + HOME-forks, webhooks/HTTP, Claude hooks + MCP). Census 2026-06-13, 8-agent read-only fan-out, every load-bearing claim re-verified on disk in-session.
- **`scripts/verify_connectome.py`** — re-walks declared probes; verdicts: **REGRESSED** (declared healthy, probe fails — the alarm), **RECOVERED** (census stale), CONFIRMED, STATIC, SKIPPED. Exit 1 on any REGRESSED. Probe types: cmd / file_exists / file_age / grep / launchd_label / md5_pair, local or via ssh.
- **`docs/connectome/README.md`** — schema, status vocabulary, maintenance rule (*new automation ⇒ new edge*).

### Smoke evidence
- 352 edges load; local run: 15 CONFIRMED / 0 REGRESSED / exit 0 (exit code captured unmasked, W64 gotcha respected).
- Companion narrative TAC by the sibling Pro session, same day: `research/operations/2026-06-13-organism-connectome-fable5.md` (PR #1376) — this PR is the machine-readable counterpart; divergences between the two censuses are recorded in the YAML rather than silently resolved.

### Census-time top anomalies (recorded in the YAML, healing tracked separately)
1. Mini-Pro2 (H24) unreachable ≥1d on all routes, no guardian alerted
2. 4 eventbus daemons crash-looping at Mini's Redis (~834 runs/7h each)
3. DLQ TERMINAL regrew 0→31 in 4 days, healing=0 (W70 stderr-capture still unshipped)
4. Required check `Bandit Python Security` toothless (`|| true`) — fix in PR #1380
5. W62 worktree reaper green on ZERO machines (M5 TCC 126, Pro exit 1)
6. fly-qdrant-backup deployed copy 2+ months stale; wr2-deploy-pull.sh HOME newer than main

### Not done here (operator/no-cron rule)
- No LaunchAgent installed for the verifier (new cron = operator authorization). Suggested: daily on Pro, weekly on M5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)