### PR TITLE
feat(intake): extract text from Word (.docx/.doc) attachments — stop silent loss

### DIFF
--- a/apps/backend-rag/backend/services/intake/preprocess.py
+++ b/apps/backend-rag/backend/services/intake/preprocess.py
@@ -146,6 +146,12 @@ def _detect_mime(blob_path: str, declared_mime: str | None) -> str:
             return "image/webp"
         if head[:2] in (b"II", b"MM"):
             return "image/tiff"
+        # OOXML (.docx/.xlsx/.pptx) and legacy OLE (.doc) share generic magic
+        # (PK zip / D0CF OLE) with other formats, so we cannot tell a .docx from
+        # a .zip by magic alone. Fall through to the extension guess below, which
+        # maps .docx -> wordprocessingml. A declared_mime from the WA row (which
+        # word docs carry) already short-circuited above, so this only matters for
+        # extension-only disk backfill.
     except OSError as exc:
         logger.warning("mime sniff failed for %s: %s", blob_path, exc)
 
@@ -330,6 +336,38 @@ def _normalize_image_sync(image_bytes: bytes) -> bytes | None:
         return None
 
 
+# Office word-processing mimes that carry a native text layer (NOT images). A
+# .docx is a zip of XML; the vision pipeline would OCR the raw zip bytes to
+# garbage -> classify "unknown" -> a real contract/akta silently lost (the
+# 9 Word docs found in adit's intake, 2026-06-20). We extract the text layer
+# directly (python-docx) and feed it downstream exactly like the PDF born-digital
+# text-layer fast-path -- 100% local, 0 bytes to cloud (Symbiosis Law 2).
+_WORD_MIMES = frozenset(
+    {
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",  # .docx
+        "application/msword",  # legacy .doc
+    }
+)
+
+
+def _extract_docx_text_sync(blob_path: str) -> str | None:
+    """Extract the text layer from a .docx via python-docx. None on failure.
+
+    Legacy binary .doc is NOT supported by python-docx (it raises); we return
+    None so the caller falls through to the raw-bytes path rather than crashing
+    the stage. Never raises -- a bad office doc is a recoverable input, not a
+    programmer error (matches the module's graceful-degradation contract).
+    """
+    try:
+        from backend.core.parsers import extract_text_from_docx
+
+        text = extract_text_from_docx(blob_path)
+        return text if text and text.strip() else None
+    except Exception as exc:  # broad: any parse failure -> graceful fallthrough
+        logger.warning("docx text extract failed for %s: %s", blob_path, exc)
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -397,6 +435,28 @@ async def preprocess_blob(
             page_pngs = [raw]  # let OCR try the raw bytes
         else:
             page_pngs = [normalized]
+    elif mime in _WORD_MIMES:
+        # Word doc: no image to OCR -- extract the native text layer and emit a
+        # single born-digital page (text set, png_bytes empty). Downstream OCR
+        # uses PageImage.text verbatim and skips the vision model, exactly like
+        # the PDF text-layer fast-path. A legacy .doc / corrupt .docx returns
+        # None -> graceful single empty page (classify -> "unknown" -> human
+        # review), never a stage crash.
+        text = await asyncio.to_thread(_extract_docx_text_sync, blob_path)
+        if text is None:
+            logger.warning("preprocess: word doc unreadable %s (mime=%s)", blob_path, mime)
+            return PreprocessResult(
+                pages=[PageImage(index=0, png_bytes=b"", enhanced=False, text=None)],
+                n_pages=1,
+                mime=mime,
+                notes="word_extract_failed",
+            )
+        return PreprocessResult(
+            pages=[PageImage(index=0, png_bytes=b"", enhanced=False, text=text)],
+            n_pages=1,
+            mime=mime,
+            notes="word_textlayer",
+        )
     else:
         # Unknown/unsupported format -- pass raw bytes through; OCR may cope.
         logger.warning("preprocess: unsupported mime %s for %s", mime, blob_path)

--- a/apps/backend-rag/backend/tests/services/intake/test_preprocess_word.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_preprocess_word.py
@@ -1,0 +1,99 @@
+"""Unit tests for Word (.docx/.doc) text extraction in preprocess_blob.
+
+Word documents arriving via WhatsApp were previously vision-only fodder: the
+pipeline OCR'd the raw .docx zip bytes to garbage -> classify "unknown" -> a
+real contract/akta silently lost (the 9 Word docs found in adit's intake,
+2026-06-20). preprocess_blob now branches on the wordprocessing mimes and emits
+a single born-digital PageImage(text=...) -- reusing the exact text-layer
+contract the PDF fast-path already feeds to classify.ocr_pages.
+
+python-docx is monkeypatched (via the parsers.extract_text_from_docx import) so
+no real .docx file or library round-trip is needed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.services.intake import preprocess as pre
+from backend.services.intake.preprocess import PageImage
+
+_DOCX_MIME = (
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+)
+_DOC_MIME = "application/msword"
+
+# Synthetic, non-PII Word body text.
+_WORD_TEXT = (
+    "SURAT PERJANJIAN KERJA SAMA antara PT CONTOH SEJAHTERA dan MITRA ABADI "
+    "tentang penyediaan jasa konsultasi perizinan berusaha tahun 2026."
+)
+
+
+def test_word_mimes_constant_covers_docx_and_doc() -> None:
+    assert _DOCX_MIME in pre._WORD_MIMES
+    assert _DOC_MIME in pre._WORD_MIMES
+
+
+@pytest.mark.asyncio
+async def test_docx_emits_textlayer_page(monkeypatch, tmp_path) -> None:
+    # Arrange: a file present on disk + a stubbed docx text extractor.
+    blob = tmp_path / "contract.docx"
+    blob.write_bytes(b"PK\x03\x04 fake docx zip bytes")
+
+    monkeypatch.setattr(
+        "backend.core.parsers.extract_text_from_docx",
+        lambda path: _WORD_TEXT,
+    )
+
+    # Act
+    result = await pre.preprocess_blob(str(blob), declared_mime=_DOCX_MIME)
+
+    # Assert: one born-digital page, text set verbatim, no image bytes, mime kept.
+    assert result.n_pages == 1
+    page = result.pages[0]
+    assert isinstance(page, PageImage)
+    assert page.text == _WORD_TEXT
+    assert page.png_bytes == b""  # no image to OCR
+    assert result.mime == _DOCX_MIME
+    assert result.notes == "word_textlayer"
+
+
+@pytest.mark.asyncio
+async def test_unreadable_word_degrades_gracefully(monkeypatch, tmp_path) -> None:
+    # A legacy/corrupt .doc that python-docx cannot parse must NOT crash the
+    # stage: it degrades to a single empty page (text=None) so classify routes
+    # it to human review as "unknown".
+    blob = tmp_path / "legacy.doc"
+    blob.write_bytes(b"\xd0\xcf\x11\xe0 legacy OLE bytes")
+
+    def _boom(path: str) -> str:
+        raise ValueError("python-docx cannot read legacy .doc")
+
+    monkeypatch.setattr("backend.core.parsers.extract_text_from_docx", _boom)
+
+    result = await pre.preprocess_blob(str(blob), declared_mime=_DOC_MIME)
+
+    assert result.n_pages == 1
+    page = result.pages[0]
+    assert page.text is None
+    assert page.png_bytes == b""
+    assert result.notes == "word_extract_failed"
+
+
+@pytest.mark.asyncio
+async def test_empty_docx_text_degrades(monkeypatch, tmp_path) -> None:
+    # An empty/whitespace-only extraction is treated as "no usable text" -> the
+    # graceful empty-page path, never a textlayer page with blank content.
+    blob = tmp_path / "blank.docx"
+    blob.write_bytes(b"PK\x03\x04 fake")
+
+    monkeypatch.setattr(
+        "backend.core.parsers.extract_text_from_docx",
+        lambda path: "   \n  ",
+    )
+
+    result = await pre.preprocess_blob(str(blob), declared_mime=_DOCX_MIME)
+
+    assert result.pages[0].text is None
+    assert result.notes == "word_extract_failed"

--- a/apps/backend-rag/requirements.txt
+++ b/apps/backend-rag/requirements.txt
@@ -140,6 +140,12 @@ psutil>=5.9.0  # Required by metrics module/tests
 pdfplumber>=0.11.0
 pdfminer.six>=20251107  # Match pdfplumber requirement
 
+# Word (.docx) text extraction — intake pipeline reads native text layer of
+# WhatsApp Word attachments (parsers.extract_text_from_docx / preprocess.py).
+# Already imported with a None fallback in backend/core/parsers.py; pinning it
+# here so Fly/CI install it (was Pro-only, 2026-06-20).
+python-docx>=1.1.0
+
 # Protocol Buffers - Pin to 5.x (compatible with OTEL + Google packages)
 protobuf>=5.27.0,<6.0.0
 

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`325 routers · 624 services · 1068 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`325 routers · 624 services · 1069 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Problem (Difetto 5)

The intake **preprocess** stage was **vision-only**: PDF/Word attachments arriving via WhatsApp that aren't images were OCR'd as raw bytes → garbage → classified `unknown` → **silently lost**.

Found tracing adit's intake (2026-06-20): of his 134 `unknown` documents, **61 are office docs** the pipeline can't read — 51 PDF + **9 Word** + 1 zip. PDFs are already handled (rasterize + text-layer fast-path); **Word docs had no branch at all** and fell through to the "unsupported mime → raw bytes → vision" path.

## Fix

`preprocess_blob` now branches on the wordprocessing mimes and extracts the **native text layer** via the existing `parsers.extract_text_from_docx`, emitting a single born-digital `PageImage(text=...)`.

This **reuses the exact contract** the PDF text-layer fast-path already feeds to `classify.ocr_pages`: a page with `text` set is used verbatim and the vision model is skipped (riga 225-241 of classify.py). 100% local, **0 bytes to cloud** (Symbiosis Law 2). A corrupt/legacy `.doc` degrades gracefully to an empty page → human review, **never a stage crash**.

### Changes
- `preprocess.py`: `_WORD_MIMES` + `_extract_docx_text_sync` + Word branch before the unsupported-mime fallback
- `requirements.txt`: pin `python-docx>=1.1.0` (was Pro-only; already imported with a `None` fallback in `parsers.py`)
- `test_preprocess_word.py`: 4 tests — docx→textlayer page, corrupt/legacy graceful degrade, empty-text degrade, mime constant

### Tests
- `test_preprocess_word.py` + `test_textlayer_fastpath.py`: **8/8** ✅
- `test_preprocess_min_dimension.py` + `test_intake_classify.py`: **28/28** ✅ (0 regressions)

### Scope note
This fixes the pipeline going **forward** (new Word docs get read). The 9 historical Word docs already in adit's `/review` (and team-wide analogues) would need a re-enqueue to benefit — separate, gated on Zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)