### PR TITLE
fix(cron): reconcile 4 chronic DLQ jobs to repo — ops_briefing/heartbeat/qdrant/skill-coach

### DIFF
--- a/apps/evaluator/nlm_deep_research/db_nlm_state.py
+++ b/apps/evaluator/nlm_deep_research/db_nlm_state.py
@@ -26,9 +26,13 @@ _DEFAULT_LOCK_PATH: Path = _DIR / "db_nlm_sync.lock"
 
 # --- Notebook IDs (populated after creation via `nlm notebook create`) ---
 # These will be set on first run or via CLI args.
-NB_OPS_ID: str = "2072e518-e6f9-437d-93ea-f9037ec54052"       # NB-11: Bali Zero Ops Live
-NB_INTEL_ID: str = "5c2c3d90-eed2-4755-86b1-269e637e51e1"      # NB-12: Bali Zero Business Intelligence
-NB_TELEMETRY_ID: str = "53441d9e-fb11-44cc-8dd8-4d70637b651f"  # NB-13: Bali Zero System Telemetry
+# Post-2026-05-18 UUID switch: NBs recreated on zero@balizero.com Workspace.
+# Old antonellosiano@ src UUIDs (2072e518/5c2c3d90/53441d9e) are dead -> ops_briefing
+# failed "NB-11 (ops) ID not found in sync state". New uuid_dst from
+# ~/logs/nb-migration-mapping.json (mapping). Pairing verified 2026-06-21.
+NB_OPS_ID: str = "446cc343-63ae-4b08-ab69-7ed916081356"       # NB-11: Bali Zero Ops Live
+NB_INTEL_ID: str = "40266e02-3588-4edd-ad74-0829aa2ead26"     # NB-12: Bali Zero Business Intelligence
+NB_TELEMETRY_ID: str = "66423f18-888e-4cec-8a35-686ef512761f"  # NB-13: Bali Zero System Telemetry
 
 # --- Source slots per notebook ---
 MAX_SOURCES_PER_NB: int = 15

--- a/apps/evaluator/nlm_deep_research/heartbeat_monitor.py
+++ b/apps/evaluator/nlm_deep_research/heartbeat_monitor.py
@@ -31,9 +31,11 @@ import argparse
 import json
 import logging
 import os
+import socket
 import subprocess
 import sys
 import tempfile
+import time
 import urllib.error
 import urllib.request
 from datetime import datetime, timedelta, timezone
@@ -425,16 +427,24 @@ def _send_telegram(text: str, dry_run: bool = False) -> bool:
         method="POST",
     )
 
-    try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            if resp.status == 200:
-                logger.info("Telegram alert sent successfully")
-                return True
-            logger.warning("Telegram API returned status %d", resp.status)
-            return False
-    except urllib.error.URLError as exc:
-        logger.error("Failed to send Telegram alert: %s", exc)
-        return False
+    # #8 network-flap: api.telegram.org can read-stall. The old URLError-only
+    # except let a bare TimeoutError escape and crash the --check run (DLQ
+    # run_heartbeat_check). Retry with backoff + catch the transport-level errors.
+    last_exc: Exception | None = None
+    for attempt in range(1, 4):
+        try:
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                if resp.status == 200:
+                    logger.info("Telegram alert sent successfully")
+                    return True
+                logger.warning("Telegram API returned status %d", resp.status)
+                return False
+        except (urllib.error.URLError, TimeoutError, socket.timeout, OSError) as exc:
+            last_exc = exc
+            if attempt < 3:
+                time.sleep(2 ** (attempt - 1))
+    logger.error("Failed to send Telegram alert after 3 attempts: %s", last_exc)
+    return False
 
 
 def _format_last_run(last_success: str | None) -> str:

--- a/apps/evaluator/nlm_deep_research/tests/test_heartbeat_monitor.py
+++ b/apps/evaluator/nlm_deep_research/tests/test_heartbeat_monitor.py
@@ -26,6 +26,7 @@ from apps.evaluator.nlm_deep_research.heartbeat_monitor import (
     _classify_staleness,
     _format_last_run,
     _read_heartbeat_state,
+    _send_telegram,
     check_all_heartbeats,
     check_memory_pressure,
     load_registry,
@@ -428,3 +429,56 @@ class TestFormatLastRun:
 
     def test_invalid(self) -> None:
         assert _format_last_run("not-a-date") == "invalid"
+
+
+# ---------------------------------------------------------------------------
+# _send_telegram retry / network-flap (#8) — regression for DLQ run_heartbeat_check
+# ---------------------------------------------------------------------------
+
+
+def _cm_resp(status=200):
+    """A urlopen return value usable as a context manager (with ... as resp)."""
+    resp = MagicMock()
+    resp.status = status
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+def test_send_telegram_retries_then_succeeds(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "x:y")
+    calls = {"n": 0}
+
+    def flaky(*a, **k):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise TimeoutError("read timed out")
+        return _cm_resp(200)
+
+    with patch(
+        "apps.evaluator.nlm_deep_research.heartbeat_monitor.urllib.request.urlopen",
+        side_effect=flaky,
+    ), patch(
+        "apps.evaluator.nlm_deep_research.heartbeat_monitor.time.sleep"
+    ) as sleep:
+        assert _send_telegram("hi") is True
+    assert calls["n"] == 3
+    assert sleep.call_count == 2
+
+
+def test_send_telegram_bare_timeout_does_not_crash(monkeypatch):
+    # Regression: old except caught only urllib.error.URLError, so a bare
+    # TimeoutError escaped and crashed the --check run (DLQ run_heartbeat_check).
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "x:y")
+    with patch(
+        "apps.evaluator.nlm_deep_research.heartbeat_monitor.urllib.request.urlopen",
+        side_effect=TimeoutError("boom"),
+    ), patch(
+        "apps.evaluator.nlm_deep_research.heartbeat_monitor.time.sleep"
+    ):
+        assert _send_telegram("hi") is False  # returns False, never raises
+
+
+def test_send_telegram_no_token_returns_false(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    assert _send_telegram("hi") is False

--- a/scripts/qdrant-snapshot.sh
+++ b/scripts/qdrant-snapshot.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Repo-canonical (W50 promotion from ~/scripts/, 2026-06-21).
+# The crontab MUST exec THIS copy; the ~/scripts fork is deprecated.
 # qdrant-snapshot.sh — Qdrant Cloud Snapshot Backup → Tigris S3
 # Creates per-collection snapshots, uploads individually to Tigris
 # Retention: last 4 snapshots per collection on Tigris
@@ -182,7 +184,8 @@ for COLLECTION in $COLLECTIONS; do
        aws s3 cp "$OUTPUT_FILE" \
            "s3://$TIGRIS_BUCKET/$S3_KEY" \
            --endpoint-url "$TIGRIS_ENDPOINT" \
-           --region auto 2>/dev/null; then
+           --region auto \
+           --cli-connect-timeout 30 --cli-read-timeout 0 2>/dev/null; then
         log "  Uploaded: s3://$TIGRIS_BUCKET/$S3_KEY"
 
         # Retention: keep last KEEP_REMOTE per collection on Tigris

--- a/scripts/skill-coach-daily.sh
+++ b/scripts/skill-coach-daily.sh
@@ -1,0 +1,99 @@
+#!/bin/zsh
+# Repo-canonical (W50 promotion from ~/.openclaw/bin/, 2026-06-21).
+# Plist MUST exec THIS copy; paths derive from repo root (no dead worktree).
+set -euo pipefail
+
+export PATH="/opt/homebrew/bin:/opt/homebrew/opt/node/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+WT="$(cd "$(dirname "${0:A}")/.." && pwd)"  # repo root (W50: derive; was dead worktree)
+APP="$WT/apps/backend-rag"
+VENV="$APP/.venv"
+OPENCLAW_NODE="/opt/homebrew/opt/node/bin/node"
+OPENCLAW_CLI="/opt/homebrew/lib/node_modules/openclaw/dist/index.js"
+LOG_DIR="$HOME/.openclaw/cron/runs"
+RUN_ID="skill-coach-launchd-$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_LOG="$LOG_DIR/${RUN_ID}.jsonl"
+LATEST="$LOG_DIR/skill-coach-daily.latest.json"
+TMP_OUTPUT="${TMPDIR:-/tmp}/skill-coach-runner.$$.$RANDOM.out"
+STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+mkdir -p "$LOG_DIR"
+cd "$APP"
+
+if [[ ! -x "$VENV/bin/python" ]]; then
+  printf '{"status":"error","error_type":"MissingVenv","message":"backend venv python not executable"}\n' > "$TMP_OUTPUT"
+  RC=1
+else
+  set +e
+  PYTHONPATH=. "$VENV/bin/python" -m backend.scripts.skill_coach_openclaw_runner --window-days 15 > "$TMP_OUTPUT" 2>&1
+  RC=$?
+  set -e
+fi
+
+"$VENV/bin/python" - "$TMP_OUTPUT" "$RC" "$RUN_ID" "$STARTED_AT" "$LATEST" "$RUN_LOG" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+output_path = Path(sys.argv[1])
+rc = int(sys.argv[2])
+run_id = sys.argv[3]
+started_at = sys.argv[4]
+latest_path = Path(sys.argv[5])
+run_log_path = Path(sys.argv[6])
+ended_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+summary = None
+for line in output_path.read_text(encoding="utf-8", errors="replace").splitlines():
+    stripped = line.strip()
+    if not stripped.startswith("{"):
+        continue
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        continue
+    if isinstance(parsed, dict):
+        summary = parsed
+if summary is None:
+    summary = {
+        "status": "error" if rc else "unknown",
+        "error_type": "NoJsonSummary",
+        "message": "runner produced no machine-readable summary",
+    }
+record = {
+    "run_id": run_id,
+    "started_at": started_at,
+    "ended_at": ended_at,
+    "rc": rc,
+    "status": "ok" if rc == 0 and summary.get("status") == "ok" else "error",
+    "summary": summary,
+}
+latest_path.write_text(json.dumps(record, sort_keys=True) + "\n", encoding="utf-8")
+with run_log_path.open("a", encoding="utf-8") as fh:
+    fh.write(json.dumps(record, sort_keys=True) + "\n")
+print(json.dumps(record, sort_keys=True))
+PY
+
+EVENT_TEXT=$("$VENV/bin/python" - "$LATEST" <<'PY'
+import json, sys
+record = json.load(open(sys.argv[1], encoding='utf-8'))
+summary = record.get('summary') or {}
+print(
+    "Skill Coach daily finished: "
+    f"status={record.get('status')} rc={record.get('rc')} "
+    f"proposals={summary.get('proposals_written')} "
+    f"evidence={summary.get('evidence_written')} "
+    f"evidence_by_status={summary.get('evidence_by_status')} "
+    f"latest={sys.argv[1]}"
+)
+PY
+)
+"$OPENCLAW_NODE" "$OPENCLAW_CLI" system event \
+  --json \
+  --mode next-heartbeat \
+  --session-key agent:ops:skill-coach-daily \
+  --text "$EVENT_TEXT" >/dev/null 2>&1 || true
+
+rm -f "$TMP_OUTPUT"
+exit "$RC"


### PR DESCRIPTION
## Why

Four chronic DLQ jobs were failing for two structural reasons (superscar #1 HOME-fork + #8 network-flap):

| job | root cause | fix |
|---|---|---|
| `run_ops_briefing` | NB-11/12/13 sync-state defaults still pointed at the dead `antonellosiano@` src UUIDs (pre 2026-05-18 Workspace UUID switch) → "NB-11 (ops) ID not found" | repoint to `uuid_dst` from `~/logs/nb-migration-mapping.json` (src→dst pairing verified against the mapping) |
| `run_heartbeat_check` | `_send_telegram` caught only `urllib.error.URLError`; a bare `TimeoutError` from an `api.telegram.org` read-stall escaped and crashed the `--check` run | bounded retry + backoff, broaden except to `TimeoutError/socket.timeout/OSError` (#8) |
| `qdrant_snapshot` | repo `scripts/qdrant-snapshot.sh` was a **byte-identical** duplicate of the live `~/scripts/` fork (HOME-fork #1) | harden the upload leg with `--cli-connect-timeout 30 --cli-read-timeout 0` + provenance header |
| `skill_coach_daily` | `~/.openclaw/bin/skill-coach-daily.sh` `cd`'d into a **dead worktree** (`.worktrees/backend-rag-skill-coach-openclaw-prod`) and exited before running | promote to `scripts/`, derive paths from the script's own repo location |

## Tests
- 3 new in `test_heartbeat_monitor.py` for the retry path, incl. the bare-`TimeoutError` regression. `62 passed` across the two touched test files.
- `bash -n`/`zsh -n` clean on both promoted scripts; `ruff --select I` clean.

## Arming (operator-side, NOT in this PR)
The runtime still execs the HOME forks. After merge + main pull, the live wiring must be repointed (W50 antidote):
- crontab `qdrant-snapshot` line: `~/scripts/qdrant-snapshot.sh` → `…/Desktop/nuzantara/scripts/qdrant-snapshot.sh`, raise `CRON_TIMEOUT=600`→`1200`
- plist `com.balizero.skill-coach.daily`: exec `…/Desktop/nuzantara/scripts/skill-coach-daily.sh` + `launchctl` reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)