### PR TITLE
feat(wa-dashboard): add Zantara case captain webapp

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_clients.py
+++ b/apps/backend-rag/backend/app/routers/crm_clients.py
@@ -5,6 +5,7 @@ Endpoints for managing client data (anagrafica clienti)
 Refactored: Migrated to asyncpg with connection pooling (2025-12-07)
 """
 
+import json
 import time
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -1720,6 +1721,69 @@ class AiSummaryResponse(BaseModel):
     status: str  # 'available' | 'not_generated' | 'pending'
 
 
+class WaCaseIntelligenceCard(BaseModel):
+    """One Zantara Captain card linked to a client's WhatsApp conversation."""
+
+    id: int
+    conversation_key: str
+    member_phone: str | None = None
+    counterpart_key: str | None = None
+    display_name: str | None = None
+    chat_kind: str
+    case_status: str
+    case_type: str | None = None
+    source_model: str
+    reasoning_effort: str | None = None
+    analysis_hash: str
+    analysis_id: str | None = None
+    message_count: int
+    unread_count: int
+    last_message_at: datetime | None = None
+    priority_score: int
+    flags: list[dict[str, Any]]
+    recap: str | None = None
+    next_action: str | None = None
+    ideal_reply: str | None = None
+    evidence: str | None = None
+    crm_packet: str | None = None
+    raw_sections: dict[str, Any]
+    analysis_output_path: str | None = None
+    generated_at: datetime | None = None
+    imported_at: datetime
+    updated_at: datetime
+
+
+class WaCaseIntelligenceResponse(BaseModel):
+    client_id: int
+    status: str  # 'available' | 'not_generated'
+    case_count: int
+    cases: list[WaCaseIntelligenceCard]
+
+
+def _coerce_json_list(value: Any) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return []
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _coerce_json_dict(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+    return value if isinstance(value, dict) else {}
+
+
 @router.get(
     "/{client_id}/ai-summary",
     operation_id="get_crm_client_ai_summary",
@@ -1851,6 +1915,68 @@ async def get_client_ai_summary(
         # CodeQL log-injection: cast to int defangs any non-numeric path.
         logger.exception(
             "ai_summary fetch failed for client %d",
+            int(client_id),
+        )
+        raise handle_database_error(e) from e
+
+
+@router.get(
+    "/{client_id}/wa-case-intelligence",
+    operation_id="get_crm_client_wa_case_intelligence",
+    response_model=WaCaseIntelligenceResponse,
+)
+async def get_client_wa_case_intelligence(
+    client_id: int,
+    limit: int = Query(12, ge=1, le=50),
+    current_user: dict = Depends(get_current_user),
+    db_pool: asyncpg.Pool = Depends(get_database_pool),
+) -> WaCaseIntelligenceResponse:
+    """Fetch Zantara Captain case cards derived from WhatsApp analysis.
+
+    This endpoint is read-only. It intentionally returns case-level intelligence
+    separately from clients.strategic_recap so the CRM can show per-conversation
+    reasoning, evidence, ideal reply, and next action without flattening multiple
+    cases into a single paragraph.
+    """
+    try:
+        async with db_pool.acquire() as conn:
+            await verify_client_access(client_id, current_user, conn, allow_assigned=True)
+            rows = await conn.fetch(
+                """
+                SELECT id, conversation_key, member_phone, counterpart_key, display_name,
+                       chat_kind, case_status, case_type, source_model, reasoning_effort,
+                       analysis_hash, analysis_id, message_count, unread_count,
+                       last_message_at, priority_score, flags, recap, next_action,
+                       ideal_reply, evidence, crm_packet, raw_sections,
+                       analysis_output_path, generated_at, imported_at, updated_at
+                FROM crm_wa_case_intelligence
+                WHERE client_id = $1
+                ORDER BY priority_score DESC, last_message_at DESC NULLS LAST, updated_at DESC
+                LIMIT $2
+                """,
+                client_id,
+                limit,
+            )
+
+            cases: list[WaCaseIntelligenceCard] = []
+            for row in rows:
+                payload = dict(row)
+                payload["flags"] = _coerce_json_list(payload.get("flags"))
+                payload["raw_sections"] = _coerce_json_dict(payload.get("raw_sections"))
+                cases.append(WaCaseIntelligenceCard(**payload))
+
+            return WaCaseIntelligenceResponse(
+                client_id=client_id,
+                status="available" if cases else "not_generated",
+                case_count=len(cases),
+                cases=cases,
+            )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(
+            "wa_case_intelligence fetch failed for client %d",
             int(client_id),
         )
         raise handle_database_error(e) from e

--- a/apps/backend-rag/backend/app/utils/crm_utils.py
+++ b/apps/backend-rag/backend/app/utils/crm_utils.py
@@ -180,10 +180,12 @@ async def verify_client_access(
             return True, assigned_to
 
         logger.warning(
-            "RBAC: User %s denied write access to client %s (assigned_to: %s)",
-            user_email,
-            client_id,
-            assigned_to,
+            "crm.rbac_client_write_denied",
+            extra={
+                "client_id": client_id,
+                "user_email_present": bool(user_email),
+                "assigned_to_present": bool(assigned_to),
+            },
         )
         raise HTTPException(
             status_code=403,
@@ -198,10 +200,12 @@ async def verify_client_access(
 
     # Access denied (only reachable if allow_assigned=False)
     logger.warning(
-        "RBAC: User %s denied access to client %s (assigned_to: %s)",
-        user_email,
-        client_id,
-        assigned_to,
+        "crm.rbac_client_access_denied",
+        extra={
+            "client_id": client_id,
+            "user_email_present": bool(user_email),
+            "assigned_to_present": bool(assigned_to),
+        },
     )
     raise HTTPException(
         status_code=403,

--- a/apps/backend-rag/backend/db/migrations_v2/232_crm_wa_case_intelligence.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/232_crm_wa_case_intelligence.sql
@@ -1,0 +1,62 @@
+-- migration 232: CRM WhatsApp case intelligence
+--
+-- Stores one Zantara Captain card per WhatsApp conversation/case linked to a
+-- CRM client. This is intentionally separate from clients.strategic_recap:
+-- the recap is the high-level client story, while this table preserves the
+-- case-level reasoning, ideal reply, evidence, and operational flags.
+
+CREATE TABLE IF NOT EXISTS crm_wa_case_intelligence (
+  id BIGSERIAL PRIMARY KEY,
+  client_id BIGINT NOT NULL REFERENCES clients(id) ON DELETE CASCADE,
+  conversation_key TEXT NOT NULL,
+  member_phone TEXT,
+  counterpart_key TEXT,
+  display_name TEXT,
+  chat_kind TEXT NOT NULL DEFAULT 'direct'
+    CHECK (chat_kind IN ('direct', 'group', 'unknown')),
+  case_status TEXT NOT NULL DEFAULT 'open'
+    CHECK (case_status IN ('open', 'waiting', 'blocked', 'done', 'archived')),
+  case_type TEXT,
+  source_model TEXT NOT NULL DEFAULT 'gpt-5.5',
+  reasoning_effort TEXT DEFAULT 'xhigh',
+  analysis_hash TEXT NOT NULL,
+  analysis_id TEXT,
+  message_count INTEGER NOT NULL DEFAULT 0,
+  unread_count INTEGER NOT NULL DEFAULT 0,
+  last_message_at TIMESTAMPTZ,
+  priority_score INTEGER NOT NULL DEFAULT 0,
+  flags JSONB NOT NULL DEFAULT '[]'::jsonb,
+  recap TEXT,
+  next_action TEXT,
+  ideal_reply TEXT,
+  evidence TEXT,
+  crm_packet TEXT,
+  raw_sections JSONB NOT NULL DEFAULT '{}'::jsonb,
+  analysis_output_path TEXT,
+  generated_at TIMESTAMPTZ,
+  imported_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT crm_wa_case_intelligence_unique_conversation
+    UNIQUE (client_id, conversation_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cwci_client_last_message
+  ON crm_wa_case_intelligence(client_id, last_message_at DESC NULLS LAST);
+
+CREATE INDEX IF NOT EXISTS idx_cwci_client_priority
+  ON crm_wa_case_intelligence(client_id, priority_score DESC, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_cwci_flags
+  ON crm_wa_case_intelligence USING GIN (flags);
+
+COMMENT ON TABLE crm_wa_case_intelligence IS
+  'Zantara Captain case cards derived from WhatsApp conversations. One row per CRM client + conversation key; stores reasoning surfaces, not raw chat logs.';
+
+COMMENT ON COLUMN crm_wa_case_intelligence.conversation_key IS
+  'Stable key from wa-dashboard analysis: chat_kind|team_member_phone|counterpart.';
+
+COMMENT ON COLUMN crm_wa_case_intelligence.crm_packet IS
+  'Human-readable CRM note candidate. Technical/debug packets must stay in raw_sections only.';
+
+-- === ROLLBACK ===
+-- DROP TABLE IF EXISTS crm_wa_case_intelligence;

--- a/apps/backend-rag/backend/db/migrations_v2/234_crm_wa_case_intelligence.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/234_crm_wa_case_intelligence.sql
@@ -1,4 +1,4 @@
--- migration 232: CRM WhatsApp case intelligence
+-- migration 234: CRM WhatsApp case intelligence
 --
 -- Stores one Zantara Captain card per WhatsApp conversation/case linked to a
 -- CRM client. This is intentionally separate from clients.strategic_recap:

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_crm_clients.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_crm_clients.py
@@ -58,6 +58,7 @@ def test_app(mock_db_pool):
     app.dependency_overrides[get_database_pool] = override_get_database_pool
     app.dependency_overrides[get_current_user] = override_get_current_user
 
+    assert app.dependency_overrides[get_database_pool] is override_get_database_pool
     return app
 
 
@@ -909,3 +910,91 @@ class TestGetClientAiSummary:
         assert isinstance(body["summary"], dict)
         assert body["summary"]["schema_version"] == "v1.0"
         assert body["summary"]["profile"]["tier"] == "VIP"
+
+
+class TestGetClientWaCaseIntelligence:
+    """Tests for GET /api/crm/clients/{client_id}/wa-case-intelligence."""
+
+    def test_case_intelligence_available(self, client, mock_db_pool):
+        pool, conn = mock_db_pool
+        now = datetime.now(tz=timezone.utc)
+
+        async def mock_fetchrow(sql, *args):
+            return {"id": 70, "assigned_to": None, "created_by": None}
+
+        conn.fetchrow = mock_fetchrow
+        conn.fetch = AsyncMock(
+            return_value=[
+                {
+                    "id": 1,
+                    "conversation_key": "direct|+6281|+3933",
+                    "member_phone": "+6281",
+                    "counterpart_key": "+3933",
+                    "display_name": "Kerrie",
+                    "chat_kind": "direct",
+                    "case_status": "open",
+                    "case_type": "referral lead",
+                    "source_model": "gpt-5.5",
+                    "reasoning_effort": "xhigh",
+                    "analysis_hash": "abc123",
+                    "analysis_id": "0dc5d3f74653-kerrie-adit",
+                    "message_count": 32,
+                    "unread_count": 0,
+                    "last_message_at": now,
+                    "priority_score": 78,
+                    "flags": '[{"id":"crm_collision","label":"CRM/thread collision"}]',
+                    "recap": "Client referred a friend and has a separate admin case.",
+                    "next_action": "Qualify the referral before quoting.",
+                    "ideal_reply": "Hi Kerrie, thanks. Can you confirm the activity and timing?",
+                    "evidence": "Messages 4-8 discuss the referral.",
+                    "crm_packet": "Kerrie has two separate tracks to keep apart.",
+                    "raw_sections": '{"state":"Two cases are merged in the chat."}',
+                    "analysis_output_path": "analyses/0dc5d3f74653-kerrie-adit.md",
+                    "generated_at": now,
+                    "imported_at": now,
+                    "updated_at": now,
+                }
+            ]
+        )
+
+        response = client.get("/api/crm/clients/70/wa-case-intelligence")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "available"
+        assert body["case_count"] == 1
+        assert body["cases"][0]["display_name"] == "Kerrie"
+        assert body["cases"][0]["flags"][0]["id"] == "crm_collision"
+        assert body["cases"][0]["raw_sections"]["state"] == "Two cases are merged in the chat."
+
+    def test_case_intelligence_not_generated(self, client, mock_db_pool):
+        pool, conn = mock_db_pool
+
+        async def mock_fetchrow(sql, *args):
+            return {"id": 70, "assigned_to": None, "created_by": None}
+
+        conn.fetchrow = mock_fetchrow
+        conn.fetch = AsyncMock(return_value=[])
+
+        response = client.get("/api/crm/clients/70/wa-case-intelligence")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "client_id": 70,
+            "status": "not_generated",
+            "case_count": 0,
+            "cases": [],
+        }
+
+    def test_case_intelligence_client_not_found(self, client, mock_db_pool):
+        pool, conn = mock_db_pool
+
+        async def mock_fetchrow(sql, *args):
+            return None
+
+        conn.fetchrow = mock_fetchrow
+
+        response = client.get("/api/crm/clients/99999/wa-case-intelligence")
+
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()

--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/OverviewTab.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/OverviewTab.tsx
@@ -32,6 +32,7 @@ import { PassportCard } from "./PassportCard";
 import { VisaCard } from "./VisaCard";
 import { AiSummaryCard } from "./AiSummaryCard";
 import { OracleChat } from "./OracleChat";
+import { WaCaseIntelligencePanel } from "./WaCaseIntelligencePanel";
 
 const INTERACTION_ICONS: Record<string, typeof MessageCircle> = {
   chat: MessageCircle,
@@ -97,6 +98,8 @@ export function OverviewTab({
       <AiSummaryCard clientId={clientId} section="overview" />
       {/* Oracle Chat — NLM-powered Q&A */}
       <OracleChat clientId={clientId} />
+      {/* WhatsApp Case Intelligence — GPT-5.5 case cards linked to this CRM profile */}
+      <WaCaseIntelligencePanel clientId={clientId} />
       {/* 3 Columns Layout - Team Member | Passport | Visa */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 items-stretch">
         {/* COLUMN 1: Client Info */}

--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/WaCaseIntelligencePanel.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/WaCaseIntelligencePanel.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  MessageCircle,
+  RefreshCw,
+  Sparkles,
+} from "lucide-react";
+import { api } from "@/lib/api";
+import { logger } from "@/lib/logger";
+import type {
+  WaCaseIntelligenceCard,
+  WaCaseIntelligenceResponse,
+} from "@/lib/api/crm/crm.types";
+
+interface WaCaseIntelligencePanelProps {
+  clientId: number;
+}
+
+function formatRelativeTime(iso?: string | null): string {
+  if (!iso) return "unknown";
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return "unknown";
+  const diffMs = Date.now() - ts;
+  const diffH = Math.floor(diffMs / 3600000);
+  if (diffH < 1) return "<1h ago";
+  if (diffH < 24) return `${diffH}h ago`;
+  const diffD = Math.floor(diffH / 24);
+  if (diffD < 30) return `${diffD}d ago`;
+  const diffM = Math.floor(diffD / 30);
+  return `${diffM}mo ago`;
+}
+
+function statusClass(status: string): string {
+  switch (status) {
+    case "blocked":
+      return "border-red-500/40 bg-red-500/10 text-red-300";
+    case "waiting":
+      return "border-yellow-500/40 bg-yellow-500/10 text-yellow-300";
+    case "done":
+      return "border-green-500/40 bg-green-500/10 text-green-300";
+    default:
+      return "border-blue-500/40 bg-blue-500/10 text-blue-300";
+  }
+}
+
+function textBlock(label: string, value?: string | null) {
+  if (!value) return null;
+  return (
+    <div>
+      <p className="text-[10px] uppercase tracking-[0.14em] text-[var(--bz-text-2)]">
+        {label}
+      </p>
+      <p className="mt-1 whitespace-pre-line text-sm leading-relaxed text-[var(--bz-text-1)]">
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function CaseRow({
+  item,
+  expanded,
+  onToggle,
+}: {
+  item: WaCaseIntelligenceCard;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const Icon = expanded ? ChevronDown : ChevronRight;
+  const flags = item.flags || [];
+
+  return (
+    <div className="border-t border-[var(--bz-border)] first:border-t-0">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-white/[0.03]"
+      >
+        <Icon className="mt-1 h-4 w-4 shrink-0 text-[var(--bz-text-2)]" />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="truncate text-sm font-semibold text-[var(--bz-text-1)]">
+              {item.display_name || item.counterpart_key || "WhatsApp case"}
+            </p>
+            <span
+              className={`rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${statusClass(item.case_status)}`}
+            >
+              {item.case_status}
+            </span>
+            {item.case_type && (
+              <span className="rounded-full border border-[var(--bz-border)] px-2 py-0.5 text-[10px] text-[var(--bz-text-2)]">
+                {item.case_type}
+              </span>
+            )}
+          </div>
+          {item.recap && (
+            <p className="mt-1 line-clamp-2 text-sm leading-relaxed text-[var(--bz-text-2)]">
+              {item.recap}
+            </p>
+          )}
+          <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px] text-[var(--bz-text-2)]">
+            <span className="inline-flex items-center gap-1">
+              <MessageCircle className="h-3 w-3" />
+              {item.message_count} messages
+            </span>
+            <span className="inline-flex items-center gap-1">
+              <Clock className="h-3 w-3" />
+              {formatRelativeTime(item.last_message_at)}
+            </span>
+            <span>{item.source_model}</span>
+          </div>
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="space-y-4 px-8 pb-4">
+          {flags.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {flags.map((flag, index) => (
+                <span
+                  key={`${flag.id || flag.label}-${index}`}
+                  className="inline-flex items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-[11px] text-amber-200"
+                >
+                  <AlertTriangle className="h-3 w-3" />
+                  {flag.label}
+                </span>
+              ))}
+            </div>
+          )}
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            {textBlock("Next action", item.next_action)}
+            {textBlock("Ideal reply", item.ideal_reply)}
+          </div>
+          {textBlock("Evidence", item.evidence)}
+          {textBlock("CRM note", item.crm_packet)}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function WaCaseIntelligencePanel({
+  clientId,
+}: WaCaseIntelligencePanelProps) {
+  const [response, setResponse] = useState<WaCaseIntelligenceResponse | null>(
+    null,
+  );
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+
+  const fetchCases = useCallback(async () => {
+    try {
+      const data = await api.crm.getClientWaCaseIntelligence(clientId);
+      setResponse(data);
+      setExpandedId(data.cases[0]?.id ?? null);
+      setError(null);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(msg);
+      logger.error(`WA case intelligence fetch failed for client ${clientId}`, {
+        component: "WaCaseIntelligencePanel",
+        itemId: String(clientId),
+        reason: msg,
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [clientId]);
+
+  useEffect(() => {
+    fetchCases();
+  }, [fetchCases]);
+
+  if (loading) {
+    return (
+      <div className="rounded-lg border border-gray-700/50 bg-gray-900/40 p-4">
+        <div className="flex items-center gap-2 text-sm text-gray-400">
+          <Sparkles className="h-4 w-4 animate-pulse" />
+          <span>Loading WhatsApp intelligence...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-700/40 bg-red-950/20 p-4">
+        <div className="flex items-start gap-2 text-sm text-red-400">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+          <div>
+            <div className="font-medium">
+              Failed to load WhatsApp intelligence
+            </div>
+            <div className="mt-1 text-xs text-red-300/70">{error}</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!response || response.status === "not_generated") return null;
+
+  return (
+    <section className="overflow-hidden rounded-lg border border-emerald-500/30 bg-gray-900/40">
+      <div className="flex items-start justify-between gap-3 border-b border-[var(--bz-border)] px-4 py-3">
+        <div className="flex items-center gap-2">
+          <MessageCircle className="h-4 w-4 text-emerald-300" />
+          <h3 className="text-sm font-semibold text-[var(--bz-text-1)]">
+            WhatsApp Case Intelligence
+          </h3>
+          <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] text-emerald-200">
+            {response.case_count}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={fetchCases}
+          className="rounded p-1 text-[var(--bz-text-2)] transition-colors hover:bg-white/[0.06] hover:text-[var(--bz-text-1)]"
+          title="Refresh WhatsApp intelligence"
+          aria-label="Refresh WhatsApp intelligence"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      <div>
+        {response.cases.map((item) => (
+          <CaseRow
+            key={item.id}
+            item={item}
+            expanded={expandedId === item.id}
+            onToggle={() =>
+              setExpandedId(expandedId === item.id ? null : item.id)
+            }
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/mouth/src/lib/api/crm/crm.api.ts
+++ b/apps/mouth/src/lib/api/crm/crm.api.ts
@@ -26,6 +26,7 @@ import type {
   TaxCompanyPilotKey,
   TaxCompanyPilotMap,
   AiSummaryResponse,
+  WaCaseIntelligenceResponse,
   WorkspaceAiAutoApproveResult,
   WorkspaceAiSnapshotReviewItem,
   WorkspaceAiSnapshotReviewStatus,
@@ -529,6 +530,20 @@ export class CrmApi {
   async getClientAiSummary(clientId: number): Promise<AiSummaryResponse> {
     return this.client.request<AiSummaryResponse>(
       `/api/crm/clients/${clientId}/ai-summary`,
+      undefined,
+      10000,
+    );
+  }
+
+  /**
+   * Get Zantara Captain WhatsApp case cards for a client.
+   */
+  async getClientWaCaseIntelligence(
+    clientId: number,
+    limit: number = 12,
+  ): Promise<WaCaseIntelligenceResponse> {
+    return this.client.request<WaCaseIntelligenceResponse>(
+      `/api/crm/clients/${clientId}/wa-case-intelligence?limit=${limit}`,
       undefined,
       10000,
     );

--- a/apps/mouth/src/lib/api/crm/crm.types.ts
+++ b/apps/mouth/src/lib/api/crm/crm.types.ts
@@ -1043,6 +1043,48 @@ export interface AiSummaryResponse {
   status: "available" | "not_generated" | "pending";
 }
 
+export interface WaCaseIntelligenceFlag {
+  id?: string;
+  label: string;
+}
+
+export interface WaCaseIntelligenceCard {
+  id: number;
+  conversation_key: string;
+  member_phone?: string | null;
+  counterpart_key?: string | null;
+  display_name?: string | null;
+  chat_kind: "direct" | "group" | "unknown" | string;
+  case_status: "open" | "waiting" | "blocked" | "done" | "archived" | string;
+  case_type?: string | null;
+  source_model: string;
+  reasoning_effort?: string | null;
+  analysis_hash: string;
+  analysis_id?: string | null;
+  message_count: number;
+  unread_count: number;
+  last_message_at?: string | null;
+  priority_score: number;
+  flags: WaCaseIntelligenceFlag[];
+  recap?: string | null;
+  next_action?: string | null;
+  ideal_reply?: string | null;
+  evidence?: string | null;
+  crm_packet?: string | null;
+  raw_sections: Record<string, unknown>;
+  analysis_output_path?: string | null;
+  generated_at?: string | null;
+  imported_at: string;
+  updated_at: string;
+}
+
+export interface WaCaseIntelligenceResponse {
+  client_id: number;
+  status: "available" | "not_generated";
+  case_count: number;
+  cases: WaCaseIntelligenceCard[];
+}
+
 export interface L1ClientSummary {
   schema_version: string;
   prompt_version?: string;

--- a/apps/wa-dashboard-m1/README.md
+++ b/apps/wa-dashboard-m1/README.md
@@ -1,4 +1,4 @@
-# wa-dashboard-m1 — Bali Zero WhatsApp 3-column read-only dashboard
+# wa-dashboard-m1 — Bali Zero WhatsApp local read-only webapp
 
 Replica del pattern M1 single-page (`~/bin/wa-viewer/`) puntata al DB di produzione
 (Fly Postgres `nuzantara-postgres.flycast`) via il proxy locale `fly-pg-proxy` su
@@ -6,9 +6,10 @@ Replica del pattern M1 single-page (`~/bin/wa-viewer/`) puntata al DB di produzi
 
 ## Layout
 
-- **Col 1**: 9 team Bali Zero da `~/.wa-mirror.accounts.json`
-- **Col 2**: Conversazioni del team selezionato (direct + group), ordinate per ultimo msg
-- **Col 3**: Messaggi della conversazione selezionata, ordine cronologico ASC, day dividers
+- **Conversazioni live**: 3 colonne WhatsApp-style, con team, thread e messaggi in read-only.
+- **Zantara risolve**: vista shadow del caso selezionato: segnali letti, diagnosi, next best action, bozza e gate umano.
+- **Training academy**: indice human-readable degli artefatti Zantara Client/Team/Owner Captain già generati e futuri.
+- **Team**: metriche aggregate per operatore, senza testo raw o PII esposta.
 
 ## Run locale
 
@@ -22,6 +23,7 @@ open http://127.0.0.1:7790
 Variabili env opzionali:
 - `WA_DASHBOARD_DATABASE_URL` (default: pg-proxy localhost:15432 → Fly DB)
 - `WA_MIRROR_ACCOUNTS_JSON` (default: `~/.wa-mirror.accounts.json`)
+- `WA_TRAINING_CORPUS_DIR` (default: `../../research/personal/wa-corpus`)
 - `PORT`, `HOST`
 
 ## Endpoint
@@ -29,12 +31,54 @@ Variabili env opzionali:
 | URL | Output |
 |---|---|
 | `GET /` | viewer.html |
-| `GET /health.json` | `{ok, db_now, team_size, db_url_host}` |
-| `GET /data.json` | overview teams + convs (5s cache) |
+| `GET /health.json` | `{ok, status, db_ok, db_now, db_error, team_size, db_url_host}` |
+| `GET /data.json` | overview teams + convs (5s cache); degraded shell if DB is unavailable |
+| `GET /training.json` | local training/shadow summary index from Markdown summaries only |
 | `GET /thread.json?member=<phone>&conv=<key>` | 500 messaggi conv |
 | `GET /metrics.json?window=<days>` | aggregati qualità per operatore (live, cache 60s) |
 | `GET /metrics-history.json?days=<n>` | trend storico da `wa_team_daily_metrics` |
 | `POST /metrics-rollup?window=<days>` | snapshot giornaliero → UPSERT (idempotente per giorno) |
+
+## Zantara Training (tab "Training")
+
+La terza vista legge in modo dinamico tutti i file `*_summary.md` sotto
+`research/personal/wa-corpus`, quindi include sia i training già generati sia quelli
+che verranno prodotti dai prossimi batch. Espone solo metriche e contratti dai
+summary Markdown: non legge né mostra JSONL raw, SQLite, testo messaggi, telefoni,
+email o ID caso.
+
+La UI è costruita per capire a colpo d'occhio:
+
+- cosa Zantara sta imparando: academy examples, replay scenarios, shadow drafts,
+  owner approval signals, owner/team/client artifacts;
+- quanto è pronta: conteggi aggregati per categoria e ultimi aggiornamenti;
+- cosa non fa da sola: `whatsapp_sends=0`, `crm_mutations=0`, local-only,
+  approval umano obbligatorio.
+
+Il contratto operativo resta read-only/shadow: la dashboard non invia WhatsApp, non
+scrive CRM, non muta training artifacts e non espone dati raw.
+
+## Zantara Risolve
+
+La vista "Zantara risolve" non chiama un modello e non inventa una soluzione:
+traduce i segnali già presenti nella conversazione selezionata in una diagnosi
+operativa leggibile. Per ogni caso mostra:
+
+- tipo conversazione: cliente CRM, prospect/lead, gruppo cliente o thread interno;
+- segnali disponibili: CRM match, owner operativo, priorità, unread, gruppo;
+- ragionamento operativo: contesto, blocco probabile, decisione richiesta;
+- prossima azione e bozza shadow;
+- gate umano: invio WhatsApp e scritture CRM restano manuali.
+
+La stessa carta appare anche sopra il thread nella tab "Conversazioni live", così
+messaggi e ragionamento restano nello stesso punto di lavoro.
+
+## Modalità degradata
+
+`/health.json` e `/data.json` non tornano più 500 quando Postgres locale è offline:
+la webapp resta aperta, mostra il team shell e mantiene disponibile la tab Training.
+Le conversazioni e le metriche live richiedono comunque che il DB locale/proxy torni
+raggiungibile.
 
 ## Team Quality (tab "Qualità Team")
 

--- a/apps/wa-dashboard-m1/README.md
+++ b/apps/wa-dashboard-m1/README.md
@@ -62,16 +62,20 @@ scrive CRM, non muta training artifacts e non espone dati raw.
 
 La vista "Zantara risolve" non chiama un modello e non inventa una soluzione:
 traduce i segnali già presenti nella conversazione selezionata in una diagnosi
-operativa leggibile. Per ogni caso mostra:
+operativa leggibile. In local Pro mode può mostrare PII dentro la UI locale
+perché non lascia la macchina. Per ogni caso mostra:
 
 - tipo conversazione: cliente CRM, prospect/lead, gruppo cliente o thread interno;
 - segnali disponibili: CRM match, owner operativo, priorità, unread, gruppo;
+- contesto reale locale: ultimo inbound/outbound del thread caricato;
 - ragionamento operativo: contesto, blocco probabile, decisione richiesta;
 - prossima azione e bozza shadow;
 - gate umano: invio WhatsApp e scritture CRM restano manuali.
 
 La stessa carta appare anche sopra il thread nella tab "Conversazioni live", così
 messaggi e ragionamento restano nello stesso punto di lavoro.
+La PII resta ammessa nella UI locale, non nei commit, PR, report condivisi, log
+lunghi o chiamate cloud.
 
 ## Modalità degradata
 

--- a/apps/wa-dashboard-m1/analysis-index.cjs
+++ b/apps/wa-dashboard-m1/analysis-index.cjs
@@ -1,0 +1,384 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const DEFAULT_ANALYSIS_DIR = path.join(
+  os.homedir(),
+  ".codex",
+  "wa-captain-analysis",
+);
+const CACHE_MS = 15000;
+const MAX_SECTION_CHARS = 1800;
+const MAX_TABLE_TEXT_CHARS = 420;
+
+let CACHE = { at: 0, baseDir: null, payload: null };
+
+function analysisBaseDir() {
+  return process.env.WA_CAPTAIN_ANALYSIS_DIR || DEFAULT_ANALYSIS_DIR;
+}
+
+function safeJson(line) {
+  try {
+    return JSON.parse(line);
+  } catch {
+    return null;
+  }
+}
+
+function readLatestManifestRows(baseDir) {
+  const manifestPath = path.join(baseDir, "manifest.jsonl");
+  if (!fs.existsSync(manifestPath)) {
+    return { manifestPath, latestRows: [], rawRows: 0, statusCounts: {} };
+  }
+
+  const lines = fs
+    .readFileSync(manifestPath, "utf8")
+    .split(/\r?\n/)
+    .filter(Boolean);
+  const latest = new Map();
+  const statusCounts = {};
+  for (const line of lines) {
+    const row = safeJson(line);
+    if (!row || !row.key) continue;
+    latest.set(row.key, row);
+  }
+
+  for (const row of latest.values()) {
+    const status = row.status || "unknown";
+    statusCounts[status] = (statusCounts[status] || 0) + 1;
+  }
+
+  return {
+    manifestPath,
+    latestRows: Array.from(latest.values()),
+    rawRows: lines.length,
+    statusCounts,
+  };
+}
+
+function readTextIfExists(filePath) {
+  if (!filePath || !fs.existsSync(filePath)) return "";
+  const stat = fs.statSync(filePath);
+  if (!stat.isFile() || stat.size < 20) return "";
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function trimText(value, maxChars = MAX_SECTION_CHARS) {
+  const text = String(value || "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars - 1).trim()}…`;
+}
+
+function stripCodeFence(text) {
+  return String(text || "")
+    .replace(/^```(?:text|yaml|yml|json)?\s*/i, "")
+    .replace(/\s*```$/i, "")
+    .trim();
+}
+
+function normalizeHeadingTitle(title) {
+  return String(title || "")
+    .replace(/\*/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function isKnownAnalysisHeading(title) {
+  const normalized = normalizeHeadingTitle(title);
+  return /^(tipo|stato|prove|eviden|cosa zantara|next action|prossima|risposta whatsapp|ideal|packet|crm|internal|cosa un dashboard|errore dashboard|deterministico|training label|training labels|gold label)\b/i.test(
+    normalized,
+  );
+}
+
+function parseSections(markdown) {
+  const sections = {};
+  let current = null;
+  let buffer = [];
+
+  const flush = () => {
+    if (!current) return;
+    const text = trimText(buffer.join("\n"));
+    sections[current.number] = {
+      number: current.number,
+      title: current.title,
+      text,
+    };
+    buffer = [];
+  };
+
+  for (const line of String(markdown || "").split(/\r?\n/)) {
+    const isMarkdownHeading = /^\s*#{1,6}\s+/.test(line);
+    const clean = line
+      .trim()
+      .replace(/^#{1,6}\s*/, "")
+      .replace(/\*\*/g, "")
+      .trim();
+    const match = clean.match(/^(\d+)\s*[\).]?\s*(.+?)\s*$/);
+    if (
+      match &&
+      Number(match[1]) >= 1 &&
+      Number(match[1]) <= 12 &&
+      match[2].length <= 90 &&
+      (isMarkdownHeading || isKnownAnalysisHeading(match[2]))
+    ) {
+      flush();
+      current = {
+        number: Number(match[1]),
+        title: match[2].trim(),
+      };
+      continue;
+    }
+    if (current) buffer.push(line);
+  }
+  flush();
+
+  return sections;
+}
+
+function findSection(sections, number, titleHints = []) {
+  if (sections[number]?.text) return stripCodeFence(sections[number].text);
+  const hints = titleHints.map(normalizeHeadingTitle);
+  for (const section of Object.values(sections)) {
+    const title = normalizeHeadingTitle(section.title);
+    if (hints.some((hint) => title.includes(hint)))
+      return stripCodeFence(section.text);
+  }
+  return "";
+}
+
+function flagSpecs() {
+  return [
+    [
+      "crm_collision",
+      "CRM/thread collision",
+      /crm_collision:\s*true|thread_collision:\s*true|actor_collision_detected:\s*true|identity_resolution_needed:\s*true|collisione\s+(forte|alta|reale)|rischio\s+(crm|di collisione)|thread attribution collision|etichettat[oa].*ma/i,
+    ],
+    [
+      "multi_case",
+      "Multi-caso",
+      /multi[-\s]?cas[oi]|sotto[-\s]?cas[oi]|casi distinti|pratiche diverse|separare.*cas/i,
+    ],
+    [
+      "media_review",
+      "Media/artifact review",
+      /media senza|allegat[oi].*verific|attachment.*verify|verify.*attachment|artifact_verification|pdf|documento.*verific|foto|immagine|ocr|file.*corretto/i,
+    ],
+    [
+      "pricingtool_required",
+      "PricingTool",
+      /pricing_required:\s*true|requires_pricing_tool:\s*true|requires.*PricingTool|usare\s+PricingTool|generare.*PricingTool|prezzo.*PricingTool|should_not_invent_price:\s*true/i,
+    ],
+    [
+      "security_credentials",
+      "Credenziali/sicurezza",
+      /otp|password|pin|credenzial|login|coretax|bank statement|passport|passaporto|ktp|npwp/i,
+    ],
+    [
+      "compliance",
+      "Compliance",
+      /compliance|oss|bpjs|wlkp|kanim|overstay|kpk|visa|permesso|legal/i,
+    ],
+    [
+      "deadline_or_overstay",
+      "Deadline/urgenza",
+      /urgent|urgente|scadenza|deadline|expiry|expired|overstay|entro oggi|p0|p1/i,
+    ],
+    [
+      "needs_reply",
+      "Needs reply",
+      /requires_follow_up:\s*true|needs_reply:\s*true|palla aperta|serve.*rispondere|rispondere.*cliente|follow[-\s]?up.*cliente/i,
+    ],
+    [
+      "reported_done_not_closed",
+      "Done non provato",
+      /acknowledgement_only|not_proven_completed|non prova|non chiuso|not completed|reported.*done/i,
+    ],
+    [
+      "internal_ops",
+      "Internal ops",
+      /conversation_type:\s*internal|internal_ops|chat interna|conversazione interna|customer_visible:\s*false|collega interna|liaison/i,
+    ],
+    [
+      "owner_decision",
+      "Owner decision",
+      /owner[_\s-]?decision|requires_owner|approval_required|decisione owner|approvazione owner|owner deve|owner:/i,
+    ],
+  ];
+}
+
+function detectFlags(fullText) {
+  const hits = [];
+  for (const [id, label, re] of flagSpecs()) {
+    if (re.test(fullText)) hits.push({ id, label });
+  }
+  return hits;
+}
+
+function priorityScore(row, flags, sections) {
+  const flagIds = new Set(flags.map((f) => f.id));
+  let score = 0;
+  if ((row.unread || 0) > 0) score += 35;
+  if ((row.n || 0) >= 100) score += 12;
+  if ((row.n || 0) >= 40) score += 7;
+  if (flagIds.has("deadline_or_overstay")) score += 35;
+  if (flagIds.has("security_credentials")) score += 30;
+  if (flagIds.has("compliance")) score += 24;
+  if (flagIds.has("crm_collision")) score += 20;
+  if (flagIds.has("pricingtool_required")) score += 18;
+  if (flagIds.has("reported_done_not_closed")) score += 18;
+  if (flagIds.has("media_review")) score += 12;
+  if (flagIds.has("owner_decision")) score += 10;
+  if (flagIds.has("multi_case")) score += 10;
+  if (sections.action) score += 6;
+  if (sections.ideal_reply) score += 5;
+  return score;
+}
+
+function caseKindLabel(row) {
+  if (row.kind === "group") return "group";
+  return "direct";
+}
+
+function buildAnalysisItem(row, baseDir) {
+  const outputPath = row.outputPath || "";
+  const markdown = readTextIfExists(outputPath);
+  if (!markdown) return null;
+
+  const parsed = parseSections(markdown);
+  const sections = {
+    type: findSection(parsed, 1, ["tipo", "attori"]),
+    state: findSection(parsed, 2, ["stato reale", "stato"]),
+    evidence: findSection(parsed, 3, ["prove", "eviden"]),
+    action: findSection(parsed, 4, ["cosa zantara", "next action", "prossima"]),
+    ideal_reply: findSection(parsed, 5, ["risposta whatsapp", "ideal"]),
+    crm_packet: findSection(parsed, 6, ["packet", "crm", "internal"]),
+    deterministic_failure: findSection(parsed, 7, [
+      "errore dashboard",
+      "deterministico",
+      "sbaglierebbe",
+    ]),
+    training_labels: findSection(parsed, 8, ["training label", "gold label"]),
+  };
+  const fullText = `${row.label || ""}\n${markdown}`;
+  const flags = detectFlags(fullText);
+  const stat = fs.statSync(outputPath);
+
+  return {
+    key: row.key,
+    label: row.label || row.key,
+    kind: row.kind || "unknown",
+    kind_label: caseKindLabel(row),
+    team: row.team || "",
+    display: row.display || "",
+    n: row.n || 0,
+    unread: row.unread || 0,
+    last_at: row.last_at || null,
+    status: row.status || "unknown",
+    analysis_id: path.basename(outputPath, ".md"),
+    relative_path: path.relative(baseDir, outputPath),
+    output_mtime: stat.mtime.toISOString(),
+    flags,
+    flag_ids: flags.map((f) => f.id),
+    priority_score: priorityScore(row, flags, sections),
+    summary: trimText(
+      sections.state || sections.type || "",
+      MAX_TABLE_TEXT_CHARS,
+    ),
+    next_action: trimText(sections.action || "", MAX_TABLE_TEXT_CHARS),
+    ideal_reply: trimText(sections.ideal_reply || "", MAX_TABLE_TEXT_CHARS),
+    sections,
+  };
+}
+
+function buildRiskCounts(items) {
+  const counts = {};
+  for (const item of items) {
+    for (const id of item.flag_ids || []) {
+      counts[id] = (counts[id] || 0) + 1;
+    }
+  }
+  return counts;
+}
+
+function buildCategoryCounts(items) {
+  const groups = { direct: 0, group: 0, unknown: 0 };
+  for (const item of items) {
+    groups[item.kind] = (groups[item.kind] || 0) + 1;
+  }
+  return groups;
+}
+
+function buildAnalysisIndexPayload(options = {}) {
+  const baseDir = analysisBaseDir();
+  const now = Date.now();
+  if (
+    !options.force &&
+    CACHE.payload &&
+    CACHE.baseDir === baseDir &&
+    now - CACHE.at < CACHE_MS
+  ) {
+    return CACHE.payload;
+  }
+
+  const { manifestPath, latestRows, rawRows, statusCounts } =
+    readLatestManifestRows(baseDir);
+  const items = latestRows
+    .map((row) => buildAnalysisItem(row, baseDir))
+    .filter(Boolean)
+    .sort((a, b) => {
+      if (b.priority_score !== a.priority_score)
+        return b.priority_score - a.priority_score;
+      return new Date(b.last_at || 0) - new Date(a.last_at || 0);
+    });
+
+  const riskCounts = buildRiskCounts(items);
+  const categoryCounts = buildCategoryCounts(items);
+  const totalFlags = Object.values(riskCounts).reduce(
+    (sum, count) => sum + count,
+    0,
+  );
+
+  const payload = {
+    generated_at: new Date().toISOString(),
+    exists: fs.existsSync(baseDir),
+    base_dir: baseDir,
+    manifest_path: manifestPath,
+    raw_manifest_rows: rawRows,
+    manifest_latest_status: statusCounts,
+    analysis_count: items.length,
+    valid_count: items.length,
+    category_counts: categoryCounts,
+    risk_counts: riskCounts,
+    total_risk_flags: totalFlags,
+    total_cards: {
+      gpt55_conversations: String(items.length),
+      valid_analyses: String(items.length),
+      crm_collisions: String(riskCounts.crm_collision || 0),
+      media_reviews: String(riskCounts.media_review || 0),
+      pricingtool_required: String(riskCounts.pricingtool_required || 0),
+      wa_sends: "0",
+      crm_writes: "0",
+    },
+    filters: flagSpecs()
+      .map(([id, label]) => ({
+        id,
+        label,
+        count: riskCounts[id] || 0,
+      }))
+      .filter((f) => f.count > 0),
+    items,
+  };
+
+  CACHE = { at: now, baseDir, payload };
+  return payload;
+}
+
+module.exports = {
+  buildAnalysisIndexPayload,
+};

--- a/apps/wa-dashboard-m1/analysis-index.cjs
+++ b/apps/wa-dashboard-m1/analysis-index.cjs
@@ -59,11 +59,28 @@ function readLatestManifestRows(baseDir) {
   };
 }
 
-function readTextIfExists(filePath) {
-  if (!filePath || !fs.existsSync(filePath)) return "";
-  const stat = fs.statSync(filePath);
-  if (!stat.isFile() || stat.size < 20) return "";
-  return fs.readFileSync(filePath, "utf8");
+function isPathInside(parentDir, childPath) {
+  const parent = path.resolve(parentDir);
+  const child = path.resolve(childPath);
+  return child === parent || child.startsWith(`${parent}${path.sep}`);
+}
+
+function readFileSnapshot(filePath) {
+  if (!filePath) return null;
+  let fd;
+  try {
+    fd = fs.openSync(filePath, "r");
+    const stat = fs.fstatSync(fd);
+    if (!stat.isFile() || stat.size < 20) return null;
+    return {
+      text: fs.readFileSync(fd, "utf8"),
+      mtime: stat.mtime,
+    };
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+  }
 }
 
 function trimText(value, maxChars = MAX_SECTION_CHARS) {
@@ -100,6 +117,7 @@ function parseSections(markdown) {
   const sections = {};
   let current = null;
   let buffer = [];
+  const source = typeof markdown === "string" ? markdown : "";
 
   const flush = () => {
     if (!current) return;
@@ -112,7 +130,7 @@ function parseSections(markdown) {
     buffer = [];
   };
 
-  for (const line of String(markdown || "").split(/\r?\n/)) {
+  for (const line of source.split(/\r?\n/)) {
     const isMarkdownHeading = /^\s*#{1,6}\s+/.test(line);
     const clean = line
       .trim()
@@ -247,10 +265,11 @@ function caseKindLabel(row) {
 
 function buildAnalysisItem(row, baseDir) {
   const outputPath = row.outputPath || "";
-  const markdown = readTextIfExists(outputPath);
-  if (!markdown) return null;
+  if (!isPathInside(baseDir, outputPath)) return null;
+  const snapshot = readFileSnapshot(outputPath);
+  if (!snapshot?.text) return null;
 
-  const parsed = parseSections(markdown);
+  const parsed = parseSections(snapshot.text);
   const sections = {
     type: findSection(parsed, 1, ["tipo", "attori"]),
     state: findSection(parsed, 2, ["stato reale", "stato"]),
@@ -265,9 +284,8 @@ function buildAnalysisItem(row, baseDir) {
     ]),
     training_labels: findSection(parsed, 8, ["training label", "gold label"]),
   };
-  const fullText = `${row.label || ""}\n${markdown}`;
+  const fullText = `${row.label || ""}\n${snapshot.text}`;
   const flags = detectFlags(fullText);
-  const stat = fs.statSync(outputPath);
 
   return {
     key: row.key,
@@ -282,7 +300,7 @@ function buildAnalysisItem(row, baseDir) {
     status: row.status || "unknown",
     analysis_id: path.basename(outputPath, ".md"),
     relative_path: path.relative(baseDir, outputPath),
-    output_mtime: stat.mtime.toISOString(),
+    output_mtime: snapshot.mtime.toISOString(),
     flags,
     flag_ids: flags.map((f) => f.id),
     priority_score: priorityScore(row, flags, sections),

--- a/apps/wa-dashboard-m1/package.json
+++ b/apps/wa-dashboard-m1/package.json
@@ -6,7 +6,8 @@
   "main": "server.cjs",
   "scripts": {
     "start": "node server.cjs",
-    "dev": "PORT=7790 node server.cjs"
+    "dev": "PORT=7790 node server.cjs",
+    "publish:case-intel": "node publish-case-intelligence.cjs"
   },
   "dependencies": {
     "express": "^4.21.0",

--- a/apps/wa-dashboard-m1/publish-case-intelligence.cjs
+++ b/apps/wa-dashboard-m1/publish-case-intelligence.cjs
@@ -1,0 +1,486 @@
+#!/usr/bin/env node
+"use strict";
+
+const crypto = require("crypto");
+const { Pool } = require("pg");
+const analysisIndex = require("./analysis-index.cjs");
+
+const DEFAULT_DASHBOARD_URL =
+  process.env.WA_DASHBOARD_URL || "http://127.0.0.1:7791";
+const DEFAULT_DATABASE_URL =
+  process.env.WA_CASE_INTEL_DATABASE_URL ||
+  process.env.WA_DASHBOARD_DATABASE_URL ||
+  process.env.DATABASE_URL ||
+  "";
+
+function parseArgs(argv) {
+  const args = {
+    dashboardUrl: DEFAULT_DASHBOARD_URL,
+    databaseUrl: DEFAULT_DATABASE_URL,
+    clientId: null,
+    limit: null,
+    json: false,
+    dryRun: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (arg === "--dashboard-url" && next) {
+      args.dashboardUrl = next;
+      i += 1;
+    } else if (arg === "--database-url" && next) {
+      args.databaseUrl = next;
+      i += 1;
+    } else if (arg === "--client-id" && next) {
+      args.clientId = Number.parseInt(next, 10);
+      i += 1;
+    } else if (arg === "--limit" && next) {
+      args.limit = Number.parseInt(next, 10);
+      i += 1;
+    } else if (arg === "--json") {
+      args.json = true;
+    } else if (arg === "--dry-run") {
+      args.dryRun = true;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (args.clientId && args.clientId <= 0) {
+    throw new Error("--client-id must be a positive integer");
+  }
+  if (args.limit && args.limit <= 0) {
+    throw new Error("--limit must be a positive integer");
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node publish-case-intelligence.cjs [options]
+
+Options:
+  --dashboard-url URL   WA dashboard URL with /data.json (default: ${DEFAULT_DASHBOARD_URL})
+  --database-url URL    Postgres URL. Defaults to WA_CASE_INTEL_DATABASE_URL, WA_DASHBOARD_DATABASE_URL, DATABASE_URL.
+  --client-id ID        Publish only one CRM client.
+  --limit N             Publish only first N matched case cards.
+  --dry-run             Build payload and print summary without writing.
+  --json                Print payload JSON and do not write.`);
+}
+
+function compactText(value, maxChars = 900) {
+  const text = String(value || "")
+    .replace(/\r/g, "")
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars - 1).trim()}…`;
+}
+
+function stripTechnicalPacketText(value) {
+  const technicalLine =
+    /^\s*(?:[-*]\s*)?(?:crm_collision|thread_health|primary_contact|operator_detected|conversation_type|cases|risk|type|intent|urgency|next_action|needs_pricing|pricing_source)\s*:/i;
+  const idLine = /^\s*-\s+id\s*:/i;
+  return String(value || "")
+    .split(/\r?\n/)
+    .filter((line) => !technicalLine.test(line) && !idLine.test(line))
+    .join("\n")
+    .replace(
+      /\b(?:crm_collision|thread_health|primary_contact|operator_detected|conversation_type|needs_pricing|pricing_source)\s*:\s*(?:"[^"]*"|[^\n]+)/gi,
+      "",
+    )
+    .trim();
+}
+
+function cleanHumanText(value, maxChars = 900) {
+  return compactText(stripTechnicalPacketText(value), maxChars)
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\s+([.,;:])/g, "$1")
+    .trim();
+}
+
+function uniqueBy(items, keyFn) {
+  const seen = new Set();
+  const out = [];
+  for (const item of items) {
+    const key = keyFn(item);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(item);
+  }
+  return out;
+}
+
+function flagIds(flags) {
+  return new Set((flags || []).map((flag) => flag.id).filter(Boolean));
+}
+
+function humanFlag(flag) {
+  const labels = {
+    crm_collision: "CRM identity or thread attribution needs human review.",
+    multi_case: "The conversation contains multiple distinct cases.",
+    media_review: "Attachments or media need to be opened and verified.",
+    pricingtool_required:
+      "Any price must be checked with PricingTool before replying.",
+    security_credentials:
+      "Credentials or sensitive documents appear in the thread.",
+    compliance: "Compliance or immigration risk is present.",
+    deadline_or_overstay:
+      "There is a deadline, expiry, travel window, or overstay risk.",
+    needs_reply: "The client or operator still needs a reply.",
+    reported_done_not_closed:
+      "Something was reported as done, but the evidence is not enough to close it.",
+    internal_ops:
+      "This is internal operations context, not a clean client-facing thread.",
+    owner_decision:
+      "Owner decision or approval is needed before moving forward.",
+  };
+  return labels[flag.id] || flag.label || flag.id;
+}
+
+function inferCaseStatus(analysis) {
+  const ids = flagIds(analysis.flags);
+  if (ids.has("owner_decision")) return "blocked";
+  if (ids.has("deadline_or_overstay")) return "open";
+  if (ids.has("needs_reply")) return "open";
+  if (ids.has("reported_done_not_closed")) return "open";
+  if (ids.has("media_review")) return "waiting";
+  return "open";
+}
+
+function inferCaseType(analysis) {
+  const ids = flagIds(analysis.flags);
+  if (ids.has("internal_ops")) return "internal operations";
+  if (ids.has("multi_case")) return "multi-case";
+  if (ids.has("crm_collision")) return "CRM review";
+  if (ids.has("pricingtool_required")) return "pricing needed";
+  if (analysis.kind === "group") return "WhatsApp group case";
+  return "WhatsApp case";
+}
+
+function buildHumanCrmNote(analysis, conv) {
+  const sections = analysis.sections || {};
+  const blocks = [];
+
+  const state = cleanHumanText(sections.state || analysis.summary || "", 1200);
+  if (state) blocks.push(`Situation\n${state}`);
+
+  const context = [];
+  const display = conv.display_name || analysis.display || conv.counterpart;
+  if (display) context.push(`Main visible contact/thread: ${display}.`);
+  if (conv.assigned_to)
+    context.push(`CRM owner currently shown as ${conv.assigned_to}.`);
+  if (analysis.kind === "group") {
+    context.push(
+      "This comes from a WhatsApp group, so actor attribution must be checked before any client-facing action.",
+    );
+  }
+  if (context.length) blocks.push(`Context\n${context.join(" ")}`);
+
+  const attention = uniqueBy((analysis.flags || []).map(humanFlag), (item) =>
+    item.toLowerCase(),
+  );
+  if (attention.length) {
+    blocks.push(
+      `Attention\n${attention.map((item) => `- ${item}`).join("\n")}`,
+    );
+  }
+
+  const action = cleanHumanText(
+    sections.action || analysis.next_action || "",
+    1200,
+  );
+  if (action) blocks.push(`Next action\n${action}`);
+
+  const idealReply = cleanHumanText(
+    sections.ideal_reply || analysis.ideal_reply || "",
+    1000,
+  );
+  if (idealReply) blocks.push(`Ideal reply\n${idealReply}`);
+
+  const evidence = cleanHumanText(sections.evidence || "", 900);
+  if (evidence) blocks.push(`Evidence read\n${evidence}`);
+
+  return compactText(blocks.join("\n\n"), 3000);
+}
+
+function stableHash(payload) {
+  return crypto
+    .createHash("sha1")
+    .update(JSON.stringify(payload))
+    .digest("hex");
+}
+
+function toDateOrNull(value) {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+async function fetchOverview(dashboardUrl) {
+  const target = new URL("/data.json", dashboardUrl);
+  const res = await fetch(target);
+  if (!res.ok) throw new Error(`GET ${target.href} returned ${res.status}`);
+  return res.json();
+}
+
+function buildRows(overview, analysisPayload, options) {
+  const analysisByKey = new Map(
+    (analysisPayload.items || []).map((item) => [item.key, item]),
+  );
+  const rows = [];
+
+  for (const [memberPhone, phoneData] of Object.entries(
+    overview.by_phone || {},
+  )) {
+    for (const conv of phoneData?.convs || []) {
+      const clientId = Number.parseInt(
+        String(
+          conv.client_id ||
+            conv.sender_client_id ||
+            conv.counterpart_client_id ||
+            "",
+        ),
+        10,
+      );
+      if (!clientId) continue;
+      if (options.clientId && clientId !== options.clientId) continue;
+
+      const conversationKey = `${conv.kind || "unknown"}|${memberPhone}|${conv.counterpart}`;
+      const analysis = analysisByKey.get(conversationKey);
+      if (!analysis) continue;
+
+      const sections = analysis.sections || {};
+      const row = {
+        client_id: clientId,
+        conversation_key: conversationKey,
+        member_phone: memberPhone,
+        counterpart_key: conv.counterpart || null,
+        display_name: conv.display_name || analysis.display || null,
+        chat_kind: ["direct", "group"].includes(conv.kind)
+          ? conv.kind
+          : "unknown",
+        case_status: inferCaseStatus(analysis),
+        case_type: inferCaseType(analysis),
+        source_model: "gpt-5.5",
+        reasoning_effort: "xhigh",
+        analysis_hash: "",
+        analysis_id: analysis.analysis_id || null,
+        message_count: Number(analysis.n ?? conv.n ?? 0),
+        unread_count: Number(analysis.unread ?? conv.unread_count ?? 0),
+        last_message_at: toDateOrNull(analysis.last_at || conv.last_at),
+        priority_score: Number(analysis.priority_score || 0),
+        flags: analysis.flags || [],
+        recap: cleanHumanText(sections.state || analysis.summary || "", 1500),
+        next_action: cleanHumanText(
+          sections.action || analysis.next_action || "",
+          1500,
+        ),
+        ideal_reply: cleanHumanText(
+          sections.ideal_reply || analysis.ideal_reply || "",
+          1500,
+        ),
+        evidence: cleanHumanText(sections.evidence || "", 1500),
+        crm_packet: buildHumanCrmNote(analysis, conv),
+        raw_sections: {
+          ...sections,
+          technical_crm_packet_raw: sections.crm_packet || "",
+          source_label: analysis.label || "",
+          source_display: analysis.display || "",
+        },
+        analysis_output_path: analysis.relative_path || null,
+        generated_at: toDateOrNull(analysis.output_mtime),
+      };
+      row.analysis_hash = stableHash({
+        conversation_key: row.conversation_key,
+        analysis_id: row.analysis_id,
+        recap: row.recap,
+        next_action: row.next_action,
+        ideal_reply: row.ideal_reply,
+        evidence: row.evidence,
+        flags: row.flags,
+      });
+      rows.push(row);
+    }
+  }
+
+  const uniqueRows = uniqueBy(
+    rows,
+    (row) => `${row.client_id}|${row.conversation_key}`,
+  ).sort((a, b) => {
+    if (b.priority_score !== a.priority_score)
+      return b.priority_score - a.priority_score;
+    return (
+      (b.last_message_at?.getTime() || 0) - (a.last_message_at?.getTime() || 0)
+    );
+  });
+
+  return options.limit ? uniqueRows.slice(0, options.limit) : uniqueRows;
+}
+
+async function publishRows(databaseUrl, rows) {
+  const pool = new Pool({
+    connectionString: databaseUrl,
+    max: 2,
+    idleTimeoutMillis: 30000,
+  });
+  const client = await pool.connect();
+  let inserted = 0;
+  let updated = 0;
+
+  try {
+    await client.query("BEGIN");
+    for (const row of rows) {
+      const result = await client.query(
+        `
+        INSERT INTO crm_wa_case_intelligence (
+          client_id, conversation_key, member_phone, counterpart_key, display_name,
+          chat_kind, case_status, case_type, source_model, reasoning_effort,
+          analysis_hash, analysis_id, message_count, unread_count,
+          last_message_at, priority_score, flags, recap, next_action,
+          ideal_reply, evidence, crm_packet, raw_sections,
+          analysis_output_path, generated_at
+        ) VALUES (
+          $1, $2, $3, $4, $5,
+          $6, $7, $8, $9, $10,
+          $11, $12, $13, $14,
+          $15, $16, $17::jsonb, $18, $19,
+          $20, $21, $22, $23::jsonb,
+          $24, $25
+        )
+        ON CONFLICT (client_id, conversation_key) DO UPDATE SET
+          member_phone = EXCLUDED.member_phone,
+          counterpart_key = EXCLUDED.counterpart_key,
+          display_name = EXCLUDED.display_name,
+          chat_kind = EXCLUDED.chat_kind,
+          case_status = EXCLUDED.case_status,
+          case_type = EXCLUDED.case_type,
+          source_model = EXCLUDED.source_model,
+          reasoning_effort = EXCLUDED.reasoning_effort,
+          analysis_hash = EXCLUDED.analysis_hash,
+          analysis_id = EXCLUDED.analysis_id,
+          message_count = EXCLUDED.message_count,
+          unread_count = EXCLUDED.unread_count,
+          last_message_at = EXCLUDED.last_message_at,
+          priority_score = EXCLUDED.priority_score,
+          flags = EXCLUDED.flags,
+          recap = EXCLUDED.recap,
+          next_action = EXCLUDED.next_action,
+          ideal_reply = EXCLUDED.ideal_reply,
+          evidence = EXCLUDED.evidence,
+          crm_packet = EXCLUDED.crm_packet,
+          raw_sections = EXCLUDED.raw_sections,
+          analysis_output_path = EXCLUDED.analysis_output_path,
+          generated_at = EXCLUDED.generated_at,
+          imported_at = NOW(),
+          updated_at = NOW()
+        RETURNING (xmax = 0) AS inserted
+        `,
+        [
+          row.client_id,
+          row.conversation_key,
+          row.member_phone,
+          row.counterpart_key,
+          row.display_name,
+          row.chat_kind,
+          row.case_status,
+          row.case_type,
+          row.source_model,
+          row.reasoning_effort,
+          row.analysis_hash,
+          row.analysis_id,
+          row.message_count,
+          row.unread_count,
+          row.last_message_at,
+          row.priority_score,
+          JSON.stringify(row.flags),
+          row.recap,
+          row.next_action,
+          row.ideal_reply,
+          row.evidence,
+          row.crm_packet,
+          JSON.stringify(row.raw_sections),
+          row.analysis_output_path,
+          row.generated_at,
+        ],
+      );
+      if (result.rows[0]?.inserted) inserted += 1;
+      else updated += 1;
+    }
+    await client.query("COMMIT");
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+
+  return { inserted, updated };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const [overview, analysisPayload] = await Promise.all([
+    fetchOverview(options.dashboardUrl),
+    Promise.resolve(analysisIndex.buildAnalysisIndexPayload({ force: true })),
+  ]);
+  const rows = buildRows(overview, analysisPayload, options);
+
+  if (options.json) {
+    process.stdout.write(
+      `${JSON.stringify({ count: rows.length, rows }, null, 2)}\n`,
+    );
+    return;
+  }
+
+  if (options.dryRun || !options.databaseUrl) {
+    console.log(
+      JSON.stringify(
+        {
+          mode: options.dryRun ? "dry_run" : "no_database_url",
+          dashboard_url: options.dashboardUrl,
+          matched_rows: rows.length,
+          clients: new Set(rows.map((row) => row.client_id)).size,
+          top_cases: rows.slice(0, 8).map((row) => ({
+            client_id: row.client_id,
+            display_name: row.display_name,
+            conversation_key: row.conversation_key,
+            case_type: row.case_type,
+            priority_score: row.priority_score,
+          })),
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  const result = await publishRows(options.databaseUrl, rows);
+  console.log(
+    JSON.stringify(
+      {
+        mode: "published",
+        dashboard_url: options.dashboardUrl,
+        matched_rows: rows.length,
+        clients: new Set(rows.map((row) => row.client_id)).size,
+        inserted: result.inserted,
+        updated: result.updated,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((err) => {
+  console.error(`[publish-case-intelligence] ${err.stack || err.message}`);
+  process.exit(1);
+});

--- a/apps/wa-dashboard-m1/server.cjs
+++ b/apps/wa-dashboard-m1/server.cjs
@@ -6,6 +6,7 @@ const { Pool } = require("pg");
 const fs = require("fs");
 const path = require("path");
 const metrics = require("./metrics.cjs");
+const training = require("./training.cjs");
 
 const PORT = parseInt(process.env.PORT || "7790", 10);
 const HOST = process.env.HOST || "0.0.0.0"; // bind also Tailnet (parity with wa-viewer:7777)
@@ -207,13 +208,8 @@ async function teamSessionFor(member) {
 }
 
 // === MAIN overview query ===
-async function fetchOverview() {
-  if (CACHE.teams.payload && Date.now() - CACHE.teams.at < CACHE_MS) {
-    return CACHE.teams.payload;
-  }
-
-  const result = { generated_at: new Date().toISOString(), team: [], by_phone: {} };
-  result.team = TEAM.map((m) => {
+function buildTeamList() {
+  return TEAM.map((m) => {
     const kindInfo = contactKindColor(m, false);
     return {
       name: m.name,
@@ -232,6 +228,15 @@ async function fetchOverview() {
       avatar_url: TEAM_AVATAR_FILES[m.e164] ? `/team-avatar/${encodeURIComponent(m.name.toLowerCase())}` : null,
     };
   });
+}
+
+async function fetchOverview() {
+  if (CACHE.teams.payload && Date.now() - CACHE.teams.at < CACHE_MS) {
+    return CACHE.teams.payload;
+  }
+
+  const result = { generated_at: new Date().toISOString(), team: [], by_phone: {} };
+  result.team = buildTeamList();
 
   // P1 fix 2026-05-26: serial for-loop → Promise.all(.map()) parallelize cross-member.
   // Each member's payload is keyed by member.phone in result.by_phone (no shared state,
@@ -737,18 +742,36 @@ app.use((req, res, next) => {
   next();
 });
 
+app.get("/favicon.ico", (_req, res) => {
+  res.status(204).end();
+});
+
+function dbUrlHost() {
+  try {
+    return new URL(DATABASE_URL.replace(/^postgres/, "http")).host;
+  } catch {
+    return "unknown";
+  }
+}
+
 app.get("/health.json", async (_req, res) => {
+  const db = { ok: false, host: dbUrlHost(), now: null, error: null };
   try {
     const r = await pool.query("SELECT 1 AS ok, NOW() AS now");
-    res.json({
-      ok: true,
-      db_now: r.rows[0].now,
-      team_size: TEAM.length,
-      db_url_host: new URL(DATABASE_URL.replace(/^postgres/, "http")).host,
-    });
+    db.ok = true;
+    db.now = r.rows[0].now;
   } catch (err) {
-    res.status(500).json({ ok: false, error: err.message });
+    db.error = err.message;
   }
+  res.json({
+    ok: true,
+    status: db.ok ? "ok" : "degraded",
+    db_ok: db.ok,
+    db_now: db.now,
+    db_error: db.error,
+    team_size: TEAM.length,
+    db_url_host: db.host,
+  });
 });
 
 app.get("/data.json", async (_req, res) => {
@@ -757,7 +780,22 @@ app.get("/data.json", async (_req, res) => {
     res.json(payload);
   } catch (err) {
     console.error("[data.json]", err);
-    res.status(500).json({ error: err.message });
+    res.json({
+      generated_at: new Date().toISOString(),
+      degraded: true,
+      error: `database unavailable: ${err.message}`,
+      team: buildTeamList(),
+      by_phone: {},
+    });
+  }
+});
+
+app.get("/training.json", (_req, res) => {
+  try {
+    res.json(training.buildTrainingPayload());
+  } catch (err) {
+    console.error("[training.json]", err);
+    res.status(500).json({ ok: false, error: err.message });
   }
 });
 
@@ -796,6 +834,32 @@ const MIME_BY_EXT = {
   ".mp4": "video/mp4", ".webm": "video/webm", ".m4a": "audio/mp4",
   ".ogg": "audio/ogg", ".mp3": "audio/mpeg", ".opus": "audio/opus",
 };
+
+function xmlEscape(value) {
+  return String(value || "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function initialsForAvatar(name) {
+  const clean = cleanName(name) || "Client";
+  const parts = clean.split(/\s+/).filter(Boolean);
+  const letters = parts.length > 1
+    ? `${parts[0][0] || ""}${parts[1][0] || ""}`
+    : clean.slice(0, 2);
+  return letters.toUpperCase();
+}
+
+function sendClientAvatarFallback(res, label) {
+  const initials = xmlEscape(initialsForAvatar(label));
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96" role="img" aria-label="Client avatar"><rect width="96" height="96" rx="48" fill="#d9fdd3"/><text x="50%" y="54%" dominant-baseline="middle" text-anchor="middle" fill="#25564a" font-family="Inter, Arial, sans-serif" font-size="34" font-weight="800">${initials}</text></svg>`;
+  res.setHeader("Content-Type", "image/svg+xml; charset=utf-8");
+  res.setHeader("Cache-Control", "private, max-age=3600");
+  return res.status(200).send(svg);
+}
+
 app.get("/media", (req, res) => {
   const p = req.query.path;
   if (!p || typeof p !== "string") return res.status(400).send("missing path");
@@ -833,12 +897,18 @@ app.get("/client-avatar/:id", async (req, res) => {
   const cid = parseInt(req.params.id, 10);
   if (!cid) return res.status(400).send("bad id");
   try {
-    const r = await pool.query(`SELECT avatar_url FROM clients WHERE id = $1 AND deleted_at IS NULL`, [cid]);
-    const a = r.rows[0]?.avatar_url;
-    if (!a) return res.status(404).send("no avatar");
+    const r = await pool.query(
+      `SELECT full_name, company_name, avatar_url FROM clients WHERE id = $1 AND deleted_at IS NULL`,
+      [cid],
+    );
+    const client = r.rows[0];
+    if (!client) return sendClientAvatarFallback(res, "Client");
+    const a = client.avatar_url;
+    const label = client.full_name || client.company_name || "Client";
+    if (!a) return sendClientAvatarFallback(res, label);
     if (a.startsWith("data:")) {
       const m = a.match(/^data:([^;]+);base64,(.+)$/);
-      if (!m) return res.status(415).send("bad data uri");
+      if (!m) return sendClientAvatarFallback(res, label);
       res.setHeader("Content-Type", m[1]);
       res.setHeader("Cache-Control", "private, max-age=3600");
       return res.end(Buffer.from(m[2], "base64"));
@@ -854,10 +924,10 @@ app.get("/client-avatar/:id", async (req, res) => {
       }
     }
     if (a.startsWith("http")) return res.redirect(a);
-    res.status(415).send("unsupported");
+    return sendClientAvatarFallback(res, label);
   } catch (err) {
-    console.error("[client-avatar]", err);
-    res.status(500).send(err.message);
+    console.warn(`[client-avatar] fallback: ${err.message}`);
+    return sendClientAvatarFallback(res, "Client");
   }
 });
 

--- a/apps/wa-dashboard-m1/training.cjs
+++ b/apps/wa-dashboard-m1/training.cjs
@@ -1,0 +1,386 @@
+"use strict";
+
+// wa-dashboard-m1 — Local Zantara training/shadow artifact index
+// ------------------------------------------------------------------
+// Pro-bound and read-only. This module scans only safe Markdown summaries
+// under research/personal/wa-corpus and never exposes raw JSONL/SQLite rows,
+// message text, phone numbers, or case identifiers.
+// ------------------------------------------------------------------
+
+const fs = require("fs");
+const path = require("path");
+
+const DEFAULT_CORPUS_DIR = path.resolve(__dirname, "../../research/personal/wa-corpus");
+const SUMMARY_RE = /_summary\.md$/i;
+const MAX_DEPTH = 5;
+const MAX_FILES = 700;
+const MAX_SUMMARY_BYTES = 256 * 1024;
+const CACHE_MS = 15_000;
+
+let CACHE = { at: 0, payload: null };
+
+const CATEGORY_RULES = [
+  {
+    id: "client_academy",
+    label: "Client Captain Academy",
+    tone: "green",
+    re: /client[-_]?captain.*academy|client_captain_academy/i,
+  },
+  {
+    id: "client_shadow",
+    label: "Client Captain Shadow",
+    tone: "blue",
+    re: /client[-_]?captain[-_]?shadow|client_captain_shadow/i,
+  },
+  {
+    id: "team_shadow",
+    label: "Team Captain Shadow",
+    tone: "cyan",
+    re: /team[-_]?captain[-_]?shadow|team_captain_shadow/i,
+  },
+  {
+    id: "owner_shadow",
+    label: "Owner Captain Shadow",
+    tone: "gold",
+    re: /owner[-_]?captain[-_]?shadow|owner_captain_shadow/i,
+  },
+  {
+    id: "owner_decision",
+    label: "Owner Decision Chain",
+    tone: "violet",
+    re: /owner[-_]?decision|owner_decision|approval|approve|reject|ledger|work[-_]?order|decision[-_]?packs|decision[-_]?inbox/i,
+  },
+  {
+    id: "operator_ops",
+    label: "Operator Ops",
+    tone: "orange",
+    re: /operator|next[-_]?best|case[-_]?closure|case[-_]?memory|case[-_]?timeline|evidence[-_]?gap|war[-_]?room/i,
+  },
+  {
+    id: "corpus_analysis",
+    label: "Corpus Analysis",
+    tone: "slate",
+    re: /analysis|allowed_|classification|registry|review|full[-_]?corpus|gold[-_]?signals|drive[-_]?import|manifest/i,
+  },
+];
+
+const IMPORTANT_METRICS = [
+  "training_examples",
+  "replay_scenarios",
+  "shadow_drafts",
+  "owner_approval_items",
+  "owner_decision_packs",
+  "owner_briefs",
+  "operator_packets",
+  "review_items",
+  "intake_items",
+  "awaiting_owner_decision",
+  "captured_decisions",
+  "team_findings",
+  "owner_findings",
+  "source_cases",
+  "depth_layers",
+  "p1_count",
+  "whatsapp_sends",
+  "crm_mutations",
+  "human_approval_required",
+];
+
+function corpusDir() {
+  return process.env.WA_TRAINING_CORPUS_DIR || DEFAULT_CORPUS_DIR;
+}
+
+function metricKey(label) {
+  return String(label || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function displayNumber(value) {
+  if (value == null || value === "") return "—";
+  if (typeof value === "number") return value.toLocaleString("it-IT");
+  const s = String(value).trim();
+  const numeric = s.replace(/,/g, "");
+  if (/^-?\d+(\.\d+)?$/.test(numeric)) {
+    return Number(numeric).toLocaleString("it-IT");
+  }
+  return s;
+}
+
+function numericValue(value) {
+  if (value == null) return null;
+  const s = String(value).trim().replace(/,/g, "");
+  if (!/^-?\d+(\.\d+)?%?$/.test(s)) return null;
+  return Number(s.replace("%", ""));
+}
+
+function cleanBullet(line) {
+  return String(line || "")
+    .replace(/^\s*[-*]\s+/, "")
+    .replace(/`/g, "")
+    .trim();
+}
+
+function markdownSections(text) {
+  const sections = [];
+  let current = null;
+  for (const line of String(text || "").split(/\r?\n/)) {
+    const heading = line.match(/^##\s+(.+?)\s*$/);
+    if (heading) {
+      if (current) sections.push(current);
+      current = { title: heading[1].trim(), body: [] };
+      continue;
+    }
+    if (current) current.body.push(line);
+  }
+  if (current) sections.push(current);
+  return sections.map((section) => ({ ...section, body: section.body.join("\n").trim() }));
+}
+
+function sectionText(text, heading) {
+  const wanted = String(heading || "").trim().toLowerCase();
+  const found = markdownSections(text).find((section) => section.title.toLowerCase() === wanted);
+  return found ? found.body : "";
+}
+
+function parseTableRows(section) {
+  const rows = [];
+  for (const raw of String(section || "").split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line.startsWith("|") || !line.endsWith("|")) continue;
+    const cells = line
+      .slice(1, -1)
+      .split("|")
+      .map((cell) => cell.trim());
+    if (cells.length < 2) continue;
+    if (/^-{2,}:?$/.test(cells[0].replace(/\s/g, ""))) continue;
+    if (/^(metric|value)$/i.test(cells[0]) && /^(value|count)$/i.test(cells[1])) continue;
+    rows.push({ label: cells[0], value: cells[1] });
+  }
+  return rows;
+}
+
+function parseTables(text) {
+  const tables = {};
+  for (const section of markdownSections(text)) {
+    const rows = parseTableRows(section.body);
+    if (rows.length) tables[section.title] = rows;
+  }
+  return tables;
+}
+
+function categorize(relativePath, title) {
+  const haystack = `${relativePath} ${title}`;
+  for (const rule of CATEGORY_RULES) {
+    if (rule.re.test(haystack)) {
+      return { id: rule.id, label: rule.label, tone: rule.tone };
+    }
+  }
+  return { id: "other", label: "Other Training Artifacts", tone: "slate" };
+}
+
+function safeStat(file) {
+  try {
+    return fs.statSync(file);
+  } catch {
+    return null;
+  }
+}
+
+function scanSummaryFiles(baseDir, dir, depth, acc) {
+  if (depth > MAX_DEPTH || acc.length >= MAX_FILES) return;
+  let entries = [];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+  for (const entry of entries) {
+    if (acc.length >= MAX_FILES) return;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      scanSummaryFiles(baseDir, full, depth + 1, acc);
+      continue;
+    }
+    if (entry.isFile() && SUMMARY_RE.test(entry.name)) {
+      const rel = path.relative(baseDir, full);
+      acc.push({ full, rel });
+    }
+  }
+}
+
+function parseSummaryText(text, relativePath, stat) {
+  const title = (text.match(/^#\s+(.+?)\s*$/m) || [])[1] || path.basename(relativePath);
+  const generatedAt =
+    (text.match(/^Generated UTC:\s*`?([^`\n]+)`?/im) || [])[1] ||
+    (text.match(/^Generated(?: at)?:\s*`?([^`\n]+)`?/im) || [])[1] ||
+    null;
+
+  const tables = parseTables(text);
+  const counts = {};
+  for (const row of tables.Counts || []) {
+    counts[metricKey(row.label)] = row.value;
+  }
+
+  const privacyBullets = sectionText(text, "Privacy Mode")
+    .split(/\r?\n/)
+    .filter((line) => /^\s*[-*]\s+/.test(line))
+    .slice(0, 6)
+    .map(cleanBullet);
+  const contractBullets = sectionText(text, "Execution Contract")
+    .split(/\r?\n/)
+    .filter((line) => /^\s*[-*]\s+/.test(line))
+    .slice(0, 8)
+    .map(cleanBullet);
+
+  const category = categorize(relativePath, title);
+  const keyMetrics = IMPORTANT_METRICS
+    .filter((key) => counts[key] != null)
+    .slice(0, 8)
+    .map((key) => ({
+      key,
+      label: key.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()),
+      value: counts[key],
+      display_value: displayNumber(counts[key]),
+    }));
+
+  if (!keyMetrics.length) {
+    for (const row of (tables.Counts || []).slice(0, 5)) {
+      keyMetrics.push({
+        key: metricKey(row.label),
+        label: row.label,
+        value: row.value,
+        display_value: displayNumber(row.value),
+      });
+    }
+  }
+
+  return {
+    title: title.trim(),
+    relative_path: relativePath,
+    category_id: category.id,
+    category_label: category.label,
+    category_tone: category.tone,
+    generated_at: generatedAt,
+    mtime: stat ? stat.mtime.toISOString() : null,
+    counts,
+    key_metrics: keyMetrics,
+    privacy: privacyBullets,
+    execution_contract: contractBullets,
+  };
+}
+
+function aggregateTotals(artifacts) {
+  const totals = {};
+  for (const artifact of artifacts) {
+    for (const [key, value] of Object.entries(artifact.counts || {})) {
+      const n = numericValue(value);
+      if (n == null) continue;
+      totals[key] = (totals[key] || 0) + n;
+    }
+  }
+  return totals;
+}
+
+function buildCategories(artifacts) {
+  const byId = new Map();
+  for (const artifact of artifacts) {
+    if (!byId.has(artifact.category_id)) {
+      byId.set(artifact.category_id, {
+        id: artifact.category_id,
+        label: artifact.category_label,
+        tone: artifact.category_tone,
+        count: 0,
+        latest_generated_at: null,
+        latest_mtime: null,
+        top_metrics: {},
+      });
+    }
+    const group = byId.get(artifact.category_id);
+    group.count += 1;
+    if (artifact.generated_at && (!group.latest_generated_at || artifact.generated_at > group.latest_generated_at)) {
+      group.latest_generated_at = artifact.generated_at;
+    }
+    if (artifact.mtime && (!group.latest_mtime || artifact.mtime > group.latest_mtime)) {
+      group.latest_mtime = artifact.mtime;
+    }
+    for (const metric of artifact.key_metrics.slice(0, 4)) {
+      if (group.top_metrics[metric.key] == null) group.top_metrics[metric.key] = metric.display_value;
+    }
+  }
+  return [...byId.values()].sort((a, b) => {
+    const ar = CATEGORY_RULES.findIndex((r) => r.id === a.id);
+    const br = CATEGORY_RULES.findIndex((r) => r.id === b.id);
+    return (ar === -1 ? 99 : ar) - (br === -1 ? 99 : br) || a.label.localeCompare(b.label);
+  });
+}
+
+function buildTrainingPayload(options = {}) {
+  const baseDir = options.baseDir || corpusDir();
+  const now = Date.now();
+  if (!options.noCache && CACHE.payload && Date.now() - CACHE.at < CACHE_MS && CACHE.payload.base_dir === baseDir) {
+    return CACHE.payload;
+  }
+
+  const files = [];
+  const exists = fs.existsSync(baseDir);
+  if (exists) scanSummaryFiles(baseDir, baseDir, 0, files);
+
+  const artifacts = [];
+  const errors = [];
+  for (const file of files) {
+    try {
+      const stat = safeStat(file.full);
+      const raw = fs.readFileSync(file.full, "utf8").slice(0, MAX_SUMMARY_BYTES);
+      artifacts.push(parseSummaryText(raw, file.rel, stat));
+    } catch (err) {
+      errors.push({ relative_path: file.rel, error: err.message });
+    }
+  }
+
+  artifacts.sort((a, b) => {
+    const at = a.generated_at || a.mtime || "";
+    const bt = b.generated_at || b.mtime || "";
+    return bt.localeCompare(at) || a.relative_path.localeCompare(b.relative_path);
+  });
+
+  const totals = aggregateTotals(artifacts);
+  const payload = {
+    generated_at: new Date().toISOString(),
+    base_dir: baseDir,
+    exists,
+    artifact_count: artifacts.length,
+    summary_limit: MAX_FILES,
+    latest_generated_at: artifacts.find((a) => a.generated_at)?.generated_at || null,
+    totals,
+    total_cards: {
+      training_examples: displayNumber(totals.training_examples || 0),
+      replay_scenarios: displayNumber(totals.replay_scenarios || 0),
+      shadow_drafts: displayNumber(totals.shadow_drafts || 0),
+      owner_queue: displayNumber(totals.awaiting_owner_decision || totals.owner_approval_items || 0),
+      whatsapp_sends: displayNumber(totals.whatsapp_sends || 0),
+      crm_mutations: displayNumber(totals.crm_mutations || 0),
+    },
+    categories: buildCategories(artifacts),
+    artifacts,
+    errors,
+    contract: {
+      local_only: true,
+      read_only: true,
+      raw_artifacts_exposed: false,
+      source: "Markdown summaries only",
+    },
+    elapsed_ms: Date.now() - now,
+  };
+  CACHE = { at: Date.now(), payload };
+  return payload;
+}
+
+module.exports = {
+  buildTrainingPayload,
+  parseSummaryText,
+  metricKey,
+};

--- a/apps/wa-dashboard-m1/training.cjs
+++ b/apps/wa-dashboard-m1/training.cjs
@@ -10,7 +10,10 @@
 const fs = require("fs");
 const path = require("path");
 
-const DEFAULT_CORPUS_DIR = path.resolve(__dirname, "../../research/personal/wa-corpus");
+const DEFAULT_CORPUS_DIR = path.resolve(
+  __dirname,
+  "../../research/personal/wa-corpus",
+);
 const SUMMARY_RE = /_summary\.md$/i;
 const MAX_DEPTH = 5;
 const MAX_FILES = 700;
@@ -113,7 +116,7 @@ function numericValue(value) {
   if (value == null) return null;
   const s = String(value).trim().replace(/,/g, "");
   if (!/^-?\d+(\.\d+)?%?$/.test(s)) return null;
-  return Number(s.replace("%", ""));
+  return Number(s.replace(/%/g, ""));
 }
 
 function cleanBullet(line) {
@@ -136,12 +139,19 @@ function markdownSections(text) {
     if (current) current.body.push(line);
   }
   if (current) sections.push(current);
-  return sections.map((section) => ({ ...section, body: section.body.join("\n").trim() }));
+  return sections.map((section) => ({
+    ...section,
+    body: section.body.join("\n").trim(),
+  }));
 }
 
 function sectionText(text, heading) {
-  const wanted = String(heading || "").trim().toLowerCase();
-  const found = markdownSections(text).find((section) => section.title.toLowerCase() === wanted);
+  const wanted = String(heading || "")
+    .trim()
+    .toLowerCase();
+  const found = markdownSections(text).find(
+    (section) => section.title.toLowerCase() === wanted,
+  );
   return found ? found.body : "";
 }
 
@@ -156,7 +166,8 @@ function parseTableRows(section) {
       .map((cell) => cell.trim());
     if (cells.length < 2) continue;
     if (/^-{2,}:?$/.test(cells[0].replace(/\s/g, ""))) continue;
-    if (/^(metric|value)$/i.test(cells[0]) && /^(value|count)$/i.test(cells[1])) continue;
+    if (/^(metric|value)$/i.test(cells[0]) && /^(value|count)$/i.test(cells[1]))
+      continue;
     rows.push({ label: cells[0], value: cells[1] });
   }
   return rows;
@@ -213,7 +224,8 @@ function scanSummaryFiles(baseDir, dir, depth, acc) {
 }
 
 function parseSummaryText(text, relativePath, stat) {
-  const title = (text.match(/^#\s+(.+?)\s*$/m) || [])[1] || path.basename(relativePath);
+  const title =
+    (text.match(/^#\s+(.+?)\s*$/m) || [])[1] || path.basename(relativePath);
   const generatedAt =
     (text.match(/^Generated UTC:\s*`?([^`\n]+)`?/im) || [])[1] ||
     (text.match(/^Generated(?: at)?:\s*`?([^`\n]+)`?/im) || [])[1] ||
@@ -237,8 +249,7 @@ function parseSummaryText(text, relativePath, stat) {
     .map(cleanBullet);
 
   const category = categorize(relativePath, title);
-  const keyMetrics = IMPORTANT_METRICS
-    .filter((key) => counts[key] != null)
+  const keyMetrics = IMPORTANT_METRICS.filter((key) => counts[key] != null)
     .slice(0, 8)
     .map((key) => ({
       key,
@@ -301,27 +312,43 @@ function buildCategories(artifacts) {
     }
     const group = byId.get(artifact.category_id);
     group.count += 1;
-    if (artifact.generated_at && (!group.latest_generated_at || artifact.generated_at > group.latest_generated_at)) {
+    if (
+      artifact.generated_at &&
+      (!group.latest_generated_at ||
+        artifact.generated_at > group.latest_generated_at)
+    ) {
       group.latest_generated_at = artifact.generated_at;
     }
-    if (artifact.mtime && (!group.latest_mtime || artifact.mtime > group.latest_mtime)) {
+    if (
+      artifact.mtime &&
+      (!group.latest_mtime || artifact.mtime > group.latest_mtime)
+    ) {
       group.latest_mtime = artifact.mtime;
     }
     for (const metric of artifact.key_metrics.slice(0, 4)) {
-      if (group.top_metrics[metric.key] == null) group.top_metrics[metric.key] = metric.display_value;
+      if (group.top_metrics[metric.key] == null)
+        group.top_metrics[metric.key] = metric.display_value;
     }
   }
   return [...byId.values()].sort((a, b) => {
     const ar = CATEGORY_RULES.findIndex((r) => r.id === a.id);
     const br = CATEGORY_RULES.findIndex((r) => r.id === b.id);
-    return (ar === -1 ? 99 : ar) - (br === -1 ? 99 : br) || a.label.localeCompare(b.label);
+    return (
+      (ar === -1 ? 99 : ar) - (br === -1 ? 99 : br) ||
+      a.label.localeCompare(b.label)
+    );
   });
 }
 
 function buildTrainingPayload(options = {}) {
   const baseDir = options.baseDir || corpusDir();
   const now = Date.now();
-  if (!options.noCache && CACHE.payload && Date.now() - CACHE.at < CACHE_MS && CACHE.payload.base_dir === baseDir) {
+  if (
+    !options.noCache &&
+    CACHE.payload &&
+    Date.now() - CACHE.at < CACHE_MS &&
+    CACHE.payload.base_dir === baseDir
+  ) {
     return CACHE.payload;
   }
 
@@ -334,7 +361,9 @@ function buildTrainingPayload(options = {}) {
   for (const file of files) {
     try {
       const stat = safeStat(file.full);
-      const raw = fs.readFileSync(file.full, "utf8").slice(0, MAX_SUMMARY_BYTES);
+      const raw = fs
+        .readFileSync(file.full, "utf8")
+        .slice(0, MAX_SUMMARY_BYTES);
       artifacts.push(parseSummaryText(raw, file.rel, stat));
     } catch (err) {
       errors.push({ relative_path: file.rel, error: err.message });
@@ -344,7 +373,9 @@ function buildTrainingPayload(options = {}) {
   artifacts.sort((a, b) => {
     const at = a.generated_at || a.mtime || "";
     const bt = b.generated_at || b.mtime || "";
-    return bt.localeCompare(at) || a.relative_path.localeCompare(b.relative_path);
+    return (
+      bt.localeCompare(at) || a.relative_path.localeCompare(b.relative_path)
+    );
   });
 
   const totals = aggregateTotals(artifacts);
@@ -354,13 +385,16 @@ function buildTrainingPayload(options = {}) {
     exists,
     artifact_count: artifacts.length,
     summary_limit: MAX_FILES,
-    latest_generated_at: artifacts.find((a) => a.generated_at)?.generated_at || null,
+    latest_generated_at:
+      artifacts.find((a) => a.generated_at)?.generated_at || null,
     totals,
     total_cards: {
       training_examples: displayNumber(totals.training_examples || 0),
       replay_scenarios: displayNumber(totals.replay_scenarios || 0),
       shadow_drafts: displayNumber(totals.shadow_drafts || 0),
-      owner_queue: displayNumber(totals.awaiting_owner_decision || totals.owner_approval_items || 0),
+      owner_queue: displayNumber(
+        totals.awaiting_owner_decision || totals.owner_approval_items || 0,
+      ),
       whatsapp_sends: displayNumber(totals.whatsapp_sends || 0),
       crm_mutations: displayNumber(totals.crm_mutations || 0),
     },

--- a/apps/wa-dashboard-m1/viewer.html
+++ b/apps/wa-dashboard-m1/viewer.html
@@ -918,14 +918,43 @@ function caseFirstName(conv) {
   return clean.split(/\s+/)[0].replace(/[^\p{L}\p{N}'-]/gu, "");
 }
 
+function detectConversationTopics(text, mediaTypes = []) {
+  const t = String(text || "").toLowerCase();
+  const topics = [];
+  if (/\b(visa|kitas|kitap|stay permit|immigration|imigrasi|e-voa|voa|permit)\b/.test(t)) topics.push("visa/immigrazione");
+  if (/\b(flight|ticket|depart|departure|arriv|arrival|leav|leaving|re-?enter|return|airport|dps|sin|bkk|cgk|jakarta|bali)\b/.test(t)) topics.push("viaggio/re-entry");
+  if (/\b(passport|ktp|npwp|akta|document|dokumen|file|photo|image|pdf|scan|screenshot)\b/.test(t) || mediaTypes.length) topics.push("documenti/media");
+  if (/\b(invoice|payment|paid|transfer|bank|price|quote|quotation|fee|harga|biaya|fattura|pagamento)\b/.test(t)) topics.push("pagamenti/quote");
+  if (/\b(company|pt |pma|director|shareholder|tax|oss|kbli|società|azienda)\b/.test(t)) topics.push("società/tax");
+  if (/\b(meeting|appointment|call|zoom|visit|schedule|jadwal|appuntamento|chiamata)\b/.test(t)) topics.push("appuntamento/call");
+  if (/\b(villa|property|land|lease|freehold|real estate|terreno|immobile)\b/.test(t)) topics.push("property");
+  return [...new Set(topics)];
+}
+
 function deriveThreadEvidence(payload, conv) {
   const messages = payload?.messages || [];
   const recentMessages = messages.slice(-12);
-  const lastInbound = [...messages].reverse().find((m) => m.direction !== "outbound" && messageTextForEvidence(m));
-  const lastOutbound = [...messages].reverse().find((m) => m.direction === "outbound" && messageTextForEvidence(m));
+  const inboundMessages = messages.filter((m) => m.direction !== "outbound" && messageTextForEvidence(m));
+  const outboundMessages = messages.filter((m) => m.direction === "outbound" && messageTextForEvidence(m));
+  const allTexts = messages.map(messageTextForEvidence).filter(Boolean);
+  const allInboundTexts = inboundMessages.map(messageTextForEvidence).filter(Boolean);
+  const allOutboundTexts = outboundMessages.map(messageTextForEvidence).filter(Boolean);
+  const lastInbound = [...inboundMessages].reverse()[0];
+  const lastOutbound = [...outboundMessages].reverse()[0];
   const lastAny = [...messages].reverse().find((m) => messageTextForEvidence(m));
+  const firstInbound = inboundMessages[0];
+  const questionMessages = inboundMessages.filter((m) => textLooksLikeQuestion(messageTextForEvidence(m)));
+  const thanksMessages = inboundMessages.filter((m) => textLooksLikeThanks(messageTextForEvidence(m)));
+  const lastMeaningfulInbound = [...inboundMessages].reverse().find((m) => {
+    const text = messageTextForEvidence(m);
+    return text && !textLooksLikeThanks(text) && !/^\[[a-z]+\]$/i.test(text);
+  });
   const lastInboundAt = lastInbound?.message_date ? new Date(lastInbound.message_date).getTime() : 0;
   const lastOutboundAt = lastOutbound?.message_date ? new Date(lastOutbound.message_date).getTime() : 0;
+  const openQuestionMessages = questionMessages.filter((m) => {
+    const at = m?.message_date ? new Date(m.message_date).getTime() : 0;
+    return !lastOutboundAt || at > lastOutboundAt;
+  });
   const recentInboundTexts = recentMessages
     .filter((m) => m.direction !== "outbound")
     .map(messageTextForEvidence)
@@ -938,31 +967,61 @@ function deriveThreadEvidence(payload, conv) {
   const recentMediaTypes = [...new Set(recentMessages.filter((m) => MEDIA_TYPES.has(m.media_type)).map((m) => m.media_type))];
   const lastInboundText = messageTextForEvidence(lastInbound);
   const lastOutboundText = messageTextForEvidence(lastOutbound);
+  const recapRaw = conv?.strategic_recap || conv?.sender_strategic_recap || "";
+  const recapSource = conv?.strategic_recap_source || (conv?.sender_strategic_recap ? "wa_thread" : "");
+  const topics = detectConversationTopics([...allTexts, recapRaw].join(" "), mediaTypes);
+  const openAttention = messages.filter((m) => m.attention_priority && !m.attention_resolved_at);
+  const openQuestions = [...openQuestionMessages]
+    .reverse()
+    .map((m) => messageSnippet(messageTextForEvidence(m), 180))
+    .filter(Boolean)
+    .slice(0, 3);
+  const count = payload?.count || conv?.n || messages.length || 0;
   return {
-    count: payload?.count || conv?.n || 0,
+    count,
+    inbound_count: inboundMessages.length,
+    outbound_count: outboundMessages.length,
+    question_count: questionMessages.length,
+    open_question_count: openQuestionMessages.length,
+    thanks_count: thanksMessages.length,
+    open_attention_count: openAttention.length,
     latest_direction: lastAny?.direction || null,
     latest_at: lastAny?.message_date || conv?.last_at || null,
     last_inbound_at: lastInbound?.message_date || null,
     last_outbound_at: lastOutbound?.message_date || null,
     last_inbound_sender: lastInbound?.sender_display || lastInbound?.sender_phone || "",
     last_outbound_sender: lastOutbound?.sender_display || lastOutbound?.sender_phone || "",
+    first_inbound: messageSnippet(messageTextForEvidence(firstInbound), 260),
     last_inbound: messageSnippet(lastInboundText, 360),
     last_outbound: messageSnippet(lastOutboundText, 260),
+    last_question: openQuestions[0] || "",
+    open_questions: openQuestions,
+    last_meaningful_customer_info: messageSnippet(messageTextForEvidence(lastMeaningfulInbound), 360),
+    whole_thread_inbound: messageSnippet(allInboundTexts.join(" · "), 900),
+    whole_thread_outbound: messageSnippet(allOutboundTexts.join(" · "), 720),
     recent_inbound: messageSnippet(recentInboundTexts.join(" · "), 520),
     recent_outbound: messageSnippet(recentOutboundTexts.join(" · "), 420),
     media_types: mediaTypes,
     recent_media_types: recentMediaTypes,
-    has_question: recentInboundTexts.some(textLooksLikeQuestion) || textLooksLikeQuestion(lastInboundText),
+    last_inbound_is_media_only: /^\[[a-z]+\]$/i.test(lastInboundText),
+    topics,
+    recap: messageSnippet(recapRaw, 700),
+    recap_source: recapSource,
+    whole_thread_summary: recapRaw
+      ? messageSnippet(recapRaw, 700)
+      : `Analisi locale su ${count} messaggi: ${inboundMessages.length} cliente/inbound, ${outboundMessages.length} team/outbound${topics.length ? `, topic ${topics.join(", ")}` : ""}.`,
+    has_question: questionMessages.length > 0,
     has_thanks: textLooksLikeThanks(lastInboundText),
     needs_reply: Boolean(conv?.unread_count) || (lastInboundAt > lastOutboundAt),
   };
 }
 
 function buildIdealReply(conv, evidence, intent) {
-  const lang = detectReplyLanguage(evidence.last_inbound || evidence.recent_inbound);
+  const lang = detectReplyLanguage(evidence.last_meaningful_customer_info || evidence.last_inbound || evidence.whole_thread_inbound);
   const name = caseFirstName(conv);
   const hi = name ? ` ${name}` : "";
-  const lastInfo = messageSnippet(evidence.last_inbound, 120);
+  const lastInfo = messageSnippet(evidence.last_meaningful_customer_info || evidence.last_inbound, 120);
+  const lastQuestion = messageSnippet(evidence.last_question || evidence.open_questions?.[0] || "", 120);
   const hasMedia = Boolean(evidence.recent_media_types?.length || evidence.media_types?.length);
   const mediaLabel = lang === "id"
     ? (hasMedia ? "file/foto yang kamu kirim" : "ini")
@@ -976,9 +1035,9 @@ function buildIdealReply(conv, evidence, intent) {
     return `You're welcome${hi}. We received it. We'll keep this case monitored and update you here if anything else is needed.`;
   }
   if (intent === "question") {
-    if (lang === "id") return `Terima kasih${hi}. Saya cek dulu dengan case kamu, lalu saya konfirmasi next step yang tepat di sini.`;
-    if (lang === "it") return `Grazie${hi}. Verifico questo punto sulla tua pratica e ti confermo qui il prossimo passaggio corretto.`;
-    return `Thanks${hi}. I'll check this against your case and confirm the correct next step here.`;
+    if (lang === "id") return `Terima kasih${hi}. Saya cek dulu poin ini${lastQuestion ? `: "${lastQuestion}"` : ""}, lalu saya konfirmasi next step yang tepat di sini.`;
+    if (lang === "it") return `Grazie${hi}. Verifico questo punto${lastQuestion ? `: "${lastQuestion}"` : ""} sulla tua pratica e ti confermo qui il prossimo passaggio corretto.`;
+    return `Thanks${hi}. I'll check this point${lastQuestion ? `: "${lastQuestion}"` : ""} against your case and confirm the correct next step here.`;
   }
   if (intent === "info") {
     if (lang === "id") return `Terima kasih${hi}, saya catat: "${lastInfo}". Kami pakai info ini untuk case kamu dan update next step di sini.`;
@@ -996,6 +1055,9 @@ function buildIdealReply(conv, evidence, intent) {
   if (intent === "already_replied") {
     return "No new message needed right now. Keep monitoring; reply only if the client asks again or the promised next step changes.";
   }
+  if (intent === "recap_monitor") {
+    return "No client message needed right now. Use the existing recap to prepare the next operator/owner update if the case status changes.";
+  }
   if (lang === "id") return `Terima kasih${hi}. Kami sedang cek statusnya dan akan update di sini dengan next step yang jelas.`;
   if (lang === "it") return `Grazie${hi}. Stiamo verificando lo stato e ti aggiorniamo qui con il prossimo passaggio chiaro.`;
   return `Thanks${hi}. We're checking the status and will update you here with the clear next step.`;
@@ -1005,19 +1067,26 @@ function buildSpecificCaseAnalysis(conv, evidence) {
   const media = evidence.recent_media_types?.length ? evidence.recent_media_types : evidence.media_types || [];
   const mediaLabel = media.length ? media.join(", ") : "";
   const specificSignals = [];
-  if (evidence.last_inbound) specificSignals.push(`Ultimo inbound: "${messageSnippet(evidence.last_inbound, 92)}"`);
+  specificSignals.push(`${evidence.count || 0} messaggi analizzati: ${evidence.inbound_count || 0} inbound / ${evidence.outbound_count || 0} outbound`);
+  if (evidence.recap) specificSignals.push(`Recap già presente (${evidence.recap_source || "CRM/WA"}): "${messageSnippet(evidence.recap, 120)}"`);
+  if (evidence.topics?.length) specificSignals.push(`Topic letti nel thread: ${evidence.topics.join(", ")}`);
+  if (evidence.question_count) specificSignals.push(`Domande cliente nel thread: ${evidence.question_count}`);
+  if (evidence.open_question_count) specificSignals.push(`Domande ancora aperte dopo ultimo team reply: ${evidence.open_question_count}`);
+  if (evidence.open_attention_count) specificSignals.push(`Alert locali aperti: ${evidence.open_attention_count}`);
+  if (evidence.last_meaningful_customer_info) specificSignals.push(`Ultimo dato cliente utile: "${messageSnippet(evidence.last_meaningful_customer_info, 92)}"`);
+  else if (evidence.last_inbound) specificSignals.push(`Ultimo inbound: "${messageSnippet(evidence.last_inbound, 92)}"`);
   if (evidence.last_outbound) specificSignals.push(`Ultimo outbound team: "${messageSnippet(evidence.last_outbound, 92)}"`);
   if (mediaLabel) specificSignals.push(`Media nel thread: ${mediaLabel}`);
-  if (evidence.has_question) specificSignals.push("C'è una domanda nel blocco recente");
   if (evidence.has_thanks) specificSignals.push("L'ultimo inbound è un ringraziamento/conferma");
   specificSignals.push(evidence.needs_reply ? "Palla al team: ultimo inbound/non letto da chiudere" : "Team già intervenuto dopo l'ultimo inbound");
 
   let intent = "status";
   if (conv?.tag === "internal") intent = "internal";
+  else if (evidence.needs_reply && evidence.open_questions?.length) intent = "question";
+  else if (evidence.needs_reply && evidence.last_meaningful_customer_info) intent = "info";
   else if (evidence.has_thanks) intent = "thanks";
-  else if (evidence.has_question) intent = "question";
-  else if (evidence.last_inbound && !/^\[[a-z]+\]$/i.test(evidence.last_inbound)) intent = "info";
-  else if (media.length) intent = "media";
+  else if (evidence.needs_reply && evidence.last_inbound_is_media_only) intent = "media";
+  else if (evidence.recap) intent = "recap_monitor";
   else if (!evidence.needs_reply) intent = "already_replied";
 
   const stateByIntent = {
@@ -1026,19 +1095,25 @@ function buildSpecificCaseAnalysis(conv, evidence) {
     info: "Dato operativo ricevuto: integrare nel caso",
     media: "Documento/media ricevuto: verifica e next step",
     internal: "Coordinamento interno: owner e blocco",
+    recap_monitor: "Recap strategico presente: monitoraggio informato",
     already_replied: "Già risposto: monitoraggio",
     status: conv?.crm_match ? "Cliente CRM: update da chiarire" : "Lead/prospect: qualificazione",
   };
+  const recapClause = evidence.recap
+    ? ` Usa anche il recap già salvato (${evidence.recap_source || "CRM/WA"}): "${messageSnippet(evidence.recap, 150)}".`
+    : " Non trova un recap già salvato, quindi costruisce la lettura dal thread locale.";
+  const threadClause = `Zantara ha letto tutto il thread disponibile (${evidence.count || 0} messaggi: ${evidence.inbound_count || 0} inbound, ${evidence.outbound_count || 0} outbound).`;
   const reasoningByIntent = {
-    thanks: `Zantara non legge questo come una nuova richiesta: l'ultimo inbound è un ringraziamento${mediaLabel ? ` e nel thread ci sono media (${mediaLabel})` : ""}. La risposta ideale è breve, conferma ricezione e lascia aperto l'update se serve.`,
-    question: `Zantara vede una domanda nel blocco recente e quindi non deve chiudere con un messaggio generico: deve verificare la pratica e rispondere al punto preciso.`,
-    info: `Zantara vede che l'ultimo inbound contiene un dato operativo concreto, non solo cortesia o allegato. Deve confermare che il dato è stato annotato e collegarlo al prossimo passaggio della pratica.`,
-    media: `Zantara vede media/documenti nel thread (${mediaLabel}). Il passaggio corretto è confermare ricezione, controllare il contenuto e promettere un next step verificabile.`,
-    internal: "Zantara tratta questa chat come coordinamento interno: non risposta cliente, ma owner, blocco, decisione richiesta e prossimo controllo.",
-    already_replied: "Zantara vede che il team è già intervenuto dopo l'ultimo inbound: non deve spingere un nuovo messaggio, deve monitorare fino a nuova domanda o scadenza.",
+    thanks: `${threadClause}${recapClause} L'ultimo inbound è un ringraziamento/conferma: la risposta ideale è breve, conferma ricezione e lascia aperto l'update se serve.`,
+    question: `${threadClause}${recapClause} Nel thread ci sono ${evidence.question_count || 1} domanda/e cliente: non deve chiudere con un messaggio generico, deve rispondere al punto preciso e collegarlo alla pratica.`,
+    info: `${threadClause}${recapClause} L'ultimo dato cliente utile non è solo cortesia o allegato: va confermato, annotato e collegato al prossimo passaggio della pratica.`,
+    media: `${threadClause}${recapClause} Ha visto media/documenti nel thread (${mediaLabel}). Il passaggio corretto è confermare ricezione, controllare il contenuto e promettere un next step verificabile.`,
+    internal: `${threadClause}${recapClause} Questa è una chat di coordinamento interno: non risposta cliente, ma owner, blocco, decisione richiesta e prossimo controllo.`,
+    recap_monitor: `${threadClause} Parte dal recap strategico già salvato (${evidence.recap_source || "CRM/WA"}) e controlla che non ci sia una palla cliente più recente. In assenza di nuova domanda, deve monitorare o preparare un update interno.`,
+    already_replied: `${threadClause}${recapClause} Il team è già intervenuto dopo l'ultimo inbound: non deve spingere un nuovo messaggio, deve monitorare fino a nuova domanda o scadenza.`,
     status: evidence.needs_reply
-      ? "Zantara vede una palla aperta sul team: serve un update concreto, non una frase generica."
-      : "Zantara vede una conversazione stabile: serve solo monitoraggio o un update programmato.",
+      ? `${threadClause}${recapClause} Vede una palla aperta sul team: serve un update concreto, non una frase generica.`
+      : `${threadClause}${recapClause} La conversazione è stabile: serve solo monitoraggio o un update programmato.`,
   };
   const nextByIntent = {
     thanks: "Rispondere con acknowledgement breve; niente escalation.",
@@ -1046,6 +1121,7 @@ function buildSpecificCaseAnalysis(conv, evidence) {
     info: "Confermare il dato ricevuto e spiegare che verrà usato nel caso.",
     media: "Confermare ricezione del media/documento e dire quando arriva l'update.",
     internal: "Scrivere owner brief: richiesta, blocco, decisione, prossimo controllo.",
+    recap_monitor: "Usare il recap come base; non inviare finché non c'è nuova domanda o cambio stato.",
     already_replied: "Non inviare ora; monitorare e riaprire solo se cambia lo stato.",
     status: evidence.needs_reply ? "Preparare update cliente con stato, blocco e prossimo passaggio." : "Tenere in monitoraggio e aggiornare solo se serve.",
   };
@@ -1145,16 +1221,22 @@ function renderCaseCaptainCard(conv, pd, payload) {
   const type = caseKindLabel(conv);
   const urgency = caseUrgencyLabel(conv);
   const signals = (d.specificSignals?.length ? d.specificSignals : d.signals || []).slice(0, 6);
+  const topicLabel = evidence.topics?.length ? evidence.topics.join(", ") : "nessun topic forte";
   return `<div class="case-captain-card">
     <div class="case-title-row">
-      <div class="case-title">Zantara legge questa conversazione</div>
+      <div class="case-title">Zantara legge tutta la conversazione</div>
       <div class="case-shadow-pill">bozza non inviata</div>
     </div>
     <div class="case-grid-mini">
       <div class="case-mini"><div class="label">Conversazione</div><div class="value">${escapeHtml(type)} · ${evidence.count || conv.n || 0} messaggi</div></div>
+      <div class="case-mini"><div class="label">Analisi</div><div class="value">${escapeHtml(`${evidence.inbound_count || 0} cliente/inbound · ${evidence.outbound_count || 0} team/outbound · ${topicLabel}`)}</div></div>
       <div class="case-mini"><div class="label">Stato Zantara</div><div class="value">${escapeHtml(d.state)} · ${escapeHtml(urgency)}</div></div>
       <div class="case-mini"><div class="label">Prossima mossa</div><div class="value">${escapeHtml(d.next)}</div></div>
     </div>
+    ${evidence.recap ? `<div class="case-local-context">
+      <div class="label">Recap già trovato nel corpus</div>
+      <div class="value">${escapeHtml(evidence.recap)}</div>
+    </div>` : ""}
     <div class="case-reasoning-grid">
       <div class="case-local-context">
         <div class="label">Perché lo pensa su questa chat</div>

--- a/apps/wa-dashboard-m1/viewer.html
+++ b/apps/wa-dashboard-m1/viewer.html
@@ -410,17 +410,238 @@
   .m-delta.down { color: #08820a; }
   .metrics-legend { margin-top: 14px; font-size: 12px; color: var(--wa-text-3); line-height: 1.7; }
   .metrics-legend b { color: var(--wa-text-2); font-weight: 600; }
+  .status-banner {
+    background: #fff7d6; border: 1px solid #f4d47b; color: #6f5200;
+    padding: 10px 12px; border-radius: 8px; margin-bottom: 14px;
+    font-size: 13px; line-height: 1.5;
+  }
+  .status-banner.error { background: #fff0f1; border-color: #f4b8bd; color: #8a1f2b; }
+  .captain-view {
+    height: calc(100vh - 60px); overflow-y: auto;
+    background: var(--wa-bg); padding: 24px 32px;
+  }
+  .captain-header h2 { font-size: 20px; font-weight: 650; color: var(--wa-text); margin: 0 0 4px; }
+  .captain-sub { font-size: 13px; color: var(--wa-text-2); margin-bottom: 18px; }
+  .captain-hero {
+    display: grid; grid-template-columns: 1.15fr 0.85fr;
+    gap: 12px; margin-bottom: 14px;
+  }
+  .captain-panel {
+    background: var(--wa-panel); border: 1px solid var(--wa-divider);
+    border-radius: 8px; padding: 16px;
+  }
+  .captain-panel h3 {
+    margin: 0 0 10px; color: var(--wa-text); font-size: 15px; font-weight: 650;
+  }
+  .captain-panel p, .captain-panel li {
+    color: var(--wa-text-2); font-size: 13px; line-height: 1.45;
+  }
+  .captain-panel p { margin: 0; }
+  .captain-panel ul { margin: 0; padding-left: 18px; }
+  .captain-focus {
+    display: flex; gap: 10px; flex-wrap: wrap; margin-top: 12px;
+  }
+  .captain-focus span {
+    background: var(--wa-panel-3); color: var(--wa-text-2);
+    border-radius: 999px; padding: 4px 9px; font-size: 12px;
+  }
+  .captain-flow {
+    display: grid; grid-template-columns: repeat(5, minmax(130px, 1fr));
+    gap: 10px; margin: 14px 0;
+  }
+  .captain-step {
+    background: var(--wa-panel); border: 1px solid var(--wa-divider);
+    border-radius: 8px; padding: 13px; min-height: 122px;
+  }
+  .captain-step .kicker {
+    color: var(--wa-accent); font-size: 11px; text-transform: uppercase;
+    font-weight: 700; margin-bottom: 7px;
+  }
+  .captain-step .title { color: var(--wa-text); font-weight: 650; margin-bottom: 5px; }
+  .captain-step .copy { color: var(--wa-text-2); font-size: 12px; line-height: 1.4; }
+  .captain-case-grid {
+    display: grid; grid-template-columns: 0.95fr 1.05fr 1fr;
+    gap: 12px; margin: 14px 0;
+  }
+  .case-captain-card {
+    margin: 12px 8% 0;
+    background: var(--wa-panel); border: 1px solid var(--wa-divider);
+    border-left: 4px solid var(--wa-accent);
+    border-radius: 8px; padding: 12px 14px;
+    box-shadow: 0 1px 0.5px rgba(0,0,0,0.08);
+  }
+  .case-captain-card .case-title,
+  .captain-case-title {
+    font-weight: 650; color: var(--wa-text); margin-bottom: 7px;
+  }
+  .case-captain-card .case-grid-mini {
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px;
+  }
+  .case-mini {
+    background: var(--wa-panel-3); border-radius: 8px; padding: 9px;
+  }
+  .case-mini .label {
+    color: var(--wa-text-3); font-size: 10px; text-transform: uppercase; font-weight: 700;
+    margin-bottom: 4px;
+  }
+  .case-mini .value {
+    color: var(--wa-text); font-size: 12px; line-height: 1.35;
+  }
+  .captain-action-row { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px; }
+  .captain-action-row button {
+    background: var(--wa-accent); color: #fff; border: 1px solid var(--wa-accent);
+    border-radius: 8px; padding: 7px 12px; cursor: pointer; font-family: inherit; font-size: 13px;
+  }
+  .captain-action-row button.secondary {
+    background: var(--wa-panel); color: var(--wa-text-2); border-color: var(--wa-border);
+  }
+  .captain-table-note {
+    color: var(--wa-text-3); font-size: 12px; margin-top: 10px; line-height: 1.5;
+  }
+  .training-top {
+    display: grid; grid-template-columns: repeat(6, minmax(110px, 1fr));
+    gap: 10px; margin: 18px 0;
+  }
+  .training-card {
+    background: var(--wa-panel); border: 1px solid var(--wa-divider);
+    border-radius: 8px; padding: 12px; min-height: 78px;
+  }
+  .training-card .label { color: var(--wa-text-2); font-size: 11px; text-transform: uppercase; font-weight: 600; }
+  .training-card .value { color: var(--wa-text); font-size: 24px; font-weight: 600; margin-top: 6px; }
+  .training-card .sub { color: var(--wa-text-3); font-size: 12px; margin-top: 2px; }
+  .training-actions { display: flex; align-items: center; gap: 8px; margin-top: 10px; }
+  .training-actions button {
+    background: var(--wa-accent); color: #fff; border: 1px solid var(--wa-accent);
+    border-radius: 8px; padding: 7px 12px; cursor: pointer; font-family: inherit; font-size: 13px;
+  }
+  .training-actions button.secondary { background: var(--wa-panel); color: var(--wa-text-2); border-color: var(--wa-border); }
+  .human-strip {
+    display: grid; grid-template-columns: 1.2fr 1fr 1fr;
+    gap: 10px; margin: 18px 0;
+  }
+  .human-card {
+    background: var(--wa-panel); border: 1px solid var(--wa-divider);
+    border-radius: 8px; padding: 14px; min-height: 108px;
+  }
+  .human-card h3 { margin: 0 0 8px; font-size: 14px; color: var(--wa-text); }
+  .human-card p { margin: 0; color: var(--wa-text-2); line-height: 1.45; font-size: 13px; }
+  .human-card strong { color: var(--wa-text); font-weight: 600; }
+  .learning-flow {
+    display: grid; grid-template-columns: repeat(5, 1fr);
+    gap: 8px; margin-bottom: 18px;
+  }
+  .flow-step {
+    background: var(--wa-panel); border: 1px solid var(--wa-divider);
+    border-radius: 8px; padding: 12px; min-height: 100px;
+  }
+  .flow-step .num {
+    width: 24px; height: 24px; border-radius: 50%; background: var(--wa-accent);
+    color: white; display: flex; align-items: center; justify-content: center;
+    font-size: 12px; font-weight: 700; margin-bottom: 8px;
+  }
+  .flow-step .title { font-weight: 600; color: var(--wa-text); margin-bottom: 4px; }
+  .flow-step .copy { color: var(--wa-text-2); font-size: 12px; line-height: 1.4; }
+  .training-filterbar {
+    display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin: 0 0 12px;
+  }
+  .training-filterbar input {
+    background: var(--wa-panel); border: 1px solid var(--wa-border);
+    border-radius: 8px; padding: 8px 10px; min-width: 260px;
+    font: inherit; color: var(--wa-text); outline: none;
+  }
+  .filter-chip {
+    border: 1px solid var(--wa-border); background: var(--wa-panel); color: var(--wa-text-2);
+    border-radius: 999px; padding: 6px 10px; cursor: pointer; font: inherit; font-size: 12px;
+  }
+  .filter-chip.active { background: var(--wa-accent); color: #fff; border-color: var(--wa-accent); }
+  .training-grid {
+    display: grid; grid-template-columns: repeat(4, minmax(180px, 1fr));
+    gap: 10px; margin-bottom: 18px;
+  }
+  .training-category {
+    background: var(--wa-panel); border: 1px solid var(--wa-divider);
+    border-left: 4px solid var(--wa-accent); border-radius: 8px; padding: 12px;
+  }
+  .training-category.blue { border-left-color: #3b82f6; }
+  .training-category.cyan { border-left-color: #06b6d4; }
+  .training-category.gold { border-left-color: #fbbf24; }
+  .training-category.violet { border-left-color: #a855f7; }
+  .training-category.orange { border-left-color: #f59e0b; }
+  .training-category.slate { border-left-color: #64748b; }
+  .training-category .title { font-weight: 600; color: var(--wa-text); font-size: 14px; }
+  .training-category .meta { color: var(--wa-text-3); font-size: 12px; margin-top: 4px; }
+  .training-kv { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 8px; }
+  .training-kv span {
+    background: var(--wa-panel-3); color: var(--wa-text-2); border-radius: 10px;
+    padding: 2px 7px; font-size: 11px;
+  }
+  .training-table td.path { color: var(--wa-text-3); font-size: 12px; max-width: 360px; overflow: hidden; text-overflow: ellipsis; }
+  .training-table-wrap { overflow-x: auto; }
+  .training-table { table-layout: fixed; min-width: 980px; }
+  .training-table th, .training-table td {
+    text-align: left; white-space: normal; vertical-align: top;
+  }
+  .training-table th:nth-child(1) { width: 24%; }
+  .training-table th:nth-child(2) { width: 16%; }
+  .training-table th:nth-child(3) { width: 12%; }
+  .training-table th:nth-child(4) { width: 28%; }
+  .training-table th:nth-child(5) { width: 20%; }
+  .training-table td.path {
+    max-width: none; overflow: visible; text-overflow: clip; word-break: break-word;
+  }
+  .training-table .metric-chip {
+    display: inline-block; background: var(--wa-panel-3); color: var(--wa-text-2);
+    border-radius: 10px; padding: 2px 7px; margin: 1px; font-size: 11px;
+  }
+  @media (max-width: 1200px) {
+    main { grid-template-columns: 220px 340px 1fr; }
+    .captain-flow { grid-template-columns: repeat(3, 1fr); }
+    .captain-case-grid { grid-template-columns: 1fr; }
+    .training-top { grid-template-columns: repeat(3, 1fr); }
+    .training-grid { grid-template-columns: repeat(2, minmax(180px, 1fr)); }
+  }
+  @media (max-width: 860px) {
+    header { gap: 10px; padding: 10px 12px; height: auto; flex-wrap: wrap; }
+    .view-tabs { order: 3; width: 100%; justify-content: flex-start; }
+    .metrics-view, .captain-view { padding: 18px 14px; }
+    .captain-hero { grid-template-columns: 1fr; }
+    .captain-flow { grid-template-columns: 1fr; }
+    .case-captain-card { margin: 10px 12px 0; }
+    .case-captain-card .case-grid-mini { grid-template-columns: 1fr; }
+    .training-top { grid-template-columns: repeat(2, minmax(130px, 1fr)); }
+    .training-grid { grid-template-columns: 1fr; }
+    .human-strip { grid-template-columns: 1fr; }
+    .learning-flow { grid-template-columns: repeat(2, 1fr); }
+    .training-filterbar input { min-width: 100%; }
+    .training-table { min-width: 0; }
+    .training-table thead { display: none; }
+    .training-table tbody, .training-table tr, .training-table td { display: block; width: 100%; box-sizing: border-box; }
+    .training-table tr { border-bottom: 1px solid var(--wa-divider); padding: 10px 12px; }
+    .training-table td {
+      border-bottom: 0; padding: 5px 0 5px 96px; min-height: 26px;
+      text-align: left; white-space: normal; position: relative;
+    }
+    .training-table td::before {
+      content: attr(data-label); position: absolute; left: 0; top: 5px; width: 84px;
+      color: var(--wa-text-3); font-size: 11px; text-transform: uppercase; font-weight: 600;
+    }
+    .training-table td.path {
+      max-width: none; overflow: visible; text-overflow: clip; word-break: break-word;
+    }
+  }
 </style>
 </head>
 <body>
 <header>
   <div class="brand">
     <div class="brand-icon">BZ</div>
-    <span>WhatsApp Dashboard</span>
+    <span>Zantara Case Captain</span>
   </div>
   <div class="view-tabs">
-    <button class="view-tab active" data-view="convs">Conversazioni</button>
-    <button class="view-tab" data-view="metrics">Qualità Team</button>
+    <button class="view-tab active" data-view="convs">Conversazioni live</button>
+    <button class="view-tab" data-view="captain">Zantara risolve</button>
+    <button class="view-tab" data-view="training">Training academy</button>
+    <button class="view-tab" data-view="metrics">Team</button>
   </div>
   <div class="meta">
     <span id="health-pill" class="badge">read-only</span>
@@ -430,21 +651,30 @@
 </header>
 <main id="view-convs">
   <div class="col" id="col-teams">
-    <div class="col-header">Team</div>
+    <div class="col-header">1 · Team</div>
     <div class="loader">Caricamento team…</div>
   </div>
   <div class="col" id="col-convs">
-    <div class="col-header">Conversazioni</div>
+    <div class="col-header">2 · Conversazioni live</div>
     <div class="empty">Seleziona un team member</div>
   </div>
   <div class="col" id="col-thread">
     <div class="empty-wa">
-      <div class="icon">💬</div>
-      <div class="text">BZ WhatsApp Dashboard</div>
-      <div class="sub">Seleziona una conversazione per leggere i messaggi.</div>
+      <div class="icon">Z</div>
+      <div class="text">Conversazioni live</div>
+      <div class="sub">Team a sinistra, conversazioni al centro, messaggi qui.</div>
     </div>
   </div>
 </main>
+<section id="view-captain" class="captain-view" style="display:none">
+  <div class="captain-header">
+    <h2>Zantara risolve il caso</h2>
+    <div class="captain-sub" id="c-sub">Shadow mode: diagnosi, piano, bozza e controllo umano. Nessun invio WhatsApp, nessuna scrittura CRM.</div>
+  </div>
+  <div id="c-root">
+    <div class="loader">Caricamento ragionamento…</div>
+  </div>
+</section>
 <section id="view-metrics" class="metrics-view" style="display:none">
   <div class="metrics-header">
     <h2>Qualità conversazioni — ultimi <span id="m-window">30</span> giorni</h2>
@@ -455,6 +685,19 @@
   </div>
   <div class="metrics-legend" id="m-legend"></div>
 </section>
+<section id="view-training" class="metrics-view" style="display:none">
+  <div class="metrics-header">
+    <h2>Zantara training locale</h2>
+    <div class="metrics-sub" id="t-sub">Caricamento…</div>
+    <div class="training-actions">
+      <button id="t-refresh">Aggiorna</button>
+      <button id="t-open-corpus" class="secondary">Corpus locale</button>
+    </div>
+  </div>
+  <div id="t-root">
+    <div class="loader">Caricamento training…</div>
+  </div>
+</section>
 <script>
 let DATA = null;
 let SELECTED_TEAM = null;
@@ -462,6 +705,9 @@ let SELECTED_CONV = null;
 let THREAD_SEARCH = "";
 let THREAD_CACHE = null;
 let THREAD_CACHE_KEY = null;
+let TRAINING = null;
+let TRAINING_FILTER = "all";
+let TRAINING_QUERY = "";
 const KITA_BASE = "https://kita.balizero.com";
 
 const colTeams = document.getElementById("col-teams");
@@ -480,6 +726,24 @@ function fmtTime(iso) {
   const y = new Date(now); y.setDate(y.getDate()-1);
   if (d.toDateString() === y.toDateString()) return "ieri " + d.toLocaleTimeString("it-IT", { hour:"2-digit", minute:"2-digit" });
   return d.toLocaleDateString("it-IT", { day:"2-digit", month:"2-digit" }) + " " + d.toLocaleTimeString("it-IT", { hour:"2-digit", minute:"2-digit" });
+}
+
+function fmtDateTime(iso) {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString("it-IT", { day:"2-digit", month:"2-digit", year:"2-digit" })
+    + " " + d.toLocaleTimeString("it-IT", { hour:"2-digit", minute:"2-digit" });
+}
+
+function compactMetricLabel(label) {
+  return String(label || "")
+    .replace("Human Approval Required", "Approval")
+    .replace("Awaiting Owner Decision", "Owner wait")
+    .replace("Training Examples", "Examples")
+    .replace("Replay Scenarios", "Replays")
+    .replace("Whatsapp Sends", "WA sends")
+    .replace("Crm Mutations", "CRM writes");
 }
 
 function fmtPreview(c) {
@@ -513,6 +777,200 @@ function companyBadgeLabel(m) {
   return "BZ";
 }
 
+function currentCaseContext() {
+  if (!DATA || !SELECTED_TEAM) return { member: null, pd: null, conv: null };
+  const member = DATA.team.find((m) => m.phone === SELECTED_TEAM) || null;
+  const pd = DATA.by_phone[SELECTED_TEAM] || null;
+  const conv = pd && SELECTED_CONV ? pd.convs.find((c) => c.counterpart === SELECTED_CONV) || null : null;
+  return { member, pd, conv };
+}
+
+function caseKindLabel(conv) {
+  if (!conv) return "Nessun caso";
+  if (conv.kind === "group") return conv.crm_match ? "Gruppo cliente" : "Gruppo operativo";
+  if (conv.tag === "internal") return "Thread interno";
+  if (conv.crm_match) return "Cliente CRM";
+  return "Prospect / lead";
+}
+
+function caseUrgencyLabel(conv) {
+  if (!conv) return "—";
+  if (conv.attention_priority === "HIGH") return "Alta: richiede gestione prima delle code normali";
+  if (conv.attention_priority === "MEDIUM") return "Media: va chiarita o sbloccata";
+  if (conv.unread_count) return "Aperta: ci sono messaggi non ancora chiusi";
+  return "Monitor: nessun segnale urgente dal mirror";
+}
+
+function zantaraCaseDiagnosis(conv, pd) {
+  if (!conv) {
+    return {
+      state: "Nessuna conversazione selezionata",
+      reasoning: "Zantara resta in attesa di un caso live.",
+      next: "Aprire una conversazione per costruire diagnosi e piano di chiusura.",
+      draft: "Nessuna bozza generata.",
+      gate: "Shadow mode attivo.",
+      signals: ["0 invii WhatsApp", "0 scritture CRM", "approval umano richiesto"],
+    };
+  }
+
+  const signals = [];
+  if (conv.crm_match) signals.push(`Aggancio CRM #${conv.client_id || "presente"}`);
+  else signals.push("Nessun aggancio CRM: qualificazione lead/prospect");
+  if (conv.assigned_to) signals.push(`Owner operativo: ${conv.assigned_to.replace("@balizero.com", "")}`);
+  if (conv.tax_consultant) signals.push(`Tax: ${conv.tax_consultant}`);
+  if (conv.unread_count) signals.push(`${conv.unread_count} messaggi da chiudere`);
+  if (conv.attention_priority) signals.push(`Priorità ${conv.attention_priority}`);
+  if (conv.kind === "group") signals.push("Thread gruppo: serve sintesi decisionale");
+  if (pd?.team?.name) signals.push(`Operatore: ${pd.team.name}`);
+
+  if (conv.tag === "internal") {
+    return {
+      state: "Coordinamento interno",
+      reasoning: "Zantara non risponde al cliente: separa task interno, decisione richiesta e operatore responsabile.",
+      next: "Creare pacchetto operativo: richiesta, owner, deadline, blocco, prossimo controllo.",
+      draft: "Chiarire cosa manca, chi decide e quando va richiuso.",
+      gate: "Non esce su WhatsApp cliente.",
+      signals,
+    };
+  }
+
+  if (conv.kind === "group") {
+    return {
+      state: conv.crm_match ? "Caso cliente in gruppo" : "Gruppo da classificare",
+      reasoning: "Zantara isola la richiesta reale dentro il gruppo, distingue update, domanda, urgenza e decisione mancante.",
+      next: conv.attention_priority ? "Produrre owner brief e risposta controllata." : "Preparare sintesi breve e prossima azione verificabile.",
+      draft: "Riepilogo stato, punto bloccante, chi deve rispondere, prossimo step.",
+      gate: "Invio solo dopo approvazione operatore/owner.",
+      signals,
+    };
+  }
+
+  if (!conv.crm_match) {
+    return {
+      state: "Lead da qualificare",
+      reasoning: "Zantara ricostruisce bisogno, timing, servizio richiesto, urgenza e dati mancanti prima di assegnare o quotare.",
+      next: "Qualificare servizio, scadenza, paese/passaporto, budget e disponibilità documenti; poi proporre owner.",
+      draft: "Domanda corta, chiara, orientata a chiudere il requisito mancante.",
+      gate: "Nessuna creazione CRM automatica.",
+      signals,
+    };
+  }
+
+  return {
+    state: "Cliente CRM da chiudere",
+    reasoning: "Zantara collega chat e pratica CRM, controlla ultimo messaggio, scadenze, documenti mancanti e responsabilità.",
+    next: conv.attention_priority ? "Aprire owner brief: rischio, cosa manca, risposta consigliata." : "Preparare update cliente con stato pratica e prossimo passaggio.",
+    draft: "Conferma ricezione, stato, documento o decisione richiesta, prossima data.",
+    gate: "Invio e CRM write restano manuali.",
+    signals,
+  };
+}
+
+function renderCaseCaptainCard(conv, pd, messageCount) {
+  const d = zantaraCaseDiagnosis(conv, pd);
+  const type = caseKindLabel(conv);
+  const urgency = caseUrgencyLabel(conv);
+  return `<div class="case-captain-card">
+    <div class="case-title">Zantara shadow su questo caso</div>
+    <div class="case-grid-mini">
+      <div class="case-mini"><div class="label">Conversazione</div><div class="value">${escapeHtml(type)} · ${messageCount || conv.n || 0} messaggi</div></div>
+      <div class="case-mini"><div class="label">Diagnosi</div><div class="value">${escapeHtml(d.state)} · ${escapeHtml(urgency)}</div></div>
+      <div class="case-mini"><div class="label">Prossima azione</div><div class="value">${escapeHtml(d.next)}</div></div>
+    </div>
+  </div>`;
+}
+
+function renderCaptainFlow() {
+  const steps = [
+    ["1", "Conversazione", "Legge il thread live e separa cliente, gruppo, prospect o interno."],
+    ["2", "Contesto", "Aggancia CRM, owner, priorità, non letti e recap strategico se esiste."],
+    ["3", "Diagnosi", "Capisce cosa blocca il caso: requisito mancante, decisione, rischio o update."],
+    ["4", "Piano", "Produce prossima azione, owner brief e bozza shadow."],
+    ["5", "Chiusura", "Passa da umano: invio WA e CRM write restano a zero finché approvati."],
+  ];
+  return `<div class="captain-flow">${steps.map((s) => `
+    <div class="captain-step">
+      <div class="kicker">Step ${escapeHtml(s[0])}</div>
+      <div class="title">${escapeHtml(s[1])}</div>
+      <div class="copy">${escapeHtml(s[2])}</div>
+    </div>`).join("")}</div>`;
+}
+
+function renderCaptainPanel() {
+  const root = document.getElementById("c-root");
+  const subEl = document.getElementById("c-sub");
+  if (!root || !subEl) return;
+  const { member, pd, conv } = currentCaseContext();
+  const d = zantaraCaseDiagnosis(conv, pd);
+  const trainingCards = TRAINING?.total_cards || {
+    training_examples: "—", replay_scenarios: "—", shadow_drafts: "—",
+    owner_queue: "—", whatsapp_sends: "0", crm_mutations: "0",
+  };
+  const caseName = conv ? conv.display_name : "Nessun caso selezionato";
+  const caseMeta = conv
+    ? `${caseKindLabel(conv)} · ${member?.name || "team"} · ${conv.n || 0} messaggi · ${caseUrgencyLabel(conv)}`
+    : "Apri Conversazioni live, scegli team e thread: qui appare la diagnosi del caso.";
+
+  subEl.textContent = `${caseName} — ${caseMeta}`;
+  root.innerHTML = `
+    <div class="captain-hero">
+      <div class="captain-panel">
+        <h3>Dal messaggio alla chiusura</h3>
+        <p>Zantara non è una lista di chat: è un processo shadow. Prende una conversazione, ricostruisce contesto e blocco, propone la prossima azione, poi lascia invio e CRM all'umano.</p>
+        <div class="captain-focus">
+          <span>${escapeHtml(trainingCards.training_examples)} esempi</span>
+          <span>${escapeHtml(trainingCards.shadow_drafts)} shadow draft</span>
+          <span>${escapeHtml(trainingCards.owner_queue)} segnali owner</span>
+          <span>${escapeHtml(trainingCards.whatsapp_sends)} WA sends</span>
+          <span>${escapeHtml(trainingCards.crm_mutations)} CRM writes</span>
+        </div>
+        <div class="captain-action-row">
+          <button data-view-jump="convs">Conversazioni live</button>
+          <button class="secondary" data-view-jump="training">Training academy</button>
+        </div>
+      </div>
+      <div class="captain-panel">
+        <h3>Caso selezionato</h3>
+        <p><strong>${escapeHtml(caseName)}</strong></p>
+        <div class="captain-focus">
+          <span>${escapeHtml(caseKindLabel(conv))}</span>
+          <span>${escapeHtml(d.state)}</span>
+          <span>${escapeHtml(d.gate)}</span>
+        </div>
+      </div>
+    </div>
+    ${renderCaptainFlow()}
+    <div class="captain-case-grid">
+      <div class="captain-panel">
+        <h3>Segnali letti</h3>
+        <ul>${d.signals.map((s) => `<li>${escapeHtml(s)}</li>`).join("")}</ul>
+      </div>
+      <div class="captain-panel">
+        <h3>Come ragiona</h3>
+        <p>${escapeHtml(d.reasoning)}</p>
+        <div class="captain-table-note">Non mostra chain-of-thought interna: espone diagnosi operativa verificabile.</div>
+      </div>
+      <div class="captain-panel">
+        <h3>Come risolve</h3>
+        <p><strong>Next best action:</strong> ${escapeHtml(d.next)}</p>
+        <p style="margin-top:10px"><strong>Bozza shadow:</strong> ${escapeHtml(d.draft)}</p>
+      </div>
+    </div>
+    <div class="status-banner">Contratto: shadow mode locale. La webapp legge mirror e summary, non invia messaggi, non scrive CRM e non sostituisce l'approvazione owner.</div>`;
+}
+
+async function renderCaptain() {
+  const root = document.getElementById("c-root");
+  if (!root) return;
+  if (!TRAINING) {
+    try {
+      const r = await fetch("/training.json");
+      if (r.ok) TRAINING = await r.json();
+    } catch {}
+  }
+  renderCaptainPanel();
+}
+
 function renderTeams() {
   if (!DATA) return;
   // 2026-05-26 sort: ZERO first, then Bali Zero, then Bayu Santera (company hierarchy)
@@ -520,7 +978,7 @@ function renderTeams() {
     const rank = (m) => m.contact_kind === "zero" ? 0 : m.contact_kind === "team_bayu" ? 2 : 1;
     return rank(a) - rank(b);
   });
-  let html = `<div class="col-header">Team · ${DATA.team.length}</div>`;
+  let html = `<div class="col-header">1 · Team · ${DATA.team.length}</div>`;
   for (const m of teamOrder) {
     const pd = DATA.by_phone[m.phone] || { total:0, direct_count:0, group_count:0, crm_count:0, attention:{high:0,medium:0} };
     const selected = SELECTED_TEAM === m.phone ? " selected" : "";
@@ -560,9 +1018,17 @@ function renderTeams() {
 }
 
 function renderConvs() {
+  if (DATA && DATA.degraded) {
+    colConvs.innerHTML = `<div class="col-header">2 · Conversazioni live</div>
+      <div class="empty">
+        DB locale non raggiungibile.<br/>
+        ${escapeHtml(DATA.error || "Le conversazioni sono temporaneamente offline.")}
+      </div>`;
+    return;
+  }
   const pd = SELECTED_TEAM ? DATA.by_phone[SELECTED_TEAM] : null;
   if (!pd) {
-    colConvs.innerHTML = `<div class="col-header">Conversazioni</div><div class="empty">Seleziona un team member</div>`;
+    colConvs.innerHTML = `<div class="col-header">2 · Conversazioni live</div><div class="empty">Seleziona un team member</div>`;
     return;
   }
   // Sort: HIGH always first, then strictly by last_at DESC (most recent wins, regardless of MEDIUM tag)
@@ -576,7 +1042,7 @@ function renderConvs() {
   const headerExtra = pd.attention.high || pd.attention.medium
     ? ` <span style="color:var(--wa-error);font-weight:500">· ${pd.attention.high} HIGH</span>${pd.attention.medium ? ` <span style="color:var(--wa-warning)">· ${pd.attention.medium} MED</span>` : ""}`
     : "";
-  let html = `<div class="col-header">${convs.length} conversazioni${headerExtra}</div>`;
+  let html = `<div class="col-header">2 · ${convs.length} conversazioni${headerExtra}</div>`;
   if (!convs.length) {
     html += `<div class="empty">Nessuna conversazione</div>`;
   } else {
@@ -662,8 +1128,17 @@ function highlightMatch(text, query) {
 }
 
 async function renderThread() {
+  if (DATA && DATA.degraded) {
+    colThread.innerHTML = `<div class="empty-wa">
+      <div class="icon">DB</div>
+      <div class="text">Database offline</div>
+      <div class="sub">La webapp resta attiva; Training e salute servizio sono ancora disponibili.</div>
+    </div>`;
+    THREAD_CACHE = null; THREAD_CACHE_KEY = null;
+    return;
+  }
   if (!SELECTED_TEAM || !SELECTED_CONV) {
-    colThread.innerHTML = `<div class="col-header">Messaggi</div><div class="empty">Seleziona una conversazione</div>`;
+    colThread.innerHTML = `<div class="col-header">3 · Messaggi + Zantara</div><div class="empty">Seleziona una conversazione</div>`;
     THREAD_CACHE = null; THREAD_CACHE_KEY = null;
     return;
   }
@@ -704,6 +1179,7 @@ async function renderThread() {
 
   const convDisplay = conv ? conv.display_name : SELECTED_CONV;
   const headerAvatarClass = conv?.kind === "group" ? "group" : conv?.tag === "crm" ? "crm" : conv?.tag === "prospect" ? "prospect" : "";
+  const captainHtml = conv ? renderCaseCaptainCard(conv, pd, payload.count) : "";
 
   // Filter messages by search query (case-insensitive, matches body + sender)
   const q = THREAD_SEARCH.trim().toLowerCase();
@@ -731,6 +1207,7 @@ async function renderThread() {
         ${q ? `<button id="thread-search-clear" title="Esc per pulire" style="background:transparent;border:none;color:var(--wa-text-3);cursor:pointer;font-size:14px">✕</button>` : ""}
       </div>
     </div>
+    ${captainHtml}
     ${recapHtml}
     <div class="thread-body">`;
   let lastDay = "";
@@ -792,20 +1269,24 @@ function selectTeam(phone) {
   THREAD_SEARCH = "";
   THREAD_CACHE = null; THREAD_CACHE_KEY = null;
   renderTeams(); renderConvs(); renderThread();
+  if (CURRENT_VIEW === "captain") renderCaptain();
 }
 function selectConv(conv) {
   SELECTED_CONV = conv;
   THREAD_SEARCH = "";
   renderConvs(); renderThread();
+  if (CURRENT_VIEW === "captain") renderCaptain();
 }
 
 async function refresh() {
   try {
     const r = await fetch("/data.json");
+    if (!r.ok) throw new Error(`data ${r.status}`);
     DATA = await r.json();
     document.getElementById("last-refresh").textContent = "refresh: " + new Date(DATA.generated_at).toLocaleTimeString("it-IT");
     if (!SELECTED_TEAM && DATA.team.length) SELECTED_TEAM = DATA.team[0].phone;
     renderTeams(); renderConvs(); renderThread();
+    if (CURRENT_VIEW === "captain") renderCaptain();
   } catch (err) {
     colTeams.innerHTML = `<div class="col-header">Errore</div><div class="empty">${escapeHtml(err.message)}</div>`;
   }
@@ -814,11 +1295,18 @@ async function refresh() {
 async function checkHealth() {
   try {
     const r = await fetch("/health.json");
+    if (!r.ok) throw new Error(`health ${r.status}`);
     const h = await r.json();
-    if (h.ok) {
-      document.getElementById("db-host").textContent = "DB: " + h.db_url_host;
-      document.getElementById("health-pill").style.background = "rgba(90,212,138,0.18)";
-      document.getElementById("health-pill").style.color = "var(--bz-success)";
+    const pill = document.getElementById("health-pill");
+    document.getElementById("db-host").textContent = "DB: " + (h.db_url_host || "unknown");
+    if (h.db_ok) {
+      pill.textContent = "read-only";
+      pill.style.background = "rgba(90,212,138,0.18)";
+      pill.style.color = "var(--bz-success)";
+    } else {
+      pill.textContent = "degraded";
+      pill.style.background = "rgba(240,170,0,0.18)";
+      pill.style.color = "var(--wa-warning)";
     }
   } catch {}
 }
@@ -830,9 +1318,13 @@ let CURRENT_VIEW = "convs";
 function switchView(view) {
   CURRENT_VIEW = view;
   document.getElementById("view-convs").style.display = view === "convs" ? "" : "none";
+  document.getElementById("view-captain").style.display = view === "captain" ? "" : "none";
   document.getElementById("view-metrics").style.display = view === "metrics" ? "" : "none";
+  document.getElementById("view-training").style.display = view === "training" ? "" : "none";
   for (const b of document.querySelectorAll(".view-tab")) b.classList.toggle("active", b.dataset.view === view);
+  if (view === "captain") renderCaptain();
   if (view === "metrics") renderMetrics();
+  if (view === "training") renderTraining();
 }
 
 function mFmt(v, suffix) { return v == null ? "—" : v + (suffix || ""); }
@@ -903,13 +1395,204 @@ async function renderMetrics() {
   }
 }
 
+function trainingCard(label, value, sub) {
+  return `<div class="training-card">
+    <div class="label">${escapeHtml(label)}</div>
+    <div class="value">${escapeHtml(value)}</div>
+    <div class="sub">${escapeHtml(sub || "")}</div>
+  </div>`;
+}
+
+function renderTrainingCategory(c) {
+  const kv = Object.entries(c.top_metrics || {})
+    .slice(0, 4)
+    .map(([key, value]) => `<span>${escapeHtml(key.replace(/_/g, " "))}: ${escapeHtml(value)}</span>`)
+    .join("");
+  return `<div class="training-category ${escapeHtml(c.tone || "slate")}">
+    <div class="title">${escapeHtml(c.label)}</div>
+    <div class="meta">${c.count} summary · latest ${escapeHtml(fmtDateTime(c.latest_generated_at || c.latest_mtime))}</div>
+    ${kv ? `<div class="training-kv">${kv}</div>` : ""}
+  </div>`;
+}
+
+function renderTrainingTable(artifacts) {
+  if (!artifacts.length) {
+    return `<div class="metrics-table-wrap training-table-wrap"><table class="metrics-table training-table">
+      <tbody><tr><td class="op">Nessun summary trovato nel corpus locale.</td></tr></tbody>
+    </table></div>`;
+  }
+  let html = `<div class="metrics-table-wrap training-table-wrap"><table class="metrics-table training-table">
+    <thead><tr>
+      <th class="op">Artifact</th><th>Tipo</th><th>Generato</th><th>Metriche</th><th class="op">Path</th>
+    </tr></thead><tbody>`;
+  for (const a of artifacts) {
+    const chips = (a.key_metrics || []).slice(0, 6)
+      .map((m) => `<span class="metric-chip">${escapeHtml(compactMetricLabel(m.label))}: ${escapeHtml(m.display_value)}</span>`)
+      .join("");
+    html += `<tr>
+      <td class="op" data-label="Artifact">${escapeHtml(a.title)}</td>
+      <td data-label="Tipo">${escapeHtml(a.category_label)}</td>
+      <td data-label="Generato">${escapeHtml(fmtDateTime(a.generated_at || a.mtime))}</td>
+      <td data-label="Metriche">${chips || "—"}</td>
+      <td class="op path" data-label="Path" title="${escapeHtml(a.relative_path)}">${escapeHtml(a.relative_path)}</td>
+    </tr>`;
+  }
+  html += `</tbody></table></div>`;
+  return html;
+}
+
+function filteredTrainingArtifacts() {
+  const all = TRAINING?.artifacts || [];
+  const q = TRAINING_QUERY.trim().toLowerCase();
+  return all.filter((a) => {
+    if (TRAINING_FILTER !== "all" && a.category_id !== TRAINING_FILTER) return false;
+    if (!q) return true;
+    const haystack = `${a.title} ${a.category_label} ${a.relative_path}`.toLowerCase();
+    return haystack.includes(q);
+  });
+}
+
+function renderLearningFlow(t) {
+  const cards = [
+    ["1", "Raccoglie", `${t.artifact_count || 0} summary locali già prodotti dal corpus WhatsApp/Drive.`],
+    ["2", "Trasforma", `${t.total_cards.training_examples} esempi e ${t.total_cards.replay_scenarios} replay diventano palestra operativa.`],
+    ["3", "Lavora in shadow", `${t.total_cards.shadow_drafts} bozze/diagnosi senza inviare messaggi.`],
+    ["4", "Porta all'owner", `${t.total_cards.owner_queue} segnali owner restano in coda finché l'umano non approva.`],
+    ["5", "Resta sicura", `${t.total_cards.whatsapp_sends} invii WA e ${t.total_cards.crm_mutations} scritture CRM dagli artifact.`],
+  ];
+  return `<div class="learning-flow">${cards.map((c) => `
+    <div class="flow-step">
+      <div class="num">${escapeHtml(c[0])}</div>
+      <div class="title">${escapeHtml(c[1])}</div>
+      <div class="copy">${escapeHtml(c[2])}</div>
+    </div>`).join("")}</div>`;
+}
+
+function renderHumanStrip(t) {
+  const examples = t.total_cards.training_examples;
+  const shadow = t.total_cards.shadow_drafts;
+  const ownerQueue = t.total_cards.owner_queue;
+  return `<div class="human-strip">
+    <div class="human-card">
+      <h3>Cosa sta imparando</h3>
+      <p>Zantara non sta leggendo a caso: sta convertendo casi passati in <strong>pattern di diagnosi, priorità, prossima azione e replay</strong>. Il training resta locale e nasce dai summary sicuri.</p>
+    </div>
+    <div class="human-card">
+      <h3>Quanto è pronta</h3>
+      <p><strong>${escapeHtml(examples)}</strong> esempi academy, <strong>${escapeHtml(shadow)}</strong> shadow draft e <strong>${escapeHtml(ownerQueue)}</strong> segnali owner aggregati. Questo indica capacità di triage, non autonomia di invio.</p>
+    </div>
+    <div class="human-card">
+      <h3>Cosa non fa da sola</h3>
+      <p>Gli artifact devono restare a <strong>0 invii WhatsApp</strong> e <strong>0 mutazioni CRM</strong>. La macchina prepara, spiega e mette in coda; la chiusura esterna resta approvata da un umano.</p>
+    </div>
+  </div>`;
+}
+
+function renderTrainingFilters() {
+  const categories = TRAINING?.categories || [];
+  const chips = [{ id: "all", label: "Tutto", count: TRAINING?.artifact_count || 0 }, ...categories.map((c) => ({ id: c.id, label: c.label, count: c.count }))];
+  return `<div class="training-filterbar">
+    <input id="t-search" type="search" placeholder="Cerca summary, owner, shadow, replay…" value="${escapeHtml(TRAINING_QUERY)}" />
+    ${chips.map((c) => `<button class="filter-chip ${TRAINING_FILTER === c.id ? "active" : ""}" data-filter="${escapeHtml(c.id)}">${escapeHtml(c.label)} · ${c.count}</button>`).join("")}
+  </div>`;
+}
+
+function wireTrainingControls() {
+  const search = document.getElementById("t-search");
+  if (search) {
+    search.addEventListener("input", (e) => {
+      TRAINING_QUERY = e.target.value;
+      renderTrainingPanel();
+      requestAnimationFrame(() => {
+        const el = document.getElementById("t-search");
+        if (el) { el.focus(); el.setSelectionRange(TRAINING_QUERY.length, TRAINING_QUERY.length); }
+      });
+    });
+  }
+  for (const chip of document.querySelectorAll(".filter-chip")) {
+    chip.addEventListener("click", () => {
+      TRAINING_FILTER = chip.dataset.filter || "all";
+      renderTrainingPanel();
+    });
+  }
+}
+
+function renderTrainingPanel() {
+  const root = document.getElementById("t-root");
+  const subEl = document.getElementById("t-sub");
+  if (!root || !subEl || !TRAINING) return;
+  const filtered = filteredTrainingArtifacts();
+  const cards = [
+    trainingCard("Summary", String(TRAINING.artifact_count || 0), "artifact locali"),
+    trainingCard("Training examples", TRAINING.total_cards.training_examples, "academy"),
+    trainingCard("Replay scenarios", TRAINING.total_cards.replay_scenarios, "valutazione"),
+    trainingCard("Shadow drafts", TRAINING.total_cards.shadow_drafts, "bozze zero-send"),
+    trainingCard("Owner signals", TRAINING.total_cards.owner_queue, "approval items"),
+    trainingCard("WA / CRM writes", `${TRAINING.total_cards.whatsapp_sends} / ${TRAINING.total_cards.crm_mutations}`, "devono restare 0"),
+  ].join("");
+  const bannerClass = TRAINING.exists ? "status-banner" : "status-banner error";
+  const bannerText = TRAINING.exists
+    ? `Indice locale read-only: legge solo Markdown summary, non JSONL/SQLite/raw chat. Ultimo aggiornamento ${fmtDateTime(TRAINING.generated_at)}.`
+    : `Corpus non trovato: ${TRAINING.base_dir}`;
+  const categories = (TRAINING.categories || []).map(renderTrainingCategory).join("");
+  root.innerHTML = `
+    <div class="${bannerClass}">${escapeHtml(bannerText)}</div>
+    ${renderHumanStrip(TRAINING)}
+    <div class="training-top">${cards}</div>
+    ${renderLearningFlow(TRAINING)}
+    <div class="training-grid">${categories}</div>
+    ${renderTrainingFilters()}
+    ${renderTrainingTable(filtered)}
+    <div class="metrics-legend">
+      <b>Contratto</b>: locale, read-only, no raw artifact exposure. I training futuri compaiono qui appena producono un nuovo <code>*_summary.md</code>.
+    </div>`;
+  subEl.textContent = `${filtered.length} di ${TRAINING.artifact_count || 0} summary · ${TRAINING.categories.length || 0} categorie · ${TRAINING.base_dir}`;
+  wireTrainingControls();
+}
+
+async function renderTraining(force) {
+  const root = document.getElementById("t-root");
+  const subEl = document.getElementById("t-sub");
+  if (!root || !subEl) return;
+  if (!TRAINING || force) root.innerHTML = `<div class="loader">Caricamento training…</div>`;
+  try {
+    const r = await fetch("/training.json");
+    if (!r.ok) throw new Error(`training ${r.status}`);
+    TRAINING = await r.json();
+    renderTrainingPanel();
+  } catch (err) {
+    root.innerHTML = `<div class="status-banner error">Errore Training: ${escapeHtml(err.message)}</div>`;
+    subEl.textContent = "Errore";
+  }
+}
+
 for (const b of document.querySelectorAll(".view-tab")) {
   b.addEventListener("click", () => switchView(b.dataset.view));
+}
+
+document.addEventListener("click", (event) => {
+  const button = event.target.closest("[data-view-jump]");
+  if (!button) return;
+  switchView(button.dataset.viewJump);
+});
+
+const trainingRefresh = document.getElementById("t-refresh");
+if (trainingRefresh) trainingRefresh.addEventListener("click", () => renderTraining(true));
+const corpusButton = document.getElementById("t-open-corpus");
+if (corpusButton) {
+  corpusButton.addEventListener("click", async () => {
+    if (!TRAINING?.base_dir || !navigator.clipboard) return;
+    await navigator.clipboard.writeText(TRAINING.base_dir);
+    corpusButton.textContent = "Path copiato";
+    setTimeout(() => { corpusButton.textContent = "Corpus locale"; }, 1400);
+  });
 }
 
 checkHealth();
 refresh();
 setInterval(refresh, 10000);
+setInterval(() => { if (CURRENT_VIEW === "captain") renderCaptain(); }, 30000);
+setInterval(() => { if (CURRENT_VIEW === "training") renderTraining(false); }, 30000);
 </script>
 </body>
 </html>

--- a/apps/wa-dashboard-m1/viewer.html
+++ b/apps/wa-dashboard-m1/viewer.html
@@ -474,6 +474,15 @@
   .captain-case-title {
     font-weight: 650; color: var(--wa-text); margin-bottom: 7px;
   }
+  .case-title-row {
+    display: flex; justify-content: space-between; align-items: center;
+    gap: 10px; margin-bottom: 9px;
+  }
+  .case-title-row .case-title { margin-bottom: 0; }
+  .case-shadow-pill {
+    color: #246455; background: #e8f5f1; border: 1px solid #b7ded1;
+    border-radius: 999px; padding: 3px 8px; font-size: 11px; white-space: nowrap;
+  }
   .case-captain-card .case-grid-mini {
     display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px;
   }
@@ -499,6 +508,22 @@
     color: var(--wa-text); font-size: 12.5px; line-height: 1.4;
     white-space: pre-wrap; max-height: 86px; overflow: hidden;
   }
+  .case-reasoning-grid {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-top: 10px;
+  }
+  .case-reasoning-grid .case-local-context { margin-top: 0; }
+  .case-reasoning-grid .case-local-context .value {
+    max-height: 132px; overflow: auto;
+  }
+  .case-local-context.case-ideal {
+    background: #e8f5f1; border-color: #b7ded1;
+  }
+  .case-local-context.case-ideal .value { max-height: 132px; }
+  .case-signal-list {
+    margin: 0; padding-left: 17px; color: var(--wa-text); font-size: 12.5px;
+    line-height: 1.45;
+  }
+  .case-signal-list li { margin: 2px 0; }
   .local-mode-banner {
     background: #e8f5f1; border: 1px solid #b7ded1; color: #246455;
     padding: 10px 12px; border-radius: 8px; margin-bottom: 14px;
@@ -622,6 +647,7 @@
     main { grid-template-columns: 220px 340px 1fr; }
     .captain-flow { grid-template-columns: repeat(3, 1fr); }
     .captain-case-grid { grid-template-columns: 1fr; }
+    .case-reasoning-grid { grid-template-columns: 1fr; }
     .training-top { grid-template-columns: repeat(3, 1fr); }
     .training-grid { grid-template-columns: repeat(2, minmax(180px, 1fr)); }
   }
@@ -871,13 +897,47 @@ function messageTextForEvidence(message) {
   return "";
 }
 
+function textLooksLikeThanks(text) {
+  return /\b(thank you|thanks|thx|appreciate|terima kasih|makasih|makasi|suksma|grazie)\b/i.test(String(text || ""));
+}
+
+function textLooksLikeQuestion(text) {
+  return /[?¿]|\b(can|could|should|when|what|how|where|why|is it|are you|bisa|apakah|kapan|dimana|di mana|berapa|bagaimana|quando|come|dove|quanto|posso|puoi)\b/i.test(String(text || ""));
+}
+
+function detectReplyLanguage(text) {
+  const t = String(text || "").toLowerCase();
+  if (/\b(grazie|ciao|buongiorno|buonasera|posso|puoi|quando|come|quanto)\b/.test(t)) return "it";
+  if (/\b(terima kasih|makasih|baik|bisa|apakah|kapan|berapa|pak|bu|mohon)\b/.test(t)) return "id";
+  return "en";
+}
+
+function caseFirstName(conv) {
+  const clean = String(conv?.display_name || "").trim();
+  if (!clean) return "";
+  return clean.split(/\s+/)[0].replace(/[^\p{L}\p{N}'-]/gu, "");
+}
+
 function deriveThreadEvidence(payload, conv) {
   const messages = payload?.messages || [];
+  const recentMessages = messages.slice(-12);
   const lastInbound = [...messages].reverse().find((m) => m.direction !== "outbound" && messageTextForEvidence(m));
   const lastOutbound = [...messages].reverse().find((m) => m.direction === "outbound" && messageTextForEvidence(m));
   const lastAny = [...messages].reverse().find((m) => messageTextForEvidence(m));
   const lastInboundAt = lastInbound?.message_date ? new Date(lastInbound.message_date).getTime() : 0;
   const lastOutboundAt = lastOutbound?.message_date ? new Date(lastOutbound.message_date).getTime() : 0;
+  const recentInboundTexts = recentMessages
+    .filter((m) => m.direction !== "outbound")
+    .map(messageTextForEvidence)
+    .filter(Boolean);
+  const recentOutboundTexts = recentMessages
+    .filter((m) => m.direction === "outbound")
+    .map(messageTextForEvidence)
+    .filter(Boolean);
+  const mediaTypes = [...new Set(messages.filter((m) => MEDIA_TYPES.has(m.media_type)).map((m) => m.media_type))];
+  const recentMediaTypes = [...new Set(recentMessages.filter((m) => MEDIA_TYPES.has(m.media_type)).map((m) => m.media_type))];
+  const lastInboundText = messageTextForEvidence(lastInbound);
+  const lastOutboundText = messageTextForEvidence(lastOutbound);
   return {
     count: payload?.count || conv?.n || 0,
     latest_direction: lastAny?.direction || null,
@@ -886,9 +946,117 @@ function deriveThreadEvidence(payload, conv) {
     last_outbound_at: lastOutbound?.message_date || null,
     last_inbound_sender: lastInbound?.sender_display || lastInbound?.sender_phone || "",
     last_outbound_sender: lastOutbound?.sender_display || lastOutbound?.sender_phone || "",
-    last_inbound: messageSnippet(messageTextForEvidence(lastInbound), 360),
-    last_outbound: messageSnippet(messageTextForEvidence(lastOutbound), 260),
+    last_inbound: messageSnippet(lastInboundText, 360),
+    last_outbound: messageSnippet(lastOutboundText, 260),
+    recent_inbound: messageSnippet(recentInboundTexts.join(" · "), 520),
+    recent_outbound: messageSnippet(recentOutboundTexts.join(" · "), 420),
+    media_types: mediaTypes,
+    recent_media_types: recentMediaTypes,
+    has_question: recentInboundTexts.some(textLooksLikeQuestion) || textLooksLikeQuestion(lastInboundText),
+    has_thanks: textLooksLikeThanks(lastInboundText),
     needs_reply: Boolean(conv?.unread_count) || (lastInboundAt > lastOutboundAt),
+  };
+}
+
+function buildIdealReply(conv, evidence, intent) {
+  const lang = detectReplyLanguage(evidence.last_inbound || evidence.recent_inbound);
+  const name = caseFirstName(conv);
+  const hi = name ? ` ${name}` : "";
+  const lastInfo = messageSnippet(evidence.last_inbound, 120);
+  const hasMedia = Boolean(evidence.recent_media_types?.length || evidence.media_types?.length);
+  const mediaLabel = lang === "id"
+    ? (hasMedia ? "file/foto yang kamu kirim" : "ini")
+    : lang === "it"
+      ? (hasMedia ? "il file/la foto che hai inviato" : "questo")
+      : (hasMedia ? "the file/photo you sent" : "this");
+
+  if (intent === "thanks") {
+    if (lang === "id") return `Sama-sama${hi}. Sudah kami terima. Kami monitor case ini dan akan update di sini kalau ada yang perlu dilengkapi.`;
+    if (lang === "it") return `Figurati${hi}. Abbiamo ricevuto tutto. Teniamo monitorato il caso e ti aggiorniamo qui se serve altro.`;
+    return `You're welcome${hi}. We received it. We'll keep this case monitored and update you here if anything else is needed.`;
+  }
+  if (intent === "question") {
+    if (lang === "id") return `Terima kasih${hi}. Saya cek dulu dengan case kamu, lalu saya konfirmasi next step yang tepat di sini.`;
+    if (lang === "it") return `Grazie${hi}. Verifico questo punto sulla tua pratica e ti confermo qui il prossimo passaggio corretto.`;
+    return `Thanks${hi}. I'll check this against your case and confirm the correct next step here.`;
+  }
+  if (intent === "info") {
+    if (lang === "id") return `Terima kasih${hi}, saya catat: "${lastInfo}". Kami pakai info ini untuk case kamu dan update next step di sini.`;
+    if (lang === "it") return `Grazie${hi}, ho segnato: "${lastInfo}". Usiamo questa informazione sulla pratica e ti aggiorniamo qui sul prossimo passaggio.`;
+    return `Thanks${hi}, noted: "${lastInfo}". We'll use this for your case and update you here with the next step.`;
+  }
+  if (intent === "media") {
+    if (lang === "id") return `Terima kasih${hi}, ${mediaLabel} sudah kami terima. Kami cek dulu, lalu update next step di sini.`;
+    if (lang === "it") return `Grazie${hi}, abbiamo ricevuto ${mediaLabel}. Lo controlliamo e ti aggiorniamo qui sul prossimo passaggio.`;
+    return `Thanks${hi}, we received ${mediaLabel}. We'll check it and update you here with the next step.`;
+  }
+  if (intent === "internal") {
+    return "Owner: confirm who decides this. Blocker: name the missing item. Next check: set one time and update the thread.";
+  }
+  if (intent === "already_replied") {
+    return "No new message needed right now. Keep monitoring; reply only if the client asks again or the promised next step changes.";
+  }
+  if (lang === "id") return `Terima kasih${hi}. Kami sedang cek statusnya dan akan update di sini dengan next step yang jelas.`;
+  if (lang === "it") return `Grazie${hi}. Stiamo verificando lo stato e ti aggiorniamo qui con il prossimo passaggio chiaro.`;
+  return `Thanks${hi}. We're checking the status and will update you here with the clear next step.`;
+}
+
+function buildSpecificCaseAnalysis(conv, evidence) {
+  const media = evidence.recent_media_types?.length ? evidence.recent_media_types : evidence.media_types || [];
+  const mediaLabel = media.length ? media.join(", ") : "";
+  const specificSignals = [];
+  if (evidence.last_inbound) specificSignals.push(`Ultimo inbound: "${messageSnippet(evidence.last_inbound, 92)}"`);
+  if (evidence.last_outbound) specificSignals.push(`Ultimo outbound team: "${messageSnippet(evidence.last_outbound, 92)}"`);
+  if (mediaLabel) specificSignals.push(`Media nel thread: ${mediaLabel}`);
+  if (evidence.has_question) specificSignals.push("C'è una domanda nel blocco recente");
+  if (evidence.has_thanks) specificSignals.push("L'ultimo inbound è un ringraziamento/conferma");
+  specificSignals.push(evidence.needs_reply ? "Palla al team: ultimo inbound/non letto da chiudere" : "Team già intervenuto dopo l'ultimo inbound");
+
+  let intent = "status";
+  if (conv?.tag === "internal") intent = "internal";
+  else if (evidence.has_thanks) intent = "thanks";
+  else if (evidence.has_question) intent = "question";
+  else if (evidence.last_inbound && !/^\[[a-z]+\]$/i.test(evidence.last_inbound)) intent = "info";
+  else if (media.length) intent = "media";
+  else if (!evidence.needs_reply) intent = "already_replied";
+
+  const stateByIntent = {
+    thanks: "Ringraziamento ricevuto: chiusura morbida",
+    question: "Domanda cliente aperta: risposta puntuale",
+    info: "Dato operativo ricevuto: integrare nel caso",
+    media: "Documento/media ricevuto: verifica e next step",
+    internal: "Coordinamento interno: owner e blocco",
+    already_replied: "Già risposto: monitoraggio",
+    status: conv?.crm_match ? "Cliente CRM: update da chiarire" : "Lead/prospect: qualificazione",
+  };
+  const reasoningByIntent = {
+    thanks: `Zantara non legge questo come una nuova richiesta: l'ultimo inbound è un ringraziamento${mediaLabel ? ` e nel thread ci sono media (${mediaLabel})` : ""}. La risposta ideale è breve, conferma ricezione e lascia aperto l'update se serve.`,
+    question: `Zantara vede una domanda nel blocco recente e quindi non deve chiudere con un messaggio generico: deve verificare la pratica e rispondere al punto preciso.`,
+    info: `Zantara vede che l'ultimo inbound contiene un dato operativo concreto, non solo cortesia o allegato. Deve confermare che il dato è stato annotato e collegarlo al prossimo passaggio della pratica.`,
+    media: `Zantara vede media/documenti nel thread (${mediaLabel}). Il passaggio corretto è confermare ricezione, controllare il contenuto e promettere un next step verificabile.`,
+    internal: "Zantara tratta questa chat come coordinamento interno: non risposta cliente, ma owner, blocco, decisione richiesta e prossimo controllo.",
+    already_replied: "Zantara vede che il team è già intervenuto dopo l'ultimo inbound: non deve spingere un nuovo messaggio, deve monitorare fino a nuova domanda o scadenza.",
+    status: evidence.needs_reply
+      ? "Zantara vede una palla aperta sul team: serve un update concreto, non una frase generica."
+      : "Zantara vede una conversazione stabile: serve solo monitoraggio o un update programmato.",
+  };
+  const nextByIntent = {
+    thanks: "Rispondere con acknowledgement breve; niente escalation.",
+    question: "Verificare la pratica e rispondere alla domanda, con prossimo step chiaro.",
+    info: "Confermare il dato ricevuto e spiegare che verrà usato nel caso.",
+    media: "Confermare ricezione del media/documento e dire quando arriva l'update.",
+    internal: "Scrivere owner brief: richiesta, blocco, decisione, prossimo controllo.",
+    already_replied: "Non inviare ora; monitorare e riaprire solo se cambia lo stato.",
+    status: evidence.needs_reply ? "Preparare update cliente con stato, blocco e prossimo passaggio." : "Tenere in monitoraggio e aggiornare solo se serve.",
+  };
+
+  return {
+    state: stateByIntent[intent],
+    reasoning: reasoningByIntent[intent],
+    next: nextByIntent[intent],
+    ideal_reply: buildIdealReply(conv, evidence, intent),
+    intent,
+    specificSignals,
   };
 }
 
@@ -899,8 +1067,10 @@ function zantaraCaseDiagnosis(conv, pd, evidence = {}) {
       reasoning: "Zantara resta in attesa di un caso live.",
       next: "Aprire una conversazione per costruire diagnosi e piano di chiusura.",
       draft: "Nessuna bozza generata.",
+      ideal_reply: "Nessuna bozza generata.",
       gate: "Shadow mode attivo.",
       signals: ["0 invii WhatsApp", "0 scritture CRM", "approval umano richiesto"],
+      specificSignals: [],
     };
   }
 
@@ -915,63 +1085,57 @@ function zantaraCaseDiagnosis(conv, pd, evidence = {}) {
   if (pd?.team?.name) signals.push(`Operatore: ${pd.team.name}`);
   if (evidence.last_inbound) signals.push("Ultimo inbound letto nel thread locale");
   if (evidence.needs_reply) signals.push("Probabile palla al team: serve risposta o update");
+  const specific = buildSpecificCaseAnalysis(conv, evidence);
+  const mergedSignals = [...specific.specificSignals, ...signals].slice(0, 9);
 
   if (conv.tag === "internal") {
     return {
-      state: "Coordinamento interno",
-      reasoning: evidence.last_inbound
-        ? "Zantara legge il messaggio interno più recente, separa richiesta, blocco, owner e scadenza operativa."
-        : "Zantara non risponde al cliente: separa task interno, decisione richiesta e operatore responsabile.",
-      next: evidence.needs_reply
-        ? "Rispondere internamente con owner, decisione richiesta e orario del prossimo controllo."
-        : "Creare pacchetto operativo: richiesta, owner, deadline, blocco, prossimo controllo.",
-      draft: "Owner, blocco, prossima verifica: scrivere una riga chiara per chi deve decidere.",
+      state: specific.state,
+      reasoning: specific.reasoning,
+      next: specific.next,
+      draft: specific.ideal_reply,
+      ideal_reply: specific.ideal_reply,
       gate: "Non esce su WhatsApp cliente.",
-      signals,
+      signals: mergedSignals,
+      specificSignals: specific.specificSignals,
     };
   }
 
   if (conv.kind === "group") {
     return {
-      state: conv.crm_match ? "Caso cliente in gruppo" : "Gruppo da classificare",
-      reasoning: evidence.last_inbound
-        ? "Zantara legge l'ultimo messaggio del gruppo, isola la richiesta reale e la trasforma in owner brief."
-        : "Zantara isola la richiesta reale dentro il gruppo, distingue update, domanda, urgenza e decisione mancante.",
-      next: conv.attention_priority || evidence.needs_reply
-        ? "Produrre owner brief e risposta controllata nel gruppo."
-        : "Preparare sintesi breve e prossima azione verificabile.",
-      draft: "Riepilogo breve: stato, blocco, responsabile, prossimo step e data promessa.",
+      state: conv.crm_match ? `Gruppo cliente: ${specific.state}` : `Gruppo operativo: ${specific.state}`,
+      reasoning: specific.reasoning,
+      next: specific.next,
+      draft: specific.ideal_reply,
+      ideal_reply: specific.ideal_reply,
       gate: "Invio solo dopo approvazione operatore/owner.",
-      signals,
+      signals: mergedSignals,
+      specificSignals: specific.specificSignals,
     };
   }
 
   if (!conv.crm_match) {
     return {
-      state: "Lead da qualificare",
-      reasoning: evidence.last_inbound
-        ? "Zantara usa l'ultimo messaggio del lead per capire servizio, timing e dato mancante prima di spingere una risposta."
-        : "Zantara ricostruisce bisogno, timing, servizio richiesto, urgenza e dati mancanti prima di assegnare o quotare.",
-      next: evidence.needs_reply
-        ? "Fare una domanda di qualificazione e portare il lead a un requisito verificabile."
-        : "Qualificare servizio, scadenza, paese/passaporto, budget e disponibilità documenti; poi proporre owner.",
-      draft: "Risposta breve: confermare che abbiamo capito la richiesta e chiedere il dato mancante più importante.",
+      state: specific.state,
+      reasoning: specific.reasoning,
+      next: specific.next,
+      draft: specific.ideal_reply,
+      ideal_reply: specific.ideal_reply,
       gate: "Nessuna creazione CRM automatica.",
-      signals,
+      signals: mergedSignals,
+      specificSignals: specific.specificSignals,
     };
   }
 
   return {
-    state: "Cliente CRM da chiudere",
-    reasoning: evidence.last_inbound
-      ? "Zantara collega chat e pratica CRM, poi usa l'ultimo inbound per capire se serve update, documento, decisione o escalation."
-      : "Zantara collega chat e pratica CRM, controlla ultimo messaggio, scadenze, documenti mancanti e responsabilità.",
-    next: conv.attention_priority || evidence.needs_reply
-      ? "Preparare risposta cliente o owner brief con stato, blocco e prossimo passaggio."
-      : "Preparare update cliente con stato pratica e prossimo passaggio.",
-    draft: "Update cliente: stato attuale, cosa manca o cosa stiamo verificando, prossimo passaggio e quando torniamo da lui.",
+    state: specific.state,
+    reasoning: specific.reasoning,
+    next: specific.next,
+    draft: specific.ideal_reply,
+    ideal_reply: specific.ideal_reply,
     gate: "Invio e CRM write restano manuali.",
-    signals,
+    signals: mergedSignals,
+    specificSignals: specific.specificSignals,
   };
 }
 
@@ -980,17 +1144,31 @@ function renderCaseCaptainCard(conv, pd, payload) {
   const d = zantaraCaseDiagnosis(conv, pd, evidence);
   const type = caseKindLabel(conv);
   const urgency = caseUrgencyLabel(conv);
+  const signals = (d.specificSignals?.length ? d.specificSignals : d.signals || []).slice(0, 6);
   return `<div class="case-captain-card">
-    <div class="case-title">Zantara shadow su questo caso</div>
+    <div class="case-title-row">
+      <div class="case-title">Zantara legge questa conversazione</div>
+      <div class="case-shadow-pill">bozza non inviata</div>
+    </div>
     <div class="case-grid-mini">
       <div class="case-mini"><div class="label">Conversazione</div><div class="value">${escapeHtml(type)} · ${evidence.count || conv.n || 0} messaggi</div></div>
-      <div class="case-mini"><div class="label">Diagnosi</div><div class="value">${escapeHtml(d.state)} · ${escapeHtml(urgency)}</div></div>
-      <div class="case-mini"><div class="label">Prossima azione</div><div class="value">${escapeHtml(d.next)}</div></div>
+      <div class="case-mini"><div class="label">Stato Zantara</div><div class="value">${escapeHtml(d.state)} · ${escapeHtml(urgency)}</div></div>
+      <div class="case-mini"><div class="label">Prossima mossa</div><div class="value">${escapeHtml(d.next)}</div></div>
     </div>
-    ${evidence.last_inbound ? `<div class="case-local-context">
-      <div class="label">Ultimo inbound letto localmente</div>
-      <div class="value">${escapeHtml(evidence.last_inbound)}</div>
-    </div>` : ""}
+    <div class="case-reasoning-grid">
+      <div class="case-local-context">
+        <div class="label">Perché lo pensa su questa chat</div>
+        <div class="value">${escapeHtml(d.reasoning)}</div>
+      </div>
+      <div class="case-local-context case-ideal">
+        <div class="label">Risposta ideale shadow</div>
+        <div class="value">${escapeHtml(d.ideal_reply || d.draft)}</div>
+      </div>
+    </div>
+    <div class="case-local-context">
+      <div class="label">Segnali specifici letti</div>
+      <ul class="case-signal-list">${signals.map((s) => `<li>${escapeHtml(s)}</li>`).join("")}</ul>
+    </div>
   </div>`;
 }
 
@@ -1082,7 +1260,7 @@ function renderCaptainPanel(threadPayload) {
       <div class="captain-panel">
         <h3>Come risolve</h3>
         <p><strong>Next best action:</strong> ${escapeHtml(d.next)}</p>
-        <p style="margin-top:10px"><strong>Bozza shadow:</strong> ${escapeHtml(d.draft)}</p>
+        <p style="margin-top:10px"><strong>Risposta ideale shadow:</strong> ${escapeHtml(d.ideal_reply || d.draft)}</p>
       </div>
     </div>
     <div class="status-banner">Contratto: shadow mode locale. La webapp legge mirror e summary, non invia messaggi, non scrive CRM e non sostituisce l'approvazione owner.</div>`;

--- a/apps/wa-dashboard-m1/viewer.html
+++ b/apps/wa-dashboard-m1/viewer.html
@@ -802,6 +802,38 @@ function companyBadgeLabel(m) {
   return "BZ";
 }
 
+function sortedConvsForTeam(pd) {
+  if (!pd?.convs) return [];
+  return [...pd.convs].sort((a,b) => {
+    const aHigh = a.attention_priority === "HIGH" ? 1 : 0;
+    const bHigh = b.attention_priority === "HIGH" ? 1 : 0;
+    if (aHigh !== bHigh) return bHigh - aHigh;
+    return new Date(b.last_at) - new Date(a.last_at);
+  });
+}
+
+function selectedConversationExists() {
+  const pd = SELECTED_TEAM ? DATA?.by_phone?.[SELECTED_TEAM] : null;
+  return Boolean(pd?.convs?.some((c) => c.counterpart === SELECTED_CONV));
+}
+
+function selectFirstConversationForTeam(phone) {
+  const pd = DATA?.by_phone?.[phone];
+  const first = sortedConvsForTeam(pd)[0];
+  SELECTED_CONV = first?.counterpart || null;
+  THREAD_SEARCH = "";
+  THREAD_CACHE = null;
+  THREAD_CACHE_KEY = null;
+  return Boolean(SELECTED_CONV);
+}
+
+function ensureVisibleCaseSelected() {
+  if (!DATA || DATA.degraded || !DATA.team?.length) return false;
+  if (!SELECTED_TEAM) SELECTED_TEAM = DATA.team[0].phone;
+  if (!selectedConversationExists()) return selectFirstConversationForTeam(SELECTED_TEAM);
+  return true;
+}
+
 function currentCaseContext() {
   if (!DATA || !SELECTED_TEAM) return { member: null, pd: null, conv: null };
   const member = DATA.team.find((m) => m.phone === SELECTED_TEAM) || null;
@@ -1071,6 +1103,7 @@ async function ensureCurrentThreadPayload() {
 async function renderCaptain() {
   const root = document.getElementById("c-root");
   if (!root) return;
+  ensureVisibleCaseSelected();
   if (!TRAINING) {
     try {
       const r = await fetch("/training.json");
@@ -1147,14 +1180,7 @@ function renderConvs() {
     colConvs.innerHTML = `<div class="col-header">2 · Conversazioni live</div><div class="empty">Seleziona un team member</div>`;
     return;
   }
-  // Sort: HIGH always first, then strictly by last_at DESC (most recent wins, regardless of MEDIUM tag)
-  // Rationale: a group msg of 5 min ago is more relevant than a 3-day-old MEDIUM-flagged direct.
-  const convs = [...pd.convs].sort((a,b) => {
-    const aHigh = a.attention_priority === "HIGH" ? 1 : 0;
-    const bHigh = b.attention_priority === "HIGH" ? 1 : 0;
-    if (aHigh !== bHigh) return bHigh - aHigh;
-    return new Date(b.last_at) - new Date(a.last_at);
-  });
+  const convs = sortedConvsForTeam(pd);
   const headerExtra = pd.attention.high || pd.attention.medium
     ? ` <span style="color:var(--wa-error);font-weight:500">· ${pd.attention.high} HIGH</span>${pd.attention.medium ? ` <span style="color:var(--wa-warning)">· ${pd.attention.medium} MED</span>` : ""}`
     : "";
@@ -1381,9 +1407,7 @@ async function renderThread() {
 function selectTeam(phone) {
   if (SELECTED_TEAM === phone) return;
   SELECTED_TEAM = phone;
-  SELECTED_CONV = null;
-  THREAD_SEARCH = "";
-  THREAD_CACHE = null; THREAD_CACHE_KEY = null;
+  selectFirstConversationForTeam(phone);
   renderTeams(); renderConvs(); renderThread();
   if (CURRENT_VIEW === "captain") renderCaptain();
 }
@@ -1400,7 +1424,7 @@ async function refresh() {
     if (!r.ok) throw new Error(`data ${r.status}`);
     DATA = await r.json();
     document.getElementById("last-refresh").textContent = "refresh: " + new Date(DATA.generated_at).toLocaleTimeString("it-IT");
-    if (!SELECTED_TEAM && DATA.team.length) SELECTED_TEAM = DATA.team[0].phone;
+    ensureVisibleCaseSelected();
     renderTeams(); renderConvs(); renderThread();
     if (CURRENT_VIEW === "captain") renderCaptain();
   } catch (err) {

--- a/apps/wa-dashboard-m1/viewer.html
+++ b/apps/wa-dashboard-m1/viewer.html
@@ -487,6 +487,31 @@
   .case-mini .value {
     color: var(--wa-text); font-size: 12px; line-height: 1.35;
   }
+  .case-local-context {
+    margin-top: 10px; background: #f7f8f8; border: 1px solid var(--wa-divider);
+    border-radius: 8px; padding: 10px;
+  }
+  .case-local-context .label {
+    color: var(--wa-text-3); font-size: 10px; text-transform: uppercase;
+    font-weight: 700; margin-bottom: 4px;
+  }
+  .case-local-context .value {
+    color: var(--wa-text); font-size: 12.5px; line-height: 1.4;
+    white-space: pre-wrap; max-height: 86px; overflow: hidden;
+  }
+  .local-mode-banner {
+    background: #e8f5f1; border: 1px solid #b7ded1; color: #246455;
+    padding: 10px 12px; border-radius: 8px; margin-bottom: 14px;
+    font-size: 13px; line-height: 1.45;
+  }
+  .captain-evidence {
+    display: grid; grid-template-columns: 1fr; gap: 8px; margin-top: 8px;
+  }
+  .captain-evidence .quote {
+    background: var(--wa-panel-3); border-radius: 8px; padding: 9px;
+    color: var(--wa-text); font-size: 12.5px; line-height: 1.4;
+    white-space: pre-wrap; max-height: 120px; overflow: auto;
+  }
   .captain-action-row { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px; }
   .captain-action-row button {
     background: var(--wa-accent); color: #fff; border: 1px solid var(--wa-accent);
@@ -801,7 +826,41 @@ function caseUrgencyLabel(conv) {
   return "Monitor: nessun segnale urgente dal mirror";
 }
 
-function zantaraCaseDiagnosis(conv, pd) {
+function messageSnippet(text, max = 260) {
+  const clean = String(text || "").replace(/\s+/g, " ").trim();
+  if (!clean) return "";
+  return clean.length > max ? clean.slice(0, max - 1) + "…" : clean;
+}
+
+function messageTextForEvidence(message) {
+  if (!message) return "";
+  if (message.body && message.body.trim()) return message.body;
+  if (message.media_type && MEDIA_TYPES.has(message.media_type)) return `[${message.media_type}]`;
+  return "";
+}
+
+function deriveThreadEvidence(payload, conv) {
+  const messages = payload?.messages || [];
+  const lastInbound = [...messages].reverse().find((m) => m.direction !== "outbound" && messageTextForEvidence(m));
+  const lastOutbound = [...messages].reverse().find((m) => m.direction === "outbound" && messageTextForEvidence(m));
+  const lastAny = [...messages].reverse().find((m) => messageTextForEvidence(m));
+  const lastInboundAt = lastInbound?.message_date ? new Date(lastInbound.message_date).getTime() : 0;
+  const lastOutboundAt = lastOutbound?.message_date ? new Date(lastOutbound.message_date).getTime() : 0;
+  return {
+    count: payload?.count || conv?.n || 0,
+    latest_direction: lastAny?.direction || null,
+    latest_at: lastAny?.message_date || conv?.last_at || null,
+    last_inbound_at: lastInbound?.message_date || null,
+    last_outbound_at: lastOutbound?.message_date || null,
+    last_inbound_sender: lastInbound?.sender_display || lastInbound?.sender_phone || "",
+    last_outbound_sender: lastOutbound?.sender_display || lastOutbound?.sender_phone || "",
+    last_inbound: messageSnippet(messageTextForEvidence(lastInbound), 360),
+    last_outbound: messageSnippet(messageTextForEvidence(lastOutbound), 260),
+    needs_reply: Boolean(conv?.unread_count) || (lastInboundAt > lastOutboundAt),
+  };
+}
+
+function zantaraCaseDiagnosis(conv, pd, evidence = {}) {
   if (!conv) {
     return {
       state: "Nessuna conversazione selezionata",
@@ -822,13 +881,19 @@ function zantaraCaseDiagnosis(conv, pd) {
   if (conv.attention_priority) signals.push(`Priorità ${conv.attention_priority}`);
   if (conv.kind === "group") signals.push("Thread gruppo: serve sintesi decisionale");
   if (pd?.team?.name) signals.push(`Operatore: ${pd.team.name}`);
+  if (evidence.last_inbound) signals.push("Ultimo inbound letto nel thread locale");
+  if (evidence.needs_reply) signals.push("Probabile palla al team: serve risposta o update");
 
   if (conv.tag === "internal") {
     return {
       state: "Coordinamento interno",
-      reasoning: "Zantara non risponde al cliente: separa task interno, decisione richiesta e operatore responsabile.",
-      next: "Creare pacchetto operativo: richiesta, owner, deadline, blocco, prossimo controllo.",
-      draft: "Chiarire cosa manca, chi decide e quando va richiuso.",
+      reasoning: evidence.last_inbound
+        ? "Zantara legge il messaggio interno più recente, separa richiesta, blocco, owner e scadenza operativa."
+        : "Zantara non risponde al cliente: separa task interno, decisione richiesta e operatore responsabile.",
+      next: evidence.needs_reply
+        ? "Rispondere internamente con owner, decisione richiesta e orario del prossimo controllo."
+        : "Creare pacchetto operativo: richiesta, owner, deadline, blocco, prossimo controllo.",
+      draft: "Owner, blocco, prossima verifica: scrivere una riga chiara per chi deve decidere.",
       gate: "Non esce su WhatsApp cliente.",
       signals,
     };
@@ -837,9 +902,13 @@ function zantaraCaseDiagnosis(conv, pd) {
   if (conv.kind === "group") {
     return {
       state: conv.crm_match ? "Caso cliente in gruppo" : "Gruppo da classificare",
-      reasoning: "Zantara isola la richiesta reale dentro il gruppo, distingue update, domanda, urgenza e decisione mancante.",
-      next: conv.attention_priority ? "Produrre owner brief e risposta controllata." : "Preparare sintesi breve e prossima azione verificabile.",
-      draft: "Riepilogo stato, punto bloccante, chi deve rispondere, prossimo step.",
+      reasoning: evidence.last_inbound
+        ? "Zantara legge l'ultimo messaggio del gruppo, isola la richiesta reale e la trasforma in owner brief."
+        : "Zantara isola la richiesta reale dentro il gruppo, distingue update, domanda, urgenza e decisione mancante.",
+      next: conv.attention_priority || evidence.needs_reply
+        ? "Produrre owner brief e risposta controllata nel gruppo."
+        : "Preparare sintesi breve e prossima azione verificabile.",
+      draft: "Riepilogo breve: stato, blocco, responsabile, prossimo step e data promessa.",
       gate: "Invio solo dopo approvazione operatore/owner.",
       signals,
     };
@@ -848,9 +917,13 @@ function zantaraCaseDiagnosis(conv, pd) {
   if (!conv.crm_match) {
     return {
       state: "Lead da qualificare",
-      reasoning: "Zantara ricostruisce bisogno, timing, servizio richiesto, urgenza e dati mancanti prima di assegnare o quotare.",
-      next: "Qualificare servizio, scadenza, paese/passaporto, budget e disponibilità documenti; poi proporre owner.",
-      draft: "Domanda corta, chiara, orientata a chiudere il requisito mancante.",
+      reasoning: evidence.last_inbound
+        ? "Zantara usa l'ultimo messaggio del lead per capire servizio, timing e dato mancante prima di spingere una risposta."
+        : "Zantara ricostruisce bisogno, timing, servizio richiesto, urgenza e dati mancanti prima di assegnare o quotare.",
+      next: evidence.needs_reply
+        ? "Fare una domanda di qualificazione e portare il lead a un requisito verificabile."
+        : "Qualificare servizio, scadenza, paese/passaporto, budget e disponibilità documenti; poi proporre owner.",
+      draft: "Risposta breve: confermare che abbiamo capito la richiesta e chiedere il dato mancante più importante.",
       gate: "Nessuna creazione CRM automatica.",
       signals,
     };
@@ -858,25 +931,34 @@ function zantaraCaseDiagnosis(conv, pd) {
 
   return {
     state: "Cliente CRM da chiudere",
-    reasoning: "Zantara collega chat e pratica CRM, controlla ultimo messaggio, scadenze, documenti mancanti e responsabilità.",
-    next: conv.attention_priority ? "Aprire owner brief: rischio, cosa manca, risposta consigliata." : "Preparare update cliente con stato pratica e prossimo passaggio.",
-    draft: "Conferma ricezione, stato, documento o decisione richiesta, prossima data.",
+    reasoning: evidence.last_inbound
+      ? "Zantara collega chat e pratica CRM, poi usa l'ultimo inbound per capire se serve update, documento, decisione o escalation."
+      : "Zantara collega chat e pratica CRM, controlla ultimo messaggio, scadenze, documenti mancanti e responsabilità.",
+    next: conv.attention_priority || evidence.needs_reply
+      ? "Preparare risposta cliente o owner brief con stato, blocco e prossimo passaggio."
+      : "Preparare update cliente con stato pratica e prossimo passaggio.",
+    draft: "Update cliente: stato attuale, cosa manca o cosa stiamo verificando, prossimo passaggio e quando torniamo da lui.",
     gate: "Invio e CRM write restano manuali.",
     signals,
   };
 }
 
-function renderCaseCaptainCard(conv, pd, messageCount) {
-  const d = zantaraCaseDiagnosis(conv, pd);
+function renderCaseCaptainCard(conv, pd, payload) {
+  const evidence = deriveThreadEvidence(payload, conv);
+  const d = zantaraCaseDiagnosis(conv, pd, evidence);
   const type = caseKindLabel(conv);
   const urgency = caseUrgencyLabel(conv);
   return `<div class="case-captain-card">
     <div class="case-title">Zantara shadow su questo caso</div>
     <div class="case-grid-mini">
-      <div class="case-mini"><div class="label">Conversazione</div><div class="value">${escapeHtml(type)} · ${messageCount || conv.n || 0} messaggi</div></div>
+      <div class="case-mini"><div class="label">Conversazione</div><div class="value">${escapeHtml(type)} · ${evidence.count || conv.n || 0} messaggi</div></div>
       <div class="case-mini"><div class="label">Diagnosi</div><div class="value">${escapeHtml(d.state)} · ${escapeHtml(urgency)}</div></div>
       <div class="case-mini"><div class="label">Prossima azione</div><div class="value">${escapeHtml(d.next)}</div></div>
     </div>
+    ${evidence.last_inbound ? `<div class="case-local-context">
+      <div class="label">Ultimo inbound letto localmente</div>
+      <div class="value">${escapeHtml(evidence.last_inbound)}</div>
+    </div>` : ""}
   </div>`;
 }
 
@@ -896,12 +978,13 @@ function renderCaptainFlow() {
     </div>`).join("")}</div>`;
 }
 
-function renderCaptainPanel() {
+function renderCaptainPanel(threadPayload) {
   const root = document.getElementById("c-root");
   const subEl = document.getElementById("c-sub");
   if (!root || !subEl) return;
   const { member, pd, conv } = currentCaseContext();
-  const d = zantaraCaseDiagnosis(conv, pd);
+  const evidence = deriveThreadEvidence(threadPayload, conv);
+  const d = zantaraCaseDiagnosis(conv, pd, evidence);
   const trainingCards = TRAINING?.total_cards || {
     training_examples: "—", replay_scenarios: "—", shadow_drafts: "—",
     owner_queue: "—", whatsapp_sends: "0", crm_mutations: "0",
@@ -913,6 +996,7 @@ function renderCaptainPanel() {
 
   subEl.textContent = `${caseName} — ${caseMeta}`;
   root.innerHTML = `
+    <div class="local-mode-banner">Local Pro mode: qui la PII è visibile perché resta dentro la webapp locale. Non viene copiata in PR, report, log lunghi o chiamate cloud.</div>
     <div class="captain-hero">
       <div class="captain-panel">
         <h3>Dal messaggio alla chiusura</h3>
@@ -946,6 +1030,19 @@ function renderCaptainPanel() {
         <ul>${d.signals.map((s) => `<li>${escapeHtml(s)}</li>`).join("")}</ul>
       </div>
       <div class="captain-panel">
+        <h3>Contesto reale locale</h3>
+        <div class="captain-evidence">
+          <div>
+            <p><strong>Ultimo inbound</strong>${evidence.last_inbound_sender ? ` · ${escapeHtml(evidence.last_inbound_sender)}` : ""}</p>
+            <div class="quote">${escapeHtml(evidence.last_inbound || "Nessun inbound testuale disponibile nel thread caricato.")}</div>
+          </div>
+          <div>
+            <p><strong>Ultimo outbound</strong>${evidence.last_outbound_sender ? ` · ${escapeHtml(evidence.last_outbound_sender)}` : ""}</p>
+            <div class="quote">${escapeHtml(evidence.last_outbound || "Nessun outbound testuale disponibile nel thread caricato.")}</div>
+          </div>
+        </div>
+      </div>
+      <div class="captain-panel">
         <h3>Come ragiona</h3>
         <p>${escapeHtml(d.reasoning)}</p>
         <div class="captain-table-note">Non mostra chain-of-thought interna: espone diagnosi operativa verificabile.</div>
@@ -959,6 +1056,18 @@ function renderCaptainPanel() {
     <div class="status-banner">Contratto: shadow mode locale. La webapp legge mirror e summary, non invia messaggi, non scrive CRM e non sostituisce l'approvazione owner.</div>`;
 }
 
+async function ensureCurrentThreadPayload() {
+  if (!SELECTED_TEAM || !SELECTED_CONV) return null;
+  const cacheKey = `${SELECTED_TEAM}|${SELECTED_CONV}`;
+  if (THREAD_CACHE_KEY === cacheKey && THREAD_CACHE) return THREAD_CACHE;
+  const r = await fetch(`/thread.json?member=${encodeURIComponent(SELECTED_TEAM)}&conv=${encodeURIComponent(SELECTED_CONV)}`);
+  if (!r.ok) throw new Error(`thread ${r.status}`);
+  const payload = await r.json();
+  THREAD_CACHE = payload;
+  THREAD_CACHE_KEY = cacheKey;
+  return payload;
+}
+
 async function renderCaptain() {
   const root = document.getElementById("c-root");
   if (!root) return;
@@ -968,7 +1077,14 @@ async function renderCaptain() {
       if (r.ok) TRAINING = await r.json();
     } catch {}
   }
-  renderCaptainPanel();
+  let threadPayload = null;
+  try {
+    threadPayload = await ensureCurrentThreadPayload();
+  } catch (err) {
+    root.innerHTML = `<div class="status-banner error">Thread non leggibile: ${escapeHtml(err.message)}</div>`;
+    return;
+  }
+  renderCaptainPanel(threadPayload);
 }
 
 function renderTeams() {
@@ -1179,7 +1295,7 @@ async function renderThread() {
 
   const convDisplay = conv ? conv.display_name : SELECTED_CONV;
   const headerAvatarClass = conv?.kind === "group" ? "group" : conv?.tag === "crm" ? "crm" : conv?.tag === "prospect" ? "prospect" : "";
-  const captainHtml = conv ? renderCaseCaptainCard(conv, pd, payload.count) : "";
+  const captainHtml = conv ? renderCaseCaptainCard(conv, pd, payload) : "";
 
   // Filter messages by search query (case-insensitive, matches body + sender)
   const q = THREAD_SEARCH.trim().toLowerCase();


### PR DESCRIPTION
## Summary
- turns the WA dashboard into a clearer local webapp with Conversazioni live, Zantara risolve, Training academy, and Team tabs
- adds the Zantara case captain shadow card for selected conversations with diagnosis, next best action, draft guidance, and human gate
- indexes local training summary artifacts through /training.json without exposing raw chats, JSONL, SQLite, phones, or case IDs
- keeps health/data endpoints usable in degraded DB mode and adds client avatar fallbacks

## Verification
- node --check apps/wa-dashboard-m1/server.cjs
- node --check apps/wa-dashboard-m1/training.cjs
- viewer script parsed with new Function
- Pro smoke: /health.json ok, /data.json ok, /training.json 96 artifacts
- Browser QA on http://100.107.22.111:7790: tabs visible, no overflow, no console errors