### PR TITLE
fix(intake): add --revive-stub to recover whatsapp docs the stub passthrough lost

### DIFF
--- a/apps/backend-rag/backend/tests/scripts/test_intake_reprocess_backlog.py
+++ b/apps/backend-rag/backend/tests/scripts/test_intake_reprocess_backlog.py
@@ -150,3 +150,15 @@ def test_supersede_sql_only_touches_review_pending() -> None:
     sql = irb.REPROCESS_SUPERSEDE_SQL
     assert "'superseded'" in sql
     assert "status = 'review_pending'" in sql  # never clobbers claimed/routed rows
+
+
+def test_revive_stub_select_guards_are_all_present() -> None:
+    irb = _load()
+    sql = irb.REVIVE_STUB_SELECT_SQL
+    # Every guard is load-bearing — losing one widens the recovery scope wrongly.
+    assert "stage_output->'route'->>'stub' = 'true'" in sql  # stub passthrough only
+    assert "iq.source = 'whatsapp'" in sql  # own-channel, not the admin Drive dump
+    assert "iq.sender_phone IS NOT NULL" in sql  # a real owner exists
+    assert "NOT EXISTS" in sql  # exclude rows that already carry a proposal
+    assert "/groups/" in sql  # the group-chat opt-out predicate
+    assert "$1::bool" in sql  # include_groups toggle

--- a/scripts/intake_reprocess_backlog.py
+++ b/scripts/intake_reprocess_backlog.py
@@ -51,6 +51,7 @@ logger = logging.getLogger("intake_reprocess_backlog")
 
 DEFAULT_DSN = "postgresql://nuzantara@127.0.0.1:5432/nuzantara_dev"
 DEFAULT_PIPELINE_VERSION = "v2.1-retro"
+DEFAULT_STUB_REVIVE_VERSION = "v2.1-stub-revive"
 DEFAULT_MEDIA_TYPES = ("document", "image")
 
 # Sweeper watermark file (the backfill ceiling: rows ABOVE it are the sweeper's).
@@ -89,6 +90,38 @@ UPDATE intake_queue
        stage_output     = '{}'::jsonb,
        pipeline_version = $2
  WHERE id = ANY($1::bigint[])
+"""
+
+# WhatsApp docs the stub passthrough stage (worker._stub_stage) marked 'done'
+# with NO real OCR/classify/route — so no proposal was ever created and the doc
+# never reached /review (silently lost). Created during the 2026-06 stub-handler
+# window. Recover them by applying the SAME v2 reset contract so the live worker
+# (real handlers) re-runs them end-to-end and emits a fresh proposal.
+#
+# Scope guards (each load-bearing, verified live 2026-06-21 against nuzantara_dev):
+#   - source='whatsapp'                       → own-channel docs only, never the
+#                                               Drive/Dropbox admin dump.
+#   - sender_phone present                    → a real sender exists (an owner).
+#   - NO proposal at all (NOT EXISTS)         → exclude rows that already carry a
+#                                               proposal (399 had a LIVE one, in
+#                                               /review); re-enqueuing dups them.
+#   - $1 include_groups OR not under /groups/ → 1:1 direct chats by default; group
+#                                               docs are mixed-confidence (client
+#                                               groups AND team/vendor noise) and
+#                                               can flood a reviewer's /review, so
+#                                               they are opt-in only.
+REVIVE_STUB_SELECT_SQL = """
+SELECT iq.id
+FROM intake_queue iq
+WHERE iq.status = 'done'
+  AND iq.stage_output->'route'->>'stub' = 'true'
+  AND iq.source = 'whatsapp'
+  AND iq.sender_phone IS NOT NULL AND iq.sender_phone <> ''
+  AND ($1::bool OR iq.blob_path NOT LIKE '%/groups/%')
+  AND NOT EXISTS (
+      SELECT 1 FROM document_routing_proposal p WHERE p.queue_id = iq.id
+  )
+ORDER BY iq.id
 """
 
 # Historical inbound media with NO intake_queue row (anti-join on source_ref).
@@ -178,6 +211,38 @@ async def run_reprocess(
     return counts
 
 
+async def run_revive_stub(
+    pool: asyncpg.Pool, pipeline_version: str, include_groups: bool, apply: bool
+) -> dict[str, int]:
+    """Re-enqueue whatsapp docs the stub passthrough marked done with no proposal.
+
+    Applies the v2 worker reset contract (same as --reprocess) so the live worker
+    re-runs OCR/classify/route end-to-end and emits a fresh proposal into /review.
+    """
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(REVIVE_STUB_SELECT_SQL, include_groups)
+        queue_ids = [r["id"] for r in rows]
+        counts = {"queue_rows": len(queue_ids)}
+        if not apply:
+            logger.info(
+                "[revive-stub][DRY-RUN] would reset %d stub-skipped whatsapp queue "
+                "rows (include_groups=%s) to pipeline_version=%s (pass --apply)",
+                counts["queue_rows"], include_groups, pipeline_version,
+            )
+            return counts
+
+        async with conn.transaction():
+            reset = await conn.execute(REPROCESS_RESET_SQL, queue_ids, pipeline_version)
+        counts["reset"] = int(reset.split()[-1]) if reset else 0
+
+    logger.info(
+        "[revive-stub] reset=%d stub-skipped whatsapp queue rows (include_groups=%s, "
+        "pipeline_version=%s) — the intake worker will re-OCR + re-route them",
+        counts.get("reset", 0), include_groups, pipeline_version,
+    )
+    return counts
+
+
 async def run_backfill(
     pool: asyncpg.Pool,
     watermark: int,
@@ -234,6 +299,12 @@ def build_parser() -> argparse.ArgumentParser:
                    help="supersede unknown/NO_MATCH review_pending proposals + reset queue rows")
     p.add_argument("--backfill", action="store_true",
                    help="enqueue historical wa-mirror media skipped by the watermark seed")
+    p.add_argument("--revive-stub", action="store_true",
+                   help="re-enqueue whatsapp docs the stub passthrough marked done with no proposal")
+    p.add_argument("--include-groups", action="store_true",
+                   help="for --revive-stub: also revive group-chat docs (default: 1:1 direct chats only)")
+    p.add_argument("--stub-pipeline-version", default=DEFAULT_STUB_REVIVE_VERSION,
+                   help=f"bumped pipeline_version for --revive-stub (default {DEFAULT_STUB_REVIVE_VERSION})")
     p.add_argument("--apply", action="store_true",
                    help="actually write (default: dry-run, counts only)")
     p.add_argument("--pipeline-version", default=DEFAULT_PIPELINE_VERSION,
@@ -252,8 +323,8 @@ async def main(argv: list[str] | None = None) -> int:
         handlers=[logging.StreamHandler(sys.stdout)],
     )
     args = build_parser().parse_args(argv)
-    if not (args.reprocess or args.backfill):
-        logger.error("nothing to do: pass --backfill and/or --reprocess")
+    if not (args.reprocess or args.backfill or args.revive_stub):
+        logger.error("nothing to do: pass --backfill and/or --reprocess and/or --revive-stub")
         return 2
 
     db_url = os.getenv(
@@ -273,6 +344,10 @@ async def main(argv: list[str] | None = None) -> int:
             await run_backfill(pool, watermark, _media_types(args.media_types), args.apply)
         if args.reprocess:
             await run_reprocess(pool, args.pipeline_version, args.apply)
+        if args.revive_stub:
+            await run_revive_stub(
+                pool, args.stub_pipeline_version, args.include_groups, args.apply
+            )
         return 0
     finally:
         await pool.close()


### PR DESCRIPTION
## What

Adds a `--revive-stub` mode to `scripts/intake_reprocess_backlog.py`.

During the 2026-06 stub-handler window the intake worker's stub passthrough stage (`worker._stub_stage`) marked WhatsApp docs `status='done'` with no real OCR/classify/route — so no `document_routing_proposal` was ever created and the doc never reached `/review`. These docs were silently lost.

## How

The new mode re-enqueues them by applying the SAME v2 worker reset contract (`status='pending'`, `stage=NULL`, lease cleared, `attempts=0`, `next_visible_at=now()`, `stage_output='{}'`) with a bumped `pipeline_version` so the live worker (with real handlers) re-runs them end-to-end and emits a fresh proposal into `/review`.

Scope guards (each load-bearing):
- `source='whatsapp'` only (never the Drive/Dropbox admin dump)
- `sender_phone` present (a real owner exists)
- `NOT EXISTS` any proposal — the 399 rows that already carry a LIVE proposal (already in `/review`) are excluded, so re-enqueuing never dups them
- 1:1 direct chats by default (**272**). Group-chat docs are mixed-confidence (client groups AND team/vendor noise) and can flood `/review`, so they are opt-in via `--include-groups` (**212** more)

## Verification

- `python3 -m py_compile` passes
- `pytest backend/tests/scripts/test_intake_reprocess_backlog.py` → 12 passed (added `test_revive_stub_select_guards_are_all_present`)
- Dry-run: 272 direct / 484 with groups
- **Recovery applied live on `nuzantara_dev`: reset=272 direct docs; residual direct stub-skipped docs verified =0 on disk**

🤖 Generated with [Claude Code](https://claude.com/claude-code)