### PR TITLE
docs(spec): phase-aware-guardrails — implementation-state update (1/3 prereq done)

### DIFF
--- a/research/operations/specs/phase-aware-guardrails.md
+++ b/research/operations/specs/phase-aware-guardrails.md
@@ -120,3 +120,51 @@ Panel: Gemini 3.1 Pro + DeepSeek V4 Pro (refuter) + Codex GPT-5.5. **Convergenza
 **Conseguenza decisionale (DeepSeek, secco):** *"La spec non deve procedere senza prova inconfutabile del read-only forzato e un blocco scrittura totalitario sul main."* Tradotto: i 2 gate 🔴 nuovi (§9-A/§9-B) sono **prerequisito**, non opzione. Si shippa nell'ordine: (1) `main_write_via_bash` + `host_boundary` 🔴 PRIMA, (2) validazione §6 di `permissionMode`, (3) solo DOPO il rilassamento dei 4 gate 🟢.
 
 **Codex:** ❌ DERAGLIATO — invece di rispondere alle Q1-Q4 ha letto il worktree dirty (stop-hook bloccato), confuso il contesto, e suggerito comandi `git commit`/`stash` per sbloccare lo Stop. Zero contenuto sulla spec. Scartato (anti-hallucination: NON lo si conta come consenso che non ha dato). Panel effettivo = 2 voci reali (Gemini + DeepSeek) **convergenti** + §9-B verificato su disco dall'orchestratore → solidità sufficiente, ma il consenso a 3 NON c'è stato.
+
+---
+
+## 10. STATO IMPLEMENTAZIONE (aggiornato 2026-06-14, verificato su disco)
+
+Il panel (§9) ha fissato l'ordine NON negoziabile: **prereq 🔴 PRIMA → validazione §6 → relax 🟢 DOPO.** Stato dei tre prerequisiti, ri-verificato su disco oggi (M5):
+
+| # | Prerequisito | Stato spec (13/06) | **Stato OGGI (verificato 14/06)** |
+|---|---|---|---|
+| 1 | §9-B `main_write_via_bash` (blocco scrittura main via Bash) | fatto-non-installato | ✅ **DONE + LIVE** — W79, PR #1399 MERGED, hook installato M5+Pro (`grep _strip_noise ~/.claude/hooks/worktree_isolation.py` = 6 match), E2E 5/5. Solo Mini pending (offline ~2gg, memory `unresolved_w79_mini_propagation_2026_06_13`). |
+| 2 | §9-A `host_boundary` (protezione `~/.claude/`+`~/.ssh`+secrets) | DA CREARE | ❌ **ANCORA BUCO** — grep 14/06 conferma: nessun hook protegge `~/.claude/` (l'unico match è un commento dentro `guardrails-static.py`). Auto-bypass-risk per `_phase.py` ancora reale. |
+| 3 | §6 probe `permissionMode` sullo stdin del PreToolUse | indiziato | ❌ **MAI PROVATO** — il campo ESISTE nei transcript (grep 14/06: `plan` 12× / `default` 30× / `bypassPermissions` 4628×) ma il transcript ≠ lo stdin dell'hook; il probe `/tmp/nuz_payload_capture.jsonl` non è mai stato eseguito. |
+| 4 | Relax dei 4 gate 🟢 (`orchestrate_gate`/`dispatch_nudge`/`stadio_zero`/`worktree-on-scratch`) | bloccato dai prereq | ⏸ **NON iniziato** — gated da #2 e #3. |
+
+**Progresso netto dal 13/06:** 1 prereq su 3 chiuso — il più delicato (blast-radius globale, scrittura-main-via-Bash). Lo switch resta NON implementabile finché #2 e #3 non sono chiusi.
+
+## 11. I DUE BLOCCHI RIMASTI — roadmap d'implementazione
+
+> Ordine NON negoziabile (verdetto panel §9): prima i due blocchi sotto, POI il relax 🟢. Mai disarmare un gate verde prima.
+
+### BLOCCO #1 — `host_boundary` 🔴 (gate nuovo, prerequisito di `_phase.py`)
+
+- **Cosa:** un PreToolUse hook (o estensione di `worktree_file_write_check.py`) che blocca scrittura mutativa (Edit/Write/MultiEdit **e** Bash `>`/`tee`/`sed -i`/`cp`/`mv`/`dd of=`/`rm`) su path sensibili FUORI dai worktree autorizzati: `~/.claude/` (hook+settings+`_phase.py`), `~/.ssh`, `~/.aws`, `~/.nuzantara-secrets.env`, `~/.zshenv`/`~/.zshrc`. Lettura di secrets: almeno WARN.
+- **Perché PRIMA:** la spec introduce `~/.claude/hooks/_phase.py`; se quel file è scrivibile da un agente (+ "Yes" distratto in plan-mode, §9 Q3), un agente può **disarmare lo switch di fase** riscrivendo `_phase.py` → auto-bypass di tutti i gate verdi. Il guardiano va blindato PRIMA di esistere.
+- **Riuso:** W79 ha già `_strip_noise`/`_write_hits_main`/`WRITE_HINT_RE` in `worktree_isolation.py` — la logica di estrazione-target-da-Bash (incl. la trappola `lsof`/heredoc/quoting) è scritta e testata; `host_boundary` la riusa cambiando solo l'allowlist (da "dentro worktree" a "fuori path-sensibili").
+- **Test:** trap-table come W79 (`infra/claude-hooks/test_*`): BLOCK `echo x > ~/.claude/hooks/_phase.py`, `sed -i ~/.claude/settings.json`, `cp x ~/.ssh/`; ALLOW scrittura dentro worktree, lettura repo, `> /tmp`.
+- **Decisione operatore:** L1 hook, blast-radius globale (3 macchine) → richiede ok Antonello prima dell'install in `~/.claude/hooks/` (stesso protocollo di W79).
+
+### BLOCCO #2 — probe `permissionMode` sullo stdin (validazione §6, anti-W64)
+
+- **Cosa:** provare EMPIRICAMENTE che `permissionMode == "plan"` arriva sullo **stdin del PreToolUse hook** (non solo nel transcript). Probe: matcher PreToolUse `/tmp/nuz_payload_probe.py` che dumpa lo stdin in `/tmp/nuz_payload_capture.jsonl`; `/hooks` reload; Shift+Tab → plan; esegui 1 Bash; leggi il dump.
+- **Perché:** claim load-bearing non provato (W64: esistere≠armato — qui "documentato≠provato"). Se il campo NON arriva sullo stdin, lo switch automatico via Shift+Tab è impossibile e degrada al solo `NUZ_PHASE=plan` manuale.
+- **Chi:** richiede sessione interattiva owner (Shift+Tab è un gesto UI; un subagent NON può entrare in plan-mode) → **azione Antonello**, o sessione interattiva guidata.
+- **Esito A** (campo presente, grafia X): si procede al relax 🟢 leggendo grafia X.
+- **Esito B** (campo assente): lo switch ricade su `NUZ_PHASE=plan` env manuale → l'idea "automatico e naturale via Shift+Tab" NON è realizzabile su questa versione di Claude Code; si rivaluta.
+
+### DOPO i due blocchi — relax dei 4 gate 🟢
+
+Solo a #1 chiuso (host_boundary live) + #2 esito A: aggiungere le 2 righe `if is_plan_phase(payload): sys.exit(0)` ai 4 gate verdi, un gate per commit, con la trap-table che prova "in plan → off, in default → on". Kill-switch `NUZ_PHASE_AWARE_OFF=1` come rete.
+
+---
+
+## 12. Riferimenti
+
+- Origine concettuale: `research/operations/2026-06-13-system-shapes-the-agent-4llm.md` (capability-equalizer / alignment-tax), cicatrice W78 (governance).
+- §9-B chiuso: W79 PR #1399, `infra/claude-hooks/worktree_isolation.py` (`_strip_noise`), `test_w79_shell_write.py`. Pending Mini: memory `unresolved_w79_mini_propagation_2026_06_13`.
+- Recupero spec: git `87ba96b5f` (il file era già su main fino a `a0517608c` = merge W79 #1399; questa revisione aggiunge §10-§12 stato-implementazione su `origin/main` 2026-06-14).
+- Panel method: `feedback_always_review_spec_with_4_llm.md`, skill `opus-mythos`.


### PR DESCRIPTION
The spec defines **phase-aware guardrails** (pensa-libero/agisci-blindato): relax the orchestrate / dispatch / stadio-zero / worktree-scratch gates in plan-mode, while keeping file-write / git-destructive / PII / host-boundary hard always. The switch is driven by `permissionMode`.

This update records implementation state verified on disk (2026-06-14):
- §9-B prereq `main_write_via_bash` (W79 / #1399) is **DONE + LIVE** on M5 + Pro.
- **BLOCK #1** — `host_boundary` 🔴 is still a hole: no hook protects `~/.claude/` yet. Must ship before introducing `_phase.py`, else an agent could disarm the switch.
- **BLOCK #2** — the `permissionMode`-on-PreToolUse-stdin probe (§6) was never run: the field exists in transcripts but stdin delivery is unproven (anti-W64). Needs an interactive owner session (Shift+Tab is a UI gesture).

Green-gate relax (§3) stays gated on both blockers. Docs-only, no code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)