### PR TITLE
feat(infra): add drive poll worker and nuz status

### DIFF
--- a/.github/workflows/cron-drive-poll.yml
+++ b/.github/workflows/cron-drive-poll.yml
@@ -1,12 +1,12 @@
-name: cron - drive poll (every 5 min)
+name: cron - drive poll monitor
 
-# Migrated from Pro crontab `*/5 * * * * drive-poll.sh` (2026-04-26).
-# Triggers Drive change polling on backend; nudges Fly out of sleep.
-# Failure path: Telegram alert to owner (cooldown 30min).
+# The Drive poll itself is owned by the Fly `drive` process group.
+# This workflow is a lightweight monitor only; it must never run the poll in
+# the HTTP request path.
 
 on:
   schedule:
-    - cron: "*/5 * * * *"
+    - cron: "*/15 * * * *"
   workflow_dispatch: {}
 
 concurrency:
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - name: POST /api/admin/drive/poll
+      - name: GET /api/admin/drive/poll/status
         id: poll
         env:
           API_KEY: ${{ secrets.NUZANTARA_API_KEY }}
@@ -26,10 +26,10 @@ jobs:
           set -uo pipefail
           BODY_FILE="$RUNNER_TEMP/body.json"
           HTTP_CODE=$(curl -sS -o "$BODY_FILE" -w "%{http_code}" --max-time 120 \
-            -X POST \
+            -X GET \
             -H "X-API-Key: $API_KEY" \
             -H "Content-Type: application/json" \
-            https://nuzantara-rag.fly.dev/api/admin/drive/poll || echo "000")
+            https://nuzantara-rag.fly.dev/api/admin/drive/poll/status || echo "000")
           BODY=$(cat "$BODY_FILE" 2>/dev/null || echo "")
           echo "http_code=$HTTP_CODE" >> "$GITHUB_OUTPUT"
           echo "body<<EOF" >> "$GITHUB_OUTPUT"
@@ -37,10 +37,15 @@ jobs:
           echo "" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
           if [ "$HTTP_CODE" = "200" ]; then
-            PROCESSED=$(echo "$BODY" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('processed',0))" 2>/dev/null || echo "?")
-            echo "✅ Drive poll OK: $PROCESSED new files processed"
+            STATUS=$(echo "$BODY" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('status','unknown'))" 2>/dev/null || echo "unknown")
+            WORKER=$(echo "$BODY" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('result',{}).get('status','unknown'))" 2>/dev/null || echo "unknown")
+            if [ "$STATUS" = "stale" ] || [ "$STATUS" = "error" ]; then
+              echo "::warning::Drive poll worker unhealthy: $BODY"
+              exit 1
+            fi
+            echo "✅ Drive poll worker monitor OK: endpoint=$STATUS worker=$WORKER"
           else
-            echo "::warning::Drive poll failed (HTTP $HTTP_CODE): $BODY"
+            echo "::warning::Drive poll monitor failed (HTTP $HTTP_CODE): $BODY"
             exit 1
           fi
 
@@ -53,7 +58,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           [ -z "$BOT" ] || [ -z "$CHAT" ] && { echo "Telegram secrets missing"; exit 0; }
-          TEXT="🚨 <b>drive-poll</b> failed
+          TEXT="🚨 <b>drive-poll monitor</b> failed
           HTTP: ${HTTP_CODE:-?}
           Run: ${RUN_URL}"
           curl -sS -m 10 -X POST \

--- a/.github/workflows/nuz-status-control.yml
+++ b/.github/workflows/nuz-status-control.yml
@@ -1,0 +1,46 @@
+name: Nuz Status Control
+
+on:
+  pull_request:
+    paths:
+      - "scripts/nuz"
+      - "scripts/nuz_status.py"
+      - "tests/scripts/test_nuz_status.py"
+      - "apps/nuz-status-mac/**"
+      - ".github/workflows/nuz-status-control.yml"
+  push:
+    branches: [main]
+    paths:
+      - "scripts/nuz"
+      - "scripts/nuz_status.py"
+      - "tests/scripts/test_nuz_status.py"
+      - "apps/nuz-status-mac/**"
+      - ".github/workflows/nuz-status-control.yml"
+  workflow_dispatch:
+
+jobs:
+  nuz-status:
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install test runner
+        run: python -m pip install pytest
+
+      - name: Unit tests
+        run: python -m pytest tests/scripts/test_nuz_status.py -q
+
+      - name: Offline status smoke
+        run: scripts/nuz status --json --offline
+
+      - name: Swift package build
+        run: |
+          if [ -f apps/nuz-status-mac/Package.swift ]; then
+            cd apps/nuz-status-mac
+            swift build
+          fi

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ nuzantara/
 - Backend: FastAPI · 329 routers · 634 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
-- Apps: 29 · Packages: 6
+- Apps: 30 · Packages: 6
 - Version: 5.2.0
 <!-- DOCSYNC:TECH_STATS_END -->
 

--- a/apps/backend-rag/backend/app/routers/admin_drive_health.py
+++ b/apps/backend-rag/backend/app/routers/admin_drive_health.py
@@ -249,7 +249,7 @@ async def _read_drive_poll_worker_status(pool: Any | None) -> dict[str, Any]:
             "healthy": False,
             "stale": False,
             "stale_after_seconds": stale_after_seconds,
-            "message": str(e)[:200],
+            "message": "Drive poll worker status unavailable",
         }
 
     values = {row["key"]: row["value"] for row in rows}
@@ -283,7 +283,12 @@ async def _read_drive_poll_worker_status(pool: Any | None) -> dict[str, Any]:
         "stale_after_seconds": stale_after_seconds,
         "last_started_at": values.get("drive_poll_worker_last_started_at"),
         "last_finished_at": values.get("drive_poll_worker_last_finished_at"),
-        "last_error": values.get("drive_poll_worker_last_error"),
+        "last_error_present": bool(values.get("drive_poll_worker_last_error")),
+        "last_error_message": (
+            "Last Drive poll worker run failed; see server logs"
+            if values.get("drive_poll_worker_last_error")
+            else None
+        ),
         "last_result": last_result,
     }
 
@@ -447,7 +452,7 @@ async def trigger_drive_poll(request: Request) -> dict[str, Any]:
         ) from e
     except Exception as e:
         logger.error("Drive poll failed: %s", e, exc_info=True)
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": "Drive poll failed"}
 
 
 @router.post("/backfill")

--- a/apps/backend-rag/backend/app/routers/admin_drive_health.py
+++ b/apps/backend-rag/backend/app/routers/admin_drive_health.py
@@ -3,8 +3,10 @@ Admin endpoint per verificare stato Google Drive e triggerare drive poll.
 """
 
 import asyncio
+import json
 import logging
 import os
+from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
@@ -160,6 +162,132 @@ def _drive_poll_api_timeout_seconds() -> float:
     return max(5.0, min(timeout, 115.0))
 
 
+def _drive_poll_api_mode() -> str:
+    """Return Drive poll API mode.
+
+    worker: HTTP only reports worker state; the Fly drive process owns polling.
+    direct: legacy behavior; the request runs the poll synchronously.
+    """
+    raw_value = os.getenv("DRIVE_POLL_API_MODE", "worker").strip().lower()
+    if raw_value in {"direct", "legacy"}:
+        return "direct"
+    return "worker"
+
+
+def _drive_poll_worker_stale_seconds() -> int:
+    raw_value = os.getenv("DRIVE_POLL_WORKER_STALE_SECONDS", "900")
+    try:
+        value = int(raw_value)
+    except ValueError:
+        logger.warning(
+            "Invalid DRIVE_POLL_WORKER_STALE_SECONDS=%r; falling back to 900",
+            raw_value,
+        )
+        return 900
+    return max(60, min(value, 86_400))
+
+
+def _parse_iso_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _get_request_pool(request: Request) -> Any | None:
+    app = getattr(request, "app", None)
+    state = getattr(app, "state", None)
+    pool = getattr(state, "db_pool", None)
+    if pool is not None and hasattr(pool, "acquire"):
+        return pool
+    return None
+
+
+async def _read_drive_poll_worker_status(pool: Any | None) -> dict[str, Any]:
+    """Read Drive worker heartbeat keys from system_settings."""
+    stale_after_seconds = _drive_poll_worker_stale_seconds()
+    if pool is None:
+        return {
+            "mode": "worker",
+            "available": False,
+            "status": "unknown",
+            "healthy": False,
+            "stale": False,
+            "stale_after_seconds": stale_after_seconds,
+            "message": "db_pool unavailable",
+        }
+
+    keys = [
+        "drive_poll_worker_heartbeat_at",
+        "drive_poll_worker_last_status",
+        "drive_poll_worker_last_started_at",
+        "drive_poll_worker_last_finished_at",
+        "drive_poll_worker_last_result",
+        "drive_poll_worker_last_error",
+    ]
+    try:
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT key, value, updated_at
+                FROM system_settings
+                WHERE key = ANY($1::text[])
+                """,
+                keys,
+            )
+    except Exception as e:
+        logger.warning("Drive poll worker status read failed: %s", e)
+        return {
+            "mode": "worker",
+            "available": False,
+            "status": "unknown",
+            "healthy": False,
+            "stale": False,
+            "stale_after_seconds": stale_after_seconds,
+            "message": str(e)[:200],
+        }
+
+    values = {row["key"]: row["value"] for row in rows}
+    heartbeat_at = _parse_iso_datetime(values.get("drive_poll_worker_heartbeat_at"))
+    age_seconds: float | None = None
+    stale = False
+    if heartbeat_at is not None:
+        age_seconds = max(0.0, (datetime.now(UTC) - heartbeat_at).total_seconds())
+        stale = age_seconds > stale_after_seconds
+
+    last_result: dict[str, Any] | None = None
+    raw_result = values.get("drive_poll_worker_last_result")
+    if raw_result:
+        try:
+            decoded = json.loads(raw_result)
+            if isinstance(decoded, dict):
+                last_result = decoded
+        except Exception:
+            last_result = {"raw": raw_result[:500], "parse_error": True}
+
+    status = values.get("drive_poll_worker_last_status") or "never_seen"
+    healthy = heartbeat_at is not None and not stale and status not in {"error"}
+    return {
+        "mode": "worker",
+        "available": True,
+        "status": status,
+        "healthy": healthy,
+        "stale": stale,
+        "heartbeat_at": heartbeat_at.isoformat() if heartbeat_at else None,
+        "heartbeat_age_seconds": age_seconds,
+        "stale_after_seconds": stale_after_seconds,
+        "last_started_at": values.get("drive_poll_worker_last_started_at"),
+        "last_finished_at": values.get("drive_poll_worker_last_finished_at"),
+        "last_error": values.get("drive_poll_worker_last_error"),
+        "last_result": last_result,
+    }
+
+
 @router.get("/health")
 async def drive_health(request: Request) -> dict[str, Any]:
     """Verifica stato Drive integration (public endpoint).
@@ -227,9 +355,60 @@ async def drive_health(request: Request) -> dict[str, Any]:
     }
 
 
+@router.get("/poll/status")
+async def drive_poll_status(request: Request) -> dict[str, Any]:
+    """Read Drive poll owner status without doing Drive or OCR work."""
+    mode = _drive_poll_api_mode()
+    if mode == "direct":
+        return {
+            "status": "direct",
+            "mode": "direct",
+            "worker_owned": False,
+            "message": "Drive poll API is in legacy direct mode",
+        }
+    worker_status = await _read_drive_poll_worker_status(_get_request_pool(request))
+    top_status = "ok"
+    if (
+        not worker_status.get("healthy")
+        or worker_status.get("stale")
+        or worker_status.get("status") == "error"
+    ):
+        top_status = "stale"
+    return {
+        "status": top_status,
+        "mode": "worker",
+        "worker_owned": True,
+        "result": worker_status,
+    }
+
+
 @router.post("/poll")
 async def trigger_drive_poll(request: Request) -> dict[str, Any]:
     """Trigger Google Drive changes poll (for cron jobs / OpenClaw automation)."""
+    mode = _drive_poll_api_mode()
+    if mode != "direct":
+        worker_status = await _read_drive_poll_worker_status(_get_request_pool(request))
+        top_status = "ok"
+        if (
+            not worker_status.get("healthy")
+            or worker_status.get("stale")
+            or worker_status.get("status") == "error"
+        ):
+            top_status = "stale"
+        logger.info(
+            "Drive poll POST handled in worker mode: status=%s stale=%s",
+            worker_status.get("status"),
+            worker_status.get("stale"),
+        )
+        return {
+            "status": top_status,
+            "processed": 0,
+            "inline_ocr": False,
+            "mode": "worker",
+            "worker_owned": True,
+            "result": worker_status,
+        }
+
     inline_ocr = _env_flag("DRIVE_POLL_INLINE_OCR", default=False)
     timeout_seconds = _drive_poll_api_timeout_seconds()
     try:

--- a/apps/backend-rag/backend/tests/unit/routers/test_admin_drive_health.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_admin_drive_health.py
@@ -7,7 +7,111 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
-from backend.app.routers.admin_drive_health import trigger_drive_poll
+from backend.app.routers.admin_drive_health import drive_poll_status, trigger_drive_poll
+
+
+class FakeAcquire:
+    def __init__(self, conn: Any) -> None:
+        self.conn = conn
+
+    async def __aenter__(self) -> Any:
+        return self.conn
+
+    async def __aexit__(self, *_args: Any) -> bool:
+        return False
+
+
+class FakePool:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.conn = AsyncMock()
+        self.conn.fetch.return_value = rows
+
+    def acquire(self) -> FakeAcquire:
+        return FakeAcquire(self.conn)
+
+
+def _request_with_pool(pool: Any | None) -> MagicMock:
+    request = MagicMock()
+    if pool is None:
+        request.app.state.db_pool = None
+    else:
+        request.app.state.db_pool = pool
+    return request
+
+
+@pytest.mark.asyncio
+async def test_drive_poll_status_reports_worker_heartbeat() -> None:
+    pool = FakePool(
+        [
+            {
+                "key": "drive_poll_worker_heartbeat_at",
+                "value": "2099-01-01T00:00:00+00:00",
+                "updated_at": None,
+            },
+            {
+                "key": "drive_poll_worker_last_status",
+                "value": "ok",
+                "updated_at": None,
+            },
+            {
+                "key": "drive_poll_worker_last_result",
+                "value": '{"status": "ok", "processed": 4}',
+                "updated_at": None,
+            },
+        ],
+    )
+
+    with patch.dict("os.environ", {"DRIVE_POLL_API_MODE": ""}, clear=False):
+        result = await drive_poll_status(_request_with_pool(pool))
+
+    assert result["status"] == "ok"
+    assert result["worker_owned"] is True
+    assert result["result"]["healthy"] is True
+    assert result["result"]["last_result"]["processed"] == 4
+
+
+@pytest.mark.asyncio
+async def test_drive_poll_status_is_stale_without_heartbeat() -> None:
+    with patch.dict("os.environ", {"DRIVE_POLL_API_MODE": ""}, clear=False):
+        result = await drive_poll_status(_request_with_pool(FakePool([])))
+
+    assert result["status"] == "stale"
+    assert result["result"]["healthy"] is False
+    assert result["result"]["status"] == "never_seen"
+
+
+@pytest.mark.asyncio
+async def test_trigger_drive_poll_defaults_to_worker_status_without_polling() -> None:
+    poll_drive_changes = AsyncMock(return_value={"status": "ok", "processed": 2})
+    pool = FakePool(
+        [
+            {
+                "key": "drive_poll_worker_heartbeat_at",
+                "value": "2099-01-01T00:00:00+00:00",
+                "updated_at": None,
+            },
+            {
+                "key": "drive_poll_worker_last_status",
+                "value": "ok",
+                "updated_at": None,
+            },
+        ],
+    )
+
+    with (
+        patch(
+            "backend.services.crm.drive_poll_service.poll_drive_changes",
+            new=poll_drive_changes,
+        ),
+        patch.dict("os.environ", {"DRIVE_POLL_API_MODE": ""}, clear=False),
+    ):
+        result = await trigger_drive_poll(_request_with_pool(pool))
+
+    poll_drive_changes.assert_not_awaited()
+    assert result["status"] == "ok"
+    assert result["processed"] == 0
+    assert result["worker_owned"] is True
+    assert result["mode"] == "worker"
 
 
 @pytest.mark.asyncio
@@ -22,6 +126,7 @@ async def test_trigger_drive_poll_disables_inline_ocr_by_default() -> None:
         patch.dict(
             "os.environ",
             {
+                "DRIVE_POLL_API_MODE": "direct",
                 "DRIVE_POLL_INLINE_OCR": "",
                 "DRIVE_POLL_API_TIMEOUT_SECONDS": "30",
             },
@@ -48,6 +153,7 @@ async def test_trigger_drive_poll_can_enable_inline_ocr_by_env() -> None:
         patch.dict(
             "os.environ",
             {
+                "DRIVE_POLL_API_MODE": "direct",
                 "DRIVE_POLL_INLINE_OCR": "true",
                 "DRIVE_POLL_API_TIMEOUT_SECONDS": "30",
             },
@@ -69,7 +175,11 @@ async def test_trigger_drive_poll_timeout_raises_504() -> None:
     with (
         patch("backend.services.crm.drive_poll_service.poll_drive_changes", new=slow_poll),
         patch("backend.app.routers.admin_drive_health._drive_poll_api_timeout_seconds", return_value=0.01),
-        patch.dict("os.environ", {"DRIVE_POLL_INLINE_OCR": ""}, clear=False),
+        patch.dict(
+            "os.environ",
+            {"DRIVE_POLL_API_MODE": "direct", "DRIVE_POLL_INLINE_OCR": ""},
+            clear=False,
+        ),
         pytest.raises(HTTPException) as exc_info,
     ):
         await trigger_drive_poll(MagicMock())

--- a/apps/backend-rag/backend/tests/unit/routers/test_admin_drive_health.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_admin_drive_health.py
@@ -81,6 +81,37 @@ async def test_drive_poll_status_is_stale_without_heartbeat() -> None:
 
 
 @pytest.mark.asyncio
+async def test_drive_poll_status_redacts_worker_error_details() -> None:
+    pool = FakePool(
+        [
+            {
+                "key": "drive_poll_worker_heartbeat_at",
+                "value": "2099-01-01T00:00:00+00:00",
+                "updated_at": None,
+            },
+            {
+                "key": "drive_poll_worker_last_status",
+                "value": "error",
+                "updated_at": None,
+            },
+            {
+                "key": "drive_poll_worker_last_error",
+                "value": "Traceback: secret internal path",
+                "updated_at": None,
+            },
+        ],
+    )
+
+    with patch.dict("os.environ", {"DRIVE_POLL_API_MODE": ""}, clear=False):
+        result = await drive_poll_status(_request_with_pool(pool))
+
+    assert result["status"] == "stale"
+    assert result["result"]["last_error_present"] is True
+    assert result["result"]["last_error_message"] == "Last Drive poll worker run failed; see server logs"
+    assert "secret internal path" not in str(result)
+
+
+@pytest.mark.asyncio
 async def test_trigger_drive_poll_defaults_to_worker_status_without_polling() -> None:
     poll_drive_changes = AsyncMock(return_value={"status": "ok", "processed": 2})
     pool = FakePool(

--- a/apps/backend-rag/backend/tests/unit/workers/test_drive_poll_worker.py
+++ b/apps/backend-rag/backend/tests/unit/workers/test_drive_poll_worker.py
@@ -1,0 +1,84 @@
+"""Tests for the Drive poll background worker."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.workers.drive_poll_worker import DrivePollWorkerConfig, load_config, run_once
+
+
+class FakeAcquire:
+    def __init__(self, conn: Any) -> None:
+        self.conn = conn
+
+    async def __aenter__(self) -> Any:
+        return self.conn
+
+    async def __aexit__(self, *_args: Any) -> bool:
+        return False
+
+
+class FakePool:
+    def __init__(self) -> None:
+        self.conn = AsyncMock()
+        self.closed = False
+
+    def acquire(self) -> FakeAcquire:
+        return FakeAcquire(self.conn)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def test_load_config_from_env() -> None:
+    with patch.dict(
+        "os.environ",
+        {
+            "DATABASE_URL": "postgresql://test/db",
+            "DRIVE_POLL_WORKER_INTERVAL_SECONDS": "120",
+            "DRIVE_POLL_WORKER_JITTER_SECONDS": "0",
+            "DRIVE_POLL_WORKER_INLINE_OCR": "true",
+        },
+        clear=False,
+    ):
+        config = load_config(["--once"])
+
+    assert config.database_url == "postgresql://test/db"
+    assert config.interval_seconds == 120
+    assert config.jitter_seconds == 0
+    assert config.inline_ocr is True
+    assert config.once is True
+
+
+@pytest.mark.asyncio
+async def test_run_once_records_heartbeat_and_result() -> None:
+    fake_pool = FakePool()
+    config = DrivePollWorkerConfig(
+        database_url="postgresql://test/db",
+        interval_seconds=300,
+        jitter_seconds=0,
+        inline_ocr=False,
+        once=True,
+    )
+    poll = AsyncMock(return_value={"status": "ok", "processed": 3})
+
+    with (
+        patch(
+            "backend.workers.drive_poll_worker.asyncpg.create_pool",
+            new=AsyncMock(return_value=fake_pool),
+        ),
+        patch("backend.workers.drive_poll_worker.poll_drive_changes", new=poll),
+    ):
+        result = await run_once(config)
+
+    assert result == {"status": "ok", "processed": 3}
+    assert fake_pool.closed is True
+    poll.assert_awaited_once_with(inline_ocr=False, acquire_advisory_lock=True)
+
+    written_keys = [call.args[1] for call in fake_pool.conn.execute.await_args_list]
+    assert "drive_poll_worker_heartbeat_at" in written_keys
+    assert "drive_poll_worker_last_status" in written_keys
+    assert "drive_poll_worker_last_result" in written_keys

--- a/apps/backend-rag/backend/workers/__init__.py
+++ b/apps/backend-rag/backend/workers/__init__.py
@@ -1,0 +1,2 @@
+"""Background worker entrypoints for non-HTTP backend processes."""
+

--- a/apps/backend-rag/backend/workers/drive_poll_worker.py
+++ b/apps/backend-rag/backend/workers/drive_poll_worker.py
@@ -1,0 +1,212 @@
+"""Fly process-group worker for CRM Google Drive polling.
+
+The HTTP API owns status and manual control only. This worker owns the periodic
+Drive poll loop so Drive/DB/OCR import chains do not compete with user-facing
+API requests inside the same Fly Machine.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import random
+import signal
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+import asyncpg
+
+from backend.services.crm.drive_poll_service import poll_drive_changes
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DrivePollWorkerConfig:
+    database_url: str
+    interval_seconds: int
+    jitter_seconds: int
+    inline_ocr: bool
+    once: bool
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _env_bool(name: str, *, default: bool = False) -> bool:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    return raw_value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str, *, default: int, minimum: int, maximum: int) -> int:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    try:
+        value = int(raw_value)
+    except ValueError:
+        logger.warning("Invalid %s=%r; using %s", name, raw_value, default)
+        return default
+    return max(minimum, min(value, maximum))
+
+
+def load_config(argv: list[str] | None = None) -> DrivePollWorkerConfig:
+    parser = argparse.ArgumentParser(description="Run the CRM Drive poll worker")
+    parser.add_argument("--once", action="store_true", help="Run one poll cycle and exit")
+    args = parser.parse_args(argv)
+
+    database_url = os.getenv("DATABASE_URL", "").strip()
+    if not database_url:
+        raise RuntimeError("DATABASE_URL is required")
+
+    return DrivePollWorkerConfig(
+        database_url=database_url,
+        interval_seconds=_env_int(
+            "DRIVE_POLL_WORKER_INTERVAL_SECONDS",
+            default=300,
+            minimum=30,
+            maximum=3600,
+        ),
+        jitter_seconds=_env_int(
+            "DRIVE_POLL_WORKER_JITTER_SECONDS",
+            default=10,
+            minimum=0,
+            maximum=120,
+        ),
+        inline_ocr=_env_bool("DRIVE_POLL_WORKER_INLINE_OCR", default=False),
+        once=args.once or _env_bool("DRIVE_POLL_WORKER_ONCE", default=False),
+    )
+
+
+async def _upsert_setting(conn: asyncpg.Connection, key: str, value: str) -> None:
+    await conn.execute(
+        """
+        INSERT INTO system_settings (key, value, updated_at)
+        VALUES ($1, $2, NOW())
+        ON CONFLICT (key) DO UPDATE
+        SET value = EXCLUDED.value, updated_at = NOW()
+        """,
+        key,
+        value,
+    )
+
+
+async def _record_state(
+    pool: asyncpg.Pool,
+    *,
+    status: str,
+    result: dict[str, Any] | None = None,
+    error: str | None = None,
+    started_at: str | None = None,
+    finished_at: str | None = None,
+) -> None:
+    payload: dict[str, str] = {
+        "drive_poll_worker_heartbeat_at": _utc_now_iso(),
+        "drive_poll_worker_last_status": status,
+    }
+    if started_at:
+        payload["drive_poll_worker_last_started_at"] = started_at
+    if finished_at:
+        payload["drive_poll_worker_last_finished_at"] = finished_at
+    if result is not None:
+        payload["drive_poll_worker_last_result"] = json.dumps(
+            result,
+            sort_keys=True,
+            default=str,
+        )
+    if error is not None:
+        payload["drive_poll_worker_last_error"] = error[:1000]
+
+    async with pool.acquire() as conn:
+        for key, value in payload.items():
+            await _upsert_setting(conn, key, value)
+
+
+async def run_once(config: DrivePollWorkerConfig) -> dict[str, Any]:
+    """Run one Drive poll cycle and persist worker heartbeat/result state."""
+    started_at = _utc_now_iso()
+    pool = await asyncpg.create_pool(config.database_url, min_size=1, max_size=1)
+    try:
+        await _record_state(pool, status="running", started_at=started_at)
+        result = await poll_drive_changes(
+            inline_ocr=config.inline_ocr,
+            acquire_advisory_lock=True,
+        )
+        status = str(result.get("status", "unknown"))
+        await _record_state(
+            pool,
+            status=status,
+            result=result,
+            finished_at=_utc_now_iso(),
+        )
+        logger.info("Drive poll worker cycle finished: %s", result)
+        return result
+    except Exception as exc:
+        logger.exception("Drive poll worker cycle failed")
+        await _record_state(
+            pool,
+            status="error",
+            error=str(exc),
+            finished_at=_utc_now_iso(),
+        )
+        return {"status": "error", "error": str(exc)}
+    finally:
+        await pool.close()
+
+
+async def run_forever(config: DrivePollWorkerConfig) -> int:
+    """Run the worker loop until SIGINT/SIGTERM."""
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    def _request_stop() -> None:
+        logger.info("Drive poll worker shutdown requested")
+        stop_event.set()
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(sig, _request_stop)
+        except NotImplementedError:
+            signal.signal(sig, lambda *_args: _request_stop())
+
+    while not stop_event.is_set():
+        await run_once(config)
+        if config.once:
+            return 0
+
+        sleep_seconds = config.interval_seconds
+        if config.jitter_seconds:
+            sleep_seconds += random.randint(0, config.jitter_seconds)
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=sleep_seconds)
+        except TimeoutError:
+            continue
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.getenv("LOG_LEVEL", "INFO").upper(),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    try:
+        config = load_config(argv)
+        return asyncio.run(run_forever(config))
+    except KeyboardInterrupt:
+        return 130
+    except Exception as exc:
+        logger.exception("Drive poll worker fatal error: %s", exc)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/backend-rag/fly.toml
+++ b/apps/backend-rag/fly.toml
@@ -29,6 +29,8 @@ primary_region = 'sin'
   # RAG is reached over Fly 6PN via rag.process.nuzantara-rag.internal, so it
   # must bind IPv6. It intentionally has no [[services]] Fly Proxy block.
   rag = "uvicorn backend.app.main_rag:app --host :: --port 8080 --workers 1 --timeout-worker-healthcheck 600"
+  # Owns periodic Drive polling outside the HTTP request path. No public service.
+  drive = "python -m backend.workers.drive_poll_worker"
 
 [env]
   ENVIRONMENT = 'production'
@@ -38,6 +40,9 @@ primary_region = 'sin'
   # QDRANT_URL set via fly secrets (Qdrant Cloud)
   PYTHONUNBUFFERED = '1'
   RAG_WORKER_URL = 'http://rag.process.nuzantara-rag.internal:8080'
+  DRIVE_POLL_API_MODE = 'worker'
+  DRIVE_POLL_WORKER_INTERVAL_SECONDS = '300'
+  DRIVE_POLL_WORKER_INLINE_OCR = 'false'
   ZANTARA_ALLOWED_ORIGINS = 'https://balizero.com,https://www.balizero.com,https://kita.balizero.com,https://www.kita.balizero.com,https://mail.balizero.com,https://calendar.balizero.com,https://drive.balizero.com,https://knowledge.balizero.com,https://nuzantara-mouth.vercel.app'
   # SQLite persistence paths (mounted volume /data on api process, PR #75)
   EXPERIENCE_DB_PATH = '/data/experience.db'
@@ -89,3 +94,10 @@ primary_region = 'sin'
   cpu_kind = 'shared'
   cpus = 2
   processes = ['rag']
+
+[[vm]]
+  # Separate Machine so Drive polling cannot OOM or starve the API process.
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1
+  processes = ['drive']

--- a/apps/nuz-status-mac/.gitignore
+++ b/apps/nuz-status-mac/.gitignore
@@ -1,0 +1,2 @@
+.build/
+.swiftpm/

--- a/apps/nuz-status-mac/Package.swift
+++ b/apps/nuz-status-mac/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "NuzStatus",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "NuzStatus", targets: ["NuzStatus"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "NuzStatus",
+            path: "Sources/NuzStatus"
+        )
+    ]
+)

--- a/apps/nuz-status-mac/README.md
+++ b/apps/nuz-status-mac/README.md
@@ -1,0 +1,20 @@
+# NuzStatus
+
+Native macOS control surface for Nuzantara operational health.
+
+The app is intentionally thin: it runs `scripts/nuz_status.py` from the repo root,
+renders the same checks as the CLI, and exposes only safe automated fixes. It does
+not talk directly to Fly, GitHub, SSH, or production data.
+
+## Run
+
+```bash
+cd apps/nuz-status-mac
+swift run NuzStatus
+```
+
+Open in Xcode with:
+
+```bash
+xed apps/nuz-status-mac
+```

--- a/apps/nuz-status-mac/Sources/NuzStatus/main.swift
+++ b/apps/nuz-status-mac/Sources/NuzStatus/main.swift
@@ -1,0 +1,433 @@
+import Foundation
+import SwiftUI
+
+struct StatusPayload: Decodable {
+    struct Machine: Decodable {
+        let user: String
+        let hostname: String
+        let role: String
+    }
+
+    struct Check: Decodable, Identifiable {
+        let id: String
+        let status: String
+        let summary: String
+    }
+
+    struct Action: Decodable, Identifiable {
+        let id: String
+        let label: String
+        let enabled: Bool
+        let target: String
+    }
+
+    let generatedAt: String
+    let overall: String
+    let machine: Machine
+    let repoRoot: String
+    let checks: [Check]
+    let actions: [Action]
+
+    enum CodingKeys: String, CodingKey {
+        case generatedAt = "generated_at"
+        case overall
+        case machine
+        case repoRoot = "repo_root"
+        case checks
+        case actions
+    }
+}
+
+struct FixPayload: Decodable {
+    let target: String
+    let ok: Bool
+    let returncode: Int
+    let stdout: String
+    let stderr: String
+}
+
+struct CommandOutput {
+    let status: Int32
+    let stdout: String
+    let stderr: String
+}
+
+enum StatusError: LocalizedError {
+    case invalidRepoRoot(String)
+    case commandFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidRepoRoot(let path):
+            return "Invalid repo root: \(path)"
+        case .commandFailed(let message):
+            return message
+        }
+    }
+}
+
+func runProcess(executable: String, arguments: [String], cwd: URL) throws -> CommandOutput {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: executable)
+    process.arguments = arguments
+    process.currentDirectoryURL = cwd
+
+    let stdoutPipe = Pipe()
+    let stderrPipe = Pipe()
+    process.standardOutput = stdoutPipe
+    process.standardError = stderrPipe
+
+    try process.run()
+    process.waitUntilExit()
+
+    let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+    let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+    return CommandOutput(
+        status: process.terminationStatus,
+        stdout: String(data: stdoutData, encoding: .utf8) ?? "",
+        stderr: String(data: stderrData, encoding: .utf8) ?? ""
+    )
+}
+
+func defaultRepoRoot() -> String {
+    let fileManager = FileManager.default
+    let current = URL(fileURLWithPath: fileManager.currentDirectoryPath)
+    var cursor = current
+    while true {
+        if fileManager.fileExists(atPath: cursor.appendingPathComponent("scripts/nuz_status.py").path) {
+            return cursor.path
+        }
+        let parent = cursor.deletingLastPathComponent()
+        if parent.path == cursor.path {
+            break
+        }
+        cursor = parent
+    }
+
+    for candidate in ["/Users/balizero/Desktop/nuzantara", "/Users/nuzantara/Desktop/nuzantara"] {
+        if fileManager.fileExists(atPath: "\(candidate)/scripts/nuz_status.py") {
+            return candidate
+        }
+    }
+    return current.path
+}
+
+@MainActor
+final class StatusModel: ObservableObject {
+    @Published var repoRoot: String = defaultRepoRoot()
+    @Published var payload: StatusPayload?
+    @Published var isLoading = false
+    @Published var lastError: String?
+    @Published var fixOutput: String?
+    @Published var includeNetworkChecks = true
+
+    var overallText: String {
+        payload?.overall.uppercased() ?? "UNKNOWN"
+    }
+
+    func refresh() {
+        isLoading = true
+        lastError = nil
+        let root = repoRoot
+        let includeNetwork = includeNetworkChecks
+
+        Task.detached {
+            do {
+                let payload = try Self.loadStatus(repoRoot: root, includeNetwork: includeNetwork)
+                await MainActor.run {
+                    self.payload = payload
+                    self.repoRoot = payload.repoRoot
+                    self.isLoading = false
+                }
+            } catch {
+                await MainActor.run {
+                    self.lastError = error.localizedDescription
+                    self.isLoading = false
+                }
+            }
+        }
+    }
+
+    func runFix(target: String) {
+        isLoading = true
+        lastError = nil
+        fixOutput = nil
+        let root = repoRoot
+
+        Task.detached {
+            do {
+                let output = try Self.safeFix(repoRoot: root, target: target)
+                await MainActor.run {
+                    self.fixOutput = output
+                    self.isLoading = false
+                    self.refresh()
+                }
+            } catch {
+                await MainActor.run {
+                    self.lastError = error.localizedDescription
+                    self.isLoading = false
+                }
+            }
+        }
+    }
+
+    nonisolated private static func loadStatus(repoRoot: String, includeNetwork: Bool) throws -> StatusPayload {
+        let root = URL(fileURLWithPath: repoRoot)
+        let script = root.appendingPathComponent("scripts/nuz_status.py")
+        guard FileManager.default.fileExists(atPath: script.path) else {
+            throw StatusError.invalidRepoRoot(repoRoot)
+        }
+
+        var arguments = [script.path, "status", "--json"]
+        if !includeNetwork {
+            arguments.append("--offline")
+        } else {
+            arguments.append("--refresh")
+        }
+
+        let output = try runProcess(executable: "/usr/bin/python3", arguments: arguments, cwd: root)
+        guard output.status == 0 else {
+            throw StatusError.commandFailed(output.stderr.isEmpty ? output.stdout : output.stderr)
+        }
+        let data = Data(output.stdout.utf8)
+        return try JSONDecoder().decode(StatusPayload.self, from: data)
+    }
+
+    nonisolated private static func safeFix(repoRoot: String, target: String) throws -> String {
+        let root = URL(fileURLWithPath: repoRoot)
+        let script = root.appendingPathComponent("scripts/nuz_status.py")
+        guard FileManager.default.fileExists(atPath: script.path) else {
+            throw StatusError.invalidRepoRoot(repoRoot)
+        }
+
+        let output = try runProcess(
+            executable: "/usr/bin/python3",
+            arguments: [script.path, "fix", "--target", target, "--json"],
+            cwd: root
+        )
+        let decoded = try JSONDecoder().decode(FixPayload.self, from: Data(output.stdout.utf8))
+        if output.status != 0 || !decoded.ok {
+            throw StatusError.commandFailed(decoded.stderr.isEmpty ? "Safe fix failed" : decoded.stderr)
+        }
+        return decoded.stdout.isEmpty ? "\(decoded.target): ok" : decoded.stdout
+    }
+}
+
+struct DashboardView: View {
+    @StateObject private var model = StatusModel()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+        }
+        .frame(minWidth: 760, minHeight: 520)
+        .onAppear {
+            model.refresh()
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 14) {
+            statusBadge(model.overallText)
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Nuzantara Control")
+                    .font(.title2.weight(.semibold))
+                if let payload = model.payload {
+                    Text("\(payload.machine.role) · \(payload.machine.user)@\(payload.machine.hostname)")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("Status not loaded")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+            Toggle("Network", isOn: $model.includeNetworkChecks)
+                .toggleStyle(.switch)
+                .onChange(of: model.includeNetworkChecks) { _ in
+                    model.refresh()
+                }
+            Button {
+                model.refresh()
+            } label: {
+                Label("Refresh", systemImage: "arrow.clockwise")
+            }
+            .keyboardShortcut("r", modifiers: [.command])
+            .disabled(model.isLoading)
+        }
+        .padding(18)
+    }
+
+    private var content: some View {
+        HStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 14) {
+                repoField
+                checksList
+            }
+            .padding(18)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+
+            Divider()
+
+            actionsPanel
+                .frame(width: 260)
+                .frame(maxHeight: .infinity, alignment: .top)
+                .padding(18)
+        }
+        .overlay {
+            if model.isLoading {
+                ProgressView()
+                    .controlSize(.large)
+                    .padding(18)
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+            }
+        }
+    }
+
+    private var repoField: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Repo")
+                .font(.headline)
+            TextField("Repo root", text: $model.repoRoot)
+                .textFieldStyle(.roundedBorder)
+                .font(.system(.body, design: .monospaced))
+                .onSubmit {
+                    model.refresh()
+                }
+        }
+    }
+
+    private var checksList: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Checks")
+                .font(.headline)
+
+            if let error = model.lastError {
+                MessageRow(kind: "fail", title: "Error", message: error)
+            }
+
+            if let payload = model.payload {
+                ForEach(payload.checks) { check in
+                    MessageRow(kind: check.status, title: check.id, message: check.summary)
+                }
+                Text("Updated \(payload.generatedAt)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 4)
+            } else if model.lastError == nil {
+                Text("Waiting for first status sample")
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var actionsPanel: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Safe Fixes")
+                .font(.headline)
+
+            if let actions = model.payload?.actions, !actions.isEmpty {
+                ForEach(actions) { action in
+                    Button {
+                        model.runFix(target: action.target)
+                    } label: {
+                        Label(action.label, systemImage: action.enabled ? "wrench.and.screwdriver" : "lock")
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .disabled(!action.enabled || model.isLoading)
+                }
+            } else {
+                Text("No automated fix available")
+                    .foregroundStyle(.secondary)
+            }
+
+            if let fixOutput = model.fixOutput {
+                Text(fixOutput)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                    .padding(.top, 8)
+            }
+
+            Spacer()
+        }
+    }
+
+    private func statusBadge(_ status: String) -> some View {
+        let color: Color = switch status.lowercased() {
+        case "ok": .green
+        case "warn": .orange
+        case "fail": .red
+        default: .gray
+        }
+        return Text(status)
+            .font(.caption.weight(.bold))
+            .foregroundStyle(.white)
+            .frame(width: 76, height: 32)
+            .background(color, in: RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+struct MessageRow: View {
+    let kind: String
+    let title: String
+    let message: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: icon)
+                .foregroundStyle(color)
+                .frame(width: 18)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.body.weight(.medium))
+                Text(message)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+            Spacer()
+        }
+        .padding(10)
+        .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var icon: String {
+        switch kind {
+        case "ok":
+            return "checkmark.circle.fill"
+        case "warn":
+            return "exclamationmark.triangle.fill"
+        case "fail":
+            return "xmark.octagon.fill"
+        default:
+            return "questionmark.circle.fill"
+        }
+    }
+
+    private var color: Color {
+        switch kind {
+        case "ok":
+            return .green
+        case "warn":
+            return .orange
+        case "fail":
+            return .red
+        default:
+            return .gray
+        }
+    }
+}
+
+@main
+struct NuzStatusApp: App {
+    var body: some Scene {
+        WindowGroup {
+            DashboardView()
+        }
+        .windowResizability(.contentSize)
+    }
+}

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`329 routers · 634 services · 1097 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`329 routers · 634 services · 1098 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/scripts/nuz
+++ b/scripts/nuz
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMAND="${1:-status}"
+if [[ $# -gt 0 ]]; then
+  shift
+fi
+
+case "$COMMAND" in
+  status)
+    exec python3 "$SCRIPT_DIR/nuz_status.py" status "$@"
+    ;;
+  fix)
+    exec python3 "$SCRIPT_DIR/nuz_status.py" fix "$@"
+    ;;
+  *)
+    echo "Usage: scripts/nuz status [--json] [--refresh] [--offline]" >&2
+    echo "       scripts/nuz fix --target pro-main|local-main [--json]" >&2
+    exit 64
+    ;;
+esac

--- a/scripts/nuz_status.py
+++ b/scripts/nuz_status.py
@@ -1,0 +1,543 @@
+#!/usr/bin/env python3
+"""Nuzantara operations status and safe-fix command surface.
+
+This is the source of truth for the native macOS dashboard. It intentionally
+uses only the Python standard library so it can run from the main checkout,
+from Xcode, and from GitHub Actions without backend dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import os
+import socket
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+DEFAULT_FLY_HEALTH_URL = "https://nuzantara-rag.fly.dev/health"
+DEFAULT_DRIVE_STATUS_URL = "https://nuzantara-rag.fly.dev/api/admin/drive/poll/status"
+DEFAULT_PEER_ALIAS = "pro"
+DEFAULT_PEER_REPO = "~/Desktop/nuzantara"
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def run_command(
+    args: list[str],
+    *,
+    cwd: Path | None = None,
+    timeout: int = 10,
+) -> CommandResult:
+    try:
+        completed = subprocess.run(
+            args,
+            cwd=str(cwd) if cwd else None,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        return CommandResult(127, "", str(exc))
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        return CommandResult(124, stdout, stderr or f"timeout after {timeout}s")
+    return CommandResult(completed.returncode, completed.stdout, completed.stderr)
+
+
+def repo_root(start: Path | None = None) -> Path:
+    here = (start or Path.cwd()).resolve()
+    current = here
+    while True:
+        if (current / ".git").exists() or (current / "scripts" / "nuz_status.py").exists():
+            return current
+        if current.parent == current:
+            return here
+        current = current.parent
+
+
+def machine_role(hostname: str, username: str) -> str:
+    if hostname in {"Nuzantara", "nuzantara"} and username == "nuzantara":
+        return "Pro"
+    if hostname in {"Mini-Pro2", "mini-pro2"}:
+        return "Mini"
+    if hostname in {"Air-M5", "air-m5"} or username == "balizero":
+        return "Air-M5"
+    return "Unknown"
+
+
+def check_status(status: str, summary: str, **details: Any) -> dict[str, Any]:
+    return {"status": status, "summary": summary, "details": details}
+
+
+def git_status(path: Path, *, refresh: bool = False) -> dict[str, Any]:
+    if refresh:
+        run_command(["git", "fetch", "--quiet", "origin", "main"], cwd=path, timeout=20)
+
+    branch = run_command(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=path)
+    head = run_command(["git", "rev-parse", "--short=12", "HEAD"], cwd=path)
+    origin = run_command(["git", "rev-parse", "--short=12", "origin/main"], cwd=path)
+    status = run_command(["git", "status", "--porcelain"], cwd=path)
+    ahead = run_command(["git", "rev-list", "--count", "origin/main..HEAD"], cwd=path)
+    behind = run_command(["git", "rev-list", "--count", "HEAD..origin/main"], cwd=path)
+
+    dirty_lines = [line for line in status.stdout.splitlines() if line.strip()]
+    return {
+        "branch": branch.stdout.strip() if branch.returncode == 0 else "unknown",
+        "head": head.stdout.strip() if head.returncode == 0 else "",
+        "origin_main": origin.stdout.strip() if origin.returncode == 0 else "",
+        "ahead": int(ahead.stdout.strip() or 0) if ahead.returncode == 0 else None,
+        "behind": int(behind.stdout.strip() or 0) if behind.returncode == 0 else None,
+        "dirty": bool(dirty_lines),
+        "dirty_count": len(dirty_lines),
+        "dirty_preview": dirty_lines[:8],
+    }
+
+
+def peer_git_status(peer: str, *, refresh: bool = False) -> dict[str, Any]:
+    fetch = "git fetch --quiet origin main >/dev/null 2>&1; " if refresh else ""
+    remote = (
+        f"cd {DEFAULT_PEER_REPO} && {fetch}"
+        "printf 'branch=%s\\n' \"$(git rev-parse --abbrev-ref HEAD 2>/dev/null)\" && "
+        "printf 'head=%s\\n' \"$(git rev-parse --short=12 HEAD 2>/dev/null)\" && "
+        "printf 'origin_main=%s\\n' \"$(git rev-parse --short=12 origin/main 2>/dev/null)\" && "
+        "printf 'ahead=%s\\n' \"$(git rev-list --count origin/main..HEAD 2>/dev/null || echo 0)\" && "
+        "printf 'behind=%s\\n' \"$(git rev-list --count HEAD..origin/main 2>/dev/null || echo 0)\" && "
+        "printf 'dirty_count=%s\\n' \"$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')\""
+    )
+    result = run_command(["ssh", "-o", "ConnectTimeout=3", peer, remote], timeout=12)
+    if result.returncode != 0:
+        return {
+            "reachable": False,
+            "error": (result.stderr or result.stdout).strip()[:300],
+        }
+
+    parsed: dict[str, Any] = {"reachable": True}
+    for line in result.stdout.splitlines():
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        parsed[key] = value.strip()
+    for key in ("ahead", "behind", "dirty_count"):
+        try:
+            parsed[key] = int(parsed.get(key, 0))
+        except (TypeError, ValueError):
+            parsed[key] = None
+    parsed["dirty"] = bool(parsed.get("dirty_count"))
+    return parsed
+
+
+def http_json(
+    url: str,
+    *,
+    timeout: int = 8,
+    headers: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    request_headers = {"User-Agent": "nuz-status/1.0"}
+    request_headers.update(headers or {})
+    req = urllib.request.Request(url, headers=request_headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            data = response.read(256_000)
+            body = json.loads(data.decode("utf-8"))
+            return {"ok": True, "status_code": response.status, "body": body}
+    except urllib.error.HTTPError as exc:
+        body = exc.read(4096).decode("utf-8", errors="replace")
+        return {"ok": False, "status_code": exc.code, "error": body}
+    except Exception as exc:
+        if "CERTIFICATE_VERIFY_FAILED" in str(exc):
+            return curl_json(url, timeout=timeout, headers=headers)
+        return {"ok": False, "status_code": None, "error": str(exc)}
+
+
+def curl_json(
+    url: str,
+    *,
+    timeout: int = 8,
+    headers: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Fetch JSON with curl as a macOS CA fallback for Python.org runtimes."""
+    curl_args = [
+        "curl",
+        "-sS",
+        "-L",
+        "--max-time",
+        str(timeout),
+        "-H",
+        "User-Agent: nuz-status/1.0",
+    ]
+    for key, value in (headers or {}).items():
+        curl_args.extend(["-H", f"{key}: {value}"])
+    curl_args.extend(["-w", "\n%{http_code}", url])
+    result = run_command(
+        curl_args,
+        timeout=timeout + 3,
+    )
+    if result.returncode != 0:
+        return {
+            "ok": False,
+            "status_code": None,
+            "error": (result.stderr or result.stdout).strip()[:500],
+        }
+
+    body, separator, status_text = result.stdout.rpartition("\n")
+    if not separator:
+        body = result.stdout
+        status_code = None
+    else:
+        try:
+            status_code = int(status_text.strip())
+        except ValueError:
+            status_code = None
+
+    try:
+        parsed = json.loads(body)
+    except json.JSONDecodeError:
+        parsed = {"raw": body[:1000]}
+
+    ok = status_code is not None and 200 <= status_code < 300
+    payload: dict[str, Any] = {"ok": ok, "status_code": status_code}
+    if ok:
+        payload["body"] = parsed
+    else:
+        payload["error"] = parsed
+    return payload
+
+
+def gh_latest_run(workflow: str) -> dict[str, Any]:
+    result = run_command(
+        [
+            "gh",
+            "run",
+            "list",
+            "--workflow",
+            workflow,
+            "--limit",
+            "1",
+            "--json",
+            "status,conclusion,createdAt,updatedAt,url",
+        ],
+        timeout=12,
+    )
+    if result.returncode != 0:
+        return {"available": False, "error": (result.stderr or result.stdout).strip()[:300]}
+    try:
+        rows = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return {"available": False, "error": str(exc)}
+    return {"available": True, "latest": rows[0] if rows else None}
+
+
+def build_checks(
+    *,
+    root: Path,
+    refresh: bool,
+    offline: bool,
+    peer: str,
+    fly_health_url: str,
+    drive_status_url: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    checks: list[dict[str, Any]] = []
+    actions: list[dict[str, Any]] = []
+
+    local_git = git_status(root, refresh=refresh)
+    local_status = "ok"
+    local_summary = f"{local_git['branch']} @ {local_git['head']}"
+    if local_git["dirty"]:
+        local_status = "warn"
+        local_summary += f" with {local_git['dirty_count']} dirty files"
+    if local_git["behind"]:
+        local_status = "warn"
+        local_summary += f", {local_git['behind']} behind origin/main"
+    checks.append({"id": "git_local", **check_status(local_status, local_summary, **local_git)})
+
+    if offline:
+        checks.append(
+            {
+                "id": "git_peer",
+                **check_status("unknown", "offline mode: peer Git not checked"),
+            },
+        )
+    else:
+        peer_git = peer_git_status(peer, refresh=refresh)
+        if not peer_git.get("reachable"):
+            checks.append(
+                {
+                    "id": "git_peer",
+                    **check_status("fail", "Pro peer unreachable", **peer_git),
+                },
+            )
+        else:
+            peer_state = "ok"
+            peer_summary = f"{peer_git.get('branch', 'unknown')} @ {peer_git.get('head', '')}"
+            if peer_git.get("dirty"):
+                peer_state = "fail"
+                peer_summary += f" with {peer_git.get('dirty_count')} dirty files"
+            elif peer_git.get("behind"):
+                peer_state = "warn"
+                peer_summary += f", {peer_git.get('behind')} behind origin/main"
+            checks.append(
+                {
+                    "id": "git_peer",
+                    **check_status(peer_state, peer_summary, **peer_git),
+                },
+            )
+            actions.append(
+                {
+                    "id": "sync_pro_main",
+                    "label": "Sync Pro main",
+                    "enabled": (
+                        peer_git.get("branch") == "main"
+                        and not peer_git.get("dirty")
+                        and bool(peer_git.get("behind"))
+                        and not peer_git.get("ahead")
+                    ),
+                    "target": "pro-main",
+                },
+            )
+
+    if offline:
+        checks.append({"id": "fly_health", **check_status("unknown", "offline mode")})
+        checks.append({"id": "drive_worker", **check_status("unknown", "offline mode")})
+    else:
+        fly = http_json(fly_health_url)
+        fly_body = fly.get("body") if isinstance(fly.get("body"), dict) else {}
+        fly_ok = bool(fly.get("ok") and fly_body.get("status") in {"healthy", "ok"})
+        checks.append(
+            {
+                "id": "fly_health",
+                **check_status(
+                    "ok" if fly_ok else "fail",
+                    f"HTTP {fly.get('status_code')}: {fly_body.get('status', fly.get('error', 'unknown'))}",
+                    **fly,
+                ),
+            },
+        )
+
+        drive_headers: dict[str, str] = {}
+        drive_api_key = os.getenv("NUZANTARA_API_KEY", "").strip()
+        if drive_api_key:
+            drive_headers["X-API-Key"] = drive_api_key
+        drive = http_json(drive_status_url, headers=drive_headers)
+        drive_body = drive.get("body") if isinstance(drive.get("body"), dict) else {}
+        drive_status = drive_body.get("status", "unknown")
+        if not drive.get("ok") and drive.get("status_code") == 401 and not drive_api_key:
+            state = "warn"
+            summary = "worker auth required: set NUZANTARA_API_KEY"
+        elif not drive.get("ok"):
+            state = "fail"
+        elif drive_status == "stale":
+            state = "fail"
+        elif drive_status == "ok":
+            state = "ok"
+        else:
+            state = "warn"
+        if not (drive.get("status_code") == 401 and not drive_api_key):
+            summary = f"worker endpoint={drive_status}"
+        checks.append(
+            {
+                "id": "drive_worker",
+                **check_status(
+                    state,
+                    summary,
+                    **drive,
+                ),
+            },
+        )
+
+    if offline:
+        checks.append({"id": "github_tests", **check_status("unknown", "offline mode")})
+    else:
+        tests = gh_latest_run("Tests & Coverage")
+        if not tests.get("available"):
+            checks.append(
+                {
+                    "id": "github_tests",
+                    **check_status("unknown", "gh unavailable", **tests),
+                },
+            )
+        else:
+            latest = tests.get("latest") or {}
+            conclusion = latest.get("conclusion")
+            status = latest.get("status")
+            state = "ok" if status == "completed" and conclusion == "success" else "warn"
+            checks.append(
+                {
+                    "id": "github_tests",
+                    **check_status(state, f"{status}/{conclusion}", **tests),
+                },
+            )
+
+    return checks, actions
+
+
+def collect_status(args: argparse.Namespace) -> dict[str, Any]:
+    root = repo_root(Path.cwd())
+    username = getpass.getuser()
+    hostname = socket.gethostname().split(".")[0]
+    checks, actions = build_checks(
+        root=root,
+        refresh=bool(args.refresh),
+        offline=bool(args.offline),
+        peer=args.peer,
+        fly_health_url=args.fly_health_url,
+        drive_status_url=args.drive_status_url,
+    )
+    failing = sum(1 for check in checks if check["status"] == "fail")
+    warning = sum(1 for check in checks if check["status"] == "warn")
+    unknown = sum(1 for check in checks if check["status"] == "unknown")
+    overall = "ok"
+    if failing:
+        overall = "fail"
+    elif warning:
+        overall = "warn"
+    elif unknown:
+        overall = "unknown"
+    return {
+        "generated_at": utc_now(),
+        "overall": overall,
+        "machine": {
+            "user": username,
+            "hostname": hostname,
+            "role": machine_role(hostname, username),
+        },
+        "repo_root": str(root),
+        "checks": checks,
+        "actions": actions,
+    }
+
+
+def safe_fix(target: str, *, peer: str) -> dict[str, Any]:
+    if target == "pro-main":
+        remote = (
+            f"cd {DEFAULT_PEER_REPO} && "
+            "git fetch --quiet origin main && "
+            "test \"$(git rev-parse --abbrev-ref HEAD)\" = main && "
+            "test -z \"$(git status --porcelain)\" && "
+            "git merge --ff-only origin/main"
+        )
+        result = run_command(["ssh", "-o", "ConnectTimeout=3", peer, remote], timeout=60)
+        return {
+            "target": target,
+            "ok": result.returncode == 0,
+            "returncode": result.returncode,
+            "stdout": result.stdout[-4000:],
+            "stderr": result.stderr[-4000:],
+        }
+
+    if target == "local-main":
+        root = repo_root(Path.cwd())
+        guard_branch = run_command(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=root)
+        guard_dirty = run_command(["git", "status", "--porcelain"], cwd=root)
+        if guard_branch.stdout.strip() != "main" or guard_dirty.stdout.strip():
+            return {
+                "target": target,
+                "ok": False,
+                "returncode": 2,
+                "stdout": "",
+                "stderr": "local checkout is not clean main",
+            }
+        fetch = run_command(["git", "fetch", "--quiet", "origin", "main"], cwd=root, timeout=30)
+        if fetch.returncode != 0:
+            return {
+                "target": target,
+                "ok": False,
+                "returncode": fetch.returncode,
+                "stdout": fetch.stdout,
+                "stderr": fetch.stderr,
+            }
+        merge = run_command(["git", "merge", "--ff-only", "origin/main"], cwd=root, timeout=60)
+        return {
+            "target": target,
+            "ok": merge.returncode == 0,
+            "returncode": merge.returncode,
+            "stdout": merge.stdout[-4000:],
+            "stderr": merge.stderr[-4000:],
+        }
+
+    return {
+        "target": target,
+        "ok": False,
+        "returncode": 64,
+        "stdout": "",
+        "stderr": f"unknown safe-fix target: {target}",
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Nuzantara status dashboard backend")
+    sub = parser.add_subparsers(dest="command")
+
+    status = sub.add_parser("status", help="Collect status")
+    status.add_argument("--json", action="store_true", help="Emit JSON")
+    status.add_argument("--refresh", action="store_true", help="Fetch fresh Git refs")
+    status.add_argument("--offline", action="store_true", help="Skip network and SSH checks")
+    status.add_argument("--peer", default=DEFAULT_PEER_ALIAS)
+    status.add_argument("--fly-health-url", default=DEFAULT_FLY_HEALTH_URL)
+    status.add_argument("--drive-status-url", default=DEFAULT_DRIVE_STATUS_URL)
+
+    fix = sub.add_parser("fix", help="Run a safe automated fix")
+    fix.add_argument("--target", required=True, choices=["pro-main", "local-main"])
+    fix.add_argument("--peer", default=DEFAULT_PEER_ALIAS)
+    fix.add_argument("--json", action="store_true")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.command in {None, "status"}:
+        if args.command is None:
+            args.command = "status"
+            args.json = False
+            args.refresh = False
+            args.offline = False
+            args.peer = DEFAULT_PEER_ALIAS
+            args.fly_health_url = DEFAULT_FLY_HEALTH_URL
+            args.drive_status_url = DEFAULT_DRIVE_STATUS_URL
+        payload = collect_status(args)
+        if args.json:
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            print(f"Nuzantara status: {payload['overall']}")
+            for check in payload["checks"]:
+                print(f"- {check['id']}: {check['status']} - {check['summary']}")
+        return 0 if payload["overall"] in {"ok", "unknown", "warn"} else 1
+
+    if args.command == "fix":
+        payload = safe_fix(args.target, peer=args.peer)
+        if args.json:
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            print(f"{args.target}: {'ok' if payload['ok'] else 'failed'}")
+            if payload["stdout"]:
+                print(payload["stdout"])
+            if payload["stderr"]:
+                print(payload["stderr"], file=sys.stderr)
+        return 0 if payload["ok"] else 1
+
+    parser.print_help()
+    return 64
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/nuz_status.py
+++ b/scripts/nuz_status.py
@@ -339,6 +339,7 @@ def build_checks(
         drive = http_json(drive_status_url, headers=drive_headers)
         drive_body = drive.get("body") if isinstance(drive.get("body"), dict) else {}
         drive_status = drive_body.get("status", "unknown")
+        summary = f"worker endpoint={drive_status}"
         if not drive.get("ok") and drive.get("status_code") == 401 and not drive_api_key:
             state = "warn"
             summary = "worker auth required: set NUZANTARA_API_KEY"
@@ -350,8 +351,6 @@ def build_checks(
             state = "ok"
         else:
             state = "warn"
-        if not (drive.get("status_code") == 401 and not drive_api_key):
-            summary = f"worker endpoint={drive_status}"
         checks.append(
             {
                 "id": "drive_worker",

--- a/tests/scripts/test_nuz_status.py
+++ b/tests/scripts/test_nuz_status.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "nuz_status",
+    ROOT / "scripts" / "nuz_status.py",
+)
+assert SPEC is not None
+assert SPEC.loader is not None
+nuz_status = importlib.util.module_from_spec(SPEC)
+sys.modules["nuz_status"] = nuz_status
+SPEC.loader.exec_module(nuz_status)
+
+
+def test_machine_role_air_m5_for_balizero() -> None:
+    assert nuz_status.machine_role("Air-M5", "balizero") == "Air-M5"
+
+
+def test_http_json_handles_error_without_raising() -> None:
+    with patch("nuz_status.urllib.request.urlopen", side_effect=OSError("offline")):
+        result = nuz_status.http_json("https://example.invalid")
+
+    assert result["ok"] is False
+    assert "offline" in result["error"]
+
+
+def test_http_json_falls_back_to_curl_on_python_ca_error() -> None:
+    with (
+        patch(
+            "nuz_status.urllib.request.urlopen",
+            side_effect=OSError("CERTIFICATE_VERIFY_FAILED"),
+        ),
+        patch(
+            "nuz_status.run_command",
+            return_value=nuz_status.CommandResult(0, '{"status":"healthy"}\n200', ""),
+        ) as run_command,
+    ):
+        result = nuz_status.http_json("https://example.invalid")
+
+    assert result == {
+        "ok": True,
+        "status_code": 200,
+        "body": {"status": "healthy"},
+    }
+    run_command.assert_called_once()
+
+
+def test_collect_status_marks_drive_401_without_key_as_warning() -> None:
+    args = Namespace(
+        refresh=False,
+        offline=False,
+        peer="pro",
+        fly_health_url="https://example.invalid/health",
+        drive_status_url="https://example.invalid/drive",
+    )
+
+    def fake_http_json(url: str, **_kwargs: object) -> dict[str, object]:
+        if url.endswith("/health"):
+            return {"ok": True, "status_code": 200, "body": {"status": "healthy"}}
+        return {"ok": False, "status_code": 401, "error": {"detail": "Authentication required"}}
+
+    with (
+        patch("nuz_status.repo_root", return_value=Path.cwd()),
+        patch(
+            "nuz_status.git_status",
+            return_value={
+                "branch": "main",
+                "head": "abc123",
+                "origin_main": "abc123",
+                "ahead": 0,
+                "behind": 0,
+                "dirty": False,
+                "dirty_count": 0,
+                "dirty_preview": [],
+            },
+        ),
+        patch("nuz_status.peer_git_status", return_value={"reachable": True, "branch": "main"}),
+        patch("nuz_status.gh_latest_run", return_value={"available": False}),
+        patch("nuz_status.http_json", side_effect=fake_http_json),
+        patch.dict("os.environ", {"NUZANTARA_API_KEY": ""}, clear=False),
+    ):
+        payload = nuz_status.collect_status(args)
+
+    drive_check = next(check for check in payload["checks"] if check["id"] == "drive_worker")
+    assert drive_check["status"] == "warn"
+    assert "NUZANTARA_API_KEY" in drive_check["summary"]
+
+
+def test_collect_status_offline_skips_network() -> None:
+    args = Namespace(
+        refresh=False,
+        offline=True,
+        peer="pro",
+        fly_health_url="https://example.invalid/health",
+        drive_status_url="https://example.invalid/drive",
+    )
+    with (
+        patch("nuz_status.repo_root", return_value=Path.cwd()),
+        patch(
+            "nuz_status.git_status",
+            return_value={
+                "branch": "main",
+                "head": "abc123",
+                "origin_main": "abc123",
+                "ahead": 0,
+                "behind": 0,
+                "dirty": False,
+                "dirty_count": 0,
+                "dirty_preview": [],
+            },
+        ),
+        patch("nuz_status.peer_git_status") as peer_git,
+        patch("nuz_status.http_json") as http_json,
+    ):
+        payload = nuz_status.collect_status(args)
+
+    assert payload["overall"] == "unknown"
+    assert {check["id"] for check in payload["checks"]} >= {
+        "git_local",
+        "git_peer",
+        "fly_health",
+        "drive_worker",
+    }
+    peer_git.assert_not_called()
+    http_json.assert_not_called()


### PR DESCRIPTION
## Summary
- move Drive polling ownership from the HTTP cron endpoint to a dedicated Fly process-group worker with heartbeat state
- convert the GitHub Drive cron from a poll trigger into a lightweight worker monitor
- add nuz status CLI plus a native macOS SwiftUI control app for live checks and safe Pro sync fixes

## Verification
- PYTHONPATH=. apps/backend-rag/.venv/bin/python -m pytest tests/scripts/test_nuz_status.py -q
- apps/backend-rag/.venv/bin/python -m pytest apps/backend-rag/backend/tests/unit/routers/test_admin_drive_health.py apps/backend-rag/backend/tests/unit/workers/test_drive_poll_worker.py -q
- swift build (apps/nuz-status-mac)
- git diff --check
- ./scripts/nuz status --json --offline

## Operational notes
- live Fly health is currently healthy from Air-M5
- Pro main is reachable but dirty with 213 local changes, so automated Pro fast-forward is intentionally disabled until those changes are classified or preserved
