### PR TITLE
fix(migrations): rename 234 collision routing_proposal → 235 (W40 antibody)

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/235_routing_proposal_quarantine_autorouted.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/235_routing_proposal_quarantine_autorouted.sql
@@ -1,4 +1,4 @@
--- Migration 234: document_routing_proposal — allow status='quarantine' + 'auto_routed' + 'duplicate'.
+-- Migration 235: document_routing_proposal — allow status='quarantine' + 'auto_routed' + 'duplicate'.
 --
 -- Three review-load-reduction levers (research/operations/2026-06-21-intake-review-time-reduction.md):
 --
@@ -30,7 +30,7 @@
 --
 -- On the Pro apply manually like 212-233:
 --   psql postgresql://nuzantara@127.0.0.1:5432/nuzantara_dev \
---     -f apps/backend-rag/backend/db/migrations_v2/234_routing_proposal_quarantine_autorouted.sql
+--     -f apps/backend-rag/backend/db/migrations_v2/235_routing_proposal_quarantine_autorouted.sql
 -- === FORWARD ===
 
 ALTER TABLE document_routing_proposal DROP CONSTRAINT IF EXISTS chk_rp_status;
@@ -39,7 +39,7 @@ ALTER TABLE document_routing_proposal ADD CONSTRAINT chk_rp_status CHECK (status
      'quarantine','auto_routed','duplicate'));
 
 COMMENT ON CONSTRAINT chk_rp_status ON document_routing_proposal IS
-    'Proposal lifecycle (migration 234): review states + terminal routed/auto_routed/rejected/dead + superseded (re-pipelined) + quarantine (noise parked) + duplicate (LEVA-3 dedup wall: client already has this doc_type on profile, parked out of /review).';
+    'Proposal lifecycle (migration 235): review states + terminal routed/auto_routed/rejected/dead + superseded (re-pipelined) + quarantine (noise parked) + duplicate (LEVA-3 dedup wall: client already has this doc_type on profile, parked out of /review).';
 
 -- === ROLLBACK ===
 -- (Only safe when no rows carry status='quarantine' or 'auto_routed'.)


### PR DESCRIPTION
## What

Two migrations landed on `main` with the **same number 234**:

| File | Commit | Order |
|------|--------|-------|
| `234_crm_wa_case_intelligence.sql` | `d3dd75df1` | first — **keeps 234** |
| `234_routing_proposal_quarantine_autorouted.sql` | `0167c1770` (#1604) | second — **yields → 235** |

Each was unique *within its own PR*, so `lint-migration-numbers.yml` (which only runs on `pull_request`) never saw the clash. The collision is now live on `main` and the **W40 pre-commit antibody** fails on every merge-commit that touches `migrations_v2/`.

## Fix

Per the W40 convention (the file that arrived **second** in git-log time yields), rename the #1604 routing-proposal migration `234 → 235`, updating its three internal `234` references (header, example path, lifecycle comment). No external code or test references the old path (`grep` clean — migrations are tracked by `migration_number`, and nothing hard-codes this one).

## Safety in prod

The body is **idempotent** — `DROP CONSTRAINT IF EXISTS chk_rp_status` + `ADD CONSTRAINT chk_rp_status CHECK (...)`, the same "cheap metadata swap" pattern as migration 226. Since #1604 already applied this as 234 in prod, re-running it as 235 is a no-op constraint swap: zero data risk.

## Verification

- `python scripts/lint_migration_numbers.py` → **119 files, all unique prefixes** ✅
- W42 rollback-marker lint green ✅
- Renamed file has **zero residual `234`** references.

Unblocks merge-commits touching `migrations_v2/` (including the portal P1 fix PR #1625).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
