### PR TITLE
fix(crm): cast strategic_recap param to text in upsert-by-phone INSERT

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_clients.py
+++ b/apps/backend-rag/backend/app/routers/crm_clients.py
@@ -1126,9 +1126,9 @@ async def upsert_client_by_phone(
                       $1, '+' || $2, '+' || $2, $2,
                       'lead', 'individual', $3, $4,
                       $5, $5, $6,
-                      $7,
-                      CASE WHEN $7 IS NULL THEN NULL ELSE 'ollama_local' END,
-                      CASE WHEN $7 IS NULL THEN NULL ELSE NOW() END
+                      $7::text,
+                      CASE WHEN $7::text IS NULL THEN NULL ELSE 'ollama_local' END,
+                      CASE WHEN $7::text IS NULL THEN NULL ELSE NOW() END
                     )
                     RETURNING id
                     """,


### PR DESCRIPTION
fix(crm): cast strategic_recap param to text in upsert-by-phone INSERT

The /upsert-by-phone CREATE path passed strategic_recap (the 7th bind param)
untyped. When the caller omits it (None), asyncpg cannot infer the parameter
type from the CASE WHEN ... IS NULL context and raises "could not determine
data type of parameter" then returns a 500. The UPDATE/enrich path was
unaffected, so this only surfaced now that the bridge is armed and exercising
CREATE for the first time (superscar 2: built, never exercised). Existing tests
mock the DB pool so they never hit the real SQL — the bug was invisible to CI.

Cast all three uses to ::text so the type is explicit. 11 endpoint tests pass.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
