### PR TITLE
fix(kbli): render L4 Bali badge — graft baliL4 into the data module the page actually uses

### DIFF
--- a/apps/mouth/src/lib/kbli-data.ts
+++ b/apps/mouth/src/lib/kbli-data.ts
@@ -419,6 +419,27 @@ function transformRecord(raw: KBLIRawCode): KBLICode {
     tier: assignTier(code),
     keywords: extractKeywords(raw.judul, raw.uraian),
     intel_2026: raw.intel_2026,
+    // L4 — Bali sovereign-local status (national PMA openness != Bali registrability).
+    // Mirrors the transform in kbli-data.server.ts; this is the module the
+    // /kbli/[code] page actually consumes via getCode()/getAllCodes().
+    baliL4: raw.l4_bali?.status
+      ? {
+          status: raw.l4_bali.status,
+          reason: raw.l4_bali.reason || "",
+          confidence: raw.l4_bali.confidence || "MEDIUM",
+          needsReview: !!raw.l4_bali.needs_review,
+          blocked: !!raw.l4_bali.blocked,
+          from2020: raw.l4_bali.from_2020 ?? null,
+          moratorium: raw.l4_bali.moratorium
+            ? {
+                rule: raw.l4_bali.moratorium.rule || "",
+                effective: raw.l4_bali.moratorium.effective || "",
+                source: raw.l4_bali.moratorium.source || "",
+                virtualOffice: raw.l4_bali.moratorium.virtual_office || "",
+              }
+            : undefined,
+        }
+      : undefined,
   };
 }
 


### PR DESCRIPTION
## Problem
The L4 Bali-status badge (PR #1575) does **not** render on `balizero.com/kbli/*` despite a successful Vercel deploy. Verified live: the serialized `kbli` object on prod has every transformed field (`titleEn`, `mappingStatus`, `isPriority`, `fictivePositive`) **except** `baliL4`.

## Root cause (proven by local-build reproduction, not theorized)
PR #1575 added the badge component, types (`KBLIBaliL4`), the data file (`l4_bali` on 1559/1563 codes), and a `baliL4` transform — but the transform went **only** into `kbli-data.server.ts`. The `/kbli/[code]` page reads code data via `getCode()`/`getAllCodes()` from the **sibling** module `kbli-data.ts` (it imports `kbli-data.server` solely for `getGoldContent`). `kbli-data.ts::transformRecord` never populated `baliL4` → `kbli.baliL4` always `undefined` → `{kbli.baliL4 && <BaliStatusBadge/>}` rendered nothing.

A local `next build` of the deployed commit `0f695b3c0` reproduced the empty badge (prerendered `01111.html` had zero L4 markers), ruling out cache/deploy/data as causes.

## Fix
Graft the identical `baliL4` transform (mirroring `kbli-data.server.ts`) into `transformRecord` in `kbli-data.ts`. One file, +21 lines.

## Verification
- `tsc --noEmit` clean (types already declare `baliL4?` on `KBLICode`).
- Rebuilt mouth from this branch → prerendered `/kbli/01111` now emits `🏝️ "Closed to foreigners"` (TERTUTUP) badge. **Before** the fix the same prerender had **zero** L4 markers.
- Post-merge prod test: `curl balizero.com/kbli/55203` → expect "Blocked in Bali (risk-class moratorium)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)