### PR TITLE
fix(tests): force fake Telegram token so pytest never spams Zero's owner chat

### DIFF
--- a/apps/backend-rag/backend/tests/conftest.py
+++ b/apps/backend-rag/backend/tests/conftest.py
@@ -28,7 +28,17 @@ os.environ.setdefault("ENVIRONMENT", "test")
 os.environ["LEGAL_INGEST_ALLOW_QDRANT_ENV_OVERRIDE"] = "1"
 os.environ.setdefault("WHATSAPP_VERIFY_TOKEN", "test_whatsapp_verify_token")
 os.environ.setdefault("INSTAGRAM_VERIFY_TOKEN", "test_instagram_verify_token")
-os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123456:test_token")
+# FORCE-assign (not setdefault): the Pro dev/cron shell exports the REAL
+# TELEGRAM_BOT_TOKEN (a GitHub secret used by all cron wrappers). With
+# setdefault the real token survived into pytest, so every un-mocked Telegram
+# sender — sentinel alerter (scripts/sentinel_lib/alerter.py), canva_renderer
+# _telegram.send_telegram, email_audit.notify_email_failure_critical — fired
+# REAL alerts to the owner chat (1125336968) during the test run (verbatim
+# leaks: "OCR ... Context: unit.test.context", "WR2 rendered: Test / DAG123",
+# "Invoice INV-2026-001 ... john@example.com"). Forcing the fake token makes
+# those calls hit a non-existent bot (401, swallowed) — never the owner.
+# Tests that genuinely exercise a sender still win via per-test monkeypatch.
+os.environ["TELEGRAM_BOT_TOKEN"] = "123456:test_token"
 os.environ.setdefault("EMBEDDING_PROVIDER", "openai")
 os.environ.setdefault("EMBEDDING_MODEL", "text-embedding-3-small")
 


### PR DESCRIPTION
## Problem — test/probe alerts leaking to Zero's real Telegram

During a health-triage of the Zantara alert stream, a large fraction of the "critical" noise turned out to be **test fixtures firing real Telegram alerts to the owner chat (`1125336968`)**. Verbatim leaks captured:

- `🟡 Sentinel | OCR cloud fallback blocked … Context: unit.test.context / ctx-unimportable / ctx`
- `🎨 WR2 rendered: Test  canva.com/design/DAG123/edit  duration: 0.0s`
- `🚨 Email delivery failure … Invoice INV-2026-001 … john@example.com` / `client#42`

## Root cause (one, shared by 3 senders)

`backend/tests/conftest.py` used `os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123456:test_token")`. On the Pro the dev/cron shell **already exports the REAL `TELEGRAM_BOT_TOKEN`** (a GitHub secret used by every cron wrapper) — so `setdefault` did **not** override it, and pytest ran with the live token. None of the three senders guards `ENVIRONMENT=test`:

- `scripts/sentinel_lib/alerter.py::send_alert`
- `apps/backend-rag/backend/services/canva_renderer_v2/_telegram.py::send_telegram`
- `apps/backend-rag/backend/services/notifications/email_audit.py::notify_email_failure_critical`

So any un-mocked sender exercised by a test fired a **real** message to Zero.

## Fix

Force-assign the fake token (assignment, not `setdefault`). Un-mocked sender calls now hit a non-existent bot (`401`, swallowed) instead of the owner. Tests that genuinely exercise a sender still win via per-test `monkeypatch`.

## Verification

- The 13 previously-leaking tests (`test_cloud_vision_gate` + `test_orchestrator`) stay green.
- Full CI-parity pre-push gate: **15229 passed, 802 skipped, 0 failed**.

## Follow-up (not in this PR)

The deeper fix-class is a shared `_telegram_enabled()` guard on all senders (so a *new* sender can't reintroduce the leak). Tracked separately — this PR stops the active bleeding with one low-risk line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)