### PR TITLE
feat(ops): add dirty nlm content triage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -400,6 +400,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "apps/admin-dashboard-local/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "apps/admin-dashboard-local/node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
     "apps/admin-dashboard-local/node_modules/recharts": {
       "version": "2.15.4",
       "license": "MIT",
@@ -419,6 +444,15 @@
       "peerDependencies": {
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "apps/admin-dashboard-local/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "apps/admin-dashboard-local/node_modules/signal-exit": {
@@ -983,6 +1017,31 @@
         }
       }
     },
+    "apps/admin-dashboard/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "apps/admin-dashboard/node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
     "apps/admin-dashboard/node_modules/rimraf": {
       "version": "3.0.2",
       "dev": true,
@@ -1014,6 +1073,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "apps/admin-dashboard/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "apps/admin-dashboard/node_modules/tailwind-merge": {
@@ -2416,6 +2484,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2432,6 +2501,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2448,6 +2518,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2464,6 +2535,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2480,6 +2552,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2496,6 +2569,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2512,6 +2586,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2528,6 +2603,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2544,6 +2620,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2560,6 +2637,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2576,6 +2654,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2592,6 +2671,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2608,6 +2688,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2624,6 +2705,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2640,6 +2722,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2656,6 +2739,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2672,6 +2756,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2688,6 +2773,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2704,6 +2790,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2720,6 +2807,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2736,6 +2824,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2752,6 +2841,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2768,6 +2858,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2784,6 +2875,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2800,6 +2892,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2816,6 +2909,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3312,9 +3406,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3330,9 +3421,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3350,9 +3438,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3368,9 +3453,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3388,9 +3470,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3406,9 +3485,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3426,9 +3502,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3445,9 +3518,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3463,9 +3533,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3489,9 +3556,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3513,9 +3577,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3539,9 +3600,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3563,9 +3621,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3589,9 +3644,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3614,9 +3666,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3638,9 +3687,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -5682,9 +5728,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5700,9 +5743,6 @@
       "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5720,9 +5760,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5738,9 +5775,6 @@
       "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9229,6 +9263,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -9245,6 +9280,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -9261,6 +9297,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -9277,6 +9314,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -9293,6 +9331,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -9304,14 +9343,12 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -9323,14 +9360,12 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -9342,14 +9377,12 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -9361,14 +9394,12 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -9380,14 +9411,12 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -9399,14 +9428,12 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -9423,6 +9450,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -9436,6 +9464,7 @@
       ],
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.10.0",
         "@emnapi/runtime": "1.10.0",
@@ -9451,6 +9480,7 @@
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -9467,6 +9497,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -9483,6 +9514,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -9627,9 +9659,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9642,9 +9671,6 @@
       "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9659,9 +9685,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9674,9 +9697,6 @@
       "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9691,9 +9711,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9706,9 +9723,6 @@
       "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9723,9 +9737,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9738,9 +9749,6 @@
       "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9755,9 +9763,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9770,9 +9775,6 @@
       "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9787,9 +9789,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9803,9 +9802,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9818,9 +9814,6 @@
       "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -10601,9 +10594,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10621,9 +10611,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10641,9 +10628,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10661,9 +10645,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12321,9 +12302,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12338,9 +12316,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12355,9 +12330,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12372,9 +12344,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12389,9 +12358,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12406,9 +12372,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12423,9 +12386,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12440,9 +12400,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12457,9 +12414,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12474,9 +12428,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24033,6 +23984,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -24053,6 +24005,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -24073,6 +24026,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -24093,6 +24047,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -24113,6 +24068,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -24128,14 +24084,12 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -24151,14 +24105,12 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -24174,14 +24126,12 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -24197,14 +24147,12 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -24225,6 +24173,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -24245,6 +24194,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -24650,7 +24600,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -24700,7 +24649,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
       "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.4",
@@ -27305,6 +27254,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/research/operations/specs/2026-06-14-dirty-nlm-content-research-triage.md
+++ b/research/operations/specs/2026-06-14-dirty-nlm-content-research-triage.md
@@ -1,0 +1,168 @@
+# Dirty NLM Content Research Triage - 2026-06-14
+
+Date: 2026-06-14
+Dispatch key: `dirty-nuzantara-nlm-content-research`
+Source report: `/Users/nuzantara/codex-spark-loop/reports/scout-20260614_041524.md`
+Owner: NLM/content/research pipeline owner
+Decision deadline: 2026-06-14 12:00 WITA
+
+## Scope
+
+Resolve the dirty shared-checkout signal in `/Users/nuzantara/Desktop/nuzantara`
+without touching Spark LaunchAgents, production systems, or unrelated operator
+work.
+
+This triage spec is deliberately decision-only. The shared checkout contains a
+mixed NLM pipeline change set, content publishing artifacts, generated research
+corpora, operational docs, and local output files. Some untracked paths look
+potentially client-sensitive. The safe remediation is to define the ownership,
+validation, commit order, and drop/archive boundaries, then leave the dirty files
+intact for the owning session or a heavier agent.
+
+## Live Evidence
+
+- Machine check: Pro, `nuzantara@Nuzantara`.
+- Mini peer check: unreachable from this session, so Pro/Mini sync is
+  unverified.
+- Isolated overnight branch:
+  `codex-overnight/spark-alarm-20260614_044854-spark-dispatch-20260614_041524-scout-dirty-nuzantara-nlm-content-research-20260614_044854`.
+- Isolated worktree HEAD:
+  `9a87de3ce fix(wa-mirror): deaf-session watchdog rests during quiet hours WITA (W77) (#1408)`.
+- Shared checkout `/Users/nuzantara/Desktop/nuzantara` is on `main` at
+  `e2b355f45 feat(articles): add translations for indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists`.
+- Shared checkout relation to `origin/main`: ahead 2, behind 161.
+  Local unpushed commits:
+  - `e2b355f45 feat(articles): add translations for indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists`
+  - `c6d6b85fe feat(articles): add translations for ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms`
+- Shared checkout dirty state, verified live at 2026-06-14 04:51 WITA:
+  - 17 tracked files modified.
+  - Untracked bulk includes 51 files under `outputs/`, 840 files under
+    `research/coherence-corpus/`, one multimodal audio artifact, five article
+    MDX files, five NB health reports, four regulatory deltas, two operations
+    research docs, two scripts, one CRM war-room script, and one
+    `research/commercial/` path not present in the Spark snapshot.
+- Large untracked directories:
+  - `outputs/`: 40M.
+  - `research/coherence-corpus/`: 44M.
+  - `apps/evaluator/nlm_deep_research/output/multimodal/`: 47M.
+  - `research/commercial/`: 16K.
+- Spark lifecycle is not actionable:
+  - `com.nuzantara.codex-spark-loop`: `state = running`, `pid = 1025`,
+    `last exit code = (never exited)`.
+  - `com.nuzantara.codex-spark-alarm`: timer job, `state = not running`,
+    `last exit code = 0`, `run interval = 120 seconds`.
+  - `com.nuzantara.codex-spark-harvester`: timer job, `state = not running`,
+    `last exit code = 0`, `run interval = 180 seconds`.
+  - `com.nuzantara.codex-overnight-runner`: `state = running`, `pid = 18380`.
+- Current `launchctl list` no longer shows a non-zero
+  `com.nuzantara.mcp-integrity`; it is `- 0`. Remaining non-Codex bad exits
+  include `com.matagaruda.redis-split-brain.check`,
+  `com.matagaruda.consumer-lag.check`, `com.balizero.wr2.plist-watchdog`, and
+  `com.balizero.domain-mesh.foundations.daily`.
+
+## Root-Cause Classification
+
+Primary cluster: an NLM/content/research working set was left in the shared
+checkout while `main` itself is stale and contains two local unpushed commits.
+
+The LaunchAgent evidence does not support a Spark lifecycle repair. The
+actionable signal is repo hygiene and handoff risk: executable changes, generated
+outputs, content files, and potentially sensitive CSV artifacts are mixed in the
+same dirty checkout with no owner-visible commit plan.
+
+## File Plan
+
+| Path or cluster | Current state | Plan | Owner | Acceptance criteria |
+| --- | --- | --- | --- | --- |
+| `apps/evaluator/nlm_deep_research/*` notebook ID changes | Tracked modifications | Keep only if these new NotebookLM IDs are current and reachable. Commit separately as NLM config rotation. | NLM pipeline owner | Verify each new notebook ID with `nlm` using the intended profile. Run focused import/compile checks for the touched modules. No hardcoded secret changes. |
+| `apps/mata-garuda/mata_garuda/workers/nlm_feeder.py` | Tracked modification | Keep only after confirming `--profile default` is the production profile for the feeder. Do not bundle with content artifacts. | Mata Garuda/NLM feeder owner | Run a dry-run or mocked feeder validation proving URL and text source add commands build with the expected profile. If `zero` remains canonical, revert or parameterize profile via env. |
+| `scripts/curiosity_loop.sh` | Tracked modification | Keep as a separate ops fix only if py3.11.11 path exists on Pro and backend venv fallback is valid. | Ops automation owner | Run `bash -n scripts/curiosity_loop.sh` and a non-destructive smoke path. Confirm no system Python fallback is selected during normal Pro execution. |
+| `docs/AUTOMATIONS_REFERENCE.md` | Tracked generated modification | Keep only if regenerated from the canonical script and current live state. | Ops documentation owner | Re-run `scripts/generate_automations_reference.py` or the documented generator. Commit generated docs separately from behavior changes. |
+| `apps/bali-intel-scraper/data/published_articles.json` | Tracked generated data modification | Keep only with the articles/content batch that consumed these URLs. | Content pipeline owner | JSON validates, entries correspond to actual published or intentionally queued article artifacts, and duplicates are checked. |
+| `apps/mouth/src/content/articles/**/*.mdx` new files | Untracked content artifacts | Keep in a content PR only after editorial/source review. | Mouth/content owner | Frontmatter validates, source claims are reviewed, localization variants match, and `apps/mouth` build or focused content validation passes. |
+| `shared/escalations_pro.jsonl` | Tracked append | Review before commit. This may contain operational or private context. | Ops owner | JSONL validates and no private/client material is exposed beyond the intended internal log boundary. Commit separately or archive locally. |
+| `research/nb-health/*.md`, `research/regulatory/*.json`, `research/operations/*.md`, `research/commercial/` | Untracked research artifacts | Keep only if they are durable research deliverables. Otherwise archive outside git or fold summaries into a single reviewed report. | Research owner | Each retained artifact has provenance, no secrets/client raw data, and belongs in the repo rather than runtime storage. |
+| `research/coherence-corpus/` | Untracked generated corpus, 840 files, 44M | Do not commit by default. Archive or move to runtime/output storage unless a corpus owner explicitly promotes it. | Research corpus owner | If retained, add a manifest, size justification, privacy review, and targeted validation. Otherwise leave ignored/archived outside the repo. |
+| `apps/evaluator/nlm_deep_research/output/multimodal/` | Untracked audio artifact, 47M | Do not commit to repo. Move to artifact storage if it is needed. | NLM multimodal owner | Artifact storage location recorded; repo remains free of large generated media. |
+| `outputs/` | Untracked local output, 51 files, 40M, including client CSV names | Treat as local-sensitive output. Do not commit. | Operator/data owner | Confirm whether files contain client data. Archive or delete locally only after owner approval. If recurrence is expected, add a separate ignore-policy PR. |
+| `apps/crm-cell/war-room/interactive_cli.sh` | Untracked script | Review as a separate CRM tool change, not part of NLM/content batch. | CRM cell owner | Shellcheck or `bash -n`, owner review for data boundaries, and commit with CRM-specific tests/docs. |
+| `scripts/nb_export_corpus.py`, `scripts/nb_generate_inventory.py` | Untracked scripts | Review with corpus ownership decision. | Research/NLM owner | Use project venv, type/import checks, no raw OSINT export to repo, and explicit output directory policy. |
+
+## Recommended Commit Order
+
+1. Preserve the dirty shared checkout before any branch switch:
+   create a normal patch or local stash from `/Users/nuzantara/Desktop/nuzantara`
+   without rewriting history or resetting.
+2. Rebase or recreate the working branch from current `origin/main`; the shared
+   checkout is behind by 161 commits.
+3. NLM configuration rotation:
+   `chore(nlm): rotate notebook ids`
+4. NLM feeder profile change, only if validated:
+   `fix(mata-garuda): use canonical nlm feeder profile`
+5. Curiosity loop Python runtime fix:
+   `fix(ops): pin curiosity loop to python 3.11`
+6. Generated automation reference refresh:
+   `docs(ops): refresh automations reference`
+7. Content publishing batch:
+   `feat(articles): publish june regulatory articles`
+8. Durable research reports:
+   `docs(research): add notebook health and regulatory deltas`
+9. Explicitly archive or ignore generated media/corpus/output directories only
+   after owner review. Do not sneak them into any commit above.
+
+Do not mix executable behavior, generated docs, content, and large outputs into
+one commit. Each category has a different owner and validation surface.
+
+## Minimal Validation Commands
+
+Run from an isolated worktree, not from an unrelated shared checkout cleanup:
+
+```bash
+cd apps/backend-rag && source .venv/bin/activate
+PYTHONPATH=. python -m compileall ../../apps/evaluator/nlm_deep_research
+```
+
+```bash
+bash -n scripts/curiosity_loop.sh
+bash -n apps/crm-cell/war-room/interactive_cli.sh
+```
+
+```bash
+python -m json.tool apps/bali-intel-scraper/data/published_articles.json >/dev/null
+python - <<'PY'
+import json
+from pathlib import Path
+for path in Path("research/regulatory").glob("2026-06-*-delta.json"):
+    json.loads(path.read_text())
+print("OK")
+PY
+```
+
+```bash
+cd apps/mouth
+npm run lint
+npm run build
+```
+
+Only run external `nlm` calls in the owner session after confirming the intended
+profile and NotebookLM account. Do not export raw WhatsApp, OSINT, or client data
+to the repo.
+
+## Non-Goals
+
+- Do not restart, unload, or rewrite `com.nuzantara.codex-spark-*` LaunchAgents.
+- Do not deploy.
+- Do not modify `backend/prompts/zantara_core.py`, `fly.toml`, `.env*`, or
+  secrets.
+- Do not clean, reset, or stage the shared checkout from this isolated overnight
+  branch.
+- Do not commit `outputs/`, generated multimodal media, or corpus bulk without
+  explicit owner review.
+- Do not use `--no-verify`, force push, or bypass branch protections.
+
+## Next Step
+
+Assign the NLM/content/research owner to split the shared checkout by the file
+plan above. If no owner has acted by 2026-06-14 12:00 WITA, preserve the dirty
+state with a normal patch or stash, then remove or ignore only local generated
+outputs after confirming they are not needed for publication or audit evidence.


### PR DESCRIPTION
## Summary
- Adds a decision-only triage spec for the dirty NLM/content/research shared-checkout signal reported by Spark.
- Classifies executable NLM changes, content artifacts, generated corpus/media/output bulk, and potentially sensitive local outputs into owner-specific commit/archive paths.
- Confirms Spark lifecycle is not the actionable issue and avoids mutating the dirty shared checkout.

## Verification
- git diff --check
- cd apps/backend-rag && source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && python -c "from backend.app.dependencies import get_current_user; print('OK')"
- cd apps/backend-rag && source /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/activate && PYTHONPATH=. pytest backend/tests/services/rag/test_kg_langgraph.py backend/tests/services/rag/test_kg_subgraphs.py backend/tests/services/rag/test_confidence.py -q (91 passed, 1 warning)

## Notes
- No production deploy.
- Mini peer was unreachable during session-start sync check, so Pro/Mini sync remains unverified.
- Shared checkout was left untouched by design.