### PR TITLE
fix(accounting): restore Import Cashout PDF button (lost in a prior merge)

### DIFF
--- a/apps/mouth/src/app/(workspace)/accounting/page.tsx
+++ b/apps/mouth/src/app/(workspace)/accounting/page.tsx
@@ -15,7 +15,7 @@
  * RBAC is enforced server-side (403 → error boundary). Money is IDR.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Loader2,
   Wallet,
@@ -25,6 +25,7 @@ import {
   ArrowDownToLine,
   ArrowUpFromLine,
   Sheet,
+  Upload,
   X,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -463,6 +464,8 @@ export default function AccountingPage() {
   const [cashout, setCashout] = useState<CashoutRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [exporting, setExporting] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const loadCashout = useCallback(async () => {
     try {
@@ -507,6 +510,28 @@ export default function AccountingPage() {
     }
   };
 
+  const handleImportFile = async (file: File | undefined) => {
+    if (!file) return;
+    setImporting(true);
+    try {
+      const res = await accountingApi.importCashout(file);
+      const weeks = res.weeks.length ? ` (${res.weeks.join(", ")})` : "";
+      const replaced = res.replaced ? `, replaced ${res.replaced} prior` : "";
+      success("Cashout imported", `${res.imported} row(s)${weeks}${replaced}`);
+      loadCashout();
+    } catch (err) {
+      // 422 = undated / non-cashout PDF; importCashout surfaces the backend
+      // `detail` as the Error's `.message`.
+      const detail =
+        (err instanceof Error && err.message) ||
+        "Import failed — is this a GABUNGAN cashout PDF?";
+      error("Import failed", detail);
+      logger.error("accounting import-cashout failed", {}, err as Error);
+    } finally {
+      setImporting(false);
+    }
+  };
+
   return (
     <div className="space-y-6 p-6">
       <div className="flex items-center justify-between">
@@ -514,14 +539,39 @@ export default function AccountingPage() {
           <Wallet className="h-6 w-6 text-[var(--bz-accent,#d4845a)]" />
           <h1 className="text-2xl font-semibold tracking-tight">Accounting</h1>
         </div>
-        <Button variant="outline" onClick={handleExport} disabled={exporting}>
-          {exporting ? (
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-          ) : (
-            <Sheet className="mr-2 h-4 w-4" />
-          )}
-          Export to Sheets
-        </Button>
+        <div className="flex items-center gap-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="application/pdf,.pdf"
+            className="hidden"
+            onChange={(e) => {
+              void handleImportFile(e.target.files?.[0]);
+              e.target.value = "";
+            }}
+          />
+          <Button
+            variant="outline"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={importing}
+            title="Import Asya's weekly cashout worksheet PDF (GABUNGAN)"
+          >
+            {importing ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Upload className="mr-2 h-4 w-4" />
+            )}
+            Import Cashout PDF
+          </Button>
+          <Button variant="outline" onClick={handleExport} disabled={exporting}>
+            {exporting ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Sheet className="mr-2 h-4 w-4" />
+            )}
+            Export to Sheets
+          </Button>
+        </div>
       </div>
 
       <SummaryCards summary={summary} />

--- a/apps/mouth/src/lib/api/workspace/accounting.api.ts
+++ b/apps/mouth/src/lib/api/workspace/accounting.api.ts
@@ -124,6 +124,13 @@ export interface ExportSheetResponse {
   range: string;
 }
 
+export interface ImportCashoutResponse {
+  source_filename: string;
+  imported: number;
+  weeks: string[];
+  replaced: number;
+}
+
 const qs = (params: Record<string, string | number | undefined>): string => {
   const parts = Object.entries(params)
     .filter(([, v]) => v !== undefined && v !== "")
@@ -194,5 +201,41 @@ export const accountingApi = {
     return api.post<ExportSheetResponse>(
       `/api/crm/accounting/export-sheet${qs({ week_label: weekLabel })}`,
     );
+  },
+
+  /**
+   * Import Asya's weekly cashout worksheet PDF (GABUNGAN) into the cashout log.
+   * Multipart upload — fetch sets the multipart boundary; we only attach CSRF +
+   * Authorization and send httpOnly cookies. Idempotent on the backend
+   * (re-uploading a file replaces that week's prior import rows). Imported rows
+   * land as type='cashout_worksheet' (a draft, excluded from the cash totals).
+   * 422 if the PDF carries no "NEW CASHOUT" title / no client rows.
+   */
+  async importCashout(file: File): Promise<ImportCashoutResponse> {
+    const form = new FormData();
+    form.append("file", file);
+
+    const headers: Record<string, string> = {};
+    const csrf = api.getCsrfToken();
+    if (csrf) headers["X-CSRF-Token"] = csrf;
+    const token = api.getToken();
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+
+    const resp = await fetch(
+      `${api.getBaseUrl()}/api/crm/accounting/import-cashout`,
+      { method: "POST", headers, body: form, credentials: "include" },
+    );
+
+    if (!resp.ok) {
+      let detail = resp.statusText;
+      try {
+        const body = await resp.json();
+        if (body?.detail) detail = String(body.detail);
+      } catch {
+        /* non-JSON error body */
+      }
+      throw new Error(detail);
+    }
+    return resp.json() as Promise<ImportCashoutResponse>;
   },
 };


### PR DESCRIPTION
## What

Restores the **"Import Cashout PDF"** button in the Accounting workspace (`kita.balizero.com/accounting`). The backend import endpoint + service + migration 239 + worksheet semantics are already live in prod (PR #1749), but the **frontend button never reached main** — it was reverted when `origin/main` merged into the feature branch. The import engine runs, but Asya had no way to trigger it.

## Files (frontend only — backend already in main)

- `apps/mouth/src/lib/api/workspace/accounting.api.ts` — `ImportCashoutResponse` + `importCashout()` multipart upload.
- `apps/mouth/src/app/(workspace)/accounting/page.tsx` — "Import Cashout PDF" button + hidden file input + handler next to "Export to Sheets"; toast reports imported count + weeks, reloads the table.

## How it was caught

A **live browser test** on prod (`kita.balizero.com`): page rendered "Export to Sheets" but **no Import button**, and Playwright's `set_input_files` found no file input. esiste≠armato (superscar #2) — surfaced by real-browser QA, not unit tests.

## Verification

- `tsc --noEmit` clean (0 errors).
- Backend untouched (identical to main).
- Backend endpoint already smoke-tested live in prod (parser PASS on a realistic GABUNGAN + SA export write PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)