### PR TITLE
chore(deps): bump starlette 1.0.1 -> 1.3.1 (4 CVEs, unblocks #1493)

### DIFF
--- a/apps/backend-rag/requirements-prod.lock.txt
+++ b/apps/backend-rag/requirements-prod.lock.txt
@@ -3710,9 +3710,9 @@ sse-starlette==3.4.4 \
     --hash=sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0 \
     --hash=sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973
     # via mcp
-starlette==1.0.1 \
-    --hash=sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f \
-    --hash=sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd
+starlette==1.3.1 \
+    --hash=sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0 \
+    --hash=sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6
     # via
     #   -r requirements-prod.txt
     #   brotli-asgi

--- a/apps/backend-rag/requirements-prod.txt
+++ b/apps/backend-rag/requirements-prod.txt
@@ -4,7 +4,7 @@
 
 # Core Framework
 fastapi>=0.135.2,!=0.136.3  # Upgraded for starlette 0.50+; exclude 0.136.3 (MAL-2026-4750 supply-chain malware injecting 'fastar' dep)
-starlette>=1.0.1,<1.1.0  # Security fix: PYSEC-2026-161 / GHSA-86qp-5c8j-p5mr; keep prod on the suite-tested 1.0.x line.
+starlette>=1.3.1,<1.4.0  # Security: bump for CVE-2026-48818/48817/54283/54282 (fixed in 1.1.0/1.3.0/1.3.1); on the 1.3.x line.
 uvicorn[standard]>=0.40.0  # Upgraded for async improvements
 pydantic>=2.12.5
 pydantic-settings>=2.5.2

--- a/apps/backend-rag/requirements.lock.txt
+++ b/apps/backend-rag/requirements.lock.txt
@@ -1032,7 +1032,6 @@ fastapi==0.136.1 \
     --hash=sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f
     # via
     #   -r requirements.txt
-    #   prometheus-fastapi-instrumentator
     #   sentry-sdk
 fastuuid==0.14.0 \
     --hash=sha256:05a8dde1f395e0c9b4be515b7a521403d1e8349443e7641761af07c7ad1624b1 \
@@ -2510,6 +2509,7 @@ numpy==2.4.6 \
     #   -r requirements.txt
     #   blis
     #   datasets
+    #   opencv-python-headless
     #   pandas
     #   qdrant-client
     #   scikit-learn
@@ -2530,6 +2530,16 @@ openai==2.38.0 \
     #   langchain-openai
     #   langfuse
     #   litellm
+opencv-python-headless==4.13.0.92 \
+    --hash=sha256:0525a3d2c0b46c611e2130b5fdebc94cf404845d8fa64d2f3a3b679572a5bd22 \
+    --hash=sha256:0bd48544f77c68b2941392fcdf9bcd2b9cdf00e98cb8c29b2455d194763cf99e \
+    --hash=sha256:1a7d040ac656c11b8c38677cc8cccdc149f98535089dbe5b081e80a4e5903209 \
+    --hash=sha256:3e0a6f0a37994ec6ce5f59e936be21d5d6384a4556f2d2da9c2f9c5dc948394c \
+    --hash=sha256:5c8cfc8e87ed452b5cecb9419473ee5560a989859fe1d10d1ce11ae87b09a2cb \
+    --hash=sha256:77a82fe35ddcec0f62c15f2ba8a12ecc2ed4207c17b0902c7a3151ae29f37fb6 \
+    --hash=sha256:a7cf08e5b191f4ebb530791acc0825a7986e0d0dee2a3c491184bd8599848a4b \
+    --hash=sha256:eb60e36b237b1ebd40a912da5384b348df8ed534f6f644d8e0b4f103e272ba7d
+    # via -r requirements.txt
 openinference-instrumentation==0.1.51 \
     --hash=sha256:7923619c9e1c3f3a8ae924f909e86bdeda27186222352a7a8a7a6cecea1771a6 \
     --hash=sha256:a35b45f4912c2668fb6986394229fa5d785b9f7ded038793dc0ceed88f699a5b
@@ -4449,14 +4459,15 @@ sse-starlette==3.4.4 \
     # via
     #   -r requirements.txt
     #   mcp
-starlette==1.0.1 \
-    --hash=sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f \
-    --hash=sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd
+starlette==1.3.1 \
+    --hash=sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0 \
+    --hash=sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6
     # via
     #   -r requirements.txt
     #   brotli-asgi
     #   fastapi
     #   mcp
+    #   prometheus-fastapi-instrumentator
     #   sse-starlette
 structlog==25.5.0 \
     --hash=sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98 \

--- a/apps/backend-rag/requirements.txt
+++ b/apps/backend-rag/requirements.txt
@@ -5,7 +5,7 @@
 
 # Core Framework
 fastapi>=0.135.2,!=0.136.3  # Upgraded for starlette 0.50+; exclude 0.136.3 (MAL-2026-4750 supply-chain malware injecting 'fastar' dep)
-starlette>=1.0.1,<1.1.0  # Security fix: PYSEC-2026-161 / GHSA-86qp-5c8j-p5mr; keep dev lock on the suite-tested 1.0.x line.
+starlette>=1.3.1,<1.4.0  # Security: bump for CVE-2026-48818/48817/54283/54282 (fixed in 1.1.0/1.3.0/1.3.1); on the 1.3.x line.
 uvicorn[standard]>=0.40.0  # Upgraded for async improvements
 sentry-sdk[fastapi]>=2.59.0  # Error monitoring
 pydantic>=2.12.5  # Compatible with MCP 1.25+, google-genai 1.56+


### PR DESCRIPTION
## What

Bumps `starlette` from `1.0.1` to `1.3.1` to close 4 live CVEs and unblock the `pip-audit` gate.

Pin change in **both** `requirements.txt` and `requirements-prod.txt`:

```
- starlette>=1.0.1,<1.1.0
+ starlette>=1.3.1,<1.4.0
```

## Why

- `starlette 1.0.1` carries **CVE-2026-48818 / 48817 / 54283 / 54282**, fixed in `1.1.0 / 1.3.0 / 1.3.1`.
- `fastapi 0.136.1` accepts `starlette>=0.46.0` (no upper bound), so `1.3.1` is fully compatible.
- Closes the live `pip-audit` failure that blocks **PR #1493** (hook drift sentinel) and other PRs.
- The old `<1.1.0` ceiling existed only to stay on the "suite-tested 1.0.x line" — CI runs the full backend suite against `1.3.1` to honor that rationale.

## Lock files

Regenerated with `uv 0.11.18` using the exact command in each lock header (`uv pip compile … --generate-hashes --python-version 3.11`):

- `requirements-prod.lock.txt`: **clean, starlette-only diff** (`1.0.1 → 1.3.1` with fresh PyPI hashes).
- `requirements.lock.txt`: `starlette 1.0.1 → 1.3.1` **plus two pre-existing lock-drift corrections** unrelated to this bump:
  - `opencv-python-headless==4.13.0.92` added — it is a **direct** dep declared in `requirements.txt:136` (since 2026-06-14) but was missing from the committed lock (stale lock).
  - `prometheus-fastapi-instrumentator` "via" attribution corrected.

## Validation

- Ephemeral isolated venv (operator `.venv` **not** touched): `starlette 1.3.1` + `fastapi 0.136.1` install, import, and `FastAPI()` construct cleanly.
- **CI backend suite is the validation gate** against the bumped pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)