### PR TITLE
fix(wa-dashboard): skip stale clients when publishing case intelligence

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/235_routing_proposal_quarantine_autorouted.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/235_routing_proposal_quarantine_autorouted.sql
@@ -1,4 +1,4 @@
--- Migration 234: document_routing_proposal — allow status='quarantine' + 'auto_routed' + 'duplicate'.
+-- Migration 235: document_routing_proposal — allow status='quarantine' + 'auto_routed' + 'duplicate'.
 --
 -- Three review-load-reduction levers (research/operations/2026-06-21-intake-review-time-reduction.md):
 --
@@ -28,9 +28,9 @@
 -- existing row keeps a value that is still in the new set, so the ADD validates
 -- with no row rewrite).
 --
--- On the Pro apply manually like 212-233:
+-- On the Pro apply manually like 212-234:
 --   psql postgresql://nuzantara@127.0.0.1:5432/nuzantara_dev \
---     -f apps/backend-rag/backend/db/migrations_v2/234_routing_proposal_quarantine_autorouted.sql
+--     -f apps/backend-rag/backend/db/migrations_v2/235_routing_proposal_quarantine_autorouted.sql
 -- === FORWARD ===
 
 ALTER TABLE document_routing_proposal DROP CONSTRAINT IF EXISTS chk_rp_status;
@@ -39,7 +39,7 @@ ALTER TABLE document_routing_proposal ADD CONSTRAINT chk_rp_status CHECK (status
      'quarantine','auto_routed','duplicate'));
 
 COMMENT ON CONSTRAINT chk_rp_status ON document_routing_proposal IS
-    'Proposal lifecycle (migration 234): review states + terminal routed/auto_routed/rejected/dead + superseded (re-pipelined) + quarantine (noise parked) + duplicate (LEVA-3 dedup wall: client already has this doc_type on profile, parked out of /review).';
+    'Proposal lifecycle (migration 235): review states + terminal routed/auto_routed/rejected/dead + superseded (re-pipelined) + quarantine (noise parked) + duplicate (LEVA-3 dedup wall: client already has this doc_type on profile, parked out of /review).';
 
 -- === ROLLBACK ===
 -- (Only safe when no rows carry status='quarantine' or 'auto_routed'.)

--- a/apps/backend-rag/backend/db/migrations_v2/235_routing_proposal_quarantine_autorouted.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/235_routing_proposal_quarantine_autorouted.sql
@@ -28,7 +28,7 @@
 -- existing row keeps a value that is still in the new set, so the ADD validates
 -- with no row rewrite).
 --
--- On the Pro apply manually like 212-234:
+-- On the Pro apply manually like 212-233:
 --   psql postgresql://nuzantara@127.0.0.1:5432/nuzantara_dev \
 --     -f apps/backend-rag/backend/db/migrations_v2/235_routing_proposal_quarantine_autorouted.sql
 -- === FORWARD ===

--- a/apps/wa-dashboard-m1/publish-case-intelligence.cjs
+++ b/apps/wa-dashboard-m1/publish-case-intelligence.cjs
@@ -425,6 +425,50 @@ async function publishRows(databaseUrl, rows) {
   return { inserted, updated };
 }
 
+async function filterRowsWithExistingClients(databaseUrl, rows) {
+  if (!rows.length) {
+    return {
+      rows,
+      skippedMissingRows: 0,
+      skippedMissingClients: 0,
+    };
+  }
+
+  const clientIds = uniqueBy(rows, (row) => row.client_id).map(
+    (row) => row.client_id,
+  );
+  const pool = new Pool({
+    connectionString: databaseUrl,
+    max: 1,
+    idleTimeoutMillis: 30000,
+  });
+
+  try {
+    const result = await pool.query(
+      "SELECT id FROM clients WHERE id = ANY($1::bigint[])",
+      [clientIds],
+    );
+    const existingClientIds = new Set(
+      result.rows.map((row) => Number(row.id)),
+    );
+    const validRows = rows.filter((row) =>
+      existingClientIds.has(row.client_id),
+    );
+    const skippedRows = rows.filter(
+      (row) => !existingClientIds.has(row.client_id),
+    );
+
+    return {
+      rows: validRows,
+      skippedMissingRows: skippedRows.length,
+      skippedMissingClients: new Set(skippedRows.map((row) => row.client_id))
+        .size,
+    };
+  } finally {
+    await pool.end();
+  }
+}
+
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   const [overview, analysisPayload] = await Promise.all([
@@ -463,14 +507,21 @@ async function main() {
     return;
   }
 
-  const result = await publishRows(options.databaseUrl, rows);
+  const filtered = await filterRowsWithExistingClients(
+    options.databaseUrl,
+    rows,
+  );
+  const result = await publishRows(options.databaseUrl, filtered.rows);
   console.log(
     JSON.stringify(
       {
         mode: "published",
         dashboard_url: options.dashboardUrl,
         matched_rows: rows.length,
-        clients: new Set(rows.map((row) => row.client_id)).size,
+        published_rows: filtered.rows.length,
+        clients: new Set(filtered.rows.map((row) => row.client_id)).size,
+        skipped_missing_client_rows: filtered.skippedMissingRows,
+        skipped_missing_clients: filtered.skippedMissingClients,
         inserted: result.inserted,
         updated: result.updated,
       },


### PR DESCRIPTION
## Summary
- keep WA case intelligence publishing from failing when the WhatsApp mirror points to client IDs no longer present in CRM
- filter rows against production clients before insert/update
- report skipped missing-client rows and client counts in the publisher output

## Verification
- /opt/homebrew/bin/node --check apps/wa-dashboard-m1/publish-case-intelligence.cjs
- python3 scripts/lint_migration_numbers.py
- PR diff now only touches apps/wa-dashboard-m1/publish-case-intelligence.cjs

## Production context
- The original migration 234 collision was resolved separately by PR #1630 and backend deploy v3608 is healthy.