### PR TITLE
feat(analytics): wire ZantaraWidget WhatsApp CTA into WhatsAppLeadButton lead capture

### DIFF
--- a/apps/mouth/src/components/ZantaraWidget.tsx
+++ b/apps/mouth/src/components/ZantaraWidget.tsx
@@ -14,6 +14,8 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import Image from "next/image";
 import { MessageCircle, X, Send, Loader2 } from "lucide-react";
 import dynamic from "next/dynamic";
+import { usePathname } from "next/navigation";
+import { WhatsAppLeadButton } from "@/components/lead/WhatsAppLeadButton";
 
 const ReactMarkdown = dynamic(() => import("react-markdown"), { ssr: false });
 
@@ -78,6 +80,8 @@ export function ZantaraWidget() {
   const [input, setInput] = useState("");
   const [isStreaming, setIsStreaming] = useState(false);
   const [hasGreeted, setHasGreeted] = useState(false);
+
+  const pathname = usePathname();
 
   const bottomRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -306,13 +310,18 @@ export function ZantaraWidget() {
             <div ref={bottomRef} />
           </div>
 
-          {/* WhatsApp CTA after 4+ messages */}
+          {/* WhatsApp CTA after 3+ user messages */}
           {messages.filter((m) => m.role === "user").length >= 3 && (
             <div className="px-4 pb-2">
-              <a
-                href="https://wa.me/6282210302328?text=Hi%20Bali%20Zero%2C%20I%20was%20chatting%20with%20Zantara%20on%20your%20website..."
-                target="_blank"
-                rel="noopener noreferrer"
+              <WhatsAppLeadButton
+                source="zantara_widget_handoff"
+                context={{ section: "zantara_widget", page: pathname }}
+                whatsappContext={[
+                  { label: "Source", value: "Zantara Chat Widget" },
+                  { label: "Page", value: pathname },
+                ]}
+                utm={{ page: pathname }}
+                fallbackHref="https://wa.me/6282210302328?text=Hi%20Bali%20Zero%2C%20I%20was%20chatting%20with%20Zantara%20on%20your%20website..."
                 className="flex items-center justify-center gap-2 w-full py-2 rounded-lg bg-[#25D366]/15 text-[#25D366] text-xs font-medium hover:bg-[#25D366]/25 transition-colors"
               >
                 <svg
@@ -323,7 +332,7 @@ export function ZantaraWidget() {
                   <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
                 </svg>
                 Continue on WhatsApp
-              </a>
+              </WhatsAppLeadButton>
             </div>
           )}
 


### PR DESCRIPTION
## Insight
The "Continue on WhatsApp" CTA inside the Zantara floating chat widget fires after a visitor sends 3+ messages — a high-intent signal — but the link was a bare hardcoded `<a href="wa.me/...">` with zero lead capture and zero analytics dispatch. This PR migrates it onto the same `WhatsAppLeadButton` pattern already in production for articles (`source="article"`) and the KBLI Navigator (`source="kbli_navigator"`).

## Studio
- `apps/mouth/src/components/ZantaraWidget.tsx` — added `usePathname` + `WhatsAppLeadButton` imports, replaced the hardcoded anchor with `<WhatsAppLeadButton source="zantara_widget_handoff" ...>`, preserved icon/styling/trigger condition unchanged.

## Source
Read-only investigation of `WhatsAppLeadButton.tsx`, two production call sites (`KBLIConsultationCTA.tsx`, `InlineNewsCTA.tsx`), `apps/backend-rag/backend/services/lead_capture/source.py` (LeadSource enum), and `packages/core/analytics/funnel-view.ts` (FUNNEL_EVENTS registry).

## Methodology
Read-only investigation first before any edit. Confirmed the `lead_whatsapp_cta` event used by `WhatsAppLeadButton` is already registered frontend+backend — no new event needed. Followed the exact pattern Antonello already approved for `CTAHandoff` (see `pr-cta-handoff-whatsapp-tracking.md`): ship the FE change as a Draft PR with the new `source` value already filled in, rather than waiting for backend registration before writing code.

## Raw Observations
- `WhatsAppLeadButton`'s `source` prop is a plain `string` in TypeScript — the real constraint is server-side, a closed Pydantic enum (`LeadSource`) in `apps/backend-rag`.
- Current enum values: `VISA_CLOCK, VISA_MATCH, KBLI_DECODER, KBLI_BUILDER, TAX_GAP, ZONING_CHECK, ARTICLE, KBLI_NAVIGATOR`. `zantara_widget_handoff` is not yet present.
- On fetch failure (including a 422 from an unregistered source), `WhatsAppLeadButton` automatically falls back to `fallbackHref` — user experience is unaffected; only the lead-capture write and `captured:true` analytics flag are skipped.
- Trigger condition (`messages.filter(m => m.role === "user").length >= 3`) and visual styling are unchanged.
- `whatsappContext`/`context` intentionally exclude chat message content — only `page: pathname` and static labels are sent, to avoid forwarding any PII a visitor may have typed before clicking.

## Reasoning Path
Mirrored the two existing production patterns rather than inventing a new shape for `context`/`whatsappContext`. Used `usePathname()` (Next.js App Router standard) instead of `window.location.pathname` for SSR-safety.

## Risk
LOW. Additive/replacement change scoped to a single CTA block in a single client component. No change to `WhatsAppLeadButton.tsx`, `FunnelFrame.tsx`, or any other CTA. Until `zantara_widget_handoff` is registered server-side, every click will hit a 422 internally and silently fall back to the bare wa.me link — same end-user behavior as before, but `lead_intent_id` will not be captured.

## Implication
Must stay in **Draft** until the backend registers `zantara_widget_handoff` in `LeadSource`. Once registered, no further FE change is needed — just convert to Ready for Review and merge.

## Recommendation
Keep as Draft scaffold for review, same pattern Antonello already approved for the CTAHandoff migration.

## Next Action
1. Antonello: add `ZANTARA_WIDGET_HANDOFF = "zantara_widget_handoff"` to `LeadSource` enum (+ required `human_name`/`result_url_path` mapping).
2. Once merged server-side: convert to Ready, verify via DevTools (`/api/lead/capture` → 200 + `lead_intent_id`) on a live click-test, then merge (self-merge eligible, `apps/mouth/**`).
3. Apply same pattern to `ServicePricing.tsx` modal (`source="pricing_modal"`) — next queued task.
