### PR TITLE
feat(connectome): cron wrapper + installer for verify_connectome (operator-authorized)

### DIFF
--- a/docs/connectome/README.md
+++ b/docs/connectome/README.md
@@ -47,9 +47,15 @@ apps/backend-rag/.venv/bin/python scripts/verify_connectome.py --no-ssh   # loca
 apps/backend-rag/.venv/bin/python scripts/verify_connectome.py --json /tmp/connectome.json
 ```
 
-Exit 1 ⇔ at least one REGRESSED edge. Designed for a future cron (NOT installed —
-new cron requires operator authorization per AUTONOMOUS_OPS); recommended cadence:
-daily on Pro, weekly on M5.
+Exit 1 ⇔ at least one REGRESSED edge.
+
+**Cron (authorized by Antonello 2026-06-13):** `com.nuzantara.verify-connectome`
+via `infra/launchagents/install_verify_connectome.sh` —
+daily 07:30 WITA on the Pro (runtime home `~/Desktop/nuzantara-deploy`) and
+weekly Monday 08:30 on M5 (covers m5-local edges the Pro cannot probe).
+Wrapper `scripts/verify_connectome_run.sh` writes the alive-signal
+`~/.agent/decisions/state/verify_connectome.json` (deadman-family convention)
+and sends one Telegram alert per run when any edge is REGRESSED.
 
 ## Maintenance rules
 

--- a/infra/launchagents/install_verify_connectome.sh
+++ b/infra/launchagents/install_verify_connectome.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# install_verify_connectome.sh — idempotent installer for the connectome
+# drift-verifier LaunchAgent (authorized by Antonello 2026-06-13).
+#
+# Schedule by machine:
+#   Pro (user nuzantara) : DAILY  07:30 WITA — canonical guardian, runs from
+#                          ~/Desktop/nuzantara-deploy (hourly-synced, W71 rule)
+#   M5  (user balizero)  : WEEKLY Monday 08:30 WITA — covers m5-local edges
+#                          the Pro cannot probe (no ssh map to M5)
+#
+# The plist is GENERATED here (not static) because $HOME differs per machine
+# (Pro /Users/nuzantara vs M5 /Users/balizero — W50/W51/W52 path-drift class).
+# Re-run after script changes: it bootout+bootstraps cleanly.
+# /bin/bash 3.2-compatible.
+set -uo pipefail
+
+LABEL="com.nuzantara.verify-connectome"
+DEST="$HOME/Library/LaunchAgents/$LABEL.plist"
+LOG_DIR="$HOME/logs"
+mkdir -p "$LOG_DIR"
+
+if [[ "$(whoami)" == "balizero" ]]; then
+    REPO_ROOT="$HOME/Desktop/nuzantara"
+    # Weekly: Monday 08:30 (Weekday 1)
+    CALENDAR='<dict>
+            <key>Weekday</key><integer>1</integer>
+            <key>Hour</key><integer>8</integer>
+            <key>Minute</key><integer>30</integer>
+        </dict>'
+else
+    REPO_ROOT="$HOME/Desktop/nuzantara-deploy"
+    # Daily 07:30
+    CALENDAR='<dict>
+            <key>Hour</key><integer>7</integer>
+            <key>Minute</key><integer>30</integer>
+        </dict>'
+fi
+
+RUNNER="$REPO_ROOT/scripts/verify_connectome_run.sh"
+if [[ ! -f "$RUNNER" ]]; then
+    echo "[install] SKIP: runner not found at $RUNNER (checkout not synced yet?)" >&2
+    exit 0
+fi
+
+cat > "$DEST" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>$LABEL</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>$RUNNER</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>REPO_ROOT</key><string>$REPO_ROOT</string>
+        <key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+    <key>StartCalendarInterval</key>
+    $CALENDAR
+    <key>RunAtLoad</key><false/>
+    <key>StandardOutPath</key><string>$LOG_DIR/verify-connectome.log</string>
+    <key>StandardErrorPath</key><string>$LOG_DIR/verify-connectome.log</string>
+</dict>
+</plist>
+PLIST
+chmod 0400 "$DEST"
+
+UID_VAL="$(id -u)"
+launchctl bootout "gui/$UID_VAL" "$DEST" 2>/dev/null || true
+launchctl bootstrap "gui/$UID_VAL" "$DEST"
+RC=$?
+if [[ $RC -eq 0 ]]; then
+    echo "[install] $LABEL armed (repo=$REPO_ROOT, $( [[ $(whoami) == balizero ]] && echo 'weekly Mon 08:30' || echo 'daily 07:30' ))"
+else
+    echo "[install] ERROR: bootstrap failed rc=$RC" >&2
+fi
+exit $RC

--- a/scripts/verify_connectome.py
+++ b/scripts/verify_connectome.py
@@ -139,6 +139,18 @@ def _expand(path: str, via: str) -> str:
     return os.path.expanduser(path) if via == "local" else path
 
 
+def _normalize_via(via: str, this_machine: str) -> str:
+    """An explicit ssh:<alias> that points at THIS machine must run locally.
+
+    The alias only resolves from OTHER machines (e.g. pro-lan exists on M5,
+    not on the Pro itself) — without this, a Pro-side cron self-ssh-fails
+    every pro-edge into a false REGRESSED.
+    """
+    if via.startswith("ssh:") and SSH_HOSTS.get(this_machine) == via.split(":", 1)[1]:
+        return "local"
+    return via
+
+
 def run_probe(edge: dict[str, Any], no_ssh: bool, this_machine: str) -> ProbeResult | None:
     """Return ProbeResult, or None if the edge has no runnable probe."""
     probe = edge.get("probe")
@@ -160,7 +172,7 @@ def run_probe(edge: dict[str, Any], no_ssh: bool, this_machine: str) -> ProbeRes
     if probe is None:
         return None
 
-    via = probe.get("via", "local")
+    via = _normalize_via(probe.get("via", "local"), this_machine)
     ptype = probe.get("type", "cmd")
 
     if ptype == "cmd":
@@ -224,7 +236,8 @@ def run_probe(edge: dict[str, Any], no_ssh: bool, this_machine: str) -> ProbeRes
             r = _run(f"md5 -q {shlex.quote(path)}", pvia, no_ssh)
             return r.detail.split()[0] if r.ok and r.detail else None
 
-        via_a, via_b = probe.get("via_a", via), probe.get("via_b", via)
+        via_a = _normalize_via(probe.get("via_a", via), this_machine)
+        via_b = _normalize_via(probe.get("via_b", via), this_machine)
         ha, hb = _md5(pa, via_a), _md5(pb, via_b)
         if ha is None or hb is None:
             return ProbeResult(False, f"missing copy a={ha is not None} b={hb is not None}")

--- a/scripts/verify_connectome_run.sh
+++ b/scripts/verify_connectome_run.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# verify_connectome_run.sh — cron wrapper for scripts/verify_connectome.py
+#
+# Runs the connectome drift-verifier against docs/connectome/edges/*.yaml,
+# writes an alive-signal state JSON (deadman-family convention), and sends
+# ONE Telegram alert when any edge REGRESSED (declared healthy, probe fails).
+#
+# Runtime homes (REPO_ROOT, overridable via env):
+#   Pro : ~/Desktop/nuzantara-deploy   (hourly-synced to origin/main — W71 rule)
+#   M5  : ~/Desktop/nuzantara          (main checkout; NEVER mutated here)
+#
+# Exit codes: 0 = no REGRESSED · 1 = REGRESSED (alert sent) · 2 = setup error.
+# /bin/bash 3.2-compatible (macOS): no declare -A, no mapfile.
+set -uo pipefail
+
+LOG_PREFIX="[verify-connectome]"
+STATE_DIR="$HOME/.agent/decisions/state"
+STATE_FILE="$STATE_DIR/verify_connectome.json"
+mkdir -p "$STATE_DIR"
+
+# ── resolve repo root per machine ────────────────────────────────────────────
+if [[ -z "${REPO_ROOT:-}" ]]; then
+    if [[ "$(whoami)" == "balizero" ]]; then
+        REPO_ROOT="$HOME/Desktop/nuzantara"
+    else
+        REPO_ROOT="$HOME/Desktop/nuzantara-deploy"
+    fi
+fi
+if [[ ! -d "$REPO_ROOT/docs/connectome/edges" ]]; then
+    echo "$LOG_PREFIX ERROR: edges dir missing under $REPO_ROOT (wrong branch or stale checkout?)" >&2
+    exit 2
+fi
+
+# Read-only staleness note — never pull/checkout from a cron (scar:
+# evolver/deploy-puller shared-worktree family).
+BRANCH="$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null || echo '?')"
+if [[ "$BRANCH" != "main" && "$BRANCH" != "deploy/main" ]]; then
+    echo "$LOG_PREFIX WARN: $REPO_ROOT on branch '$BRANCH' (not main) — verifier may be stale" >&2
+fi
+
+# ── python: backend venv first (PyYAML guaranteed), else system if yaml works ─
+PYBIN="$REPO_ROOT/apps/backend-rag/.venv/bin/python3"
+if [[ ! -x "$PYBIN" ]]; then
+    if python3 -c "import yaml" >/dev/null 2>&1; then
+        PYBIN="python3"
+    else
+        echo "$LOG_PREFIX ERROR: no venv at $PYBIN and system python3 lacks PyYAML" >&2
+        exit 2
+    fi
+fi
+
+# ── run the verifier ─────────────────────────────────────────────────────────
+cd "$REPO_ROOT" || exit 2
+OUT="$("$PYBIN" scripts/verify_connectome.py --json "$STATE_FILE" 2>&1)"
+RC=$?
+echo "$OUT"
+
+if [[ $RC -eq 2 ]]; then
+    echo "$LOG_PREFIX ERROR: verifier setup failure (exit 2)" >&2
+    exit 2
+fi
+
+# ── Telegram alert on REGRESSED (deadman convention — never hardcode token) ──
+if [[ $RC -eq 1 ]]; then
+    if [[ -f "$HOME/.nuzantara-secrets.env" ]]; then
+        # shellcheck disable=SC1091
+        source "$HOME/.nuzantara-secrets.env"
+    fi
+    TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN:-${BALIZEROBOT_TOKEN:-}}"
+    TELEGRAM_CHAT_ID="${TELEGRAM_OWNER_CHAT_ID:-${TELEGRAM_ADMIN_CHAT_ID:-${TELEGRAM_CHAT_ID:-1125336968}}}"
+    REGRESSED_LINES="$(printf '%s\n' "$OUT" | grep -a 'REGRESSED ' | head -10)"
+    if [[ -n "$TELEGRAM_BOT_TOKEN" && -n "$TELEGRAM_CHAT_ID" ]]; then
+        MSG="connectome REGRESSED on $(hostname -s) $(date '+%Y-%m-%d %H:%M')
+${REGRESSED_LINES}
+state: ~/.agent/decisions/state/verify_connectome.json"
+        curl -sS -m 15 -X POST \
+            "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${MSG}" >/dev/null \
+            || echo "$LOG_PREFIX WARN: telegram send failed" >&2
+    else
+        echo "$LOG_PREFIX WARN: REGRESSED but no TELEGRAM_BOT_TOKEN — log-only" >&2
+    fi
+fi
+
+exit $RC


### PR DESCRIPTION
## Why

Antonello authorized the `verify_connectome.py` cron (2026-06-13, follow-up of #1381). This arms the connectome drift-verifier as a scheduled guardian instead of a manual tool.

## What

- **`_normalize_via()`** in `scripts/verify_connectome.py`: an explicit `via: ssh:<alias>` that maps to the machine the verifier is running ON now executes locally. Without this, a Pro-side cron would self-ssh `pro-lan` (an alias that only resolves from M5) and fail **every pro-edge into a false REGRESSED** — a guardian that lies (W71 class). Applied to the probe `via` and `md5_pair` `via_a`/`via_b`. Unit-checked.
- **`scripts/verify_connectome_run.sh`** (cron wrapper): writes alive-signal `~/.agent/decisions/state/verify_connectome.json` (deadman-family convention), sends one Telegram alert per run when any edge REGRESSED (token sourced from `~/.nuzantara-secrets.env` like `cost_breaker_deadman.sh`, never hardcoded), warns-but-never-pulls if the checkout isn't on main (evolver/deploy-puller shared-worktree scar).
- **`infra/launchagents/install_verify_connectome.sh`**: generates + arms `com.nuzantara.verify-connectome` per machine — plist is generated, not static, because `$HOME` differs Pro/M5 (W50-class path-drift). **Pro: daily 07:30 WITA** from `~/Desktop/nuzantara-deploy` (W71 runtime-home rule). **M5: weekly Monday 08:30** (covers m5-local edges the Pro can't probe — no ssh map to M5).
- `docs/connectome/README.md`: cron section updated from "NOT installed" to the authorized schedule.

## Fire-test (M5, this branch)

Full verifier run: **0 REGRESSED / 182 CONFIRMED / 23 RECOVERED / 144 STATIC / 3 SKIPPED**; wrapper exit 0, state JSON written, branch-staleness warning fires correctly.

## Deferred

- Deadman `OBSERVED_FILES` integration: its single 30-min threshold is incompatible with a daily cadence — needs per-file thresholds first.
- The 23 RECOVERED census statuses (edges healed by the 2026-06-13 campaign) — census YAML update is a separate housekeeping pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)