### PR TITLE
fix(ops)+test(setup): Antibody Debt ledger #2 + #5 — cleanup-cron exit semantics + manifest-registration parity gate

### DIFF
--- a/apps/backend-rag/CLAUDE.md
+++ b/apps/backend-rag/CLAUDE.md
@@ -103,20 +103,34 @@ The `api` process has a persistent Fly volume (`nuzantara_api_data → /data`). 
 
 Both env vars are set in `fly.toml [env]`. Data survives rolling deploys. The `rag` process has its own separate volume (`nuzantara_rag_data`).
 
-### Router Registration — Manifest Pattern (PR #63)
+### Router Registration — Manifest + Parity Gate (PR #63, corrected 2026-06-13)
 
-**NEVER edit `router_registration.py` directly.** It reads from `router_manifest.py`.
+> CORRECTION 2026-06-13: this section previously claimed `router_registration.py`
+> "reads from router_manifest.py" and "no other file needs editing" — FALSE.
+> Registration is EXPLICIT imports + `include_router` calls (see scar #424:
+> the fix WAS editing registration). The drift the old text declared
+> "structurally impossible" happened repeatedly (#54/#55/#60, #422→#424,
+> olympus/intel trio caught 2026-06-13). What IS structural now is the
+> parity test below.
 
-To add a new router:
+To add a new router (all 3 steps, same PR):
 
 1. Create file in `backend/app/routers/`
 2. Add `RouterEntry` in `backend/app/setup/router_manifest.py` with correct `process_groups`
-3. Run `PYTHONPATH=. pytest backend/tests/setup/test_router_manifest.py -q`
-4. Done. No other file needs editing.
+3. Add the matching `api.include_router(...)` calls in `backend/app/setup/router_registration.py`:
+   ALWAYS in `include_routers()` (monolithic = full union), PLUS
+   `include_light_routers()` for `_API` and/or `include_heavy_routers()` for `_RAG`
+
+Then run BOTH gates:
+
+```bash
+PYTHONPATH=. pytest backend/tests/setup/test_router_manifest.py \
+  backend/tests/setup/test_manifest_registration_parity.py -q
+```
 
 Process groups: `_API` (light, public HTTP via main_api), `_RAG` (heavy, internal via main_rag), `_BOTH` (health checks).
 
-**SCAR:** PRs #54/#55/#60 registered routers only in `include_routers()` (dev) but not `include_light_routers()` (prod), causing silent 404s. The manifest makes this structurally impossible.
+**SCAR:** PRs #54/#55/#60 registered routers only in `include_routers()` (dev) but not `include_light_routers()` (prod) → silent 404s; #422 needed hotfix #424 for the same class. `test_manifest_registration_parity.py` (2026-06-13) enforces bidirectional manifest ↔ registration parity per process group — on its first run it caught `olympus.internal_router` missing from main_api prod and the `intel` trio missing from the monolithic app.
 
 ### ABSTAIN Override (reasoning.py)
 

--- a/apps/backend-rag/backend/app/setup/router_registration.py
+++ b/apps/backend-rag/backend/app/setup/router_registration.py
@@ -85,8 +85,11 @@ def include_routers(api: FastAPI) -> None:
         instagram_chat,
         intake_gate,  # [INTAKE-GATE] login-gate status (Anello 7)
         intake_review,  # [FASE 5A] doc-intake HITL review-queue (read-only + claim)
+        intel,  # [PARITY 2026-06-13] rag-group in prod; monolithic app = full union
+        intel_analytics,
         intel_lake,
         intel_observability,
+        intel_scraper,
         kbli_notebook,
         kbli_notebook_chat,
         kg_agentic,
@@ -327,6 +330,12 @@ def include_routers(api: FastAPI) -> None:
     api.include_router(instagram_chat.router)  # Instagram DM auto-reply via RAG
     api.include_router(instagram_chat.webhook_router)  # [NEW] Instagram webhook
     api.include_router(intel_lake.router)  # Intel Lake Wave 1 ingest (mig 168)
+    # [PARITY 2026-06-13] intel trio is rag-group in prod (needs /data volume on
+    # the rag process) but the monolithic app is the full union of both groups —
+    # it was missing ONLY these 3 (caught by test_manifest_registration_parity).
+    api.include_router(intel.router)
+    api.include_router(intel_scraper.router)
+    api.include_router(intel_analytics.router)
     api.include_router(intel_observability.router)  # Intel Lake + WR2 pipeline health
     api.include_router(webhooks.router)  # External webhooks (OpenClaw, etc.)
     api.include_router(
@@ -534,6 +543,7 @@ def include_light_routers(api: FastAPI) -> None:
         newsletter,
         nusantara_health,
         observed_shell,  # [OBSERVED-SHELL] Sprint 1 PR-1.2 — cell-core observability bridge
+        olympus,  # [PARITY 2026-06-13] manifest declares internal_router on api group
         omnichannel,
         partners,  # [PARTNERS] CRM Partners module v1 (PR #141 + follow-ups)
         performance,
@@ -587,6 +597,11 @@ def include_light_routers(api: FastAPI) -> None:
     api.include_router(auth.router)
     api.include_router(health.router)
     api.include_router(nusantara_health.router)
+    # [PARITY 2026-06-13] /internal/olympus/* — declared api-group in the
+    # manifest but was mounted only in the monolithic app: on the main_api
+    # prod process these paths returned 404 (scar #54/#55/#60 class, caught
+    # by test_manifest_registration_parity on its first run).
+    api.include_router(olympus.internal_router)
     api.include_router(handlers.router)
 
     # Debug router (dev/staging always, production only if ADMIN_API_KEY is set)

--- a/apps/backend-rag/backend/tests/setup/test_manifest_registration_parity.py
+++ b/apps/backend-rag/backend/tests/setup/test_manifest_registration_parity.py
@@ -1,0 +1,208 @@
+"""Manifest ↔ registration parity tests (Antibody Debt ledger #5, 2026-06-13).
+
+SCAR CONTEXT (PR #422 → hotfix #423/#424, 2026-05-02): a router landed in
+router_manifest.py but router_registration.py uses EXPLICIT imports +
+api.include_router(...) calls — the manifest entry without matching include
+calls shipped a silent 404 to prod (and PRs #54/#55/#60 hit the same class
+before: present in include_routers() but missing from include_light_routers()
+used by main_api in production).
+
+test_router_manifest.py validates the manifest INTERNALLY; nothing validated
+that the manifest and the three include_* functions stay in lockstep. These
+tests parse router_registration.py with ast (no app boot, no env needed) and
+assert bidirectional parity per process group:
+
+  - every manifest entry for group "api" is included in BOTH include_routers()
+    (monolithic, app_factory) and include_light_routers() (main_api prod);
+  - every manifest entry for group "rag" is included in BOTH include_routers()
+    and include_heavy_routers() (main_rag prod);
+  - every include_router(...) target in each function maps back to a manifest
+    entry of the right group (no undeclared routers).
+
+Conditional includes (debug, autonomous_lab) are still statically present in
+the AST, so condition-gated entries are matched like any other.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from backend.app.setup.router_manifest import ROUTER_MANIFEST, RouterEntry
+
+SETUP_DIR = Path(__file__).resolve().parents[2] / "app" / "setup"
+REGISTRATION_PATH = SETUP_DIR / "router_registration.py"
+
+# Targets included by a registration function that are deliberately NOT in the
+# manifest. Keep this list EMPTY unless a special mount is verified intentional
+# — every addition needs a comment with the reason.
+UNDECLARED_ALLOWLIST: frozenset[tuple[str, str]] = frozenset()
+
+
+# ── AST extraction ────────────────────────────────────────────────────────────
+
+
+def _load_functions() -> dict[str, ast.FunctionDef]:
+    tree = ast.parse(REGISTRATION_PATH.read_text())
+    fns = {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    missing = {"include_routers", "include_light_routers", "include_heavy_routers"} - set(fns)
+    assert not missing, f"router_registration.py lost function(s): {missing}"
+    return fns
+
+
+def _alias_map(fn: ast.FunctionDef) -> dict[str, tuple[str, str]]:
+    """local name -> (module path, original imported name)."""
+    aliases: dict[str, tuple[str, str]] = {}
+    for node in ast.walk(fn):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for a in node.names:
+                aliases[a.asname or a.name] = (node.module, a.name)
+    return aliases
+
+
+def _include_targets(fn: ast.FunctionDef) -> set[tuple[str, str]]:
+    """Resolve every `<x>.include_router(<target>)` in fn to
+    (module_import_path, router_attr) using the function-local imports."""
+    aliases = _alias_map(fn)
+    targets: set[tuple[str, str]] = set()
+    unresolved: list[str] = []
+    for node in ast.walk(fn):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "include_router"
+            and node.args
+        ):
+            continue
+        arg = node.args[0]
+        if isinstance(arg, ast.Attribute) and isinstance(arg.value, ast.Name):
+            # e.g. `auth.router`, `debug.v1_router` — `auth` imported via
+            # `from backend.app.routers import (auth, ...)`
+            src = aliases.get(arg.value.id)
+            if src:
+                targets.add((f"{src[0]}.{src[1]}", arg.attr))
+            else:
+                unresolved.append(ast.dump(arg))
+        elif isinstance(arg, ast.Name):
+            # e.g. `identity_router` — imported via
+            # `from backend.app.modules.identity.router import router as identity_router`
+            src = aliases.get(arg.id)
+            if src:
+                targets.add((src[0], src[1]))
+            else:
+                unresolved.append(arg.id)
+        else:
+            unresolved.append(ast.dump(arg))
+    assert not unresolved, (
+        f"{fn.name}: include_router target(s) this parser cannot resolve "
+        f"(extend the test, do not ignore): {unresolved}"
+    )
+    return targets
+
+
+def _entry_key(entry: RouterEntry) -> tuple[str, str]:
+    module_path = entry.import_path or f"backend.app.routers.{entry.name}"
+    return (module_path, entry.attr)
+
+
+def _entries_for(group: str) -> list[RouterEntry]:
+    return [e for e in ROUTER_MANIFEST if group in e.process_groups]
+
+
+FNS = _load_functions()
+TARGETS = {name: _include_targets(fn) for name, fn in FNS.items()}
+
+
+# ── Manifest → registration (the #424 / #54-#55-#60 killer) ─────────────────
+
+
+class TestManifestEntriesAreRegistered:
+    @pytest.mark.parametrize("entry", _entries_for("api"), ids=lambda e: f"{e.name}.{e.attr}")
+    def test_api_entry_in_monolithic_include(self, entry: RouterEntry) -> None:
+        assert _entry_key(entry) in TARGETS["include_routers"], (
+            f"manifest entry {entry.name} (attr={entry.attr}, groups=api) has NO "
+            f"include_router call in include_routers() — scar #424 class"
+        )
+
+    @pytest.mark.parametrize("entry", _entries_for("api"), ids=lambda e: f"{e.name}.{e.attr}")
+    def test_api_entry_in_light_include(self, entry: RouterEntry) -> None:
+        assert _entry_key(entry) in TARGETS["include_light_routers"], (
+            f"manifest entry {entry.name} (attr={entry.attr}, groups=api) missing "
+            f"from include_light_routers() — main_api PROD would 404 (scar #54/#55/#60 class)"
+        )
+
+    @pytest.mark.parametrize("entry", _entries_for("rag"), ids=lambda e: f"{e.name}.{e.attr}")
+    def test_rag_entry_in_monolithic_include(self, entry: RouterEntry) -> None:
+        assert _entry_key(entry) in TARGETS["include_routers"], (
+            f"manifest entry {entry.name} (attr={entry.attr}, groups=rag) has NO "
+            f"include_router call in include_routers()"
+        )
+
+    @pytest.mark.parametrize("entry", _entries_for("rag"), ids=lambda e: f"{e.name}.{e.attr}")
+    def test_rag_entry_in_heavy_include(self, entry: RouterEntry) -> None:
+        assert _entry_key(entry) in TARGETS["include_heavy_routers"], (
+            f"manifest entry {entry.name} (attr={entry.attr}, groups=rag) missing "
+            f"from include_heavy_routers() — main_rag PROD would 404"
+        )
+
+
+# ── Registration → manifest (no undeclared routers) ─────────────────────────
+
+
+class TestRegisteredTargetsAreDeclared:
+    def _undeclared(self, fn_name: str, group: str | None) -> set[tuple[str, str]]:
+        if group is None:
+            declared = {_entry_key(e) for e in ROUTER_MANIFEST}
+        else:
+            declared = {_entry_key(e) for e in _entries_for(group)}
+        return TARGETS[fn_name] - declared - UNDECLARED_ALLOWLIST
+
+    def test_monolithic_targets_declared(self) -> None:
+        extra = self._undeclared("include_routers", None)
+        assert not extra, (
+            f"include_routers() mounts router(s) absent from ROUTER_MANIFEST "
+            f"(declare them or allowlist with a reason): {sorted(extra)}"
+        )
+
+    def test_light_targets_declared_as_api(self) -> None:
+        extra = self._undeclared("include_light_routers", "api")
+        assert not extra, (
+            f"include_light_routers() mounts router(s) not declared with "
+            f"process_groups containing 'api': {sorted(extra)}"
+        )
+
+    def test_heavy_targets_declared_as_rag(self) -> None:
+        extra = self._undeclared("include_heavy_routers", "rag")
+        assert not extra, (
+            f"include_heavy_routers() mounts router(s) not declared with "
+            f"process_groups containing 'rag': {sorted(extra)}"
+        )
+
+
+# ── Self-checks on the parser (the verifier must be verifiable) ──────────────
+
+
+class TestParserSanity:
+    def test_extraction_found_a_plausible_volume(self) -> None:
+        """323 include_router calls existed at authoring time; a parser
+        regression that silently extracts ~0 targets must fail loudly."""
+        assert len(TARGETS["include_routers"]) > 50
+        assert len(TARGETS["include_light_routers"]) > 30
+        assert len(TARGETS["include_heavy_routers"]) > 5
+
+    def test_known_multi_attr_module_resolved(self) -> None:
+        """instagram_chat declares router AND webhook_router — both must be
+        seen as distinct targets (attr-level parity, not module-level)."""
+        mono = TARGETS["include_routers"]
+        assert ("backend.app.routers.instagram_chat", "router") in mono
+        assert ("backend.app.routers.instagram_chat", "webhook_router") in mono
+
+    def test_known_module_router_resolved(self) -> None:
+        """identity is a module router imported as a bare alias name."""
+        assert ("backend.app.modules.identity.router", "router") in TARGETS["include_routers"]

--- a/scripts/agent_worktree_cleanup_cron.sh
+++ b/scripts/agent_worktree_cleanup_cron.sh
@@ -15,14 +15,22 @@
 # location (parents[1]). It MUST run from the MAIN checkout, never a worktree
 # copy, or it would scan .worktrees/<wt>/.worktrees/ (nonexistent) and no-op.
 #
-# Exit codes: 0 = clean (or live-session skips only); 1 = a WIP worktree was
-# skipped (operator must commit/stash); 2 = broker disabled / env missing.
+# Exit codes (Antibody Debt ledger #2, 2026-06-13): 0 = clean OR expected
+# skips (live-session / WIP — the broker is doing its job, not failing);
+# 2 = broker disabled / env missing; other = real broker error.
+# RATIONALE: the broker's RC=1 on WIP-skip is BY DESIGN (W62 WIP-safe guard),
+# but propagating it from an unattended nightly cron made launchd count a
+# permanent "failure" every night (observed 2026-06-12: 3 WIP skips → exit 1
+# → failed-jobs noise, DLQ-classification surface). The operator signal is
+# preserved through the heartbeat status=warn AND the WARN lines in the log —
+# a non-zero exit adds no information there, only noise.
 
 set -euo pipefail
 
 # Hardcoded MAIN checkout — do NOT derive from $0 (this wrapper may itself be
 # invoked from a worktree copy). The broker path below is the canonical one.
-REPO_ROOT="${HOME}/Desktop/nuzantara"
+# Env override exists for the test harness ONLY (point at a stub repo).
+REPO_ROOT="${AGENT_WORKTREE_CLEANUP_REPO_ROOT:-${HOME}/Desktop/nuzantara}"
 BROKER="${REPO_ROOT}/scripts/agent_start.py"
 
 LOG_DIR="${HOME}/logs"
@@ -34,8 +42,14 @@ log() {
 }
 
 # Heartbeat helper (no-op fallback if not present).
-# shellcheck disable=SC1091
-if ! source "${REPO_ROOT}/scripts/lib/heartbeat.sh" 2>/dev/null; then
+# LATENT-BUG fix (found by the stub harness, 2026-06-13): bash 3.2 EXITS the
+# whole non-interactive script when `source` cannot find the file — even
+# inside `if !` under set -e. Guard with an existence check instead.
+if [ -f "${REPO_ROOT}/scripts/lib/heartbeat.sh" ]; then
+    # shellcheck disable=SC1091
+    source "${REPO_ROOT}/scripts/lib/heartbeat.sh" || true
+fi
+if ! declare -F organism_heartbeat >/dev/null 2>&1; then
     organism_heartbeat() { :; }
 fi
 
@@ -61,12 +75,26 @@ set -e
 echo "$OUTPUT" | tee -a "$LOG"
 
 # Heartbeat must never mask the broker's real RC under set -e (codex P3):
-# guard every call with || true and exit on the captured $RC.
+# guard every call with || true.
+# RC=1 (WIP skipped) maps to exit 0: expected guard behavior in cron context,
+# signal carried by heartbeat=warn + WARN log lines (ledger #2, 2026-06-13).
 case "$RC" in
-    0) organism_heartbeat "pro.agent_worktree_cleanup" "ok" "clean" || true ;;
-    1) organism_heartbeat "pro.agent_worktree_cleanup" "warn" "WIP worktree skipped" || true ;;
-    *) organism_heartbeat "pro.agent_worktree_cleanup" "fail" "exit $RC" || true ;;
+    0)
+        organism_heartbeat "pro.agent_worktree_cleanup" "ok" "clean" || true
+        EXIT_RC=0
+        ;;
+    1)
+        WIP_COUNT="$(printf '%s\n' "$OUTPUT" | grep -c 'WARN: skip' || true)"
+        organism_heartbeat "pro.agent_worktree_cleanup" "warn" \
+            "WIP worktree skipped (${WIP_COUNT}x) — commit/stash to let the reaper through" || true
+        log "WARN: ${WIP_COUNT} WIP worktree(s) skipped — expected guard, not a failure"
+        EXIT_RC=0
+        ;;
+    *)
+        organism_heartbeat "pro.agent_worktree_cleanup" "fail" "exit $RC" || true
+        EXIT_RC="$RC"
+        ;;
 esac
 
-log "done (exit $RC)"
-exit "$RC"
+log "done (broker rc=$RC, exit $EXIT_RC)"
+exit "$EXIT_RC"


### PR DESCRIPTION
## Summary
Ships dormant antibodies **#2** and **#5** from the Antibody Debt ledger (`research/operations/2026-06-13-organism-connectome-fable5.md`, PR #1376).

### #2 — worktree-cleanup cron: WIP-skip is a guard, not a failure (W62 follow-up)
- Broker `--cleanup` rc=1 on WIP-skip is by design, but the cron wrapper propagated it as a nightly launchd failure (3 WIP skips observed 2026-06-12). Wrapper now maps rc=1 → exit 0; signal preserved via heartbeat `warn` (with skip count) + WARN log lines. Real errors (rc≥2) propagate verbatim.
- **Bonus latent bug found by the stub harness**: bash 3.2 exits the whole script when `source` can't find `heartbeat.sh` — even inside `if !` under `set -e`. On any machine without that lib the cron died silently before logging. Guarded with `[ -f ]` + `declare -F` fallback.
- Empirical matrix (stub broker, isolated HOME): rc 0→0, 1→0, 2→2, 3→3.

### #5 — manifest ↔ registration parity gate (scar #422/#423/#424 + #54/#55/#60 class)
- New `backend/tests/setup/test_manifest_registration_parity.py`: AST-parses `router_registration.py` (no app boot) and asserts bidirectional parity per process group (manifest entry ⇄ include calls in `include_routers` / `include_light_routers` / `include_heavy_routers`), with parser self-checks.
- **First run caught 4 real violations, fixed here**:
  - `olympus.internal_router` (api group) mounted only in the monolithic app → `/internal/olympus/*` returned **404 on main_api prod**
  - `intel`, `intel_scraper`, `intel_analytics` (rag group) missing from the monolithic `include_routers()` (union held for 161/164 entries)
- `apps/backend-rag/CLAUDE.md` corrected: it claimed registration "reads from the manifest" / "no other file needs editing" — false since inception; now documents the real 3-step procedure + both gates.

## Test plan
- [x] 334 parity tests green; falsifiability proven (commenting one include → 2 failures, restored → green)
- [x] `test_router_manifest.py` cumulative 353 green; integration `test_endpoints_reachable.py` 5 passed
- [x] Import smoke `backend.app.setup.router_registration` OK; ruff clean
- [x] Wrapper stub matrix 0/0/2/3 + `bash -n`

🤖 Generated with [Claude Code](https://claude.com/claude-code)