### PR TITLE
fix(intake-proxy): raise Fly→Pro read timeout 5s→30s — fixes detail/blob 503 over slow tunnel

### DIFF
--- a/apps/backend-rag/backend/app/rag_proxy.py
+++ b/apps/backend-rag/backend/app/rag_proxy.py
@@ -142,9 +142,15 @@ async def get_proxy_client() -> httpx.AsyncClient:
 async def get_intake_client() -> httpx.AsyncClient:
     """Persistent client for the intake-review target (Golden Rule #10 — never per-request).
 
-    TIGHT timeouts (connect=3, read=5): the Pro reader is over a Cloudflare Tunnel and may be
-    offline. A short fail-fast prevents a Pro outage from exhausting the Fly worker pool and
-    taking down the WHOLE api (Gemini P0 / Codex P1#3). Bounded base_url to the tunnel host.
+    Timeouts (connect=3, read=30): a SHORT connect (3s) still fail-fasts when the Pro is
+    offline — an unreachable tunnel fails at connect, so a Pro outage can't exhaust the Fly
+    worker pool and take down the WHOLE api (Gemini P0 / Codex P1#3). But the READ budget must
+    cover the full round-trip over the Cloudflare Tunnel on the Pro's mobile/hotspot uplink:
+    the detail/blob endpoints (which load the document blob + candidate clients) routinely take
+    >5s end-to-end, so a 5s read budget mapped EVERY detail open to a spurious 503 "reader
+    offline" while /queue (a fast PG read) stayed 200. 30s read covers the slow link without
+    re-opening the worker-pool-exhaustion risk (connect, not read, is the offline guard).
+    Bounded base_url to the tunnel host.
     """
     global _intake_client
     if _intake_client is None or _intake_client.is_closed:
@@ -153,7 +159,7 @@ async def get_intake_client() -> httpx.AsyncClient:
                 base = get_intake_review_worker_url()
                 _intake_client = httpx.AsyncClient(
                     base_url=base or "",
-                    timeout=httpx.Timeout(5.0, connect=3.0),
+                    timeout=httpx.Timeout(30.0, connect=3.0),
                     limits=httpx.Limits(max_connections=10, max_keepalive_connections=5),
                 )
     return _intake_client

--- a/apps/backend-rag/backend/tests/unit/app/test_rag_proxy_intake_split.py
+++ b/apps/backend-rag/backend/tests/unit/app/test_rag_proxy_intake_split.py
@@ -184,14 +184,16 @@ async def test_intake_upstream_5xx_mapped_to_503(monkeypatch):
 
 
 async def test_intake_tight_timeout_configured(monkeypatch):
-    """The intake client uses a TIGHT timeout (connect<=3, read<=5), not the 300s RAG one."""
+    """The intake client fail-fasts on CONNECT (<=3s, the Pro-offline guard) and bounds READ
+    well under the 300s RAG timeout. Read is 30s — enough for the detail/blob round-trip over
+    the Pro's mobile tunnel (a 5s read budget mapped every detail open to a spurious 503)."""
     monkeypatch.setenv("INTAKE_REVIEW_WORKER_URL", "https://intake-review.balizero.com")
     # Force a fresh client to pick up the env-derived base_url.
     monkeypatch.setattr(rag_proxy, "_intake_client", None)
     client = await rag_proxy.get_intake_client()
     try:
         assert client.timeout.connect is not None and client.timeout.connect <= 3.0
-        assert client.timeout.read is not None and client.timeout.read <= 5.0
+        assert client.timeout.read is not None and client.timeout.read <= 30.0
     finally:
         await client.aclose()
         rag_proxy._intake_client = None


### PR DESCRIPTION
## Problem (live, reported by Zero — team about to start work)
Team members (e.g. krisna@, Executive Consultant) clicking ANY proposal in `/review` — **including their own** — got **"Could not open the document."** The detail/blob endpoints returned **503**, while `/queue` returned 200 (so the list showed proposals the click then failed to open).

## Root cause (verified live, not theorized)
- `GET /api/intake/review/{id}` on the **LOCAL Pro reader** = **200** in <1s (reader is healthy).
- Same request through Fly = **503**, body empty. Response headers: `via: 1.1 fly.io` (one hop, **no** `cf-ray`) vs `/queue`'s `via: fly.io, fly.io` + `cf-ray` — i.e. **Fly timed out before reaching the Pro tunnel**, it did not get a 503 from the reader.
- The Fly intake proxy (`rag_proxy.py`) used `httpx.Timeout(5.0, connect=3.0)` and maps **every** `TimeoutException` to `503 "intake review reader offline"`. The detail endpoint (loads the document blob + candidate clients) over the Cloudflare Tunnel on the Pro's **mobile/hotspot uplink** routinely takes **>5s** end-to-end → spurious 503. `/queue` (fast PG read) stayed <5s → 200.

(Separately: the Pro tunnel was also flapping on QUIC over the hotspot link — fixed Pro-side by switching the cloudflared tunnel to `protocol: http2`, infra change, not in this PR.)

## Fix
`rag_proxy.py` intake client read timeout **5s → 30s**; **connect stays 3s**. The Pro-offline guard is **connect** (an unreachable tunnel fails at connect, so a Pro outage still can't exhaust the Fly worker pool — the original concern). Read only bounds a *live-but-slow* round-trip. 30s ≪ the 300s RAG budget.

## Verification
- `pytest backend/tests/unit/app/test_rag_proxy_intake_split.py` → **9/9 pass** (updated `test_intake_tight_timeout_configured` to assert read ≤ 30, connect ≤ 3).
- Diff: 1 source file + 1 test, +10/-4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)