### PR TITLE
fix(review): move classifyResolvedDecideError out of page.tsx — unblocks Vercel prod deploy

### DIFF
--- a/apps/mouth/src/app/(workspace)/review/decide-error.test.ts
+++ b/apps/mouth/src/app/(workspace)/review/decide-error.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { classifyResolvedDecideError } from "./page";
+import { classifyResolvedDecideError } from "./decide-error";
 
 describe("classifyResolvedDecideError", () => {
   it("treats an already-routed (filed) 409 as already_filed", () => {

--- a/apps/mouth/src/app/(workspace)/review/decide-error.ts
+++ b/apps/mouth/src/app/(workspace)/review/decide-error.ts
@@ -1,0 +1,26 @@
+/**
+ * Detect the "the proposal already left the claimable state" 409, so a retry
+ * after a transient blip (whose write already committed) is shown as an
+ * informational refresh, NOT a red "action failed" error.
+ *
+ * The backend guard (shared by approve AND reject) raises HTTP 409 with
+ * detail=`Proposal must be review_claimed (status=<actual>).`; the api client
+ * surfaces that detail verbatim into Error.message. We anchor on the stable
+ * "must be review_claimed" phrase, then branch on the terminal status:
+ *   - status=routed   → the document was already approved & filed.
+ *   - status=rejected → the proposal was already rejected.
+ * Any other status (e.g. review_pending) or a different error (network/500,
+ * "Claim lease expired", etc.) returns null and stays on the normal error path.
+ *
+ * Lives in its own module (not page.tsx): Next.js App Router rejects any
+ * non-reserved named export from a `page.tsx` ("does not match the required
+ * types of a Next.js Page"), which fails the production `next build`.
+ */
+export function classifyResolvedDecideError(
+  message: string | undefined | null,
+): "already_filed" | "already_rejected" | null {
+  if (!message || !message.includes("must be review_claimed")) return null;
+  if (message.includes("status=routed")) return "already_filed";
+  if (message.includes("status=rejected")) return "already_rejected";
+  return null;
+}

--- a/apps/mouth/src/app/(workspace)/review/page.tsx
+++ b/apps/mouth/src/app/(workspace)/review/page.tsx
@@ -31,6 +31,7 @@ import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
 import type { CreateClientParams } from "@/lib/api/crm/crm.types";
 
+import { classifyResolvedDecideError } from "./decide-error";
 import {
   categoriesForGroup,
   categoryGroups,
@@ -197,29 +198,6 @@ function prefillFromExtractedFields(
     phone: "",
     email: "",
   };
-}
-
-/**
- * Detect the "the proposal already left the claimable state" 409, so a retry
- * after a transient blip (whose write already committed) is shown as an
- * informational refresh, NOT a red "action failed" error.
- *
- * The backend guard (shared by approve AND reject) raises HTTP 409 with
- * detail=`Proposal must be review_claimed (status=<actual>).`; the api client
- * surfaces that detail verbatim into Error.message. We anchor on the stable
- * "must be review_claimed" phrase, then branch on the terminal status:
- *   - status=routed   → the document was already approved & filed.
- *   - status=rejected → the proposal was already rejected.
- * Any other status (e.g. review_pending) or a different error (network/500,
- * "Claim lease expired", etc.) returns null and stays on the normal error path.
- */
-export function classifyResolvedDecideError(
-  message: string | undefined | null,
-): "already_filed" | "already_rejected" | null {
-  if (!message || !message.includes("must be review_claimed")) return null;
-  if (message.includes("status=routed")) return "already_filed";
-  if (message.includes("status=rejected")) return "already_rejected";
-  return null;
 }
 
 /**


### PR DESCRIPTION
## Problem
Vercel **production** deploy of `main` has been **failing** (production serves a ~30h-stale build), so the merged #1565 "Could not open the document" fix is **not live**.

Root cause — `apps/mouth/src/app/(workspace)/review/page.tsx` has a named export (`classifyResolvedDecideError`) alongside `export default`. Next.js App Router rejects it:
```
Type error: Page "src/app/(workspace)/review/page.tsx" does not match the required types of a Next.js Page.
  "classifyResolvedDecideError" is not a valid Page export field.
```

**Why it slipped the gate:** the 18 required checks run vitest (which passes) but do NOT run a Next.js `next build`. The page-type-check happens only in the Vercel deploy, which is non-required. Pre-existing on main (62f725d51, which doesn't touch page.tsx, already shows Vercel=failure) — the named export came from an earlier commit (#1551/#1555), not #1565.

## Fix
Move `classifyResolvedDecideError` into a sibling module `review/decide-error.ts` (a `decide-error.test.ts` already existed targeting this never-created module — this completes that convention). `page.tsx` now ends with ONLY `export default`.

## Verification
- `npx next build --webpack` (cwd apps/mouth) → **exit 0**, `✓ Compiled successfully`, TypeScript clean, 230/230 static pages.
- `vitest review/decide-error.test.ts` → 6/6 pass (classify logic still tested from new location).
- Swept ALL mouth page/layout/template/error/loading/not-found/default files for non-reserved named exports — `review/page.tsx` was the ONLY offender; the full `next build` confirms no other page trips it.
- Diff: 3 files, +28/-24, frontend-only.

## Follow-up (not in this PR)
Make `next build` a required check (or add a build-smoke to CI) so a page that breaks production deploy can't pass all required checks again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)