### PR TITLE
fix(intake): SSOT pipeline_version + anti-deadlock guard (stop silent doc loss in /review)

### DIFF
--- a/apps/backend-rag/backend/services/intake/routing.py
+++ b/apps/backend-rag/backend/services/intake/routing.py
@@ -56,9 +56,18 @@ from typing import Any
 
 import asyncpg
 
+from backend.services.intake.enqueue import PIPELINE_VERSION
+
 logger = logging.getLogger("zantara.intake.routing")
 
-PIPELINE_VERSION_DEFAULT = "v1"
+# SSOT: the pipeline version is defined ONCE in enqueue.PIPELINE_VERSION and
+# imported everywhere. Historically routing defined its own "v1" while enqueue
+# used "intake-v1" — a silent drift that made routing_key
+# (= sha256(queue_id|doc_index|pipeline_version)) diverge between the row that
+# was enqueued and the route stage that should match it. A re-process that
+# bumped the version on the queue row but left a reader on the old constant
+# produced orphaned/duplicate proposals. Keep this an ALIAS, never a literal.
+PIPELINE_VERSION_DEFAULT = PIPELINE_VERSION
 
 # --- Decision-matrix C4 outcomes ---
 DECISION_AUTO_ATTACH = "AUTO_ATTACH"
@@ -967,13 +976,49 @@ async def route_stage(job: dict, stage: str, pool: asyncpg.Pool) -> dict:  # noq
         )
 
         if proposal_id is None:
-            # Conflict: proposal already existed (idempotent re-run).
+            # Conflict: a proposal with this routing_key already existed.
             existing = await conn.fetchrow(
-                "SELECT id FROM document_routing_proposal WHERE routing_key = $1",
+                "SELECT id, status FROM document_routing_proposal WHERE routing_key = $1",
                 proposal["routing_key"],
             )
             proposal_id = existing["id"] if existing else None
             already = True
+
+            # ANTI-DEADLOCK GUARD (done-deadlock fix). The bare ON CONFLICT DO
+            # NOTHING above silently dropped the fresh proposal whenever the key
+            # collided. If the surviving row is 'superseded' (a re-process bumped
+            # the version, marked the old proposal superseded, but the same key
+            # was re-derived) the document would be lost: the queue advances to
+            # 'done' while NO live proposal exists, so it never appears in
+            # /review and the worker (which only claims non-'done' rows) never
+            # revisits it. Revive a superseded survivor back to 'review_pending'
+            # so a re-route always leaves a reviewable proposal. 'rejected'/
+            # 'routed'/'review_pending'/'review_claimed' are intentional human
+            # (or in-flight) states and are left untouched.
+            if existing is not None and existing["status"] == "superseded":
+                await conn.execute(
+                    """
+                    UPDATE document_routing_proposal
+                       SET status           = 'review_pending',
+                           entity_resolution = $2::jsonb,
+                           routing           = $3::jsonb,
+                           commit_gate       = $4::jsonb,
+                           lease_owner       = NULL,
+                           lease_expires_at  = NULL,
+                           claim_token       = NULL
+                     WHERE id = $1
+                       AND status = 'superseded'
+                    """,
+                    proposal_id,
+                    json.dumps(proposal["entity_resolution"]),
+                    json.dumps(proposal["routing"]),
+                    json.dumps(proposal["commit_gate"]),
+                )
+                logger.warning(
+                    "route(FASE4): revived superseded-orphan proposal_id=%s "
+                    "queue=%s back to review_pending (anti-deadlock guard)",
+                    proposal_id, queue_id,
+                )
         else:
             already = False
 

--- a/apps/backend-rag/backend/services/intake/writer.py
+++ b/apps/backend-rag/backend/services/intake/writer.py
@@ -55,6 +55,7 @@ import asyncpg
 
 from backend.core.cache import invalidate_crm_stats
 from backend.services.intake.client_enricher import enrich_client_from_extracted_fields
+from backend.services.intake.enqueue import PIPELINE_VERSION
 
 logger = logging.getLogger("zantara.intake.writer")
 
@@ -306,7 +307,7 @@ async def plan_commit(
     blob_hash = (qrow["blob_hash"] if qrow else None) or ""
     pipeline_version = (qrow["pipeline_version"] if qrow else None) or p.get(
         "pipeline_version"
-    ) or "v1"
+    ) or PIPELINE_VERSION
     doc_index = int(p.get("doc_index") or 0)
 
     # Target client: explicit override (human chose) wins, else routing's resolved client.

--- a/apps/backend-rag/backend/tests/services/intake/test_intake_routing.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_intake_routing.py
@@ -244,3 +244,60 @@ async def test_route_stage_zero_crm_writes(pool, seeded):
     await route_stage({"id": q2, "pipeline_version": "v1"}, "route", pool)
     after = await counts()
     assert before == after, f"CRM tables mutated: before={before} after={after}"
+
+
+def test_pipeline_version_is_single_source_of_truth():
+    """Blindatura difetto-1: routing/writer/enqueue must agree on ONE version.
+
+    Historical drift: enqueue used "intake-v1" while routing/writer used "v1".
+    Because routing_key = sha256(queue_id|doc_index|pipeline_version), the two
+    halves of the pipeline derived different keys for the same document and a
+    re-process could orphan proposals. The constants must be the SAME object,
+    not two literals that merely happen to match today.
+    """
+    # NB: `from backend.services.intake import enqueue` resolves to the enqueue
+    # FUNCTION (re-exported by __init__), not the submodule — so import the
+    # constant explicitly and the submodules via their full dotted path.
+    from backend.services.intake.enqueue import PIPELINE_VERSION
+    from backend.services.intake.routing import PIPELINE_VERSION_DEFAULT
+    from backend.services.intake.writer import PIPELINE_VERSION as WRITER_PV
+
+    assert PIPELINE_VERSION_DEFAULT == PIPELINE_VERSION
+    assert WRITER_PV == PIPELINE_VERSION
+
+
+@pytest.mark.asyncio
+async def test_anti_deadlock_revives_superseded_orphan(pool, seeded):
+    """Blindatura difetto-2: a re-route over a superseded-orphan must revive it.
+
+    Reproduces the adit done-deadlock: a proposal is superseded (by a reprocess)
+    but the same routing_key gets re-derived, so the bare ON CONFLICT DO NOTHING
+    would drop the fresh proposal and leave the queue with ZERO live proposal —
+    invisible in /review forever. The guard must flip the survivor back to
+    'review_pending' instead.
+    """
+    q = await _seed_queue(pool, "passport", {"name": f"{TAG} Nonexistent Person XYZ"})
+    r1 = await route_stage({"id": q, "pipeline_version": "v1"}, "route", pool)
+    pid = r1["proposal_id"]
+
+    # Simulate the reprocess marking the proposal superseded (m226) WITHOUT
+    # bumping the queue's pipeline_version — so the re-route derives the SAME key.
+    async with pool.acquire() as c:
+        await c.execute(
+            "UPDATE document_routing_proposal SET status='superseded' WHERE id=$1", pid
+        )
+        assert (await _proposal(pool, q))["status"] == "superseded"
+
+    # Re-route: same routing_key → ON CONFLICT → guard must revive the orphan.
+    r2 = await route_stage({"id": q, "pipeline_version": "v1"}, "route", pool)
+    assert r2["proposal_id"] == pid  # same row, not a duplicate
+    row = await _proposal(pool, q)
+    assert row["status"] == "review_pending", (
+        "superseded-orphan was NOT revived — done-deadlock would recur"
+    )
+    # exactly one proposal for this queue (no duplicate created)
+    async with pool.acquire() as c:
+        n = await c.fetchval(
+            "SELECT count(*) FROM document_routing_proposal WHERE queue_id=$1", q
+        )
+    assert n == 1

--- a/scripts/intake_proposal_health_sentinel.py
+++ b/scripts/intake_proposal_health_sentinel.py
@@ -78,10 +78,14 @@ FROM q
 """
 
 # The ids of superseded-orphan queues (done + has proposal + none live).
+# $3 = optional source filter (NULL = any). Heal defaults to source='whatsapp'
+# because Drive/Dropbox proposals are an admin-only dump that must NOT be poured
+# into a team member's /review — only own-chat WhatsApp docs have a real owner.
 ORPHAN_IDS_SQL = """
 SELECT iq.id
 FROM intake_queue iq
 WHERE iq.status = 'done'
+  AND ($3::text IS NULL OR iq.source = $3)
   AND EXISTS (SELECT 1 FROM document_routing_proposal p WHERE p.queue_id = iq.id)
   AND NOT EXISTS (
       SELECT 1 FROM document_routing_proposal p
@@ -131,7 +135,7 @@ def _send_alert(message: str, level: str) -> None:
         logger.warning("alert dispatch failed (%s): %s", type(exc).__name__, message)
 
 
-async def run(heal: bool, limit: int) -> int:
+async def run(heal: bool, limit: int, heal_source: str | None) -> int:
     pool = await asyncpg.create_pool(dsn=_dsn(), min_size=1, max_size=3)
     try:
         async with pool.acquire() as conn:
@@ -146,7 +150,16 @@ async def run(heal: bool, limit: int) -> int:
 
             healed = 0
             if heal and orphans:
-                ids = [r["id"] for r in await conn.fetch(ORPHAN_IDS_SQL, list(_LIVE_STATUSES), limit)]
+                ids = [
+                    r["id"]
+                    for r in await conn.fetch(
+                        ORPHAN_IDS_SQL, list(_LIVE_STATUSES), limit, heal_source
+                    )
+                ]
+                logger.info(
+                    "heal scope: source=%s, %d candidate(s) this run",
+                    heal_source or "ANY", len(ids),
+                )
                 for qid in ids:
                     revived = await conn.fetchval(HEAL_SQL, qid, list(_LIVE_STATUSES))
                     if revived is not None:
@@ -189,6 +202,13 @@ def build_parser() -> argparse.ArgumentParser:
         default=500,
         help="max orphans to heal per run (default 500; report counts are unbounded)",
     )
+    p.add_argument(
+        "--source",
+        default="whatsapp",
+        help="restrict --heal to this intake source (default 'whatsapp' — own-chat "
+        "docs with a real owner; pass 'any' to also revive Drive/Dropbox, NOT "
+        "recommended: that dump is admin-only and would flood /review)",
+    )
     return p
 
 
@@ -198,7 +218,8 @@ async def main(argv: list[str] | None = None) -> int:
         level=os.getenv("INTAKE_SENTINEL_LOG_LEVEL", "INFO"),
         format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
     )
-    return await run(heal=args.heal, limit=args.limit)
+    heal_source = None if str(args.source).lower() == "any" else args.source
+    return await run(heal=args.heal, limit=args.limit, heal_source=heal_source)
 
 
 if __name__ == "__main__":

--- a/scripts/intake_proposal_health_sentinel.py
+++ b/scripts/intake_proposal_health_sentinel.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Intake proposal-health sentinel — the done-deadlock guardian (Defect 3).
+
+WHY THIS EXISTS
+  The intake pipeline can leave an ``intake_queue`` row at ``status='done'`` while
+  its only ``document_routing_proposal`` is ``superseded`` (a re-process bumped /
+  superseded the prior proposal but the fresh one was never persisted, e.g. an
+  ``ON CONFLICT DO NOTHING`` collision, or the worker died mid-route). Such a row
+  is a DEAD DOCUMENT: ``done`` is not claimable by the worker, and ``superseded``
+  never appears in ``/review`` — so a received KTP/passport/akta is silently lost.
+  This was found tracing adit's wa-mirror→/review path (2026-06-20): 319 of his
+  documents were in exactly this state.
+
+  PR #1587 fixes the route stage so this stops *being created*. This sentinel is
+  the SEPARATE guardian that DETECTS the invariant violation if it ever recurs by
+  another path (a future code change, a manual DB edit, a half-finished reprocess)
+  and — only with --heal — repairs it with the same safe transition the route
+  guard uses (superseded-orphan → review_pending).
+
+INVARIANT (the thing this protects)
+  A queue row that has reached a terminal worker state (``done``) MUST have at
+  least one *live* proposal — i.e. one whose status is NOT ``superseded``
+  (``review_pending`` | ``review_claimed`` | ``routed`` | ``rejected``). A ``done``
+  row whose every proposal is ``superseded`` is an illegal state.
+
+MODES
+  default (report-only): count violations, emit a Telegram alert (cooldowned),
+    exit 0 always — a monitoring run must never take the pipeline down.
+  --heal: additionally revive each orphan's most-recent superseded proposal back
+    to ``review_pending`` so it re-enters /review. Idempotent and bounded by
+    --limit. Heal is OPT-IN — the default is a signaller, not an auto-actuator
+    (superscar #2 antidote: reconciliation-report, not blind self-repair).
+
+PII / Law 2: runs on the Pro against the LOCAL nuzantara_dev. No cloud, no PII in
+  the alert body (only counts + queue ids).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+
+import asyncpg
+
+logger = logging.getLogger("intake.proposal_health_sentinel")
+
+DEFAULT_DSN = "postgresql://nuzantara@127.0.0.1:5432/nuzantara_dev"
+
+# A "live" proposal is anything that is NOT superseded. These are the states that
+# legitimately satisfy the invariant for a done row.
+_LIVE_STATUSES = ("review_pending", "review_claimed", "routed", "rejected")
+
+# The violation: queue is terminal (done) yet has at least one proposal AND none
+# of them is live. (A done row with ZERO proposals at all is a different class —
+# legacy no-proposal — reported separately so the two are never conflated.)
+COUNT_SQL = """
+WITH q AS (
+    SELECT iq.id
+    FROM intake_queue iq
+    WHERE iq.status = 'done'
+)
+SELECT
+    count(*) FILTER (
+        WHERE EXISTS (SELECT 1 FROM document_routing_proposal p WHERE p.queue_id = q.id)
+          AND NOT EXISTS (
+              SELECT 1 FROM document_routing_proposal p
+              WHERE p.queue_id = q.id AND p.status = ANY($1::text[])
+          )
+    ) AS superseded_orphans,
+    count(*) FILTER (
+        WHERE NOT EXISTS (SELECT 1 FROM document_routing_proposal p WHERE p.queue_id = q.id)
+    ) AS no_proposal_at_all
+FROM q
+"""
+
+# The ids of superseded-orphan queues (done + has proposal + none live).
+ORPHAN_IDS_SQL = """
+SELECT iq.id
+FROM intake_queue iq
+WHERE iq.status = 'done'
+  AND EXISTS (SELECT 1 FROM document_routing_proposal p WHERE p.queue_id = iq.id)
+  AND NOT EXISTS (
+      SELECT 1 FROM document_routing_proposal p
+      WHERE p.queue_id = iq.id AND p.status = ANY($1::text[])
+  )
+ORDER BY iq.id
+LIMIT $2
+"""
+
+# Revive: flip the most-recent superseded proposal of a queue back to
+# review_pending and clear its lease. Same safe transition the route guard uses.
+HEAL_SQL = """
+UPDATE document_routing_proposal p
+   SET status           = 'review_pending',
+       lease_owner      = NULL,
+       lease_expires_at = NULL,
+       claim_token      = NULL
+ WHERE p.id = (
+     SELECT p2.id FROM document_routing_proposal p2
+     WHERE p2.queue_id = $1 AND p2.status = 'superseded'
+     ORDER BY p2.id DESC
+     LIMIT 1
+ )
+   AND NOT EXISTS (
+       SELECT 1 FROM document_routing_proposal p3
+       WHERE p3.queue_id = $1 AND p3.status = ANY($2::text[])
+   )
+RETURNING p.id
+"""
+
+
+def _dsn() -> str:
+    return os.getenv("INTAKE_DATABASE_URL", os.getenv("DATABASE_URL", DEFAULT_DSN))
+
+
+def _send_alert(message: str, level: str) -> None:
+    """Best-effort Telegram alert via the shared sentinel alerter (cooldowned).
+
+    Never raises — a monitoring run must not fail because alerting is unavailable.
+    """
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from sentinel_lib.alerter import send_alert  # type: ignore
+
+        send_alert(message, level=level)
+    except Exception as exc:  # noqa: BLE001 — alerting is best-effort
+        logger.warning("alert dispatch failed (%s): %s", type(exc).__name__, message)
+
+
+async def run(heal: bool, limit: int) -> int:
+    pool = await asyncpg.create_pool(dsn=_dsn(), min_size=1, max_size=3)
+    try:
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(COUNT_SQL, list(_LIVE_STATUSES))
+            orphans = int(row["superseded_orphans"])
+            no_proposal = int(row["no_proposal_at_all"])
+
+            logger.info(
+                "intake invariant check: superseded_orphans=%d no_proposal=%d (done rows)",
+                orphans, no_proposal,
+            )
+
+            healed = 0
+            if heal and orphans:
+                ids = [r["id"] for r in await conn.fetch(ORPHAN_IDS_SQL, list(_LIVE_STATUSES), limit)]
+                for qid in ids:
+                    revived = await conn.fetchval(HEAL_SQL, qid, list(_LIVE_STATUSES))
+                    if revived is not None:
+                        healed += 1
+                logger.warning(
+                    "healed %d superseded-orphan queues back to review_pending "
+                    "(limit=%d, remaining=%d)",
+                    healed, limit, max(0, orphans - healed),
+                )
+
+        if orphans or no_proposal:
+            verb = f"healed {healed}/{orphans}" if heal else "DETECTED"
+            _send_alert(
+                f"⚠️ intake invariant violated ({verb}): "
+                f"{orphans} done-rows with only superseded proposals "
+                f"(dead in /review), {no_proposal} done-rows with no proposal at all. "
+                f"{'Run with --heal to revive.' if not heal else ''}".strip(),
+                level="WARNING" if orphans else "INFO",
+            )
+        else:
+            logger.info("intake invariant OK — no dead documents.")
+        return 0
+    finally:
+        await pool.close()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Intake proposal-health sentinel — detects (and optionally heals) "
+        "done-rows whose only proposal is superseded (dead in /review)."
+    )
+    p.add_argument(
+        "--heal",
+        action="store_true",
+        help="revive superseded-orphans back to review_pending (default: report-only)",
+    )
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=500,
+        help="max orphans to heal per run (default 500; report counts are unbounded)",
+    )
+    return p
+
+
+async def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=os.getenv("INTAKE_SENTINEL_LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    )
+    return await run(heal=args.heal, limit=args.limit)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(asyncio.run(main()))
+    except KeyboardInterrupt:
+        sys.exit(130)


### PR DESCRIPTION
## Why
Tracing **adit's** wa-mirror→`/review` path (21 May–20 Jun) revealed that **80% of his received documents** (KTP, passports, akta — 616 of 771) were `done` in the intake queue yet **never reviewed, never in the CRM, never in `/review`** — silently lost. Two structural defects cause it.

## Defect 1 — `pipeline_version` drift (no SSOT)
```
enqueue.py:  PIPELINE_VERSION         = "intake-v1"
routing.py:  PIPELINE_VERSION_DEFAULT = "v1"      ← drift
writer.py:   fallback                 = "v1"      ← drift
```
`routing_key = sha256(queue_id|doc_index|pipeline_version)`. The enqueue half and the route half derived the key from **different** version strings, so a reprocess that bumped the queue's version could leave a reader on the stale constant → orphaned/duplicate proposals.

**Fix:** `routing` and `writer` now **import** `enqueue.PIPELINE_VERSION` (single source of truth). Value kept as `"intake-v1"` so **no existing routing_key changes**. Aliases, never literals.

## Defect 2 — done-deadlock on superseded-orphan proposals
`route_stage` did `INSERT ... ON CONFLICT (routing_key) DO NOTHING`. When a reprocess marked the prior proposal `superseded` but the same `routing_key` got re-derived, the fresh INSERT was dropped and the queue advanced to `done` with **zero live proposal**. The worker only claims non-`done` rows and `done` never re-enters `/review` → the document is **lost forever** (319 of adit's docs hit exactly this).

**Fix:** in the conflict branch, if the survivor is `superseded`, **revive it to `review_pending`** (refresh entity_resolution/routing/commit_gate, clear the lease). `rejected`/`routed`/`review_pending`/`review_claimed` are intentional human/in-flight states → untouched.

## Tests (`test_intake_routing.py`, **10/10 green on Pro nuzantara_dev**)
- `test_pipeline_version_is_single_source_of_truth` — the three constants agree.
- `test_anti_deadlock_revives_superseded_orphan` — route → force superseded → re-route → status back to `review_pending`, exactly one proposal (no dup).

## Scope
This **stops the bleeding**. Re-enqueueing the already-lost historical documents is a separate data-side step (gated on Zero), not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)