### PR TITLE
fix(portal): soft-delete silently rolled back — valid event_type + decoupled audit [Bug D]

### DIFF
--- a/apps/backend-rag/backend/services/portal/_mixins/documents.py
+++ b/apps/backend-rag/backend/services/portal/_mixins/documents.py
@@ -289,6 +289,41 @@ class PortalDocumentsMixin:
             "mime_type": mime_type,
         }
 
+    async def _record_timeline_event(
+        self,
+        client_id: int,
+        *,
+        title: str,
+        description: str,
+        color: str,
+    ) -> None:
+        """Best-effort audit log on a SEPARATE connection (Bug D).
+
+        Written AFTER the mutating transaction has committed, on its own
+        connection, so a failure here can never roll back the caller's mutation.
+        event_type is 'status_change' — a value allowed by the
+        chk_timeline_event_type CHECK constraint (document_removed /
+        document_restored are NOT allowed and previously aborted the txn).
+        """
+        try:
+            async with self.pool.acquire() as conn:
+                await conn.execute(
+                    """
+                    INSERT INTO timeline_events (
+                        client_id, event_type, title,
+                        description, event_date, client_visible, color
+                    )
+                    VALUES ($1, 'status_change', $2, $3, NOW(), true, $4)
+                    """,
+                    client_id,
+                    title,
+                    description,
+                    color,
+                )
+        except Exception as e:
+            if not self._is_undefined_table_error(e):
+                logger.warning("Could not create timeline event (%s): %s", title, e)
+
     @cache_invalidating(
         [
             lambda _self, client_id, *_a, **_k: f"zantara:portal_documents:{client_id}:*",
@@ -311,6 +346,12 @@ class PortalDocumentsMixin:
         timeline event records the action for the case officer.
         """
         deleted_by = current_user.get("email") or f"client:{client_id}"
+        # The soft-delete UPDATE commits ON ITS OWN. The timeline INSERT is a
+        # best-effort audit log written on a SEPARATE connection AFTER the commit,
+        # so it can NEVER roll back the deletion. (Bug D: it used to share the same
+        # transaction AND used event_type='document_removed', which violates the
+        # chk_timeline_event_type CHECK constraint — the violation aborted the txn
+        # and silently rolled the UPDATE back while returning 200 "deleted: true".)
         async with self.pool.acquire() as conn:
             async with conn.transaction():
                 row = await conn.fetchrow(
@@ -330,22 +371,13 @@ class PortalDocumentsMixin:
                 if not row:
                     return None
 
-                try:
-                    await conn.execute(
-                        """
-                        INSERT INTO timeline_events (
-                            client_id, event_type, title,
-                            description, event_date, client_visible, color
-                        )
-                        VALUES ($1, 'document_removed', 'Document removed',
-                                $2, NOW(), true, 'warning')
-                        """,
-                        client_id,
-                        f"{row['file_name']} removed by client (recoverable for 30 days)",
-                    )
-                except Exception as e:
-                    if not self._is_undefined_table_error(e):
-                        logger.warning("Could not create timeline event for soft-delete: %s", e)
+        # Audit log — separate connection, after the delete has committed.
+        await self._record_timeline_event(
+            client_id,
+            title="Document removed",
+            description=f"{row['file_name']} removed by client (recoverable for 30 days)",
+            color="warning",
+        )
 
         logger.info(
             "🗑️ Document %s soft-deleted by %s (client %s)",
@@ -394,22 +426,13 @@ class PortalDocumentsMixin:
                 if not row:
                     return None
 
-                try:
-                    await conn.execute(
-                        """
-                        INSERT INTO timeline_events (
-                            client_id, event_type, title,
-                            description, event_date, client_visible, color
-                        )
-                        VALUES ($1, 'document_restored', 'Document restored',
-                                $2, NOW(), true, 'success')
-                        """,
-                        client_id,
-                        f"{row['file_name']} restored by client",
-                    )
-                except Exception as e:
-                    if not self._is_undefined_table_error(e):
-                        logger.warning("Could not create timeline event for restore: %s", e)
+        # Audit log — separate connection, after the restore has committed (Bug D).
+        await self._record_timeline_event(
+            client_id,
+            title="Document restored",
+            description=f"{row['file_name']} restored by client",
+            color="success",
+        )
 
         logger.info(
             "♻️ Document %s restored by %s (client %s)",

--- a/apps/backend-rag/backend/tests/unit/app/services/portal/test_documents_mixin.py
+++ b/apps/backend-rag/backend/tests/unit/app/services/portal/test_documents_mixin.py
@@ -284,9 +284,11 @@ async def test_soft_delete_document_marks_deleted_and_returns_summary() -> None:
     assert "deleted_at IS NULL" in update_sql  # idempotent: only live rows
     # actor + ids passed through
     assert mock_conn.fetchrow.call_args.args[1:] == (10, 1, "client@example.com")
-    # timeline event recorded
+    # timeline event recorded with a CONSTRAINT-VALID event_type (Bug D).
+    # 'document_removed' violates chk_timeline_event_type; must be 'status_change'.
     assert mock_conn.execute.await_count == 1
-    assert "document_removed" in mock_conn.execute.call_args.args[0]
+    assert "'status_change'" in mock_conn.execute.call_args.args[0]
+    assert "document_removed" not in mock_conn.execute.call_args.args[0]
 
 
 @pytest.mark.asyncio
@@ -327,7 +329,9 @@ async def test_restore_document_clears_deleted_and_returns_summary() -> None:
     assert "deleted_at IS NOT NULL" in update_sql  # only restore actually-deleted rows
     assert mock_conn.fetchrow.call_args.args[1:] == (11, 1)
     assert mock_conn.execute.await_count == 1
-    assert "document_restored" in mock_conn.execute.call_args.args[0]
+    # Bug D: 'document_restored' violates chk_timeline_event_type; must be 'status_change'.
+    assert "'status_change'" in mock_conn.execute.call_args.args[0]
+    assert "document_restored" not in mock_conn.execute.call_args.args[0]
 
 
 @pytest.mark.asyncio
@@ -894,3 +898,89 @@ async def test_upload_to_drive_no_auth_does_not_raise_attribute_error() -> None:
     assert result["file_id"] is None
     assert result["file_url"] is None
 
+
+# ---------------------------------------------------------------------------
+# Bug D — soft-delete must NOT share a transaction with the timeline INSERT, and
+# the timeline event_type must be a value allowed by chk_timeline_event_type.
+# Previously soft_delete_document INSERTed event_type='document_removed' inside the
+# SAME conn.transaction() as the UPDATE; the CHECK violation aborted the txn and
+# silently rolled the soft-delete back while returning 200 "deleted: true".
+# ---------------------------------------------------------------------------
+
+
+def _make_two_conn_service(row: dict[str, Any] | None):
+    """Service whose pool hands out a DISTINCT conn on each acquire(), so we can
+    assert the UPDATE and the timeline INSERT run on SEPARATE connections."""
+    update_conn = AsyncMock()
+    update_conn.fetchrow.return_value = row
+    update_conn.transaction = MagicMock(return_value=_AsyncCtx())
+
+    audit_conn = AsyncMock()
+    audit_conn.transaction = MagicMock(return_value=_AsyncCtx())
+
+    conns = iter([update_conn, audit_conn])
+
+    def _acquire(*_a: object, **_k: object):
+        ctx = MagicMock()
+        chosen = next(conns)
+        ctx.__aenter__ = AsyncMock(return_value=chosen)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        return ctx
+
+    mock_pool = MagicMock()
+    mock_pool.acquire.side_effect = _acquire
+    return PortalService(mock_pool), update_conn, audit_conn
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_uses_valid_event_type_on_separate_conn() -> None:
+    row = {"id": 7, "file_name": "akta.pdf", "document_type": "company"}
+    service, update_conn, audit_conn = _make_two_conn_service(row)
+
+    result = await service.soft_delete_document(
+        client_id=1, document_id=7, current_user={"client_id": 1, "email": "c@x.com"}
+    )
+
+    assert result is not None and result["deleted"] is True
+    # The UPDATE ran inside a transaction on the first connection.
+    update_conn.transaction.assert_called_once()
+    # The timeline INSERT ran on a DIFFERENT connection (audit_conn) and was NOT
+    # wrapped in update_conn's transaction — so it can never roll back the delete.
+    audit_conn.execute.assert_awaited_once()
+    sql = audit_conn.execute.call_args.args[0]
+    assert "'status_change'" in sql, "timeline event_type must be the allowed value"
+    assert "document_removed" not in sql, "must not use the constraint-violating value"
+    # The delete connection must NOT have run the timeline INSERT.
+    for call in update_conn.execute.await_args_list:
+        assert "timeline_events" not in (call.args[0] if call.args else "")
+
+
+@pytest.mark.asyncio
+async def test_restore_uses_valid_event_type_on_separate_conn() -> None:
+    row = {"id": 7, "file_name": "akta.pdf", "document_type": "company"}
+    service, update_conn, audit_conn = _make_two_conn_service(row)
+
+    result = await service.restore_document(
+        client_id=1, document_id=7, current_user={"client_id": 1, "email": "c@x.com"}
+    )
+
+    assert result is not None and result["deleted"] is False
+    audit_conn.execute.assert_awaited_once()
+    sql = audit_conn.execute.call_args.args[0]
+    assert "'status_change'" in sql
+    assert "document_restored" not in sql
+
+
+@pytest.mark.asyncio
+async def test_timeline_failure_does_not_break_soft_delete() -> None:
+    """If the audit-log INSERT fails, the soft-delete result still succeeds —
+    proving the audit log can no longer roll back the mutation."""
+    row = {"id": 7, "file_name": "akta.pdf", "document_type": "company"}
+    service, _update_conn, audit_conn = _make_two_conn_service(row)
+    audit_conn.execute.side_effect = RuntimeError("timeline boom")
+
+    result = await service.soft_delete_document(
+        client_id=1, document_id=7, current_user={"client_id": 1, "email": "c@x.com"}
+    )
+
+    assert result is not None and result["deleted"] is True


### PR DESCRIPTION
## Bug D — FASE5 document soft-delete silently rolls back

Returned 200 "deleted: true" but did NOT persist; restore then 404'd (`finding_portal_e2e_6_bugs`).

**Root cause (verified against the real nuzantara_dev DB this session):** `chk_timeline_event_type` allows only `{deadline, milestone, document_request, document_received, status_change, payment_due, appointment, reminder, completion}`. `soft_delete_document`/`restore_document` INSERTed `event_type='document_removed'`/`'document_restored'` (NOT allowed) **inside the same `conn.transaction()` as the UPDATE** → CHECK violation aborted the txn → the UPDATE was rolled back. The try/except caught the Python error but could not rescue the aborted Postgres transaction.

## Fix
- New `_record_timeline_event()`: `event_type='status_change'` (constraint-valid), on its **own** pool connection, **after** the mutating transaction commits → a timeline failure can never roll back the delete/restore.

## Verification (independent)
- ✅ **32/32** mixin tests — 3 new (valid event_type, separate connection, timeline-failure-doesn't-break-delete) + 2 pre-existing corrected (they had *encoded* the buggy values).
- ✅ ruff clean, FastAPI import-chain OK, anti-reward-hacking lint clean.

> Supersedes #1652. The GUI agent's "no bug" claim tested the WRONG function (crm `delete_client`) against a DB lacking `documents.deleted_at` — a false negative caught by independent verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)