### PR TITLE
feat(self-loop): arm A2 Heartbeat Semantico on wr2.fact_extractor (2nd organ)

### DIFF
--- a/apps/organism/organism/organs_registry.yaml
+++ b/apps/organism/organism/organs_registry.yaml
@@ -1182,6 +1182,14 @@ organs:
     type: cron
     expected_hb_seconds: 1800
     owner_module: apps/war-room/scripts/wr2_fact_extractor.py
+    # A2 Heartbeat Semantico (self-loop Anello 2). fact_extractor appends ONE JSONL
+    # line per successfully fact-checked draft and writes NOTHING on a no-work run
+    # (no ready drafts -> early return BEFORE _log_telemetry). So a frozen [size,sha256]
+    # across STARVED_TICKS=3 ticks = 3 consecutive runs that fact-checked zero drafts
+    # while the cron still fires green — the green!=working stall the bare heartbeat
+    # (ts fresh + status ok) cannot see. CONTENT-hash, not mtime: per-line work ts
+    # only, no top-level run-timestamp, so an unchanged file stays byte-identical.
+    output_artifact: ~/logs/wr2_fact_extractor_telemetry.jsonl
     dependencies:
       - wr2.supervisor
       - infra.postgres


### PR DESCRIPTION
Declares output_artifact ~/logs/wr2_fact_extractor_telemetry.jsonl on wr2.fact_extractor so the A2 starved-axis in sentinel-aggregate.py observes a 2nd live organ (was 1/120). Verified A2-safe over 29 organs (3-batch Pro fan-out): single stable path, append-only, per-line ts (no top-level run-timestamp), single-writer, writes nothing on no-work run. Empirically tested frozen->starved@tick3, advance->ok. +8 YAML lines, additive opt-in fail-open.

Co-Authored-By: Claude Opus 4.8

🤖 Generated with Claude Code