### PR TITLE
fix(curiosity): SEA-LION-32B + 240s timeout for gap research (was qwen3.5:9b/60s)

### DIFF
--- a/apps/graph-engine/src/nuzantara_graph/curiosity/dispatchers/simple.py
+++ b/apps/graph-engine/src/nuzantara_graph/curiosity/dispatchers/simple.py
@@ -2,14 +2,32 @@
 
 # Organo: graph-engine/curiosity/dispatchers → produce ResearchEvidence
 
-Uses Ollama qwen3.5:9b to generate evidence for well-defined regulatory gaps.
-Falls back to template-based evidence summary when Ollama is unavailable.
-Graceful degradation: returns empty evidence list on any failure.
+Uses a local SEA-trained Ollama model to generate evidence for well-defined
+regulatory gaps. Falls back to template-based evidence summary when Ollama is
+unavailable. Graceful degradation: returns empty evidence list on any failure.
+
+Model + timeout chosen from a live benchmark on the Pro (2026-06-16). The
+previous default (qwen3.5:9b, 60s timeout) timed out on EVERY gap — the
+regulatory-research + JSON task takes ~100-120s on the Pro (a loaded H24
+workhorse), so the 60s cap meant the cron ran for 10 days producing only
+template placeholders, never real research. Three locally-present models on
+the real prompt:
+  - qwen3.5:9b   104s, cites a stale framework (Negative Investment List,
+                 superseded by the Positive List / Perpres 10/2021)
+  - gemma3:27b   194s, hallucinated a non-existent "Law 6/2023" for PT PMA
+  - SEA-LION-32B 121s, correct Indonesian terminology (BKPM, MoJ, UU 11/2020) —
+                 AI Singapore's model is trained on Southeast-Asian context,
+                 best accuracy for the Indonesian regulatory domain.
+SEA-LION wins on accuracy at +17s vs qwen — irrelevant for a once-nightly cron.
+Timeout 180s gives headroom over the measured 121s incl. cold-start variance.
+Model/URL/timeout are env-overridable so the Pro and Mini can diverge without
+a code change (the Mini only has <=9B models).
 """
 from __future__ import annotations
 
 import json
 import logging
+import os
 import urllib.request
 from typing import Any
 
@@ -17,9 +35,16 @@ from nuzantara_graph.curiosity.models import ResearchEvidence
 
 logger = logging.getLogger(__name__)
 
-OLLAMA_URL = "http://localhost:11434/api/chat"
-OLLAMA_MODEL = "qwen3.5:9b"
-OLLAMA_TIMEOUT = 60
+OLLAMA_URL = os.environ.get("CURIOSITY_OLLAMA_URL", "http://localhost:11434/api/chat")
+# SEA-LION v4 32B (AI Singapore) — best Indonesian-regulatory accuracy in the
+# 2026-06-16 Pro benchmark. Override per host via CURIOSITY_OLLAMA_MODEL.
+OLLAMA_MODEL = os.environ.get(
+    "CURIOSITY_OLLAMA_MODEL", "aisingapore/Qwen-SEA-LION-v4-32B-IT:q4_k_m"
+)
+# Live E2E on the Pro measured 103s and 170s on two real gaps — the second
+# brushed a 180s cap, so 240s gives genuine cold-start headroom. A once-nightly
+# cron can well afford it. Override via env.
+OLLAMA_TIMEOUT = int(os.environ.get("CURIOSITY_OLLAMA_TIMEOUT", "240"))
 
 RESEARCH_PROMPT = """You are a regulatory research assistant for Indonesian business services.
 


### PR DESCRIPTION
## Problema
Follow-up del fix curiosity_loop (PR #1490, già merged). Quel fix ha reso il cron VIVO (errors=0), ma un'indagine sulla qualità ha rivelato che **il robot girava a vuoto**: `SimpleDispatcher` chiamava Ollama `qwen3.5:9b` con timeout **60s**, ma la task (ricerca regolatoria + JSON) richiede **~100-170s** sul Pro (workhorse H24 carico). Risultato: **ogni** gap andava in timeout → fallback a un placeholder template (`"Gap identified: X. Requires external research."`). 10 giorni di cron, ricerca vera su **zero** gap.

## Benchmark live (Pro, 2026-06-16) — 3 modelli già presenti
| Modello | Latenza | Qualità |
|---|---|---|
| qwen3.5:9b (vecchio) | 104s | framework datato (DNI, sostituita da Positive List/Perpres 10/2021) |
| gemma3:27b | 194s | allucina "Law 6/2023" per PT PMA (inesistente) |
| **SEA-LION-v4-32B** | 121s | ✅ terminologia indonesiana corretta (BKPM/MoJ/UU 11-2020), AI Singapore SEA-trained |

## Fix
- Modello default → `aisingapore/Qwen-SEA-LION-v4-32B-IT:q4_k_m`
- Timeout → **240s** (E2E ha misurato 103s e 170s; il secondo sfiorava un cap a 180s → 240s per margine cold-start)
- Modello/URL/timeout ora **env-overridable** (`CURIOSITY_OLLAMA_MODEL/_URL/_TIMEOUT`) — Pro e Mini possono divergere (il Mini ha solo modelli ≤9B)

## Verificato E2E LIVE sul Pro ✅
Due gap reali col dispatcher patchato:
- **PT PMA setup 2025** → `source_type=ollama` (era `template`), 103s, conf 0.85: *UU 11/2020, BKPM, MoJ, Izin Usaha*
- **Immigration overstay 2025** → `source_type=ollama`, 170s, conf 0.80: *IDR 1M/giorno cap IDR 100M, UU 6/2011, PP 23/2019, regolarizzazione 30gg*

## Residuo noto (fase 2, già approvata da operatore)
SEA-LION talvolta cita ancora la DNI deprecata. Verrà aggiunto un tier di **verifica web** per ancorare le citazioni a fonti pubbliche live (regolatorio = dato pubblico, no PII).

🤖 Generated with [Claude Code](https://claude.com/claude-code)