### PR TITLE
fix(wr2): reproducible .venv-wr2-html setup — arm HTML renderer after worktree re-add

### DIFF
--- a/docs/runbooks/wr2-html-cutover.md
+++ b/docs/runbooks/wr2-html-cutover.md
@@ -19,6 +19,8 @@ HTML/CSS→PNG, uploads to Drive, and notifies Antonello+Damar over WhatsApp (24
    `scripts/wr2_html_renderer/*`, `infra/launchagents/com.balizero.wr2.html-apply.plist`
    present in `~/Desktop/nuzantara-deploy`.
 3. Pro-local venv `~/Desktop/nuzantara-deploy/.venv-wr2-html` exists; `--selftest` OK.
+   **If missing** (it evaporates on every deploy-worktree re-add — scar W81/html-venv):
+   `bash scripts/setup_wr2_html_venv.sh` recreates it reproducibly (~3-5 min), then re-run `--selftest`.
 4. SHADOW run done on a throwaway draft, Drive output inspected by hand.
 
 ## SHADOW run (safe — no WA, no status flip to real)

--- a/scripts/setup_wr2_html_venv.sh
+++ b/scripts/setup_wr2_html_venv.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Reproducible setup for the WR2 HTML renderer venv (.venv-wr2-html).
+#
+# WHY THIS EXISTS (scar W81 / html-venv-evaporation):
+#   The deploy worktree (~/Desktop/nuzantara-deploy) is periodically re-added
+#   (git worktree add) which restores only tracked files. Venvs are gitignored,
+#   so .venv-wr2-html evaporates on every re-add and the html-apply worker dies
+#   with "No such file or directory: .../.venv-wr2-html/bin/python".
+#   The backend venv self-heals (wr2-script-wrapper.sh), but the html venv had
+#   no equivalent. This script is that equivalent — idempotent, re-run anytime.
+#
+# Deps: render (playwright + cached chromium), vision (claude CLI, in PATH),
+#       OCR (easyocr), AND the backend.* import chain the Drive uploader pulls
+#       (backend/services/integrations/__init__ → zoho → metrics → psutil, +
+#       config → pydantic/pydantic-settings, + google-api). Installed via the
+#       backend's own requirements-prod.txt (minus the editable cell-core line,
+#       which is DNA-recording, unused by the renderer, and unresolvable here).
+set -euo pipefail
+REPO="${WR2_REPO_ROOT:-$HOME/Desktop/nuzantara-deploy}"
+PYENV_PY="${PYENV_PY311:-$HOME/.pyenv/versions/3.11.11/bin/python}"
+VENV="$REPO/.venv-wr2-html"
+VPY="$VENV/bin/python"
+REQ="$REPO/apps/backend-rag/requirements-prod.txt"
+
+[ -x "$PYENV_PY" ] || { echo "ERROR: pyenv 3.11.11 not found at $PYENV_PY" >&2; exit 75; }
+[ -f "$REQ" ]      || { echo "ERROR: requirements-prod.txt not found at $REQ" >&2; exit 75; }
+
+echo "[setup-html-venv] creating $VENV"
+"$PYENV_PY" -m venv "$VENV"
+"$VPY" -m pip install -q --upgrade pip
+
+echo "[setup-html-venv] installing backend prod deps (cell-core editable stripped)"
+FILTERED="$(mktemp)"
+grep -vE "^-e |cell-core" "$REQ" > "$FILTERED"
+"$VPY" -m pip install -q -r "$FILTERED" || true   # torch/setuptools cosmetic conflict is non-fatal
+rm -f "$FILTERED"
+
+echo "[setup-html-venv] installing renderer-only deps (playwright/easyocr not in prod reqs)"
+"$VPY" -m pip install -q playwright easyocr
+
+echo "[setup-html-venv] verifying full import chain"
+cd "$REPO"
+"$VPY" - <<PYEOF
+import sys
+sys.path.insert(0, "$REPO/apps/backend-rag"); sys.path.insert(0, "$REPO/scripts")
+from backend.services.integrations.service_account_drive_service import ServiceAccountDriveService
+import playwright, easyocr, psutil, numpy, PIL, asyncpg, pydantic, pydantic_settings
+from playwright.sync_api import sync_playwright
+print("[setup-html-venv] OK: render + vision + OCR + Drive-uploader import chain all resolve")
+PYEOF
+echo "[setup-html-venv] DONE"


### PR DESCRIPTION
## Problem
WR2 HTML renderer (html-apply worker) **dead since ~29 May**. Pipeline frozen at `success_rate=0%`, `pipeline_frozen` alert firing every minute (27k+ log lines), 14 `render_failed` drafts. No carousels produced for ~3 weeks despite 40 "green" LaunchAgents.

## Root cause (scar W81 / venv-evaporation, HOME-fork family)
The deploy worktree (`~/Desktop/nuzantara-deploy`) is periodically re-added (`git worktree add`), which restores only tracked files. **Venvs are gitignored → `.venv-wr2-html` evaporates on every re-add**, and the worker dies with `No such file or directory: .../.venv-wr2-html/bin/python`. The backend venv self-heals (`wr2-script-wrapper.sh`); the html venv had **no equivalent**.

Secondary: the Drive uploader pulls the full `backend.*` import chain (`integrations/__init__` → zoho → metrics → `psutil`; `config` → pydantic; drive → google-api), which a bare playwright venv lacks.

## Fix
`scripts/setup_wr2_html_venv.sh` — idempotent, reproducible venv recreation. Installs render+vision+OCR deps **plus** the backend `requirements-prod.txt` (minus the editable `cell-core` line — DNA-recording, unused by the renderer, unresolvable from a worktree). Verifies the full import chain. Runbook step 3 now points at it.

## Verified live on Pro (this session)
- `--selftest` OK (chromium launches + DB reachable + kill_switch=True)
- Stuck draft `7c1f4e62` **rendered to a real Drive folder** (`1u_AWCHY...`), slides + logo uploaded, `status=rendered`
- **No WhatsApp sent** — 24h window closed → messages enqueued only (C6 behaviour correct, Legge 5 respected)

## Notes / follow-up (not in this PR)
- The cutover itself was already 90% armed (route→html-apply, canva off, kill-switch ON, mig-222). This PR closes the last-mile (venv durability).
- The deploy worktree was found GONE mid-session (repaired via `git worktree add`); repairing it wiped the backend venv too (will self-heal on next worker run).
- Consider wiring the html venv into an auto-heal block in the html-apply plist `ProgramArguments` (like the backend wrapper) — deferred, plist is a sensitive surface.
- Cicatrix scar entry to be appended (html-venv-evaporation, family #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)