### PR TITLE
fix(crm): coerce non-dict custom_fields so one dirty row can't 500 the client list

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_clients.py
+++ b/apps/backend-rag/backend/app/routers/crm_clients.py
@@ -421,6 +421,24 @@ class ClientResponse(BaseModel):
             return []
         return v
 
+    @field_validator("custom_fields", mode="before")
+    @classmethod
+    def ensure_custom_fields_dict(cls, v: Any) -> Any:
+        """Coerce custom_fields to a dict regardless of the stored jsonb shape.
+
+        custom_fields is jsonb and the schema expects an object, but a handful of
+        legacy rows hold a non-object value (e.g. a json array — id 10816 had
+        ``custom_fields`` stored as ``[]``). Without this coercion Pydantic raises
+        ``Input should be a valid dictionary`` on that row, and since the list
+        endpoint validates the whole page in one comprehension a single bad row
+        500s the entire request (reproduced: sahira@ page 2, limit>=75). Any
+        non-dict — array, scalar, null — degrades to ``{}`` so one dirty row can
+        never poison a list page.
+        """
+        if isinstance(v, dict):
+            return v
+        return {}
+
     @field_validator("passport_expiry", "date_of_birth", mode="before")
     @classmethod
     def convert_date_to_string(cls, v: Any) -> Any:

--- a/apps/backend-rag/backend/tests/unit/routers/test_crm_clients_coverage.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_crm_clients_coverage.py
@@ -246,6 +246,46 @@ def test_client_response_tags_none_becomes_list():
     assert r.tags == []
 
 
+@pytest.mark.parametrize("dirty_value", [[], ["x"], None, "string", 42])
+def test_client_response_custom_fields_non_dict_becomes_empty(dirty_value):
+    """A legacy row with a non-object custom_fields must not 500 a list page.
+
+    Regression: client id 10816 stored custom_fields as a json array ([]); the
+    list endpoint validates the whole page in one comprehension, so that single
+    row raised ValidationError and 500'd sahira@'s entire page 2 (limit>=75).
+    Any non-dict jsonb shape must degrade to {} instead of raising.
+    """
+    from backend.app.routers.crm_clients import ClientResponse
+
+    r = ClientResponse(
+        id=1,
+        uuid="abc",
+        full_name="Test",
+        status="active",
+        client_type="individual",
+        custom_fields=dirty_value,
+        created_at=datetime.now(tz=timezone.utc),
+        updated_at=datetime.now(tz=timezone.utc),
+    )
+    assert r.custom_fields == {}
+
+
+def test_client_response_custom_fields_dict_preserved():
+    from backend.app.routers.crm_clients import ClientResponse
+
+    r = ClientResponse(
+        id=1,
+        uuid="abc",
+        full_name="Test",
+        status="active",
+        client_type="individual",
+        custom_fields={"k": "v"},
+        created_at=datetime.now(tz=timezone.utc),
+        updated_at=datetime.now(tz=timezone.utc),
+    )
+    assert r.custom_fields == {"k": "v"}
+
+
 def test_client_response_date_conversion():
     from backend.app.routers.crm_clients import ClientResponse
 


### PR DESCRIPTION
## Problem
`GET /api/crm/clients?limit>=75` returns **500** for non-admin **sahira@** (and any team member whose page includes a legacy bad row). Discovered during the live RBAC test (Zero, 2026-06-20).

**It is NOT RBAC** — sahira gets her filtered page (no leak), and **NOT a perf problem** — `EXPLAIN ANALYZE` of the real list query runs in **5.9 ms** with all indexes used (BitmapAnd on `idx_clients_assigned_status`, two LATERAL index scans). My first hypothesis (LATERAL subqueries) was wrong; I measured it on Fly prod.

## Root cause
The 500 happens **after** the SQL, in:
```python
clients = [ClientResponse(**dict(row)) for row in rows]
```
`ClientResponse.custom_fields: dict = {}` had **no `mode="before"` validator**. Exactly **one** row in the whole book (id `10816`, assigned to sahira@) stores `custom_fields` as a json **array** `[]` instead of an object (1 of 1492). Pydantic v2 rejects a `list` for a `dict` field → `ValidationError` → caught by the endpoint's `except Exception` → `handle_database_error` → **500**. Because the list validates the whole page in one comprehension, **one dirty row poisons the entire page**.

Reproduced precisely:
| request | result |
|---|---|
| `limit<=50` (page 1) | 200 |
| `limit>=75` / `offset=50` (page with row 63 = id 10816) | **500** |

## Fix (defensive, structural — not a one-row data patch)
- Add `ensure_custom_fields_dict` validator (`mode="before"`) mirroring the existing `ensure_tags_list`. Any non-dict jsonb shape (array, scalar, null) degrades to `{}` → no present-or-future dirty row can ever 500 a list page.
- The offending row stays readable; its `custom_fields` just renders as `{}`.

## Test
- Parametrized regression over `[[], ["x"], None, "string", 42]` + dict-preserved case.
- **Verified the test FAILS without the validator** (same `ValidationError / dict_type` as prod) and passes with it.
- `59/59` crm_clients tests green, 0 regressions.

## Follow-up (optional, separate)
Data-normalize row id 10816 in prod (`custom_fields '[]' → '{}'`) so the DB is clean too — but the validator is the real cure and is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)