### PR TITLE
feat(kbli): render Bali L4 badge for 3 unmapped statuses (153 silent codes)

### DIFF
--- a/apps/mouth/src/components/kbli/BaliStatusBadge.tsx
+++ b/apps/mouth/src/components/kbli/BaliStatusBadge.tsx
@@ -6,6 +6,9 @@ import { cn } from "@/lib/utils";
 export type BaliStatus =
   | "OK_or_HIGHER_RISK"
   | "BLOCCATO_CLASSE_RISCHIO"
+  | "BLOCCATO_DIPENDE_SCOPE"
+  | "CHIUSO_PMA_NO_BESAR"
+  | "NEEDS_REVIEW_NO_OSS_SCOPE"
   | "CHIUSO_BALI"
   | "CHIUSO_BALI_PROPOSTO"
   | "TERTUTUP"
@@ -31,12 +34,48 @@ const config: Record<
     icon: "🚫",
     tone: "block",
   },
+  // Besar-scale risk is low on some ruang lingkup but higher on others: OSS computes
+  // risk per (code × scope × scale), so registrability depends on the declared scope.
+  // (deep research 2026-06-20: rejection is on "tingkat risiko", not on the code.)
+  BLOCCATO_DIPENDE_SCOPE: {
+    label: "Conditional in Bali — depends on declared scope",
+    icon: "⚠️",
+    tone: "warn",
+  },
+  // No Usaha Besar scale row in OSS → activity reserved for cooperatives/MSME under
+  // Perpres 10/2021 (amended 49/2021), Lampiran II Pasal 5(1)(a). A PT PMA is Usaha
+  // Besar by law (UU 6/2023 + Permeninves 5/2025) and cannot register it.
+  CHIUSO_PMA_NO_BESAR: {
+    label: "Reserved for MSME — closed to PT PMA",
+    icon: "🚫",
+    tone: "block",
+  },
+  // No OSS-RBA risk scope at all (404): special/sectoral regime — finance (OJK/BI),
+  // pharma (BPOM), and other sensitive activities licensed outside the ordinary RBA
+  // flow. Not mechanically caught by the low-risk Bali block → verify case-by-case.
+  NEEDS_REVIEW_NO_OSS_SCOPE: {
+    label: "Special regime — verify case-by-case",
+    icon: "❓",
+    tone: "warn",
+  },
   CHIUSO_BALI: { label: "Closed for PMA in Bali", icon: "🚫", tone: "block" },
-  CHIUSO_BALI_PROPOSTO: { label: "Closure proposed (Bali)", icon: "⚠️", tone: "warn" },
+  CHIUSO_BALI_PROPOSTO: {
+    label: "Closure proposed (Bali)",
+    icon: "⚠️",
+    tone: "warn",
+  },
   TERTUTUP: { label: "Closed to foreigners", icon: "🚫", tone: "block" },
   TERBATAS: { label: "Restricted (foreign cap)", icon: "⚠️", tone: "warn" },
-  TERTUTUP_CANDIDATE: { label: "Likely closed — verify", icon: "❓", tone: "warn" },
-  TERBATAS_CANDIDATE: { label: "Likely restricted — verify", icon: "❓", tone: "warn" },
+  TERTUTUP_CANDIDATE: {
+    label: "Likely closed — verify",
+    icon: "❓",
+    tone: "warn",
+  },
+  TERBATAS_CANDIDATE: {
+    label: "Likely restricted — verify",
+    icon: "❓",
+    tone: "warn",
+  },
 };
 
 const toneClass = {


### PR DESCRIPTION
## What

The KBLI navigator already grafts `baliL4` (PR #1585) and renders `BaliStatusBadge`, but the badge config mapped only **8 of the 11** L4 statuses now live in the dataset. The 3 statuses introduced by the L2/L4 OSS-risk re-anchor (per-scala-Besar rule, PRs #1592/#1598) had no config entry, so `if (!c) return null` produced **NO Bali badge for 153 codes**:

| Status | Codes |
|---|---|
| `BLOCCATO_DIPENDE_SCOPE` | 70 |
| `NEEDS_REVIEW_NO_OSS_SCOPE` | 63 |
| `CHIUSO_PMA_NO_BESAR` | 20 |

For those 153, the page showed the national PMA badge with **no Bali caveat** — the exact client-facing error the L4 layer exists to prevent (national openness ≠ Bali registrability). Now all 9 live statuses render.

## Labels are anchored to deep research (2026-06-20), not invented

- **DIPENDE_SCOPE** → *"Conditional in Bali — depends on declared scope"*. OSS computes risk per (code × ruang lingkup × scale); the Bali rejection is on *"tingkat risiko"*, not on the code → declaring a higher-risk scope can pass.
- **CHIUSO_PMA_NO_BESAR** → *"Reserved for MSME — closed to PT PMA"*. No Usaha Besar scale row = reserved for cooperatives/MSME, **Perpres 10/2021 (amended 49/2021) Lampiran II Pasal 5(1)(a)**; a PT PMA is Usaha Besar by law (UU 6/2023 + Permeninves 5/2025) and cannot register it.
- **NEEDS_REVIEW_NO_OSS_SCOPE** → *"Special regime — verify case-by-case"*. No OSS-RBA risk scope at all (404): finance (OJK/BI), pharma (BPOM), and other sensitive activities licensed outside the ordinary RBA flow; not mechanically caught by the low-risk Bali block.

## Why no data change

Verified against the OSS raw fetch: all 63 `NEEDS_REVIEW` codes genuinely return 404 (no RBA scope). Their `per_skala` is legacy non-OSS data (`_l2_source: none`) — the exact "fictitious verdict" the L2/L4 builder correctly declined to trust. **The dataset classification is correct; only the badge was silent.** No data/Qdrant change.

## Verification

- `tsc --noEmit` clean
- 0 codes left without a Bali badge (was 153)
- pre-push backend suite: 15348 passed / 852 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)