### PR TITLE
fix(review): Profile group dropdown can be switched (seed destination once per doc)

### DIFF
--- a/apps/mouth/src/app/(workspace)/review/page.test.tsx
+++ b/apps/mouth/src/app/(workspace)/review/page.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import ReviewPage from "./page";
@@ -71,5 +72,95 @@ describe("ReviewPage", () => {
       await screen.findByText("Operator: adit@balizero.com"),
     ).toBeVisible();
     expect(screen.getByText("Operator: unassigned")).toBeVisible();
+  });
+
+  it("keeps a manually switched Profile group instead of snapping back", async () => {
+    const user = userEvent.setup();
+    apiMock.get.mockImplementation(async (endpoint: string) => {
+      if (endpoint.startsWith("/api/intake/review/queue")) {
+        return {
+          items: [
+            {
+              proposal_id: 1,
+              doc_type: "passport",
+              decision: "AUTO_ATTACH",
+              source: "whatsapp",
+              status: "review_pending",
+              received_by: "adit@balizero.com",
+              entity_candidates: [{ client_id: 21, full_name: "Client One" }],
+              extracted_fields: {},
+              created_at: "2026-06-15T09:00:00Z",
+            },
+          ],
+        };
+      }
+      if (endpoint === "/api/intake/review/document-categories") {
+        return {
+          items: [
+            {
+              code: "passport",
+              name: "Passport",
+              category_group: "immigration",
+            },
+            { code: "nib", name: "NIB", category_group: "pma" },
+          ],
+        };
+      }
+      if (endpoint === "/api/intake/review/1") {
+        return {
+          proposal_id: 1,
+          doc_type: "passport",
+          decision: "AUTO_ATTACH",
+          source: "whatsapp",
+          status: "review_pending",
+          received_by: "adit@balizero.com",
+          entity_candidates: [{ client_id: 21, full_name: "Client One" }],
+          extracted_fields: {},
+          created_at: "2026-06-15T09:00:00Z",
+          routing: null,
+        };
+      }
+      if (endpoint.startsWith("/api/intake/review/clients/")) {
+        return { items: [] };
+      }
+      throw new Error(`Unexpected GET ${endpoint}`);
+    });
+    apiMock.post.mockImplementation(async (endpoint: string) => {
+      if (endpoint === "/api/intake/review/1/claim") {
+        return {
+          proposal_id: 1,
+          claim_token: "tok-1",
+          lease_expires_at: "2026-06-15T09:15:00Z",
+        };
+      }
+      return {};
+    });
+
+    render(<ReviewPage />);
+
+    await user.click(await screen.findByRole("button", { name: "Review" }));
+
+    // Passport auto-infers Immigration on open (auto-inference must still work).
+    const groupSelect = (await screen.findByLabelText(
+      "Profile group",
+    )) as HTMLSelectElement;
+    await waitFor(() => expect(groupSelect.value).toBe("immigration"));
+
+    // Manually switch to Company (pma) — must STICK, not snap back.
+    await user.selectOptions(groupSelect, "pma");
+    expect(groupSelect.value).toBe("pma");
+
+    // The Category dropdown must repopulate for the new group.
+    const categorySelect = (await screen.findByLabelText(
+      "Category",
+    )) as HTMLSelectElement;
+    expect(
+      within(categorySelect).getByRole("option", { name: "NIB" }),
+    ).toBeInTheDocument();
+
+    // Give the (now ref-guarded) re-inference effect a chance to misbehave;
+    // the group must remain on the manual choice, never revert.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(groupSelect.value).toBe("pma");
   });
 });

--- a/apps/mouth/src/app/(workspace)/review/page.tsx
+++ b/apps/mouth/src/app/(workspace)/review/page.tsx
@@ -24,7 +24,7 @@
  * The <img>/<iframe> preview rides the same-origin SSO cookie.
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { api } from "@/lib/api";
@@ -168,6 +168,10 @@ export default function ReviewPage() {
   const [busy, setBusy] = useState<number | null>(null);
   const [detail, setDetail] = useState<ProposalDetail | null>(null);
   const [claimToken, setClaimToken] = useState<string | null>(null);
+  // Seed the destination (group+category) exactly ONCE per opened proposal,
+  // so a manual Profile-group / Category change is never clobbered by the
+  // doc_type re-inference. Keyed by proposal_id; re-seeds for a new document.
+  const destinationSeededRef = useRef<number | null>(null);
 
   // ── Decision-panel state ────────────────────────────────────────────────
   const [selectedClient, setSelectedClient] = useState<EntityCandidate | null>(
@@ -234,6 +238,9 @@ export default function ReviewPage() {
       setBusy(proposalId);
       setError(null);
       setNotice(null);
+      // A fresh open must re-seed the destination (even re-opening the
+      // same proposal); the seed effect owns the one-shot per proposal.
+      destinationSeededRef.current = null;
       try {
         // Claim first (15-min lease) so approve/reject have a valid token.
         const claim = await api.post<ClaimResponse>(
@@ -287,14 +294,19 @@ export default function ReviewPage() {
   );
 
   useEffect(() => {
-    if (!detail || categories.length === 0 || selectedCategoryCode) return;
+    // Re-derive the destination from doc_type ONCE per proposal, after the
+    // category list has loaded. The ref guard (not selectedCategoryCode)
+    // ensures a manual group/category switch is never re-inferred away.
+    if (!detail || categories.length === 0) return;
+    if (destinationSeededRef.current === detail.proposal_id) return;
+    destinationSeededRef.current = detail.proposal_id;
     const inferredDestination = inferDestinationFromDocType(
       detail.doc_type,
       categories,
     );
     setSelectedGroup(inferredDestination.group);
     setSelectedCategoryCode(inferredDestination.categoryCode);
-  }, [categories, detail, selectedCategoryCode]);
+  }, [categories, detail]);
 
   // ── Practice list follows the selected client ───────────────────────────
   useEffect(() => {


### PR DESCRIPTION
## Bug
On kita.balizero.com/review, the **Profile group** dropdown in the Destination picker could not be switched (e.g. Immigration to Company): it snapped back to the doc_type-inferred group.

## Root cause
- The Profile-group select onChange set the new group AND cleared selectedCategoryCode.
- A re-inference useEffect re-derived the group from detail.doc_type whenever selectedCategoryCode was empty (guard: if (!detail || categories.length === 0 || selectedCategoryCode) return; deps [categories, detail, selectedCategoryCode]).
- Result: clearing the category on a manual group switch made the effect fall through and overwrite the manual choice, so the group snapped back. For doc_types whose inferred categoryCode is empty, the effect re-fired every render and pinned the group permanently.

## Fix
Gate the seeding behind a per-proposal ref (destinationSeededRef, keyed by proposal_id):
- The effect now seeds the destination **once per opened document** (after categories load) and never re-infers again for that proposal, so a manual group/category change is never clobbered.
- selectedCategoryCode removed from the effect deps (it was the re-trigger).
- openDetail resets the ref on every open, so re-opening any document (even the same one) re-seeds correctly.
- Auto-inference on first open still works (passport still defaults to Immigration on open).

Selecting a different Profile group now (a) sticks, (b) repopulates the Category dropdown for that group, (c) does not revert.

## Tests
- New regression test in page.test.tsx: opens a passport proposal (auto-infers Immigration), switches to Company, asserts the group sticks, the Category dropdown repopulates (NIB), and the group does not revert.
- Existing destination.test.ts (5) + page.test.tsx operator test stay green: 7/7 review tests pass. Pre-push full backend suite: 15238 passed, 802 skipped.

Frontend only, deploys to Vercel on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
