### PR TITLE
feat(review): NO_MATCH leads with 'Create new client' CTA prefilled from OCR, not an error

### DIFF
--- a/apps/mouth/src/app/(workspace)/review/page.test.tsx
+++ b/apps/mouth/src/app/(workspace)/review/page.test.tsx
@@ -1,13 +1,17 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import ReviewPage from "./page";
+
+const createClientMock = vi.hoisted(() => vi.fn());
+const getProfileMock = vi.hoisted(() => vi.fn());
 
 const apiMock = vi.hoisted(() => ({
   get: vi.fn(),
   post: vi.fn(),
   getToken: vi.fn(() => null),
+  getProfile: getProfileMock,
+  crm: { createClient: createClientMock },
 }));
 
 vi.mock("@/lib/api", () => ({ api: apiMock }));
@@ -20,6 +24,24 @@ vi.mock("@/lib/logger", () => ({
     debug: vi.fn(),
   },
 }));
+
+const NO_MATCH_PROPOSAL = {
+  proposal_id: 2,
+  doc_type: "passport",
+  decision: "NO_MATCH",
+  source: "drive",
+  status: "review_pending",
+  received_by: null,
+  entity_candidates: [],
+  extracted_fields: {
+    name: "Walter White",
+    nationality: "US",
+    passport_no: "P1234567",
+    dob: "1965-09-07",
+    expiry: "2030-01-01",
+  },
+  created_at: "2026-06-15T10:00:00Z",
+};
 
 describe("ReviewPage", () => {
   beforeEach(() => {
@@ -44,24 +66,38 @@ describe("ReviewPage", () => {
               extracted_fields: {},
               created_at: "2026-06-15T09:00:00Z",
             },
-            {
-              proposal_id: 2,
-              doc_type: "npwp",
-              decision: "AMBIGUOUS",
-              source: "drive",
-              status: "review_pending",
-              received_by: null,
-              entity_candidates: [],
-              extracted_fields: {},
-              created_at: "2026-06-15T10:00:00Z",
-            },
+            NO_MATCH_PROPOSAL,
           ],
         };
       }
       if (endpoint === "/api/intake/review/document-categories") {
         return { items: [] };
       }
+      if (endpoint === `/api/intake/review/${NO_MATCH_PROPOSAL.proposal_id}`) {
+        return NO_MATCH_PROPOSAL;
+      }
+      if (/\/clients\/\d+\/practices$/.test(endpoint)) {
+        return { items: [] };
+      }
       throw new Error(`Unexpected GET ${endpoint}`);
+    });
+    apiMock.post.mockImplementation(async (endpoint: string) => {
+      if (endpoint.endsWith("/claim")) {
+        return {
+          proposal_id: NO_MATCH_PROPOSAL.proposal_id,
+          claim_token: "tok-1",
+          lease_expires_at: "2026-06-15T10:15:00Z",
+        };
+      }
+      if (endpoint.endsWith("/approve")) {
+        return {
+          proposal_id: NO_MATCH_PROPOSAL.proposal_id,
+          dry_run: false,
+          outcome: "committed",
+          status: "routed",
+        };
+      }
+      return {};
     });
   });
 
@@ -74,93 +110,78 @@ describe("ReviewPage", () => {
     expect(screen.getByText("Operator: unassigned")).toBeVisible();
   });
 
-  it("keeps a manually switched Profile group instead of snapping back", async () => {
-    const user = userEvent.setup();
-    apiMock.get.mockImplementation(async (endpoint: string) => {
-      if (endpoint.startsWith("/api/intake/review/queue")) {
-        return {
-          items: [
-            {
-              proposal_id: 1,
-              doc_type: "passport",
-              decision: "AUTO_ATTACH",
-              source: "whatsapp",
-              status: "review_pending",
-              received_by: "adit@balizero.com",
-              entity_candidates: [{ client_id: 21, full_name: "Client One" }],
-              extracted_fields: {},
-              created_at: "2026-06-15T09:00:00Z",
-            },
-          ],
-        };
-      }
-      if (endpoint === "/api/intake/review/document-categories") {
-        return {
-          items: [
-            {
-              code: "passport",
-              name: "Passport",
-              category_group: "immigration",
-            },
-            { code: "nib", name: "NIB", category_group: "pma" },
-          ],
-        };
-      }
-      if (endpoint === "/api/intake/review/1") {
-        return {
-          proposal_id: 1,
-          doc_type: "passport",
-          decision: "AUTO_ATTACH",
-          source: "whatsapp",
-          status: "review_pending",
-          received_by: "adit@balizero.com",
-          entity_candidates: [{ client_id: 21, full_name: "Client One" }],
-          extracted_fields: {},
-          created_at: "2026-06-15T09:00:00Z",
-          routing: null,
-        };
-      }
-      if (endpoint.startsWith("/api/intake/review/clients/")) {
-        return { items: [] };
-      }
-      throw new Error(`Unexpected GET ${endpoint}`);
+  it("leads a NO_MATCH proposal with a 'Create new client' CTA prefilled from the extracted fields", async () => {
+    render(<ReviewPage />);
+
+    // Open the NO_MATCH proposal (the second card has no proposed client).
+    const reviewButtons = await screen.findAllByRole("button", {
+      name: "Review",
     });
-    apiMock.post.mockImplementation(async (endpoint: string) => {
-      if (endpoint === "/api/intake/review/1/claim") {
-        return {
-          proposal_id: 1,
-          claim_token: "tok-1",
-          lease_expires_at: "2026-06-15T09:15:00Z",
-        };
-      }
-      return {};
+    // The NO_MATCH card is the one labelled "No client matched — needs a decision".
+    expect(
+      screen.getByText("No client matched — needs a decision"),
+    ).toBeVisible();
+    fireEvent.click(reviewButtons[1]);
+
+    // The primary, helpful CTA — NOT an error.
+    expect(await screen.findByText("➕ New client")).toBeVisible();
+    expect(
+      screen.getByText(
+        "No existing client matched — is this a new client? Create one from the document data:",
+      ),
+    ).toBeVisible();
+
+    // Prefilled from extracted_fields (intake schema → CRM field mapping).
+    // Some values also appear in the raw "Extracted fields" editor above, so
+    // assert presence (>=1), not uniqueness.
+    expect(screen.getAllByDisplayValue("Walter White").length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.getAllByDisplayValue("US").length).toBeGreaterThan(0);
+    expect(screen.getAllByDisplayValue("P1234567").length).toBeGreaterThan(0);
+    expect(screen.getAllByDisplayValue("1965-09-07").length).toBeGreaterThan(0);
+    expect(screen.getAllByDisplayValue("2030-01-01").length).toBeGreaterThan(0);
+  });
+
+  it("creates the new client then files the document via the existing approve flow", async () => {
+    getProfileMock.mockResolvedValue({ email: "adit@balizero.com" });
+    createClientMock.mockResolvedValue({
+      id: 999,
+      full_name: "Walter White",
+      email: undefined,
+      phone: undefined,
+      nationality: "US",
+      assigned_to: "adit@balizero.com",
     });
 
     render(<ReviewPage />);
 
-    await user.click(await screen.findByRole("button", { name: "Review" }));
+    const reviewButtons = await screen.findAllByRole("button", {
+      name: "Review",
+    });
+    fireEvent.click(reviewButtons[1]);
 
-    // Passport auto-infers Immigration on open (auto-inference must still work).
-    const groupSelect = (await screen.findByLabelText(
-      "Profile group",
-    )) as HTMLSelectElement;
-    await waitFor(() => expect(groupSelect.value).toBe("immigration"));
+    const createBtn = await screen.findByRole("button", {
+      name: "➕ Create new client + file this document",
+    });
+    fireEvent.click(createBtn);
 
-    // Manually switch to Company (pma) — must STICK, not snap back.
-    await user.selectOptions(groupSelect, "pma");
-    expect(groupSelect.value).toBe("pma");
+    await waitFor(() => {
+      expect(createClientMock).toHaveBeenCalledTimes(1);
+    });
+    // Created with the prefilled name + the current user's email as creator.
+    const [payload, createdBy] = createClientMock.mock.calls[0];
+    expect(payload.full_name).toBe("Walter White");
+    expect(payload.passport_number).toBe("P1234567");
+    expect(createdBy).toBe("adit@balizero.com");
 
-    // The Category dropdown must repopulate for the new group.
-    const categorySelect = (await screen.findByLabelText(
-      "Category",
-    )) as HTMLSelectElement;
-    expect(
-      within(categorySelect).getByRole("option", { name: "NIB" }),
-    ).toBeInTheDocument();
-
-    // Give the (now ref-guarded) re-inference effect a chance to misbehave;
-    // the group must remain on the manual choice, never revert.
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    expect(groupSelect.value).toBe("pma");
+    // The SAME approve path files the doc to the new client_id (999).
+    await waitFor(() => {
+      const approveCall = apiMock.post.mock.calls.find((c: unknown[]) =>
+        String(c[0]).endsWith("/approve"),
+      );
+      expect(approveCall).toBeTruthy();
+      expect((approveCall![1] as { client_id?: number }).client_id).toBe(999);
+    });
   });
 });

--- a/apps/mouth/src/app/(workspace)/review/page.tsx
+++ b/apps/mouth/src/app/(workspace)/review/page.tsx
@@ -29,6 +29,7 @@ import { useRouter } from "next/navigation";
 
 import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
+import type { CreateClientParams } from "@/lib/api/crm/crm.types";
 
 import {
   categoriesForGroup,
@@ -160,6 +161,45 @@ function fieldToString(v: unknown): string {
 }
 
 /**
+ * Build a pre-filled new-client form from the document's OCR-extracted fields.
+ *
+ * The intake extract schema keys (``name`` / ``company_name`` / ``passport_no`` /
+ * ``dob`` / ``expiry`` / ``nationality``) are NOT the CRM column names — this is the
+ * exact translation the backend enricher applies
+ * (``backend/services/intake/client_enricher.py::ENRICHMENT_MAP``). We mirror it on
+ * the client so a reviewer never has to retype what the document already says.
+ * Values may be wrapped as ``{value: ...}`` (confidence envelope); ``fieldToString``
+ * unwraps that. Nothing is invented: a missing key stays an empty, editable field.
+ */
+function prefillFromExtractedFields(
+  fields: Record<string, unknown>,
+): CreateClientParams {
+  const pick = (...keys: string[]): string => {
+    for (const key of keys) {
+      if (key in fields) {
+        const s = fieldToString(fields[key]).trim();
+        if (s) return s;
+      }
+    }
+    return "";
+  };
+  const companyName = pick("company_name");
+  const personName = pick("name", "full_name", "holder_name");
+  return {
+    // Prefer the person's name; fall back to the company name so the form is never blank.
+    full_name: personName || companyName,
+    nationality: pick("nationality"),
+    passport_number: pick("passport_no", "passport_number", "kitas_no"),
+    passport_expiry: pick("expiry", "passport_expiry"),
+    date_of_birth: pick("dob", "date_of_birth"),
+    company_name: companyName || undefined,
+    client_type: companyName && !personName ? "company" : "individual",
+    phone: "",
+    email: "",
+  };
+}
+
+/**
  * Detect the "the proposal already left the claimable state" 409, so a retry
  * after a transient blip (whose write already committed) is shown as an
  * informational refresh, NOT a red "action failed" error.
@@ -210,6 +250,12 @@ export default function ReviewPage() {
   const [selectedCategoryCode, setSelectedCategoryCode] = useState("");
   const [showOcr, setShowOcr] = useState(false);
   const [previewFailed, setPreviewFailed] = useState(false);
+  // ── "Create new client" inline form (NO_MATCH leads with this) ──────────
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [createForm, setCreateForm] = useState<CreateClientParams>({
+    full_name: "",
+  });
+  const [createBusy, setCreateBusy] = useState(false);
 
   const loadQueue = useCallback(async () => {
     setLoading(true);
@@ -280,6 +326,10 @@ export default function ReviewPage() {
         setSearch("");
         setSearchResults([]);
         setFieldEdits({});
+        // Lead with the create form ONLY when nothing matched; with a candidate
+        // (even a weak one) the reviewer can still open it as a secondary option.
+        setShowCreateForm((d.entity_candidates?.length ?? 0) === 0);
+        setCreateForm(prefillFromExtractedFields(d.extracted_fields ?? {}));
         const inferredDestination = inferDestinationFromDocType(
           d.doc_type,
           categories,
@@ -404,18 +454,23 @@ export default function ReviewPage() {
     setSelectedGroup("other");
     setSelectedCategoryCode("");
     setFieldEdits({});
+    setShowCreateForm(false);
+    setCreateForm({ full_name: "" });
   }, [detail, claimToken]);
 
   const decide = useCallback(
-    async (action: "approve" | "reject") => {
+    async (action: "approve" | "reject", clientOverride?: EntityCandidate) => {
       if (!detail || !claimToken) return;
+      // A just-created client is passed explicitly: React state (selectedClient)
+      // has not flushed yet, so the approve body must read the override.
+      const approveClient = clientOverride ?? selectedClient;
       setBusy(detail.proposal_id);
       setError(null);
       setNotice(null);
       try {
         if (action === "approve") {
           const body: Record<string, unknown> = { claim_token: claimToken };
-          if (selectedClient) body.client_id = selectedClient.client_id;
+          if (approveClient) body.client_id = approveClient.client_id;
           // practice_id key is ALWAYS sent on approve: an explicit null means
           // "archive only" and must not fall back to routing's hint server-side.
           body.practice_id =
@@ -435,7 +490,7 @@ export default function ReviewPage() {
             );
           } else if (res.outcome === "committed") {
             setNotice(
-              `✓ Document filed to ${selectedClient?.full_name ?? "client"}.`,
+              `✓ Document filed to ${approveClient?.full_name ?? "client"}.`,
             );
           } else {
             setNotice(`Approve outcome: ${res.outcome}.`);
@@ -493,6 +548,70 @@ export default function ReviewPage() {
       loadQueue,
     ],
   );
+
+  // ── Create a NEW client from the document, then file the doc to it ───────
+  // Reuses the canonical create path (`api.crm.createClient`, same as
+  // clients/new) and the SAME approve flow — no parallel writer.
+  const createAndApprove = useCallback(async () => {
+    if (!detail || !claimToken) return;
+    const name = (createForm.full_name ?? "").trim();
+    if (name.length < 2) {
+      setError(
+        "Enter the client's name (at least 2 characters) before creating.",
+      );
+      return;
+    }
+    setCreateBusy(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const user = await api.getProfile();
+      if (!user?.email) {
+        setError("Could not identify you — please re-login, then retry.");
+        return;
+      }
+      // Drop empty optional fields so the backend keeps them NULL, not "".
+      const payload: CreateClientParams = { full_name: name };
+      const opt: (keyof CreateClientParams)[] = [
+        "nationality",
+        "passport_number",
+        "passport_expiry",
+        "date_of_birth",
+        "phone",
+        "email",
+        "company_name",
+      ];
+      for (const k of opt) {
+        const v = createForm[k];
+        if (typeof v === "string" && v.trim())
+          (payload as unknown as Record<string, unknown>)[k] = v.trim();
+      }
+      payload.client_type = createForm.client_type ?? "individual";
+      payload.lead_source = "whatsapp";
+      const created = await api.crm.createClient(payload, user.email);
+      const newClient: EntityCandidate = {
+        client_id: created.id,
+        full_name: created.full_name,
+        email: created.email ?? null,
+        phone: created.phone ?? null,
+        nationality: created.nationality ?? null,
+        assigned_to: created.assigned_to ?? user.email,
+      };
+      setSelectedClient(newClient);
+      setShowCreateForm(false);
+      // File the document to the brand-new client via the existing approve path.
+      await decide("approve", newClient);
+    } catch (e) {
+      setError("Could not create the client. Please retry.");
+      logger.error(
+        "review create-client failed",
+        { component: "ReviewPage", action: "createAndApprove" },
+        e instanceof Error ? e : new Error(String(e)),
+      );
+    } finally {
+      setCreateBusy(false);
+    }
+  }, [detail, claimToken, createForm, decide]);
 
   // ── Destination summary (the "exact flow" line) ──────────────────────────
   const selectedPractice = useMemo(
@@ -831,13 +950,106 @@ export default function ReviewPage() {
                   </div>
                 )}
 
+                {/* Create-new-client lead — primary action for NO_MATCH.
+                    "Help, don't dump the decision": when nothing matched we lead
+                    with a prefilled create form instead of an error. */}
+                {(showCreateForm ||
+                  (detail.entity_candidates?.length ?? 0) === 0) && (
+                  <div
+                    className="rounded-md border p-3"
+                    style={{
+                      borderColor: "var(--bz-accent, #d4845a)",
+                      background: "var(--bz-surface)",
+                    }}
+                  >
+                    <h3
+                      className="mb-1 text-sm font-semibold"
+                      style={{ color: "var(--bz-text-1)" }}
+                    >
+                      ➕ New client
+                    </h3>
+                    <p
+                      className="mb-2 text-xs"
+                      style={{ color: "var(--bz-text-2)" }}
+                    >
+                      No existing client matched — is this a new client? Create
+                      one from the document data:
+                    </p>
+                    <div className="space-y-1.5">
+                      {(
+                        [
+                          ["full_name", "Name"],
+                          ["nationality", "Nationality"],
+                          ["passport_number", "Passport / KITAS no."],
+                          ["date_of_birth", "Date of birth"],
+                          ["passport_expiry", "Expiry"],
+                          ["phone", "Phone"],
+                          ["email", "Email"],
+                        ] as [keyof CreateClientParams, string][]
+                      ).map(([key, label]) => (
+                        <div key={key} className="flex items-center gap-2">
+                          <span
+                            className="w-36 shrink-0 truncate text-xs"
+                            style={{ color: "var(--bz-text-3)" }}
+                          >
+                            {label}
+                          </span>
+                          <input
+                            className="w-full rounded border px-2 py-1 text-xs"
+                            style={{
+                              borderColor: "var(--bz-border)",
+                              background: "var(--bz-surface)",
+                              color: "var(--bz-text-1)",
+                            }}
+                            placeholder={
+                              key === "full_name" ? "required" : "optional"
+                            }
+                            value={(createForm[key] as string) ?? ""}
+                            onChange={(e) =>
+                              setCreateForm((prev) => ({
+                                ...prev,
+                                [key]: e.target.value,
+                              }))
+                            }
+                          />
+                        </div>
+                      ))}
+                    </div>
+                    <button
+                      type="button"
+                      disabled={
+                        createBusy ||
+                        busy === detail.proposal_id ||
+                        (createForm.full_name ?? "").trim().length < 2
+                      }
+                      onClick={() => void createAndApprove()}
+                      className="mt-3 w-full rounded-md px-4 py-2 text-sm font-medium text-white"
+                      style={{
+                        background: "var(--bz-accent, #d4845a)",
+                        opacity:
+                          createBusy ||
+                          busy === detail.proposal_id ||
+                          (createForm.full_name ?? "").trim().length < 2
+                            ? 0.5
+                            : 1,
+                      }}
+                    >
+                      {createBusy
+                        ? "Creating…"
+                        : "➕ Create new client + file this document"}
+                    </button>
+                  </div>
+                )}
+
                 {/* Candidate clients */}
                 <div>
                   <h3
                     className="mb-1 text-sm font-medium"
                     style={{ color: "var(--bz-text-1)" }}
                   >
-                    Client
+                    {(detail.entity_candidates?.length ?? 0) === 0
+                      ? "Or attach to an existing client"
+                      : "Client"}
                   </h3>
                   {detail.entity_candidates?.length ? (
                     <div className="space-y-1">
@@ -959,6 +1171,20 @@ export default function ReviewPage() {
                       ))}
                     </ul>
                   )}
+
+                  {/* Secondary "create new" affordance when candidates exist
+                      (the homonym case: "or create new"). */}
+                  {(detail.entity_candidates?.length ?? 0) > 0 &&
+                    !showCreateForm && (
+                      <button
+                        type="button"
+                        onClick={() => setShowCreateForm(true)}
+                        className="mt-2 text-xs underline"
+                        style={{ color: "var(--bz-accent, #d4845a)" }}
+                      >
+                        ➕ None of these — create a new client
+                      </button>
+                    )}
                 </div>
 
                 {/* Destination category */}


### PR DESCRIPTION
## Owner ask

> "Metti per primo: è un cliente nuovo? Dobbiamo AIUTARE, non andare per conto nostro."

37 of the 68 `review_pending` proposals are `NO_MATCH` (no CRM client matched) = new clients. The review UI framed this as an error ("No client matched — needs a decision") and dumped the decision on the reviewer. Per the owner: **lead with a prominent, prefilled create-client action — help, don't dump the decision.**

## What it does

When a proposal has zero candidate clients (NO_MATCH), the review modal now **leads** with a primary "➕ New client" panel instead of an error:

- A small inline form, **prefilled from the document's OCR `extracted_fields`** — name, nationality, passport/KITAS number, date of birth, expiry — all editable. Phone/email are blank-editable (the proposal payload carries no sender phone). The mapping mirrors the backend enricher exactly (`backend/services/intake/client_enricher.py::ENRICHMENT_MAP`): intake-schema keys `name`/`passport_no`/`dob`/`expiry`/`nationality` → CRM fields. Company docs prefill `company_name` + `client_type="company"`.
- One click — **"➕ Create new client + file this document"** — creates the client, then files the document to it via the **existing approve flow** (no parallel writer): the new `client_id` is threaded into `decide("approve", newClient)`.
- Copy is helpful, not error-toned: *"No existing client matched — is this a new client? Create one from the document data:"*.
- The existing **client search box is kept**, and when candidates DO exist there's a secondary **"➕ None of these — create a new client"** link (the homonym "or create new" case).
- **No auto-create** — the human reviews the prefilled fields and clicks Create.

## Reuses

- Create-client: **`api.crm.createClient(payload, user.email)` → `POST /api/crm/clients?created_by=…`** (backend `crm_clients.py:443::create_client`), the same path `clients/new/page.tsx` uses. No new endpoint added.
- File-to-client: the existing `/api/intake/review/{id}/approve` flow (claim lease already held), reused verbatim via a `clientOverride` param on `decide()`.

## Surface

Frontend only (Vercel auto-deploy on merge to `main`). Files: `apps/mouth/src/app/(workspace)/review/page.tsx` + its test. Zero Python touched.

## Tests

`tsc --noEmit` clean, eslint clean. 15 frontend review tests pass, incl. 2 new: (1) NO_MATCH renders the prefilled "➕ New client" CTA from `extracted_fields`; (2) create-then-file calls `createClient` with the prefilled name + creator email, then approves with the new `client_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)