### PR TITLE
fix(portal): dashboard 404 not 500 for soft-deleted linked client (BUG C)

### DIFF
--- a/apps/backend-rag/backend/app/routers/portal.py
+++ b/apps/backend-rag/backend/app/routers/portal.py
@@ -282,6 +282,16 @@ async def get_dashboard(
             "success": True,
             "data": data,
         }
+    except ValueError as e:
+        # BUG C: get_dashboard raises ValueError("Client X not found") when the
+        # linked client row is gone / soft-deleted (it filters
+        # `... WHERE id = $1 AND deleted_at IS NULL`). That's a not-found
+        # condition, not an internal error — surface 404 so a soft-deleted
+        # client's portal doesn't 500 the whole dashboard.
+        logger.warning(
+            f"Dashboard client not found for client {client['client_id']}: {e}"
+        )
+        raise HTTPException(status_code=404, detail="Client not found") from e
     except Exception as e:
         logger.error(f"Failed to get dashboard for client {client['client_id']}: {e}")
         raise HTTPException(

--- a/apps/backend-rag/backend/tests/unit/routers/test_portal.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_portal.py
@@ -101,11 +101,26 @@ class TestDashboard:
         assert "active_visa" in data["data"]
 
     def test_dashboard_service_error(self, client, mock_portal_service):
-        """Service exception returns 500."""
+        """Generic service exception returns 500."""
         mock_portal_service.get_dashboard.side_effect = Exception("DB down")
 
         response = client.get("/api/portal/dashboard")
         assert response.status_code == 500
+
+    def test_dashboard_client_not_found_returns_404_not_500(
+        self, client, mock_portal_service
+    ):
+        """BUG C: if the portal account is linked to a soft-deleted client,
+        get_dashboard raises ValueError('Client X not found'). That is a
+        not-found condition (the client row is gone / soft-deleted), NOT an
+        internal error — it must surface as 404, not a 500 that crashes the
+        whole dashboard."""
+        mock_portal_service.get_dashboard.side_effect = ValueError(
+            "Client 42 not found"
+        )
+
+        response = client.get("/api/portal/dashboard")
+        assert response.status_code == 404
 
 
 # ============================================


### PR DESCRIPTION
## BUG C — portal dashboard 500 when the linked client is soft-deleted

Found by live-browser E2E test on 2026-06-22.

### Root cause
`get_dashboard` does `SELECT ... FROM clients WHERE id = $1 AND deleted_at IS NULL` and raises `ValueError("Client X not found")` when the row is soft-deleted. The router caught every exception as a blanket **500**, so a portal account linked to a soft-deleted client crashes the whole dashboard.

### Fix
Catch `ValueError` separately and return **404 "Client not found"** — a missing/soft-deleted client is a not-found condition, not an internal error. The frontend already handles a failed dashboard fetch. Generic exceptions still return 500.

### Test
`test_dashboard_client_not_found_returns_404_not_500` (RED before fix, GREEN after). Full `test_portal.py` 33/33 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)