### PR TITLE
fix(wr2-render): expand {{#each}} list blocks — no more raw mustache slides

### DIFF
--- a/scripts/wr2_html_renderer/composer.py
+++ b/scripts/wr2_html_renderer/composer.py
@@ -888,6 +888,89 @@ def _facts_block_html(pairs: list[tuple[str, str]], source_text: str | None) -> 
     return "\n".join(rows)
 
 
+# Storyboarder→template field aliases for {{#each}} loops. The layout templates
+# iterate a canonical variable (`items`, `facts`, `citations`, `events`) but the
+# storyboarder emits domain-named arrays (`list_items`, …). Map the alias to the
+# template's variable so the loop binds instead of shipping raw {{#each items}}.
+_EACH_ALIASES: dict[str, tuple[str, ...]] = {
+    "items": ("list_items", "items"),          # dark-status-list
+    "facts": ("facts", "fact_items"),          # evidence-carved
+    "citations": ("citations", "sources"),     # source-citation
+    "events": ("events", "timeline", "list_items"),  # timeline-pinboard
+}
+
+
+def _resolve_each_rows(var: str, slide: dict[str, Any]) -> list[Any] | None:
+    """Find the array a {{#each <var>}} loop should iterate, honoring aliases."""
+    for key in _EACH_ALIASES.get(var, (var,)):
+        rows = slide.get(key)
+        if isinstance(rows, list) and rows:
+            return rows
+    return None
+
+
+def _expand_each_blocks(html: str, slide: dict[str, Any]) -> str:
+    """Expand Handlebars-style ``{{#each <var>}}…{{/each}}`` blocks.
+
+    For each row, the inner template's ``{{field}}`` placeholders are filled from
+    that row dict (``{{this}}`` → the row itself when it is a scalar), and a nested
+    ``{{#if field}}…{{/if}}`` keeps its body only when the row has a truthy field.
+    Field values are HTML-escaped (rows carry user copy). A block whose array is
+    missing/empty is removed entirely (no raw mustache shipped) — this is the bug
+    fix: previously the whole ``{{#each}}`` block reached the renderer verbatim.
+    """
+    each_re = re.compile(r"\{\{#each\s+([a-z_]+)\}\}(.*?)\{\{/each\}\}", re.DOTALL)
+
+    def _render_block(m: re.Match[str]) -> str:
+        var, inner = m.group(1), m.group(2)
+        rows = _resolve_each_rows(var, slide)
+        if not rows:
+            return ""  # no data → drop the block (never ship raw {{#each}})
+        out: list[str] = []
+        for row in rows:
+            chunk = inner
+            if isinstance(row, dict):
+                # nested {{#if field}}…{{/if}} per row
+                def _if_sub(mi: re.Match[str], _row: dict[str, Any] = row) -> str:
+                    return mi.group(2) if _row.get(mi.group(1)) else ""
+                chunk = re.sub(
+                    r"\{\{#if\s+([a-z_]+)\}\}(.*?)\{\{/if\}\}", _if_sub, chunk,
+                    flags=re.DOTALL,
+                )
+                for fk, fv in row.items():
+                    chunk = chunk.replace("{{%s}}" % fk, _html_escape(str(fv)))
+                chunk = chunk.replace("{{this}}", _html_escape(str(row)))
+            else:
+                # scalar row: {{this}} is the value
+                chunk = chunk.replace("{{this}}", _html_escape(str(row)))
+            # strip any leftover {{field}} the row didn't supply (no raw mustache)
+            chunk = re.sub(r"\{\{[a-z_]+\}\}", "", chunk)
+            out.append(chunk)
+        return "".join(out)
+
+    return each_re.sub(_render_block, html)
+
+
+def _qa_dialogue_fields(slide: dict[str, Any]) -> dict[str, str]:
+    """Adapt the storyboarder's ``qa_pairs`` array to qa-dialogue's flat fields.
+
+    The qa-dialogue template wants ``voice_a_label/voice_a_quote/voice_b_*`` but
+    the storyboarder emits ``qa_pairs: [{voice, line}, …]``. Map the first two
+    pairs onto the two voices. Returns {} when qa_pairs is absent (template then
+    falls back to whatever flat fields the slide already carries).
+    """
+    pairs = slide.get("qa_pairs")
+    if not isinstance(pairs, list) or len(pairs) < 1:
+        return {}
+    out: dict[str, str] = {}
+    for idx, key in ((0, "a"), (1, "b")):
+        if idx < len(pairs) and isinstance(pairs[idx], dict):
+            p = pairs[idx]
+            out["voice_%s_label" % key] = str(p.get("voice") or p.get("label") or "")
+            out["voice_%s_quote" % key] = str(p.get("line") or p.get("quote") or "")
+    return out
+
+
 def _fill_placeholders(
     html: str,
     slide: dict[str, Any],
@@ -977,6 +1060,11 @@ def _fill_placeholders(
         else:
             statement_emphasis_html = f'<span class="emphasis">{words[0]}</span>'
 
+    # Expand {{#each <var>}} list blocks FIRST (dark-status-list / evidence-carved /
+    # source-citation / timeline-pinboard) so the loop rows are materialized before
+    # the scalar placeholder pass. Previously unhandled → raw mustache shipped.
+    html = _expand_each_blocks(html, slide)
+
     replacements = {
         "{{heading}}": headline,
         "{{subheading}}": subhead,
@@ -986,6 +1074,9 @@ def _fill_placeholders(
         "{{statement}}": statement,
         "{{statement_html_with_emphasis_span}}": statement_emphasis_html,
     }
+    # qa-dialogue: map qa_pairs → the template's flat voice_a/voice_b fields.
+    for fk, fv in _qa_dialogue_fields(slide).items():
+        replacements["{{%s}}" % fk] = _html_escape(fv)
     for k, v in replacements.items():
         html = html.replace(k, v)
 

--- a/scripts/wr2_html_renderer/tests/test_each_block_render.py
+++ b/scripts/wr2_html_renderer/tests/test_each_block_render.py
@@ -1,0 +1,102 @@
+"""Regression test for the {{#each}} list-block render bug (2026-06-25).
+
+Slides 3/6/7 of `indonesia-visafree-myth-reality` shipped with RAW Handlebars
+placeholders (`{{#each items}}`, `{{LABEL}}`, `{{VALUE}}`) because _fill_placeholders
+never expanded {{#each}} blocks: the storyboarder emits `list_items` / `qa_pairs`,
+the templates iterate `items` / want flat `voice_a/b_*`, and nothing bridged them.
+
+This test pins both halves of the cure:
+  - _expand_each_blocks: binds the loop (alias list_items→items), drops the block
+    when the array is missing (NEVER ships raw {{#each}}), escapes row copy.
+  - _qa_dialogue_fields: maps qa_pairs[0/1] → voice_a/voice_b flat fields.
+
+Innocence: a slide with no {{#each}} block is returned byte-identical.
+Guilt: a dark-status-list template with list_items → rows materialized, zero
+raw mustache left.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+from wr2_html_renderer import composer as C  # noqa: E402
+
+
+def _check(name: str, got: bool, want: bool = True) -> bool:
+    ok = got == want
+    print(f"  {'✅' if ok else '❌'} {name}")
+    return ok
+
+
+def main() -> int:
+    passed = True
+
+    # --- GUILT: dark-status-list each block binds from list_items -------------
+    tmpl = (
+        '<div class="items">{{#each items}}'
+        '<div class="item status-{{status}}">'
+        '<div class="label">{{label}}</div>'
+        '<div class="value">{{value}}</div>'
+        "</div>{{/each}}</div>"
+    )
+    slide = {
+        "layout_family": "dark-status-list",
+        "list_items": [
+            {"label": "FRAMEWORK", "value": "Perpres 95/2024", "status": "neutral"},
+            {"label": "BVK LIST", "value": "16 nationalities", "status": "positive"},
+        ],
+    }
+    out = C._expand_each_blocks(tmpl, slide)
+    passed &= _check("guilt: no raw {{#each}} left", "{{#each" not in out)
+    passed &= _check("guilt: no raw {{label}} left", "{{label}}" not in out)
+    passed &= _check("guilt: no raw {{value}} left", "{{value}}" not in out)
+    passed &= _check("guilt: FRAMEWORK row rendered", "FRAMEWORK" in out)
+    passed &= _check("guilt: BVK row rendered", "BVK LIST" in out)
+    passed &= _check("guilt: status class bound", 'status-positive' in out)
+    # count only row divs (`class="item `), not the wrapper (`class="items"`)
+    passed &= _check("guilt: both rows present (2 items)", out.count('class="item ') == 2)
+
+    # --- GUILT: {{this}} scalar rows (evidence-carved facts) ------------------
+    tmpl2 = "<ul>{{#each facts}}<li>{{this}}</li>{{/each}}</ul>"
+    out2 = C._expand_each_blocks(tmpl2, {"facts": ["FACT ONE", "FACT TWO"]})
+    passed &= _check("guilt: {{this}} scalar bound", "FACT ONE" in out2 and "FACT TWO" in out2)
+    passed &= _check("guilt: no raw {{this}}", "{{this}}" not in out2)
+
+    # --- INNOCENCE: no each block → unchanged --------------------------------
+    plain = '<div class="heading">{{heading}}</div><div class="body">{{body}}</div>'
+    out3 = C._expand_each_blocks(plain, {"heading": "X"})
+    passed &= _check("innocence: no-each html unchanged", out3 == plain)
+
+    # --- GUILT-by-absence: each block with missing array is DROPPED ----------
+    out4 = C._expand_each_blocks(tmpl, {"layout_family": "dark-status-list"})  # no list_items
+    passed &= _check("absent-array: block dropped, no raw {{#each}}", "{{#each" not in out4)
+    passed &= _check("absent-array: no leftover {{label}}", "{{label}}" not in out4)
+
+    # --- qa-dialogue: qa_pairs → flat voice fields ---------------------------
+    qa = {
+        "layout_family": "qa-dialogue",
+        "qa_pairs": [
+            {"voice": "INVESTOR", "line": "IS JAPAN VISA-FREE?"},
+            {"voice": "BALI ZERO", "line": "NO. NOT ON THE LIST."},
+        ],
+    }
+    fields = C._qa_dialogue_fields(qa)
+    passed &= _check("qa: voice_a_label = INVESTOR", fields.get("voice_a_label") == "INVESTOR")
+    passed &= _check("qa: voice_a_quote bound", fields.get("voice_a_quote") == "IS JAPAN VISA-FREE?")
+    passed &= _check("qa: voice_b_label = BALI ZERO", fields.get("voice_b_label") == "BALI ZERO")
+    passed &= _check("qa: voice_b_quote bound", fields.get("voice_b_quote") == "NO. NOT ON THE LIST.")
+    passed &= _check("qa: empty pairs → {}", C._qa_dialogue_fields({"qa_pairs": []}) == {})
+
+    # --- HTML escaping: row copy with < > & is escaped -----------------------
+    out5 = C._expand_each_blocks(
+        "{{#each items}}<li>{{value}}</li>{{/each}}",
+        {"items": [{"value": "a < b & c"}]},
+    )
+    passed &= _check("escaping: < and & escaped in row", "&lt;" in out5 and "&amp;" in out5)
+
+    print()
+    print("RESULT:", "ALL PASS" if passed else "FAILURES")
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Bug

Carousel slides using a **list layout** (`dark-status-list`, `evidence-carved`, `source-citation`, `timeline-pinboard`) and `qa-dialogue` shipped with **raw Handlebars placeholders baked into the PNG** — `{{#each items}}`, `{{LABEL}}`, `{{VALUE}}` — instead of the actual data. Caught on `indonesia-visafree-myth-reality` slides 3, 6, 7.

## Root cause

`composer._fill_placeholders` only handled scalar `{{...}}` + `{{#if regulation_code}}`. It **never expanded `{{#each}}` blocks** — the module docstring even *promised* `{{#each}}` support that didn't exist. Compounding it: the storyboarder emits `list_items` / `qa_pairs`, but the templates iterate `items` / want flat `voice_a/voice_b_*` fields → nothing bound, so the whole `{{#each}}` block reached the renderer verbatim.

## Fix (`scripts/wr2_html_renderer/composer.py`)

- **`_expand_each_blocks()`** — expands `{{#each <var>}}…{{/each}}`, binds each row's `{{field}}` (and `{{this}}` for scalar rows), honors a storyboarder→template **alias map** (`list_items`→`items`, plus `facts`/`citations`/`events`), supports nested `{{#if field}}` per row, HTML-escapes row copy, and **drops the block when the array is absent** (never ships raw `{{#each}}` again).
- **`_qa_dialogue_fields()`** — adapts `qa_pairs: [{voice, line}, …]` → the template's flat `voice_a_label/voice_a_quote/voice_b_*`.
- Both called inside `_fill_placeholders` before the scalar pass.

## Verification (empirical)

- Re-rendered `indonesia-visafree-myth-reality` with the fixed composer → slides **3/6/7 now show the real list rows / Q&A dialogue**, **0 raw placeholders** in the HTML (grep-verified) and in the PNG (visually confirmed: status-colored rows, yellow `positive`, two-voice dialogue).
- New unit test `tests/test_each_block_render.py` — **innocence** (no-each html byte-identical; absent-array block dropped) + **guilt** (rows bound, status class, `{{this}}` scalar, qa mapping, HTML escaping). ALL PASS.
- Orphan-gate regression test green (no collateral).

## Blast radius

`composer.py` is the shared production renderer (L2). The change is **additive**: slides without `{{#each}}` are returned byte-identical (innocence test pins this). Only list/qa layouts gain correct binding where they previously shipped broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)