### PR TITLE
fix(intake): file NIB/akta to 02_Company not 99_Misc (canonical category 'pma')

### DIFF
--- a/apps/backend-rag/backend/services/intake/writer.py
+++ b/apps/backend-rag/backend/services/intake/writer.py
@@ -224,12 +224,17 @@ def _document_payload(
             fields = {}
 
     # map intake doc_type → CRM document_category (folder) — mirrors create_document.
+    # NOTE: the canonical company category is "pma" (→ CATEGORY_TO_FOLDER["pma"] = "02_Company"),
+    # NOT "company": the latter is absent from document_categorizer.CATEGORY_TO_FOLDER, so it would
+    # silently fall through to the "99_Misc" default at crm_enhanced_documents.py and file NIB/akta
+    # into the Misc folder instead of 02_Company. Canonical value verified by
+    # tests/unit/app/services/portal/test_documents_mixin.py:45.
     category_map = {
         "passport": "immigration",
         "kitas": "immigration",
         "npwp": "tax",
-        "nib": "company",
-        "akta_pendirian": "company",
+        "nib": "pma",
+        "akta_pendirian": "pma",
     }
     category = category_map.get(doc_type)
 

--- a/apps/backend-rag/backend/tests/services/intake/test_intake_writer.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_intake_writer.py
@@ -498,3 +498,44 @@ async def test_rollback_commit_undoes_document(pool, seed, monkeypatch):
             )
     assert res2.outcome == "rolled_back"
     assert res2.doc_id is None, "second rollback should find nothing to undo"
+
+
+# --------------------------------------------------------------------------- #
+# Company-document folder routing (regression: NIB/akta were filed to 99_Misc)
+# Pure unit — no DB. Falsifies the company→folder mismatch end to end.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "doc_type, expected_category, expected_folder",
+    [
+        ("nib", "pma", "02_Company"),
+        ("akta_pendirian", "pma", "02_Company"),
+        ("passport", "immigration", "01_Immigration"),
+        ("npwp", "tax", "03_Tax"),
+    ],
+)
+def test_company_doc_category_maps_to_company_folder(
+    doc_type, expected_category, expected_folder
+):
+    """Intake-derived category must be the CANONICAL one that resolves to the
+    right Drive folder. Before the fix, nib/akta produced category='company',
+    which is absent from CATEGORY_TO_FOLDER → fell through to '99_Misc' (Drive
+    'Misc' instead of '02_Company'). This test fails if either side drifts:
+    the intake category map, OR the folder map.
+    """
+    from backend.services.crm.document_categorizer import CATEGORY_TO_FOLDER
+
+    payload = intake_writer._document_payload(
+        routing={"doc_type": doc_type},
+        stage_output={},
+        source_ref="test-ref",
+    )
+    category = payload["document_category"]
+    assert category == expected_category, (
+        f"{doc_type}: intake produced category={category!r}, "
+        f"expected canonical {expected_category!r}"
+    )
+    # The category MUST be a real key (not a silent 99_Misc fallthrough).
+    assert category in CATEGORY_TO_FOLDER, (
+        f"category {category!r} missing from CATEGORY_TO_FOLDER → would file to 99_Misc"
+    )
+    assert CATEGORY_TO_FOLDER[category] == expected_folder


### PR DESCRIPTION
## Problem

Intake-derived company documents (NIB, akta pendirian) were filed to Drive **`99_Misc`** instead of **`02_Company`**.

Root cause (`writer.py` `_document_payload`): the intake `doc_type → category` map produced `"company"` for `nib`/`akta_pendirian`, but `"company"` is **absent** from `document_categorizer.CATEGORY_TO_FOLDER`. It silently fell through to the `99_Misc` default → a PT PMA client's NIB/akta landed in the "Misc" folder in kita.balizero instead of `02_Company`.

## Fix

2-line map correction: `"company"` → `"pma"` (the canonical category that resolves to `02_Company`). Added an explanatory comment citing the source of truth.

## Test

New parametrized regression test (`test_company_doc_category_maps_to_company_folder`):
- asserts `nib`/`akta_pendirian` → category `"pma"` → folder `02_Company`
- control cases `passport`→`01_Immigration`, `npwp`→`03_Tax`
- **anti-drift on both sides**: fails if either the intake category map OR `CATEGORY_TO_FOLDER` drifts
- explicit `category in CATEGORY_TO_FOLDER` assert — catches the exact "silent 99_Misc fallthrough" class

Pure unit, no DB. **4 passed locally**; full intake suite **157 passed / 0 failed**.

## Notes
Discovered during the 2026-06-15 intake message-journey TAC (4-LLM validated). Original commit `d72ad8961` (M5), cherry-picked clean onto fresh main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)