### PR TITLE
feat(hooks): host_boundary 🔴 — block writes to ~/.claude/ + secrets (phase-aware §9-A)

### DIFF
--- a/infra/claude-hooks/_phase.py
+++ b/infra/claude-hooks/_phase.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""_phase — shared phase-detection helper for phase-aware-guardrails (STEP 2).
+
+`is_plan_phase(payload)` is True ONLY when the session is in plan-mode, so the
+"green" gates (orchestrate_gate / dispatch_nudge / stadio_zero_nudge /
+worktree_isolation scratch-git) can step aside during exploration and stay hard
+during implementation — automatically, no manual toggle.
+
+SIGNAL (empirically verified 2026-06-14 via a temporary PreToolUse probe that
+captured the real hook stdin): the field is top-level `permission_mode`
+(snake_case) with value `"plan"` in plan-mode vs `"bypassPermissions"`/`"default"`
+otherwise. The spec originally assumed camelCase `permissionMode` from the
+TRANSCRIPT — the transcript uses camelCase but the HOOK STDIN uses snake_case.
+We read snake_case PRIMARY + camelCase fallback so a future Claude Code rename
+in either direction can't silently disarm us.
+
+FAIL-SAFE: field absent / unparseable → False (guardrail STAYS ON / deny-by-
+default). A relaxation only ever happens on a POSITIVE "plan" signal, never on
+absence (panel §9 Q2).
+
+KILL SWITCH: NUZ_PHASE_AWARE_OFF=1 → always False (behaviour = before phase-aware;
+every green gate behaves exactly as today). This wins over everything.
+
+MANUAL ESCAPE: NUZ_PHASE=plan → True, for plan-phase work outside the plan-mode
+UI (e.g. a brainstorm in chat where Shift+Tab wasn't pressed).
+
+This module is itself protected from agent writes by host_boundary 🔴 (it lives
+in ~/.claude/hooks/), so it cannot be silently rewritten to auto-bypass.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def is_plan_phase(payload: Any) -> bool:
+    """True iff the session is in plan-mode. Fail-safe to False on anything else."""
+    # Kill switch wins over all (operator full disable).
+    if os.environ.get("NUZ_PHASE_AWARE_OFF") == "1":
+        return False
+    if not isinstance(payload, dict):
+        return False
+    # snake_case is the proven hook-stdin grafia; camelCase kept as defensive fallback.
+    mode = payload.get("permission_mode") or payload.get("permissionMode") or ""
+    if mode == "plan":
+        return True
+    # Manual escape for plan-phase work outside the plan-mode UI.
+    if os.environ.get("NUZ_PHASE") == "plan":
+        return True
+    return False

--- a/infra/claude-hooks/dispatch_nudge.py
+++ b/infra/claude-hooks/dispatch_nudge.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""UserPromptSubmit hook — counter orchestration regression.
+
+Reads transcript file from Claude env, if long session + zero subagent
+dispatch in recent history, injects system reminder.
+
+Reference: research/operations/specs/T1.1-dispatch-nudge-hook.md
+"""
+import json
+import pathlib
+import sys
+
+# Phase-aware (STEP 3): path-safe import of _phase. Missing _phase → "never plan"
+# (gate stays ON) — fail-safe. _phase.py is protected by host_boundary 🔴.
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+try:
+    from _phase import is_plan_phase
+except Exception:
+    def is_plan_phase(payload):
+        return False
+
+LINE_THRESHOLD = 500
+RECENT_BYTES = 40_000
+# DA Patch 2 (H2) — match actual JSON transcript format, NOT Python-call literals.
+# Empirical (devils-advocate scan 2026-05-22): "Agent(" appears 0× in transcripts,
+# "Task(" matches "TaskCreate" only partially. Real tool_use blocks have
+# {"name": "TaskCreate"} or {"name": "Task"} + {"subagent_type": "..."}.
+DISPATCH_KEYWORDS = ('"name":"TaskCreate"', '"name": "TaskCreate"', '"subagent_type"', '"name":"Task"', '"name": "Task"')
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+        if is_plan_phase(payload): sys.exit(0)  # phase-aware: relax in plan-mode
+    except Exception:
+        sys.exit(0)
+
+    transcript_path = payload.get("transcript_path", "")
+    if not transcript_path:
+        sys.exit(0)
+
+    p = pathlib.Path(transcript_path)
+    if not p.exists():
+        sys.exit(0)
+
+    try:
+        full_text = p.read_text(errors="ignore")
+    except Exception:
+        sys.exit(0)
+
+    total_lines = full_text.count("\n")
+    if total_lines <= LINE_THRESHOLD:
+        sys.exit(0)
+
+    recent = full_text[-RECENT_BYTES:]
+    dispatch_count = sum(recent.count(kw) for kw in DISPATCH_KEYWORDS)
+
+    if dispatch_count == 0:
+        reminder = (
+            "ORCHESTRATION REMINDER — session is {} lines but no subagent "
+            "has been dispatched recently. Before answering, choose one: "
+            "(a) direct Bash, (b) load skill, (c) spawn subagent, (d) call MCP — "
+            "and state why this choice fits the task."
+        ).format(total_lines)
+        print(json.dumps({"systemMessage": reminder}))
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/claude-hooks/host_boundary.py
+++ b/infra/claude-hooks/host_boundary.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""host_boundary — PreToolUse hook 🔴 (phase-aware-guardrails BLOCK #1 / §9-A).
+
+Blocks MUTATING WRITES to host-sensitive paths OUTSIDE the project worktrees —
+in particular the agent's own control plane (`~/.claude/`), credentials
+(`~/.ssh`, `~/.aws`, secret dotfiles), and the decision/state dir
+(`~/.agent/decisions/`). Reads of secret files emit a non-blocking WARN.
+
+WHY THIS EXISTS (load-bearing): the phase-aware switch introduces
+`~/.claude/hooks/_phase.py`. plan-mode is NOT a physical sandbox (panel §9 Q3 —
+it is user-in-the-loop; a distracted "Yes" can still write). Without this gate,
+an agent could rewrite `_phase.py` / `settings.json` and DISARM the phase switch
+itself (auto-bypass). So the guardian of the switch must exist and be hard
+BEFORE the switch does. This gate stays 🔴 in EVERY phase (never relaxed in plan).
+
+It does NOT protect the project repo (that's worktree_isolation.py + W79 +
+worktree_file_write_check.py). It is the orthogonal "outside the repo" boundary.
+
+Covered surfaces:
+  - Bash: `>`/`>>`/`tee`/`sed -i`/`dd of=`/`cp`/`mv`/`install` whose resolved
+    destination lands under a protected dir → exit 2 (BLOCK).
+  - Edit/Write/MultiEdit: `tool_input.file_path` under a protected dir → exit 2.
+  - Read-of-secret (cat/less/head/tail/Read on a secret dotfile) → stderr WARN,
+    exit 0 (non-blocking — visibility, not prevention).
+
+Reuses the W79 Bash-write-target extraction (verbatim) from
+worktree_isolation.py, so the heredoc/quoting/`lsof`-class false-positive
+killers come for free. Conservative by design: a target we cannot resolve is
+ALLOWED (we only block HIGH-CONFIDENCE writes into a protected dir).
+
+Kill switch: HOST_BOUNDARY_OFF=1 → always exit 0 (behaviour = before this hook).
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+import sys
+
+# --- Protected destinations (writes here are blocked, anywhere on the host) ----
+# Resolved against $HOME. Directory prefixes (a write to any descendant blocks)
+# and exact secret files.
+_HOME = pathlib.Path(os.path.expanduser("~")).resolve()
+
+PROTECTED_DIRS = [
+    _HOME / ".claude",          # hooks, settings.json, _phase.py — the control plane
+    _HOME / ".ssh",
+    _HOME / ".aws",
+    _HOME / ".agent" / "decisions",
+]
+PROTECTED_FILES = [
+    _HOME / ".nuzantara-secrets.env",
+    _HOME / ".zshenv",
+    _HOME / ".zshrc",
+]
+# Secret-ISH read targets → WARN only (visibility, not block).
+SECRET_READ_HINTS = (
+    ".env", "secrets", "id_rsa", "id_ed25519", "credentials",
+    ".nuzantara-secrets", "token",
+)
+
+# --- W79 write-target extraction (CLONED VERBATIM from worktree_isolation.py) --
+# Quick gate: does the command contain anything that could write a file?
+WRITE_HINT_RE = re.compile(r"(>>?|\btee\b|\bsed\b[^|]*-i|\bdd\b[^|]*\bof=|\b(?:cp|mv|install)\b)")
+REDIR_RE = re.compile(r"(?<![0-9>&])>>?\s*([^\s|;&)]+)")
+TEE_RE = re.compile(r"\btee\s+(?:-a\s+)?([^\s|;&)]+)")
+SEDI_RE = re.compile(r"\bsed\b[^|;&]*?-i\S*\s+(?:-e\s+\S+\s+|'[^']*'\s+|\"[^\"]*\"\s+|\S+\s+)([^\s|;&)]+)")
+DDOF_RE = re.compile(r"\bdd\b[^|;&]*?\bof=([^\s|;&)]+)")
+CPMV_RE = re.compile(r"\b(?:cp|mv|install)\b((?:\s+(?:-\S+|[^\s|;&)]+))+)")
+# Read commands whose FIRST file arg, if a secret, triggers a WARN.
+READ_CMD_RE = re.compile(r"\b(cat|less|more|head|tail|bat)\b\s+((?:-\S+\s+)*)([^\s|;&)]+)")
+
+
+def _strip_noise(cmd: str) -> str:
+    """Neutralize heredoc bodies + quoted strings before scanning for write
+    targets (W79 false-positive killer — verbatim)."""
+    def _drop_heredocs(s: str) -> str:
+        lines = s.split("\n")
+        out: list[str] = []
+        i = 0
+        hd_re = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
+        while i < len(lines):
+            line = lines[i]
+            m = hd_re.search(line)
+            out.append(line)
+            if m:
+                word = m.group(2)
+                i += 1
+                while i < len(lines) and lines[i].strip() != word:
+                    i += 1
+                i += 1
+                continue
+            i += 1
+        return "\n".join(out)
+
+    s = _drop_heredocs(cmd)
+    s = re.sub(r"'[^']*'", "''", s)
+    s = re.sub(r'"[^"]*"', '""', s)
+    return s
+
+
+def _extract_write_targets(cmd: str) -> list[str]:
+    """Best-effort write-destination paths (W79 logic — verbatim). Conservative:
+    unresolvable target → not returned → ALLOWED."""
+    cmd = _strip_noise(cmd)
+    targets: list[str] = []
+    for m in REDIR_RE.finditer(cmd):
+        targets.append(m.group(1))
+    for m in TEE_RE.finditer(cmd):
+        targets.append(m.group(1))
+    for m in SEDI_RE.finditer(cmd):
+        targets.append(m.group(1))
+    for m in DDOF_RE.finditer(cmd):
+        targets.append(m.group(1))
+    for m in CPMV_RE.finditer(cmd):
+        toks = [t for t in m.group(1).split() if not t.startswith("-")]
+        if toks:
+            targets.append(toks[-1])
+    cleaned = []
+    for t in targets:
+        t = t.strip().strip("'\"")
+        if not t or t.startswith("/dev/") or t in {"&1", "&2"} or t.startswith("$("):
+            continue
+        cleaned.append(t)
+    return cleaned
+
+
+def _resolve_target(path_str: str, cwd: str) -> pathlib.Path | None:
+    """Resolve a possibly-relative target against cwd (W79 — verbatim)."""
+    try:
+        p = pathlib.Path(os.path.expanduser(path_str))
+        if not p.is_absolute() and cwd:
+            p = pathlib.Path(cwd) / p
+        return p.resolve()
+    except Exception:
+        return None
+
+
+def _is_protected(resolved: pathlib.Path) -> bool:
+    """True if a resolved path is a protected file or under a protected dir."""
+    if resolved in PROTECTED_FILES:
+        return True
+    for d in PROTECTED_DIRS:
+        try:
+            if resolved == d or resolved.is_relative_to(d):
+                return True
+        except AttributeError:  # py<3.9
+            try:
+                resolved.relative_to(d)
+                return True
+            except ValueError:
+                pass
+    return False
+
+
+def _write_hits_sensitive(cmd: str, cwd: str) -> pathlib.Path | None:
+    """Offending path if a Bash write lands in a protected dir/file. Else None."""
+    if not WRITE_HINT_RE.search(cmd):
+        return None
+    for raw in _extract_write_targets(cmd):
+        resolved = _resolve_target(raw, cwd)
+        if resolved is None:
+            continue  # unclassifiable → conservative allow
+        if _is_protected(resolved):
+            return resolved
+    return None
+
+
+def _read_hits_secret(cmd: str, cwd: str) -> pathlib.Path | None:
+    """Offending path if a Bash read targets a secret-ish file (WARN only)."""
+    m = READ_CMD_RE.search(_strip_noise(cmd))
+    if not m:
+        return None
+    target = m.group(3)
+    low = target.lower()
+    if not any(h in low for h in SECRET_READ_HINTS):
+        return None
+    resolved = _resolve_target(target, cwd)
+    if resolved is None:
+        return None
+    # WARN only for secrets that are protected OR look secret by name
+    return resolved
+
+
+def _block(offending: pathlib.Path, surface: str) -> None:
+    sys.stderr.write(
+        "HOST BOUNDARY VIOLATION (write to host-sensitive path)\n"
+        f"  surface: {surface}\n"
+        f"  target : {offending}\n"
+        "  This path is the agent control plane / credentials — writing it can\n"
+        "  disarm guardrails or leak/alter secrets. Blocked in EVERY phase\n"
+        "  (host_boundary 🔴, phase-aware §9-A). If this is intentional operator\n"
+        "  work, run it yourself outside the agent, or set HOST_BOUNDARY_OFF=1.\n"
+    )
+    sys.exit(2)
+
+
+def main() -> int:
+    if os.environ.get("HOST_BOUNDARY_OFF") == "1":
+        return 0
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0  # unparseable → never block on our own parse failure
+
+    tool = payload.get("tool_name") or payload.get("name") or ""
+
+    # --- Edit/Write/MultiEdit: direct file_path ---
+    if tool in ("Edit", "Write", "MultiEdit"):
+        fp = (payload.get("tool_input") or {}).get("file_path", "")
+        if fp:
+            resolved = _resolve_target(fp, payload.get("cwd", ""))
+            if resolved is not None and _is_protected(resolved):
+                _block(resolved, f"{tool} file_path")
+        return 0
+
+    # --- Bash: shell writes + secret reads ---
+    if tool == "Bash":
+        cmd = (payload.get("tool_input") or {}).get("command", "")
+        cwd = payload.get("cwd", "")
+        offending = _write_hits_sensitive(cmd, cwd)
+        if offending is not None:
+            _block(offending, "Bash write")
+        secret = _read_hits_secret(cmd, cwd)
+        if secret is not None:
+            sys.stderr.write(
+                f"HOST BOUNDARY WARN (read of secret-ish file): {secret}\n"
+                "  Allowed, but flagged — avoid printing secrets into transcripts "
+                "(cicatrix 2026-06-03 P0). Prefer reading config via code.\n"
+            )
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infra/claude-hooks/install_phase_aware.sh
+++ b/infra/claude-hooks/install_phase_aware.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# install_phase_aware.sh — install the phase-aware-guardrails layer into ~/.claude/hooks/
+#
+# Idempotent. Copies host_boundary.py + _phase.py + the 3 relaxed green gates
+# (orchestrate_gate / dispatch_nudge / stadio_zero_nudge) from this repo dir into
+# ~/.claude/hooks/, backs up any file it overwrites, and registers host_boundary
+# as a PreToolUse matcher in ~/.claude/settings.json (if not already present).
+#
+# worktree_isolation.py is NOT installed here — it is managed by W79 and is NOT
+# phase-relaxed (its scratch git-ops are already permitted without plan-mode;
+# relaxing its main-checkout block would be a hole — see spec §10 correction).
+#
+# Run on each machine (M5 done in-session; Pro+Mini via this script after merge):
+#   bash infra/claude-hooks/install_phase_aware.sh
+#
+# Kill switches after install: NUZ_PHASE_AWARE_OFF=1 (disable the switch),
+# HOST_BOUNDARY_OFF=1 (disable host_boundary).
+set -uo pipefail
+
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DST="$HOME/.claude/hooks"
+TS="$(date +%Y%m%d-%H%M%S)"
+
+mkdir -p "$DST"
+
+install_file() {
+    local name="$1"
+    local src="$SRC/$name"
+    local dst="$DST/$name"
+    if [ ! -f "$src" ]; then
+        echo "  SKIP $name (not in repo dir)"
+        return
+    fi
+    if [ -f "$dst" ] && ! diff -q "$src" "$dst" >/dev/null 2>&1; then
+        cp "$dst" "$dst.bak-pre-phaseaware-$TS"
+        echo "  backed up existing $name -> $name.bak-pre-phaseaware-$TS"
+    fi
+    cp "$src" "$dst"
+    chmod 700 "$dst"
+    echo "  installed $name"
+}
+
+echo "== installing phase-aware hooks into $DST =="
+install_file host_boundary.py
+install_file _phase.py
+install_file orchestrate_gate.py
+install_file dispatch_nudge.py
+install_file stadio_zero_nudge.py
+
+echo "== registering host_boundary in settings.json =="
+python3 - <<'PY'
+import json, os, pathlib, shutil, time
+p = pathlib.Path.home() / ".claude" / "settings.json"
+if not p.exists():
+    print("  WARN: settings.json missing — skip host_boundary registration")
+    raise SystemExit(0)
+s = json.loads(p.read_text())
+pre = s.setdefault("hooks", {}).setdefault("PreToolUse", [])
+cmd = "python3 ~/.claude/hooks/host_boundary.py"
+if any(cmd in hh.get("command", "") for g in pre for hh in g.get("hooks", [])):
+    print("  host_boundary already registered")
+else:
+    shutil.copy2(p, p.with_name(p.name + f".bak-pre-phaseaware-{time.strftime('%Y%m%d-%H%M%S')}"))
+    pre.insert(0, {"matcher": "Bash|Edit|Write|MultiEdit",
+                   "hooks": [{"type": "command", "command": cmd}]})
+    p.write_text(json.dumps(s, indent=2))
+    print("  host_boundary registered at top of PreToolUse")
+PY
+
+echo "== done. Reload hooks with /hooks (or restart the session). =="
+echo "   Kill switches: NUZ_PHASE_AWARE_OFF=1 / HOST_BOUNDARY_OFF=1"

--- a/infra/claude-hooks/orchestrate_gate.py
+++ b/infra/claude-hooks/orchestrate_gate.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""PreToolUse hard-gate — Gap 1 fix (2026-05-25).
+
+Blocca Bash|Edit|Write se:
+  - transcript >800 lines AND
+  - zero subagent dispatch in last 300 lines
+
+Exit 2 + stderr message → Claude rilegge il blocco e riconsidera.
+Override: env ORCHESTRATE_GATE_OFF=1.
+
+Upgrade di dispatch_nudge.py (soft warn UserPromptSubmit) a hard-block PreToolUse.
+Cicatrix family: T1.1 dispatch reminder, W33 kill-switch pattern.
+"""
+import json
+import os
+import pathlib
+import sys
+
+# Phase-aware (STEP 3): path-safe import of _phase. Missing _phase → "never plan"
+# (gate stays ON) — fail-safe. _phase.py is protected by host_boundary 🔴.
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+try:
+    from _phase import is_plan_phase
+except Exception:
+    def is_plan_phase(payload):
+        return False
+
+HARD_BLOCK_THRESHOLD = 800
+RECENT_LINES = 300
+DISPATCH_KEYWORDS = (
+    '"name":"TaskCreate"', '"name": "TaskCreate"',
+    '"subagent_type"',
+    '"name":"Task"', '"name": "Task"',
+)
+GATED_TOOLS = {"Bash", "Edit", "Write"}
+
+
+def main():
+    if os.environ.get("ORCHESTRATE_GATE_OFF") == "1":
+        sys.exit(0)
+
+    try:
+        payload = json.load(sys.stdin)
+        if is_plan_phase(payload): sys.exit(0)  # phase-aware: relax in plan-mode
+    except Exception:
+        sys.exit(0)
+
+    tool_name = payload.get("tool_name") or payload.get("name") or ""
+    if tool_name not in GATED_TOOLS:
+        sys.exit(0)
+
+    transcript_path = payload.get("transcript_path", "")
+    if not transcript_path:
+        sys.exit(0)
+
+    p = pathlib.Path(transcript_path)
+    if not p.exists():
+        sys.exit(0)
+
+    try:
+        full_text = p.read_text(errors="ignore")
+    except Exception:
+        sys.exit(0)
+
+    lines = full_text.splitlines()
+    total_lines = len(lines)
+    if total_lines <= HARD_BLOCK_THRESHOLD:
+        sys.exit(0)
+
+    recent = "\n".join(lines[-RECENT_LINES:])
+    dispatch_count = sum(recent.count(kw) for kw in DISPATCH_KEYWORDS)
+
+    if dispatch_count > 0:
+        sys.exit(0)
+
+    msg = (
+        f"\n[ORCHESTRATE-GATE] Session {total_lines} lines, zero subagent "
+        f"dispatch in last {RECENT_LINES} lines. Direct {tool_name} BLOCKED.\n"
+        f"Choose: (a) Agent(subagent_type=Explore|backend-verifier|frontend-browser|"
+        f"nb-curator|mcp-health|spalla-review|general-purpose, ...) "
+        f"or (b) `export ORCHESTRATE_GATE_OFF=1` if intentional direct work.\n"
+    )
+    print(msg, file=sys.stderr)
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/claude-hooks/stadio_zero_nudge.py
+++ b/infra/claude-hooks/stadio_zero_nudge.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""PreToolUse soft-nudge — STADIO-0 STUDY reminder (FASE-0 of the SOTA meta-dev-loop).
+
+The judgment (what is relevant, which acceptance criteria) belongs to the agent — only
+the agent can do the STUDY. This hook does the ANTI-FORGETTING half: if a session starts
+EDITING code without having done the STUDY, it injects ONE reminder. It NEVER blocks
+(sys.exit(0) always) — a blocking gate on a judgment act invites empty STUDYs to unblock
+(reward-hacking, the exact failure P1 warns about). Mirrors dispatch_nudge.py.
+
+Fires once per session, on the first Edit|Write|MultiEdit, only when no STUDY marker is
+present in the transcript and the session is still young. Self-silences on trivial tasks.
+
+Kill switch: env STADIO_ZERO_NUDGE_OFF=1.
+Reference: STADIO-0 STUDY skill at ~/.claude/skills/stadio-zero/SKILL.md
+"""
+import json
+import os
+import pathlib
+import sys
+
+# Phase-aware (STEP 3): path-safe import of _phase. Missing _phase → "never plan"
+# (gate stays ON) — fail-safe. _phase.py is protected by host_boundary 🔴.
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+try:
+    from _phase import is_plan_phase
+except Exception:
+    def is_plan_phase(payload):
+        return False
+
+GATED_TOOLS = {"Edit", "Write", "MultiEdit"}
+# Only nudge while the session is still young — a long session has clearly moved past
+# the entry point, and a late nudge is just noise.
+YOUNG_SESSION_MAX_LINES = 400
+
+# Markers that the STUDY was done OR explicitly skipped → no nudge.
+# (a) skill invoked, (b) the STUDY output sections present, (c) explicit opt-out.
+STUDY_MARKERS = (
+    "stadio-zero",                 # skill name (invoked)
+    "STADIO-0 STUDY",              # the output block heading
+    "STADIO-0 skip",               # explicit skip declaration
+    "STADIO-0 PII",                # a STUDY section was written
+    "Memory-hits:",                # STUDY output section
+    "Hot-files verificati",        # STUDY output section
+)
+# Trivial-intent markers → self-silence (don't nag on a typo/rename).
+TRIVIAL_MARKERS = ("typo", "trivial", "one-liner", "rename", "skip study", "wip:", "checkpoint")
+
+# Per-session guard: don't nudge twice. Keyed by transcript path hash.
+STATE_DIR = pathlib.Path.home() / ".agent" / "decisions" / "state"
+
+
+def _already_nudged(transcript_path: str) -> bool:
+    """One nudge per session. Guard file keyed by transcript basename."""
+    try:
+        key = pathlib.Path(transcript_path).name
+        marker = STATE_DIR / f"stadio_zero_nudge.{key}.done"
+        if marker.exists():
+            return True
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        marker.write_text("1")
+        return False
+    except OSError:
+        # If we can't write the guard, fall back to nudging (better a dup than silence).
+        return False
+
+
+def main() -> None:
+    if os.environ.get("STADIO_ZERO_NUDGE_OFF") == "1":
+        sys.exit(0)
+
+    try:
+        payload = json.load(sys.stdin)
+        if is_plan_phase(payload): sys.exit(0)  # phase-aware: relax in plan-mode
+    except Exception:
+        sys.exit(0)
+
+    tool_name = payload.get("tool_name") or payload.get("name") or ""
+    if tool_name not in GATED_TOOLS:
+        sys.exit(0)
+
+    transcript_path = payload.get("transcript_path", "")
+    if not transcript_path:
+        sys.exit(0)
+    p = pathlib.Path(transcript_path)
+    if not p.exists():
+        sys.exit(0)
+
+    try:
+        text = p.read_text(errors="ignore")
+    except Exception:
+        sys.exit(0)
+
+    # Only nudge a young session (the entry point). Past that, it's noise.
+    if text.count("\n") > YOUNG_SESSION_MAX_LINES:
+        sys.exit(0)
+
+    lower = text.lower()
+    # STUDY already done/skipped, or trivial task → no nudge.
+    if any(m.lower() in lower for m in STUDY_MARKERS):
+        sys.exit(0)
+    if any(m in lower for m in TRIVIAL_MARKERS):
+        sys.exit(0)
+
+    # One per session.
+    if _already_nudged(transcript_path):
+        sys.exit(0)
+
+    reminder = (
+        "STADIO-0 reminder — about to edit code without a STUDY in this session. "
+        "Before building, ground the task: (1) memory-hits (`mem query`), "
+        "(2) hot-files VERIFIED on disk (never trust a cited path), (3) PII-risk scope (Law 2), "
+        "(4) falsifiable acceptance criteria. Run /stadio-zero, or state in one line why you skip "
+        "(trivial task). This does NOT block — it reminds."
+    )
+    print(json.dumps({"systemMessage": reminder}))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/claude-hooks/test_host_boundary.py
+++ b/infra/claude-hooks/test_host_boundary.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Trap-table for host_boundary.py (phase-aware BLOCK #1 / §9-A).
+
+Mirror of test_w79_shell_write.py: a (command|file_path, cwd, expect_block)
+table run against the REAL hook logic, plus a few process-level invocations to
+prove exit codes. Each guard MUST: block writes into protected dirs/files,
+ALLOW writes elsewhere (worktree, /tmp, repo), and never block on a read.
+
+Run: python infra/claude-hooks/test_host_boundary.py  (exit 0 = all green)
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+HERE = pathlib.Path(__file__).resolve().parent
+HOOK = HERE / "host_boundary.py"
+
+
+def _load_mod(fake_home: pathlib.Path):
+    spec = importlib.util.spec_from_file_location("host_boundary_uut", str(HOOK))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    # Repoint the protected set at a FAKE home so the test never depends on the
+    # real ~/.claude etc. (and never accidentally blocks on the tester's home).
+    mod._HOME = fake_home
+    mod.PROTECTED_DIRS = [
+        fake_home / ".claude",
+        fake_home / ".ssh",
+        fake_home / ".aws",
+        fake_home / ".agent" / "decisions",
+    ]
+    mod.PROTECTED_FILES = [
+        fake_home / ".nuzantara-secrets.env",
+        fake_home / ".zshenv",
+        fake_home / ".zshrc",
+    ]
+    return mod
+
+
+def main() -> int:
+    # .resolve() up-front: on macOS tempfile gives /var/... which is a symlink to
+    # /private/var/...; the hook's _resolve_target also .resolve()s, so the
+    # protected set MUST be the resolved form or every match misses (W80/lsof
+    # symlink-mismatch class).
+    tmp = pathlib.Path(tempfile.mkdtemp()).resolve()
+    home = tmp / "home"
+    (home / ".claude" / "hooks").mkdir(parents=True)
+    (home / ".ssh").mkdir(parents=True)
+    (home / ".agent" / "decisions").mkdir(parents=True)
+    repo = tmp / "Desktop" / "nuzantara"
+    (repo / "apps").mkdir(parents=True)
+    (repo / ".worktrees" / "lane-x").mkdir(parents=True)
+    (tmp / "scratch").mkdir(parents=True)
+
+    mod = _load_mod(home)
+    H = str(home)
+    R = str(repo)
+
+    # --- Bash write/read trap table: (command, cwd, expect_block) ---
+    bash_cases = [
+        # BLOCK — writes into protected dirs/files
+        (f"echo x > {H}/.claude/hooks/_phase.py", R, True),
+        (f"sed -i 's/a/b/' {H}/.claude/settings.json", R, True),
+        (f"cp /tmp/x {H}/.ssh/authorized_keys", R, True),
+        (f"echo k >> {H}/.aws/credentials", R, True),
+        (f"tee {H}/.nuzantara-secrets.env", R, True),
+        (f"echo x > {H}/.zshrc", R, True),
+        (f"echo j > {H}/.agent/decisions/state.json", R, True),
+        # relative target resolving into protected dir (cwd = ~/.claude/hooks)
+        ("echo x > _phase.py", f"{H}/.claude/hooks", True),
+        # BLOCK survives heredoc/quote noise (W79 strip): real redirect into .claude
+        (f"cat > {H}/.claude/x <<'EOF'\nbody with > and ssh words\nEOF", R, True),
+        # ALLOW — writes elsewhere
+        ("echo x > /tmp/scratch.txt", "/tmp", False),
+        (f"echo x > {R}/apps/f.py", R, False),                     # repo (other hooks guard this)
+        (f"echo x > {R}/.worktrees/lane-x/f.py", R, False),        # scratch worktree
+        (f"echo x > {tmp}/scratch/note.md", R, False),             # neutral tmp dir
+        # ALLOW — `>` inside quotes / heredoc body is NOT a real target
+        (f'git commit -m "edit > .claude in message"', R, False),
+        (f"echo \"writing to ~/.ssh someday\" > /tmp/note", "/tmp", False),
+        # ALLOW — reads never block (secret read → WARN, exit 0, expect_block False)
+        (f"cat {H}/.nuzantara-secrets.env", R, False),
+        (f"cat {R}/apps/f.py", R, False),
+        # ALLOW — fd-dup, sink
+        ("python x.py 2>&1 | tail", R, False),
+        ("echo ok > /dev/null", R, False),
+    ]
+
+    fails = 0
+    for cmd, cwd, expect in bash_cases:
+        got = mod._write_hits_sensitive(cmd, cwd) is not None
+        ok = got == expect
+        if not ok:
+            fails += 1
+        print(f"  [{'OK ' if ok else 'FAIL'}] block={got!s:5} expect={expect!s:5}  bash: {cmd[:60]}")
+
+    # --- Edit/Write file_path cases (via _is_protected on resolved path) ---
+    edit_cases = [
+        (f"{H}/.claude/hooks/_phase.py", True),
+        (f"{H}/.claude/settings.json", True),
+        (f"{H}/.ssh/config", True),
+        (f"{R}/apps/f.py", False),
+        (f"{R}/.worktrees/lane-x/f.py", False),
+        ("/tmp/x.py", False),
+    ]
+    for fp, expect in edit_cases:
+        resolved = mod._resolve_target(fp, R)
+        got = resolved is not None and mod._is_protected(resolved)
+        ok = got == expect
+        if not ok:
+            fails += 1
+        print(f"  [{'OK ' if ok else 'FAIL'}] block={got!s:5} expect={expect!s:5}  edit: {fp[:60]}")
+
+    # --- Process-level exit-code check (real hook invocation) ---
+    # Block case via Edit payload → expect exit 2; allow case → exit 0.
+    # NB: the subprocess uses the REAL ~/.claude protected set, so we craft a
+    # payload that targets the real home .claude path (read-only test of the
+    # exit code path; nothing is written — the hook only inspects file_path).
+    real_phase = str(pathlib.Path("~/.claude/hooks/_phase.py").expanduser())
+    proc_cases = [
+        ({"tool_name": "Edit", "tool_input": {"file_path": real_phase}, "cwd": R}, 2),
+        ({"tool_name": "Edit", "tool_input": {"file_path": "/tmp/ok.py"}, "cwd": R}, 0),
+        ({"tool_name": "Read", "tool_input": {"file_path": real_phase}, "cwd": R}, 0),  # Read tool not gated
+    ]
+    for payload, expect_rc in proc_cases:
+        r = subprocess.run([sys.executable, str(HOOK)], input=json.dumps(payload),
+                           capture_output=True, text=True)
+        ok = r.returncode == expect_rc
+        if not ok:
+            fails += 1
+        print(f"  [{'OK ' if ok else 'FAIL'}] rc={r.returncode} expect={expect_rc}  proc: {payload['tool_name']} {payload['tool_input']['file_path'][:40]}")
+
+    print("=== ALL GREEN ===" if not fails else f"=== {fails} FAIL ===")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infra/claude-hooks/test_phase.py
+++ b/infra/claude-hooks/test_phase.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Test for _phase.is_plan_phase (phase-aware STEP 2).
+
+Run: python infra/claude-hooks/test_phase.py  (exit 0 = all green)
+Covers the proven snake_case signal, camelCase fallback, fail-safe-on-missing,
+the NUZ_PHASE manual escape, and the NUZ_PHASE_AWARE_OFF kill-switch precedence.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import pathlib
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("phase_uut", str(HERE / "_phase.py"))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def main() -> int:
+    mod = _load()
+    fails = 0
+
+    def check(name, got, expect):
+        nonlocal fails
+        ok = got is expect
+        if not ok:
+            fails += 1
+        print(f"  [{'OK ' if ok else 'FAIL'}] {got!s:5} expect={expect!s:5}  {name}")
+
+    # Clean env baseline for the deterministic cases.
+    for k in ("NUZ_PHASE", "NUZ_PHASE_AWARE_OFF"):
+        os.environ.pop(k, None)
+
+    # 1. proven snake_case signal
+    check("permission_mode=plan", mod.is_plan_phase({"permission_mode": "plan"}), True)
+    check("permission_mode=bypassPermissions",
+          mod.is_plan_phase({"permission_mode": "bypassPermissions"}), False)
+    check("permission_mode=default", mod.is_plan_phase({"permission_mode": "default"}), False)
+    # 2. camelCase fallback (defensive)
+    check("permissionMode=plan (camel fallback)",
+          mod.is_plan_phase({"permissionMode": "plan"}), True)
+    # 3. fail-safe: missing field / empty / wrong type → False
+    check("empty dict", mod.is_plan_phase({}), False)
+    check("no mode key", mod.is_plan_phase({"tool_name": "Bash"}), False)
+    check("None payload", mod.is_plan_phase(None), False)
+    check("str payload", mod.is_plan_phase("plan"), False)
+
+    # 4. NUZ_PHASE=plan manual escape (no field) → True
+    os.environ["NUZ_PHASE"] = "plan"
+    check("NUZ_PHASE=plan, empty payload", mod.is_plan_phase({}), True)
+    os.environ.pop("NUZ_PHASE")
+
+    # 5. kill-switch precedence: wins even over a real plan signal AND manual escape
+    os.environ["NUZ_PHASE_AWARE_OFF"] = "1"
+    os.environ["NUZ_PHASE"] = "plan"
+    check("OFF=1 beats permission_mode=plan",
+          mod.is_plan_phase({"permission_mode": "plan"}), False)
+    check("OFF=1 beats NUZ_PHASE=plan", mod.is_plan_phase({}), False)
+    os.environ.pop("NUZ_PHASE_AWARE_OFF")
+    os.environ.pop("NUZ_PHASE")
+
+    print("=== ALL GREEN ===" if not fails else f"=== {fails} FAIL ===")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/operations/specs/phase-aware-guardrails.md
+++ b/research/operations/specs/phase-aware-guardrails.md
@@ -123,42 +123,44 @@ Panel: Gemini 3.1 Pro + DeepSeek V4 Pro (refuter) + Codex GPT-5.5. **Convergenza
 
 ---
 
-## 10. STATO IMPLEMENTAZIONE (aggiornato 2026-06-14, verificato su disco)
+## 10. STATO IMPLEMENTAZIONE (aggiornato 2026-06-14, verificato su disco — FEATURE LIVE)
 
-Il panel (§9) ha fissato l'ordine NON negoziabile: **prereq 🔴 PRIMA → validazione §6 → relax 🟢 DOPO.** Stato dei tre prerequisiti, ri-verificato su disco oggi (M5):
+Il panel (§9) ha fissato l'ordine NON negoziabile: **prereq 🔴 PRIMA → validazione §6 → relax 🟢 DOPO.** Tutti e tre i prerequisiti sono ora chiusi e il relax è installato su M5. Stato ri-verificato su disco oggi (M5):
 
-| # | Prerequisito | Stato spec (13/06) | **Stato OGGI (verificato 14/06)** |
-|---|---|---|---|
-| 1 | §9-B `main_write_via_bash` (blocco scrittura main via Bash) | fatto-non-installato | ✅ **DONE + LIVE** — W79, PR #1399 MERGED, hook installato M5+Pro (`grep _strip_noise ~/.claude/hooks/worktree_isolation.py` = 6 match), E2E 5/5. Solo Mini pending (offline ~2gg, memory `unresolved_w79_mini_propagation_2026_06_13`). |
-| 2 | §9-A `host_boundary` (protezione `~/.claude/`+`~/.ssh`+secrets) | DA CREARE | ❌ **ANCORA BUCO** — grep 14/06 conferma: nessun hook protegge `~/.claude/` (l'unico match è un commento dentro `guardrails-static.py`). Auto-bypass-risk per `_phase.py` ancora reale. |
-| 3 | §6 probe `permissionMode` sullo stdin del PreToolUse | indiziato | ❌ **MAI PROVATO** — il campo ESISTE nei transcript (grep 14/06: `plan` 12× / `default` 30× / `bypassPermissions` 4628×) ma il transcript ≠ lo stdin dell'hook; il probe `/tmp/nuz_payload_capture.jsonl` non è mai stato eseguito. |
-| 4 | Relax dei 4 gate 🟢 (`orchestrate_gate`/`dispatch_nudge`/`stadio_zero`/`worktree-on-scratch`) | bloccato dai prereq | ⏸ **NON iniziato** — gated da #2 e #3. |
+| # | Prerequisito | **Stato OGGI (verificato 14/06)** |
+|---|---|---|
+| 1 | §9-B `main_write_via_bash` (blocco scrittura main via Bash) | ✅ **DONE + LIVE** — W79, PR #1399 MERGED, hook installato M5+Pro (`grep _strip_noise ~/.claude/hooks/worktree_isolation.py` = 6 match), E2E 5/5. Solo Mini pending (offline ~2gg, memory `unresolved_w79_mini_propagation_2026_06_13`). |
+| 2 | §9-A `host_boundary` (protezione `~/.claude/`+`~/.ssh`+secrets) | ✅ **DONE + LIVE** — `infra/claude-hooks/host_boundary.py` (riusa la logica W79 `_strip_noise`/`_extract_write_targets`/`_resolve_target`/regex), trap-table 28 casi verde, installato in `~/.claude/hooks/` + registrato in cima a PreToolUse (`matcher Bash\|Edit\|Write\|MultiEdit`). **Live-provato**: ha BLOCCATO un mio Edit di `orchestrate_gate.py` in `~/.claude/hooks/` (exit 2) durante questa stessa sessione — W64 armato E funziona. Policy: block-hard (exit 2) su scrittura mutativa, WARN su lettura secret. Kill-switch `HOST_BOUNDARY_OFF=1`. |
+| 3 | §6 probe `permission_mode` sullo stdin del PreToolUse | ✅ **RISOLTO — esito A** — probe `/tmp/nuz_payload_probe.py` ha catturato lo stdin reale in plan-mode (`/tmp/nuz_payload_capture.jsonl`): il campo top-level **`permission_mode`** (snake_case, NON `permissionMode`) arriva con valori `plan` (24×) / `bypassPermissions` (20×), cambia con la fase. **Correzione load-bearing (classe W78):** il transcript usa camelCase `permissionMode`, lo stdin dell'hook usa snake_case `permission_mode`. `_phase.py` legge snake_case primario + camelCase fallback. |
+| 4 | Relax dei gate 🟢 | ✅ **3 SU 4 fatti + live-provati** — `orchestrate_gate`/`dispatch_nudge`/`stadio_zero_nudge` rilassati (`if is_plan_phase(payload): sys.exit(0)` dopo il parse del payload). **`orchestrate_gate` live-provato**: stesso payload-bloccante → in `default` BLOCK exit 2, in `plan` PASS exit 0. **`worktree_isolation` deliberatamente NON rilassato** — vedi correzione sotto. |
 
-**Progresso netto dal 13/06:** 1 prereq su 3 chiuso — il più delicato (blast-radius globale, scrittura-main-via-Bash). Lo switch resta NON implementabile finché #2 e #3 non sono chiusi.
+### ⚠️ Correzione di design (load-bearing): solo 3 gate su 4 — `worktree_isolation` NON si rilassa
 
-## 11. I DUE BLOCCHI RIMASTI — roadmap d'implementazione
+Lo spec originale (§9, tabella §file-toccati) elencava 4 gate verdi da rilassare, incluso il ramo scratch-worktree di `worktree_isolation.py`. **In implementazione ho rilassato `worktree_isolation` e poi ho RIMOSSO chirurgicamente la patch**, per una ragione che lo spec a tavolino non aveva colto:
 
-> Ordine NON negoziabile (verdetto panel §9): prima i due blocchi sotto, POI il relax 🟢. Mai disarmare un gate verde prima.
+- `worktree_isolation.py` non ha un solo ramo "scratch git-op": il guard di fase, inserito dopo il parse del payload, si applicava all'INTERO hook — incluso il blocco git-su-main. Risultato: in plan-mode passava `git reset --hard HEAD~1` **su main**. Questo viola direttamente §9 ("il blocco git-su-main NON si rilassa, resta 🔴 in ogni fase").
+- Le operazioni scratch-git che il relax avrebbe dovuto sbloccare sono **già permesse senza plan-mode** (l'hook le consente di base nei worktree autorizzati). Quindi rilassarlo non sblocca nulla di utile e apre solo il buco git-su-main.
+- **Decisione:** `worktree_isolation` resta integralmente 🔴 (gestito da W79, non phase-relaxed). I gate verdi rilassati sono SOLO i 3 soft-gate (`orchestrate_gate`, `dispatch_nudge`, `stadio_zero_nudge`) — quelli che tassano l'esplorazione (dispatch-nudge / orchestrate / stadio-zero) senza proteggere alcun confine fisico. Un futuro agente NON deve "completare" il 4° gate: ricreerebbe il buco.
 
-### BLOCCO #1 — `host_boundary` 🔴 (gate nuovo, prerequisito di `_phase.py`)
+**Progresso netto:** feature COMPLETA su M5. host_boundary 🔴 + _phase + 3 soft-gate rilassati, tutti live-provati (RUN il gate, non solo `python -c` — W64). Resta: propagazione Pro+Mini via `infra/claude-hooks/install_phase_aware.sh`, e il `/hooks` reload perché Claude Code rilegga settings.json in questa sessione.
 
-- **Cosa:** un PreToolUse hook (o estensione di `worktree_file_write_check.py`) che blocca scrittura mutativa (Edit/Write/MultiEdit **e** Bash `>`/`tee`/`sed -i`/`cp`/`mv`/`dd of=`/`rm`) su path sensibili FUORI dai worktree autorizzati: `~/.claude/` (hook+settings+`_phase.py`), `~/.ssh`, `~/.aws`, `~/.nuzantara-secrets.env`, `~/.zshenv`/`~/.zshrc`. Lettura di secrets: almeno WARN.
-- **Perché PRIMA:** la spec introduce `~/.claude/hooks/_phase.py`; se quel file è scrivibile da un agente (+ "Yes" distratto in plan-mode, §9 Q3), un agente può **disarmare lo switch di fase** riscrivendo `_phase.py` → auto-bypass di tutti i gate verdi. Il guardiano va blindato PRIMA di esistere.
-- **Riuso:** W79 ha già `_strip_noise`/`_write_hits_main`/`WRITE_HINT_RE` in `worktree_isolation.py` — la logica di estrazione-target-da-Bash (incl. la trappola `lsof`/heredoc/quoting) è scritta e testata; `host_boundary` la riusa cambiando solo l'allowlist (da "dentro worktree" a "fuori path-sensibili").
-- **Test:** trap-table come W79 (`infra/claude-hooks/test_*`): BLOCK `echo x > ~/.claude/hooks/_phase.py`, `sed -i ~/.claude/settings.json`, `cp x ~/.ssh/`; ALLOW scrittura dentro worktree, lettura repo, `> /tmp`.
-- **Decisione operatore:** L1 hook, blast-radius globale (3 macchine) → richiede ok Antonello prima dell'install in `~/.claude/hooks/` (stesso protocollo di W79).
+## 11. COSA È STATO COSTRUITO (record d'implementazione — per propagazione + audit)
 
-### BLOCCO #2 — probe `permissionMode` sullo stdin (validazione §6, anti-W64)
+> I "due blocchi rimasti" della revisione precedente sono entrambi chiusi (§10). Questa sezione registra cosa esiste su disco, per la propagazione Pro+Mini e per un futuro audit anti-W64.
 
-- **Cosa:** provare EMPIRICAMENTE che `permissionMode == "plan"` arriva sullo **stdin del PreToolUse hook** (non solo nel transcript). Probe: matcher PreToolUse `/tmp/nuz_payload_probe.py` che dumpa lo stdin in `/tmp/nuz_payload_capture.jsonl`; `/hooks` reload; Shift+Tab → plan; esegui 1 Bash; leggi il dump.
-- **Perché:** claim load-bearing non provato (W64: esistere≠armato — qui "documentato≠provato"). Se il campo NON arriva sullo stdin, lo switch automatico via Shift+Tab è impossibile e degrada al solo `NUZ_PHASE=plan` manuale.
-- **Chi:** richiede sessione interattiva owner (Shift+Tab è un gesto UI; un subagent NON può entrare in plan-mode) → **azione Antonello**, o sessione interattiva guidata.
-- **Esito A** (campo presente, grafia X): si procede al relax 🟢 leggendo grafia X.
-- **Esito B** (campo assente): lo switch ricade su `NUZ_PHASE=plan` env manuale → l'idea "automatico e naturale via Shift+Tab" NON è realizzabile su questa versione di Claude Code; si rivaluta.
+**File nuovi (source-of-truth in repo, `infra/claude-hooks/`):**
+- `host_boundary.py` 🔴 + `test_host_boundary.py` (28 casi). PROTECTED_DIRS = `~/.claude`, `~/.ssh`, `~/.aws`, `~/.agent/decisions`; PROTECTED_FILES = `~/.nuzantara-secrets.env`, `~/.zshenv`, `~/.zshrc`. Copre Bash + Edit/Write/MultiEdit. Block-hard su scrittura, WARN su lettura secret. Kill-switch `HOST_BOUNDARY_OFF=1`.
+- `_phase.py` + `test_phase.py` (11 casi). `is_plan_phase(payload)`: legge `permission_mode` (snake_case primario, provato dal probe) → `permissionMode` (camelCase fallback) → `NUZ_PHASE=plan` (env manuale per brainstorm fuori UI). Fail-safe: campo assente → False (gate ON). Kill-switch `NUZ_PHASE_AWARE_OFF=1` vince su tutto.
+- `orchestrate_gate.py` / `dispatch_nudge.py` / `stadio_zero_nudge.py` — mirror HOME-fork dei 3 soft-gate rilassati (W50/W51/W52: vivevano SOLO in `~/.claude/hooks/`, ora versionati qui così un re-sync non perde il relax). Ognuno: import path-safe di `_phase` + `if is_plan_phase(payload): sys.exit(0)` dopo il parse del payload.
+- `install_phase_aware.sh` — installer idempotente: copia i 5 file in `~/.claude/hooks/` (backup `.bak-pre-phaseaware-<ts>` di ogni overwrite, chmod 700), registra host_boundary in cima a PreToolUse. **NON installa `worktree_isolation`** (W79-managed, non phase-relaxed — vedi §10 correzione).
 
-### DOPO i due blocchi — relax dei 4 gate 🟢
+**Installato + live-provato su M5 in questa sessione** (W64 — RUN il gate, non solo `bash -n`):
+- host_boundary: ha BLOCCATO un mio Edit di `orchestrate_gate.py` in `~/.claude/hooks/` (exit 2) — la prova che è armato E funziona, non solo registrato.
+- orchestrate_gate: stesso payload-bloccante → `default` BLOCK exit 2, `plan` PASS exit 0.
 
-Solo a #1 chiuso (host_boundary live) + #2 esito A: aggiungere le 2 righe `if is_plan_phase(payload): sys.exit(0)` ai 4 gate verdi, un gate per commit, con la trap-table che prova "in plan → off, in default → on". Kill-switch `NUZ_PHASE_AWARE_OFF=1` come rete.
+**Propagazione (W79 protocol):** install su Pro+Mini via `bash infra/claude-hooks/install_phase_aware.sh` dopo il merge di questa PR. Mini offline ~2gg (memory `unresolved_w79_mini_propagation_2026_06_13`) — propagare al rientro.
+
+**Nota `/hooks` reload:** host_boundary + gate rilassati sono su disco e in settings.json, ma Claude Code rilegge gli hook solo a `/hooks` reload o restart di sessione — sono LIVE per uno smoke da shell (provato) ma non ancora applicati alla sessione corrente finché non si ricarica.
 
 ---
 


### PR DESCRIPTION
New PreToolUse hook = **BLOCK #1** of the phase-aware-guardrails plan (panel verdict §9-A). It blocks MUTATING writes to host-sensitive paths outside the project worktrees: `~/.claude/` (the agent control plane incl. `_phase.py` + `settings.json`), `~/.ssh`, `~/.aws`, secret dotfiles (`~/.nuzantara-secrets.env`, `~/.zshenv`/`~/.zshrc`), and `~/.agent/decisions/` — on Bash + Edit/Write/MultiEdit — and emits a non-blocking WARN on secret-ish reads.

Rationale: plan-mode is not a physical sandbox, so an agent could otherwise rewrite `_phase.py` and disarm the phase switch itself; the guardian must be hard BEFORE the switch exists, and stays 🔴 in every phase.

Reuses the W79 write-target extraction verbatim (`_strip_noise` + `_extract_write_targets` + regexes — heredoc/quote-safe), with the allowlist inverted into `_write_hits_sensitive` (block fixed sensitive dirs, allow everything else). Kill-switch: `HOST_BOUNDARY_OFF=1`. Tests: 28-case trap-table, ALL GREEN. Install to `~/.claude/hooks/` + `settings.json` is the gated final step (operator-decided, done separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)