### PR TITLE
feat(llm): add MLXProvider — local Apple Silicon LLM via OpenAI-compatible server

### DIFF
--- a/apps/backend-rag/backend/llm/provider_registry.py
+++ b/apps/backend-rag/backend/llm/provider_registry.py
@@ -77,6 +77,13 @@ def _register_builtin_providers():
     except ImportError:
         pass
 
+    try:
+        from backend.llm.providers.mlx import MLXProvider
+
+        register_provider("mlx", MLXProvider)
+    except ImportError:
+        pass
+
 
 # Auto-register built-in providers on module import
 _register_builtin_providers()

--- a/apps/backend-rag/backend/llm/providers/__init__.py
+++ b/apps/backend-rag/backend/llm/providers/__init__.py
@@ -6,11 +6,13 @@ Used by RAGAS evaluation and integration tests.
 """
 
 from backend.llm.providers.gemini import GeminiProvider
+from backend.llm.providers.mlx import MLXProvider
 from backend.llm.providers.ollama import OllamaProvider
 from backend.llm.providers.openrouter import OpenRouterProvider
 
 __all__ = [
     "GeminiProvider",
+    "MLXProvider",
     "OllamaProvider",
     "OpenRouterProvider",
 ]

--- a/apps/backend-rag/backend/llm/providers/mlx.py
+++ b/apps/backend-rag/backend/llm/providers/mlx.py
@@ -1,0 +1,213 @@
+"""
+MLX LLM Provider
+
+Local LLM provider for Apple Silicon via the MLX server's OpenAI-compatible
+endpoint (`mlx_lm.server`, default http://localhost:8080/v1).
+
+Unlike OllamaProvider (which speaks Ollama's native /api/generate), MLX exposes
+the OpenAI Chat Completions contract, so this adapter sends a `messages` array to
+`/v1/chat/completions` and reads `choices[].message.content` + `usage`.
+
+Drop-in for the same `LLMProvider` interface (base.py): same `generate`/`stream`
+signatures, same `LLMResponse` fields (`content`/`model`/`tokens_used`/
+`finish_reason`/`provider`). Registered as "mlx" in provider_registry when MLX is
+enabled. POC / hardening role: a third local failure-domain beside ollama_pro /
+ollama_mini — see MODEL_TOPOLOGY.json.
+"""
+
+import json
+import logging
+from collections.abc import AsyncIterator
+
+import httpx
+
+from backend.llm.base import LLMMessage, LLMProvider, LLMResponse
+
+logger = logging.getLogger(__name__)
+
+
+class MLXProvider(LLMProvider):
+    """
+    LLMProvider adapter for an MLX OpenAI-compatible server (Apple Silicon, local).
+
+    Usage:
+        provider = MLXProvider(model="mlx-community/Qwen3-8B-4bit")
+        response = await provider.generate([LLMMessage(role="user", content="Hi")])
+    """
+
+    def __init__(
+        self,
+        model: str = "mlx-community/Qwen3-8B-4bit",
+        base_url: str = "http://localhost:8080",
+    ) -> None:
+        """
+        Initialize MLX provider.
+
+        Args:
+            model: MLX model name served by mlx_lm.server (loaded server-side).
+            base_url: MLX server base URL (default http://localhost:8080). The
+                `/v1` suffix is appended internally — pass the bare host:port.
+        """
+        self._model = model
+        self._base_url = base_url.rstrip("/")
+        # mlx_lm.server is OpenAI-compatible: chat lives under /v1/chat/completions.
+        # Tolerate a base_url that already includes /v1 so callers can pass either.
+        suffix = "" if self._base_url.endswith("/v1") else "/v1"
+        self._chat_url = f"{self._base_url}{suffix}/chat/completions"
+        self._available = False
+        self._async_client: httpx.AsyncClient | None = None  # init before _init_client
+        self._init_client()
+
+    def _init_client(self) -> None:
+        """Mark provider available; actual connectivity checked on first use."""
+        self._available = True
+        logger.info(
+            "MLXProvider initialized: model=%s url=%s (connectivity verified on first request)",
+            self._model,
+            self._chat_url,
+        )
+
+    @property
+    def name(self) -> str:
+        return "mlx"
+
+    @property
+    def is_available(self) -> bool:
+        return self._available
+
+    async def _get_async_client(self) -> httpx.AsyncClient:
+        """Get or create persistent async HTTP client (Golden Rule #10)."""
+        if self._async_client is None or self._async_client.is_closed:
+            self._async_client = httpx.AsyncClient(timeout=120.0)
+        return self._async_client
+
+    async def aclose(self) -> None:
+        """Close the persistent HTTP client."""
+        if self._async_client and not self._async_client.is_closed:
+            await self._async_client.aclose()
+            self._async_client = None
+
+    @staticmethod
+    def _to_openai_messages(messages: list[LLMMessage]) -> list[dict[str, str]]:
+        """Map internal LLMMessage list to the OpenAI `messages` array."""
+        return [{"role": m.role, "content": m.content} for m in messages]
+
+    @staticmethod
+    def _chat_template_kwargs(kwargs: dict) -> dict:
+        """
+        Build the MLX `chat_template_kwargs` block.
+
+        Default `enable_thinking=False`: Qwen3 served by mlx_lm.server otherwise
+        runs its reasoning mode on trivial agentic calls and returns a `reasoning`
+        field with NO `content` (finish_reason="length") — i.e. an empty answer.
+        Verified live 2026-06-20 against mlx_lm.server 0.31.3 on M5. Callers that
+        explicitly want reasoning can pass `enable_thinking=True`.
+        """
+        enable_thinking = bool(kwargs.pop("enable_thinking", False))
+        return {"enable_thinking": enable_thinking}
+
+    async def generate(
+        self,
+        messages: list[LLMMessage],
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+        **kwargs,
+    ) -> LLMResponse:
+        """Generate a response via MLX /v1/chat/completions (non-streaming)."""
+        if not self.is_available:
+            raise RuntimeError("MLX provider not available")
+
+        # `think` is an Ollama-native option with no OpenAI equivalent — drop it
+        # rather than forward an unsupported field to the MLX server.
+        kwargs.pop("think", None)
+
+        payload: dict[str, object] = {
+            "model": self._model,
+            "messages": self._to_openai_messages(messages),
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "stream": False,
+            "chat_template_kwargs": self._chat_template_kwargs(kwargs),
+        }
+
+        try:
+            client = await self._get_async_client()
+            response = await client.post(self._chat_url, json=payload)
+
+            if response.status_code != 200:
+                raise RuntimeError(f"MLX API error: {response.status_code}")
+
+            data = response.json()
+            choices = data.get("choices") or [{}]
+            message = choices[0].get("message") or {}
+            content = (message.get("content") or "").strip()
+            usage = data.get("usage") or {}
+
+            return LLMResponse(
+                content=content,
+                model=data.get("model", self._model),
+                tokens_used=usage.get("total_tokens"),
+                finish_reason=choices[0].get("finish_reason"),
+                provider=self.name,
+            )
+
+        except httpx.TimeoutException as exc:
+            raise RuntimeError("MLX request timeout") from exc
+        except httpx.ConnectError as exc:
+            # MLX server not running locally — explicit, distinct from a 5xx.
+            raise RuntimeError(f"MLX connection failed: {self._chat_url}") from exc
+        except Exception as exc:
+            logger.error("MLX generation error: %s", exc)
+            raise RuntimeError(f"MLX generation failed: {exc}") from exc
+
+    async def stream(
+        self,
+        messages: list[LLMMessage],
+        temperature: float = 0.7,
+        **kwargs,
+    ) -> AsyncIterator[str]:
+        """Stream a response via MLX /v1/chat/completions (SSE delta chunks)."""
+        if not self.is_available:
+            raise RuntimeError("MLX provider not available")
+
+        kwargs.pop("think", None)
+
+        payload: dict[str, object] = {
+            "model": self._model,
+            "messages": self._to_openai_messages(messages),
+            "temperature": temperature,
+            "stream": True,
+            "chat_template_kwargs": self._chat_template_kwargs(kwargs),
+        }
+
+        try:
+            client = await self._get_async_client()
+            async with client.stream("POST", self._chat_url, json=payload) as response:
+                if response.status_code != 200:
+                    raise RuntimeError(f"MLX API error: {response.status_code}")
+
+                async for line in response.aiter_lines():
+                    if not line:
+                        continue
+                    # OpenAI SSE framing: "data: {json}" lines, ending with "[DONE]".
+                    if line.startswith("data:"):
+                        line = line[len("data:") :].strip()
+                    if not line or line == "[DONE]":
+                        if line == "[DONE]":
+                            break
+                        continue
+                    try:
+                        data = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    choices = data.get("choices") or [{}]
+                    delta = choices[0].get("delta") or {}
+                    chunk = delta.get("content")
+                    if chunk:
+                        yield chunk
+
+        except (httpx.TimeoutException, httpx.ConnectError) as exc:
+            raise RuntimeError(f"MLX streaming connection error: {exc}") from exc
+        except Exception as exc:
+            logger.error("MLX streaming error: %s", exc)
+            raise RuntimeError(f"MLX streaming failed: {exc}") from exc

--- a/apps/backend-rag/backend/tests/unit/llm/providers/test_mlx.py
+++ b/apps/backend-rag/backend/tests/unit/llm/providers/test_mlx.py
@@ -1,0 +1,220 @@
+"""
+Unit tests for MLXProvider (OpenAI-compatible MLX server adapter).
+
+Exercises generate() / stream() against a mocked httpx client (no live MLX
+server needed), plus registry registration and the OpenAI-contract mapping that
+ollama.py does NOT cover (choices[].message.content + usage.total_tokens).
+"""
+
+import sys
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+backend_path = Path(__file__).parent.parent.parent.parent.parent.parent / "backend"
+if str(backend_path) not in sys.path:
+    sys.path.insert(0, str(backend_path))
+
+from backend.llm.base import LLMMessage, LLMResponse
+from backend.llm.providers.mlx import MLXProvider
+
+
+@pytest.fixture
+def mlx_provider():
+    """MLXProvider with default model/url (connectivity deferred to first call)."""
+    provider = MLXProvider(model="mlx-community/Qwen3-8B-4bit")
+    provider._async_client = None
+    return provider
+
+
+class TestMLXProviderInit:
+    def test_init_defaults(self):
+        provider = MLXProvider()
+        assert provider.name == "mlx"
+        assert provider._base_url == "http://localhost:8080"
+        # /v1 is appended internally, chat endpoint resolved.
+        assert provider._chat_url == "http://localhost:8080/v1/chat/completions"
+        assert provider.is_available is True
+
+    def test_init_custom_url_without_v1(self):
+        provider = MLXProvider(base_url="http://mini:8080")
+        assert provider._chat_url == "http://mini:8080/v1/chat/completions"
+
+    def test_init_url_already_has_v1_is_not_doubled(self):
+        # Tolerate callers that pass the /v1 suffix already.
+        provider = MLXProvider(base_url="http://localhost:8080/v1")
+        assert provider._chat_url == "http://localhost:8080/v1/chat/completions"
+
+    def test_init_trailing_slash_stripped(self):
+        provider = MLXProvider(base_url="http://localhost:8080/")
+        assert provider._chat_url == "http://localhost:8080/v1/chat/completions"
+
+
+class TestMLXProviderGenerate:
+    @pytest.mark.asyncio
+    async def test_generate_maps_openai_response_to_llmresponse(self, mlx_provider):
+        """content from choices[0].message.content, tokens from usage.total_tokens."""
+        mock_data = {
+            "model": "mlx-community/Qwen3-8B-4bit",
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "  Hello from MLX  "},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = mock_data
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mlx_provider._get_async_client = AsyncMock(return_value=mock_client)
+
+        resp = await mlx_provider.generate([LLMMessage(role="user", content="hi")])
+
+        assert isinstance(resp, LLMResponse)
+        assert resp.content == "Hello from MLX"  # stripped
+        assert resp.model == "mlx-community/Qwen3-8B-4bit"
+        assert resp.tokens_used == 15
+        assert resp.finish_reason == "stop"
+        assert resp.provider == "mlx"
+
+    @pytest.mark.asyncio
+    async def test_generate_sends_openai_messages_array(self, mlx_provider):
+        """The request body must use the OpenAI `messages` array, not a flat prompt."""
+        captured = {}
+
+        async def fake_post(url, json):
+            captured["url"] = url
+            captured["json"] = json
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"choices": [{"message": {"content": "ok"}}]}
+            return mock_response
+
+        mock_client = AsyncMock()
+        mock_client.post = fake_post
+        mlx_provider._get_async_client = AsyncMock(return_value=mock_client)
+
+        await mlx_provider.generate(
+            [
+                LLMMessage(role="system", content="be brief"),
+                LLMMessage(role="user", content="hi"),
+            ]
+        )
+
+        assert captured["url"].endswith("/v1/chat/completions")
+        assert captured["json"]["messages"] == [
+            {"role": "system", "content": "be brief"},
+            {"role": "user", "content": "hi"},
+        ]
+        assert captured["json"]["stream"] is False
+        # Qwen3 reasoning-mode suppressed by default (verified live 2026-06-20).
+        assert captured["json"]["chat_template_kwargs"] == {"enable_thinking": False}
+
+    @pytest.mark.asyncio
+    async def test_generate_enable_thinking_opt_in(self, mlx_provider):
+        """Callers can re-enable reasoning explicitly."""
+        captured = {}
+
+        async def fake_post(url, json):
+            captured["json"] = json
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"choices": [{"message": {"content": "ok"}}]}
+            return mock_response
+
+        mock_client = AsyncMock()
+        mock_client.post = fake_post
+        mlx_provider._get_async_client = AsyncMock(return_value=mock_client)
+
+        await mlx_provider.generate(
+            [LLMMessage(role="user", content="hi")], enable_thinking=True
+        )
+
+        assert captured["json"]["chat_template_kwargs"] == {"enable_thinking": True}
+
+    @pytest.mark.asyncio
+    async def test_generate_drops_ollama_think_kwarg(self, mlx_provider):
+        """`think` is Ollama-native; MLX/OpenAI must never receive it."""
+        captured = {}
+
+        async def fake_post(url, json):
+            captured["json"] = json
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"choices": [{"message": {"content": "ok"}}]}
+            return mock_response
+
+        mock_client = AsyncMock()
+        mock_client.post = fake_post
+        mlx_provider._get_async_client = AsyncMock(return_value=mock_client)
+
+        await mlx_provider.generate([LLMMessage(role="user", content="hi")], think=False)
+
+        assert "think" not in captured["json"]
+
+    @pytest.mark.asyncio
+    async def test_generate_unavailable_raises(self):
+        provider = MLXProvider()
+        provider._available = False
+        with pytest.raises(RuntimeError, match="not available"):
+            await provider.generate([LLMMessage(role="user", content="x")])
+
+    @pytest.mark.asyncio
+    async def test_generate_non_200_raises(self, mlx_provider):
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mlx_provider._get_async_client = AsyncMock(return_value=mock_client)
+
+        with pytest.raises(RuntimeError, match="MLX API error: 503"):
+            await mlx_provider.generate([LLMMessage(role="user", content="x")])
+
+
+class TestMLXProviderStream:
+    @pytest.mark.asyncio
+    async def test_stream_yields_openai_deltas(self, mlx_provider):
+        """Stream parses OpenAI SSE `data: {...}` delta frames, ends on [DONE]."""
+        lines = [
+            'data: {"choices":[{"delta":{"content":"Hel"}}]}',
+            'data: {"choices":[{"delta":{"content":"lo"}}]}',
+            "",  # keep-alive blank line ignored
+            'data: {"choices":[{"delta":{}}]}',  # empty delta ignored
+            "data: [DONE]",
+        ]
+
+        async def mock_aiter_lines():
+            for line in lines:
+                yield line
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.aiter_lines = mock_aiter_lines
+
+        @asynccontextmanager
+        async def mock_stream_ctx(*args, **kwargs):
+            yield mock_response
+
+        mock_client = MagicMock()
+        mock_client.stream = mock_stream_ctx
+        mlx_provider._get_async_client = AsyncMock(return_value=mock_client)
+
+        chunks = [c async for c in mlx_provider.stream([LLMMessage(role="user", content="x")])]
+
+        assert chunks == ["Hel", "lo"]
+        assert all(isinstance(c, str) for c in chunks)
+
+
+class TestMLXRegistry:
+    def test_mlx_registered_in_provider_registry(self):
+        from backend.llm.provider_registry import get_provider, list_providers
+
+        assert "mlx" in list_providers()
+        provider = get_provider("mlx", model="mlx-community/Qwen3-8B-4bit")
+        assert provider is not None
+        assert provider.name == "mlx"


### PR DESCRIPTION
## What
Adds `MLXProvider` — a local LLM provider for Apple Silicon (M-series) that talks to an MLX OpenAI-compatible server (`mlx_lm.server`). Wires it into `provider_registry.py`.

## Why
Recovers a feature-complete change that was built but never promoted (it sat in a suspended worktree). Gives the backend a $0, sovereign, local LLM path on the M5/Pro/Mini fleet (`~/mlx-env` Qwen3-8B-4bit) — aligned with the free-first / local-sovereignty rule (Law 6).

## Files (442 lines, all new — zero drift on main)
- `backend/llm/providers/mlx.py` (213) — the provider
- `backend/tests/unit/llm/providers/test_mlx.py` (220) — unit tests
- `backend/llm/provider_registry.py` (+7), `backend/llm/providers/__init__.py` (+2) — registration

## Tests
`pytest backend/tests/unit/llm/providers/test_mlx.py` → **12 passed**. Verified the 4 touched files are unchanged on main (clean apply).

Cherry-picked clean from origin/main (not the stale worktree base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)