### PR TITLE
fix(intake-review): WhatsApp-only review queue — gate Drive/Dropbox archive out

### DIFF
--- a/apps/backend-rag/backend/app/routers/intake_review.py
+++ b/apps/backend-rag/backend/app/routers/intake_review.py
@@ -56,6 +56,25 @@ router = APIRouter(prefix="/api/intake/review", tags=["intake-review"])
 # How long a single reviewer holds a proposal before it becomes reclaimable.
 CLAIM_TTL_MINUTES = 15
 
+# Which intake sources surface in the human review queue. Per Zero (2026-06-19):
+# the review queue is WhatsApp-only "for now" — Drive/Dropbox documents are still
+# catalogued into intake_queue + document_routing_proposal (the DB record is kept
+# and the worker keeps running), they just must NOT flood the team/admin review
+# list. The Dropbox→Drive mirror is the team's whole historical archive (years of
+# scans + iPhone camera rolls), so draining it into review buried the ~107 real
+# WhatsApp docs under ~19.6k archive proposals. This is the single gate that keeps
+# the queue honest; widen it only by setting INTAKE_REVIEW_SOURCES.
+#
+# Override (CSV, e.g. "whatsapp,drive") to re-admit other sources without a code
+# change. An empty/whitespace value falls back to the default allowlist.
+_DEFAULT_REVIEW_SOURCES = ("whatsapp",)
+
+
+def _review_source_allowlist() -> tuple[str, ...]:
+    raw = os.getenv("INTAKE_REVIEW_SOURCES", "")
+    parsed = tuple(s.strip().lower() for s in raw.split(",") if s.strip())
+    return parsed or _DEFAULT_REVIEW_SOURCES
+
 # MIME types a browser can render inline WITHOUT a script-execution surface.
 # Deliberately excludes image/svg+xml (can embed <script>) and text/html.
 _INLINE_SAFE_MIME = frozenset(
@@ -269,7 +288,14 @@ async def list_review_queue(
     user: dict[str, Any] = Depends(get_current_user),
     pool: asyncpg.Pool = Depends(get_database_pool),
     status: str = Query("review_pending", pattern="^(review_pending|review_claimed)$"),
-    source: str | None = Query(None, description="Filter by intake source (whatsapp|drive|zoho)"),
+    source: str | None = Query(
+        None,
+        description=(
+            "Filter by intake source. Must be within the review allowlist "
+            "(WhatsApp-only by default; see INTAKE_REVIEW_SOURCES). An out-of-"
+            "allowlist source returns an empty page, never Drive/Dropbox docs."
+        ),
+    ),
     decision: str | None = Query(
         None, description="Filter by entity_resolution.decision (AUTO_ATTACH|LINK_CANDIDATE|AMBIGUOUS|NO_MATCH)"
     ),
@@ -285,6 +311,18 @@ async def list_review_queue(
     """
     admin = is_crm_admin(user)
     user_email = (user.get("email") or "").lower().strip()
+
+    # Source gate (WhatsApp-only by default): an explicit ?source= still wins for
+    # ad-hoc inspection, but MUST be inside the allowlist — a caller cannot ask
+    # for ?source=drive unless INTAKE_REVIEW_SOURCES admits it. With no ?source=,
+    # the queue is scoped to the whole allowlist. Both go through the same
+    # `q.source = ANY($2)` clause so Drive/Dropbox proposals never surface here.
+    allowlist = _review_source_allowlist()
+    if source is not None and source.lower() not in allowlist:
+        # Asking for a source the queue doesn't admit → an empty, honest page
+        # (not an error: the proposal exists in the DB, it's just not reviewable).
+        return {"total": 0, "limit": limit, "offset": offset, "items": []}
+    source_filter = [source.lower()] if source is not None else list(allowlist)
 
     async with pool.acquire() as conn:
         rows = await conn.fetch(
@@ -308,12 +346,12 @@ async def list_review_queue(
             FROM document_routing_proposal p
             JOIN intake_queue q ON q.id = p.queue_id
             WHERE p.status = $1
-              AND ($2::text IS NULL OR q.source = $2)
+              AND q.source = ANY($2::text[])
               AND ($3::boolean OR q.received_by = $4)
             ORDER BY p.created_at ASC, p.id ASC
             """,
             status,
-            source,
+            source_filter,
             admin,
             user_email,
         )

--- a/apps/backend-rag/backend/tests/routers/test_intake_review.py
+++ b/apps/backend-rag/backend/tests/routers/test_intake_review.py
@@ -75,7 +75,7 @@ async def seed(pool: asyncpg.Pool) -> AsyncIterator[dict]:
         created["clients"] += [cid_owner, cid_other]
 
         async def mk_proposal(
-            entity_resolution: dict, source: str = "drive", received_by: str | None = None,
+            entity_resolution: dict, source: str = "whatsapp", received_by: str | None = None,
             stage_output: dict | None = None,
         ) -> int:
             bh = uuid.uuid4().hex + uuid.uuid4().hex  # 64-char
@@ -135,9 +135,11 @@ async def seed(pool: asyncpg.Pool) -> AsyncIterator[dict]:
         p_nomatch = await mk_proposal(
             {"decision": "NO_MATCH", "candidates": []},
             received_by=TEAM_OWNER["email"])
+        # p_null is a Drive doc on the shared line (received_by=NULL) — admin-only
+        # AND now also source-gated OUT of the WhatsApp-only review queue.
         p_null = await mk_proposal(
             {"decision": "NO_MATCH", "candidates": []},
-            received_by=None)
+            source="drive", received_by=None)
         # CURRENT pipeline: OCR text lives in classify.ocr_text_per_page; the
         # ocr stage only writes a marker with NO pages. The detail reader must
         # still surface the text (regression for the empty-review-area bug).
@@ -201,18 +203,65 @@ async def _crm_counts(pool: asyncpg.Pool) -> tuple[int, int]:
 
 # --------------------------------------------------------------------------- #
 async def test_queue_admin_sees_all(pool, seed):
-    """Admin sees the ENTIRE queue — every worker's docs, incl. NULL-received_by.
+    """Admin sees every WhatsApp doc — every worker's, incl. NULL-received_by —
+    but NOT Drive docs (source-gated out of the WhatsApp-only review queue).
 
     Robust to nuzantara_dev size: the queue endpoint orders by ``created_at ASC``
     and caps ``limit`` at 200, so the freshly-seeded (newest) rows live at the
-    TAIL of a live DB that holds thousands of real ``review_pending`` drive rows.
-    A single ``limit=200, offset=0`` window returns the 200 OLDEST and would miss
-    the seeds deterministically once the table outgrows 200 rows. We therefore
-    page through the WHOLE ``source=drive`` queue (the endpoint reports ``total``)
-    and assert the seeds appear SOMEWHERE in the admin's view — verifying the
-    RBAC scope (admin sees every worker's docs incl. NULL received_by) without
-    depending on the seeds being in the first N rows.
+    TAIL of a live DB. We page through the WHOLE WhatsApp queue (the endpoint
+    reports ``total``) and assert the three WhatsApp seeds appear SOMEWHERE in
+    the admin's view, while the Drive seed (p_null) is absent — verifying both
+    the RBAC scope (admin sees every worker's WhatsApp docs incl. NULL
+    received_by) AND the source gate.
     """
+    app = _make_app(pool, ADMIN)
+    ids: set[int] = set()
+    async with _client(app) as cl:
+        offset = 0
+        page_size = 200
+        while True:
+            # No explicit ?source= → the WhatsApp-only allowlist default applies.
+            r = await cl.get(
+                "/api/intake/review/queue",
+                params={"limit": page_size, "offset": offset},
+            )
+            assert r.status_code == 200, r.text
+            body = r.json()
+            items = body["items"]
+            ids.update(it["proposal_id"] for it in items)
+            offset += page_size
+            # Stop when this page was the last (fewer than a full page returned)
+            # or we have covered the reported total. ``total`` is the full count
+            # BEFORE pagination, so it is the authoritative stop condition.
+            if len(items) < page_size or offset >= body["total"]:
+                break
+    # The three WhatsApp seeds are visible to the admin…
+    assert {seed["p_owner"], seed["p_other"], seed["p_nomatch"]} <= ids
+    # …but the Drive doc is gated out of the review queue (still in the DB).
+    assert seed["p_null"] not in ids
+
+
+async def test_queue_drive_source_gated_out(pool, seed):
+    """An explicit ?source=drive is OUTSIDE the WhatsApp-only allowlist → empty
+    page, never the Drive proposal. The Dropbox→Drive archive stays catalogued in
+    the DB but is kept out of the team/admin review list (Zero, 2026-06-19)."""
+    app = _make_app(pool, ADMIN)
+    async with _client(app) as cl:
+        r = await cl.get(
+            "/api/intake/review/queue",
+            params={"source": "drive", "limit": 200},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["total"] == 0
+    assert body["items"] == []
+
+
+async def test_queue_source_allowlist_env_readmits_drive(pool, seed, monkeypatch):
+    """INTAKE_REVIEW_SOURCES re-admits a source without a code change ('for now'
+    is a config, not a hardcode). With drive admitted, ?source=drive surfaces the
+    Drive seed again."""
+    monkeypatch.setenv("INTAKE_REVIEW_SOURCES", "whatsapp,drive")
     app = _make_app(pool, ADMIN)
     ids: set[int] = set()
     async with _client(app) as cl:
@@ -225,15 +274,11 @@ async def test_queue_admin_sees_all(pool, seed):
             )
             assert r.status_code == 200, r.text
             body = r.json()
-            items = body["items"]
-            ids.update(it["proposal_id"] for it in items)
+            ids.update(it["proposal_id"] for it in body["items"])
             offset += page_size
-            # Stop when this page was the last (fewer than a full page returned)
-            # or we have covered the reported total. ``total`` is the full count
-            # BEFORE pagination, so it is the authoritative stop condition.
-            if len(items) < page_size or offset >= body["total"]:
+            if len(body["items"]) < page_size or offset >= body["total"]:
                 break
-    assert {seed["p_owner"], seed["p_other"], seed["p_nomatch"], seed["p_null"]} <= ids
+    assert seed["p_null"] in ids
 
 
 async def test_queue_team_rbac_filter(pool, seed):

--- a/apps/backend-rag/backend/tests/routers/test_intake_review.py
+++ b/apps/backend-rag/backend/tests/routers/test_intake_review.py
@@ -259,26 +259,30 @@ async def test_queue_drive_source_gated_out(pool, seed):
 
 async def test_queue_source_allowlist_env_readmits_drive(pool, seed, monkeypatch):
     """INTAKE_REVIEW_SOURCES re-admits a source without a code change ('for now'
-    is a config, not a hardcode). With drive admitted, ?source=drive surfaces the
-    Drive seed again."""
-    monkeypatch.setenv("INTAKE_REVIEW_SOURCES", "whatsapp,drive")
+    is a config, not a hardcode).
+
+    Asserted by the GATE, not by finding the seed: against the live nuzantara_dev
+    (thousands of real Drive rows), ?source=drive returns total=0 by DEFAULT and
+    total>0 once drive is admitted. We never page the whole Drive backlog (that is
+    slow and races the live drain cron); the total flip is the contract.
+    """
     app = _make_app(pool, ADMIN)
-    ids: set[int] = set()
     async with _client(app) as cl:
-        offset = 0
-        page_size = 200
-        while True:
-            r = await cl.get(
-                "/api/intake/review/queue",
-                params={"source": "drive", "limit": page_size, "offset": offset},
-            )
-            assert r.status_code == 200, r.text
-            body = r.json()
-            ids.update(it["proposal_id"] for it in body["items"])
-            offset += page_size
-            if len(body["items"]) < page_size or offset >= body["total"]:
-                break
-    assert seed["p_null"] in ids
+        # Default allowlist (whatsapp only): Drive is gated → empty.
+        r_default = await cl.get(
+            "/api/intake/review/queue", params={"source": "drive", "limit": 1}
+        )
+        assert r_default.status_code == 200, r_default.text
+        assert r_default.json()["total"] == 0
+
+        # Re-admit drive via env → the same query now reports the real backlog.
+        monkeypatch.setenv("INTAKE_REVIEW_SOURCES", "whatsapp,drive")
+        r_admitted = await cl.get(
+            "/api/intake/review/queue", params={"source": "drive", "limit": 1}
+        )
+        assert r_admitted.status_code == 200, r_admitted.text
+        # The seeded p_null (source=drive) guarantees at least one row exists.
+        assert r_admitted.json()["total"] >= 1
 
 
 async def test_queue_team_rbac_filter(pool, seed):


### PR DESCRIPTION
## Problem (Zero, 2026-06-19)

The intake `/review` queue must surface **only WhatsApp documents** "for now". Drive/Dropbox files stay catalogued in the DB (the worker keeps running, the records are kept) — they just must **not flood the team/admin review list**.

### Why it bit
The `Dropbox→Drive` mirror (`LaunchAgent drive-intake-drain`, scope = the `Dropbox-Intake` folder) is the team's **whole historical archive** — years of KITAS scans, "SUDAH UPLOAD" folders, iPhone camera rolls (`gendu/100APPLE/*.MOV`). Draining it into review created **~18.2k proposals in one day (19/06)**, burying the **~107 real WhatsApp docs** under **~19.6k archive rows**.

All Drive rows are `received_by=NULL` (admin-only), so the team never saw them — but they choked Zero's admin queue, and every terminal one reopened as a "view only" zombie (see also #1572).

## Fix

A single **source allowlist** on `GET /api/intake/review/queue`:
- **Default = `whatsapp` only.**
- An explicit `?source=` must be **inside** the allowlist — an out-of-allowlist source returns an **empty page**, never Drive docs.
- Widen without a code change via **`INTAKE_REVIEW_SOURCES`** (CSV, e.g. `"whatsapp,drive"`) — *"for now"* is config, not a hardcode.

Drive/Dropbox proposals are **untouched in the DB** — only their visibility in the human review queue changes.

## Tests (real local DB — validated on the Pro where `nuzantara_dev` lives)
- the three WhatsApp seeds remain visible to the admin;
- the Drive seed is gated out of the default queue;
- `?source=drive` → empty page (`total=0`);
- `INTAKE_REVIEW_SOURCES=whatsapp,drive` re-admits Drive.
- `mk_proposal` default source flips `drive`→`whatsapp` to match the new contract.

## Deploy note
Takes effect on `fly deploy` of `nuzantara-rag` (the `/queue` runs on the Pro reader via the proxy, but the router code ships with the backend). No data migration; fully reversible via `INTAKE_REVIEW_SOURCES`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)