### PR TITLE
docs(kbli): articles 11-20 (batch 2/2) — TIER 3 + data-journalism

### DIFF
--- a/research/content/articles/11-minimarket-closed-to-foreigners.md
+++ b/research/content/articles/11-minimarket-closed-to-foreigners.md
@@ -1,0 +1,46 @@
+---
+date: 2026-06-21
+domain: compliance
+client_case: none
+kbli_codes:
+  - "47111 — Perdagangan Eceran Berbagai Macam Barang (minimarket/supermarket, self-service, food-dominant) — National: TERBATAS (0% foreign) — Bali: TERTUTUP (closed, reserved for WNI)"
+  - "47112 — Perdagangan Eceran Berbagai Macam Barang (department-store style, non-food-dominant) — National: TERBUKA 100% — Bali: TERTUTUP (closed, reserved for WNI)"
+  - "47191 — Perdagangan Eceran Berbagai Macam Barang Lainnya — National: TERBUKA 100% — Bali: BLOCCATO_CLASSE_RISCHIO (blocked)"
+  - "47711 — Perdagangan Eceran Pakaian — National: TERBUKA 100% — Bali: BLOCCATO_CLASSE_RISCHIO (blocked)"
+status: published-draft
+---
+
+# Minimarket Is Closed to Foreigners
+
+Every few months a hopeful email lands in our inbox with the same plan: a small chain of tidy minimarkets, foreign-funded, "just like the ones on every corner." The math looks beautiful on a spreadsheet. The problem is that the spreadsheet is illegal before the first shelf is stocked.
+
+Convenience retail in Indonesia is not a grey area you can lawyer your way through. It is one of the oldest, hardest-locked doors in the whole investment regime — and Bali has now bolted it shut a second time, from the other side.
+
+## The national lock comes first
+
+The code for a self-service grocery — minimarket, supermarket, hypermarket selling mostly food, drink, and tobacco — is **KBLI 47111 (Perdagangan Eceran Berbagai Macam Barang yang Utamanya Makanan, Minuman, atau Tembakau dengan Sistem Swalayan).** Nationally it carries the status **TERBATAS** — restricted — at **0% foreign ownership.** That is not a high bar to clear with more capital. It is a flat zero. The activity is reserved for Indonesian nationals (WNI) as a matter of national protectionist policy, and has been for years. A PT PMA cannot hold 47111 anywhere in Indonesia.
+
+So before Bali ever enters the conversation, the dream is already over for 47111. The convenience-store corner is a WNI-only business by national design.
+
+## And then Bali locks it again
+
+Here is the part that surprises people who assumed the rule was purely national. In the 2025 Bali classification, **47111 is marked TERTUTUP** — *closed* — at the provincial level too. The data note on this code is blunt: it is "triple-locked." National 0%, provincial TERTUTUP, and the 13 May 2026 moratorium on top. There is no single key that opens any of the three locks for a foreigner.
+
+The sibling code **47112** — the broader "various goods, not predominantly food" self-service store, the department-store shape — is more revealing. **Nationally it is TERBUKA, 100% open.** On paper, a foreigner could own it. **In Bali it is also TERTUTUP.** This is the cleanest possible illustration of the theme that runs through this whole series: *national-open is not the same as Bali-registrable.* You can clear the national gate on 47112 and still hit a provincial wall that does not budge.
+
+## It is not just the grocery
+
+Foreigners sometimes pivot from groceries to "general retail" hoping to slip the lock. The neighbouring general-retail and apparel codes are open nationally but do not survive Bali either:
+
+- **47191 — Perdagangan Eceran Berbagai Macam Barang Lainnya** (other general retail): national TERBUKA, but **blocked in Bali** as a low/medium-low-risk activity under the moratorium.
+- **47711 — Perdagangan Eceran Pakaian** (clothing retail): national TERBUKA, **blocked in Bali** for the same reason.
+
+The pattern is consistent. Small-scale, low-risk, walk-in retail is precisely the category the Bali moratorium was built to reserve for local families. A foreigner pointing at "but it's open nationally!" is reading the wrong half of the map.
+
+## What this means in practice
+
+There is no clever entity structure, no "management company that happens to run a store," no nominee arrangement that makes foreign-owned convenience retail lawful in Bali in 2026. The nominee route in particular is now criminally exposed — a separate problem we treat elsewhere in this series. The honest advice is the unglamorous one: if your plan depends on owning the till in a Bali shop, the plan needs to change, not the paperwork.
+
+Where foreigners do legitimately operate near retail, it is almost always on a different code entirely — wholesale to local-owned stores, franchising and brand licensing, or import-distribution structures — each with its own status that must be checked on its own merits, not assumed from the retail dream.
+
+*Before you budget for a single shelf, check the live Bali status of 47111, 47112, and any retail code on the Bali Zero KBLI Navigator at balizero.com — the national-vs-Bali view shows you instantly when a "100% open" code is still closed where you actually want to trade.*

--- a/research/content/articles/12-the-it-escape-route.md
+++ b/research/content/articles/12-the-it-escape-route.md
@@ -1,0 +1,67 @@
+---
+date: 2026-06-21
+domain: compliance
+client_case: none
+kbli_codes:
+  - "62110 — Pengembangan Video Gim, Perangkat Lunak Video Gim, dan Perangkat Lunak Pendukungnya — National: TERBUKA 100% — Bali: OK_or_HIGHER_RISK (registrable)"
+  - "62191 — Aktivitas Pengembangan Aplikasi Perdagangan melalui Internet (e-commerce app dev) — National: TERBUKA 100% — Bali: OK_or_HIGHER_RISK (registrable)"
+  - "62199 — Aktivitas Pemrograman Komputer Lainnya YTDL — National: TERBUKA 100% — Bali: OK_or_HIGHER_RISK (registrable)"
+  - "62201 — Aktivitas Konsultansi dan Manajemen Keamanan Siber (cybersecurity) — National: TERBUKA 100% — Bali: OK_or_HIGHER_RISK (registrable)"
+  - "62202 — Aktivitas Penyediaan dan Pengelolaan Identitas Digital — National: TERBUKA 100% — Bali: OK_or_HIGHER_RISK (registrable)"
+  - "62203 — Aktivitas Penyediaan Sertifikat Elektronik dan Jasa Terkait — National: TERBUKA 100% — Bali: OK_or_HIGHER_RISK (registrable)"
+  - "62209 — Aktivitas Konsultansi Komputer dan Manajemen Fasilitas Komputer Lainnya — National: TERBUKA 100% — Bali: OK_or_HIGHER_RISK (registrable)"
+  - "63101 — Aktivitas Pengolahan Data (data processing) — National: TERBUKA 100% — Bali: OK_or_HIGHER_RISK (registrable)"
+  - "63102 — Aktivitas Penyediaan Infrastruktur Komputasi, Hosting (hosting/cloud) — National: TERBUKA 100% — Bali: OK_or_HIGHER_RISK (registrable)"
+  - "62193 — Aktivitas Pengembangan Aplikasi Berbasis Teknologi Blockchain — National: TERBUKA 100% — Bali: BLOCCATO_CLASSE_RISCHIO (blocked)"
+  - "62194 — Aktivitas Pengembangan Komponen Dasar Kecerdasan Buatan (AI) — National: TERBUKA 100% — Bali: BLOCCATO_CLASSE_RISCHIO (blocked)"
+  - "62204 — Aktivitas Konsultansi dan Perancangan Internet of Things — National: TERBUKA 100% — Bali: BLOCCATO_CLASSE_RISCHIO (blocked)"
+  - "62900 — Aktivitas Jasa Teknologi Informasi dan Komputer Lainnya — National: TERBUKA 100% — Bali: BLOCCATO_CLASSE_RISCHIO (blocked)"
+  - "95101 — Reparasi dan Pemeliharaan Komputer dan Peralatan Sejenisnya — National: TERBUKA 100% — Bali: BLOCCATO_CLASSE_RISCHIO (blocked)"
+status: published-draft
+---
+
+# The IT Escape Route
+
+Most of this series is a tour of locked doors. This article is the rare exception: a corridor that is genuinely open. If your business is software, and you build it the right way under the right code, you can still register a foreign-owned company in Bali in 2026 while the villa, the café, and the consulting firm next door cannot.
+
+But the corridor is narrow, and it has trapdoors. The difference between an IT code that passes the Bali moratorium and one that is silently blocked is not the kind of work you do — it is the **risk class** the OSS system assigns. Get the code right and you are in. Reach for the wrong "tech" code and you hit the same wall as everyone else.
+
+## Why IT survives when almost nothing else does
+
+The Bali block (Governor letter **B.27.000/642/PM/DPMPTSP**, effective 13 May 2026) freezes new PMA registration for any activity the OSS system rates **low or medium-low risk.** A PT PMA is, by law, a large-scale (*Besar*) business — so what matters is the risk class at the *Besar* scale. Serious software development, at large scale, lands in **medium-high** or **high** risk. That higher risk class is exactly what lets it through the filter. The moratorium was built to stop low-risk micro-businesses; substantial IT operations are the opposite of that.
+
+## The codes that pass (verified)
+
+Each of these is nationally **TERBUKA (100% open)** and, in the 2025 Bali classification, **registrable** — `OK_or_HIGHER_RISK` — because its large-scale risk class survives the moratorium:
+
+- **62110** — game and supporting-software development
+- **62191** — e-commerce / internet-trading application development
+- **62199** — other computer programming (the broad "we build software" catch-all)
+- **62201** — cybersecurity consulting and management
+- **62202** — digital-identity provision and management
+- **62203** — electronic-certificate and trust services
+- **62209** — computer consulting and IT-facilities management
+- **63101** — data processing
+- **63102** — computing infrastructure, hosting, and cloud
+
+For a foreign founder running a real software, SaaS, data, or cloud operation, this is a workable spine. **62199** and **62110** cover most "we write code" businesses; **62201/62202/62203** cover the security-and-trust niche; **63101/63102** cover data and hosting.
+
+## The trapdoors that look like IT but are blocked
+
+Here is where confident people fall. These codes *sound* like the future of tech, but the OSS system rates them in the low/medium-low band, so the Bali moratorium **blocks** them for PMA — even though all are nationally open:
+
+- **62193** — blockchain application development → BLOCKED
+- **62194** — core artificial-intelligence component development → BLOCKED
+- **62204** — Internet of Things consulting and design → BLOCKED
+- **62900** — other IT and computer services (the vague "miscellaneous tech" bucket) → BLOCKED
+- **95101** — computer and peripheral repair/maintenance → BLOCKED
+
+The irony is sharp: a founder building an *AI* or *blockchain* company — exactly the kind of high-tech work you'd assume Bali would welcome — picks 62194 or 62193 and is refused, while a plainer "other computer programming" company on 62199 walks straight in. The label is glamorous; the risk class is what the gate reads.
+
+## One more warning: the dead codes
+
+Older guides will hand you IT numbers that no longer exist in KBLI 2025 at all — the 2020-era 62011 / 62019 / 63122 and similar were aggregated into the newer codes above. Registering against a retired number is a non-starter, the same dead-end as the phantom 74149 we bury in another article. Always confirm the code is a *live 2025 code* first, then confirm its Bali status second.
+
+The IT escape route is real. It is also the most code-sensitive choice in this series: two activities that feel identical to the founder can sit on opposite sides of the wall. This is precisely the kind of decision to verify against ground-truth data, not a forum post.
+
+*Check the live Bali status of your exact IT code — 62199, 62110, 63101 and the rest — on the Bali Zero KBLI Navigator at balizero.com, so you build on a code that passes the moratorium instead of a blockchain or AI label that quietly doesn't.*

--- a/research/content/articles/13-pt-pma-vs-nominee-the-math-of-the-bet.md
+++ b/research/content/articles/13-pt-pma-vs-nominee-the-math-of-the-bet.md
@@ -1,0 +1,47 @@
+---
+date: 2026-06-21
+domain: compliance
+client_case: none
+kbli_codes:
+  - "55203 — Aktivitas Vila — National: TERBUKA 100% — Bali: CHIUSO_PMA_NO_BESAR (blocked) — illustrative of the activity people try to nominee"
+  - "55201 — Aktivitas Rumah Tinggal Sewa (Homestay/Pondok Wisata) — National: TERBUKA 100% — Bali: TERTUTUP (closed, reserved for WNI)"
+status: published-draft
+---
+
+# PT PMA vs Nominee: The Math of the Bet
+
+Sooner or later, every foreigner who hits one of the locked doors in this series is offered the same whispered alternative. A local "partner" holds the shares or the land on paper; you hold a stack of side-agreements — a loan, a power of attorney, an option to buy, a pledge — that supposedly give you the real control. It is cheaper than a PT PMA. It opens codes a PT PMA can never touch. And it is, in the cold legal sense, a bet you are structured to lose.
+
+This article does not moralise. It does the math.
+
+## What the nominee actually buys you
+
+The appeal is honest enough. A villa-rental activity like **KBLI 55203 (Aktivitas Vila)** is **100% open nationally** yet **blocked for a foreign PT PMA in Bali** — reserved, in effect, for local UMKM operators. A homestay code like **55201 (Pondok Wisata)** is **TERTUTUP** outright, 0% foreign. A nominee structure pretends to solve this by putting an Indonesian name on the activity and the asset, while the foreigner keeps the cash flow. For the price of some notarised side-letters, you appear to have walked through a wall.
+
+That is the entire upside. Now the other side of the ledger.
+
+## What the nominee actually costs you
+
+**1. The side-agreements are void where it counts.** Indonesian law treats nominee arrangements over land and shares as agreements designed to circumvent ownership restrictions. The Investment Law and the Agrarian Law both contain provisions that render such structures null. "Void" is not a technicality — it means that in a dispute, the document you are relying on may be treated as if it never existed. You are holding paper that the court can refuse to read.
+
+**2. The nominee holds the real title.** Strip away the side-letters and the legal owner of the company and the land is the local partner. If that person sells, mortgages, dies, divorces, or simply changes their mind, your recourse runs through exactly the agreements a court may decline to enforce. The "control" was always contingent on the other party's goodwill, not on law.
+
+**3. The criminal exposure is now live, not theoretical.** This is the part that changed. The risk is no longer just "you might lose the asset." Nominee arrangements have moved into the enforcement spotlight, with deportation and blacklisting of the foreigner and penalties for the parties involved. The downside is not merely losing the bet — it is losing the bet *and* your ability to stay in the country.
+
+**4. It does not even fix the original problem cleanly.** The activity is still legally a local one. You cannot bank, invoice, hire, or scale it as a foreign-owned business, because on paper it is not yours. Every growth step re-exposes the fiction.
+
+## The expected value of the bet
+
+Put plainly: the nominee route trades a **known, bounded cost** (the higher capital and compliance of a lawful PT PMA, or the discipline of choosing a registrable code) for an **unknown, unbounded one** (a void structure, a counterparty who holds your asset, and personal immigration consequences). The upside is capped at "I saved some money up front." The downside is uncapped. That is the definition of a bad bet — you are risking the whole position to win the entry fee.
+
+## The honest alternative
+
+The boring path almost always wins here, and it usually exists:
+
+- **Pivot the code.** The villa dream becomes an apart-hotel or a management/intermediation company on a code that *is* registrable for a PMA. Most blocked activities have a higher-risk sibling that survives.
+- **Register elsewhere, operate lawfully.** Some activities blocked in Bali are open in other provinces; the structure stays clean even if the address changes.
+- **Use leasehold properly, in your own name.** Foreigners can lawfully hold long leasehold (Hak Sewa) and right-to-use structures without pretending to own freehold through a local.
+
+None of these is as cheap as a nominee on day one. All of them leave you holding something a court will actually recognise on the day it matters — and that day, in this business, tends to arrive.
+
+*Before you sign anything with a local "partner," map your activity to a code you can lawfully own as a PT PMA on the Bali Zero KBLI Navigator at balizero.com — the registrable pivot is usually one code away from the wall you were about to climb the wrong way.*

--- a/research/content/articles/14-risk-class-is-destiny-in-bali-now.md
+++ b/research/content/articles/14-risk-class-is-destiny-in-bali-now.md
@@ -1,0 +1,61 @@
+---
+date: 2026-06-21
+domain: compliance
+client_case: none
+kbli_codes:
+  - "62110 — Pengembangan Video Gim — National: TERBUKA 100% — Bali: OK_or_HIGHER_RISK — Besar-scale risk = Menengah Tinggi (illustrates risk rising with scale)"
+  - "56301 — Aktivitas Bar — National: TERBUKA 100% — Bali: OK_or_HIGHER_RISK (registrable)"
+  - "56303 — Aktivitas Rumah Minum/Kafe — National: TERBUKA 100% — Bali: BLOCCATO_CLASSE_RISCHIO (blocked, low-risk)"
+  - "46494 — Perdagangan Besar Perhiasan dan Jam — National: TERBUKA 100% — Bali: BLOCCATO_CLASSE_RISCHIO (blocked, low-risk)"
+  - "86105 — Aktivitas Klinik Swasta — National: TERBUKA 100% — Bali: OK_or_HIGHER_RISK (registrable)"
+status: published-draft
+---
+
+# Risk Class Is Destiny in Bali Now
+
+For years, the first question a foreigner asked about a business in Indonesia was "is it open to foreign ownership?" In Bali, since 13 May 2026, that is the wrong first question. The question that now decides your fate is colder and less intuitive: **what risk class does the OSS system assign your activity?**
+
+Risk class used to be a back-office detail — it set how much licensing paperwork you'd face. Now it is the gate. Under the Bali moratorium, risk class decides whether you can register at all.
+
+## The four classes, and the line that matters
+
+Every KBLI activity in the OSS system is rated, scale by scale, into one of four risk bands. In rising order they are:
+
+- **Rendah** — low risk
+- **Menengah Rendah** — medium-low risk
+- **Menengah Tinggi** — medium-high risk
+- **Tinggi** — high risk
+
+The Governor's letter (**B.27.000/642/PM/DPMPTSP**) draws one line through that ladder: it **blocks new PMA registration for everything rated low or medium-low** (Rendah and Menengah Rendah), island-wide. Above the line — medium-high and high — survives. Below the line — the supposedly "easy," low-paperwork activities — is shut.
+
+So the intuition inverts. The businesses that used to be *easiest* to license (low risk, automatic NIB, minimal inspection) are now the ones a foreigner *cannot* have. The ones with heavier risk profiles are the ones that pass.
+
+## Why a PT PMA reads the *Besar* row
+
+There is a crucial mechanical detail. The OSS system rates each activity separately at each business scale — Mikro, Kecil, Menengah, Besar. A PT PMA is, by law, a **large-scale (Besar)** enterprise. So the only risk row that matters for a foreigner is the **Besar** one.
+
+This is why two activities that feel similar can split. Take **game/software development (62110):** at micro, small, and medium scale it is rated medium-low — but at **Besar scale it rises to Menengah Tinggi (medium-high).** That escalation at the top scale is exactly what carries it over the moratorium line. A foreigner registers at Besar, reads the medium-high row, and passes.
+
+## Same sector, opposite fate
+
+The clearest way to feel the rule is to watch neighbours diverge:
+
+- **Bar (56301)** is registrable — its risk class survives. **Café (56303)** is blocked — low-risk, caught by the line. Same street, same drinks license intuition, opposite outcome.
+- **Private clinic (86105)** is registrable — medical activity carries genuine risk weight. Lighter wellness and cosmetic activities next door often fall below the line and are blocked.
+- **Wholesale jewellery (46494)** is blocked precisely *because* it is low-risk — a clean, simple trading activity with little to inspect, and therefore exactly what the moratorium reserves for local operators.
+
+None of these outcomes follows from the national ownership rule. All of them follow from risk class.
+
+## What to do with this
+
+The practical move is to stop thinking in sectors ("hospitality," "retail," "tech") and start thinking in risk classes. When you map your plan:
+
+1. Find the exact 2025 KBLI code for what you actually do.
+2. Read its **Besar-scale** risk class, not the micro one.
+3. If it's Rendah or Menengah Rendah, assume it's blocked in Bali and hunt for the higher-risk sibling that does the same job.
+
+That sibling frequently exists — a more substantial, higher-risk version of the activity that the system rates medium-high. Choosing it is not gaming the rule; it is registering as the serious, large-scale operator a PT PMA is supposed to be.
+
+Risk class is now the single most decision-relevant fact about any Bali business code. It is also invisible on the national investment lists the old blogs quote — which is why they keep sending people into walls.
+
+*Look up the Besar-scale risk class and the live Bali status of your exact code on the Bali Zero KBLI Navigator at balizero.com — the national status and the Bali risk-class verdict sit side by side, so you can see the line your activity falls on before you commit capital.*

--- a/research/content/articles/15-paid-up-vs-investment-the-rp-10bn-myth.md
+++ b/research/content/articles/15-paid-up-vs-investment-the-rp-10bn-myth.md
@@ -1,0 +1,50 @@
+---
+date: 2026-06-21
+domain: compliance
+client_case: none
+kbli_codes:
+  - "55204 — Aktivitas Apartemen Hotel — National: TERBUKA 100% — Bali: OK_or_HIGHER_RISK (registrable) — illustrative of an investment-threshold-per-location activity"
+  - "62199 — Aktivitas Pemrograman Komputer Lainnya YTDL — National: TERBUKA 100% — Bali: OK_or_HIGHER_RISK (registrable) — illustrative of a service activity with lighter capital footprint"
+status: published-draft
+---
+
+# Paid-Up vs Investment: The Rp 10bn Myth
+
+There is a number tattooed on the Bali expat brain: **ten billion rupiah.** Repeat it in any co-working space and heads nod. "You need 10 billion to open a PT PMA." It is the single most-quoted figure in foreign company setup — and it is quoted so loosely that it has hardened into a myth that misleads more than it informs.
+
+The number is not invented. But what it actually *is*, and what you actually have to *put in the bank*, are two very different things — and the gap between them is where most budgeting goes wrong.
+
+## Two numbers people fuse into one
+
+The confusion comes from collapsing two separate concepts:
+
+- **Investment plan (nilai investasi).** This is the *total* planned investment for your PT PMA per business field per project location — land, building, equipment, working capital, the lot. The headline "above ten billion" figure that floats around the foreign-investment regime refers to this total investment plan, and it has long *excluded* land and buildings from the threshold calculation. It is a planning commitment, not a single deposit.
+- **Paid-up / issued capital (modal disetor).** This is the share capital actually placed into the company. It is a much smaller, separately-regulated number, and it is the one that touches your bank account on day one.
+
+When someone says "you need 10 billion," they are usually gesturing at the *investment plan*, then unconsciously implying you must *deposit* it. You generally do not deposit the full investment figure as cash on incorporation. Conflating the two is how a workable plan gets talked out of existence over coffee.
+
+## It is per-code and per-location, not one flat wall
+
+The more important correction is that there is no longer a single, universal number that applies to every foreigner equally. Under the evolving investment rules — the framework refreshed by **Permeninves 5/2025** and its predecessors — the threshold and the structuring expectations vary **by KBLI activity and by project location.** A capital-light services activity and a capital-heavy hospitality build are not held to the same yardstick, and the same activity can carry different expectations in different regencies.
+
+That is why this article gives you ranges and a method, not a magic figure:
+
+- A **service / software** activity such as **62199 (other computer programming)** has a fundamentally lighter physical footprint — its investment plan is built from people, tooling, and working capital, not land and machinery.
+- A **bricks-and-mortar hospitality** activity such as **55204 (apart-hotel)** carries a far heavier investment plan, dominated by property and fit-out — but, crucially, the land-and-building portion has historically sat *outside* the threshold calculation, which changes the math again.
+
+The right figure for *your* company is a function of your code, your scale, and your location — exactly the kind of value that moves with regulation and must be checked live, not memorised from a slogan.
+
+## And none of it helps if the code is blocked in Bali
+
+Here is the trap that catches the well-capitalised. People assume the threshold is the only gate: clear the capital bar and you're in. In Bali since 13 May 2026, that is false. The **risk-class moratorium** (Governor letter **B.27.000/642/PM/DPMPTSP**) blocks low and medium-low-risk codes for PMA regardless of how much money you bring. You can be ready to invest far above any threshold and still be refused — not for too little capital, but for the wrong code. Capital answers "can I afford it?"; risk class answers "am I allowed?" — and in Bali the second question now comes first.
+
+## How to budget honestly
+
+1. **Fix the code first.** Confirm it is a live 2025 KBLI and that it is registrable for a PMA in Bali (risk-class check), *before* costing anything.
+2. **Separate the two numbers.** Build your *investment plan* (total, often excluding land/building) and your *paid-up capital* (the cash deposit) as distinct lines — never one fused figure.
+3. **Price it per code and location.** Treat the threshold as a range driven by your activity and regency, refreshed against the current Permeninves framework, not a flat ten-billion stamp.
+4. **Leave room for it to move.** These thresholds evolve; build the plan so a regulatory update is an adjustment, not a demolition.
+
+The "Rp 10bn myth" isn't wrong so much as lazy. The real answer is more forgiving for some businesses and stricter for others — and it is never the reason a Bali registration fails when the code itself is the thing that's blocked.
+
+*Map your exact code to its registrability and its current investment expectations on the Bali Zero KBLI Navigator at balizero.com — so you budget against the real, per-code numbers instead of a coffee-shop slogan.*

--- a/research/content/articles/16-the-banjar-is-the-real-authority.md
+++ b/research/content/articles/16-the-banjar-is-the-real-authority.md
@@ -1,0 +1,49 @@
+---
+date: 2026-06-21
+domain: compliance
+client_case: none
+kbli_codes:
+  - "55203 — Aktivitas Vila — National: TERBUKA 100% — Bali: CHIUSO_PMA_NO_BESAR (blocked) — illustrative of a build that must also clear zoning + banjar"
+  - "56301 — Aktivitas Bar — National: TERBUKA 100% — Bali: OK_or_HIGHER_RISK (registrable) — registrable on paper, still subject to zoning + local consent"
+status: published-draft
+---
+
+# The Banjar Is the Real Authority
+
+You can clear the national investment list. You can survive the Bali risk-class moratorium. You can hold a valid KBLI, a NIB, and a building permit. And you can still be quietly, completely stopped — not by a ministry in Jakarta, but by a meeting of neighbours in a community hall a hundred metres from your land.
+
+The **banjar** — the traditional Balinese village-community council — is the layer of authority that no national portal will ever show you, and the one that most often decides whether a business actually lives or dies on the ground.
+
+## Three authorities, not one
+
+Foreigners tend to picture Indonesian permission as a single stack: get the central-government boxes ticked and you're cleared. Bali runs on at least three overlapping authorities, and they do not always agree:
+
+1. **National** — the investment list, the KBLI ownership status (TERBUKA / TERBATAS / TERTUTUP). This is the layer the English-language blogs describe.
+2. **Provincial / regency** — spatial planning and zoning (RTRW — *Rencana Tata Ruang Wilayah*, the regional spatial plan, and the detailed ITR/zoning beneath it), plus, since 13 May 2026, the **risk-class moratorium** on low-risk PMA codes.
+3. **Adat (customary)** — the banjar and the desa adat (customary village), which govern land use, ceremony, water, access, and the social licence to operate, under Bali's recognised customary-village authority.
+
+A business plan that satisfies layer 1 and fails layer 2 or 3 is, in practice, dead — and layers 2 and 3 are invisible from a desk in Europe.
+
+## Zoning: where, not just whether
+
+Even a registrable activity must sit on land zoned for it. The RTRW divides the island into designated uses — tourism, residential, agriculture, and protected **green zones** (jalur hijau / protected agricultural and conservation land). A bar code like **56301** may be perfectly registrable as a PMA on paper, but if the parcel sits in a green zone or a residential-only zone, the building and operating permits will not follow. People routinely sign long land leases for a "tourism business" on land the spatial plan reserves for rice fields, then discover the zoning will never permit the structure.
+
+Green zones in particular are a recurring trap: cheap, beautiful, agriculturally-zoned land marketed as "investment opportunity," where the one thing you cannot lawfully do is build the commercial project you bought it for.
+
+## The banjar: the social licence
+
+Above zoning sits something no permit captures: community consent. The banjar can object to a project on grounds of noise, traffic, water use, density, proximity to a temple, or simple social fit. A banjar that opposes you can make operation untenable in ways that are entirely real even when they are not written on any certificate — blocked access, withheld cooperation, escalation to the regency. Conversely, a banjar that supports you is the most durable protection a foreign business can have on this island.
+
+This is why experienced operators treat the banjar relationship as a core part of due diligence, not an afterthought: a courtesy introduction, an understanding of local contributions and ceremony obligations, and genuine consultation *before* committing capital — not a notice served after the lease is signed.
+
+## What this means for your plan
+
+The national-and-provincial checks in this series are necessary but not sufficient. Before you commit:
+
+- **Confirm the code is registrable** (national status + Bali risk class).
+- **Confirm the land's zoning** against the RTRW for the specific parcel — tourism vs residential vs green zone — not the seller's description.
+- **Confirm the social licence** — engage the banjar early, understand customary obligations, and treat their consent as a real gate.
+
+Indonesia decentralised hard over two decades, and in Bali that decentralisation runs all the way down to the village. The most important authority over your business may not be a government office at all. Plan as if the meeting in the community hall is the one that counts — because frequently it is.
+
+*Check the registrability of your KBLI code first on the Bali Zero KBLI Navigator at balizero.com — then bring the zoning and banjar questions to the table early, so the layers no portal shows you don't surface after the deposit is gone.*

--- a/research/content/articles/17-tka-can-you-hire-or-be-the-foreign-worker.md
+++ b/research/content/articles/17-tka-can-you-hire-or-be-the-foreign-worker.md
@@ -1,0 +1,47 @@
+---
+date: 2026-06-21
+domain: compliance
+client_case: none
+kbli_codes:
+  - "62199 — Aktivitas Pemrograman Komputer Lainnya YTDL — National: TERBUKA 100% — Bali: OK_or_HIGHER_RISK (registrable) — illustrative employer code for a foreign-staffed tech PMA"
+  - "55204 — Aktivitas Apartemen Hotel — National: TERBUKA 100% — Bali: OK_or_HIGHER_RISK (registrable) — illustrative hospitality employer code"
+status: published-draft
+---
+
+# TKA: Can You Hire (or Be) the Foreign Worker?
+
+The PT PMA is registered. The code survives the moratorium. Now the founder asks the question that quietly decides whether the company can actually function: *who is allowed to work in it?* You, the foreign owner, want to manage it. You want to bring in a foreign chef, a foreign developer, a foreign creative director. And you assume that owning the company entitles you to staff it as you please.
+
+It does not. Foreign workers — **TKA (Tenaga Kerja Asing)** — are governed by a separate regime that sits on top of your company registration, and it answers to a different logic: every foreigner in the company must occupy a position an Indonesian could not readily fill, and every foreign hire must be justified, sponsored, and paired with local employment.
+
+## The instrument: RPTKA
+
+The gateway document is the **RPTKA (Rencana Penggunaan Tenaga Kerja Asing)** — the Foreign Worker Utilisation Plan. Before a foreigner can lawfully work, the company must obtain an approved RPTKA from the manpower authority, declaring:
+
+- the **positions** to be held by foreigners,
+- **how many** foreign workers, and for **how long**,
+- the **Indonesian counterparts** assigned to each foreign role, and
+- the company's plan to **transfer skills** to local staff over time.
+
+The RPTKA is the company's licence to employ foreigners at all. The individual's work-and-stay permit (the KITAS work permit) flows *from* an approved RPTKA — not the other way around. No approved plan, no lawful foreign worker, including the owner if the owner intends to draw a salary and work in an operational role.
+
+## The rule beneath the rule: positions, not people
+
+The system is built on a simple principle that trips up founders: foreigners may hold **certain positions**, not any position. Roles that an Indonesian workforce can readily supply are reserved for locals. Certain positions — notably in **human resources** and several others — are closed to foreigners by design. The justification a company must make is always the same shape: *this role genuinely requires a foreigner, and we are training Indonesians alongside.*
+
+This is why "I'll just put my whole team on KITAS" rarely works. The manpower regime expects a foreign-owned company to be a **net employer of Indonesians**, with foreigners concentrated in genuinely specialised or directing roles. A tech PMA on **62199** can justify foreign engineers and a foreign CTO far more easily than it can justify a foreign office manager; a hospitality PMA on **55204** can justify a foreign executive chef or GM more easily than foreign front-desk staff.
+
+## "Can I be the foreign worker?" — owner ≠ worker
+
+The most common personal version of the question: as the foreign owner-director, can *you* work in your own company? Owning shares and holding a director seat is one thing; performing a salaried operational job is another. If you intend to actively work and be paid as an employee or working director, you generally need to be covered by the company's RPTKA and hold the corresponding work permit. A purely passive shareholder or a non-working commissioner sits in a different category. The distinction — between *owning* the company and *working in* it — is exactly the one the manpower rules police.
+
+## What to plan for
+
+1. **Budget the RPTKA before the hire.** Foreign staffing is a planned, approved process, not a hiring decision you make after the fact.
+2. **Map positions, not headcount.** Decide which roles genuinely require a foreigner and which the system expects you to fill locally — and check whether any of your intended roles are closed to foreigners outright.
+3. **Pair every foreign role with a local plan.** Skill-transfer and Indonesian counterparts are not box-ticking; they are the basis on which the plan is granted and renewed.
+4. **Clarify your own status early.** If you'll work in the business, plan your own permit as a TKA, not just as a shareholder.
+
+The TKA regime is the reason a perfectly registrable company can still stall: the codes let you *exist*, but the manpower rules decide who can *operate*. Plan the people question with the same seriousness as the code question.
+
+*Confirm your company's KBLI code is registrable in Bali on the Bali Zero KBLI Navigator at balizero.com — then build the foreign-staffing plan (RPTKA and permitted positions) around it, so the company you can register is also a company you can lawfully run.*

--- a/research/content/articles/18-how-to-read-a-kbli-like-a-pro.md
+++ b/research/content/articles/18-how-to-read-a-kbli-like-a-pro.md
@@ -1,0 +1,48 @@
+---
+date: 2026-06-21
+domain: compliance
+client_case: none
+kbli_codes:
+  - "56301 — Aktivitas Bar — National: TERBUKA 100% — Bali: OK_or_HIGHER_RISK (registrable) — used as the worked OSS example (judul/uraian/ruang lingkup)"
+  - "56303 — Aktivitas Rumah Minum/Kafe — National: TERBUKA 100% — Bali: BLOCCATO_CLASSE_RISCHIO (blocked) — the neighbour that the uraian distinguishes"
+status: published-draft
+---
+
+# How to Read a KBLI Like a Pro
+
+Most foreigners treat a KBLI code as a label — a five-digit sticker that says "restaurant" or "consulting" or "villa." That is exactly the mistake that ends in a wrong registration. A KBLI entry is not a label; it is a small legal document with parts, and each part answers a different question. Learn to read the parts, and you stop guessing.
+
+Let's read a real one, straight from the 2025 OSS ground-truth: **KBLI 56301, Aktivitas Bar.**
+
+## Part 1 — Judul: the title (what it's called)
+
+The **judul** is the official name of the activity. For our code it is simply **"Aktivitas Bar."** This is the headline — useful for searching, useless for deciding. Two codes can have near-identical titles and opposite fates. The judul tells you what bucket you're near; it does not tell you whether you belong in it. Never register on the strength of a title alone.
+
+## Part 2 — Uraian: the description (what it actually covers)
+
+The **uraian** is where the real decision lives. It is the prose definition of what the activity includes — and, just as importantly, excludes. Here is the actual 2025 uraian for 56301 (translated):
+
+> "This group covers activities primarily serving drinks, both alcoholic (such as spirits, beer, wine, whisky) and non-alcoholic. This group also covers — **beach clubs that primarily serve drinks**; bar activities aboard transport such as trains or ships, when carried out by a separate unit."
+
+Read that closely and three things jump out. First, the activity is defined by **serving drinks**, not food. Second — and this is the kind of detail only the uraian gives you — a **beach club** that primarily serves drinks lives *here*, under the bar code, not under some "beach club" code (there isn't one). Third, by implication, a venue whose primary activity is serving *food* or *coffee* is **not** 56301 — it belongs to a different code.
+
+That last point is decisive in Bali. The drinks-led venue (56301, Bar) is **registrable for a PMA**. The food-and-coffee-led venue (56303, Rumah Minum/Kafe) is **blocked** under the moratorium. The line between "I can register this" and "I cannot" is drawn inside the uraian — in the word "primarily." Read the label and you'd never see it; read the description and it's the whole story.
+
+## Part 3 — Ruang lingkup: the scope (the activity's reach)
+
+The **ruang lingkup** is the declared scope of the activity. For 56301 the 2025 data records the scope as **"Seluruh"** — *all / entire* — meaning the code covers the full breadth of the bar activity rather than a narrow carve-out. For other codes, the scope is where activities split into low-risk and higher-risk variants, and — as we cover elsewhere in this series — that scope choice can decide whether a foreigner can register at all (a code can be blocked on its low-risk scope but registrable on a higher-risk one). The scope is not decoration; it is sometimes the lever.
+
+## Reading it the way a professional does
+
+Put the parts in the right order and the workflow is obvious:
+
+1. **Search by judul** to find candidate codes — but never stop there.
+2. **Read the uraian word by word.** Find the verb that defines the activity ("serving drinks") and the includes/excludes. This is where you discover your real code is the neighbour, not the one you assumed.
+3. **Check the ruang lingkup** — is the activity whole, or split into scopes that change the risk and the registrability?
+4. **Only then** check the national ownership status and the Bali risk class.
+
+The amateur reads the title and registers a café when they wanted a bar — and finds out at the OSS counter that one is blocked and the other isn't. The professional reads the uraian and registers the right code the first time.
+
+A KBLI code rewards close reading the way a contract does. The five digits are the citation; the uraian is the clause that binds you.
+
+*Read the full judul, uraian, and scope of your candidate code — alongside its national and Bali status — on the Bali Zero KBLI Navigator at balizero.com, so you register against what the code actually says, not what its title suggests.*

--- a/research/content/articles/19-what-changed-from-kbli-2020-to-2025.md
+++ b/research/content/articles/19-what-changed-from-kbli-2020-to-2025.md
@@ -1,0 +1,51 @@
+---
+date: 2026-06-21
+domain: compliance
+client_case: none
+kbli_codes:
+  - "74149 — PHANTOM / DEAD CODE — does NOT exist in KBLI 2025 (absent from OSS ground-truth); the surviving 'other specialised design' bucket is 74199"
+  - "74199 — Aktivitas Desain Khusus Lainnya YTDL — National: TERBUKA 100% — Bali: CHIUSO_PMA_NO_BESAR (blocked) — the real 2025 'other design' catch-all"
+  - "55203 — Aktivitas Vila — National: TERBUKA 100% — Bali: CHIUSO_PMA_NO_BESAR (blocked) — concrete renumbering example (CODICE_RINUMERATO from 55193)"
+  - "55193 — RETIRED 2020 code (renumbered to 55203 in KBLI 2025) — does NOT exist as a 2025 code"
+status: published-draft
+---
+
+# What Changed from KBLI 2020 to 2025
+
+Here is a quiet way to lose money: take perfectly good advice — and apply it to the wrong version of reality. Indonesia replaced its business-classification system, moving from KBLI 2020 to KBLI 2025, and in doing so it renumbered, merged, split, and retired codes across the entire economy. The five-digit number a 2021 blog post hands you with total confidence may now point to nothing, or to something different from what you intend.
+
+The codes did not just get a new coat of paint. The map was redrawn.
+
+## Four kinds of change
+
+Working through the 2025 ground-truth, every code carries a tag for how it relates to its 2020 ancestor. Four patterns dominate:
+
+- **MATCH_LANGSUNG — direct match.** The largest group: the activity and its number carried straight over. Old advice on these codes is still broadly safe (on the *national* side, anyway). This is the comforting majority.
+- **CODICE_RINUMERATO — renumbered.** A few hundred activities kept their meaning but changed their number. Same business, new digits. Cite the old number and the OSS system shrugs.
+- **MATCH_CON_AGGREGAZIONE — merged / aggregated.** Activities that were scattered across several 2020 codes got folded into a single 2025 code (or the reverse — one old code split into several new ones). The work still exists; the *boundaries* moved.
+- **BPS_ONLY — newly introduced.** Activities that simply did not have a standalone code before, now created — the system getting more granular about modern sectors.
+
+The lesson is structural: a 2025 code is not guaranteed to be the same animal as the 2020 code with the same number, and a 2020 code is not guaranteed to still exist.
+
+## The retired code: 74149
+
+The cleanest cautionary tale in this series is a number that the expat internet still circulates with great confidence: **74149.** It is handed out as "the content creator / specialised design code." Run it against the 2025 OSS ground-truth and you get nothing — **74149 does not exist as a 2025 code.** It is retired. Any quote, structure, or notary instruction built on 74149 is built on a number the system has no record of.
+
+Where did the activity go? The specialised-design family was reorganised into the **74111–74199** block in 2025 — design of transport equipment, household goods, textiles and fashion, packaging, interiors, graphic/visual communication, and so on — with **74199 (Aktivitas Desain Khusus Lainnya — "other specialised design")** as the genuine catch-all for niche design work that fits nowhere more specific. So the honest replacement for the person who reached for the dead 74149 is to find the precise 74111–74199 code for what they actually design — and to note that **74199 itself is blocked for a PMA in Bali** (no large-scale OSS row, reserved for UMKM). The phantom didn't just change number; its real successors mostly can't be foreign-owned in Bali anyway.
+
+## A concrete renumbering: 55193 → 55203
+
+For a textbook **CODICE_RINUMERATO**, take the villa. The villa-rental activity was **55193** in KBLI 2020. In 2025 it became **55203 (Aktivitas Vila).** The licensing data maps the old 55193 to the new 55203 at a 100% match — same risk level, same permits, same obligations. For an operator, the transition is purely administrative: same business, new code. But anyone still *registering* against 55193 in 2026 is citing a number that no longer exists — and anyone reading 2020-era advice about "55193" needs to mentally rewrite it to 55203 before any of the modern Bali rules (it's now `CHIUSO_PMA_NO_BESAR` — blocked for PMA in Bali) even apply.
+
+## Why the old articles mislead — twice
+
+So the old blogs hurt you on two layers at once:
+
+1. **Wrong number.** They cite retired or renumbered codes (74149, 55193) that the OSS system no longer accepts.
+2. **Wrong world.** Even when the number is still valid nationally, they predate the 13 May 2026 Bali moratorium entirely — so they describe a national-open code as freely registrable, with no idea it is now blocked in Bali on risk-class grounds.
+
+A pre-2025 guide can be wrong about the code *and* wrong about the geography in the same sentence. That is how confident, well-funded people end up committed to a business that points at a dead code in a province that wouldn't allow the live one.
+
+The fix is unglamorous and absolute: never trust a KBLI number you didn't confirm against current 2025 data, and never trust a national "open" status without checking the Bali risk-class verdict on top.
+
+*Check whether your code still exists in KBLI 2025 — and its live Bali status — on the Bali Zero KBLI Navigator at balizero.com, so a five-year-old number from a forum post doesn't send you to a notary with a code the system retired.*

--- a/research/content/articles/20-the-honest-map-blocked-bali-codes.md
+++ b/research/content/articles/20-the-honest-map-blocked-bali-codes.md
@@ -1,0 +1,60 @@
+---
+date: 2026-06-21
+domain: compliance
+client_case: none
+kbli_codes:
+  - "Dataset-wide measurement, not a single code. Source: KBLI_2025_FINAL_CLEAN.json (1,559 records with an l4_bali Bali-status verdict)."
+  - "Measured: 465 of 1,559 records flagged l4_bali.blocked == true → 29.8% blocked for PMA in Bali."
+  - "55203 (Aktivitas Vila) and 56303 (Kafe) used as illustrative blocked codes; 56301 (Bar) as a surviving sibling."
+status: published-draft
+methodology: "Counted records where l4_bali.blocked == true across all 1,559 classified records; reported measured figure, not the editorial plan's earlier 945/39% estimate (which counted a larger 2,422-row OSS scope set)."
+---
+
+# The Honest Map: Nearly a Third of Bali Business Codes Are Blocked for PMA
+
+This whole series has shown you locked doors one at a time — the villa, the café, the minimarket, the consulting firm. This final article steps back and counts them. How much of the Bali business map is actually walled off to foreign investment? Not as a slogan, but as a number you can audit.
+
+So we counted. And because the honest thing to do is show our work, here is exactly what we measured — and where our own first estimate turned out to be too high.
+
+## The method
+
+We took the cleaned 2025 classification dataset — the same ground-truth file that every article in this series looked up codes against — and counted, mechanically, every code carrying a Bali-status verdict. The dataset holds **1,559 classified codes**, each tagged with whether a foreign-owned PT PMA can register it in Bali (a simple `blocked: true / false` flag derived from the code's national status and its OSS risk class under the 13 May 2026 moratorium).
+
+The count is not a vibe. It is a filter over a file.
+
+## The number
+
+**Of 1,559 classified KBLI codes, 465 are blocked for a foreign PT PMA in Bali. That is 29.8% — just under one in three.**
+
+That is the honest headline. Not "half the economy," not a scare figure — but not small either. **Nearly a third** of the business activities a foreigner might reasonably consider are, in 2026 Bali, off-limits to foreign ownership.
+
+And here is the part most counts hide: those 465 break down into distinct *kinds* of "no" —
+
+- **373 — blocked by risk class** (`BLOCCATO_CLASSE_RISCHIO`): nationally open, but low/medium-low risk, so the moratorium catches them. This is the dominant category — the café, the jewellery wholesaler, the general retailer.
+- **63 — blocked pending OSS scope review** (`NEEDS_REVIEW_NO_OSS_SCOPE`): the system shows no clear registrable scope; treat as blocked until verified live.
+- **20 — blocked by "no large-scale row"** (`CHIUSO_PMA_NO_BESAR`): reserved for UMKM, no Usaha Besar slot, so a PMA (large by law) cannot register. This is the villa's exact trap.
+- **8 — closed outright** (`TERTUTUP`): reserved for Indonesian nationals, 0% foreign — the minimarket family.
+- **1 — specifically closed** (`CHIUSO_BALI`): the early consulting closure (70209).
+
+The walls are not one wall. They are five different walls, and a foreigner can hit any of them.
+
+## Where our own estimate was too high
+
+Early in planning this series we carried a working figure of "about 945 codes, roughly 39% blocked." We are correcting it in public, because a series built on *verify-don't-presume* cannot quietly keep a number it can no longer defend.
+
+The 945/39% figure came from a **larger, looser count** — the full 2,422-row OSS export, which includes multiple scope and sub-scale rows per activity, so a single business code can appear several times. Counting at that granularity inflates both the numerator and the denominator and mixes scope-rows with activity-codes. When we count at the level that actually matters to a founder — **one verdict per business code**, across the 1,559 cleaned codes — the rate settles at **29.8%.**
+
+Both statements describe the same reality (a large, structural block on low-risk foreign investment). But the figure you can stand behind, code-by-code, is **465 of 1,559 — 29.8%**, not 39%. The lower number is the more honest one, and it is still big enough to reshape almost every foreigner's plan.
+
+## What the map actually tells you
+
+Two readings follow from the count, and they point the same way:
+
+- **Nearly a third closed** means do not assume your idea is registrable. The base rate of "blocked" is high enough that hope is not a strategy.
+- **Just over two-thirds open** (1,094 codes survive) means the door you want is *probably* findable — usually as the higher-risk sibling of the code you first reached for. The pivot exists more often than not.
+
+The map is not "Bali is closed." It is "Bali is closed to the *easy, low-risk* version of most things, and open to the *serious, higher-risk* version of many of them." That single sentence, backed by 465 counted codes, is the whole moratorium in one line.
+
+We will keep this count current as the OSS data and the moratorium evolve — and we will keep showing the arithmetic, because the moment a number can't be reproduced from the file, it stops being journalism and starts being a rumour.
+
+*Don't take the aggregate on faith — check your own exact code against the live count on the Bali Zero KBLI Navigator at balizero.com, where every code's national status and Bali verdict sit side by side, drawn from the same data this article counted.*

--- a/research/content/articles/_INDEX.md
+++ b/research/content/articles/_INDEX.md
@@ -129,3 +129,110 @@ File: `10-jewelry-wholesale-low-risk-equals-blocked.md` · ~684 words.
 - **59112** (`BLOCCATO_DIPENDE_SCOPE`): registrable in Bali ONLY by declaring the higher-risk scope. Article 8 states this as conditional and tells the reader to verify the live OSS status of their exact activity. Parent: confirm the higher-risk scope is genuinely available for a foreign producer before this is treated as an "open" route.
 - **68111** (`CHIUSO_BALI_PROPOSTO`): status is *proposed*, time-sensitive. If the proposal lands as a hard block, Article 7's "not yet blocked" framing needs a one-line update.
 - **Article 12 (IT escape route)** is NOT in this batch (items 1-10 only) but its real codes are documented in Correction #2 above for the next writer — the plan's flagged codes were all confirmed absent.
+
+---
+
+## Batch 2 (11-20)
+
+Plan items 11-20 — TIER 2 closer (11-12) + TIER 3 structural/mindset (13-20). Same "Pragmatic Sherpa" voice, hook opening, soft Navigator CTA close, frontmatter (date 2026-06-21, domain compliance, kbli_codes cited+verified). Every code + status looked up in `KBLI_2025_FINAL_CLEAN.json` (1,559 records) before citing — never from memory. Ranges (not exact prices) throughout. ~600-800 words each.
+
+### 11 — Minimarket Is Closed to Foreigners
+File: `11-minimarket-closed-to-foreigners.md` · ~667 words · retail reserved for WNI.
+| Code | Judul | National | Bali status | Verdict |
+|---|---|---|---|---|
+| 47111 | Perdagangan Eceran ... Swalayan (minimarket, food-dominant) | TERBATAS (0%) | `TERTUTUP` | CLOSED (triple-locked: national 0% + provincial + moratorium) |
+| 47112 | Perdagangan Eceran ... (non-food-dominant, dept-store) | TERBUKA 100% | `TERTUTUP` | CLOSED (national-open but Bali-closed — clean illustration) |
+| 47191 | Perdagangan Eceran Berbagai Macam Barang Lainnya | TERBUKA 100% | `BLOCCATO_CLASSE_RISCHIO` | BLOCKED |
+| 47711 | Perdagangan Eceran Pakaian | TERBUKA 100% | `BLOCCATO_CLASSE_RISCHIO` | BLOCKED |
+
+### 12 — The IT Escape Route
+File: `12-the-it-escape-route.md` · ~694 words · the IT codes that PASS the moratorium, and the traps that don't. **Uses the REAL 2025 codes (the plan's 63122/62011/62019 are absent — corrected per batch-1 _INDEX Correction #2).**
+| Code | Judul | National | Bali status | Verdict |
+|---|---|---|---|---|
+| 62110 | Pengembangan Video Gim / software | TERBUKA 100% | `OK_or_HIGHER_RISK` | REGISTRABLE |
+| 62191 | Pengembangan Aplikasi Perdagangan via Internet | TERBUKA 100% | `OK_or_HIGHER_RISK` | REGISTRABLE |
+| 62199 | Pemrograman Komputer Lainnya YTDL | TERBUKA 100% | `OK_or_HIGHER_RISK` | REGISTRABLE |
+| 62201 | Konsultansi & Manajemen Keamanan Siber | TERBUKA 100% | `OK_or_HIGHER_RISK` | REGISTRABLE |
+| 62202 | Penyediaan & Pengelolaan Identitas Digital | TERBUKA 100% | `OK_or_HIGHER_RISK` | REGISTRABLE |
+| 62203 | Penyediaan Sertifikat Elektronik & Jasa Terkait | TERBUKA 100% | `OK_or_HIGHER_RISK` | REGISTRABLE |
+| 62209 | Konsultansi Komputer & Manajemen Fasilitas Komputer | TERBUKA 100% | `OK_or_HIGHER_RISK` | REGISTRABLE |
+| 63101 | Pengolahan Data | TERBUKA 100% | `OK_or_HIGHER_RISK` | REGISTRABLE |
+| 63102 | Infrastruktur Komputasi, Hosting/Cloud | TERBUKA 100% | `OK_or_HIGHER_RISK` | REGISTRABLE |
+| 62193 | Pengembangan Aplikasi Blockchain | TERBUKA 100% | `BLOCCATO_CLASSE_RISCHIO` | BLOCKED (trap) |
+| 62194 | Pengembangan Komponen Dasar AI | TERBUKA 100% | `BLOCCATO_CLASSE_RISCHIO` | BLOCKED (trap) |
+| 62204 | Konsultansi & Perancangan IoT | TERBUKA 100% | `BLOCCATO_CLASSE_RISCHIO` | BLOCKED (trap) |
+| 62900 | Jasa Teknologi Informasi & Komputer Lainnya | TERBUKA 100% | `BLOCCATO_CLASSE_RISCHIO` | BLOCKED (trap) |
+| 95101 | Reparasi & Pemeliharaan Komputer | TERBUKA 100% | `BLOCCATO_CLASSE_RISCHIO` | BLOCKED (trap) |
+
+### 13 — PT PMA vs Nominee: The Math of the Bet
+File: `13-pt-pma-vs-nominee-the-math-of-the-bet.md` · ~747 words · the honest, unbounded-downside math of nominee structures (void agreements + criminal/immigration exposure). No fabricated statute — frames the Investment/Agrarian-Law voidness + enforcement spotlight.
+| Code | Judul | National | Bali status | Verdict |
+|---|---|---|---|---|
+| 55203 | Aktivitas Vila | TERBUKA 100% | `CHIUSO_PMA_NO_BESAR` | BLOCKED (the activity people try to nominee) |
+| 55201 | Aktivitas Rumah Tinggal Sewa (Pondok Wisata) | TERBUKA 100% | `TERTUTUP` | CLOSED |
+
+### 14 — Risk Class Is Destiny in Bali Now
+File: `14-risk-class-is-destiny-in-bali-now.md` · ~674 words · how the OSS risk class (Rendah → Tinggi) at *Besar* scale decides Bali registrability. The moratorium line = blocks Rendah + Menengah Rendah.
+| Code | Judul | National | Bali status | Verdict |
+|---|---|---|---|---|
+| 62110 | Pengembangan Video Gim | TERBUKA 100% | `OK_or_HIGHER_RISK` | REGISTRABLE (Besar-scale risk rises to Menengah Tinggi — verified in per_skala) |
+| 56301 | Aktivitas Bar | TERBUKA 100% | `OK_or_HIGHER_RISK` | REGISTRABLE |
+| 56303 | Rumah Minum/Kafe | TERBUKA 100% | `BLOCCATO_CLASSE_RISCHIO` | BLOCKED (low-risk) |
+| 46494 | Perdagangan Besar Perhiasan dan Jam | TERBUKA 100% | `BLOCCATO_CLASSE_RISCHIO` | BLOCKED (low-risk) |
+| 86105 | Aktivitas Klinik Swasta | TERBUKA 100% | `OK_or_HIGHER_RISK` | REGISTRABLE |
+
+### 15 — Paid-Up vs Investment: The Rp 10bn Myth
+File: `15-paid-up-vs-investment-the-rp-10bn-myth.md` · ~789 words · separates *nilai investasi* (total investment plan, land/building historically excluded) from *modal disetor* (paid-up capital). Permeninves 5/2025 framed as evolving, per-KBLI/per-location — RANGES not exact figures, no invented numbers.
+| Code | Judul | National | Bali status | Verdict |
+|---|---|---|---|---|
+| 55204 | Aktivitas Apartemen Hotel | TERBUKA 100% | `OK_or_HIGHER_RISK` | REGISTRABLE (capital-heavy illustration) |
+| 62199 | Pemrograman Komputer Lainnya YTDL | TERBUKA 100% | `OK_or_HIGHER_RISK` | REGISTRABLE (capital-light illustration) |
+
+### 16 — The Banjar Is the Real Authority
+File: `16-the-banjar-is-the-real-authority.md` · ~706 words · three authority layers (national / provincial+RTRW-ITR / adat-banjar), green-zone (jalur hijau) zoning trap, social licence. Structural — no new codes asserted; 55203/56301 used illustratively.
+| Code | Judul | National | Bali status | Verdict |
+|---|---|---|---|---|
+| 55203 | Aktivitas Vila | TERBUKA 100% | `CHIUSO_PMA_NO_BESAR` | BLOCKED (illustration: even a build must clear zoning + banjar) |
+| 56301 | Aktivitas Bar | TERBUKA 100% | `OK_or_HIGHER_RISK` | REGISTRABLE on paper, still subject to zoning + local consent |
+
+### 17 — TKA: Can You Hire (or Be) the Foreign Worker?
+File: `17-tka-can-you-hire-or-be-the-foreign-worker.md` · ~739 words · RPTKA gateway, permitted vs reserved positions (HR closed to foreigners), KITAS work permit flows from RPTKA, owner ≠ working-worker distinction. No KBLI-specific TKA data in FINAL_CLEAN (only 2 records mention TKA) — leans on the regulatory frame; 62199/55204 used as illustrative employer codes.
+| Code | Judul | National | Bali status | Verdict |
+|---|---|---|---|---|
+| 62199 | Pemrograman Komputer Lainnya YTDL | TERBUKA 100% | `OK_or_HIGHER_RISK` | REGISTRABLE (tech employer — foreign engineers easier to justify) |
+| 55204 | Aktivitas Apartemen Hotel | TERBUKA 100% | `OK_or_HIGHER_RISK` | REGISTRABLE (hospitality employer — foreign chef/GM) |
+
+### 18 — How to Read a KBLI Like a Pro
+File: `18-how-to-read-a-kbli-like-a-pro.md` · ~715 words · educational — judul vs uraian vs ruang lingkup, using the REAL OSS 56301 record (its uraian literally lists "beach club" + the "primarily serves drinks" line that splits Bar from Café).
+| Code | Judul | National | Bali status | Verdict |
+|---|---|---|---|---|
+| 56301 | Aktivitas Bar (worked example: judul/uraian/ruang lingkup="Seluruh") | TERBUKA 100% | `OK_or_HIGHER_RISK` | REGISTRABLE |
+| 56303 | Rumah Minum/Kafe (the neighbour the uraian distinguishes) | TERBUKA 100% | `BLOCCATO_CLASSE_RISCHIO` | BLOCKED |
+
+### 19 — What Changed from KBLI 2020 to 2025
+File: `19-what-changed-from-kbli-2020-to-2025.md` · ~798 words · four status_mapping classes (MATCH_LANGSUNG 926 / CODICE_RINUMERATO 264 / MATCH_CON_AGGREGAZIONE 194 / BPS_ONLY 174). Concrete retired-code example: **74149 (phantom, absent) → its successors are the 74111–74199 design family, with 74199 the "other design" catch-all (itself CHIUSO_PMA_NO_BESAR in Bali)**; concrete renumbering: **55193 → 55203** (villa, 100% PP28 match, from `whatChanged`).
+| Code | Judul | National | Bali status | Verdict |
+|---|---|---|---|---|
+| 74149 | — | — | **DOES NOT EXIST** | PHANTOM / RETIRED |
+| 74199 | Aktivitas Desain Khusus Lainnya YTDL (real "other design" bucket) | TERBUKA 100% | `CHIUSO_PMA_NO_BESAR` | BLOCKED |
+| 55193 | — (2020 villa code) | — | **DOES NOT EXIST as 2025 code** | RENUMBERED → 55203 |
+| 55203 | Aktivitas Vila | TERBUKA 100% | `CHIUSO_PMA_NO_BESAR` | BLOCKED (the renumbering target) |
+
+### 20 — The Honest Map: ~30% of Bali Business Codes Are Blocked for PMA
+File: `20-the-honest-map-blocked-bali-codes.md` · ~796 words · data-journalism. **Measured count, not the plan's 945/39%.**
+- **MEASURED: 465 of 1,559 classified codes have `l4_bali.blocked == true` → 29.83% (just under one in three).** Computed by counting `blocked==true` across all 1,559 records in FINAL_CLEAN.
+- Breakdown of the 465: `BLOCCATO_CLASSE_RISCHIO` 373 · `NEEDS_REVIEW_NO_OSS_SCOPE` 63 · `CHIUSO_PMA_NO_BESAR` 20 · `TERTUTUP` 8 · `CHIUSO_BALI` 1.
+- The 1,094 NOT-blocked: `OK_or_HIGHER_RISK` 1014 · `BLOCCATO_DIPENDE_SCOPE` 70 (registrable only via higher-risk scope) · `TERBATAS` 5 · `CHIUSO_BALI_PROPOSTO` 5.
+- Article explains the discrepancy publicly: the plan's "945/39%" came from the larger 2,422-row OSS export (multiple scope/sub-scale rows per code, inflating both numerator and denominator); counting at one-verdict-per-business-code (1,559) gives the defensible 465/29.8%.
+
+## Corrections / measurements made in Batch 2 (fact-gated against FINAL_CLEAN)
+
+1. **Article 20 blocked-count — CORRECTED from plan's 945/39% to MEASURED 465/29.83%.** The plan's figure counted the 2,422-row OSS scope-level export; FINAL_CLEAN holds 1,559 one-verdict-per-code records, of which exactly 465 are `l4_bali.blocked==true`. Article 20 reports the measured 29.8% and explains the discrepancy in-text (per the "verify, don't presume" mandate). The two figures describe the same structural reality; 29.8% is the one defensible code-by-code.
+
+2. **Article 12 IT codes — used the REAL 2025 codes per batch-1 Correction #2.** All 9 pass-codes (62110/62191/62199/62201/62202/62203/62209/63101/63102) re-verified `OK_or_HIGHER_RISK` and all 5 trap-codes (62193/62194/62204/62900/95101) re-verified BLOCKED in this batch. The plan's 63122/62011/62019 confirmed ABSENT.
+
+3. **Article 19 — 74149→74199 framing refined.** 74149 confirmed ABSENT (phantom). The literal "74149 → 74199" mapping the prompt suggested is approximate: 74149's design-services family was reorganised into the 74111–74199 block, with **74199 ("Aktivitas Desain Khusus Lainnya") as the real surviving "other design" catch-all**. 74199's own `whatChanged` is MATCH_LANGSUNG (not itself renumbered), so the article presents it as "where the dead 74149's activity now lives" rather than a strict 1:1 renumber. The clean CODICE_RINUMERATO example used instead is **55193 → 55203** (villa, verbatim from `whatChanged`, 100% PP28 match). Note: 74199 is itself `CHIUSO_PMA_NO_BESAR` (blocked for PMA in Bali) — stated in the article.
+
+4. **Articles 15 & 17 — no fabricated numbers.** FINAL_CLEAN carries almost no TKA/RPTKA or investment-threshold data (2 TKA mentions, 10 Rp-10bn-ish mentions across 1,559 records). Both articles therefore frame the regime (Permeninves 5/2025 investment plan vs paid-up capital; RPTKA + permitted positions) qualitatively with RANGES and "evolving / per-code / per-location" caveats — no invented exact figures or invented statutes.
+
+5. **47112 — verified TERBUKA national but TERTUTUP in Bali.** Used in Article 11 as the cleanest "national-open ≠ Bali-registrable" retail illustration (its sibling 47111 is national TERBATAS 0% + Bali TERTUTUP — "triple-locked" per its `baliContext`).


### PR DESCRIPTION
## What

Final 10 of the 20-article plan (TIER 3 + data-journalism). ~7,325 words, Pragmatic Sherpa voice, appended to `_INDEX.md` (batch-1 intact): minimarket (TERTUTUP), IT escape route, PT PMA vs nominee, risk-class, paid-up myth, banjar, TKA, how-to-read-a-KBLI, what-changed 2020→2025, the honest blocked-map.

## The big correction (data-journalism)

**The plan's "945 / 39% blocked" was WRONG** — it counted the 2,422-row OSS scope export (multiple scope-rows per code). At one-verdict-per-business-code (1,559 FINAL_CLEAN records), the real measured figure is **465 / 1,559 = 29.8%** (373 BLOCCATO_CLASSE_RISCHIO · 63 NEEDS_REVIEW · 20 CHIUSO_PMA_NO_BESAR · 8 TERTUTUP · 1 CHIUSO_BALI). Agent measured it; parent re-verified independently. Article 20 reports the real number + explains the discrepancy — avoiding a wrong public statistic.

## Other corrections (verified vs FINAL_CLEAN)
- Article 12: plan codes 63122/62011/62019 absent in 2025 → real pass-codes (62110/62191/62199/62201/62202/62203/62209/63101/63102) + trap-codes (62193/62194/62204/62900/95101 blocked).
- Article 19: 74149 phantom; 55193→55203 (villa) as the clean renumber example; 74199 itself blocked.
- Articles 15/17: ranges only (near-zero investment/TKA data in FINAL_CLEAN).

Research/editorial under `research/content/articles/`. KBLI = public econ classification, zero PII.

🤖 Generated with [Claude Code](https://claude.com/claude-code)