### PR TITLE
feat(organism): A4 generator≠grader workflow template (doctrine→reusable artifact)

### DIFF
--- a/infra/workflows/README.md
+++ b/infra/workflows/README.md
@@ -1,0 +1,32 @@
+# infra/workflows — reusable Workflow templates
+
+Versioned, repo-tracked Workflow scripts (the `Workflow` tool's `scriptPath` input).
+Born from the self-loop plan Anello 4: the generator≠grader pattern was well-documented
+in the `sota-architecture-loop` skill but only ever EXECUTED via ad-hoc, ephemeral
+session files (`<session>/workflows/scripts/*.js`) that vanish. These are the durable,
+citable artifacts.
+
+## verify-template.js — generator≠grader (gather → adversarial-verify → synthesize)
+
+The one principle of the whole self-loop: **judging < generating**. A finding survives
+ONLY if an INDEPENDENT skeptic on FRESH context could not refute it (the grader is never
+the generator — no self-approval; the W65 lesson).
+
+Run it for any research / audit / multi-claim verification:
+
+```
+Workflow({ scriptPath: "infra/workflows/verify-template.js", args: {
+  question: "the question to answer",
+  angles: [ { key: "a", prompt: "lens A …" }, { key: "b", prompt: "lens B …" } ],
+  synthesisPrompt: "(optional) how to merge survivors",
+  skeptics: 1            // 1 default; 3 for high-stakes (security / regulatory / client-quote)
+}})
+```
+
+Returns `{ synthesis, survivors, refutedCount, anglesRun }`. Calibration follows
+`sota-architecture-loop` §3/6: one strong skeptic by default (troublemaker), not consensus,
+not a massacre. Heterogeneity > numerosity — give each angle a DISTINCT lens.
+
+**Doctrine reference**: skill `sota-architecture-loop` ("verifica esterna batte
+autodichiarazione · adversarialità calibrata batte consenso") + `opus-mythos` (never trust
+your own subagent). This file is the doctrine made executable & reusable.

--- a/infra/workflows/verify-template.js
+++ b/infra/workflows/verify-template.js
@@ -1,0 +1,132 @@
+// verify-template.js — the generator≠grader workflow, promoted to a reusable repo artifact.
+//
+// Self-loop plan Anello 4 (research/operations/2026-06-23-self-loop-implementation-plan.md).
+// The Anthropic self-improvement research found that our most mature loop is "never trust
+// your own subagent + verify on fresh context" (opus-mythos TAC + the sota-architecture-loop
+// skill). The DOCTRINE already exists (sota-architecture-loop: "verifica esterna batte
+// autodichiarazione · adversarialità calibrata batte consenso"). What was MISSING is a
+// reusable EXECUTABLE artifact — every research/audit re-wrote the gather→verify→synthesize
+// workflow ad-hoc in ephemeral session files that vanish. This is that artifact, versioned.
+//
+// WHAT IT ENCODES (the one principle of the whole self-loop): "judging < generating".
+// A finding survives ONLY if an INDEPENDENT grader on FRESH context could not refute it.
+// The grader is a different agent than the generator (no self-approval — the W65 lesson:
+// even the refuter hallucinates, but a generator grading itself is strictly worse).
+//
+// HOW TO RUN (from the main loop, when a task is research / audit / multi-claim verification):
+//   Workflow({ scriptPath: "infra/workflows/verify-template.js", args: {
+//     question: "the question to answer",
+//     angles: [ { key: "angleA", prompt: "research angle A …" }, … ],   // 2-6 distinct lenses
+//     synthesisPrompt: "how to merge the verified findings (optional)",
+//     skeptics: 1,                                                       // graders per finding (1 default; 3 for high-stakes)
+//   }})
+// Omit `angles` and it falls back to a single-angle pass on `question`.
+//
+// CALIBRATION (sota-architecture-loop §3/6): NOT pure-adversarial, NOT consensus. The default
+// is one strong skeptic per finding (the "troublemaker"); set skeptics:3 for high-stakes
+// (security / regulatory / client-quote) and a finding survives on majority-not-refuted.
+// Heterogeneity > numerosity: give each angle a DISTINCT lens, not N copies of one.
+
+export const meta = {
+  name: 'verify-template',
+  description: 'Reusable generator≠grader workflow: gather N angles → adversarially verify each → synthesize survivors',
+  phases: [
+    { title: 'Gather', detail: 'one agent per angle, structured findings' },
+    { title: 'Verify', detail: 'independent skeptic(s) per finding on fresh context — refute or keep' },
+    { title: 'Synthesize', detail: 'merge only findings that survived refutation' },
+  ],
+}
+
+// ----- input (args), with safe fallbacks ------------------------------------
+const A = (typeof args === 'string' ? JSON.parse(args) : args) || {}
+const QUESTION = A.question || 'No question provided (pass args.question).'
+const ANGLES = Array.isArray(A.angles) && A.angles.length
+  ? A.angles
+  : [{ key: 'single', prompt: QUESTION }]
+const SKEPTICS = Math.max(1, Math.min(5, A.skeptics || 1))
+const SYNTH_PROMPT = A.synthesisPrompt ||
+  `Synthesize a cited answer to: "${QUESTION}". Use ONLY findings that survived refutation. ` +
+  `Be explicit about what is well-sourced vs inferred. No fluff.`
+
+// structured finding schema — forces each claim to carry its own evidence + self-rated confidence
+const FINDING_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['angle', 'findings'],
+  properties: {
+    angle: { type: 'string' },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object', additionalProperties: false,
+        required: ['claim', 'evidence', 'source', 'confidence'],
+        properties: {
+          claim: { type: 'string' },
+          evidence: { type: 'string', description: 'the concrete basis — quote/path/number' },
+          source: { type: 'string', description: 'real URL/file:line you actually checked, or "INFERENCE"' },
+          confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+        },
+      },
+    },
+  },
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['refuted', 'reason'],
+  properties: {
+    refuted: { type: 'boolean', description: 'true if the claim is false/overstated/unsupported' },
+    reason: { type: 'string' },
+    confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+  },
+}
+
+// ----- the pipeline: gather → verify (per finding) → collect survivors -------
+phase('Gather')
+const perAngle = await pipeline(
+  ANGLES,
+  a => agent(
+    a.prompt + '\n\nReturn structured findings. Cite a REAL source you actually checked; ' +
+    'mark INFERENCE if it is not from a source.',
+    { label: `gather:${a.key}`, phase: 'Gather', schema: FINDING_SCHEMA }
+  ),
+  // verify each finding of this angle with independent skeptic(s) on fresh context
+  (res, a) => {
+    if (!res || !res.findings) return { angle: a.key, verified: [] }
+    return parallel(res.findings.map(f => () =>
+      parallel(Array.from({ length: SKEPTICS }, (_unused, i) => () =>
+        agent(
+          `You are skeptic #${i + 1}, an INDEPENDENT adversarial grader. Try to REFUTE this claim. ` +
+          `It is suspect if the source is vague/invented, the evidence is hand-wavy, or it overstates. ` +
+          `Default to refuted=true when uncertain. Verify the source if you can.\n\n` +
+          `CLAIM: ${f.claim}\nEVIDENCE: ${f.evidence}\nSOURCE: ${f.source} (self-rated ${f.confidence})`,
+          { label: `verify:${a.key}`, phase: 'Verify', schema: VERDICT_SCHEMA }
+        )
+      )).then(votes => {
+        const v = votes.filter(Boolean)
+        const refutedCount = v.filter(x => x.refuted).length
+        const survives = refutedCount < Math.ceil(v.length / 2)   // majority-not-refuted
+        return { ...f, survives, refutedCount, votes: v.length }
+      })
+    )).then(checked => ({ angle: a.key, verified: checked.filter(Boolean) }))
+  }
+)
+
+phase('Synthesize')
+const survivors = perAngle.filter(Boolean).flatMap(r =>
+  (r.verified || []).filter(f => f.survives).map(f => ({ angle: r.angle, ...f }))
+)
+const refuted = perAngle.filter(Boolean).flatMap(r =>
+  (r.verified || []).filter(f => !f.survives)
+)
+log(`survivors: ${survivors.length} · refuted/dropped: ${refuted.length}`)
+
+const corpus = survivors.map(f =>
+  `### ${f.angle}\n- ${f.claim}\n  evidence: ${f.evidence} [${f.confidence}] (${f.source})`
+).join('\n\n')
+
+const synthesis = survivors.length
+  ? await agent(`${SYNTH_PROMPT}\n\nVERIFIED FINDINGS (survived refutation):\n${corpus}`,
+      { label: 'synthesize', phase: 'Synthesize' })
+  : 'No findings survived adversarial refutation — the question needs better sources or re-scoping.'
+
+return { synthesis, survivors, refutedCount: refuted.length, anglesRun: ANGLES.length }


### PR DESCRIPTION
## What — self-loop plan, Anello 4

The generator≠grader pattern is well-documented in the `sota-architecture-loop` skill ("verifica esterna batte autodichiarazione · adversarialità calibrata batte consenso") and `opus-mythos` (never trust your own subagent). But it was only ever **executed** via ad-hoc, ephemeral session files (`<session>/workflows/scripts/*.js`) that vanish. Every research/audit re-wrote `gather→verify→synthesize` from scratch — including this session's Anthropic research and the 7-perspective test of A1.

This is the **durable, citable artifact**: doctrine made executable & reusable.

## How

`infra/workflows/verify-template.js` — parameterized via `args`:
- **gather**: one agent per angle, structured findings (each carries its own evidence + source + self-rated confidence)
- **verify**: independent skeptic(s) per finding, on **fresh context**, prompted to REFUTE (grader ≠ generator — the W65 lesson: even refuters hallucinate, but self-grading is strictly worse). Majority-not-refuted survives.
- **synthesize**: only survivors.

Calibration per `sota-architecture-loop` §3/6: one strong skeptic default (troublemaker), `skeptics:3` for high-stakes (security/regulatory/client-quote), never consensus, never a massacre. Heterogeneity > numerosity.

## Validation

Body parses in async context (the Workflow runtime). `node --check` on the raw file *falsely* flags top-level `return`/`await` — the working session workflows (e.g. this session's Anthropic research, 9 agents, ran fine) have the identical shape. `meta` is a pure literal.

The principle this encodes is the same one the whole self-loop rests on: **judging < generating**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)