### PR TITLE
chore(scar): raise scar-file size limit 40k→10M (magazzino has no context cost)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,25 +1,26 @@
 echo "🔍 Running pre-commit hooks..."
 
-# ── CICATRIX AUTO-ARCHIVE (2026-06-07) ───────────────────────────────────────
-# Root cause of the recurring "cicatrix-scars.md over 40k-char limit" warning:
-# /scar APPENDS but nothing PRUNES, and the old check_cicatrix_size.sh only
-# BLOCKED (never archived) and was never even wired here. This auto-REPAIRS:
-# when a commit touches cicatrix-scars.md and it's over the 40k limit, archive
-# old RESOLVED/INFO (+ STRUCTURAL >=15d as fallback) into the archive file and
-# re-stage both — so the file never lands over-limit. Self-healing, not a wall.
+# ── CICATRIX AUTO-ARCHIVE (2026-06-07; limit raised 40k→10M 2026-06-16) ───────
+# The recurring "cicatrix-scars.md over 40k-char limit" warning came from /scar
+# APPENDING with nothing to PRUNE. BUT the 40k limit itself was decided in error:
+# cicatrix-scars.md (the scar MAGAZZINO) is NOT loaded into agent context — only
+# the ponte cicatrix-superscar.md is. So the magazzino body has no practical size
+# limit and a scar must never be archived just to fit a threshold. Limit raised to
+# 10M (apparatus left in place but dormant; auto-archive preserved for optional
+# manual cleanup). Decision 2026-06-16. Self-healing, not a wall.
 # Kill switch: CICATRIX_ARCHIVE_ENFORCEMENT=false
 if [ "${CICATRIX_ARCHIVE_ENFORCEMENT:-true}" != "false" ]; then
     CICATRIX_FILE=".claude/rules/cicatrix-scars.md"
     if git diff --cached --name-only --diff-filter=ACMR | grep -Fxq "$CICATRIX_FILE"; then
         # Size of the STAGED blob (what would actually be committed).
         STAGED_SIZE=$(git show ":$CICATRIX_FILE" 2>/dev/null | LC_ALL=C wc -c | tr -d '[:space:]')
-        if [ -n "$STAGED_SIZE" ] && [ "$STAGED_SIZE" -gt "${CICATRIX_SIZE_LIMIT_CHARS:-40000}" ]; then
-            echo "🗄️  [cicatrix] staged scars file is ${STAGED_SIZE} chars (> 40k) — auto-archiving..."
+        if [ -n "$STAGED_SIZE" ] && [ "$STAGED_SIZE" -gt "${CICATRIX_SIZE_LIMIT_CHARS:-10000000}" ]; then
+            echo "🗄️  [cicatrix] staged scars file is ${STAGED_SIZE} chars (> 10M) — auto-archiving..."
             if python3 scripts/archive_cicatrix_scars.py; then
                 git add "$CICATRIX_FILE" .claude/rules/cicatrix-scars-archive.md
-                echo "✅ [cicatrix] archived old scars and re-staged (now under 40k)."
+                echo "✅ [cicatrix] archived old scars and re-staged (now under 10M)."
             else
-                echo "❌ [cicatrix] auto-archive could not bring the file under 40k."
+                echo "❌ [cicatrix] auto-archive could not bring the file under 10M."
                 echo "   Run: python3 scripts/archive_cicatrix_scars.py --dry-run"
                 echo "   Then move scars manually, or lower --structural-age-days."
                 echo "   Override (emergency only): CICATRIX_ARCHIVE_ENFORCEMENT=false git commit ..."

--- a/infra/launchagents/cicatrix_autoarchive.sh
+++ b/infra/launchagents/cicatrix_autoarchive.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
-# cicatrix_autoarchive.sh — daily safety net for the cicatrix-scars.md 40k limit.
+# cicatrix_autoarchive.sh — daily safety net for the cicatrix-scars.md size limit.
 #
-# WHY: /scar APPENDS to .claude/rules/cicatrix-scars.md but nothing PRUNES.
-# The pre-commit hook auto-archives only when someone commits THAT file; this
-# cron catches the case where /scar appends and no commit touches it for days,
-# so the harness keeps warning "... over the 40.0k-char limit" every session.
+# LIMIT RAISED 40k→10M (decision 2026-06-16): cicatrix-scars.md (the scar
+# MAGAZZINO) is NOT loaded into agent context — only the ponte
+# cicatrix-superscar.md is. So the magazzino has no practical size limit and a
+# scar must never be archived just to fit a threshold. This cron is left in place
+# but DORMANT (limit 10M); auto-archive logic preserved for optional cleanup.
+#
+# WHY (original): /scar APPENDS to .claude/rules/cicatrix-scars.md but nothing
+# PRUNES. The pre-commit hook auto-archives only when someone commits THAT file;
+# this cron catches the case where /scar appends and no commit touches it — now a
+# no-op until the magazzino exceeds 10M.
 #
 # SAFETY (sibling-race aware, per cicatrix W59/W62/untracked-lost family):
 #   - Operates on the authoritative checkout ($REPO_ROOT, default ~/Desktop/nuzantara).
@@ -26,7 +32,7 @@ fi
 REPO_ROOT="${REPO_ROOT:-$HOME/Desktop/nuzantara}"
 ACTIVE=".claude/rules/cicatrix-scars.md"
 ARCHIVE=".claude/rules/cicatrix-scars-archive.md"
-LIMIT="${CICATRIX_SIZE_LIMIT_CHARS:-40000}"
+LIMIT="${CICATRIX_SIZE_LIMIT_CHARS:-10000000}"
 
 cd "$REPO_ROOT" || { echo "[cicatrix-cron] FATAL: cannot cd $REPO_ROOT"; exit 1; }
 

--- a/scripts/archive_cicatrix_scars.py
+++ b/scripts/archive_cicatrix_scars.py
@@ -1,15 +1,23 @@
 #!/usr/bin/env python3
-"""Auto-archive resolved/info/old cicatrix scars to keep the active file under
-the 40k-char agent auto-load threshold.
+"""Auto-archive resolved/info/old cicatrix scars (DORMANT optional cleanup).
+
+LIMIT RAISED 40k→10M (decision 2026-06-16)
+------------------------------------------
+The original 40k-char limit was decided in error. `cicatrix-scars.md` (the scar
+MAGAZZINO) is NOT loaded into agent context — only the ponte cicatrix-superscar.md
+(~16k, the 10 superscar families + one-line members) is. So the magazzino body has
+no practical size limit and a scar must NEVER be archived/sacrificed just to fit a
+threshold. The limit is now 10M; this archiver is left in place but dormant, kept
+for OPTIONAL manual cleanup only.
 
 WHY THIS EXISTS
 ---------------
 `cicatrix-scars.md` grows monotonically: the `/scar` skill APPENDS new entries,
 but nothing ever PRUNES. Past size-control was done by hand ("Archived YYYY-MM-DD
 sweep" notes in the file) and a checker (`check_cicatrix_size.sh`) that only
-BLOCKS at commit time and was never even wired into the pre-commit hook. Result:
-the file repeatedly blows past 40k and the Claude Code harness warns
-"... is over the 40.0k-char limit · /memory to free up context".
+BLOCKS at commit time and was never even wired into the pre-commit hook. The limit
+has since been raised to 10M (magazzino is non-context, no practical size limit),
+so this loop now only runs as an optional manual cleanup, never as a wall.
 
 This script closes the loop: append (by /scar) + auto-archive (by this) =
 bounded size.
@@ -54,10 +62,11 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 ACTIVE = REPO_ROOT / ".claude" / "rules" / "cicatrix-scars.md"
 ARCHIVE = REPO_ROOT / ".claude" / "rules" / "cicatrix-scars-archive.md"
 
-# Hard ceiling the harness enforces. We archive down to TARGET (< LIMIT) so a
-# fresh /scar append doesn't immediately re-cross the line.
-LIMIT_CHARS = 40_000
-DEFAULT_TARGET_CHARS = 32_000
+# Limit raised 40k→10M (decision 2026-06-16): the magazzino is NOT loaded into
+# agent context (only the ponte cicatrix-superscar.md is), so there is no practical
+# size limit. We archive down to TARGET (< LIMIT) only when run manually.
+LIMIT_CHARS = 10_000_000
+DEFAULT_TARGET_CHARS = 9_000_000
 DEFAULT_RESOLVED_AGE_DAYS = 14
 # Antonello 2026-06-07: file mass is OPEN ⚠️ STRUCTURAL ~30-39d old; a 60d
 # fallback could never bring it under 40k. 15d makes old-but-open structural


### PR DESCRIPTION
The 40k limit on cicatrix-scars.md was decided in error. The scar MAGAZZINO is NOT loaded in context — only the ponte cicatrix-superscar.md (the 10 superscar families + one-line members) is. So the magazzino has no practical size limit; a scar must never be archived just to fit a threshold.

Raised 40000→10_000_000 in all 3 enforcement points: husky pre-commit, scripts/archive_cicatrix_scars.py (LIMIT_CHARS), infra/launchagents/cicatrix_autoarchive.sh. Apparatus left in place but dormant (auto-archive logic preserved for optional manual cleanup). Per operator decision 2026-06-16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)