### PR TITLE
fix(kbli): frame gold licensing steps as national procedure not applicable to PT PMA in Bali

### DIFF
--- a/apps/mouth/src/components/kbli/LicensingSection.tsx
+++ b/apps/mouth/src/components/kbli/LicensingSection.tsx
@@ -723,8 +723,45 @@ export function LicensingSection({ kbli, gold }: LicensingSectionProps) {
   const parsed = gold ? parseWhatYouNeed(gold.whatYouNeed) : null;
   const currentTier = kbli.licensing[activeTier] ?? kbli.licensing[0];
 
+  // When Bali blocks this code for PMA, the licensing steps below are still the
+  // correct NATIONAL procedure (open in Jakarta/Lombok/etc.) — but they must NOT
+  // be read as a how-to for a foreign-owned company IN BALI. Frame, don't hide:
+  // the steps are national truth; the Bali restriction is the local override.
+  const baliBlocked = !!kbli.baliL4?.blocked;
+
   return (
     <div className="space-y-8">
+      {/* ── NATIONAL-vs-BALI FRAME (only when Bali blocks PMA for this code) ── */}
+      {baliBlocked && (
+        <div
+          className="rounded-xl border px-5 py-4"
+          style={{
+            background: "rgba(232, 113, 108, 0.06)",
+            borderColor: "rgba(232, 113, 108, 0.25)",
+          }}
+        >
+          <div className="mb-1.5 flex items-center gap-2">
+            <span aria-hidden="true">🏝️</span>
+            <span
+              className="text-xs font-bold uppercase tracking-[0.12em]"
+              style={{ color: "var(--kbli-pma-closed)" }}
+            >
+              National procedure — does not apply to a PT PMA in Bali
+            </span>
+          </div>
+          <p className="text-sm leading-relaxed text-[var(--foreground-secondary)]">
+            The licensing path below is the <strong>national</strong> procedure,
+            valid for a foreign-owned company outside Bali (e.g. Jakarta). In{" "}
+            <strong>Bali</strong>, this activity is currently{" "}
+            {kbli.baliL4?.status === "CHIUSO_PMA_NO_BESAR"
+              ? "reserved for micro/small/medium enterprises and closed to a PT PMA"
+              : "blocked for a PT PMA under the 13 May 2026 moratorium"}
+            {kbli.baliL4?.reason ? ` — ${kbli.baliL4.reason}` : ""}. See the
+            Bali status badge above before planning a Bali setup.
+          </p>
+        </div>
+      )}
+
       {/* ── KEY FACTS AT A GLANCE ── */}
       <KeyFacts licensing={kbli.licensing} pma={kbli.pma} />
 


### PR DESCRIPTION
## Problem

The 104 gold-tier KBLI codes that are **Bali-blocked for a PT PMA** (`baliL4.blocked`) still rendered a confident national licensing how-to — e.g. `/kbli/55203` (villa rental) taught "PT PMA incorporation" 7 steps even though a foreign-owned company **cannot register that activity in Bali** under the 13 May 2026 moratorium / reserved-for-MSME rule.

`#1605` fixed the **non-gold** path (148 `intel_2026` records rewired grounded). But gold-tier codes read their body from `kbli-gold-all.json` via `getGoldContent()` — a **second source** `#1605` did not touch. So 104 of the 148 still showed the contradiction in the `LicensingSection`.

## Fix (structural, not per-record)

Per Zero's directive — **"il blocco è solo Bali, non nazionale, questo va chiarito"** — the national steps are **TRUE and valid outside Bali** (e.g. Jakarta). The error was presenting them as applicable in Bali. So we **frame**, not hide.

Added a conditional banner in `LicensingSection.tsx`, gated on `kbli.baliL4?.blocked`, rendered above the licensing steps:

> 🏝️ **National procedure — does not apply to a PT PMA in Bali**
> The licensing path below is the national procedure, valid for a foreign-owned company outside Bali. In Bali, this activity is currently {reserved for MSME / blocked under the 13 May 2026 moratorium} — {reason}. See the Bali status badge above before planning a Bali setup.

- Covers **all 104 gold blocked codes today + any future one** (no per-record edit, no parser change, no data mutation).
- `LicensingSection` renders only inside the gold branch; non-gold blocked codes already use the grounded `intel_2026` from `#1605`.
- **Coverage of the 148 contradictions is now complete**: 44 non-gold (#1605) + 104 gold (this PR).

## Verification
- `tsc` 0 errors
- Banner gated correctly on `baliL4?.blocked` (non-blocked gold codes unchanged)
- Pre-commit hooks passed

Follow-up (separate, NOT in this PR): 17 REJECT codes manual-regen, 768 non-core L3 gaps, wiring the 276 core mute codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)