### PR TITLE
fix(crm-guardian): retry DB connect over fly-proxy/WireGuard flap (superscar #8)

### DIFF
--- a/scripts/crm_guardian_gemini_cli_worker.py
+++ b/scripts/crm_guardian_gemini_cli_worker.py
@@ -223,6 +223,48 @@ def _resolve_db_url() -> str:
     )
 
 
+# DB connect retry: this worker reaches Fly Postgres through a long-running flyctl
+# proxy on localhost:15432. When the WireGuard tunnel briefly flaps, asyncpg's
+# single-shot connect raised ConnectionDoesNotExistError mid-handshake and the whole
+# 5-min tick exited 1 (superscar #8 network flap — ~4 spurious FAILs/2.5h observed
+# 2026-06-21). A short bounded retry rides over the transient flap; a genuinely-down
+# proxy still surfaces after the last attempt.
+DB_CONNECT_MAX_ATTEMPTS = int(os.getenv("CRM_GUARDIAN_DB_CONNECT_ATTEMPTS", "4"))
+DB_CONNECT_BASE_DELAY_S = float(os.getenv("CRM_GUARDIAN_DB_CONNECT_BASE_DELAY", "1.0"))
+
+
+async def _connect_with_retry(asyncpg, db_url: str):
+    """Connect to Postgres with bounded exponential-backoff retry on transient
+    connection failures (proxy/WireGuard flap). Re-raises the last error once the
+    attempt budget is exhausted, so a real outage is NOT masked."""
+    exc = asyncpg.exceptions
+    retryable = tuple(
+        c for c in (
+            getattr(exc, "ConnectionDoesNotExistError", None),
+            getattr(exc, "CannotConnectNowError", None),
+            getattr(exc, "ConnectionFailureError", None),
+            getattr(exc, "InterfaceError", None),
+            getattr(exc, "PostgresConnectionError", None),
+        ) if c is not None
+    ) + (ConnectionError, OSError, asyncio.TimeoutError)
+    last_exc: Exception | None = None
+    for attempt in range(1, DB_CONNECT_MAX_ATTEMPTS + 1):
+        try:
+            return await asyncpg.connect(db_url)
+        except retryable as e:
+            last_exc = e
+            if attempt >= DB_CONNECT_MAX_ATTEMPTS:
+                break
+            delay = DB_CONNECT_BASE_DELAY_S * (2 ** (attempt - 1))
+            LOG.warning(
+                "DB connect transient failure attempt %d/%d: %s — retrying in %.1fs",
+                attempt, DB_CONNECT_MAX_ATTEMPTS, type(e).__name__, delay,
+            )
+            await asyncio.sleep(delay)
+    assert last_exc is not None
+    raise last_exc
+
+
 async def fetch_client(conn, client_id: int) -> dict[str, Any] | None:
     """Fetch a CRM client row. Schema canonical 2026-05-17."""
     row = await conn.fetchrow(
@@ -1517,7 +1559,7 @@ async def main() -> int:
     )
 
     db_url = _resolve_db_url()
-    conn = await asyncpg.connect(db_url)
+    conn = await _connect_with_retry(asyncpg, db_url)
 
     if args.client_id:
         targets = [args.client_id]

--- a/scripts/tests/test_crm_guardian_connect_retry.py
+++ b/scripts/tests/test_crm_guardian_connect_retry.py
@@ -1,0 +1,102 @@
+"""2026-06-21 — crm_guardian_gemini_cli_worker DB connect retry (superscar #8).
+
+The worker reaches Fly Postgres through a long-running flyctl proxy on
+localhost:15432. When the WireGuard tunnel flaps, asyncpg's single-shot connect
+raised ConnectionDoesNotExistError mid-handshake and the whole 5-min tick exited 1
+(~4 spurious FAILs/2.5h observed in System Doctor RED 2026-06-21). _connect_with_retry
+rides over the transient flap with bounded exponential backoff, but re-raises once the
+attempt budget is exhausted so a genuine outage is NOT masked.
+
+The worker imports backend.services.crm_guardian.* at module top, so the module is
+loaded via importlib with apps/backend-rag on sys.path. No real DB / asyncpg is
+touched — a fake asyncpg (connect coroutine + exceptions namespace) drives the helper.
+"""
+import asyncio
+import importlib.util
+import os
+import sys
+import types
+
+import pytest
+
+_SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+_ROOT = os.path.dirname(_SCRIPTS_DIR)
+_BACKEND = os.path.join(_ROOT, "apps", "backend-rag")
+
+
+class _ConnDoesNotExist(Exception):
+    """Stand-in for asyncpg.exceptions.ConnectionDoesNotExistError."""
+
+
+@pytest.fixture()
+def worker():
+    for p in (_BACKEND, _SCRIPTS_DIR):
+        if p not in sys.path:
+            sys.path.insert(0, p)
+    spec = importlib.util.spec_from_file_location(
+        "cgw_retry", os.path.join(_SCRIPTS_DIR, "crm_guardian_gemini_cli_worker.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _fake_asyncpg(fail_times: int, exc=_ConnDoesNotExist):
+    """asyncpg double: connect() fails `fail_times`, then returns a sentinel conn."""
+    calls = {"n": 0}
+
+    async def connect(db_url):
+        calls["n"] += 1
+        if calls["n"] <= fail_times:
+            raise exc("transient proxy flap")
+        return f"CONN[{db_url}]"
+
+    ns = types.SimpleNamespace()
+    ns.connect = connect
+    ns.exceptions = types.SimpleNamespace(ConnectionDoesNotExistError=exc)
+    ns._calls = calls
+    return ns
+
+
+class TestConnectWithRetry:
+    def test_recovers_after_transient_flaps(self, worker, monkeypatch):
+        monkeypatch.setattr(worker, "DB_CONNECT_BASE_DELAY_S", 0.0)
+        fake = _fake_asyncpg(fail_times=2)
+        conn = asyncio.run(worker._connect_with_retry(fake, "postgres://x"))
+        assert conn == "CONN[postgres://x]"
+        assert fake._calls["n"] == 3  # 2 flaps + 1 success
+
+    def test_reraises_after_exhausting_attempts(self, worker, monkeypatch):
+        monkeypatch.setattr(worker, "DB_CONNECT_BASE_DELAY_S", 0.0)
+        monkeypatch.setattr(worker, "DB_CONNECT_MAX_ATTEMPTS", 3)
+        fake = _fake_asyncpg(fail_times=99)
+        with pytest.raises(_ConnDoesNotExist):
+            asyncio.run(worker._connect_with_retry(fake, "postgres://x"))
+        assert fake._calls["n"] == 3  # exactly MAX_ATTEMPTS tries, no infinite loop
+
+    def test_succeeds_first_try_no_sleep(self, worker, monkeypatch):
+        monkeypatch.setattr(worker, "DB_CONNECT_BASE_DELAY_S", 0.0)
+        fake = _fake_asyncpg(fail_times=0)
+        conn = asyncio.run(worker._connect_with_retry(fake, "postgres://y"))
+        assert conn == "CONN[postgres://y]"
+        assert fake._calls["n"] == 1
+
+    def test_non_retryable_error_raises_immediately(self, worker, monkeypatch):
+        monkeypatch.setattr(worker, "DB_CONNECT_BASE_DELAY_S", 0.0)
+
+        class Boom(Exception):
+            pass
+
+        calls = {"n": 0}
+
+        async def connect(db_url):
+            calls["n"] += 1
+            raise Boom("auth failed — not a transient flap")
+
+        fake = types.SimpleNamespace(
+            connect=connect,
+            exceptions=types.SimpleNamespace(ConnectionDoesNotExistError=_ConnDoesNotExist),
+        )
+        with pytest.raises(Boom):
+            asyncio.run(worker._connect_with_retry(fake, "z"))
+        assert calls["n"] == 1  # no retry on a non-connection error


### PR DESCRIPTION
## Problema (System Doctor RED, 2026-06-21)

`crm-guardian-cli-worker failed (exit=1, duration=11s)` ripetuto (00:21, 00:26, 00:47, 02:47 WITA) con:

\`\`\`
asyncpg.exceptions.ConnectionDoesNotExistError: connection was closed in the middle of operation
\`\`\`

Ogni FAIL recuperava al tick successivo (5 min) → puro rumore, ~4 FAIL spuri in 2.5h.

## Root cause (superscar #8 — network flap)

Il worker raggiunge Fly Postgres via un **flyctl proxy long-running su localhost:15432** (WireGuard). `scripts/crm_guardian_gemini_cli_worker.py:1520` faceva `conn = await asyncpg.connect(db_url)` **single-shot, senza retry**. Quando il tunnel WireGuard flappa per un istante durante l'handshake, asyncpg solleva `ConnectionDoesNotExistError` e l'intero tick esce 1. Il `nc -z 15432` precondition nel wrapper non cattura i drop mid-connect.

## Fix

`_connect_with_retry(asyncpg, db_url)` — retry esponenziale **bounded** (4 tentativi, base 1s → 1/2/4s) sulle eccezioni di connessione (asyncpg `ConnectionDoesNotExist`/`CannotConnectNow`/`ConnectionFailure`/`InterfaceError`/`PostgresConnection` + `ConnectionError`/`OSError`/`TimeoutError`). **Ri-solleva l'ultima eccezione a budget esaurito** → un proxy davvero down NON viene mascherato (fail-closed sull'outage reale). Tunabile via env `CRM_GUARDIAN_DB_CONNECT_ATTEMPTS` / `CRM_GUARDIAN_DB_CONNECT_BASE_DELAY`.

## Test (`scripts/tests/test_crm_guardian_connect_retry.py`)

4 casi (fake asyncpg, nessun I/O reale): recupero dopo 2 flap, ri-sollevamento a tentativi esauriti (no loop infinito), successo al primo colpo, errore non-retryable solleva subito.

- ✅ **4 passed**
- ✅ pre-push CI-parity backend suite verde

## ⚠️ Propagazione (HOME-fork #1)

Il cron live esegue il worker dal checkout **`nuzantara-deploy`** (deploy-path). Questo fix in `main` diventa attivo sul cron solo dopo che il deploy-checkout fa **pull da main**. Il resto del System Doctor RED del 21/6 era transiente (flap DB mezzanotte rientrato) o low-grade (Olympus 1 query, Fly health blip → prod 200 ora), tracciato separatamente; vedi anche PR #1610 (corpse-sweep organism fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)