### PR TITLE
feat(wa-dashboard): Team Quality metrics tab + daily rollup

### DIFF
--- a/apps/wa-dashboard-m1/README.md
+++ b/apps/wa-dashboard-m1/README.md
@@ -32,6 +32,31 @@ Variabili env opzionali:
 | `GET /health.json` | `{ok, db_now, team_size, db_url_host}` |
 | `GET /data.json` | overview teams + convs (5s cache) |
 | `GET /thread.json?member=<phone>&conv=<key>` | 500 messaggi conv |
+| `GET /metrics.json?window=<days>` | aggregati qualità per operatore (live, cache 60s) |
+| `GET /metrics-history.json?days=<n>` | trend storico da `wa_team_daily_metrics` |
+| `POST /metrics-rollup?window=<days>` | snapshot giornaliero → UPSERT (idempotente per giorno) |
+
+## Team Quality (tab "Qualità Team")
+
+Seconda vista della dashboard (toggle in header). Metriche aggregate per operatore
+calcolate da `whatsapp_message_context`, attribuite per `team_member_phone` + alias
+(parità con le colonne conversazioni — NON per email), in `metrics.cjs`:
+
+- volume (msg / in / out), clienti distinti, copertura (active days), lunghezza media outbound
+- response latency p50/p90, % risposte < 5 min
+- % outbound after-hours (fuori 8–18 WITA)
+- backlog: thread con ultimo msg inbound fermo > 24h (palla al team)
+- volume group-chat
+
+Storicizzazione: `POST /metrics-rollup` scrive uno snapshot/giorno in
+`wa_team_daily_metrics` (creata idempotente al boot via `ensureMetricsSchema`). Ogni
+riga porta `metrics_schema_version` — bumpala quando cambi una formula, così il trend
+confronta solo righe pari-versione (anti state-schema-drift, superscar #9). Tutto
+aggregato, Pro-bound, zero PII. La parte qualitativa-LLM resta on-demand, fuori da qui.
+
+Scheduler giornaliero: `scripts/launchd/com.balizero.wa-team-metrics-rollup.plist`
+(StartCalendarInterval 06:30 WITA, **no** KeepAlive — è un cron, non un daemon;
+anti superscar #7). Heartbeat reale = la riga scritta nel DB (`computed_at`).
 
 ## Cosa NON fa (al momento)
 
@@ -61,3 +86,9 @@ Variabili env opzionali:
 - 2026-05-25: shipped da `feat/wa-dashboard-m1-readonly-2026-05-25` (worktree isolato).
 - DB Fly contiene 67 messaggi reali 23-24/05 (verificato), bridge wa-mirror locali scrivono lì.
 - DB locale `nuzantara_dev` contiene solo dati di import storico + test M1 sintetici.
+- **2026-06-16 (doc-drift corretto)**: il deployment Pro ATTUALE punta a `nuzantara_dev`
+  LOCALE — verificato via `/health.json` (`db_url_host=127.0.0.1:5432`) + plist
+  `WA_DASHBOARD_DATABASE_URL`, NON a Fly. Il mirror vivo del team ora scrive nel locale
+  (`source='wa_mirror'` ~20k msg, aggiornato in giornata); su Fly resta un residuo di
+  1872 msg fermo al 24/05. L'intro "Fly via pg-proxy 15432" e la riga `WA_DASHBOARD_DATABASE_URL`
+  qui sopra sono storiche — il default operativo reale è il pg locale.

--- a/apps/wa-dashboard-m1/metrics.cjs
+++ b/apps/wa-dashboard-m1/metrics.cjs
@@ -1,0 +1,313 @@
+"use strict";
+
+// wa-dashboard-m1 — Team Quality Metrics module
+// ------------------------------------------------------------------
+// Pro-bound: reads/writes ONLY the local nuzantara_dev Postgres (same pool
+// as server.cjs). No PII leaves the box — output is aggregate counts/latencies.
+//
+// Attribution key = team_member_phone + aliasesForTeamMember() (parity with
+// fetchOverview in server.cjs), NOT team_member_email. Using email would
+// produce numbers that do not reconcile with the conversations columns.
+//
+// Schema versioning (metrics_schema_version) guards trend comparability:
+// when a metric formula changes (e.g. backlog 55%→25% rewrite), bump the
+// version so history queries compare only same-version rows. (cicatrix #9
+// state-schema drift.)
+// ------------------------------------------------------------------
+
+const METRICS_SCHEMA_VERSION = 1;
+const DEFAULT_WINDOW_DAYS = 30;
+const LIVE_CACHE_MS = 60_000; // metrics move slowly; protect the DB
+
+// in-module cache keyed by windowDays
+const LIVE_CACHE = new Map();
+
+function intOr(v, fallback) {
+  const n = parseInt(v, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+async function ensureMetricsSchema(pool) {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS wa_team_daily_metrics (
+      id                     BIGSERIAL PRIMARY KEY,
+      snapshot_date          DATE        NOT NULL,
+      metrics_schema_version INTEGER     NOT NULL,
+      team_member_phone      TEXT        NOT NULL,
+      team_member_name       TEXT,
+      window_days            INTEGER     NOT NULL DEFAULT 30,
+      msgs_total             INTEGER     NOT NULL DEFAULT 0,
+      msgs_in                INTEGER     NOT NULL DEFAULT 0,
+      msgs_out               INTEGER     NOT NULL DEFAULT 0,
+      clients                INTEGER     NOT NULL DEFAULT 0,
+      active_days            INTEGER     NOT NULL DEFAULT 0,
+      avg_out_chars          INTEGER,
+      pct_afterhours         NUMERIC(5,1),
+      resp_median_min        NUMERIC(8,1),
+      resp_p90_min           NUMERIC(8,1),
+      pct_under5min          NUMERIC(5,1),
+      n_replies              INTEGER     NOT NULL DEFAULT 0,
+      backlog_threads        INTEGER     NOT NULL DEFAULT 0,
+      backlog_ball_team      INTEGER     NOT NULL DEFAULT 0,
+      backlog_stale24h       INTEGER     NOT NULL DEFAULT 0,
+      grp_msgs               INTEGER     NOT NULL DEFAULT 0,
+      computed_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (snapshot_date, metrics_schema_version, team_member_phone)
+    );
+    CREATE INDEX IF NOT EXISTS idx_wa_team_daily_metrics_lookup
+      ON wa_team_daily_metrics (team_member_phone, snapshot_date DESC);
+  `);
+}
+
+// --- Per-member aggregation (3 parallel queries; member fixed → partition by counterpart) ---
+async function aggregateForMember(pool, aliases, windowDays) {
+  const since = `${intOr(windowDays, DEFAULT_WINDOW_DAYS)} days`;
+
+  const [volRow, respRow, backlogRow, grpRow] = await Promise.all([
+    // (A) volume / coverage / length / after-hours — DIRECT chats
+    pool.query(
+      `
+      WITH base AS (
+        SELECT direction, message_date,
+               COALESCE(NULLIF(body,''), NULLIF(message_text,'')) AS txt,
+               counterpart_phone AS cp
+        FROM whatsapp_message_context
+        WHERE team_member_phone = ANY($1::text[])
+          AND chat_type = 'direct'
+          AND message_date >= NOW() - INTERVAL '${since}'
+      )
+      SELECT
+        count(*)                                              AS msgs_total,
+        count(*) FILTER (WHERE direction='inbound')           AS msgs_in,
+        count(*) FILTER (WHERE direction='outbound')          AS msgs_out,
+        count(DISTINCT cp) FILTER (WHERE cp IS NOT NULL)      AS clients,
+        count(DISTINCT (message_date AT TIME ZONE 'Asia/Makassar')::date) AS active_days,
+        round(avg(length(txt)) FILTER (WHERE direction='outbound'))::int  AS avg_out_chars,
+        round(100.0 * count(*) FILTER (WHERE direction='outbound'
+              AND (EXTRACT(HOUR FROM message_date AT TIME ZONE 'Asia/Makassar') < 8
+                OR EXTRACT(HOUR FROM message_date AT TIME ZONE 'Asia/Makassar') >= 18))
+              / NULLIF(count(*) FILTER (WHERE direction='outbound'),0), 1) AS pct_afterhours
+      FROM base
+      `,
+      [aliases],
+    ),
+    // (B) response latency — outbound after client inbound, same thread, 0..12h
+    pool.query(
+      `
+      WITH base AS (
+        SELECT counterpart_phone AS cp, direction, message_date
+        FROM whatsapp_message_context
+        WHERE team_member_phone = ANY($1::text[])
+          AND chat_type = 'direct'
+          AND message_date >= NOW() - INTERVAL '${since}'
+      ),
+      seq AS (
+        SELECT cp, direction, message_date,
+               LAG(direction)    OVER w AS prev_dir,
+               LAG(message_date) OVER w AS prev_ts
+        FROM base WINDOW w AS (PARTITION BY cp ORDER BY message_date)
+      ),
+      resp AS (
+        SELECT EXTRACT(EPOCH FROM (message_date - prev_ts)) AS lat_s
+        FROM seq
+        WHERE direction='outbound' AND prev_dir='inbound'
+          AND (message_date - prev_ts) BETWEEN INTERVAL '0 second' AND INTERVAL '12 hours'
+      )
+      SELECT
+        count(*)                                                        AS n_replies,
+        round((percentile_cont(0.5) WITHIN GROUP (ORDER BY lat_s)/60)::numeric, 1) AS resp_median_min,
+        round((percentile_cont(0.9) WITHIN GROUP (ORDER BY lat_s)/60)::numeric, 1) AS resp_p90_min,
+        round(100.0 * count(*) FILTER (WHERE lat_s <= 300)
+              / NULLIF(count(*),0), 1)                                  AS pct_under5min
+      FROM resp
+      `,
+      [aliases],
+    ),
+    // (C) backlog — last message in a direct thread is INBOUND (ball with team); stale >24h
+    pool.query(
+      `
+      WITH base AS (
+        SELECT counterpart_phone AS cp, direction, message_date
+        FROM whatsapp_message_context
+        WHERE team_member_phone = ANY($1::text[])
+          AND chat_type = 'direct'
+          AND counterpart_phone IS NOT NULL AND counterpart_phone <> ''
+          AND message_date >= NOW() - INTERVAL '${since}'
+      ),
+      last_per_thread AS (
+        SELECT DISTINCT ON (cp) cp, direction, message_date
+        FROM base
+        ORDER BY cp, message_date DESC
+      )
+      SELECT
+        count(*)                                                       AS backlog_threads,
+        count(*) FILTER (WHERE direction='inbound')                    AS backlog_ball_team,
+        count(*) FILTER (WHERE direction='inbound'
+              AND message_date < NOW() - INTERVAL '24 hours')          AS backlog_stale24h
+      FROM last_per_thread
+      `,
+      [aliases],
+    ),
+    // (D) group-chat volume
+    pool.query(
+      `
+      SELECT count(*) AS grp_msgs
+      FROM whatsapp_message_context
+      WHERE team_member_phone = ANY($1::text[])
+        AND chat_type = 'group'
+        AND message_date >= NOW() - INTERVAL '${since}'
+      `,
+      [aliases],
+    ),
+  ]);
+
+  const v = volRow.rows[0] || {};
+  const r = respRow.rows[0] || {};
+  const b = backlogRow.rows[0] || {};
+  const g = grpRow.rows[0] || {};
+
+  const numOrNull = (x) => (x === null || x === undefined ? null : Number(x));
+  const intVal = (x) => parseInt(x || 0, 10);
+
+  return {
+    msgs_total: intVal(v.msgs_total),
+    msgs_in: intVal(v.msgs_in),
+    msgs_out: intVal(v.msgs_out),
+    clients: intVal(v.clients),
+    active_days: intVal(v.active_days),
+    avg_out_chars: v.avg_out_chars === null ? null : intVal(v.avg_out_chars),
+    pct_afterhours: numOrNull(v.pct_afterhours),
+    n_replies: intVal(r.n_replies),
+    resp_median_min: numOrNull(r.resp_median_min),
+    resp_p90_min: numOrNull(r.resp_p90_min),
+    pct_under5min: numOrNull(r.pct_under5min),
+    backlog_threads: intVal(b.backlog_threads),
+    backlog_ball_team: intVal(b.backlog_ball_team),
+    backlog_stale24h: intVal(b.backlog_stale24h),
+    grp_msgs: intVal(g.grp_msgs),
+  };
+}
+
+// --- Live metrics for the whole team (cached) ---
+// team: array of {name, e164, ...}; aliasesFor: (member)=>string[]; hideNames: Set<string>
+async function fetchLiveMetrics(pool, team, aliasesFor, hideNames, windowDays) {
+  const wd = intOr(windowDays, DEFAULT_WINDOW_DAYS);
+  const cacheKey = `w${wd}`;
+  const cached = LIVE_CACHE.get(cacheKey);
+  if (cached && Date.now() - cached.at < LIVE_CACHE_MS) return cached.payload;
+
+  const members = team.filter((m) => m && m.e164 && !(hideNames && hideNames.has(m.name)));
+  const rows = await Promise.all(
+    members.map(async (m) => {
+      const agg = await aggregateForMember(pool, aliasesFor(m), wd);
+      return {
+        team_member_phone: m.e164,
+        team_member_name: m.full_name || m.name,
+        ...agg,
+      };
+    }),
+  );
+  // rank by total volume desc (stable, informative for triage)
+  rows.sort((a, b) => b.msgs_total - a.msgs_total);
+
+  const payload = {
+    generated_at: new Date().toISOString(),
+    metrics_schema_version: METRICS_SCHEMA_VERSION,
+    window_days: wd,
+    operators: rows,
+  };
+  LIVE_CACHE.set(cacheKey, { at: Date.now(), payload });
+  return payload;
+}
+
+// --- Compute today's snapshot and UPSERT into the rollup table (heartbeat) ---
+async function computeAndStoreRollup(pool, team, aliasesFor, hideNames, windowDays) {
+  const wd = intOr(windowDays, DEFAULT_WINDOW_DAYS);
+  // bypass cache for the authoritative nightly snapshot
+  LIVE_CACHE.delete(`w${wd}`);
+  const live = await fetchLiveMetrics(pool, team, aliasesFor, hideNames, wd);
+
+  let written = 0;
+  for (const op of live.operators) {
+    await pool.query(
+      `
+      INSERT INTO wa_team_daily_metrics
+        (snapshot_date, metrics_schema_version, team_member_phone, team_member_name,
+         window_days, msgs_total, msgs_in, msgs_out, clients, active_days, avg_out_chars,
+         pct_afterhours, resp_median_min, resp_p90_min, pct_under5min, n_replies,
+         backlog_threads, backlog_ball_team, backlog_stale24h, grp_msgs, computed_at)
+      VALUES
+        ((NOW() AT TIME ZONE 'Asia/Makassar')::date, $1, $2, $3,
+         $4, $5, $6, $7, $8, $9, $10,
+         $11, $12, $13, $14, $15,
+         $16, $17, $18, $19, NOW())
+      ON CONFLICT (snapshot_date, metrics_schema_version, team_member_phone)
+      DO UPDATE SET
+        team_member_name = EXCLUDED.team_member_name,
+        window_days      = EXCLUDED.window_days,
+        msgs_total       = EXCLUDED.msgs_total,
+        msgs_in          = EXCLUDED.msgs_in,
+        msgs_out         = EXCLUDED.msgs_out,
+        clients          = EXCLUDED.clients,
+        active_days      = EXCLUDED.active_days,
+        avg_out_chars    = EXCLUDED.avg_out_chars,
+        pct_afterhours   = EXCLUDED.pct_afterhours,
+        resp_median_min  = EXCLUDED.resp_median_min,
+        resp_p90_min     = EXCLUDED.resp_p90_min,
+        pct_under5min    = EXCLUDED.pct_under5min,
+        n_replies        = EXCLUDED.n_replies,
+        backlog_threads  = EXCLUDED.backlog_threads,
+        backlog_ball_team= EXCLUDED.backlog_ball_team,
+        backlog_stale24h = EXCLUDED.backlog_stale24h,
+        grp_msgs         = EXCLUDED.grp_msgs,
+        computed_at      = NOW()
+      `,
+      [
+        METRICS_SCHEMA_VERSION, op.team_member_phone, op.team_member_name,
+        wd, op.msgs_total, op.msgs_in, op.msgs_out, op.clients, op.active_days, op.avg_out_chars,
+        op.pct_afterhours, op.resp_median_min, op.resp_p90_min, op.pct_under5min, op.n_replies,
+        op.backlog_threads, op.backlog_ball_team, op.backlog_stale24h, op.grp_msgs,
+      ],
+    );
+    written += 1;
+  }
+
+  return {
+    ok: true,
+    snapshot_date: live.generated_at.slice(0, 10),
+    metrics_schema_version: METRICS_SCHEMA_VERSION,
+    window_days: wd,
+    rows_written: written,
+    computed_at: new Date().toISOString(),
+  };
+}
+
+// --- Historical trend (for sparklines / delta vs prior period) ---
+async function fetchHistory(pool, { days = 90, schemaVersion = METRICS_SCHEMA_VERSION } = {}) {
+  const r = await pool.query(
+    `
+    SELECT snapshot_date, team_member_phone, team_member_name,
+           msgs_total, msgs_in, msgs_out, clients, active_days, avg_out_chars,
+           pct_afterhours, resp_median_min, resp_p90_min, pct_under5min, n_replies,
+           backlog_threads, backlog_ball_team, backlog_stale24h, grp_msgs, computed_at
+    FROM wa_team_daily_metrics
+    WHERE metrics_schema_version = $1
+      AND snapshot_date >= ((NOW() AT TIME ZONE 'Asia/Makassar')::date - ($2::int))
+    ORDER BY snapshot_date ASC, team_member_phone ASC
+    `,
+    [schemaVersion, intOr(days, 90)],
+  );
+  return {
+    metrics_schema_version: schemaVersion,
+    days: intOr(days, 90),
+    rows: r.rows,
+  };
+}
+
+module.exports = {
+  METRICS_SCHEMA_VERSION,
+  ensureMetricsSchema,
+  fetchLiveMetrics,
+  computeAndStoreRollup,
+  fetchHistory,
+};

--- a/apps/wa-dashboard-m1/server.cjs
+++ b/apps/wa-dashboard-m1/server.cjs
@@ -5,6 +5,7 @@ const express = require("express");
 const { Pool } = require("pg");
 const fs = require("fs");
 const path = require("path");
+const metrics = require("./metrics.cjs");
 
 const PORT = parseInt(process.env.PORT || "7790", 10);
 const HOST = process.env.HOST || "0.0.0.0"; // bind also Tailnet (parity with wa-viewer:7777)
@@ -23,6 +24,14 @@ const ACCOUNTS_JSON =
 
 const MEDIA_ROOT = process.env.WA_MIRROR_MEDIA_ROOT || "/Users/nuzantara/wa-mirror-media";
 const TEAM_AVATAR_DIR = process.env.WA_TEAM_AVATAR_DIR || "/Users/nuzantara/Desktop/nuzantara/apps/mouth/public/static/team";
+
+// Team members hidden from views (parity with conversations columns; Law-2 perimeter).
+const HIDE_TEAM_NAMES = new Set(
+  (process.env.HIDE_TEAM_NAMES || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean),
+);
 
 const TEAM = (() => {
   try {
@@ -879,6 +888,45 @@ app.get("/lid-stats", async (_req, res) => {
   }
 });
 
+// === Team Quality Metrics (quality tab) ===
+// Live aggregate metrics per operator. Attribution by team_member_phone + aliases
+// (parity with fetchOverview). Aggregate-only output — no PII leaves the box.
+app.get("/metrics.json", async (req, res) => {
+  try {
+    const windowDays = parseInt(req.query.window, 10) || 30;
+    const payload = await metrics.fetchLiveMetrics(pool, TEAM, aliasesForTeamMember, HIDE_TEAM_NAMES, windowDays);
+    res.json(payload);
+  } catch (err) {
+    console.error("[metrics.json]", err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Historical rollup trend (sparklines / delta vs prior period).
+app.get("/metrics-history.json", async (req, res) => {
+  try {
+    const days = parseInt(req.query.days, 10) || 90;
+    const payload = await metrics.fetchHistory(pool, { days });
+    res.json(payload);
+  } catch (err) {
+    console.error("[metrics-history.json]", err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Compute + persist today's snapshot (scheduled daily; idempotent UPSERT per day).
+// Heartbeat: returns rows_written + computed_at so the scheduler proves real liveness.
+app.post("/metrics-rollup", async (req, res) => {
+  try {
+    const windowDays = parseInt(req.query.window, 10) || 30;
+    const result = await metrics.computeAndStoreRollup(pool, TEAM, aliasesForTeamMember, HIDE_TEAM_NAMES, windowDays);
+    res.json(result);
+  } catch (err) {
+    console.error("[metrics-rollup]", err);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
 app.get("/", (_req, res) => {
   res.sendFile(path.join(__dirname, "viewer.html"));
 });
@@ -887,4 +935,8 @@ app.listen(PORT, HOST, () => {
   console.log(`[wa-dashboard-m1] listening on http://${HOST}:${PORT}`);
   console.log(`[wa-dashboard-m1] DB: ${DATABASE_URL.replace(/:[^@]+@/, ":***@")}`);
   console.log(`[wa-dashboard-m1] Team size: ${TEAM.length} | Media root: ${MEDIA_ROOT}`);
+  // Ensure the team-quality rollup table exists (idempotent, local DB).
+  metrics.ensureMetricsSchema(pool)
+    .then(() => console.log("[wa-dashboard-m1] wa_team_daily_metrics schema ready"))
+    .catch((err) => console.error("[wa-dashboard-m1] metrics schema init failed:", err.message));
 });

--- a/apps/wa-dashboard-m1/viewer.html
+++ b/apps/wa-dashboard-m1/viewer.html
@@ -370,6 +370,46 @@
     font-size: 12.5px; padding: 5px 12px; border-radius: 8px;
     box-shadow: 0 1px 0.5px rgba(0,0,0,0.13);
   }
+
+  /* View toggle (Conversazioni / Qualità Team) */
+  .view-tabs { display: flex; gap: 4px; }
+  .view-tab {
+    background: transparent; border: 1px solid var(--wa-border);
+    color: var(--wa-text-2); padding: 6px 14px; border-radius: 8px;
+    font-size: 13px; cursor: pointer; font-family: inherit;
+    transition: background 0.1s;
+  }
+  .view-tab.active { background: var(--wa-accent); color: #fff; border-color: var(--wa-accent); }
+  .view-tab:hover:not(.active) { background: var(--wa-panel-2); }
+
+  /* Metrics view (Qualità Team) */
+  .metrics-view {
+    height: calc(100vh - 60px); overflow-y: auto;
+    background: var(--wa-bg); padding: 24px 32px;
+  }
+  .metrics-header h2 { font-size: 18px; font-weight: 600; color: var(--wa-text); margin: 0 0 4px; }
+  .metrics-sub { font-size: 13px; color: var(--wa-text-2); margin-bottom: 18px; }
+  .metrics-table-wrap { background: var(--wa-panel); border-radius: 10px; overflow: hidden; box-shadow: 0 1px 2px rgba(0,0,0,0.06); }
+  .metrics-table { border-collapse: collapse; width: 100%; }
+  .metrics-table th, .metrics-table td {
+    padding: 10px 12px; text-align: right; font-size: 13px;
+    border-bottom: 1px solid var(--wa-divider); white-space: nowrap;
+  }
+  .metrics-table th {
+    background: var(--wa-header-bg); color: var(--wa-text-2); font-weight: 600;
+    position: sticky; top: 0; font-size: 11px; text-transform: uppercase; letter-spacing: 0.3px;
+  }
+  .metrics-table td.op, .metrics-table th.op { text-align: left; font-weight: 500; color: var(--wa-text); }
+  .metrics-table tbody tr:hover td { background: var(--wa-panel-2); }
+  .metrics-table tbody tr:last-child td { border-bottom: none; }
+  .m-good { color: #08820a; font-weight: 600; }
+  .m-warn { color: #b8860b; font-weight: 600; }
+  .m-bad  { color: var(--wa-error); font-weight: 600; }
+  .m-delta { font-size: 11px; margin-left: 4px; }
+  .m-delta.up { color: var(--wa-error); }
+  .m-delta.down { color: #08820a; }
+  .metrics-legend { margin-top: 14px; font-size: 12px; color: var(--wa-text-3); line-height: 1.7; }
+  .metrics-legend b { color: var(--wa-text-2); font-weight: 600; }
 </style>
 </head>
 <body>
@@ -378,13 +418,17 @@
     <div class="brand-icon">BZ</div>
     <span>WhatsApp Dashboard</span>
   </div>
+  <div class="view-tabs">
+    <button class="view-tab active" data-view="convs">Conversazioni</button>
+    <button class="view-tab" data-view="metrics">Qualità Team</button>
+  </div>
   <div class="meta">
     <span id="health-pill" class="badge">read-only</span>
     <span id="db-host">DB: …</span>
     <span id="last-refresh">aggiornato: …</span>
   </div>
 </header>
-<main>
+<main id="view-convs">
   <div class="col" id="col-teams">
     <div class="col-header">Team</div>
     <div class="loader">Caricamento team…</div>
@@ -401,6 +445,16 @@
     </div>
   </div>
 </main>
+<section id="view-metrics" class="metrics-view" style="display:none">
+  <div class="metrics-header">
+    <h2>Qualità conversazioni — ultimi <span id="m-window">30</span> giorni</h2>
+    <div class="metrics-sub" id="m-sub">Caricamento…</div>
+  </div>
+  <div class="metrics-table-wrap">
+    <table class="metrics-table" id="m-table"></table>
+  </div>
+  <div class="metrics-legend" id="m-legend"></div>
+</section>
 <script>
 let DATA = null;
 let SELECTED_TEAM = null;
@@ -767,6 +821,90 @@ async function checkHealth() {
       document.getElementById("health-pill").style.color = "var(--bz-success)";
     }
   } catch {}
+}
+
+// === View toggle + Team Quality metrics ===
+let METRICS = null;
+let CURRENT_VIEW = "convs";
+
+function switchView(view) {
+  CURRENT_VIEW = view;
+  document.getElementById("view-convs").style.display = view === "convs" ? "" : "none";
+  document.getElementById("view-metrics").style.display = view === "metrics" ? "" : "none";
+  for (const b of document.querySelectorAll(".view-tab")) b.classList.toggle("active", b.dataset.view === view);
+  if (view === "metrics") renderMetrics();
+}
+
+function mFmt(v, suffix) { return v == null ? "—" : v + (suffix || ""); }
+function respClass(v) { return v == null ? "" : v <= 5 ? "m-good" : v <= 30 ? "" : "m-warn"; }
+function staleClass(stale, threads) {
+  if (!threads) return "";
+  const r = stale / threads;
+  return r > 0.35 ? "m-bad" : r > 0.2 ? "m-warn" : "m-good";
+}
+
+async function renderMetrics() {
+  const tableEl = document.getElementById("m-table");
+  const subEl = document.getElementById("m-sub");
+  const legendEl = document.getElementById("m-legend");
+  tableEl.innerHTML = `<tbody><tr><td class="op">Caricamento…</td></tr></tbody>`;
+  try {
+    const [mr, hr] = await Promise.all([
+      fetch("/metrics.json?window=30").then((r) => r.json()),
+      fetch("/metrics-history.json?days=14").then((r) => r.json()).catch(() => ({ rows: [] })),
+    ]);
+    METRICS = mr;
+    document.getElementById("m-window").textContent = mr.window_days;
+
+    // most-recent PRIOR snapshot per operator (for backlog delta), excluding today
+    const today = new Date().toISOString().slice(0, 10);
+    const priorByOp = {};
+    for (const row of hr.rows || []) {
+      if (row.snapshot_date && String(row.snapshot_date).slice(0, 10) >= today) continue;
+      priorByOp[row.team_member_phone] = row; // rows date-ascending → last kept = most recent prior
+    }
+
+    let html = `<thead><tr>
+      <th class="op">Operatore</th><th>Msg</th><th>In</th><th>Out</th><th>Clienti</th>
+      <th>Resp p50</th><th>Resp p90</th><th>&lt;5min</th><th>After-hrs</th><th>Backlog 24h+</th><th>Gruppi</th>
+    </tr></thead><tbody>`;
+    for (const o of mr.operators) {
+      const prior = priorByOp[o.team_member_phone];
+      let delta = "";
+      if (prior && prior.backlog_stale24h != null) {
+        const d = o.backlog_stale24h - prior.backlog_stale24h;
+        if (d !== 0) delta = `<span class="m-delta ${d > 0 ? "up" : "down"}">${d > 0 ? "▲" : "▼"}${Math.abs(d)}</span>`;
+      }
+      html += `<tr>
+        <td class="op">${escapeHtml(o.team_member_name || "")}</td>
+        <td>${o.msgs_total}</td><td>${o.msgs_in}</td><td>${o.msgs_out}</td><td>${o.clients}</td>
+        <td class="${respClass(o.resp_median_min)}">${mFmt(o.resp_median_min, "′")}</td>
+        <td class="${respClass(o.resp_p90_min)}">${mFmt(o.resp_p90_min, "′")}</td>
+        <td>${mFmt(o.pct_under5min, "%")}</td>
+        <td class="${o.pct_afterhours > 20 ? "m-warn" : ""}">${mFmt(o.pct_afterhours, "%")}</td>
+        <td class="${staleClass(o.backlog_stale24h, o.backlog_threads)}">${o.backlog_stale24h}${delta}</td>
+        <td>${o.grp_msgs}</td>
+      </tr>`;
+    }
+    html += `</tbody>`;
+    tableEl.innerHTML = html;
+
+    const histDates = new Set((hr.rows || []).map((r) => String(r.snapshot_date).slice(0, 10)));
+    subEl.textContent = `${mr.operators.length} operatori · schema v${mr.metrics_schema_version} · `
+      + `${histDates.size} snapshot storici · attribuzione per numero+alias (parità con le conversazioni)`;
+    legendEl.innerHTML =
+      `<b>Resp p50/p90</b>: mediana e 90° percentile del tempo di risposta (outbound dopo inbound, 0–12h). `
+      + `<b>&lt;5min</b>: % risposte sotto 5 minuti. <b>After-hrs</b>: % outbound fuori 8–18 WITA. `
+      + `<b>Backlog 24h+</b>: thread con ultimo messaggio inbound fermo da oltre 24h (palla al team); `
+      + `▲/▼ = variazione vs snapshot precedente. Verde/giallo/rosso = soglie qualità. `
+      + `Aggregati Pro-bound, nessun dato cliente in chiaro.`;
+  } catch (err) {
+    tableEl.innerHTML = `<tbody><tr><td class="op">Errore: ${escapeHtml(err.message)}</td></tr></tbody>`;
+  }
+}
+
+for (const b of document.querySelectorAll(".view-tab")) {
+  b.addEventListener("click", () => switchView(b.dataset.view));
 }
 
 checkHealth();

--- a/research/operations/2026-06-16-wa-business-conversation-analysis-methodology.md
+++ b/research/operations/2026-06-16-wa-business-conversation-analysis-methodology.md
@@ -1,0 +1,207 @@
+---
+date: 2026-06-16
+domain: operations
+client_case: none
+sources:
+  - https://www.maestroqa.com/blog/how-to-build-a-qa-scorecard
+  - https://www.zendesk.com/blog/quality-assurance/workforce-optimization/qa-scorecard/
+  - https://www.calabrio.com/blog/quality-assurance-qa-scorecard/
+  - https://www.balto.ai/blog/call-center-quality-assurance-metrics/
+  - https://justcall.io/blog/customer-service-metrics-kpis.html
+  - https://www.intercom.com/learning-center/customer-service-metrics
+  - https://www.sqmgroup.com/resources/library/blog/fcr-metric-operating-philosophy
+  - https://formbricks.com/blog/customer-effort-score
+  - https://www.plecto.com/blog/customer-service/csat-vs-nps-vs-ces/
+  - https://thelevel.ai/blog/conversation-analytics-software/
+  - https://www.lorikeetcx.ai/articles/best-ai-qa-tools-support
+  - https://authenticx.com/page/types-of-conversation-analysis/
+  - https://edulearn.intelektual.org/index.php/EduLearn/article/view/21041
+  - https://emcawiki.net/Adjacency_pair
+  - https://secondnature.ai/meddpicc-spin-or-bant-the-right-sales-technique-for-your-organization/
+  - https://www.claap.io/blog/bant-vs-spin
+  - https://delvetool.com/blog/grounded-theory-vs-thematic-analysis
+  - https://getthematic.com/insights/coding-qualitative-data
+  - https://arxiv.org/pdf/2507.21017
+  - https://blog.jetbrains.com/pycharm/2026/05/llm-evaluation-and-ai-observability-for-agent-monitoring/
+  - https://www.gorgias.com/blog/whatsapp-for-customer-service
+  - https://www.salesforce.com/service/contact-center/whatsapp-for-customer-service/
+  - https://wolf.financial/blog/brand-voice-guide-financial-marketing-compliance
+---
+
+# Methodology: Analyzing Business / Customer-Service WhatsApp Conversations for Agent Evaluation
+
+**Scope & purpose.** This is a public-methodology framework for evaluating individual customer-service agents at a regulated advisory firm (immigration / tax / company-setup) whose primary channel is asynchronous WhatsApp. It synthesizes contact-center QA literature, conversation-analytics vendor frameworks, academic Conversation Analysis (CA), sales-qualification models, qualitative-coding methods, and the current LLM-assisted auto-QA debate. It contains **no client data, no PII** — only the analytical scaffolding. The core principle throughout: combine **quantitative operational telemetry** (cheap, 100%-coverage, gameable) with **qualitative scorecard judgment** (expensive, sampled, meaningful), and never let one stand in for the other.
+
+---
+
+## 1. Operational / Quantitative Metrics
+
+These are the channel-level "vital signs" — derivable from message timestamps and conversation metadata without reading content.
+
+- **First Response Time (FRT):** elapsed time from a customer's inbound message to the agent's first *meaningful* reply. Formula: total first-reply times / number of conversations. Benchmarks vary by channel — chat <90s, email <24h, phone <3min — but messaging sits between live chat and email (JustCall; Intercom; Gorgias).
+- **Average / Next Response Time (ART / NRT):** mean time to *subsequent* replies within an open thread. In async WhatsApp this matters more than FRT, because a single conversation can span days with many turns; NRT captures whether an agent keeps the thread warm or lets it stall (Gorgias).
+- **Resolution Time:** total duration from conversation open to closure. Formula: total resolution time / conversations resolved (JustCall).
+- **First-Contact Resolution (FCR):** % of issues fully resolved without a follow-up contact. Formula: (resolved on first contact / total) x 100; industry benchmark 60–80%. FCR is widely treated as the single highest-leverage operational metric because it correlates strongly with CSAT and inversely with repeat-contact rate (SQM Group; JustCall).
+- **Message volume & inbound/outbound ratio:** interactions handled per agent per day/week, and the ratio of agent-sent to customer-sent messages. Volume must always be read *alongside* quality, never in isolation (JustCall).
+- **Conversation length / turns:** number of message exchanges to resolution; an outlier-long thread can signal either complexity or poor handling.
+- **After-hours coverage:** share of inbound arriving / answered outside business hours — load-bearing for a Bali-based firm serving European (Italian) and other time-zone clients.
+- **SLA adherence:** % of first responses (and resolutions) inside the agreed target. Formula: responses within SLA / total responses (Freshworks/JustCall). Adjacent operational metrics: **occupancy** (75–85%), **schedule adherence** (90–95%), **repeat-contact rate**, **handover/escalation rate**, and **backlog/unread** (open threads awaiting an agent reply) (JustCall; Balto).
+
+---
+
+## 2. CX Outcome Metrics
+
+Operational speed is a proxy; outcome metrics measure whether the customer was actually served well.
+
+- **CSAT (Customer Satisfaction):** post-interaction "How satisfied were you?" on a 1–5 or 1–10 scale; CSAT = satisfied responses / total x 100; benchmark >85% (JustCall; Plecto).
+- **NPS (Net Promoter Score):** relational loyalty, "How likely to recommend?" 0–10; NPS = %promoters(9–10) - %detractors(0–6); >50 excellent (Plecto).
+- **CES (Customer Effort Score):** "How easy was it to get your issue resolved?" on a 5–7-point Likert; strong retention predictor; use after task-based interactions (Formbricks; Plecto).
+- **Sentiment analysis:** automated polarity/emotion scoring across the thread — the *only* outcome signal available at 100% coverage when surveys are sparse. Track trajectory (did sentiment recover by the close?) not just average (thelevel.ai; Authenticx).
+- **Churn / escalation signals:** explicit ("I'll go elsewhere", refund/complaint language), and implicit (rising effort, repeat contacts, ghosting after a quote). These are the leading indicators a regulated-advisory firm most needs to catch early.
+
+---
+
+## 3. Qualitative QA Scorecards
+
+A QA scorecard is the rubric a reviewer uses to grade an interaction against the firm's standards, spanning **soft skills** (tone, empathy, listening) and **hard checks** (accuracy, compliance, resolution) (MaestroQA; Calabrio; Balto). Two widely-cited organizing frameworks: the **4C Framework** — Communication, Customer Connection, Compliance & Security, Correct & Complete Content (MaestroQA/Zendesk); and pillar models splitting Soft Skills / Issue Resolution / Procedure. Scoring mechanics: yes/no checkboxes, anchored linear scales (1–5 or 1–10), and **weighted** categories, plus an **auto-fail / critical-error** section that zeroes the whole interaction on a non-negotiable breach (e.g. wrong regulatory advice, data-protection violation) (MaestroQA).
+
+**Recommended agent-scoring rubric (1–5 anchored).** Each dimension scored 1–5; weights tuned to a regulated advisory; any "Auto-fail" trigger overrides the total to 0.
+
+| # | Dimension | What it measures | 1 (fail) | 3 (meets) | 5 (excellent) | Weight |
+|---|-----------|------------------|----------|-----------|---------------|--------|
+| 1 | Greeting & Identification | Opens, identifies self/firm, confirms who the client is | No greeting; ambiguous identity | Polite open, names self | Warm, branded, confirms client + context | 5% |
+| 2 | Comprehension | Grasps the real question behind the question | Misreads the request | Answers the literal ask | Surfaces underlying need, asks clarifying Q | 10% |
+| 3 | Accuracy / Correctness | Regulatory/factual correctness of advice | Wrong info given **(Auto-fail)** | Correct, slightly incomplete | Correct, precise, sourced/caveated | 25% |
+| 4 | Resolution / Completeness | Issue actually resolved or clear next step | Left unresolved, no owner | Resolved or routed | Resolved + confirms understanding + next step | 20% |
+| 5 | Empathy & Tone | Acknowledges emotion, on-brand register | Cold/curt/dismissive | Neutral-polite | Genuinely empathetic, reassuring | 10% |
+| 6 | Personalization | Tailors to client's case, no blind macro | Generic copy-paste | Light tailoring | Fully contextual to the case | 5% |
+| 7 | Proactivity | Anticipates next obstacle / upsell-with-integrity | Reactive only | Answers what's asked | Flags deadline/risk/next service | 10% |
+| 8 | Closing | Confirms resolution, invites follow-up | Abrupt / no close | Clean close | Confirms + sets expectation + warm sign-off | 5% |
+| 9 | Compliance & Data Handling | Disclaimers, PII discipline, no off-channel leakage | Breach **(Auto-fail)** | Compliant | Compliant + proactively protective | 10% |
+
+---
+
+## 4. Conversation Analysis (CA) Applied to Service Chats
+
+CA is the academic discipline that treats talk as *structured social action*; its constructs map cleanly onto chat QA (Authenticx; EduLearn; emcawiki):
+
+- **Turn-taking:** how parties manage who "speaks" — in async chat, who holds the floor, batching, overlap, and silence (a 6-hour gap *means* something).
+- **Adjacency pairs:** first-pair-part -> expected second-pair-part (question->answer, greeting->greeting, request->grant/deny). A *missing* or *dispreferred* second-pair-part (question left unanswered) is a measurable defect.
+- **Repair:** how breakdowns get fixed — self-initiated self-repair (the agent clarifies), other-initiated (client says "I don't understand"). Frequency and *type* of repair is a quality signal: lots of client-initiated repair = unclear agent communication.
+- **Openings & closings:** institutional service openings ("How can I help?") and ritualized closings; CA shows closings are *negotiated*, not unilateral — an agent who closes before the client's concern is fully addressed produces a "dispreferred" close.
+
+CA gives the *vocabulary* and *unit of analysis* (the sequence, not the isolated message) that elevates a scorecard from gut-feel to defensible structure.
+
+---
+
+## 5. Sales / Lead Frameworks for Chat
+
+Bali Zero's inbound WhatsApp is half service, half sales (lead -> quote -> close), so the framework must score *conversion behavior* too (secondnature.ai; Claap):
+
+- **SPIN (Rackham):** Situation, Problem, Implication, Need-payoff questions — built for consultative, multi-touch, >30-day cycles; ideal for visa/company-setup advisory. Measure whether the agent *diagnoses* before *prescribing*.
+- **BANT:** Budget, Authority, Need, Timeline — fast transactional qualification; score whether the agent established these four before investing effort.
+- **Objection handling:** acknowledge -> clarify -> reframe -> confirm; track which objections recur (price, timeline, trust) and how agents resolve them.
+- **Funnel / conversion-in-chat:** measure inquiry -> qualified -> quote-sent -> closed within the thread; per-agent conversion rate and quote-to-close lag.
+- **Follow-up cadence:** did the agent follow up after a quote went quiet? Ghosted-lead recovery is a high-value, easily-audited behavior.
+
+---
+
+## 6. Qualitative Coding Methods (Corpus-Level)
+
+To learn *what* clients ask and *where* agents fail across thousands of threads, code the corpus (Delvetool; Getthematic; thelevel.ai):
+
+- **Thematic analysis:** assign codes to phrases, cluster into themes; works **deductive/top-down** (start from a predefined codebook: "KITAS query", "tax deadline", "pricing objection") or **inductive/bottom-up** (let themes emerge).
+- **Grounded theory:** open coding -> axial coding (relate codes) -> selective coding (build a core narrative) — for discovering *why* a failure pattern exists, not just that it does.
+- **Intent classification:** map each inbound to an intent taxonomy (price, document-request, status-check, complaint, new-lead) — enables routing analytics and per-intent FCR.
+- **Topic modeling:** unsupervised clustering (LDA/embeddings) to surface latent topics and seasonal spikes (e.g. visa-rule change -> query surge).
+
+A practical pipeline: build a deductive codebook from domain knowledge, validate inductively on a sample, then let an LLM apply it at scale — with human-validated inter-coder agreement on a held-out sample.
+
+---
+
+## 7. Tone / Brand-Voice & Regulatory-Accuracy QA
+
+For regulated advisory (visa/tax/legal), **wrong information is a liability**, not a style nit. QA in regulated industries treats compliance as a *non-negotiable, often auto-fail* category — were required disclaimers given, was statutory info correct, was data handled per regulation (Zendesk/4C; Calabrio; wolf.financial). Two distinct axes:
+
+1. **Brand-voice compliance:** does the agent sound like one firm — approved vocabulary, register, no taboo phrases? A brand-voice guide that *maps approved language to compliance requirements* reduces review cycles (wolf.financial). This is checkable semi-automatically against a lexicon.
+2. **Regulatory accuracy:** the highest-stakes check. Every factual claim about a visa type, tax rate, deadline, or KBLI code must be verifiable against ground truth. Recommended: a **claim-extraction + verification** step — pull every factual assertion from the thread and check against an authoritative source; any unverifiable or wrong claim is a critical error. This is exactly where automation must *flag for human review*, not auto-pass.
+
+---
+
+## 8. Modern LLM-Assisted Conversation Analytics
+
+LLM/auto-QA platforms now score **100% of interactions** against custom scorecards (greeting, empathy, policy mention, resolution), versus the 1–2% a human team samples — auto-transcription, automated sentiment, summarization, and agent scorecards feeding coaching dashboards (thelevel.ai; Lorikeet; Balto). This is transformative for coverage and for catching the rare critical error in a long tail of conversations.
+
+**But the pitfalls are real and documented:**
+- **Hallucinated scoring:** LLMs produce confident-but-unsupported judgments; using an LLM to self-evaluate compounds the risk. Agent-trace hallucinations arise from multi-turn, evolving context and *cannot* be caught by conventional NLG checks (MIRAGE-Bench, arXiv 2507.21017).
+- **Self-preference bias:** evaluator LLMs favor outputs from the same model family, inflating scores — a structural gaming vulnerability (MIRAGE-Bench; JetBrains).
+- **Gaming & sensitivity:** scores drift with prompt design, transcript length, and contextual embeddings; agents (and models) learn to satisfy the rubric's letter, not spirit (JetBrains; arXiv 2412.05520).
+- **Mitigations:** treat the LLM judge as a *first-pass triage*, calibrate it against human labels (TPR/TNR), reserve high-stakes regulatory-accuracy and auto-fail decisions for human reviewers, and **never** rank or discipline agents on an unvalidated automated score alone.
+
+---
+
+## 9. WhatsApp-Specific Considerations
+
+WhatsApp breaks several assumptions baked into call-center metrics (Gorgias; Salesforce; Intercom):
+
+- **Asynchronous cadence:** "response time" != live-chat. A 30-minute reply is fine async, terrible in live chat. Measure FRT *and* NRT, normalize by business hours, and weight after-hours separately. Conversation "open/closed" boundaries are fuzzy — define a reopen window (e.g. 24h).
+- **Voice notes:** in SE Asia/LATAM a large share of clients communicate by voice note; these must be **transcribed** before any text analytics, and transcription quality caps every downstream metric.
+- **Media / documents / OCR:** clients send passport photos, akta, NPWP, contracts. Handling quality (did the agent correctly read/route the document?) is part of resolution — and a PII-handling compliance surface.
+- **Group vs direct chats:** group threads change turn-taking and accountability (who answered?); attribute per-agent metrics carefully.
+- **Multilingual informal register:** Bahasa Indonesia / Italian / English **code-switching** within one thread. Sentiment, intent, and tone models must be multilingual and robust to informal/slang register, or they mis-score.
+- **No native CSAT survey:** WhatsApp has no built-in post-chat survey. Substitutes: a sent CSAT/1-tap template message, **sentiment-trajectory as a CSAT proxy**, NPS via periodic broadcast, or inferred satisfaction from resolution + repeat-contact + thank-you-language signals.
+
+---
+
+## Recommended Metric Set for an Async WhatsApp Consultancy (Checklist)
+
+Operational (100% coverage, automated):
+- [ ] First Response Time (business-hours-normalized) + after-hours FRT split out
+- [ ] Next Response Time (median, to catch stalled threads)
+- [ ] Resolution Time + open-thread backlog/unread count per agent
+- [ ] First-Contact Resolution proxy (no reopen within 7 days)
+- [ ] SLA adherence %, message volume, inbound/outbound ratio, escalation/handover rate
+
+Outcome (sampled or proxied):
+- [ ] Sentiment trajectory per thread (proxy for CSAT, 100% coverage)
+- [ ] CSAT via sent 1-tap template (transactional); periodic NPS broadcast; CES after task-completion
+- [ ] Repeat-contact rate + churn/escalation language flags
+
+Qualitative (sampled, human-validated, LLM-assisted triage):
+- [ ] 9-dimension 1–5 scorecard on a stratified sample per agent per week (Section 3)
+- [ ] **Auto-fail audit at 100% coverage** for regulatory-accuracy + PII/data-handling (LLM flags -> human confirms)
+- [ ] Brand-voice lexicon compliance scan
+- [ ] Conversion funnel + follow-up-cadence per agent (sales threads)
+- [ ] Quarterly corpus-level thematic/intent coding to update the codebook + spot systemic gaps
+
+Guardrails:
+- [ ] LLM judges calibrated vs human labels; never discipline on unvalidated auto-score
+- [ ] Voice notes transcribed before scoring; multilingual models verified on ID/IT/EN code-switch
+
+---
+
+## Sources (inline-cited)
+
+1. [MaestroQA — How to Build Your First QA Scorecard](https://www.maestroqa.com/blog/how-to-build-a-qa-scorecard) — 4C framework, dimensions, scoring scales, auto-fail.
+2. [Zendesk — How to build a QA scorecard](https://www.zendesk.com/blog/quality-assurance/workforce-optimization/qa-scorecard/) — categories, critical errors, 4C.
+3. [Calabrio — Call Center QA Scorecards](https://www.calabrio.com/blog/quality-assurance-qa-scorecard/) — soft vs hard skills, coaching tie-in.
+4. [Balto — 20 Call Center QA Metrics](https://www.balto.ai/blog/call-center-quality-assurance-metrics/) — QA metric inventory.
+5. [JustCall — Customer Service KPIs](https://justcall.io/blog/customer-service-metrics-kpis.html) — FRT/ART/FCR/SLA/occupancy formulas + benchmarks.
+6. [Intercom — Customer Service Metrics](https://www.intercom.com/learning-center/customer-service-metrics) — metric definitions.
+7. [SQM Group — FCR](https://www.sqmgroup.com/resources/library/blog/fcr-metric-operating-philosophy) — FCR as operating philosophy.
+8. [Formbricks — Customer Effort Score](https://formbricks.com/blog/customer-effort-score) — CES formula, Likert, benchmarks.
+9. [Plecto — CSAT vs NPS vs CES](https://www.plecto.com/blog/customer-service/csat-vs-nps-vs-ces/) — formulas, transactional vs relational.
+10. [thelevel.ai — Conversation Analytics Software](https://thelevel.ai/blog/conversation-analytics-software/) — 100% coverage auto-QA, sentiment.
+11. [Lorikeet — Best AI QA Tools for Support](https://www.lorikeetcx.ai/articles/best-ai-qa-tools-support) — auto-QA coverage framing.
+12. [Authenticx — Types of Conversation Analysis](https://authenticx.com/page/types-of-conversation-analysis/) — CA constructs applied to CX.
+13. [EduLearn — Turn-taking, repair, adjacency pairs in online interaction](https://edulearn.intelektual.org/index.php/EduLearn/article/view/21041) — academic CA.
+14. [emcawiki — Adjacency pair](https://emcawiki.net/Adjacency_pair) — CA reference.
+15. [SecondNature — MEDDPICC, SPIN, or BANT](https://secondnature.ai/meddpicc-spin-or-bant-the-right-sales-technique-for-your-organization/) — methodology vs technique.
+16. [Claap — BANT vs SPIN](https://www.claap.io/blog/bant-vs-spin) — when each framework fits.
+17. [Delvetool — Grounded Theory vs Thematic Analysis](https://delvetool.com/blog/grounded-theory-vs-thematic-analysis) — coding distinctions.
+18. [Getthematic — Coding Qualitative Data](https://getthematic.com/insights/coding-qualitative-data) — codebook, deductive/inductive.
+19. [MIRAGE-Bench (arXiv 2507.21017)](https://arxiv.org/pdf/2507.21017) — LLM-agent hallucination, self-preference bias.
+20. [JetBrains/PyCharm — LLM Evaluation & AI Observability](https://blog.jetbrains.com/pycharm/2026/05/llm-evaluation-and-ai-observability-for-agent-monitoring/) — eval pitfalls, calibration.
+21. [Gorgias — WhatsApp for Customer Service](https://www.gorgias.com/blog/whatsapp-for-customer-service) — async FRT/NRT, voice notes, media.
+22. [Salesforce — WhatsApp for Customer Service](https://www.salesforce.com/service/contact-center/whatsapp-for-customer-service/) — best practices, multilingual.
+23. [Wolf Financial — Brand Voice & Compliance](https://wolf.financial/blog/brand-voice-guide-financial-marketing-compliance) — regulated brand-voice/compliance mapping.

--- a/scripts/launchd/com.balizero.wa-team-metrics-rollup.plist
+++ b/scripts/launchd/com.balizero.wa-team-metrics-rollup.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  wa-team-metrics-rollup — daily snapshot of WhatsApp team-quality metrics.
+  POSTs to the live wa-dashboard-m1 (:7790) /metrics-rollup endpoint, which
+  computes per-operator aggregates and UPSERTs one row/operator/day into
+  wa_team_daily_metrics (local nuzantara_dev — Pro-bound, no PII).
+
+  One-shot daily (StartCalendarInterval), NOT KeepAlive — this is a cron, not a
+  daemon (anti superscar #7 daemon-vs-cron misconfig). Real heartbeat is the row
+  written in the DB (computed_at), echoed in the log as rows_written.
+
+  Install (Pro only — wa-mirror is Pro-bound):
+    cp scripts/launchd/com.balizero.wa-team-metrics-rollup.plist ~/Library/LaunchAgents/
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.balizero.wa-team-metrics-rollup.plist
+    launchctl kickstart -k gui/$(id -u)/com.balizero.wa-team-metrics-rollup   # optional first run
+  Requires the dashboard (:7790) to already expose /metrics-rollup (merge + restart first).
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.balizero.wa-team-metrics-rollup</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-c</string>
+    <string>echo "[wa-team-metrics-rollup] $(date) start"; curl -sS -X POST "http://127.0.0.1:7790/metrics-rollup?window=30" -m 180; echo; echo "[wa-team-metrics-rollup] $(date) done"</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>6</integer>
+    <key>Minute</key>
+    <integer>30</integer>
+  </dict>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>StandardOutPath</key>
+  <string>/Users/nuzantara/logs/wa-team-metrics-rollup.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/nuzantara/logs/wa-team-metrics-rollup.err.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Cosa

Seconda vista nella dashboard `wa-dashboard-m1` (:7790): tab **Qualità Team** con metriche aggregate di qualità conversazionale per operatore, + storicizzazione + scheduler giornaliero. Fonde l'analisi WA team-quality dentro l'app esistente (niente organo separato).

## File

- `apps/wa-dashboard-m1/metrics.cjs` (nuovo) — modulo aggregazione su pool locale `nuzantara_dev` (Pro-bound, output solo aggregato, zero PII). Tabella rollup `wa_team_daily_metrics` con `metrics_schema_version` (anti state-schema-drift).
- `apps/wa-dashboard-m1/server.cjs` — `GET /metrics.json` (live, cache 60s), `GET /metrics-history.json` (trend), `POST /metrics-rollup` (UPSERT idempotente per giorno, heartbeat = riga DB). `ensureMetricsSchema` al boot.
- `apps/wa-dashboard-m1/viewer.html` — toggle header Conversazioni/Qualità Team + tabella metriche full-width con soglie qualità + delta backlog vs snapshot precedente. Vanilla JS, zero dipendenze nuove.
- `scripts/launchd/com.balizero.wa-team-metrics-rollup.plist` — cron giornaliero 06:30 WITA (StartCalendarInterval, **no** KeepAlive — anti superscar #7).
- `apps/wa-dashboard-m1/README.md` — documenta la tab + corregge il doc-drift sul DB target.

## Attribuzione

Per `team_member_phone` + alias (`aliasesForTeamMember`, gestisce il double-7 Baileys) — **parità con le colonne conversazioni**, non per email. Garantisce che i numeri della tab combacino con il resto della dashboard.

## Verifica (eseguita su istanza di test :17790 → nuzantara_dev locale)

- `GET /metrics.json` → 9 operatori (= team_size)
- `POST /metrics-rollup` x2 → 9 righe (non 18) = idempotente per giorno
- `GET /metrics-history.json` → rilegge 9 righe, schema v1
- `node --check` passa su `server.cjs` e sullo `<script>` estratto da `viewer.html`
- HTML servito HTTP 200, struttura tab presente

## Deploy (Pro)

1. merge
2. `cd ~/Desktop/nuzantara && git pull`
3. restart dashboard: `launchctl kickstart -k gui/$(id -u)/com.balizero.wa-dashboard-m1` (prende il nuovo `server.cjs` + `ensureMetricsSchema` crea la tabella)
4. install scheduler: `cp scripts/launchd/com.balizero.wa-team-metrics-rollup.plist ~/Library/LaunchAgents/ && launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.balizero.wa-team-metrics-rollup.plist`
5. QA visivo: apri :7790 → tab "Qualità Team"

## Note

- **DB drift corretto**: il deploy live legge `nuzantara_dev` LOCALE (verificato via `/health.json` + plist), non Fly — README/package.json erano stantii.
- **Law 2 flag (separato, fuori scope)**: su Fly restano 1872 msg `wa_mirror` fermi al 24/05 — residuo di vecchio sync su infra condivisa, candidato a cleanup.
- Verifica pixel-finale del rendering pending (browser MCP headless era giù durante il build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)