### PR TITLE
fix(intake): reconcile drive-intake-drain HOME-fork (repo-tracked wrapper)

### DIFF
--- a/infra/launchagents/com.balizero.drive-intake-drain.plist
+++ b/infra/launchagents/com.balizero.drive-intake-drain.plist
@@ -10,13 +10,19 @@
         <string>__HOME__</string>
         <key>PATH</key>
         <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>INTAKE_REPO_ROOT</key>
+        <string>__REPO_ROOT__</string>
+        <key>INTAKE_VENV_PYTHON</key>
+        <string>__VENV_PYTHON__</string>
+        <key>INTAKE_SA_FILE</key>
+        <string>__SA_FILE__</string>
         <key>INTAKE_DRIVE_SCOPE_FOLDER_ID</key>
         <string>__SCOPE_FOLDER_ID__</string>
     </dict>
     <key>ProgramArguments</key>
     <array>
-        <string>__VENV_PYTHON__</string>
-        <string>__REPO_ROOT__/scripts/drive_intake_drain.py</string>
+        <string>/bin/bash</string>
+        <string>__REPO_ROOT__/scripts/drive-intake-drain-run.sh</string>
     </array>
     <key>StartInterval</key>
     <integer>600</integer>

--- a/infra/launchagents/install_drive_intake.sh
+++ b/infra/launchagents/install_drive_intake.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# install_drive_intake.sh <scope-folder-id> — installer for the Drive→intake drain cron.
+# install_drive_intake.sh <scope-folder-id> [sa-file] — installer for the Drive→intake drain cron.
 #
 # Run ON the Pro, AFTER the Dropbox backfill has completed (arming during the
 # backfill would flood intake_queue with the historical corpus). The first run
@@ -8,29 +8,42 @@
 #
 # <scope-folder-id> = Drive folder id of Dropbox-Intake/ — find it with:
 #   rclone lsf gdrive: --dirs-only --format "ip" | grep Dropbox-Intake
+# [sa-file] = path to the Drive service-account JSON (0600). Defaults to
+#   $HOME/.config/nuzantara/service-accounts/nuzantara-google-drive-sa-20260530.json
+#   (override via arg 2 or $INTAKE_SA_FILE). Read at runtime by the wrapper —
+#   never inlined in the plist (cicatrix #4).
 set -euo pipefail
 
 SCOPE_ID="${1:-}"
-[ -n "$SCOPE_ID" ] || { echo "usage: $0 <scope-folder-id>"; exit 2; }
+[ -n "$SCOPE_ID" ] || { echo "usage: $0 <scope-folder-id> [sa-file]"; exit 2; }
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PLIST_SRC="$REPO_ROOT/infra/launchagents/com.balizero.drive-intake-drain.plist"
 SCRIPT="$REPO_ROOT/scripts/drive_intake_drain.py"
+WRAPPER="$REPO_ROOT/scripts/drive-intake-drain-run.sh"
 VENV_PYTHON="$REPO_ROOT/apps/backend-rag/.venv/bin/python"
+SA_FILE="${2:-${INTAKE_SA_FILE:-$HOME/.config/nuzantara/service-accounts/nuzantara-google-drive-sa-20260530.json}}"
 LABEL="com.balizero.drive-intake-drain"
 PLIST_DST="$HOME/Library/LaunchAgents/$LABEL.plist"
 
 [ -f "$PLIST_SRC" ] || { echo "SKIP: $PLIST_SRC missing"; exit 0; }
 [ -f "$SCRIPT" ] || { echo "SKIP: $SCRIPT missing"; exit 0; }
+[ -f "$WRAPPER" ] || { echo "SKIP: $WRAPPER missing"; exit 0; }
 [ -x "$VENV_PYTHON" ] || { echo "SKIP: venv python missing at $VENV_PYTHON"; exit 0; }
+# Do NOT arm a blind drain: the SA file must be present + readable, else the
+# wrapper would exit 78 every tick (cron theater — superscar #2).
+[ -r "$SA_FILE" ] || { echo "SKIP: SA file unreadable at $SA_FILE (set arg 2 or \$INTAKE_SA_FILE)"; exit 0; }
 
+chmod +x "$WRAPPER"
 mkdir -p "$HOME/logs"
 
-# No secrets in the plist by design (scar 2026-04-29) — the folder id is an
-# identifier, not a credential.
+# No secrets in the plist by design (scar 2026-04-29): the folder id and the SA
+# FILE PATH are identifiers, not credentials. The SA JSON itself is read from
+# the 0600 file at runtime by the wrapper (cicatrix #4).
 sed -e "s|__HOME__|$HOME|g" \
     -e "s|__REPO_ROOT__|$REPO_ROOT|g" \
     -e "s|__VENV_PYTHON__|$VENV_PYTHON|g" \
+    -e "s|__SA_FILE__|$SA_FILE|g" \
     -e "s|__SCOPE_FOLDER_ID__|$SCOPE_ID|g" \
     "$PLIST_SRC" > "$PLIST_DST"
 chmod 0644 "$PLIST_DST"
@@ -40,4 +53,4 @@ launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
 launchctl bootstrap "gui/$(id -u)" "$PLIST_DST"
 launchctl kickstart "gui/$(id -u)/$LABEL"
 
-echo "OK: $LABEL installed + kickstarted (scope=$SCOPE_ID, repo=$REPO_ROOT)"
+echo "OK: $LABEL installed + kickstarted (scope=$SCOPE_ID, repo=$REPO_ROOT, sa=$SA_FILE)"

--- a/scripts/drive-intake-drain-run.sh
+++ b/scripts/drive-intake-drain-run.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# drive-intake-drain-run.sh — wrapper for the com.balizero.drive-intake-drain
+# LaunchAgent. Loads backend secrets (.env via CWD + python-dotenv) and the
+# Drive service-account JSON (read at runtime from a 0600 file — NEVER inlined
+# in the plist, cicatrix #4) before exec'ing the drain.
+#
+# Source of truth: THIS repo file (no HOME-fork — superscar #1). The plist passes
+# machine-specifics as env (INTAKE_REPO_ROOT / INTAKE_VENV_PYTHON / INTAKE_SA_FILE
+# / INTAKE_DRIVE_SCOPE_FOLDER_ID), so this script stays static + tracked and is
+# executed in place from the repo. install_drive_intake.sh wires the env values.
+set -euo pipefail
+
+: "${INTAKE_REPO_ROOT:?INTAKE_REPO_ROOT not set (installer wires it via the plist)}"
+: "${INTAKE_VENV_PYTHON:?INTAKE_VENV_PYTHON not set}"
+: "${INTAKE_SA_FILE:?INTAKE_SA_FILE not set}"
+: "${INTAKE_DRIVE_SCOPE_FOLDER_ID:?INTAKE_DRIVE_SCOPE_FOLDER_ID not set}"
+
+# Fail loud, not blind: a missing/unreadable SA file means no Drive creds, which
+# silently ingests 0 (superscar #2 cron theater). Exit non-zero so it is visible.
+[ -r "$INTAKE_SA_FILE" ] || { echo "drain: SA file unreadable: $INTAKE_SA_FILE" >&2; exit 78; }
+
+cd "$INTAKE_REPO_ROOT/apps/backend-rag"
+
+# Service-account JSON read from the 0600 file at runtime (never in the plist).
+GOOGLE_SERVICE_ACCOUNT_JSON="$(cat "$INTAKE_SA_FILE")"
+export GOOGLE_SERVICE_ACCOUNT_JSON
+export GOOGLE_CREDENTIALS_JSON="$GOOGLE_SERVICE_ACCOUNT_JSON"
+export INTAKE_DRIVE_SCOPE_FOLDER_ID
+
+exec "$INTAKE_VENV_PYTHON" "$INTAKE_REPO_ROOT/scripts/drive_intake_drain.py"


### PR DESCRIPTION
## Cosa

Riconcilia la HOME-fork del drain Drive→intake creata live la scorsa sessione (superscar #1 — HOME-fork drift). Il wrapper vivo `~/scripts/drive-intake-drain-run.sh` era divergente dal repo, e il plist nel repo non aveva il wiring del service-account → un reinstall avrebbe ri-accecato il drain.

## Modifiche

- **`scripts/drive-intake-drain-run.sh`** (NEW, repo-tracked, mode 100755): wrapper statico env-driven. Legge `INTAKE_REPO_ROOT` / `INTAKE_VENV_PYTHON` / `INTAKE_SA_FILE` / `INTAKE_DRIVE_SCOPE_FOLDER_ID` (`: "${VAR:?...}"`). Verifica `[ -r "$INTAKE_SA_FILE" ]` → `exit 78` (loud) se il SA manca (no blind-arming — superscar #2). Legge il JSON dal file 0600 a runtime, mai inlineato (cicatrix #4).
- **`infra/launchagents/com.balizero.drive-intake-drain.plist`**: `EnvironmentVariables` ora porta i 4 identificatori (path SA, non valore); `ProgramArguments` punta al wrapper repo-tracked; `StartInterval=600`, `KeepAlive=false`.
- **`infra/launchagents/install_drive_intake.sh`**: aggiunge `SA_FILE` (arg 2 / `$INTAKE_SA_FILE` / default), rifiuta l'arming se il SA è illeggibile (`[ -r ] || SKIP exit 0`), `chmod +x` wrapper, sed `__SA_FILE__`.

## Sicurezza (cicatrix #4 + superscar #2)

- Nel plist solo il **path** del SA (identificatore), mai il valore JSON.
- Il JSON è letto dal file 0600 a runtime dentro il wrapper.
- L'installer **rifiuta** di armare un drain cieco se il SA non è leggibile.
- Il wrapper esce **78** (rumoroso) invece di girare a vuoto, così il drain non diventa cron-theater.

## Verifica

- `plutil -lint` plist ✅
- `bash -n` wrapper + installer ✅
- wrapper mode 100755 ✅
- pre-push full backend suite: 15225 passed, 802 skipped ✅

## NON in questa PR

Re-install live sul Pro / `launchctl`: richiede step operatore-verificato (NON tocco la macchina viva qui).

🤖 Generated with [Claude Code](https://claude.com/claude-code)