### PR TITLE
fix(db): resolve migration-230 collision (rename autologout→231, W40) — UNBLOCKS merge queue

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/231_autologout_idempotency_guard.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/231_autologout_idempotency_guard.sql
@@ -1,4 +1,4 @@
--- 230_autologout_idempotency_guard.sql
+-- 231_autologout_idempotency_guard.sql
 --
 -- Fix the auto-logout cron loop that wrote 174 duplicate clock_out rows for a
 -- single team member (damar@balizero.com, 2026-06-15). Root cause:


### PR DESCRIPTION
## What
Renames `230_autologout_idempotency_guard.sql` → **`231_…`** to resolve a duplicate migration-number `230` already on `main`.

## Why this is urgent (unblocks everything)
Two migrations share prefix `230` on main (`230_kg_proposals` + `230_autologout_idempotency_guard`). This makes `lint_migration_numbers.py` and `migration_manager._assert_unique_migration_numbers` **fail**, turning **"Hot-zone enforcement"** and **"Backend Tests (Python)"** RED on **every open PR** → the entire merge queue is blocked, not just the two offenders.

Per cicatrix **W40** convention: the file that arrived **second** in git-log time yields. `230_autologout` (22:32) > `230_kg_proposals` (22:28) → autologout renamed to 231 (verified free).

## Production safety — verified via postgres MCP (read-only) BEFORE the rename
- `_schema_versions`: `230_kg_proposals` applied; `230_autologout` **never recorded** (runner applied one 230, silently skipped the other — the W40 symptom).
- **But** the live `auto_logout_expired_sessions()` function **already has the idempotency guard**, and `damar@` shows exactly **1 clock_out/day** (8–14 Jun, zero duplicates). → The auto-logout bug is **NOT live**; the fix is operative in prod (applied out-of-band). This rename only realigns the migration **registry** with the DB.
- SQL is `CREATE OR REPLACE` (idempotent) → re-applying as 231 is safe.

## Verification
Local `lint_migration_numbers.py`: **115 files, all unique prefixes, exit 0**.

## Scope
1 file renamed (+1-line header comment). No SQL logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)