### PR TITLE
fix(intake-review): open proposals without claiming + create-client from decision panel

### DIFF
--- a/apps/backend-rag/backend/tests/routers/test_intake_review.py
+++ b/apps/backend-rag/backend/tests/routers/test_intake_review.py
@@ -306,6 +306,35 @@ async def test_detail_null_received_by_admin_only(pool, seed):
     assert r2.status_code == 200, r2.text
 
 
+async def test_detail_terminal_routed_view_without_claim(pool, seed):
+    """A processed (terminal `routed`) proposal must stay VIEWABLE: GET detail
+    returns 200 with status=routed and never requires a lease, while POST claim
+    correctly 409s (state machine unchanged — `routed` is not claimable).
+
+    This is the contract the /review UI relies on to open an already-filed
+    document read-only instead of showing 'Could not open the document.'
+    """
+    pid = seed["p_owner"]
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE document_routing_proposal "
+            "SET status='routed', lease_owner=NULL, lease_expires_at=NULL, "
+            "claim_token=NULL WHERE id=$1",
+            pid,
+        )
+    app = _make_app(pool, ADMIN)
+    async with _client(app) as cl:
+        # GET detail works WITHOUT any claim/lease.
+        r = await cl.get(f"/api/intake/review/{pid}")
+        assert r.status_code == 200, r.text
+        assert r.json()["status"] == "routed"
+        # Claiming a terminal proposal is rejected — view-only is the only path.
+        rc = await cl.post(f"/api/intake/review/{pid}/claim")
+        assert rc.status_code == 409, rc.text
+        assert "not claimable" in rc.json()["detail"].lower()
+        assert "status=routed" in rc.json()["detail"]
+
+
 async def test_claim_rbac_own_chat(pool, seed):
     """Non-admin claim is gated by own-chat (received_by), not assigned_to.
 

--- a/apps/mouth/src/app/(workspace)/review/page.test.tsx
+++ b/apps/mouth/src/app/(workspace)/review/page.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import ReviewPage from "./page";
@@ -20,9 +21,67 @@ vi.mock("@/lib/logger", () => ({
   },
 }));
 
+// jsdom has no fetch; the blob-preview effect calls fetch(). A rejected stub
+// keeps the preview path quiet without touching the open/claim logic under test.
+const fetchMock = vi.hoisted(() =>
+  vi.fn(async () => {
+    throw new Error("no preview in test");
+  }),
+);
+
+// Placeholder ids only — never real client PII (UU PDP, intake is PII-L2).
+const ROUTED_DETAIL = {
+  proposal_id: 1,
+  doc_type: "passport",
+  decision: "AUTO_ATTACH",
+  source: "whatsapp",
+  status: "routed",
+  received_by: "adit@balizero.com",
+  entity_candidates: [{ client_id: 21, full_name: "Client One" }],
+  extracted_fields: {},
+  created_at: "2026-06-15T09:00:00Z",
+  routing: {},
+};
+
+const PENDING_DETAIL = {
+  ...ROUTED_DETAIL,
+  status: "review_pending",
+};
+
+function mockQueueOnly() {
+  apiMock.get.mockImplementation(async (endpoint: string) => {
+    if (endpoint.startsWith("/api/intake/review/queue")) {
+      return {
+        items: [
+          {
+            proposal_id: 1,
+            doc_type: "passport",
+            decision: "AUTO_ATTACH",
+            source: "whatsapp",
+            status: "review_pending",
+            received_by: "adit@balizero.com",
+            entity_candidates: [{ client_id: 21, full_name: "Client One" }],
+            extracted_fields: {},
+            created_at: "2026-06-15T09:00:00Z",
+          },
+        ],
+      };
+    }
+    if (endpoint === "/api/intake/review/document-categories") {
+      return { items: [] };
+    }
+    throw new Error(`Unexpected GET ${endpoint}`);
+  });
+}
+
 describe("ReviewPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal("fetch", fetchMock);
+    mockQueueOnly();
+  });
+
+  it("shows the receiving operator on each review card", async () => {
     apiMock.get.mockImplementation(async (endpoint: string) => {
       if (endpoint.startsWith("/api/intake/review/queue")) {
         return {
@@ -34,12 +93,7 @@ describe("ReviewPage", () => {
               source: "whatsapp",
               status: "review_pending",
               received_by: "adit@balizero.com",
-              entity_candidates: [
-                {
-                  client_id: 21,
-                  full_name: "Client One",
-                },
-              ],
+              entity_candidates: [{ client_id: 21, full_name: "Client One" }],
               extracted_fields: {},
               created_at: "2026-06-15T09:00:00Z",
             },
@@ -62,14 +116,130 @@ describe("ReviewPage", () => {
       }
       throw new Error(`Unexpected GET ${endpoint}`);
     });
-  });
 
-  it("shows the receiving operator on each review card", async () => {
     render(<ReviewPage />);
 
     expect(
       await screen.findByText("Operator: adit@balizero.com"),
     ).toBeVisible();
     expect(screen.getByText("Operator: unassigned")).toBeVisible();
+  });
+
+  it("opens a terminal (routed) proposal READ-ONLY without an error and without claiming", async () => {
+    // The detail GET reports a terminal status (it turned `routed` between the
+    // pending-queue load and the click — the exact PROD repro).
+    const baseGet = apiMock.get.getMockImplementation()!;
+    apiMock.get.mockImplementation(async (endpoint: string) => {
+      if (endpoint === "/api/intake/review/1") return ROUTED_DETAIL;
+      if (/^\/api\/intake\/review\/clients\//.test(endpoint))
+        return { items: [] };
+      return baseGet(endpoint);
+    });
+
+    const user = userEvent.setup();
+    render(<ReviewPage />);
+
+    await user.click(await screen.findByRole("button", { name: "Review" }));
+
+    // Read-only notice is shown…
+    expect(
+      await screen.findByText(/already filed — view only/i),
+    ).toBeVisible();
+    // …the generic failure toast is NOT shown…
+    expect(
+      screen.queryByText("Could not open the document."),
+    ).not.toBeInTheDocument();
+    // …and we NEVER attempted to claim a terminal proposal.
+    expect(apiMock.post).not.toHaveBeenCalled();
+
+    // Actions are disabled in read-only mode.
+    expect(screen.getByRole("button", { name: "Approve" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Reject" })).toBeDisabled();
+  });
+
+  it("falls back to read-only 'claimed by another reviewer' on a live-claim 409", async () => {
+    const baseGet = apiMock.get.getMockImplementation()!;
+    apiMock.get.mockImplementation(async (endpoint: string) => {
+      // Detail still says claimable…
+      if (endpoint === "/api/intake/review/1") return PENDING_DETAIL;
+      if (/^\/api\/intake\/review\/clients\//.test(endpoint))
+        return { items: [] };
+      return baseGet(endpoint);
+    });
+    // …but the claim races and 409s, surfacing the FastAPI detail verbatim.
+    apiMock.post.mockRejectedValueOnce(
+      new Error(
+        "Proposal not claimable (status=review_claimed, lease_owner=other@balizero.com)",
+      ),
+    );
+
+    const user = userEvent.setup();
+    render(<ReviewPage />);
+
+    await user.click(await screen.findByRole("button", { name: "Review" }));
+
+    expect(
+      await screen.findByText(/claimed by another reviewer — view only/i),
+    ).toBeVisible();
+    expect(
+      screen.queryByText("Could not open the document."),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Approve" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Reject" })).toBeDisabled();
+  });
+
+  it("claims and enables actions when the proposal is genuinely claimable", async () => {
+    const baseGet = apiMock.get.getMockImplementation()!;
+    apiMock.get.mockImplementation(async (endpoint: string) => {
+      if (endpoint === "/api/intake/review/1") return PENDING_DETAIL;
+      if (/^\/api\/intake\/review\/clients\//.test(endpoint))
+        return { items: [] };
+      return baseGet(endpoint);
+    });
+    apiMock.post.mockResolvedValueOnce({
+      proposal_id: 1,
+      claim_token: "tok-123",
+      lease_expires_at: "2026-06-15T09:15:00Z",
+    });
+
+    const user = userEvent.setup();
+    render(<ReviewPage />);
+
+    await user.click(await screen.findByRole("button", { name: "Review" }));
+
+    // The claim was attempted exactly once on the claim endpoint.
+    await waitFor(() => expect(apiMock.post).toHaveBeenCalledTimes(1));
+    expect(apiMock.post).toHaveBeenCalledWith(
+      "/api/intake/review/1/claim",
+      {},
+    );
+    // No read-only notice, and a candidate is pre-selected → Approve enabled.
+    expect(
+      screen.queryByText(/view only/i),
+    ).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Approve" })).toBeEnabled(),
+    );
+    expect(screen.getByRole("button", { name: "Reject" })).toBeEnabled();
+  });
+
+  it("shows the generic failure only when the detail GET itself fails", async () => {
+    const baseGet = apiMock.get.getMockImplementation()!;
+    apiMock.get.mockImplementation(async (endpoint: string) => {
+      if (endpoint === "/api/intake/review/1")
+        throw new Error("HTTP 500");
+      return baseGet(endpoint);
+    });
+
+    const user = userEvent.setup();
+    render(<ReviewPage />);
+
+    await user.click(await screen.findByRole("button", { name: "Review" }));
+
+    expect(
+      await screen.findByText("Could not open the document."),
+    ).toBeVisible();
+    // The detail GET failed before any claim attempt.
+    expect(apiMock.post).not.toHaveBeenCalled();
   });
 });

--- a/apps/mouth/src/app/(workspace)/review/page.test.tsx
+++ b/apps/mouth/src/app/(workspace)/review/page.test.tsx
@@ -8,6 +8,8 @@ const apiMock = vi.hoisted(() => ({
   get: vi.fn(),
   post: vi.fn(),
   getToken: vi.fn(() => null),
+  getProfile: vi.fn(async () => ({ email: "adit@balizero.com" })),
+  crm: { createClient: vi.fn() },
 }));
 
 vi.mock("@/lib/api", () => ({ api: apiMock }));
@@ -241,5 +243,175 @@ describe("ReviewPage", () => {
     ).toBeVisible();
     // The detail GET failed before any claim attempt.
     expect(apiMock.post).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fix #2 — "create new client" from the review panel (NO_MATCH / LINK_CANDIDATE)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Placeholder ids only — never real client PII (UU PDP, intake is PII-L2).
+const NO_MATCH_DETAIL = {
+  proposal_id: 1,
+  doc_type: "passport",
+  decision: "NO_MATCH",
+  source: "whatsapp",
+  status: "review_pending",
+  received_by: "adit@balizero.com",
+  entity_candidates: [],
+  extracted_fields: {},
+  created_at: "2026-06-15T09:00:00Z",
+  routing: {},
+};
+
+const AUTO_ATTACH_DETAIL = {
+  ...NO_MATCH_DETAIL,
+  decision: "AUTO_ATTACH",
+  entity_candidates: [{ client_id: 21, full_name: "Existing One" }],
+};
+
+/** Queue with one card so the modal can be opened, plus a detail responder. */
+function mockQueueAndDetail(detail: Record<string, unknown>) {
+  apiMock.get.mockImplementation(async (endpoint: string) => {
+    if (endpoint.startsWith("/api/intake/review/queue")) {
+      return {
+        items: [
+          {
+            proposal_id: 1,
+            doc_type: "passport",
+            decision: detail.decision,
+            source: "whatsapp",
+            status: "review_pending",
+            received_by: "adit@balizero.com",
+            entity_candidates: detail.entity_candidates,
+            extracted_fields: {},
+            created_at: "2026-06-15T09:00:00Z",
+          },
+        ],
+      };
+    }
+    if (endpoint === "/api/intake/review/document-categories")
+      return { items: [] };
+    if (endpoint === "/api/intake/review/1") return detail;
+    if (/^\/api\/intake\/review\/clients\//.test(endpoint))
+      return { items: [] };
+    throw new Error(`Unexpected GET ${endpoint}`);
+  });
+}
+
+describe("ReviewPage — create new client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", fetchMock);
+    apiMock.getProfile.mockResolvedValue({ email: "adit@balizero.com" });
+  });
+
+  it("offers 'Crea nuovo cliente' for a NO_MATCH claimable proposal", async () => {
+    mockQueueAndDetail(NO_MATCH_DETAIL);
+    apiMock.post.mockResolvedValueOnce({
+      proposal_id: 1,
+      claim_token: "tok-1",
+      lease_expires_at: "2026-06-15T09:15:00Z",
+    });
+
+    const user = userEvent.setup();
+    render(<ReviewPage />);
+    await user.click(await screen.findByRole("button", { name: "Review" }));
+
+    expect(
+      await screen.findByRole("button", { name: "+ Crea nuovo cliente" }),
+    ).toBeEnabled();
+  });
+
+  it("does NOT offer create-client for an AUTO_ATTACH proposal", async () => {
+    mockQueueAndDetail(AUTO_ATTACH_DETAIL);
+    apiMock.post.mockResolvedValueOnce({
+      proposal_id: 1,
+      claim_token: "tok-1",
+      lease_expires_at: "2026-06-15T09:15:00Z",
+    });
+
+    const user = userEvent.setup();
+    render(<ReviewPage />);
+    await user.click(await screen.findByRole("button", { name: "Review" }));
+
+    // The detail modal is open (Destination heading present)…
+    expect(await screen.findByText("Destination")).toBeVisible();
+    // …but the create-client entry point is NOT rendered.
+    expect(
+      screen.queryByRole("button", { name: "+ Crea nuovo cliente" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps create-client DISABLED in read-only mode (NO_MATCH but terminal)", async () => {
+    mockQueueAndDetail({ ...NO_MATCH_DETAIL, status: "routed" });
+    // status is terminal → openDetail never claims; if the UI mistakenly tried,
+    // a 409 stub guards against a false positive.
+    apiMock.post.mockRejectedValue(
+      new Error("Proposal not claimable (status=routed, lease_owner=None)"),
+    );
+
+    const user = userEvent.setup();
+    render(<ReviewPage />);
+    await user.click(await screen.findByRole("button", { name: "Review" }));
+
+    // Read-only notice shown, no claim held → no create-client entry point.
+    expect(
+      await screen.findByText(/already filed — view only/i),
+    ).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: "+ Crea nuovo cliente" }),
+    ).not.toBeInTheDocument();
+    // We never claimed a terminal proposal.
+    expect(apiMock.post).not.toHaveBeenCalled();
+  });
+
+  it("creates a client and sets it as the destination (enables Approve)", async () => {
+    mockQueueAndDetail(NO_MATCH_DETAIL);
+    // 1st post = claim (review opens editable).
+    apiMock.post.mockResolvedValueOnce({
+      proposal_id: 1,
+      claim_token: "tok-1",
+      lease_expires_at: "2026-06-15T09:15:00Z",
+    });
+    // createClient returns the new client (placeholder id).
+    apiMock.crm.createClient.mockResolvedValueOnce({
+      id: 99,
+      full_name: "Brand New",
+      assigned_to: "adit@balizero.com",
+    });
+
+    const user = userEvent.setup();
+    render(<ReviewPage />);
+    await user.click(await screen.findByRole("button", { name: "Review" }));
+
+    await user.click(
+      await screen.findByRole("button", { name: "+ Crea nuovo cliente" }),
+    );
+    await user.type(
+      await screen.findByLabelText("New client full name"),
+      "Brand New",
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: "Create client & set as destination",
+      }),
+    );
+
+    // createClient called with the typed name + the operator email as created_by.
+    await waitFor(() =>
+      expect(apiMock.crm.createClient).toHaveBeenCalledTimes(1),
+    );
+    const [payload, createdBy] = apiMock.crm.createClient.mock.calls[0];
+    expect(payload.full_name).toBe("Brand New");
+    expect(createdBy).toBe("adit@balizero.com");
+
+    // Success notice + the new client is now the destination → Approve enabled.
+    expect(
+      await screen.findByText(/New client created: Brand New/i),
+    ).toBeVisible();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Approve" })).toBeEnabled(),
+    );
   });
 });

--- a/apps/mouth/src/app/(workspace)/review/page.tsx
+++ b/apps/mouth/src/app/(workspace)/review/page.tsx
@@ -159,6 +159,44 @@ function fieldToString(v: unknown): string {
   return String(v);
 }
 
+/**
+ * Terminal proposal statuses — a proposal that has already been processed and
+ * can never be claimed again (migration 212 CHECK: review_pending |
+ * review_claimed | routed | rejected | dead). `routed` is the SUCCESS terminal.
+ */
+const TERMINAL_STATUSES = new Set(["routed", "rejected", "dead"]);
+
+/** Human-facing label for a terminal status used in the read-only notice. */
+function terminalLabel(status: string): string {
+  switch (status) {
+    case "routed":
+      return "already filed";
+    case "rejected":
+      return "rejected";
+    case "dead":
+      return "discarded";
+    default:
+      return `already ${status}`;
+  }
+}
+
+/**
+ * The backend `/claim` 409 surfaces its FastAPI `detail` string verbatim as the
+ * thrown Error.message (see api/client.ts: `throw new Error(error.detail ...)`).
+ * The detail reads `Proposal not claimable (status=<s>, lease_owner=<o>)`. We
+ * key off that string — NOT off "409", which never appears in the message.
+ */
+function isNotClaimable(e: unknown): boolean {
+  return e instanceof Error && /not claimable/i.test(e.message);
+}
+
+/** Extract the `status=<s>` token from a "not claimable" 409 detail string. */
+function statusFromClaimError(e: unknown): string | null {
+  if (!(e instanceof Error)) return null;
+  const m = /status=([a-z_]+)/i.exec(e.message);
+  return m ? m[1] : null;
+}
+
 export default function ReviewPage() {
   const router = useRouter();
   const [items, setItems] = useState<ProposalSummary[]>([]);
@@ -168,6 +206,9 @@ export default function ReviewPage() {
   const [busy, setBusy] = useState<number | null>(null);
   const [detail, setDetail] = useState<ProposalDetail | null>(null);
   const [claimToken, setClaimToken] = useState<string | null>(null);
+  // Read-only reason when a proposal is opened WITHOUT a live claim (terminal
+  // status, or claimed by another reviewer). null ⇒ the open is editable.
+  const [readOnlyReason, setReadOnlyReason] = useState<string | null>(null);
 
   // ── Decision-panel state ────────────────────────────────────────────────
   const [selectedClient, setSelectedClient] = useState<EntityCandidate | null>(
@@ -228,22 +269,73 @@ export default function ReviewPage() {
     void loadCategories();
   }, [loadCategories]);
 
-  // ── Open: claim + detail + seed the decision panel ──────────────────────
+  // ── Open: detail FIRST, claim only when claimable, seed the panel ────────
+  //
+  // Viewing is decoupled from claiming. We ALWAYS fetch the read-only detail
+  // first (GET requires only RBAC, never a lease) so the operator can open any
+  // authorised proposal — including terminal ones (routed/rejected/dead) and
+  // ones another reviewer holds live. We attempt the 15-min claim ONLY when the
+  // proposal is in a claimable state; on success the panel is editable, on a
+  // 409 (raced / live-claimed by someone else) we fall back to read-only. A
+  // failed claim is NEVER an error toast — the document still opens.
   const openDetail = useCallback(
     async (proposalId: number) => {
       setBusy(proposalId);
       setError(null);
       setNotice(null);
+      setClaimToken(null);
+      setReadOnlyReason(null);
       try {
-        // Claim first (15-min lease) so approve/reject have a valid token.
-        const claim = await api.post<ClaimResponse>(
-          `/api/intake/review/${proposalId}/claim`,
-          {},
-        );
-        setClaimToken(claim.claim_token);
+        // 1) Fetch the detail first — this works for any authorised proposal,
+        //    regardless of status or lease ownership.
         const d = await api.get<ProposalDetail>(
           `/api/intake/review/${proposalId}`,
         );
+
+        // 2) Claim only when the proposal is not in a terminal state. The
+        //    backend atomically handles steal-expired / renew-own / 409-other,
+        //    so we just attempt it for any non-terminal status.
+        let token: string | null = null;
+        let roReason: string | null = null;
+        if (TERMINAL_STATUSES.has(d.status)) {
+          roReason = `This proposal is ${terminalLabel(d.status)} — view only.`;
+        } else {
+          try {
+            const claim = await api.post<ClaimResponse>(
+              `/api/intake/review/${proposalId}/claim`,
+              {},
+            );
+            token = claim.claim_token;
+          } catch (claimErr) {
+            if (isNotClaimable(claimErr)) {
+              // Lost the race between list-load and click. Distinguish a
+              // status that turned terminal from a live claim by another.
+              const st = statusFromClaimError(claimErr);
+              roReason =
+                st && TERMINAL_STATUSES.has(st)
+                  ? `This proposal is ${terminalLabel(st)} — view only.`
+                  : "Claimed by another reviewer — view only.";
+            } else {
+              // A real claim failure (404/500/network). Detail already loaded;
+              // surface a soft read-only notice rather than hiding the document.
+              roReason = "Could not claim this proposal — view only.";
+              logger.warn(
+                "review claim failed (detail still shown)",
+                {
+                  component: "ReviewPage",
+                  action: "openDetail",
+                  metadata: { proposalId },
+                },
+                claimErr instanceof Error
+                  ? claimErr
+                  : new Error(String(claimErr)),
+              );
+            }
+          }
+        }
+
+        setClaimToken(token);
+        setReadOnlyReason(roReason);
         setDetail(d);
         setPreviewFailed(false);
         setShowOcr(false);
@@ -269,13 +361,11 @@ export default function ReviewPage() {
             : "",
         );
       } catch (e) {
-        const msg =
-          e instanceof Error && /409/.test(e.message)
-            ? "Already claimed by another reviewer."
-            : "Could not open the document.";
-        setError(msg);
+        // Only the detail GET reaching here is a true failure (the claim has
+        // its own catch above and never re-throws).
+        setError("Could not open the document.");
         logger.error(
-          "review claim/detail failed",
+          "review detail load failed",
           { component: "ReviewPage", action: "openDetail" },
           e instanceof Error ? e : new Error(String(e)),
         );
@@ -363,6 +453,7 @@ export default function ReviewPage() {
     }
     setDetail(null);
     setClaimToken(null);
+    setReadOnlyReason(null);
     setSelectedClient(null);
     setPractices([]);
     setSelectedPracticeId("");
@@ -415,6 +506,7 @@ export default function ReviewPage() {
         }
         setDetail(null);
         setClaimToken(null);
+        setReadOnlyReason(null);
         setSelectedClient(null);
         await loadQueue();
       } catch (e) {
@@ -660,6 +752,19 @@ export default function ReviewPage() {
                 ✕
               </button>
             </div>
+
+            {readOnlyReason && (
+              <div
+                className="mb-3 rounded-md border px-3 py-2 text-sm"
+                role="status"
+                style={{
+                  borderColor: "var(--bz-warning, #d4923a)",
+                  color: "var(--bz-text-1)",
+                }}
+              >
+                {readOnlyReason}
+              </div>
+            )}
 
             <div className="grid gap-5 md:grid-cols-2">
               {/* ── LEFT: the exact document ──────────────────────────── */}
@@ -1038,13 +1143,19 @@ export default function ReviewPage() {
                 <div className="flex gap-3">
                   <button
                     type="button"
-                    disabled={busy === detail.proposal_id || !selectedClient}
+                    disabled={
+                      busy === detail.proposal_id ||
+                      !claimToken ||
+                      !selectedClient
+                    }
                     onClick={() => void decide("approve")}
                     className="flex-1 rounded-md px-4 py-2 text-sm font-medium text-white"
                     style={{
                       background: "var(--bz-success, #2e9e6b)",
                       opacity:
-                        busy === detail.proposal_id || !selectedClient
+                        busy === detail.proposal_id ||
+                        !claimToken ||
+                        !selectedClient
                           ? 0.5
                           : 1,
                     }}
@@ -1053,12 +1164,13 @@ export default function ReviewPage() {
                   </button>
                   <button
                     type="button"
-                    disabled={busy === detail.proposal_id}
+                    disabled={busy === detail.proposal_id || !claimToken}
                     onClick={() => void decide("reject")}
                     className="flex-1 rounded-md px-4 py-2 text-sm font-medium text-white"
                     style={{
                       background: "var(--bz-error, #d95f5a)",
-                      opacity: busy === detail.proposal_id ? 0.6 : 1,
+                      opacity:
+                        busy === detail.proposal_id || !claimToken ? 0.6 : 1,
                     }}
                   >
                     Reject

--- a/apps/mouth/src/app/(workspace)/review/page.tsx
+++ b/apps/mouth/src/app/(workspace)/review/page.tsx
@@ -29,6 +29,11 @@ import { useRouter } from "next/navigation";
 
 import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
+import {
+  createClientSchema,
+  type CreateClientInput,
+} from "@/lib/api/crm/crm.schemas";
+import type { CreateClientParams } from "@/lib/api/crm/crm.types";
 
 import {
   categoriesForGroup,
@@ -197,6 +202,48 @@ function statusFromClaimError(e: unknown): string | null {
   return m ? m[1] : null;
 }
 
+/**
+ * The "create new client" path unlocks ONLY for proposals where no existing
+ * client fits: NO_MATCH (entity resolution found nothing) and LINK_CANDIDATE (a
+ * client was PROPOSED but may be wrong, so the reviewer may reject it and create
+ * a fresh one). AUTO_ATTACH / AMBIGUOUS keep the pick-an-existing flow.
+ */
+const CREATE_CLIENT_DECISIONS = new Set(["NO_MATCH", "LINK_CANDIDATE"]);
+
+/** Minimal create-client form state — only what the operator may need to type. */
+interface NewClientFields {
+  full_name: string;
+  email: string;
+  phone: string;
+  nationality: string;
+}
+
+const EMPTY_NEW_CLIENT: NewClientFields = {
+  full_name: "",
+  email: "",
+  phone: "",
+  nationality: "",
+};
+
+/**
+ * Prefill a new-client form from the proposal: a LINK_CANDIDATE carries the
+ * proposed (maybe-wrong) name as its first candidate; otherwise scan the
+ * extracted document fields for a name-like key. `fieldToString` unwraps the
+ * `{value, confidence}` shape the extractor uses.
+ */
+function prefillNewClient(detail: ProposalDetail): NewClientFields {
+  const proposed = detail.entity_candidates?.[0]?.full_name;
+  let name = proposed ?? "";
+  if (!name) {
+    const fields = detail.extracted_fields ?? {};
+    const nameKey = Object.keys(fields).find((k) =>
+      /(^|_)(full_?name|name|holder|nama)(_|$)/i.test(k),
+    );
+    if (nameKey) name = fieldToString(fields[nameKey]);
+  }
+  return { ...EMPTY_NEW_CLIENT, full_name: name };
+}
+
 export default function ReviewPage() {
   const router = useRouter();
   const [items, setItems] = useState<ProposalSummary[]>([]);
@@ -209,6 +256,12 @@ export default function ReviewPage() {
   // Read-only reason when a proposal is opened WITHOUT a live claim (terminal
   // status, or claimed by another reviewer). null ⇒ the open is editable.
   const [readOnlyReason, setReadOnlyReason] = useState<string | null>(null);
+
+  // ── Create-new-client (unlocked only for NO_MATCH / LINK_CANDIDATE) ───────
+  const [showCreateClient, setShowCreateClient] = useState(false);
+  const [newClient, setNewClient] = useState<NewClientFields>(EMPTY_NEW_CLIENT);
+  const [newClientError, setNewClientError] = useState<string | null>(null);
+  const [creatingClient, setCreatingClient] = useState(false);
 
   // ── Decision-panel state ────────────────────────────────────────────────
   const [selectedClient, setSelectedClient] = useState<EntityCandidate | null>(
@@ -285,6 +338,9 @@ export default function ReviewPage() {
       setNotice(null);
       setClaimToken(null);
       setReadOnlyReason(null);
+      setShowCreateClient(false);
+      setNewClient(EMPTY_NEW_CLIENT);
+      setNewClientError(null);
       try {
         // 1) Fetch the detail first — this works for any authorised proposal,
         //    regardless of status or lease ownership.
@@ -454,6 +510,9 @@ export default function ReviewPage() {
     setDetail(null);
     setClaimToken(null);
     setReadOnlyReason(null);
+    setShowCreateClient(false);
+    setNewClient(EMPTY_NEW_CLIENT);
+    setNewClientError(null);
     setSelectedClient(null);
     setPractices([]);
     setSelectedPracticeId("");
@@ -461,6 +520,63 @@ export default function ReviewPage() {
     setSelectedCategoryCode("");
     setFieldEdits({});
   }, [detail, claimToken]);
+
+  // ── Create a brand-new client and set it as the destination ──────────────
+  // Reuses the existing CRM create endpoint + Zod schema (no new validation).
+  // On success the new client becomes selectedClient so the operator files the
+  // document to it via the normal Approve flow.
+  const createNewClient = useCallback(async () => {
+    setNewClientError(null);
+    // Validate with the SAME schema the full New-Client page uses. Only
+    // full_name is required; blank optionals are dropped to undefined.
+    const candidate: CreateClientInput = {
+      full_name: newClient.full_name,
+      email: newClient.email || undefined,
+      phone: newClient.phone || undefined,
+      nationality: newClient.nationality || undefined,
+      lead_source: "whatsapp",
+    };
+    const parsed = createClientSchema.safeParse(candidate);
+    if (!parsed.success) {
+      setNewClientError(
+        parsed.error.issues[0]?.message ?? "Please check the client details.",
+      );
+      return;
+    }
+    setCreatingClient(true);
+    try {
+      const profile = await api.getProfile();
+      if (!profile?.email) throw new Error("User email not available");
+      const created = await api.crm.createClient(
+        parsed.data as CreateClientParams,
+        profile.email,
+      );
+      // Become the document destination via the normal radio/selectedClient path.
+      setSelectedClient({
+        client_id: created.id,
+        full_name: created.full_name,
+        assigned_to: created.assigned_to ?? profile.email,
+        email: created.email ?? null,
+        phone: created.phone ?? null,
+        nationality: created.nationality ?? null,
+      });
+      setSelectedPracticeId("");
+      setShowCreateClient(false);
+      setNewClient(EMPTY_NEW_CLIENT);
+      setNotice(`✓ New client created: ${created.full_name}. Pick a category, then Approve.`);
+    } catch (e) {
+      setNewClientError(
+        e instanceof Error ? e.message : "Could not create the client.",
+      );
+      logger.error(
+        "review create-client failed",
+        { component: "ReviewPage", action: "createNewClient" },
+        e instanceof Error ? e : new Error(String(e)),
+      );
+    } finally {
+      setCreatingClient(false);
+    }
+  }, [newClient]);
 
   const decide = useCallback(
     async (action: "approve" | "reject") => {
@@ -559,6 +675,18 @@ export default function ReviewPage() {
       : "client document archive";
     return `${selectedClient.full_name} → ${groupLabel(selectedGroup)} / ${categoryLabel} → ${practiceLabel}`;
   }, [selectedCategory, selectedClient, selectedGroup, selectedPractice]);
+
+  // "Create new client" unlocks ONLY for the no-existing-client cases
+  // (NO_MATCH / LINK_CANDIDATE) AND only while the reviewer holds a live claim
+  // (read-only / terminal opens keep it disabled — "si sblocca solo per questo
+  // caso").
+  const canCreateClient = useMemo(
+    () =>
+      Boolean(claimToken) &&
+      Boolean(detail?.decision) &&
+      CREATE_CLIENT_DECISIONS.has(detail!.decision),
+    [claimToken, detail],
+  );
 
   // Authenticated blob preview: an <iframe>/<img> request cannot carry the
   // Bearer header, so a direct src 401s ("Connessione negata"). Fetch the
@@ -1009,6 +1137,149 @@ export default function ReviewPage() {
                         </li>
                       ))}
                     </ul>
+                  )}
+
+                  {/* Create new client — unlocked ONLY for NO_MATCH /
+                      LINK_CANDIDATE while a claim is held. */}
+                  {canCreateClient && !showCreateClient && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (detail) setNewClient(prefillNewClient(detail));
+                        setNewClientError(null);
+                        setShowCreateClient(true);
+                      }}
+                      className="mt-2 w-full rounded border border-dashed px-2 py-1.5 text-sm"
+                      style={{
+                        borderColor: "var(--bz-accent, #d4845a)",
+                        color: "var(--bz-accent, #d4845a)",
+                      }}
+                    >
+                      + Crea nuovo cliente
+                    </button>
+                  )}
+
+                  {canCreateClient && showCreateClient && (
+                    <div
+                      className="mt-2 space-y-2 rounded-md border p-3"
+                      style={{ borderColor: "var(--bz-accent, #d4845a)" }}
+                    >
+                      <div className="flex items-center justify-between">
+                        <h4
+                          className="text-sm font-medium"
+                          style={{ color: "var(--bz-text-1)" }}
+                        >
+                          New client
+                        </h4>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setShowCreateClient(false);
+                            setNewClientError(null);
+                          }}
+                          className="text-xs"
+                          style={{ color: "var(--bz-text-3)" }}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                      <input
+                        className="w-full rounded border px-2 py-1.5 text-sm"
+                        style={{
+                          borderColor: "var(--bz-border)",
+                          background: "var(--bz-surface)",
+                          color: "var(--bz-text-1)",
+                        }}
+                        placeholder="Full name (required)"
+                        aria-label="New client full name"
+                        value={newClient.full_name}
+                        onChange={(e) =>
+                          setNewClient((p) => ({
+                            ...p,
+                            full_name: e.target.value,
+                          }))
+                        }
+                      />
+                      <div className="grid gap-2 sm:grid-cols-2">
+                        <input
+                          className="w-full rounded border px-2 py-1.5 text-sm"
+                          style={{
+                            borderColor: "var(--bz-border)",
+                            background: "var(--bz-surface)",
+                            color: "var(--bz-text-1)",
+                          }}
+                          placeholder="Phone (optional)"
+                          aria-label="New client phone"
+                          value={newClient.phone}
+                          onChange={(e) =>
+                            setNewClient((p) => ({
+                              ...p,
+                              phone: e.target.value,
+                            }))
+                          }
+                        />
+                        <input
+                          className="w-full rounded border px-2 py-1.5 text-sm"
+                          style={{
+                            borderColor: "var(--bz-border)",
+                            background: "var(--bz-surface)",
+                            color: "var(--bz-text-1)",
+                          }}
+                          placeholder="Nationality (optional)"
+                          aria-label="New client nationality"
+                          value={newClient.nationality}
+                          onChange={(e) =>
+                            setNewClient((p) => ({
+                              ...p,
+                              nationality: e.target.value,
+                            }))
+                          }
+                        />
+                      </div>
+                      <input
+                        className="w-full rounded border px-2 py-1.5 text-sm"
+                        style={{
+                          borderColor: "var(--bz-border)",
+                          background: "var(--bz-surface)",
+                          color: "var(--bz-text-1)",
+                        }}
+                        placeholder="Email (optional)"
+                        aria-label="New client email"
+                        type="email"
+                        value={newClient.email}
+                        onChange={(e) =>
+                          setNewClient((p) => ({
+                            ...p,
+                            email: e.target.value,
+                          }))
+                        }
+                      />
+                      {newClientError && (
+                        <p
+                          className="text-xs"
+                          style={{ color: "var(--bz-error, #d95f5a)" }}
+                        >
+                          {newClientError}
+                        </p>
+                      )}
+                      <button
+                        type="button"
+                        disabled={creatingClient || !newClient.full_name.trim()}
+                        onClick={() => void createNewClient()}
+                        className="w-full rounded-md px-3 py-1.5 text-sm font-medium text-white"
+                        style={{
+                          background: "var(--bz-accent, #d4845a)",
+                          opacity:
+                            creatingClient || !newClient.full_name.trim()
+                              ? 0.5
+                              : 1,
+                        }}
+                      >
+                        {creatingClient
+                          ? "Creating…"
+                          : "Create client & set as destination"}
+                      </button>
+                    </div>
                   )}
                 </div>
 


### PR DESCRIPTION
Two operator-facing fixes to `kita.balizero.com/review` (intake document review). Diagnosed live this session — the service infra was healthy (Pro reader :18795 up, Cloudflare tunnel up, kita HTTP 200); both issues were **code**, not infra.

## Fix 1 — "Could not open the document" (commit 1bb149491)
**Root cause:** `review/page.tsx` `openDetail` called `POST /{id}/claim` **before** fetching the detail. `routed` is a terminal success state (`writer.py:760`, migration 212 CHECK: `review_pending|review_claimed|routed|rejected|dead`), so the backend correctly 409s a claim on it — but the UI tried anyway and showed the generic error. Compounding: the catch branch tested `/409/.test(e.message)`, but the api client throws the FastAPI **detail string** (`"Proposal not claimable (status=routed...)"`) which contains no "409", so every 409 fell through to "Could not open the document."

**Fix (frontend only — `GET /{id}` detail is RBAC-only, needs no claim):**
- Fetch detail FIRST, always show it (even terminal / live-claimed-by-other proposals → read-only).
- Claim only when the proposal is non-terminal; a failed/raced claim opens read-only with an inline notice, never an error toast.
- Error mapping keyed off the detail string: terminal → "already <status> — view only", live-claim → "Claimed by another reviewer", real GET failure → "Could not open the document." Approve/Reject gated on holding a claim token.

## Fix 2 — Create a new client from the decision panel (commit 048188bb5)
For proposals where no existing client fits — **NO_MATCH** and **LINK_CANDIDATE** — the operator can now be led into a create-client form, **unlocked only for those two cases** while holding a live claim (`canCreateClient = claimToken && decision ∈ {NO_MATCH, LINK_CANDIDATE}`; hidden in read-only/terminal and for AUTO_ATTACH/AMBIGUOUS).

**Reuse-first (no new endpoint/validation):** wires the existing `api.crm.createClient()` (`crm.api.ts:356`) + `createClientSchema` (`crm.schemas.ts:99`). Prefills the proposed name from LINK_CANDIDATE / extracted entity fields. On success the new client becomes the document destination (`selectedClient`) so the operator files via the normal Approve flow.

## Tests
- Frontend: 9/9 pass (5 fix-1 + 4 fix-2) — `review/page.test.tsx`, run locally via vitest. Covers: terminal proposal opens read-only without error/claim; live-claim 409 → read-only; genuinely-claimable → claims+enables; generic failure only on detail-GET failure; create-client offered for NO_MATCH-claimable, hidden for AUTO_ATTACH, disabled read-only, and sets new client as destination.
- Backend: 48/48 pass — `test_intake_review.py` incl. new `test_detail_terminal_routed_view_without_claim` (GET detail 200 on `routed` without claim; POST claim still 409s).
- `tsc --noEmit` clean, eslint clean.

## Notes
- `lead_source` defaults to `"whatsapp"` on create (intake is WhatsApp-dominated). One-line tweak if other sources should map differently — flagging the product assumption.
- PII-L2 (UU PDP): tests use placeholder ids only.
- **Post-merge:** browser QA on `kita.balizero.com/review` against a real NO_MATCH/terminal proposal recommended (tests are mocked; the bug was in PROD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)