### PR TITLE
fix(sentinel): close blind heal-loop — real stderr enrich + auto-resurrect TERMINAL (W70 Mythos-P1)

### DIFF
--- a/scripts/nuzantara-sentinel.py
+++ b/scripts/nuzantara-sentinel.py
@@ -13,6 +13,7 @@ import glob
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 import time
@@ -506,6 +507,46 @@ def _process_openclaw_job(
 
 # ─── Main job processor ───────────────────────────────────────────────────────
 
+# W70 (2026-06-14): the cron wrappers (cron-state.sh / cron-runner.sh) write a
+# bare last_error="exit N" to the state file — zero diagnostic signal, so
+# classify() returns UNKNOWN and the autopilot/sentinel act blind (33 jobs piled
+# into DLQ-TERMINAL, all classification=UNKNOWN c=0.0). The job's REAL stderr is
+# in its own cron log (cron redirects stdout+stderr there). This bridges the gap.
+_BARE_FAILURE_SUMMARY = re.compile(
+    r"^\s*(?:exit\s+\d+(?:\s*\([^)]*\))?(?:\s+after\s+\d+\s+attempts)?"
+    r"|timeout(?:\s+after\s+\d+s)?)?\s*$",
+    re.IGNORECASE,
+)
+# Real cron-log locations, in priority order. The 2026-06-13 orphan attempt read
+# only ~/logs/cron (empty for these jobs) with a regex that required
+# "exit N after M attempts" — the wrapper never emits that, so it never fired.
+_CRON_LOG_DIRS = ("~/logs/cron-tmp", "~/logs", "~/logs/cron", "~/logs/cron-agent-python")
+
+
+def _enrich_last_error_from_cron_log(job_id: str, last_error: str) -> str:
+    """Append the tail of the job's real cron log when last_error carries no
+    diagnostic signal (bare 'exit N' / empty), so classify(), _infer_files and
+    the DLQ log_tail see the actual stderr instead of a useless exit code.
+    A last_error that already contains a real message is returned unchanged."""
+    if last_error and not _BARE_FAILURE_SUMMARY.match(last_error.strip()):
+        return last_error
+    dash = job_id.replace("_", "-")
+    for d in _CRON_LOG_DIRS:
+        base = os.path.expanduser(d)
+        for name in (f"{job_id}.log", f"{dash}.log"):
+            path = os.path.join(base, name)
+            try:
+                with open(path, "r", errors="replace") as fh:
+                    lines = fh.readlines()
+            except OSError:
+                continue
+            tail = [ln.rstrip("\n") for ln in lines[-40:] if ln.strip()]
+            if tail:
+                prefix = last_error or "(no exit summary)"
+                return f"{prefix}\n--- cron log tail ({name}) ---\n" + "\n".join(tail)
+    return last_error
+
+
 def process_job(job_id: str, state: dict, registry: dict,
                 openclaw_is_down: bool = False,
                 dlq_terminal_set: set | None = None) -> dict:
@@ -549,6 +590,7 @@ def process_job(job_id: str, state: dict, registry: dict,
             logger.warning(f"{job_id}: state ts has unparseable type/value {_raw_ts!r}, treating as never-run")
             last_ts = 0.0
     last_error = state.get("last_error", "") or ""
+    last_error = _enrich_last_error_from_cron_log(job_id, last_error)  # W70: real stderr
     retry_attempt = state.get("retry_attempt", 0)
 
     # Staleness check
@@ -559,6 +601,20 @@ def process_job(job_id: str, state: dict, registry: dict,
 
     if status == "ok":
         record_success(job_id)
+        # W70-resurrect (2026-06-14): a job parked TERMINAL in the DLQ that has
+        # since recovered (current state=ok and FRESH — the staleness downgrade
+        # above already turned ok→stale for old timestamps, so we only reach here
+        # for genuine recoveries) is a corpse. dlq_autopilot's TERMINAL guard
+        # never re-checks live state, so without this the entry stays forever
+        # (pre-fix: 19 of 33 DLQ-TERMINAL entries were already-healthy corpses).
+        # Clearing it is the missing edge that closes the heal-loop.
+        if job_id in dlq_terminal_set:
+            try:
+                clear_dlq_entry(job_id)
+                logger.info(f"{job_id}: recovered while DLQ-TERMINAL — resurrected (corpse cleared)")
+                return {"action": "resurrected_terminal", "tier": 0, "success": True}
+            except Exception as exc:  # never let a clear failure break the cycle
+                logger.warning(f"{job_id}: resurrection clear failed: {exc}")
         return {"action": "healthy", "tier": 0, "success": True}
 
     if status == "running":
@@ -954,6 +1010,7 @@ def run_sentinel() -> None:
         "jobs_checked": len(results),
         "healthy": sum(1 for r in results.values() if r.get("action") == "healthy"),
         "retried": sum(1 for r in results.values() if "retried" in r.get("action", "")),
+        "resurrected": sum(1 for r in results.values() if r.get("action") == "resurrected_terminal"),
         "escalated": sum(1 for r in results.values() if "escalated" in r.get("action", "")),
         "suppressed": sum(1 for r in results.values() if r.get("action") == "suppressed_gateway_down"),
         "openclaw_down": openclaw_is_down,
@@ -1001,12 +1058,12 @@ def run_sentinel() -> None:
         "jobs_healthy": log_entry["healthy"],
         "jobs_circuit_open": sum(1 for v in circuit_states.values() if v.get("state") == "OPEN"),
         "jobs_circuit_terminal": dlq_terminal,
-        "jobs_healing": log_entry["retried"],
+        "jobs_healing": log_entry["retried"] + log_entry.get("resurrected", 0),
         "jobs_suppressed": log_entry["suppressed"],
         "dlq_entries": dlq_entries,
         "dlq_terminal": dlq_terminal,
         "dlq_phase_distribution": dlq_phase_distribution,  # D4.3
-        "healing_actions_24h": log_entry["retried"],  # current cycle; full 24h requires log scan
+        "healing_actions_24h": log_entry["retried"] + log_entry.get("resurrected", 0),  # retried+resurrected this cycle; full 24h requires log scan
         "openclaw_gateway": "down" if openclaw_is_down else "healthy",
         "last_sentinel_duration_s": round(duration, 2),
         "timed_out": timed_out,

--- a/scripts/tests/test_sentinel_w70_resurrect_enrich.py
+++ b/scripts/tests/test_sentinel_w70_resurrect_enrich.py
@@ -1,0 +1,148 @@
+"""W70 (2026-06-14) — Mythos P1 immune-system fixes for nuzantara-sentinel.py.
+
+Covers the two structural cures shipped on top of #1344's blind-heal-loop detector:
+
+1. ``_enrich_last_error_from_cron_log`` — the cron wrappers write a bare
+   ``last_error="exit N"`` to the state file (zero diagnostic signal), so the
+   classifier returns UNKNOWN and the heal-loop acts blind. The enricher appends
+   the tail of the job's REAL cron log. The 2026-06-13 orphan attempt had two
+   bugs this test pins shut: (a) a regex that required "exit N after M attempts"
+   (never emitted by the wrapper) so it never fired on the bare "exit 1"; (b) it
+   read only ~/logs/cron (empty for these jobs) instead of ~/logs/cron-tmp.
+
+2. ``process_job`` auto-resurrection — a job parked DLQ-TERMINAL that has since
+   recovered (state=ok AND fresh) must have its corpse cleared, else dlq_terminal
+   only ever grows (pre-fix: 19 of 33 TERMINAL entries were already-healthy).
+   A stale (ok-but-old) job must NOT resurrect (it hasn't proven recovery).
+
+The sentinel module name is hyphenated and runs logging.basicConfig at import,
+so it is loaded via importlib with HOME pointed at a tmp dir.
+"""
+import importlib.util
+import os
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_SCRIPTS_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..")
+)
+
+
+@pytest.fixture()
+def sentinel(tmp_path, monkeypatch):
+    """Load nuzantara-sentinel.py fresh with HOME redirected to a tmp dir so the
+    module-level logging.FileHandler does not touch the real ~/logs."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+    if _SCRIPTS_DIR not in sys.path:
+        sys.path.insert(0, _SCRIPTS_DIR)
+    spec = importlib.util.spec_from_file_location(
+        "nuzantara_sentinel_w70", os.path.join(_SCRIPTS_DIR, "nuzantara-sentinel.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    # Neutralise circuit-breaker / repairer side effects for unit isolation.
+    monkeypatch.setattr(mod, "get_state", lambda job_id: "CLOSED")
+    monkeypatch.setattr(mod, "record_success", lambda job_id: None)
+    monkeypatch.setattr(mod, "record_failure", lambda job_id: None)
+    return mod, tmp_path
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _enrich_last_error_from_cron_log
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestEnrichLastError:
+    def test_bare_exit_1_is_enriched_from_cron_tmp(self, sentinel):
+        mod, home = sentinel
+        log = home / "logs" / "cron-tmp" / "garuda-indexer.log"
+        log.parent.mkdir(parents=True, exist_ok=True)
+        log.write_text("starting\nasyncpg.InvalidPasswordError: password auth failed\n")
+        out = mod._enrich_last_error_from_cron_log("garuda_indexer", "exit 1")
+        assert "InvalidPasswordError" in out
+        assert out.startswith("exit 1")  # original summary preserved as prefix
+
+    def test_underscore_jobname_maps_to_dashed_log(self, sentinel):
+        mod, home = sentinel
+        log = home / "logs" / "cron-tmp" / "knowledge-graph-builder.log"
+        log.parent.mkdir(parents=True, exist_ok=True)
+        log.write_text("NUZANTARA_API_KEY non impostata\n")
+        out = mod._enrich_last_error_from_cron_log("knowledge_graph_builder", "exit 1")
+        assert "NUZANTARA_API_KEY" in out
+
+    def test_empty_last_error_still_enriches(self, sentinel):
+        mod, home = sentinel
+        log = home / "logs" / "dropbox-intake.log"
+        log.write_text("rclone: drive upload limit reached\n")
+        out = mod._enrich_last_error_from_cron_log("dropbox_intake", "")
+        assert "drive upload limit" in out
+
+    def test_real_error_is_left_untouched(self, sentinel):
+        mod, _ = sentinel
+        real = "Postgres relation kg_proposals does not exist"
+        assert mod._enrich_last_error_from_cron_log("curiosity_loop", real) == real
+
+    def test_bare_exit_with_no_log_returns_unchanged(self, sentinel):
+        mod, _ = sentinel
+        assert mod._enrich_last_error_from_cron_log("no_such_job_xyz", "exit 1") == "exit 1"
+
+    def test_exit_127_matches_bare_pattern(self, sentinel):
+        mod, home = sentinel
+        log = home / "logs" / "cron-tmp" / "zantara-vision-warmup.log"
+        log.parent.mkdir(parents=True, exist_ok=True)
+        log.write_text("bash: warmup-vision.sh: No such file or directory\n")
+        out = mod._enrich_last_error_from_cron_log("zantara_vision_warmup", "exit 127")
+        assert "No such file" in out
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# process_job — auto-resurrection
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestResurrection:
+    def test_fresh_ok_job_in_terminal_set_is_resurrected(self, sentinel, monkeypatch):
+        mod, _ = sentinel
+        clear = MagicMock()
+        monkeypatch.setattr(mod, "clear_dlq_entry", clear)
+        state = {"status": "ok", "ts": time.time(), "last_error": ""}
+        registry = {"job1": {"staleness_threshold_s": 999999}}
+        result = mod.process_job("job1", state, registry, dlq_terminal_set={"job1"})
+        assert result["action"] == "resurrected_terminal"
+        assert result["success"] is True
+        clear.assert_called_once_with("job1")
+
+    def test_stale_ok_job_in_terminal_set_is_NOT_resurrected(self, sentinel, monkeypatch):
+        mod, _ = sentinel
+        clear = MagicMock()
+        monkeypatch.setattr(mod, "clear_dlq_entry", clear)
+        # ok but ts very old → staleness downgrades to "stale" → W53 suppression,
+        # not resurrection (a stale job hasn't proven it recovered).
+        state = {"status": "ok", "ts": time.time() - 10_000_000, "last_error": ""}
+        registry = {"job1": {"staleness_threshold_s": 93600}}
+        result = mod.process_job("job1", state, registry, dlq_terminal_set={"job1"})
+        assert result["action"] == "skipped_dlq_terminal"
+        clear.assert_not_called()
+
+    def test_healthy_job_not_in_terminal_set_is_not_cleared(self, sentinel, monkeypatch):
+        mod, _ = sentinel
+        clear = MagicMock()
+        monkeypatch.setattr(mod, "clear_dlq_entry", clear)
+        state = {"status": "ok", "ts": time.time(), "last_error": ""}
+        registry = {"job1": {"staleness_threshold_s": 999999}}
+        result = mod.process_job("job1", state, registry, dlq_terminal_set=set())
+        assert result["action"] == "healthy"
+        clear.assert_not_called()
+
+    def test_resurrection_clear_failure_falls_back_to_healthy(self, sentinel, monkeypatch):
+        mod, _ = sentinel
+        monkeypatch.setattr(mod, "clear_dlq_entry", MagicMock(side_effect=OSError("locked")))
+        state = {"status": "ok", "ts": time.time(), "last_error": ""}
+        registry = {"job1": {"staleness_threshold_s": 999999}}
+        result = mod.process_job("job1", state, registry, dlq_terminal_set={"job1"})
+        # A clear failure must never break the cycle — degrade to healthy.
+        assert result["action"] == "healthy"
+        assert result["success"] is True


### PR DESCRIPTION
## What
Closes the immune-loop's two structural gaps found in the **Mythos P1 immune-system audit** (Pro, 2026-06-14). Live DLQ had **33 TERMINAL jobs, healing_actions_24h=0** — the loop catalogued its own sick jobs and never healed them.

## Root causes (verified on-disk)
1. **Blindness** — cron wrappers write a bare `last_error="exit N"` → `classify()` returns `UNKNOWN c=0.0` → autopilot retries blind to TERMINAL. PR #1344 added a heal=0 *detector* but no stderr capture; the 2026-06-13 `_enrich` attempt used a regex requiring `"exit N after M attempts"` (never emitted) and read the empty `~/logs/cron` — **and lived in a HOME-fork copy launchd doesn't run**.
2. **No resurrection** — a recovered job (state=ok) keeps its TERMINAL corpse forever. **19 of 33** TERMINAL entries were already-healthy jobs.

## Changes (`scripts/nuzantara-sentinel.py`)
- `_enrich_last_error_from_cron_log` — fires on the bare `"exit N"`/empty the wrapper actually writes; searches the real dirs (`~/logs/cron-tmp` first). Real-error strings pass through untouched.
- `process_job` **auto-resurrection** — a fresh-ok job in `dlq_terminal_set` → `clear_dlq_entry` + counted as a healing action. Staleness already downgrades old ok→stale, so only genuine recoveries resurrect.
- `healing_actions_24h` / `jobs_healing` include resurrections, so #1344's heal=0 detector stops false-alarming when the loop self-clears corpses.

## Tests
10 behavioral tests (`scripts/tests/test_sentinel_w70_resurrect_enrich.py`), importlib-loaded + HOME-isolated, **all green**. Existing sentinel tests unaffected (the lone `test_format_schedule` failure is a pre-existing stale assertion on `generate_automations_reference`, absent on origin/main too).

## Live healing already applied (this session, not in this diff)
11 already-healthy/false-positive corpses `dlq clear`'d (dlq_terminal 33→22) + `mkdir ~/.cron-agent/logs` (nb_agents path-drift). The remaining ~10 real failures are env/config/secret drift handed to the operator (see report).

## Deploy note (operator)
The live sentinel runs from the **dev checkout `~/Desktop/nuzantara`** which is **162 commits behind origin/main** with **no auto-puller** — so this fix (like #1344) won't execute until that checkout is pulled. Full analysis: `research/operations/2026-06-14-mythos-p1-immune-system.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)