### PR TITLE
feat(intake): add fallback page and text-layer recovery

### DIFF
--- a/apps/backend-rag/backend/services/intake/classify.py
+++ b/apps/backend-rag/backend/services/intake/classify.py
@@ -633,6 +633,7 @@ def _stay_permit_subtype(text: str) -> str | None:
 # Confidence CAP for a vision-only classification: always in the review band,
 # NEVER enough to auto-commit (the gate needs >= human review on vision alone).
 VISION_CLASSIFY_CONF = 0.55
+VISION_CLASSIFY_MAX_PAGES = 3
 
 # One constrained call. qwen2.5vl:7b is used directly (NOT the qwen3-vl
 # primary): the 2026-06-04 empirical finding above shows qwen3-vl buries its
@@ -669,8 +670,8 @@ def _parse_vision_answer(raw: str | None) -> str | None:
     return cleaned if cleaned in DOC_TYPES else None
 
 
-async def _vision_classify_first_page(png_bytes: bytes) -> str | None:
-    """ONE local vision call to type a document the keywords could not.
+async def _vision_classify_page(png_bytes: bytes) -> str | None:
+    """ONE local vision call to type a document page the keywords could not.
 
     Returns a DOC_TYPES member or None. NEVER raises: any error/timeout/
     non-conforming answer degrades to None (caller keeps "unknown").
@@ -696,11 +697,29 @@ async def _vision_classify_first_page(png_bytes: bytes) -> str | None:
     return answer
 
 
+async def _vision_classify_pages(pages: list[bytes]) -> tuple[str | None, int | None]:
+    """Try up to VISION_CLASSIFY_MAX_PAGES pages, returning (type, page_offset).
+
+    The fallback is intentionally sequential and capped: it runs only after the
+    keyword floor fails, and every vision-only type remains review-band. Page 1
+    is often a cover/blank scan in WhatsApp uploads; letting page 2/3 answer
+    rescues those without guessing from text.
+    """
+    for offset, png in enumerate(pages[:VISION_CLASSIFY_MAX_PAGES]):
+        if not png:
+            continue
+        answer = await _vision_classify_page(png)
+        if answer and answer != "unknown":
+            return answer, offset
+    return None, None
+
+
 async def classify_document(
     ocr_text: str | None,
     pages: list[dict[str, Any]] | None = None,
     *,
     first_page_png: bytes | None = None,
+    vision_page_pngs: list[bytes] | None = None,
 ) -> dict[str, Any]:
     """Classify a document from OCR text. Local-only, anti-hallucination.
 
@@ -708,10 +727,12 @@ async def classify_document(
         ocr_text: concatenated OCR text (all pages). If None, derived from pages.
         pages: per-page OCR dicts from ``ocr_pages`` (used to attribute the
                winning evidence to a specific source page).
-        first_page_png: optional raw PNG bytes of the FIRST page. When the
-               keyword score lands below the unknown floor, ONE constrained
-               local vision call (:func:`_vision_classify_first_page`) gets a
-               chance to type the document — confidence capped at
+        first_page_png: backward-compatible shortcut for a single first-page
+               fallback image.
+        vision_page_pngs: optional raw PNG bytes for the first candidate pages.
+               When the keyword score lands below the unknown floor, capped
+               local vision calls (:func:`_vision_classify_pages`) get a
+               chance to type the document -- confidence capped at
                ``VISION_CLASSIFY_CONF`` (review band, never auto-commit).
 
     Returns:
@@ -747,15 +768,25 @@ async def classify_document(
             }
 
     # Anti-hallucination floor: weak keyword evidence -> NOT a guess. One local
-    # vision attempt (catalog v2) may still type it — capped in the review band.
+    # vision pass (catalog v2) may still type it -- capped in the review band.
     if best_type is None or best_score < 0.30:
-        if first_page_png is not None:
-            vtype = await _vision_classify_first_page(first_page_png)
+        candidate_pngs = vision_page_pngs or (
+            [first_page_png] if first_page_png is not None else []
+        )
+        if candidate_pngs:
+            vtype, page_offset = await _vision_classify_pages(candidate_pngs)
             if vtype and vtype != "unknown":
+                source_page = None
+                if page_offset is not None:
+                    source_page = (
+                        pages[page_offset].get("page")
+                        if page_offset < len(pages)
+                        else page_offset
+                    )
                 return {
                     "type": vtype,
                     "confidence": VISION_CLASSIFY_CONF,
-                    "source_page": pages[0].get("page") if pages else None,
+                    "source_page": source_page,
                     "scores": scores,
                     "via": "vision_fallback",
                 }
@@ -882,7 +913,17 @@ async def _run_classify_stage(pool: asyncpg.Pool, job: dict) -> dict:
     ocr = await ocr_pages(pre.pages)
     full_text = "\n".join(p["text"] for p in ocr)
     first_png = getattr(pre.pages[0], "png_bytes", None) if pre.pages else None
-    cls = await classify_document(full_text, ocr, first_page_png=first_png)
+    vision_pngs = [
+        getattr(page, "png_bytes", b"")
+        for page in pre.pages[:VISION_CLASSIFY_MAX_PAGES]
+        if getattr(page, "png_bytes", b"")
+    ]
+    cls = await classify_document(
+        full_text,
+        ocr,
+        first_page_png=first_png,
+        vision_page_pngs=vision_pngs,
+    )
 
     return {
         "doc_type": cls["type"],

--- a/apps/backend-rag/backend/services/intake/preprocess.py
+++ b/apps/backend-rag/backend/services/intake/preprocess.py
@@ -349,6 +349,14 @@ _WORD_MIMES = frozenset(
     }
 )
 
+_TEXT_MIMES = frozenset(
+    {
+        "text/plain",
+        "text/csv",
+        "application/csv",
+    }
+)
+
 
 def _extract_docx_text_sync(blob_path: str) -> str | None:
     """Extract the text layer from a .docx via python-docx. None on failure.
@@ -366,6 +374,23 @@ def _extract_docx_text_sync(blob_path: str) -> str | None:
     except Exception as exc:  # broad: any parse failure -> graceful fallthrough
         logger.warning("docx text extract failed for %s: %s", blob_path, exc)
         return None
+
+
+def _decode_plain_text_sync(raw: bytes) -> str | None:
+    """Decode local text-ish blobs into a born-digital text layer.
+
+    WhatsApp/Drive can deliver .txt/.csv intake evidence as plain files. Treating
+    those bytes as an image sends garbage to the VLM and lands real text in
+    unknown. Decode locally and let ocr_pages consume it like a PDF text layer.
+    """
+    for encoding in ("utf-8-sig", "utf-16", "latin-1"):
+        try:
+            text = raw.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+        if text and text.strip():
+            return text
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -444,7 +469,7 @@ async def preprocess_blob(
         # review), never a stage crash.
         text = await asyncio.to_thread(_extract_docx_text_sync, blob_path)
         if text is None:
-            logger.warning("preprocess: word doc unreadable %s (mime=%s)", blob_path, mime)
+            logger.warning("preprocess: word doc unreadable (mime=%s)", mime)
             return PreprocessResult(
                 pages=[PageImage(index=0, png_bytes=b"", enhanced=False, text=None)],
                 n_pages=1,
@@ -456,6 +481,22 @@ async def preprocess_blob(
             n_pages=1,
             mime=mime,
             notes="word_textlayer",
+        )
+    elif mime in _TEXT_MIMES:
+        text = await asyncio.to_thread(_decode_plain_text_sync, raw)
+        if text is None:
+            logger.warning("preprocess: text blob unreadable (mime=%s)", mime)
+            return PreprocessResult(
+                pages=[PageImage(index=0, png_bytes=b"", enhanced=False, text=None)],
+                n_pages=1,
+                mime=mime,
+                notes="text_extract_failed",
+            )
+        return PreprocessResult(
+            pages=[PageImage(index=0, png_bytes=b"", enhanced=False, text=text)],
+            n_pages=1,
+            mime=mime,
+            notes="text_textlayer",
         )
     else:
         # Unknown/unsupported format -- pass raw bytes through; OCR may cope.

--- a/apps/backend-rag/backend/tests/services/intake/test_intake_classify_vision.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_intake_classify_vision.py
@@ -4,7 +4,7 @@ The Ollama vision helper is monkeypatched — no GPU/model needed. Locked
 behaviours:
 
   * the fallback fires ONLY when the keyword score is below the 0.30 floor
-    AND a first-page image is available;
+    AND at least one candidate page image is available;
   * only an EXACT DOC_TYPES member (case-insensitive, single token) is
     accepted — a sentence or an off-list word degrades to unknown;
   * confidence is CAPPED at VISION_CLASSIFY_CONF (review band — a vision-only
@@ -42,6 +42,20 @@ def _fake_vision(answer: str, calls: list[dict[str, Any]]):
     return fake
 
 
+def _fake_vision_sequence(answers: list[str], calls: list[dict[str, Any]]):
+    async def fake(
+        model: str,
+        png_b64: str,
+        prompt: str = "",
+        num_predict: int = 0,
+    ) -> tuple[str, str | None]:
+        calls.append({"model": model, "prompt": prompt, "num_predict": num_predict})
+        answer = answers.pop(0) if answers else "unknown"
+        return answer, ""
+
+    return fake
+
+
 # ---------------------------------------------------------------------------
 # _parse_vision_answer — exact-member contract
 # ---------------------------------------------------------------------------
@@ -60,6 +74,10 @@ def _fake_vision(answer: str, calls: list[dict[str, Any]]):
         ("family_card", "family_card"),
         ("birth_certificate", "birth_certificate"),
         ("marriage_certificate", "marriage_certificate"),
+        ("payment_receipt", "payment_receipt"),
+        ("travel_ticket", "travel_ticket"),
+        ("bank_statement", "bank_statement"),
+        ("medical_insurance", "medical_insurance"),
         ("receipt", None),  # off-list word -> rejected
         ("", None),
         (None, None),
@@ -86,6 +104,47 @@ async def test_vision_fires_below_floor_and_caps_confidence(monkeypatch):
     assert r["via"] == "vision_fallback"
     assert len(calls) == 1  # exactly ONE vision call
     assert "EXACTLY ONE word" in calls[0]["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_vision_scans_candidate_pages_until_known_type(monkeypatch):
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        cls,
+        "_ollama_vision",
+        _fake_vision_sequence(["unknown", "travel_ticket", "passport"], calls),
+    )
+
+    r = await cls.classify_document(
+        _WEAK_TEXT,
+        pages=[
+            {"page": 0, "text": ""},
+            {"page": 1, "text": ""},
+            {"page": 2, "text": ""},
+        ],
+        vision_page_pngs=[b"page-1", b"page-2", b"page-3"],
+    )
+
+    assert r["type"] == "travel_ticket"
+    assert r["confidence"] == cls.VISION_CLASSIFY_CONF
+    assert r["source_page"] == 1
+    assert r["via"] == "vision_fallback"
+    assert len(calls) == 2  # stops as soon as a typed page answers
+
+
+@pytest.mark.asyncio
+async def test_vision_candidate_pages_are_capped(monkeypatch):
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(cls, "_ollama_vision", _fake_vision("unknown", calls))
+
+    r = await cls.classify_document(
+        _WEAK_TEXT,
+        vision_page_pngs=[b"page-1", b"page-2", b"page-3", b"page-4"],
+    )
+
+    assert r["type"] == "unknown"
+    assert r["confidence"] == 0.0
+    assert len(calls) == cls.VISION_CLASSIFY_MAX_PAGES
 
 
 @pytest.mark.asyncio

--- a/apps/backend-rag/backend/tests/services/intake/test_preprocess_word.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_preprocess_word.py
@@ -35,6 +35,10 @@ def test_word_mimes_constant_covers_docx_and_doc() -> None:
     assert _DOC_MIME in pre._WORD_MIMES
 
 
+def test_text_mimes_constant_covers_plain_text() -> None:
+    assert "text/plain" in pre._TEXT_MIMES
+
+
 @pytest.mark.asyncio
 async def test_docx_emits_textlayer_page(monkeypatch, tmp_path) -> None:
     # Arrange: a file present on disk + a stubbed docx text extractor.
@@ -97,3 +101,34 @@ async def test_empty_docx_text_degrades(monkeypatch, tmp_path) -> None:
 
     assert result.pages[0].text is None
     assert result.notes == "word_extract_failed"
+
+
+@pytest.mark.asyncio
+async def test_plain_text_emits_textlayer_page(tmp_path) -> None:
+    blob = tmp_path / "note.txt"
+    text = "BOARDING PASS\nPassenger: Example Person\nTicket number: 123456"
+    blob.write_text(text, encoding="utf-8")
+
+    result = await pre.preprocess_blob(str(blob), declared_mime="text/plain")
+
+    assert result.n_pages == 1
+    page = result.pages[0]
+    assert page.text == text
+    assert page.png_bytes == b""
+    assert result.mime == "text/plain"
+    assert result.notes == "text_textlayer"
+
+
+@pytest.mark.asyncio
+async def test_plain_text_empty_degrades_without_logging_blob_path(caplog, tmp_path) -> None:
+    blob = tmp_path / "empty.txt"
+    blob.write_text("   \n\t", encoding="utf-8")
+    caplog.set_level("WARNING")
+
+    result = await pre.preprocess_blob(str(blob), declared_mime="text/plain")
+
+    assert result.pages[0].text is None
+    assert result.pages[0].png_bytes == b""
+    assert result.notes == "text_extract_failed"
+    assert "text blob unreadable" in caplog.text
+    assert str(blob) not in caplog.text


### PR DESCRIPTION
## Summary
- Try a capped local vision fallback across the first three candidate pages when keyword evidence stays below the unknown floor.
- Decode text/plain and CSV intake uploads as born-digital text layers instead of sending raw bytes to vision OCR.
- Keep vision-only classifications in review band and avoid logging raw blob paths for unreadable text/Word files.

## Tests
- `ruff check backend/services/intake/classify.py backend/services/intake/preprocess.py backend/tests/services/intake/test_intake_classify_vision.py backend/tests/services/intake/test_preprocess_word.py`
- `PYTHONPATH=. pytest backend/tests/services/intake/test_intake_classify_vision.py backend/tests/services/intake/test_preprocess_word.py -q`

## Notes
- Full `backend/tests/services/intake` was previously run in this worktree and showed unrelated shared-dev-DB worker failures in `test_intake_worker.py`; the targeted OCR/classify surface is green.
