### PR TITLE
fix(mata-garuda): resolve LHKPN gaps with known NIP

### DIFF
--- a/apps/mata-garuda/mata_garuda/agents/lhkpn_harvester.py
+++ b/apps/mata-garuda/mata_garuda/agents/lhkpn_harvester.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 
 import json
 import logging
+import re
+import unicodedata
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -48,19 +50,32 @@ GENOME_FILE = str(Path(__file__).parent / "lhkpn_harvester_GENOME.md")
 # ── Tool functions exposed to the agent ───────────────────────────────
 
 
-def harvest_lhkpn_for_nip(nip: str) -> dict[str, Any]:
-    """Fetch the LHKPN profile for a given NIP and publish to garuda:raw.
+def _normalise_name(value: str) -> str:
+    """Return an ASCII-ish lowercase token string for conservative matching."""
+    ascii_value = (
+        unicodedata.normalize("NFKD", value)
+        .encode("ascii", "ignore")
+        .decode("ascii")
+        .lower()
+    )
+    return re.sub(r"[^a-z0-9]+", " ", ascii_value).strip()
 
-    Returns {"case_resolved": bool, "nip": str, "reason": str, "msg_id"?: str}.
-    """
-    profile = scrape_lhkpn_profile(nip)
-    if not profile or not profile.get("nip"):
-        return {
-            "case_resolved": False,
-            "nip": nip,
-            "reason": "empty profile (HTTP failure or NIP not found)",
-        }
 
+def _names_match(expected: str, found: str) -> bool:
+    """Conservative name match for portal rows."""
+    expected_norm = _normalise_name(expected)
+    found_norm = _normalise_name(found)
+    if not expected_norm or not found_norm:
+        return False
+    return (
+        expected_norm == found_norm
+        or expected_norm in found_norm
+        or found_norm in expected_norm
+    )
+
+
+def _publish_lhkpn_profile(profile: dict[str, Any]) -> dict[str, Any]:
+    """Publish a normalised LHKPN profile to garuda:raw."""
     title = (
         f"LHKPN {profile.get('nama', 'unknown')} "
         f"({profile.get('jabatan', '?')})"
@@ -82,9 +97,30 @@ def harvest_lhkpn_for_nip(nip: str) -> dict[str, Any]:
     }
 
     msg_id = stream_publish_redis(STREAM_RAW, fields)
-    logger.info("Published LHKPN profile for NIP %s (msg %s)", nip, msg_id)
+    logger.info("Published LHKPN profile for NIP %s (msg %s)", profile.get("nip"), msg_id)
 
-    return {"case_resolved": True, "nip": nip, "reason": "", "msg_id": msg_id}
+    return {
+        "case_resolved": True,
+        "nip": profile.get("nip", ""),
+        "reason": "",
+        "msg_id": msg_id,
+    }
+
+
+def harvest_lhkpn_for_nip(nip: str) -> dict[str, Any]:
+    """Fetch the LHKPN profile for a given NIP and publish to garuda:raw.
+
+    Returns {"case_resolved": bool, "nip": str, "reason": str, "msg_id"?: str}.
+    """
+    profile = scrape_lhkpn_profile(nip)
+    if not profile or not profile.get("nip"):
+        return {
+            "case_resolved": False,
+            "nip": nip,
+            "reason": "empty profile (HTTP failure or NIP not found)",
+        }
+
+    return _publish_lhkpn_profile(profile)
 
 
 def harvest_lhkpn_by_name(name: str) -> dict[str, Any]:
@@ -92,26 +128,77 @@ def harvest_lhkpn_by_name(name: str) -> dict[str, Any]:
 
     Returns {"case_resolved": bool, "name": str, "reason": str, ...}.
     """
-    hits = scrape_lhkpn_search(name)
+    return harvest_lhkpn_for_person(name=name, nip="")
+
+
+def harvest_lhkpn_for_person(name: str, nip: str = "") -> dict[str, Any]:
+    """Search LHKPN by name and publish the best exact-name hit.
+
+    The current KPK portal does not search by NIP, but legacy OSINT gaps often
+    carry both ``entity_name`` and ``entity_nip``. Use the name to query the
+    portal, then attach the already-known NIP to the normalised profile.
+    """
+    clean_name = name.strip()
+    clean_nip = nip.strip()
+    if not clean_name:
+        if clean_nip:
+            return harvest_lhkpn_for_nip(clean_nip)
+        return {"case_resolved": False, "name": name, "reason": "missing name and NIP"}
+
+    hits = scrape_lhkpn_search(clean_name)
     if not hits:
         return {
             "case_resolved": False,
-            "name": name,
+            "name": clean_name,
             "reason": "no search results",
         }
 
-    first = hits[0]
-    nip = first.get("nip", "")
-    if not nip:
+    matching_hits = [hit for hit in hits if _names_match(clean_name, hit.get("nama", ""))]
+    if not matching_hits:
         return {
             "case_resolved": False,
-            "name": name,
-            "reason": "first search hit has no NIP",
+            "name": clean_name,
+            "reason": "no exact name match",
         }
 
-    result = harvest_lhkpn_for_nip(nip)
-    result["name"] = name
-    result["matched_nip"] = nip
+    first = matching_hits[0]
+    matched_nip = first.get("nip", "").strip()
+    if not clean_nip and matched_nip:
+        result = harvest_lhkpn_for_nip(matched_nip)
+        result["name"] = clean_name
+        result["matched_nip"] = matched_nip
+        return result
+    if not clean_nip:
+        return {
+            "case_resolved": False,
+            "name": clean_name,
+            "reason": "matched declaration has no NIP; provide entity_nip",
+        }
+
+    raw = first.get("_raw") or {}
+    profile = {
+        "nama": first.get("nama", ""),
+        "nip": clean_nip,
+        "jabatan": first.get("jabatan", ""),
+        "angkatan": "",
+        "total_harta_idr": int(raw.get("total_harta", 0) or 0),
+        "properties_count": 0,
+        "vehicles_count": 0,
+        "accounts_count": 0,
+        "_raw": {
+            "tahun_data": raw.get("tahun_data", first.get("report_year", "")),
+            "lembaga": raw.get("lembaga", ""),
+            "unit_kerja": raw.get("unit_kerja", ""),
+            "tanggal_lapor": raw.get("tanggal_lapor", ""),
+            "jenis_laporan": raw.get("jenis_laporan", ""),
+            "data_id": raw.get("data_id", ""),
+            "pdf_path": raw.get("pdf_path", ""),
+        },
+    }
+
+    result = _publish_lhkpn_profile(profile)
+    result["name"] = clean_name
+    result["matched_nip"] = clean_nip
     return result
 
 
@@ -130,10 +217,11 @@ elhkpn.kpk.go.id (the post-2026-04-26 KPK e-Announcement portal) and
 publish to the garuda:raw Redis Stream.
 
 WORKFLOW:
-1. If you have a NIP, call harvest_lhkpn_for_nip(nip)
-2. If you have only a name, call harvest_lhkpn_by_name(name)
-3. On case_resolved → call case_resolved with summary
-4. On failure → call case_not_resolved with the reason
+1. If you have both a name and NIP, call harvest_lhkpn_for_person(name, nip)
+2. If you have only a NIP, call harvest_lhkpn_for_nip(nip)
+3. If you have only a name, call harvest_lhkpn_by_name(name)
+4. On case_resolved → call case_resolved with summary
+5. On failure → call case_not_resolved with the reason
 
 CONSTRAINTS (from GENOME.md):
 - Source: https://elhkpn.kpk.go.id/ (SPA + reCAPTCHA v3)
@@ -157,6 +245,7 @@ ERROR HANDLING:
         functions=[
             harvest_lhkpn_for_nip,
             harvest_lhkpn_by_name,
+            harvest_lhkpn_for_person,
             case_resolved,
             case_not_resolved,
         ],

--- a/apps/mata-garuda/mata_garuda/workers/gap_consumer.py
+++ b/apps/mata-garuda/mata_garuda/workers/gap_consumer.py
@@ -119,6 +119,18 @@ def _lhkpn_terminal_skip_reason(gap_type: str, payload: dict[str, Any]) -> str |
     return None
 
 
+def _dispatch_lhkpn_known_person(payload: dict[str, Any]) -> dict[str, Any] | None:
+    """Resolve LHKPN directly when a legacy gap already carries name + NIP."""
+    name = str(payload.get("entity_name") or payload.get("person_name") or "").strip()
+    nip = str(payload.get("entity_nip") or payload.get("nip") or "").strip()
+    if not name or not nip:
+        return None
+
+    from mata_garuda.agents.lhkpn_harvester import harvest_lhkpn_for_person
+
+    return harvest_lhkpn_for_person(name=name, nip=nip)
+
+
 def _default_dispatch_agent(agent_name: str, payload: dict[str, Any]) -> dict[str, Any]:
     """Default dispatcher: invokes the registered agent via Lamarckian loop.
 
@@ -198,6 +210,29 @@ def process_gap(
             )
             xack(STREAM_NEXUS_GAPS, CONSUMER_GROUP, msg_id)
             return {"status": "skipped", "agent": agent_name, "reason": skip_reason}
+        if gap_type == "gap.missing_lhkpn":
+            direct_result = _dispatch_lhkpn_known_person(enriched)
+            if direct_result is not None:
+                if direct_result.get("case_resolved"):
+                    xack(STREAM_NEXUS_GAPS, CONSUMER_GROUP, msg_id)
+                    logger.info(
+                        "Gap %s resolved directly by %s (msg %s)",
+                        gap_type,
+                        agent_name,
+                        msg_id,
+                    )
+                    return {"status": "resolved", "agent": agent_name}
+                logger.warning(
+                    "Gap %s direct LHKPN resolution failed (msg %s): %s — NOT acking",
+                    gap_type,
+                    msg_id,
+                    direct_result.get("reason", ""),
+                )
+                return {
+                    "status": "failed",
+                    "agent": agent_name,
+                    "reason": direct_result.get("reason", ""),
+                }
 
     try:
         result = dispatch_agent(agent_name=agent_name, payload=enriched)

--- a/apps/mata-garuda/tests/test_gap_consumer.py
+++ b/apps/mata-garuda/tests/test_gap_consumer.py
@@ -175,7 +175,7 @@ def test_process_gap_dispatches_lhkpn_missing_lhkpn_when_nip_present():
     result = process_gap(
         msg_id="3-2",
         gap_type="gap.missing_lhkpn",
-        payload={"entity_name": "redacted", "entity_nip": "123"},
+        payload={"entity_nip": "123"},
         dispatch_agent=fake_dispatch,
         xack=fake_xack,
     )
@@ -188,6 +188,59 @@ def test_process_gap_dispatches_lhkpn_missing_lhkpn_when_nip_present():
     assert result["status"] == "resolved"
     assert result["agent"] == "lhkpn_harvester"
     fake_xack.assert_called_once()
+
+
+def test_process_gap_resolves_lhkpn_known_person_directly(monkeypatch):
+    """Name + NIP LHKPN gaps use the local scraper tool, not the LLM dispatch."""
+    fake_dispatch = MagicMock()
+    fake_xack = MagicMock()
+
+    def fake_harvest_lhkpn_for_person(name: str, nip: str) -> dict[str, object]:
+        assert name == "Redacted Official"
+        assert nip == "123"
+        return {"case_resolved": True, "msg_id": "raw-1"}
+
+    monkeypatch.setattr(
+        "mata_garuda.agents.lhkpn_harvester.harvest_lhkpn_for_person",
+        fake_harvest_lhkpn_for_person,
+    )
+
+    result = process_gap(
+        msg_id="3-4",
+        gap_type="gap.missing_lhkpn",
+        payload={"entity_name": "Redacted Official", "entity_nip": "123"},
+        dispatch_agent=fake_dispatch,
+        xack=fake_xack,
+    )
+
+    fake_dispatch.assert_not_called()
+    fake_xack.assert_called_once()
+    assert result["status"] == "resolved"
+    assert result["agent"] == "lhkpn_harvester"
+
+
+def test_process_gap_lhkpn_direct_failure_does_not_ack(monkeypatch):
+    """A failed direct LHKPN lookup must remain pending for retry/audit."""
+    fake_dispatch = MagicMock()
+    fake_xack = MagicMock()
+
+    monkeypatch.setattr(
+        "mata_garuda.agents.lhkpn_harvester.harvest_lhkpn_for_person",
+        lambda name, nip: {"case_resolved": False, "reason": "no search results"},
+    )
+
+    result = process_gap(
+        msg_id="3-5",
+        gap_type="gap.missing_lhkpn",
+        payload={"entity_name": "Redacted Official", "entity_nip": "123"},
+        dispatch_agent=fake_dispatch,
+        xack=fake_xack,
+    )
+
+    fake_dispatch.assert_not_called()
+    fake_xack.assert_not_called()
+    assert result["status"] == "failed"
+    assert result["reason"] == "no search results"
 
 
 def test_process_gap_skips_lhkpn_missing_angkatan():
@@ -309,7 +362,7 @@ def test_run_gap_consumer_processes_batch():
         {"id": "10-0", "data": {
             "id": "uuid-10", "type": "gap.missing_lhkpn", "source": "gap_detector",
             "timestamp": "2026-04-16T00:00:00+08:00", "priority": "3",
-            "payload": '{"entity_name": "A", "entity_nip": "123"}',
+            "payload": '{"entity_nip": "123"}',
         }},
         {"id": "11-0", "data": {
             "id": "uuid-11", "type": "gap.stale_official", "source": "gap_detector",
@@ -464,7 +517,7 @@ def test_run_gap_consumer_mixed_canonical_and_legacy_batch():
         # legacy mappable
         {"id": "201-0", "data": {
             "gap_type": "missing_attribute", "attribute": "lhkpn",
-            "entity_name": "Bar", "entity_nip": "123", "priority": "2",
+            "entity_nip": "123", "priority": "2",
         }},
         # legacy drained
         {"id": "202-0", "data": {

--- a/apps/mata-garuda/tests/test_lhkpn_harvester.py
+++ b/apps/mata-garuda/tests/test_lhkpn_harvester.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from mata_garuda.agents.lhkpn_harvester import (
     harvest_lhkpn_by_name,
+    harvest_lhkpn_for_person,
     harvest_lhkpn_for_nip,
 )
 
@@ -105,6 +106,55 @@ def test_harvest_by_name_first_hit_no_nip_fails():
     fake_publish.assert_not_called()
 
 
+def test_harvest_for_person_uses_name_search_with_known_nip():
+    """New portal search has no NIP, so use the gap-provided NIP."""
+    search_hits = [
+        {
+            "nama": "Ahmad Wijaya",
+            "nip": "",
+            "jabatan": "x",
+            "report_year": "2025",
+            "_raw": {
+                "tahun_data": "2025",
+                "lembaga": "KPK",
+                "unit_kerja": "Unit",
+                "tanggal_lapor": "2025-01-01",
+                "jenis_laporan": "Periodik",
+                "total_harta": 5_000_000,
+                "data_id": "opaque",
+            },
+        },
+    ]
+
+    with patch("mata_garuda.agents.lhkpn_harvester.scrape_lhkpn_search", return_value=search_hits), \
+         patch("mata_garuda.agents.lhkpn_harvester.stream_publish_redis", return_value="3-0") as fake_publish:
+        result = harvest_lhkpn_for_person("Ahmad Wijaya", "199001012010011001")
+
+    assert result["case_resolved"] is True
+    assert result["nip"] == "199001012010011001"
+    fake_publish.assert_called_once()
+    stream, fields = fake_publish.call_args.args
+    assert stream == "garuda:raw"
+    content = fields["content"]
+    assert "199001012010011001" in content
+    assert "5000000" in content
+
+
+def test_harvest_for_person_rejects_non_matching_name():
+    """Avoid publishing first-row data when the portal match is ambiguous."""
+    search_hits = [
+        {"nama": "Different Person", "nip": "", "jabatan": "x", "report_year": "2025"},
+    ]
+
+    with patch("mata_garuda.agents.lhkpn_harvester.scrape_lhkpn_search", return_value=search_hits), \
+         patch("mata_garuda.agents.lhkpn_harvester.stream_publish_redis") as fake_publish:
+        result = harvest_lhkpn_for_person("Ahmad Wijaya", "199001012010011001")
+
+    assert result["case_resolved"] is False
+    assert result["reason"] == "no exact name match"
+    fake_publish.assert_not_called()
+
+
 def test_agent_registered_in_registry():
     """Importing the module registers lhkpn_harvester in the global registry."""
     # Trigger registration by importing the module
@@ -120,6 +170,7 @@ def test_agent_registered_in_registry():
     fn_names = {fn.__name__ for fn in agent.functions}
     assert "harvest_lhkpn_for_nip" in fn_names
     assert "harvest_lhkpn_by_name" in fn_names
+    assert "harvest_lhkpn_for_person" in fn_names
 
 
 def test_genome_md_exists_and_has_constraints():


### PR DESCRIPTION
## Summary
- add harvest_lhkpn_for_person(name, nip) for post-2026 KPK portal behavior
- resolve legacy LHKPN gaps with known name+NIP directly via the local scraper tool
- avoid qwen/Ollama tool-call timeouts for deterministic LHKPN enrichment

## Runtime proof
- installed missing Playwright Chromium in OSINT-Nexus venv on Pro
- processed pending LHKPN gap 1781798461400-0: status=resolved, garuda:raw 3926->3927, still_pending=false

## Tests
- PYTHONPATH=. ~/Desktop/nuzantara/apps/mata-garuda/.venv/bin/python -m pytest tests/test_lhkpn_harvester.py tests/test_gap_consumer.py tests/test_lamarckian.py tests/test_ollama_tools.py -q