### PR TITLE
fix(portal): FASE5 soft-delete silently rolled back — invalid timeline event_type

### DIFF
--- a/apps/backend-rag/backend/services/portal/_mixins/documents.py
+++ b/apps/backend-rag/backend/services/portal/_mixins/documents.py
@@ -312,6 +312,14 @@ class PortalDocumentsMixin:
         """
         deleted_by = current_user.get("email") or f"client:{client_id}"
         async with self.pool.acquire() as conn:
+            # BUG D: the soft-delete UPDATE and the timeline INSERT used to live
+            # in the SAME transaction. The INSERT used event_type
+            # 'document_removed', which VIOLATES chk_timeline_event_type, so the
+            # constraint violation poisoned the transaction and rolled back the
+            # UPDATE deleted_at — yet the endpoint still returned 200 'deleted'.
+            # Two-part fix: (1) use a constraint-valid event_type
+            # ('status_change'); (2) commit the UPDATE in its OWN transaction so
+            # a timeline failure can never roll back the soft-delete.
             async with conn.transaction():
                 row = await conn.fetchrow(
                     """
@@ -330,22 +338,23 @@ class PortalDocumentsMixin:
                 if not row:
                     return None
 
-                try:
-                    await conn.execute(
-                        """
-                        INSERT INTO timeline_events (
-                            client_id, event_type, title,
-                            description, event_date, client_visible, color
-                        )
-                        VALUES ($1, 'document_removed', 'Document removed',
-                                $2, NOW(), true, 'warning')
-                        """,
-                        client_id,
-                        f"{row['file_name']} removed by client (recoverable for 30 days)",
+            # Timeline event is best-effort and OUTSIDE the delete transaction.
+            try:
+                await conn.execute(
+                    """
+                    INSERT INTO timeline_events (
+                        client_id, event_type, title,
+                        description, event_date, client_visible, color
                     )
-                except Exception as e:
-                    if not self._is_undefined_table_error(e):
-                        logger.warning("Could not create timeline event for soft-delete: %s", e)
+                    VALUES ($1, 'status_change', 'Document removed',
+                            $2, NOW(), true, 'warning')
+                    """,
+                    client_id,
+                    f"{row['file_name']} removed by client (recoverable for 30 days)",
+                )
+            except Exception as e:
+                if not self._is_undefined_table_error(e):
+                    logger.warning("Could not create timeline event for soft-delete: %s", e)
 
         logger.info(
             "🗑️ Document %s soft-deleted by %s (client %s)",
@@ -377,6 +386,9 @@ class PortalDocumentsMixin:
     ) -> dict[str, Any] | None:
         """Restore a previously soft-deleted document (recovery path)."""
         async with self.pool.acquire() as conn:
+            # BUG D (restore side): same two-part fix as soft_delete_document —
+            # constraint-valid event_type + timeline INSERT outside the restore
+            # transaction so it can never roll back the restore.
             async with conn.transaction():
                 row = await conn.fetchrow(
                     """
@@ -394,22 +406,23 @@ class PortalDocumentsMixin:
                 if not row:
                     return None
 
-                try:
-                    await conn.execute(
-                        """
-                        INSERT INTO timeline_events (
-                            client_id, event_type, title,
-                            description, event_date, client_visible, color
-                        )
-                        VALUES ($1, 'document_restored', 'Document restored',
-                                $2, NOW(), true, 'success')
-                        """,
-                        client_id,
-                        f"{row['file_name']} restored by client",
+            # Timeline event is best-effort and OUTSIDE the restore transaction.
+            try:
+                await conn.execute(
+                    """
+                    INSERT INTO timeline_events (
+                        client_id, event_type, title,
+                        description, event_date, client_visible, color
                     )
-                except Exception as e:
-                    if not self._is_undefined_table_error(e):
-                        logger.warning("Could not create timeline event for restore: %s", e)
+                    VALUES ($1, 'status_change', 'Document restored',
+                            $2, NOW(), true, 'success')
+                    """,
+                    client_id,
+                    f"{row['file_name']} restored by client",
+                )
+            except Exception as e:
+                if not self._is_undefined_table_error(e):
+                    logger.warning("Could not create timeline event for restore: %s", e)
 
         logger.info(
             "♻️ Document %s restored by %s (client %s)",

--- a/apps/backend-rag/backend/tests/unit/app/services/portal/test_documents_mixin.py
+++ b/apps/backend-rag/backend/tests/unit/app/services/portal/test_documents_mixin.py
@@ -284,9 +284,14 @@ async def test_soft_delete_document_marks_deleted_and_returns_summary() -> None:
     assert "deleted_at IS NULL" in update_sql  # idempotent: only live rows
     # actor + ids passed through
     assert mock_conn.fetchrow.call_args.args[1:] == (10, 1, "client@example.com")
-    # timeline event recorded
+    # timeline event recorded with a constraint-valid event_type (BUG D):
+    # 'document_removed' violated chk_timeline_event_type and silently rolled
+    # back the whole soft-delete. The human-facing title is unchanged.
     assert mock_conn.execute.await_count == 1
-    assert "document_removed" in mock_conn.execute.call_args.args[0]
+    insert_sql = mock_conn.execute.call_args.args[0]
+    assert "'status_change'" in insert_sql
+    assert "Document removed" in insert_sql
+    assert "document_removed" not in insert_sql
 
 
 @pytest.mark.asyncio
@@ -326,8 +331,14 @@ async def test_restore_document_clears_deleted_and_returns_summary() -> None:
     assert "deleted_at = NULL" in update_sql
     assert "deleted_at IS NOT NULL" in update_sql  # only restore actually-deleted rows
     assert mock_conn.fetchrow.call_args.args[1:] == (11, 1)
+    # timeline event recorded with a constraint-valid event_type (BUG D):
+    # 'document_restored' violated chk_timeline_event_type and silently rolled
+    # back the restore. The human-facing title is unchanged.
     assert mock_conn.execute.await_count == 1
-    assert "document_restored" in mock_conn.execute.call_args.args[0]
+    insert_sql = mock_conn.execute.call_args.args[0]
+    assert "'status_change'" in insert_sql
+    assert "Document restored" in insert_sql
+    assert "document_restored" not in insert_sql
 
 
 @pytest.mark.asyncio
@@ -801,4 +812,75 @@ async def test_upload_to_drive_oauth_success() -> None:
     assert drive_service.upload_file_to_folder.call_args.kwargs["folder_id"] == "type_folder"
     assert drive_service.upload_file_to_folder.call_args.kwargs["file_name"].endswith(
         "_passport.pdf"
+    )
+
+
+# Valid timeline_events.event_type values, per chk_timeline_event_type in prod.
+_VALID_TIMELINE_EVENT_TYPES = {
+    "deadline",
+    "milestone",
+    "document_request",
+    "document_received",
+    "status_change",
+    "payment_due",
+    "appointment",
+    "reminder",
+    "completion",
+}
+
+
+def _timeline_event_type_from_execute(mock_conn: AsyncMock) -> str:
+    """Pull the event_type literal out of the timeline INSERT the mixin ran."""
+    for call in mock_conn.execute.await_args_list:
+        sql = call.args[0]
+        if "INSERT INTO timeline_events" in sql:
+            # event_type is the literal in the VALUES (...) clause.
+            for et in _VALID_TIMELINE_EVENT_TYPES | {"document_removed", "document_restored"}:
+                if f"'{et}'" in sql:
+                    return et
+    raise AssertionError("no timeline_events INSERT was issued")
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_timeline_event_type_is_constraint_valid() -> None:
+    """BUG D: soft_delete_document inserted a timeline event with
+    event_type='document_removed', which VIOLATES chk_timeline_event_type
+    (allowed set above). In prod that violation poisoned the same transaction
+    as the UPDATE deleted_at, so the soft-delete was rolled back while the
+    endpoint still returned 200 'deleted'. The event_type must be one the
+    constraint accepts."""
+    service, mock_conn = _make_service_with_fetchrow(
+        {"id": 10, "file_name": "passport.pdf", "document_type": "passport"}
+    )
+
+    await service.soft_delete_document(
+        client_id=1,
+        document_id=10,
+        current_user={"client_id": 1, "email": "client@example.com"},
+    )
+
+    event_type = _timeline_event_type_from_execute(mock_conn)
+    assert event_type in _VALID_TIMELINE_EVENT_TYPES, (
+        f"timeline event_type {event_type!r} is not in chk_timeline_event_type"
+    )
+
+
+@pytest.mark.asyncio
+async def test_restore_timeline_event_type_is_constraint_valid() -> None:
+    """BUG D (restore side): same as above for restore_document, which used
+    event_type='document_restored' (also invalid)."""
+    service, mock_conn = _make_service_with_fetchrow(
+        {"id": 10, "file_name": "passport.pdf", "document_type": "passport"}
+    )
+
+    await service.restore_document.__wrapped__.__wrapped__(
+        service,
+        client_id=1,
+        document_id=10,
+        current_user={"client_id": 1, "email": "client@example.com"},
+    )
+
+    event_type = _timeline_event_type_from_execute(mock_conn)
+    assert event_type in _VALID_TIMELINE_EVENT_TYPES, (
+        f"timeline event_type {event_type!r} is not in chk_timeline_event_type"
     )


### PR DESCRIPTION
## Bug (found via live-browser E2E on my.balizero.com)

Soft-deleting a portal document returned `200 {deleted: true}` but the
document **stayed visible** — `deleted_at` was never persisted. Same defect
on the symmetric restore path.

## Root cause

`soft_delete_document` / `restore_document` wrote the audit `timeline_events`
row **inside the same asyncpg transaction** as the `UPDATE documents ... SET
deleted_at`, using `event_type = 'document_removed'` / `'document_restored'`.

Neither value is allowed by the DB constraint:

```
chk_timeline_event_type ∈ {deadline, milestone, document_request,
document_received, status_change, payment_due, appointment, reminder,
completion}
```

So the INSERT raised a `CheckViolation` that **poisoned the transaction and
rolled back the UPDATE** — while the handler still returned success from the
in-memory `RETURNING` row. Classic superscar #9 (state-schema/contract drift)
× silent-rollback.

CI never caught it: the existing unit tests mock the asyncpg connection, so
the constraint never actually executes.

## Fix (two parts)

1. **Constraint-valid `event_type`** → `'status_change'`. The human-facing
   `title` (`Document removed` / `Document restored`), description and color
   are unchanged, so the client timeline UI is identical.
2. **Move the best-effort timeline INSERT OUTSIDE the delete/restore
   transaction** so a future timeline failure can never roll back the actual
   soft-delete/restore again (defense-in-depth).

## Tests

- 2 new TDD tests assert the emitted `event_type` is constraint-valid for both
  soft-delete and restore.
- The 2 pre-existing tests now assert `'status_change'` + the preserved title
  (they previously asserted the buggy literal).
- Full portal-services unit suite green: **102 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)