### PR TITLE
fix(wa-inbox): send X-Internal-Key on api→rag hop so the bot can reply

### DIFF
--- a/apps/backend-rag/backend/services/integrations/wa_inbox_bot.py
+++ b/apps/backend-rag/backend/services/integrations/wa_inbox_bot.py
@@ -40,6 +40,7 @@ from typing import Any
 import asyncpg
 import httpx
 
+from backend.app.core.config import settings
 from backend.app.rag_proxy import get_rag_worker_url
 
 logger = logging.getLogger("zantara.backend")
@@ -69,8 +70,30 @@ def is_bot_autoreply_enabled() -> bool:
     )
 
 
+def _rag_client_headers() -> dict[str, str]:
+    """Service-to-service auth for the api→rag hop.
+
+    ``/api/agentic-rag/query`` is NOT a public endpoint, so HybridAuthMiddleware
+    rejects an unauthenticated hop with 401 "Authentication required". Send the
+    X-Internal-Key header (settings.wa_mirror_internal_key, Fly secret
+    WA_MIRROR_INTERNAL_KEY) — the middleware maps a matching key to a
+    "role=internal" pseudo-user, the same channel Pro-side internal scripts use.
+    Without this the bot can NEVER generate a reply (every call → 401 → worker
+    marks the row failed).
+    """
+    internal_key = getattr(settings, "wa_mirror_internal_key", None)
+    if internal_key:
+        return {"X-Internal-Key": internal_key}
+    logger.warning(
+        "wa-inbox bot: WA_MIRROR_INTERNAL_KEY not configured — "
+        "RAG calls will be rejected by HybridAuthMiddleware (401)"
+    )
+    return {}
+
+
 async def _get_rag_client() -> httpx.AsyncClient:
     global _rag_client
+    headers = _rag_client_headers()
     if _rag_client is None or _rag_client.is_closed:
         async with _rag_client_lock:
             if _rag_client is None or _rag_client.is_closed:
@@ -78,6 +101,7 @@ async def _get_rag_client() -> httpx.AsyncClient:
                     base_url=get_rag_worker_url(),
                     timeout=httpx.Timeout(120.0, connect=10.0),
                     limits=httpx.Limits(max_connections=10, max_keepalive_connections=5),
+                    headers=headers,
                 )
     return _rag_client
 

--- a/apps/backend-rag/backend/tests/unit/services/test_wa_inbox_bot.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_wa_inbox_bot.py
@@ -147,3 +147,37 @@ async def test_escalate_marker_stripped(monkeypatch):
     answer = await wa_inbox_bot.generate_bot_reply(pool, _thread())
     assert "[ESCALATE]" not in answer
     assert answer == "Ti metto in contatto col team"
+
+
+# ── Service-to-service auth header (X-Internal-Key) ──
+# Regression guard for the silent-401 bug: /api/agentic-rag/query is not public,
+# so the api→rag hop MUST carry X-Internal-Key or HybridAuthMiddleware rejects it
+# with 401 → the worker marks every bot row failed → the bot never replies.
+
+
+def test_rag_client_headers_sends_internal_key_when_configured(monkeypatch):
+    monkeypatch.setattr(wa_inbox_bot.settings, "wa_mirror_internal_key", "secret-xyz")
+    headers = wa_inbox_bot._rag_client_headers()
+    assert headers == {"X-Internal-Key": "secret-xyz"}
+
+
+def test_rag_client_headers_omits_internal_key_and_warns_when_unset(monkeypatch, caplog):
+    monkeypatch.setattr(wa_inbox_bot.settings, "wa_mirror_internal_key", None)
+    with caplog.at_level("WARNING"):
+        headers = wa_inbox_bot._rag_client_headers()
+    assert headers == {}
+    assert any("WA_MIRROR_INTERNAL_KEY not configured" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_get_rag_client_applies_internal_key_header(monkeypatch):
+    """End-to-end: the cached client carries the X-Internal-Key header."""
+    monkeypatch.setattr(wa_inbox_bot, "_rag_client", None)
+    monkeypatch.setattr(wa_inbox_bot.settings, "wa_mirror_internal_key", "secret-xyz")
+    monkeypatch.setattr(wa_inbox_bot, "get_rag_worker_url", lambda: "http://rag.internal:8080")
+    client = await wa_inbox_bot._get_rag_client()
+    try:
+        assert client.headers.get("x-internal-key") == "secret-xyz"
+    finally:
+        await client.aclose()
+        wa_inbox_bot._rag_client = None


### PR DESCRIPTION
## Problem (superscar #11 — last mile severed)

The WA Meta-inbox bot auto-reply (armed last session, PR #1603 + flag
`WA_INBOX_BOT_AUTOREPLY=true`) **never worked end-to-end**. `generate_bot_reply`
POSTs to `/api/agentic-rag/query` on the rag worker, but that endpoint is **not**
in `PUBLIC_ENDPOINTS`, so `HybridAuthMiddleware` rejects the unauthenticated
api→rag hop with **401 "Authentication required"**. The `wa_outbox` worker
counts every 401 as a generation failure → retry/backoff → `failed` after
`MAX_ATTEMPTS`. Net effect: the bot **received** inbound messages but could
**never answer**.

## Discovery

Found via a synthetic webhook injection (real inbound → webhook → enqueue →
scheduler → `bot_generate_fn`): the outbox row stuck at `attempts=3`,
`reply_error=null`. An **A/B probe** from inside the `api` machine proved it:
the same RAG call returned `401` without `X-Internal-Key` and **HTTP 200 + a
1750-char answer** with it.

## Fix

`_get_rag_client()` now attaches the `X-Internal-Key` header
(`settings.wa_mirror_internal_key`, Fly secret `WA_MIRROR_INTERNAL_KEY`) — the
same service-to-service channel Pro-side internal scripts use; the middleware
maps a matching key to a `role=internal` pseudo-user. Graceful: logs a WARNING
and omits the header if the key is unset (failure mode visible, not silent).

Header construction was hoisted to a `_rag_client_headers()` helper so the
`httpx.AsyncClient(...)` stays within 5 lines of its `is_closed` guard
(Golden Rule #10 `test_no_httpx_violators` guard).

## Tests

9/9 in `test_wa_inbox_bot.py` (3 new: header present when key configured;
absent + WARNING when unset; end-to-end client carries header) + the full
`backend/tests/` suite green (15371 passed) via the local pre-push gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)