### PR TITLE
fix(cron): skill-coach launcher bash-portable + crontab migration (W84)

### DIFF
--- a/scripts/skill-coach-daily.sh
+++ b/scripts/skill-coach-daily.sh
@@ -1,10 +1,12 @@
-#!/bin/zsh
+#!/usr/bin/env bash
 # Repo-canonical (W50 promotion from ~/.openclaw/bin/, 2026-06-21).
-# Plist MUST exec THIS copy; paths derive from repo root (no dead worktree).
+# Run via crontab + cron-runner.sh, NOT launchd: on Pro launchd lacks the TCC/
+# Full-Disk-Access grant for ~/Desktop (scar W84) so it cannot open files here,
+# while cron has it. Paths derive from this file's own repo location.
 set -euo pipefail
 
 export PATH="/opt/homebrew/bin:/opt/homebrew/opt/node/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-WT="$(cd "$(dirname "${0:A}")/.." && pwd)"  # repo root (W50: derive; was dead worktree)
+WT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"  # repo root (W50: derive; portable bash)
 APP="$WT/apps/backend-rag"
 VENV="$APP/.venv"
 OPENCLAW_NODE="/opt/homebrew/opt/node/bin/node"


### PR DESCRIPTION
Clean single-file follow-up to #1640 (the earlier branch was pre-#1640 and would have reverted unrelated KBLI work, so it was closed).

The promoted `scripts/skill-coach-daily.sh` had two defects found while arming it live:

1. **zsh-only `${0:A}` crashed under bash** — `cron-runner.sh` runs scripts via `bash`, where `${0:A}` → `A: unbound variable` → `cd //apps/backend-rag`. Fixed: `#!/usr/bin/env bash` + `${BASH_SOURCE[0]}` derivation.
2. **launchd can't run repo scripts on Pro (scar W84)** — launchd lacks the TCC/Full-Disk-Access grant for `~/Desktop`, so the LaunchAgent gets `exit 127: can't open input file`. `cron` HAS the grant (every other nlm job runs from `~/Desktop` via crontab). Migrated from `com.balizero.skill-coach.daily` (booted-out + disabled) to a crontab line at 02:20 WITA via `cron-runner.sh`.

**Verified live**: `exit 0` / `status=ok` (evidence_written=3, proposals_written=3) via `cron-runner.sh` from the main checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)