### PR TITLE
fix(kbli): section-list cards must show Bali block, not just national 'Open 100%'

### DIFF
--- a/apps/mouth/src/components/kbli/KBLICard.tsx
+++ b/apps/mouth/src/components/kbli/KBLICard.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { PMABadge } from "./PMABadge";
 import { RiskBadge } from "./RiskBadge";
 import { TransitionBadge } from "./TransitionBadge";
+import { BaliStatusBadge } from "./BaliStatusBadge";
 import type { KBLICode } from "@/lib/kbli-types";
 
 interface KBLICardProps {
@@ -75,6 +76,12 @@ export function KBLICard({ code, showTransition = false }: KBLICardProps) {
 
       {/* Badges */}
       <div className="mt-3 flex flex-wrap items-center gap-2">
+        {/* Bali L4 status first — national openness (PMA) != Bali registrability.
+            A card showing only "Open · 100% Foreign" would teach the national truth
+            and hide the Bali moratorium block. Show the Bali verdict up front. */}
+        {code.baliL4?.status && (
+          <BaliStatusBadge status={code.baliL4.status} size="sm" />
+        )}
         <PMABadge
           status={code.pma.status}
           maxForeign={code.pma.maxForeign}


### PR DESCRIPTION
## The bug (found in live browser QA)

The KBLI section-list pages (`/kbli/sectors/I` etc.) rendered **every** code as "✅ Open · 100% Foreign" — the national PMA status only. Codes that are **blocked in Bali** showed as Open in the list:

- **55203 Villa Rental** → list says "✅ Open · 100% Foreign", but the detail page says CHIUSO_PMA_NO_BESAR (blocked).
- **56303 Cafe** → "Open" in the list, BLOCCATO_CLASSE_RISCHIO in Bali.

A user scanning the sector list sees "Villa = Open" and never clicks through to discover the block. This is the exact disease the whole KBLI L4 effort exists to cure (superscar #3: a badge telling the *form* — national openness — not the *fact* — Bali registrability), but on the **most-scanned surface** (the list), while we'd only cured the detail page.

## The fix

`KBLICard` rendered only `PMABadge` (national). Added `BaliStatusBadge` **before** it, gated on `code.baliL4?.status`. Both data and component already existed:
- `getCodesBySection` maps `l4_bali` fully (kbli-data.ts:425) → the card already receives `code.baliL4`.
- `BaliStatusBadge` already has every status mapped with client-facing labels ("Blocked in Bali", "Reserved for MSME — closed to PT PMA", "Conditional in Bali — depends on declared scope").

So this is a 3-line surface fix, no data/logic change. National openness stays visible (PMABadge) but the Bali verdict comes first. Typecheck green.

## Verify after merge
`balizero.com/kbli/sectors/I`: 55203 + 56303 should show a 🚫 Bali block badge, not just "Open 100% Foreign".

🤖 Generated with [Claude Code](https://claude.com/claude-code)