### PR TITLE
fix(wr2): orphan entity-gate — logo-sits-alone is composition not HARD orphan (scar #3)

### DIFF
--- a/scripts/wr2_html_renderer/designer_loop.py
+++ b/scripts/wr2_html_renderer/designer_loop.py
@@ -179,38 +179,41 @@ def _is_composition_only_lever(lever_names: set[str]) -> bool:
     return bool(lever_names) and lever_names <= _COMPOSITION_LEVERS
 
 
-# A typographic-orphan marker ("sits alone", "stranded", "widow") describes a
-# TEXT element on a line. The SAME words describe a composition element ("the
-# logo sits alone", "the mark is stranded"). Superscar #3 (over-match on form,
-# not entity): "sits alone" matched a LOGO-isolation critique and mis-graded a
-# pure composition residual as a HARD typographic orphan, blocking the render.
-# Gate on the SUBJECT: an orphan claim is typographic only when it is about text
-# (word/line/title/headline/wrap/caption), not when it is about a non-text
-# layout element (logo/mark/image/photo/icon/element) with no text context.
-_ORPHAN_TEXT_SUBJECTS = (
-    # true typographic subjects — a wrap/line/word of TEXT. Deliberately excludes
-    # bare "text" (it matches "text block"/"text element" — a composition
-    # reference inside a logo/image critique, not a typographic-orphan subject).
-    "word", "line", "title", "headline", "heading", "wrap", "caption",
-    "sentence", "tail", "row", "label", "last line", "middle line",
-    "on its own line", "on the line",
+# Superscar #3 cure (4th over-match): identify a typographic orphan POSITIVELY,
+# don't blacklist metaphors. A real orphan is a unit of running TEXT that wrapped
+# or landed badly on a line. "decorative orphan", "logo sits alone", "image
+# stranded", "divider stranded" reuse the same words for SPATIAL isolation of a
+# layout element — they carry no text-unit, so they are composition, not orphans.
+
+# A unit of running text that can wrap badly.
+_ORPHAN_TEXT_UNITS = (
+    "word", "line", "title", "headline", "heading", "sentence",
+    "tail", "caption", "body copy",
 )
-_ORPHAN_NONTEXT_SUBJECTS = (
-    "logo", "mark", "image", "photo", "icon", "graphic", "element",
-    "badge", "emblem", "watermark",
+# How that text unit failed to land — the "bad-landing" predicate.
+_ORPHAN_BAD_LANDING = (
+    "orphan", "stub", "widow", "stranded", "sits alone",
+    "alone on line", "alone on the line", "dangling", "ragged",
+    "short tail", "short last line", "wraps", "wrapped", "wrap",
+    "rewrap", "re-wrap", "extra line", "line stub", "3-line", "4-line",
+    "two-line", "three-line", "on its own line", "on the line",
 )
 
 
-def _orphan_subject_is_text(low: str) -> bool:
-    """True unless the orphan claim is clearly about a NON-text layout element.
+def _is_typographic_orphan(low: str) -> bool:
+    """Positive identification of a TEXT orphan (superscar #3 cure).
 
-    Default-True (fail toward the existing strict behavior): only when the claim
-    names a non-text subject AND names no text subject do we treat the
-    "sits alone"/"stranded" wording as composition, not a typographic orphan.
+    True iff an explicit one-word marker is present, OR a text-unit token
+    co-occurs with a bad-landing predicate. A bare bad-landing word with no
+    text-unit ("decorative orphan", "logo sits alone", "divider stranded") is a
+    composition metaphor, not a typographic orphan — keys on INTENT, not phrase.
     """
-    has_nontext = _contains_any_word(low, _ORPHAN_NONTEXT_SUBJECTS)
-    has_text = _contains_any_word(low, _ORPHAN_TEXT_SUBJECTS)
-    return has_text or not has_nontext
+    if _contains_any_word(low, _ONE_WORD_ORPHAN_MARKERS):
+        return True
+    return (
+        _contains_any_word(low, _ORPHAN_TEXT_UNITS)
+        and _contains_any_word(low, _ORPHAN_BAD_LANDING)
+    )
 
 
 def _orphan_is_hard(low: str, *, rebalance_applied: bool) -> tuple[bool, bool]:
@@ -225,12 +228,8 @@ def _orphan_is_hard(low: str, *, rebalance_applied: bool) -> tuple[bool, bool]:
       - if NO re-wrap was attempted, an orphan claim is a real unfixed defect
         → HARD (fail-safe toward the strict gate).
     """
-    if not _contains_any_word(low, _ORPHAN_MARKERS):
-        return False, False  # not an orphan/stub/wrap claim at all
-    # Superscar #3 entity-gate: "sits alone"/"stranded" about a LOGO/mark/image is
-    # a composition critique, not a typographic orphan. Only text subjects qualify.
-    if not _orphan_subject_is_text(low):
-        return False, False
+    if not _is_typographic_orphan(low):
+        return False, False  # not a TEXT orphan (or a composition metaphor)
     # a genuine 1-word orphan is a real defect regardless of re-wrap state.
     if _contains_any_word(low, _ONE_WORD_ORPHAN_MARKERS):
         return True, True

--- a/scripts/wr2_html_renderer/designer_loop.py
+++ b/scripts/wr2_html_renderer/designer_loop.py
@@ -179,6 +179,40 @@ def _is_composition_only_lever(lever_names: set[str]) -> bool:
     return bool(lever_names) and lever_names <= _COMPOSITION_LEVERS
 
 
+# A typographic-orphan marker ("sits alone", "stranded", "widow") describes a
+# TEXT element on a line. The SAME words describe a composition element ("the
+# logo sits alone", "the mark is stranded"). Superscar #3 (over-match on form,
+# not entity): "sits alone" matched a LOGO-isolation critique and mis-graded a
+# pure composition residual as a HARD typographic orphan, blocking the render.
+# Gate on the SUBJECT: an orphan claim is typographic only when it is about text
+# (word/line/title/headline/wrap/caption), not when it is about a non-text
+# layout element (logo/mark/image/photo/icon/element) with no text context.
+_ORPHAN_TEXT_SUBJECTS = (
+    # true typographic subjects — a wrap/line/word of TEXT. Deliberately excludes
+    # bare "text" (it matches "text block"/"text element" — a composition
+    # reference inside a logo/image critique, not a typographic-orphan subject).
+    "word", "line", "title", "headline", "heading", "wrap", "caption",
+    "sentence", "tail", "row", "label", "last line", "middle line",
+    "on its own line", "on the line",
+)
+_ORPHAN_NONTEXT_SUBJECTS = (
+    "logo", "mark", "image", "photo", "icon", "graphic", "element",
+    "badge", "emblem", "watermark",
+)
+
+
+def _orphan_subject_is_text(low: str) -> bool:
+    """True unless the orphan claim is clearly about a NON-text layout element.
+
+    Default-True (fail toward the existing strict behavior): only when the claim
+    names a non-text subject AND names no text subject do we treat the
+    "sits alone"/"stranded" wording as composition, not a typographic orphan.
+    """
+    has_nontext = _contains_any_word(low, _ORPHAN_NONTEXT_SUBJECTS)
+    has_text = _contains_any_word(low, _ORPHAN_TEXT_SUBJECTS)
+    return has_text or not has_nontext
+
+
 def _orphan_is_hard(low: str, *, rebalance_applied: bool) -> tuple[bool, bool]:
     """Grade an orphan / stub / wrap-rhythm claim. Returns (is_orphan_claim, is_hard).
 
@@ -193,6 +227,10 @@ def _orphan_is_hard(low: str, *, rebalance_applied: bool) -> tuple[bool, bool]:
     """
     if not _contains_any_word(low, _ORPHAN_MARKERS):
         return False, False  # not an orphan/stub/wrap claim at all
+    # Superscar #3 entity-gate: "sits alone"/"stranded" about a LOGO/mark/image is
+    # a composition critique, not a typographic orphan. Only text subjects qualify.
+    if not _orphan_subject_is_text(low):
+        return False, False
     # a genuine 1-word orphan is a real defect regardless of re-wrap state.
     if _contains_any_word(low, _ONE_WORD_ORPHAN_MARKERS):
         return True, True

--- a/scripts/wr2_html_renderer/tests/test_orphan_entity_gate.py
+++ b/scripts/wr2_html_renderer/tests/test_orphan_entity_gate.py
@@ -1,54 +1,59 @@
-"""Regression test for superscar #3 in _orphan_is_hard (orphan entity over-match).
+"""Regression test for superscar #3 in _orphan_is_hard — orphan over-match (4 occurrences).
 
-A typographic-orphan marker ("sits alone", "stranded", "widow") must grade as a
-HARD orphan ONLY when the subject is text (word/line/title/headline/wrap), NOT
-when it describes a non-text composition element (logo/mark/image floating alone).
-Born from draft 4212d91a slide-2 render_failed (2026-06-25): "the logo sits alone"
-was mis-graded a HARD orphan, blocking a pure-composition slide the W82 boolean
-cure should have accepted.
+The Claude vision critic reuses orphan vocabulary ("orphan", "sits alone",
+"stranded") metaphorically for SPATIAL isolation of layout elements (logo, rule,
+image), not just typographic orphans. A blacklist of phrases is whack-a-mole
+(4 consecutive over-matches). The structural cure identifies a typographic orphan
+POSITIVELY: a text-unit (word/line/title/headline/…) co-occurring with a
+bad-landing predicate, OR an explicit one-word marker. A bare bad-landing word
+with no text-unit is composition.
+
+Born from draft 4212d91a (2026-06-25): "logo sits alone", "image stranded",
+"decorative orphan… a label" all blocked composition-only slides as HARD orphans,
+defeating the W82 boolean cure (has_hard=True short-circuits it).
 """
 import sys, os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "scripts"))
 from wr2_html_renderer import designer_loop as dl  # noqa: E402
 
-
-def test_logo_sits_alone_is_not_a_typographic_orphan():
-    logo = ("logo isolation: the bali zero mark sits alone and undersized at ~91% "
-            "height with no anchor relationship to the text block. it floats rather than grounds.")
-    assert dl._orphan_is_hard(logo, rebalance_applied=False) == (False, False)
-
-
-def test_image_stranded_is_composition_not_orphan():
-    img = "the hero image feels stranded — floats alone with no anchor."
-    assert dl._orphan_is_hard(img.lower(), rebalance_applied=False) == (False, False)
-
-
-def test_real_headline_orphans_stay_hard():
-    cases = [
-        "one-word orphan 'not' on the final headline line — the four-line wrap leaves a lone word.",
-        "the title wraps leaving a single word stranded on its own line.",
-        "'nobody' sits alone on the middle line of the headline — a one-word island.",
-        "short tail: the last line of the title is a stub.",
-    ]
-    for c in cases:
-        assert dl._orphan_is_hard(c, rebalance_applied=False) == (True, True), c
+_CASES = [
+    # (name, text, expected (is_orphan, is_hard))
+    ("innocence_oneword_headline", "one-word orphan 'not' on the final headline line — the four-line wrap leaves a lone word.", (True, True)),
+    ("innocence_title_single_word", "the title wraps leaving a single word stranded on its own line.", (True, True)),
+    ("innocence_sits_alone_headline", "'nobody' sits alone on the middle line of the headline — a one-word island.", (True, True)),
+    ("innocence_title_stub", "short tail: the last line of the title is a stub.", (True, True)),
+    ("guilt_logo_sits_alone", "logo isolation: the bali zero mark sits alone and undersized. it floats rather than grounds.", (False, False)),
+    ("guilt_image_stranded", "the hero image feels stranded — floats alone with no anchor.", (False, False)),
+    ("guilt_decorative_orphan_rule", "yellow dash/rule has no kicker or eyebrow text — it functions as a decorative orphan rather than an entry point. a label that never arrives.", (False, False)),
+    ("stress_eyebrow_dangling_stub", "the section eyebrow is a dangling stub with nothing after it.", (False, False)),
+    ("stress_ragged_oneword_tail", "the headline's last line is a ragged one-word tail.", (True, True)),
+    ("boundary_divider_stranded", "the divider bar is stranded with nothing around it.", (False, False)),
+    ("boundary_stub_line_headline", "a stub of a final line dangles under the headline.", (True, True)),
+]
 
 
-def test_full_classify_accepts_logo_composition_slide():
-    issues = [
-        "Bottom-third dead zone: ~35% of the canvas below the body copy is pure void before the logo.",
-        "Logo isolation: the Bali Zero mark sits alone and undersized with no anchor to the text block. It floats rather than grounds.",
-        "Top-plus-bottom void pinch: both the top third and the bottom third are empty.",
+def test_orphan_entity_intent_grading():
+    for name, text, want in _CASES:
+        got = dl._orphan_is_hard(text, rebalance_applied=False)
+        assert got == want, f"{name}: want {want} got {got}"
+
+
+def test_logo_composition_slide_not_hard():
+    """The 4212d91a slide-4 issue set must no longer set has_hard via a false orphan."""
+    slide4 = [
+        "Top ~40% of the frame is dead anthracite void — the content block has sunk to the lower half.",
+        "Yellow dash/rule functions as a decorative orphan rather than an editorial entry point. The visual grammar implies a label that never arrives.",
+        "Excessive dead zone between body text end and logo. The logo floats at the bottom in isolation.",
+        "Body text is rendered bold.",
         "vision: unbalanced/crammed",
     ]
-    has_hard, _ = dl._classify_residual_issues(issues, rebalance_applied=False)
-    assert has_hard is False  # no false typographic-orphan HARD anymore
+    has_hard, _ = dl._classify_residual_issues(slide4, rebalance_applied=False)
+    assert has_hard is False
 
 
 if __name__ == "__main__":
-    for fn in [test_logo_sits_alone_is_not_a_typographic_orphan,
-               test_image_stranded_is_composition_not_orphan,
-               test_real_headline_orphans_stay_hard,
-               test_full_classify_accepts_logo_composition_slide]:
-        fn(); print("PASS", fn.__name__)
+    test_orphan_entity_intent_grading()
+    print("PASS test_orphan_entity_intent_grading (11 cases)")
+    test_logo_composition_slide_not_hard()
+    print("PASS test_logo_composition_slide_not_hard")
     print("ALL PASS")

--- a/scripts/wr2_html_renderer/tests/test_orphan_entity_gate.py
+++ b/scripts/wr2_html_renderer/tests/test_orphan_entity_gate.py
@@ -1,0 +1,54 @@
+"""Regression test for superscar #3 in _orphan_is_hard (orphan entity over-match).
+
+A typographic-orphan marker ("sits alone", "stranded", "widow") must grade as a
+HARD orphan ONLY when the subject is text (word/line/title/headline/wrap), NOT
+when it describes a non-text composition element (logo/mark/image floating alone).
+Born from draft 4212d91a slide-2 render_failed (2026-06-25): "the logo sits alone"
+was mis-graded a HARD orphan, blocking a pure-composition slide the W82 boolean
+cure should have accepted.
+"""
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "scripts"))
+from wr2_html_renderer import designer_loop as dl  # noqa: E402
+
+
+def test_logo_sits_alone_is_not_a_typographic_orphan():
+    logo = ("logo isolation: the bali zero mark sits alone and undersized at ~91% "
+            "height with no anchor relationship to the text block. it floats rather than grounds.")
+    assert dl._orphan_is_hard(logo, rebalance_applied=False) == (False, False)
+
+
+def test_image_stranded_is_composition_not_orphan():
+    img = "the hero image feels stranded — floats alone with no anchor."
+    assert dl._orphan_is_hard(img.lower(), rebalance_applied=False) == (False, False)
+
+
+def test_real_headline_orphans_stay_hard():
+    cases = [
+        "one-word orphan 'not' on the final headline line — the four-line wrap leaves a lone word.",
+        "the title wraps leaving a single word stranded on its own line.",
+        "'nobody' sits alone on the middle line of the headline — a one-word island.",
+        "short tail: the last line of the title is a stub.",
+    ]
+    for c in cases:
+        assert dl._orphan_is_hard(c, rebalance_applied=False) == (True, True), c
+
+
+def test_full_classify_accepts_logo_composition_slide():
+    issues = [
+        "Bottom-third dead zone: ~35% of the canvas below the body copy is pure void before the logo.",
+        "Logo isolation: the Bali Zero mark sits alone and undersized with no anchor to the text block. It floats rather than grounds.",
+        "Top-plus-bottom void pinch: both the top third and the bottom third are empty.",
+        "vision: unbalanced/crammed",
+    ]
+    has_hard, _ = dl._classify_residual_issues(issues, rebalance_applied=False)
+    assert has_hard is False  # no false typographic-orphan HARD anymore
+
+
+if __name__ == "__main__":
+    for fn in [test_logo_sits_alone_is_not_a_typographic_orphan,
+               test_image_stranded_is_composition_not_orphan,
+               test_real_headline_orphans_stay_hard,
+               test_full_classify_accepts_logo_composition_slide]:
+        fn(); print("PASS", fn.__name__)
+    print("ALL PASS")


### PR DESCRIPTION
## Structural cure: positive typographic-orphan identification (superscar #3, 4th over-match)

### The recurrence
Re-rendering frozen draft `4212d91a` with the W82 boolean cure live still produced `render_failed` — the designer-loop's `_orphan_is_hard` graded **composition** critiques as HARD typographic orphans because the Claude vision critic reuses orphan vocabulary metaphorically:
- "the logo **sits alone** and undersized… floats rather than grounds" (logo placement)
- "the hero image feels **stranded** — floats alone" (image placement)
- "yellow dash/rule functions as a **decorative orphan**… a label that never arrives" (rule placement)

With `has_hard=True`, the W82 `readable`/`balanced` cure at the accept gate became a no-op, so composition-only slides failed. **Four consecutive over-matches of the same guard** — the cicatrix signal to stop patching and cure the root.

### The cure (invert blacklist → positive ID)
A real typographic orphan **is** a unit of running TEXT that wrapped/landed badly. The detector now *requires both halves of that definition*: a text-unit (`word/line/title/headline/heading/sentence/tail/caption`) co-occurring with a bad-landing predicate (`orphan/stub/widow/stranded/sits-alone/dangling/ragged/wraps/…`), OR an explicit one-word marker. A bare bad-landing word with no text-unit is composition. Layout labels (label/tag/kicker/eyebrow/dash/rule) are NOT text-units, so they no longer rescue the HARD grade.

Designed by an independent agent, replaces the whack-a-mole `_ORPHAN_MARKERS`/`_orphan_subject_is_text` with `_ORPHAN_TEXT_UNITS` + `_ORPHAN_BAD_LANDING` + `_is_typographic_orphan`.

### Verified live (not just unit-tested)
- 11 grading cases pass: 4 real headline/title orphans stay HARD; 3 metaphor + 4 boundary/stress cases become composition. Test: `scripts/wr2_html_renderer/tests/test_orphan_entity_gate.py`.
- **Hotfixed into the runtime and re-rendered `4212d91a`**: slide 2 (decorative-orphan / logo-sits-alone) — **0 failures post-cure** (it failed every prior run). The over-match is dead.
- The classifier still discriminates correctly: the render now stops at slide 3 on a **real legibility defect** — "Body ALL-CAPS 47-word paragraph… cognitively fatiguing… legal-fine-print vs NYT/FT ~25-word cap" — which is `readable=false` and rightly stays HARD. (That's a content-generation issue: the draft body is genuinely too long, not a classifier bug.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
