### PR TITLE
feat(curiosity): arm gap-research cron + promote weekly batch into repo

### DIFF
--- a/infra/launchagents/com.nuzantara.curiosity-loop.daily.plist
+++ b/infra/launchagents/com.nuzantara.curiosity-loop.daily.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.nuzantara.curiosity-loop.daily</string>
+
+    <!-- Runs the REPO wrapper (not a HOME-fork). The wrapper picks a >=3.11
+         Python, sources ~/.nuzantara-secrets.env, and runs gap_fill_autonomous.py
+         which researches knowledge gaps (SEA-LION + Exa web-verify) and writes
+         propose-only rows to kg_proposals for Zero to approve. -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__REPO__/scripts/curiosity_loop.sh</string>
+    </array>
+
+    <!-- Daily 04:30 WITA (Asia/Makassar UTC+8), per the wrapper header. Off-peak,
+         well clear of the Sunday 20:00 curiosity_batch weekly. -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>4</integer>
+        <key>Minute</key>
+        <integer>30</integer>
+    </dict>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin</string>
+        <key>HOME</key>
+        <string>__HOME__</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/logs/curiosity-loop-launchd.log</string>
+    <key>StandardErrorPath</key>
+    <string>__HOME__/logs/curiosity-loop-launchd.log</string>
+
+    <!-- one-shot cron, NOT a daemon: no KeepAlive (avoids restart-storm,
+         superscar #7), no RunAtLoad. -->
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/infra/launchagents/install_curiosity_loop_cron.sh
+++ b/infra/launchagents/install_curiosity_loop_cron.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Install the curiosity_loop daily cron (com.nuzantara.curiosity-loop.daily).
+#
+# Why: scripts/curiosity_loop.sh declared in its header that it is invoked by
+# ~/Library/LaunchAgents/com.graph.curiosity-loop.plist, but that plist was
+# never installed (or was lost) — so the gap-research robot never ran
+# autonomously and kg_proposals stayed empty (superscar #2 Esiste!=Armato; the
+# schedule lived only as a code comment, not a tracked artifact). This installer
+# renders the tracked template for the current host and loads it.
+#
+# Idempotent. Kill switch:
+#   launchctl bootout gui/$(id -u)/com.nuzantara.curiosity-loop.daily
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# If invoked from a throwaway worktree, resolve the STABLE main checkout — a
+# cron pointed at .worktrees/ would break when the worktree is reaped (W81:
+# cron armed on an ephemeral path).
+case "$REPO" in
+  */.worktrees/*) REPO="${REPO%%/.worktrees/*}" ;;
+esac
+
+HOME_DIR="$HOME"
+LABEL="com.nuzantara.curiosity-loop.daily"
+SRC="$REPO/infra/launchagents/$LABEL.plist"
+DST="$HOME_DIR/Library/LaunchAgents/$LABEL.plist"
+
+if [ "${CURIOSITY_LOOP_CRON_ENABLED:-true}" = "false" ]; then
+    echo "CURIOSITY_LOOP_CRON_ENABLED=false — skipping install"; exit 0
+fi
+[ -f "$SRC" ] || { echo "FATAL: template not found at $SRC"; exit 1; }
+
+mkdir -p "$HOME_DIR/Library/LaunchAgents" "$HOME_DIR/logs"
+
+# Render placeholders for THIS host (no hardcoded /Users/<name> in the repo).
+sed -e "s|__REPO__|$REPO|g" -e "s|__HOME__|$HOME_DIR|g" "$SRC" > "$DST"
+chmod 644 "$DST"
+
+launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$DST"
+
+echo "Installed $LABEL -> $DST (REPO=$REPO)"
+echo "Verify:  launchctl list | grep curiosity-loop"
+echo "Run now: launchctl kickstart -k gui/$(id -u)/$LABEL"

--- a/scripts/cron-agent-python/curiosity_batch.py
+++ b/scripts/cron-agent-python/curiosity_batch.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+Curiosita Pilastro 6 -- weekly batch
+Legge top 10 findings da cell_curiosity_findings (by information_gain DESC)
+Invia Telegram batch ad Antonello per review.
+
+Schema reale cell_curiosity_findings:
+  id, source, question, method, finding, actionable,
+  information_gain, related_goal_id, created_at
+NOTE: no 'status' column -- tabella non ha approvazione; il batch e solo informativo.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from datetime import datetime, timezone
+
+import asyncpg
+import httpx
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+TELEGRAM_BOT_TOKEN = os.environ["TELEGRAM_BOT_TOKEN"]
+TELEGRAM_CHAT_ID = "1125336968"  # Zero @zero0101010101010
+
+# DB: DATABASE_URL from env (sourced from ~/.nuzantara-secrets.env by the wrapper).
+# DB connection — env-only. The plaintext fallback that used to live
+# here (a real backend_rag_v2 password) was a cleartext-secret leak
+# (cicatrix #4) and was stripped when this file was promoted into the repo.
+DATABASE_URL = os.environ["DATABASE_URL"]
+
+TOP_N = 10
+
+
+# ---------------------------------------------------------------------------
+# DB query
+# ---------------------------------------------------------------------------
+
+
+async def get_top_findings(
+    conn: asyncpg.Connection, limit: int = TOP_N
+) -> list[asyncpg.Record]:
+    """Top findings per information_gain DESC, poi per data recente."""
+    return await conn.fetch(
+        """
+        SELECT id, source, question, method, finding,
+               actionable, information_gain, created_at
+        FROM cell_curiosity_findings
+        ORDER BY information_gain DESC, created_at DESC
+        LIMIT $1
+        """,
+        limit,
+    )
+
+
+async def get_summary_stats(conn: asyncpg.Connection) -> dict:
+    """Stats aggregate per il report."""
+    row = await conn.fetchrow(
+        """
+        SELECT
+            COUNT(*) AS total,
+            SUM(CASE WHEN actionable THEN 1 ELSE 0 END) AS actionable_cnt,
+            MAX(created_at) AS last_finding_at
+        FROM cell_curiosity_findings
+        """
+    )
+    return dict(row) if row else {}
+
+
+# ---------------------------------------------------------------------------
+# Telegram
+# ---------------------------------------------------------------------------
+
+
+def _source_emoji(source: str) -> str:
+    if source == "pattern_mining":
+        return "📊"
+    if source == "retrospective_query":
+        return "🤔"
+    return "🔍"
+
+
+def _html_escape(text: str) -> str:
+    """Escape HTML special chars for Telegram HTML parse_mode."""
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+async def send_telegram_batch(
+    findings: list[asyncpg.Record], stats: dict
+) -> None:
+    """Invia batch Telegram usando HTML parse_mode (piu robusto di MarkdownV2)."""
+    if not findings:
+        print("No findings to send", flush=True)
+        return
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    total = stats.get("total", "?")
+    actionable = stats.get("actionable_cnt", "?")
+    last_at = stats.get("last_finding_at")
+    last_str = last_at.strftime("%Y-%m-%d") if last_at else "?"
+
+    lines: list[str] = [
+        "<b>Curiosita Pilastro 6 — Weekly Digest</b>",
+        f"<i>{today}</i> | totale: {total} findings | actionable: {actionable} | ultimo: {last_str}",
+        f"\n<b>Top {len(findings)} per information_gain:</b>",
+    ]
+
+    for i, f in enumerate(findings, 1):
+        emoji = _source_emoji(f["source"])
+        gain = f["information_gain"] or 0.0
+        actionable_flag = "✅" if f["actionable"] else "—"
+        question = _html_escape((f["question"] or "N/A")[:100])
+        finding_preview = _html_escape(
+            (f["finding"] or "")[:150].replace("\n", " ")
+        )
+
+        lines.append(
+            f"\n{i}. {emoji} <b>{question}</b>\n"
+            f"   gain={gain:.2f} {actionable_flag} | src={f['source']}\n"
+            f"   <i>{finding_preview}</i>"
+        )
+
+    text = "\n".join(lines)
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(
+            f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendMessage",
+            json={
+                "chat_id": TELEGRAM_CHAT_ID,
+                "text": text,
+                "parse_mode": "HTML",
+            },
+        )
+        if resp.status_code != 200:
+            print(
+                f"Telegram error {resp.status_code}: {resp.text[:200]}", flush=True
+            )
+            resp.raise_for_status()
+
+    print(f"Telegram batch sent: {len(findings)} findings", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+async def main() -> None:
+    print(
+        f"{datetime.now(timezone.utc).isoformat()} curiosity_batch starting",
+        flush=True,
+    )
+
+    conn = await asyncpg.connect(DATABASE_URL)
+    try:
+        stats = await get_summary_stats(conn)
+        print(
+            f"DB stats: total={stats.get('total')} actionable={stats.get('actionable_cnt')}",
+            flush=True,
+        )
+
+        if not stats.get("total"):
+            print("No findings in DB, skipping Telegram", flush=True)
+            return
+
+        findings = await get_top_findings(conn)
+        print(f"Fetched {len(findings)} findings for batch", flush=True)
+
+        await send_telegram_batch(findings, stats)
+    finally:
+        await conn.close()
+
+    print(
+        f"{datetime.now(timezone.utc).isoformat()} curiosity_batch done",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/curiosity-batch.sh
+++ b/scripts/curiosity-batch.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# curiosity-batch.sh — SYMBIOSIS Pillar 6 weekly Telegram digest wrapper.
+#
+# Reads the top cell_curiosity_findings and sends Zero a weekly Telegram summary.
+# Promoted into the repo (was a ~/scripts HOME-fork, superscar #1). The DB
+# password that used to be exported here in cleartext (cicatrix #4) is gone:
+# DATABASE_URL now comes from ~/.nuzantara-secrets.env like every other secret.
+#
+# Runs every Sunday 20:00 WITA (12:00 UTC) via com.nuzantara.curiosity-batch.weekly.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+case "$REPO" in */.worktrees/*) REPO="${REPO%%/.worktrees/*}" ;; esac
+
+LOG="$HOME/logs/curiosity-batch.log"
+SCRIPT="$REPO/scripts/cron-agent-python/curiosity_batch.py"
+VENV="$REPO/apps/backend-rag/.venv"
+SECRETS="$HOME/.nuzantara-secrets.env"
+
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ): Starting curiosity batch" >> "$LOG"
+
+if [ -f "$SECRETS" ]; then
+    set -a; source "$SECRETS"; set +a
+else
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ): WARNING secrets file not found at $SECRETS" >> "$LOG"
+fi
+
+source "$VENV/bin/activate"
+
+# DATABASE_URL must come from the secrets file (env-only, no hardcoded password).
+if [ -z "${DATABASE_URL:-}" ]; then
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ): FATAL DATABASE_URL not set — aborting" >> "$LOG"
+    exit 1
+fi
+
+python3 "$SCRIPT" >> "$LOG" 2>&1
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ): Curiosity batch completed" >> "$LOG"


### PR DESCRIPTION
## What

Promotes the **curiosity_loop** gap-research scheduler to a tracked artifact and cures two `~/scripts` HOME-fork scripts. Final last-mile of the curiosity-loop revival (after #1490, #1506, #1508).

## Why

The curiosity_loop robot (SYMBIOSIS Pillar 6 — autonomous knowledge-gap research → propose-only `kg_proposals` for Zero to approve) was diagnosed, fixed and **verified live** in three prior PRs:

- **#1490** — missing `kg_proposals` table + interpreter selection + asyncpg reconnect-retry
- **#1506** — SEA-LION-v4-32B model (`CURIOSITY_OLLAMA_MODEL`) + 240s timeout (Ollama was timing out)
- **#1508** — Exa web-verification (`source_type=ollama+web`, `.go.id` ranking)

…but it **had no scheduler**. `scripts/curiosity_loop.sh` declared in its header that it was invoked by `~/Library/LaunchAgents/com.graph.curiosity-loop.plist`, but **that plist was never tracked or installed** — the schedule lived only as a code comment. So the robot never ran autonomously and `kg_proposals` stayed empty.

This is the **superscar #2 "Esiste ≠ Armato"** (built-not-armed / W81) meta-pattern: the organism *constructs* the last-mile but never *arms* it.

## Files

| File | What |
|---|---|
| `infra/launchagents/com.nuzantara.curiosity-loop.daily.plist` | Daily **04:30 WITA** one-shot cron. `StartCalendarInterval`, **no `KeepAlive`** (avoids restart-storm, superscar #7), `RunAtLoad=false`. `__REPO__`/`__HOME__` placeholders rendered per-host by the installer; runs the **REPO** wrapper, never a HOME-fork. |
| `infra/launchagents/install_curiosity_loop_cron.sh` | Idempotent installer. Resolves the **stable main checkout** when invoked from a throwaway worktree (`.worktrees/ → main`) so the cron is never armed on an ephemeral path that gets reaped (**W81** prevention). Kill switch `CURIOSITY_LOOP_CRON_ENABLED=false`. |
| `scripts/cron-agent-python/curiosity_batch.py` | Promoted from `~/scripts` HOME-fork (superscar #1). Weekly Telegram digest of top `cell_curiosity_findings`. |
| `scripts/curiosity-batch.sh` | Promoted wrapper. env-only, fail-fast if `DATABASE_URL` unset. |

## Security (cicatrix #4)

The promoted `~/scripts` versions had a **hardcoded `backend_rag_v2` DB password in cleartext** (cleartext-secret leak, cicatrix #4). **Stripped** in the repo versions — `DATABASE_URL` now comes from `~/.nuzantara-secrets.env` env-only, like every other secret.

⚠️ **OPERATOR FOLLOW-UP:** the `backend_rag_v2` password that was historically world-readable in the HOME-fork **must be rotated** (it has been on-disk in cleartext).

## Verification

- `python -m py_compile curiosity_batch.py` → OK
- `bash -n` on both wrappers → OK
- `plutil -lint` on the plist → OK
- The daily cron is already **installed + kickstarted live on the Pro** from this branch's worktree; this PR makes the installer/template authoritative in the repo so any node can re-arm idempotently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)