### PR TITLE
fix(mouth): proxy login cookie follows backend token lifetime (not hardcoded 24h)

### DIFF
--- a/apps/mouth/src/app/api/[...path]/route.ts
+++ b/apps/mouth/src/app/api/[...path]/route.ts
@@ -311,7 +311,10 @@ async function proxy(req: NextRequest): Promise<Response> {
                 /\s+/g,
                 "",
               );
-          const maxAge = 86400; // 24h
+          // Follow the backend token lifetime (expiresIn = JWT_ACCESS_TOKEN_EXPIRE_HOURS*3600)
+          // so the cookie never outlives or under-lives the JWT. Mirrors
+          // app/api/auth/login/route.ts. Fallback 86400 only if expiresIn is absent.
+          const maxAge = bodyJson?.data?.expiresIn || 86400;
           // CRITICAL: Strip upstream Set-Cookie headers — they carry SameSite=none
           // which Chrome 130+ rejects without Partitioned. We re-set cookies manually
           // using raw header strings to bypass Vercel Edge Runtime restrictions.


### PR DESCRIPTION
## Cleanup follow-up to the 12h session change

After extending the kita.balizero.com session to 12h via the Fly secret `JWT_ACCESS_TOKEN_EXPIRE_HOURS=12`, the blast-radius test flagged one residual inconsistency: the catch-all API proxy (`app/api/[...path]/route.ts`) re-set the `nz_access_token` / `nz_csrf_token` cookies with a **hardcoded `Max-Age=86400` (24h)**, out of step with the JWT `exp`.

The dedicated login route (`app/api/auth/login/route.ts:42`) already does the right thing (`expiresIn || 86400`). This aligns the proxy path: it now derives `Max-Age` from the login response's `expiresIn` (= `JWT_ACCESS_TOKEN_EXPIRE_HOURS * 3600`), with `86400` only as a fallback. Both cookies share the same `maxAge` var.

The login form bypasses this proxy path, so it was latent — but any future login routed through `[...path]` would have wrapped a 12h JWT in a 24h cookie. Now consistent.

### Reviewed and deliberately NOT changed
`visa_oracle.py:601` (`verify_exp=True`) — the earlier audit flagged it as "out of step", but it is a **separate short-lived visa-funnel token** (`type="visa_funnel"`, `sub=check_hash`) that **should** expire and be rejected when stale (it has its own "Wizard context expired" path). Enforcing exp there is correct, not an inconsistency. Left as-is.

## Verification
- `tsc --noEmit` (mouth) ✅
- Single-line behavioral change; `expiresIn` field path confirmed (`auth.py:421` → `data.data.expiresIn`, same as login route reads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)