### PR TITLE
fix(mata-garuda): skip unresolved LHKPN name gaps

### DIFF
--- a/apps/mata-garuda/mata_garuda/workers/gap_consumer.py
+++ b/apps/mata-garuda/mata_garuda/workers/gap_consumer.py
@@ -103,6 +103,14 @@ def _payload_has_nip(payload: dict[str, Any]) -> bool:
     return False
 
 
+def _payload_has_person_name(payload: dict[str, Any]) -> bool:
+    """True when the payload carries a usable official/person name."""
+    for key in ("entity_name", "person_name", "name"):
+        if str(payload.get(key, "")).strip():
+            return True
+    return False
+
+
 def _lhkpn_terminal_skip_reason(gap_type: str, payload: dict[str, Any]) -> str | None:
     """Return a reason when an LHKPN gap is structurally unresolvable today.
 
@@ -116,6 +124,8 @@ def _lhkpn_terminal_skip_reason(gap_type: str, payload: dict[str, Any]) -> str |
         return "lhkpn_portal_does_not_expose_angkatan"
     if gap_type == "gap.missing_lhkpn" and not _payload_has_nip(payload):
         return "lhkpn_profile_fetch_requires_existing_nip"
+    if gap_type == "gap.missing_lhkpn" and not _payload_has_person_name(payload):
+        return "lhkpn_portal_search_requires_person_name"
     return None
 
 

--- a/apps/mata-garuda/tests/test_gap_consumer.py
+++ b/apps/mata-garuda/tests/test_gap_consumer.py
@@ -167,9 +167,9 @@ def test_process_gap_skips_lhkpn_missing_lhkpn_without_nip():
     assert result["reason"] == "lhkpn_profile_fetch_requires_existing_nip"
 
 
-def test_process_gap_dispatches_lhkpn_missing_lhkpn_when_nip_present():
-    """gap.missing_lhkpn with an existing NIP remains dispatchable."""
-    fake_dispatch = MagicMock(return_value={"case_resolved": True})
+def test_process_gap_skips_lhkpn_missing_lhkpn_without_name():
+    """The current KPK portal searches by name, not by NIP alone."""
+    fake_dispatch = MagicMock()
     fake_xack = MagicMock()
 
     result = process_gap(
@@ -180,13 +180,9 @@ def test_process_gap_dispatches_lhkpn_missing_lhkpn_when_nip_present():
         xack=fake_xack,
     )
 
-    fake_dispatch.assert_called_once()
-    call_kwargs = fake_dispatch.call_args.kwargs
-    assert call_kwargs["agent_name"] == "lhkpn_harvester"
-    assert call_kwargs["payload"]["entity_nip"] == "123"
-    assert call_kwargs["payload"]["_gap_type"] == "gap.missing_lhkpn"
-    assert result["status"] == "resolved"
-    assert result["agent"] == "lhkpn_harvester"
+    fake_dispatch.assert_not_called()
+    assert result["status"] == "skipped"
+    assert result["reason"] == "lhkpn_portal_search_requires_person_name"
     fake_xack.assert_called_once()
 
 
@@ -346,7 +342,7 @@ def test_process_gap_dispatch_exception_caught_no_ack():
 
     result = process_gap(
         msg_id="6-0",
-        gap_type="gap.missing_lhkpn",
+        gap_type="gap.stale_official",
         payload={"entity_nip": "123"},
         dispatch_agent=fake_dispatch,
         xack=fake_xack,
@@ -383,9 +379,10 @@ def test_run_gap_consumer_processes_batch():
     )
 
     assert stats["read"] == 2
-    assert stats["resolved"] == 2
+    assert stats["resolved"] == 1
+    assert stats["skipped"] == 1
     assert stats["failed"] == 0
-    assert fake_dispatch.call_count == 2
+    assert fake_dispatch.call_count == 1
     assert fake_xack.call_count == 2
 
 
@@ -536,10 +533,10 @@ def test_run_gap_consumer_mixed_canonical_and_legacy_batch():
     )
 
     assert stats["read"] == 3
-    assert stats["resolved"] == 2  # canonical + mappable legacy
-    assert stats["skipped"] == 1   # drained legacy
-    assert fake_dispatch.call_count == 2
-    # All three entries got acked (2 via process_gap on resolve, 1 via drain)
+    assert stats["resolved"] == 1  # canonical regulation gap
+    assert stats["skipped"] == 2   # LHKPN without name + drained legacy
+    assert fake_dispatch.call_count == 1
+    # All three entries got acked (1 resolve, 2 skip/drain)
     assert fake_xack.call_count == 3
 
 


### PR DESCRIPTION
## Summary
- skip gap.missing_lhkpn payloads that have NIP but no person name
- avoid falling back to qwen for LHKPN cases the KPK portal cannot search
- update gap consumer tests for the post-2026 KPK search constraint

## Verification
- PYTHONPATH=. /Users/nuzantara/Desktop/nuzantara/apps/mata-garuda/.venv/bin/python -m pytest tests/test_lhkpn_harvester.py tests/test_gap_consumer.py tests/test_lhkpn_tools.py tests/test_ollama_tools.py -q
