### PR TITLE
fix(channels): tighten IG overlay cap 900→800 (live replies hit 961-1023 chars)

### DIFF
--- a/apps/backend-rag/backend/prompts/channel_overlays.py
+++ b/apps/backend-rag/backend/prompts/channel_overlays.py
@@ -51,9 +51,10 @@ CHANNEL_CONFIGS: dict[str, ChannelConfig] = {
         progressive=False,
         extra_instructions=(
             "NO markdown (no **, ##, *, -, backticks — they render as raw symbols "
-            "in Instagram DMs). Plain text only. Keep the whole reply under 900 "
-            "characters so Instagram never truncates it mid-sentence. Be short, "
-            "direct and complete — end with one clear next step."
+            "in Instagram DMs). Plain text only. HARD LIMIT: keep the whole reply "
+            "under 800 characters — Instagram truncates at 1000, so going over "
+            "loses your closing line and source. Prefer fewer, tighter points over "
+            "completeness. Be short, direct, and end with one clear next step."
         ),
     ),
     "voice": ChannelConfig(

--- a/apps/backend-rag/backend/tests/unit/test_channel_overlays_instagram.py
+++ b/apps/backend-rag/backend/tests/unit/test_channel_overlays_instagram.py
@@ -41,7 +41,7 @@ def test_build_channel_context_instagram_is_plain_no_markdown() -> None:
     # The extra-instructions must explicitly forbid markdown and bound length.
     lowered = block.lower()
     assert "no markdown" in lowered
-    assert "900" in block, "must cap reply length so IG never truncates mid-sentence"
+    assert "800" in block, "must cap reply length so IG never truncates mid-sentence"
 
 
 def test_unknown_channel_still_returns_empty() -> None:


### PR DESCRIPTION
## Context
Follow-up to #1628 (IG/WA channel-overlay), verified live on v3610. The overlay works — markdown gone, language-matched, accurate across tax/visa/KBLI/property (EN/ID/IT). But the model treated `under 900` loosely:

| live reply | chars |
|---|---|
| tax (Bahasa) | 961 |
| property (IT) | **1023** |

Instagram hard-truncates DMs at 1000 chars → the 1023-char property reply loses its closing CTA + source line.

## Fix
Tighten the overlay hint to a **`HARD LIMIT under 800`** with an explicit *"prefer fewer, tighter points over completeness"* so the model leaves headroom below the 1000 ceiling. Markdown suppression is already perfect; this only addresses the length tail. Test assert bumped 900→800. 4/4 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)