### PR TITLE
fix(kbli): correct hardcoded 1,563→1,559 + replace misleading '100% PMA' stat

### DIFF
--- a/apps/mouth/src/app/(blog)/components/KBLINavigatorSection.tsx
+++ b/apps/mouth/src/app/(blog)/components/KBLINavigatorSection.tsx
@@ -36,7 +36,7 @@ export default function KBLINavigatorSection() {
               KBLI 2025 Navigator
             </h2>
             <p className="text-white/70 text-lg mb-8 leading-relaxed">
-              Instant access to all 1,563 KBLI 2025 codes with intelligent
+              Instant access to all 1,559 KBLI 2025 codes with intelligent
               search, 4-level risk assessment, PMA status tracking, and
               AI-powered guidance.
             </p>

--- a/apps/mouth/src/app/(blog)/services/page.tsx
+++ b/apps/mouth/src/app/(blog)/services/page.tsx
@@ -56,7 +56,7 @@ const SERVICES: Service[] = [
     accent: "#d4a017",
     icon: Building2,
     bullets: [
-      "1,563 KBLI 2025 codes · 4-level risk mapping",
+      "1,559 KBLI 2025 codes · 4-level risk mapping",
       "PT PMA minimum capital & classified sectors",
       "OSS, SKK, operational licenses",
       "Shareholder structures, nominee-free",

--- a/apps/mouth/src/app/(marketing)/FunnelCTAs.tsx
+++ b/apps/mouth/src/app/(marketing)/FunnelCTAs.tsx
@@ -41,7 +41,7 @@ const funnels: Array<{
   {
     title: "KBLI Navigator",
     funnel: "kbli",
-    description: "Decode 1,563 Indonesian business codes",
+    description: "Decode 1,559 Indonesian business codes",
     href: "/kbli",
     accent: "#d4845a",
     accentGlow: "rgba(212, 132, 90, 0.15)",

--- a/apps/mouth/src/app/kbli/page.tsx
+++ b/apps/mouth/src/app/kbli/page.tsx
@@ -10,11 +10,11 @@ import { FunnelFrame } from "@balizero/core";
 export const metadata: Metadata = {
   title: "KBLI 2025 Navigator — Indonesia Business Classification Guide",
   description:
-    "Navigate Indonesia's 1,563 KBLI 2025 business codes. PMA investment rules, licensing requirements, and 2020→2025 transition mapping. Powered by Zantara AI.",
+    "Navigate Indonesia's 1,559 KBLI 2025 business codes. PMA investment rules, licensing requirements, and 2020→2025 transition mapping. Powered by Zantara AI.",
   openGraph: {
     title: "KBLI 2025 Navigator — Zantara by Bali Zero",
     description:
-      "The definitive guide to Indonesia's KBLI 2025 business classification. 1,563 codes, PMA rules, and AI-powered analysis.",
+      "The definitive guide to Indonesia's KBLI 2025 business classification. 1,559 codes, PMA rules, and AI-powered analysis.",
     type: "website",
   },
   alternates: {
@@ -112,7 +112,7 @@ export default async function KBLIHomePage({
 
               {/* Inline stats */}
               <p className="mt-3 text-sm text-zinc-500 tracking-wide">
-                1,563 codes&ensp;&middot;&ensp;22 sectors&ensp;&middot;&ensp;PMA
+                1,559 codes&ensp;&middot;&ensp;22 sectors&ensp;&middot;&ensp;PMA
                 rules
               </p>
 
@@ -181,9 +181,9 @@ export default async function KBLIHomePage({
         {/* ── TRUST BAR ── */}
         <div className="flex flex-wrap items-center justify-center gap-4 sm:gap-6 -mt-4">
           {[
-            { num: "1,563", label: "KBLI Codes" },
+            { num: "1,559", label: "KBLI Codes" },
             { num: "22", label: "Industry Sectors" },
-            { num: "100%", label: "PMA Coverage" },
+            { num: "~30%", label: "Blocked in Bali" },
             { num: "AI", label: "Powered by Zantara" },
           ].map((t) => (
             <div

--- a/apps/mouth/src/app/sitemap.ts
+++ b/apps/mouth/src/app/sitemap.ts
@@ -11,7 +11,7 @@ import { logger } from "@/lib/logger";
  * - Service pages (4 main services)
  * - News categories (8 categories)
  * - Blog articles (all published articles)
- * - KBLI 2025 codes (1,563 pages)
+ * - KBLI 2025 codes (1,559 pages)
  * - KBLI sectors index + individual sector pages (~22)
  * Priority scale:
  * - 1.0: Homepage
@@ -194,7 +194,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     );
   }
 
-  // 5. KBLI Codes (1,563 pages)
+  // 5. KBLI Codes (1,559 pages)
   try {
     const codes = getAllCodes();
     const kbliPages = codes.map((c) => ({

--- a/apps/mouth/src/app/v2/_components/FunnelBoxes.tsx
+++ b/apps/mouth/src/app/v2/_components/FunnelBoxes.tsx
@@ -28,7 +28,7 @@ const BOXES: Box[] = [
     title: "KBLI Navigator",
     desc: "Complete Indonesian business classification with PMA eligibility and risk scoring.",
     stats: [
-      { l: "Categories", v: "1,563" },
+      { l: "Categories", v: "1,559" },
       { l: "PMA eligible", v: "847" },
       { l: "Updated", v: "KBLI 2025" },
     ],

--- a/apps/mouth/src/app/v2/_components/FunnelFeature.tsx
+++ b/apps/mouth/src/app/v2/_components/FunnelFeature.tsx
@@ -112,7 +112,7 @@ const CONFIGS: Record<
       "Instant access to the complete Indonesian business classification with bilingual search, 4-level risk assessment, PMA status, minimum capital, required licenses.",
     features: [
       "AI narrows down. Our licensed notaries file.",
-      "1,563 codes · bilingual search (EN/ID)",
+      "1,559 codes · bilingual search (EN/ID)",
       "4-level risk + PMA eligibility + minimum capital",
       "Hub-and-spoke linked to our PT PMA guides",
     ],

--- a/apps/mouth/src/app/v2/_components/HeroCarousel.tsx
+++ b/apps/mouth/src/app/v2/_components/HeroCarousel.tsx
@@ -31,7 +31,7 @@ const SLIDES: Slide[] = [
   },
   {
     funnel: "kbli",
-    badge: "1,563 BUSINESS CATEGORIES · KBLI 2025",
+    badge: "1,559 BUSINESS CATEGORIES · KBLI 2025",
     titleTop: "Your",
     titleAccent: "business",
     titleBottom: "code. In 60 seconds.",
@@ -66,7 +66,7 @@ const SLIDES: Slide[] = [
 
 const STATS = [
   { n: "5,000+", l: "CLIENTS SERVED" },
-  { n: "1,563", l: "KBLI CATEGORIES" },
+  { n: "1,559", l: "KBLI CATEGORIES" },
   { n: "24/7", l: "AI SUPPORT" },
 ];
 

--- a/apps/mouth/src/app/v2/_components/PersonaDoors.tsx
+++ b/apps/mouth/src/app/v2/_components/PersonaDoors.tsx
@@ -30,7 +30,7 @@ import {
  *
  * Fact lines verified against the codebase 2026-06-11:
  *  - E33G / C1: live visa funnel + SocialProof reference both codes
- *  - 1,563 KBLI codes: kbli/page.tsx + sitemap.ts
+ *  - 1,559 KBLI codes: kbli/page.tsx + sitemap.ts
  *  - PPh · PPN · LKPM: TAX_DEADLINES kinds in
  *    app/api/tax-calendar/deadlines.ts (the tax.balizero.com calendar)
  *  - leasehold 25–30 yr: property KB ground truth (W68 scar verification)
@@ -83,7 +83,7 @@ const DOORS: Door[] = [
     body: "PT PMA setup, KBLI codes, licensing. From idea to a legal Indonesian company — without the nominee traps.",
     fact: (
       <>
-        <b style={{ color: NAVY }}>1,563 KBLI codes</b> mapped
+        <b style={{ color: NAVY }}>1,559 KBLI codes</b> mapped
       </>
     ),
     tool: {


### PR DESCRIPTION
## Found in live browser QA

The navigator UI hardcoded **"1,563 KBLI codes"** in 15 spots across 9 files (kbli/page.tsx, navigator section, services, funnel components, sitemap). The real count is **1,559** (FINAL_CLEAN records; the section sums on the live page = 1,559; `StatsCounter.tsx` already had 1559). The sitemap also *declared* 1,563 pages when 1,559 exist.

Also replaced the misleading **"100% PMA Coverage"** hero stat — it reads as "100% open to PMA" (false) — with **"~30% Blocked in Bali"**, the real measured figure (465/1,559 = 29.8% blocked by the moratorium). Honest + on-message: the whole point of the navigator is national openness ≠ Bali registrability.

## Scope discipline
Editorial MDX articles (slow-paralysis "1,563 codes restructured" — a historical claim about the restructure) and an unrelated USD price coincidentally "1,563" left untouched. Only product/UI surfaces changed. Typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)