### PR TITLE
docs(claude): add Air-M5 node to project machine table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,11 +12,12 @@
 
 | Machine | User | Hostname | Role | RAM |
 |---|---|---|---|---|
-| **Pro** | `nuzantara` | `Nuzantara` | Dev primario, interactive Claude Code | 48GB M4 Pro |
+| **Air-M5** | `balizero` | `Air-M5` | Dev workstation PRINCIPALE interattiva, leggera — no daemon/cron/Ollama H24 | 24GB M5 |
+| **Pro** | `nuzantara` | `Nuzantara` | Dev primario, interactive Claude Code; workhorse H24 (176 daemon, modelli 32B) | 48GB M4 Pro |
 | **Mini-Pro2** | `nuzantara` | `Mini-Pro2` | Server H24, Ollama dedicato, cron pesanti | 24GB M4 Pro |
 
-- `whoami=nuzantara` on both; distinguish via `hostname`. SSH alias `ssh pro` / `ssh mini` (Tailscale `100.93.236.6` for Mini, `100.107.22.111` for Pro from Mini).
-- First-response prefix: `[Pro]` or `[Mini]`.
+- `whoami=nuzantara` su Pro/Mini, `balizero` su M5 (home `/Users/balizero/` — path-aware scripts mandatory); distinguish via `hostname`. SSH alias `ssh pro` / `ssh mini` / `ssh air` (Tailscale `100.93.236.6` for Mini, `100.107.22.111` for Pro from Mini).
+- First-response prefix: `[Pro]`, `[Mini]`, or `[Air]`.
 - **Air decommissioned 2026-05-05** — handed off to Ari/Bali Zero. Historical references in code/scripts are archaeology, NOT active.
 
 ## Agent Worktree Discipline (2026-05-24)


### PR DESCRIPTION
Adds the **Air-M5** node to the project machine table (Part A §1), which was still the pre-M5 2-node table.

3-node stack since 2026-05-31:
- **Air-M5** (`balizero@Air-M5`, 24GB M5, `ssh air`, prefix `[Air]`, home `/Users/balizero/`) — primary interactive dev workstation, light (no daemon/cron/Ollama H24)
- **Pro** — H24 workhorse (176 daemon, 32B models) + interactive dev
- **Mini-Pro2** — H24 server

Also corrects the `whoami`/SSH-alias/prefix bullets (`balizero` on M5, `ssh air`, `[Air]`).

Diff is the **machine-table region only** — §5 (PII boundary) and §14, recently reworded on `main`, are untouched (verified). Mirrors the same fix already applied to the global `~/.claude/CLAUDE.md`. Source: `decision_m5_air_fleet_join_2026_05_31`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)