### PR TITLE
feat(repo-hygiene): ignore generated dirty-tree debris

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -638,6 +638,9 @@ scripts/.rag_canary/
 .ai-dispatch-cache/
 
 # Data exports and snapshots
+/outputs/
+apps/evaluator/nlm_deep_research/output/multimodal/
+research/coherence-corpus/
 data/exports/
 data/kbli_2025_export/
 data/scraping/


### PR DESCRIPTION
## Summary

- Verified the Spark lifecycle signal live: spark loop is running; alarm and harvester are healthy StartInterval jobs with last exit 0.
- Confirmed the actionable signal is the dirty root checkout, not a Spark LaunchAgent failure.
- Added narrow ignore rules for generated/local debris observed in the dirty root checkout: root `outputs/`, NLM multimodal artifacts, and local NotebookLM coherence-corpus exports.

## Root Checkout Classification

- Unsafe to touch from this branch: staged W70 sentinel/DLQ changes in `scripts/nuzantara-sentinel.py` and `scripts/dlq_autopilot.py` look like active operator/automation work.
- Likely intentional deliverables left visible: published articles, research reports, regulatory deltas, NLM scripts, cicatrix docs.
- Generated debris covered by this PR: 40 MB root `outputs/`, 171 MB NLM output tree with new multimodal audio, and 44 MB `research/coherence-corpus/` export corpus.

## Validation

- `git check-ignore -v outputs/clients_all.csv apps/evaluator/nlm_deep_research/output/multimodal/nb2/audio/20260614_nb2.m4a research/coherence-corpus/nb3-company-curated/_manifest.json` passes.
- `git check-ignore -v apps/evaluator/nlm_deep_research/output/nlm_bali_permits.md apps/mouth/src/content/articles/immigration/indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists.mdx research/regulatory/2026-06-14-delta.json scripts/nb_export_corpus.py` returns no ignored paths.
- `PYTHONPATH=. /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -c "from backend.app.dependencies import get_current_user; print('OK')"` passes.
- `PYTHONPATH=. /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m pytest backend/tests/services/rag/test_kg_langgraph.py backend/tests/services/rag/test_kg_subgraphs.py backend/tests/services/rag/test_confidence.py -q` passes: 91 passed, 1 warning.

## Operational Note

The first `gh pr create --body` attempt used an inline shell string with unescaped Markdown backticks. zsh interpolated those snippets, which triggered one `scripts/nuzantara-sentinel.py` run and one `scripts/dlq_autopilot.py` run at 02:16 WITA before the PR body was corrected with this file. The overnight branch remained clean afterward. No production deploy.
