### PR TITLE
fix(theme): provider respects pre-paint persona-aware data-theme — portal light theme was invisible

### DIFF
--- a/packages/core/components/ThemeProvider.test.tsx
+++ b/packages/core/components/ThemeProvider.test.tsx
@@ -53,6 +53,32 @@ describe("ThemeProvider", () => {
     expect(document.documentElement.dataset.theme).toBe("light");
   });
 
+  it("respects the pre-paint data-theme (persona-aware) over defaultTheme", () => {
+    // Simulates the pre-paint themeInitScript on my.balizero.com: it set
+    // data-theme=operative-light by hostname BEFORE React hydrated. The
+    // provider must NOT clobber it with defaultTheme=editorial.
+    document.documentElement.dataset.theme = "operative-light";
+    const { getByTestId } = render(
+      <ThemeProvider defaultTheme="editorial">
+        <Probe />
+      </ThemeProvider>,
+    );
+    expect(document.documentElement.dataset.theme).toBe("operative-light");
+    expect(getByTestId("theme").textContent).toBe("operative-light");
+  });
+
+  it("localStorage('theme') still wins over the pre-paint value", () => {
+    // Explicit user choice beats the hostname default.
+    document.documentElement.dataset.theme = "operative-light";
+    localStorage.setItem("theme", "dark");
+    render(
+      <ThemeProvider defaultTheme="editorial">
+        <Probe />
+      </ThemeProvider>,
+    );
+    expect(document.documentElement.dataset.theme).toBe("dark");
+  });
+
   it("useTheme exposes funnel state and setter", () => {
     const { getByTestId } = render(
       <ThemeProvider defaultTheme="dark">

--- a/packages/core/components/ThemeProvider.tsx
+++ b/packages/core/components/ThemeProvider.tsx
@@ -52,22 +52,42 @@ export function ThemeProvider({
   const [theme, setThemeState] = useState<Theme>(defaultTheme);
   const [funnel, setFunnelState] = useState<Funnel>(defaultFunnel);
 
-  // On mount: read localStorage and sync to state + DOM.
+  // On mount: reconcile React state with the DOM/localStorage source of truth.
+  //
+  // Precedence (matches the pre-paint themeInitScript in app/layout.tsx):
+  //   1. localStorage('theme')  — explicit user choice, wins everywhere
+  //   2. the data-theme the pre-paint script ALREADY set, persona-aware by
+  //      hostname (my./zantara. → operative-light, kita./prime. → operative-dark,
+  //      public → editorial). We must NOT clobber it with `defaultTheme`.
+  //   3. defaultTheme prop — only when neither of the above is present.
+  //
+  // The previous code wrote `defaultTheme` whenever localStorage was empty,
+  // which silently overrode the persona-aware decision after hydration (the
+  // portal showed navy instead of paper). Reading the pre-paint value back
+  // keeps the provider hostname-aware for free.
   useEffect(() => {
+    const isTheme = (v: string | null | undefined): v is Theme =>
+      v === "dark" ||
+      v === "light" ||
+      v === "editorial" ||
+      v === "operative-light" ||
+      v === "operative-dark";
+
     const stored =
       typeof window !== "undefined" ? localStorage.getItem("theme") : null;
-    if (
-      stored === "dark" ||
-      stored === "light" ||
-      stored === "editorial" ||
-      stored === "operative-light" ||
-      stored === "operative-dark"
-    ) {
-      setThemeState(stored as Theme);
-      document.documentElement.dataset.theme = stored;
-    } else {
-      document.documentElement.dataset.theme = defaultTheme;
-    }
+    const prePaint =
+      typeof document !== "undefined"
+        ? document.documentElement.dataset.theme
+        : null;
+
+    const resolved: Theme = isTheme(stored)
+      ? stored
+      : isTheme(prePaint)
+        ? prePaint
+        : defaultTheme;
+
+    setThemeState(resolved);
+    document.documentElement.dataset.theme = resolved;
   }, [defaultTheme]);
 
   const setTheme = useCallback((next: Theme) => {


### PR DESCRIPTION
## What

The portal (`my.balizero.com`) shipped its **operative-light** surface in #1633 but rendered **navy** — the light theme was invisible in prod. This is a fix in the shared core `ThemeProvider`, not the CSS.

## Root cause

The CSS is sound: pre-seeding `localStorage('theme')='operative-light'` renders `body bg = #f4f1ea` exactly. The bug is in `packages/core/components/ThemeProvider.tsx` (a custom context provider — **not** next-themes).

The pre-paint `themeInitScript` in `app/layout.tsx` sets `data-theme` by hostname *before* hydration:
- `my.` / `zantara.` → `operative-light`
- `kita.` / `prime.` → `operative-dark`
- public → `editorial`

But the provider's mount effect wrote **`defaultTheme`** (always `"editorial"`, passed uniformly by the layout to every domain) onto `data-theme` whenever `localStorage('theme')` was empty — silently **clobbering** the persona-aware decision after hydration. The provider was never hostname-aware.

## Fix

On mount, reconcile against the real source of truth in precedence order:
1. `localStorage('theme')` — explicit user choice, wins everywhere
2. the `data-theme` the pre-paint script **already set** (persona-aware) — read it back instead of overwriting it
3. `defaultTheme` prop — only when neither is present

Reading the pre-paint value back makes the provider hostname-aware for free, with zero new wiring. `kita`/public are untouched — their pre-paint value now flows through unchanged (previously they were also being forced to `editorial`, but both happen to be dark so the regression was only visible on the light portal).

## Tests

`packages/core/components/ThemeProvider.test.tsx`: **7/7 green** — +2 new (pre-paint preserved over defaultTheme; localStorage still wins over pre-paint), 5 existing unchanged.

## Note on QA provenance

Found during the post-deploy portal QA. A browser subagent first fingered `apps/mouth/src/components/providers/ThemeProvider.tsx` — but that file is **not** the one the layout imports (`@balizero/core/components/ThemeProvider`). Verified the real consumer before fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
