### PR TITLE
fix(monitoring): escalating backoff per alert key to stop Telegram flood

### DIFF
--- a/apps/backend-rag/backend/services/monitoring/alert_service.py
+++ b/apps/backend-rag/backend/services/monitoring/alert_service.py
@@ -68,7 +68,19 @@ class AlertService:
         # Rate limiting: track last send time per (title, path) key
         # Prevents same error from spamming Telegram on repeated failures
         self._last_alert_time: dict[str, float] = {}
-        self._alert_cooldown_seconds: float = 300.0  # 5 min per error type
+        self._alert_cooldown_seconds: float = 300.0  # base cooldown: first re-alert after 5 min
+
+        # Per-key escalating backoff. A condition that PERSISTS (the same
+        # alert key re-fired every monitor cycle) must NOT keep re-alerting at
+        # the fixed base cooldown forever — that is exactly what floods
+        # Telegram with hundreds of identical messages/day. Instead the
+        # cooldown doubles after each send (5m → 10m → 20m … capped), so a
+        # stuck condition decays to a rare reminder. The escalation resets
+        # once the key has been quiet long enough that the condition has
+        # almost certainly resolved (logic in send_alert).
+        self._alert_repeat: dict[str, int] = {}
+        self._alert_last_seen: dict[str, float] = {}
+        self._alert_backoff_max_seconds: float = 21600.0  # cap re-alert at 6 h
 
         # Global rate limiter: max N Telegram messages per minute across ALL paths
         self._global_send_times: list[float] = []
@@ -111,6 +123,7 @@ class AlertService:
         message: str,
         level: AlertLevel = AlertLevel.ERROR,
         metadata: dict[str, Any] | None = None,
+        dedup_key: str | None = None,
     ) -> dict[str, bool]:
         """
         Send alert to all configured channels.
@@ -120,6 +133,10 @@ class AlertService:
             message: Alert message
             level: Alert severity level
             metadata: Additional metadata to include
+            dedup_key: Stable key for rate-limiting/backoff. Pass this when the
+                title embeds a changing value (e.g. a live metric reading) so
+                the escalating cooldown still recognises repeats of the *same*
+                condition. Defaults to "{title}:{metadata[path]}".
 
         Returns:
             Dict with status for each channel
@@ -133,15 +150,42 @@ class AlertService:
         except Exception as e:
             logger.error("Failed to log alert: %s", e)
 
-        # Rate limiting: deduplicate same alert within cooldown window
-        rate_key = f"{title}:{metadata.get('path', '') if metadata else ''}"
+        # Per-key escalating backoff: deduplicate + decay re-alerts for a
+        # condition that persists. Without this, a stuck metric (dead tuples
+        # above threshold for hours, a long-running query that never clears)
+        # re-alerts every monitor cycle forever and floods Telegram.
+        rate_key = dedup_key or f"{title}:{metadata.get('path', '') if metadata else ''}"
         now = time.monotonic()
-        last_sent = self._last_alert_time.get(rate_key, 0.0)
-        if now - last_sent < self._alert_cooldown_seconds:
-            logger.debug(
-                f"[alert] Rate limited '{title}' — {int(self._alert_cooldown_seconds - (now - last_sent))}s remaining",
+        last_sent = self._last_alert_time.get(rate_key)
+        repeat = self._alert_repeat.get(rate_key, 0)
+        last_seen = self._alert_last_seen.get(rate_key)
+
+        # Reset the escalation if this key has been quiet (no attempts) for
+        # long enough that the underlying condition has very likely resolved.
+        # The quiet window scales with the current cooldown, so a slow-decayed
+        # alert needs a correspondingly longer silence to be treated as fresh.
+        if last_seen is not None:
+            reset_after = (
+                min(self._alert_cooldown_seconds * (2**repeat), self._alert_backoff_max_seconds) * 2
             )
-            return results
+            if now - last_seen >= reset_after:
+                repeat = 0
+                last_sent = None
+        self._alert_last_seen[rate_key] = now  # record this attempt
+
+        # Escalating cooldown = base * 2^(sends_so_far - 1), capped. The first
+        # send for a key (repeat == 0) is never suppressed here.
+        if last_sent is not None:
+            required = min(
+                self._alert_cooldown_seconds * (2 ** max(repeat - 1, 0)),
+                self._alert_backoff_max_seconds,
+            )
+            if now - last_sent < required:
+                logger.debug(
+                    f"[alert] backoff-suppressed '{rate_key}' (repeat={repeat}, "
+                    f"{int(required - (now - last_sent))}s remaining)",
+                )
+                return results
 
         # Global rate limiter: prevent Telegram spam across ALL error paths
         self._global_send_times = [
@@ -155,6 +199,7 @@ class AlertService:
         self._global_send_times.append(now)
 
         self._last_alert_time[rate_key] = now
+        self._alert_repeat[rate_key] = repeat + 1
 
         # Send to Telegram (primary channel)
         if self.enable_telegram:
@@ -525,7 +570,13 @@ class AlertService:
             "threshold": f"{threshold:.1f}{unit}",
         }
 
-        await self.send_alert(title=title, message=message, level=level, metadata=metadata)
+        await self.send_alert(
+            title=title,
+            message=message,
+            level=level,
+            metadata=metadata,
+            dedup_key=f"resource:{resource}",
+        )
 
 
 # Global singleton instance

--- a/apps/backend-rag/backend/tests/unit/services/monitoring/test_alert_service.py
+++ b/apps/backend-rag/backend/tests/unit/services/monitoring/test_alert_service.py
@@ -117,26 +117,29 @@ class TestLogAlert:
         from backend.services.monitoring.alert_service import AlertLevel
 
         svc = _make_service()
-        # Should not raise
-        svc._log_alert("Title", "Message", AlertLevel.CRITICAL, {"key": "val"})
+        result = svc._log_alert("Title", "Message", AlertLevel.CRITICAL, {"key": "val"})
+        assert result is None  # void; no exception = log was written
 
     def test_log_error(self):
         from backend.services.monitoring.alert_service import AlertLevel
 
         svc = _make_service()
-        svc._log_alert("Title", "Message", AlertLevel.ERROR)
+        result = svc._log_alert("Title", "Message", AlertLevel.ERROR)
+        assert result is None
 
     def test_log_warning(self):
         from backend.services.monitoring.alert_service import AlertLevel
 
         svc = _make_service()
-        svc._log_alert("Title", "Message", AlertLevel.WARNING)
+        result = svc._log_alert("Title", "Message", AlertLevel.WARNING)
+        assert result is None
 
     def test_log_info(self):
         from backend.services.monitoring.alert_service import AlertLevel
 
         svc = _make_service()
-        svc._log_alert("Title", "Message", AlertLevel.INFO)
+        result = svc._log_alert("Title", "Message", AlertLevel.INFO)
+        assert result is None
 
 
 # ---------------------------------------------------------------------------
@@ -475,3 +478,63 @@ class TestGetAlertService:
             mock_cls.return_value = MagicMock()
             svc = mod.get_alert_service()
             assert svc is not None
+
+
+# ---------------------------------------------------------------------------
+# Escalating backoff for persistent alerts (anti-flood)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestEscalatingBackoff:
+    @staticmethod
+    def _mock_telegram(svc):
+        mock_client = AsyncMock()
+        mock_client.is_closed = False
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_client.post.return_value = mock_resp
+        svc._client = mock_client
+        return mock_client
+
+    async def test_persistent_alert_cooldown_doubles(self, monkeypatch):
+        svc = _make_service(telegram=True)
+        self._mock_telegram(svc)
+        clock = {"t": 0.0}
+        monkeypatch.setattr(
+            "backend.services.monitoring.alert_service.time.monotonic",
+            lambda: clock["t"],
+        )
+        base = svc._alert_cooldown_seconds
+
+        clock["t"] = 0.0
+        assert (await svc.send_alert("Stuck", "m", dedup_key="k"))["telegram"] is True
+        clock["t"] = base - 1
+        assert (await svc.send_alert("Stuck", "m", dedup_key="k"))["telegram"] is False
+        clock["t"] = base
+        assert (await svc.send_alert("Stuck", "m", dedup_key="k"))["telegram"] is True
+        clock["t"] = base + 2 * base - 1
+        assert (await svc.send_alert("Stuck", "m", dedup_key="k"))["telegram"] is False
+        clock["t"] = base + 2 * base
+        assert (await svc.send_alert("Stuck", "m", dedup_key="k"))["telegram"] is True
+
+    async def test_backoff_resets_after_long_silence(self, monkeypatch):
+        svc = _make_service(telegram=True)
+        self._mock_telegram(svc)
+        clock = {"t": 0.0}
+        monkeypatch.setattr(
+            "backend.services.monitoring.alert_service.time.monotonic",
+            lambda: clock["t"],
+        )
+        clock["t"] = 0.0
+        assert (await svc.send_alert("Flap", "m", dedup_key="k"))["telegram"] is True
+        clock["t"] = svc._alert_backoff_max_seconds * 4
+        assert (await svc.send_alert("Flap", "m", dedup_key="k"))["telegram"] is True
+
+    async def test_resource_alert_uses_stable_dedup_key(self):
+        svc = _make_service(telegram=False)
+        svc.send_alert = AsyncMock()
+        await svc.send_resource_alert("pg_dead_tuples", 17000.0, 10000.0, " dead tuples")
+        await svc.send_resource_alert("pg_dead_tuples", 18000.0, 10000.0, " dead tuples")
+        keys = [c.kwargs["dedup_key"] for c in svc.send_alert.call_args_list]
+        assert keys == ["resource:pg_dead_tuples", "resource:pg_dead_tuples"]


### PR DESCRIPTION
## Problema
Il canale Telegram dell'owner riceve ~550-600 messaggi/giorno. La causa NON è infra rotta: è **alerting troppo chiacchierone su condizioni che persistono**. Due flooder dal backend Fly:

- **`pg_dead_tuples`** (~216/g): `health_monitor` ri-allarma a cooldown fisso 5min su una condizione che non si risolve (dead tuples ~17.800, autovacuum solo 02-06 WITA o >50k). Inoltre la rate-key in `AlertService` includeva il valore corrente nel `title` → cambiava a ogni ciclo → il per-key cooldown non agganciava mai.
- **Olympus "long-running queries"** (~240/g): `heartbeat.check_alerts` → `AlertService.send_alert`, title stabile → cooldown 5min agganciava ma ri-allarmava in eterno.

## Fix (un solo punto, massimo leverage)
`AlertService` ora ha un **backoff esponenziale per-chiave**: il cooldown raddoppia dopo ogni invio (5m → 10m → 20m → … cap 6h), così una condizione bloccata decade a un promemoria raro invece di urlare ogni 5 minuti. L'escalation si **resetta automaticamente** dopo che la chiave è stata silente abbastanza a lungo (condizione risolta → il prossimo evento riparte pulito). `send_resource_alert` passa ora un **`dedup_key` stabile** (`resource:{resource}`) così i valori-metrica che cambiano non sconfiggono più il limiter.

Effetto atteso: da ~456 msg/g (pg_dead_tuples + Olympus) a ~10-20/g, **senza perdere il primo alert** né i segnali veri (HIGH attention CRM, email failures, ecc. restano immediati).

## Test
- 3 nuovi test `TestEscalatingBackoff`: escalation che raddoppia, reset dopo silenzio, dedup-key stabile per resource alert.
- I test pre-esistenti `test_rate_limits_duplicate_alert` + `test_global_rate_limit` continuano a passare (il primo re-alert resta a 5min).
- Full pre-push suite: 15196 passed, 802 skipped.

## Note
- Nessun cambio di firma rompente: `dedup_key` è opzionale.
- Il flooder WR2 plist-watchdog (~96/g) è una causa SEPARATA (HOME-fork drift locale) — gestita fuori da questa PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)