### PR TITLE
fix(voice): prevent local audio IPC hangs

### DIFF
--- a/apps/backend-rag/backend/app/services/local_audio/chatterbox.py
+++ b/apps/backend-rag/backend/app/services/local_audio/chatterbox.py
@@ -7,7 +7,6 @@ import importlib
 import importlib.util
 import multiprocessing as mp
 import os
-import queue
 import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -308,11 +307,11 @@ def _run_chatterbox_generation_process(
         raise TimeoutError("Chatterbox generate concurrency limit reached")
 
     context = mp.get_context("spawn")
-    result_queue = context.Queue(maxsize=1)
+    result_receiver, result_sender = context.Pipe(duplex=False)
     process = context.Process(
         target=_run_chatterbox_generation_child,
         args=(
-            result_queue,
+            result_sender,
             text,
             str(output_path),
             module_name,
@@ -325,6 +324,7 @@ def _run_chatterbox_generation_process(
 
     try:
         process.start()
+        result_sender.close()
         process.join(timeout_seconds)
         if process.is_alive():
             process.terminate()
@@ -334,9 +334,14 @@ def _run_chatterbox_generation_process(
                 process.join(timeout=1.0)
             raise TimeoutError(f"Chatterbox generate timed out after {timeout_seconds}s")
 
+        if not result_receiver.poll():
+            exit_code = process.exitcode
+            raise RuntimeError(
+                f"Chatterbox generate process exited without result: {exit_code}",
+            )
         try:
-            result = result_queue.get_nowait()
-        except queue.Empty as exc:
+            result = result_receiver.recv()
+        except EOFError as exc:
             exit_code = process.exitcode
             raise RuntimeError(
                 f"Chatterbox generate process exited without result: {exit_code}",
@@ -349,13 +354,13 @@ def _run_chatterbox_generation_process(
             raise RuntimeError(f"Chatterbox generate failed: {result[1]}")
         raise RuntimeError("Chatterbox generate returned an invalid result")
     finally:
-        result_queue.close()
-        result_queue.join_thread()
+        result_receiver.close()
+        result_sender.close()
         _CHATTERBOX_PROCESS_SEMAPHORE.release()
 
 
 def _run_chatterbox_generation_child(
-    result_queue: Any,
+    result_sender: Any,
     text: str,
     output_path: str,
     module_name: str,
@@ -372,9 +377,11 @@ def _run_chatterbox_generation_child(
             t3_model=t3_model,
             language_id=language_id,
         )
-        result_queue.put(("ok", None))
+        result_sender.send(("ok", None))
     except BaseException as exc:
-        result_queue.put(("error", type(exc).__name__))
+        result_sender.send(("error", type(exc).__name__))
+    finally:
+        result_sender.close()
 
 
 def _generate_chatterbox_wav_in_current_process(

--- a/apps/backend-rag/backend/app/services/local_audio/silero_vad.py
+++ b/apps/backend-rag/backend/app/services/local_audio/silero_vad.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import asyncio
 import importlib
 import importlib.util
+import json
 import multiprocessing as mp
 import os
-import queue
+import tempfile
 import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -174,50 +175,60 @@ def _run_silero_detection_process(
         raise TimeoutError("Silero VAD concurrency limit reached")
 
     context = mp.get_context("spawn")
-    result_queue = context.Queue(maxsize=1)
-    process = context.Process(
-        target=_run_silero_detection_child,
-        args=(
-            result_queue,
-            str(audio_path),
-            module_name,
-            sampling_rate,
-            threshold,
-        ),
-    )
-    process.daemon = True
-
-    try:
-        process.start()
-        process.join(timeout_seconds)
-        if process.is_alive():
-            process.terminate()
-            process.join(timeout=1.0)
-            if process.is_alive():
-                process.kill()
-                process.join(timeout=1.0)
-            raise TimeoutError(f"Silero VAD timed out after {timeout_seconds}s")
+    with tempfile.TemporaryDirectory(prefix="silero-vad-") as tmpdir:
+        result_path = Path(tmpdir) / "segments.json"
+        result_receiver, result_sender = context.Pipe(duplex=False)
+        process = context.Process(
+            target=_run_silero_detection_child,
+            args=(
+                result_sender,
+                str(result_path),
+                str(audio_path),
+                module_name,
+                sampling_rate,
+                threshold,
+            ),
+        )
+        process.daemon = True
 
         try:
-            result = result_queue.get_nowait()
-        except queue.Empty as exc:
-            exit_code = process.exitcode
-            raise RuntimeError(f"Silero VAD process exited without result: {exit_code}") from exc
+            process.start()
+            result_sender.close()
+            process.join(timeout_seconds)
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=1.0)
+                if process.is_alive():
+                    process.kill()
+                    process.join(timeout=1.0)
+                raise TimeoutError(f"Silero VAD timed out after {timeout_seconds}s")
 
-        status = result[0]
-        if status == "ok":
-            return result[1]
-        if status == "error":
-            raise RuntimeError(f"Silero VAD failed: {result[1]}")
-        raise RuntimeError("Silero VAD returned an invalid result")
-    finally:
-        result_queue.close()
-        result_queue.join_thread()
-        _SILERO_PROCESS_SEMAPHORE.release()
+            if not result_receiver.poll():
+                exit_code = process.exitcode
+                raise RuntimeError(f"Silero VAD process exited without result: {exit_code}")
+            try:
+                result = result_receiver.recv()
+            except EOFError as exc:
+                exit_code = process.exitcode
+                raise RuntimeError(
+                    f"Silero VAD process exited without result: {exit_code}",
+                ) from exc
+
+            status = result[0]
+            if status == "ok":
+                return _read_silero_result_file(result_path)
+            if status == "error":
+                raise RuntimeError(f"Silero VAD failed: {result[1]}")
+            raise RuntimeError("Silero VAD returned an invalid result")
+        finally:
+            result_receiver.close()
+            result_sender.close()
+            _SILERO_PROCESS_SEMAPHORE.release()
 
 
 def _run_silero_detection_child(
-    result_queue: Any,
+    result_sender: Any,
+    result_path: str,
     audio_path: str,
     module_name: str,
     sampling_rate: int,
@@ -230,9 +241,31 @@ def _run_silero_detection_child(
             sampling_rate=sampling_rate,
             threshold=threshold,
         )
-        result_queue.put(("ok", segments))
+        Path(result_path).write_text(json.dumps(segments), encoding="utf-8")
+        result_sender.send(("ok", None))
     except BaseException as exc:
-        result_queue.put(("error", type(exc).__name__))
+        result_sender.send(("error", type(exc).__name__))
+    finally:
+        result_sender.close()
+
+
+def _read_silero_result_file(result_path: Path) -> list[tuple[float, float]]:
+    try:
+        payload = json.loads(result_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise RuntimeError("Silero VAD process exited without result file") from exc
+    if not isinstance(payload, list):
+        raise RuntimeError("Silero VAD returned an invalid result file")
+    segments: list[tuple[float, float]] = []
+    for item in payload:
+        if (
+            not isinstance(item, list)
+            or len(item) != 2
+            or not all(isinstance(value, (int, float)) for value in item)
+        ):
+            raise RuntimeError("Silero VAD returned an invalid result file")
+        segments.append((float(item[0]), float(item[1])))
+    return segments
 
 
 def _detect_silero_segments_in_current_process(

--- a/apps/backend-rag/backend/tests/unit/app/services/local_audio/test_runtime_stubs.py
+++ b/apps/backend-rag/backend/tests/unit/app/services/local_audio/test_runtime_stubs.py
@@ -419,12 +419,16 @@ def test_chatterbox_model_loader_uses_local_checkpoint_and_v3_selector(
 def test_chatterbox_process_timeout_terminates_child(monkeypatch, tmp_path) -> None:
     events: list[str] = []
 
-    class FakeQueue:
-        def close(self) -> None:
-            events.append("queue.close")
+    class FakeReceiver:
+        def poll(self) -> bool:
+            return False
 
-        def join_thread(self) -> None:
-            events.append("queue.join_thread")
+        def close(self) -> None:
+            events.append("receiver.close")
+
+    class FakeSender:
+        def close(self) -> None:
+            events.append("sender.close")
 
     class FakeProcess:
         daemon = False
@@ -450,9 +454,12 @@ def test_chatterbox_process_timeout_terminates_child(monkeypatch, tmp_path) -> N
             events.append("process.kill")
 
     class FakeContext:
-        def Queue(self, *, maxsize: int) -> FakeQueue:
-            assert maxsize == 1
-            return FakeQueue()
+        def Pipe(self, *, duplex: bool) -> tuple[FakeReceiver, FakeSender]:
+            assert duplex is False
+            return FakeReceiver(), FakeSender()
+
+        def Queue(self, *args, **kwargs) -> None:
+            raise AssertionError("Chatterbox process IPC must use Pipe, not Queue")
 
         def Process(self, *args, **kwargs) -> FakeProcess:
             return FakeProcess()
@@ -471,7 +478,61 @@ def test_chatterbox_process_timeout_terminates_child(monkeypatch, tmp_path) -> N
         )
 
     assert "process.terminate" in events
-    assert events[-2:] == ["queue.close", "queue.join_thread"]
+    assert "receiver.close" in events
+    assert "sender.close" in events
+
+
+def test_chatterbox_process_missing_pipe_payload_is_sanitized(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    class FakeReceiver:
+        def poll(self) -> bool:
+            return True
+
+        def recv(self):
+            raise EOFError
+
+        def close(self) -> None:
+            pass
+
+    class FakeSender:
+        def close(self) -> None:
+            pass
+
+    class FakeProcess:
+        daemon = False
+        exitcode = 0
+
+        def start(self) -> None:
+            pass
+
+        def join(self, timeout=None) -> None:
+            pass
+
+        def is_alive(self) -> bool:
+            return False
+
+    class FakeContext:
+        def Pipe(self, *, duplex: bool) -> tuple[FakeReceiver, FakeSender]:
+            assert duplex is False
+            return FakeReceiver(), FakeSender()
+
+        def Process(self, *args, **kwargs) -> FakeProcess:
+            return FakeProcess()
+
+    monkeypatch.setattr(chatterbox_module.mp, "get_context", lambda _name: FakeContext())
+
+    with pytest.raises(RuntimeError, match="exited without result: 0"):
+        chatterbox_module._run_chatterbox_generation_process(
+            "ciao",
+            tmp_path / "out.wav",
+            module_name="chatterbox",
+            model_path=tmp_path / "model",
+            t3_model="v3",
+            language_id="en",
+            timeout_seconds=0.01,
+        )
 
 
 def test_silero_status_unavailable_when_runtime_missing(monkeypatch) -> None:
@@ -730,12 +791,16 @@ def test_silero_current_process_forces_offline_runtime_env(monkeypatch) -> None:
 def test_silero_process_timeout_terminates_child(monkeypatch) -> None:
     events: list[str] = []
 
-    class FakeQueue:
-        def close(self) -> None:
-            events.append("queue.close")
+    class FakeReceiver:
+        def poll(self) -> bool:
+            return False
 
-        def join_thread(self) -> None:
-            events.append("queue.join_thread")
+        def close(self) -> None:
+            events.append("receiver.close")
+
+    class FakeSender:
+        def close(self) -> None:
+            events.append("sender.close")
 
     class FakeProcess:
         daemon = False
@@ -761,9 +826,12 @@ def test_silero_process_timeout_terminates_child(monkeypatch) -> None:
             events.append("process.kill")
 
     class FakeContext:
-        def Queue(self, *, maxsize: int) -> FakeQueue:
-            assert maxsize == 1
-            return FakeQueue()
+        def Pipe(self, *, duplex: bool) -> tuple[FakeReceiver, FakeSender]:
+            assert duplex is False
+            return FakeReceiver(), FakeSender()
+
+        def Queue(self, *args, **kwargs) -> None:
+            raise AssertionError("Silero process IPC must use Pipe, not Queue")
 
         def Process(self, *args, **kwargs) -> FakeProcess:
             return FakeProcess()
@@ -780,7 +848,56 @@ def test_silero_process_timeout_terminates_child(monkeypatch) -> None:
         )
 
     assert "process.terminate" in events
-    assert events[-2:] == ["queue.close", "queue.join_thread"]
+    assert "receiver.close" in events
+    assert "sender.close" in events
+
+
+def test_silero_process_missing_pipe_payload_is_sanitized(monkeypatch) -> None:
+    class FakeReceiver:
+        def poll(self) -> bool:
+            return True
+
+        def recv(self):
+            raise EOFError
+
+        def close(self) -> None:
+            pass
+
+    class FakeSender:
+        def close(self) -> None:
+            pass
+
+    class FakeProcess:
+        daemon = False
+        exitcode = 0
+
+        def start(self) -> None:
+            pass
+
+        def join(self, timeout=None) -> None:
+            pass
+
+        def is_alive(self) -> bool:
+            return False
+
+    class FakeContext:
+        def Pipe(self, *, duplex: bool) -> tuple[FakeReceiver, FakeSender]:
+            assert duplex is False
+            return FakeReceiver(), FakeSender()
+
+        def Process(self, *args, **kwargs) -> FakeProcess:
+            return FakeProcess()
+
+    monkeypatch.setattr(silero_vad_module.mp, "get_context", lambda _name: FakeContext())
+
+    with pytest.raises(RuntimeError, match="exited without result: 0"):
+        silero_vad_module._run_silero_detection_process(
+            Path("/tmp/sample.wav"),
+            module_name="silero_vad",
+            sampling_rate=16000,
+            threshold=0.5,
+            timeout_seconds=0.01,
+        )
 
 
 def test_optional_silero_runtime_import_smoke() -> None:


### PR DESCRIPTION
## Summary
- replace local Chatterbox/Silero multiprocessing Queue IPC with one-way Pipe IPC
- keep large Silero segment payloads out of the pipe via a temporary result file
- add regression tests for timeout cleanup and closed-pipe/no-payload cases

## Verification
- `PYTHONPATH=. pytest backend/tests/unit/app/services/local_audio/test_runtime_stubs.py backend/tests/unit/app/routers/test_voice_legacy.py -q` -> 59 passed, 1 skipped
- `ruff check backend/app/services/local_audio/chatterbox.py backend/app/services/local_audio/silero_vad.py backend/tests/unit/app/services/local_audio/test_runtime_stubs.py` -> passed
- runtime smoke on Pro backend + Air frontend:
  - `/lab/voice-concierge` -> 200
  - `/api/lab/voice-concierge/status` -> backend source, VAD ready, TTS ready, STT gated by missing large-v3-turbo
  - `/api/lab/voice-concierge/synthesize` -> 200 audio/wav in 27.4s while status remained responsive
  - `/api/lab/voice-concierge/transcribe` -> expected STT gate failure until large-v3-turbo is installed

## Notes
- Whisper production roundtrip is still blocked by missing `large-v3-turbo` model on Pro.
- The runtime smoke patch was copied into the Pro smoke worktree only for validation; the authoritative change is this branch.
