### PR TITLE
fix(intake): upscale sub-28px images before OCR — guard qwen2.5vl SmartResize panic (TAC #16)

### DIFF
--- a/apps/backend-rag/backend/services/intake/preprocess.py
+++ b/apps/backend-rag/backend/services/intake/preprocess.py
@@ -66,6 +66,13 @@ MAX_PAGES = 30
 # would only add artifacts, so we skip it.
 LOW_CONTRAST_STD_THRESHOLD = 55.0
 
+# qwen2.5vl's ImageProcessor.SmartResize panics (kills the whole Ollama vision
+# runner, taking down every queued OCR request — TAC 2026-06-19, finding #16)
+# when an image side is smaller than its resize factor of 28px. Any image with
+# a side below this is upscaled before it ever reaches the model. Upscale, not
+# drop: a tiny thumbnail still gets a chance at OCR instead of silently 0-char.
+MIN_OCR_DIMENSION = 28
+
 # Text-layer fast-path. Born-digital PDFs (NIB/OSS/NPWP printouts, e-akta, bank
 # letters) carry a selectable text layer -- extracting it is ~instant and
 # lossless, vs ~120s/page on the local vision model rasterizing an image of the
@@ -285,6 +292,28 @@ def _extract_pdf_textlayer_sync(pdf_bytes: bytes, max_pages: int) -> list[str | 
         return []
 
 
+def _upscale_if_below_min(im: "Any", Image: "Any") -> "Any":
+    """Upscale an image so its smallest side is >= MIN_OCR_DIMENSION.
+
+    Guards qwen2.5vl's SmartResize panic on sub-28px images (kills the Ollama
+    vision runner). Preserves aspect ratio; no-op when already large enough.
+    """
+    w, h = im.size
+    smallest = min(w, h)
+    if smallest >= MIN_OCR_DIMENSION:
+        return im
+    if smallest <= 0:
+        return im  # degenerate; let the caller's try/except handle it
+    scale = MIN_OCR_DIMENSION / smallest
+    new_size = (max(MIN_OCR_DIMENSION, round(w * scale)),
+                max(MIN_OCR_DIMENSION, round(h * scale)))
+    logger.warning(
+        "OCR image %dx%d below %dpx floor — upscaling to %dx%d (qwen2.5vl SmartResize guard)",
+        w, h, MIN_OCR_DIMENSION, new_size[0], new_size[1],
+    )
+    return im.resize(new_size, Image.LANCZOS)
+
+
 def _normalize_image_sync(image_bytes: bytes) -> bytes | None:
     """Re-encode an arbitrary image (jpeg/webp/tiff) to PNG. None on failure."""
     try:
@@ -292,6 +321,7 @@ def _normalize_image_sync(image_bytes: bytes) -> bytes | None:
 
         with Image.open(io.BytesIO(image_bytes)) as im:
             im = im.convert("RGB")
+            im = _upscale_if_below_min(im, Image)
             buf = io.BytesIO()
             im.save(buf, format="PNG")
             return buf.getvalue()

--- a/apps/backend-rag/backend/services/intake/preprocess.py
+++ b/apps/backend-rag/backend/services/intake/preprocess.py
@@ -292,7 +292,7 @@ def _extract_pdf_textlayer_sync(pdf_bytes: bytes, max_pages: int) -> list[str | 
         return []
 
 
-def _upscale_if_below_min(im: "Any", Image: "Any") -> "Any":
+def _upscale_if_below_min(im: object, Image: object) -> object:
     """Upscale an image so its smallest side is >= MIN_OCR_DIMENSION.
 
     Guards qwen2.5vl's SmartResize panic on sub-28px images (kills the Ollama

--- a/apps/backend-rag/backend/tests/services/intake/test_preprocess_min_dimension.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_preprocess_min_dimension.py
@@ -1,0 +1,61 @@
+"""Guard for the qwen2.5vl sub-28px SmartResize panic (TAC 2026-06-19 #16).
+
+A vision image whose smallest side is < 28px makes Ollama's qwen2.5vl
+ImageProcessor.SmartResize panic, killing the whole vision runner and taking
+down every queued OCR request with it. `_normalize_image_sync` must upscale
+such images so they never reach the model below the floor.
+"""
+
+from __future__ import annotations
+
+import io
+
+from PIL import Image
+
+from backend.services.intake.preprocess import (
+    MIN_OCR_DIMENSION,
+    _normalize_image_sync,
+)
+
+
+def _png_bytes(width: int, height: int) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), (200, 100, 50)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _dims(png: bytes) -> tuple[int, int]:
+    with Image.open(io.BytesIO(png)) as im:
+        return im.size
+
+
+def test_tiny_image_is_upscaled_above_floor() -> None:
+    """An 8x8 image (the exact panic repro) is upscaled to >= the floor."""
+    out = _normalize_image_sync(_png_bytes(8, 8))
+    assert out is not None
+    w, h = _dims(out)
+    assert min(w, h) >= MIN_OCR_DIMENSION
+
+
+def test_thin_strip_smallest_side_lifted() -> None:
+    """A 4x500 strip: only the small side is below the floor; it gets lifted,
+    aspect ratio preserved (width grows proportionally)."""
+    out = _normalize_image_sync(_png_bytes(4, 500))
+    assert out is not None
+    w, h = _dims(out)
+    assert min(w, h) >= MIN_OCR_DIMENSION
+    assert h > w  # portrait orientation preserved
+
+
+def test_normal_image_is_not_resized() -> None:
+    """A comfortably-large image passes through untouched (no needless resize)."""
+    out = _normalize_image_sync(_png_bytes(800, 600))
+    assert out is not None
+    assert _dims(out) == (800, 600)
+
+
+def test_exactly_at_floor_is_untouched() -> None:
+    """28x28 is exactly the floor — must NOT be upscaled (boundary)."""
+    out = _normalize_image_sync(_png_bytes(MIN_OCR_DIMENSION, MIN_OCR_DIMENSION))
+    assert out is not None
+    assert _dims(out) == (MIN_OCR_DIMENSION, MIN_OCR_DIMENSION)


### PR DESCRIPTION
## What
`_normalize_image_sync` (the single intake OCR preprocess chokepoint) now upscales any image whose smallest side is `< 28px` before re-encoding.

## Why (TAC 2026-06-19, finding #16 — re-diagnosed)
The intake OCR worker returned **0 chars on ~19/99 docs/day**. First-guess root cause was RAM saturation. **Reading the actual Ollama server log disproved that**: qwen2.5vl's `ImageProcessor.SmartResize` **panics** (`model runner has unexpectedly stopped`, stack at `qwen25vl/process_image.go:50`) when an image side is below its resize factor of **28px**. The panic kills the whole vision runner, so every OCR request queued behind a tiny image also fails — that's why the 0-char docs clustered.

The A/B that settled it: the crash reproduces with `Pages free ~2.5GB` (RAM not saturated), and persists after the heavy models are already evicted — so it's not memory, it's the sub-28px image.

## How
Upscale (not drop) at the single preprocess chokepoint → every OCR call-site covered. Aspect ratio preserved; a tiny thumbnail still gets a shot at OCR instead of silently returning 0 chars.

## Verified end-to-end on the Pro
An 8×8 image (the exact repro) crashes qwen2.5vl raw; upscaled to 28×28 by this guard, the model **responds normally** (no `unexpectedly stopped`). 4 unit tests: repro, thin strip, normal image (no needless resize), exact-floor boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)