### PR TITLE
[codex] Add cleanup cron regression coverage

### DIFF
--- a/.github/workflows/broker-hygiene.yml
+++ b/.github/workflows/broker-hygiene.yml
@@ -21,6 +21,7 @@ on:
     paths:
       - "scripts/agent_start.py"
       - "scripts/agent_worktree_cleanup_cron.sh"
+      - "scripts/tests/test_agent_worktree_cleanup_cron.py"
       - "scripts/tests/test_agent_start.py"
       - "tests/integration/test_no_stale_worktrees.py"
       - "infra/launchagents/com.nuzantara.agent-worktree-cleanup.daily.plist.example"
@@ -55,6 +56,9 @@ jobs:
 
       - name: Broker unit tests
         run: python -m pytest scripts/tests/test_agent_start.py -q
+
+      - name: Cleanup cron wrapper tests
+        run: python -m pytest scripts/tests/test_agent_worktree_cleanup_cron.py -q
 
       - name: No stale worktrees (24h orphan guard)
         run: python -m pytest tests/integration/test_no_stale_worktrees.py -q

--- a/scripts/tests/test_agent_worktree_cleanup_cron.py
+++ b/scripts/tests/test_agent_worktree_cleanup_cron.py
@@ -1,0 +1,99 @@
+"""Tests for the LaunchAgent wrapper around scripts/agent_start.py --cleanup.
+
+The broker intentionally returns rc=1 when it skips dirty WIP worktrees. In an
+interactive run that is useful operator signal; in the daily LaunchAgent it must
+not become a launchd bad-exit, because WIP-safe skipping is expected behavior.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WRAPPER = REPO_ROOT / "scripts" / "agent_worktree_cleanup_cron.sh"
+
+
+def _write_stub_broker(stub_repo: Path, body: str) -> None:
+    scripts_dir = stub_repo / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (scripts_dir / "agent_start.py").write_text(
+        textwrap.dedent(body).lstrip(),
+        encoding="utf-8",
+    )
+
+
+def _run_wrapper(tmp_path: Path, stub_repo: Path) -> subprocess.CompletedProcess[str]:
+    home = tmp_path / "home"
+    home.mkdir()
+    env = dict(os.environ)
+    env.update(
+        {
+            "AGENT_WORKTREE_CLEANUP_REPO_ROOT": str(stub_repo),
+            "HOME": str(home),
+        }
+    )
+    return subprocess.run(
+        ["/bin/bash", str(WRAPPER)],
+        cwd=REPO_ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_cleanup_cron_maps_wip_skip_to_success(tmp_path: Path) -> None:
+    stub_repo = tmp_path / "repo"
+    _write_stub_broker(
+        stub_repo,
+        """
+        #!/usr/bin/env python3
+        import sys
+
+        assert sys.argv[1:] == ["--cleanup"]
+        print(
+            "WARN: skip dirty-wip (WIP). Commit or stash inside "
+            "/tmp/dirty-wip, then re-run --cleanup."
+        )
+        raise SystemExit(1)
+        """,
+    )
+
+    proc = _run_wrapper(tmp_path, stub_repo)
+
+    assert proc.returncode == 0
+    combined = proc.stdout + proc.stderr
+    assert "WARN: skip dirty-wip" in combined
+    log = (tmp_path / "home" / "logs" / "agent-worktree-cleanup.log").read_text(
+        encoding="utf-8"
+    )
+    assert "WIP worktree(s) skipped" in log
+    assert "expected guard, not a failure" in log
+    assert "done (broker rc=1, exit 0)" in log
+
+
+def test_cleanup_cron_preserves_real_broker_error(tmp_path: Path) -> None:
+    stub_repo = tmp_path / "repo"
+    _write_stub_broker(
+        stub_repo,
+        """
+        #!/usr/bin/env python3
+        import sys
+
+        assert sys.argv[1:] == ["--cleanup"]
+        print("ERROR: synthetic broker failure")
+        raise SystemExit(42)
+        """,
+    )
+
+    proc = _run_wrapper(tmp_path, stub_repo)
+
+    assert proc.returncode == 42
+    combined = proc.stdout + proc.stderr
+    assert "ERROR: synthetic broker failure" in combined
+    log = (tmp_path / "home" / "logs" / "agent-worktree-cleanup.log").read_text(
+        encoding="utf-8"
+    )
+    assert "done (broker rc=42, exit 42)" in log


### PR DESCRIPTION
## Summary

- Adds a focused regression test for `scripts/agent_worktree_cleanup_cron.sh`.
- Wires the new wrapper test into the broker-hygiene workflow.

## Root Cause

Spark correctly flagged `com.nuzantara.agent-worktree-cleanup.daily` with `last exit code = 1`.
Live verification showed the LaunchAgent is running the stale main-checkout wrapper at `/Users/nuzantara/Desktop/nuzantara/scripts/agent_worktree_cleanup_cron.sh`.
That checkout is 156 commits behind `origin/main` and still propagates broker rc `1` for WIP-safe skips into launchd.

The current branch already has the intended remediation from PR #1382: broker rc `1` means dirty WIP was safely skipped and should emit warn telemetry/logs, but the unattended cron exits `0`.
This PR freezes that behavior with a direct wrapper test so the bad-exit noise cannot regress.

## Validation

- `bash -n scripts/agent_worktree_cleanup_cron.sh`
- `/tmp/codex-overnight-20260614_002414-venv/bin/python -m pytest scripts/tests/test_agent_worktree_cleanup_cron.py -q`
- `PATH="/usr/sbin:/usr/bin:/bin:/opt/homebrew/bin:$PATH" /tmp/codex-overnight-20260614_002414-venv/bin/python -m pytest scripts/tests/test_agent_start.py -q`
- `/tmp/codex-overnight-20260614_002414-venv/bin/python -m pytest tests/integration/test_no_stale_worktrees.py -q`
- `PYTHONPATH=. /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -c "from backend.app.dependencies import get_current_user; print('OK')"`
- `PYTHONPATH=. /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m pytest backend/tests/services/rag/test_kg_langgraph.py backend/tests/services/rag/test_kg_subgraphs.py backend/tests/services/rag/test_confidence.py -q`

## Runtime Note

No production deploy was performed. I did not pull or modify the dirty main checkout because it contains unrelated operator/agent work.
Next operational step after merge is to update the runtime checkout safely, or run the LaunchAgent against a checkout that contains the fixed wrapper.
