### PR TITLE
feat(kbli): L4-Bali complete — 85 needs_review resolved + per-scala-Besar rule

### DIFF
--- a/apps/backend-rag/scripts/build_kbli_l2_oss_risk.py
+++ b/apps/backend-rag/scripts/build_kbli_l2_oss_risk.py
@@ -1,0 +1,293 @@
+"""Build KBLI L2 from OSS official risk (KbliResikos) + recompute L4-Bali blocks.
+
+Input:
+  - /tmp/oss_risk_raw.jsonl  (raw ruang-lingkup/{uuid} dumps, one per code)
+  - the L1 dataset (base) at data/source_documents/KBLI_2025_FINAL_CLEAN.json
+
+For each code with scope, rebuild per_skala from the OFFICIAL KbliResikos:
+  skala_usaha, kategori_risiko (Resiko), jangka_waktu, perizinan (KbliIzins),
+  persyaratan (KbliPersyaratans), kewajiban (KbliKewajibans), kewenangan.
+Mark provenance _l2_source = OSS_RBA_resiko. Keep the OLD per_skala under
+per_skala_legacy for audit. Codes with no OSS risk (404/no-scope) keep the old
+per_skala and are flagged _l2_status="no_oss_risk".
+
+Then RECOMPUTE l4_bali.blocked from the official lowest risk:
+  - if any scale is Rendah or Menengah Rendah  -> BLOCCATO_CLASSE_RISCHIO (moratorium)
+  - else (Menengah Tinggi / Tinggi only)        -> OK_or_HIGHER_RISK
+  - TERTUTUP / TERBATAS / CHIUSO_* statuses are PRESERVED (they are not risk-derived).
+
+Writes a COMPARISON report (old vs new) to stdout. Does NOT write the dataset unless
+--apply is passed (Zero must see the divergence first).
+
+Usage:
+    python scripts/build_kbli_l2_oss_risk.py            # report only
+    python scripts/build_kbli_l2_oss_risk.py --apply    # write the dataset
+"""
+import argparse, json
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path("/tmp/kbli-l2-risk")
+RAW = Path("/tmp/oss_risk_raw.jsonl")
+TARGETS = [
+    ROOT / "data" / "source_documents" / "KBLI_2025_FINAL_CLEAN.json",
+    ROOT / "apps" / "mouth" / "data" / "KBLI_2025_FINAL_CLEAN.json",
+]
+BLOCK_RISKS = {"rendah", "menengah rendah"}            # → moratorium blocks PMA Bali
+PRESERVE_STATUSES = {"TERTUTUP", "TERBATAS", "CHIUSO_BALI", "CHIUSO_BALI_PROPOSTO",
+                     "TERTUTUP_CANDIDATE", "TERBATAS_CANDIDATE"}
+
+
+def loc(d, lang="id", field="uraian"):
+    if not isinstance(d, dict):
+        return None
+    l = d.get("localization")
+    if not isinstance(l, dict):
+        return None
+    sub = l.get(lang)
+    if not isinstance(sub, dict):
+        return None
+    return sub.get(field)
+
+
+def parse_per_skala(raw_data):
+    """Return list of official per_skala dicts from one code's raw ruang-lingkup payload.
+
+    Each ruang lingkup (scope) is kept SEPARATE — its uraian (the sub-activity the
+    PMA declares in the NIB) decides which risk row applies. We tag every per_skala
+    row with `scope_index` + `scope_uraian` so the Bali-block verdict can be computed
+    per-scope (a PMA is scale Besar by law, so only the Besar row of the CHOSEN scope
+    matters). Dedup is per-scope (skala, risk), not global.
+    """
+    out = []
+    for si, rl in enumerate(raw_data.get("data", []) or []):
+        scope_uraian = loc(rl) or ""
+        seen = set()
+        for res in rl.get("KbliResikos", []) or []:
+            skala = loc(res.get("SkalaUsaha"))
+            risk = loc(res.get("Resiko"))
+            if not skala:
+                continue
+            # normalize "Usaha Mikro" -> "Mikro"
+            skala_norm = skala.replace("Usaha ", "").strip()
+            key = (skala_norm, risk)
+            if key in seen:
+                continue
+            seen.add(key)
+            izin = [loc(x) for x in (res.get("KbliIzins") or []) if loc(x)]
+            pers = [loc(x) for x in (res.get("KbliPersyaratans") or []) if loc(x)]
+            kew = [loc(x) for x in (res.get("KbliKewajibans") or []) if loc(x)]
+            kewn = []
+            for k in (res.get("KbliResikoKewenangans") or []):
+                kw = k.get("Kewenangan") if isinstance(k, dict) else None
+                v = loc(kw) if kw else None
+                if v:
+                    kewn.append(v)
+            out.append({
+                "skala_usaha": [skala_norm],
+                "kategori_risiko": risk,
+                "jangka_waktu": res.get("jangka_waktu") or "",
+                "scope_index": si,
+                "scope_uraian": scope_uraian,
+                "perizinan": izin,
+                "persyaratan": pers,
+                "kewajiban": kew,
+                "kewenangan": kewn,
+            })
+    return out
+
+
+def besar_block_verdict(per_skala):
+    """Bali moratorium verdict from the OFFICIAL per-scope risk at scale Besar.
+
+    A PMA is scale Besar by law (modal >=10 bn). The OSS computes risk at the
+    applicant's scale, so ONLY the Besar row of each scope matters. Per scope:
+      - Besar risk in {Rendah, Menengah Rendah}  -> that scope is BLOCKED
+      - otherwise                                 -> that scope is OPEN
+    Roll up across the code's scopes:
+      - every scope with a Besar row is blocked, none open -> "BLOCKED"   (D-all)
+      - some scopes blocked, some open                     -> "AMBIGUOUS" (passable
+                                                              by declaring the open
+                                                              scope, e.g. 47901 PPMSE)
+      - no scope blocked at Besar                          -> "OPEN"
+      - no Besar row anywhere                              -> "NO_BESAR" (flag)
+    """
+    blocked_scopes = 0
+    open_scopes = 0
+    besar_seen = False
+    for ps in per_skala:
+        if "Besar" not in (ps.get("skala_usaha") or []):
+            continue
+        besar_seen = True
+        r = (ps.get("kategori_risiko") or "").strip().lower()
+        if r in BLOCK_RISKS:
+            blocked_scopes += 1
+        else:
+            open_scopes += 1
+    if not besar_seen:
+        return "NO_BESAR"
+    if blocked_scopes and not open_scopes:
+        return "BLOCKED"
+    if blocked_scopes and open_scopes:
+        return "AMBIGUOUS"
+    return "OPEN"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply", action="store_true")
+    args = ap.parse_args()
+
+    raw = {}
+    for line in RAW.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        r = json.loads(line)
+        raw[r["kode"]] = r
+
+    ds = json.loads(TARGETS[0].read_text(encoding="utf-8"))
+    records = ds["data"]
+
+    stats = Counter()
+    block_changes = []          # codes whose l4 blocked flips
+    perskala_fixed = []         # codes whose per_skala scale-count changed
+    risk_mismatch = []          # codes whose risk text differs from old
+
+    for rec in records:
+        code = str(rec.get("kode_kbli_2025") or "")
+        r = raw.get(code)
+        old_ps = rec.get("per_skala", []) or []
+        old_l4 = rec.get("l4_bali", {}) or {}
+        old_status = old_l4.get("status")
+
+        if not r or r.get("status") != 200 or not r.get("data", {}).get("success"):
+            stats["no_oss_risk"] += 1
+            # 221 codes have no OSS scope (404). Most are special-regime activities
+            # (central bank, OJK-regulated finance 64xxx/66xxx, narcotics, radioactive
+            # waste, bonded warehouse) that sit OUTSIDE the ordinary RBA flow — the old
+            # "BLOCCATO_CLASSE_RISCHIO" is a fictitious risk-derived verdict we cannot
+            # re-confirm. Relabel as NEEDS_REVIEW (sectoral check), but PRESERVE the
+            # non-risk-derived closed statuses (TERTUTUP/TERBATAS) untouched.
+            was_blocked = bool((old_l4 or {}).get("blocked"))
+            if args.apply:
+                rec["_l2_status"] = "no_oss_risk"
+                if old_status not in PRESERVE_STATUSES and was_blocked:
+                    rec["_l4_needs_review"] = "no_oss_scope_special_regime"
+                    rec["l4_bali"]["status"] = "NEEDS_REVIEW_NO_OSS_SCOPE"
+                    rec["l4_bali"]["blocked"] = True  # stay conservative until sectoral check
+                    rec["l4_bali"]["reason"] = (
+                        "no OSS-RBA scope (special/sectoral regime: OJK/BI/BPOM/etc.) — "
+                        "Bali registrability needs manual sectoral verification")
+                    stats["needs_review_no_scope_blocked"] += 1
+            elif old_status not in PRESERVE_STATUSES and was_blocked:
+                stats["needs_review_no_scope_blocked"] += 1
+            continue
+
+        new_ps = parse_per_skala(r["data"])
+        if not new_ps:
+            rec["_l2_status"] = "empty_oss_risk"
+            stats["empty_oss_risk"] += 1
+            continue
+
+        # scale-count change?
+        if len(new_ps) != len(old_ps):
+            perskala_fixed.append((code, len(old_ps), len(new_ps)))
+        # risk text change (lowest)?
+        old_risks = {(p.get("kategori_risiko") or "").lower() for p in old_ps}
+        new_risks = {(p.get("kategori_risiko") or "").lower() for p in new_ps}
+        if old_risks != new_risks:
+            risk_mismatch.append((code, sorted(old_risks), sorted(new_risks)))
+
+        # recompute Bali block (only for risk-derived statuses) using the
+        # OFFICIAL per-scope risk at scale Besar (Regola D, chosen by Zero 2026-06-20).
+        if old_status not in PRESERVE_STATUSES:
+            verdict = besar_block_verdict(new_ps)   # BLOCKED / AMBIGUOUS / OPEN / NO_BESAR
+            new_blocked = verdict == "BLOCKED"       # binary block flag (D-all)
+            new_l4_status = {
+                "BLOCKED": "BLOCCATO_CLASSE_RISCHIO",
+                "AMBIGUOUS": "BLOCCATO_DIPENDE_SCOPE",
+                "OPEN": "OK_or_HIGHER_RISK",
+                # no Besar row at all = activity reserved for UMKM (Perpres 49/2021 Annex II);
+                # a PMA (Besar by law) cannot register it. NB-3 verbatim: "unavailable / fails
+                # validation for a PT PMA profile". This is a CLOSURE, not openness.
+                "NO_BESAR": "CHIUSO_PMA_NO_BESAR",
+            }[verdict]
+            # NO_BESAR is a block (PMA cannot register), like BLOCKED
+            new_blocked = verdict in ("BLOCKED", "NO_BESAR")
+            stats[f"verdict_{verdict}"] += 1
+            old_blocked = bool(old_l4.get("blocked"))
+            # a "flip" = the binary block flag changed vs the old (paraphrase) data
+            if new_blocked != old_blocked:
+                block_changes.append((code, old_status, new_l4_status,
+                                      sorted(new_risks)))
+            if args.apply:
+                rec.setdefault("per_skala_legacy", old_ps)
+                rec["per_skala"] = new_ps
+                rec["_l2_source"] = "OSS_RBA_resiko_2025"
+                rec["l4_bali"]["blocked"] = new_blocked
+                rec["l4_bali"]["status"] = new_l4_status
+                rec["l4_bali"]["verdict"] = verdict
+                if verdict == "NO_BESAR":
+                    # has OSS scope but no Besar risk row — can't derive PMA verdict
+                    rec["_l4_needs_review"] = "oss_scope_present_but_no_besar_risk_row"
+                rec["l4_bali"]["rule"] = "per-scala-Besar (OSS risk at scale Besar; PMA is Besar by law)"
+                if verdict == "BLOCKED":
+                    rec["l4_bali"]["reason"] = (
+                        "OSS risk at scale Besar is Rendah/Menengah-Rendah on every scope "
+                        "→ blocked by Bali moratorium 13/5/26")
+                elif verdict == "AMBIGUOUS":
+                    rec["l4_bali"]["reason"] = (
+                        "OSS risk at scale Besar is low on SOME scope(s) but higher on other(s): "
+                        "registrable as PMA in Bali only by declaring the higher-risk scope "
+                        "(e.g. PPMSE for platform-trade codes) — verify live OSS per exact activity")
+                elif verdict == "NO_BESAR":
+                    rec["l4_bali"]["reason"] = (
+                        "OSS has no Usaha Besar scale row → activity reserved for UMKM "
+                        "(Perpres 49/2021 Annex II); a PT PMA (Besar by law) cannot register it")
+                else:
+                    rec["l4_bali"]["reason"] = (
+                        "OSS risk at scale Besar is Menengah-Tinggi/Tinggi → not blocked by moratorium")
+        elif args.apply:
+            rec.setdefault("per_skala_legacy", old_ps)
+            rec["per_skala"] = new_ps
+            rec["_l2_source"] = "OSS_RBA_resiko_2025"
+        stats["l2_applied"] += 1
+
+    # ---- REPORT ----
+    print("=" * 70)
+    print("KBLI L2 OSS-risk re-anchor — DIVERGENCE REPORT (old vs official OSS)")
+    print("=" * 70)
+    print(f"records: {len(records)}")
+    for k, v in stats.items():
+        print(f"  {k}: {v}")
+    print(f"\nper_skala scale-count CHANGED (was incomplete): {len(perskala_fixed)}")
+    for c, o, n in perskala_fixed[:15]:
+        print(f"  {c}: {o} scales -> {n} scales")
+    print(f"\nrisk text CHANGED: {len(risk_mismatch)}")
+    for c, o, n in risk_mismatch[:15]:
+        print(f"  {c}: {o} -> {n}")
+    print("\n*** L4-BALI VERDICT (per-scala-Besar, Regola D) ***")
+    print(f"  BLOCKED   (Besar low on every scope): {stats.get('verdict_BLOCKED', 0)}")
+    print(f"  AMBIGUOUS (Besar low on some scope)  : {stats.get('verdict_AMBIGUOUS', 0)}  -> flagged BLOCCATO_DIPENDE_SCOPE")
+    print(f"  OPEN      (Besar never low)          : {stats.get('verdict_OPEN', 0)}")
+    print(f"  NO_BESAR  (no Besar row at all)      : {stats.get('verdict_NO_BESAR', 0)}  -> treated OPEN, needs_review")
+    print(f"\n*** L4-BALI BLOCK FLIPS vs old paraphrase data: {len(block_changes)} ***")
+    flips_to_blocked = [x for x in block_changes if x[2] == "BLOCCATO_CLASSE_RISCHIO"]
+    flips_to_open = [x for x in block_changes if x[2] != "BLOCCATO_CLASSE_RISCHIO"]
+    print(f"  newly BLOCKED (were open): {len(flips_to_blocked)}")
+    print(f"  newly OPEN/ambiguous (were blocked): {len(flips_to_open)}")
+    for c, os_, ns, risks in block_changes[:20]:
+        print(f"    {c}: {os_} -> {ns}  (official risk {risks})")
+
+    if args.apply:
+        ds["metadata"]["version"] = "v10.0-L2-oss-risk"
+        blob = json.dumps(ds, ensure_ascii=False, indent=2)
+        for t in TARGETS:
+            t.write_text(blob, encoding="utf-8")
+        print(f"\nAPPLIED. wrote {len(blob)} bytes to both targets. version v10.0-L2-oss-risk")
+    else:
+        print("\n(report only — pass --apply to write the dataset)")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/backend-rag/scripts/fetch_oss_risk.py
+++ b/apps/backend-rag/scripts/fetch_oss_risk.py
@@ -1,0 +1,97 @@
+"""Fetch the OFFICIAL risk/licensing ground-truth from OSS RBA for all 1559 5-digit KBLI.
+
+Endpoint: GET gw.oss.go.id/v2/portal/kbli/ruang-lingkup/{uuid}
+Auth: static app credential (user_key) — ZERO PII (public economic classification).
+The response carries KbliResikos[] per scope, each with SkalaUsaha + Resiko (official
+Tingkat Resiko) + jangka_waktu + KbliPersyaratans/KbliIzins/KbliKewajibans/Kewenangans.
+
+Phase 1 = raw dump only (separate network from transform). Writes one JSON line per code
+to /tmp/oss_risk_raw.jsonl so a parsing bug never forces a re-download.
+
+Usage:
+    python scripts/fetch_oss_risk.py [--limit N] [--start N]
+"""
+import argparse, json, os, time, urllib.request, urllib.error
+from pathlib import Path
+
+OSS_GT = Path("/Users/balizero/Desktop/nuzantara/data/source_documents/KBLI_2025_OSS_GROUND_TRUTH.json")
+OUT = Path("/tmp/oss_risk_raw.jsonl")
+# Static app credential of the OSS RBA iOS app (gw.oss.go.id) — NOT a Bali Zero secret:
+# it is embedded in the public government app, identical for every user, and unlocks only
+# public economic-classification data (zero PII, no user login). Read from env so the
+# high-entropy literal stays out of the repo; the value is the one published in the app.
+USER_KEY = os.environ.get("OSS_RBA_USER_KEY", "")
+BASE = "https://gw.oss.go.id/v2/portal/kbli/ruang-lingkup/"
+
+
+def fetch(uuid, retries=3):
+    req = urllib.request.Request(BASE + uuid, headers={"user_key": USER_KEY, "accept": "application/json"})
+    # bypass system proxy explicitly (memory trap: urllib honors it)
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    for attempt in range(retries):
+        try:
+            with opener.open(req, timeout=25) as r:
+                return json.loads(r.read().decode("utf-8")), r.status
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return {"success": False, "code": 404}, 404
+            if attempt == retries - 1:
+                return {"error": f"HTTP {e.code}"}, e.code
+        except Exception as e:
+            if attempt == retries - 1:
+                return {"error": str(e)}, 0
+        time.sleep(1.5 * (attempt + 1))
+    return {"error": "exhausted"}, 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=0)
+    ap.add_argument("--start", type=int, default=0)
+    args = ap.parse_args()
+
+    if not USER_KEY:
+        raise SystemExit(
+            "set OSS_RBA_USER_KEY (the OSS RBA app's static public user_key) before running, "
+            "e.g. OSS_RBA_USER_KEY=<key> python scripts/fetch_oss_risk.py")
+
+    gt = json.loads(OSS_GT.read_text(encoding="utf-8"))
+    codes = [(str(x["kode"]), x["uuid"]) for x in gt["data"] if x.get("digits") == 5]
+    codes = codes[args.start:]
+    if args.limit:
+        codes = codes[: args.limit]
+
+    # resume: skip codes already in OUT
+    done = set()
+    if OUT.exists():
+        for line in OUT.read_text(encoding="utf-8").splitlines():
+            try:
+                done.add(json.loads(line)["kode"])
+            except Exception:
+                pass
+
+    ok = err = skip = notfound = 0
+    with OUT.open("a", encoding="utf-8") as f:
+        for i, (kode, uuid) in enumerate(codes):
+            if kode in done:
+                skip += 1
+                continue
+            data, status = fetch(uuid)
+            rec = {"kode": kode, "uuid": uuid, "status": status, "data": data}
+            f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+            f.flush()
+            if status == 200 and data.get("success"):
+                ok += 1
+            elif status == 404:
+                notfound += 1
+            else:
+                err += 1
+            if (i + 1) % 100 == 0:
+                print(f"  {i+1}/{len(codes)} ok={ok} 404={notfound} err={err} skip={skip}", flush=True)
+            time.sleep(0.15)  # be polite
+
+    print(f"DONE ok={ok} 404={notfound} err={err} skip={skip} total_lines={ok+notfound+err+skip}")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/backend-rag/scripts/patch_qdrant_bali_l4.py
+++ b/apps/backend-rag/scripts/patch_qdrant_bali_l4.py
@@ -1,0 +1,206 @@
+"""Patch the LIVE kbli_2025_final_hybrid Qdrant collection's Bali-block fields in place.
+
+WHY in-place (no re-embed): only the L4-Bali verdict changed, not the embedding text.
+Re-embedding 4424 chunks would cost OpenAI calls and risk reshaping the (untracked)
+chunked {text, metadata-nested} format. We only rewrite metadata.bali_blocked /
+bali_status / bali_reason per chunk, using the OFFICIAL per-scala-Besar rule.
+
+Chunk model (discovered by inspecting the live collection):
+  - chunk_type="per_skala": one chunk per (kode x scala-group). Carries
+    metadata.skala_usaha (list) + metadata.kategori_risiko (that group's risk).
+  - chunk_type="uraian": the per-code parent chunk.
+
+Rule (per-scala-Besar, decided by Zero):
+  - A PMA is scale Besar by law -> only the Besar risk row matters.
+  - per_skala chunk whose skala_usaha includes "Besar":
+        blocked = risk in {Rendah, Menengah Rendah}
+  - per_skala chunk WITHOUT Besar (pure Mikro/Kecil/Menengah, UMKM scales a PMA
+        cannot use): blocked = False, reason "non-PMA scale".
+  - uraian (parent) chunk: use the code-level verdict from the L2 dataset
+        (BLOCKED / AMBIGUOUS / OPEN), so the parent reflects the whole-code answer.
+
+Idempotent: running twice yields the same payloads. Dry-run prints the diff counts
+and a sample without writing.
+
+Usage:
+    QDRANT_URL=... QDRANT_API_KEY=... python scripts/patch_qdrant_bali_l4.py --dry-run
+    QDRANT_URL=... QDRANT_API_KEY=... python scripts/patch_qdrant_bali_l4.py --apply
+"""
+import argparse
+import json
+import os
+import sys
+from collections import Counter
+from pathlib import Path
+
+import httpx
+
+COLLECTION = "kbli_2025_final_hybrid"
+BLOCK_RISKS = {"rendah", "menengah rendah"}
+# statuses that are NOT risk-derived (closed/restricted lists) -> never overwrite
+PRESERVE_STATUSES = {"TERTUTUP", "TERBATAS", "CHIUSO_BALI", "CHIUSO_BALI_PROPOSTO",
+                     "TERTUTUP_CANDIDATE", "TERBATAS_CANDIDATE"}
+L2_DATASET = Path("/tmp/kbli-l2-risk/data/source_documents/KBLI_2025_FINAL_CLEAN.json")
+
+REASON_BLOCKED = "OSS risk at scale Besar is Rendah/Menengah-Rendah -> Bali moratorium 13/5/26 blocks PMA"
+REASON_OPEN = "OSS risk at scale Besar is Menengah-Tinggi/Tinggi -> not blocked by moratorium"
+REASON_AMBIG = ("OSS risk at scale Besar is low on some scope but higher on others -> "
+                "registrable as PMA only by declaring the higher-risk scope (verify live OSS)")
+REASON_NONPMA = "non-PMA scale (PMA operates at scale Besar by law); chunk informational only"
+REASON_NO_BESAR = ("OSS has no Usaha Besar scale row -> activity reserved for UMKM "
+                   "(Perpres 49/2021 Annex II); a PT PMA (Besar by law) cannot register it")
+REASON_NEEDS_REVIEW = ("no OSS-RBA scope (special/sectoral regime: OJK/BI/BPOM/etc.) -> "
+                       "Bali registrability needs manual sectoral verification")
+
+
+def code_verdict_map():
+    """kode -> code-level verdict from the L2 dataset.
+
+    Uses l4_bali.verdict when present (BLOCKED/AMBIGUOUS/OPEN/NO_BESAR). For the
+    no-OSS-scope special-regime codes (no verdict, status relabelled), maps to the
+    synthetic verdict "NEEDS_REVIEW" so the parent chunk reflects it.
+    """
+    ds = json.loads(L2_DATASET.read_text(encoding="utf-8"))
+    out = {}
+    for rec in ds["data"]:
+        code = str(rec.get("kode_kbli_2025") or "")
+        if not code:
+            continue
+        v = (rec.get("l4_bali") or {}).get("verdict")
+        if v:
+            out[code] = v
+        elif (rec.get("l4_bali") or {}).get("status") == "NEEDS_REVIEW_NO_OSS_SCOPE":
+            out[code] = "NEEDS_REVIEW"
+    return out
+
+
+def chunk_bali(md, verdicts):
+    """Return (blocked, status, reason) or None if the chunk must be left untouched."""
+    ct = md.get("chunk_type")
+    kode = str(md.get("kode") or md.get("kode_kbli_2025") or "")
+    # never overwrite a non-risk-derived status (TERTUTUP/TERBATAS/closed lists)
+    if (md.get("bali_status") or "") in PRESERVE_STATUSES:
+        return None
+    if ct == "uraian":
+        v = verdicts.get(kode, "OPEN")
+        if v == "BLOCKED":
+            return True, "BLOCCATO_CLASSE_RISCHIO", REASON_BLOCKED
+        if v == "AMBIGUOUS":
+            return False, "BLOCCATO_DIPENDE_SCOPE", REASON_AMBIG
+        if v == "NO_BESAR":
+            return True, "CHIUSO_PMA_NO_BESAR", REASON_NO_BESAR
+        if v == "NEEDS_REVIEW":
+            return True, "NEEDS_REVIEW_NO_OSS_SCOPE", REASON_NEEDS_REVIEW
+        return False, "OK_or_HIGHER_RISK", REASON_OPEN
+    # per_skala chunk
+    skala = md.get("skala_usaha") or []
+    risk = (md.get("kategori_risiko") or "").strip().lower()
+    if "Besar" in skala:
+        blocked = risk in BLOCK_RISKS
+        if blocked:
+            return True, "BLOCCATO_CLASSE_RISCHIO", REASON_BLOCKED
+        return False, "OK_or_HIGHER_RISK", REASON_OPEN
+    # pure non-Besar scales: a PMA cannot use them
+    return False, "OK_NON_PMA_SCALE", REASON_NONPMA
+
+
+def scroll_all(client, url, headers):
+    points = []
+    offset = None
+    while True:
+        body = {"limit": 250, "with_payload": True, "with_vector": False}
+        if offset is not None:
+            body["offset"] = offset
+        r = client.post(f"{url}/collections/{COLLECTION}/points/scroll", json=body, headers=headers)
+        r.raise_for_status()
+        res = r.json()["result"]
+        points.extend(res["points"])
+        offset = res.get("next_page_offset")
+        if offset is None:
+            break
+    return points
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+    if not args.apply and not args.dry_run:
+        args.dry_run = True
+
+    url = os.environ["QDRANT_URL"].rstrip("/")
+    key = os.environ.get("QDRANT_API_KEY", "")
+    headers = {"Content-Type": "application/json"}
+    if key:
+        headers["api-key"] = key
+
+    verdicts = code_verdict_map()
+    print(f"L2 dataset: {len(verdicts)} code-level verdicts loaded")
+
+    with httpx.Client(timeout=120) as client:
+        points = scroll_all(client, url, headers)
+        print(f"scrolled {len(points)} live points from {COLLECTION}")
+
+        changes = []           # (id, full_new_metadata, kode, old_status, new_status)
+        stat_old = Counter()
+        stat_new = Counter()
+        ct_count = Counter()
+        for p in points:
+            md = p.get("payload", {}).get("metadata", {})
+            ct_count[md.get("chunk_type")] += 1
+            old_blocked = md.get("bali_blocked")
+            old_status = md.get("bali_status")
+            stat_old[bool(old_blocked)] += 1
+            verdict = chunk_bali(md, verdicts)
+            if verdict is None:
+                stat_new["preserved"] += 1
+                continue
+            new_blocked, new_status, new_reason = verdict
+            stat_new[new_blocked] += 1
+            if old_blocked != new_blocked or old_status != new_status:
+                # CRITICAL: Qdrant set_payload REPLACES the whole `metadata` object
+                # (no deep-merge — verified by round-trip test that wiped 16 fields).
+                # So we must rewrite the FULL metadata: existing fields + new bali_*.
+                full_md = dict(md)
+                full_md["bali_blocked"] = new_blocked
+                full_md["bali_status"] = new_status
+                full_md["bali_reason"] = new_reason
+                changes.append((p["id"], full_md, md.get("kode"), old_status, new_status))
+
+        print(f"chunk_type distribution: {dict(ct_count)}")
+        print(f"OLD bali_blocked: {dict(stat_old)}")
+        print(f"NEW bali_blocked: {dict(stat_new)}")
+        print(f"CHANGES: {len(changes)} chunks change verdict")
+        flip_to_open = sum(1 for c in changes if not c[4].startswith("BLOCCATO_C"))
+        flip_to_blocked = sum(1 for c in changes if c[4] == "BLOCCATO_CLASSE_RISCHIO")
+        print(f"  -> now NOT classe-blocked: {flip_to_open}")
+        print(f"  -> now classe-blocked: {flip_to_blocked}")
+        for cid, full_md, kode, os_, ns in changes[:15]:
+            print(f"    {kode}: {os_} -> {ns}")
+
+        if not args.apply:
+            print("\n(dry-run — pass --apply to write FULL-metadata set_payload to the live collection)")
+            return
+
+        # apply: rewrite the FULL metadata per changed point (set_payload replaces metadata).
+        # one point per call to be safe (full metadata differs per point).
+        print(f"\nAPPLYING full-metadata set_payload to {len(changes)} chunks (one per call)...")
+        applied = 0
+        for cid, full_md, kode, _, _ in changes:
+            payload = {"payload": {"metadata": full_md}, "points": [cid]}
+            r = client.post(
+                f"{url}/collections/{COLLECTION}/points/payload",
+                json=payload, headers=headers,
+            )
+            if r.status_code != 200:
+                print(f"  ERROR set_payload on {cid} ({kode}): {r.status_code} {r.text[:200]}")
+                sys.exit(1)
+            applied += 1
+            if applied % 250 == 0:
+                print(f"  patched {applied}/{len(changes)}")
+        print(f"\nDONE. {applied} chunks patched in {COLLECTION}.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Clean rebase replacing #1596 (which conflicted on the 28 MB dataset because #1592 merged squashed). Same content, no conflict. Combines the full **L2 OSS re-anchor** + the **85 needs_review resolution** into one dataset state that **exactly matches the live Qdrant collection** (already patched in place).

## The rule

L4-Bali moratorium uses **per-scala-Besar**: a PT PMA is scale Besar by law → only the Besar risk row matters. Verified against real OSS tests (46494 blocked, 62209 open, etc.).

## Final taxonomy (1559 codes — dataset + Qdrant identical)

| Status | Codes | Meaning |
|---|---|---|
| OK_or_HIGHER_RISK | 1014 | Besar risk Menengah-Tinggi/Tinggi → registrable |
| BLOCCATO_CLASSE_RISCHIO | 373 | Besar low on every scope → moratorium block |
| BLOCCATO_DIPENDE_SCOPE | 70 | low on some scope → passable via higher-risk scope (PPMSE) |
| NEEDS_REVIEW_NO_OSS_SCOPE | 63 | special regime (OJK/BI/narcotics/radioactive) — sectoral check |
| CHIUSO_PMA_NO_BESAR | 20 | no Besar row → reserved UMKM (55203 Vila, 79903 guide, 96210 barber…) |
| TERTUTUP/TERBATAS/CHIUSO_BALI | 19 | closed-list, preserved |

## Notes

- `per_skala` rebuilt from official OSS `KbliResikos` (1296/1338 were incomplete).
- Extraction/build/patch scripts land under `apps/backend-rag/scripts/` for reuse.
- Qdrant `kbli_2025_final_hybrid` already patched in place: 4424 points, zero corruption, all casi-verità correct.
- Two earlier client-facing errors fixed: NO_BESAR codes (villa/guide/barber) were wrongly "open"; NO_SCOPE special-regime codes had a fictitious risk-block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)