### PR TITLE
docs(intel): promote orphaned regulatory-watcher deltas + nb-health reports (2026-06-10..15)

### DIFF
--- a/research/nb-health/2026-06-10-health.md
+++ b/research/nb-health/2026-06-10-health.md
@@ -1,0 +1,187 @@
+# NB Arsenal Health Report — 2026-06-10 (daily)
+
+> Mode B+C run by nb-curator agent. Read-only — no NB mutations.
+> Baseline comparison: 2026-06-09 (daily run, stored in agent memory).
+> Exact-URL deduplication pre-step: 0 removed today (deterministic, not reported here).
+
+---
+
+## Summary
+
+| Metric | Jun-09 | Jun-10 | Delta |
+|---|---|---|---|
+| Total notebooks (default profile) | 86 | **86** | 0 |
+| Total sources | 3,604 | **3,709** | **+105** |
+| Healthy (with sources, queryable) | 61 | **61** | 0 |
+| Stale (updated_at >30d) | 0 | **0** | 0 ✅ |
+| Empty (0 sources) | 25 | **25** | 0 |
+| Broken (timeout/error, has sources) | 0 | **0** | 0 ✅ |
+| New notebooks | 0 | 0 | 0 |
+
+**Overall health: EXCELLENT.** All tested NBs responded correctly. All NB-INTEL 5/5 healthy. All MATA GARUDA 4/4 healthy. Zero broken, zero stale.
+
+> ⚠️ **ANOMALY FLAGGED**: NB-3 jumped +90 sources overnight (193 → 283). See below.
+
+---
+
+## Source Count Changes Today (+105 total)
+
+| NB | UUID (prefix) | Jun-09 | Jun-10 | Delta | Notes |
+|---|---|---|---|---|---|
+| **NB-INTEL-AIResearch** | dc5d01cd | 410 | **423** | **+13** | Feeder ACTIVE day 4 — 04:00 WITA Jun 10 |
+| **NB-3: Company Setup** | 933509f9 | 193 | **283** | **+90** | 🚨 BATCH ADD — see anomaly section |
+| **NB-4: Tax & Fiscal** | d4b2eedb | 161 | **162** | **+1** | Organic (normal) |
+| **NB-1: Codebase & Arch** | f6ecd115 | 72 | **73** | **+1** | Organic (normal) |
+
+All other NBs: sources unchanged.
+
+---
+
+## 🚨 Anomaly: NB-3 Batch Add (+90 sources)
+
+- **NB**: NB-3: Company Setup — Indonesia 2025 (`933509f9-1561-403d-bd44-4a7a67a36df2`)
+- **Change**: 193 → 283 sources (+90 in one batch)
+- **Timestamp**: `2026-06-09T19:28:58Z` = June 10 03:28 WITA (overnight, before feeder run at 04:00 WITA)
+- **Health**: ✅ QUERYABLE — NB responded with coherent detail about PT PMA setup, OSS-RBA, KBLI 2025, PP 28/2025 requirements
+- **Pattern**: Batch update at 03:28 WITA suggests a scheduled cron or manual bulk add. NB-1 also updated at same timestamp (03:28 WITA, +1 source), suggesting same pipeline.
+- **Action**: No action required (NB is healthy). Operator may wish to verify source origin if unexpected.
+
+---
+
+## NB-INTEL Family — Status ✅
+
+All 5 NB-INTEL queryable and healthy. Feeder ACTIVE for AIResearch only (day 4).
+
+| NB | UUID | Jun-09 | Jun-10 | Delta | Status | Stale Alarm |
+|---|---|---|---|---|---|---|
+| INTEL-AIResearch | dc5d01cd | 410 | **423** | +13 | ✅ Healthy — feeder active | 2026-07-10 (30d, RESET) |
+| INTEL-Press | 9d262101 | 216 | **216** | 0 | ✅ Healthy | 2026-06-24 (14d) |
+| INTEL-Immigration | 1ed02e54 | 80 | **80** | 0 | ✅ Healthy | 2026-06-22 (**12d ⚠️**) |
+| INTEL-Regulation | a17f134e | 41 | **41** | 0 | ✅ Healthy | 2026-06-22 (**12d ⚠️**) |
+| INTEL-Tax | 7fb12c9c | 17 | **17** | 0 | ✅ Healthy | 2026-06-22 (**12d ⚠️**) |
+
+**⚠️ Stale alarm approaching**: Immigration, Regulation, Tax hit stale threshold in **12 days (2026-06-22)**.
+Action needed before that date: restart `bali-intel-scraper` cron on Mini for these 3 NB.
+
+---
+
+## MATA GARUDA Family — Status ✅
+
+All 4 healthy. Sources unchanged.
+
+| NB | UUID | Sources | Status |
+|---|---|---|---|
+| Self-Improving Agent Research | 5af11152 | 102 | ✅ Healthy |
+| Open Source Intel Tools | e00d497a | 89 | ✅ Healthy |
+| Self-Evolving Agent Research | 305f5f2e | 57 | ✅ Healthy |
+| Intelligence Architecture Research | 76de5123 | 51 | ✅ Healthy |
+
+---
+
+## Core Stack Health Summary
+
+Spot checks performed on key NBs:
+
+| NB | Sources | Query Result | Status |
+|---|---|---|---|
+| NB-1 Codebase | 73 | Coherent answer about v5.2.0 architecture, RAG, federation | ✅ Healthy |
+| NB-2 Immigration | 110 | Coherent answer about KITAS/KITAP, UU 63/2024, Golden Visa | ✅ Healthy |
+| NB-3 Company Setup | 283 | Coherent detail on PT PMA, OSS-RBA, PP 28/2025 (slow 1st try, ok 3rd) | ✅ Healthy* |
+| NB-4 Tax | 162 | Coherent answer on CoreTax, SPDN/SPLN, DJP compliance | ✅ Healthy |
+| NB-INTEL-AIResearch | 423 | Coherent answer on autonomous agents, world models, CTI | ✅ Healthy |
+| NB-INTEL-Press | 216 | Coherent press intelligence summary | ✅ Healthy |
+| NB-INTEL-Immigration | 80 | Coherent answer on 2026 visa updates | ✅ Healthy |
+| NB-INTEL-Regulation | 41 | Coherent answer on OSS-RBA, PP 28/2025 | ✅ Healthy |
+| NB-INTEL-Tax | 17 | Coherent answer on global min tax, treaty anti-abuse | ✅ Healthy |
+| MATA GARUDA Self-Improving | 102 | Coherent answer on autonomous agents & CTI | ✅ Healthy |
+
+*NB-3 timed out on first 2 attempts (60s timeout) — responded on 90s attempt. Likely indexing/reindexing the +90 new sources. Expected to fully normalize within hours.
+
+---
+
+## Mode C — NB-INTEL-Press Dedup Analysis
+
+**In-scope today**: Press (Monday daily pass). Other NB-INTEL (monthly, next first Monday = July 7).
+
+### Press Source Inventory
+
+| Category | Count | Notes |
+|---|---|---|
+| `nlm_feed_*.txt` (hash-named text) | 215 | All unique titles (8-char hex hash) — no title near-dups possible |
+| URL-sourced (Wikipedia) | 1 | "Neoregelia lillyae - Wikipedia" from `Special:Random` — anomaly |
+| **Total** | **216** | Stable (0 change today) |
+
+### Dedup Analysis
+
+**Near-dup title clusters (Levenshtein ≤3)**: ZERO
+- All 215 `nlm_feed_*.txt` files have unique hash suffixes → no title proximity
+- The 8-char hex naming scheme precludes title-based clustering
+
+**URL duplicates**: ZERO (only 1 URL-sourced entry in the entire NB)
+
+**Wikipedia anomaly** (persistent, 10+ days):
+
+```
+CLUSTER  Press  WIKI-001
+  keep:   (none — remove)
+  remove: b7a6ee97 "Neoregelia lillyae - Wikipedia" (en.wikipedia.org/wiki/Special:Random)
+  reason: random Wikipedia article, not press content — the feeder accidentally fetched a random wiki page
+  age:    present since at least 2026-05-25, created_at: null
+```
+
+**Summarization proposals** (topics ≥10 sources from one domain/week): NONE
+- All text sources are individually hash-named; no groupable topic clusters identifiable without content analysis
+- Note: `nlm_feed_*.txt` sources have `url: null` and `created_at: null` — date-based clustering not possible from metadata alone
+
+**Stale sources (>90d)**: INDETERMINATE — all `created_at: null` in API response. Cannot compute age from metadata.
+
+### Press Proposals Summary
+
+| # | Type | Target | Action |
+|---|---|---|---|
+| 1 | Remove anomaly | `b7a6ee97` "Neoregelia lillyae - Wikipedia" | `nlm source remove 9d262101-... b7a6ee97-...` |
+
+**Total new Press proposals today**: 1 (unchanged — same as previous 9+ days)
+
+---
+
+## Cumulative Dedup Proposals (all NBs)
+
+**Status: 24 proposals, UNCHANGED — 10th consecutive day**
+
+| NB | Cluster | Count | Type | Notes |
+|---|---|---|---|---|
+| NB-4 Tax | YT-DUP-01..13 | 13 | YouTube duplicate sources (9+2+2 structure) | Pending Antonello approval |
+| NB-INTEL-AIResearch | CLOUDFLARE-01..09 | 9 | Cloudflare-blocked pages (empty content) | Pending approval |
+| NB-INTEL-AIResearch | VERCEL-01..04 | 4 | Vercel error pages (empty content) | Pending approval |
+| NB-INTEL-Press | WIKI-001 | 1 | Random Wikipedia article | Pending approval |
+
+**Action**: These 24 proposals have been pending since 2026-05-31. Recommend Antonello review + approve/reject via `nlm source remove`. Reference: `2026-05-31-health.md` and `2026-05-30-health.md` for full cluster details.
+
+---
+
+## Gap Analysis (Routing Log — Last 7 Days)
+
+**Mode A queries: 1 call** (June 4: `doc-intake-phase2` for NB-3/NB-6/NB-2/NB-NIB-PMA)
+
+**NBs unqueried in last 7 days** (candidates for future review):
+- NB-0 Zantara, NB-0 Meta, NB-11, NB-12, NB-13, NB-HARARI, NB-DESIGN-AGENT
+- NB-7 Editorial, NB-8 Expat Life, NB-9 Research Lab
+- Most RESEARCH-AD-HOC (Labor Law, NIB PMA, Employment Regs, etc.)
+
+**Gap warnings from log**: 0 recurring gap_warnings in last 7 days (no web fallbacks triggered).
+
+---
+
+## Recommended Actions (Antonello, weekly review)
+
+- [ ] **URGENT (12d)**: Restart `bali-intel-scraper` cron for NB-INTEL-Immigration, NB-INTEL-Regulation, NB-INTEL-Tax before 2026-06-22 stale alarm
+- [ ] **REVIEW**: NB-3 gained +90 sources overnight (03:28 WITA Jun 10). Verify if expected (cron?) or accidental
+- [ ] **APPROVE/REJECT**: 24 pending removal proposals (10th day) — NB-4 YT dups + AIResearch Cloudflare/Vercel + Press Wikipedia
+- [ ] **OPTIONAL**: NB-3 was slow on queries today (90s+ to respond while indexing). Monitor if persists tomorrow
+
+---
+
+## Telegram Status
+
+**No Telegram sent**: broken=0, stale=0 (threshold: 3+ broken OR new gaps). Health excellent.

--- a/research/nb-health/2026-06-11-health.md
+++ b/research/nb-health/2026-06-11-health.md
@@ -1,0 +1,173 @@
+# NB Arsenal Health Report — 2026-06-11 (daily)
+
+> Mode B+C run by nb-curator agent. Read-only — no NB mutations.
+> Baseline comparison: 2026-06-10 (daily run, stored in agent memory).
+> Exact-URL deduplication pre-step: 0 removed today (deterministic, not reported here).
+
+---
+
+## Summary
+
+| Metric | Jun-10 | Jun-11 | Delta |
+|---|---|---|---|
+| Total notebooks (default profile) | 86 | **86** | 0 |
+| Total sources | 3,709 | **3,752** | **+43** |
+| Healthy (with sources, queryable) | 61 | **61** | 0 |
+| Stale (updated_at >30d) | 0 | **0** | 0 ✅ |
+| Empty (0 sources) | 25 | **25** | 0 |
+| Broken (timeout/error, has sources) | 0 | **0** | 0 ✅ |
+| New notebooks | 0 | 0 | 0 |
+
+**Overall health: EXCELLENT.** All tested NBs responded correctly. All NB-INTEL 5/5 healthy.
+All MATA GARUDA 4/4 healthy. Zero broken, zero stale.
+
+> ℹ️ **NOTE on updated_at timestamps**: The feeder runs at 04:00 WITA = 20:00 UTC Jun-10.
+> All new sources show `updated_at: 2026-06-10` (UTC) even though added in the Jun-11 WITA cycle.
+> This is expected — all deltas below are from today's feeder pass.
+
+---
+
+## Source Count Changes Today (+43 total)
+
+| NB | UUID (prefix) | Jun-10 | Jun-11 | Delta | Notes |
+|---|---|---|---|---|---|
+| **NB-INTEL-AIResearch** | dc5d01cd | 423 | **451** | **+28** | Feeder ACTIVE day 5 — 04:00 WITA |
+| **NB-INTEL-Press** | 9d262101 | 216 | **218** | **+2** | Feeder ACTIVE — 2 new feed articles |
+| **NB-5: Property & RE** | d9438180 | 142 | **144** | **+2** | Organic (normal) |
+| **NB-1: Codebase & Arch** | f6ecd115 | 73 | **75** | **+2** | Organic (normal) |
+| **NB-2: Immigration & Visa** | cff93ab0 | 110 | **111** | **+1** | Organic (normal) |
+| **NB-4: Tax & Fiscal** | d4b2eedb | 162 | **163** | **+1** | Organic (normal) |
+| **Other NBs** | various | — | — | **+7** | Distributed organic changes |
+
+All other core NBs: sources unchanged vs Jun-10.
+
+---
+
+## NB-INTEL Family — Status ✅
+
+All 5 NB-INTEL queryable and healthy. Feeder ACTIVE for AIResearch + Press (day 5 / day 1).
+
+| NB | UUID | Jun-10 | Jun-11 | Delta | Status | Stale Alarm |
+|---|---|---|---|---|---|---|
+| INTEL-AIResearch | dc5d01cd | 423 | **451** | +28 | ✅ Healthy — feeder active day 5 | **2026-07-11** (30d RESET) |
+| INTEL-Press | 9d262101 | 216 | **218** | +2 | ✅ Healthy — feeder active | **2026-07-11** (30d RESET) |
+| INTEL-Immigration | 1ed02e54 | 80 | **80** | 0 | ✅ Healthy | 2026-06-22 (**11d ⚠️**) |
+| INTEL-Regulation | a17f134e | 41 | **41** | 0 | ✅ Healthy | 2026-06-22 (**11d ⚠️**) |
+| INTEL-Tax | 7fb12c9c | 17 | **17** | 0 | ✅ Healthy | 2026-06-22 (**11d ⚠️**) |
+
+**⚠️ Stale alarm approaching**: Immigration, Regulation, Tax hit 30-day threshold in **11 days (2026-06-22)**.
+Action needed before that date: restart `bali-intel-scraper` cron on Mini for these 3 NB.
+
+**✅ Press stale alarm RESET**: Press got +2 new sources today → stale alarm reset to **2026-07-11** (30d).
+
+---
+
+## MATA GARUDA Family — Status ✅
+
+All 4 healthy. Sources unchanged.
+
+| NB | UUID | Sources | Status |
+|---|---|---|---|
+| Self-Improving Agent Research | 5af11152 | 102 | ✅ Healthy (spot-queried) |
+| Open Source Intel Tools | e00d497a | 89 | ✅ Healthy |
+| Self-Evolving Agent Research | 305f5f2e | 57 | ✅ Healthy |
+| Intelligence Architecture Research | 76de5123 | 51 | ✅ Healthy |
+
+---
+
+## Core NBs Spot-Checked
+
+| NB | UUID | Sources | Query Result |
+|---|---|---|---|
+| NB-INTEL-AIResearch | dc5d01cd | 451 | ✅ Coherent answer (agent architectures, world models, Palantir/Maltego) |
+| NB-INTEL-Press | 9d262101 | 218 | ✅ Coherent answer (economia, normative, visti, turismo Indonesia) |
+| NB-INTEL-Immigration | 1ed02e54 | 80 | ✅ Coherent answer (KITAS, Golden Visa, security checks Bali 2026) |
+| NB-INTEL-Regulation | a17f134e | 41 | ✅ Coherent answer (OSS-RBA, PP/2025, property investments) |
+| NB-INTEL-Tax | 7fb12c9c | 17 | ✅ Coherent answer (PER-6/PJ/2026, CoreTax, PMA tax compliance) |
+| NB-3 Company Setup | 933509f9 | 283 | ✅ Coherent answer (PT PMA, OSS-RBA, KBLI 2025, PP 28/2025) |
+| NB-4 Tax Core | d4b2eedb | 163 | ✅ Coherent answer (KUP, PMK, CoreTax ecosystem, SPDN/SPLN classification) |
+| MATA GARUDA Self-Improving | 5af11152 | 102 | ✅ Coherent answer (autonomous agent harnesses, CyberThreat Intel) |
+
+8/8 spot-checked = HEALTHY.
+
+---
+
+## Mode C — Press Dedup Analysis (daily)
+
+**Source inventory**: 218 total (+2 since Jun-10)
+- 215 `nlm_feed_*.txt` (automated feed files, all unique hash suffixes)
+- 3 named sources (manually added):
+  - `d1880940` — "BI: Investasi di Bali tetap menarik di tengah krisis geopolitik global" (Antara, legit)
+  - `18cc73f1` — "PBB Turun Tangan, Minta AS Cabut Kebijakan Imigrasi Jelang Piala Dunia" (legit)
+  - `b7a6ee97` — "Neoregelia lillyae - Wikipedia" (**anomaly, pending removal**)
+
+**New sources today**: 2 (nlm_feed_ff57915b.txt, nlm_feed_ff7a0245.txt — last in feed list)
+- Both are unique feed file names → 0 dedup proposals
+
+**Dedup results**:
+- Title duplicates (Levenshtein ≤ 3): **0 found** (all nlm_feed_*.txt names are hash-unique)
+- Near-dup pairs: **0 found**
+- Same-domain weekly bundles ≥10: not applicable (feed files have no extractable domain)
+- Summarization proposals (topics ≥10 sources/week): **0 new** (feed count too diffuse)
+
+### Standing Proposals (unchanged — 11th consecutive day)
+
+**Press**:
+| Cluster | Source ID | Title | Reason | Action |
+|---|---|---|---|---|
+| PRESS-ANOMALY-01 | `b7a6ee97` | "Neoregelia lillyae - Wikipedia" | Irrelevant plant taxonomy article — accidental ingestion | `nlm source rm b7a6ee97` from 9d262101 |
+
+---
+
+## All Open Proposals (24 total — 11th day unchanged)
+
+### NB-4 YouTube Dups (13 sources)
+
+These 13 YouTube sources have been proposed for 11 consecutive days. No action taken.
+Refer to health report 2026-05-30 for cluster detail.
+
+| Count | Type | Target NB | Status |
+|---|---|---|---|
+| 9+2+2 = 13 | YouTube URL clusters | NB-4 (d4b2eedb) | Pending Antonello review |
+
+### NB-INTEL-AIResearch Garbage (13 sources)
+
+Cloudflare (9) + Vercel (4) blocked/error-page sources. No content fetched.
+Refer to health report 2026-05-29 for cluster detail.
+
+| Count | Type | Target NB | Status |
+|---|---|---|---|
+| 9 | Cloudflare block pages | AIResearch (dc5d01cd) | Pending Antonello review |
+| 4 | Vercel deploy error pages | AIResearch (dc5d01cd) | Pending Antonello review |
+
+### Press Anomaly (1 source)
+
+| Source | Title | Target NB | Status |
+|---|---|---|---|
+| b7a6ee97 | "Neoregelia lillyae - Wikipedia" | Press (9d262101) | Pending Antonello review |
+
+---
+
+## Recommended Actions (Antonello, weekly review)
+
+- [ ] **URGENT (11 days)**: Restart `bali-intel-scraper` on Mini for Immigration / Regulation / Tax feeders — stale alarm hits 2026-06-22
+- [ ] **Review 24 standing proposals** (unchanged for 11 days): NB-4 YouTube dups (13) + AIResearch garbage (13) + Press Wikipedia anomaly (1)
+- [ ] **Optional**: Verify NB-1 (+2) and NB-5 (+2) organic source origins — both may be from same pipeline
+
+---
+
+## Feeder Status Summary
+
+| Feeder | Status | Last Added | Sources | Stale Alarm |
+|---|---|---|---|---|
+| bali-intel-scraper → AIResearch | ✅ ACTIVE (day 5) | Jun-11 WITA (+28) | 451 | 2026-07-11 |
+| bali-intel-scraper → Press | ✅ ACTIVE (+2 today) | Jun-11 WITA (+2) | 218 | 2026-07-11 |
+| bali-intel-scraper → Immigration | ⚠️ PAUSED (no new content) | ~2026-05-23 (19d) | 80 | **2026-06-22 (11d)** |
+| bali-intel-scraper → Regulation | ⚠️ PAUSED (no new content) | ~2026-05-23 (19d) | 41 | **2026-06-22 (11d)** |
+| bali-intel-scraper → Tax | ⚠️ PAUSED (no new content) | ~2026-05-23 (19d) | 17 | **2026-06-22 (11d)** |
+
+---
+
+## Telegram
+
+Not sent (0 broken, 0 stale, no new alarms triggered)

--- a/research/nb-health/2026-06-12-health.md
+++ b/research/nb-health/2026-06-12-health.md
@@ -1,0 +1,204 @@
+# NB Arsenal Health Report — 2026-06-12 (daily)
+
+> Mode B+C run by nb-curator agent. Read-only — no NB mutations.
+> Baseline comparison: 2026-06-11 (daily run, stored in agent memory).
+> Exact-URL deduplication pre-step: 0 removed today (deterministic, not reported here).
+
+---
+
+## Summary
+
+| Metric | Jun-11 | Jun-12 | Delta |
+|---|---|---|---|
+| Total notebooks (default profile) | 86 | **86** | 0 |
+| Total sources | 3,752 | **3,769** | **+17** |
+| Healthy (with sources, queryable) | 61 | **62** | **+1** |
+| Stale (updated_at >30d) | 0 | **0** | 0 ✅ |
+| Empty (0 sources) | 25 | **24** | **−1** |
+| Broken (timeout/error, has sources) | 0 | **0** | 0 ✅ |
+| New notebooks | 0 | 0 | 0 |
+
+**Overall health: EXCELLENT.** All tested NBs responded correctly. All NB-INTEL 5/5 healthy.
+All MATA GARUDA 4/4 (spot-checked 1/4). Zero broken, zero stale.
+
+> ℹ️ **NOTE on NB-PROBE-SANDBOX**: `7e6ae978` moved from empty (0 src) to non-empty (14 src).
+> Content confirmed via query: "synthetic fixtures for e2e testing" — sandbox scaffolding, not active domain NB.
+> This accounts for the healthy +1 / empty −1 transition. Not a health concern.
+
+> ℹ️ **NOTE on updated_at timestamps**: The feeder runs at 04:00 WITA = 20:00 UTC Jun-11.
+> New sources for today's cycle show `updated_at: 2026-06-11` (UTC). Expected — all deltas
+> below are from today's Jun-12 WITA feeder pass.
+
+---
+
+## Source Count Changes Today (+17 total)
+
+| NB | UUID (prefix) | Jun-11 | Jun-12 | Delta | Notes |
+|---|---|---|---|---|---|
+| **NB-PROBE-SANDBOX** | 7e6ae978 | 0 | **14** | **+14** | e2e test fixtures (added Jun-11 post-morning-run) |
+| **NB-INTEL-AIResearch** | dc5d01cd | 451 | **454** | **+3** | Feeder ACTIVE day 6 — 04:00 WITA |
+| **NB-INTEL-Press** | 9d262101 | 218 | **220** | **+2** | Feeder ACTIVE day 2 — 2 new articles |
+| **NB-4: Tax & Fiscal** | d4b2eedb | 163 | **165** | **+2** | Organic (normal) |
+| **NB-6: Ops & Compliance** | 85207af3 | 199 | **201** | **+2** | Organic (normal) |
+| **NB-5: Property & RE** | d9438180 | 144 | **145** | **+1** | Organic (normal) |
+| **Other NBs** | various | — | — | **−7** | Net distributed small changes |
+
+All other core NBs: sources unchanged or minor negative noise vs Jun-11.
+
+---
+
+## NB-INTEL Family — Status ✅
+
+All 5 NB-INTEL queryable and healthy. Feeder ACTIVE for AIResearch (day 6) + Press (day 2).
+
+| NB | UUID | Jun-11 | Jun-12 | Delta | Status | Stale Alarm |
+|---|---|---|---|---|---|---|
+| INTEL-AIResearch | dc5d01cd | 451 | **454** | +3 | ✅ Healthy — feeder active day 6 | **2026-07-12** (30d RESET) |
+| INTEL-Press | 9d262101 | 218 | **220** | +2 | ✅ Healthy — feeder active day 2 | **2026-07-12** (30d RESET) |
+| INTEL-Immigration | 1ed02e54 | 80 | **80** | 0 | ✅ Healthy | 2026-06-22 (**10d ⚠️**) |
+| INTEL-Regulation | a17f134e | 41 | **41** | 0 | ✅ Healthy | 2026-06-22 (**10d ⚠️**) |
+| INTEL-Tax | 7fb12c9c | 17 | **17** | 0 | ✅ Healthy | 2026-06-22 (**10d ⚠️**) |
+
+**⚠️ Stale alarm approaching**: Immigration, Regulation, Tax hit 30-day threshold in **10 days (2026-06-22)**.
+Action needed before that date: restart `bali-intel-scraper` cron on Mini for these 3 NBs.
+
+**✅ AIResearch + Press stale alarms RESET**: Both got new sources today → stale alarms reset to **2026-07-12** (30d).
+
+---
+
+## MATA GARUDA Family — Status ✅
+
+Spot-checked 1/4 (Self-Improving). All 4 assumed healthy (no change in source counts).
+
+| NB | UUID | Sources | Status |
+|---|---|---|---|
+| Self-Improving Agent Research | 5af11152 | 102 | ✅ Healthy (spot-queried) |
+| Open Source Intel Tools | e00d497a | 89 | ✅ Assumed healthy (unchanged src) |
+| Self-Evolving Agent Research | 305f5f2e | 57 | ✅ Assumed healthy (unchanged src) |
+| Intelligence Architecture Research | 76de5123 | 51 | ✅ Assumed healthy (unchanged src) |
+
+---
+
+## Core NBs Spot-Checked
+
+| NB | UUID | Sources | Query Result |
+|---|---|---|---|
+| NB-INTEL-AIResearch | dc5d01cd | 454 | ✅ Coherent (AI agents, world models, Palantir/CTI architecture) |
+| NB-INTEL-Press | 9d262101 | 220 | ✅ Coherent (visa/immigrazione, normative, economia, turismo Bali) |
+| NB-INTEL-Immigration | 1ed02e54 | 80 | ✅ Coherent (KITAS/Golden Visa/sicurezza stranieri Bali 2026) |
+| NB-INTEL-Regulation | a17f134e | 41 | ✅ Coherent (OSS-RBA female participation, immobiliare Bali) |
+| NB-INTEL-Tax | 7fb12c9c | 17 | ✅ Coherent (PER-6/PJ/2026, tassazione globale minima, società PMA) |
+| MATA GARUDA Self-Improving | 5af11152 | 102 | ✅ Coherent (agenti autonomi, OSINT, CTI, architetture multi-agent) |
+| NB-PROBE-SANDBOX | 7e6ae978 | 14 | ✅ Coherent (fixture sintetiche per test e2e — sandbox confermato) |
+
+7/7 spot-checked = HEALTHY.
+
+---
+
+## Notable: NB-PROBE-SANDBOX (7e6ae978) — Empty → Non-Empty
+
+- **Before (Jun-11 morning)**: 0 sources (empty)
+- **After (Jun-12 morning)**: 14 sources, updated_at: 2026-06-11
+- **Content confirmed**: "raccolta di dati di prova sintetici (fixture) isolati in un ambiente sandbox, utilizzati per eseguire test e2e"
+- **Assessment**: Intentional scraper/NLM pipeline testing. NOT a routing-eligible NB (sandbox only).
+- **Action**: None. Monitoring for future growth patterns.
+
+---
+
+## Mode C — Press Dedup Analysis (daily)
+
+**Source inventory**: 220 total (+2 since Jun-11)
+- 215 nlm_feed_*.txt (automated feed files, all unique hash suffixes)
+- 5 named sources (manually added):
+  - d1880940 — "BI: Investasi di Bali tetap menarik di tengah krisis geopolitik global" (Antara, legit)
+  - ed7b5942 — "Cegah penyalahgunaan visa turis, Pengawasan TKA di Yogyakarta diperketat" (NEW today, ANTARA, legit)
+  - 18cc73f1 — "PBB Turun Tangan, Minta AS Cabut Kebijakan Imigrasi Jelang Piala Dunia" (legit)
+  - f5c4a811 — "Spouse Visa in Indonesia E31A: Can You Keep Your Residency Status After Divorce?" (NEW today, legit)
+  - b7a6ee97 — "Neoregelia lillyae - Wikipedia" (anomaly, pending removal — 12th day)
+
+**New sources today**: 2
+- ed7b5942 — ANTARA article on TKA enforcement at Yogyakarta — UNIQUE, no dedup
+- f5c4a811 — Spouse Visa E31A divorce residency — UNIQUE, no dedup
+
+**Dedup results**:
+- Title duplicates (Levenshtein <= 3): 0 found (all nlm_feed_*.txt names are hash-unique)
+- Near-dup pairs among named sources: 0 found
+- Same-domain weekly bundles >= 10: not applicable (feed files have no extractable domain)
+- Summarization proposals (topics >= 10 sources/week): 0 new
+
+### Standing Proposals (unchanged — 12th consecutive day)
+
+**Press**:
+| Cluster | Source ID | Title | Reason | Action |
+|---|---|---|---|---|
+| PRESS-ANOMALY-01 | b7a6ee97 | "Neoregelia lillyae - Wikipedia" | Irrelevant plant taxonomy — accidental ingestion | nlm source rm b7a6ee97 from 9d262101 |
+
+---
+
+## All Open Proposals (24 total — 12th day unchanged)
+
+### NB-4 YouTube Dups (13 sources)
+
+These 13 YouTube sources have been proposed for 12 consecutive days. No action taken.
+Refer to health report 2026-05-30 for cluster detail.
+
+| Count | Type | Target NB | Status |
+|---|---|---|---|
+| 9+2+2 = 13 | YouTube URL clusters | NB-4 (d4b2eedb) | Pending Antonello review |
+
+### NB-INTEL-AIResearch Garbage (13 sources)
+
+Cloudflare (9) + Vercel (4) blocked/error-page sources. No content fetched.
+Refer to health report 2026-05-29 for cluster detail.
+
+| Count | Type | Target NB | Status |
+|---|---|---|---|
+| 9 | Cloudflare block pages | AIResearch (dc5d01cd) | Pending Antonello review |
+| 4 | Vercel deploy error pages | AIResearch (dc5d01cd) | Pending Antonello review |
+
+### Press Anomaly (1 source)
+
+| Source | Title | Target NB | Status |
+|---|---|---|---|
+| b7a6ee97 | "Neoregelia lillyae - Wikipedia" | Press (9d262101) | Pending Antonello review — 12 days |
+
+---
+
+## Query Gap Analysis (last 7 days)
+
+From routing log 2026-06-06..2026-06-12:
+- Mode A calls within 7 days: 0 (last Mode A was doc-intake-phase2 on Jun-04)
+- All log entries are Mode B/C health checks only
+
+**Underused NBs** (0 Mode A queries for 7+ days):
+NB-1, NB-2, NB-7, NB-8, NB-9, NB-10, NB-AGENTS, NB-HARARI, NB-DESIGN-AGENT, all RESEARCH-AD-HOC NBs.
+
+Note: Consistent with prior weeks — low-query period, no active pipeline runs. Not an alarm.
+
+**Recurring gap warnings**: 0 in last 7 days.
+
+---
+
+## Feeder Status Summary
+
+| Feeder | Status | Last Added | Sources | Stale Alarm |
+|---|---|---|---|---|
+| bali-intel-scraper -> AIResearch | ACTIVE (day 6) | Jun-12 WITA (+3) | 454 | 2026-07-12 (RESET today) |
+| bali-intel-scraper -> Press | ACTIVE (day 2) | Jun-12 WITA (+2) | 220 | 2026-07-12 (RESET today) |
+| bali-intel-scraper -> Immigration | PAUSED | ~2026-05-23 (20d) | 80 | 2026-06-22 (10d) |
+| bali-intel-scraper -> Regulation | PAUSED | ~2026-05-23 (20d) | 41 | 2026-06-22 (10d) |
+| bali-intel-scraper -> Tax | PAUSED | ~2026-05-23 (20d) | 17 | 2026-06-22 (10d) |
+
+---
+
+## Recommended Actions (Antonello, weekly review)
+
+- [ ] URGENT (10 days): Restart bali-intel-scraper on Mini for Immigration / Regulation / Tax feeders — stale alarm hits 2026-06-22
+- [ ] Review 24 standing proposals (unchanged for 12 days): NB-4 YouTube dups (13) + AIResearch garbage (13) + Press Wikipedia anomaly (1)
+- [ ] Optional: NB-PROBE-SANDBOX (7e6ae978) now has 14 e2e fixture sources — verify this is expected pipeline testing, not accidental feed
+
+---
+
+## Telegram
+
+Not sent (0 broken, 0 stale, no new alarms triggered, proposals unchanged)

--- a/research/nb-health/2026-06-13-health.md
+++ b/research/nb-health/2026-06-13-health.md
@@ -1,0 +1,215 @@
+# NB Arsenal Health Report — 2026-06-13 (daily)
+
+> Mode B+C run by nb-curator agent. Read-only — no NB mutations.
+> Baseline comparison: 2026-06-12 (daily run, stored in agent memory).
+> Exact-URL deduplication pre-step: 0 removed today (deterministic, not reported here).
+
+---
+
+## Summary
+
+| Metric | Jun-12 | Jun-13 | Delta |
+|---|---|---|---|
+| Total notebooks (default profile) | 86 | **86** | 0 |
+| Total sources | 3,769 | **3,780** | **+11** |
+| Healthy (with sources, queryable) | 62 | **62** | 0 |
+| Stale (updated_at >30d) | 0 | **0** | 0 ✅ |
+| Empty (0 sources) | 24 | **24** | 0 |
+| Broken (timeout/error, has sources) | 0 | **0** | 0 ✅ |
+| New notebooks | 0 | 0 | 0 |
+
+**Overall health: EXCELLENT.** All spot-checked NBs responded correctly. All NB-INTEL 5/5 healthy.
+MATA GARUDA 1/4 spot-checked (healthy). Zero broken, zero stale.
+
+> ℹ️ **KEY DISCOVERY**: NB-INTEL-Tax feeder **RESUMED TODAY**. Tax went 17→20 (+3 sources),
+> updated_at = 2026-06-12T20:00:36Z (= 2026-06-13T04:00 WITA). Stale alarm for Tax **RESET
+> to 2026-07-13** (30 days from today). Only Immigration and Regulation remain at the June-22
+> stale alarm threshold (9 days away).
+
+> ℹ️ **NEW GARBAGE PROPOSAL**: NB-INTEL-Tax source `587edb85` titled "Just a moment..." is
+> a Cloudflare challenge/block page — no actual tax content. Added to standing proposals (total: 25).
+
+---
+
+## Source Count Changes Today (+11 total)
+
+| NB | UUID (prefix) | Jun-12 | Jun-13 | Delta | Notes |
+|---|---|---|---|---|---|
+| **NB-INTEL-Tax** | 7fb12c9c | 17 | **20** | **+3** | **Feeder RESUMED** at 04:00 WITA — stale alarm RESET |
+| **NB-INTEL-Press** | 9d262101 | 220 | **223** | **+3** | Feeder ACTIVE day 3 — 3 new named sources |
+| **NB-PROBE-SANDBOX** | 7e6ae978 | 14 | **20** | **+6** | More e2e fixtures (batch add) |
+| **NB-2: Immigration** | cff93ab0 | 111 | **112** | **+1** | Organic |
+| **NB-1: Codebase** | f6ecd115 | 75 | **73** | **−2** | Source removal (operator action) |
+
+All other NBs: sources unchanged.
+
+---
+
+## NB-INTEL Family — Status ✅
+
+All 5 NB-INTEL queryable and healthy. All 5 had updated_at refreshed at 04:00 WITA today.
+
+| NB | UUID | Jun-12 | Jun-13 | Delta | Status | Stale Alarm |
+|---|---|---|---|---|---|---|
+| INTEL-AIResearch | dc5d01cd | 454 | **454** | 0 | ✅ Healthy — feeder active (0 new today) | **2026-07-12** (29d) |
+| INTEL-Press | 9d262101 | 220 | **223** | +3 | ✅ Healthy — feeder active day 3 | **2026-07-12** (29d) |
+| INTEL-Immigration | 1ed02e54 | 80 | **80** | 0 | ✅ Healthy | 2026-06-22 (**9d ⚠️**) |
+| INTEL-Regulation | a17f134e | 41 | **41** | 0 | ✅ Healthy | 2026-06-22 (**9d ⚠️**) |
+| INTEL-Tax | 7fb12c9c | 17 | **20** | +3 | ✅ Healthy — **feeder RESUMED** | **2026-07-13** (**RESET today**) |
+
+**⚠️ Stale alarm approaching**: Immigration + Regulation hit 30-day threshold in **9 days (2026-06-22)**.
+Action needed before that date: verify bali-intel-scraper cron on Mini for these 2 NBs.
+
+**✅ Tax feeder RESUMED**: +3 new sources today → stale alarm reset to 2026-07-13.
+**✅ AIResearch + Press stale alarms**: Remain valid at 2026-07-12 (set during Jun 12 feeder run).
+
+---
+
+## MATA GARUDA Family — Status ✅
+
+Spot-checked 1/4 (Self-Improving — full UUID: 5af11152-7809-4ece-8000-7ca8ce4e9678).
+
+| NB | UUID | Sources | Status |
+|---|---|---|---|
+| Self-Improving Agent Research | 5af11152 | 102 | ✅ Healthy (spot-queried — coherent, autonomous AI/CTI/multi-agent) |
+| Open Source Intel Tools | e00d497a | 89 | ✅ Assumed healthy (unchanged src) |
+| Self-Evolving Agent Research | 305f5f2e | 57 | ✅ Assumed healthy (unchanged src) |
+| Intelligence Architecture Research | 76de5123 | 51 | ✅ Assumed healthy (unchanged src) |
+
+---
+
+## Core NBs Spot-Checked
+
+| NB | UUID | Sources | Query Result |
+|---|---|---|---|
+| NB-INTEL-Tax | 7fb12c9c | 20 | ✅ Coherent (PER-6/PJ/2026 tassazione minima globale, kurs pajak, Tukin DJP, anti-abuse treaties) |
+| NB-INTEL-Immigration | 1ed02e54 | 80 | ✅ Coherent (KITAS/Golden Visa/Silmy KPK arresto/overstay esenzioni) |
+| NB-INTEL-Regulation | a17f134e | 41 | ✅ Coherent (OSS-RBA female participation, immobiliare Bali 2026) |
+| NB-INTEL-Press | 9d262101 | 223 | ✅ Coherent — latest Jun 10-12: demo BEM UI, KPK Silmy Karim, Parent Visa E31G, Bali investimenti +17.85%, ONU Mondiali 2026 |
+| NB-INTEL-AIResearch | dc5d01cd | 454 | ✅ Coherent (AI agents harness engineering, world models, CTI platforms) |
+| MATA GARUDA Self-Improving | 5af11152 | 102 | ✅ Coherent (agenti autonomi, ricerca biologica, CTI, multi-agent) |
+
+6/6 spot-checked = HEALTHY.
+
+> ℹ️ **NB-INTEL-AIResearch timeout on first attempt** (60s, exit 124). Second attempt with 70s
+> timeout succeeded. Not a health concern — large NB (454 src) with slower response time.
+> Recommend increasing timeout to 90s for AIResearch queries.
+
+---
+
+## Mode C — Press Dedup Analysis (daily)
+
+**Source inventory**: 223 total (+3 since Jun-12)
+- 215 nlm_feed_*.txt (automated feed files, unchanged)
+- 8 named sources (+3 new vs Jun-12):
+
+| Source ID | Title | Status |
+|---|---|---|
+| d1880940 | "BI: Investasi di Bali tetap menarik..." (Antara) | Legit (unchanged) |
+| ed7b5942 | "Cegah penyalahgunaan visa turis..." (Antara) | Legit (unchanged) |
+| b7a6ee97 | "Neoregelia lillyae - Wikipedia" | ANOMALY — 13th day, removal pending |
+| 18cc73f1 | "PBB Turun Tangan, Minta AS Cabut Kebijakan Imigrasi..." | Legit (unchanged) |
+| c33b0140 | "Pemerintah siapkan golden visa untuk wisman - ANTARA" | NEW today — legit |
+| 34016ccd | "Silmy: Imigrasi tertibkan penyalahgunaan visa..." | NEW today — legit |
+| f5c4a811 | "Spouse Visa in Indonesia E31A..." | Legit (unchanged) |
+| 7bb57c65 | "[POPULER GLOBAL] Pilot Terbang tanpa Lisensi..." | NEW today — legit |
+
+**New sources today**: 3 — all unique, no dedup needed.
+
+**Dedup results**:
+- Title duplicates (Levenshtein <= 3): 0 found
+- Near-dup pairs among named sources: 0 found
+- Same-domain weekly bundles >= 10: not applicable
+- Summarization proposals (topics >= 10 sources/week): 0 new
+
+---
+
+## Mode C — NB-INTEL-Tax Dedup (feeder resume inspection)
+
+**Source inventory**: 20 total — 16 nlm_feed_*.txt + 4 named:
+
+| Source ID | Title | Assessment |
+|---|---|---|
+| fadfb0a4 | "DJP Terbitkan PER 6/2026, Atur Teknis Pelaporan Pajak Minimum Global" | Legit |
+| e4ec4f1d | "Direktorat Jenderal Strategi Ekonomi dan Fiskal - Kurs Pajak" | Legit |
+| 693a5522 | "Formula Tukin DJP Diubah, Pengamat Ingatkan Risiko Tekanan ke Wajib Pajak" | Legit |
+| **587edb85** | **"Just a moment..."** | GARBAGE — Cloudflare challenge page |
+| a4d86b33 | "" (body: "Direktorat Jenderal Pajak") | Ambiguous — possibly DJP homepage. Monitor. |
+
+**New Tax proposal**: 587edb85 "Just a moment..." → Cloudflare block page, zero real content.
+Command: `nlm source delete 587edb85 from 7fb12c9c-4e12-4a8d-9bd1-c5b857bf310f`
+
+---
+
+## All Open Proposals (25 total — 1 new today)
+
+### NB-4 YouTube Dups (13 sources) — Day 13
+
+| Count | Type | Target NB | Status |
+|---|---|---|---|
+| 9+2+2 = 13 | YouTube URL clusters | NB-4 (d4b2eedb) | Pending Antonello review |
+
+### NB-INTEL-AIResearch Garbage (13 sources) — Day 13
+
+| Count | Type | Target NB | Status |
+|---|---|---|---|
+| 9 | Cloudflare block pages | AIResearch (dc5d01cd) | Pending Antonello review |
+| 4 | Vercel deploy error pages | AIResearch (dc5d01cd) | Pending Antonello review |
+
+### Press Anomaly (1 source) — Day 13
+
+| Source | Title | Target NB | Status |
+|---|---|---|---|
+| b7a6ee97 | "Neoregelia lillyae - Wikipedia" | Press (9d262101) | Pending — 13 days |
+
+### Tax Garbage (1 source) — NEW TODAY
+
+| Source | Title | Target NB | Status |
+|---|---|---|---|
+| 587edb85 | "Just a moment..." | Tax (7fb12c9c) | NEW — Cloudflare block page |
+
+---
+
+## Query Gap Analysis (last 7 days)
+
+From routing log 2026-06-07..2026-06-13:
+- Mode A calls within 7 days: 0 (last Mode A was doc-intake-phase2 on Jun-04)
+- All log entries are Mode B/C health checks only
+
+**Underused NBs** (0 Mode A queries for 7+ days):
+NB-1, NB-2, NB-7, NB-8, NB-9, NB-10, NB-AGENTS, NB-HARARI, NB-DESIGN-AGENT, all RESEARCH-AD-HOC NBs.
+
+Note: Consistent with prior weeks — low-query period, no active pipeline runs. Not an alarm.
+
+**Recurring gap warnings**: 0 in last 7 days.
+
+---
+
+## Feeder Status Summary
+
+| Feeder | Status | Last Added | Sources | Stale Alarm |
+|---|---|---|---|---|
+| bali-intel-scraper -> AIResearch | ACTIVE (0 new today) | Jun-12 WITA | 454 | 2026-07-12 (29d) |
+| bali-intel-scraper -> Press | ACTIVE day 3 | Jun-13 WITA (+3) | 223 | 2026-07-12 (29d) |
+| bali-intel-scraper -> Tax | RESUMED | Jun-13 WITA (+3) | 20 | 2026-07-13 (RESET today) |
+| bali-intel-scraper -> Immigration | PAUSED/0-new | ~2026-05-23 (21d) | 80 | 2026-06-22 (9d) |
+| bali-intel-scraper -> Regulation | PAUSED/0-new | ~2026-05-23 (21d) | 41 | 2026-06-22 (9d) |
+
+> All 5 NB-INTEL had updated_at refreshed to 2026-06-12T20:0xZ (=04:00 WITA Jun-13).
+> Tax uniquely captured 3 new articles. AIResearch feeder ran but 0 new content today.
+
+---
+
+## Recommended Actions (Antonello, weekly review)
+
+- [ ] URGENT (9 days): Verify/restart bali-intel-scraper on Mini for Immigration + Regulation — stale alarm 2026-06-22. Tax now safe (feeder resumed today).
+- [ ] NEW: Remove Tax garbage source 587edb85 "Just a moment..." — Cloudflare block page in NB-INTEL-Tax.
+- [ ] Review 24 standing proposals (now 13 days unchanged): NB-4 YouTube dups (13) + AIResearch garbage (13) + Press Wikipedia anomaly (1)
+- [ ] Consider increasing AIResearch query timeout from 60s to 90s in health-check scripts (large NB, 454 src)
+- [ ] Optional: NB-PROBE-SANDBOX (7e6ae978) now 20 sources (+6 today) — verify expected pipeline testing
+
+---
+
+## Telegram
+
+Not sent (0 broken, 0 stale, 1 new proposal only — does not meet ≥3 broken threshold)

--- a/research/nb-health/2026-06-14-health.md
+++ b/research/nb-health/2026-06-14-health.md
@@ -1,0 +1,187 @@
+# NB Arsenal Health Report — 2026-06-14 (daily)
+
+> Mode B+C run by nb-curator agent. Read-only — no NB mutations.
+> Baseline comparison: 2026-06-13 (daily run).
+> Exact-URL deduplication pre-step: 0 removed today (deterministic, not reported here).
+
+---
+
+## Summary
+
+| Metric | Jun-13 | Jun-14 | Delta |
+|---|---|---|---|
+| Total notebooks (default profile) | 86 | **86** | 0 |
+| Total sources | 3,780 | **3,785** | **+5** |
+| Healthy (with sources, queryable) | 62 | **62** | 0 |
+| Stale (updated_at >30d) | 0 | **0** | 0 OK |
+| Empty (0 sources) | 24 | **24** | 0 |
+| Broken (timeout/error, has sources) | 0 | **0** | 0 OK |
+| New notebooks | 0 | 0 | 0 |
+
+**Overall health: EXCELLENT.** 6/6 spot-checked NBs responded correctly and coherently.
+All NB-INTEL 5/5 healthy. MATA GARUDA 1/4 spot-checked (healthy). Zero broken, zero stale.
+
+---
+
+## Source Count Changes Today (+5 total)
+
+| NB | UUID prefix | Jun-13 | Jun-14 | Delta | Notes |
+|---|---|---|---|---|---|
+| NB-INTEL-Press | 9d262101 | 223 | **224** | **+1** | Feeder ACTIVE day 4 — E31G Parent Visa article |
+| NB-INTEL-Tax | 7fb12c9c | 20 | **21** | **+1** | Feeder ACTIVE day 2 — PPh Final UMKM article |
+| NB-2: Immigration | cff93ab0 | 112 | **113** | **+1** | Organic |
+| NB-14: Session Memory | 1e5f9b04 | 13 | **14** | **+1** | Organic |
+| NB-PROBE-SANDBOX | 7e6ae978 | 20 | **22** | **+2** | More e2e fixtures |
+| NB-1: Codebase | f6ecd115 | 73 | **72** | **-1** | Source removal (operator, 2nd consecutive day) |
+
+All other NBs: sources unchanged.
+
+Note: NB-1 losing 1 source/day for 2 consecutive days (73 Jun-12 to 72 Jun-14). Operator cleanup in progress; not an alarm.
+
+---
+
+## NB-INTEL Family — Status OK
+
+All 5 NB-INTEL queryable and healthy. All 5 had updated_at refreshed at 04:00 WITA today.
+
+| NB | UUID | Jun-13 | Jun-14 | Delta | Status | Stale Alarm |
+|---|---|---|---|---|---|---|
+| INTEL-AIResearch | dc5d01cd | 454 | **454** | 0 | OK Healthy — feeder active (0 new today) | 2026-07-13 (29d) |
+| INTEL-Press | 9d262101 | 223 | **224** | +1 | OK Healthy — feeder ACTIVE day 4 | 2026-07-13 (29d) |
+| INTEL-Immigration | 1ed02e54 | 80 | **80** | 0 | OK Healthy | 2026-06-22 (8d WARN) |
+| INTEL-Regulation | a17f134e | 41 | **41** | 0 | OK Healthy | 2026-06-22 (8d WARN) |
+| INTEL-Tax | 7fb12c9c | 20 | **21** | +1 | OK Healthy — feeder ACTIVE day 2 | 2026-07-13 (29d) |
+
+URGENT — Stale alarm approaching: Immigration + Regulation hit 30-day threshold in 8 days (2026-06-22).
+Action needed: verify/restart bali-intel-scraper on Mini for these 2 NBs.
+
+AIResearch + Press + Tax feeders ACTIVE — stale alarms all at 2026-07-13 (29 days).
+
+---
+
+## MATA GARUDA Family — Status OK
+
+Spot-checked 1/4 (Self-Improving — UUID: 5af11152-7809-4ece-8000-7ca8ce4e9678).
+
+| NB | UUID | Sources | Status |
+|---|---|---|---|
+| Self-Improving Agent Research | 5af11152 | 102 | OK Healthy — agenti autonomi, harness eng, biologia/difesa, CTI |
+| Open Source Intel Tools | e00d497a | 89 | OK Assumed healthy (unchanged src) |
+| Self-Evolving Agent Research | 305f5f2e | 57 | OK Assumed healthy (unchanged src) |
+| Intelligence Architecture Research | 76de5123 | 51 | OK Assumed healthy (unchanged src) |
+
+---
+
+## Spot Checks (6/6)
+
+| NB | UUID | Sources | Query Result |
+|---|---|---|---|
+| NB-INTEL-AIResearch | dc5d01cd | 454 | OK — archivio 2024-2026: agenti IA autonomi, world models, CTI (Palantir, OpenCTI, MISP) |
+| NB-INTEL-Press | 9d262101 | 224 | OK — piu recente: 12 giu 2026 22:05 WIB — Trump/Iran accordo nucleare + proteste Indonesia |
+| NB-INTEL-Tax | 7fb12c9c | 21 | OK — PER-6/PJ/2026 tassazione minima globale, Kurs Pajak, Tukin DJP, PPh Final UMKM 0.5% |
+| NB-INTEL-Immigration | 1ed02e54 | 80 | OK — KITAS/Golden Visa/nomadi digitali, Silmy KPK, overstay esenzioni, controlli stranieri Bali |
+| NB-INTEL-Regulation | a17f134e | 41 | OK — OSS-RBA partecipazione femminile, investimenti esteri, mercato immobiliare Bali 2026 |
+| MATA GARUDA Self-Improving | 5af11152 | 102 | OK — agenti IA autonomi/auto-evolutivi, harness engineering, biologia/difesa, CTI |
+
+---
+
+## Mode C — Press Dedup Analysis (daily — feeder day 4)
+
+Source inventory: 224 total (+1 since Jun-13)
+- 215 nlm_feed_*.txt (feed files, unchanged)
+- 9 named sources (+1 new vs Jun-13)
+
+Named sources:
+  d1880940  BI: Investasi di Bali tetap menarik... (Antara) — LEGIT (unchanged)
+  ed7b5942  Cegah penyalahgunaan visa turis... — LEGIT (unchanged)
+  0f7f7d75  E31G Parent Visa Indonesia: Long-Term Stay Permit... — NEW TODAY LEGIT
+  b7a6ee97  Neoregelia lillyae - Wikipedia — ANOMALY day 14, removal pending
+  18cc73f1  PBB Turun Tangan, Minta AS Cabut Kebijakan Imigrasi... — LEGIT (unchanged)
+  c33b0140  Pemerintah siapkan golden visa untuk wisman - ANTARA — LEGIT (unchanged)
+  34016ccd  Silmy: Imigrasi tertibkan penyalahgunaan visa... — LEGIT (unchanged)
+  f5c4a811  Spouse Visa in Indonesia E31A... — LEGIT (unchanged)
+  7bb57c65  [POPULER GLOBAL] Pilot Terbang tanpa Lisensi... — LEGIT (unchanged)
+
+Near-dup check: E31G (0f7f7d75) vs E31A (f5c4a811) — different visa types, NOT duplicates.
+
+Dedup results:
+- Title duplicates (Levenshtein <= 3): 0 found
+- Same-domain weekly bundles >= 10: not applicable (9 named sources)
+- Summarization proposals (topics >= 10 sources/week): 0 new
+
+---
+
+## Mode C — NB-INTEL-Tax Dedup (feeder day 2)
+
+Source inventory: 21 total (+1 new)
+
+  01faf6b4  Aturan Baru PPh Final UMKM Picu Pertanyaan soal Penghasilan Usaha — NEW TODAY LEGIT
+  fadfb0a4  DJP Terbitkan PER 6/2026, Atur Teknis Pelaporan Pajak Minimum Global — LEGIT (unchanged)
+  e4ec4f1d  Direktorat Jenderal Strategi Ekonomi dan Fiskal - Kurs Pajak — LEGIT (unchanged)
+  693a5522  Formula Tukin DJP Diubah, Pengamat Ingatkan Risiko Tekanan ke Wajib Pajak — LEGIT
+  587edb85  "Just a moment..." — GARBAGE Cloudflare challenge page (day 2, pending removal)
+  a4d86b33  (empty title, body: Direktorat Jenderal Pajak) — AMBIGUOUS, monitor
+  + 16 nlm_feed_*.txt (automated)
+
+No new garbage or duplicates detected.
+
+---
+
+## All Open Proposals (25 total — UNCHANGED, day 15)
+
+### NB-4 YouTube Dups (13 sources) — Day 15
+Count: 9+2+2 = 13 YouTube URL clusters | Target: NB-4 (d4b2eedb) | Pending Antonello review
+
+### NB-INTEL-AIResearch Garbage (13 sources) — Day 15
+Count: 9 Cloudflare block pages + 4 Vercel deploy errors | Target: AIResearch (dc5d01cd) | Pending
+
+### Press Anomaly (1 source) — Day 14
+Source: b7a6ee97 "Neoregelia lillyae - Wikipedia" | Target: Press (9d262101) | Pending 14 days
+
+### Tax Garbage (1 source) — Day 2
+Source: 587edb85 "Just a moment..." | Target: Tax (7fb12c9c) | Cloudflare block page
+
+---
+
+## Query Gap Analysis (last 7 days)
+
+Routing log 2026-06-08..2026-06-14:
+- Mode A calls within 7 days: 0 (last Mode A was doc-intake-phase2 on Jun-04)
+- All log entries are Mode B/C health checks only
+
+Underused NBs (0 Mode A queries last 7 days):
+NB-1, NB-2, NB-7, NB-8, NB-9, NB-10, NB-AGENTS, NB-HARARI, NB-DESIGN-AGENT, all RESEARCH-AD-HOC NBs.
+Consistent with prior weeks — low-query period, no active pipeline runs. Not an alarm.
+
+Recurring gap warnings: 0 in last 7 days.
+
+---
+
+## Feeder Status Summary
+
+| Feeder | Status | Last Added | Sources | Stale Alarm |
+|---|---|---|---|---|
+| bali-intel-scraper -> AIResearch | ACTIVE (0 new today) | Jun-13 04:00 WITA | 454 | 2026-07-13 (29d) |
+| bali-intel-scraper -> Press | ACTIVE day 4 | Jun-14 04:00 WITA (+1) | 224 | 2026-07-13 (29d) |
+| bali-intel-scraper -> Tax | ACTIVE day 2 | Jun-14 04:00 WITA (+1) | 21 | 2026-07-13 (29d) |
+| bali-intel-scraper -> Immigration | PAUSED/0-new | ~2026-05-23 (22d) | 80 | 2026-06-22 (8d WARN) |
+| bali-intel-scraper -> Regulation | PAUSED/0-new | ~2026-05-23 (22d) | 41 | 2026-06-22 (8d WARN) |
+
+---
+
+## Recommended Actions (Antonello)
+
+- [ ] URGENT (8 days): Verify/restart bali-intel-scraper on Mini for Immigration + Regulation — stale alarm 2026-06-22.
+- [ ] Proposals day 15 (consider acting before day 21):
+    NB-4: 13 YouTube dups -> propose manual cleanup
+    AIResearch: 13 garbage sources (Cloudflare+Vercel) -> propose manual cleanup
+    Press: Wikipedia anomaly b7a6ee97 -> propose removal
+    Tax: 587edb85 Cloudflare -> propose removal
+- [ ] NB-1: losing 1 source/day for 2 days — confirm intentional operator cleanup or investigate.
+- [ ] Consider increasing AIResearch query timeout to 90s in health-check scripts (454 src, margin thin).
+
+---
+
+## Telegram
+
+Not sent (0 broken, 0 stale, proposals unchanged — does not meet >=3 broken threshold).

--- a/research/nb-health/2026-06-15-curation.md
+++ b/research/nb-health/2026-06-15-curation.md
@@ -1,0 +1,240 @@
+# NB Arsenal Health Report + Mode C Curation — 2026-06-15
+
+**Run**: 2026-06-15 ~05:30 WITA | Mode B (full) + Mode C (Monday full pass)
+**Previous**: 2026-06-14 (3785 src, 62 healthy, 25 proposals)
+
+---
+
+## Executive Summary
+
+- **Total**: 86 notebooks, **3867 sources** (+82 vs Jun-14 — biggest single-day delta recorded)
+- **Healthy**: 62 | **Stale**: 0 | **Broken**: 0 | **Empty**: 24
+- **HEADLINE**: All 5 NB-INTEL feeders active. Immigration + Regulation **SELF-RESUMED** after 22-day pause (stale alarm cancelled).
+- **AIResearch hits 500 sources** — monitor for NLM per-notebook ceiling.
+- **Proposals**: 28 (+3 new vs 25 yesterday)
+
+---
+
+## PART 1 — Mode B Health Check
+
+### NB-INTEL Feeder Status
+
+All timestamps: 2026-06-14T20:00-20:03 UTC = 04:00-04:03 WITA (cron confirmed running)
+
+| NB | Jun-14 | Jun-15 | Delta | Stale Alarm | Status |
+|---|---|---|---|---|---|
+| AIResearch | 454 | 500 | +46 | 2026-07-15 (30d) | ACTIVE day 7 |
+| Immigration | 80 | 92 | +12 | 2026-07-15 (30d) | RESUMED (was PAUSED 22d) |
+| Press | 224 | 230 | +6 | 2026-07-15 (30d) | ACTIVE day 5 |
+| Tax | 21 | 27 | +6 | 2026-07-15 (30d) | ACTIVE day 3 |
+| Regulation | 41 | 45 | +4 | 2026-07-15 (30d) | RESUMED (was PAUSED 22d) |
+
+ALERT CANCELLED: "URGENT restart for Imm+Reg before 2026-06-22" from Jun-14 is void. Feeders self-corrected. ALL 5 stale alarms uniformly reset to 2026-07-15.
+
+### NB-INTEL Spot Checks (via nlm notebook query)
+
+| NB | UUID | Result |
+|---|---|---|
+| AIResearch | dc5d01cd | HEALTHY — agenti IA autonomi, world models, CTI, MCP |
+| Press | 9d262101 | HEALTHY — visti, normative aziendali, economia, Bali |
+| Tax | 7fb12c9c | HEALTHY — PP 20/2026 PPh Final UMKM, PER-6/PJ/2026, kurs pajak |
+| Immigration | 1ed02e54 | HEALTHY — KITAS/Golden Visa, nomadi digitali, overstay esenzioni |
+| Regulation | a17f134e | HEALTHY — OSS RBA partecipazione femminile, immobiliare Bali 2026 |
+
+### Core Curated NB Spot Checks
+
+| NB | UUID | Sources | Delta | Status |
+|---|---|---|---|---|
+| NB-3 Company Setup | 933509f9 | 283 | 0 | HEALTHY (spot-checked) |
+| NB-4 Tax Curated | d4b2eedb | 167 | 0 | HEALTHY (spot-checked) |
+| NB-2 Immigration | cff93ab0 | 113 | 0 | HEALTHY (spot-checked) |
+| MATA GARUDA Self-Improving | 5af11152 | 102 | 0 | HEALTHY (spot-checked) |
+| NB-6 Operations | 85207af3 | 203 | 0 | STABLE (unchanged) |
+| NB-9 Research Lab | d2a05271 | 197 | 0 | STABLE (unchanged) |
+| NB-10 Team Guides | f0307c2c | 161 | 0 | STABLE (unchanged) |
+| NB-AGENTS | 6d449787 | 157 | 0 | STABLE (unchanged) |
+| NB-8 Expat Life | 4fd8cd0f | 150 | 0 | STABLE (unchanged) |
+| NB-5 Property | d9438180 | 147 | 0 | STABLE (unchanged) |
+
+### Full Inventory Delta (all non-zero-change NBs)
+
+| NB | Jun-14 | Jun-15 | Delta |
+|---|---|---|---|
+| NB-INTEL-AIResearch | 454 | 500 | +46 |
+| NB-INTEL-Immigration | 80 | 92 | +12 |
+| NB-INTEL-Press | 224 | 230 | +6 |
+| NB-INTEL-Tax | 21 | 27 | +6 |
+| NB-INTEL-Regulation | 41 | 45 | +4 |
+| All others | — | — | 0 |
+
+Total: 3785 -> 3867 (+82)
+
+### AIResearch 500-Source Watch
+
+AIResearch (dc5d01cd) now at 500 sources — largest NB in arsenal. At +40-50/day feeder pace, monitor for NLM ceiling. If Jun-16 count plateaus at 500, NLM may be silently enforcing a hard limit. Check Jun-16 count. No action today.
+
+### Empty Notebooks (24 — unchanged)
+
+All 0-source scaffolds stable. WA-team notebooks (7 NB-WA-*) still empty.
+
+---
+
+## PART 2 — Mode C Dedup/Summarize Proposals
+
+Schedule: Monday Jun-15 (day-of-month=15, not first-Monday) spec = Press-only + stale-all.
+User override in prompt: full pass on all 5 NB-INTEL executed.
+
+### NB-INTEL-AIResearch (500 sources)
+
+Source mix: 274 no-URL (uploaded/pasted docs), 226 web sources
+Top web domains: arxiv.org(20), github.com(17), reddit.com(16), code.claude.com(13), palantir.com(12)
+Stale >90d: 0 (source API has no date fields)
+
+Existing garbage proposals (day 16 — PENDING Antonello):
+
+  CLUSTER AIResearch CLOUDFLARE-9
+    remove: 50bf613a, 88a840bc, 8d600b73, 9c7ad762, ad88f4db,
+            b85199c9, bda8a48e, cda0e126, e143f418
+    reason: title="Just a moment..." Cloudflare challenge page
+
+  CLUSTER AIResearch VERCEL-4
+    remove: 0a48f083, 1ef262e8, 9cb188a0, ef5a2a75
+    reason: title="Vercel Security Checkpoint" blocked page
+
+NEW PROPOSALS — Near-dup title clusters:
+
+  CLUSTER AIResearch NEAR-DUP-A [NEW day 1]
+    keep:   fedb6853-854c-4dbe-8441-cdb87254d34e
+            "Diffusion Models Are Real-Time Game Engines"
+            url: https://arxiv.org/html/2408.14837v1
+    remove: 1c140766-ceb2-45a2-bd82-627647b48b13
+            "Diffusion Models Are Real-Time Game Engines"
+            url: https://openreview.net/forum?id=P8pqeEkn1H
+    reason: same paper (GameNGen); arxiv=full preprint; openreview=peer review only;
+            Levenshtein distance <=3 on normalized title
+
+  CLUSTER AIResearch NEAR-DUP-B [NEW day 1]
+    keep:   96766838-9743-4521-8457-fcab3068f072
+            "How to Set Up Claude Code Agent Teams"
+            url: https://www.reddit.com/r/ClaudeCode/comments/1qz8tyy/
+    remove: 737b287a-d61b-4190-9451-110c99a95eaa
+            "How to Set Up Claude Code Agent Teams"
+            url: https://www.reddit.com/r/AIAgentsInAction/comments/1qz8vew/
+    reason: same video cross-posted 2 subreddits; r/ClaudeCode is primary community
+            confidence MEDIUM (different comment threads, same external content)
+
+NOT-DUP confirmed today:
+  Maltego KB 4x (5a2d4999, 7b43831a, b0c8cdeb, eec390b2) — 4 different docs.maltego.com articles. NO removal.
+
+### NB-INTEL-Press (230 sources)
+
+Source mix: 218 no-URL, 12 web. Stale >90d: 0. Title near-dups: None.
+
+  CLUSTER Press WIKIPEDIA-ANOMALY [day 16 PENDING]
+    remove: b7a6ee97-3687-45c7-b42e-fd3e7d85cacc
+            "Neoregelia lillyae - Wikipedia"
+            url: https://en.wikipedia.org/wiki/Special:Random
+    reason: Special:Random URL — no Bali Zero relevance, test/error upload
+
+Summarization: Insufficient URL metadata for topic clustering. No proposals (cost constraint).
+
+### NB-INTEL-Tax (27 sources)
+
+Stale >90d: 0. Title near-dups: None (all 27 unique).
+
+  CLUSTER Tax CLOUDFLARE-1 [day 17 PENDING]
+    remove: 587edb85-0747-4e61-aa75-9d1a52e0565c
+            "Just a moment..."
+            url: https://www.detiksumsel.com/.../pp-nomor-20-tahun-2026...
+    reason: Cloudflare challenge captured. Action: delete + re-add when accessible.
+
+### NB-INTEL-Immigration (92 sources)
+
+Stale >90d: 0. Title near-dups: None. +12 sources added by feeder (count delta confirmed).
+
+### NB-INTEL-Regulation (45 sources)
+
+Stale >90d: 0.
+
+OSS RBA title-match CONFIRMED NOT-DUP (re-verified today with URL check):
+  370c6e89 -> https://oss.go.id/id/berita/oss-contact-center-service-hours
+  574f0767 -> https://oss.go.id/id/berita/rosan-perkasa-roeslani-officially-assumes-office...
+  Same site-name pattern as Maltego KB. Different articles. NO removal proposed.
+
+### NB-4 Tax Curated (167 sources) — Extended Review
+
+YouTube-type dup clusters (no URL in API — title-match only):
+
+Existing proposals (3 clusters, 10 removals — day 17 PENDING Antonello):
+
+  CLUSTER NB4-YT-A: "Step by Step Belajar Mudah Mengisi SPT PPh Badan di Coretax" (9 COPIES)
+    keep:   0044a518-fb4a-4bbe-b861-c67599dbd69b
+    remove: 31b1e576, 5fa290ff, 6d966bdd, 9f036179, a9167e83, c119363c, f3be654f, fea0725e
+    reason: identical title, no URL, 9x duplication (YouTube import)
+
+  CLUSTER NB4-YT-B: "TUTORIAL CORETAX RESMI: Panduan SPT Tahunan Wajib Pajak Badan" (2 COPIES)
+    keep:   184fc0b8-a0f6-4d01-b6d3-7dae331526fa
+    remove: c9203fa0-f5ee-4e35-b582-2160fff5c262
+
+  CLUSTER NB4-YT-C: "Tutorial Pelaporan SPT Tahunan Orang Pribadi" (2 COPIES)
+    keep:   1320d061-daa1-47fc-92f7-8d2bfc0d18e7
+    remove: 7531256f-6cea-48b1-8364-48fc29cfc686
+
+NEW PROPOSAL:
+
+  CLUSTER NB4-YT-D: "[Podcast Cermati Eps. 34] - SPT Tahunan PPh 2025" [NEW day 1]
+    keep:   0b889bda-67a3-4b21-ad8c-a4f267b4bd5a
+    remove: 65e3a6be-762c-4c87-b5ca-f5fb50a7fa47
+    reason: identical title, no URL, 2x duplication (podcast/YouTube import)
+
+---
+
+## Open Proposals Summary
+
+| # | Notebook | Cluster | Type | Removals | Age | Status |
+|---|---|---|---|---|---|---|
+| 1 | AIResearch | CLOUDFLARE-9 | garbage | 9 | day 16 | PENDING |
+| 2 | AIResearch | VERCEL-4 | garbage | 4 | day 16 | PENDING |
+| 3 | AIResearch | NEAR-DUP-A Diffusion Models | near-dup | 1 | day 1 | NEW |
+| 4 | AIResearch | NEAR-DUP-B Claude Code Teams | near-dup | 1 | day 1 | NEW |
+| 5 | NB-4 Tax | NB4-YT-A spt_badan 9x | dup | 8 | day 17 | PENDING |
+| 6 | NB-4 Tax | NB4-YT-B tutorial_coretax 2x | dup | 1 | day 17 | PENDING |
+| 7 | NB-4 Tax | NB4-YT-C pelaporan_spt 2x | dup | 1 | day 17 | PENDING |
+| 8 | NB-4 Tax | NB4-YT-D podcast_cermati 2x | dup | 1 | day 1 | NEW |
+| 9 | Press | Wikipedia anomaly | garbage | 1 | day 16 | PENDING |
+| 10 | Tax INTEL | CLOUDFLARE-1 | garbage | 1 | day 17 | PENDING |
+
+Total: 10 clusters, 28 individual removal actions (+3 vs Jun-14)
+
+---
+
+## Operator Actions
+
+### No longer urgent:
+- RESOLVED: Immigration + Regulation feeders self-resumed overnight. Stale alarm cancelled.
+
+### Monitor:
+- AIResearch at 500 sources — check Jun-16 count for NLM ceiling signal.
+- Proposals at day 16-17 — consider batch cleanup.
+
+### Batch cleanup commands (PROPOSE ONLY — execute after Antonello approval):
+
+NB-4 YouTube dups (11 removals):
+  nlm source delete d4b2eedb 31b1e576 5fa290ff 6d966bdd 9f036179 a9167e83 c119363c f3be654f fea0725e
+  nlm source delete d4b2eedb c9203fa0 7531256f 65e3a6be
+
+AIResearch garbage (13 removals):
+  nlm source delete dc5d01cd 50bf613a 88a840bc 8d600b73 9c7ad762 ad88f4db b85199c9 bda8a48e cda0e126 e143f418 0a48f083 1ef262e8 9cb188a0 ef5a2a75
+
+AIResearch near-dups (2 removals — MEDIUM confidence):
+  nlm source delete dc5d01cd 1c140766 737b287a
+
+Press Wikipedia (1 removal):
+  nlm source delete 9d262101 b7a6ee97
+
+Tax INTEL Cloudflare (1 removal):
+  nlm source delete 7fb12c9c 587edb85
+
+---
+
+## Telegram: NOT sent (0 broken, 0 stale — no threshold triggered)

--- a/research/nb-monitor/report-2026-W24.md
+++ b/research/nb-monitor/report-2026-W24.md
@@ -1,0 +1,162 @@
+# NB Mitochondrial Value Monitor — 2026-W24
+
+_Generated at 2026-06-14T18:30:04+00:00_
+
+## Ranking
+
+| rank | name | tier | rf7 | rf30 | Δ vs lastweek | age (d) |
+|---:|---|:---:|---:|---:|---:|---:|
+| 1 | `NB-2: Immigration & Visa — Indonesia 2025` | DYING | 0 | 40 | +0 | 17 |
+| 2 | `NB-3: Company Setup — Indonesia 2025` | DYING | 0 | 4 | +0 | 17 |
+| 3 | `NB-4 — Tax & Fiscal Indonesia | Bali Zero` | DYING | 0 | 3 | +0 | 17 |
+| 4 | `NB-5 — Property & Real Estate Indonesia 2025` | DYING | 0 | 2 | +0 | 17 |
+| 5 | `NB-7 Editorial & Content Strategy 2025 — Bali Zero` | DYING | 0 | 1 | +0 | 17 |
+| 6 | `NB-INTEL-Tax — Daily Tax/Fiscal Intelligence` | DYING | 0 | 0 | +0 | 17 |
+| 7 | `NB-INTEL-Immigration — Daily Immigration Intelligence` | DYING | 0 | 0 | +0 | 17 |
+| 8 | `NB-INTEL-Press — Daily Press Intelligence` | DYING | 0 | 0 | +0 | 17 |
+| 9 | `NB-INTEL-Regulation — Daily Regulatory Intelligence` | DYING | 0 | 0 | +0 | 17 |
+| 10 | `NB-1: Nuzantara Codebase & Architecture` | DYING | 0 | 0 | +0 | 17 |
+| 11 | `WA CRM Enrichment Architecture 2026` | DYING | 0 | 0 | +0 | 17 |
+| 12 | `ANALISI-LEGALE-ZANTARA` | DYING | 0 | 0 | +0 | 17 |
+| 13 | `Immigration Regulation Search 2025-2026` | DYING | 0 | 0 | +0 | 17 |
+| 14 | `KITAS Research 2025-2026` | DYING | 0 | 0 | +0 | 17 |
+| 15 | `KITAP Research 2025-2026` | DYING | 0 | 0 | +0 | 17 |
+| 16 | `Indonesian Tax Updates 2025-2026` | DYING | 0 | 0 | +0 | 17 |
+| 17 | `Meet 2026-05-13 Salvatore Iorio — Bali Real Estate` | DYING | 0 | 0 | +0 | 17 |
+| 18 | `[ARCHIVED-DELETE-2026-05-07] NB-NLM-ELEVATION — SOTA research & brainstorm 2026-04-25` | DYING | 0 | 0 | +0 | 17 |
+| 19 | `[MERGED-INTO-dc5d01cd-2026-05-07] Claude Code optimization research 2026-04-21` | DYING | 0 | 0 | +0 | 17 |
+| 20 | `[MERGED-INTO-d2a05271-2026-05-07] Digital Sovereignty & Ancestral Wisdom AI` | DYING | 0 | 0 | +0 | 17 |
+| 21 | `[MERGED-INTO-dc5d01cd-2026-05-07] World Models 2026 — Comprehensive Survey (Genie, Waypoint, GameNGen, SORA)` | DYING | 0 | 0 | +0 | 17 |
+| 22 | `[ARCHIVED-DELETE-2026-05-07] Analisi Video AI Agency` | DYING | 0 | 0 | +0 | 17 |
+| 23 | `[MERGED-INTO-dc5d01cd-2026-05-07] Nexus — Palantir Architecture Deep Research` | DYING | 0 | 0 | +0 | 17 |
+| 24 | `NB-6 Operations & Compliance Indonesia 2025 — Bali Zero` | DYING | 0 | 0 | +0 | 17 |
+| 25 | `Piano di Ristrutturazione e Conformità per PT Wirramanda` | DYING | 0 | 0 | +0 | 17 |
+| 26 | `Agenti in Evoluzione: Rapporto sulla Ricerca 2026` | DYING | 0 | 0 | +0 | 17 |
+| 27 | `[EXPORTED-2026-05-07] BZ Morning News — Multi-Domain Briefing` | DYING | 0 | 0 | +0 | 17 |
+| 28 | `Bali Zero Setup Guide Mac+Mobile — Cinematic ID` | DYING | 0 | 0 | +0 | 17 |
+| 29 | `WR2 Badung HOREKA Waste Carousel Verification 2026-05-11` | DYING | 0 | 0 | +0 | 17 |
+| 30 | `Labor Regulatory Check May 2026` | DYING | 0 | 0 | +0 | 17 |
+| 31 | `CRM sync open-source patterns fast import 2026-05-09` | DYING | 0 | 0 | +0 | 17 |
+| 32 | `Kura Kura Bali Crisis 2026-05-12 — OSINT briefing` | DYING | 0 | 0 | +0 | 17 |
+| 33 | `Ciclo di Vita e Manutenzione dei Sistemi Informativi NotebookLM` | DYING | 0 | 0 | +0 | 17 |
+| 34 | `AI Evolutionary Frontier quicktime 2026 — ALTK/DGM/PTB/SoM` | DYING | 0 | 0 | +0 | 17 |
+| 35 | `NLM Video Falla Research 2026-05-08` | DYING | 0 | 0 | +0 | 17 |
+| 36 | `NIB PMA Regulations 2025-2026 Research` | DYING | 0 | 0 | +0 | 17 |
+| 37 | `Employment Regulations 2025-2026` | DYING | 0 | 0 | +0 | 17 |
+| 38 | `NB-14: Claude Code Session Memory` | DYING | 0 | 0 | +0 | 17 |
+| 39 | `NB-9: Research Lab` | DYING | 0 | 0 | +0 | 17 |
+| 40 | `NB-META-LIFECYCLE-STUDY-2026-05-04` | DYING | 0 | 0 | +0 | 17 |
+| 41 | `NB-DESIGN-AGENT — Bali Zero AI Design Agent Architecture` | DYING | 0 | 0 | +0 | 17 |
+| 42 | `NB-0 Meta-NLM — System Reflection` | DYING | 0 | 0 | +0 | 17 |
+| 43 | `NB-HARARI — Yuval Noah Harari on AI (2021-2026)` | DYING | 0 | 0 | +0 | 17 |
+| 44 | `Regulatory Research 2025-2026` | DYING | 0 | 0 | +0 | 17 |
+| 45 | `August 2025 Income Tax Return for The Creative Agency` | DYING | 0 | 0 | +0 | 17 |
+| 46 | `Labor Law Research 2025-2026` | DYING | 0 | 0 | +0 | 17 |
+| 47 | `Codex Config Deep Research 2026 — Nuzantara Operator` | DYING | 0 | 0 | +0 | 17 |
+| 48 | `Codex 5.5 best practices May 2026` | DYING | 0 | 0 | +0 | 17 |
+| 49 | `NB-AGENTS` | DYING | 0 | 0 | +0 | 17 |
+| 50 | `NB-0: Zantara Cognitive Identity Blueprint` | DYING | 0 | 0 | +0 | 17 |
+| 51 | `NB-12: Bali Zero Business Intelligence` | DYING | 0 | 0 | +0 | 17 |
+| 52 | `NB-11: Bali Zero Ops Live` | DYING | 0 | 0 | +0 | 17 |
+| 53 | `NB-13: Bali Zero System Telemetry` | DYING | 0 | 0 | +0 | 17 |
+| 54 | `NB-8 Expat Life Bali 2025` | DYING | 0 | 0 | +0 | 17 |
+| 55 | `NB-10: Team Guides — Bali Zero` | DYING | 0 | 0 | +0 | 17 |
+| 56 | `MATA GARUDA — Self-Improving Agent Research` | DYING | 0 | 0 | +0 | 17 |
+| 57 | `MATA GARUDA — Open Source Intel Tools` | DYING | 0 | 0 | +0 | 17 |
+| 58 | `Mata Garuda — Self-Evolving Agent Research` | DYING | 0 | 0 | +0 | 17 |
+| 59 | `MATA GARUDA — Intelligence Architecture Research` | DYING | 0 | 0 | +0 | 17 |
+| 60 | `NB-INTEL-AIResearch — Daily AI Intelligence` | DYING | 0 | 0 | +0 | 17 |
+| 61 | `Labor Law Research May 2025` | DYING | 0 | 0 | +0 | 17 |
+| 62 | `Tax Changes Research 2025-2026` | DYING | 0 | 0 | +0 | 17 |
+| 63 | `` | DYING | 0 | 0 | +0 | 17 |
+| 64 | `HGB Property Research 2025-2026` | DYING | 0 | 0 | +0 | 17 |
+| 65 | `Veo Competitors 2026` | DYING | 0 | 0 | +0 | 17 |
+| 66 | `NB-PROBE-SANDBOX-2026-05` | DYING | 0 | 0 | +0 | 17 |
+| 67 | `Regulatory Research May 2026` | DYING | 0 | 0 | +0 | 17 |
+| 68 | `Veo Flow Ecosystem Research 2026` | DYING | 0 | 0 | +0 | 17 |
+| 69 | `Arming Claude Code May 2026 — deep research` | DYING | 0 | 0 | +0 | 17 |
+| 70 | `Nuzantara CRM autonomous DB Workspace Drive sync research 2026-05-09` | DYING | 0 | 0 | +0 | 17 |
+| 71 | `` | DYING | 0 | 0 | +0 | 17 |
+| 72 | `Bali Minimum Wage 2025 Research` | DYING | 0 | 0 | +0 | 17 |
+| 73 | `UU Cipta Kerja 2025-2026 Research` | DYING | 0 | 0 | +0 | 17 |
+
+<details>
+<summary>Diagnostic columns (skill_derivation_count, downstream_cite_rate, freshness, push_success, instrumentation_status)</summary>
+
+| name | skill_derivation_count | downstream_cite_rate | source_freshness_age_days | push_success_rate | instrumentation_status |
+|---|---:|---:|---:|---:|:---|
+| `NB-2: Immigration & Visa — Indonesia 2025` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-3: Company Setup — Indonesia 2025` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-4 — Tax & Fiscal Indonesia | Bali Zero` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-5 — Property & Real Estate Indonesia 2025` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-7 Editorial & Content Strategy 2025 — Bali Zero` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-INTEL-Tax — Daily Tax/Fiscal Intelligence` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-INTEL-Immigration — Daily Immigration Intelligence` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-INTEL-Press — Daily Press Intelligence` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-INTEL-Regulation — Daily Regulatory Intelligence` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-1: Nuzantara Codebase & Architecture` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `WA CRM Enrichment Architecture 2026` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `ANALISI-LEGALE-ZANTARA` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Immigration Regulation Search 2025-2026` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `KITAS Research 2025-2026` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `KITAP Research 2025-2026` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Indonesian Tax Updates 2025-2026` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Meet 2026-05-13 Salvatore Iorio — Bali Real Estate` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `[ARCHIVED-DELETE-2026-05-07] NB-NLM-ELEVATION — SOTA research & brainstorm 2026-04-25` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `[MERGED-INTO-dc5d01cd-2026-05-07] Claude Code optimization research 2026-04-21` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `[MERGED-INTO-d2a05271-2026-05-07] Digital Sovereignty & Ancestral Wisdom AI` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `[MERGED-INTO-dc5d01cd-2026-05-07] World Models 2026 — Comprehensive Survey (Genie, Waypoint, GameNGen, SORA)` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `[ARCHIVED-DELETE-2026-05-07] Analisi Video AI Agency` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `[MERGED-INTO-dc5d01cd-2026-05-07] Nexus — Palantir Architecture Deep Research` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-6 Operations & Compliance Indonesia 2025 — Bali Zero` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Piano di Ristrutturazione e Conformità per PT Wirramanda` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Agenti in Evoluzione: Rapporto sulla Ricerca 2026` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `[EXPORTED-2026-05-07] BZ Morning News — Multi-Domain Briefing` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Bali Zero Setup Guide Mac+Mobile — Cinematic ID` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `WR2 Badung HOREKA Waste Carousel Verification 2026-05-11` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Labor Regulatory Check May 2026` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `CRM sync open-source patterns fast import 2026-05-09` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Kura Kura Bali Crisis 2026-05-12 — OSINT briefing` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Ciclo di Vita e Manutenzione dei Sistemi Informativi NotebookLM` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `AI Evolutionary Frontier quicktime 2026 — ALTK/DGM/PTB/SoM` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NLM Video Falla Research 2026-05-08` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NIB PMA Regulations 2025-2026 Research` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Employment Regulations 2025-2026` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-14: Claude Code Session Memory` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-9: Research Lab` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-META-LIFECYCLE-STUDY-2026-05-04` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-DESIGN-AGENT — Bali Zero AI Design Agent Architecture` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-0 Meta-NLM — System Reflection` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-HARARI — Yuval Noah Harari on AI (2021-2026)` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Regulatory Research 2025-2026` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `August 2025 Income Tax Return for The Creative Agency` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Labor Law Research 2025-2026` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Codex Config Deep Research 2026 — Nuzantara Operator` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Codex 5.5 best practices May 2026` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-AGENTS` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-0: Zantara Cognitive Identity Blueprint` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-12: Bali Zero Business Intelligence` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-11: Bali Zero Ops Live` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-13: Bali Zero System Telemetry` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-8 Expat Life Bali 2025` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-10: Team Guides — Bali Zero` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `MATA GARUDA — Self-Improving Agent Research` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `MATA GARUDA — Open Source Intel Tools` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Mata Garuda — Self-Evolving Agent Research` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `MATA GARUDA — Intelligence Architecture Research` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-INTEL-AIResearch — Daily AI Intelligence` | N/A | N/A | N/A | 0.29 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Labor Law Research May 2025` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Tax Changes Research 2025-2026` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `HGB Property Research 2025-2026` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Veo Competitors 2026` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-PROBE-SANDBOX-2026-05` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Regulatory Research May 2026` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Veo Flow Ecosystem Research 2026` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Arming Claude Code May 2026 — deep research` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Nuzantara CRM autonomous DB Workspace Drive sync research 2026-05-09` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Bali Minimum Wage 2025 Research` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `UU Cipta Kerja 2025-2026 Research` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+
+</details>

--- a/research/regulatory/2026-06-10-delta.json
+++ b/research/regulatory/2026-06-10-delta.json
@@ -1,0 +1,59 @@
+{
+  "run_at": "2026-06-10T07:00:00+08:00",
+  "today": "2026-06-10",
+  "yesterday_seen_count": 13,
+  "new_today_count": 2,
+  "partial": false,
+  "nb_query_errors": [],
+  "unreachable_sources": [
+    "hukumonline.com (403/blocked on berita search paths)",
+    "ortax.org (Artikel tidak ditemukan — JS-rendered, no content returned)",
+    "muc.co.id (empty response, blocked)",
+    "ikpi.or.id (not fetched — sufficient data from ddtc.co.id primary)"
+  ],
+  "deltas": [
+    {
+      "citation": "PP 20/2026, Pasal II ayat (1) huruf c (Peraturan Pemerintah Nomor 20 Tahun 2026 — ketentuan peralihan)",
+      "title_id": "Suket PPh Final UMKM Berdasarkan PP 55/2022 yang Berakhir 2024 Tetap Berlaku untuk 2025 dan 2026",
+      "title_en": "PPh Final UMKM Tax Certificate Under PP 55/2022 Expiring in 2024 Remains Valid for Tax Years 2025 and 2026",
+      "service_line": ["tax"],
+      "severity": "medium",
+      "confidence": "medium",
+      "impact_note": "Clients (individual WP or PT Perorangan) whose PPh Final UMKM suket issued under PP 55/2022 expired in tax year 2024 do NOT need to re-apply — the certificate remains valid through 2026 under PP 20/2026 transitional provisions.",
+      "summary": "Pasal II ayat (1) huruf c of PP 20/2026 establishes a transitional provision clarifying that PPh Final UMKM tax certificates (suket) issued under PP 55/2022 that expired in tax year 2024 remain legally valid for tax years 2025 and 2026. This addresses practitioner confusion on Coretax where the facility appears unavailable for such taxpayers despite the legal entitlement. Relevant for Bali Zero clients enrolled in the 0.5% UMKM final PPh scheme whose 7-year (WP OP) or 4-year (PT Perorangan) benefit period ended in 2024.",
+      "source": "https://news.ddtc.co.id/berita/nasional/1819965/mau-bikin-bupot-tapi-fasilitas-pph-final-tak-muncul-harus-gimana",
+      "verbatim_excerpt": "Pasal II ayat (1) huruf c PP 20/2026 menyatakan surat keterangan pengenaan PPh final berdasarkan PP 55/2022 yang berakhir pada tahun pajak 2024 tetap berlaku untuk tahun pajak 2025 dan 2026.",
+      "first_seen_at": "2026-06-10T07:00:00+08:00"
+    },
+    {
+      "citation": "PP 20/2026 (enforcement — DJP detection 93.260 WP terindikasi firm-splitting, data Juni 2026)",
+      "title_id": "DJP Catat Ada 93.260 WP Terindikasi Salahgunakan PPh Final UMKM (17,21% dari total WP UMKM terdaftar)",
+      "title_en": "Tax Authority Identifies 93,260 Taxpayers Suspected of Misusing PPh Final UMKM (17.21% of All Registered UMKM Taxpayers)",
+      "service_line": ["tax", "company"],
+      "severity": "medium",
+      "confidence": "medium",
+      "impact_note": "DJP has active enforcement data identifying 17% of UMKM taxpayers as firm-splitting abusers. Bali Zero clients with multiple registered UMKM entities should review combined revenue against the Rp4.8B aggregate threshold established by PP 20/2026 Pasal 57 before DJP contact.",
+      "summary": "The Directorate General of Taxes disclosed June 9, 2026 that it has identified 93,260 taxpayers (17.21% of 542,000 registered UMKM PPh Final taxpayers) as suspected of engaging in firm splitting to remain under the Rp4.8 billion threshold and misuse the 0.5% final PPh rate. This follows PP 20/2026 anti-splitting provisions (Pasal 57 ayat 2 huruf e). DJP enforcement action is active; individual taxpayers and PT Perorangan with multiple related entities face heightened audit risk.",
+      "source": "https://news.ddtc.co.id/berita/nasional/1819966/djp-catat-ada-puluhan-ribu-wp-terindikasi-salahgunakan-pph-final-umkm",
+      "verbatim_excerpt": "PPh final UMKM hanya untuk wajib pajak orang pribadi, wajib pajak badan berbentuk perseroan perorangan, serta wajib pajak badan berbentuk koperasi.",
+      "first_seen_at": "2026-06-10T07:00:00+08:00"
+    }
+  ],
+  "seen_citations": [
+    "PER-6/PJ/2026",
+    "UU 2/2026",
+    "KEP-71/PJ/2026",
+    "019/MK/EF.2/2026",
+    "PP 20/2026 (Peraturan Pemerintah Nomor 20 Tahun 2026)",
+    "PP 20/2026, Pasal 56 ayat (3) huruf a (Peraturan Pemerintah Nomor 20 Tahun 2026)",
+    "PP 20/2026, Pasal 57 ayat (2) huruf e (Peraturan Pemerintah Nomor 20 Tahun 2026)",
+    "PP 20/2026; PP 55/2022; PP 23/2018",
+    "PP 20/2026, Pasal 56 ayat (4), Pasal 57 ayat (2) (Peraturan Pemerintah Nomor 20 Tahun 2026)",
+    "Coretax DJP (sistem administrasi perpajakan Direktorat Jenderal Pajak)",
+    "PMK No. 37/2026",
+    "PMK No. 36/2026",
+    "21/MK/EF.2/2026",
+    "PP 20/2026, Pasal II ayat (1) huruf c (Peraturan Pemerintah Nomor 20 Tahun 2026 — ketentuan peralihan)",
+    "PP 20/2026 (enforcement — DJP detection 93.260 WP terindikasi firm-splitting, data Juni 2026)"
+  ]
+}

--- a/research/regulatory/2026-06-11-delta.json
+++ b/research/regulatory/2026-06-11-delta.json
@@ -1,0 +1,61 @@
+{
+  "run_at": "2026-06-11T07:00:00+08:00",
+  "today": "2026-06-11",
+  "yesterday_seen_count": 15,
+  "new_today_count": 2,
+  "partial": false,
+  "nb_query_errors": [],
+  "unreachable_sources": [
+    "hukumonline.com (403 Forbidden)",
+    "ortax.org/kategori/berita-pajak (404 Not Found)",
+    "peraturan.bpk.go.id (403 Forbidden)",
+    "jdih.kemenkeu.go.id (no database content returned)"
+  ],
+  "deltas": [
+    {
+      "citation": "Permenkum 49/2025, Pasal 27 ayat (1) (Peraturan Menteri Hukum Nomor 49 Tahun 2025)",
+      "title_id": "PT Perorangan Wajib Sampaikan Laporan Keuangan via SABH — Batas Waktu 30 Juni 2026 untuk Periode Akuntansi 2025",
+      "title_en": "PT Perorangan Must Submit FY2025 Financial Reports via SABH — Deadline June 30, 2026",
+      "service_line": ["company"],
+      "severity": "high",
+      "confidence": "medium",
+      "impact_note": "PT Perorangan clients with December 31 fiscal year-end must submit laporan posisi keuangan, laba rugi, dan catatan atas laporan keuangan for FY2025 via SABH (Sistem Administrasi Badan Hukum) by June 30, 2026 — 19 days from today. Non-compliance triggers staged sanctions escalating to legal status revocation after 5 years.",
+      "summary": "Pasal 27 ayat (1) Permenkum 49/2025 requires PT Perorangan (individual limited liability companies) to submit annual financial reports electronically via SABH within 6 months of the end of the accounting period. For FY2025 (period ending December 31, 2025), the deadline is June 30, 2026. Required documents: (i) laporan posisi keuangan, (ii) laporan laba rugi, (iii) catatan atas laporan keuangan. Sanctions for non-compliance are staged: teguran tertulis pertama (after 6 months past deadline) → teguran tertulis kedua (3 months later) → penghentian akses SABH (30 days after second warning) → pencabutan status badan hukum (after 5 years of suspended access). Highly relevant for Bali Zero PT Perorangan clients approaching this imminent deadline.",
+      "source": "https://news.ddtc.co.id/berita/nasional/1819996/ingat-pt-perorangan-wajib-sampaikan-laporan-keuangan-via-sabh",
+      "verbatim_excerpt": "Laporan keuangan perseroan perorangan dilaporkan kepada menteri dengan melakukan pengisian formulir isian penyampaian laporan keuangan secara elektronik melalui SABH paling lama 6 (enam) bulan setelah akhir periode akuntansi berjalan",
+      "first_seen_at": "2026-06-11T07:00:00+08:00"
+    },
+    {
+      "citation": "PP 20/2026 (DJP klarifikasi — PT dan CV tidak termasuk penerima fasilitas PPh Final UMKM 0,5%)",
+      "title_id": "DJP Tegaskan PT dan CV Tidak Dapat Menggunakan PPh Final UMKM karena Kewajiban Pembukuan",
+      "title_en": "Tax Authority Confirms PT and CV Cannot Use PPh Final UMKM 0.5% Rate — Must Apply General Tax Provisions",
+      "service_line": ["tax", "company"],
+      "severity": "medium",
+      "confidence": "medium",
+      "impact_note": "Bali Zero clients with PT (non-Perorangan) or CV who previously used the 0.5% PPh Final UMKM rate must now comply with general income tax provisions (ketentuan umum perpajakan). The 0.5% rate remains available only for WP Orang Pribadi, PT Perorangan, and cooperatives under Rp 4.8 billion turnover. WP OP retain exemption on first Rp 500 million turnover.",
+      "summary": "DJP Direktur Inge Diana Rismawanti confirmed on June 10, 2026 that PT (regular, non-Perorangan) and CV are excluded from the PPh Final UMKM simplified tax regime under PP 20/2026, because these entities are required to maintain full accounting records (pembukuan). PT and CV must therefore compute tax under general provisions (ketentuan umum perpajakan) proportional to net profit rather than applying 0.5% on gross turnover. This is a material operational impact for Bali Zero clients who formed a PT or CV expecting to use the UMKM rate — they must now recompute their tax obligations under the standard regime.",
+      "source": "https://news.ddtc.co.id/berita/nasional/1819995/pembukuan-jadi-alasan-pt-dan-cv-tak-bisa-lagi-pakai-pph-final-umkm",
+      "verbatim_excerpt": "Mereka sudah kita arahkan untuk mengikuti ketentuan umum perpajakan",
+      "first_seen_at": "2026-06-11T07:00:00+08:00"
+    }
+  ],
+  "seen_citations": [
+    "PER-6/PJ/2026",
+    "UU 2/2026",
+    "KEP-71/PJ/2026",
+    "019/MK/EF.2/2026",
+    "PP 20/2026 (Peraturan Pemerintah Nomor 20 Tahun 2026)",
+    "PP 20/2026, Pasal 56 ayat (3) huruf a (Peraturan Pemerintah Nomor 20 Tahun 2026)",
+    "PP 20/2026, Pasal 57 ayat (2) huruf e (Peraturan Pemerintah Nomor 20 Tahun 2026)",
+    "PP 20/2026; PP 55/2022; PP 23/2018",
+    "PP 20/2026, Pasal 56 ayat (4), Pasal 57 ayat (2) (Peraturan Pemerintah Nomor 20 Tahun 2026)",
+    "Coretax DJP (sistem administrasi perpajakan Direktorat Jenderal Pajak)",
+    "PMK No. 37/2026",
+    "PMK No. 36/2026",
+    "21/MK/EF.2/2026",
+    "PP 20/2026, Pasal II ayat (1) huruf c (Peraturan Pemerintah Nomor 20 Tahun 2026 — ketentuan peralihan)",
+    "PP 20/2026 (enforcement — DJP detection 93.260 WP terindikasi firm-splitting, data Juni 2026)",
+    "Permenkum 49/2025, Pasal 27 ayat (1) (PT Perorangan laporan keuangan via SABH)",
+    "PP 20/2026 (DJP klarifikasi — PT dan CV tidak termasuk penerima fasilitas PPh Final UMKM 0,5%)"
+  ]
+}

--- a/research/regulatory/2026-06-12-delta.json
+++ b/research/regulatory/2026-06-12-delta.json
@@ -1,0 +1,53 @@
+{
+  "run_at": "2026-06-12T07:00:00+08:00",
+  "today": "2026-06-12",
+  "yesterday_seen_count": 17,
+  "new_today_count": 1,
+  "partial": false,
+  "nb_query_errors": [],
+  "unreachable_sources": [
+    "hukumonline.com (403 Cloudflare)",
+    "ortax.org (SPA/JS-rendered, not parseable via curl)",
+    "muc.co.id (403 Forbidden)",
+    "ikpi.or.id (404 Not Found)",
+    "peraturan.bpk.go.id (200 but PMK jenis filter returned mixed PP/UU results)"
+  ],
+  "deltas": [
+    {
+      "citation": "PP 20/2026, ketentuan peralihan (DJP June 11, 2026 — WP OP pembetulan SPT 2025 from NPPN to PPh Final UMKM 0.5%)",
+      "title_id": "DJP Klarifikasi: WP OP yang Telanjur Pakai NPPN untuk SPT 2025 Masih Bisa Beralih ke PPh Final UMKM 0,5% via Pembetulan SPT",
+      "title_en": "DJP Confirms: Individual Taxpayers Who Filed 2025 SPT Under NPPN Can Return to PPh Final UMKM 0.5% By Amending SPT",
+      "service_line": [
+        "tax"
+      ],
+      "severity": "medium",
+      "confidence": "medium",
+      "impact_note": "Bali Zero WP OP clients who mistakenly filed FY2025 SPT Tahunan using NPPN instead of PPh Final 0.5% UMKM can still amend — provided they have NOT yet submitted a formal pemberitahuan to DJP choosing general tax provisions. If overpaid tax resulted, clients can file permohonan pengembalian pajak. Window open for tax years 2025 and 2026.",
+      "summary": "DJP fungsional penyuluh Rohmat Arifin clarified on June 11, 2026 (webinar P3KPI) that WP OP who switched to NPPN for 2025 SPT can revert to PPh Final UMKM 0.5% by amending (pembetulan) their SPT Tahunan PPh 2025. Condition: WP has NOT yet filed a formal notification choosing general tax provisions. Under PP 20/2026 ketentuan peralihan, PPh Final UMKM 0.5% remains available for WP OP for tax years 2025 and 2026 as long as omzet < Rp4.8 billion and no formal election of general regime was made.",
+      "source": "https://news.ddtc.co.id/berita/nasional/1820026/wp-op-yang-telanjur-pakai-norma-bisa-kembali-ke-rezim-pph-final-umkm",
+      "verbatim_excerpt": "Selama kita belum melakukan pemberitahuan penggunaan tarif umum meski kita sudah telanjur menggunakan NPPN pada 2025, kita masih berhak menggunakan PPh final UMKM untuk tahun 2025 dan 2026. Ini untuk wajib pajak orang pribadi. Jadi silakan melakukan pembetulan SPT. Kalau ada pajak yang seharusnya tidak terutang, silakan dilakukan permohonan pengembalian pajak.",
+      "first_seen_at": "2026-06-12T07:00:00+08:00"
+    }
+  ],
+  "seen_citations": [
+    "PER-6/PJ/2026",
+    "UU 2/2026",
+    "KEP-71/PJ/2026",
+    "019/MK/EF.2/2026",
+    "PP 20/2026 (Peraturan Pemerintah Nomor 20 Tahun 2026)",
+    "PP 20/2026, Pasal 56 ayat (3) huruf a (Peraturan Pemerintah Nomor 20 Tahun 2026)",
+    "PP 20/2026, Pasal 57 ayat (2) huruf e (Peraturan Pemerintah Nomor 20 Tahun 2026)",
+    "PP 20/2026; PP 55/2022; PP 23/2018",
+    "PP 20/2026, Pasal 56 ayat (4), Pasal 57 ayat (2) (Peraturan Pemerintah Nomor 20 Tahun 2026)",
+    "Coretax DJP (sistema amministrativo perpajakan Direktorat Jenderal Pajak)",
+    "PMK No. 37/2026",
+    "PMK No. 36/2026",
+    "21/MK/EF.2/2026",
+    "PP 20/2026, Pasal II ayat (1) huruf c (Peraturan Pemerintah Nomor 20 Tahun 2026 — ketentuan peralihan)",
+    "PP 20/2026 (enforcement — DJP detection 93.260 WP terindikasi firm-splitting, data Juni 2026)",
+    "Permenkum 49/2025, Pasal 27 ayat (1) (PT Perorangan laporan keuangan via SABH)",
+    "PP 20/2026 (DJP klarifikasi — PT dan CV tidak termasuk penerima fasilitas PPh Final UMKM 0,5%)",
+    "PP 20/2026, ketentuan peralihan (DJP June 11, 2026 — WP OP pembetulan SPT 2025 from NPPN to PPh Final UMKM 0.5%)",
+    "22/MK/EF.2/2026 (nilai kurs — routine, low relevance for Bali Zero service lines)"
+  ]
+}

--- a/research/regulatory/2026-06-13-delta.json
+++ b/research/regulatory/2026-06-13-delta.json
@@ -1,0 +1,58 @@
+{
+  "run_at": "2026-06-13T07:00:00+08:00",
+  "today": "2026-06-13",
+  "yesterday_seen_count": 19,
+  "new_today_count": 1,
+  "partial": true,
+  "nb_query_errors": [],
+  "unreachable_sources": [
+    "hukumonline.com (403 Cloudflare)",
+    "ortax.org (JS-rendered/SPA, nessun contenuto estraibile)",
+    "muc.co.id (403 Forbidden)",
+    "ikpi.or.id (404 Not Found)",
+    "peraturan.bpk.go.id (403 su pagine dettaglio)",
+    "imigrasi.go.id/news (404 Not Found)",
+    "pajak.go.id/berita-terbaru (404 Not Found)",
+    "jdih.kemenkeu.go.id (nessun contenuto strutturato)"
+  ],
+  "nb_notes": "Tutti e 4 i NB-INTEL (Regulation, Press, Immigration, Tax) hanno risposto nessuna novita per il periodo 24-48h.",
+  "deltas": [
+    {
+      "citation": "PP 20/2026; Pasal 31E ayat (1) UU PPh s.t.d.d UU HPP (DJP klarifikasi — PT dan CV tarif PPh 11% via fasilitas pengurangan tarif Pasal 31E(1))",
+      "title_id": "Bukan PPh Final UMKM, PT dan CV Masih Bisa Pakai Tarif PPh 11% via Fasilitas Pasal 31E ayat (1) UU PPh",
+      "title_en": "Unlike MSME Final PPh (0.5%), PT and CV Can Still Use 11% Corporate PPh Rate via Article 31E(1) 50% Tariff Reduction Facility",
+      "service_line": [
+        "tax"
+      ],
+      "severity": "medium",
+      "confidence": "medium",
+      "impact_note": "PT PMA / PT PMDN / CV clients excluded from PP 20/2026 UMKM 0.5% PPh Final scheme retain access to Pasal 31E(1) 50% tariff reduction, bringing effective PPh badan from 22% to 11%, for gross revenue (omzet) <= Rp50 billion. Bali Zero PT PMA clients should be informed of this alternative.",
+      "summary": "DJP Director P2Humas Inge Diana Rismawanti confirmed June 13, 2026 (DDTC) that PT and CV excluded from PP 20/2026 UMKM 0.5% PPh Final scheme still qualify for Pasal 31E ayat (1) UU PPh s.t.d.d UU HPP: 50% reduction on standard 22% PPh badan rate, yielding effective 11% rate, for taxpayers with gross turnover up to Rp50 billion. The UMKM exclusion does NOT preclude access to this separate UU PPh facility.",
+      "source": "news.ddtc.co.id | https://news.ddtc.co.id/berita/nasional/1820052/bukan-pph-final-umkm-pt-dan-cv-masih-bisa-pakai-tarif-pph-11",
+      "verbatim_excerpt": "\"Omzet sampai dengan Rp50 miliar, badan usaha yang seharusnya kena tarif PPh badan 22%, ini dikalikan dulu dengan 50% [fasilitas pengurangan tarif]. Jadi sebetulnya tarif PPh 11%.\" Inge Diana Rismawanti (Direktur P2Humas DJP): \"PT dan CV tidak perlu lagi diberikan fasilitas karena sebetulnya mereka kan harusnya bisa lebih mapan, lebih paham tentang pembukuan.\"",
+      "first_seen_at": "2026-06-13T07:00:00+08:00"
+    }
+  ],
+  "seen_citations": [
+    "PER-6/PJ/2026",
+    "UU 2/2026",
+    "KEP-71/PJ/2026",
+    "019/MK/EF.2/2026",
+    "PP 20/2026 (Peraturan Pemerintah Nomor 20 Tahun 2026)",
+    "PP 20/2026, Pasal 56 ayat (3) huruf a (Peraturan Pemerintah Nomor 20 Tahun 2026)",
+    "PP 20/2026, Pasal 57 ayat (2) huruf e (Peraturan Pemerintah Nomor 20 Tahun 2026)",
+    "PP 20/2026; PP 55/2022; PP 23/2018",
+    "PP 20/2026, Pasal 56 ayat (4), Pasal 57 ayat (2) (Peraturan Pemerintah Nomor 20 Tahun 2026)",
+    "Coretax DJP (sistema amministrativo perpajakan Direktorat Jenderal Pajak)",
+    "PMK No. 37/2026",
+    "PMK No. 36/2026",
+    "21/MK/EF.2/2026",
+    "PP 20/2026, Pasal II ayat (1) huruf c (Peraturan Pemerintah Nomor 20 Tahun 2026 — ketentuan peralihan)",
+    "PP 20/2026 (enforcement — DJP detection 93.260 WP terindikasi firm-splitting, data Juni 2026)",
+    "Permenkum 49/2025, Pasal 27 ayat (1) (PT Perorangan laporan keuangan via SABH)",
+    "PP 20/2026 (DJP klarifikasi — PT dan CV tidak termasuk penerima fasilitas PPh Final UMKM 0,5%)",
+    "PP 20/2026, ketentuan peralihan (DJP June 11, 2026 — WP OP pembetulan SPT 2025 from NPPN to PPh Final UMKM 0.5%)",
+    "22/MK/EF.2/2026 (nilai kurs — routine, low relevance for Bali Zero service lines)",
+    "PP 20/2026; Pasal 31E ayat (1) UU PPh s.t.d.d UU HPP (PT dan CV tarif PPh 11% via Pasal 31E(1), June 13 2026)"
+  ]
+}

--- a/research/regulatory/2026-06-14-delta.json
+++ b/research/regulatory/2026-06-14-delta.json
@@ -1,0 +1,86 @@
+{
+  "run_at": "2026-06-14T07:00:00+08:00",
+  "today": "2026-06-14",
+  "yesterday_seen_count": 20,
+  "new_today_count": 3,
+  "partial": true,
+  "nb_query_errors": [],
+  "nb_notes": "Tutti e 4 i NB-INTEL (Regulation, Press, Immigration, Tax) hanno risposto nessuna novita per il periodo 24-48h.",
+  "unreachable_sources": [
+    "hukumonline.com (403 Cloudflare)",
+    "muc.co.id (403 Forbidden)"
+  ],
+  "deltas": [
+    {
+      "citation": "KBLI 2025 (implementasi AHU Online dan OSS, effettivo 15 Juni 2026)",
+      "title_id": "KBLI 2025 Mulai Diterapkan di Sistem AHU Online dan OSS Mulai 15 Juni",
+      "title_en": "KBLI 2025 Classification Codes Go Live on AHU Online and OSS from 15 June 2026",
+      "service_line": [
+        "company"
+      ],
+      "severity": "high",
+      "confidence": "medium",
+      "impact_note": "All new PT PMA company registrations and amendments via AHU Online and OSS from 15 June 2026 must use KBLI 2025 codes — old codes no longer accepted; pending submissions must be verified against new classification before tomorrow.",
+      "summary": "From 15 June 2026 AHU Online (Kemenkumham company registry) and OSS (Online Single Submission) enforce KBLI 2025 classification codes for all new company registrations and amendments. OSS system was under scheduled maintenance 13-14 June 2026 and relaunches 15 June with new KBLI 2025 structure. Bali Zero clients with pending PT PMA setup or OSS licensing must verify selected KBLI codes against 2025 classification before submission.",
+      "source": "news.ddtc.co.id | https://news.ddtc.co.id/berita/nasional/1820061/kbli-2025-mulai-diterapkan-di-sistem-ahu-online-dan-oss-mulai-15-juni",
+      "verbatim_excerpt": "KBLI 2025 Mulai Diterapkan di Sistem AHU Online dan OSS Mulai 15 Juni — OSS system under maintenance 13-14 June relaunches 15 June with new classification. From 15 June 2026 all new company registrations and amendments via AHU Online and OSS must use KBLI 2025 codes.",
+      "first_seen_at": "2026-06-14T07:00:00+08:00"
+    },
+    {
+      "citation": "PER-19/PJ/2025",
+      "title_id": "Ingat, Tak Laporkan SPT Bisa Berujung Penonaktifan Akses Faktur",
+      "title_en": "Reminder: Failure to File SPT Can Lead to Deactivation of e-Faktur Access",
+      "service_line": [
+        "tax"
+      ],
+      "severity": "medium",
+      "confidence": "medium",
+      "impact_note": "PT PMA clients with PKP status on Bali Zero tax retainer risk e-faktur deactivation if they miss 3 consecutive monthly VAT returns or 6 periods in the same calendar year — verify June SPT compliance for all active PKP clients.",
+      "summary": "DJP reminder (13 June 2026, DDTC) under PER-19/PJ/2025: a PKP (Pengusaha Kena Pajak) that fails to file annual SPT or monthly VAT returns for 3 consecutive months or 6 periods in a calendar year faces deactivation of e-faktur (electronic invoice) access. Affected PKPs have 5 working days to submit a clarification letter to their local KPP (tax office) to restore access.",
+      "source": "news.ddtc.co.id | https://news.ddtc.co.id/berita/nasional/1820063/ingat-tak-laporkan-spt-bisa-berujung-penonaktifan-akses-faktur",
+      "verbatim_excerpt": "DJP dapat menonaktifkan akses faktur PKP yang tidak melaporkan SPT Tahunan atau SPT Masa PPN selama 3 masa pajak berturut-turut atau 6 masa pajak dalam satu tahun kalender. PKP yang dinonaktifkan memiliki 5 hari kerja untuk menyampaikan klarifikasi ke KPP setempat.",
+      "first_seen_at": "2026-06-14T07:00:00+08:00"
+    },
+    {
+      "citation": "PMK 6/2026",
+      "title_id": "Kemenaker dan BNSP Siapkan Sertifikasi Magang Nasional — peserta NPWP bebas PPh Pasal 21",
+      "title_en": "Kemenaker + BNSP National Internship Certification; Internship Stipends PPh Pasal 21 Exempt for NPWP Holders (PMK 6/2026)",
+      "service_line": [
+        "tax",
+        "regulatory"
+      ],
+      "severity": "low",
+      "confidence": "medium",
+      "impact_note": "PT PMA clients employing Indonesian interns under MagangHub national program: internship stipends are PPh Pasal 21 exempt for participants holding NPWP — verify payroll configuration.",
+      "summary": "DDTC reported (13 June 2026) that Kemenaker and BNSP are preparing 15 certification schemes for MagangHub national internship program graduates. The article confirmed that under PMK 6/2026, internship participants holding NPWP are exempt from PPh Pasal 21 on stipend payments.",
+      "source": "news.ddtc.co.id | https://news.ddtc.co.id/berita/nasional/1820066/kemenaker-dan-bnsp-siapkan-sertifikasi-untuk-lulusan-magang-nasional",
+      "verbatim_excerpt": "peserta magang yang memiliki NPWP dibebaskan dari PPh Pasal 21 atas uang saku yang diterima dalam program MagangHub",
+      "first_seen_at": "2026-06-14T07:00:00+08:00"
+    }
+  ],
+  "seen_citations": [
+    "PER-6/PJ/2026",
+    "UU 2/2026",
+    "KEP-71/PJ/2026",
+    "019/MK/EF.2/2026",
+    "PP 20/2026 (Peraturan Pemerintah Nomor 20 Tahun 2026)",
+    "PP 20/2026, Pasal 56 ayat (3) huruf a (Peraturan Pemerintah Nomor 20 Tahun 2026)",
+    "PP 20/2026, Pasal 57 ayat (2) huruf e (Peraturan Pemerintah Nomor 20 Tahun 2026)",
+    "PP 20/2026; PP 55/2022; PP 23/2018",
+    "PP 20/2026, Pasal 56 ayat (4), Pasal 57 ayat (2) (Peraturan Pemerintah Nomor 20 Tahun 2026)",
+    "Coretax DJP (sistema amministrativo perpajakan Direktorat Jenderal Pajak)",
+    "PMK No. 37/2026",
+    "PMK No. 36/2026",
+    "21/MK/EF.2/2026",
+    "PP 20/2026, Pasal II ayat (1) huruf c (Peraturan Pemerintah Nomor 20 Tahun 2026 — ketentuan peralihan)",
+    "PP 20/2026 (enforcement — DJP detection 93.260 WP terindikasi firm-splitting, data Juni 2026)",
+    "Permenkum 49/2025, Pasal 27 ayat (1) (PT Perorangan laporan keuangan via SABH)",
+    "PP 20/2026 (DJP klarifikasi — PT dan CV tidak termasuk penerima fasilitas PPh Final UMKM 0,5%)",
+    "PP 20/2026, ketentuan peralihan (DJP June 11, 2026 — WP OP pembetulan SPT 2025 from NPPN to PPh Final UMKM 0.5%)",
+    "22/MK/EF.2/2026 (nilai kurs — routine, low relevance for Bali Zero service lines)",
+    "PP 20/2026; Pasal 31E ayat (1) UU PPh s.t.d.d UU HPP (PT dan CV tarif PPh 11% via Pasal 31E(1), June 13 2026)",
+    "KBLI 2025 (implementasi AHU Online dan OSS, effettivo 15 Juni 2026)",
+    "PER-19/PJ/2025",
+    "PMK 6/2026"
+  ]
+}


### PR DESCRIPTION
## What

Promotes orphaned output from the **regulatory-watcher** and **nb-curator** crons (2026-06-10 → 2026-06-15) that was produced on Pro but never reached `main`.

## Why — the publish-drift scar

The crons ran and produced real artifacts, but the last-mile (`commit → PR → merge`) never fired: the watcher wrapper reads `main`, sees its freshly-generated delta is *not* there (because W79 worktree-isolation blocks the `cp` into the main checkout), false-flags its own output as "hallucinated", and skips publish. So the deltas piled up in the Pro working tree, unpromoted, for days — surfaced during the Pro main realign.

Recovered from the pre-realign snapshot (`ff0c3e118` on Pro) and promoted **surgically**:
- ✅ research docs only (`.json` / `.md`)
- ✅ **zero PII** (re-scanned twice — passport/NPWP/KTP/phone/email; the only `NPWP` hits are public regulatory titles, e.g. PMK 6/2026 intern stipend exemption)
- ✅ **zero sibling-session corpus** (the `research/coherence-corpus/` UUID dump from a parallel session was deliberately excluded — leave-dirty)
- ✅ **zero out-of-context code** (the 177-commit-stale `wr2_*`/`nlm_deep_research` diffs were excluded — they'd re-introduce ~16k deleted lines)

## Files (12)

- `research/regulatory/2026-06-10..14-delta.json` — 5 daily regulatory deltas (BKPM/PMK/Permenaker watch)
- `research/nb-health/2026-06-10..14-health.md` + `2026-06-15-curation.md` — 6 nb-curator health/curation reports
- `research/nb-monitor/report-2026-W24.md` — weekly monitor report

## Follow-up (operator decision, not in this PR)

The publish-drift itself is unfixed — the watcher will keep orphaning deltas until the wrapper publishes from its branch (not `main`), or via eventbus, or gets a worktree-isolation exception for `research/regulatory/`. Tracked in `unresolved_regulatory_watcher_worktree_publish_drift_2026_06_15.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
