### PR TITLE
fix(rag): streaming CRM pre-call reads tool_map via reasoning_engine, not core

### DIFF
--- a/apps/backend-rag/backend/services/rag/agentic/orchestrator_streaming_core.py
+++ b/apps/backend-rag/backend/services/rag/agentic/orchestrator_streaming_core.py
@@ -214,7 +214,13 @@ class OrchestratorStreamingCore:
         }
         query_lower = query.lower()
         if any(kw in query_lower for kw in _crm_keywords):
-            crm_tool = self.core.tool_map.get("crm_query")
+            # OrchestratorCore has no `tool_map`; the {name: tool} dict lives on
+            # its reasoning_engine (ReasoningEngine.tool_map). Accessing
+            # self.core.tool_map raised AttributeError on every CRM-keyword query
+            # (e.g. any Bahasa query with "berapa", or "how many"/"breakdown"),
+            # crashing the whole streaming path → the channel bot replied with a
+            # generic error. Non-streaming path was unaffected (never read tool_map).
+            crm_tool = self.core.reasoning_engine.tool_map.get("crm_query")
             if crm_tool:
                 try:
                     # Determine best query_type

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_streaming_crm_precall_toolmap.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_streaming_crm_precall_toolmap.py
@@ -1,0 +1,48 @@
+"""Regression test for the streaming CRM pre-call tool_map access.
+
+Bug (2026-06-21): `orchestrator_streaming_core.py` read `self.core.tool_map`,
+but OrchestratorCore has NO `tool_map` attribute — the {name: tool} dict lives
+on `OrchestratorCore.reasoning_engine.tool_map`. Any query containing a CRM
+keyword (e.g. Bahasa "berapa", "how many", "breakdown") entered the CRM pre-call
+branch and raised AttributeError, crashing the whole streaming path → the channel
+bot (Instagram/WhatsApp/Telegram) replied with a generic error. The non-streaming
+path was unaffected (it never reads tool_map).
+
+This test pins the correct access path so the regression cannot silently return.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from backend.services.rag.agentic import orchestrator_streaming_core
+
+
+def test_streaming_crm_precall_reads_toolmap_via_reasoning_engine():
+    """The CRM pre-call must read tool_map through reasoning_engine, not core."""
+    src = inspect.getsource(orchestrator_streaming_core)
+    # The broken access must be gone …
+    assert "self.core.tool_map.get" not in src, (
+        "Regression: streaming CRM pre-call reads self.core.tool_map, which "
+        "AttributeErrors (OrchestratorCore has no tool_map). Use "
+        "self.core.reasoning_engine.tool_map instead."
+    )
+    # … and the correct access must be present.
+    assert "self.core.reasoning_engine.tool_map.get(" in src
+
+
+def test_orchestrator_core_has_no_tool_map_but_reasoning_engine_does():
+    """Pin the structural fact the fix relies on: tool_map lives on
+    reasoning_engine, never directly on OrchestratorCore."""
+    from backend.services.rag.agentic.orchestrator_core import OrchestratorCore
+    from backend.services.rag.agentic.reasoning import ReasoningEngine
+
+    # OrchestratorCore.__init__ does not assign self.tool_map
+    core_src = inspect.getsource(OrchestratorCore.__init__)
+    assert "self.tool_map" not in core_src, (
+        "OrchestratorCore now sets self.tool_map — update the fix/test: the CRM "
+        "pre-call could read it directly again."
+    )
+    # ReasoningEngine.__init__ does assign self.tool_map
+    re_src = inspect.getsource(ReasoningEngine.__init__)
+    assert "self.tool_map" in re_src

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`325 routers · 625 services · 1070 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`325 routers · 625 services · 1071 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Problem — channel bots crash on any CRM-keyword query

Found while loop-testing the **Instagram bot** end-to-end (synthetic webhook
injection + DLQ content capture, focus: bot IG). Any message to the bot
(IG / WhatsApp / Telegram) containing a CRM keyword crashed and returned the
generic *"Mi dispiace, si è verificato un errore. Riprova tra poco."*

`_crm_keywords` includes **`"berapa"`** (= "how much" in Bahasa — extremely
common), `"how many"`, `"breakdown"`, `"leads"`, etc. So a very large slice of
real Indonesian/English traffic hit the crash.

## Root cause

`orchestrator_streaming_core.py` did `self.core.tool_map.get("crm_query")`, but
**`OrchestratorCore` has no `tool_map`** — the `{name: tool}` dict lives on
`OrchestratorCore.reasoning_engine.tool_map` (`ReasoningEngine.__init__`). The
CRM pre-call therefore raised `AttributeError: 'OrchestratorCore' object has no
attribute 'tool_map'`, surfaced as `Stream failed: ...` → the ConversationEngine
caught it and emitted the generic error to the user.

**Only the streaming path was affected** (channel bots use streaming). Proven by
an A/B probe: the non-streaming `/api/agentic-rag/query` returned a 2165-char
correct Bahasa tax answer for the exact query that crashed the bot.

## Fix

`self.core.reasoning_engine.tool_map.get("crm_query")` (one line) + a regression
test that pins both the correct access path and the structural fact (tool_map on
reasoning_engine, never on OrchestratorCore). Full `backend/tests/` suite green
via the local pre-push gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)