### PR TITLE
feat(portal): FASE 5 — document trust UX (purpose + soft-delete recovery)

### DIFF
--- a/apps/backend-rag/backend/app/routers/portal.py
+++ b/apps/backend-rag/backend/app/routers/portal.py
@@ -516,6 +516,7 @@ async def upload_document(
     file: UploadFile = File(...),
     document_type: str = Form(...),
     practice_id: int | None = Form(None),
+    document_purpose: str | None = Form(None),
     client: dict = Depends(get_current_client),
     portal_service: PortalService = Depends(get_portal_service),
 ) -> dict[str, Any]:
@@ -526,6 +527,8 @@ async def upload_document(
     - file: The document file
     - document_type: Type of document (passport, nib, etc.)
     - practice_id: Optional practice to link to
+    - document_purpose: Optional client-facing note on why this document was
+      provided (trust UX — shown back to the client in the vault)
     """
     # Validate file
     if not file.filename:
@@ -546,6 +549,11 @@ async def upload_document(
             detail=f"File type not allowed. Allowed types: {', '.join(allowed_extensions)}",
         )
 
+    # Cap the client-facing purpose note (trust UX field, not free-form storage)
+    purpose = (document_purpose or "").strip() or None
+    if purpose and len(purpose) > 500:
+        purpose = purpose[:500]
+
     try:
         document = await portal_service.upload_document(
             client_id=client["client_id"],
@@ -554,6 +562,7 @@ async def upload_document(
             document_type=document_type,
             mime_type=file.content_type,
             practice_id=practice_id,
+            document_purpose=purpose,
             current_user=client,
         )
         return {
@@ -605,6 +614,72 @@ async def download_document(
             f"Failed to download document {document_id} for client {client['client_id']}: {e}"
         )
         raise HTTPException(status_code=500, detail="Failed to download document") from e
+
+
+@router.delete("/documents/{document_id}")
+async def delete_document(
+    document_id: int,
+    client: dict = Depends(get_current_client),
+    portal_service: PortalService = Depends(get_portal_service),
+) -> dict[str, Any]:
+    """
+    Soft-delete a client-visible document.
+
+    The document is hidden from the vault but recoverable for 30 days
+    (the file stays in Google Drive and the DB row is preserved).
+    """
+    try:
+        result = await portal_service.soft_delete_document(
+            client["client_id"],
+            document_id,
+            current_user=client,
+        )
+        if result is None:
+            raise HTTPException(status_code=404, detail="Document not found")
+        return {
+            "success": True,
+            "message": "Document removed. You can restore it within 30 days.",
+            "data": result,
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(
+            f"Failed to delete document {document_id} for client {client['client_id']}: {e}"
+        )
+        raise HTTPException(status_code=500, detail="Failed to remove document") from e
+
+
+@router.post("/documents/{document_id}/restore")
+async def restore_document(
+    document_id: int,
+    client: dict = Depends(get_current_client),
+    portal_service: PortalService = Depends(get_portal_service),
+) -> dict[str, Any]:
+    """Restore a previously removed document (recovery path)."""
+    try:
+        result = await portal_service.restore_document(
+            client["client_id"],
+            document_id,
+            current_user=client,
+        )
+        if result is None:
+            raise HTTPException(
+                status_code=404,
+                detail="Document not found or not eligible for restore",
+            )
+        return {
+            "success": True,
+            "message": "Document restored.",
+            "data": result,
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(
+            f"Failed to restore document {document_id} for client {client['client_id']}: {e}"
+        )
+        raise HTTPException(status_code=500, detail="Failed to restore document") from e
 
 
 # ================================================

--- a/apps/backend-rag/backend/db/migrations_v2/236_portal_documents_purpose_softdelete.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/236_portal_documents_purpose_softdelete.sql
@@ -1,0 +1,50 @@
+-- Migration 236: portal documents — purpose statement + soft-delete with recovery.
+--
+-- FASE 5 (trust UX, two low-risk levers from the my.balizero.com client-ready
+-- blueprint research/operations/2026-06-21-my-balizero-portal-client-ready-design.md):
+--
+--   * document_purpose (TEXT, client-facing "why we hold this document"): distinct
+--     from the existing `notes` column, which is internal team scratch. Surfaced to
+--     the client in the vault so they understand what each file is FOR — a GDPR-style
+--     purpose statement that builds trust. NULL = no purpose stated (legacy rows).
+--
+--   * Soft-delete with recovery (deleted_at + deleted_by): a client delete becomes a
+--     recoverable trash, NOT a hard DELETE. Distinct from the existing `is_archived`
+--     flag (archive = team lifecycle; delete = client intent to remove). The vault
+--     list query filters `deleted_at IS NULL`; a restore endpoint clears it. Rows are
+--     never physically removed here — recovery stays possible until a separate purge
+--     policy (out of scope) reaps them.
+--
+-- Pure additive: three nullable columns, no constraint change, no row rewrite — every
+-- existing row keeps deleted_at=NULL (visible) and document_purpose=NULL.
+--
+-- On the Pro apply manually like 212-235:
+--   psql postgresql://nuzantara@127.0.0.1:5432/nuzantara_dev \
+--     -f apps/backend-rag/backend/db/migrations_v2/236_portal_documents_purpose_softdelete.sql
+
+-- === FORWARD ===
+
+ALTER TABLE documents ADD COLUMN IF NOT EXISTS document_purpose TEXT;
+ALTER TABLE documents ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+ALTER TABLE documents ADD COLUMN IF NOT EXISTS deleted_by VARCHAR(255);
+
+-- Partial index: the vault list query is always `WHERE client_id = $1 AND
+-- deleted_at IS NULL`, so index the live rows per client. Partial keeps it small
+-- (trash rows excluded) and serves the hot path.
+CREATE INDEX IF NOT EXISTS idx_documents_client_live
+    ON documents (client_id)
+    WHERE deleted_at IS NULL;
+
+COMMENT ON COLUMN documents.document_purpose IS
+    'Client-facing purpose statement ("why we hold this document"). Distinct from notes (internal). FASE 5 trust UX, migration 236.';
+COMMENT ON COLUMN documents.deleted_at IS
+    'Soft-delete timestamp. NULL = live. Set by a client delete; cleared by restore. Distinct from is_archived (team lifecycle). FASE 5, migration 236.';
+COMMENT ON COLUMN documents.deleted_by IS
+    'Who soft-deleted (client email or impersonating superuser). Audit for the trash/recovery flow. FASE 5, migration 236.';
+
+-- === ROLLBACK ===
+-- (Safe: additive columns, no data depends on them outside FASE 5 code paths.)
+-- DROP INDEX IF EXISTS idx_documents_client_live;
+-- ALTER TABLE documents DROP COLUMN IF EXISTS deleted_by;
+-- ALTER TABLE documents DROP COLUMN IF EXISTS deleted_at;
+-- ALTER TABLE documents DROP COLUMN IF EXISTS document_purpose;

--- a/apps/backend-rag/backend/services/portal/_mixins/documents.py
+++ b/apps/backend-rag/backend/services/portal/_mixins/documents.py
@@ -181,12 +181,14 @@ class PortalDocumentsMixin:
             query = """
                 SELECT d.id, d.document_type, d.file_name, d.status,
                        d.expiry_date, d.file_url, d.file_id, d.file_size_kb, d.created_at,
+                       d.document_purpose,
                        p.id as practice_id, pt.name as practice_name
                 FROM documents d
                 LEFT JOIN practices p ON p.id = d.practice_id
                 LEFT JOIN practice_types pt ON pt.id = p.practice_type_id
                 WHERE d.client_id = $1
                 AND d.client_visible = true
+                AND d.deleted_at IS NULL
             """
             params = [client_id]
 
@@ -210,6 +212,7 @@ class PortalDocumentsMixin:
                     "practice_name": d["practice_name"],
                     "downloadable": d["file_url"] is not None or d["file_id"] is not None,
                     "created_at": d["created_at"].isoformat(),
+                    "purpose": d["document_purpose"],
                 }
                 for d in documents
             ]
@@ -231,6 +234,7 @@ class PortalDocumentsMixin:
                 WHERE id = $1
                   AND client_id = $2
                   AND client_visible = true
+                  AND deleted_at IS NULL
                 LIMIT 1
                 """,
                 document_id,
@@ -293,6 +297,141 @@ class PortalDocumentsMixin:
         ]
     )
     @require_client_access
+    async def soft_delete_document(
+        self,
+        client_id: int,
+        document_id: int,
+        *,
+        current_user: ClientContext,
+    ) -> dict[str, Any] | None:
+        """Soft-delete a client-visible document (recoverable for 30 days).
+
+        Sets deleted_at / deleted_by. The file stays in Google Drive and the DB
+        row is preserved — only get_documents / download_document hide it. A
+        timeline event records the action for the case officer.
+        """
+        deleted_by = current_user.get("email") or f"client:{client_id}"
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                row = await conn.fetchrow(
+                    """
+                    UPDATE documents
+                    SET deleted_at = NOW(), deleted_by = $3
+                    WHERE id = $1
+                      AND client_id = $2
+                      AND client_visible = true
+                      AND deleted_at IS NULL
+                    RETURNING id, file_name, document_type
+                    """,
+                    document_id,
+                    client_id,
+                    deleted_by,
+                )
+                if not row:
+                    return None
+
+                try:
+                    await conn.execute(
+                        """
+                        INSERT INTO timeline_events (
+                            client_id, event_type, title,
+                            description, event_date, client_visible, color
+                        )
+                        VALUES ($1, 'document_removed', 'Document removed',
+                                $2, NOW(), true, 'warning')
+                        """,
+                        client_id,
+                        f"{row['file_name']} removed by client (recoverable for 30 days)",
+                    )
+                except Exception as e:
+                    if not self._is_undefined_table_error(e):
+                        logger.warning("Could not create timeline event for soft-delete: %s", e)
+
+        logger.info(
+            "🗑️ Document %s soft-deleted by %s (client %s)",
+            document_id,
+            deleted_by,
+            client_id,
+        )
+        return {
+            "id": row["id"],
+            "name": row["file_name"],
+            "type": row["document_type"],
+            "deleted": True,
+        }
+
+    @cache_invalidating(
+        [
+            lambda _self, client_id, *_a, **_k: f"zantara:portal_documents:{client_id}:*",
+            "zantara:portal_documents:*",
+            "zantara:portal_timeline:*",
+        ]
+    )
+    @require_client_access
+    async def restore_document(
+        self,
+        client_id: int,
+        document_id: int,
+        *,
+        current_user: ClientContext,
+    ) -> dict[str, Any] | None:
+        """Restore a previously soft-deleted document (recovery path)."""
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                row = await conn.fetchrow(
+                    """
+                    UPDATE documents
+                    SET deleted_at = NULL, deleted_by = NULL
+                    WHERE id = $1
+                      AND client_id = $2
+                      AND client_visible = true
+                      AND deleted_at IS NOT NULL
+                    RETURNING id, file_name, document_type
+                    """,
+                    document_id,
+                    client_id,
+                )
+                if not row:
+                    return None
+
+                try:
+                    await conn.execute(
+                        """
+                        INSERT INTO timeline_events (
+                            client_id, event_type, title,
+                            description, event_date, client_visible, color
+                        )
+                        VALUES ($1, 'document_restored', 'Document restored',
+                                $2, NOW(), true, 'success')
+                        """,
+                        client_id,
+                        f"{row['file_name']} restored by client",
+                    )
+                except Exception as e:
+                    if not self._is_undefined_table_error(e):
+                        logger.warning("Could not create timeline event for restore: %s", e)
+
+        logger.info(
+            "♻️ Document %s restored by %s (client %s)",
+            document_id,
+            current_user.get("email") or f"client:{client_id}",
+            client_id,
+        )
+        return {
+            "id": row["id"],
+            "name": row["file_name"],
+            "type": row["document_type"],
+            "deleted": False,
+        }
+
+    @cache_invalidating(
+        [
+            lambda _self, client_id, *_a, **_k: f"zantara:portal_documents:{client_id}:*",
+            "zantara:portal_documents:*",
+            "zantara:portal_timeline:*",
+        ]
+    )
+    @require_client_access
     async def upload_document(
         self,
         client_id: int,
@@ -301,6 +440,7 @@ class PortalDocumentsMixin:
         document_type: str,
         mime_type: str | None = None,
         practice_id: int | None = None,
+        document_purpose: str | None = None,
         *,
         current_user: ClientContext,
     ) -> dict[str, Any]:
@@ -476,13 +616,13 @@ class PortalDocumentsMixin:
                             client_id, practice_id, document_type, document_category, file_name,
                             status, uploaded_by, uploaded_source, file_size_kb, mime_type,
                             storage_type, storage_path, file_id, file_url,
-                            extracted_text, expiry_date,
+                            extracted_text, expiry_date, document_purpose,
                             client_visible, created_at
                         )
                         VALUES (
                             $1, $2, $3, $13, $4, 'received', $5, 'client', $6, $7,
                             'google_drive', $8, $9, $10,
-                            $11, $12,
+                            $11, $12, $14,
                             true, NOW()
                         )
                         RETURNING id, document_type, file_name, status, created_at, expiry_date
@@ -502,6 +642,7 @@ class PortalDocumentsMixin:
                         else None,  # Limit text size
                         expiry_result.get("expiry_date"),
                         doc_category,
+                        document_purpose,
                     )
                 except Exception as e:
                     # Backward compatibility: try without new columns

--- a/apps/backend-rag/backend/tests/unit/app/services/portal/test_documents_mixin.py
+++ b/apps/backend-rag/backend/tests/unit/app/services/portal/test_documents_mixin.py
@@ -91,6 +91,7 @@ async def test_get_documents_shapes_client_visible_rows() -> None:
             "created_at": created_at,
             "practice_id": 3,
             "practice_name": "KITAS",
+            "document_purpose": "Passport for KITAS renewal",
         },
     ]
 
@@ -117,8 +118,12 @@ async def test_get_documents_shapes_client_visible_rows() -> None:
             "practice_name": "KITAS",
             "downloadable": True,
             "created_at": created_at.isoformat(),
+            "purpose": "Passport for KITAS renewal",
         },
     ]
+    # FASE 5: live documents only (soft-deleted hidden) + purpose surfaced
+    assert "d.deleted_at IS NULL" in mock_conn.fetch.call_args.args[0]
+    assert "d.document_purpose" in mock_conn.fetch.call_args.args[0]
     assert "d.document_type = $2" in mock_conn.fetch.call_args.args[0]
     assert mock_conn.fetch.call_args.args[1:] == (1, "passport")
 
@@ -193,7 +198,150 @@ async def test_upload_document_success_stores_processed_document() -> None:
     assert service._metrics["drive_uploads"] == 1
     assert service._metrics["ocr_processed"] == 1
     assert spawn_mock.call_count == 2
-    assert mock_conn.fetchrow.call_args_list[2].args[-1] == "personal"
+    # doc_category is now second-to-last positional ($13); document_purpose is last ($14)
+    assert mock_conn.fetchrow.call_args_list[2].args[-2] == "personal"
+    assert mock_conn.fetchrow.call_args_list[2].args[-1] is None
+
+
+@pytest.mark.asyncio
+async def test_upload_document_persists_document_purpose() -> None:
+    """FASE 5: a client-provided purpose note is stored as the last INSERT arg."""
+    service, mock_conn = _make_service_with_fetchrow(row=None)
+    created_at = datetime(2026, 5, 10, 10, 0, tzinfo=timezone.utc)
+    mock_conn.fetchrow.side_effect = [
+        None,
+        {"email": "client@example.com", "full_name": "Client One", "assigned_to": None},
+        {
+            "id": 90,
+            "document_type": "passport",
+            "file_name": "passport.pdf",
+            "status": "received",
+            "created_at": created_at,
+            "expiry_date": None,
+        },
+    ]
+    service._upload_to_drive = AsyncMock(
+        return_value={
+            "success": True,
+            "file_id": "drive_file_90",
+            "file_url": "https://drive.google.com/file/d/drive_file_90/view",
+            "folder_path": "Zantara Portal Uploads/1_Client One/Passport",
+        }
+    )
+
+    with (
+        patch(
+            "backend.services.portal._mixins.documents.DocumentOCR.extract_text",
+            new=AsyncMock(return_value={"success": True, "text": "txt", "pages": 1}),
+        ),
+        patch(
+            "backend.services.portal._mixins.documents.ExpiryDetector.detect_expiry",
+            return_value={"expiry_date": None, "confidence": 0.0},
+        ),
+        patch(
+            "backend.services.documents.ocr_dispatcher_service.dispatch_ocr_by_folder",
+            return_value=object(),
+        ),
+        patch("backend.services.portal._mixins.documents.spawn", side_effect=_close_spawn),
+    ):
+        result = await service.upload_document(
+            client_id=1,
+            file_content=b"%PDF-1.4 clean passport",
+            file_name="passport.pdf",
+            document_type="passport",
+            mime_type="application/pdf",
+            document_purpose="Required for KITAS renewal",
+            current_user={"client_id": 1, "email": "client@example.com"},
+        )
+
+    assert result["id"] == 90
+    # document_purpose is the last positional arg of the INSERT ($14)
+    assert mock_conn.fetchrow.call_args_list[2].args[-1] == "Required for KITAS renewal"
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_document_marks_deleted_and_returns_summary() -> None:
+    """FASE 5: soft-delete sets deleted_at/deleted_by and records a timeline event."""
+    service, mock_conn = _make_service_with_fetchrow(
+        {"id": 10, "file_name": "passport.pdf", "document_type": "passport"}
+    )
+
+    result = await service.soft_delete_document(
+        client_id=1,
+        document_id=10,
+        current_user={"client_id": 1, "email": "client@example.com"},
+    )
+
+    assert result == {
+        "id": 10,
+        "name": "passport.pdf",
+        "type": "passport",
+        "deleted": True,
+    }
+    update_sql = mock_conn.fetchrow.call_args.args[0]
+    assert "UPDATE documents" in update_sql
+    assert "deleted_at = NOW()" in update_sql
+    assert "deleted_at IS NULL" in update_sql  # idempotent: only live rows
+    # actor + ids passed through
+    assert mock_conn.fetchrow.call_args.args[1:] == (10, 1, "client@example.com")
+    # timeline event recorded
+    assert mock_conn.execute.await_count == 1
+    assert "document_removed" in mock_conn.execute.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_document_returns_none_when_not_found() -> None:
+    service, mock_conn = _make_service_with_fetchrow(row=None)
+
+    result = await service.soft_delete_document(
+        client_id=1,
+        document_id=404,
+        current_user={"client_id": 1, "email": "client@example.com"},
+    )
+
+    assert result is None
+    # no timeline event when nothing was deleted
+    assert mock_conn.execute.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_restore_document_clears_deleted_and_returns_summary() -> None:
+    service, mock_conn = _make_service_with_fetchrow(
+        {"id": 11, "file_name": "kitas.pdf", "document_type": "kitas"}
+    )
+
+    result = await service.restore_document(
+        client_id=1,
+        document_id=11,
+        current_user={"client_id": 1, "email": "client@example.com"},
+    )
+
+    assert result == {
+        "id": 11,
+        "name": "kitas.pdf",
+        "type": "kitas",
+        "deleted": False,
+    }
+    update_sql = mock_conn.fetchrow.call_args.args[0]
+    assert "deleted_at = NULL" in update_sql
+    assert "deleted_at IS NOT NULL" in update_sql  # only restore actually-deleted rows
+    assert mock_conn.fetchrow.call_args.args[1:] == (11, 1)
+    assert mock_conn.execute.await_count == 1
+    assert "document_restored" in mock_conn.execute.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_restore_document_returns_none_when_not_deleted() -> None:
+    service, mock_conn = _make_service_with_fetchrow(row=None)
+
+    result = await service.restore_document(
+        client_id=1,
+        document_id=11,
+        current_user={"client_id": 1, "email": "client@example.com"},
+    )
+
+    assert result is None
+    assert mock_conn.execute.await_count == 0
 
 
 @pytest.mark.asyncio

--- a/apps/backend-rag/backend/tests/unit/routers/test_portal.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_portal.py
@@ -334,6 +334,70 @@ class TestDocuments:
         assert call.args == (42, 10)
         assert call.kwargs["current_user"]["client_id"] == 42
 
+    def test_upload_document_forwards_purpose(self, client, mock_portal_service):
+        """FASE 5: a document_purpose form field reaches the service (trimmed)."""
+        mock_portal_service.upload_document.return_value = {"id": 10, "file_name": "passport.pdf"}
+
+        response = client.post(
+            "/api/portal/documents/upload",
+            data={"document_type": "passport", "document_purpose": "  KITAS renewal  "},
+            files={"file": ("passport.pdf", b"PDF_CONTENT", "application/pdf")},
+        )
+
+        assert response.status_code == 200
+        call = mock_portal_service.upload_document.call_args
+        assert call.kwargs["document_purpose"] == "KITAS renewal"
+
+    def test_delete_document_success(self, client, mock_portal_service):
+        """FASE 5: soft-delete returns recovery message."""
+        mock_portal_service.soft_delete_document.return_value = {
+            "id": 10,
+            "name": "passport.pdf",
+            "type": "passport",
+            "deleted": True,
+        }
+
+        response = client.delete("/api/portal/documents/10")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert "restore" in data["message"].lower()
+        call = mock_portal_service.soft_delete_document.call_args
+        assert call.args == (42, 10)
+        assert call.kwargs["current_user"]["client_id"] == 42
+
+    def test_delete_document_not_found(self, client, mock_portal_service):
+        """FASE 5: soft-delete of an unknown doc returns 404."""
+        mock_portal_service.soft_delete_document.return_value = None
+
+        response = client.delete("/api/portal/documents/404")
+        assert response.status_code == 404
+
+    def test_restore_document_success(self, client, mock_portal_service):
+        """FASE 5: restore returns the recovered document."""
+        mock_portal_service.restore_document.return_value = {
+            "id": 10,
+            "name": "passport.pdf",
+            "type": "passport",
+            "deleted": False,
+        }
+
+        response = client.post("/api/portal/documents/10/restore")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        call = mock_portal_service.restore_document.call_args
+        assert call.args == (42, 10)
+
+    def test_restore_document_not_found(self, client, mock_portal_service):
+        """FASE 5: restore of a non-deleted/unknown doc returns 404."""
+        mock_portal_service.restore_document.return_value = None
+
+        response = client.post("/api/portal/documents/404/restore")
+        assert response.status_code == 404
+
 
 # ============================================
 # MESSAGE TESTS

--- a/apps/mouth/src/components/portal/vault/VaultFileGrid.test.tsx
+++ b/apps/mouth/src/components/portal/vault/VaultFileGrid.test.tsx
@@ -53,4 +53,37 @@ describe("VaultFileGrid", () => {
     expect(onDownload).toHaveBeenCalledTimes(1);
     expect(onDownload).toHaveBeenCalledWith(file);
   });
+
+  // FASE 5 — purpose + soft-delete/restore
+  it("renders the document purpose when present", () => {
+    const file = makeFile({ purpose: "Passport for KITAS renewal" });
+    render(<VaultFileGrid files={[file]} />);
+    expect(screen.getByText(/Passport for KITAS renewal/)).toBeInTheDocument();
+  });
+
+  it("omits Remove button when onDelete is not provided", () => {
+    render(<VaultFileGrid files={[makeFile()]} />);
+    expect(
+      screen.queryByRole("button", { name: /remove/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("fires onDelete and then shows an Undo affordance", async () => {
+    const onDelete = vi.fn().mockResolvedValue(true);
+    const onRestore = vi.fn().mockResolvedValue(true);
+    const file = makeFile({ id: 7, name: "kitas.pdf" });
+    render(
+      <VaultFileGrid
+        files={[file]}
+        onDelete={onDelete}
+        onRestore={onRestore}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /remove kitas\.pdf/i }));
+    expect(onDelete).toHaveBeenCalledWith(file);
+    // Undo card appears after the delete resolves
+    const undo = await screen.findByRole("button", { name: /undo/i });
+    fireEvent.click(undo);
+    expect(onRestore).toHaveBeenCalledWith(file);
+  });
 });

--- a/apps/mouth/src/components/portal/vault/VaultFileGrid.tsx
+++ b/apps/mouth/src/components/portal/vault/VaultFileGrid.tsx
@@ -1,9 +1,12 @@
 "use client";
+import { useState } from "react";
 import {
   FileText,
   Image as ImgIcon,
   File as FileIcon,
   Download,
+  Trash2,
+  Undo2,
 } from "lucide-react";
 import type { VaultFile } from "@/lib/schemas/vault";
 
@@ -37,62 +40,141 @@ function formatDate(iso: string): string {
 interface Props {
   files: VaultFile[];
   onDownload?: (file: VaultFile) => void;
+  /** FASE 5 — soft-delete a document (recoverable). */
+  onDelete?: (file: VaultFile) => void | Promise<unknown>;
+  /** FASE 5 — restore a just-removed document (undo). */
+  onRestore?: (file: VaultFile) => void | Promise<unknown>;
+  /** id currently mid-action (for disabling the row's buttons). */
+  pendingId?: number | null;
 }
 
-export function VaultFileGrid({ files, onDownload }: Props) {
-  if (files.length === 0) {
+export function VaultFileGrid({
+  files,
+  onDownload,
+  onDelete,
+  onRestore,
+  pendingId,
+}: Props) {
+  // Track ids removed in THIS session so we can offer a transient "Undo".
+  // The SWR list drops the row on revalidation; we keep a local undo card.
+  const [undoable, setUndoable] = useState<Record<number, VaultFile>>({});
+
+  if (files.length === 0 && Object.keys(undoable).length === 0) {
     return (
       <p className="text-sm text-[#c9a96e]/60 py-8 text-center">
         No files in this view.
       </p>
     );
   }
+
+  const handleDelete = async (f: VaultFile) => {
+    if (!onDelete) return;
+    await onDelete(f);
+    setUndoable((prev) => ({ ...prev, [f.id]: f }));
+  };
+
+  const handleRestore = async (f: VaultFile) => {
+    if (onRestore) await onRestore(f);
+    setUndoable((prev) => {
+      const next = { ...prev };
+      delete next[f.id];
+      return next;
+    });
+  };
+
   return (
-    <ul
-      aria-label="Vault files"
-      className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3"
-    >
-      {files.map((f) => {
-        const Icon = iconFor(f.type);
-        return (
-          <li
-            key={f.id}
-            className="p-3 rounded-lg border border-white/10 hover:border-white/30 flex flex-col gap-2"
-          >
-            <div className="flex items-start gap-2">
-              <Icon
-                aria-hidden
-                className="w-8 h-8 text-[#c9a96e]/70 shrink-0"
-              />
-              <div className="min-w-0 flex-1">
-                <p className="text-xs text-[#f0ece4] truncate" title={f.name}>
-                  {f.name}
-                </p>
-                <p className="text-[10px] uppercase tracking-[2px] text-[#c9a96e]/40 mt-1">
-                  {f.type}
-                </p>
-              </div>
-            </div>
-            <div className="flex items-center justify-between text-[10px] text-[#c9a96e]/40">
-              <span>{formatDate(f.created_at)}</span>
-              {f.size_kb != null && <span>{f.size_kb} KB</span>}
-            </div>
-            {f.downloadable && onDownload && (
-              <button
-                onClick={() => onDownload(f)}
-                className="text-[11px] uppercase tracking-[2px] text-[#d4845a] hover:underline inline-flex items-center gap-1"
-              >
-                <Download aria-hidden className="w-3 h-3" /> Download
-              </button>
-            )}
-            {f.status && (
-              <span className="text-[10px] uppercase tracking-[2px] text-[#c9a96e]/60">
-                {f.status}
+    <div className="space-y-3">
+      {Object.values(undoable).length > 0 && (
+        <ul aria-label="Recently removed" className="space-y-2">
+          {Object.values(undoable).map((f) => (
+            <li
+              key={`undo-${f.id}`}
+              className="flex items-center justify-between gap-3 p-3 rounded-lg border border-[#d4845a]/30 bg-white/5 text-xs text-[#f0ece4]"
+            >
+              <span className="truncate">
+                Removed <strong>{f.name}</strong>. Recoverable for 30 days.
               </span>
-            )}
-          </li>
-        );
-      })}
-    </ul>
+              {onRestore && (
+                <button
+                  onClick={() => handleRestore(f)}
+                  disabled={pendingId === f.id}
+                  className="shrink-0 text-[11px] uppercase tracking-[2px] text-[#d4845a] hover:underline inline-flex items-center gap-1 disabled:opacity-50"
+                >
+                  <Undo2 aria-hidden className="w-3 h-3" /> Undo
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+      <ul
+        aria-label="Vault files"
+        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3"
+      >
+        {files.map((f) => {
+          const Icon = iconFor(f.type);
+          return (
+            <li
+              key={f.id}
+              className="p-3 rounded-lg border border-white/10 hover:border-white/30 flex flex-col gap-2"
+            >
+              <div className="flex items-start gap-2">
+                <Icon
+                  aria-hidden
+                  className="w-8 h-8 text-[#c9a96e]/70 shrink-0"
+                />
+                <div className="min-w-0 flex-1">
+                  <p className="text-xs text-[#f0ece4] truncate" title={f.name}>
+                    {f.name}
+                  </p>
+                  <p className="text-[10px] uppercase tracking-[2px] text-[#c9a96e]/40 mt-1">
+                    {f.type}
+                  </p>
+                </div>
+              </div>
+              {f.purpose && (
+                <p
+                  className="text-[11px] text-[#c9a96e]/70 italic line-clamp-2"
+                  title={f.purpose}
+                >
+                  “{f.purpose}”
+                </p>
+              )}
+              <div className="flex items-center justify-between text-[10px] text-[#c9a96e]/40">
+                <span>{formatDate(f.created_at)}</span>
+                {f.size_kb != null && <span>{f.size_kb} KB</span>}
+              </div>
+              <div className="flex items-center justify-between gap-2">
+                {f.downloadable && onDownload ? (
+                  <button
+                    onClick={() => onDownload(f)}
+                    className="text-[11px] uppercase tracking-[2px] text-[#d4845a] hover:underline inline-flex items-center gap-1"
+                  >
+                    <Download aria-hidden className="w-3 h-3" /> Download
+                  </button>
+                ) : (
+                  <span />
+                )}
+                {onDelete && (
+                  <button
+                    onClick={() => handleDelete(f)}
+                    disabled={pendingId === f.id}
+                    aria-label={`Remove ${f.name}`}
+                    className="text-[11px] uppercase tracking-[2px] text-[#c9a96e]/50 hover:text-[#c94a4a] inline-flex items-center gap-1 disabled:opacity-50"
+                  >
+                    <Trash2 aria-hidden className="w-3 h-3" /> Remove
+                  </button>
+                )}
+              </div>
+              {f.status && (
+                <span className="text-[10px] uppercase tracking-[2px] text-[#c9a96e]/60">
+                  {f.status}
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
   );
 }

--- a/apps/mouth/src/components/portal/vault/VaultLayout.tsx
+++ b/apps/mouth/src/components/portal/vault/VaultLayout.tsx
@@ -6,10 +6,17 @@ import { VaultSearchBar } from "./VaultSearchBar";
 import { VaultUploadZone } from "./VaultUploadZone";
 import { VaultErrorBoundary } from "./VaultErrorBoundary";
 import { useVaultFiles } from "@/hooks/useVaultFiles";
+import { useVaultDocumentActions } from "@/hooks/useVaultDocumentActions";
 import type { VaultFile } from "@/lib/schemas/vault";
 
 export function VaultLayout() {
   const { data, error, isLoading, mutate } = useVaultFiles();
+  const {
+    remove,
+    restore,
+    pendingId,
+    error: actionError,
+  } = useVaultDocumentActions(() => mutate());
   const [practiceFilter, setPracticeFilter] = useState<string | null>(null);
   const [typeFilter, setTypeFilter] = useState<string | null>(null);
   const [q, setQ] = useState("");
@@ -79,8 +86,19 @@ export function VaultLayout() {
                 </button>
               </div>
             )}
+            {actionError && (
+              <p role="alert" className="text-xs text-[#c94a4a] mb-2">
+                {actionError}
+              </p>
+            )}
             {data && (
-              <VaultFileGrid files={filtered} onDownload={handleDownload} />
+              <VaultFileGrid
+                files={filtered}
+                onDownload={handleDownload}
+                onDelete={(f) => remove(f.id)}
+                onRestore={(f) => restore(f.id)}
+                pendingId={pendingId}
+              />
             )}
           </div>
         </div>

--- a/apps/mouth/src/components/portal/vault/VaultUploadZone.test.tsx
+++ b/apps/mouth/src/components/portal/vault/VaultUploadZone.test.tsx
@@ -45,7 +45,31 @@ describe("VaultUploadZone", () => {
     fireEvent.change(input);
     expect(mockUpload).toHaveBeenCalledTimes(1);
     expect(mockUpload.mock.calls[0][0]).toBe(file);
-    expect(mockUpload.mock.calls[0][1]).toEqual({ practiceId: 42 });
+    // FASE 5: purpose is now part of the upload options (empty when untouched).
+    expect(mockUpload.mock.calls[0][1]).toEqual({
+      practiceId: 42,
+      purpose: "",
+    });
+  });
+
+  it("forwards the typed purpose to upload()", () => {
+    render(<VaultUploadZone practiceId={42} />);
+    const purposeInput = screen.getByLabelText(
+      /what is this document for/i,
+    ) as HTMLInputElement;
+    fireEvent.change(purposeInput, {
+      target: { value: "Passport for KITAS renewal" },
+    });
+    const input = screen.getByLabelText(
+      "Choose file to upload",
+    ) as HTMLInputElement;
+    const file = new File(["x"], "a.pdf", { type: "application/pdf" });
+    Object.defineProperty(input, "files", { value: [file] });
+    fireEvent.change(input);
+    expect(mockUpload.mock.calls[0][1]).toEqual({
+      practiceId: 42,
+      purpose: "Passport for KITAS renewal",
+    });
   });
 
   it("renders error state when upload state is error", () => {

--- a/apps/mouth/src/components/portal/vault/VaultUploadZone.tsx
+++ b/apps/mouth/src/components/portal/vault/VaultUploadZone.tsx
@@ -11,71 +11,97 @@ interface Props {
 export function VaultUploadZone({ practiceId, onDone }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [dragOver, setDragOver] = useState(false);
+  const [purpose, setPurpose] = useState("");
   const { state, upload, reset } = useVaultUpload();
 
   useEffect(() => {
     if (state.status === "done") {
       onDone?.();
-      const t = setTimeout(reset, 3000);
+      const t = setTimeout(() => {
+        reset();
+        setPurpose("");
+      }, 3000);
       return () => clearTimeout(t);
     }
   }, [state, onDone, reset]);
 
   const handleFiles = (files: FileList | null) => {
     if (!files || files.length === 0) return;
-    upload(files[0], { practiceId });
+    upload(files[0], { practiceId, purpose });
   };
 
   return (
-    <div
-      data-testid="vault-upload-zone"
-      data-drag-over={dragOver ? "true" : "false"}
-      onDragOver={(e) => {
-        e.preventDefault();
-        setDragOver(true);
-      }}
-      onDragLeave={() => setDragOver(false)}
-      onDrop={(e) => {
-        e.preventDefault();
-        setDragOver(false);
-        handleFiles(e.dataTransfer.files);
-      }}
-      className={`rounded-lg border-2 border-dashed p-6 text-center transition ${
-        dragOver ? "border-[#d4845a] bg-white/5" : "border-white/20"
-      }`}
-    >
-      <Upload aria-hidden className="w-6 h-6 mx-auto text-[#c9a96e]/60 mb-2" />
-      <p className="text-sm text-[#c9a96e]/70 mb-3">Drag & drop here, or</p>
-      <button
-        type="button"
-        onClick={() => inputRef.current?.click()}
-        className="text-xs uppercase tracking-[2px] text-[#d4845a] hover:underline"
+    <div className="space-y-2">
+      <div>
+        <label
+          htmlFor="vault-upload-purpose"
+          className="block text-[10px] uppercase tracking-[2px] text-[#c9a96e]/50 mb-1"
+        >
+          What is this document for? (optional)
+        </label>
+        <input
+          id="vault-upload-purpose"
+          type="text"
+          value={purpose}
+          maxLength={500}
+          onChange={(e) => setPurpose(e.target.value)}
+          placeholder="e.g. Passport for KITAS renewal"
+          className="w-full rounded-lg border border-white/15 bg-transparent px-3 py-2 text-sm text-[#f0ece4] placeholder:text-[#c9a96e]/30 focus:border-[#d4845a] focus:outline-none"
+        />
+      </div>
+      <div
+        data-testid="vault-upload-zone"
+        data-drag-over={dragOver ? "true" : "false"}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragOver(true);
+        }}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={(e) => {
+          e.preventDefault();
+          setDragOver(false);
+          handleFiles(e.dataTransfer.files);
+        }}
+        className={`rounded-lg border-2 border-dashed p-6 text-center transition ${
+          dragOver ? "border-[#d4845a] bg-white/5" : "border-white/20"
+        }`}
       >
-        Choose file
-      </button>
-      <input
-        ref={inputRef}
-        type="file"
-        className="sr-only"
-        onChange={(e) => handleFiles(e.target.files)}
-        aria-label="Choose file to upload"
-      />
-      {state.status === "uploading" && (
-        <p role="status" className="text-xs text-[#c9a96e]/60 mt-3">
-          Uploading… {Math.round(state.progress)}%
-        </p>
-      )}
-      {state.status === "error" && (
-        <p role="alert" className="text-xs text-[#c94a4a] mt-3">
-          {state.message}
-        </p>
-      )}
-      {state.status === "done" && (
-        <p role="status" className="text-xs text-[#4a9c5c] mt-3">
-          Uploaded: {state.file.name}
-          {!state.processing.virus_clean && " (flagged)"}
-        </p>
-      )}
+        <Upload
+          aria-hidden
+          className="w-6 h-6 mx-auto text-[#c9a96e]/60 mb-2"
+        />
+        <p className="text-sm text-[#c9a96e]/70 mb-3">Drag & drop here, or</p>
+        <button
+          type="button"
+          onClick={() => inputRef.current?.click()}
+          className="text-xs uppercase tracking-[2px] text-[#d4845a] hover:underline"
+        >
+          Choose file
+        </button>
+        <input
+          ref={inputRef}
+          type="file"
+          className="sr-only"
+          onChange={(e) => handleFiles(e.target.files)}
+          aria-label="Choose file to upload"
+        />
+        {state.status === "uploading" && (
+          <p role="status" className="text-xs text-[#c9a96e]/60 mt-3">
+            Uploading… {Math.round(state.progress)}%
+          </p>
+        )}
+        {state.status === "error" && (
+          <p role="alert" className="text-xs text-[#c94a4a] mt-3">
+            {state.message}
+          </p>
+        )}
+        {state.status === "done" && (
+          <p role="status" className="text-xs text-[#4a9c5c] mt-3">
+            Uploaded: {state.file.name}
+            {!state.processing.virus_clean && " (flagged)"}
+          </p>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/mouth/src/hooks/useVaultDocumentActions.ts
+++ b/apps/mouth/src/hooks/useVaultDocumentActions.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { api } from "@/lib/api";
+
+/**
+ * FASE 5 — soft-delete / restore actions for portal vault documents.
+ *
+ *   - DELETE /api/portal/documents/{id}            → soft-delete (recoverable)
+ *   - POST   /api/portal/documents/{id}/restore    → restore
+ *
+ * Both endpoints return `{ success, message, data }`. We surface only the
+ * in-flight id (for per-row spinners/disabling) and the last error message;
+ * the caller revalidates the SWR list on success via the `onMutated` callback.
+ */
+export function useVaultDocumentActions(onMutated?: () => void) {
+  const [pendingId, setPendingId] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const remove = useCallback(
+    async (id: number): Promise<boolean> => {
+      setPendingId(id);
+      setError(null);
+      try {
+        await api.delete<unknown>(`/api/portal/documents/${id}`);
+        onMutated?.();
+        return true;
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to remove document");
+        return false;
+      } finally {
+        setPendingId(null);
+      }
+    },
+    [onMutated],
+  );
+
+  const restore = useCallback(
+    async (id: number): Promise<boolean> => {
+      setPendingId(id);
+      setError(null);
+      try {
+        await api.post<unknown>(`/api/portal/documents/${id}/restore`);
+        onMutated?.();
+        return true;
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to restore document");
+        return false;
+      } finally {
+        setPendingId(null);
+      }
+    },
+    [onMutated],
+  );
+
+  return { remove, restore, pendingId, error };
+}

--- a/apps/mouth/src/hooks/useVaultUpload.ts
+++ b/apps/mouth/src/hooks/useVaultUpload.ts
@@ -23,6 +23,11 @@ export type UploadState =
 export interface UploadOptions {
   practiceId?: number | string | null;
   documentType?: string;
+  /**
+   * FASE 5 — client-facing note on why this document is being provided.
+   * Sent as the `document_purpose` form field; trimmed/capped server-side.
+   */
+  purpose?: string | null;
 }
 
 /**
@@ -67,6 +72,9 @@ export function useVaultUpload() {
     }
     if (opts.documentType) {
       fd.append("document_type", opts.documentType);
+    }
+    if (opts.purpose != null && opts.purpose.trim() !== "") {
+      fd.append("document_purpose", opts.purpose.trim());
     }
 
     const xhr = new XMLHttpRequest();

--- a/apps/mouth/src/lib/schemas/vault.ts
+++ b/apps/mouth/src/lib/schemas/vault.ts
@@ -113,6 +113,11 @@ export const VaultFile = z.object({
 
   // `.isoformat()` of DB `created_at` (NOT NULL, defaults to NOW()).
   created_at: z.string(),
+
+  // FASE 5 — client-facing note on why this document was provided (DB
+  // `document_purpose`). Distinct from the internal `notes` column. Null when
+  // not set; absent for rows predating the migration.
+  purpose: z.string().nullable().optional(),
 });
 export type VaultFile = z.infer<typeof VaultFile>;
 


### PR DESCRIPTION
## FASE 5 — Document trust UX for my.balizero.com

Two client-facing trust features for the portal vault, per the blueprint:

### Purpose statement
An optional client-facing note ("why is this document here?") captured at upload (`document_purpose`, **distinct** from the internal `notes` column) and surfaced back to the client in the vault. Helps clients understand what each document is for and reduces "why did you ask for this?" back-and-forth.

### Soft-delete + recovery
Clients can remove a document (hidden from the vault, **file kept in Drive**, DB row preserved) and **undo within 30 days**. Both actions write a client-visible timeline event so the case officer sees the change.

## Backend
- **Migration 236** (idempotent, `ROLLBACK` marker): `documents.document_purpose` TEXT, `deleted_at` TIMESTAMPTZ, `deleted_by` VARCHAR + partial index `idx_documents_client_live` (`client_id WHERE deleted_at IS NULL`).
- `get_documents` / `download_document` now filter `deleted_at IS NULL`; `get_documents` returns `purpose`. `upload_document` accepts `document_purpose`.
- New mixin methods `soft_delete_document` / `restore_document` (cache-invalidating; idempotent guards — soft-delete only touches live rows, restore only touches deleted rows).
- Router: `DELETE /api/portal/documents/{id}`, `POST /api/portal/documents/{id}/restore`, `document_purpose` form field on upload (trimmed, capped 500 chars).

## Frontend
- `vault.ts` Zod `purpose`; `useVaultUpload` forwards `purpose`; `VaultUploadZone` purpose input; new `useVaultDocumentActions` (delete/restore); `VaultFileGrid` shows purpose + Remove + transient Undo; wired in `VaultLayout`.

## Verification
- Backend: 41 tests (mixin + router) green.
- Frontend: 38 vault tests (vitest) green; `tsc --noEmit` clean; eslint clean.
- Migration lint: 120 files all unique; W42 ROLLBACK marker present.
- Full backend suite: **15446 passed, 852 skipped** against local CI-parity Postgres.
- `docs_sync --check`: OK (no new test *files*, only edits).

## Law 2 / safety
No PII leaves local processing. `deleted_by` records the portal-session actor email; superuser impersonation is separately audited in `security_audit_log`. Soft-delete is recoverable — no destructive data loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)