### PR TITLE
fix(connectome): align 5 false-REGRESSED edges to BY_DESIGN_OFF

### DIFF
--- a/docs/connectome/edges/launchd-pro.yaml
+++ b/docs/connectome/edges/launchd-pro.yaml
@@ -298,7 +298,8 @@ edges:
       id: com.nuzantara.codex-spark-loop,
       kind: launchd,
       machine: pro,
-      status: ALIVE,
+      status: BY_DESIGN_OFF,
+      notes: "disabled W81 firebreak 2026-06-15 (.plist.disabled-W81)",
     }
   - { id: com.balizero.wa-viewer, kind: launchd, machine: pro, status: ALIVE }
   - {
@@ -416,8 +417,9 @@ edges:
       id: com.nuzantara.codex-spark-harvester,
       kind: launchd,
       machine: pro,
-      status: ALIVE,
+      status: BY_DESIGN_OFF,
       producer: "180s",
+      notes: "disabled W81 firebreak 2026-06-15 (.plist.disabled-W81)",
     }
   - {
       id: com.nuzantara.merge-train,
@@ -993,8 +995,9 @@ edges:
       id: com.balizero.l5-2-phase2b-trigger,
       kind: launchd,
       machine: pro,
-      status: ALIVE,
+      status: BY_DESIGN_OFF,
       producer: "daily 9:00",
+      notes: "unloaded; target l5_2_phase2b_auto_analyzer.py removed from repo — retired 2026-06-20, restore script before re-arming",
       oneshot_sentinel: "~/.agent/l5-2-phase2b-fired.sentinel",
     }
   - {
@@ -1043,15 +1046,17 @@ edges:
       id: com.nuzantara.codex-overnight-feeder,
       kind: launchd,
       machine: pro,
-      status: ALIVE,
+      status: BY_DESIGN_OFF,
       producer: "daily 21:30",
+      notes: "disabled W81 firebreak 2026-06-15 (.plist.disabled-W81)",
     }
   - {
       id: com.nuzantara.codex-overnight-runner,
       kind: launchd,
       machine: pro,
-      status: ALIVE,
+      status: BY_DESIGN_OFF,
       producer: "daily 22:00",
+      notes: "disabled W81 firebreak 2026-06-15 (.plist.disabled-W81)",
     }
   - {
       id: com.nuzantara.automations-reference,


### PR DESCRIPTION
verify-connectome flagged 5 launchd edges REGRESSED (declared ALIVE, label not loaded). All 5 are intentionally-off, not broken:
- 4 codex-* (spark-loop/harvester, overnight-feeder/runner) = .plist.disabled-W81 firebreak (2026-06-15)
- l5-2-phase2b-trigger = target script l5_2_phase2b_auto_analyzer.py removed from repo

Cure = align declaration to reality (status ALIVE→BY_DESIGN_OFF + notes), NOT re-arm. **verify_connectome.py now exits 0** (was 1), zero REGRESSED. Closes the 5 false alarms that drown the real REGRESSED signal (meta-pattern superscar #2 'declaration ≠ execution').

🤖 Generated with [Claude Code](https://claude.com/claude-code)