### PR TITLE
feat(self-loop): arm A2 — output_artifact mode + first pilot (intel_nightly)

### DIFF
--- a/apps/organism/organism/organs_registry.yaml
+++ b/apps/organism/organism/organs_registry.yaml
@@ -363,6 +363,14 @@ organs:
       label: com.balizero.intel.nightly
     severity_on_silence: warning
     cicatrix_refs: []
+    # A2 Heartbeat-Semantico opt-in (first pilot, 2026-06-23). The nightly intel job
+    # EXISTS to add scraped articles; its output artifact grows on real work. A2 flags
+    # 'starved' if the artifact is byte-identical (mtime_ns+size unchanged) across
+    # STARVED_TICKS=3 ticks — i.e. 3 consecutive nights of ZERO new articles, a real
+    # stall the bare heartbeat (ts fresh + status ok) cannot see. CAVEAT (operator-
+    # accepted): published_articles.json is repo-tracked, so a manual edit could reset
+    # the streak — unlikely to mask a genuine 3-night stall.
+    output_artifact: ~/Desktop/nuzantara/apps/bali-intel-scraper/data/published_articles.json
     bridge_source:
       type: state_file
       path: ~/.agent/decisions/state/intel_scraper.last.json

--- a/scripts/sentinel-aggregate.py
+++ b/scripts/sentinel-aggregate.py
@@ -80,15 +80,35 @@ def _read_prior_snapshot() -> dict[str, dict[str, Any]]:
 
 def _progress_value(hb: dict[str, Any] | None, organ: dict[str, Any]) -> Any:
     """A2: the organ's OUTPUT-progress signal — what must ADVANCE for the organ to be alive,
-    not merely fresh. The field name is registry-declared (`progress_field`); we read it off
-    the already-loaded heartbeat dict. Returns None when no progress field is declared/present
-    (→ organ opts out of A2, classified the classic way — additive, never regresses #9)."""
-    if hb is None:
-        return None
+    not merely fresh. Two declaration modes (registry-driven, both OPT-IN, additive #9):
+
+      1. progress_field — read a value off the already-loaded heartbeat dict. Use when the
+         organ ALREADY emits a monotone counter in its payload (no writer-change needed).
+
+      2. output_artifact — a filesystem path the organ PRODUCES. We return a (mtime_ns, size)
+         tuple: "did output advance?" becomes "did the artifact change on disk?". This needs
+         ZERO writer-change to any H24 organ — A2 observes the artifact, not the heartbeat.
+         CRITICAL (anti-false-alarm): mtime is a real advance-signal ONLY when the writer
+         REWRITES the artifact on real work and leaves it untouched otherwise — which is the
+         normal case (a scraper appends to its JSON, a renderer overwrites its output). A
+         writer that re-stamps the file every tick regardless of work would defeat this; such
+         organs must NOT declare output_artifact (they have no honest disk progress signal).
+
+    Returns None when neither is declared / the artifact is missing → organ opts out of A2,
+    classified the classic way. NEVER raises (a stat() failure = opt-out, not a crash)."""
     field = organ.get("progress_field")
-    if not field:
-        return None
-    return hb.get(field)
+    if field and hb is not None:
+        return hb.get(field)
+    artifact = organ.get("output_artifact")
+    if artifact:
+        try:
+            st = Path(os.path.expanduser(str(artifact))).stat()
+        except OSError:
+            return None  # missing/unreadable artifact → opt out, not a false starve
+        # JSON-serialisable tuple → list; survives the aggregate.json round-trip so the
+        # prior-snapshot comparison in _classify works byte-identically across ticks.
+        return [st.st_mtime_ns, st.st_size]
+    return None
 
 
 def _now_epoch() -> float:

--- a/scripts/test_sentinel_starved.py
+++ b/scripts/test_sentinel_starved.py
@@ -20,8 +20,11 @@ Exit 0 = all pass.
 """
 from __future__ import annotations
 import importlib.util
+import os
 import pathlib
 import sys
+import tempfile
+import time
 
 HERE = pathlib.Path(__file__).resolve().parent
 spec = importlib.util.spec_from_file_location("sentinel_aggregate", str(HERE / "sentinel-aggregate.py"))
@@ -120,7 +123,47 @@ def main() -> int:
     check("guilt-recovery: a single output advance clears starved back to ok",
           r["status"] == "ok" and r.get("starved_streak") == 0)
 
-    total = 10
+    # ======================================================================
+    # ARTIFACT-MTIME mode — the honest opt-in for organs whose payload has NO
+    # monotone field: A2 observes the OUTPUT ARTIFACT on disk (mtime_ns,size),
+    # zero writer-change. Same innocence+guilt discipline.
+    # ======================================================================
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    art = tmp / "scraped.json"
+    art.write_text("[]")
+
+    def _art_organ():
+        # NO progress_field; declares output_artifact instead.
+        return {"id": "demo.scraper", "runtime": "cron", "type": "cron",
+                "expected_hb_seconds": 3600, "severity_on_silence": "warning",
+                "output_artifact": str(art)}
+
+    # INNOCENCE A: missing artifact → opt out (None), never starved even with prior.
+    miss = {"id": "x", "runtime": "cron", "type": "cron", "expected_hb_seconds": 3600,
+            "severity_on_silence": "warning", "output_artifact": str(tmp / "nope.json")}
+    r = _classify(miss, _hb(60), prior={"progress_value": [1, 2], "starved_streak": 9})
+    check("artifact innocence: missing artifact opts out (ok, no progress_value, never starved)",
+          r["status"] == "ok" and "progress_value" not in r)
+
+    # INNOCENCE B: artifact CHANGED on disk between ticks → advance → streak stays 0.
+    r1 = _classify(_art_organ(), _hb(60), prior=None)
+    pv1 = r1.get("progress_value")
+    check("artifact innocence: first observation records [mtime_ns,size], streak 0",
+          isinstance(pv1, list) and len(pv1) == 2 and r1.get("starved_streak") == 0)
+    time.sleep(0.01)
+    art.write_text('[{"id":1}]')  # real work: artifact rewritten (mtime + size change)
+    r2 = _classify(_art_organ(), _hb(60), prior={"progress_value": pv1, "starved_streak": 2})
+    check("artifact innocence: artifact rewrite (output advanced) -> streak resets to 0, ok",
+          r2["status"] == "ok" and r2.get("starved_streak") == 0 and r2.get("progress_value") != pv1)
+
+    # GUILT: artifact UNCHANGED on disk across STARVED_TICKS ticks -> starved.
+    pv = r2.get("progress_value")  # current on-disk signal; we now freeze the file
+    prior = {"progress_value": pv, "starved_streak": S.STARVED_TICKS - 1}
+    r = _classify(_art_organ(), _hb(60), prior=prior)  # file untouched since pv captured
+    check(f"artifact guilt: frozen artifact for STARVED_TICKS={S.STARVED_TICKS} ticks -> starved",
+          r["status"] == "starved")
+
+    total = 14
     print(f"\n=== {'ALL ' + str(total) + ' PASS' if not fails else str(fails) + ' FAIL'} ===")
     return 1 if fails else 0
 


### PR DESCRIPTION
## What

Takes A2 Heartbeat-Semantico (PR #1691) from **dormant capability** to **armed**.

### The problem (empirically falsified, 4 candidates)
A2 'starved' could only read a monotone field from the heartbeat payload. Inspecting the **real** payloads on Pro: **no organ emits one**. The counters are gauges (`dlq queue_size` up AND down) or reset-per-run (`translate total/sent=0` at idle). Pointing `progress_field` at any → guaranteed false `starved` (superscar #3 over-match).

### Fix — `output_artifact` mode (zero writer-change)
Second OPT-IN mode in `_progress_value`: declare a **filesystem path the organ produces**. "Did output advance?" → "did the artifact change on disk?" (`[mtime_ns, size]`). A2 observes the **artifact**, not the heartbeat → **no H24 writer touched**. Anti-false-alarm contract documented; missing/unreadable → opt out, never raises. Additive (#9).

### First pilot — `pro.intel_nightly`
Opts in the nightly scraper; A2 flags `starved` if `published_articles.json` is byte-identical across `STARVED_TICKS=3` = 3 nights of zero new articles. **Caveat (operator-accepted, Zero):** file is repo-tracked → manual edit could reset streak; unlikely over 3 nights; switch to runtime artifact/counter if noisy.

## Test
- `test_sentinel_starved.py` 10→14 (artifact innocence + guilt)
- `scar_A2` gate ARMED, meta-verifier GREEN (`--scope repo`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)