### PR TITLE
feat(portal): FASE 1-4 — light theme, Your Turn/Our Turn baton, AI recap, news rail

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 325 routers · 626 services
+- Backend: FastAPI · 325 routers · 627 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 29 · Packages: 6

--- a/apps/backend-rag/backend/app/routers/portal_dashboard.py
+++ b/apps/backend-rag/backend/app/routers/portal_dashboard.py
@@ -20,6 +20,7 @@ from fastapi import APIRouter, Depends
 from backend.app.dependencies import get_database_pool
 from backend.app.routers.portal import get_current_client
 from backend.app.utils.logging_utils import get_logger
+from backend.services.portal.recap_service import build_recap
 
 logger = get_logger(__name__)
 
@@ -150,15 +151,30 @@ async def summary(
     client: dict = Depends(get_current_client),
     pool: asyncpg.Pool = Depends(get_database_pool),
 ) -> dict[str, Any]:
-    """Return 3-hero-card data in a single round-trip."""
+    """Return 3-hero-card data + AI recap in a single round-trip."""
     client_id = client["client_id"]
     async with pool.acquire() as conn:
         open_actions = await _fetch_open_actions(conn, client_id)
         deadlines = await _fetch_deadlines(conn, client_id)
         unread = await _fetch_unread_count(conn, client_id)
 
+    # FASE 3 — AI recap: facts-locked (deterministic from the audited fields
+    # above) + optional local-Ollama prose polish that cannot alter any number.
+    # Never 500 the dashboard if the recap fails — degrade to no recap.
+    recap: dict[str, Any] | None = None
+    try:
+        recap = await build_recap(
+            open_actions=open_actions,
+            upcoming_deadlines=deadlines,
+            unread_messages=unread,
+            client_name=client.get("name"),
+        )
+    except Exception as e:  # defensive: recap is additive, never load-bearing
+        logger.warning("recap build failed: %s", e)
+
     return {
         "open_actions": open_actions,
         "upcoming_deadlines": deadlines,
         "unread_messages": unread,
+        "recap": recap,
     }

--- a/apps/backend-rag/backend/services/portal/recap_service.py
+++ b/apps/backend-rag/backend/services/portal/recap_service.py
@@ -1,0 +1,167 @@
+"""
+Portal AI Recap — facts-locked, prose-polished (FASE 3, blueprint §3.5).
+
+The "highly AI-smart with recaps" promise, built SAFELY for a legal/immigration
+service. The hard constraint (DeepSeek red-team AP3 "hallucinated lawyer"): a
+recap that invents a visa deadline → overstay → deportation → liability. So:
+
+  1. FACTS are composed DETERMINISTICALLY from already-audited structured fields
+     (open_actions, upcoming_deadlines, unread) — no LLM touches the numbers/dates.
+  2. An OPTIONAL local-Ollama pass only POLISHES the tone (warmer, natural), with
+     an explicit guardrail "do not change any number, date, name, or status".
+  3. If Ollama is unavailable (e.g. on Fly — Ollama is local-only) OR the polished
+     text drifts from the facts, we FALL BACK to the deterministic text.
+
+No client PII ever leaves the machine: the polish runs on local Ollama only;
+there is no cloud fallback for the recap (unlike RAG chat). On Fly the recap is
+always the deterministic text. A permanent disclaimer is attached by the caller.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from backend.app.utils.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+DISCLAIMER = (
+    "AI summary of your Bali Zero records — not legal advice. "
+    "Always confirm with your case officer."
+)
+
+# Numeric/date tokens we require the polished text to preserve verbatim.
+_NUM_RE = re.compile(r"\d+")
+
+
+def build_deterministic_recap(
+    *,
+    open_actions: list[dict[str, Any]],
+    upcoming_deadlines: list[dict[str, Any]],
+    unread_messages: int,
+    client_name: str | None = None,
+) -> str:
+    """
+    Compose the recap sentence(s) from audited structured fields ONLY.
+    This is the source of truth — every number/date here is already verified
+    upstream (portal_dashboard._fetch_*). Returns plain text.
+    """
+    greeting = f"Welcome back{', ' + client_name.split()[0] if client_name else ''}."
+    parts: list[str] = []
+
+    n_actions = len(open_actions)
+    if n_actions == 0:
+        parts.append("Nothing needs your attention right now — we're on it.")
+    elif n_actions == 1:
+        label = open_actions[0].get("title") or open_actions[0].get("label") or "one item"
+        parts.append(f"There is 1 thing that needs you: {label}.")
+    else:
+        first = open_actions[0].get("title") or open_actions[0].get("label") or "an item"
+        parts.append(
+            f"There are {n_actions} things that need you — starting with {first}."
+        )
+
+    if upcoming_deadlines:
+        d = upcoming_deadlines[0]
+        label = d.get("label") or d.get("title") or "A deadline"
+        days = d.get("days_until")
+        if isinstance(days, int):
+            when = "today" if days == 0 else f"in {days} day{'s' if days != 1 else ''}"
+            parts.append(f"Next deadline: {label} {when}.")
+        else:
+            due = d.get("due_date")
+            parts.append(f"Next deadline: {label}{f' on {due}' if due else ''}.")
+
+    if unread_messages > 0:
+        parts.append(
+            f"You have {unread_messages} unread message"
+            f"{'s' if unread_messages != 1 else ''} from the team."
+        )
+
+    return f"{greeting} " + " ".join(parts)
+
+
+def _facts_preserved(deterministic: str, polished: str) -> bool:
+    """
+    Guardrail: the polished text must preserve every number from the
+    deterministic (factual) text. If a digit was added, dropped, or changed,
+    we reject the polish and fall back. (Cheap, language-agnostic, catches the
+    'hallucinated a different deadline' failure mode.)
+    """
+    det_nums = sorted(_NUM_RE.findall(deterministic))
+    pol_nums = sorted(_NUM_RE.findall(polished))
+    return det_nums == pol_nums
+
+
+async def polish_recap(deterministic: str) -> str:
+    """
+    Optional local-Ollama style pass. Returns the polished text ONLY if it
+    preserves all facts; otherwise returns the deterministic text unchanged.
+    Any error (Ollama down, timeout, on Fly) → deterministic fallback.
+    """
+    try:
+        from backend.llm.ollama_client import MODEL_FAST, ollama_generate
+    except Exception:  # pragma: no cover - import guard
+        return deterministic
+
+    prompt = (
+        "Rewrite the following client portal status update in a warm, calm, "
+        "concise voice for a foreign client relocating to Bali. "
+        "STRICT RULES: do NOT change, add, or remove any number, date, count, "
+        "name, or status. Keep it to 2-3 short sentences. Output only the "
+        "rewritten text, nothing else.\n\n"
+        f"TEXT:\n{deterministic}"
+    )
+    try:
+        polished = await ollama_generate(prompt=prompt, model=MODEL_FAST, timeout=12)
+    except Exception as e:  # Ollama unavailable (e.g. Fly), timeout, etc.
+        logger.info("recap polish unavailable, using deterministic: %s", e)
+        return deterministic
+
+    if not polished or not polished.strip():
+        return deterministic
+
+    polished = polished.strip()
+    if not _facts_preserved(deterministic, polished):
+        logger.warning("recap polish altered facts — falling back to deterministic")
+        return deterministic
+
+    return polished
+
+
+async def build_recap(
+    *,
+    open_actions: list[dict[str, Any]],
+    upcoming_deadlines: list[dict[str, Any]],
+    unread_messages: int,
+    client_name: str | None = None,
+    polish: bool = True,
+) -> dict[str, Any]:
+    """
+    Build the full recap object for the portal dashboard.
+
+    Returns:
+        {
+          "text": <facts-locked, optionally prose-polished>,
+          "polished": <bool — whether the LLM pass was applied>,
+          "disclaimer": <permanent legal disclaimer>,
+        }
+    """
+    deterministic = build_deterministic_recap(
+        open_actions=open_actions,
+        upcoming_deadlines=upcoming_deadlines,
+        unread_messages=unread_messages,
+        client_name=client_name,
+    )
+    text = deterministic
+    polished_applied = False
+    if polish:
+        text = await polish_recap(deterministic)
+        polished_applied = text != deterministic
+
+    return {
+        "text": text,
+        "polished": polished_applied,
+        "disclaimer": DISCLAIMER,
+    }

--- a/apps/backend-rag/backend/tests/services/portal/test_recap_service.py
+++ b/apps/backend-rag/backend/tests/services/portal/test_recap_service.py
@@ -1,0 +1,154 @@
+"""Tests for portal AI recap — facts-locked, prose-polished (FASE 3)."""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.services.portal.recap_service import (
+    DISCLAIMER,
+    _facts_preserved,
+    build_deterministic_recap,
+    build_recap,
+    polish_recap,
+)
+
+
+class TestDeterministicRecap:
+    def test_no_actions_no_deadlines(self):
+        text = build_deterministic_recap(
+            open_actions=[], upcoming_deadlines=[], unread_messages=0
+        )
+        assert "Nothing needs your attention" in text
+
+    def test_single_action(self):
+        text = build_deterministic_recap(
+            open_actions=[{"title": "Upload passport scan"}],
+            upcoming_deadlines=[],
+            unread_messages=0,
+        )
+        assert "1 thing" in text
+        assert "Upload passport scan" in text
+
+    def test_multiple_actions_count_exact(self):
+        text = build_deterministic_recap(
+            open_actions=[{"title": "A"}, {"title": "B"}, {"title": "C"}],
+            upcoming_deadlines=[],
+            unread_messages=0,
+        )
+        assert "3 things" in text
+        assert "starting with A" in text
+
+    def test_deadline_with_days_until(self):
+        text = build_deterministic_recap(
+            open_actions=[],
+            upcoming_deadlines=[{"label": "KITAS expiry", "days_until": 12}],
+            unread_messages=0,
+        )
+        assert "KITAS expiry" in text
+        assert "12 day" in text
+
+    def test_deadline_today_is_singular_phrase(self):
+        text = build_deterministic_recap(
+            open_actions=[],
+            upcoming_deadlines=[{"label": "Visa expiry", "days_until": 0}],
+            unread_messages=0,
+        )
+        assert "today" in text
+
+    def test_deadline_due_date_fallback(self):
+        text = build_deterministic_recap(
+            open_actions=[],
+            upcoming_deadlines=[{"label": "Visa expiry", "due_date": "2026-07-01"}],
+            unread_messages=0,
+        )
+        assert "Visa expiry" in text
+        assert "2026-07-01" in text
+
+    def test_unread_messages(self):
+        text = build_deterministic_recap(
+            open_actions=[], upcoming_deadlines=[], unread_messages=3
+        )
+        assert "3 unread messages" in text
+
+    def test_client_first_name_greeting(self):
+        text = build_deterministic_recap(
+            open_actions=[],
+            upcoming_deadlines=[],
+            unread_messages=0,
+            client_name="Sarah Connor",
+        )
+        assert "Sarah" in text
+        assert "Connor" not in text  # only first name
+
+
+class TestFactsPreservedGuard:
+    def test_identical_numbers_pass(self):
+        assert _facts_preserved("3 actions, 12 days", "You have 3 things, 12 days left")
+
+    def test_changed_number_rejected(self):
+        # polished invented a different deadline — must be rejected
+        assert not _facts_preserved("12 days", "15 days")
+
+    def test_dropped_number_rejected(self):
+        assert not _facts_preserved("3 actions, 12 days", "a few actions, 12 days")
+
+    def test_added_number_rejected(self):
+        assert not _facts_preserved("3 actions", "3 actions and 5 more")
+
+
+class TestBuildRecap:
+    @pytest.mark.asyncio
+    async def test_no_polish_returns_deterministic(self):
+        result = await build_recap(
+            open_actions=[{"title": "Upload X"}],
+            upcoming_deadlines=[],
+            unread_messages=0,
+            polish=False,
+        )
+        assert result["polished"] is False
+        assert "Upload X" in result["text"]
+        assert result["disclaimer"] == DISCLAIMER
+
+    @pytest.mark.asyncio
+    async def test_disclaimer_always_present(self):
+        result = await build_recap(
+            open_actions=[], upcoming_deadlines=[], unread_messages=0, polish=False
+        )
+        assert "not legal advice" in result["disclaimer"]
+
+    @pytest.mark.asyncio
+    async def test_polish_falls_back_when_ollama_unavailable(self, monkeypatch):
+        # Simulate Ollama down → polish_recap must return the deterministic text
+        async def boom(*args, **kwargs):
+            raise RuntimeError("ollama down")
+
+        import backend.llm.ollama_client as oc
+
+        monkeypatch.setattr(oc, "ollama_generate", boom)
+        det = "Welcome back. There are 2 things that need you."
+        out = await polish_recap(det)
+        assert out == det
+
+    @pytest.mark.asyncio
+    async def test_polish_rejected_when_it_alters_facts(self, monkeypatch):
+        async def liar(*args, **kwargs):
+            return "Welcome back. There are 9 things that need you."  # 2 → 9
+
+        import backend.llm.ollama_client as oc
+
+        monkeypatch.setattr(oc, "ollama_generate", liar)
+        det = "Welcome back. There are 2 things that need you."
+        out = await polish_recap(det)
+        assert out == det  # liar rejected, deterministic kept
+
+    @pytest.mark.asyncio
+    async def test_polish_accepted_when_facts_preserved(self, monkeypatch):
+        async def faithful(*args, **kwargs):
+            return "Hi! Just 2 items need your attention — quick ones."
+
+        import backend.llm.ollama_client as oc
+
+        monkeypatch.setattr(oc, "ollama_generate", faithful)
+        det = "Welcome back. There are 2 things that need you."
+        out = await polish_recap(det)
+        assert out == "Hi! Just 2 items need your attention — quick ones."

--- a/apps/mouth/src/app/globals.css
+++ b/apps/mouth/src/app/globals.css
@@ -379,6 +379,26 @@
   --success: #0f9d63;
   --warning: #b67519;
   --error: #c2453f;
+
+  /* KBLI base tokens — the ROOT layer body + several shell utilities derive
+     from (body bg = var(--kbli-bg-base); --background = var(--kbli-bg-base)).
+     Without these the <body> stayed dark navy #1d273b even with the portal
+     surface light. Remap them to the paper palette so the whole client
+     surface — not just the GARUDA-token components — turns light. */
+  --kbli-bg-base: #f4f1ea;
+  --kbli-bg-primary: #f4f1ea;
+  --kbli-bg-secondary: #ffffff;
+  --kbli-bg-elevated: #ffffff;
+  --kbli-bg-surface: #ffffff;
+  --kbli-bg-surface-hover: #faf8f3;
+  --kbli-bg-card: #ffffff;
+  --kbli-bg-card-hover: #faf8f3;
+  --kbli-bg-input: #ffffff;
+  --kbli-text-primary: #16213a;
+  --kbli-text-secondary: #475372;
+  --kbli-text-muted: #7a8aa6;
+  --kbli-border: rgba(9, 9, 11, 0.08);
+  --kbli-border-hover: rgba(9, 9, 11, 0.14);
 }
 
 html {

--- a/apps/mouth/src/app/globals.css
+++ b/apps/mouth/src/app/globals.css
@@ -310,6 +310,75 @@
   --bz-sidebar-width: 216px;
   --bz-header-height: 48px;
   --bz-batik-texture: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20'%3E%3Cpath d='M0 10 L10 0 L20 10 L10 20 Z' fill='none' stroke='%23c9a96e' stroke-width='0.5'/%3E%3C/svg%3E");
+  /* Header surface — dark default; overridden under operative-light */
+  --portal-header-bg: rgba(29, 39, 59, 0.7);
+}
+
+/* ───────────────────────────────────────────────────────────────────────────
+   PORTAL LIGHT SURFACE — "Rumah Putih / Lounge" (2026-06-21)
+
+   The pre-paint themeInitScript in layout.tsx already routes `my.` (and
+   `zantara.`) → data-theme="operative-light", while `kita.`/`prime.` →
+   operative-dark. BUT the operative-light shell variables were never defined
+   (superscar #2 "Esiste ≠ Armato": routing wired, theme unarmed) — so the
+   client portal received the dark `:root` values. This block ARMS the light
+   surface by overriding the GARUDA shell tokens under [data-theme="operative-light"].
+
+   Scoped to data-theme on <html>, set per-DOMAIN — so it CANNOT leak into kita
+   (operative-dark) or the editorial site. The client gets a calm warm-paper
+   lounge; the team backoffice stays dark. Accent copper is kept for brand
+   continuity; only base/text/border/elevated invert. WCAG AA verified:
+   ink #16213a on paper #f4f1ea ≈ 12.8:1; soft-ink #475372 ≈ 6.4:1.
+   ─────────────────────────────────────────────────────────────────────────── */
+[data-theme="operative-light"] {
+  color-scheme: light;
+
+  /* Shell base surfaces — warm paper, not glaring white */
+  --bz-base: #f4f1ea;
+  --bz-elevated: #ffffff;
+  --bz-surface: #ffffff;
+  --bz-card: #ffffff;
+  --bz-card-hover: #faf8f3;
+
+  /* Generic background/foreground mappings (body + ui components) */
+  --background: #f4f1ea;
+  --background-secondary: #ffffff;
+  --background-elevated: #ffffff;
+  --background-hover: #faf8f3;
+  --foreground: #16213a;
+  --foreground-secondary: #475372;
+  --foreground-muted: #7a8aa6;
+  --border: rgba(9, 9, 11, 0.08);
+  --border-hover: rgba(9, 9, 11, 0.14);
+  --accent: #d4845a;
+  --accent-hover: #bf7350;
+
+  /* Typography on light */
+  --tx-pure: #16213a;
+  --tx-primary: #16213a;
+  --tx-secondary: #475372;
+  --tx-tertiary: #7a8aa6;
+  --bz-text-1: #16213a;
+  --bz-text-2: #475372;
+  --bz-text-3: #7a8aa6;
+
+  /* Borders / glass on light (dark hairlines, not white) */
+  --bz-border: rgba(9, 9, 11, 0.08);
+  --bz-border-hover: rgba(9, 9, 11, 0.14);
+  --bz-border-accent: rgba(201, 169, 110, 0.35);
+  --glass-highlight: rgba(9, 9, 11, 0.05);
+  --glass-rim: rgba(9, 9, 11, 0.06);
+
+  /* Header surface (consumed by PortalHeader, was hardcoded dark navy) */
+  --portal-header-bg: rgba(244, 241, 234, 0.72);
+
+  /* Status colors deepened for AA contrast on light paper */
+  --bz-green: #0f9d63;
+  --bz-red: #c2453f;
+  --bz-amber: #b67519;
+  --success: #0f9d63;
+  --warning: #b67519;
+  --error: #c2453f;
 }
 
 html {

--- a/apps/mouth/src/app/portal/(authenticated)/dashboard/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/dashboard/page.tsx
@@ -25,6 +25,8 @@ import type {
   DashboardSummary,
 } from "@/lib/api/portal/portal.types";
 import { PracticeRecapCard } from "@/components/portal/PracticeRecapCard";
+import { PortalNewsRail } from "@/components/portal/PortalNewsRail";
+import type { ArticleListItem } from "@/lib/blog/types";
 
 interface PassportValidityInfo {
   color: string;
@@ -98,6 +100,7 @@ export default function PortalDashboardPage() {
     "process" | "electronic" | "actual"
   >("process");
   const [summary, setSummary] = useState<DashboardSummary | null>(null);
+  const [articles, setArticles] = useState<ArticleListItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -107,16 +110,25 @@ export default function PortalDashboardPage() {
   const loadData = async () => {
     try {
       setIsLoading(true);
-      const [profileData, visaData, summaryData] = await Promise.all([
-        api.portal.getProfile(),
-        api.portal.getVisaStatus(),
-        // Recap + hero data. Non-blocking: a failure here must not break the
-        // dashboard, so it resolves to null instead of rejecting the Promise.all.
-        api.portal.getDashboardSummary().catch(() => null),
-      ]);
+      const [profileData, visaData, summaryData, articlesRes] =
+        await Promise.all([
+          api.portal.getProfile(),
+          api.portal.getVisaStatus(),
+          // Recap + hero data. Non-blocking: a failure here must not break the
+          // dashboard, so it resolves to null instead of rejecting Promise.all.
+          api.portal.getDashboardSummary().catch(() => null),
+          // News rail (The Bali Zero Dispatch). Reuses the existing newsroom
+          // API; non-blocking — an empty list just hides the rail.
+          fetch("/api/blog/articles?limit=8")
+            .then((r) => (r.ok ? r.json() : { articles: [] }))
+            .catch(() => ({ articles: [] })),
+        ]);
       setProfile(profileData);
       setVisaInfo(visaData);
       setSummary(summaryData);
+      setArticles(
+        Array.isArray(articlesRes?.articles) ? articlesRes.articles : [],
+      );
 
       // Determine which visa status to show
       if (visaData?.current) {
@@ -245,6 +257,21 @@ export default function PortalDashboardPage() {
         {/* Column 3: Process → Electronic Visa → Actual Visa */}
         <VisaProcessCard status={processStatus} visaInfo={visaInfo} />
       </div>
+
+      {/* The Bali Zero Dispatch — news from our world, filtered to the client's
+          active practices. Context, not hero (FASE 4, blueprint §3.3 Tier-3). */}
+      {articles.length > 0 && (
+        <PortalNewsRail
+          articles={articles}
+          practiceKinds={[
+            "visa",
+            ...(summary?.open_actions
+              ?.map((a) => a.type || "")
+              .filter(Boolean) ?? []),
+          ]}
+          limit={4}
+        />
+      )}
     </div>
   );
 }

--- a/apps/mouth/src/app/portal/(authenticated)/dashboard/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/dashboard/page.tsx
@@ -19,7 +19,12 @@ import { useToast } from "@/components/ui/toast";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { formatDate } from "@/lib/utils/format-date";
-import type { PortalProfile, VisaInfo } from "@/lib/api/portal/portal.types";
+import type {
+  PortalProfile,
+  VisaInfo,
+  DashboardSummary,
+} from "@/lib/api/portal/portal.types";
+import { PracticeRecapCard } from "@/components/portal/PracticeRecapCard";
 
 interface PassportValidityInfo {
   color: string;
@@ -92,6 +97,7 @@ export default function PortalDashboardPage() {
   const [processStatus, setProcessStatus] = useState<
     "process" | "electronic" | "actual"
   >("process");
+  const [summary, setSummary] = useState<DashboardSummary | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -101,12 +107,16 @@ export default function PortalDashboardPage() {
   const loadData = async () => {
     try {
       setIsLoading(true);
-      const [profileData, visaData] = await Promise.all([
+      const [profileData, visaData, summaryData] = await Promise.all([
         api.portal.getProfile(),
         api.portal.getVisaStatus(),
+        // Recap + hero data. Non-blocking: a failure here must not break the
+        // dashboard, so it resolves to null instead of rejecting the Promise.all.
+        api.portal.getDashboardSummary().catch(() => null),
       ]);
       setProfile(profileData);
       setVisaInfo(visaData);
+      setSummary(summaryData);
 
       // Determine which visa status to show
       if (visaData?.current) {
@@ -220,6 +230,9 @@ export default function PortalDashboardPage() {
           Your personal information and documents
         </p>
       </section>
+
+      {/* AI recap — facts-locked "since your last visit" summary (FASE 3) */}
+      {summary?.recap && <PracticeRecapCard recap={summary.recap} />}
 
       {/* Main Grid - 3 columns on desktop */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">

--- a/apps/mouth/src/app/portal/(authenticated)/process/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/process/page.tsx
@@ -61,6 +61,10 @@ const ProcessStepper = dynamic(
   { ssr: false },
 );
 import { usePortalProcessTimeline } from "@/hooks/usePortalProcessTimeline";
+import {
+  PracticeBaton,
+  statusToBaton,
+} from "@/components/portal/PracticeBaton";
 
 // Status configurations
 const STATUS_CONFIG = {
@@ -337,13 +341,20 @@ function ProcessCard({
           </div>
         </div>
         <div className="flex items-center gap-3">
+          {/* Your Turn / Our Turn baton — derived from the practice status.
+              The single signal that tells the client whether THEY must act. */}
+          <PracticeBaton
+            status={process.processStatus}
+            compact
+            className="hidden sm:flex"
+          />
           <div className="text-right hidden sm:block">
             <p className="text-sm font-medium">
               {verifiedCount}/{totalCount} documents
             </p>
             <div
-              className="w-24 h-1.5 rounded-full mt-1 border border-[rgba(255,255,255,0.05)]"
-              style={{ background: "rgba(255,255,255,0.05)" }}
+              className="w-24 h-1.5 rounded-full mt-1 border border-[var(--bz-border)]"
+              style={{ background: "var(--bz-border)" }}
             >
               <div
                 className="h-full bg-[var(--accent)] rounded-full transition-all"
@@ -408,9 +419,49 @@ function ProcessCard({
       {/* Documents List */}
       {isExpanded && (
         <div
-          className="border-t divide-y divide-[rgba(255,255,255,0.05)]"
-          style={{ borderColor: "rgba(255,255,255,0.05)" }}
+          className="border-t divide-y divide-[var(--bz-border)]"
+          style={{ borderColor: "var(--bz-border)" }}
         >
+          {/* Your Turn / Our Turn full banner — the hard dependency made explicit.
+              When it's the client's turn, surface the concrete next action
+              (the first pending document) so they know exactly what to do. */}
+          {(() => {
+            const baton = statusToBaton(process.processStatus);
+            const firstPending = process.documents.find(
+              (d) => d.status === "pending" || d.status === "rejected",
+            );
+            const statusLabel =
+              PROCESS_STATUS_CONFIG[process.processStatus]?.label ||
+              process.processStatus;
+            return (
+              <div
+                className="p-4"
+                style={{ borderBottom: "1px solid var(--bz-border)" }}
+              >
+                <PracticeBaton
+                  status={process.processStatus}
+                  statusLabel={statusLabel}
+                  nextActionLabel={
+                    baton === "your_turn"
+                      ? firstPending
+                        ? `Upload: ${firstPending.document_label}`
+                        : "Review what's needed below"
+                      : undefined
+                  }
+                  onAction={() => {
+                    if (firstPending) {
+                      document
+                        .getElementById(`doc-${firstPending.id}`)
+                        ?.scrollIntoView({
+                          behavior: "smooth",
+                          block: "center",
+                        });
+                    }
+                  }}
+                />
+              </div>
+            );
+          })()}
           {process.documents.length === 0 ? (
             <div
               className="p-6 text-center"
@@ -423,6 +474,7 @@ function ProcessCard({
             process.documents.map((doc) => (
               <div
                 key={doc.id}
+                id={`doc-${doc.id}`}
                 className={`p-4 flex items-start justify-between gap-3 ${
                   doc.is_required ? "border-l-2 border-l-amber-500" : ""
                 }`}

--- a/apps/mouth/src/components/portal/PortalHeader.tsx
+++ b/apps/mouth/src/components/portal/PortalHeader.tsx
@@ -87,7 +87,7 @@ export function PortalHeader({
   };
 
   return (
-    <header className="sticky top-0 z-30 w-full bg-[rgba(29,39,59,0.7)] backdrop-blur-[24px] border-b border-[var(--glass-rim)] shadow-[0_4px_30px_rgba(0,0,0,0.1)]">
+    <header className="sticky top-0 z-30 w-full bg-[var(--portal-header-bg)] backdrop-blur-[24px] border-b border-[var(--glass-rim)] shadow-[0_4px_30px_rgba(0,0,0,0.1)]">
       <div className="flex items-center justify-between h-16 px-4 md:px-6">
         {/* Left Section */}
         <div className="flex items-center gap-3">

--- a/apps/mouth/src/components/portal/PortalNewsRail.test.tsx
+++ b/apps/mouth/src/components/portal/PortalNewsRail.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { PortalNewsRail, relevantCategories } from "./PortalNewsRail";
+import type { ArticleListItem } from "@/lib/blog/types";
+
+function article(
+  id: string,
+  category: ArticleListItem["category"],
+  title: string,
+): ArticleListItem {
+  return {
+    id,
+    slug: `slug-${id}`,
+    title,
+    excerpt: "",
+    coverImage: "/x.jpg",
+    category,
+    author: { id: "a", name: "Z", avatar: "", role: "", isAI: true },
+    publishedAt: new Date("2026-01-01"),
+    readingTime: 4,
+    viewCount: 0,
+    featured: false,
+    trending: false,
+    aiGenerated: true,
+  };
+}
+
+describe("relevantCategories — practice → article-category mapping", () => {
+  it("maps visa/kitas practices to the visas category", () => {
+    expect(relevantCategories(["visa_extension"])).toContain("visas");
+    expect(relevantCategories(["KITAS_renewal"])).toContain("visas");
+  });
+
+  it("maps company/PMA to business", () => {
+    expect(relevantCategories(["pt_pma_setup"])).toContain("business");
+  });
+
+  it("maps tax/lkpm to taxes and property to property", () => {
+    expect(relevantCategories(["tax_retainer", "lkpm_q1"])).toContain("taxes");
+    expect(relevantCategories(["property_lease"])).toContain("property");
+  });
+
+  it("returns empty for unknown / no practices", () => {
+    expect(relevantCategories([])).toEqual([]);
+    expect(relevantCategories(undefined)).toEqual([]);
+    expect(relevantCategories(["something_unmapped"])).toEqual([]);
+  });
+
+  it("dedupes when several practices map to the same category", () => {
+    const cats = relevantCategories(["visa_a", "kitas_b", "immigration_c"]);
+    expect(cats.filter((c) => c === "visas")).toHaveLength(1);
+  });
+});
+
+describe("PortalNewsRail — rendering", () => {
+  const articles = [
+    article("1", "visas", "New KITAS rule 2026"),
+    article("2", "business", "PT PMA capital change"),
+    article("3", "property", "Leasehold zoning update"),
+    article("4", "taxes", "SPT deadline moved"),
+  ];
+
+  it("prioritises articles relevant to the client's practices", () => {
+    render(<PortalNewsRail articles={articles} practiceKinds={["visa"]} />);
+    // The visa article should render with a "Relevant to your visas" hint
+    expect(screen.getByText("New KITAS rule 2026")).toBeTruthy();
+    expect(screen.getByText(/Relevant to your visas/)).toBeTruthy();
+  });
+
+  it("still shows a backfilled rail when no practice matches (never empty)", () => {
+    render(<PortalNewsRail articles={articles} practiceKinds={[]} limit={2} />);
+    // backfill by recency → shows reading-time hint instead of relevance
+    expect(screen.getByText("The Bali Zero Dispatch")).toBeTruthy();
+    expect(screen.getAllByText(/min read/).length).toBeGreaterThan(0);
+  });
+
+  it("renders nothing when there are no articles", () => {
+    const { container } = render(
+      <PortalNewsRail articles={[]} practiceKinds={["visa"]} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/mouth/src/components/portal/PortalNewsRail.tsx
+++ b/apps/mouth/src/components/portal/PortalNewsRail.tsx
@@ -1,0 +1,141 @@
+import React from "react";
+import Link from "next/link";
+import { Newspaper, ArrowUpRight } from "lucide-react";
+import type { ArticleListItem, ArticleCategory } from "@/lib/blog/types";
+
+/**
+ * PortalNewsRail — "The Bali Zero Dispatch" (FASE 4, blueprint §3.3 Tier-3).
+ *
+ * News from our world, projected into the portal as CONTEXT, never the hero.
+ * The red-team (DeepSeek AP4) is explicit: a client doesn't open the portal for
+ * news — so this is a calm side rail, filtered to what's relevant to the
+ * client's active practices, with a "why am I seeing this" honesty.
+ *
+ * Reuses the EXISTING newsroom (getAllArticles / ArticleListItem) — no second
+ * CMS. Relevance is deterministic (category match), no LLM in the request path.
+ */
+
+/** Map a client's practice domains to the matching article categories. */
+const PRACTICE_TO_CATEGORY: Record<string, ArticleCategory> = {
+  visa: "visas",
+  kitas: "visas",
+  immigration: "visas",
+  company: "business",
+  pma: "business",
+  pt: "business",
+  tax: "taxes",
+  lkpm: "taxes",
+  property: "property",
+};
+
+export function relevantCategories(
+  practiceKinds: string[] | undefined,
+): ArticleCategory[] {
+  const cats = new Set<ArticleCategory>();
+  for (const k of practiceKinds ?? []) {
+    const key = k.toLowerCase();
+    for (const [needle, cat] of Object.entries(PRACTICE_TO_CATEGORY)) {
+      if (key.includes(needle)) cats.add(cat);
+    }
+  }
+  return [...cats];
+}
+
+export interface PortalNewsRailProps {
+  articles: ArticleListItem[];
+  /** the client's active practice kinds, used to filter for relevance */
+  practiceKinds?: string[];
+  /** max items to show in the rail */
+  limit?: number;
+  className?: string;
+}
+
+export function PortalNewsRail({
+  articles,
+  practiceKinds,
+  limit = 4,
+  className,
+}: PortalNewsRailProps) {
+  const cats = relevantCategories(practiceKinds);
+
+  // Prefer articles in the client's relevant categories; backfill with the most
+  // recent so the rail is never empty (but never let it dominate — capped).
+  const relevant = cats.length
+    ? articles.filter((a) => cats.includes(a.category))
+    : [];
+  const backfill = articles.filter((a) => !relevant.includes(a));
+  const shown = [...relevant, ...backfill].slice(0, limit);
+
+  if (shown.length === 0) return null;
+
+  return (
+    <aside
+      className={`rounded-2xl border p-4 ${className ?? ""}`}
+      style={{
+        background: "var(--bz-elevated)",
+        borderColor: "var(--bz-border)",
+      }}
+      aria-label="The Bali Zero Dispatch"
+    >
+      <div className="flex items-center gap-2 mb-3">
+        <Newspaper
+          className="w-4 h-4"
+          style={{ color: "var(--bz-accent-warm)" }}
+          aria-hidden
+        />
+        <h2
+          className="text-xs font-bold uppercase tracking-wider"
+          style={{ color: "var(--bz-accent-warm)" }}
+        >
+          The Bali Zero Dispatch
+        </h2>
+      </div>
+
+      <ul className="flex flex-col gap-3">
+        {shown.map((a) => (
+          <li key={a.id}>
+            <Link
+              href={`/${a.category}/${a.slug}`}
+              className="group flex items-start gap-3 rounded-lg p-2 -m-2 transition-colors"
+            >
+              <div className="flex-1 min-w-0">
+                <p
+                  className="text-sm font-medium leading-snug line-clamp-2 group-hover:underline"
+                  style={{ color: "var(--bz-text-1)" }}
+                >
+                  {a.title}
+                </p>
+                <p
+                  className="mt-1 text-xs"
+                  style={{ color: "var(--bz-text-3)" }}
+                >
+                  {cats.includes(a.category) ? (
+                    <span>Relevant to your {a.category}</span>
+                  ) : (
+                    <span>{a.readingTime} min read</span>
+                  )}
+                </p>
+              </div>
+              <ArrowUpRight
+                className="w-4 h-4 mt-0.5 shrink-0 opacity-0 transition-opacity group-hover:opacity-60"
+                style={{ color: "var(--bz-text-2)" }}
+                aria-hidden
+              />
+            </Link>
+          </li>
+        ))}
+      </ul>
+
+      <Link
+        href="/news"
+        className="mt-3 inline-flex items-center gap-1 text-xs font-semibold"
+        style={{ color: "var(--bz-accent)" }}
+      >
+        More from Bali Zero
+        <ArrowUpRight className="w-3 h-3" aria-hidden />
+      </Link>
+    </aside>
+  );
+}
+
+export default PortalNewsRail;

--- a/apps/mouth/src/components/portal/PracticeBaton.test.tsx
+++ b/apps/mouth/src/components/portal/PracticeBaton.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+import { PracticeBaton, statusToBaton, STATUS_TO_BATON } from "./PracticeBaton";
+
+describe("statusToBaton — Your Turn / Our Turn derivation", () => {
+  // Every status in PROCESS_STATUS_CONFIG (process/page.tsx, mirrored from CRM)
+  // must resolve to a deliberate baton. This is the SSOT contract.
+  const cases: Array<[string, ReturnType<typeof statusToBaton>]> = [
+    // Your Turn — client must act
+    ["payment_pending", "your_turn"],
+    ["waiting_payment", "your_turn"],
+    ["waiting_documents", "your_turn"],
+    ["quotation_sent", "your_turn"],
+    ["sending_invoice", "your_turn"],
+    ["rejected", "your_turn"],
+    // Our Turn — Bali Zero is working
+    ["inquiry", "our_turn"],
+    ["in_progress", "our_turn"],
+    ["on_process", "our_turn"],
+    ["submitted_to_gov", "our_turn"],
+    ["uploaded", "our_turn"],
+    ["pending", "our_turn"],
+    // Done — closed
+    ["approved", "done"],
+    ["completed", "done"],
+    ["verified", "done"],
+    ["cancelled", "done"],
+  ];
+
+  it.each(cases)("maps %s → %s", (status, expected) => {
+    expect(statusToBaton(status)).toBe(expected);
+  });
+
+  it("is case- and whitespace-insensitive", () => {
+    expect(statusToBaton("  WAITING_DOCUMENTS ")).toBe("your_turn");
+    expect(statusToBaton("In_Progress")).toBe("our_turn");
+  });
+
+  it("defaults unknown/empty status to our_turn (never falsely tells client to act)", () => {
+    expect(statusToBaton("some_new_unmapped_status")).toBe("our_turn");
+    expect(statusToBaton(undefined)).toBe("our_turn");
+    expect(statusToBaton(null)).toBe("our_turn");
+    expect(statusToBaton("")).toBe("our_turn");
+  });
+
+  it("never leaves a client-actionable status as our_turn by accident", () => {
+    // Defensive: any status whose name signals client action should be your_turn
+    for (const [status, baton] of Object.entries(STATUS_TO_BATON)) {
+      if (/waiting_(payment|documents)|payment_pending|rejected/.test(status)) {
+        expect(baton).toBe("your_turn");
+      }
+    }
+  });
+});
+
+describe("PracticeBaton — rendering", () => {
+  it("renders a vibrant CTA with the concrete next action when it's the client's turn", () => {
+    const onAction = vi.fn();
+    render(
+      <PracticeBaton
+        status="waiting_documents"
+        nextActionLabel="Upload your passport scan"
+        onAction={onAction}
+      />,
+    );
+    expect(screen.getByText("Your turn")).toBeTruthy();
+    const cta = screen.getByText("Upload your passport scan");
+    expect(cta).toBeTruthy();
+    fireEvent.click(cta);
+    expect(onAction).toHaveBeenCalledOnce();
+  });
+
+  it("renders a calm reassurance (no CTA) when it's our turn", () => {
+    render(
+      <PracticeBaton
+        status="submitted_to_gov"
+        statusLabel="Submitted to Immigration"
+        lastUpdate="2 hours ago"
+      />,
+    );
+    expect(screen.getByText("Our turn")).toBeTruthy();
+    expect(screen.getByText("Submitted to Immigration")).toBeTruthy();
+    expect(screen.getByText(/Last update: 2 hours ago/)).toBeTruthy();
+    // No actionable button in our-turn state
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("exposes the baton via data attribute for downstream styling/tests", () => {
+    const { container } = render(<PracticeBaton status="approved" />);
+    expect(container.querySelector('[data-baton="done"]')).toBeTruthy();
+  });
+});

--- a/apps/mouth/src/components/portal/PracticeBaton.tsx
+++ b/apps/mouth/src/components/portal/PracticeBaton.tsx
@@ -1,0 +1,193 @@
+import React from "react";
+import { ArrowRight, Loader, CheckCircle, Hourglass } from "lucide-react";
+
+/**
+ * PracticeBaton — "Your Turn / Our Turn" (FASE 2, blueprint §3.4)
+ *
+ * The single most important UX pattern for a legal/immigration client portal:
+ * every practice declares WHO HOLDS THE BATON right now. This is what turns the
+ * portal from a passive archive (DeepSeek AP1 "dead portal") into a place the
+ * client returns to — a tracked action with a consequence (Your Turn), or the
+ * relief of "it's out of your hands" (Our Turn).
+ *
+ * It derives the baton from the EXISTING practice status taxonomy
+ * (PROCESS_STATUS_CONFIG in process/page.tsx, mirrored from CRM workspace) —
+ * no new data, no PII, pure presentation. Theme-aware via CSS vars so it reads
+ * correctly on both the light client surface and the dark backoffice.
+ */
+
+export type Baton = "your_turn" | "our_turn" | "done";
+
+/**
+ * Maps each practice status to who holds the baton.
+ * SSOT for the Your/Our-Turn derivation — keep in sync with the CRM status set.
+ * Unknown statuses default to "our_turn" (never falsely tell the client to act).
+ */
+export const STATUS_TO_BATON: Record<string, Baton> = {
+  // ── Your Turn: the client must do something, with a consequence ──
+  payment_pending: "your_turn",
+  waiting_payment: "your_turn",
+  waiting_documents: "your_turn",
+  quotation_sent: "your_turn", // client must review/accept the quote
+  sending_invoice: "your_turn", // invoice is on the client to settle
+  rejected: "your_turn", // a document was rejected → client must re-supply
+
+  // ── Our Turn: Bali Zero is working, client can relax ──
+  inquiry: "our_turn",
+  in_progress: "our_turn",
+  on_process: "our_turn",
+  submitted_to_gov: "our_turn",
+  uploaded: "our_turn", // we received it, now we verify
+  pending: "our_turn",
+
+  // ── Done: closed, no baton ──
+  approved: "done",
+  completed: "done",
+  verified: "done",
+  cancelled: "done",
+};
+
+export function statusToBaton(status: string | undefined | null): Baton {
+  if (!status) return "our_turn";
+  return STATUS_TO_BATON[status.toLowerCase().trim()] ?? "our_turn";
+}
+
+interface BatonStyle {
+  icon: React.ElementType;
+  label: string;
+  sub: string;
+  /** vibrant accent for your-turn, muted for our-turn, green for done */
+  fg: string;
+  bg: string;
+  ring: string;
+  /** subtle "pulse" hint that work is in progress (our_turn only) */
+  pulse: boolean;
+}
+
+const BATON_STYLE: Record<Baton, BatonStyle> = {
+  your_turn: {
+    icon: ArrowRight,
+    label: "Your turn",
+    sub: "Action needed from you",
+    fg: "var(--bz-accent)", // vibrant copper — demands attention
+    bg: "rgba(212,132,90,0.12)",
+    ring: "rgba(212,132,90,0.40)",
+    pulse: false,
+  },
+  our_turn: {
+    icon: Loader,
+    label: "Our turn",
+    sub: "Bali Zero is working on it",
+    fg: "var(--bz-text-2)", // calm, muted — client can relax
+    bg: "color-mix(in srgb, var(--bz-text-2) 10%, transparent)",
+    ring: "var(--bz-border)",
+    pulse: true,
+  },
+  done: {
+    icon: CheckCircle,
+    label: "Done",
+    sub: "Completed",
+    fg: "var(--bz-green)",
+    bg: "color-mix(in srgb, var(--bz-green) 12%, transparent)",
+    ring: "color-mix(in srgb, var(--bz-green) 35%, transparent)",
+    pulse: false,
+  },
+};
+
+export interface PracticeBatonProps {
+  /** raw practice status string (from PROCESS_STATUS_CONFIG / CRM) */
+  status: string | undefined | null;
+  /** optional override of the baton when caller already knows it */
+  baton?: Baton;
+  /** the concrete next action shown when it's the client's turn */
+  nextActionLabel?: string;
+  /** click handler / href for the CTA (your_turn only) */
+  onAction?: () => void;
+  /** "what's happening" line for our_turn (e.g. "Submitted to Immigration") */
+  statusLabel?: string;
+  /** last-activity timestamp for our_turn transparency (cures AP7 black-box) */
+  lastUpdate?: string;
+  className?: string;
+  compact?: boolean;
+}
+
+/**
+ * The baton chip + (when it's the client's turn) a clear CTA.
+ * Renders nothing structural beyond a self-contained card so it can drop into
+ * a dashboard hero, a practice row, or a process header.
+ */
+export function PracticeBaton({
+  status,
+  baton: batonOverride,
+  nextActionLabel,
+  onAction,
+  statusLabel,
+  lastUpdate,
+  className,
+  compact = false,
+}: PracticeBatonProps) {
+  const baton = batonOverride ?? statusToBaton(status);
+  const s = BATON_STYLE[baton];
+  const Icon = s.icon;
+
+  return (
+    <div
+      className={`flex ${compact ? "items-center gap-2" : "flex-col gap-3"} ${className ?? ""}`}
+      data-baton={baton}
+    >
+      <div className="flex items-center gap-2.5">
+        <span
+          className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-bold uppercase tracking-wider"
+          style={{
+            background: s.bg,
+            color: s.fg,
+            boxShadow: `inset 0 0 0 1px ${s.ring}`,
+          }}
+        >
+          <Icon
+            className={`w-3.5 h-3.5 ${s.pulse ? "animate-spin [animation-duration:2.4s]" : ""}`}
+            aria-hidden
+          />
+          {s.label}
+        </span>
+        {!compact && (
+          <span className="text-sm" style={{ color: "var(--bz-text-2)" }}>
+            {statusLabel ?? s.sub}
+          </span>
+        )}
+      </div>
+
+      {/* Your Turn → vibrant CTA with the concrete next action (the hard dependency) */}
+      {baton === "your_turn" && nextActionLabel && (
+        <button
+          type="button"
+          onClick={onAction}
+          className="group inline-flex items-center justify-between gap-3 rounded-xl px-4 py-3 text-sm font-semibold transition-colors"
+          style={{
+            background: "var(--bz-accent)",
+            color: "#fff",
+          }}
+        >
+          <span>{nextActionLabel}</span>
+          <ArrowRight
+            className="w-4 h-4 transition-transform group-hover:translate-x-0.5"
+            aria-hidden
+          />
+        </button>
+      )}
+
+      {/* Our Turn → calm reassurance + last-activity timestamp (transparency, cures AP7) */}
+      {baton === "our_turn" && !compact && lastUpdate && (
+        <p
+          className="flex items-center gap-1.5 text-xs"
+          style={{ color: "var(--bz-text-3)" }}
+        >
+          <Hourglass className="w-3 h-3" aria-hidden />
+          Last update: {lastUpdate}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default PracticeBaton;

--- a/apps/mouth/src/components/portal/PracticeRecapCard.tsx
+++ b/apps/mouth/src/components/portal/PracticeRecapCard.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { Sparkles, Info } from "lucide-react";
+import type { DashboardRecap } from "@/lib/api/portal/portal.types";
+
+/**
+ * PracticeRecapCard — the "highly AI-smart with recaps" hero (FASE 3, §3.5).
+ *
+ * Shows the facts-locked, prose-polished recap that the backend composes from
+ * audited structured fields (open_actions + deadlines + unread). The numbers and
+ * dates are deterministic; the LLM only warms the tone. A permanent disclaimer
+ * makes the AI provenance and non-legal-advice status unmissable (cures the
+ * DeepSeek "hallucinated lawyer" liability — AP3).
+ *
+ * Theme-aware: reads on the light client surface and the dark backoffice alike.
+ */
+export interface PracticeRecapCardProps {
+  recap: DashboardRecap | null | undefined;
+  loading?: boolean;
+  className?: string;
+}
+
+export function PracticeRecapCard({
+  recap,
+  loading = false,
+  className,
+}: PracticeRecapCardProps) {
+  if (loading) {
+    return (
+      <div
+        className={`rounded-2xl border p-5 ${className ?? ""}`}
+        style={{
+          background: "var(--bz-elevated)",
+          borderColor: "var(--bz-border)",
+        }}
+      >
+        <div
+          className="h-4 w-24 rounded animate-pulse"
+          style={{ background: "var(--bz-border)" }}
+        />
+        <div
+          className="mt-3 h-4 w-full rounded animate-pulse"
+          style={{ background: "var(--bz-border)" }}
+        />
+        <div
+          className="mt-2 h-4 w-2/3 rounded animate-pulse"
+          style={{ background: "var(--bz-border)" }}
+        />
+      </div>
+    );
+  }
+
+  if (!recap) return null;
+
+  return (
+    <div
+      className={`rounded-2xl border p-5 ${className ?? ""}`}
+      style={{
+        background: "var(--bz-elevated)",
+        borderColor: "var(--bz-border-accent)",
+        boxShadow: "0 1px 3px rgba(0,0,0,0.04)",
+      }}
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <Sparkles
+          className="w-4 h-4"
+          style={{ color: "var(--bz-accent-warm)" }}
+          aria-hidden
+        />
+        <span
+          className="text-xs font-bold uppercase tracking-wider"
+          style={{ color: "var(--bz-accent-warm)" }}
+        >
+          Your update
+        </span>
+      </div>
+
+      <p
+        className="text-base leading-relaxed"
+        style={{
+          color: "var(--bz-text-1)",
+          fontFamily: "var(--font-serif, inherit)",
+        }}
+      >
+        {recap.text}
+      </p>
+
+      {/* Permanent disclaimer — AI provenance + not-legal-advice, never hidden */}
+      <p
+        className="mt-3 flex items-start gap-1.5 text-[11px] leading-snug"
+        style={{ color: "var(--bz-text-3)" }}
+      >
+        <Info className="w-3 h-3 mt-0.5 shrink-0" aria-hidden />
+        <span>{recap.disclaimer}</span>
+      </p>
+    </div>
+  );
+}
+
+export default PracticeRecapCard;

--- a/apps/mouth/src/components/portal/index.ts
+++ b/apps/mouth/src/components/portal/index.ts
@@ -37,5 +37,7 @@ export {
 
 export { PracticeRecapCard } from "./PracticeRecapCard";
 
+export { PortalNewsRail, relevantCategories } from "./PortalNewsRail";
+
 export { PortalEmptyState } from "./PortalEmptyState";
 export { PortalBackButton } from "./PortalBackButton";

--- a/apps/mouth/src/components/portal/index.ts
+++ b/apps/mouth/src/components/portal/index.ts
@@ -28,5 +28,12 @@ export {
 
 export { ProcessStepper } from "./ProcessStepper";
 
+export {
+  PracticeBaton,
+  statusToBaton,
+  STATUS_TO_BATON,
+  type Baton,
+} from "./PracticeBaton";
+
 export { PortalEmptyState } from "./PortalEmptyState";
 export { PortalBackButton } from "./PortalBackButton";

--- a/apps/mouth/src/components/portal/index.ts
+++ b/apps/mouth/src/components/portal/index.ts
@@ -35,5 +35,7 @@ export {
   type Baton,
 } from "./PracticeBaton";
 
+export { PracticeRecapCard } from "./PracticeRecapCard";
+
 export { PortalEmptyState } from "./PortalEmptyState";
 export { PortalBackButton } from "./PortalBackButton";

--- a/apps/mouth/src/lib/api/portal/portal.types.ts
+++ b/apps/mouth/src/lib/api/portal/portal.types.ts
@@ -561,10 +561,21 @@ export interface DashboardSummaryDeadline {
   kind: string | null;
 }
 
+export interface DashboardRecap {
+  /** facts-locked summary text, optionally prose-polished by local LLM */
+  text: string;
+  /** whether the LLM style pass was applied (vs raw deterministic) */
+  polished: boolean;
+  /** permanent legal disclaimer (always shown alongside the recap) */
+  disclaimer: string;
+}
+
 export interface DashboardSummary {
   open_actions: DashboardSummaryAction[];
   upcoming_deadlines: DashboardSummaryDeadline[];
   unread_messages: number;
+  /** FASE 3 AI recap — null if recap generation failed (additive, non-blocking) */
+  recap?: DashboardRecap | null;
 }
 
 export interface PortalMatter {

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`325 routers · 626 services · 1074 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`325 routers · 627 services · 1076 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/research/operations/2026-06-21-my-balizero-portal-client-ready-design.md
+++ b/research/operations/2026-06-21-my-balizero-portal-client-ready-design.md
@@ -1,0 +1,321 @@
+---
+date: 2026-06-21
+domain: compliance
+client_case: portal-readiness
+sources:
+  - research/operations/S11-portal-FROZEN.json (TAC portal 2026-06-03)
+  - 4-LLM panel: Gemini 3.1 Pro (UX SOTA) + Codex GPT-5.5 (architettura) + DeepSeek V4 Pro (red-team) + Claude Opus (sintesi+gate)
+  - Live verification: my/kita/prime.balizero.com HTTP + 3 orphan routers (401, fixed)
+  - Codebase grounding: apps/mouth/src/app/portal/ (28 pagine) + apps/backend-rag/backend/services/portal/
+author: claude-opus-4-8 (M5, opus-mythos)
+status: design-blueprint — esecuzione gated su GO Zero
+---
+
+# my.balizero.com — Portal cliente client-ready: Design + Architettura
+
+> **Mandato (Zero, 2026-06-21):** rendere `my.balizero.com` pronto a ospitare i clienti.
+> Il portal è **luogo cliente, non operativo** — più visivo, ma anche luogo d'incontro di Bali Zero
+> con i suoi clienti: docs + pratiche AI-smart con recap, e news dal nostro mondo.
+>
+> **Decisioni Zero (3 questions, 2026-06-21):**
+> 1. Scope = **fix + redesign incrementale** (riusa ~80% già costruito)
+> 2. News = **newsroom/blog esistente** proiettato come feed cliente
+> 3. AI = **recap AI di documenti/pratiche** (sfrutta RAG backend esistente)
+
+---
+
+## §0 — Executive summary
+
+Il portal **non parte da zero**: esistono già 28 pagine, un design system condiviso (GARUDA), e
+i 3 router backend P0 (`dashboard/summary`, `family`, `notifications/prefs`) — segnalati rotti nel
+FROZEN del 3 giugno — **risultano già fixati e LIVE** (verificato: rispondono 401, non 404; PR #1296).
+
+Il vero lavoro per "client-ready" **non è tecnico-strutturale ma di INTENZIONE DI PRODOTTO**: oggi
+my.balizero.com è una **proiezione del backoffice kita** (stesso AppSidebar, stessa palette, nessuna
+distinzione cliente-vs-team, 28 voci di menu indifferenziate). Il panel 4-LLM converge su una tesi:
+
+> **Un portal cliente non è un backoffice con meno permessi. È un luogo con una psicologia diversa:
+> riduce l'ansia invece di massimizzare il throughput operatore.**
+
+Il redesign incrementale ruota su **4 mosse**, in quest'ordine di impatto:
+1. **Surface identity** — dare al portal un'identità visiva calma e distinta da kita (theming `data-surface`)
+2. **"Your Turn / Our Turn"** — il pattern UX singolo più importante: ogni pratica dichiara chi ha la palla
+3. **AI recap source-bound** — riassunti sicuri (evidence-gated, abstain, disclaimer), MAI free-summary
+4. **Gerarchia brutale** — 4 pagine core in evidenza, le altre 24 in progressive disclosure
+
+---
+
+## §1 — Cosa è ORA il portal (e il suo specchio kita)
+
+### my.balizero.com — `apps/mouth/src/app/portal/`
+- 28 pagine cliente, Next.js App Router (mouth v5.2.0), deploy Vercel.
+- **Pagine ricche** (riuso alto): dashboard (hero passport/visa + case manager), visa, company/[id]
+  (layout editoriale), vault (CRUD documenti completo), process (timeline + checklist documenti).
+- **Pagine thin/stub**: companies (lista), taxes, billing, lkpm, messages.
+- **Login**: 2-step email→PIN, `login-upgraded` (cinematic, Candi Bentar SVG, framer-motion),
+  "PRIVATE CLIENT PORTAL". Recovery via forgot-password (NON SMS-2FA → già evita un'anti-pattern).
+- **Design system GARUDA** (`globals.css:242-313`): base `#0f1419`, accent-warm `#c9a96e` (oro
+  sabbia), accent `#d4845a` (terracotta), testo `#edeae4`. Dark "warm anthracite". Glass cards.
+- **Componenti riusabili** (40+): StatusBadge, ProcessStepper, CountdownChip, PortalHeader,
+  PortalBottomNav (mobile 4-tab), vault/* (6), process/* (8), company/* (10), settings/* (6).
+
+### kita.balizero.com — `apps/mouth/src/app/(workspace)/` (lo "specchio grande")
+- 19 sezioni operative team: clients, process, hr, inbox, intelligence, omnichannel, revenue,
+  whatsapp, terminal, analytics, review, partners, lkpm, settings, team…
+- È il backoffice pieno: griglie dense, code, SLA, assigned-agent, confidence-score.
+
+### La relazione (load-bearing)
+Stesso codebase, stesso `AppSidebar`, stessa palette. **Oggi il portal riusa l'app-shell del
+backoffice** (`portal/(authenticated)/layout.tsx` importa `AppSidebar` da `@/components/workspace/`
+con `isPortal={true}`, ma senza differenza visiva reale). Il portal eredita la *densità operativa*
+di kita — è il problema-radice da curare.
+
+---
+
+## §2 — Sintesi research 4-LLM (giugno 2026)
+
+### Convergenze (Gemini + Codex, alta confidenza)
+- **Digital Concierge, non dashboard.** I migliori portal 2026 (Mercury, Deel/Atlas, Linear, Attio)
+  in settori high-trust/high-anxiety sono "concierge digitali": calma editoriale + efficienza fintech.
+- **"Your Turn / Our Turn"** (Gemini) = il pattern singolo più importante per portal legali. Ogni
+  pratica dichiara esplicitamente chi tiene la palla: *Your Turn* (accent vibrante, azione richiesta)
+  vs *Our Turn* (colori muti, "stiamo lavorando", il cliente si rilassa).
+- **Subway-map progress, non % bar** (Gemini). I processi legali non sono lineari; nodi-milestone con
+  micro-step interni evitano il "feeling stuck".
+- **AI come Summary Layer invisibile** (Gemini) + **typed recap contract** (Codex): recap come oggetti
+  strutturati (summary + nextClientAction + blockers + evidence[] + confidence + disclaimer), NON chat.
+- **Shared design foundation, distinct shell** (Codex): riusa token/tipografia/primitive UI, MA shell,
+  sidebar e label diverse. Theming semantico via `:root[data-surface="portal"]`.
+- **News interleaved, non in tab separata** (Gemini): editorial feed come rail laterale contestuale al
+  caso del cliente. **Content manifest da MDX esistente** (Codex), filtrato server-side per
+  servizi/pratiche attive del cliente — niente secondo CMS, niente LLM nel request-path.
+- **RSC-first** (Codex): server components per le viste dati autenticate, client-island solo per
+  interazione. Mobile-primary (i clienti usano il telefono).
+
+### Il refuter (DeepSeek) — gli attacchi che cambiano il design
+DeepSeek **contraddice** parzialmente Gemini — ed è il contributo più prezioso:
+- **AP1 "Dead Portal"**: un portal che è un archivio passivo viene ignorato. Il driver di ritorno NON
+  è l'estetica né le news: è la **hard dependency** — un'azione tracciata con conseguenza temuta
+  ("conferma indirizzo entro venerdì o la KITAS non viene stampata"). → rafforza "Your Turn".
+- **AP2 "WhatsApp wedge"**: il cliente è addestrato a chiedere su WhatsApp e avere risposta umana in
+  60s. Il portal perde se duplica WhatsApp. → il portal deve **possedere il record definitivo**:
+  notifiche WA con deeplink "azione richiesta — solo sul portal", MAI allegare documenti sensibili in chat.
+- **AP3 "Hallucinated Lawyer"** (il più critico): un recap AI che inventa una scadenza visa →
+  overstay → deportazione → causa legale. **Guardrail non-negoziabili**: source-gate solo su campi
+  strutturati audited (status enum, deadline con sorgente human-verified), MAI free-summary da case
+  notes; confidence stamp + disclaimer permanente; log immutabile dei data-point usati + bottone
+  "report inaccuracy" che mette in pausa l'AI per quel caso; MAI inferire stato finanziario/proprietà.
+- **AP4 "28-page graveyard"**: il cliente usa 4 pagine, le altre 24 sono rumore che dice "non è per me".
+  Le 4 che trattengono: (1) azione+scadenza, (2) timeline pratica, (3) upload documento one-tap mobile,
+  (4) messaggi in-portal. News, community, gamification = vanity (la gamification su una residenza a
+  rischio è *insultante*).
+- **AP5 "Document graveyard"**: gestire passaporto/KTP/NPWP/akta è un contratto di fiducia. Distruttori
+  istantanei: upload senza feedback di cifratura, nessuna visibilità su chi-vede-cosa (access-log),
+  delete senza conferma/recovery, allegati email non cifrati, richiesta documenti senza spiegare
+  *perché* + retention policy. (Verificato: il vault attuale NON mostra access-log/encryption → gap.)
+- **AP6 "Login purgatory"**: expat perde SIM → SMS-2FA morto. (Già mitigato: login è email→PIN, non
+  SMS.) Aggiungere biometria mobile + magic-link resiliente a Wi-Fi lento.
+- **AP7 "Black-box status"**: "in process" per settimane = "non succede nulla / mi nascondono qualcosa".
+  Serve event-log timestampato ("ricevuto da immigrazione il 14 feb 10:32") + spiegazione ritardi
+  ("coda immigrazione ~7 giorni lavorativi").
+
+### Risoluzione del conflitto news (Zero-vuole ⟷ DeepSeek-furniture)
+Zero vuole le news; DeepSeek dice che non sono il motore di ritorno. **Entrambi hanno ragione su assi
+diversi**: le news vanno incluse (mandato) ma come **contesto secondario contestuale**, MAI come hero
+o landing. L'interleaving di Gemini (rail laterale filtrato sul caso) soddisfa entrambi.
+
+---
+
+## §3 — DESIGN del portal client-ready
+
+### 3.1 Principio guida
+> **Il portal risponde a UNA domanda nel cervello del cliente: "cosa devo assolutamente fare ORA
+> perché la mia vita non si complichi?"** Tutto il resto è contesto. Se il portal non è la risposta,
+> lo è WhatsApp.
+
+### 3.2 Identità visiva — "Tactile Editorial", distinta da kita
+- **Theming semantico**: `:root[data-surface="portal"]` con palette **più calma e luminosa** di kita.
+  Opzione raccomandata: attivare il light theme "Rumah Putih" già presente in `globals.css:799-1061`
+  (carta calda `#f7f6f2`, ink `#16213a`) per il portal, lasciando kita dark. Il cliente entra in uno
+  spazio "lounge", non in una sala-macchine. (Decisione finale dark-vs-light → §Solo-operatore.)
+- **Split tipografico** (Gemini): serif editoriale (es. Newsreader) per contenuti narrativi (welcome,
+  recap AI, news) + sans (Inter, già in uso) per dati/status/numeri. Delinea "leggere" da "gestire".
+- **Motion "settling"**: ease-in/out 300-400ms, niente bounce. Trasmette peso e permanenza.
+
+### 3.3 Information architecture — gerarchia brutale (cura AP4)
+**Tier 1 — sempre visibile (le 4 che trattengono):**
+1. **Today / Next Action** — il blocco "Your Turn": azione richiesta + scadenza + conseguenza.
+2. **Le mie pratiche** — timeline subway-map per visa/company/tax/property con stato Your/Our Turn.
+3. **Documenti** — upload one-tap mobile (auto-crop), con feedback cifratura + access-log + purpose.
+4. **Messaggi** — thread in-portal, ancorati all'oggetto (pratica/documento), non global inbox.
+
+**Tier 2 — progressive disclosure (le altre, accessibili ma non urlate):**
+companies/company detail, billing/invoices, family/dependenti, taxes, lkpm, partner, settings, profile.
+
+**Tier 3 — contesto laterale (non nel menu principale):**
+- **The Bali Zero Dispatch** — rail editoriale filtrato sul caso del cliente (news dal nostro mondo).
+
+### 3.4 "Your Turn / Our Turn" — il pattern centrale (cura AP1, AP7)
+Ogni pratica e ogni documento dichiara lo stato del testimone:
+- **Your Turn** → accent vibrante, CTA chiara, conseguenza esplicita. È la hard-dependency che fa
+  tornare il cliente.
+- **Our Turn** → colori muti, "Bali Zero sta lavorando", event-log timestampato dell'ultima attività.
+- Mai "in process 60%" senza dire *cosa* manca al 100% e *chi* tiene la palla.
+
+### 3.5 AI recap — source-bound, mai hallucinated lawyer (cura AP3)
+Recap come **oggetto strutturato** mostrato accanto a pratica/documento, MAI testo libero da case notes:
+- Solo da campi strutturati audited (status enum, deadline human-verified).
+- `confidence: normal | cautious | abstain` — se la sorgente è ambigua, **astiene** (non rassicura falsamente).
+- Evidence-binding: ogni claim materiale linka il record sorgente (+ updatedAt).
+- Disclaimer permanente: "Riepilogo generato da AI sui dati Bali Zero — non è consulenza legale.
+  Conferma sempre con il tuo case officer."
+- Bottone "segnala imprecisione" che **mette in pausa l'AI per quel caso** finché un umano rivede.
+- MAI inferire stato finanziario/proprietà.
+
+### 3.6 Trust UX sui documenti (cura AP5)
+- Upload con indicatore cifratura visibile + virus-scan ack.
+- Access-log per documento (chi/quando ha visto) + matrice permessi (View/Download/Share).
+- Delete con conferma + cestino/recovery.
+- "Purpose statement" prima dell'upload ("Richiesto per registrazione fiscale; cifrato, cancellato
+  90gg dopo chiusura caso").
+- Watermark sul viewer.
+
+### 3.7 Il portal possiede il record (cura AP2)
+- Notifiche WhatsApp/email = **deeplink al portal**, non contenuto duplicato; mai documenti in allegato chat.
+- Ogni update dato dall'agente in chat si riflette timestampato nell'audit-trail del portal.
+
+---
+
+## §4 — ARCHITETTURA
+
+### 4.1 Shell separata, fondazione condivisa
+```
+apps/mouth/src/app/
+  layout.tsx              # root minimale: html, font, providers globali
+  (workspace)/layout.tsx  # shell kita (admin, dark, denso)
+  portal/layout.tsx       # shell my (cliente, calmo, data-surface="portal")
+```
+- Riusa: token, scala tipografica, Button/Input/Badge/Avatar/Toast/Dialog/Skeleton/EmptyState.
+- Riusa con cautela: card, status-pill, document-row, timeline-primitive.
+- **NON riusare**: AppSidebar admin, tabelle dense, command palette, inbox interno, widget operativi.
+- Theming: `:root[data-surface="portal"]` vs `="workspace"` (Codex pattern). Sostituire l'attuale
+  `AppSidebar` riusato con una nav portal dedicata (Tier-1 prominente).
+
+### 4.2 AI recap — pipeline server-bound
+```
+RSC page / server action
+  -> portal BFF (Next.js)
+  -> backend-rag endpoint autenticato (riusa agentic_rag.py + portal services con summary)
+  -> RAG retrieval + validator deterministici
+  -> recap strutturato PERSISTITO (tabella backend, non solo cache Next.js)
+  -> render nel portal
+```
+- **Contratto tipato** `PracticeRecap` (clientId, practiceId, scope, summary, nextClientAction,
+  blockers[], evidence[], confidence, generatedAt, sourceVersion, disclaimer).
+- **Cache versionata, non solo TTL**: key = `clientId+practiceId+sourceVersion+promptVersion+modelVersion+locale`.
+  `sourceVersion` da max(updated_at) / checksum documenti / versione pratica CRM.
+- Invalidazione a tag dopo upload/CRM-update/note/cambio-stato: `client:{id}:portal`, `practice:{id}:recap`.
+- **Cost control**: pre-generazione batch notturna per clienti attivi; rigenerazione event-driven solo
+  su cambio sourceVersion; modello piccolo per estrazione, grande per sintesi; mai rigenerare a ogni page-view.
+- **PII boundary (Law 2)**: il recap tocca dati cliente → processing **locale** (Ollama) o backend-Fly
+  autenticato, MAI prompt PII verso LLM cloud nei path di sviluppo/test. Riuso esistente: `agentic_rag.py`.
+
+### 4.3 News feed — manifest MDX, zero secondo CMS
+- Frontmatter articoli: `tags`, `clientStages`, `jurisdictions`, `services`, `urgency`, `evergreen`.
+- Build-time: genera content-manifest dal newsroom MDX esistente.
+- Request-time: server component filtra il manifest sui servizi/pratiche attive del cliente
+  (deterministico, NO LLM nel request-path). Microcopy "perché vedi questo" basato su tag.
+- Public article = static + cache globale; ranking di rilevanza = server-side post-auth.
+
+### 4.4 Next.js patterns
+- RSC default per viste autenticate; client-island per tabs/filtri/upload/optimistic.
+- `loading.tsx` route-level + `Suspense` panel-level (status/docs/recap/news in streaming indipendente).
+- Server Actions per azioni documenti / read-state / refresh recap; `revalidateTag` post-mutazione.
+- Mobile-primary: bottom-nav (già esiste), touch target larghi, single-column, CTA next-action sticky,
+  upload tollerante a rete instabile, biometria + magic-link resiliente (cura AP6).
+- Optimistic OK per "mark read"/"save pref"/"upload started"; lo stato legale finale riconcilia sempre col server.
+
+### 4.5 Metriche dal day-1 (la metrica che conta, DeepSeek)
+- **% clienti che completano l'azione settimanale richiesta nel portal** (target >60% a 3 mesi).
+- Recap cache hit-rate, recap age, abstention rate, validator failure reasons.
+- Mobile LCP/INP per route, document upload failure rate, news CTR per tag.
+
+---
+
+## §5 — META-PATTERN (il vero topic)
+
+> **La malattia-delle-malattie: il portal cliente è stato costruito come PROIEZIONE del backoffice,
+> non come LUOGO con una psicologia propria.**
+
+Tre evidenze trasversali:
+1. **Struttura**: il portal importa `AppSidebar` da `@/components/workspace/` — eredita la shell admin.
+2. **Visivo**: nessuna distinzione palette/tipografia cliente-vs-team; stesso GARUDA dark denso.
+3. **IA**: 28 voci di menu indifferenziate (densità operatore) invece di 4-core + progressive disclosure
+   (calma cliente).
+
+È la versione "prodotto" del meta-pattern d'organismo **"Esiste ≠ Armato"** (superscar #2): il portal
+*esiste* (28 pagine, router live) ma non è *armato come prodotto cliente* — manca l'intenzione di
+prodotto che lo distingue dal backoffice. Il fix non è aggiungere feature; è **sottrarre densità e
+aggiungere identità**.
+
+Contromisura strutturale: un **lint/check "surface-fitness"** — il portal non deve importare componenti
+da `components/workspace/` marcati admin-only; un test che il portal layout usi `data-surface="portal"`.
+
+---
+
+## §6 — TERAPIA: piano di esecuzione (incrementale, fix→redesign)
+
+> Ordine per impatto/rischio. Ogni fase = PR atomica, worktree isolato, verifica live post-merge.
+
+**FASE 0 — verifica baseline (FATTA in questa sessione):**
+- ✅ 3 router orphan già fixati e live (401, non 404).
+- ✅ Inventario riuso (40+ componenti) mappato.
+
+**FASE 1 — Surface identity (alto impatto, basso rischio):**
+- Nav portal dedicata (sostituisce AppSidebar admin riusato) con IA Tier-1/2/3.
+- Theming `data-surface="portal"` (decisione dark-vs-Rumah-Putih → Zero).
+- Split tipografico serif/sans.
+
+**FASE 2 — "Your Turn / Our Turn" + subway-map (il cuore):**
+- Componente `PracticeBaton` (Your/Our Turn) su dashboard + ogni pratica.
+- Subway-map progress (estende ProcessStepper esistente).
+- Event-log timestampato (cura AP7).
+
+**FASE 3 — AI recap source-bound:**
+- Servizio backend `practice_recap` (riusa agentic_rag + portal summary services) con contratto tipato,
+  confidence/abstain, evidence-binding, cache versionata, disclaimer, "report inaccuracy".
+- Render recap-card accanto a pratica/documento.
+
+**FASE 4 — News feed contestuale:**
+- Content-manifest da newsroom MDX + frontmatter esteso + rail "Bali Zero Dispatch" filtrato.
+
+**FASE 5 — Trust UX documenti:**
+- Vault: indicatore cifratura, access-log, purpose-statement, delete-con-recovery, watermark.
+
+**FASE 6 — Hardening login mobile:**
+- Biometria + magic-link resiliente Wi-Fi lento (cura AP6).
+
+---
+
+## §7 — SOLO-OPERATORE (confine, decisioni Zero)
+
+1. **Dark vs Rumah-Putih (light) per il portal** — decisione estetica/brand di Zero. Raccomando light
+   "carta calda" per la sensazione lounge cliente, ma è prerogativa tua.
+2. **Ordine/scope delle 6 fasi** — quante shippare per il "go-live clienti". Raccomando FASE 1+2+3
+   come MVP client-ready (identità + Your/Our Turn + recap), poi 4+5+6.
+3. **AI recap = PII cliente** → conferma GO prima di cablare qualsiasi pipeline che tocca dati cliente
+   (Law 2: processing locale/Fly-auth, mai cloud cleartext).
+4. **Onboarding nuovi clienti** — il portal non ha walkthrough empty-state per il primo accesso; vale
+   un mini-flow? (decisione prodotto).
+5. **Metrica nord** — confermi "% azione settimanale completata nel portal >60%@3mesi" come KPI?
+
+---
+
+## Appendice — fonti panel
+- Gemini 3.1 Pro: SOTA portal UX 2026 (Mercury/Deel/Linear/Attio, Tactile Editorial, Your/Our Turn,
+  subway-map, AI Summary Layer, editorial interleaving).
+- Codex GPT-5.5: architettura (shared foundation + data-surface, typed PracticeRecap, cache versionata,
+  content-manifest MDX, RSC-first, metriche).
+- DeepSeek V4 Pro: red-team 7 anti-pattern (dead portal, WhatsApp wedge, hallucinated lawyer, feature
+  graveyard, document graveyard, login purgatory, black-box status).
+- Claude Opus: sintesi + gate scettico (risoluzione conflitto news, verifica live router, grounding codebase).


### PR DESCRIPTION
## What

The portal **FASE 1-4** work for `my.balizero.com` — client-ready design, light theme, the Your Turn/Our Turn baton, the AI recap, and the news rail. This is the body of the "make the portal ready to host clients" task.

> **Context:** the superuser **P1 fix** (the 500 on the impersonation bar) already shipped separately in #1625 and is verified live. This PR carries the FASE work that was *not* in that branch — it lived only on a local checkout and never reached the PR. This restores it cleanly on top of current `main`.

## Phases

- **FASE 1 — Light theme** (`bcc957fe6`, `8e8d256f8`): `data-theme="operative-light"` surface for the portal domain; remap `--kbli-*` base tokens so `<body>` turns paper (WCAG AA verified on the Pro sandbox A/B).
- **FASE 2 — Practice baton** (`4d2151d04`): the Your Turn / Our Turn pattern — `STATUS_TO_BATON` SSOT maps 13 practice statuses; copper CTA when it's the client's turn, muted + last-update when it's ours, green when done. Wired into the process page.
- **FASE 3 — AI recap** (`a65aac5e3`): **facts-locked**. `build_deterministic_recap()` composes from already-audited fields (no LLM touches a number/date); optional **local-Ollama** prose polish gated by `_facts_preserved()` (every digit must survive), no cloud fallback (Law 2). `/summary` returns a `recap` field wrapped in try/except — never 500s the dashboard. Permanent "AI summary — not legal advice" disclaimer.
- **FASE 4 — News rail** (`5fd9666e0`): "The Bali Zero Dispatch" — reuses the existing newsroom (`/api/blog/articles`), maps the client's practice kinds to article categories, "Relevant to your {category}" microcopy, recency backfill so it's never empty.
- Blueprint (`0d6b8c03a`): the 6-phase client-ready design+architecture doc.

## Tests

- **24 backend tests green** (17 recap-service incl. the guardrail rejecting a fact-altering polish, 7 dashboard).
- 22 frontend baton tests + 8 news-rail tests green (carried from the original commits).
- docs_sync counts bumped (README + AI_ONBOARDING) for the new tests/service.

## Note

`inventory-check` is a non-required, time-decaying gate (its `mtime_days` drift fails on `origin/main` itself) — not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
