### PR TITLE
fix(intake): prioritize WhatsApp pending jobs

### DIFF
--- a/apps/backend-rag/backend/services/intake/worker.py
+++ b/apps/backend-rag/backend/services/intake/worker.py
@@ -601,6 +601,15 @@ class IntakeWorker:
                     WHEN 'processing'   THEN 5
                     ELSE 9  -- 'pending' last
                   END,
+                  -- WhatsApp mirror is the client-facing intake lane. Once all
+                  -- cheap downstream stages are drained, do not let historical
+                  -- Drive backfills bury fresh WA attachments behind tens of
+                  -- thousands of pending OCR jobs.
+                  CASE
+                    WHEN status = 'pending' AND source = 'whatsapp' THEN 0
+                    WHEN status = 'pending'                         THEN 1
+                    ELSE 0
+                  END,
                   next_visible_at, id
                 LIMIT 1
                 FOR UPDATE SKIP LOCKED

--- a/apps/backend-rag/backend/tests/services/intake/test_intake_worker_main_wiring.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_intake_worker_main_wiring.py
@@ -68,3 +68,29 @@ async def test_main_uses_stub_when_env_set(captured, monkeypatch):
     await worker_mod.main()
     # Stub path: main() does NOT pass stage_handler → IntakeWorker default (None here).
     assert captured["stage_handler"] is None
+
+
+@pytest.mark.asyncio
+async def test_claim_prioritizes_pending_whatsapp_before_drive_backfill():
+    """WA mirror attachments must not sit behind the historical Drive backlog."""
+
+    class _FakeConn:
+        sql: str | None = None
+        args: tuple | None = None
+
+        async def fetchrow(self, sql, *args):  # noqa: ANN001, ANN202
+            self.sql = sql
+            self.args = args
+            return None
+
+    conn = _FakeConn()
+    worker = worker_mod.IntakeWorker(_FakePool())
+
+    await worker._claim_with_inbound(conn)
+
+    assert conn.sql is not None
+    assert "WHEN status = 'pending' AND source = 'whatsapp' THEN 0" in conn.sql
+    assert "WHEN status = 'pending'                         THEN 1" in conn.sql
+    assert conn.sql.index("WHEN 'ocr_done'") < conn.sql.index(
+        "WHEN status = 'pending' AND source = 'whatsapp' THEN 0"
+    )


### PR DESCRIPTION
## Summary
- prioritize `source='whatsapp'` pending intake jobs ahead of historical Drive backfill pending jobs
- preserve existing stage priority so `validated`, `extracted`, and `ocr_done` rows still drain before new OCR work
- add DB-free regression coverage for the claim SQL ordering

## Evidence
- Local unit: `PYTHONPATH=. .venv/bin/python -m pytest backend/tests/services/intake/test_intake_worker_main_wiring.py -q` -> 3 passed
- Lint: `PYTHONPATH=. .venv/bin/python -m ruff check backend/services/intake/worker.py backend/tests/services/intake/test_intake_worker_main_wiring.py` -> passed
- Live DB read-only q100 pending-order simulation:
  - old next 100 pending claims: 99 Drive, 1 WhatsApp
  - new next 100 pending claims: 100 WhatsApp

## Privacy
No CRM writes, no routing changes, no document content printed. The DB check was aggregate/redacted only.
