### PR TITLE
fix(portal): upload 500 — guard missing TeamDriveService.service_account_available (BUG B)

### DIFF
--- a/apps/backend-rag/backend/services/portal/_mixins/documents.py
+++ b/apps/backend-rag/backend/services/portal/_mixins/documents.py
@@ -825,7 +825,13 @@ class PortalDocumentsMixin:
             # Use Service Account if OAuth unavailable
             if use_service_account:
                 team_drive = TeamDriveService(db_pool=self.pool)
-                if not team_drive.service_account_available:
+                # BUG B (portal upload 500): TeamDriveService does NOT expose a
+                # `service_account_available` attribute (the SA-fallback code
+                # predates the facade refactor). Reading it directly raised
+                # AttributeError, which the outer except turned into a 500 on
+                # every upload that hit this path. Use getattr so a missing
+                # attribute degrades to the handled "no auth" branch instead.
+                if not getattr(team_drive, "service_account_available", False):
                     logger.error("Service Account also not available")
                     result["error"] = "No Drive authentication available"
                     return result

--- a/apps/backend-rag/backend/tests/unit/app/services/portal/test_documents_mixin.py
+++ b/apps/backend-rag/backend/tests/unit/app/services/portal/test_documents_mixin.py
@@ -802,3 +802,43 @@ async def test_upload_to_drive_oauth_success() -> None:
     assert drive_service.upload_file_to_folder.call_args.kwargs["file_name"].endswith(
         "_passport.pdf"
     )
+
+
+@pytest.mark.asyncio
+async def test_upload_to_drive_service_account_guard_uses_real_team_drive() -> None:
+    """BUG B (portal upload 500): the SA-fallback guard reads
+    `team_drive.service_account_available`, but the REAL TeamDriveService never
+    defines that attribute. The CI test mocked TeamDriveService and set the
+    attribute on the mock, so it stayed green while prod raised
+    AttributeError → aborted txn → 500 on every upload that hit the SA path.
+
+    Here we patch ONLY GoogleDriveService (to force the SA path) and let the
+    REAL TeamDriveService be constructed. The guard must degrade gracefully
+    (success=False, error set) instead of raising AttributeError.
+    """
+    service, _mock_conn = _make_service_with_fetchrow(row=None)
+
+    with patch(
+        "backend.services.integrations.google_drive_service.GoogleDriveService"
+    ) as drive_cls:
+        # Force the Service-Account fallback path.
+        drive_cls.return_value.is_configured.return_value = True
+        drive_cls.return_value.get_valid_token = AsyncMock(return_value=None)
+
+        # NOTE: TeamDriveService is intentionally NOT patched — we exercise the
+        # real class, which is what runs in production.
+        result = await service._upload_to_drive(
+            conn=AsyncMock(),
+            client_id=1,
+            client_name="Client One",
+            document_type="passport",
+            file_content=b"PDF",
+            file_name="passport.pdf",
+            mime_type="application/pdf",
+        )
+
+    # Must NOT raise; must degrade to the HANDLED "no auth" error, not leak an
+    # AttributeError string (which is what the bug produces when the guard
+    # blindly reads a non-existent attribute on the real TeamDriveService).
+    assert result["success"] is False
+    assert result["error"] == "No Drive authentication available"


### PR DESCRIPTION
## BUG B — client portal upload 500 on the Service-Account fallback path

Found by **live-browser E2E test** of the client portal upload (my.balizero.com) on 2026-06-22.

### Root cause
`_upload_to_drive` (documents.py:828) reads `team_drive.service_account_available`, but the real `TeamDriveService` **never defines that attribute** — the SA-fallback code predates the facade refactor. The `AttributeError` leaks into `result["error"]` and the aborted state surfaces as a **500** to the client on every upload that falls back to the Service Account path.

### Fix
Read the guard via `getattr(team_drive, "service_account_available", False)` → a missing attribute degrades to the existing `"No Drive authentication available"` branch. Upload degrades gracefully (doc still saved, `drive_uploaded=false`) instead of 500ing.

### Why CI was green while prod crashed
The existing tests **mocked** `TeamDriveService` and set `service_account_available` on the **mock** — testing the mock, not the code. Added `test_upload_to_drive_service_account_guard_uses_real_team_drive` (real class, RED before fix, GREEN after). Mixin suite 30/30 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)