### PR TITLE
feat(whatsapp-corpus): ZANTARA Captain depth-stack — decision-chain + captain shadow + operator packets

### DIFF
--- a/docs/superpowers/plans/2026-06-16-zantara-captain-depth-stack.md
+++ b/docs/superpowers/plans/2026-06-16-zantara-captain-depth-stack.md
@@ -1,0 +1,116 @@
+# Zantara Captain Depth Stack Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the local-only Captain pipeline with five Client Captain depth layers, plus Team Captain and Owner Captain artifacts with progressively deeper aggregate reasoning layers.
+
+**Architecture:** Client Captain remains the per-case shadow runtime and writes five deterministic depth layers per draft. Team Captain reads the local client shadow DB and aggregates operator/team coaching into six layers per specialist lane. Owner Captain reads the local team and client shadow DBs and writes seven owner-level governance layers without raw message text, WhatsApp sends, CRM mutations, or cloud LLM calls.
+
+**Tech Stack:** Python 3, SQLite, pytest, local ignored artifacts under `research/personal/wa-corpus/`.
+
+---
+
+### Task 1: Client Captain Depth Layers
+
+**Files:**
+
+- Modify: `scripts/whatsapp_corpus/build_client_captain_shadow.py`
+- Modify: `scripts/tests/test_whatsapp_corpus_client_captain_shadow.py`
+
+- [x] **Step 1: Write the failing test**
+
+Assert that each client shadow draft writes five `shadow_depth_layers` rows with levels 1..5.
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=. pytest -q scripts/tests/test_whatsapp_corpus_client_captain_shadow.py`
+Expected: FAIL because `shadow_depth_layers` does not exist.
+
+- [x] **Step 3: Write minimal implementation**
+
+Add deterministic layer generation:
+
+1. signal readout
+2. diagnosis
+3. decision
+4. draft gate
+5. operator coaching
+
+- [x] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=. pytest -q scripts/tests/test_whatsapp_corpus_client_captain_shadow.py`
+Expected: PASS.
+
+### Task 2: Team Captain Shadow Artifact
+
+**Files:**
+
+- Create: `scripts/whatsapp_corpus/build_team_captain_shadow.py`
+- Create: `scripts/tests/test_whatsapp_corpus_team_captain_shadow.py`
+- Modify: `scripts/whatsapp_corpus/README.md`
+
+- [x] **Step 1: Write the failing test**
+
+Create a small client shadow DB, run Team Captain, and assert one team finding per specialist lane plus six depth layers per finding.
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=. pytest -q scripts/tests/test_whatsapp_corpus_team_captain_shadow.py`
+Expected: FAIL because module is missing.
+
+- [x] **Step 3: Write minimal implementation**
+
+Read `client_captain_shadow.local.sqlite`, group by specialist lane, write `team_captain_findings` and `team_captain_depth_layers`.
+
+- [x] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=. pytest -q scripts/tests/test_whatsapp_corpus_team_captain_shadow.py`
+Expected: PASS.
+
+### Task 3: Owner Captain Shadow Artifact
+
+**Files:**
+
+- Create: `scripts/whatsapp_corpus/build_owner_captain_shadow.py`
+- Create: `scripts/tests/test_whatsapp_corpus_owner_captain_shadow.py`
+- Modify: `scripts/whatsapp_corpus/README.md`
+
+- [x] **Step 1: Write the failing test**
+
+Create client and team shadow DBs, run Owner Captain, and assert one owner finding plus seven depth layers.
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=. pytest -q scripts/tests/test_whatsapp_corpus_owner_captain_shadow.py`
+Expected: FAIL because module is missing.
+
+- [x] **Step 3: Write minimal implementation**
+
+Read aggregate-safe client/team shadow DBs, write `owner_captain_findings` and `owner_captain_depth_layers`.
+
+- [x] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=. pytest -q scripts/tests/test_whatsapp_corpus_owner_captain_shadow.py`
+Expected: PASS.
+
+### Task 4: Real Generation and Verification
+
+**Files:**
+
+- Runtime outputs under `/Users/nuzantara/Desktop/nuzantara/research/personal/wa-corpus/drive-*`
+
+- [x] **Step 1: Sync code to Pro worktree**
+
+Use rsync for the changed scripts/tests/README into `/Users/nuzantara/Desktop/nuzantara/.worktrees/backend-rag-zantara-client-captain-academy`.
+
+- [x] **Step 2: Run targeted tests on Pro**
+
+Run the Client, Team, Owner, Academy, Drive import, review manifest, and privacy audit tests.
+
+- [x] **Step 3: Generate real Team and Owner artifacts**
+
+Run Team Captain and Owner Captain against the full Drive Client Shadow DB.
+
+- [x] **Step 4: Audit privacy and count outputs**
+
+Run `audit_privacy_outputs.py` on the new summary/output directories and query SQLite counts.

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+MIN_TEST_NOFILE_LIMIT = 4096
+
+
+def pytest_configure(config: object) -> None:
+    _ = config
+    try:
+        import resource
+    except ImportError:
+        return
+
+    try:
+        soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+    except (OSError, ValueError):
+        return
+
+    target_limit = min(max(soft_limit, MIN_TEST_NOFILE_LIMIT), hard_limit)
+    if target_limit <= soft_limit:
+        return
+
+    try:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (target_limit, hard_limit))
+    except (OSError, ValueError):
+        return

--- a/scripts/tests/test_whatsapp_corpus_approval_routing_queue.py
+++ b/scripts/tests/test_whatsapp_corpus_approval_routing_queue.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.whatsapp_corpus.build_approval_routing_queue import (
+    build_approval_routing_queue,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_approval_routing_queue.py"
+
+
+def _write_owner_brief_renderer_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE owner_brief_renderer_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_case_count INTEGER NOT NULL,
+                owner_item_count INTEGER NOT NULL,
+                pack_count INTEGER NOT NULL,
+                brief_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE owner_briefs (
+                brief_id TEXT PRIMARY KEY,
+                pack_id TEXT NOT NULL,
+                case_card_id TEXT NOT NULL,
+                brief_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                decision_priority TEXT NOT NULL,
+                brief_title TEXT NOT NULL,
+                owner_focus TEXT NOT NULL,
+                recommended_decision TEXT NOT NULL,
+                draft_action_type TEXT NOT NULL,
+                safety_lock TEXT NOT NULL,
+                approval_status TEXT NOT NULL,
+                brief_markdown TEXT NOT NULL,
+                brief_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO owner_brief_renderer_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_case_count, owner_item_count, pack_count, brief_count,
+                send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, 4, 2, 2, 2, 0, 0)
+            """,
+            (
+                "2026-06-17T16:00:00+00:00",
+                "2026-06-17T15:00:00+00:00",
+                "local_only_owner_brief_no_raw_text_no_send_no_crm_mutation",
+            ),
+        )
+        rows = [
+            (
+                "owner-brief-followup",
+                "owner-pack-followup",
+                "card-owner-followup",
+                1,
+                "sahira",
+                "approve_client_recovery_followup",
+                "now",
+                "Client recovery follow-up approval",
+                "review_client_recovery_language",
+                "approve_recovery_followup_after_review",
+                "owner_review_client_followup_draft",
+                "owner_approval_required_no_send_no_crm",
+                "pending_owner_review",
+                "# Client recovery follow-up approval\n\nPriority: now\nLane: sahira\n",
+            ),
+            (
+                "owner-brief-status",
+                "owner-pack-status",
+                "card-owner-status",
+                2,
+                "ari",
+                "approve_immigration_status_escalation",
+                "now",
+                "Immigration status escalation approval",
+                "review_immigration_status_escalation",
+                "approve_status_escalation_after_review",
+                "owner_review_status_escalation_draft",
+                "owner_approval_required_no_send_no_crm",
+                "pending_owner_review",
+                "# Immigration status escalation approval\n\nPriority: now\nLane: ari\n",
+            ),
+        ]
+        conn.executemany(
+            """
+            INSERT INTO owner_briefs (
+                brief_id, pack_id, case_card_id, brief_rank, assigned_lane,
+                decision_type, decision_priority, brief_title, owner_focus,
+                recommended_decision, draft_action_type, safety_lock,
+                approval_status, brief_markdown, brief_payload_json,
+                send_whatsapp, crm_mutation, requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 1)
+            """,
+            [
+                (
+                    *row,
+                    json.dumps(
+                        {
+                            "schema_version": "owner_brief_renderer.v1",
+                            "raw_text_included": False,
+                            "send_whatsapp": False,
+                            "crm_mutation": False,
+                            "requires_human_approval": True,
+                        },
+                        sort_keys=True,
+                    ),
+                )
+                for row in rows
+            ],
+        )
+        conn.commit()
+
+
+def test_build_approval_routing_queue_writes_owner_queue(
+    tmp_path: Path,
+) -> None:
+    owner_briefs_db = tmp_path / "owner_brief_renderer.local.sqlite"
+    output_dir = tmp_path / "approval-routing-queue"
+    summary_path = output_dir / "approval_routing_queue_summary.md"
+    _write_owner_brief_renderer_db(owner_briefs_db)
+
+    result = build_approval_routing_queue(
+        owner_briefs_db=owner_briefs_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+        generated_at_utc="2026-06-17T17:00:00+00:00",
+    )
+
+    assert result.source_case_count == 4
+    assert result.owner_item_count == 2
+    assert result.pack_count == 2
+    assert result.brief_count == 2
+    assert result.queue_item_count == 2
+    assert result.output_db == output_dir / "approval_routing_queue.local.sqlite"
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.decision_type_counts == {
+        "approve_client_recovery_followup": 1,
+        "approve_immigration_status_escalation": 1,
+    }
+    assert result.lane_counts == {"sahira": 1, "ari": 1}
+    assert result.route_bucket_counts == {"owner_now": 2}
+
+    with sqlite3.connect(result.output_db) as conn:
+        routes = conn.execute(
+            """
+            SELECT case_card_id, brief_id, pack_id, route_rank, assigned_lane,
+                   decision_type, decision_priority, owner_focus, route_bucket,
+                   next_actor, queue_status, allowed_decisions_json,
+                   recommended_decision, draft_action_type, safety_lock,
+                   approval_status, send_whatsapp, crm_mutation,
+                   requires_human_approval, route_payload_json
+            FROM approval_routing_items
+            ORDER BY route_rank
+            """
+        ).fetchall()
+        run = conn.execute(
+            """
+            SELECT source_case_count, owner_item_count, pack_count, brief_count,
+                   queue_item_count, now_count, send_whatsapp_count,
+                   crm_mutation_count
+            FROM approval_routing_queue_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+
+    assert run == (4, 2, 2, 2, 2, 2, 0, 0)
+    assert routes[0][0:11] == (
+        "card-owner-followup",
+        "owner-brief-followup",
+        "owner-pack-followup",
+        1,
+        "sahira",
+        "approve_client_recovery_followup",
+        "now",
+        "review_client_recovery_language",
+        "owner_now",
+        "owner",
+        "waiting_owner_decision",
+    )
+    assert json.loads(routes[0][11]) == ["approve", "reject", "defer"]
+    assert routes[0][12:19] == (
+        "approve_recovery_followup_after_review",
+        "owner_review_client_followup_draft",
+        "owner_approval_required_no_send_no_crm",
+        "pending_owner_review",
+        0,
+        0,
+        1,
+    )
+    assert routes[1][0:11] == (
+        "card-owner-status",
+        "owner-brief-status",
+        "owner-pack-status",
+        2,
+        "ari",
+        "approve_immigration_status_escalation",
+        "now",
+        "review_immigration_status_escalation",
+        "owner_now",
+        "owner",
+        "waiting_owner_decision",
+    )
+    assert json.loads(routes[1][11]) == ["approve", "reject", "defer"]
+
+    payload = json.loads(routes[0][19])
+    assert payload["schema_version"] == "approval_routing_queue.v1"
+    assert payload["privacy_mode"] == "local_only_approval_routing_no_raw_text"
+    assert payload["allowed_decisions"] == ["approve", "reject", "defer"]
+    assert payload["owner_action_required"] is True
+    assert payload["raw_text_included"] is False
+    assert payload["send_whatsapp"] is False
+    assert payload["crm_mutation"] is False
+    assert payload["requires_human_approval"] is True
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Approval Routing Queue Summary" in summary
+    assert "| Source cases | 4 |" in summary
+    assert "| Owner briefs | 2 |" in summary
+    assert "| Queue items | 2 |" in summary
+    assert "| WhatsApp sends | 0 |" in summary
+    assert "| CRM mutations | 0 |" in summary
+    assert "card-owner-followup" not in summary
+    assert "card-owner-status" not in summary
+    assert "owner-brief-followup" not in summary
+    assert "owner-brief-status" not in summary
+    assert "owner-pack-followup" not in summary
+    assert "owner-pack-status" not in summary
+
+
+def test_build_approval_routing_queue_rejects_unexpected_input_name(
+    tmp_path: Path,
+) -> None:
+    unexpected_db = tmp_path / "owner_decision_packs.local.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    with pytest.raises(
+        ValueError,
+        match="Refusing to read unexpected Owner Brief Renderer DB",
+    ):
+        build_approval_routing_queue(
+            owner_briefs_db=unexpected_db,
+            output_dir=tmp_path / "approval-routing-queue",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_cli_writes_json_without_route_details(tmp_path: Path) -> None:
+    owner_briefs_db = tmp_path / "owner_brief_renderer.local.sqlite"
+    output_dir = tmp_path / "approval-routing-queue"
+    summary_path = output_dir / "approval_routing_queue_summary.md"
+    _write_owner_brief_renderer_db(owner_briefs_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--owner-briefs-db",
+            str(owner_briefs_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--generated-at-utc",
+            "2026-06-17T17:00:00+00:00",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "brief_count": 2,
+        "crm_mutation_count": 0,
+        "owner_item_count": 2,
+        "pack_count": 2,
+        "queue_item_count": 2,
+        "send_whatsapp_count": 0,
+        "source_case_count": 4,
+    }
+    assert "card-owner-followup" not in result.stdout
+    assert "card-owner-status" not in result.stdout
+    assert "owner-brief-followup" not in result.stdout
+    assert "owner-brief-status" not in result.stdout
+    assert "owner-pack-followup" not in result.stdout
+    assert "owner-pack-status" not in result.stdout

--- a/scripts/tests/test_whatsapp_corpus_approve_reject_ledger.py
+++ b/scripts/tests/test_whatsapp_corpus_approve_reject_ledger.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.whatsapp_corpus.build_approve_reject_ledger import (
+    build_approve_reject_ledger,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_approve_reject_ledger.py"
+
+
+def _write_approval_routing_queue_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE approval_routing_queue_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_case_count INTEGER NOT NULL,
+                owner_item_count INTEGER NOT NULL,
+                pack_count INTEGER NOT NULL,
+                brief_count INTEGER NOT NULL,
+                queue_item_count INTEGER NOT NULL,
+                now_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE approval_routing_items (
+                route_id TEXT PRIMARY KEY,
+                case_card_id TEXT NOT NULL,
+                brief_id TEXT NOT NULL,
+                pack_id TEXT NOT NULL,
+                route_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                decision_priority TEXT NOT NULL,
+                owner_focus TEXT NOT NULL,
+                route_bucket TEXT NOT NULL,
+                next_actor TEXT NOT NULL,
+                queue_status TEXT NOT NULL,
+                allowed_decisions_json TEXT NOT NULL,
+                recommended_decision TEXT NOT NULL,
+                draft_action_type TEXT NOT NULL,
+                safety_lock TEXT NOT NULL,
+                approval_status TEXT NOT NULL,
+                route_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO approval_routing_queue_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_case_count, owner_item_count, pack_count, brief_count,
+                queue_item_count, now_count, send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, 4, 2, 2, 2, 2, 2, 0, 0)
+            """,
+            (
+                "2026-06-17T17:00:00+00:00",
+                "2026-06-17T16:00:00+00:00",
+                "local_only_approval_routing_no_raw_text_no_send_no_crm_mutation",
+            ),
+        )
+        rows = [
+            (
+                "approval-route-followup",
+                "card-owner-followup",
+                "owner-brief-followup",
+                "owner-pack-followup",
+                1,
+                "sahira",
+                "approve_client_recovery_followup",
+                "now",
+                "review_client_recovery_language",
+                "owner_now",
+                "owner",
+                "waiting_owner_decision",
+                "approve_recovery_followup_after_review",
+                "owner_review_client_followup_draft",
+                "owner_approval_required_no_send_no_crm",
+                "pending_owner_review",
+            ),
+            (
+                "approval-route-status",
+                "card-owner-status",
+                "owner-brief-status",
+                "owner-pack-status",
+                2,
+                "ari",
+                "approve_immigration_status_escalation",
+                "now",
+                "review_immigration_status_escalation",
+                "owner_now",
+                "owner",
+                "waiting_owner_decision",
+                "approve_status_escalation_after_review",
+                "owner_review_status_escalation_draft",
+                "owner_approval_required_no_send_no_crm",
+                "pending_owner_review",
+            ),
+        ]
+        conn.executemany(
+            """
+            INSERT INTO approval_routing_items (
+                route_id, case_card_id, brief_id, pack_id, route_rank,
+                assigned_lane, decision_type, decision_priority, owner_focus,
+                route_bucket, next_actor, queue_status, allowed_decisions_json,
+                recommended_decision, draft_action_type, safety_lock,
+                approval_status, route_payload_json, send_whatsapp, crm_mutation,
+                requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 1)
+            """,
+            [
+                (
+                    *row[0:12],
+                    json.dumps(["approve", "reject", "defer"]),
+                    row[12],
+                    row[13],
+                    row[14],
+                    row[15],
+                    json.dumps(
+                        {
+                            "schema_version": "approval_routing_queue.v1",
+                            "raw_text_included": False,
+                            "send_whatsapp": False,
+                            "crm_mutation": False,
+                            "requires_human_approval": True,
+                        },
+                        sort_keys=True,
+                    ),
+                )
+                for row in rows
+            ],
+        )
+        conn.commit()
+
+
+def test_build_approve_reject_ledger_writes_pending_decision_slots(
+    tmp_path: Path,
+) -> None:
+    approval_routing_db = tmp_path / "approval_routing_queue.local.sqlite"
+    output_dir = tmp_path / "approve-reject-ledger"
+    summary_path = output_dir / "approve_reject_ledger_summary.md"
+    _write_approval_routing_queue_db(approval_routing_db)
+
+    result = build_approve_reject_ledger(
+        approval_routing_db=approval_routing_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+        generated_at_utc="2026-06-17T18:00:00+00:00",
+    )
+
+    assert result.source_case_count == 4
+    assert result.owner_item_count == 2
+    assert result.pack_count == 2
+    assert result.brief_count == 2
+    assert result.queue_item_count == 2
+    assert result.ledger_entry_count == 2
+    assert result.pending_decision_count == 2
+    assert result.output_db == output_dir / "approve_reject_ledger.local.sqlite"
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.decision_status_counts == {"awaiting_owner_decision": 2}
+    assert result.owner_decision_counts == {"pending": 2}
+    assert result.event_type_counts == {"decision_slot_opened": 2}
+    assert result.route_bucket_counts == {"owner_now": 2}
+
+    with sqlite3.connect(result.output_db) as conn:
+        entries = conn.execute(
+            """
+            SELECT case_card_id, route_id, brief_id, pack_id, ledger_rank,
+                   assigned_lane, decision_type, decision_priority, route_bucket,
+                   next_actor, queue_status, decision_status, owner_decision,
+                   allowed_decisions_json, recommended_decision, draft_action_type,
+                   immutable_event_type, send_whatsapp, crm_mutation,
+                   requires_human_approval, ledger_entry_hash, ledger_payload_json
+            FROM approve_reject_ledger_entries
+            ORDER BY ledger_rank
+            """
+        ).fetchall()
+        run = conn.execute(
+            """
+            SELECT source_case_count, owner_item_count, pack_count, brief_count,
+                   queue_item_count, ledger_entry_count, pending_decision_count,
+                   send_whatsapp_count, crm_mutation_count
+            FROM approve_reject_ledger_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+
+    assert run == (4, 2, 2, 2, 2, 2, 2, 0, 0)
+    assert entries[0][0:13] == (
+        "card-owner-followup",
+        "approval-route-followup",
+        "owner-brief-followup",
+        "owner-pack-followup",
+        1,
+        "sahira",
+        "approve_client_recovery_followup",
+        "now",
+        "owner_now",
+        "owner",
+        "waiting_owner_decision",
+        "awaiting_owner_decision",
+        "pending",
+    )
+    assert json.loads(entries[0][13]) == ["approve", "reject", "defer"]
+    assert entries[0][14:20] == (
+        "approve_recovery_followup_after_review",
+        "owner_review_client_followup_draft",
+        "decision_slot_opened",
+        0,
+        0,
+        1,
+    )
+    assert entries[1][0:13] == (
+        "card-owner-status",
+        "approval-route-status",
+        "owner-brief-status",
+        "owner-pack-status",
+        2,
+        "ari",
+        "approve_immigration_status_escalation",
+        "now",
+        "owner_now",
+        "owner",
+        "waiting_owner_decision",
+        "awaiting_owner_decision",
+        "pending",
+    )
+    assert json.loads(entries[1][13]) == ["approve", "reject", "defer"]
+
+    entry_hash = entries[0][20]
+    assert len(entry_hash) == 64
+    int(entry_hash, 16)
+
+    payload = json.loads(entries[0][21])
+    assert payload["schema_version"] == "approve_reject_ledger.v1"
+    assert payload["privacy_mode"] == "local_only_approve_reject_ledger_no_raw_text"
+    assert payload["source_route_rank"] == 1
+    assert payload["source_queue_status"] == "waiting_owner_decision"
+    assert payload["decision_status"] == "awaiting_owner_decision"
+    assert payload["owner_decision"] == "pending"
+    assert payload["allowed_decisions"] == ["approve", "reject", "defer"]
+    assert payload["immutable_event_type"] == "decision_slot_opened"
+    assert payload["raw_text_included"] is False
+    assert payload["send_whatsapp"] is False
+    assert payload["crm_mutation"] is False
+    assert payload["requires_human_approval"] is True
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Approve/Reject Ledger Summary" in summary
+    assert "| Source cases | 4 |" in summary
+    assert "| Queue items | 2 |" in summary
+    assert "| Ledger entries | 2 |" in summary
+    assert "| Pending owner decisions | 2 |" in summary
+    assert "| WhatsApp sends | 0 |" in summary
+    assert "| CRM mutations | 0 |" in summary
+    assert "card-owner-followup" not in summary
+    assert "card-owner-status" not in summary
+    assert "approval-route-followup" not in summary
+    assert "approval-route-status" not in summary
+    assert "owner-brief-followup" not in summary
+    assert "owner-pack-followup" not in summary
+
+
+def test_build_approve_reject_ledger_rejects_unexpected_input_name(
+    tmp_path: Path,
+) -> None:
+    unexpected_db = tmp_path / "owner_brief_renderer.local.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    with pytest.raises(
+        ValueError,
+        match="Refusing to read unexpected Approval Routing Queue DB",
+    ):
+        build_approve_reject_ledger(
+            approval_routing_db=unexpected_db,
+            output_dir=tmp_path / "approve-reject-ledger",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_cli_writes_json_without_ledger_details(tmp_path: Path) -> None:
+    approval_routing_db = tmp_path / "approval_routing_queue.local.sqlite"
+    output_dir = tmp_path / "approve-reject-ledger"
+    summary_path = output_dir / "approve_reject_ledger_summary.md"
+    _write_approval_routing_queue_db(approval_routing_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--approval-routing-db",
+            str(approval_routing_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--generated-at-utc",
+            "2026-06-17T18:00:00+00:00",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "brief_count": 2,
+        "crm_mutation_count": 0,
+        "ledger_entry_count": 2,
+        "owner_item_count": 2,
+        "pack_count": 2,
+        "pending_decision_count": 2,
+        "queue_item_count": 2,
+        "send_whatsapp_count": 0,
+        "source_case_count": 4,
+    }
+    assert "card-owner-followup" not in result.stdout
+    assert "card-owner-status" not in result.stdout
+    assert "approval-route-followup" not in result.stdout
+    assert "approval-route-status" not in result.stdout
+    assert "owner-brief-followup" not in result.stdout
+    assert "owner-pack-followup" not in result.stdout

--- a/scripts/tests/test_whatsapp_corpus_breach_war_room.py
+++ b/scripts/tests/test_whatsapp_corpus_breach_war_room.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.whatsapp_corpus.build_breach_war_room import build_breach_war_room
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_breach_war_room.py"
+
+
+def _write_operator_sla_clock_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE operator_sla_clock_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_inbox_generated_at_utc TEXT NOT NULL,
+                as_of_utc TEXT NOT NULL,
+                inbox_item_count INTEGER NOT NULL,
+                clock_count INTEGER NOT NULL,
+                overdue_count INTEGER NOT NULL,
+                breach_risk_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE operator_sla_clock (
+                inbox_item_id TEXT PRIMARY KEY,
+                case_card_id TEXT NOT NULL,
+                queue_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                priority_label TEXT NOT NULL,
+                queue_bucket TEXT NOT NULL,
+                action_code TEXT NOT NULL,
+                reason_code TEXT NOT NULL,
+                sla_minutes INTEGER NOT NULL,
+                source_inbox_generated_at_utc TEXT NOT NULL,
+                due_at_utc TEXT NOT NULL,
+                as_of_utc TEXT NOT NULL,
+                minutes_until_due INTEGER NOT NULL,
+                aging_minutes INTEGER NOT NULL,
+                sla_status TEXT NOT NULL,
+                breach_risk TEXT NOT NULL,
+                escalation_label TEXT NOT NULL,
+                clock_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO operator_sla_clock_runs VALUES (
+                1, '2026-06-17T14:00:00+00:00',
+                'local_only_operator_sla_clock_no_raw_text_no_send_no_crm_mutation',
+                '2026-06-17T08:00:00+00:00',
+                '2026-06-17T14:00:00+00:00',
+                4, 4, 1, 2, 0, 0
+            )
+            """
+        )
+        rows = [
+            (
+                "inbox-breached",
+                "case-breached",
+                4,
+                "sahira",
+                "now",
+                "follow_up_now",
+                "crm_followup",
+                "stale_followup",
+                240,
+                "2026-06-17T08:00:00+00:00",
+                "2026-06-17T12:00:00+00:00",
+                "2026-06-17T14:00:00+00:00",
+                -120,
+                360,
+                "overdue",
+                "breached",
+                "owner_review",
+                json.dumps(
+                    {
+                        "schema_version": "operator_sla_clock.v1",
+                        "raw_text_included": False,
+                        "send_whatsapp": False,
+                        "crm_mutation": False,
+                    },
+                    sort_keys=True,
+                ),
+                0,
+                0,
+                1,
+            ),
+            (
+                "inbox-high",
+                "case-high",
+                1,
+                "ari",
+                "now",
+                "status_check_now",
+                "immigration_status_check",
+                "status_stale",
+                240,
+                "2026-06-17T08:00:00+00:00",
+                "2026-06-17T12:00:00+00:00",
+                "2026-06-17T14:00:00+00:00",
+                45,
+                360,
+                "due_today",
+                "high",
+                "lane_lead_watch",
+                json.dumps(
+                    {
+                        "schema_version": "operator_sla_clock.v1",
+                        "raw_text_included": False,
+                        "send_whatsapp": False,
+                        "crm_mutation": False,
+                    },
+                    sort_keys=True,
+                ),
+                0,
+                0,
+                1,
+            ),
+            (
+                "inbox-medium",
+                "case-medium",
+                2,
+                "adit",
+                "today",
+                "document_gap_today",
+                "document_chase",
+                "document_gap",
+                1440,
+                "2026-06-17T08:00:00+00:00",
+                "2026-06-18T08:00:00+00:00",
+                "2026-06-17T14:00:00+00:00",
+                1080,
+                360,
+                "due_today",
+                "medium",
+                "operator_watch",
+                json.dumps(
+                    {
+                        "schema_version": "operator_sla_clock.v1",
+                        "raw_text_included": False,
+                        "send_whatsapp": False,
+                        "crm_mutation": False,
+                    },
+                    sort_keys=True,
+                ),
+                0,
+                0,
+                1,
+            ),
+            (
+                "inbox-low",
+                "case-low",
+                3,
+                "surya",
+                "next",
+                "finance_next",
+                "payment_reconcile",
+                "payment_risk",
+                4320,
+                "2026-06-17T08:00:00+00:00",
+                "2026-06-20T08:00:00+00:00",
+                "2026-06-17T14:00:00+00:00",
+                3960,
+                360,
+                "scheduled",
+                "low",
+                "none",
+                json.dumps(
+                    {
+                        "schema_version": "operator_sla_clock.v1",
+                        "raw_text_included": False,
+                        "send_whatsapp": False,
+                        "crm_mutation": False,
+                    },
+                    sort_keys=True,
+                ),
+                0,
+                0,
+                1,
+            ),
+        ]
+        conn.executemany(
+            """
+            INSERT INTO operator_sla_clock VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            """,
+            rows,
+        )
+        conn.commit()
+
+
+def test_build_breach_war_room_filters_and_orders_hot_clocks(
+    tmp_path: Path,
+) -> None:
+    sla_db = tmp_path / "operator_sla_clock.local.sqlite"
+    output_dir = tmp_path / "breach-war-room"
+    summary_path = output_dir / "breach_war_room_summary.md"
+    _write_operator_sla_clock_db(sla_db)
+
+    result = build_breach_war_room(
+        operator_sla_clock_db=sla_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+        generated_at_utc="2026-06-17T14:05:00+00:00",
+    )
+
+    assert result.clock_count == 4
+    assert result.room_item_count == 2
+    assert result.output_db == output_dir / "breach_war_room.local.sqlite"
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.severity_counts == {"critical": 1, "hot": 1}
+    assert result.lane_counts == {"sahira": 1, "ari": 1}
+
+    with sqlite3.connect(result.output_db) as conn:
+        rows = conn.execute(
+            """
+            SELECT room_item_id, inbox_item_id, case_card_id, war_room_rank,
+                   assigned_lane, action_code, breach_risk, sla_status,
+                   severity_band, command_channel, decision_gate,
+                   send_whatsapp, crm_mutation, requires_human_approval,
+                   war_room_payload_json
+            FROM breach_war_room
+            ORDER BY war_room_rank
+            """
+        ).fetchall()
+
+    critical = rows[0]
+    hot = rows[1]
+    assert critical[0:11] == (
+        "war-room-000001",
+        "inbox-breached",
+        "case-breached",
+        1,
+        "sahira",
+        "crm_followup",
+        "breached",
+        "overdue",
+        "critical",
+        "owner_war_room",
+        "owner_review_required",
+    )
+    assert hot[0:11] == (
+        "war-room-000002",
+        "inbox-high",
+        "case-high",
+        2,
+        "ari",
+        "immigration_status_check",
+        "high",
+        "due_today",
+        "hot",
+        "lane_hot_queue",
+        "lane_lead_review_required",
+    )
+    assert {row[11] for row in rows} == {0}
+    assert {row[12] for row in rows} == {0}
+    assert {row[13] for row in rows} == {1}
+    payload = json.loads(critical[14])
+    assert payload["schema_version"] == "breach_war_room.v1"
+    assert payload["raw_text_included"] is False
+    assert payload["send_whatsapp"] is False
+    assert payload["crm_mutation"] is False
+    assert payload["requires_human_approval"] is True
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Breach War Room Summary" in summary
+    assert "| SLA clocks reviewed | 4 |" in summary
+    assert "| War room items | 2 |" in summary
+    assert "| WhatsApp sends | 0 |" in summary
+    assert "| CRM mutations | 0 |" in summary
+    assert "inbox-breached" not in summary
+    assert "case-breached" not in summary
+
+
+def test_build_breach_war_room_rejects_unexpected_input_name(
+    tmp_path: Path,
+) -> None:
+    unexpected_db = tmp_path / "operator_action_inbox.local.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    with pytest.raises(ValueError, match="Refusing to read unexpected SLA Clock DB"):
+        build_breach_war_room(
+            operator_sla_clock_db=unexpected_db,
+            output_dir=tmp_path / "breach-war-room",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_cli_writes_json_without_raw_case_details(tmp_path: Path) -> None:
+    sla_db = tmp_path / "operator_sla_clock.local.sqlite"
+    output_dir = tmp_path / "breach-war-room"
+    summary_path = output_dir / "breach_war_room_summary.md"
+    _write_operator_sla_clock_db(sla_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--operator-sla-clock-db",
+            str(sla_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--generated-at-utc",
+            "2026-06-17T14:05:00+00:00",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["clock_count"] == 4
+    assert payload["room_item_count"] == 2
+    assert payload["send_whatsapp_count"] == 0
+    assert payload["crm_mutation_count"] == 0
+    assert "inbox-breached" not in result.stdout
+    assert "case-breached" not in result.stdout

--- a/scripts/tests/test_whatsapp_corpus_case_closure_judge.py
+++ b/scripts/tests/test_whatsapp_corpus_case_closure_judge.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.whatsapp_corpus.build_case_closure_judge import (
+    build_case_closure_judge,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_case_closure_judge.py"
+
+
+def _write_evidence_gaps_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE evidence_gap_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                case_count INTEGER NOT NULL,
+                gap_count INTEGER NOT NULL,
+                closure_blocker_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE evidence_gaps (
+                gap_id TEXT PRIMARY KEY,
+                case_card_id TEXT NOT NULL,
+                gap_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                primary_action TEXT NOT NULL,
+                timeline_status TEXT NOT NULL,
+                highest_risk TEXT NOT NULL,
+                blocker_code TEXT NOT NULL,
+                gap_code TEXT NOT NULL,
+                gap_category TEXT NOT NULL,
+                gap_severity TEXT NOT NULL,
+                closure_blocker INTEGER NOT NULL CHECK (closure_blocker = 1),
+                resolution_gate TEXT NOT NULL,
+                gap_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO evidence_gap_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                case_count, gap_count, closure_blocker_count,
+                send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, 3, 3, 3, 0, 0)
+            """,
+            (
+                "2026-06-17T11:00:00+00:00",
+                "2026-06-17T10:10:00+00:00",
+                "local_only_evidence_gap_no_raw_text_no_send_no_crm_mutation",
+            ),
+        )
+        rows = [
+            (
+                "gap-owner",
+                "card-owner",
+                1,
+                "sahira",
+                "crm_followup",
+                "war_room_active",
+                "P1",
+                "case_stall_followup_risk",
+                "client_followup_confirmation_missing",
+                "client_response",
+                "urgent",
+                "owner_review_required",
+            ),
+            (
+                "gap-doc",
+                "card-doc",
+                2,
+                "adit",
+                "document_chase",
+                "operator_due_today",
+                "P2",
+                "document_gap_today",
+                "required_document_evidence_missing",
+                "document",
+                "medium",
+                "operator_upload_required",
+            ),
+            (
+                "gap-lane",
+                "card-lane",
+                3,
+                "ari",
+                "immigration_status_check",
+                "operator_due_today",
+                "P2",
+                "immigration_status_gap",
+                "immigration_status_evidence_missing",
+                "status",
+                "medium",
+                "lane_review_required",
+            ),
+        ]
+        conn.executemany(
+            """
+            INSERT INTO evidence_gaps (
+                gap_id, case_card_id, gap_rank, assigned_lane, primary_action,
+                timeline_status, highest_risk, blocker_code, gap_code,
+                gap_category, gap_severity, closure_blocker, resolution_gate,
+                gap_payload_json, send_whatsapp, crm_mutation,
+                requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, 0, 0, 1)
+            """,
+            [
+                (
+                    *row,
+                    json.dumps(
+                        {
+                            "schema_version": "evidence_gap_detector.v1",
+                            "raw_text_included": False,
+                        },
+                        sort_keys=True,
+                    ),
+                )
+                for row in rows
+            ],
+        )
+        conn.commit()
+
+
+def test_build_case_closure_judge_writes_case_judgments(tmp_path: Path) -> None:
+    evidence_gaps_db = tmp_path / "evidence_gaps.local.sqlite"
+    output_dir = tmp_path / "case-closure-judge"
+    summary_path = output_dir / "case_closure_judge_summary.md"
+    _write_evidence_gaps_db(evidence_gaps_db)
+
+    result = build_case_closure_judge(
+        evidence_gaps_db=evidence_gaps_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+        generated_at_utc="2026-06-17T12:00:00+00:00",
+    )
+
+    assert result.case_count == 3
+    assert result.blocked_count == 3
+    assert result.ready_to_close_count == 0
+    assert result.output_db == output_dir / "case_closure_judge.local.sqlite"
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.status_counts == {
+        "owner_review_blocked": 1,
+        "evidence_upload_blocked": 1,
+        "lane_review_blocked": 1,
+    }
+
+    with sqlite3.connect(result.output_db) as conn:
+        judgments = conn.execute(
+            """
+            SELECT case_card_id, judgment_rank, assigned_lane, primary_action,
+                   closure_status, closure_blocker_count, top_gap_code,
+                   top_gap_category, top_gap_severity, resolution_gate,
+                   owner_attention_required, operator_evidence_required,
+                   lane_review_required, send_whatsapp, crm_mutation,
+                   requires_human_approval, judge_payload_json
+            FROM case_closure_judgments
+            ORDER BY judgment_rank
+            """
+        ).fetchall()
+        run = conn.execute(
+            """
+            SELECT case_count, blocked_count, ready_to_close_count,
+                   owner_review_count, operator_evidence_count,
+                   lane_review_count, send_whatsapp_count, crm_mutation_count
+            FROM case_closure_judge_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+
+    assert run == (3, 3, 0, 1, 1, 1, 0, 0)
+    assert judgments[0][0:13] == (
+        "card-owner",
+        1,
+        "sahira",
+        "crm_followup",
+        "owner_review_blocked",
+        1,
+        "client_followup_confirmation_missing",
+        "client_response",
+        "urgent",
+        "owner_review_required",
+        1,
+        0,
+        0,
+    )
+    assert judgments[1][0:13] == (
+        "card-doc",
+        2,
+        "adit",
+        "document_chase",
+        "evidence_upload_blocked",
+        1,
+        "required_document_evidence_missing",
+        "document",
+        "medium",
+        "operator_upload_required",
+        0,
+        1,
+        0,
+    )
+    assert judgments[2][0:13] == (
+        "card-lane",
+        3,
+        "ari",
+        "immigration_status_check",
+        "lane_review_blocked",
+        1,
+        "immigration_status_evidence_missing",
+        "status",
+        "medium",
+        "lane_review_required",
+        0,
+        0,
+        1,
+    )
+    assert {row[13] for row in judgments} == {0}
+    assert {row[14] for row in judgments} == {0}
+    assert {row[15] for row in judgments} == {1}
+
+    payload = json.loads(judgments[0][16])
+    assert payload["schema_version"] == "case_closure_judge.v1"
+    assert payload["raw_text_included"] is False
+    assert payload["closure_decision"] == "blocked"
+    assert payload["send_whatsapp"] is False
+    assert payload["crm_mutation"] is False
+    assert payload["requires_human_approval"] is True
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Case Closure Judge Summary" in summary
+    assert "| Cases judged | 3 |" in summary
+    assert "| Blocked cases | 3 |" in summary
+    assert "| Ready to close | 0 |" in summary
+    assert "| WhatsApp sends | 0 |" in summary
+    assert "| CRM mutations | 0 |" in summary
+    assert "card-owner" not in summary
+    assert "card-doc" not in summary
+    assert "card-lane" not in summary
+
+
+def test_build_case_closure_judge_rejects_unexpected_input_name(
+    tmp_path: Path,
+) -> None:
+    unexpected_db = tmp_path / "case_timelines.local.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    with pytest.raises(ValueError, match="Refusing to read unexpected Evidence Gaps DB"):
+        build_case_closure_judge(
+            evidence_gaps_db=unexpected_db,
+            output_dir=tmp_path / "case-closure-judge",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_cli_writes_json_without_case_details(tmp_path: Path) -> None:
+    evidence_gaps_db = tmp_path / "evidence_gaps.local.sqlite"
+    output_dir = tmp_path / "case-closure-judge"
+    summary_path = output_dir / "case_closure_judge_summary.md"
+    _write_evidence_gaps_db(evidence_gaps_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--evidence-gaps-db",
+            str(evidence_gaps_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--generated-at-utc",
+            "2026-06-17T12:00:00+00:00",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "blocked_count": 3,
+        "case_count": 3,
+        "crm_mutation_count": 0,
+        "output_db": str(output_dir / "case_closure_judge.local.sqlite"),
+        "ready_to_close_count": 0,
+        "send_whatsapp_count": 0,
+        "summary_path": str(summary_path),
+    }
+    assert "card-owner" not in result.stdout
+    assert "card-doc" not in result.stdout
+    assert "card-lane" not in result.stdout

--- a/scripts/tests/test_whatsapp_corpus_case_memory_cards.py
+++ b/scripts/tests/test_whatsapp_corpus_case_memory_cards.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.whatsapp_corpus.build_case_memory_cards import build_case_memory_cards
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_case_memory_cards.py"
+
+
+def _write_client_shadow_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE shadow_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                draft_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE shadow_drafts (
+                shadow_id TEXT PRIMARY KEY,
+                source_example_id TEXT NOT NULL,
+                source_replay_id TEXT NOT NULL,
+                source_window_id TEXT NOT NULL,
+                source_file_id TEXT NOT NULL,
+                case_owner TEXT NOT NULL,
+                status TEXT NOT NULL,
+                priority TEXT NOT NULL,
+                risk_level TEXT NOT NULL,
+                action_type TEXT NOT NULL,
+                human_specialist TEXT NOT NULL,
+                diagnosis_code TEXT NOT NULL,
+                draft_reply_intent TEXT NOT NULL,
+                operator_coaching_mode TEXT NOT NULL,
+                operator_nudge TEXT NOT NULL,
+                first_month TEXT NOT NULL,
+                last_month TEXT NOT NULL,
+                first_message_index INTEGER NOT NULL,
+                last_message_index INTEGER NOT NULL,
+                cut_message_index INTEGER NOT NULL,
+                dominant_domain TEXT NOT NULL,
+                event_count INTEGER NOT NULL,
+                message_count INTEGER NOT NULL,
+                domain_count INTEGER NOT NULL,
+                severity_high_count INTEGER NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE TABLE shadow_depth_layers (
+                shadow_id TEXT NOT NULL,
+                depth_level INTEGER NOT NULL,
+                layer_code TEXT NOT NULL,
+                layer_title TEXT NOT NULL,
+                layer_payload_json TEXT NOT NULL,
+                PRIMARY KEY (shadow_id, depth_level)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO shadow_runs VALUES (
+                1, '2026-06-16T00:00:00+00:00',
+                'local_only_shadow_drafts_no_send_no_crm_mutation', 2, 0, 0
+            )
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO shadow_drafts VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            """,
+            [
+                (
+                    "shadow-followup",
+                    "cca-followup",
+                    "replay-followup",
+                    "cw-followup",
+                    "wa-file-alpha",
+                    "zantara_client_captain",
+                    "shadow_draft",
+                    "high",
+                    "P1",
+                    "crm_followup",
+                    "sahira",
+                    "case_stall_followup_risk",
+                    "Draft a status follow-up after a human confirms the latest system update.",
+                    "firm_accountability_nudge",
+                    "Firm: operator must make a system update before continuing.",
+                    "2026-05",
+                    "2026-06",
+                    10,
+                    42,
+                    26,
+                    "followup_risk",
+                    21,
+                    9,
+                    2,
+                    3,
+                    0,
+                    0,
+                    1,
+                ),
+                (
+                    "shadow-payment",
+                    "cca-payment",
+                    "replay-payment",
+                    "cw-payment",
+                    "wa-file-beta",
+                    "zantara_client_captain",
+                    "shadow_draft",
+                    "normal",
+                    "P2",
+                    "payment_reconcile",
+                    "surya",
+                    "payment_reconciliation_needed",
+                    "Draft a payment clarification after finance verifies the ledger.",
+                    "steady_family_motivation",
+                    "Supportive: keep the operator moving.",
+                    "2026-04",
+                    "2026-04",
+                    3,
+                    15,
+                    9,
+                    "tax_payment",
+                    8,
+                    4,
+                    1,
+                    0,
+                    0,
+                    0,
+                    1,
+                ),
+            ],
+        )
+        layer_rows = []
+        for shadow_id in ("shadow-followup", "shadow-payment"):
+            for level, code in enumerate(
+                [
+                    "signal_readout",
+                    "case_diagnosis",
+                    "captain_decision",
+                    "draft_gate",
+                    "operator_coaching",
+                ],
+                start=1,
+            ):
+                layer_rows.append(
+                    (
+                        shadow_id,
+                        level,
+                        code,
+                        code.replace("_", " ").title(),
+                        json.dumps(
+                            {
+                                "send_whatsapp": False,
+                                "crm_mutation": False,
+                                "requires_human_approval": True,
+                            },
+                            sort_keys=True,
+                        ),
+                    )
+                )
+        conn.executemany(
+            """
+            INSERT INTO shadow_depth_layers (
+                shadow_id, depth_level, layer_code, layer_title, layer_payload_json
+            )
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            layer_rows,
+        )
+        conn.commit()
+
+
+def test_build_case_memory_cards_writes_compact_local_cards(tmp_path: Path) -> None:
+    client_shadow_db = tmp_path / "client_captain_shadow.local.sqlite"
+    output_dir = tmp_path / "case-memory-cards"
+    summary_path = output_dir / "case_memory_cards_summary.md"
+    _write_client_shadow_db(client_shadow_db)
+
+    result = build_case_memory_cards(
+        client_shadow_db=client_shadow_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+    )
+
+    assert result.card_count == 2
+    assert result.output_db == output_dir / "case_memory_cards.local.sqlite"
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.risk_counts == {"P1": 1, "P2": 1}
+
+    with sqlite3.connect(result.output_db) as conn:
+        rows = conn.execute(
+            """
+            SELECT case_card_id, source_shadow_id, case_status, risk_level,
+                   next_best_action, assigned_lane, latest_movement, blocker_code,
+                   review_rank, send_whatsapp, crm_mutation, requires_human_approval,
+                   card_payload_json
+            FROM case_memory_cards
+            ORDER BY review_rank, case_card_id
+            """
+        ).fetchall()
+
+    assert len(rows) == 2
+    assert rows[0][0] == "card-shadow-followup"
+    assert rows[0][1] == "shadow-followup"
+    assert rows[0][2] == "needs_human_review"
+    assert rows[0][3] == "P1"
+    assert rows[0][4] == "crm_followup"
+    assert rows[0][5] == "sahira"
+    assert rows[0][6] == "2026-06:42"
+    assert rows[0][7] == "case_stall_followup_risk"
+    assert rows[0][8] == 1
+    assert {row[9] for row in rows} == {0}
+    assert {row[10] for row in rows} == {0}
+    assert {row[11] for row in rows} == {1}
+    payload = json.loads(rows[0][12])
+    assert payload["raw_text_included"] is False
+    assert payload["depth_layer_count"] == 5
+    assert payload["send_whatsapp"] is False
+    assert payload["crm_mutation"] is False
+    assert rows[1][2] == "monitor_and_prepare"
+    assert rows[1][4] == "payment_reconcile"
+    assert rows[1][6] == "2026-04:15"
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Case Memory Cards Summary" in summary
+    assert "| Case memory cards | 2 |" in summary
+    assert "| WhatsApp sends | 0 |" in summary
+    assert "| CRM mutations | 0 |" in summary
+    assert "shadow-followup" not in summary
+    assert "wa-file-alpha" not in summary
+    assert "cw-followup" not in summary
+
+
+def test_build_case_memory_cards_rejects_unexpected_input_name(tmp_path: Path) -> None:
+    unexpected_db = tmp_path / "client_captain_academy.local.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    with pytest.raises(ValueError, match="Refusing to read unexpected Client Shadow DB"):
+        build_case_memory_cards(
+            client_shadow_db=unexpected_db,
+            output_dir=tmp_path / "case-memory-cards",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_cli_writes_json_without_raw_details(tmp_path: Path) -> None:
+    client_shadow_db = tmp_path / "client_captain_shadow.local.sqlite"
+    output_dir = tmp_path / "case-memory-cards"
+    summary_path = output_dir / "case_memory_cards_summary.md"
+    _write_client_shadow_db(client_shadow_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--client-shadow-db",
+            str(client_shadow_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["card_count"] == 2
+    assert payload["send_whatsapp_count"] == 0
+    assert payload["crm_mutation_count"] == 0
+    assert "shadow-followup" not in result.stdout
+    assert "wa-file-alpha" not in result.stdout

--- a/scripts/tests/test_whatsapp_corpus_case_timeline_synthesizer.py
+++ b/scripts/tests/test_whatsapp_corpus_case_timeline_synthesizer.py
@@ -1,0 +1,572 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.whatsapp_corpus.build_case_timeline_synthesizer import (
+    build_case_timeline_synthesizer,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_case_timeline_synthesizer.py"
+
+
+def _write_case_memory_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE case_memory_card_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                card_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE case_memory_cards (
+                case_card_id TEXT PRIMARY KEY,
+                source_shadow_id TEXT NOT NULL,
+                source_window_id TEXT NOT NULL,
+                case_owner TEXT NOT NULL,
+                case_status TEXT NOT NULL,
+                risk_level TEXT NOT NULL,
+                next_best_action TEXT NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                latest_movement TEXT NOT NULL,
+                blocker_code TEXT NOT NULL,
+                review_rank INTEGER NOT NULL,
+                card_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO case_memory_card_runs VALUES (
+                1, '2026-06-17T08:00:00+00:00',
+                'local_only_case_memory_cards_no_raw_text_no_send_no_crm_mutation',
+                2, 0, 0
+            )
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO case_memory_cards VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            """,
+            [
+                (
+                    "card-hot",
+                    "shadow-hot",
+                    "window-hot",
+                    "zantara",
+                    "needs_human_review",
+                    "P1",
+                    "crm_followup",
+                    "sahira",
+                    "2026-06:42",
+                    "case_stall_followup_risk",
+                    1,
+                    json.dumps({"raw_text_included": False}, sort_keys=True),
+                    0,
+                    0,
+                    1,
+                ),
+                (
+                    "card-cool",
+                    "shadow-cool",
+                    "window-cool",
+                    "zantara",
+                    "monitor_and_prepare",
+                    "P2",
+                    "document_chase",
+                    "adit",
+                    "2026-04:15",
+                    "document_gap",
+                    2,
+                    json.dumps({"raw_text_included": False}, sort_keys=True),
+                    0,
+                    0,
+                    1,
+                ),
+            ],
+        )
+        conn.commit()
+
+
+def _write_operator_inbox_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE operator_action_inbox_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                case_count INTEGER NOT NULL,
+                inbox_item_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE operator_action_inbox (
+                inbox_item_id TEXT PRIMARY KEY,
+                case_card_id TEXT NOT NULL,
+                queue_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                priority_label TEXT NOT NULL,
+                queue_bucket TEXT NOT NULL,
+                action_code TEXT NOT NULL,
+                action_title TEXT NOT NULL,
+                reason_code TEXT NOT NULL,
+                urgency_score INTEGER NOT NULL,
+                impact_score INTEGER NOT NULL,
+                combined_score INTEGER NOT NULL,
+                operator_instruction TEXT NOT NULL,
+                approval_mode TEXT NOT NULL,
+                item_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO operator_action_inbox_runs VALUES (
+                1, '2026-06-17T09:00:00+00:00',
+                'local_only_operator_action_inbox_no_raw_text_no_send_no_crm_mutation',
+                2, 2, 0, 0
+            )
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO operator_action_inbox VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            """,
+            [
+                (
+                    "inbox-hot",
+                    "card-hot",
+                    1,
+                    "sahira",
+                    "now",
+                    "follow_up_now",
+                    "crm_followup",
+                    "Crm Followup",
+                    "stale_followup",
+                    100,
+                    85,
+                    94,
+                    "Operator must review the CRM follow-up.",
+                    "human_review_required",
+                    json.dumps({"raw_text_included": False}, sort_keys=True),
+                    0,
+                    0,
+                    1,
+                ),
+                (
+                    "inbox-cool",
+                    "card-cool",
+                    2,
+                    "adit",
+                    "today",
+                    "document_gap_today",
+                    "document_chase",
+                    "Document Chase",
+                    "document_gap",
+                    70,
+                    75,
+                    72,
+                    "Operator must review document evidence.",
+                    "human_review_required",
+                    json.dumps({"raw_text_included": False}, sort_keys=True),
+                    0,
+                    0,
+                    1,
+                ),
+            ],
+        )
+        conn.commit()
+
+
+def _write_operator_sla_clock_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE operator_sla_clock_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_inbox_generated_at_utc TEXT NOT NULL,
+                as_of_utc TEXT NOT NULL,
+                inbox_item_count INTEGER NOT NULL,
+                clock_count INTEGER NOT NULL,
+                overdue_count INTEGER NOT NULL,
+                breach_risk_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE operator_sla_clock (
+                inbox_item_id TEXT PRIMARY KEY,
+                case_card_id TEXT NOT NULL,
+                queue_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                priority_label TEXT NOT NULL,
+                queue_bucket TEXT NOT NULL,
+                action_code TEXT NOT NULL,
+                reason_code TEXT NOT NULL,
+                sla_minutes INTEGER NOT NULL,
+                source_inbox_generated_at_utc TEXT NOT NULL,
+                due_at_utc TEXT NOT NULL,
+                as_of_utc TEXT NOT NULL,
+                minutes_until_due INTEGER NOT NULL,
+                aging_minutes INTEGER NOT NULL,
+                sla_status TEXT NOT NULL,
+                breach_risk TEXT NOT NULL,
+                escalation_label TEXT NOT NULL,
+                clock_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO operator_sla_clock_runs VALUES (
+                1, '2026-06-17T10:00:00+00:00',
+                'local_only_operator_sla_clock_no_raw_text_no_send_no_crm_mutation',
+                '2026-06-17T09:00:00+00:00',
+                '2026-06-17T10:00:00+00:00',
+                2, 2, 0, 1, 0, 0
+            )
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO operator_sla_clock VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            """,
+            [
+                (
+                    "inbox-hot",
+                    "card-hot",
+                    1,
+                    "sahira",
+                    "now",
+                    "follow_up_now",
+                    "crm_followup",
+                    "stale_followup",
+                    240,
+                    "2026-06-17T09:00:00+00:00",
+                    "2026-06-17T13:00:00+00:00",
+                    "2026-06-17T10:00:00+00:00",
+                    180,
+                    60,
+                    "due_today",
+                    "high",
+                    "lane_lead_watch",
+                    json.dumps({"raw_text_included": False}, sort_keys=True),
+                    0,
+                    0,
+                    1,
+                ),
+                (
+                    "inbox-cool",
+                    "card-cool",
+                    2,
+                    "adit",
+                    "today",
+                    "document_gap_today",
+                    "document_chase",
+                    "document_gap",
+                    1440,
+                    "2026-06-17T09:00:00+00:00",
+                    "2026-06-18T09:00:00+00:00",
+                    "2026-06-17T10:00:00+00:00",
+                    1380,
+                    60,
+                    "due_today",
+                    "medium",
+                    "operator_watch",
+                    json.dumps({"raw_text_included": False}, sort_keys=True),
+                    0,
+                    0,
+                    1,
+                ),
+            ],
+        )
+        conn.commit()
+
+
+def _write_breach_war_room_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE breach_war_room_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_sla_clock_generated_at_utc TEXT NOT NULL,
+                source_as_of_utc TEXT NOT NULL,
+                clock_count INTEGER NOT NULL,
+                room_item_count INTEGER NOT NULL,
+                critical_count INTEGER NOT NULL,
+                hot_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE breach_war_room (
+                room_item_id TEXT PRIMARY KEY,
+                inbox_item_id TEXT NOT NULL,
+                case_card_id TEXT NOT NULL,
+                source_queue_rank INTEGER NOT NULL,
+                war_room_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                priority_label TEXT NOT NULL,
+                queue_bucket TEXT NOT NULL,
+                action_code TEXT NOT NULL,
+                reason_code TEXT NOT NULL,
+                due_at_utc TEXT NOT NULL,
+                as_of_utc TEXT NOT NULL,
+                minutes_until_due INTEGER NOT NULL,
+                aging_minutes INTEGER NOT NULL,
+                sla_status TEXT NOT NULL,
+                breach_risk TEXT NOT NULL,
+                escalation_label TEXT NOT NULL,
+                severity_band TEXT NOT NULL,
+                command_channel TEXT NOT NULL,
+                decision_gate TEXT NOT NULL,
+                captain_instruction TEXT NOT NULL,
+                war_room_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO breach_war_room_runs VALUES (
+                1, '2026-06-17T10:05:00+00:00',
+                'local_only_breach_war_room_no_raw_text_no_send_no_crm_mutation',
+                '2026-06-17T10:00:00+00:00',
+                '2026-06-17T10:00:00+00:00',
+                2, 1, 0, 1, 0, 0
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO breach_war_room VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            """,
+            (
+                "war-room-hot",
+                "inbox-hot",
+                "card-hot",
+                1,
+                1,
+                "sahira",
+                "now",
+                "follow_up_now",
+                "crm_followup",
+                "stale_followup",
+                "2026-06-17T13:00:00+00:00",
+                "2026-06-17T10:00:00+00:00",
+                180,
+                60,
+                "due_today",
+                "high",
+                "lane_lead_watch",
+                "hot",
+                "lane_hot_queue",
+                "lane_lead_review_required",
+                "Review Sahira CRM follow-up SLA clock.",
+                json.dumps({"raw_text_included": False}, sort_keys=True),
+                0,
+                0,
+                1,
+            ),
+        )
+        conn.commit()
+
+
+def test_build_case_timeline_synthesizer_writes_operational_timeline(
+    tmp_path: Path,
+) -> None:
+    case_memory_db = tmp_path / "case_memory_cards.local.sqlite"
+    operator_inbox_db = tmp_path / "operator_action_inbox.local.sqlite"
+    operator_sla_clock_db = tmp_path / "operator_sla_clock.local.sqlite"
+    breach_war_room_db = tmp_path / "breach_war_room.local.sqlite"
+    output_dir = tmp_path / "case-timelines"
+    summary_path = output_dir / "case_timelines_summary.md"
+    _write_case_memory_db(case_memory_db)
+    _write_operator_inbox_db(operator_inbox_db)
+    _write_operator_sla_clock_db(operator_sla_clock_db)
+    _write_breach_war_room_db(breach_war_room_db)
+
+    result = build_case_timeline_synthesizer(
+        case_memory_db=case_memory_db,
+        operator_inbox_db=operator_inbox_db,
+        operator_sla_clock_db=operator_sla_clock_db,
+        breach_war_room_db=breach_war_room_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+        generated_at_utc="2026-06-17T10:10:00+00:00",
+    )
+
+    assert result.case_count == 2
+    assert result.event_count == 7
+    assert result.output_db == output_dir / "case_timelines.local.sqlite"
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.status_counts == {"war_room_active": 1, "operator_due_today": 1}
+    assert result.lane_counts == {"sahira": 1, "adit": 1}
+
+    with sqlite3.connect(result.output_db) as conn:
+        timelines = conn.execute(
+            """
+            SELECT case_card_id, timeline_status, highest_risk, assigned_lane,
+                   primary_action, event_count, has_war_room_item,
+                   send_whatsapp, crm_mutation, requires_human_approval,
+                   timeline_payload_json
+            FROM case_timelines
+            ORDER BY timeline_rank
+            """
+        ).fetchall()
+        events = conn.execute(
+            """
+            SELECT case_card_id, event_rank, event_stage, event_status,
+                   event_lane, action_code, event_payload_json,
+                   send_whatsapp, crm_mutation, requires_human_approval
+            FROM case_timeline_events
+            ORDER BY case_card_id, event_rank
+            """
+        ).fetchall()
+
+    assert timelines[0][0:7] == (
+        "card-hot",
+        "war_room_active",
+        "P1",
+        "sahira",
+        "crm_followup",
+        4,
+        1,
+    )
+    assert timelines[1][0:7] == (
+        "card-cool",
+        "operator_due_today",
+        "P2",
+        "adit",
+        "document_chase",
+        3,
+        0,
+    )
+    assert {row[7] for row in timelines} == {0}
+    assert {row[8] for row in timelines} == {0}
+    assert {row[9] for row in timelines} == {1}
+    payload = json.loads(timelines[0][10])
+    assert payload["schema_version"] == "case_timeline_synthesizer.v1"
+    assert payload["raw_text_included"] is False
+    assert payload["send_whatsapp"] is False
+    assert payload["crm_mutation"] is False
+    assert payload["requires_human_approval"] is True
+
+    hot_stages = [row[2] for row in events if row[0] == "card-hot"]
+    cool_stages = [row[2] for row in events if row[0] == "card-cool"]
+    assert hot_stages == ["case_memory", "operator_action", "sla_clock", "war_room"]
+    assert cool_stages == ["case_memory", "operator_action", "sla_clock"]
+    assert {row[7] for row in events} == {0}
+    assert {row[8] for row in events} == {0}
+    assert {row[9] for row in events} == {1}
+    assert json.loads(events[0][6])["raw_text_included"] is False
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Case Timeline Synthesizer Summary" in summary
+    assert "| Cases synthesized | 2 |" in summary
+    assert "| Timeline events | 7 |" in summary
+    assert "| WhatsApp sends | 0 |" in summary
+    assert "| CRM mutations | 0 |" in summary
+    assert "card-hot" not in summary
+    assert "inbox-hot" not in summary
+    assert "war-room-hot" not in summary
+
+
+def test_build_case_timeline_synthesizer_rejects_unexpected_input_name(
+    tmp_path: Path,
+) -> None:
+    unexpected_db = tmp_path / "operator_sla_clock.local.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    with pytest.raises(ValueError, match="Refusing to read unexpected Case Memory DB"):
+        build_case_timeline_synthesizer(
+            case_memory_db=unexpected_db,
+            operator_inbox_db=tmp_path / "operator_action_inbox.local.sqlite",
+            operator_sla_clock_db=tmp_path / "operator_sla_clock.local.sqlite",
+            breach_war_room_db=tmp_path / "breach_war_room.local.sqlite",
+            output_dir=tmp_path / "case-timelines",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_cli_writes_json_without_raw_case_details(tmp_path: Path) -> None:
+    case_memory_db = tmp_path / "case_memory_cards.local.sqlite"
+    operator_inbox_db = tmp_path / "operator_action_inbox.local.sqlite"
+    operator_sla_clock_db = tmp_path / "operator_sla_clock.local.sqlite"
+    breach_war_room_db = tmp_path / "breach_war_room.local.sqlite"
+    output_dir = tmp_path / "case-timelines"
+    summary_path = output_dir / "case_timelines_summary.md"
+    _write_case_memory_db(case_memory_db)
+    _write_operator_inbox_db(operator_inbox_db)
+    _write_operator_sla_clock_db(operator_sla_clock_db)
+    _write_breach_war_room_db(breach_war_room_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--case-memory-db",
+            str(case_memory_db),
+            "--operator-inbox-db",
+            str(operator_inbox_db),
+            "--operator-sla-clock-db",
+            str(operator_sla_clock_db),
+            "--breach-war-room-db",
+            str(breach_war_room_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--generated-at-utc",
+            "2026-06-17T10:10:00+00:00",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["case_count"] == 2
+    assert payload["event_count"] == 7
+    assert payload["send_whatsapp_count"] == 0
+    assert payload["crm_mutation_count"] == 0
+    assert "card-hot" not in result.stdout
+    assert "inbox-hot" not in result.stdout
+    assert "war-room-hot" not in result.stdout

--- a/scripts/tests/test_whatsapp_corpus_client_captain_academy.py
+++ b/scripts/tests/test_whatsapp_corpus_client_captain_academy.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.whatsapp_corpus.build_client_captain_academy import (
+    build_client_captain_academy,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_client_captain_academy.py"
+
+
+def _write_case_windows_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE case_windows (
+                window_id TEXT PRIMARY KEY,
+                file_id TEXT NOT NULL,
+                window_ordinal INTEGER NOT NULL,
+                first_timestamp TEXT,
+                last_timestamp TEXT,
+                first_month TEXT NOT NULL,
+                last_month TEXT NOT NULL,
+                first_message_index INTEGER NOT NULL,
+                last_message_index INTEGER NOT NULL,
+                event_count INTEGER NOT NULL,
+                message_count INTEGER NOT NULL,
+                domain_count INTEGER NOT NULL,
+                dominant_domain TEXT NOT NULL,
+                severity_high_count INTEGER NOT NULL,
+                top_event_codes_json TEXT NOT NULL
+            );
+            CREATE TABLE case_window_domains (
+                window_id TEXT NOT NULL,
+                domain_code TEXT NOT NULL,
+                event_count INTEGER NOT NULL,
+                message_count INTEGER NOT NULL,
+                PRIMARY KEY (window_id, domain_code)
+            );
+            CREATE TABLE case_window_event_codes (
+                window_id TEXT NOT NULL,
+                rank INTEGER NOT NULL,
+                domain_code TEXT NOT NULL,
+                event_code TEXT NOT NULL,
+                event_count INTEGER NOT NULL,
+                PRIMARY KEY (window_id, rank)
+            );
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO case_windows (
+                window_id, file_id, window_ordinal, first_timestamp, last_timestamp,
+                first_month, last_month, first_message_index, last_message_index,
+                event_count, message_count, domain_count, dominant_domain,
+                severity_high_count, top_event_codes_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    "cw-001",
+                    "wa-file-alpha",
+                    1,
+                    "2026-05-01T08:00:00",
+                    "2026-05-01T13:00:00",
+                    "2026-05",
+                    "2026-05",
+                    10,
+                    42,
+                    61,
+                    18,
+                    3,
+                    "immigration_lifecycle",
+                    4,
+                    json.dumps(
+                        [
+                            {
+                                "domain_code": "immigration_lifecycle",
+                                "event_code": "visa_stage",
+                                "event_count": 9,
+                            },
+                            {
+                                "domain_code": "document_requirement",
+                                "event_code": "passport_identity_document",
+                                "event_count": 5,
+                            },
+                        ]
+                    ),
+                ),
+                (
+                    "cw-002",
+                    "wa-file-beta",
+                    1,
+                    "2026-05-02T08:00:00",
+                    "2026-05-04T09:00:00",
+                    "2026-05",
+                    "2026-05",
+                    3,
+                    15,
+                    18,
+                    8,
+                    2,
+                    "tax_payment",
+                    0,
+                    json.dumps(
+                        [
+                            {
+                                "domain_code": "tax_payment",
+                                "event_code": "payment_or_transfer",
+                                "event_count": 4,
+                            }
+                        ]
+                    ),
+                ),
+            ],
+        )
+        conn.executemany(
+            """
+            INSERT INTO case_window_domains
+                (window_id, domain_code, event_count, message_count)
+            VALUES (?, ?, ?, ?)
+            """,
+            [
+                ("cw-001", "immigration_lifecycle", 40, 13),
+                ("cw-001", "document_requirement", 14, 4),
+                ("cw-001", "followup_risk", 7, 3),
+                ("cw-002", "tax_payment", 12, 5),
+                ("cw-002", "followup_risk", 6, 2),
+            ],
+        )
+        conn.executemany(
+            """
+            INSERT INTO case_window_event_codes
+                (window_id, rank, domain_code, event_code, event_count)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            [
+                ("cw-001", 1, "immigration_lifecycle", "visa_stage", 9),
+                ("cw-001", 2, "document_requirement", "passport_identity_document", 5),
+                ("cw-001", 3, "followup_risk", "deadline_or_urgency", 4),
+                ("cw-002", 1, "tax_payment", "payment_or_transfer", 4),
+                ("cw-002", 2, "followup_risk", "followup_waiting", 2),
+            ],
+        )
+        conn.commit()
+
+
+def test_build_client_captain_academy_writes_local_examples_and_replay(
+    tmp_path: Path,
+) -> None:
+    case_windows_db = tmp_path / "allowed_case_windows.local.sqlite"
+    output_dir = tmp_path / "client-captain"
+    summary_path = output_dir / "client_captain_academy_summary.md"
+    _write_case_windows_db(case_windows_db)
+
+    result = build_client_captain_academy(
+        case_windows_db=case_windows_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+        max_examples=10,
+    )
+
+    assert result.example_count == 2
+    assert result.replay_count == 2
+    assert result.owner_counts == {"zantara_client_captain": 2}
+    assert result.priority_counts == {"high": 1, "normal": 1}
+    assert (output_dir / "client_captain_academy.local.sqlite").exists()
+    assert (output_dir / "training_examples.local.jsonl").exists()
+
+    jsonl_rows = [
+        json.loads(line)
+        for line in (output_dir / "training_examples.local.jsonl").read_text(
+            encoding="utf-8"
+        ).splitlines()
+    ]
+    assert {row["case_owner"] for row in jsonl_rows} == {"zantara_client_captain"}
+    assert jsonl_rows[0]["academy_task"] == "case_captain_next_action"
+    assert jsonl_rows[0]["captain_output"]["next_action"] == "immigration_status_check"
+    assert jsonl_rows[0]["captain_output"]["human_specialist"] == "ari"
+    assert jsonl_rows[1]["captain_output"]["next_action"] == "payment_reconcile"
+    assert jsonl_rows[1]["captain_output"]["human_specialist"] == "surya"
+
+    with sqlite3.connect(output_dir / "client_captain_academy.local.sqlite") as conn:
+        examples = conn.execute(
+            """
+            SELECT example_id, case_owner, priority, next_action, human_specialist
+            FROM captain_training_examples
+            ORDER BY example_id
+            """
+        ).fetchall()
+        replay = conn.execute(
+            """
+            SELECT example_id, cut_message_index, expected_next_action
+            FROM captain_replay_scenarios
+            ORDER BY example_id
+            """
+        ).fetchall()
+
+    assert examples == [
+        ("cca-cw-001", "zantara_client_captain", "high", "immigration_status_check", "ari"),
+        ("cca-cw-002", "zantara_client_captain", "normal", "payment_reconcile", "surya"),
+    ]
+    assert replay == [
+        ("cca-cw-001", 26, "immigration_status_check"),
+        ("cca-cw-002", 9, "payment_reconcile"),
+    ]
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Client Captain Academy Summary" in summary
+    assert "| Training examples | 2 |" in summary
+    assert "| zantara_client_captain | 2 |" in summary
+    assert "wa-file-alpha" not in summary
+    assert "cw-001" not in summary
+    assert "passport_identity_document" not in summary
+
+
+def test_build_client_captain_academy_rejects_unexpected_input_name(
+    tmp_path: Path,
+) -> None:
+    unexpected_db = tmp_path / "full_messages.local.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    with pytest.raises(ValueError, match="Refusing to read unexpected input artifact"):
+        build_client_captain_academy(
+            case_windows_db=unexpected_db,
+            output_dir=tmp_path / "client-captain",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_cli_writes_json_without_raw_window_details(tmp_path: Path) -> None:
+    case_windows_db = tmp_path / "allowed_case_windows.local.sqlite"
+    output_dir = tmp_path / "client-captain"
+    summary_path = output_dir / "client_captain_academy_summary.md"
+    _write_case_windows_db(case_windows_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--case-windows-db",
+            str(case_windows_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "example_count": 2,
+        "replay_count": 2,
+    }
+    assert "wa-file-alpha" not in result.stdout
+    assert "cw-001" not in result.stdout
+    assert "passport_identity_document" not in result.stdout
+    assert summary_path.exists()
+
+
+def test_cli_error_is_sanitized_for_unexpected_input_name(tmp_path: Path) -> None:
+    wrong_db = tmp_path / "wrong_input_should_not_leak.local.sqlite"
+    wrong_db.write_bytes(b"")
+    output_dir = tmp_path / "client-captain"
+    summary_path = output_dir / "client_captain_academy_summary.md"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--case-windows-db",
+            str(wrong_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert result.stderr == "ERROR: Client Captain Academy input is missing or invalid.\n"
+    forbidden_markers = [
+        str(tmp_path),
+        str(wrong_db),
+        wrong_db.name,
+        str(output_dir),
+        str(summary_path),
+        "Traceback",
+        ".sqlite",
+    ]
+    for marker in forbidden_markers:
+        assert marker not in result.stderr

--- a/scripts/tests/test_whatsapp_corpus_client_captain_shadow.py
+++ b/scripts/tests/test_whatsapp_corpus_client_captain_shadow.py
@@ -1,0 +1,432 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.whatsapp_corpus import build_client_captain_shadow as client_shadow_module
+from scripts.whatsapp_corpus.build_client_captain_shadow import (
+    build_client_captain_shadow,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_client_captain_shadow.py"
+GENERIC_CLIENT_CLI_ERROR = "ERROR: Client Captain input is missing or invalid.\n"
+SYSTEM_CLIENT_CLI_ERROR = "ERROR: Client Captain shadow run failed safely.\n"
+
+
+def _assert_no_raw_client_markers(
+    text: str, *, academy_db: Path, output_dir: Path, summary_path: Path
+) -> None:
+    forbidden_markers = [
+        "wa-file-alpha",
+        "cw-followup",
+        "replay-followup",
+        "client_captain_academy.local.sqlite",
+        "client_captain_shadow.local.sqlite",
+        str(academy_db),
+        str(output_dir),
+        str(summary_path),
+        "research/personal/wa-corpus",
+    ]
+    for marker in forbidden_markers:
+        assert marker not in text
+
+
+def _assert_sanitized_client_cli_error(
+    result: subprocess.CompletedProcess[str],
+    *,
+    forbidden_markers: list[str],
+    expected_stderr: str = GENERIC_CLIENT_CLI_ERROR,
+) -> None:
+    assert result.returncode == 1
+    assert result.stderr == expected_stderr
+    assert result.stdout == ""
+    for marker in forbidden_markers:
+        assert marker not in result.stderr
+
+
+def _write_academy_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE academy_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                example_count INTEGER NOT NULL,
+                replay_count INTEGER NOT NULL
+            );
+            CREATE TABLE captain_training_examples (
+                example_id TEXT PRIMARY KEY,
+                source_window_id TEXT NOT NULL,
+                file_id TEXT NOT NULL,
+                case_owner TEXT NOT NULL,
+                dominant_domain TEXT NOT NULL,
+                priority TEXT NOT NULL,
+                next_action TEXT NOT NULL,
+                human_specialist TEXT NOT NULL,
+                operator_coaching_mode TEXT NOT NULL,
+                first_month TEXT NOT NULL,
+                last_month TEXT NOT NULL,
+                first_message_index INTEGER NOT NULL,
+                last_message_index INTEGER NOT NULL,
+                event_count INTEGER NOT NULL,
+                message_count INTEGER NOT NULL,
+                domain_count INTEGER NOT NULL,
+                severity_high_count INTEGER NOT NULL,
+                captain_input_json TEXT NOT NULL,
+                captain_output_json TEXT NOT NULL
+            );
+            CREATE TABLE captain_replay_scenarios (
+                replay_id TEXT PRIMARY KEY,
+                example_id TEXT NOT NULL,
+                cut_message_index INTEGER NOT NULL,
+                expected_next_action TEXT NOT NULL,
+                expected_priority TEXT NOT NULL,
+                expected_human_specialist TEXT NOT NULL,
+                expected_case_owner TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO academy_runs (
+                id, generated_at_utc, privacy_mode, example_count, replay_count
+            )
+            VALUES (1, '2026-06-16T00:00:00+00:00',
+                    'local_only_case_windows_no_raw_text_no_raw_paths', 2, 2)
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO captain_training_examples (
+                example_id, source_window_id, file_id, case_owner, dominant_domain,
+                priority, next_action, human_specialist, operator_coaching_mode,
+                first_month, last_month, first_message_index, last_message_index,
+                event_count, message_count, domain_count, severity_high_count,
+                captain_input_json, captain_output_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    "cca-window-followup",
+                    "cw-followup",
+                    "wa-file-alpha",
+                    "zantara_client_captain",
+                    "followup_risk",
+                    "high",
+                    "crm_followup",
+                    "sahira",
+                    "firm_accountability_nudge",
+                    "2026-05",
+                    "2026-05",
+                    10,
+                    42,
+                    21,
+                    9,
+                    2,
+                    3,
+                    json.dumps({"privacy_mode": "local_only_aggregate_no_raw_text"}),
+                    json.dumps({"send_whatsapp": False, "crm_mutation": False}),
+                ),
+                (
+                    "cca-window-tax",
+                    "cw-tax",
+                    "wa-file-beta",
+                    "zantara_client_captain",
+                    "tax_payment",
+                    "normal",
+                    "payment_reconcile",
+                    "surya",
+                    "steady_family_motivation",
+                    "2026-05",
+                    "2026-05",
+                    3,
+                    15,
+                    8,
+                    4,
+                    1,
+                    0,
+                    json.dumps({"privacy_mode": "local_only_aggregate_no_raw_text"}),
+                    json.dumps({"send_whatsapp": False, "crm_mutation": False}),
+                ),
+            ],
+        )
+        conn.executemany(
+            """
+            INSERT INTO captain_replay_scenarios (
+                replay_id, example_id, cut_message_index, expected_next_action,
+                expected_priority, expected_human_specialist, expected_case_owner
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    "replay-followup",
+                    "cca-window-followup",
+                    26,
+                    "crm_followup",
+                    "high",
+                    "sahira",
+                    "zantara_client_captain",
+                ),
+                (
+                    "replay-tax",
+                    "cca-window-tax",
+                    9,
+                    "payment_reconcile",
+                    "normal",
+                    "surya",
+                    "zantara_client_captain",
+                ),
+            ],
+        )
+        conn.commit()
+
+
+def test_build_client_captain_shadow_writes_draft_only_diagnoses(
+    tmp_path: Path,
+) -> None:
+    academy_db = tmp_path / "client_captain_academy.local.sqlite"
+    output_dir = tmp_path / "client-captain-shadow"
+    summary_path = output_dir / "client_captain_shadow_summary.md"
+    _write_academy_db(academy_db)
+
+    result = build_client_captain_shadow(
+        academy_db=academy_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+    )
+
+    assert result.draft_count == 2
+    assert result.output_db == output_dir / "client_captain_shadow.local.sqlite"
+    assert result.priority_counts == {"high": 1, "normal": 1}
+    assert result.action_counts == {"crm_followup": 1, "payment_reconcile": 1}
+
+    with sqlite3.connect(result.output_db) as conn:
+        rows = conn.execute(
+            """
+            SELECT case_owner, status, action_type, diagnosis_code, risk_level,
+                   draft_reply_intent, operator_coaching_mode, operator_nudge,
+                   send_whatsapp, crm_mutation, requires_human_approval
+            FROM shadow_drafts
+            ORDER BY shadow_id
+            """
+        ).fetchall()
+        depth_rows = conn.execute(
+            """
+            SELECT shadow_id, depth_level, layer_code, layer_title, layer_payload_json
+            FROM shadow_depth_layers
+            ORDER BY shadow_id, depth_level
+            """
+        ).fetchall()
+
+    assert len(rows) == 2
+    assert {row[0] for row in rows} == {"zantara_client_captain"}
+    assert {row[1] for row in rows} == {"shadow_draft"}
+    assert {row[8] for row in rows} == {0}
+    assert {row[9] for row in rows} == {0}
+    assert {row[10] for row in rows} == {1}
+    assert rows[0][2] == "crm_followup"
+    assert rows[0][3] == "case_stall_followup_risk"
+    assert rows[0][4] == "P1"
+    assert "system update" in rows[0][7]
+    assert rows[1][2] == "payment_reconcile"
+    assert rows[1][3] == "payment_reconciliation_needed"
+    assert rows[1][4] == "P2"
+    assert "payment status" in rows[1][5]
+    assert len(depth_rows) == 10
+    assert [row[1] for row in depth_rows[:5]] == [1, 2, 3, 4, 5]
+    assert [row[2] for row in depth_rows[:5]] == [
+        "signal_readout",
+        "case_diagnosis",
+        "captain_decision",
+        "draft_gate",
+        "operator_coaching",
+    ]
+    assert json.loads(depth_rows[0][4])["send_whatsapp"] is False
+    assert json.loads(depth_rows[0][4])["crm_mutation"] is False
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Client Captain Shadow Mode Summary" in summary
+    assert "| Shadow drafts | 2 |" in summary
+    assert "| Depth layers | 10 |" in summary
+    assert "wa-file-alpha" not in summary
+    assert "cw-followup" not in summary
+    assert "replay-followup" not in summary
+
+
+def test_build_client_captain_shadow_rejects_unexpected_input_name(
+    tmp_path: Path,
+) -> None:
+    unexpected_db = tmp_path / "allowed_messages.local.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    with pytest.raises(ValueError, match="Refusing to read unexpected Academy DB"):
+        build_client_captain_shadow(
+            academy_db=unexpected_db,
+            output_dir=tmp_path / "client-captain-shadow",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_client_cli_wrong_input_name_error_is_generic(tmp_path: Path) -> None:
+    unexpected_db = tmp_path / "allowed_messages.local.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--academy-db",
+            str(unexpected_db),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    _assert_sanitized_client_cli_error(
+        result,
+        forbidden_markers=[
+            "allowed_messages.local.sqlite",
+            str(unexpected_db),
+            str(tmp_path),
+            "Refusing to read unexpected Academy DB",
+            "Traceback",
+        ],
+    )
+    assert result.returncode == 1
+
+
+def test_client_cli_missing_input_error_is_generic(tmp_path: Path) -> None:
+    missing_db = tmp_path / "client_captain_academy.local.sqlite"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--academy-db",
+            str(missing_db),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    _assert_sanitized_client_cli_error(
+        result,
+        forbidden_markers=[
+            "client_captain_academy.local.sqlite",
+            str(missing_db),
+            str(tmp_path),
+            "Academy DB not found",
+            "Traceback",
+        ],
+    )
+    assert result.returncode == 1
+
+
+def test_client_cli_sqlite_error_is_generic_system_failure(tmp_path: Path) -> None:
+    malformed_db = tmp_path / "client_captain_academy.local.sqlite"
+    malformed_db.write_bytes(b"")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--academy-db",
+            str(malformed_db),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    _assert_sanitized_client_cli_error(
+        result,
+        expected_stderr=SYSTEM_CLIENT_CLI_ERROR,
+        forbidden_markers=[
+            "client_captain_academy.local.sqlite",
+            str(malformed_db),
+            str(tmp_path),
+            "no such table",
+            "sqlite",
+            "Traceback",
+        ],
+    )
+    assert result.returncode == 1
+
+
+def test_client_main_unexpected_error_is_generic_system_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def raise_unexpected(**_: object) -> None:
+        raise RuntimeError(
+            "secret /tmp/raw client_captain_shadow.local.sqlite shadow_drafts"
+        )
+
+    monkeypatch.setattr(
+        client_shadow_module,
+        "build_client_captain_shadow",
+        raise_unexpected,
+    )
+
+    assert client_shadow_module.main(["--json"]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == SYSTEM_CLIENT_CLI_ERROR
+    for marker in [
+        "secret",
+        "/tmp/raw",
+        "client_captain_shadow.local.sqlite",
+        "shadow_drafts",
+        "RuntimeError",
+        "Traceback",
+    ]:
+        assert marker not in captured.err
+
+
+def test_client_cli_writes_json_without_raw_details(tmp_path: Path) -> None:
+    academy_db = tmp_path / "client_captain_academy.local.sqlite"
+    output_dir = tmp_path / "client-captain-shadow"
+    summary_path = output_dir / "client_captain_shadow_summary.md"
+    _write_academy_db(academy_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--academy-db",
+            str(academy_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["draft_count"] == 2
+    assert payload["send_whatsapp_count"] == 0
+    assert payload["crm_mutation_count"] == 0
+    assert "output_db" not in payload
+    assert "summary_path" not in payload
+    _assert_no_raw_client_markers(
+        result.stdout,
+        academy_db=academy_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+    )

--- a/scripts/tests/test_whatsapp_corpus_decision_chain_cli_contract.py
+++ b/scripts/tests/test_whatsapp_corpus_decision_chain_cli_contract.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = REPO_ROOT / "scripts" / "whatsapp_corpus"
+DECISION_CHAIN_SCRIPT_NAMES = [
+    "build_approval_routing_queue.py",
+    "build_approve_reject_ledger.py",
+    "build_owner_approval_console.py",
+    "build_owner_brief_renderer.py",
+    "build_owner_decision_intake.py",
+    "build_owner_decision_inbox.py",
+    "build_owner_decision_event_capture.py",
+    "build_owner_decision_packs.py",
+    "build_owner_decision_compiler.py",
+    "build_owner_decision_cockpit.py",
+    "build_owner_decision_pipeline.py",
+    "build_owner_decision_replay.py",
+    "build_post_decision_work_order_queue.py",
+    "build_operator_action_inbox.py",
+    "build_operator_execution_packets.py",
+    "build_operator_packet_review_console.py",
+    "build_operator_sla_clock.py",
+]
+PATH_HARDENED_SCRIPT_NAMES = [
+    *DECISION_CHAIN_SCRIPT_NAMES,
+    "build_client_captain_academy.py",
+    "build_drive_export_manifest.py",
+    "import_drive_exports.py",
+]
+
+
+@pytest.mark.parametrize(
+    ("script_name", "input_arg", "error_stderr"),
+    [
+        (
+            "build_approval_routing_queue.py",
+            "--owner-briefs-db",
+            "ERROR: Approval routing queue input is missing or invalid.\n",
+        ),
+        (
+            "build_approve_reject_ledger.py",
+            "--approval-routing-db",
+            "ERROR: Approve/reject ledger input is missing or invalid.\n",
+        ),
+        (
+            "build_owner_approval_console.py",
+            "--case-closure-db",
+            "ERROR: Owner approval console input is missing or invalid.\n",
+        ),
+        (
+            "build_owner_brief_renderer.py",
+            "--owner-packs-db",
+            "ERROR: Owner brief renderer input is missing or invalid.\n",
+        ),
+        (
+            "build_owner_decision_intake.py",
+            "--review-console-db",
+            "ERROR: Owner decision intake input is missing or invalid.\n",
+        ),
+        (
+            "build_owner_decision_inbox.py",
+            "--review-console-db",
+            "ERROR: Owner decision inbox input is missing or invalid.\n",
+        ),
+        (
+            "build_owner_decision_event_capture.py",
+            "--ledger-db",
+            "ERROR: Owner decision event capture input is missing or invalid.\n",
+        ),
+        (
+            "build_owner_decision_packs.py",
+            "--owner-approval-db",
+            "ERROR: Owner decision packs input is missing or invalid.\n",
+        ),
+        (
+            "build_owner_decision_compiler.py",
+            "--owner-inbox-db",
+            "ERROR: Owner decision compiler input is missing or invalid.\n",
+        ),
+        (
+            "build_owner_decision_cockpit.py",
+            "--owner-inbox-db",
+            "ERROR: Owner decision cockpit input is missing or invalid.\n",
+        ),
+        (
+            "build_owner_decision_pipeline.py",
+            "--ledger-db",
+            "ERROR: Owner decision pipeline input is missing or invalid.\n",
+        ),
+        (
+            "build_owner_decision_replay.py",
+            "--ledger-db",
+            "ERROR: Owner decision replay input is missing or invalid.\n",
+        ),
+        (
+            "build_post_decision_work_order_queue.py",
+            "--owner-events-db",
+            "ERROR: Post-decision work order queue input is missing or invalid.\n",
+        ),
+        (
+            "build_operator_action_inbox.py",
+            "--next-best-actions-db",
+            "ERROR: Operator action inbox input is missing or invalid.\n",
+        ),
+        (
+            "build_operator_execution_packets.py",
+            "--work-orders-db",
+            "ERROR: Operator execution packets input is missing or invalid.\n",
+        ),
+        (
+            "build_operator_packet_review_console.py",
+            "--packets-db",
+            "ERROR: Operator packet review console input is missing or invalid.\n",
+        ),
+        (
+            "build_operator_sla_clock.py",
+            "--operator-inbox-db",
+            "ERROR: Operator SLA clock input is missing or invalid.\n",
+        ),
+    ],
+)
+def test_decision_chain_cli_wrong_input_name_is_sanitized(
+    tmp_path: Path,
+    script_name: str,
+    input_arg: str,
+    error_stderr: str,
+) -> None:
+    wrong_db = tmp_path / "wrong_input_should_not_leak.local.sqlite"
+    wrong_db.write_bytes(b"")
+    output_dir = tmp_path / "output"
+    summary_path = output_dir / "summary.md"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_DIR / script_name),
+            input_arg,
+            str(wrong_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert result.stderr == error_stderr
+    forbidden_markers = [
+        str(tmp_path),
+        str(wrong_db),
+        wrong_db.name,
+        str(output_dir),
+        str(summary_path),
+        "Traceback",
+        ".sqlite",
+    ]
+    for marker in forbidden_markers:
+        assert marker not in result.stderr
+
+
+@pytest.mark.parametrize("script_name", PATH_HARDENED_SCRIPT_NAMES)
+def test_decision_chain_cli_json_payload_has_no_local_path_fields(
+    script_name: str,
+) -> None:
+    source = (SCRIPT_DIR / script_name).read_text(encoding="utf-8")
+
+    forbidden_fields = [
+        '"output_db":',
+        '"output_jsonl":',
+        '"output_template":',
+        '"summary_path":',
+    ]
+    for field in forbidden_fields:
+        assert field not in source
+
+
+@pytest.mark.parametrize("script_name", PATH_HARDENED_SCRIPT_NAMES)
+def test_decision_chain_cli_plaintext_success_uses_basename_only(
+    script_name: str,
+) -> None:
+    source = (SCRIPT_DIR / script_name).read_text(encoding="utf-8")
+
+    forbidden_interpolations = [
+        "{result.output_db}",
+        "{result.output_jsonl}",
+        "{result.output_template}",
+        "{result.summary_path}",
+    ]
+    for interpolation in forbidden_interpolations:
+        assert interpolation not in source

--- a/scripts/tests/test_whatsapp_corpus_drive_export_manifest.py
+++ b/scripts/tests/test_whatsapp_corpus_drive_export_manifest.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.whatsapp_corpus.build_drive_export_manifest import (
+    build_drive_export_manifest,
+)
+
+
+def _write_lsjson(path: Path) -> None:
+    records = [
+        {
+            "Path": "Private Clients/WhatsApp Chat - VeryPrivateClient.zip",
+            "Name": "WhatsApp Chat - VeryPrivateClient.zip",
+            "Size": 1024,
+            "ModTime": "2026-06-01T10:00:00Z",
+            "MimeType": "application/zip",
+            "IsDir": False,
+            "ID": "drive-file-secret-alpha",
+        },
+        {
+            "Path": "Private Clients/not-a-chat.zip",
+            "Name": "not-a-chat.zip",
+            "Size": 512,
+            "ModTime": "2026-06-01T10:10:00Z",
+            "MimeType": "application/zip",
+            "IsDir": False,
+            "ID": "drive-file-secret-beta",
+        },
+        {
+            "Path": "Archive/whatsapp chat - CompanyOps.zip",
+            "Name": "whatsapp chat - CompanyOps.zip",
+            "Size": 2048,
+            "ModTime": "2026-06-02T11:00:00Z",
+            "MimeType": "application/octet-stream",
+            "IsDir": False,
+            "ID": "drive-file-secret-gamma",
+        },
+        {
+            "Path": "Archive/WhatsApp Chat - Folder",
+            "Name": "WhatsApp Chat - Folder",
+            "Size": 0,
+            "ModTime": "2026-06-02T11:00:00Z",
+            "MimeType": "inode/directory",
+            "IsDir": True,
+            "ID": "drive-folder-secret",
+        },
+    ]
+    path.write_text(json.dumps(records), encoding="utf-8")
+
+
+def test_build_drive_export_manifest_writes_local_db_and_safe_summary(tmp_path: Path) -> None:
+    lsjson = tmp_path / "drive_lsjson.local.json"
+    output_db = tmp_path / "drive_export_manifest.local.sqlite"
+    summary = tmp_path / "drive_export_manifest_summary.md"
+    _write_lsjson(lsjson)
+
+    result = build_drive_export_manifest(
+        lsjson_path=lsjson,
+        output_db=output_db,
+        summary_path=summary,
+        remote_label="gdrive",
+    )
+
+    assert result.scanned_records == 4
+    assert result.candidate_count == 2
+    assert result.total_size_bytes == 3072
+
+    with sqlite3.connect(output_db) as conn:
+        rows = conn.execute(
+            """
+            SELECT file_id, candidate_kind, raw_path, path_hash, drive_id_hash
+            FROM drive_export_candidates
+            ORDER BY file_id
+            """
+        ).fetchall()
+    assert rows[0][0] == "drive-wa-0001"
+    assert rows[0][1] == "whatsapp_chat_zip"
+    assert rows[0][2] == "Private Clients/WhatsApp Chat - VeryPrivateClient.zip"
+    assert rows[0][3]
+    assert rows[0][4]
+    assert rows[1][0] == "drive-wa-0002"
+
+    rendered = summary.read_text(encoding="utf-8")
+    assert "VeryPrivateClient" not in rendered
+    assert "CompanyOps" not in rendered
+    assert "drive-file-secret" not in rendered
+    assert "Private Clients" not in rendered
+    assert "3,072" in rendered
+    assert "drive-wa-0001" in rendered
+    assert "whatsapp_chat_zip" in rendered
+
+
+def test_cli_writes_json_counts_without_raw_drive_names(tmp_path: Path) -> None:
+    lsjson = tmp_path / "drive_lsjson.local.json"
+    output_db = tmp_path / "drive_export_manifest.local.sqlite"
+    summary = tmp_path / "drive_export_manifest_summary.md"
+    _write_lsjson(lsjson)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.whatsapp_corpus.build_drive_export_manifest",
+            "--lsjson",
+            str(lsjson),
+            "--output-db",
+            str(output_db),
+            "--summary",
+            str(summary),
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "candidate_count": 2,
+        "scanned_records": 4,
+        "total_size_bytes": 3072,
+    }
+    assert "VeryPrivateClient" not in result.stdout
+    assert "drive-file-secret" not in result.stdout
+
+
+def test_cli_error_is_sanitized_for_missing_lsjson(tmp_path: Path) -> None:
+    missing_lsjson = tmp_path / "VeryPrivateClient_drive_lsjson.local.json"
+    output_db = tmp_path / "drive_export_manifest.local.sqlite"
+    summary = tmp_path / "drive_export_manifest_summary.md"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.whatsapp_corpus.build_drive_export_manifest",
+            "--lsjson",
+            str(missing_lsjson),
+            "--output-db",
+            str(output_db),
+            "--summary",
+            str(summary),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert result.stderr == "ERROR: Drive export manifest input is missing or invalid.\n"
+    forbidden_markers = [
+        str(tmp_path),
+        str(missing_lsjson),
+        missing_lsjson.name,
+        str(output_db),
+        str(summary),
+        "Traceback",
+        ".json",
+        ".sqlite",
+    ]
+    for marker in forbidden_markers:
+        assert marker not in result.stderr
+
+
+def test_manifest_allows_duplicate_names_when_drive_ids_differ(tmp_path: Path) -> None:
+    lsjson = tmp_path / "drive_lsjson.local.json"
+    output_db = tmp_path / "drive_export_manifest.local.sqlite"
+    summary = tmp_path / "drive_export_manifest_summary.md"
+    records = [
+        {
+            "Path": "WhatsApp Chat - Duplicate.zip",
+            "Name": "WhatsApp Chat - Duplicate.zip",
+            "Size": 100,
+            "IsDir": False,
+            "ID": "drive-file-duplicate-a",
+        },
+        {
+            "Path": "WhatsApp Chat - Duplicate.zip",
+            "Name": "WhatsApp Chat - Duplicate.zip",
+            "Size": 200,
+            "IsDir": False,
+            "ID": "drive-file-duplicate-b",
+        },
+    ]
+    lsjson.write_text(json.dumps(records), encoding="utf-8")
+
+    result = build_drive_export_manifest(
+        lsjson_path=lsjson,
+        output_db=output_db,
+        summary_path=summary,
+        remote_label="gdrive",
+    )
+
+    assert result.candidate_count == 2
+    with sqlite3.connect(output_db) as conn:
+        path_hashes = [
+            row[0]
+            for row in conn.execute(
+                "SELECT path_hash FROM drive_export_candidates ORDER BY file_id"
+            )
+        ]
+    assert len(set(path_hashes)) == 2
+
+
+def test_summary_formats_large_numbers_with_separators(tmp_path: Path) -> None:
+    lsjson = tmp_path / "drive_lsjson.local.json"
+    output_db = tmp_path / "drive_export_manifest.local.sqlite"
+    summary = tmp_path / "drive_export_manifest_summary.md"
+    records = [
+        {
+            "Path": "WhatsApp Chat - BigExport.zip",
+            "Name": "WhatsApp Chat - BigExport.zip",
+            "Size": 7567964172,
+            "IsDir": False,
+            "ID": "drive-file-big-export",
+        },
+    ]
+    lsjson.write_text(json.dumps(records), encoding="utf-8")
+
+    build_drive_export_manifest(
+        lsjson_path=lsjson,
+        output_db=output_db,
+        summary_path=summary,
+        remote_label="gdrive",
+    )
+
+    rendered = summary.read_text(encoding="utf-8")
+    assert "7567964172" not in rendered
+    assert "7,567,964,172" in rendered

--- a/scripts/tests/test_whatsapp_corpus_evidence_gap_detector.py
+++ b/scripts/tests/test_whatsapp_corpus_evidence_gap_detector.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.whatsapp_corpus.build_evidence_gap_detector import (
+    build_evidence_gap_detector,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_evidence_gap_detector.py"
+
+
+def _write_case_timelines_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE case_timeline_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                case_count INTEGER NOT NULL,
+                event_count INTEGER NOT NULL,
+                war_room_case_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE case_timelines (
+                case_card_id TEXT PRIMARY KEY,
+                timeline_rank INTEGER NOT NULL,
+                timeline_status TEXT NOT NULL,
+                highest_risk TEXT NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                primary_action TEXT NOT NULL,
+                latest_movement TEXT NOT NULL,
+                blocker_code TEXT NOT NULL,
+                event_count INTEGER NOT NULL,
+                has_war_room_item INTEGER NOT NULL,
+                timeline_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE TABLE case_timeline_events (
+                event_id TEXT PRIMARY KEY,
+                case_card_id TEXT NOT NULL,
+                event_rank INTEGER NOT NULL,
+                event_stage TEXT NOT NULL,
+                event_status TEXT NOT NULL,
+                event_lane TEXT NOT NULL,
+                action_code TEXT NOT NULL,
+                event_signal TEXT NOT NULL,
+                event_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO case_timeline_runs (
+                id, generated_at_utc, privacy_mode, case_count, event_count,
+                war_room_case_count, send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, 3, 3, 1, 0, 0)
+            """,
+            (
+                "2026-06-17T10:10:00+00:00",
+                "local_only_case_timeline_no_raw_text_no_send_no_crm_mutation",
+            ),
+        )
+        rows = [
+            (
+                "card-hot-followup",
+                1,
+                "war_room_active",
+                "P1",
+                "sahira",
+                "crm_followup",
+                "client_followup_due",
+                "case_stall_followup_risk",
+                4,
+                1,
+            ),
+            (
+                "card-doc",
+                2,
+                "operator_due_today",
+                "P2",
+                "adit",
+                "document_chase",
+                "document_request_due",
+                "document_gap_today",
+                3,
+                0,
+            ),
+            (
+                "card-pay",
+                3,
+                "operator_due_today",
+                "P2",
+                "surya",
+                "payment_reconcile",
+                "payment_check_due",
+                "payment_reconciliation_needed",
+                3,
+                0,
+            ),
+        ]
+        conn.executemany(
+            """
+            INSERT INTO case_timelines (
+                case_card_id, timeline_rank, timeline_status, highest_risk,
+                assigned_lane, primary_action, latest_movement, blocker_code,
+                event_count, has_war_room_item, timeline_payload_json,
+                send_whatsapp, crm_mutation, requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 1)
+            """,
+            [
+                (
+                    *row,
+                    json.dumps(
+                        {
+                            "schema_version": "case_timeline_synthesizer.v1",
+                            "raw_text_included": False,
+                        },
+                        sort_keys=True,
+                    ),
+                )
+                for row in rows
+            ],
+        )
+        conn.executemany(
+            """
+            INSERT INTO case_timeline_events (
+                event_id, case_card_id, event_rank, event_stage, event_status,
+                event_lane, action_code, event_signal, event_payload_json,
+                send_whatsapp, crm_mutation, requires_human_approval
+            )
+            VALUES (?, ?, 1, 'case_memory', ?, ?, ?, ?, ?, 0, 0, 1)
+            """,
+            [
+                (
+                    f"event-{row[0]}",
+                    row[0],
+                    row[2],
+                    row[4],
+                    row[5],
+                    row[7],
+                    json.dumps({"raw_text_included": False}, sort_keys=True),
+                )
+                for row in rows
+            ],
+        )
+        conn.commit()
+
+
+def test_build_evidence_gap_detector_writes_local_gap_queue(tmp_path: Path) -> None:
+    case_timelines_db = tmp_path / "case_timelines.local.sqlite"
+    output_dir = tmp_path / "evidence-gaps"
+    summary_path = output_dir / "evidence_gaps_summary.md"
+    _write_case_timelines_db(case_timelines_db)
+
+    result = build_evidence_gap_detector(
+        case_timelines_db=case_timelines_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+        generated_at_utc="2026-06-17T11:00:00+00:00",
+    )
+
+    assert result.case_count == 3
+    assert result.gap_count == 3
+    assert result.output_db == output_dir / "evidence_gaps.local.sqlite"
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.category_counts == {"client_response": 1, "document": 1, "finance": 1}
+    assert result.severity_counts == {"urgent": 1, "medium": 2}
+
+    with sqlite3.connect(result.output_db) as conn:
+        gaps = conn.execute(
+            """
+            SELECT case_card_id, gap_rank, assigned_lane, primary_action,
+                   gap_code, gap_category, gap_severity, closure_blocker,
+                   resolution_gate, send_whatsapp, crm_mutation,
+                   requires_human_approval, gap_payload_json
+            FROM evidence_gaps
+            ORDER BY gap_rank
+            """
+        ).fetchall()
+        run = conn.execute(
+            """
+            SELECT case_count, gap_count, closure_blocker_count,
+                   send_whatsapp_count, crm_mutation_count
+            FROM evidence_gap_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+
+    assert run == (3, 3, 3, 0, 0)
+    assert gaps[0][0:9] == (
+        "card-hot-followup",
+        1,
+        "sahira",
+        "crm_followup",
+        "client_followup_confirmation_missing",
+        "client_response",
+        "urgent",
+        1,
+        "owner_review_required",
+    )
+    assert gaps[1][0:9] == (
+        "card-doc",
+        2,
+        "adit",
+        "document_chase",
+        "required_document_evidence_missing",
+        "document",
+        "medium",
+        1,
+        "operator_upload_required",
+    )
+    assert gaps[2][0:9] == (
+        "card-pay",
+        3,
+        "surya",
+        "payment_reconcile",
+        "payment_reconciliation_evidence_missing",
+        "finance",
+        "medium",
+        1,
+        "operator_upload_required",
+    )
+    assert {row[9] for row in gaps} == {0}
+    assert {row[10] for row in gaps} == {0}
+    assert {row[11] for row in gaps} == {1}
+
+    payload = json.loads(gaps[0][12])
+    assert payload["schema_version"] == "evidence_gap_detector.v1"
+    assert payload["raw_text_included"] is False
+    assert payload["send_whatsapp"] is False
+    assert payload["crm_mutation"] is False
+    assert payload["requires_human_approval"] is True
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Evidence Gap Detector Summary" in summary
+    assert "| Cases reviewed | 3 |" in summary
+    assert "| Evidence gaps | 3 |" in summary
+    assert "| Closure blockers | 3 |" in summary
+    assert "| WhatsApp sends | 0 |" in summary
+    assert "| CRM mutations | 0 |" in summary
+    assert "card-hot-followup" not in summary
+    assert "card-doc" not in summary
+    assert "card-pay" not in summary
+
+
+def test_build_evidence_gap_detector_rejects_unexpected_input_name(
+    tmp_path: Path,
+) -> None:
+    unexpected_db = tmp_path / "operator_sla_clock.local.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    with pytest.raises(ValueError, match="Refusing to read unexpected Case Timelines DB"):
+        build_evidence_gap_detector(
+            case_timelines_db=unexpected_db,
+            output_dir=tmp_path / "evidence-gaps",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_cli_writes_json_without_case_details(tmp_path: Path) -> None:
+    case_timelines_db = tmp_path / "case_timelines.local.sqlite"
+    output_dir = tmp_path / "evidence-gaps"
+    summary_path = output_dir / "evidence_gaps_summary.md"
+    _write_case_timelines_db(case_timelines_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--case-timelines-db",
+            str(case_timelines_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--generated-at-utc",
+            "2026-06-17T11:00:00+00:00",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "case_count": 3,
+        "crm_mutation_count": 0,
+        "gap_count": 3,
+        "output_db": str(output_dir / "evidence_gaps.local.sqlite"),
+        "send_whatsapp_count": 0,
+        "summary_path": str(summary_path),
+    }
+    assert "card-hot-followup" not in result.stdout
+    assert "card-doc" not in result.stdout
+    assert "card-pay" not in result.stdout

--- a/scripts/tests/test_whatsapp_corpus_import_drive_exports.py
+++ b/scripts/tests/test_whatsapp_corpus_import_drive_exports.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import subprocess
+import shutil
+import sqlite3
+import sys
+import zipfile
+from pathlib import Path
+
+from scripts.whatsapp_corpus.build_drive_export_manifest import build_drive_export_manifest
+from scripts.whatsapp_corpus.import_drive_exports import import_drive_exports
+
+
+def _write_manifest(tmp_path: Path, *, drive_id: str | None = "drive-file-secret") -> Path:
+    lsjson = tmp_path / "drive_lsjson.local.json"
+    output_db = tmp_path / "drive_export_manifest.local.sqlite"
+    summary = tmp_path / "drive_export_manifest_summary.md"
+    id_fragment = f', "ID": "{drive_id}"' if drive_id else ""
+    lsjson.write_text(
+        "["
+        "{"
+        '"Path": "Private Clients/WhatsApp Chat - VeryPrivateClient.zip",'
+        '"Name": "WhatsApp Chat - VeryPrivateClient.zip",'
+        '"Size": 1024,'
+        '"IsDir": false'
+        f"{id_fragment}"
+        "}"
+        "]",
+        encoding="utf-8",
+    )
+    build_drive_export_manifest(
+        lsjson_path=lsjson,
+        output_db=output_db,
+        summary_path=summary,
+        remote_label="gdrive",
+    )
+    return output_db
+
+
+def test_dry_run_writes_safe_summary_without_downloading(tmp_path: Path) -> None:
+    manifest_db = _write_manifest(tmp_path)
+    summary = tmp_path / "drive_import_summary.md"
+    called: list[list[str]] = []
+
+    result = import_drive_exports(
+        manifest_db=manifest_db,
+        download_dir=tmp_path / "downloads.local",
+        corpus_root=tmp_path / "corpus",
+        summary_path=summary,
+        execute=False,
+        runner=lambda command: called.append(command) or 0,
+    )
+
+    assert result.selected_count == 1
+    assert result.downloaded_count == 0
+    assert result.extracted_text_files == 0
+    assert called == []
+
+    rendered = summary.read_text(encoding="utf-8")
+    assert "VeryPrivateClient" not in rendered
+    assert "Private Clients" not in rendered
+    assert "drive-file-secret" not in rendered
+    assert "drive-wa-0001" in rendered
+    assert "dry_run" in rendered
+
+    with sqlite3.connect(manifest_db) as conn:
+        row = conn.execute(
+            "SELECT download_status, imported_to_corpus FROM drive_export_candidates"
+        ).fetchone()
+    assert row == ("pending", 0)
+
+
+def test_import_by_drive_id_uses_copyid_and_extracts_sanitized_txt(tmp_path: Path) -> None:
+    manifest_db = _write_manifest(tmp_path)
+    source_zip = tmp_path / "source.zip"
+    with zipfile.ZipFile(source_zip, "w") as archive:
+        archive.writestr(
+            "WhatsApp Chat with Secret Person.txt",
+            "[01/06/26, 08.00.00] Secret Person: raw local message\n",
+        )
+        archive.writestr("Secret Person.jpg", b"not imported")
+
+    commands: list[list[str]] = []
+
+    def fake_runner(command: list[str]) -> int:
+        commands.append(command)
+        shutil.copyfile(source_zip, command[-1])
+        return 0
+
+    result = import_drive_exports(
+        manifest_db=manifest_db,
+        download_dir=tmp_path / "downloads.local",
+        corpus_root=tmp_path / "corpus",
+        summary_path=tmp_path / "drive_import_summary.md",
+        execute=True,
+        runner=fake_runner,
+    )
+
+    assert result.selected_count == 1
+    assert result.downloaded_count == 1
+    assert result.extracted_text_files == 1
+    assert commands == [
+        [
+            "rclone",
+            "backend",
+            "copyid",
+            "gdrive:",
+            "drive-file-secret",
+            str(tmp_path / "downloads.local" / "drive-wa-0001.zip"),
+        ]
+    ]
+
+    imported = tmp_path / "corpus" / "03_drive-imports" / "drive-wa-0001" / "chat-0001.txt"
+    assert imported.read_text(encoding="utf-8") == (
+        "[01/06/26, 08.00.00] Secret Person: raw local message\n"
+    )
+    assert not list((tmp_path / "corpus").rglob("*Secret*"))
+
+    with sqlite3.connect(manifest_db) as conn:
+        row = conn.execute(
+            "SELECT download_status, imported_to_corpus FROM drive_export_candidates"
+        ).fetchone()
+    assert row == ("imported", 1)
+
+
+def test_import_without_drive_id_falls_back_to_copyto(tmp_path: Path) -> None:
+    manifest_db = _write_manifest(tmp_path, drive_id=None)
+    source_zip = tmp_path / "source.zip"
+    with zipfile.ZipFile(source_zip, "w") as archive:
+        archive.writestr("_chat.txt", "[01/06/26, 08.00.00] Person: body\n")
+
+    commands: list[list[str]] = []
+
+    def fake_runner(command: list[str]) -> int:
+        commands.append(command)
+        shutil.copyfile(source_zip, command[-1])
+        return 0
+
+    import_drive_exports(
+        manifest_db=manifest_db,
+        download_dir=tmp_path / "downloads.local",
+        corpus_root=tmp_path / "corpus",
+        summary_path=tmp_path / "drive_import_summary.md",
+        execute=True,
+        runner=fake_runner,
+    )
+
+    assert commands[0][:3] == ["rclone", "copyto", "gdrive:Private Clients/WhatsApp Chat - VeryPrivateClient.zip"]
+
+
+def test_cli_error_is_sanitized_for_unexpected_manifest_name(tmp_path: Path) -> None:
+    wrong_db = tmp_path / "wrong_manifest_should_not_leak.local.sqlite"
+    wrong_db.write_bytes(b"")
+    download_dir = tmp_path / "downloads.local"
+    corpus_root = tmp_path / "corpus"
+    summary = tmp_path / "drive_import_summary.md"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.whatsapp_corpus.import_drive_exports",
+            "--manifest-db",
+            str(wrong_db),
+            "--download-dir",
+            str(download_dir),
+            "--corpus-root",
+            str(corpus_root),
+            "--summary",
+            str(summary),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert result.stderr == "ERROR: Drive import input is missing or invalid.\n"
+    forbidden_markers = [
+        str(tmp_path),
+        str(wrong_db),
+        wrong_db.name,
+        str(download_dir),
+        str(corpus_root),
+        str(summary),
+        "Traceback",
+        ".sqlite",
+    ]
+    for marker in forbidden_markers:
+        assert marker not in result.stderr

--- a/scripts/tests/test_whatsapp_corpus_next_best_action_ranker.py
+++ b/scripts/tests/test_whatsapp_corpus_next_best_action_ranker.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.whatsapp_corpus.build_next_best_action_ranker import build_next_best_action_ranker
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_next_best_action_ranker.py"
+
+
+def _write_case_memory_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE case_memory_card_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                card_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE case_memory_cards (
+                case_card_id TEXT PRIMARY KEY,
+                source_shadow_id TEXT NOT NULL,
+                source_window_id TEXT NOT NULL,
+                case_owner TEXT NOT NULL,
+                case_status TEXT NOT NULL,
+                risk_level TEXT NOT NULL,
+                next_best_action TEXT NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                latest_movement TEXT NOT NULL,
+                blocker_code TEXT NOT NULL,
+                review_rank INTEGER NOT NULL,
+                card_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO case_memory_card_runs VALUES (
+                1, '2026-06-17T00:00:00+00:00',
+                'local_only_case_memory_cards_no_raw_text_no_send_no_crm_mutation',
+                2, 0, 0
+            )
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO case_memory_cards VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            """,
+            [
+                (
+                    "card-followup",
+                    "shadow-followup",
+                    "cw-followup",
+                    "zantara_client_captain",
+                    "needs_human_review",
+                    "P1",
+                    "crm_followup",
+                    "sahira",
+                    "2026-06:42",
+                    "case_stall_followup_risk",
+                    1,
+                    json.dumps(
+                        {
+                            "event_count": 21,
+                            "message_count": 9,
+                            "severity_high_count": 3,
+                            "raw_text_included": False,
+                        },
+                        sort_keys=True,
+                    ),
+                    0,
+                    0,
+                    1,
+                ),
+                (
+                    "card-payment",
+                    "shadow-payment",
+                    "cw-payment",
+                    "zantara_client_captain",
+                    "monitor_and_prepare",
+                    "P2",
+                    "payment_reconcile",
+                    "surya",
+                    "2026-04:15",
+                    "payment_reconciliation_needed",
+                    2,
+                    json.dumps(
+                        {
+                            "event_count": 8,
+                            "message_count": 4,
+                            "severity_high_count": 0,
+                            "raw_text_included": False,
+                        },
+                        sort_keys=True,
+                    ),
+                    0,
+                    0,
+                    1,
+                ),
+            ],
+        )
+        conn.commit()
+
+
+def test_build_next_best_action_ranker_writes_top_three_actions_per_card(
+    tmp_path: Path,
+) -> None:
+    case_memory_db = tmp_path / "case_memory_cards.local.sqlite"
+    output_dir = tmp_path / "next-best-actions"
+    summary_path = output_dir / "next_best_actions_summary.md"
+    _write_case_memory_db(case_memory_db)
+
+    result = build_next_best_action_ranker(
+        case_memory_db=case_memory_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+    )
+
+    assert result.case_count == 2
+    assert result.action_count == 6
+    assert result.output_db == output_dir / "next_best_actions.local.sqlite"
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.top_action_counts == {"crm_followup": 1, "payment_reconcile": 1}
+
+    with sqlite3.connect(result.output_db) as conn:
+        rows = conn.execute(
+            """
+            SELECT case_card_id, action_rank, action_code, reason_code,
+                   urgency_score, impact_score, combined_score, assigned_lane,
+                   send_whatsapp, crm_mutation, requires_human_approval,
+                   action_payload_json
+            FROM next_best_action_rankings
+            ORDER BY case_card_id, action_rank
+            """
+        ).fetchall()
+
+    followup_rows = [row for row in rows if row[0] == "card-followup"]
+    payment_rows = [row for row in rows if row[0] == "card-payment"]
+    assert [row[1] for row in followup_rows] == [1, 2, 3]
+    assert [row[2] for row in followup_rows] == [
+        "crm_followup",
+        "operator_system_update",
+        "client_status_draft_review",
+    ]
+    assert [row[3] for row in followup_rows] == [
+        "stale_followup",
+        "missing_system_update",
+        "client_confused_or_silent",
+    ]
+    assert followup_rows[0][4:7] == (100, 85, 94)
+    assert {row[7] for row in followup_rows} == {"sahira"}
+    assert [row[2] for row in payment_rows] == [
+        "payment_reconcile",
+        "ledger_check",
+        "proof_of_payment_review",
+    ]
+    assert payment_rows[0][3] == "payment_risk"
+    assert payment_rows[0][4:7] == (70, 90, 78)
+    assert {row[8] for row in rows} == {0}
+    assert {row[9] for row in rows} == {0}
+    assert {row[10] for row in rows} == {1}
+    payload = json.loads(followup_rows[0][11])
+    assert payload["raw_text_included"] is False
+    assert payload["send_whatsapp"] is False
+    assert payload["crm_mutation"] is False
+    assert payload["source_case_status"] == "needs_human_review"
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Next Best Action Ranker Summary" in summary
+    assert "| Ranked cases | 2 |" in summary
+    assert "| Ranked actions | 6 |" in summary
+    assert "| WhatsApp sends | 0 |" in summary
+    assert "| CRM mutations | 0 |" in summary
+    assert "card-followup" not in summary
+    assert "shadow-followup" not in summary
+    assert "cw-followup" not in summary
+
+
+def test_build_next_best_action_ranker_rejects_unexpected_input_name(
+    tmp_path: Path,
+) -> None:
+    unexpected_db = tmp_path / "client_captain_shadow.local.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    with pytest.raises(ValueError, match="Refusing to read unexpected Case Memory DB"):
+        build_next_best_action_ranker(
+            case_memory_db=unexpected_db,
+            output_dir=tmp_path / "next-best-actions",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_cli_writes_json_without_raw_details(tmp_path: Path) -> None:
+    case_memory_db = tmp_path / "case_memory_cards.local.sqlite"
+    output_dir = tmp_path / "next-best-actions"
+    summary_path = output_dir / "next_best_actions_summary.md"
+    _write_case_memory_db(case_memory_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--case-memory-db",
+            str(case_memory_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["case_count"] == 2
+    assert payload["action_count"] == 6
+    assert payload["send_whatsapp_count"] == 0
+    assert payload["crm_mutation_count"] == 0
+    assert "card-followup" not in result.stdout
+    assert "shadow-followup" not in result.stdout

--- a/scripts/tests/test_whatsapp_corpus_operator_action_inbox.py
+++ b/scripts/tests/test_whatsapp_corpus_operator_action_inbox.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.whatsapp_corpus.build_operator_action_inbox import build_operator_action_inbox
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_operator_action_inbox.py"
+
+
+def _write_next_best_actions_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE next_best_action_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                case_count INTEGER NOT NULL,
+                action_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE next_best_action_rankings (
+                case_card_id TEXT NOT NULL,
+                action_rank INTEGER NOT NULL,
+                action_code TEXT NOT NULL,
+                action_title TEXT NOT NULL,
+                reason_code TEXT NOT NULL,
+                urgency_score INTEGER NOT NULL,
+                impact_score INTEGER NOT NULL,
+                combined_score INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                action_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1),
+                PRIMARY KEY (case_card_id, action_rank)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO next_best_action_runs VALUES (
+                1, '2026-06-17T00:00:00+00:00',
+                'local_only_next_best_actions_no_raw_text_no_send_no_crm_mutation',
+                2, 6, 0, 0
+            )
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO next_best_action_rankings VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            """,
+            [
+                (
+                    "card-followup",
+                    1,
+                    "crm_followup",
+                    "Crm Followup",
+                    "stale_followup",
+                    100,
+                    85,
+                    94,
+                    "sahira",
+                    json.dumps(
+                        {
+                            "source_case_status": "needs_human_review",
+                            "source_risk_level": "P1",
+                            "source_blocker_code": "case_stall_followup_risk",
+                            "latest_movement": "2026-06:42",
+                            "raw_text_included": False,
+                        },
+                        sort_keys=True,
+                    ),
+                    0,
+                    0,
+                    1,
+                ),
+                (
+                    "card-followup",
+                    2,
+                    "operator_system_update",
+                    "Operator System Update",
+                    "missing_system_update",
+                    95,
+                    80,
+                    89,
+                    "sahira",
+                    json.dumps({"raw_text_included": False}, sort_keys=True),
+                    0,
+                    0,
+                    1,
+                ),
+                (
+                    "card-followup",
+                    3,
+                    "client_status_draft_review",
+                    "Client Status Draft Review",
+                    "client_confused_or_silent",
+                    90,
+                    75,
+                    84,
+                    "sahira",
+                    json.dumps({"raw_text_included": False}, sort_keys=True),
+                    0,
+                    0,
+                    1,
+                ),
+                (
+                    "card-payment",
+                    1,
+                    "payment_reconcile",
+                    "Payment Reconcile",
+                    "payment_risk",
+                    70,
+                    90,
+                    78,
+                    "surya",
+                    json.dumps(
+                        {
+                            "source_case_status": "monitor_and_prepare",
+                            "source_risk_level": "P2",
+                            "source_blocker_code": "payment_reconciliation_needed",
+                            "latest_movement": "2026-04:15",
+                            "raw_text_included": False,
+                        },
+                        sort_keys=True,
+                    ),
+                    0,
+                    0,
+                    1,
+                ),
+                (
+                    "card-payment",
+                    2,
+                    "ledger_check",
+                    "Ledger Check",
+                    "finance_verification",
+                    65,
+                    80,
+                    71,
+                    "surya",
+                    json.dumps({"raw_text_included": False}, sort_keys=True),
+                    0,
+                    0,
+                    1,
+                ),
+                (
+                    "card-payment",
+                    3,
+                    "proof_of_payment_review",
+                    "Proof Of Payment Review",
+                    "payment_evidence_gap",
+                    60,
+                    75,
+                    66,
+                    "surya",
+                    json.dumps({"raw_text_included": False}, sort_keys=True),
+                    0,
+                    0,
+                    1,
+                ),
+            ],
+        )
+        conn.commit()
+
+
+def test_build_operator_action_inbox_writes_one_review_item_per_case(
+    tmp_path: Path,
+) -> None:
+    next_best_db = tmp_path / "next_best_actions.local.sqlite"
+    output_dir = tmp_path / "operator-inbox"
+    summary_path = output_dir / "operator_action_inbox_summary.md"
+    _write_next_best_actions_db(next_best_db)
+
+    result = build_operator_action_inbox(
+        next_best_actions_db=next_best_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+    )
+
+    assert result.case_count == 2
+    assert result.candidate_action_count == 6
+    assert result.inbox_item_count == 2
+    assert result.output_db == output_dir / "operator_action_inbox.local.sqlite"
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.priority_counts == {"now": 1, "today": 1}
+    assert result.lane_counts == {"sahira": 1, "surya": 1}
+
+    with sqlite3.connect(result.output_db) as conn:
+        rows = conn.execute(
+            """
+            SELECT inbox_item_id, case_card_id, queue_rank, assigned_lane,
+                   priority_label, queue_bucket, action_code, reason_code,
+                   urgency_score, combined_score, operator_instruction,
+                   approval_mode, send_whatsapp, crm_mutation,
+                   requires_human_approval, item_payload_json
+            FROM operator_action_inbox
+            ORDER BY queue_rank
+            """
+        ).fetchall()
+
+    assert [row[1] for row in rows] == ["card-followup", "card-payment"]
+    assert [row[2] for row in rows] == [1, 2]
+    assert rows[0][3:10] == (
+        "sahira",
+        "now",
+        "follow_up_now",
+        "crm_followup",
+        "stale_followup",
+        100,
+        94,
+    )
+    assert rows[1][3:10] == (
+        "surya",
+        "today",
+        "finance_today",
+        "payment_reconcile",
+        "payment_risk",
+        70,
+        78,
+    )
+    assert "review the CRM follow-up" in rows[0][10]
+    assert rows[0][11] == "human_review_required"
+    assert {row[12] for row in rows} == {0}
+    assert {row[13] for row in rows} == {0}
+    assert {row[14] for row in rows} == {1}
+    payload = json.loads(rows[0][15])
+    assert payload["schema_version"] == "operator_action_inbox.v1"
+    assert payload["source_action_rank"] == 1
+    assert payload["candidate_action_count"] == 3
+    assert payload["raw_text_included"] is False
+    assert payload["send_whatsapp"] is False
+    assert payload["crm_mutation"] is False
+    assert payload["requires_human_approval"] is True
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Operator Action Inbox Summary" in summary
+    assert "| Inbox items | 2 |" in summary
+    assert "| Candidate actions reviewed | 6 |" in summary
+    assert "| WhatsApp sends | 0 |" in summary
+    assert "| CRM mutations | 0 |" in summary
+    assert "card-followup" not in summary
+    assert "card-payment" not in summary
+
+
+def test_build_operator_action_inbox_rejects_unexpected_input_name(
+    tmp_path: Path,
+) -> None:
+    unexpected_db = tmp_path / "case_memory_cards.local.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    with pytest.raises(ValueError, match="Refusing to read unexpected Next Best Actions DB"):
+        build_operator_action_inbox(
+            next_best_actions_db=unexpected_db,
+            output_dir=tmp_path / "operator-inbox",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_cli_writes_json_without_raw_case_details(tmp_path: Path) -> None:
+    next_best_db = tmp_path / "next_best_actions.local.sqlite"
+    output_dir = tmp_path / "operator-inbox"
+    summary_path = output_dir / "operator_action_inbox_summary.md"
+    _write_next_best_actions_db(next_best_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--next-best-actions-db",
+            str(next_best_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["case_count"] == 2
+    assert payload["candidate_action_count"] == 6
+    assert payload["inbox_item_count"] == 2
+    assert payload["send_whatsapp_count"] == 0
+    assert payload["crm_mutation_count"] == 0
+    assert "card-followup" not in result.stdout
+    assert "card-payment" not in result.stdout

--- a/scripts/tests/test_whatsapp_corpus_operator_execution_packets.py
+++ b/scripts/tests/test_whatsapp_corpus_operator_execution_packets.py
@@ -1,0 +1,475 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.whatsapp_corpus.build_operator_execution_packets import (
+    build_operator_execution_packets,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = (
+    REPO_ROOT
+    / "scripts"
+    / "whatsapp_corpus"
+    / "build_operator_execution_packets.py"
+)
+
+
+def _write_post_decision_work_order_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE post_decision_work_order_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_case_count INTEGER NOT NULL,
+                owner_item_count INTEGER NOT NULL,
+                pack_count INTEGER NOT NULL,
+                brief_count INTEGER NOT NULL,
+                queue_item_count INTEGER NOT NULL,
+                ledger_entry_count INTEGER NOT NULL,
+                event_row_count INTEGER NOT NULL,
+                work_order_count INTEGER NOT NULL,
+                ready_count INTEGER NOT NULL,
+                blocked_count INTEGER NOT NULL,
+                deferred_count INTEGER NOT NULL,
+                rejected_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE post_decision_work_orders (
+                work_order_id TEXT PRIMARY KEY,
+                event_id TEXT NOT NULL,
+                entry_id TEXT NOT NULL,
+                route_id TEXT NOT NULL,
+                case_card_id TEXT NOT NULL,
+                brief_id TEXT NOT NULL,
+                pack_id TEXT NOT NULL,
+                work_order_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                decision_priority TEXT NOT NULL,
+                route_bucket TEXT NOT NULL,
+                owner_decision TEXT NOT NULL,
+                source_capture_status TEXT NOT NULL,
+                work_order_status TEXT NOT NULL,
+                work_order_type TEXT NOT NULL,
+                execution_gate TEXT NOT NULL,
+                next_actor TEXT NOT NULL,
+                action_intent TEXT NOT NULL,
+                decision_effect TEXT NOT NULL,
+                decision_note TEXT NOT NULL,
+                source_event_hash TEXT NOT NULL,
+                work_order_hash TEXT NOT NULL UNIQUE,
+                work_order_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO post_decision_work_order_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_case_count, owner_item_count, pack_count, brief_count,
+                queue_item_count, ledger_entry_count, event_row_count,
+                work_order_count, ready_count, blocked_count, deferred_count,
+                rejected_count, send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, 8, 4, 4, 4, 4, 4, 4, 4, 1, 1, 1, 1, 0, 0)
+            """,
+            (
+                "2026-06-17T20:00:00+00:00",
+                "2026-06-17T19:00:00+00:00",
+                "local_only_post_decision_work_order_no_raw_text_no_send_no_crm_mutation",
+            ),
+        )
+        rows = [
+            (
+                "post-work-order-pending",
+                "owner-event-pending",
+                "ledger-entry-pending",
+                "approval-route-pending",
+                "card-owner-pending",
+                "owner-brief-pending",
+                "owner-pack-pending",
+                1,
+                "sahira",
+                "approve_client_recovery_followup",
+                "now",
+                "owner_now",
+                "pending",
+                "awaiting_owner_input",
+                "blocked_awaiting_owner_decision",
+                "owner_decision_required",
+                "owner_input_required",
+                "owner",
+                "wait_for_owner_decision",
+                "no_action_until_owner_decision",
+                "owner_decision_required",
+                "event-a",
+                "a" * 64,
+            ),
+            (
+                "post-work-order-approve",
+                "owner-event-approve",
+                "ledger-entry-approve",
+                "approval-route-approve",
+                "card-owner-approve",
+                "owner-brief-approve",
+                "owner-pack-approve",
+                2,
+                "sahira",
+                "approve_client_recovery_followup",
+                "now",
+                "owner_now",
+                "approve",
+                "captured",
+                "ready_for_operator_review",
+                "approved_client_recovery_followup",
+                "human_review_before_send_or_crm",
+                "sahira",
+                "prepare_client_recovery_followup_for_human_review",
+                "owner_approved_internal_work_order",
+                "approved recovery follow-up",
+                "event-b",
+                "b" * 64,
+            ),
+            (
+                "post-work-order-defer",
+                "owner-event-defer",
+                "ledger-entry-defer",
+                "approval-route-defer",
+                "card-owner-defer",
+                "owner-brief-defer",
+                "owner-pack-defer",
+                3,
+                "ari",
+                "approve_immigration_status_escalation",
+                "now",
+                "owner_now",
+                "defer",
+                "captured",
+                "deferred_owner_followup",
+                "owner_deferred_followup",
+                "owner_revisit_required",
+                "owner",
+                "schedule_owner_revisit",
+                "deferred_no_external_action",
+                "wait for immigration evidence",
+                "event-c",
+                "c" * 64,
+            ),
+            (
+                "post-work-order-reject",
+                "owner-event-reject",
+                "ledger-entry-reject",
+                "approval-route-reject",
+                "card-owner-reject",
+                "owner-brief-reject",
+                "owner-pack-reject",
+                4,
+                "ari",
+                "approve_immigration_status_escalation",
+                "now",
+                "owner_now",
+                "reject",
+                "captured",
+                "rejected_no_action",
+                "owner_rejected_no_action",
+                "no_external_action",
+                "owner",
+                "record_rejection_and_stop",
+                "rejected_no_external_action",
+                "do not proceed",
+                "event-d",
+                "d" * 64,
+            ),
+        ]
+        conn.executemany(
+            """
+            INSERT INTO post_decision_work_orders (
+                work_order_id, event_id, entry_id, route_id, case_card_id,
+                brief_id, pack_id, work_order_rank, assigned_lane, decision_type,
+                decision_priority, route_bucket, owner_decision,
+                source_capture_status, work_order_status, work_order_type,
+                execution_gate, next_actor, action_intent, decision_effect,
+                decision_note, source_event_hash, work_order_hash,
+                work_order_payload_json, send_whatsapp, crm_mutation,
+                requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 1)
+            """,
+            [
+                (
+                    *row,
+                    json.dumps(
+                        {
+                            "schema_version": "post_decision_work_order_queue.v1",
+                            "raw_text_included": False,
+                            "send_whatsapp": False,
+                            "crm_mutation": False,
+                            "requires_human_approval": True,
+                        },
+                        sort_keys=True,
+                    ),
+                )
+                for row in rows
+            ],
+        )
+        conn.commit()
+
+
+def test_build_operator_execution_packets_maps_work_orders_to_internal_packets(
+    tmp_path: Path,
+) -> None:
+    work_orders_db = tmp_path / "post_decision_work_order_queue.local.sqlite"
+    output_dir = tmp_path / "operator-execution-packets"
+    summary_path = output_dir / "operator_execution_packets_summary.md"
+    _write_post_decision_work_order_db(work_orders_db)
+
+    result = build_operator_execution_packets(
+        work_orders_db=work_orders_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+        generated_at_utc="2026-06-17T21:00:00+00:00",
+    )
+
+    assert result.source_case_count == 8
+    assert result.owner_item_count == 4
+    assert result.pack_count == 4
+    assert result.brief_count == 4
+    assert result.queue_item_count == 4
+    assert result.ledger_entry_count == 4
+    assert result.event_row_count == 4
+    assert result.work_order_count == 4
+    assert result.packet_count == 4
+    assert result.ready_packet_count == 1
+    assert result.blocked_packet_count == 1
+    assert result.deferred_packet_count == 1
+    assert result.rejected_packet_count == 1
+    assert result.output_db == output_dir / "operator_execution_packets.local.sqlite"
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.packet_status_counts == {
+        "blocked_awaiting_owner_decision": 1,
+        "deferred_owner_followup": 1,
+        "ready_for_operator_review": 1,
+        "rejected_no_action": 1,
+    }
+    assert result.operator_lane_counts == {"owner": 3, "sahira": 1}
+
+    with sqlite3.connect(result.output_db) as conn:
+        rows = conn.execute(
+            """
+            SELECT case_card_id, work_order_id, event_id, packet_rank,
+                   assigned_lane, operator_lane, owner_decision,
+                   source_work_order_status, packet_status, packet_type,
+                   packet_gate, packet_action, operator_instruction,
+                   escalation_target, send_whatsapp, crm_mutation,
+                   requires_human_approval, packet_hash, packet_payload_json
+            FROM operator_execution_packets
+            ORDER BY packet_rank
+            """
+        ).fetchall()
+        run = conn.execute(
+            """
+            SELECT source_case_count, owner_item_count, pack_count, brief_count,
+                   queue_item_count, ledger_entry_count, event_row_count,
+                   work_order_count, packet_count, ready_packet_count,
+                   blocked_packet_count, deferred_packet_count,
+                   rejected_packet_count, send_whatsapp_count, crm_mutation_count
+            FROM operator_execution_packet_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+
+    assert run == (8, 4, 4, 4, 4, 4, 4, 4, 4, 1, 1, 1, 1, 0, 0)
+    assert rows[0][0:17] == (
+        "card-owner-pending",
+        "post-work-order-pending",
+        "owner-event-pending",
+        1,
+        "sahira",
+        "owner",
+        "pending",
+        "blocked_awaiting_owner_decision",
+        "blocked_awaiting_owner_decision",
+        "owner_decision_required_packet",
+        "owner_input_required",
+        "wait_for_owner_decision",
+        "no_operator_execution_until_owner_decides",
+        "owner",
+        0,
+        0,
+        1,
+    )
+    assert rows[1][0:17] == (
+        "card-owner-approve",
+        "post-work-order-approve",
+        "owner-event-approve",
+        2,
+        "sahira",
+        "sahira",
+        "approve",
+        "ready_for_operator_review",
+        "ready_for_operator_review",
+        "client_recovery_followup_packet",
+        "human_review_before_send_or_crm",
+        "prepare_client_recovery_followup_for_human_review",
+        "review_client_recovery_followup_before_any_send",
+        "owner",
+        0,
+        0,
+        1,
+    )
+    assert rows[2][8:14] == (
+        "deferred_owner_followup",
+        "owner_deferred_packet",
+        "owner_revisit_required",
+        "schedule_owner_revisit",
+        "hold_operator_execution_until_owner_revisits",
+        "owner",
+    )
+    assert rows[3][8:14] == (
+        "rejected_no_action",
+        "owner_rejected_packet",
+        "no_external_action",
+        "record_rejection_and_stop",
+        "do_not_execute_rejected_work_order",
+        "owner",
+    )
+    assert len({row[17] for row in rows}) == 4
+    assert all(len(row[17]) == 64 for row in rows)
+
+    payload = json.loads(rows[0][18])
+    assert payload["schema_version"] == "operator_execution_packets.v1"
+    assert payload["privacy_mode"] == "local_only_operator_execution_packet_no_raw_text"
+    assert payload["source_work_order_rank"] == 1
+    assert payload["source_work_order_status"] == "blocked_awaiting_owner_decision"
+    assert payload["owner_decision"] == "pending"
+    assert payload["packet_status"] == "blocked_awaiting_owner_decision"
+    assert payload["packet_gate"] == "owner_input_required"
+    assert payload["raw_text_included"] is False
+    assert payload["send_whatsapp"] is False
+    assert payload["crm_mutation"] is False
+    assert payload["requires_human_approval"] is True
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Operator Execution Packets Summary" in summary
+    assert "| Source cases | 8 |" in summary
+    assert "| Work orders | 4 |" in summary
+    assert "| Operator packets | 4 |" in summary
+    assert "| Ready packets | 1 |" in summary
+    assert "| Blocked packets | 1 |" in summary
+    assert "| Deferred packets | 1 |" in summary
+    assert "| Rejected packets | 1 |" in summary
+    assert "| WhatsApp sends | 0 |" in summary
+    assert "| CRM mutations | 0 |" in summary
+    assert "card-owner-pending" not in summary
+    assert "post-work-order-pending" not in summary
+    assert "owner-event-pending" not in summary
+    assert "ledger-entry-pending" not in summary
+    assert "approval-route-pending" not in summary
+
+
+def test_build_operator_execution_packets_rejects_unknown_work_order_status(
+    tmp_path: Path,
+) -> None:
+    work_orders_db = tmp_path / "post_decision_work_order_queue.local.sqlite"
+    output_dir = tmp_path / "operator-execution-packets"
+    _write_post_decision_work_order_db(work_orders_db)
+    with sqlite3.connect(work_orders_db) as conn:
+        conn.execute(
+            """
+            UPDATE post_decision_work_orders
+            SET work_order_status = 'send_now'
+            WHERE work_order_id = 'post-work-order-approve'
+            """
+        )
+        conn.commit()
+
+    with pytest.raises(ValueError, match="Unsupported work order status"):
+        build_operator_execution_packets(
+            work_orders_db=work_orders_db,
+            output_dir=output_dir,
+            summary_path=output_dir / "summary.md",
+        )
+
+
+def test_build_operator_execution_packets_rejects_unexpected_input_name(
+    tmp_path: Path,
+) -> None:
+    unexpected_db = tmp_path / "post_decision_work_order_queue.bad.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    with pytest.raises(
+        ValueError,
+        match="Refusing to read unexpected Post-Decision Work Order Queue DB",
+    ):
+        build_operator_execution_packets(
+            work_orders_db=unexpected_db,
+            output_dir=tmp_path / "operator-execution-packets",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_cli_writes_json_without_packet_details(tmp_path: Path) -> None:
+    work_orders_db = tmp_path / "post_decision_work_order_queue.local.sqlite"
+    output_dir = tmp_path / "operator-execution-packets"
+    summary_path = output_dir / "operator_execution_packets_summary.md"
+    _write_post_decision_work_order_db(work_orders_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--work-orders-db",
+            str(work_orders_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--generated-at-utc",
+            "2026-06-17T21:00:00+00:00",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "blocked_packet_count": 1,
+        "brief_count": 4,
+        "crm_mutation_count": 0,
+        "deferred_packet_count": 1,
+        "event_row_count": 4,
+        "ledger_entry_count": 4,
+        "operator_packet_count": 4,
+        "owner_item_count": 4,
+        "pack_count": 4,
+        "queue_item_count": 4,
+        "ready_packet_count": 1,
+        "rejected_packet_count": 1,
+        "send_whatsapp_count": 0,
+        "source_case_count": 8,
+        "work_order_count": 4,
+    }
+    assert "card-owner-pending" not in result.stdout
+    assert "post-work-order-pending" not in result.stdout
+    assert "owner-event-pending" not in result.stdout
+    assert "ledger-entry-pending" not in result.stdout
+    assert "approval-route-pending" not in result.stdout

--- a/scripts/tests/test_whatsapp_corpus_operator_packet_review_console.py
+++ b/scripts/tests/test_whatsapp_corpus_operator_packet_review_console.py
@@ -1,0 +1,504 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.whatsapp_corpus.build_operator_packet_review_console import (
+    build_operator_packet_review_console,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = (
+    REPO_ROOT
+    / "scripts"
+    / "whatsapp_corpus"
+    / "build_operator_packet_review_console.py"
+)
+
+
+def _write_operator_execution_packets_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE operator_execution_packet_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_case_count INTEGER NOT NULL,
+                owner_item_count INTEGER NOT NULL,
+                pack_count INTEGER NOT NULL,
+                brief_count INTEGER NOT NULL,
+                queue_item_count INTEGER NOT NULL,
+                ledger_entry_count INTEGER NOT NULL,
+                event_row_count INTEGER NOT NULL,
+                work_order_count INTEGER NOT NULL,
+                packet_count INTEGER NOT NULL,
+                ready_packet_count INTEGER NOT NULL,
+                blocked_packet_count INTEGER NOT NULL,
+                deferred_packet_count INTEGER NOT NULL,
+                rejected_packet_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE operator_execution_packets (
+                packet_id TEXT PRIMARY KEY,
+                work_order_id TEXT NOT NULL,
+                event_id TEXT NOT NULL,
+                entry_id TEXT NOT NULL,
+                route_id TEXT NOT NULL,
+                case_card_id TEXT NOT NULL,
+                brief_id TEXT NOT NULL,
+                pack_id TEXT NOT NULL,
+                packet_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                operator_lane TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                decision_priority TEXT NOT NULL,
+                route_bucket TEXT NOT NULL,
+                owner_decision TEXT NOT NULL,
+                source_work_order_status TEXT NOT NULL,
+                packet_status TEXT NOT NULL,
+                packet_type TEXT NOT NULL,
+                packet_gate TEXT NOT NULL,
+                packet_action TEXT NOT NULL,
+                operator_instruction TEXT NOT NULL,
+                escalation_target TEXT NOT NULL,
+                decision_note TEXT NOT NULL,
+                source_work_order_hash TEXT NOT NULL,
+                packet_hash TEXT NOT NULL UNIQUE,
+                packet_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO operator_execution_packet_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_case_count, owner_item_count, pack_count, brief_count,
+                queue_item_count, ledger_entry_count, event_row_count,
+                work_order_count, packet_count, ready_packet_count,
+                blocked_packet_count, deferred_packet_count,
+                rejected_packet_count, send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, 8, 4, 4, 4, 4, 4, 4, 4, 4, 1, 1, 1, 1, 0, 0)
+            """,
+            (
+                "2026-06-17T21:00:00+00:00",
+                "2026-06-17T20:00:00+00:00",
+                "local_only_operator_execution_packet_no_raw_text_no_send_no_crm_mutation",
+            ),
+        )
+        rows = [
+            (
+                "operator-packet-pending",
+                "post-work-order-pending",
+                "owner-event-pending",
+                "ledger-entry-pending",
+                "approval-route-pending",
+                "card-owner-pending",
+                "owner-brief-pending",
+                "owner-pack-pending",
+                1,
+                "sahira",
+                "owner",
+                "approve_client_recovery_followup",
+                "now",
+                "owner_now",
+                "pending",
+                "blocked_awaiting_owner_decision",
+                "blocked_awaiting_owner_decision",
+                "owner_decision_required_packet",
+                "owner_input_required",
+                "wait_for_owner_decision",
+                "no_operator_execution_until_owner_decides",
+                "owner",
+                "owner_decision_required",
+                "a" * 64,
+                "e" * 64,
+            ),
+            (
+                "operator-packet-approve",
+                "post-work-order-approve",
+                "owner-event-approve",
+                "ledger-entry-approve",
+                "approval-route-approve",
+                "card-owner-approve",
+                "owner-brief-approve",
+                "owner-pack-approve",
+                2,
+                "sahira",
+                "sahira",
+                "approve_client_recovery_followup",
+                "now",
+                "owner_now",
+                "approve",
+                "ready_for_operator_review",
+                "ready_for_operator_review",
+                "client_recovery_followup_packet",
+                "human_review_before_send_or_crm",
+                "prepare_client_recovery_followup_for_human_review",
+                "review_client_recovery_followup_before_any_send",
+                "owner",
+                "approved recovery follow-up",
+                "b" * 64,
+                "f" * 64,
+            ),
+            (
+                "operator-packet-defer",
+                "post-work-order-defer",
+                "owner-event-defer",
+                "ledger-entry-defer",
+                "approval-route-defer",
+                "card-owner-defer",
+                "owner-brief-defer",
+                "owner-pack-defer",
+                3,
+                "ari",
+                "owner",
+                "approve_immigration_status_escalation",
+                "now",
+                "owner_now",
+                "defer",
+                "deferred_owner_followup",
+                "deferred_owner_followup",
+                "owner_deferred_packet",
+                "owner_revisit_required",
+                "schedule_owner_revisit",
+                "hold_operator_execution_until_owner_revisits",
+                "owner",
+                "wait for immigration evidence",
+                "c" * 64,
+                "1" * 64,
+            ),
+            (
+                "operator-packet-reject",
+                "post-work-order-reject",
+                "owner-event-reject",
+                "ledger-entry-reject",
+                "approval-route-reject",
+                "card-owner-reject",
+                "owner-brief-reject",
+                "owner-pack-reject",
+                4,
+                "ari",
+                "owner",
+                "approve_immigration_status_escalation",
+                "now",
+                "owner_now",
+                "reject",
+                "rejected_no_action",
+                "rejected_no_action",
+                "owner_rejected_packet",
+                "no_external_action",
+                "record_rejection_and_stop",
+                "do_not_execute_rejected_work_order",
+                "owner",
+                "do not proceed",
+                "d" * 64,
+                "2" * 64,
+            ),
+        ]
+        conn.executemany(
+            """
+            INSERT INTO operator_execution_packets (
+                packet_id, work_order_id, event_id, entry_id, route_id,
+                case_card_id, brief_id, pack_id, packet_rank, assigned_lane,
+                operator_lane, decision_type, decision_priority, route_bucket,
+                owner_decision, source_work_order_status, packet_status,
+                packet_type, packet_gate, packet_action, operator_instruction,
+                escalation_target, decision_note, source_work_order_hash,
+                packet_hash, packet_payload_json, send_whatsapp, crm_mutation,
+                requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 1)
+            """,
+            [
+                (
+                    *row,
+                    json.dumps(
+                        {
+                            "schema_version": "operator_execution_packets.v1",
+                            "raw_text_included": False,
+                            "send_whatsapp": False,
+                            "crm_mutation": False,
+                            "requires_human_approval": True,
+                        },
+                        sort_keys=True,
+                    ),
+                )
+                for row in rows
+            ],
+        )
+        conn.commit()
+
+
+def test_build_operator_packet_review_console_maps_packets_to_review_items(
+    tmp_path: Path,
+) -> None:
+    packets_db = tmp_path / "operator_execution_packets.local.sqlite"
+    output_dir = tmp_path / "operator-packet-review-console"
+    summary_path = output_dir / "operator_packet_review_console_summary.md"
+    _write_operator_execution_packets_db(packets_db)
+
+    result = build_operator_packet_review_console(
+        packets_db=packets_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+        generated_at_utc="2026-06-17T22:00:00+00:00",
+    )
+
+    assert result.source_case_count == 8
+    assert result.owner_item_count == 4
+    assert result.pack_count == 4
+    assert result.brief_count == 4
+    assert result.queue_item_count == 4
+    assert result.ledger_entry_count == 4
+    assert result.event_row_count == 4
+    assert result.work_order_count == 4
+    assert result.packet_count == 4
+    assert result.review_item_count == 4
+    assert result.owner_decision_item_count == 1
+    assert result.operator_ready_item_count == 1
+    assert result.deferred_item_count == 1
+    assert result.rejected_item_count == 1
+    assert result.output_db == output_dir / "operator_packet_review_console.local.sqlite"
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.review_state_counts == {
+        "deferred_owner_revisit": 1,
+        "ready_for_human_review": 1,
+        "rejected_closed": 1,
+        "waiting_owner_decision": 1,
+    }
+    assert result.console_bucket_counts == {
+        "closed_no_action": 1,
+        "operator_review_queue": 1,
+        "owner_decision_inbox": 1,
+        "owner_revisit_queue": 1,
+    }
+
+    with sqlite3.connect(result.output_db) as conn:
+        rows = conn.execute(
+            """
+            SELECT case_card_id, packet_id, work_order_id, review_rank,
+                   assigned_lane, operator_lane, owner_decision, packet_status,
+                   review_state, console_bucket, review_priority,
+                   visible_owner_action, operator_action, console_instruction,
+                   review_gate, action_lock, send_whatsapp, crm_mutation,
+                   requires_human_approval, review_hash, review_payload_json
+            FROM operator_packet_review_items
+            ORDER BY review_rank
+            """
+        ).fetchall()
+        run = conn.execute(
+            """
+            SELECT source_case_count, owner_item_count, pack_count, brief_count,
+                   queue_item_count, ledger_entry_count, event_row_count,
+                   work_order_count, packet_count, review_item_count,
+                   owner_decision_item_count, operator_ready_item_count,
+                   deferred_item_count, rejected_item_count,
+                   send_whatsapp_count, crm_mutation_count
+            FROM operator_packet_review_console_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+
+    assert run == (8, 4, 4, 4, 4, 4, 4, 4, 4, 4, 1, 1, 1, 1, 0, 0)
+    assert rows[0][0:19] == (
+        "card-owner-pending",
+        "operator-packet-pending",
+        "post-work-order-pending",
+        1,
+        "sahira",
+        "owner",
+        "pending",
+        "blocked_awaiting_owner_decision",
+        "waiting_owner_decision",
+        "owner_decision_inbox",
+        "owner_now",
+        "capture_owner_decision",
+        "no_operator_action",
+        "owner_must_approve_reject_or_defer_before_team_work",
+        "owner_input_required",
+        "locked_until_owner_decision",
+        0,
+        0,
+        1,
+    )
+    assert rows[1][0:19] == (
+        "card-owner-approve",
+        "operator-packet-approve",
+        "post-work-order-approve",
+        2,
+        "sahira",
+        "sahira",
+        "approve",
+        "ready_for_operator_review",
+        "ready_for_human_review",
+        "operator_review_queue",
+        "operator_now",
+        "no_owner_action_required",
+        "review_packet_before_send_or_crm",
+        "review_ready_packet_and_request_human_approval",
+        "human_review_before_send_or_crm",
+        "locked_until_human_review",
+        0,
+        0,
+        1,
+    )
+    assert rows[2][8:16] == (
+        "deferred_owner_revisit",
+        "owner_revisit_queue",
+        "owner_revisit",
+        "revisit_deferred_decision",
+        "no_operator_action",
+        "owner_must_revisit_deferred_packet",
+        "owner_revisit_required",
+        "locked_until_owner_revisit",
+    )
+    assert rows[3][8:16] == (
+        "rejected_closed",
+        "closed_no_action",
+        "closed",
+        "no_action",
+        "no_operator_action",
+        "no_action_packet_rejected",
+        "no_external_action",
+        "closed_no_external_action",
+    )
+    assert len({row[19] for row in rows}) == 4
+    assert all(len(row[19]) == 64 for row in rows)
+
+    payload = json.loads(rows[0][20])
+    assert payload["schema_version"] == "operator_packet_review_console.v1"
+    assert payload["privacy_mode"] == "local_only_operator_packet_review_console_no_raw_text"
+    assert payload["source_packet_rank"] == 1
+    assert payload["packet_status"] == "blocked_awaiting_owner_decision"
+    assert payload["review_state"] == "waiting_owner_decision"
+    assert payload["console_bucket"] == "owner_decision_inbox"
+    assert payload["raw_text_included"] is False
+    assert payload["send_whatsapp"] is False
+    assert payload["crm_mutation"] is False
+    assert payload["requires_human_approval"] is True
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Operator Packet Review Console Summary" in summary
+    assert "| Source cases | 8 |" in summary
+    assert "| Operator packets | 4 |" in summary
+    assert "| Review items | 4 |" in summary
+    assert "| Owner decision items | 1 |" in summary
+    assert "| Operator-ready items | 1 |" in summary
+    assert "| Deferred items | 1 |" in summary
+    assert "| Rejected items | 1 |" in summary
+    assert "| WhatsApp sends | 0 |" in summary
+    assert "| CRM mutations | 0 |" in summary
+    assert "card-owner-pending" not in summary
+    assert "operator-packet-pending" not in summary
+    assert "post-work-order-pending" not in summary
+    assert "owner-event-pending" not in summary
+    assert "ledger-entry-pending" not in summary
+    assert "approval-route-pending" not in summary
+
+
+def test_build_operator_packet_review_console_rejects_unknown_packet_status(
+    tmp_path: Path,
+) -> None:
+    packets_db = tmp_path / "operator_execution_packets.local.sqlite"
+    output_dir = tmp_path / "operator-packet-review-console"
+    _write_operator_execution_packets_db(packets_db)
+    with sqlite3.connect(packets_db) as conn:
+        conn.execute(
+            """
+            UPDATE operator_execution_packets
+            SET packet_status = 'send_now'
+            WHERE packet_id = 'operator-packet-approve'
+            """
+        )
+        conn.commit()
+
+    with pytest.raises(ValueError, match="Unsupported packet status"):
+        build_operator_packet_review_console(
+            packets_db=packets_db,
+            output_dir=output_dir,
+            summary_path=output_dir / "summary.md",
+        )
+
+
+def test_build_operator_packet_review_console_rejects_unexpected_input_name(
+    tmp_path: Path,
+) -> None:
+    unexpected_db = tmp_path / "operator_execution_packets.bad.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    with pytest.raises(
+        ValueError,
+        match="Refusing to read unexpected Operator Execution Packets DB",
+    ):
+        build_operator_packet_review_console(
+            packets_db=unexpected_db,
+            output_dir=tmp_path / "operator-packet-review-console",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_cli_writes_json_without_review_details(tmp_path: Path) -> None:
+    packets_db = tmp_path / "operator_execution_packets.local.sqlite"
+    output_dir = tmp_path / "operator-packet-review-console"
+    summary_path = output_dir / "operator_packet_review_console_summary.md"
+    _write_operator_execution_packets_db(packets_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--packets-db",
+            str(packets_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--generated-at-utc",
+            "2026-06-17T22:00:00+00:00",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "brief_count": 4,
+        "crm_mutation_count": 0,
+        "deferred_item_count": 1,
+        "event_row_count": 4,
+        "ledger_entry_count": 4,
+        "operator_ready_item_count": 1,
+        "owner_decision_item_count": 1,
+        "owner_item_count": 4,
+        "pack_count": 4,
+        "packet_count": 4,
+        "queue_item_count": 4,
+        "rejected_item_count": 1,
+        "review_item_count": 4,
+        "send_whatsapp_count": 0,
+        "source_case_count": 8,
+        "work_order_count": 4,
+    }
+    assert "card-owner-pending" not in result.stdout
+    assert "operator-packet-pending" not in result.stdout
+    assert "post-work-order-pending" not in result.stdout
+    assert "owner-event-pending" not in result.stdout
+    assert "ledger-entry-pending" not in result.stdout
+    assert "approval-route-pending" not in result.stdout

--- a/scripts/tests/test_whatsapp_corpus_operator_sla_clock.py
+++ b/scripts/tests/test_whatsapp_corpus_operator_sla_clock.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.whatsapp_corpus.build_operator_sla_clock import build_operator_sla_clock
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_operator_sla_clock.py"
+
+
+def _write_operator_inbox_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE operator_action_inbox_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                case_count INTEGER NOT NULL,
+                inbox_item_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE operator_action_inbox (
+                inbox_item_id TEXT PRIMARY KEY,
+                case_card_id TEXT NOT NULL,
+                queue_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                priority_label TEXT NOT NULL,
+                queue_bucket TEXT NOT NULL,
+                action_code TEXT NOT NULL,
+                action_title TEXT NOT NULL,
+                reason_code TEXT NOT NULL,
+                urgency_score INTEGER NOT NULL,
+                impact_score INTEGER NOT NULL,
+                combined_score INTEGER NOT NULL,
+                operator_instruction TEXT NOT NULL,
+                approval_mode TEXT NOT NULL,
+                item_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO operator_action_inbox_runs VALUES (
+                1, '2026-06-17T08:00:00+00:00',
+                'local_only_operator_action_inbox_no_raw_text_no_send_no_crm_mutation',
+                2, 2, 0, 0
+            )
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO operator_action_inbox VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            """,
+            [
+                (
+                    "inbox-card-followup",
+                    "card-followup",
+                    1,
+                    "sahira",
+                    "now",
+                    "follow_up_now",
+                    "crm_followup",
+                    "Crm Followup",
+                    "stale_followup",
+                    100,
+                    85,
+                    94,
+                    "Operator must review the CRM follow-up.",
+                    "human_review_required",
+                    json.dumps(
+                        {
+                            "source_risk_level": "P1",
+                            "latest_movement": "2026-06:42",
+                            "raw_text_included": False,
+                        },
+                        sort_keys=True,
+                    ),
+                    0,
+                    0,
+                    1,
+                ),
+                (
+                    "inbox-card-payment",
+                    "card-payment",
+                    2,
+                    "surya",
+                    "today",
+                    "finance_today",
+                    "payment_reconcile",
+                    "Payment Reconcile",
+                    "payment_risk",
+                    70,
+                    90,
+                    78,
+                    "Operator must reconcile payment evidence.",
+                    "human_review_required",
+                    json.dumps(
+                        {
+                            "source_risk_level": "P2",
+                            "latest_movement": "2026-04:15",
+                            "raw_text_included": False,
+                        },
+                        sort_keys=True,
+                    ),
+                    0,
+                    0,
+                    1,
+                ),
+            ],
+        )
+        conn.commit()
+
+
+def test_build_operator_sla_clock_marks_overdue_and_due_today(
+    tmp_path: Path,
+) -> None:
+    inbox_db = tmp_path / "operator_action_inbox.local.sqlite"
+    output_dir = tmp_path / "operator-sla-clock"
+    summary_path = output_dir / "operator_sla_clock_summary.md"
+    _write_operator_inbox_db(inbox_db)
+
+    result = build_operator_sla_clock(
+        operator_inbox_db=inbox_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+        as_of_utc="2026-06-17T13:00:00+00:00",
+        generated_at_utc="2026-06-17T13:05:00+00:00",
+    )
+
+    assert result.inbox_item_count == 2
+    assert result.clock_count == 2
+    assert result.output_db == output_dir / "operator_sla_clock.local.sqlite"
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.status_counts == {"due_today": 1, "overdue": 1}
+    assert result.breach_risk_counts == {"breached": 1, "high": 1}
+
+    with sqlite3.connect(result.output_db) as conn:
+        rows = conn.execute(
+            """
+            SELECT inbox_item_id, case_card_id, queue_rank, assigned_lane,
+                   priority_label, queue_bucket, action_code, sla_minutes,
+                   source_inbox_generated_at_utc, due_at_utc, as_of_utc,
+                   minutes_until_due, aging_minutes, sla_status, breach_risk,
+                   escalation_label, send_whatsapp, crm_mutation,
+                   requires_human_approval, clock_payload_json
+            FROM operator_sla_clock
+            ORDER BY queue_rank
+            """
+        ).fetchall()
+
+    followup = rows[0]
+    payment = rows[1]
+    assert followup[0:8] == (
+        "inbox-card-followup",
+        "card-followup",
+        1,
+        "sahira",
+        "now",
+        "follow_up_now",
+        "crm_followup",
+        240,
+    )
+    assert followup[8:16] == (
+        "2026-06-17T08:00:00+00:00",
+        "2026-06-17T12:00:00+00:00",
+        "2026-06-17T13:00:00+00:00",
+        -60,
+        300,
+        "overdue",
+        "breached",
+        "owner_review",
+    )
+    assert payment[7:16] == (
+        480,
+        "2026-06-17T08:00:00+00:00",
+        "2026-06-17T16:00:00+00:00",
+        "2026-06-17T13:00:00+00:00",
+        180,
+        300,
+        "due_today",
+        "high",
+        "lane_lead_watch",
+    )
+    assert {row[16] for row in rows} == {0}
+    assert {row[17] for row in rows} == {0}
+    assert {row[18] for row in rows} == {1}
+    payload = json.loads(followup[19])
+    assert payload["schema_version"] == "operator_sla_clock.v1"
+    assert payload["raw_text_included"] is False
+    assert payload["send_whatsapp"] is False
+    assert payload["crm_mutation"] is False
+    assert payload["requires_human_approval"] is True
+    assert payload["source_priority_label"] == "now"
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Operator SLA Clock Summary" in summary
+    assert "| Inbox items reviewed | 2 |" in summary
+    assert "| SLA clocks | 2 |" in summary
+    assert "| Overdue clocks | 1 |" in summary
+    assert "| WhatsApp sends | 0 |" in summary
+    assert "| CRM mutations | 0 |" in summary
+    assert "card-followup" not in summary
+    assert "inbox-card-followup" not in summary
+
+
+def test_build_operator_sla_clock_rejects_unexpected_input_name(
+    tmp_path: Path,
+) -> None:
+    unexpected_db = tmp_path / "next_best_actions.local.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    with pytest.raises(ValueError, match="Refusing to read unexpected Operator Inbox DB"):
+        build_operator_sla_clock(
+            operator_inbox_db=unexpected_db,
+            output_dir=tmp_path / "operator-sla-clock",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_cli_writes_json_without_raw_case_details(tmp_path: Path) -> None:
+    inbox_db = tmp_path / "operator_action_inbox.local.sqlite"
+    output_dir = tmp_path / "operator-sla-clock"
+    summary_path = output_dir / "operator_sla_clock_summary.md"
+    _write_operator_inbox_db(inbox_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--operator-inbox-db",
+            str(inbox_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--as-of-utc",
+            "2026-06-17T13:00:00+00:00",
+            "--generated-at-utc",
+            "2026-06-17T13:05:00+00:00",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["inbox_item_count"] == 2
+    assert payload["clock_count"] == 2
+    assert payload["overdue_count"] == 1
+    assert payload["send_whatsapp_count"] == 0
+    assert payload["crm_mutation_count"] == 0
+    assert "card-followup" not in result.stdout
+    assert "inbox-card-followup" not in result.stdout

--- a/scripts/tests/test_whatsapp_corpus_owner_approval_console.py
+++ b/scripts/tests/test_whatsapp_corpus_owner_approval_console.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.whatsapp_corpus.build_owner_approval_console import (
+    build_owner_approval_console,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_owner_approval_console.py"
+
+
+def _write_case_closure_judge_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE case_closure_judge_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                case_count INTEGER NOT NULL,
+                blocked_count INTEGER NOT NULL,
+                ready_to_close_count INTEGER NOT NULL,
+                owner_review_count INTEGER NOT NULL,
+                operator_evidence_count INTEGER NOT NULL,
+                lane_review_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE case_closure_judgments (
+                judgment_id TEXT PRIMARY KEY,
+                case_card_id TEXT NOT NULL,
+                judgment_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                primary_action TEXT NOT NULL,
+                closure_status TEXT NOT NULL,
+                closure_blocker_count INTEGER NOT NULL,
+                top_gap_code TEXT NOT NULL,
+                top_gap_category TEXT NOT NULL,
+                top_gap_severity TEXT NOT NULL,
+                resolution_gate TEXT NOT NULL,
+                owner_attention_required INTEGER NOT NULL,
+                operator_evidence_required INTEGER NOT NULL,
+                lane_review_required INTEGER NOT NULL,
+                judge_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO case_closure_judge_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                case_count, blocked_count, ready_to_close_count,
+                owner_review_count, operator_evidence_count, lane_review_count,
+                send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, 4, 4, 0, 2, 1, 1, 0, 0)
+            """,
+            (
+                "2026-06-17T12:00:00+00:00",
+                "2026-06-17T11:00:00+00:00",
+                "local_only_case_closure_no_raw_text_no_send_no_crm_mutation",
+            ),
+        )
+        rows = [
+            (
+                "closure-owner-followup",
+                "card-owner-followup",
+                1,
+                "sahira",
+                "crm_followup",
+                "owner_review_blocked",
+                1,
+                "client_followup_confirmation_missing",
+                "client_response",
+                "urgent",
+                "owner_review_required",
+                1,
+                0,
+                0,
+            ),
+            (
+                "closure-doc",
+                "card-doc",
+                2,
+                "adit",
+                "document_chase",
+                "evidence_upload_blocked",
+                1,
+                "required_document_evidence_missing",
+                "document",
+                "medium",
+                "operator_upload_required",
+                0,
+                1,
+                0,
+            ),
+            (
+                "closure-owner-status",
+                "card-owner-status",
+                3,
+                "ari",
+                "immigration_status_check",
+                "owner_review_blocked",
+                1,
+                "immigration_status_evidence_missing",
+                "status",
+                "urgent",
+                "owner_review_required",
+                1,
+                0,
+                0,
+            ),
+            (
+                "closure-lane",
+                "card-lane",
+                4,
+                "ari",
+                "immigration_status_check",
+                "lane_review_blocked",
+                1,
+                "immigration_status_evidence_missing",
+                "status",
+                "medium",
+                "lane_review_required",
+                0,
+                0,
+                1,
+            ),
+        ]
+        conn.executemany(
+            """
+            INSERT INTO case_closure_judgments (
+                judgment_id, case_card_id, judgment_rank, assigned_lane,
+                primary_action, closure_status, closure_blocker_count,
+                top_gap_code, top_gap_category, top_gap_severity,
+                resolution_gate, owner_attention_required,
+                operator_evidence_required, lane_review_required,
+                judge_payload_json, send_whatsapp, crm_mutation,
+                requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 1)
+            """,
+            [
+                (
+                    *row,
+                    json.dumps(
+                        {
+                            "schema_version": "case_closure_judge.v1",
+                            "raw_text_included": False,
+                        },
+                        sort_keys=True,
+                    ),
+                )
+                for row in rows
+            ],
+        )
+        conn.commit()
+
+
+def test_build_owner_approval_console_filters_owner_decisions(tmp_path: Path) -> None:
+    case_closure_db = tmp_path / "case_closure_judge.local.sqlite"
+    output_dir = tmp_path / "owner-approval-console"
+    summary_path = output_dir / "owner_approval_console_summary.md"
+    _write_case_closure_judge_db(case_closure_db)
+
+    result = build_owner_approval_console(
+        case_closure_db=case_closure_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+        generated_at_utc="2026-06-17T13:00:00+00:00",
+    )
+
+    assert result.source_case_count == 4
+    assert result.owner_item_count == 2
+    assert result.output_db == output_dir / "owner_approval_console.local.sqlite"
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.decision_type_counts == {
+        "approve_client_recovery_followup": 1,
+        "approve_immigration_status_escalation": 1,
+    }
+    assert result.lane_counts == {"sahira": 1, "ari": 1}
+
+    with sqlite3.connect(result.output_db) as conn:
+        items = conn.execute(
+            """
+            SELECT case_card_id, approval_rank, assigned_lane, primary_action,
+                   decision_type, decision_priority, owner_prompt_code,
+                   recommended_owner_action, approval_status, top_gap_code,
+                   top_gap_category, top_gap_severity, resolution_gate,
+                   owner_decision_required, send_whatsapp, crm_mutation,
+                   requires_human_approval, approval_payload_json
+            FROM owner_approval_items
+            ORDER BY approval_rank
+            """
+        ).fetchall()
+        run = conn.execute(
+            """
+            SELECT source_case_count, owner_item_count, urgent_item_count,
+                   send_whatsapp_count, crm_mutation_count
+            FROM owner_approval_console_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+
+    assert run == (4, 2, 2, 0, 0)
+    assert items[0][0:14] == (
+        "card-owner-followup",
+        1,
+        "sahira",
+        "crm_followup",
+        "approve_client_recovery_followup",
+        "now",
+        "owner_client_recovery_followup",
+        "Review and approve the client recovery follow-up before any message is sent.",
+        "pending_owner_review",
+        "client_followup_confirmation_missing",
+        "client_response",
+        "urgent",
+        "owner_review_required",
+        1,
+    )
+    assert items[1][0:14] == (
+        "card-owner-status",
+        2,
+        "ari",
+        "immigration_status_check",
+        "approve_immigration_status_escalation",
+        "now",
+        "owner_immigration_status_escalation",
+        "Review and approve the immigration status escalation before any message is sent.",
+        "pending_owner_review",
+        "immigration_status_evidence_missing",
+        "status",
+        "urgent",
+        "owner_review_required",
+        1,
+    )
+    assert {row[14] for row in items} == {0}
+    assert {row[15] for row in items} == {0}
+    assert {row[16] for row in items} == {1}
+
+    payload = json.loads(items[0][17])
+    assert payload["schema_version"] == "owner_approval_console.v1"
+    assert payload["raw_text_included"] is False
+    assert payload["send_whatsapp"] is False
+    assert payload["crm_mutation"] is False
+    assert payload["requires_human_approval"] is True
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Owner Approval Console Summary" in summary
+    assert "| Source cases judged | 4 |" in summary
+    assert "| Owner approval items | 2 |" in summary
+    assert "| Urgent owner items | 2 |" in summary
+    assert "| WhatsApp sends | 0 |" in summary
+    assert "| CRM mutations | 0 |" in summary
+    assert "card-owner-followup" not in summary
+    assert "card-owner-status" not in summary
+    assert "card-doc" not in summary
+    assert "card-lane" not in summary
+
+
+def test_build_owner_approval_console_rejects_unexpected_input_name(
+    tmp_path: Path,
+) -> None:
+    unexpected_db = tmp_path / "evidence_gaps.local.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    with pytest.raises(ValueError, match="Refusing to read unexpected Case Closure DB"):
+        build_owner_approval_console(
+            case_closure_db=unexpected_db,
+            output_dir=tmp_path / "owner-approval-console",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_cli_writes_json_without_case_details(tmp_path: Path) -> None:
+    case_closure_db = tmp_path / "case_closure_judge.local.sqlite"
+    output_dir = tmp_path / "owner-approval-console"
+    summary_path = output_dir / "owner_approval_console_summary.md"
+    _write_case_closure_judge_db(case_closure_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--case-closure-db",
+            str(case_closure_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--generated-at-utc",
+            "2026-06-17T13:00:00+00:00",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "crm_mutation_count": 0,
+        "owner_item_count": 2,
+        "send_whatsapp_count": 0,
+        "source_case_count": 4,
+    }
+    assert "card-owner-followup" not in result.stdout
+    assert "card-owner-status" not in result.stdout
+    assert "card-doc" not in result.stdout
+    assert "card-lane" not in result.stdout

--- a/scripts/tests/test_whatsapp_corpus_owner_brief_renderer.py
+++ b/scripts/tests/test_whatsapp_corpus_owner_brief_renderer.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.whatsapp_corpus.build_owner_brief_renderer import build_owner_brief_renderer
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_owner_brief_renderer.py"
+
+
+def _write_owner_decision_packs_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE owner_decision_pack_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_case_count INTEGER NOT NULL,
+                owner_item_count INTEGER NOT NULL,
+                pack_count INTEGER NOT NULL,
+                urgent_pack_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE owner_decision_packs (
+                pack_id TEXT PRIMARY KEY,
+                case_card_id TEXT NOT NULL,
+                pack_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                decision_priority TEXT NOT NULL,
+                owner_prompt_code TEXT NOT NULL,
+                pack_title TEXT NOT NULL,
+                risk_brief TEXT NOT NULL,
+                recommended_decision TEXT NOT NULL,
+                draft_action_type TEXT NOT NULL,
+                draft_action_status TEXT NOT NULL,
+                approval_status TEXT NOT NULL,
+                top_gap_code TEXT NOT NULL,
+                top_gap_category TEXT NOT NULL,
+                top_gap_severity TEXT NOT NULL,
+                resolution_gate TEXT NOT NULL,
+                owner_decision_required INTEGER NOT NULL CHECK (owner_decision_required = 1),
+                pack_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO owner_decision_pack_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_case_count, owner_item_count, pack_count,
+                urgent_pack_count, send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, 4, 2, 2, 2, 0, 0)
+            """,
+            (
+                "2026-06-17T15:00:00+00:00",
+                "2026-06-17T14:00:00+00:00",
+                "local_only_owner_decision_pack_no_raw_text_no_send_no_crm_mutation",
+            ),
+        )
+        rows = [
+            (
+                "owner-pack-followup",
+                "card-owner-followup",
+                1,
+                "sahira",
+                "approve_client_recovery_followup",
+                "now",
+                "owner_client_recovery_followup",
+                "Client recovery follow-up approval",
+                "Urgent client response gap requires owner-approved recovery follow-up.",
+                "approve_recovery_followup_after_review",
+                "owner_review_client_followup_draft",
+                "draft_ready_for_owner_review",
+                "pending_owner_review",
+                "client_followup_confirmation_missing",
+                "client_response",
+                "urgent",
+                "owner_review_required",
+            ),
+            (
+                "owner-pack-status",
+                "card-owner-status",
+                2,
+                "ari",
+                "approve_immigration_status_escalation",
+                "now",
+                "owner_immigration_status_escalation",
+                "Immigration status escalation approval",
+                "Urgent immigration status gap requires owner-approved escalation.",
+                "approve_status_escalation_after_review",
+                "owner_review_status_escalation_draft",
+                "draft_ready_for_owner_review",
+                "pending_owner_review",
+                "immigration_status_evidence_missing",
+                "status",
+                "urgent",
+                "owner_review_required",
+            ),
+        ]
+        conn.executemany(
+            """
+            INSERT INTO owner_decision_packs (
+                pack_id, case_card_id, pack_rank, assigned_lane, decision_type,
+                decision_priority, owner_prompt_code, pack_title, risk_brief,
+                recommended_decision, draft_action_type, draft_action_status,
+                approval_status, top_gap_code, top_gap_category, top_gap_severity,
+                resolution_gate, owner_decision_required, pack_payload_json,
+                send_whatsapp, crm_mutation, requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, 0, 0, 1)
+            """,
+            [
+                (
+                    *row,
+                    json.dumps(
+                        {
+                            "schema_version": "owner_decision_packs.v1",
+                            "raw_text_included": False,
+                            "send_whatsapp": False,
+                            "crm_mutation": False,
+                            "requires_human_approval": True,
+                        },
+                        sort_keys=True,
+                    ),
+                )
+                for row in rows
+            ],
+        )
+        conn.commit()
+
+
+def test_build_owner_brief_renderer_writes_readable_owner_briefs(
+    tmp_path: Path,
+) -> None:
+    owner_packs_db = tmp_path / "owner_decision_packs.local.sqlite"
+    output_dir = tmp_path / "owner-brief-renderer"
+    summary_path = output_dir / "owner_brief_renderer_summary.md"
+    _write_owner_decision_packs_db(owner_packs_db)
+
+    result = build_owner_brief_renderer(
+        owner_packs_db=owner_packs_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+        generated_at_utc="2026-06-17T16:00:00+00:00",
+    )
+
+    assert result.source_case_count == 4
+    assert result.owner_item_count == 2
+    assert result.pack_count == 2
+    assert result.brief_count == 2
+    assert result.output_db == output_dir / "owner_brief_renderer.local.sqlite"
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.decision_type_counts == {
+        "approve_client_recovery_followup": 1,
+        "approve_immigration_status_escalation": 1,
+    }
+    assert result.lane_counts == {"sahira": 1, "ari": 1}
+
+    with sqlite3.connect(result.output_db) as conn:
+        briefs = conn.execute(
+            """
+            SELECT case_card_id, pack_id, brief_rank, assigned_lane,
+                   decision_type, decision_priority, brief_title,
+                   owner_focus, recommended_decision, draft_action_type,
+                   safety_lock, approval_status, send_whatsapp,
+                   crm_mutation, requires_human_approval, brief_markdown,
+                   brief_payload_json
+            FROM owner_briefs
+            ORDER BY brief_rank
+            """
+        ).fetchall()
+        run = conn.execute(
+            """
+            SELECT source_case_count, owner_item_count, pack_count,
+                   brief_count, send_whatsapp_count, crm_mutation_count
+            FROM owner_brief_renderer_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+
+    assert run == (4, 2, 2, 2, 0, 0)
+    assert briefs[0][0:15] == (
+        "card-owner-followup",
+        "owner-pack-followup",
+        1,
+        "sahira",
+        "approve_client_recovery_followup",
+        "now",
+        "Client recovery follow-up approval",
+        "review_client_recovery_language",
+        "approve_recovery_followup_after_review",
+        "owner_review_client_followup_draft",
+        "owner_approval_required_no_send_no_crm",
+        "pending_owner_review",
+        0,
+        0,
+        1,
+    )
+    assert briefs[1][0:15] == (
+        "card-owner-status",
+        "owner-pack-status",
+        2,
+        "ari",
+        "approve_immigration_status_escalation",
+        "now",
+        "Immigration status escalation approval",
+        "review_immigration_status_escalation",
+        "approve_status_escalation_after_review",
+        "owner_review_status_escalation_draft",
+        "owner_approval_required_no_send_no_crm",
+        "pending_owner_review",
+        0,
+        0,
+        1,
+    )
+
+    markdown = briefs[0][15]
+    assert "# Client recovery follow-up approval" in markdown
+    assert "Priority: now" in markdown
+    assert "Lane: sahira" in markdown
+    assert "Safety lock: owner approval required before send or CRM mutation." in markdown
+    assert "card-owner-followup" not in markdown
+    assert "owner-pack-followup" not in markdown
+
+    payload = json.loads(briefs[0][16])
+    assert payload["schema_version"] == "owner_brief_renderer.v1"
+    assert payload["privacy_mode"] == "local_only_owner_brief_no_raw_text"
+    assert payload["rendered_markdown_includes_ids"] is False
+    assert payload["raw_text_included"] is False
+    assert payload["send_whatsapp"] is False
+    assert payload["crm_mutation"] is False
+    assert payload["requires_human_approval"] is True
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Owner Brief Renderer Summary" in summary
+    assert "| Source cases | 4 |" in summary
+    assert "| Owner decision packs | 2 |" in summary
+    assert "| Rendered owner briefs | 2 |" in summary
+    assert "| WhatsApp sends | 0 |" in summary
+    assert "| CRM mutations | 0 |" in summary
+    assert "card-owner-followup" not in summary
+    assert "card-owner-status" not in summary
+    assert "owner-pack-followup" not in summary
+    assert "owner-pack-status" not in summary
+
+
+def test_build_owner_brief_renderer_rejects_unexpected_input_name(
+    tmp_path: Path,
+) -> None:
+    unexpected_db = tmp_path / "owner_approval_console.local.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    with pytest.raises(
+        ValueError,
+        match="Refusing to read unexpected Owner Decision Packs DB",
+    ):
+        build_owner_brief_renderer(
+            owner_packs_db=unexpected_db,
+            output_dir=tmp_path / "owner-brief-renderer",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_cli_writes_json_without_owner_brief_details(tmp_path: Path) -> None:
+    owner_packs_db = tmp_path / "owner_decision_packs.local.sqlite"
+    output_dir = tmp_path / "owner-brief-renderer"
+    summary_path = output_dir / "owner_brief_renderer_summary.md"
+    _write_owner_decision_packs_db(owner_packs_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--owner-packs-db",
+            str(owner_packs_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--generated-at-utc",
+            "2026-06-17T16:00:00+00:00",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "brief_count": 2,
+        "crm_mutation_count": 0,
+        "owner_item_count": 2,
+        "pack_count": 2,
+        "send_whatsapp_count": 0,
+        "source_case_count": 4,
+    }
+    assert "card-owner-followup" not in result.stdout
+    assert "card-owner-status" not in result.stdout
+    assert "owner-pack-followup" not in result.stdout
+    assert "owner-pack-status" not in result.stdout

--- a/scripts/tests/test_whatsapp_corpus_owner_captain_shadow.py
+++ b/scripts/tests/test_whatsapp_corpus_owner_captain_shadow.py
@@ -1,0 +1,623 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.whatsapp_corpus import build_owner_captain_shadow as owner_shadow_module
+from scripts.whatsapp_corpus.build_owner_captain_shadow import build_owner_captain_shadow
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_owner_captain_shadow.py"
+GENERIC_OWNER_CLI_ERROR = "ERROR: Owner Captain input is missing or invalid.\n"
+SYSTEM_OWNER_CLI_ERROR = "ERROR: Owner Captain shadow run failed safely.\n"
+
+
+def _assert_no_raw_owner_markers(text: str, *, output_dir: Path, summary_path: Path) -> None:
+    forbidden_markers = [
+        "shadow-1",
+        "shadow-2",
+        "shadow-3",
+        "team-sahira",
+        "team-surya",
+        "client_captain_shadow.local.sqlite",
+        "team_captain_shadow.local.sqlite",
+        str(output_dir),
+        str(summary_path),
+        "research/personal/wa-corpus",
+    ]
+    for marker in forbidden_markers:
+        assert marker not in text
+
+
+def _assert_sanitized_owner_cli_error(
+    result: subprocess.CompletedProcess[str],
+    *,
+    forbidden_markers: list[str],
+    expected_stderr: str = GENERIC_OWNER_CLI_ERROR,
+) -> None:
+    assert result.returncode == 1
+    assert result.stderr == expected_stderr
+    assert result.stdout == ""
+    for marker in forbidden_markers:
+        assert marker not in result.stderr
+
+
+def _write_owner_inputs(client_db: Path, team_db: Path) -> None:
+    with sqlite3.connect(client_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE shadow_drafts (
+                shadow_id TEXT PRIMARY KEY,
+                risk_level TEXT NOT NULL,
+                action_type TEXT NOT NULL,
+                human_specialist TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL,
+                crm_mutation INTEGER NOT NULL,
+                requires_human_approval INTEGER NOT NULL
+            );
+            """
+        )
+        conn.executemany(
+            "INSERT INTO shadow_drafts VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [
+                ("shadow-1", "P1", "crm_followup", "sahira", 0, 0, 1),
+                ("shadow-2", "P1", "document_chase", "sahira", 0, 0, 1),
+                ("shadow-3", "P2", "payment_reconcile", "surya", 0, 0, 1),
+            ],
+        )
+        conn.commit()
+    with sqlite3.connect(team_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE team_captain_findings (
+                team_captain_id TEXT PRIMARY KEY,
+                team_owner TEXT NOT NULL,
+                human_specialist TEXT NOT NULL,
+                draft_count INTEGER NOT NULL,
+                p1_count INTEGER NOT NULL,
+                p2_count INTEGER NOT NULL,
+                primary_action_type TEXT NOT NULL,
+                accountability_mode TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL,
+                crm_mutation INTEGER NOT NULL,
+                requires_human_approval INTEGER NOT NULL
+            );
+            """
+        )
+        conn.executemany(
+            "INSERT INTO team_captain_findings VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                (
+                    "team-sahira",
+                    "zantara_team_captain",
+                    "sahira",
+                    2,
+                    2,
+                    0,
+                    "crm_followup",
+                    "firm_family_accountability",
+                    0,
+                    0,
+                    1,
+                ),
+                (
+                    "team-surya",
+                    "zantara_team_captain",
+                    "surya",
+                    1,
+                    0,
+                    1,
+                    "payment_reconcile",
+                    "steady_family_motivation",
+                    0,
+                    0,
+                    1,
+                ),
+            ],
+        )
+        conn.commit()
+
+
+def test_build_owner_captain_shadow_writes_one_owner_finding_and_seven_layers(
+    tmp_path: Path,
+) -> None:
+    client_db = tmp_path / "client_captain_shadow.local.sqlite"
+    team_db = tmp_path / "team_captain_shadow.local.sqlite"
+    output_dir = tmp_path / "owner-captain-shadow"
+    summary_path = output_dir / "owner_captain_shadow_summary.md"
+    _write_owner_inputs(client_db, team_db)
+
+    result = build_owner_captain_shadow(
+        client_shadow_db=client_db,
+        team_shadow_db=team_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+    )
+
+    assert result.finding_count == 1
+    assert result.depth_layer_count == 7
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+
+    with sqlite3.connect(result.output_db) as conn:
+        finding = conn.execute(
+            """
+            SELECT owner_captain_id, owner_scope, draft_count, team_lane_count,
+                   p1_count, primary_bottleneck_lane, owner_decision_mode,
+                   send_whatsapp, crm_mutation, requires_human_approval
+            FROM owner_captain_findings
+            """
+        ).fetchone()
+        layers = conn.execute(
+            """
+            SELECT depth_level, layer_code, layer_payload_json
+            FROM owner_captain_depth_layers
+            ORDER BY depth_level
+            """
+        ).fetchall()
+
+    assert finding[1] == "global_case_ops"
+    assert finding[2] == 3
+    assert finding[3] == 2
+    assert finding[4] == 2
+    assert finding[5] == "sahira"
+    assert finding[6] == "owner_review_required"
+    assert finding[7:] == (0, 0, 1)
+    assert [row[0] for row in layers] == [1, 2, 3, 4, 5, 6, 7]
+    assert layers[-1][1] == "owner_decision"
+    assert json.loads(layers[-1][2])["send_whatsapp"] is False
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Owner Captain Shadow Summary" in summary
+    assert "| Owner findings | 1 |" in summary
+    assert "| Depth layers | 7 |" in summary
+    assert "shadow-1" not in summary
+
+
+def test_build_owner_captain_shadow_rejects_unexpected_input_names(tmp_path: Path) -> None:
+    client_db = tmp_path / "client_captain_academy.local.sqlite"
+    team_db = tmp_path / "team_captain_shadow.local.sqlite"
+    client_db.write_bytes(b"")
+    team_db.write_bytes(b"")
+
+    with pytest.raises(ValueError, match="Refusing to read unexpected Client Shadow DB"):
+        build_owner_captain_shadow(
+            client_shadow_db=client_db,
+            team_shadow_db=team_db,
+            output_dir=tmp_path / "owner-captain-shadow",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_owner_cli_wrong_input_name_error_is_generic(tmp_path: Path) -> None:
+    client_db = tmp_path / "client_captain_academy.local.sqlite"
+    team_db = tmp_path / "team_captain_shadow.local.sqlite"
+    client_db.write_bytes(b"")
+    team_db.write_bytes(b"")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--client-shadow-db",
+            str(client_db),
+            "--team-shadow-db",
+            str(team_db),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    _assert_sanitized_owner_cli_error(
+        result,
+        forbidden_markers=[
+            "client_captain_academy.local.sqlite",
+            "team_captain_shadow.local.sqlite",
+            str(client_db),
+            str(team_db),
+            str(tmp_path),
+            "Traceback",
+        ],
+    )
+    assert result.returncode == 1
+
+
+def test_owner_cli_missing_input_error_is_generic(tmp_path: Path) -> None:
+    client_db = tmp_path / "client_captain_shadow.local.sqlite"
+    team_db = tmp_path / "team_captain_shadow.local.sqlite"
+    team_db.write_bytes(b"")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--client-shadow-db",
+            str(client_db),
+            "--team-shadow-db",
+            str(team_db),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    _assert_sanitized_owner_cli_error(
+        result,
+        forbidden_markers=[
+            "client_captain_shadow.local.sqlite",
+            "team_captain_shadow.local.sqlite",
+            str(client_db),
+            str(team_db),
+            str(tmp_path),
+            "Traceback",
+        ],
+    )
+    assert result.returncode == 1
+
+
+def test_owner_cli_malformed_input_error_is_generic_system_failure(
+    tmp_path: Path,
+) -> None:
+    client_db = tmp_path / "client_captain_shadow.local.sqlite"
+    team_db = tmp_path / "team_captain_shadow.local.sqlite"
+    client_db.write_bytes(b"not sqlite")
+    team_db.write_bytes(b"")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--client-shadow-db",
+            str(client_db),
+            "--team-shadow-db",
+            str(team_db),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    _assert_sanitized_owner_cli_error(
+        result,
+        expected_stderr=SYSTEM_OWNER_CLI_ERROR,
+        forbidden_markers=[
+            "client_captain_shadow.local.sqlite",
+            "team_captain_shadow.local.sqlite",
+            str(client_db),
+            str(team_db),
+            str(tmp_path),
+            "file is not a database",
+            "Traceback",
+        ],
+    )
+    assert result.returncode == 1
+
+
+def test_owner_main_unexpected_error_is_generic_system_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def raise_unexpected(**_: object) -> None:
+        raise RuntimeError(
+            "secret /tmp/raw owner_captain_shadow.local.sqlite owner_captain_findings"
+        )
+
+    monkeypatch.setattr(
+        owner_shadow_module,
+        "build_owner_captain_shadow",
+        raise_unexpected,
+    )
+
+    assert owner_shadow_module.main(["--json"]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == SYSTEM_OWNER_CLI_ERROR
+    for marker in [
+        "secret",
+        "/tmp/raw",
+        "owner_captain_shadow.local.sqlite",
+        "owner_captain_findings",
+        "RuntimeError",
+        "Traceback",
+    ]:
+        assert marker not in captured.err
+
+
+def test_owner_cli_null_numeric_input_error_is_generic(tmp_path: Path) -> None:
+    client_db = tmp_path / "client_captain_shadow.local.sqlite"
+    team_db = tmp_path / "team_captain_shadow.local.sqlite"
+    valid_client_db = tmp_path / "valid_client_captain_shadow.local.sqlite"
+    _write_owner_inputs(valid_client_db, team_db)
+    with sqlite3.connect(client_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE shadow_drafts (
+                shadow_id TEXT PRIMARY KEY,
+                risk_level TEXT,
+                action_type TEXT,
+                human_specialist TEXT,
+                send_whatsapp INTEGER,
+                crm_mutation INTEGER,
+                requires_human_approval INTEGER
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO shadow_drafts VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("shadow-null", "P3", "crm_followup", "sahira", None, 0, 1),
+        )
+        conn.commit()
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--client-shadow-db",
+            str(client_db),
+            "--team-shadow-db",
+            str(team_db),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    _assert_sanitized_owner_cli_error(
+        result,
+        forbidden_markers=[
+            "client_captain_shadow.local.sqlite",
+            "team_captain_shadow.local.sqlite",
+            str(client_db),
+            str(team_db),
+            str(tmp_path),
+            "NoneType",
+            "TypeError",
+            "Traceback",
+        ],
+    )
+    assert result.returncode == 1
+
+
+def test_build_owner_captain_shadow_reports_upstream_contract_violations(
+    tmp_path: Path,
+) -> None:
+    client_db = tmp_path / "client_captain_shadow.local.sqlite"
+    team_db = tmp_path / "team_captain_shadow.local.sqlite"
+    output_dir = tmp_path / "owner-captain-shadow"
+    summary_path = output_dir / "owner_captain_shadow_summary.md"
+    _write_owner_inputs(client_db, team_db)
+
+    with sqlite3.connect(client_db) as conn:
+        conn.execute(
+            """
+            UPDATE shadow_drafts
+            SET send_whatsapp = 1, requires_human_approval = 0
+            WHERE shadow_id = 'shadow-1'
+            """
+        )
+        conn.commit()
+    with sqlite3.connect(team_db) as conn:
+        conn.execute(
+            """
+            UPDATE team_captain_findings
+            SET crm_mutation = 1
+            WHERE team_captain_id = 'team-surya'
+            """
+        )
+        conn.commit()
+
+    result = build_owner_captain_shadow(
+        client_shadow_db=client_db,
+        team_shadow_db=team_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+    )
+
+    assert result.input_contract_violation_count == 2
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+
+    with sqlite3.connect(result.output_db) as conn:
+        run_count = conn.execute(
+            """
+            SELECT input_contract_violation_count, send_whatsapp_count,
+                   crm_mutation_count
+            FROM owner_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+        finding_count = conn.execute(
+            """
+            SELECT input_contract_violation_count, send_whatsapp, crm_mutation,
+                   requires_human_approval
+            FROM owner_captain_findings
+            """
+        ).fetchone()
+    assert run_count == (2, 0, 0)
+    assert finding_count == (2, 0, 0, 1)
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "| Input contract violations | 2 |" in summary
+    _assert_no_raw_owner_markers(summary, output_dir=output_dir, summary_path=summary_path)
+
+
+def test_contract_violations_alone_force_owner_review(
+    tmp_path: Path,
+) -> None:
+    client_db = tmp_path / "client_captain_shadow.local.sqlite"
+    team_db = tmp_path / "team_captain_shadow.local.sqlite"
+    output_dir = tmp_path / "owner-captain-shadow"
+    summary_path = output_dir / "owner_captain_shadow_summary.md"
+    _write_owner_inputs(client_db, team_db)
+
+    with sqlite3.connect(client_db) as conn:
+        conn.execute("UPDATE shadow_drafts SET risk_level = 'P3'")
+        conn.execute(
+            """
+            UPDATE shadow_drafts
+            SET crm_mutation = 1
+            WHERE shadow_id = 'shadow-3'
+            """
+        )
+        conn.commit()
+    with sqlite3.connect(team_db) as conn:
+        conn.execute("UPDATE team_captain_findings SET p1_count = 0")
+        conn.commit()
+
+    result = build_owner_captain_shadow(
+        client_shadow_db=client_db,
+        team_shadow_db=team_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+    )
+
+    with sqlite3.connect(result.output_db) as conn:
+        finding = conn.execute(
+            """
+            SELECT p1_count, owner_decision_mode, input_contract_violation_count,
+                   send_whatsapp, crm_mutation, requires_human_approval
+            FROM owner_captain_findings
+            """
+        ).fetchone()
+
+    assert finding == (0, "owner_review_required", 1, 0, 0, 1)
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "| P1 count | 0 |" in summary
+    assert "| Input contract violations | 1 |" in summary
+    _assert_no_raw_owner_markers(summary, output_dir=output_dir, summary_path=summary_path)
+
+
+def test_owner_captain_uses_team_p2_as_risk_fallback(
+    tmp_path: Path,
+) -> None:
+    client_db = tmp_path / "client_captain_shadow.local.sqlite"
+    team_db = tmp_path / "team_captain_shadow.local.sqlite"
+    output_dir = tmp_path / "owner-captain-shadow"
+    summary_path = output_dir / "owner_captain_shadow_summary.md"
+    _write_owner_inputs(client_db, team_db)
+
+    with sqlite3.connect(client_db) as conn:
+        conn.execute("UPDATE shadow_drafts SET risk_level = 'P3'")
+        conn.commit()
+    with sqlite3.connect(team_db) as conn:
+        conn.execute("UPDATE team_captain_findings SET p1_count = 0")
+        conn.execute("UPDATE team_captain_findings SET p2_count = 0")
+        conn.execute(
+            """
+            UPDATE team_captain_findings
+            SET p2_count = 3
+            WHERE team_captain_id = 'team-surya'
+            """
+        )
+        conn.commit()
+
+    result = build_owner_captain_shadow(
+        client_shadow_db=client_db,
+        team_shadow_db=team_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+    )
+
+    with sqlite3.connect(result.output_db) as conn:
+        finding = conn.execute(
+            """
+            SELECT p1_count, p2_count, owner_decision_mode
+            FROM owner_captain_findings
+            """
+        ).fetchone()
+
+    assert finding == (0, 3, "monitor")
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "| P1 count | 0 |" in summary
+    assert "| P2 count | 3 |" in summary
+
+
+def test_build_owner_captain_shadow_uses_team_p1_as_review_fallback(
+    tmp_path: Path,
+) -> None:
+    client_db = tmp_path / "client_captain_shadow.local.sqlite"
+    team_db = tmp_path / "team_captain_shadow.local.sqlite"
+    output_dir = tmp_path / "owner-captain-shadow"
+    summary_path = output_dir / "owner_captain_shadow_summary.md"
+    _write_owner_inputs(client_db, team_db)
+
+    with sqlite3.connect(client_db) as conn:
+        conn.execute("UPDATE shadow_drafts SET risk_level = 'P3'")
+        conn.commit()
+    with sqlite3.connect(team_db) as conn:
+        conn.execute("UPDATE team_captain_findings SET p1_count = 0")
+        conn.execute(
+            """
+            UPDATE team_captain_findings
+            SET p1_count = 1
+            WHERE team_captain_id = 'team-surya'
+            """
+        )
+        conn.commit()
+
+    result = build_owner_captain_shadow(
+        client_shadow_db=client_db,
+        team_shadow_db=team_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+    )
+
+    with sqlite3.connect(result.output_db) as conn:
+        finding = conn.execute(
+            """
+            SELECT p1_count, owner_decision_mode, send_whatsapp, crm_mutation,
+                   requires_human_approval
+            FROM owner_captain_findings
+            """
+        ).fetchone()
+
+    assert finding == (1, "owner_review_required", 0, 0, 1)
+    assert "| P1 count | 1 |" in summary_path.read_text(encoding="utf-8")
+
+
+def test_owner_cli_writes_json_without_raw_details(tmp_path: Path) -> None:
+    client_db = tmp_path / "client_captain_shadow.local.sqlite"
+    team_db = tmp_path / "team_captain_shadow.local.sqlite"
+    output_dir = tmp_path / "owner-captain-shadow"
+    summary_path = output_dir / "owner_captain_shadow_summary.md"
+    _write_owner_inputs(client_db, team_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--client-shadow-db",
+            str(client_db),
+            "--team-shadow-db",
+            str(team_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["finding_count"] == 1
+    assert payload["depth_layer_count"] == 7
+    assert payload["send_whatsapp_count"] == 0
+    assert payload["crm_mutation_count"] == 0
+    assert payload["input_contract_violation_count"] == 0
+    assert "output_db" not in payload
+    assert "summary_path" not in payload
+    _assert_no_raw_owner_markers(result.stdout, output_dir=output_dir, summary_path=summary_path)

--- a/scripts/tests/test_whatsapp_corpus_owner_decision_cockpit.py
+++ b/scripts/tests/test_whatsapp_corpus_owner_decision_cockpit.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.tests.test_whatsapp_corpus_owner_decision_intake import (
+    _write_operator_packet_review_console_db,
+)
+from scripts.whatsapp_corpus.build_owner_decision_compiler import (
+    build_owner_decision_compiler,
+)
+from scripts.whatsapp_corpus.build_owner_decision_cockpit import (
+    build_owner_decision_cockpit,
+)
+from scripts.whatsapp_corpus.build_owner_decision_inbox import (
+    build_owner_decision_inbox,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_owner_decision_cockpit.py"
+
+
+def _build_inbox_fixture(tmp_path: Path) -> tuple[Path, Path]:
+    review_console_db = tmp_path / "operator_packet_review_console.local.sqlite"
+    inbox_dir = tmp_path / "owner-decision-inbox"
+    _write_operator_packet_review_console_db(review_console_db)
+    inbox_result = build_owner_decision_inbox(
+        review_console_db=review_console_db,
+        output_dir=inbox_dir,
+        summary_path=inbox_dir / "owner_decision_inbox_summary.md",
+        generated_at_utc="2026-06-18T00:00:00+00:00",
+    )
+    return inbox_result.output_db, inbox_result.output_template
+
+
+def _write_owner_inputs(path: Path, rows: list[dict[str, str]]) -> None:
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def test_build_owner_decision_cockpit_writes_template_for_compiler(
+    tmp_path: Path,
+) -> None:
+    inbox_db, _blank_template = _build_inbox_fixture(tmp_path)
+    owner_inputs = tmp_path / "owner_inputs.local.jsonl"
+    output_dir = tmp_path / "owner-decision-cockpit"
+    _write_owner_inputs(
+        owner_inputs,
+        [
+            {
+                "decision_note": "owner approved recovery",
+                "event_recorded_at_utc": "2026-06-18T00:01:00+00:00",
+                "owner_decision": "approve",
+                "review_item_id": "operator-packet-review-item-pending",
+            },
+            {
+                "decision_note": "owner rejects escalation",
+                "owner_decision": "reject",
+                "review_item_id": "operator-packet-review-item-defer",
+            },
+        ],
+    )
+
+    result = build_owner_decision_cockpit(
+        owner_inbox_db=inbox_db,
+        owner_inputs_jsonl=owner_inputs,
+        output_dir=output_dir,
+        summary_path=output_dir / "owner_decision_cockpit_summary.md",
+        generated_at_utc="2026-06-18T00:02:00+00:00",
+    )
+
+    assert result.inbox_item_count == 2
+    assert result.captured_decision_count == 2
+    assert result.awaiting_owner_input_count == 0
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.output_template == output_dir / "owner_decisions_template.local.jsonl"
+
+    template_rows = [
+        json.loads(line)
+        for line in result.output_template.read_text(encoding="utf-8").splitlines()
+    ]
+    assert template_rows == [
+        {
+            "allowed_decisions": ["approve", "reject", "defer"],
+            "assigned_lane": "sahira",
+            "console_bucket": "owner_decision_inbox",
+            "decision_note": "owner approved recovery",
+            "decision_type": "approve_client_recovery_followup",
+            "entry_id": "ledger-entry-pending",
+            "event_actor": "owner",
+            "event_recorded_at_utc": "2026-06-18T00:01:00+00:00",
+            "owner_decision": "approve",
+            "packet_id": "operator-packet-pending",
+            "review_item_id": "operator-packet-review-item-pending",
+            "review_state": "waiting_owner_decision",
+        },
+        {
+            "allowed_decisions": ["approve", "reject", "defer"],
+            "assigned_lane": "ari",
+            "console_bucket": "owner_revisit_queue",
+            "decision_note": "owner rejects escalation",
+            "decision_type": "approve_immigration_status_escalation",
+            "entry_id": "ledger-entry-defer",
+            "event_actor": "owner",
+            "event_recorded_at_utc": "",
+            "owner_decision": "reject",
+            "packet_id": "operator-packet-defer",
+            "review_item_id": "operator-packet-review-item-defer",
+            "review_state": "deferred_owner_revisit",
+        },
+    ]
+
+    with sqlite3.connect(result.output_db) as conn:
+        run = conn.execute(
+            """
+            SELECT inbox_item_count, captured_decision_count,
+                   awaiting_owner_input_count, send_whatsapp_count, crm_mutation_count
+            FROM owner_decision_cockpit_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+        rows = conn.execute(
+            """
+            SELECT review_item_id, owner_decision, cockpit_status,
+                   send_whatsapp, crm_mutation, requires_human_approval
+            FROM owner_decision_cockpit_items
+            ORDER BY cockpit_rank
+            """
+        ).fetchall()
+    assert run == (2, 2, 0, 0, 0)
+    assert rows == [
+        (
+            "operator-packet-review-item-pending",
+            "approve",
+            "ready_for_compile",
+            0,
+            0,
+            1,
+        ),
+        (
+            "operator-packet-review-item-defer",
+            "reject",
+            "ready_for_compile",
+            0,
+            0,
+            1,
+        ),
+    ]
+
+    compiler_result = build_owner_decision_compiler(
+        owner_inbox_db=inbox_db,
+        edited_template_jsonl=result.output_template,
+        output_dir=tmp_path / "owner-decision-compiler",
+        generated_at_utc="2026-06-18T00:03:00+00:00",
+    )
+    assert compiler_result.compiled_decision_count == 2
+    assert compiler_result.send_whatsapp_count == 0
+    assert compiler_result.crm_mutation_count == 0
+
+
+def test_build_owner_decision_cockpit_keeps_missing_decisions_blank(
+    tmp_path: Path,
+) -> None:
+    inbox_db, _blank_template = _build_inbox_fixture(tmp_path)
+    owner_inputs = tmp_path / "owner_inputs.local.jsonl"
+    output_dir = tmp_path / "owner-decision-cockpit"
+    _write_owner_inputs(
+        owner_inputs,
+        [
+            {
+                "owner_decision": "defer",
+                "review_item_id": "operator-packet-review-item-pending",
+            },
+        ],
+    )
+
+    result = build_owner_decision_cockpit(
+        owner_inbox_db=inbox_db,
+        owner_inputs_jsonl=owner_inputs,
+        output_dir=output_dir,
+        summary_path=output_dir / "owner_decision_cockpit_summary.md",
+        generated_at_utc="2026-06-18T00:02:00+00:00",
+    )
+
+    assert result.captured_decision_count == 1
+    assert result.awaiting_owner_input_count == 1
+    rows = [
+        json.loads(line)
+        for line in result.output_template.read_text(encoding="utf-8").splitlines()
+    ]
+    assert [row["owner_decision"] for row in rows] == ["defer", ""]
+    assert rows[1]["decision_note"] == ""
+    assert rows[1]["event_recorded_at_utc"] == ""
+
+
+@pytest.mark.parametrize(
+    ("owner_row", "message"),
+    [
+        (
+            {
+                "owner_decision": "maybe",
+                "review_item_id": "operator-packet-review-item-pending",
+            },
+            "Owner cockpit decision is not allowed",
+        ),
+        (
+            {
+                "owner_decision": "approve",
+                "review_item_id": "unknown-review-item",
+            },
+            "references unknown inbox item",
+        ),
+        (
+            {
+                "owner_decision": "approve",
+                "review_item_id": "operator-packet-review-item-pending",
+                "event_actor": "operator",
+            },
+            "has invalid actor",
+        ),
+    ],
+)
+def test_build_owner_decision_cockpit_rejects_invalid_owner_inputs(
+    tmp_path: Path,
+    owner_row: dict[str, str],
+    message: str,
+) -> None:
+    inbox_db, _blank_template = _build_inbox_fixture(tmp_path)
+    owner_inputs = tmp_path / "owner_inputs.local.jsonl"
+    _write_owner_inputs(owner_inputs, [owner_row])
+
+    with pytest.raises(ValueError, match=message):
+        build_owner_decision_cockpit(
+            owner_inbox_db=inbox_db,
+            owner_inputs_jsonl=owner_inputs,
+            output_dir=tmp_path / "owner-decision-cockpit",
+            generated_at_utc="2026-06-18T00:02:00+00:00",
+        )
+
+
+def test_build_owner_decision_cockpit_rejects_duplicate_review_items(
+    tmp_path: Path,
+) -> None:
+    inbox_db, _blank_template = _build_inbox_fixture(tmp_path)
+    owner_inputs = tmp_path / "owner_inputs.local.jsonl"
+    _write_owner_inputs(
+        owner_inputs,
+        [
+            {
+                "owner_decision": "approve",
+                "review_item_id": "operator-packet-review-item-pending",
+            },
+            {
+                "owner_decision": "reject",
+                "review_item_id": "operator-packet-review-item-pending",
+            },
+        ],
+    )
+
+    with pytest.raises(ValueError, match="Duplicate owner cockpit decision"):
+        build_owner_decision_cockpit(
+            owner_inbox_db=inbox_db,
+            owner_inputs_jsonl=owner_inputs,
+            output_dir=tmp_path / "owner-decision-cockpit",
+            generated_at_utc="2026-06-18T00:02:00+00:00",
+        )
+
+
+def test_cli_writes_json_without_owner_item_ids(tmp_path: Path) -> None:
+    inbox_db, _blank_template = _build_inbox_fixture(tmp_path)
+    owner_inputs = tmp_path / "owner_inputs.local.jsonl"
+    output_dir = tmp_path / "owner-decision-cockpit"
+    summary_path = output_dir / "owner_decision_cockpit_summary.md"
+    _write_owner_inputs(
+        owner_inputs,
+        [
+            {
+                "owner_decision": "approve",
+                "review_item_id": "operator-packet-review-item-pending",
+            },
+        ],
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--owner-inbox-db",
+            str(inbox_db),
+            "--owner-inputs-jsonl",
+            str(owner_inputs),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--generated-at-utc",
+            "2026-06-18T00:02:00+00:00",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "awaiting_owner_input_count": 1,
+        "captured_decision_count": 1,
+        "crm_mutation_count": 0,
+        "inbox_item_count": 2,
+        "send_whatsapp_count": 0,
+    }
+    assert "operator-packet-review-item-pending" not in result.stdout
+
+
+def test_cli_accepts_inline_owner_decisions_without_editing_jsonl(tmp_path: Path) -> None:
+    inbox_db, _blank_template = _build_inbox_fixture(tmp_path)
+    output_dir = tmp_path / "owner-decision-cockpit"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--owner-inbox-db",
+            str(inbox_db),
+            "--decision",
+            "operator-packet-review-item-pending=approve",
+            "--decision",
+            "operator-packet-review-item-defer=defer",
+            "--decision-note",
+            "operator-packet-review-item-pending=owner approved inline",
+            "--output-dir",
+            str(output_dir),
+            "--generated-at-utc",
+            "2026-06-18T00:02:00+00:00",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["captured_decision_count"] == 2
+    rows = [
+        json.loads(line)
+        for line in (output_dir / "owner_decisions_template.local.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert [row["owner_decision"] for row in rows] == ["approve", "defer"]
+    assert rows[0]["decision_note"] == "owner approved inline"
+    assert rows[1]["decision_note"] == ""
+
+
+def test_readme_documents_cockpit_before_compiler() -> None:
+    readme = (REPO_ROOT / "scripts" / "whatsapp_corpus" / "README.md").read_text(
+        encoding="utf-8"
+    )
+
+    cockpit_index = readme.index("## Build Owner Decision Cockpit")
+    compiler_index = readme.index("## Build Owner Decision Compiler")
+    assert cockpit_index < compiler_index
+    assert "python -m scripts.whatsapp_corpus.build_owner_decision_cockpit" in readme
+    assert "--decision operator-packet-review-item-pending=approve" in readme
+
+
+def test_build_owner_decision_cockpit_has_no_sender_or_cloud_imports() -> None:
+    forbidden_imports = (
+        "anthropic",
+        "backend.app.services.crm",
+        "backend.channels.whatsapp",
+        "httpx",
+        "openai",
+        "requests",
+    )
+    import_lines = [
+        line.strip()
+        for line in SCRIPT.read_text(encoding="utf-8").splitlines()
+        if line.startswith("import ") or line.startswith("from ")
+    ]
+
+    for import_line in import_lines:
+        assert not any(forbidden in import_line for forbidden in forbidden_imports)

--- a/scripts/tests/test_whatsapp_corpus_owner_decision_compiler.py
+++ b/scripts/tests/test_whatsapp_corpus_owner_decision_compiler.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.tests.test_whatsapp_corpus_owner_decision_intake import (
+    _write_operator_packet_review_console_db,
+)
+from scripts.whatsapp_corpus.build_owner_decision_inbox import (
+    build_owner_decision_inbox,
+)
+from scripts.whatsapp_corpus.build_owner_decision_intake import (
+    build_owner_decision_intake,
+)
+from scripts.whatsapp_corpus.build_owner_decision_compiler import (
+    build_owner_decision_compiler,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_owner_decision_compiler.py"
+
+
+def _build_inbox_fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    review_console_db = tmp_path / "operator_packet_review_console.local.sqlite"
+    inbox_dir = tmp_path / "owner-decision-inbox"
+    _write_operator_packet_review_console_db(review_console_db)
+    inbox_result = build_owner_decision_inbox(
+        review_console_db=review_console_db,
+        output_dir=inbox_dir,
+        summary_path=inbox_dir / "owner_decision_inbox_summary.md",
+        generated_at_utc="2026-06-18T00:00:00+00:00",
+    )
+    return (
+        review_console_db,
+        inbox_result.output_db,
+        inbox_result.output_template,
+        inbox_dir,
+    )
+
+
+def _write_edited_template(
+    template_path: Path,
+    *,
+    decisions: list[str],
+    timestamps: list[str] | None = None,
+    extra_fields: dict[str, str] | None = None,
+) -> None:
+    rows = [
+        json.loads(line)
+        for line in template_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(rows) == len(decisions)
+    for index, (row, decision) in enumerate(zip(rows, decisions, strict=True)):
+        row["owner_decision"] = decision
+        row["decision_note"] = f"owner note {decision}"
+        if timestamps is not None:
+            row["event_recorded_at_utc"] = timestamps[index]
+        if extra_fields:
+            row.update(extra_fields)
+    template_path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def test_build_owner_decision_compiler_emits_clean_input_for_real_intake(
+    tmp_path: Path,
+) -> None:
+    review_console_db, inbox_db, template_path, _inbox_dir = _build_inbox_fixture(tmp_path)
+    output_dir = tmp_path / "owner-decision-compiler"
+    _write_edited_template(
+        template_path,
+        decisions=["approve", "reject"],
+        timestamps=["2026-06-18T00:01:00+00:00", ""],
+        extra_fields={
+            "client_phone_number": "+62 812 0000 0000",
+            "message_text": "raw text must never pass through",
+        },
+    )
+
+    result = build_owner_decision_compiler(
+        owner_inbox_db=inbox_db,
+        edited_template_jsonl=template_path,
+        output_dir=output_dir,
+        summary_path=output_dir / "owner_decision_compiler_summary.md",
+        generated_at_utc="2026-06-18T00:02:00+00:00",
+    )
+
+    assert result.source_inbox_item_count == 2
+    assert result.template_row_count == 2
+    assert result.compiled_decision_count == 2
+    assert result.backfilled_timestamp_count == 1
+    assert result.owner_supplied_timestamp_count == 1
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.output_jsonl == output_dir / "owner_decisions.local.jsonl"
+
+    output_rows = [
+        json.loads(line)
+        for line in result.output_jsonl.read_text(encoding="utf-8").splitlines()
+    ]
+    assert output_rows == [
+        {
+            "decision_note": "owner note approve",
+            "event_actor": "owner",
+            "event_recorded_at_utc": "2026-06-18T00:01:00+00:00",
+            "owner_decision": "approve",
+            "review_item_id": "operator-packet-review-item-pending",
+            "timestamp_source": "owner_supplied",
+        },
+        {
+            "decision_note": "owner note reject",
+            "event_actor": "owner",
+            "event_recorded_at_utc": "2026-06-18T00:02:00+00:00",
+            "owner_decision": "reject",
+            "review_item_id": "operator-packet-review-item-defer",
+            "timestamp_source": "compiler_generated_at_utc",
+        },
+    ]
+    assert "client_phone_number" not in result.output_jsonl.read_text(encoding="utf-8")
+    assert "message_text" not in result.output_jsonl.read_text(encoding="utf-8")
+
+    with sqlite3.connect(result.output_db) as conn:
+        run = conn.execute(
+            """
+            SELECT source_inbox_item_count, template_row_count,
+                   compiled_decision_count, backfilled_timestamp_count,
+                   owner_supplied_timestamp_count, send_whatsapp_count,
+                   crm_mutation_count
+            FROM owner_decision_compiler_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+        db_rows = conn.execute(
+            """
+            SELECT review_item_id, owner_decision, timestamp_source,
+                   send_whatsapp, crm_mutation, requires_human_approval
+            FROM owner_decision_compiler_items
+            ORDER BY compile_rank
+            """
+        ).fetchall()
+    assert run == (2, 2, 2, 1, 1, 0, 0)
+    assert db_rows == [
+        (
+            "operator-packet-review-item-pending",
+            "approve",
+            "owner_supplied",
+            0,
+            0,
+            1,
+        ),
+        (
+            "operator-packet-review-item-defer",
+            "reject",
+            "compiler_generated_at_utc",
+            0,
+            0,
+            1,
+        ),
+    ]
+
+    intake_dir = tmp_path / "owner-decision-intake"
+    intake_result = build_owner_decision_intake(
+        review_console_db=review_console_db,
+        owner_decisions_jsonl=result.output_jsonl,
+        output_dir=intake_dir,
+        summary_path=intake_dir / "owner_decision_intake_summary.md",
+        generated_at_utc="2026-06-18T00:03:00+00:00",
+    )
+    assert intake_result.captured_decision_count == 2
+    assert intake_result.replay_event_count == 2
+    assert intake_result.send_whatsapp_count == 0
+    assert intake_result.crm_mutation_count == 0
+
+    summary = result.summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Owner Decision Compiler Summary" in summary
+    assert "| Compiled decisions | 2 |" in summary
+    assert "| WhatsApp sends | 0 |" in summary
+    assert "| CRM mutations | 0 |" in summary
+    assert "operator-packet-review-item-pending" not in summary
+    assert "client_phone_number" not in summary
+    assert "message_text" not in summary
+
+
+@pytest.mark.parametrize(
+    ("mutator", "message"),
+    [
+        (
+            lambda row: row.update({"owner_decision": ""}),
+            "Owner decision is missing",
+        ),
+        (
+            lambda row: row.update({"owner_decision": "maybe"}),
+            "Owner decision is not allowed",
+        ),
+        (
+            lambda row: row.update({"review_item_id": "unknown-review-item"}),
+            "references unknown inbox item",
+        ),
+        (
+            lambda row: row.update({"packet_id": "tampered-packet"}),
+            "does not match inbox DB",
+        ),
+    ],
+)
+def test_build_owner_decision_compiler_rejects_invalid_template_rows(
+    tmp_path: Path,
+    mutator,
+    message: str,
+) -> None:
+    _review_console_db, inbox_db, template_path, _inbox_dir = _build_inbox_fixture(tmp_path)
+    _write_edited_template(
+        template_path,
+        decisions=["approve", "defer"],
+        timestamps=["2026-06-18T00:01:00+00:00", "2026-06-18T00:02:00+00:00"],
+    )
+    rows = [
+        json.loads(line)
+        for line in template_path.read_text(encoding="utf-8").splitlines()
+    ]
+    mutator(rows[0])
+    template_path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=message):
+        build_owner_decision_compiler(
+            owner_inbox_db=inbox_db,
+            edited_template_jsonl=template_path,
+            output_dir=tmp_path / "owner-decision-compiler",
+            summary_path=tmp_path / "summary.md",
+            generated_at_utc="2026-06-18T00:02:00+00:00",
+        )
+
+
+def test_build_owner_decision_compiler_rejects_duplicate_review_items(
+    tmp_path: Path,
+) -> None:
+    _review_console_db, inbox_db, template_path, _inbox_dir = _build_inbox_fixture(tmp_path)
+    _write_edited_template(
+        template_path,
+        decisions=["approve", "reject"],
+        timestamps=["2026-06-18T00:01:00+00:00", "2026-06-18T00:02:00+00:00"],
+    )
+    rows = [
+        json.loads(line)
+        for line in template_path.read_text(encoding="utf-8").splitlines()
+    ]
+    rows[1]["review_item_id"] = rows[0]["review_item_id"]
+    template_path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Duplicate owner decision compiler row"):
+        build_owner_decision_compiler(
+            owner_inbox_db=inbox_db,
+            edited_template_jsonl=template_path,
+            output_dir=tmp_path / "owner-decision-compiler",
+            summary_path=tmp_path / "summary.md",
+            generated_at_utc="2026-06-18T00:02:00+00:00",
+        )
+
+
+def test_build_owner_decision_compiler_removes_stale_outputs_on_invalid_rerun(
+    tmp_path: Path,
+) -> None:
+    _review_console_db, inbox_db, template_path, _inbox_dir = _build_inbox_fixture(tmp_path)
+    output_dir = tmp_path / "owner-decision-compiler"
+    summary_path = output_dir / "owner_decision_compiler_summary.md"
+    _write_edited_template(
+        template_path,
+        decisions=["approve", "reject"],
+        timestamps=["2026-06-18T00:01:00+00:00", "2026-06-18T00:02:00+00:00"],
+    )
+    first_result = build_owner_decision_compiler(
+        owner_inbox_db=inbox_db,
+        edited_template_jsonl=template_path,
+        output_dir=output_dir,
+        summary_path=summary_path,
+        generated_at_utc="2026-06-18T00:03:00+00:00",
+    )
+    assert first_result.output_db.exists()
+    assert first_result.output_jsonl.exists()
+    assert first_result.summary_path.exists()
+
+    rows = [
+        json.loads(line)
+        for line in template_path.read_text(encoding="utf-8").splitlines()
+    ]
+    rows[0]["owner_decision"] = ""
+    template_path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Owner decision is missing"):
+        build_owner_decision_compiler(
+            owner_inbox_db=inbox_db,
+            edited_template_jsonl=template_path,
+            output_dir=output_dir,
+            summary_path=summary_path,
+            generated_at_utc="2026-06-18T00:04:00+00:00",
+        )
+
+    assert not first_result.output_db.exists()
+    assert not first_result.output_jsonl.exists()
+    assert not first_result.summary_path.exists()
+
+
+def test_readme_owner_decision_chain_consumes_compiler_output_path() -> None:
+    readme = (REPO_ROOT / "scripts" / "whatsapp_corpus" / "README.md").read_text(
+        encoding="utf-8"
+    )
+    compiler_path = (
+        "research/personal/wa-corpus/owner-decision-compiler/"
+        "owner_decisions.local.jsonl"
+    )
+    legacy_intake_path = (
+        "research/personal/wa-corpus/owner-decision-intake/"
+        "owner_decisions.local.jsonl"
+    )
+
+    assert f"--owner-decisions-jsonl {compiler_path} \\" in readme
+    assert legacy_intake_path not in readme
+
+
+def test_cli_writes_json_without_owner_item_ids(tmp_path: Path) -> None:
+    _review_console_db, inbox_db, template_path, _inbox_dir = _build_inbox_fixture(tmp_path)
+    output_dir = tmp_path / "owner-decision-compiler"
+    _write_edited_template(
+        template_path,
+        decisions=["approve", "reject"],
+        timestamps=["2026-06-18T00:01:00+00:00", "2026-06-18T00:02:00+00:00"],
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--owner-inbox-db",
+            str(inbox_db),
+            "--edited-template-jsonl",
+            str(template_path),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(output_dir / "owner_decision_compiler_summary.md"),
+            "--generated-at-utc",
+            "2026-06-18T00:02:00+00:00",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "backfilled_timestamp_count": 0,
+        "compiled_decision_count": 2,
+        "crm_mutation_count": 0,
+        "owner_supplied_timestamp_count": 2,
+        "send_whatsapp_count": 0,
+        "source_inbox_item_count": 2,
+        "template_row_count": 2,
+    }
+    assert "operator-packet-review-item-pending" not in result.stdout
+
+
+def test_cli_derives_default_summary_from_output_dir(tmp_path: Path) -> None:
+    _review_console_db, inbox_db, template_path, _inbox_dir = _build_inbox_fixture(tmp_path)
+    output_dir = tmp_path / "custom-owner-decision-compiler"
+    _write_edited_template(
+        template_path,
+        decisions=["approve", "reject"],
+        timestamps=["2026-06-18T00:01:00+00:00", "2026-06-18T00:02:00+00:00"],
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--owner-inbox-db",
+            str(inbox_db),
+            "--edited-template-jsonl",
+            str(template_path),
+            "--output-dir",
+            str(output_dir),
+            "--generated-at-utc",
+            "2026-06-18T00:02:00+00:00",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    expected_summary = output_dir / "owner_decision_compiler_summary.md"
+    assert "summary_path" not in payload
+    assert expected_summary.exists()
+
+
+def test_build_owner_decision_compiler_has_no_sender_or_cloud_imports() -> None:
+    forbidden_imports = (
+        "anthropic",
+        "backend.app.services.crm",
+        "backend.channels.whatsapp",
+        "httpx",
+        "openai",
+        "requests",
+    )
+    import_lines = [
+        line.strip()
+        for line in SCRIPT.read_text(encoding="utf-8").splitlines()
+        if line.startswith("import ") or line.startswith("from ")
+    ]
+
+    for import_line in import_lines:
+        assert not any(forbidden in import_line for forbidden in forbidden_imports)

--- a/scripts/tests/test_whatsapp_corpus_owner_decision_event_capture.py
+++ b/scripts/tests/test_whatsapp_corpus_owner_decision_event_capture.py
@@ -1,0 +1,432 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.whatsapp_corpus.build_owner_decision_event_capture import (
+    build_owner_decision_event_capture,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = (
+    REPO_ROOT
+    / "scripts"
+    / "whatsapp_corpus"
+    / "build_owner_decision_event_capture.py"
+)
+
+
+def _write_approve_reject_ledger_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE approve_reject_ledger_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_case_count INTEGER NOT NULL,
+                owner_item_count INTEGER NOT NULL,
+                pack_count INTEGER NOT NULL,
+                brief_count INTEGER NOT NULL,
+                queue_item_count INTEGER NOT NULL,
+                ledger_entry_count INTEGER NOT NULL,
+                pending_decision_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE approve_reject_ledger_entries (
+                entry_id TEXT PRIMARY KEY,
+                route_id TEXT NOT NULL,
+                case_card_id TEXT NOT NULL,
+                brief_id TEXT NOT NULL,
+                pack_id TEXT NOT NULL,
+                ledger_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                decision_priority TEXT NOT NULL,
+                route_bucket TEXT NOT NULL,
+                next_actor TEXT NOT NULL,
+                queue_status TEXT NOT NULL,
+                decision_status TEXT NOT NULL,
+                owner_decision TEXT NOT NULL,
+                allowed_decisions_json TEXT NOT NULL,
+                recommended_decision TEXT NOT NULL,
+                draft_action_type TEXT NOT NULL,
+                immutable_event_type TEXT NOT NULL,
+                ledger_entry_hash TEXT NOT NULL UNIQUE,
+                ledger_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO approve_reject_ledger_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_case_count, owner_item_count, pack_count, brief_count,
+                queue_item_count, ledger_entry_count, pending_decision_count,
+                send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, 4, 2, 2, 2, 2, 2, 2, 0, 0)
+            """,
+            (
+                "2026-06-17T18:00:00+00:00",
+                "2026-06-17T17:00:00+00:00",
+                "local_only_approve_reject_ledger_no_raw_text_no_send_no_crm_mutation",
+            ),
+        )
+        rows = [
+            (
+                "ledger-entry-followup",
+                "approval-route-followup",
+                "card-owner-followup",
+                "owner-brief-followup",
+                "owner-pack-followup",
+                1,
+                "sahira",
+                "approve_client_recovery_followup",
+                "now",
+                "owner_now",
+                "owner",
+                "waiting_owner_decision",
+                "awaiting_owner_decision",
+                "pending",
+                "approve_recovery_followup_after_review",
+                "owner_review_client_followup_draft",
+                "a" * 64,
+            ),
+            (
+                "ledger-entry-status",
+                "approval-route-status",
+                "card-owner-status",
+                "owner-brief-status",
+                "owner-pack-status",
+                2,
+                "ari",
+                "approve_immigration_status_escalation",
+                "now",
+                "owner_now",
+                "owner",
+                "waiting_owner_decision",
+                "awaiting_owner_decision",
+                "pending",
+                "approve_status_escalation_after_review",
+                "owner_review_status_escalation_draft",
+                "b" * 64,
+            ),
+        ]
+        conn.executemany(
+            """
+            INSERT INTO approve_reject_ledger_entries (
+                entry_id, route_id, case_card_id, brief_id, pack_id, ledger_rank,
+                assigned_lane, decision_type, decision_priority, route_bucket,
+                next_actor, queue_status, decision_status, owner_decision,
+                allowed_decisions_json, recommended_decision, draft_action_type,
+                immutable_event_type, ledger_entry_hash, ledger_payload_json,
+                send_whatsapp, crm_mutation, requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 1)
+            """,
+            [
+                (
+                    *row[0:14],
+                    json.dumps(["approve", "reject", "defer"]),
+                    row[14],
+                    row[15],
+                    "decision_slot_opened",
+                    row[16],
+                    json.dumps(
+                        {
+                            "schema_version": "approve_reject_ledger.v1",
+                            "raw_text_included": False,
+                            "send_whatsapp": False,
+                            "crm_mutation": False,
+                            "requires_human_approval": True,
+                        },
+                        sort_keys=True,
+                    ),
+                )
+                for row in rows
+            ],
+        )
+        conn.commit()
+
+
+def test_build_owner_decision_event_capture_keeps_missing_events_awaiting_owner(
+    tmp_path: Path,
+) -> None:
+    ledger_db = tmp_path / "approve_reject_ledger.local.sqlite"
+    output_dir = tmp_path / "owner-decision-events"
+    summary_path = output_dir / "owner_decision_event_capture_summary.md"
+    _write_approve_reject_ledger_db(ledger_db)
+
+    result = build_owner_decision_event_capture(
+        ledger_db=ledger_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+        generated_at_utc="2026-06-17T19:00:00+00:00",
+    )
+
+    assert result.source_case_count == 4
+    assert result.owner_item_count == 2
+    assert result.pack_count == 2
+    assert result.brief_count == 2
+    assert result.queue_item_count == 2
+    assert result.ledger_entry_count == 2
+    assert result.captured_event_count == 0
+    assert result.awaiting_input_count == 2
+    assert result.output_db == output_dir / "owner_decision_event_capture.local.sqlite"
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.capture_status_counts == {"awaiting_owner_input": 2}
+    assert result.owner_decision_counts == {"pending": 2}
+    assert result.event_type_counts == {"owner_decision_not_submitted": 2}
+
+    with sqlite3.connect(result.output_db) as conn:
+        rows = conn.execute(
+            """
+            SELECT case_card_id, entry_id, route_id, event_rank, assigned_lane,
+                   decision_type, route_bucket, capture_status, owner_decision,
+                   event_type, event_source, event_actor, allowed_decisions_json,
+                   decision_note, send_whatsapp, crm_mutation,
+                   requires_human_approval, event_hash, event_payload_json
+            FROM owner_decision_event_rows
+            ORDER BY event_rank
+            """
+        ).fetchall()
+        run = conn.execute(
+            """
+            SELECT source_case_count, owner_item_count, pack_count, brief_count,
+                   queue_item_count, ledger_entry_count, captured_event_count,
+                   awaiting_input_count, send_whatsapp_count, crm_mutation_count
+            FROM owner_decision_event_capture_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+
+    assert run == (4, 2, 2, 2, 2, 2, 0, 2, 0, 0)
+    assert rows[0][0:12] == (
+        "card-owner-followup",
+        "ledger-entry-followup",
+        "approval-route-followup",
+        1,
+        "sahira",
+        "approve_client_recovery_followup",
+        "owner_now",
+        "awaiting_owner_input",
+        "pending",
+        "owner_decision_not_submitted",
+        "local_owner_event_capture",
+        "owner",
+    )
+    assert json.loads(rows[0][12]) == ["approve", "reject", "defer"]
+    assert rows[0][13:17] == ("owner_decision_required", 0, 0, 1)
+    assert len(rows[0][17]) == 64
+    int(rows[0][17], 16)
+
+    payload = json.loads(rows[0][18])
+    assert payload["schema_version"] == "owner_decision_event_capture.v1"
+    assert payload["privacy_mode"] == "local_only_owner_decision_event_no_raw_text"
+    assert payload["source_ledger_rank"] == 1
+    assert payload["capture_status"] == "awaiting_owner_input"
+    assert payload["owner_decision"] == "pending"
+    assert payload["event_type"] == "owner_decision_not_submitted"
+    assert payload["event_actor"] == "owner"
+    assert payload["decision_note"] == "owner_decision_required"
+    assert payload["raw_text_included"] is False
+    assert payload["send_whatsapp"] is False
+    assert payload["crm_mutation"] is False
+    assert payload["requires_human_approval"] is True
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Owner Decision Event Capture Summary" in summary
+    assert "| Source cases | 4 |" in summary
+    assert "| Ledger entries | 2 |" in summary
+    assert "| Captured owner events | 0 |" in summary
+    assert "| Awaiting owner input | 2 |" in summary
+    assert "| WhatsApp sends | 0 |" in summary
+    assert "| CRM mutations | 0 |" in summary
+    assert "card-owner-followup" not in summary
+    assert "ledger-entry-followup" not in summary
+    assert "approval-route-followup" not in summary
+    assert "owner-brief-followup" not in summary
+    assert "owner-pack-followup" not in summary
+
+
+def test_build_owner_decision_event_capture_captures_local_owner_events(
+    tmp_path: Path,
+) -> None:
+    ledger_db = tmp_path / "approve_reject_ledger.local.sqlite"
+    output_dir = tmp_path / "owner-decision-events"
+    summary_path = output_dir / "owner_decision_event_capture_summary.md"
+    owner_events_jsonl = output_dir / "owner_events.local.jsonl"
+    _write_approve_reject_ledger_db(ledger_db)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    owner_events_jsonl.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "entry_id": "ledger-entry-followup",
+                        "owner_decision": "approve",
+                        "decision_note": "approved recovery follow-up",
+                        "event_actor": "owner",
+                        "event_recorded_at_utc": "2026-06-17T19:01:00+00:00",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "entry_id": "ledger-entry-status",
+                        "owner_decision": "defer",
+                        "decision_note": "wait for immigration evidence",
+                        "event_actor": "owner",
+                        "event_recorded_at_utc": "2026-06-17T19:02:00+00:00",
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = build_owner_decision_event_capture(
+        ledger_db=ledger_db,
+        owner_events_jsonl=owner_events_jsonl,
+        output_dir=output_dir,
+        summary_path=summary_path,
+        generated_at_utc="2026-06-17T19:00:00+00:00",
+    )
+
+    assert result.captured_event_count == 2
+    assert result.awaiting_input_count == 0
+    assert result.capture_status_counts == {"captured": 2}
+    assert result.owner_decision_counts == {"approve": 1, "defer": 1}
+    assert result.event_type_counts == {"owner_decision_captured": 2}
+
+    with sqlite3.connect(result.output_db) as conn:
+        rows = conn.execute(
+            """
+            SELECT entry_id, capture_status, owner_decision, event_type,
+                   decision_note, event_hash
+            FROM owner_decision_event_rows
+            ORDER BY event_rank
+            """
+        ).fetchall()
+
+    assert rows[0][0:5] == (
+        "ledger-entry-followup",
+        "captured",
+        "approve",
+        "owner_decision_captured",
+        "approved recovery follow-up",
+    )
+    assert rows[1][0:5] == (
+        "ledger-entry-status",
+        "captured",
+        "defer",
+        "owner_decision_captured",
+        "wait for immigration evidence",
+    )
+    assert len({row[5] for row in rows}) == 2
+    assert all(len(row[5]) == 64 for row in rows)
+
+
+def test_build_owner_decision_event_capture_rejects_invalid_owner_decision(
+    tmp_path: Path,
+) -> None:
+    ledger_db = tmp_path / "approve_reject_ledger.local.sqlite"
+    output_dir = tmp_path / "owner-decision-events"
+    owner_events_jsonl = output_dir / "owner_events.local.jsonl"
+    _write_approve_reject_ledger_db(ledger_db)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    owner_events_jsonl.write_text(
+        json.dumps(
+            {
+                "entry_id": "ledger-entry-followup",
+                "owner_decision": "send_now",
+                "decision_note": "bad",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Owner decision is not allowed"):
+        build_owner_decision_event_capture(
+            ledger_db=ledger_db,
+            owner_events_jsonl=owner_events_jsonl,
+            output_dir=output_dir,
+            summary_path=output_dir / "summary.md",
+        )
+
+
+def test_build_owner_decision_event_capture_rejects_unexpected_input_name(
+    tmp_path: Path,
+) -> None:
+    unexpected_db = tmp_path / "approve_reject_ledger.bad.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    with pytest.raises(
+        ValueError,
+        match="Refusing to read unexpected Approve/Reject Ledger DB",
+    ):
+        build_owner_decision_event_capture(
+            ledger_db=unexpected_db,
+            output_dir=tmp_path / "owner-decision-events",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_cli_writes_json_without_decision_details(tmp_path: Path) -> None:
+    ledger_db = tmp_path / "approve_reject_ledger.local.sqlite"
+    output_dir = tmp_path / "owner-decision-events"
+    summary_path = output_dir / "owner_decision_event_capture_summary.md"
+    _write_approve_reject_ledger_db(ledger_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--ledger-db",
+            str(ledger_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--generated-at-utc",
+            "2026-06-17T19:00:00+00:00",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "awaiting_input_count": 2,
+        "brief_count": 2,
+        "captured_event_count": 0,
+        "crm_mutation_count": 0,
+        "ledger_entry_count": 2,
+        "owner_item_count": 2,
+        "pack_count": 2,
+        "queue_item_count": 2,
+        "send_whatsapp_count": 0,
+        "source_case_count": 4,
+    }
+    assert "card-owner-followup" not in result.stdout
+    assert "ledger-entry-followup" not in result.stdout
+    assert "approval-route-followup" not in result.stdout
+    assert "owner-brief-followup" not in result.stdout
+    assert "owner-pack-followup" not in result.stdout

--- a/scripts/tests/test_whatsapp_corpus_owner_decision_inbox.py
+++ b/scripts/tests/test_whatsapp_corpus_owner_decision_inbox.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.tests.test_whatsapp_corpus_owner_decision_intake import (
+    _write_operator_packet_review_console_db,
+)
+from scripts.whatsapp_corpus.build_owner_decision_inbox import (
+    build_owner_decision_inbox,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_owner_decision_inbox.py"
+
+
+def test_build_owner_decision_inbox_writes_actionable_rows_and_template(
+    tmp_path: Path,
+) -> None:
+    review_console_db = tmp_path / "operator_packet_review_console.local.sqlite"
+    output_dir = tmp_path / "owner-decision-inbox"
+    summary_path = output_dir / "owner_decision_inbox_summary.md"
+    _write_operator_packet_review_console_db(review_console_db)
+
+    result = build_owner_decision_inbox(
+        review_console_db=review_console_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+        generated_at_utc="2026-06-18T00:01:00+00:00",
+    )
+
+    assert result.source_case_count == 8
+    assert result.source_review_item_count == 4
+    assert result.inbox_item_count == 2
+    assert result.waiting_decision_count == 1
+    assert result.revisit_decision_count == 1
+    assert result.excluded_review_item_count == 2
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.output_db == output_dir / "owner_decision_inbox.local.sqlite"
+    assert result.output_template == output_dir / "owner_decisions_template.local.jsonl"
+
+    with sqlite3.connect(result.output_db) as conn:
+        run = conn.execute(
+            """
+            SELECT source_case_count, source_review_item_count, inbox_item_count,
+                   waiting_decision_count, revisit_decision_count,
+                   excluded_review_item_count, send_whatsapp_count,
+                   crm_mutation_count
+            FROM owner_decision_inbox_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+        rows = conn.execute(
+            """
+            SELECT owner_inbox_item_id, review_item_id, packet_id, entry_id,
+                   inbox_rank, assigned_lane, operator_lane, decision_type,
+                   review_state, console_bucket, review_priority,
+                   visible_owner_action, owner_decision_status,
+                   template_status, allowed_decisions_json,
+                   owner_decision_input, decision_note_input,
+                   send_whatsapp, crm_mutation, requires_human_approval,
+                   inbox_payload_json
+            FROM owner_decision_inbox_items
+            ORDER BY inbox_rank
+            """
+        ).fetchall()
+
+    assert run == (8, 4, 2, 1, 1, 2, 0, 0)
+    assert [row[1] for row in rows] == [
+        "operator-packet-review-item-pending",
+        "operator-packet-review-item-defer",
+    ]
+    assert rows[0][4:14] == (
+        1,
+        "sahira",
+        "owner",
+        "approve_client_recovery_followup",
+        "waiting_owner_decision",
+        "owner_decision_inbox",
+        "owner_now",
+        "capture_owner_decision",
+        "needs_owner_decision",
+        "blank_owner_decision_required",
+    )
+    assert rows[1][4:14] == (
+        2,
+        "ari",
+        "owner",
+        "approve_immigration_status_escalation",
+        "deferred_owner_revisit",
+        "owner_revisit_queue",
+        "owner_revisit",
+        "revisit_deferred_decision",
+        "needs_owner_revisit",
+        "blank_owner_decision_required",
+    )
+    assert json.loads(rows[0][14]) == ["approve", "reject", "defer"]
+    assert rows[0][15] == ""
+    assert rows[0][16] == ""
+    assert {row[17] for row in rows} == {0}
+    assert {row[18] for row in rows} == {0}
+    assert {row[19] for row in rows} == {1}
+    payload = json.loads(rows[0][20])
+    assert payload["schema_version"] == "owner_decision_inbox.v1"
+    assert payload["privacy_mode"] == "local_only_owner_decision_inbox_no_raw_text"
+    assert payload["source_review_rank"] == 1
+    assert payload["raw_text_included"] is False
+    assert payload["send_whatsapp"] is False
+    assert payload["crm_mutation"] is False
+    assert payload["requires_human_approval"] is True
+
+    template_rows = [
+        json.loads(line)
+        for line in result.output_template.read_text(encoding="utf-8").splitlines()
+    ]
+    assert template_rows == [
+        {
+            "allowed_decisions": ["approve", "reject", "defer"],
+            "assigned_lane": "sahira",
+            "console_bucket": "owner_decision_inbox",
+            "decision_note": "",
+            "decision_type": "approve_client_recovery_followup",
+            "entry_id": "ledger-entry-pending",
+            "event_actor": "owner",
+            "event_recorded_at_utc": "",
+            "owner_decision": "",
+            "packet_id": "operator-packet-pending",
+            "review_item_id": "operator-packet-review-item-pending",
+            "review_state": "waiting_owner_decision",
+        },
+        {
+            "allowed_decisions": ["approve", "reject", "defer"],
+            "assigned_lane": "ari",
+            "console_bucket": "owner_revisit_queue",
+            "decision_note": "",
+            "decision_type": "approve_immigration_status_escalation",
+            "entry_id": "ledger-entry-defer",
+            "event_actor": "owner",
+            "event_recorded_at_utc": "",
+            "owner_decision": "",
+            "packet_id": "operator-packet-defer",
+            "review_item_id": "operator-packet-review-item-defer",
+            "review_state": "deferred_owner_revisit",
+        },
+    ]
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Owner Decision Inbox Summary" in summary
+    assert "| Source cases | 8 |" in summary
+    assert "| Owner inbox items | 2 |" in summary
+    assert "| Waiting owner decision | 1 |" in summary
+    assert "| Owner revisit needed | 1 |" in summary
+    assert "| WhatsApp sends | 0 |" in summary
+    assert "| CRM mutations | 0 |" in summary
+    assert "operator-packet-review-item-pending" not in summary
+    assert "ledger-entry-pending" not in summary
+
+
+def test_build_owner_decision_inbox_rejects_unexpected_input_name(
+    tmp_path: Path,
+) -> None:
+    unexpected_db = tmp_path / "owner_decision_intake.local.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    with pytest.raises(ValueError, match="Refusing to read unexpected"):
+        build_owner_decision_inbox(
+            review_console_db=unexpected_db,
+            output_dir=tmp_path / "owner-decision-inbox",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_cli_writes_json_without_owner_item_ids(tmp_path: Path) -> None:
+    review_console_db = tmp_path / "operator_packet_review_console.local.sqlite"
+    output_dir = tmp_path / "owner-decision-inbox"
+    summary_path = output_dir / "owner_decision_inbox_summary.md"
+    _write_operator_packet_review_console_db(review_console_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--review-console-db",
+            str(review_console_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--generated-at-utc",
+            "2026-06-18T00:01:00+00:00",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "crm_mutation_count": 0,
+        "excluded_review_item_count": 2,
+        "inbox_item_count": 2,
+        "revisit_decision_count": 1,
+        "send_whatsapp_count": 0,
+        "source_case_count": 8,
+        "source_review_item_count": 4,
+        "waiting_decision_count": 1,
+    }
+    assert "operator-packet-review-item-pending" not in result.stdout
+    assert "ledger-entry-pending" not in result.stdout

--- a/scripts/tests/test_whatsapp_corpus_owner_decision_intake.py
+++ b/scripts/tests/test_whatsapp_corpus_owner_decision_intake.py
@@ -1,0 +1,686 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.whatsapp_corpus.build_owner_decision_intake import (
+    build_owner_decision_intake,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_owner_decision_intake.py"
+
+
+def _write_operator_packet_review_console_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE operator_packet_review_console_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_case_count INTEGER NOT NULL,
+                owner_item_count INTEGER NOT NULL,
+                pack_count INTEGER NOT NULL,
+                brief_count INTEGER NOT NULL,
+                queue_item_count INTEGER NOT NULL,
+                ledger_entry_count INTEGER NOT NULL,
+                event_row_count INTEGER NOT NULL,
+                work_order_count INTEGER NOT NULL,
+                packet_count INTEGER NOT NULL,
+                review_item_count INTEGER NOT NULL,
+                owner_decision_item_count INTEGER NOT NULL,
+                operator_ready_item_count INTEGER NOT NULL,
+                deferred_item_count INTEGER NOT NULL,
+                rejected_item_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE operator_packet_review_items (
+                review_item_id TEXT PRIMARY KEY,
+                packet_id TEXT NOT NULL,
+                work_order_id TEXT NOT NULL,
+                event_id TEXT NOT NULL,
+                entry_id TEXT NOT NULL,
+                route_id TEXT NOT NULL,
+                case_card_id TEXT NOT NULL,
+                brief_id TEXT NOT NULL,
+                pack_id TEXT NOT NULL,
+                review_rank INTEGER NOT NULL,
+                source_packet_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                operator_lane TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                decision_priority TEXT NOT NULL,
+                route_bucket TEXT NOT NULL,
+                owner_decision TEXT NOT NULL,
+                packet_status TEXT NOT NULL,
+                packet_type TEXT NOT NULL,
+                packet_gate TEXT NOT NULL,
+                packet_action TEXT NOT NULL,
+                operator_instruction TEXT NOT NULL,
+                escalation_target TEXT NOT NULL,
+                review_state TEXT NOT NULL,
+                console_bucket TEXT NOT NULL,
+                review_priority TEXT NOT NULL,
+                visible_owner_action TEXT NOT NULL,
+                operator_action TEXT NOT NULL,
+                console_instruction TEXT NOT NULL,
+                review_gate TEXT NOT NULL,
+                action_lock TEXT NOT NULL,
+                decision_note TEXT NOT NULL,
+                source_packet_hash TEXT NOT NULL,
+                review_hash TEXT NOT NULL UNIQUE,
+                review_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO operator_packet_review_console_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_case_count, owner_item_count, pack_count, brief_count,
+                queue_item_count, ledger_entry_count, event_row_count,
+                work_order_count, packet_count, review_item_count,
+                owner_decision_item_count, operator_ready_item_count,
+                deferred_item_count, rejected_item_count,
+                send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, 8, 4, 4, 4, 4, 4, 4, 4, 4, 4, 1, 1, 1, 1, 0, 0)
+            """,
+            (
+                "2026-06-17T22:00:00+00:00",
+                "2026-06-17T21:00:00+00:00",
+                "local_only_operator_packet_review_console_no_raw_text_no_send_no_crm_mutation",
+            ),
+        )
+        rows = [
+            (
+                "operator-packet-review-item-pending",
+                "operator-packet-pending",
+                "post-work-order-pending",
+                "owner-event-pending",
+                "ledger-entry-pending",
+                "approval-route-pending",
+                "card-owner-pending",
+                "owner-brief-pending",
+                "owner-pack-pending",
+                1,
+                1,
+                "sahira",
+                "owner",
+                "approve_client_recovery_followup",
+                "now",
+                "owner_now",
+                "pending",
+                "blocked_awaiting_owner_decision",
+                "owner_decision_required_packet",
+                "owner_input_required",
+                "wait_for_owner_decision",
+                "no_operator_execution_until_owner_decides",
+                "owner",
+                "waiting_owner_decision",
+                "owner_decision_inbox",
+                "owner_now",
+                "capture_owner_decision",
+                "no_operator_action",
+                "owner_must_approve_reject_or_defer_before_team_work",
+                "owner_input_required",
+                "locked_until_owner_decision",
+                "owner_decision_required",
+                "a" * 64,
+                "b" * 64,
+            ),
+            (
+                "operator-packet-review-item-ready",
+                "operator-packet-ready",
+                "post-work-order-ready",
+                "owner-event-ready",
+                "ledger-entry-ready",
+                "approval-route-ready",
+                "card-owner-ready",
+                "owner-brief-ready",
+                "owner-pack-ready",
+                2,
+                2,
+                "sahira",
+                "sahira",
+                "approve_client_recovery_followup",
+                "now",
+                "owner_now",
+                "approve",
+                "ready_for_operator_review",
+                "client_recovery_followup_packet",
+                "human_review_before_send_or_crm",
+                "prepare_client_recovery_followup_for_human_review",
+                "review_client_recovery_followup_before_any_send",
+                "owner",
+                "ready_for_human_review",
+                "operator_review_queue",
+                "operator_now",
+                "no_owner_action_required",
+                "review_packet_before_send_or_crm",
+                "review_ready_packet_and_request_human_approval",
+                "human_review_before_send_or_crm",
+                "locked_until_human_review",
+                "approved recovery follow-up",
+                "c" * 64,
+                "d" * 64,
+            ),
+            (
+                "operator-packet-review-item-defer",
+                "operator-packet-defer",
+                "post-work-order-defer",
+                "owner-event-defer",
+                "ledger-entry-defer",
+                "approval-route-defer",
+                "card-owner-defer",
+                "owner-brief-defer",
+                "owner-pack-defer",
+                3,
+                3,
+                "ari",
+                "owner",
+                "approve_immigration_status_escalation",
+                "now",
+                "owner_now",
+                "defer",
+                "deferred_owner_followup",
+                "owner_deferred_packet",
+                "owner_revisit_required",
+                "schedule_owner_revisit",
+                "hold_operator_execution_until_owner_revisits",
+                "owner",
+                "deferred_owner_revisit",
+                "owner_revisit_queue",
+                "owner_revisit",
+                "revisit_deferred_decision",
+                "no_operator_action",
+                "owner_must_revisit_deferred_packet",
+                "owner_revisit_required",
+                "locked_until_owner_revisit",
+                "wait for immigration evidence",
+                "e" * 64,
+                "f" * 64,
+            ),
+            (
+                "operator-packet-review-item-reject",
+                "operator-packet-reject",
+                "post-work-order-reject",
+                "owner-event-reject",
+                "ledger-entry-reject",
+                "approval-route-reject",
+                "card-owner-reject",
+                "owner-brief-reject",
+                "owner-pack-reject",
+                4,
+                4,
+                "ari",
+                "owner",
+                "approve_immigration_status_escalation",
+                "now",
+                "owner_now",
+                "reject",
+                "rejected_no_action",
+                "owner_rejected_packet",
+                "no_external_action",
+                "record_rejection_and_stop",
+                "do_not_execute_rejected_work_order",
+                "owner",
+                "rejected_closed",
+                "closed_no_action",
+                "closed",
+                "no_action",
+                "no_operator_action",
+                "no_action_packet_rejected",
+                "no_external_action",
+                "closed_no_external_action",
+                "do not proceed",
+                "1" * 64,
+                "2" * 64,
+            ),
+        ]
+        conn.executemany(
+            """
+            INSERT INTO operator_packet_review_items (
+                review_item_id, packet_id, work_order_id, event_id, entry_id,
+                route_id, case_card_id, brief_id, pack_id, review_rank,
+                source_packet_rank, assigned_lane, operator_lane, decision_type,
+                decision_priority, route_bucket, owner_decision, packet_status,
+                packet_type, packet_gate, packet_action, operator_instruction,
+                escalation_target, review_state, console_bucket, review_priority,
+                visible_owner_action, operator_action, console_instruction,
+                review_gate, action_lock, decision_note, source_packet_hash,
+                review_hash, review_payload_json, send_whatsapp, crm_mutation,
+                requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 1)
+            """,
+            [
+                (
+                    *row,
+                    json.dumps(
+                        {
+                            "schema_version": "operator_packet_review_console.v1",
+                            "raw_text_included": False,
+                            "send_whatsapp": False,
+                            "crm_mutation": False,
+                            "requires_human_approval": True,
+                        },
+                        sort_keys=True,
+                    ),
+                )
+                for row in rows
+            ],
+        )
+        conn.commit()
+
+
+def test_build_owner_decision_intake_exports_replay_jsonl_for_owner_actions(
+    tmp_path: Path,
+) -> None:
+    review_db = tmp_path / "operator_packet_review_console.local.sqlite"
+    output_dir = tmp_path / "owner-decision-intake"
+    summary_path = output_dir / "owner_decision_intake_summary.md"
+    owner_decisions_jsonl = output_dir / "owner_decisions.local.jsonl"
+    _write_operator_packet_review_console_db(review_db)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    owner_decisions_jsonl.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "review_item_id": "operator-packet-review-item-pending",
+                        "owner_decision": "approve",
+                        "decision_note": "approved recovery follow-up",
+                        "event_actor": "owner",
+                        "event_recorded_at_utc": "2026-06-17T23:01:00+00:00",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "packet_id": "operator-packet-defer",
+                        "owner_decision": "reject",
+                        "decision_note": "do not proceed after revisit",
+                        "event_actor": "owner",
+                        "event_recorded_at_utc": "2026-06-17T23:02:00+00:00",
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = build_owner_decision_intake(
+        review_console_db=review_db,
+        owner_decisions_jsonl=owner_decisions_jsonl,
+        output_dir=output_dir,
+        summary_path=summary_path,
+        generated_at_utc="2026-06-17T23:00:00+00:00",
+    )
+
+    assert result.source_case_count == 8
+    assert result.packet_count == 4
+    assert result.review_item_count == 4
+    assert result.intake_item_count == 4
+    assert result.captured_decision_count == 2
+    assert result.awaiting_owner_decision_count == 0
+    assert result.awaiting_owner_revisit_count == 0
+    assert result.no_owner_action_required_count == 1
+    assert result.closed_item_count == 1
+    assert result.replay_event_count == 2
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.output_db == output_dir / "owner_decision_intake.local.sqlite"
+    assert result.output_jsonl == output_dir / "owner_events.local.jsonl"
+    assert result.output_template == output_dir / "owner_decisions_template.local.jsonl"
+    assert result.intake_status_counts == {
+        "captured": 2,
+        "closed_no_owner_action": 1,
+        "no_owner_action_required": 1,
+    }
+
+    with sqlite3.connect(result.output_db) as conn:
+        rows = conn.execute(
+            """
+            SELECT review_item_id, packet_id, entry_id, intake_rank,
+                   review_state, console_bucket, visible_owner_action,
+                   submitted_owner_decision, intake_status, replay_event_status,
+                   replay_event_type, event_actor, event_recorded_at_utc,
+                   decision_note, send_whatsapp, crm_mutation,
+                   requires_human_approval, intake_hash, intake_payload_json
+            FROM owner_decision_intake_items
+            ORDER BY intake_rank
+            """
+        ).fetchall()
+        run = conn.execute(
+            """
+            SELECT source_case_count, packet_count, review_item_count,
+                   intake_item_count, captured_decision_count,
+                   awaiting_owner_decision_count, awaiting_owner_revisit_count,
+                   no_owner_action_required_count, closed_item_count,
+                   replay_event_count, send_whatsapp_count, crm_mutation_count
+            FROM owner_decision_intake_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+
+    assert run == (8, 4, 4, 4, 2, 0, 0, 1, 1, 2, 0, 0)
+    assert rows[0][0:17] == (
+        "operator-packet-review-item-pending",
+        "operator-packet-pending",
+        "ledger-entry-pending",
+        1,
+        "waiting_owner_decision",
+        "owner_decision_inbox",
+        "capture_owner_decision",
+        "approve",
+        "captured",
+        "emitted_to_owner_events_jsonl",
+        "owner_decision_intake_captured",
+        "owner",
+        "2026-06-17T23:01:00+00:00",
+        "approved recovery follow-up",
+        0,
+        0,
+        1,
+    )
+    assert rows[1][7:11] == (
+        "approve",
+        "no_owner_action_required",
+        "not_emitted",
+        "owner_action_not_required",
+    )
+    assert rows[2][7:11] == (
+        "reject",
+        "captured",
+        "emitted_to_owner_events_jsonl",
+        "owner_decision_intake_captured",
+    )
+    assert rows[3][7:11] == (
+        "reject",
+        "closed_no_owner_action",
+        "not_emitted",
+        "owner_action_closed",
+    )
+    assert len({row[17] for row in rows}) == 4
+    assert all(len(row[17]) == 64 for row in rows)
+
+    payload = json.loads(rows[0][18])
+    assert payload["schema_version"] == "owner_decision_intake.v1"
+    assert payload["privacy_mode"] == "local_only_owner_decision_intake_no_raw_text"
+    assert payload["source_review_rank"] == 1
+    assert payload["submitted_owner_decision"] == "approve"
+    assert payload["intake_status"] == "captured"
+    assert payload["replay_event_status"] == "emitted_to_owner_events_jsonl"
+    assert payload["raw_text_included"] is False
+    assert payload["send_whatsapp"] is False
+    assert payload["crm_mutation"] is False
+    assert payload["requires_human_approval"] is True
+
+    replay_rows = [
+        json.loads(line)
+        for line in result.output_jsonl.read_text(encoding="utf-8").splitlines()
+    ]
+    assert replay_rows == [
+        {
+            "decision_note": "approved recovery follow-up",
+            "entry_id": "ledger-entry-pending",
+            "event_actor": "owner",
+            "event_recorded_at_utc": "2026-06-17T23:01:00+00:00",
+            "owner_decision": "approve",
+        },
+        {
+            "decision_note": "do not proceed after revisit",
+            "entry_id": "ledger-entry-defer",
+            "event_actor": "owner",
+            "event_recorded_at_utc": "2026-06-17T23:02:00+00:00",
+            "owner_decision": "reject",
+        },
+    ]
+    assert result.output_template.read_text(encoding="utf-8") == ""
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Owner Decision Intake Summary" in summary
+    assert "| Source cases | 8 |" in summary
+    assert "| Review items | 4 |" in summary
+    assert "| Captured decisions | 2 |" in summary
+    assert "| Replay events | 2 |" in summary
+    assert "| WhatsApp sends | 0 |" in summary
+    assert "| CRM mutations | 0 |" in summary
+    assert "operator-packet-review-item-pending" not in summary
+    assert "operator-packet-pending" not in summary
+    assert "ledger-entry-pending" not in summary
+
+
+def test_build_owner_decision_intake_keeps_missing_owner_items_awaiting(
+    tmp_path: Path,
+) -> None:
+    review_db = tmp_path / "operator_packet_review_console.local.sqlite"
+    output_dir = tmp_path / "owner-decision-intake"
+    _write_operator_packet_review_console_db(review_db)
+
+    result = build_owner_decision_intake(
+        review_console_db=review_db,
+        output_dir=output_dir,
+        summary_path=output_dir / "summary.md",
+        generated_at_utc="2026-06-17T23:00:00+00:00",
+    )
+
+    assert result.captured_decision_count == 0
+    assert result.awaiting_owner_decision_count == 1
+    assert result.awaiting_owner_revisit_count == 1
+    assert result.no_owner_action_required_count == 1
+    assert result.closed_item_count == 1
+    assert result.replay_event_count == 0
+    assert result.output_jsonl.read_text(encoding="utf-8") == ""
+    template_rows = [
+        json.loads(line)
+        for line in result.output_template.read_text(encoding="utf-8").splitlines()
+    ]
+    assert template_rows == [
+        {
+            "allowed_decisions": ["approve", "reject", "defer"],
+            "assigned_lane": "sahira",
+            "console_bucket": "owner_decision_inbox",
+            "decision_note": "",
+            "decision_type": "approve_client_recovery_followup",
+            "entry_id": "ledger-entry-pending",
+            "event_actor": "owner",
+            "event_recorded_at_utc": "2026-06-17T23:00:00+00:00",
+            "owner_decision": "",
+            "packet_id": "operator-packet-pending",
+            "review_item_id": "operator-packet-review-item-pending",
+            "review_state": "waiting_owner_decision",
+        },
+        {
+            "allowed_decisions": ["approve", "reject", "defer"],
+            "assigned_lane": "ari",
+            "console_bucket": "owner_revisit_queue",
+            "decision_note": "",
+            "decision_type": "approve_immigration_status_escalation",
+            "entry_id": "ledger-entry-defer",
+            "event_actor": "owner",
+            "event_recorded_at_utc": "2026-06-17T23:00:00+00:00",
+            "owner_decision": "",
+            "packet_id": "operator-packet-defer",
+            "review_item_id": "operator-packet-review-item-defer",
+            "review_state": "deferred_owner_revisit",
+        },
+    ]
+    assert result.intake_status_counts == {
+        "awaiting_owner_decision": 1,
+        "awaiting_owner_revisit": 1,
+        "closed_no_owner_action": 1,
+        "no_owner_action_required": 1,
+    }
+
+
+def test_build_owner_decision_intake_rejects_invalid_decision(
+    tmp_path: Path,
+) -> None:
+    review_db = tmp_path / "operator_packet_review_console.local.sqlite"
+    output_dir = tmp_path / "owner-decision-intake"
+    owner_decisions_jsonl = output_dir / "owner_decisions.local.jsonl"
+    _write_operator_packet_review_console_db(review_db)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    owner_decisions_jsonl.write_text(
+        json.dumps(
+            {
+                "review_item_id": "operator-packet-review-item-pending",
+                "owner_decision": "send_now",
+                "decision_note": "bad",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Owner decision is not allowed"):
+        build_owner_decision_intake(
+            review_console_db=review_db,
+            owner_decisions_jsonl=owner_decisions_jsonl,
+            output_dir=output_dir,
+            summary_path=output_dir / "summary.md",
+        )
+
+
+def test_build_owner_decision_intake_rejects_non_owner_action_item(
+    tmp_path: Path,
+) -> None:
+    review_db = tmp_path / "operator_packet_review_console.local.sqlite"
+    output_dir = tmp_path / "owner-decision-intake"
+    owner_decisions_jsonl = output_dir / "owner_decisions.local.jsonl"
+    _write_operator_packet_review_console_db(review_db)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    owner_decisions_jsonl.write_text(
+        json.dumps(
+            {
+                "review_item_id": "operator-packet-review-item-ready",
+                "owner_decision": "reject",
+                "decision_note": "bad target",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="not owner-actionable"):
+        build_owner_decision_intake(
+            review_console_db=review_db,
+            owner_decisions_jsonl=owner_decisions_jsonl,
+            output_dir=output_dir,
+            summary_path=output_dir / "summary.md",
+        )
+
+
+def test_build_owner_decision_intake_rejects_duplicate_references(
+    tmp_path: Path,
+) -> None:
+    review_db = tmp_path / "operator_packet_review_console.local.sqlite"
+    output_dir = tmp_path / "owner-decision-intake"
+    owner_decisions_jsonl = output_dir / "owner_decisions.local.jsonl"
+    _write_operator_packet_review_console_db(review_db)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    owner_decisions_jsonl.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "review_item_id": "operator-packet-review-item-pending",
+                        "owner_decision": "approve",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "entry_id": "ledger-entry-pending",
+                        "owner_decision": "defer",
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Duplicate owner decision intake"):
+        build_owner_decision_intake(
+            review_console_db=review_db,
+            owner_decisions_jsonl=owner_decisions_jsonl,
+            output_dir=output_dir,
+            summary_path=output_dir / "summary.md",
+        )
+
+
+def test_build_owner_decision_intake_rejects_unexpected_input_name(
+    tmp_path: Path,
+) -> None:
+    unexpected_db = tmp_path / "operator_packet_review_console.bad.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    with pytest.raises(
+        ValueError,
+        match="Refusing to read unexpected Operator Packet Review Console DB",
+    ):
+        build_owner_decision_intake(
+            review_console_db=unexpected_db,
+            output_dir=tmp_path / "owner-decision-intake",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_cli_writes_json_without_intake_details(tmp_path: Path) -> None:
+    review_db = tmp_path / "operator_packet_review_console.local.sqlite"
+    output_dir = tmp_path / "owner-decision-intake"
+    summary_path = output_dir / "owner_decision_intake_summary.md"
+    _write_operator_packet_review_console_db(review_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--review-console-db",
+            str(review_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--generated-at-utc",
+            "2026-06-17T23:00:00+00:00",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "awaiting_owner_decision_count": 1,
+        "awaiting_owner_revisit_count": 1,
+        "captured_decision_count": 0,
+        "closed_item_count": 1,
+        "crm_mutation_count": 0,
+        "intake_item_count": 4,
+        "no_owner_action_required_count": 1,
+        "packet_count": 4,
+        "replay_event_count": 0,
+        "review_item_count": 4,
+        "send_whatsapp_count": 0,
+        "source_case_count": 8,
+    }
+    assert "operator-packet-review-item-pending" not in result.stdout
+    assert "operator-packet-pending" not in result.stdout
+    assert "ledger-entry-pending" not in result.stdout

--- a/scripts/tests/test_whatsapp_corpus_owner_decision_packs.py
+++ b/scripts/tests/test_whatsapp_corpus_owner_decision_packs.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.whatsapp_corpus.build_owner_decision_packs import (
+    build_owner_decision_packs,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_owner_decision_packs.py"
+
+
+def _write_owner_approval_console_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE owner_approval_console_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_case_count INTEGER NOT NULL,
+                owner_item_count INTEGER NOT NULL,
+                urgent_item_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE owner_approval_items (
+                approval_id TEXT PRIMARY KEY,
+                case_card_id TEXT NOT NULL,
+                approval_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                primary_action TEXT NOT NULL,
+                closure_status TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                decision_priority TEXT NOT NULL,
+                owner_prompt_code TEXT NOT NULL,
+                recommended_owner_action TEXT NOT NULL,
+                approval_status TEXT NOT NULL,
+                top_gap_code TEXT NOT NULL,
+                top_gap_category TEXT NOT NULL,
+                top_gap_severity TEXT NOT NULL,
+                resolution_gate TEXT NOT NULL,
+                owner_decision_required INTEGER NOT NULL CHECK (owner_decision_required = 1),
+                approval_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO owner_approval_console_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_case_count, owner_item_count, urgent_item_count,
+                send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, 4, 2, 2, 0, 0)
+            """,
+            (
+                "2026-06-17T14:00:00+00:00",
+                "2026-06-17T13:00:00+00:00",
+                "local_only_owner_approval_no_raw_text_no_send_no_crm_mutation",
+            ),
+        )
+        rows = [
+            (
+                "owner-approval-followup",
+                "card-owner-followup",
+                1,
+                "sahira",
+                "crm_followup",
+                "owner_review_blocked",
+                "approve_client_recovery_followup",
+                "now",
+                "owner_client_recovery_followup",
+                "Review and approve the client recovery follow-up before any message is sent.",
+                "pending_owner_review",
+                "client_followup_confirmation_missing",
+                "client_response",
+                "urgent",
+                "owner_review_required",
+            ),
+            (
+                "owner-approval-status",
+                "card-owner-status",
+                2,
+                "ari",
+                "immigration_status_check",
+                "owner_review_blocked",
+                "approve_immigration_status_escalation",
+                "now",
+                "owner_immigration_status_escalation",
+                "Review and approve the immigration status escalation before any message is sent.",
+                "pending_owner_review",
+                "immigration_status_evidence_missing",
+                "status",
+                "urgent",
+                "owner_review_required",
+            ),
+        ]
+        conn.executemany(
+            """
+            INSERT INTO owner_approval_items (
+                approval_id, case_card_id, approval_rank, assigned_lane,
+                primary_action, closure_status, decision_type, decision_priority,
+                owner_prompt_code, recommended_owner_action, approval_status,
+                top_gap_code, top_gap_category, top_gap_severity, resolution_gate,
+                owner_decision_required, approval_payload_json, send_whatsapp,
+                crm_mutation, requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, 0, 0, 1)
+            """,
+            [
+                (
+                    *row,
+                    json.dumps(
+                        {
+                            "schema_version": "owner_approval_console.v1",
+                            "raw_text_included": False,
+                            "send_whatsapp": False,
+                            "crm_mutation": False,
+                            "requires_human_approval": True,
+                        },
+                        sort_keys=True,
+                    ),
+                )
+                for row in rows
+            ],
+        )
+        conn.commit()
+
+
+def test_build_owner_decision_packs_writes_owner_ready_packets(tmp_path: Path) -> None:
+    owner_approval_db = tmp_path / "owner_approval_console.local.sqlite"
+    output_dir = tmp_path / "owner-decision-packs"
+    summary_path = output_dir / "owner_decision_packs_summary.md"
+    _write_owner_approval_console_db(owner_approval_db)
+
+    result = build_owner_decision_packs(
+        owner_approval_db=owner_approval_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+        generated_at_utc="2026-06-17T15:00:00+00:00",
+    )
+
+    assert result.source_case_count == 4
+    assert result.owner_item_count == 2
+    assert result.pack_count == 2
+    assert result.output_db == output_dir / "owner_decision_packs.local.sqlite"
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.decision_type_counts == {
+        "approve_client_recovery_followup": 1,
+        "approve_immigration_status_escalation": 1,
+    }
+    assert result.lane_counts == {"sahira": 1, "ari": 1}
+
+    with sqlite3.connect(result.output_db) as conn:
+        packs = conn.execute(
+            """
+            SELECT case_card_id, pack_rank, assigned_lane, decision_type,
+                   decision_priority, pack_title, risk_brief,
+                   recommended_decision, draft_action_type,
+                   draft_action_status, approval_status, top_gap_code,
+                   top_gap_category, top_gap_severity, resolution_gate,
+                   owner_decision_required, send_whatsapp, crm_mutation,
+                   requires_human_approval, pack_payload_json
+            FROM owner_decision_packs
+            ORDER BY pack_rank
+            """
+        ).fetchall()
+        run = conn.execute(
+            """
+            SELECT source_case_count, owner_item_count, pack_count,
+                   urgent_pack_count, send_whatsapp_count, crm_mutation_count
+            FROM owner_decision_pack_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+
+    assert run == (4, 2, 2, 2, 0, 0)
+    assert packs[0][0:16] == (
+        "card-owner-followup",
+        1,
+        "sahira",
+        "approve_client_recovery_followup",
+        "now",
+        "Client recovery follow-up approval",
+        "Urgent client response gap requires owner-approved recovery follow-up.",
+        "approve_recovery_followup_after_review",
+        "owner_review_client_followup_draft",
+        "draft_ready_for_owner_review",
+        "pending_owner_review",
+        "client_followup_confirmation_missing",
+        "client_response",
+        "urgent",
+        "owner_review_required",
+        1,
+    )
+    assert packs[1][0:16] == (
+        "card-owner-status",
+        2,
+        "ari",
+        "approve_immigration_status_escalation",
+        "now",
+        "Immigration status escalation approval",
+        "Urgent immigration status gap requires owner-approved escalation.",
+        "approve_status_escalation_after_review",
+        "owner_review_status_escalation_draft",
+        "draft_ready_for_owner_review",
+        "pending_owner_review",
+        "immigration_status_evidence_missing",
+        "status",
+        "urgent",
+        "owner_review_required",
+        1,
+    )
+    assert {row[16] for row in packs} == {0}
+    assert {row[17] for row in packs} == {0}
+    assert {row[18] for row in packs} == {1}
+
+    payload = json.loads(packs[0][19])
+    assert payload["schema_version"] == "owner_decision_packs.v1"
+    assert payload["privacy_mode"] == "local_only_owner_decision_pack_no_raw_text"
+    assert payload["source_owner_prompt_code"] == "owner_client_recovery_followup"
+    assert payload["owner_decision_required"] is True
+    assert payload["raw_text_included"] is False
+    assert payload["send_whatsapp"] is False
+    assert payload["crm_mutation"] is False
+    assert payload["requires_human_approval"] is True
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Owner Decision Packs Summary" in summary
+    assert "| Source cases | 4 |" in summary
+    assert "| Owner approval items | 2 |" in summary
+    assert "| Owner decision packs | 2 |" in summary
+    assert "| WhatsApp sends | 0 |" in summary
+    assert "| CRM mutations | 0 |" in summary
+    assert "card-owner-followup" not in summary
+    assert "card-owner-status" not in summary
+    assert "owner-approval-followup" not in summary
+    assert "owner-approval-status" not in summary
+
+
+def test_build_owner_decision_packs_rejects_unexpected_input_name(
+    tmp_path: Path,
+) -> None:
+    unexpected_db = tmp_path / "case_closure_judge.local.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    with pytest.raises(
+        ValueError,
+        match="Refusing to read unexpected Owner Approval Console DB",
+    ):
+        build_owner_decision_packs(
+            owner_approval_db=unexpected_db,
+            output_dir=tmp_path / "owner-decision-packs",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_cli_writes_json_without_owner_case_details(tmp_path: Path) -> None:
+    owner_approval_db = tmp_path / "owner_approval_console.local.sqlite"
+    output_dir = tmp_path / "owner-decision-packs"
+    summary_path = output_dir / "owner_decision_packs_summary.md"
+    _write_owner_approval_console_db(owner_approval_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--owner-approval-db",
+            str(owner_approval_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--generated-at-utc",
+            "2026-06-17T15:00:00+00:00",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "crm_mutation_count": 0,
+        "owner_item_count": 2,
+        "pack_count": 2,
+        "send_whatsapp_count": 0,
+        "source_case_count": 4,
+    }
+    assert "card-owner-followup" not in result.stdout
+    assert "card-owner-status" not in result.stdout
+    assert "owner-approval-followup" not in result.stdout
+    assert "owner-approval-status" not in result.stdout

--- a/scripts/tests/test_whatsapp_corpus_owner_decision_pipeline.py
+++ b/scripts/tests/test_whatsapp_corpus_owner_decision_pipeline.py
@@ -1,0 +1,465 @@
+from __future__ import annotations
+
+import ast
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import scripts.whatsapp_corpus.build_owner_decision_pipeline as pipeline_module
+from scripts.tests.test_whatsapp_corpus_owner_decision_intake import (
+    _write_operator_packet_review_console_db,
+)
+from scripts.tests.test_whatsapp_corpus_owner_decision_replay import (
+    _write_matching_approve_reject_ledger_db,
+)
+from scripts.whatsapp_corpus.build_owner_decision_pipeline import (
+    OwnerDecisionPipelineBuildResult,
+    StageOutput,
+    build_owner_decision_pipeline,
+    _write_manifest_sqlite,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_owner_decision_pipeline.py"
+
+
+def _write_pipeline_sources(tmp_path: Path) -> tuple[Path, Path]:
+    ledger_db = tmp_path / "approve_reject_ledger.local.sqlite"
+    review_console_db = tmp_path / "operator_packet_review_console.local.sqlite"
+    _write_matching_approve_reject_ledger_db(ledger_db)
+    _write_operator_packet_review_console_db(review_console_db)
+    return ledger_db, review_console_db
+
+
+def test_build_owner_decision_pipeline_runs_full_local_chain_from_inline_decisions(
+    tmp_path: Path,
+) -> None:
+    ledger_db, review_console_db = _write_pipeline_sources(tmp_path)
+    output_dir = tmp_path / "owner-decision-pipeline"
+
+    result = build_owner_decision_pipeline(
+        ledger_db=ledger_db,
+        review_console_db=review_console_db,
+        inline_decisions=(
+            "operator-packet-review-item-pending=approve",
+            "operator-packet-review-item-defer=reject",
+        ),
+        inline_decision_notes=(
+            "operator-packet-review-item-pending=owner approved recovery",
+        ),
+        output_dir=output_dir,
+        summary_path=output_dir / "owner_decision_pipeline_summary.md",
+        generated_at_utc="2026-06-18T01:00:00+00:00",
+    )
+
+    assert result.pipeline_status == "replayed"
+    assert result.inbox_item_count == 2
+    assert result.captured_decision_count == 2
+    assert result.awaiting_owner_input_count == 0
+    assert result.compiled_decision_count == 2
+    assert result.replay_event_count == 2
+    assert result.final_review_item_count == 2
+    assert result.final_operator_ready_item_count == 1
+    assert result.final_rejected_item_count == 1
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.output_db == output_dir / "owner_decision_pipeline.local.sqlite"
+    assert result.owner_inbox_db == (
+        output_dir / "owner-decision-inbox/owner_decision_inbox.local.sqlite"
+    )
+    assert result.owner_cockpit_db == (
+        output_dir / "owner-decision-cockpit/owner_decision_cockpit.local.sqlite"
+    )
+    assert result.owner_compiler_db == (
+        output_dir / "owner-decision-compiler/owner_decision_compiler.local.sqlite"
+    )
+    assert result.owner_replay_db == (
+        output_dir / "owner-decision-replay/owner_decision_replay.local.sqlite"
+    )
+    summary = result.summary_path.read_text(encoding="utf-8")
+    assert str(tmp_path) not in summary
+    assert "research/personal/wa-corpus" not in summary
+
+    with sqlite3.connect(result.output_db) as conn:
+        run = conn.execute(
+            """
+            SELECT pipeline_status, inbox_item_count, captured_decision_count,
+                   awaiting_owner_input_count, compiled_decision_count,
+                   replay_event_count, final_review_item_count,
+                   send_whatsapp_count, crm_mutation_count
+            FROM owner_decision_pipeline_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+        stages = conn.execute(
+            """
+            SELECT stage_name, item_count
+            FROM owner_decision_pipeline_stage_outputs
+            ORDER BY stage_rank
+            """
+        ).fetchall()
+    assert run == ("replayed", 2, 2, 0, 2, 2, 2, 0, 0)
+    assert stages == [
+        ("owner_decision_inbox", 2),
+        ("owner_decision_cockpit", 2),
+        ("owner_decision_compiler", 2),
+        ("owner_decision_replay", 2),
+    ]
+
+
+def test_build_owner_decision_pipeline_stops_before_compiler_when_input_is_missing(
+    tmp_path: Path,
+) -> None:
+    ledger_db, review_console_db = _write_pipeline_sources(tmp_path)
+    output_dir = tmp_path / "owner-decision-pipeline"
+
+    result = build_owner_decision_pipeline(
+        ledger_db=ledger_db,
+        review_console_db=review_console_db,
+        inline_decisions=("operator-packet-review-item-pending=defer",),
+        output_dir=output_dir,
+        summary_path=output_dir / "owner_decision_pipeline_summary.md",
+        generated_at_utc="2026-06-18T01:00:00+00:00",
+    )
+
+    assert result.pipeline_status == "awaiting_owner_input"
+    assert result.inbox_item_count == 2
+    assert result.captured_decision_count == 1
+    assert result.awaiting_owner_input_count == 1
+    assert result.compiled_decision_count == 0
+    assert result.replay_event_count == 0
+    assert result.final_review_item_count == 0
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.owner_compiler_db is None
+    assert result.owner_replay_db is None
+    assert not (output_dir / "owner-decision-compiler").exists()
+    assert not (output_dir / "owner-decision-replay").exists()
+
+    with sqlite3.connect(result.output_db) as conn:
+        stages = conn.execute(
+            """
+            SELECT stage_name, item_count
+            FROM owner_decision_pipeline_stage_outputs
+            ORDER BY stage_rank
+            """
+        ).fetchall()
+    assert stages == [
+        ("owner_decision_inbox", 2),
+        ("owner_decision_cockpit", 2),
+    ]
+
+
+def test_pipeline_removes_stale_downstream_outputs_when_later_awaiting(
+    tmp_path: Path,
+) -> None:
+    ledger_db, review_console_db = _write_pipeline_sources(tmp_path)
+    output_dir = tmp_path / "owner-decision-pipeline"
+
+    replayed = build_owner_decision_pipeline(
+        ledger_db=ledger_db,
+        review_console_db=review_console_db,
+        inline_decisions=(
+            "operator-packet-review-item-pending=approve",
+            "operator-packet-review-item-defer=reject",
+        ),
+        output_dir=output_dir,
+        summary_path=output_dir / "owner_decision_pipeline_summary.md",
+        generated_at_utc="2026-06-18T01:00:00+00:00",
+    )
+    assert replayed.pipeline_status == "replayed"
+    assert (output_dir / "owner-decision-compiler").exists()
+    assert (output_dir / "owner-decision-replay").exists()
+
+    awaiting = build_owner_decision_pipeline(
+        ledger_db=ledger_db,
+        review_console_db=review_console_db,
+        inline_decisions=("operator-packet-review-item-pending=defer",),
+        output_dir=output_dir,
+        summary_path=output_dir / "owner_decision_pipeline_summary.md",
+        generated_at_utc="2026-06-18T01:00:00+00:00",
+    )
+
+    assert awaiting.pipeline_status == "awaiting_owner_input"
+    assert not (output_dir / "owner-decision-compiler").exists()
+    assert not (output_dir / "owner-decision-replay").exists()
+
+
+def test_cli_writes_json_without_review_item_ids(tmp_path: Path) -> None:
+    ledger_db, review_console_db = _write_pipeline_sources(tmp_path)
+    output_dir = tmp_path / "owner-decision-pipeline"
+    summary_path = output_dir / "owner_decision_pipeline_summary.md"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--ledger-db",
+            str(ledger_db),
+            "--review-console-db",
+            str(review_console_db),
+            "--decision",
+            "operator-packet-review-item-pending=approve",
+            "--decision",
+            "operator-packet-review-item-defer=reject",
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--generated-at-utc",
+            "2026-06-18T01:00:00+00:00",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "awaiting_owner_input_count": 0,
+        "captured_decision_count": 2,
+        "compiled_decision_count": 2,
+        "crm_mutation_count": 0,
+        "final_review_item_count": 2,
+        "inbox_item_count": 2,
+        "pipeline_status": "replayed",
+        "replay_event_count": 2,
+        "send_whatsapp_count": 0,
+    }
+    assert str(tmp_path) not in result.stdout
+    assert "operator-packet-review-item-pending" not in result.stdout
+    assert "ledger-entry-pending" not in result.stdout
+
+
+def test_cli_errors_do_not_leak_absolute_paths(tmp_path: Path) -> None:
+    missing_review_console = (
+        tmp_path / "missing" / "operator_packet_review_console.local.sqlite"
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--review-console-db",
+            str(missing_review_console),
+            "--output-dir",
+            str(tmp_path / "owner-decision-pipeline"),
+            "--json",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert result.stderr == "ERROR: Owner decision pipeline input is missing or invalid.\n"
+    assert str(tmp_path) not in result.stderr
+    assert "operator_packet_review_console.local.sqlite" not in result.stderr
+    assert ".sqlite" not in result.stderr
+
+
+def test_readme_documents_owner_decision_pipeline() -> None:
+    readme = (REPO_ROOT / "scripts" / "whatsapp_corpus" / "README.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "## Build Owner Decision Pipeline" in readme
+    assert "python -m scripts.whatsapp_corpus.build_owner_decision_pipeline" in readme
+    assert "awaiting_owner_input" in readme
+
+
+@pytest.mark.parametrize(("send_count", "crm_count"), ((1, 0), (0, 1)))
+def test_manifest_rejects_nonzero_send_or_crm_counts(
+    tmp_path: Path,
+    send_count: int,
+    crm_count: int,
+) -> None:
+    result = OwnerDecisionPipelineBuildResult(
+        pipeline_status="replayed",
+        inbox_item_count=1,
+        captured_decision_count=1,
+        awaiting_owner_input_count=0,
+        compiled_decision_count=1,
+        replay_event_count=1,
+        final_review_item_count=1,
+        final_operator_ready_item_count=1,
+        final_rejected_item_count=0,
+        send_whatsapp_count=send_count,
+        crm_mutation_count=crm_count,
+        output_db=tmp_path / "owner_decision_pipeline.local.sqlite",
+        summary_path=tmp_path / "owner_decision_pipeline_summary.md",
+        owner_inbox_db=tmp_path / "owner_decision_inbox.local.sqlite",
+        owner_cockpit_db=tmp_path / "owner_decision_cockpit.local.sqlite",
+        owner_compiler_db=tmp_path / "owner_decision_compiler.local.sqlite",
+        owner_replay_db=tmp_path / "owner_decision_replay.local.sqlite",
+    )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        _write_manifest_sqlite(
+            result.output_db,
+            result=result,
+            stages=(
+                StageOutput(
+                    1,
+                    "owner_decision_inbox",
+                    1,
+                    result.owner_inbox_db,
+                    tmp_path / "owner_decision_inbox_summary.md",
+                ),
+            ),
+            generated_at_utc="2026-06-18T01:00:00+00:00",
+        )
+
+
+def test_pipeline_manifest_counts_include_all_invoked_stages(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "owner-decision-pipeline"
+
+    def fake_inbox(**_: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            inbox_item_count=1,
+            send_whatsapp_count=1,
+            crm_mutation_count=0,
+            output_db=output_dir / "owner-decision-inbox/owner_decision_inbox.local.sqlite",
+        )
+
+    def fake_cockpit(**_: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            inbox_item_count=1,
+            captured_decision_count=1,
+            awaiting_owner_input_count=0,
+            send_whatsapp_count=0,
+            crm_mutation_count=0,
+            output_db=output_dir / "owner-decision-cockpit/owner_decision_cockpit.local.sqlite",
+            output_template=output_dir
+            / "owner-decision-cockpit/owner_decisions_template.local.jsonl",
+        )
+
+    def fake_compiler(**_: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            compiled_decision_count=1,
+            send_whatsapp_count=0,
+            crm_mutation_count=0,
+            output_db=output_dir / "owner-decision-compiler/owner_decision_compiler.local.sqlite",
+            output_jsonl=output_dir / "owner-decision-compiler/owner_decisions.local.jsonl",
+        )
+
+    def fake_replay(**_: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            replay_event_count=1,
+            final_review_item_count=1,
+            final_operator_ready_item_count=1,
+            final_rejected_item_count=0,
+            send_whatsapp_count=0,
+            crm_mutation_count=0,
+            output_db=output_dir / "owner-decision-replay/owner_decision_replay.local.sqlite",
+        )
+
+    monkeypatch.setattr(pipeline_module, "build_owner_decision_inbox", fake_inbox)
+    monkeypatch.setattr(pipeline_module, "build_owner_decision_cockpit", fake_cockpit)
+    monkeypatch.setattr(pipeline_module, "build_owner_decision_compiler", fake_compiler)
+    monkeypatch.setattr(pipeline_module, "build_owner_decision_replay", fake_replay)
+
+    with pytest.raises(sqlite3.IntegrityError):
+        build_owner_decision_pipeline(
+            ledger_db=tmp_path / "ledger.local.sqlite",
+            review_console_db=tmp_path / "review.local.sqlite",
+            output_dir=output_dir,
+            summary_path=output_dir / "owner_decision_pipeline_summary.md",
+            generated_at_utc="2026-06-18T01:00:00+00:00",
+        )
+
+
+def test_build_owner_decision_pipeline_has_no_sender_or_cloud_imports() -> None:
+    forbidden_imports = (
+        "anthropic",
+        "backend.app.services.crm",
+        "backend.channels.whatsapp",
+        "httpx",
+        "openai",
+        "requests",
+    )
+    import_lines = [
+        line.strip()
+        for line in SCRIPT.read_text(encoding="utf-8").splitlines()
+        if line.startswith("import ") or line.startswith("from ")
+    ]
+
+    for import_line in import_lines:
+        assert not any(forbidden in import_line for forbidden in forbidden_imports)
+
+
+def _collect_whatsapp_corpus_import_closure(entrypoint: Path) -> set[Path]:
+    pending = [entrypoint]
+    visited: set[Path] = set()
+    while pending:
+        script = pending.pop()
+        if script in visited:
+            continue
+        visited.add(script)
+        tree = ast.parse(script.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            prefix = "scripts.whatsapp_corpus."
+            module_names: list[str] = []
+            if isinstance(node, ast.ImportFrom) and node.module is not None:
+                module_names.append(node.module)
+            elif isinstance(node, ast.Import):
+                module_names.extend(alias.name for alias in node.names)
+            for module_name in module_names:
+                if not module_name.startswith(prefix):
+                    continue
+                local_module = module_name.removeprefix(prefix)
+                module_path = (
+                    REPO_ROOT / "scripts" / "whatsapp_corpus" / f"{local_module}.py"
+                )
+                if module_path.exists() and module_path not in visited:
+                    pending.append(module_path)
+    return visited
+
+
+def test_invoked_owner_decision_modules_have_no_sender_or_cloud_imports() -> None:
+    forbidden_imports = (
+        "anthropic",
+        "backend.app.services.crm",
+        "backend.channels.whatsapp",
+        "httpx",
+        "openai",
+        "requests",
+    )
+    invoked_scripts = _collect_whatsapp_corpus_import_closure(
+        REPO_ROOT
+        / "scripts"
+        / "whatsapp_corpus"
+        / "build_owner_decision_pipeline.py"
+    )
+
+    assert {
+        script.name for script in invoked_scripts
+    } >= {
+        "build_owner_decision_pipeline.py",
+        "build_owner_decision_inbox.py",
+        "build_owner_decision_cockpit.py",
+        "build_owner_decision_compiler.py",
+        "build_owner_decision_replay.py",
+    }
+
+    for script in invoked_scripts:
+        import_lines = [
+            line.strip()
+            for line in script.read_text(encoding="utf-8").splitlines()
+            if line.startswith("import ") or line.startswith("from ")
+        ]
+        assert not any(
+            forbidden in import_line
+            for import_line in import_lines
+            for forbidden in forbidden_imports
+        ), script.name

--- a/scripts/tests/test_whatsapp_corpus_owner_decision_replay.py
+++ b/scripts/tests/test_whatsapp_corpus_owner_decision_replay.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.tests.test_whatsapp_corpus_owner_decision_intake import (
+    _write_operator_packet_review_console_db,
+)
+from scripts.whatsapp_corpus.build_owner_decision_replay import (
+    build_owner_decision_replay,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_owner_decision_replay.py"
+
+
+def _write_matching_approve_reject_ledger_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE approve_reject_ledger_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_case_count INTEGER NOT NULL,
+                owner_item_count INTEGER NOT NULL,
+                pack_count INTEGER NOT NULL,
+                brief_count INTEGER NOT NULL,
+                queue_item_count INTEGER NOT NULL,
+                ledger_entry_count INTEGER NOT NULL,
+                pending_decision_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE approve_reject_ledger_entries (
+                entry_id TEXT PRIMARY KEY,
+                route_id TEXT NOT NULL,
+                case_card_id TEXT NOT NULL,
+                brief_id TEXT NOT NULL,
+                pack_id TEXT NOT NULL,
+                ledger_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                decision_priority TEXT NOT NULL,
+                route_bucket TEXT NOT NULL,
+                next_actor TEXT NOT NULL,
+                queue_status TEXT NOT NULL,
+                decision_status TEXT NOT NULL,
+                owner_decision TEXT NOT NULL,
+                allowed_decisions_json TEXT NOT NULL,
+                recommended_decision TEXT NOT NULL,
+                draft_action_type TEXT NOT NULL,
+                immutable_event_type TEXT NOT NULL,
+                ledger_entry_hash TEXT NOT NULL UNIQUE,
+                ledger_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO approve_reject_ledger_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_case_count, owner_item_count, pack_count, brief_count,
+                queue_item_count, ledger_entry_count, pending_decision_count,
+                send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, 8, 2, 2, 2, 2, 2, 2, 0, 0)
+            """,
+            (
+                "2026-06-17T23:00:00+00:00",
+                "2026-06-17T22:00:00+00:00",
+                "local_only_approve_reject_ledger_no_raw_text_no_send_no_crm_mutation",
+            ),
+        )
+        rows = [
+            (
+                "ledger-entry-pending",
+                "approval-route-pending",
+                "card-owner-pending",
+                "owner-brief-pending",
+                "owner-pack-pending",
+                1,
+                "sahira",
+                "approve_client_recovery_followup",
+                "now",
+                "owner_now",
+                "approve_recovery_followup_after_review",
+                "owner_review_client_followup_draft",
+                "a" * 64,
+            ),
+            (
+                "ledger-entry-defer",
+                "approval-route-defer",
+                "card-owner-defer",
+                "owner-brief-defer",
+                "owner-pack-defer",
+                2,
+                "ari",
+                "approve_immigration_status_escalation",
+                "now",
+                "owner_now",
+                "approve_status_escalation_after_review",
+                "owner_review_status_escalation_draft",
+                "b" * 64,
+            ),
+        ]
+        conn.executemany(
+            """
+            INSERT INTO approve_reject_ledger_entries (
+                entry_id, route_id, case_card_id, brief_id, pack_id, ledger_rank,
+                assigned_lane, decision_type, decision_priority, route_bucket,
+                next_actor, queue_status, decision_status, owner_decision,
+                allowed_decisions_json, recommended_decision, draft_action_type,
+                immutable_event_type, ledger_entry_hash, ledger_payload_json,
+                send_whatsapp, crm_mutation, requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'owner',
+                    'waiting_owner_decision', 'awaiting_owner_decision',
+                    'pending', ?, ?, ?, 'decision_slot_opened', ?, ?, 0, 0, 1)
+            """,
+            [
+                (
+                    *row[0:10],
+                    json.dumps(["approve", "reject", "defer"]),
+                    row[10],
+                    row[11],
+                    row[12],
+                    json.dumps(
+                        {
+                            "schema_version": "approve_reject_ledger.v1",
+                            "raw_text_included": False,
+                            "send_whatsapp": False,
+                            "crm_mutation": False,
+                            "requires_human_approval": True,
+                        },
+                        sort_keys=True,
+                    ),
+                )
+                for row in rows
+            ],
+        )
+        conn.commit()
+
+
+def test_build_owner_decision_replay_runs_full_local_chain(tmp_path: Path) -> None:
+    ledger_db = tmp_path / "approve_reject_ledger.local.sqlite"
+    review_console_db = tmp_path / "operator_packet_review_console.local.sqlite"
+    owner_decisions_jsonl = tmp_path / "owner_decisions.local.jsonl"
+    output_dir = tmp_path / "owner-decision-replay"
+    summary_path = output_dir / "owner_decision_replay_summary.md"
+    _write_matching_approve_reject_ledger_db(ledger_db)
+    _write_operator_packet_review_console_db(review_console_db)
+    owner_decisions_jsonl.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "review_item_id": "operator-packet-review-item-pending",
+                        "owner_decision": "approve",
+                        "decision_note": "approved recovery follow-up",
+                        "event_actor": "owner",
+                        "event_recorded_at_utc": "2026-06-17T23:01:00+00:00",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "packet_id": "operator-packet-defer",
+                        "owner_decision": "reject",
+                        "decision_note": "do not proceed after revisit",
+                        "event_actor": "owner",
+                        "event_recorded_at_utc": "2026-06-17T23:02:00+00:00",
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = build_owner_decision_replay(
+        ledger_db=ledger_db,
+        review_console_db=review_console_db,
+        owner_decisions_jsonl=owner_decisions_jsonl,
+        output_dir=output_dir,
+        summary_path=summary_path,
+        generated_at_utc="2026-06-17T23:03:00+00:00",
+    )
+
+    assert result.source_case_count == 8
+    assert result.source_review_item_count == 4
+    assert result.intake_item_count == 4
+    assert result.captured_owner_decision_count == 2
+    assert result.replay_event_count == 2
+    assert result.captured_event_count == 2
+    assert result.awaiting_input_count == 0
+    assert result.work_order_count == 2
+    assert result.ready_work_order_count == 1
+    assert result.rejected_work_order_count == 1
+    assert result.packet_count == 2
+    assert result.ready_packet_count == 1
+    assert result.rejected_packet_count == 1
+    assert result.final_review_item_count == 2
+    assert result.final_operator_ready_item_count == 1
+    assert result.final_rejected_item_count == 1
+    assert result.final_owner_decision_item_count == 0
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.output_db == output_dir / "owner_decision_replay.local.sqlite"
+
+    assert result.intake_db == output_dir / "owner-decision-intake/owner_decision_intake.local.sqlite"
+    assert result.owner_events_db == (
+        output_dir / "owner-decision-events/owner_decision_event_capture.local.sqlite"
+    )
+    assert result.work_orders_db == (
+        output_dir / "post-decision-work-orders/post_decision_work_order_queue.local.sqlite"
+    )
+    assert result.operator_packets_db == (
+        output_dir / "operator-execution-packets/operator_execution_packets.local.sqlite"
+    )
+    assert result.final_review_console_db == (
+        output_dir
+        / "operator-packet-review-console/operator_packet_review_console.local.sqlite"
+    )
+
+    with sqlite3.connect(result.output_db) as conn:
+        run = conn.execute(
+            """
+            SELECT source_case_count, source_review_item_count, intake_item_count,
+                   captured_owner_decision_count, replay_event_count,
+                   captured_event_count, awaiting_input_count, work_order_count,
+                   ready_work_order_count, rejected_work_order_count,
+                   packet_count, ready_packet_count, rejected_packet_count,
+                   final_review_item_count, final_operator_ready_item_count,
+                   final_rejected_item_count, send_whatsapp_count,
+                   crm_mutation_count
+            FROM owner_decision_replay_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+        stages = conn.execute(
+            """
+            SELECT stage_name, item_count, output_db, output_summary
+            FROM owner_decision_replay_stage_outputs
+            ORDER BY stage_rank
+            """
+        ).fetchall()
+
+    assert run == (8, 4, 4, 2, 2, 2, 0, 2, 1, 1, 2, 1, 1, 2, 1, 1, 0, 0)
+    assert [stage[0:2] for stage in stages] == [
+        ("owner_decision_intake", 4),
+        ("owner_decision_event_capture", 2),
+        ("post_decision_work_order_queue", 2),
+        ("operator_execution_packets", 2),
+        ("operator_packet_review_console", 2),
+    ]
+    assert all(stage[2] for stage in stages)
+    assert all(stage[3] for stage in stages)
+
+    with sqlite3.connect(result.final_review_console_db) as conn:
+        final_rows = conn.execute(
+            """
+            SELECT owner_decision, review_state, console_bucket, send_whatsapp,
+                   crm_mutation, requires_human_approval
+            FROM operator_packet_review_items
+            ORDER BY review_rank
+            """
+        ).fetchall()
+
+    assert final_rows == [
+        ("approve", "ready_for_human_review", "operator_review_queue", 0, 0, 1),
+        ("reject", "rejected_closed", "closed_no_action", 0, 0, 1),
+    ]
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Owner Decision Replay Summary" in summary
+    assert "| Source cases | 8 |" in summary
+    assert "| Captured owner decisions | 2 |" in summary
+    assert "| Work orders | 2 |" in summary
+    assert "| Final review items | 2 |" in summary
+    assert "| WhatsApp sends | 0 |" in summary
+    assert "| CRM mutations | 0 |" in summary
+    assert "operator-packet-review-item-pending" not in summary
+    assert "ledger-entry-pending" not in summary
+
+
+def test_build_owner_decision_replay_accepts_empty_owner_decision_file(
+    tmp_path: Path,
+) -> None:
+    ledger_db = tmp_path / "approve_reject_ledger.local.sqlite"
+    review_console_db = tmp_path / "operator_packet_review_console.local.sqlite"
+    owner_decisions_jsonl = tmp_path / "owner_decisions.local.jsonl"
+    output_dir = tmp_path / "owner-decision-replay"
+    _write_matching_approve_reject_ledger_db(ledger_db)
+    _write_operator_packet_review_console_db(review_console_db)
+    owner_decisions_jsonl.write_text("", encoding="utf-8")
+
+    result = build_owner_decision_replay(
+        ledger_db=ledger_db,
+        review_console_db=review_console_db,
+        owner_decisions_jsonl=owner_decisions_jsonl,
+        output_dir=output_dir,
+        summary_path=output_dir / "summary.md",
+        generated_at_utc="2026-06-17T23:03:00+00:00",
+    )
+
+    assert result.captured_owner_decision_count == 0
+    assert result.replay_event_count == 0
+    assert result.captured_event_count == 0
+    assert result.awaiting_input_count == 2
+    assert result.final_owner_decision_item_count == 2
+    assert result.final_operator_ready_item_count == 0
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+
+
+def test_build_owner_decision_replay_rejects_invalid_decision(
+    tmp_path: Path,
+) -> None:
+    ledger_db = tmp_path / "approve_reject_ledger.local.sqlite"
+    review_console_db = tmp_path / "operator_packet_review_console.local.sqlite"
+    owner_decisions_jsonl = tmp_path / "owner_decisions.local.jsonl"
+    output_dir = tmp_path / "owner-decision-replay"
+    _write_matching_approve_reject_ledger_db(ledger_db)
+    _write_operator_packet_review_console_db(review_console_db)
+    owner_decisions_jsonl.write_text(
+        json.dumps(
+            {
+                "review_item_id": "operator-packet-review-item-pending",
+                "owner_decision": "send_now",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Owner decision is not allowed"):
+        build_owner_decision_replay(
+            ledger_db=ledger_db,
+            review_console_db=review_console_db,
+            owner_decisions_jsonl=owner_decisions_jsonl,
+            output_dir=output_dir,
+            summary_path=output_dir / "summary.md",
+        )
+
+
+def test_cli_writes_json_without_replay_details(tmp_path: Path) -> None:
+    ledger_db = tmp_path / "approve_reject_ledger.local.sqlite"
+    review_console_db = tmp_path / "operator_packet_review_console.local.sqlite"
+    owner_decisions_jsonl = tmp_path / "owner_decisions.local.jsonl"
+    output_dir = tmp_path / "owner-decision-replay"
+    summary_path = output_dir / "owner_decision_replay_summary.md"
+    _write_matching_approve_reject_ledger_db(ledger_db)
+    _write_operator_packet_review_console_db(review_console_db)
+    owner_decisions_jsonl.write_text("", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--ledger-db",
+            str(ledger_db),
+            "--review-console-db",
+            str(review_console_db),
+            "--owner-decisions-jsonl",
+            str(owner_decisions_jsonl),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--generated-at-utc",
+            "2026-06-17T23:03:00+00:00",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "awaiting_input_count": 2,
+        "captured_event_count": 0,
+        "captured_owner_decision_count": 0,
+        "crm_mutation_count": 0,
+        "final_operator_ready_item_count": 0,
+        "final_owner_decision_item_count": 2,
+        "final_rejected_item_count": 0,
+        "final_review_item_count": 2,
+        "packet_count": 2,
+        "replay_event_count": 0,
+        "send_whatsapp_count": 0,
+        "source_case_count": 8,
+        "source_review_item_count": 4,
+        "work_order_count": 2,
+    }
+    assert "operator-packet-review-item-pending" not in result.stdout
+    assert "ledger-entry-pending" not in result.stdout

--- a/scripts/tests/test_whatsapp_corpus_post_decision_work_order_queue.py
+++ b/scripts/tests/test_whatsapp_corpus_post_decision_work_order_queue.py
@@ -1,0 +1,459 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.whatsapp_corpus.build_post_decision_work_order_queue import (
+    build_post_decision_work_order_queue,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = (
+    REPO_ROOT
+    / "scripts"
+    / "whatsapp_corpus"
+    / "build_post_decision_work_order_queue.py"
+)
+
+
+def _write_owner_decision_event_capture_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE owner_decision_event_capture_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_case_count INTEGER NOT NULL,
+                owner_item_count INTEGER NOT NULL,
+                pack_count INTEGER NOT NULL,
+                brief_count INTEGER NOT NULL,
+                queue_item_count INTEGER NOT NULL,
+                ledger_entry_count INTEGER NOT NULL,
+                captured_event_count INTEGER NOT NULL,
+                awaiting_input_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE owner_decision_event_rows (
+                event_id TEXT PRIMARY KEY,
+                entry_id TEXT NOT NULL,
+                route_id TEXT NOT NULL,
+                case_card_id TEXT NOT NULL,
+                brief_id TEXT NOT NULL,
+                pack_id TEXT NOT NULL,
+                event_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                decision_priority TEXT NOT NULL,
+                route_bucket TEXT NOT NULL,
+                capture_status TEXT NOT NULL,
+                owner_decision TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                event_source TEXT NOT NULL,
+                event_actor TEXT NOT NULL,
+                event_recorded_at_utc TEXT NOT NULL,
+                allowed_decisions_json TEXT NOT NULL,
+                recommended_decision TEXT NOT NULL,
+                draft_action_type TEXT NOT NULL,
+                decision_note TEXT NOT NULL,
+                source_ledger_hash TEXT NOT NULL,
+                event_hash TEXT NOT NULL UNIQUE,
+                event_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO owner_decision_event_capture_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_case_count, owner_item_count, pack_count, brief_count,
+                queue_item_count, ledger_entry_count, captured_event_count,
+                awaiting_input_count, send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, 8, 4, 4, 4, 4, 4, 3, 1, 0, 0)
+            """,
+            (
+                "2026-06-17T19:00:00+00:00",
+                "2026-06-17T18:00:00+00:00",
+                "local_only_owner_decision_event_no_raw_text_no_send_no_crm_mutation",
+            ),
+        )
+        rows = [
+            (
+                "owner-event-pending",
+                "ledger-entry-pending",
+                "approval-route-pending",
+                "card-owner-pending",
+                "owner-brief-pending",
+                "owner-pack-pending",
+                1,
+                "sahira",
+                "approve_client_recovery_followup",
+                "now",
+                "owner_now",
+                "awaiting_owner_input",
+                "pending",
+                "owner_decision_not_submitted",
+                "owner_decision_required",
+                "a" * 64,
+            ),
+            (
+                "owner-event-approve",
+                "ledger-entry-approve",
+                "approval-route-approve",
+                "card-owner-approve",
+                "owner-brief-approve",
+                "owner-pack-approve",
+                2,
+                "sahira",
+                "approve_client_recovery_followup",
+                "now",
+                "owner_now",
+                "captured",
+                "approve",
+                "owner_decision_captured",
+                "approved recovery follow-up",
+                "b" * 64,
+            ),
+            (
+                "owner-event-defer",
+                "ledger-entry-defer",
+                "approval-route-defer",
+                "card-owner-defer",
+                "owner-brief-defer",
+                "owner-pack-defer",
+                3,
+                "ari",
+                "approve_immigration_status_escalation",
+                "now",
+                "owner_now",
+                "captured",
+                "defer",
+                "owner_decision_captured",
+                "wait for immigration evidence",
+                "c" * 64,
+            ),
+            (
+                "owner-event-reject",
+                "ledger-entry-reject",
+                "approval-route-reject",
+                "card-owner-reject",
+                "owner-brief-reject",
+                "owner-pack-reject",
+                4,
+                "ari",
+                "approve_immigration_status_escalation",
+                "now",
+                "owner_now",
+                "captured",
+                "reject",
+                "owner_decision_captured",
+                "do not proceed",
+                "d" * 64,
+            ),
+        ]
+        conn.executemany(
+            """
+            INSERT INTO owner_decision_event_rows (
+                event_id, entry_id, route_id, case_card_id, brief_id, pack_id,
+                event_rank, assigned_lane, decision_type, decision_priority,
+                route_bucket, capture_status, owner_decision, event_type,
+                event_source, event_actor, event_recorded_at_utc,
+                allowed_decisions_json, recommended_decision, draft_action_type,
+                decision_note, source_ledger_hash, event_hash,
+                event_payload_json, send_whatsapp, crm_mutation,
+                requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 1)
+            """,
+            [
+                (
+                    *row[0:14],
+                    "local_owner_event_capture",
+                    "owner",
+                    f"2026-06-17T19:0{row[6]}:00+00:00",
+                    json.dumps(["approve", "reject", "defer"]),
+                    (
+                        "approve_recovery_followup_after_review"
+                        if row[8] == "approve_client_recovery_followup"
+                        else "approve_status_escalation_after_review"
+                    ),
+                    (
+                        "owner_review_client_followup_draft"
+                        if row[8] == "approve_client_recovery_followup"
+                        else "owner_review_status_escalation_draft"
+                    ),
+                    row[14],
+                    f"ledger-{row[15]}",
+                    row[15],
+                    json.dumps(
+                        {
+                            "schema_version": "owner_decision_event_capture.v1",
+                            "raw_text_included": False,
+                            "send_whatsapp": False,
+                            "crm_mutation": False,
+                            "requires_human_approval": True,
+                        },
+                        sort_keys=True,
+                    ),
+                )
+                for row in rows
+            ],
+        )
+        conn.commit()
+
+
+def test_build_post_decision_work_order_queue_maps_owner_decisions_to_work_orders(
+    tmp_path: Path,
+) -> None:
+    events_db = tmp_path / "owner_decision_event_capture.local.sqlite"
+    output_dir = tmp_path / "post-decision-work-orders"
+    summary_path = output_dir / "post_decision_work_order_queue_summary.md"
+    _write_owner_decision_event_capture_db(events_db)
+
+    result = build_post_decision_work_order_queue(
+        owner_events_db=events_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+        generated_at_utc="2026-06-17T20:00:00+00:00",
+    )
+
+    assert result.source_case_count == 8
+    assert result.owner_item_count == 4
+    assert result.pack_count == 4
+    assert result.brief_count == 4
+    assert result.queue_item_count == 4
+    assert result.ledger_entry_count == 4
+    assert result.event_row_count == 4
+    assert result.work_order_count == 4
+    assert result.ready_count == 1
+    assert result.blocked_count == 1
+    assert result.deferred_count == 1
+    assert result.rejected_count == 1
+    assert result.output_db == output_dir / "post_decision_work_order_queue.local.sqlite"
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+    assert result.work_order_status_counts == {
+        "blocked_awaiting_owner_decision": 1,
+        "deferred_owner_followup": 1,
+        "ready_for_operator_review": 1,
+        "rejected_no_action": 1,
+    }
+    assert result.owner_decision_counts == {
+        "approve": 1,
+        "defer": 1,
+        "pending": 1,
+        "reject": 1,
+    }
+
+    with sqlite3.connect(result.output_db) as conn:
+        rows = conn.execute(
+            """
+            SELECT case_card_id, event_id, entry_id, work_order_rank,
+                   assigned_lane, owner_decision, source_capture_status,
+                   work_order_status, work_order_type, execution_gate,
+                   next_actor, action_intent, decision_effect, decision_note,
+                   send_whatsapp, crm_mutation, requires_human_approval,
+                   work_order_hash, work_order_payload_json
+            FROM post_decision_work_orders
+            ORDER BY work_order_rank
+            """
+        ).fetchall()
+        run = conn.execute(
+            """
+            SELECT source_case_count, owner_item_count, pack_count, brief_count,
+                   queue_item_count, ledger_entry_count, event_row_count,
+                   work_order_count, ready_count, blocked_count, deferred_count,
+                   rejected_count, send_whatsapp_count, crm_mutation_count
+            FROM post_decision_work_order_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+
+    assert run == (8, 4, 4, 4, 4, 4, 4, 4, 1, 1, 1, 1, 0, 0)
+    assert rows[0][0:17] == (
+        "card-owner-pending",
+        "owner-event-pending",
+        "ledger-entry-pending",
+        1,
+        "sahira",
+        "pending",
+        "awaiting_owner_input",
+        "blocked_awaiting_owner_decision",
+        "owner_decision_required",
+        "owner_input_required",
+        "owner",
+        "wait_for_owner_decision",
+        "no_action_until_owner_decision",
+        "owner_decision_required",
+        0,
+        0,
+        1,
+    )
+    assert rows[1][0:17] == (
+        "card-owner-approve",
+        "owner-event-approve",
+        "ledger-entry-approve",
+        2,
+        "sahira",
+        "approve",
+        "captured",
+        "ready_for_operator_review",
+        "approved_client_recovery_followup",
+        "human_review_before_send_or_crm",
+        "sahira",
+        "prepare_client_recovery_followup_for_human_review",
+        "owner_approved_internal_work_order",
+        "approved recovery follow-up",
+        0,
+        0,
+        1,
+    )
+    assert rows[2][7:13] == (
+        "deferred_owner_followup",
+        "owner_deferred_followup",
+        "owner_revisit_required",
+        "owner",
+        "schedule_owner_revisit",
+        "deferred_no_external_action",
+    )
+    assert rows[3][7:13] == (
+        "rejected_no_action",
+        "owner_rejected_no_action",
+        "no_external_action",
+        "owner",
+        "record_rejection_and_stop",
+        "rejected_no_external_action",
+    )
+    assert len({row[17] for row in rows}) == 4
+    assert all(len(row[17]) == 64 for row in rows)
+
+    payload = json.loads(rows[0][18])
+    assert payload["schema_version"] == "post_decision_work_order_queue.v1"
+    assert payload["privacy_mode"] == "local_only_post_decision_work_order_no_raw_text"
+    assert payload["source_event_rank"] == 1
+    assert payload["source_capture_status"] == "awaiting_owner_input"
+    assert payload["owner_decision"] == "pending"
+    assert payload["work_order_status"] == "blocked_awaiting_owner_decision"
+    assert payload["execution_gate"] == "owner_input_required"
+    assert payload["raw_text_included"] is False
+    assert payload["send_whatsapp"] is False
+    assert payload["crm_mutation"] is False
+    assert payload["requires_human_approval"] is True
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Post-Decision Work Order Queue Summary" in summary
+    assert "| Source cases | 8 |" in summary
+    assert "| Event rows | 4 |" in summary
+    assert "| Work orders | 4 |" in summary
+    assert "| Ready work orders | 1 |" in summary
+    assert "| Blocked work orders | 1 |" in summary
+    assert "| Deferred work orders | 1 |" in summary
+    assert "| Rejected work orders | 1 |" in summary
+    assert "| WhatsApp sends | 0 |" in summary
+    assert "| CRM mutations | 0 |" in summary
+    assert "card-owner-pending" not in summary
+    assert "owner-event-pending" not in summary
+    assert "ledger-entry-pending" not in summary
+    assert "approval-route-pending" not in summary
+
+
+def test_build_post_decision_work_order_queue_rejects_unknown_owner_decision(
+    tmp_path: Path,
+) -> None:
+    events_db = tmp_path / "owner_decision_event_capture.local.sqlite"
+    output_dir = tmp_path / "post-decision-work-orders"
+    _write_owner_decision_event_capture_db(events_db)
+    with sqlite3.connect(events_db) as conn:
+        conn.execute(
+            """
+            UPDATE owner_decision_event_rows
+            SET owner_decision = 'send_now'
+            WHERE event_id = 'owner-event-approve'
+            """
+        )
+        conn.commit()
+
+    with pytest.raises(ValueError, match="Unsupported owner decision"):
+        build_post_decision_work_order_queue(
+            owner_events_db=events_db,
+            output_dir=output_dir,
+            summary_path=output_dir / "summary.md",
+        )
+
+
+def test_build_post_decision_work_order_queue_rejects_unexpected_input_name(
+    tmp_path: Path,
+) -> None:
+    unexpected_db = tmp_path / "owner_decision_event_capture.bad.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    with pytest.raises(
+        ValueError,
+        match="Refusing to read unexpected Owner Decision Event Capture DB",
+    ):
+        build_post_decision_work_order_queue(
+            owner_events_db=unexpected_db,
+            output_dir=tmp_path / "post-decision-work-orders",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_cli_writes_json_without_work_order_details(tmp_path: Path) -> None:
+    events_db = tmp_path / "owner_decision_event_capture.local.sqlite"
+    output_dir = tmp_path / "post-decision-work-orders"
+    summary_path = output_dir / "post_decision_work_order_queue_summary.md"
+    _write_owner_decision_event_capture_db(events_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--owner-events-db",
+            str(events_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--generated-at-utc",
+            "2026-06-17T20:00:00+00:00",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "blocked_count": 1,
+        "brief_count": 4,
+        "crm_mutation_count": 0,
+        "deferred_count": 1,
+        "event_row_count": 4,
+        "ledger_entry_count": 4,
+        "owner_item_count": 4,
+        "pack_count": 4,
+        "queue_item_count": 4,
+        "ready_count": 1,
+        "rejected_count": 1,
+        "send_whatsapp_count": 0,
+        "source_case_count": 8,
+        "work_order_count": 4,
+    }
+    assert "card-owner-pending" not in result.stdout
+    assert "owner-event-pending" not in result.stdout
+    assert "ledger-entry-pending" not in result.stdout
+    assert "approval-route-pending" not in result.stdout

--- a/scripts/tests/test_whatsapp_corpus_review_manifest.py
+++ b/scripts/tests/test_whatsapp_corpus_review_manifest.py
@@ -69,6 +69,22 @@ def test_select_review_rows_orders_by_volume(tmp_path: Path) -> None:
     assert selected[0].message_start_count == 2
 
 
+def test_select_review_rows_filters_by_source(tmp_path: Path) -> None:
+    _, classification_db = build_classification_db(tmp_path)
+    rows = read_classified_rows(classification_db)
+
+    selected = select_review_rows(
+        rows,
+        limit=10,
+        gates=set(),
+        labels=set(),
+        sources={"03_drive-icloud"},
+    )
+
+    assert len(selected) == 1
+    assert selected[0].source == "03_drive-icloud"
+
+
 def test_build_review_manifest_writes_private_paths_but_safe_summary(tmp_path: Path) -> None:
     root, classification_db = build_classification_db(tmp_path)
     output_dir = tmp_path / "review"

--- a/scripts/tests/test_whatsapp_corpus_team_captain_shadow.py
+++ b/scripts/tests/test_whatsapp_corpus_team_captain_shadow.py
@@ -1,0 +1,843 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.whatsapp_corpus import build_team_captain_shadow as team_shadow_module
+from scripts.whatsapp_corpus.build_team_captain_shadow import (
+    OperatorReviewConsoleRow,
+    build_operator_coaching_cards,
+    build_team_captain_shadow,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "whatsapp_corpus" / "build_team_captain_shadow.py"
+GENERIC_TEAM_CLI_ERROR = "ERROR: Team Captain input is missing or invalid.\n"
+SYSTEM_TEAM_CLI_ERROR = "ERROR: Team Captain shadow run failed safely.\n"
+
+
+def _assert_no_raw_team_markers(
+    text: str,
+    *,
+    client_shadow_db: Path,
+    output_dir: Path,
+    summary_path: Path,
+) -> None:
+    forbidden_markers = [
+        "wa-file-1",
+        "cw-1",
+        "shadow-1",
+        "operator-packet-deferred",
+        "case-deferred",
+        "work-deferred",
+        "client_captain_shadow.local.sqlite",
+        "team_captain_shadow.local.sqlite",
+        str(client_shadow_db),
+        str(output_dir),
+        str(summary_path),
+        "research/personal/wa-corpus",
+    ]
+    for marker in forbidden_markers:
+        assert marker not in text
+
+
+def _assert_sanitized_team_cli_error(
+    result: subprocess.CompletedProcess[str],
+    *,
+    forbidden_markers: list[str],
+    expected_stderr: str = GENERIC_TEAM_CLI_ERROR,
+) -> None:
+    assert result.returncode == 1
+    assert result.stderr == expected_stderr
+    assert result.stdout == ""
+    for marker in forbidden_markers:
+        assert marker not in result.stderr
+
+
+def _write_client_shadow_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE shadow_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                draft_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+            CREATE TABLE shadow_drafts (
+                shadow_id TEXT PRIMARY KEY,
+                source_example_id TEXT NOT NULL,
+                source_replay_id TEXT NOT NULL,
+                source_window_id TEXT NOT NULL,
+                source_file_id TEXT NOT NULL,
+                case_owner TEXT NOT NULL,
+                status TEXT NOT NULL,
+                priority TEXT NOT NULL,
+                risk_level TEXT NOT NULL,
+                action_type TEXT NOT NULL,
+                human_specialist TEXT NOT NULL,
+                diagnosis_code TEXT NOT NULL,
+                draft_reply_intent TEXT NOT NULL,
+                operator_coaching_mode TEXT NOT NULL,
+                operator_nudge TEXT NOT NULL,
+                first_month TEXT NOT NULL,
+                last_month TEXT NOT NULL,
+                first_message_index INTEGER NOT NULL,
+                last_message_index INTEGER NOT NULL,
+                cut_message_index INTEGER NOT NULL,
+                dominant_domain TEXT NOT NULL,
+                event_count INTEGER NOT NULL,
+                message_count INTEGER NOT NULL,
+                domain_count INTEGER NOT NULL,
+                severity_high_count INTEGER NOT NULL,
+                send_whatsapp INTEGER NOT NULL,
+                crm_mutation INTEGER NOT NULL,
+                requires_human_approval INTEGER NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO shadow_runs VALUES (
+                1, '2026-06-16T00:00:00+00:00',
+                'local_only_shadow_drafts_no_send_no_crm_mutation', 3, 0, 0
+            )
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO shadow_drafts VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            """,
+            [
+                (
+                    "shadow-1",
+                    "ex-1",
+                    "replay-1",
+                    "cw-1",
+                    "wa-file-1",
+                    "zantara_client_captain",
+                    "shadow_draft",
+                    "high",
+                    "P1",
+                    "crm_followup",
+                    "sahira",
+                    "case_stall_followup_risk",
+                    "Draft follow-up.",
+                    "firm_accountability_nudge",
+                    "Firm: operator must make a system update.",
+                    "2026-05",
+                    "2026-05",
+                    1,
+                    10,
+                    5,
+                    "followup_risk",
+                    20,
+                    7,
+                    2,
+                    3,
+                    0,
+                    0,
+                    1,
+                ),
+                (
+                    "shadow-2",
+                    "ex-2",
+                    "replay-2",
+                    "cw-2",
+                    "wa-file-2",
+                    "zantara_client_captain",
+                    "shadow_draft",
+                    "normal",
+                    "P2",
+                    "payment_reconcile",
+                    "surya",
+                    "payment_reconciliation_needed",
+                    "Draft payment status.",
+                    "steady_family_motivation",
+                    "Supportive: keep moving.",
+                    "2026-05",
+                    "2026-05",
+                    11,
+                    18,
+                    14,
+                    "tax_payment",
+                    9,
+                    4,
+                    1,
+                    0,
+                    0,
+                    0,
+                    1,
+                ),
+                (
+                    "shadow-3",
+                    "ex-3",
+                    "replay-3",
+                    "cw-3",
+                    "wa-file-3",
+                    "zantara_client_captain",
+                    "shadow_draft",
+                    "high",
+                    "P1",
+                    "document_chase",
+                    "sahira",
+                    "missing_document_chase_needed",
+                    "Draft document chase.",
+                    "supportive_urgent_nudge",
+                    "Urgent: close the loop.",
+                    "2026-05",
+                    "2026-05",
+                    20,
+                    40,
+                    30,
+                    "document_requirement",
+                    12,
+                    5,
+                    2,
+                    1,
+                    0,
+                    0,
+                    1,
+                ),
+            ],
+        )
+        conn.commit()
+
+
+def _write_operator_review_console_db(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE operator_packet_review_items (
+                packet_id TEXT PRIMARY KEY,
+                case_card_id TEXT NOT NULL,
+                work_order_id TEXT NOT NULL,
+                review_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                operator_lane TEXT NOT NULL,
+                review_state TEXT NOT NULL,
+                console_bucket TEXT NOT NULL,
+                review_priority TEXT NOT NULL,
+                operator_action TEXT NOT NULL,
+                console_instruction TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO operator_packet_review_items VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 1
+            )
+            """,
+            [
+                (
+                    "operator-packet-ready",
+                    "case-ready",
+                    "work-ready",
+                    1,
+                    "sahira",
+                    "sahira",
+                    "ready_for_human_review",
+                    "operator_review_queue",
+                    "operator_now",
+                    "review_packet_before_send_or_crm",
+                    "review_ready_packet_and_request_human_approval",
+                ),
+                (
+                    "operator-packet-mismatch",
+                    "case-mismatch",
+                    "work-mismatch",
+                    2,
+                    "surya",
+                    "ari",
+                    "ready_for_human_review",
+                    "operator_review_queue",
+                    "operator_now",
+                    "review_packet_before_send_or_crm",
+                    "review_ready_packet_and_request_human_approval",
+                ),
+                (
+                    "operator-packet-owner",
+                    "case-owner",
+                    "work-owner",
+                    3,
+                    "sahira",
+                    "owner",
+                    "waiting_owner_decision",
+                    "owner_decision_inbox",
+                    "owner_now",
+                    "no_operator_action",
+                    "owner_must_approve_reject_or_defer_before_team_work",
+                ),
+                (
+                    "operator-packet-rejected",
+                    "case-rejected",
+                    "work-rejected",
+                    4,
+                    "ari",
+                    "owner",
+                    "rejected_closed",
+                    "closed_no_action",
+                    "closed",
+                    "no_operator_action",
+                    "no_action_packet_rejected",
+                ),
+            ],
+        )
+        conn.commit()
+
+
+def _write_minimal_operator_review_console_db(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE operator_packet_review_items (
+                packet_id TEXT PRIMARY KEY,
+                case_card_id TEXT NOT NULL,
+                work_order_id TEXT NOT NULL,
+                review_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                operator_lane TEXT NOT NULL,
+                review_state TEXT NOT NULL,
+                console_bucket TEXT NOT NULL,
+                review_priority TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO operator_packet_review_items VALUES (
+                'operator-packet-deferred', 'case-deferred', 'work-deferred',
+                1, 'sahira', 'owner', 'deferred_owner_revisit',
+                'owner_revisit_queue', 'owner_later', 0, 0, 1
+            )
+            """
+        )
+        conn.commit()
+
+
+def test_build_team_captain_shadow_groups_lanes_with_six_depth_layers(
+    tmp_path: Path,
+) -> None:
+    client_shadow_db = tmp_path / "client_captain_shadow.local.sqlite"
+    output_dir = tmp_path / "team-captain-shadow"
+    summary_path = output_dir / "team_captain_shadow_summary.md"
+    _write_client_shadow_db(client_shadow_db)
+
+    result = build_team_captain_shadow(
+        client_shadow_db=client_shadow_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+    )
+
+    assert result.finding_count == 2
+    assert result.depth_layer_count == 12
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+
+    with sqlite3.connect(result.output_db) as conn:
+        findings = conn.execute(
+            """
+            SELECT team_captain_id, team_owner, human_specialist, draft_count,
+                   p1_count, primary_action_type, accountability_mode,
+                   send_whatsapp, crm_mutation, requires_human_approval
+            FROM team_captain_findings
+            ORDER BY human_specialist
+            """
+        ).fetchall()
+        layers = conn.execute(
+            """
+            SELECT team_captain_id, depth_level, layer_code, layer_payload_json
+            FROM team_captain_depth_layers
+            ORDER BY team_captain_id, depth_level
+            """
+        ).fetchall()
+
+    assert findings[0][2] == "sahira"
+    assert findings[0][3] == 2
+    assert findings[0][4] == 2
+    assert findings[0][6] == "firm_family_accountability"
+    assert {row[7] for row in findings} == {0}
+    assert {row[8] for row in findings} == {0}
+    assert {row[9] for row in findings} == {1}
+    assert [row[1] for row in layers[:6]] == [1, 2, 3, 4, 5, 6]
+    assert json.loads(layers[0][3])["raw_text_included"] is False
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# Zantara Team Captain Shadow Summary" in summary
+    assert "| Team findings | 2 |" in summary
+    assert "| Depth layers | 12 |" in summary
+    assert "wa-file-1" not in summary
+    assert "cw-1" not in summary
+
+
+def test_client_shadow_contract_violation_is_aggregated_without_actions(
+    tmp_path: Path,
+) -> None:
+    client_shadow_db = tmp_path / "client_captain_shadow.local.sqlite"
+    output_dir = tmp_path / "team-captain-shadow"
+    summary_path = output_dir / "team_captain_shadow_summary.md"
+    _write_client_shadow_db(client_shadow_db)
+    with sqlite3.connect(client_shadow_db) as conn:
+        conn.execute(
+            """
+            UPDATE shadow_drafts
+            SET send_whatsapp = 1, requires_human_approval = 0
+            WHERE shadow_id = 'shadow-1'
+            """
+        )
+        conn.commit()
+
+    result = build_team_captain_shadow(
+        client_shadow_db=client_shadow_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+    )
+
+    assert result.input_contract_violation_count == 1
+    assert result.send_whatsapp_count == 0
+    assert result.crm_mutation_count == 0
+
+    with sqlite3.connect(result.output_db) as conn:
+        rows = conn.execute(
+            """
+            SELECT human_specialist, input_contract_violation_count,
+                   send_whatsapp, crm_mutation, requires_human_approval
+            FROM team_captain_findings
+            ORDER BY human_specialist
+            """
+        ).fetchall()
+
+    assert rows == [
+        ("sahira", 1, 0, 0, 1),
+        ("surya", 0, 0, 0, 1),
+    ]
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "| Input contract violations | 1 |" in summary
+    assert "shadow-1" not in summary
+
+
+def test_build_team_captain_shadow_adds_operator_coaching_cards(
+    tmp_path: Path,
+) -> None:
+    client_shadow_db = tmp_path / "client_captain_shadow.local.sqlite"
+    operator_review_db = tmp_path / "operator_packet_review_console.local.sqlite"
+    output_dir = tmp_path / "team-captain-shadow"
+    summary_path = output_dir / "team_captain_shadow_summary.md"
+    _write_client_shadow_db(client_shadow_db)
+    _write_operator_review_console_db(operator_review_db)
+
+    result = build_team_captain_shadow(
+        client_shadow_db=client_shadow_db,
+        operator_review_console_db=operator_review_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+    )
+
+    assert result.operator_coaching_card_count == 4
+
+    with sqlite3.connect(result.output_db) as conn:
+        run = conn.execute(
+            """
+            SELECT operator_coaching_card_count, send_whatsapp_count, crm_mutation_count
+            FROM team_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+        rows = conn.execute(
+            """
+            SELECT assigned_lane, operator_lane, review_state, team_signal,
+                   captain_tone, operator_push, system_discipline,
+                   send_whatsapp, crm_mutation, requires_human_approval,
+                   coaching_payload_json
+            FROM team_operator_coaching_cards
+            ORDER BY assigned_lane, operator_lane, review_state
+            """
+        ).fetchall()
+
+    assert run == (4, 0, 0)
+    assert len(rows) == 4
+    cards = {
+        (row[0], row[1], row[2]): {
+            "team_signal": row[3],
+            "captain_tone": row[4],
+            "operator_push": row[5],
+            "system_discipline": row[6],
+            "send_whatsapp": row[7],
+            "crm_mutation": row[8],
+            "requires_human_approval": row[9],
+            "payload": json.loads(row[10]),
+        }
+        for row in rows
+    }
+    assert cards[("sahira", "sahira", "ready_for_human_review")] == {
+        "team_signal": "operator_action_required",
+        "captain_tone": "warm_family_push",
+        "operator_push": "review_ready_packet_now",
+        "system_discipline": "use_review_console_before_any_send_or_crm",
+        "send_whatsapp": 0,
+        "crm_mutation": 0,
+        "requires_human_approval": 1,
+        "payload": {
+            "assigned_lane": "sahira",
+            "captain_tone": "warm_family_push",
+            "console_bucket": "operator_review_queue",
+            "crm_mutation": False,
+            "input_contract_violation": False,
+            "operator_lane": "sahira",
+            "operator_push": "review_ready_packet_now",
+            "raw_text_included": False,
+            "requires_human_approval": True,
+            "review_state": "ready_for_human_review",
+            "send_whatsapp": False,
+            "system_discipline": "use_review_console_before_any_send_or_crm",
+            "team_signal": "operator_action_required",
+        },
+    }
+    assert cards[("surya", "ari", "ready_for_human_review")]["team_signal"] == (
+        "routing_mismatch"
+    )
+    assert cards[("surya", "ari", "ready_for_human_review")]["captain_tone"] == (
+        "firm_system_correction"
+    )
+    assert cards[("sahira", "owner", "waiting_owner_decision")]["operator_push"] == (
+        "do_not_execute_until_owner_decides"
+    )
+    assert cards[("ari", "owner", "rejected_closed")]["team_signal"] == "closed_no_action"
+
+    db_surface = "\n".join(str(tuple(row)) for row in rows)
+    assert "review_packet_before_send_or_crm" not in db_surface
+    assert "review_ready_packet_and_request_human_approval" not in db_surface
+    assert "owner_must_approve_reject_or_defer_before_team_work" not in db_surface
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "| Operator coaching cards | 4 |" in summary
+    assert "firm_system_correction" in summary
+    assert "operator-packet-ready" not in summary
+    assert "case-ready" not in summary
+    assert "work-ready" not in summary
+    assert "review_packet_before_send_or_crm" not in summary
+    assert "review_ready_packet_and_request_human_approval" not in summary
+    assert "owner_must_approve_reject_or_defer_before_team_work" not in summary
+
+
+def test_team_captain_reads_operator_console_without_free_text_columns(
+    tmp_path: Path,
+) -> None:
+    client_shadow_db = tmp_path / "client_captain_shadow.local.sqlite"
+    operator_review_db = tmp_path / "operator_packet_review_console.local.sqlite"
+    output_dir = tmp_path / "team-captain-shadow"
+    summary_path = output_dir / "team_captain_shadow_summary.md"
+    _write_client_shadow_db(client_shadow_db)
+    _write_minimal_operator_review_console_db(operator_review_db)
+
+    result = build_team_captain_shadow(
+        client_shadow_db=client_shadow_db,
+        operator_review_console_db=operator_review_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+    )
+
+    assert result.operator_coaching_card_count == 1
+
+    with sqlite3.connect(result.output_db) as conn:
+        row = conn.execute(
+            """
+            SELECT review_state, team_signal, captain_tone, operator_push,
+                   system_discipline, send_whatsapp, crm_mutation,
+                   requires_human_approval
+            FROM team_operator_coaching_cards
+            """
+        ).fetchone()
+
+    assert row == (
+        "deferred_owner_revisit",
+        "owner_revisit_required",
+        "steady_owner_followup",
+        "support_owner_revisit_without_client_action",
+        "hold_deferred_case_until_owner_revisits",
+        0,
+        0,
+        1,
+    )
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "operator-packet-deferred" not in summary
+    assert "case-deferred" not in summary
+    assert "work-deferred" not in summary
+
+
+def test_runtime_contract_violation_becomes_safe_team_correction() -> None:
+    cards = build_operator_coaching_cards(
+        (
+            OperatorReviewConsoleRow(
+                assigned_lane="sahira",
+                operator_lane="sahira",
+                review_state="ready_for_human_review",
+                console_bucket="operator_review_queue",
+                review_priority="operator_now",
+                send_whatsapp=True,
+                crm_mutation=False,
+                requires_human_approval=True,
+            ),
+        )
+    )
+
+    assert len(cards) == 1
+    card = cards[0]
+    assert card.team_signal == "runtime_contract_violation"
+    assert card.captain_tone == "firm_system_correction"
+    assert card.operator_push == "stop_and_restore_human_approval_gate"
+    assert card.system_discipline == "no_send_no_crm_requires_human_approval"
+    assert card.send_whatsapp is False
+    assert card.crm_mutation is False
+    assert card.requires_human_approval is True
+    assert card.coaching_payload["input_contract_violation"] is True
+
+
+def test_unknown_operator_review_state_fails_closed() -> None:
+    with pytest.raises(ValueError, match="Unsupported operator review state"):
+        build_operator_coaching_cards(
+            (
+                OperatorReviewConsoleRow(
+                    assigned_lane="sahira",
+                    operator_lane="sahira",
+                    review_state="unexpected_future_state",
+                    console_bucket="operator_review_queue",
+                    review_priority="operator_now",
+                    send_whatsapp=False,
+                    crm_mutation=False,
+                    requires_human_approval=True,
+                ),
+            )
+        )
+
+
+def test_build_team_captain_shadow_rejects_unexpected_input_name(tmp_path: Path) -> None:
+    unexpected_db = tmp_path / "client_captain_academy.local.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    with pytest.raises(ValueError, match="Refusing to read unexpected Client Shadow DB"):
+        build_team_captain_shadow(
+            client_shadow_db=unexpected_db,
+            output_dir=tmp_path / "team-captain-shadow",
+            summary_path=tmp_path / "summary.md",
+        )
+
+
+def test_team_cli_wrong_input_name_error_is_generic(tmp_path: Path) -> None:
+    unexpected_db = tmp_path / "client_captain_academy.local.sqlite"
+    unexpected_db.write_bytes(b"")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--client-shadow-db",
+            str(unexpected_db),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    _assert_sanitized_team_cli_error(
+        result,
+        forbidden_markers=[
+            "client_captain_academy.local.sqlite",
+            str(unexpected_db),
+            str(tmp_path),
+            "Refusing to read unexpected Client Shadow DB",
+            "Traceback",
+        ],
+    )
+    assert result.returncode == 1
+
+
+def test_team_cli_missing_input_error_is_generic(tmp_path: Path) -> None:
+    missing_db = tmp_path / "client_captain_shadow.local.sqlite"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--client-shadow-db",
+            str(missing_db),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    _assert_sanitized_team_cli_error(
+        result,
+        forbidden_markers=[
+            "client_captain_shadow.local.sqlite",
+            str(missing_db),
+            str(tmp_path),
+            "Client Shadow DB not found",
+            "Traceback",
+        ],
+    )
+    assert result.returncode == 1
+
+
+def test_team_cli_sqlite_error_is_generic_system_failure(tmp_path: Path) -> None:
+    malformed_db = tmp_path / "client_captain_shadow.local.sqlite"
+    malformed_db.write_bytes(b"")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--client-shadow-db",
+            str(malformed_db),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    _assert_sanitized_team_cli_error(
+        result,
+        expected_stderr=SYSTEM_TEAM_CLI_ERROR,
+        forbidden_markers=[
+            "client_captain_shadow.local.sqlite",
+            str(malformed_db),
+            str(tmp_path),
+            "no such table",
+            "sqlite",
+            "Traceback",
+        ],
+    )
+    assert result.returncode == 1
+
+
+def test_team_main_unexpected_error_is_generic_system_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def raise_unexpected(**_: object) -> None:
+        raise RuntimeError(
+            "secret /tmp/raw team_captain_shadow.local.sqlite team_captain_findings"
+        )
+
+    monkeypatch.setattr(
+        team_shadow_module,
+        "build_team_captain_shadow",
+        raise_unexpected,
+    )
+
+    assert team_shadow_module.main(["--json"]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == SYSTEM_TEAM_CLI_ERROR
+    for marker in [
+        "secret",
+        "/tmp/raw",
+        "team_captain_shadow.local.sqlite",
+        "team_captain_findings",
+        "RuntimeError",
+        "Traceback",
+    ]:
+        assert marker not in captured.err
+
+
+def test_team_cli_writes_json_without_raw_details(tmp_path: Path) -> None:
+    client_shadow_db = tmp_path / "client_captain_shadow.local.sqlite"
+    output_dir = tmp_path / "team-captain-shadow"
+    summary_path = output_dir / "team_captain_shadow_summary.md"
+    _write_client_shadow_db(client_shadow_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--client-shadow-db",
+            str(client_shadow_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["finding_count"] == 2
+    assert payload["depth_layer_count"] == 12
+    assert payload["input_contract_violation_count"] == 0
+    assert payload["send_whatsapp_count"] == 0
+    assert payload["crm_mutation_count"] == 0
+    assert "output_db" not in payload
+    assert "summary_path" not in payload
+    _assert_no_raw_team_markers(
+        result.stdout,
+        client_shadow_db=client_shadow_db,
+        output_dir=output_dir,
+        summary_path=summary_path,
+    )
+
+
+def test_team_cli_writes_json_with_operator_console_without_raw_details(
+    tmp_path: Path,
+) -> None:
+    client_shadow_db = tmp_path / "client_captain_shadow.local.sqlite"
+    operator_review_db = tmp_path / "operator_packet_review_console.local.sqlite"
+    output_dir = tmp_path / "team-captain-shadow"
+    summary_path = output_dir / "team_captain_shadow_summary.md"
+    _write_client_shadow_db(client_shadow_db)
+    _write_minimal_operator_review_console_db(operator_review_db)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--client-shadow-db",
+            str(client_shadow_db),
+            "--operator-review-console-db",
+            str(operator_review_db),
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+            str(summary_path),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["finding_count"] == 2
+    assert payload["depth_layer_count"] == 12
+    assert payload["operator_coaching_card_count"] == 1
+    assert payload["input_contract_violation_count"] == 0
+    assert payload["send_whatsapp_count"] == 0
+    assert payload["crm_mutation_count"] == 0
+    assert "operator-packet-deferred" not in result.stdout
+    assert "case-deferred" not in result.stdout
+    assert "work-deferred" not in result.stdout

--- a/scripts/whatsapp_corpus/README.md
+++ b/scripts/whatsapp_corpus/README.md
@@ -190,6 +190,879 @@ Outputs:
 Rows left blank, held, denied, duplicated, or marked `no_action` do not become
 actions.
 
+## Build Client Captain Academy
+
+Build local-only training and replay examples for Zantara Client Captain from
+the anonymous case-window artifact:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_client_captain_academy \
+  --case-windows-db research/personal/wa-corpus/analysis/allowed_case_windows.local.sqlite \
+  --output-dir research/personal/wa-corpus/client-captain \
+  --summary research/personal/wa-corpus/client-captain/client_captain_academy_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/client-captain/client_captain_academy.local.sqlite`
+- `research/personal/wa-corpus/client-captain/training_examples.local.jsonl`
+- `research/personal/wa-corpus/client-captain/client_captain_academy_summary.md`
+
+The `.local.sqlite` and `.local.jsonl` files are ignored by git and must stay on
+the Pro. The summary is aggregate-only. The Captain is always the case owner;
+team names in local examples are specialist lanes, not ownership assignment.
+This builder does not read raw message bodies, does not send WhatsApp messages,
+does not mutate CRM records, and does not call cloud LLMs.
+
+## Build Client Captain Shadow Mode
+
+Build deterministic local-only Shadow Mode diagnoses and draft intents from the
+Client Captain Academy replay artifact:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_client_captain_shadow \
+  --academy-db research/personal/wa-corpus/client-captain/client_captain_academy.local.sqlite \
+  --output-dir research/personal/wa-corpus/client-captain-shadow \
+  --summary research/personal/wa-corpus/client-captain-shadow/client_captain_shadow_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/client-captain-shadow/client_captain_shadow.local.sqlite`
+- `research/personal/wa-corpus/client-captain-shadow/client_captain_shadow_summary.md`
+
+Shadow Mode can diagnose, draft intent, coach the operator, and require human
+approval. It cannot send WhatsApp messages and cannot mutate CRM records. The
+summary is aggregate-only; the `.local.sqlite` artifact stays local on the Pro.
+Each draft also writes five deterministic depth layers:
+
+1. signal readout
+2. case diagnosis
+3. captain decision
+4. draft gate
+5. operator coaching
+
+Every layer preserves the same runtime contract: `send_whatsapp=false`,
+`crm_mutation=false`, and `requires_human_approval=true`.
+
+## Build Case Memory Cards
+
+Build compact local case memory cards from Client Captain Shadow drafts:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_case_memory_cards \
+  --client-shadow-db research/personal/wa-corpus/client-captain-shadow/client_captain_shadow.local.sqlite \
+  --output-dir research/personal/wa-corpus/case-memory-cards \
+  --summary research/personal/wa-corpus/case-memory-cards/case_memory_cards_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/case-memory-cards/case_memory_cards.local.sqlite`
+- `research/personal/wa-corpus/case-memory-cards/case_memory_cards_summary.md`
+
+Each card is a compact local memory object for one shadow case: status, risk,
+next best action, assigned lane, latest movement, blocker code, and review rank.
+The builder reads only Client Captain Shadow outputs, not raw message text. It
+cannot send WhatsApp messages, cannot mutate CRM records, and keeps human
+approval mandatory.
+
+## Build Next Best Action Rankings
+
+Build top-three local next best actions from Case Memory Cards:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_next_best_action_ranker \
+  --case-memory-db research/personal/wa-corpus/case-memory-cards/case_memory_cards.local.sqlite \
+  --output-dir research/personal/wa-corpus/next-best-actions \
+  --summary research/personal/wa-corpus/next-best-actions/next_best_actions_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/next-best-actions/next_best_actions.local.sqlite`
+- `research/personal/wa-corpus/next-best-actions/next_best_actions_summary.md`
+
+For every case card, the ranker writes three ordered actions with urgency score,
+impact score, combined score, reason code, and assigned lane. The ranker is
+deterministic and local-only: it does not read raw WhatsApp text, does not call a
+cloud LLM, does not send WhatsApp messages, and does not mutate CRM records.
+
+## Build Operator Action Inbox
+
+Build one local operator review item per case from the top-ranked next best
+action:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_operator_action_inbox \
+  --next-best-actions-db research/personal/wa-corpus/next-best-actions/next_best_actions.local.sqlite \
+  --output-dir research/personal/wa-corpus/operator-action-inbox \
+  --summary research/personal/wa-corpus/operator-action-inbox/operator_action_inbox_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/operator-action-inbox/operator_action_inbox.local.sqlite`
+- `research/personal/wa-corpus/operator-action-inbox/operator_action_inbox_summary.md`
+
+The inbox selects the top-ranked action per case and turns it into a review
+queue with priority label, queue bucket, assigned lane, reason code, scores, and
+operator instruction. It is deterministic and local-only: it does not read raw
+WhatsApp text, does not call a cloud LLM, does not send WhatsApp messages, and
+does not mutate CRM records.
+
+## Build Operator SLA Clock
+
+Build one local SLA clock per operator inbox item:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_operator_sla_clock \
+  --operator-inbox-db research/personal/wa-corpus/operator-action-inbox/operator_action_inbox.local.sqlite \
+  --output-dir research/personal/wa-corpus/operator-sla-clock \
+  --summary research/personal/wa-corpus/operator-sla-clock/operator_sla_clock_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/operator-sla-clock/operator_sla_clock.local.sqlite`
+- `research/personal/wa-corpus/operator-sla-clock/operator_sla_clock_summary.md`
+
+The SLA Clock turns each inbox item into a deadline, aging counter, due status,
+breach risk, and escalation label. It is deterministic and local-only: it does
+not read raw WhatsApp text, does not call a cloud LLM, does not send WhatsApp
+messages, and does not mutate CRM records. Human approval remains mandatory for
+every clock.
+
+## Build Breach War Room
+
+Build the local owner/lane war room from urgent SLA clocks:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_breach_war_room \
+  --operator-sla-clock-db research/personal/wa-corpus/operator-sla-clock/operator_sla_clock.local.sqlite \
+  --output-dir research/personal/wa-corpus/breach-war-room \
+  --summary research/personal/wa-corpus/breach-war-room/breach_war_room_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/breach-war-room/breach_war_room.local.sqlite`
+- `research/personal/wa-corpus/breach-war-room/breach_war_room_summary.md`
+
+The Breach War Room filters SLA clocks into the owner/lane hot queue. Breached
+or overdue clocks become `critical` owner review items; high-risk clocks become
+`hot` lane review items. It is deterministic and local-only: it does not read
+raw WhatsApp text, does not call a cloud LLM, does not send WhatsApp messages,
+and does not mutate CRM records. Human approval remains mandatory for every
+war-room item.
+
+## Build Case Timeline Synthesizer
+
+Build local operational timelines from case memory, operator inbox, SLA clock,
+and breach war room artifacts:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_case_timeline_synthesizer \
+  --case-memory-db research/personal/wa-corpus/case-memory-cards/case_memory_cards.local.sqlite \
+  --operator-inbox-db research/personal/wa-corpus/operator-action-inbox/operator_action_inbox.local.sqlite \
+  --operator-sla-clock-db research/personal/wa-corpus/operator-sla-clock/operator_sla_clock.local.sqlite \
+  --breach-war-room-db research/personal/wa-corpus/breach-war-room/breach_war_room.local.sqlite \
+  --output-dir research/personal/wa-corpus/case-timelines \
+  --summary research/personal/wa-corpus/case-timelines/case_timelines_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/case-timelines/case_timelines.local.sqlite`
+- `research/personal/wa-corpus/case-timelines/case_timelines_summary.md`
+
+The Case Timeline Synthesizer composes one operational timeline per case using
+existing local artifacts only. Each timeline can include case memory, operator
+action, SLA clock, and war-room events. It is deterministic and local-only: it
+does not parse raw WhatsApp text, does not call a cloud LLM, does not send
+WhatsApp messages, and does not mutate CRM records. Human approval remains
+mandatory for every timeline row and event.
+
+## Build Evidence Gap Detector
+
+Build closure blockers from the local case timeline artifact:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_evidence_gap_detector \
+  --case-timelines-db research/personal/wa-corpus/case-timelines/case_timelines.local.sqlite \
+  --output-dir research/personal/wa-corpus/evidence-gaps \
+  --summary research/personal/wa-corpus/evidence-gaps/evidence_gaps_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/evidence-gaps/evidence_gaps.local.sqlite`
+- `research/personal/wa-corpus/evidence-gaps/evidence_gaps_summary.md`
+
+The Evidence Gap Detector converts each local case timeline into an explicit
+closure blocker: client response confirmation, document evidence, immigration
+status proof, payment reconciliation, or lane review. It is deterministic and
+local-only: it does not parse raw WhatsApp text, does not call a cloud LLM, does
+not send WhatsApp messages, and does not mutate CRM records. Human approval
+remains mandatory for every evidence gap.
+
+## Build Case Closure Judge
+
+Build case-level closure judgments from the local evidence gap artifact:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_case_closure_judge \
+  --evidence-gaps-db research/personal/wa-corpus/evidence-gaps/evidence_gaps.local.sqlite \
+  --output-dir research/personal/wa-corpus/case-closure-judge \
+  --summary research/personal/wa-corpus/case-closure-judge/case_closure_judge_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/case-closure-judge/case_closure_judge.local.sqlite`
+- `research/personal/wa-corpus/case-closure-judge/case_closure_judge_summary.md`
+
+The Case Closure Judge turns evidence gaps into one closure decision per case:
+owner review blocked, evidence upload blocked, lane review blocked, or ready to
+close when no closure blockers remain. It is deterministic and local-only: it
+does not parse raw WhatsApp text, does not call a cloud LLM, does not send
+WhatsApp messages, and does not mutate CRM records. Human approval remains
+mandatory for every closure judgment.
+
+## Build Owner Approval Console
+
+Build owner-only approval items from the local case closure artifact:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_owner_approval_console \
+  --case-closure-db research/personal/wa-corpus/case-closure-judge/case_closure_judge.local.sqlite \
+  --output-dir research/personal/wa-corpus/owner-approval-console \
+  --summary research/personal/wa-corpus/owner-approval-console/owner_approval_console_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/owner-approval-console/owner_approval_console.local.sqlite`
+- `research/personal/wa-corpus/owner-approval-console/owner_approval_console_summary.md`
+
+The Owner Approval Console filters closure judgments down to the decisions that
+need owner review now: client recovery follow-up, immigration status escalation,
+document evidence request, payment reconciliation, or owner case review. It is
+deterministic and local-only: it does not parse raw WhatsApp text, does not call
+a cloud LLM, does not send WhatsApp messages, and does not mutate CRM records.
+Owner approval remains mandatory before every client-facing message or
+operational mutation.
+
+## Build Owner Decision Packs
+
+Build readable owner decision packets from the local owner approval artifact:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_owner_decision_packs \
+  --owner-approval-db research/personal/wa-corpus/owner-approval-console/owner_approval_console.local.sqlite \
+  --output-dir research/personal/wa-corpus/owner-decision-packs \
+  --summary research/personal/wa-corpus/owner-decision-packs/owner_decision_packs_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/owner-decision-packs/owner_decision_packs.local.sqlite`
+- `research/personal/wa-corpus/owner-decision-packs/owner_decision_packs_summary.md`
+
+The Owner Decision Pack turns each owner approval row into a compact local-only
+packet with the decision type, risk brief, recommended decision, and draft
+action type. It is deterministic and local-only: it does not parse raw WhatsApp
+text, does not call a cloud LLM, does not send WhatsApp messages, and does not
+mutate CRM records. Owner approval remains mandatory before every client-facing
+message or operational mutation.
+
+## Build Owner Brief Renderer
+
+Build readable owner briefs from the local owner decision pack artifact:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_owner_brief_renderer \
+  --owner-packs-db research/personal/wa-corpus/owner-decision-packs/owner_decision_packs.local.sqlite \
+  --output-dir research/personal/wa-corpus/owner-brief-renderer \
+  --summary research/personal/wa-corpus/owner-brief-renderer/owner_brief_renderer_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/owner-brief-renderer/owner_brief_renderer.local.sqlite`
+- `research/personal/wa-corpus/owner-brief-renderer/owner_brief_renderer_summary.md`
+
+The Owner Brief Renderer turns each decision pack into a readable owner brief
+with priority, lane, owner focus, risk, recommended decision, draft action, and
+safety lock. It is deterministic and local-only: it does not parse raw WhatsApp
+text, does not call a cloud LLM, does not send WhatsApp messages, and does not
+mutate CRM records. Rendered brief markdown intentionally omits case IDs and
+pack IDs.
+
+## Build Approval Routing Queue
+
+Build owner approval route items from the local owner brief artifact:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_approval_routing_queue \
+  --owner-briefs-db research/personal/wa-corpus/owner-brief-renderer/owner_brief_renderer.local.sqlite \
+  --output-dir research/personal/wa-corpus/approval-routing-queue \
+  --summary research/personal/wa-corpus/approval-routing-queue/approval_routing_queue_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/approval-routing-queue/approval_routing_queue.local.sqlite`
+- `research/personal/wa-corpus/approval-routing-queue/approval_routing_queue_summary.md`
+
+The Approval Routing Queue turns each owner brief into a local owner review
+route with next actor, route bucket, queue status, and allowed decisions:
+approve, reject, or defer. It is deterministic and local-only: it does not
+parse raw WhatsApp text, does not call a cloud LLM, does not send WhatsApp
+messages, and does not mutate CRM records. It prepares owner decisions but does
+not automatically approve anything.
+
+## Build Approve/Reject Ledger
+
+Build immutable local owner decision slots from the approval routing queue:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_approve_reject_ledger \
+  --approval-routing-db research/personal/wa-corpus/approval-routing-queue/approval_routing_queue.local.sqlite \
+  --output-dir research/personal/wa-corpus/approve-reject-ledger \
+  --summary research/personal/wa-corpus/approve-reject-ledger/approve_reject_ledger_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/approve-reject-ledger/approve_reject_ledger.local.sqlite`
+- `research/personal/wa-corpus/approve-reject-ledger/approve_reject_ledger_summary.md`
+
+The Approve/Reject Ledger opens one immutable decision slot per approval route.
+Each slot starts as `awaiting_owner_decision` / `pending` and keeps the allowed
+owner decisions: approve, reject, or defer. It is deterministic and local-only:
+it does not parse raw WhatsApp text, does not call a cloud LLM, does not send
+WhatsApp messages, and does not mutate CRM records. Pending means no owner
+approval has been invented by the system.
+
+## Build Owner Decision Event Capture
+
+Capture explicit local owner decisions from the Approve/Reject Ledger:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_owner_decision_event_capture \
+  --ledger-db research/personal/wa-corpus/approve-reject-ledger/approve_reject_ledger.local.sqlite \
+  --output-dir research/personal/wa-corpus/owner-decision-events \
+  --summary research/personal/wa-corpus/owner-decision-events/owner_decision_event_capture_summary.md \
+  --json
+```
+
+Optional local owner event input:
+
+```bash
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_owner_decision_event_capture \
+  --ledger-db research/personal/wa-corpus/approve-reject-ledger/approve_reject_ledger.local.sqlite \
+  --owner-events-jsonl research/personal/wa-corpus/owner-decision-events/owner_events.local.jsonl \
+  --output-dir research/personal/wa-corpus/owner-decision-events \
+  --summary research/personal/wa-corpus/owner-decision-events/owner_decision_event_capture_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/owner-decision-events/owner_decision_event_capture.local.sqlite`
+- `research/personal/wa-corpus/owner-decision-events/owner_decision_event_capture_summary.md`
+
+The Owner Decision Event Capture records approve, reject, or defer only when an
+explicit local owner event is provided. Missing events remain
+`awaiting_owner_input` / `pending`; the system never invents approval. It is
+deterministic and local-only: it does not parse raw WhatsApp text, does not call
+a cloud LLM, does not send WhatsApp messages, and does not mutate CRM records.
+Human approval remains mandatory before every client-facing message or
+operational mutation.
+
+## Build Post-Decision Work Order Queue
+
+Convert captured owner decisions into internal work orders:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_post_decision_work_order_queue \
+  --owner-events-db research/personal/wa-corpus/owner-decision-events/owner_decision_event_capture.local.sqlite \
+  --output-dir research/personal/wa-corpus/post-decision-work-orders \
+  --summary research/personal/wa-corpus/post-decision-work-orders/post_decision_work_order_queue_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/post-decision-work-orders/post_decision_work_order_queue.local.sqlite`
+- `research/personal/wa-corpus/post-decision-work-orders/post_decision_work_order_queue_summary.md`
+
+The Post-Decision Work Order Queue turns owner decision events into internal
+tasks only. Pending owner decisions remain blocked, approved decisions become
+operator-review work orders, and deferred or rejected decisions create no
+external action. It is deterministic and local-only: it does not parse raw
+WhatsApp text, does not call a cloud LLM, does not send WhatsApp messages, and
+does not mutate CRM records. Human approval remains mandatory before every
+client-facing message or operational mutation.
+
+## Build Operator Execution Packets
+
+Convert post-decision work orders into internal operator execution packets:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_operator_execution_packets \
+  --work-orders-db research/personal/wa-corpus/post-decision-work-orders/post_decision_work_order_queue.local.sqlite \
+  --output-dir research/personal/wa-corpus/operator-execution-packets \
+  --summary research/personal/wa-corpus/operator-execution-packets/operator_execution_packets_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/operator-execution-packets/operator_execution_packets.local.sqlite`
+- `research/personal/wa-corpus/operator-execution-packets/operator_execution_packets_summary.md`
+
+The Operator Execution Packets artifact translates internal work orders into
+the exact packet an operator can review. Pending owner decisions stay blocked,
+approved packets remain behind a human-review gate, deferred packets wait for
+owner revisit, and rejected packets stop with no external action. It is
+deterministic and local-only: it does not parse raw WhatsApp text, does not call
+a cloud LLM, does not send WhatsApp messages, and does not mutate CRM records.
+Human approval remains mandatory before every client-facing message or
+operational mutation.
+
+## Build Operator Packet Review Console
+
+Convert operator execution packets into review-console rows:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_operator_packet_review_console \
+  --packets-db research/personal/wa-corpus/operator-execution-packets/operator_execution_packets.local.sqlite \
+  --output-dir research/personal/wa-corpus/operator-packet-review-console \
+  --summary research/personal/wa-corpus/operator-packet-review-console/operator_packet_review_console_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/operator-packet-review-console/operator_packet_review_console.local.sqlite`
+- `research/personal/wa-corpus/operator-packet-review-console/operator_packet_review_console_summary.md`
+
+The Operator Packet Review Console is an internal owner/team reading surface.
+It groups packet work into review states and buckets: waiting owner decision,
+ready for human review, deferred owner revisit, or rejected closed. It is
+deterministic and local-only: it does not parse raw WhatsApp text, does not call
+a cloud LLM, does not send WhatsApp messages, and does not mutate CRM records.
+Human approval remains mandatory before every client-facing message or
+operational mutation.
+
+## Build Owner Decision Intake
+
+Convert explicit owner decisions from the review console into replayable local
+events:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_owner_decision_intake \
+  --review-console-db research/personal/wa-corpus/operator-packet-review-console/operator_packet_review_console.local.sqlite \
+  --owner-decisions-jsonl research/personal/wa-corpus/owner-decision-compiler/owner_decisions.local.jsonl \
+  --output-dir research/personal/wa-corpus/owner-decision-intake \
+  --summary research/personal/wa-corpus/owner-decision-intake/owner_decision_intake_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/owner-decision-intake/owner_decision_intake.local.sqlite`
+- `research/personal/wa-corpus/owner-decision-intake/owner_events.local.jsonl`
+- `research/personal/wa-corpus/owner-decision-intake/owner_decisions_template.local.jsonl`
+- `research/personal/wa-corpus/owner-decision-intake/owner_decision_intake_summary.md`
+
+The Owner Decision Intake accepts only explicit `approve`, `reject`, or `defer`
+records for owner-actionable review items. Captured decisions are exported as
+`owner_events.local.jsonl`, which can be replayed through
+`build_owner_decision_event_capture` and the downstream work-order / packet /
+review-console chain. Missing decisions remain awaiting owner input and are
+listed in the local `owner_decisions_template.local.jsonl` edit template;
+operator ready and closed items cannot be changed through this intake. It is
+deterministic and local-only: it does not parse raw WhatsApp text, does not call
+a cloud LLM, does not send WhatsApp messages, and does not mutate CRM records.
+Human approval remains mandatory before every client-facing message or
+operational mutation.
+
+## Build Owner Decision Replay
+
+Replay explicit owner decisions through the full local-only chain:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_owner_decision_replay \
+  --ledger-db research/personal/wa-corpus/approve-reject-ledger/approve_reject_ledger.local.sqlite \
+  --review-console-db research/personal/wa-corpus/operator-packet-review-console/operator_packet_review_console.local.sqlite \
+  --owner-decisions-jsonl research/personal/wa-corpus/owner-decision-compiler/owner_decisions.local.jsonl \
+  --output-dir research/personal/wa-corpus/owner-decision-replay \
+  --summary research/personal/wa-corpus/owner-decision-replay/owner_decision_replay_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/owner-decision-replay/owner_decision_replay.local.sqlite`
+- `research/personal/wa-corpus/owner-decision-replay/owner_decision_replay_summary.md`
+- `research/personal/wa-corpus/owner-decision-replay/owner-decision-intake/`
+- `research/personal/wa-corpus/owner-decision-replay/owner-decision-events/`
+- `research/personal/wa-corpus/owner-decision-replay/post-decision-work-orders/`
+- `research/personal/wa-corpus/owner-decision-replay/operator-execution-packets/`
+- `research/personal/wa-corpus/owner-decision-replay/operator-packet-review-console/`
+
+The Owner Decision Replay is the deterministic case-closure loop for owner
+decisions. It regenerates owner decision intake, owner event capture,
+post-decision work orders, operator packets, and the final review console from
+one explicit owner-decision JSONL file. Empty decision files are valid and keep
+the chain waiting for owner input; the runner never invents approval, rejection,
+or deferral. It is local-only: it does not parse raw WhatsApp text, does not call
+a cloud LLM, does not send WhatsApp messages, and does not mutate CRM records.
+Human approval remains mandatory before every client-facing message or
+operational mutation.
+
+## Build Owner Decision Inbox
+
+Build the local owner-editable inbox from review-console rows:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_owner_decision_inbox \
+  --review-console-db research/personal/wa-corpus/operator-packet-review-console/operator_packet_review_console.local.sqlite \
+  --output-dir research/personal/wa-corpus/owner-decision-inbox \
+  --summary research/personal/wa-corpus/owner-decision-inbox/owner_decision_inbox_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/owner-decision-inbox/owner_decision_inbox.local.sqlite`
+- `research/personal/wa-corpus/owner-decision-inbox/owner_decisions_template.local.jsonl`
+- `research/personal/wa-corpus/owner-decision-inbox/owner_decision_inbox_summary.md`
+
+The Owner Decision Inbox selects only owner-actionable review rows: waiting
+owner decision and owner revisit. The JSONL template is intentionally blank for
+`owner_decision`, so the system never invents approval, rejection, or deferral.
+After explicit owner decisions are recorded through
+`build_owner_decision_cockpit`, compile that cockpit template through
+`build_owner_decision_compiler` before feeding the resulting
+`owner_decisions.local.jsonl` into the intake/replay path. The inbox is
+deterministic and local-only: it does not parse raw WhatsApp text, does not call
+a cloud LLM, does not send WhatsApp messages, and does not mutate CRM records.
+Human approval remains mandatory before every client-facing message or
+operational mutation.
+
+## Build Owner Decision Cockpit
+
+Record explicit owner decisions into a compiler-compatible local template:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_owner_decision_cockpit \
+  --owner-inbox-db research/personal/wa-corpus/owner-decision-inbox/owner_decision_inbox.local.sqlite \
+  --decision operator-packet-review-item-pending=approve \
+  --decision-note operator-packet-review-item-pending="owner approved recovery follow-up" \
+  --output-dir research/personal/wa-corpus/owner-decision-cockpit \
+  --summary research/personal/wa-corpus/owner-decision-cockpit/owner_decision_cockpit_summary.md \
+  --json
+```
+
+Optional local JSONL input:
+
+```bash
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_owner_decision_cockpit \
+  --owner-inbox-db research/personal/wa-corpus/owner-decision-inbox/owner_decision_inbox.local.sqlite \
+  --owner-inputs-jsonl research/personal/wa-corpus/owner-decision-cockpit/owner_inputs.local.jsonl \
+  --output-dir research/personal/wa-corpus/owner-decision-cockpit \
+  --summary research/personal/wa-corpus/owner-decision-cockpit/owner_decision_cockpit_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/owner-decision-cockpit/owner_decision_cockpit.local.sqlite`
+- `research/personal/wa-corpus/owner-decision-cockpit/owner_decisions_template.local.jsonl`
+- `research/personal/wa-corpus/owner-decision-cockpit/owner_decision_cockpit_summary.md`
+
+The Owner Decision Cockpit is the owner input surface before the compiler. It
+accepts only explicit `approve`, `reject`, or `defer` decisions for inbox items,
+keeps missing decisions blank as `awaiting_owner_input`, rejects duplicates,
+unknown review items, invalid actors, and invalid decisions, then writes the
+full template expected by `build_owner_decision_compiler`. Inline `--decision`
+arguments are the quickest path when the owner wants to approve, reject, or
+defer without hand-editing JSONL. It is deterministic and local-only: it does
+not parse raw WhatsApp text, does not call a cloud LLM, does not send WhatsApp
+messages, and does not mutate CRM records. Human approval remains mandatory
+before every client-facing message or operational mutation.
+
+## Build Owner Decision Compiler
+
+Compile an edited Owner Decision Inbox template into clean intake-ready owner
+decisions:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_owner_decision_compiler \
+  --owner-inbox-db research/personal/wa-corpus/owner-decision-inbox/owner_decision_inbox.local.sqlite \
+  --edited-template-jsonl research/personal/wa-corpus/owner-decision-cockpit/owner_decisions_template.local.jsonl \
+  --output-dir research/personal/wa-corpus/owner-decision-compiler \
+  --summary research/personal/wa-corpus/owner-decision-compiler/owner_decision_compiler_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/owner-decision-compiler/owner_decision_compiler.local.sqlite`
+- `research/personal/wa-corpus/owner-decision-compiler/owner_decisions.local.jsonl`
+- `research/personal/wa-corpus/owner-decision-compiler/owner_decision_compiler_summary.md`
+
+The Owner Decision Compiler is a narrow binder, not a second decision engine. It
+matches every edited template row back to `owner_decision_inbox.local.sqlite`,
+imports the allowed decision enum from Owner Decision Intake, rejects blank,
+invalid, duplicate, unknown, missing, or tampered rows, and records whether each
+timestamp was owner supplied or filled with compile time. The output JSONL uses a
+single `review_item_id` reference per row so `build_owner_decision_intake` can
+consume it deterministically. It does not parse raw WhatsApp text, does not call
+a cloud LLM, does not send WhatsApp messages, and does not mutate CRM records.
+Human approval remains mandatory before every client-facing message or
+operational mutation.
+
+## Build Owner Decision Pipeline
+
+Run the local owner-decision path without hand-wiring the Cockpit, Compiler, and
+Replay paths:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_owner_decision_pipeline \
+  --ledger-db research/personal/wa-corpus/approve-reject-ledger/approve_reject_ledger.local.sqlite \
+  --review-console-db research/personal/wa-corpus/operator-packet-review-console/operator_packet_review_console.local.sqlite \
+  --decision operator-packet-review-item-pending=approve \
+  --decision-note operator-packet-review-item-pending="owner approved recovery follow-up" \
+  --output-dir research/personal/wa-corpus/owner-decision-pipeline \
+  --summary research/personal/wa-corpus/owner-decision-pipeline/owner_decision_pipeline_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/owner-decision-pipeline/owner_decision_pipeline.local.sqlite`
+- `research/personal/wa-corpus/owner-decision-pipeline/owner_decision_pipeline_summary.md`
+- `research/personal/wa-corpus/owner-decision-pipeline/owner-decision-inbox/`
+- `research/personal/wa-corpus/owner-decision-pipeline/owner-decision-cockpit/`
+- `research/personal/wa-corpus/owner-decision-pipeline/owner-decision-compiler/`
+- `research/personal/wa-corpus/owner-decision-pipeline/owner-decision-replay/`
+
+The Owner Decision Pipeline runs Inbox, Cockpit, Compiler, and Replay in order,
+passing the Cockpit template path explicitly into the Compiler. If even one
+owner input is missing, the pipeline stops at the Cockpit with
+`awaiting_owner_input` and does not run Compiler or Replay, avoiding the manual
+path error where an incomplete template reaches the compiler. It is
+deterministic and local-only: it does not parse raw WhatsApp text, does not call
+a cloud LLM, does not send WhatsApp messages, and does not mutate CRM records.
+Human approval remains mandatory before every client-facing message or
+operational mutation.
+
+## Build Team Captain Shadow Mode
+
+Build aggregate Team Captain findings from the Client Captain Shadow artifact:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_team_captain_shadow \
+  --client-shadow-db research/personal/wa-corpus/client-captain-shadow/client_captain_shadow.local.sqlite \
+  --operator-review-console-db research/personal/wa-corpus/operator-packet-review-console/operator_packet_review_console.local.sqlite \
+  --output-dir research/personal/wa-corpus/team-captain-shadow \
+  --summary research/personal/wa-corpus/team-captain-shadow/team_captain_shadow_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/team-captain-shadow/team_captain_shadow.local.sqlite`
+- `research/personal/wa-corpus/team-captain-shadow/team_captain_shadow_summary.md`
+
+Team Captain reads no raw message text. It groups Client Captain drafts by
+specialist lane and writes one aggregate finding per lane, plus six depth layers
+per lane:
+
+1. lane workload
+2. risk pressure
+3. behavior pattern
+4. motivation plan
+5. accountability nudge
+6. team escalation gate
+
+This is the "family but firm" layer: it motivates, coaches, and flags
+accountability when the operator is not using the system well. It still cannot
+send WhatsApp messages and cannot mutate CRM records.
+
+When `--operator-review-console-db` is provided, Team Captain also reads the
+local Operator Packet Review Console and writes `team_operator_coaching_cards`.
+Those cards are the operational discipline layer: warm push for operator-ready
+packets, protective stop when owner decision is missing, closure discipline for
+rejected packets, and firm correction when a ready packet is routed to the wrong
+operator lane. The cards store no packet IDs, case IDs, work-order IDs, raw text,
+source paths, or free-text console instructions. If an upstream console row ever
+violates the no-send/no-CRM/human-approval contract, Team Captain records only a
+boolean contract-violation marker and emits a safe firm correction card. The
+summary also reports only the aggregate count of input contract violations from
+Client Shadow and Operator Console inputs.
+
+## Build Owner Captain Shadow Mode
+
+Build the owner-level governance artifact from Client and Team Captain Shadow:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_owner_captain_shadow \
+  --client-shadow-db research/personal/wa-corpus/client-captain-shadow/client_captain_shadow.local.sqlite \
+  --team-shadow-db research/personal/wa-corpus/team-captain-shadow/team_captain_shadow.local.sqlite \
+  --output-dir research/personal/wa-corpus/owner-captain-shadow \
+  --summary research/personal/wa-corpus/owner-captain-shadow/owner_captain_shadow_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/owner-captain-shadow/owner_captain_shadow.local.sqlite`
+- `research/personal/wa-corpus/owner-captain-shadow/owner_captain_shadow_summary.md`
+
+Owner Captain sees only aggregate Client and Team Captain outputs. It writes one
+global owner finding plus seven depth layers:
+
+1. operational volume
+2. risk concentration
+3. team bottleneck
+4. client experience risk
+5. automation leverage
+6. governance boundary
+7. owner decision
+
+Owner Captain is a governance and decision-support artifact, not an autonomous
+sender. It cannot send WhatsApp messages, cannot mutate CRM records, includes no
+raw text, and requires human approval for every decision. If Client Shadow or
+Team Captain inputs violate the no-send/no-CRM/human-approval contract, Owner
+Captain reports only the aggregate input contract violation count and keeps the
+output itself safe.
+
+## Build Cloud Export Manifest
+
+Before importing more chat archives from cloud storage, save a local rclone
+metadata listing and convert it into a privacy-safe manifest:
+
+```bash
+source .venv/bin/activate
+rclone lsjson gdrive: --recursive --files-only --include "*WhatsApp Chat*.zip" \
+  > research/personal/wa-corpus/drive/drive_lsjson.local.json
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_drive_export_manifest \
+  --lsjson research/personal/wa-corpus/drive/drive_lsjson.local.json \
+  --output-db research/personal/wa-corpus/drive/drive_export_manifest.local.sqlite \
+  --summary research/personal/wa-corpus/drive/drive_export_manifest_summary.md \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/drive/drive_lsjson.local.json`
+- `research/personal/wa-corpus/drive/drive_export_manifest.local.sqlite`
+- `research/personal/wa-corpus/drive/drive_export_manifest_summary.md`
+
+The `.local.json` and `.local.sqlite` files are ignored by git and must stay on
+the Pro. The summary is aggregate-only: no raw cloud paths, no raw file names,
+and no cloud file ids. This step does not download ZIPs or parse message text;
+it only creates a resolver manifest for the next local import pass.
+
+## Import Selected Cloud ZIPs Locally
+
+After the manifest exists, import a bounded batch into the local corpus. The
+default command is a dry-run; add `--execute` only when importing on the Pro:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python -m scripts.whatsapp_corpus.import_drive_exports \
+  --manifest-db research/personal/wa-corpus/drive/drive_export_manifest.local.sqlite \
+  --download-dir research/personal/wa-corpus/drive/downloads.local \
+  --corpus-root "$HOME/Desktop/wa-chats-MASTER-2026-05-26" \
+  --limit 10 \
+  --json
+```
+
+Execute mode:
+
+```bash
+PYTHONPATH=. python -m scripts.whatsapp_corpus.import_drive_exports \
+  --manifest-db research/personal/wa-corpus/drive/drive_export_manifest.local.sqlite \
+  --download-dir research/personal/wa-corpus/drive/downloads.local \
+  --corpus-root "$HOME/Desktop/wa-chats-MASTER-2026-05-26" \
+  --rclone-bin /opt/homebrew/bin/rclone \
+  --limit 10 \
+  --execute \
+  --json
+```
+
+Outputs:
+
+- `research/personal/wa-corpus/drive/downloads.local/drive-wa-*.zip`
+- `$HOME/Desktop/wa-chats-MASTER-2026-05-26/03_drive-imports/drive-wa-*/chat-*.txt`
+- `research/personal/wa-corpus/drive/drive_import_summary.md`
+
+The importer resolves Drive files by private ID when present, not by filename.
+It extracts only `.txt` chat files and renames them to anonymized local names.
+Media files are ignored. The downloaded ZIPs and raw chat text are local-only
+and must stay on the Pro. Re-run the registry/classification pipeline after a
+batch import, then create a source-scoped review manifest:
+
+```bash
+PYTHONPATH=. python -m scripts.whatsapp_corpus.build_review_manifest \
+  --root "$HOME/Desktop/wa-chats-MASTER-2026-05-26" \
+  --classification-db research/personal/wa-corpus/classification/chat_classification.sqlite \
+  --output-dir research/personal/wa-corpus/review \
+  --source 03_drive-imports \
+  --limit 80
+```
+
+Do not feed imported cleartext directly to cloud LLMs.
+
 ## Full Cleartext Local Corpus
 
 When the owner explicitly authorizes full local processing, parse every readable

--- a/scripts/whatsapp_corpus/build_approval_routing_queue.py
+++ b/scripts/whatsapp_corpus/build_approval_routing_queue.py
@@ -1,0 +1,551 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_OWNER_BRIEF_DIR = Path("research/personal/wa-corpus/owner-brief-renderer")
+DEFAULT_APPROVAL_ROUTING_DIR = Path(
+    "research/personal/wa-corpus/approval-routing-queue"
+)
+
+DEFAULT_OWNER_BRIEFS_DB = DEFAULT_OWNER_BRIEF_DIR / "owner_brief_renderer.local.sqlite"
+DEFAULT_OUTPUT_DB = DEFAULT_APPROVAL_ROUTING_DIR / "approval_routing_queue.local.sqlite"
+DEFAULT_SUMMARY = DEFAULT_APPROVAL_ROUTING_DIR / "approval_routing_queue_summary.md"
+
+EXPECTED_OWNER_BRIEFS_DB_NAME = "owner_brief_renderer.local.sqlite"
+ALLOWED_DECISIONS = ("approve", "reject", "defer")
+
+
+@dataclass(frozen=True)
+class OwnerBriefRow:
+    brief_id: str
+    pack_id: str
+    case_card_id: str
+    brief_rank: int
+    assigned_lane: str
+    decision_type: str
+    decision_priority: str
+    brief_title: str
+    owner_focus: str
+    recommended_decision: str
+    draft_action_type: str
+    safety_lock: str
+    approval_status: str
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class ApprovalRouteItem:
+    route_id: str
+    case_card_id: str
+    brief_id: str
+    pack_id: str
+    route_rank: int
+    assigned_lane: str
+    decision_type: str
+    decision_priority: str
+    owner_focus: str
+    route_bucket: str
+    next_actor: str
+    queue_status: str
+    allowed_decisions: tuple[str, ...]
+    recommended_decision: str
+    draft_action_type: str
+    safety_lock: str
+    approval_status: str
+    route_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class ApprovalRoutingQueueBuildResult:
+    source_case_count: int
+    owner_item_count: int
+    pack_count: int
+    brief_count: int
+    queue_item_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    decision_type_counts: dict[str, int]
+    lane_counts: dict[str, int]
+    route_bucket_counts: dict[str, int]
+    output_db: Path
+    summary_path: Path
+
+
+def _format_utc(value: str | None = None) -> str:
+    if value is not None:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).isoformat(timespec="seconds")
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _connect_ro(db_path: Path, *, expected_name: str, label: str) -> sqlite3.Connection:
+    if db_path.name != expected_name:
+        raise ValueError(f"Refusing to read unexpected {label} DB: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"{label} DB not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def read_source_metadata(db_path: Path) -> tuple[str, int, int, int, int]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_OWNER_BRIEFS_DB_NAME,
+        label="Owner Brief Renderer",
+    ) as conn:
+        row = conn.execute(
+            """
+            SELECT generated_at_utc, source_case_count, owner_item_count,
+                   pack_count, brief_count
+            FROM owner_brief_renderer_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+    if row is None:
+        return "unknown", 0, 0, 0, 0
+    return (
+        str(row["generated_at_utc"]),
+        int(row["source_case_count"]),
+        int(row["owner_item_count"]),
+        int(row["pack_count"]),
+        int(row["brief_count"]),
+    )
+
+
+def read_owner_brief_rows(db_path: Path) -> tuple[OwnerBriefRow, ...]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_OWNER_BRIEFS_DB_NAME,
+        label="Owner Brief Renderer",
+    ) as conn:
+        rows = conn.execute(
+            """
+            SELECT brief_id, pack_id, case_card_id, brief_rank, assigned_lane,
+                   decision_type, decision_priority, brief_title, owner_focus,
+                   recommended_decision, draft_action_type, safety_lock,
+                   approval_status, send_whatsapp, crm_mutation,
+                   requires_human_approval
+            FROM owner_briefs
+            ORDER BY brief_rank, case_card_id
+            """
+        ).fetchall()
+    return tuple(
+        OwnerBriefRow(
+            brief_id=str(row["brief_id"]),
+            pack_id=str(row["pack_id"]),
+            case_card_id=str(row["case_card_id"]),
+            brief_rank=int(row["brief_rank"]),
+            assigned_lane=str(row["assigned_lane"]),
+            decision_type=str(row["decision_type"]),
+            decision_priority=str(row["decision_priority"]),
+            brief_title=str(row["brief_title"]),
+            owner_focus=str(row["owner_focus"]),
+            recommended_decision=str(row["recommended_decision"]),
+            draft_action_type=str(row["draft_action_type"]),
+            safety_lock=str(row["safety_lock"]),
+            approval_status=str(row["approval_status"]),
+            send_whatsapp=bool(row["send_whatsapp"]),
+            crm_mutation=bool(row["crm_mutation"]),
+            requires_human_approval=bool(row["requires_human_approval"]),
+        )
+        for row in rows
+    )
+
+
+def _route_bucket(decision_priority: str) -> str:
+    if decision_priority == "now":
+        return "owner_now"
+    if decision_priority == "today":
+        return "owner_today"
+    return "owner_review"
+
+
+def build_route_items(rows: Sequence[OwnerBriefRow]) -> tuple[ApprovalRouteItem, ...]:
+    routes: list[ApprovalRouteItem] = []
+    for rank, row in enumerate(rows, start=1):
+        route_bucket = _route_bucket(row.decision_priority)
+        payload = {
+            "schema_version": "approval_routing_queue.v1",
+            "privacy_mode": "local_only_approval_routing_no_raw_text",
+            "source_brief_rank": row.brief_rank,
+            "source_decision_type": row.decision_type,
+            "owner_focus": row.owner_focus,
+            "route_bucket": route_bucket,
+            "next_actor": "owner",
+            "queue_status": "waiting_owner_decision",
+            "allowed_decisions": list(ALLOWED_DECISIONS),
+            "owner_action_required": True,
+            "raw_text_included": False,
+            "send_whatsapp": False,
+            "crm_mutation": False,
+            "requires_human_approval": True,
+        }
+        routes.append(
+            ApprovalRouteItem(
+                route_id=f"approval-route-{rank:06d}",
+                case_card_id=row.case_card_id,
+                brief_id=row.brief_id,
+                pack_id=row.pack_id,
+                route_rank=rank,
+                assigned_lane=row.assigned_lane,
+                decision_type=row.decision_type,
+                decision_priority=row.decision_priority,
+                owner_focus=row.owner_focus,
+                route_bucket=route_bucket,
+                next_actor="owner",
+                queue_status="waiting_owner_decision",
+                allowed_decisions=ALLOWED_DECISIONS,
+                recommended_decision=row.recommended_decision,
+                draft_action_type=row.draft_action_type,
+                safety_lock=row.safety_lock,
+                approval_status=row.approval_status,
+                route_payload=payload,
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(routes)
+
+
+def write_approval_routing_sqlite(
+    output_db: Path,
+    *,
+    routes: Sequence[ApprovalRouteItem],
+    source_case_count: int,
+    owner_item_count: int,
+    pack_count: int,
+    brief_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    output_db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(output_db) as conn:
+        conn.executescript(
+            """
+            DROP TABLE IF EXISTS approval_routing_queue_runs;
+            DROP TABLE IF EXISTS approval_routing_items;
+
+            CREATE TABLE approval_routing_queue_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_case_count INTEGER NOT NULL,
+                owner_item_count INTEGER NOT NULL,
+                pack_count INTEGER NOT NULL,
+                brief_count INTEGER NOT NULL,
+                queue_item_count INTEGER NOT NULL,
+                now_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE approval_routing_items (
+                route_id TEXT PRIMARY KEY,
+                case_card_id TEXT NOT NULL,
+                brief_id TEXT NOT NULL,
+                pack_id TEXT NOT NULL,
+                route_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                decision_priority TEXT NOT NULL,
+                owner_focus TEXT NOT NULL,
+                route_bucket TEXT NOT NULL,
+                next_actor TEXT NOT NULL,
+                queue_status TEXT NOT NULL,
+                allowed_decisions_json TEXT NOT NULL,
+                recommended_decision TEXT NOT NULL,
+                draft_action_type TEXT NOT NULL,
+                safety_lock TEXT NOT NULL,
+                approval_status TEXT NOT NULL,
+                route_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE INDEX idx_approval_route_rank ON approval_routing_items(route_rank);
+            CREATE INDEX idx_approval_route_lane ON approval_routing_items(assigned_lane);
+            CREATE INDEX idx_approval_route_type ON approval_routing_items(decision_type);
+            CREATE INDEX idx_approval_route_bucket ON approval_routing_items(route_bucket);
+            CREATE INDEX idx_approval_route_status ON approval_routing_items(queue_status);
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO approval_routing_queue_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_case_count, owner_item_count, pack_count, brief_count,
+                queue_item_count, now_count, send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0)
+            """,
+            (
+                generated_at_utc,
+                source_generated_at_utc,
+                "local_only_approval_routing_no_raw_text_no_send_no_crm_mutation",
+                source_case_count,
+                owner_item_count,
+                pack_count,
+                brief_count,
+                len(routes),
+                sum(1 for route in routes if route.route_bucket == "owner_now"),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO approval_routing_items (
+                route_id, case_card_id, brief_id, pack_id, route_rank,
+                assigned_lane, decision_type, decision_priority, owner_focus,
+                route_bucket, next_actor, queue_status, allowed_decisions_json,
+                recommended_decision, draft_action_type, safety_lock,
+                approval_status, route_payload_json, send_whatsapp, crm_mutation,
+                requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    route.route_id,
+                    route.case_card_id,
+                    route.brief_id,
+                    route.pack_id,
+                    route.route_rank,
+                    route.assigned_lane,
+                    route.decision_type,
+                    route.decision_priority,
+                    route.owner_focus,
+                    route.route_bucket,
+                    route.next_actor,
+                    route.queue_status,
+                    json.dumps(list(route.allowed_decisions), ensure_ascii=False),
+                    route.recommended_decision,
+                    route.draft_action_type,
+                    route.safety_lock,
+                    route.approval_status,
+                    json.dumps(route.route_payload, ensure_ascii=False, sort_keys=True),
+                    int(route.send_whatsapp),
+                    int(route.crm_mutation),
+                    int(route.requires_human_approval),
+                )
+                for route in routes
+            ],
+        )
+        conn.commit()
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'unknown'} | {count} |")
+    return lines
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    routes: Sequence[ApprovalRouteItem],
+    source_case_count: int,
+    owner_item_count: int,
+    pack_count: int,
+    brief_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    decision_counts = Counter(route.decision_type for route in routes)
+    priority_counts = Counter(route.decision_priority for route in routes)
+    lane_counts = Counter(route.assigned_lane for route in routes)
+    bucket_counts = Counter(route.route_bucket for route in routes)
+    queue_counts = Counter(route.queue_status for route in routes)
+    actor_counts = Counter(route.next_actor for route in routes)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Approval Routing Queue Summary",
+        "",
+        f"Generated UTC: `{generated_at_utc}`",
+        f"Source Owner Brief Renderer UTC: `{source_generated_at_utc}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, case card IDs, judgment IDs, approval IDs, pack IDs, brief IDs, route IDs, gap IDs, event IDs, inbox item IDs, or room item IDs.",
+        "- Approval routes are local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Source cases | {source_case_count} |",
+        f"| Owner approval items | {owner_item_count} |",
+        f"| Owner decision packs | {pack_count} |",
+        f"| Owner briefs | {brief_count} |",
+        f"| Queue items | {len(routes)} |",
+        f"| Owner now items | {sum(1 for route in routes if route.route_bucket == 'owner_now')} |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("Decision Types", decision_counts),
+        "",
+        *_counter_table("Decision Priorities", priority_counts),
+        "",
+        *_counter_table("Assigned Lanes", lane_counts),
+        "",
+        *_counter_table("Route Buckets", bucket_counts),
+        "",
+        *_counter_table("Queue Status", queue_counts),
+        "",
+        *_counter_table("Next Actors", actor_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- The Approval Routing Queue turns owner briefs into reviewable owner route items.",
+        "- Allowed owner decisions are approve, reject, and defer.",
+        "- It does not parse raw WhatsApp messages.",
+        "- It does not call a cloud LLM.",
+        "- Runtime must not send WhatsApp messages from this artifact.",
+        "- Runtime must not mutate CRM records from this artifact.",
+        "- Owner approval remains mandatory before any client-facing message or operational mutation.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_approval_routing_queue(
+    *,
+    owner_briefs_db: Path = DEFAULT_OWNER_BRIEFS_DB,
+    output_dir: Path = DEFAULT_APPROVAL_ROUTING_DIR,
+    output_db: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+    generated_at_utc: str | None = None,
+) -> ApprovalRoutingQueueBuildResult:
+    """Build local-only owner approval routes from rendered owner briefs."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    generated = _format_utc(generated_at_utc)
+    (
+        source_generated,
+        source_case_count,
+        owner_item_count,
+        pack_count,
+        brief_count,
+    ) = read_source_metadata(owner_briefs_db)
+    rows = read_owner_brief_rows(owner_briefs_db)
+    routes = build_route_items(rows)
+    source_case_total = source_case_count or len(rows)
+    owner_item_total = owner_item_count or len(rows)
+    pack_total = pack_count or len(rows)
+    brief_total = brief_count or len(rows)
+    write_approval_routing_sqlite(
+        output_db,
+        routes=routes,
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        brief_count=brief_total,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    write_summary(
+        summary_path=summary_path,
+        routes=routes,
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        brief_count=brief_total,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    return ApprovalRoutingQueueBuildResult(
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        brief_count=brief_total,
+        queue_item_count=len(routes),
+        send_whatsapp_count=sum(1 for route in routes if route.send_whatsapp),
+        crm_mutation_count=sum(1 for route in routes if route.crm_mutation),
+        decision_type_counts=dict(Counter(route.decision_type for route in routes)),
+        lane_counts=dict(Counter(route.assigned_lane for route in routes)),
+        route_bucket_counts=dict(Counter(route.route_bucket for route in routes)),
+        output_db=output_db,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build local-only Zantara approval routing queue from owner briefs."
+    )
+    parser.add_argument("--owner-briefs-db", type=Path, default=DEFAULT_OWNER_BRIEFS_DB)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_APPROVAL_ROUTING_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--generated-at-utc", default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_approval_routing_queue(
+            owner_briefs_db=args.owner_briefs_db,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            summary_path=args.summary,
+            generated_at_utc=args.generated_at_utc,
+        )
+    except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
+        print("ERROR: Approval routing queue input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError):
+        print("ERROR: Approval routing queue run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        print("ERROR: Approval routing queue run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "brief_count": result.brief_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                    "owner_item_count": result.owner_item_count,
+                    "pack_count": result.pack_count,
+                    "queue_item_count": result.queue_item_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "source_case_count": result.source_case_count,
+                },
+                sort_keys=True,
+            )
+        )
+    else:
+        print(
+            "Approval routing queue complete: "
+            f"{result.queue_item_count} routes -> {result.output_db.name}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/whatsapp_corpus/build_approve_reject_ledger.py
+++ b/scripts/whatsapp_corpus/build_approve_reject_ledger.py
@@ -1,0 +1,638 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_APPROVAL_ROUTING_DIR = Path(
+    "research/personal/wa-corpus/approval-routing-queue"
+)
+DEFAULT_APPROVE_REJECT_LEDGER_DIR = Path(
+    "research/personal/wa-corpus/approve-reject-ledger"
+)
+
+DEFAULT_APPROVAL_ROUTING_DB = (
+    DEFAULT_APPROVAL_ROUTING_DIR / "approval_routing_queue.local.sqlite"
+)
+DEFAULT_OUTPUT_DB = (
+    DEFAULT_APPROVE_REJECT_LEDGER_DIR / "approve_reject_ledger.local.sqlite"
+)
+DEFAULT_SUMMARY = (
+    DEFAULT_APPROVE_REJECT_LEDGER_DIR / "approve_reject_ledger_summary.md"
+)
+
+EXPECTED_APPROVAL_ROUTING_DB_NAME = "approval_routing_queue.local.sqlite"
+PENDING_DECISION_STATUS = "awaiting_owner_decision"
+PENDING_OWNER_DECISION = "pending"
+IMMUTABLE_EVENT_TYPE = "decision_slot_opened"
+
+
+@dataclass(frozen=True)
+class ApprovalRoutingRow:
+    route_id: str
+    case_card_id: str
+    brief_id: str
+    pack_id: str
+    route_rank: int
+    assigned_lane: str
+    decision_type: str
+    decision_priority: str
+    route_bucket: str
+    next_actor: str
+    queue_status: str
+    allowed_decisions: tuple[str, ...]
+    recommended_decision: str
+    draft_action_type: str
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class ApproveRejectLedgerEntry:
+    entry_id: str
+    route_id: str
+    case_card_id: str
+    brief_id: str
+    pack_id: str
+    ledger_rank: int
+    assigned_lane: str
+    decision_type: str
+    decision_priority: str
+    route_bucket: str
+    next_actor: str
+    queue_status: str
+    decision_status: str
+    owner_decision: str
+    allowed_decisions: tuple[str, ...]
+    recommended_decision: str
+    draft_action_type: str
+    immutable_event_type: str
+    ledger_payload: dict[str, object]
+    ledger_entry_hash: str
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class ApproveRejectLedgerBuildResult:
+    source_case_count: int
+    owner_item_count: int
+    pack_count: int
+    brief_count: int
+    queue_item_count: int
+    ledger_entry_count: int
+    pending_decision_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    decision_status_counts: dict[str, int]
+    owner_decision_counts: dict[str, int]
+    event_type_counts: dict[str, int]
+    route_bucket_counts: dict[str, int]
+    output_db: Path
+    summary_path: Path
+
+
+def _format_utc(value: str | None = None) -> str:
+    if value is not None:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).isoformat(timespec="seconds")
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _connect_ro(db_path: Path, *, expected_name: str, label: str) -> sqlite3.Connection:
+    if db_path.name != expected_name:
+        raise ValueError(f"Refusing to read unexpected {label} DB: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"{label} DB not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _parse_allowed_decisions(value: str) -> tuple[str, ...]:
+    decoded = json.loads(value)
+    if not isinstance(decoded, list):
+        raise ValueError("allowed_decisions_json must contain a JSON list")
+    return tuple(str(item) for item in decoded)
+
+
+def _hash_ledger_entry(payload: dict[str, object]) -> str:
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def read_source_metadata(db_path: Path) -> tuple[str, int, int, int, int, int]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_APPROVAL_ROUTING_DB_NAME,
+        label="Approval Routing Queue",
+    ) as conn:
+        row = conn.execute(
+            """
+            SELECT generated_at_utc, source_case_count, owner_item_count,
+                   pack_count, brief_count, queue_item_count
+            FROM approval_routing_queue_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+    if row is None:
+        return "unknown", 0, 0, 0, 0, 0
+    return (
+        str(row["generated_at_utc"]),
+        int(row["source_case_count"]),
+        int(row["owner_item_count"]),
+        int(row["pack_count"]),
+        int(row["brief_count"]),
+        int(row["queue_item_count"]),
+    )
+
+
+def read_approval_routes(db_path: Path) -> tuple[ApprovalRoutingRow, ...]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_APPROVAL_ROUTING_DB_NAME,
+        label="Approval Routing Queue",
+    ) as conn:
+        rows = conn.execute(
+            """
+            SELECT route_id, case_card_id, brief_id, pack_id, route_rank,
+                   assigned_lane, decision_type, decision_priority, route_bucket,
+                   next_actor, queue_status, allowed_decisions_json,
+                   recommended_decision, draft_action_type, send_whatsapp,
+                   crm_mutation, requires_human_approval
+            FROM approval_routing_items
+            ORDER BY route_rank, case_card_id
+            """
+        ).fetchall()
+    return tuple(
+        ApprovalRoutingRow(
+            route_id=str(row["route_id"]),
+            case_card_id=str(row["case_card_id"]),
+            brief_id=str(row["brief_id"]),
+            pack_id=str(row["pack_id"]),
+            route_rank=int(row["route_rank"]),
+            assigned_lane=str(row["assigned_lane"]),
+            decision_type=str(row["decision_type"]),
+            decision_priority=str(row["decision_priority"]),
+            route_bucket=str(row["route_bucket"]),
+            next_actor=str(row["next_actor"]),
+            queue_status=str(row["queue_status"]),
+            allowed_decisions=_parse_allowed_decisions(str(row["allowed_decisions_json"])),
+            recommended_decision=str(row["recommended_decision"]),
+            draft_action_type=str(row["draft_action_type"]),
+            send_whatsapp=bool(row["send_whatsapp"]),
+            crm_mutation=bool(row["crm_mutation"]),
+            requires_human_approval=bool(row["requires_human_approval"]),
+        )
+        for row in rows
+    )
+
+
+def build_ledger_entries(
+    rows: Sequence[ApprovalRoutingRow],
+) -> tuple[ApproveRejectLedgerEntry, ...]:
+    entries: list[ApproveRejectLedgerEntry] = []
+    for rank, row in enumerate(rows, start=1):
+        payload = {
+            "schema_version": "approve_reject_ledger.v1",
+            "privacy_mode": "local_only_approve_reject_ledger_no_raw_text",
+            "source_route_rank": row.route_rank,
+            "source_queue_status": row.queue_status,
+            "decision_status": PENDING_DECISION_STATUS,
+            "owner_decision": PENDING_OWNER_DECISION,
+            "allowed_decisions": list(row.allowed_decisions),
+            "immutable_event_type": IMMUTABLE_EVENT_TYPE,
+            "raw_text_included": False,
+            "send_whatsapp": False,
+            "crm_mutation": False,
+            "requires_human_approval": True,
+        }
+        hash_payload = {
+            **payload,
+            "entry_id": f"ledger-entry-{rank:06d}",
+            "route_id": row.route_id,
+            "case_card_id": row.case_card_id,
+            "brief_id": row.brief_id,
+            "pack_id": row.pack_id,
+            "ledger_rank": rank,
+            "assigned_lane": row.assigned_lane,
+            "decision_type": row.decision_type,
+            "decision_priority": row.decision_priority,
+            "route_bucket": row.route_bucket,
+            "recommended_decision": row.recommended_decision,
+            "draft_action_type": row.draft_action_type,
+        }
+        entries.append(
+            ApproveRejectLedgerEntry(
+                entry_id=f"ledger-entry-{rank:06d}",
+                route_id=row.route_id,
+                case_card_id=row.case_card_id,
+                brief_id=row.brief_id,
+                pack_id=row.pack_id,
+                ledger_rank=rank,
+                assigned_lane=row.assigned_lane,
+                decision_type=row.decision_type,
+                decision_priority=row.decision_priority,
+                route_bucket=row.route_bucket,
+                next_actor=row.next_actor,
+                queue_status=row.queue_status,
+                decision_status=PENDING_DECISION_STATUS,
+                owner_decision=PENDING_OWNER_DECISION,
+                allowed_decisions=row.allowed_decisions,
+                recommended_decision=row.recommended_decision,
+                draft_action_type=row.draft_action_type,
+                immutable_event_type=IMMUTABLE_EVENT_TYPE,
+                ledger_payload=payload,
+                ledger_entry_hash=_hash_ledger_entry(hash_payload),
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(entries)
+
+
+def write_approve_reject_ledger_sqlite(
+    output_db: Path,
+    *,
+    entries: Sequence[ApproveRejectLedgerEntry],
+    source_case_count: int,
+    owner_item_count: int,
+    pack_count: int,
+    brief_count: int,
+    queue_item_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    output_db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(output_db) as conn:
+        conn.executescript(
+            """
+            DROP TABLE IF EXISTS approve_reject_ledger_runs;
+            DROP TABLE IF EXISTS approve_reject_ledger_entries;
+
+            CREATE TABLE approve_reject_ledger_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_case_count INTEGER NOT NULL,
+                owner_item_count INTEGER NOT NULL,
+                pack_count INTEGER NOT NULL,
+                brief_count INTEGER NOT NULL,
+                queue_item_count INTEGER NOT NULL,
+                ledger_entry_count INTEGER NOT NULL,
+                pending_decision_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE approve_reject_ledger_entries (
+                entry_id TEXT PRIMARY KEY,
+                route_id TEXT NOT NULL,
+                case_card_id TEXT NOT NULL,
+                brief_id TEXT NOT NULL,
+                pack_id TEXT NOT NULL,
+                ledger_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                decision_priority TEXT NOT NULL,
+                route_bucket TEXT NOT NULL,
+                next_actor TEXT NOT NULL,
+                queue_status TEXT NOT NULL,
+                decision_status TEXT NOT NULL,
+                owner_decision TEXT NOT NULL,
+                allowed_decisions_json TEXT NOT NULL,
+                recommended_decision TEXT NOT NULL,
+                draft_action_type TEXT NOT NULL,
+                immutable_event_type TEXT NOT NULL,
+                ledger_entry_hash TEXT NOT NULL UNIQUE,
+                ledger_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE INDEX idx_approve_reject_ledger_rank
+                ON approve_reject_ledger_entries(ledger_rank);
+            CREATE INDEX idx_approve_reject_ledger_route
+                ON approve_reject_ledger_entries(route_id);
+            CREATE INDEX idx_approve_reject_ledger_status
+                ON approve_reject_ledger_entries(decision_status);
+            CREATE INDEX idx_approve_reject_ledger_decision
+                ON approve_reject_ledger_entries(owner_decision);
+            CREATE INDEX idx_approve_reject_ledger_event
+                ON approve_reject_ledger_entries(immutable_event_type);
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO approve_reject_ledger_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_case_count, owner_item_count, pack_count, brief_count,
+                queue_item_count, ledger_entry_count, pending_decision_count,
+                send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0)
+            """,
+            (
+                generated_at_utc,
+                source_generated_at_utc,
+                "local_only_approve_reject_ledger_no_raw_text_no_send_no_crm_mutation",
+                source_case_count,
+                owner_item_count,
+                pack_count,
+                brief_count,
+                queue_item_count,
+                len(entries),
+                sum(
+                    1
+                    for entry in entries
+                    if entry.decision_status == PENDING_DECISION_STATUS
+                ),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO approve_reject_ledger_entries (
+                entry_id, route_id, case_card_id, brief_id, pack_id, ledger_rank,
+                assigned_lane, decision_type, decision_priority, route_bucket,
+                next_actor, queue_status, decision_status, owner_decision,
+                allowed_decisions_json, recommended_decision, draft_action_type,
+                immutable_event_type, ledger_entry_hash, ledger_payload_json,
+                send_whatsapp, crm_mutation, requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    entry.entry_id,
+                    entry.route_id,
+                    entry.case_card_id,
+                    entry.brief_id,
+                    entry.pack_id,
+                    entry.ledger_rank,
+                    entry.assigned_lane,
+                    entry.decision_type,
+                    entry.decision_priority,
+                    entry.route_bucket,
+                    entry.next_actor,
+                    entry.queue_status,
+                    entry.decision_status,
+                    entry.owner_decision,
+                    json.dumps(list(entry.allowed_decisions), ensure_ascii=False),
+                    entry.recommended_decision,
+                    entry.draft_action_type,
+                    entry.immutable_event_type,
+                    entry.ledger_entry_hash,
+                    json.dumps(entry.ledger_payload, ensure_ascii=False, sort_keys=True),
+                    int(entry.send_whatsapp),
+                    int(entry.crm_mutation),
+                    int(entry.requires_human_approval),
+                )
+                for entry in entries
+            ],
+        )
+        conn.commit()
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'unknown'} | {count} |")
+    return lines
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    entries: Sequence[ApproveRejectLedgerEntry],
+    source_case_count: int,
+    owner_item_count: int,
+    pack_count: int,
+    brief_count: int,
+    queue_item_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    decision_counts = Counter(entry.decision_type for entry in entries)
+    priority_counts = Counter(entry.decision_priority for entry in entries)
+    lane_counts = Counter(entry.assigned_lane for entry in entries)
+    bucket_counts = Counter(entry.route_bucket for entry in entries)
+    queue_counts = Counter(entry.queue_status for entry in entries)
+    status_counts = Counter(entry.decision_status for entry in entries)
+    owner_decision_counts = Counter(entry.owner_decision for entry in entries)
+    event_counts = Counter(entry.immutable_event_type for entry in entries)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Approve/Reject Ledger Summary",
+        "",
+        f"Generated UTC: `{generated_at_utc}`",
+        f"Source Approval Routing Queue UTC: `{source_generated_at_utc}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, case card IDs, judgment IDs, approval IDs, pack IDs, brief IDs, route IDs, ledger entry IDs, gap IDs, event IDs, inbox item IDs, or room item IDs.",
+        "- Approve/reject ledger entries are local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Source cases | {source_case_count} |",
+        f"| Owner approval items | {owner_item_count} |",
+        f"| Owner decision packs | {pack_count} |",
+        f"| Owner briefs | {brief_count} |",
+        f"| Queue items | {queue_item_count} |",
+        f"| Ledger entries | {len(entries)} |",
+        f"| Pending owner decisions | {sum(1 for entry in entries if entry.decision_status == PENDING_DECISION_STATUS)} |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("Decision Types", decision_counts),
+        "",
+        *_counter_table("Decision Priorities", priority_counts),
+        "",
+        *_counter_table("Assigned Lanes", lane_counts),
+        "",
+        *_counter_table("Route Buckets", bucket_counts),
+        "",
+        *_counter_table("Queue Status", queue_counts),
+        "",
+        *_counter_table("Decision Status", status_counts),
+        "",
+        *_counter_table("Owner Decisions", owner_decision_counts),
+        "",
+        *_counter_table("Immutable Event Types", event_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- The Approve/Reject Ledger opens one immutable decision slot per approval route.",
+        "- Pending means no owner decision has been made yet.",
+        "- Allowed owner decisions remain approve, reject, and defer.",
+        "- It does not parse raw WhatsApp messages.",
+        "- It does not call a cloud LLM.",
+        "- Runtime must not send WhatsApp messages from this artifact.",
+        "- Runtime must not mutate CRM records from this artifact.",
+        "- Owner approval remains mandatory before any client-facing message or operational mutation.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_approve_reject_ledger(
+    *,
+    approval_routing_db: Path = DEFAULT_APPROVAL_ROUTING_DB,
+    output_dir: Path = DEFAULT_APPROVE_REJECT_LEDGER_DIR,
+    output_db: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+    generated_at_utc: str | None = None,
+) -> ApproveRejectLedgerBuildResult:
+    """Build local-only immutable owner decision slots from approval routes."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    generated = _format_utc(generated_at_utc)
+    (
+        source_generated,
+        source_case_count,
+        owner_item_count,
+        pack_count,
+        brief_count,
+        queue_item_count,
+    ) = read_source_metadata(approval_routing_db)
+    rows = read_approval_routes(approval_routing_db)
+    entries = build_ledger_entries(rows)
+    source_case_total = source_case_count or len(rows)
+    owner_item_total = owner_item_count or len(rows)
+    pack_total = pack_count or len(rows)
+    brief_total = brief_count or len(rows)
+    queue_total = queue_item_count or len(rows)
+    write_approve_reject_ledger_sqlite(
+        output_db,
+        entries=entries,
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        brief_count=brief_total,
+        queue_item_count=queue_total,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    write_summary(
+        summary_path=summary_path,
+        entries=entries,
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        brief_count=brief_total,
+        queue_item_count=queue_total,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    return ApproveRejectLedgerBuildResult(
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        brief_count=brief_total,
+        queue_item_count=queue_total,
+        ledger_entry_count=len(entries),
+        pending_decision_count=sum(
+            1 for entry in entries if entry.decision_status == PENDING_DECISION_STATUS
+        ),
+        send_whatsapp_count=sum(1 for entry in entries if entry.send_whatsapp),
+        crm_mutation_count=sum(1 for entry in entries if entry.crm_mutation),
+        decision_status_counts=dict(
+            Counter(entry.decision_status for entry in entries)
+        ),
+        owner_decision_counts=dict(Counter(entry.owner_decision for entry in entries)),
+        event_type_counts=dict(Counter(entry.immutable_event_type for entry in entries)),
+        route_bucket_counts=dict(Counter(entry.route_bucket for entry in entries)),
+        output_db=output_db,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build local-only Zantara approve/reject ledger from approval routes."
+    )
+    parser.add_argument(
+        "--approval-routing-db",
+        type=Path,
+        default=DEFAULT_APPROVAL_ROUTING_DB,
+    )
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_APPROVE_REJECT_LEDGER_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--generated-at-utc", default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_approve_reject_ledger(
+            approval_routing_db=args.approval_routing_db,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            summary_path=args.summary,
+            generated_at_utc=args.generated_at_utc,
+        )
+    except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
+        print("ERROR: Approve/reject ledger input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError):
+        print("ERROR: Approve/reject ledger run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        print("ERROR: Approve/reject ledger run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "brief_count": result.brief_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                    "ledger_entry_count": result.ledger_entry_count,
+                    "owner_item_count": result.owner_item_count,
+                    "pack_count": result.pack_count,
+                    "pending_decision_count": result.pending_decision_count,
+                    "queue_item_count": result.queue_item_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "source_case_count": result.source_case_count,
+                },
+                sort_keys=True,
+            )
+        )
+    else:
+        print(
+            "Approve/reject ledger complete: "
+            f"{result.ledger_entry_count} entries -> {result.output_db.name}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/whatsapp_corpus/build_breach_war_room.py
+++ b/scripts/whatsapp_corpus/build_breach_war_room.py
@@ -1,0 +1,543 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_SLA_CLOCK_DIR = Path("research/personal/wa-corpus/operator-sla-clock")
+DEFAULT_BREACH_WAR_ROOM_DIR = Path("research/personal/wa-corpus/breach-war-room")
+DEFAULT_OPERATOR_SLA_CLOCK_DB = DEFAULT_SLA_CLOCK_DIR / "operator_sla_clock.local.sqlite"
+DEFAULT_OUTPUT_DB = DEFAULT_BREACH_WAR_ROOM_DIR / "breach_war_room.local.sqlite"
+DEFAULT_SUMMARY = DEFAULT_BREACH_WAR_ROOM_DIR / "breach_war_room_summary.md"
+
+EXPECTED_SLA_CLOCK_DB_NAME = "operator_sla_clock.local.sqlite"
+
+
+@dataclass(frozen=True)
+class SlaClockRow:
+    inbox_item_id: str
+    case_card_id: str
+    queue_rank: int
+    assigned_lane: str
+    priority_label: str
+    queue_bucket: str
+    action_code: str
+    reason_code: str
+    due_at_utc: str
+    as_of_utc: str
+    minutes_until_due: int
+    aging_minutes: int
+    sla_status: str
+    breach_risk: str
+    escalation_label: str
+    clock_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class BreachWarRoomItem:
+    room_item_id: str
+    inbox_item_id: str
+    case_card_id: str
+    source_queue_rank: int
+    war_room_rank: int
+    assigned_lane: str
+    priority_label: str
+    queue_bucket: str
+    action_code: str
+    reason_code: str
+    due_at_utc: str
+    as_of_utc: str
+    minutes_until_due: int
+    aging_minutes: int
+    sla_status: str
+    breach_risk: str
+    escalation_label: str
+    severity_band: str
+    command_channel: str
+    decision_gate: str
+    captain_instruction: str
+    war_room_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class BreachWarRoomBuildResult:
+    clock_count: int
+    room_item_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    severity_counts: dict[str, int]
+    lane_counts: dict[str, int]
+    output_db: Path
+    summary_path: Path
+
+
+def _parse_utc(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _format_utc(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat(timespec="seconds")
+
+
+def _connect_sla_clock(db_path: Path) -> sqlite3.Connection:
+    if db_path.name != EXPECTED_SLA_CLOCK_DB_NAME:
+        raise ValueError(f"Refusing to read unexpected SLA Clock DB: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"SLA Clock DB not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def read_sla_clock(
+    db_path: Path,
+) -> tuple[str, str, tuple[SlaClockRow, ...]]:
+    with _connect_sla_clock(db_path) as conn:
+        run = conn.execute(
+            "SELECT generated_at_utc, as_of_utc FROM operator_sla_clock_runs WHERE id = 1"
+        ).fetchone()
+        if run is None:
+            raise ValueError("SLA Clock DB is missing operator_sla_clock_runs row 1")
+        rows = conn.execute(
+            """
+            SELECT inbox_item_id, case_card_id, queue_rank, assigned_lane,
+                   priority_label, queue_bucket, action_code, reason_code,
+                   due_at_utc, as_of_utc, minutes_until_due, aging_minutes,
+                   sla_status, breach_risk, escalation_label, clock_payload_json,
+                   send_whatsapp, crm_mutation, requires_human_approval
+            FROM operator_sla_clock
+            ORDER BY queue_rank, inbox_item_id
+            """
+        ).fetchall()
+    return (
+        str(run["generated_at_utc"]),
+        str(run["as_of_utc"]),
+        tuple(
+            SlaClockRow(
+                inbox_item_id=str(row["inbox_item_id"]),
+                case_card_id=str(row["case_card_id"]),
+                queue_rank=int(row["queue_rank"]),
+                assigned_lane=str(row["assigned_lane"]),
+                priority_label=str(row["priority_label"]),
+                queue_bucket=str(row["queue_bucket"]),
+                action_code=str(row["action_code"]),
+                reason_code=str(row["reason_code"]),
+                due_at_utc=str(row["due_at_utc"]),
+                as_of_utc=str(row["as_of_utc"]),
+                minutes_until_due=int(row["minutes_until_due"]),
+                aging_minutes=int(row["aging_minutes"]),
+                sla_status=str(row["sla_status"]),
+                breach_risk=str(row["breach_risk"]),
+                escalation_label=str(row["escalation_label"]),
+                clock_payload=json.loads(str(row["clock_payload_json"])),
+                send_whatsapp=bool(row["send_whatsapp"]),
+                crm_mutation=bool(row["crm_mutation"]),
+                requires_human_approval=bool(row["requires_human_approval"]),
+            )
+            for row in rows
+        ),
+    )
+
+
+def _is_war_room_candidate(row: SlaClockRow) -> bool:
+    return row.sla_status == "overdue" or row.breach_risk in {"breached", "high"}
+
+
+def _severity_band(row: SlaClockRow) -> str:
+    if row.sla_status == "overdue" or row.breach_risk == "breached":
+        return "critical"
+    if row.breach_risk == "high":
+        return "hot"
+    return "watch"
+
+
+def _command_channel(severity_band: str) -> str:
+    return {
+        "critical": "owner_war_room",
+        "hot": "lane_hot_queue",
+        "watch": "operator_watch_queue",
+    }.get(severity_band, "operator_watch_queue")
+
+
+def _decision_gate(severity_band: str) -> str:
+    return {
+        "critical": "owner_review_required",
+        "hot": "lane_lead_review_required",
+        "watch": "operator_review_required",
+    }.get(severity_band, "operator_review_required")
+
+
+def _sort_key(row: SlaClockRow) -> tuple[int, int, int, str]:
+    severity_rank = {"critical": 0, "hot": 1, "watch": 2}
+    return (
+        severity_rank.get(_severity_band(row), 9),
+        row.minutes_until_due,
+        row.queue_rank,
+        row.inbox_item_id,
+    )
+
+
+def build_war_room_items(rows: Sequence[SlaClockRow]) -> tuple[BreachWarRoomItem, ...]:
+    candidates = sorted((row for row in rows if _is_war_room_candidate(row)), key=_sort_key)
+    items: list[BreachWarRoomItem] = []
+    for rank, row in enumerate(candidates, start=1):
+        severity = _severity_band(row)
+        command_channel = _command_channel(severity)
+        decision_gate = _decision_gate(severity)
+        captain_instruction = (
+            f"Review {row.assigned_lane} {row.action_code} SLA clock: "
+            f"{severity} risk, {row.minutes_until_due} minutes until due."
+        )
+        payload = {
+            "schema_version": "breach_war_room.v1",
+            "privacy_mode": "local_only_breach_war_room_no_raw_text",
+            "source_priority_label": row.priority_label,
+            "source_queue_bucket": row.queue_bucket,
+            "source_action_code": row.action_code,
+            "source_reason_code": row.reason_code,
+            "source_sla_status": row.sla_status,
+            "source_breach_risk": row.breach_risk,
+            "severity_band": severity,
+            "command_channel": command_channel,
+            "decision_gate": decision_gate,
+            "raw_text_included": False,
+            "send_whatsapp": False,
+            "crm_mutation": False,
+            "requires_human_approval": True,
+        }
+        items.append(
+            BreachWarRoomItem(
+                room_item_id=f"war-room-{rank:06d}",
+                inbox_item_id=row.inbox_item_id,
+                case_card_id=row.case_card_id,
+                source_queue_rank=row.queue_rank,
+                war_room_rank=rank,
+                assigned_lane=row.assigned_lane,
+                priority_label=row.priority_label,
+                queue_bucket=row.queue_bucket,
+                action_code=row.action_code,
+                reason_code=row.reason_code,
+                due_at_utc=row.due_at_utc,
+                as_of_utc=row.as_of_utc,
+                minutes_until_due=row.minutes_until_due,
+                aging_minutes=row.aging_minutes,
+                sla_status=row.sla_status,
+                breach_risk=row.breach_risk,
+                escalation_label=row.escalation_label,
+                severity_band=severity,
+                command_channel=command_channel,
+                decision_gate=decision_gate,
+                captain_instruction=captain_instruction,
+                war_room_payload=payload,
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(items)
+
+
+def write_war_room_sqlite(
+    path: Path,
+    *,
+    items: Sequence[BreachWarRoomItem],
+    clock_count: int,
+    source_sla_clock_generated_at_utc: str,
+    source_as_of_utc: str,
+    generated_at_utc: str,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        path.unlink()
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE breach_war_room_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_sla_clock_generated_at_utc TEXT NOT NULL,
+                source_as_of_utc TEXT NOT NULL,
+                clock_count INTEGER NOT NULL,
+                room_item_count INTEGER NOT NULL,
+                critical_count INTEGER NOT NULL,
+                hot_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE breach_war_room (
+                room_item_id TEXT PRIMARY KEY,
+                inbox_item_id TEXT NOT NULL,
+                case_card_id TEXT NOT NULL,
+                source_queue_rank INTEGER NOT NULL,
+                war_room_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                priority_label TEXT NOT NULL,
+                queue_bucket TEXT NOT NULL,
+                action_code TEXT NOT NULL,
+                reason_code TEXT NOT NULL,
+                due_at_utc TEXT NOT NULL,
+                as_of_utc TEXT NOT NULL,
+                minutes_until_due INTEGER NOT NULL,
+                aging_minutes INTEGER NOT NULL,
+                sla_status TEXT NOT NULL,
+                breach_risk TEXT NOT NULL,
+                escalation_label TEXT NOT NULL,
+                severity_band TEXT NOT NULL,
+                command_channel TEXT NOT NULL,
+                decision_gate TEXT NOT NULL,
+                captain_instruction TEXT NOT NULL,
+                war_room_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE INDEX idx_breach_war_room_severity ON breach_war_room(severity_band);
+            CREATE INDEX idx_breach_war_room_lane ON breach_war_room(assigned_lane);
+            CREATE INDEX idx_breach_war_room_due ON breach_war_room(due_at_utc);
+            CREATE INDEX idx_breach_war_room_channel ON breach_war_room(command_channel);
+            """
+        )
+        severity_counts = Counter(item.severity_band for item in items)
+        conn.execute(
+            """
+            INSERT INTO breach_war_room_runs (
+                id, generated_at_utc, privacy_mode,
+                source_sla_clock_generated_at_utc, source_as_of_utc,
+                clock_count, room_item_count, critical_count, hot_count,
+                send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0)
+            """,
+            (
+                generated_at_utc,
+                "local_only_breach_war_room_no_raw_text_no_send_no_crm_mutation",
+                source_sla_clock_generated_at_utc,
+                source_as_of_utc,
+                clock_count,
+                len(items),
+                severity_counts.get("critical", 0),
+                severity_counts.get("hot", 0),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO breach_war_room (
+                room_item_id, inbox_item_id, case_card_id, source_queue_rank,
+                war_room_rank, assigned_lane, priority_label, queue_bucket,
+                action_code, reason_code, due_at_utc, as_of_utc,
+                minutes_until_due, aging_minutes, sla_status, breach_risk,
+                escalation_label, severity_band, command_channel, decision_gate,
+                captain_instruction, war_room_payload_json, send_whatsapp,
+                crm_mutation, requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    item.room_item_id,
+                    item.inbox_item_id,
+                    item.case_card_id,
+                    item.source_queue_rank,
+                    item.war_room_rank,
+                    item.assigned_lane,
+                    item.priority_label,
+                    item.queue_bucket,
+                    item.action_code,
+                    item.reason_code,
+                    item.due_at_utc,
+                    item.as_of_utc,
+                    item.minutes_until_due,
+                    item.aging_minutes,
+                    item.sla_status,
+                    item.breach_risk,
+                    item.escalation_label,
+                    item.severity_band,
+                    item.command_channel,
+                    item.decision_gate,
+                    item.captain_instruction,
+                    json.dumps(item.war_room_payload, ensure_ascii=False, sort_keys=True),
+                    int(item.send_whatsapp),
+                    int(item.crm_mutation),
+                    int(item.requires_human_approval),
+                )
+                for item in items
+            ],
+        )
+        conn.commit()
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'unknown'} | {count} |")
+    return lines
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    items: Sequence[BreachWarRoomItem],
+    clock_count: int,
+    source_sla_clock_generated_at_utc: str,
+    source_as_of_utc: str,
+    generated_at_utc: str,
+) -> None:
+    severity_counts = Counter(item.severity_band for item in items)
+    lane_counts = Counter(item.assigned_lane for item in items)
+    action_counts = Counter(item.action_code for item in items)
+    channel_counts = Counter(item.command_channel for item in items)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Breach War Room Summary",
+        "",
+        f"Generated UTC: `{generated_at_utc}`",
+        f"Source SLA Clock generated UTC: `{source_sla_clock_generated_at_utc}`",
+        f"Source as-of UTC: `{source_as_of_utc}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, case card IDs, inbox item IDs, room item IDs, shadow IDs, or window IDs.",
+        "- War room rows are local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| SLA clocks reviewed | {clock_count} |",
+        f"| War room items | {len(items)} |",
+        f"| Critical items | {severity_counts.get('critical', 0)} |",
+        f"| Hot items | {severity_counts.get('hot', 0)} |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("Severity Bands", severity_counts),
+        "",
+        *_counter_table("Assigned Lanes", lane_counts),
+        "",
+        *_counter_table("Action Codes", action_counts),
+        "",
+        *_counter_table("Command Channels", channel_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- The Breach War Room prioritizes urgent clocks for owner and lane review.",
+        "- It does not execute any action.",
+        "- Runtime must not send WhatsApp messages from this artifact.",
+        "- Runtime must not mutate CRM records from this artifact.",
+        "- A human must approve any client-facing message or operational mutation.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_breach_war_room(
+    *,
+    operator_sla_clock_db: Path = DEFAULT_OPERATOR_SLA_CLOCK_DB,
+    output_dir: Path = DEFAULT_BREACH_WAR_ROOM_DIR,
+    output_db: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+    generated_at_utc: str | None = None,
+) -> BreachWarRoomBuildResult:
+    """Build a local-only breach war room from the Operator SLA Clock."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    source_sla_generated_at_utc, source_as_of_utc, rows = read_sla_clock(operator_sla_clock_db)
+    now_utc = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    generated = _format_utc(_parse_utc(generated_at_utc or now_utc))
+    items = build_war_room_items(rows)
+    write_war_room_sqlite(
+        output_db,
+        items=items,
+        clock_count=len(rows),
+        source_sla_clock_generated_at_utc=source_sla_generated_at_utc,
+        source_as_of_utc=source_as_of_utc,
+        generated_at_utc=generated,
+    )
+    write_summary(
+        summary_path=summary_path,
+        items=items,
+        clock_count=len(rows),
+        source_sla_clock_generated_at_utc=source_sla_generated_at_utc,
+        source_as_of_utc=source_as_of_utc,
+        generated_at_utc=generated,
+    )
+    return BreachWarRoomBuildResult(
+        clock_count=len(rows),
+        room_item_count=len(items),
+        send_whatsapp_count=sum(1 for item in items if item.send_whatsapp),
+        crm_mutation_count=sum(1 for item in items if item.crm_mutation),
+        severity_counts=dict(Counter(item.severity_band for item in items)),
+        lane_counts=dict(Counter(item.assigned_lane for item in items)),
+        output_db=output_db,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build a local-only Zantara Breach War Room from the SLA clock."
+    )
+    parser.add_argument("--operator-sla-clock-db", type=Path, default=DEFAULT_OPERATOR_SLA_CLOCK_DB)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_BREACH_WAR_ROOM_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--generated-at-utc", default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_breach_war_room(
+            operator_sla_clock_db=args.operator_sla_clock_db,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            summary_path=args.summary,
+            generated_at_utc=args.generated_at_utc,
+        )
+    except (FileNotFoundError, ValueError, sqlite3.Error, OSError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "clock_count": result.clock_count,
+                    "room_item_count": result.room_item_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                    "output_db": str(result.output_db),
+                    "summary_path": str(result.summary_path),
+                },
+                sort_keys=True,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/whatsapp_corpus/build_case_closure_judge.py
+++ b/scripts/whatsapp_corpus/build_case_closure_judge.py
@@ -1,0 +1,511 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_EVIDENCE_GAPS_DIR = Path("research/personal/wa-corpus/evidence-gaps")
+DEFAULT_CASE_CLOSURE_DIR = Path("research/personal/wa-corpus/case-closure-judge")
+
+DEFAULT_EVIDENCE_GAPS_DB = DEFAULT_EVIDENCE_GAPS_DIR / "evidence_gaps.local.sqlite"
+DEFAULT_OUTPUT_DB = DEFAULT_CASE_CLOSURE_DIR / "case_closure_judge.local.sqlite"
+DEFAULT_SUMMARY = DEFAULT_CASE_CLOSURE_DIR / "case_closure_judge_summary.md"
+
+EXPECTED_EVIDENCE_GAPS_DB_NAME = "evidence_gaps.local.sqlite"
+
+
+@dataclass(frozen=True)
+class EvidenceGapRow:
+    gap_id: str
+    case_card_id: str
+    gap_rank: int
+    assigned_lane: str
+    primary_action: str
+    timeline_status: str
+    highest_risk: str
+    blocker_code: str
+    gap_code: str
+    gap_category: str
+    gap_severity: str
+    closure_blocker: bool
+    resolution_gate: str
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class CaseClosureJudgment:
+    judgment_id: str
+    case_card_id: str
+    judgment_rank: int
+    assigned_lane: str
+    primary_action: str
+    closure_status: str
+    closure_blocker_count: int
+    top_gap_code: str
+    top_gap_category: str
+    top_gap_severity: str
+    resolution_gate: str
+    owner_attention_required: bool
+    operator_evidence_required: bool
+    lane_review_required: bool
+    judge_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class CaseClosureJudgeBuildResult:
+    case_count: int
+    blocked_count: int
+    ready_to_close_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    status_counts: dict[str, int]
+    output_db: Path
+    summary_path: Path
+
+
+def _format_utc(value: str | None = None) -> str:
+    if value is not None:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).isoformat(timespec="seconds")
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _connect_ro(db_path: Path, *, expected_name: str, label: str) -> sqlite3.Connection:
+    if db_path.name != expected_name:
+        raise ValueError(f"Refusing to read unexpected {label} DB: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"{label} DB not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def read_evidence_gaps(db_path: Path) -> tuple[EvidenceGapRow, ...]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_EVIDENCE_GAPS_DB_NAME,
+        label="Evidence Gaps",
+    ) as conn:
+        rows = conn.execute(
+            """
+            SELECT gap_id, case_card_id, gap_rank, assigned_lane, primary_action,
+                   timeline_status, highest_risk, blocker_code, gap_code,
+                   gap_category, gap_severity, closure_blocker, resolution_gate,
+                   send_whatsapp, crm_mutation, requires_human_approval
+            FROM evidence_gaps
+            ORDER BY gap_rank, case_card_id, gap_id
+            """
+        ).fetchall()
+    return tuple(
+        EvidenceGapRow(
+            gap_id=str(row["gap_id"]),
+            case_card_id=str(row["case_card_id"]),
+            gap_rank=int(row["gap_rank"]),
+            assigned_lane=str(row["assigned_lane"]),
+            primary_action=str(row["primary_action"]),
+            timeline_status=str(row["timeline_status"]),
+            highest_risk=str(row["highest_risk"]),
+            blocker_code=str(row["blocker_code"]),
+            gap_code=str(row["gap_code"]),
+            gap_category=str(row["gap_category"]),
+            gap_severity=str(row["gap_severity"]),
+            closure_blocker=bool(row["closure_blocker"]),
+            resolution_gate=str(row["resolution_gate"]),
+            send_whatsapp=bool(row["send_whatsapp"]),
+            crm_mutation=bool(row["crm_mutation"]),
+            requires_human_approval=bool(row["requires_human_approval"]),
+        )
+        for row in rows
+    )
+
+
+def read_source_generated_at(db_path: Path) -> str:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_EVIDENCE_GAPS_DB_NAME,
+        label="Evidence Gaps",
+    ) as conn:
+        row = conn.execute(
+            "SELECT generated_at_utc FROM evidence_gap_runs WHERE id = 1"
+        ).fetchone()
+    if row is None:
+        return "unknown"
+    return str(row["generated_at_utc"])
+
+
+def _severity_weight(value: str) -> int:
+    return {"urgent": 3, "high": 2, "medium": 1}.get(value, 0)
+
+
+def _pick_top_gap(rows: Sequence[EvidenceGapRow]) -> EvidenceGapRow:
+    return sorted(
+        rows,
+        key=lambda row: (
+            -_severity_weight(row.gap_severity),
+            row.gap_rank,
+            row.gap_id,
+        ),
+    )[0]
+
+
+def _closure_status(rows: Sequence[EvidenceGapRow]) -> str:
+    blockers = [row for row in rows if row.closure_blocker]
+    if not blockers:
+        return "ready_to_close"
+    if any(
+        row.resolution_gate == "owner_review_required" or row.gap_severity == "urgent"
+        for row in blockers
+    ):
+        return "owner_review_blocked"
+    if any(row.resolution_gate == "operator_upload_required" for row in blockers):
+        return "evidence_upload_blocked"
+    return "lane_review_blocked"
+
+
+def build_judgments(gaps: Sequence[EvidenceGapRow]) -> tuple[CaseClosureJudgment, ...]:
+    grouped: dict[str, list[EvidenceGapRow]] = defaultdict(list)
+    for gap in gaps:
+        grouped[gap.case_card_id].append(gap)
+
+    ordered_cases = sorted(
+        grouped.items(),
+        key=lambda item: (min(row.gap_rank for row in item[1]), item[0]),
+    )
+    judgments: list[CaseClosureJudgment] = []
+    for rank, (case_card_id, rows) in enumerate(ordered_cases, start=1):
+        top_gap = _pick_top_gap(rows)
+        closure_status = _closure_status(rows)
+        owner_attention_required = closure_status == "owner_review_blocked"
+        operator_evidence_required = closure_status == "evidence_upload_blocked"
+        lane_review_required = closure_status == "lane_review_blocked"
+        blocker_count = sum(1 for row in rows if row.closure_blocker)
+        payload = {
+            "schema_version": "case_closure_judge.v1",
+            "privacy_mode": "local_only_case_closure_no_raw_text",
+            "closure_decision": "ready_to_close" if blocker_count == 0 else "blocked",
+            "closure_status": closure_status,
+            "source_gap_count": len(rows),
+            "closure_blocker_count": blocker_count,
+            "top_gap_code": top_gap.gap_code,
+            "top_gap_category": top_gap.gap_category,
+            "top_gap_severity": top_gap.gap_severity,
+            "resolution_gate": top_gap.resolution_gate,
+            "raw_text_included": False,
+            "send_whatsapp": False,
+            "crm_mutation": False,
+            "requires_human_approval": True,
+        }
+        judgments.append(
+            CaseClosureJudgment(
+                judgment_id=f"closure-{rank:06d}",
+                case_card_id=case_card_id,
+                judgment_rank=rank,
+                assigned_lane=top_gap.assigned_lane,
+                primary_action=top_gap.primary_action,
+                closure_status=closure_status,
+                closure_blocker_count=blocker_count,
+                top_gap_code=top_gap.gap_code,
+                top_gap_category=top_gap.gap_category,
+                top_gap_severity=top_gap.gap_severity,
+                resolution_gate=top_gap.resolution_gate,
+                owner_attention_required=owner_attention_required,
+                operator_evidence_required=operator_evidence_required,
+                lane_review_required=lane_review_required,
+                judge_payload=payload,
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(judgments)
+
+
+def write_case_closure_sqlite(
+    output_db: Path,
+    *,
+    judgments: Sequence[CaseClosureJudgment],
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    output_db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(output_db) as conn:
+        conn.executescript(
+            """
+            DROP TABLE IF EXISTS case_closure_judge_runs;
+            DROP TABLE IF EXISTS case_closure_judgments;
+
+            CREATE TABLE case_closure_judge_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                case_count INTEGER NOT NULL,
+                blocked_count INTEGER NOT NULL,
+                ready_to_close_count INTEGER NOT NULL,
+                owner_review_count INTEGER NOT NULL,
+                operator_evidence_count INTEGER NOT NULL,
+                lane_review_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE case_closure_judgments (
+                judgment_id TEXT PRIMARY KEY,
+                case_card_id TEXT NOT NULL,
+                judgment_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                primary_action TEXT NOT NULL,
+                closure_status TEXT NOT NULL,
+                closure_blocker_count INTEGER NOT NULL,
+                top_gap_code TEXT NOT NULL,
+                top_gap_category TEXT NOT NULL,
+                top_gap_severity TEXT NOT NULL,
+                resolution_gate TEXT NOT NULL,
+                owner_attention_required INTEGER NOT NULL,
+                operator_evidence_required INTEGER NOT NULL,
+                lane_review_required INTEGER NOT NULL,
+                judge_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE INDEX idx_case_closure_rank ON case_closure_judgments(judgment_rank);
+            CREATE INDEX idx_case_closure_status ON case_closure_judgments(closure_status);
+            CREATE INDEX idx_case_closure_lane ON case_closure_judgments(assigned_lane);
+            CREATE INDEX idx_case_closure_gate ON case_closure_judgments(resolution_gate);
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO case_closure_judge_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                case_count, blocked_count, ready_to_close_count,
+                owner_review_count, operator_evidence_count, lane_review_count,
+                send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0)
+            """,
+            (
+                generated_at_utc,
+                source_generated_at_utc,
+                "local_only_case_closure_no_raw_text_no_send_no_crm_mutation",
+                len(judgments),
+                sum(1 for row in judgments if row.closure_status != "ready_to_close"),
+                sum(1 for row in judgments if row.closure_status == "ready_to_close"),
+                sum(1 for row in judgments if row.owner_attention_required),
+                sum(1 for row in judgments if row.operator_evidence_required),
+                sum(1 for row in judgments if row.lane_review_required),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO case_closure_judgments (
+                judgment_id, case_card_id, judgment_rank, assigned_lane,
+                primary_action, closure_status, closure_blocker_count,
+                top_gap_code, top_gap_category, top_gap_severity,
+                resolution_gate, owner_attention_required,
+                operator_evidence_required, lane_review_required,
+                judge_payload_json, send_whatsapp, crm_mutation,
+                requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    row.judgment_id,
+                    row.case_card_id,
+                    row.judgment_rank,
+                    row.assigned_lane,
+                    row.primary_action,
+                    row.closure_status,
+                    row.closure_blocker_count,
+                    row.top_gap_code,
+                    row.top_gap_category,
+                    row.top_gap_severity,
+                    row.resolution_gate,
+                    int(row.owner_attention_required),
+                    int(row.operator_evidence_required),
+                    int(row.lane_review_required),
+                    json.dumps(row.judge_payload, ensure_ascii=False, sort_keys=True),
+                    int(row.send_whatsapp),
+                    int(row.crm_mutation),
+                    int(row.requires_human_approval),
+                )
+                for row in judgments
+            ],
+        )
+        conn.commit()
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'unknown'} | {count} |")
+    return lines
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    judgments: Sequence[CaseClosureJudgment],
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    status_counts = Counter(row.closure_status for row in judgments)
+    lane_counts = Counter(row.assigned_lane for row in judgments)
+    action_counts = Counter(row.primary_action for row in judgments)
+    gate_counts = Counter(row.resolution_gate for row in judgments)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Case Closure Judge Summary",
+        "",
+        f"Generated UTC: `{generated_at_utc}`",
+        f"Source Evidence Gaps UTC: `{source_generated_at_utc}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, case card IDs, gap IDs, event IDs, inbox item IDs, or room item IDs.",
+        "- Closure judgment rows are local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Cases judged | {len(judgments)} |",
+        f"| Blocked cases | {sum(1 for row in judgments if row.closure_status != 'ready_to_close')} |",
+        f"| Ready to close | {sum(1 for row in judgments if row.closure_status == 'ready_to_close')} |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("Closure Status", status_counts),
+        "",
+        *_counter_table("Assigned Lanes", lane_counts),
+        "",
+        *_counter_table("Primary Actions", action_counts),
+        "",
+        *_counter_table("Resolution Gates", gate_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- The Case Closure Judge converts evidence gaps into case-level closure decisions.",
+        "- It does not parse raw WhatsApp messages.",
+        "- It does not call a cloud LLM.",
+        "- Runtime must not send WhatsApp messages from this artifact.",
+        "- Runtime must not mutate CRM records from this artifact.",
+        "- A human must approve every closure decision, client-facing message, or operational mutation.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_case_closure_judge(
+    *,
+    evidence_gaps_db: Path = DEFAULT_EVIDENCE_GAPS_DB,
+    output_dir: Path = DEFAULT_CASE_CLOSURE_DIR,
+    output_db: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+    generated_at_utc: str | None = None,
+) -> CaseClosureJudgeBuildResult:
+    """Build local-only case closure judgments from evidence gaps."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    generated = _format_utc(generated_at_utc)
+    source_generated = read_source_generated_at(evidence_gaps_db)
+    gaps = read_evidence_gaps(evidence_gaps_db)
+    judgments = build_judgments(gaps)
+    write_case_closure_sqlite(
+        output_db,
+        judgments=judgments,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    write_summary(
+        summary_path=summary_path,
+        judgments=judgments,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    return CaseClosureJudgeBuildResult(
+        case_count=len(judgments),
+        blocked_count=sum(1 for row in judgments if row.closure_status != "ready_to_close"),
+        ready_to_close_count=sum(
+            1 for row in judgments if row.closure_status == "ready_to_close"
+        ),
+        send_whatsapp_count=sum(1 for row in judgments if row.send_whatsapp),
+        crm_mutation_count=sum(1 for row in judgments if row.crm_mutation),
+        status_counts=dict(Counter(row.closure_status for row in judgments)),
+        output_db=output_db,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build local-only Zantara case closure judgments from evidence gaps."
+    )
+    parser.add_argument("--evidence-gaps-db", type=Path, default=DEFAULT_EVIDENCE_GAPS_DB)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_CASE_CLOSURE_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--generated-at-utc", default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_case_closure_judge(
+            evidence_gaps_db=args.evidence_gaps_db,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            summary_path=args.summary,
+            generated_at_utc=args.generated_at_utc,
+        )
+    except (FileNotFoundError, ValueError, sqlite3.Error, OSError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "blocked_count": result.blocked_count,
+                    "case_count": result.case_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                    "output_db": str(result.output_db),
+                    "ready_to_close_count": result.ready_to_close_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "summary_path": str(result.summary_path),
+                },
+                sort_keys=True,
+            )
+        )
+    else:
+        print(
+            "Case closure judge complete: "
+            f"{result.case_count} cases -> {result.output_db}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/whatsapp_corpus/build_case_memory_cards.py
+++ b/scripts/whatsapp_corpus/build_case_memory_cards.py
@@ -1,0 +1,445 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_CLIENT_SHADOW_DIR = Path("research/personal/wa-corpus/client-captain-shadow")
+DEFAULT_CASE_MEMORY_DIR = Path("research/personal/wa-corpus/case-memory-cards")
+DEFAULT_CLIENT_SHADOW_DB = DEFAULT_CLIENT_SHADOW_DIR / "client_captain_shadow.local.sqlite"
+DEFAULT_OUTPUT_DB = DEFAULT_CASE_MEMORY_DIR / "case_memory_cards.local.sqlite"
+DEFAULT_SUMMARY = DEFAULT_CASE_MEMORY_DIR / "case_memory_cards_summary.md"
+
+EXPECTED_CLIENT_SHADOW_DB_NAME = "client_captain_shadow.local.sqlite"
+
+
+@dataclass(frozen=True)
+class ShadowDraftRow:
+    shadow_id: str
+    source_window_id: str
+    case_owner: str
+    priority: str
+    risk_level: str
+    action_type: str
+    human_specialist: str
+    diagnosis_code: str
+    draft_reply_intent: str
+    operator_coaching_mode: str
+    operator_nudge: str
+    first_month: str
+    last_month: str
+    first_message_index: int
+    last_message_index: int
+    cut_message_index: int
+    dominant_domain: str
+    event_count: int
+    message_count: int
+    domain_count: int
+    severity_high_count: int
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class CaseMemoryCard:
+    case_card_id: str
+    source_shadow_id: str
+    source_window_id: str
+    case_owner: str
+    case_status: str
+    risk_level: str
+    next_best_action: str
+    assigned_lane: str
+    latest_movement: str
+    blocker_code: str
+    review_rank: int
+    card_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class CaseMemoryBuildResult:
+    card_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    risk_counts: dict[str, int]
+    action_counts: dict[str, int]
+    output_db: Path
+    summary_path: Path
+
+
+def _connect_client_shadow(db_path: Path) -> sqlite3.Connection:
+    if db_path.name != EXPECTED_CLIENT_SHADOW_DB_NAME:
+        raise ValueError(f"Refusing to read unexpected Client Shadow DB: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"Client Shadow DB not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def read_shadow_drafts(db_path: Path, *, limit: int | None = None) -> tuple[ShadowDraftRow, ...]:
+    with _connect_client_shadow(db_path) as conn:
+        sql = """
+            SELECT shadow_id, source_window_id, case_owner, priority, risk_level,
+                   action_type, human_specialist, diagnosis_code, draft_reply_intent,
+                   operator_coaching_mode, operator_nudge, first_month, last_month,
+                   first_message_index, last_message_index, cut_message_index,
+                   dominant_domain, event_count, message_count, domain_count,
+                   severity_high_count, send_whatsapp, crm_mutation,
+                   requires_human_approval
+            FROM shadow_drafts
+            ORDER BY
+                CASE risk_level WHEN 'P1' THEN 0 WHEN 'P2' THEN 1 WHEN 'P3' THEN 2 ELSE 3 END,
+                severity_high_count DESC,
+                event_count DESC,
+                message_count DESC,
+                shadow_id
+        """
+        if limit is not None:
+            sql += " LIMIT ?"
+            rows = conn.execute(sql, (limit,)).fetchall()
+        else:
+            rows = conn.execute(sql).fetchall()
+    return tuple(
+        ShadowDraftRow(
+            shadow_id=str(row["shadow_id"]),
+            source_window_id=str(row["source_window_id"]),
+            case_owner=str(row["case_owner"]),
+            priority=str(row["priority"]),
+            risk_level=str(row["risk_level"]),
+            action_type=str(row["action_type"]),
+            human_specialist=str(row["human_specialist"]),
+            diagnosis_code=str(row["diagnosis_code"]),
+            draft_reply_intent=str(row["draft_reply_intent"]),
+            operator_coaching_mode=str(row["operator_coaching_mode"]),
+            operator_nudge=str(row["operator_nudge"]),
+            first_month=str(row["first_month"]),
+            last_month=str(row["last_month"]),
+            first_message_index=int(row["first_message_index"]),
+            last_message_index=int(row["last_message_index"]),
+            cut_message_index=int(row["cut_message_index"]),
+            dominant_domain=str(row["dominant_domain"]),
+            event_count=int(row["event_count"]),
+            message_count=int(row["message_count"]),
+            domain_count=int(row["domain_count"]),
+            severity_high_count=int(row["severity_high_count"]),
+            send_whatsapp=bool(row["send_whatsapp"]),
+            crm_mutation=bool(row["crm_mutation"]),
+            requires_human_approval=bool(row["requires_human_approval"]),
+        )
+        for row in rows
+    )
+
+
+def read_depth_layer_counts(db_path: Path) -> dict[str, int]:
+    with _connect_client_shadow(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT shadow_id, COUNT(*) AS layer_count
+            FROM shadow_depth_layers
+            GROUP BY shadow_id
+            """
+        ).fetchall()
+    return {str(row["shadow_id"]): int(row["layer_count"]) for row in rows}
+
+
+def _case_status(row: ShadowDraftRow) -> str:
+    if row.risk_level == "P1":
+        return "needs_human_review"
+    if row.risk_level == "P2":
+        return "monitor_and_prepare"
+    return "watch"
+
+
+def _risk_rank(risk_level: str) -> int:
+    return {"P1": 1, "P2": 2, "P3": 3}.get(risk_level, 9)
+
+
+def _latest_movement(row: ShadowDraftRow) -> str:
+    return f"{row.last_month}:{row.last_message_index}"
+
+
+def build_cards(
+    rows: Sequence[ShadowDraftRow],
+    *,
+    depth_layer_counts: dict[str, int],
+) -> tuple[CaseMemoryCard, ...]:
+    cards: list[CaseMemoryCard] = []
+    for index, row in enumerate(rows, start=1):
+        payload = {
+            "schema_version": "case_memory_card.v1",
+            "privacy_mode": "local_only_shadow_aggregate_no_raw_text",
+            "case_owner": row.case_owner,
+            "dominant_domain": row.dominant_domain,
+            "priority": row.priority,
+            "diagnosis_code": row.diagnosis_code,
+            "draft_reply_intent": row.draft_reply_intent,
+            "operator_coaching_mode": row.operator_coaching_mode,
+            "operator_nudge": row.operator_nudge,
+            "first_month": row.first_month,
+            "last_month": row.last_month,
+            "message_count": row.message_count,
+            "event_count": row.event_count,
+            "domain_count": row.domain_count,
+            "severity_high_count": row.severity_high_count,
+            "depth_layer_count": depth_layer_counts.get(row.shadow_id, 0),
+            "raw_text_included": False,
+            "send_whatsapp": False,
+            "crm_mutation": False,
+            "requires_human_approval": True,
+        }
+        cards.append(
+            CaseMemoryCard(
+                case_card_id=f"card-{row.shadow_id}",
+                source_shadow_id=row.shadow_id,
+                source_window_id=row.source_window_id,
+                case_owner=row.case_owner,
+                case_status=_case_status(row),
+                risk_level=row.risk_level,
+                next_best_action=row.action_type,
+                assigned_lane=row.human_specialist,
+                latest_movement=_latest_movement(row),
+                blocker_code=row.diagnosis_code,
+                review_rank=index,
+                card_payload=payload,
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(cards)
+
+
+def write_cards_sqlite(path: Path, cards: Sequence[CaseMemoryCard]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        path.unlink()
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE case_memory_card_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                card_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE case_memory_cards (
+                case_card_id TEXT PRIMARY KEY,
+                source_shadow_id TEXT NOT NULL,
+                source_window_id TEXT NOT NULL,
+                case_owner TEXT NOT NULL,
+                case_status TEXT NOT NULL,
+                risk_level TEXT NOT NULL,
+                next_best_action TEXT NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                latest_movement TEXT NOT NULL,
+                blocker_code TEXT NOT NULL,
+                review_rank INTEGER NOT NULL,
+                card_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE INDEX idx_case_memory_cards_rank ON case_memory_cards(review_rank);
+            CREATE INDEX idx_case_memory_cards_risk ON case_memory_cards(risk_level);
+            CREATE INDEX idx_case_memory_cards_lane ON case_memory_cards(assigned_lane);
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO case_memory_card_runs (
+                id, generated_at_utc, privacy_mode, card_count,
+                send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, 0, 0)
+            """,
+            (
+                datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                "local_only_case_memory_cards_no_raw_text_no_send_no_crm_mutation",
+                len(cards),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO case_memory_cards (
+                case_card_id, source_shadow_id, source_window_id, case_owner,
+                case_status, risk_level, next_best_action, assigned_lane,
+                latest_movement, blocker_code, review_rank, card_payload_json,
+                send_whatsapp, crm_mutation, requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    card.case_card_id,
+                    card.source_shadow_id,
+                    card.source_window_id,
+                    card.case_owner,
+                    card.case_status,
+                    card.risk_level,
+                    card.next_best_action,
+                    card.assigned_lane,
+                    card.latest_movement,
+                    card.blocker_code,
+                    card.review_rank,
+                    json.dumps(card.card_payload, ensure_ascii=False, sort_keys=True),
+                    int(card.send_whatsapp),
+                    int(card.crm_mutation),
+                    int(card.requires_human_approval),
+                )
+                for card in cards
+            ],
+        )
+        conn.commit()
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'unknown'} | {count} |")
+    return lines
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    cards: Sequence[CaseMemoryCard],
+    generated_at_utc: str | None = None,
+) -> None:
+    generated = generated_at_utc or datetime.now(timezone.utc).isoformat(timespec="seconds")
+    risk_counts = Counter(card.risk_level for card in cards)
+    action_counts = Counter(card.next_best_action for card in cards)
+    lane_counts = Counter(card.assigned_lane for card in cards)
+    status_counts = Counter(card.case_status for card in cards)
+    blocker_counts = Counter(card.blocker_code for card in cards)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Case Memory Cards Summary",
+        "",
+        f"Generated UTC: `{generated}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, file IDs, window IDs, or shadow IDs.",
+        "- Case memory cards are local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Case memory cards | {len(cards)} |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("Case Statuses", status_counts),
+        "",
+        *_counter_table("Risk Levels", risk_counts),
+        "",
+        *_counter_table("Next Best Actions", action_counts),
+        "",
+        *_counter_table("Assigned Lanes", lane_counts),
+        "",
+        *_counter_table("Blocker Codes", blocker_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- A card is a compact local memory object for human review.",
+        "- Cards can rank, summarize, and route work.",
+        "- Runtime must not send WhatsApp messages from this artifact.",
+        "- Runtime must not mutate CRM records from this artifact.",
+        "- A human must approve any client-facing message or operational mutation.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_case_memory_cards(
+    *,
+    client_shadow_db: Path = DEFAULT_CLIENT_SHADOW_DB,
+    output_dir: Path = DEFAULT_CASE_MEMORY_DIR,
+    output_db: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+    max_cards: int | None = None,
+) -> CaseMemoryBuildResult:
+    """Build compact local-only case memory cards from Client Captain Shadow drafts."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    rows = read_shadow_drafts(client_shadow_db, limit=max_cards)
+    depth_layer_counts = read_depth_layer_counts(client_shadow_db)
+    cards = build_cards(rows, depth_layer_counts=depth_layer_counts)
+    write_cards_sqlite(output_db, cards)
+    write_summary(summary_path=summary_path, cards=cards)
+    return CaseMemoryBuildResult(
+        card_count=len(cards),
+        send_whatsapp_count=sum(1 for card in cards if card.send_whatsapp),
+        crm_mutation_count=sum(1 for card in cards if card.crm_mutation),
+        risk_counts=dict(Counter(card.risk_level for card in cards)),
+        action_counts=dict(Counter(card.next_best_action for card in cards)),
+        output_db=output_db,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build local-only Zantara Case Memory Cards from Client Captain Shadow."
+    )
+    parser.add_argument("--client-shadow-db", type=Path, default=DEFAULT_CLIENT_SHADOW_DB)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_CASE_MEMORY_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--max-cards", type=int, default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_case_memory_cards(
+            client_shadow_db=args.client_shadow_db,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            summary_path=args.summary,
+            max_cards=args.max_cards,
+        )
+    except (FileNotFoundError, ValueError, sqlite3.Error, OSError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "card_count": result.card_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                    "output_db": str(result.output_db),
+                    "summary_path": str(result.summary_path),
+                },
+                sort_keys=True,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/whatsapp_corpus/build_case_timeline_synthesizer.py
+++ b/scripts/whatsapp_corpus/build_case_timeline_synthesizer.py
@@ -1,0 +1,765 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_CASE_MEMORY_DIR = Path("research/personal/wa-corpus/case-memory-cards")
+DEFAULT_OPERATOR_INBOX_DIR = Path("research/personal/wa-corpus/operator-action-inbox")
+DEFAULT_SLA_CLOCK_DIR = Path("research/personal/wa-corpus/operator-sla-clock")
+DEFAULT_BREACH_WAR_ROOM_DIR = Path("research/personal/wa-corpus/breach-war-room")
+DEFAULT_CASE_TIMELINES_DIR = Path("research/personal/wa-corpus/case-timelines")
+
+DEFAULT_CASE_MEMORY_DB = DEFAULT_CASE_MEMORY_DIR / "case_memory_cards.local.sqlite"
+DEFAULT_OPERATOR_INBOX_DB = DEFAULT_OPERATOR_INBOX_DIR / "operator_action_inbox.local.sqlite"
+DEFAULT_OPERATOR_SLA_CLOCK_DB = DEFAULT_SLA_CLOCK_DIR / "operator_sla_clock.local.sqlite"
+DEFAULT_BREACH_WAR_ROOM_DB = DEFAULT_BREACH_WAR_ROOM_DIR / "breach_war_room.local.sqlite"
+DEFAULT_OUTPUT_DB = DEFAULT_CASE_TIMELINES_DIR / "case_timelines.local.sqlite"
+DEFAULT_SUMMARY = DEFAULT_CASE_TIMELINES_DIR / "case_timelines_summary.md"
+
+EXPECTED_CASE_MEMORY_DB_NAME = "case_memory_cards.local.sqlite"
+EXPECTED_OPERATOR_INBOX_DB_NAME = "operator_action_inbox.local.sqlite"
+EXPECTED_OPERATOR_SLA_CLOCK_DB_NAME = "operator_sla_clock.local.sqlite"
+EXPECTED_BREACH_WAR_ROOM_DB_NAME = "breach_war_room.local.sqlite"
+
+
+@dataclass(frozen=True)
+class CaseMemoryRow:
+    case_card_id: str
+    case_status: str
+    risk_level: str
+    next_best_action: str
+    assigned_lane: str
+    latest_movement: str
+    blocker_code: str
+    review_rank: int
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OperatorInboxRow:
+    case_card_id: str
+    inbox_item_id: str
+    queue_rank: int
+    assigned_lane: str
+    priority_label: str
+    queue_bucket: str
+    action_code: str
+    reason_code: str
+    urgency_score: int
+    combined_score: int
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class SlaClockRow:
+    case_card_id: str
+    inbox_item_id: str
+    due_at_utc: str
+    as_of_utc: str
+    minutes_until_due: int
+    aging_minutes: int
+    sla_status: str
+    breach_risk: str
+    escalation_label: str
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class WarRoomRow:
+    case_card_id: str
+    room_item_id: str
+    war_room_rank: int
+    severity_band: str
+    command_channel: str
+    decision_gate: str
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class CaseTimeline:
+    case_card_id: str
+    timeline_rank: int
+    timeline_status: str
+    highest_risk: str
+    assigned_lane: str
+    primary_action: str
+    latest_movement: str
+    blocker_code: str
+    event_count: int
+    has_war_room_item: bool
+    timeline_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class CaseTimelineEvent:
+    event_id: str
+    case_card_id: str
+    event_rank: int
+    event_stage: str
+    event_status: str
+    event_lane: str
+    action_code: str
+    event_signal: str
+    event_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class CaseTimelineBuildResult:
+    case_count: int
+    event_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    status_counts: dict[str, int]
+    lane_counts: dict[str, int]
+    output_db: Path
+    summary_path: Path
+
+
+def _format_utc(value: str | None = None) -> str:
+    if value is not None:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).isoformat(timespec="seconds")
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _connect_ro(db_path: Path, *, expected_name: str, label: str) -> sqlite3.Connection:
+    if db_path.name != expected_name:
+        raise ValueError(f"Refusing to read unexpected {label} DB: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"{label} DB not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def read_case_memory(db_path: Path) -> tuple[CaseMemoryRow, ...]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_CASE_MEMORY_DB_NAME,
+        label="Case Memory",
+    ) as conn:
+        rows = conn.execute(
+            """
+            SELECT case_card_id, case_status, risk_level, next_best_action,
+                   assigned_lane, latest_movement, blocker_code, review_rank,
+                   send_whatsapp, crm_mutation, requires_human_approval
+            FROM case_memory_cards
+            ORDER BY review_rank, case_card_id
+            """
+        ).fetchall()
+    return tuple(
+        CaseMemoryRow(
+            case_card_id=str(row["case_card_id"]),
+            case_status=str(row["case_status"]),
+            risk_level=str(row["risk_level"]),
+            next_best_action=str(row["next_best_action"]),
+            assigned_lane=str(row["assigned_lane"]),
+            latest_movement=str(row["latest_movement"]),
+            blocker_code=str(row["blocker_code"]),
+            review_rank=int(row["review_rank"]),
+            send_whatsapp=bool(row["send_whatsapp"]),
+            crm_mutation=bool(row["crm_mutation"]),
+            requires_human_approval=bool(row["requires_human_approval"]),
+        )
+        for row in rows
+    )
+
+
+def read_operator_inbox(db_path: Path) -> dict[str, OperatorInboxRow]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_OPERATOR_INBOX_DB_NAME,
+        label="Operator Inbox",
+    ) as conn:
+        rows = conn.execute(
+            """
+            SELECT case_card_id, inbox_item_id, queue_rank, assigned_lane,
+                   priority_label, queue_bucket, action_code, reason_code,
+                   urgency_score, combined_score, send_whatsapp, crm_mutation,
+                   requires_human_approval
+            FROM operator_action_inbox
+            ORDER BY queue_rank, inbox_item_id
+            """
+        ).fetchall()
+    return {
+        str(row["case_card_id"]): OperatorInboxRow(
+            case_card_id=str(row["case_card_id"]),
+            inbox_item_id=str(row["inbox_item_id"]),
+            queue_rank=int(row["queue_rank"]),
+            assigned_lane=str(row["assigned_lane"]),
+            priority_label=str(row["priority_label"]),
+            queue_bucket=str(row["queue_bucket"]),
+            action_code=str(row["action_code"]),
+            reason_code=str(row["reason_code"]),
+            urgency_score=int(row["urgency_score"]),
+            combined_score=int(row["combined_score"]),
+            send_whatsapp=bool(row["send_whatsapp"]),
+            crm_mutation=bool(row["crm_mutation"]),
+            requires_human_approval=bool(row["requires_human_approval"]),
+        )
+        for row in rows
+    }
+
+
+def read_sla_clock(db_path: Path) -> dict[str, SlaClockRow]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_OPERATOR_SLA_CLOCK_DB_NAME,
+        label="SLA Clock",
+    ) as conn:
+        rows = conn.execute(
+            """
+            SELECT case_card_id, inbox_item_id, due_at_utc, as_of_utc,
+                   minutes_until_due, aging_minutes, sla_status, breach_risk,
+                   escalation_label, send_whatsapp, crm_mutation,
+                   requires_human_approval
+            FROM operator_sla_clock
+            ORDER BY queue_rank, inbox_item_id
+            """
+        ).fetchall()
+    return {
+        str(row["case_card_id"]): SlaClockRow(
+            case_card_id=str(row["case_card_id"]),
+            inbox_item_id=str(row["inbox_item_id"]),
+            due_at_utc=str(row["due_at_utc"]),
+            as_of_utc=str(row["as_of_utc"]),
+            minutes_until_due=int(row["minutes_until_due"]),
+            aging_minutes=int(row["aging_minutes"]),
+            sla_status=str(row["sla_status"]),
+            breach_risk=str(row["breach_risk"]),
+            escalation_label=str(row["escalation_label"]),
+            send_whatsapp=bool(row["send_whatsapp"]),
+            crm_mutation=bool(row["crm_mutation"]),
+            requires_human_approval=bool(row["requires_human_approval"]),
+        )
+        for row in rows
+    }
+
+
+def read_war_room(db_path: Path) -> dict[str, WarRoomRow]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_BREACH_WAR_ROOM_DB_NAME,
+        label="Breach War Room",
+    ) as conn:
+        rows = conn.execute(
+            """
+            SELECT case_card_id, room_item_id, war_room_rank, severity_band,
+                   command_channel, decision_gate, send_whatsapp, crm_mutation,
+                   requires_human_approval
+            FROM breach_war_room
+            ORDER BY war_room_rank, room_item_id
+            """
+        ).fetchall()
+    war_room: dict[str, WarRoomRow] = {}
+    for row in rows:
+        case_card_id = str(row["case_card_id"])
+        war_room.setdefault(
+            case_card_id,
+            WarRoomRow(
+                case_card_id=case_card_id,
+                room_item_id=str(row["room_item_id"]),
+                war_room_rank=int(row["war_room_rank"]),
+                severity_band=str(row["severity_band"]),
+                command_channel=str(row["command_channel"]),
+                decision_gate=str(row["decision_gate"]),
+                send_whatsapp=bool(row["send_whatsapp"]),
+                crm_mutation=bool(row["crm_mutation"]),
+                requires_human_approval=bool(row["requires_human_approval"]),
+            ),
+        )
+    return war_room
+
+
+def _timeline_status(sla: SlaClockRow | None, war_room: WarRoomRow | None) -> str:
+    if war_room is not None:
+        return "war_room_active"
+    if sla is None:
+        return "memory_only"
+    if sla.breach_risk in {"breached", "high"}:
+        return "sla_hot"
+    if sla.sla_status == "due_today":
+        return "operator_due_today"
+    return "monitor"
+
+
+def _event_payload(stage: str, **values: object) -> dict[str, object]:
+    return {
+        "schema_version": "case_timeline_event.v1",
+        "event_stage": stage,
+        "raw_text_included": False,
+        "send_whatsapp": False,
+        "crm_mutation": False,
+        "requires_human_approval": True,
+        **values,
+    }
+
+
+def _build_events(
+    card: CaseMemoryRow,
+    inbox: OperatorInboxRow | None,
+    sla: SlaClockRow | None,
+    war_room: WarRoomRow | None,
+) -> tuple[CaseTimelineEvent, ...]:
+    rows: list[CaseTimelineEvent] = [
+        CaseTimelineEvent(
+            event_id=f"{card.case_card_id}-event-001",
+            case_card_id=card.case_card_id,
+            event_rank=1,
+            event_stage="case_memory",
+            event_status=card.case_status,
+            event_lane=card.assigned_lane,
+            action_code=card.next_best_action,
+            event_signal=card.blocker_code,
+            event_payload=_event_payload(
+                "case_memory",
+                risk_level=card.risk_level,
+                latest_movement=card.latest_movement,
+                blocker_code=card.blocker_code,
+            ),
+            send_whatsapp=False,
+            crm_mutation=False,
+            requires_human_approval=True,
+        )
+    ]
+    if inbox is not None:
+        rows.append(
+            CaseTimelineEvent(
+                event_id=f"{card.case_card_id}-event-{len(rows) + 1:03d}",
+                case_card_id=card.case_card_id,
+                event_rank=len(rows) + 1,
+                event_stage="operator_action",
+                event_status=inbox.priority_label,
+                event_lane=inbox.assigned_lane,
+                action_code=inbox.action_code,
+                event_signal=inbox.reason_code,
+                event_payload=_event_payload(
+                    "operator_action",
+                    queue_bucket=inbox.queue_bucket,
+                    urgency_score=inbox.urgency_score,
+                    combined_score=inbox.combined_score,
+                ),
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    if sla is not None:
+        rows.append(
+            CaseTimelineEvent(
+                event_id=f"{card.case_card_id}-event-{len(rows) + 1:03d}",
+                case_card_id=card.case_card_id,
+                event_rank=len(rows) + 1,
+                event_stage="sla_clock",
+                event_status=sla.sla_status,
+                event_lane=(inbox.assigned_lane if inbox is not None else card.assigned_lane),
+                action_code=(inbox.action_code if inbox is not None else card.next_best_action),
+                event_signal=sla.breach_risk,
+                event_payload=_event_payload(
+                    "sla_clock",
+                    minutes_until_due=sla.minutes_until_due,
+                    aging_minutes=sla.aging_minutes,
+                    escalation_label=sla.escalation_label,
+                ),
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    if war_room is not None:
+        rows.append(
+            CaseTimelineEvent(
+                event_id=f"{card.case_card_id}-event-{len(rows) + 1:03d}",
+                case_card_id=card.case_card_id,
+                event_rank=len(rows) + 1,
+                event_stage="war_room",
+                event_status=war_room.severity_band,
+                event_lane=(inbox.assigned_lane if inbox is not None else card.assigned_lane),
+                action_code=(inbox.action_code if inbox is not None else card.next_best_action),
+                event_signal=war_room.command_channel,
+                event_payload=_event_payload(
+                    "war_room",
+                    severity_band=war_room.severity_band,
+                    command_channel=war_room.command_channel,
+                    decision_gate=war_room.decision_gate,
+                ),
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(rows)
+
+
+def build_timelines(
+    cards: Sequence[CaseMemoryRow],
+    inbox_by_case: dict[str, OperatorInboxRow],
+    sla_by_case: dict[str, SlaClockRow],
+    war_room_by_case: dict[str, WarRoomRow],
+) -> tuple[tuple[CaseTimeline, ...], tuple[CaseTimelineEvent, ...]]:
+    timelines: list[CaseTimeline] = []
+    events: list[CaseTimelineEvent] = []
+    for rank, card in enumerate(cards, start=1):
+        inbox = inbox_by_case.get(card.case_card_id)
+        sla = sla_by_case.get(card.case_card_id)
+        war_room = war_room_by_case.get(card.case_card_id)
+        case_events = _build_events(card, inbox, sla, war_room)
+        events.extend(case_events)
+        assigned_lane = inbox.assigned_lane if inbox is not None else card.assigned_lane
+        primary_action = inbox.action_code if inbox is not None else card.next_best_action
+        payload = {
+            "schema_version": "case_timeline_synthesizer.v1",
+            "privacy_mode": "local_only_case_timeline_no_raw_text",
+            "timeline_status": _timeline_status(sla, war_room),
+            "highest_risk": card.risk_level,
+            "event_count": len(case_events),
+            "has_war_room_item": war_room is not None,
+            "raw_text_included": False,
+            "send_whatsapp": False,
+            "crm_mutation": False,
+            "requires_human_approval": True,
+        }
+        timelines.append(
+            CaseTimeline(
+                case_card_id=card.case_card_id,
+                timeline_rank=rank,
+                timeline_status=_timeline_status(sla, war_room),
+                highest_risk=card.risk_level,
+                assigned_lane=assigned_lane,
+                primary_action=primary_action,
+                latest_movement=card.latest_movement,
+                blocker_code=card.blocker_code,
+                event_count=len(case_events),
+                has_war_room_item=war_room is not None,
+                timeline_payload=payload,
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(timelines), tuple(events)
+
+
+def write_timeline_sqlite(
+    path: Path,
+    *,
+    timelines: Sequence[CaseTimeline],
+    events: Sequence[CaseTimelineEvent],
+    generated_at_utc: str,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        path.unlink()
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE case_timeline_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                case_count INTEGER NOT NULL,
+                event_count INTEGER NOT NULL,
+                war_room_case_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE case_timelines (
+                case_card_id TEXT PRIMARY KEY,
+                timeline_rank INTEGER NOT NULL,
+                timeline_status TEXT NOT NULL,
+                highest_risk TEXT NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                primary_action TEXT NOT NULL,
+                latest_movement TEXT NOT NULL,
+                blocker_code TEXT NOT NULL,
+                event_count INTEGER NOT NULL,
+                has_war_room_item INTEGER NOT NULL,
+                timeline_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE TABLE case_timeline_events (
+                event_id TEXT PRIMARY KEY,
+                case_card_id TEXT NOT NULL,
+                event_rank INTEGER NOT NULL,
+                event_stage TEXT NOT NULL,
+                event_status TEXT NOT NULL,
+                event_lane TEXT NOT NULL,
+                action_code TEXT NOT NULL,
+                event_signal TEXT NOT NULL,
+                event_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE INDEX idx_case_timelines_status ON case_timelines(timeline_status);
+            CREATE INDEX idx_case_timelines_lane ON case_timelines(assigned_lane);
+            CREATE INDEX idx_case_timeline_events_case ON case_timeline_events(case_card_id);
+            CREATE INDEX idx_case_timeline_events_stage ON case_timeline_events(event_stage);
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO case_timeline_runs (
+                id, generated_at_utc, privacy_mode, case_count, event_count,
+                war_room_case_count, send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, ?, ?, 0, 0)
+            """,
+            (
+                generated_at_utc,
+                "local_only_case_timeline_no_raw_text_no_send_no_crm_mutation",
+                len(timelines),
+                len(events),
+                sum(1 for timeline in timelines if timeline.has_war_room_item),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO case_timelines (
+                case_card_id, timeline_rank, timeline_status, highest_risk,
+                assigned_lane, primary_action, latest_movement, blocker_code,
+                event_count, has_war_room_item, timeline_payload_json,
+                send_whatsapp, crm_mutation, requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    timeline.case_card_id,
+                    timeline.timeline_rank,
+                    timeline.timeline_status,
+                    timeline.highest_risk,
+                    timeline.assigned_lane,
+                    timeline.primary_action,
+                    timeline.latest_movement,
+                    timeline.blocker_code,
+                    timeline.event_count,
+                    int(timeline.has_war_room_item),
+                    json.dumps(timeline.timeline_payload, ensure_ascii=False, sort_keys=True),
+                    int(timeline.send_whatsapp),
+                    int(timeline.crm_mutation),
+                    int(timeline.requires_human_approval),
+                )
+                for timeline in timelines
+            ],
+        )
+        conn.executemany(
+            """
+            INSERT INTO case_timeline_events (
+                event_id, case_card_id, event_rank, event_stage, event_status,
+                event_lane, action_code, event_signal, event_payload_json,
+                send_whatsapp, crm_mutation, requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    event.event_id,
+                    event.case_card_id,
+                    event.event_rank,
+                    event.event_stage,
+                    event.event_status,
+                    event.event_lane,
+                    event.action_code,
+                    event.event_signal,
+                    json.dumps(event.event_payload, ensure_ascii=False, sort_keys=True),
+                    int(event.send_whatsapp),
+                    int(event.crm_mutation),
+                    int(event.requires_human_approval),
+                )
+                for event in events
+            ],
+        )
+        conn.commit()
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'unknown'} | {count} |")
+    return lines
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    timelines: Sequence[CaseTimeline],
+    events: Sequence[CaseTimelineEvent],
+    generated_at_utc: str,
+) -> None:
+    status_counts = Counter(timeline.timeline_status for timeline in timelines)
+    risk_counts = Counter(timeline.highest_risk for timeline in timelines)
+    lane_counts = Counter(timeline.assigned_lane for timeline in timelines)
+    action_counts = Counter(timeline.primary_action for timeline in timelines)
+    stage_counts = Counter(event.event_stage for event in events)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Case Timeline Synthesizer Summary",
+        "",
+        f"Generated UTC: `{generated_at_utc}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, case card IDs, inbox item IDs, room item IDs, shadow IDs, or window IDs.",
+        "- Timeline rows are local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Cases synthesized | {len(timelines)} |",
+        f"| Timeline events | {len(events)} |",
+        f"| War room cases | {sum(1 for timeline in timelines if timeline.has_war_room_item)} |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("Timeline Status", status_counts),
+        "",
+        *_counter_table("Risk Levels", risk_counts),
+        "",
+        *_counter_table("Assigned Lanes", lane_counts),
+        "",
+        *_counter_table("Primary Actions", action_counts),
+        "",
+        *_counter_table("Event Stages", stage_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- The Case Timeline Synthesizer composes local operational artifacts into a case timeline.",
+        "- It does not parse raw WhatsApp messages.",
+        "- Runtime must not send WhatsApp messages from this artifact.",
+        "- Runtime must not mutate CRM records from this artifact.",
+        "- A human must approve any client-facing message or operational mutation.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_case_timeline_synthesizer(
+    *,
+    case_memory_db: Path = DEFAULT_CASE_MEMORY_DB,
+    operator_inbox_db: Path = DEFAULT_OPERATOR_INBOX_DB,
+    operator_sla_clock_db: Path = DEFAULT_OPERATOR_SLA_CLOCK_DB,
+    breach_war_room_db: Path = DEFAULT_BREACH_WAR_ROOM_DB,
+    output_dir: Path = DEFAULT_CASE_TIMELINES_DIR,
+    output_db: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+    generated_at_utc: str | None = None,
+) -> CaseTimelineBuildResult:
+    """Build local-only operational timelines from case artifacts."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    generated = _format_utc(generated_at_utc)
+    cards = read_case_memory(case_memory_db)
+    inbox_by_case = read_operator_inbox(operator_inbox_db)
+    sla_by_case = read_sla_clock(operator_sla_clock_db)
+    war_room_by_case = read_war_room(breach_war_room_db)
+    timelines, events = build_timelines(cards, inbox_by_case, sla_by_case, war_room_by_case)
+    write_timeline_sqlite(
+        output_db,
+        timelines=timelines,
+        events=events,
+        generated_at_utc=generated,
+    )
+    write_summary(
+        summary_path=summary_path,
+        timelines=timelines,
+        events=events,
+        generated_at_utc=generated,
+    )
+    return CaseTimelineBuildResult(
+        case_count=len(timelines),
+        event_count=len(events),
+        send_whatsapp_count=sum(1 for timeline in timelines if timeline.send_whatsapp),
+        crm_mutation_count=sum(1 for timeline in timelines if timeline.crm_mutation),
+        status_counts=dict(Counter(timeline.timeline_status for timeline in timelines)),
+        lane_counts=dict(Counter(timeline.assigned_lane for timeline in timelines)),
+        output_db=output_db,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build local-only Zantara case timelines from operational artifacts."
+    )
+    parser.add_argument("--case-memory-db", type=Path, default=DEFAULT_CASE_MEMORY_DB)
+    parser.add_argument("--operator-inbox-db", type=Path, default=DEFAULT_OPERATOR_INBOX_DB)
+    parser.add_argument("--operator-sla-clock-db", type=Path, default=DEFAULT_OPERATOR_SLA_CLOCK_DB)
+    parser.add_argument("--breach-war-room-db", type=Path, default=DEFAULT_BREACH_WAR_ROOM_DB)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_CASE_TIMELINES_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--generated-at-utc", default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_case_timeline_synthesizer(
+            case_memory_db=args.case_memory_db,
+            operator_inbox_db=args.operator_inbox_db,
+            operator_sla_clock_db=args.operator_sla_clock_db,
+            breach_war_room_db=args.breach_war_room_db,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            summary_path=args.summary,
+            generated_at_utc=args.generated_at_utc,
+        )
+    except (FileNotFoundError, ValueError, sqlite3.Error, OSError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "case_count": result.case_count,
+                    "event_count": result.event_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                    "output_db": str(result.output_db),
+                    "summary_path": str(result.summary_path),
+                },
+                sort_keys=True,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/whatsapp_corpus/build_client_captain_academy.py
+++ b/scripts/whatsapp_corpus/build_client_captain_academy.py
@@ -1,0 +1,554 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_ANALYSIS_DIR = Path("research/personal/wa-corpus/analysis")
+DEFAULT_CLIENT_CAPTAIN_DIR = Path("research/personal/wa-corpus/client-captain")
+DEFAULT_CASE_WINDOWS_DB = DEFAULT_ANALYSIS_DIR / "allowed_case_windows.local.sqlite"
+DEFAULT_OUTPUT_DB = DEFAULT_CLIENT_CAPTAIN_DIR / "client_captain_academy.local.sqlite"
+DEFAULT_JSONL = DEFAULT_CLIENT_CAPTAIN_DIR / "training_examples.local.jsonl"
+DEFAULT_SUMMARY = DEFAULT_CLIENT_CAPTAIN_DIR / "client_captain_academy_summary.md"
+
+EXPECTED_CASE_WINDOWS_DB_NAME = "allowed_case_windows.local.sqlite"
+CASE_OWNER = "zantara_client_captain"
+
+
+@dataclass(frozen=True)
+class CaseWindowRow:
+    window_id: str
+    file_id: str
+    window_ordinal: int
+    first_timestamp: str | None
+    last_timestamp: str | None
+    first_month: str
+    last_month: str
+    first_message_index: int
+    last_message_index: int
+    event_count: int
+    message_count: int
+    domain_count: int
+    dominant_domain: str
+    severity_high_count: int
+    top_event_codes_json: str
+
+
+@dataclass(frozen=True)
+class DomainFeature:
+    domain_code: str
+    event_count: int
+    message_count: int
+
+
+@dataclass(frozen=True)
+class EventCodeFeature:
+    rank: int
+    domain_code: str
+    event_code: str
+    event_count: int
+
+
+@dataclass(frozen=True)
+class CaptainExample:
+    example_id: str
+    window: CaseWindowRow
+    domains: tuple[DomainFeature, ...]
+    event_codes: tuple[EventCodeFeature, ...]
+    priority: str
+    next_action: str
+    human_specialist: str
+    operator_coaching_mode: str
+
+    @property
+    def cut_message_index(self) -> int:
+        return (self.window.first_message_index + self.window.last_message_index) // 2
+
+    def input_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": "client_captain_academy.v1",
+            "privacy_mode": "local_only_aggregate_no_raw_text",
+            "case_owner": CASE_OWNER,
+            "case_window": {
+                "first_month": self.window.first_month,
+                "last_month": self.window.last_month,
+                "event_count": self.window.event_count,
+                "message_count": self.window.message_count,
+                "domain_count": self.window.domain_count,
+                "dominant_domain": self.window.dominant_domain,
+                "severity_high_count": self.window.severity_high_count,
+            },
+            "domain_features": [
+                {
+                    "domain_code": domain.domain_code,
+                    "event_count": domain.event_count,
+                    "message_count": domain.message_count,
+                }
+                for domain in self.domains
+            ],
+            "top_event_codes": [
+                {
+                    "rank": event.rank,
+                    "domain_code": event.domain_code,
+                    "event_code": event.event_code,
+                    "event_count": event.event_count,
+                }
+                for event in self.event_codes
+            ],
+        }
+
+    def output_payload(self) -> dict[str, object]:
+        return {
+            "case_owner": CASE_OWNER,
+            "next_action": self.next_action,
+            "priority": self.priority,
+            "human_specialist": self.human_specialist,
+            "operator_coaching_mode": self.operator_coaching_mode,
+            "send_whatsapp": False,
+            "crm_mutation": False,
+        }
+
+    def jsonl_record(self) -> dict[str, object]:
+        return {
+            "example_id": self.example_id,
+            "academy_task": "case_captain_next_action",
+            "case_owner": CASE_OWNER,
+            "captain_input": self.input_payload(),
+            "captain_output": self.output_payload(),
+        }
+
+
+@dataclass(frozen=True)
+class AcademyBuildResult:
+    example_count: int
+    replay_count: int
+    owner_counts: dict[str, int]
+    priority_counts: dict[str, int]
+    output_db: Path
+    output_jsonl: Path
+    summary_path: Path
+
+
+def _connect_case_windows(db_path: Path) -> sqlite3.Connection:
+    if db_path.name != EXPECTED_CASE_WINDOWS_DB_NAME:
+        raise ValueError(f"Refusing to read unexpected input artifact: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"Input DB not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _read_case_windows(db_path: Path) -> tuple[CaseWindowRow, ...]:
+    with _connect_case_windows(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT window_id, file_id, window_ordinal, first_timestamp, last_timestamp,
+                   first_month, last_month, first_message_index, last_message_index,
+                   event_count, message_count, domain_count, dominant_domain,
+                   severity_high_count, top_event_codes_json
+            FROM case_windows
+            ORDER BY severity_high_count DESC, event_count DESC, message_count DESC,
+                     domain_count DESC, window_id
+            """
+        ).fetchall()
+    return tuple(
+        CaseWindowRow(
+            window_id=str(row["window_id"]),
+            file_id=str(row["file_id"]),
+            window_ordinal=int(row["window_ordinal"]),
+            first_timestamp=row["first_timestamp"],
+            last_timestamp=row["last_timestamp"],
+            first_month=str(row["first_month"]),
+            last_month=str(row["last_month"]),
+            first_message_index=int(row["first_message_index"]),
+            last_message_index=int(row["last_message_index"]),
+            event_count=int(row["event_count"]),
+            message_count=int(row["message_count"]),
+            domain_count=int(row["domain_count"]),
+            dominant_domain=str(row["dominant_domain"]),
+            severity_high_count=int(row["severity_high_count"]),
+            top_event_codes_json=str(row["top_event_codes_json"]),
+        )
+        for row in rows
+    )
+
+
+def _read_domain_features(db_path: Path) -> dict[str, tuple[DomainFeature, ...]]:
+    with _connect_case_windows(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT window_id, domain_code, event_count, message_count
+            FROM case_window_domains
+            ORDER BY window_id, event_count DESC, domain_code
+            """
+        ).fetchall()
+    grouped: dict[str, list[DomainFeature]] = defaultdict(list)
+    for row in rows:
+        grouped[str(row["window_id"])].append(
+            DomainFeature(
+                domain_code=str(row["domain_code"]),
+                event_count=int(row["event_count"]),
+                message_count=int(row["message_count"]),
+            )
+        )
+    return {window_id: tuple(features) for window_id, features in grouped.items()}
+
+
+def _read_event_code_features(db_path: Path) -> dict[str, tuple[EventCodeFeature, ...]]:
+    with _connect_case_windows(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT window_id, rank, domain_code, event_code, event_count
+            FROM case_window_event_codes
+            ORDER BY window_id, rank
+            """
+        ).fetchall()
+    grouped: dict[str, list[EventCodeFeature]] = defaultdict(list)
+    for row in rows:
+        grouped[str(row["window_id"])].append(
+            EventCodeFeature(
+                rank=int(row["rank"]),
+                domain_code=str(row["domain_code"]),
+                event_code=str(row["event_code"]),
+                event_count=int(row["event_count"]),
+            )
+        )
+    return {window_id: tuple(features) for window_id, features in grouped.items()}
+
+
+def _next_action_for_domain(domain_code: str) -> tuple[str, str]:
+    return {
+        "immigration_lifecycle": ("immigration_status_check", "ari"),
+        "document_requirement": ("document_chase", "adit"),
+        "tax_payment": ("payment_reconcile", "surya"),
+        "followup_risk": ("crm_followup", "sahira"),
+        "operational_risk": ("team_escalation", "sahira"),
+        "crm_lead_intake": ("lead_context_review", "sahira"),
+        "knowledge_mining": ("kb_extract", "adit"),
+        "relationship_memory": ("case_note", "sahira"),
+    }.get(domain_code, ("case_note", "sahira"))
+
+
+def _priority(window: CaseWindowRow) -> str:
+    if window.severity_high_count > 0:
+        return "high"
+    if window.dominant_domain in {"followup_risk", "operational_risk"}:
+        return "high"
+    return "normal"
+
+
+def _operator_coaching_mode(window: CaseWindowRow, priority: str) -> str:
+    if priority == "high" and window.dominant_domain == "followup_risk":
+        return "firm_accountability_nudge"
+    if priority == "high":
+        return "supportive_urgent_nudge"
+    return "steady_family_motivation"
+
+
+def build_examples(
+    case_windows_db: Path,
+    *,
+    max_examples: int | None = None,
+) -> tuple[CaptainExample, ...]:
+    windows = _read_case_windows(case_windows_db)
+    domain_features = _read_domain_features(case_windows_db)
+    event_code_features = _read_event_code_features(case_windows_db)
+    selected = windows[:max_examples] if max_examples is not None else windows
+    examples: list[CaptainExample] = []
+    for window in selected:
+        next_action, human_specialist = _next_action_for_domain(window.dominant_domain)
+        priority = _priority(window)
+        examples.append(
+            CaptainExample(
+                example_id=f"cca-{window.window_id}",
+                window=window,
+                domains=domain_features.get(window.window_id, ()),
+                event_codes=event_code_features.get(window.window_id, ()),
+                priority=priority,
+                next_action=next_action,
+                human_specialist=human_specialist,
+                operator_coaching_mode=_operator_coaching_mode(window, priority),
+            )
+        )
+    return tuple(examples)
+
+
+def write_jsonl(path: Path, examples: Sequence[CaptainExample]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        json.dumps(example.jsonl_record(), ensure_ascii=False, sort_keys=True)
+        for example in examples
+    ]
+    path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+
+def write_sqlite(path: Path, examples: Sequence[CaptainExample]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        path.unlink()
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE academy_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                example_count INTEGER NOT NULL,
+                replay_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE captain_training_examples (
+                example_id TEXT PRIMARY KEY,
+                source_window_id TEXT NOT NULL,
+                file_id TEXT NOT NULL,
+                case_owner TEXT NOT NULL,
+                dominant_domain TEXT NOT NULL,
+                priority TEXT NOT NULL,
+                next_action TEXT NOT NULL,
+                human_specialist TEXT NOT NULL,
+                operator_coaching_mode TEXT NOT NULL,
+                first_month TEXT NOT NULL,
+                last_month TEXT NOT NULL,
+                first_message_index INTEGER NOT NULL,
+                last_message_index INTEGER NOT NULL,
+                event_count INTEGER NOT NULL,
+                message_count INTEGER NOT NULL,
+                domain_count INTEGER NOT NULL,
+                severity_high_count INTEGER NOT NULL,
+                captain_input_json TEXT NOT NULL,
+                captain_output_json TEXT NOT NULL
+            );
+
+            CREATE TABLE captain_replay_scenarios (
+                replay_id TEXT PRIMARY KEY,
+                example_id TEXT NOT NULL,
+                cut_message_index INTEGER NOT NULL,
+                expected_next_action TEXT NOT NULL,
+                expected_priority TEXT NOT NULL,
+                expected_human_specialist TEXT NOT NULL,
+                expected_case_owner TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO academy_runs (
+                id, generated_at_utc, privacy_mode, example_count, replay_count
+            )
+            VALUES (1, ?, ?, ?, ?)
+            """,
+            (
+                datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                "local_only_case_windows_no_raw_text_no_raw_paths",
+                len(examples),
+                len(examples),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO captain_training_examples (
+                example_id, source_window_id, file_id, case_owner, dominant_domain,
+                priority, next_action, human_specialist, operator_coaching_mode,
+                first_month, last_month, first_message_index, last_message_index,
+                event_count, message_count, domain_count, severity_high_count,
+                captain_input_json, captain_output_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    example.example_id,
+                    example.window.window_id,
+                    example.window.file_id,
+                    CASE_OWNER,
+                    example.window.dominant_domain,
+                    example.priority,
+                    example.next_action,
+                    example.human_specialist,
+                    example.operator_coaching_mode,
+                    example.window.first_month,
+                    example.window.last_month,
+                    example.window.first_message_index,
+                    example.window.last_message_index,
+                    example.window.event_count,
+                    example.window.message_count,
+                    example.window.domain_count,
+                    example.window.severity_high_count,
+                    json.dumps(example.input_payload(), ensure_ascii=False, sort_keys=True),
+                    json.dumps(example.output_payload(), ensure_ascii=False, sort_keys=True),
+                )
+                for example in examples
+            ],
+        )
+        conn.executemany(
+            """
+            INSERT INTO captain_replay_scenarios (
+                replay_id, example_id, cut_message_index, expected_next_action,
+                expected_priority, expected_human_specialist, expected_case_owner
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    f"replay-{example.example_id}",
+                    example.example_id,
+                    example.cut_message_index,
+                    example.next_action,
+                    example.priority,
+                    example.human_specialist,
+                    CASE_OWNER,
+                )
+                for example in examples
+            ],
+        )
+        conn.commit()
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    rows = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        rows.append(f"| {value or 'unknown'} | {count} |")
+    if not counts:
+        rows.append("| none | 0 |")
+    return rows
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    examples: Sequence[CaptainExample],
+    generated_at_utc: str | None = None,
+) -> None:
+    generated = generated_at_utc or datetime.now(timezone.utc).isoformat(timespec="seconds")
+    owner_counts = Counter(CASE_OWNER for _ in examples)
+    priority_counts = Counter(example.priority for example in examples)
+    action_counts = Counter(example.next_action for example in examples)
+    specialist_counts = Counter(example.human_specialist for example in examples)
+    domain_counts = Counter(example.window.dominant_domain for example in examples)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Client Captain Academy Summary",
+        "",
+        f"Generated UTC: `{generated}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, or raw paths.",
+        "- This summary contains no per-window IDs, per-file IDs, or event-code values.",
+        "- Local `.local.sqlite` and `.local.jsonl` artifacts stay ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Training examples | {len(examples)} |",
+        f"| Replay scenarios | {len(examples)} |",
+        "",
+        *_counter_table("Case Owners", owner_counts),
+        "",
+        *_counter_table("Priorities", priority_counts),
+        "",
+        *_counter_table("Next Actions", action_counts),
+        "",
+        *_counter_table("Human Specialists", specialist_counts),
+        "",
+        *_counter_table("Dominant Domains", domain_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- The Captain is always the case owner.",
+        "- Human names are specialist lanes, not ownership assignment.",
+        "- Shadow mode remains the only allowed runtime target for this dataset.",
+        "- Do not train a cloud model on the generated local JSONL.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_client_captain_academy(
+    *,
+    case_windows_db: Path = DEFAULT_CASE_WINDOWS_DB,
+    output_dir: Path = DEFAULT_CLIENT_CAPTAIN_DIR,
+    output_db: Path | None = None,
+    output_jsonl: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+    max_examples: int | None = None,
+) -> AcademyBuildResult:
+    """Build local-only Client Captain examples from anonymous case windows."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    output_jsonl = output_jsonl or output_dir / DEFAULT_JSONL.name
+    examples = build_examples(case_windows_db, max_examples=max_examples)
+    write_sqlite(output_db, examples)
+    write_jsonl(output_jsonl, examples)
+    write_summary(summary_path=summary_path, examples=examples)
+    owner_counts = Counter(CASE_OWNER for _ in examples)
+    priority_counts = Counter(example.priority for example in examples)
+    return AcademyBuildResult(
+        example_count=len(examples),
+        replay_count=len(examples),
+        owner_counts=dict(owner_counts),
+        priority_counts=dict(priority_counts),
+        output_db=output_db,
+        output_jsonl=output_jsonl,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build local-only Zantara Client Captain Academy examples."
+    )
+    parser.add_argument("--case-windows-db", type=Path, default=DEFAULT_CASE_WINDOWS_DB)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_CLIENT_CAPTAIN_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--output-jsonl", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--max-examples", type=int, default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_client_captain_academy(
+            case_windows_db=args.case_windows_db,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            output_jsonl=args.output_jsonl,
+            summary_path=args.summary,
+            max_examples=args.max_examples,
+        )
+    except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
+        print("ERROR: Client Captain Academy input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError):
+        print("ERROR: Client Captain Academy run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        print("ERROR: Client Captain Academy run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "example_count": result.example_count,
+                    "replay_count": result.replay_count,
+                },
+                sort_keys=True,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/whatsapp_corpus/build_client_captain_shadow.py
+++ b/scripts/whatsapp_corpus/build_client_captain_shadow.py
@@ -1,0 +1,631 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_CLIENT_CAPTAIN_DIR = Path("research/personal/wa-corpus/client-captain")
+DEFAULT_SHADOW_DIR = Path("research/personal/wa-corpus/client-captain-shadow")
+DEFAULT_ACADEMY_DB = DEFAULT_CLIENT_CAPTAIN_DIR / "client_captain_academy.local.sqlite"
+DEFAULT_OUTPUT_DB = DEFAULT_SHADOW_DIR / "client_captain_shadow.local.sqlite"
+DEFAULT_SUMMARY = DEFAULT_SHADOW_DIR / "client_captain_shadow_summary.md"
+
+EXPECTED_ACADEMY_DB_NAME = "client_captain_academy.local.sqlite"
+CASE_OWNER = "zantara_client_captain"
+
+
+@dataclass(frozen=True)
+class AcademyReplayRow:
+    example_id: str
+    replay_id: str
+    source_window_id: str
+    file_id: str
+    case_owner: str
+    dominant_domain: str
+    priority: str
+    next_action: str
+    human_specialist: str
+    operator_coaching_mode: str
+    first_month: str
+    last_month: str
+    first_message_index: int
+    last_message_index: int
+    cut_message_index: int
+    event_count: int
+    message_count: int
+    domain_count: int
+    severity_high_count: int
+
+
+@dataclass(frozen=True)
+class ShadowDraft:
+    shadow_id: str
+    source_example_id: str
+    source_replay_id: str
+    source_window_id: str
+    source_file_id: str
+    case_owner: str
+    status: str
+    priority: str
+    risk_level: str
+    action_type: str
+    human_specialist: str
+    diagnosis_code: str
+    draft_reply_intent: str
+    operator_coaching_mode: str
+    operator_nudge: str
+    first_month: str
+    last_month: str
+    first_message_index: int
+    last_message_index: int
+    cut_message_index: int
+    dominant_domain: str
+    event_count: int
+    message_count: int
+    domain_count: int
+    severity_high_count: int
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class ShadowDepthLayer:
+    shadow_id: str
+    depth_level: int
+    layer_code: str
+    layer_title: str
+    layer_payload: dict[str, object]
+
+
+@dataclass(frozen=True)
+class ShadowBuildResult:
+    draft_count: int
+    depth_layer_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    priority_counts: dict[str, int]
+    action_counts: dict[str, int]
+    output_db: Path
+    summary_path: Path
+
+
+def _connect_academy(db_path: Path) -> sqlite3.Connection:
+    if db_path.name != EXPECTED_ACADEMY_DB_NAME:
+        raise ValueError(f"Refusing to read unexpected Academy DB: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"Academy DB not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def read_academy_replays(db_path: Path, *, limit: int | None = None) -> tuple[AcademyReplayRow, ...]:
+    with _connect_academy(db_path) as conn:
+        sql = """
+            SELECT
+                t.example_id,
+                r.replay_id,
+                t.source_window_id,
+                t.file_id,
+                t.case_owner,
+                t.dominant_domain,
+                t.priority,
+                t.next_action,
+                t.human_specialist,
+                t.operator_coaching_mode,
+                t.first_month,
+                t.last_month,
+                t.first_message_index,
+                t.last_message_index,
+                r.cut_message_index,
+                t.event_count,
+                t.message_count,
+                t.domain_count,
+                t.severity_high_count
+            FROM captain_training_examples AS t
+            JOIN captain_replay_scenarios AS r
+                ON r.example_id = t.example_id
+            ORDER BY
+                CASE t.priority WHEN 'high' THEN 0 WHEN 'normal' THEN 1 ELSE 2 END,
+                t.severity_high_count DESC,
+                t.event_count DESC,
+                t.example_id
+        """
+        if limit is not None:
+            sql += " LIMIT ?"
+            rows = conn.execute(sql, (limit,)).fetchall()
+        else:
+            rows = conn.execute(sql).fetchall()
+    return tuple(
+        AcademyReplayRow(
+            example_id=str(row["example_id"]),
+            replay_id=str(row["replay_id"]),
+            source_window_id=str(row["source_window_id"]),
+            file_id=str(row["file_id"]),
+            case_owner=str(row["case_owner"]),
+            dominant_domain=str(row["dominant_domain"]),
+            priority=str(row["priority"]),
+            next_action=str(row["next_action"]),
+            human_specialist=str(row["human_specialist"]),
+            operator_coaching_mode=str(row["operator_coaching_mode"]),
+            first_month=str(row["first_month"]),
+            last_month=str(row["last_month"]),
+            first_message_index=int(row["first_message_index"]),
+            last_message_index=int(row["last_message_index"]),
+            cut_message_index=int(row["cut_message_index"]),
+            event_count=int(row["event_count"]),
+            message_count=int(row["message_count"]),
+            domain_count=int(row["domain_count"]),
+            severity_high_count=int(row["severity_high_count"]),
+        )
+        for row in rows
+    )
+
+
+def _risk_level(priority: str) -> str:
+    if priority == "high":
+        return "P1"
+    if priority == "normal":
+        return "P2"
+    return "P3"
+
+
+def _diagnosis_code(row: AcademyReplayRow) -> str:
+    if row.dominant_domain == "followup_risk" or row.next_action == "crm_followup":
+        return "case_stall_followup_risk"
+    if row.next_action == "payment_reconcile":
+        return "payment_reconciliation_needed"
+    if row.next_action == "document_chase":
+        return "missing_document_chase_needed"
+    if row.next_action == "immigration_status_check":
+        return "immigration_status_gap"
+    if row.next_action == "team_escalation":
+        return "operator_escalation_needed"
+    if row.next_action == "kb_extract":
+        return "knowledge_capture_needed"
+    return "case_note_needed"
+
+
+def _draft_reply_intent(row: AcademyReplayRow) -> str:
+    return {
+        "crm_followup": (
+            "Draft a concise status follow-up after a human confirms the latest system update."
+        ),
+        "payment_reconcile": (
+            "Draft a payment status clarification after finance verifies the ledger and proof."
+        ),
+        "document_chase": (
+            "Draft a missing-document request after the operator verifies the case checklist."
+        ),
+        "immigration_status_check": (
+            "Draft an immigration status update after the specialist confirms the current stage."
+        ),
+        "team_escalation": (
+            "Draft no client reply; create an internal escalation brief for the team first."
+        ),
+        "kb_extract": (
+            "Draft no client reply; capture the reusable knowledge point for review first."
+        ),
+    }.get(row.next_action, "Draft an internal case note for human review before any reply.")
+
+
+def _operator_nudge(row: AcademyReplayRow) -> str:
+    if row.operator_coaching_mode == "firm_accountability_nudge":
+        return "Firm: operator must make a system update before continuing; no silent handling."
+    if row.operator_coaching_mode == "supportive_urgent_nudge":
+        return "Urgent: help the operator close the loop quickly and log the next step."
+    return "Supportive: keep the operator moving and reinforce the family-standard workflow."
+
+
+def build_shadow_drafts(rows: Sequence[AcademyReplayRow]) -> tuple[ShadowDraft, ...]:
+    drafts: list[ShadowDraft] = []
+    for row in rows:
+        if row.case_owner != CASE_OWNER:
+            continue
+        drafts.append(
+            ShadowDraft(
+                shadow_id=f"shadow-{row.example_id}",
+                source_example_id=row.example_id,
+                source_replay_id=row.replay_id,
+                source_window_id=row.source_window_id,
+                source_file_id=row.file_id,
+                case_owner=CASE_OWNER,
+                status="shadow_draft",
+                priority=row.priority,
+                risk_level=_risk_level(row.priority),
+                action_type=row.next_action,
+                human_specialist=row.human_specialist,
+                diagnosis_code=_diagnosis_code(row),
+                draft_reply_intent=_draft_reply_intent(row),
+                operator_coaching_mode=row.operator_coaching_mode,
+                operator_nudge=_operator_nudge(row),
+                first_month=row.first_month,
+                last_month=row.last_month,
+                first_message_index=row.first_message_index,
+                last_message_index=row.last_message_index,
+                cut_message_index=row.cut_message_index,
+                dominant_domain=row.dominant_domain,
+                event_count=row.event_count,
+                message_count=row.message_count,
+                domain_count=row.domain_count,
+                severity_high_count=row.severity_high_count,
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(drafts)
+
+
+def build_depth_layers(drafts: Sequence[ShadowDraft]) -> tuple[ShadowDepthLayer, ...]:
+    layers: list[ShadowDepthLayer] = []
+    for draft in drafts:
+        base_payload = {
+            "case_owner": draft.case_owner,
+            "send_whatsapp": False,
+            "crm_mutation": False,
+            "requires_human_approval": True,
+        }
+        layer_specs = [
+            (
+                1,
+                "signal_readout",
+                "Signal readout",
+                {
+                    "risk_level": draft.risk_level,
+                    "dominant_domain": draft.dominant_domain,
+                    "event_count": draft.event_count,
+                    "message_count": draft.message_count,
+                },
+            ),
+            (
+                2,
+                "case_diagnosis",
+                "Case diagnosis",
+                {
+                    "diagnosis_code": draft.diagnosis_code,
+                    "severity_high_count": draft.severity_high_count,
+                    "domain_count": draft.domain_count,
+                },
+            ),
+            (
+                3,
+                "captain_decision",
+                "Captain decision",
+                {
+                    "action_type": draft.action_type,
+                    "human_specialist": draft.human_specialist,
+                    "priority": draft.priority,
+                },
+            ),
+            (
+                4,
+                "draft_gate",
+                "Draft gate",
+                {
+                    "draft_reply_intent": draft.draft_reply_intent,
+                    "status": draft.status,
+                },
+            ),
+            (
+                5,
+                "operator_coaching",
+                "Operator coaching",
+                {
+                    "operator_coaching_mode": draft.operator_coaching_mode,
+                    "operator_nudge": draft.operator_nudge,
+                },
+            ),
+        ]
+        for depth_level, code, title, payload in layer_specs:
+            layers.append(
+                ShadowDepthLayer(
+                    shadow_id=draft.shadow_id,
+                    depth_level=depth_level,
+                    layer_code=code,
+                    layer_title=title,
+                    layer_payload={**base_payload, **payload},
+                )
+            )
+    return tuple(layers)
+
+
+def write_shadow_sqlite(
+    path: Path,
+    drafts: Sequence[ShadowDraft],
+    layers: Sequence[ShadowDepthLayer],
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        path.unlink()
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE shadow_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                draft_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE shadow_drafts (
+                shadow_id TEXT PRIMARY KEY,
+                source_example_id TEXT NOT NULL,
+                source_replay_id TEXT NOT NULL,
+                source_window_id TEXT NOT NULL,
+                source_file_id TEXT NOT NULL,
+                case_owner TEXT NOT NULL,
+                status TEXT NOT NULL,
+                priority TEXT NOT NULL,
+                risk_level TEXT NOT NULL,
+                action_type TEXT NOT NULL,
+                human_specialist TEXT NOT NULL,
+                diagnosis_code TEXT NOT NULL,
+                draft_reply_intent TEXT NOT NULL,
+                operator_coaching_mode TEXT NOT NULL,
+                operator_nudge TEXT NOT NULL,
+                first_month TEXT NOT NULL,
+                last_month TEXT NOT NULL,
+                first_message_index INTEGER NOT NULL,
+                last_message_index INTEGER NOT NULL,
+                cut_message_index INTEGER NOT NULL,
+                dominant_domain TEXT NOT NULL,
+                event_count INTEGER NOT NULL,
+                message_count INTEGER NOT NULL,
+                domain_count INTEGER NOT NULL,
+                severity_high_count INTEGER NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE TABLE shadow_depth_layers (
+                shadow_id TEXT NOT NULL,
+                depth_level INTEGER NOT NULL,
+                layer_code TEXT NOT NULL,
+                layer_title TEXT NOT NULL,
+                layer_payload_json TEXT NOT NULL,
+                PRIMARY KEY (shadow_id, depth_level)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO shadow_runs (
+                id, generated_at_utc, privacy_mode, draft_count,
+                send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, 0, 0)
+            """,
+            (
+                datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                "local_only_shadow_drafts_no_send_no_crm_mutation",
+                len(drafts),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO shadow_drafts (
+                shadow_id, source_example_id, source_replay_id, source_window_id,
+                source_file_id, case_owner, status, priority, risk_level, action_type,
+                human_specialist, diagnosis_code, draft_reply_intent,
+                operator_coaching_mode, operator_nudge, first_month, last_month,
+                first_message_index, last_message_index, cut_message_index,
+                dominant_domain, event_count, message_count, domain_count,
+                severity_high_count, send_whatsapp, crm_mutation,
+                requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    draft.shadow_id,
+                    draft.source_example_id,
+                    draft.source_replay_id,
+                    draft.source_window_id,
+                    draft.source_file_id,
+                    draft.case_owner,
+                    draft.status,
+                    draft.priority,
+                    draft.risk_level,
+                    draft.action_type,
+                    draft.human_specialist,
+                    draft.diagnosis_code,
+                    draft.draft_reply_intent,
+                    draft.operator_coaching_mode,
+                    draft.operator_nudge,
+                    draft.first_month,
+                    draft.last_month,
+                    draft.first_message_index,
+                    draft.last_message_index,
+                    draft.cut_message_index,
+                    draft.dominant_domain,
+                    draft.event_count,
+                    draft.message_count,
+                    draft.domain_count,
+                    draft.severity_high_count,
+                    int(draft.send_whatsapp),
+                    int(draft.crm_mutation),
+                    int(draft.requires_human_approval),
+                )
+                for draft in drafts
+            ],
+        )
+        conn.executemany(
+            """
+            INSERT INTO shadow_depth_layers (
+                shadow_id, depth_level, layer_code, layer_title, layer_payload_json
+            )
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    layer.shadow_id,
+                    layer.depth_level,
+                    layer.layer_code,
+                    layer.layer_title,
+                    json.dumps(layer.layer_payload, ensure_ascii=False, sort_keys=True),
+                )
+                for layer in layers
+            ],
+        )
+        conn.commit()
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'unknown'} | {count} |")
+    return lines
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    drafts: Sequence[ShadowDraft],
+    generated_at_utc: str | None = None,
+) -> None:
+    generated = generated_at_utc or datetime.now(timezone.utc).isoformat(timespec="seconds")
+    priority_counts = Counter(draft.priority for draft in drafts)
+    risk_counts = Counter(draft.risk_level for draft in drafts)
+    action_counts = Counter(draft.action_type for draft in drafts)
+    diagnosis_counts = Counter(draft.diagnosis_code for draft in drafts)
+    coaching_counts = Counter(draft.operator_coaching_mode for draft in drafts)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Client Captain Shadow Mode Summary",
+        "",
+        f"Generated UTC: `{generated}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, file IDs, window IDs, or replay IDs.",
+        "- Shadow output is local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Shadow drafts | {len(drafts)} |",
+        f"| Depth layers | {len(drafts) * 5} |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("Priorities", priority_counts),
+        "",
+        *_counter_table("Risk Levels", risk_counts),
+        "",
+        *_counter_table("Action Types", action_counts),
+        "",
+        *_counter_table("Diagnosis Codes", diagnosis_counts),
+        "",
+        *_counter_table("Operator Coaching Modes", coaching_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- The Captain remains the case owner.",
+        "- Shadow mode can diagnose, draft, coach, and queue review only.",
+        "- Runtime must not send WhatsApp messages from this artifact.",
+        "- Runtime must not mutate CRM records from this artifact.",
+        "- A human must approve any client-facing message or operational mutation.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_client_captain_shadow(
+    *,
+    academy_db: Path = DEFAULT_ACADEMY_DB,
+    output_dir: Path = DEFAULT_SHADOW_DIR,
+    output_db: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+    max_drafts: int | None = None,
+) -> ShadowBuildResult:
+    """Build deterministic local-only Shadow Mode drafts from Academy replays."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    rows = read_academy_replays(academy_db, limit=max_drafts)
+    drafts = build_shadow_drafts(rows)
+    layers = build_depth_layers(drafts)
+    write_shadow_sqlite(output_db, drafts, layers)
+    write_summary(summary_path=summary_path, drafts=drafts)
+    send_whatsapp_count = sum(1 for draft in drafts if draft.send_whatsapp)
+    crm_mutation_count = sum(1 for draft in drafts if draft.crm_mutation)
+    return ShadowBuildResult(
+        draft_count=len(drafts),
+        depth_layer_count=len(layers),
+        send_whatsapp_count=send_whatsapp_count,
+        crm_mutation_count=crm_mutation_count,
+        priority_counts=dict(Counter(draft.priority for draft in drafts)),
+        action_counts=dict(Counter(draft.action_type for draft in drafts)),
+        output_db=output_db,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build local-only Zantara Client Captain Shadow Mode drafts."
+    )
+    parser.add_argument("--academy-db", type=Path, default=DEFAULT_ACADEMY_DB)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_SHADOW_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--max-drafts", type=int, default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_client_captain_shadow(
+            academy_db=args.academy_db,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            summary_path=args.summary,
+            max_drafts=args.max_drafts,
+        )
+    except (FileNotFoundError, ValueError, TypeError):
+        # Keep this fixed literal: exception text may include local paths or DB names.
+        print("ERROR: Client Captain input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError):
+        # Keep this fixed literal: exception text may include local paths or DB names.
+        print("ERROR: Client Captain shadow run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        # CLI boundary must fail closed; the Python API still exposes details.
+        print("ERROR: Client Captain shadow run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "draft_count": result.draft_count,
+                    "depth_layer_count": result.depth_layer_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                },
+                sort_keys=True,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/whatsapp_corpus/build_drive_export_manifest.py
+++ b/scripts/whatsapp_corpus/build_drive_export_manifest.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sqlite3
+import sys
+import unicodedata
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+DEFAULT_LSJSON = Path("research/personal/wa-corpus/drive/drive_lsjson.local.json")
+DEFAULT_OUTPUT_DIR = Path("research/personal/wa-corpus/drive")
+DEFAULT_OUTPUT_DB = DEFAULT_OUTPUT_DIR / "drive_export_manifest.local.sqlite"
+DEFAULT_SUMMARY = DEFAULT_OUTPUT_DIR / "drive_export_manifest_summary.md"
+
+
+@dataclass(frozen=True)
+class DriveExportCandidate:
+    file_id: str
+    candidate_kind: str
+    raw_path: str
+    raw_name: str
+    path_hash: str
+    name_hash: str
+    drive_id: str | None
+    drive_id_hash: str | None
+    size_bytes: int
+    mod_time: str | None
+    mime_type: str | None
+
+
+@dataclass(frozen=True)
+class DriveManifestResult:
+    scanned_records: int
+    candidate_count: int
+    total_size_bytes: int
+
+
+def short_hash(value: str, length: int = 24) -> str:
+    """Return a stable short hash for private identifiers."""
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:length]
+
+
+def load_lsjson(path: Path) -> list[dict[str, Any]]:
+    """Load rclone lsjson output from a local JSON file."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError("rclone lsjson payload must be a JSON array")
+    records: list[dict[str, Any]] = []
+    for item in data:
+        if not isinstance(item, dict):
+            raise ValueError("rclone lsjson entries must be JSON objects")
+        records.append(item)
+    return records
+
+
+def build_candidates(
+    records: Iterable[dict[str, Any]],
+    *,
+    remote_label: str,
+) -> list[DriveExportCandidate]:
+    """Build privacy-addressable WhatsApp export candidates from lsjson records."""
+    selected: list[dict[str, Any]] = []
+    seen_keys: set[str] = set()
+    for record in records:
+        if bool(record.get("IsDir")):
+            continue
+        raw_path = str(record.get("Path") or record.get("Name") or "").strip()
+        raw_name = str(record.get("Name") or Path(raw_path).name).strip()
+        if not raw_path or not raw_name:
+            continue
+        if not _is_whatsapp_chat_zip(raw_path, raw_name, str(record.get("MimeType") or "")):
+            continue
+        drive_id = str(record.get("ID") or "").strip()
+        dedupe_key = drive_id or raw_path
+        if dedupe_key in seen_keys:
+            continue
+        seen_keys.add(dedupe_key)
+        selected.append(record)
+
+    width = max(4, len(str(len(selected))))
+    candidates: list[DriveExportCandidate] = []
+    for index, record in enumerate(selected, start=1):
+        raw_path = str(record.get("Path") or record.get("Name") or "").strip()
+        raw_name = str(record.get("Name") or Path(raw_path).name).strip()
+        drive_id = str(record.get("ID") or "").strip() or None
+        size_bytes = _as_int(record.get("Size"))
+        private_locator = drive_id or raw_path
+        candidates.append(
+            DriveExportCandidate(
+                file_id=f"drive-wa-{index:0{width}d}",
+                candidate_kind="whatsapp_chat_zip",
+                raw_path=raw_path,
+                raw_name=raw_name,
+                path_hash=short_hash(f"{remote_label}\n{private_locator}\n{raw_path}"),
+                name_hash=short_hash(raw_name),
+                drive_id=drive_id,
+                drive_id_hash=short_hash(drive_id) if drive_id else None,
+                size_bytes=size_bytes,
+                mod_time=str(record.get("ModTime") or "").strip() or None,
+                mime_type=str(record.get("MimeType") or "").strip() or None,
+            )
+        )
+    return candidates
+
+
+def write_sqlite(
+    *,
+    db_path: Path,
+    remote_label: str,
+    scanned_records: int,
+    candidates: list[DriveExportCandidate],
+) -> None:
+    """Write the local-only manifest database."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    if db_path.exists():
+        db_path.unlink()
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE drive_manifest_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                remote_label_hash TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                scanned_records INTEGER NOT NULL,
+                candidate_count INTEGER NOT NULL,
+                total_size_bytes INTEGER NOT NULL
+            );
+
+            CREATE TABLE drive_export_candidates (
+                file_id TEXT PRIMARY KEY,
+                candidate_kind TEXT NOT NULL,
+                raw_path TEXT NOT NULL,
+                raw_name TEXT NOT NULL,
+                path_hash TEXT NOT NULL UNIQUE,
+                name_hash TEXT NOT NULL,
+                drive_id TEXT,
+                drive_id_hash TEXT,
+                size_bytes INTEGER NOT NULL,
+                mod_time TEXT,
+                mime_type TEXT,
+                download_status TEXT NOT NULL,
+                imported_to_corpus INTEGER NOT NULL
+            );
+
+            CREATE INDEX idx_drive_export_candidates_kind
+                ON drive_export_candidates(candidate_kind);
+            CREATE INDEX idx_drive_export_candidates_size
+                ON drive_export_candidates(size_bytes);
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO drive_manifest_runs (
+                id, generated_at_utc, remote_label_hash, privacy_mode,
+                scanned_records, candidate_count, total_size_bytes
+            )
+            VALUES (1, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                short_hash(remote_label, length=16),
+                "local_only_raw_drive_paths_in_ignored_sqlite_summary_aggregate_only",
+                scanned_records,
+                len(candidates),
+                sum(candidate.size_bytes for candidate in candidates),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO drive_export_candidates (
+                file_id, candidate_kind, raw_path, raw_name, path_hash, name_hash,
+                drive_id, drive_id_hash, size_bytes, mod_time, mime_type,
+                download_status, imported_to_corpus
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', 0)
+            """,
+            [
+                (
+                    candidate.file_id,
+                    candidate.candidate_kind,
+                    candidate.raw_path,
+                    candidate.raw_name,
+                    candidate.path_hash,
+                    candidate.name_hash,
+                    candidate.drive_id,
+                    candidate.drive_id_hash,
+                    candidate.size_bytes,
+                    candidate.mod_time,
+                    candidate.mime_type,
+                )
+                for candidate in candidates
+            ],
+        )
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    db_path: Path,
+    scanned_records: int,
+    candidates: list[DriveExportCandidate],
+) -> None:
+    """Write a shareable aggregate-only summary."""
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    kind_counts = Counter(candidate.candidate_kind for candidate in candidates)
+    total_size = sum(candidate.size_bytes for candidate in candidates)
+    lines: list[str] = [
+        "# Cloud Export Manifest Summary",
+        "",
+        f"Generated UTC: `{datetime.now(timezone.utc).isoformat(timespec='seconds')}`",
+        f"SQLite manifest file: `{db_path.name}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- Aggregate summary only.",
+        "- No raw cloud file names.",
+        "- No raw cloud paths.",
+        "- No cloud file ids.",
+        "- Raw resolver fields exist only in the ignored local SQLite manifest.",
+        "",
+        "## Global Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Metadata records scanned | {_fmt_int(scanned_records)} |",
+        f"| Candidate export ZIP files | {_fmt_int(len(candidates))} |",
+        f"| Candidate total size bytes | {_fmt_int(total_size)} |",
+        "",
+        "## Candidate Kinds",
+        "",
+        "| Kind | Files |",
+        "|---|---:|",
+    ]
+    if kind_counts:
+        for kind, count in kind_counts.most_common():
+            lines.append(f"| {kind} | {_fmt_int(count)} |")
+    else:
+        lines.append("| none | 0 |")
+
+    lines.extend(
+        [
+            "",
+            "## Candidate References",
+            "",
+            "| File ID | Kind | Size bytes | Modified month |",
+            "|---|---|---:|---|",
+        ]
+    )
+    for candidate in candidates[:50]:
+        lines.append(
+            "| {file_id} | {kind} | {size} | {month} |".format(
+                file_id=candidate.file_id,
+                kind=candidate.candidate_kind,
+                size=_fmt_int(candidate.size_bytes),
+                month=_month_bucket(candidate.mod_time),
+            )
+        )
+    if len(candidates) > 50:
+        lines.append(f"| more | hidden | {_fmt_int(len(candidates) - 50)} | aggregate-only |")
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_drive_export_manifest(
+    *,
+    lsjson_path: Path,
+    output_db: Path = DEFAULT_OUTPUT_DB,
+    summary_path: Path = DEFAULT_SUMMARY,
+    remote_label: str = "gdrive",
+) -> DriveManifestResult:
+    """Build the local-only manifest from a saved rclone lsjson payload."""
+    records = load_lsjson(lsjson_path)
+    candidates = build_candidates(records, remote_label=remote_label)
+    write_sqlite(
+        db_path=output_db,
+        remote_label=remote_label,
+        scanned_records=len(records),
+        candidates=candidates,
+    )
+    write_summary(
+        summary_path=summary_path,
+        db_path=output_db,
+        scanned_records=len(records),
+        candidates=candidates,
+    )
+    return DriveManifestResult(
+        scanned_records=len(records),
+        candidate_count=len(candidates),
+        total_size_bytes=sum(candidate.size_bytes for candidate in candidates),
+    )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build a local-only WhatsApp export manifest from rclone lsjson output."
+    )
+    parser.add_argument("--lsjson", type=Path, default=DEFAULT_LSJSON)
+    parser.add_argument("--output-db", type=Path, default=DEFAULT_OUTPUT_DB)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--remote-label", default="gdrive")
+    parser.add_argument("--json", action="store_true", help="Print aggregate counts as JSON.")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        result = build_drive_export_manifest(
+            lsjson_path=args.lsjson,
+            output_db=args.output_db,
+            summary_path=args.summary,
+            remote_label=args.remote_label,
+        )
+    except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
+        print("ERROR: Drive export manifest input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError):
+        print("ERROR: Drive export manifest run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        print("ERROR: Drive export manifest run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "candidate_count": result.candidate_count,
+                    "scanned_records": result.scanned_records,
+                    "total_size_bytes": result.total_size_bytes,
+                },
+                sort_keys=True,
+            )
+            + "\n"
+        )
+    return 0
+
+
+def _as_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _is_whatsapp_chat_zip(raw_path: str, raw_name: str, mime_type: str) -> bool:
+    text = _normalize_text(f"{raw_path} {raw_name}")
+    if not (raw_path.lower().endswith(".zip") or raw_name.lower().endswith(".zip")):
+        return False
+    if "whatsapp chat" in text:
+        return True
+    return "application/zip" in mime_type.lower() and "whatsapp chat" in text
+
+
+def _normalize_text(value: str) -> str:
+    normalized = unicodedata.normalize("NFKC", value).lower()
+    return " ".join(normalized.replace("_", " ").replace("-", " ").split())
+
+
+def _month_bucket(value: str | None) -> str:
+    if not value:
+        return "unknown"
+    return value[:7] if len(value) >= 7 else "unknown"
+
+
+def _fmt_int(value: int) -> str:
+    return f"{value:,}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/whatsapp_corpus/build_evidence_gap_detector.py
+++ b/scripts/whatsapp_corpus/build_evidence_gap_detector.py
@@ -1,0 +1,495 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_CASE_TIMELINES_DIR = Path("research/personal/wa-corpus/case-timelines")
+DEFAULT_EVIDENCE_GAPS_DIR = Path("research/personal/wa-corpus/evidence-gaps")
+
+DEFAULT_CASE_TIMELINES_DB = DEFAULT_CASE_TIMELINES_DIR / "case_timelines.local.sqlite"
+DEFAULT_OUTPUT_DB = DEFAULT_EVIDENCE_GAPS_DIR / "evidence_gaps.local.sqlite"
+DEFAULT_SUMMARY = DEFAULT_EVIDENCE_GAPS_DIR / "evidence_gaps_summary.md"
+
+EXPECTED_CASE_TIMELINES_DB_NAME = "case_timelines.local.sqlite"
+
+
+@dataclass(frozen=True)
+class CaseTimelineRow:
+    case_card_id: str
+    timeline_rank: int
+    timeline_status: str
+    highest_risk: str
+    assigned_lane: str
+    primary_action: str
+    latest_movement: str
+    blocker_code: str
+    event_count: int
+    has_war_room_item: bool
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class EvidenceGap:
+    gap_id: str
+    case_card_id: str
+    gap_rank: int
+    assigned_lane: str
+    primary_action: str
+    timeline_status: str
+    highest_risk: str
+    blocker_code: str
+    gap_code: str
+    gap_category: str
+    gap_severity: str
+    closure_blocker: bool
+    resolution_gate: str
+    gap_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class EvidenceGapBuildResult:
+    case_count: int
+    gap_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    category_counts: dict[str, int]
+    severity_counts: dict[str, int]
+    output_db: Path
+    summary_path: Path
+
+
+def _format_utc(value: str | None = None) -> str:
+    if value is not None:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).isoformat(timespec="seconds")
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _connect_ro(db_path: Path, *, expected_name: str, label: str) -> sqlite3.Connection:
+    if db_path.name != expected_name:
+        raise ValueError(f"Refusing to read unexpected {label} DB: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"{label} DB not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def read_case_timelines(db_path: Path) -> tuple[CaseTimelineRow, ...]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_CASE_TIMELINES_DB_NAME,
+        label="Case Timelines",
+    ) as conn:
+        rows = conn.execute(
+            """
+            SELECT case_card_id, timeline_rank, timeline_status, highest_risk,
+                   assigned_lane, primary_action, latest_movement, blocker_code,
+                   event_count, has_war_room_item, send_whatsapp, crm_mutation,
+                   requires_human_approval
+            FROM case_timelines
+            ORDER BY timeline_rank, case_card_id
+            """
+        ).fetchall()
+    return tuple(
+        CaseTimelineRow(
+            case_card_id=str(row["case_card_id"]),
+            timeline_rank=int(row["timeline_rank"]),
+            timeline_status=str(row["timeline_status"]),
+            highest_risk=str(row["highest_risk"]),
+            assigned_lane=str(row["assigned_lane"]),
+            primary_action=str(row["primary_action"]),
+            latest_movement=str(row["latest_movement"]),
+            blocker_code=str(row["blocker_code"]),
+            event_count=int(row["event_count"]),
+            has_war_room_item=bool(row["has_war_room_item"]),
+            send_whatsapp=bool(row["send_whatsapp"]),
+            crm_mutation=bool(row["crm_mutation"]),
+            requires_human_approval=bool(row["requires_human_approval"]),
+        )
+        for row in rows
+    )
+
+
+def read_source_generated_at(db_path: Path) -> str:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_CASE_TIMELINES_DB_NAME,
+        label="Case Timelines",
+    ) as conn:
+        row = conn.execute(
+            "SELECT generated_at_utc FROM case_timeline_runs WHERE id = 1"
+        ).fetchone()
+    if row is None:
+        return "unknown"
+    return str(row["generated_at_utc"])
+
+
+def _gap_mapping(row: CaseTimelineRow) -> tuple[str, str, str]:
+    is_war_room = row.timeline_status == "war_room_active" or row.has_war_room_item
+    if row.primary_action == "crm_followup":
+        return (
+            "client_followup_confirmation_missing",
+            "client_response",
+            "urgent" if is_war_room else "high",
+        )
+    if row.primary_action == "document_chase":
+        return (
+            "required_document_evidence_missing",
+            "document",
+            "high" if is_war_room else "medium",
+        )
+    if row.primary_action == "immigration_status_check":
+        return (
+            "immigration_status_evidence_missing",
+            "status",
+            "urgent" if is_war_room else "medium",
+        )
+    if row.primary_action == "payment_reconcile":
+        return (
+            "payment_reconciliation_evidence_missing",
+            "finance",
+            "high" if is_war_room else "medium",
+        )
+    return (
+        "operator_review_evidence_missing",
+        "operator_review",
+        "high" if is_war_room else "medium",
+    )
+
+
+def _resolution_gate(*, gap_category: str, gap_severity: str) -> str:
+    if gap_severity == "urgent":
+        return "owner_review_required"
+    if gap_category in {"document", "finance"}:
+        return "operator_upload_required"
+    return "lane_review_required"
+
+
+def build_gaps(timelines: Sequence[CaseTimelineRow]) -> tuple[EvidenceGap, ...]:
+    gaps: list[EvidenceGap] = []
+    for rank, row in enumerate(timelines, start=1):
+        gap_code, gap_category, gap_severity = _gap_mapping(row)
+        resolution_gate = _resolution_gate(
+            gap_category=gap_category,
+            gap_severity=gap_severity,
+        )
+        payload = {
+            "schema_version": "evidence_gap_detector.v1",
+            "privacy_mode": "local_only_evidence_gap_no_raw_text",
+            "source_timeline_status": row.timeline_status,
+            "source_highest_risk": row.highest_risk,
+            "source_blocker_code": row.blocker_code,
+            "source_latest_movement": row.latest_movement,
+            "source_event_count": row.event_count,
+            "source_has_war_room_item": row.has_war_room_item,
+            "closure_blocker": True,
+            "raw_text_included": False,
+            "send_whatsapp": False,
+            "crm_mutation": False,
+            "requires_human_approval": True,
+        }
+        gaps.append(
+            EvidenceGap(
+                gap_id=f"gap-{rank:06d}",
+                case_card_id=row.case_card_id,
+                gap_rank=rank,
+                assigned_lane=row.assigned_lane,
+                primary_action=row.primary_action,
+                timeline_status=row.timeline_status,
+                highest_risk=row.highest_risk,
+                blocker_code=row.blocker_code,
+                gap_code=gap_code,
+                gap_category=gap_category,
+                gap_severity=gap_severity,
+                closure_blocker=True,
+                resolution_gate=resolution_gate,
+                gap_payload=payload,
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(gaps)
+
+
+def write_evidence_gap_sqlite(
+    output_db: Path,
+    *,
+    gaps: Sequence[EvidenceGap],
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    output_db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(output_db) as conn:
+        conn.executescript(
+            """
+            DROP TABLE IF EXISTS evidence_gap_runs;
+            DROP TABLE IF EXISTS evidence_gaps;
+
+            CREATE TABLE evidence_gap_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                case_count INTEGER NOT NULL,
+                gap_count INTEGER NOT NULL,
+                closure_blocker_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE evidence_gaps (
+                gap_id TEXT PRIMARY KEY,
+                case_card_id TEXT NOT NULL,
+                gap_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                primary_action TEXT NOT NULL,
+                timeline_status TEXT NOT NULL,
+                highest_risk TEXT NOT NULL,
+                blocker_code TEXT NOT NULL,
+                gap_code TEXT NOT NULL,
+                gap_category TEXT NOT NULL,
+                gap_severity TEXT NOT NULL,
+                closure_blocker INTEGER NOT NULL CHECK (closure_blocker = 1),
+                resolution_gate TEXT NOT NULL,
+                gap_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE INDEX idx_evidence_gaps_rank ON evidence_gaps(gap_rank);
+            CREATE INDEX idx_evidence_gaps_category ON evidence_gaps(gap_category);
+            CREATE INDEX idx_evidence_gaps_severity ON evidence_gaps(gap_severity);
+            CREATE INDEX idx_evidence_gaps_lane ON evidence_gaps(assigned_lane);
+            CREATE INDEX idx_evidence_gaps_gate ON evidence_gaps(resolution_gate);
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO evidence_gap_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                case_count, gap_count, closure_blocker_count,
+                send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, ?, ?, ?, 0, 0)
+            """,
+            (
+                generated_at_utc,
+                source_generated_at_utc,
+                "local_only_evidence_gap_no_raw_text_no_send_no_crm_mutation",
+                len(gaps),
+                len(gaps),
+                sum(1 for gap in gaps if gap.closure_blocker),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO evidence_gaps (
+                gap_id, case_card_id, gap_rank, assigned_lane, primary_action,
+                timeline_status, highest_risk, blocker_code, gap_code,
+                gap_category, gap_severity, closure_blocker, resolution_gate,
+                gap_payload_json, send_whatsapp, crm_mutation,
+                requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    gap.gap_id,
+                    gap.case_card_id,
+                    gap.gap_rank,
+                    gap.assigned_lane,
+                    gap.primary_action,
+                    gap.timeline_status,
+                    gap.highest_risk,
+                    gap.blocker_code,
+                    gap.gap_code,
+                    gap.gap_category,
+                    gap.gap_severity,
+                    int(gap.closure_blocker),
+                    gap.resolution_gate,
+                    json.dumps(gap.gap_payload, ensure_ascii=False, sort_keys=True),
+                    int(gap.send_whatsapp),
+                    int(gap.crm_mutation),
+                    int(gap.requires_human_approval),
+                )
+                for gap in gaps
+            ],
+        )
+        conn.commit()
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'unknown'} | {count} |")
+    return lines
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    gaps: Sequence[EvidenceGap],
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    category_counts = Counter(gap.gap_category for gap in gaps)
+    severity_counts = Counter(gap.gap_severity for gap in gaps)
+    action_counts = Counter(gap.primary_action for gap in gaps)
+    lane_counts = Counter(gap.assigned_lane for gap in gaps)
+    gate_counts = Counter(gap.resolution_gate for gap in gaps)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Evidence Gap Detector Summary",
+        "",
+        f"Generated UTC: `{generated_at_utc}`",
+        f"Source Case Timelines UTC: `{source_generated_at_utc}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, case card IDs, event IDs, inbox item IDs, or room item IDs.",
+        "- Evidence gap rows are local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Cases reviewed | {len(gaps)} |",
+        f"| Evidence gaps | {len(gaps)} |",
+        f"| Closure blockers | {sum(1 for gap in gaps if gap.closure_blocker)} |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("Gap Categories", category_counts),
+        "",
+        *_counter_table("Gap Severities", severity_counts),
+        "",
+        *_counter_table("Primary Actions", action_counts),
+        "",
+        *_counter_table("Assigned Lanes", lane_counts),
+        "",
+        *_counter_table("Resolution Gates", gate_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- The Evidence Gap Detector converts local case timelines into explicit closure blockers.",
+        "- It does not parse raw WhatsApp messages.",
+        "- It does not call a cloud LLM.",
+        "- Runtime must not send WhatsApp messages from this artifact.",
+        "- Runtime must not mutate CRM records from this artifact.",
+        "- A human must approve every client-facing message or operational mutation.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_evidence_gap_detector(
+    *,
+    case_timelines_db: Path = DEFAULT_CASE_TIMELINES_DB,
+    output_dir: Path = DEFAULT_EVIDENCE_GAPS_DIR,
+    output_db: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+    generated_at_utc: str | None = None,
+) -> EvidenceGapBuildResult:
+    """Build local-only evidence gap blockers from case timelines."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    generated = _format_utc(generated_at_utc)
+    source_generated = read_source_generated_at(case_timelines_db)
+    timelines = read_case_timelines(case_timelines_db)
+    gaps = build_gaps(timelines)
+    write_evidence_gap_sqlite(
+        output_db,
+        gaps=gaps,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    write_summary(
+        summary_path=summary_path,
+        gaps=gaps,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    return EvidenceGapBuildResult(
+        case_count=len(timelines),
+        gap_count=len(gaps),
+        send_whatsapp_count=sum(1 for gap in gaps if gap.send_whatsapp),
+        crm_mutation_count=sum(1 for gap in gaps if gap.crm_mutation),
+        category_counts=dict(Counter(gap.gap_category for gap in gaps)),
+        severity_counts=dict(Counter(gap.gap_severity for gap in gaps)),
+        output_db=output_db,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build local-only Zantara evidence gaps from case timelines."
+    )
+    parser.add_argument("--case-timelines-db", type=Path, default=DEFAULT_CASE_TIMELINES_DB)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_EVIDENCE_GAPS_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--generated-at-utc", default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_evidence_gap_detector(
+            case_timelines_db=args.case_timelines_db,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            summary_path=args.summary,
+            generated_at_utc=args.generated_at_utc,
+        )
+    except (FileNotFoundError, ValueError, sqlite3.Error, OSError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "case_count": result.case_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                    "gap_count": result.gap_count,
+                    "output_db": str(result.output_db),
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "summary_path": str(result.summary_path),
+                },
+                sort_keys=True,
+            )
+        )
+    else:
+        print(
+            "Evidence gap build complete: "
+            f"{result.gap_count} gaps -> {result.output_db}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/whatsapp_corpus/build_next_best_action_ranker.py
+++ b/scripts/whatsapp_corpus/build_next_best_action_ranker.py
@@ -1,0 +1,453 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_CASE_MEMORY_DIR = Path("research/personal/wa-corpus/case-memory-cards")
+DEFAULT_NEXT_ACTION_DIR = Path("research/personal/wa-corpus/next-best-actions")
+DEFAULT_CASE_MEMORY_DB = DEFAULT_CASE_MEMORY_DIR / "case_memory_cards.local.sqlite"
+DEFAULT_OUTPUT_DB = DEFAULT_NEXT_ACTION_DIR / "next_best_actions.local.sqlite"
+DEFAULT_SUMMARY = DEFAULT_NEXT_ACTION_DIR / "next_best_actions_summary.md"
+
+EXPECTED_CASE_MEMORY_DB_NAME = "case_memory_cards.local.sqlite"
+
+
+@dataclass(frozen=True)
+class CaseMemoryCardRow:
+    case_card_id: str
+    case_owner: str
+    case_status: str
+    risk_level: str
+    next_best_action: str
+    assigned_lane: str
+    latest_movement: str
+    blocker_code: str
+    review_rank: int
+    card_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class RankedAction:
+    case_card_id: str
+    action_rank: int
+    action_code: str
+    action_title: str
+    reason_code: str
+    urgency_score: int
+    impact_score: int
+    combined_score: int
+    assigned_lane: str
+    action_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class NextBestActionBuildResult:
+    case_count: int
+    action_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    top_action_counts: dict[str, int]
+    reason_counts: dict[str, int]
+    output_db: Path
+    summary_path: Path
+
+
+def _connect_case_memory(db_path: Path) -> sqlite3.Connection:
+    if db_path.name != EXPECTED_CASE_MEMORY_DB_NAME:
+        raise ValueError(f"Refusing to read unexpected Case Memory DB: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"Case Memory DB not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def read_case_memory_cards(
+    db_path: Path,
+    *,
+    limit: int | None = None,
+) -> tuple[CaseMemoryCardRow, ...]:
+    with _connect_case_memory(db_path) as conn:
+        sql = """
+            SELECT case_card_id, case_owner, case_status, risk_level,
+                   next_best_action, assigned_lane, latest_movement, blocker_code,
+                   review_rank, card_payload_json, send_whatsapp, crm_mutation,
+                   requires_human_approval
+            FROM case_memory_cards
+            ORDER BY review_rank, case_card_id
+        """
+        if limit is not None:
+            sql += " LIMIT ?"
+            rows = conn.execute(sql, (limit,)).fetchall()
+        else:
+            rows = conn.execute(sql).fetchall()
+    return tuple(
+        CaseMemoryCardRow(
+            case_card_id=str(row["case_card_id"]),
+            case_owner=str(row["case_owner"]),
+            case_status=str(row["case_status"]),
+            risk_level=str(row["risk_level"]),
+            next_best_action=str(row["next_best_action"]),
+            assigned_lane=str(row["assigned_lane"]),
+            latest_movement=str(row["latest_movement"]),
+            blocker_code=str(row["blocker_code"]),
+            review_rank=int(row["review_rank"]),
+            card_payload=json.loads(str(row["card_payload_json"])),
+            send_whatsapp=bool(row["send_whatsapp"]),
+            crm_mutation=bool(row["crm_mutation"]),
+            requires_human_approval=bool(row["requires_human_approval"]),
+        )
+        for row in rows
+    )
+
+
+def _reason_code(card: CaseMemoryCardRow) -> str:
+    return {
+        "case_stall_followup_risk": "stale_followup",
+        "payment_reconciliation_needed": "payment_risk",
+        "missing_document_chase_needed": "missing_doc",
+        "immigration_status_gap": "status_gap",
+        "operator_escalation_needed": "operator_escalation",
+        "knowledge_capture_needed": "knowledge_capture",
+    }.get(card.blocker_code, "case_review_needed")
+
+
+def _action_title(action_code: str) -> str:
+    return action_code.replace("_", " ").title()
+
+
+def _action_templates(card: CaseMemoryCardRow) -> tuple[tuple[str, str, int], ...]:
+    primary_reason = _reason_code(card)
+    templates: dict[str, tuple[tuple[str, str, int], ...]] = {
+        "crm_followup": (
+            ("crm_followup", primary_reason, 85),
+            ("operator_system_update", "missing_system_update", 80),
+            ("client_status_draft_review", "client_confused_or_silent", 75),
+        ),
+        "payment_reconcile": (
+            ("payment_reconcile", primary_reason, 90),
+            ("ledger_check", "finance_verification", 80),
+            ("proof_of_payment_review", "payment_evidence_gap", 75),
+        ),
+        "document_chase": (
+            ("document_chase", primary_reason, 88),
+            ("checklist_gap_review", "missing_doc", 82),
+            ("document_request_draft_review", "client_confused_or_silent", 74),
+        ),
+        "immigration_status_check": (
+            ("immigration_status_check", primary_reason, 88),
+            ("case_timeline_review", "status_gap", 82),
+            ("specialist_status_confirmation", "operator_escalation", 76),
+        ),
+        "team_escalation": (
+            ("team_escalation", primary_reason, 86),
+            ("owner_attention_review", "operator_escalation", 84),
+            ("operator_system_update", "missing_system_update", 78),
+        ),
+    }
+    return templates.get(
+        card.next_best_action,
+        (
+            (card.next_best_action, primary_reason, 80),
+            ("case_timeline_review", "case_review_needed", 75),
+            ("operator_system_update", "missing_system_update", 70),
+        ),
+    )
+
+
+def _urgency_score(card: CaseMemoryCardRow, action_rank: int) -> int:
+    base = {"P1": 100, "P2": 70, "P3": 45}.get(card.risk_level, 40)
+    score = base - ((action_rank - 1) * 5)
+    if card.review_rank > 1000:
+        score -= 5
+    return max(0, min(100, score))
+
+
+def _combined_score(urgency_score: int, impact_score: int) -> int:
+    return round((urgency_score * 0.6) + (impact_score * 0.4))
+
+
+def build_ranked_actions(cards: Sequence[CaseMemoryCardRow]) -> tuple[RankedAction, ...]:
+    actions: list[RankedAction] = []
+    for card in cards:
+        for action_rank, (action_code, reason_code, impact_score) in enumerate(
+            _action_templates(card),
+            start=1,
+        ):
+            urgency_score = _urgency_score(card, action_rank)
+            payload = {
+                "schema_version": "next_best_action.v1",
+                "privacy_mode": "local_only_case_memory_no_raw_text",
+                "case_owner": card.case_owner,
+                "source_case_status": card.case_status,
+                "source_risk_level": card.risk_level,
+                "source_blocker_code": card.blocker_code,
+                "latest_movement": card.latest_movement,
+                "reason_code": reason_code,
+                "urgency_score": urgency_score,
+                "impact_score": impact_score,
+                "combined_score": _combined_score(urgency_score, impact_score),
+                "raw_text_included": False,
+                "send_whatsapp": False,
+                "crm_mutation": False,
+                "requires_human_approval": True,
+            }
+            actions.append(
+                RankedAction(
+                    case_card_id=card.case_card_id,
+                    action_rank=action_rank,
+                    action_code=action_code,
+                    action_title=_action_title(action_code),
+                    reason_code=reason_code,
+                    urgency_score=urgency_score,
+                    impact_score=impact_score,
+                    combined_score=int(payload["combined_score"]),
+                    assigned_lane=card.assigned_lane,
+                    action_payload=payload,
+                    send_whatsapp=False,
+                    crm_mutation=False,
+                    requires_human_approval=True,
+                )
+            )
+    return tuple(actions)
+
+
+def write_rankings_sqlite(path: Path, actions: Sequence[RankedAction]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        path.unlink()
+    case_count = len({action.case_card_id for action in actions})
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE next_best_action_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                case_count INTEGER NOT NULL,
+                action_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE next_best_action_rankings (
+                case_card_id TEXT NOT NULL,
+                action_rank INTEGER NOT NULL,
+                action_code TEXT NOT NULL,
+                action_title TEXT NOT NULL,
+                reason_code TEXT NOT NULL,
+                urgency_score INTEGER NOT NULL,
+                impact_score INTEGER NOT NULL,
+                combined_score INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                action_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1),
+                PRIMARY KEY (case_card_id, action_rank)
+            );
+
+            CREATE INDEX idx_next_best_action_rankings_rank ON next_best_action_rankings(action_rank);
+            CREATE INDEX idx_next_best_action_rankings_code ON next_best_action_rankings(action_code);
+            CREATE INDEX idx_next_best_action_rankings_reason ON next_best_action_rankings(reason_code);
+            CREATE INDEX idx_next_best_action_rankings_lane ON next_best_action_rankings(assigned_lane);
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO next_best_action_runs (
+                id, generated_at_utc, privacy_mode, case_count, action_count,
+                send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, ?, 0, 0)
+            """,
+            (
+                datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                "local_only_next_best_actions_no_raw_text_no_send_no_crm_mutation",
+                case_count,
+                len(actions),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO next_best_action_rankings (
+                case_card_id, action_rank, action_code, action_title, reason_code,
+                urgency_score, impact_score, combined_score, assigned_lane,
+                action_payload_json, send_whatsapp, crm_mutation,
+                requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    action.case_card_id,
+                    action.action_rank,
+                    action.action_code,
+                    action.action_title,
+                    action.reason_code,
+                    action.urgency_score,
+                    action.impact_score,
+                    action.combined_score,
+                    action.assigned_lane,
+                    json.dumps(action.action_payload, ensure_ascii=False, sort_keys=True),
+                    int(action.send_whatsapp),
+                    int(action.crm_mutation),
+                    int(action.requires_human_approval),
+                )
+                for action in actions
+            ],
+        )
+        conn.commit()
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'unknown'} | {count} |")
+    return lines
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    actions: Sequence[RankedAction],
+    generated_at_utc: str | None = None,
+) -> None:
+    generated = generated_at_utc or datetime.now(timezone.utc).isoformat(timespec="seconds")
+    ranked_cases = {action.case_card_id for action in actions}
+    top_action_counts = Counter(
+        action.action_code for action in actions if action.action_rank == 1
+    )
+    reason_counts = Counter(action.reason_code for action in actions)
+    lane_counts = Counter(action.assigned_lane for action in actions if action.action_rank == 1)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Next Best Action Ranker Summary",
+        "",
+        f"Generated UTC: `{generated}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, case card IDs, shadow IDs, or window IDs.",
+        "- Next best action rankings are local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Ranked cases | {len(ranked_cases)} |",
+        f"| Ranked actions | {len(actions)} |",
+        "| Actions per case | 3 |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("Top Ranked Actions", top_action_counts),
+        "",
+        *_counter_table("Reason Codes", reason_counts),
+        "",
+        *_counter_table("Primary Lanes", lane_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- The ranker orders possible actions by urgency and impact.",
+        "- It creates review-ready options; it does not execute them.",
+        "- Runtime must not send WhatsApp messages from this artifact.",
+        "- Runtime must not mutate CRM records from this artifact.",
+        "- A human must approve any client-facing message or operational mutation.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_next_best_action_ranker(
+    *,
+    case_memory_db: Path = DEFAULT_CASE_MEMORY_DB,
+    output_dir: Path = DEFAULT_NEXT_ACTION_DIR,
+    output_db: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+    max_cases: int | None = None,
+) -> NextBestActionBuildResult:
+    """Build local-only top-three next best actions for each case memory card."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    cards = read_case_memory_cards(case_memory_db, limit=max_cases)
+    actions = build_ranked_actions(cards)
+    write_rankings_sqlite(output_db, actions)
+    write_summary(summary_path=summary_path, actions=actions)
+    return NextBestActionBuildResult(
+        case_count=len(cards),
+        action_count=len(actions),
+        send_whatsapp_count=sum(1 for action in actions if action.send_whatsapp),
+        crm_mutation_count=sum(1 for action in actions if action.crm_mutation),
+        top_action_counts=dict(
+            Counter(action.action_code for action in actions if action.action_rank == 1)
+        ),
+        reason_counts=dict(Counter(action.reason_code for action in actions)),
+        output_db=output_db,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build local-only Zantara Next Best Action rankings from case memory cards."
+    )
+    parser.add_argument("--case-memory-db", type=Path, default=DEFAULT_CASE_MEMORY_DB)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_NEXT_ACTION_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--max-cases", type=int, default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_next_best_action_ranker(
+            case_memory_db=args.case_memory_db,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            summary_path=args.summary,
+            max_cases=args.max_cases,
+        )
+    except (FileNotFoundError, ValueError, sqlite3.Error, OSError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "case_count": result.case_count,
+                    "action_count": result.action_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                    "output_db": str(result.output_db),
+                    "summary_path": str(result.summary_path),
+                },
+                sort_keys=True,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/whatsapp_corpus/build_operator_action_inbox.py
+++ b/scripts/whatsapp_corpus/build_operator_action_inbox.py
@@ -1,0 +1,496 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_NEXT_ACTION_DIR = Path("research/personal/wa-corpus/next-best-actions")
+DEFAULT_OPERATOR_INBOX_DIR = Path("research/personal/wa-corpus/operator-action-inbox")
+DEFAULT_NEXT_ACTION_DB = DEFAULT_NEXT_ACTION_DIR / "next_best_actions.local.sqlite"
+DEFAULT_OUTPUT_DB = DEFAULT_OPERATOR_INBOX_DIR / "operator_action_inbox.local.sqlite"
+DEFAULT_SUMMARY = DEFAULT_OPERATOR_INBOX_DIR / "operator_action_inbox_summary.md"
+
+EXPECTED_NEXT_ACTION_DB_NAME = "next_best_actions.local.sqlite"
+
+
+@dataclass(frozen=True)
+class NextBestActionRow:
+    case_card_id: str
+    action_rank: int
+    action_code: str
+    action_title: str
+    reason_code: str
+    urgency_score: int
+    impact_score: int
+    combined_score: int
+    assigned_lane: str
+    action_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OperatorInboxItem:
+    inbox_item_id: str
+    case_card_id: str
+    queue_rank: int
+    assigned_lane: str
+    priority_label: str
+    queue_bucket: str
+    action_code: str
+    action_title: str
+    reason_code: str
+    urgency_score: int
+    impact_score: int
+    combined_score: int
+    operator_instruction: str
+    approval_mode: str
+    item_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OperatorActionInboxBuildResult:
+    case_count: int
+    candidate_action_count: int
+    inbox_item_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    priority_counts: dict[str, int]
+    lane_counts: dict[str, int]
+    bucket_counts: dict[str, int]
+    output_db: Path
+    summary_path: Path
+
+
+def _connect_next_best_actions(db_path: Path) -> sqlite3.Connection:
+    if db_path.name != EXPECTED_NEXT_ACTION_DB_NAME:
+        raise ValueError(f"Refusing to read unexpected Next Best Actions DB: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"Next Best Actions DB not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def read_ranked_actions(db_path: Path) -> tuple[NextBestActionRow, ...]:
+    with _connect_next_best_actions(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT case_card_id, action_rank, action_code, action_title, reason_code,
+                   urgency_score, impact_score, combined_score, assigned_lane,
+                   action_payload_json, send_whatsapp, crm_mutation,
+                   requires_human_approval
+            FROM next_best_action_rankings
+            ORDER BY case_card_id, action_rank
+            """
+        ).fetchall()
+    return tuple(
+        NextBestActionRow(
+            case_card_id=str(row["case_card_id"]),
+            action_rank=int(row["action_rank"]),
+            action_code=str(row["action_code"]),
+            action_title=str(row["action_title"]),
+            reason_code=str(row["reason_code"]),
+            urgency_score=int(row["urgency_score"]),
+            impact_score=int(row["impact_score"]),
+            combined_score=int(row["combined_score"]),
+            assigned_lane=str(row["assigned_lane"]),
+            action_payload=json.loads(str(row["action_payload_json"])),
+            send_whatsapp=bool(row["send_whatsapp"]),
+            crm_mutation=bool(row["crm_mutation"]),
+            requires_human_approval=bool(row["requires_human_approval"]),
+        )
+        for row in rows
+    )
+
+
+def _priority_label(action: NextBestActionRow) -> str:
+    if action.urgency_score >= 90 or action.combined_score >= 90:
+        return "now"
+    if action.urgency_score >= 65 or action.combined_score >= 75:
+        return "today"
+    return "next"
+
+
+def _queue_bucket(action: NextBestActionRow, priority_label: str) -> str:
+    if action.action_code == "crm_followup":
+        return "follow_up_now" if priority_label == "now" else "follow_up_today"
+    if action.action_code == "payment_reconcile":
+        return "finance_now" if priority_label == "now" else "finance_today"
+    if action.action_code == "document_chase":
+        return "document_gap_now" if priority_label == "now" else "document_gap_today"
+    if action.action_code == "immigration_status_check":
+        return "status_check_now" if priority_label == "now" else "status_check_today"
+    if action.action_code == "team_escalation":
+        return "team_escalation_now" if priority_label == "now" else "team_escalation_today"
+    return f"operator_review_{priority_label}"
+
+
+def _operator_instruction(action: NextBestActionRow) -> str:
+    instructions = {
+        "crm_followup": (
+            "Operator must review the CRM follow-up, prepare the client status draft, "
+            "and wait for human approval before any send."
+        ),
+        "payment_reconcile": (
+            "Operator must reconcile payment evidence, check the ledger, and request "
+            "human approval before any client-facing update."
+        ),
+        "document_chase": (
+            "Operator must review the missing-document checklist, draft the request, "
+            "and wait for human approval before contacting the client."
+        ),
+        "immigration_status_check": (
+            "Operator must verify immigration status, update the internal timeline, "
+            "and request specialist confirmation before any reply."
+        ),
+        "team_escalation": (
+            "Operator must escalate the case internally, capture the blocker, and wait "
+            "for owner or specialist review."
+        ),
+    }
+    return instructions.get(
+        action.action_code,
+        "Operator must review the case action, capture the next step, and wait for human approval.",
+    )
+
+
+def _priority_sort_value(priority_label: str) -> int:
+    return {"now": 0, "today": 1, "next": 2}.get(priority_label, 9)
+
+
+def build_inbox_items(actions: Sequence[NextBestActionRow]) -> tuple[OperatorInboxItem, ...]:
+    grouped: dict[str, list[NextBestActionRow]] = defaultdict(list)
+    for action in actions:
+        grouped[action.case_card_id].append(action)
+
+    provisional: list[tuple[NextBestActionRow, int, str, str]] = []
+    for case_card_id in sorted(grouped):
+        ranked = sorted(grouped[case_card_id], key=lambda item: item.action_rank)
+        if not ranked:
+            continue
+        top_action = ranked[0]
+        priority_label = _priority_label(top_action)
+        provisional.append(
+            (
+                top_action,
+                len(ranked),
+                priority_label,
+                _queue_bucket(top_action, priority_label),
+            )
+        )
+
+    provisional.sort(
+        key=lambda item: (
+            _priority_sort_value(item[2]),
+            -item[0].combined_score,
+            -item[0].urgency_score,
+            item[0].assigned_lane,
+            item[0].action_code,
+            item[0].case_card_id,
+        )
+    )
+
+    items: list[OperatorInboxItem] = []
+    for queue_rank, (action, candidate_action_count, priority_label, queue_bucket) in enumerate(
+        provisional,
+        start=1,
+    ):
+        payload = {
+            "schema_version": "operator_action_inbox.v1",
+            "privacy_mode": "local_only_operator_inbox_no_raw_text",
+            "source_action_rank": action.action_rank,
+            "candidate_action_count": candidate_action_count,
+            "source_action_code": action.action_code,
+            "source_reason_code": action.reason_code,
+            "source_case_status": action.action_payload.get("source_case_status", "unknown"),
+            "source_risk_level": action.action_payload.get("source_risk_level", "unknown"),
+            "source_blocker_code": action.action_payload.get("source_blocker_code", "unknown"),
+            "latest_movement": action.action_payload.get("latest_movement", "unknown"),
+            "priority_label": priority_label,
+            "queue_bucket": queue_bucket,
+            "raw_text_included": False,
+            "send_whatsapp": False,
+            "crm_mutation": False,
+            "requires_human_approval": True,
+        }
+        items.append(
+            OperatorInboxItem(
+                inbox_item_id=f"inbox-{action.case_card_id}",
+                case_card_id=action.case_card_id,
+                queue_rank=queue_rank,
+                assigned_lane=action.assigned_lane,
+                priority_label=priority_label,
+                queue_bucket=queue_bucket,
+                action_code=action.action_code,
+                action_title=action.action_title,
+                reason_code=action.reason_code,
+                urgency_score=action.urgency_score,
+                impact_score=action.impact_score,
+                combined_score=action.combined_score,
+                operator_instruction=_operator_instruction(action),
+                approval_mode="human_review_required",
+                item_payload=payload,
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(items)
+
+
+def write_inbox_sqlite(path: Path, items: Sequence[OperatorInboxItem]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        path.unlink()
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE operator_action_inbox_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                case_count INTEGER NOT NULL,
+                inbox_item_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE operator_action_inbox (
+                inbox_item_id TEXT PRIMARY KEY,
+                case_card_id TEXT NOT NULL,
+                queue_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                priority_label TEXT NOT NULL,
+                queue_bucket TEXT NOT NULL,
+                action_code TEXT NOT NULL,
+                action_title TEXT NOT NULL,
+                reason_code TEXT NOT NULL,
+                urgency_score INTEGER NOT NULL,
+                impact_score INTEGER NOT NULL,
+                combined_score INTEGER NOT NULL,
+                operator_instruction TEXT NOT NULL,
+                approval_mode TEXT NOT NULL,
+                item_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE INDEX idx_operator_action_inbox_rank ON operator_action_inbox(queue_rank);
+            CREATE INDEX idx_operator_action_inbox_lane ON operator_action_inbox(assigned_lane);
+            CREATE INDEX idx_operator_action_inbox_priority ON operator_action_inbox(priority_label);
+            CREATE INDEX idx_operator_action_inbox_bucket ON operator_action_inbox(queue_bucket);
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO operator_action_inbox_runs (
+                id, generated_at_utc, privacy_mode, case_count, inbox_item_count,
+                send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, ?, 0, 0)
+            """,
+            (
+                datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                "local_only_operator_action_inbox_no_raw_text_no_send_no_crm_mutation",
+                len({item.case_card_id for item in items}),
+                len(items),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO operator_action_inbox (
+                inbox_item_id, case_card_id, queue_rank, assigned_lane,
+                priority_label, queue_bucket, action_code, action_title,
+                reason_code, urgency_score, impact_score, combined_score,
+                operator_instruction, approval_mode, item_payload_json,
+                send_whatsapp, crm_mutation, requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    item.inbox_item_id,
+                    item.case_card_id,
+                    item.queue_rank,
+                    item.assigned_lane,
+                    item.priority_label,
+                    item.queue_bucket,
+                    item.action_code,
+                    item.action_title,
+                    item.reason_code,
+                    item.urgency_score,
+                    item.impact_score,
+                    item.combined_score,
+                    item.operator_instruction,
+                    item.approval_mode,
+                    json.dumps(item.item_payload, ensure_ascii=False, sort_keys=True),
+                    int(item.send_whatsapp),
+                    int(item.crm_mutation),
+                    int(item.requires_human_approval),
+                )
+                for item in items
+            ],
+        )
+        conn.commit()
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'unknown'} | {count} |")
+    return lines
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    items: Sequence[OperatorInboxItem],
+    candidate_action_count: int,
+    generated_at_utc: str | None = None,
+) -> None:
+    generated = generated_at_utc or datetime.now(timezone.utc).isoformat(timespec="seconds")
+    priority_counts = Counter(item.priority_label for item in items)
+    bucket_counts = Counter(item.queue_bucket for item in items)
+    lane_counts = Counter(item.assigned_lane for item in items)
+    action_counts = Counter(item.action_code for item in items)
+    reason_counts = Counter(item.reason_code for item in items)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Operator Action Inbox Summary",
+        "",
+        f"Generated UTC: `{generated}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, case card IDs, shadow IDs, or window IDs.",
+        "- Operator inbox rows are local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Inbox items | {len(items)} |",
+        f"| Candidate actions reviewed | {candidate_action_count} |",
+        "| Actions per inbox item | 1 top-ranked action |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("Priority Labels", priority_counts),
+        "",
+        *_counter_table("Queue Buckets", bucket_counts),
+        "",
+        *_counter_table("Assigned Lanes", lane_counts),
+        "",
+        *_counter_table("Inbox Actions", action_counts),
+        "",
+        *_counter_table("Reason Codes", reason_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- The inbox selects the top ranked action per case for operator review.",
+        "- It creates a local work queue; it does not execute any action.",
+        "- Runtime must not send WhatsApp messages from this artifact.",
+        "- Runtime must not mutate CRM records from this artifact.",
+        "- A human must approve any client-facing message or operational mutation.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_operator_action_inbox(
+    *,
+    next_best_actions_db: Path = DEFAULT_NEXT_ACTION_DB,
+    output_dir: Path = DEFAULT_OPERATOR_INBOX_DIR,
+    output_db: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+) -> OperatorActionInboxBuildResult:
+    """Build a local-only operator inbox from top-ranked next best actions."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    actions = read_ranked_actions(next_best_actions_db)
+    items = build_inbox_items(actions)
+    write_inbox_sqlite(output_db, items)
+    write_summary(
+        summary_path=summary_path,
+        items=items,
+        candidate_action_count=len(actions),
+    )
+    return OperatorActionInboxBuildResult(
+        case_count=len({action.case_card_id for action in actions}),
+        candidate_action_count=len(actions),
+        inbox_item_count=len(items),
+        send_whatsapp_count=sum(1 for item in items if item.send_whatsapp),
+        crm_mutation_count=sum(1 for item in items if item.crm_mutation),
+        priority_counts=dict(Counter(item.priority_label for item in items)),
+        lane_counts=dict(Counter(item.assigned_lane for item in items)),
+        bucket_counts=dict(Counter(item.queue_bucket for item in items)),
+        output_db=output_db,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build a local-only Zantara Operator Action Inbox from next best actions."
+    )
+    parser.add_argument("--next-best-actions-db", type=Path, default=DEFAULT_NEXT_ACTION_DB)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OPERATOR_INBOX_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_operator_action_inbox(
+            next_best_actions_db=args.next_best_actions_db,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            summary_path=args.summary,
+        )
+    except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
+        print("ERROR: Operator action inbox input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError):
+        print("ERROR: Operator action inbox run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        print("ERROR: Operator action inbox run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "case_count": result.case_count,
+                    "candidate_action_count": result.candidate_action_count,
+                    "inbox_item_count": result.inbox_item_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                },
+                sort_keys=True,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/whatsapp_corpus/build_operator_execution_packets.py
+++ b/scripts/whatsapp_corpus/build_operator_execution_packets.py
@@ -1,0 +1,831 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_POST_DECISION_WORK_ORDER_DIR = Path(
+    "research/personal/wa-corpus/post-decision-work-orders"
+)
+DEFAULT_OPERATOR_EXECUTION_PACKET_DIR = Path(
+    "research/personal/wa-corpus/operator-execution-packets"
+)
+
+DEFAULT_WORK_ORDERS_DB = (
+    DEFAULT_POST_DECISION_WORK_ORDER_DIR
+    / "post_decision_work_order_queue.local.sqlite"
+)
+DEFAULT_OUTPUT_DB = (
+    DEFAULT_OPERATOR_EXECUTION_PACKET_DIR
+    / "operator_execution_packets.local.sqlite"
+)
+DEFAULT_SUMMARY = (
+    DEFAULT_OPERATOR_EXECUTION_PACKET_DIR
+    / "operator_execution_packets_summary.md"
+)
+
+EXPECTED_WORK_ORDERS_DB_NAME = "post_decision_work_order_queue.local.sqlite"
+
+
+@dataclass(frozen=True)
+class PostDecisionWorkOrderRow:
+    work_order_id: str
+    event_id: str
+    entry_id: str
+    route_id: str
+    case_card_id: str
+    brief_id: str
+    pack_id: str
+    work_order_rank: int
+    assigned_lane: str
+    decision_type: str
+    decision_priority: str
+    route_bucket: str
+    owner_decision: str
+    source_capture_status: str
+    work_order_status: str
+    work_order_type: str
+    execution_gate: str
+    next_actor: str
+    action_intent: str
+    decision_effect: str
+    decision_note: str
+    source_event_hash: str
+    work_order_hash: str
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OperatorPacketPolicy:
+    packet_status: str
+    packet_type: str
+    operator_lane: str
+    packet_gate: str
+    packet_action: str
+    operator_instruction: str
+    escalation_target: str
+
+
+@dataclass(frozen=True)
+class OperatorExecutionPacket:
+    packet_id: str
+    work_order_id: str
+    event_id: str
+    entry_id: str
+    route_id: str
+    case_card_id: str
+    brief_id: str
+    pack_id: str
+    packet_rank: int
+    assigned_lane: str
+    operator_lane: str
+    decision_type: str
+    decision_priority: str
+    route_bucket: str
+    owner_decision: str
+    source_work_order_status: str
+    packet_status: str
+    packet_type: str
+    packet_gate: str
+    packet_action: str
+    operator_instruction: str
+    escalation_target: str
+    decision_note: str
+    source_work_order_hash: str
+    packet_hash: str
+    packet_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OperatorExecutionPacketsBuildResult:
+    source_case_count: int
+    owner_item_count: int
+    pack_count: int
+    brief_count: int
+    queue_item_count: int
+    ledger_entry_count: int
+    event_row_count: int
+    work_order_count: int
+    packet_count: int
+    ready_packet_count: int
+    blocked_packet_count: int
+    deferred_packet_count: int
+    rejected_packet_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    packet_status_counts: dict[str, int]
+    operator_lane_counts: dict[str, int]
+    output_db: Path
+    summary_path: Path
+
+
+def _format_utc(value: str | None = None) -> str:
+    if value is not None:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).isoformat(timespec="seconds")
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _connect_ro(db_path: Path, *, expected_name: str, label: str) -> sqlite3.Connection:
+    if db_path.name != expected_name:
+        raise ValueError(f"Refusing to read unexpected {label} DB: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"{label} DB not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _hash_packet(payload: dict[str, object]) -> str:
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def read_source_metadata(db_path: Path) -> tuple[str, int, int, int, int, int, int, int, int]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_WORK_ORDERS_DB_NAME,
+        label="Post-Decision Work Order Queue",
+    ) as conn:
+        row = conn.execute(
+            """
+            SELECT generated_at_utc, source_case_count, owner_item_count,
+                   pack_count, brief_count, queue_item_count, ledger_entry_count,
+                   event_row_count, work_order_count
+            FROM post_decision_work_order_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+    if row is None:
+        return "unknown", 0, 0, 0, 0, 0, 0, 0, 0
+    return (
+        str(row["generated_at_utc"]),
+        int(row["source_case_count"]),
+        int(row["owner_item_count"]),
+        int(row["pack_count"]),
+        int(row["brief_count"]),
+        int(row["queue_item_count"]),
+        int(row["ledger_entry_count"]),
+        int(row["event_row_count"]),
+        int(row["work_order_count"]),
+    )
+
+
+def read_work_orders(db_path: Path) -> tuple[PostDecisionWorkOrderRow, ...]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_WORK_ORDERS_DB_NAME,
+        label="Post-Decision Work Order Queue",
+    ) as conn:
+        rows = conn.execute(
+            """
+            SELECT work_order_id, event_id, entry_id, route_id, case_card_id,
+                   brief_id, pack_id, work_order_rank, assigned_lane, decision_type,
+                   decision_priority, route_bucket, owner_decision,
+                   source_capture_status, work_order_status, work_order_type,
+                   execution_gate, next_actor, action_intent, decision_effect,
+                   decision_note, source_event_hash, work_order_hash,
+                   send_whatsapp, crm_mutation, requires_human_approval
+            FROM post_decision_work_orders
+            ORDER BY work_order_rank, case_card_id
+            """
+        ).fetchall()
+    return tuple(
+        PostDecisionWorkOrderRow(
+            work_order_id=str(row["work_order_id"]),
+            event_id=str(row["event_id"]),
+            entry_id=str(row["entry_id"]),
+            route_id=str(row["route_id"]),
+            case_card_id=str(row["case_card_id"]),
+            brief_id=str(row["brief_id"]),
+            pack_id=str(row["pack_id"]),
+            work_order_rank=int(row["work_order_rank"]),
+            assigned_lane=str(row["assigned_lane"]),
+            decision_type=str(row["decision_type"]),
+            decision_priority=str(row["decision_priority"]),
+            route_bucket=str(row["route_bucket"]),
+            owner_decision=str(row["owner_decision"]),
+            source_capture_status=str(row["source_capture_status"]),
+            work_order_status=str(row["work_order_status"]),
+            work_order_type=str(row["work_order_type"]),
+            execution_gate=str(row["execution_gate"]),
+            next_actor=str(row["next_actor"]),
+            action_intent=str(row["action_intent"]),
+            decision_effect=str(row["decision_effect"]),
+            decision_note=str(row["decision_note"]),
+            source_event_hash=str(row["source_event_hash"]),
+            work_order_hash=str(row["work_order_hash"]),
+            send_whatsapp=bool(row["send_whatsapp"]),
+            crm_mutation=bool(row["crm_mutation"]),
+            requires_human_approval=bool(row["requires_human_approval"]),
+        )
+        for row in rows
+    )
+
+
+def _approved_packet_type_and_instruction(order: PostDecisionWorkOrderRow) -> tuple[str, str]:
+    if (
+        order.action_intent == "prepare_client_recovery_followup_for_human_review"
+        or order.decision_type == "approve_client_recovery_followup"
+    ):
+        return (
+            "client_recovery_followup_packet",
+            "review_client_recovery_followup_before_any_send",
+        )
+    if (
+        order.action_intent == "prepare_immigration_status_escalation_for_human_review"
+        or order.decision_type == "approve_immigration_status_escalation"
+    ):
+        return (
+            "immigration_status_escalation_packet",
+            "review_immigration_status_escalation_before_any_send",
+        )
+    return (
+        "approved_operator_packet",
+        "review_owner_approved_action_before_execution",
+    )
+
+
+def derive_packet_policy(order: PostDecisionWorkOrderRow) -> OperatorPacketPolicy:
+    if order.send_whatsapp or order.crm_mutation:
+        raise ValueError(f"Unsafe work order flags on {order.work_order_id}")
+    if not order.requires_human_approval:
+        raise ValueError(f"Work order missing human approval gate: {order.work_order_id}")
+
+    allowed_statuses = {
+        "ready_for_operator_review",
+        "blocked_awaiting_owner_decision",
+        "deferred_owner_followup",
+        "rejected_no_action",
+    }
+    if order.work_order_status not in allowed_statuses:
+        raise ValueError(
+            f"Unsupported work order status for {order.work_order_id}: "
+            f"{order.work_order_status}"
+        )
+
+    if (
+        order.work_order_status == "ready_for_operator_review"
+        and order.owner_decision == "approve"
+    ):
+        packet_type, instruction = _approved_packet_type_and_instruction(order)
+        operator_lane = order.next_actor if order.next_actor != "owner" else order.assigned_lane
+        return OperatorPacketPolicy(
+            packet_status="ready_for_operator_review",
+            packet_type=packet_type,
+            operator_lane=operator_lane,
+            packet_gate="human_review_before_send_or_crm",
+            packet_action=order.action_intent,
+            operator_instruction=instruction,
+            escalation_target="owner",
+        )
+    if (
+        order.work_order_status == "blocked_awaiting_owner_decision"
+        or order.owner_decision == "pending"
+    ):
+        return OperatorPacketPolicy(
+            packet_status="blocked_awaiting_owner_decision",
+            packet_type="owner_decision_required_packet",
+            operator_lane="owner",
+            packet_gate="owner_input_required",
+            packet_action="wait_for_owner_decision",
+            operator_instruction="no_operator_execution_until_owner_decides",
+            escalation_target="owner",
+        )
+    if order.work_order_status == "deferred_owner_followup" or order.owner_decision == "defer":
+        return OperatorPacketPolicy(
+            packet_status="deferred_owner_followup",
+            packet_type="owner_deferred_packet",
+            operator_lane="owner",
+            packet_gate="owner_revisit_required",
+            packet_action="schedule_owner_revisit",
+            operator_instruction="hold_operator_execution_until_owner_revisits",
+            escalation_target="owner",
+        )
+    if order.work_order_status == "rejected_no_action" or order.owner_decision == "reject":
+        return OperatorPacketPolicy(
+            packet_status="rejected_no_action",
+            packet_type="owner_rejected_packet",
+            operator_lane="owner",
+            packet_gate="no_external_action",
+            packet_action="record_rejection_and_stop",
+            operator_instruction="do_not_execute_rejected_work_order",
+            escalation_target="owner",
+        )
+    raise ValueError(
+        f"Unsupported work order status for {order.work_order_id}: "
+        f"{order.work_order_status}"
+    )
+
+
+def build_packets(
+    work_orders: Sequence[PostDecisionWorkOrderRow],
+) -> tuple[OperatorExecutionPacket, ...]:
+    packets: list[OperatorExecutionPacket] = []
+    for rank, order in enumerate(work_orders, start=1):
+        policy = derive_packet_policy(order)
+        payload = {
+            "schema_version": "operator_execution_packets.v1",
+            "privacy_mode": "local_only_operator_execution_packet_no_raw_text",
+            "source_work_order_rank": order.work_order_rank,
+            "source_work_order_status": order.work_order_status,
+            "source_work_order_type": order.work_order_type,
+            "owner_decision": order.owner_decision,
+            "packet_status": policy.packet_status,
+            "packet_type": policy.packet_type,
+            "packet_gate": policy.packet_gate,
+            "packet_action": policy.packet_action,
+            "operator_instruction": policy.operator_instruction,
+            "operator_lane": policy.operator_lane,
+            "escalation_target": policy.escalation_target,
+            "decision_note": order.decision_note,
+            "raw_text_included": False,
+            "send_whatsapp": False,
+            "crm_mutation": False,
+            "requires_human_approval": True,
+        }
+        packet_id = f"operator-execution-packet-{rank:06d}"
+        packet_hash = _hash_packet(
+            {
+                **payload,
+                "packet_id": packet_id,
+                "work_order_id": order.work_order_id,
+                "event_id": order.event_id,
+                "entry_id": order.entry_id,
+                "route_id": order.route_id,
+                "case_card_id": order.case_card_id,
+                "brief_id": order.brief_id,
+                "pack_id": order.pack_id,
+                "packet_rank": rank,
+                "source_work_order_hash": order.work_order_hash,
+            }
+        )
+        packets.append(
+            OperatorExecutionPacket(
+                packet_id=packet_id,
+                work_order_id=order.work_order_id,
+                event_id=order.event_id,
+                entry_id=order.entry_id,
+                route_id=order.route_id,
+                case_card_id=order.case_card_id,
+                brief_id=order.brief_id,
+                pack_id=order.pack_id,
+                packet_rank=rank,
+                assigned_lane=order.assigned_lane,
+                operator_lane=policy.operator_lane,
+                decision_type=order.decision_type,
+                decision_priority=order.decision_priority,
+                route_bucket=order.route_bucket,
+                owner_decision=order.owner_decision,
+                source_work_order_status=order.work_order_status,
+                packet_status=policy.packet_status,
+                packet_type=policy.packet_type,
+                packet_gate=policy.packet_gate,
+                packet_action=policy.packet_action,
+                operator_instruction=policy.operator_instruction,
+                escalation_target=policy.escalation_target,
+                decision_note=order.decision_note,
+                source_work_order_hash=order.work_order_hash,
+                packet_hash=packet_hash,
+                packet_payload=payload,
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(packets)
+
+
+def write_operator_execution_packets_sqlite(
+    output_db: Path,
+    *,
+    packets: Sequence[OperatorExecutionPacket],
+    source_case_count: int,
+    owner_item_count: int,
+    pack_count: int,
+    brief_count: int,
+    queue_item_count: int,
+    ledger_entry_count: int,
+    event_row_count: int,
+    work_order_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    output_db.parent.mkdir(parents=True, exist_ok=True)
+    status_counts = Counter(packet.packet_status for packet in packets)
+    with sqlite3.connect(output_db) as conn:
+        conn.executescript(
+            """
+            DROP TABLE IF EXISTS operator_execution_packet_runs;
+            DROP TABLE IF EXISTS operator_execution_packets;
+
+            CREATE TABLE operator_execution_packet_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_case_count INTEGER NOT NULL,
+                owner_item_count INTEGER NOT NULL,
+                pack_count INTEGER NOT NULL,
+                brief_count INTEGER NOT NULL,
+                queue_item_count INTEGER NOT NULL,
+                ledger_entry_count INTEGER NOT NULL,
+                event_row_count INTEGER NOT NULL,
+                work_order_count INTEGER NOT NULL,
+                packet_count INTEGER NOT NULL,
+                ready_packet_count INTEGER NOT NULL,
+                blocked_packet_count INTEGER NOT NULL,
+                deferred_packet_count INTEGER NOT NULL,
+                rejected_packet_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE operator_execution_packets (
+                packet_id TEXT PRIMARY KEY,
+                work_order_id TEXT NOT NULL,
+                event_id TEXT NOT NULL,
+                entry_id TEXT NOT NULL,
+                route_id TEXT NOT NULL,
+                case_card_id TEXT NOT NULL,
+                brief_id TEXT NOT NULL,
+                pack_id TEXT NOT NULL,
+                packet_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                operator_lane TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                decision_priority TEXT NOT NULL,
+                route_bucket TEXT NOT NULL,
+                owner_decision TEXT NOT NULL,
+                source_work_order_status TEXT NOT NULL,
+                packet_status TEXT NOT NULL,
+                packet_type TEXT NOT NULL,
+                packet_gate TEXT NOT NULL,
+                packet_action TEXT NOT NULL,
+                operator_instruction TEXT NOT NULL,
+                escalation_target TEXT NOT NULL,
+                decision_note TEXT NOT NULL,
+                source_work_order_hash TEXT NOT NULL,
+                packet_hash TEXT NOT NULL UNIQUE,
+                packet_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE INDEX idx_operator_execution_packet_rank
+                ON operator_execution_packets(packet_rank);
+            CREATE INDEX idx_operator_execution_packet_status
+                ON operator_execution_packets(packet_status);
+            CREATE INDEX idx_operator_execution_packet_lane
+                ON operator_execution_packets(operator_lane);
+            CREATE INDEX idx_operator_execution_packet_decision
+                ON operator_execution_packets(owner_decision);
+            CREATE INDEX idx_operator_execution_packet_work_order
+                ON operator_execution_packets(work_order_id);
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO operator_execution_packet_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_case_count, owner_item_count, pack_count, brief_count,
+                queue_item_count, ledger_entry_count, event_row_count,
+                work_order_count, packet_count, ready_packet_count,
+                blocked_packet_count, deferred_packet_count,
+                rejected_packet_count, send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0)
+            """,
+            (
+                generated_at_utc,
+                source_generated_at_utc,
+                "local_only_operator_execution_packet_no_raw_text_no_send_no_crm_mutation",
+                source_case_count,
+                owner_item_count,
+                pack_count,
+                brief_count,
+                queue_item_count,
+                ledger_entry_count,
+                event_row_count,
+                work_order_count,
+                len(packets),
+                status_counts.get("ready_for_operator_review", 0),
+                status_counts.get("blocked_awaiting_owner_decision", 0),
+                status_counts.get("deferred_owner_followup", 0),
+                status_counts.get("rejected_no_action", 0),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO operator_execution_packets (
+                packet_id, work_order_id, event_id, entry_id, route_id,
+                case_card_id, brief_id, pack_id, packet_rank, assigned_lane,
+                operator_lane, decision_type, decision_priority, route_bucket,
+                owner_decision, source_work_order_status, packet_status,
+                packet_type, packet_gate, packet_action, operator_instruction,
+                escalation_target, decision_note, source_work_order_hash,
+                packet_hash, packet_payload_json, send_whatsapp, crm_mutation,
+                requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    packet.packet_id,
+                    packet.work_order_id,
+                    packet.event_id,
+                    packet.entry_id,
+                    packet.route_id,
+                    packet.case_card_id,
+                    packet.brief_id,
+                    packet.pack_id,
+                    packet.packet_rank,
+                    packet.assigned_lane,
+                    packet.operator_lane,
+                    packet.decision_type,
+                    packet.decision_priority,
+                    packet.route_bucket,
+                    packet.owner_decision,
+                    packet.source_work_order_status,
+                    packet.packet_status,
+                    packet.packet_type,
+                    packet.packet_gate,
+                    packet.packet_action,
+                    packet.operator_instruction,
+                    packet.escalation_target,
+                    packet.decision_note,
+                    packet.source_work_order_hash,
+                    packet.packet_hash,
+                    json.dumps(packet.packet_payload, ensure_ascii=False, sort_keys=True),
+                    int(packet.send_whatsapp),
+                    int(packet.crm_mutation),
+                    int(packet.requires_human_approval),
+                )
+                for packet in packets
+            ],
+        )
+        conn.commit()
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'unknown'} | {count} |")
+    return lines
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    packets: Sequence[OperatorExecutionPacket],
+    source_case_count: int,
+    owner_item_count: int,
+    pack_count: int,
+    brief_count: int,
+    queue_item_count: int,
+    ledger_entry_count: int,
+    event_row_count: int,
+    work_order_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    status_counts = Counter(packet.packet_status for packet in packets)
+    type_counts = Counter(packet.packet_type for packet in packets)
+    lane_counts = Counter(packet.operator_lane for packet in packets)
+    decision_counts = Counter(packet.owner_decision for packet in packets)
+    decision_type_counts = Counter(packet.decision_type for packet in packets)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Operator Execution Packets Summary",
+        "",
+        f"Generated UTC: `{generated_at_utc}`",
+        f"Source Post-Decision Work Order Queue UTC: `{source_generated_at_utc}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, case card IDs, judgment IDs, approval IDs, pack IDs, brief IDs, route IDs, ledger entry IDs, event IDs, work order IDs, packet IDs, inbox item IDs, or room item IDs.",
+        "- Operator execution packets are local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Source cases | {source_case_count} |",
+        f"| Owner approval items | {owner_item_count} |",
+        f"| Owner decision packs | {pack_count} |",
+        f"| Owner briefs | {brief_count} |",
+        f"| Queue items | {queue_item_count} |",
+        f"| Ledger entries | {ledger_entry_count} |",
+        f"| Event rows | {event_row_count} |",
+        f"| Work orders | {work_order_count} |",
+        f"| Operator packets | {len(packets)} |",
+        f"| Ready packets | {status_counts.get('ready_for_operator_review', 0)} |",
+        f"| Blocked packets | {status_counts.get('blocked_awaiting_owner_decision', 0)} |",
+        f"| Deferred packets | {status_counts.get('deferred_owner_followup', 0)} |",
+        f"| Rejected packets | {status_counts.get('rejected_no_action', 0)} |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("Packet Status", status_counts),
+        "",
+        *_counter_table("Packet Types", type_counts),
+        "",
+        *_counter_table("Operator Lanes", lane_counts),
+        "",
+        *_counter_table("Owner Decisions", decision_counts),
+        "",
+        *_counter_table("Decision Types", decision_type_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- Operator execution packets are internal instructions only.",
+        "- Pending owner decisions remain blocked and do not become operator work.",
+        "- Approved packets require human review before any send or CRM mutation.",
+        "- Deferred packets wait for owner revisit.",
+        "- Rejected packets stop with no external action.",
+        "- It does not parse raw WhatsApp messages.",
+        "- It does not call a cloud LLM.",
+        "- Runtime must not send WhatsApp messages from this artifact.",
+        "- Runtime must not mutate CRM records from this artifact.",
+        "- Human approval remains mandatory before any client-facing message or operational mutation.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_operator_execution_packets(
+    *,
+    work_orders_db: Path = DEFAULT_WORK_ORDERS_DB,
+    output_dir: Path = DEFAULT_OPERATOR_EXECUTION_PACKET_DIR,
+    output_db: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+    generated_at_utc: str | None = None,
+) -> OperatorExecutionPacketsBuildResult:
+    """Build local-only operator packets from post-decision work orders."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    generated = _format_utc(generated_at_utc)
+    (
+        source_generated,
+        source_case_count,
+        owner_item_count,
+        pack_count,
+        brief_count,
+        queue_item_count,
+        ledger_entry_count,
+        event_row_count,
+        source_work_order_count,
+    ) = read_source_metadata(work_orders_db)
+    work_orders = read_work_orders(work_orders_db)
+    packets = build_packets(work_orders)
+    source_case_total = source_case_count or len(packets)
+    owner_item_total = owner_item_count or len(packets)
+    pack_total = pack_count or len(packets)
+    brief_total = brief_count or len(packets)
+    queue_total = queue_item_count or len(packets)
+    ledger_total = ledger_entry_count or len(packets)
+    event_row_total = event_row_count or len(packets)
+    work_order_total = source_work_order_count or len(work_orders)
+    write_operator_execution_packets_sqlite(
+        output_db,
+        packets=packets,
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        brief_count=brief_total,
+        queue_item_count=queue_total,
+        ledger_entry_count=ledger_total,
+        event_row_count=event_row_total,
+        work_order_count=work_order_total,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    write_summary(
+        summary_path=summary_path,
+        packets=packets,
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        brief_count=brief_total,
+        queue_item_count=queue_total,
+        ledger_entry_count=ledger_total,
+        event_row_count=event_row_total,
+        work_order_count=work_order_total,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    status_counts = Counter(packet.packet_status for packet in packets)
+    lane_counts = Counter(packet.operator_lane for packet in packets)
+    return OperatorExecutionPacketsBuildResult(
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        brief_count=brief_total,
+        queue_item_count=queue_total,
+        ledger_entry_count=ledger_total,
+        event_row_count=event_row_total,
+        work_order_count=work_order_total,
+        packet_count=len(packets),
+        ready_packet_count=status_counts.get("ready_for_operator_review", 0),
+        blocked_packet_count=status_counts.get("blocked_awaiting_owner_decision", 0),
+        deferred_packet_count=status_counts.get("deferred_owner_followup", 0),
+        rejected_packet_count=status_counts.get("rejected_no_action", 0),
+        send_whatsapp_count=sum(1 for packet in packets if packet.send_whatsapp),
+        crm_mutation_count=sum(1 for packet in packets if packet.crm_mutation),
+        packet_status_counts=dict(status_counts),
+        operator_lane_counts=dict(lane_counts),
+        output_db=output_db,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build local-only Zantara operator execution packets."
+    )
+    parser.add_argument("--work-orders-db", type=Path, default=DEFAULT_WORK_ORDERS_DB)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OPERATOR_EXECUTION_PACKET_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--generated-at-utc", default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_operator_execution_packets(
+            work_orders_db=args.work_orders_db,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            summary_path=args.summary,
+            generated_at_utc=args.generated_at_utc,
+        )
+    except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
+        print("ERROR: Operator execution packets input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError):
+        print("ERROR: Operator execution packets run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        print("ERROR: Operator execution packets run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "blocked_packet_count": result.blocked_packet_count,
+                    "brief_count": result.brief_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                    "deferred_packet_count": result.deferred_packet_count,
+                    "event_row_count": result.event_row_count,
+                    "ledger_entry_count": result.ledger_entry_count,
+                    "operator_packet_count": result.packet_count,
+                    "owner_item_count": result.owner_item_count,
+                    "pack_count": result.pack_count,
+                    "queue_item_count": result.queue_item_count,
+                    "ready_packet_count": result.ready_packet_count,
+                    "rejected_packet_count": result.rejected_packet_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "source_case_count": result.source_case_count,
+                    "work_order_count": result.work_order_count,
+                },
+                sort_keys=True,
+            )
+        )
+    else:
+        print(
+            "Operator execution packets complete: "
+            f"{result.packet_count} packets -> {result.output_db.name}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/whatsapp_corpus/build_operator_packet_review_console.py
+++ b/scripts/whatsapp_corpus/build_operator_packet_review_console.py
@@ -1,0 +1,876 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_OPERATOR_EXECUTION_PACKET_DIR = Path(
+    "research/personal/wa-corpus/operator-execution-packets"
+)
+DEFAULT_OPERATOR_PACKET_REVIEW_CONSOLE_DIR = Path(
+    "research/personal/wa-corpus/operator-packet-review-console"
+)
+
+DEFAULT_PACKETS_DB = (
+    DEFAULT_OPERATOR_EXECUTION_PACKET_DIR
+    / "operator_execution_packets.local.sqlite"
+)
+DEFAULT_OUTPUT_DB = (
+    DEFAULT_OPERATOR_PACKET_REVIEW_CONSOLE_DIR
+    / "operator_packet_review_console.local.sqlite"
+)
+DEFAULT_SUMMARY = (
+    DEFAULT_OPERATOR_PACKET_REVIEW_CONSOLE_DIR
+    / "operator_packet_review_console_summary.md"
+)
+
+EXPECTED_PACKETS_DB_NAME = "operator_execution_packets.local.sqlite"
+
+
+@dataclass(frozen=True)
+class OperatorExecutionPacketRow:
+    packet_id: str
+    work_order_id: str
+    event_id: str
+    entry_id: str
+    route_id: str
+    case_card_id: str
+    brief_id: str
+    pack_id: str
+    packet_rank: int
+    assigned_lane: str
+    operator_lane: str
+    decision_type: str
+    decision_priority: str
+    route_bucket: str
+    owner_decision: str
+    source_work_order_status: str
+    packet_status: str
+    packet_type: str
+    packet_gate: str
+    packet_action: str
+    operator_instruction: str
+    escalation_target: str
+    decision_note: str
+    source_work_order_hash: str
+    packet_hash: str
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class ReviewConsolePolicy:
+    review_state: str
+    console_bucket: str
+    review_priority: str
+    visible_owner_action: str
+    operator_action: str
+    console_instruction: str
+    review_gate: str
+    action_lock: str
+
+
+@dataclass(frozen=True)
+class OperatorPacketReviewItem:
+    review_item_id: str
+    packet_id: str
+    work_order_id: str
+    event_id: str
+    entry_id: str
+    route_id: str
+    case_card_id: str
+    brief_id: str
+    pack_id: str
+    review_rank: int
+    source_packet_rank: int
+    assigned_lane: str
+    operator_lane: str
+    decision_type: str
+    decision_priority: str
+    route_bucket: str
+    owner_decision: str
+    packet_status: str
+    packet_type: str
+    packet_gate: str
+    packet_action: str
+    operator_instruction: str
+    escalation_target: str
+    review_state: str
+    console_bucket: str
+    review_priority: str
+    visible_owner_action: str
+    operator_action: str
+    console_instruction: str
+    review_gate: str
+    action_lock: str
+    decision_note: str
+    source_packet_hash: str
+    review_hash: str
+    review_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OperatorPacketReviewConsoleBuildResult:
+    source_case_count: int
+    owner_item_count: int
+    pack_count: int
+    brief_count: int
+    queue_item_count: int
+    ledger_entry_count: int
+    event_row_count: int
+    work_order_count: int
+    packet_count: int
+    review_item_count: int
+    owner_decision_item_count: int
+    operator_ready_item_count: int
+    deferred_item_count: int
+    rejected_item_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    review_state_counts: dict[str, int]
+    console_bucket_counts: dict[str, int]
+    output_db: Path
+    summary_path: Path
+
+
+def _format_utc(value: str | None = None) -> str:
+    if value is not None:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).isoformat(timespec="seconds")
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _connect_ro(db_path: Path, *, expected_name: str, label: str) -> sqlite3.Connection:
+    if db_path.name != expected_name:
+        raise ValueError(f"Refusing to read unexpected {label} DB: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"{label} DB not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _hash_review_item(payload: dict[str, object]) -> str:
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def read_source_metadata(db_path: Path) -> tuple[str, int, int, int, int, int, int, int, int, int]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_PACKETS_DB_NAME,
+        label="Operator Execution Packets",
+    ) as conn:
+        row = conn.execute(
+            """
+            SELECT generated_at_utc, source_case_count, owner_item_count,
+                   pack_count, brief_count, queue_item_count, ledger_entry_count,
+                   event_row_count, work_order_count, packet_count
+            FROM operator_execution_packet_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+    if row is None:
+        return "unknown", 0, 0, 0, 0, 0, 0, 0, 0, 0
+    return (
+        str(row["generated_at_utc"]),
+        int(row["source_case_count"]),
+        int(row["owner_item_count"]),
+        int(row["pack_count"]),
+        int(row["brief_count"]),
+        int(row["queue_item_count"]),
+        int(row["ledger_entry_count"]),
+        int(row["event_row_count"]),
+        int(row["work_order_count"]),
+        int(row["packet_count"]),
+    )
+
+
+def read_operator_packets(db_path: Path) -> tuple[OperatorExecutionPacketRow, ...]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_PACKETS_DB_NAME,
+        label="Operator Execution Packets",
+    ) as conn:
+        rows = conn.execute(
+            """
+            SELECT packet_id, work_order_id, event_id, entry_id, route_id,
+                   case_card_id, brief_id, pack_id, packet_rank, assigned_lane,
+                   operator_lane, decision_type, decision_priority, route_bucket,
+                   owner_decision, source_work_order_status, packet_status,
+                   packet_type, packet_gate, packet_action, operator_instruction,
+                   escalation_target, decision_note, source_work_order_hash,
+                   packet_hash, send_whatsapp, crm_mutation,
+                   requires_human_approval
+            FROM operator_execution_packets
+            ORDER BY packet_rank, case_card_id
+            """
+        ).fetchall()
+    return tuple(
+        OperatorExecutionPacketRow(
+            packet_id=str(row["packet_id"]),
+            work_order_id=str(row["work_order_id"]),
+            event_id=str(row["event_id"]),
+            entry_id=str(row["entry_id"]),
+            route_id=str(row["route_id"]),
+            case_card_id=str(row["case_card_id"]),
+            brief_id=str(row["brief_id"]),
+            pack_id=str(row["pack_id"]),
+            packet_rank=int(row["packet_rank"]),
+            assigned_lane=str(row["assigned_lane"]),
+            operator_lane=str(row["operator_lane"]),
+            decision_type=str(row["decision_type"]),
+            decision_priority=str(row["decision_priority"]),
+            route_bucket=str(row["route_bucket"]),
+            owner_decision=str(row["owner_decision"]),
+            source_work_order_status=str(row["source_work_order_status"]),
+            packet_status=str(row["packet_status"]),
+            packet_type=str(row["packet_type"]),
+            packet_gate=str(row["packet_gate"]),
+            packet_action=str(row["packet_action"]),
+            operator_instruction=str(row["operator_instruction"]),
+            escalation_target=str(row["escalation_target"]),
+            decision_note=str(row["decision_note"]),
+            source_work_order_hash=str(row["source_work_order_hash"]),
+            packet_hash=str(row["packet_hash"]),
+            send_whatsapp=bool(row["send_whatsapp"]),
+            crm_mutation=bool(row["crm_mutation"]),
+            requires_human_approval=bool(row["requires_human_approval"]),
+        )
+        for row in rows
+    )
+
+
+def derive_review_console_policy(packet: OperatorExecutionPacketRow) -> ReviewConsolePolicy:
+    if packet.send_whatsapp or packet.crm_mutation:
+        raise ValueError(f"Unsafe packet flags on {packet.packet_id}")
+    if not packet.requires_human_approval:
+        raise ValueError(f"Packet missing human approval gate: {packet.packet_id}")
+
+    allowed_statuses = {
+        "ready_for_operator_review",
+        "blocked_awaiting_owner_decision",
+        "deferred_owner_followup",
+        "rejected_no_action",
+    }
+    if packet.packet_status not in allowed_statuses:
+        raise ValueError(
+            f"Unsupported packet status for {packet.packet_id}: {packet.packet_status}"
+        )
+
+    if (
+        packet.packet_status == "blocked_awaiting_owner_decision"
+        or packet.owner_decision == "pending"
+    ):
+        return ReviewConsolePolicy(
+            review_state="waiting_owner_decision",
+            console_bucket="owner_decision_inbox",
+            review_priority="owner_now",
+            visible_owner_action="capture_owner_decision",
+            operator_action="no_operator_action",
+            console_instruction="owner_must_approve_reject_or_defer_before_team_work",
+            review_gate="owner_input_required",
+            action_lock="locked_until_owner_decision",
+        )
+    if (
+        packet.packet_status == "ready_for_operator_review"
+        and packet.owner_decision == "approve"
+    ):
+        return ReviewConsolePolicy(
+            review_state="ready_for_human_review",
+            console_bucket="operator_review_queue",
+            review_priority="operator_now",
+            visible_owner_action="no_owner_action_required",
+            operator_action="review_packet_before_send_or_crm",
+            console_instruction="review_ready_packet_and_request_human_approval",
+            review_gate="human_review_before_send_or_crm",
+            action_lock="locked_until_human_review",
+        )
+    if packet.packet_status == "deferred_owner_followup" or packet.owner_decision == "defer":
+        return ReviewConsolePolicy(
+            review_state="deferred_owner_revisit",
+            console_bucket="owner_revisit_queue",
+            review_priority="owner_revisit",
+            visible_owner_action="revisit_deferred_decision",
+            operator_action="no_operator_action",
+            console_instruction="owner_must_revisit_deferred_packet",
+            review_gate="owner_revisit_required",
+            action_lock="locked_until_owner_revisit",
+        )
+    if packet.packet_status == "rejected_no_action" or packet.owner_decision == "reject":
+        return ReviewConsolePolicy(
+            review_state="rejected_closed",
+            console_bucket="closed_no_action",
+            review_priority="closed",
+            visible_owner_action="no_action",
+            operator_action="no_operator_action",
+            console_instruction="no_action_packet_rejected",
+            review_gate="no_external_action",
+            action_lock="closed_no_external_action",
+        )
+    raise ValueError(
+        f"Unsupported packet status for {packet.packet_id}: {packet.packet_status}"
+    )
+
+
+def build_review_items(
+    packets: Sequence[OperatorExecutionPacketRow],
+) -> tuple[OperatorPacketReviewItem, ...]:
+    items: list[OperatorPacketReviewItem] = []
+    for rank, packet in enumerate(packets, start=1):
+        policy = derive_review_console_policy(packet)
+        payload = {
+            "schema_version": "operator_packet_review_console.v1",
+            "privacy_mode": "local_only_operator_packet_review_console_no_raw_text",
+            "source_packet_rank": packet.packet_rank,
+            "packet_status": packet.packet_status,
+            "packet_type": packet.packet_type,
+            "packet_gate": packet.packet_gate,
+            "packet_action": packet.packet_action,
+            "owner_decision": packet.owner_decision,
+            "review_state": policy.review_state,
+            "console_bucket": policy.console_bucket,
+            "review_priority": policy.review_priority,
+            "visible_owner_action": policy.visible_owner_action,
+            "operator_action": policy.operator_action,
+            "console_instruction": policy.console_instruction,
+            "review_gate": policy.review_gate,
+            "action_lock": policy.action_lock,
+            "raw_text_included": False,
+            "send_whatsapp": False,
+            "crm_mutation": False,
+            "requires_human_approval": True,
+        }
+        review_item_id = f"operator-packet-review-item-{rank:06d}"
+        review_hash = _hash_review_item(
+            {
+                **payload,
+                "review_item_id": review_item_id,
+                "packet_id": packet.packet_id,
+                "work_order_id": packet.work_order_id,
+                "event_id": packet.event_id,
+                "entry_id": packet.entry_id,
+                "route_id": packet.route_id,
+                "case_card_id": packet.case_card_id,
+                "brief_id": packet.brief_id,
+                "pack_id": packet.pack_id,
+                "review_rank": rank,
+                "source_packet_hash": packet.packet_hash,
+            }
+        )
+        items.append(
+            OperatorPacketReviewItem(
+                review_item_id=review_item_id,
+                packet_id=packet.packet_id,
+                work_order_id=packet.work_order_id,
+                event_id=packet.event_id,
+                entry_id=packet.entry_id,
+                route_id=packet.route_id,
+                case_card_id=packet.case_card_id,
+                brief_id=packet.brief_id,
+                pack_id=packet.pack_id,
+                review_rank=rank,
+                source_packet_rank=packet.packet_rank,
+                assigned_lane=packet.assigned_lane,
+                operator_lane=packet.operator_lane,
+                decision_type=packet.decision_type,
+                decision_priority=packet.decision_priority,
+                route_bucket=packet.route_bucket,
+                owner_decision=packet.owner_decision,
+                packet_status=packet.packet_status,
+                packet_type=packet.packet_type,
+                packet_gate=packet.packet_gate,
+                packet_action=packet.packet_action,
+                operator_instruction=packet.operator_instruction,
+                escalation_target=packet.escalation_target,
+                review_state=policy.review_state,
+                console_bucket=policy.console_bucket,
+                review_priority=policy.review_priority,
+                visible_owner_action=policy.visible_owner_action,
+                operator_action=policy.operator_action,
+                console_instruction=policy.console_instruction,
+                review_gate=policy.review_gate,
+                action_lock=policy.action_lock,
+                decision_note=packet.decision_note,
+                source_packet_hash=packet.packet_hash,
+                review_hash=review_hash,
+                review_payload=payload,
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(items)
+
+
+def write_operator_packet_review_console_sqlite(
+    output_db: Path,
+    *,
+    review_items: Sequence[OperatorPacketReviewItem],
+    source_case_count: int,
+    owner_item_count: int,
+    pack_count: int,
+    brief_count: int,
+    queue_item_count: int,
+    ledger_entry_count: int,
+    event_row_count: int,
+    work_order_count: int,
+    packet_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    output_db.parent.mkdir(parents=True, exist_ok=True)
+    state_counts = Counter(item.review_state for item in review_items)
+    with sqlite3.connect(output_db) as conn:
+        conn.executescript(
+            """
+            DROP TABLE IF EXISTS operator_packet_review_console_runs;
+            DROP TABLE IF EXISTS operator_packet_review_items;
+
+            CREATE TABLE operator_packet_review_console_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_case_count INTEGER NOT NULL,
+                owner_item_count INTEGER NOT NULL,
+                pack_count INTEGER NOT NULL,
+                brief_count INTEGER NOT NULL,
+                queue_item_count INTEGER NOT NULL,
+                ledger_entry_count INTEGER NOT NULL,
+                event_row_count INTEGER NOT NULL,
+                work_order_count INTEGER NOT NULL,
+                packet_count INTEGER NOT NULL,
+                review_item_count INTEGER NOT NULL,
+                owner_decision_item_count INTEGER NOT NULL,
+                operator_ready_item_count INTEGER NOT NULL,
+                deferred_item_count INTEGER NOT NULL,
+                rejected_item_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE operator_packet_review_items (
+                review_item_id TEXT PRIMARY KEY,
+                packet_id TEXT NOT NULL,
+                work_order_id TEXT NOT NULL,
+                event_id TEXT NOT NULL,
+                entry_id TEXT NOT NULL,
+                route_id TEXT NOT NULL,
+                case_card_id TEXT NOT NULL,
+                brief_id TEXT NOT NULL,
+                pack_id TEXT NOT NULL,
+                review_rank INTEGER NOT NULL,
+                source_packet_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                operator_lane TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                decision_priority TEXT NOT NULL,
+                route_bucket TEXT NOT NULL,
+                owner_decision TEXT NOT NULL,
+                packet_status TEXT NOT NULL,
+                packet_type TEXT NOT NULL,
+                packet_gate TEXT NOT NULL,
+                packet_action TEXT NOT NULL,
+                operator_instruction TEXT NOT NULL,
+                escalation_target TEXT NOT NULL,
+                review_state TEXT NOT NULL,
+                console_bucket TEXT NOT NULL,
+                review_priority TEXT NOT NULL,
+                visible_owner_action TEXT NOT NULL,
+                operator_action TEXT NOT NULL,
+                console_instruction TEXT NOT NULL,
+                review_gate TEXT NOT NULL,
+                action_lock TEXT NOT NULL,
+                decision_note TEXT NOT NULL,
+                source_packet_hash TEXT NOT NULL,
+                review_hash TEXT NOT NULL UNIQUE,
+                review_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE INDEX idx_operator_packet_review_rank
+                ON operator_packet_review_items(review_rank);
+            CREATE INDEX idx_operator_packet_review_state
+                ON operator_packet_review_items(review_state);
+            CREATE INDEX idx_operator_packet_review_bucket
+                ON operator_packet_review_items(console_bucket);
+            CREATE INDEX idx_operator_packet_review_lane
+                ON operator_packet_review_items(operator_lane);
+            CREATE INDEX idx_operator_packet_review_packet
+                ON operator_packet_review_items(packet_id);
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO operator_packet_review_console_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_case_count, owner_item_count, pack_count, brief_count,
+                queue_item_count, ledger_entry_count, event_row_count,
+                work_order_count, packet_count, review_item_count,
+                owner_decision_item_count, operator_ready_item_count,
+                deferred_item_count, rejected_item_count,
+                send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0)
+            """,
+            (
+                generated_at_utc,
+                source_generated_at_utc,
+                "local_only_operator_packet_review_console_no_raw_text_no_send_no_crm_mutation",
+                source_case_count,
+                owner_item_count,
+                pack_count,
+                brief_count,
+                queue_item_count,
+                ledger_entry_count,
+                event_row_count,
+                work_order_count,
+                packet_count,
+                len(review_items),
+                state_counts.get("waiting_owner_decision", 0),
+                state_counts.get("ready_for_human_review", 0),
+                state_counts.get("deferred_owner_revisit", 0),
+                state_counts.get("rejected_closed", 0),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO operator_packet_review_items (
+                review_item_id, packet_id, work_order_id, event_id, entry_id,
+                route_id, case_card_id, brief_id, pack_id, review_rank,
+                source_packet_rank, assigned_lane, operator_lane, decision_type,
+                decision_priority, route_bucket, owner_decision, packet_status,
+                packet_type, packet_gate, packet_action, operator_instruction,
+                escalation_target, review_state, console_bucket, review_priority,
+                visible_owner_action, operator_action, console_instruction,
+                review_gate, action_lock, decision_note, source_packet_hash,
+                review_hash, review_payload_json, send_whatsapp, crm_mutation,
+                requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    item.review_item_id,
+                    item.packet_id,
+                    item.work_order_id,
+                    item.event_id,
+                    item.entry_id,
+                    item.route_id,
+                    item.case_card_id,
+                    item.brief_id,
+                    item.pack_id,
+                    item.review_rank,
+                    item.source_packet_rank,
+                    item.assigned_lane,
+                    item.operator_lane,
+                    item.decision_type,
+                    item.decision_priority,
+                    item.route_bucket,
+                    item.owner_decision,
+                    item.packet_status,
+                    item.packet_type,
+                    item.packet_gate,
+                    item.packet_action,
+                    item.operator_instruction,
+                    item.escalation_target,
+                    item.review_state,
+                    item.console_bucket,
+                    item.review_priority,
+                    item.visible_owner_action,
+                    item.operator_action,
+                    item.console_instruction,
+                    item.review_gate,
+                    item.action_lock,
+                    item.decision_note,
+                    item.source_packet_hash,
+                    item.review_hash,
+                    json.dumps(item.review_payload, ensure_ascii=False, sort_keys=True),
+                    int(item.send_whatsapp),
+                    int(item.crm_mutation),
+                    int(item.requires_human_approval),
+                )
+                for item in review_items
+            ],
+        )
+        conn.commit()
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'unknown'} | {count} |")
+    return lines
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    review_items: Sequence[OperatorPacketReviewItem],
+    source_case_count: int,
+    owner_item_count: int,
+    pack_count: int,
+    brief_count: int,
+    queue_item_count: int,
+    ledger_entry_count: int,
+    event_row_count: int,
+    work_order_count: int,
+    packet_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    state_counts = Counter(item.review_state for item in review_items)
+    bucket_counts = Counter(item.console_bucket for item in review_items)
+    priority_counts = Counter(item.review_priority for item in review_items)
+    lane_counts = Counter(item.operator_lane for item in review_items)
+    owner_action_counts = Counter(item.visible_owner_action for item in review_items)
+    operator_action_counts = Counter(item.operator_action for item in review_items)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Operator Packet Review Console Summary",
+        "",
+        f"Generated UTC: `{generated_at_utc}`",
+        f"Source Operator Execution Packets UTC: `{source_generated_at_utc}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, case card IDs, judgment IDs, approval IDs, pack IDs, brief IDs, route IDs, ledger entry IDs, event IDs, work order IDs, packet IDs, review item IDs, inbox item IDs, or room item IDs.",
+        "- Operator packet review console artifacts are local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Source cases | {source_case_count} |",
+        f"| Owner approval items | {owner_item_count} |",
+        f"| Owner decision packs | {pack_count} |",
+        f"| Owner briefs | {brief_count} |",
+        f"| Queue items | {queue_item_count} |",
+        f"| Ledger entries | {ledger_entry_count} |",
+        f"| Event rows | {event_row_count} |",
+        f"| Work orders | {work_order_count} |",
+        f"| Operator packets | {packet_count} |",
+        f"| Review items | {len(review_items)} |",
+        f"| Owner decision items | {state_counts.get('waiting_owner_decision', 0)} |",
+        f"| Operator-ready items | {state_counts.get('ready_for_human_review', 0)} |",
+        f"| Deferred items | {state_counts.get('deferred_owner_revisit', 0)} |",
+        f"| Rejected items | {state_counts.get('rejected_closed', 0)} |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("Review States", state_counts),
+        "",
+        *_counter_table("Console Buckets", bucket_counts),
+        "",
+        *_counter_table("Review Priorities", priority_counts),
+        "",
+        *_counter_table("Operator Lanes", lane_counts),
+        "",
+        *_counter_table("Visible Owner Actions", owner_action_counts),
+        "",
+        *_counter_table("Operator Actions", operator_action_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- The review console is an internal operator and owner reading surface only.",
+        "- Waiting-owner items require explicit owner approve, reject, or defer before team work.",
+        "- Operator-ready items remain locked until human review before send or CRM mutation.",
+        "- Deferred items remain locked until owner revisit.",
+        "- Rejected items are closed with no external action.",
+        "- It does not parse raw WhatsApp messages.",
+        "- It does not call a cloud LLM.",
+        "- Runtime must not send WhatsApp messages from this artifact.",
+        "- Runtime must not mutate CRM records from this artifact.",
+        "- Human approval remains mandatory before any client-facing message or operational mutation.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_operator_packet_review_console(
+    *,
+    packets_db: Path = DEFAULT_PACKETS_DB,
+    output_dir: Path = DEFAULT_OPERATOR_PACKET_REVIEW_CONSOLE_DIR,
+    output_db: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+    generated_at_utc: str | None = None,
+) -> OperatorPacketReviewConsoleBuildResult:
+    """Build local-only review console rows from operator execution packets."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    generated = _format_utc(generated_at_utc)
+    (
+        source_generated,
+        source_case_count,
+        owner_item_count,
+        pack_count,
+        brief_count,
+        queue_item_count,
+        ledger_entry_count,
+        event_row_count,
+        work_order_count,
+        source_packet_count,
+    ) = read_source_metadata(packets_db)
+    packets = read_operator_packets(packets_db)
+    review_items = build_review_items(packets)
+    source_case_total = source_case_count or len(review_items)
+    owner_item_total = owner_item_count or len(review_items)
+    pack_total = pack_count or len(review_items)
+    brief_total = brief_count or len(review_items)
+    queue_total = queue_item_count or len(review_items)
+    ledger_total = ledger_entry_count or len(review_items)
+    event_row_total = event_row_count or len(review_items)
+    work_order_total = work_order_count or len(review_items)
+    packet_total = source_packet_count or len(packets)
+    write_operator_packet_review_console_sqlite(
+        output_db,
+        review_items=review_items,
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        brief_count=brief_total,
+        queue_item_count=queue_total,
+        ledger_entry_count=ledger_total,
+        event_row_count=event_row_total,
+        work_order_count=work_order_total,
+        packet_count=packet_total,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    write_summary(
+        summary_path=summary_path,
+        review_items=review_items,
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        brief_count=brief_total,
+        queue_item_count=queue_total,
+        ledger_entry_count=ledger_total,
+        event_row_count=event_row_total,
+        work_order_count=work_order_total,
+        packet_count=packet_total,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    state_counts = Counter(item.review_state for item in review_items)
+    bucket_counts = Counter(item.console_bucket for item in review_items)
+    return OperatorPacketReviewConsoleBuildResult(
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        brief_count=brief_total,
+        queue_item_count=queue_total,
+        ledger_entry_count=ledger_total,
+        event_row_count=event_row_total,
+        work_order_count=work_order_total,
+        packet_count=packet_total,
+        review_item_count=len(review_items),
+        owner_decision_item_count=state_counts.get("waiting_owner_decision", 0),
+        operator_ready_item_count=state_counts.get("ready_for_human_review", 0),
+        deferred_item_count=state_counts.get("deferred_owner_revisit", 0),
+        rejected_item_count=state_counts.get("rejected_closed", 0),
+        send_whatsapp_count=sum(1 for item in review_items if item.send_whatsapp),
+        crm_mutation_count=sum(1 for item in review_items if item.crm_mutation),
+        review_state_counts=dict(state_counts),
+        console_bucket_counts=dict(bucket_counts),
+        output_db=output_db,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build local-only Zantara operator packet review console."
+    )
+    parser.add_argument("--packets-db", type=Path, default=DEFAULT_PACKETS_DB)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OPERATOR_PACKET_REVIEW_CONSOLE_DIR,
+    )
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--generated-at-utc", default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_operator_packet_review_console(
+            packets_db=args.packets_db,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            summary_path=args.summary,
+            generated_at_utc=args.generated_at_utc,
+        )
+    except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
+        print("ERROR: Operator packet review console input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError):
+        print("ERROR: Operator packet review console run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        print("ERROR: Operator packet review console run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "brief_count": result.brief_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                    "deferred_item_count": result.deferred_item_count,
+                    "event_row_count": result.event_row_count,
+                    "ledger_entry_count": result.ledger_entry_count,
+                    "operator_ready_item_count": result.operator_ready_item_count,
+                    "owner_decision_item_count": result.owner_decision_item_count,
+                    "owner_item_count": result.owner_item_count,
+                    "pack_count": result.pack_count,
+                    "packet_count": result.packet_count,
+                    "queue_item_count": result.queue_item_count,
+                    "rejected_item_count": result.rejected_item_count,
+                    "review_item_count": result.review_item_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "source_case_count": result.source_case_count,
+                    "work_order_count": result.work_order_count,
+                },
+                sort_keys=True,
+            )
+        )
+    else:
+        print(
+            "Operator packet review console complete: "
+            f"{result.review_item_count} review items -> {result.output_db.name}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/whatsapp_corpus/build_operator_sla_clock.py
+++ b/scripts/whatsapp_corpus/build_operator_sla_clock.py
@@ -1,0 +1,533 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_OPERATOR_INBOX_DIR = Path("research/personal/wa-corpus/operator-action-inbox")
+DEFAULT_SLA_CLOCK_DIR = Path("research/personal/wa-corpus/operator-sla-clock")
+DEFAULT_OPERATOR_INBOX_DB = DEFAULT_OPERATOR_INBOX_DIR / "operator_action_inbox.local.sqlite"
+DEFAULT_OUTPUT_DB = DEFAULT_SLA_CLOCK_DIR / "operator_sla_clock.local.sqlite"
+DEFAULT_SUMMARY = DEFAULT_SLA_CLOCK_DIR / "operator_sla_clock_summary.md"
+
+EXPECTED_OPERATOR_INBOX_DB_NAME = "operator_action_inbox.local.sqlite"
+
+SLA_MINUTES_BY_BUCKET = {
+    "finance_now": 120,
+    "follow_up_now": 240,
+    "status_check_now": 240,
+    "team_escalation_now": 240,
+    "document_gap_now": 360,
+    "finance_today": 480,
+    "follow_up_today": 720,
+    "document_gap_today": 1440,
+    "status_check_today": 1440,
+    "team_escalation_today": 1440,
+}
+
+
+@dataclass(frozen=True)
+class OperatorInboxRow:
+    inbox_item_id: str
+    case_card_id: str
+    queue_rank: int
+    assigned_lane: str
+    priority_label: str
+    queue_bucket: str
+    action_code: str
+    reason_code: str
+    urgency_score: int
+    combined_score: int
+    approval_mode: str
+    item_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OperatorSlaClock:
+    inbox_item_id: str
+    case_card_id: str
+    queue_rank: int
+    assigned_lane: str
+    priority_label: str
+    queue_bucket: str
+    action_code: str
+    reason_code: str
+    sla_minutes: int
+    source_inbox_generated_at_utc: str
+    due_at_utc: str
+    as_of_utc: str
+    minutes_until_due: int
+    aging_minutes: int
+    sla_status: str
+    breach_risk: str
+    escalation_label: str
+    clock_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OperatorSlaClockBuildResult:
+    inbox_item_count: int
+    clock_count: int
+    overdue_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    status_counts: dict[str, int]
+    breach_risk_counts: dict[str, int]
+    lane_counts: dict[str, int]
+    output_db: Path
+    summary_path: Path
+
+
+def _parse_utc(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _format_utc(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat(timespec="seconds")
+
+
+def _connect_operator_inbox(db_path: Path) -> sqlite3.Connection:
+    if db_path.name != EXPECTED_OPERATOR_INBOX_DB_NAME:
+        raise ValueError(f"Refusing to read unexpected Operator Inbox DB: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"Operator Inbox DB not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def read_operator_inbox(
+    db_path: Path,
+) -> tuple[str, tuple[OperatorInboxRow, ...]]:
+    with _connect_operator_inbox(db_path) as conn:
+        run = conn.execute(
+            "SELECT generated_at_utc FROM operator_action_inbox_runs WHERE id = 1"
+        ).fetchone()
+        if run is None:
+            raise ValueError("Operator Inbox DB is missing operator_action_inbox_runs row 1")
+        rows = conn.execute(
+            """
+            SELECT inbox_item_id, case_card_id, queue_rank, assigned_lane,
+                   priority_label, queue_bucket, action_code, reason_code,
+                   urgency_score, combined_score, approval_mode,
+                   item_payload_json, send_whatsapp, crm_mutation,
+                   requires_human_approval
+            FROM operator_action_inbox
+            ORDER BY queue_rank, inbox_item_id
+            """
+        ).fetchall()
+    return (
+        str(run["generated_at_utc"]),
+        tuple(
+            OperatorInboxRow(
+                inbox_item_id=str(row["inbox_item_id"]),
+                case_card_id=str(row["case_card_id"]),
+                queue_rank=int(row["queue_rank"]),
+                assigned_lane=str(row["assigned_lane"]),
+                priority_label=str(row["priority_label"]),
+                queue_bucket=str(row["queue_bucket"]),
+                action_code=str(row["action_code"]),
+                reason_code=str(row["reason_code"]),
+                urgency_score=int(row["urgency_score"]),
+                combined_score=int(row["combined_score"]),
+                approval_mode=str(row["approval_mode"]),
+                item_payload=json.loads(str(row["item_payload_json"])),
+                send_whatsapp=bool(row["send_whatsapp"]),
+                crm_mutation=bool(row["crm_mutation"]),
+                requires_human_approval=bool(row["requires_human_approval"]),
+            )
+            for row in rows
+        ),
+    )
+
+
+def _sla_minutes(row: OperatorInboxRow) -> int:
+    if row.queue_bucket in SLA_MINUTES_BY_BUCKET:
+        return SLA_MINUTES_BY_BUCKET[row.queue_bucket]
+    return {"now": 240, "today": 1440, "next": 4320}.get(row.priority_label, 1440)
+
+
+def _sla_status(minutes_until_due: int) -> str:
+    if minutes_until_due < 0:
+        return "overdue"
+    if minutes_until_due <= 240:
+        return "due_today"
+    if minutes_until_due <= 1440:
+        return "due_today"
+    return "scheduled"
+
+
+def _breach_risk(status: str, minutes_until_due: int, priority_label: str) -> str:
+    if status == "overdue":
+        return "breached"
+    if priority_label == "now" or minutes_until_due <= 240:
+        return "high"
+    if status == "due_today":
+        return "medium"
+    return "low"
+
+
+def _escalation_label(breach_risk: str) -> str:
+    return {
+        "breached": "owner_review",
+        "high": "lane_lead_watch",
+        "medium": "operator_watch",
+        "low": "none",
+    }.get(breach_risk, "operator_watch")
+
+
+def build_sla_clocks(
+    rows: Sequence[OperatorInboxRow],
+    *,
+    source_inbox_generated_at_utc: str,
+    as_of_utc: str,
+) -> tuple[OperatorSlaClock, ...]:
+    source_generated = _parse_utc(source_inbox_generated_at_utc)
+    as_of = _parse_utc(as_of_utc)
+    clocks: list[OperatorSlaClock] = []
+    for row in rows:
+        sla_minutes = _sla_minutes(row)
+        due_at = source_generated + timedelta(minutes=sla_minutes)
+        minutes_until_due = int((due_at - as_of).total_seconds() // 60)
+        aging_minutes = max(0, int((as_of - source_generated).total_seconds() // 60))
+        status = _sla_status(minutes_until_due)
+        risk = _breach_risk(status, minutes_until_due, row.priority_label)
+        payload = {
+            "schema_version": "operator_sla_clock.v1",
+            "privacy_mode": "local_only_operator_sla_no_raw_text",
+            "source_priority_label": row.priority_label,
+            "source_queue_bucket": row.queue_bucket,
+            "source_action_code": row.action_code,
+            "source_reason_code": row.reason_code,
+            "source_risk_level": row.item_payload.get("source_risk_level", "unknown"),
+            "latest_movement": row.item_payload.get("latest_movement", "unknown"),
+            "sla_minutes": sla_minutes,
+            "sla_status": status,
+            "breach_risk": risk,
+            "raw_text_included": False,
+            "send_whatsapp": False,
+            "crm_mutation": False,
+            "requires_human_approval": True,
+        }
+        clocks.append(
+            OperatorSlaClock(
+                inbox_item_id=row.inbox_item_id,
+                case_card_id=row.case_card_id,
+                queue_rank=row.queue_rank,
+                assigned_lane=row.assigned_lane,
+                priority_label=row.priority_label,
+                queue_bucket=row.queue_bucket,
+                action_code=row.action_code,
+                reason_code=row.reason_code,
+                sla_minutes=sla_minutes,
+                source_inbox_generated_at_utc=_format_utc(source_generated),
+                due_at_utc=_format_utc(due_at),
+                as_of_utc=_format_utc(as_of),
+                minutes_until_due=minutes_until_due,
+                aging_minutes=aging_minutes,
+                sla_status=status,
+                breach_risk=risk,
+                escalation_label=_escalation_label(risk),
+                clock_payload=payload,
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(clocks)
+
+
+def write_sla_sqlite(path: Path, clocks: Sequence[OperatorSlaClock], generated_at_utc: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        path.unlink()
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE operator_sla_clock_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_inbox_generated_at_utc TEXT NOT NULL,
+                as_of_utc TEXT NOT NULL,
+                inbox_item_count INTEGER NOT NULL,
+                clock_count INTEGER NOT NULL,
+                overdue_count INTEGER NOT NULL,
+                breach_risk_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE operator_sla_clock (
+                inbox_item_id TEXT PRIMARY KEY,
+                case_card_id TEXT NOT NULL,
+                queue_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                priority_label TEXT NOT NULL,
+                queue_bucket TEXT NOT NULL,
+                action_code TEXT NOT NULL,
+                reason_code TEXT NOT NULL,
+                sla_minutes INTEGER NOT NULL,
+                source_inbox_generated_at_utc TEXT NOT NULL,
+                due_at_utc TEXT NOT NULL,
+                as_of_utc TEXT NOT NULL,
+                minutes_until_due INTEGER NOT NULL,
+                aging_minutes INTEGER NOT NULL,
+                sla_status TEXT NOT NULL,
+                breach_risk TEXT NOT NULL,
+                escalation_label TEXT NOT NULL,
+                clock_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE INDEX idx_operator_sla_clock_status ON operator_sla_clock(sla_status);
+            CREATE INDEX idx_operator_sla_clock_risk ON operator_sla_clock(breach_risk);
+            CREATE INDEX idx_operator_sla_clock_due ON operator_sla_clock(due_at_utc);
+            CREATE INDEX idx_operator_sla_clock_lane ON operator_sla_clock(assigned_lane);
+            """
+        )
+        source_generated = clocks[0].source_inbox_generated_at_utc if clocks else ""
+        as_of = clocks[0].as_of_utc if clocks else ""
+        conn.execute(
+            """
+            INSERT INTO operator_sla_clock_runs (
+                id, generated_at_utc, privacy_mode, source_inbox_generated_at_utc,
+                as_of_utc, inbox_item_count, clock_count, overdue_count,
+                breach_risk_count, send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0)
+            """,
+            (
+                generated_at_utc,
+                "local_only_operator_sla_clock_no_raw_text_no_send_no_crm_mutation",
+                source_generated,
+                as_of,
+                len(clocks),
+                len(clocks),
+                sum(1 for clock in clocks if clock.sla_status == "overdue"),
+                sum(1 for clock in clocks if clock.breach_risk in {"breached", "high"}),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO operator_sla_clock (
+                inbox_item_id, case_card_id, queue_rank, assigned_lane, priority_label,
+                queue_bucket, action_code, reason_code, sla_minutes,
+                source_inbox_generated_at_utc, due_at_utc, as_of_utc,
+                minutes_until_due, aging_minutes, sla_status, breach_risk,
+                escalation_label, clock_payload_json, send_whatsapp, crm_mutation,
+                requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    clock.inbox_item_id,
+                    clock.case_card_id,
+                    clock.queue_rank,
+                    clock.assigned_lane,
+                    clock.priority_label,
+                    clock.queue_bucket,
+                    clock.action_code,
+                    clock.reason_code,
+                    clock.sla_minutes,
+                    clock.source_inbox_generated_at_utc,
+                    clock.due_at_utc,
+                    clock.as_of_utc,
+                    clock.minutes_until_due,
+                    clock.aging_minutes,
+                    clock.sla_status,
+                    clock.breach_risk,
+                    clock.escalation_label,
+                    json.dumps(clock.clock_payload, ensure_ascii=False, sort_keys=True),
+                    int(clock.send_whatsapp),
+                    int(clock.crm_mutation),
+                    int(clock.requires_human_approval),
+                )
+                for clock in clocks
+            ],
+        )
+        conn.commit()
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'unknown'} | {count} |")
+    return lines
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    clocks: Sequence[OperatorSlaClock],
+    generated_at_utc: str,
+) -> None:
+    status_counts = Counter(clock.sla_status for clock in clocks)
+    breach_risk_counts = Counter(clock.breach_risk for clock in clocks)
+    escalation_counts = Counter(clock.escalation_label for clock in clocks)
+    lane_counts = Counter(clock.assigned_lane for clock in clocks)
+    bucket_counts = Counter(clock.queue_bucket for clock in clocks)
+    source_generated = clocks[0].source_inbox_generated_at_utc if clocks else ""
+    as_of = clocks[0].as_of_utc if clocks else ""
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Operator SLA Clock Summary",
+        "",
+        f"Generated UTC: `{generated_at_utc}`",
+        f"Source inbox generated UTC: `{source_generated}`",
+        f"As-of UTC: `{as_of}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, case card IDs, inbox item IDs, shadow IDs, or window IDs.",
+        "- SLA clock rows are local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Inbox items reviewed | {len(clocks)} |",
+        f"| SLA clocks | {len(clocks)} |",
+        f"| Overdue clocks | {status_counts.get('overdue', 0)} |",
+        f"| High/breached clocks | {sum(1 for clock in clocks if clock.breach_risk in {'breached', 'high'})} |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("SLA Status", status_counts),
+        "",
+        *_counter_table("Breach Risk", breach_risk_counts),
+        "",
+        *_counter_table("Escalation Labels", escalation_counts),
+        "",
+        *_counter_table("Assigned Lanes", lane_counts),
+        "",
+        *_counter_table("Queue Buckets", bucket_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- The SLA clock marks urgency and breach risk for operator review.",
+        "- It does not execute any action.",
+        "- Runtime must not send WhatsApp messages from this artifact.",
+        "- Runtime must not mutate CRM records from this artifact.",
+        "- A human must approve any client-facing message or operational mutation.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_operator_sla_clock(
+    *,
+    operator_inbox_db: Path = DEFAULT_OPERATOR_INBOX_DB,
+    output_dir: Path = DEFAULT_SLA_CLOCK_DIR,
+    output_db: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+    as_of_utc: str | None = None,
+    generated_at_utc: str | None = None,
+) -> OperatorSlaClockBuildResult:
+    """Build a local-only SLA clock from the operator action inbox."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    source_generated_at_utc, rows = read_operator_inbox(operator_inbox_db)
+    now_utc = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    as_of = as_of_utc or now_utc
+    generated = generated_at_utc or now_utc
+    clocks = build_sla_clocks(
+        rows,
+        source_inbox_generated_at_utc=source_generated_at_utc,
+        as_of_utc=as_of,
+    )
+    write_sla_sqlite(output_db, clocks, _format_utc(_parse_utc(generated)))
+    write_summary(
+        summary_path=summary_path,
+        clocks=clocks,
+        generated_at_utc=_format_utc(_parse_utc(generated)),
+    )
+    return OperatorSlaClockBuildResult(
+        inbox_item_count=len(rows),
+        clock_count=len(clocks),
+        overdue_count=sum(1 for clock in clocks if clock.sla_status == "overdue"),
+        send_whatsapp_count=sum(1 for clock in clocks if clock.send_whatsapp),
+        crm_mutation_count=sum(1 for clock in clocks if clock.crm_mutation),
+        status_counts=dict(Counter(clock.sla_status for clock in clocks)),
+        breach_risk_counts=dict(Counter(clock.breach_risk for clock in clocks)),
+        lane_counts=dict(Counter(clock.assigned_lane for clock in clocks)),
+        output_db=output_db,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build a local-only Zantara Operator SLA Clock from the action inbox."
+    )
+    parser.add_argument("--operator-inbox-db", type=Path, default=DEFAULT_OPERATOR_INBOX_DB)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_SLA_CLOCK_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--as-of-utc", default=None)
+    parser.add_argument("--generated-at-utc", default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_operator_sla_clock(
+            operator_inbox_db=args.operator_inbox_db,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            summary_path=args.summary,
+            as_of_utc=args.as_of_utc,
+            generated_at_utc=args.generated_at_utc,
+        )
+    except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
+        print("ERROR: Operator SLA clock input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError):
+        print("ERROR: Operator SLA clock run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        print("ERROR: Operator SLA clock run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "inbox_item_count": result.inbox_item_count,
+                    "clock_count": result.clock_count,
+                    "overdue_count": result.overdue_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                },
+                sort_keys=True,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/whatsapp_corpus/build_owner_approval_console.py
+++ b/scripts/whatsapp_corpus/build_owner_approval_console.py
@@ -1,0 +1,530 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_CASE_CLOSURE_DIR = Path("research/personal/wa-corpus/case-closure-judge")
+DEFAULT_OWNER_APPROVAL_DIR = Path("research/personal/wa-corpus/owner-approval-console")
+
+DEFAULT_CASE_CLOSURE_DB = DEFAULT_CASE_CLOSURE_DIR / "case_closure_judge.local.sqlite"
+DEFAULT_OUTPUT_DB = DEFAULT_OWNER_APPROVAL_DIR / "owner_approval_console.local.sqlite"
+DEFAULT_SUMMARY = DEFAULT_OWNER_APPROVAL_DIR / "owner_approval_console_summary.md"
+
+EXPECTED_CASE_CLOSURE_DB_NAME = "case_closure_judge.local.sqlite"
+
+
+@dataclass(frozen=True)
+class CaseClosureJudgmentRow:
+    judgment_id: str
+    case_card_id: str
+    judgment_rank: int
+    assigned_lane: str
+    primary_action: str
+    closure_status: str
+    closure_blocker_count: int
+    top_gap_code: str
+    top_gap_category: str
+    top_gap_severity: str
+    resolution_gate: str
+    owner_attention_required: bool
+    operator_evidence_required: bool
+    lane_review_required: bool
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OwnerApprovalItem:
+    approval_id: str
+    case_card_id: str
+    approval_rank: int
+    assigned_lane: str
+    primary_action: str
+    closure_status: str
+    decision_type: str
+    decision_priority: str
+    owner_prompt_code: str
+    recommended_owner_action: str
+    approval_status: str
+    top_gap_code: str
+    top_gap_category: str
+    top_gap_severity: str
+    resolution_gate: str
+    owner_decision_required: bool
+    approval_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OwnerApprovalConsoleBuildResult:
+    source_case_count: int
+    owner_item_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    decision_type_counts: dict[str, int]
+    lane_counts: dict[str, int]
+    output_db: Path
+    summary_path: Path
+
+
+def _format_utc(value: str | None = None) -> str:
+    if value is not None:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).isoformat(timespec="seconds")
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _connect_ro(db_path: Path, *, expected_name: str, label: str) -> sqlite3.Connection:
+    if db_path.name != expected_name:
+        raise ValueError(f"Refusing to read unexpected {label} DB: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"{label} DB not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def read_source_metadata(db_path: Path) -> tuple[str, int]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_CASE_CLOSURE_DB_NAME,
+        label="Case Closure",
+    ) as conn:
+        row = conn.execute(
+            "SELECT generated_at_utc, case_count FROM case_closure_judge_runs WHERE id = 1"
+        ).fetchone()
+    if row is None:
+        return "unknown", 0
+    return str(row["generated_at_utc"]), int(row["case_count"])
+
+
+def read_case_closure_judgments(db_path: Path) -> tuple[CaseClosureJudgmentRow, ...]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_CASE_CLOSURE_DB_NAME,
+        label="Case Closure",
+    ) as conn:
+        rows = conn.execute(
+            """
+            SELECT judgment_id, case_card_id, judgment_rank, assigned_lane,
+                   primary_action, closure_status, closure_blocker_count,
+                   top_gap_code, top_gap_category, top_gap_severity,
+                   resolution_gate, owner_attention_required,
+                   operator_evidence_required, lane_review_required,
+                   send_whatsapp, crm_mutation, requires_human_approval
+            FROM case_closure_judgments
+            ORDER BY judgment_rank, case_card_id
+            """
+        ).fetchall()
+    return tuple(
+        CaseClosureJudgmentRow(
+            judgment_id=str(row["judgment_id"]),
+            case_card_id=str(row["case_card_id"]),
+            judgment_rank=int(row["judgment_rank"]),
+            assigned_lane=str(row["assigned_lane"]),
+            primary_action=str(row["primary_action"]),
+            closure_status=str(row["closure_status"]),
+            closure_blocker_count=int(row["closure_blocker_count"]),
+            top_gap_code=str(row["top_gap_code"]),
+            top_gap_category=str(row["top_gap_category"]),
+            top_gap_severity=str(row["top_gap_severity"]),
+            resolution_gate=str(row["resolution_gate"]),
+            owner_attention_required=bool(row["owner_attention_required"]),
+            operator_evidence_required=bool(row["operator_evidence_required"]),
+            lane_review_required=bool(row["lane_review_required"]),
+            send_whatsapp=bool(row["send_whatsapp"]),
+            crm_mutation=bool(row["crm_mutation"]),
+            requires_human_approval=bool(row["requires_human_approval"]),
+        )
+        for row in rows
+    )
+
+
+def _decision_type(row: CaseClosureJudgmentRow) -> str:
+    if row.primary_action == "crm_followup" or row.top_gap_category == "client_response":
+        return "approve_client_recovery_followup"
+    if row.primary_action == "immigration_status_check" or row.top_gap_category == "status":
+        return "approve_immigration_status_escalation"
+    if row.primary_action == "document_chase" or row.top_gap_category == "document":
+        return "approve_document_evidence_request"
+    if row.primary_action == "payment_reconcile" or row.top_gap_category == "finance":
+        return "approve_payment_reconciliation_review"
+    return "approve_owner_case_review"
+
+
+def _decision_priority(row: CaseClosureJudgmentRow) -> str:
+    if row.top_gap_severity == "urgent":
+        return "now"
+    if row.top_gap_severity == "high":
+        return "today"
+    return "review"
+
+
+def _owner_prompt_code(decision_type: str) -> str:
+    return {
+        "approve_client_recovery_followup": "owner_client_recovery_followup",
+        "approve_immigration_status_escalation": "owner_immigration_status_escalation",
+        "approve_document_evidence_request": "owner_document_evidence_request",
+        "approve_payment_reconciliation_review": "owner_payment_reconciliation_review",
+    }.get(decision_type, "owner_case_review")
+
+
+def _recommended_owner_action(decision_type: str) -> str:
+    return {
+        "approve_client_recovery_followup": (
+            "Review and approve the client recovery follow-up before any message is sent."
+        ),
+        "approve_immigration_status_escalation": (
+            "Review and approve the immigration status escalation before any message is sent."
+        ),
+        "approve_document_evidence_request": (
+            "Review and approve the document evidence request before any message is sent."
+        ),
+        "approve_payment_reconciliation_review": (
+            "Review and approve the payment reconciliation review before any message is sent."
+        ),
+    }.get(
+        decision_type,
+        "Review and approve the owner case decision before any message is sent.",
+    )
+
+
+def build_owner_items(
+    judgments: Sequence[CaseClosureJudgmentRow],
+) -> tuple[OwnerApprovalItem, ...]:
+    owner_rows = [row for row in judgments if row.owner_attention_required]
+    items: list[OwnerApprovalItem] = []
+    for rank, row in enumerate(owner_rows, start=1):
+        decision_type = _decision_type(row)
+        owner_prompt_code = _owner_prompt_code(decision_type)
+        recommended_action = _recommended_owner_action(decision_type)
+        payload = {
+            "schema_version": "owner_approval_console.v1",
+            "privacy_mode": "local_only_owner_approval_no_raw_text",
+            "source_closure_status": row.closure_status,
+            "source_judgment_rank": row.judgment_rank,
+            "decision_type": decision_type,
+            "decision_priority": _decision_priority(row),
+            "owner_prompt_code": owner_prompt_code,
+            "approval_status": "pending_owner_review",
+            "raw_text_included": False,
+            "send_whatsapp": False,
+            "crm_mutation": False,
+            "requires_human_approval": True,
+        }
+        items.append(
+            OwnerApprovalItem(
+                approval_id=f"owner-approval-{rank:06d}",
+                case_card_id=row.case_card_id,
+                approval_rank=rank,
+                assigned_lane=row.assigned_lane,
+                primary_action=row.primary_action,
+                closure_status=row.closure_status,
+                decision_type=decision_type,
+                decision_priority=_decision_priority(row),
+                owner_prompt_code=owner_prompt_code,
+                recommended_owner_action=recommended_action,
+                approval_status="pending_owner_review",
+                top_gap_code=row.top_gap_code,
+                top_gap_category=row.top_gap_category,
+                top_gap_severity=row.top_gap_severity,
+                resolution_gate=row.resolution_gate,
+                owner_decision_required=True,
+                approval_payload=payload,
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(items)
+
+
+def write_owner_approval_sqlite(
+    output_db: Path,
+    *,
+    items: Sequence[OwnerApprovalItem],
+    source_case_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    output_db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(output_db) as conn:
+        conn.executescript(
+            """
+            DROP TABLE IF EXISTS owner_approval_console_runs;
+            DROP TABLE IF EXISTS owner_approval_items;
+
+            CREATE TABLE owner_approval_console_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_case_count INTEGER NOT NULL,
+                owner_item_count INTEGER NOT NULL,
+                urgent_item_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE owner_approval_items (
+                approval_id TEXT PRIMARY KEY,
+                case_card_id TEXT NOT NULL,
+                approval_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                primary_action TEXT NOT NULL,
+                closure_status TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                decision_priority TEXT NOT NULL,
+                owner_prompt_code TEXT NOT NULL,
+                recommended_owner_action TEXT NOT NULL,
+                approval_status TEXT NOT NULL,
+                top_gap_code TEXT NOT NULL,
+                top_gap_category TEXT NOT NULL,
+                top_gap_severity TEXT NOT NULL,
+                resolution_gate TEXT NOT NULL,
+                owner_decision_required INTEGER NOT NULL CHECK (owner_decision_required = 1),
+                approval_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE INDEX idx_owner_approval_rank ON owner_approval_items(approval_rank);
+            CREATE INDEX idx_owner_approval_lane ON owner_approval_items(assigned_lane);
+            CREATE INDEX idx_owner_approval_type ON owner_approval_items(decision_type);
+            CREATE INDEX idx_owner_approval_priority ON owner_approval_items(decision_priority);
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO owner_approval_console_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_case_count, owner_item_count, urgent_item_count,
+                send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, ?, ?, ?, 0, 0)
+            """,
+            (
+                generated_at_utc,
+                source_generated_at_utc,
+                "local_only_owner_approval_no_raw_text_no_send_no_crm_mutation",
+                source_case_count,
+                len(items),
+                sum(1 for item in items if item.decision_priority == "now"),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO owner_approval_items (
+                approval_id, case_card_id, approval_rank, assigned_lane,
+                primary_action, closure_status, decision_type, decision_priority,
+                owner_prompt_code, recommended_owner_action, approval_status,
+                top_gap_code, top_gap_category, top_gap_severity, resolution_gate,
+                owner_decision_required, approval_payload_json, send_whatsapp,
+                crm_mutation, requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    item.approval_id,
+                    item.case_card_id,
+                    item.approval_rank,
+                    item.assigned_lane,
+                    item.primary_action,
+                    item.closure_status,
+                    item.decision_type,
+                    item.decision_priority,
+                    item.owner_prompt_code,
+                    item.recommended_owner_action,
+                    item.approval_status,
+                    item.top_gap_code,
+                    item.top_gap_category,
+                    item.top_gap_severity,
+                    item.resolution_gate,
+                    int(item.owner_decision_required),
+                    json.dumps(item.approval_payload, ensure_ascii=False, sort_keys=True),
+                    int(item.send_whatsapp),
+                    int(item.crm_mutation),
+                    int(item.requires_human_approval),
+                )
+                for item in items
+            ],
+        )
+        conn.commit()
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'unknown'} | {count} |")
+    return lines
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    items: Sequence[OwnerApprovalItem],
+    source_case_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    decision_counts = Counter(item.decision_type for item in items)
+    lane_counts = Counter(item.assigned_lane for item in items)
+    priority_counts = Counter(item.decision_priority for item in items)
+    action_counts = Counter(item.primary_action for item in items)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Owner Approval Console Summary",
+        "",
+        f"Generated UTC: `{generated_at_utc}`",
+        f"Source Case Closure UTC: `{source_generated_at_utc}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, case card IDs, judgment IDs, approval IDs, gap IDs, event IDs, inbox item IDs, or room item IDs.",
+        "- Owner approval rows are local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Source cases judged | {source_case_count} |",
+        f"| Owner approval items | {len(items)} |",
+        f"| Urgent owner items | {sum(1 for item in items if item.decision_priority == 'now')} |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("Decision Types", decision_counts),
+        "",
+        *_counter_table("Decision Priorities", priority_counts),
+        "",
+        *_counter_table("Assigned Lanes", lane_counts),
+        "",
+        *_counter_table("Primary Actions", action_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- The Owner Approval Console filters case closure judgments down to owner-only decisions.",
+        "- It does not parse raw WhatsApp messages.",
+        "- It does not call a cloud LLM.",
+        "- Runtime must not send WhatsApp messages from this artifact.",
+        "- Runtime must not mutate CRM records from this artifact.",
+        "- Owner approval remains mandatory before any client-facing message or operational mutation.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_owner_approval_console(
+    *,
+    case_closure_db: Path = DEFAULT_CASE_CLOSURE_DB,
+    output_dir: Path = DEFAULT_OWNER_APPROVAL_DIR,
+    output_db: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+    generated_at_utc: str | None = None,
+) -> OwnerApprovalConsoleBuildResult:
+    """Build local-only owner approval items from case closure judgments."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    generated = _format_utc(generated_at_utc)
+    source_generated, source_case_count = read_source_metadata(case_closure_db)
+    judgments = read_case_closure_judgments(case_closure_db)
+    items = build_owner_items(judgments)
+    write_owner_approval_sqlite(
+        output_db,
+        items=items,
+        source_case_count=source_case_count or len(judgments),
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    write_summary(
+        summary_path=summary_path,
+        items=items,
+        source_case_count=source_case_count or len(judgments),
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    return OwnerApprovalConsoleBuildResult(
+        source_case_count=source_case_count or len(judgments),
+        owner_item_count=len(items),
+        send_whatsapp_count=sum(1 for item in items if item.send_whatsapp),
+        crm_mutation_count=sum(1 for item in items if item.crm_mutation),
+        decision_type_counts=dict(Counter(item.decision_type for item in items)),
+        lane_counts=dict(Counter(item.assigned_lane for item in items)),
+        output_db=output_db,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build local-only Zantara owner approval console from case closure judgments."
+    )
+    parser.add_argument("--case-closure-db", type=Path, default=DEFAULT_CASE_CLOSURE_DB)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OWNER_APPROVAL_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--generated-at-utc", default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_owner_approval_console(
+            case_closure_db=args.case_closure_db,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            summary_path=args.summary,
+            generated_at_utc=args.generated_at_utc,
+        )
+    except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
+        print("ERROR: Owner approval console input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError):
+        print("ERROR: Owner approval console run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        print("ERROR: Owner approval console run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "crm_mutation_count": result.crm_mutation_count,
+                    "owner_item_count": result.owner_item_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "source_case_count": result.source_case_count,
+                },
+                sort_keys=True,
+            )
+        )
+    else:
+        print(
+            "Owner approval console complete: "
+            f"{result.owner_item_count} items -> {result.output_db.name}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/whatsapp_corpus/build_owner_brief_renderer.py
+++ b/scripts/whatsapp_corpus/build_owner_brief_renderer.py
@@ -1,0 +1,543 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_OWNER_PACKS_DIR = Path("research/personal/wa-corpus/owner-decision-packs")
+DEFAULT_OWNER_BRIEF_DIR = Path("research/personal/wa-corpus/owner-brief-renderer")
+
+DEFAULT_OWNER_PACKS_DB = DEFAULT_OWNER_PACKS_DIR / "owner_decision_packs.local.sqlite"
+DEFAULT_OUTPUT_DB = DEFAULT_OWNER_BRIEF_DIR / "owner_brief_renderer.local.sqlite"
+DEFAULT_SUMMARY = DEFAULT_OWNER_BRIEF_DIR / "owner_brief_renderer_summary.md"
+
+EXPECTED_OWNER_PACKS_DB_NAME = "owner_decision_packs.local.sqlite"
+
+
+@dataclass(frozen=True)
+class OwnerDecisionPackRow:
+    pack_id: str
+    case_card_id: str
+    pack_rank: int
+    assigned_lane: str
+    decision_type: str
+    decision_priority: str
+    owner_prompt_code: str
+    pack_title: str
+    risk_brief: str
+    recommended_decision: str
+    draft_action_type: str
+    draft_action_status: str
+    approval_status: str
+    top_gap_code: str
+    top_gap_category: str
+    top_gap_severity: str
+    resolution_gate: str
+    owner_decision_required: bool
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OwnerBrief:
+    brief_id: str
+    pack_id: str
+    case_card_id: str
+    brief_rank: int
+    assigned_lane: str
+    decision_type: str
+    decision_priority: str
+    brief_title: str
+    owner_focus: str
+    recommended_decision: str
+    draft_action_type: str
+    safety_lock: str
+    approval_status: str
+    brief_markdown: str
+    brief_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OwnerBriefRendererBuildResult:
+    source_case_count: int
+    owner_item_count: int
+    pack_count: int
+    brief_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    decision_type_counts: dict[str, int]
+    lane_counts: dict[str, int]
+    output_db: Path
+    summary_path: Path
+
+
+def _format_utc(value: str | None = None) -> str:
+    if value is not None:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).isoformat(timespec="seconds")
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _connect_ro(db_path: Path, *, expected_name: str, label: str) -> sqlite3.Connection:
+    if db_path.name != expected_name:
+        raise ValueError(f"Refusing to read unexpected {label} DB: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"{label} DB not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def read_source_metadata(db_path: Path) -> tuple[str, int, int, int]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_OWNER_PACKS_DB_NAME,
+        label="Owner Decision Packs",
+    ) as conn:
+        row = conn.execute(
+            """
+            SELECT generated_at_utc, source_case_count, owner_item_count, pack_count
+            FROM owner_decision_pack_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+    if row is None:
+        return "unknown", 0, 0, 0
+    return (
+        str(row["generated_at_utc"]),
+        int(row["source_case_count"]),
+        int(row["owner_item_count"]),
+        int(row["pack_count"]),
+    )
+
+
+def read_owner_pack_rows(db_path: Path) -> tuple[OwnerDecisionPackRow, ...]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_OWNER_PACKS_DB_NAME,
+        label="Owner Decision Packs",
+    ) as conn:
+        rows = conn.execute(
+            """
+            SELECT pack_id, case_card_id, pack_rank, assigned_lane,
+                   decision_type, decision_priority, owner_prompt_code,
+                   pack_title, risk_brief, recommended_decision,
+                   draft_action_type, draft_action_status, approval_status,
+                   top_gap_code, top_gap_category, top_gap_severity,
+                   resolution_gate, owner_decision_required, send_whatsapp,
+                   crm_mutation, requires_human_approval
+            FROM owner_decision_packs
+            ORDER BY pack_rank, case_card_id
+            """
+        ).fetchall()
+    return tuple(
+        OwnerDecisionPackRow(
+            pack_id=str(row["pack_id"]),
+            case_card_id=str(row["case_card_id"]),
+            pack_rank=int(row["pack_rank"]),
+            assigned_lane=str(row["assigned_lane"]),
+            decision_type=str(row["decision_type"]),
+            decision_priority=str(row["decision_priority"]),
+            owner_prompt_code=str(row["owner_prompt_code"]),
+            pack_title=str(row["pack_title"]),
+            risk_brief=str(row["risk_brief"]),
+            recommended_decision=str(row["recommended_decision"]),
+            draft_action_type=str(row["draft_action_type"]),
+            draft_action_status=str(row["draft_action_status"]),
+            approval_status=str(row["approval_status"]),
+            top_gap_code=str(row["top_gap_code"]),
+            top_gap_category=str(row["top_gap_category"]),
+            top_gap_severity=str(row["top_gap_severity"]),
+            resolution_gate=str(row["resolution_gate"]),
+            owner_decision_required=bool(row["owner_decision_required"]),
+            send_whatsapp=bool(row["send_whatsapp"]),
+            crm_mutation=bool(row["crm_mutation"]),
+            requires_human_approval=bool(row["requires_human_approval"]),
+        )
+        for row in rows
+    )
+
+
+def _owner_focus(decision_type: str) -> str:
+    return {
+        "approve_client_recovery_followup": "review_client_recovery_language",
+        "approve_immigration_status_escalation": "review_immigration_status_escalation",
+        "approve_document_evidence_request": "review_document_evidence_request",
+        "approve_payment_reconciliation_review": "review_payment_reconciliation",
+    }.get(decision_type, "review_owner_case_decision")
+
+
+def _brief_markdown(row: OwnerDecisionPackRow, *, owner_focus: str) -> str:
+    lines = [
+        f"# {row.pack_title}",
+        "",
+        f"Priority: {row.decision_priority}",
+        f"Lane: {row.assigned_lane}",
+        f"Owner focus: {owner_focus}",
+        f"Risk: {row.risk_brief}",
+        f"Recommended decision: {row.recommended_decision}",
+        f"Draft action: {row.draft_action_type}",
+        f"Approval status: {row.approval_status}",
+        "Safety lock: owner approval required before send or CRM mutation.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def build_briefs(rows: Sequence[OwnerDecisionPackRow]) -> tuple[OwnerBrief, ...]:
+    briefs: list[OwnerBrief] = []
+    for rank, row in enumerate(rows, start=1):
+        owner_focus = _owner_focus(row.decision_type)
+        markdown = _brief_markdown(row, owner_focus=owner_focus)
+        payload = {
+            "schema_version": "owner_brief_renderer.v1",
+            "privacy_mode": "local_only_owner_brief_no_raw_text",
+            "source_pack_rank": row.pack_rank,
+            "source_decision_type": row.decision_type,
+            "source_owner_prompt_code": row.owner_prompt_code,
+            "owner_focus": owner_focus,
+            "recommended_decision": row.recommended_decision,
+            "draft_action_type": row.draft_action_type,
+            "safety_lock": "owner_approval_required_no_send_no_crm",
+            "rendered_markdown_includes_ids": False,
+            "raw_text_included": False,
+            "send_whatsapp": False,
+            "crm_mutation": False,
+            "requires_human_approval": True,
+        }
+        briefs.append(
+            OwnerBrief(
+                brief_id=f"owner-brief-{rank:06d}",
+                pack_id=row.pack_id,
+                case_card_id=row.case_card_id,
+                brief_rank=rank,
+                assigned_lane=row.assigned_lane,
+                decision_type=row.decision_type,
+                decision_priority=row.decision_priority,
+                brief_title=row.pack_title,
+                owner_focus=owner_focus,
+                recommended_decision=row.recommended_decision,
+                draft_action_type=row.draft_action_type,
+                safety_lock="owner_approval_required_no_send_no_crm",
+                approval_status=row.approval_status,
+                brief_markdown=markdown,
+                brief_payload=payload,
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(briefs)
+
+
+def write_owner_briefs_sqlite(
+    output_db: Path,
+    *,
+    briefs: Sequence[OwnerBrief],
+    source_case_count: int,
+    owner_item_count: int,
+    pack_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    output_db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(output_db) as conn:
+        conn.executescript(
+            """
+            DROP TABLE IF EXISTS owner_brief_renderer_runs;
+            DROP TABLE IF EXISTS owner_briefs;
+
+            CREATE TABLE owner_brief_renderer_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_case_count INTEGER NOT NULL,
+                owner_item_count INTEGER NOT NULL,
+                pack_count INTEGER NOT NULL,
+                brief_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE owner_briefs (
+                brief_id TEXT PRIMARY KEY,
+                pack_id TEXT NOT NULL,
+                case_card_id TEXT NOT NULL,
+                brief_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                decision_priority TEXT NOT NULL,
+                brief_title TEXT NOT NULL,
+                owner_focus TEXT NOT NULL,
+                recommended_decision TEXT NOT NULL,
+                draft_action_type TEXT NOT NULL,
+                safety_lock TEXT NOT NULL,
+                approval_status TEXT NOT NULL,
+                brief_markdown TEXT NOT NULL,
+                brief_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE INDEX idx_owner_brief_rank ON owner_briefs(brief_rank);
+            CREATE INDEX idx_owner_brief_lane ON owner_briefs(assigned_lane);
+            CREATE INDEX idx_owner_brief_type ON owner_briefs(decision_type);
+            CREATE INDEX idx_owner_brief_priority ON owner_briefs(decision_priority);
+            CREATE INDEX idx_owner_brief_focus ON owner_briefs(owner_focus);
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO owner_brief_renderer_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_case_count, owner_item_count, pack_count, brief_count,
+                send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, ?, ?, ?, ?, 0, 0)
+            """,
+            (
+                generated_at_utc,
+                source_generated_at_utc,
+                "local_only_owner_brief_no_raw_text_no_send_no_crm_mutation",
+                source_case_count,
+                owner_item_count,
+                pack_count,
+                len(briefs),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO owner_briefs (
+                brief_id, pack_id, case_card_id, brief_rank, assigned_lane,
+                decision_type, decision_priority, brief_title, owner_focus,
+                recommended_decision, draft_action_type, safety_lock,
+                approval_status, brief_markdown, brief_payload_json,
+                send_whatsapp, crm_mutation, requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    brief.brief_id,
+                    brief.pack_id,
+                    brief.case_card_id,
+                    brief.brief_rank,
+                    brief.assigned_lane,
+                    brief.decision_type,
+                    brief.decision_priority,
+                    brief.brief_title,
+                    brief.owner_focus,
+                    brief.recommended_decision,
+                    brief.draft_action_type,
+                    brief.safety_lock,
+                    brief.approval_status,
+                    brief.brief_markdown,
+                    json.dumps(brief.brief_payload, ensure_ascii=False, sort_keys=True),
+                    int(brief.send_whatsapp),
+                    int(brief.crm_mutation),
+                    int(brief.requires_human_approval),
+                )
+                for brief in briefs
+            ],
+        )
+        conn.commit()
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'unknown'} | {count} |")
+    return lines
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    briefs: Sequence[OwnerBrief],
+    source_case_count: int,
+    owner_item_count: int,
+    pack_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    decision_counts = Counter(brief.decision_type for brief in briefs)
+    lane_counts = Counter(brief.assigned_lane for brief in briefs)
+    priority_counts = Counter(brief.decision_priority for brief in briefs)
+    focus_counts = Counter(brief.owner_focus for brief in briefs)
+    safety_counts = Counter(brief.safety_lock for brief in briefs)
+    approval_counts = Counter(brief.approval_status for brief in briefs)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Owner Brief Renderer Summary",
+        "",
+        f"Generated UTC: `{generated_at_utc}`",
+        f"Source Owner Decision Packs UTC: `{source_generated_at_utc}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, case card IDs, judgment IDs, approval IDs, pack IDs, brief IDs, gap IDs, event IDs, inbox item IDs, or room item IDs.",
+        "- Rendered owner briefs are local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Source cases | {source_case_count} |",
+        f"| Owner approval items | {owner_item_count} |",
+        f"| Owner decision packs | {pack_count} |",
+        f"| Rendered owner briefs | {len(briefs)} |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("Decision Types", decision_counts),
+        "",
+        *_counter_table("Decision Priorities", priority_counts),
+        "",
+        *_counter_table("Assigned Lanes", lane_counts),
+        "",
+        *_counter_table("Owner Focus", focus_counts),
+        "",
+        *_counter_table("Safety Locks", safety_counts),
+        "",
+        *_counter_table("Approval Status", approval_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- The Owner Brief Renderer turns decision packs into readable owner briefs.",
+        "- Rendered brief markdown contains no raw IDs.",
+        "- It does not parse raw WhatsApp messages.",
+        "- It does not call a cloud LLM.",
+        "- Runtime must not send WhatsApp messages from this artifact.",
+        "- Runtime must not mutate CRM records from this artifact.",
+        "- Owner approval remains mandatory before any client-facing message or operational mutation.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_owner_brief_renderer(
+    *,
+    owner_packs_db: Path = DEFAULT_OWNER_PACKS_DB,
+    output_dir: Path = DEFAULT_OWNER_BRIEF_DIR,
+    output_db: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+    generated_at_utc: str | None = None,
+) -> OwnerBriefRendererBuildResult:
+    """Build local-only rendered owner briefs from decision packs."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    generated = _format_utc(generated_at_utc)
+    source_generated, source_case_count, owner_item_count, pack_count = read_source_metadata(
+        owner_packs_db
+    )
+    rows = read_owner_pack_rows(owner_packs_db)
+    briefs = build_briefs(rows)
+    source_case_total = source_case_count or len(rows)
+    owner_item_total = owner_item_count or len(rows)
+    pack_total = pack_count or len(rows)
+    write_owner_briefs_sqlite(
+        output_db,
+        briefs=briefs,
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    write_summary(
+        summary_path=summary_path,
+        briefs=briefs,
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    return OwnerBriefRendererBuildResult(
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        brief_count=len(briefs),
+        send_whatsapp_count=sum(1 for brief in briefs if brief.send_whatsapp),
+        crm_mutation_count=sum(1 for brief in briefs if brief.crm_mutation),
+        decision_type_counts=dict(Counter(brief.decision_type for brief in briefs)),
+        lane_counts=dict(Counter(brief.assigned_lane for brief in briefs)),
+        output_db=output_db,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build local-only Zantara owner brief renderer from owner decision packs."
+    )
+    parser.add_argument("--owner-packs-db", type=Path, default=DEFAULT_OWNER_PACKS_DB)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OWNER_BRIEF_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--generated-at-utc", default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_owner_brief_renderer(
+            owner_packs_db=args.owner_packs_db,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            summary_path=args.summary,
+            generated_at_utc=args.generated_at_utc,
+        )
+    except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
+        print("ERROR: Owner brief renderer input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError):
+        print("ERROR: Owner brief renderer run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        print("ERROR: Owner brief renderer run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "brief_count": result.brief_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                    "owner_item_count": result.owner_item_count,
+                    "pack_count": result.pack_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "source_case_count": result.source_case_count,
+                },
+                sort_keys=True,
+            )
+        )
+    else:
+        print(
+            "Owner brief renderer complete: "
+            f"{result.brief_count} briefs -> {result.output_db.name}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/whatsapp_corpus/build_owner_captain_shadow.py
+++ b/scripts/whatsapp_corpus/build_owner_captain_shadow.py
@@ -1,0 +1,509 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_CLIENT_SHADOW_DIR = Path("research/personal/wa-corpus/client-captain-shadow")
+DEFAULT_TEAM_SHADOW_DIR = Path("research/personal/wa-corpus/team-captain-shadow")
+DEFAULT_OWNER_SHADOW_DIR = Path("research/personal/wa-corpus/owner-captain-shadow")
+DEFAULT_CLIENT_SHADOW_DB = DEFAULT_CLIENT_SHADOW_DIR / "client_captain_shadow.local.sqlite"
+DEFAULT_TEAM_SHADOW_DB = DEFAULT_TEAM_SHADOW_DIR / "team_captain_shadow.local.sqlite"
+DEFAULT_OUTPUT_DB = DEFAULT_OWNER_SHADOW_DIR / "owner_captain_shadow.local.sqlite"
+DEFAULT_SUMMARY = DEFAULT_OWNER_SHADOW_DIR / "owner_captain_shadow_summary.md"
+
+EXPECTED_CLIENT_SHADOW_DB_NAME = "client_captain_shadow.local.sqlite"
+EXPECTED_TEAM_SHADOW_DB_NAME = "team_captain_shadow.local.sqlite"
+OWNER_SCOPE = "global_case_ops"
+
+
+@dataclass(frozen=True)
+class ClientAggregate:
+    draft_count: int
+    p1_count: int
+    p2_count: int
+    action_counts: Counter[str]
+    specialist_counts: Counter[str]
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    approval_count: int
+    input_contract_violation_count: int
+
+
+@dataclass(frozen=True)
+class TeamAggregateRow:
+    human_specialist: str
+    draft_count: int
+    p1_count: int
+    p2_count: int
+    primary_action_type: str
+    accountability_mode: str
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OwnerFinding:
+    owner_captain_id: str
+    owner_scope: str
+    draft_count: int
+    team_lane_count: int
+    p1_count: int
+    p2_count: int
+    primary_bottleneck_lane: str
+    primary_action_type: str
+    owner_decision_mode: str
+    input_contract_violation_count: int
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OwnerDepthLayer:
+    owner_captain_id: str
+    depth_level: int
+    layer_code: str
+    layer_title: str
+    layer_payload: dict[str, object]
+
+
+@dataclass(frozen=True)
+class OwnerBuildResult:
+    finding_count: int
+    depth_layer_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    input_contract_violation_count: int
+    output_db: Path
+    summary_path: Path
+
+
+def _connect_expected(db_path: Path, *, expected_name: str, label: str) -> sqlite3.Connection:
+    if db_path.name != expected_name:
+        raise ValueError(f"Refusing to read unexpected {label}: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"{label} not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def read_client_aggregate(db_path: Path) -> ClientAggregate:
+    with _connect_expected(
+        db_path,
+        expected_name=EXPECTED_CLIENT_SHADOW_DB_NAME,
+        label="Client Shadow DB",
+    ) as conn:
+        rows = conn.execute(
+            """
+            SELECT risk_level, action_type, human_specialist,
+                   send_whatsapp, crm_mutation, requires_human_approval
+            FROM shadow_drafts
+            """
+        ).fetchall()
+    action_counts = Counter(str(row["action_type"]) for row in rows)
+    specialist_counts = Counter(str(row["human_specialist"]) for row in rows)
+    return ClientAggregate(
+        draft_count=len(rows),
+        p1_count=sum(1 for row in rows if str(row["risk_level"]) == "P1"),
+        p2_count=sum(1 for row in rows if str(row["risk_level"]) == "P2"),
+        action_counts=action_counts,
+        specialist_counts=specialist_counts,
+        send_whatsapp_count=sum(int(row["send_whatsapp"]) for row in rows),
+        crm_mutation_count=sum(int(row["crm_mutation"]) for row in rows),
+        approval_count=sum(int(row["requires_human_approval"]) for row in rows),
+        input_contract_violation_count=sum(
+            1
+            for row in rows
+            if bool(row["send_whatsapp"])
+            or bool(row["crm_mutation"])
+            or not bool(row["requires_human_approval"])
+        ),
+    )
+
+
+def read_team_rows(db_path: Path) -> tuple[TeamAggregateRow, ...]:
+    with _connect_expected(
+        db_path,
+        expected_name=EXPECTED_TEAM_SHADOW_DB_NAME,
+        label="Team Shadow DB",
+    ) as conn:
+        rows = conn.execute(
+            """
+            SELECT human_specialist, draft_count, p1_count, p2_count,
+                   primary_action_type, accountability_mode, send_whatsapp,
+                   crm_mutation, requires_human_approval
+            FROM team_captain_findings
+            ORDER BY p1_count DESC, draft_count DESC, human_specialist
+            """
+        ).fetchall()
+    return tuple(
+        TeamAggregateRow(
+            human_specialist=str(row["human_specialist"]),
+            draft_count=int(row["draft_count"]),
+            p1_count=int(row["p1_count"]),
+            p2_count=int(row["p2_count"]),
+            primary_action_type=str(row["primary_action_type"]),
+            accountability_mode=str(row["accountability_mode"]),
+            send_whatsapp=bool(row["send_whatsapp"]),
+            crm_mutation=bool(row["crm_mutation"]),
+            requires_human_approval=bool(row["requires_human_approval"]),
+        )
+        for row in rows
+    )
+
+
+def _most_common(counter: Counter[str], fallback: str = "unknown") -> str:
+    if not counter:
+        return fallback
+    return counter.most_common(1)[0][0]
+
+
+def build_owner_finding(
+    client: ClientAggregate,
+    team_rows: Sequence[TeamAggregateRow],
+) -> OwnerFinding:
+    bottleneck = team_rows[0].human_specialist if team_rows else "none"
+    team_contract_violation_count = sum(
+        1
+        for row in team_rows
+        if row.send_whatsapp or row.crm_mutation or not row.requires_human_approval
+    )
+    input_contract_violation_count = (
+        client.input_contract_violation_count + team_contract_violation_count
+    )
+    p1_count = max(client.p1_count, sum(row.p1_count for row in team_rows))
+    p2_count = max(client.p2_count, sum(row.p2_count for row in team_rows))
+    return OwnerFinding(
+        owner_captain_id="owner-global-case-ops",
+        owner_scope=OWNER_SCOPE,
+        draft_count=client.draft_count,
+        team_lane_count=len(team_rows),
+        p1_count=p1_count,
+        p2_count=p2_count,
+        primary_bottleneck_lane=bottleneck,
+        primary_action_type=_most_common(client.action_counts),
+        owner_decision_mode=(
+            "owner_review_required"
+            if p1_count or input_contract_violation_count
+            else "monitor"
+        ),
+        input_contract_violation_count=input_contract_violation_count,
+        send_whatsapp=False,
+        crm_mutation=False,
+        requires_human_approval=True,
+    )
+
+
+def build_owner_depth_layers(finding: OwnerFinding) -> tuple[OwnerDepthLayer, ...]:
+    base_payload = {
+        "owner_scope": finding.owner_scope,
+        "send_whatsapp": False,
+        "crm_mutation": False,
+        "requires_human_approval": True,
+        "raw_text_included": False,
+    }
+    layer_specs = [
+        (
+            1,
+            "operational_volume",
+            "Operational volume",
+            {"draft_count": finding.draft_count, "team_lane_count": finding.team_lane_count},
+        ),
+        (
+            2,
+            "risk_concentration",
+            "Risk concentration",
+            {"p1_count": finding.p1_count, "p2_count": finding.p2_count},
+        ),
+        (
+            3,
+            "team_bottleneck",
+            "Team bottleneck",
+            {"primary_bottleneck_lane": finding.primary_bottleneck_lane},
+        ),
+        (
+            4,
+            "client_experience_risk",
+            "Client experience risk",
+            {"primary_action_type": finding.primary_action_type},
+        ),
+        (
+            5,
+            "automation_leverage",
+            "Automation leverage",
+            {"candidate_loop": "shadow_to_review_queue"},
+        ),
+        (
+            6,
+            "governance_boundary",
+            "Governance boundary",
+            {
+                "runtime_contract": "no_send_no_crm_mutation_without_human_approval",
+                "input_contract_violation_count": finding.input_contract_violation_count,
+            },
+        ),
+        (
+            7,
+            "owner_decision",
+            "Owner decision",
+            {"owner_decision_mode": finding.owner_decision_mode},
+        ),
+    ]
+    return tuple(
+        OwnerDepthLayer(
+            owner_captain_id=finding.owner_captain_id,
+            depth_level=depth_level,
+            layer_code=code,
+            layer_title=title,
+            layer_payload={**base_payload, **payload},
+        )
+        for depth_level, code, title, payload in layer_specs
+    )
+
+
+def write_owner_sqlite(
+    path: Path,
+    finding: OwnerFinding,
+    layers: Sequence[OwnerDepthLayer],
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        path.unlink()
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE owner_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                finding_count INTEGER NOT NULL,
+                depth_layer_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL,
+                input_contract_violation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE owner_captain_findings (
+                owner_captain_id TEXT PRIMARY KEY,
+                owner_scope TEXT NOT NULL,
+                draft_count INTEGER NOT NULL,
+                team_lane_count INTEGER NOT NULL,
+                p1_count INTEGER NOT NULL,
+                p2_count INTEGER NOT NULL,
+                primary_bottleneck_lane TEXT NOT NULL,
+                primary_action_type TEXT NOT NULL,
+                owner_decision_mode TEXT NOT NULL,
+                input_contract_violation_count INTEGER NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE TABLE owner_captain_depth_layers (
+                owner_captain_id TEXT NOT NULL,
+                depth_level INTEGER NOT NULL,
+                layer_code TEXT NOT NULL,
+                layer_title TEXT NOT NULL,
+                layer_payload_json TEXT NOT NULL,
+                PRIMARY KEY (owner_captain_id, depth_level)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO owner_runs (
+                id, generated_at_utc, privacy_mode, finding_count, depth_layer_count,
+                send_whatsapp_count, crm_mutation_count, input_contract_violation_count
+            )
+            VALUES (1, ?, ?, 1, ?, 0, 0, ?)
+            """,
+            (
+                datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                "local_only_owner_shadow_no_send_no_crm_mutation",
+                len(layers),
+                finding.input_contract_violation_count,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO owner_captain_findings (
+                owner_captain_id, owner_scope, draft_count, team_lane_count,
+                p1_count, p2_count, primary_bottleneck_lane, primary_action_type,
+                owner_decision_mode, input_contract_violation_count, send_whatsapp, crm_mutation,
+                requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                finding.owner_captain_id,
+                finding.owner_scope,
+                finding.draft_count,
+                finding.team_lane_count,
+                finding.p1_count,
+                finding.p2_count,
+                finding.primary_bottleneck_lane,
+                finding.primary_action_type,
+                finding.owner_decision_mode,
+                finding.input_contract_violation_count,
+                int(finding.send_whatsapp),
+                int(finding.crm_mutation),
+                int(finding.requires_human_approval),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO owner_captain_depth_layers (
+                owner_captain_id, depth_level, layer_code, layer_title, layer_payload_json
+            )
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    layer.owner_captain_id,
+                    layer.depth_level,
+                    layer.layer_code,
+                    layer.layer_title,
+                    json.dumps(layer.layer_payload, ensure_ascii=False, sort_keys=True),
+                )
+                for layer in layers
+            ],
+        )
+        conn.commit()
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    finding: OwnerFinding,
+    layers: Sequence[OwnerDepthLayer],
+    generated_at_utc: str | None = None,
+) -> None:
+    generated = generated_at_utc or datetime.now(timezone.utc).isoformat(timespec="seconds")
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Owner Captain Shadow Summary",
+        "",
+        f"Generated UTC: `{generated}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, file IDs, window IDs, replay IDs, or shadow IDs.",
+        "- Owner Shadow output is local-only and ignored by git.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        "| Owner findings | 1 |",
+        f"| Depth layers | {len(layers)} |",
+        f"| Shadow drafts reviewed | {finding.draft_count} |",
+        f"| Team lanes reviewed | {finding.team_lane_count} |",
+        f"| P1 count | {finding.p1_count} |",
+        f"| P2 count | {finding.p2_count} |",
+        f"| Input contract violations | {finding.input_contract_violation_count} |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        "## Execution Contract",
+        "",
+        "- The Owner Captain summarizes business risk and governance gates only.",
+        "- It reports upstream contract violations only as aggregate counts.",
+        "- It cannot send WhatsApp messages.",
+        "- It cannot mutate CRM records.",
+        "- It can recommend owner review, but the owner remains the approving human.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_owner_captain_shadow(
+    *,
+    client_shadow_db: Path = DEFAULT_CLIENT_SHADOW_DB,
+    team_shadow_db: Path = DEFAULT_TEAM_SHADOW_DB,
+    output_dir: Path = DEFAULT_OWNER_SHADOW_DIR,
+    output_db: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+) -> OwnerBuildResult:
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    client = read_client_aggregate(client_shadow_db)
+    team_rows = read_team_rows(team_shadow_db)
+    finding = build_owner_finding(client, team_rows)
+    layers = build_owner_depth_layers(finding)
+    write_owner_sqlite(output_db, finding, layers)
+    write_summary(summary_path=summary_path, finding=finding, layers=layers)
+    return OwnerBuildResult(
+        finding_count=1,
+        depth_layer_count=len(layers),
+        send_whatsapp_count=int(finding.send_whatsapp),
+        crm_mutation_count=int(finding.crm_mutation),
+        input_contract_violation_count=finding.input_contract_violation_count,
+        output_db=output_db,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build local-only Zantara Owner Captain Shadow Mode findings."
+    )
+    parser.add_argument("--client-shadow-db", type=Path, default=DEFAULT_CLIENT_SHADOW_DB)
+    parser.add_argument("--team-shadow-db", type=Path, default=DEFAULT_TEAM_SHADOW_DB)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OWNER_SHADOW_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_owner_captain_shadow(
+            client_shadow_db=args.client_shadow_db,
+            team_shadow_db=args.team_shadow_db,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            summary_path=args.summary,
+        )
+    except (FileNotFoundError, ValueError, TypeError):
+        # Keep this fixed literal: exception text may include local paths or DB names.
+        print("ERROR: Owner Captain input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError):
+        # Keep this fixed literal: exception text may include local paths or DB names.
+        print("ERROR: Owner Captain shadow run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        # CLI boundary must fail closed; the Python API still exposes details.
+        print("ERROR: Owner Captain shadow run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "finding_count": result.finding_count,
+                    "depth_layer_count": result.depth_layer_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                    "input_contract_violation_count": result.input_contract_violation_count,
+                },
+                sort_keys=True,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/whatsapp_corpus/build_owner_decision_cockpit.py
+++ b/scripts/whatsapp_corpus/build_owner_decision_cockpit.py
@@ -1,0 +1,728 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.whatsapp_corpus.build_owner_decision_intake import (
+    ALLOWED_OWNER_DECISIONS,
+    DEFAULT_EVENT_ACTOR,
+    _format_utc,
+)
+
+DEFAULT_OWNER_DECISION_INBOX_DIR = Path(
+    "research/personal/wa-corpus/owner-decision-inbox"
+)
+DEFAULT_OWNER_DECISION_COCKPIT_DIR = Path(
+    "research/personal/wa-corpus/owner-decision-cockpit"
+)
+
+DEFAULT_OWNER_INBOX_DB = DEFAULT_OWNER_DECISION_INBOX_DIR / "owner_decision_inbox.local.sqlite"
+DEFAULT_OUTPUT_DB = (
+    DEFAULT_OWNER_DECISION_COCKPIT_DIR / "owner_decision_cockpit.local.sqlite"
+)
+DEFAULT_OUTPUT_TEMPLATE = (
+    DEFAULT_OWNER_DECISION_COCKPIT_DIR / "owner_decisions_template.local.jsonl"
+)
+DEFAULT_SUMMARY = (
+    DEFAULT_OWNER_DECISION_COCKPIT_DIR / "owner_decision_cockpit_summary.md"
+)
+
+EXPECTED_OWNER_INBOX_DB_NAME = "owner_decision_inbox.local.sqlite"
+COCKPIT_READY_FOR_COMPILE = "ready_for_compile"
+COCKPIT_AWAITING_OWNER_INPUT = "awaiting_owner_input"
+
+
+@dataclass(frozen=True)
+class OwnerDecisionInboxRow:
+    owner_inbox_item_id: str
+    review_item_id: str
+    packet_id: str
+    entry_id: str
+    inbox_rank: int
+    assigned_lane: str
+    decision_type: str
+    review_state: str
+    console_bucket: str
+    allowed_decisions: tuple[str, ...]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OwnerDecisionInput:
+    review_item_id: str
+    owner_decision: str
+    decision_note: str
+    event_actor: str
+    event_recorded_at_utc: str
+
+
+@dataclass(frozen=True)
+class OwnerDecisionCockpitItem:
+    cockpit_item_id: str
+    review_item_id: str
+    packet_id: str
+    entry_id: str
+    cockpit_rank: int
+    inbox_rank: int
+    assigned_lane: str
+    decision_type: str
+    review_state: str
+    console_bucket: str
+    owner_decision: str
+    decision_note: str
+    event_actor: str
+    event_recorded_at_utc: str
+    cockpit_status: str
+    template_record: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OwnerDecisionCockpitBuildResult:
+    inbox_item_count: int
+    captured_decision_count: int
+    awaiting_owner_input_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    status_counts: dict[str, int]
+    decision_counts: dict[str, int]
+    output_db: Path
+    output_template: Path
+    summary_path: Path
+
+
+def _connect_ro(db_path: Path, *, expected_name: str, label: str) -> sqlite3.Connection:
+    if db_path.name != expected_name:
+        raise ValueError(f"Refusing to read unexpected {label}: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"{label} not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def read_source_metadata(db_path: Path) -> tuple[str, int]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_OWNER_INBOX_DB_NAME,
+        label="Owner Decision Inbox DB",
+    ) as conn:
+        row = conn.execute(
+            """
+            SELECT generated_at_utc, inbox_item_count
+            FROM owner_decision_inbox_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+    if row is None:
+        raise ValueError("Owner Decision Inbox DB missing run metadata")
+    return str(row["generated_at_utc"]), int(row["inbox_item_count"])
+
+
+def read_owner_inbox_rows(db_path: Path) -> tuple[OwnerDecisionInboxRow, ...]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_OWNER_INBOX_DB_NAME,
+        label="Owner Decision Inbox DB",
+    ) as conn:
+        rows = conn.execute(
+            """
+            SELECT owner_inbox_item_id, review_item_id, packet_id, entry_id,
+                   inbox_rank, assigned_lane, decision_type, review_state,
+                   console_bucket, allowed_decisions_json, send_whatsapp,
+                   crm_mutation, requires_human_approval
+            FROM owner_decision_inbox_items
+            ORDER BY inbox_rank, review_item_id
+            """
+        ).fetchall()
+
+    inbox_rows: list[OwnerDecisionInboxRow] = []
+    for row in rows:
+        allowed_raw = json.loads(str(row["allowed_decisions_json"]))
+        if not isinstance(allowed_raw, list) or not all(
+            isinstance(item, str) for item in allowed_raw
+        ):
+            raise ValueError(f"Invalid allowed decisions on {row['review_item_id']}")
+        allowed = tuple(allowed_raw)
+        if set(allowed) != set(ALLOWED_OWNER_DECISIONS):
+            raise ValueError(f"Owner cockpit allowed decisions drifted for {row['review_item_id']}")
+        if bool(row["send_whatsapp"]) or bool(row["crm_mutation"]):
+            raise ValueError(f"Unsafe owner inbox item flags on {row['review_item_id']}")
+        if not bool(row["requires_human_approval"]):
+            raise ValueError(f"Owner inbox item missing human approval gate: {row['review_item_id']}")
+        inbox_rows.append(
+            OwnerDecisionInboxRow(
+                owner_inbox_item_id=str(row["owner_inbox_item_id"]),
+                review_item_id=str(row["review_item_id"]),
+                packet_id=str(row["packet_id"]),
+                entry_id=str(row["entry_id"]),
+                inbox_rank=int(row["inbox_rank"]),
+                assigned_lane=str(row["assigned_lane"]),
+                decision_type=str(row["decision_type"]),
+                review_state=str(row["review_state"]),
+                console_bucket=str(row["console_bucket"]),
+                allowed_decisions=allowed,
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(inbox_rows)
+
+
+def _read_jsonl(path: Path) -> tuple[dict[str, object], ...]:
+    if not path.exists():
+        raise FileNotFoundError(f"Owner cockpit input JSONL not found: {path}")
+    rows: list[dict[str, object]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            decoded = json.loads(stripped)
+            if not isinstance(decoded, dict):
+                raise ValueError(f"Owner cockpit input line {line_number} must be a JSON object")
+            rows.append(decoded)
+    return tuple(rows)
+
+
+def _parse_assignment(raw: str, *, label: str) -> tuple[str, str]:
+    if "=" not in raw:
+        raise ValueError(f"{label} must use review_item_id=value")
+    key, value = raw.split("=", 1)
+    key = key.strip()
+    if not key:
+        raise ValueError(f"{label} missing review_item_id")
+    return key, value.strip()
+
+
+def _inline_input_rows(
+    *,
+    decisions: Sequence[str],
+    decision_notes: Sequence[str],
+    event_recorded_at_utc: Sequence[str],
+) -> tuple[dict[str, object], ...]:
+    rows_by_review_item: dict[str, dict[str, object]] = {}
+    for raw in decisions:
+        review_item_id, owner_decision = _parse_assignment(raw, label="--decision")
+        if review_item_id in rows_by_review_item:
+            raise ValueError(f"Duplicate owner cockpit decision: {review_item_id}")
+        rows_by_review_item[review_item_id] = {
+            "owner_decision": owner_decision,
+            "review_item_id": review_item_id,
+        }
+    for raw in decision_notes:
+        review_item_id, decision_note = _parse_assignment(raw, label="--decision-note")
+        if review_item_id not in rows_by_review_item:
+            raise ValueError(f"--decision-note references missing decision: {review_item_id}")
+        rows_by_review_item[review_item_id]["decision_note"] = decision_note
+    for raw in event_recorded_at_utc:
+        review_item_id, timestamp = _parse_assignment(raw, label="--event-recorded-at-utc")
+        if review_item_id not in rows_by_review_item:
+            raise ValueError(
+                f"--event-recorded-at-utc references missing decision: {review_item_id}"
+            )
+        rows_by_review_item[review_item_id]["event_recorded_at_utc"] = timestamp
+    return tuple(rows_by_review_item.values())
+
+
+def _owner_inputs_by_review_item(
+    rows: Sequence[dict[str, object]],
+    *,
+    generated_at_utc: str,
+) -> dict[str, OwnerDecisionInput]:
+    inputs: dict[str, OwnerDecisionInput] = {}
+    for raw in rows:
+        review_item_id_raw = raw.get("review_item_id")
+        if not isinstance(review_item_id_raw, str) or not review_item_id_raw:
+            raise ValueError("Owner cockpit input missing review_item_id")
+        if review_item_id_raw in inputs:
+            raise ValueError(f"Duplicate owner cockpit decision: {review_item_id_raw}")
+
+        owner_decision_raw = raw.get("owner_decision")
+        if not isinstance(owner_decision_raw, str) or not owner_decision_raw:
+            raise ValueError(f"Owner cockpit decision is missing for {review_item_id_raw}")
+        if owner_decision_raw not in ALLOWED_OWNER_DECISIONS:
+            raise ValueError(
+                f"Owner cockpit decision is not allowed for {review_item_id_raw}: "
+                f"{owner_decision_raw}"
+            )
+
+        event_actor_raw = raw.get("event_actor")
+        event_actor = (
+            event_actor_raw
+            if isinstance(event_actor_raw, str) and event_actor_raw
+            else DEFAULT_EVENT_ACTOR
+        )
+        if event_actor != DEFAULT_EVENT_ACTOR:
+            raise ValueError(f"Owner cockpit decision {review_item_id_raw} has invalid actor")
+
+        decision_note_raw = raw.get("decision_note")
+        decision_note = (
+            decision_note_raw
+            if isinstance(decision_note_raw, str) and decision_note_raw
+            else ""
+        )
+        timestamp_raw = raw.get("event_recorded_at_utc")
+        if isinstance(timestamp_raw, str) and timestamp_raw:
+            event_recorded_at_utc = _format_utc(timestamp_raw)
+        else:
+            event_recorded_at_utc = ""
+
+        inputs[review_item_id_raw] = OwnerDecisionInput(
+            review_item_id=review_item_id_raw,
+            owner_decision=owner_decision_raw,
+            decision_note=decision_note,
+            event_actor=event_actor,
+            event_recorded_at_utc=event_recorded_at_utc,
+        )
+    _ = generated_at_utc
+    return inputs
+
+
+def build_cockpit_items(
+    inbox_rows: Sequence[OwnerDecisionInboxRow],
+    owner_inputs: dict[str, OwnerDecisionInput],
+) -> tuple[OwnerDecisionCockpitItem, ...]:
+    by_review_item = {row.review_item_id: row for row in inbox_rows}
+    unknown = set(owner_inputs) - set(by_review_item)
+    if unknown:
+        first = sorted(unknown)[0]
+        raise ValueError(f"Owner cockpit input references unknown inbox item: {first}")
+
+    items: list[OwnerDecisionCockpitItem] = []
+    for cockpit_rank, inbox_row in enumerate(inbox_rows, start=1):
+        owner_input = owner_inputs.get(inbox_row.review_item_id)
+        owner_decision = owner_input.owner_decision if owner_input else ""
+        decision_note = owner_input.decision_note if owner_input else ""
+        event_recorded_at_utc = owner_input.event_recorded_at_utc if owner_input else ""
+        cockpit_status = (
+            COCKPIT_READY_FOR_COMPILE if owner_input else COCKPIT_AWAITING_OWNER_INPUT
+        )
+        template_record = {
+            "allowed_decisions": list(inbox_row.allowed_decisions),
+            "assigned_lane": inbox_row.assigned_lane,
+            "console_bucket": inbox_row.console_bucket,
+            "decision_note": decision_note,
+            "decision_type": inbox_row.decision_type,
+            "entry_id": inbox_row.entry_id,
+            "event_actor": DEFAULT_EVENT_ACTOR,
+            "event_recorded_at_utc": event_recorded_at_utc,
+            "owner_decision": owner_decision,
+            "packet_id": inbox_row.packet_id,
+            "review_item_id": inbox_row.review_item_id,
+            "review_state": inbox_row.review_state,
+        }
+        items.append(
+            OwnerDecisionCockpitItem(
+                cockpit_item_id=f"owner-decision-cockpit-item-{inbox_row.inbox_rank:06d}",
+                review_item_id=inbox_row.review_item_id,
+                packet_id=inbox_row.packet_id,
+                entry_id=inbox_row.entry_id,
+                cockpit_rank=cockpit_rank,
+                inbox_rank=inbox_row.inbox_rank,
+                assigned_lane=inbox_row.assigned_lane,
+                decision_type=inbox_row.decision_type,
+                review_state=inbox_row.review_state,
+                console_bucket=inbox_row.console_bucket,
+                owner_decision=owner_decision,
+                decision_note=decision_note,
+                event_actor=DEFAULT_EVENT_ACTOR,
+                event_recorded_at_utc=event_recorded_at_utc,
+                cockpit_status=cockpit_status,
+                template_record=template_record,
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(items)
+
+
+def _replace_sqlite(temp_db: Path, output_db: Path) -> None:
+    output_db.parent.mkdir(parents=True, exist_ok=True)
+    if output_db.exists():
+        output_db.unlink()
+    temp_db.replace(output_db)
+
+
+def _unlink_file_if_present(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+
+
+def _clear_cockpit_outputs(*, output_db: Path, output_template: Path, summary_path: Path) -> None:
+    for path in (output_db, output_template, summary_path):
+        _unlink_file_if_present(path)
+        _unlink_file_if_present(path.with_name(f".{path.name}.tmp"))
+
+
+def write_owner_decision_cockpit_sqlite(
+    output_db: Path,
+    *,
+    items: Sequence[OwnerDecisionCockpitItem],
+    source_inbox_item_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    output_db.parent.mkdir(parents=True, exist_ok=True)
+    temp_db = output_db.with_name(f".{output_db.name}.tmp")
+    if temp_db.exists():
+        temp_db.unlink()
+    status_counts = Counter(item.cockpit_status for item in items)
+    with sqlite3.connect(temp_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE owner_decision_cockpit_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_inbox_item_count INTEGER NOT NULL,
+                inbox_item_count INTEGER NOT NULL,
+                captured_decision_count INTEGER NOT NULL,
+                awaiting_owner_input_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL CHECK (send_whatsapp_count = 0),
+                crm_mutation_count INTEGER NOT NULL CHECK (crm_mutation_count = 0)
+            );
+
+            CREATE TABLE owner_decision_cockpit_items (
+                cockpit_item_id TEXT PRIMARY KEY,
+                review_item_id TEXT NOT NULL UNIQUE,
+                packet_id TEXT NOT NULL,
+                entry_id TEXT NOT NULL,
+                cockpit_rank INTEGER NOT NULL,
+                inbox_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                review_state TEXT NOT NULL,
+                console_bucket TEXT NOT NULL,
+                owner_decision TEXT NOT NULL,
+                decision_note TEXT NOT NULL,
+                event_actor TEXT NOT NULL,
+                event_recorded_at_utc TEXT NOT NULL,
+                cockpit_status TEXT NOT NULL,
+                output_template_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE INDEX idx_owner_decision_cockpit_rank
+                ON owner_decision_cockpit_items(cockpit_rank);
+            CREATE INDEX idx_owner_decision_cockpit_status
+                ON owner_decision_cockpit_items(cockpit_status);
+            CREATE INDEX idx_owner_decision_cockpit_decision
+                ON owner_decision_cockpit_items(owner_decision);
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO owner_decision_cockpit_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_inbox_item_count, inbox_item_count,
+                captured_decision_count, awaiting_owner_input_count,
+                send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, ?, ?, ?, ?, 0, 0)
+            """,
+            (
+                generated_at_utc,
+                source_generated_at_utc,
+                "local_only_owner_decision_cockpit_no_raw_text_no_send_no_crm_mutation",
+                source_inbox_item_count,
+                len(items),
+                status_counts.get(COCKPIT_READY_FOR_COMPILE, 0),
+                status_counts.get(COCKPIT_AWAITING_OWNER_INPUT, 0),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO owner_decision_cockpit_items (
+                cockpit_item_id, review_item_id, packet_id, entry_id,
+                cockpit_rank, inbox_rank, assigned_lane, decision_type,
+                review_state, console_bucket, owner_decision, decision_note,
+                event_actor, event_recorded_at_utc, cockpit_status,
+                output_template_json, send_whatsapp, crm_mutation,
+                requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    item.cockpit_item_id,
+                    item.review_item_id,
+                    item.packet_id,
+                    item.entry_id,
+                    item.cockpit_rank,
+                    item.inbox_rank,
+                    item.assigned_lane,
+                    item.decision_type,
+                    item.review_state,
+                    item.console_bucket,
+                    item.owner_decision,
+                    item.decision_note,
+                    item.event_actor,
+                    item.event_recorded_at_utc,
+                    item.cockpit_status,
+                    json.dumps(item.template_record, ensure_ascii=False, sort_keys=True),
+                    int(item.send_whatsapp),
+                    int(item.crm_mutation),
+                    int(item.requires_human_approval),
+                )
+                for item in items
+            ],
+        )
+        conn.commit()
+    _replace_sqlite(temp_db, output_db)
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_name(f".{path.name}.tmp")
+    temp_path.write_text(text, encoding="utf-8")
+    temp_path.replace(path)
+
+
+def write_owner_decision_template_jsonl(
+    output_template: Path,
+    items: Sequence[OwnerDecisionCockpitItem],
+) -> None:
+    _atomic_write_text(
+        output_template,
+        "".join(
+            json.dumps(item.template_record, ensure_ascii=False, sort_keys=True) + "\n"
+            for item in items
+        ),
+    )
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'blank'} | {count} |")
+    return lines
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    items: Sequence[OwnerDecisionCockpitItem],
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    status_counts = Counter(item.cockpit_status for item in items)
+    decision_counts = Counter(item.owner_decision for item in items)
+    lane_counts = Counter(item.assigned_lane for item in items)
+    lines = [
+        "# Zantara Owner Decision Cockpit Summary",
+        "",
+        f"Generated UTC: `{generated_at_utc}`",
+        f"Source Owner Decision Inbox UTC: `{source_generated_at_utc}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, case IDs, pack IDs, packet IDs, review item IDs, or inbox item IDs.",
+        "- Owner Decision Cockpit artifacts are local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Owner inbox items | {len(items)} |",
+        f"| Captured decisions | {status_counts.get(COCKPIT_READY_FOR_COMPILE, 0)} |",
+        f"| Awaiting owner input | {status_counts.get(COCKPIT_AWAITING_OWNER_INPUT, 0)} |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("Cockpit Status", status_counts),
+        "",
+        *_counter_table("Owner Decisions", decision_counts),
+        "",
+        *_counter_table("Assigned Lanes", lane_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- The Owner Decision Cockpit records only explicit owner inputs.",
+        "- Missing owner inputs stay blank and awaiting owner input.",
+        "- It writes a compiler-compatible owner decision template.",
+        "- It does not parse raw WhatsApp messages.",
+        "- It does not call a cloud LLM.",
+        "- Runtime must not send WhatsApp messages from this artifact.",
+        "- Runtime must not mutate CRM records from this artifact.",
+        "- Human approval remains mandatory before any client-facing message or operational mutation.",
+    ]
+    _atomic_write_text(summary_path, "\n".join(lines) + "\n")
+
+
+def build_owner_decision_cockpit(
+    *,
+    owner_inbox_db: Path = DEFAULT_OWNER_INBOX_DB,
+    owner_inputs_jsonl: Path | None = None,
+    inline_decisions: Sequence[str] = (),
+    inline_decision_notes: Sequence[str] = (),
+    inline_event_recorded_at_utc: Sequence[str] = (),
+    output_dir: Path = DEFAULT_OWNER_DECISION_COCKPIT_DIR,
+    output_db: Path | None = None,
+    output_template: Path | None = None,
+    summary_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> OwnerDecisionCockpitBuildResult:
+    """Build a local cockpit artifact and compiler-compatible decision template."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    output_template = output_template or output_dir / DEFAULT_OUTPUT_TEMPLATE.name
+    summary_path = summary_path or output_dir / DEFAULT_SUMMARY.name
+    generated = _format_utc(generated_at_utc)
+    _clear_cockpit_outputs(
+        output_db=output_db,
+        output_template=output_template,
+        summary_path=summary_path,
+    )
+
+    try:
+        source_generated, source_count = read_source_metadata(owner_inbox_db)
+        inbox_rows = read_owner_inbox_rows(owner_inbox_db)
+        raw_inputs: list[dict[str, object]] = []
+        if owner_inputs_jsonl is not None:
+            raw_inputs.extend(_read_jsonl(owner_inputs_jsonl))
+        raw_inputs.extend(
+            _inline_input_rows(
+                decisions=inline_decisions,
+                decision_notes=inline_decision_notes,
+                event_recorded_at_utc=inline_event_recorded_at_utc,
+            )
+        )
+        owner_inputs = _owner_inputs_by_review_item(
+            raw_inputs,
+            generated_at_utc=generated,
+        )
+        items = build_cockpit_items(inbox_rows, owner_inputs)
+        source_total = source_count or len(inbox_rows)
+
+        write_owner_decision_cockpit_sqlite(
+            output_db,
+            items=items,
+            source_inbox_item_count=source_total,
+            generated_at_utc=generated,
+            source_generated_at_utc=source_generated,
+        )
+        write_owner_decision_template_jsonl(output_template, items)
+        write_summary(
+            summary_path=summary_path,
+            items=items,
+            generated_at_utc=generated,
+            source_generated_at_utc=source_generated,
+        )
+    except Exception:
+        _clear_cockpit_outputs(
+            output_db=output_db,
+            output_template=output_template,
+            summary_path=summary_path,
+        )
+        raise
+
+    status_counts = Counter(item.cockpit_status for item in items)
+    decision_counts = Counter(item.owner_decision for item in items)
+    return OwnerDecisionCockpitBuildResult(
+        inbox_item_count=len(items),
+        captured_decision_count=status_counts.get(COCKPIT_READY_FOR_COMPILE, 0),
+        awaiting_owner_input_count=status_counts.get(COCKPIT_AWAITING_OWNER_INPUT, 0),
+        send_whatsapp_count=sum(1 for item in items if item.send_whatsapp),
+        crm_mutation_count=sum(1 for item in items if item.crm_mutation),
+        status_counts=dict(status_counts),
+        decision_counts=dict(decision_counts),
+        output_db=output_db,
+        output_template=output_template,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build a local-only Zantara Owner Decision Cockpit template."
+    )
+    parser.add_argument("--owner-inbox-db", type=Path, default=DEFAULT_OWNER_INBOX_DB)
+    parser.add_argument("--owner-inputs-jsonl", type=Path, default=None)
+    parser.add_argument("--decision", action="append", default=[])
+    parser.add_argument("--decision-note", action="append", default=[])
+    parser.add_argument("--event-recorded-at-utc", action="append", default=[])
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OWNER_DECISION_COCKPIT_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--output-template", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=None)
+    parser.add_argument("--generated-at-utc", default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_owner_decision_cockpit(
+            owner_inbox_db=args.owner_inbox_db,
+            owner_inputs_jsonl=args.owner_inputs_jsonl,
+            inline_decisions=args.decision,
+            inline_decision_notes=args.decision_note,
+            inline_event_recorded_at_utc=args.event_recorded_at_utc,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            output_template=args.output_template,
+            summary_path=args.summary,
+            generated_at_utc=args.generated_at_utc,
+        )
+    except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
+        print("ERROR: Owner decision cockpit input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError):
+        print("ERROR: Owner decision cockpit run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        print("ERROR: Owner decision cockpit run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "awaiting_owner_input_count": result.awaiting_owner_input_count,
+                    "captured_decision_count": result.captured_decision_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                    "inbox_item_count": result.inbox_item_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                },
+                sort_keys=True,
+            )
+        )
+    else:
+        print(
+            "Owner decision cockpit complete: "
+            f"{result.captured_decision_count}/{result.inbox_item_count} decisions -> "
+            f"{result.output_template.name}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/whatsapp_corpus/build_owner_decision_compiler.py
+++ b/scripts/whatsapp_corpus/build_owner_decision_compiler.py
@@ -1,0 +1,695 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.whatsapp_corpus.build_owner_decision_intake import (
+    ALLOWED_OWNER_DECISIONS,
+    DEFAULT_EVENT_ACTOR,
+    _format_utc,
+)
+
+DEFAULT_OWNER_DECISION_INBOX_DIR = Path(
+    "research/personal/wa-corpus/owner-decision-inbox"
+)
+DEFAULT_OWNER_DECISION_COMPILER_DIR = Path(
+    "research/personal/wa-corpus/owner-decision-compiler"
+)
+
+DEFAULT_OWNER_INBOX_DB = DEFAULT_OWNER_DECISION_INBOX_DIR / "owner_decision_inbox.local.sqlite"
+DEFAULT_EDITED_TEMPLATE_JSONL = (
+    DEFAULT_OWNER_DECISION_INBOX_DIR / "owner_decisions_template.local.jsonl"
+)
+DEFAULT_OUTPUT_DB = (
+    DEFAULT_OWNER_DECISION_COMPILER_DIR / "owner_decision_compiler.local.sqlite"
+)
+DEFAULT_OUTPUT_JSONL = DEFAULT_OWNER_DECISION_COMPILER_DIR / "owner_decisions.local.jsonl"
+DEFAULT_SUMMARY = (
+    DEFAULT_OWNER_DECISION_COMPILER_DIR / "owner_decision_compiler_summary.md"
+)
+
+EXPECTED_OWNER_INBOX_DB_NAME = "owner_decision_inbox.local.sqlite"
+EXPECTED_EDITED_TEMPLATE_NAME = "owner_decisions_template.local.jsonl"
+TIMESTAMP_OWNER_SUPPLIED = "owner_supplied"
+TIMESTAMP_COMPILER_GENERATED = "compiler_generated_at_utc"
+
+
+@dataclass(frozen=True)
+class OwnerInboxRow:
+    owner_inbox_item_id: str
+    review_item_id: str
+    packet_id: str
+    entry_id: str
+    inbox_rank: int
+    assigned_lane: str
+    decision_type: str
+    review_state: str
+    console_bucket: str
+    owner_decision_status: str
+    allowed_decisions: tuple[str, ...]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class CompiledOwnerDecision:
+    compiler_item_id: str
+    review_item_id: str
+    packet_id: str
+    entry_id: str
+    compile_rank: int
+    inbox_rank: int
+    assigned_lane: str
+    decision_type: str
+    review_state: str
+    console_bucket: str
+    owner_decision: str
+    decision_note: str
+    event_actor: str
+    event_recorded_at_utc: str
+    timestamp_source: str
+    output_payload: dict[str, str]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OwnerDecisionCompilerBuildResult:
+    source_inbox_item_count: int
+    template_row_count: int
+    compiled_decision_count: int
+    backfilled_timestamp_count: int
+    owner_supplied_timestamp_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    decision_counts: dict[str, int]
+    timestamp_source_counts: dict[str, int]
+    output_db: Path
+    output_jsonl: Path
+    summary_path: Path
+
+
+def _connect_ro(db_path: Path, *, expected_name: str, label: str) -> sqlite3.Connection:
+    if db_path.name != expected_name:
+        raise ValueError(f"Refusing to read unexpected {label}: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"{label} not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _read_jsonl(path: Path) -> tuple[dict[str, object], ...]:
+    if path.name != EXPECTED_EDITED_TEMPLATE_NAME:
+        raise ValueError(f"Refusing to read unexpected owner decision template: {path.name}")
+    if not path.exists():
+        raise FileNotFoundError(f"Owner decision template not found: {path}")
+    rows: list[dict[str, object]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            decoded = json.loads(stripped)
+            if not isinstance(decoded, dict):
+                raise ValueError(f"Owner decision compiler line {line_number} must be a JSON object")
+            rows.append(decoded)
+    return tuple(rows)
+
+
+def read_source_metadata(db_path: Path) -> tuple[str, int]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_OWNER_INBOX_DB_NAME,
+        label="Owner Decision Inbox DB",
+    ) as conn:
+        row = conn.execute(
+            """
+            SELECT generated_at_utc, inbox_item_count
+            FROM owner_decision_inbox_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+    if row is None:
+        return "unknown", 0
+    return str(row["generated_at_utc"]), int(row["inbox_item_count"])
+
+
+def read_owner_inbox_rows(db_path: Path) -> tuple[OwnerInboxRow, ...]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_OWNER_INBOX_DB_NAME,
+        label="Owner Decision Inbox DB",
+    ) as conn:
+        rows = conn.execute(
+            """
+            SELECT owner_inbox_item_id, review_item_id, packet_id, entry_id,
+                   inbox_rank, assigned_lane, decision_type, review_state,
+                   console_bucket, owner_decision_status, allowed_decisions_json,
+                   send_whatsapp, crm_mutation, requires_human_approval
+            FROM owner_decision_inbox_items
+            ORDER BY inbox_rank, review_item_id
+            """
+        ).fetchall()
+    return tuple(
+        OwnerInboxRow(
+            owner_inbox_item_id=str(row["owner_inbox_item_id"]),
+            review_item_id=str(row["review_item_id"]),
+            packet_id=str(row["packet_id"]),
+            entry_id=str(row["entry_id"]),
+            inbox_rank=int(row["inbox_rank"]),
+            assigned_lane=str(row["assigned_lane"]),
+            decision_type=str(row["decision_type"]),
+            review_state=str(row["review_state"]),
+            console_bucket=str(row["console_bucket"]),
+            owner_decision_status=str(row["owner_decision_status"]),
+            allowed_decisions=tuple(json.loads(str(row["allowed_decisions_json"]))),
+            send_whatsapp=bool(row["send_whatsapp"]),
+            crm_mutation=bool(row["crm_mutation"]),
+            requires_human_approval=bool(row["requires_human_approval"]),
+        )
+        for row in rows
+    )
+
+
+def _get_required_string(raw: dict[str, object], key: str, *, reference: str) -> str:
+    value = raw.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"Owner decision compiler row {reference} missing {key}")
+    return value
+
+
+def _verify_template_matches_inbox(raw: dict[str, object], inbox_row: OwnerInboxRow) -> None:
+    reference = inbox_row.review_item_id
+    expected = {
+        "assigned_lane": inbox_row.assigned_lane,
+        "console_bucket": inbox_row.console_bucket,
+        "decision_type": inbox_row.decision_type,
+        "entry_id": inbox_row.entry_id,
+        "packet_id": inbox_row.packet_id,
+        "review_state": inbox_row.review_state,
+    }
+    for key, expected_value in expected.items():
+        actual = raw.get(key)
+        if actual != expected_value:
+            raise ValueError(
+                f"Owner decision compiler row {reference} does not match inbox DB: {key}"
+            )
+
+
+def _timestamp_from_raw(
+    raw: dict[str, object],
+    *,
+    reference: str,
+    generated_at_utc: str,
+) -> tuple[str, str]:
+    raw_timestamp = raw.get("event_recorded_at_utc")
+    if raw_timestamp is None or raw_timestamp == "":
+        return generated_at_utc, TIMESTAMP_COMPILER_GENERATED
+    if not isinstance(raw_timestamp, str):
+        raise ValueError(f"Owner decision compiler row {reference} has invalid timestamp")
+    return _format_utc(raw_timestamp), TIMESTAMP_OWNER_SUPPLIED
+
+
+def build_compiled_decisions(
+    inbox_rows: Sequence[OwnerInboxRow],
+    edited_template_rows: Sequence[dict[str, object]],
+    *,
+    generated_at_utc: str,
+) -> tuple[CompiledOwnerDecision, ...]:
+    by_review_item = {row.review_item_id: row for row in inbox_rows}
+    if len(edited_template_rows) != len(inbox_rows):
+        raise ValueError("Owner decision compiler template must contain every inbox item")
+
+    seen: set[str] = set()
+    compiled: list[CompiledOwnerDecision] = []
+    for raw in edited_template_rows:
+        raw_review_item_id = raw.get("review_item_id")
+        if not isinstance(raw_review_item_id, str) or not raw_review_item_id:
+            raise ValueError("Owner decision compiler row missing review_item_id")
+        if raw_review_item_id in seen:
+            raise ValueError(f"Duplicate owner decision compiler row: {raw_review_item_id}")
+        seen.add(raw_review_item_id)
+
+        inbox_row = by_review_item.get(raw_review_item_id)
+        if inbox_row is None:
+            raise ValueError(
+                f"Owner decision compiler row references unknown inbox item: {raw_review_item_id}"
+            )
+        if inbox_row.send_whatsapp or inbox_row.crm_mutation:
+            raise ValueError(f"Unsafe inbox item flags on {raw_review_item_id}")
+        if not inbox_row.requires_human_approval:
+            raise ValueError(f"Inbox item missing human approval gate: {raw_review_item_id}")
+        if set(inbox_row.allowed_decisions) != set(ALLOWED_OWNER_DECISIONS):
+            raise ValueError(f"Inbox allowed decisions drifted for {raw_review_item_id}")
+        _verify_template_matches_inbox(raw, inbox_row)
+
+        owner_decision = raw.get("owner_decision")
+        if not isinstance(owner_decision, str) or not owner_decision:
+            raise ValueError(f"Owner decision is missing for {raw_review_item_id}")
+        if owner_decision not in ALLOWED_OWNER_DECISIONS:
+            raise ValueError(
+                f"Owner decision is not allowed for {raw_review_item_id}: {owner_decision}"
+            )
+
+        event_actor_raw = raw.get("event_actor")
+        event_actor = (
+            event_actor_raw
+            if isinstance(event_actor_raw, str) and event_actor_raw
+            else DEFAULT_EVENT_ACTOR
+        )
+        if event_actor != DEFAULT_EVENT_ACTOR:
+            raise ValueError(f"Owner decision compiler row {raw_review_item_id} has invalid actor")
+        decision_note_raw = raw.get("decision_note")
+        decision_note = (
+            decision_note_raw
+            if isinstance(decision_note_raw, str) and decision_note_raw
+            else ""
+        )
+        event_recorded_at_utc, timestamp_source = _timestamp_from_raw(
+            raw,
+            reference=raw_review_item_id,
+            generated_at_utc=generated_at_utc,
+        )
+        output_payload = {
+            "decision_note": decision_note,
+            "event_actor": event_actor,
+            "event_recorded_at_utc": event_recorded_at_utc,
+            "owner_decision": owner_decision,
+            "review_item_id": raw_review_item_id,
+            "timestamp_source": timestamp_source,
+        }
+        compiled.append(
+            CompiledOwnerDecision(
+                compiler_item_id=f"owner-decision-compiler-item-{inbox_row.inbox_rank:06d}",
+                review_item_id=raw_review_item_id,
+                packet_id=inbox_row.packet_id,
+                entry_id=inbox_row.entry_id,
+                compile_rank=inbox_row.inbox_rank,
+                inbox_rank=inbox_row.inbox_rank,
+                assigned_lane=inbox_row.assigned_lane,
+                decision_type=inbox_row.decision_type,
+                review_state=inbox_row.review_state,
+                console_bucket=inbox_row.console_bucket,
+                owner_decision=owner_decision,
+                decision_note=decision_note,
+                event_actor=event_actor,
+                event_recorded_at_utc=event_recorded_at_utc,
+                timestamp_source=timestamp_source,
+                output_payload=output_payload,
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    missing = set(by_review_item) - seen
+    if missing:
+        raise ValueError("Owner decision compiler template is missing inbox items")
+    return tuple(sorted(compiled, key=lambda item: (item.compile_rank, item.review_item_id)))
+
+
+def _replace_sqlite(temp_db: Path, output_db: Path) -> None:
+    output_db.parent.mkdir(parents=True, exist_ok=True)
+    if output_db.exists():
+        output_db.unlink()
+    temp_db.replace(output_db)
+
+
+def _unlink_file_if_present(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+
+
+def _clear_compiler_outputs(*, output_db: Path, output_jsonl: Path, summary_path: Path) -> None:
+    for path in (output_db, output_jsonl, summary_path):
+        _unlink_file_if_present(path)
+        _unlink_file_if_present(path.with_name(f".{path.name}.tmp"))
+
+
+def write_owner_decision_compiler_sqlite(
+    output_db: Path,
+    *,
+    items: Sequence[CompiledOwnerDecision],
+    source_inbox_item_count: int,
+    template_row_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    output_db.parent.mkdir(parents=True, exist_ok=True)
+    temp_db = output_db.with_name(f".{output_db.name}.tmp")
+    if temp_db.exists():
+        temp_db.unlink()
+    decision_counts = Counter(item.owner_decision for item in items)
+    timestamp_counts = Counter(item.timestamp_source for item in items)
+    with sqlite3.connect(temp_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE owner_decision_compiler_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_inbox_item_count INTEGER NOT NULL,
+                template_row_count INTEGER NOT NULL,
+                compiled_decision_count INTEGER NOT NULL,
+                backfilled_timestamp_count INTEGER NOT NULL,
+                owner_supplied_timestamp_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL CHECK (send_whatsapp_count = 0),
+                crm_mutation_count INTEGER NOT NULL CHECK (crm_mutation_count = 0)
+            );
+
+            CREATE TABLE owner_decision_compiler_items (
+                compiler_item_id TEXT PRIMARY KEY,
+                review_item_id TEXT NOT NULL UNIQUE,
+                packet_id TEXT NOT NULL,
+                entry_id TEXT NOT NULL,
+                compile_rank INTEGER NOT NULL,
+                inbox_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                review_state TEXT NOT NULL,
+                console_bucket TEXT NOT NULL,
+                owner_decision TEXT NOT NULL,
+                decision_note TEXT NOT NULL,
+                event_actor TEXT NOT NULL,
+                event_recorded_at_utc TEXT NOT NULL,
+                timestamp_source TEXT NOT NULL,
+                output_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE INDEX idx_owner_decision_compiler_rank
+                ON owner_decision_compiler_items(compile_rank);
+            CREATE INDEX idx_owner_decision_compiler_decision
+                ON owner_decision_compiler_items(owner_decision);
+            CREATE INDEX idx_owner_decision_compiler_timestamp_source
+                ON owner_decision_compiler_items(timestamp_source);
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO owner_decision_compiler_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_inbox_item_count, template_row_count,
+                compiled_decision_count, backfilled_timestamp_count,
+                owner_supplied_timestamp_count, send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0)
+            """,
+            (
+                generated_at_utc,
+                source_generated_at_utc,
+                "local_only_owner_decision_compiler_no_raw_text_no_send_no_crm_mutation",
+                source_inbox_item_count,
+                template_row_count,
+                len(items),
+                timestamp_counts.get(TIMESTAMP_COMPILER_GENERATED, 0),
+                timestamp_counts.get(TIMESTAMP_OWNER_SUPPLIED, 0),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO owner_decision_compiler_items (
+                compiler_item_id, review_item_id, packet_id, entry_id,
+                compile_rank, inbox_rank, assigned_lane, decision_type,
+                review_state, console_bucket, owner_decision, decision_note,
+                event_actor, event_recorded_at_utc, timestamp_source,
+                output_payload_json, send_whatsapp, crm_mutation,
+                requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    item.compiler_item_id,
+                    item.review_item_id,
+                    item.packet_id,
+                    item.entry_id,
+                    item.compile_rank,
+                    item.inbox_rank,
+                    item.assigned_lane,
+                    item.decision_type,
+                    item.review_state,
+                    item.console_bucket,
+                    item.owner_decision,
+                    item.decision_note,
+                    item.event_actor,
+                    item.event_recorded_at_utc,
+                    item.timestamp_source,
+                    json.dumps(item.output_payload, ensure_ascii=False, sort_keys=True),
+                    int(item.send_whatsapp),
+                    int(item.crm_mutation),
+                    int(item.requires_human_approval),
+                )
+                for item in items
+            ],
+        )
+        conn.commit()
+    _replace_sqlite(temp_db, output_db)
+    _ = decision_counts
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_name(f".{path.name}.tmp")
+    temp_path.write_text(text, encoding="utf-8")
+    temp_path.replace(path)
+
+
+def write_owner_decisions_jsonl(
+    output_jsonl: Path,
+    items: Sequence[CompiledOwnerDecision],
+) -> None:
+    _atomic_write_text(
+        output_jsonl,
+        "".join(
+            json.dumps(item.output_payload, ensure_ascii=False, sort_keys=True) + "\n"
+            for item in items
+        ),
+    )
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'unknown'} | {count} |")
+    return lines
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    items: Sequence[CompiledOwnerDecision],
+    source_inbox_item_count: int,
+    template_row_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    decision_counts = Counter(item.owner_decision for item in items)
+    timestamp_counts = Counter(item.timestamp_source for item in items)
+    lane_counts = Counter(item.assigned_lane for item in items)
+    lines = [
+        "# Zantara Owner Decision Compiler Summary",
+        "",
+        f"Generated UTC: `{generated_at_utc}`",
+        f"Source Owner Decision Inbox UTC: `{source_generated_at_utc}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, case card IDs, judgment IDs, approval IDs, pack IDs, brief IDs, route IDs, ledger entry IDs, event IDs, work order IDs, packet IDs, review item IDs, or inbox item IDs.",
+        "- Owner decision compiler artifacts are local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Source inbox items | {source_inbox_item_count} |",
+        f"| Template rows | {template_row_count} |",
+        f"| Compiled decisions | {len(items)} |",
+        f"| Backfilled timestamps | {timestamp_counts.get(TIMESTAMP_COMPILER_GENERATED, 0)} |",
+        f"| Owner supplied timestamps | {timestamp_counts.get(TIMESTAMP_OWNER_SUPPLIED, 0)} |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("Owner Decisions", decision_counts),
+        "",
+        *_counter_table("Timestamp Sources", timestamp_counts),
+        "",
+        *_counter_table("Assigned Lanes", lane_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- The Owner Decision Compiler binds edited owner template rows to the local inbox DB.",
+        "- It imports the downstream intake decision enum instead of redefining it.",
+        "- It rejects blank, invalid, duplicate, unknown, or tampered owner decision rows.",
+        "- It emits clean `owner_decisions.local.jsonl` for the real Owner Decision Intake.",
+        "- It does not parse raw WhatsApp messages.",
+        "- It does not call a cloud LLM.",
+        "- Runtime must not send WhatsApp messages from this artifact.",
+        "- Runtime must not mutate CRM records from this artifact.",
+        "- Human approval remains mandatory before any client-facing message or operational mutation.",
+    ]
+    _atomic_write_text(summary_path, "\n".join(lines) + "\n")
+
+
+def build_owner_decision_compiler(
+    *,
+    owner_inbox_db: Path = DEFAULT_OWNER_INBOX_DB,
+    edited_template_jsonl: Path = DEFAULT_EDITED_TEMPLATE_JSONL,
+    output_dir: Path = DEFAULT_OWNER_DECISION_COMPILER_DIR,
+    output_db: Path | None = None,
+    output_jsonl: Path | None = None,
+    summary_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> OwnerDecisionCompilerBuildResult:
+    """Compile edited owner inbox decisions into intake-ready JSONL."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    output_jsonl = output_jsonl or output_dir / DEFAULT_OUTPUT_JSONL.name
+    summary_path = summary_path or output_dir / DEFAULT_SUMMARY.name
+    generated = _format_utc(generated_at_utc)
+    _clear_compiler_outputs(
+        output_db=output_db,
+        output_jsonl=output_jsonl,
+        summary_path=summary_path,
+    )
+    try:
+        source_generated, source_count = read_source_metadata(owner_inbox_db)
+        inbox_rows = read_owner_inbox_rows(owner_inbox_db)
+        template_rows = _read_jsonl(edited_template_jsonl)
+        source_total = source_count or len(inbox_rows)
+        compiled = build_compiled_decisions(
+            inbox_rows,
+            template_rows,
+            generated_at_utc=generated,
+        )
+
+        write_owner_decision_compiler_sqlite(
+            output_db,
+            items=compiled,
+            source_inbox_item_count=source_total,
+            template_row_count=len(template_rows),
+            generated_at_utc=generated,
+            source_generated_at_utc=source_generated,
+        )
+        write_owner_decisions_jsonl(output_jsonl, compiled)
+        write_summary(
+            summary_path=summary_path,
+            items=compiled,
+            source_inbox_item_count=source_total,
+            template_row_count=len(template_rows),
+            generated_at_utc=generated,
+            source_generated_at_utc=source_generated,
+        )
+    except Exception:
+        _clear_compiler_outputs(
+            output_db=output_db,
+            output_jsonl=output_jsonl,
+            summary_path=summary_path,
+        )
+        raise
+
+    timestamp_counts = Counter(item.timestamp_source for item in compiled)
+    return OwnerDecisionCompilerBuildResult(
+        source_inbox_item_count=source_total,
+        template_row_count=len(template_rows),
+        compiled_decision_count=len(compiled),
+        backfilled_timestamp_count=timestamp_counts.get(TIMESTAMP_COMPILER_GENERATED, 0),
+        owner_supplied_timestamp_count=timestamp_counts.get(TIMESTAMP_OWNER_SUPPLIED, 0),
+        send_whatsapp_count=sum(1 for item in compiled if item.send_whatsapp),
+        crm_mutation_count=sum(1 for item in compiled if item.crm_mutation),
+        decision_counts=dict(Counter(item.owner_decision for item in compiled)),
+        timestamp_source_counts=dict(timestamp_counts),
+        output_db=output_db,
+        output_jsonl=output_jsonl,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Compile edited local owner decision inbox rows into intake-ready JSONL."
+    )
+    parser.add_argument("--owner-inbox-db", type=Path, default=DEFAULT_OWNER_INBOX_DB)
+    parser.add_argument(
+        "--edited-template-jsonl",
+        type=Path,
+        default=DEFAULT_EDITED_TEMPLATE_JSONL,
+    )
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OWNER_DECISION_COMPILER_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--output-jsonl", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=None)
+    parser.add_argument("--generated-at-utc", default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_owner_decision_compiler(
+            owner_inbox_db=args.owner_inbox_db,
+            edited_template_jsonl=args.edited_template_jsonl,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            output_jsonl=args.output_jsonl,
+            summary_path=args.summary,
+            generated_at_utc=args.generated_at_utc,
+        )
+    except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
+        print("ERROR: Owner decision compiler input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError):
+        print("ERROR: Owner decision compiler run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        print("ERROR: Owner decision compiler run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "backfilled_timestamp_count": result.backfilled_timestamp_count,
+                    "compiled_decision_count": result.compiled_decision_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                    "owner_supplied_timestamp_count": result.owner_supplied_timestamp_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "source_inbox_item_count": result.source_inbox_item_count,
+                    "template_row_count": result.template_row_count,
+                },
+                sort_keys=True,
+            )
+        )
+    else:
+        print(
+            "Owner decision compiler complete: "
+            f"{result.compiled_decision_count} decisions -> {result.output_jsonl.name}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/whatsapp_corpus/build_owner_decision_event_capture.py
+++ b/scripts/whatsapp_corpus/build_owner_decision_event_capture.py
@@ -1,0 +1,761 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_APPROVE_REJECT_LEDGER_DIR = Path(
+    "research/personal/wa-corpus/approve-reject-ledger"
+)
+DEFAULT_OWNER_DECISION_EVENT_DIR = Path(
+    "research/personal/wa-corpus/owner-decision-events"
+)
+
+DEFAULT_LEDGER_DB = DEFAULT_APPROVE_REJECT_LEDGER_DIR / "approve_reject_ledger.local.sqlite"
+DEFAULT_OUTPUT_DB = (
+    DEFAULT_OWNER_DECISION_EVENT_DIR / "owner_decision_event_capture.local.sqlite"
+)
+DEFAULT_SUMMARY = (
+    DEFAULT_OWNER_DECISION_EVENT_DIR / "owner_decision_event_capture_summary.md"
+)
+
+EXPECTED_LEDGER_DB_NAME = "approve_reject_ledger.local.sqlite"
+DEFAULT_EVENT_SOURCE = "local_owner_event_capture"
+DEFAULT_EVENT_ACTOR = "owner"
+CAPTURED_STATUS = "captured"
+AWAITING_STATUS = "awaiting_owner_input"
+CAPTURED_EVENT_TYPE = "owner_decision_captured"
+AWAITING_EVENT_TYPE = "owner_decision_not_submitted"
+PENDING_OWNER_DECISION = "pending"
+DEFAULT_DECISION_NOTE = "owner_decision_required"
+
+
+@dataclass(frozen=True)
+class LedgerEntryRow:
+    entry_id: str
+    route_id: str
+    case_card_id: str
+    brief_id: str
+    pack_id: str
+    ledger_rank: int
+    assigned_lane: str
+    decision_type: str
+    decision_priority: str
+    route_bucket: str
+    next_actor: str
+    queue_status: str
+    decision_status: str
+    owner_decision: str
+    allowed_decisions: tuple[str, ...]
+    recommended_decision: str
+    draft_action_type: str
+    immutable_event_type: str
+    ledger_entry_hash: str
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OwnerDecisionEventInput:
+    entry_id: str
+    owner_decision: str
+    decision_note: str
+    event_actor: str
+    event_recorded_at_utc: str | None
+
+
+@dataclass(frozen=True)
+class OwnerDecisionEventRow:
+    event_id: str
+    entry_id: str
+    route_id: str
+    case_card_id: str
+    brief_id: str
+    pack_id: str
+    event_rank: int
+    assigned_lane: str
+    decision_type: str
+    decision_priority: str
+    route_bucket: str
+    capture_status: str
+    owner_decision: str
+    event_type: str
+    event_source: str
+    event_actor: str
+    event_recorded_at_utc: str
+    allowed_decisions: tuple[str, ...]
+    recommended_decision: str
+    draft_action_type: str
+    decision_note: str
+    source_ledger_hash: str
+    event_hash: str
+    event_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OwnerDecisionEventCaptureBuildResult:
+    source_case_count: int
+    owner_item_count: int
+    pack_count: int
+    brief_count: int
+    queue_item_count: int
+    ledger_entry_count: int
+    captured_event_count: int
+    awaiting_input_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    capture_status_counts: dict[str, int]
+    owner_decision_counts: dict[str, int]
+    event_type_counts: dict[str, int]
+    output_db: Path
+    summary_path: Path
+
+
+def _format_utc(value: str | None = None) -> str:
+    if value is not None:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).isoformat(timespec="seconds")
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _connect_ro(db_path: Path, *, expected_name: str, label: str) -> sqlite3.Connection:
+    if db_path.name != expected_name:
+        raise ValueError(f"Refusing to read unexpected {label} DB: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"{label} DB not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _parse_allowed_decisions(value: str) -> tuple[str, ...]:
+    decoded = json.loads(value)
+    if not isinstance(decoded, list):
+        raise ValueError("allowed_decisions_json must contain a JSON list")
+    return tuple(str(item) for item in decoded)
+
+
+def _hash_event(payload: dict[str, object]) -> str:
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def read_source_metadata(db_path: Path) -> tuple[str, int, int, int, int, int, int]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_LEDGER_DB_NAME,
+        label="Approve/Reject Ledger",
+    ) as conn:
+        row = conn.execute(
+            """
+            SELECT generated_at_utc, source_case_count, owner_item_count,
+                   pack_count, brief_count, queue_item_count, ledger_entry_count
+            FROM approve_reject_ledger_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+    if row is None:
+        return "unknown", 0, 0, 0, 0, 0, 0
+    return (
+        str(row["generated_at_utc"]),
+        int(row["source_case_count"]),
+        int(row["owner_item_count"]),
+        int(row["pack_count"]),
+        int(row["brief_count"]),
+        int(row["queue_item_count"]),
+        int(row["ledger_entry_count"]),
+    )
+
+
+def read_ledger_entries(db_path: Path) -> tuple[LedgerEntryRow, ...]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_LEDGER_DB_NAME,
+        label="Approve/Reject Ledger",
+    ) as conn:
+        rows = conn.execute(
+            """
+            SELECT entry_id, route_id, case_card_id, brief_id, pack_id,
+                   ledger_rank, assigned_lane, decision_type, decision_priority,
+                   route_bucket, next_actor, queue_status, decision_status,
+                   owner_decision, allowed_decisions_json, recommended_decision,
+                   draft_action_type, immutable_event_type, ledger_entry_hash,
+                   send_whatsapp, crm_mutation, requires_human_approval
+            FROM approve_reject_ledger_entries
+            ORDER BY ledger_rank, case_card_id
+            """
+        ).fetchall()
+    return tuple(
+        LedgerEntryRow(
+            entry_id=str(row["entry_id"]),
+            route_id=str(row["route_id"]),
+            case_card_id=str(row["case_card_id"]),
+            brief_id=str(row["brief_id"]),
+            pack_id=str(row["pack_id"]),
+            ledger_rank=int(row["ledger_rank"]),
+            assigned_lane=str(row["assigned_lane"]),
+            decision_type=str(row["decision_type"]),
+            decision_priority=str(row["decision_priority"]),
+            route_bucket=str(row["route_bucket"]),
+            next_actor=str(row["next_actor"]),
+            queue_status=str(row["queue_status"]),
+            decision_status=str(row["decision_status"]),
+            owner_decision=str(row["owner_decision"]),
+            allowed_decisions=_parse_allowed_decisions(str(row["allowed_decisions_json"])),
+            recommended_decision=str(row["recommended_decision"]),
+            draft_action_type=str(row["draft_action_type"]),
+            immutable_event_type=str(row["immutable_event_type"]),
+            ledger_entry_hash=str(row["ledger_entry_hash"]),
+            send_whatsapp=bool(row["send_whatsapp"]),
+            crm_mutation=bool(row["crm_mutation"]),
+            requires_human_approval=bool(row["requires_human_approval"]),
+        )
+        for row in rows
+    )
+
+
+def _read_jsonl(path: Path) -> tuple[dict[str, object], ...]:
+    rows: list[dict[str, object]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            decoded = json.loads(stripped)
+            if not isinstance(decoded, dict):
+                raise ValueError(f"Owner event line {line_number} must be a JSON object")
+            rows.append(decoded)
+    return tuple(rows)
+
+
+def read_owner_event_inputs(
+    jsonl_path: Path | None,
+) -> dict[str, OwnerDecisionEventInput]:
+    if jsonl_path is None:
+        return {}
+    events: dict[str, OwnerDecisionEventInput] = {}
+    for raw in _read_jsonl(jsonl_path):
+        entry_id = raw.get("entry_id")
+        owner_decision = raw.get("owner_decision")
+        if not isinstance(entry_id, str) or not entry_id:
+            raise ValueError("Owner event is missing entry_id")
+        if not isinstance(owner_decision, str) or not owner_decision:
+            raise ValueError(f"Owner event for {entry_id} is missing owner_decision")
+        if entry_id in events:
+            raise ValueError(f"Duplicate owner decision event: {entry_id}")
+        decision_note = raw.get("decision_note")
+        event_actor = raw.get("event_actor")
+        event_recorded_at_utc = raw.get("event_recorded_at_utc")
+        if event_recorded_at_utc is not None and not isinstance(event_recorded_at_utc, str):
+            raise ValueError(f"Owner event for {entry_id} has invalid timestamp")
+        events[entry_id] = OwnerDecisionEventInput(
+            entry_id=entry_id,
+            owner_decision=owner_decision,
+            decision_note=(
+                decision_note if isinstance(decision_note, str) and decision_note else ""
+            ),
+            event_actor=(
+                event_actor if isinstance(event_actor, str) and event_actor else DEFAULT_EVENT_ACTOR
+            ),
+            event_recorded_at_utc=event_recorded_at_utc,
+        )
+    return events
+
+
+def build_event_rows(
+    entries: Sequence[LedgerEntryRow],
+    event_inputs: dict[str, OwnerDecisionEventInput],
+    *,
+    generated_at_utc: str,
+) -> tuple[OwnerDecisionEventRow, ...]:
+    known_entries = {entry.entry_id for entry in entries}
+    unknown_events = sorted(set(event_inputs) - known_entries)
+    if unknown_events:
+        raise ValueError(f"Owner event references unknown ledger entry: {unknown_events[0]}")
+
+    events: list[OwnerDecisionEventRow] = []
+    for rank, entry in enumerate(entries, start=1):
+        submitted = event_inputs.get(entry.entry_id)
+        if submitted is None:
+            capture_status = AWAITING_STATUS
+            owner_decision = PENDING_OWNER_DECISION
+            event_type = AWAITING_EVENT_TYPE
+            decision_note = DEFAULT_DECISION_NOTE
+            event_actor = DEFAULT_EVENT_ACTOR
+            event_recorded_at_utc = generated_at_utc
+        else:
+            owner_decision = submitted.owner_decision
+            if owner_decision not in entry.allowed_decisions:
+                raise ValueError(
+                    "Owner decision is not allowed for "
+                    f"{entry.entry_id}: {owner_decision}"
+                )
+            capture_status = CAPTURED_STATUS
+            event_type = CAPTURED_EVENT_TYPE
+            decision_note = (
+                submitted.decision_note or f"owner_decision_{owner_decision}"
+            )
+            event_actor = submitted.event_actor
+            event_recorded_at_utc = _format_utc(
+                submitted.event_recorded_at_utc or generated_at_utc
+            )
+
+        payload = {
+            "schema_version": "owner_decision_event_capture.v1",
+            "privacy_mode": "local_only_owner_decision_event_no_raw_text",
+            "source_ledger_rank": entry.ledger_rank,
+            "source_decision_status": entry.decision_status,
+            "capture_status": capture_status,
+            "owner_decision": owner_decision,
+            "event_type": event_type,
+            "event_source": DEFAULT_EVENT_SOURCE,
+            "event_actor": event_actor,
+            "event_recorded_at_utc": event_recorded_at_utc,
+            "decision_note": decision_note,
+            "allowed_decisions": list(entry.allowed_decisions),
+            "raw_text_included": False,
+            "send_whatsapp": False,
+            "crm_mutation": False,
+            "requires_human_approval": True,
+        }
+        event_id = f"owner-event-{rank:06d}"
+        event_hash = _hash_event(
+            {
+                **payload,
+                "event_id": event_id,
+                "entry_id": entry.entry_id,
+                "route_id": entry.route_id,
+                "case_card_id": entry.case_card_id,
+                "brief_id": entry.brief_id,
+                "pack_id": entry.pack_id,
+                "event_rank": rank,
+                "source_ledger_hash": entry.ledger_entry_hash,
+            }
+        )
+        events.append(
+            OwnerDecisionEventRow(
+                event_id=event_id,
+                entry_id=entry.entry_id,
+                route_id=entry.route_id,
+                case_card_id=entry.case_card_id,
+                brief_id=entry.brief_id,
+                pack_id=entry.pack_id,
+                event_rank=rank,
+                assigned_lane=entry.assigned_lane,
+                decision_type=entry.decision_type,
+                decision_priority=entry.decision_priority,
+                route_bucket=entry.route_bucket,
+                capture_status=capture_status,
+                owner_decision=owner_decision,
+                event_type=event_type,
+                event_source=DEFAULT_EVENT_SOURCE,
+                event_actor=event_actor,
+                event_recorded_at_utc=event_recorded_at_utc,
+                allowed_decisions=entry.allowed_decisions,
+                recommended_decision=entry.recommended_decision,
+                draft_action_type=entry.draft_action_type,
+                decision_note=decision_note,
+                source_ledger_hash=entry.ledger_entry_hash,
+                event_hash=event_hash,
+                event_payload=payload,
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(events)
+
+
+def write_owner_decision_events_sqlite(
+    output_db: Path,
+    *,
+    events: Sequence[OwnerDecisionEventRow],
+    source_case_count: int,
+    owner_item_count: int,
+    pack_count: int,
+    brief_count: int,
+    queue_item_count: int,
+    ledger_entry_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    output_db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(output_db) as conn:
+        conn.executescript(
+            """
+            DROP TABLE IF EXISTS owner_decision_event_capture_runs;
+            DROP TABLE IF EXISTS owner_decision_event_rows;
+
+            CREATE TABLE owner_decision_event_capture_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_case_count INTEGER NOT NULL,
+                owner_item_count INTEGER NOT NULL,
+                pack_count INTEGER NOT NULL,
+                brief_count INTEGER NOT NULL,
+                queue_item_count INTEGER NOT NULL,
+                ledger_entry_count INTEGER NOT NULL,
+                captured_event_count INTEGER NOT NULL,
+                awaiting_input_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE owner_decision_event_rows (
+                event_id TEXT PRIMARY KEY,
+                entry_id TEXT NOT NULL,
+                route_id TEXT NOT NULL,
+                case_card_id TEXT NOT NULL,
+                brief_id TEXT NOT NULL,
+                pack_id TEXT NOT NULL,
+                event_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                decision_priority TEXT NOT NULL,
+                route_bucket TEXT NOT NULL,
+                capture_status TEXT NOT NULL,
+                owner_decision TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                event_source TEXT NOT NULL,
+                event_actor TEXT NOT NULL,
+                event_recorded_at_utc TEXT NOT NULL,
+                allowed_decisions_json TEXT NOT NULL,
+                recommended_decision TEXT NOT NULL,
+                draft_action_type TEXT NOT NULL,
+                decision_note TEXT NOT NULL,
+                source_ledger_hash TEXT NOT NULL,
+                event_hash TEXT NOT NULL UNIQUE,
+                event_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE INDEX idx_owner_decision_event_rank
+                ON owner_decision_event_rows(event_rank);
+            CREATE INDEX idx_owner_decision_event_entry
+                ON owner_decision_event_rows(entry_id);
+            CREATE INDEX idx_owner_decision_event_status
+                ON owner_decision_event_rows(capture_status);
+            CREATE INDEX idx_owner_decision_event_decision
+                ON owner_decision_event_rows(owner_decision);
+            CREATE INDEX idx_owner_decision_event_type
+                ON owner_decision_event_rows(event_type);
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO owner_decision_event_capture_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_case_count, owner_item_count, pack_count, brief_count,
+                queue_item_count, ledger_entry_count, captured_event_count,
+                awaiting_input_count, send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0)
+            """,
+            (
+                generated_at_utc,
+                source_generated_at_utc,
+                "local_only_owner_decision_event_no_raw_text_no_send_no_crm_mutation",
+                source_case_count,
+                owner_item_count,
+                pack_count,
+                brief_count,
+                queue_item_count,
+                ledger_entry_count,
+                sum(1 for event in events if event.capture_status == CAPTURED_STATUS),
+                sum(1 for event in events if event.capture_status == AWAITING_STATUS),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO owner_decision_event_rows (
+                event_id, entry_id, route_id, case_card_id, brief_id, pack_id,
+                event_rank, assigned_lane, decision_type, decision_priority,
+                route_bucket, capture_status, owner_decision, event_type,
+                event_source, event_actor, event_recorded_at_utc,
+                allowed_decisions_json, recommended_decision, draft_action_type,
+                decision_note, source_ledger_hash, event_hash,
+                event_payload_json, send_whatsapp, crm_mutation,
+                requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    event.event_id,
+                    event.entry_id,
+                    event.route_id,
+                    event.case_card_id,
+                    event.brief_id,
+                    event.pack_id,
+                    event.event_rank,
+                    event.assigned_lane,
+                    event.decision_type,
+                    event.decision_priority,
+                    event.route_bucket,
+                    event.capture_status,
+                    event.owner_decision,
+                    event.event_type,
+                    event.event_source,
+                    event.event_actor,
+                    event.event_recorded_at_utc,
+                    json.dumps(list(event.allowed_decisions), ensure_ascii=False),
+                    event.recommended_decision,
+                    event.draft_action_type,
+                    event.decision_note,
+                    event.source_ledger_hash,
+                    event.event_hash,
+                    json.dumps(event.event_payload, ensure_ascii=False, sort_keys=True),
+                    int(event.send_whatsapp),
+                    int(event.crm_mutation),
+                    int(event.requires_human_approval),
+                )
+                for event in events
+            ],
+        )
+        conn.commit()
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'unknown'} | {count} |")
+    return lines
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    events: Sequence[OwnerDecisionEventRow],
+    source_case_count: int,
+    owner_item_count: int,
+    pack_count: int,
+    brief_count: int,
+    queue_item_count: int,
+    ledger_entry_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    capture_counts = Counter(event.capture_status for event in events)
+    owner_decision_counts = Counter(event.owner_decision for event in events)
+    event_type_counts = Counter(event.event_type for event in events)
+    decision_counts = Counter(event.decision_type for event in events)
+    lane_counts = Counter(event.assigned_lane for event in events)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Owner Decision Event Capture Summary",
+        "",
+        f"Generated UTC: `{generated_at_utc}`",
+        f"Source Approve/Reject Ledger UTC: `{source_generated_at_utc}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, case card IDs, judgment IDs, approval IDs, pack IDs, brief IDs, route IDs, ledger entry IDs, gap IDs, event IDs, inbox item IDs, or room item IDs.",
+        "- Owner decision event rows are local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Source cases | {source_case_count} |",
+        f"| Owner approval items | {owner_item_count} |",
+        f"| Owner decision packs | {pack_count} |",
+        f"| Owner briefs | {brief_count} |",
+        f"| Queue items | {queue_item_count} |",
+        f"| Ledger entries | {ledger_entry_count} |",
+        f"| Captured owner events | {capture_counts.get(CAPTURED_STATUS, 0)} |",
+        f"| Awaiting owner input | {capture_counts.get(AWAITING_STATUS, 0)} |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("Capture Status", capture_counts),
+        "",
+        *_counter_table("Owner Decisions", owner_decision_counts),
+        "",
+        *_counter_table("Event Types", event_type_counts),
+        "",
+        *_counter_table("Decision Types", decision_counts),
+        "",
+        *_counter_table("Assigned Lanes", lane_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- The Owner Decision Event Capture records explicit local owner events when provided.",
+        "- Missing owner events remain awaiting owner input and do not become approvals.",
+        "- Allowed owner decisions remain approve, reject, and defer.",
+        "- It does not parse raw WhatsApp messages.",
+        "- It does not call a cloud LLM.",
+        "- Runtime must not send WhatsApp messages from this artifact.",
+        "- Runtime must not mutate CRM records from this artifact.",
+        "- Human approval remains mandatory before any client-facing message or operational mutation.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_owner_decision_event_capture(
+    *,
+    ledger_db: Path = DEFAULT_LEDGER_DB,
+    owner_events_jsonl: Path | None = None,
+    output_dir: Path = DEFAULT_OWNER_DECISION_EVENT_DIR,
+    output_db: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+    generated_at_utc: str | None = None,
+) -> OwnerDecisionEventCaptureBuildResult:
+    """Capture local owner approve/reject/defer events without acting on them."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    generated = _format_utc(generated_at_utc)
+    (
+        source_generated,
+        source_case_count,
+        owner_item_count,
+        pack_count,
+        brief_count,
+        queue_item_count,
+        source_ledger_entry_count,
+    ) = read_source_metadata(ledger_db)
+    entries = read_ledger_entries(ledger_db)
+    owner_events = read_owner_event_inputs(owner_events_jsonl)
+    events = build_event_rows(entries, owner_events, generated_at_utc=generated)
+    source_case_total = source_case_count or len(entries)
+    owner_item_total = owner_item_count or len(entries)
+    pack_total = pack_count or len(entries)
+    brief_total = brief_count or len(entries)
+    queue_total = queue_item_count or len(entries)
+    ledger_total = source_ledger_entry_count or len(entries)
+    write_owner_decision_events_sqlite(
+        output_db,
+        events=events,
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        brief_count=brief_total,
+        queue_item_count=queue_total,
+        ledger_entry_count=ledger_total,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    write_summary(
+        summary_path=summary_path,
+        events=events,
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        brief_count=brief_total,
+        queue_item_count=queue_total,
+        ledger_entry_count=ledger_total,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    return OwnerDecisionEventCaptureBuildResult(
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        brief_count=brief_total,
+        queue_item_count=queue_total,
+        ledger_entry_count=ledger_total,
+        captured_event_count=sum(
+            1 for event in events if event.capture_status == CAPTURED_STATUS
+        ),
+        awaiting_input_count=sum(
+            1 for event in events if event.capture_status == AWAITING_STATUS
+        ),
+        send_whatsapp_count=sum(1 for event in events if event.send_whatsapp),
+        crm_mutation_count=sum(1 for event in events if event.crm_mutation),
+        capture_status_counts=dict(Counter(event.capture_status for event in events)),
+        owner_decision_counts=dict(Counter(event.owner_decision for event in events)),
+        event_type_counts=dict(Counter(event.event_type for event in events)),
+        output_db=output_db,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Capture local owner decision events from the approve/reject ledger."
+    )
+    parser.add_argument("--ledger-db", type=Path, default=DEFAULT_LEDGER_DB)
+    parser.add_argument("--owner-events-jsonl", type=Path, default=None)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OWNER_DECISION_EVENT_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--generated-at-utc", default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_owner_decision_event_capture(
+            ledger_db=args.ledger_db,
+            owner_events_jsonl=args.owner_events_jsonl,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            summary_path=args.summary,
+            generated_at_utc=args.generated_at_utc,
+        )
+    except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
+        print("ERROR: Owner decision event capture input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError):
+        print("ERROR: Owner decision event capture run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        print("ERROR: Owner decision event capture run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "awaiting_input_count": result.awaiting_input_count,
+                    "brief_count": result.brief_count,
+                    "captured_event_count": result.captured_event_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                    "ledger_entry_count": result.ledger_entry_count,
+                    "owner_item_count": result.owner_item_count,
+                    "pack_count": result.pack_count,
+                    "queue_item_count": result.queue_item_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "source_case_count": result.source_case_count,
+                },
+                sort_keys=True,
+            )
+        )
+    else:
+        print(
+            "Owner decision event capture complete: "
+            f"{result.ledger_entry_count} entries -> {result.output_db.name}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/whatsapp_corpus/build_owner_decision_inbox.py
+++ b/scripts/whatsapp_corpus/build_owner_decision_inbox.py
@@ -1,0 +1,604 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.whatsapp_corpus.build_owner_decision_intake import (
+    ReviewConsoleRow,
+    read_review_console_items,
+    read_source_metadata,
+)
+
+DEFAULT_OPERATOR_PACKET_REVIEW_CONSOLE_DIR = Path(
+    "research/personal/wa-corpus/operator-packet-review-console"
+)
+DEFAULT_OWNER_DECISION_INBOX_DIR = Path(
+    "research/personal/wa-corpus/owner-decision-inbox"
+)
+
+DEFAULT_REVIEW_CONSOLE_DB = (
+    DEFAULT_OPERATOR_PACKET_REVIEW_CONSOLE_DIR
+    / "operator_packet_review_console.local.sqlite"
+)
+DEFAULT_OUTPUT_DB = DEFAULT_OWNER_DECISION_INBOX_DIR / "owner_decision_inbox.local.sqlite"
+DEFAULT_OUTPUT_TEMPLATE = (
+    DEFAULT_OWNER_DECISION_INBOX_DIR / "owner_decisions_template.local.jsonl"
+)
+DEFAULT_SUMMARY = DEFAULT_OWNER_DECISION_INBOX_DIR / "owner_decision_inbox_summary.md"
+
+ALLOWED_OWNER_DECISIONS = ("approve", "reject", "defer")
+ACTIONABLE_REVIEW_STATES = frozenset(
+    {"waiting_owner_decision", "deferred_owner_revisit"}
+)
+DEFAULT_EVENT_ACTOR = "owner"
+
+
+@dataclass(frozen=True)
+class OwnerDecisionInboxItem:
+    owner_inbox_item_id: str
+    review_item_id: str
+    packet_id: str
+    work_order_id: str
+    event_id: str
+    entry_id: str
+    route_id: str
+    case_card_id: str
+    brief_id: str
+    pack_id: str
+    inbox_rank: int
+    source_review_rank: int
+    assigned_lane: str
+    operator_lane: str
+    decision_type: str
+    decision_priority: str
+    route_bucket: str
+    current_owner_decision: str
+    review_state: str
+    console_bucket: str
+    review_priority: str
+    visible_owner_action: str
+    console_instruction: str
+    review_gate: str
+    action_lock: str
+    owner_decision_status: str
+    template_status: str
+    allowed_decisions: tuple[str, ...]
+    owner_decision_input: str
+    decision_note_input: str
+    inbox_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+    def template_record(self) -> dict[str, object]:
+        return {
+            "allowed_decisions": list(self.allowed_decisions),
+            "assigned_lane": self.assigned_lane,
+            "console_bucket": self.console_bucket,
+            "decision_note": self.decision_note_input,
+            "decision_type": self.decision_type,
+            "entry_id": self.entry_id,
+            "event_actor": DEFAULT_EVENT_ACTOR,
+            "event_recorded_at_utc": "",
+            "owner_decision": self.owner_decision_input,
+            "packet_id": self.packet_id,
+            "review_item_id": self.review_item_id,
+            "review_state": self.review_state,
+        }
+
+
+@dataclass(frozen=True)
+class OwnerDecisionInboxBuildResult:
+    source_case_count: int
+    source_review_item_count: int
+    inbox_item_count: int
+    waiting_decision_count: int
+    revisit_decision_count: int
+    excluded_review_item_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    status_counts: dict[str, int]
+    lane_counts: dict[str, int]
+    output_db: Path
+    output_template: Path
+    summary_path: Path
+
+
+def _format_utc(value: str | None = None) -> str:
+    if value is not None:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).isoformat(timespec="seconds")
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _priority_sort_value(item: ReviewConsoleRow) -> int:
+    if item.review_state == "waiting_owner_decision":
+        return 0
+    if item.review_state == "deferred_owner_revisit":
+        return 1
+    return 9
+
+
+def _owner_decision_status(item: ReviewConsoleRow) -> str:
+    if item.review_state == "waiting_owner_decision":
+        return "needs_owner_decision"
+    if item.review_state == "deferred_owner_revisit":
+        return "needs_owner_revisit"
+    raise ValueError(f"Unsupported owner inbox review state: {item.review_state}")
+
+
+def _build_payload(item: ReviewConsoleRow, *, status: str) -> dict[str, object]:
+    return {
+        "schema_version": "owner_decision_inbox.v1",
+        "privacy_mode": "local_only_owner_decision_inbox_no_raw_text",
+        "source_review_rank": item.review_rank,
+        "source_packet_rank": item.source_packet_rank,
+        "decision_type": item.decision_type,
+        "decision_priority": item.decision_priority,
+        "route_bucket": item.route_bucket,
+        "review_state": item.review_state,
+        "console_bucket": item.console_bucket,
+        "visible_owner_action": item.visible_owner_action,
+        "owner_decision_status": status,
+        "allowed_decisions": list(ALLOWED_OWNER_DECISIONS),
+        "raw_text_included": False,
+        "send_whatsapp": False,
+        "crm_mutation": False,
+        "requires_human_approval": True,
+    }
+
+
+def build_inbox_items(
+    review_items: Sequence[ReviewConsoleRow],
+) -> tuple[OwnerDecisionInboxItem, ...]:
+    actionable = [
+        item for item in review_items if item.review_state in ACTIONABLE_REVIEW_STATES
+    ]
+    actionable.sort(
+        key=lambda item: (
+            _priority_sort_value(item),
+            item.review_rank,
+            item.assigned_lane,
+            item.review_item_id,
+        )
+    )
+
+    items: list[OwnerDecisionInboxItem] = []
+    for inbox_rank, item in enumerate(actionable, start=1):
+        if item.send_whatsapp or item.crm_mutation:
+            raise ValueError(f"Unsafe review item flags on {item.review_item_id}")
+        if not item.requires_human_approval:
+            raise ValueError(f"Review item missing human approval gate: {item.review_item_id}")
+        status = _owner_decision_status(item)
+        items.append(
+            OwnerDecisionInboxItem(
+                owner_inbox_item_id=f"owner-inbox-{item.review_item_id}",
+                review_item_id=item.review_item_id,
+                packet_id=item.packet_id,
+                work_order_id=item.work_order_id,
+                event_id=item.event_id,
+                entry_id=item.entry_id,
+                route_id=item.route_id,
+                case_card_id=item.case_card_id,
+                brief_id=item.brief_id,
+                pack_id=item.pack_id,
+                inbox_rank=inbox_rank,
+                source_review_rank=item.review_rank,
+                assigned_lane=item.assigned_lane,
+                operator_lane=item.operator_lane,
+                decision_type=item.decision_type,
+                decision_priority=item.decision_priority,
+                route_bucket=item.route_bucket,
+                current_owner_decision=item.owner_decision,
+                review_state=item.review_state,
+                console_bucket=item.console_bucket,
+                review_priority=item.review_priority,
+                visible_owner_action=item.visible_owner_action,
+                console_instruction=item.console_instruction,
+                review_gate=item.review_gate,
+                action_lock=item.action_lock,
+                owner_decision_status=status,
+                template_status="blank_owner_decision_required",
+                allowed_decisions=ALLOWED_OWNER_DECISIONS,
+                owner_decision_input="",
+                decision_note_input="",
+                inbox_payload=_build_payload(item, status=status),
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(items)
+
+
+def write_owner_decision_inbox_sqlite(
+    path: Path,
+    *,
+    items: Sequence[OwnerDecisionInboxItem],
+    source_case_count: int,
+    source_review_item_count: int,
+    excluded_review_item_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    status_counts = Counter(item.owner_decision_status for item in items)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        path.unlink()
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE owner_decision_inbox_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_case_count INTEGER NOT NULL,
+                source_review_item_count INTEGER NOT NULL,
+                inbox_item_count INTEGER NOT NULL,
+                waiting_decision_count INTEGER NOT NULL,
+                revisit_decision_count INTEGER NOT NULL,
+                excluded_review_item_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL CHECK (send_whatsapp_count = 0),
+                crm_mutation_count INTEGER NOT NULL CHECK (crm_mutation_count = 0)
+            );
+
+            CREATE TABLE owner_decision_inbox_items (
+                owner_inbox_item_id TEXT PRIMARY KEY,
+                review_item_id TEXT NOT NULL UNIQUE,
+                packet_id TEXT NOT NULL,
+                work_order_id TEXT NOT NULL,
+                event_id TEXT NOT NULL,
+                entry_id TEXT NOT NULL,
+                route_id TEXT NOT NULL,
+                case_card_id TEXT NOT NULL,
+                brief_id TEXT NOT NULL,
+                pack_id TEXT NOT NULL,
+                inbox_rank INTEGER NOT NULL,
+                source_review_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                operator_lane TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                decision_priority TEXT NOT NULL,
+                route_bucket TEXT NOT NULL,
+                current_owner_decision TEXT NOT NULL,
+                review_state TEXT NOT NULL,
+                console_bucket TEXT NOT NULL,
+                review_priority TEXT NOT NULL,
+                visible_owner_action TEXT NOT NULL,
+                console_instruction TEXT NOT NULL,
+                review_gate TEXT NOT NULL,
+                action_lock TEXT NOT NULL,
+                owner_decision_status TEXT NOT NULL,
+                template_status TEXT NOT NULL,
+                allowed_decisions_json TEXT NOT NULL,
+                owner_decision_input TEXT NOT NULL,
+                decision_note_input TEXT NOT NULL,
+                inbox_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE INDEX idx_owner_decision_inbox_rank
+                ON owner_decision_inbox_items(inbox_rank);
+            CREATE INDEX idx_owner_decision_inbox_lane
+                ON owner_decision_inbox_items(assigned_lane);
+            CREATE INDEX idx_owner_decision_inbox_status
+                ON owner_decision_inbox_items(owner_decision_status);
+            CREATE INDEX idx_owner_decision_inbox_review_state
+                ON owner_decision_inbox_items(review_state);
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO owner_decision_inbox_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_case_count, source_review_item_count, inbox_item_count,
+                waiting_decision_count, revisit_decision_count,
+                excluded_review_item_count, send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0)
+            """,
+            (
+                generated_at_utc,
+                source_generated_at_utc,
+                "local_only_owner_decision_inbox_no_raw_text_no_send_no_crm_mutation",
+                source_case_count,
+                source_review_item_count,
+                len(items),
+                status_counts.get("needs_owner_decision", 0),
+                status_counts.get("needs_owner_revisit", 0),
+                excluded_review_item_count,
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO owner_decision_inbox_items (
+                owner_inbox_item_id, review_item_id, packet_id, work_order_id,
+                event_id, entry_id, route_id, case_card_id, brief_id, pack_id,
+                inbox_rank, source_review_rank, assigned_lane, operator_lane,
+                decision_type, decision_priority, route_bucket,
+                current_owner_decision, review_state, console_bucket,
+                review_priority, visible_owner_action, console_instruction,
+                review_gate, action_lock, owner_decision_status,
+                template_status, allowed_decisions_json, owner_decision_input,
+                decision_note_input, inbox_payload_json, send_whatsapp,
+                crm_mutation, requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    item.owner_inbox_item_id,
+                    item.review_item_id,
+                    item.packet_id,
+                    item.work_order_id,
+                    item.event_id,
+                    item.entry_id,
+                    item.route_id,
+                    item.case_card_id,
+                    item.brief_id,
+                    item.pack_id,
+                    item.inbox_rank,
+                    item.source_review_rank,
+                    item.assigned_lane,
+                    item.operator_lane,
+                    item.decision_type,
+                    item.decision_priority,
+                    item.route_bucket,
+                    item.current_owner_decision,
+                    item.review_state,
+                    item.console_bucket,
+                    item.review_priority,
+                    item.visible_owner_action,
+                    item.console_instruction,
+                    item.review_gate,
+                    item.action_lock,
+                    item.owner_decision_status,
+                    item.template_status,
+                    json.dumps(list(item.allowed_decisions), sort_keys=True),
+                    item.owner_decision_input,
+                    item.decision_note_input,
+                    json.dumps(item.inbox_payload, ensure_ascii=False, sort_keys=True),
+                    int(item.send_whatsapp),
+                    int(item.crm_mutation),
+                    int(item.requires_human_approval),
+                )
+                for item in items
+            ],
+        )
+        conn.commit()
+
+
+def write_owner_decision_template_jsonl(
+    path: Path,
+    items: Sequence[OwnerDecisionInboxItem],
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(
+            json.dumps(item.template_record(), ensure_ascii=False, sort_keys=True) + "\n"
+            for item in items
+        ),
+        encoding="utf-8",
+    )
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'unknown'} | {count} |")
+    return lines
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    items: Sequence[OwnerDecisionInboxItem],
+    source_case_count: int,
+    source_review_item_count: int,
+    excluded_review_item_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    status_counts = Counter(item.owner_decision_status for item in items)
+    state_counts = Counter(item.review_state for item in items)
+    lane_counts = Counter(item.assigned_lane for item in items)
+    bucket_counts = Counter(item.console_bucket for item in items)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Owner Decision Inbox Summary",
+        "",
+        f"Generated UTC: `{generated_at_utc}`",
+        f"Source Review Console UTC: `{source_generated_at_utc}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, case card IDs, judgment IDs, approval IDs, pack IDs, brief IDs, route IDs, ledger entry IDs, event IDs, work order IDs, packet IDs, review item IDs, or inbox item IDs.",
+        "- Owner decision inbox artifacts are local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Source cases | {source_case_count} |",
+        f"| Source review items | {source_review_item_count} |",
+        f"| Owner inbox items | {len(items)} |",
+        f"| Waiting owner decision | {status_counts.get('needs_owner_decision', 0)} |",
+        f"| Owner revisit needed | {status_counts.get('needs_owner_revisit', 0)} |",
+        f"| Excluded review items | {excluded_review_item_count} |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("Owner Decision Status", status_counts),
+        "",
+        *_counter_table("Review States", state_counts),
+        "",
+        *_counter_table("Console Buckets", bucket_counts),
+        "",
+        *_counter_table("Assigned Lanes", lane_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- The Owner Decision Inbox selects only owner-actionable review items.",
+        "- The JSONL template starts with blank owner decisions and requires explicit approve, reject, or defer input.",
+        "- It does not invent owner decisions.",
+        "- It does not parse raw WhatsApp messages.",
+        "- It does not call a cloud LLM.",
+        "- Runtime must not send WhatsApp messages from this artifact.",
+        "- Runtime must not mutate CRM records from this artifact.",
+        "- Human approval remains mandatory before any client-facing message or operational mutation.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_owner_decision_inbox(
+    *,
+    review_console_db: Path = DEFAULT_REVIEW_CONSOLE_DB,
+    output_dir: Path = DEFAULT_OWNER_DECISION_INBOX_DIR,
+    output_db: Path | None = None,
+    output_template: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+    generated_at_utc: str | None = None,
+) -> OwnerDecisionInboxBuildResult:
+    """Build local-only owner decision inbox rows from the review console."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    output_template = output_template or output_dir / DEFAULT_OUTPUT_TEMPLATE.name
+    generated = _format_utc(generated_at_utc)
+    (
+        source_generated,
+        source_case_count,
+        _owner_item_count,
+        _pack_count,
+        _brief_count,
+        _queue_item_count,
+        _ledger_entry_count,
+        _event_row_count,
+        _work_order_count,
+        _packet_count,
+    ) = read_source_metadata(review_console_db)
+    review_items = read_review_console_items(review_console_db)
+    inbox_items = build_inbox_items(review_items)
+    source_case_total = source_case_count or len(review_items)
+    review_total = len(review_items)
+    excluded_count = review_total - len(inbox_items)
+
+    write_owner_decision_inbox_sqlite(
+        output_db,
+        items=inbox_items,
+        source_case_count=source_case_total,
+        source_review_item_count=review_total,
+        excluded_review_item_count=excluded_count,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    write_owner_decision_template_jsonl(output_template, inbox_items)
+    write_summary(
+        summary_path=summary_path,
+        items=inbox_items,
+        source_case_count=source_case_total,
+        source_review_item_count=review_total,
+        excluded_review_item_count=excluded_count,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    status_counts = Counter(item.owner_decision_status for item in inbox_items)
+    lane_counts = Counter(item.assigned_lane for item in inbox_items)
+    return OwnerDecisionInboxBuildResult(
+        source_case_count=source_case_total,
+        source_review_item_count=review_total,
+        inbox_item_count=len(inbox_items),
+        waiting_decision_count=status_counts.get("needs_owner_decision", 0),
+        revisit_decision_count=status_counts.get("needs_owner_revisit", 0),
+        excluded_review_item_count=excluded_count,
+        send_whatsapp_count=sum(1 for item in inbox_items if item.send_whatsapp),
+        crm_mutation_count=sum(1 for item in inbox_items if item.crm_mutation),
+        status_counts=dict(status_counts),
+        lane_counts=dict(lane_counts),
+        output_db=output_db,
+        output_template=output_template,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build a local-only Zantara Owner Decision Inbox from review-console rows."
+    )
+    parser.add_argument("--review-console-db", type=Path, default=DEFAULT_REVIEW_CONSOLE_DB)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OWNER_DECISION_INBOX_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--output-template", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--generated-at-utc", default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_owner_decision_inbox(
+            review_console_db=args.review_console_db,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            output_template=args.output_template,
+            summary_path=args.summary,
+            generated_at_utc=args.generated_at_utc,
+        )
+    except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
+        print("ERROR: Owner decision inbox input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError):
+        print("ERROR: Owner decision inbox run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        print("ERROR: Owner decision inbox run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "crm_mutation_count": result.crm_mutation_count,
+                    "excluded_review_item_count": result.excluded_review_item_count,
+                    "inbox_item_count": result.inbox_item_count,
+                    "revisit_decision_count": result.revisit_decision_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "source_case_count": result.source_case_count,
+                    "source_review_item_count": result.source_review_item_count,
+                    "waiting_decision_count": result.waiting_decision_count,
+                },
+                sort_keys=True,
+            )
+        )
+    else:
+        print(
+            "Owner decision inbox complete: "
+            f"{result.inbox_item_count} owner items -> {result.output_db.name}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/whatsapp_corpus/build_owner_decision_intake.py
+++ b/scripts/whatsapp_corpus/build_owner_decision_intake.py
@@ -1,0 +1,1046 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_OPERATOR_PACKET_REVIEW_CONSOLE_DIR = Path(
+    "research/personal/wa-corpus/operator-packet-review-console"
+)
+DEFAULT_OWNER_DECISION_INTAKE_DIR = Path(
+    "research/personal/wa-corpus/owner-decision-intake"
+)
+
+DEFAULT_REVIEW_CONSOLE_DB = (
+    DEFAULT_OPERATOR_PACKET_REVIEW_CONSOLE_DIR
+    / "operator_packet_review_console.local.sqlite"
+)
+DEFAULT_OUTPUT_DB = DEFAULT_OWNER_DECISION_INTAKE_DIR / "owner_decision_intake.local.sqlite"
+DEFAULT_OUTPUT_JSONL = DEFAULT_OWNER_DECISION_INTAKE_DIR / "owner_events.local.jsonl"
+DEFAULT_OUTPUT_TEMPLATE = (
+    DEFAULT_OWNER_DECISION_INTAKE_DIR / "owner_decisions_template.local.jsonl"
+)
+DEFAULT_SUMMARY = DEFAULT_OWNER_DECISION_INTAKE_DIR / "owner_decision_intake_summary.md"
+
+EXPECTED_REVIEW_CONSOLE_DB_NAME = "operator_packet_review_console.local.sqlite"
+ALLOWED_OWNER_DECISIONS = frozenset({"approve", "reject", "defer"})
+ACTIONABLE_REVIEW_STATES = frozenset(
+    {"waiting_owner_decision", "deferred_owner_revisit"}
+)
+DEFAULT_EVENT_ACTOR = "owner"
+CAPTURED_STATUS = "captured"
+
+
+@dataclass(frozen=True)
+class ReviewConsoleRow:
+    review_item_id: str
+    packet_id: str
+    work_order_id: str
+    event_id: str
+    entry_id: str
+    route_id: str
+    case_card_id: str
+    brief_id: str
+    pack_id: str
+    review_rank: int
+    source_packet_rank: int
+    assigned_lane: str
+    operator_lane: str
+    decision_type: str
+    decision_priority: str
+    route_bucket: str
+    owner_decision: str
+    packet_status: str
+    packet_type: str
+    packet_gate: str
+    packet_action: str
+    operator_instruction: str
+    escalation_target: str
+    review_state: str
+    console_bucket: str
+    review_priority: str
+    visible_owner_action: str
+    operator_action: str
+    console_instruction: str
+    review_gate: str
+    action_lock: str
+    decision_note: str
+    source_packet_hash: str
+    review_hash: str
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OwnerDecisionInput:
+    reference_key: str
+    owner_decision: str
+    decision_note: str
+    event_actor: str
+    event_recorded_at_utc: str | None
+
+
+@dataclass(frozen=True)
+class OwnerDecisionIntakeItem:
+    intake_item_id: str
+    review_item_id: str
+    packet_id: str
+    work_order_id: str
+    event_id: str
+    entry_id: str
+    route_id: str
+    case_card_id: str
+    brief_id: str
+    pack_id: str
+    intake_rank: int
+    source_review_rank: int
+    assigned_lane: str
+    operator_lane: str
+    decision_type: str
+    decision_priority: str
+    route_bucket: str
+    review_state: str
+    console_bucket: str
+    review_priority: str
+    visible_owner_action: str
+    operator_action: str
+    submitted_owner_decision: str
+    intake_status: str
+    replay_event_status: str
+    replay_event_type: str
+    event_actor: str
+    event_recorded_at_utc: str
+    decision_note: str
+    source_review_hash: str
+    intake_hash: str
+    intake_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+    def replay_jsonl_record(self) -> dict[str, str] | None:
+        if self.replay_event_status != "emitted_to_owner_events_jsonl":
+            return None
+        return {
+            "decision_note": self.decision_note,
+            "entry_id": self.entry_id,
+            "event_actor": self.event_actor,
+            "event_recorded_at_utc": self.event_recorded_at_utc,
+            "owner_decision": self.submitted_owner_decision,
+        }
+
+
+@dataclass(frozen=True)
+class OwnerDecisionIntakeBuildResult:
+    source_case_count: int
+    owner_item_count: int
+    pack_count: int
+    brief_count: int
+    queue_item_count: int
+    ledger_entry_count: int
+    event_row_count: int
+    work_order_count: int
+    packet_count: int
+    review_item_count: int
+    intake_item_count: int
+    captured_decision_count: int
+    awaiting_owner_decision_count: int
+    awaiting_owner_revisit_count: int
+    no_owner_action_required_count: int
+    closed_item_count: int
+    replay_event_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    intake_status_counts: dict[str, int]
+    replay_event_status_counts: dict[str, int]
+    output_db: Path
+    output_jsonl: Path
+    output_template: Path
+    summary_path: Path
+
+
+def _format_utc(value: str | None = None) -> str:
+    if value is not None:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).isoformat(timespec="seconds")
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _connect_ro(db_path: Path, *, expected_name: str, label: str) -> sqlite3.Connection:
+    if db_path.name != expected_name:
+        raise ValueError(f"Refusing to read unexpected {label}: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"{label} not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _read_jsonl(path: Path) -> tuple[dict[str, object], ...]:
+    rows: list[dict[str, object]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            decoded = json.loads(stripped)
+            if not isinstance(decoded, dict):
+                raise ValueError(f"Owner intake line {line_number} must be a JSON object")
+            rows.append(decoded)
+    return tuple(rows)
+
+
+def _hash_intake_item(payload: dict[str, object]) -> str:
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def read_source_metadata(db_path: Path) -> tuple[str, int, int, int, int, int, int, int, int, int]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_REVIEW_CONSOLE_DB_NAME,
+        label="Operator Packet Review Console DB",
+    ) as conn:
+        row = conn.execute(
+            """
+            SELECT generated_at_utc, source_case_count, owner_item_count,
+                   pack_count, brief_count, queue_item_count, ledger_entry_count,
+                   event_row_count, work_order_count, packet_count
+            FROM operator_packet_review_console_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+    if row is None:
+        return "unknown", 0, 0, 0, 0, 0, 0, 0, 0, 0
+    return (
+        str(row["generated_at_utc"]),
+        int(row["source_case_count"]),
+        int(row["owner_item_count"]),
+        int(row["pack_count"]),
+        int(row["brief_count"]),
+        int(row["queue_item_count"]),
+        int(row["ledger_entry_count"]),
+        int(row["event_row_count"]),
+        int(row["work_order_count"]),
+        int(row["packet_count"]),
+    )
+
+
+def read_review_console_items(db_path: Path) -> tuple[ReviewConsoleRow, ...]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_REVIEW_CONSOLE_DB_NAME,
+        label="Operator Packet Review Console DB",
+    ) as conn:
+        rows = conn.execute(
+            """
+            SELECT review_item_id, packet_id, work_order_id, event_id, entry_id,
+                   route_id, case_card_id, brief_id, pack_id, review_rank,
+                   source_packet_rank, assigned_lane, operator_lane, decision_type,
+                   decision_priority, route_bucket, owner_decision, packet_status,
+                   packet_type, packet_gate, packet_action, operator_instruction,
+                   escalation_target, review_state, console_bucket, review_priority,
+                   visible_owner_action, operator_action, console_instruction,
+                   review_gate, action_lock, decision_note, source_packet_hash,
+                   review_hash, send_whatsapp, crm_mutation, requires_human_approval
+            FROM operator_packet_review_items
+            ORDER BY review_rank, case_card_id
+            """
+        ).fetchall()
+    return tuple(
+        ReviewConsoleRow(
+            review_item_id=str(row["review_item_id"]),
+            packet_id=str(row["packet_id"]),
+            work_order_id=str(row["work_order_id"]),
+            event_id=str(row["event_id"]),
+            entry_id=str(row["entry_id"]),
+            route_id=str(row["route_id"]),
+            case_card_id=str(row["case_card_id"]),
+            brief_id=str(row["brief_id"]),
+            pack_id=str(row["pack_id"]),
+            review_rank=int(row["review_rank"]),
+            source_packet_rank=int(row["source_packet_rank"]),
+            assigned_lane=str(row["assigned_lane"]),
+            operator_lane=str(row["operator_lane"]),
+            decision_type=str(row["decision_type"]),
+            decision_priority=str(row["decision_priority"]),
+            route_bucket=str(row["route_bucket"]),
+            owner_decision=str(row["owner_decision"]),
+            packet_status=str(row["packet_status"]),
+            packet_type=str(row["packet_type"]),
+            packet_gate=str(row["packet_gate"]),
+            packet_action=str(row["packet_action"]),
+            operator_instruction=str(row["operator_instruction"]),
+            escalation_target=str(row["escalation_target"]),
+            review_state=str(row["review_state"]),
+            console_bucket=str(row["console_bucket"]),
+            review_priority=str(row["review_priority"]),
+            visible_owner_action=str(row["visible_owner_action"]),
+            operator_action=str(row["operator_action"]),
+            console_instruction=str(row["console_instruction"]),
+            review_gate=str(row["review_gate"]),
+            action_lock=str(row["action_lock"]),
+            decision_note=str(row["decision_note"]),
+            source_packet_hash=str(row["source_packet_hash"]),
+            review_hash=str(row["review_hash"]),
+            send_whatsapp=bool(row["send_whatsapp"]),
+            crm_mutation=bool(row["crm_mutation"]),
+            requires_human_approval=bool(row["requires_human_approval"]),
+        )
+        for row in rows
+    )
+
+
+def _extract_reference(raw: dict[str, object]) -> str:
+    reference_keys = [
+        key
+        for key in ("review_item_id", "packet_id", "entry_id")
+        if isinstance(raw.get(key), str) and raw.get(key)
+    ]
+    if len(reference_keys) != 1:
+        raise ValueError(
+            "Owner decision intake must reference exactly one of "
+            "review_item_id, packet_id, or entry_id"
+        )
+    return str(raw[reference_keys[0]])
+
+
+def read_owner_decision_inputs(
+    jsonl_path: Path | None,
+    rows: Sequence[ReviewConsoleRow],
+) -> dict[str, OwnerDecisionInput]:
+    if jsonl_path is None:
+        return {}
+
+    by_reference: dict[str, ReviewConsoleRow] = {}
+    for row in rows:
+        by_reference[row.review_item_id] = row
+        by_reference[row.packet_id] = row
+        by_reference[row.entry_id] = row
+
+    decisions: dict[str, OwnerDecisionInput] = {}
+    for raw in _read_jsonl(jsonl_path):
+        reference = _extract_reference(raw)
+        row = by_reference.get(reference)
+        if row is None:
+            raise ValueError(f"Owner decision intake references unknown item: {reference}")
+        if row.review_item_id in decisions:
+            raise ValueError(f"Duplicate owner decision intake: {row.review_item_id}")
+        if row.review_state not in ACTIONABLE_REVIEW_STATES:
+            raise ValueError(f"Review item is not owner-actionable: {row.review_item_id}")
+
+        owner_decision = raw.get("owner_decision")
+        if not isinstance(owner_decision, str) or not owner_decision:
+            raise ValueError(f"Owner decision is missing for {reference}")
+        if owner_decision not in ALLOWED_OWNER_DECISIONS:
+            raise ValueError(
+                f"Owner decision is not allowed for {row.review_item_id}: {owner_decision}"
+            )
+
+        decision_note = raw.get("decision_note")
+        event_actor = raw.get("event_actor")
+        event_recorded_at_utc = raw.get("event_recorded_at_utc")
+        if event_recorded_at_utc is not None and not isinstance(event_recorded_at_utc, str):
+            raise ValueError(f"Owner decision for {reference} has invalid timestamp")
+        decisions[row.review_item_id] = OwnerDecisionInput(
+            reference_key=reference,
+            owner_decision=owner_decision,
+            decision_note=(
+                decision_note if isinstance(decision_note, str) and decision_note else ""
+            ),
+            event_actor=(
+                event_actor if isinstance(event_actor, str) and event_actor else DEFAULT_EVENT_ACTOR
+            ),
+            event_recorded_at_utc=event_recorded_at_utc,
+        )
+    return decisions
+
+
+def _status_for_row(
+    row: ReviewConsoleRow,
+    submitted: OwnerDecisionInput | None,
+) -> tuple[str, str, str, str, str]:
+    if submitted is not None:
+        return (
+            submitted.owner_decision,
+            CAPTURED_STATUS,
+            "emitted_to_owner_events_jsonl",
+            "owner_decision_intake_captured",
+            submitted.decision_note or f"owner_decision_{submitted.owner_decision}",
+        )
+    if row.review_state == "waiting_owner_decision":
+        return (
+            row.owner_decision,
+            "awaiting_owner_decision",
+            "not_emitted",
+            "owner_decision_intake_pending",
+            "owner_decision_required",
+        )
+    if row.review_state == "deferred_owner_revisit":
+        return (
+            row.owner_decision,
+            "awaiting_owner_revisit",
+            "not_emitted",
+            "owner_revisit_required",
+            "owner_revisit_required",
+        )
+    if row.review_state == "ready_for_human_review":
+        return (
+            row.owner_decision,
+            "no_owner_action_required",
+            "not_emitted",
+            "owner_action_not_required",
+            row.decision_note,
+        )
+    if row.review_state == "rejected_closed":
+        return (
+            row.owner_decision,
+            "closed_no_owner_action",
+            "not_emitted",
+            "owner_action_closed",
+            row.decision_note,
+        )
+    raise ValueError(f"Unsupported review state for {row.review_item_id}: {row.review_state}")
+
+
+def build_intake_items(
+    rows: Sequence[ReviewConsoleRow],
+    owner_decisions: dict[str, OwnerDecisionInput],
+    *,
+    generated_at_utc: str,
+) -> tuple[OwnerDecisionIntakeItem, ...]:
+    items: list[OwnerDecisionIntakeItem] = []
+    for rank, row in enumerate(rows, start=1):
+        if row.send_whatsapp or row.crm_mutation:
+            raise ValueError(f"Unsafe review item flags on {row.review_item_id}")
+        if not row.requires_human_approval:
+            raise ValueError(f"Review item missing human approval gate: {row.review_item_id}")
+
+        submitted = owner_decisions.get(row.review_item_id)
+        (
+            submitted_owner_decision,
+            intake_status,
+            replay_event_status,
+            replay_event_type,
+            decision_note,
+        ) = _status_for_row(row, submitted)
+        event_actor = submitted.event_actor if submitted is not None else DEFAULT_EVENT_ACTOR
+        event_recorded_at_utc = _format_utc(
+            submitted.event_recorded_at_utc if submitted is not None else generated_at_utc
+        )
+        payload = {
+            "schema_version": "owner_decision_intake.v1",
+            "privacy_mode": "local_only_owner_decision_intake_no_raw_text",
+            "source_review_rank": row.review_rank,
+            "review_state": row.review_state,
+            "console_bucket": row.console_bucket,
+            "visible_owner_action": row.visible_owner_action,
+            "submitted_owner_decision": submitted_owner_decision,
+            "intake_status": intake_status,
+            "replay_event_status": replay_event_status,
+            "replay_event_type": replay_event_type,
+            "event_actor": event_actor,
+            "event_recorded_at_utc": event_recorded_at_utc,
+            "raw_text_included": False,
+            "send_whatsapp": False,
+            "crm_mutation": False,
+            "requires_human_approval": True,
+        }
+        intake_item_id = f"owner-decision-intake-item-{rank:06d}"
+        intake_hash = _hash_intake_item(
+            {
+                **payload,
+                "intake_item_id": intake_item_id,
+                "review_item_id": row.review_item_id,
+                "packet_id": row.packet_id,
+                "work_order_id": row.work_order_id,
+                "event_id": row.event_id,
+                "entry_id": row.entry_id,
+                "route_id": row.route_id,
+                "case_card_id": row.case_card_id,
+                "brief_id": row.brief_id,
+                "pack_id": row.pack_id,
+                "intake_rank": rank,
+                "source_review_hash": row.review_hash,
+            }
+        )
+        items.append(
+            OwnerDecisionIntakeItem(
+                intake_item_id=intake_item_id,
+                review_item_id=row.review_item_id,
+                packet_id=row.packet_id,
+                work_order_id=row.work_order_id,
+                event_id=row.event_id,
+                entry_id=row.entry_id,
+                route_id=row.route_id,
+                case_card_id=row.case_card_id,
+                brief_id=row.brief_id,
+                pack_id=row.pack_id,
+                intake_rank=rank,
+                source_review_rank=row.review_rank,
+                assigned_lane=row.assigned_lane,
+                operator_lane=row.operator_lane,
+                decision_type=row.decision_type,
+                decision_priority=row.decision_priority,
+                route_bucket=row.route_bucket,
+                review_state=row.review_state,
+                console_bucket=row.console_bucket,
+                review_priority=row.review_priority,
+                visible_owner_action=row.visible_owner_action,
+                operator_action=row.operator_action,
+                submitted_owner_decision=submitted_owner_decision,
+                intake_status=intake_status,
+                replay_event_status=replay_event_status,
+                replay_event_type=replay_event_type,
+                event_actor=event_actor,
+                event_recorded_at_utc=event_recorded_at_utc,
+                decision_note=decision_note,
+                source_review_hash=row.review_hash,
+                intake_hash=intake_hash,
+                intake_payload=payload,
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(items)
+
+
+def write_owner_decision_intake_sqlite(
+    output_db: Path,
+    *,
+    items: Sequence[OwnerDecisionIntakeItem],
+    source_case_count: int,
+    owner_item_count: int,
+    pack_count: int,
+    brief_count: int,
+    queue_item_count: int,
+    ledger_entry_count: int,
+    event_row_count: int,
+    work_order_count: int,
+    packet_count: int,
+    review_item_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    output_db.parent.mkdir(parents=True, exist_ok=True)
+    status_counts = Counter(item.intake_status for item in items)
+    replay_counts = Counter(item.replay_event_status for item in items)
+    with sqlite3.connect(output_db) as conn:
+        conn.executescript(
+            """
+            DROP TABLE IF EXISTS owner_decision_intake_runs;
+            DROP TABLE IF EXISTS owner_decision_intake_items;
+
+            CREATE TABLE owner_decision_intake_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_case_count INTEGER NOT NULL,
+                owner_item_count INTEGER NOT NULL,
+                pack_count INTEGER NOT NULL,
+                brief_count INTEGER NOT NULL,
+                queue_item_count INTEGER NOT NULL,
+                ledger_entry_count INTEGER NOT NULL,
+                event_row_count INTEGER NOT NULL,
+                work_order_count INTEGER NOT NULL,
+                packet_count INTEGER NOT NULL,
+                review_item_count INTEGER NOT NULL,
+                intake_item_count INTEGER NOT NULL,
+                captured_decision_count INTEGER NOT NULL,
+                awaiting_owner_decision_count INTEGER NOT NULL,
+                awaiting_owner_revisit_count INTEGER NOT NULL,
+                no_owner_action_required_count INTEGER NOT NULL,
+                closed_item_count INTEGER NOT NULL,
+                replay_event_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE owner_decision_intake_items (
+                intake_item_id TEXT PRIMARY KEY,
+                review_item_id TEXT NOT NULL,
+                packet_id TEXT NOT NULL,
+                work_order_id TEXT NOT NULL,
+                event_id TEXT NOT NULL,
+                entry_id TEXT NOT NULL,
+                route_id TEXT NOT NULL,
+                case_card_id TEXT NOT NULL,
+                brief_id TEXT NOT NULL,
+                pack_id TEXT NOT NULL,
+                intake_rank INTEGER NOT NULL,
+                source_review_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                operator_lane TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                decision_priority TEXT NOT NULL,
+                route_bucket TEXT NOT NULL,
+                review_state TEXT NOT NULL,
+                console_bucket TEXT NOT NULL,
+                review_priority TEXT NOT NULL,
+                visible_owner_action TEXT NOT NULL,
+                operator_action TEXT NOT NULL,
+                submitted_owner_decision TEXT NOT NULL,
+                intake_status TEXT NOT NULL,
+                replay_event_status TEXT NOT NULL,
+                replay_event_type TEXT NOT NULL,
+                event_actor TEXT NOT NULL,
+                event_recorded_at_utc TEXT NOT NULL,
+                decision_note TEXT NOT NULL,
+                source_review_hash TEXT NOT NULL,
+                intake_hash TEXT NOT NULL UNIQUE,
+                intake_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE INDEX idx_owner_decision_intake_rank
+                ON owner_decision_intake_items(intake_rank);
+            CREATE INDEX idx_owner_decision_intake_review
+                ON owner_decision_intake_items(review_item_id);
+            CREATE INDEX idx_owner_decision_intake_packet
+                ON owner_decision_intake_items(packet_id);
+            CREATE INDEX idx_owner_decision_intake_entry
+                ON owner_decision_intake_items(entry_id);
+            CREATE INDEX idx_owner_decision_intake_status
+                ON owner_decision_intake_items(intake_status);
+            CREATE INDEX idx_owner_decision_intake_replay
+                ON owner_decision_intake_items(replay_event_status);
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO owner_decision_intake_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_case_count, owner_item_count, pack_count, brief_count,
+                queue_item_count, ledger_entry_count, event_row_count,
+                work_order_count, packet_count, review_item_count,
+                intake_item_count, captured_decision_count,
+                awaiting_owner_decision_count, awaiting_owner_revisit_count,
+                no_owner_action_required_count, closed_item_count,
+                replay_event_count, send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0)
+            """,
+            (
+                generated_at_utc,
+                source_generated_at_utc,
+                "local_only_owner_decision_intake_no_raw_text_no_send_no_crm_mutation",
+                source_case_count,
+                owner_item_count,
+                pack_count,
+                brief_count,
+                queue_item_count,
+                ledger_entry_count,
+                event_row_count,
+                work_order_count,
+                packet_count,
+                review_item_count,
+                len(items),
+                status_counts.get(CAPTURED_STATUS, 0),
+                status_counts.get("awaiting_owner_decision", 0),
+                status_counts.get("awaiting_owner_revisit", 0),
+                status_counts.get("no_owner_action_required", 0),
+                status_counts.get("closed_no_owner_action", 0),
+                replay_counts.get("emitted_to_owner_events_jsonl", 0),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO owner_decision_intake_items (
+                intake_item_id, review_item_id, packet_id, work_order_id,
+                event_id, entry_id, route_id, case_card_id, brief_id, pack_id,
+                intake_rank, source_review_rank, assigned_lane, operator_lane,
+                decision_type, decision_priority, route_bucket, review_state,
+                console_bucket, review_priority, visible_owner_action,
+                operator_action, submitted_owner_decision, intake_status,
+                replay_event_status, replay_event_type, event_actor,
+                event_recorded_at_utc, decision_note, source_review_hash,
+                intake_hash, intake_payload_json, send_whatsapp, crm_mutation,
+                requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    item.intake_item_id,
+                    item.review_item_id,
+                    item.packet_id,
+                    item.work_order_id,
+                    item.event_id,
+                    item.entry_id,
+                    item.route_id,
+                    item.case_card_id,
+                    item.brief_id,
+                    item.pack_id,
+                    item.intake_rank,
+                    item.source_review_rank,
+                    item.assigned_lane,
+                    item.operator_lane,
+                    item.decision_type,
+                    item.decision_priority,
+                    item.route_bucket,
+                    item.review_state,
+                    item.console_bucket,
+                    item.review_priority,
+                    item.visible_owner_action,
+                    item.operator_action,
+                    item.submitted_owner_decision,
+                    item.intake_status,
+                    item.replay_event_status,
+                    item.replay_event_type,
+                    item.event_actor,
+                    item.event_recorded_at_utc,
+                    item.decision_note,
+                    item.source_review_hash,
+                    item.intake_hash,
+                    json.dumps(item.intake_payload, ensure_ascii=False, sort_keys=True),
+                    int(item.send_whatsapp),
+                    int(item.crm_mutation),
+                    int(item.requires_human_approval),
+                )
+                for item in items
+            ],
+        )
+        conn.commit()
+
+
+def write_replay_jsonl(path: Path, items: Sequence[OwnerDecisionIntakeItem]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    records = [
+        record
+        for item in items
+        if (record := item.replay_jsonl_record()) is not None
+    ]
+    path.write_text(
+        "".join(
+            json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n"
+            for record in records
+        ),
+        encoding="utf-8",
+    )
+
+
+def write_owner_decision_template_jsonl(
+    path: Path,
+    items: Sequence[OwnerDecisionIntakeItem],
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    actionable_statuses = {"awaiting_owner_decision", "awaiting_owner_revisit"}
+    records = [
+        {
+            "allowed_decisions": ["approve", "reject", "defer"],
+            "assigned_lane": item.assigned_lane,
+            "console_bucket": item.console_bucket,
+            "decision_note": "",
+            "decision_type": item.decision_type,
+            "entry_id": item.entry_id,
+            "event_actor": DEFAULT_EVENT_ACTOR,
+            "event_recorded_at_utc": item.event_recorded_at_utc,
+            "owner_decision": "",
+            "packet_id": item.packet_id,
+            "review_item_id": item.review_item_id,
+            "review_state": item.review_state,
+        }
+        for item in items
+        if item.intake_status in actionable_statuses
+    ]
+    path.write_text(
+        "".join(
+            json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n"
+            for record in records
+        ),
+        encoding="utf-8",
+    )
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'unknown'} | {count} |")
+    return lines
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    items: Sequence[OwnerDecisionIntakeItem],
+    source_case_count: int,
+    owner_item_count: int,
+    pack_count: int,
+    brief_count: int,
+    queue_item_count: int,
+    ledger_entry_count: int,
+    event_row_count: int,
+    work_order_count: int,
+    packet_count: int,
+    review_item_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    status_counts = Counter(item.intake_status for item in items)
+    replay_counts = Counter(item.replay_event_status for item in items)
+    decision_counts = Counter(item.submitted_owner_decision for item in items)
+    state_counts = Counter(item.review_state for item in items)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Owner Decision Intake Summary",
+        "",
+        f"Generated UTC: `{generated_at_utc}`",
+        f"Source Operator Packet Review Console UTC: `{source_generated_at_utc}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, case card IDs, judgment IDs, approval IDs, pack IDs, brief IDs, route IDs, ledger entry IDs, event IDs, work order IDs, packet IDs, review item IDs, intake item IDs, inbox item IDs, or room item IDs.",
+        "- Owner decision intake artifacts are local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Source cases | {source_case_count} |",
+        f"| Owner approval items | {owner_item_count} |",
+        f"| Owner decision packs | {pack_count} |",
+        f"| Owner briefs | {brief_count} |",
+        f"| Queue items | {queue_item_count} |",
+        f"| Ledger entries | {ledger_entry_count} |",
+        f"| Event rows | {event_row_count} |",
+        f"| Work orders | {work_order_count} |",
+        f"| Operator packets | {packet_count} |",
+        f"| Review items | {review_item_count} |",
+        f"| Intake items | {len(items)} |",
+        f"| Captured decisions | {status_counts.get(CAPTURED_STATUS, 0)} |",
+        f"| Awaiting owner decision | {status_counts.get('awaiting_owner_decision', 0)} |",
+        f"| Awaiting owner revisit | {status_counts.get('awaiting_owner_revisit', 0)} |",
+        f"| No owner action required | {status_counts.get('no_owner_action_required', 0)} |",
+        f"| Closed items | {status_counts.get('closed_no_owner_action', 0)} |",
+        f"| Replay events | {replay_counts.get('emitted_to_owner_events_jsonl', 0)} |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("Intake Status", status_counts),
+        "",
+        *_counter_table("Replay Event Status", replay_counts),
+        "",
+        *_counter_table("Submitted Owner Decisions", decision_counts),
+        "",
+        *_counter_table("Source Review States", state_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- The Owner Decision Intake accepts only explicit owner approve, reject, or defer records.",
+        "- Missing owner decisions remain awaiting owner input or owner revisit.",
+        "- Captured decisions are exported to `owner_events.local.jsonl` for deterministic replay through Owner Decision Event Capture.",
+        "- Operator-ready and closed items cannot be changed through this intake.",
+        "- It does not parse raw WhatsApp messages.",
+        "- It does not call a cloud LLM.",
+        "- Runtime must not send WhatsApp messages from this artifact.",
+        "- Runtime must not mutate CRM records from this artifact.",
+        "- Human approval remains mandatory before any client-facing message or operational mutation.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_owner_decision_intake(
+    *,
+    review_console_db: Path = DEFAULT_REVIEW_CONSOLE_DB,
+    owner_decisions_jsonl: Path | None = None,
+    output_dir: Path = DEFAULT_OWNER_DECISION_INTAKE_DIR,
+    output_db: Path | None = None,
+    output_jsonl: Path | None = None,
+    output_template: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+    generated_at_utc: str | None = None,
+) -> OwnerDecisionIntakeBuildResult:
+    """Build local owner decision intake rows and replay JSONL from review items."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    output_jsonl = output_jsonl or output_dir / DEFAULT_OUTPUT_JSONL.name
+    output_template = output_template or output_dir / DEFAULT_OUTPUT_TEMPLATE.name
+    generated = _format_utc(generated_at_utc)
+    (
+        source_generated,
+        source_case_count,
+        owner_item_count,
+        pack_count,
+        brief_count,
+        queue_item_count,
+        ledger_entry_count,
+        event_row_count,
+        work_order_count,
+        source_packet_count,
+    ) = read_source_metadata(review_console_db)
+    review_items = read_review_console_items(review_console_db)
+    owner_decisions = read_owner_decision_inputs(owner_decisions_jsonl, review_items)
+    intake_items = build_intake_items(
+        review_items,
+        owner_decisions,
+        generated_at_utc=generated,
+    )
+    source_case_total = source_case_count or len(intake_items)
+    owner_item_total = owner_item_count or len(intake_items)
+    pack_total = pack_count or len(intake_items)
+    brief_total = brief_count or len(intake_items)
+    queue_total = queue_item_count or len(intake_items)
+    ledger_total = ledger_entry_count or len(intake_items)
+    event_total = event_row_count or len(intake_items)
+    work_order_total = work_order_count or len(intake_items)
+    packet_total = source_packet_count or len(intake_items)
+    review_total = len(review_items)
+
+    write_owner_decision_intake_sqlite(
+        output_db,
+        items=intake_items,
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        brief_count=brief_total,
+        queue_item_count=queue_total,
+        ledger_entry_count=ledger_total,
+        event_row_count=event_total,
+        work_order_count=work_order_total,
+        packet_count=packet_total,
+        review_item_count=review_total,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    write_replay_jsonl(output_jsonl, intake_items)
+    write_owner_decision_template_jsonl(output_template, intake_items)
+    write_summary(
+        summary_path=summary_path,
+        items=intake_items,
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        brief_count=brief_total,
+        queue_item_count=queue_total,
+        ledger_entry_count=ledger_total,
+        event_row_count=event_total,
+        work_order_count=work_order_total,
+        packet_count=packet_total,
+        review_item_count=review_total,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    status_counts = Counter(item.intake_status for item in intake_items)
+    replay_counts = Counter(item.replay_event_status for item in intake_items)
+    return OwnerDecisionIntakeBuildResult(
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        brief_count=brief_total,
+        queue_item_count=queue_total,
+        ledger_entry_count=ledger_total,
+        event_row_count=event_total,
+        work_order_count=work_order_total,
+        packet_count=packet_total,
+        review_item_count=review_total,
+        intake_item_count=len(intake_items),
+        captured_decision_count=status_counts.get(CAPTURED_STATUS, 0),
+        awaiting_owner_decision_count=status_counts.get("awaiting_owner_decision", 0),
+        awaiting_owner_revisit_count=status_counts.get("awaiting_owner_revisit", 0),
+        no_owner_action_required_count=status_counts.get("no_owner_action_required", 0),
+        closed_item_count=status_counts.get("closed_no_owner_action", 0),
+        replay_event_count=replay_counts.get("emitted_to_owner_events_jsonl", 0),
+        send_whatsapp_count=sum(1 for item in intake_items if item.send_whatsapp),
+        crm_mutation_count=sum(1 for item in intake_items if item.crm_mutation),
+        intake_status_counts=dict(status_counts),
+        replay_event_status_counts=dict(replay_counts),
+        output_db=output_db,
+        output_jsonl=output_jsonl,
+        output_template=output_template,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build local owner decision intake rows from the operator packet review console."
+    )
+    parser.add_argument("--review-console-db", type=Path, default=DEFAULT_REVIEW_CONSOLE_DB)
+    parser.add_argument("--owner-decisions-jsonl", type=Path, default=None)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OWNER_DECISION_INTAKE_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--output-jsonl", type=Path, default=None)
+    parser.add_argument("--output-template", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--generated-at-utc", default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_owner_decision_intake(
+            review_console_db=args.review_console_db,
+            owner_decisions_jsonl=args.owner_decisions_jsonl,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            output_jsonl=args.output_jsonl,
+            output_template=args.output_template,
+            summary_path=args.summary,
+            generated_at_utc=args.generated_at_utc,
+        )
+    except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
+        print("ERROR: Owner decision intake input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError):
+        print("ERROR: Owner decision intake run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        print("ERROR: Owner decision intake run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "awaiting_owner_decision_count": result.awaiting_owner_decision_count,
+                    "awaiting_owner_revisit_count": result.awaiting_owner_revisit_count,
+                    "captured_decision_count": result.captured_decision_count,
+                    "closed_item_count": result.closed_item_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                    "intake_item_count": result.intake_item_count,
+                    "no_owner_action_required_count": result.no_owner_action_required_count,
+                    "packet_count": result.packet_count,
+                    "replay_event_count": result.replay_event_count,
+                    "review_item_count": result.review_item_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "source_case_count": result.source_case_count,
+                },
+                sort_keys=True,
+            )
+        )
+    else:
+        print(
+            "Owner decision intake complete: "
+            f"{result.intake_item_count} items -> {result.output_db.name}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/whatsapp_corpus/build_owner_decision_packs.py
+++ b/scripts/whatsapp_corpus/build_owner_decision_packs.py
@@ -1,0 +1,561 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_OWNER_APPROVAL_DIR = Path("research/personal/wa-corpus/owner-approval-console")
+DEFAULT_OWNER_DECISION_PACK_DIR = Path("research/personal/wa-corpus/owner-decision-packs")
+
+DEFAULT_OWNER_APPROVAL_DB = DEFAULT_OWNER_APPROVAL_DIR / "owner_approval_console.local.sqlite"
+DEFAULT_OUTPUT_DB = DEFAULT_OWNER_DECISION_PACK_DIR / "owner_decision_packs.local.sqlite"
+DEFAULT_SUMMARY = DEFAULT_OWNER_DECISION_PACK_DIR / "owner_decision_packs_summary.md"
+
+EXPECTED_OWNER_APPROVAL_DB_NAME = "owner_approval_console.local.sqlite"
+
+
+@dataclass(frozen=True)
+class OwnerApprovalRow:
+    approval_id: str
+    case_card_id: str
+    approval_rank: int
+    assigned_lane: str
+    primary_action: str
+    closure_status: str
+    decision_type: str
+    decision_priority: str
+    owner_prompt_code: str
+    recommended_owner_action: str
+    approval_status: str
+    top_gap_code: str
+    top_gap_category: str
+    top_gap_severity: str
+    resolution_gate: str
+    owner_decision_required: bool
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OwnerDecisionPack:
+    pack_id: str
+    case_card_id: str
+    pack_rank: int
+    assigned_lane: str
+    decision_type: str
+    decision_priority: str
+    owner_prompt_code: str
+    pack_title: str
+    risk_brief: str
+    recommended_decision: str
+    draft_action_type: str
+    draft_action_status: str
+    approval_status: str
+    top_gap_code: str
+    top_gap_category: str
+    top_gap_severity: str
+    resolution_gate: str
+    owner_decision_required: bool
+    pack_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OwnerDecisionPacksBuildResult:
+    source_case_count: int
+    owner_item_count: int
+    pack_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    decision_type_counts: dict[str, int]
+    lane_counts: dict[str, int]
+    output_db: Path
+    summary_path: Path
+
+
+def _format_utc(value: str | None = None) -> str:
+    if value is not None:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).isoformat(timespec="seconds")
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _connect_ro(db_path: Path, *, expected_name: str, label: str) -> sqlite3.Connection:
+    if db_path.name != expected_name:
+        raise ValueError(f"Refusing to read unexpected {label} DB: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"{label} DB not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def read_source_metadata(db_path: Path) -> tuple[str, int, int]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_OWNER_APPROVAL_DB_NAME,
+        label="Owner Approval Console",
+    ) as conn:
+        row = conn.execute(
+            """
+            SELECT generated_at_utc, source_case_count, owner_item_count
+            FROM owner_approval_console_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+    if row is None:
+        return "unknown", 0, 0
+    return (
+        str(row["generated_at_utc"]),
+        int(row["source_case_count"]),
+        int(row["owner_item_count"]),
+    )
+
+
+def read_owner_approval_rows(db_path: Path) -> tuple[OwnerApprovalRow, ...]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_OWNER_APPROVAL_DB_NAME,
+        label="Owner Approval Console",
+    ) as conn:
+        rows = conn.execute(
+            """
+            SELECT approval_id, case_card_id, approval_rank, assigned_lane,
+                   primary_action, closure_status, decision_type,
+                   decision_priority, owner_prompt_code,
+                   recommended_owner_action, approval_status, top_gap_code,
+                   top_gap_category, top_gap_severity, resolution_gate,
+                   owner_decision_required, send_whatsapp, crm_mutation,
+                   requires_human_approval
+            FROM owner_approval_items
+            ORDER BY approval_rank, case_card_id
+            """
+        ).fetchall()
+    return tuple(
+        OwnerApprovalRow(
+            approval_id=str(row["approval_id"]),
+            case_card_id=str(row["case_card_id"]),
+            approval_rank=int(row["approval_rank"]),
+            assigned_lane=str(row["assigned_lane"]),
+            primary_action=str(row["primary_action"]),
+            closure_status=str(row["closure_status"]),
+            decision_type=str(row["decision_type"]),
+            decision_priority=str(row["decision_priority"]),
+            owner_prompt_code=str(row["owner_prompt_code"]),
+            recommended_owner_action=str(row["recommended_owner_action"]),
+            approval_status=str(row["approval_status"]),
+            top_gap_code=str(row["top_gap_code"]),
+            top_gap_category=str(row["top_gap_category"]),
+            top_gap_severity=str(row["top_gap_severity"]),
+            resolution_gate=str(row["resolution_gate"]),
+            owner_decision_required=bool(row["owner_decision_required"]),
+            send_whatsapp=bool(row["send_whatsapp"]),
+            crm_mutation=bool(row["crm_mutation"]),
+            requires_human_approval=bool(row["requires_human_approval"]),
+        )
+        for row in rows
+    )
+
+
+def _pack_title(decision_type: str) -> str:
+    return {
+        "approve_client_recovery_followup": "Client recovery follow-up approval",
+        "approve_immigration_status_escalation": "Immigration status escalation approval",
+        "approve_document_evidence_request": "Document evidence request approval",
+        "approve_payment_reconciliation_review": "Payment reconciliation review approval",
+    }.get(decision_type, "Owner case review approval")
+
+
+def _risk_brief(row: OwnerApprovalRow) -> str:
+    if row.decision_type == "approve_client_recovery_followup":
+        return "Urgent client response gap requires owner-approved recovery follow-up."
+    if row.decision_type == "approve_immigration_status_escalation":
+        return "Urgent immigration status gap requires owner-approved escalation."
+    if row.decision_type == "approve_document_evidence_request":
+        return "Document evidence gap requires owner-approved evidence request."
+    if row.decision_type == "approve_payment_reconciliation_review":
+        return "Finance evidence gap requires owner-approved reconciliation review."
+    return "Case gap requires owner-approved operational review."
+
+
+def _recommended_decision(decision_type: str) -> str:
+    return {
+        "approve_client_recovery_followup": "approve_recovery_followup_after_review",
+        "approve_immigration_status_escalation": "approve_status_escalation_after_review",
+        "approve_document_evidence_request": "approve_document_request_after_review",
+        "approve_payment_reconciliation_review": "approve_payment_review_after_review",
+    }.get(decision_type, "approve_case_review_after_review")
+
+
+def _draft_action_type(decision_type: str) -> str:
+    return {
+        "approve_client_recovery_followup": "owner_review_client_followup_draft",
+        "approve_immigration_status_escalation": "owner_review_status_escalation_draft",
+        "approve_document_evidence_request": "owner_review_document_request_draft",
+        "approve_payment_reconciliation_review": "owner_review_payment_reconciliation_draft",
+    }.get(decision_type, "owner_review_case_draft")
+
+
+def build_packs(rows: Sequence[OwnerApprovalRow]) -> tuple[OwnerDecisionPack, ...]:
+    packs: list[OwnerDecisionPack] = []
+    for rank, row in enumerate(rows, start=1):
+        payload = {
+            "schema_version": "owner_decision_packs.v1",
+            "privacy_mode": "local_only_owner_decision_pack_no_raw_text",
+            "source_approval_rank": row.approval_rank,
+            "source_approval_status": row.approval_status,
+            "source_closure_status": row.closure_status,
+            "source_owner_prompt_code": row.owner_prompt_code,
+            "decision_type": row.decision_type,
+            "decision_priority": row.decision_priority,
+            "recommended_owner_action": row.recommended_owner_action,
+            "recommended_decision": _recommended_decision(row.decision_type),
+            "draft_action_type": _draft_action_type(row.decision_type),
+            "draft_action_status": "draft_ready_for_owner_review",
+            "owner_decision_required": True,
+            "raw_text_included": False,
+            "send_whatsapp": False,
+            "crm_mutation": False,
+            "requires_human_approval": True,
+        }
+        packs.append(
+            OwnerDecisionPack(
+                pack_id=f"owner-pack-{rank:06d}",
+                case_card_id=row.case_card_id,
+                pack_rank=rank,
+                assigned_lane=row.assigned_lane,
+                decision_type=row.decision_type,
+                decision_priority=row.decision_priority,
+                owner_prompt_code=row.owner_prompt_code,
+                pack_title=_pack_title(row.decision_type),
+                risk_brief=_risk_brief(row),
+                recommended_decision=_recommended_decision(row.decision_type),
+                draft_action_type=_draft_action_type(row.decision_type),
+                draft_action_status="draft_ready_for_owner_review",
+                approval_status=row.approval_status,
+                top_gap_code=row.top_gap_code,
+                top_gap_category=row.top_gap_category,
+                top_gap_severity=row.top_gap_severity,
+                resolution_gate=row.resolution_gate,
+                owner_decision_required=True,
+                pack_payload=payload,
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(packs)
+
+
+def write_packs_sqlite(
+    output_db: Path,
+    *,
+    packs: Sequence[OwnerDecisionPack],
+    source_case_count: int,
+    owner_item_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    output_db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(output_db) as conn:
+        conn.executescript(
+            """
+            DROP TABLE IF EXISTS owner_decision_pack_runs;
+            DROP TABLE IF EXISTS owner_decision_packs;
+
+            CREATE TABLE owner_decision_pack_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_case_count INTEGER NOT NULL,
+                owner_item_count INTEGER NOT NULL,
+                pack_count INTEGER NOT NULL,
+                urgent_pack_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE owner_decision_packs (
+                pack_id TEXT PRIMARY KEY,
+                case_card_id TEXT NOT NULL,
+                pack_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                decision_priority TEXT NOT NULL,
+                owner_prompt_code TEXT NOT NULL,
+                pack_title TEXT NOT NULL,
+                risk_brief TEXT NOT NULL,
+                recommended_decision TEXT NOT NULL,
+                draft_action_type TEXT NOT NULL,
+                draft_action_status TEXT NOT NULL,
+                approval_status TEXT NOT NULL,
+                top_gap_code TEXT NOT NULL,
+                top_gap_category TEXT NOT NULL,
+                top_gap_severity TEXT NOT NULL,
+                resolution_gate TEXT NOT NULL,
+                owner_decision_required INTEGER NOT NULL CHECK (owner_decision_required = 1),
+                pack_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE INDEX idx_owner_pack_rank ON owner_decision_packs(pack_rank);
+            CREATE INDEX idx_owner_pack_lane ON owner_decision_packs(assigned_lane);
+            CREATE INDEX idx_owner_pack_type ON owner_decision_packs(decision_type);
+            CREATE INDEX idx_owner_pack_priority ON owner_decision_packs(decision_priority);
+            CREATE INDEX idx_owner_pack_draft_action ON owner_decision_packs(draft_action_type);
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO owner_decision_pack_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_case_count, owner_item_count, pack_count,
+                urgent_pack_count, send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, ?, ?, ?, ?, 0, 0)
+            """,
+            (
+                generated_at_utc,
+                source_generated_at_utc,
+                "local_only_owner_decision_pack_no_raw_text_no_send_no_crm_mutation",
+                source_case_count,
+                owner_item_count,
+                len(packs),
+                sum(1 for pack in packs if pack.decision_priority == "now"),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO owner_decision_packs (
+                pack_id, case_card_id, pack_rank, assigned_lane, decision_type,
+                decision_priority, owner_prompt_code, pack_title, risk_brief,
+                recommended_decision, draft_action_type, draft_action_status,
+                approval_status, top_gap_code, top_gap_category, top_gap_severity,
+                resolution_gate, owner_decision_required, pack_payload_json,
+                send_whatsapp, crm_mutation, requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    pack.pack_id,
+                    pack.case_card_id,
+                    pack.pack_rank,
+                    pack.assigned_lane,
+                    pack.decision_type,
+                    pack.decision_priority,
+                    pack.owner_prompt_code,
+                    pack.pack_title,
+                    pack.risk_brief,
+                    pack.recommended_decision,
+                    pack.draft_action_type,
+                    pack.draft_action_status,
+                    pack.approval_status,
+                    pack.top_gap_code,
+                    pack.top_gap_category,
+                    pack.top_gap_severity,
+                    pack.resolution_gate,
+                    int(pack.owner_decision_required),
+                    json.dumps(pack.pack_payload, ensure_ascii=False, sort_keys=True),
+                    int(pack.send_whatsapp),
+                    int(pack.crm_mutation),
+                    int(pack.requires_human_approval),
+                )
+                for pack in packs
+            ],
+        )
+        conn.commit()
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'unknown'} | {count} |")
+    return lines
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    packs: Sequence[OwnerDecisionPack],
+    source_case_count: int,
+    owner_item_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    decision_counts = Counter(pack.decision_type for pack in packs)
+    lane_counts = Counter(pack.assigned_lane for pack in packs)
+    priority_counts = Counter(pack.decision_priority for pack in packs)
+    draft_counts = Counter(pack.draft_action_type for pack in packs)
+    status_counts = Counter(pack.draft_action_status for pack in packs)
+    approval_counts = Counter(pack.approval_status for pack in packs)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Owner Decision Packs Summary",
+        "",
+        f"Generated UTC: `{generated_at_utc}`",
+        f"Source Owner Approval UTC: `{source_generated_at_utc}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, case card IDs, judgment IDs, approval IDs, pack IDs, gap IDs, event IDs, inbox item IDs, or room item IDs.",
+        "- Owner decision packs are local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Source cases | {source_case_count} |",
+        f"| Owner approval items | {owner_item_count} |",
+        f"| Owner decision packs | {len(packs)} |",
+        f"| Urgent owner packs | {sum(1 for pack in packs if pack.decision_priority == 'now')} |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("Decision Types", decision_counts),
+        "",
+        *_counter_table("Decision Priorities", priority_counts),
+        "",
+        *_counter_table("Assigned Lanes", lane_counts),
+        "",
+        *_counter_table("Draft Action Types", draft_counts),
+        "",
+        *_counter_table("Draft Action Status", status_counts),
+        "",
+        *_counter_table("Approval Status", approval_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- The Owner Decision Pack turns owner approval rows into readable decision packets.",
+        "- It does not parse raw WhatsApp messages.",
+        "- It does not call a cloud LLM.",
+        "- Runtime must not send WhatsApp messages from this artifact.",
+        "- Runtime must not mutate CRM records from this artifact.",
+        "- Owner approval remains mandatory before any client-facing message or operational mutation.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_owner_decision_packs(
+    *,
+    owner_approval_db: Path = DEFAULT_OWNER_APPROVAL_DB,
+    output_dir: Path = DEFAULT_OWNER_DECISION_PACK_DIR,
+    output_db: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+    generated_at_utc: str | None = None,
+) -> OwnerDecisionPacksBuildResult:
+    """Build local-only owner decision packs from owner approval rows."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    generated = _format_utc(generated_at_utc)
+    source_generated, source_case_count, owner_item_count = read_source_metadata(
+        owner_approval_db
+    )
+    approval_rows = read_owner_approval_rows(owner_approval_db)
+    packs = build_packs(approval_rows)
+    source_case_total = source_case_count or len(approval_rows)
+    owner_item_total = owner_item_count or len(approval_rows)
+    write_packs_sqlite(
+        output_db,
+        packs=packs,
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    write_summary(
+        summary_path=summary_path,
+        packs=packs,
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    return OwnerDecisionPacksBuildResult(
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=len(packs),
+        send_whatsapp_count=sum(1 for pack in packs if pack.send_whatsapp),
+        crm_mutation_count=sum(1 for pack in packs if pack.crm_mutation),
+        decision_type_counts=dict(Counter(pack.decision_type for pack in packs)),
+        lane_counts=dict(Counter(pack.assigned_lane for pack in packs)),
+        output_db=output_db,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build local-only Zantara owner decision packs from owner approval rows."
+    )
+    parser.add_argument("--owner-approval-db", type=Path, default=DEFAULT_OWNER_APPROVAL_DB)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OWNER_DECISION_PACK_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--generated-at-utc", default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_owner_decision_packs(
+            owner_approval_db=args.owner_approval_db,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            summary_path=args.summary,
+            generated_at_utc=args.generated_at_utc,
+        )
+    except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
+        print("ERROR: Owner decision packs input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError):
+        print("ERROR: Owner decision packs run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        print("ERROR: Owner decision packs run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "crm_mutation_count": result.crm_mutation_count,
+                    "owner_item_count": result.owner_item_count,
+                    "pack_count": result.pack_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "source_case_count": result.source_case_count,
+                },
+                sort_keys=True,
+            )
+        )
+    else:
+        print(
+            "Owner decision packs complete: "
+            f"{result.pack_count} packs -> {result.output_db.name}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/whatsapp_corpus/build_owner_decision_pipeline.py
+++ b/scripts/whatsapp_corpus/build_owner_decision_pipeline.py
@@ -1,0 +1,500 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sqlite3
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.whatsapp_corpus.build_owner_decision_cockpit import (
+    build_owner_decision_cockpit,
+)
+from scripts.whatsapp_corpus.build_owner_decision_compiler import (
+    build_owner_decision_compiler,
+)
+from scripts.whatsapp_corpus.build_owner_decision_inbox import (
+    build_owner_decision_inbox,
+)
+from scripts.whatsapp_corpus.build_owner_decision_intake import _format_utc
+from scripts.whatsapp_corpus.build_owner_decision_replay import (
+    build_owner_decision_replay,
+)
+
+DEFAULT_APPROVE_REJECT_LEDGER_DIR = Path(
+    "research/personal/wa-corpus/approve-reject-ledger"
+)
+DEFAULT_OPERATOR_PACKET_REVIEW_CONSOLE_DIR = Path(
+    "research/personal/wa-corpus/operator-packet-review-console"
+)
+DEFAULT_OWNER_DECISION_PIPELINE_DIR = Path(
+    "research/personal/wa-corpus/owner-decision-pipeline"
+)
+
+DEFAULT_LEDGER_DB = DEFAULT_APPROVE_REJECT_LEDGER_DIR / "approve_reject_ledger.local.sqlite"
+DEFAULT_REVIEW_CONSOLE_DB = (
+    DEFAULT_OPERATOR_PACKET_REVIEW_CONSOLE_DIR
+    / "operator_packet_review_console.local.sqlite"
+)
+DEFAULT_OUTPUT_DB = DEFAULT_OWNER_DECISION_PIPELINE_DIR / "owner_decision_pipeline.local.sqlite"
+DEFAULT_SUMMARY = DEFAULT_OWNER_DECISION_PIPELINE_DIR / "owner_decision_pipeline_summary.md"
+
+INBOX_STAGE_DIR = "owner-decision-inbox"
+COCKPIT_STAGE_DIR = "owner-decision-cockpit"
+COMPILER_STAGE_DIR = "owner-decision-compiler"
+REPLAY_STAGE_DIR = "owner-decision-replay"
+
+PIPELINE_STATUS_REPLAYED = "replayed"
+PIPELINE_STATUS_AWAITING_OWNER_INPUT = "awaiting_owner_input"
+
+
+@dataclass(frozen=True)
+class StageOutput:
+    stage_rank: int
+    stage_name: str
+    item_count: int
+    output_db: Path
+    output_summary: Path
+
+
+@dataclass(frozen=True)
+class OwnerDecisionPipelineBuildResult:
+    pipeline_status: str
+    inbox_item_count: int
+    captured_decision_count: int
+    awaiting_owner_input_count: int
+    compiled_decision_count: int
+    replay_event_count: int
+    final_review_item_count: int
+    final_operator_ready_item_count: int
+    final_rejected_item_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    output_db: Path
+    summary_path: Path
+    owner_inbox_db: Path
+    owner_cockpit_db: Path
+    owner_compiler_db: Path | None
+    owner_replay_db: Path | None
+
+
+def _remove_path_if_present(path: Path) -> None:
+    if path.is_dir():
+        shutil.rmtree(path)
+    else:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            return
+
+
+def _reset_downstream_outputs(output_dir: Path) -> None:
+    for stage_dir in (COMPILER_STAGE_DIR, REPLAY_STAGE_DIR):
+        _remove_path_if_present(output_dir / stage_dir)
+
+
+def _sum_stage_count(results: Sequence[object], field_name: str) -> int:
+    return sum(int(getattr(result, field_name)) for result in results)
+
+
+def _write_manifest_sqlite(
+    output_db: Path,
+    *,
+    result: OwnerDecisionPipelineBuildResult,
+    stages: Sequence[StageOutput],
+    generated_at_utc: str,
+) -> None:
+    output_db.parent.mkdir(parents=True, exist_ok=True)
+    temp_db = output_db.with_name(f".{output_db.name}.tmp")
+    if temp_db.exists():
+        temp_db.unlink()
+    with sqlite3.connect(temp_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE owner_decision_pipeline_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                pipeline_status TEXT NOT NULL,
+                inbox_item_count INTEGER NOT NULL,
+                captured_decision_count INTEGER NOT NULL,
+                awaiting_owner_input_count INTEGER NOT NULL,
+                compiled_decision_count INTEGER NOT NULL,
+                replay_event_count INTEGER NOT NULL,
+                final_review_item_count INTEGER NOT NULL,
+                final_operator_ready_item_count INTEGER NOT NULL,
+                final_rejected_item_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL CHECK (send_whatsapp_count = 0),
+                crm_mutation_count INTEGER NOT NULL CHECK (crm_mutation_count = 0),
+                owner_inbox_db TEXT NOT NULL,
+                owner_cockpit_db TEXT NOT NULL,
+                owner_compiler_db TEXT NOT NULL,
+                owner_replay_db TEXT NOT NULL
+            );
+
+            CREATE TABLE owner_decision_pipeline_stage_outputs (
+                stage_rank INTEGER PRIMARY KEY,
+                stage_name TEXT NOT NULL UNIQUE,
+                item_count INTEGER NOT NULL,
+                output_db TEXT NOT NULL,
+                output_summary TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO owner_decision_pipeline_runs (
+                id, generated_at_utc, privacy_mode, pipeline_status,
+                inbox_item_count, captured_decision_count,
+                awaiting_owner_input_count, compiled_decision_count,
+                replay_event_count, final_review_item_count,
+                final_operator_ready_item_count, final_rejected_item_count,
+                send_whatsapp_count, crm_mutation_count, owner_inbox_db,
+                owner_cockpit_db, owner_compiler_db, owner_replay_db
+            )
+            VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                generated_at_utc,
+                "local_only_owner_decision_pipeline_no_raw_text_no_send_no_crm_mutation",
+                result.pipeline_status,
+                result.inbox_item_count,
+                result.captured_decision_count,
+                result.awaiting_owner_input_count,
+                result.compiled_decision_count,
+                result.replay_event_count,
+                result.final_review_item_count,
+                result.final_operator_ready_item_count,
+                result.final_rejected_item_count,
+                result.send_whatsapp_count,
+                result.crm_mutation_count,
+                str(result.owner_inbox_db),
+                str(result.owner_cockpit_db),
+                str(result.owner_compiler_db or ""),
+                str(result.owner_replay_db or ""),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO owner_decision_pipeline_stage_outputs (
+                stage_rank, stage_name, item_count, output_db, output_summary
+            )
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    stage.stage_rank,
+                    stage.stage_name,
+                    stage.item_count,
+                    str(stage.output_db),
+                    str(stage.output_summary),
+                )
+                for stage in stages
+            ],
+        )
+        conn.commit()
+    if output_db.exists():
+        output_db.unlink()
+    temp_db.replace(output_db)
+
+
+def _write_summary(
+    summary_path: Path,
+    *,
+    result: OwnerDecisionPipelineBuildResult,
+    stages: Sequence[StageOutput],
+    generated_at_utc: str,
+) -> None:
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Owner Decision Pipeline Summary",
+        "",
+        f"Generated UTC: `{generated_at_utc}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, case IDs, ledger entry IDs, packet IDs, review item IDs, or inbox item IDs.",
+        "- Owner Decision Pipeline artifacts stay in the local ignored workspace.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Pipeline status | {result.pipeline_status} |",
+        f"| Owner inbox items | {result.inbox_item_count} |",
+        f"| Captured decisions | {result.captured_decision_count} |",
+        f"| Awaiting owner input | {result.awaiting_owner_input_count} |",
+        f"| Compiled decisions | {result.compiled_decision_count} |",
+        f"| Replay events | {result.replay_event_count} |",
+        f"| Final review items | {result.final_review_item_count} |",
+        f"| Final operator-ready items | {result.final_operator_ready_item_count} |",
+        f"| Final rejected items | {result.final_rejected_item_count} |",
+        f"| WhatsApp sends | {result.send_whatsapp_count} |",
+        f"| CRM mutations | {result.crm_mutation_count} |",
+        "| Human approval required | 100% |",
+        "",
+        "## Stage Outputs",
+        "",
+        "| Stage | Items |",
+        "|---|---:|",
+    ]
+    lines.extend(f"| {stage.stage_name} | {stage.item_count} |" for stage in stages)
+    lines.extend(
+        [
+            "",
+            "## Execution Contract",
+            "",
+            "- This pipeline runs Owner Decision Inbox, Owner Decision Cockpit, Owner Decision Compiler, and Owner Decision Replay in order.",
+            "- It records only explicit owner approve, reject, or defer inputs.",
+            "- If any owner input is missing, it stops at the Cockpit with `awaiting_owner_input` and does not run the Compiler or Replay.",
+            "- It passes the Cockpit template path explicitly into the Compiler.",
+            "- It does not parse raw WhatsApp messages.",
+            "- It does not call a cloud LLM.",
+            "- Runtime must not send WhatsApp messages from this artifact.",
+            "- Runtime must not mutate CRM records from this artifact.",
+            "- Human approval remains mandatory before any client-facing message or operational mutation.",
+        ]
+    )
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_owner_decision_pipeline(
+    *,
+    ledger_db: Path = DEFAULT_LEDGER_DB,
+    review_console_db: Path = DEFAULT_REVIEW_CONSOLE_DB,
+    owner_inputs_jsonl: Path | None = None,
+    inline_decisions: Sequence[str] = (),
+    inline_decision_notes: Sequence[str] = (),
+    inline_event_recorded_at_utc: Sequence[str] = (),
+    output_dir: Path = DEFAULT_OWNER_DECISION_PIPELINE_DIR,
+    output_db: Path | None = None,
+    summary_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> OwnerDecisionPipelineBuildResult:
+    """Run the local-only owner decision path from inbox through replay."""
+    generated = _format_utc(generated_at_utc)
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    summary_path = summary_path or output_dir / DEFAULT_SUMMARY.name
+    _reset_downstream_outputs(output_dir)
+
+    inbox_dir = output_dir / INBOX_STAGE_DIR
+    cockpit_dir = output_dir / COCKPIT_STAGE_DIR
+    compiler_dir = output_dir / COMPILER_STAGE_DIR
+    replay_dir = output_dir / REPLAY_STAGE_DIR
+
+    inbox_summary = inbox_dir / "owner_decision_inbox_summary.md"
+    cockpit_summary = cockpit_dir / "owner_decision_cockpit_summary.md"
+    compiler_summary = compiler_dir / "owner_decision_compiler_summary.md"
+    replay_summary = replay_dir / "owner_decision_replay_summary.md"
+
+    inbox_result = build_owner_decision_inbox(
+        review_console_db=review_console_db,
+        output_dir=inbox_dir,
+        summary_path=inbox_summary,
+        generated_at_utc=generated,
+    )
+    cockpit_result = build_owner_decision_cockpit(
+        owner_inbox_db=inbox_result.output_db,
+        owner_inputs_jsonl=owner_inputs_jsonl,
+        inline_decisions=inline_decisions,
+        inline_decision_notes=inline_decision_notes,
+        inline_event_recorded_at_utc=inline_event_recorded_at_utc,
+        output_dir=cockpit_dir,
+        summary_path=cockpit_summary,
+        generated_at_utc=generated,
+    )
+
+    stages: list[StageOutput] = [
+        StageOutput(
+            1,
+            "owner_decision_inbox",
+            inbox_result.inbox_item_count,
+            inbox_result.output_db,
+            inbox_summary,
+        ),
+        StageOutput(
+            2,
+            "owner_decision_cockpit",
+            cockpit_result.inbox_item_count,
+            cockpit_result.output_db,
+            cockpit_summary,
+        ),
+    ]
+
+    if cockpit_result.awaiting_owner_input_count:
+        invoked_results = (inbox_result, cockpit_result)
+        result = OwnerDecisionPipelineBuildResult(
+            pipeline_status=PIPELINE_STATUS_AWAITING_OWNER_INPUT,
+            inbox_item_count=inbox_result.inbox_item_count,
+            captured_decision_count=cockpit_result.captured_decision_count,
+            awaiting_owner_input_count=cockpit_result.awaiting_owner_input_count,
+            compiled_decision_count=0,
+            replay_event_count=0,
+            final_review_item_count=0,
+            final_operator_ready_item_count=0,
+            final_rejected_item_count=0,
+            send_whatsapp_count=_sum_stage_count(
+                invoked_results, "send_whatsapp_count"
+            ),
+            crm_mutation_count=_sum_stage_count(invoked_results, "crm_mutation_count"),
+            output_db=output_db,
+            summary_path=summary_path,
+            owner_inbox_db=inbox_result.output_db,
+            owner_cockpit_db=cockpit_result.output_db,
+            owner_compiler_db=None,
+            owner_replay_db=None,
+        )
+    else:
+        compiler_result = build_owner_decision_compiler(
+            owner_inbox_db=inbox_result.output_db,
+            edited_template_jsonl=cockpit_result.output_template,
+            output_dir=compiler_dir,
+            summary_path=compiler_summary,
+            generated_at_utc=generated,
+        )
+        replay_result = build_owner_decision_replay(
+            ledger_db=ledger_db,
+            review_console_db=review_console_db,
+            owner_decisions_jsonl=compiler_result.output_jsonl,
+            output_dir=replay_dir,
+            summary_path=replay_summary,
+            generated_at_utc=generated,
+        )
+        invoked_results = (
+            inbox_result,
+            cockpit_result,
+            compiler_result,
+            replay_result,
+        )
+        stages.extend(
+            [
+                StageOutput(
+                    3,
+                    "owner_decision_compiler",
+                    compiler_result.compiled_decision_count,
+                    compiler_result.output_db,
+                    compiler_summary,
+                ),
+                StageOutput(
+                    4,
+                    "owner_decision_replay",
+                    replay_result.final_review_item_count,
+                    replay_result.output_db,
+                    replay_summary,
+                ),
+            ]
+        )
+        result = OwnerDecisionPipelineBuildResult(
+            pipeline_status=PIPELINE_STATUS_REPLAYED,
+            inbox_item_count=inbox_result.inbox_item_count,
+            captured_decision_count=cockpit_result.captured_decision_count,
+            awaiting_owner_input_count=0,
+            compiled_decision_count=compiler_result.compiled_decision_count,
+            replay_event_count=replay_result.replay_event_count,
+            final_review_item_count=replay_result.final_review_item_count,
+            final_operator_ready_item_count=replay_result.final_operator_ready_item_count,
+            final_rejected_item_count=replay_result.final_rejected_item_count,
+            send_whatsapp_count=_sum_stage_count(
+                invoked_results, "send_whatsapp_count"
+            ),
+            crm_mutation_count=_sum_stage_count(invoked_results, "crm_mutation_count"),
+            output_db=output_db,
+            summary_path=summary_path,
+            owner_inbox_db=inbox_result.output_db,
+            owner_cockpit_db=cockpit_result.output_db,
+            owner_compiler_db=compiler_result.output_db,
+            owner_replay_db=replay_result.output_db,
+        )
+
+    _write_manifest_sqlite(
+        output_db,
+        result=result,
+        stages=stages,
+        generated_at_utc=generated,
+    )
+    _write_summary(
+        summary_path,
+        result=result,
+        stages=stages,
+        generated_at_utc=generated,
+    )
+    return result
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the local-only Zantara Owner Decision Pipeline."
+    )
+    parser.add_argument("--ledger-db", type=Path, default=DEFAULT_LEDGER_DB)
+    parser.add_argument("--review-console-db", type=Path, default=DEFAULT_REVIEW_CONSOLE_DB)
+    parser.add_argument("--owner-inputs-jsonl", type=Path, default=None)
+    parser.add_argument("--decision", action="append", default=[])
+    parser.add_argument("--decision-note", action="append", default=[])
+    parser.add_argument("--event-recorded-at-utc", action="append", default=[])
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OWNER_DECISION_PIPELINE_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=None)
+    parser.add_argument("--generated-at-utc", default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_owner_decision_pipeline(
+            ledger_db=args.ledger_db,
+            review_console_db=args.review_console_db,
+            owner_inputs_jsonl=args.owner_inputs_jsonl,
+            inline_decisions=args.decision,
+            inline_decision_notes=args.decision_note,
+            inline_event_recorded_at_utc=args.event_recorded_at_utc,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            summary_path=args.summary,
+            generated_at_utc=args.generated_at_utc,
+        )
+    except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
+        print("ERROR: Owner decision pipeline input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError):
+        print("ERROR: Owner decision pipeline run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        print("ERROR: Owner decision pipeline run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "awaiting_owner_input_count": result.awaiting_owner_input_count,
+                    "captured_decision_count": result.captured_decision_count,
+                    "compiled_decision_count": result.compiled_decision_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                    "final_review_item_count": result.final_review_item_count,
+                    "inbox_item_count": result.inbox_item_count,
+                    "pipeline_status": result.pipeline_status,
+                    "replay_event_count": result.replay_event_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                },
+                sort_keys=True,
+            )
+        )
+    else:
+        print(
+            "Owner decision pipeline complete: "
+            f"{result.pipeline_status} -> {result.output_db.name}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/whatsapp_corpus/build_owner_decision_replay.py
+++ b/scripts/whatsapp_corpus/build_owner_decision_replay.py
@@ -1,0 +1,546 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.whatsapp_corpus.build_operator_execution_packets import (
+    build_operator_execution_packets,
+)
+from scripts.whatsapp_corpus.build_operator_packet_review_console import (
+    build_operator_packet_review_console,
+)
+from scripts.whatsapp_corpus.build_owner_decision_event_capture import (
+    build_owner_decision_event_capture,
+)
+from scripts.whatsapp_corpus.build_owner_decision_intake import (
+    build_owner_decision_intake,
+)
+from scripts.whatsapp_corpus.build_post_decision_work_order_queue import (
+    build_post_decision_work_order_queue,
+)
+
+DEFAULT_APPROVE_REJECT_LEDGER_DIR = Path(
+    "research/personal/wa-corpus/approve-reject-ledger"
+)
+DEFAULT_OPERATOR_PACKET_REVIEW_CONSOLE_DIR = Path(
+    "research/personal/wa-corpus/operator-packet-review-console"
+)
+DEFAULT_OWNER_DECISION_INTAKE_DIR = Path(
+    "research/personal/wa-corpus/owner-decision-intake"
+)
+DEFAULT_OWNER_DECISION_REPLAY_DIR = Path(
+    "research/personal/wa-corpus/owner-decision-replay"
+)
+
+DEFAULT_LEDGER_DB = DEFAULT_APPROVE_REJECT_LEDGER_DIR / "approve_reject_ledger.local.sqlite"
+DEFAULT_REVIEW_CONSOLE_DB = (
+    DEFAULT_OPERATOR_PACKET_REVIEW_CONSOLE_DIR
+    / "operator_packet_review_console.local.sqlite"
+)
+DEFAULT_OWNER_DECISIONS_JSONL = (
+    DEFAULT_OWNER_DECISION_INTAKE_DIR / "owner_decisions.local.jsonl"
+)
+DEFAULT_OUTPUT_DB = DEFAULT_OWNER_DECISION_REPLAY_DIR / "owner_decision_replay.local.sqlite"
+DEFAULT_SUMMARY = DEFAULT_OWNER_DECISION_REPLAY_DIR / "owner_decision_replay_summary.md"
+
+INTAKE_STAGE_DIR = "owner-decision-intake"
+OWNER_EVENTS_STAGE_DIR = "owner-decision-events"
+WORK_ORDERS_STAGE_DIR = "post-decision-work-orders"
+OPERATOR_PACKETS_STAGE_DIR = "operator-execution-packets"
+FINAL_REVIEW_STAGE_DIR = "operator-packet-review-console"
+
+
+@dataclass(frozen=True)
+class OwnerDecisionReplayBuildResult:
+    source_case_count: int
+    source_review_item_count: int
+    intake_item_count: int
+    captured_owner_decision_count: int
+    replay_event_count: int
+    captured_event_count: int
+    awaiting_input_count: int
+    work_order_count: int
+    ready_work_order_count: int
+    blocked_work_order_count: int
+    deferred_work_order_count: int
+    rejected_work_order_count: int
+    packet_count: int
+    ready_packet_count: int
+    blocked_packet_count: int
+    deferred_packet_count: int
+    rejected_packet_count: int
+    final_review_item_count: int
+    final_owner_decision_item_count: int
+    final_operator_ready_item_count: int
+    final_deferred_item_count: int
+    final_rejected_item_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    output_db: Path
+    summary_path: Path
+    intake_db: Path
+    owner_events_db: Path
+    work_orders_db: Path
+    operator_packets_db: Path
+    final_review_console_db: Path
+
+
+@dataclass(frozen=True)
+class StageOutput:
+    stage_rank: int
+    stage_name: str
+    item_count: int
+    output_db: Path
+    output_summary: Path
+
+
+def _format_utc(value: str | None = None) -> str:
+    if value is not None:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).isoformat(timespec="seconds")
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _write_manifest_sqlite(
+    output_db: Path,
+    *,
+    result: OwnerDecisionReplayBuildResult,
+    stages: Sequence[StageOutput],
+    generated_at_utc: str,
+) -> None:
+    output_db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(output_db) as conn:
+        conn.executescript(
+            """
+            DROP TABLE IF EXISTS owner_decision_replay_runs;
+            DROP TABLE IF EXISTS owner_decision_replay_stage_outputs;
+
+            CREATE TABLE owner_decision_replay_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_case_count INTEGER NOT NULL,
+                source_review_item_count INTEGER NOT NULL,
+                intake_item_count INTEGER NOT NULL,
+                captured_owner_decision_count INTEGER NOT NULL,
+                replay_event_count INTEGER NOT NULL,
+                captured_event_count INTEGER NOT NULL,
+                awaiting_input_count INTEGER NOT NULL,
+                work_order_count INTEGER NOT NULL,
+                ready_work_order_count INTEGER NOT NULL,
+                blocked_work_order_count INTEGER NOT NULL,
+                deferred_work_order_count INTEGER NOT NULL,
+                rejected_work_order_count INTEGER NOT NULL,
+                packet_count INTEGER NOT NULL,
+                ready_packet_count INTEGER NOT NULL,
+                blocked_packet_count INTEGER NOT NULL,
+                deferred_packet_count INTEGER NOT NULL,
+                rejected_packet_count INTEGER NOT NULL,
+                final_review_item_count INTEGER NOT NULL,
+                final_owner_decision_item_count INTEGER NOT NULL,
+                final_operator_ready_item_count INTEGER NOT NULL,
+                final_deferred_item_count INTEGER NOT NULL,
+                final_rejected_item_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL CHECK (send_whatsapp_count = 0),
+                crm_mutation_count INTEGER NOT NULL CHECK (crm_mutation_count = 0)
+            );
+
+            CREATE TABLE owner_decision_replay_stage_outputs (
+                stage_rank INTEGER PRIMARY KEY,
+                stage_name TEXT NOT NULL UNIQUE,
+                item_count INTEGER NOT NULL,
+                output_db TEXT NOT NULL,
+                output_summary TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO owner_decision_replay_runs (
+                id, generated_at_utc, privacy_mode, source_case_count,
+                source_review_item_count, intake_item_count,
+                captured_owner_decision_count, replay_event_count,
+                captured_event_count, awaiting_input_count, work_order_count,
+                ready_work_order_count, blocked_work_order_count,
+                deferred_work_order_count, rejected_work_order_count,
+                packet_count, ready_packet_count, blocked_packet_count,
+                deferred_packet_count, rejected_packet_count,
+                final_review_item_count, final_owner_decision_item_count,
+                final_operator_ready_item_count, final_deferred_item_count,
+                final_rejected_item_count, send_whatsapp_count,
+                crm_mutation_count
+            )
+            VALUES (
+                1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?, ?, ?, ?, ?, ?
+            )
+            """,
+            (
+                generated_at_utc,
+                "local_only_owner_decision_replay_no_raw_text_no_send_no_crm_mutation",
+                result.source_case_count,
+                result.source_review_item_count,
+                result.intake_item_count,
+                result.captured_owner_decision_count,
+                result.replay_event_count,
+                result.captured_event_count,
+                result.awaiting_input_count,
+                result.work_order_count,
+                result.ready_work_order_count,
+                result.blocked_work_order_count,
+                result.deferred_work_order_count,
+                result.rejected_work_order_count,
+                result.packet_count,
+                result.ready_packet_count,
+                result.blocked_packet_count,
+                result.deferred_packet_count,
+                result.rejected_packet_count,
+                result.final_review_item_count,
+                result.final_owner_decision_item_count,
+                result.final_operator_ready_item_count,
+                result.final_deferred_item_count,
+                result.final_rejected_item_count,
+                result.send_whatsapp_count,
+                result.crm_mutation_count,
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO owner_decision_replay_stage_outputs (
+                stage_rank, stage_name, item_count, output_db, output_summary
+            )
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    stage.stage_rank,
+                    stage.stage_name,
+                    stage.item_count,
+                    str(stage.output_db),
+                    str(stage.output_summary),
+                )
+                for stage in stages
+            ],
+        )
+        conn.commit()
+
+
+def _write_summary(
+    summary_path: Path,
+    *,
+    result: OwnerDecisionReplayBuildResult,
+    stages: Sequence[StageOutput],
+    generated_at_utc: str,
+) -> None:
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Owner Decision Replay Summary",
+        "",
+        f"Generated UTC: `{generated_at_utc}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, case card IDs, judgment IDs, approval IDs, pack IDs, brief IDs, route IDs, ledger entry IDs, event IDs, work order IDs, packet IDs, or review item IDs.",
+        "- Owner decision replay artifacts are local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Source cases | {result.source_case_count} |",
+        f"| Source review items | {result.source_review_item_count} |",
+        f"| Intake items | {result.intake_item_count} |",
+        f"| Captured owner decisions | {result.captured_owner_decision_count} |",
+        f"| Replay events | {result.replay_event_count} |",
+        f"| Captured events | {result.captured_event_count} |",
+        f"| Awaiting owner input | {result.awaiting_input_count} |",
+        f"| Work orders | {result.work_order_count} |",
+        f"| Ready work orders | {result.ready_work_order_count} |",
+        f"| Rejected work orders | {result.rejected_work_order_count} |",
+        f"| Operator packets | {result.packet_count} |",
+        f"| Ready packets | {result.ready_packet_count} |",
+        f"| Rejected packets | {result.rejected_packet_count} |",
+        f"| Final review items | {result.final_review_item_count} |",
+        f"| Final owner-decision items | {result.final_owner_decision_item_count} |",
+        f"| Final operator-ready items | {result.final_operator_ready_item_count} |",
+        f"| Final rejected items | {result.final_rejected_item_count} |",
+        f"| WhatsApp sends | {result.send_whatsapp_count} |",
+        f"| CRM mutations | {result.crm_mutation_count} |",
+        "| Human approval required | 100% |",
+        "",
+        "## Stage Outputs",
+        "",
+        "| Stage | Items |",
+        "|---|---:|",
+    ]
+    lines.extend(
+        f"| {stage.stage_name} | {stage.item_count} |" for stage in stages
+    )
+    lines.extend(
+        [
+            "",
+            "## Execution Contract",
+            "",
+            "- This replay regenerates the owner decision intake, owner event capture, post-decision work orders, operator packets, and final review console.",
+            "- It accepts only explicit owner approve, reject, or defer records.",
+            "- Empty owner-decision files are valid and keep the chain waiting for owner input.",
+            "- It does not invent owner decisions.",
+            "- It does not parse raw WhatsApp messages.",
+            "- It does not call a cloud LLM.",
+            "- Runtime must not send WhatsApp messages from this artifact.",
+            "- Runtime must not mutate CRM records from this artifact.",
+            "- Human approval remains mandatory before any client-facing message or operational mutation.",
+        ]
+    )
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_owner_decision_replay(
+    *,
+    ledger_db: Path = DEFAULT_LEDGER_DB,
+    review_console_db: Path = DEFAULT_REVIEW_CONSOLE_DB,
+    owner_decisions_jsonl: Path = DEFAULT_OWNER_DECISIONS_JSONL,
+    output_dir: Path = DEFAULT_OWNER_DECISION_REPLAY_DIR,
+    output_db: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+    generated_at_utc: str | None = None,
+) -> OwnerDecisionReplayBuildResult:
+    """Replay explicit owner decisions through the full local-only chain."""
+    generated = _format_utc(generated_at_utc)
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+
+    intake_dir = output_dir / INTAKE_STAGE_DIR
+    owner_events_dir = output_dir / OWNER_EVENTS_STAGE_DIR
+    work_orders_dir = output_dir / WORK_ORDERS_STAGE_DIR
+    operator_packets_dir = output_dir / OPERATOR_PACKETS_STAGE_DIR
+    final_review_dir = output_dir / FINAL_REVIEW_STAGE_DIR
+
+    intake_summary = intake_dir / "owner_decision_intake_summary.md"
+    owner_events_summary = owner_events_dir / "owner_decision_event_capture_summary.md"
+    work_orders_summary = work_orders_dir / "post_decision_work_order_queue_summary.md"
+    operator_packets_summary = operator_packets_dir / "operator_execution_packets_summary.md"
+    final_review_summary = final_review_dir / "operator_packet_review_console_summary.md"
+
+    intake_result = build_owner_decision_intake(
+        review_console_db=review_console_db,
+        owner_decisions_jsonl=owner_decisions_jsonl,
+        output_dir=intake_dir,
+        summary_path=intake_summary,
+        generated_at_utc=generated,
+    )
+    owner_events_result = build_owner_decision_event_capture(
+        ledger_db=ledger_db,
+        owner_events_jsonl=intake_result.output_jsonl,
+        output_dir=owner_events_dir,
+        summary_path=owner_events_summary,
+        generated_at_utc=generated,
+    )
+    work_orders_result = build_post_decision_work_order_queue(
+        owner_events_db=owner_events_result.output_db,
+        output_dir=work_orders_dir,
+        summary_path=work_orders_summary,
+        generated_at_utc=generated,
+    )
+    operator_packets_result = build_operator_execution_packets(
+        work_orders_db=work_orders_result.output_db,
+        output_dir=operator_packets_dir,
+        summary_path=operator_packets_summary,
+        generated_at_utc=generated,
+    )
+    final_review_result = build_operator_packet_review_console(
+        packets_db=operator_packets_result.output_db,
+        output_dir=final_review_dir,
+        summary_path=final_review_summary,
+        generated_at_utc=generated,
+    )
+
+    send_whatsapp_count = sum(
+        (
+            intake_result.send_whatsapp_count,
+            owner_events_result.send_whatsapp_count,
+            work_orders_result.send_whatsapp_count,
+            operator_packets_result.send_whatsapp_count,
+            final_review_result.send_whatsapp_count,
+        )
+    )
+    crm_mutation_count = sum(
+        (
+            intake_result.crm_mutation_count,
+            owner_events_result.crm_mutation_count,
+            work_orders_result.crm_mutation_count,
+            operator_packets_result.crm_mutation_count,
+            final_review_result.crm_mutation_count,
+        )
+    )
+
+    result = OwnerDecisionReplayBuildResult(
+        source_case_count=intake_result.source_case_count,
+        source_review_item_count=intake_result.review_item_count,
+        intake_item_count=intake_result.intake_item_count,
+        captured_owner_decision_count=intake_result.captured_decision_count,
+        replay_event_count=intake_result.replay_event_count,
+        captured_event_count=owner_events_result.captured_event_count,
+        awaiting_input_count=owner_events_result.awaiting_input_count,
+        work_order_count=work_orders_result.work_order_count,
+        ready_work_order_count=work_orders_result.ready_count,
+        blocked_work_order_count=work_orders_result.blocked_count,
+        deferred_work_order_count=work_orders_result.deferred_count,
+        rejected_work_order_count=work_orders_result.rejected_count,
+        packet_count=operator_packets_result.packet_count,
+        ready_packet_count=operator_packets_result.ready_packet_count,
+        blocked_packet_count=operator_packets_result.blocked_packet_count,
+        deferred_packet_count=operator_packets_result.deferred_packet_count,
+        rejected_packet_count=operator_packets_result.rejected_packet_count,
+        final_review_item_count=final_review_result.review_item_count,
+        final_owner_decision_item_count=final_review_result.owner_decision_item_count,
+        final_operator_ready_item_count=final_review_result.operator_ready_item_count,
+        final_deferred_item_count=final_review_result.deferred_item_count,
+        final_rejected_item_count=final_review_result.rejected_item_count,
+        send_whatsapp_count=send_whatsapp_count,
+        crm_mutation_count=crm_mutation_count,
+        output_db=output_db,
+        summary_path=summary_path,
+        intake_db=intake_result.output_db,
+        owner_events_db=owner_events_result.output_db,
+        work_orders_db=work_orders_result.output_db,
+        operator_packets_db=operator_packets_result.output_db,
+        final_review_console_db=final_review_result.output_db,
+    )
+    stages = (
+        StageOutput(
+            1,
+            "owner_decision_intake",
+            intake_result.intake_item_count,
+            intake_result.output_db,
+            intake_summary,
+        ),
+        StageOutput(
+            2,
+            "owner_decision_event_capture",
+            owner_events_result.captured_event_count,
+            owner_events_result.output_db,
+            owner_events_summary,
+        ),
+        StageOutput(
+            3,
+            "post_decision_work_order_queue",
+            work_orders_result.work_order_count,
+            work_orders_result.output_db,
+            work_orders_summary,
+        ),
+        StageOutput(
+            4,
+            "operator_execution_packets",
+            operator_packets_result.packet_count,
+            operator_packets_result.output_db,
+            operator_packets_summary,
+        ),
+        StageOutput(
+            5,
+            "operator_packet_review_console",
+            final_review_result.review_item_count,
+            final_review_result.output_db,
+            final_review_summary,
+        ),
+    )
+    _write_manifest_sqlite(
+        output_db,
+        result=result,
+        stages=stages,
+        generated_at_utc=generated,
+    )
+    _write_summary(
+        summary_path,
+        result=result,
+        stages=stages,
+        generated_at_utc=generated,
+    )
+    return result
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Replay explicit owner decisions through the full local-only Zantara chain."
+    )
+    parser.add_argument("--ledger-db", type=Path, default=DEFAULT_LEDGER_DB)
+    parser.add_argument("--review-console-db", type=Path, default=DEFAULT_REVIEW_CONSOLE_DB)
+    parser.add_argument(
+        "--owner-decisions-jsonl",
+        type=Path,
+        default=DEFAULT_OWNER_DECISIONS_JSONL,
+    )
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OWNER_DECISION_REPLAY_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--generated-at-utc", default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_owner_decision_replay(
+            ledger_db=args.ledger_db,
+            review_console_db=args.review_console_db,
+            owner_decisions_jsonl=args.owner_decisions_jsonl,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            summary_path=args.summary,
+            generated_at_utc=args.generated_at_utc,
+        )
+    except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
+        print("ERROR: Owner decision replay input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError):
+        print("ERROR: Owner decision replay run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        print("ERROR: Owner decision replay run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "awaiting_input_count": result.awaiting_input_count,
+                    "captured_event_count": result.captured_event_count,
+                    "captured_owner_decision_count": result.captured_owner_decision_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                    "final_operator_ready_item_count": result.final_operator_ready_item_count,
+                    "final_owner_decision_item_count": result.final_owner_decision_item_count,
+                    "final_rejected_item_count": result.final_rejected_item_count,
+                    "final_review_item_count": result.final_review_item_count,
+                    "packet_count": result.packet_count,
+                    "replay_event_count": result.replay_event_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "source_case_count": result.source_case_count,
+                    "source_review_item_count": result.source_review_item_count,
+                    "work_order_count": result.work_order_count,
+                },
+                sort_keys=True,
+            )
+        )
+    else:
+        print(
+            "Owner decision replay complete: "
+            f"{result.final_review_item_count} final review items -> {result.output_db.name}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/whatsapp_corpus/build_post_decision_work_order_queue.py
+++ b/scripts/whatsapp_corpus/build_post_decision_work_order_queue.py
@@ -1,0 +1,767 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_OWNER_DECISION_EVENT_DIR = Path(
+    "research/personal/wa-corpus/owner-decision-events"
+)
+DEFAULT_POST_DECISION_WORK_ORDER_DIR = Path(
+    "research/personal/wa-corpus/post-decision-work-orders"
+)
+
+DEFAULT_OWNER_EVENTS_DB = (
+    DEFAULT_OWNER_DECISION_EVENT_DIR / "owner_decision_event_capture.local.sqlite"
+)
+DEFAULT_OUTPUT_DB = (
+    DEFAULT_POST_DECISION_WORK_ORDER_DIR
+    / "post_decision_work_order_queue.local.sqlite"
+)
+DEFAULT_SUMMARY = (
+    DEFAULT_POST_DECISION_WORK_ORDER_DIR
+    / "post_decision_work_order_queue_summary.md"
+)
+
+EXPECTED_OWNER_EVENTS_DB_NAME = "owner_decision_event_capture.local.sqlite"
+PENDING_OWNER_DECISION = "pending"
+CAPTURED_STATUS = "captured"
+
+
+@dataclass(frozen=True)
+class OwnerDecisionEventRow:
+    event_id: str
+    entry_id: str
+    route_id: str
+    case_card_id: str
+    brief_id: str
+    pack_id: str
+    event_rank: int
+    assigned_lane: str
+    decision_type: str
+    decision_priority: str
+    route_bucket: str
+    capture_status: str
+    owner_decision: str
+    event_type: str
+    event_source: str
+    event_actor: str
+    event_recorded_at_utc: str
+    recommended_decision: str
+    draft_action_type: str
+    decision_note: str
+    source_ledger_hash: str
+    event_hash: str
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class WorkOrderPolicy:
+    work_order_status: str
+    work_order_type: str
+    execution_gate: str
+    next_actor: str
+    action_intent: str
+    decision_effect: str
+
+
+@dataclass(frozen=True)
+class PostDecisionWorkOrder:
+    work_order_id: str
+    event_id: str
+    entry_id: str
+    route_id: str
+    case_card_id: str
+    brief_id: str
+    pack_id: str
+    work_order_rank: int
+    assigned_lane: str
+    decision_type: str
+    decision_priority: str
+    route_bucket: str
+    owner_decision: str
+    source_capture_status: str
+    work_order_status: str
+    work_order_type: str
+    execution_gate: str
+    next_actor: str
+    action_intent: str
+    decision_effect: str
+    decision_note: str
+    source_event_hash: str
+    work_order_hash: str
+    work_order_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class PostDecisionWorkOrderQueueBuildResult:
+    source_case_count: int
+    owner_item_count: int
+    pack_count: int
+    brief_count: int
+    queue_item_count: int
+    ledger_entry_count: int
+    event_row_count: int
+    work_order_count: int
+    ready_count: int
+    blocked_count: int
+    deferred_count: int
+    rejected_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    work_order_status_counts: dict[str, int]
+    owner_decision_counts: dict[str, int]
+    output_db: Path
+    summary_path: Path
+
+
+def _format_utc(value: str | None = None) -> str:
+    if value is not None:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).isoformat(timespec="seconds")
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _connect_ro(db_path: Path, *, expected_name: str, label: str) -> sqlite3.Connection:
+    if db_path.name != expected_name:
+        raise ValueError(f"Refusing to read unexpected {label} DB: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"{label} DB not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _hash_work_order(payload: dict[str, object]) -> str:
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def read_source_metadata(db_path: Path) -> tuple[str, int, int, int, int, int, int, int]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_OWNER_EVENTS_DB_NAME,
+        label="Owner Decision Event Capture",
+    ) as conn:
+        row = conn.execute(
+            """
+            SELECT generated_at_utc, source_case_count, owner_item_count,
+                   pack_count, brief_count, queue_item_count, ledger_entry_count,
+                   captured_event_count + awaiting_input_count AS event_row_count
+            FROM owner_decision_event_capture_runs
+            WHERE id = 1
+            """
+        ).fetchone()
+    if row is None:
+        return "unknown", 0, 0, 0, 0, 0, 0, 0
+    return (
+        str(row["generated_at_utc"]),
+        int(row["source_case_count"]),
+        int(row["owner_item_count"]),
+        int(row["pack_count"]),
+        int(row["brief_count"]),
+        int(row["queue_item_count"]),
+        int(row["ledger_entry_count"]),
+        int(row["event_row_count"]),
+    )
+
+
+def read_owner_decision_events(db_path: Path) -> tuple[OwnerDecisionEventRow, ...]:
+    with _connect_ro(
+        db_path,
+        expected_name=EXPECTED_OWNER_EVENTS_DB_NAME,
+        label="Owner Decision Event Capture",
+    ) as conn:
+        rows = conn.execute(
+            """
+            SELECT event_id, entry_id, route_id, case_card_id, brief_id, pack_id,
+                   event_rank, assigned_lane, decision_type, decision_priority,
+                   route_bucket, capture_status, owner_decision, event_type,
+                   event_source, event_actor, event_recorded_at_utc,
+                   recommended_decision, draft_action_type, decision_note,
+                   source_ledger_hash, event_hash, send_whatsapp, crm_mutation,
+                   requires_human_approval
+            FROM owner_decision_event_rows
+            ORDER BY event_rank, case_card_id
+            """
+        ).fetchall()
+    return tuple(
+        OwnerDecisionEventRow(
+            event_id=str(row["event_id"]),
+            entry_id=str(row["entry_id"]),
+            route_id=str(row["route_id"]),
+            case_card_id=str(row["case_card_id"]),
+            brief_id=str(row["brief_id"]),
+            pack_id=str(row["pack_id"]),
+            event_rank=int(row["event_rank"]),
+            assigned_lane=str(row["assigned_lane"]),
+            decision_type=str(row["decision_type"]),
+            decision_priority=str(row["decision_priority"]),
+            route_bucket=str(row["route_bucket"]),
+            capture_status=str(row["capture_status"]),
+            owner_decision=str(row["owner_decision"]),
+            event_type=str(row["event_type"]),
+            event_source=str(row["event_source"]),
+            event_actor=str(row["event_actor"]),
+            event_recorded_at_utc=str(row["event_recorded_at_utc"]),
+            recommended_decision=str(row["recommended_decision"]),
+            draft_action_type=str(row["draft_action_type"]),
+            decision_note=str(row["decision_note"]),
+            source_ledger_hash=str(row["source_ledger_hash"]),
+            event_hash=str(row["event_hash"]),
+            send_whatsapp=bool(row["send_whatsapp"]),
+            crm_mutation=bool(row["crm_mutation"]),
+            requires_human_approval=bool(row["requires_human_approval"]),
+        )
+        for row in rows
+    )
+
+
+def _approved_action_intent(decision_type: str) -> tuple[str, str]:
+    if decision_type == "approve_client_recovery_followup":
+        return (
+            "approved_client_recovery_followup",
+            "prepare_client_recovery_followup_for_human_review",
+        )
+    if decision_type == "approve_immigration_status_escalation":
+        return (
+            "approved_immigration_status_escalation",
+            "prepare_immigration_status_escalation_for_human_review",
+        )
+    return (f"approved_{decision_type}", "prepare_approved_action_for_human_review")
+
+
+def derive_work_order_policy(event: OwnerDecisionEventRow) -> WorkOrderPolicy:
+    if event.send_whatsapp or event.crm_mutation:
+        raise ValueError(f"Unsafe owner event flags on {event.event_id}")
+    if not event.requires_human_approval:
+        raise ValueError(f"Owner event missing human approval gate: {event.event_id}")
+
+    if event.capture_status != CAPTURED_STATUS or event.owner_decision == PENDING_OWNER_DECISION:
+        return WorkOrderPolicy(
+            work_order_status="blocked_awaiting_owner_decision",
+            work_order_type="owner_decision_required",
+            execution_gate="owner_input_required",
+            next_actor="owner",
+            action_intent="wait_for_owner_decision",
+            decision_effect="no_action_until_owner_decision",
+        )
+    if event.owner_decision == "approve":
+        work_order_type, action_intent = _approved_action_intent(event.decision_type)
+        return WorkOrderPolicy(
+            work_order_status="ready_for_operator_review",
+            work_order_type=work_order_type,
+            execution_gate="human_review_before_send_or_crm",
+            next_actor=event.assigned_lane,
+            action_intent=action_intent,
+            decision_effect="owner_approved_internal_work_order",
+        )
+    if event.owner_decision == "defer":
+        return WorkOrderPolicy(
+            work_order_status="deferred_owner_followup",
+            work_order_type="owner_deferred_followup",
+            execution_gate="owner_revisit_required",
+            next_actor="owner",
+            action_intent="schedule_owner_revisit",
+            decision_effect="deferred_no_external_action",
+        )
+    if event.owner_decision == "reject":
+        return WorkOrderPolicy(
+            work_order_status="rejected_no_action",
+            work_order_type="owner_rejected_no_action",
+            execution_gate="no_external_action",
+            next_actor="owner",
+            action_intent="record_rejection_and_stop",
+            decision_effect="rejected_no_external_action",
+        )
+    raise ValueError(
+        f"Unsupported owner decision for {event.event_id}: {event.owner_decision}"
+    )
+
+
+def build_work_orders(
+    events: Sequence[OwnerDecisionEventRow],
+) -> tuple[PostDecisionWorkOrder, ...]:
+    work_orders: list[PostDecisionWorkOrder] = []
+    for rank, event in enumerate(events, start=1):
+        policy = derive_work_order_policy(event)
+        payload = {
+            "schema_version": "post_decision_work_order_queue.v1",
+            "privacy_mode": "local_only_post_decision_work_order_no_raw_text",
+            "source_event_rank": event.event_rank,
+            "source_capture_status": event.capture_status,
+            "owner_decision": event.owner_decision,
+            "work_order_status": policy.work_order_status,
+            "work_order_type": policy.work_order_type,
+            "execution_gate": policy.execution_gate,
+            "next_actor": policy.next_actor,
+            "action_intent": policy.action_intent,
+            "decision_effect": policy.decision_effect,
+            "decision_note": event.decision_note,
+            "raw_text_included": False,
+            "send_whatsapp": False,
+            "crm_mutation": False,
+            "requires_human_approval": True,
+        }
+        work_order_id = f"post-decision-work-order-{rank:06d}"
+        work_order_hash = _hash_work_order(
+            {
+                **payload,
+                "work_order_id": work_order_id,
+                "event_id": event.event_id,
+                "entry_id": event.entry_id,
+                "route_id": event.route_id,
+                "case_card_id": event.case_card_id,
+                "brief_id": event.brief_id,
+                "pack_id": event.pack_id,
+                "work_order_rank": rank,
+                "source_event_hash": event.event_hash,
+            }
+        )
+        work_orders.append(
+            PostDecisionWorkOrder(
+                work_order_id=work_order_id,
+                event_id=event.event_id,
+                entry_id=event.entry_id,
+                route_id=event.route_id,
+                case_card_id=event.case_card_id,
+                brief_id=event.brief_id,
+                pack_id=event.pack_id,
+                work_order_rank=rank,
+                assigned_lane=event.assigned_lane,
+                decision_type=event.decision_type,
+                decision_priority=event.decision_priority,
+                route_bucket=event.route_bucket,
+                owner_decision=event.owner_decision,
+                source_capture_status=event.capture_status,
+                work_order_status=policy.work_order_status,
+                work_order_type=policy.work_order_type,
+                execution_gate=policy.execution_gate,
+                next_actor=policy.next_actor,
+                action_intent=policy.action_intent,
+                decision_effect=policy.decision_effect,
+                decision_note=event.decision_note,
+                source_event_hash=event.event_hash,
+                work_order_hash=work_order_hash,
+                work_order_payload=payload,
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(work_orders)
+
+
+def write_post_decision_work_orders_sqlite(
+    output_db: Path,
+    *,
+    work_orders: Sequence[PostDecisionWorkOrder],
+    source_case_count: int,
+    owner_item_count: int,
+    pack_count: int,
+    brief_count: int,
+    queue_item_count: int,
+    ledger_entry_count: int,
+    event_row_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    output_db.parent.mkdir(parents=True, exist_ok=True)
+    status_counts = Counter(order.work_order_status for order in work_orders)
+    with sqlite3.connect(output_db) as conn:
+        conn.executescript(
+            """
+            DROP TABLE IF EXISTS post_decision_work_order_runs;
+            DROP TABLE IF EXISTS post_decision_work_orders;
+
+            CREATE TABLE post_decision_work_order_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                source_generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                source_case_count INTEGER NOT NULL,
+                owner_item_count INTEGER NOT NULL,
+                pack_count INTEGER NOT NULL,
+                brief_count INTEGER NOT NULL,
+                queue_item_count INTEGER NOT NULL,
+                ledger_entry_count INTEGER NOT NULL,
+                event_row_count INTEGER NOT NULL,
+                work_order_count INTEGER NOT NULL,
+                ready_count INTEGER NOT NULL,
+                blocked_count INTEGER NOT NULL,
+                deferred_count INTEGER NOT NULL,
+                rejected_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE post_decision_work_orders (
+                work_order_id TEXT PRIMARY KEY,
+                event_id TEXT NOT NULL,
+                entry_id TEXT NOT NULL,
+                route_id TEXT NOT NULL,
+                case_card_id TEXT NOT NULL,
+                brief_id TEXT NOT NULL,
+                pack_id TEXT NOT NULL,
+                work_order_rank INTEGER NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                decision_priority TEXT NOT NULL,
+                route_bucket TEXT NOT NULL,
+                owner_decision TEXT NOT NULL,
+                source_capture_status TEXT NOT NULL,
+                work_order_status TEXT NOT NULL,
+                work_order_type TEXT NOT NULL,
+                execution_gate TEXT NOT NULL,
+                next_actor TEXT NOT NULL,
+                action_intent TEXT NOT NULL,
+                decision_effect TEXT NOT NULL,
+                decision_note TEXT NOT NULL,
+                source_event_hash TEXT NOT NULL,
+                work_order_hash TEXT NOT NULL UNIQUE,
+                work_order_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE INDEX idx_post_decision_work_order_rank
+                ON post_decision_work_orders(work_order_rank);
+            CREATE INDEX idx_post_decision_work_order_status
+                ON post_decision_work_orders(work_order_status);
+            CREATE INDEX idx_post_decision_work_order_decision
+                ON post_decision_work_orders(owner_decision);
+            CREATE INDEX idx_post_decision_work_order_actor
+                ON post_decision_work_orders(next_actor);
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO post_decision_work_order_runs (
+                id, generated_at_utc, source_generated_at_utc, privacy_mode,
+                source_case_count, owner_item_count, pack_count, brief_count,
+                queue_item_count, ledger_entry_count, event_row_count,
+                work_order_count, ready_count, blocked_count, deferred_count,
+                rejected_count, send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0)
+            """,
+            (
+                generated_at_utc,
+                source_generated_at_utc,
+                "local_only_post_decision_work_order_no_raw_text_no_send_no_crm_mutation",
+                source_case_count,
+                owner_item_count,
+                pack_count,
+                brief_count,
+                queue_item_count,
+                ledger_entry_count,
+                event_row_count,
+                len(work_orders),
+                status_counts.get("ready_for_operator_review", 0),
+                status_counts.get("blocked_awaiting_owner_decision", 0),
+                status_counts.get("deferred_owner_followup", 0),
+                status_counts.get("rejected_no_action", 0),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO post_decision_work_orders (
+                work_order_id, event_id, entry_id, route_id, case_card_id,
+                brief_id, pack_id, work_order_rank, assigned_lane, decision_type,
+                decision_priority, route_bucket, owner_decision,
+                source_capture_status, work_order_status, work_order_type,
+                execution_gate, next_actor, action_intent, decision_effect,
+                decision_note, source_event_hash, work_order_hash,
+                work_order_payload_json, send_whatsapp, crm_mutation,
+                requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    order.work_order_id,
+                    order.event_id,
+                    order.entry_id,
+                    order.route_id,
+                    order.case_card_id,
+                    order.brief_id,
+                    order.pack_id,
+                    order.work_order_rank,
+                    order.assigned_lane,
+                    order.decision_type,
+                    order.decision_priority,
+                    order.route_bucket,
+                    order.owner_decision,
+                    order.source_capture_status,
+                    order.work_order_status,
+                    order.work_order_type,
+                    order.execution_gate,
+                    order.next_actor,
+                    order.action_intent,
+                    order.decision_effect,
+                    order.decision_note,
+                    order.source_event_hash,
+                    order.work_order_hash,
+                    json.dumps(order.work_order_payload, ensure_ascii=False, sort_keys=True),
+                    int(order.send_whatsapp),
+                    int(order.crm_mutation),
+                    int(order.requires_human_approval),
+                )
+                for order in work_orders
+            ],
+        )
+        conn.commit()
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'unknown'} | {count} |")
+    return lines
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    work_orders: Sequence[PostDecisionWorkOrder],
+    source_case_count: int,
+    owner_item_count: int,
+    pack_count: int,
+    brief_count: int,
+    queue_item_count: int,
+    ledger_entry_count: int,
+    event_row_count: int,
+    generated_at_utc: str,
+    source_generated_at_utc: str,
+) -> None:
+    status_counts = Counter(order.work_order_status for order in work_orders)
+    decision_counts = Counter(order.owner_decision for order in work_orders)
+    type_counts = Counter(order.work_order_type for order in work_orders)
+    actor_counts = Counter(order.next_actor for order in work_orders)
+    lane_counts = Counter(order.assigned_lane for order in work_orders)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Post-Decision Work Order Queue Summary",
+        "",
+        f"Generated UTC: `{generated_at_utc}`",
+        f"Source Owner Decision Event Capture UTC: `{source_generated_at_utc}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, case card IDs, judgment IDs, approval IDs, pack IDs, brief IDs, route IDs, ledger entry IDs, event IDs, work order IDs, inbox item IDs, or room item IDs.",
+        "- Post-decision work orders are local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Source cases | {source_case_count} |",
+        f"| Owner approval items | {owner_item_count} |",
+        f"| Owner decision packs | {pack_count} |",
+        f"| Owner briefs | {brief_count} |",
+        f"| Queue items | {queue_item_count} |",
+        f"| Ledger entries | {ledger_entry_count} |",
+        f"| Event rows | {event_row_count} |",
+        f"| Work orders | {len(work_orders)} |",
+        f"| Ready work orders | {status_counts.get('ready_for_operator_review', 0)} |",
+        f"| Blocked work orders | {status_counts.get('blocked_awaiting_owner_decision', 0)} |",
+        f"| Deferred work orders | {status_counts.get('deferred_owner_followup', 0)} |",
+        f"| Rejected work orders | {status_counts.get('rejected_no_action', 0)} |",
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("Work Order Status", status_counts),
+        "",
+        *_counter_table("Owner Decisions", decision_counts),
+        "",
+        *_counter_table("Work Order Types", type_counts),
+        "",
+        *_counter_table("Next Actors", actor_counts),
+        "",
+        *_counter_table("Assigned Lanes", lane_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- The Post-Decision Work Order Queue converts owner decision events into internal work orders only.",
+        "- Pending owner decisions remain blocked and do not become operational work.",
+        "- Approved decisions become operator-review work orders, not automatic sends.",
+        "- Deferred and rejected decisions produce no external action.",
+        "- It does not parse raw WhatsApp messages.",
+        "- It does not call a cloud LLM.",
+        "- Runtime must not send WhatsApp messages from this artifact.",
+        "- Runtime must not mutate CRM records from this artifact.",
+        "- Human approval remains mandatory before any client-facing message or operational mutation.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_post_decision_work_order_queue(
+    *,
+    owner_events_db: Path = DEFAULT_OWNER_EVENTS_DB,
+    output_dir: Path = DEFAULT_POST_DECISION_WORK_ORDER_DIR,
+    output_db: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+    generated_at_utc: str | None = None,
+) -> PostDecisionWorkOrderQueueBuildResult:
+    """Build local-only internal work orders from captured owner decisions."""
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    generated = _format_utc(generated_at_utc)
+    (
+        source_generated,
+        source_case_count,
+        owner_item_count,
+        pack_count,
+        brief_count,
+        queue_item_count,
+        ledger_entry_count,
+        source_event_row_count,
+    ) = read_source_metadata(owner_events_db)
+    events = read_owner_decision_events(owner_events_db)
+    work_orders = build_work_orders(events)
+    source_case_total = source_case_count or len(events)
+    owner_item_total = owner_item_count or len(events)
+    pack_total = pack_count or len(events)
+    brief_total = brief_count or len(events)
+    queue_total = queue_item_count or len(events)
+    ledger_total = ledger_entry_count or len(events)
+    event_row_total = source_event_row_count or len(events)
+    write_post_decision_work_orders_sqlite(
+        output_db,
+        work_orders=work_orders,
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        brief_count=brief_total,
+        queue_item_count=queue_total,
+        ledger_entry_count=ledger_total,
+        event_row_count=event_row_total,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    write_summary(
+        summary_path=summary_path,
+        work_orders=work_orders,
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        brief_count=brief_total,
+        queue_item_count=queue_total,
+        ledger_entry_count=ledger_total,
+        event_row_count=event_row_total,
+        generated_at_utc=generated,
+        source_generated_at_utc=source_generated,
+    )
+    status_counts = Counter(order.work_order_status for order in work_orders)
+    return PostDecisionWorkOrderQueueBuildResult(
+        source_case_count=source_case_total,
+        owner_item_count=owner_item_total,
+        pack_count=pack_total,
+        brief_count=brief_total,
+        queue_item_count=queue_total,
+        ledger_entry_count=ledger_total,
+        event_row_count=event_row_total,
+        work_order_count=len(work_orders),
+        ready_count=status_counts.get("ready_for_operator_review", 0),
+        blocked_count=status_counts.get("blocked_awaiting_owner_decision", 0),
+        deferred_count=status_counts.get("deferred_owner_followup", 0),
+        rejected_count=status_counts.get("rejected_no_action", 0),
+        send_whatsapp_count=sum(1 for order in work_orders if order.send_whatsapp),
+        crm_mutation_count=sum(1 for order in work_orders if order.crm_mutation),
+        work_order_status_counts=dict(status_counts),
+        owner_decision_counts=dict(Counter(order.owner_decision for order in work_orders)),
+        output_db=output_db,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build local-only Zantara post-decision work order queue."
+    )
+    parser.add_argument("--owner-events-db", type=Path, default=DEFAULT_OWNER_EVENTS_DB)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_POST_DECISION_WORK_ORDER_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--generated-at-utc", default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_post_decision_work_order_queue(
+            owner_events_db=args.owner_events_db,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            summary_path=args.summary,
+            generated_at_utc=args.generated_at_utc,
+        )
+    except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
+        print("ERROR: Post-decision work order queue input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError):
+        print("ERROR: Post-decision work order queue run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        print("ERROR: Post-decision work order queue run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "blocked_count": result.blocked_count,
+                    "brief_count": result.brief_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                    "deferred_count": result.deferred_count,
+                    "event_row_count": result.event_row_count,
+                    "ledger_entry_count": result.ledger_entry_count,
+                    "owner_item_count": result.owner_item_count,
+                    "pack_count": result.pack_count,
+                    "queue_item_count": result.queue_item_count,
+                    "ready_count": result.ready_count,
+                    "rejected_count": result.rejected_count,
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "source_case_count": result.source_case_count,
+                    "work_order_count": result.work_order_count,
+                },
+                sort_keys=True,
+            )
+        )
+    else:
+        print(
+            "Post-decision work order queue complete: "
+            f"{result.work_order_count} work orders -> {result.output_db.name}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/whatsapp_corpus/build_review_manifest.py
+++ b/scripts/whatsapp_corpus/build_review_manifest.py
@@ -105,14 +105,17 @@ def select_review_rows(
     limit: int,
     gates: set[str],
     labels: set[str],
+    sources: set[str] | None = None,
 ) -> list[ClassifiedRow]:
     """Select the highest-volume rows requiring owner review."""
+    source_filter = sources or set()
     selected = [
         row
         for row in rows
         if row.review_required
         and (not gates or row.processing_gate in gates)
         and (not labels or row.classification_label in labels)
+        and (not source_filter or row.source in source_filter)
     ]
     return sorted(
         selected,
@@ -352,10 +355,17 @@ def build_review_manifest(
     limit: int,
     gates: set[str],
     labels: set[str],
+    sources: set[str] | None = None,
 ) -> list[ReviewManifestRow]:
     """Build the private review manifest and safe tracked summary."""
     classified_rows = read_classified_rows(classification_db)
-    selected = select_review_rows(classified_rows, limit=limit, gates=gates, labels=labels)
+    selected = select_review_rows(
+        classified_rows,
+        limit=limit,
+        gates=gates,
+        labels=labels,
+        sources=sources,
+    )
     refs_by_file_id = file_ref_index(build_file_refs(root))
     manifest_rows = build_manifest_rows(
         selected_rows=selected,
@@ -408,6 +418,12 @@ def build_arg_parser() -> argparse.ArgumentParser:
         default=[],
         help="Optional classification_label filter. Can be repeated.",
     )
+    parser.add_argument(
+        "--source",
+        action="append",
+        default=[],
+        help="Optional source filter. Can be repeated.",
+    )
     return parser
 
 
@@ -434,6 +450,7 @@ def main(argv: list[str] | None = None) -> int:
             limit=args.limit,
             gates=set(args.gate),
             labels=set(args.label),
+            sources=set(args.source),
         )
     except FileNotFoundError as exc:
         LOGGER.error("%s", exc)

--- a/scripts/whatsapp_corpus/build_team_captain_shadow.py
+++ b/scripts/whatsapp_corpus/build_team_captain_shadow.py
@@ -1,0 +1,793 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sqlite3
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_CLIENT_SHADOW_DIR = Path("research/personal/wa-corpus/client-captain-shadow")
+DEFAULT_OPERATOR_REVIEW_CONSOLE_DIR = Path(
+    "research/personal/wa-corpus/operator-packet-review-console"
+)
+DEFAULT_TEAM_SHADOW_DIR = Path("research/personal/wa-corpus/team-captain-shadow")
+DEFAULT_CLIENT_SHADOW_DB = DEFAULT_CLIENT_SHADOW_DIR / "client_captain_shadow.local.sqlite"
+DEFAULT_OPERATOR_REVIEW_CONSOLE_DB = (
+    DEFAULT_OPERATOR_REVIEW_CONSOLE_DIR / "operator_packet_review_console.local.sqlite"
+)
+DEFAULT_OUTPUT_DB = DEFAULT_TEAM_SHADOW_DIR / "team_captain_shadow.local.sqlite"
+DEFAULT_SUMMARY = DEFAULT_TEAM_SHADOW_DIR / "team_captain_shadow_summary.md"
+
+EXPECTED_CLIENT_SHADOW_DB_NAME = "client_captain_shadow.local.sqlite"
+EXPECTED_OPERATOR_REVIEW_CONSOLE_DB_NAME = "operator_packet_review_console.local.sqlite"
+TEAM_OWNER = "zantara_team_captain"
+
+
+@dataclass(frozen=True)
+class ClientShadowRow:
+    shadow_id: str
+    risk_level: str
+    action_type: str
+    human_specialist: str
+    diagnosis_code: str
+    operator_coaching_mode: str
+    dominant_domain: str
+    event_count: int
+    message_count: int
+    severity_high_count: int
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class OperatorReviewConsoleRow:
+    assigned_lane: str
+    operator_lane: str
+    review_state: str
+    console_bucket: str
+    review_priority: str
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class TeamFinding:
+    team_captain_id: str
+    team_owner: str
+    human_specialist: str
+    draft_count: int
+    p1_count: int
+    p2_count: int
+    primary_action_type: str
+    primary_diagnosis_code: str
+    primary_coaching_mode: str
+    accountability_mode: str
+    total_event_count: int
+    total_message_count: int
+    input_contract_violation_count: int
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class TeamDepthLayer:
+    team_captain_id: str
+    depth_level: int
+    layer_code: str
+    layer_title: str
+    layer_payload: dict[str, object]
+
+
+@dataclass(frozen=True)
+class TeamOperatorCoachingCard:
+    team_coaching_id: str
+    team_owner: str
+    assigned_lane: str
+    operator_lane: str
+    review_state: str
+    console_bucket: str
+    review_priority: str
+    team_signal: str
+    captain_tone: str
+    operator_push: str
+    system_discipline: str
+    coaching_payload: dict[str, object]
+    send_whatsapp: bool
+    crm_mutation: bool
+    requires_human_approval: bool
+
+
+@dataclass(frozen=True)
+class TeamBuildResult:
+    finding_count: int
+    depth_layer_count: int
+    operator_coaching_card_count: int
+    input_contract_violation_count: int
+    send_whatsapp_count: int
+    crm_mutation_count: int
+    output_db: Path
+    summary_path: Path
+
+
+def _connect_client_shadow(db_path: Path) -> sqlite3.Connection:
+    if db_path.name != EXPECTED_CLIENT_SHADOW_DB_NAME:
+        raise ValueError(f"Refusing to read unexpected Client Shadow DB: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"Client Shadow DB not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def read_client_shadow_rows(db_path: Path) -> tuple[ClientShadowRow, ...]:
+    with _connect_client_shadow(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT shadow_id, risk_level, action_type, human_specialist,
+                   diagnosis_code, operator_coaching_mode, dominant_domain,
+                   event_count, message_count, severity_high_count,
+                   send_whatsapp, crm_mutation, requires_human_approval
+            FROM shadow_drafts
+            ORDER BY human_specialist, risk_level, action_type, shadow_id
+            """
+        ).fetchall()
+    return tuple(
+        ClientShadowRow(
+            shadow_id=str(row["shadow_id"]),
+            risk_level=str(row["risk_level"]),
+            action_type=str(row["action_type"]),
+            human_specialist=str(row["human_specialist"]),
+            diagnosis_code=str(row["diagnosis_code"]),
+            operator_coaching_mode=str(row["operator_coaching_mode"]),
+            dominant_domain=str(row["dominant_domain"]),
+            event_count=int(row["event_count"]),
+            message_count=int(row["message_count"]),
+            severity_high_count=int(row["severity_high_count"]),
+            send_whatsapp=bool(row["send_whatsapp"]),
+            crm_mutation=bool(row["crm_mutation"]),
+            requires_human_approval=bool(row["requires_human_approval"]),
+        )
+        for row in rows
+    )
+
+
+def _connect_operator_review_console(db_path: Path) -> sqlite3.Connection:
+    if db_path.name != EXPECTED_OPERATOR_REVIEW_CONSOLE_DB_NAME:
+        raise ValueError(
+            f"Refusing to read unexpected Operator Review Console DB: {db_path.name}"
+        )
+    if not db_path.exists():
+        raise FileNotFoundError(f"Operator Review Console DB not found: {db_path}")
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def read_operator_review_rows(db_path: Path) -> tuple[OperatorReviewConsoleRow, ...]:
+    with _connect_operator_review_console(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT assigned_lane, operator_lane, review_state, console_bucket,
+                   review_priority, send_whatsapp, crm_mutation,
+                   requires_human_approval
+            FROM operator_packet_review_items
+            ORDER BY review_rank, assigned_lane, operator_lane, review_state
+            """
+        ).fetchall()
+    return tuple(
+        OperatorReviewConsoleRow(
+            assigned_lane=str(row["assigned_lane"]),
+            operator_lane=str(row["operator_lane"]),
+            review_state=str(row["review_state"]),
+            console_bucket=str(row["console_bucket"]),
+            review_priority=str(row["review_priority"]),
+            send_whatsapp=bool(row["send_whatsapp"]),
+            crm_mutation=bool(row["crm_mutation"]),
+            requires_human_approval=bool(row["requires_human_approval"]),
+        )
+        for row in rows
+    )
+
+
+def _most_common(values: Sequence[str], fallback: str = "unknown") -> str:
+    if not values:
+        return fallback
+    return Counter(values).most_common(1)[0][0]
+
+
+def _accountability_mode(rows: Sequence[ClientShadowRow]) -> str:
+    p1_count = sum(1 for row in rows if row.risk_level == "P1")
+    firm_count = sum(
+        1 for row in rows if row.operator_coaching_mode == "firm_accountability_nudge"
+    )
+    if p1_count or firm_count:
+        return "firm_family_accountability"
+    if any(row.risk_level == "P2" for row in rows):
+        return "steady_family_motivation"
+    return "supportive_family_momentum"
+
+
+def build_team_findings(rows: Sequence[ClientShadowRow]) -> tuple[TeamFinding, ...]:
+    grouped: dict[str, list[ClientShadowRow]] = defaultdict(list)
+    for row in rows:
+        grouped[row.human_specialist].append(row)
+
+    findings: list[TeamFinding] = []
+    for specialist, specialist_rows in sorted(grouped.items()):
+        p1_count = sum(1 for row in specialist_rows if row.risk_level == "P1")
+        p2_count = sum(1 for row in specialist_rows if row.risk_level == "P2")
+        findings.append(
+            TeamFinding(
+                team_captain_id=f"team-{specialist}",
+                team_owner=TEAM_OWNER,
+                human_specialist=specialist,
+                draft_count=len(specialist_rows),
+                p1_count=p1_count,
+                p2_count=p2_count,
+                primary_action_type=_most_common([row.action_type for row in specialist_rows]),
+                primary_diagnosis_code=_most_common(
+                    [row.diagnosis_code for row in specialist_rows]
+                ),
+                primary_coaching_mode=_most_common(
+                    [row.operator_coaching_mode for row in specialist_rows]
+                ),
+                accountability_mode=_accountability_mode(specialist_rows),
+                total_event_count=sum(row.event_count for row in specialist_rows),
+                total_message_count=sum(row.message_count for row in specialist_rows),
+                input_contract_violation_count=sum(
+                    1
+                    for row in specialist_rows
+                    if row.send_whatsapp
+                    or row.crm_mutation
+                    or not row.requires_human_approval
+                ),
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(findings)
+
+
+def _coaching_classifier(row: OperatorReviewConsoleRow) -> tuple[str, str, str, str]:
+    if row.send_whatsapp or row.crm_mutation or not row.requires_human_approval:
+        return (
+            "runtime_contract_violation",
+            "firm_system_correction",
+            "stop_and_restore_human_approval_gate",
+            "no_send_no_crm_requires_human_approval",
+        )
+    if (
+        row.review_state == "ready_for_human_review"
+        and row.operator_lane != row.assigned_lane
+    ):
+        return (
+            "routing_mismatch",
+            "firm_system_correction",
+            "reroute_to_assigned_lane_before_execution",
+            "correct_lane_before_touching_client",
+        )
+    if row.review_state == "ready_for_human_review":
+        return (
+            "operator_action_required",
+            "warm_family_push",
+            "review_ready_packet_now",
+            "use_review_console_before_any_send_or_crm",
+        )
+    if row.review_state == "waiting_owner_decision":
+        return (
+            "owner_decision_block",
+            "protect_operator_focus",
+            "do_not_execute_until_owner_decides",
+            "respect_owner_gate_before_team_work",
+        )
+    if row.review_state == "deferred_owner_revisit":
+        return (
+            "owner_revisit_required",
+            "steady_owner_followup",
+            "support_owner_revisit_without_client_action",
+            "hold_deferred_case_until_owner_revisits",
+        )
+    if row.review_state == "rejected_closed":
+        return (
+            "closed_no_action",
+            "closure_discipline",
+            "record_closure_and_do_not_reopen_without_owner",
+            "do_not_execute_rejected_packet",
+        )
+    raise ValueError(f"Unsupported operator review state: {row.review_state}")
+
+
+def _team_coaching_id(row: OperatorReviewConsoleRow, index: int) -> str:
+    digest = hashlib.sha256(
+        "|".join(
+            [
+                row.assigned_lane,
+                row.operator_lane,
+                row.review_state,
+                row.console_bucket,
+                row.review_priority,
+                str(index),
+            ]
+        ).encode("utf-8")
+    ).hexdigest()[:12]
+    return f"team-coach-{index:04d}-{digest}"
+
+
+def build_operator_coaching_cards(
+    rows: Sequence[OperatorReviewConsoleRow],
+) -> tuple[TeamOperatorCoachingCard, ...]:
+    cards: list[TeamOperatorCoachingCard] = []
+    for index, row in enumerate(rows, start=1):
+        input_contract_violation = (
+            row.send_whatsapp or row.crm_mutation or not row.requires_human_approval
+        )
+        team_signal, captain_tone, operator_push, system_discipline = _coaching_classifier(
+            row
+        )
+        payload = {
+            "assigned_lane": row.assigned_lane,
+            "operator_lane": row.operator_lane,
+            "review_state": row.review_state,
+            "console_bucket": row.console_bucket,
+            "team_signal": team_signal,
+            "captain_tone": captain_tone,
+            "operator_push": operator_push,
+            "system_discipline": system_discipline,
+            "input_contract_violation": input_contract_violation,
+            "raw_text_included": False,
+            "send_whatsapp": False,
+            "crm_mutation": False,
+            "requires_human_approval": True,
+        }
+        cards.append(
+            TeamOperatorCoachingCard(
+                team_coaching_id=_team_coaching_id(row, index),
+                team_owner=TEAM_OWNER,
+                assigned_lane=row.assigned_lane,
+                operator_lane=row.operator_lane,
+                review_state=row.review_state,
+                console_bucket=row.console_bucket,
+                review_priority=row.review_priority,
+                team_signal=team_signal,
+                captain_tone=captain_tone,
+                operator_push=operator_push,
+                system_discipline=system_discipline,
+                coaching_payload=payload,
+                send_whatsapp=False,
+                crm_mutation=False,
+                requires_human_approval=True,
+            )
+        )
+    return tuple(cards)
+
+
+def build_team_depth_layers(findings: Sequence[TeamFinding]) -> tuple[TeamDepthLayer, ...]:
+    layers: list[TeamDepthLayer] = []
+    for finding in findings:
+        base_payload = {
+            "team_owner": finding.team_owner,
+            "human_specialist": finding.human_specialist,
+            "raw_text_included": False,
+            "send_whatsapp": False,
+            "crm_mutation": False,
+            "requires_human_approval": True,
+        }
+        layer_specs = [
+            (
+                1,
+                "lane_workload",
+                "Lane workload",
+                {"draft_count": finding.draft_count, "total_message_count": finding.total_message_count},
+            ),
+            (
+                2,
+                "risk_pressure",
+                "Risk pressure",
+                {"p1_count": finding.p1_count, "p2_count": finding.p2_count},
+            ),
+            (
+                3,
+                "behavior_pattern",
+                "Behavior pattern",
+                {
+                    "primary_action_type": finding.primary_action_type,
+                    "primary_diagnosis_code": finding.primary_diagnosis_code,
+                },
+            ),
+            (
+                4,
+                "motivation_plan",
+                "Motivation plan",
+                {"primary_coaching_mode": finding.primary_coaching_mode},
+            ),
+            (
+                5,
+                "accountability_nudge",
+                "Accountability nudge",
+                {"accountability_mode": finding.accountability_mode},
+            ),
+            (
+                6,
+                "team_escalation_gate",
+                "Team escalation gate",
+                {"escalate_to_owner": finding.p1_count > 0},
+            ),
+        ]
+        for depth_level, code, title, payload in layer_specs:
+            layers.append(
+                TeamDepthLayer(
+                    team_captain_id=finding.team_captain_id,
+                    depth_level=depth_level,
+                    layer_code=code,
+                    layer_title=title,
+                    layer_payload={**base_payload, **payload},
+                )
+            )
+    return tuple(layers)
+
+
+def write_team_sqlite(
+    path: Path,
+    findings: Sequence[TeamFinding],
+    layers: Sequence[TeamDepthLayer],
+    operator_coaching_cards: Sequence[TeamOperatorCoachingCard],
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        path.unlink()
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE team_runs (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                generated_at_utc TEXT NOT NULL,
+                privacy_mode TEXT NOT NULL,
+                finding_count INTEGER NOT NULL,
+                depth_layer_count INTEGER NOT NULL,
+                operator_coaching_card_count INTEGER NOT NULL,
+                input_contract_violation_count INTEGER NOT NULL,
+                send_whatsapp_count INTEGER NOT NULL,
+                crm_mutation_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE team_captain_findings (
+                team_captain_id TEXT PRIMARY KEY,
+                team_owner TEXT NOT NULL,
+                human_specialist TEXT NOT NULL,
+                draft_count INTEGER NOT NULL,
+                p1_count INTEGER NOT NULL,
+                p2_count INTEGER NOT NULL,
+                primary_action_type TEXT NOT NULL,
+                primary_diagnosis_code TEXT NOT NULL,
+                primary_coaching_mode TEXT NOT NULL,
+                accountability_mode TEXT NOT NULL,
+                total_event_count INTEGER NOT NULL,
+                total_message_count INTEGER NOT NULL,
+                input_contract_violation_count INTEGER NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+
+            CREATE TABLE team_captain_depth_layers (
+                team_captain_id TEXT NOT NULL,
+                depth_level INTEGER NOT NULL,
+                layer_code TEXT NOT NULL,
+                layer_title TEXT NOT NULL,
+                layer_payload_json TEXT NOT NULL,
+                PRIMARY KEY (team_captain_id, depth_level)
+            );
+
+            CREATE TABLE team_operator_coaching_cards (
+                team_coaching_id TEXT PRIMARY KEY,
+                team_owner TEXT NOT NULL,
+                assigned_lane TEXT NOT NULL,
+                operator_lane TEXT NOT NULL,
+                review_state TEXT NOT NULL,
+                console_bucket TEXT NOT NULL,
+                review_priority TEXT NOT NULL,
+                team_signal TEXT NOT NULL,
+                captain_tone TEXT NOT NULL,
+                operator_push TEXT NOT NULL,
+                system_discipline TEXT NOT NULL,
+                coaching_payload_json TEXT NOT NULL,
+                send_whatsapp INTEGER NOT NULL CHECK (send_whatsapp = 0),
+                crm_mutation INTEGER NOT NULL CHECK (crm_mutation = 0),
+                requires_human_approval INTEGER NOT NULL CHECK (requires_human_approval = 1)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO team_runs (
+                id, generated_at_utc, privacy_mode, finding_count, depth_layer_count,
+                operator_coaching_card_count, input_contract_violation_count,
+                send_whatsapp_count, crm_mutation_count
+            )
+            VALUES (1, ?, ?, ?, ?, ?, ?, 0, 0)
+            """,
+            (
+                datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                "local_only_team_shadow_no_send_no_crm_mutation",
+                len(findings),
+                len(layers),
+                len(operator_coaching_cards),
+                _input_contract_violation_count(findings, operator_coaching_cards),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO team_captain_findings (
+                team_captain_id, team_owner, human_specialist, draft_count,
+                p1_count, p2_count, primary_action_type, primary_diagnosis_code,
+                primary_coaching_mode, accountability_mode, total_event_count,
+                total_message_count, input_contract_violation_count,
+                send_whatsapp, crm_mutation, requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    finding.team_captain_id,
+                    finding.team_owner,
+                    finding.human_specialist,
+                    finding.draft_count,
+                    finding.p1_count,
+                    finding.p2_count,
+                    finding.primary_action_type,
+                    finding.primary_diagnosis_code,
+                    finding.primary_coaching_mode,
+                    finding.accountability_mode,
+                    finding.total_event_count,
+                    finding.total_message_count,
+                    finding.input_contract_violation_count,
+                    int(finding.send_whatsapp),
+                    int(finding.crm_mutation),
+                    int(finding.requires_human_approval),
+                )
+                for finding in findings
+            ],
+        )
+        conn.executemany(
+            """
+            INSERT INTO team_captain_depth_layers (
+                team_captain_id, depth_level, layer_code, layer_title, layer_payload_json
+            )
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    layer.team_captain_id,
+                    layer.depth_level,
+                    layer.layer_code,
+                    layer.layer_title,
+                    json.dumps(layer.layer_payload, ensure_ascii=False, sort_keys=True),
+                )
+                for layer in layers
+            ],
+        )
+        conn.executemany(
+            """
+            INSERT INTO team_operator_coaching_cards (
+                team_coaching_id, team_owner, assigned_lane, operator_lane,
+                review_state, console_bucket, review_priority, team_signal,
+                captain_tone, operator_push, system_discipline,
+                coaching_payload_json, send_whatsapp, crm_mutation,
+                requires_human_approval
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    card.team_coaching_id,
+                    card.team_owner,
+                    card.assigned_lane,
+                    card.operator_lane,
+                    card.review_state,
+                    card.console_bucket,
+                    card.review_priority,
+                    card.team_signal,
+                    card.captain_tone,
+                    card.operator_push,
+                    card.system_discipline,
+                    json.dumps(card.coaching_payload, ensure_ascii=False, sort_keys=True),
+                    int(card.send_whatsapp),
+                    int(card.crm_mutation),
+                    int(card.requires_human_approval),
+                )
+                for card in operator_coaching_cards
+            ],
+        )
+        conn.commit()
+
+
+def _counter_table(title: str, counts: Counter[str]) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "|---|---:|"]
+    if not counts:
+        lines.append("| none | 0 |")
+        return lines
+    for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| {value or 'unknown'} | {count} |")
+    return lines
+
+
+def _input_contract_violation_count(
+    findings: Sequence[TeamFinding],
+    operator_coaching_cards: Sequence[TeamOperatorCoachingCard],
+) -> int:
+    return sum(finding.input_contract_violation_count for finding in findings) + sum(
+        1
+        for card in operator_coaching_cards
+        if bool(card.coaching_payload.get("input_contract_violation"))
+    )
+
+
+def write_summary(
+    *,
+    summary_path: Path,
+    findings: Sequence[TeamFinding],
+    layers: Sequence[TeamDepthLayer],
+    operator_coaching_cards: Sequence[TeamOperatorCoachingCard],
+    generated_at_utc: str | None = None,
+) -> None:
+    generated = generated_at_utc or datetime.now(timezone.utc).isoformat(timespec="seconds")
+    specialist_counts = Counter(finding.human_specialist for finding in findings)
+    action_counts = Counter(finding.primary_action_type for finding in findings)
+    accountability_counts = Counter(finding.accountability_mode for finding in findings)
+    team_signal_counts = Counter(card.team_signal for card in operator_coaching_cards)
+    captain_tone_counts = Counter(card.captain_tone for card in operator_coaching_cards)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Zantara Team Captain Shadow Summary",
+        "",
+        f"Generated UTC: `{generated}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- This summary contains no raw message text.",
+        "- This summary contains no message snippets.",
+        "- This summary contains no phone numbers, emails, raw paths, file IDs, window IDs, or replay IDs.",
+        "- Team Shadow output is local-only and ignored under `research/personal/wa-corpus/`.",
+        "",
+        "## Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Team findings | {len(findings)} |",
+        f"| Depth layers | {len(layers)} |",
+        f"| Operator coaching cards | {len(operator_coaching_cards)} |",
+        (
+            "| Input contract violations | "
+            f"{_input_contract_violation_count(findings, operator_coaching_cards)} |"
+        ),
+        "| WhatsApp sends | 0 |",
+        "| CRM mutations | 0 |",
+        "| Human approval required | 100% |",
+        "",
+        *_counter_table("Specialist Lanes", specialist_counts),
+        "",
+        *_counter_table("Primary Action Types", action_counts),
+        "",
+        *_counter_table("Accountability Modes", accountability_counts),
+        "",
+        *_counter_table("Team Signals", team_signal_counts),
+        "",
+        *_counter_table("Captain Tones", captain_tone_counts),
+        "",
+        "## Execution Contract",
+        "",
+        "- The Team Captain motivates, coaches, and flags accountability only.",
+        "- The Team Captain can firmly correct wrong system usage or lane mismatch.",
+        "- It cannot send WhatsApp messages.",
+        "- It cannot mutate CRM records.",
+        "- Owner escalation is advisory until a human approves it.",
+    ]
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_team_captain_shadow(
+    *,
+    client_shadow_db: Path = DEFAULT_CLIENT_SHADOW_DB,
+    operator_review_console_db: Path | None = None,
+    output_dir: Path = DEFAULT_TEAM_SHADOW_DIR,
+    output_db: Path | None = None,
+    summary_path: Path = DEFAULT_SUMMARY,
+) -> TeamBuildResult:
+    output_db = output_db or output_dir / DEFAULT_OUTPUT_DB.name
+    client_rows = read_client_shadow_rows(client_shadow_db)
+    findings = build_team_findings(client_rows)
+    layers = build_team_depth_layers(findings)
+    operator_rows = (
+        read_operator_review_rows(operator_review_console_db)
+        if operator_review_console_db is not None
+        else ()
+    )
+    operator_coaching_cards = build_operator_coaching_cards(operator_rows)
+    write_team_sqlite(output_db, findings, layers, operator_coaching_cards)
+    write_summary(
+        summary_path=summary_path,
+        findings=findings,
+        layers=layers,
+        operator_coaching_cards=operator_coaching_cards,
+    )
+    return TeamBuildResult(
+        finding_count=len(findings),
+        depth_layer_count=len(layers),
+        operator_coaching_card_count=len(operator_coaching_cards),
+        input_contract_violation_count=_input_contract_violation_count(
+            findings, operator_coaching_cards
+        ),
+        send_whatsapp_count=sum(1 for finding in findings if finding.send_whatsapp),
+        crm_mutation_count=sum(1 for finding in findings if finding.crm_mutation),
+        output_db=output_db,
+        summary_path=summary_path,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build local-only Zantara Team Captain Shadow Mode findings."
+    )
+    parser.add_argument("--client-shadow-db", type=Path, default=DEFAULT_CLIENT_SHADOW_DB)
+    parser.add_argument("--operator-review-console-db", type=Path, default=None)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_TEAM_SHADOW_DIR)
+    parser.add_argument("--output-db", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = build_team_captain_shadow(
+            client_shadow_db=args.client_shadow_db,
+            operator_review_console_db=args.operator_review_console_db,
+            output_dir=args.output_dir,
+            output_db=args.output_db,
+            summary_path=args.summary,
+        )
+    except (FileNotFoundError, ValueError, TypeError):
+        # Keep this fixed literal: exception text may include local paths or DB names.
+        print("ERROR: Team Captain input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError):
+        # Keep this fixed literal: exception text may include local paths or DB names.
+        print("ERROR: Team Captain shadow run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        # CLI boundary must fail closed; the Python API still exposes details.
+        print("ERROR: Team Captain shadow run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "finding_count": result.finding_count,
+                    "depth_layer_count": result.depth_layer_count,
+                    "operator_coaching_card_count": result.operator_coaching_card_count,
+                    "input_contract_violation_count": (
+                        result.input_contract_violation_count
+                    ),
+                    "send_whatsapp_count": result.send_whatsapp_count,
+                    "crm_mutation_count": result.crm_mutation_count,
+                },
+                sort_keys=True,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/whatsapp_corpus/import_drive_exports.py
+++ b/scripts/whatsapp_corpus/import_drive_exports.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sqlite3
+import subprocess
+import sys
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Sequence
+
+DEFAULT_DRIVE_DIR = Path("research/personal/wa-corpus/drive")
+DEFAULT_MANIFEST_DB = DEFAULT_DRIVE_DIR / "drive_export_manifest.local.sqlite"
+DEFAULT_DOWNLOAD_DIR = DEFAULT_DRIVE_DIR / "downloads.local"
+DEFAULT_CORPUS_ROOT = Path.home() / "Desktop" / "wa-chats-MASTER-2026-05-26"
+DEFAULT_IMPORT_SOURCE = "03_drive-imports"
+DEFAULT_SUMMARY = DEFAULT_DRIVE_DIR / "drive_import_summary.md"
+EXPECTED_MANIFEST_DB_NAME = "drive_export_manifest.local.sqlite"
+
+Runner = Callable[[list[str]], int]
+
+
+@dataclass(frozen=True)
+class ImportCandidate:
+    file_id: str
+    raw_path: str
+    drive_id: str | None
+    size_bytes: int
+
+
+@dataclass(frozen=True)
+class ImportRowResult:
+    file_id: str
+    status: str
+    size_bytes: int
+    extracted_text_files: int
+
+
+@dataclass(frozen=True)
+class DriveImportResult:
+    selected_count: int
+    downloaded_count: int
+    extracted_text_files: int
+    failed_count: int
+    summary_path: Path
+
+
+def _default_runner(command: list[str]) -> int:
+    completed = subprocess.run(command, check=False, capture_output=True, text=True)
+    return completed.returncode
+
+
+def _connect_manifest(db_path: Path) -> sqlite3.Connection:
+    if db_path.name != EXPECTED_MANIFEST_DB_NAME:
+        raise ValueError(f"Refusing unexpected manifest DB: {db_path.name}")
+    if not db_path.exists():
+        raise FileNotFoundError(f"Manifest DB not found: {db_path}")
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _load_candidates(
+    conn: sqlite3.Connection,
+    *,
+    limit: int,
+    max_size_bytes: int | None,
+) -> list[ImportCandidate]:
+    clauses = [
+        "candidate_kind = 'whatsapp_chat_zip'",
+        "download_status = 'pending'",
+        "imported_to_corpus = 0",
+    ]
+    params: list[int] = []
+    if max_size_bytes is not None:
+        clauses.append("size_bytes <= ?")
+        params.append(max_size_bytes)
+    sql = f"""
+        SELECT file_id, raw_path, drive_id, size_bytes
+        FROM drive_export_candidates
+        WHERE {" AND ".join(clauses)}
+        ORDER BY size_bytes ASC, file_id
+        LIMIT ?
+    """
+    params.append(limit)
+    rows = conn.execute(sql, params).fetchall()
+    return [
+        ImportCandidate(
+            file_id=str(row["file_id"]),
+            raw_path=str(row["raw_path"]),
+            drive_id=str(row["drive_id"]) if row["drive_id"] else None,
+            size_bytes=int(row["size_bytes"]),
+        )
+        for row in rows
+    ]
+
+
+def _download_command(
+    *,
+    candidate: ImportCandidate,
+    remote_label: str,
+    rclone_bin: str,
+    destination_zip: Path,
+) -> list[str]:
+    if candidate.drive_id:
+        return [
+            rclone_bin,
+            "backend",
+            "copyid",
+            f"{remote_label}:",
+            candidate.drive_id,
+            str(destination_zip),
+        ]
+    return [
+        rclone_bin,
+        "copyto",
+        f"{remote_label}:{candidate.raw_path}",
+        str(destination_zip),
+    ]
+
+
+def _extract_chat_texts(
+    *,
+    zip_path: Path,
+    import_source_dir: Path,
+    file_id: str,
+) -> int:
+    destination = import_source_dir / file_id
+    if destination.exists():
+        shutil.rmtree(destination)
+    destination.mkdir(parents=True, exist_ok=True)
+
+    extracted = 0
+    with zipfile.ZipFile(zip_path) as archive:
+        for member in archive.infolist():
+            if member.is_dir() or not member.filename.lower().endswith(".txt"):
+                continue
+            extracted += 1
+            output_path = destination / f"chat-{extracted:04d}.txt"
+            with archive.open(member, "r") as source, output_path.open("wb") as target:
+                shutil.copyfileobj(source, target)
+    return extracted
+
+
+def _update_status(
+    conn: sqlite3.Connection,
+    *,
+    file_id: str,
+    status: str,
+    imported_to_corpus: bool,
+) -> None:
+    conn.execute(
+        """
+        UPDATE drive_export_candidates
+        SET download_status = ?, imported_to_corpus = ?
+        WHERE file_id = ?
+        """,
+        (status, 1 if imported_to_corpus else 0, file_id),
+    )
+
+
+def _write_summary(
+    *,
+    summary_path: Path,
+    rows: list[ImportRowResult],
+    execute: bool,
+    import_source_name: str,
+) -> None:
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    selected_count = len(rows)
+    downloaded_count = sum(1 for row in rows if row.status == "imported")
+    extracted_count = sum(row.extracted_text_files for row in rows)
+    failed_count = sum(1 for row in rows if row.status == "failed")
+    mode = "execute" if execute else "dry_run"
+    lines = [
+        "# Drive Export Import Summary",
+        "",
+        f"Generated UTC: `{datetime.now(timezone.utc).isoformat(timespec='seconds')}`",
+        "",
+        "## Privacy Mode",
+        "",
+        "- Aggregate summary only.",
+        "- No raw cloud file names.",
+        "- No raw cloud paths.",
+        "- No cloud file ids.",
+        "- Downloaded ZIPs and extracted chat TXT files stay local-only on the Pro.",
+        "",
+        "## Import Scope",
+        "",
+        f"- Mode: `{mode}`",
+        f"- Local corpus source: `{import_source_name}`",
+        "",
+        "## Global Counts",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Candidates selected | {_fmt_int(selected_count)} |",
+        f"| ZIPs imported | {_fmt_int(downloaded_count)} |",
+        f"| Text files extracted | {_fmt_int(extracted_count)} |",
+        f"| Failed candidates | {_fmt_int(failed_count)} |",
+        "",
+        "## Candidate Results",
+        "",
+        "| File ID | Status | Size bytes | Text files |",
+        "|---|---|---:|---:|",
+    ]
+    for row in rows[:50]:
+        lines.append(
+            f"| {row.file_id} | {row.status} | {_fmt_int(row.size_bytes)} | "
+            f"{_fmt_int(row.extracted_text_files)} |"
+        )
+    if len(rows) > 50:
+        lines.append(f"| more | hidden | {_fmt_int(len(rows) - 50)} | aggregate-only |")
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def import_drive_exports(
+    *,
+    manifest_db: Path = DEFAULT_MANIFEST_DB,
+    download_dir: Path = DEFAULT_DOWNLOAD_DIR,
+    corpus_root: Path = DEFAULT_CORPUS_ROOT,
+    summary_path: Path = DEFAULT_SUMMARY,
+    remote_label: str = "gdrive",
+    rclone_bin: str = "rclone",
+    import_source_name: str = DEFAULT_IMPORT_SOURCE,
+    limit: int = 10,
+    max_size_bytes: int | None = None,
+    execute: bool = False,
+    runner: Runner = _default_runner,
+) -> DriveImportResult:
+    """Import selected Drive ZIP exports into the local corpus with anonymized paths."""
+    if limit < 1:
+        raise ValueError("limit must be >= 1")
+    download_dir.mkdir(parents=True, exist_ok=True)
+    import_source_dir = corpus_root / import_source_name
+    rows: list[ImportRowResult] = []
+
+    with _connect_manifest(manifest_db) as conn:
+        candidates = _load_candidates(conn, limit=limit, max_size_bytes=max_size_bytes)
+        for candidate in candidates:
+            if not execute:
+                rows.append(
+                    ImportRowResult(
+                        file_id=candidate.file_id,
+                        status="dry_run",
+                        size_bytes=candidate.size_bytes,
+                        extracted_text_files=0,
+                    )
+                )
+                continue
+
+            destination_zip = download_dir / f"{candidate.file_id}.zip"
+            command = _download_command(
+                candidate=candidate,
+                remote_label=remote_label,
+                rclone_bin=rclone_bin,
+                destination_zip=destination_zip,
+            )
+            return_code = runner(command)
+            if return_code != 0 or not destination_zip.exists():
+                _update_status(
+                    conn,
+                    file_id=candidate.file_id,
+                    status="failed",
+                    imported_to_corpus=False,
+                )
+                rows.append(
+                    ImportRowResult(
+                        file_id=candidate.file_id,
+                        status="failed",
+                        size_bytes=candidate.size_bytes,
+                        extracted_text_files=0,
+                    )
+                )
+                continue
+
+            extracted_text_files = _extract_chat_texts(
+                zip_path=destination_zip,
+                import_source_dir=import_source_dir,
+                file_id=candidate.file_id,
+            )
+            status = "imported" if extracted_text_files else "no_text"
+            _update_status(
+                conn,
+                file_id=candidate.file_id,
+                status=status,
+                imported_to_corpus=bool(extracted_text_files),
+            )
+            rows.append(
+                ImportRowResult(
+                    file_id=candidate.file_id,
+                    status=status,
+                    size_bytes=candidate.size_bytes,
+                    extracted_text_files=extracted_text_files,
+                )
+            )
+        conn.commit()
+
+    _write_summary(
+        summary_path=summary_path,
+        rows=rows,
+        execute=execute,
+        import_source_name=import_source_name,
+    )
+    return DriveImportResult(
+        selected_count=len(rows),
+        downloaded_count=sum(1 for row in rows if row.status == "imported"),
+        extracted_text_files=sum(row.extracted_text_files for row in rows),
+        failed_count=sum(1 for row in rows if row.status == "failed"),
+        summary_path=summary_path,
+    )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Import selected Drive WhatsApp ZIP exports into the local corpus."
+    )
+    parser.add_argument("--manifest-db", type=Path, default=DEFAULT_MANIFEST_DB)
+    parser.add_argument("--download-dir", type=Path, default=DEFAULT_DOWNLOAD_DIR)
+    parser.add_argument("--corpus-root", type=Path, default=DEFAULT_CORPUS_ROOT)
+    parser.add_argument("--summary", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--remote-label", default="gdrive")
+    parser.add_argument("--rclone-bin", default="rclone")
+    parser.add_argument("--import-source-name", default=DEFAULT_IMPORT_SOURCE)
+    parser.add_argument("--limit", type=int, default=10)
+    parser.add_argument("--max-size-bytes", type=int)
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Actually download and extract selected ZIPs. Default is dry-run.",
+    )
+    parser.add_argument("--json", action="store_true", help="Print aggregate counts as JSON.")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        result = import_drive_exports(
+            manifest_db=args.manifest_db,
+            download_dir=args.download_dir,
+            corpus_root=args.corpus_root,
+            summary_path=args.summary,
+            remote_label=args.remote_label,
+            rclone_bin=args.rclone_bin,
+            import_source_name=args.import_source_name,
+            limit=args.limit,
+            max_size_bytes=args.max_size_bytes,
+            execute=args.execute,
+        )
+    except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
+        print("ERROR: Drive import input is missing or invalid.", file=sys.stderr)
+        return 1
+    except (sqlite3.Error, OSError, zipfile.BadZipFile):
+        print("ERROR: Drive import run failed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        print("ERROR: Drive import run failed safely.", file=sys.stderr)
+        return 1
+    if args.json:
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "downloaded_count": result.downloaded_count,
+                    "extracted_text_files": result.extracted_text_files,
+                    "failed_count": result.failed_count,
+                    "selected_count": result.selected_count,
+                },
+                sort_keys=True,
+            )
+            + "\n"
+        )
+    return 0 if result.failed_count == 0 else 1
+
+
+def _fmt_int(value: int) -> str:
+    return f"{value:,}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## ZANTARA Captain depth-stack (rescue promotion)

Promotes a rescued, uncommitted body of work (`refs/rescue/captain-academy-20260617`) into a tracked PR: the **ZANTARA Captain depth-stack** built atop the existing `scripts/whatsapp_corpus/` registry.

### What's in it
- **17 new `build_*` decision-chain modules** in `scripts/whatsapp_corpus/`:
  - Owner decision chain: `owner_decision_intake → compiler → cockpit → approval_console → replay` (+ inbox / packs / pipeline / event_capture / brief_renderer)
  - Captain shadow trio: `client_captain_shadow`, `owner_captain_shadow`, `team_captain_shadow` (+ `client_captain_academy`)
  - Operator packets: `operator_action_inbox`, `operator_execution_packets`, `operator_sla_clock`, `operator_packet_review_console`, `approval_routing_queue`, `approve_reject_ledger`, `breach_war_room`, `post_decision_work_order_queue`
  - Case intelligence: `case_timeline_synthesizer`, `case_memory_cards`, `case_closure_judge`, `evidence_gap_detector`, `next_best_action_ranker`
  - Drive ingest: `import_drive_exports`, `build_drive_export_manifest`
- **33 test modules** under `scripts/tests/` (+ shared `conftest.py`) and the design doc `docs/superpowers/plans/2026-06-16-zantara-captain-depth-stack.md`.

### Privacy contract (Law 2 / UU PDP)
No cloud LLM, no raw message text — modules operate on `file_id` / `path_hash` only. The CLI error paths are explicitly sanitized (generic stderr, no path/PII leakage), covered by the captain-shadow CLI tests.

### Lint note (RH005)
Fixed **10** anti-reward-hacking RH005 false-positives in the captain-shadow CLI tests. Those tests assert via a local helper `_assert_sanitized_*_cli_error(...)` (which the linter, matching `assert*`-prefixed names only, cannot see). Added an explicit trailing `assert result.returncode == 1` after each helper call — re-stating the helper's own first contract, semantics unchanged. RH lint now clean.

### Verification
- Pre-push full suite: **15235 passed, 801 skipped, 0 failed**
- 64 files, +30256 / -1
- No `.agent-task.json`, no collateral root-README change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
