### PR TITLE
fix(mata-garuda): stop LHKPN quota loop

### DIFF
--- a/apps/mata-garuda/mata_garuda/agents/lhkpn_harvester.py
+++ b/apps/mata-garuda/mata_garuda/agents/lhkpn_harvester.py
@@ -119,7 +119,7 @@ def harvest_lhkpn_by_name(name: str) -> dict[str, Any]:
 
 
 @register_agent(name="lhkpn_harvester", func_name="get_lhkpn_harvester")
-def get_lhkpn_harvester(model: str = "claude") -> Agent:
+def get_lhkpn_harvester(model: str = "ollama:qwen3.5:9b") -> Agent:
     """Harvester agent for LHKPN wealth declarations."""
 
     def instructions(context_variables: dict) -> str:

--- a/apps/mata-garuda/mata_garuda/runtime/cli_runtime.py
+++ b/apps/mata-garuda/mata_garuda/runtime/cli_runtime.py
@@ -1,7 +1,7 @@
 """
 Mata Garuda — CLI Runtime.
 
-Subprocess wrapper per LLM CLI (claude, gemini, codex).
+Subprocess wrapper per LLM CLI/local tools (claude, gemini, codex, ollama).
 Vincolo inviolabile: MAI API HTTP, MAI SDK import.
 Tutto passa via subprocess blocking.
 
@@ -52,6 +52,8 @@ RATE_LIMIT_PATTERNS = re.compile(
 )
 
 # Mapping model -> CLI command + flags
+DEFAULT_OLLAMA_MODEL = os.environ.get("MATA_GARUDA_OLLAMA_MODEL", "qwen3.5:9b")
+
 CLI_CONFIGS: dict[str, dict] = {
     "claude": {
         "cmd": "claude",
@@ -77,6 +79,12 @@ CLI_CONFIGS: dict[str, dict] = {
     "codex": {
         "cmd": "codex",
         "print_flag": "exec",
+        "system_flag": None,
+        "model_flag": None,
+    },
+    "ollama": {
+        "cmd": "ollama",
+        "print_flag": "run",
         "system_flag": None,
         "model_flag": None,
     },
@@ -145,7 +153,7 @@ class CLIRuntime:
     """
     Subprocess wrapper per LLM CLI tools.
 
-    Supporta: claude (--print), gemini (--prompt), codex (exec).
+    Supporta: claude (--print), gemini (--prompt), codex (exec), ollama (local).
     Sempre blocking, mai interattivo.
 
     Claude multi-account fallback:
@@ -160,6 +168,13 @@ class CLIRuntime:
         timeout: int = DEFAULT_TIMEOUT,
         working_dir: Optional[str] = None,
     ):
+        self.ollama_model: str | None = None
+        if model.startswith("ollama:"):
+            self.ollama_model = model.split(":", 1)[1].strip() or DEFAULT_OLLAMA_MODEL
+            model = "ollama"
+        elif model == "ollama":
+            self.ollama_model = DEFAULT_OLLAMA_MODEL
+
         if model not in CLI_CONFIGS:
             raise ValueError(
                 f"Unknown model '{model}'. Supported: {list(CLI_CONFIGS.keys())}"
@@ -183,6 +198,17 @@ class CLIRuntime:
             cmd.append(self.config["print_flag"])
             cmd.append(prompt)
             return cmd
+
+        if self.model == "ollama":
+            combined = prompt
+            if system_prompt:
+                combined = f"<system>\n{system_prompt}\n</system>\n\n{prompt}"
+            return [
+                self.config["cmd"],
+                self.config["print_flag"],
+                self.ollama_model or DEFAULT_OLLAMA_MODEL,
+                combined,
+            ]
 
         # claude: --print "prompt" / gemini: --prompt "prompt"
         cmd.append(self.config["print_flag"])
@@ -216,6 +242,61 @@ class CLIRuntime:
             timeout=self.timeout,
             cwd=self.working_dir,
             env=env,
+        )
+
+    def _invoke_ollama(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+    ) -> CLIResult:
+        """Invoke local Ollama through the shared curl-based helper."""
+        from mata_garuda.tools.ollama_tools import generate
+
+        combined = prompt
+        if system_prompt:
+            combined = f"<system>\n{system_prompt}\n</system>\n\n{prompt}"
+
+        start = time.monotonic()
+        model_name = self.ollama_model or DEFAULT_OLLAMA_MODEL
+        try:
+            output = generate(
+                model_name,
+                combined,
+                num_predict=int(os.environ.get("MATA_GARUDA_OLLAMA_NUM_PREDICT", "700")),
+                timeout=self.timeout,
+            )
+        except Exception as exc:  # pragma: no cover - defensive local subprocess
+            elapsed = time.monotonic() - start
+            return CLIResult(
+                stdout="",
+                stderr=f"Ollama invocation failed: {type(exc).__name__}: {exc}",
+                returncode=1,
+                elapsed_seconds=round(elapsed, 2),
+                model=f"ollama:{model_name}",
+                token_used="local_ollama",
+                command=["ollama", "run", model_name, "<prompt>"],
+            )
+
+        elapsed = time.monotonic() - start
+        if output is None:
+            return CLIResult(
+                stdout="",
+                stderr=f"Ollama returned no output for {model_name}",
+                returncode=1,
+                elapsed_seconds=round(elapsed, 2),
+                model=f"ollama:{model_name}",
+                token_used="local_ollama",
+                command=["ollama", "run", model_name, "<prompt>"],
+            )
+
+        return CLIResult(
+            stdout=output,
+            stderr="",
+            returncode=0,
+            elapsed_seconds=round(elapsed, 2),
+            model=f"ollama:{model_name}",
+            token_used="local_ollama",
+            command=["ollama", "run", model_name, "<prompt>"],
         )
 
     def _invoke_single(
@@ -289,6 +370,13 @@ class CLIRuntime:
         Returns:
             CLIResult with stdout, stderr, returncode, timing
         """
+        if self.model == "ollama":
+            logger.info(
+                f"[CLIRuntime] Invoking local Ollama "
+                f"({self.ollama_model or DEFAULT_OLLAMA_MODEL})"
+            )
+            return self._invoke_ollama(prompt, system_prompt)
+
         cmd = self._build_command(prompt, system_prompt, extra_flags)
 
         # Non-Claude models: single call, no fallback chain

--- a/apps/mata-garuda/mata_garuda/runtime/lamarckian.py
+++ b/apps/mata-garuda/mata_garuda/runtime/lamarckian.py
@@ -14,6 +14,7 @@ Reference: docs/mata-garuda/40d-AUTOAGENT-PATTERNS.md Pattern 3
 from __future__ import annotations
 
 import logging
+import os
 import re
 from typing import Optional
 
@@ -40,6 +41,10 @@ from mata_garuda.types import Agent, Response
 logger = logging.getLogger("mata_garuda.runtime")
 
 MAX_RETRY = 3
+DEFAULT_REFLECTION_MODEL = os.environ.get(
+    "MATA_GARUDA_REFLECTION_MODEL",
+    "ollama:qwen3.5:9b",
+)
 
 # Hints get progressively more specific
 RETRY_HINTS = [
@@ -101,7 +106,7 @@ def _run_post_reflection(
             genome_snippet=genome_snippet,
         )
 
-        runtime = CLIRuntime(model="claude")
+        runtime = CLIRuntime(model=DEFAULT_REFLECTION_MODEL)
         result = runtime.invoke(prompt=prompt, system_prompt="Output only JSON.")
 
         if result.success:
@@ -243,18 +248,34 @@ def run_with_lamarckian_feedback(
 
             continue
 
-        # No terminal state detected — treat as implicit resolution
-        record_run(agent.name, success=True, mutation_version=mutation_version)
-        logger.info(
-            f"[lamarckian] {agent.name} finished without explicit case status "
-            f"on attempt {attempt + 1} — treating as resolved"
+        feedback_path = log_feedback(
+            agent_name=agent.name,
+            attempt=attempt + 1,
+            failure_reason="missing_terminal_case_status",
+            take_away=(
+                "Agent ended without calling case_resolved or case_not_resolved."
+            ),
         )
-        _run_post_reflection(agent, query, True, all_messages, kb)
-        return Response(
-            messages=all_messages,
-            agent=agent,
-            context_variables=context_variables,
+        record_run(agent.name, success=False, mutation_version=mutation_version)
+        logger.warning(
+            f"[lamarckian] {agent.name} ended without explicit case status "
+            f"on attempt {attempt + 1}"
         )
+
+        if attempt >= max_retry - 1:
+            _run_post_reflection(agent, query, False, all_messages, kb)
+            escalation_msg = {
+                "role": "system",
+                "content": (
+                    f"[ESCALATION] Agent {agent.name} failed without a terminal "
+                    f"case status after {max_retry} attempts. Feedback logged at "
+                    f"{feedback_path}."
+                ),
+            }
+            all_messages.append(escalation_msg)
+            break
+
+        continue
 
     # Check fitness after the run
     check_and_auto_revert(agent.name)

--- a/apps/mata-garuda/mata_garuda/runtime/loop.py
+++ b/apps/mata-garuda/mata_garuda/runtime/loop.py
@@ -148,11 +148,11 @@ def run_agent_loop(
 
         if not tool_calls:
             # No tool calls — check for case resolution in plain text
-            if "Case resolved" in output or "case_resolved" in output.lower():
+            if "Case resolved." in output:
                 logger.info(f"[MetaChain] {agent.name} resolved the case")
                 break
 
-            if "Case not resolved" in output or "case_not_resolved" in output.lower():
+            if "Case not resolved." in output:
                 logger.info(f"[MetaChain] {agent.name} could not resolve the case")
                 break
 

--- a/apps/mata-garuda/mata_garuda/types.py
+++ b/apps/mata-garuda/mata_garuda/types.py
@@ -26,7 +26,7 @@ class Agent(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     name: str = "Agent"
-    model: str = "claude"  # CLI runtime: "claude" | "gemini" | "codex" | "deepseek"
+    model: str = "claude"  # CLI runtime: "claude" | "gemini" | "codex" | "ollama:*"
     instructions: Union[str, Callable[[dict], str]] = "You are a helpful agent."
     functions: List[AgentFunction] = Field(default_factory=list)
     tool_choice: Optional[str] = None  # "required" forces tool use

--- a/apps/mata-garuda/mata_garuda/workers/gap_consumer.py
+++ b/apps/mata-garuda/mata_garuda/workers/gap_consumer.py
@@ -40,6 +40,9 @@ CONSUMER_NAME = "consumer-1"
 # Rate limit: max dispatches per run + sleep between them
 MAX_DISPATCH_PER_RUN = 5
 DISPATCH_SLEEP_S = 2
+AGENT_MAX_RETRIES = {
+    "lhkpn_harvester": 1,
+}
 
 # Gap type → agent name (None = Phase 2, skipped with ack)
 #
@@ -71,6 +74,46 @@ GAP_DISPATCH: dict[str, Optional[str]] = {
 }
 
 
+def _extract_terminal_case_status(messages: list[dict[str, Any]]) -> tuple[bool, str]:
+    """Return the final explicit case status from agent messages.
+
+    Intermediate tool payloads such as ``{"case_resolved": False}`` are not
+    terminal states. Only the status tools return these exact strings.
+    """
+    for msg in reversed(messages):
+        content = msg.get("content", "") if isinstance(msg, dict) else ""
+        if "Case not resolved." in content:
+            return False, content[:200]
+        if "Case resolved." in content:
+            return True, ""
+    return False, "missing_terminal_case_status"
+
+
+def _payload_has_nip(payload: dict[str, Any]) -> bool:
+    """True when any known payload key carries a usable NIP-like identifier."""
+    for key in ("nip", "entity_nip", "matched_nip"):
+        value = str(payload.get(key, "")).strip()
+        if value:
+            return True
+    return False
+
+
+def _lhkpn_terminal_skip_reason(gap_type: str, payload: dict[str, Any]) -> str | None:
+    """Return a reason when an LHKPN gap is structurally unresolvable today.
+
+    KPK's post-2026-04-26 portal search rows do not expose NIP, and the
+    current profile path cannot derive angkatan. Spending LLM turns on those
+    shapes only creates redelivery loops.
+    """
+    if gap_type == "gap.missing_nip":
+        return "lhkpn_portal_search_does_not_return_nip"
+    if gap_type == "gap.missing_angkatan":
+        return "lhkpn_portal_does_not_expose_angkatan"
+    if gap_type == "gap.missing_lhkpn" and not _payload_has_nip(payload):
+        return "lhkpn_profile_fetch_requires_existing_nip"
+    return None
+
+
 def _default_dispatch_agent(agent_name: str, payload: dict[str, Any]) -> dict[str, Any]:
     """Default dispatcher: invokes the registered agent via Lamarckian loop.
 
@@ -90,24 +133,18 @@ def _default_dispatch_agent(agent_name: str, payload: dict[str, Any]) -> dict[st
     query = json.dumps(payload, ensure_ascii=False)
     kb = KnowledgeBase()
     try:
-        response = run_with_lamarckian_feedback(agent, query, kb=kb)
+        response = run_with_lamarckian_feedback(
+            agent,
+            query,
+            kb=kb,
+            max_retry=AGENT_MAX_RETRIES.get(agent_name, 3),
+        )
     finally:
         kb.close()
 
-    # Inspect the response messages for the case_resolved/case_not_resolved tool call.
-    # The lamarckian loop ends with one of these tools being called.
-    resolved = False
-    reason = ""
-    if response is not None and hasattr(response, "messages"):
-        for msg in response.messages:
-            content = msg.get("content", "") if isinstance(msg, dict) else ""
-            if "Case resolved" in content or "case_resolved" in content.lower():
-                resolved = True
-                break
-            if "Case not resolved" in content or "case_not_resolved" in content.lower():
-                resolved = False
-                reason = content[:200]
-                break
+    resolved, reason = _extract_terminal_case_status(
+        response.messages if response is not None and hasattr(response, "messages") else []
+    )
 
     return {"case_resolved": resolved, "reason": reason}
 
@@ -144,6 +181,17 @@ def process_gap(
 
     # Inject _gap_type so the agent knows what it's solving
     enriched = {**payload, "_gap_type": gap_type}
+
+    if agent_name == "lhkpn_harvester":
+        skip_reason = _lhkpn_terminal_skip_reason(gap_type, enriched)
+        if skip_reason:
+            logger.warning(
+                "Gap %s skipped before LHKPN dispatch (%s) — ACKing",
+                gap_type,
+                skip_reason,
+            )
+            xack(STREAM_NEXUS_GAPS, CONSUMER_GROUP, msg_id)
+            return {"status": "skipped", "agent": agent_name, "reason": skip_reason}
 
     try:
         result = dispatch_agent(agent_name=agent_name, payload=enriched)

--- a/apps/mata-garuda/tests/test_gap_consumer.py
+++ b/apps/mata-garuda/tests/test_gap_consumer.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from mata_garuda.workers.gap_consumer import (
     GAP_DISPATCH,
+    _extract_terminal_case_status,
     process_gap,
     run_gap_consumer,
 )
@@ -103,9 +104,32 @@ def test_process_gap_unknown_type_skips_with_ack():
     fake_xack.assert_called_once()
 
 
-def test_process_gap_dispatches_lhkpn_for_missing_nip():
-    """gap.missing_nip → lhkpn_harvester."""
-    fake_dispatch = MagicMock(return_value={"case_resolved": True})
+def test_terminal_case_status_ignores_intermediate_false_payload():
+    """Tool payloads with case_resolved=False are not terminal success."""
+    messages = [
+        {"role": "tool", "content": "[harvest] {'case_resolved': False}"},
+        {"role": "tool", "content": "Case not resolved. Reason: no NIP. Insight: stop"},
+    ]
+
+    resolved, reason = _extract_terminal_case_status(messages)
+
+    assert resolved is False
+    assert "Case not resolved" in reason
+
+
+def test_terminal_case_status_requires_explicit_status_tool():
+    """A run without case_resolved/case_not_resolved is a failure signal."""
+    resolved, reason = _extract_terminal_case_status([
+        {"role": "assistant", "content": "I stopped without calling a status tool."}
+    ])
+
+    assert resolved is False
+    assert reason == "missing_terminal_case_status"
+
+
+def test_process_gap_skips_lhkpn_missing_nip_without_dispatch():
+    """gap.missing_nip is structurally unresolvable in the current KPK portal."""
+    fake_dispatch = MagicMock()
     fake_xack = MagicMock()
 
     result = process_gap(
@@ -116,14 +140,72 @@ def test_process_gap_dispatches_lhkpn_for_missing_nip():
         xack=fake_xack,
     )
 
+    fake_dispatch.assert_not_called()
+    fake_xack.assert_called_once()
+    assert result["status"] == "skipped"
+    assert result["agent"] == "lhkpn_harvester"
+    assert result["reason"] == "lhkpn_portal_search_does_not_return_nip"
+
+
+def test_process_gap_skips_lhkpn_missing_lhkpn_without_nip():
+    """gap.missing_lhkpn needs a NIP before it is worth dispatching."""
+    fake_dispatch = MagicMock()
+    fake_xack = MagicMock()
+
+    result = process_gap(
+        msg_id="3-1",
+        gap_type="gap.missing_lhkpn",
+        payload={"entity_name": "redacted", "entity_nip": ""},
+        dispatch_agent=fake_dispatch,
+        xack=fake_xack,
+    )
+
+    fake_dispatch.assert_not_called()
+    fake_xack.assert_called_once()
+    assert result["status"] == "skipped"
+    assert result["reason"] == "lhkpn_profile_fetch_requires_existing_nip"
+
+
+def test_process_gap_dispatches_lhkpn_missing_lhkpn_when_nip_present():
+    """gap.missing_lhkpn with an existing NIP remains dispatchable."""
+    fake_dispatch = MagicMock(return_value={"case_resolved": True})
+    fake_xack = MagicMock()
+
+    result = process_gap(
+        msg_id="3-2",
+        gap_type="gap.missing_lhkpn",
+        payload={"entity_name": "redacted", "entity_nip": "123"},
+        dispatch_agent=fake_dispatch,
+        xack=fake_xack,
+    )
+
     fake_dispatch.assert_called_once()
     call_kwargs = fake_dispatch.call_args.kwargs
     assert call_kwargs["agent_name"] == "lhkpn_harvester"
-    assert call_kwargs["payload"]["person_name"] == "Budi"
-    assert call_kwargs["payload"]["_gap_type"] == "gap.missing_nip"
+    assert call_kwargs["payload"]["entity_nip"] == "123"
+    assert call_kwargs["payload"]["_gap_type"] == "gap.missing_lhkpn"
     assert result["status"] == "resolved"
     assert result["agent"] == "lhkpn_harvester"
     fake_xack.assert_called_once()
+
+
+def test_process_gap_skips_lhkpn_missing_angkatan():
+    """Current LHKPN source cannot derive angkatan, so avoid retry loops."""
+    fake_dispatch = MagicMock()
+    fake_xack = MagicMock()
+
+    result = process_gap(
+        msg_id="3-3",
+        gap_type="gap.missing_angkatan",
+        payload={"entity_name": "redacted", "entity_nip": "123"},
+        dispatch_agent=fake_dispatch,
+        xack=fake_xack,
+    )
+
+    fake_dispatch.assert_not_called()
+    fake_xack.assert_called_once()
+    assert result["status"] == "skipped"
+    assert result["reason"] == "lhkpn_portal_does_not_expose_angkatan"
 
 
 def test_process_gap_dispatches_regulation_watcher_for_stale_official():
@@ -153,8 +235,8 @@ def test_process_gap_does_not_ack_on_case_not_resolved():
 
     result = process_gap(
         msg_id="5-0",
-        gap_type="gap.missing_nip",
-        payload={"person_name": "x"},
+        gap_type="gap.missing_lhkpn",
+        payload={"entity_name": "redacted", "entity_nip": "123"},
         dispatch_agent=fake_dispatch,
         xack=fake_xack,
     )
@@ -170,8 +252,8 @@ def test_process_gap_dispatch_exception_caught_no_ack():
 
     result = process_gap(
         msg_id="6-0",
-        gap_type="gap.missing_nip",
-        payload={},
+        gap_type="gap.missing_lhkpn",
+        payload={"entity_nip": "123"},
         dispatch_agent=fake_dispatch,
         xack=fake_xack,
     )
@@ -184,9 +266,9 @@ def test_run_gap_consumer_processes_batch():
     """run_gap_consumer reads N messages and processes each."""
     msgs = [
         {"id": "10-0", "data": {
-            "id": "uuid-10", "type": "gap.missing_nip", "source": "gap_detector",
+            "id": "uuid-10", "type": "gap.missing_lhkpn", "source": "gap_detector",
             "timestamp": "2026-04-16T00:00:00+08:00", "priority": "3",
-            "payload": '{"person_name": "A"}',
+            "payload": '{"entity_name": "A", "entity_nip": "123"}',
         }},
         {"id": "11-0", "data": {
             "id": "uuid-11", "type": "gap.stale_official", "source": "gap_detector",
@@ -235,7 +317,7 @@ def test_run_gap_consumer_handles_invalid_json_payload():
     """Invalid JSON in payload field → empty dict, still processes."""
     msgs = [
         {"id": "12-0", "data": {
-            "id": "uuid-12", "type": "gap.missing_nip", "source": "gap_detector",
+            "id": "uuid-12", "type": "gap.stale_official", "source": "gap_detector",
             "timestamp": "2026-04-16T00:00:00+08:00", "priority": "3",
             "payload": "not json {{{",
         }},
@@ -256,15 +338,15 @@ def test_run_gap_consumer_handles_invalid_json_payload():
     # dispatch was called even with empty payload (only _gap_type added)
     fake_dispatch.assert_called_once()
     payload = fake_dispatch.call_args.kwargs["payload"]
-    assert payload == {"_gap_type": "gap.missing_nip"}
+    assert payload == {"_gap_type": "gap.stale_official"}
 
 
 # ── legacy stream end-to-end (coerce + dispatch) ───────────────────────
 
 
-def test_run_gap_consumer_routes_legacy_missing_nip_to_lhkpn():
+def test_run_gap_consumer_skips_legacy_missing_nip_without_dispatch():
     """Legacy entry (gap_type=missing_attribute, attribute=nip) reaches
-    lhkpn_harvester via canonical translation."""
+    a terminal LHKPN skip because KPK search no longer returns NIP."""
     msgs = [
         {
             "id": "100-0",
@@ -273,7 +355,7 @@ def test_run_gap_consumer_routes_legacy_missing_nip_to_lhkpn():
                 "gap_type": "missing_attribute",
                 "attribute": "nip",
                 "entity_type": "Official",
-                "entity_name": "Felucia Sengky Ratna",
+                "entity_name": "redacted",
                 "entity_nip": "",
                 "priority": "2",
                 "ttl_seconds": "86400",
@@ -293,13 +375,9 @@ def test_run_gap_consumer_routes_legacy_missing_nip_to_lhkpn():
     )
 
     assert stats["read"] == 1
-    assert stats["resolved"] == 1
-    assert fake_dispatch.call_args.kwargs["agent_name"] == "lhkpn_harvester"
-    payload = fake_dispatch.call_args.kwargs["payload"]
-    # Legacy fields preserved + audit marker present
-    assert payload["entity_name"] == "Felucia Sengky Ratna"
-    assert payload["_legacy_source"] == "nexus:gaps:pre-2026-04-14"
-    assert payload["_gap_type"] == "gap.missing_nip"
+    assert stats["skipped"] == 1
+    fake_dispatch.assert_not_called()
+    fake_xack.assert_called_once()
 
 
 def test_run_gap_consumer_drains_unmappable_legacy_with_ack():
@@ -345,7 +423,7 @@ def test_run_gap_consumer_mixed_canonical_and_legacy_batch():
         # legacy mappable
         {"id": "201-0", "data": {
             "gap_type": "missing_attribute", "attribute": "lhkpn",
-            "entity_name": "Bar", "priority": "2",
+            "entity_name": "Bar", "entity_nip": "123", "priority": "2",
         }},
         # legacy drained
         {"id": "202-0", "data": {

--- a/apps/mata-garuda/tests/test_lamarckian.py
+++ b/apps/mata-garuda/tests/test_lamarckian.py
@@ -129,6 +129,36 @@ class TestParseCaseStatus:
         assert status is None
         assert details is None
 
+    def test_missing_terminal_status_records_failure(self, monkeypatch):
+        import mata_garuda.runtime.lamarckian as lamarckian
+        from mata_garuda.types import Agent, Response
+
+        agent = Agent(name=TEST_AGENT, model="ollama:qwen3.5:9b")
+
+        def fake_run_agent_loop(**kwargs):
+            return Response(
+                messages=[{
+                    "role": "assistant",
+                    "content": "Finished without a status tool.",
+                }],
+                agent=agent,
+            )
+
+        monkeypatch.setattr(lamarckian, "run_agent_loop", fake_run_agent_loop)
+
+        response = lamarckian.run_with_lamarckian_feedback(
+            agent,
+            "test query",
+            max_retry=1,
+        )
+
+        runs = get_recent_runs(TEST_AGENT, window=1)
+        assert runs[-1]["success"] is False
+        assert any(
+            "failed without a terminal case status" in msg.get("content", "")
+            for msg in response.messages
+        )
+
 
 # ─── Feedback Logging Tests ───────────────────────────────────────────
 

--- a/apps/mata-garuda/tests/test_lhkpn_harvester.py
+++ b/apps/mata-garuda/tests/test_lhkpn_harvester.py
@@ -114,6 +114,7 @@ def test_agent_registered_in_registry():
     agent = get_agent("lhkpn_harvester")
     assert agent is not None
     assert agent.name == "lhkpn_harvester"
+    assert agent.model == "ollama:qwen3.5:9b"
     assert agent.layer == "harvester"
     # Tools are functions; check by name
     fn_names = {fn.__name__ for fn in agent.functions}

--- a/apps/mata-garuda/tests/test_meta_agent.py
+++ b/apps/mata-garuda/tests/test_meta_agent.py
@@ -276,6 +276,36 @@ class TestCLIRuntime:
         # Gemini prepends system prompt to user prompt
         assert any("<system>" in arg for arg in cmd)
 
+    def test_build_command_ollama_alias(self):
+        from mata_garuda.runtime.cli_runtime import CLIRuntime
+
+        rt = CLIRuntime(model="ollama:qwen3.5:9b")
+        cmd = rt._build_command("hello", system_prompt="You are helpful")
+        assert cmd[:3] == ["ollama", "run", "qwen3.5:9b"]
+        assert any("<system>" in arg for arg in cmd)
+
+    def test_invoke_ollama_uses_local_helper(self, monkeypatch):
+        from mata_garuda.runtime import cli_runtime
+
+        calls = []
+
+        def fake_generate(model, prompt, **kwargs):
+            calls.append((model, prompt, kwargs))
+            return "local output"
+
+        monkeypatch.setattr(
+            "mata_garuda.tools.ollama_tools.generate",
+            fake_generate,
+        )
+
+        rt = cli_runtime.CLIRuntime(model="ollama:qwen3.5:9b")
+        result = rt.invoke("hello", system_prompt="You are helpful")
+
+        assert result.success is True
+        assert result.model == "ollama:qwen3.5:9b"
+        assert result.token_used == "local_ollama"
+        assert calls[0][0] == "qwen3.5:9b"
+
     def test_unknown_model_raises(self):
         from mata_garuda.runtime.cli_runtime import CLIRuntime
 


### PR DESCRIPTION
## Summary
- routes the LHKPN harvester and Lamarckian reflections to local Ollama (`ollama:qwen3.5:9b`) by default
- removes implicit-success behavior when an agent ends without `case_resolved` / `case_not_resolved`
- prevents structurally unresolvable LHKPN gaps from entering the LLM loop
- caps LHKPN Lamarckian retries to one attempt and adds regression tests for false success signals

## Verification
- `PYTHONPATH=. ~/Desktop/nuzantara/apps/mata-garuda/.venv/bin/python -m pytest tests/test_gap_consumer.py tests/test_lamarckian.py tests/test_lhkpn_harvester.py tests/test_meta_agent.py tests/test_ollama_tools.py -q` -> 123 passed
- `PYTHONPATH=. ~/Desktop/nuzantara/apps/mata-garuda/.venv/bin/python -m compileall -q mata_garuda/workers/gap_consumer.py mata_garuda/runtime/lamarckian.py mata_garuda/runtime/loop.py mata_garuda/runtime/cli_runtime.py mata_garuda/agents/lhkpn_harvester.py mata_garuda/types.py`
- local Ollama smoke on Pro: `qwen3.5:9b` returned output
- `launchctl print gui/$(id -u)/com.matagaruda.gap.consumer` still returns service not found; worker process count remains 0

## Operational note
`com.matagaruda.gap.consumer` is intentionally still stopped. Restart only after this branch is merged or the same patch is applied to the runtime checkout.
