### PR TITLE
ci(self-loop): gate the WR3 reflexion test (close the #1696-invisible gap)

### DIFF
--- a/.github/workflows/verify-the-verifiers.yml
+++ b/.github/workflows/verify-the-verifiers.yml
@@ -52,7 +52,7 @@ jobs:
           fi
           base="${{ github.event.pull_request.base.sha }}"
           if git diff --name-only "$base"...HEAD | grep -qE \
-            '^(scripts/verify_the_verifiers\.py|scripts/verify_the_verifiers_gates\.yaml|\.github/verify-the-verifiers\.sha256|\.github/workflows/verify-the-verifiers\.yml|\.github/workflows/hot-zone-pr-gate\.yml|scripts/tests/test_verify_the_verifiers\.py)$'; then
+            '^(scripts/verify_the_verifiers\.py|scripts/verify_the_verifiers_gates\.yaml|\.github/verify-the-verifiers\.sha256|\.github/workflows/verify-the-verifiers\.yml|\.github/workflows/hot-zone-pr-gate\.yml|scripts/tests/test_verify_the_verifiers\.py|scripts/tests/test_wr3_reflexion_synthesis\.py|scripts/wr3_reflexion_synthesis\.py|scripts/lib/reflexion\.py)$'; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
@@ -99,6 +99,15 @@ jobs:
       - name: Run meta-verifier tests
         if: steps.relevant.outputs.run == 'true'
         run: python3 -m pytest scripts/tests/test_verify_the_verifiers.py -q
+
+      # Closes the gap that made the #1696 A3-cabling regression invisible: the WR3
+      # reflexion Delta-Gate test existed but was run by NO CI workflow, so a schema
+      # break (episodes_found->signals_found, status vocabulary) merged green. Now it
+      # is a required check here. Pinned to the relevant-paths regex above so it only
+      # runs when the reflexion code/test changes (cheap, no noise).
+      - name: Run WR3 reflexion Delta-Gate test
+        if: steps.relevant.outputs.run == 'true'
+        run: python3 -m pytest scripts/tests/test_wr3_reflexion_synthesis.py -q
 
       # --scope repo: a CI runner has no ~/.claude/ hooks, so the local-scope
       # claude_hook gates are SKIPPED (not DISARMED) here. The repo-scope gates


### PR DESCRIPTION
## What — closes the gap that made the #1696 regression invisible

The A3-cabling regression in #1696 (status vocabulary + `episodes_found`→`signals_found` schema break) merged **green** because `scripts/tests/test_wr3_reflexion_synthesis.py` was run by **no CI workflow** — it existed but was never armed (superscar #2 "Esiste ≠ Armato", applied to a test). #1699 fixed the regression; this arms the test so the class can't recur silently.

## Two edits to `verify-the-verifiers.yml` (meta-gate, CODEOWNERS-protected)
1. **Relevant-paths regex**: add `test_wr3_reflexion_synthesis.py` + `wr3_reflexion_synthesis.py` + `lib/reflexion.py` → a change to the reflexion code/test triggers the work steps (cheap — only fires when reflexion changes, no noise on unrelated PRs).
2. **New step** "Run WR3 reflexion Delta-Gate test" → pytest the file as a required check.

## Safety
- **No sha256 baseline change**: the integrity hash covers `verify_the_verifiers.py` + `.gates.yaml` only, NOT this workflow file. The workflow's own tamper-protection is CODEOWNERS review (this PR).
- Static **literal path** additions to an allowlist regex — no untrusted input, no `${{ github.event.* }}`, no injection surface.

## Verified
- workflow YAML valid; WR3 test **5/5** under the repo venv; test deps = stdlib + pytest (the step's existing `pip install pyyaml pytest` covers it); baseline unchanged.

Note: this is the operator-gated residual flagged in #1699's close-out — requires @Balizero1987 review (CODEOWNERS on `.github/workflows/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)