### PR TITLE
fix(portal): register magic-link endpoints as public — FASE 6 was 401-dead in prod

### DIFF
--- a/apps/backend-rag/backend/app/auth/public_endpoints.py
+++ b/apps/backend-rag/backend/app/auth/public_endpoints.py
@@ -173,6 +173,20 @@ _AUTH = (
         Category.AUTH,
         "CSRF token generation — must be public for CSRF protection flow",
     ),
+    PublicEndpoint(
+        "/api/auth/request-magic-link",
+        Category.AUTH,
+        "Passwordless magic-link request (FASE 6) — must be public; an "
+        "unauthenticated client asks for a sign-in link. Enumeration-safe.",
+        match="exact",
+    ),
+    PublicEndpoint(
+        "/api/auth/verify-magic/",
+        Category.AUTH,
+        "Passwordless magic-link verify (FASE 6) — must be public; consumes the "
+        "single-use token and establishes the session. Prefix match: the token "
+        "is a path param.",
+    ),
     # 2026-05-28: removed "/api/workflow/" prefix entry. All workflow_queue routes
     # (/enqueue, /status/{job_id}, /chains) require Depends(get_current_user), so the
     # public declaration was dead+contradictory (middleware bypassed auth, route 401'd).

--- a/apps/backend-rag/backend/tests/unit/middleware/test_public_endpoints_registry.py
+++ b/apps/backend-rag/backend/tests/unit/middleware/test_public_endpoints_registry.py
@@ -86,6 +86,23 @@ class TestB1_NoUndocumentedPublicRoutes:
         req = self._mock_request("/api/lead/capture/admin")
         assert not middleware.is_public_endpoint(req)
 
+    def test_magic_link_endpoints_are_public(self, middleware):
+        """Regression (FASE 6): the passwordless magic-link endpoints must be
+        public. They were registered as routes but missing from this registry,
+        so prod returned 401 to unauthenticated clients requesting a link —
+        the feature was dead-on-arrival until added here."""
+        # Request: exact match, must not open sibling paths.
+        assert middleware.is_public_endpoint(
+            self._mock_request("/api/auth/request-magic-link")
+        )
+        assert not middleware.is_public_endpoint(
+            self._mock_request("/api/auth/request-magic-link/extra")
+        )
+        # Verify: prefix match (token is a path param).
+        assert middleware.is_public_endpoint(
+            self._mock_request("/api/auth/verify-magic/some-raw-token")
+        )
+
     def test_non_registered_paths_require_auth(self, middleware):
         """A selection of sensitive paths must NOT be public."""
         sensitive = [


### PR DESCRIPTION
## Magic-link was dead-on-arrival in prod

Post-deploy live verification of FASE 6 (#1638) found both passwordless magic-link routes returning **401 to unauthenticated callers**:

```
POST /api/auth/request-magic-link  → 401
GET  /api/auth/verify-magic/{token} → 401
```

An unauthenticated visitor is exactly who needs these. Root cause: the routes were mounted but **missing from the public-endpoint registry** (`backend/app/auth/public_endpoints.py`), so `HybridAuthMiddleware` treated them as protected.

This is the same class as the `/api/lead/capture` regression already pinned in the registry tests — superscar #2 (built-but-not-armed last-mile). Caught by probing the real route, not trusting deploy-green.

## Fix
- `request-magic-link`: **exact** match (POST). `verify-magic/`: **prefix** match (token is a path param).
- The public-endpoint check short-circuits BEFORE CSRF validation (`hybrid_auth.py:196` vs `:432`), so the POST also correctly bypasses CSRF (a first-time unauthenticated visitor has no CSRF token).
- Added `test_magic_link_endpoints_are_public` regression test (exact-match doesn't open siblings; prefix matches a token).

## Verification
- Registry + reachability parity tests: 17/17 green (`test_every_entry_resolves`, `test_public_paths_bypass_auth` pass with the new entries).
- Migration 237 table + FASE 5 migration 236 columns/index confirmed live via Postgres MCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)