### PR TITLE
feat(kbli): propagate validated L3 intel into RAG source file (front C)

### DIFF
--- a/scripts/kbli_propagate_intel_to_source.py
+++ b/scripts/kbli_propagate_intel_to_source.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Propagate already-validated intel_2026 from the navigator file (apps/mouth/data, 0 mutes)
+into the RAG/Qdrant source file (data/source_documents, 1055 mutes) — front C residue.
+
+WHY: #1612 merged 995 fact-gated L3 records into apps/mouth/data/KBLI_2025_FINAL_CLEAN.json
+(the navigator's file). The data/source_documents/ copy — read by the RAG/Qdrant ingest path
+(reindex_kbli_2025_final.py, kbli_eye.py, build_kbli_oss_twin.py) — never received them and
+still has 1055 mute records. The navigator shows rich intel; the RAG index shows nothing.
+
+This is a DATA COPY, not generation: every intel_2026 block copied here was already
+fact-gated when it was written into apps/mouth. We invent NOTHING. We match by
+kode_kbli_2025 and only fill records that are currently mute in source_documents.
+
+Idempotent: only fills a source record if (a) it is mute AND (b) the navigator has intel
+for that exact code. Never overwrites an existing non-mute source record.
+
+DRY-RUN by default. Pass --apply to write.
+"""
+import json
+import os
+import sys
+import argparse
+
+WT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+NAV = f"{WT}/apps/mouth/data/KBLI_2025_FINAL_CLEAN.json"
+SRC = f"{WT}/data/source_documents/KBLI_2025_FINAL_CLEAN.json"
+KEY = "kode_kbli_2025"
+
+
+def load(path):
+    with open(path) as fh:
+        d = json.load(fh)
+    if isinstance(d, list):
+        return d, None
+    recs = d.get("data") or d.get("records")
+    if recs is not None:
+        return recs, d
+    # dict keyed by code
+    return list(d.values()), d
+
+
+def is_mute(rec):
+    it = rec.get("intel_2026") or {}
+    return not (it.get("whatItMeans") or it.get("whatYouNeed"))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply", action="store_true", help="write the file (default: dry-run)")
+    args = ap.parse_args()
+
+    nav_recs, _ = load(NAV)
+    src_recs, src_wrapper = load(SRC)
+
+    # index navigator intel by code (only non-mute)
+    nav_intel = {}
+    for r in nav_recs:
+        code = str(r.get(KEY) or "")
+        if code and not is_mute(r):
+            nav_intel[code] = r.get("intel_2026")
+
+    filled = 0
+    skipped_no_nav = 0
+    already_ok = 0
+    for r in src_recs:
+        code = str(r.get(KEY) or "")
+        if not is_mute(r):
+            already_ok += 1
+            continue
+        if code in nav_intel:
+            if args.apply:
+                r["intel_2026"] = nav_intel[code]
+            filled += 1
+        else:
+            skipped_no_nav += 1
+
+    print(f"source records total:          {len(src_recs)}")
+    print(f"  already non-mute:            {already_ok}")
+    print(f"  WOULD FILL (nav has intel):  {filled}")
+    print(f"  still mute (nav also mute):  {skipped_no_nav}")
+    print(f"navigator non-mute codes:      {len(nav_intel)}")
+
+    if args.apply:
+        out = src_wrapper if src_wrapper is not None else src_recs
+        if src_wrapper is not None and "data" in src_wrapper:
+            src_wrapper["data"] = src_recs
+        elif src_wrapper is not None and "records" in src_wrapper:
+            src_wrapper["records"] = src_recs
+        with open(SRC, "w") as fh:
+            json.dump(out, fh, ensure_ascii=False, indent=2)
+        print(f"\n✅ APPLIED: wrote {filled} intel blocks into {SRC}")
+    else:
+        print("\n(dry-run — pass --apply to write)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Propagate the already-validated `intel_2026` editorial blocks from the navigator file (`apps/mouth/data/KBLI_2025_FINAL_CLEAN.json`, 0 mutes) into the RAG/Qdrant source file (`data/source_documents/KBLI_2025_FINAL_CLEAN.json`), which was left behind with **1055 mute records**.

## Why

`#1612` merged 995 fact-gated L3 records into the navigator's file. But the `data/source_documents/` copy — read by the RAG/Qdrant ingest path (`reindex_kbli_2025_final.py`, `kbli_eye.py`, `build_kbli_oss_twin.py`) — never received them. The navigator showed rich intel; the RAG index saw nothing.

## How (zero LLM generation — pure data copy)

`scripts/kbli_propagate_intel_to_source.py` copies intel by exact `kode_kbli_2025` match, filling **only** mute records. Every block copied was already fact-gated when first written into the navigator. Idempotent, DRY-RUN by default.

## Verification

- source_documents: **1055 → 0 mutes**
- sampled record (47594) byte-identical to navigator, fact-anchored (cites Bali moratorium 13/5/26)
- diff additive: 1055 records gain intel, **no existing record altered**
- branch cherry-picked clean from fresh `origin/main` — magic-link FASE 6 allowlist preserved, no portal/auth files touched

## Scope note

Qdrant re-ingest (cantiere 4) stays GO-Zero on Pro; this only readies the data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)