### PR TITLE
fix(intake): pad undersized pages before qwen2.5vl OCR — unfreeze intake tail

### DIFF
--- a/apps/backend-rag/backend/services/intake/classify.py
+++ b/apps/backend-rag/backend/services/intake/classify.py
@@ -195,6 +195,41 @@ def _heuristic_confidence(text: str) -> float:
     return round(max(0.0, base - penalty), 3)
 
 
+# qwen2.5vl in Ollama (>=0.20.x) panics in SmartResize when an image dimension
+# is below the patch factor (28px): "height:N or width:N must be larger than
+# factor:28" -> the runner crashes -> HTTP 500 -> the whole job stalls at
+# ocr_done with chars=0 (SCAR 2026-06-20: this silently froze the intake tail
+# for 33h). Pad any too-small page up to MIN_OCR_DIM before sending to the VLM.
+MIN_OCR_DIM = 32  # one patch above the 28px factor, safe margin
+
+
+def _ensure_min_size(png: bytes) -> bytes:
+    """Pad a PNG so both dimensions are >= MIN_OCR_DIM. No-op if already large
+    enough or if PIL/parse fails (degrade to original bytes, never crash)."""
+    try:
+        import io
+
+        from PIL import Image
+
+        with Image.open(io.BytesIO(png)) as im:
+            w, h = im.size
+            if w >= MIN_OCR_DIM and h >= MIN_OCR_DIM:
+                return png
+            new_w, new_h = max(w, MIN_OCR_DIM), max(h, MIN_OCR_DIM)
+            canvas = Image.new("RGB", (new_w, new_h), (255, 255, 255))
+            canvas.paste(im.convert("RGB"), (0, 0))
+            out = io.BytesIO()
+            canvas.save(out, format="PNG")
+            logger.info(
+                "intake OCR padded undersized page %dx%d -> %dx%d (avoids qwen25vl SmartResize panic)",
+                w, h, new_w, new_h,
+            )
+            return out.getvalue()
+    except Exception as exc:  # never let padding break OCR
+        logger.warning("intake OCR _ensure_min_size skipped: %s", exc)
+        return png
+
+
 async def ocr_pages(pages: list[Any]) -> list[dict[str, Any]]:
     """OCR each preprocessed page LOCALLY. Returns one dict per page.
 
@@ -240,7 +275,7 @@ async def ocr_pages(pages: list[Any]) -> list[dict[str, Any]]:
             )
             continue
 
-        b64 = base64.b64encode(png).decode("ascii")
+        b64 = base64.b64encode(_ensure_min_size(png)).decode("ascii")
 
         text = ""
         via = "empty"
@@ -526,7 +561,7 @@ async def _vision_classify_first_page(png_bytes: bytes) -> str | None:
     non-conforming answer degrades to None (caller keeps "unknown").
     """
     try:
-        b64 = base64.b64encode(png_bytes).decode("ascii")
+        b64 = base64.b64encode(_ensure_min_size(png_bytes)).decode("ascii")
         resp, thinking = await asyncio.wait_for(
             _ollama_vision(
                 _VISION_CLASSIFY_MODEL,


### PR DESCRIPTION
qwen2.5vl in Ollama >=0.20.x panics in SmartResize on image dims below the 28px patch factor → runner crash → HTTP 500 → page chars=0 → job stalls at ocr_done. **Silently froze the intake tail ~33h** (0 rows to done since 2026-06-19 14:05; 12.6k pending). Reproduced live: 8x8 PNG→500, 64x64→200.

Fix: `_ensure_min_size()` pads pages <32px before base64 at both VLM call sites. Degrades to original on PIL error. Verified 8x8→32x32, 64x64 no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)