### PR TITLE
docs(autonomous-ops): clarify L2 arms --auto, never "leave merge to operator"

### DIFF
--- a/AUTONOMOUS_OPS.md
+++ b/AUTONOMOUS_OPS.md
@@ -61,6 +61,16 @@ Claude falls back to conservative mode and pings the user to re-certify.
 
 ## Level 2 — Autonomous to deploy and post-deploy verification
 
+> **No "I'll leave the merge to you at CI green".** Arming `--auto` IS the merge
+> decision and it is autonomous at L2. Writing "I'll leave the merge to you" on a
+> normal feature PR is being _more conservative than this contract_ — don't.
+> `--auto` is the professional move precisely because it cannot force a red merge:
+> GitHub holds the PR until required checks pass, so branch protection stays the
+> safety layer above Claude. Confirmed by Antonello 2026-06-25. (Exception: the
+> "Still requires confirmation" list below — guardrail/contract/critical-config
+> changes, migrations without a green dry-run, force push, destructive DB ops —
+> still merge by the operator.)
+
 **Additional autonomous actions on top of L1:**
 
 - `gh pr merge --auto --squash` immediately after opening a PR. GitHub holds


### PR DESCRIPTION
## What

Adds an explicit clarification under the **Level 2** header of `AUTONOMOUS_OPS.md`: arming `gh pr merge --auto --squash` IS the autonomous merge decision at L2 — Claude should never write *"I'll leave the merge to you at CI green"* on a normal feature PR.

## Why

Per Antonello (2026-06-25). The L2 contract already authorizes `--auto` at step 5, but the prose left room for Claude to be **more conservative than the contract** (which is what happened on PR #1743). This closes that gap in words, without changing the actual permission level.

`--auto` is the professional move precisely because it **cannot force a red merge**: GitHub holds the PR until required checks pass, so branch protection remains the safety layer above Claude.

## Scope guard

The "Still requires confirmation" list is untouched — guardrail/contract/critical-config changes, migrations without a green dry-run, force push, and destructive DB ops **still merge by the operator**. (This very PR is a guardrail change, so per the contract its own merge is left to Antonello.)

## Merge

**Operator merge** — guardrail/contract change, not auto-armed by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)