### PR TITLE
fix(wr2): kill banal filler images — desk+pen cliché ban (LLM + image-model) + raised hero bar

### DIFF
--- a/scripts/tests/test_wr2_image_generator_backend.py
+++ b/scripts/tests/test_wr2_image_generator_backend.py
@@ -320,3 +320,23 @@ def test_backend_unavailable_error_is_runtime_error(wig):
     """BackendUnavailableError extends RuntimeError so existing exception
     handlers in cron wrappers don't need updating."""
     assert issubclass(wig.BackendUnavailableError, RuntimeError)
+
+
+def test_desk_pen_cliche_ban_reaches_final_image_prompt(wig):
+    """The document/deed-on-a-desk-with-a-pen cliché ban (Antonello 2026-06-13)
+    must be in the prompt that EVERY image backend actually receives.
+
+    Regression guard for the wiring bug found 2026-06-13: the draft-generator's
+    NEGATIVE_PROMPT/BRAND_SUFFIX ban only ever reached the LLM that writes the
+    image_prompt — never the image model. The only anti-cliché text that reaches
+    Gemini/gpt-image-2/FlowKit is ANTI_CLICHE_SUFFIX via _compose_final_prompt;
+    the ban therefore has to live there to take effect at generation time.
+    """
+    final = wig._compose_final_prompt("a property transaction in Bali")
+    low = final.lower()
+    assert "document" in low and "desk" in low, final
+    assert "fountain pen" in low or "signing pen" in low, final
+    assert "notary-desk still life" in low, final
+    # every tonal-palette variant carries the ban too (suffix is palette-agnostic)
+    for palette in ("warm-ochre", "cool-teal", "monochrome", None):
+        assert "notary-desk still life" in wig._compose_final_prompt("x", palette).lower()

--- a/scripts/wr2_draft_generator.py
+++ b/scripts/wr2_draft_generator.py
@@ -71,7 +71,9 @@ TIGRIS_PUBLIC_BASE = f"https://{TIGRIS_BUCKET}.fly.storage.tigris.dev"
 # Settings() which requires JWT_SECRET_KEY etc. — unacceptable for a cron entry.
 BRAND_SUFFIX: str = (
     "Editorial style, high resolution, no stock imagery, "
-    "no handshakes, no generic passports, cinematic lighting"
+    "no handshakes, no generic passports, "
+    "NO documents or pens on a desk, NO paperwork close-ups, "
+    "cinematic lighting"
 )
 _DEFAULT_STYLE_MODIFIERS: tuple[str, ...] = (
     "macrografia editoriale",
@@ -82,7 +84,13 @@ _DEFAULT_STYLE_MODIFIERS: tuple[str, ...] = (
 NEGATIVE_PROMPT: str = (
     "hands holding objects, passport close-ups, generic handshake, "
     "stock photo aesthetic, text overlays, watermark, logo, "
-    "deformed hands, extra fingers, distorted faces, illegible text"
+    "deformed hands, extra fingers, distorted faces, illegible text, "
+    # 2026-06-13 (Antonello): the document-and-pen-on-a-desk cliché is the
+    # single most off-brand image WR2 keeps producing. Ban it explicitly.
+    "document on a desk, contract on a table, land deed on a desk, "
+    "fountain pen, signing pen, pen resting on paper, hand signing, "
+    "official seal close-up, stack of papers, paperwork on a desk, "
+    "notary scene, clipboard, ballpoint pen, desk with documents"
 )
 
 
@@ -164,13 +172,21 @@ HARD RULES:
 - Slide 1 = cover (is_cover: true, is_hero_image: true ALWAYS)
 - LAST slide = CTA to Bali Zero
 - HERO slides must include image_prompt: editorial scene in Wired/Bloomberg style, NO stock photos, NO handshakes, NO passport close-ups (text-only slides do NOT need image_prompt)
+- BANNED IMAGE CLICHÉ (HARD — Antonello 2026-06-13): NEVER a document / deed /
+  contract / form lying on a desk or table with a pen (especially a fountain
+  pen) resting on or beside it, NEVER paperwork close-ups, NEVER a hand signing,
+  NEVER an official seal close-up. This "papers + pen on a desk" image is the
+  single most off-brand stock cliché — the brand rejects it outright. Show the
+  HUMAN and PLACE reality behind the rule instead: people in a real moment, a
+  Balinese/Indonesian place or building, an architectural detail, a tense
+  street/landscape scene — never the lawyer's-desk still life.
 
 TONAL PALETTE (per HERO slide — drives the photographic look, fights monotony):
 Each HERO slide MUST include a `tonal_palette` field. Pick ONE
 that fits the slide's mood; do NOT use the same palette for every hero slide,
 and vary it across carousels on the same topic (the brand forbids two
 same-domain carousels looking identical):
-- "warm-ochre": warm, intimate, document/interior mood (the house style)
+- "warm-ochre": warm, intimate, lived-in interior/place mood
 - "cool-teal": detached, analytical, institutional, data-heavy
 - "monochrome": stark, archival, historical, high-gravity
 - "high-contrast": tense, confrontational, urgent
@@ -181,7 +197,9 @@ Each HERO slide MUST include an `image_mode` field naming the
 KIND of scene. Pick the ONE mode that matches what the photo depicts, and VARY
 it across the hero slides (two same-domain carousels must not repeat the same
 dominant mode — the brand forbids monotony). Choose from EXACTLY these 9 modes:
-- "desk-document": papers, forms, a desk, a document close enough to read
+- "desk-document": USE SPARINGLY and only for a genuinely novel documentary
+  detail — NEVER the banned "document + pen on a desk" still life (see HARD
+  rule above). Prefer a different mode whenever possible.
 - "event-photo": a real moment/scene with people doing something
 - "architecture-or-texture": buildings, surfaces, materials, no people
 - "provocation-photo": a tense or confrontational image that unsettles
@@ -190,7 +208,7 @@ dominant mode — the brand forbids monotony). Choose from EXACTLY these 9 modes
 - "calendar-photo": dates, deadlines, time made visible
 - "data-visualization": a chart, graph, map, or numbers as the image
 - "cultural-photo": Indonesian/Balinese culture, ritual, place, daily life
-Use the slug verbatim (e.g. "desk-document").
+Use the slug verbatim (e.g. "cultural-photo").
 
 HERO IMAGE SELECTION (SMART — decision 2026-06-13):
 Choose 6-11 slides as the story needs. Mark `is_hero_image: true` ONLY on
@@ -272,7 +290,7 @@ Structure:
       "subhead": "1-6 WORD KICKER",
       "body": "...",
       "image_prompt": "editorial scene, 1-2 sentences",
-      "image_mode": "desk-document"
+      "image_mode": "architecture-or-texture"
     },
     {
       "slide_number": 2,

--- a/scripts/wr2_draft_generator.py
+++ b/scripts/wr2_draft_generator.py
@@ -210,17 +210,33 @@ dominant mode — the brand forbids monotony). Choose from EXACTLY these 9 modes
 - "cultural-photo": Indonesian/Balinese culture, ritual, place, daily life
 Use the slug verbatim (e.g. "cultural-photo").
 
-HERO IMAGE SELECTION (SMART — decision 2026-06-13):
-Choose 6-11 slides as the story needs. Mark `is_hero_image: true` ONLY on
-slides with real visual value — the cover (ALWAYS), the CTA closer (usually),
-and mid slides that show a SCENE, a turning point, or a provocation. Mark
-`is_hero_image: false` on slides that live on TEXT — dense lists, stacked
-facts, verbatim citations, pure editorial "take" statements: these read better
-as clean text-on-color, NOT as text floating over a decorative photo.
-Typically 4-8 of N slides are hero. Each HERO slide MUST carry `image_prompt`,
-`tonal_palette` AND `image_mode` (vary the modes — never let one dominate; use
-at least 4 of the 9 modes across the hero slides). Non-hero slides do NOT need
-`image_prompt`, `tonal_palette` or `image_mode`.
+HERO IMAGE SELECTION (SMART + ANTI-BANALITY — decision 2026-06-13):
+An image must EARN its place. The enemy is the banal filler photo — an image
+generated "tanto per", just so the slide has a picture. A decorative or
+generic image is WORSE than no image: it cheapens the whole carousel.
+
+DEFAULT = TEXT-ONLY (`is_hero_image: false`). Mark `is_hero_image: true` ONLY
+when a photograph adds meaning the words cannot — a specific real SCENE, a
+human face of the story, a charged place, a turning point, a provocation. The
+cover is ALWAYS hero. Beyond that, be STINGY: usually only 1-3 mid slides plus
+(optionally) the CTA truly deserve a photo. If the best image you can imagine
+for a slide is a GENERIC illustration of the topic — a nondescript office, a
+generic building, a stock chart, a calendar, a desk, "a person looking at a
+laptop", anything that just visualises the concept rather than telling THIS
+story — then it is filler: mark the slide text-only instead. When in doubt,
+text-only.
+
+The image_prompt for a hero slide must describe a SPECIFIC, concrete,
+photographable moment ("a half-built villa fenced off at dusk, one security
+lamp on") — never a generic concept ("real estate in Bali", "tax compliance",
+"a business meeting"). If you cannot name a specific scene, the slide is
+text-only.
+
+Each HERO slide MUST carry `image_prompt`, `tonal_palette` AND `image_mode`
+(vary the modes — never let one dominate, and never reach for the generic
+"data-visualization"/"calendar-photo"/"object-comparison" modes just to
+justify an image; those are the usual filler traps). Non-hero slides do NOT
+need `image_prompt`, `tonal_palette` or `image_mode`.
 
 STORYTELLING DIRECTIVES (overrides any default factual mode):
 

--- a/scripts/wr2_image_generator.py
+++ b/scripts/wr2_image_generator.py
@@ -239,7 +239,16 @@ ANTI_CLICHE_SUFFIX = (
     "Strictly NO palm trees, NO laptops on beaches, NO digital nomad cliches, "
     "NO infinity pools, NO neon lights. NO Balinese temples, religious offerings, "
     "or traditional dancers. NO AI-art fingerprints: no hyperrealistic faces, "
-    "no glowing edges, no fantasy elements."
+    "no glowing edges, no fantasy elements. "
+    # 2026-06-13 (Antonello): the document/deed/contract-on-a-desk-with-a-pen
+    # still life is the single most off-brand cliché WR2 keeps rendering — it
+    # was reaching the image model because the draft-generator's NEGATIVE_PROMPT
+    # only steers the LLM that writes the prompt, never the image backend. Ban
+    # it here too, in the one anti-cliché string every backend actually sees.
+    "Strictly NO documents, deeds, contracts, or forms lying on a desk or "
+    "table, NO fountain pen or signing pen, NO pen resting on paper, NO hand "
+    "signing, NO official seal close-up, NO stack of papers or paperwork "
+    "close-up, NO notary-desk still life."
 )
 
 GEMINI_PROMPT_PREFIX = "Please generate a photograph for an editorial magazine carousel. Describe the image based on this concept:\n\n"


### PR DESCRIPTION
## Why

Antonello (2026-06-13) flagged a generated carousel **cover** showing a document + pen on a desk and said the real problem is **banality** — *"immagini tanto per"*, images generated just so a slide has a picture. A generic/decorative image is worse than no image: it cheapens the carousel.

This PR attacks the banality on three layers.

## 1. Ban the desk+pen cliché where the LLM writes the prompt
`scripts/wr2_draft_generator.py`: `NEGATIVE_PROMPT` + `BRAND_SUFFIX` + a prompt HARD RULE explicitly forbid the document/deed/contract-on-a-desk-with-a-pen still life, and tell the model to show the **human + place** reality instead.

## 2. Enforce that ban at IMAGE-GEN time (deterministic, every backend)
The layer-1 ban only ever reached the LLM that writes `image_prompt` — **never the image model**. `wr2_image_generator.py` has its own independent brand block; the only anti-cliché string every backend (Gemini UI / gpt-image-2 / FlowKit) actually receives is `ANTI_CLICHE_SUFFIX` via `_compose_final_prompt`. Added the document/pen ban there, so it bites regardless of what the LLM wrote. Regression test asserts it's present in the final composed prompt for every tonal palette.

## 3. Raise the hero-image bar to kill filler
`HERO IMAGE SELECTION` rewritten: **default is text-only**, hero is the exception. Dropped the "typically 4-8 of N are hero" floor that encouraged filler → now "cover always, then usually only 1-3 mid slides that truly deserve a photo; when in doubt, text-only". If the best image for a slide is a generic illustration of the topic (nondescript office, generic building, stock chart, calendar, desk, "person looking at a laptop") → it's filler → text-only. `image_prompt` must name a **specific, concrete, photographable scene**, never a generic concept.

## Tests
- `test_wr2_image_generator_backend.py`: **13/13** (incl. new desk-pen-ban regression).
- `test_wr2_smart_hero.py` + `test_wr2_all_hero_slides.py`: **22/22** (smart-hero mechanics unchanged).

## Scope
3 commits, 3 files: `scripts/wr2_draft_generator.py`, `scripts/wr2_image_generator.py`, `scripts/tests/test_wr2_image_generator_backend.py`. Builds on #1393 (smart-hero), already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)