### PR TITLE
fix(process): allow non-round IDR prices in quote/discount inputs

### DIFF
--- a/apps/mouth/src/app/(workspace)/process/[id]/page.tsx
+++ b/apps/mouth/src/app/(workspace)/process/[id]/page.tsx
@@ -1341,7 +1341,7 @@ export default function CaseDetailPage() {
                       autoFocus
                       type="number"
                       min="0"
-                      step="100000"
+                      step="1"
                       value={priceValue}
                       onChange={(e) => setPriceValue(e.target.value)}
                       onKeyDown={(e) => {
@@ -1395,7 +1395,7 @@ export default function CaseDetailPage() {
                       autoFocus
                       type="number"
                       min="0"
-                      step="100000"
+                      step="1"
                       value={priceValue}
                       onChange={(e) => setPriceValue(e.target.value)}
                       onKeyDown={(e) => {

--- a/apps/mouth/src/app/(workspace)/process/new/page.tsx
+++ b/apps/mouth/src/app/(workspace)/process/new/page.tsx
@@ -807,7 +807,7 @@ export default function NewPracticePage() {
                 <input
                   type="number"
                   min="0"
-                  step="100000"
+                  step="1"
                   value={formData.quoted_price}
                   onChange={(e) =>
                     setFormData((prev) => ({
@@ -872,7 +872,7 @@ export default function NewPracticePage() {
                 <input
                   type="number"
                   min="0"
-                  step="100000"
+                  step="1"
                   value={formData.discount_amount}
                   onChange={(e) =>
                     setFormData((prev) => ({


### PR DESCRIPTION
## Problem

Operator **Krisna** reported that the **Quoted Price (IDR)** field in the process/quote form rejects non-round amounts. Typing `4250000` triggers the browser validation:

> Please enter a valid value. The two nearest valid values are 4200000 and 4300000.

## Root cause

The IDR price/discount `<input type="number">` fields used `step="100000"`, which makes HTML5 constraint validation accept **only multiples of 100,000**. Any exact quote (e.g. 4.25M) is blocked.

## Fix

Switch `step="100000"` → `step="1"` on all 4 IDR amount inputs:

- `process/new/page.tsx` — Quoted Price, Discount
- `process/[id]/page.tsx` — Quoted Price, Actual Price

Any integer IDR amount is now valid (no sub-rupiah cents). Spinner arrows still work, incrementing by 1 instead of 100k. The `step="0.01"` decimal-currency fields are untouched.

Verified there is **no** Zod/JS/server-side multiple-of-100k constraint — the HTML `step` attribute was the sole blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)