### PR TITLE
fix(portal): accept camel case practice id in messages

### DIFF
--- a/apps/backend-rag/backend/app/routers/portal.py
+++ b/apps/backend-rag/backend/app/routers/portal.py
@@ -21,7 +21,7 @@ from urllib.parse import quote
 import asyncpg
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile
 from fastapi.responses import Response
-from pydantic import BaseModel
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 from backend.app.core.config import settings
 from backend.app.dependencies import get_database_pool
@@ -46,9 +46,14 @@ router = APIRouter(prefix="/api/portal", tags=["portal"])
 class SendMessageRequest(BaseModel):
     """Request to send a message"""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     content: str
     subject: str | None = None
-    practice_id: int | None = None
+    practice_id: int | None = Field(
+        default=None,
+        validation_alias=AliasChoices("practice_id", "practiceId"),
+    )
 
 
 class UpdatePreferencesRequest(BaseModel):

--- a/apps/backend-rag/backend/tests/unit/routers/test_portal.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_portal.py
@@ -452,6 +452,27 @@ class TestMessages:
         assert data["success"] is True
         assert data["message"] == "Message sent"
 
+    def test_send_message_accepts_camel_case_practice_id(
+        self, client, mock_portal_service
+    ):
+        """Browser payloads use camelCase, but service expects snake_case."""
+        mock_portal_service.send_message.return_value = {
+            "id": 5,
+            "content": "Need help with process",
+            "practice_id": 603,
+        }
+
+        response = client.post(
+            "/api/portal/messages",
+            json={"content": "Need help with process", "practiceId": 603},
+        )
+
+        assert response.status_code == 200
+        mock_portal_service.send_message.assert_awaited_once()
+        assert (
+            mock_portal_service.send_message.await_args.kwargs["practice_id"] == 603
+        )
+
     def test_mark_message_read(self, client, mock_portal_service):
         """Mark message as read."""
         mock_portal_service.mark_message_read.return_value = None


### PR DESCRIPTION
## Summary
- accept both practice_id and browser practiceId payloads for portal messages
- keep the service boundary snake_case while preserving existing clients
- add router regression coverage for camelCase message practice association

## Tests
- PYTHONPATH=. pytest backend/tests/unit/routers/test_portal.py::TestMessages::test_send_message_accepts_camel_case_practice_id backend/tests/unit/routers/test_portal.py::TestMessages::test_send_message_success backend/tests/unit/app/services/portal/test_portal_service.py::TestPortalServiceMessaging -q
- ruff check backend/app/routers/portal.py backend/tests/unit/routers/test_portal.py