### PR TITLE
fix(intake-review): venv auto-heal reinstalls deps (#1546 follow-up)

### DIFF
--- a/scripts/intake_review_reader_run.sh
+++ b/scripts/intake_review_reader_run.sh
@@ -53,5 +53,34 @@ fi
 cd "${BACKEND_DIR}"
 export PYTHONPATH="${BACKEND_DIR}"
 
+# Venv auto-heal (scar #1546 follow-up / superscar #1 HOME-fork + W81 deploy-worktree
+# evaporation): the deploy worktree this wrapper runs from can lose its .venv (re-add,
+# sibling-race, GC). PR #1546 healed the WR2 html venv but this reader was left bare:
+# a missing-or-dep-incomplete venv made `exec uvicorn` die with
+# `ModuleNotFoundError: No module named 'uvicorn'` and KeepAlive crash-looped every
+# ThrottleInterval (10s), taking down kita/review (2026-06-17).
+#
+# Heal BEFORE exec so the FIRST boot after evaporation self-recovers instead of looping:
+#   1. venv shell gone   -> recreate it (python3 -m venv).
+#   2. deps unimportable  -> pip install -r requirements.txt. CRITICAL: cwd MUST be
+#      BACKEND_DIR — requirements.txt has `-e ../../packages/cell-core`, a path-relative
+#      editable that only resolves from apps/backend-rag/. We are already cd'd here.
+# Idempotent + cheap on the happy path: the import probe short-circuits when deps exist,
+# so a healthy boot adds one ~0.1s python invocation and never touches pip.
+if [[ ! -x "${VENV_PY}" ]]; then
+  echo "[intake-review-reader] WARN: venv python missing at ${VENV_PY} — recreating (scar #1546)" >&2
+  if ! python3 -m venv "${BACKEND_DIR}/.venv" >&2; then
+    echo "[intake-review-reader] FATAL: venv shell creation failed" >&2
+    exit 75  # EX_OSERR
+  fi
+fi
+if ! "${VENV_PY}" -c 'import uvicorn' 2>/dev/null; then
+  echo "[intake-review-reader] WARN: uvicorn unimportable — pip install -r requirements.txt (cwd=${BACKEND_DIR}; scar #1546)" >&2
+  if ! "${VENV_PY}" -m pip install -r requirements.txt >&2; then
+    echo "[intake-review-reader] FATAL: dependency install failed" >&2
+    exit 75  # EX_OSERR
+  fi
+fi
+
 exec "${VENV_PY}" -m uvicorn backend.app.intake_review_reader:app \
   --host "${HOST}" --port "${PORT}" --no-access-log


### PR DESCRIPTION
**Root cause:** PR #1546 hardened the WR2 html-renderer venv against evaporation, but the intake-review reader's wrapper (`scripts/intake_review_reader_run.sh`) was left bare. It rebuilt/assumed the deploy-worktree venv *shell* (the `python` symlink) but never reinstalled requirements. When the deploy-worktree `.venv` evaporated (re-add / sibling-race / GC — same W81 class), `exec uvicorn` died with `ModuleNotFoundError: No module named 'uvicorn'`, and the KeepAlive LaunchAgent crash-looped every 10s — taking down kita.balizero.com/review in prod (2026-06-17 ~20:55 WITA). Manual cure already restored prod: `cd <repo>/apps/backend-rag && .venv/bin/python -m pip install -r requirements.txt` + kickstart.

**Fix:** guarded venv auto-heal in the wrapper, BEFORE `exec uvicorn` (so the first boot after evaporation self-heals instead of looping):
1. venv shell missing → recreate (`python3 -m venv`).
2. `uvicorn` unimportable → `pip install -r requirements.txt` with **cwd = `apps/backend-rag`** — CRITICAL because `requirements.txt` has `-e ../../packages/cell-core`, a path-relative editable that only resolves from there (we are already `cd`'d in).

Idempotent + cheap on the happy path (an `import uvicorn` probe short-circuits when deps exist — verified: pip is skipped when healthy). Uses the venv's own python, respects the existing `INTAKE_REVIEW_REPO_ROOT` var (deploy-worktree path). `bash -n` clean; full pre-push suite green (15238 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
