### PR TITLE
feat(intake): Mythos M4 — dead-bridge liveness alarm + opencv-headless + TAC report

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 325 routers · 608 services
+- Backend: FastAPI · 325 routers · 607 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 28 · Packages: 6

--- a/apps/backend-rag/requirements.txt
+++ b/apps/backend-rag/requirements.txt
@@ -133,6 +133,7 @@ openinference-instrumentation-openai>=0.1.45  # Auto-trace OpenAI-compat (DeepSe
 datasets>=2.19.0
 pandas>=2.0.0
 numpy>=2.0.0,<3.0.0  # Updated for compatibility with scipy/sklearn
+opencv-python-headless>=4.10.0  # intake OCR preprocess deskew/denoise (preprocess.py:18 promised "already in venv" but was missing; graceful-fallback to raw page when absent, Mythos M4 2026-06-14)
 psutil>=5.9.0  # Required by metrics module/tests
 
 # PDF Processing - UPGRADED

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`325 routers · 608 services · 1042 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`325 routers · 607 services · 1039 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/research/operations/2026-06-14-mythos-m4-intake-pipeline.md
+++ b/research/operations/2026-06-14-mythos-m4-intake-pipeline.md
@@ -1,0 +1,190 @@
+---
+date: 2026-06-14
+domain: operations
+client_case: false
+organ: intake-pipeline (digestive apparatus)
+session: Opus Mythos M4 (M5)
+sources:
+  - Postgres nuzantara_dev (Pro, read-only via 192.168.0.20)
+  - apps/backend-rag/backend/services/intake/{worker,stages,validate_rules,preprocess,classify}.py
+  - scripts/wa_mirror_{session_janitor,intake_sweeper}.py
+  - empirical OCR measurement (qwen2.5vl:7b / qwen3-vl:8b, synthetic non-PII docs)
+  - Gemini 3.5 Flash High (meta-pattern synthesis, meta-data only)
+  - DeepSeek V4 Pro (adversarial refuter, meta-data only)
+  - memories fix_wa_intake_p1_p3_done_p2_ocr_diagnosed_2026_06_09, decision_intake_catalog_v2_rollout, decision_smistamento_drive_crm, fix_intake_review_ui_shipped
+verdict_method: 4-LLM asymmetric panel (subagent fan-out → Gemini synthesis → DeepSeek refute → Opus gate ×2)
+---
+
+# Mythos M4 — TAC dell'apparato digerente (pipeline intake documenti)
+
+## §0 — Executive
+
+**Tesi di partenza:** "l'apparato mastica ma non digerisce" — worker che abbandonano job,
+OCR che fallisce 1 pagina su 3, backlog che cresce inutile.
+
+**Verdetto:** la tesi è **superata dai fatti**. Il malato-primario delle memorie (lease-orphan,
+backlog 1934 stuck) è **strutturalmente curato** (PR #1299). La coda è SANA: 1694 done, 0
+processing, 0 lease orfani. L'OCR **non fallisce** sul modello (misurato: 0/5 empty su doc pulito
+E degradato). Il backlog è **drenato**.
+
+Ma sotto la salute apparente c'è il vero reperto — un **meta-pattern di 2° ordine** (§Meta-pattern):
+l'organismo **degrada in silenzio e non rende osservabile la divergenza tra ciò che la config
+dichiara e ciò che la realtà fisica è**. Non "mastica ma non digerisce" — piuttosto *"digerisce
+bene, ma se smettesse di farlo non te ne accorgeresti"*.
+
+**Cosa è stato curato in questa sessione** (PR su `agent/air-m5/cell/mythos-m4-intake`):
+1. **Antibody dead-bridge alarm** — chiude il buco "intake cieco indistinguibile da linea quieta".
+2. **opencv-python-headless** in requirements — mantiene una promessa che il codice già si faceva.
+
+**Cosa NON è stato fatto (confine operatore, §Solo-operatore):** armare il watcher Drive (backfill
+ancora in corso), flippare `INTAKE_WRITER_ENABLED`, rimuovere `INTAKE_CONCURRENCY=3` dal plist HOME
+del Pro, re-link QR di bridge loggati-out.
+
+---
+
+## §1 — Organo A: Worker / lease (la peristalsi) — FIXED
+
+Memoria 2026-06-09: il worker abbandonava job in `processing`, lease_owner vuoto, 40 stuck, nessun
+reclaim → backlog mai drenato. **Era il malato-primario.**
+
+**Verificato ORA (disco + PG, 2 round):** strutturalmente curato da **PR #1299** (`b24c64ce3`,
+"flow v2 — lease-only worker"). sha256 deploy worker.py == main (`d4d727ee…`).
+- **Claim** (`worker.py:560-599`): l'`UPDATE` scrive SOLO `lease_owner`+`lease_expires_at`. Lo
+  `status` resta il cursore-di-stage, mai toccato dal claim. `FOR UPDATE SKIP LOCKED`.
+- **Reclaim intrinseco** (`worker.py:578`): il predicato del claim include
+  `(lease_owner IS NULL OR lease_expires_at < now())` → un lease scaduto è auto-ri-claimabile allo
+  stesso stage. TTL 900s + heartbeat 120s → finestra orfano ≤15min, zero janitor necessario.
+- **Live:** 0 processing, 0 righe con lease, 1694 done. Boot-remap (`remap_legacy_statuses`) ha
+  ritirato gli status legacy v1.
+
+**Caveat (non bug di correttezza):** `INTAKE_CONCURRENCY=3` nel plist HOME del Pro è **config morta**
+— zero consumer nel backend (grep verificato da me), `flock` single-instance → drena **serialmente,
+1 job alla volta**. Il `3` mente sul parallelismo. → §Solo-operatore.
+
+---
+
+## §2 — Organo B: OCR (gli enzimi) — il "fallimento" era LATENZA, non rottura
+
+Memorie: primario qwen3-vl:8b "fallisce con errore vuoto" → cascata a qwen2.5vl:7b (~170s/job);
+empty-page ~30%; cv2 mancante.
+
+**Misurato empiricamente (Law 2: doc sintetici non-PII, OCR locale sul Pro):**
+- Doc **pulito**, 5×: qwen2.5vl:7b → **0/5 empty, 0 errori** (~5s/call). qwen3-vl:8b → **0/5 empty,
+  0 errori** (~25-46s/call). → "qwen3-vl fails" **FALSIFICATO** su input pulito.
+- Il vero motivo per cui qwen2.5vl è primario: **latenza 5×**, non un guasto. Il deploy
+  MODEL_TOPOLOGY ha già `ocr_vision=qwen2.5vl:7b` (= il "v2.2-ocrfix" runtime, non un commit git).
+- Doc **degradato** (skew 7°, contrasto -45%, blur 1.2px — peggio di una foto WA media):
+  qwen2.5vl RAW (senza cv2) → **score 5/5 token chiave**. Il VLM moderno fa internamente ciò che
+  cv2 deskew+threshold faceva per Tesseract.
+
+**Conclusione OCR:** l'empty-page ~30% reale è **(B) scansioni genuinamente illeggibili/vuote**
+(retro bianchi, foto fuori fuoco oltre il recuperabile) — un problema di *input upstream*, non
+dell'enzima. **cv2 è quasi-cosmetico** per l'intake (nessun path Tesseract nell'intake — verificato;
+solo in `core/parsers.py` e crm_guardian, fuori dal path intake). Lo installo come **hedge
+low-effort** che mantiene la promessa del docstring (`preprocess.py:18` dichiara verbatim
+"opencv-python-headless *already in the venv*" — promessa rotta, ora mantenuta), **non** come fix
+load-bearing.
+
+---
+
+## §3 — Organo D: Backfill (il bolo arretrato) — RUNNING, non finito
+
+- **Dropbox→Drive copy-only backfill (527 GiB):** rclone **PID 2781 vivo** (verificato 2 volte),
+  ~47% di un denominatore ancora in crescita (`--fast-list` sta ancora scoprendo il corpus), retry
+  pass dopo 22k errori transienti (Google rate-limit sotto bwlimit 4M). L'ETA "oggi" era ottimista.
+- **Dead job (1):** id 2127, `intake-v1` legacy, morto in `validate` su
+  `RuntimeError('QDRANT_URL/API_KEY not set; cannot validate KBLI')`. Lo stage validate **è ancora
+  vivo in v2** (`stages.py:67`), ma i 1694 done v2 non muoiono lì → QDRANT *è* settato in prod; è un
+  tombstone legacy, non un incendio attivo.
+- **6 review_pending:** fixtures `test-5b` (source=drive, doc_type=npwp), attempts=0, mai actionate
+  da adit. Rumore di test, non stuck.
+
+---
+
+## §4 — Organo E: Watcher Drive (una nuova bocca) — NON armare (confine operatore)
+
+- Watcher `com.balizero.drive-intake-drain` **non armato** (plist assente — corretto by-design).
+- Fail-safe verificati nel codice: `drive_adapter.py:153-159` rifiuta senza
+  `INTAKE_DRIVE_SCOPE_FOLDER_ID`; il cursor si semina a "now" (`get_start_page_token`) → arma SOLO i
+  file NUOVI da arm-time. **Ma durante il backfill, ogni file copiato È un nuovo change Drive** → il
+  fail-safe NON protegge: armare ora = flood storico (~170s/job = mesi).
+- **Scope folder id risolto:** `1LjJjBdJZ115Iyu_Bthl-PVC2XKlXRDrF` (`Dropbox-Intake/`).
+- **Verdetto: WAIT.** Armare quando: `ps aux | grep '[r]clone copy dropbox-bayu'` vuoto + un tick
+  delta-only `copied=0` + `dropbox_intake.last.json status:ok`. → §Solo-operatore.
+
+---
+
+## §Meta-pattern — la malattia-delle-malattie (il vero topic)
+
+**Convinzione difettosa che genera l'intera famiglia:**
+
+> *L'organismo degrada in silenzio e tratta la divergenza tra config-dichiarata e realtà-fisica come
+> non-osservabile. Ogni organo "mente per omissione": fa una promessa (config, docstring, status DB)
+> che la realtà contraddice, senza renderlo visibile all'operatore — che vive in un modello mentale
+> falso dello stato vero della pipeline.*
+
+**3 evidenze trasversali (organi diversi, stessa cecità):**
+1. **Worker:** `INTAKE_CONCURRENCY=3` promette parallelismo 3× che il `flock` rende seriale (1×). La
+   config mente, in silenzio.
+2. **OCR:** `preprocess.py:18` dichiara "opencv-python-headless *already in the venv*" — ma manca. Il
+   codice asserisce come fatto qualcosa di falso; il fallback graceful inghiotte la discrepanza con
+   un `logger.warning` che nessuno legge.
+3. **Mouth:** un bridge WhatsApp morto e una linea quieta producono il **sintomo identico** ("no new
+   media"). La pipeline non ha modo di distinguere "non arriva cibo" da "la bocca è paralizzata".
+
+**Raffinamento dal panel (asimmetrico, non consenso):** Gemini ha proposto come meta-pattern
+"silent degradation" + cura "halt at boot / ban graceful continuation". **DeepSeek (refuter) l'ha
+demolito**, e io ho confermato a gate-2: (a) la "silent degradation" del cv2 NON è la malattia — è
+un fallback *corretto* (5/5 raw misurato); lumarlo cogli altri è *category inflation*; (b) la cura
+"halt at boot" **viola Law 6** (sovranità locale: la disconnessione è stato naturale, non guasto) —
+un boot-assert sull'upstream trasformerebbe ogni blip di rete in un kill totale del nodo.
+
+**Contromisura strutturale corretta (NON "halt"):** *rendere ESPLICITE e MONITORABILI le divergenze
+config↔realtà, senza sacrificare il degraded-mode quando è sicuro.* Concretamente:
+- divergenza config↔codice (concurrency) → o si cabla o si rimuove l'env che mente;
+- dipendenza opzionale mancante (cv2) → fallback graceful + dichiararlo nei requirements;
+- canale esterno morto (bridge) → **runtime probe + alarm osservabile**, MAI boot-halt.
+
+---
+
+## §Terapia eseguita (cura-mentre-diagnostico — verificata live)
+
+**PR `agent/air-m5/cell/mythos-m4-intake` (commit 92bf5f536):**
+
+1. **`scripts/wa_mirror_bridge_liveness_alarm.py`** (NUOVO, 265 righe) — l'antibody mouth.
+   Runtime probe Law-6-safe (NON boot-assert): allerta l'operatore via Telegram SOLO quando un
+   bridge che il DB crede `connected` ha il processo morto **AND** stale oltre 20min di grace
+   **AND** è orario di lavoro WITA (8-20). Cooldown 120min/account anti-spam. Riusa il pattern
+   PID-liveness di `wa_mirror_session_janitor.py` + il pattern Telegram di `drive_token_watchdog.py`.
+   **Verificato live sul Pro:** gira contro il DB reale (1 bridge `sahira` connected+vivo → 0 falsi
+   positivi); logica testata ramo-per-ramo (business-hours True@11h/False@3h, liveness su processo
+   inesistente=False, config corretta). Chiude esattamente il buco "intake cieco = linea quieta".
+   → **Da installare** come LaunchAgent (StartInterval 300, parità sweeper) — §Solo-operatore.
+
+2. **`opencv-python-headless>=4.10.0`** in `apps/backend-rag/requirements.txt` — mantiene la
+   promessa di `preprocess.py:18`. Hedge low-effort; entra nel deploy venv al prossimo build.
+
+**NON curato di proposito (declassato dal panel):**
+- cv2 come fix dell'empty-page → l'A/B prova che NON muove l'ago (5/5 raw). Cosmetico.
+- preflight env-var hard-fail QDRANT → DeepSeek lo indicava #1, ma il gate-2 mostra che in prod
+  QDRANT *è* settato (1694 done v2) → guardia difensiva, non emergenza. Lasciato come nota.
+
+---
+
+## §Solo-operatore (il confine — azione fisica / decisione Zero)
+
+1. **Armare il watcher Drive** — solo quando il backfill 527GiB è finito (oggi NO, rclone PID 2781
+   vivo). Comando, sul Pro: `cd ~/Desktop/nuzantara && bash infra/launchagents/install_drive_intake.sh 1LjJjBdJZ115Iyu_Bthl-PVC2XKlXRDrF` + fire-test E2E (drop doc → kita/review). Re-check giornaliero.
+2. **Installare l'antibody dead-bridge** come LaunchAgent sul Pro (StartInterval 300) +
+   `TELEGRAM_BOT_TOKEN` nell'env del plist. La PR porta lo script; l'install è runtime Pro.
+3. **`INTAKE_CONCURRENCY=3`** nel plist HOME del Pro (`~/Library/LaunchAgents/com.nuzantara.intake-worker.plist`)
+   — config che mente. Decisione: o cablare un vero pool (rischio: parallelismo non testato), o
+   **rimuovere l'env** (più sicuro: allinea promessa a realtà seriale). Non in repo, è drift Pro-only.
+4. **`INTAKE_WRITER_ENABLED`** resta OFF (dry-run) finché Adit valida il review flow — decisione Zero.
+5. **Re-link QR** bridge loggati-out (sahira è tornato connected; vino/ari deferred) — azione fisica.
+
+---
+
+> Metodo: subagent fan-out (4, 1 morto su session-limit→rifatto) → gate-Opus round 1 → Gemini 3.5
+> Flash High synthesis (meta-data only) → DeepSeek V4 Pro refuter (meta-data only) → gate-Opus round
+> 2 → cura verificata live. Zero contenuto-documento è uscito dal Pro (Law 2). OCR misurato in locale.

--- a/scripts/wa_mirror_bridge_liveness_alarm.py
+++ b/scripts/wa_mirror_bridge_liveness_alarm.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""wa-mirror bridge-liveness ALARM — the antibody for the silent-paralysis gap.
+
+The intake mouth has a blind spot (Mythos M4, 2026-06-14): when no new client
+media is enqueued, the pipeline cannot tell "no food is arriving" (benign quiet)
+from "the WhatsApp bridge is paralyzed" (a dead intake channel). The
+``wa_mirror_session_janitor`` *cleans* the ghost DB row but says nothing to the
+operator — so a dead bridge during business hours is silently indistinguishable
+from a quiet line.
+
+This probe closes that gap WITHOUT violating Law 6 (local sovereignty:
+disconnection is a natural state, not a fault). It is a **periodic runtime
+probe**, never a boot-assert: it does not block startup, it does not halt the
+node on a missing peer. It only *escalates an observable alarm* when a bridge
+that the DB believes is ``connected`` has a dead process AND has been stale past
+a grace window AND we are inside business hours WITA — i.e. exactly the window
+where "no media" should mean "the team is working", so silence is suspicious.
+
+Design (mirrors ``wa_mirror_session_janitor`` deliberately — reuse, not reinvent):
+  * Liveness signal = same PID-file + ``pgrep --employee=<name>`` check.
+  * A bridge is ALARMING only if ALL hold:
+      1. its DB row status is ``connected`` (the system *believes* it is up), AND
+      2. no live bridge process for that account, AND
+      3. ``last_seen_at`` older than ``WA_LIVENESS_GRACE_MINUTES`` (default 20)
+         — generous, so a routine restart / brief network blip never fires, AND
+      4. now is within business hours WITA (``WA_LIVENESS_BUSINESS_START``..``END``,
+         default 08..20) — outside hours, a dead bridge is expected (overnight).
+  * Cooldown: one alarm per (account) per ``WA_LIVENESS_COOLDOWN_MINUTES``
+    (default 120) via a state file, so a persistently-dead bridge does not spam.
+
+Read-only on the DB (no UPDATE — the janitor owns state mutation; this only
+observes). Cron-tick shim (flock single-instance), local DB only, no PII leaves
+the Pro (only an account name + e164 + timestamp go to the owner's Telegram —
+the same metadata the existing watchdogs already send).
+
+Env:
+  WA_MIRROR_DATABASE_URL        (default postgresql://nuzantara@localhost:5432/nuzantara_dev)
+  WA_LIVENESS_GRACE_MINUTES     (default 20)
+  WA_LIVENESS_COOLDOWN_MINUTES  (default 120)
+  WA_LIVENESS_BUSINESS_START    (default 8,  WITA hour)
+  WA_LIVENESS_BUSINESS_END      (default 20, WITA hour)
+  TELEGRAM_BOT_TOKEN            (from env or ~/.cell-bridge-state/*.env)
+  WA_LIVENESS_DRY_RUN=1         (print instead of send)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import fcntl
+import json
+import logging
+import os
+import subprocess
+import sys
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import asyncpg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+)
+logger = logging.getLogger("wa_liveness_alarm")
+
+STATE_DIR = Path.home() / ".cell-bridge-state"
+LOCK_FILE = STATE_DIR / "wa_liveness_alarm.lock"
+COOLDOWN_STATE = STATE_DIR / "wa_liveness_alarm.cooldown.json"
+PID_DIR = Path("/tmp/wa-mirror-pids")
+ACCOUNTS_JSON = Path.home() / ".wa-mirror.accounts.json"
+
+WITA = ZoneInfo("Asia/Makassar")
+TELEGRAM_OWNER_CHAT_ID = "1125336968"  # Zero — per CLAUDE.md §13 / drive_token_watchdog parity
+
+_GRACE_MIN = int(os.getenv("WA_LIVENESS_GRACE_MINUTES", "20"))
+_COOLDOWN_MIN = int(os.getenv("WA_LIVENESS_COOLDOWN_MINUTES", "120"))
+_BIZ_START = int(os.getenv("WA_LIVENESS_BUSINESS_START", "8"))
+_BIZ_END = int(os.getenv("WA_LIVENESS_BUSINESS_END", "20"))
+_DRY_RUN = os.getenv("WA_LIVENESS_DRY_RUN", "") == "1"
+
+_LOCK_FD: int | None = None
+
+
+def _acquire_lock_or_exit() -> None:
+    STATE_DIR.mkdir(exist_ok=True)
+    fd = os.open(str(LOCK_FILE), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        logger.info("[wa_liveness] another instance running, skipping tick")
+        os.close(fd)
+        sys.exit(0)
+    global _LOCK_FD
+    _LOCK_FD = fd
+
+
+def _db_url() -> str:
+    return os.getenv("WA_MIRROR_DATABASE_URL", "") or "postgresql://nuzantara@localhost:5432/nuzantara_dev"
+
+
+def _bot_token() -> str:
+    tok = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+    if tok:
+        return tok
+    # Parity with the durable-secret env-file convention (PR #1208).
+    for envf in (STATE_DIR / "wa-media.env", STATE_DIR / "intake.env"):
+        try:
+            for line in envf.read_text().splitlines():
+                if line.startswith("TELEGRAM_BOT_TOKEN="):
+                    return line.split("=", 1)[1].strip().strip('"').strip("'")
+        except OSError:
+            continue
+    return ""
+
+
+def _phone_to_name() -> dict[str, str]:
+    try:
+        data = json.loads(ACCOUNTS_JSON.read_text())
+    except (OSError, ValueError) as exc:
+        logger.warning("[wa_liveness] accounts file unreadable (%s)", exc)
+        return {}
+    accounts = data.get("accounts", data if isinstance(data, list) else [])
+    out: dict[str, str] = {}
+    for a in accounts:
+        phone = a.get("phone") or a.get("e164")
+        name = a.get("name")
+        if phone and name:
+            out[phone] = name.lower()
+    return out
+
+
+def _bridge_alive(name: str) -> bool:
+    """Same liveness check as the janitor: PID file then pgrep --employee."""
+    pidfile = PID_DIR / name
+    try:
+        pid = int(pidfile.read_text().strip())
+        os.kill(pid, 0)
+        return True
+    except (OSError, ValueError):
+        pass
+    try:
+        res = subprocess.run(
+            ["pgrep", "-f", f"--employee={name}"],
+            capture_output=True, text=True, timeout=5,
+        )
+        return res.returncode == 0 and bool(res.stdout.strip())
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def _in_business_hours(now: dt.datetime) -> bool:
+    return _BIZ_START <= now.hour < _BIZ_END
+
+
+def _load_cooldown() -> dict[str, float]:
+    try:
+        return json.loads(COOLDOWN_STATE.read_text())
+    except (OSError, ValueError):
+        return {}
+
+
+def _save_cooldown(state: dict[str, float]) -> None:
+    try:
+        COOLDOWN_STATE.write_text(json.dumps(state))
+    except OSError as exc:
+        logger.warning("[wa_liveness] cooldown state write failed: %s", exc)
+
+
+def _send_telegram(text: str) -> bool:
+    if _DRY_RUN:
+        print(f"[DRY RUN] Telegram: {text}")
+        return True
+    token = _bot_token()
+    if not token:
+        logger.warning("[wa_liveness] TELEGRAM_BOT_TOKEN not found; cannot alert")
+        return False
+    try:
+        data = urllib.parse.urlencode(
+            {"chat_id": TELEGRAM_OWNER_CHAT_ID, "text": text, "parse_mode": "HTML"}
+        ).encode()
+        urllib.request.urlopen(
+            f"https://api.telegram.org/bot{token}/sendMessage", data, timeout=10
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[wa_liveness] telegram send failed: %s", exc)
+        return False
+
+
+async def _run(now: dt.datetime) -> int:
+    if not _in_business_hours(now):
+        logger.info("[wa_liveness] outside business hours WITA (%02d:00); a dead bridge is expected, no alarm", now.hour)
+        return 0
+
+    name_map = _phone_to_name()
+    conn = await asyncpg.connect(_db_url())
+    try:
+        rows = await conn.fetch(
+            """
+            SELECT id, team_member_name, team_member_phone, last_seen_at,
+                   (last_seen_at IS NULL
+                    OR last_seen_at < now() - ($1::int * interval '1 minute')) AS past_grace
+            FROM whatsapp_team_sessions
+            WHERE status = 'connected'
+            """,
+            _GRACE_MIN,
+        )
+    finally:
+        await conn.close()
+
+    cooldown = _load_cooldown()
+    now_ts = now.timestamp()
+    alarmed = 0
+
+    for r in rows:
+        name = (r["team_member_name"] or name_map.get(r["team_member_phone"] or "", "")).lower()
+        if not name:
+            continue
+        if _bridge_alive(name):
+            continue  # healthy — the common case
+        if not r["past_grace"]:
+            continue  # dead but within grace (routine restart / blip) — stay quiet
+
+        # DB says connected, process is dead, past grace, business hours → PARALYSIS.
+        last_alarm = cooldown.get(name, 0.0)
+        if now_ts - last_alarm < _COOLDOWN_MIN * 60:
+            logger.info("[wa_liveness] %s still dead but within cooldown; not re-alerting", name)
+            continue
+
+        phone = r["team_member_phone"] or "?"
+        last_seen = r["last_seen_at"].astimezone(WITA).strftime("%Y-%m-%d %H:%M WITA") if r["last_seen_at"] else "never"
+        msg = (
+            f"🔴 <b>WA bridge PARALIZZATO</b>\n"
+            f"Account: <b>{name}</b> ({phone})\n"
+            f"Il DB lo crede <code>connected</code> ma il processo è MORTO da &gt;{_GRACE_MIN}min "
+            f"(ultimo segnale: {last_seen}).\n"
+            f"Durante orario di lavoro = intake CIECO su questa linea, non quiete.\n"
+            f"Re-link: <code>bash ~/scripts/wa-mirror-launcher/start-one.sh {name} --qr</code>"
+        )
+        if _send_telegram(msg):
+            cooldown[name] = now_ts
+            alarmed += 1
+            logger.info("[wa_liveness] ALARM sent for %s (dead, past grace, business hours)", name)
+
+    if alarmed == 0:
+        logger.info("[wa_liveness] all 'connected' bridges alive (or within grace/cooldown); active=%d", len(rows))
+    _save_cooldown(cooldown)
+    return alarmed
+
+
+def main() -> None:
+    _acquire_lock_or_exit()
+    try:
+        now = dt.datetime.now(WITA)
+        asyncio.run(_run(now))
+    finally:
+        if _LOCK_FD is not None:
+            os.close(_LOCK_FD)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Mythos M4 — TAC dell'apparato digerente (intake pipeline)

Forensic audit (4-LLM asymmetric panel: subagent fan-out → Gemini synthesis → DeepSeek refuter → Opus gate ×2). Full report: `research/operations/2026-06-14-mythos-m4-intake-pipeline.md`.

### Findings (verified on-disk/PG, 2 gate rounds)
- **Worker/lease**: lease-orphan (the 2026-06-09 "primary patient") is **structurally FIXED** (PR #1299). 0 orphan leases, 1694 done, queue healthy.
- **OCR**: "qwen3-vl fails" **FALSIFIED** — empirical 5× on clean AND degraded synthetic docs (Law 2, local) → both models 0/5 empty. qwen2.5vl primary was a **latency** choice (5×), not a failure fix. cv2 quasi-cosmetic (VLM robust to skew/blur).
- **Backfill**: rclone still running (527 GiB) → Drive watcher correctly **NOT armed** (operator action when done).

### Meta-pattern (the real topic)
The organism **degrades silently and does not make config-vs-reality divergence observable**: `INTAKE_CONCURRENCY=3` that's really 1, `preprocess.py:18` claiming opencv "already in venv" when missing, a dead bridge indistinguishable from a quiet line. DeepSeek refuted Gemini's "halt at boot" cure as a **Law-6 violation** (would turn a network blip into a total node kill).

### Cure in this PR
1. **`scripts/wa_mirror_bridge_liveness_alarm.py`** — runtime probe (NOT boot-assert, Law-6-safe) that alerts the operator when a DB-`connected` bridge has a dead process past 20min grace during business hours WITA. Closes the silent-paralysis gap. **Verified live** on Pro (0 false positives; branch logic unit-tested). Reuses the janitor PID-liveness + watchdog Telegram patterns.
2. **`opencv-python-headless>=4.10.0`** in requirements — keeps the promise `preprocess.py:18` already made; graceful-fallback when absent.

### Operator (not in this PR)
Install the alarm as a LaunchAgent (StartInterval 300); arm Drive watcher post-backfill (folder `1LjJjBdJZ115Iyu_Bthl-PVC2XKlXRDrF`); decide on `INTAKE_CONCURRENCY` plist drift; keep `INTAKE_WRITER_ENABLED` OFF until Adit validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)