### PR TITLE
feat(wr2): full-bleed photo carousel — 3 layout families + per-slide override + family-aware hero gate

### DIFF
--- a/scripts/tests/test_hero_visible_family.py
+++ b/scripts/tests/test_hero_visible_family.py
@@ -1,0 +1,126 @@
+"""Layout-aware hero-visibility gate (Antonello 2026-06-13).
+
+The `_hero_visible_in_png` gate samples where the PHOTO is exposed for a given
+layout family, instead of always sampling the top third:
+
+  - cover-photo / photo-headline-yellow-sub / photo-fullbleed / default/unknown:
+    TOP THIRD (unchanged behavior — text sits on the bottom scrim).
+  - photo-fullbleed-top:  LOWER band (~55%-85%) — top is covered by scrim+text.
+  - photo-fullbleed-split: MIDDLE band (~40%-60%) — clear photo band between the
+    top title and the bottom body.
+
+These tests build synthetic PNGs with PIL: a 1080x1350 image that is FLAT BLACK
+in the top third but a bright varied gradient from ~38% downward (so the photo
+is exposed in BOTH the split mid-band and the top-layout lower band). A
+top-third sampler must see flat black (False); a lower/middle sampler must see
+the bright gradient (True). A fully-flat image must be False for every family
+(the covered-hero false positive the gate exists to catch).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+from PIL import Image
+
+SCRIPTS_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from wr2_html_renderer.renderer import _hero_visible_in_png  # noqa: E402
+
+CANVAS_W = 1080
+CANVAS_H = 1350
+
+
+def _black_top_bright_below(path: Path, *, bright_start_frac: float = 0.38) -> None:
+    """1080x1350: flat black in the top third, a bright VARIED gradient below.
+
+    Above `bright_start_frac*h` → pure black (a covered/scrimmed top).
+    Below it → a per-pixel varied gradient that is mostly non-dark and has wide
+    color spread (a real exposed photo band).
+    """
+    img = Image.new("RGB", (CANVAS_W, CANVAS_H), (0, 0, 0))
+    px = img.load()
+    bright_start = int(CANVAS_H * bright_start_frac)
+    for y in range(bright_start, CANVAS_H):
+        for x in range(CANVAS_W):
+            # bright, varied across both axes → high bright_frac AND high spread
+            r = 90 + (x * 160 // CANVAS_W)          # 90..250 across width
+            g = 80 + ((y - bright_start) * 150 // (CANVAS_H - bright_start))  # ramps down
+            b = 110 + ((x + y) % 130)               # extra spread
+            px[x, y] = (r, g, b)
+    img.save(path)
+
+
+def _flat_black(path: Path) -> None:
+    """1080x1350 fully flat black — the covered-hero case (must be False)."""
+    Image.new("RGB", (CANVAS_W, CANVAS_H), (0, 0, 0)).save(path)
+
+
+# ── top-layout (lower band) sees the photo; top-third does not ────────────────
+
+
+def test_top_layout_sees_lower_band_photo(tmp_path: Path) -> None:
+    p = tmp_path / "black_top_bright_below.png"
+    _black_top_bright_below(p)
+    # photo-fullbleed-top samples ~55%-85% → the bright band → VISIBLE
+    assert _hero_visible_in_png(p, "photo-fullbleed-top") is True
+
+
+def test_top_third_blind_to_lower_band_photo(tmp_path: Path) -> None:
+    p = tmp_path / "black_top_bright_below.png"
+    _black_top_bright_below(p)
+    # photo-fullbleed (top-third sampler) sees only the flat-black top → NOT visible
+    assert _hero_visible_in_png(p, "photo-fullbleed") is False
+
+
+# ── split-layout (middle band) sees the photo ─────────────────────────────────
+
+
+def test_split_layout_sees_middle_band_photo(tmp_path: Path) -> None:
+    p = tmp_path / "black_top_bright_below.png"
+    _black_top_bright_below(p)
+    # photo-fullbleed-split samples ~40%-60% → inside the bright band → VISIBLE
+    assert _hero_visible_in_png(p, "photo-fullbleed-split") is True
+
+
+# ── default / unknown / None → top-third behavior (back-compat) ───────────────
+
+
+def test_default_none_is_top_third(tmp_path: Path) -> None:
+    p = tmp_path / "black_top_bright_below.png"
+    _black_top_bright_below(p)
+    # family=None must behave EXACTLY like the legacy top-third gate → blind here
+    assert _hero_visible_in_png(p, None) is False
+
+
+def test_unknown_family_is_top_third(tmp_path: Path) -> None:
+    p = tmp_path / "black_top_bright_below.png"
+    _black_top_bright_below(p)
+    # an unknown family falls back to top-third (never crashes, never lower-band)
+    assert _hero_visible_in_png(p, "some-future-family") is False
+
+
+def test_cover_photo_is_top_third(tmp_path: Path) -> None:
+    p = tmp_path / "black_top_bright_below.png"
+    _black_top_bright_below(p)
+    assert _hero_visible_in_png(p, "cover-photo") is False
+    assert _hero_visible_in_png(p, "photo-headline-yellow-sub") is False
+
+
+# ── covered-hero (flat black) is False for EVERY family ───────────────────────
+
+
+def test_flat_black_false_for_all_families(tmp_path: Path) -> None:
+    p = tmp_path / "flat_black.png"
+    _flat_black(p)
+    for fam in (
+        None,
+        "cover-photo",
+        "photo-headline-yellow-sub",
+        "photo-fullbleed",
+        "photo-fullbleed-top",
+        "photo-fullbleed-split",
+        "some-future-family",
+    ):
+        assert _hero_visible_in_png(p, fam) is False, f"flat black passed for {fam!r}"

--- a/scripts/tests/test_wr2_smart_hero.py
+++ b/scripts/tests/test_wr2_smart_hero.py
@@ -178,3 +178,64 @@ def test_editorial_text_skeleton_is_text_only() -> None:
     assert "{{image_url}}" not in skel
     # logo present per brand convention
     assert "logo" in skel
+
+
+# ── 5. photo-fullbleed: per-slide layout_family override + full-bleed skeleton ─
+
+
+def test_routing_layout_family_override_honored_on_mid_hero() -> None:
+    # An explicit layout_family pins the family even for a mid hero slide that
+    # would otherwise auto-route to photo-headline-yellow-sub.
+    fam = map_slide_to_family(
+        {"slide_type": "body", "is_hero_image": True,
+         "layout_family": "photo-fullbleed"}, 4, 8
+    )
+    assert fam == "photo-fullbleed"
+
+
+def test_routing_layout_family_override_beats_cover_and_cta_hard_rules() -> None:
+    # The override bypasses the Art 9.3 cover (index==1) and Art 9.5 CTA/last
+    # (index==total) hard rules — required for a fully-photographic carousel.
+    cover = map_slide_to_family(
+        {"is_cover": True, "layout_family": "photo-fullbleed"}, 1, 8
+    )
+    cta = map_slide_to_family(
+        {"slide_type": "cta", "layout_family": "photo-fullbleed"}, 8, 8
+    )
+    assert cover == "photo-fullbleed"
+    assert cta == "photo-fullbleed"
+
+
+def test_routing_layout_family_typo_falls_through_to_auto() -> None:
+    # A typo / undefined layout_family is ignored (never emit a blank skeleton):
+    # routing falls through to the normal auto rules.
+    fam = map_slide_to_family(
+        {"slide_type": "body", "is_hero_image": False,
+         "layout_family": "photo-fulbleed"}, 4, 8  # intentional typo
+    )
+    assert fam == "editorial-text"
+    # an UNDEFINED (named-but-no-skeleton) family is also ignored
+    fam2 = map_slide_to_family(
+        {"slide_type": "body", "is_hero_image": True,
+         "layout_family": "stat-card-hero"}, 4, 8
+    )
+    assert fam2 == "photo-headline-yellow-sub"
+
+
+def test_photo_fullbleed_in_renderable_families() -> None:
+    from wr2_html_renderer.composer import RENDERABLE_FAMILIES  # noqa: E402
+    assert "photo-fullbleed" in RENDERABLE_FAMILIES
+
+
+def test_photo_fullbleed_skeleton_is_full_bleed_photo_with_body() -> None:
+    skel = _extract_skeleton("photo-fullbleed")
+    # full-bleed background photo bound to image_url (NOT a text-only family)
+    assert ".hero" in skel
+    assert "{{image_url}}" in skel
+    # carries heading + body overlaid (unlike cover-photo which has no body)
+    assert "{{heading}}" in skel
+    assert "{{body}}" in skel
+    # reinforced scrim layer for text legibility over the photo
+    assert ".scrim" in skel
+    # logo present per brand convention
+    assert "logo" in skel

--- a/scripts/wr2_html_renderer/composer.py
+++ b/scripts/wr2_html_renderer/composer.py
@@ -48,6 +48,9 @@ _LAYOUTS = _BRAND / "layouts"
 RENDERABLE_FAMILIES = {
     "cover-photo",
     "photo-headline-yellow-sub",
+    "photo-fullbleed",
+    "photo-fullbleed-top",
+    "photo-fullbleed-split",
     "editorial-text",
     "qa-dialogue",
     "timeline-pinboard",
@@ -102,6 +105,16 @@ def map_slide_to_family(slide: dict[str, Any], index: int, total: int) -> str:
 
     Returns a family in RENDERABLE_FAMILIES. Never returns an UNDEFINED one.
     """
+    # Per-slide explicit override (manual full-bleed-photo carousels, 2026-06-13):
+    # a slides.json may pin `layout_family` directly to opt a slide into a
+    # specific renderable family (e.g. "photo-fullbleed" for the foto-a-tutta-slide
+    # treatment). Honoured ONLY when it names a RENDERABLE family — a typo or an
+    # UNDEFINED value falls through to auto-routing so we never emit a blank
+    # skeleton. This intentionally lets a manual author bypass the Art 9.3/9.5
+    # cover/CTA hard rules for a fully-photographic carousel.
+    explicit = (slide.get("layout_family") or "").strip()
+    if explicit in RENDERABLE_FAMILIES:
+        return explicit
     if index == 1 or slide.get("is_cover"):
         return "cover-photo"
     st = (slide.get("slide_type") or "").lower()
@@ -996,7 +1009,7 @@ async def compose_carousel(
         plans.append(SlidePlan(index=i, family=family, slide=slide, expect_hero=expect_hero))
 
     # Download heroes + materialize HTML per slide
-    html_specs: list[tuple[Path, bool]] = []
+    html_specs: list[tuple[Path, bool, str]] = []
     async with httpx.AsyncClient() as client:
         for plan in plans:
             hero_filename: str | None = None
@@ -1024,7 +1037,9 @@ async def compose_carousel(
 
             html_path = slides_dir / f"{plan.index:02d}.html"
             html_path.write_text(html, encoding="utf-8")
-            html_specs.append((html_path, plan.expect_hero))
+            # 3-tuple: thread the layout family so the renderer's hero-visibility
+            # gate samples where THIS family exposes the photo (top/lower/middle).
+            html_specs.append((html_path, plan.expect_hero, plan.family))
 
     result = await render_html_files(html_specs, output_dir, timeout_ms=timeout_ms, make_pdf=True)
 
@@ -1123,8 +1138,13 @@ def make_slide_render_fn(
         html_path = slides_dir / f"{index:02d}.html"
         # render_html_files writes PNG to (render_root/"slides")/f"{enum_idx:02d}.png"
         # where enum_idx is the 1-based position in the list → always "01" here.
+        # Thread the layout family (same derivation materialize_slide_html used)
+        # so the hero-visibility gate samples the right band for this layout.
+        family = map_slide_to_family(slide_with_levers, index, total)
+        if family in UNDEFINED_FAMILIES:
+            family = "photo-headline-yellow-sub"
         res = await render_html_files(
-            [(html_path, expect_hero_for_index(slide_with_levers, index))],
+            [(html_path, expect_hero_for_index(slide_with_levers, index), family)],
             render_root,
             timeout_ms=timeout_ms,
             make_pdf=False,

--- a/scripts/wr2_html_renderer/renderer.py
+++ b/scripts/wr2_html_renderer/renderer.py
@@ -203,6 +203,7 @@ async def _render_one(
     *,
     expect_hero: bool,
     timeout_ms: int,
+    family: str | None = None,
 ) -> tuple[bool, bool, str | None]:
     """Render one HTML file to PNG. Returns (rendered_ok, hero_placed, error).
 
@@ -240,16 +241,31 @@ async def _render_one(
     return (True, False, None)
 
 
+def _unpack_spec(spec: tuple) -> tuple[Path, bool, str | None]:
+    """Normalize an html_spec to (html_path, expect_hero, family).
+
+    Back-compat: a 2-tuple (html_path, expect_hero) yields family=None, which the
+    visibility gate treats as the legacy top-third sampling.
+    """
+    if len(spec) >= 3:
+        return spec[0], bool(spec[1]), spec[2]
+    return spec[0], bool(spec[1]), None
+
+
 async def render_html_files(
-    html_specs: list[tuple[Path, bool]],
+    html_specs: list[tuple[Path, bool] | tuple[Path, bool, str | None]],
     output_dir: Path,
     *,
     timeout_ms: int = 30000,
     make_pdf: bool = True,
 ) -> RenderResult:
-    """Render a list of (html_path, expect_hero) to PNGs in output_dir/slides.
+    """Render a list of html_specs to PNGs in output_dir/slides.
 
-    html_specs: ordered list; each is (path-to-html, whether-this-slide-has-a-hero).
+    html_specs: ordered list; each is (html_path, expect_hero) OR
+    (html_path, expect_hero, family). `family` is the brand layout family, used
+    by the visibility gate to sample where the photo is EXPOSED for that layout
+    (top-third for default/None, lower band for photo-fullbleed-top, middle band
+    for photo-fullbleed-split). A 2-tuple → family=None → top-third (back-compat).
     Assets (fonts, logo, _base.css) must already be staged in output_dir by the
     caller (or call render_slides_json which stages them).
 
@@ -258,7 +274,8 @@ async def render_html_files(
     """
     from playwright.async_api import async_playwright  # lazy import
 
-    result = RenderResult(heroes_expected=sum(1 for _, h in html_specs if h))
+    specs = [_unpack_spec(s) for s in html_specs]
+    result = RenderResult(heroes_expected=sum(1 for _, h, _ in specs if h))
     slides_out = output_dir / "slides"
     slides_out.mkdir(parents=True, exist_ok=True)
 
@@ -272,10 +289,11 @@ async def render_html_files(
             page = await context.new_page()
             page.set_default_timeout(timeout_ms)
 
-            for idx, (html_path, expect_hero) in enumerate(html_specs, start=1):
+            for idx, (html_path, expect_hero, family) in enumerate(specs, start=1):
                 png_path = slides_out / f"{idx:02d}.png"
                 rendered_ok, hero_placed, error = await _render_one(
-                    page, html_path, png_path, expect_hero=expect_hero, timeout_ms=timeout_ms
+                    page, html_path, png_path,
+                    expect_hero=expect_hero, timeout_ms=timeout_ms, family=family,
                 )
                 if rendered_ok and png_path.is_file():
                     # verify dimensions
@@ -288,12 +306,14 @@ async def render_html_files(
                         # Second gate (anti false-positive): decode() proved the
                         # bytes loaded; now prove the hero is VISIBLE on canvas
                         # (not covered/painted-over — the 2026-06-07 cover bug).
-                        if _hero_visible_in_png(png_path):
+                        # Layout-aware: sample where THIS family exposes the photo.
+                        if _hero_visible_in_png(png_path, family):
                             result.heroes_placed += 1
                         else:
                             result.failures.append(
                                 f"{png_path.name}: HERO DECODED BUT NOT VISIBLE — "
-                                f"top region is flat/empty (covered or mis-layered); "
+                                f"photo band (family={family or 'top-third'}) is "
+                                f"flat/empty (covered or mis-layered); "
                                 f"not counting as placed"
                             )
                 if error:
@@ -319,27 +339,46 @@ def _verify_png_dims(png_path: Path) -> bool:
         return img.size == (CANVAS_W, CANVAS_H)
 
 
-def _hero_visible_in_png(png_path: Path) -> bool:
-    """Pixel-level check that a hero photo is actually VISIBLE in the top region.
+def _hero_visible_in_png(png_path: Path, family: str | None = None) -> bool:
+    """Pixel-level check that a hero photo is actually VISIBLE on the canvas.
 
     Defends against the decode-but-covered false positive found 2026-06-07 (the
     cover slide: the hero <img> decoded fine — gate said placed — but a sibling
     .hero div with background-color painted over it, so the rendered top was flat
     black). `img.decode()` proves the bytes loaded; THIS proves they reached the
-    canvas. A real photo has color variance in the top third; a covered/missing
+    canvas. A real photo has color variance where it is exposed; a covered/missing
     hero is near-uniform (flat black or flat antracite).
 
-    Returns True if the top third shows enough non-background, varied pixels.
+    LAYOUT-AWARE sampling (Antonello 2026-06-13): the top-third assumption breaks
+    any layout whose scrim+text covers the top. We sample where the PHOTO is
+    EXPOSED for the given family:
+      - cover-photo / photo-headline-yellow-sub / photo-fullbleed / default/None/
+        unknown: TOP THIRD (~8%-33%) — text sits on the BOTTOM scrim. UNCHANGED.
+      - photo-fullbleed-top:  LOWER band (~55%-85%) — top is scrim+text, photo
+        is exposed below.
+      - photo-fullbleed-split: MIDDLE band (~40%-60%) — the clear photo band
+        between the top title and the bottom body.
+
+    family=None → top-third behavior (back-compat with the 1-arg caller).
+    Returns True if the sampled band shows enough non-background, varied pixels.
     """
     from PIL import Image  # lazy
 
     with Image.open(png_path) as img:
         img = img.convert("RGB")
         w, h = img.size
-        # Sample the TOP THIRD (hero photo dominates above the gradient+text
-        # block which sits in the bottom ~180px+).
+        # Family-aware vertical band: sample where this layout EXPOSES the photo.
+        if family == "photo-fullbleed-top":
+            # ~55%-85%: photo exposed below the top text block.
+            ys = range(11 * h // 20, 17 * h // 20, 30)
+        elif family == "photo-fullbleed-split":
+            # ~40%-60%: the clear photo band between top title and bottom body.
+            ys = range(2 * h // 5, 3 * h // 5, 30)
+        else:
+            # TOP THIRD (~8%-33%) for cover-photo / photo-headline-yellow-sub /
+            # photo-fullbleed and any default/unknown/None family. UNCHANGED.
+            ys = range(h // 12, h // 3, 30)
         xs = range(w // 8, 7 * w // 8, 30)
-        ys = range(h // 12, h // 3, 30)
         samples = []
         for y in ys:
             for x in xs:

--- a/scripts/wr2_image_generator.py
+++ b/scripts/wr2_image_generator.py
@@ -200,6 +200,11 @@ TONAL_PALETTES: dict[str, str] = {
         "bright bleached daylight, airy high-exposure palette of bone whites "
         "and pale sand, gentle haze, minimal shadow."
     ),
+    "vivid": (
+        "bright natural daylight, vivid saturated colours, rich warm tones, "
+        "punchy contrast and lively energy, full of life and motion — NOT "
+        "desaturated, NOT muted, NOT low-key."
+    ),
 }
 DEFAULT_TONAL_KEY = "default"
 


### PR DESCRIPTION
## What

Foundation for the **full-bleed photo carousel** in the WR2 HTML render lane: slides where the photo fills the entire frame and text sits over a light scrim — variety across slides instead of every slide cloning the cover.

### 3 layout families (renderable)
- `photo-fullbleed` — text bottom, bottom scrim
- `photo-fullbleed-top` — text top, heavy top scrim
- `photo-fullbleed-split` — kicker+heading top, body bottom, scrim both ends

Body copy UPPERCASE; bigger font tokens (`headline-slide` 60px / body 38px).

### Mechanics
- **Per-slide `layout_family` override** in `composer.map_slide_to_family()` — a slide can pin its family (bypasses the cover/CTA auto-rules) so one deck mixes top/bottom/split.
- **Family-aware hero-visibility gate** `renderer._hero_visible_in_png(png, family)` — samples the band where the photo is actually exposed per family (top-third / lower / middle), so a legit full-bleed slide isn't failed for "hero not visible". `render_html_files` accepts 2- or 3-tuples (family threaded through).
- `wr2_image_generator` gains the `vivid` tonal palette.

## Files (5, +269/-18)
- `scripts/wr2_html_renderer/composer.py`
- `scripts/wr2_html_renderer/renderer.py`
- `scripts/wr2_image_generator.py`
- `scripts/tests/test_wr2_smart_hero.py` (+5 tests)
- `scripts/tests/test_hero_visible_family.py` (NEW, +7 tests)

## Tests
`26 passed` (`test_wr2_smart_hero` + `test_hero_visible_family`). Full backend pre-push suite green (15130+ passed).

## ⚠️ Deploy note — layout skeletons live in HOME, NOT in this PR
The 3 skeleton `.md` files (`~/.claude/skills/bali-zero-brand/layouts/photo-fullbleed{,-top,-split}.md`) are **not versioned** (project convention: layout `.md` live only in HOME). The composer resolves families from there at render time → **they must be propagated to the deploy machine's HOME** (`~/.claude/skills/bali-zero-brand/layouts/`) or the new families won't resolve.

## Merge
**No auto-merge.** Merge + WR2 kill-switch flip remain the operator's decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
