### PR TITLE
feat(wa-inbox): wire bot auto-reply via RAG (Option B, flag-gated)

### DIFF
--- a/apps/backend-rag/backend/app/main_api.py
+++ b/apps/backend-rag/backend/app/main_api.py
@@ -22,17 +22,23 @@ init_sentry()
 logger = logging.getLogger("zantara.backend")
 
 
-async def _wa_bot_generate_not_implemented(_thread: object) -> str:
-    """v1 bot generator: not wired yet (human-send-only scope).
+def _make_wa_bot_generate(app: FastAPI):
+    """Build the bot_generate_fn for the wa_outbox scheduler.
 
-    The WA Meta inbox v1 ships SEND for operator-typed replies only. Bot
-    auto-reply (RAG generation) is a follow-up PR. A ``needs_generation`` row
-    should not exist in v1 (the webhook only enqueues bot replies when the bot
-    path is active), but if one does, this raises and the outbox worker marks
-    it failed/retry — it is NEVER left orphaned (worker has a guard around
-    bot_generate_fn). See docs/superpowers/specs/2026-06-04-wa-outbox-scheduler.md.
+    v1.1 (Option B): wires the RAG orchestrator so the Meta-inbox bot actually
+    auto-replies. Gated behind the WA_INBOX_BOT_AUTOREPLY flag inside
+    generate_bot_reply — when off, it raises and the worker marks the row
+    failed/retry (never a wrong send), preserving v1 behaviour by default.
+
+    The pool is bound here via closure because process_outbox_once passes only
+    the thread row to bot_generate_fn.
     """
-    raise NotImplementedError("wa-inbox bot auto-reply not enabled in v1")
+    from backend.services.integrations.wa_inbox_bot import generate_bot_reply
+
+    async def _bot_generate(thread: object) -> str:
+        return await generate_bot_reply(app.state.db_pool, thread)
+
+    return _bot_generate
 
 
 async def _run_wa_outbox_scheduler(app: FastAPI) -> None:
@@ -48,11 +54,12 @@ async def _run_wa_outbox_scheduler(app: FastAPI) -> None:
 
     interval = float(os.getenv("WA_OUTBOX_POLL_SECONDS", "3"))
     pool = app.state.db_pool
+    bot_generate_fn = _make_wa_bot_generate(app)
     logger.info("✅ WA outbox scheduler started (poll=%ss)", interval)
     while True:
         try:
             status = await process_outbox_once(
-                pool, whatsapp_service, _wa_bot_generate_not_implemented
+                pool, whatsapp_service, bot_generate_fn
             )
             # Drain fast while sending, but always yield the loop (sleep(0)
             # would not starve asyncio, but a tiny throttle is safer under a
@@ -138,6 +145,9 @@ async def lifespan_light(app: FastAPI):
     from backend.app.rag_proxy import close_proxy_client
 
     await close_proxy_client()
+    from backend.services.integrations.wa_inbox_bot import close_rag_client
+
+    await close_rag_client()
 
 
 def create_api_app() -> FastAPI:

--- a/apps/backend-rag/backend/services/integrations/wa_inbox_bot.py
+++ b/apps/backend-rag/backend/services/integrations/wa_inbox_bot.py
@@ -1,0 +1,197 @@
+"""WA Meta-inbox bot reply generator (Option B — RAG auto-reply).
+
+The wa_outbox scheduler (``main_api.py::_run_wa_outbox_scheduler``) drains the
+send-queue and, for rows with ``needs_generation = true``, calls a
+``bot_generate_fn(thread) -> str`` to produce the reply text. v1 shipped a
+``NotImplementedError`` sentinel (human-send only). This module is the v1.1
+follow-up the spec named "Option B": generate the reply via the RAG
+orchestrator and return its text.
+
+Architecture (Fly process groups):
+    The scheduler runs on the ``api`` process group, which does NOT host the
+    RAG orchestrator in-process (that lives on the ``rag`` group). So we reach
+    it over Fly's private network via HTTP — the SAME hop the rag_proxy uses
+    (``RAG_WORKER_URL`` → ``POST /api/agentic-rag/query``). This is the exact
+    path the live WhatsApp webhook channel uses for non-Meta-inbox numbers
+    (``whatsapp_chat.py`` → ``orchestrator.process_query``), just over HTTP
+    instead of in-process because of the group split.
+
+Safety contract (mirrors the worker's expectations in wa_outbox_worker.py):
+    * Feature flag ``WA_INBOX_BOT_AUTOREPLY`` (default OFF) — when off, this
+      raises so the worker marks the row failed/retry, NEVER a wrong send. Arm
+      it via a Fly secret only when ready.
+    * On ABSTAIN or any RAG error → raise. The worker has a retry/backoff guard
+      (MAX_ATTEMPTS) and then marks ``failed`` — the operator can take over the
+      thread. We NEVER fabricate a reply or send an empty/placeholder body.
+    * The 24h Meta customer-care window is enforced by the worker AFTER us, so
+      we do not re-check it here.
+
+Reference spec: docs/superpowers/specs/2026-06-04-wa-outbox-scheduler.md
+(§ bot_generate_fn — v1 scope decision, Option B).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+import asyncpg
+import httpx
+
+from backend.app.rag_proxy import get_rag_worker_url
+
+logger = logging.getLogger("zantara.backend")
+
+# How many prior turns of the thread to feed the orchestrator as context.
+_HISTORY_TURNS = 12
+
+# Persistent client (Golden Rule #10 — never per-call). Bounded timeout: the
+# agentic RAG path with tool calls can take a while, but the scheduler tick must
+# not hang forever — cap at 120s (read) so a stuck RAG cannot wedge the drainer.
+_rag_client: httpx.AsyncClient | None = None
+_rag_client_lock = asyncio.Lock()
+
+
+def is_bot_autoreply_enabled() -> bool:
+    """True only when the Fly secret WA_INBOX_BOT_AUTOREPLY is truthy.
+
+    Default OFF so deploying this code does not silently start auto-replying.
+    Arm with: ``fly secrets set WA_INBOX_BOT_AUTOREPLY=true -a nuzantara-rag``.
+    Kill-switch: unset it (or set to false) — takes effect on next restart.
+    """
+    return os.getenv("WA_INBOX_BOT_AUTOREPLY", "false").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+async def _get_rag_client() -> httpx.AsyncClient:
+    global _rag_client
+    if _rag_client is None or _rag_client.is_closed:
+        async with _rag_client_lock:
+            if _rag_client is None or _rag_client.is_closed:
+                _rag_client = httpx.AsyncClient(
+                    base_url=get_rag_worker_url(),
+                    timeout=httpx.Timeout(120.0, connect=10.0),
+                    limits=httpx.Limits(max_connections=10, max_keepalive_connections=5),
+                )
+    return _rag_client
+
+
+async def close_rag_client() -> None:
+    """Close the persistent client on shutdown (mirror rag_proxy.close_proxy_client)."""
+    global _rag_client
+    if _rag_client and not _rag_client.is_closed:
+        await _rag_client.aclose()
+        _rag_client = None
+
+
+async def _load_thread_context(
+    pool: asyncpg.Pool, thread_id: int
+) -> tuple[str, list[dict[str, str]]]:
+    """Return (latest_customer_text, conversation_history) for a thread.
+
+    History is oldest→newest, mapped to the orchestrator's {role, content}
+    shape: customer→user, bot/human→assistant. The latest customer message is
+    the query; it is EXCLUDED from history so it is not duplicated.
+    """
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT direction, sender_role, body, created_at
+            FROM meta_inbox_messages
+            WHERE thread_id = $1 AND body IS NOT NULL AND body <> ''
+            ORDER BY created_at DESC, id DESC
+            LIMIT $2
+            """,
+            thread_id,
+            _HISTORY_TURNS + 1,
+        )
+
+    # rows are newest→oldest; find the latest inbound customer message = query.
+    latest_query = ""
+    query_idx = -1
+    for idx, r in enumerate(rows):
+        if r["direction"] == "inbound" and r["sender_role"] == "customer":
+            latest_query = r["body"]
+            query_idx = idx
+            break
+
+    # Build history oldest→newest, excluding the query row.
+    history: list[dict[str, str]] = []
+    for idx in range(len(rows) - 1, -1, -1):
+        if idx == query_idx:
+            continue
+        r = rows[idx]
+        role = "user" if r["sender_role"] == "customer" else "assistant"
+        history.append({"role": role, "content": r["body"]})
+
+    return latest_query, history
+
+
+async def generate_bot_reply(pool: asyncpg.Pool, thread: Any) -> str:
+    """bot_generate_fn for process_outbox_once — produce the reply text.
+
+    Args:
+        pool: asyncpg pool (bound via closure in main_api).
+        thread: asyncpg.Record with thread_id, counterpart_phone (the worker
+            passes the meta_inbox_threads row).
+
+    Returns:
+        The bot reply text to send.
+
+    Raises:
+        RuntimeError: feature flag off, no customer message, RAG abstained, or
+            RAG returned an empty answer. The worker's guard turns this into a
+            retry/backoff and eventually ``failed`` — never a wrong send.
+        httpx errors propagate (also caught by the worker guard) → retry.
+    """
+    if not is_bot_autoreply_enabled():
+        raise RuntimeError("wa-inbox bot auto-reply disabled (WA_INBOX_BOT_AUTOREPLY off)")
+
+    thread_id = thread["thread_id"]
+    phone = thread["counterpart_phone"]
+
+    query, history = await _load_thread_context(pool, thread_id)
+    if not query:
+        raise RuntimeError(f"wa-inbox bot: no customer message in thread {thread_id}")
+
+    payload = {
+        "query": query,
+        "user_id": f"whatsapp_{phone}",
+        "session_id": f"wa_meta_session_{thread_id}",
+        "conversation_history": history,
+        "channel": "whatsapp",
+    }
+
+    client = await _get_rag_client()
+    resp = await client.post("/api/agentic-rag/query", json=payload)
+    resp.raise_for_status()
+    data = resp.json()
+
+    if data.get("abstain"):
+        # RAG refused — do not guess. Let the worker park it; operator can take over.
+        raise RuntimeError(
+            f"wa-inbox bot: RAG abstained for thread {thread_id} "
+            f"(reason={data.get('abstain_reason')!r})"
+        )
+
+    answer = (data.get("answer") or "").strip()
+    if not answer:
+        raise RuntimeError(f"wa-inbox bot: empty RAG answer for thread {thread_id}")
+
+    # Strip an [ESCALATE] marker if the persona emitted one (mirror whatsapp_chat.py).
+    answer = answer.replace("[ESCALATE]", "").strip()
+    if not answer:
+        raise RuntimeError(f"wa-inbox bot: answer empty after ESCALATE strip, thread {thread_id}")
+
+    logger.info(
+        "wa-inbox bot generated reply for thread %s (%d chars)",
+        thread_id,
+        len(answer),
+    )
+    return answer

--- a/apps/backend-rag/backend/tests/unit/services/test_wa_inbox_bot.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_wa_inbox_bot.py
@@ -1,0 +1,149 @@
+"""Tests for the WA Meta-inbox bot reply generator (generate_bot_reply).
+
+Covers the Option-B safety contract:
+  - feature flag OFF (default) → raises (worker marks failed/retry, no send).
+  - no customer message in thread → raises.
+  - RAG abstain → raises (never guess).
+  - empty RAG answer → raises.
+  - happy path → returns the RAG answer, sends the correct payload to the
+    RAG worker (query = latest customer msg, history oldest→newest, channel).
+  - [ESCALATE] marker stripped from the answer.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.services.integrations import wa_inbox_bot
+
+
+class _Conn:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    async def fetch(self, sql: str, *args: Any) -> list[dict[str, Any]]:
+        return self._rows
+
+
+class _Pool:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._conn = _Conn(rows)
+
+    def acquire(self) -> Any:
+        @asynccontextmanager
+        async def _cm():
+            yield self._conn
+
+        return _cm()
+
+
+def _thread(thread_id: int = 7, phone: str = "62811") -> dict[str, Any]:
+    return {"thread_id": thread_id, "counterpart_phone": phone}
+
+
+def _mock_rag(monkeypatch, response_json: dict[str, Any]) -> dict[str, Any]:
+    """Patch the persistent RAG client; return a captured dict for assertions."""
+    captured: dict[str, Any] = {}
+
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock(return_value=None)
+    resp.json = MagicMock(return_value=response_json)
+
+    async def _post(url: str, json: dict[str, Any]) -> Any:
+        captured["url"] = url
+        captured["json"] = json
+        return resp
+
+    client = MagicMock()
+    client.post = AsyncMock(side_effect=_post)
+
+    async def _get_client() -> Any:
+        return client
+
+    monkeypatch.setattr(wa_inbox_bot, "_get_rag_client", _get_client)
+    return captured
+
+
+# newest→oldest as the SQL ORDER BY DESC returns them.
+_ROWS_NEWEST_FIRST = [
+    {"direction": "inbound", "sender_role": "customer", "body": "Quanto costa un KITAS?"},
+    {"direction": "outbound", "sender_role": "bot", "body": "Ciao! Come posso aiutarti?"},
+    {"direction": "inbound", "sender_role": "customer", "body": "Ciao"},
+]
+
+
+@pytest.mark.asyncio
+async def test_flag_off_raises(monkeypatch):
+    monkeypatch.delenv("WA_INBOX_BOT_AUTOREPLY", raising=False)
+    pool = _Pool(_ROWS_NEWEST_FIRST)
+    with pytest.raises(RuntimeError, match="disabled"):
+        await wa_inbox_bot.generate_bot_reply(pool, _thread())
+
+
+@pytest.mark.asyncio
+async def test_no_customer_message_raises(monkeypatch):
+    monkeypatch.setenv("WA_INBOX_BOT_AUTOREPLY", "true")
+    pool = _Pool([{"direction": "outbound", "sender_role": "bot", "body": "hi"}])
+    with pytest.raises(RuntimeError, match="no customer message"):
+        await wa_inbox_bot.generate_bot_reply(pool, _thread())
+
+
+@pytest.mark.asyncio
+async def test_abstain_raises(monkeypatch):
+    monkeypatch.setenv("WA_INBOX_BOT_AUTOREPLY", "true")
+    _mock_rag(monkeypatch, {"abstain": True, "abstain_reason": "low_evidence", "answer": ""})
+    pool = _Pool(_ROWS_NEWEST_FIRST)
+    with pytest.raises(RuntimeError, match="abstained"):
+        await wa_inbox_bot.generate_bot_reply(pool, _thread())
+
+
+@pytest.mark.asyncio
+async def test_empty_answer_raises(monkeypatch):
+    monkeypatch.setenv("WA_INBOX_BOT_AUTOREPLY", "true")
+    _mock_rag(monkeypatch, {"abstain": False, "answer": "   "})
+    pool = _Pool(_ROWS_NEWEST_FIRST)
+    with pytest.raises(RuntimeError, match="empty RAG answer"):
+        await wa_inbox_bot.generate_bot_reply(pool, _thread())
+
+
+@pytest.mark.asyncio
+async def test_happy_path_returns_answer_and_payload(monkeypatch):
+    monkeypatch.setenv("WA_INBOX_BOT_AUTOREPLY", "true")
+    captured = _mock_rag(
+        monkeypatch,
+        {"abstain": False, "answer": "Il KITAS investitore parte da..."},
+    )
+    pool = _Pool(_ROWS_NEWEST_FIRST)
+
+    answer = await wa_inbox_bot.generate_bot_reply(pool, _thread(thread_id=7, phone="62811"))
+
+    assert answer == "Il KITAS investitore parte da..."
+    sent = captured["json"]
+    # query = the LATEST inbound customer message
+    assert sent["query"] == "Quanto costa un KITAS?"
+    assert sent["channel"] == "whatsapp"
+    assert sent["user_id"] == "whatsapp_62811"
+    assert sent["session_id"] == "wa_meta_session_7"
+    # history oldest→newest, EXCLUDING the query row → ["Ciao"(user), bot(assistant)]
+    hist = sent["conversation_history"]
+    assert hist == [
+        {"role": "user", "content": "Ciao"},
+        {"role": "assistant", "content": "Ciao! Come posso aiutarti?"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_escalate_marker_stripped(monkeypatch):
+    monkeypatch.setenv("WA_INBOX_BOT_AUTOREPLY", "true")
+    _mock_rag(
+        monkeypatch,
+        {"abstain": False, "answer": "Ti metto in contatto col team [ESCALATE]"},
+    )
+    pool = _Pool(_ROWS_NEWEST_FIRST)
+    answer = await wa_inbox_bot.generate_bot_reply(pool, _thread())
+    assert "[ESCALATE]" not in answer
+    assert answer == "Ti metto in contatto col team"

--- a/apps/backend-rag/backend/tests/unit/services/test_wa_outbox_scheduler.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_wa_outbox_scheduler.py
@@ -4,7 +4,9 @@ Covers the panel-2026-06-04 fixes:
   - cadence: sleep ~0.1s after 'sent' (drain fast), full interval after 'idle'.
   - resilience: a raised exception in a tick is logged and the loop continues.
   - cancellation: the loop exits cleanly on CancelledError (shutdown path).
-  - v1 sentinel bot generator raises NotImplementedError (human-send-only).
+  - bot generator (Option B): _make_wa_bot_generate returns a flag-gated
+    closure that raises (RuntimeError) when WA_INBOX_BOT_AUTOREPLY is off —
+    so the worker marks the row failed/retry, never a wrong send (default).
 
 The loop is driven against a fake app whose state.db_pool is a sentinel, with
 process_outbox_once monkeypatched to a scripted sequence of statuses. We cap
@@ -23,9 +25,15 @@ from backend.app import main_api
 
 
 @pytest.mark.asyncio
-async def test_v1_bot_generator_raises_not_implemented() -> None:
-    with pytest.raises(NotImplementedError):
-        await main_api._wa_bot_generate_not_implemented(object())
+async def test_bot_generator_flag_off_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Default (flag off) → the closure raises so the worker never sends a wrong
+    # reply. Option B is opt-in via WA_INBOX_BOT_AUTOREPLY.
+    monkeypatch.delenv("WA_INBOX_BOT_AUTOREPLY", raising=False)
+    app = SimpleNamespace(state=SimpleNamespace(db_pool=object()))
+    bot_fn = main_api._make_wa_bot_generate(app)
+    thread = {"thread_id": 1, "counterpart_phone": "62811"}
+    with pytest.raises(RuntimeError, match="disabled"):
+        await bot_fn(thread)
 
 
 @pytest.mark.asyncio
@@ -62,8 +70,10 @@ async def test_scheduler_cadence_sent_then_idle(monkeypatch: pytest.MonkeyPatch)
     assert sleeps[0] == pytest.approx(0.1)
     assert sleeps[1] == pytest.approx(0.1)
     assert sleeps[2] == pytest.approx(3.0)
-    # the bot generator passed through is the v1 sentinel
-    assert calls[0][2] is main_api._wa_bot_generate_not_implemented
+    # the bot generator passed through is the Option-B closure (callable,
+    # built once and reused for every tick of this scheduler run)
+    assert callable(calls[0][2])
+    assert calls[0][2] is calls[1][2]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The WA Meta-inbox webhook (`whatsapp_chat.py`) enqueues a bot reply
(`wa_outbox needs_generation=true`) for **every** inbound on the official
Business number (`META_INBOX_PHONE_NUMBER_ID`) when the thread is bot-handled.
But v1 shipped a `NotImplementedError` sentinel for `bot_generate_fn`
(human-send-only scope, Option A). Live state on Fly prod (verified):

- **45 customer messages** (3/6→19/6) `received`, **never answered**
- **46 bot-reply rows** all `failed` (audit-trail: "auto-reply not enabled in v1")
- 3 human sends `done`/`delivered`/`read` — the human path works fine

Superscar #11 (producer green, consumer never wired) / #2 (costruito ≠ armato):
the whole pipeline (webhook → enqueue → scheduler → send) is armed except the
generator.

## Fix — Option B from the spec

`docs/superpowers/specs/2026-06-04-wa-outbox-scheduler.md` named this exact
follow-up. New `wa_inbox_bot.generate_bot_reply(pool, thread)`:

- Loads the latest customer message + recent history from the Meta-inbox ledger.
- Calls the RAG orchestrator over the **same Fly private-network hop** the
  rag_proxy uses (`RAG_WORKER_URL` → `POST /api/agentic-rag/query`,
  `channel="whatsapp"`) — the `api` group has no in-process RAG. Mirrors the
  live WhatsApp webhook channel's `orchestrator.process_query` path.
- `main_api.py` swaps the sentinel for a pool-bound, flag-gated closure
  (`_make_wa_bot_generate`).

## Safety

- **Flag-gated** `WA_INBOX_BOT_AUTOREPLY` (default **OFF**) — merging+deploying
  this does NOT start auto-replying. Arm via `fly secrets set
  WA_INBOX_BOT_AUTOREPLY=true -a nuzantara-rag`. Kill-switch by unset.
- **Fail-safe**: ABSTAIN / empty answer / RAG error → raise → worker
  retry/backoff → `failed` (never a wrong or empty send). Operator can take over.
- **No double-reply**: the Meta-inbox number is explicitly excluded from the
  synchronous webhook path (`whatsapp_chat.py:1218-1221`).
- Persistent httpx client (Golden Rule #10), closed in lifespan shutdown.

## Tests

- 6 new (`test_wa_inbox_bot.py`): flag-off / no-msg / abstain / empty /
  happy-payload / escalate-strip
- `test_wa_outbox_scheduler.py` updated for the Option-B closure (4 tests)
- full suite green (the one flaky `test_confirmation_service` ConfirmationTimeout
  is a pre-existing clock-race, passes in isolation — unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)