### PR TITLE
fix(rag): property subgraph confidence call passed wrong kwargs → TypeError every run

### DIFF
--- a/apps/backend-rag/backend/services/rag/kg_subgraph_property.py
+++ b/apps/backend-rag/backend/services/rag/kg_subgraph_property.py
@@ -382,15 +382,25 @@ async def synthesize_property_workflow(state: PropertyState, config: dict) -> di
             f"Based on this, the requirements are: {'; '.join(reqs)}."
         )
 
-    # Dynamic confidence based on data quality instead of hardcoded values
+    # Dynamic confidence based on data quality instead of hardcoded values.
+    # NOTE (2026-06-14): this call previously passed chains=/entities=/query=,
+    # which are NOT the function signature — it raised TypeError on every run
+    # and silently fell back to the hardcoded 0.85/0.4 it was meant to replace.
+    # Fixed to mirror the working call in synthesize_property_workflow_legacy
+    # (workflow_source/steps_count/has_db_validation/unique_sources), and to
+    # read the `.overall` attribute of the ConfidenceBreakdown dataclass
+    # (it is NOT a dict — `.get()` never existed on it).
     from backend.services.rag.confidence import calculate_subgraph_confidence
 
+    has_zoning = "error" not in zoning
+    kg_sources = state.get("kg_sources_used", 0)
     breakdown = calculate_subgraph_confidence(
-        chains=state.get("kg_chains", []),
-        entities=state.get("resolved_entities", []),
-        query=state.get("query", ""),
+        workflow_source="property_subgraph",
+        steps_count=len(reqs),
+        has_db_validation=has_zoning,
+        unique_sources=max(1, kg_sources),
     )
-    confidence = breakdown.get("final_score", 0.85 if "error" not in zoning else 0.4)
+    confidence = breakdown.overall
 
     return {"final_analysis": analysis, "confidence_score": confidence}
 

--- a/apps/backend-rag/backend/tests/unit/services/rag/test_kg_subgraph_property.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/test_kg_subgraph_property.py
@@ -377,30 +377,57 @@ class TestGetPropertyRequirements:
 
 
 class TestSynthesizePropertyWorkflow:
+    # NOTE (2026-06-14): these tests previously mocked
+    # calculate_subgraph_confidence with a return_value of {"final_score": ...}
+    # (a dict). That mock HID a real bug — the production call passed
+    # chains=/entities=/query= (wrong signature → TypeError) and read
+    # breakdown.get("final_score") (ConfidenceBreakdown is a dataclass, no
+    # .get). Both were masked because the mock swallowed the bad kwargs and
+    # the dict happened to support .get(). The tests below now exercise the
+    # REAL confidence function (no mock) so the call contract is enforced.
+
     @pytest.mark.asyncio
-    async def test_with_error(self, base_state):
+    async def test_with_error_uses_real_confidence(self, base_state):
         base_state["zoning_info"] = {"error": "No data"}
         base_state["workflow_steps"] = ["Step 1", "Step 2"]
 
-        with patch(
-            "backend.services.rag.confidence.calculate_subgraph_confidence",
-            return_value={"final_score": 0.4},
-        ):
-            result = await synthesize_property_workflow(base_state, {})
+        # No mock: if the call signature regresses, this raises TypeError.
+        result = await synthesize_property_workflow(base_state, {})
         assert "couldn't retrieve" in result["final_analysis"].lower()
+        # Dynamic confidence is a real float in [0, 1], not the hardcoded
+        # fallback that the old TypeError path produced.
+        assert isinstance(result["confidence_score"], float)
+        assert 0.0 <= result["confidence_score"] <= 1.0
 
     @pytest.mark.asyncio
-    async def test_with_valid_zoning(self, base_state):
+    async def test_with_valid_zoning_uses_real_confidence(self, base_state):
         base_state["zoning_info"] = {"zoning_type": "R-1", "district_name": "Badung"}
         base_state["workflow_steps"] = ["Req 1", "Req 2"]
 
-        with patch(
-            "backend.services.rag.confidence.calculate_subgraph_confidence",
-            return_value={"final_score": 0.85},
-        ):
-            result = await synthesize_property_workflow(base_state, {})
+        result = await synthesize_property_workflow(base_state, {})
         assert "R-1" in result["final_analysis"]
-        assert result["confidence_score"] > 0
+        assert isinstance(result["confidence_score"], float)
+        assert 0.0 < result["confidence_score"] <= 1.0
+
+    @pytest.mark.asyncio
+    async def test_confidence_reflects_db_validation(self, base_state):
+        """has_db_validation flips on real zoning → higher entity_conf → score
+        differs from the error case. Proves the value is DYNAMIC, not the old
+        hardcoded 0.85/0.4 fallback."""
+        base_state["workflow_steps"] = ["Req 1", "Req 2"]
+
+        base_state["zoning_info"] = {"zoning_type": "R-1", "district_name": "Badung"}
+        valid = (await synthesize_property_workflow(base_state, {}))["confidence_score"]
+
+        base_state["zoning_info"] = {"error": "No data"}
+        errored = (await synthesize_property_workflow(base_state, {}))["confidence_score"]
+
+        # Valid zoning has has_db_validation=True → entity_conf 0.8 vs 0.5,
+        # so the dynamic score must be strictly higher. If both were the old
+        # hardcoded fallback this would still differ (0.85 vs 0.4) — so also
+        # assert neither equals those exact legacy constants.
+        assert valid > errored
+        assert valid != 0.85 and errored != 0.4
 
 
 # ============================================================================


### PR DESCRIPTION
## The bug (found during Mythos M1 audit, out-of-scope there)

`synthesize_property_workflow` in `kg_subgraph_property.py:388` called `calculate_subgraph_confidence(chains=, entities=, query=)` — **not the function signature** (`workflow_source/steps_count/has_db_validation/unique_sources`). Every call raised `TypeError: unexpected keyword argument 'chains'` and silently fell into the `except`/fallback, returning the **hardcoded 0.85/0.4** the dynamic-confidence code was written to replace. The anti-hardcoding antibody restored the exact hardcoded values it was removing.

Second bug: it read `breakdown.get("final_score")`, but `ConfidenceBreakdown` is a **dataclass** — `.get()` never existed on it.

## Fix

Mirrors the working sibling call (`synthesize_property_workflow_legacy:600`, always correct):
- `workflow_source="property_subgraph"`, `steps_count=len(reqs)`, `has_db_validation=("error" not in zoning)`, `unique_sources=max(1, kg_sources_used)`
- read `breakdown.overall`

## Why it survived (the interesting part)

The two existing tests **mocked** `calculate_subgraph_confidence` with `return_value={"final_score": ...}` (a dict) — masking BOTH the bad-kwargs TypeError AND the `.get`-on-dataclass error. Classic green-but-broken from a mock unfaithful to the real signature.

Rewrote them to exercise the **real** confidence function (no mock), so the call contract is enforced. Added `test_confidence_reflects_db_validation` proving the score is dynamic (valid zoning > error case, neither equals the legacy 0.85/0.4).

## Verified
- Before/after: BEFORE raised `TypeError: unexpected keyword argument 'chains'`; AFTER `overall=0.67` (dynamic)
- 88 property/subgraph/confidence tests pass · import-chain OK · ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)