### PR TITLE
fix(crm-rbac): arm the per-user ownership filter on CRM read-lists

### DIFF
--- a/apps/backend-rag/backend/app/deps/crm_access.py
+++ b/apps/backend-rag/backend/app/deps/crm_access.py
@@ -83,7 +83,13 @@ def get_crm_user_filter(
         # assigned_filter is None → show all
         # assigned_filter is "user@email.com" → WHERE assigned_to = $N
     """
-    if can_view_all_clients(current_user):
+    # RBAC: admins see the whole book (None = no filter). Non-admins are scoped to
+    # their own assigned clients. NB: this is gated on is_crm_admin, NOT on
+    # can_view_all_clients() — the latter stays True so the direct write-guards in
+    # wa_actions/omnichannel/channels keep working unchanged. Before this fix the
+    # function gated on can_view_all_clients() and thus returned None for everyone,
+    # silently disarming the ownership filter on every CRM read-list endpoint.
+    if is_crm_admin(current_user):
         return None
     return current_user.get("email", "").lower()
 

--- a/apps/backend-rag/backend/app/routers/crm_clients.py
+++ b/apps/backend-rag/backend/app/routers/crm_clients.py
@@ -679,7 +679,11 @@ async def list_clients(
             params: list[Any] = []
             param_index = 1
 
-            # RBAC: enforce assigned_to filter for non-admin users
+            # RBAC: enforce assigned_to filter for non-admin users. A non-admin
+            # sees ONLY their own assigned clients (admins get rbac_filter=None =
+            # full view). Decision 2026-06-19: NOT "own + unassigned" — 93% of the
+            # book is unassigned, so an OR-NULL clause would leak ~10.7k clients to
+            # every team member. Unassigned clients stay admin-only until triaged.
             if rbac_filter is not None:
                 query_parts.append(f" AND c.assigned_to = ${param_index}")
                 params.append(rbac_filter)

--- a/apps/backend-rag/backend/tests/unit/app/deps/test_crm_list_rbac.py
+++ b/apps/backend-rag/backend/tests/unit/app/deps/test_crm_list_rbac.py
@@ -1,0 +1,54 @@
+"""RBAC: CRM read-list ownership filter is ARMED for non-admins.
+
+Root cause this locks: get_crm_user_filter() used to gate on
+can_view_all_clients() (which returns True for everyone), so it returned None
+for every user and silently disarmed the ownership filter across ~12 CRM
+read-list endpoints. It now gates on is_crm_admin().
+"""
+
+from __future__ import annotations
+
+from backend.app.deps import crm_access
+
+
+# --------------------------------------------------------------------------- #
+# get_crm_user_filter — admin sees all (None), non-admin scoped to own email   #
+# --------------------------------------------------------------------------- #
+
+def test_admin_gets_no_filter():
+    # zero@ is in the CRM admin set -> full view (None means no WHERE filter)
+    admin = {"email": "zero@balizero.com", "role": "founder"}
+    assert crm_access.get_crm_user_filter(admin) is None
+
+
+def test_admin_by_role_gets_no_filter():
+    admin = {"email": "someone@balizero.com", "role": "admin"}
+    assert crm_access.get_crm_user_filter(admin) is None
+
+
+def test_non_admin_scoped_to_own_email():
+    # Sahira: real role from prod, NOT an admin -> filtered to her own email
+    sahira = {"email": "Sahira@balizero.com", "role": "Marketing & Accounting"}
+    assert crm_access.get_crm_user_filter(sahira) == "sahira@balizero.com"
+
+
+def test_non_admin_junior_consultant_scoped():
+    damar = {"email": "damar@balizero.com", "role": "Junior Consultant"}
+    assert crm_access.get_crm_user_filter(damar) == "damar@balizero.com"
+
+
+def test_empty_user_is_filtered_not_full_view():
+    # defense: an empty/anon user must NOT get the full book
+    assert crm_access.get_crm_user_filter({}) == ""
+
+
+# --------------------------------------------------------------------------- #
+# can_view_all_clients stays True — write-guards in wa_actions/omnichannel     #
+# that call it directly must NOT regress.                                      #
+# --------------------------------------------------------------------------- #
+
+def test_can_view_all_clients_unchanged_for_non_admin():
+    # The list filter is now is_crm_admin-gated, but the blanket guard helper
+    # stays True so direct write-guards keep their current behaviour.
+    sahira = {"email": "sahira@balizero.com", "role": "Marketing & Accounting"}
+    assert crm_access.can_view_all_clients(sahira) is True

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`325 routers · 624 services · 1066 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`325 routers · 624 services · 1068 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
fix(crm-rbac): arm the per-user ownership filter on CRM read-lists

From the live RBAC siege (2026-06-19, Sahira profile): a non-admin opening the
CRM client list saw all 11.5k clients, only 35 of them hers.

ROOT CAUSE (one disarmed gate, ~12 endpoints): get_crm_user_filter() gated on
can_view_all_clients(), which returns True for every authenticated user, so the
filter always returned None and silently disarmed the ownership scope on every
CRM read-list (crm_clients, crm_shared_memory, crm_analytics, crm_notifications,
crm_portal_integration). The endpoints all do `if assigned_filter is not None:
apply filter` — written expecting a non-None value for non-admins that never came.
This is "Esiste != Armato" applied to RBAC: the filter exists in code, unarmed.

FIX (surgical, no write-guard regression):
- get_crm_user_filter() now gates on is_crm_admin() instead of
  can_view_all_clients(). Admins -> None (full view, unchanged). Non-admins ->
  their own email, so the ownership filter finally bites across all read-lists.
- can_view_all_clients() is LEFT AS-IS (return True). The five direct write-guards
  in wa_actions/omnichannel/channels that call it as a blanket 403 keep their
  current behaviour — no regression there.
- crm_clients list WHERE stays `assigned_to = $N` (own-only), NOT own+unassigned:
  93% of the book (10.7k of 11.5k) has assigned_to NULL, so an OR-NULL clause
  would leak almost the entire list to every team member. Unassigned clients stay
  admin-only until triaged. (ai_summary single-id read keeps its OR-NULL: opening
  one unassigned client you're about to take is fine; it's not a list leak.)

Verified on the Pro nuzantara_dev: Sahira now scopes from 11533 to her 35
assigned; admin (zero@) still sees all. 6 new dep tests + 2045 CRM/RBAC/intake/
notifications/analytics/portal tests pass, 0 regressions.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
