### PR TITLE
fix(observability): DLQ corpse-sweep staleness + connectome firebreak verdicts

### DIFF
--- a/docs/connectome/edges/launchd-pro.yaml
+++ b/docs/connectome/edges/launchd-pro.yaml
@@ -995,6 +995,7 @@ edges:
       machine: pro,
       status: ALIVE,
       producer: "daily 9:00",
+      oneshot_sentinel: "~/.agent/l5-2-phase2b-fired.sentinel",
     }
   - {
       id: com.balizero.sota.m13-checkpoint,

--- a/scripts/dlq_autopilot.py
+++ b/scripts/dlq_autopilot.py
@@ -77,6 +77,13 @@ LOCK_STALE_AGE_S = 1500          # 25min — if lock older than this, treat as s
 MAX_ATTEMPTS = 10                 # per DLQ entry (default; per-job override via registry max_attempts)
 DLQ_TTL_S = 172800                # 48h — abandon entries older than this with empty error
 MIN_ERROR_LEN = 20                # skip reasoning if error_summary shorter than this
+# Corpse-sweep freshness window: only drain a "recovered" (status==ok) DLQ entry if
+# its state file's "ok" is RECENT. A stale "ok" (job hasn't actually re-run in this
+# window) is NOT proof of recovery — draining it just re-arms the blind loop
+# (drain → sentinel re-adds on next failure → drain → forever; 90 consecutive blind
+# cycles observed 2026-06-20). Genuinely-recovered jobs write a fresh ok on success
+# and drain on the next tick. Fail-closed on missing/old ts.
+CORPSE_SWEEP_FRESH_S = int(os.getenv("DLQ_CORPSE_SWEEP_FRESH_S", str(6 * 3600)))  # 6h
 CONFIDENCE_RETRY = 0.95           # no-code-change retry threshold
 CONFIDENCE_AIDER = 0.90           # code-change aider threshold
 REASONING_TIMEOUT_S = 90          # claude --print timeout
@@ -158,8 +165,30 @@ def load_registry() -> dict:
         return {}
 
 
+def _state_is_fresh(state: dict) -> bool:
+    """True iff the state file's timestamp is within CORPSE_SWEEP_FRESH_S of now.
+
+    A missing / zero / unparseable ts is NOT fresh (fail-closed: never drain on an
+    absent timestamp). Tolerates the legacy ISO-8601 ts format older writers emitted
+    (W54) the same way the sentinel does.
+    """
+    raw = state.get("ts", 0)
+    try:
+        ts = float(raw) if raw not in (None, "") else 0.0
+    except (TypeError, ValueError):
+        try:
+            import datetime as _dt
+            ts = _dt.datetime.strptime(str(raw), "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=_dt.timezone.utc).timestamp()
+        except Exception:
+            return False
+    if ts <= 0:
+        return False
+    return (time.time() - ts) <= CORPSE_SWEEP_FRESH_S
+
+
 def sweep_recovered_corpses(queue: list) -> tuple[list, list]:
-    """Drain DLQ entries whose job has since recovered (state.status == 'ok').
+    """Drain DLQ entries whose job has since recovered (state.status == 'ok' AND fresh).
 
     Root cause this fixes (W81 / blind heal-loop, 2026-06-15): process_entry()'s
     TERMINAL guard skips TERMINAL entries forever, and the sentinel's W70-resurrect
@@ -180,9 +209,12 @@ def sweep_recovered_corpses(queue: list) -> tuple[list, list]:
         except (FileNotFoundError, json.JSONDecodeError, OSError):
             kept.append(entry)
             continue
-        if state.get("status") == "ok":
+        if state.get("status") == "ok" and _state_is_fresh(state):
             cleared.append(job)
         else:
+            # status != ok OR a stale "ok" (no proof the job re-ran in the window):
+            # keep in DLQ for audit. The sentinel's own staleness path (ok→stale)
+            # re-classifies it through the normal failure flow if it really died.
             kept.append(entry)
     return kept, cleared
 

--- a/scripts/verify_connectome.py
+++ b/scripts/verify_connectome.py
@@ -97,6 +97,29 @@ def is_healthy(declared: str) -> bool:
     return any(head.startswith(p) for p in HEALTHY_PREFIXES)
 
 
+LAUNCHAGENTS_DIR = Path.home() / "Library" / "LaunchAgents"
+
+
+def plist_intentionally_disabled(label: str) -> str | None:
+    """If a LaunchAgent plist for `label` exists ONLY in a disabled/renamed form
+    (e.g. *.plist.disabled-W81-*, *.disabled-*), the edge is a deliberate firebreak,
+    not a regression. Returns the disabled filename if so, else None.
+
+    An active plist == exactly '<label>.plist'. Anything else carrying the label as a
+    prefix (disabled-*, superseded-*, .bak) is an intentional non-arming. An
+    active-but-dead plist still has '<label>.plist' present → returns None → it still
+    REGRESSES (a genuine silent death is never masked).
+    """
+    if not label.startswith("com.") or not LAUNCHAGENTS_DIR.is_dir():
+        return None
+    if (LAUNCHAGENTS_DIR / f"{label}.plist").exists():
+        return None
+    for f in LAUNCHAGENTS_DIR.glob(f"{label}.plist.*"):
+        if "disabled" in f.name or "superseded" in f.name or f.name.endswith(".bak"):
+            return f.name
+    return None
+
+
 @dataclass
 class ProbeResult:
     ok: bool
@@ -338,7 +361,28 @@ def main() -> int:
         elif result.ok and not healthy:
             verdict = "RECOVERED"
         elif not result.ok and healthy:
-            verdict = "REGRESSED"
+            # Before calling a failed-probe healthy edge REGRESSED, distinguish a
+            # deliberate firebreak (plist intentionally renamed *.disabled-*) and a
+            # completed one-shot (its sentinel exists on disk) from a true silent
+            # death — both are "Esiste≠Armato" (#2): census says ALIVE but the
+            # activation state on disk says intentionally-not-armed.
+            disabled_as = (
+                plist_intentionally_disabled(edge["id"])
+                if (machine in ("", this_machine) and edge.get("kind") == "launchd")
+                else None
+            )
+            sentinel = edge.get("oneshot_sentinel")
+            sentinel_present = bool(
+                sentinel and Path(os.path.expanduser(str(sentinel))).exists()
+            )
+            if disabled_as:
+                verdict = "DISABLED"
+                result = ProbeResult(False, f"intentional firebreak: {disabled_as}")
+            elif sentinel_present:
+                verdict = "COMPLETED"
+                result = ProbeResult(False, f"one-shot done: sentinel {sentinel}")
+            else:
+                verdict = "REGRESSED"
         else:
             verdict = "CONFIRMED"  # declared dead, still dead
         reports.append(


### PR DESCRIPTION
Two guardian false-positive fixes from the 2026-06-20 alert-wall TAC. Both narrow false alarms; neither can mask a real fault.

## 1. DLQ corpse-sweep staleness guard (`scripts/dlq_autopilot.py`)
`sweep_recovered_corpses` drained any DLQ entry with `state.last.json status==ok` and NO recency check → a 2-week-old "ok" drained like a fresh one. The sentinel re-adds the healthy-but-parked job each cycle → **drain→re-add→forever** (90 consecutive blind cycles, 0 heal actions/24h observed). Adds `CORPSE_SWEEP_FRESH_S` (6h, env-overridable) + `_state_is_fresh`: only drain a recent ok. Fail-closed on missing/old ts. Stale-ok stays in DLQ for audit; the sentinel's own ok→stale path handles a real death — never masked. No add-side change.
- **Verified**: `_state_is_fresh` drains fresh (ts=now→True), keeps stale (353h→False), rejects missing-ts→False.

## 2. Connectome firebreak/one-shot verdicts (`scripts/verify_connectome.py` + `launchd-pro.yaml`)
`launchctl list | grep <label>` fails for an intentionally-renamed firebreak plist (`*.plist.disabled-W81-*`) or a completed one-shot → a census-ALIVE edge was called **REGRESSED**. 5 false REGRESSED on Pro (4 codex W81 firebreaks + l5-2-phase2b one-shot). Adds `plist_intentionally_disabled()` (an active `<label>.plist` still present → still REGRESSES; a genuine death never masked) + an `oneshot_sentinel` edge field → classifies as DISABLED/COMPLETED, which the exit gate + Telegram alert (keyed on REGRESSED only) ignore.
- **Verified on Pro**: `verify_connectome --no-ssh` verdicts `REGRESSED 6→0` (DISABLED 4 + COMPLETED 1), zero genuine edges suppressed.

Both files are hot-zone (sentinel/dlq) — lease-check passed clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)