### PR TITLE
fix(agent-broker): base new worktrees on fresh origin/<base>, not stale local ref

### DIFF
--- a/scripts/agent_start.py
+++ b/scripts/agent_start.py
@@ -382,17 +382,40 @@ def cmd_create(
 
     WORKTREES_DIR.mkdir(parents=True, exist_ok=True)
 
+    # Base the worktree on the FRESH upstream tip, not the (possibly stale)
+    # local branch. The main checkout routinely lags origin/main by dozens of
+    # commits on this high-traffic repo (it is read-only for agents, so nothing
+    # fast-forwards it). Branching from local `main` then yields a worktree N
+    # commits behind → every PR opened from it conflicts with intervening work
+    # on the same files (sibling-race / merge-train class, superscar #5).
+    # Fetch origin/<base> and branch from there. If the fetch fails (offline —
+    # Law 6 sovereignty: disconnection is a NORMAL state, not a fault), fall
+    # back to the local ref with a loud warning rather than blocking work.
+    start_point = base_branch
+    try:
+        _run_git(["fetch", "origin", base_branch])
+        start_point = f"origin/{base_branch}"
+    except subprocess.CalledProcessError as exc:
+        logger.warning(
+            "could not fetch origin/%s (offline?) — basing worktree on LOCAL "
+            "%s, which may lag upstream: %s",
+            base_branch,
+            base_branch,
+            (exc.stderr or "").strip(),
+        )
+
     logger.info(
-        "creating worktree lane=%s task_id=%s branch=%s base=%s ttl_min=%d",
+        "creating worktree lane=%s task_id=%s branch=%s base=%s start=%s ttl_min=%d",
         lane,
         task_id,
         branch,
         base_branch,
+        start_point,
         ttl_minutes,
     )
 
     try:
-        _run_git(["worktree", "add", "-b", branch, str(worktree), base_branch])
+        _run_git(["worktree", "add", "-b", branch, str(worktree), start_point])
     except subprocess.CalledProcessError as exc:
         stderr = (exc.stderr or "").strip()
         raise SystemExit(f"ERROR: git worktree add failed: {stderr}") from exc


### PR DESCRIPTION
## Problem (observed live this session)
The main checkout is read-only for agents and routinely lags `origin/main` by dozens of commits on this high-traffic repo (nothing fast-forwards it — it was **28 commits behind** today). `agent_start.py cmd_create` branched new worktrees from the LOCAL `main`, so every worktree was born N commits stale → PRs opened from it CONFLICTED with intervening work on the same files (sibling-race / merge-train, superscar #5).

Concretely: two consecutive intake-review PRs (#1564, then the rebased #1565) were built on a 28-commits-stale base; #1564 came out CONFLICTING and half-redundant with #1555 which had merged in the meantime.

## Fix
`cmd_create` now `git fetch origin <base>` and branches from `origin/<base>`. Offline fallback (Law 6 — disconnection is a normal state): on fetch failure it bases on the local ref with a loud warning rather than blocking. Aligns the worktree BASE with the principle `_branch_in_origin_main` already used (origin/main is the source of truth; local main can lag).

## Tests
36/36 pass (`scripts/tests/test_agent_start.py`, run via backend venv). Functional check: a probe worktree created with the patched script based on `origin/main` tip (86e057ccc), not the stale local `a65a65275`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)