### PR TITLE
fix(whatsapp): send-gate recognizes team members as valid recipients, not just CRM clients

### DIFF
--- a/apps/backend-rag/backend/app/routers/whatsapp_conversations.py
+++ b/apps/backend-rag/backend/app/routers/whatsapp_conversations.py
@@ -3,9 +3,9 @@ WhatsApp Conversations API - Final Stabilized Version
 
 Outbound /send endpoint re-enabled 2026-03-15 with safety gates:
 - Rate limit: max 20 outbound messages per phone per hour
-- CRM validation: recipient must exist in clients table
-  (team/staff numbers in WHATSAPP_TEAM_ALLOWLIST bypass the CRM check
-  without polluting the CRM)
+- Recipient validation: must be a known CRM client OR a Bali Zero team member
+  (team_members.whatsapp). Team/staff numbers in WHATSAPP_TEAM_ALLOWLIST also
+  bypass the check via env config, without polluting the CRM.
 - Auth required: only authenticated users can send
 """
 
@@ -241,8 +241,9 @@ async def send_whatsapp_message(
     Safety gates:
     - Auth required (JWT)
     - Rate limit: 20 msgs/phone/hour
-    - CRM validation: recipient must exist in clients table, UNLESS the number
-      is in WHATSAPP_TEAM_ALLOWLIST (staff numbers stay out of the CRM)
+    - Recipient validation: must be a known CRM client (clients.phone) OR a
+      Bali Zero team member (team_members.whatsapp). Numbers in
+      WHATSAPP_TEAM_ALLOWLIST also bypass via env config (staff stay out of CRM)
     """
     phone = body.phone.lstrip("+")
 
@@ -259,17 +260,34 @@ async def send_whatsapp_message(
             "whatsapp send to team-allowlisted number (****%s)",
             _normalize_phone(phone)[-4:],
         )
-    # Gate 2b: CRM validation — any other recipient must be a known client
+    # Gate 2b: recipient validation — accept a known CRM client OR a Bali Zero
+    # team member. Team-member numbers live in team_members.whatsapp (the HR
+    # source of truth) and are NOT mirrored into the clients table, so a
+    # clients-only check rejected staff as "unknown contacts" (e.g. Surya,
+    # whose number sits in team_members.whatsapp but not in clients). This DB
+    # check is the durable backstop to the env-var allowlist above: it works
+    # even when WHATSAPP_TEAM_ALLOWLIST is empty or stale.
     elif db:
         async with db.acquire() as conn:
-            client_exists = await conn.fetchval(
-                "SELECT EXISTS(SELECT 1 FROM clients WHERE phone LIKE $1 AND deleted_at IS NULL)",
+            recipient_known = await conn.fetchval(
+                """
+                SELECT EXISTS(
+                    SELECT 1 FROM clients
+                    WHERE phone LIKE $1 AND deleted_at IS NULL
+                    UNION ALL
+                    SELECT 1 FROM team_members
+                    WHERE whatsapp LIKE $1 AND COALESCE(active, true) = true
+                )
+                """,
                 f"%{phone[-10:]}%",
             )
-            if not client_exists:
+            if not recipient_known:
                 raise HTTPException(
                     status_code=403,
-                    detail=f"Phone {body.phone} not found in CRM. Cannot send to unknown contacts.",
+                    detail=(
+                        f"Phone {body.phone} not found in CRM or team directory. "
+                        "Cannot send to unknown contacts."
+                    ),
                 )
 
     # Send via Meta WhatsApp Cloud API

--- a/apps/backend-rag/backend/tests/unit/routers/test_whatsapp_conversations_send.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_whatsapp_conversations_send.py
@@ -6,7 +6,10 @@ Coverage:
   check without a clients-table record.
 - Unknown numbers still get 403 (anti-spam guard unchanged).
 - Phone normalization: '+62 878-6187-0777' == '6287861870777' == '+6287861870777'.
-- Empty allowlist == today's behavior (CRM validation for everyone).
+- Empty allowlist == CRM/team-directory validation for everyone.
+- Team members (team_members.whatsapp) pass the DB gate even with an empty
+  allowlist and no clients-table record (CURE), while a number in neither
+  clients nor team_members is still rejected (INNOCENCE).
 """
 
 from unittest.mock import AsyncMock, patch
@@ -191,3 +194,77 @@ def test_empty_allowlist_team_number_still_403(client, mock_db_conn, monkeypatch
     assert response.status_code == 403
     assert "not found in CRM" in response.json()["detail"]
     mock_send.assert_not_awaited()
+
+
+# ============================================================
+# (e) DB recipient gate: team members pass, unknown numbers don't
+# ============================================================
+#
+# The /send DB gate accepts a recipient that is EITHER a non-deleted client
+# (clients.phone) OR an active team member (team_members.whatsapp), in a single
+# UNION-ALL EXISTS query. These tests pin both halves of that contract:
+#   - CURE: a team-member number absent from clients still sends (no 403).
+#   - INNOCENCE: a number in neither table is still rejected (403).
+# The DB is mocked, so the boolean returned by fetchval stands in for "the
+# UNION query found a matching row". We additionally assert the SQL actually
+# consults team_members, so the gate cannot silently regress to clients-only.
+
+
+def _send_query_sql(mock_db_conn) -> str:
+    """Return the SQL string passed to the single fetchval recipient-gate call."""
+    mock_db_conn.fetchval.assert_awaited_once()
+    args, _ = mock_db_conn.fetchval.await_args
+    return args[0]
+
+
+def test_team_member_in_db_bypasses_clients_only_gate(client, mock_db_conn, monkeypatch):
+    """CURE: a team-member number (in team_members.whatsapp, not in clients) sends.
+
+    Allowlist is empty, so the env short-circuit cannot help — the send must
+    succeed purely on the DB gate matching team_members. This is Surya's case:
+    +6282298000137 lives in team_members.whatsapp but not in clients.
+    """
+    _set_allowlist(monkeypatch, "")
+    # fetchval True == the UNION query found a row (here: the team_members half).
+    mock_db_conn.fetchval = AsyncMock(return_value=True)
+    surya_phone = "+6282298000137"
+
+    with patch.object(
+        whatsapp_conversations.whatsapp_service,
+        "send_message",
+        new=AsyncMock(return_value={"messages": [{"id": "wamid.test"}]}),
+    ) as mock_send:
+        response = client.post(
+            "/api/whatsapp/send", json={"phone": surya_phone, "message": "ciao Surya"}
+        )
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    mock_send.assert_awaited_once()
+    # Prove the gate actually consults team_members (not a blanket allow and not
+    # a clients-only check): the SQL must reference both source tables.
+    sql = _send_query_sql(mock_db_conn)
+    assert "team_members" in sql
+    assert "whatsapp" in sql
+    assert "clients" in sql
+
+
+def test_unknown_number_not_in_clients_or_team_still_403(client, mock_db_conn, monkeypatch):
+    """INNOCENCE: a number in NEITHER clients NOR team_members is still rejected.
+
+    The team-member fix must not turn the gate into a blanket allow.
+    """
+    _set_allowlist(monkeypatch, "")
+    mock_db_conn.fetchval = AsyncMock(return_value=False)  # in no table
+
+    with patch.object(
+        whatsapp_conversations.whatsapp_service, "send_message", new=AsyncMock()
+    ) as mock_send:
+        response = client.post(
+            "/api/whatsapp/send", json={"phone": UNKNOWN_PHONE, "message": "spam?"}
+        )
+
+    assert response.status_code == 403
+    assert "not found in CRM" in response.json()["detail"]
+    mock_send.assert_not_awaited()
+    mock_db_conn.fetchval.assert_awaited_once()


### PR DESCRIPTION
## Problem
`POST /api/whatsapp/send` rejected Bali Zero **team members** as unknown contacts. The recipient gate only checked the `clients` table:

```sql
SELECT EXISTS(SELECT 1 FROM clients WHERE phone LIKE $1 AND deleted_at IS NULL)
```

A team member number lives in `team_members.whatsapp` (the HR source of truth) and is intentionally **not** mirrored into `clients`, so the send 403d with `Phone … not found in CRM. Cannot send to unknown contacts.`

Confirmed live: **Surya** (`+6282298000137`, surya@balizero.com) is in `team_members.whatsapp` but not in `clients` → staff sends 403d. The env-var `WHATSAPP_TEAM_ALLOWLIST` bypass only partially masked this; it needs manual upkeep and silently fails staff when empty/stale.

## Fix
The DB recipient check now accepts a number matching **EITHER** a non-deleted client **OR** an active team member, in a single `UNION ALL` `EXISTS` query (one `fetchval` call, LIKE pattern unchanged):

```sql
SELECT EXISTS(
    SELECT 1 FROM clients
    WHERE phone LIKE $1 AND deleted_at IS NULL
    UNION ALL
    SELECT 1 FROM team_members
    WHERE whatsapp LIKE $1 AND COALESCE(active, true) = true
)
```

- `$1` is the existing `%<last-10-digits>%` LIKE pattern — preserved verbatim.
- 403 message updated to `… not found in CRM or team directory. …` (still contains the `not found in CRM` substring existing tests assert on).
- This DB check is the durable backstop to the env allowlist: it works even when `WHATSAPP_TEAM_ALLOWLIST` is empty.

## Schema matched (verified on disk)
- `team_members.whatsapp` — the staff number column (per live prod; Surya value `+6282298000137`).
- `team_members.active` — boolean, confirmed present in dev + test schemas → used via `COALESCE(active, true) = true` (no soft-delete `deleted_at` column on team_members).
- `clients.phone` + `clients.deleted_at` — unchanged.

## Tests (DB mocked → single `fetchval`)
- **CURE**: `test_team_member_in_db_bypasses_clients_only_gate` — team-member number (not in clients) sends; asserts emitted SQL references `team_members`/`whatsapp`/`clients`. Proven to **fail** against the old clients-only query via a mutation check.
- **INNOCENCE**: `test_unknown_number_not_in_clients_or_team_still_403` — a number in neither table is still 403 (not a blanket allow).
- **Regression**: known client still sends; env-allowlist bypass still works.

`pytest backend/tests/unit/routers/test_whatsapp_conversations_send.py` → **20 passed**. Ruff lint + format clean. Anti-reward-hacking lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)