### PR TITLE
docs(connectome): track skill-coach launchd→crontab migration (W84)

### DIFF
--- a/docs/connectome/edges/launchd-pro.yaml
+++ b/docs/connectome/edges/launchd-pro.yaml
@@ -169,6 +169,26 @@ edges:
       status: BY_DESIGN_OFF,
       notes: "HTML cutover",
     }
+  - {
+      id: com.balizero.skill-coach.daily,
+      kind: launchd,
+      machine: pro,
+      status: BY_DESIGN_OFF,
+      consumer: "scripts/skill-coach-daily.sh",
+      notes: "launchctl disable + bootout + plist renamed .disabled-W84-2026-06-22 (W84 TCC: launchd lacks Full-Disk-Access for ~/Desktop on Pro -> exit 127 can't open input file). Migrated to crontab (see pro-crontab-skill-coach-daily)",
+    }
+  - id: pro-crontab-skill-coach-daily
+    kind: cron
+    machine: pro
+    status: SCHEDULED_ALIVE
+    consumer: "scripts/skill-coach-daily.sh via scripts/cron-runner.sh (02:20 daily WITA)"
+    notes: "migrated from launchd com.balizero.skill-coach.daily (W84 TCC firebreak). Verified live exit 0 status=ok 2026-06-21"
+    probe:
+      {
+        type: cmd,
+        via: "ssh:pro-lan",
+        cmd: "crontab -l | grep -F skill-coach-daily.sh",
+      }
   # ── DISARMED (loaded, no trigger — on-demand kickstart targets) ──
   - {
       id: com.balizero.sota.m13-collect,


### PR DESCRIPTION
Follow-up to #1640/#1643. After migrating `skill-coach-daily` off launchd (scar W84: on Pro launchd lacks TCC/Full-Disk-Access for `~/Desktop`) to crontab, the connectome graph had no record of the job at all — the guardian was blind to it.

Adds two edges to `docs/connectome/edges/launchd-pro.yaml`:
- **`com.balizero.skill-coach.daily`** (`kind: launchd`, `BY_DESIGN_OFF`) — plist disabled + renamed `.disabled-W84-2026-06-22`; a failed launchctl probe yields CONFIRMED, never REGRESSED.
- **`pro-crontab-skill-coach-daily`** (`kind: cron`, `SCHEDULED_ALIVE`) — probes `crontab -l | grep skill-coach-daily.sh` via `ssh:pro-lan` so the guardian actively confirms the cron line stays armed (closes the #2 "Esiste≠Armato" gap for the migrated job).

Validated: `yaml.safe_load` clean; `verify_connectome.py --only-kind cron --machine pro` loads both with no REGRESSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)