### PR TITLE
feat(curiosity): kg-propose operator CLI — wire the Curiosity Loop consumer (TAC #11)

### DIFF
--- a/scripts/kg_propose.py
+++ b/scripts/kg_propose.py
@@ -55,7 +55,7 @@ def _get_database_url() -> str:
         "DATABASE_URL",
         os.environ.get(
             "NUZANTARA_DATABASE_URL",
-            "postgresql://postgres:postgres@localhost:5432/nuzantara_rag",
+            "postgresql://postgres:postgres@localhost:5432/nuzantara_rag",  # pragma: allowlist secret  # localhost dev default, not a production credential
         ),
     )
 

--- a/scripts/kg_propose.py
+++ b/scripts/kg_propose.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""kg-propose — operator CLI for the Curiosity Loop proposal queue.
+
+The Curiosity Loop (gap_fill_autonomous.py) generates KG node/edge/property
+proposals into the `kg_proposals` table in PROPOSE-ONLY mode — it never
+auto-promotes to the live knowledge graph. Until this CLI existed there was no
+operator path to consume that queue: proposals accumulated `pending` forever
+(TAC 2026-06-19, superscar #11 "Anello di Chiusura Reciso" — the producer ran
+green while the consumer was never wired). `curiosity_loop.sh` documents
+`kg-propose apply <id>` as the approval path; this is that command.
+
+It is a THIN wrapper around the existing, tested `KGProposalStore` methods
+(`list_proposals` / `approve` / `apply_approved` / `reject`). No KG-mutation
+logic lives here — `apply_approved` is the single sanctioned write path to
+kg_nodes/kg_edges, and it already enforces the two-phase approve→apply gate
+and an atomic, rolling-back transaction.
+
+Usage:
+    kg-propose list [--status pending] [--domain company] [--limit 50]
+    kg-propose show <proposal_id>
+    kg-propose approve <proposal_id> [--by <name>]
+    kg-propose apply <proposal_id> --yes        # mutates the live KG
+    kg-propose reject <proposal_id> [--reason "..."]
+    kg-propose apply-all --status approved --yes  # batch-apply approved
+
+`apply` / `apply-all` mutate production KG state and therefore REQUIRE an
+explicit `--yes`. Without it they run as a dry-run that only reports what
+would happen. This keeps the destructive boundary explicit per AUTONOMOUS_OPS.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+
+# graph-engine package lives outside backend; make it importable when run
+# either from repo root or via an installed console-script.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_GRAPH_SRC = os.path.join(_REPO_ROOT, "apps", "graph-engine", "src")
+if _GRAPH_SRC not in sys.path:
+    sys.path.insert(0, _GRAPH_SRC)
+
+from nuzantara_graph.curiosity.proposals import KGProposalStore  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger("kg-propose")
+
+
+def _get_database_url() -> str:
+    """Resolve database URL — identical resolution to gap_fill_autonomous.py."""
+    return os.environ.get(
+        "DATABASE_URL",
+        os.environ.get(
+            "NUZANTARA_DATABASE_URL",
+            "postgresql://postgres:postgres@localhost:5432/nuzantara_rag",
+        ),
+    )
+
+
+def _fmt_row(p: dict) -> str:
+    """One-line summary of a proposal for the list view."""
+    label = p.get("node_label") or p.get("relationship_type") or p.get("property_key") or "—"
+    score = p.get("self_rag_score")
+    score_s = f"{score:.2f}" if isinstance(score, (int, float)) else "  —"
+    return (
+        f"{str(p.get('proposal_id', ''))[:8]}  "
+        f"{str(p.get('status', '')):9}  "
+        f"{str(p.get('proposal_type', '')):9}  "
+        f"{str(p.get('domain', '')):10}  "
+        f"score={score_s}  {label}"
+    )
+
+
+async def cmd_list(store: KGProposalStore, args: argparse.Namespace) -> int:
+    proposals = await store.list_proposals(
+        status=args.status, domain=args.domain, limit=args.limit
+    )
+    if not proposals:
+        logger.info("No proposals match (status=%s domain=%s).", args.status, args.domain)
+        return 0
+    logger.info("%d proposal(s):", len(proposals))
+    for p in proposals:
+        logger.info("  %s", _fmt_row(p))
+    return 0
+
+
+async def cmd_show(store: KGProposalStore, args: argparse.Namespace) -> int:
+    p = await store.get_proposal(args.proposal_id)
+    if not p:
+        logger.error("Proposal %s not found.", args.proposal_id)
+        return 1
+    for k, v in p.items():
+        logger.info("  %-22s %s", k, v)
+    return 0
+
+
+async def cmd_approve(store: KGProposalStore, args: argparse.Namespace) -> int:
+    ok = await store.approve(args.proposal_id, approved_by=args.by)
+    if ok:
+        logger.info("Approved %s (by %s). Run `kg-propose apply %s --yes` to materialize.",
+                    args.proposal_id[:8], args.by, args.proposal_id[:8])
+        return 0
+    logger.error("Approve failed for %s (not found or not in 'pending').", args.proposal_id)
+    return 1
+
+
+async def cmd_reject(store: KGProposalStore, args: argparse.Namespace) -> int:
+    ok = await store.reject(args.proposal_id, reason=args.reason)
+    logger.info("%s %s", "Rejected" if ok else "Reject failed for", args.proposal_id[:8])
+    return 0 if ok else 1
+
+
+async def cmd_apply(store: KGProposalStore, args: argparse.Namespace) -> int:
+    p = await store.get_proposal(args.proposal_id)
+    if not p:
+        logger.error("Proposal %s not found.", args.proposal_id)
+        return 1
+    if p.get("status") != "approved":
+        logger.error("Proposal %s is '%s', not 'approved'. Run `kg-propose approve` first.",
+                     args.proposal_id[:8], p.get("status"))
+        return 1
+    if not args.yes:
+        logger.info("DRY-RUN — would apply %s to the live KG:", args.proposal_id[:8])
+        logger.info("  %s", _fmt_row(p))
+        logger.info("Re-run with --yes to mutate production KG.")
+        return 0
+    ok = await store.apply_approved(args.proposal_id)
+    logger.info("%s %s", "Applied" if ok else "Apply FAILED for", args.proposal_id[:8])
+    return 0 if ok else 1
+
+
+async def cmd_apply_all(store: KGProposalStore, args: argparse.Namespace) -> int:
+    proposals = await store.list_proposals(status="approved", limit=args.limit)
+    if not proposals:
+        logger.info("No 'approved' proposals to apply.")
+        return 0
+    if not args.yes:
+        logger.info("DRY-RUN — would apply %d approved proposal(s):", len(proposals))
+        for p in proposals:
+            logger.info("  %s", _fmt_row(p))
+        logger.info("Re-run with --yes to mutate production KG.")
+        return 0
+    applied = 0
+    for p in proposals:
+        if await store.apply_approved(p["proposal_id"]):
+            applied += 1
+    logger.info("Applied %d/%d approved proposal(s).", applied, len(proposals))
+    return 0 if applied == len(proposals) else 1
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="kg-propose", description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_list = sub.add_parser("list", help="list proposals")
+    p_list.add_argument("--status", default="pending")
+    p_list.add_argument("--domain", default=None)
+    p_list.add_argument("--limit", type=int, default=50)
+    p_list.set_defaults(func=cmd_list)
+
+    p_show = sub.add_parser("show", help="show one proposal in full")
+    p_show.add_argument("proposal_id")
+    p_show.set_defaults(func=cmd_show)
+
+    p_approve = sub.add_parser("approve", help="approve a pending proposal")
+    p_approve.add_argument("proposal_id")
+    p_approve.add_argument("--by", default="zero")
+    p_approve.set_defaults(func=cmd_approve)
+
+    p_reject = sub.add_parser("reject", help="reject a pending proposal")
+    p_reject.add_argument("proposal_id")
+    p_reject.add_argument("--reason", default="")
+    p_reject.set_defaults(func=cmd_reject)
+
+    p_apply = sub.add_parser("apply", help="apply an approved proposal to the live KG")
+    p_apply.add_argument("proposal_id")
+    p_apply.add_argument("--yes", action="store_true", help="confirm production KG mutation")
+    p_apply.set_defaults(func=cmd_apply)
+
+    p_apply_all = sub.add_parser("apply-all", help="apply all approved proposals")
+    p_apply_all.add_argument("--limit", type=int, default=100)
+    p_apply_all.add_argument("--yes", action="store_true", help="confirm production KG mutation")
+    p_apply_all.set_defaults(func=cmd_apply_all)
+
+    return parser
+
+
+async def _amain(argv: list[str]) -> int:
+    args = _build_parser().parse_args(argv)
+    store = KGProposalStore(database_url=_get_database_url())
+    try:
+        return await args.func(store, args)
+    finally:
+        await store.close()
+
+
+def main() -> None:
+    sys.exit(asyncio.run(_amain(sys.argv[1:])))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_kg_propose_cli.py
+++ b/scripts/tests/test_kg_propose_cli.py
@@ -1,0 +1,104 @@
+"""Unit tests for the kg-propose operator CLI (scripts/kg_propose.py).
+
+These tests mock KGProposalStore entirely — no DB, no network. They lock down
+the two things that matter for safety: (1) command routing reaches the right
+store method, and (2) `apply`/`apply-all` are dry-run UNLESS `--yes` is passed
+(the production-KG-mutation boundary). The KG-write logic itself lives in the
+already-tested KGProposalStore.apply_approved and is not re-tested here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+
+# Load the CLI module by path (scripts/ is not a package).
+_CLI_PATH = Path(__file__).resolve().parents[1] / "kg_propose.py"
+_spec = importlib.util.spec_from_file_location("kg_propose", _CLI_PATH)
+assert _spec and _spec.loader
+kg_propose = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(kg_propose)
+
+
+def _store(**overrides) -> AsyncMock:
+    store = AsyncMock()
+    store.list_proposals.return_value = overrides.get("list", [])
+    store.get_proposal.return_value = overrides.get("get", None)
+    store.approve.return_value = overrides.get("approve", True)
+    store.reject.return_value = overrides.get("reject", True)
+    store.apply_approved.return_value = overrides.get("apply", True)
+    return store
+
+
+def _run(store: AsyncMock, args: list[str]) -> int:
+    parsed = kg_propose._build_parser().parse_args(args)
+    return asyncio.run(parsed.func(store, parsed))
+
+
+_APPROVED = {
+    "proposal_id": "abc12345-0000-0000-0000-000000000000",
+    "status": "approved",
+    "proposal_type": "node",
+    "domain": "company",
+    "node_label": "NIB registration",
+    "self_rag_score": 0.99,
+}
+_PENDING = {**_APPROVED, "status": "pending"}
+
+
+def test_list_routes_to_store() -> None:
+    store = _store(list=[_PENDING])
+    assert _run(store, ["list", "--status", "pending"]) == 0
+    store.list_proposals.assert_awaited_once()
+
+
+def test_approve_routes_with_by() -> None:
+    store = _store(approve=True)
+    assert _run(store, ["approve", _APPROVED["proposal_id"], "--by", "zero"]) == 0
+    store.approve.assert_awaited_once_with(_APPROVED["proposal_id"], approved_by="zero")
+
+
+def test_apply_without_yes_is_dry_run() -> None:
+    """The safety contract: no --yes => apply_approved is NEVER called."""
+    store = _store(get=_APPROVED)
+    rc = _run(store, ["apply", _APPROVED["proposal_id"]])
+    assert rc == 0
+    store.apply_approved.assert_not_awaited()
+
+
+def test_apply_with_yes_mutates() -> None:
+    store = _store(get=_APPROVED, apply=True)
+    rc = _run(store, ["apply", _APPROVED["proposal_id"], "--yes"])
+    assert rc == 0
+    store.apply_approved.assert_awaited_once_with(_APPROVED["proposal_id"])
+
+
+def test_apply_refuses_non_approved() -> None:
+    """apply on a 'pending' proposal must fail loudly and never mutate."""
+    store = _store(get=_PENDING)
+    rc = _run(store, ["apply", _PENDING["proposal_id"], "--yes"])
+    assert rc == 1
+    store.apply_approved.assert_not_awaited()
+
+
+def test_apply_all_without_yes_is_dry_run() -> None:
+    store = _store(list=[_APPROVED, _APPROVED])
+    rc = _run(store, ["apply-all"])
+    assert rc == 0
+    store.apply_approved.assert_not_awaited()
+
+
+def test_apply_all_with_yes_applies_each() -> None:
+    store = _store(list=[_APPROVED, _APPROVED], apply=True)
+    rc = _run(store, ["apply-all", "--yes"])
+    assert rc == 0
+    assert store.apply_approved.await_count == 2
+
+
+def test_reject_routes_with_reason() -> None:
+    store = _store(reject=True)
+    assert _run(store, ["reject", _PENDING["proposal_id"], "--reason", "dup"]) == 0
+    store.reject.assert_awaited_once_with(_PENDING["proposal_id"], reason="dup")


### PR DESCRIPTION
## What
Adds `scripts/kg_propose.py` — the operator CLI to consume the Curiosity Loop proposal queue.

## Why (TAC 2026-06-19, superscar #11 "Anello di Chiusura Reciso")
The Curiosity Loop generates KG proposals into `kg_proposals` (propose-only) but there was **no operator path to apply them**: 17 proposals (self_rag 0.99, real regulatory citations — NIB, KBLI 2020, PT PMA capital) sat `pending` indefinitely. `curiosity_loop.sh` documents `kg-propose apply <id>` but the command never existed (`which kg-propose` → not found). The producer ran green while the consumer was never wired.

## How
Thin CLI over the **existing, tested** `KGProposalStore` methods (`list_proposals` / `approve` / `apply_approved` / `reject`). **No new KG-mutation logic** — `apply_approved` is the single sanctioned write path and already enforces the two-phase approve→apply gate + atomic rollback.

Safety: `apply` / `apply-all` are **dry-run unless `--yes`**, keeping the production-KG-mutation boundary explicit (AUTONOMOUS_OPS).

## Tests
8 unit tests (mocked store, no DB): command routing + the `--yes` safety contract (no `--yes` ⇒ `apply_approved` never called; `apply` refuses non-approved). All green.

## Operator note
The first real `apply` of the 17 pending proposals mutates production KG — that's an operator action (`kg-propose approve <id>` then `kg-propose apply <id> --yes`), intentionally NOT done in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)