### PR TITLE
fix(wr2): body-length — prompt contradiction + de-uppercase photo bodies (slide-3 legibility)

### DIFF
--- a/scripts/wr2_draft_generator.py
+++ b/scripts/wr2_draft_generator.py
@@ -168,7 +168,7 @@ HARD RULES:
 - NEVER use tones "cinico" or "istituzionale_severo" (legacy WR1, FORBIDDEN)
 - Language: ENGLISH (international expat audience)
 - Headlines max 60 characters
-- Body max 280 characters
+- Body max 280 characters AND ~40 words (whichever first; ~25-35 words ideal)
 - Slide 1 = cover (is_cover: true, is_hero_image: true ALWAYS)
 - LAST slide = CTA to Bali Zero
 - HERO slides must include image_prompt: editorial scene in Wired/Bloomberg style, NO stock photos, NO handshakes, NO passport close-ups (text-only slides do NOT need image_prompt)
@@ -245,11 +245,13 @@ STORYTELLING DIRECTIVES (overrides any default factual mode):
    END of the body in the form "[Source: <law-or-doc>]" — never at the
    beginning, never as the entire body.
 
-2. Body length: TARGET ~50-70 words (≈350-450 characters). Hard cap 280
-   characters per the format constraint above. If you cannot fit the story
-   in 280 chars, cut the citation, not the story. The skill that paints
-   these onto Canva slides has fixed text boxes; longer copy will overflow
-   and look bad.
+2. Body length: TARGET ~25-35 words (≈180-250 characters). HARD cap 280
+   characters AND ~40 words — whichever is hit first. Editorial reference
+   bodies (NYT/FT carousels) cap at ~25 words / 2-3 short sentences; past
+   ~40 words a slide reads as a dense legal-fine-print "text brick" the
+   vision critic rejects, ESPECIALLY on photo slides where the body renders
+   over an image. If you cannot fit the story, cut the citation, not the
+   story. Fixed text boxes overflow and look bad with longer copy.
 
 3. Headline is the HOOK, not the topic title. "Sham Investor KITAS: The
    Clock Is Ticking" is good (urgency, stakes). "Field Inspections Are

--- a/skills/bali-zero-brand/layouts/photo-fullbleed-split.md
+++ b/skills/bali-zero-brand/layouts/photo-fullbleed-split.md
@@ -31,7 +31,7 @@ html, body { background: var(--color-bg-black); margin: 0; padding: 0; }
 .content-bottom { position: absolute; left: var(--spacing-edge-margin); right: var(--spacing-edge-margin); bottom: 200px; color: var(--color-text-white); }
 .subheading { font-weight: var(--font-weight-extrabold); font-size: var(--font-size-subheadline); line-height: var(--line-height-snug); letter-spacing: var(--letter-spacing-title); color: var(--color-accent-yellow); text-transform: uppercase; margin-bottom: 18px; }
 .heading { font-weight: var(--font-weight-extrabold); font-size: var(--font-size-headline-slide); line-height: var(--line-height-tight); letter-spacing: var(--letter-spacing-title); color: var(--color-text-white); text-transform: uppercase; text-wrap: balance; text-shadow: 0 2px 18px rgba(0,0,0,0.55); }
-.body { font-weight: var(--font-weight-bold); font-size: 38px; line-height: var(--line-height-normal); letter-spacing: var(--letter-spacing-body); color: var(--color-text-white); text-transform: uppercase; text-shadow: 0 1px 12px rgba(0,0,0,0.6); }
+.body { font-weight: var(--font-weight-bold); font-size: 38px; line-height: var(--line-height-normal); letter-spacing: var(--letter-spacing-body); color: var(--color-text-white); text-shadow: 0 1px 12px rgba(0,0,0,0.6); }  /* text-transform:uppercase removed 2026-06-25: mixed-case body forced to ALL-CAPS reads as illegible text-brick (critic HARD-rejects), esp. over photos. Same fix as evidence-carved.md 2026-05-22. Keeps bold+shadow. */
 </style></head>
 <body>
   <div class="hero" data-zone-type="hero-photo"></div>

--- a/skills/bali-zero-brand/layouts/photo-fullbleed-top.md
+++ b/skills/bali-zero-brand/layouts/photo-fullbleed-top.md
@@ -31,7 +31,7 @@ html, body { background: var(--color-bg-black); margin: 0; padding: 0; }
 .content { position: absolute; left: var(--spacing-edge-margin); right: var(--spacing-edge-margin); top: 120px; color: var(--color-text-white); }
 .subheading { font-weight: var(--font-weight-extrabold); font-size: var(--font-size-subheadline); line-height: var(--line-height-snug); letter-spacing: var(--letter-spacing-title); color: var(--color-accent-yellow); text-transform: uppercase; margin-bottom: 18px; }
 .heading { font-weight: var(--font-weight-extrabold); font-size: var(--font-size-headline-slide); line-height: var(--line-height-tight); letter-spacing: var(--letter-spacing-title); color: var(--color-text-white); text-transform: uppercase; text-wrap: balance; margin-bottom: 22px; text-shadow: 0 2px 18px rgba(0,0,0,0.55); }
-.body { font-weight: var(--font-weight-bold); font-size: 38px; line-height: var(--line-height-normal); letter-spacing: var(--letter-spacing-body); color: var(--color-text-white); text-transform: uppercase; text-shadow: 0 1px 12px rgba(0,0,0,0.6); }
+.body { font-weight: var(--font-weight-bold); font-size: 38px; line-height: var(--line-height-normal); letter-spacing: var(--letter-spacing-body); color: var(--color-text-white); text-shadow: 0 1px 12px rgba(0,0,0,0.6); }  /* text-transform:uppercase removed 2026-06-25: mixed-case body forced to ALL-CAPS reads as illegible text-brick (critic HARD-rejects), esp. over photos. Same fix as evidence-carved.md 2026-05-22. Keeps bold+shadow. */
 </style></head>
 <body>
   <div class="hero" data-zone-type="hero-photo"></div>


### PR DESCRIPTION
## Body-length: kill the prompt contradiction + de-uppercase photo bodies

### Live trigger
With the orphan structural cure live (PR #1722), re-rendering `4212d91a` advanced past the composition slides and stopped at **slide 3** on a *real* legibility defect:
> "Body **ALL-CAPS** 47-word paragraph — uppercase strips ascenders/descenders… cognitively fatiguing… legal-fine-print vs NYT/FT ~25-word cap."

`readable=false`, correctly HARD. The classifier was right — the defect is upstream. Two root causes, neither the classifier:

### 1. Prompt self-contradiction (`wr2_draft_generator.py`)
The body-length guidance said *"TARGET ~50-70 words (≈350-450 characters). Hard cap 280 characters"* — the **target exceeds its own hard cap**. The model followed the salient word count → 33-47-word bodies. Fixed to a coherent dual cap: **TARGET ~25-35 words, HARD cap 280 chars AND ~40 words** (whichever first), with the NYT/FT reference and an explicit photo-slide note.

### 2. Template forced ALL-CAPS (skill layouts)
`photo-fullbleed-split` / `photo-fullbleed-top` applied `.body { text-transform: uppercase }`, turning a perfectly-legible **33-word mixed-case** body ("Before KITAP, there's KITAS…") into an uppercase text-brick. Removed `text-transform:uppercase` from `.body` in both (kept bold + shadow for photo legibility) — the exact fix already applied to `evidence-carved.md` (2026-05-22). Applied to BOTH the runtime path (`~/.claude/skills`, live, with backups) and the git-tracked repo copy (`skills/bali-zero-brand/layouts`, which had drifted — HOME-fork scar #1).

### Evidence
The body source was **33 words / 217 chars / mixed-case** — well within all limits. The illegibility was injected by the template, not the content. DB audit (107 live slide-bodies): 0 exceed 280 chars, but 13 exceed 40 words — the word/char mismatch the prompt fix closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
