### PR TITLE
fix(intake): drain near-done jobs first + inject Qdrant creds in worker runner

### DIFF
--- a/apps/backend-rag/backend/services/intake/intake-worker-run.sh
+++ b/apps/backend-rag/backend/services/intake/intake-worker-run.sh
@@ -26,5 +26,23 @@ fi
 cd "${BACKEND}"
 # shellcheck disable=SC1091
 source .venv/bin/activate
+
+# Inject ONLY the Qdrant credentials from backend-rag/.env. The `validate` stage
+# resolves KBLI codes against the live Qdrant store (validate_rules.py), and a
+# bare launchd env (no QDRANT_URL/KEY) made it raise
+# `RuntimeError: QDRANT_URL / QDRANT_API_KEY not set; cannot validate KBLI` for
+# company docs (akta/NIB/OSS/profil_perseroan) — those went to dead while
+# non-KBLI docs (passport/ktp/kitas) passed (scar: 5 dead in the 319-adit reocr,
+# 2026-06-21). We extract ONLY these two keys — NOT `source .env` wholesale —
+# because .env also carries a divergent DATABASE_URL (Fly-proxy :15432) and
+# unrelated secrets the worker must NOT inherit (the worker's DB is the plist's
+# INTAKE_DATABASE_URL=…/nuzantara_dev; do not let .env shadow it).
+if [[ -f .env ]]; then
+    for _k in QDRANT_URL QDRANT_API_KEY; do
+        _line="$(grep -E "^${_k}=" .env | tail -1 || true)"
+        [[ -n "${_line}" ]] && export "${_line?}"
+    done
+    unset _k _line
+fi
 export PYTHONPATH="${BACKEND}"
 exec python -m backend.services.intake.worker

--- a/apps/backend-rag/backend/services/intake/worker.py
+++ b/apps/backend-rag/backend/services/intake/worker.py
@@ -585,7 +585,23 @@ class IntakeWorker:
                 WHERE status = ANY($1::text[])
                   AND next_visible_at <= now()
                   AND (lease_owner IS NULL OR lease_expires_at < now())
-                ORDER BY next_visible_at, id
+                -- Downstream stages (extract/validate/route) cost ~3ms; the
+                -- classify+OCR stage costs ~50-90s on the local VLM. Pure FIFO
+                -- lets a backlog of 'pending' jobs starve the cheap downstream
+                -- stages, so 'ocr_done' piles up and nothing reaches 'done'
+                -- (SCAR 2026-06-21). Drain near-done work FIRST: later pipeline
+                -- stages rank ahead of 'pending', then FIFO within each rank.
+                ORDER BY
+                  CASE status
+                    WHEN 'validated'    THEN 0
+                    WHEN 'extracted'    THEN 1
+                    WHEN 'ocr_done'     THEN 2
+                    WHEN 'classified'   THEN 3
+                    WHEN 'ocr'          THEN 4
+                    WHEN 'processing'   THEN 5
+                    ELSE 9  -- 'pending' last
+                  END,
+                  next_visible_at, id
                 LIMIT 1
                 FOR UPDATE SKIP LOCKED
             )


### PR DESCRIPTION
## Why

Two real intake fixes from the 2026-06-21 remediation that existed **only as uncommitted edits in the Pro main checkout**. They were at HOME-fork risk: a `git reset --hard` (during the recurring local-main↔origin reconcile) would have silently destroyed them. Adopted into a clean worktree branched from current `origin/main` and PR'd so they survive on origin and deploy to Fly.

The third dirty file in that checkout (`classify.py` `_ensure_min_size` pad-OCR) is **deliberately excluded** — its sibling fix already landed via #1602, so it was redundant and would only conflict.

## What

**1. `worker.py` — stage-priority job claim (was pure FIFO).**
`classify+OCR` costs ~50-90s on the local VLM; downstream `extract`/`validate`/`route` cost ~3ms. Pure FIFO let a backlog of `pending` jobs starve the cheap downstream stages, so `ocr_done` piled up and **nothing reached `done`** (SCAR 2026-06-21). The claim query now ranks later pipeline stages ahead of `pending` (`validated`→`extracted`→`ocr_done`→`classified`→`ocr`→`processing`→`pending`), FIFO within each rank.

**2. `intake-worker-run.sh` — selectively inject `QDRANT_URL`/`QDRANT_API_KEY` from `backend-rag/.env`.**
The `validate` stage resolves KBLI codes against the live Qdrant store, and a bare launchd env raised `RuntimeError: QDRANT_URL / QDRANT_API_KEY not set; cannot validate KBLI` for company docs (akta/NIB/OSS/profil_perseroan) → those went to `dead` while non-KBLI docs (passport/ktp/kitas) passed (5 dead in the 319-adit reocr). Extracts **only those 2 keys** — NOT `source .env` wholesale — to avoid shadowing the plist's `INTAKE_DATABASE_URL` (nuzantara_dev) with `.env`'s divergent Fly-proxy `DATABASE_URL`.

## Verification

- `bash -n` (run.sh) + `py_compile` (worker.py): clean
- Pre-commit gate: linting + typecheck + FastAPI import-chain ✅
- Pre-push gate: full backend pytest suite (CI-parity, local PG) passed ✅
- Change surface is SQL-string + shell only — no Python import surface touched

Cicatrix: #1 HOME-fork drift (the reason this is a PR, not a local-only patch).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)