### PR TITLE
🎨 Palette: Add exit animation to ThinkingIndicator

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -50,3 +50,7 @@
 ## 2026-06-15 - [Proper Nesting in Semantic Lists and Standard Iconography]
 **Learning:** Refactoring generic containers to semantic lists must be done with care to avoid invalid HTML (e.g., nesting an `<li>` directly inside another `<li>`). Additionally, micro-UX improvements should adhere to established iconography patterns—such as using `ChevronRight` for collapsed and `ChevronDown` for expanded states—to maintain an intuitive visual language across the application.
 **Action:** Double-check HTML structure for valid nesting when using `ul`/`li`. Follow project-standard icon orientations for collapsible components to ensure a predictable user experience.
+
+## 2026-06-16 - [Safe Exit Animations for Streaming UI]
+**Learning:** Exit animations in streaming interfaces (e.g., transitions from a 'thinking' state to a 'response' state) can feel abrupt if elements simply disappear. Wrapping conditional status indicators in `AnimatePresence` ensures a smooth visual handoff. However, avoid implementing live timers with `aria-live="polite"` as it creates excessive screen reader noise; prioritize silent visual progress for frequent updates.
+**Action:** Always use `AnimatePresence` for smooth transitions between streaming states. Avoid frequent `aria-live` updates for rapidly changing values like timers.

--- a/apps/mouth/src/components/chat/ChatMessageList.tsx
+++ b/apps/mouth/src/components/chat/ChatMessageList.tsx
@@ -2,7 +2,7 @@
 
 import { RefObject } from "react";
 import Image from "next/image";
-import { motion } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { MessageBubble } from "./MessageBubble";
 import { ThinkingIndicator } from "./ThinkingIndicator";
@@ -133,14 +133,16 @@ export function ChatMessageList({
       })}
 
       {/* Thinking Indicator */}
-      {isLoading && (
-        <ThinkingIndicator
-          isVisible={isLoading}
-          currentStatus={messages[messages.length - 1]?.currentStatus}
-          steps={messages[messages.length - 1]?.steps}
-          elapsedTime={thinkingElapsedTime}
-        />
-      )}
+      <AnimatePresence>
+        {isLoading && (
+          <ThinkingIndicator
+            isVisible={isLoading}
+            currentStatus={messages[messages.length - 1]?.currentStatus}
+            steps={messages[messages.length - 1]?.steps}
+            elapsedTime={thinkingElapsedTime}
+          />
+        )}
+      </AnimatePresence>
 
       <div ref={messagesEndRef} />
     </div>

--- a/apps/mouth/src/components/chat/ChatMessageListVirtualized.tsx
+++ b/apps/mouth/src/components/chat/ChatMessageListVirtualized.tsx
@@ -3,7 +3,7 @@
 import { RefObject, useRef, useCallback, useEffect, useState } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import Image from "next/image";
-import { motion } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { MessageBubble } from "./MessageBubble";
 import { ThinkingIndicator } from "./ThinkingIndicator";
@@ -256,16 +256,18 @@ export function ChatMessageListVirtualized({
           </div>
 
           {/* Thinking Indicator */}
-          {isLoading && (
-            <div className="max-w-3xl mx-auto px-4 pb-6">
-              <ThinkingIndicator
-                isVisible={isLoading}
-                currentStatus={messages[messages.length - 1]?.currentStatus}
-                steps={messages[messages.length - 1]?.steps}
-                elapsedTime={thinkingElapsedTime}
-              />
-            </div>
-          )}
+          <AnimatePresence>
+            {isLoading && (
+              <div className="max-w-3xl mx-auto px-4 pb-6">
+                <ThinkingIndicator
+                  isVisible={isLoading}
+                  currentStatus={messages[messages.length - 1]?.currentStatus}
+                  steps={messages[messages.length - 1]?.steps}
+                  elapsedTime={thinkingElapsedTime}
+                />
+              </div>
+            )}
+          </AnimatePresence>
 
           <div ref={messagesEndRef} />
         </div>
@@ -305,14 +307,16 @@ export function ChatMessageListVirtualized({
           })}
 
           {/* Thinking Indicator */}
-          {isLoading && (
-            <ThinkingIndicator
-              isVisible={isLoading}
-              currentStatus={messages[messages.length - 1]?.currentStatus}
-              steps={messages[messages.length - 1]?.steps}
-              elapsedTime={thinkingElapsedTime}
-            />
-          )}
+          <AnimatePresence>
+            {isLoading && (
+              <ThinkingIndicator
+                isVisible={isLoading}
+                currentStatus={messages[messages.length - 1]?.currentStatus}
+                steps={messages[messages.length - 1]?.steps}
+                elapsedTime={thinkingElapsedTime}
+              />
+            )}
+          </AnimatePresence>
 
           <div ref={messagesEndRef} />
         </div>


### PR DESCRIPTION
This PR implements a single micro-UX improvement by adding exit animations to the `ThinkingIndicator` component in the chat interface.

💡 **What**: Wrapped the `ThinkingIndicator` in `AnimatePresence` from `framer-motion` within both `ChatMessageList.tsx` and `ChatMessageListVirtualized.tsx`.

🎯 **Why**: Previously, the "thinking" state would abruptly disappear as soon as the first chunk of the assistant's response arrived. This change creates a smooth fade-out transition, making the interface feel more polished and less "jumpy" during the transition from reasoning to responding.

♿ **Accessibility**: No functional changes to accessibility, but it improves the visual predictability of state transitions. I explicitly avoided adding high-frequency `aria-live` updates to the recording timer based on feedback regarding screen reader noise.

Verified with existing Vitest suites and manual linting.

---
*PR created automatically by Jules for task [16198885472215171172](https://jules.google.com/task/16198885472215171172) started by @Balizero1987*