### PR TITLE
fix(kbli): cap per_skala + embedding text length in reindex script

### DIFF
--- a/apps/backend-rag/backend/scripts/reindex_kbli_2025_final.py
+++ b/apps/backend-rag/backend/scripts/reindex_kbli_2025_final.py
@@ -100,10 +100,18 @@ def build_embedding_text(entry: dict) -> str:
         parts.append("")
 
     # PP28/2025 licensing (per_skala)
+    # CAP: some codes (e.g. 61108 telecom) carry 60+ per_skala entries whose verbatim
+    # persyaratan/kewajiban blow the embedding text past the 8192-token limit of
+    # text-embedding-3-small (observed 539k chars). The licensing detail is repetitive
+    # across scale combinations; for SEMANTIC SEARCH the first N distinct entries carry
+    # the signal. We cap to PER_SKALA_MAX entries and note the omission, so the embedding
+    # stays under the model limit without losing the discriminating content.
+    PER_SKALA_MAX = 12
     per_skala = entry.get("per_skala", [])
     if per_skala:
         parts.append("## Perizinan per Skala Usaha (PP 28/2025)")
-        for skala in per_skala:
+        omitted = len(per_skala) - PER_SKALA_MAX
+        for skala in per_skala[:PER_SKALA_MAX]:
             skala_names = ", ".join(skala.get("skala_usaha", []))
             risiko = skala.get("kategori_risiko", "")
             perizinan = skala.get("perizinan", "")
@@ -135,6 +143,12 @@ def build_embedding_text(entry: dict) -> str:
             if fiktif:
                 parts.append("- Fiktif positif: Ya (otomatis jika tidak ditolak)")
 
+            parts.append("")
+        if omitted > 0:
+            parts.append(
+                f"(... {omitted} kombinasi skala/ruang-lingkup tambahan dengan pola "
+                "perizinan serupa tidak ditampilkan di sini.)",
+            )
             parts.append("")
 
     # Intel 2026 (Bali-specific intelligence)
@@ -168,7 +182,15 @@ def build_embedding_text(entry: dict) -> str:
         )
         parts.append("")
 
-    return "\n".join(parts)
+    text = "\n".join(parts)
+    # Final safety cap: text-embedding-3-small rejects inputs over 8192 tokens.
+    # ~24000 chars is a conservative ceiling (mixed ID/EN ≈ 3 chars/token); the
+    # PER_SKALA_MAX cap above keeps virtually every code well under this, but a
+    # pathological uraian or ruang_lingkup must never abort the whole re-index.
+    MAX_EMBED_CHARS = 20000
+    if len(text) > MAX_EMBED_CHARS:
+        text = text[:MAX_EMBED_CHARS].rsplit("\n", 1)[0] + "\n(... dipotong untuk batas panjang.)"
+    return text
 
 
 def build_payload(entry: dict, embedding_text: str) -> dict:


### PR DESCRIPTION
## Problem

`reindex_kbli_2025_final.py` aborted mid-run with OpenAI `400 — maximum input length is 8192 tokens`. **105 of 1559** codes built an embedding text over the limit (worst: `61108` = **539k chars**) because `build_embedding_text` concatenated **all** `per_skala` entries verbatim (some codes carry 60+ scale/scope combinations).

The script embeds *before* it deletes — every failure left the production collection fully intact (4424 points), no data loss.

## Fix

Embedding model stays FROZEN (`text-embedding-3-small` / 1536):
- `PER_SKALA_MAX = 12` licensing entries + omission note.
- `MAX_EMBED_CHARS = 20000` final ceiling (defence-in-depth).

## Verification

- tiktoken `cl100k_base`: max **6841 tokens** across all 1559, **0 over 8192**.
- Re-index completed: 1559 codes → `kbli_2025_final_hybrid` (Qdrant Cloud), gold preserved (5983 points, green).
- Vector smoke-test "villa Bali" → rank 1 `55203 Aktivitas Vila`, `bali_status=CHIUSO_PMA_NO_BESAR`. L3 + L4 Bali searchable in the RAG index.

Closes KBLI cantiere 4. (Replaces #1647, which carried a stale-base deletion.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)