### PR TITLE
fix(ui): fab-zantara collapses to lopsided pill on mobile

### DIFF
--- a/apps/mouth/src/app/v2/_components/ZantaraFAB.tsx
+++ b/apps/mouth/src/app/v2/_components/ZantaraFAB.tsx
@@ -6,7 +6,7 @@ export function ZantaraFAB() {
   return (
     <button
       aria-label="Ask Zantara, your AI assistant"
-      className="fab-zantara fixed z-[50] flex items-center gap-3 rounded-full transition-all hover:-translate-y-1 hover:scale-[1.03] group"
+      className="fab-zantara fixed z-[50] flex items-center gap-3 rounded-full transition-all hover:-translate-y-1 hover:scale-[1.03] group p-[10px] sm:pr-[20px]"
       style={{
         background: "linear-gradient(135deg, #a78bfa 0%, #6d28d9 100%)",
         boxShadow:
@@ -14,7 +14,6 @@ export function ZantaraFAB() {
         border: "1px solid rgba(255,255,255,0.18)",
         bottom: 24,
         right: 24,
-        padding: "10px 20px 10px 10px",
       }}
     >
       {/* Lotus disc */}


### PR DESCRIPTION
## Insight
`ZantaraFAB` hardcodes asymmetric padding (`10px 20px 10px 10px`) intended for the desktop label state. The label (`fab-label`) is hidden below the `sm` breakpoint via `hidden sm:flex`, but the padding never adjusts — on mobile the button renders as a 70×60 lopsided pill with ~20px of dead gradient space to the right of the icon instead of a clean 60×60 circle.

## Studio
- `apps/mouth/src/app/v2/_components/ZantaraFAB.tsx` — removed hardcoded `padding` from inline style, added `p-[10px] sm:pr-[20px]` to className

## Source
Code inspection of `ZantaraFAB.tsx` against the backlog item "ZantaraFAB mobile collapse — z-[500] overlap on mobile 390px." Cross-checked for a z-index collision (`grep` for `z-[500]`, `zIndex`, fixed-position siblings) — none found. The only nearby fixed-position component (`MobileNav`) is a left-side drawer that only renders when the hamburger is tapped, not a persistent overlap.

## Methodology
Read-only inspection (`cat -n`, `grep`) before editing. Confirmed no z-index conflict exists in the codebase under the literal value cited in the backlog. Identified the padding/breakpoint mismatch as the actual visible defect matching the "collapse" wording in the title.

## Raw Observations
- `z-[500]` does not exist anywhere in `apps/mouth/src` (grep, zero matches)
- Nearest fixed-position z-index values found: `MobileNav.tsx` backdrop at 398 and drawer panel at 399 — both conditional on the hamburger menu being open, not persistent
- FAB padding was inline-style, which cannot respond to breakpoints; Tailwind classes can

## Reasoning Path
The backlog title's "z-[500]" detail didn't match any code in the repo. Rather than guess at the wrong fix, traced the actual mobile rendering of the FAB directly and found a layout-breaking padding asymmetry that only manifests once the label hides at the `sm:` breakpoint — consistent with "collapse" in the title, and independently verifiable without the original screenshot.

## Risk
Low. Purely visual/CSS change, single component, no analytics or business logic touched.

## Implication
FAB renders as a clean 60×60 circle on mobile instead of a 70×60 lopsided pill. Desktop appearance with the label is unchanged — the `sm:pr-[20px]` override preserves the original look exactly.

## Recommendation
Merge as-is. If the original "z-[500] overlap" report had different specifics (e.g. a screenshot showing collision with another element), flag separately — this PR addresses a real, independently-verified defect but may not be the exact same issue originally reported.

## Next Action
Self-merge once CI is green — `apps/mouth`-only change, no `packages/core`, no Antonello review required per VERDE rules.
