### PR TITLE
fix(portal): keep client portal production-ready

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_enhanced_documents.py
+++ b/apps/backend-rag/backend/app/routers/crm_enhanced_documents.py
@@ -31,6 +31,10 @@ from backend.services.integrations.service_account_drive_service import ServiceA
 logger = get_logger(__name__)
 
 
+def _access_not_preverified() -> bool:
+    return False
+
+
 def _parse_date_or_none(date_str: str | None) -> date | None:
     """Parse YYYY-MM-DD date string or return None."""
     if not date_str:
@@ -551,14 +555,18 @@ async def upload_document_base64(
     pool: Any = Depends(get_database_pool),
     current_user: dict = Depends(get_current_user),
     background_tasks: BackgroundTasks = BackgroundTasks(),
+    access_already_verified: bool = Depends(_access_not_preverified),
 ) -> dict[str, Any]:
     """
     Upload a document via Base64 (for frontend integration).
     Handles Google Drive upload and document creation.
     """
     # RBAC check before processing upload
-    async with pool.acquire() as _conn:
-        await verify_client_access(client_id, current_user, _conn, allow_assigned=True, write=True)
+    if access_already_verified is not True:
+        async with pool.acquire() as _conn:
+            await verify_client_access(
+                client_id, current_user, _conn, allow_assigned=True, write=True
+            )
 
     try:
         # Decode Base64

--- a/apps/backend-rag/backend/app/routers/crm_portal_integration.py
+++ b/apps/backend-rag/backend/app/routers/crm_portal_integration.py
@@ -13,7 +13,7 @@ This creates the "intradinamici" connection between Team and Portal.
 Created: 2025-12-30
 """
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import asyncpg
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -23,8 +23,13 @@ from backend.app.dependencies import get_current_user, get_database_pool
 from backend.app.deps.crm_access import get_crm_user_filter
 from backend.app.utils.crm_utils import verify_client_access
 from backend.app.utils.logging_utils import get_logger
-from backend.services.portal import InviteService, PortalService
 from backend.services.portal._rbac import ClientContext
+
+if TYPE_CHECKING:
+    from backend.services.portal import InviteService, PortalService
+else:
+    InviteService = Any
+    PortalService = Any
 
 
 def _team_impersonation_ctx(client_id: int, current_user: dict) -> ClientContext:
@@ -106,12 +111,16 @@ def require_team_auth(current_user: dict = Depends(get_current_user)) -> dict:
 
 def get_invite_service(db_pool: asyncpg.Pool = Depends(get_database_pool)) -> InviteService:
     """Dependency injection for InviteService"""
-    return InviteService(db_pool)
+    from backend.services.portal import InviteService as _InviteService
+
+    return _InviteService(db_pool)
 
 
 def get_portal_service(db_pool: asyncpg.Pool = Depends(get_database_pool)) -> PortalService:
     """Dependency injection for PortalService"""
-    return PortalService(db_pool)
+    from backend.services.portal import PortalService as _PortalService
+
+    return _PortalService(db_pool)
 
 
 # ================================================

--- a/apps/backend-rag/backend/app/routers/crm_practices.py
+++ b/apps/backend-rag/backend/app/routers/crm_practices.py
@@ -2196,6 +2196,7 @@ async def upload_client_document(
             pool=db_pool,
             current_user=current_user,
             background_tasks=background_tasks,
+            access_already_verified=True,
         )
         doc_id = upload_result["document_id"]
 

--- a/apps/backend-rag/backend/app/routers/portal.py
+++ b/apps/backend-rag/backend/app/routers/portal.py
@@ -15,7 +15,7 @@ All endpoints require client authentication (role='client').
 Created: 2025-12-30
 """
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
 
 import asyncpg
@@ -27,7 +27,11 @@ from backend.app.core.config import settings
 from backend.app.dependencies import get_database_pool
 from backend.app.utils.logging_utils import get_logger
 from backend.core.cache import invalidate_cache
-from backend.services.portal import PortalService
+
+if TYPE_CHECKING:
+    from backend.services.portal import PortalService
+else:
+    PortalService = Any
 
 logger = get_logger(__name__)
 
@@ -249,7 +253,9 @@ async def get_current_client(
 
 def get_portal_service(db_pool: asyncpg.Pool = Depends(get_database_pool)) -> PortalService:
     """Dependency injection for PortalService"""
-    return PortalService(db_pool)
+    from backend.services.portal import PortalService as _PortalService
+
+    return _PortalService(db_pool)
 
 
 # ================================================

--- a/apps/backend-rag/backend/app/routers/portal_billing.py
+++ b/apps/backend-rag/backend/app/routers/portal_billing.py
@@ -4,7 +4,7 @@ Portal Billing Router.
 Exposes invoice data to client portal via PortalService.
 """
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
 
 import asyncpg
@@ -14,7 +14,11 @@ from fastapi.responses import Response
 from backend.app.dependencies import get_database_pool
 from backend.app.routers.portal import get_current_client
 from backend.app.utils.logging_utils import get_logger
-from backend.services.portal import PortalService
+
+if TYPE_CHECKING:
+    from backend.services.portal import PortalService
+else:
+    PortalService = Any
 
 logger = get_logger(__name__)
 
@@ -22,7 +26,9 @@ router = APIRouter(prefix="/api/portal/billing", tags=["portal-billing"])
 
 
 def _get_portal_service(db_pool: asyncpg.Pool = Depends(get_database_pool)) -> PortalService:
-    return PortalService(db_pool)
+    from backend.services.portal import PortalService as _PortalService
+
+    return _PortalService(db_pool)
 
 
 @router.get("")

--- a/apps/backend-rag/backend/app/routers/portal_invite.py
+++ b/apps/backend-rag/backend/app/routers/portal_invite.py
@@ -9,6 +9,7 @@ Handles client invitation and registration:
 Created: 2025-12-30
 """
 
+from html import escape
 from typing import Any
 
 import asyncpg
@@ -17,8 +18,8 @@ from pydantic import BaseModel, EmailStr, field_validator
 
 from backend.app.core.config import settings
 from backend.app.dependencies import get_current_user, get_database_pool
+from backend.app.services.internal_email import send_internal_email
 from backend.app.utils.logging_utils import get_logger
-from backend.services.integrations.zoho_email_service import ZohoEmailService
 from backend.services.portal import InviteService
 
 logger = get_logger(__name__)
@@ -86,13 +87,11 @@ def get_invite_service(db_pool: asyncpg.Pool = Depends(get_database_pool)) -> In
     return InviteService(db_pool)
 
 
-def get_email_service(db_pool: asyncpg.Pool = Depends(get_database_pool)) -> ZohoEmailService:
-    """Dependency injection for ZohoEmailService"""
-    return ZohoEmailService(db_pool)
-
-
 def build_invite_email_html(client_name: str, invite_url: str) -> str:
     """Build HTML email for client invitation."""
+    safe_client_name = escape(client_name, quote=True)
+    safe_invite_url = escape(invite_url, quote=True)
+
     return f"""
 <!DOCTYPE html>
 <html>
@@ -109,7 +108,7 @@ def build_invite_email_html(client_name: str, invite_url: str) -> str:
                         Welcome to Bali Zero Portal
                     </h1>
                     <p style="color: #334155; font-size: 16px; line-height: 1.6; margin: 0 0 20px 0;">
-                        Hello {client_name},
+                        Hello {safe_client_name},
                     </p>
                     <p style="color: #334155; font-size: 16px; line-height: 1.6; margin: 0 0 20px 0;">
                         You've been invited to access your client portal where you can:
@@ -120,7 +119,7 @@ def build_invite_email_html(client_name: str, invite_url: str) -> str:
                         <li>Access and upload documents</li>
                         <li>Communicate with our team</li>
                     </ul>
-                    <a href="{invite_url}" style="display: inline-block; background-color: #059669; color: white; padding: 14px 28px; font-size: 16px; font-weight: 600; text-decoration: none; border-radius: 8px;">
+                    <a href="{safe_invite_url}" style="display: inline-block; background-color: #059669; color: white; padding: 14px 28px; font-size: 16px; font-weight: 600; text-decoration: none; border-radius: 8px;">
                         Activate Your Portal
                     </a>
                     <p style="color: #94a3b8; font-size: 13px; margin: 30px 0 0 0;">
@@ -138,6 +137,27 @@ def build_invite_email_html(client_name: str, invite_url: str) -> str:
 """
 
 
+async def send_portal_invite_email(
+    *,
+    to: str,
+    client_name: str,
+    invite_url: str,
+    db_pool: asyncpg.Pool,
+    client_id: int,
+) -> None:
+    """Send a client portal invite through the canonical Brevo adapter."""
+    await send_internal_email(
+        to=to,
+        subject="Welcome to Bali Zero Client Portal",
+        body=build_invite_email_html(client_name=client_name, invite_url=invite_url),
+        log_context=f"portal invite client={client_id}",
+        raise_on_failure=True,
+        email_type="welcome",
+        pool=db_pool,
+        client_id=client_id,
+    )
+
+
 # ================================================
 # TEAM-SIDE ENDPOINTS (Require team auth)
 # ================================================
@@ -148,12 +168,12 @@ async def send_invitation(
     request: SendInviteRequest,
     current_user: dict = Depends(get_current_user),
     invite_service: InviteService = Depends(get_invite_service),
-    email_service: ZohoEmailService = Depends(get_email_service),
+    db_pool: asyncpg.Pool = Depends(get_database_pool),
 ) -> dict[str, Any]:
     """
     Send invitation to a client (team member action).
 
-    Requires team authentication. Creates invite token and sends email via Zoho.
+    Requires team authentication. Creates invite token and sends email via Brevo.
     """
     # Verify team member role (not client)
     if current_user.get("role") == "client":
@@ -173,25 +193,19 @@ async def send_invitation(
         base_url = settings.frontend_portal_url
         full_invite_url = f"{base_url}{result['invite_url']}"
 
-        # Try to send email via Zoho (using current user's connected account)
+        # Try to send email via the canonical Brevo adapter.
         email_sent = False
         email_error = None
         try:
-            user_email = current_user.get("email", "")
-            if user_email:
-                html_content = build_invite_email_html(
-                    client_name=result["client_name"],
-                    invite_url=full_invite_url,
-                )
-                await email_service.send_email(
-                    user_id=user_email,
-                    to=[request.email],
-                    subject="Welcome to Bali Zero Client Portal",
-                    content=html_content,
-                    is_html=True,
-                )
-                email_sent = True
-                logger.info(f"Invitation email sent to {request.email}")
+            await send_portal_invite_email(
+                to=str(request.email),
+                client_name=result["client_name"],
+                invite_url=full_invite_url,
+                db_pool=db_pool,
+                client_id=request.client_id,
+            )
+            email_sent = True
+            logger.info(f"Invitation email sent to {request.email}")
         except Exception as email_err:
             email_error = str(email_err)
             logger.warning("Failed to send invitation email: %s", email_err)
@@ -203,7 +217,7 @@ async def send_invitation(
         return {
             "success": True,
             "message": "Invitation created"
-            + (" and email sent" if email_sent else " (email not sent - check Zoho connection)"),
+            + (" and email sent" if email_sent else " (email not sent - check email service)"),
             "email_sent": email_sent,
             "email_error": email_error if not email_sent else None,
             "data": {

--- a/apps/backend-rag/backend/services/portal/__init__.py
+++ b/apps/backend-rag/backend/services/portal/__init__.py
@@ -4,7 +4,22 @@ Portal Services
 - PortalService: Client portal data access
 """
 
-from .invite_service import InviteService
-from .portal_service import PortalService
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .invite_service import InviteService
+    from .portal_service import PortalService
 
 __all__ = ["InviteService", "PortalService"]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "InviteService":
+        from .invite_service import InviteService
+
+        return InviteService
+    if name == "PortalService":
+        from .portal_service import PortalService
+
+        return PortalService
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/apps/backend-rag/backend/tests/unit/app/setup/test_light_router_startup_imports.py
+++ b/apps/backend-rag/backend/tests/unit/app/setup/test_light_router_startup_imports.py
@@ -1,0 +1,46 @@
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def test_light_router_registration_does_not_eager_import_portal_document_pipeline() -> None:
+    backend_root = Path(__file__).resolve().parents[5]
+    script = textwrap.dedent(
+        """
+        import sys
+
+        from fastapi import FastAPI
+
+        from backend.app.setup.router_registration import include_light_routers
+
+        app = FastAPI()
+        include_light_routers(app)
+
+        unexpected = [
+            name
+            for name in (
+                "backend.services.portal.portal_service",
+                "backend.services.portal.document_processing",
+                "backend.services.multimodal.pdf_vision_service",
+            )
+            if name in sys.modules
+        ]
+        if unexpected:
+            raise SystemExit(f"unexpected eager imports: {unexpected}")
+        """
+    )
+    env = {**os.environ, "PYTHONPATH": "."}
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=backend_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/apps/backend-rag/backend/tests/unit/routers/test_crm_enhanced_documents.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_crm_enhanced_documents.py
@@ -748,6 +748,39 @@ def test_document_upload_base64_model():
 
 
 @pytest.mark.asyncio
+async def test_upload_document_base64_can_use_preverified_client_access(
+    mock_db_pool,
+    mock_current_user,
+):
+    from backend.app.routers.crm_enhanced_documents import (
+        DocumentUploadBase64,
+        upload_document_base64,
+    )
+
+    verify_client_access = AsyncMock()
+
+    with patch(
+        "backend.app.routers.crm_enhanced_documents.verify_client_access",
+        new=verify_client_access,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await upload_document_base64(
+                client_id=1,
+                data=DocumentUploadBase64(
+                    file="not-base64",
+                    file_name="passport.pdf",
+                    document_type="passport",
+                ),
+                pool=mock_db_pool,
+                current_user=mock_current_user,
+                access_already_verified=True,
+            )
+
+    assert exc_info.value.status_code == 400
+    verify_client_access.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_upload_document_base64_mirrors_company_upload_to_company_documents(
     mock_db_pool,
     mock_current_user,

--- a/apps/backend-rag/backend/tests/unit/routers/test_crm_practices.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_crm_practices.py
@@ -1241,6 +1241,7 @@ class TestUploadClientDocument:
         assert upload_kwargs["client_id"] == 42
         assert upload_kwargs["pool"] is mock_db_pool
         assert upload_kwargs["current_user"] is admin_user
+        assert upload_kwargs["access_already_verified"] is True
         assert upload_kwargs["data"].file_name == "passport.pdf"
         assert upload_kwargs["data"].document_type == "passport"
         assert upload_kwargs["data"].practice_id == 7

--- a/apps/backend-rag/backend/tests/unit/routers/test_portal_invite.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_portal_invite.py
@@ -1,0 +1,155 @@
+"""Tests for the client portal invitation router."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from backend.app.routers.portal_invite import (
+    SendInviteRequest,
+    send_invitation,
+    send_portal_invite_email,
+)
+
+
+class FakeInviteService:
+    """Small async fake for the portal invite service."""
+
+    def __init__(self) -> None:
+        self.created: dict[str, object] | None = None
+
+    async def create_invitation(
+        self,
+        *,
+        client_id: int,
+        email: str,
+        created_by: str,
+    ) -> dict[str, object]:
+        self.created = {
+            "client_id": client_id,
+            "email": email,
+            "created_by": created_by,
+        }
+        return {
+            "client_id": client_id,
+            "client_name": "Kaiser Test",
+            "email": email,
+            "invite_url": "/portal/invite?token=tok-123",
+            "token": "tok-123",
+        }
+
+
+@pytest.mark.asyncio
+async def test_send_portal_invite_email_uses_internal_brevo_adapter() -> None:
+    db_pool = MagicMock()
+
+    with patch(
+        "backend.app.routers.portal_invite.send_internal_email",
+        new=AsyncMock(),
+    ) as mock_sender:
+        await send_portal_invite_email(
+            to="kaiser@example.com",
+            client_name='Kaiser & "Demo"',
+            invite_url="https://my.balizero.com/portal/invite?token=abc&x=1",
+            db_pool=db_pool,
+            client_id=11898,
+        )
+
+    assert mock_sender.await_count == 1
+    kwargs = mock_sender.await_args.kwargs
+    assert kwargs["to"] == "kaiser@example.com"
+    assert kwargs["subject"] == "Welcome to Bali Zero Client Portal"
+    assert kwargs["raise_on_failure"] is True
+    assert kwargs["email_type"] == "welcome"
+    assert kwargs["pool"] is db_pool
+    assert kwargs["client_id"] == 11898
+    assert "Kaiser &amp; &quot;Demo&quot;" in kwargs["body"]
+    assert "token=abc&amp;x=1" in kwargs["body"]
+
+
+@pytest.mark.asyncio
+async def test_send_invitation_sends_email_through_internal_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_service = FakeInviteService()
+    db_pool = MagicMock()
+    monkeypatch.setattr(
+        "backend.app.routers.portal_invite.settings.frontend_portal_url",
+        "https://my.balizero.com",
+    )
+
+    with patch(
+        "backend.app.routers.portal_invite.send_portal_invite_email",
+        new=AsyncMock(),
+    ) as mock_sender:
+        response = await send_invitation(
+            SendInviteRequest(
+                client_id=11898,
+                email="kaiser198719871987@gmail.com",
+            ),
+            current_user={"email": "zero@balizero.com", "role": "Founder"},
+            invite_service=fake_service,  # type: ignore[arg-type]
+            db_pool=db_pool,
+        )
+
+    assert response["success"] is True
+    assert response["email_sent"] is True
+    assert response["email_error"] is None
+    assert "email sent" in response["message"]
+    assert fake_service.created == {
+        "client_id": 11898,
+        "email": "kaiser198719871987@gmail.com",
+        "created_by": "zero@balizero.com",
+    }
+    mock_sender.assert_awaited_once_with(
+        to="kaiser198719871987@gmail.com",
+        client_name="Kaiser Test",
+        invite_url="https://my.balizero.com/portal/invite?token=tok-123",
+        db_pool=db_pool,
+        client_id=11898,
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_invitation_reports_email_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_service = FakeInviteService()
+    monkeypatch.setattr(
+        "backend.app.routers.portal_invite.settings.frontend_portal_url",
+        "https://my.balizero.com",
+    )
+
+    with patch(
+        "backend.app.routers.portal_invite.send_portal_invite_email",
+        new=AsyncMock(side_effect=RuntimeError("brevo unavailable")),
+    ):
+        response = await send_invitation(
+            SendInviteRequest(
+                client_id=11898,
+                email="kaiser198719871987@gmail.com",
+            ),
+            current_user={"email": "zero@balizero.com", "role": "Founder"},
+            invite_service=fake_service,  # type: ignore[arg-type]
+            db_pool=MagicMock(),
+        )
+
+    assert response["success"] is True
+    assert response["email_sent"] is False
+    assert response["email_error"] == "brevo unavailable"
+    assert "check email service" in response["message"]
+
+
+@pytest.mark.asyncio
+async def test_send_invitation_rejects_client_role() -> None:
+    with pytest.raises(HTTPException) as exc:
+        await send_invitation(
+            SendInviteRequest(client_id=1, email="client@example.com"),
+            current_user={"email": "client@example.com", "role": "client"},
+            invite_service=FakeInviteService(),  # type: ignore[arg-type]
+            db_pool=MagicMock(),
+        )
+
+    assert exc.value.status_code == 403

--- a/apps/mouth/src/lib/api/portal/portal.api.test.ts
+++ b/apps/mouth/src/lib/api/portal/portal.api.test.ts
@@ -478,6 +478,48 @@ describe("PortalApi", () => {
         },
       );
     });
+
+    it("should normalize snake_case messages from the production portal API", async () => {
+      mockRequest.mockResolvedValue({
+        data: {
+          messages: [
+            {
+              id: 1659,
+              content: "Kaiser Test portal QA",
+              from_team: false,
+              sent_by: "kaiser198719871987@gmail.com",
+              subject: null,
+              practice_id: 603,
+              practice_name: "Kaiser Test - B1 VOA",
+              created_at: "2026-06-25T10:37:28.266006+00:00",
+              is_read: false,
+            },
+          ],
+          total: 1,
+          unread_count: 0,
+        },
+      });
+
+      const result = await portalApi.getMessages();
+
+      expect(result).toEqual({
+        messages: [
+          {
+            id: "1659",
+            content: "Kaiser Test portal QA",
+            direction: "client_to_team",
+            sentBy: "kaiser198719871987@gmail.com",
+            subject: undefined,
+            practiceId: 603,
+            practiceName: "Kaiser Test - B1 VOA",
+            createdAt: "2026-06-25T10:37:28.266006+00:00",
+            readAt: undefined,
+          },
+        ],
+        total: 1,
+        unreadCount: 0,
+      });
+    });
   });
 
   describe("sendMessage", () => {
@@ -498,6 +540,37 @@ describe("PortalApi", () => {
         body: JSON.stringify(request),
       });
       expect(result).toEqual(mockMessage);
+    });
+
+    it("should normalize a snake_case sent message response", async () => {
+      const request: SendMessageRequest = {
+        content: "Test message",
+      };
+
+      mockRequest.mockResolvedValue({
+        data: {
+          id: 1660,
+          content: "Test message",
+          from_team: true,
+          sent_by: "zero@balizero.com",
+          created_at: "2026-06-25T10:40:00.000000+00:00",
+          read_at: null,
+        },
+      });
+
+      const result = await portalApi.sendMessage(request);
+
+      expect(result).toEqual({
+        id: "1660",
+        content: "Test message",
+        direction: "team_to_client",
+        sentBy: "zero@balizero.com",
+        subject: undefined,
+        practiceId: undefined,
+        practiceName: undefined,
+        createdAt: "2026-06-25T10:40:00.000000+00:00",
+        readAt: undefined,
+      });
     });
   });
 

--- a/apps/mouth/src/lib/api/portal/portal.api.ts
+++ b/apps/mouth/src/lib/api/portal/portal.api.ts
@@ -33,6 +33,60 @@ import type {
 } from "./portal.types";
 import type { TimelineResponse } from "../types/timeline.types";
 
+type RawPortalMessage = {
+  id: number | string;
+  content: string;
+  direction?: "client_to_team" | "team_to_client";
+  from_team?: boolean;
+  sentBy?: string;
+  sent_by?: string;
+  subject?: string | null;
+  practiceId?: number | null;
+  practice_id?: number | null;
+  practiceName?: string | null;
+  practice_name?: string | null;
+  createdAt?: string;
+  created_at?: string;
+  readAt?: string | null;
+  read_at?: string | null;
+  is_read?: boolean;
+};
+
+type RawMessagesResponse = {
+  messages?: RawPortalMessage[];
+  total?: number;
+  unreadCount?: number;
+  unread_count?: number;
+};
+
+function normalizePortalMessage(message: RawPortalMessage): PortalMessage {
+  return {
+    id: String(message.id),
+    content: message.content,
+    direction:
+      message.direction ??
+      (message.from_team === true ? "team_to_client" : "client_to_team"),
+    sentBy: message.sentBy ?? message.sent_by ?? "",
+    subject: message.subject ?? undefined,
+    practiceId: message.practiceId ?? message.practice_id ?? undefined,
+    practiceName: message.practiceName ?? message.practice_name ?? undefined,
+    createdAt: message.createdAt ?? message.created_at ?? "",
+    readAt:
+      message.readAt ??
+      message.read_at ??
+      (message.is_read === true ? message.createdAt ?? message.created_at : undefined) ??
+      undefined,
+  };
+}
+
+function normalizeMessagesResponse(response: RawMessagesResponse): MessagesResponse {
+  return {
+    messages: (response.messages ?? []).map(normalizePortalMessage),
+    total: response.total ?? 0,
+    unreadCount: response.unreadCount ?? response.unread_count ?? 0,
+  };
+}
+
 export class PortalApi {
   constructor(private client: ApiClientBase) {}
 
@@ -322,21 +376,21 @@ export class PortalApi {
 
   async getMessages(limit = 50, offset = 0): Promise<MessagesResponse> {
     const response = await this.client.request<
-      PortalApiResponse<MessagesResponse>
+      PortalApiResponse<RawMessagesResponse>
     >(`/api/portal/messages?limit=${limit}&offset=${offset}`, {
       method: "GET",
     });
-    return response.data!;
+    return normalizeMessagesResponse(response.data!);
   }
 
   async sendMessage(request: SendMessageRequest): Promise<PortalMessage> {
     const response = await this.client.request<
-      PortalApiResponse<PortalMessage>
+      PortalApiResponse<RawPortalMessage>
     >("/api/portal/messages", {
       method: "POST",
       body: JSON.stringify(request),
     });
-    return response.data!;
+    return normalizePortalMessage(response.data!);
   }
 
   async markMessageRead(messageId: number): Promise<void> {

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`325 routers · 628 services · 1087 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`325 routers · 628 services · 1088 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`325 routers · 628 services · 1086 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`325 routers · 628 services · 1087 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary
- keep light API startup from importing the portal OCR/document pipeline eagerly
- allow preverified client required-document uploads through the canonical upload endpoint
- normalize portal message payloads from the production API before rendering the chat UI

## Verification
- PYTHONPATH=. pytest backend/tests/unit/app/setup/test_light_router_startup_imports.py backend/tests/unit/routers/test_portal_billing.py backend/tests/unit/routers/test_portal_profile_update.py backend/tests/unit/routers/test_crm_practices.py::TestUploadClientDocument::test_uses_canonical_document_upload_and_updates_required_doc backend/tests/unit/routers/test_crm_enhanced_documents.py::test_upload_document_base64_can_use_preverified_client_access -q
- npm --prefix apps/mouth test -- --run src/lib/api/portal/portal.api.test.ts
- npm --prefix apps/mouth run typecheck
- node ../../node_modules/eslint/bin/eslint.js --no-warn-ignored src/lib/api/portal/portal.api.ts
- Fly production deploy and /health/ready smoke passed
- Vercel preview build for commit e60bac4 is Ready