### PR TITLE
docs(sync): regenerate DOCSYNC counts after MLXProvider merge (#1670)

### DIFF
--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`325 routers · 628 services · 1083 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`325 routers · 628 services · 1084 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## What
Regenerates `docs/AI_ONBOARDING.md` DOCSYNC counts: **1083 → 1084 tests** (the MLXProvider test file added by #1670).

## Why
#1670 (MLXProvider) auto-merged the moment its CI went green, *before* its companion docs-sync bump landed — so `AI_ONBOARDING.md` test count stayed stale on main. This left `check-docs-sync` red for the next backend PR. This is the one-line repair.

## Files
- `docs/AI_ONBOARDING.md` (+1/-1, auto-generated by `scripts/docs_sync.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)