### PR TITLE
fix(review): prune terminal proposals from the queue so they stop reopening as zombies

### DIFF
--- a/apps/mouth/src/app/(workspace)/review/page.test.tsx
+++ b/apps/mouth/src/app/(workspace)/review/page.test.tsx
@@ -228,6 +228,15 @@ describe("ReviewPage", () => {
     // Actions are disabled in read-only mode.
     expect(screen.getByRole("button", { name: "Approve" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Reject" })).toBeDisabled();
+
+    // …and the now-terminal row is PRUNED from the in-memory queue so it can no
+    // longer be reopened as a zombie (it turned terminal mid-session — a full
+    // loadQueue() would also drop it, this does it eagerly). The list started
+    // with two cards (proposal 1 + the NO_MATCH proposal); after opening the
+    // terminal one, only the NO_MATCH 'Review' button remains.
+    await waitFor(() =>
+      expect(screen.getAllByRole("button", { name: "Review" })).toHaveLength(1),
+    );
   });
 
   it("falls back to read-only 'claimed by another reviewer' on a live-claim 409", async () => {

--- a/apps/mouth/src/app/(workspace)/review/page.tsx
+++ b/apps/mouth/src/app/(workspace)/review/page.tsx
@@ -354,6 +354,14 @@ export default function ReviewPage() {
         let roReason: string | null = null;
         if (TERMINAL_STATUSES.has(d.status)) {
           roReason = `This proposal is ${terminalLabel(d.status)} — view only.`;
+          // Prune the now-terminal row from the in-memory list. A proposal can
+          // turn terminal because ANOTHER operator decided it while this page
+          // was open — loadQueue() only re-runs after *our* own decide, so the
+          // stale row lingers as a clickable zombie that always reopens
+          // read-only. Dropping it here keeps the queue honest without a full
+          // refetch (the backend WHERE status='review_pending' already excludes
+          // it, so a reload would drop it too — this just does it eagerly).
+          setItems((prev) => prev.filter((p) => p.proposal_id !== proposalId));
         } else {
           try {
             const claim = await api.post<ClaimResponse>(
@@ -366,10 +374,19 @@ export default function ReviewPage() {
               // Lost the race between list-load and click. Distinguish a
               // status that turned terminal from a live claim by another.
               const st = statusFromClaimError(claimErr);
-              roReason =
-                st && TERMINAL_STATUSES.has(st)
-                  ? `This proposal is ${terminalLabel(st)} — view only.`
-                  : "Claimed by another reviewer — view only.";
+              if (st && TERMINAL_STATUSES.has(st)) {
+                roReason = `This proposal is ${terminalLabel(st)} — view only.`;
+                // Same as the up-front terminal branch: another operator drove
+                // it to a terminal state mid-session — prune the zombie row.
+                setItems((prev) =>
+                  prev.filter((p) => p.proposal_id !== proposalId),
+                );
+              } else {
+                // Live claim held by a DIFFERENT reviewer — the row is NOT
+                // terminal, it is legitimately still pending for them; keep it
+                // in the list (it may free up when their lease expires).
+                roReason = "Claimed by another reviewer — view only.";
+              }
             } else {
               // A real claim failure (404/500/network). Detail already loaded;
               // surface a soft read-only notice rather than hiding the document.


### PR DESCRIPTION
## Problem (Zero, 2026-06-19 — "ne ho altri tre che sono view only ma mi bloccano uguale")

A proposal can turn **terminal** (`routed`/`rejected`/`dead`) because **another operator** decided it while this reviewer's `/review` page is open. The list only re-runs `loadQueue()` after the reviewer's **own** decide — so the stale row lingers as a **clickable zombie** that always reopens read-only:

> *"This proposal is rejected — view only."*

Zero hit exactly this: `rejected` docs from `surya@` kept appearing in his open list and blocking — every time he clicked one he got the view-only panel with disabled Approve/Reject.

## Root cause — verified live, not theorized

Investigated on PROD with the team session (browser network + Pro DB + Fly DB):

- **Backend is SANE.** The `/queue` `WHERE p.status='review_pending'` **correctly excludes** terminal rows (proposal 12691 = `rejected` is NOT in a fresh queue). `/claim` works (200) when the `X-CSRF-Token` header is sent (it is, via `client.ts`). No split-brain (Fly `document_routing_proposal` = 0 rows; everything on Pro `nuzantara_dev`).
- The zombie is **purely client-side stale state**: the row was loaded when pending, another operator rejected it, and the open page never refetched.

## Fix

When `openDetail` discovers the proposal is already terminal — either from the **detail GET status** or from a **claim 409** whose `status=` token is terminal — drop that row from the in-memory list (`setItems(prev => prev.filter(...))`). The backend already excludes it, so a full reload would drop it too; this just does it **eagerly**, no refetch.

The genuine **"live-claimed by another reviewer"** case (status NOT terminal) is **left** in the list, since it may free up when the lease expires.

## Test

Extends the existing *"opens a terminal (routed) proposal READ-ONLY"* test to assert the row is pruned (2 cards → 1 after opening the terminal one). `7/7` pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)