### PR TITLE
feat(nb-curator): arm challenge-page sweep + move propose-only brain to agy Flash

### DIFF
--- a/apps/bali-intel-scraper/scripts/nb_dedup_exact_url.py
+++ b/apps/bali-intel-scraper/scripts/nb_dedup_exact_url.py
@@ -14,6 +14,16 @@ captures anti-bot placeholder titles ("just a moment", "security checkpoint",
 site name) on DISTINCT articles, so identical titles are false positives. Title
 and fuzzy dedup are left to the LLM Mode C propose-only pass.
 
+Challenge-sweep mode (--challenge-sweep): the ONE narrow exception to "no title
+dedup". Anti-bot placeholder pages ("Just a moment...", "Vercel Security
+Checkpoint") are zero-content garbage that never get a URL-dup partner, so the
+LLM proposes their deletion every day but is forbidden from applying it — they
+pile up until a notebook hits NotebookLM's hard 500-source ceiling and silently
+drops new sources. This mode deletes ONLY those exact-title placeholders, ONLY in
+notebooks at/near the ceiling (--near-cap). STRICT exact allowlist, never fuzzy/
+substring, so a real article whose title merely contains "moment"/"security" is
+untouched. Same per-run cap / --apply gate / audit log as the dedup path.
+
 Safety:
   - Only canonical-URL matches (L1+L4). NEVER title/Levenshtein/fuzzy.
   - Per-run delete cap (default 20): abort the whole run if exceeded — a large
@@ -49,6 +59,17 @@ TRACKING_PARAMS = frozenset({
     "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content",
     "fbclid", "gclid", "gbraid", "wbraid", "msclkid", "mc_cid", "mc_eid",
     "ref", "ref_src", "igshid", "_hsenc", "_hsmi", "yclid", "dclid",
+})
+
+# Anti-bot challenge-page placeholder titles (zero real content) the scraper
+# captures when a site's WAF blocks it. STRICT exact-match allowlist on the
+# NORMALIZED title (see _norm_title) — NEVER substring/fuzzy, so a real article
+# titled "A moment of reckoning" or "Vercel raises Series D" is never matched.
+# Only used by --challenge-sweep, and only on notebooks at/near the 500 ceiling.
+CHALLENGE_TITLES = frozenset({
+    "just a moment",                       # Cloudflare interstitial
+    "attention required! | cloudflare",    # Cloudflare block page
+    "vercel security checkpoint",          # Vercel WAF interstitial
 })
 
 # NB-INTEL live UUIDs (post 2026-05-18 switch). Source of truth: `nlm list notebooks`.
@@ -116,6 +137,41 @@ def find_duplicates(sources: list[dict]) -> list[tuple[str, list[str]]]:
     return out
 
 
+def _norm_title(title: str) -> str:
+    """Normalize a title for exact challenge-page comparison: lowercase, fold the
+    unicode ellipsis to '...', strip trailing dots/whitespace. So 'Just a moment...',
+    'Just a moment…' and '  JUST A MOMENT ' all collapse to 'just a moment'."""
+    return title.strip().lower().replace("…", "...").rstrip(". ")
+
+
+def find_challenge_pages(sources: list[dict]) -> list[str]:
+    """Return ids of sources whose NORMALIZED title is an exact challenge-page
+    placeholder (CHALLENGE_TITLES). Exact-match only — a title that merely contains
+    one of these words does not match."""
+    out: list[str] = []
+    for src in sources:
+        sid = src.get("id")
+        if sid and _norm_title(src.get("title") or "") in CHALLENGE_TITLES:
+            out.append(sid)
+    return out
+
+
+def select_challenge_deletions(
+    sources_by_nb: dict[str, list[dict]], near_cap: int
+) -> list[tuple[str, str]]:
+    """Plan challenge-page deletions, but ONLY for notebooks at/near the hard
+    500-source ceiling (len(sources) >= near_cap). Below the ceiling there is no
+    space pressure, so challenge pages stay as LLM propose-only items.
+    Returns [(nb_key, source_id), ...] in notebook order."""
+    plan: list[tuple[str, str]] = []
+    for key, sources in sources_by_nb.items():
+        if len(sources) < near_cap:
+            continue
+        for sid in find_challenge_pages(sources):
+            plan.append((key, sid))
+    return plan
+
+
 def delete_sources(source_ids: list[str]):
     """Delete sources via nlm in chunks (large argv fails).
 
@@ -143,11 +199,79 @@ def audit(entry: dict) -> None:
         f.write(json.dumps(entry) + "\n")
 
 
+def run_challenge_sweep(apply: bool, cap: int, near_cap: int) -> int:
+    """Delete anti-bot challenge-page placeholders, but ONLY in NB-INTEL notebooks
+    at/near the 500-source ceiling. Mirrors main()'s safety: cap-abort, --apply gate,
+    per-deletion audit. Exit codes match main() (0 ok, 2 cap exceeded, 3 nlm error)."""
+    sources_by_nb: dict[str, list[dict]] = {}
+    for key, nb_uuid in NB_INTEL.items():
+        try:
+            sources_by_nb[key] = list_sources(nb_uuid)
+        except (RuntimeError, subprocess.TimeoutExpired, json.JSONDecodeError) as e:
+            logger.error("skip %s (%s): %s", key, nb_uuid, e)
+
+    plan = select_challenge_deletions(sources_by_nb, near_cap)
+    total = len(plan)
+    if total == 0:
+        logger.info(
+            "challenge-sweep: no challenge pages in near-cap NB-INTEL (near_cap=%d)", near_cap
+        )
+        print(json.dumps({"challenge_deleted": 0, "planned": 0, "applied": apply}))
+        return 0
+
+    if total > cap:
+        logger.error("ABORT challenge-sweep: %d planned exceed cap %d", total, cap)
+        print(json.dumps({"challenge_deleted": 0, "planned": total, "aborted_cap": cap}))
+        return 2
+
+    if not apply:
+        for key, sid in plan:
+            logger.info("[dry-run] challenge-sweep %s: would delete %s", key, sid)
+        print(json.dumps({"challenge_deleted": 0, "planned": total, "applied": False}))
+        return 0
+
+    deleted = 0
+    ts = datetime.now(timezone.utc).isoformat()
+    by_nb: dict[str, list[str]] = defaultdict(list)
+    for key, sid in plan:
+        by_nb[key].append(sid)
+    for key, ids in by_nb.items():
+        nb_deleted = 0
+        try:
+            for sid in delete_sources(ids):
+                audit({"ts": ts, "nb": key, "deleted_id": sid, "reason": "challenge_page_at_cap"})
+                deleted += 1
+                nb_deleted += 1
+        except (RuntimeError, subprocess.TimeoutExpired) as e:
+            logger.error("challenge-sweep delete failed for %s after %d: %s", key, nb_deleted, e)
+            print(json.dumps({"challenge_deleted": deleted, "planned": total, "applied": True, "error": str(e)}))
+            return 3
+        logger.info("%s: deleted %d challenge pages (at cap)", key, nb_deleted)
+
+    print(json.dumps({"challenge_deleted": deleted, "planned": total, "applied": True}))
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Exact-URL dedup for NB-INTEL notebooks.")
     parser.add_argument("--apply", action="store_true", help="Actually delete (default: dry-run).")
     parser.add_argument("--cap", type=int, default=DELETE_CAP_PER_RUN, help="Abort if planned deletes exceed this.")
+    parser.add_argument(
+        "--challenge-sweep",
+        action="store_true",
+        help="Instead of URL-dedup: delete exact-title anti-bot challenge pages, "
+        "but only in notebooks at/near the 500 ceiling (--near-cap).",
+    )
+    parser.add_argument(
+        "--near-cap",
+        type=int,
+        default=480,
+        help="Challenge-sweep only runs on a notebook with >= this many sources (default 480).",
+    )
     args = parser.parse_args()
+
+    if args.challenge_sweep:
+        return run_challenge_sweep(apply=args.apply, cap=args.cap, near_cap=args.near_cap)
 
     plan: list[tuple[str, str, str]] = []  # (legacy_key, kept_id, dup_id)
     for key, nb_uuid in NB_INTEL.items():

--- a/apps/bali-intel-scraper/tests/unit/test_nb_dedup_challenge_sweep.py
+++ b/apps/bali-intel-scraper/tests/unit/test_nb_dedup_challenge_sweep.py
@@ -1,0 +1,98 @@
+"""Tests for the --challenge-sweep mode of nb_dedup_exact_url.
+
+Covers the deterministic challenge-page garbage sweep that unblocks an NB-INTEL
+notebook stuck at NotebookLM's hard 500-source ceiling. The load-bearing test is
+`test_find_challenge_pages_innocence` (cicatrix superscar #3 guard-over-match):
+the exact-title allowlist must NOT fire on a legitimate article whose title merely
+contains "moment" / "security" / "vercel".
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2] / "scripts" / "nb_dedup_exact_url.py"
+)
+_spec = importlib.util.spec_from_file_location("nb_dedup_exact_url", SCRIPT)
+nbd = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(nbd)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("Just a moment...", "just a moment"),
+        ("Just a moment…", "just a moment"),  # unicode ellipsis
+        ("  JUST A MOMENT ", "just a moment"),
+        ("Vercel Security Checkpoint", "vercel security checkpoint"),
+        ("Attention Required! | Cloudflare", "attention required! | cloudflare"),
+    ],
+)
+def test_norm_title_folds_variants(raw, expected):
+    assert nbd._norm_title(raw) == expected
+
+
+def test_find_challenge_pages_matches_garbage():
+    sources = [
+        {"id": "a", "title": "Just a moment..."},
+        {"id": "b", "title": "Vercel Security Checkpoint"},
+        {"id": "c", "title": "Attention Required! | Cloudflare"},
+        {"id": "d", "title": "Indonesia raises corporate tax to 22%"},  # real
+    ]
+    assert sorted(nbd.find_challenge_pages(sources)) == ["a", "b", "c"]
+
+
+def test_find_challenge_pages_innocence():
+    """superscar #3: exact-title only — substring lookalikes must NOT match."""
+    legit = [
+        {"id": "1", "title": "A moment of reckoning for crypto regulation"},
+        {"id": "2", "title": "Security checkpoint delays at Ngurah Rai airport"},
+        {"id": "3", "title": "Vercel raises Series E at $9B valuation"},
+        {"id": "4", "title": "Just a moment in the life of a notary"},  # trailing words
+        {"id": "5", "title": "Cloudflare outage post-mortem"},
+    ]
+    assert nbd.find_challenge_pages(legit) == []
+
+
+def test_find_challenge_pages_skips_missing_id_or_title():
+    sources = [
+        {"title": "Just a moment..."},          # no id
+        {"id": "x"},                             # no title
+        {"id": "y", "title": None},              # null title
+    ]
+    assert nbd.find_challenge_pages(sources) == []
+
+
+def test_select_challenge_deletions_gated_below_cap():
+    """A notebook BELOW near_cap is left alone even if it has garbage."""
+    small_nb = [{"id": "g", "title": "Just a moment..."}] + [
+        {"id": f"s{i}", "title": f"Article {i}", "url": f"https://x/{i}"} for i in range(10)
+    ]
+    plan = nbd.select_challenge_deletions({"ai_research": small_nb}, near_cap=480)
+    assert plan == []
+
+
+def test_select_challenge_deletions_fires_at_cap():
+    """A notebook AT/ABOVE near_cap gets its garbage planned for deletion."""
+    big_nb = [{"id": "g1", "title": "Just a moment..."}, {"id": "g2", "title": "Vercel Security Checkpoint"}]
+    big_nb += [{"id": f"s{i}", "title": f"Article {i}"} for i in range(498)]  # total 500
+    plan = nbd.select_challenge_deletions({"ai_research": big_nb}, near_cap=480)
+    assert sorted(sid for _, sid in plan) == ["g1", "g2"]
+    assert all(key == "ai_research" for key, _ in plan)
+
+
+def test_select_challenge_deletions_multi_nb_mixed():
+    """Only near-cap notebooks contribute; below-cap ones (even with garbage) don't."""
+    at_cap = [{"id": "bad", "title": "Just a moment..."}] + [
+        {"id": f"a{i}", "title": f"A{i}"} for i in range(499)
+    ]
+    below = [{"id": "alsobad", "title": "Just a moment..."}] + [
+        {"id": f"b{i}", "title": f"B{i}"} for i in range(50)
+    ]
+    plan = nbd.select_challenge_deletions(
+        {"ai_research": at_cap, "press": below}, near_cap=480
+    )
+    assert plan == [("ai_research", "bad")]

--- a/scripts/nb-curator-daily.sh
+++ b/scripts/nb-curator-daily.sh
@@ -114,7 +114,7 @@ else
     REPORT_PATH="$OUTPUT_DIR/${DATE_STR}-health.md"
 fi
 
-MODE_PROMPT="Run nb-curator daily pass. Follow your spec in ~/.claude/agents/nb-curator.md exactly. Today is $DATE_STR.
+MODE_PROMPT="Run nb-curator daily pass. FIRST read your full operating spec at ~/.claude/agents/nb-curator.md (use your file-read tool) and follow it exactly. You have shell + file tools: use them to run 'nlm' and to write the report file. Today is $DATE_STR.
 
 PART 1 — Mode B health check (ALL notebooks):
 1. Read inventory from ~/.claude/projects/-Users-nuzantara/memory/reference_notebooklm_arsenal_full.md
@@ -136,14 +136,40 @@ OUTPUT:
 
 Hard rules: read-only on NB content. NEVER call 'nlm source add/delete' or any mutating command. Propose only (Article 1)."
 
-log "Mode B+C ($C_SCOPE). Report: $REPORT_PATH"
+log "Mode B+C ($C_SCOPE) via brain=${NB_CURATOR_BRAIN:-agy}. Report: $REPORT_PATH"
 
+# ── Brain: agy Gemini 3.5 Flash primary, claude-cascade --agent fallback ──────
+# The brain is PROPOSE-ONLY now that every deletion is deterministic (Step 1 +
+# Step 1c), so Flash is sufficient — and it frees Claude MAX quota. It is also a
+# REAL fallback: the old path (claude-cascade --agent) made tier3-5 self-skip
+# whenever --agent was set ("neither CLI loads Claude Code agents"), so a
+# quota-exhausted nb-curator simply died (ALL TIERS FAILED). agy in print mode
+# with --dangerously-skip-permissions executes nlm + writes files autonomously
+# (verified 2026-06-16). Override with NB_CURATOR_BRAIN=claude.
+export PATH="$HOME/.local/bin:$PATH"   # ensure the brain (agy/claude) finds nlm
 TMPOUT=$(mktemp)
-"$HOME/scripts/claude-cascade.sh" "$MODE_PROMPT" \
-    --model claude-sonnet-4-6 \
-    --agent nb-curator \
-    > "$TMPOUT" 2>> "$LOG"
-EXIT=$?
+AGY_BIN="$HOME/.local/bin/agy"
+BRAIN_USED=""; EXIT=1
+if [ "${NB_CURATOR_BRAIN:-agy}" = "agy" ] && [ -x "$AGY_BIN" ]; then
+    printf '%s' "$MODE_PROMPT" | "$AGY_BIN" --dangerously-skip-permissions \
+        --model "Gemini 3.5 Flash (Medium)" -p --print-timeout 20m \
+        > "$TMPOUT" 2>> "$LOG"
+    EXIT=$?
+    if [ "$EXIT" -eq 0 ] && grep -qE 'SUMMARY:' "$TMPOUT"; then
+        BRAIN_USED="agy-flash"
+    else
+        log "agy brain failed (exit=$EXIT or no SUMMARY line) — falling back to claude-cascade"
+    fi
+fi
+if [ -z "$BRAIN_USED" ]; then
+    "$HOME/scripts/claude-cascade.sh" "$MODE_PROMPT" \
+        --model claude-sonnet-4-6 \
+        --agent nb-curator \
+        > "$TMPOUT" 2>> "$LOG"
+    EXIT=$?
+    BRAIN_USED="claude-cascade"
+fi
+log "brain used: $BRAIN_USED (exit=$EXIT)"
 cat "$TMPOUT" >> "$LOG"
 
 # ── Step 4: Telegram digest ONLY if action/anomaly ────────────────────────────

--- a/scripts/nb-curator-daily.sh
+++ b/scripts/nb-curator-daily.sh
@@ -1,0 +1,170 @@
+#!/bin/zsh
+# nb-curator-daily.sh — Daily nb-curator orchestrator (Mode A on-demand / B+C cron).
+#
+# Runs every day 04:00 WITA. Steps:
+#   1.  Exact-URL dedup (deterministic Python, --apply, cap 20/run) on 5 NB-INTEL.
+#   1c. Challenge-page sweep at the 500 ceiling (deterministic, gated, kill-switch).
+#   2.  Mode B health check on all NBs (always).
+#   3.  Mode C-Press dedup/summarize proposals (Press grows ~30/wk → daily).
+#       + Monday: Mode C full pass on all 5 NB-INTEL.
+#       + First Monday/month: stale >90d deep pass.
+#   4.  Telegram digest ONLY if action/anomaly (dedup>0 OR challenge>0 OR broken>0 OR proposals>0).
+#
+# Invoked by: com.balizero.nb-curator.daily.plist
+# Logs: ~/logs/nb-curator.log (per-run) + ~/logs/nb-curator-daily-launchd.{log,err}
+#
+# SSOT: this file lives in the repo (scripts/nb-curator-daily.sh). The LaunchAgent
+# must point HERE, not at a ~/scripts/ copy (cicatrix superscar #1 — HOME-fork).
+
+set -uo pipefail
+
+# ── Secrets & defense-in-depth ────────────────────────────────────────────────
+unset ANTHROPIC_API_KEY
+[ -f "$HOME/.nuzantara-secrets.env" ] && { set -a; source "$HOME/.nuzantara-secrets.env"; set +a; }
+unset ANTHROPIC_API_KEY
+
+# ── Paths ─────────────────────────────────────────────────────────────────────
+LOCK_FILE="/tmp/nb-curator.lock"
+LOG="$HOME/logs/nb-curator.log"
+OUTPUT_DIR="$HOME/Desktop/nuzantara/research/nb-health"
+DEDUP_SCRIPT="$HOME/Desktop/nuzantara/apps/bali-intel-scraper/scripts/nb_dedup_exact_url.py"
+DATE_STR=$(TZ=Asia/Makassar date +%Y-%m-%d)
+MONTH_STR=$(TZ=Asia/Makassar date +%Y-%m)
+DOW=$(TZ=Asia/Makassar date +%u)   # 1=Mon..7=Sun
+DAY=$(TZ=Asia/Makassar date +%-d)  # day-of-month
+TG_CHAT="1125336968"
+
+mkdir -p "$HOME/logs" "$OUTPUT_DIR"
+
+# ── flock — prevent overlapping runs ──────────────────────────────────────────
+exec 9>"$LOCK_FILE"
+flock -n 9 || {
+    echo "$(TZ=Asia/Makassar date '+%Y-%m-%dT%H:%M:%S WITA'): nb-curator already running, skipping" >> "$LOG"
+    exit 0
+}
+
+log() { echo "$(TZ=Asia/Makassar date '+%Y-%m-%dT%H:%M:%S WITA'): $*" >> "$LOG"; }
+log "nb-curator-daily started (DOW=$DOW DAY=$DAY)"
+
+# ── Step 1: deterministic exact-URL dedup (auto-apply, cap 20) ────────────────
+DEDUP_DELETED=0
+if [ -f "$DEDUP_SCRIPT" ]; then
+    DEDUP_OUT=$(timeout 300 /usr/bin/python3 "$DEDUP_SCRIPT" --apply --cap 20 2>>"$LOG")
+    log "dedup: $DEDUP_OUT"
+    DEDUP_DELETED=$(echo "$DEDUP_OUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('deleted',0))" 2>/dev/null || echo 0)
+    # cap-exceeded (exit 2) → alert: anomaly, possible matching bug
+    if echo "$DEDUP_OUT" | grep -q 'aborted_cap'; then
+        curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d "chat_id=${TG_CHAT}" \
+            -d "text=⚠️ nb-curator dedup ABORT: planned deletes > cap 20 (possible matching bug). Check ~/logs/nb-curator.log" >/dev/null 2>&1
+    fi
+else
+    log "WARN: dedup script missing at $DEDUP_SCRIPT"
+fi
+
+# ── Step 1c: challenge-page sweep at ceiling (deterministic, gated) ───────────
+# Step 1 deliberately skips anti-bot placeholder titles ("Just a moment...",
+# "Vercel Security Checkpoint") because they share no URL. The LLM (Step 2+3) can
+# only PROPOSE their removal (Article 1, propose-only) — so they piled up unapplied
+# for weeks until NB-INTEL-AIResearch hit NotebookLM's hard 500-source ceiling and
+# silently dropped new sources. This step deletes ONLY those exact-title garbage
+# pages, ONLY when a notebook is at/near the ceiling (--near-cap 480). Strict
+# allowlist, never fuzzy. Kill-switch: NB_CURATOR_CHALLENGE_SWEEP_ENABLED=false.
+CHALLENGE_DELETED=0
+if [ "${NB_CURATOR_CHALLENGE_SWEEP_ENABLED:-true}" = "true" ] && [ -f "$DEDUP_SCRIPT" ]; then
+    SWEEP_OUT=$(timeout 300 /usr/bin/python3 "$DEDUP_SCRIPT" --challenge-sweep --apply --near-cap 480 --cap 20 2>>"$LOG")
+    log "challenge-sweep: $SWEEP_OUT"
+    CHALLENGE_DELETED=$(echo "$SWEEP_OUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('challenge_deleted',0))" 2>/dev/null || echo 0)
+    if echo "$SWEEP_OUT" | grep -q 'aborted_cap'; then
+        curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d "chat_id=${TG_CHAT}" \
+            -d "text=⚠️ nb-curator challenge-sweep ABORT: planned deletes > cap 20 (possible title-match bug). Check ~/logs/nb-curator.log" >/dev/null 2>&1
+    fi
+else
+    log "challenge-sweep skipped (NB_CURATOR_CHALLENGE_SWEEP_ENABLED!=true or script missing)"
+fi
+
+# -- Step 1b: auto-regenerate inventory from live --discover (anti-stale) -------
+# The curator routes off reference_notebooklm_arsenal_full.md; it goes stale as NBs
+# are added/merged/archived (observed 3-week drift). Regenerate deterministically
+# from the live account BEFORE Mode B reads it, so routing is never on a stale map.
+INV_GEN="$HOME/Desktop/nuzantara/scripts/nb_generate_inventory.py"
+INV_VENV="$HOME/Desktop/nuzantara/apps/nlm-bridge/.venv/bin/python"
+if [ -f "$INV_GEN" ] && [ -x "$INV_VENV" ]; then
+    TIMEOUT_BIN=$(command -v timeout || command -v gtimeout || echo /opt/homebrew/bin/timeout)
+    [ -x "$TIMEOUT_BIN" ] || TIMEOUT_BIN=""
+    if $TIMEOUT_BIN 120 "$INV_VENV" "$INV_GEN" --write >>"$LOG" 2>&1; then
+        log "inventory auto-regenerated from live --discover"
+    else
+        log "WARN: inventory regen failed (using existing file)"
+    fi
+else
+    log "WARN: inventory generator or bridge venv missing -- skipping regen"
+fi
+
+# ── Step 2+3: Mode B (always) + Mode C scope by day ───────────────────────────
+if [ "$DOW" -eq 1 ] && [ "$DAY" -le 7 ]; then
+    C_SCOPE="full pass on all 5 NB-INTEL + stale >90d deep cleanup (first Monday of month)"
+    REPORT_PATH="$OUTPUT_DIR/${MONTH_STR}-nb-intel-curation.md"
+elif [ "$DOW" -eq 1 ]; then
+    C_SCOPE="full pass on all 5 NB-INTEL (weekly Monday)"
+    REPORT_PATH="$OUTPUT_DIR/${DATE_STR}-curation.md"
+else
+    C_SCOPE="NB-INTEL-Press only (daily — Press grows ~30/week)"
+    REPORT_PATH="$OUTPUT_DIR/${DATE_STR}-health.md"
+fi
+
+MODE_PROMPT="Run nb-curator daily pass. Follow your spec in ~/.claude/agents/nb-curator.md exactly. Today is $DATE_STR.
+
+PART 1 — Mode B health check (ALL notebooks):
+1. Read inventory from ~/.claude/projects/-Users-nuzantara/memory/reference_notebooklm_arsenal_full.md
+2. For each NB UUID: test with 'nlm query <uuid> \"Riassumi in 1 frase\" --timeout 60' → healthy / stale (>30d) / broken
+3. Compare with last report in $OUTPUT_DIR/ to detect transitions
+4. Read nb-curator-routing.log last 7 days: unqueried NBs + recurring gap_warnings
+
+PART 2 — Mode C dedup/summarize proposals: $C_SCOPE
+5. For in-scope NB-INTEL: fetch 'nlm source list <uuid> --json'
+6. Propose near-dup clusters (Levenshtein title <=3, same-domain weekly bundles) — PROPOSE ONLY
+7. For NB-INTEL-Press: propose summarization for topic clusters >=10 sources
+8. Flag stale sources (>90d) where applicable
+
+NOTE: exact-URL duplicates AND exact-title anti-bot challenge pages (\"Just a moment...\", \"Vercel Security Checkpoint\") in near-cap notebooks are already auto-removed by deterministic pre-steps ($DEDUP_DELETED exact-dup + $CHALLENGE_DELETED challenge removed today) — do NOT propose exact-URL merges or challenge-page deletions, only fuzzy/title/summarization.
+
+OUTPUT:
+9. Write report to: $REPORT_PATH
+10. End your response with a single line: SUMMARY: broken=<n> stale=<n> proposals=<n> press_new=<n>
+
+Hard rules: read-only on NB content. NEVER call 'nlm source add/delete' or any mutating command. Propose only (Article 1)."
+
+log "Mode B+C ($C_SCOPE). Report: $REPORT_PATH"
+
+TMPOUT=$(mktemp)
+"$HOME/scripts/claude-cascade.sh" "$MODE_PROMPT" \
+    --model claude-sonnet-4-6 \
+    --agent nb-curator \
+    > "$TMPOUT" 2>> "$LOG"
+EXIT=$?
+cat "$TMPOUT" >> "$LOG"
+
+# ── Step 4: Telegram digest ONLY if action/anomaly ────────────────────────────
+SUMMARY_LINE=$(grep -oE 'SUMMARY: broken=[0-9]+ stale=[0-9]+ proposals=[0-9]+ press_new=[0-9]+' "$TMPOUT" | tail -1)
+rm -f "$TMPOUT"
+
+BROKEN=$(echo "$SUMMARY_LINE" | grep -oE 'broken=[0-9]+' | cut -d= -f2); BROKEN=${BROKEN:-0}
+PROPOSALS=$(echo "$SUMMARY_LINE" | grep -oE 'proposals=[0-9]+' | cut -d= -f2); PROPOSALS=${PROPOSALS:-0}
+
+if [ "$EXIT" -ne 0 ]; then
+    log "nb-curator ALL TIERS FAILED (exit=$EXIT)"
+    curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+        -d "chat_id=${TG_CHAT}" \
+        -d "text=⚠️ nb-curator daily FAILED (exit=$EXIT). Log: ~/logs/nb-curator.log" >/dev/null 2>&1
+elif [ "$DEDUP_DELETED" -gt 0 ] || [ "$CHALLENGE_DELETED" -gt 0 ] || [ "$BROKEN" -gt 0 ] || [ "$PROPOSALS" -gt 0 ]; then
+    MSG="🗂 nb-curator $DATE_STR: ${DEDUP_DELETED} exact-dup + ${CHALLENGE_DELETED} challenge removed · ${BROKEN} broken · ${PROPOSALS} proposals. Report: ${REPORT_PATH##*/}"
+    curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+        -d "chat_id=${TG_CHAT}" -d "text=$MSG" >/dev/null 2>&1
+    log "Telegram sent: $MSG"
+else
+    log "nb-curator daily OK — no action/anomaly, no Telegram (dedup=0 challenge=0 broken=0 proposals=0)"
+fi
+
+exit 0


### PR DESCRIPTION
## Problem
nb-curator accumulated **28 cleanup proposals for 19 days without applying them**. NB-INTEL-AIResearch (uuid `dc5d01cd…`) hit NotebookLM's **hard 500-source ceiling** and silently dropped new AI-research sources (feeder log: `enriched: processed 10, fed 0, errors 10` -> `skip add_text (NB at cap)`).

**Root cause = a gap between two executors** (superscar #2 "Esiste != Armato" — green cron that proposes but never acts):
- the deterministic dedup (`nb_dedup_exact_url.py`) only auto-applies **exact-URL** duplicates and *deliberately* skips anti-bot placeholder titles ("Just a moment...", "Vercel Security Checkpoint") because they share no URL;
- the LLM Mode C pass *identifies* that garbage but is hard-forbidden from mutating (Article 1, propose-only).

So the garbage fell in the gap and piled up unapplied until the ceiling. No code path applied it; no code detected the cap.

## Fix
Give the garbage category a **deterministic executor (never the LLM)**:
- **`--challenge-sweep` mode** in `nb_dedup_exact_url.py`: deletes ONLY exact-title challenge pages (strict allowlist `CHALLENGE_TITLES`, normalized exact-match, **never fuzzy/substring**), and ONLY in notebooks at/near the ceiling (`--near-cap 480`). Reuses the existing cap-abort, `--apply` gate and `~/logs/nb-dedup-deleted.jsonl` audit.
- **promote the runtime wrapper into the repo** (`scripts/nb-curator-daily.sh`) — it lived only in `~/scripts` (HOME-fork, cicatrix #1, unversioned). New **Step 1c** invokes the sweep with kill-switch `NB_CURATOR_CHALLENGE_SWEEP_ENABLED`; the LLM prompt is told the challenge pages are auto-removed so it stops re-proposing them forever.
- **tests** (11, all green): incl. the superscar #3 **innocence test** — a real article titled "A moment of reckoning" / "Security checkpoint delays" / "Vercel raises Series E" must NOT match — and the near-cap gate.

## Verified
- `pytest tests/unit/test_nb_dedup_challenge_sweep.py` -> **11 passed**
- live dry-run (`--challenge-sweep --near-cap 480`, no `--apply`) -> `{"challenge_deleted": 0, "planned": 0}` (the 13 garbage sources were already hand-cleaned this session; AIResearch is back to ~493 and the feeder resumed adding).

## Activation (last-mile, NOT done in this PR)
The live LaunchAgent `com.balizero.nb-curator.daily.plist` still points at `~/scripts/nb-curator-daily.sh`. To arm Step 1c in prod the plist must be repointed to the repo copy (`scripts/nb-curator-daily.sh`) — this also closes the HOME-fork. Until then this is **built but not armed** (W81).

## Not solved here
This is a release valve for **garbage** at the ceiling, not a capacity fix — a notebook that fills with **legitimate** sources will still hit 500. Structural fix (archive / split / stop-feed) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
