### PR TITLE
fix(ci): hot-zone migration lint reads merge-tree, not base — kills W40 fleet-deadlock

### DIFF
--- a/.github/workflows/hot-zone-pr-gate.yml
+++ b/.github/workflows/hot-zone-pr-gate.yml
@@ -225,18 +225,47 @@ jobs:
       # push:main. We re-execute here to ensure Phase 2a observability covers
       # the same surface even when that workflow's `paths:` filter were to
       # bypass (cicatrix W40 root pattern). Cheap duplicate.
+      #
+      # cicatrix W40 fleet-deadlock (2026-06-21): the working tree here is the
+      # BASE ref (Step 1 checks out base.sha, not the PR head). Linting the base
+      # is blind to the PR's own diff — so a collision ALREADY on main fails this
+      # check on EVERY open PR (including the very PR that renames the colliding
+      # file to fix it → catch-22, required-check, needed a kill-switch dance to
+      # break). Fix: reconstruct the MERGE tree (base + PR diff) before linting,
+      # so the lint sees the files as they WILL exist post-merge. Falls back to
+      # base-only lint if the head SHA is unavailable (same degradation as Step 2).
       # ---------------------------------------------------------------------
       - name: Replay lint_migration_numbers.py
         if: |
           steps.kill_switch.outputs.disabled != 'true' &&
           contains(steps.diff.outputs.changed_files, 'apps/backend-rag/backend/db/migrations_v2/')
         continue-on-error: false
+        env:
+          HEAD_SHA: ${{ github.event.merge_group.head_sha || github.event.pull_request.head.sha }}
         run: |
           set -u
           if [[ ! -f scripts/lint_migration_numbers.py ]]; then
             echo "::warning::scripts/lint_migration_numbers.py not in repo at base SHA — skipped"
             exit 0
           fi
+
+          # Materialize the merge tree: overlay the PR head's migrations dir on
+          # top of the base working tree so the lint evaluates post-merge state,
+          # not the base alone (W40 fleet-deadlock fix). git fetch of HEAD_SHA
+          # was already attempted in Step 2; re-fetch defensively (cheap, cached).
+          MIG_DIR="apps/backend-rag/backend/db/migrations_v2"
+          git fetch --no-tags --depth=200 origin "$HEAD_SHA" 2>&1 | tail -3 || true
+          if git cat-file -e "$HEAD_SHA" 2>/dev/null; then
+            echo "Overlaying PR head ($HEAD_SHA) migrations dir onto base for merge-tree lint"
+            # Replace the base migrations dir with the PR head's version so renames,
+            # additions and deletions in the PR are all reflected before linting.
+            rm -rf "$MIG_DIR"
+            git checkout "$HEAD_SHA" -- "$MIG_DIR" 2>/dev/null || {
+              echo "::warning::could not checkout $MIG_DIR from $HEAD_SHA — linting base only"; }
+          else
+            echo "::warning::HEAD SHA $HEAD_SHA not in fetched history — linting base only (degraded)"
+          fi
+
           python3 scripts/lint_migration_numbers.py
           echo "lint_migration_numbers exit: $?"
 


### PR DESCRIPTION
## Problem (fleet-wide CI deadlock, observed 2026-06-21)
The `Hot-zone enforcement` gate's **Replay lint_migration_numbers.py** step runs the lint against the **base ref's** working tree (Step 1 checks out `base.sha`, never the PR head). Linting the base is blind to the PR's own diff, so a migration-number collision **already on main** fails this **required** check on **every open PR** — including the very PR that renames the colliding file to resolve it.

That catch-22 hit PR #1631 (the fix for the 234 collision): its own Hot-zone failed because the replay ran on main's tree. Breaking it required a kill-switch dance (`L5_2_SERVER_ENFORCEMENT_ENABLED=false` → merge → re-arm), with the gate disarmed fleet-wide for the duration.

## Fix
Before linting, reconstruct the **merge tree** — `rm -rf migrations_v2` then `git checkout <head_sha> -- migrations_v2` — so the lint evaluates the dir as it **will exist post-merge** (renames, adds, deletes from the PR all reflected).

- The `rm -rf` is **load-bearing**: a plain overlay leaves the pre-rename file orphaned and keeps reporting the collision. Verified locally against the real #1604 (base→dup) and #1631 (merge-tree→clean) SHAs.
- `head_sha` = `pull_request.head.sha` / `merge_group.head_sha` — a verified 40-hex git SHA gated by `git cat-file -e`, passed via `env:` + quoted (no injection), matching the existing Step 2 pattern.
- Degrades to base-only lint with a `::warning::` if the head SHA is unavailable (same fallback as Step 2).

This PR touches only the workflow (no migrations) → the replay step itself doesn't fire here, and main is currently clean, so no deadlock on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)