### PR TITLE
feat(self-loop): arm A2 on 3 cron organs + reconcile 15 owner_module path-drifts

### DIFF
--- a/apps/organism/organism/organs_registry.yaml
+++ b/apps/organism/organism/organs_registry.yaml
@@ -1,1723 +1,1704 @@
 version: 1
 checksum_algo: sha256
-checksum: ae5dcddb59506cffea8caa8169eceb46e6e0bf857a5bac84be3519beb9d5d63c
+checksum: 6e2e50f189622a4e21a1adf3703752243f2a7e860d32762da38bd23325fce16a
 organs:
-  - id: infra.postgres
-    runtime: fly_machine
-    type: daemon
-    expected_hb_seconds: 0
-    owner_module: infra/fly/nuzantara-postgres
-    dependencies: []
-    recovery_action: fly_machines_start
-    recovery_params:
-      app: nuzantara-postgres
-    severity_on_silence: critical
-    cicatrix_refs: []
-  - id: infra.redis
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 0
-    owner_module: brew/redis
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: homebrew.mxcl.redis
-    severity_on_silence: critical
-    cicatrix_refs: []
-  - id: infra.qdrant
-    runtime: fly_machine
-    type: daemon
-    expected_hb_seconds: 0
-    owner_module: infra/fly/nuzantara-qdrant
-    dependencies: []
-    recovery_action: fly_machines_start
-    recovery_params:
-      app: nuzantara-qdrant
-    severity_on_silence: critical
-    cicatrix_refs: []
-  - id: backend.api
-    runtime: fly_machine
-    type: webhook
-    expected_hb_seconds: 60
-    owner_module: apps/backend-rag/backend/app/main.py
-    dependencies:
-      - infra.postgres
-      - infra.redis
-      - infra.qdrant
-    recovery_action: fly_machines_start
-    recovery_params:
-      app: nuzantara-rag
-      process_group: api
-    severity_on_silence: critical
-    cicatrix_refs:
-      - 2026-04-29-startup-failed-mask
-      - 2026-04-29-drive-poll-attribute-error
-  - id: backend.surface_router
-    runtime: fly_machine
-    type: daemon
-    expected_hb_seconds: 60
-    owner_module: apps/backend-rag/backend/services/routing/surface_router.py
-    dependencies:
-      - backend.api
-      - infra.postgres
-    recovery_action: fly_machines_start
-    recovery_params:
-      app: nuzantara-rag
-      process_group: api
-    severity_on_silence: warning
-    notes:
-      R5 Phase 3 — in-process routing organ. Routes queries to KG vs vector vs
-      NLM. Always-on since Phase 3 deploy.
-    cicatrix_refs: []
-  - id: backend.kg_langgraph_orchestrator
-    runtime: fly_machine
-    type: daemon
-    enabled: false
-    disabled_reason:
-      "R5 Phase 5: feature-flagged via ENABLE_KG_LANGGRAPH=false (default).
-      Enable via fly secrets set ENABLE_KG_LANGGRAPH=1 on nuzantara-rag. Fast-path wired
-      in OrchestratorCore._try_kg_fast_path() — safe to enable per domain."
-    expected_hb_seconds: 60
-    owner_module: apps/backend-rag/backend/services/rag/kg_langgraph_orchestrator.py
-    dependencies:
-      - backend.api
-      - infra.postgres
-    recovery_action: fly_machines_start
-    recovery_params:
-      app: nuzantara-rag
-      process_group: api
-    severity_on_silence: warning
-    notes:
-      R5 Phase 5 — KG LangGraph fast-path organ. Bypasses vector search for entity-heavy
-      queries when subgraph available.
-    cicatrix_refs: []
-  - id: backend.crm.drive_poll
-    runtime: pro_launchd
-    type: cron
-    enabled: false
-    disabled_reason:
-      DISABLED 2026-04-29 in crontab after drive_poll saturated PG; keep
-      registered as disabled until explicitly restored.
-    expected_hb_seconds: 360
-    owner_module: scripts/openclaw-cron/drive-poll.sh
-    dependencies:
-      - infra.postgres
-      - backend.api
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.nuzantara.drive-poll
-    severity_on_silence: warning
-    cicatrix_refs:
-      - 2026-04-29-drive-poll-attribute-error
-    bridge_source:
-      type: state_file
-      path: ~/.agent/decisions/state/drive_poll.last.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.claude_max_watcher
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 3600
-    owner_module: scripts/claude-max-usage-watcher.py
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.nuzantara.claude-max-usage-watcher
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.claude/usage-watcher/last_run.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.login_healthcheck
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 900
-    owner_module: scripts/login-healthcheck.sh
-    dependencies:
-      - backend.api
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.nuzantara.login-healthcheck
-    severity_on_silence: critical
-    cicatrix_refs:
-      - 2026-04-29-startup-failed-mask
-    bridge_source:
-      type: state_file
-      path: ~/.agent/decisions/state/login_healthcheck.last.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.fly_restart_loop_detector
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 1350
-    owner_module: scripts/fly-restart-loop-detector.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.nuzantara.fly-restart-loop-detector
-    severity_on_silence: critical
-    cicatrix_refs:
-      - 2026-04-29-drive-poll-attribute-error
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.fly_restart_loop_detector.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.cpu_monitor
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 1350
-    owner_module: scripts/cpu-monitor.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.nuzantara.cpu-monitor
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.cpu_monitor.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.disk_monitor
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 1350
-    owner_module: scripts/disk-monitor.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.nuzantara.disk-monitor
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.disk_monitor.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.zombie_hunter
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90
-    owner_module: .claude/scripts/zombie-hunter.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.nuzantara.zombie-hunter
-    severity_on_silence: warning
-    cicatrix_refs:
-      - 2026-04-29-untracked-files-lost
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.zombie_hunter.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.dlq_autopilot
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 2700
-    owner_module: scripts/dlq_autopilot.py
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.nuzantara.dlq-autopilot
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.dlq_autopilot.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.sentinel
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/nuzantara-sentinel.py
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.nuzantara.sentinel
-    severity_on_silence: critical
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.sentinel.json
-      timestamp_field: ts
-      status_field: status
-  - id: cell.organism
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 90
-    owner_module: apps/cell/cell/main.py
-    dependencies:
-      - infra.postgres
-      - infra.redis
-    recovery_action: human_only
-    recovery_params:
-      label: com.cell.organism
-    severity_on_silence: critical
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/cell.organism.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.metabolic_rollup
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/metabolic_rollup_pro.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.cell.metabolic-rollup
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.metabolic_rollup.json
-      timestamp_field: ts
-      status_field: status
-  - id: channel.whatsapp
-    runtime: fly_machine
-    type: webhook
-    expected_hb_seconds: 120
-    owner_module: apps/backend-rag/backend/channels/whatsapp
-    dependencies:
-      - backend.api
-    recovery_action: fly_machines_start
-    recovery_params:
-      app: nuzantara-rag
-      process_group: api
-    severity_on_silence: critical
-    cicatrix_refs: []
-    bridge_source:
-      type: http
-      path: https://kita.balizero.com/api/channels/health-public
-      timestamp_field: ts
-      json_path: channels.whatsapp.status
-  - id: channel.telegram
-    runtime: fly_machine
-    type: webhook
-    expected_hb_seconds: 120
-    owner_module: apps/backend-rag/backend/channels/telegram
-    dependencies:
-      - backend.api
-    recovery_action: fly_machines_start
-    recovery_params:
-      app: nuzantara-rag
-      process_group: api
-    severity_on_silence: critical
-    cicatrix_refs: []
-    bridge_source:
-      type: http
-      path: https://kita.balizero.com/api/channels/health-public
-      timestamp_field: ts
-      json_path: channels.telegram.status
-  - id: channel.instagram
-    runtime: fly_machine
-    type: webhook
-    expected_hb_seconds: 120
-    owner_module: apps/backend-rag/backend/channels/instagram
-    dependencies:
-      - backend.api
-    recovery_action: fly_machines_start
-    recovery_params:
-      app: nuzantara-rag
-      process_group: api
-    severity_on_silence: critical
-    cicatrix_refs: []
-    bridge_source:
-      type: http
-      path: https://kita.balizero.com/api/channels/health-public
-      timestamp_field: ts
-      json_path: channels.instagram.status
-  - id: channel.web
-    runtime: fly_machine
-    type: webhook
-    expected_hb_seconds: 120
-    owner_module: apps/backend-rag/backend/channels/web
-    dependencies:
-      - backend.api
-    recovery_action: fly_machines_start
-    recovery_params:
-      app: nuzantara-rag
-      process_group: api
-    severity_on_silence: critical
-    cicatrix_refs: []
-    bridge_source:
-      type: http
-      path: https://kita.balizero.com/api/channels/health-public
-      timestamp_field: ts
-      json_path: channels.web.status
-  - id: pro.intel_nightly
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/bali-intel-scraper/scripts/run_intel_pipeline.py
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.balizero.intel.nightly
-    severity_on_silence: warning
-    cicatrix_refs: []
-    # A2 Heartbeat-Semantico opt-in (first pilot, 2026-06-23). The nightly intel job
-    # EXISTS to add scraped articles; its output artifact's CONTENT grows on real work.
-    # A2 flags 'starved' if the artifact's [size, sha256] is unchanged across
-    # STARVED_TICKS=3 ticks — i.e. 3 consecutive nights of ZERO new articles, a real
-    # stall the bare heartbeat (ts fresh + status ok) cannot see. CONTENT-hash, not
-    # mtime: run_intel_pipeline.py rewrites published_articles.json UNCONDITIONALLY even
-    # on a zero-article night (L1899), so an mtime signal would re-stamp every tick and
-    # NEVER starve — hashing the content makes an unchanged rewrite a non-advance (the
-    # green!=working trap, corrected in _progress_value). CAVEAT (operator-accepted):
-    # repo-tracked, so a real content edit resets the streak — unlikely over 3 nights.
-    output_artifact: ~/Desktop/nuzantara/apps/bali-intel-scraper/data/published_articles.json
-    bridge_source:
-      type: state_file
-      path: ~/.agent/decisions/state/intel_scraper.last.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.translate_hourly
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 5400
-    owner_module: scripts/translate-articles.py
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.balizero.translate.hourly
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.translate_hourly.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.renewal_alerts
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/openclaw-cron/renewal-alerts.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.balizero.renewal-alerts
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.agent/decisions/state/expiry_alerter.last.json
-      timestamp_field: ts
-      status_field: status
-  - id: wr2.supervisor
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 300
-    owner_module: scripts/wr2_supervisor.py
-    dependencies:
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.balizero.wr2.supervisor
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/wr2.supervisor.json
-      timestamp_field: ts
-      status_field: status
-  - id: wr2.oracle
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 1209600
-    owner_module: backend.services.cognitive.oracle_cli
-    dependencies:
-      - infra.postgres
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.balizero.wr2.oracle
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/wr2.oracle.json
-      timestamp_field: ts
-      status_field: status
-  - id: wr2.newsletter
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 1209600
-    owner_module: backend.services.newsletter.newsletter_cli
-    dependencies:
-      - infra.postgres
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.balizero.wr2.newsletter
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/wr2.newsletter.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.organism_control_panel
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 120
-    owner_module: apps/organism/organism/control_panel.py
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.nuzantara.organism.control-panel
-    severity_on_silence: critical
-    cicatrix_refs: []
-    bridge_source:
-      type: http
-      path: http://127.0.0.1:1819/health
-      timestamp_field: ts
-      json_path: status
-  - id: mata_garuda.watcher_daily.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/mata-garuda/scripts/run_watcher.sh
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.watcher.daily
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.reg_alert_30min.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 5400
-    owner_module: apps/mata-garuda/scripts/run_regulation_alert.py
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.reg-alert.30min
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.kg_linker.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 7200
-    owner_module: apps/mata-garuda/mata_garuda/workers/kg_linker.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.kg-linker
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.wr_topic.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 691200
-    owner_module: apps/mata-garuda/scripts/run_wr_topic.py
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.wr-topic
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.wr2_bridge_hourly.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 7200
-    owner_module: apps/mata-garuda/scripts/run_wr2_bridge.py
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.wr2-bridge
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.bridge_adaptive.pro
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 180
-    owner_module: apps/mata-garuda/scripts/run_bridge_adaptive.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.bridge.adaptive
-    severity_on_silence: error
-    cicatrix_refs: []
-  - id: mata_garuda.sentinel_daily.mini
-    runtime: mini_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/mata-garuda/scripts/run_sentinel.py
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: mini
-      label: com.matagaruda.sentinel.daily
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.intel_bridge_daily.mini
-    runtime: mini_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/mata-garuda/scripts/run_intel_bridge.py
-    dependencies:
-      - infra.redis
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: mini
-      label: com.matagaruda.intel-bridge.daily
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.daily_briefing.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/mata-garuda/scripts/run_daily_briefing.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.daily-briefing
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.kita_feed_daily.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/mata-garuda/scripts/run_kita_feed.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.kita-feed
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.public_channel.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/mata-garuda/scripts/run_public_channel.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.public-channel
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.weekly_digest.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 691200
-    owner_module: apps/mata-garuda/scripts/run_weekly_digest.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.weekly-digest
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.gap_consumer.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 4200
-    owner_module: apps/mata-garuda/mata_garuda/workers/gap_consumer.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.gap.consumer
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.invalidation_sweep.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/mata-garuda/scripts/run_invalidation_sweep.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.invalidation-sweep
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.nlm_feeder_stream_hourly.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 7200
-    owner_module: apps/mata-garuda/mata_garuda/workers/nlm_feeder.py
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.nlm-feeder-stream.hourly
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.nlm_expander_weekly.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 691200
-    owner_module: apps/mata-garuda/scripts/run_nlm_expander.py
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.nlm-expander.weekly
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.ner_worker_hourly.mini
-    runtime: mini_launchd
-    type: cron
-    expected_hb_seconds: 7200
-    owner_module: apps/mata-garuda/mata_garuda/workers/ner_worker.py
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: mini
-      label: com.matagaruda.ner-worker.hourly
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.normalizer_hourly.mini
-    runtime: mini_launchd
-    type: cron
-    expected_hb_seconds: 7200
-    owner_module: apps/mata-garuda/mata_garuda/workers/normalizer.py
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: mini
-      label: com.matagaruda.normalizer.hourly
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.canva_apply
-    runtime: pro_launchd
-    type: daemon
-    enabled: false
-    disabled_reason: Superseded by S12; LaunchAgent archived as .disabled-2026-05-09-superseded-by-S12.
-    expected_hb_seconds: 600
-    owner_module: apps/war-room/scripts/wr2_canva_apply.py
-    dependencies:
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.canva-apply
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.connector
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/war-room/scripts/wr2_connector.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.connector
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.dossier_compiler
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/war-room/scripts/wr2_dossier_compiler.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.dossier-compiler
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.draft_generator
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 600
-    owner_module: apps/war-room/scripts/wr2_draft_generator.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.draft-generator
-    severity_on_silence: error
-    cicatrix_refs: []
-  - id: wr2.hardening
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 600
-    owner_module: apps/war-room/scripts/wr2_hardening.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.hardening
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.image_generator
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 600
-    owner_module: apps/war-room/scripts/wr2_image_generator.py
-    dependencies:
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.image-generator
-    severity_on_silence: error
-    cicatrix_refs: []
-  - id: wr2.learner_nightly
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/war-room/scripts/wr2_learner_nightly.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.learner-nightly
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.measurer
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 600
-    owner_module: apps/war-room/scripts/wr2_measurer.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.measurer
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.pg_proxy
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 60
-    owner_module: apps/war-room/scripts/wr2_pg_proxy.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.pg-proxy
-    severity_on_silence: critical
-    cicatrix_refs: []
-  - id: wr2.sla_worker
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 600
-    owner_module: apps/war-room/scripts/wr2_sla_worker.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.sla-worker
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.strategos
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 691200
-    owner_module: apps/war-room/scripts/wr2_strategos.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.strategos
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.topic_selector
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/war-room/scripts/wr2_topic_selector.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.topic-selector
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.trend_hunter
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 600
-    owner_module: apps/war-room/scripts/wr2_trend_hunter.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.trend-hunter
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.codex_autofix_ci
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 7200
-    owner_module: scripts/codex/codex_autofix_ci.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.codex-autofix-ci
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: pro.codex_overnight_runner
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/codex/codex_overnight_runner.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.codex-overnight-runner
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: pro.cost_advisor_daily_cap
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/cost-advisor/daily_cap.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.cost-advisor-daily-cap
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.openclaw_children_watchdog
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 3900
-    owner_module: scripts/openclaw-children-watchdog.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.openclaw-children-watchdog
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.nb_intel_delta_watcher
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 7200
-    owner_module: scripts/nb-intel-delta-watcher.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.nb-intel-delta-watcher.hourly
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.sentinel_meta_watchdog
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 4200
-    owner_module: scripts/sentinel-meta-watchdog.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.sentinel-meta-watchdog
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.federation_alert_dispatcher
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 180
-    owner_module: scripts/federation-alert-dispatcher.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.federation-alert-dispatcher
-    severity_on_silence: error
-    cicatrix_refs: []
-  - id: pro.secrets_sync_mini
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/mini-setup/secrets-sync-mini.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.secrets-sync-mini
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: nlm.bridge
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 180
-    owner_module: apps/nlm-bridge/main.py
-    dependencies:
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.nlm-bridge
-    severity_on_silence: critical
-    notes:
-      "R5 Phase 6 (2026-05-17): RAG pipeline no longer routes through NLM. Bridge
-      kept for NAGA agent (non-RAG NLM queries) and human-facing NLM UI. Severity critical
-      unchanged — NAGA depends on it."
-    cicatrix_refs: []
-  - id: cell.observatory
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 90
-    owner_module: apps/cell-observatory-collector/cell_observatory/__main__.py
-    dependencies:
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.cell-observatory
-    severity_on_silence: critical
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/cell.observatory.json
-      timestamp_field: ts
-      status_field: status
-  - id: cell.observatory_prune
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/cell-observatory-collector/cell_observatory/prune.py
-    dependencies:
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.cell-observatory-prune
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: cell.observatory_selfcheck
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 3900
-    owner_module: apps/cell-observatory-collector/scripts/healthcheck.sh
-    dependencies:
-      - cell.observatory
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.cell-observatory-selfcheck
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.post_publish_poller
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/bali-intel-scraper/scripts/post_publish_poller.py
-    dependencies:
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.post-publish-poller
-    severity_on_silence: error
-    cicatrix_refs: []
-  - id: sota.m13_checkpoint
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/backend-rag/backend/services/sota_loop/m13_checkpoint.py
-    dependencies:
-      - infra.postgres
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.sota.m13-checkpoint
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: sota.m13_collect
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/backend-rag/backend/services/sota_loop/m13_collect.py
-    dependencies:
-      - infra.postgres
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.sota.m13-collect
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: sota.m13_monthly
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 2678400
-    owner_module: apps/backend-rag/backend/services/sota_loop/m13_monthly.py
-    dependencies:
-      - infra.postgres
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.sota.m13-monthly
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: sota.m13_weekly
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 691200
-    owner_module: apps/backend-rag/backend/services/sota_loop/m13_weekly.py
-    dependencies:
-      - infra.postgres
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.sota.m13-weekly
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.canva_oauth_watchdog
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 3600
-    owner_module: scripts/wr2-canva-oauth-watchdog.sh
-    dependencies:
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.canva-oauth-watchdog
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.deploy_puller
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 600
-    owner_module: scripts/wr2-deploy-pull.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.deploy-puller
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.fact_checker
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 1800
-    owner_module: apps/war-room/scripts/wr2_fact_checker.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.fact-checker
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.fact_extractor
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 1800
-    owner_module: apps/war-room/scripts/wr2_fact_extractor.py
-    # A2 Heartbeat Semantico (self-loop Anello 2). fact_extractor appends ONE JSONL
-    # line per successfully fact-checked draft and writes NOTHING on a no-work run
-    # (no ready drafts -> early return BEFORE _log_telemetry). So a frozen [size,sha256]
-    # across STARVED_TICKS=3 ticks = 3 consecutive runs that fact-checked zero drafts
-    # while the cron still fires green — the green!=working stall the bare heartbeat
-    # (ts fresh + status ok) cannot see. CONTENT-hash, not mtime: per-line work ts
-    # only, no top-level run-timestamp, so an unchanged file stays byte-identical.
-    output_artifact: ~/logs/wr2_fact_extractor_telemetry.jsonl
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.fact-extractor
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.ig_scraper_daily
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: .claude/skills/bali-zero-brand/_ig-metrics-scraper.py
-    dependencies:
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.ig-scraper.daily
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: wr2.queue_server
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 300
-    owner_module: .claude/skills/bali-zero-brand/_damar-queue-server.py
-    dependencies:
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.queue-server
-    severity_on_silence: error
-    cicatrix_refs: []
-  - id: wr2.reflexion_weekly
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 691200
-    owner_module: .claude/skills/bali-zero-brand/_reflexion-synthesis.py
-    dependencies:
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.reflexion.weekly
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: wr2.supervisor_watchdog
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 600
-    owner_module: apps/war-room/scripts/wr2_supervisor_watchdog.py
-    dependencies:
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.supervisor-watchdog
-    severity_on_silence: critical
-    cicatrix_refs: []
-  - id: wr2.voyager_weekly
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 691200
-    owner_module: .claude/skills/bali-zero-brand/_voyager-curriculum.py
-    dependencies:
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.voyager.weekly
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: codex.spalla_calibrate
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/codex-spalla-calibrate.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.codex-spalla-calibrate
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: codex.coverage_improver
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/codex-nightly-coverage-improver.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.codex-coverage-improver
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: codex.overnight_feeder
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/codex-overnight-queue-feeder.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.codex-overnight-feeder
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: codex.research_actor
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/codex-daily-research-actor.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.codex-research-actor
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: pro.cost_advisor_weekly
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 691200
-    owner_module: apps/backend-rag/backend/scripts/cost_advisor_cli.py
-    dependencies:
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.cost-advisor-weekly
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: pro.automap_server
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 300
-    owner_module: scripts/automap/automap_server.py
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.automap-server
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.automap_telegram
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 300
-    owner_module: scripts/automap/automap_telegram.py
-    dependencies:
-      - pro.automap_server
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.automap-telegram
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.automap_watchdog
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90
-    owner_module: scripts/automap/automap_watchdog.py
-    dependencies:
-      - pro.automap_server
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.automap-watchdog
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: organism.supervisor
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 120
-    owner_module: apps/organism/organism/supervisor/daemon.py
-    dependencies:
-      - infra.postgres
-    recovery_action: human_only
-    recovery_params:
-      host: pro
-      label: com.nuzantara.organism.supervisor
-    severity_on_silence: critical
-    cicatrix_refs: []
-  - id: organism.scheduled_tick
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 600
-    owner_module: apps/organism/organism/scheduled_tick.py
-    dependencies:
-      - organism.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.organism.scheduled-tick
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.heartbeat_bridge
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 120
-    owner_module: apps/cell/scripts/launch_heartbeat_bridge.sh
-    dependencies:
-      - infra.postgres
-      - cell.organism
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.heartbeat-bridge
-    severity_on_silence: critical
-    cicatrix_refs: []
-  - id: pro.launchagent_state_bridge
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 600
-    owner_module: scripts/launchagent-state-bridge.py
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.launchagent-state-bridge
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.supervisor_liveness_watchdog
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 900
-    owner_module: scripts/supervisor_liveness_watchdog.sh
-    dependencies:
-      - organism.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.supervisor-liveness-watchdog
-    severity_on_silence: critical
-    cicatrix_refs: []
-  - id: pro.memory_sync_bidirectional
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 600
-    owner_module: scripts/mini-setup/memory-sync-bidirectional.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.memory-sync-bidirectional
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.claude_config_sync
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/mini-setup/claude-config-sync.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.claude-config-sync
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: pro.indexing_sweep_daily
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/daily_indexing_cron_wrapper.sh
-    dependencies:
-      - infra.postgres
-      - infra.qdrant
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.indexing-sweep.daily
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.intel_radar_daily_digest
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/cron-agent-python/intel_radar_daily_digest.py
-    dependencies:
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.intel-radar-daily-digest
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.post_publish_webhook
-    runtime: pro_launchd
-    type: webhook
-    expected_hb_seconds: 300
-    owner_module: apps/bali-intel-scraper/scripts/post_publish_webhook.py
-    dependencies:
-      - backend.api
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.post-publish-webhook
-    severity_on_silence: error
-    cicatrix_refs: []
-  - id: pro.setup_team_daily
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: infra/scripts/setup-team-cron.sh
-    dependencies:
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.setup-team.daily
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.seo_cell_daily
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/openclaw-cron/seo-cell-daily.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.seo-cell.daily
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.seo_cell_28d_check
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 2419200
-    owner_module: scripts/openclaw-cron/seo-cell-28d-check.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.seo-cell.28d-check
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: pro.bz_daily_visual_pipeline
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/bz-daily-visual-pipeline.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.bz-daily-visual-pipeline
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.domain_mesh_foundations_daily
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/domain-mesh-foundations-cron.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.domain-mesh.foundations.daily
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: pro.client_value_predictor
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/openclaw-cron/client-value-predictor.sh
-    dependencies:
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.client-value-predictor
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: pro.automations_reference
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/generate-automations-all.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.automations-reference
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: pro.prime_tunnel
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 300
-    owner_module: cloudflared/config-prime.yml
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.prime-tunnel
-    severity_on_silence: error
-    cicatrix_refs: []
-  - id: pro.ollama_warm_pin
-    runtime: pro_launchd
-    type: cron
-    enabled: false
-    disabled_reason:
-      LaunchAgent archived from Pro on 2026-05-09; warm pin now runs
-      from crontab weekly after Ollama restart.
-    expected_hb_seconds: 900
-    owner_module: scripts/ollama-warm-pin.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.ollama-warm-pin
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.vector_reindex_check
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/vector-reindex-check.py
-    dependencies:
-      - infra.qdrant
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.vector-reindex-check
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.launchd_env_loader
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/launchd_env_loader.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.launchd-env-loader
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: pro.openclaw_logrotate
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/openclaw-logrotate.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.openclaw-logrotate
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: pro.nb_mitochondrial_monitor_daily
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/mata-garuda/mata_garuda/scripts/nb_monitor/run.py
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.nb-mitochondrial-monitor.daily
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.regulatory_watcher_daily
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/regulatory-watcher-run.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.regulatory-watcher.daily
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.pg_organism_bridge
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 120
-    owner_module: scripts/pg-to-organism-bridge.py
-    dependencies:
-      - infra.postgres
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.pg-organism-bridge
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.pg_organism_bridge.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.sentinel_aggregate
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 600
-    owner_module: scripts/sentinel-aggregate.py
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.sentinel-aggregate
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.sentinel_aggregate.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.outbox_prune_daily
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/outbox-prune.sh
-    dependencies:
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.outbox-prune.daily
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.outbox_prune_daily.json
-      timestamp_field: ts
-      status_field: status
+- id: infra.postgres
+  runtime: fly_machine
+  type: daemon
+  expected_hb_seconds: 0
+  owner_module: infra/fly/nuzantara-postgres
+  dependencies: []
+  recovery_action: fly_machines_start
+  recovery_params:
+    app: nuzantara-postgres
+  severity_on_silence: critical
+  cicatrix_refs: []
+- id: infra.redis
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 0
+  owner_module: brew/redis
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: homebrew.mxcl.redis
+  severity_on_silence: critical
+  cicatrix_refs: []
+- id: infra.qdrant
+  runtime: fly_machine
+  type: daemon
+  expected_hb_seconds: 0
+  owner_module: infra/fly/nuzantara-qdrant
+  dependencies: []
+  recovery_action: fly_machines_start
+  recovery_params:
+    app: nuzantara-qdrant
+  severity_on_silence: critical
+  cicatrix_refs: []
+- id: backend.api
+  runtime: fly_machine
+  type: webhook
+  expected_hb_seconds: 60
+  owner_module: apps/backend-rag/backend/app/main.py
+  dependencies:
+  - infra.postgres
+  - infra.redis
+  - infra.qdrant
+  recovery_action: fly_machines_start
+  recovery_params:
+    app: nuzantara-rag
+    process_group: api
+  severity_on_silence: critical
+  cicatrix_refs:
+  - 2026-04-29-startup-failed-mask
+  - 2026-04-29-drive-poll-attribute-error
+- id: backend.surface_router
+  runtime: fly_machine
+  type: daemon
+  expected_hb_seconds: 60
+  owner_module: apps/backend-rag/backend/services/routing/surface_router.py
+  dependencies:
+  - backend.api
+  - infra.postgres
+  recovery_action: fly_machines_start
+  recovery_params:
+    app: nuzantara-rag
+    process_group: api
+  severity_on_silence: warning
+  notes: R5 Phase 3 — in-process routing organ. Routes queries to KG vs vector vs
+    NLM. Always-on since Phase 3 deploy.
+  cicatrix_refs: []
+- id: backend.kg_langgraph_orchestrator
+  runtime: fly_machine
+  type: daemon
+  enabled: false
+  disabled_reason: 'R5 Phase 5: feature-flagged via ENABLE_KG_LANGGRAPH=false (default).
+    Enable via fly secrets set ENABLE_KG_LANGGRAPH=1 on nuzantara-rag. Fast-path wired
+    in OrchestratorCore._try_kg_fast_path() — safe to enable per domain.'
+  expected_hb_seconds: 60
+  owner_module: apps/backend-rag/backend/services/rag/kg_langgraph_orchestrator.py
+  dependencies:
+  - backend.api
+  - infra.postgres
+  recovery_action: fly_machines_start
+  recovery_params:
+    app: nuzantara-rag
+    process_group: api
+  severity_on_silence: warning
+  notes: R5 Phase 5 — KG LangGraph fast-path organ. Bypasses vector search for entity-heavy
+    queries when subgraph available.
+  cicatrix_refs: []
+- id: backend.crm.drive_poll
+  runtime: pro_launchd
+  type: cron
+  enabled: false
+  disabled_reason: DISABLED 2026-04-29 in crontab after drive_poll saturated PG; keep
+    registered as disabled until explicitly restored.
+  expected_hb_seconds: 360
+  owner_module: scripts/openclaw-cron/drive-poll.sh
+  dependencies:
+  - infra.postgres
+  - backend.api
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.drive-poll
+  severity_on_silence: warning
+  cicatrix_refs:
+  - 2026-04-29-drive-poll-attribute-error
+  bridge_source:
+    type: state_file
+    path: ~/.agent/decisions/state/drive_poll.last.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.claude_max_watcher
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 3600
+  owner_module: scripts/claude-max-usage-watcher.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.claude-max-usage-watcher
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.claude/usage-watcher/last_run.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.login_healthcheck
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 900
+  owner_module: scripts/login-healthcheck.sh
+  dependencies:
+  - backend.api
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.login-healthcheck
+  severity_on_silence: critical
+  cicatrix_refs:
+  - 2026-04-29-startup-failed-mask
+  bridge_source:
+    type: state_file
+    path: ~/.agent/decisions/state/login_healthcheck.last.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.fly_restart_loop_detector
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 1350
+  owner_module: scripts/fly-restart-loop-detector.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.fly-restart-loop-detector
+  severity_on_silence: critical
+  cicatrix_refs:
+  - 2026-04-29-drive-poll-attribute-error
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.fly_restart_loop_detector.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.cpu_monitor
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 1350
+  owner_module: scripts/cpu-monitor.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.cpu-monitor
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.cpu_monitor.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.disk_monitor
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 1350
+  owner_module: scripts/disk-monitor.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.disk-monitor
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.disk_monitor.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.zombie_hunter
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90
+  owner_module: .claude/scripts/zombie-hunter.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.zombie-hunter
+  severity_on_silence: warning
+  cicatrix_refs:
+  - 2026-04-29-untracked-files-lost
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.zombie_hunter.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.dlq_autopilot
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 2700
+  owner_module: scripts/dlq_autopilot.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.dlq-autopilot
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.dlq_autopilot.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.sentinel
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/nuzantara-sentinel.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.sentinel
+  severity_on_silence: critical
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.sentinel.json
+    timestamp_field: ts
+    status_field: status
+- id: cell.organism
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 90
+  owner_module: apps/cell/cell/main.py
+  dependencies:
+  - infra.postgres
+  - infra.redis
+  recovery_action: human_only
+  recovery_params:
+    label: com.cell.organism
+  severity_on_silence: critical
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/cell.organism.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.metabolic_rollup
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/metabolic_rollup_pro.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.cell.metabolic-rollup
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.metabolic_rollup.json
+    timestamp_field: ts
+    status_field: status
+- id: channel.whatsapp
+  runtime: fly_machine
+  type: webhook
+  expected_hb_seconds: 120
+  owner_module: apps/backend-rag/backend/channels/whatsapp
+  dependencies:
+  - backend.api
+  recovery_action: fly_machines_start
+  recovery_params:
+    app: nuzantara-rag
+    process_group: api
+  severity_on_silence: critical
+  cicatrix_refs: []
+  bridge_source:
+    type: http
+    path: https://kita.balizero.com/api/channels/health-public
+    timestamp_field: ts
+    json_path: channels.whatsapp.status
+- id: channel.telegram
+  runtime: fly_machine
+  type: webhook
+  expected_hb_seconds: 120
+  owner_module: apps/backend-rag/backend/channels/telegram
+  dependencies:
+  - backend.api
+  recovery_action: fly_machines_start
+  recovery_params:
+    app: nuzantara-rag
+    process_group: api
+  severity_on_silence: critical
+  cicatrix_refs: []
+  bridge_source:
+    type: http
+    path: https://kita.balizero.com/api/channels/health-public
+    timestamp_field: ts
+    json_path: channels.telegram.status
+- id: channel.instagram
+  runtime: fly_machine
+  type: webhook
+  expected_hb_seconds: 120
+  owner_module: apps/backend-rag/backend/channels/instagram
+  dependencies:
+  - backend.api
+  recovery_action: fly_machines_start
+  recovery_params:
+    app: nuzantara-rag
+    process_group: api
+  severity_on_silence: critical
+  cicatrix_refs: []
+  bridge_source:
+    type: http
+    path: https://kita.balizero.com/api/channels/health-public
+    timestamp_field: ts
+    json_path: channels.instagram.status
+- id: channel.web
+  runtime: fly_machine
+  type: webhook
+  expected_hb_seconds: 120
+  owner_module: apps/backend-rag/backend/channels/web
+  dependencies:
+  - backend.api
+  recovery_action: fly_machines_start
+  recovery_params:
+    app: nuzantara-rag
+    process_group: api
+  severity_on_silence: critical
+  cicatrix_refs: []
+  bridge_source:
+    type: http
+    path: https://kita.balizero.com/api/channels/health-public
+    timestamp_field: ts
+    json_path: channels.web.status
+- id: pro.intel_nightly
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/bali-intel-scraper/scripts/run_intel_pipeline.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.balizero.intel.nightly
+  severity_on_silence: warning
+  cicatrix_refs: []
+  starved_after_periods: 2
+  output_artifact: ~/Desktop/nuzantara/apps/bali-intel-scraper/data/published_articles.json
+  bridge_source:
+    type: state_file
+    path: ~/.agent/decisions/state/intel_scraper.last.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.translate_hourly
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 5400
+  owner_module: scripts/translate-articles.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.balizero.translate.hourly
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.translate_hourly.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.renewal_alerts
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/openclaw-cron/renewal-alerts.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.balizero.renewal-alerts
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.agent/decisions/state/expiry_alerter.last.json
+    timestamp_field: ts
+    status_field: status
+- id: wr2.supervisor
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 300
+  owner_module: scripts/wr2_supervisor.py
+  dependencies:
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.balizero.wr2.supervisor
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/wr2.supervisor.json
+    timestamp_field: ts
+    status_field: status
+- id: wr2.oracle
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 1209600
+  owner_module: backend.services.cognitive.oracle_cli
+  dependencies:
+  - infra.postgres
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.balizero.wr2.oracle
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/wr2.oracle.json
+    timestamp_field: ts
+    status_field: status
+- id: wr2.newsletter
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 1209600
+  owner_module: backend.services.newsletter.newsletter_cli
+  dependencies:
+  - infra.postgres
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.balizero.wr2.newsletter
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/wr2.newsletter.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.organism_control_panel
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 120
+  owner_module: apps/organism/organism/control_panel.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.organism.control-panel
+  severity_on_silence: critical
+  cicatrix_refs: []
+  bridge_source:
+    type: http
+    path: http://127.0.0.1:1819/health
+    timestamp_field: ts
+    json_path: status
+- id: mata_garuda.watcher_daily.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/mata-garuda/scripts/run_watcher.sh
+  dependencies:
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.watcher.daily
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.reg_alert_30min.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 5400
+  owner_module: apps/mata-garuda/scripts/run_regulation_alert.py
+  dependencies:
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.reg-alert.30min
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.kg_linker.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 7200
+  owner_module: apps/mata-garuda/mata_garuda/workers/kg_linker.py
+  dependencies:
+  - infra.redis
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.kg-linker
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.wr_topic.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 691200
+  owner_module: apps/mata-garuda/scripts/run_wr_topic.py
+  dependencies:
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.wr-topic
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.wr2_bridge_hourly.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 7200
+  owner_module: apps/mata-garuda/scripts/run_wr2_bridge.py
+  dependencies:
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.wr2-bridge
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.bridge_adaptive.pro
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 180
+  owner_module: apps/mata-garuda/scripts/run_bridge_adaptive.py
+  dependencies:
+  - infra.redis
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.bridge.adaptive
+  severity_on_silence: error
+  cicatrix_refs: []
+- id: mata_garuda.sentinel_daily.mini
+  runtime: mini_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/mata-garuda/scripts/run_sentinel.py
+  dependencies:
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: mini
+    label: com.matagaruda.sentinel.daily
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.intel_bridge_daily.mini
+  runtime: mini_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/mata-garuda/scripts/run_intel_bridge.py
+  dependencies:
+  - infra.redis
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: mini
+    label: com.matagaruda.intel-bridge.daily
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.daily_briefing.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/mata-garuda/scripts/run_daily_briefing.py
+  dependencies:
+  - infra.redis
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.daily-briefing
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.kita_feed_daily.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/mata-garuda/scripts/run_kita_feed.py
+  dependencies:
+  - infra.redis
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.kita-feed
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.public_channel.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/mata-garuda/scripts/run_public_channel.py
+  dependencies:
+  - infra.redis
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.public-channel
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.weekly_digest.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 691200
+  owner_module: apps/mata-garuda/scripts/run_weekly_digest.py
+  dependencies:
+  - infra.redis
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.weekly-digest
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.gap_consumer.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 4200
+  owner_module: apps/mata-garuda/mata_garuda/workers/gap_consumer.py
+  dependencies:
+  - infra.redis
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.gap.consumer
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.invalidation_sweep.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/mata-garuda/scripts/run_invalidation_sweep.py
+  dependencies:
+  - infra.redis
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.invalidation-sweep
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.nlm_feeder_stream_hourly.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 7200
+  owner_module: apps/mata-garuda/mata_garuda/workers/nlm_feeder.py
+  dependencies:
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.nlm-feeder-stream.hourly
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.nlm_expander_weekly.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 691200
+  owner_module: apps/mata-garuda/scripts/run_nlm_expander.py
+  dependencies:
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.nlm-expander.weekly
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.ner_worker_hourly.mini
+  runtime: mini_launchd
+  type: cron
+  expected_hb_seconds: 7200
+  owner_module: apps/mata-garuda/mata_garuda/workers/ner_worker.py
+  dependencies:
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: mini
+    label: com.matagaruda.ner-worker.hourly
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.normalizer_hourly.mini
+  runtime: mini_launchd
+  type: cron
+  expected_hb_seconds: 7200
+  owner_module: apps/mata-garuda/mata_garuda/workers/normalizer.py
+  dependencies:
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: mini
+    label: com.matagaruda.normalizer.hourly
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.canva_apply
+  runtime: pro_launchd
+  type: daemon
+  enabled: false
+  disabled_reason: Superseded by S12; LaunchAgent archived as .disabled-2026-05-09-superseded-by-S12.
+  expected_hb_seconds: 600
+  owner_module: apps/war-room/scripts/wr2_canva_apply.py
+  dependencies:
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.canva-apply
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.connector
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/war-room/scripts/wr2_connector.py
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.connector
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.dossier_compiler
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/war-room/scripts/wr2_dossier_compiler.py
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.dossier-compiler
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.draft_generator
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 600
+  owner_module: scripts/wr2_draft_generator.py
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.draft-generator
+  severity_on_silence: error
+  cicatrix_refs: []
+- id: wr2.hardening
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 600
+  owner_module: apps/war-room/scripts/wr2_hardening.py
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.hardening
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.image_generator
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 600
+  owner_module: scripts/wr2_image_generator.py
+  dependencies:
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.image-generator
+  severity_on_silence: error
+  cicatrix_refs: []
+- id: wr2.learner_nightly
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/war-room/scripts/wr2_learner_nightly.py
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.learner-nightly
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.measurer
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 600
+  owner_module: apps/war-room/scripts/wr2_measurer.py
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.measurer
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.pg_proxy
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 60
+  owner_module: apps/war-room/scripts/wr2_pg_proxy.py
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.pg-proxy
+  severity_on_silence: critical
+  cicatrix_refs: []
+- id: wr2.sla_worker
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 600
+  owner_module: apps/war-room/scripts/wr2_sla_worker.py
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.sla-worker
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.strategos
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 691200
+  owner_module: apps/war-room/scripts/wr2_strategos.py
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.strategos
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.topic_selector
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/wr2_topic_selector.py
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.topic-selector
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.trend_hunter
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 600
+  owner_module: apps/war-room/scripts/wr2_trend_hunter.py
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.trend-hunter
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.codex_autofix_ci
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 7200
+  owner_module: scripts/codex/codex_autofix_ci.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.codex-autofix-ci
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: pro.codex_overnight_runner
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/codex/codex_overnight_runner.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.codex-overnight-runner
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: pro.cost_advisor_daily_cap
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/cost-advisor/daily_cap.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.cost-advisor-daily-cap
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.openclaw_children_watchdog
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 3900
+  owner_module: scripts/openclaw-children-watchdog.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.openclaw-children-watchdog
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.nb_intel_delta_watcher
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 7200
+  owner_module: scripts/nb-intel-delta-watcher.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.nb-intel-delta-watcher.hourly
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.sentinel_meta_watchdog
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 4200
+  owner_module: scripts/sentinel-meta-watchdog.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.sentinel-meta-watchdog
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.federation_alert_dispatcher
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 180
+  owner_module: scripts/federation-alert-dispatcher.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.federation-alert-dispatcher
+  severity_on_silence: error
+  cicatrix_refs: []
+- id: pro.secrets_sync_mini
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/mini-setup/secrets-sync-mini.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.secrets-sync-mini
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: nlm.bridge
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 180
+  owner_module: apps/nlm-bridge/main.py
+  dependencies:
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.nlm-bridge
+  severity_on_silence: critical
+  notes: 'R5 Phase 6 (2026-05-17): RAG pipeline no longer routes through NLM. Bridge
+    kept for NAGA agent (non-RAG NLM queries) and human-facing NLM UI. Severity critical
+    unchanged — NAGA depends on it.'
+  cicatrix_refs: []
+- id: cell.observatory
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 90
+  owner_module: apps/cell-observatory-collector/cell_observatory/__main__.py
+  dependencies:
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.cell-observatory
+  severity_on_silence: critical
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/cell.observatory.json
+    timestamp_field: ts
+    status_field: status
+- id: cell.observatory_prune
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/cell-observatory-collector/cell_observatory/prune.py
+  dependencies:
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.cell-observatory-prune
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: cell.observatory_selfcheck
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 3900
+  owner_module: apps/cell-observatory-collector/scripts/healthcheck.sh
+  dependencies:
+  - cell.observatory
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.cell-observatory-selfcheck
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.post_publish_poller
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/bali-intel-scraper/scripts/post_publish_poller.py
+  dependencies:
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.post-publish-poller
+  severity_on_silence: error
+  cicatrix_refs: []
+- id: sota.m13_checkpoint
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/backend-rag/backend/services/sota_loop/m13_checkpoint.py
+  dependencies:
+  - infra.postgres
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.sota.m13-checkpoint
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: sota.m13_collect
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/backend-rag/backend/services/sota_loop/m13_collect.py
+  dependencies:
+  - infra.postgres
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.sota.m13-collect
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: sota.m13_monthly
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 2678400
+  owner_module: apps/backend-rag/backend/services/sota_loop/m13_monthly.py
+  dependencies:
+  - infra.postgres
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.sota.m13-monthly
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: sota.m13_weekly
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 691200
+  owner_module: apps/backend-rag/backend/services/sota_loop/m13_weekly.py
+  dependencies:
+  - infra.postgres
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.sota.m13-weekly
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.canva_oauth_watchdog
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 3600
+  owner_module: scripts/wr2-canva-oauth-watchdog.sh
+  dependencies:
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.canva-oauth-watchdog
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.deploy_puller
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 600
+  owner_module: scripts/wr2-deploy-pull.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.deploy-puller
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.fact_checker
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 1800
+  owner_module: scripts/wr2_fact_checker.py
+  starved_after_periods: 2
+  output_artifact: ~/logs/wr2_fact_checker_telemetry.jsonl
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.fact-checker
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.fact_extractor
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 1800
+  owner_module: scripts/wr2_fact_extractor.py
+  starved_after_periods: 2
+  output_artifact: ~/logs/wr2_fact_extractor_telemetry.jsonl
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.fact-extractor
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.ig_scraper_daily
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: skills/bali-zero-brand/_ig-metrics-scraper.py
+  dependencies:
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.ig-scraper.daily
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: wr2.queue_server
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 300
+  owner_module: skills/bali-zero-brand/_damar-queue-server.py
+  dependencies:
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.queue-server
+  severity_on_silence: error
+  cicatrix_refs: []
+- id: wr2.reflexion_weekly
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 691200
+  owner_module: .claude/skills/bali-zero-brand/_reflexion-synthesis.py
+  dependencies:
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.reflexion.weekly
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: wr2.supervisor_watchdog
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 600
+  owner_module: scripts/wr2_supervisor_watchdog.py
+  dependencies:
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.supervisor-watchdog
+  severity_on_silence: critical
+  cicatrix_refs: []
+- id: wr2.voyager_weekly
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 691200
+  owner_module: skills/bali-zero-brand/_voyager-curriculum.py
+  dependencies:
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.voyager.weekly
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: codex.spalla_calibrate
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/codex-spalla-calibrate.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.codex-spalla-calibrate
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: codex.coverage_improver
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/codex/codex-nightly-coverage-improver.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.codex-coverage-improver
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: codex.overnight_feeder
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/codex/codex-overnight-queue-feeder.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.codex-overnight-feeder
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: codex.research_actor
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/codex/codex-daily-research-actor.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.codex-research-actor
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: pro.cost_advisor_weekly
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 691200
+  owner_module: apps/backend-rag/backend/scripts/cost_advisor_cli.py
+  dependencies:
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.cost-advisor-weekly
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: pro.automap_server
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 300
+  owner_module: scripts/automap/automap_server.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.automap-server
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.automap_telegram
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 300
+  owner_module: scripts/automap/automap_telegram.py
+  dependencies:
+  - pro.automap_server
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.automap-telegram
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.automap_watchdog
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90
+  owner_module: scripts/automap/automap_watchdog.py
+  dependencies:
+  - pro.automap_server
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.automap-watchdog
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: organism.supervisor
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 120
+  owner_module: apps/organism/organism/supervisor/daemon.py
+  dependencies:
+  - infra.postgres
+  recovery_action: human_only
+  recovery_params:
+    host: pro
+    label: com.nuzantara.organism.supervisor
+  severity_on_silence: critical
+  cicatrix_refs: []
+- id: organism.scheduled_tick
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 600
+  owner_module: apps/organism/organism/scheduled_tick.py
+  dependencies:
+  - organism.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.organism.scheduled-tick
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.heartbeat_bridge
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 120
+  owner_module: apps/cell/scripts/launch_heartbeat_bridge.sh
+  dependencies:
+  - infra.postgres
+  - cell.organism
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.heartbeat-bridge
+  severity_on_silence: critical
+  cicatrix_refs: []
+- id: pro.launchagent_state_bridge
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 600
+  owner_module: scripts/launchagent-state-bridge.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.launchagent-state-bridge
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.supervisor_liveness_watchdog
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 900
+  owner_module: scripts/supervisor_liveness_watchdog.sh
+  dependencies:
+  - organism.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.supervisor-liveness-watchdog
+  severity_on_silence: critical
+  cicatrix_refs: []
+- id: pro.memory_sync_bidirectional
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 600
+  owner_module: infra/sync-daemons/memory-sync-bidirectional.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.memory-sync-bidirectional
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.claude_config_sync
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/mini-setup/claude-config-sync.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.claude-config-sync
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: pro.indexing_sweep_daily
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/daily_indexing_cron_wrapper.sh
+  dependencies:
+  - infra.postgres
+  - infra.qdrant
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.indexing-sweep.daily
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.intel_radar_daily_digest
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/cron-agent-python/intel_radar_daily_digest.py
+  dependencies:
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.intel-radar-daily-digest
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.post_publish_webhook
+  runtime: pro_launchd
+  type: webhook
+  expected_hb_seconds: 300
+  owner_module: apps/bali-intel-scraper/scripts/post_publish_webhook.py
+  dependencies:
+  - backend.api
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.post-publish-webhook
+  severity_on_silence: error
+  cicatrix_refs: []
+- id: pro.setup_team_daily
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: infra/scripts/setup-team-cron.sh
+  dependencies:
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.setup-team.daily
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.seo_cell_daily
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/openclaw-cron/seo-cell-daily.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.seo-cell.daily
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.seo_cell_28d_check
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 2419200
+  owner_module: scripts/openclaw-cron/seo-cell-28d-check.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.seo-cell.28d-check
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: pro.bz_daily_visual_pipeline
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/bz-daily-visual-pipeline.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.bz-daily-visual-pipeline
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.domain_mesh_foundations_daily
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: infra/scripts/domain-mesh-foundations-cron.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.domain-mesh.foundations.daily
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: pro.client_value_predictor
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/openclaw-cron/client-value-predictor.sh
+  dependencies:
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.client-value-predictor
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: pro.automations_reference
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/generate-automations-all.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.automations-reference
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: pro.prime_tunnel
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 300
+  owner_module: cloudflared/config-prime.yml
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.prime-tunnel
+  severity_on_silence: error
+  cicatrix_refs: []
+- id: pro.ollama_warm_pin
+  runtime: pro_launchd
+  type: cron
+  enabled: false
+  disabled_reason: LaunchAgent archived from Pro on 2026-05-09; warm pin now runs
+    from crontab weekly after Ollama restart.
+  expected_hb_seconds: 900
+  owner_module: scripts/ollama-warm-pin.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.ollama-warm-pin
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.vector_reindex_check
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/vector-reindex-check.py
+  dependencies:
+  - infra.qdrant
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.vector-reindex-check
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.launchd_env_loader
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/launchd_env_loader.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.launchd-env-loader
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: pro.openclaw_logrotate
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/openclaw-logrotate.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.openclaw-logrotate
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: pro.nb_mitochondrial_monitor_daily
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/mata-garuda/mata_garuda/scripts/nb_monitor/run.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.nb-mitochondrial-monitor.daily
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.regulatory_watcher_daily
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: infra/launchagents/wrappers/regulatory-watcher-run.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.regulatory-watcher.daily
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.pg_organism_bridge
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 120
+  owner_module: scripts/pg-to-organism-bridge.py
+  dependencies:
+  - infra.postgres
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.pg-organism-bridge
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.pg_organism_bridge.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.sentinel_aggregate
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 600
+  owner_module: scripts/sentinel-aggregate.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.sentinel-aggregate
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.sentinel_aggregate.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.outbox_prune_daily
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/outbox-prune.sh
+  dependencies:
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.outbox-prune.daily
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.outbox_prune_daily.json
+    timestamp_field: ts
+    status_field: status


### PR DESCRIPTION
## What
Builds on #1755 (frequency-aware starved threshold). Two fronts, one declarative file (`organs_registry.yaml`), **no code change**.

### Front A — arm A2 Heartbeat-Semantico on cron organs with an HONEST artifact
Each gets `starved_after_periods` so the #1755 cure actually applies:
| organ | hb | starved_after_periods | threshold | why |
|---|---|---|---|---|
| `pro.intel_nightly` | 90000 (daily) | 2 | ~600 ticks (~2 nights) | Was the textbook false positive — sentinel ticks every 5min, it advances once/night. Verified live 2026-06-27: `published_articles.json` is a real dedup ledger (372→386 on a work night). |
| `wr2.fact_extractor` | 1800 | 2 | ~12 ticks (~1h) | Empty WR2 queue during a Damar publish-gate standby is **business**, not a bug. |
| `wr2.fact_checker` | 1800 | 2 | ~12 ticks (~1h) | **Newly armed.** |

**`wr2.fact_checker` is the only newly-armed organ** — of 7 self-loop candidates audited 2026-06-27, it's the ONLY one with a clean honest artifact (`_log_telemetry` append-only JSONL, work-gated per-draft, no date rotation — verified live). The other 6 were **rejected**:
- `pro.regulatory_watcher_daily` → date-rotated filename (`<DATE>-delta.json`)
- `wr2.voyager_weekly` / `wr2.reflexion_weekly` / `wr2.learner_nightly` → unconditional timestamp-rewrite every run (content changes on a zero-work run)
- `wr2.topic_selector` → DB INSERT + Telegram only, no growing file
- `wr2.ig_scraper_daily` → in-place SQLite UPDATE / full-rewrite, poor heartbeat substrate

**Deeper finding:** the threshold wasn't the only blocker — those 6 loops have **no honest output signal to observe at all**. Arming them would require giving them a work-gated ledger first (separate work).

### Front B — reconcile owner_module path-drift (superscar #1)
15 organs whose `owner_module` pointed at a stale path (war-room scripts → `scripts/`; skills in `skills/` not `.claude/skills/`; codex under `scripts/codex/`; regulatory wrapper in `infra/launchagents/wrappers/`). **Only the 15 with a single confident on-disk match were fixed.**

**NOT touched — surfaced to operator:** ~42 organs whose `owner_module` basename is **missing on disk entirely**. That's a separate audit (possible dead organs / HOME-fork — cicatrix #1/W81 "armed at nothing"), not auto-resolved here.

## Verification
- Registry checksum regenerated via `validate_organs_registry --update-checksum` → ✓ valid (would have failed CI otherwise).
- A2 test suite `scripts/test_sentinel_starved.py` → **29/29 PASS** (code unchanged).
- Semantic diff confirmed: 120→120 organs, **0 organs lost a field** (the large textual diff is YAML re-normalization by the dumper, not semantic change).
- Threshold check on the 3 armed organs matches intent (intel=600 ticks, fact_checker/fact_extractor=12 ticks).

## Scope
Pure observability declarations + path hygiene. No PII, no backend-rag, no code logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)