### PR TITLE
fix(voice): keep local TTS on short spoken answers

### DIFF
--- a/apps/mouth/src/app/(workspace)/intelligence/voice-concierge/VoiceConciergeClient.test.tsx
+++ b/apps/mouth/src/app/(workspace)/intelligence/voice-concierge/VoiceConciergeClient.test.tsx
@@ -274,7 +274,7 @@ describe("VoiceConciergeClient", () => {
         expect(init?.method).toBe("POST");
         expect(init?.headers).toEqual({ "Content-Type": "application/json" });
         expect(JSON.parse(String(init?.body))).toEqual({
-          text: "Per una PT PMA, parti da KBLI e zoning.",
+          text: "Triage PMA pronto. Parti da KBLI e zoning.",
           language: "it",
         });
         return new Response("RIFF", {
@@ -285,7 +285,9 @@ describe("VoiceConciergeClient", () => {
 
       return new Response(
         JSON.stringify({
-          answer: "Per una PT PMA, parti da KBLI e zoning.",
+          answer:
+            "Per una PT PMA, i primi controlli utili sono attivita, KBLI, limiti di proprieta straniera, indirizzo/zoning e permessi extra.",
+          spoken_answer: "Triage PMA pronto. Parti da KBLI e zoning.",
           intent: "company",
           risk_level: "medium",
           next_action: "collect_non_pii_context",
@@ -308,7 +310,9 @@ describe("VoiceConciergeClient", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("Per una PT PMA, parti da KBLI e zoning."),
+        screen.getByText(
+          "Per una PT PMA, i primi controlli utili sono attivita, KBLI, limiti di proprieta straniera, indirizzo/zoning e permessi extra.",
+        ),
       ).toBeInTheDocument();
       expect(playAudio).toHaveBeenCalledTimes(1);
     });

--- a/apps/mouth/src/app/(workspace)/intelligence/voice-concierge/VoiceConciergeClient.tsx
+++ b/apps/mouth/src/app/(workspace)/intelligence/voice-concierge/VoiceConciergeClient.tsx
@@ -45,6 +45,7 @@ interface ConciergeMessage {
 
 interface ConciergeResponse {
   answer: string;
+  spoken_answer?: string;
   intent: ConciergeIntent;
   risk_level: ConciergeRisk;
   next_action: ConciergeNextAction;
@@ -116,6 +117,10 @@ function isConciergeResponse(
   payload: ConciergeResponse | ConciergeErrorResponse,
 ): payload is ConciergeResponse {
   return "answer" in payload;
+}
+
+function getSpeechText(response: ConciergeResponse): string {
+  return (response.spoken_answer?.trim() || response.answer).trim();
 }
 
 function canUseBrowserRecorder(): boolean {
@@ -432,7 +437,7 @@ export function VoiceConciergeClient(): React.JSX.Element {
         };
         setLastResponse(payload);
         setMessages([...nextMessages, assistantMessage].slice(-6));
-        void playLocalSpeech(payload.answer);
+        void playLocalSpeech(getSpeechText(payload));
       } catch (requestError) {
         setError(
           requestError instanceof Error
@@ -785,13 +790,13 @@ export function VoiceConciergeClient(): React.JSX.Element {
                     }
                     onClick={() =>
                       lastResponse &&
-                      void playLocalSpeech(lastResponse.answer, {
+                      void playLocalSpeech(getSpeechText(lastResponse), {
                         reportError: true,
                       })
                     }
                     title={
                       isManualAudioReady
-                        ? "Read the latest answer with local TTS."
+                        ? "Read the latest short voice response with local TTS."
                         : "Local TTS is gated until local audio roundtrip is ready."
                     }
                     variant="outline"

--- a/apps/mouth/src/app/api/lab/voice-concierge/route.test.ts
+++ b/apps/mouth/src/app/api/lab/voice-concierge/route.test.ts
@@ -431,6 +431,7 @@ describe("voice concierge route", () => {
       provider: "local-demo",
       intent: "company",
       next_action: "collect_non_pii_context",
+      spoken_answer: "PMA triage ready. Start with KBLI and zoning.",
     });
     expect(global.fetch).not.toHaveBeenCalled();
   });
@@ -485,6 +486,7 @@ describe("voice concierge route", () => {
                       risk_level: "medium",
                       next_action: "collect_non_pii_context",
                       quick_replies: ["Ask about KBLI", "Check zoning"],
+                      spoken_answer: "PMA triage ready. Check KBLI and zoning.",
                     }),
                   },
                 ],
@@ -508,6 +510,7 @@ describe("voice concierge route", () => {
       model: "gemini-test",
       intent: "company",
       next_action: "collect_non_pii_context",
+      spoken_answer: "PMA triage ready. Check KBLI and zoning.",
     });
     expect(body.quick_replies).toEqual(["Ask about KBLI", "Check zoning"]);
     expect(global.fetch).toHaveBeenCalledWith(

--- a/apps/mouth/src/app/api/lab/voice-concierge/route.ts
+++ b/apps/mouth/src/app/api/lab/voice-concierge/route.ts
@@ -33,6 +33,7 @@ interface SafeHistoryTurn {
 
 interface VoiceConciergeResponse {
   answer: string;
+  spoken_answer?: string;
   intent: ConciergeIntent;
   risk_level: ConciergeRisk;
   next_action: ConciergeNextAction;
@@ -56,6 +57,7 @@ interface GeminiResponse {
 const DEFAULT_MODEL = "gemini-2.5-flash";
 const MAX_MESSAGE_LENGTH = 1200;
 const MAX_HISTORY_ITEMS = 4;
+const MAX_SPOKEN_ANSWER_LENGTH = 96;
 const TEXT_PROVIDER_TIMEOUT_MS = 15_000;
 const SUPPORTED_LOCALES = new Set<SupportedLocale>([
   "en",
@@ -71,6 +73,7 @@ const SYSTEM_PROMPT = [
   "Do not ask for passports, KTP, NPWP, phone numbers, emails, exact client names, document numbers, or private WhatsApp/CRM details.",
   "If the user needs case-specific advice, collect only non-PII context and suggest a team handoff.",
   "Never quote prices. Tell the user that pricing must be checked through the Bali Zero pricing tool/team.",
+  "Also return spoken_answer: one short sentence for local TTS, max 96 characters, no PII.",
   "Return only JSON that matches the requested schema.",
 ].join("\n");
 
@@ -78,6 +81,7 @@ const RESPONSE_SCHEMA = {
   type: "object",
   properties: {
     answer: { type: "string" },
+    spoken_answer: { type: "string" },
     intent: {
       type: "string",
       enum: ["visa", "company", "tax", "property", "operations", "unknown"],
@@ -97,7 +101,14 @@ const RESPONSE_SCHEMA = {
       items: { type: "string" },
     },
   },
-  required: ["answer", "intent", "risk_level", "next_action", "quick_replies"],
+  required: [
+    "answer",
+    "spoken_answer",
+    "intent",
+    "risk_level",
+    "next_action",
+    "quick_replies",
+  ],
 };
 
 function getApiKey(): string | undefined {
@@ -242,6 +253,24 @@ function inferIntent(message: string): ConciergeIntent {
   return "unknown";
 }
 
+function compactForSpeech(text: string): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (normalized.length <= MAX_SPOKEN_ANSWER_LENGTH) return normalized;
+
+  const firstSentence = normalized.match(/^.*?[.!?](?:\s|$)/)?.[0]?.trim();
+  if (firstSentence && firstSentence.length <= MAX_SPOKEN_ANSWER_LENGTH) {
+    return firstSentence;
+  }
+
+  const candidate = normalized.slice(0, MAX_SPOKEN_ANSWER_LENGTH + 1);
+  const lastSpace = candidate.lastIndexOf(" ");
+  const endIndex =
+    lastSpace >= Math.floor(MAX_SPOKEN_ANSWER_LENGTH * 0.6)
+      ? lastSpace
+      : MAX_SPOKEN_ANSWER_LENGTH;
+  return `${normalized.slice(0, endIndex).replace(/[,:;.\-\s]+$/, "")}.`;
+}
+
 function demoResponse(
   message: string,
   locale: SupportedLocale,
@@ -289,10 +318,42 @@ function demoResponse(
         "Saya bisa mengarahkan pertanyaan ke visa, company, tax, property, atau operations. Tanyakan dengan bahasa natural tanpa identitas pribadi atau nomor dokumen.",
     },
   };
+  const spokenByLocale: Record<
+    "en" | "it" | "id",
+    Record<ConciergeIntent, string>
+  > = {
+    en: {
+      visa: "Visa triage ready. Share only broad, non-private context.",
+      company: "PMA triage ready. Start with KBLI and zoning.",
+      tax: "Tax triage ready. Keep NPWP and client IDs out.",
+      property: "Property triage ready. Start with title and zoning.",
+      operations: "Workflow triage ready. I can route the next team step.",
+      unknown: "I can route this into visa, company, tax, property, or ops.",
+    },
+    it: {
+      visa: "Triage visa pronto. Usa solo contesto generale, non privato.",
+      company: "Triage PMA pronto. Parti da KBLI e zoning.",
+      tax: "Triage fiscale pronto. Tieni fuori NPWP e dati cliente.",
+      property: "Triage property pronto. Parti da titolo e zoning.",
+      operations: "Triage workflow pronto. Posso instradare il prossimo step.",
+      unknown: "Posso instradare su visa, company, tax, property o ops.",
+    },
+    id: {
+      visa: "Triage visa siap. Pakai konteks umum saja.",
+      company: "Triage PMA siap. Mulai dari KBLI dan zoning.",
+      tax: "Triage pajak siap. Jangan masukkan NPWP atau identitas klien.",
+      property: "Triage properti siap. Mulai dari status hak dan zoning.",
+      operations: "Triage workflow siap. Saya bisa arahkan langkah tim.",
+      unknown: "Saya bisa arahkan ke visa, company, tax, property, atau ops.",
+    },
+  };
   const byIntent = byLocale[locale === "it" || locale === "id" ? locale : "en"];
+  const spokenByIntent =
+    spokenByLocale[locale === "it" || locale === "id" ? locale : "en"];
 
   return {
     answer: byIntent[intent],
+    spoken_answer: spokenByIntent[intent],
     intent,
     risk_level: intent === "unknown" ? "low" : "medium",
     next_action:
@@ -317,14 +378,16 @@ function normalizeResponse(
   const intent = parsed.intent ?? "unknown";
   const riskLevel = parsed.risk_level ?? "medium";
   const nextAction = parsed.next_action ?? "collect_non_pii_context";
+  const answer =
+    parsed.answer ??
+    "I can help, but I need a clearer non-PII question before routing this.";
   const quickReplies = Array.isArray(parsed.quick_replies)
     ? parsed.quick_replies.slice(0, 4).filter((reply) => reply.trim())
     : [];
 
   return {
-    answer:
-      parsed.answer ??
-      "I can help, but I need a clearer non-PII question before routing this.",
+    answer,
+    spoken_answer: compactForSpeech(parsed.spoken_answer ?? answer),
     intent,
     risk_level: riskLevel,
     next_action: nextAction,

--- a/apps/mouth/src/app/api/lab/voice-concierge/synthesize/route.test.ts
+++ b/apps/mouth/src/app/api/lab/voice-concierge/synthesize/route.test.ts
@@ -32,6 +32,8 @@ describe("voice concierge synthesize route", () => {
   const originalTtsMaxChars = process.env.VOICE_CONCIERGE_TTS_MAX_CHARS;
   const originalTtsAudioMaxBytes =
     process.env.VOICE_CONCIERGE_TTS_AUDIO_MAX_BYTES;
+  const originalSynthesizeTimeoutMs =
+    process.env.VOICE_CONCIERGE_SYNTHESIZE_TIMEOUT_MS;
 
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -47,6 +49,7 @@ describe("voice concierge synthesize route", () => {
     delete process.env.VOICE_CONCIERGE_SYNTHESIZE_TOKEN;
     delete process.env.VOICE_CONCIERGE_TTS_MAX_CHARS;
     delete process.env.VOICE_CONCIERGE_TTS_AUDIO_MAX_BYTES;
+    delete process.env.VOICE_CONCIERGE_SYNTHESIZE_TIMEOUT_MS;
     global.fetch = vi.fn();
   });
 
@@ -68,6 +71,10 @@ describe("voice concierge synthesize route", () => {
     restoreEnv("VOICE_CONCIERGE_SYNTHESIZE_TOKEN", originalSynthesizeToken);
     restoreEnv("VOICE_CONCIERGE_TTS_MAX_CHARS", originalTtsMaxChars);
     restoreEnv("VOICE_CONCIERGE_TTS_AUDIO_MAX_BYTES", originalTtsAudioMaxBytes);
+    restoreEnv(
+      "VOICE_CONCIERGE_SYNTHESIZE_TIMEOUT_MS",
+      originalSynthesizeTimeoutMs,
+    );
   });
 
   it("fails closed without calling the backend when local audio is disabled", async () => {
@@ -305,6 +312,34 @@ describe("voice concierge synthesize route", () => {
         redirect: "error",
         signal: expect.any(AbortSignal),
         body: JSON.stringify({ text: "Hello", voice: "en" }),
+      }),
+    );
+  });
+
+  it("uses a configurable backend synthesis timeout", async () => {
+    process.env.VOICE_CONCIERGE_LOCAL_AUDIO = "true";
+    process.env.VOICE_CONCIERGE_BACKEND_API_KEY = "test-key";
+    process.env.VOICE_CONCIERGE_BACKEND_URL = "https://backend.test/api";
+    process.env.VOICE_CONCIERGE_SYNTHESIZE_TIMEOUT_MS = "180000";
+    const timeoutSignal = new AbortController().signal;
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, "timeout")
+      .mockReturnValue(timeoutSignal);
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response("RIFF", {
+        status: 200,
+        headers: { "Content-Type": "audio/wav" },
+      }),
+    );
+
+    const response = await POST(synthesizeRequest({ text: "Hello" }));
+
+    expect(response.status).toBe(200);
+    expect(timeoutSpy).toHaveBeenCalledWith(180_000);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://backend.test/api/voice/local-audio/synthesize",
+      expect.objectContaining({
+        signal: timeoutSignal,
       }),
     );
   });

--- a/apps/mouth/src/app/api/lab/voice-concierge/synthesize/route.ts
+++ b/apps/mouth/src/app/api/lab/voice-concierge/synthesize/route.ts
@@ -9,7 +9,7 @@ export const runtime = "nodejs";
 
 const DEFAULT_TTS_MAX_CHARS = 1200;
 const DEFAULT_TTS_AUDIO_MAX_BYTES = 10 * 1024 * 1024;
-const BACKEND_SYNTHESIZE_TIMEOUT_MS = 65_000;
+const DEFAULT_BACKEND_SYNTHESIZE_TIMEOUT_MS = 240_000;
 
 interface SynthesizeRequestBody {
   text?: unknown;
@@ -48,6 +48,16 @@ function getTtsAudioMaxBytes(): number {
   return Number.isFinite(configured) && configured > 0
     ? configured
     : DEFAULT_TTS_AUDIO_MAX_BYTES;
+}
+
+function getBackendSynthesizeTimeoutMs(): number {
+  const configured = Number.parseInt(
+    process.env.VOICE_CONCIERGE_SYNTHESIZE_TIMEOUT_MS ?? "",
+    10,
+  );
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_BACKEND_SYNTHESIZE_TIMEOUT_MS;
 }
 
 function getOptionalString(value: unknown): string | undefined {
@@ -144,7 +154,7 @@ export async function POST(request: Request): Promise<Response> {
           "X-API-Key": apiKey,
         },
         redirect: "error",
-        signal: AbortSignal.timeout(BACKEND_SYNTHESIZE_TIMEOUT_MS),
+        signal: AbortSignal.timeout(getBackendSynthesizeTimeoutMs()),
         body: JSON.stringify(payload),
       },
     );


### PR DESCRIPTION
## Summary
- add a compact `spoken_answer` field for the voice concierge response path
- use the compact spoken answer for local Chatterbox playback while preserving the full text answer in the UI
- make the local synthesize bridge timeout configurable for slow first-run local TTS

## Verification
- `npm run test -- --run 'src/app/api/lab/voice-concierge/route.test.ts' 'src/app/api/lab/voice-concierge/synthesize/route.test.ts' 'src/app/(workspace)/intelligence/voice-concierge/VoiceConciergeClient.test.tsx'`
- `npm run typecheck`
- local E2E: WAV -> whisper.cpp -> concierge response -> Chatterbox WAV

## Notes
- Chatterbox remains high-quality but slow for real-time concierge: observed 63s first synthesis and 92s in a full E2E pass on the local Pro runtime.
