### PR TITLE
fix(self-loop): A2 artifact signal = content-hash not mtime (un-defeat the pilot)

### DIFF
--- a/apps/organism/organism/organs_registry.yaml
+++ b/apps/organism/organism/organs_registry.yaml
@@ -364,12 +364,15 @@ organs:
     severity_on_silence: warning
     cicatrix_refs: []
     # A2 Heartbeat-Semantico opt-in (first pilot, 2026-06-23). The nightly intel job
-    # EXISTS to add scraped articles; its output artifact grows on real work. A2 flags
-    # 'starved' if the artifact is byte-identical (mtime_ns+size unchanged) across
+    # EXISTS to add scraped articles; its output artifact's CONTENT grows on real work.
+    # A2 flags 'starved' if the artifact's [size, sha256] is unchanged across
     # STARVED_TICKS=3 ticks — i.e. 3 consecutive nights of ZERO new articles, a real
-    # stall the bare heartbeat (ts fresh + status ok) cannot see. CAVEAT (operator-
-    # accepted): published_articles.json is repo-tracked, so a manual edit could reset
-    # the streak — unlikely to mask a genuine 3-night stall.
+    # stall the bare heartbeat (ts fresh + status ok) cannot see. CONTENT-hash, not
+    # mtime: run_intel_pipeline.py rewrites published_articles.json UNCONDITIONALLY even
+    # on a zero-article night (L1899), so an mtime signal would re-stamp every tick and
+    # NEVER starve — hashing the content makes an unchanged rewrite a non-advance (the
+    # green!=working trap, corrected in _progress_value). CAVEAT (operator-accepted):
+    # repo-tracked, so a real content edit resets the streak — unlikely over 3 nights.
     output_artifact: ~/Desktop/nuzantara/apps/bali-intel-scraper/data/published_articles.json
     bridge_source:
       type: state_file

--- a/scripts/sentinel-aggregate.py
+++ b/scripts/sentinel-aggregate.py
@@ -33,6 +33,7 @@ Exit codes:
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import subprocess
@@ -85,29 +86,36 @@ def _progress_value(hb: dict[str, Any] | None, organ: dict[str, Any]) -> Any:
       1. progress_field — read a value off the already-loaded heartbeat dict. Use when the
          organ ALREADY emits a monotone counter in its payload (no writer-change needed).
 
-      2. output_artifact — a filesystem path the organ PRODUCES. We return a (mtime_ns, size)
-         tuple: "did output advance?" becomes "did the artifact change on disk?". This needs
+      2. output_artifact — a filesystem path the organ PRODUCES. We return a [size, sha256]
+         pair: "did output advance?" becomes "did the artifact's CONTENT change?". This needs
          ZERO writer-change to any H24 organ — A2 observes the artifact, not the heartbeat.
-         CRITICAL (anti-false-alarm): mtime is a real advance-signal ONLY when the writer
-         REWRITES the artifact on real work and leaves it untouched otherwise — which is the
-         normal case (a scraper appends to its JSON, a renderer overwrites its output). A
-         writer that re-stamps the file every tick regardless of work would defeat this; such
-         organs must NOT declare output_artifact (they have no honest disk progress signal).
+
+         CRITICAL (anti-false-alarm, the trap this design corrects): we hash CONTENT, NOT
+         mtime. Many writers REWRITE the file every run unconditionally even when nothing
+         changed (e.g. run_intel_pipeline.py re-serialises published_articles.json on a
+         zero-article night) — mtime would advance every tick and the organ could NEVER be
+         flagged starved (the "green != working" disease applied to the detector itself).
+         A content hash is identical across an unchanged rewrite, so a frozen output is seen
+         as frozen regardless of how often the writer touches the file. The remaining
+         contract: declare output_artifact only when the CONTENT is meant to grow/change on
+         real work (a content-rotated dated filename or an in-place per-run shuffle would
+         still misfire — those organs have no honest content-progress signal).
 
     Returns None when neither is declared / the artifact is missing → organ opts out of A2,
-    classified the classic way. NEVER raises (a stat() failure = opt-out, not a crash)."""
+    classified the classic way. NEVER raises (a read failure = opt-out, not a crash)."""
     field = organ.get("progress_field")
     if field and hb is not None:
         return hb.get(field)
     artifact = organ.get("output_artifact")
     if artifact:
         try:
-            st = Path(os.path.expanduser(str(artifact))).stat()
+            data = Path(os.path.expanduser(str(artifact))).read_bytes()
         except OSError:
             return None  # missing/unreadable artifact → opt out, not a false starve
-        # JSON-serialisable tuple → list; survives the aggregate.json round-trip so the
-        # prior-snapshot comparison in _classify works byte-identically across ticks.
-        return [st.st_mtime_ns, st.st_size]
+        # [size, sha256]: content-based, immune to unconditional re-stamps (mtime would not
+        # be). JSON-serialisable list → survives the aggregate.json round-trip so the
+        # prior-snapshot equality check in _classify holds byte-identically across ticks.
+        return [len(data), hashlib.sha256(data).hexdigest()]
     return None
 
 

--- a/scripts/test_sentinel_starved.py
+++ b/scripts/test_sentinel_starved.py
@@ -124,9 +124,10 @@ def main() -> int:
           r["status"] == "ok" and r.get("starved_streak") == 0)
 
     # ======================================================================
-    # ARTIFACT-MTIME mode — the honest opt-in for organs whose payload has NO
-    # monotone field: A2 observes the OUTPUT ARTIFACT on disk (mtime_ns,size),
-    # zero writer-change. Same innocence+guilt discipline.
+    # ARTIFACT mode — the honest opt-in for organs whose payload has NO monotone
+    # field: A2 observes the OUTPUT ARTIFACT on disk as [size, sha256] of its
+    # CONTENT (NOT mtime), zero writer-change. Content-hash is the fix for the
+    # unconditional-rewrite trap (see the dedicated regression below).
     # ======================================================================
     tmp = pathlib.Path(tempfile.mkdtemp())
     art = tmp / "scraped.json"
@@ -141,29 +142,37 @@ def main() -> int:
     # INNOCENCE A: missing artifact → opt out (None), never starved even with prior.
     miss = {"id": "x", "runtime": "cron", "type": "cron", "expected_hb_seconds": 3600,
             "severity_on_silence": "warning", "output_artifact": str(tmp / "nope.json")}
-    r = _classify(miss, _hb(60), prior={"progress_value": [1, 2], "starved_streak": 9})
+    r = _classify(miss, _hb(60), prior={"progress_value": [1, "ab"], "starved_streak": 9})
     check("artifact innocence: missing artifact opts out (ok, no progress_value, never starved)",
           r["status"] == "ok" and "progress_value" not in r)
 
-    # INNOCENCE B: artifact CHANGED on disk between ticks → advance → streak stays 0.
+    # INNOCENCE B: first observation records [size, sha256]; CONTENT change → advance.
     r1 = _classify(_art_organ(), _hb(60), prior=None)
     pv1 = r1.get("progress_value")
-    check("artifact innocence: first observation records [mtime_ns,size], streak 0",
-          isinstance(pv1, list) and len(pv1) == 2 and r1.get("starved_streak") == 0)
-    time.sleep(0.01)
-    art.write_text('[{"id":1}]')  # real work: artifact rewritten (mtime + size change)
+    check("artifact innocence: first observation records [size,sha256], streak 0",
+          isinstance(pv1, list) and len(pv1) == 2 and isinstance(pv1[1], str)
+          and len(pv1[1]) == 64 and r1.get("starved_streak") == 0)
+    art.write_text('[{"id":1}]')  # real work: CONTENT changed (size + hash change)
     r2 = _classify(_art_organ(), _hb(60), prior={"progress_value": pv1, "starved_streak": 2})
-    check("artifact innocence: artifact rewrite (output advanced) -> streak resets to 0, ok",
+    check("artifact innocence: content change (output advanced) -> streak resets to 0, ok",
           r2["status"] == "ok" and r2.get("starved_streak") == 0 and r2.get("progress_value") != pv1)
 
-    # GUILT: artifact UNCHANGED on disk across STARVED_TICKS ticks -> starved.
-    pv = r2.get("progress_value")  # current on-disk signal; we now freeze the file
+    # REGRESSION (the intel_nightly trap): writer REWRITES identical content every tick.
+    # mtime advances but CONTENT is unchanged → must NOT count as advance, must still starve.
+    pv = r2.get("progress_value")
+    time.sleep(0.01)
+    art.write_text('[{"id":1}]')  # SAME content rewritten (mtime advances, hash identical)
+    r_restamp = _classify(_art_organ(), _hb(60), prior={"progress_value": pv, "starved_streak": 1})
+    check("artifact REGRESSION: unconditional rewrite of identical content does NOT advance",
+          r_restamp.get("progress_value") == pv and r_restamp.get("starved_streak") == 2)
+
+    # GUILT: content frozen across STARVED_TICKS ticks -> starved (even with re-stamps).
     prior = {"progress_value": pv, "starved_streak": S.STARVED_TICKS - 1}
-    r = _classify(_art_organ(), _hb(60), prior=prior)  # file untouched since pv captured
-    check(f"artifact guilt: frozen artifact for STARVED_TICKS={S.STARVED_TICKS} ticks -> starved",
+    r = _classify(_art_organ(), _hb(60), prior=prior)
+    check(f"artifact guilt: frozen content for STARVED_TICKS={S.STARVED_TICKS} ticks -> starved",
           r["status"] == "starved")
 
-    total = 14
+    total = 15
     print(f"\n=== {'ALL ' + str(total) + ' PASS' if not fails else str(fails) + ' FAIL'} ===")
     return 1 if fails else 0
 


### PR DESCRIPTION
## What — un-defeats the A2 pilot (a real defect in armed prod code)

A skeptic read-only audit of Pro caught that the A2 pilot `pro.intel_nightly` (armed in #1694) **could never flag starved**.

### Root cause (verified on disk)
`apps/bali-intel-scraper/scripts/run_intel_pipeline.py:1899` rewrites `published_articles.json` **unconditionally** at the end of `step_publishing` — even on a zero-article night the file is re-serialised with identical content. The old `_progress_value` returned `[mtime_ns, size]`; **mtime advances on every rewrite** → the tuple differs every tick → `starved_streak` resets forever → the detector is blind. The "green != working" disease applied to the detector itself.

### Fix
`_progress_value` now returns `[size, sha256]` of the artifact's **CONTENT** (`read_bytes` + `hashlib.sha256`). An unchanged rewrite is a **non-advance** regardless of how often/when the writer touches the file. mtime is never consulted. Opt-out + never-raises contract unchanged.

## Test
`scripts/test_sentinel_starved.py` 14→15 — adds the **regression** that pins the trap: *"unconditional rewrite of identical content does NOT advance"* (FAILS under the old mtime signal). scar_A2 stays ARMED, meta-verifier GREEN, integrity baseline untouched (verifier files not modified).

## Scope note
The pilot-hunt subagent found **ZERO additional safe pilots** beyond intel_nightly — every other Pro producer fails the bar (per-tick `generated_at` re-stamp, latest-dump overwrite, dated-filename rotation, append-always SQLite, /tmp+cloud push, stale owner path). So this PR **hardens the one pilot** rather than adding more; new pilots await a producer with an honest content-progress artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)