### PR TITLE
fix(ci): install pytest-asyncio in Golden Rule #10 lint (clears exit-4 on every PR)

### DIFF
--- a/.github/workflows/lint-golden-rule-10.yml
+++ b/.github/workflows/lint-golden-rule-10.yml
@@ -42,7 +42,13 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y ripgrep
           python -m pip install --upgrade pip
-          python -m pip install pytest "pydantic>=2.12.5"
+          # pytest-asyncio is required even though test_no_httpx_violators.py is
+          # sync: apps/backend-rag/pytest.ini declares asyncio_default_fixture_loop_scope,
+          # an ini option only the pytest-asyncio plugin registers. Without the plugin
+          # installed, pytest aborts at config load with "Unknown config option" (exit 4)
+          # before any test runs — turning this lint red on every PR. Pin mirrors
+          # apps/backend-rag/requirements.txt.
+          python -m pip install pytest "pytest-asyncio>=1.3.0" "pydantic>=2.12.5"
 
       - name: Run regression test (single source of truth)
         working-directory: apps/backend-rag


### PR DESCRIPTION
## Problem

The **"Detect Golden Rule #10 violations"** check (`.github/workflows/lint-golden-rule-10.yml`) is RED on **every PR** — reproduced identical on #1475, #1476, #1477.

Root cause: the workflow installs `pytest` alone (`pip install pytest "pydantic>=2.12.5"`), but `apps/backend-rag/pytest.ini` declares `asyncio_default_fixture_loop_scope` — an ini option registered **only** by the `pytest-asyncio` plugin. With the plugin absent, pytest aborts at config load:

```
ERROR: Unknown config option: asyncio_default_fixture_loop_scope
##[error]Process completed with exit code 4.
```

…**before** `test_no_httpx_violators.py` (a pure sync AST-scan test) ever runs. So the lint never actually checked anything — it just failed at startup.

## Fix

Add `pytest-asyncio>=1.3.0` to the install step (pin mirrors `apps/backend-rag/requirements.txt`). The test is unchanged and still sync; the plugin is needed only so pytest recognises the shared ini option.

`pytest.ini` is intentionally **NOT** touched — the option is valid and used by every other CI job that installs the full requirements. The bug was this one workflow's minimal install, not the config.

## Verification
- Option accepted by pytest-asyncio 1.4.0 locally (pytest 9.0.3) → no error.
- YAML lint passes.
- No untrusted input in the workflow (static pip strings only — no `github.event.*`).

Found while diagnosing why "Detect Golden Rule" was red on the intake PRs #1475/#1477 — it's repo-wide CI hygiene, not those PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)