### PR TITLE
feat(ops): add Codex profile health controls

### DIFF
--- a/docs/runbooks/codex-nuzantara-profiles.md
+++ b/docs/runbooks/codex-nuzantara-profiles.md
@@ -1,0 +1,123 @@
+# Runbook - Codex Nuzantara Profiles
+
+> **What it is.** The operating map for Codex 5.5 xhigh inside Nuzantara.
+> Codex executes work; Skill Coach extracts reusable lessons; Genome stores
+> accepted skills/scars; Symbiosis governs the boundaries.
+
+## Profiles
+
+| Profile | Wrapper | Use for | Default rule |
+| --- | --- | --- | --- |
+| `nuzantara-core` | `codex-nz-core` | normal coding, review, architecture, repo work | clean surface, plugins off |
+| `nuzantara-research` | `codex-nz-research` | deep research, specs, multi-source synthesis | clean surface, slightly more verbose |
+| `nuzantara-toolful` | not armed yet | Drive, Gmail, browser, Canva, connector-heavy tasks | opt-in only after plugin cache cleanup |
+| `nuzantara-operator` | not armed yet | explicit local operations | use only when the operator wants machine control |
+
+The default should stay `nuzantara-core`. Do not make a single always-loaded
+"monster" profile.
+
+## Commands
+
+```bash
+# Normal Codex session
+codex-nz-core exec "task..."
+
+# Research/spec session
+codex-nz-research exec "task..."
+
+# Local health check from repo root
+python scripts/ops/codex_config_health.py --allow-warnings
+```
+
+The wrappers set `RUST_LOG=error` and pick the intended profile. They do not
+hide real task failures.
+
+## Health Gates
+
+`scripts/ops/codex_config_health.py` checks:
+
+- Nuzantara profile TOML parses.
+- `nuzantara-core` and `nuzantara-research` use `gpt-5.5` with `xhigh`.
+- clean profiles keep `plugins=false` and `plugin_hooks=false`.
+- Codex and Claude user hook configs have no active `SessionStart`,
+  `UserPromptSubmit`, or `Stop` entries.
+- local skill frontmatter is shaped so Codex can parse it.
+- user/repo `AGENTS.md` files fit the configured context budget.
+
+Warnings are allowed during migration. Failures mean the default Codex surface
+is no longer clean.
+
+## Council Trigger
+
+Use one Codex xhigh pass by default.
+
+Escalate to a multi-LLM council only when at least one is true:
+
+- the decision is expensive to reverse;
+- the task crosses architecture, data, and ops boundaries;
+- there are competing priors that matter;
+- the work will become a reusable skill/scar;
+- a red-team view is materially useful.
+
+Council roles:
+
+| Reviewer | Role |
+| --- | --- |
+| Codex | implementation and repo feasibility |
+| Claude/Opus | reasoning, ambiguity, instruction quality |
+| Gemini | long-context and external source synthesis |
+| DeepSeek | adversarial logic and cheap second opinion |
+
+Consensus is not the criterion. The output is useful only when it changes the
+spec, test plan, or risk boundary.
+
+## Law 2
+
+Law 2 is a cleartext-output boundary for every LLM in the system.
+
+Client PII, raw OSINT, credentials, passports, KTP, NPWP, and WhatsApp raw data
+must not be transcribed or persisted in cleartext inside prompts saved for
+reuse, logs, reports, skills, memories, alerts, or shared artifacts. Use IDs,
+hashes, placeholders, and redaction.
+
+This is not Hermes-specific and not Codex-specific.
+
+## Worktree Rule
+
+When Codex mutates the Nuzantara repo, work in a dedicated worktree:
+
+```bash
+python scripts/agent_start.py --lane ops --task-id <slug>
+cd .worktrees/ops-<slug>
+codex-nz-core exec "task..."
+```
+
+The main checkout is for the operator and emergency hotfixes.
+
+## Experience Bridge
+
+At the end of material work, produce a redacted trajectory candidate for Skill
+Coach:
+
+```json
+{
+  "agent": "codex",
+  "machine": "Air-M5|Pro|Mini",
+  "organ": "backend-rag|mouth|agent-library|ops|research",
+  "outcome": "success|failed|blocked",
+  "verification": ["command or observable evidence"],
+  "files_touched": ["repo-relative paths"],
+  "law2_status": "redacted|not_applicable",
+  "candidate_learning": "short reusable lesson"
+}
+```
+
+Skill Coach may propose a skill/scar. Genome accepts it only after shadow
+evaluation and the normal human gate.
+
+## Anti-Pattern
+
+Do not clone the full Claude Code startup behavior into Codex.
+
+Claude Code taught us useful patterns: skills, scars, memory, hooks. Codex
+should steal the principles, not inherit the startup noise.

--- a/research/operations/2026-06-16-codex-55-xhigh-configuration-architecture.md
+++ b/research/operations/2026-06-16-codex-55-xhigh-configuration-architecture.md
@@ -1,0 +1,430 @@
+# Codex 5.5 XHigh Configuration Architecture - Nuzantara
+
+Date: 2026-06-16
+Scope: Codex desktop/CLI configuration, Nuzantara agent operating model, Symbiosis/Genome/Cell integration.
+Status: Final research spec with first operational controls armed.
+
+## Executive Decision
+
+Do not make Codex "bigger" by loading more prompt, hooks, and plugins at startup.
+
+The strongest architecture is:
+
+1. Keep Codex 5.5 xhigh as the high-agency reasoning cell.
+2. Keep startup context small and clean.
+3. Move operational intelligence into on-demand skills, profiles, MCP tools, and Genome/Skill Coach feedback.
+4. Treat successful Codex work as experience that can become a Nuzantara skill proposal.
+5. Keep noisy hooks out of the user surface.
+
+The target is not "Codex replaces Claude Code" and not "Hermes replaces the organism".
+The target is: Codex becomes a disciplined Nuzantara cell that can work, verify, and feed learnings back into Symbiosis/Genome.
+
+## Grounding Sources
+
+Official Codex sources consulted:
+
+- Codex configuration reference: https://developers.openai.com/codex/config-reference
+- Codex advanced configuration and profiles: https://developers.openai.com/codex/config-advanced
+- Codex best practices: https://developers.openai.com/codex/learn/best-practices
+- Codex AGENTS.md behavior: https://developers.openai.com/codex/guides/agents-md
+- Codex hooks: https://developers.openai.com/codex/hooks
+- Codex skills: https://developers.openai.com/codex/skills
+- Codex plugins: https://developers.openai.com/codex/plugins
+- Codex subagents: https://developers.openai.com/codex/subagents
+- Codex import from other agents: https://developers.openai.com/codex/import
+
+Official Claude Code sources consulted:
+
+- Claude Code skills: https://code.claude.com/docs/en/skills
+- Claude Code memory: https://code.claude.com/docs/en/memory
+- Claude Code settings: https://docs.anthropic.com/en/docs/claude-code/settings
+- Claude Code hooks: https://docs.anthropic.com/en/docs/claude-code/hooks
+
+Local Nuzantara sources consulted:
+
+- `/Users/balizero/.codex/config.toml`
+- `/Users/balizero/.codex/*.config.toml`
+- `/Users/balizero/.codex/hooks.json`
+- `/Users/balizero/.claude/settings.json`
+- `/Users/balizero/Desktop/nuzantara/AGENTS.md`
+- `/Users/balizero/Desktop/nuzantara/SYMBIOSIS.md`
+- `/Users/balizero/Desktop/nuzantara/VADEMECUM.md`
+- `research/operations/2026-05-21-codex-best-config-audit.md`
+- `research/operations/2026-06-04-codex-orchestrator-map.md`
+- `research/operations/2026-06-06-sota-agentic-dev-workflow.md`
+- `research/operations/2026-06-09-dev-ai-stack-additions-4llm-panel.md`
+- `agent-library/learn/README.md`
+
+No local secrets are reproduced in this document.
+
+## Current State
+
+Codex local state is already powerful:
+
+- Base model: `gpt-5.5`
+- Reasoning effort: `xhigh`
+- Verbosity: low
+- Auto compact token limit: 140k
+- Sandbox: danger-full-access
+- Approval policy: never
+- Enabled capabilities include hooks, memories, plugins, apps, browser, computer use, multi-agent, and workspace dependencies.
+- User profiles already exist: `cheap`, `standard`, `spark`, `power`, `max`.
+
+The important problem is not lack of power.
+The problem is control surface and startup load.
+
+Observed noise/control issues:
+
+- Current Codex session shows skill-description compression because too many plugin skills are visible in the 2 percent skill context budget.
+- User explicitly rejected noisy SessionStart/UserPromptSubmit/Stop output.
+- SessionStart/UserPromptSubmit/Stop are now disabled in both Codex and Claude user hook configs.
+- The old global Codex `AGENTS.md` is stale relative to Air-M5 thin-client reality and model naming.
+- The project `.codex/` directory is local and not versioned, so repository architecture cannot depend on it as source of truth.
+
+Observed good state:
+
+- Repo `AGENTS.md` contains the corrected Law 2 boundary.
+- `SYMBIOSIS.md` already defines the organism model: successes produce skills, failures produce scars.
+- `VADEMECUM.md` already defines Cell/Genome patterns for agents.
+- `agent-library/learn` already implements the safe half of learning: propose-only, shadow-first, human-gated.
+- Skill Coach already exists as the right ingestion/evolution organ.
+
+## Key Finding
+
+The best Hermes idea is not "more tools".
+It is "competence accumulation".
+
+For Nuzantara this maps cleanly:
+
+```mermaid
+flowchart LR
+    A["Codex task"] --> B["Verification evidence"]
+    B --> C["Redacted experience event"]
+    C --> D["Experience trajectory"]
+    D --> E["Skill Coach"]
+    E --> F["Proposal only"]
+    F --> G["Shadow evaluation"]
+    G --> H["Human gate"]
+    H --> I["Genome skill / scar"]
+```
+
+This keeps Codex operationally powerful while letting Nuzantara own memory, learning, and governance.
+
+## Architecture Principles
+
+### 1. Short Startup, Deep On Demand
+
+Codex should not load the entire organism into startup context.
+
+Startup context should answer:
+
+- Where am I?
+- What safety boundary applies?
+- What source of truth should I read next?
+- Which profile am I using?
+- Which organ owns this work?
+
+Everything else should be pulled on demand through:
+
+- AGENTS hierarchy
+- Skills
+- MCP tools
+- Repo docs
+- Genome/Skill Coach
+- Official web/docs when information is fresh or external
+
+### 2. Profiles, Not One Monster Config
+
+Codex profiles are the right place to encode operating modes.
+
+Recommended profile families:
+
+| Profile | Purpose | Default surface |
+| --- | --- | --- |
+| `nuzantara-core` | Normal high-quality coding and architecture work | GPT-5.5 xhigh, low verbosity, large compaction, project docs raised |
+| `nuzantara-research` | Deep research, review, architecture synthesis | GPT-5.5 xhigh, medium verbosity, clean CLI by default |
+| `nuzantara-operator` | Local machine operations with full trust | Current full-access behavior, explicit use only |
+| `nuzantara-creative` | Canva/presentation/content work | Creative plugins visible, lower code pressure |
+| `nuzantara-business` | Gmail/calendar/Drive/sheets work | Business connectors visible, no repo mutation by default |
+
+This avoids one permanently overloaded session.
+
+### 3. Hook Output Must Be Quiet
+
+Hooks can guard, enrich, and route.
+Hooks must not narrate unless there is an actionable block.
+
+Allowed:
+
+- Silent validation
+- Deterministic JSON-valid block
+- Short `statusMessage` only when useful
+- PostToolUse event capture into local files/queues
+
+Disallowed:
+
+- Long SessionStart dumps
+- Repeated Stop warnings when user is not asking about git state
+- Invalid hook JSON
+- Hook output that looks like assistant output
+
+User-facing rule:
+
+> Codex output is the assistant output. Hook output is machine telemetry and must stay out of the conversational surface unless it blocks action.
+
+### 4. AGENTS.md Becomes A Router
+
+Official Codex behavior combines global AGENTS plus project AGENTS chain, with a default project document byte budget.
+
+Current risk:
+
+- The global user AGENTS is large and stale.
+- The project AGENTS is very large and may exceed the default document budget.
+- Important late-file rules can be truncated.
+
+Target:
+
+- `~/.codex/AGENTS.md`: personal/router layer, max roughly 120 lines.
+- Repo root `AGENTS.md`: project constitution, still concise.
+- Directory-level AGENTS files: local rules for `apps/backend-rag`, `apps/mouth`, `agent-library`, `research`.
+- Long reference material moves to linked docs.
+
+Stopgap:
+
+- Raise `project_doc_max_bytes` in Nuzantara profiles to 65536 so current repo rules are not silently truncated.
+
+Final target:
+
+- Shrink root docs so the raised byte budget is a safety net, not a crutch.
+
+### 5. Skills Are The Operational Cortex
+
+Codex skills are progressive disclosure: the list is visible, full instructions load only when selected.
+
+The current warning means the visible catalog is too broad.
+
+Target:
+
+- Keep local Nuzantara skills concise and high-signal.
+- Avoid enabling all broad plugin skills in the default high-agency coding session.
+- Use profile-specific plugin surfaces for research, creative, business, and security work.
+- Turn repeated successful workflows into Nuzantara-owned skills, not ad-hoc prompt bloat.
+
+Nuzantara skill acceptance criteria:
+
+- Clear trigger
+- Short description
+- Exact tool boundaries
+- Law 2 redaction rule
+- Verification command or observable evidence
+- Failure mode and fallback
+- Metrics
+
+### 6. Codex Is A Cell, Not The Genome
+
+Codex should not own long-term identity, governance, or organism memory.
+
+Codex should:
+
+- Execute tasks.
+- Verify observable results.
+- Emit clean experience summaries.
+- Propose learnings.
+- Call Genome/Skill Coach when the work pattern repeats.
+
+Symbiosis/Genome should:
+
+- Store durable skills and scars.
+- Govern inheritance.
+- Silence stale skills.
+- Share safe operational knowledge through `cell:skills`.
+- Prevent raw client/OSINT leakage.
+
+This is exactly the Hermes principle, but implemented inside Nuzantara's existing organs.
+
+## Law 2 For Codex
+
+Correct Law 2 is not "no LLM may ever see context".
+
+Correct Law 2 is:
+
+> For every LLM in the system, do not transcribe or persist client PII/OSINT in cleartext in outputs, memories, skills, logs, reports, alerts, prompts saved for reuse, or shared artifacts. Use IDs, hashes, placeholders, or redaction. Raw OSINT mirror remains Pro-bound.
+
+Implication:
+
+- Codex can reason over authorized operational context.
+- Codex must not leak raw identifiers into durable artifacts.
+- Skill Coach must ingest redacted trajectories, not raw transcripts.
+- Research/spec docs must talk about process and architecture, not client facts.
+
+## Recommended Codex Profiles
+
+Two opt-in profile files were created outside the repo:
+
+- `/Users/balizero/.codex/nuzantara-core.config.toml`
+- `/Users/balizero/.codex/nuzantara-research.config.toml`
+
+They are intentionally conservative:
+
+- They do not modify the default profile.
+- They do not copy secrets.
+- They do not alter plugin credentials.
+- They raise `project_doc_max_bytes` as a stopgap for the large current Nuzantara AGENTS chain.
+- They disable broad plugins by default because the current plugin marketplace cache emits noisy warnings in `codex exec`.
+
+Suggested usage:
+
+```bash
+codex --profile nuzantara-core
+codex --profile nuzantara-research
+```
+
+For non-interactive smoke tests, suppress Rust warning noise:
+
+```bash
+RUST_LOG=error codex exec --profile nuzantara-core --sandbox read-only --ephemeral "Reply exactly: OK"
+```
+
+Verified on 2026-06-17:
+
+- `nuzantara-core` loads `gpt-5.5`, `xhigh`, `plugins=false`, `plugin_hooks=false`.
+- `nuzantara-research` loads `gpt-5.5`, `xhigh`, `plugins=false`, `plugin_hooks=false`.
+- Plugin hook dumps disappeared after disabling broad plugins.
+- Local skill YAML load errors disappeared after quoting three local skill descriptions.
+- Remaining CLI banner is Codex native output, not a hook failure.
+
+Operational artifacts added on 2026-06-17:
+
+- Health checker: `scripts/ops/codex_config_health.py`
+- Health checker tests: `tests/scripts/test_codex_config_health.py`
+- Profile runbook: `docs/runbooks/codex-nuzantara-profiles.md`
+- Local wrappers: `/Users/balizero/.local/bin/codex-nz-core` and `/Users/balizero/.local/bin/codex-nz-research`
+
+## Implementation Plan
+
+### P0 - Already Done
+
+- Disable noisy SessionStart/UserPromptSubmit/Stop hook classes in user configs.
+- Keep Stop hook noise out of the user-facing loop.
+- Keep current base Codex 5.5 xhigh capability.
+
+### P1 - This Spec
+
+- Capture final architecture decision in repo research.
+- Add opt-in Codex profiles for Nuzantara work.
+- Do not mutate the live default.
+
+### P2 - Global Codex AGENTS Cleanup
+
+Replace `/Users/balizero/.codex/AGENTS.md` with a compact router.
+
+Recommended sections:
+
+1. Machine and language.
+2. Read project AGENTS first.
+3. Law 2 output boundary.
+4. Worktree discipline.
+5. No hook noise.
+6. Use profiles.
+7. Use skills on demand.
+8. Verify before claiming completion.
+
+Remove from global AGENTS:
+
+- Stale Air decommissioning language.
+- Claude-specific model names as Codex routing.
+- Large project internals that belong in repo docs.
+- Long API/provider policy detail that can live in linked references.
+
+### P3 - Project AGENTS Split
+
+Keep root repo AGENTS authoritative but shorter.
+
+Candidate split:
+
+- `AGENTS.md`: constitution and routing.
+- `apps/backend-rag/AGENTS.md`: backend rules.
+- `apps/mouth/AGENTS.md`: frontend rules.
+- `agent-library/AGENTS.md`: skills/scars/learn rules.
+- `research/AGENTS.md`: spec/research format.
+
+### P4 - Codex Experience Bridge
+
+Add a Codex-to-Skill-Coach bridge:
+
+1. Detect task completion with verification evidence.
+2. Produce a redacted trajectory record.
+3. Store in the existing experience database or proposal input directory.
+4. Let Skill Coach generate proposals.
+5. Keep all application propose-only until shadow metrics pass.
+
+Minimum trajectory schema:
+
+```json
+{
+  "agent": "codex",
+  "machine": "Air-M5|Pro|Mini",
+  "repo": "nuzantara",
+  "task_id": "string",
+  "timestamp": "ISO-8601",
+  "organ": "backend-rag|mouth|agent-library|ops|research",
+  "actions": ["redacted summary"],
+  "verification": ["command or observable evidence"],
+  "files_touched": ["repo-relative paths"],
+  "law2_status": "redacted|not_applicable",
+  "outcome": "success|failed|blocked",
+  "candidate_learning": "short reusable lesson"
+}
+```
+
+### P5 - Profile Health Check
+
+Add a non-invasive health check script:
+
+- Parse TOML profiles.
+- Confirm hooks are valid JSON.
+- Confirm SessionStart/UserPromptSubmit/Stop remain disabled unless explicitly requested.
+- Count visible skill directories.
+- Report if project AGENTS exceeds configured byte budget.
+- Report whether `.codex/` project config is untracked local state.
+
+Initial implementation: `scripts/ops/codex_config_health.py`.
+
+## Verification Metrics
+
+The architecture is successful only if metrics improve.
+
+Primary metrics:
+
+- Startup hook noise: target 0 user-visible non-blocking dumps.
+- Invalid hook JSON events: target 0.
+- Skill catalog warning frequency: target near 0 in default/core profile.
+- Time to first useful action: lower than current overloaded startup.
+- Verification-before-completion rate: target 100 percent for code changes.
+- Successful trajectories captured: count per week.
+- Skill Coach proposal precision after shadow review: rising trend.
+
+Secondary metrics:
+
+- Number of tasks completed without opening irrelevant plugin surfaces.
+- Number of repeated workflows converted to skills.
+- Number of stale skills silenced by Genome.
+- Number of PII/OSINT redaction violations: target 0.
+
+## Decision
+
+Adopt Codex 5.5 xhigh as a Nuzantara cell with profile-based operating modes.
+
+Do not turn Codex into a giant always-loaded brain.
+Do not clone Claude Code configuration blindly.
+Do not import Hermes as a replacement.
+
+Use the best pattern from both Claude Code and Hermes:
+
+- Claude Code gives skill discipline, hook guardrails, and repo worktree habits.
+- Hermes gives the competence-accumulation mental model.
+- Symbiosis/Genome/Cell gives the organism-level ownership layer.
+
+Final target:
+
+> Codex executes. Skill Coach learns. Genome remembers. Symbiosis governs.

--- a/scripts/ops/codex_config_health.py
+++ b/scripts/ops/codex_config_health.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Health checks for the local Codex/Nuzantara operating profile.
+
+The checker is intentionally read-only. It validates the quiet Codex profiles,
+hook-noise policy, skill frontmatter shape, and AGENTS.md context budget without
+printing secrets or large config bodies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any, NamedTuple
+
+
+REQUIRED_MODEL = "gpt-5.5"
+REQUIRED_REASONING = "xhigh"
+MIN_PROJECT_DOC_BYTES = 65_536
+NOISY_HOOK_EVENTS = ("SessionStart", "UserPromptSubmit", "Stop")
+
+
+class Check(NamedTuple):
+    name: str
+    status: str
+    message: str
+    path: str = ""
+
+
+def make_check(name: str, status: str, message: str, path: Path | str | None = None) -> Check:
+    return Check(name=name, status=status, message=message, path=str(path or ""))
+
+
+def check_profile(
+    path: Path,
+    label: str,
+    *,
+    require_quiet_plugins: bool,
+    min_project_doc_bytes: int = MIN_PROJECT_DOC_BYTES,
+    missing_status: str = "FAIL",
+) -> list[Check]:
+    checks: list[Check] = []
+    parse_name = f"profile:{label}:parse"
+    if not path.exists():
+        return [make_check(parse_name, missing_status, "profile file is missing", path)]
+
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        return [make_check(parse_name, "FAIL", f"TOML parse error: {exc}", path)]
+
+    checks.append(make_check(parse_name, "PASS", "TOML parses", path))
+
+    model = data.get("model")
+    checks.append(
+        make_check(
+            f"profile:{label}:model",
+            "PASS" if model == REQUIRED_MODEL else "FAIL",
+            "model is gpt-5.5" if model == REQUIRED_MODEL else "model is not gpt-5.5",
+            path,
+        )
+    )
+
+    reasoning = data.get("model_reasoning_effort")
+    checks.append(
+        make_check(
+            f"profile:{label}:reasoning",
+            "PASS" if reasoning == REQUIRED_REASONING else "FAIL",
+            "reasoning effort is xhigh"
+            if reasoning == REQUIRED_REASONING
+            else "reasoning effort is not xhigh",
+            path,
+        )
+    )
+
+    project_doc_max_bytes = data.get("project_doc_max_bytes")
+    budget_ok = isinstance(project_doc_max_bytes, int) and project_doc_max_bytes >= min_project_doc_bytes
+    checks.append(
+        make_check(
+            f"profile:{label}:project_doc_budget",
+            "PASS" if budget_ok else "WARN",
+            f"project_doc_max_bytes >= {min_project_doc_bytes}"
+            if budget_ok
+            else f"project_doc_max_bytes below {min_project_doc_bytes}",
+            path,
+        )
+    )
+
+    features = data.get("features", {})
+    if not isinstance(features, dict):
+        features = {}
+    plugin_hooks = features.get("plugin_hooks")
+    plugins = features.get("plugins")
+
+    expected_status = "PASS"
+    noisy_status = "FAIL" if require_quiet_plugins else "WARN"
+    checks.append(
+        make_check(
+            f"profile:{label}:plugin_hooks",
+            expected_status if plugin_hooks is False else noisy_status,
+            "plugin_hooks disabled"
+            if plugin_hooks is False
+            else "plugin_hooks not disabled; startup hook noise can return",
+            path,
+        )
+    )
+    checks.append(
+        make_check(
+            f"profile:{label}:plugins",
+            expected_status if plugins is False else noisy_status,
+            "plugins disabled"
+            if plugins is False
+            else "plugins not disabled; plugin-provided hooks can return",
+            path,
+        )
+    )
+    return checks
+
+
+def _hook_count(value: Any) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, list):
+        return len(value)
+    return 1
+
+
+def check_hooks_file(path: Path, label: str) -> list[Check]:
+    parse_name = f"hooks:{label}:parse"
+    if not path.exists():
+        return [make_check(parse_name, "WARN", "hook config file is missing", path)]
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [make_check(parse_name, "FAIL", f"JSON parse error: {exc}", path)]
+
+    hooks = payload.get("hooks", {})
+    if not isinstance(hooks, dict):
+        return [make_check(parse_name, "FAIL", "hooks key is not an object", path)]
+
+    checks = [make_check(parse_name, "PASS", "JSON parses", path)]
+    for event in NOISY_HOOK_EVENTS:
+        count = _hook_count(hooks.get(event))
+        checks.append(
+            make_check(
+                f"hooks:{label}:{event}",
+                "PASS" if count == 0 else "FAIL",
+                "no active entries" if count == 0 else f"{count} active entries",
+                path,
+            )
+        )
+    return checks
+
+
+def _frontmatter_lines(path: Path) -> tuple[list[str], str | None]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0].strip() != "---":
+        return [], "missing opening frontmatter marker"
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            return lines[1:index], None
+    return [], "missing closing frontmatter marker"
+
+
+def check_skill_frontmatter(path: Path) -> list[Check]:
+    name = f"skill:{path.name}:frontmatter"
+    try:
+        lines, error = _frontmatter_lines(path)
+    except UnicodeDecodeError as exc:
+        return [make_check(name, "FAIL", f"cannot decode UTF-8: {exc}", path)]
+
+    if error is not None:
+        return [make_check(name, "FAIL", error, path)]
+
+    has_name = False
+    has_description = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("name:"):
+            has_name = True
+        if stripped.startswith("description:"):
+            has_description = True
+            value = stripped.partition(":")[2].strip()
+            is_block_scalar = value in {">", ">-", "|", "|-"}
+            is_quoted = (value.startswith('"') and value.endswith('"')) or (
+                value.startswith("'") and value.endswith("'")
+            )
+            if ": " in value and not is_block_scalar and not is_quoted:
+                return [
+                    make_check(
+                        name,
+                        "FAIL",
+                        "description contains an unquoted colon; use a block scalar",
+                        path,
+                    )
+                ]
+
+    if not has_name or not has_description:
+        missing = ", ".join(
+            field
+            for field, present in (("name", has_name), ("description", has_description))
+            if not present
+        )
+        return [make_check(name, "FAIL", f"missing required field(s): {missing}", path)]
+
+    return [make_check(name, "PASS", "frontmatter has name and description", path)]
+
+
+def check_skill_root(root: Path, label: str) -> list[Check]:
+    if not root.exists():
+        return [make_check(f"skills:{label}:root", "WARN", "skill root is missing", root)]
+
+    skill_files = sorted(root.glob("*/SKILL.md"))
+    if not skill_files:
+        return [make_check(f"skills:{label}:root", "WARN", "no skill files found", root)]
+
+    checks = [make_check(f"skills:{label}:root", "PASS", f"{len(skill_files)} skill files found", root)]
+    for skill_file in skill_files:
+        skill_checks = check_skill_frontmatter(skill_file)
+        for check in skill_checks:
+            checks.append(
+                make_check(
+                    f"skills:{label}:{skill_file.parent.name}:frontmatter",
+                    check.status,
+                    check.message,
+                    skill_file,
+                )
+            )
+    return checks
+
+
+def check_agents_budget(path: Path, label: str, *, budget_bytes: int) -> list[Check]:
+    name = f"agents:{label}:budget"
+    if not path.exists():
+        return [make_check(name, "WARN", "AGENTS.md is missing", path)]
+
+    size = path.stat().st_size
+    status = "PASS" if size <= budget_bytes else "WARN"
+    return [
+        make_check(
+            name,
+            status,
+            f"{size} bytes within {budget_bytes} byte budget"
+            if status == "PASS"
+            else f"{size} bytes exceeds {budget_bytes} byte budget",
+            path,
+        )
+    ]
+
+
+def find_repo_root(start: Path) -> Path:
+    current = start.resolve()
+    for parent in (current, *current.parents):
+        if (parent / ".git").exists() or (parent / "AGENTS.md").exists():
+            return parent
+    return current
+
+
+def run_checks(repo_root: Path, home: Path) -> list[Check]:
+    profile_specs = (
+        ("nuzantara-core", home / ".codex" / "nuzantara-core.config.toml", True, "FAIL"),
+        ("nuzantara-research", home / ".codex" / "nuzantara-research.config.toml", True, "FAIL"),
+        ("nuzantara-toolful", home / ".codex" / "nuzantara-toolful.config.toml", False, "WARN"),
+    )
+
+    checks: list[Check] = []
+    for label, path, require_quiet_plugins, missing_status in profile_specs:
+        checks.extend(
+            check_profile(
+                path,
+                label,
+                require_quiet_plugins=require_quiet_plugins,
+                missing_status=missing_status,
+            )
+        )
+
+    checks.extend(check_hooks_file(home / ".codex" / "hooks.json", "codex"))
+    checks.extend(check_hooks_file(home / ".claude" / "settings.json", "claude"))
+
+    checks.extend(check_skill_root(home / ".agents" / "skills", "home-agents"))
+    checks.extend(check_skill_root(home / ".codex" / "skills", "home-codex"))
+    checks.extend(check_skill_root(repo_root / ".agents" / "skills", "repo"))
+
+    checks.extend(check_agents_budget(home / ".codex" / "AGENTS.md", "home-codex", budget_bytes=MIN_PROJECT_DOC_BYTES))
+    checks.extend(check_agents_budget(repo_root / "AGENTS.md", "repo", budget_bytes=MIN_PROJECT_DOC_BYTES))
+
+    return checks
+
+
+def checks_to_json(checks: list[Check]) -> str:
+    return json.dumps([check._asdict() for check in checks], indent=2, sort_keys=True)
+
+
+def print_text_report(checks: list[Check]) -> None:
+    for check in checks:
+        location = f" [{check.path}]" if check.path else ""
+        print(f"{check.status} {check.name}: {check.message}{location}")
+
+    fail_count = sum(1 for check in checks if check.status == "FAIL")
+    warn_count = sum(1 for check in checks if check.status == "WARN")
+    pass_count = sum(1 for check in checks if check.status == "PASS")
+    summary_status = "FAIL" if fail_count else "WARN" if warn_count else "PASS"
+    print(f"SUMMARY status={summary_status} pass={pass_count} warn={warn_count} fail={fail_count}")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Check local Codex/Nuzantara profile health.")
+    parser.add_argument("--repo-root", type=Path, default=None, help="Repository root. Defaults to auto-detect.")
+    parser.add_argument("--home", type=Path, default=Path.home(), help="Home directory to inspect.")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    parser.add_argument(
+        "--allow-warnings",
+        action="store_true",
+        help="Exit 0 when only warnings are present. Failures still exit 1.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    repo_root = args.repo_root or find_repo_root(Path.cwd())
+    checks = run_checks(repo_root.resolve(), args.home.expanduser().resolve())
+
+    if args.json:
+        print(checks_to_json(checks))
+    else:
+        print_text_report(checks)
+
+    has_failure = any(check.status == "FAIL" for check in checks)
+    has_warning = any(check.status == "WARN" for check in checks)
+    if has_failure:
+        return 1
+    if has_warning and not args.allow_warnings:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_codex_config_health.py
+++ b/tests/scripts/test_codex_config_health.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ops" / "codex_config_health.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("codex_config_health", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def statuses(checks):
+    return {check.name: check.status for check in checks}
+
+
+def test_clean_profile_requires_quiet_plugins(tmp_path: Path) -> None:
+    module = load_module()
+    profile = tmp_path / "nuzantara-core.config.toml"
+    profile.write_text(
+        '\n'.join(
+            [
+                'model = "gpt-5.5"',
+                'model_reasoning_effort = "xhigh"',
+                'project_doc_max_bytes = 65536',
+                '',
+                '[features]',
+                'plugins = false',
+                'plugin_hooks = false',
+                '',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = statuses(module.check_profile(profile, "nuzantara-core", require_quiet_plugins=True))
+
+    assert result["profile:nuzantara-core:parse"] == "PASS"
+    assert result["profile:nuzantara-core:model"] == "PASS"
+    assert result["profile:nuzantara-core:reasoning"] == "PASS"
+    assert result["profile:nuzantara-core:plugin_hooks"] == "PASS"
+    assert result["profile:nuzantara-core:plugins"] == "PASS"
+
+
+def test_noisy_profile_fails_clean_plugin_policy(tmp_path: Path) -> None:
+    module = load_module()
+    profile = tmp_path / "nuzantara-research.config.toml"
+    profile.write_text(
+        '\n'.join(
+            [
+                'model = "gpt-5.5"',
+                'model_reasoning_effort = "xhigh"',
+                'project_doc_max_bytes = 65536',
+                '',
+                '[features]',
+                'plugins = true',
+                'plugin_hooks = true',
+                '',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = statuses(module.check_profile(profile, "nuzantara-research", require_quiet_plugins=True))
+
+    assert result["profile:nuzantara-research:plugin_hooks"] == "FAIL"
+    assert result["profile:nuzantara-research:plugins"] == "FAIL"
+
+
+def test_hook_noise_is_reported(tmp_path: Path) -> None:
+    module = load_module()
+    hooks = tmp_path / "hooks.json"
+    hooks.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "SessionStart": [{"hooks": [{"command": "echo noisy"}]}],
+                    "UserPromptSubmit": [],
+                    "Stop": [{"hooks": [{"command": "echo blocked"}]}],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = statuses(module.check_hooks_file(hooks, "codex"))
+
+    assert result["hooks:codex:SessionStart"] == "FAIL"
+    assert result["hooks:codex:UserPromptSubmit"] == "PASS"
+    assert result["hooks:codex:Stop"] == "FAIL"
+
+
+def test_skill_frontmatter_accepts_block_scalar_description(tmp_path: Path) -> None:
+    module = load_module()
+    skill = tmp_path / "SKILL.md"
+    skill.write_text(
+        """---
+name: example
+description: >-
+  Use when a description needs colon: value text.
+---
+
+# Example
+""",
+        encoding="utf-8",
+    )
+
+    checks = module.check_skill_frontmatter(skill)
+
+    assert statuses(checks)["skill:SKILL.md:frontmatter"] == "PASS"
+
+
+def test_skill_frontmatter_rejects_unquoted_colon_description(tmp_path: Path) -> None:
+    module = load_module()
+    skill = tmp_path / "SKILL.md"
+    skill.write_text(
+        """---
+name: example
+description: Use when this breaks: yaml scanners in Codex.
+---
+
+# Example
+""",
+        encoding="utf-8",
+    )
+
+    checks = module.check_skill_frontmatter(skill)
+
+    assert statuses(checks)["skill:SKILL.md:frontmatter"] == "FAIL"
+
+
+def test_agents_budget_warns_when_doc_exceeds_budget(tmp_path: Path) -> None:
+    module = load_module()
+    agents = tmp_path / "AGENTS.md"
+    agents.write_text("x" * 12, encoding="utf-8")
+
+    checks = module.check_agents_budget(agents, "repo", budget_bytes=10)
+
+    assert statuses(checks)["agents:repo:budget"] == "WARN"
+
+
+def test_optional_profile_missing_is_warning(tmp_path: Path) -> None:
+    module = load_module()
+    checks = module.check_profile(
+        tmp_path / "missing.config.toml",
+        "nuzantara-toolful",
+        require_quiet_plugins=False,
+        missing_status="WARN",
+    )
+
+    assert statuses(checks)["profile:nuzantara-toolful:parse"] == "WARN"


### PR DESCRIPTION
## Summary

- add a read-only Codex/Nuzantara config health checker for profiles, quiet hooks, skill frontmatter, and AGENTS.md budget
- document the Codex profile operating model, council trigger, Law 2 output boundary, and Skill Coach trajectory handoff
- record the first armed controls in the Codex 5.5 xhigh research spec

## Why

This turns the Hermes lesson into a Nuzantara-native control: Codex stays clean and focused, while reusable learning is routed to Skill Coach/Genome instead of bloating startup context.

## Validation

- `/Users/balizero/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m pytest tests/scripts/test_codex_config_health.py -q`
- `/Users/balizero/Desktop/nuzantara/apps/backend-rag/.venv/bin/python scripts/ops/codex_config_health.py --allow-warnings`
- `/Users/balizero/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m py_compile scripts/ops/codex_config_health.py`
- `git diff --check`
- `/Users/balizero/.local/bin/codex-nz-core --version`
- `/Users/balizero/.local/bin/codex-nz-research --version`

## Notes

`nuzantara-toolful` is intentionally reported as a warning because the connector-heavy profile is not armed yet.
