### PR TITLE
feat(wr2): operator-gated Instagram carousel publish (Legge 5) — publisher + endpoint + caption

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 327 routers · 632 services
+- Backend: FastAPI · 329 routers · 633 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 29 · Packages: 6

--- a/apps/backend-rag/backend/app/routers/wr2_publish.py
+++ b/apps/backend-rag/backend/app/routers/wr2_publish.py
@@ -1,0 +1,462 @@
+"""WR2 Instagram publish router — server-side, operator-gated (Legge 5).
+
+WHY THIS EXISTS (2026-06-25)
+---------------------------
+The WR2 Control app runs on M5 (the operator's workstation). The Instagram
+publisher needs three things that live ONLY on the Fly backend, never on M5:
+
+  * Tigris creds (already used by ``/api/assets/upload`` to host the slide PNGs)
+  * the ``wr2_publish_attempts`` ledger DB (anti-double-publish guard)
+  * the Instagram access token + account id (``INSTAGRAM_ACCESS_TOKEN`` /
+    ``INSTAGRAM_ACCOUNT_ID`` Fly secrets)
+
+So the publish step is driven server-side. The flow the app follows:
+
+  1. App renders the 8 slides locally, then POSTs each PNG to
+     ``/api/assets/upload`` (existing endpoint) → 8 public, Graph-fetchable
+     ``https://...tigris.dev/...`` URLs.
+  2. App POSTs those URLs here. This endpoint NEVER touches raw bytes — it
+     receives ``image_urls`` that are already public.
+
+LEGGE 5 — operator gate
+-----------------------
+The endpoint publishes ONLY when ``confirm == True``. With ``confirm == False``
+(the default) it builds the :class:`DraftPayload`, runs ``IGPublisher.validate``,
+and returns exactly what WOULD be posted — it NEVER calls ``publish()`` and it
+NEVER writes a terminal ledger row. ``approval_state`` is set to ``"approved"``
+ONLY when ``confirm == True``; that is the single flag that the restored
+publisher checks at ``ig_publisher.py:239`` before dispatching to Meta.
+
+ANTI-DOUBLE-PUBLISH
+-------------------
+Before ``publish()`` (confirm path only) we apply the SAME ledger precondition
+as the CLI ``scripts/wr2_ig_publish.py`` (``_ledger_precondition``): resolve a
+REAL ``wr2_carousel_runs.carousel_id``, REFUSE (HTTP 409 + prior permalink) if a
+prior attempt for this carousel+content is already in a terminal state
+(``published``/``recorded``), else write a ``planned`` row as a hard precondition
+keyed on the SAME ``idempotency_key`` format
+(``<carousel_id>:<platform>:<content_hash[:16]>``). The two code paths therefore
+share one ledger and one idempotency guarantee. Fails CLOSED if the DB is
+unreachable — a real publish without the guard is refused, never silently
+skipped.
+
+The ``scripts/wr2_ig_publish.py`` helpers are NOT importable on Fly (the
+Dockerfile ships ``apps/backend-rag/scripts``, not the repo-root ``scripts/``
+where that module lives), so the precondition is replicated here — same SQL,
+same key format, ledger-compatible with the CLI.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from typing import Any
+
+import asyncpg
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from backend.app.core.config import settings
+from backend.app.dependencies import get_current_user
+from backend.app.utils.crm_utils import is_crm_admin
+from backend.app.utils.logging_utils import get_logger
+from backend.services.publisher.base import DraftPayload, SlidePayload
+
+logger = get_logger(__name__)
+
+# Graph host. The live Fly secret INSTAGRAM_ACCESS_TOKEN is an "Instagram API
+# with Instagram Login" token (verified 2026-06-25): it works against
+# graph.instagram.com, NOT graph.facebook.com (the restored IGPublisher's
+# default). scripts/wr2_ig_publish.py wires the publisher the same way — we
+# reuse that exact pattern: IGPublisher(graph_base=_IG_GRAPH_BASE).
+_IG_GRAPH_BASE = "https://graph.instagram.com/v22.0"
+
+_PLATFORM = "instagram"
+
+# Deterministic namespace so the same slug always maps to the same draft UUID
+# (mirrors scripts/wr2_ig_publish.py:_WR2_DRAFT_NAMESPACE).
+_WR2_DRAFT_NAMESPACE = uuid.UUID("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
+
+
+# ── Auth gate (same pattern as war_room_dashboard._require_admin) ──────────────
+
+
+async def _require_admin(
+    current_user: dict[str, Any] = Depends(get_current_user),
+) -> dict[str, Any]:
+    if not is_crm_admin(current_user):
+        raise HTTPException(status_code=403, detail="Admin access required")
+    return current_user
+
+
+router = APIRouter(
+    prefix="/api/war-room",
+    tags=["war-room", "wr2", "publish"],
+    dependencies=[Depends(_require_admin)],
+)
+
+
+# ── Request / response models ──────────────────────────────────────────────────
+
+
+class PublishIGRequest(BaseModel):
+    slug: str = Field(..., min_length=1, description="Carousel slug (== wr2_carousel_runs.topic).")
+    image_urls: list[str] = Field(
+        ...,
+        min_length=1,
+        max_length=10,
+        description="Public Tigris URLs of the slides, slide 1 = cover. Max 10 (IG carousel limit).",
+    )
+    caption: str = Field(..., description="IG caption (max 2200 chars, enforced by publisher).")
+    alt_texts: list[str] | None = Field(
+        default=None,
+        description="Optional per-slide alt-text, aligned to image_urls by index.",
+    )
+    confirm: bool = Field(
+        default=False,
+        description="LEGGE 5 operator gate. False = dry validation (no publish). True = publish.",
+    )
+
+
+# ── Content key + draft assembly ───────────────────────────────────────────────
+
+
+def _content_hash(image_urls: list[str], caption: str) -> str:
+    """sha256 over the ordered slide URLs + caption — the idempotency content key.
+
+    The CLI hashes raw slide bytes; here the bytes live behind content-addressed
+    Tigris URLs (the URL embeds the sha256 of the bytes), so hashing the ordered
+    URLs + caption yields an equally stable, content-bound key for this path.
+    """
+    h = hashlib.sha256()
+    for u in image_urls:
+        h.update(u.encode("utf-8"))
+        h.update(b"\x00")
+    h.update(caption.encode("utf-8"))
+    return h.hexdigest()
+
+
+def _build_draft(
+    *,
+    slug: str,
+    draft_id: uuid.UUID,
+    image_urls: list[str],
+    caption: str,
+    alt_texts: list[str] | None,
+    approved: bool,
+) -> DraftPayload:
+    """Assemble a DraftPayload. cover = image_urls[0]; rest = body slides."""
+
+    def _alt(idx: int) -> str | None:
+        if alt_texts and idx < len(alt_texts):
+            return alt_texts[idx]
+        return None
+
+    cover_url = image_urls[0]
+    body = [
+        SlidePayload(slide_number=i + 1, image_url=url, caption=None, alt_text=_alt(i))
+        for i, url in enumerate(image_urls[1:], start=1)
+    ]
+    return DraftPayload(
+        draft_id=draft_id,
+        topic=slug,
+        tone_register=None,
+        cover_image_url=cover_url,
+        main_caption=caption,
+        slides=body,
+        cover_alt_text=_alt(0),
+        approval_state="approved" if approved else "pending",
+    )
+
+
+# ── Ledger (anti-double-publish) — replicated from scripts/wr2_ig_publish.py ────
+
+
+async def _resolve_carousel_id(conn: asyncpg.Connection, slug: str) -> str:
+    """Return a REAL ``wr2_carousel_runs.carousel_id`` (UUID) for this slug.
+
+    Mirrors scripts/wr2_ig_publish.py:_resolve_carousel_id — look up an existing
+    run by topic == slug (newest first), else create a minimal 'rendered' row.
+    Never swallows a FK error: if neither find nor create works the caller fails
+    closed (the exception propagates and the publish is refused).
+    """
+    row = await conn.fetchrow(
+        "SELECT carousel_id FROM wr2_carousel_runs "
+        "WHERE topic = $1 ORDER BY created_at DESC LIMIT 1",
+        slug,
+    )
+    if row is not None:
+        cid = str(row["carousel_id"])
+        logger.info("wr2_publish: found carousel_run slug=%s -> %s", slug, cid)
+        return cid
+
+    topic_hash = hashlib.sha256(slug.encode("utf-8")).hexdigest()
+    session_id = f"wr2_publish_endpoint:{slug}"
+    new_row = await conn.fetchrow(
+        "INSERT INTO wr2_carousel_runs "
+        "(topic, topic_hash, state, session_id, publish_mode) "
+        "VALUES ($1, $2, 'rendered', $3, 'manual') "
+        "RETURNING carousel_id",
+        slug,
+        topic_hash,
+        session_id,
+    )
+    cid = str(new_row["carousel_id"])
+    logger.info("wr2_publish: created carousel_run slug=%s -> %s", slug, cid)
+    return cid
+
+
+async def _ledger_precondition(
+    *,
+    slug: str,
+    content_hash: str,
+) -> tuple[str, str, str | None]:
+    """HARD precondition before media_publish. Returns (carousel_id, action, prior_url).
+
+    action == "proceed" -> a 'planned' row was written; caller may publish.
+    action == "refuse"  -> already published/recorded; caller MUST NOT publish.
+
+    Fails closed (raises HTTPException 503) if the ledger DB is unreachable or
+    the carousel_runs FK can't be satisfied — NEVER silently skips the guard.
+    Identical SQL + idempotency_key format to scripts/wr2_ig_publish.py so the
+    two paths share one ledger.
+    """
+    dsn = settings.database_url
+    if not dsn:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "ledger DB unreachable (DATABASE_URL not set). A real publish "
+                "REQUIRES the wr2_publish_attempts idempotency guard — refusing "
+                "to publish without it (fail-closed)."
+            ),
+        )
+
+    try:
+        conn = await asyncpg.connect(dsn)
+    except Exception as exc:  # any connect failure must fail closed
+        logger.error("wr2_publish: ledger DB unreachable: %s", exc)
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                f"ledger DB unreachable ({type(exc).__name__}). Refusing to "
+                "publish without the idempotency guard (fail-closed)."
+            ),
+        ) from exc
+
+    try:
+        carousel_id = await _resolve_carousel_id(conn, slug)
+        idempotency_key = f"{carousel_id}:{_PLATFORM}:{content_hash[:16]}"
+
+        prior = await conn.fetchrow(
+            "SELECT state, provider_response FROM wr2_publish_attempts "
+            "WHERE idempotency_key = $1",
+            idempotency_key,
+        )
+        if prior is not None and prior["state"] in ("published", "recorded"):
+            prior_url = None
+            pr = prior["provider_response"]
+            if pr:
+                try:
+                    pr_d = pr if isinstance(pr, dict) else json.loads(pr)
+                    prior_url = pr_d.get("permalink") or pr_d.get("post_url")
+                except (ValueError, TypeError):
+                    prior_url = None
+            logger.warning(
+                "wr2_publish: REFUSE double-publish key=%s already state=%s",
+                idempotency_key,
+                prior["state"],
+            )
+            return carousel_id, "refuse", prior_url
+
+        await conn.execute(
+            "INSERT INTO wr2_publish_attempts "
+            "(carousel_id, platform, content_hash, state, idempotency_key) "
+            "VALUES ($1, $2, $3, 'planned', $4) "
+            "ON CONFLICT (idempotency_key) DO UPDATE "
+            "SET state = 'planned', updated_at = now()",
+            uuid.UUID(carousel_id),
+            _PLATFORM,
+            content_hash,
+            idempotency_key,
+        )
+        logger.info(
+            "wr2_publish: ledger 'planned' written key=%s carousel_id=%s",
+            idempotency_key,
+            carousel_id,
+        )
+        return carousel_id, "proceed", None
+    finally:
+        await conn.close()
+
+
+async def _ledger_record_result(
+    *,
+    carousel_id: str,
+    content_hash: str,
+    state: str,
+    provider_response: dict[str, Any] | None,
+) -> None:
+    """Update the ledger row to a terminal state after the publish attempt.
+
+    Best-effort: a failure here is logged but NEVER flips a successful Meta
+    publish into a failure (the post already exists). The anti-double-publish
+    guarantee is the PRE-publish 'planned' row + UNIQUE key, already committed.
+    """
+    try:
+        dsn = settings.database_url
+        if not dsn:
+            return
+        conn = await asyncpg.connect(dsn)
+        try:
+            idempotency_key = f"{carousel_id}:{_PLATFORM}:{content_hash[:16]}"
+            await conn.execute(
+                "UPDATE wr2_publish_attempts "
+                "SET state = $1, provider_response = $2::jsonb, updated_at = now() "
+                "WHERE idempotency_key = $3",
+                state,
+                json.dumps(provider_response or {}),
+                idempotency_key,
+            )
+            logger.info("wr2_publish: ledger updated state=%s key=%s", state, idempotency_key)
+        finally:
+            await conn.close()
+    except Exception as exc:  # bookkeeping must never crash a live post
+        logger.warning("wr2_publish: ledger result update failed (non-fatal): %s", exc)
+
+
+# ── Endpoint ───────────────────────────────────────────────────────────────────
+
+
+@router.post("/publish-ig")
+async def publish_ig(body: PublishIGRequest) -> dict[str, Any]:
+    """Publish (or dry-validate) a WR2 carousel to Instagram, server-side.
+
+    LEGGE 5: ``confirm == False`` => dry validation only, ``publish()`` is never
+    called and ``approval_state`` stays ``"pending"``. ``confirm == True`` =>
+    ledger precondition + real publish with ``approval_state == "approved"``.
+    """
+    from backend.services.publisher.ig_publisher import (
+        IGPublisher,
+        close_ig_publisher_client,
+    )
+    from backend.services.publisher.base import PublisherError
+
+    slug = body.slug
+    image_urls = body.image_urls
+    caption = body.caption
+    draft_id = uuid.uuid5(_WR2_DRAFT_NAMESPACE, slug)
+    content_hash = _content_hash(image_urls, caption)
+
+    # ── DRY path (LEGGE 5): build draft (pending) + validate, NEVER publish. ──
+    if not body.confirm:
+        draft = _build_draft(
+            slug=slug,
+            draft_id=draft_id,
+            image_urls=image_urls,
+            caption=caption,
+            alt_texts=body.alt_texts,
+            approved=False,  # stays 'pending' — publisher gate would refuse.
+        )
+        try:
+            publisher = IGPublisher(graph_base=_IG_GRAPH_BASE)
+        except PublisherError as exc:
+            # Missing creds — surface as 503 (service not configured), no publish.
+            raise HTTPException(status_code=503, detail=f"IG publisher not configured: {exc}") from exc
+        validation = await publisher.validate(draft)
+        logger.info(
+            "wr2_publish: DRY validation slug=%s items=%d valid=%s",
+            slug,
+            len(image_urls),
+            validation.ok,
+        )
+        return {
+            "ok": True,
+            "dry_run": True,
+            "would_publish": {
+                "slug": slug,
+                "cover_image_url": image_urls[0],
+                "slide_count": len(image_urls),
+                "image_urls": image_urls,
+                "caption_chars": len(caption),
+                "approval_state": draft.approval_state,  # 'pending'
+            },
+            "validation": {"ok": validation.ok, "issues": validation.issues},
+            "note": "confirm=false → publish() NOT called (Legge 5). Re-send with confirm=true to publish.",
+        }
+
+    # ── CONFIRM path: ledger precondition (anti-double-publish), then publish. ──
+    carousel_id, action, prior_url = await _ledger_precondition(
+        slug=slug, content_hash=content_hash
+    )
+    if action == "refuse":
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "already_published",
+                "message": "A prior attempt for this carousel+content is already published.",
+                "permalink": prior_url,
+            },
+        )
+
+    draft = _build_draft(
+        slug=slug,
+        draft_id=draft_id,
+        image_urls=image_urls,
+        caption=caption,
+        alt_texts=body.alt_texts,
+        approved=True,  # flips publisher's internal gate (ig_publisher.py:239).
+    )
+
+    try:
+        publisher = IGPublisher(graph_base=_IG_GRAPH_BASE)
+    except PublisherError as exc:
+        await _ledger_record_result(
+            carousel_id=carousel_id,
+            content_hash=content_hash,
+            state="failed",
+            provider_response={"error": f"publisher init: {exc}"},
+        )
+        raise HTTPException(status_code=503, detail=f"IG publisher not configured: {exc}") from exc
+
+    try:
+        result = await publisher.publish(draft)
+    finally:
+        await close_ig_publisher_client()
+
+    if not result.ok:
+        await _ledger_record_result(
+            carousel_id=carousel_id,
+            content_hash=content_hash,
+            state="failed",
+            provider_response={"error": result.error},
+        )
+        # The publisher's approval-gate refusal and validation failures both
+        # surface here as result.ok == False — return a clear 4xx, not a 500.
+        logger.warning("wr2_publish: publish failed slug=%s err=%s", slug, result.error)
+        raise HTTPException(status_code=422, detail={"error": "publish_failed", "message": result.error})
+
+    await _ledger_record_result(
+        carousel_id=carousel_id,
+        content_hash=content_hash,
+        state="published",
+        provider_response={
+            "permalink": result.post_url,
+            "post_external_id": result.post_external_id,
+            "meta": result.meta,
+        },
+    )
+
+    logger.info(
+        "wr2_publish: PUBLISHED slug=%s media_id=%s permalink=%s",
+        slug,
+        result.post_external_id,
+        result.post_url,
+    )
+    return {
+        "ok": True,
+        "dry_run": False,
+        "permalink": result.post_url,
+        "post_id": result.post_external_id,
+    }

--- a/apps/backend-rag/backend/app/setup/router_manifest.py
+++ b/apps/backend-rag/backend/app/setup/router_manifest.py
@@ -342,6 +342,12 @@ ROUTER_MANIFEST: tuple[RouterEntry, ...] = (
         process_groups=_API,
         tags=("war-room", "admin"),
     ),
+    # ── WR2 IG Publish (server-side operator-gated carousel publish, Legge 5) ──
+    RouterEntry(
+        name="wr2_publish",
+        process_groups=_API,
+        tags=("war-room", "wr2", "publish", "admin"),
+    ),
     # ── Webhooks ──
     RouterEntry(name="webhooks", process_groups=_API, tags=("channels",)),
     # ── WebSocket ──

--- a/apps/backend-rag/backend/app/setup/router_registration.py
+++ b/apps/backend-rag/backend/app/setup/router_registration.py
@@ -159,6 +159,7 @@ def include_routers(api: FastAPI) -> None:
         workflow_queue,
         workspace_analytics,
         workspace_inbox,  # /api/workspace/inbox unified team feed (wa-mirror, telegram, email)
+        wr2_publish,  # [WR2 LEGGE 5] /api/war-room/publish-ig server-side operator-gated IG publish
         zoho_email,
     )
 
@@ -276,6 +277,7 @@ def include_routers(api: FastAPI) -> None:
     # Analytics routers (Admin/reporting)
     api.include_router(analytics.router)
     api.include_router(war_room_dashboard.router)
+    api.include_router(wr2_publish.router)  # [WR2 LEGGE 5] /api/war-room/publish-ig
     api.include_router(workspace_analytics.router)
 
     # SOTA research controls (kill-switch guarded)
@@ -593,6 +595,7 @@ def include_light_routers(api: FastAPI) -> None:
         workflow_queue,
         workspace_analytics,
         workspace_inbox,  # /api/workspace/inbox unified team feed
+        wr2_publish,  # [WR2 LEGGE 5] /api/war-room/publish-ig server-side operator-gated IG publish
         zoho_email,
     )
 
@@ -697,6 +700,7 @@ def include_light_routers(api: FastAPI) -> None:
     # Analytics routers
     api.include_router(analytics.router)
     api.include_router(war_room_dashboard.router)
+    api.include_router(wr2_publish.router)  # [WR2 LEGGE 5] /api/war-room/publish-ig
     api.include_router(workspace_analytics.router)
 
     # SOTA research controls (kill-switch guarded)

--- a/apps/backend-rag/backend/services/canva_renderer_v2/_tigris.py
+++ b/apps/backend-rag/backend/services/canva_renderer_v2/_tigris.py
@@ -120,6 +120,84 @@ def upload_pdf(
     raise TigrisError(f"Tigris exhausted retries for {key}: {last_exc}") from last_exc
 
 
+def upload_png(
+    s3: Any,
+    png: bytes | Path,
+    *,
+    draft_id: str,
+    slide_index: int,
+    prefix: str = "wr2-ig",
+) -> tuple[str, str]:
+    """Upload a carousel slide PNG to Tigris S3, return (public_url, s3_key).
+
+    Mirrors :func:`upload_pdf` but for ``image/png`` carousel slides. The
+    Meta Graph carousel API requires a publicly-fetchable image URL — Drive
+    HTML preview pages are rejected, so we serve the raw PNG bytes from
+    Tigris (``public-read`` ACL) at a deterministic per-slide key.
+
+    Args:
+        s3: boto3 S3 client from :func:`get_s3_client`.
+        png: PNG bytes, or a :class:`pathlib.Path` to a ``.png`` file.
+        draft_id: draft / carousel identifier (groups all slides of one post).
+        slide_index: 0-based slide ordinal — zero-padded to 2 digits in key.
+        prefix: S3 key prefix (default ``wr2-ig``).
+
+    Returns:
+        ``(public_url, s3_key)`` — the public URL is fed to IGPublisher.
+
+    Raises:
+        TigrisError: on non-transient S3 error or exhausted retries.
+    """
+    body = png.read_bytes() if isinstance(png, Path) else png
+    key = f"{prefix}/{draft_id}/{slide_index:02d}.png"
+
+    last_exc: Exception | None = None
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            s3.put_object(
+                Bucket=BUCKET,
+                Key=key,
+                Body=body,
+                ContentType="image/png",
+                ACL="public-read",
+            )
+            logger.info("Tigris PNG upload OK: %s (attempt %d)", key, attempt)
+            # Verify ContentType=image/png via HEAD before returning URL.
+            try:
+                head = s3.head_object(Bucket=BUCKET, Key=key)
+                head_ct = head.get("ContentType", "")
+                if head_ct != "image/png":
+                    raise TigrisError(
+                        f"Tigris HEAD ContentType mismatch for {key}: "
+                        f"expected image/png, got {head_ct!r}",
+                    )
+                logger.info(
+                    "Tigris PNG HEAD ok: ContentType=%s len=%s",
+                    head_ct,
+                    head.get("ContentLength", "?"),
+                )
+            except TigrisError:
+                raise
+            except Exception as e:  # HEAD verify best-effort on transport errors
+                logger.warning("Tigris PNG HEAD verify failed (non-fatal): %s", e)
+            return f"https://{PUBLIC_HOST}/{key}", key
+        except (ClientError, BotoCoreError) as e:
+            last_exc = e
+            if not _is_transient(e):
+                raise TigrisError(f"Tigris non-transient error: {e}") from e
+            if attempt < MAX_RETRIES:
+                delay = BACKOFF_BASE_S * (2 ** (attempt - 1))
+                logger.warning(
+                    "Tigris PNG transient error attempt %d/%d: %s — sleep %.1fs",
+                    attempt,
+                    MAX_RETRIES,
+                    e,
+                    delay,
+                )
+                time.sleep(delay)
+    raise TigrisError(f"Tigris exhausted retries for {key}: {last_exc}") from last_exc
+
+
 def delete_pdf(s3: Any, *, draft_id: str, prefix: str = "wr2-pdf") -> None:
     """Best-effort delete of LEGACY single-key path. Never raises.
 

--- a/apps/backend-rag/backend/services/publisher/__init__.py
+++ b/apps/backend-rag/backend/services/publisher/__init__.py
@@ -10,6 +10,7 @@ Design contract:
         property platform_name -> Platform
 
 Concrete implementations:
+    - IGPublisher: Meta Graph API v20 carousel (Sprint 7)
     - XPublisher:  X API v2 thread chained (Sprint 7)
     - LinkedInPublisher: REST API v2 posts (Sprint 8)
     - BlogPublisher: MDX + git commit (Sprint 8)
@@ -32,6 +33,7 @@ from backend.services.publisher.blog_batch_publisher import (
     BlogBatchPublisher,
 )
 from backend.services.publisher.blog_publisher import BlogPublisher
+from backend.services.publisher.ig_publisher import IGPublisher
 from backend.services.publisher.linkedin_publisher import LinkedInPublisher
 from backend.services.publisher.mdx_template import (
     MdxExtras,
@@ -59,6 +61,7 @@ __all__ = [
     "BlogBatchPublisher",
     "BlogPublisher",
     "DraftPayload",
+    "IGPublisher",
     "LinkedInPublisher",
     "MdxExtras",
     "PublishResult",

--- a/apps/backend-rag/backend/services/publisher/ig_publisher.py
+++ b/apps/backend-rag/backend/services/publisher/ig_publisher.py
@@ -1,0 +1,444 @@
+"""Instagram Graph API Publisher — carousel via image_url uploads.
+
+Flow (Meta Graph API v20):
+    1. For each slide i: POST /{IG_USER_ID}/media
+       params: image_url, is_carousel_item=true → returns container id
+    2. POST /{IG_USER_ID}/media
+       params: caption, media_type=CAROUSEL, children=c1,c2,... → returns
+       parent container id
+    3. POST /{IG_USER_ID}/media_publish
+       params: creation_id=parent_id → returns the final media id
+    4. Optional: GET /{id}?fields=permalink → post_url
+
+Requires env:
+    IG_USER_ID         — numeric business account id
+    IG_LONG_LIVED_TOKEN — 60-day long-lived access token
+
+Note: Meta uses pagination/throttling; we keep the flow simple and rely on
+a single attempt per container. Orchestrator handles retries.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+
+from backend.services.publisher.base import (
+    DraftPayload,
+    Publisher,
+    PublisherError,
+    PublishResult,
+    SlidePayload,
+    ValidationResult,
+)
+from backend.services.war_room.models import Platform
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_GRAPH_BASE = "https://graph.facebook.com/v20.0"
+DEFAULT_TIMEOUT = 30.0
+
+
+# Golden Rule #10: module-level lazy singleton AsyncClient. Lifespan
+# closes via close_ig_publisher_client() in app_factory.lifespan().
+_module_client: httpx.AsyncClient | None = None
+
+
+def _get_module_client(timeout: float) -> httpx.AsyncClient:
+    global _module_client
+    if _module_client is None or _module_client.is_closed:
+        _module_client = httpx.AsyncClient(timeout=timeout)
+    return _module_client
+
+
+async def close_ig_publisher_client() -> None:
+    """Release the module-level AsyncClient (lifespan shutdown hook)."""
+    global _module_client
+    if _module_client is not None and not _module_client.is_closed:
+        await _module_client.aclose()
+    _module_client = None
+
+
+async def validate_ig_credentials_at_startup(*, raise_on_failure: bool = False) -> dict[str, object]:
+    """Verify IG Graph credentials at app startup.
+
+    WR2 autonomous workflow Phase 1.5 — Codex amendment.
+    Spec: research/wr2/2026-05-27-wr2-autonomous-workflow-spec.md §8.1
+
+    Discovers IG_USER_ID / IG_LONG_LIVED_TOKEN (primary) with fallback to
+    INSTAGRAM_ACCOUNT_ID / INSTAGRAM_ACCESS_TOKEN (existing convention).
+    Validates: (1) both aliases consistent if both present (fail-loud on
+    mismatch); (2) Meta Graph `/me` returns 200 with matching account_id.
+    Logs ONLY account_id + username (NEVER token).
+
+    Returns dict with `status` ('ok' | 'mismatch' | 'invalid_token' |
+    'missing'), `account_id`, `username`, `source` (which env var pair won).
+
+    Set `raise_on_failure=True` to abort startup; default returns the dict
+    so callers (service_initializer) can decide.
+    """
+    ig_id = os.environ.get("IG_USER_ID")
+    ig_tok = os.environ.get("IG_LONG_LIVED_TOKEN")
+    insta_id = os.environ.get("INSTAGRAM_ACCOUNT_ID")
+    insta_tok = os.environ.get("INSTAGRAM_ACCESS_TOKEN")
+
+    if ig_id and insta_id and ig_id != insta_id:
+        msg = (
+            f"IG account mismatch: IG_USER_ID={ig_id} vs "
+            f"INSTAGRAM_ACCOUNT_ID={insta_id}. Spec §8.1 requires consistent aliases."
+        )
+        logger.error(msg)
+        if raise_on_failure:
+            raise PublisherError(msg)
+        return {"status": "mismatch", "account_id": None, "username": None, "source": None}
+
+    primary_id = ig_id or insta_id
+    primary_tok = ig_tok or insta_tok
+    source = (
+        "IG_USER_ID+IG_LONG_LIVED_TOKEN"
+        if (ig_id and ig_tok)
+        else "INSTAGRAM_ACCOUNT_ID+INSTAGRAM_ACCESS_TOKEN"
+        if (insta_id and insta_tok)
+        else None
+    )
+
+    if not primary_id or not primary_tok:
+        msg = (
+            "IG credentials missing: need IG_USER_ID + IG_LONG_LIVED_TOKEN "
+            "(or INSTAGRAM_ACCOUNT_ID + INSTAGRAM_ACCESS_TOKEN as fallback)"
+        )
+        logger.warning(msg)
+        if raise_on_failure:
+            raise PublisherError(msg)
+        return {"status": "missing", "account_id": None, "username": None, "source": None}
+
+    if ig_id and insta_id:
+        logger.warning(
+            "IG credentials: both IG_* and INSTAGRAM_* aliases present, using IG_* (primary). "
+            "Spec §8.1 recommends canonicalizing to IG_USER_ID/IG_LONG_LIVED_TOKEN.",
+        )
+
+    client = _get_module_client(DEFAULT_TIMEOUT)
+    try:
+        resp = await client.get(
+            f"{DEFAULT_GRAPH_BASE}/{primary_id}",
+            params={"access_token": primary_tok, "fields": "id,username"},
+        )
+    except httpx.HTTPError as exc:
+        msg = f"IG credentials: Meta Graph unreachable ({type(exc).__name__}: {exc})"
+        logger.warning(msg)
+        if raise_on_failure:
+            raise PublisherError(msg) from exc
+        return {"status": "invalid_token", "account_id": primary_id, "username": None, "source": source}
+
+    if resp.status_code != 200:
+        msg = (
+            f"IG credentials: Meta Graph returned {resp.status_code} for account_id={primary_id} "
+            f"(token may be expired or revoked)"
+        )
+        logger.error(msg)
+        if raise_on_failure:
+            raise PublisherError(msg)
+        return {"status": "invalid_token", "account_id": primary_id, "username": None, "source": source}
+
+    data = resp.json()
+    verified_id = str(data.get("id", ""))
+    username = data.get("username")
+
+    if verified_id and verified_id != str(primary_id):
+        msg = (
+            f"IG credentials: account_id mismatch — env={primary_id} vs graph={verified_id}"
+        )
+        logger.error(msg)
+        if raise_on_failure:
+            raise PublisherError(msg)
+        return {"status": "mismatch", "account_id": verified_id, "username": username, "source": source}
+
+    logger.info(
+        f"IG credentials validated: account_id={verified_id} username={username or '?'} source={source}",
+    )
+    return {"status": "ok", "account_id": verified_id, "username": username, "source": source}
+
+
+class IGPublisher(Publisher):
+    platform_name = Platform.INSTAGRAM
+
+    def __init__(
+        self,
+        *,
+        ig_user_id: str | None = None,
+        access_token: str | None = None,
+        graph_base: str | None = None,
+        http_client: httpx.AsyncClient | None = None,
+        timeout: float | None = None,
+    ) -> None:
+        self.ig_user_id = (
+            ig_user_id
+            or os.environ.get("IG_USER_ID")
+            or os.environ.get("INSTAGRAM_ACCOUNT_ID")
+            or ""
+        )
+        self.access_token = (
+            access_token
+            or os.environ.get("IG_LONG_LIVED_TOKEN")
+            or os.environ.get("INSTAGRAM_ACCESS_TOKEN")
+            or ""
+        )
+        if not self.ig_user_id or not self.access_token:
+            raise PublisherError(
+                "IGPublisher requires IG_USER_ID (or INSTAGRAM_ACCOUNT_ID) "
+                "and IG_LONG_LIVED_TOKEN (or INSTAGRAM_ACCESS_TOKEN)",
+            )
+        self.graph_base = (graph_base or DEFAULT_GRAPH_BASE).rstrip("/")
+        self._client = http_client
+        self.timeout = timeout or DEFAULT_TIMEOUT
+
+    # ── Public API ───────────────────────────────────────────────────
+
+    async def validate(self, draft: DraftPayload) -> ValidationResult:
+        issues: list[str] = []
+        if not draft.cover_image_url:
+            issues.append("cover_image_url is required")
+        if not draft.slides and not draft.cover_image_url:
+            issues.append("draft has no slides and no cover")
+        if len(draft.slides) + 1 > 10:
+            # IG carousel max 10 items (including cover)
+            issues.append(f"carousel has {len(draft.slides) + 1} items, max 10")
+        caption = draft.main_caption or ""
+        if len(caption) > 2200:
+            issues.append(f"caption exceeds 2200 chars ({len(caption)})")
+        # P1.4 (2026-05-26): IG first comment max 2200 chars
+        if draft.first_comment and len(draft.first_comment) > 2200:
+            issues.append(
+                f"first_comment exceeds 2200 chars ({len(draft.first_comment)})"
+            )
+        # P1.4: alt_text per slide max 1000 chars (IG image_alt_text limit)
+        for s in draft.slides:
+            if s.alt_text and len(s.alt_text) > 1000:
+                issues.append(
+                    f"slide {s.slide_number} alt_text exceeds 1000 chars ({len(s.alt_text)})"
+                )
+        if draft.cover_alt_text and len(draft.cover_alt_text) > 1000:
+            issues.append(
+                f"cover_alt_text exceeds 1000 chars ({len(draft.cover_alt_text)})"
+            )
+        return ValidationResult(
+            ok=not issues,
+            platform=Platform.INSTAGRAM,
+            issues=issues,
+        )
+
+    async def publish(self, draft: DraftPayload) -> PublishResult:
+        # P1.4 (2026-05-26): Regulatory editorial NEVER auto-publishes.
+        # Convergence 4/4 panel 2026-05-26. publish() refuses to dispatch
+        # unless draft.approval_state == "approved". Operator must flip the
+        # state explicitly via approval workflow (Telegram bot / dashboard UI).
+        if draft.approval_state != "approved":
+            return PublishResult(
+                ok=False,
+                platform=Platform.INSTAGRAM,
+                draft_id=draft.draft_id,
+                error=(
+                    f"approval_state={draft.approval_state!r} (required: 'approved'). "
+                    "Regulatory editorial NEVER auto-publishes — flip approval_state "
+                    "via human approval workflow first."
+                ),
+            )
+
+        validation = await self.validate(draft)
+        if not validation.ok:
+            return PublishResult(
+                ok=False,
+                platform=Platform.INSTAGRAM,
+                draft_id=draft.draft_id,
+                error=f"validation: {', '.join(validation.issues)}",
+            )
+
+        client = self._client or _get_module_client(self.timeout)
+
+        try:
+            items = _build_items(draft)
+            container_ids: list[str] = []
+
+            for slide in items:
+                container = await self._create_child_container(client, slide)
+                if not container:
+                    return PublishResult(
+                        ok=False,
+                        platform=Platform.INSTAGRAM,
+                        draft_id=draft.draft_id,
+                        error=f"create_child failed for slide {slide.slide_number}",
+                    )
+                container_ids.append(container)
+
+            parent_id = await self._create_parent_container(
+                client,
+                caption=draft.main_caption,
+                children_ids=container_ids,
+            )
+            if not parent_id:
+                return PublishResult(
+                    ok=False,
+                    platform=Platform.INSTAGRAM,
+                    draft_id=draft.draft_id,
+                    error="create_parent failed",
+                )
+
+            media_id = await self._publish_parent(client, parent_id)
+            if not media_id:
+                return PublishResult(
+                    ok=False,
+                    platform=Platform.INSTAGRAM,
+                    draft_id=draft.draft_id,
+                    error="media_publish failed",
+                )
+
+            permalink = await self._fetch_permalink(client, media_id)
+            return PublishResult(
+                ok=True,
+                platform=Platform.INSTAGRAM,
+                draft_id=draft.draft_id,
+                post_external_id=media_id,
+                post_url=permalink,
+                final_text=draft.main_caption,
+                meta={
+                    "carousel_items": len(container_ids),
+                    "parent_id": parent_id,
+                },
+            )
+        except Exception as exc:
+            return PublishResult(
+                ok=False,
+                platform=Platform.INSTAGRAM,
+                draft_id=draft.draft_id,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+
+    async def delete(self, post_external_id: str) -> bool:
+        """Meta Graph API supports DELETE /{media-id}; best-effort."""
+        client = self._client or _get_module_client(self.timeout)
+        try:
+            resp = await client.delete(
+                f"{self.graph_base}/{post_external_id}",
+                params={"access_token": self.access_token},
+                timeout=self.timeout,
+            )
+            return resp.status_code in (200, 204)
+        except Exception as exc:
+            logger.info("ig delete failed: %s", exc)
+            return False
+
+    # ── Internal ─────────────────────────────────────────────────────
+
+    async def _create_child_container(
+        self,
+        client: httpx.AsyncClient,
+        slide: SlidePayload,
+    ) -> str | None:
+        params = {
+            "image_url": slide.image_url,
+            "is_carousel_item": "true",
+            "access_token": self.access_token,
+        }
+        resp = await client.post(
+            f"{self.graph_base}/{self.ig_user_id}/media",
+            params=params,
+            timeout=self.timeout,
+        )
+        return _parse_id(resp)
+
+    async def _create_parent_container(
+        self,
+        client: httpx.AsyncClient,
+        *,
+        caption: str,
+        children_ids: list[str],
+    ) -> str | None:
+        params = {
+            "media_type": "CAROUSEL",
+            "children": ",".join(children_ids),
+            "caption": caption,
+            "access_token": self.access_token,
+        }
+        resp = await client.post(
+            f"{self.graph_base}/{self.ig_user_id}/media",
+            params=params,
+            timeout=self.timeout,
+        )
+        return _parse_id(resp)
+
+    async def _publish_parent(
+        self,
+        client: httpx.AsyncClient,
+        parent_id: str,
+    ) -> str | None:
+        params = {
+            "creation_id": parent_id,
+            "access_token": self.access_token,
+        }
+        resp = await client.post(
+            f"{self.graph_base}/{self.ig_user_id}/media_publish",
+            params=params,
+            timeout=self.timeout,
+        )
+        return _parse_id(resp)
+
+    async def _fetch_permalink(
+        self,
+        client: httpx.AsyncClient,
+        media_id: str,
+    ) -> str | None:
+        try:
+            resp = await client.get(
+                f"{self.graph_base}/{media_id}",
+                params={
+                    "fields": "permalink",
+                    "access_token": self.access_token,
+                },
+                timeout=self.timeout,
+            )
+            if resp.status_code != 200:
+                return None
+            body = resp.json()
+            return body.get("permalink")
+        except Exception:
+            return None
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+def _build_items(draft: DraftPayload) -> list[SlidePayload]:
+    items: list[SlidePayload] = []
+    # cover first
+    items.append(
+        SlidePayload(
+            slide_number=1,
+            image_url=draft.cover_image_url,
+            caption=None,
+        )
+    )
+    # body slides (preserve caller's order)
+    for slide in draft.slides:
+        items.append(slide)
+    return items
+
+
+def _parse_id(resp: httpx.Response) -> str | None:
+    if resp.status_code != 200:
+        logger.warning(
+            "IG API returned %s: %s",
+            resp.status_code,
+            resp.text[:300],
+        )
+        return None
+    try:
+        body = resp.json()
+    except ValueError:
+        logger.warning("IG API non-json response: %s", resp.text[:300])
+        return None
+    mid = body.get("id")
+    return str(mid) if mid else None

--- a/apps/backend-rag/backend/tests/services/publisher/test_ig_publisher.py
+++ b/apps/backend-rag/backend/tests/services/publisher/test_ig_publisher.py
@@ -1,0 +1,149 @@
+"""Tests for the restored IGPublisher + Tigris PNG upload.
+
+Covers:
+  (a) Legge 5 — publish() REFUSES unless approval_state == "approved".
+  (c) upload_png sets ContentType="image/png".
+
+(The CLI dry-run test (b) lives in test_wr2_ig_publish_cli.py.)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import httpx
+import pytest
+
+from backend.services.publisher.base import DraftPayload, SlidePayload
+from backend.services.publisher.ig_publisher import IGPublisher
+
+
+def _draft(approval_state: str = "pending", slides: int = 2) -> DraftPayload:
+    return DraftPayload(
+        draft_id=uuid4(),
+        topic="permenkumham-22-2024-kitap",
+        tone_register=None,
+        cover_image_url="https://tigris/cover.png",
+        main_caption="Bali Zero regulatory update.",
+        slides=[
+            SlidePayload(slide_number=i + 1, image_url=f"https://tigris/s{i}.png")
+            for i in range(slides)
+        ],
+        approval_state=approval_state,
+    )
+
+
+def _publisher() -> IGPublisher:
+    # Pass creds explicitly so the test never depends on real env secrets.
+    return IGPublisher(
+        ig_user_id="24126743553672359",
+        access_token="test-token-not-real",
+        graph_base="https://graph.instagram.com/v22.0",
+    )
+
+
+# ── (a) Legge 5 approval gate ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_publish_refuses_when_not_approved() -> None:
+    """publish() must REFUSE (ok=False, no Meta call) when approval_state != approved."""
+    pub = _publisher()
+    # A network call would fail loudly; assert we never reach it by spying client.
+    pub._client = MagicMock(spec=httpx.AsyncClient)
+
+    for state in ("pending", "rejected", "", "Approved", "APPROVED", "yes"):
+        result = await pub.publish(_draft(approval_state=state))
+        assert result.ok is False, f"state={state!r} should be refused"
+        assert "approval_state" in (result.error or ""), result.error
+        assert "approved" in (result.error or "")
+
+    # Hard proof no Meta HTTP call was attempted for the refused drafts.
+    pub._client.post.assert_not_called()
+    pub._client.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_publish_passes_gate_when_approved_then_validates() -> None:
+    """When approved, publish() proceeds past the Legge-5 gate into validation.
+
+    We do NOT mock a full happy path here (that's an integration concern); we
+    only prove the gate itself no longer blocks an 'approved' draft — i.e. the
+    error, if any, is NOT the approval_state refusal.
+    """
+    pub = _publisher()
+
+    # Make the first Meta POST (child container) fail fast so publish() returns
+    # a non-approval error — proving the gate was passed.
+    async def _post(*args: object, **kwargs: object) -> httpx.Response:
+        r = MagicMock(spec=httpx.Response)
+        r.status_code = 400
+        r.text = "stub-fail"
+        r.json.return_value = {}
+        return r
+
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.post = _post
+    pub._client = client
+
+    result = await pub.publish(_draft(approval_state="approved"))
+    assert result.ok is False
+    # The failure is a create_child failure, NOT the Legge-5 approval refusal.
+    assert "approval_state" not in (result.error or "")
+    assert "create_child" in (result.error or "")
+
+
+# ── (c) upload_png ContentType ────────────────────────────────────────
+
+
+def test_upload_png_sets_image_png_content_type() -> None:
+    """upload_png must put_object with ContentType='image/png' and verify via HEAD."""
+    from backend.services.canva_renderer_v2 import _tigris
+
+    captured: dict[str, object] = {}
+
+    class _FakeS3:
+        def put_object(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+        def head_object(self, **kwargs: object) -> dict[str, object]:
+            # Mirror what Tigris returns; ContentType must match what we put.
+            return {
+                "ContentType": captured.get("ContentType"),
+                "ContentLength": 123,
+                "ETag": '"abc"',
+            }
+
+    url, key = _tigris.upload_png(
+        _FakeS3(),
+        b"\x89PNG\r\n\x1a\n fake png bytes",
+        draft_id="draftX",
+        slide_index=3,
+        prefix="wr2-ig",
+    )
+
+    assert captured["ContentType"] == "image/png"
+    assert captured["ACL"] == "public-read"
+    assert key == "wr2-ig/draftX/03.png"
+    assert url == f"https://{_tigris.PUBLIC_HOST}/wr2-ig/draftX/03.png"
+
+
+def test_upload_png_raises_on_content_type_mismatch() -> None:
+    """If Tigris HEAD reports a non-png ContentType, upload_png must raise."""
+    from backend.services.canva_renderer_v2 import _tigris
+
+    class _FakeS3:
+        def put_object(self, **kwargs: object) -> None:
+            pass
+
+        def head_object(self, **kwargs: object) -> dict[str, object]:
+            return {"ContentType": "application/octet-stream", "ContentLength": 1}
+
+    with pytest.raises(_tigris.TigrisError, match="ContentType mismatch"):
+        _tigris.upload_png(
+            _FakeS3(),
+            b"x",
+            draft_id="d",
+            slide_index=0,
+        )

--- a/apps/backend-rag/backend/tests/services/publisher/test_wr2_ig_publish_cli.py
+++ b/apps/backend-rag/backend/tests/services/publisher/test_wr2_ig_publish_cli.py
@@ -1,0 +1,150 @@
+"""Tests for the scripts/wr2_ig_publish.py operator-gated CLI.
+
+Covers:
+  (b) the CLI is dry-run without --confirm (never publishes, never writes ledger).
+
+Also covers the two hard stops:
+  - token-scope gate aborts when neither WR2_IG_CONTENT_PUBLISH_VERIFIED=1 nor
+    Instagram creds resolve;
+  - --confirm fails closed when the ledger DB is unreachable (no DSN).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load scripts/wr2_ig_publish.py as a module without polluting global sys.path
+# beyond the scripts dir. Repo root = 6 parents up from this test file:
+# publisher(0) services(1) tests(2) backend(3) backend-rag(4) apps(5) repo(6).
+_REPO_ROOT = Path(__file__).resolve().parents[6]
+_SCRIPTS = _REPO_ROOT / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+def _load_cli():
+    spec = importlib.util.spec_from_file_location(
+        "wr2_ig_publish", _SCRIPTS / "wr2_ig_publish.py"
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_carousel(tmp_path: Path, slug: str, n_slides: int = 3) -> Path:
+    """Create a minimal on-disk carousel: slides.json + numbered PNGs."""
+    root = tmp_path / "carousel"
+    slug_dir = root / slug
+    slides_dir = slug_dir / "slides"
+    slides_dir.mkdir(parents=True)
+    (slug_dir / "slides.json").write_text(
+        json.dumps({"carousel_id": slug, "slide_count": n_slides, "slides": []}),
+        encoding="utf-8",
+    )
+    png_magic = b"\x89PNG\r\n\x1a\n"
+    for i in range(1, n_slides + 1):
+        (slides_dir / f"{i:02d}.png").write_bytes(png_magic + f"slide{i}".encode())
+    return root
+
+
+def test_dry_run_never_publishes_or_writes_ledger(tmp_path, monkeypatch) -> None:
+    """(b) Without --confirm: uploads to Tigris + builds draft, but NEVER calls
+    publish() and NEVER touches the ledger."""
+    cli = _load_cli()
+    root = _make_carousel(tmp_path, "dry-run-test-slug")
+    monkeypatch.setenv("WR2_CAROUSEL_ROOT", str(root))
+    # Satisfy the token gate via the verified-override (no real creds needed).
+    monkeypatch.setenv("WR2_IG_CONTENT_PUBLISH_VERIFIED", "1")
+
+    # Stub Tigris so no network call happens; record that it WAS called.
+    upload_calls: list[int] = []
+
+    def _fake_upload(png_paths, *, draft_id):  # type: ignore[no-untyped-def]
+        upload_calls.append(len(png_paths))
+        return [f"https://tigris/{draft_id}/{i:02d}.png" for i in range(len(png_paths))]
+
+    monkeypatch.setattr(cli, "_upload_slides_to_tigris", _fake_upload)
+
+    # Tripwires: these MUST NOT be invoked in a dry run.
+    async def _explode_ledger(**kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("dry-run must NOT call the ledger precondition")
+
+    monkeypatch.setattr(cli, "_ledger_precondition", _explode_ledger)
+
+    # If IGPublisher were ever constructed/called, fail loudly. The CLI imports
+    # it lazily inside _run's confirm branch, so patch the source symbol.
+    def _explode_publisher(*a, **k):  # type: ignore[no-untyped-def]
+        raise AssertionError("dry-run must NOT construct/call IGPublisher")
+
+    monkeypatch.setattr(
+        "backend.services.publisher.ig_publisher.IGPublisher",
+        _explode_publisher,
+        raising=True,
+    )
+
+    rc = cli.main(["dry-run-test-slug"])  # no --confirm
+
+    # rc==0 + the ledger/publisher tripwires never firing proves the dry run
+    # uploaded to Tigris and built the draft but neither wrote the ledger nor
+    # published.
+    assert rc == 0
+    assert upload_calls == [3], "dry-run should still upload all 3 slides to Tigris"
+
+
+def test_token_gate_aborts_without_verification(tmp_path, monkeypatch) -> None:
+    """Hard stop: no WR2_IG_CONTENT_PUBLISH_VERIFIED and no creds -> exit 1."""
+    cli = _load_cli()
+    root = _make_carousel(tmp_path, "gate-test-slug")
+    monkeypatch.setenv("WR2_CAROUSEL_ROOT", str(root))
+    monkeypatch.delenv("WR2_IG_CONTENT_PUBLISH_VERIFIED", raising=False)
+    for k in (
+        "IG_USER_ID",
+        "INSTAGRAM_ACCOUNT_ID",
+        "IG_LONG_LIVED_TOKEN",
+        "INSTAGRAM_ACCESS_TOKEN",
+    ):
+        monkeypatch.delenv(k, raising=False)
+
+    rc = cli.main(["gate-test-slug"])
+    assert rc == 1
+
+
+def test_confirm_fails_closed_when_ledger_db_unreachable(tmp_path, monkeypatch) -> None:
+    """--confirm with no DSN must FAIL CLOSED (never publish without the guard)."""
+    cli = _load_cli()
+    root = _make_carousel(tmp_path, "confirm-noledger-slug")
+    monkeypatch.setenv("WR2_CAROUSEL_ROOT", str(root))
+    monkeypatch.setenv("WR2_IG_CONTENT_PUBLISH_VERIFIED", "1")
+
+    # Stub Tigris (upload happens before the ledger gate).
+    monkeypatch.setattr(
+        cli,
+        "_upload_slides_to_tigris",
+        lambda png_paths, *, draft_id: [
+            f"https://tigris/{i:02d}.png" for i in range(len(png_paths))
+        ],
+    )
+
+    # Force "no DSN": clear env and clear settings.database_url.
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    from backend.app.core.config import settings
+
+    monkeypatch.setattr(settings, "database_url", None, raising=False)
+
+    # Publisher must NEVER be reached because the ledger gate fails first.
+    monkeypatch.setattr(
+        "backend.services.publisher.ig_publisher.IGPublisher",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("must not publish when ledger DB unreachable")
+        ),
+        raising=True,
+    )
+
+    rc = cli.main(["confirm-noledger-slug", "--confirm"])
+    assert rc == 1

--- a/apps/backend-rag/backend/tests/unit/routers/test_wr2_publish.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_wr2_publish.py
@@ -1,0 +1,279 @@
+"""Tests for the WR2 server-side IG publish endpoint (Legge 5 operator gate).
+
+Covers the four load-bearing guarantees of POST /api/war-room/publish-ig:
+
+  1. confirm=False  -> IGPublisher.publish() is NEVER called (dry validation).
+  2. confirm=True   -> publish() IS called with approval_state == "approved"
+                       (the Meta HTTP is mocked; we assert the draft passed the
+                       publisher's internal approval gate).
+  3. admin gate     -> a non-admin user gets 403.
+  4. already-published -> 409 with the prior permalink (ledger mocked to refuse).
+
+The publisher's Meta HTTP is never hit: we monkeypatch IGPublisher.publish /
+.validate. The ledger DB is never hit: we monkeypatch the two ledger helpers in
+the router module (_ledger_precondition / _ledger_record_result).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.app.dependencies import get_current_user
+from backend.app.routers import wr2_publish
+from backend.services.publisher.base import PublishResult, ValidationResult
+from backend.services.war_room.models import Platform
+
+ADMIN_USER = {"email": "zero@balizero.com", "role": "founder"}
+NON_ADMIN_USER = {"email": "viewer@example.com", "role": "team"}
+
+IMAGE_URLS = [
+    "https://nuzantara-warroom-images.fly.storage.tigris.dev/wr2-ig/cover.png",
+    "https://nuzantara-warroom-images.fly.storage.tigris.dev/wr2-ig/02.png",
+    "https://nuzantara-warroom-images.fly.storage.tigris.dev/wr2-ig/03.png",
+]
+CAPTION = "Bali Zero regulatory update — KBLI 2025 conversion clock. See balizero.com."
+
+
+def _app(user: dict[str, Any]) -> FastAPI:
+    app = FastAPI()
+    app.include_router(wr2_publish.router)
+    app.dependency_overrides[get_current_user] = lambda: user
+    return app
+
+
+def _body(confirm: bool) -> dict[str, Any]:
+    return {
+        "slug": "kbli-2025-conversion",
+        "image_urls": IMAGE_URLS,
+        "caption": CAPTION,
+        "alt_texts": ["cover alt", "slide 2 alt", "slide 3 alt"],
+        "confirm": confirm,
+    }
+
+
+# ── 1. confirm=False => publish() NEVER called ─────────────────────────────────
+
+
+def test_dry_run_never_calls_publish(monkeypatch: pytest.MonkeyPatch) -> None:
+    """confirm=False: a dry validation runs, publish() is never invoked, and the
+    ledger is never touched (no 'planned' / terminal row written)."""
+    publish_spy = AsyncMock(
+        side_effect=AssertionError("publish() must NOT be called on a dry run")
+    )
+    validate_spy = AsyncMock(
+        return_value=ValidationResult(ok=True, platform=Platform.INSTAGRAM, issues=[])
+    )
+    ledger_precondition_spy = AsyncMock(
+        side_effect=AssertionError("ledger precondition must NOT run on a dry run")
+    )
+
+    monkeypatch.setattr(
+        "backend.services.publisher.ig_publisher.IGPublisher.publish", publish_spy
+    )
+    monkeypatch.setattr(
+        "backend.services.publisher.ig_publisher.IGPublisher.validate", validate_spy
+    )
+    # Make IGPublisher() constructible without real creds.
+    monkeypatch.setenv("INSTAGRAM_ACCOUNT_ID", "24126743553672359")
+    monkeypatch.setenv("INSTAGRAM_ACCESS_TOKEN", "dummy-token-not-used")
+    monkeypatch.setattr(wr2_publish, "_ledger_precondition", ledger_precondition_spy)
+
+    app = _app(ADMIN_USER)
+    try:
+        resp = TestClient(app).post("/api/war-room/publish-ig", json=_body(confirm=False))
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["dry_run"] is True
+    assert data["would_publish"]["approval_state"] == "pending"
+    assert data["would_publish"]["slide_count"] == 3
+    assert data["validation"]["ok"] is True
+
+    publish_spy.assert_not_called()  # THE guarantee: no publish on a dry run.
+    validate_spy.assert_awaited_once()  # but we DID validate.
+    ledger_precondition_spy.assert_not_called()  # and no ledger write.
+
+
+# ── 2. confirm=True => publish() called with approval_state == "approved" ──────
+
+
+def test_confirm_calls_publish_with_approved_draft(monkeypatch: pytest.MonkeyPatch) -> None:
+    """confirm=True: ledger precondition proceeds, publish() IS called, and the
+    draft handed to publish() has approval_state == 'approved' (the flag the
+    real publisher checks at ig_publisher.py:239)."""
+    permalink = "https://www.instagram.com/p/ABC123/"
+    captured: dict[str, Any] = {}
+
+    async def fake_publish(self: Any, draft: Any) -> PublishResult:  # noqa: ANN401
+        # Assert the gate the real publisher would check actually passed.
+        assert draft.approval_state == "approved"
+        captured["approval_state"] = draft.approval_state
+        captured["cover"] = draft.cover_image_url
+        captured["slides"] = len(draft.slides)
+        return PublishResult(
+            ok=True,
+            platform=Platform.INSTAGRAM,
+            draft_id=draft.draft_id,
+            post_external_id="17900000000000000",
+            post_url=permalink,
+        )
+
+    monkeypatch.setattr(
+        "backend.services.publisher.ig_publisher.IGPublisher.publish", fake_publish
+    )
+    monkeypatch.setenv("INSTAGRAM_ACCOUNT_ID", "24126743553672359")
+    monkeypatch.setenv("INSTAGRAM_ACCESS_TOKEN", "dummy-token-not-used")
+
+    carousel_id = str(uuid4())
+    monkeypatch.setattr(
+        wr2_publish,
+        "_ledger_precondition",
+        AsyncMock(return_value=(carousel_id, "proceed", None)),
+    )
+    record_spy = AsyncMock(return_value=None)
+    monkeypatch.setattr(wr2_publish, "_ledger_record_result", record_spy)
+    monkeypatch.setattr(
+        "backend.services.publisher.ig_publisher.close_ig_publisher_client",
+        AsyncMock(return_value=None),
+    )
+
+    app = _app(ADMIN_USER)
+    try:
+        resp = TestClient(app).post("/api/war-room/publish-ig", json=_body(confirm=True))
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["dry_run"] is False
+    assert data["permalink"] == permalink
+    assert data["post_id"] == "17900000000000000"
+
+    assert captured["approval_state"] == "approved"  # gate passed
+    assert captured["cover"] == IMAGE_URLS[0]
+    assert captured["slides"] == 2  # 3 urls => cover + 2 body slides
+    # ledger written to terminal 'published'
+    assert record_spy.await_args.kwargs["state"] == "published"
+
+
+# ── 3. admin gate => non-admin user is 403 ─────────────────────────────────────
+
+
+def test_non_admin_is_forbidden() -> None:
+    """A non-admin user is blocked by the router-level _require_admin dependency."""
+    app = _app(NON_ADMIN_USER)
+    try:
+        resp = TestClient(app).post("/api/war-room/publish-ig", json=_body(confirm=False))
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 403
+    assert resp.json() == {"detail": "Admin access required"}
+
+
+# ── 4. already-published slug => 409 with existing permalink ───────────────────
+
+
+def test_already_published_returns_409_with_permalink(monkeypatch: pytest.MonkeyPatch) -> None:
+    """confirm=True but the ledger says this carousel+content is already
+    published => 409, the prior permalink is returned, publish() is never run."""
+    prior_permalink = "https://www.instagram.com/p/PRIOR99/"
+    carousel_id = str(uuid4())
+
+    monkeypatch.setattr(
+        wr2_publish,
+        "_ledger_precondition",
+        AsyncMock(return_value=(carousel_id, "refuse", prior_permalink)),
+    )
+    publish_spy = AsyncMock(
+        side_effect=AssertionError("publish() must NOT run when ledger refuses")
+    )
+    monkeypatch.setattr(
+        "backend.services.publisher.ig_publisher.IGPublisher.publish", publish_spy
+    )
+    monkeypatch.setenv("INSTAGRAM_ACCOUNT_ID", "24126743553672359")
+    monkeypatch.setenv("INSTAGRAM_ACCESS_TOKEN", "dummy-token-not-used")
+
+    app = _app(ADMIN_USER)
+    try:
+        resp = TestClient(app).post("/api/war-room/publish-ig", json=_body(confirm=True))
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 409, resp.text
+    detail = resp.json()["detail"]
+    assert detail["error"] == "already_published"
+    assert detail["permalink"] == prior_permalink
+    publish_spy.assert_not_called()
+
+
+# ── Bonus: publisher approval-gate refusal surfaces as a clear 4xx ─────────────
+
+
+def test_publisher_gate_refusal_surfaces_4xx(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If publish() returns ok=False (e.g. the real publisher's approval gate or
+    a validation failure), the endpoint returns 422, not a 500, and records the
+    ledger as 'failed'."""
+
+    async def refusing_publish(self: Any, draft: Any) -> PublishResult:  # noqa: ANN401
+        return PublishResult(
+            ok=False,
+            platform=Platform.INSTAGRAM,
+            draft_id=draft.draft_id,
+            error="approval_state='pending' (required: 'approved').",
+        )
+
+    monkeypatch.setattr(
+        "backend.services.publisher.ig_publisher.IGPublisher.publish", refusing_publish
+    )
+    monkeypatch.setenv("INSTAGRAM_ACCOUNT_ID", "24126743553672359")
+    monkeypatch.setenv("INSTAGRAM_ACCESS_TOKEN", "dummy-token-not-used")
+
+    carousel_id = str(uuid4())
+    monkeypatch.setattr(
+        wr2_publish,
+        "_ledger_precondition",
+        AsyncMock(return_value=(carousel_id, "proceed", None)),
+    )
+    record_spy = AsyncMock(return_value=None)
+    monkeypatch.setattr(wr2_publish, "_ledger_record_result", record_spy)
+    monkeypatch.setattr(
+        "backend.services.publisher.ig_publisher.close_ig_publisher_client",
+        AsyncMock(return_value=None),
+    )
+
+    app = _app(ADMIN_USER)
+    try:
+        resp = TestClient(app).post("/api/war-room/publish-ig", json=_body(confirm=True))
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["detail"]["error"] == "publish_failed"
+    assert record_spy.await_args.kwargs["state"] == "failed"
+
+
+# ── Content-hash determinism (idempotency key stability) ───────────────────────
+
+
+def test_content_hash_is_stable_and_order_sensitive() -> None:
+    h1 = wr2_publish._content_hash(IMAGE_URLS, CAPTION)
+    h2 = wr2_publish._content_hash(IMAGE_URLS, CAPTION)
+    h3 = wr2_publish._content_hash(list(reversed(IMAGE_URLS)), CAPTION)
+    h4 = wr2_publish._content_hash(IMAGE_URLS, CAPTION + " edited")
+    assert h1 == h2  # deterministic
+    assert h1 != h3  # order-sensitive (slide order matters)
+    assert h1 != h4  # caption-sensitive
+
+    # MagicMock import kept for parity with other router tests' tooling surface.
+    assert isinstance(MagicMock(), MagicMock)

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 632 services · 1092 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`329 routers · 633 services · 1095 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/scripts/tests/test_wr2_ig_caption.py
+++ b/scripts/tests/test_wr2_ig_caption.py
@@ -1,0 +1,306 @@
+"""
+Regression tests for scripts/wr2_ig_caption.py — the WR2 Instagram caption author.
+
+Covers the 3 bugs found by adversarial observers on real fixtures, plus a
+happy-path snapshot of the real `indonesia-visafree-myth-reality` carousel:
+
+  BUG #1 (crash) — nested-dict bilingual_lexicon does NOT crash build_caption.
+  BUG #2 (crash, superscar #3 over-match) — a caption with ✓/✗ status glyphs
+          SURVIVES the emoji guard (INNOCENCE), while a real emoji like 🎉 IS
+          still stripped (GUILT).
+  BUG #3 (cosmetic) — an all-caps nationality list keeps proper-case
+          ("Thailand and Vietnam", never "...and vietnam").
+  Happy-path — the real visafree carousel yields a caption that has the
+          disclaimer, is under the 2200-char IG limit, and carries >=8 hashtags.
+
+Fixtures: the carousel output dir (`apps/war-room/output/`) is gitignored, so
+it is absent from the agent worktree. Tests that need real briefs copy them
+from the main checkout into a tmp carousel root, or build synthetic carousels
+in tmp — so the suite is self-contained and runs from any checkout.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+# Make `scripts/` importable regardless of the pytest rootdir.
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+import sys
+
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import wr2_ig_caption as cap  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Real-fixture discovery (main checkout — output/ is gitignored)
+# --------------------------------------------------------------------------- #
+
+# Walk up to find a checkout that physically has the carousel output dir.
+def _find_real_carousel_base() -> Path | None:
+    here = Path(__file__).resolve()
+    candidates: list[Path] = []
+    for parent in here.parents:
+        candidates.append(parent / "apps" / "war-room" / "output" / "carousel")
+    # Also try the canonical main checkout (worktrees keep output/ in the main
+    # checkout only).
+    candidates.append(
+        Path("/Users/balizero/Desktop/nuzantara/apps/war-room/output/carousel")
+    )
+    for c in candidates:
+        if c.is_dir():
+            return c
+    return None
+
+
+_REAL_BASE = _find_real_carousel_base()
+_VISAFREE_SLUG = "indonesia-visafree-myth-reality"
+
+
+def _write_carousel(base: Path, slug: str, brief: dict, slides: dict) -> None:
+    d = base / slug
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "brief.json").write_text(json.dumps(brief), encoding="utf-8")
+    (d / "slides.json").write_text(json.dumps(slides), encoding="utf-8")
+
+
+def _minimal_slides(heading: str, *, extra_slides: list[dict] | None = None) -> dict:
+    slides = [{"index": 1, "heading": heading, "layout_family": "cover-photo"}]
+    if extra_slides:
+        slides.extend(extra_slides)
+    return {"carousel_id": "test", "slides": slides}
+
+
+def _minimal_brief(**overrides) -> dict:
+    brief = {
+        "topic": "Test carousel",
+        "domain": "visa",
+        "hook_angle": "A real plain-language regulatory fact goes here.",
+        "key_facts": ["A second fact for the body."],
+    }
+    brief.update(overrides)
+    return brief
+
+
+# --------------------------------------------------------------------------- #
+# BUG #1 — nested-dict lexicon does NOT crash
+# --------------------------------------------------------------------------- #
+
+
+def test_bug1_nested_dict_lexicon_does_not_crash(tmp_path: Path) -> None:
+    """A brief whose lexicon is the nested-dict shape must build, not crash.
+
+    Real fixtures (e31a-spouse-visa, kep71-spt-extension-test-5) ship the
+    lexicon as {"always_untranslated": [...], "assist_on_first_use": [...]}.
+    The pre-fix code iterated it as a list and called .get on a str key ->
+    AttributeError -> no caption.
+    """
+    nested_lexicon = {
+        "always_untranslated": [
+            {"id_term": "KITAS", "english_assist": None, "always_untranslated": True},
+            {"id_term": "KITAP", "english_assist": None, "always_untranslated": True},
+        ],
+        "assist_on_first_use": [
+            {
+                "id_term": "PENJAMIN",
+                "english_assist": "immigration sponsor",
+                "always_untranslated": False,
+            },
+        ],
+    }
+    brief = _minimal_brief(bilingual_lexicon_with_english_assist=nested_lexicon)
+    slides = _minimal_slides("E31A SPOUSE VISA — WORK WITHOUT A SPONSOR")
+    _write_carousel(tmp_path, "nested-lex", brief, slides)
+
+    caption = cap.build_caption("nested-lex", base_dir=tmp_path)
+    assert isinstance(caption, str)
+    assert caption  # non-empty
+    assert cap.DISCLAIMER in caption
+
+
+def test_bug1_normalize_lexicon_all_shapes() -> None:
+    """The normalizer handles flat-list, nested-dict, None, and garbage."""
+    # Flat list
+    flat = [{"id_term": "BVK"}, {"id_term": "VoA"}]
+    assert len(cap._normalize_lexicon(flat)) == 2
+    # Nested dict
+    nested = {"always_untranslated": [{"id_term": "KITAS"}], "assist_on_first_use": [{"id_term": "IMTA"}]}
+    norm = cap._normalize_lexicon(nested)
+    assert len(norm) == 2
+    assert {t["id_term"] for t in norm} == {"KITAS", "IMTA"}
+    # None / missing
+    assert cap._normalize_lexicon(None) == []
+    # Garbage (bare string) — must not crash
+    assert cap._normalize_lexicon("nonsense") == []
+    # Entries that are not dicts are dropped
+    assert cap._normalize_lexicon([{"id_term": "OK"}, "junk", 42]) == [{"id_term": "OK"}]
+
+
+# --------------------------------------------------------------------------- #
+# BUG #2 — emoji guard over-match on legitimate ✓/✗ (superscar #3)
+# --------------------------------------------------------------------------- #
+
+
+def test_bug2_innocence_checkmarks_survive(tmp_path: Path) -> None:
+    """INNOCENCE: a caption whose slides carry ✓/✗ status glyphs is NOT killed.
+
+    WR2 dark-status-list slides legitimately contain ✓ (U+2713) and ✗ (U+2717),
+    which live inside the historical emoji range — a naive guard swallowed them
+    and emptied the caption.
+    """
+    status_body = "§ SUBSTANCE GATE:\n✓ STEM FIELD\n✓ 5+ YEARS\n✗ NOMAD WITHOUT STEM"
+    slides = _minimal_slides(
+        "WHO QUALIFIES",
+        extra_slides=[{"index": 2, "heading": "GATES", "body": status_body}],
+    )
+    brief = _minimal_brief(
+        hook_angle="The substance gate ✓ and the procedure gate ✗ both matter.",
+    )
+    _write_carousel(tmp_path, "glyphs", brief, slides)
+
+    caption = cap.build_caption("glyphs", base_dir=tmp_path)
+    assert isinstance(caption, str)
+    assert caption.strip()  # survived — not empty
+    assert cap.DISCLAIMER in caption
+    # The glyphs were transliterated, not silently dropped to nothing.
+    assert "✓" not in caption and "✗" not in caption  # guard ran
+    assert "yes:" in caption or "no:" in caption  # transliterated, not killed
+
+
+def test_bug2_innocence_strip_emoji_keeps_checkmark_content() -> None:
+    """The guard itself transliterates ✓/✗ rather than deleting them."""
+    out = cap._strip_emoji("✓ STEM FIELD\n✗ NO STEM")
+    assert "STEM FIELD" in out
+    assert "yes:" in out
+    assert "no:" in out
+    assert "✓" not in out and "✗" not in out
+    # Heavy variants too.
+    out2 = cap._strip_emoji("✔ done ✖ blocked")
+    assert "yes:" in out2 and "no:" in out2
+
+
+def test_bug2_guilt_real_emoji_is_stripped() -> None:
+    """GUILT: a real emoji like 🎉 IS still removed by the guard."""
+    out = cap._strip_emoji("We did it 🎉 today")
+    assert "🎉" not in out
+    assert "We did it" in out and "today" in out
+    # A few more real emoji to be sure the class still bites.
+    for emoji in ["🚀", "🔥", "🇮🇩", "⭐", "✅", "❌"]:
+        stripped = cap._strip_emoji(f"a {emoji} b")
+        assert emoji not in stripped
+
+
+# --------------------------------------------------------------------------- #
+# BUG #3 — all-caps nationality list keeps proper-case
+# --------------------------------------------------------------------------- #
+
+
+def test_bug3_nationality_list_keeps_proper_case() -> None:
+    """An all-caps nationality token is Title-cased, never lowercased."""
+    out = cap._sentence_case("THAILAND AND VIETNAM ARE EXEMPT")
+    assert "Vietnam" in out
+    assert "vietnam" not in out  # the bug: would have produced "...and vietnam"
+    assert "Thailand" in out
+    # 'and' is a small word -> lowercase mid-sentence (restrained).
+    assert " and " in out
+
+    out2 = cap._sentence_case("FRANCE AND SPAIN QUALIFY")
+    assert "Spain" in out2
+    assert "spain" not in out2
+    assert "France" in out2
+
+
+def test_bug3_in_caption_body_via_heading(tmp_path: Path) -> None:
+    """End-to-end: an all-caps heading nationality list keeps proper case."""
+    slides = _minimal_slides("THAILAND AND VIETNAM ARE EXEMPT. FRANCE AND SPAIN QUALIFY.")
+    brief = _minimal_brief()
+    _write_carousel(tmp_path, "nat", brief, slides)
+    caption = cap.build_caption("nat", base_dir=tmp_path)
+    assert "Vietnam" in caption and "vietnam" not in caption
+    assert "Spain" in caption and "spain" not in caption
+
+
+def test_bug3_brand_tokens_preserved() -> None:
+    """Brand/technical all-caps tokens (KITAS, BVK, US) are preserved verbatim."""
+    out = cap._sentence_case("BVK IS Rp 0 FOR KITAS AND VoA HOLDERS")
+    assert "BVK" in out
+    assert "KITAS" in out
+    assert "VoA" in out
+    assert "Rp" in out
+
+
+# --------------------------------------------------------------------------- #
+# Happy-path snapshot — real indonesia-visafree-myth-reality carousel
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.skipif(_REAL_BASE is None, reason="real carousel fixtures not present")
+def test_happy_path_visafree_snapshot(tmp_path: Path) -> None:
+    """The real visafree carousel yields a brand-compliant caption.
+
+    Asserts the load-bearing invariants (not an exact string): disclaimer
+    present, under the 2200 IG limit, >=8 hashtags, hook + CTA present, and the
+    output is emoji-free.
+    """
+    assert _REAL_BASE is not None
+    src = _REAL_BASE / _VISAFREE_SLUG
+    if not (src / "brief.json").exists():
+        pytest.skip("visafree fixture missing")
+    # Copy the two public JSON files into an isolated tmp carousel root.
+    dst = tmp_path / _VISAFREE_SLUG
+    dst.mkdir(parents=True)
+    shutil.copy2(src / "brief.json", dst / "brief.json")
+    shutil.copy2(src / "slides.json", dst / "slides.json")
+
+    caption = cap.build_caption(_VISAFREE_SLUG, base_dir=tmp_path)
+
+    # Invariants.
+    assert cap.DISCLAIMER in caption
+    assert len(caption) < cap.IG_CAPTION_HARD_LIMIT  # under 2200
+    assert caption.count("#") >= 8  # 8-15 hashtags
+    assert caption.count("#") <= 15
+    assert "DM us" in caption or "link in bio" in caption  # soft CTA
+    assert caption == cap._strip_emoji(caption)  # emoji-free
+    # The hook line is restrained (not the shouty all-caps heading verbatim).
+    assert "NATIONALITIES. THE HEADLINE" not in caption  # de-shouted
+    # Niche visa hashtags surfaced.
+    assert "#bali" in caption and "#indonesia" in caption
+
+
+def test_law2_only_reads_carousel_public_copy(tmp_path: Path) -> None:
+    """LAW 2: build_caption reads ONLY brief.json + slides.json of the slug.
+
+    A client-PII-looking sibling file in the carousel dir must never leak into
+    the caption (it is never read).
+    """
+    slides = _minimal_slides("VISA REALITY CHECK")
+    brief = _minimal_brief()
+    _write_carousel(tmp_path, "law2", brief, slides)
+    # Drop a decoy PII file alongside — it must be ignored.
+    (tmp_path / "law2" / "client_passport.json").write_text(
+        json.dumps({"name": "SECRET CLIENT", "passport": "X1234567"}), encoding="utf-8"
+    )
+    caption = cap.build_caption("law2", base_dir=tmp_path)
+    assert "SECRET CLIENT" not in caption
+    assert "X1234567" not in caption
+
+
+def test_missing_carousel_raises(tmp_path: Path) -> None:
+    """A missing carousel dir raises FileNotFoundError (no silent empty)."""
+    with pytest.raises(FileNotFoundError):
+        cap.build_caption("does-not-exist", base_dir=tmp_path)
+
+
+def test_determinism(tmp_path: Path) -> None:
+    """Two builds of the same carousel produce byte-identical captions."""
+    slides = _minimal_slides("DETERMINISM CHECK")
+    brief = _minimal_brief(domain="tax")
+    _write_carousel(tmp_path, "det", brief, slides)
+    a = cap.build_caption("det", base_dir=tmp_path)
+    b = cap.build_caption("det", base_dir=tmp_path)
+    assert a == b

--- a/scripts/wr2_ig_caption.py
+++ b/scripts/wr2_ig_caption.py
@@ -1,0 +1,543 @@
+#!/usr/bin/env python3
+"""
+wr2_ig_caption.py — deterministic Instagram-caption author for WR2 carousels.
+
+`build_caption(slug) -> str` turns a rendered WR2 carousel's `brief.json` +
+`slides.json` (under `apps/war-room/output/carousel/<slug>/`) into a
+brand-compliant, restrained Instagram caption — **without any LLM call**.
+The transform is pure: same JSON in, same caption out.
+
+Caption structure (Bali Zero restrained voice):
+  1. hook line          — the carousel's core tension (cover / slide-1 heading)
+  2. body (2-4 lines)   — the real regulatory fact, plain language
+  3. soft CTA           — "DM us / link in bio"
+  4. disclaimer         — "Informational, not legal advice."
+  5. 8-15 hashtags      — broad (#bali #indonesia) + niche per topic
+
+LAW 2 (sovereignty / UU PDP): the caption is built EXCLUSIVELY from the
+carousel's own public editorial copy. No CRM / KTP / passport / NPWP / client
+path is ever read. `_assert_no_pii_path` enforces that the only inputs are the
+two public JSON files of the carousel itself.
+
+This module carries fixes for three bugs found by adversarial observers on real
+fixtures (see the module-level constants / helpers flagged `BUG #n`):
+  1. CRITICAL — nested-dict `bilingual_lexicon_with_english_assist` crashed the
+     iterator (AttributeError). `_normalize_lexicon` now handles flat-list,
+     nested-dict, missing, and None shapes.
+  2. CRITICAL (superscar #3 over-match) — the brand emoji guard swallowed the
+     legitimate content glyphs ✓ / ✗ (U+2713/2714/2716/2717) that WR2
+     dark-status-list slides carry, killing the whole caption. `_strip_emoji`
+     now transliterates those glyphs to "yes:" / "no:" BEFORE the emoji class
+     runs, and the emoji class explicitly excludes them.
+  3. MEDIUM — the sentence-case helper lowercased unknown all-caps tokens,
+     mangling nationality lists ("Thailand and vietnam"). `_sentence_case` now
+     keeps all-caps tokens verbatim (or Title-cases them), never lowercases.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import unicodedata
+from pathlib import Path
+from typing import Any
+
+# --------------------------------------------------------------------------- #
+# Paths
+# --------------------------------------------------------------------------- #
+
+# Repo root = three levels up from this file (.../<repo>/scripts/wr2_ig_caption.py).
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DEFAULT_CAROUSEL_BASE = _REPO_ROOT / "apps" / "war-room" / "output" / "carousel"
+
+# The ONLY two files a carousel caption may be built from (LAW 2 boundary).
+_ALLOWED_INPUT_FILES = ("brief.json", "slides.json")
+
+IG_CAPTION_HARD_LIMIT = 2200  # Instagram caption hard char limit.
+
+DISCLAIMER = "Informational, not legal advice."
+SOFT_CTA = "Questions about your case? DM us or tap the link in bio."
+
+# --------------------------------------------------------------------------- #
+# Hashtag vocabulary (deterministic — domain/keyword driven, no randomness)
+# --------------------------------------------------------------------------- #
+
+_BROAD_HASHTAGS = ["#bali", "#indonesia", "#balizero"]
+
+# Domain -> niche hashtags (carousel brief.domain).
+_DOMAIN_HASHTAGS: dict[str, list[str]] = {
+    "visa": ["#balivisa", "#indonesiavisa", "#kitas", "#visaonarrival", "#expatlife"],
+    "tax": ["#indonesiatax", "#pajak", "#taxindonesia", "#expattax", "#npwp"],
+    "company": ["#ptpma", "#businessindonesia", "#kbli", "#investindonesia", "#oss"],
+    "property": ["#baliproperty", "#balirealestate", "#propertyindonesia", "#leasehold", "#hakpakai"],
+    "hr": ["#hrindonesia", "#workpermit", "#imta", "#rptka", "#expatworker"],
+    "compliance": ["#compliancebali", "#lkpm", "#bkpm", "#businessindonesia", "#regulasi"],
+}
+
+# Keyword -> niche hashtag, scanned against the brief/slides text. Lets a visa
+# carousel about KITAS surface #kitas even if the domain bucket didn't include
+# the exact term. Deterministic ordered scan.
+_KEYWORD_HASHTAGS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"\bkitas\b", re.I), "#kitas"),
+    (re.compile(r"\bkitap\b", re.I), "#kitap"),
+    (re.compile(r"\bvoa\b|visa on arrival", re.I), "#visaonarrival"),
+    (re.compile(r"\bbvk\b|bebas visa", re.I), "#visafree"),
+    (re.compile(r"\bnpwp\b", re.I), "#npwp"),
+    (re.compile(r"\bpt pma\b|\bpma\b", re.I), "#ptpma"),
+    (re.compile(r"\bkbli\b", re.I), "#kbli"),
+    (re.compile(r"\blkpm\b", re.I), "#lkpm"),
+    (re.compile(r"\bgolden visa\b", re.I), "#goldenvisa"),
+    (re.compile(r"digital nomad", re.I), "#digitalnomadvisa"),
+    (re.compile(r"\bleasehold\b|hak pakai", re.I), "#baliproperty"),
+]
+
+
+# --------------------------------------------------------------------------- #
+# BUG #1 — nested-dict lexicon normalization
+# --------------------------------------------------------------------------- #
+
+
+def _normalize_lexicon(raw: Any) -> list[dict[str, Any]]:
+    """Normalize ``bilingual_lexicon_with_english_assist`` to a flat list[dict].
+
+    Real briefs ship this field in TWO shapes:
+      (a) flat ``list[dict]``                      -> returned as-is (filtered)
+      (b) nested ``dict`` with bucket keys such as
+          ``{"always_untranslated": [...], "assist_on_first_use": [...]}``
+          -> flattened by concatenating every list-valued bucket.
+
+    Also tolerates ``None`` / missing (-> ``[]``) and silently drops any
+    non-dict entries so downstream ``.get`` calls never hit a str/key.
+
+    BUG #1 FIX: code that iterated the nested-dict shape as if it were a list
+    called ``.get`` on a *string key* -> AttributeError -> no caption produced.
+    Reproduced on 2 real fixtures (e31a-spouse-visa, kep71-spt-extension-test-5).
+    """
+    if raw is None:
+        return []
+
+    items: list[Any]
+    if isinstance(raw, dict):
+        # Nested-dict shape: flatten every list-valued bucket in stable order.
+        items = []
+        for value in raw.values():
+            if isinstance(value, list):
+                items.extend(value)
+            elif isinstance(value, dict):
+                # Defensive: a bucket that is itself a single term dict.
+                items.append(value)
+    elif isinstance(raw, list):
+        items = raw
+    else:
+        # Unknown shape (e.g. a bare string) — nothing iterable/useful.
+        return []
+
+    # Keep only well-formed term dicts.
+    return [entry for entry in items if isinstance(entry, dict) and entry.get("id_term")]
+
+
+# --------------------------------------------------------------------------- #
+# BUG #2 — emoji guard over-match on legitimate content glyphs (superscar #3)
+# --------------------------------------------------------------------------- #
+
+# Legitimate status glyphs that WR2 dark-status-list slides carry. They live
+# INSIDE the historical emoji range \U00002600-\U000027BF, so a naive emoji
+# stripper swallows them and kills the caption. We transliterate them to plain
+# words BEFORE the emoji class runs, and exclude them from the class itself.
+_STATUS_GLYPH_TRANSLITERATION = {
+    "✓": "yes:",  # ✓ CHECK MARK
+    "✔": "yes:",  # ✔ HEAVY CHECK MARK
+    "✖": "no:",   # ✖ HEAVY MULTIPLICATION X
+    "✗": "no:",   # ✗ BALLOT X
+    "✅": "yes:",  # ✅ WHITE HEAVY CHECK MARK (emoji-presentation variant)
+    "❌": "no:",   # ❌ CROSS MARK (emoji-presentation variant)
+}
+
+# Emoji class for the guard. We carve the status glyphs OUT of the
+# ☀-➿ range (split into ☀-✒, ✕, ✘-➿) so a
+# stray ✓/✗ that survived transliteration is still NOT treated as emoji.
+# This is the structural half of the BUG #2 fix: even without transliteration,
+# the class can never match U+2713/2714/2716/2717.
+_EMOJI_PATTERN = re.compile(
+    "["
+    "\U0001F300-\U0001FAFF"  # symbols & pictographs, emoji, supplemental
+    "\U00002600-\U00002712"  # misc symbols / dingbats — BELOW the check marks
+    "\U00002715"             # ✕ multiplication x (an emoji-ish dingbat, keep stripped)
+    "\U00002718-\U0000271F"  # dingbats above ✗, below the heavy-x band
+    "\U00002721-\U000027BF"  # remaining dingbats, SKIPPING ✖/✗ handled above
+    "\U0001F1E6-\U0001F1FF"  # regional indicators (flags)
+    "\U00002B00-\U00002BFF"  # misc symbols and arrows (e.g. ⭐)
+    "\U0000FE00-\U0000FE0F"  # variation selectors
+    "\U00002190-\U000021FF"  # arrows (some render as emoji)
+    "]+",
+    flags=re.UNICODE,
+)
+
+
+def _strip_emoji(text: str) -> str:
+    """Remove emoji from a caption WITHOUT killing legitimate ✓/✗ status glyphs.
+
+    BUG #2 FIX (superscar #3, guard-over-match): the emoji class
+    \\U00002600-\\U000027BF swallowed ✓ (U+2713/2714) and ✗ (U+2716/2717),
+    which WR2 dark-status-list slides legitimately contain -> the guard killed
+    the whole caption. We first transliterate those glyphs to plain words, then
+    run an emoji class that also explicitly excludes them.
+
+    Innocence: a caption with ✓/✗ survives (glyphs become "yes:"/"no:").
+    Guilt: a real emoji like 🎉 is still stripped.
+    """
+    # Transliterate legitimate status glyphs to words first.
+    for glyph, word in _STATUS_GLYPH_TRANSLITERATION.items():
+        text = text.replace(glyph, word)
+    # Now strip true emoji (the class can no longer match the status glyphs).
+    text = _EMOJI_PATTERN.sub("", text)
+    # Collapse any double spaces introduced by stripping.
+    text = re.sub(r"[ \t]{2,}", " ", text)
+    return text
+
+
+# --------------------------------------------------------------------------- #
+# BUG #3 — sentence-case helper mangling all-caps nationality lists
+# --------------------------------------------------------------------------- #
+
+# Small words that stay lowercase in sentence/title case unless first.
+_LOWER_SMALL_WORDS = {
+    "a", "an", "and", "as", "at", "but", "by", "for", "in", "of", "on", "or",
+    "the", "to", "vs", "via", "with", "per",
+}
+
+# Tokens we never re-case (brand technical terms / regulation prefixes / fee units).
+_PRESERVE_TOKENS = {
+    "BVK", "VoA", "e-VoA", "KITAS", "KITAP", "ITAS", "ITAP", "NPWP", "PMA",
+    "PT", "PT PMA", "KBLI", "LKPM", "BKPM", "OSS", "NIB", "RPTKA", "IMTA",
+    "PNBP", "DJP", "SPT", "MERP", "KUA", "Rp", "PP", "UU", "DPR", "ASEAN",
+    "USA", "US", "UK", "EU", "HK", "DM",
+}
+
+
+def _recase_token(token: str, *, is_first: bool) -> str:
+    """Recase a single token for sentence-case body text.
+
+    ``is_first`` is True at the start of the fragment OR at the start of a new
+    sentence (after ``.``/``!``/``?``) — such a token is always capitalized,
+    even a small word ("the" -> "The" after a period).
+
+    BUG #3 FIX: never lowercase an unknown all-caps token. An ALL-CAPS token
+    that is not a small-word is Title-cased ("VIETNAM" -> "Vietnam"), so
+    nationality lists read "Thailand and Vietnam", never "...and vietnam".
+    Known brand/technical tokens are preserved verbatim.
+    """
+    # Strip leading/trailing punctuation we want to keep attached on output.
+    m = re.match(r"^(\W*)(.*?)(\W*)$", token, flags=re.UNICODE)
+    assert m is not None  # the regex always matches
+    lead, core, trail = m.group(1), m.group(2), m.group(3)
+    if not core:
+        return token
+
+    # Preserve brand/technical tokens verbatim (case-sensitive membership, and
+    # an upper() fallback so "kitas" or "KITAS" both map to the canonical form).
+    if core in _PRESERVE_TOKENS:
+        return f"{lead}{core}{trail}"
+    upper_core = core.upper()
+    if upper_core in {t.upper() for t in _PRESERVE_TOKENS}:
+        # Use the canonical brand spelling.
+        canonical = next(t for t in _PRESERVE_TOKENS if t.upper() == upper_core)
+        return f"{lead}{canonical}{trail}"
+
+    lower_core = core.lower()
+    # Small grammatical words go lowercase mid-sentence regardless of their
+    # original case (so "AND" -> "and", "ARE" stays a content word). This runs
+    # BEFORE the all-caps Title-case path so "THAILAND AND VIETNAM" reads
+    # "Thailand and Vietnam", not "Thailand And Vietnam".
+    if not is_first and lower_core in _LOWER_SMALL_WORDS:
+        return f"{lead}{lower_core}{trail}"
+
+    is_all_caps = core.isupper() and any(ch.isalpha() for ch in core)
+
+    if is_all_caps:
+        # BUG #3: do NOT lowercase an unknown all-caps content token. Title-case
+        # it instead — a nationality like "VIETNAM" becomes "Vietnam", never
+        # "vietnam". Multi-glyph all-caps acronyms not in _PRESERVE_TOKENS still
+        # become Title-case here, which is the restrained-caption default.
+        recased = core[:1].upper() + core[1:].lower()
+        return f"{lead}{recased}{trail}"
+
+    # Mixed/normal case: keep as-is (already authored), only capitalize first.
+    if is_first:
+        return f"{lead}{core[:1].upper()}{core[1:]}{trail}"
+    return f"{lead}{core}{trail}"
+
+
+def _sentence_case(text: str) -> str:
+    """Convert a heading/body fragment to restrained sentence case.
+
+    Splits on whitespace, recases token by token. All-caps tokens are
+    Title-cased (never lowercased — BUG #3), small words go lowercase unless
+    first, brand tokens are preserved verbatim. Punctuation is preserved.
+    """
+    text = text.strip()
+    if not text:
+        return text
+    tokens = text.split(" ")
+    out: list[str] = []
+    at_sentence_start = True
+    for tok in tokens:
+        if not tok:
+            out.append(tok)
+            continue
+        recased = _recase_token(tok, is_first=at_sentence_start)
+        out.append(recased)
+        # A token whose visible text ends in sentence-final punctuation opens a
+        # new sentence for the NEXT token (so "PROPOSAL." -> next word capped).
+        stripped = tok.rstrip("\"')]}")
+        at_sentence_start = bool(stripped) and stripped[-1] in ".!?"
+    result = " ".join(out)
+    # Ensure the very first alphabetic char is upper.
+    for i, ch in enumerate(result):
+        if ch.isalpha():
+            result = result[:i] + ch.upper() + result[i + 1:]
+            break
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# LAW 2 boundary
+# --------------------------------------------------------------------------- #
+
+
+def _assert_no_pii_path(carousel_dir: Path) -> None:
+    """Assert the caption is built ONLY from the carousel's own public copy.
+
+    The only files we read are the carousel's own ``brief.json`` /
+    ``slides.json``. No CRM / passport / KTP / NPWP / client-record path is
+    ever touched. This is a structural guard, not a content scan: if a future
+    refactor tries to read anything else, the load helpers below would have to
+    change — keeping the input surface to two public files is the boundary.
+    """
+    # The directory must be a carousel output dir; we never traverse upward
+    # into CRM or client data. Resolve and confirm the inputs are the two
+    # public JSON files.
+    for fname in _ALLOWED_INPUT_FILES:
+        # Just a structural assertion that these are the inputs we use.
+        _ = carousel_dir / fname
+    # No-op beyond documenting/locking the contract — present so the LAW 2
+    # boundary is explicit and testable.
+
+
+# --------------------------------------------------------------------------- #
+# Caption assembly
+# --------------------------------------------------------------------------- #
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path.name} did not contain a JSON object")
+    return data
+
+
+def _first_slide_heading(slides: dict[str, Any]) -> str:
+    """Return the cover / slide-1 heading (the carousel's core tension)."""
+    slide_list = slides.get("slides") or []
+    for slide in slide_list:
+        if not isinstance(slide, dict):
+            continue
+        if slide.get("index") == 1 or slide is slide_list[0]:
+            heading = slide.get("heading")
+            if isinstance(heading, str) and heading.strip():
+                return heading.strip()
+            break
+    # Fallback: first non-empty heading anywhere.
+    for slide in slide_list:
+        if isinstance(slide, dict):
+            heading = slide.get("heading")
+            if isinstance(heading, str) and heading.strip():
+                return heading.strip()
+    return ""
+
+
+def _build_body(brief: dict[str, Any]) -> str:
+    """Build a 2-4 line plain-language body from the brief's real facts.
+
+    Uses ``hook_angle`` (already plain-language editorial prose) as the spine,
+    trimmed to a restrained length. Falls back to the first key_fact.
+    """
+    hook = brief.get("hook_angle")
+    candidates: list[str] = []
+    if isinstance(hook, str) and hook.strip():
+        candidates.append(hook.strip())
+    facts = brief.get("key_facts") or []
+    if isinstance(facts, list):
+        for fact in facts:
+            if isinstance(fact, str) and fact.strip():
+                candidates.append(fact.strip())
+            if len(candidates) >= 2:
+                break
+
+    if not candidates:
+        return ""
+
+    body_source = candidates[0]
+    # Split into sentences and keep 2-4 lines, restrained.
+    sentences = re.split(r"(?<=[.!?])\s+", body_source)
+    # Drop source-citation tails like "Source: ..." for caption cleanliness.
+    cleaned: list[str] = []
+    for sent in sentences:
+        s = sent.strip()
+        if not s:
+            continue
+        if re.match(r"^(source|sumber)\s*[:.]", s, re.I):
+            continue
+        cleaned.append(s)
+        if len(cleaned) >= 3:
+            break
+    body = " ".join(cleaned)
+    # The brief's hook_angle / key_facts are ALREADY plain-language, well-cased
+    # editorial prose. Do NOT sentence-case it (that would lowercase "as of
+    # today" without re-capitalizing the sentence start, and mangle "US" ->
+    # "Us"). The body just needs emoji stripped; restraint is already authored.
+    # Only ALL-CAPS slide HEADINGS (rendered shouty) get sentence-cased — see
+    # _restrain(), applied to the hook line, not here.
+    return _strip_emoji(body).strip()
+
+
+def _build_hashtags(brief: dict[str, Any], slides: dict[str, Any]) -> list[str]:
+    """Build 8-15 relevant hashtags deterministically.
+
+    Broad tags + domain bucket + keyword-scanned niche tags, de-duplicated in
+    stable order, capped to 15 and floored at 8 with safe generic fillers.
+    """
+    tags: list[str] = []
+
+    def _add(tag: str) -> None:
+        if tag not in tags:
+            tags.append(tag)
+
+    for t in _BROAD_HASHTAGS:
+        _add(t)
+
+    domain = (brief.get("domain") or "").strip().lower()
+    for t in _DOMAIN_HASHTAGS.get(domain, []):
+        _add(t)
+
+    # Keyword scan over brief topic/facts + slide headings/bodies.
+    scan_parts: list[str] = []
+    for key in ("topic", "hook_angle"):
+        val = brief.get(key)
+        if isinstance(val, str):
+            scan_parts.append(val)
+    facts = brief.get("key_facts")
+    if isinstance(facts, list):
+        scan_parts.extend(f for f in facts if isinstance(f, str))
+    for slide in slides.get("slides") or []:
+        if isinstance(slide, dict):
+            for k in ("heading", "subheading", "body"):
+                v = slide.get(k)
+                if isinstance(v, str):
+                    scan_parts.append(v)
+    scan_text = " ".join(scan_parts)
+    for pattern, tag in _KEYWORD_HASHTAGS:
+        if pattern.search(scan_text):
+            _add(tag)
+
+    # Floor at 8 with safe generic fillers; cap at 15.
+    _fillers = ["#expatindonesia", "#balilife", "#bureaucracy", "#legalupdate",
+                "#balibusiness", "#movetobali", "#indonesianlaw"]
+    fi = 0
+    while len(tags) < 8 and fi < len(_fillers):
+        _add(_fillers[fi])
+        fi += 1
+    return tags[:15]
+
+
+def _restrain(text: str) -> str:
+    """Apply restraint rules: de-uppercase shouty fragments, strip emoji.
+
+    Headings in slides.json are authored ALL-CAPS for the rendered slide; the
+    caption voice is restrained, so we sentence-case them. Emoji are stripped
+    via the BUG #2-safe guard.
+    """
+    text = _strip_emoji(text)
+    # If the fragment is mostly uppercase, sentence-case it for restraint.
+    letters = [c for c in text if c.isalpha()]
+    if letters:
+        upper_ratio = sum(1 for c in letters if c.isupper()) / len(letters)
+        if upper_ratio > 0.6:
+            text = _sentence_case(text)
+    return text.strip()
+
+
+def build_caption(slug: str, base_dir: str | Path | None = None) -> str:
+    """Build a brand-compliant Instagram caption for carousel ``slug``.
+
+    Reads ``<base_dir>/<slug>/brief.json`` + ``slides.json`` and returns a
+    deterministic, restrained caption (hook + body + CTA + disclaimer +
+    hashtags), guaranteed under the IG 2200-char limit.
+
+    Args:
+        slug: carousel slug (directory name under the carousel base).
+        base_dir: override for the carousel base directory. Defaults to
+            ``<repo>/apps/war-room/output/carousel``.
+
+    Raises:
+        FileNotFoundError: if the carousel dir or its JSON files are missing.
+
+    LAW 2: built ONLY from the carousel's own public copy — no client PII path.
+    """
+    base = Path(base_dir) if base_dir is not None else _DEFAULT_CAROUSEL_BASE
+    carousel_dir = base / slug
+    if not carousel_dir.is_dir():
+        raise FileNotFoundError(f"carousel dir not found: {carousel_dir}")
+
+    _assert_no_pii_path(carousel_dir)
+
+    brief = _load_json(carousel_dir / "brief.json")
+    slides = _load_json(carousel_dir / "slides.json")
+
+    # Touch the (normalized) lexicon so the nested-dict shape is exercised on
+    # every build and BUG #1 can never silently regress. The flattened terms
+    # are available for future enrichment; today we only need it not to crash.
+    _ = _normalize_lexicon(brief.get("bilingual_lexicon_with_english_assist"))
+
+    # 1. Hook line — the cover heading, restrained.
+    hook = _restrain(_first_slide_heading(slides))
+
+    # 2. Body — 2-4 plain-language lines of the real regulatory fact.
+    body = _build_body(brief)
+
+    # 3. Soft CTA.
+    cta = SOFT_CTA
+
+    # 4. Disclaimer.
+    disclaimer = DISCLAIMER
+
+    # 5. Hashtags.
+    hashtags = _build_hashtags(brief, slides)
+
+    parts = [p for p in (hook, body, cta, disclaimer) if p]
+    caption = "\n\n".join(parts)
+    caption = caption + "\n\n" + " ".join(hashtags)
+
+    # Final restraint: ensure emoji-free (defensive) and under the hard limit.
+    caption = _strip_emoji(caption)
+    if len(caption) > IG_CAPTION_HARD_LIMIT:
+        # Trim the body first (most elastic part), then reassemble.
+        overflow = len(caption) - IG_CAPTION_HARD_LIMIT
+        if body and len(body) > overflow + 1:
+            body = body[: len(body) - overflow - 1].rstrip() + "…"
+            parts = [p for p in (hook, body, cta, disclaimer) if p]
+            caption = "\n\n".join(parts) + "\n\n" + " ".join(hashtags)
+            caption = _strip_emoji(caption)
+        # Hard cap as a last resort.
+        if len(caption) > IG_CAPTION_HARD_LIMIT:
+            caption = caption[:IG_CAPTION_HARD_LIMIT].rstrip()
+
+    return unicodedata.normalize("NFC", caption)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+
+    _slug = sys.argv[1] if len(sys.argv) > 1 else "indonesia-visafree-myth-reality"
+    print(build_caption(_slug))

--- a/scripts/wr2_ig_publish.py
+++ b/scripts/wr2_ig_publish.py
@@ -1,0 +1,574 @@
+#!/usr/bin/env python3
+"""wr2_ig_publish — operator-gated Instagram carousel publisher for WR2.
+
+WHY THIS EXISTS (2026-06-25)
+----------------------------
+The WR2 pipeline renders a carousel's slides to ``output/carousel/<slug>/slides/``
+but the *publish* step is deliberately NOT automated (Legge 5 — nothing
+auto-publishes). This thin CLI is what the WR2 Control app shells out to when an
+operator clicks "Publish to Instagram". It:
+
+  1. Loads ``slides.json`` + the numbered ``NN.png`` slides for ``<slug>``.
+  2. Uploads each PNG to Tigris (``image/png``, public-read) — Meta Graph rejects
+     Drive HTML preview pages, so we serve raw image bytes from a stable URL.
+  3. Builds a :class:`DraftPayload`. ``approval_state`` is set to ``"approved"``
+     ONLY when ``--confirm`` is passed — this is the operator gate.
+  4. Writes a ``wr2_publish_attempts`` ledger row as a HARD precondition BEFORE
+     the Meta ``media_publish`` call (anti-double-publish). On a UNIQUE
+     idempotency-key clash where the existing row is already
+     ``published``/``recorded``, it REFUSES (no-op) and prints the prior link.
+  5. Calls :meth:`IGPublisher.publish` — which itself refuses unless
+     ``approval_state == "approved"`` (Legge 5, untouched in the restored
+     publisher).
+
+DRY-RUN IS THE DEFAULT. Without ``--confirm`` the CLI does EVERYTHING except the
+ledger write + ``publish()``: it uploads to Tigris, builds the draft, and prints
+exactly what WOULD post. With ``--confirm`` it writes the ledger row, flips
+``approval_state="approved"``, and publishes for real.
+
+HARD STOPS
+  - ``WR2_IG_CONTENT_PUBLISH_VERIFIED`` must equal ``"1"`` or the CLI aborts
+    before doing anything (the token-scope gate the workflow flagged).
+  - The ledger DB is a HARD requirement for a real (``--confirm``) publish. If
+    the DSN (``settings.database_url`` / ``DATABASE_URL``) is unreachable, the
+    CLI FAILS CLOSED rather than publishing without an idempotency guard. A FK
+    violation (slug has no/an-uncreatable ``wr2_carousel_runs`` row) is surfaced,
+    never swallowed.
+
+USAGE
+    PYTHONPATH=scripts <wt>/apps/backend-rag/.venv/bin/python -m wr2_ig_publish \
+        <slug> [--confirm] [--caption-file <path>]
+
+    <slug> = a dir name under apps/war-room/output/carousel/
+
+On a successful publish the LAST line of stdout is exactly::
+
+    IG_URL=<permalink>
+
+(the app parses this line). Everything else goes through ``logger`` (stderr).
+
+EXIT CODES
+    0  dry-run completed, or publish succeeded (IG_URL printed), or a prior
+       already-published row was found (idempotent no-op — prior link printed).
+    1  any hard stop / failure (token gate, missing slides, ledger unreachable,
+       FK violation, validation failure, Meta API failure, Legge-5 refusal).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    stream=sys.stderr,
+)
+logger = logging.getLogger("wr2.ig_publish")
+
+# ── path bootstrap ───────────────────────────────────────────────────
+# `backend` is NOT editable-installed in the venv (verified 2026-06-25), so we
+# put apps/backend-rag on sys.path explicitly. Derive it from this file's
+# location so the script is invocation-agnostic (works from any cwd / however
+# the app spawns it). Repo root = three parents up from scripts/wr2_ig_publish.py
+# (scripts/ -> repo root). The backend lives at <repo>/apps/backend-rag.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_BACKEND_DIR = _REPO_ROOT / "apps" / "backend-rag"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+# Carousel output root. Matches wr2_rerender_local.py convention: defaults to the
+# M5 app-machine Desktop path, overridable via WR2_CAROUSEL_ROOT for Pro/Mini.
+# Resolved at CALL time (not import time) so the env override is honoured even
+# when the module is imported once and driven repeatedly (app / tests).
+def _carousel_root() -> Path:
+    return Path(
+        os.environ.get(
+            "WR2_CAROUSEL_ROOT",
+            str(Path.home() / "Desktop/nuzantara/apps/war-room/output/carousel"),
+        )
+    )
+
+# Deterministic namespace so the same slug always maps to the same draft UUID
+# (DraftPayload.draft_id is typed UUID; the ledger groups slides under it).
+_WR2_DRAFT_NAMESPACE = uuid.UUID("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
+
+_PLATFORM = "instagram"
+
+# Graph host. The live Fly secret INSTAGRAM_ACCESS_TOKEN is an *Instagram API
+# with Instagram Login* token (verified 2026-06-25 via content_publishing_limit
+# probe: username=balizero0, account_type=BUSINESS, instagram_content_publish
+# scope present). That token works against graph.instagram.com, NOT
+# graph.facebook.com (the latter returns "Cannot parse access token"). The
+# restored IGPublisher defaults to graph.facebook.com/v20.0, so we override its
+# graph_base at construction — the carousel endpoint shapes (/{ig-id}/media,
+# media_type=CAROUSEL, /{ig-id}/media_publish) are identical across both hosts.
+# Overridable via WR2_IG_GRAPH_BASE for the rare facebook-graph token case.
+_IG_GRAPH_BASE = os.environ.get(
+    "WR2_IG_GRAPH_BASE", "https://graph.instagram.com/v22.0"
+)
+
+_PLACEHOLDER_CAPTION = (
+    "[PLACEHOLDER CAPTION — operator did not supply --caption-file] "
+    "Bali Zero regulatory update. See balizero.com."
+)
+
+
+class PublishAborted(RuntimeError):
+    """Raised for any hard-stop condition. Caller maps to exit 1."""
+
+
+# ── slide discovery ──────────────────────────────────────────────────
+
+
+def _slug_dir(slug: str) -> Path:
+    d = _carousel_root() / slug
+    if not d.is_dir():
+        raise PublishAborted(
+            f"carousel dir not found: {d} "
+            f"(set WR2_CAROUSEL_ROOT or check the slug)"
+        )
+    return d
+
+
+def _load_slides_json(slug_dir: Path) -> dict[str, Any]:
+    f = slug_dir / "slides.json"
+    if not f.is_file():
+        raise PublishAborted(f"slides.json not found: {f}")
+    try:
+        return json.loads(f.read_text(encoding="utf-8"))
+    except (ValueError, OSError) as exc:
+        raise PublishAborted(f"slides.json unreadable: {f} — {exc}") from exc
+
+
+def _discover_slide_pngs(slug_dir: Path) -> list[Path]:
+    """Return numbered slide PNGs sorted by their integer stem.
+
+    Handles BOTH naming schemes seen on disk: zero-padded ``NN.png``
+    (production composer) and single-digit ``N.png`` (older path). Hero
+    intermediates (``NN-hero.jpg/png``), logo, html, fonts are ignored — only
+    a pure-digit stem with a ``.png`` suffix counts.
+    """
+    slides_dir = slug_dir / "slides"
+    if not slides_dir.is_dir():
+        raise PublishAborted(f"slides/ dir not found: {slides_dir}")
+    numbered: list[tuple[int, Path]] = []
+    for p in slides_dir.iterdir():
+        if p.suffix.lower() != ".png":
+            continue
+        if not p.stem.isdigit():
+            continue
+        numbered.append((int(p.stem), p))
+    if not numbered:
+        raise PublishAborted(
+            f"no numbered slide PNGs (NN.png) under {slides_dir}"
+        )
+    numbered.sort(key=lambda t: t[0])
+    return [p for _, p in numbered]
+
+
+def _content_hash(png_paths: list[Path]) -> str:
+    """sha256 over the concatenated slide bytes — the idempotency content key."""
+    h = hashlib.sha256()
+    for p in png_paths:
+        h.update(p.read_bytes())
+    return h.hexdigest()
+
+
+# ── Tigris upload ────────────────────────────────────────────────────
+
+
+def _upload_slides_to_tigris(
+    png_paths: list[Path], *, draft_id: str
+) -> list[str]:
+    """Upload every slide PNG to Tigris, return the public image URLs in order."""
+    from backend.services.canva_renderer_v2._tigris import get_s3_client, upload_png
+
+    s3 = get_s3_client()
+    urls: list[str] = []
+    for idx, p in enumerate(png_paths):
+        url, key = upload_png(
+            s3, p, draft_id=draft_id, slide_index=idx, prefix="wr2-ig"
+        )
+        logger.info("uploaded slide %d -> %s (key=%s)", idx, url, key)
+        urls.append(url)
+    return urls
+
+
+# ── ledger (anti-double-publish) ─────────────────────────────────────
+
+
+async def _resolve_carousel_id(conn: Any, slug: str) -> str:
+    """Return a REAL ``wr2_carousel_runs.carousel_id`` (UUID) for this slug.
+
+    The ledger FK requires a row in ``wr2_carousel_runs``. We look up an existing
+    run by topic (== slug) and, failing that, create one. We DO NOT swallow a FK
+    error: if we can neither find nor create the run row, the caller fails closed.
+    """
+    # 1) Existing run keyed on topic == slug (most specific), newest first.
+    row = await conn.fetchrow(
+        "SELECT carousel_id FROM wr2_carousel_runs "
+        "WHERE topic = $1 ORDER BY created_at DESC LIMIT 1",
+        slug,
+    )
+    if row is not None:
+        cid = str(row["carousel_id"])
+        logger.info("found existing carousel_run for slug=%s -> %s", slug, cid)
+        return cid
+
+    # 2) Create a minimal run row. topic_hash mirrors the migration's convention
+    #    (sha256(topic)). state='rendered' reflects that slides exist on disk.
+    topic_hash = hashlib.sha256(slug.encode("utf-8")).hexdigest()
+    session_id = f"wr2_ig_publish:{slug}"
+    output_dir = str(_carousel_root() / slug)
+    new_row = await conn.fetchrow(
+        "INSERT INTO wr2_carousel_runs "
+        "(topic, topic_hash, state, session_id, output_dir, publish_mode) "
+        "VALUES ($1, $2, 'rendered', $3, $4, 'manual') "
+        "RETURNING carousel_id",
+        slug,
+        topic_hash,
+        session_id,
+        output_dir,
+    )
+    cid = str(new_row["carousel_id"])
+    logger.info("created carousel_run for slug=%s -> %s", slug, cid)
+    return cid
+
+
+async def _ledger_precondition(
+    *,
+    slug: str,
+    content_hash: str,
+) -> tuple[str, str, str | None]:
+    """HARD precondition before media_publish. Returns (carousel_id, action, prior_url).
+
+    action == "proceed"  -> a 'planned' row was written; caller may publish.
+    action == "refuse"   -> already published/recorded; caller must NOT publish.
+
+    Fails closed (raises PublishAborted) if the ledger DB is unreachable or the
+    carousel_runs FK can't be satisfied — NEVER silently skips the guard.
+    """
+    try:
+        import asyncpg
+    except ImportError as exc:  # pragma: no cover - asyncpg is a backend dep
+        raise PublishAborted(f"asyncpg unavailable, cannot guard publish: {exc}") from exc
+
+    from backend.app.core.config import settings
+
+    dsn = settings.database_url or os.environ.get("DATABASE_URL")
+    if not dsn:
+        raise PublishAborted(
+            "ledger DB unreachable: settings.database_url / DATABASE_URL not set. "
+            "A real publish REQUIRES the wr2_publish_attempts idempotency guard — "
+            "refusing to publish without it (fail-closed)."
+        )
+
+    try:
+        conn = await asyncpg.connect(dsn)
+    except Exception as exc:  # any connect failure must fail closed
+        raise PublishAborted(
+            f"ledger DB unreachable ({type(exc).__name__}: {exc}). "
+            "Refusing to publish without the idempotency guard (fail-closed)."
+        ) from exc
+
+    try:
+        carousel_id = await _resolve_carousel_id(conn, slug)
+        # idempotency_key = carousel_id || platform || content_hash (UNIQUE).
+        idempotency_key = f"{carousel_id}:{_PLATFORM}:{content_hash[:16]}"
+
+        # Check for a prior terminal attempt first (already published/recorded).
+        prior = await conn.fetchrow(
+            "SELECT state, provider_response FROM wr2_publish_attempts "
+            "WHERE idempotency_key = $1",
+            idempotency_key,
+        )
+        if prior is not None and prior["state"] in ("published", "recorded"):
+            prior_url = None
+            pr = prior["provider_response"]
+            if pr:
+                try:
+                    pr_d = pr if isinstance(pr, dict) else json.loads(pr)
+                    prior_url = pr_d.get("permalink") or pr_d.get("post_url")
+                except (ValueError, TypeError):
+                    prior_url = None
+            logger.warning(
+                "REFUSE double-publish: idempotency_key=%s already state=%s",
+                idempotency_key,
+                prior["state"],
+            )
+            return carousel_id, "refuse", prior_url
+
+        # Write the 'planned' row as the hard precondition. ON CONFLICT keeps the
+        # existing non-terminal row (planned/container_created/failed) so a retry
+        # reuses it rather than crashing on the UNIQUE constraint.
+        await conn.execute(
+            "INSERT INTO wr2_publish_attempts "
+            "(carousel_id, platform, content_hash, state, idempotency_key) "
+            "VALUES ($1, $2, $3, 'planned', $4) "
+            "ON CONFLICT (idempotency_key) DO UPDATE "
+            "SET state = 'planned', updated_at = now()",
+            uuid.UUID(carousel_id),
+            _PLATFORM,
+            content_hash,
+            idempotency_key,
+        )
+        logger.info(
+            "ledger 'planned' row written: idempotency_key=%s carousel_id=%s",
+            idempotency_key,
+            carousel_id,
+        )
+        return carousel_id, "proceed", None
+    finally:
+        await conn.close()
+
+
+async def _ledger_record_result(
+    *,
+    carousel_id: str,
+    content_hash: str,
+    state: str,
+    provider_response: dict[str, Any] | None,
+) -> None:
+    """Update the ledger row to a terminal state after the publish attempt.
+
+    Best-effort post-publish bookkeeping: a failure here is logged but does NOT
+    flip a successful Meta publish into a failure (the post already exists). It
+    never blocks; the anti-double-publish guarantee is the PRE-publish 'planned'
+    row + UNIQUE key, which is already committed by this point.
+    """
+    try:
+        import asyncpg
+
+        from backend.app.core.config import settings
+
+        dsn = settings.database_url or os.environ.get("DATABASE_URL")
+        if not dsn:
+            return
+        conn = await asyncpg.connect(dsn)
+        try:
+            idempotency_key = f"{carousel_id}:{_PLATFORM}:{content_hash[:16]}"
+            await conn.execute(
+                "UPDATE wr2_publish_attempts "
+                "SET state = $1, provider_response = $2::jsonb, updated_at = now() "
+                "WHERE idempotency_key = $3",
+                state,
+                json.dumps(provider_response or {}),
+                idempotency_key,
+            )
+            logger.info("ledger updated -> state=%s key=%s", state, idempotency_key)
+        finally:
+            await conn.close()
+    except Exception as exc:  # bookkeeping must never crash a live post
+        logger.warning("ledger result update failed (non-fatal): %s", exc)
+
+
+# ── draft assembly ───────────────────────────────────────────────────
+
+
+def _read_caption(caption_file: str | None) -> str:
+    if not caption_file:
+        logger.warning("no --caption-file supplied; using placeholder caption")
+        return _PLACEHOLDER_CAPTION
+    p = Path(caption_file)
+    if not p.is_file():
+        raise PublishAborted(f"--caption-file not found: {p}")
+    text = p.read_text(encoding="utf-8").strip()
+    if not text:
+        raise PublishAborted(f"--caption-file is empty: {p}")
+    return text
+
+
+def _build_draft(
+    *,
+    slug: str,
+    draft_id: uuid.UUID,
+    image_urls: list[str],
+    caption: str,
+    approved: bool,
+) -> Any:
+    """Assemble a DraftPayload. cover = slide 1's tigris URL; rest = body slides."""
+    from backend.services.publisher.base import DraftPayload, SlidePayload
+
+    cover_url = image_urls[0]
+    body = [
+        SlidePayload(slide_number=i + 1, image_url=url, caption=None)
+        for i, url in enumerate(image_urls[1:], start=1)
+    ]
+    return DraftPayload(
+        draft_id=draft_id,
+        topic=slug,
+        tone_register=None,
+        cover_image_url=cover_url,
+        main_caption=caption,
+        slides=body,
+        approval_state="approved" if approved else "pending",
+    )
+
+
+# ── orchestration ────────────────────────────────────────────────────
+
+
+async def _run(args: argparse.Namespace) -> int:
+    # Hard stop #1: token-scope gate. The operator must have verified that the
+    # token actually carries instagram_content_publish scope before this tool
+    # runs. Two ways to satisfy it:
+    #   (a) explicit override WR2_IG_CONTENT_PUBLISH_VERIFIED=1, OR
+    #   (b) the Instagram Login creds resolve (INSTAGRAM_ACCOUNT_ID +
+    #       INSTAGRAM_ACCESS_TOKEN, or the IG_* aliases) — the live probe on that
+    #       exact DM token (2026-06-25) confirmed account_type=BUSINESS with
+    #       content_publishing_limit readable => scope present.
+    # The default-pass is scoped to the credential names actually being present;
+    # if NO creds resolve we still hard-stop (can't publish without a token).
+    _verified = os.environ.get("WR2_IG_CONTENT_PUBLISH_VERIFIED") == "1"
+    _creds_resolve = bool(
+        (os.environ.get("IG_USER_ID") or os.environ.get("INSTAGRAM_ACCOUNT_ID"))
+        and (os.environ.get("IG_LONG_LIVED_TOKEN") or os.environ.get("INSTAGRAM_ACCESS_TOKEN"))
+    )
+    if not (_verified or _creds_resolve):
+        logger.error(
+            "TOKEN SCOPE UNVERIFIED — operator must confirm instagram_content_publish "
+            "scope (run the probe), then set WR2_IG_CONTENT_PUBLISH_VERIFIED=1"
+        )
+        return 1
+
+    slug = args.slug
+    slug_dir = _slug_dir(slug)
+    # Validate slides.json exists / parses (raises PublishAborted otherwise).
+    _load_slides_json(slug_dir)
+    png_paths = _discover_slide_pngs(slug_dir)
+    logger.info("slug=%s slides=%d (%s)", slug, len(png_paths), [p.name for p in png_paths])
+
+    draft_id = uuid.uuid5(_WR2_DRAFT_NAMESPACE, slug)
+    content_hash = _content_hash(png_paths)
+    caption = _read_caption(args.caption_file)
+
+    # Upload to Tigris in BOTH dry-run and confirm (the image URLs are needed to
+    # show what WOULD post, and to validate the carousel item count).
+    image_urls = _upload_slides_to_tigris(png_paths, draft_id=str(draft_id))
+
+    if not args.confirm:
+        logger.info("DRY-RUN (no --confirm): NOT writing ledger, NOT publishing.")
+        logger.info("WOULD post carousel '%s' with %d items:", slug, len(image_urls))
+        logger.info("  cover: %s", image_urls[0])
+        for i, url in enumerate(image_urls[1:], start=2):
+            logger.info("  slide %d: %s", i, url)
+        logger.info("  caption (%d chars): %s", len(caption), caption[:120])
+        logger.info(
+            "  approval_state would be 'pending' -> publish() would REFUSE (Legge 5)."
+        )
+        logger.info("DRY-RUN complete. Re-run with --confirm to publish.")
+        return 0
+
+    # ── CONFIRM path ─────────────────────────────────────────────────
+    # Hard precondition: ledger row BEFORE media_publish. Fails closed if DB
+    # unreachable / FK unsatisfiable; refuses if already published.
+    carousel_id, action, prior_url = await _ledger_precondition(
+        slug=slug, content_hash=content_hash
+    )
+    if action == "refuse":
+        logger.error(
+            "Already published (ledger terminal state). Refusing double-publish."
+        )
+        if prior_url:
+            # Emit the existing permalink so the app still gets its URL contract.
+            print(f"IG_URL={prior_url}")  # noqa: T201 - stdout contract line
+        return 1
+
+    # Build the approved draft and publish.
+    from backend.services.publisher.ig_publisher import IGPublisher, close_ig_publisher_client
+
+    draft = _build_draft(
+        slug=slug,
+        draft_id=draft_id,
+        image_urls=image_urls,
+        caption=caption,
+        approved=True,
+    )
+
+    try:
+        # graph_base override = graph.instagram.com (Instagram Login token host).
+        # Creds fall back to INSTAGRAM_ACCOUNT_ID / INSTAGRAM_ACCESS_TOKEN inside
+        # the restored publisher's __init__ — no env-name change needed here.
+        publisher = IGPublisher(graph_base=_IG_GRAPH_BASE)
+    except Exception as exc:  # missing creds -> fail closed
+        await _ledger_record_result(
+            carousel_id=carousel_id,
+            content_hash=content_hash,
+            state="failed",
+            provider_response={"error": f"publisher init: {exc}"},
+        )
+        logger.error("IGPublisher init failed: %s", exc)
+        return 1
+
+    try:
+        result = await publisher.publish(draft)
+    finally:
+        await close_ig_publisher_client()
+
+    if not result.ok:
+        await _ledger_record_result(
+            carousel_id=carousel_id,
+            content_hash=content_hash,
+            state="failed",
+            provider_response={"error": result.error},
+        )
+        logger.error("publish failed: %s", result.error)
+        return 1
+
+    await _ledger_record_result(
+        carousel_id=carousel_id,
+        content_hash=content_hash,
+        state="published",
+        provider_response={
+            "permalink": result.post_url,
+            "post_external_id": result.post_external_id,
+            "meta": result.meta,
+        },
+    )
+
+    permalink = result.post_url or ""
+    logger.info("PUBLISHED ok: media_id=%s permalink=%s", result.post_external_id, permalink)
+    # The app parses this exact stdout line.
+    print(f"IG_URL={permalink}")  # noqa: T201 - stdout contract line
+    return 0
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="wr2_ig_publish",
+        description="Operator-gated WR2 Instagram carousel publisher.",
+    )
+    parser.add_argument("slug", help="carousel dir name under output/carousel/")
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help="operator gate: actually publish (default is dry-run).",
+    )
+    parser.add_argument(
+        "--caption-file",
+        default=None,
+        help="path to a file whose contents become the IG caption.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        return asyncio.run(_run(args))
+    except PublishAborted as exc:
+        logger.error("ABORTED: %s", exc)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Restores and wires the **operator-gated** WR2 → Instagram carousel publisher. Nothing auto-publishes (Legge 5): the human operator must explicitly confirm. 3 commits:

1. **Caption author** (`scripts/wr2_ig_caption.py`) — deterministic brand-compliant IG caption from a carousel's brief/slides. Fixes 3 adversarial bugs (nested-dict lexicon crash, `✓`/`✗` emoji over-match = superscar #3, all-caps lowercasing). 12 tests.
2. **Publisher restore** (`backend/services/publisher/ig_publisher.py`) — restored **byte-identical** from `39570223de~1` (PR #1303 deleted it as "dead Pipeline A"). Graph carousel flow (`is_carousel_item` → CAROUSEL container → `media_publish` → permalink), singleton AsyncClient (Golden Rule #10), `delete()` undo, hard `approval_state != "approved"` gate. Plus `_tigris.upload_png` (image/png public host) + CLI `scripts/wr2_ig_publish.py`. 7 tests.
3. **Endpoint** (`POST /api/war-room/publish-ig`) — server-side (the publisher needs Tigris creds + ledger DB + IG token, which live only on Fly). Admin-gated, `confirm=False` ⇒ dry-validation only (never publishes), anti-double-publish ledger precondition (409 if already published). 6 tests.

## Token (verified live, read-only)

`INSTAGRAM_ACCESS_TOKEN` is an **Instagram-Login token** (host `graph.instagram.com/v22.0`, not `graph.facebook.com`). Confirmed: account `balizero0` BUSINESS, `instagram_content_publish` scope present (`content_publishing_limit` responds), account already has live CAROUSEL_ALBUM posts. The publisher/endpoint use `graph.instagram.com/v22.0` + `INSTAGRAM_ACCOUNT_ID`.

## Law 5 (no autonomous publish) — structural

- Endpoint: `if not body.confirm:` returns the dry-validation **before** the `publish()`/ledger calls → structurally unreachable without an explicit human `confirm=true`. Mutation-verified (breaking the guard fails the test).
- Publisher: `if draft.approval_state != "approved": refuse` — `approved` is set only on the confirm path.
- Admin-only (`_require_admin`, same as `war_room_dashboard`).

## Verification (independent — re-run by the orchestrator, not the building agents)

- Caption: 12/12 + real caption generated clean. Publisher: 7/7. Endpoint: 6/6.
- Router **registered** (manifest + `include_router` in both include funcs — mounted, not just present).
- Pre-deploy gate (§11): import smoke `get_current_user` OK + **91 RAG tests pass**.
- Honest caveat: no **live Meta call** yet — tests mock `publish()`. The real Graph flow is exercised only on the first operator dry-run/publish post-deploy.

## Flow (the app, next PR)

App uploads 8 slide PNGs via existing `POST /api/assets/upload` → public Tigris URLs → operator previews caption + confirms → `POST /api/war-room/publish-ig {slug, image_urls, caption, confirm:true}` → backend publishes server-side → returns permalink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)