### PR TITLE
fix(migrations): resolve 234 collision on main — rename second-lander to 235 (W40)

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/235_routing_proposal_quarantine_autorouted.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/235_routing_proposal_quarantine_autorouted.sql
@@ -1,4 +1,4 @@
--- Migration 234: document_routing_proposal — allow status='quarantine' + 'auto_routed' + 'duplicate'.
+-- Migration 235: document_routing_proposal — allow status='quarantine' + 'auto_routed' + 'duplicate'.
 --
 -- Three review-load-reduction levers (research/operations/2026-06-21-intake-review-time-reduction.md):
 --
@@ -30,7 +30,7 @@
 --
 -- On the Pro apply manually like 212-233:
 --   psql postgresql://nuzantara@127.0.0.1:5432/nuzantara_dev \
---     -f apps/backend-rag/backend/db/migrations_v2/234_routing_proposal_quarantine_autorouted.sql
+--     -f apps/backend-rag/backend/db/migrations_v2/235_routing_proposal_quarantine_autorouted.sql
 -- === FORWARD ===
 
 ALTER TABLE document_routing_proposal DROP CONSTRAINT IF EXISTS chk_rp_status;
@@ -39,7 +39,7 @@ ALTER TABLE document_routing_proposal ADD CONSTRAINT chk_rp_status CHECK (status
      'quarantine','auto_routed','duplicate'));
 
 COMMENT ON CONSTRAINT chk_rp_status ON document_routing_proposal IS
-    'Proposal lifecycle (migration 234): review states + terminal routed/auto_routed/rejected/dead + superseded (re-pipelined) + quarantine (noise parked) + duplicate (LEVA-3 dedup wall: client already has this doc_type on profile, parked out of /review).';
+    'Proposal lifecycle (migration 235): review states + terminal routed/auto_routed/rejected/dead + superseded (re-pipelined) + quarantine (noise parked) + duplicate (LEVA-3 dedup wall: client already has this doc_type on profile, parked out of /review).';
 
 -- === ROLLBACK ===
 -- (Only safe when no rows carry status='quarantine' or 'auto_routed'.)


### PR DESCRIPTION
## Problem (fleet-wide blocker)
Two PRs merged to `main` with the **same migration number 234**, leaving `migrations_v2/` permanently duplicated:

| file | landed | source |
|---|---|---|
| `234_crm_wa_case_intelligence.sql` | 08:26 | case-intelligence PR |
| `234_routing_proposal_quarantine_autorouted.sql` | 09:02 | #1604 (intake 2-levers) |

`Hot-zone enforcement` replays `lint_migration_numbers.py` **against the base ref (main)** — so a broken `main` fails the check on **every open PR**, not just the one that introduced it. Confirmed live: PR #1628's Hot-zone failed on its own clean HEAD (`lint` = 119 unique there) because the replay runs on main's tree.

## Fix (W40 convention)
cicatrix RESOLVED 2026-05-23 W40: the file that arrived **second** in git-log time yields and is renamed to the next free number. `234_routing` (09:02) is the second-lander → renamed `234 → 235`. SQL header comment, self-referenced apply path, and lifecycle comment updated to match. No `tests/*` reference the old path.

`lint_migration_numbers.py` → ✅ 119 files, all unique prefixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)