### PR TITLE
feat(kbli): wire KBLIConsultationCTA price to PricingTool (drop hardcoded IDR 20M)

### DIFF
--- a/apps/mouth/data/bali-zero-prices.json
+++ b/apps/mouth/data/bali-zero-prices.json
@@ -1,0 +1,21 @@
+{
+  "_source": "apps/backend-rag/backend/data/bali_zero_official_prices_2026.json (PricingTool canonical)",
+  "_note": "SYNCED COPY — do not hand-edit. Regenerate via scripts/sync_frontend_prices.py. Parity enforced by apps/mouth/src/lib/bali-zero-prices.test.ts.",
+  "company_services": {
+    "company-pma": {
+      "name": "New Company (PT PMA)",
+      "price": "20.000.000 IDR",
+      "icon_id": "company-pma"
+    },
+    "company-virtual": {
+      "name": "Virtual Office",
+      "price": "5.000.000 IDR",
+      "icon_id": "company-virtual"
+    },
+    "company-akta": {
+      "name": "Akta Perubahan (Revision Company)",
+      "price": "Depend (Contact for quote)",
+      "icon_id": "company-akta"
+    }
+  }
+}

--- a/apps/mouth/src/components/kbli/KBLIConsultationCTA.tsx
+++ b/apps/mouth/src/components/kbli/KBLIConsultationCTA.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { WhatsAppLeadButton } from "@/components/lead/WhatsAppLeadButton";
+import { getKbliCtaPrices } from "@/lib/bali-zero-prices";
 
 const WHATSAPP_BASE = "https://wa.me/6282264599868";
 
@@ -10,18 +11,35 @@ interface KBLIConsultationCTAProps {
   pmaStatus: string;
 }
 
+/**
+ * Normalize a PricingTool price string (e.g. "<amount> IDR") to the CTA's
+ * "IDR <amount>" display order, without altering the figure itself.
+ */
+function toIdrDisplay(price: string | null): string | null {
+  if (!price) return null;
+  const amount = price.replace(/\s*IDR\s*/i, "").trim();
+  return `IDR ${amount}`;
+}
+
 export function KBLIConsultationCTA({
   code,
   titleEn,
   pmaStatus,
 }: KBLIConsultationCTAProps) {
   const isPMAOpen = pmaStatus === "open" || pmaStatus === "restricted";
+  // Prices come from PricingTool (synced catalog), NEVER hardcoded (CLAUDE.md §8.11).
+  const prices = getKbliCtaPrices();
+  const ptPmaPrice = toIdrDisplay(prices.ptPma);
+  const virtualOfficePrice = toIdrDisplay(prices.virtualOffice);
   const waText = encodeURIComponent(
     `Hello Bali Zero! I'm looking at KBLI ${code} (${titleEn}). I need help setting up my company. Can you guide me?`,
   );
 
   return (
-    <section className="mt-12">
+    // Dark island: the promotional card keeps its terracotta→charcoal gradient
+    // (an inline style CSS overrides cannot reach), so it stays a dark island on
+    // the light KBLI detail page (FT pattern) — its --kbli-text-* stay light.
+    <section className="rp-dark-island mt-12">
       <div
         className="rounded-2xl border p-6 sm:p-8"
         style={{
@@ -52,7 +70,7 @@ export function KBLIConsultationCTA({
 
           {/* Service cards */}
           <div className="grid gap-3 sm:grid-cols-2">
-            {isPMAOpen && (
+            {isPMAOpen && ptPmaPrice && (
               <div
                 className="rounded-xl border p-4"
                 style={{
@@ -64,30 +82,32 @@ export function KBLIConsultationCTA({
                   PT PMA Setup
                 </p>
                 <p className="mt-1 text-xl font-bold text-[var(--kbli-text-primary)]">
-                  IDR 20.000.000
+                  {ptPmaPrice}
                 </p>
                 <p className="mt-1 text-xs text-[var(--kbli-text-muted)]">
                   Company registration, KBLI, NIB, domicile
                 </p>
               </div>
             )}
-            <div
-              className="rounded-xl border p-4"
-              style={{
-                background: "rgba(255,255,255,0.03)",
-                borderColor: "rgba(255,255,255,0.06)",
-              }}
-            >
-              <p className="text-xs font-medium uppercase tracking-wider text-[var(--kbli-text-muted)]">
-                Virtual Office
-              </p>
-              <p className="mt-1 text-xl font-bold text-[var(--kbli-text-primary)]">
-                IDR 5.000.000
-              </p>
-              <p className="mt-1 text-xs text-[var(--kbli-text-muted)]">
-                Legal address for your PT PMA in Bali
-              </p>
-            </div>
+            {virtualOfficePrice && (
+              <div
+                className="rounded-xl border p-4"
+                style={{
+                  background: "rgba(255,255,255,0.03)",
+                  borderColor: "rgba(255,255,255,0.06)",
+                }}
+              >
+                <p className="text-xs font-medium uppercase tracking-wider text-[var(--kbli-text-muted)]">
+                  Virtual Office
+                </p>
+                <p className="mt-1 text-xl font-bold text-[var(--kbli-text-primary)]">
+                  {virtualOfficePrice}
+                </p>
+                <p className="mt-1 text-xs text-[var(--kbli-text-muted)]">
+                  Legal address for your PT PMA in Bali
+                </p>
+              </div>
+            )}
           </div>
 
           {/* Trust + CTA */}

--- a/apps/mouth/src/lib/bali-zero-prices.test.ts
+++ b/apps/mouth/src/lib/bali-zero-prices.test.ts
@@ -1,0 +1,86 @@
+import fs from "fs";
+import path from "path";
+import { describe, expect, it } from "vitest";
+
+import { getCompanyServicePrice, getKbliCtaPrices } from "./bali-zero-prices";
+
+/**
+ * Bali Zero prices come from PricingTool, NEVER from a hardcoded literal
+ * (CLAUDE.md §8.11). These tests pin that contract:
+ *
+ *  1. The frontend lib resolves the two KBLI-CTA prices from the synced catalog
+ *     (`apps/mouth/data/bali-zero-prices.json`) — not a constant in code.
+ *  2. That synced catalog is in PARITY with the PricingTool canonical
+ *     (`apps/backend-rag/backend/data/bali_zero_official_prices_2026.json`). If
+ *     the canonical changes and the sync script (`scripts/sync_frontend_prices.py`)
+ *     was not re-run, this test FAILS — drift cannot ship silently, and a real
+ *     catalog change propagates to the frontend.
+ *  3. The consuming component (`KBLIConsultationCTA`) reads the source, not a
+ *     literal — asserted by grepping the component for `getKbliCtaPrices` and
+ *     for the absence of the hardcoded `20.000.000` / `5.000.000` strings.
+ */
+
+// Repo root from apps/mouth/src/lib → up 4 levels.
+const REPO_ROOT = path.resolve(__dirname, "../../../..");
+const CANONICAL = path.join(
+  REPO_ROOT,
+  "apps/backend-rag/backend/data/bali_zero_official_prices_2026.json",
+);
+const CTA_COMPONENT = path.join(
+  REPO_ROOT,
+  "apps/mouth/src/components/kbli/KBLIConsultationCTA.tsx",
+);
+
+function canonicalCompanyServices(): Record<
+  string,
+  { name?: string; price?: string; icon_id?: string }
+> {
+  const raw = JSON.parse(fs.readFileSync(CANONICAL, "utf-8"));
+  return raw.services.company_services;
+}
+
+describe("bali-zero-prices (PricingTool source-of-truth)", () => {
+  it("resolves the KBLI-CTA prices from the synced catalog, not a literal", () => {
+    const { ptPma, virtualOffice } = getKbliCtaPrices();
+    // Values are present and come from the catalog (verbatim "… IDR" form).
+    expect(ptPma).toBe("20.000.000 IDR");
+    expect(virtualOffice).toBe("5.000.000 IDR");
+  });
+
+  it("keys company services by stable icon_id", () => {
+    expect(getCompanyServicePrice("company-pma")?.name).toBe(
+      "New Company (PT PMA)",
+    );
+    expect(getCompanyServicePrice("company-virtual")?.name).toBe(
+      "Virtual Office",
+    );
+    expect(getCompanyServicePrice("does-not-exist")).toBeUndefined();
+  });
+
+  it("is in parity with the PricingTool canonical (no silent drift)", () => {
+    const canonical = canonicalCompanyServices();
+    const byIcon: Record<string, string> = {};
+    for (const svc of Object.values(canonical)) {
+      if (svc.icon_id && svc.price) byIcon[svc.icon_id] = svc.price;
+    }
+    // Every price the frontend serves must equal the canonical value.
+    for (const iconId of ["company-pma", "company-virtual"]) {
+      expect(getCompanyServicePrice(iconId)?.price).toBe(byIcon[iconId]);
+    }
+  });
+});
+
+describe("KBLIConsultationCTA reads from the pricing source", () => {
+  const src = fs.readFileSync(CTA_COMPONENT, "utf-8");
+
+  it("imports the PricingTool-backed price helper", () => {
+    expect(src).toMatch(/getKbliCtaPrices/);
+    expect(src).toMatch(/from "@\/lib\/bali-zero-prices"/);
+  });
+
+  it("does NOT hardcode the price figures in the component", () => {
+    // The literals must live only in the catalog, never in the component.
+    expect(src).not.toMatch(/20\.000\.000/);
+    expect(src).not.toMatch(/5\.000\.000/);
+  });
+});

--- a/apps/mouth/src/lib/bali-zero-prices.ts
+++ b/apps/mouth/src/lib/bali-zero-prices.ts
@@ -1,0 +1,97 @@
+// =============================================================================
+// Bali Zero company-service prices — sourced from PricingTool, NEVER hardcoded.
+//
+// Absolute rule (CLAUDE.md §8.11 "PricingTool Only"): Bali Zero prices live in
+// ONE place — `apps/backend-rag/backend/data/bali_zero_official_prices_2026.json`,
+// the file `PricingService._load_prices()` reads ("PricingTool"). The Next.js
+// frontend is built/deployed separately on Vercel and cannot reach the backend
+// at request time for two annual-static company prices, so it reads a COMMITTED,
+// GENERATED copy under `apps/mouth/data/bali-zero-prices.json`.
+//
+//   - The copy is produced by `scripts/sync_frontend_prices.py` FROM the
+//     PricingTool canonical (it is NOT a hand-authored re-hardcode).
+//   - Drift is CI-blocked: `bali-zero-prices.test.ts` asserts the committed copy
+//     equals the canonical catalog, so a stale price cannot ship silently.
+//   - A future catalog change therefore propagates: edit the canonical JSON,
+//     run the sync script, and this module + the consuming component update.
+//
+// This module is consumed by server components at BUILD time (the KBLI [code]
+// page is statically generated, `revalidate = 604800`), exactly like
+// `kbli-gold-codes.ts` / `kbli-data.ts` read their committed `data/*.json`.
+// =============================================================================
+
+import fs from "fs";
+import path from "path";
+
+export interface CompanyServicePrice {
+  /** Display name from the PricingTool catalog. */
+  name: string;
+  /** Price string verbatim from PricingTool, e.g. "20.000.000 IDR". */
+  price: string;
+  /** Stable key (matches the catalog `icon_id`). */
+  iconId: string;
+}
+
+interface RawPricesFile {
+  company_services?: Record<
+    string,
+    { name?: string; price?: string; icon_id?: string }
+  >;
+}
+
+let _byIconId: Record<string, CompanyServicePrice> | null = null;
+
+function loadCompanyServices(): Record<string, CompanyServicePrice> {
+  if (_byIconId) return _byIconId;
+  try {
+    const jsonPath = path.join(process.cwd(), "data", "bali-zero-prices.json");
+    const raw = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as RawPricesFile;
+    const services: Record<string, CompanyServicePrice> = {};
+    for (const [iconId, svc] of Object.entries(raw.company_services ?? {})) {
+      if (!svc?.price) continue;
+      services[iconId] = {
+        name: svc.name ?? iconId,
+        price: svc.price,
+        iconId: svc.icon_id ?? iconId,
+      };
+    }
+    // Only memoize a successful, non-empty read — a transient/cold-start read
+    // failure must NOT poison the module cache for the server's lifetime
+    // (the next render retries instead of permanently serving no prices).
+    if (Object.keys(services).length > 0) {
+      _byIconId = services;
+      return _byIconId;
+    }
+    return services;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Look up a company-service price by its stable `icon_id`.
+ *
+ * Returns `undefined` if the catalog is missing the service (the consuming
+ * component must handle that — never substitute a hardcoded literal).
+ */
+export function getCompanyServicePrice(
+  iconId: string,
+): CompanyServicePrice | undefined {
+  return loadCompanyServices()[iconId];
+}
+
+/**
+ * Render the PT PMA + Virtual Office prices the KBLI consultation CTA shows.
+ * Each value comes straight from PricingTool via the synced catalog; if a
+ * service is somehow absent, the field is `null` (the CTA hides that card)
+ * rather than falling back to a hardcoded number.
+ */
+export function getKbliCtaPrices(): {
+  ptPma: string | null;
+  virtualOffice: string | null;
+} {
+  return {
+    ptPma: getCompanyServicePrice("company-pma")?.price ?? null,
+    virtualOffice: getCompanyServicePrice("company-virtual")?.price ?? null,
+  };
+}

--- a/scripts/sync_frontend_prices.py
+++ b/scripts/sync_frontend_prices.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Sync the frontend company-services price catalog from the PricingTool canonical JSON.
+
+Single source of truth for Bali Zero prices is
+``apps/backend-rag/backend/data/bali_zero_official_prices_2026.json`` (the file
+``PricingService._load_prices()`` reads — i.e. "PricingTool"). The Next.js
+frontend (apps/mouth) is built/deployed separately on Vercel and cannot reach
+the backend at request time for two annual-static company prices, so it reads a
+COMMITTED, GENERATED copy under ``apps/mouth/data/``.
+
+This script regenerates that copy. It extracts ONLY the ``company_services``
+block, keyed by ``icon_id`` (stable against display-name changes). Run it
+whenever the canonical catalog changes; CI parity is enforced by
+``apps/mouth/src/lib/bali-zero-prices.test.ts`` (the test fails if the copy
+drifts from the canonical), so a stale copy cannot ship silently.
+
+Usage:
+    python3 scripts/sync_frontend_prices.py          # write
+    python3 scripts/sync_frontend_prices.py --check   # exit 1 if drift (no write)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC = (
+    REPO_ROOT
+    / "apps/backend-rag/backend/data/bali_zero_official_prices_2026.json"
+)
+DST = REPO_ROOT / "apps/mouth/data/bali-zero-prices.json"
+
+
+def build_payload() -> dict:
+    src = json.loads(SRC.read_text(encoding="utf-8"))
+    company_services = src["services"]["company_services"]
+    out: dict = {
+        "_source": (
+            "apps/backend-rag/backend/data/bali_zero_official_prices_2026.json "
+            "(PricingTool canonical)"
+        ),
+        "_note": (
+            "SYNCED COPY — do not hand-edit. Regenerate via "
+            "scripts/sync_frontend_prices.py. Parity enforced by "
+            "apps/mouth/src/lib/bali-zero-prices.test.ts."
+        ),
+        "company_services": {},
+    }
+    for name, svc in company_services.items():
+        icon = svc.get("icon_id")
+        if not icon:
+            continue
+        out["company_services"][icon] = {
+            "name": svc.get("name", name),
+            "price": svc.get("price"),
+            "icon_id": icon,
+        }
+    return out
+
+
+def serialize(payload: dict) -> str:
+    return json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit 1 if the committed copy is out of sync (no write)",
+    )
+    args = parser.parse_args()
+
+    payload = build_payload()
+    rendered = serialize(payload)
+
+    if args.check:
+        current = DST.read_text(encoding="utf-8") if DST.exists() else ""
+        if current != rendered:
+            sys.stderr.write(
+                f"DRIFT: {DST} is out of sync with {SRC}. "
+                "Run: python3 scripts/sync_frontend_prices.py\n"
+            )
+            return 1
+        print(f"OK: {DST} is in sync with PricingTool canonical.")
+        return 0
+
+    DST.parent.mkdir(parents=True, exist_ok=True)
+    DST.write_text(rendered, encoding="utf-8")
+    print(f"WROTE {DST}")
+    print(f"  company-pma     -> {payload['company_services'].get('company-pma')}")
+    print(f"  company-virtual -> {payload['company_services'].get('company-virtual')}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Extracted PricingTool slice from #1311 (clean, conflict-free). Removes hardcoded IDR 20.000.000/5.000.000 from KBLIConsultationCTA → getKbliCtaPrices() reading the synced price JSON. Golden Rule #11. Closes the valuable part of #1311; the rest is superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)