### PR TITLE
fix(monitoring): silence 3 false-positive alert sources (Olympus self-count, tiny-table dead-tuples, cell-weekly DSN)

### DIFF
--- a/apps/backend-rag/backend/services/monitoring/health_monitor.py
+++ b/apps/backend-rag/backend/services/monitoring/health_monitor.py
@@ -278,6 +278,16 @@ class HealthMonitor:
                 # dead / 777k live, frac 0.07) trip a >10000 "critical" — a pure
                 # false-positive (verified live 2026-06-20). Rank by fraction of the
                 # table's own threshold instead.
+                # Require a meaningful ABSOLUTE dead-tuple floor before ranking
+                # by fraction. A table with only a handful of dead tuples is never
+                # an operational concern — autovacuum clears it in one trivial
+                # pass. Tiny churning tables (e.g. wa_lid_phone_resolution: 79 dead,
+                # frac 1.2x; kg_proposals: 41 dead, frac 0.72) otherwise trip the
+                # warn threshold purely because their OWN autovacuum trigger is also
+                # tiny (50 + 0.2*live). A genuinely vacuum-starved table accumulates
+                # dead tuples without bound and clears this floor immediately, so the
+                # floor suppresses noise without hiding a real autovacuum failure.
+                min_dead = int(os.getenv("PG_DEAD_TUPLE_MIN", "1000"))
                 bloat = await conn.fetchrow(
                     """
                     SELECT relname,
@@ -287,10 +297,11 @@ class HealthMonitor:
                                + current_setting('autovacuum_vacuum_scale_factor')::float
                                  * n_live_tup, 0)) AS frac
                     FROM pg_stat_user_tables
-                    WHERE n_dead_tup > 0
+                    WHERE n_dead_tup >= $1
                     ORDER BY frac DESC NULLS LAST
                     LIMIT 1
-                    """
+                    """,
+                    min_dead,
                 )
                 worst_table = bloat["relname"] if bloat else None
                 worst_dead = int(bloat["n_dead_tup"]) if bloat and bloat["n_dead_tup"] else 0

--- a/apps/backend-rag/backend/services/olympus/heartbeat.py
+++ b/apps/backend-rag/backend/services/olympus/heartbeat.py
@@ -215,9 +215,21 @@ class Heartbeat:
 
     @staticmethod
     async def _count_long_queries(conn: asyncpg.Connection, threshold_seconds: int) -> int:
+        # Exclude this very probe connection and any background/auxiliary
+        # processes: pg_stat_activity lists autovacuum workers, walsenders and
+        # the monitoring connection itself, all of which can sit "active" past
+        # the threshold without being a stuck client query. Counting them made
+        # Olympus report "1 long-running query" every single heartbeat cycle
+        # (verified 2026-06-21: pg_stat_activity live = 0 genuinely stuck) — a
+        # perpetual false-positive. Restrict to real client backends other than
+        # ourselves, in our own database.
         row = await conn.fetchrow(
             "SELECT count(*) AS cnt FROM pg_stat_activity "
-            "WHERE state = 'active' AND query_start < now() - make_interval(secs => $1)",
+            "WHERE state = 'active' "
+            "AND backend_type = 'client backend' "
+            "AND pid <> pg_backend_pid() "
+            "AND datname = current_database() "
+            "AND query_start < now() - make_interval(secs => $1)",
             threshold_seconds,
         )
         return int(row["cnt"]) if row else 0

--- a/apps/cell/scripts/cell_weekly_report_cron.sh
+++ b/apps/cell/scripts/cell_weekly_report_cron.sh
@@ -17,6 +17,11 @@ SECRETS_FILE="${HOME}/.nuzantara-secrets.env"
 if [ -f "${SECRETS_FILE}" ]; then
     set -a; source "${SECRETS_FILE}"; set +a
 fi
+# Honour the fallback this script's own comment promises ("CELL_DATABASE_URL or
+# DATABASE_URL key"): the generic DATABASE_URL points at the same Fly Postgres,
+# so use it when the cell-specific var is absent. Without this the report failed
+# every Sunday since 2026-05-10 (exit 3) despite the DSN being present in secrets.
+: "${CELL_DATABASE_URL:=${DATABASE_URL:-}}"
 if [ -z "${CELL_DATABASE_URL:-}" ]; then
     echo "[cell-weekly-report] FATAL: CELL_DATABASE_URL not set." >&2
     echo "[cell-weekly-report]        Add it to ${SECRETS_FILE} or export before running." >&2


### PR DESCRIPTION
Three monitors were firing on **non-faults** — the recurring Zantara alert-wall noise (triage 2026-06-21). Each is a class-b false-positive verified on disk/live.

### 1. Olympus "1 long-running query" every ~10min, all night
`olympus/heartbeat.py::_count_long_queries` counted **every** `pg_stat_activity` row active past 30s — including autovacuum workers, walsenders, and Olympus's **own probe connection**. `pg_stat_activity` showed **0** genuinely-stuck client queries (verified live). Now restricted to real client backends other than ourselves, in our own DB:
```sql
AND backend_type = 'client backend' AND pid <> pg_backend_pid() AND datname = current_database()
```

### 2. Dead-tuple warn on a tiny churning table
`health_monitor.py` fired `1.2x autovacuum trigger on wa_lid_phone_resolution (79 dead tuples)`. The #1599 ratio logic is right for big tables, but a tiny table trips `frac>=1.2` on a trivial absolute count (its own autovacuum trigger is also tiny: `50 + 0.2*live`). Added an absolute floor `PG_DEAD_TUPLE_MIN` (default **1000**) before ranking by fraction. A genuinely vacuum-starved table accumulates dead tuples without bound and clears 1000 instantly → noise gone, real autovacuum failures still caught. (Verified via live `pg_stat_user_tables`: only tiny churners — kg_proposals 41, intake_gate_doc_counts 36 — were in the high-frac band; api_audit_trail 50995 dead correctly sits at frac 0.34.)

### 3. cell-weekly-report exit 3 every Sunday since 2026-05-10
The script `FATAL: CELL_DATABASE_URL not set` despite the DSN being present in secrets as `DATABASE_URL`. The script's own comment promised a "CELL_DATABASE_URL or DATABASE_URL key" fallback that was never implemented. Added it: `: "${CELL_DATABASE_URL:=${DATABASE_URL:-}}"`.

**Tests:** health_monitor 55/55, olympus heartbeat 6/6. #1 and #2 take effect on next Fly deploy of `nuzantara-rag`; #3 on next Sunday cron run (no deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)