### PR TITLE
feat(skill-coach): add OpenClaw cycle runner

### DIFF
--- a/apps/backend-rag/backend/scripts/skill_coach_openclaw_runner.py
+++ b/apps/backend-rag/backend/scripts/skill_coach_openclaw_runner.py
@@ -1,0 +1,176 @@
+"""Run the safe Skill Coach cycle as one OpenClaw-friendly job.
+
+This runner wires the existing propose-only learning loop:
+
+1. aggregate successful Genome trajectories into skill-creation proposals;
+2. evaluate those proposals into redacted Skill Coach evidence cards.
+
+It never records active skills and never publishes HGT events. Zero still
+decides which evidence card becomes a real Skill Registry entry.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from backend.scripts.experience_to_skill_aggregator import main as aggregate_main
+from backend.scripts.skill_coach_evaluate_proposals import main as evaluate_main
+from backend.services.skill_coach.service import (
+    DEFAULT_DB_PATH,
+    SKILL_COACH_EVIDENCE_PATH,
+    SKILL_CREATION_PROPOSALS_PATH,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def run_skill_coach_cycle(
+    *,
+    db_path: str = DEFAULT_DB_PATH,
+    proposals_path: str = SKILL_CREATION_PROPOSALS_PATH,
+    evidence_path: str = SKILL_COACH_EVIDENCE_PATH,
+    min_cluster_size: int = 10,
+    window_days: int = 7,
+    min_support: int = 3,
+    run_aggregator: bool = True,
+) -> dict[str, Any]:
+    """Run one safe learning cycle and return a structured summary."""
+    _validate_positive("min_cluster_size", min_cluster_size)
+    _validate_positive("window_days", window_days)
+    _validate_positive("min_support", min_support)
+
+    if run_aggregator:
+        _ensure_parent(proposals_path)
+        aggregate_rc = aggregate_main(
+            [
+                "--db-path",
+                db_path,
+                "--out",
+                proposals_path,
+                "--min-cluster-size",
+                str(min_cluster_size),
+                "--window-days",
+                str(window_days),
+            ]
+        )
+        if aggregate_rc != 0:
+            raise RuntimeError(f"experience_to_skill_aggregator failed rc={aggregate_rc}")
+
+    _ensure_parent(evidence_path)
+    evaluate_rc = evaluate_main(
+        [
+            "--db-path",
+            db_path,
+            "--proposals",
+            proposals_path,
+            "--out",
+            evidence_path,
+            "--min-support",
+            str(min_support),
+        ]
+    )
+    if evaluate_rc != 0:
+        raise RuntimeError(f"skill_coach_evaluate_proposals failed rc={evaluate_rc}")
+
+    evidence_rows = _read_jsonl(evidence_path)
+    status_counts = Counter(str(row.get("status", "unknown")) for row in evidence_rows)
+    summary = {
+        "status": "ok",
+        "aggregator_ran": run_aggregator,
+        "db_path": db_path,
+        "proposals_path": proposals_path,
+        "evidence_path": evidence_path,
+        "proposals_written": _count_jsonl(proposals_path),
+        "evidence_written": len(evidence_rows),
+        "evidence_by_status": dict(sorted(status_counts.items())),
+        "min_cluster_size": min_cluster_size,
+        "window_days": window_days,
+        "min_support": min_support,
+    }
+    logger.info(
+        "skill-coach OpenClaw cycle ok: proposals=%d evidence=%d",
+        summary["proposals_written"],
+        summary["evidence_written"],
+    )
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--db-path", default=DEFAULT_DB_PATH)
+    parser.add_argument("--proposals", default=SKILL_CREATION_PROPOSALS_PATH)
+    parser.add_argument("--out", default=SKILL_COACH_EVIDENCE_PATH)
+    parser.add_argument("--min-cluster-size", type=int, default=10)
+    parser.add_argument("--window-days", type=int, default=7)
+    parser.add_argument("--min-support", type=int, default=3)
+    parser.add_argument(
+        "--skip-aggregator",
+        action="store_true",
+        help="Refresh evidence from an existing proposals file without regenerating it.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        summary = run_skill_coach_cycle(
+            db_path=args.db_path,
+            proposals_path=args.proposals,
+            evidence_path=args.out,
+            min_cluster_size=args.min_cluster_size,
+            window_days=args.window_days,
+            min_support=args.min_support,
+            run_aggregator=not args.skip_aggregator,
+        )
+    except Exception as exc:
+        logger.exception("skill-coach OpenClaw cycle failed")
+        error_summary = {
+            "status": "error",
+            "error_type": type(exc).__name__,
+            "message": str(exc),
+        }
+        sys.stdout.write(json.dumps(error_summary, sort_keys=True) + "\n")
+        return 1
+
+    sys.stdout.write(json.dumps(summary, sort_keys=True) + "\n")
+    return 0
+
+
+def _validate_positive(name: str, value: int) -> None:
+    if value < 1:
+        raise ValueError(f"{name} must be >= 1")
+
+
+def _ensure_parent(path: str) -> None:
+    Path(path).expanduser().parent.mkdir(parents=True, exist_ok=True)
+
+
+def _count_jsonl(path: str) -> int:
+    return len(_read_jsonl(path))
+
+
+def _read_jsonl(path: str) -> list[dict[str, Any]]:
+    file_path = Path(path).expanduser()
+    if not file_path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    with file_path.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, dict):
+                rows.append(parsed)
+    return rows
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/apps/backend-rag/backend/tests/unit/scripts/test_skill_coach_openclaw_runner.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_skill_coach_openclaw_runner.py
@@ -1,0 +1,123 @@
+"""Tests for the Skill Coach OpenClaw cycle runner."""
+
+from __future__ import annotations
+
+import json
+
+from cell_core.genome import Genome
+
+
+def test_runner_aggregates_and_evaluates_skill_coach_cycle(tmp_path):
+    from backend.scripts.skill_coach_openclaw_runner import run_skill_coach_cycle
+
+    db_path = tmp_path / "experience.db"
+    proposals_path = tmp_path / "skill_creation_proposals.jsonl"
+    evidence_path = tmp_path / "skill_coach_evidence.jsonl"
+
+    genome = Genome(db_path=str(db_path))
+    for i in range(3):
+        genome.record_trajectory(
+            cell="rag",
+            trajectory_id=f"t{i}",
+            outcome="success",
+            procedure=f"retrieve clean context iteration {i}",
+            tags=["retrieval"],
+        )
+
+    summary = run_skill_coach_cycle(
+        db_path=str(db_path),
+        proposals_path=str(proposals_path),
+        evidence_path=str(evidence_path),
+        min_cluster_size=3,
+        window_days=7,
+        min_support=3,
+    )
+
+    assert summary["status"] == "ok"
+    assert summary["proposals_written"] == 1
+    assert summary["evidence_written"] == 1
+    assert summary["evidence_by_status"] == {"shadow_eligible": 1}
+    assert proposals_path.exists()
+    assert evidence_path.exists()
+
+    evidence = [json.loads(line) for line in evidence_path.read_text().splitlines()]
+    assert evidence[0]["status"] == "shadow_eligible"
+    assert evidence[0]["support_count"] == 3
+    assert "retrieve clean context" in evidence[0]["procedure"]
+    assert "customer raw content" not in evidence_path.read_text()
+
+
+def test_runner_can_skip_aggregation_and_only_refresh_evidence(tmp_path):
+    from backend.scripts.skill_coach_openclaw_runner import run_skill_coach_cycle
+
+    db_path = tmp_path / "experience.db"
+    proposals_path = tmp_path / "skill_creation_proposals.jsonl"
+    evidence_path = tmp_path / "skill_coach_evidence.jsonl"
+
+    genome = Genome(db_path=str(db_path))
+    for i in range(2):
+        genome.record_trajectory(
+            cell="crm",
+            trajectory_id=f"crm-{i}",
+            outcome="success",
+            procedure=f"normalise contact field iteration {i}",
+            tags=["crm", "normalise"],
+        )
+
+    proposals_path.write_text(
+        json.dumps(
+            {
+                "cell": "crm",
+                "skill_id": "crm:agg_normalise",
+                "tags": ["crm", "normalise"],
+                "procedure": "Normalise contact fields before merge.",
+                "precondition": "CRM intake has repeated contact-shape drift.",
+                "success_criterion": "Contact merge completes without duplicated fields.",
+                "confidence": 0.45,
+                "example_trajectory_ids": ["crm-0", "crm-1"],
+            }
+        )
+        + "\n"
+    )
+
+    summary = run_skill_coach_cycle(
+        db_path=str(db_path),
+        proposals_path=str(proposals_path),
+        evidence_path=str(evidence_path),
+        min_support=3,
+        run_aggregator=False,
+    )
+
+    assert summary["status"] == "ok"
+    assert summary["aggregator_ran"] is False
+    assert summary["proposals_written"] == 1
+    assert summary["evidence_written"] == 1
+    assert summary["evidence_by_status"] == {"proposed": 1}
+
+
+def test_cli_writes_single_json_summary(tmp_path, capsys):
+    from backend.scripts.skill_coach_openclaw_runner import main
+
+    db_path = tmp_path / "experience.db"
+    proposals_path = tmp_path / "skill_creation_proposals.jsonl"
+    evidence_path = tmp_path / "skill_coach_evidence.jsonl"
+    proposals_path.write_text("")
+
+    rc = main(
+        [
+            "--db-path",
+            str(db_path),
+            "--proposals",
+            str(proposals_path),
+            "--out",
+            str(evidence_path),
+            "--skip-aggregator",
+        ]
+    )
+
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["status"] == "ok"
+    assert output["aggregator_ran"] is False
+    assert output["proposals_written"] == 0
+    assert output["evidence_written"] == 0

--- a/apps/backend-rag/config/openclaw_skill_coach_cron.yaml
+++ b/apps/backend-rag/config/openclaw_skill_coach_cron.yaml
@@ -1,0 +1,20 @@
+# Skill Coach — OpenClaw cron configuration
+# Deploy on Pro only:
+#   cp /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/config/openclaw_skill_coach_cron.yaml \
+#      ~/.openclaw/crons/skill_coach.yaml
+# Or symlink:
+#   ln -s /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/config/openclaw_skill_coach_cron.yaml \
+#      ~/.openclaw/crons/skill_coach.yaml
+
+jobs:
+  # Daily Skill Coach: 02:20 WITA (UTC+8) = 18:20 UTC
+  - name: skill-coach-daily
+    schedule: "20 18 * * *" # UTC — 02:20 WITA
+    command: >
+      cd /Users/nuzantara/Desktop/nuzantara/apps/backend-rag &&
+      source .venv/bin/activate &&
+      PYTHONPATH=. python -m backend.scripts.skill_coach_openclaw_runner
+    timeout: 900 # 15 minutes max
+    on_failure: telegram
+    description: "Skill Coach daily learning loop — Genome trajectories to redacted evidence cards"
+    enabled: true

--- a/apps/backend-rag/requirements-prod.lock.txt
+++ b/apps/backend-rag/requirements-prod.lock.txt
@@ -3710,9 +3710,9 @@ sse-starlette==3.4.4 \
     --hash=sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0 \
     --hash=sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973
     # via mcp
-starlette==1.0.1 \
-    --hash=sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f \
-    --hash=sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd
+starlette==1.3.1 \
+    --hash=sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0 \
+    --hash=sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6
     # via
     #   -r requirements-prod.txt
     #   brotli-asgi

--- a/apps/backend-rag/requirements-prod.txt
+++ b/apps/backend-rag/requirements-prod.txt
@@ -4,7 +4,7 @@
 
 # Core Framework
 fastapi>=0.135.2,!=0.136.3  # Upgraded for starlette 0.50+; exclude 0.136.3 (MAL-2026-4750 supply-chain malware injecting 'fastar' dep)
-starlette>=1.0.1,<1.1.0  # Security fix: PYSEC-2026-161 / GHSA-86qp-5c8j-p5mr; keep prod on the suite-tested 1.0.x line.
+starlette>=1.3.1,<1.4.0  # Security fix: CVE-2026-48817/CVE-2026-48818/CVE-2026-54282/CVE-2026-54283.
 uvicorn[standard]>=0.40.0  # Upgraded for async improvements
 pydantic>=2.12.5
 pydantic-settings>=2.5.2

--- a/apps/backend-rag/requirements.lock.txt
+++ b/apps/backend-rag/requirements.lock.txt
@@ -4449,9 +4449,9 @@ sse-starlette==3.4.4 \
     # via
     #   -r requirements.txt
     #   mcp
-starlette==1.0.1 \
-    --hash=sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f \
-    --hash=sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd
+starlette==1.3.1 \
+    --hash=sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0 \
+    --hash=sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6
     # via
     #   -r requirements.txt
     #   brotli-asgi

--- a/apps/backend-rag/requirements.txt
+++ b/apps/backend-rag/requirements.txt
@@ -5,7 +5,7 @@
 
 # Core Framework
 fastapi>=0.135.2,!=0.136.3  # Upgraded for starlette 0.50+; exclude 0.136.3 (MAL-2026-4750 supply-chain malware injecting 'fastar' dep)
-starlette>=1.0.1,<1.1.0  # Security fix: PYSEC-2026-161 / GHSA-86qp-5c8j-p5mr; keep dev lock on the suite-tested 1.0.x line.
+starlette>=1.3.1,<1.4.0  # Security fix: CVE-2026-48817/CVE-2026-48818/CVE-2026-54282/CVE-2026-54283.
 uvicorn[standard]>=0.40.0  # Upgraded for async improvements
 sentry-sdk[fastapi]>=2.59.0  # Error monitoring
 pydantic>=2.12.5  # Compatible with MCP 1.25+, google-genai 1.56+

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`325 routers · 611 services · 1045 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`325 routers · 611 services · 1046 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/docs/SKILL_REGISTRY_OPS.md
+++ b/docs/SKILL_REGISTRY_OPS.md
@@ -43,7 +43,13 @@ from trajectories at query time, and sharing the table means a single
               ▼ writes proposals to
   ~/.nuzantara/skill_creation_proposals.jsonl
               │
-              ▼ (Zero reviews)
+              ▼ (OpenClaw sidecar, dry-run)
+  scripts/skill_coach_openclaw_runner.py
+              │
+              ▼ writes redacted evidence to
+  ~/.nuzantara/skill_coach_evidence.jsonl
+              │
+              ▼ (Zero reviews via GET /api/skill/creation-proposals)
   POST /api/skill/record            (Week 3-4 — canonical skills)
               │
               ▼
@@ -107,6 +113,7 @@ the canonical way to do X" → Skill.
 | `EXPERIENCE_DB_PATH`            | ⚙️        | SQLite path (shared with Experience Library)             |
 | `SKILL_MERGE_PROPOSALS_PATH`    | ⚙️        | jsonl target for `skill_merge_proposals.py` (default `~/.nuzantara/skill_merge_proposals.jsonl`) |
 | `SKILL_CREATION_PROPOSALS_PATH` | ⚙️        | jsonl target for `experience_to_skill_aggregator.py`     |
+| `SKILL_COACH_EVIDENCE_PATH`     | ⚙️        | jsonl target for redacted Skill Coach evidence cards     |
 | `OPENAI_API_KEY`                | ✅       | Required by the merge-proposals job (text-embedding-3-small) |
 | `JWT_SECRET_KEY`, `API_KEYS`    | ✅       | Auth for the HTTP surface                                 |
 
@@ -238,7 +245,7 @@ PYTHONPATH=. python backend/scripts/skill_merge_proposals.py \
 Never merges — only suggests. Zero reads via `GET /api/skill/merge-proposals`
 and decides.
 
-### Experience → Skill aggregation (weekly, NOT scheduled yet)
+### Experience → Skill aggregation (standalone building block)
 
 `scripts/experience_to_skill_aggregator.py` clusters successful trajectories
 by (cell, sorted tags) inside a rolling window. When a cluster hits
@@ -251,7 +258,40 @@ PYTHONPATH=. python backend/scripts/experience_to_skill_aggregator.py \
 ```
 
 Never creates — only suggests. Zero reviews and either recorded the skill
-manually via `POST /api/skill/record` or ignores the proposal.
+manually via `POST /api/skill/record` or ignores the proposal. For scheduled
+operations, use the Skill Coach OpenClaw cycle below so the proposals are also
+converted into redacted evidence cards.
+
+### Skill Coach OpenClaw cycle (daily sidecar, propose-only)
+
+`scripts/skill_coach_openclaw_runner.py` is the runner OpenClaw should call.
+It chains the conservative aggregator with the Skill Coach evaluator and emits
+one machine-readable JSON summary for the cron gateway:
+
+```bash
+cd apps/backend-rag
+source .venv/bin/activate
+PYTHONPATH=. python -m backend.scripts.skill_coach_openclaw_runner
+```
+
+The runner writes:
+
+- proposals: `~/.nuzantara/skill_creation_proposals.jsonl`
+- redacted evidence: `~/.nuzantara/skill_coach_evidence.jsonl`
+
+It never records a skill, never promotes a skill, and never publishes HGT.
+Only the evidence cards become visible to admins at
+`GET /api/skill/creation-proposals`.
+
+To arm it on the Pro OpenClaw gateway:
+
+```bash
+cp /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/config/openclaw_skill_coach_cron.yaml \
+   ~/.openclaw/crons/skill_coach.yaml
+```
+
+The config runs daily at 02:20 WITA. Use `--skip-aggregator` only when you want
+to re-evaluate an existing proposals file without regenerating it.
 
 ## Daily Operations
 
@@ -282,6 +322,7 @@ curl -s "http://localhost:8000/api/skill/top?tier=tier1&limit=10" \
 ```bash
 cat ~/.nuzantara/skill_merge_proposals.jsonl | jq -c '{pair, cosine}' | head
 cat ~/.nuzantara/skill_creation_proposals.jsonl | jq -c '{cell, skill_id, n_trajectories}' | head
+cat ~/.nuzantara/skill_coach_evidence.jsonl | jq -c '{skill_id, status, support_count}' | head
 ```
 
 ## Maintenance
@@ -314,6 +355,7 @@ grows past ~10k rows.
 | 422 on every record                              | client sending empty precondition/success_criterion        | both fields are required by Pydantic — enforce upstream                             |
 | Merge proposals file stays empty                 | fewer than 2 active skills, or threshold too tight        | lower `--threshold`, check `/api/skill/stats.total`                                 |
 | Aggregator proposals file stays empty            | no (cell, tags) cluster hits `--min-cluster-size`         | lower the threshold temporarily for inspection; `--window-days` can widen the lens  |
+| Skill Coach evidence file stays empty            | proposals file is empty, or runner was called with wrong paths | run `skill_coach_openclaw_runner.py` manually and inspect its JSON summary        |
 
 ## Design Notes (from DeepSeek R1 federation review, 2026-04-16)
 


### PR DESCRIPTION
## Summary
- Add a single OpenClaw-friendly Skill Coach runner that aggregates Genome trajectories and evaluates redacted evidence cards.
- Add deployable OpenClaw cron config for Pro, plus Skill Registry runbook updates.
- Add unit coverage for full cycle, skip-aggregator mode, and JSON CLI output.

## Safety
- Propose-only: no active skill creation, no promotion, no HGT publish.
- Live OpenClaw install is intentionally not performed by this PR; copy/symlink to ~/.openclaw/crons/ remains an explicit ops step.

## Test plan
- source .venv/bin/activate && PYTHONPATH=. pytest backend/tests/unit/scripts/test_skill_coach_openclaw_runner.py backend/tests/unit/scripts/test_skill_coach_evaluate_proposals.py backend/tests/unit/scripts/test_experience_to_skill_aggregator.py backend/tests/unit/services/skill_coach/test_service.py backend/tests/unit/app/routers/test_skill.py -q
- source .venv/bin/activate && ruff check backend/scripts/skill_coach_openclaw_runner.py backend/tests/unit/scripts/test_skill_coach_openclaw_runner.py
- source .venv/bin/activate && PYTHONPATH=. python -m backend.scripts.skill_coach_openclaw_runner --db-path <tmp>/experience.db --proposals <tmp>/proposals.jsonl --out <tmp>/evidence.jsonl --min-cluster-size 3 --min-support 3