### PR TITLE
fix(wa-mirror): cure 26-day classifier blind spot (Baileys senderPn→sender_phone LID drift)

### DIFF
--- a/scripts/wa-mirror-attention-classifier.py
+++ b/scripts/wa-mirror-attention-classifier.py
@@ -200,14 +200,18 @@ async def fetch_unclassified_inbound(conn: asyncpg.Connection) -> list[dict]:
           m.created_at,
           m.client_id,
           m.practice_id,
-          REGEXP_REPLACE(m.raw_baileys_event->'key'->>'senderPn', '@.*', '') AS phone,
+          -- WhatsApp LID migration (~2026-05-25): raw_baileys_event.key.senderPn was
+          -- dropped; identity now lives in the structured sender_phone column (E.164,
+          -- already LID-resolved upstream by wa-mirror-auto-promote-leads.py). Strip to
+          -- digits to match clients.phone_normalized (stored as bare 62… digits).
+          REGEXP_REPLACE(m.sender_phone, '\\D', '', 'g') AS phone,
           COALESCE(NULLIF(m.body,''), NULLIF(m.message_text,'')) AS body,
           m.media_type,
           m.media_stored_path
         FROM whatsapp_message_context m
         WHERE m.direction = 'inbound'
           AND m.attention_priority IS NULL
-          AND m.raw_baileys_event->'key'->>'senderPn' ~ '^[0-9]+@'
+          AND m.sender_phone IS NOT NULL
         ORDER BY m.created_at DESC
         LIMIT 200
       )
@@ -224,7 +228,7 @@ async def fetch_unclassified_inbound(conn: asyncpg.Connection) -> list[dict]:
                       AND p.status NOT IN ('completed','cancelled','rejected')
                       AND p.actual_completion_date IS NULL) AS has_active_practice,
              (SELECT COUNT(*) FROM whatsapp_message_context m2
-              WHERE REGEXP_REPLACE(m2.raw_baileys_event->'key'->>'senderPn','@.*','') = u.phone
+              WHERE REGEXP_REPLACE(m2.sender_phone,'\\D','','g') = u.phone
                 AND m2.direction='inbound'
                 AND m2.attention_resolved_at IS NULL
                 AND m2.created_at >= u.created_at - INTERVAL '48 hours'
@@ -248,8 +252,9 @@ async def apply_decay(conn: asyncpg.Connection) -> int:
       FROM (
         SELECT inb.id,
                (SELECT MIN(out_.created_at) FROM whatsapp_message_context out_
-                WHERE REGEXP_REPLACE(out_.raw_baileys_event->'key'->>'senderPn','@.*','')
-                      = REGEXP_REPLACE(inb.raw_baileys_event->'key'->>'senderPn','@.*','')
+                -- inbound client = sender_phone; outbound client = counterpart_phone
+                WHERE REGEXP_REPLACE(out_.counterpart_phone,'\\D','','g')
+                      = REGEXP_REPLACE(inb.sender_phone,'\\D','','g')
                   AND out_.direction='outbound'
                   AND out_.created_at > inb.created_at
                   AND out_.created_at <= inb.created_at + INTERVAL '2 hours'


### PR DESCRIPTION
## Problem (business-critical)
The WhatsApp attention classifier read the client identity from `raw_baileys_event.key.senderPn`. The WhatsApp **LID migration dropped that key ~2026-05-25** (identity moved to `remoteJid`/`participant`, then resolved into structured columns). The filter `senderPn ~ '^[0-9]+@'` then rejected **100% of inbound since 2026-05-26**:

- **13,383** inbound messages left unclassified
- **0** new WhatsApp leads auto-promoted to CRM for ~26 days
- the daily digest's "0 inbound" line was a **false metric** — real inbound ≈ **138/day** (ingest was alive the whole time)

Found during the 2026-06-20 alert-wall TAC. Scar family: #9 state-schema mutation drift (primary) + #3 guard form-match + #2 Esiste≠Armato.

## Fix
Repoint the identity source from the legacy JSONB path to the **structured `sender_phone` column** — already LID-resolved upstream by `wa-mirror-auto-promote-leads.py` (`needs_lid_resolve = 0`, 100% populated on inbound). Reuse-first: the promoter already migrated to these columns; the classifier was the one left behind.

- `phone = REGEXP_REPLACE(sender_phone, '\D', '', 'g')` — E.164 → bare digits to match `clients.phone_normalized`
- filter `sender_phone IS NOT NULL` (was the broken senderPn regex)
- `n_inbound_unresolved` subquery → `sender_phone`
- `apply_decay` matches outbound `counterpart_phone` to inbound `sender_phone` (the conversation-stable client identity per direction; `chat_jid` is NULL in this schema)

No schema change, no write-path change — only which column the SELECTs read.

## Verification (on nuzantara_dev, Pro)
- candidates/batch: **0 → 200** (134 known clients, 54 team senders)
- dry-run end-to-end (`WA_ATTENTION_DRY_RUN=1`): HIGH 1 / MEDIUM 135 / LOW 64, **0 writes**, exit 0
- full backend suite (pre-push CI-parity): **15394 passed, 802 skipped, 0 failed**
- backlog (13,383 since 25/05) self-drains at 200/batch on the 5-min cron

## Coordination
File-disjoint from the concurrent M5 wa-mirror work: PR #1587 (intake SSOT), `wa-promote-db-retry`, and the `wa-dashboard-training-tab` Codex branch — none touch `wa-mirror-attention-classifier.py`. Safe to merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)