### PR TITLE
fix(intake): surface failed Pro→Fly/Drive delivery in approve status

### DIFF
--- a/apps/backend-rag/backend/app/routers/intake_review.py
+++ b/apps/backend-rag/backend/app/routers/intake_review.py
@@ -1054,6 +1054,14 @@ async def approve_review(
             plan=plan,
             result=result,
         )
+        # Visibility (intake message-journey TAC 2026-06-15): the local commit
+        # is final but the Fly/Drive delivery leg is best-effort and NEVER
+        # raises. A failed delivery means the document exists in the Pro DB but
+        # is ABSENT from kita.balizero (Drive + Fly CRM) — a silent
+        # config↔reality divergence (superscar #2 "green ≠ working"). Surface it
+        # in the top-level status so the operator/front-end knows the doc did
+        # NOT land in kita, instead of seeing a success "routed".
+        response_status = _delivery_aware_status(response_status, crm_push_info)
 
     logger.info(
         "intake.review.approve proposal=%s reviewer=%s dry_run=%s outcome=%s status=%s",
@@ -1187,3 +1195,36 @@ def _as_dict(value: Any) -> dict[str, Any]:
 
 def _iso(value: datetime | None) -> str | None:
     return value.isoformat() if isinstance(value, datetime) else None
+
+
+# CrmPushResult.status values that do NOT mean "the document failed to reach
+# kita". `pushed` = delivered to Fly+Drive; `disabled` = push leg intentionally
+# off (writer/push OFF by design); `already_delivered` = the local row already
+# carries a Drive file (re-upload skipped). Every other status (`unreachable`,
+# `server_error`, `denied_rbac`, `rejected`, `too_large`, `no_token`,
+# `missing_blob`, `error`) means: committed in the Pro DB but ABSENT from
+# kita.balizero — a divergence the operator must see.
+_DELIVERY_OK_OR_NEUTRAL: frozenset[str] = frozenset(
+    {"pushed", "disabled", "already_delivered"}
+)
+
+DELIVERY_FAILED_STATUS = "committed_local_delivery_failed"
+
+
+def _delivery_aware_status(
+    base_status: str, crm_push_info: dict[str, Any] | None
+) -> str:
+    """Downgrade a 'routed' approve to a delivery-failure status when the
+    Pro→Fly/Drive push did not actually deliver the committed document.
+
+    Pure function (no I/O) so it is unit-testable across the full CrmPushResult
+    status space. Only rewrites the success case: a non-'routed' base status
+    (e.g. 'review_claimed' for a dry-run/blocked plan) is returned untouched,
+    and a missing/None push_info (delivery leg never ran) is left as-is.
+    """
+    if base_status != "routed" or not crm_push_info:
+        return base_status
+    push_status = crm_push_info.get("status")
+    if push_status in _DELIVERY_OK_OR_NEUTRAL:
+        return base_status
+    return DELIVERY_FAILED_STATUS

--- a/apps/backend-rag/backend/tests/routers/test_intake_review.py
+++ b/apps/backend-rag/backend/tests/routers/test_intake_review.py
@@ -911,3 +911,59 @@ async def test_candidate_ids_routing_fallback_and_companies_excluded(pool, seed)
         assert seed["cid_owner"] in ids, f"routing.client_id fallback missing: {cands}"
         assert seed["cid_other"] not in ids, (
             f"companies-table id leaked into clients lookup: {cands}")
+
+
+# --------------------------------------------------------------------------- #
+# Delivery-aware response status (intake message-journey TAC 2026-06-15)
+# Pure unit — no DB, no app. The Pro→Fly/Drive push NEVER raises, so a failed
+# delivery must be visible in the top-level approve status instead of a silent
+# "routed" (committed locally but ABSENT from kita.balizero — superscar #2).
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "push_status, expected",
+    [
+        # Delivered or intentionally-neutral → keep success status
+        ("pushed", "routed"),
+        ("disabled", "routed"),
+        ("already_delivered", "routed"),
+        # Every real delivery failure → operator-visible divergence status
+        ("unreachable", "committed_local_delivery_failed"),
+        ("server_error", "committed_local_delivery_failed"),
+        ("denied_rbac", "committed_local_delivery_failed"),
+        ("rejected", "committed_local_delivery_failed"),
+        ("too_large", "committed_local_delivery_failed"),
+        ("no_token", "committed_local_delivery_failed"),
+        ("missing_blob", "committed_local_delivery_failed"),
+        ("error", "committed_local_delivery_failed"),
+    ],
+)
+def test_delivery_aware_status_committed_path(push_status, expected):
+    from backend.app.routers.intake_review import _delivery_aware_status
+
+    out = _delivery_aware_status("routed", {"status": push_status})
+    assert out == expected, (
+        f"push status {push_status!r}: got {out!r}, expected {expected!r}"
+    )
+
+
+def test_delivery_aware_status_leaves_non_routed_untouched():
+    """A dry-run / blocked plan never reaches 'routed' — its status (and the
+    absence of a delivery leg) must pass through unchanged."""
+    from backend.app.routers.intake_review import _delivery_aware_status
+
+    # review_claimed is the dry-run/blocked base — never rewritten even if a
+    # (defensive) push_info were present.
+    assert _delivery_aware_status("review_claimed", None) == "review_claimed"
+    assert (
+        _delivery_aware_status("review_claimed", {"status": "unreachable"})
+        == "review_claimed"
+    )
+
+
+def test_delivery_aware_status_no_push_info_is_noop():
+    """If the delivery leg never ran (push_info is None/empty), a committed
+    'routed' stays 'routed' — we only downgrade on an OBSERVED failure."""
+    from backend.app.routers.intake_review import _delivery_aware_status
+
+    assert _delivery_aware_status("routed", None) == "routed"
+    assert _delivery_aware_status("routed", {}) == "routed"


### PR DESCRIPTION
## Problem

The 2026-06-15 intake message-journey TAC found a **silent config↔reality divergence** in the document journey `WhatsApp → intake → review → Drive → kita`.

When an operator approves a document:
1. `writer.py` commits it to the **Pro DB** (final, atomic locally)
2. `crm_push.push_committed_document` delivers it to **Fly CRM + Drive** — this leg is **best-effort and NEVER raises**

On a delivery failure (token expired / 404 client / 403 RBAC / >9MB / unreachable / 5xx), the document exists in the Pro DB but is **ABSENT from kita.balizero**, while `/approve` still returned `status="routed"` (success). **The operator sees ✅ for a document that never reached kita.** This is superscar #2 "green ≠ working".

## Fix

Pure helper `_delivery_aware_status(base_status, crm_push_info)` downgrades the top-level `"routed"` to **`"committed_local_delivery_failed"`** when the `CrmPushResult` status is a real delivery failure. Delivered/intentionally-neutral statuses (`pushed` / `disabled` / `already_delivered`) keep `"routed"`. The local commit is unchanged — only the operator-facing status now reflects whether the doc actually landed in kita ("rendi osservabile la divergenza senza sacrificare il degraded-mode").

## Test

Pure unit (no DB, no app) over the **full `CrmPushResult` status space** (11 statuses) + edges:
- 3 delivered/neutral → `routed`
- 8 real failures → `committed_local_delivery_failed`
- non-routed base (dry-run/blocked) passes through untouched
- missing/None push_info → no-op

**13 passed**, no regressions in `test_intake_review.py` (13 passed / 34 skipped).

## Why now (not after a lost doc)

`INTAKE_WRITER_ENABLED` is currently **OFF** (dry-run, Adit validation pending), so **0 orphan documents exist in production** (verified: 0 / 18553 docs with `file_id` NULL from intake). This arms the visibility **before** the writer goes ON — the opposite of the "build-but-don't-arm" meta-pattern (W81).

## Out of scope (follow-up)
A background **reconciler** that re-pushes orphaned docs (`storage_type='google_drive' AND file_id IS NULL`) needs a **service token** (`crm_push` currently uses the reviewer's own JWT) — deferred until that auth path exists and the writer is armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)