### PR TITLE
fix(cron): repair auto_test venv selection + NB-11/12/13 fallback IDs

### DIFF
--- a/apps/evaluator/nlm_deep_research/db_nlm_state.py
+++ b/apps/evaluator/nlm_deep_research/db_nlm_state.py
@@ -26,9 +26,9 @@ _DEFAULT_LOCK_PATH: Path = _DIR / "db_nlm_sync.lock"
 
 # --- Notebook IDs (populated after creation via `nlm notebook create`) ---
 # These will be set on first run or via CLI args.
-NB_OPS_ID: str = ""       # NB-11: Bali Zero Ops Live
-NB_INTEL_ID: str = ""      # NB-12: Bali Zero Business Intelligence
-NB_TELEMETRY_ID: str = ""  # NB-13: Bali Zero System Telemetry
+NB_OPS_ID: str = "2072e518-e6f9-437d-93ea-f9037ec54052"       # NB-11: Bali Zero Ops Live
+NB_INTEL_ID: str = "5c2c3d90-eed2-4755-86b1-269e637e51e1"      # NB-12: Bali Zero Business Intelligence
+NB_TELEMETRY_ID: str = "53441d9e-fb11-44cc-8dd8-4d70637b651f"  # NB-13: Bali Zero System Telemetry
 
 # --- Source slots per notebook ---
 MAX_SOURCES_PER_NB: int = 15

--- a/apps/evaluator/nlm_deep_research/ops_intelligence.py
+++ b/apps/evaluator/nlm_deep_research/ops_intelligence.py
@@ -49,19 +49,29 @@ ANOMALY_THRESHOLD_PCT = 25.0
 # ── NB IDs ────────────────────────────────────────────────────────────────────
 
 def _load_nb_ids() -> dict[str, str]:
-    """Load NB-11/12/13 IDs from db_nlm_sync state."""
+    """Load NB-11/12/13 IDs from db_nlm_sync state, falling back to the
+    committed defaults in db_nlm_state when the runtime state file is absent
+    or a key is blank. The state file is gitignored runtime state and may
+    not exist on a fresh checkout, so the committed constants are the
+    source of truth for which notebooks to query."""
+    from apps.evaluator.nlm_deep_research import db_nlm_state as _dbs
+    defaults = {
+        "ops": _dbs.NB_OPS_ID,
+        "intel": _dbs.NB_INTEL_ID,
+        "telemetry": _dbs.NB_TELEMETRY_ID,
+    }
     if not _SYNC_STATE_FILE.exists():
-        return {}
+        return dict(defaults)
     try:
         state = json.loads(_SYNC_STATE_FILE.read_text())
         return {
-            "ops": state.get("nb_ops_id", ""),        # NB-11
-            "intel": state.get("nb_intel_id", ""),    # NB-12
-            "telemetry": state.get("nb_telemetry_id", ""),  # NB-13
+            "ops": state.get("nb_ops_id", "") or defaults["ops"],
+            "intel": state.get("nb_intel_id", "") or defaults["intel"],
+            "telemetry": state.get("nb_telemetry_id", "") or defaults["telemetry"],
         }
     except Exception as exc:
         logger.error("Failed to load NB IDs from sync state: %s", exc)
-        return {}
+        return dict(defaults)
 
 
 # ── Telegram ──────────────────────────────────────────────────────────────────

--- a/scripts/auto_test.sh
+++ b/scripts/auto_test.sh
@@ -48,12 +48,14 @@ export OLLAMA_MODEL="${OLLAMA_MODEL:-qwen2.5:latest}"
 log "--- Phase 1: Agent pytest suite ---"
 cd "$BACKEND_DIR" || exit 1
 # Activate virtualenv for pytest — use full path as fallback for cron
-# Prefer venv (Python 3.11, has pytest) over .venv (Python 3.13, no pytest)
+# The backend venv is .venv (Python 3.11.11, has pytest); legacy venv/ no longer exists.
+# Use the .venv/bin/python symlink (version-agnostic) so a future minor bump can't break this.
 if [ -d "$BACKEND_DIR/venv" ] && "$BACKEND_DIR/venv/bin/python" -c "import pytest" 2>/dev/null; then
     source "$BACKEND_DIR/venv/bin/activate" 2>/dev/null || true
     PYTEST_CMD=("$BACKEND_DIR/venv/bin/python" "-m" "pytest")
-elif [ -d "$BACKEND_DIR/.venv" ] && "$BACKEND_DIR/.venv/bin/python3.13" -c "import pytest" 2>/dev/null; then
-    PYTEST_CMD=("$BACKEND_DIR/.venv/bin/python3.13" "-m" "pytest")
+elif [ -d "$BACKEND_DIR/.venv" ] && "$BACKEND_DIR/.venv/bin/python" -c "import pytest" 2>/dev/null; then
+    source "$BACKEND_DIR/.venv/bin/activate" 2>/dev/null || true
+    PYTEST_CMD=("$BACKEND_DIR/.venv/bin/python" "-m" "pytest")
 else
     PYTEST_CMD=("python3" "-m" "pytest")
 fi


### PR DESCRIPTION
## Last orphan-code branch from the reconciliation audit

Surgical promotion of the only real net-new **code** branch left across M5/Pro/Mini after tonight's cleanup (`worktree-agent-aee35df3c7d7711bd` on Pro, 1 commit, never opened as a PR). Cherry-picked clean onto current `origin/main`.

### Fix
- **`scripts/auto_test.sh`** — the venv selector hardcoded `.venv/bin/python3.13`, a path that no longer exists (backend venv is Python 3.11). The cron's pytest path was dead. **Bug still live on main** (`auto_test.sh:55-56`, verified). Fixed to the version-agnostic `.venv/bin/python` symlink + `source activate`, so a future minor bump can't re-break it.
- **`apps/evaluator/nlm_deep_research/{db_nlm_state,ops_intelligence}.py`** — wire NB-11/12/13 default IDs as fallback when the sync-state file is missing.

### Verified live on M5
`python3.13` dead path gone (0 residual), both `.py` AST-valid, `auto_test.sh` `bash -n` clean. Diff: 3 files, `+24/-12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)