### PR TITLE
fix(portal): harden client message and upload dialog

### DIFF
--- a/apps/backend-rag/backend/services/portal/_mixins/messaging.py
+++ b/apps/backend-rag/backend/services/portal/_mixins/messaging.py
@@ -115,7 +115,7 @@ class PortalMessagingMixin:
                     client_id, practice_id, subject, direction, content, sent_by
                 )
                 VALUES ($1, $2, $3, 'client_to_team', $4, $5)
-                RETURNING id, created_at
+                RETURNING id, subject, content, direction, sent_by, read_at, created_at, practice_id
                 """,
                 client_id,
                 practice_id,
@@ -126,6 +126,13 @@ class PortalMessagingMixin:
 
             return {
                 "id": message["id"],
+                "subject": message["subject"],
+                "content": message["content"],
+                "from_team": message["direction"] == "team_to_client",
+                "sent_by": message["sent_by"],
+                "is_read": message["read_at"] is not None,
+                "practice_id": message["practice_id"],
+                "practice_name": None,
                 "created_at": message["created_at"].isoformat(),
             }
 

--- a/apps/backend-rag/backend/tests/unit/app/services/portal/test_portal_service.py
+++ b/apps/backend-rag/backend/tests/unit/app/services/portal/test_portal_service.py
@@ -574,16 +574,32 @@ class TestPortalServiceMessaging:
         now = datetime.now(timezone.utc)
         mock_conn.fetchrow.side_effect = [
             {"email": "client@test.com"},
-            {"id": 42, "created_at": now},
+            {
+                "id": 42,
+                "subject": "Visa question",
+                "content": "Need help with visa",
+                "direction": "client_to_team",
+                "sent_by": "client@test.com",
+                "read_at": None,
+                "created_at": now,
+                "practice_id": 603,
+            },
         ]
 
         result = await portal_service.send_message(
             client_id=1,
             content="Need help with visa",
             subject="Visa question",
+            practice_id=603,
             current_user=ctx_client_1,
         )
         assert result["id"] == 42
+        assert result["content"] == "Need help with visa"
+        assert result["from_team"] is False
+        assert result["sent_by"] == "client@test.com"
+        assert result["is_read"] is False
+        assert result["practice_id"] == 603
+        assert result["created_at"] == now.isoformat()
 
     @pytest.mark.asyncio
     async def test_mark_message_read_success(

--- a/apps/mouth/src/app/portal/(authenticated)/process/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/process/page.tsx
@@ -20,30 +20,13 @@ import { logger } from "@/lib/logger";
 import { useToast } from "@/components/ui/toast";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import type { ClientRequiredDocument } from "@/lib/types/required-documents";
-
-// Lazy: Dialog is only used inside modals (not first paint)
-const Dialog = dynamic(
-  () => import("@/components/ui/dialog").then((m) => ({ default: m.Dialog })),
-  { ssr: false },
-);
-const DialogContent = dynamic(
-  () =>
-    import("@/components/ui/dialog").then((m) => ({
-      default: m.DialogContent,
-    })),
-  { ssr: false },
-);
-const DialogHeader = dynamic(
-  () =>
-    import("@/components/ui/dialog").then((m) => ({ default: m.DialogHeader })),
-  { ssr: false },
-);
-const DialogTitle = dynamic(
-  () =>
-    import("@/components/ui/dialog").then((m) => ({ default: m.DialogTitle })),
-  { ssr: false },
-);
 
 // Lazy: FileUploadField only renders when user clicks upload (not first paint)
 const FileUploadField = dynamic(


### PR DESCRIPTION
## Summary
- return a full display-ready portal message payload after client message send
- keep Radix upload dialog primitives mounted synchronously so DialogTitle is present when DialogContent mounts
- add unit coverage for the send-message response shape

## Verification
- `PYTHONPATH=. pytest backend/tests/unit/app/services/portal/test_portal_service.py::TestPortalServiceMessaging -q`
- `python -c "from backend.app.dependencies import get_current_user; print(OK)"`
- `../../node_modules/.bin/eslint --max-warnings=0 "src/app/portal/(authenticated)/process/page.tsx"`
- `npm run typecheck`
- live browser loop against `https://my.balizero.com` with Kaiser Test / Zero passed after backend deploy; frontend a11y warning fix pending production deployment
