### PR TITLE
fix(review): idempotent approve UX — already-routed/rejected 409 refreshes instead of red error

### DIFF
--- a/apps/mouth/src/app/(workspace)/review/decide-error.test.ts
+++ b/apps/mouth/src/app/(workspace)/review/decide-error.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyResolvedDecideError } from "./page";
+
+describe("classifyResolvedDecideError", () => {
+  it("treats an already-routed (filed) 409 as already_filed", () => {
+    // The exact backend detail surfaced verbatim into Error.message by the api client.
+    expect(
+      classifyResolvedDecideError(
+        "Proposal must be review_claimed (status=routed).",
+      ),
+    ).toBe("already_filed");
+  });
+
+  it("treats an already-rejected 409 as already_rejected", () => {
+    expect(
+      classifyResolvedDecideError(
+        "Proposal must be review_claimed (status=rejected).",
+      ),
+    ).toBe("already_rejected");
+  });
+
+  it("does NOT swallow a still-claimable / unexpected status (stays on error path)", () => {
+    // e.g. review_pending — the proposal is still actionable, a real conflict.
+    expect(
+      classifyResolvedDecideError(
+        "Proposal must be review_claimed (status=review_pending).",
+      ),
+    ).toBeNull();
+  });
+
+  it("does NOT swallow a different 409 (lease expired)", () => {
+    expect(
+      classifyResolvedDecideError("Claim lease expired - re-claim first."),
+    ).toBeNull();
+  });
+
+  it("does NOT swallow a generic network / 500 failure", () => {
+    expect(classifyResolvedDecideError("HTTP 500")).toBeNull();
+    expect(classifyResolvedDecideError("Failed to fetch")).toBeNull();
+  });
+
+  it("is null-safe", () => {
+    expect(classifyResolvedDecideError(undefined)).toBeNull();
+    expect(classifyResolvedDecideError(null)).toBeNull();
+    expect(classifyResolvedDecideError("")).toBeNull();
+  });
+});

--- a/apps/mouth/src/app/(workspace)/review/page.tsx
+++ b/apps/mouth/src/app/(workspace)/review/page.tsx
@@ -159,6 +159,29 @@ function fieldToString(v: unknown): string {
   return String(v);
 }
 
+/**
+ * Detect the "the proposal already left the claimable state" 409, so a retry
+ * after a transient blip (whose write already committed) is shown as an
+ * informational refresh, NOT a red "action failed" error.
+ *
+ * The backend guard (shared by approve AND reject) raises HTTP 409 with
+ * detail=`Proposal must be review_claimed (status=<actual>).`; the api client
+ * surfaces that detail verbatim into Error.message. We anchor on the stable
+ * "must be review_claimed" phrase, then branch on the terminal status:
+ *   - status=routed   → the document was already approved & filed.
+ *   - status=rejected → the proposal was already rejected.
+ * Any other status (e.g. review_pending) or a different error (network/500,
+ * "Claim lease expired", etc.) returns null and stays on the normal error path.
+ */
+export function classifyResolvedDecideError(
+  message: string | undefined | null,
+): "already_filed" | "already_rejected" | null {
+  if (!message || !message.includes("must be review_claimed")) return null;
+  if (message.includes("status=routed")) return "already_filed";
+  if (message.includes("status=rejected")) return "already_rejected";
+  return null;
+}
+
 export default function ReviewPage() {
   const router = useRouter();
   const [items, setItems] = useState<ProposalSummary[]>([]);
@@ -418,12 +441,31 @@ export default function ReviewPage() {
         setSelectedClient(null);
         await loadQueue();
       } catch (e) {
-        setError(`Action "${action}" failed. Please retry.`);
-        logger.error(
-          "review decide failed",
-          { component: "ReviewPage", action },
-          e instanceof Error ? e : new Error(String(e)),
+        // Idempotent path: a transient blip may have hidden a response whose
+        // write already committed. Retrying then hits the backend 409 guard
+        // (status=routed/rejected). Surface that as an informational refresh,
+        // never a red failure that invites confusing re-clicks.
+        const resolved = classifyResolvedDecideError(
+          e instanceof Error ? e.message : String(e),
         );
+        if (resolved) {
+          setNotice(
+            resolved === "already_rejected"
+              ? "This document was already rejected — refreshing the queue."
+              : "This document was already filed — refreshing the queue.",
+          );
+          setDetail(null);
+          setClaimToken(null);
+          setSelectedClient(null);
+          await loadQueue();
+        } else {
+          setError(`Action "${action}" failed. Please retry.`);
+          logger.error(
+            "review decide failed",
+            { component: "ReviewPage", action },
+            e instanceof Error ? e : new Error(String(e)),
+          );
+        }
       } finally {
         setBusy(null);
       }


### PR DESCRIPTION
## Root cause

On kita.balizero.com/review, when a transient network blip hid the **approve** (or reject) response **after** the backend had already committed the write, the proposal advanced review_claimed -> routed (or -> rejected). Re-clicking Approve then hit the backend guard in intake_review.py:831:

    HTTP 409  detail="Proposal must be review_claimed (status=routed)."

The api client (client.ts:371) surfaces that detail verbatim into Error.message, and decide()s catch showed the **generic red** `Action "approve" failed. Please retry.` -- which is wrong and confusing: the document was already filed, so the owner kept re-clicking into more 409s. This happened in prod tonight (2026-06-17) and confused the owner.

## Fix (frontend only)

In decide()s catch, detect the *already-left-the-claimable-state* 409 and treat it as success-ish instead of a failure:

- New small exported pure helper classifyResolvedDecideError(message):
  - anchors on the stable substring "must be review_claimed",
  - branches on status=routed -> already_filed, status=rejected -> already_rejected,
  - returns null for anything else.
- When resolved: show an **informational** notice ("This document was already filed -- refreshing the queue." / "...already rejected..."), close the detail modal (setDetail/ClaimToken/SelectedClient null) and await loadQueue() -- exactly mirroring the happy-path close+reload.
- **Generic failures still error**: a real 500 / Failed to fetch / "Claim lease expired" / a still-claimable status=review_pending all return null from the helper and stay on the original red retry-error path. Only the already-resolved 409 becomes friendly.

decide() handles **both** approve and reject (same shared backend guard), so the friendly message fits both (routed=filed, rejected=already rejected).

Backend untouched. Happy path untouched.

## Tests

- New decide-error.test.ts (6 cases): already_filed, already_rejected, still-claimable review_pending -> null, lease-expired -> null, generic 500/network -> null, null-safe.
- Existing review suite green: destination.test.ts (5) + page.test.tsx (1) + new (6) = **12 passed**.
- tsc --noEmit exit 0, 0 errors. Pre-push full backend suite **15238 passed / 802 skipped / 0 failed**.

## Deploy

Frontend only -> Vercel auto-deploy on merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
