### PR TITLE
feat(wr2): operator-gated IG publish from the app — Tigris upload endpoint + remote CLI

### DIFF
--- a/apps/backend-rag/backend/app/routers/wr2_publish.py
+++ b/apps/backend-rag/backend/app/routers/wr2_publish.py
@@ -54,7 +54,7 @@ import uuid
 from typing import Any
 
 import asyncpg
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from pydantic import BaseModel, Field
 
 from backend.app.core.config import settings
@@ -324,6 +324,75 @@ async def _ledger_record_result(
             await conn.close()
     except Exception as exc:  # bookkeeping must never crash a live post
         logger.warning("wr2_publish: ledger result update failed (non-fatal): %s", exc)
+
+
+# ── Slide upload (PNG bytes → public Tigris URL) ───────────────────────────────
+
+
+# Cap per slide PNG. The production renderer writes ~100KB–2.5MB slides; 8MB is a
+# generous ceiling that still rejects a runaway/garbage body before it hits Tigris.
+_MAX_SLIDE_BYTES = 8 * 1024 * 1024
+
+
+@router.post("/upload-slide")
+async def upload_slide(
+    file: UploadFile = File(..., description="A single carousel slide PNG."),
+    draft_id: str = Form(..., description="Groups all slides of one carousel post."),
+    slide_index: int = Form(..., ge=0, le=9, description="0-based slide ordinal (0=cover)."),
+) -> dict[str, Any]:
+    """Upload ONE carousel slide PNG to Tigris, return its public Graph-fetchable URL.
+
+    The WR2 Control app renders slides locally on M5, where the Tigris creds do NOT
+    live — only the Fly backend has them. So the app POSTs each slide's bytes here;
+    this admin-gated endpoint puts them on Tigris (``public-read``) and returns the
+    URL the operator then passes to ``/publish-ig`` as one of ``image_urls``.
+
+    Mirrors the exact ``upload_png`` path the live dry-run exercised (2026-06-26):
+    deterministic key ``wr2-ig/<draft_id>/<NN>.png``, ContentType ``image/png``,
+    HEAD-verified. The endpoint NEVER publishes — it only hosts bytes. LEGGE 5 is
+    enforced at ``/publish-ig`` (the ``confirm`` flag), not here.
+    """
+    from backend.services.canva_renderer_v2._tigris import (
+        TigrisError,
+        get_s3_client,
+        upload_png,
+    )
+
+    ct = (file.content_type or "").lower()
+    if ct not in ("image/png", "application/octet-stream", ""):
+        raise HTTPException(status_code=415, detail=f"expected image/png, got {ct!r}")
+
+    body = await file.read()
+    if not body:
+        raise HTTPException(status_code=400, detail="empty file")
+    if len(body) > _MAX_SLIDE_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"slide too large ({len(body)} bytes, max {_MAX_SLIDE_BYTES})",
+        )
+    # Magic-byte check: reject anything that is not actually a PNG before we put it
+    # on a public bucket (Graph rejects non-PNG anyway; fail fast + honest 400).
+    if body[:8] != b"\x89PNG\r\n\x1a\n":
+        raise HTTPException(status_code=400, detail="body is not a PNG (bad magic bytes)")
+
+    safe_draft = "".join(c for c in draft_id if c.isalnum() or c in "-_").strip()
+    if not safe_draft:
+        raise HTTPException(status_code=400, detail="draft_id must be alphanumeric/-/_")
+
+    try:
+        s3 = get_s3_client()
+        public_url, key = upload_png(
+            s3, body, draft_id=safe_draft, slide_index=slide_index
+        )
+    except TigrisError as exc:
+        logger.error("wr2_publish: slide upload to Tigris failed: %s", exc)
+        raise HTTPException(status_code=502, detail=f"Tigris upload failed: {exc}") from exc
+
+    logger.info(
+        "wr2_publish: slide uploaded draft=%s idx=%d key=%s bytes=%d",
+        safe_draft, slide_index, key, len(body),
+    )
+    return {"ok": True, "url": public_url, "key": key, "slide_index": slide_index}
 
 
 # ── Endpoint ───────────────────────────────────────────────────────────────────

--- a/apps/backend-rag/backend/tests/unit/routers/test_wr2_publish.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_wr2_publish.py
@@ -277,3 +277,109 @@ def test_content_hash_is_stable_and_order_sensitive() -> None:
 
     # MagicMock import kept for parity with other router tests' tooling surface.
     assert isinstance(MagicMock(), MagicMock)
+
+
+# ── /upload-slide : PNG bytes -> public Tigris URL ─────────────────────────────
+
+# A minimal valid 1x1 PNG (magic bytes + IHDR + IEND), enough to pass the magic
+# check. The real bytes never reach Tigris in tests — upload_png is mocked.
+_PNG_1X1 = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00\x01"
+    b"\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+def test_upload_slide_returns_public_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A PNG is uploaded to Tigris and the public URL is returned. upload_png is
+    mocked so no real S3 call happens; we assert the bytes + key args flow through."""
+    captured: dict[str, Any] = {}
+
+    def fake_upload_png(s3: Any, png: Any, *, draft_id: str, slide_index: int, **kw: Any):  # noqa: ANN401
+        captured["bytes_len"] = len(png)
+        captured["draft_id"] = draft_id
+        captured["slide_index"] = slide_index
+        url = f"https://nuzantara-warroom-images.fly.storage.tigris.dev/wr2-ig/{draft_id}/{slide_index:02d}.png"
+        return url, f"wr2-ig/{draft_id}/{slide_index:02d}.png"
+
+    monkeypatch.setattr(
+        "backend.services.canva_renderer_v2._tigris.get_s3_client",
+        lambda: MagicMock(),
+    )
+    monkeypatch.setattr(
+        "backend.services.canva_renderer_v2._tigris.upload_png", fake_upload_png
+    )
+
+    app = _app(ADMIN_USER)
+    try:
+        resp = TestClient(app).post(
+            "/api/war-room/upload-slide",
+            files={"file": ("01.png", _PNG_1X1, "image/png")},
+            data={"draft_id": "my-carousel", "slide_index": "0"},
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["url"].endswith("/wr2-ig/my-carousel/00.png")
+    assert data["slide_index"] == 0
+    assert captured["bytes_len"] == len(_PNG_1X1)
+    assert captured["draft_id"] == "my-carousel"
+
+
+def test_upload_slide_non_admin_is_forbidden() -> None:
+    app = _app(NON_ADMIN_USER)
+    try:
+        resp = TestClient(app).post(
+            "/api/war-room/upload-slide",
+            files={"file": ("01.png", _PNG_1X1, "image/png")},
+            data={"draft_id": "my-carousel", "slide_index": "0"},
+        )
+    finally:
+        app.dependency_overrides.clear()
+    assert resp.status_code == 403
+
+
+def test_upload_slide_rejects_non_png() -> None:
+    """A body without the PNG magic bytes is rejected 400 before touching Tigris."""
+    app = _app(ADMIN_USER)
+    try:
+        resp = TestClient(app).post(
+            "/api/war-room/upload-slide",
+            files={"file": ("evil.png", b"GIF89a not a png", "image/png")},
+            data={"draft_id": "my-carousel", "slide_index": "0"},
+        )
+    finally:
+        app.dependency_overrides.clear()
+    assert resp.status_code == 400
+    assert "not a PNG" in resp.json()["detail"]
+
+
+def test_upload_slide_tigris_failure_is_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A TigrisError surfaces as 502 (upstream storage failure), not a 500."""
+    from backend.services.canva_renderer_v2._tigris import TigrisError
+
+    def boom(*a: Any, **k: Any) -> None:  # noqa: ANN401
+        raise TigrisError("simulated S3 outage")
+
+    monkeypatch.setattr(
+        "backend.services.canva_renderer_v2._tigris.get_s3_client",
+        lambda: MagicMock(),
+    )
+    monkeypatch.setattr(
+        "backend.services.canva_renderer_v2._tigris.upload_png", boom
+    )
+
+    app = _app(ADMIN_USER)
+    try:
+        resp = TestClient(app).post(
+            "/api/war-room/upload-slide",
+            files={"file": ("01.png", _PNG_1X1, "image/png")},
+            data={"draft_id": "my-carousel", "slide_index": "0"},
+        )
+    finally:
+        app.dependency_overrides.clear()
+    assert resp.status_code == 502
+    assert "Tigris upload failed" in resp.json()["detail"]

--- a/scripts/wr2_ig_publish_remote.py
+++ b/scripts/wr2_ig_publish_remote.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""wr2_ig_publish_remote — publish a WR2 carousel to Instagram FROM the operator's
+workstation (M5), driving the Fly backend over HTTP. The operator gate (Legge 5).
+
+WHY A SECOND CLI (2026-06-26)
+-----------------------------
+``scripts/wr2_ig_publish.py`` runs the publish SERVER-SIDE: it imports the backend
+Tigris client + IGPublisher directly, so it only works where those creds live (Fly).
+The WR2 Control app runs on M5, where there are NO Tigris creds and NO IG token. So
+the app cannot use that CLI. THIS CLI is the M5 path: it talks to the deployed
+backend over HTTP and never needs any secret beyond the operator's own login.
+
+Flow (mirrors the server-side dry-run that PASSED 2026-06-26):
+  1. POST /api/auth/login {email, pin}            -> admin JWT (never printed)
+  2. For each local slide PNG:
+       POST /api/war-room/upload-slide (multipart) -> public Tigris URL
+  3. build_caption(slug) locally (pure stdlib, no backend deps)
+  4. POST /api/war-room/publish-ig {slug, image_urls, caption, confirm}
+       - confirm=False (DEFAULT): backend dry-validates, NEVER posts (Legge 5)
+       - confirm=True  (--confirm): backend publishes the carousel
+
+LEGGE 5 — nothing posts without --confirm. The flag maps 1:1 to the backend's
+``confirm`` gate; a dry run exercises upload + the real Graph carousel assembly
+(child + parent containers) but the backend never calls /media_publish.
+
+CREDENTIALS (no secret ever printed, none persisted by this CLI):
+  WR2_PUBLISH_EMAIL  — admin email (default: zero@balizero.com)
+  WR2_PUBLISH_PIN    — admin login PIN/password (or via macOS Keychain, see below)
+  WR2_BACKEND_URL    — backend base URL (default: https://nuzantara-rag.fly.dev)
+
+If WR2_PUBLISH_PIN is unset, the PIN is read from the macOS Keychain item
+``wr2-publish-pin`` (account = the email) via ``security find-generic-password``.
+
+USAGE
+    python scripts/wr2_ig_publish_remote.py <slug>            # DRY-RUN (default)
+    python scripts/wr2_ig_publish_remote.py <slug> --confirm  # PUBLISH (operator click)
+
+EXIT 0 = dry-run validated OR publish succeeded. EXIT 1 = failure (reason printed).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("wr2.ig.remote")
+
+_DEFAULT_BACKEND = "https://nuzantara-rag.fly.dev"
+_DEFAULT_EMAIL = "zero@balizero.com"
+_KEYCHAIN_ITEM = "wr2-publish-pin"
+
+_CAROUSEL_ROOT = Path(
+    os.environ.get(
+        "WR2_CAROUSEL_ROOT",
+        str(Path.home() / "Desktop/nuzantara/apps/war-room/output/carousel"),
+    )
+)
+
+
+class PublishAborted(RuntimeError):
+    """Raised when the run cannot proceed (missing creds, bad slug, HTTP error)."""
+
+
+# ── Local slide discovery ──────────────────────────────────────────────────────
+
+
+def _slug_dir(slug: str) -> Path:
+    d = _CAROUSEL_ROOT / slug
+    if not d.is_dir():
+        raise PublishAborted(f"carousel dir not found: {d}")
+    return d
+
+
+def _discover_slide_pngs(slug_dir: Path) -> list[Path]:
+    """Return the numbered slide PNGs (``<digits>.png``) in slide order.
+
+    Matches the app's slide filter: any digit-stem PNG, sorted by int(stem). The
+    re-render sweep guarantees a single padding scheme, so there are no dupes.
+    """
+    slides_dir = slug_dir / "slides"
+    src = slides_dir if slides_dir.is_dir() else slug_dir
+    pngs = [p for p in src.glob("*.png") if p.stem.isdigit()]
+    if not pngs:
+        raise PublishAborted(f"no numbered slide PNGs under {src}")
+    pngs.sort(key=lambda p: int(p.stem))
+    if len(pngs) > 10:
+        raise PublishAborted(f"{len(pngs)} slides — IG carousel max is 10")
+    return pngs
+
+
+# ── Caption (pure, local) ──────────────────────────────────────────────────────
+
+
+def _build_caption(slug: str) -> str:
+    """Deterministic brand caption via the pure-stdlib author (no backend deps)."""
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from wr2_ig_caption import build_caption  # noqa: PLC0415
+
+    return build_caption(slug, base_dir=_CAROUSEL_ROOT)
+
+
+# ── Credentials (never printed, never persisted) ───────────────────────────────
+
+
+def _resolve_pin(email: str) -> str:
+    pin = os.environ.get("WR2_PUBLISH_PIN")
+    if pin:
+        return pin
+    # Fall back to the macOS Keychain — value is captured, never logged.
+    try:
+        out = subprocess.run(
+            [
+                "security", "find-generic-password",
+                "-s", _KEYCHAIN_ITEM, "-a", email, "-w",
+            ],
+            capture_output=True, text=True, timeout=10, check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise PublishAborted(f"keychain lookup failed: {exc}") from exc
+    pin = (out.stdout or "").strip()
+    if not pin:
+        raise PublishAborted(
+            "no PIN: set WR2_PUBLISH_PIN or add Keychain item "
+            f"'{_KEYCHAIN_ITEM}' for account '{email}' "
+            f"(security add-generic-password -s {_KEYCHAIN_ITEM} -a {email} -w)"
+        )
+    return pin
+
+
+# ── Backend HTTP ───────────────────────────────────────────────────────────────
+
+
+async def _login(client: httpx.AsyncClient, base: str, email: str, pin: str) -> str:
+    resp = await client.post(
+        f"{base}/api/auth/login", json={"email": email, "pin": pin}, timeout=30
+    )
+    if resp.status_code != 200:
+        raise PublishAborted(f"login failed: HTTP {resp.status_code} {resp.text[:160]}")
+    data = resp.json().get("data") or {}
+    token = data.get("token")
+    if not token:
+        raise PublishAborted("login response had no token")
+    return token  # never logged
+
+
+async def _upload_slide(
+    client: httpx.AsyncClient, base: str, headers: dict[str, str],
+    png: Path, draft_id: str, slide_index: int,
+) -> str:
+    with png.open("rb") as fh:
+        files = {"file": (png.name, fh, "image/png")}
+        data = {"draft_id": draft_id, "slide_index": str(slide_index)}
+        resp = await client.post(
+            f"{base}/api/war-room/upload-slide",
+            headers=headers, files=files, data=data, timeout=120,
+        )
+    if resp.status_code != 200:
+        raise PublishAborted(
+            f"upload slide {slide_index} failed: HTTP {resp.status_code} {resp.text[:160]}"
+        )
+    url = resp.json().get("url")
+    if not url:
+        raise PublishAborted(f"upload slide {slide_index}: no url in response")
+    logger.info("uploaded slide %d -> %s", slide_index, url)
+    return url
+
+
+async def _publish(
+    client: httpx.AsyncClient, base: str, headers: dict[str, str],
+    slug: str, image_urls: list[str], caption: str, confirm: bool,
+) -> dict[str, Any]:
+    resp = await client.post(
+        f"{base}/api/war-room/publish-ig",
+        headers=headers,
+        json={
+            "slug": slug,
+            "image_urls": image_urls,
+            "caption": caption,
+            "confirm": confirm,
+        },
+        timeout=180,
+    )
+    if resp.status_code == 409:
+        detail = resp.json().get("detail", {})
+        raise PublishAborted(
+            f"already published: {detail.get('permalink') or detail}"
+        )
+    if resp.status_code != 200:
+        raise PublishAborted(f"publish failed: HTTP {resp.status_code} {resp.text[:240]}")
+    return resp.json()
+
+
+# ── Orchestration ──────────────────────────────────────────────────────────────
+
+
+async def _run(args: argparse.Namespace) -> int:
+    base = os.environ.get("WR2_BACKEND_URL", _DEFAULT_BACKEND).rstrip("/")
+    email = os.environ.get("WR2_PUBLISH_EMAIL", _DEFAULT_EMAIL)
+    slug = args.slug.strip()
+
+    slug_dir = _slug_dir(slug)
+    pngs = _discover_slide_pngs(slug_dir)
+    caption = _build_caption(slug)
+    pin = _resolve_pin(email)
+
+    logger.info(
+        "slug=%s slides=%d caption_chars=%d backend=%s confirm=%s",
+        slug, len(pngs), len(caption), base, args.confirm,
+    )
+
+    # draft_id groups the slides under one Tigris prefix; deterministic per slug.
+    draft_id = f"app-{slug}"[:64]
+
+    async with httpx.AsyncClient() as client:
+        token = await _login(client, base, email, pin)
+        headers = {"Authorization": f"Bearer {token}"}
+
+        image_urls: list[str] = []
+        for idx, png in enumerate(pngs):
+            url = await _upload_slide(client, base, headers, png, draft_id, idx)
+            image_urls.append(url)
+
+        result = await _publish(
+            client, base, headers, slug, image_urls, caption, args.confirm
+        )
+
+    if not args.confirm:
+        val = result.get("validation", {})
+        logger.info(
+            "DRY-RUN OK: backend validated %d slides (valid=%s). %s",
+            result.get("would_publish", {}).get("slide_count", len(image_urls)),
+            val.get("ok"),
+            result.get("note", ""),
+        )
+        logger.info("Re-run with --confirm to PUBLISH (Legge 5 — explicit operator click).")
+        return 0
+
+    permalink = result.get("permalink") or result.get("post_url")
+    logger.info("✅ PUBLISHED: %s", permalink or "(no permalink returned)")
+    return 0
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("slug", help="carousel dir name under output/carousel/")
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help="LEGGE 5 operator gate. Without it = dry-run (no post). With it = PUBLISH.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        return asyncio.run(_run(args))
+    except PublishAborted as exc:
+        logger.error("ABORTED: %s", exc)
+        return 1
+    except httpx.HTTPError as exc:
+        # Network/transport failure (backend down, DNS, TLS) — clean message, not
+        # a raw traceback (the app surfaces this stderr line to the operator).
+        logger.error("ABORTED: backend unreachable: %s", exc)
+        return 1
+    except KeyboardInterrupt:
+        return 130
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("publish crashed: %s", exc)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Completes the operator-gated WR2 → Instagram publish so the **"Pubblica su IG" button in the WR2 Control app works**. The app runs on M5 (no Tigris creds, no IG token — only Fly has them), so the app must drive the backend over HTTP. This PR adds the two missing pieces.

### 1. `POST /api/war-room/upload-slide` (admin-gated)
On the existing `wr2_publish` router. Accepts one slide PNG (multipart) + `draft_id` + `slide_index`, uploads it to Tigris via the same `upload_png` path the live dry-run exercised, returns the public Graph-fetchable URL. PNG magic-byte check + 8MB cap + 415/413/502 error mapping. **NEVER publishes** — Legge 5 stays at `/publish-ig` (the `confirm` flag).

### 2. `scripts/wr2_ig_publish_remote.py` — the M5/app CLI
Pure HTTP client (no backend imports, no local secret beyond the operator's own login): logs in (`/api/auth/login` → JWT, never printed), uploads the 8 slides, builds the deterministic brand caption locally (`wr2_ig_caption`, pure stdlib), then POSTs `/publish-ig`. **Dry-run by default; `--confirm` is the operator gate.** PIN from `WR2_PUBLISH_PIN` or the macOS Keychain item `wr2-publish-pin`. Clean abort on backend-unreachable.

The existing `scripts/wr2_ig_publish.py` (server-side, imports backend Tigris + IGPublisher) is unchanged — it remains the on-Fly path.

## Why this is safe (Legge 5)

Nothing publishes without an explicit operator click. The app's button shows a confirm popover: **"Verifica (dry-run)"** exercises upload + the real Graph CAROUSEL assembly and posts NOTHING; **"Pubblica ora"** is the only path that sends `confirm=true`.

## Verification

- 10/10 `test_wr2_publish.py` (6 publish + 4 new upload: success, non-admin 403, non-PNG 400, Tigris 502)
- import-chain smoke OK · 357 manifest-parity tests pass
- remote CLI local pipeline verified to the HTTP boundary (8-slide discovery + 537-char caption + cred resolve)
- **the full Graph flow was already proven live** by a server-side dry-run (2026-06-26): Graph fetched 8 Tigris slides + assembled the CAROUSEL container; `_publish_parent` never called; balizero0 had zero new posts.

## App side (separate locale-only repo, already done)

The "Pubblica su IG" button + `publishToInstagram(slug:lang:confirm:)` are built, tested (59/0), and propagated to M5+Pro. The button runs THIS CLI — it goes from disarmed to armed when this PR merges + deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)