### PR TITLE
fix(cron): auto_test venv selection + ops-briefing NB IDs

### DIFF
--- a/apps/evaluator/nlm_deep_research/db_nlm_state.py
+++ b/apps/evaluator/nlm_deep_research/db_nlm_state.py
@@ -26,9 +26,9 @@ _DEFAULT_LOCK_PATH: Path = _DIR / "db_nlm_sync.lock"
 
 # --- Notebook IDs (populated after creation via `nlm notebook create`) ---
 # These will be set on first run or via CLI args.
-NB_OPS_ID: str = ""       # NB-11: Bali Zero Ops Live
-NB_INTEL_ID: str = ""      # NB-12: Bali Zero Business Intelligence
-NB_TELEMETRY_ID: str = ""  # NB-13: Bali Zero System Telemetry
+NB_OPS_ID: str = "2072e518-e6f9-437d-93ea-f9037ec54052"       # NB-11: Bali Zero Ops Live
+NB_INTEL_ID: str = "5c2c3d90-eed2-4755-86b1-269e637e51e1"      # NB-12: Bali Zero Business Intelligence
+NB_TELEMETRY_ID: str = "53441d9e-fb11-44cc-8dd8-4d70637b651f"  # NB-13: Bali Zero System Telemetry
 
 # --- Source slots per notebook ---
 MAX_SOURCES_PER_NB: int = 15

--- a/apps/evaluator/nlm_deep_research/ops_intelligence.py
+++ b/apps/evaluator/nlm_deep_research/ops_intelligence.py
@@ -49,19 +49,29 @@ ANOMALY_THRESHOLD_PCT = 25.0
 # ── NB IDs ────────────────────────────────────────────────────────────────────
 
 def _load_nb_ids() -> dict[str, str]:
-    """Load NB-11/12/13 IDs from db_nlm_sync state."""
+    """Load NB-11/12/13 IDs from db_nlm_sync state, falling back to the
+    committed defaults in db_nlm_state when the runtime state file is absent
+    or a key is blank. The state file is gitignored runtime state and may
+    not exist on a fresh checkout, so the committed constants are the
+    source of truth for which notebooks to query."""
+    from apps.evaluator.nlm_deep_research import db_nlm_state as _dbs
+    defaults = {
+        "ops": _dbs.NB_OPS_ID,
+        "intel": _dbs.NB_INTEL_ID,
+        "telemetry": _dbs.NB_TELEMETRY_ID,
+    }
     if not _SYNC_STATE_FILE.exists():
-        return {}
+        return dict(defaults)
     try:
         state = json.loads(_SYNC_STATE_FILE.read_text())
         return {
-            "ops": state.get("nb_ops_id", ""),        # NB-11
-            "intel": state.get("nb_intel_id", ""),    # NB-12
-            "telemetry": state.get("nb_telemetry_id", ""),  # NB-13
+            "ops": state.get("nb_ops_id", "") or defaults["ops"],
+            "intel": state.get("nb_intel_id", "") or defaults["intel"],
+            "telemetry": state.get("nb_telemetry_id", "") or defaults["telemetry"],
         }
     except Exception as exc:
         logger.error("Failed to load NB IDs from sync state: %s", exc)
-        return {}
+        return dict(defaults)
 
 
 # ── Telegram ──────────────────────────────────────────────────────────────────

--- a/scripts/auto_test.sh
+++ b/scripts/auto_test.sh
@@ -48,12 +48,14 @@ export OLLAMA_MODEL="${OLLAMA_MODEL:-qwen2.5:latest}"
 log "--- Phase 1: Agent pytest suite ---"
 cd "$BACKEND_DIR" || exit 1
 # Activate virtualenv for pytest — use full path as fallback for cron
-# Prefer venv (Python 3.11, has pytest) over .venv (Python 3.13, no pytest)
+# The backend venv is .venv (Python 3.11.11, has pytest); legacy venv/ no longer exists.
+# Use the .venv/bin/python symlink (version-agnostic) so a future minor bump can't break this.
 if [ -d "$BACKEND_DIR/venv" ] && "$BACKEND_DIR/venv/bin/python" -c "import pytest" 2>/dev/null; then
     source "$BACKEND_DIR/venv/bin/activate" 2>/dev/null || true
     PYTEST_CMD=("$BACKEND_DIR/venv/bin/python" "-m" "pytest")
-elif [ -d "$BACKEND_DIR/.venv" ] && "$BACKEND_DIR/.venv/bin/python3.13" -c "import pytest" 2>/dev/null; then
-    PYTEST_CMD=("$BACKEND_DIR/.venv/bin/python3.13" "-m" "pytest")
+elif [ -d "$BACKEND_DIR/.venv" ] && "$BACKEND_DIR/.venv/bin/python" -c "import pytest" 2>/dev/null; then
+    source "$BACKEND_DIR/.venv/bin/activate" 2>/dev/null || true
+    PYTEST_CMD=("$BACKEND_DIR/.venv/bin/python" "-m" "pytest")
 else
     PYTEST_CMD=("python3" "-m" "pytest")
 fi


### PR DESCRIPTION
Two verified cron fixes — both DLQ root causes, both empirically tested before push.

## Root cause 1 — `scripts/auto_test.sh` picks the wrong Python → false "FAILED"

The venv-selection cascade looked for `$BACKEND_DIR/.venv/bin/python3.13` and a non-existent `venv/` (no dot). The backend venv is `.venv` = **Python 3.11.11** — there is no `python3.13` symlink and no `venv/`. Both branches missed → fell to system `python3` (3.14, no pytest) → exited "FAILED" while the suite was actually healthy.

**Fix**: drop the dead `python3.13` literal; use the version-agnostic `.venv/bin/python` symlink (so a future minor bump can't re-break it) + add an `activate` line for parity with the `venv/` branch. Also corrects the inverted comment ("Python 3.13, no pytest" was wrong).

## Root cause 2 — `run_ops_briefing` cron exits 1 (NB IDs never wired)

`ops_intelligence._load_nb_ids()` read ONLY the gitignored runtime file `db_nlm_sync_state.json`, which does not exist on a fresh checkout. With an empty NB-11 id, `run_briefing()` set `status="error"` and `main()` did `sys.exit(1)` → cron failed → DLQ. The 3 notebooks exist; their IDs were just never committed (`db_nlm_state.py` constants were empty placeholders).

**Fix**:
- `db_nlm_state.py`: fill the 3 placeholder constants with the verified UUIDs (corroborated in `research/nb-health/S14-curation-FROZEN.json` + `docs/superpowers/plans/2026-04-06-nb-rag-v2.md`):
  - `NB_OPS_ID = 2072e518-e6f9-437d-93ea-f9037ec54052` (NB-11 Ops Live)
  - `NB_INTEL_ID = 5c2c3d90-eed2-4755-86b1-269e637e51e1` (NB-12 Business Intelligence)
  - `NB_TELEMETRY_ID = 53441d9e-fb11-44cc-8dd8-4d70637b651f` (NB-13 System Telemetry)
- `ops_intelligence._load_nb_ids()`: fall back to those committed constants when the runtime state file is absent OR a key is blank (state file still wins when present + populated).

## Tests (run against the real backend `.venv`, Python 3.11.11)

**TEST 1** (fixed venv conditional against the real backend venv):
```
branch2 .venv OK -> Python 3.11.11
```

**TEST 2a** (`_load_nb_ids()` returns all 3 UUIDs, no empty strings):
```
{'ops': '2072e518-e6f9-437d-93ea-f9037ec54052', 'intel': '5c2c3d90-eed2-4755-86b1-269e637e51e1', 'telemetry': '53441d9e-fb11-44cc-8dd8-4d70637b651f'}
```

**TEST 2b** (`--briefing --dry-run` exit code; was exit 1 "NB-11 ID missing" before):
```
EXIT=0
Briefing: ok
  Week: Settimana 24 — 15 Jun 2026
  NB-11 queried: True
  NB-12 queried: True
  Anomalies: 0
  Telegram sent: False
```

**TEST 2c** (regression — `test_db_nlm_sync.py`):
```
23 passed in 0.11s
```

## NOT in scope (Zero / Law-5 decision)

Activating the DB→NotebookLM cloud-**upload** pipeline (`db_to_nlm_sync.py` / `run_db_nlm_sync.sh`) is intentionally untouched. Scope-guard verified: `db_to_nlm_sync.py` imports only the *classes* (`DBNLMLockError`, `DBNLMPIDLock`, `DBNLMStatePersistence`, `DBNLMSyncState`) from `db_nlm_state` — **never** the module constants this PR sets. Its NB IDs come exclusively from `os.environ.get("NB_OPS_ID","")` (CLI-arg default) `or state.nb_ops_id`, and with neither present it still `sys.exit(1)`. So the constants do not reach it → the cloud-upload sync stays dormant. Arming it remains a Zero-only structural decision (Law 5 + Law 2).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>