### PR TITLE
feat(organism): runtime/dev checkout split — P0 inert scaffolding (anti-W81)

### DIFF
--- a/docs/runbooks/runtime-dev-checkout-split.md
+++ b/docs/runbooks/runtime-dev-checkout-split.md
@@ -1,0 +1,60 @@
+# Runtime/Dev checkout split — runbook (P0 shipped, P1/P2 operator-gated)
+
+> **Why this exists.** On Pro, `~/Desktop/nuzantara` is BOTH the h24 runtime (104 launchd organs
+> run from it) AND a dirty dev scratch (sessions sully it). So it can't be pulled — it sits 169
+> commits / 6 days behind origin/main, and every merge is **sterile** (never reaches the live
+> organs). 20 more organs point at `~/Desktop/nuzantara-deploy`, a stable auto-pulled checkout
+> that **vanished** (scar W81). Fix: every runtime organ runs from a read-only, auto-pulled
+> `-deploy` clone; the main checkout becomes dev-only.
+>
+> Council-validated design + full rationale: `mem query "runtime dev checkout split"` (decision
+> 2026-06-27). This runbook is the operative half.
+
+## Phases (each its own PR + operator gate — DO NOT batch)
+- **P0 — INERT scaffolding (this PR).** Three scripts, nothing migrated, no live organ touched.
+- **P1 — operator-gated, no live session on Pro.** Bootstrap the `-deploy` clone, point the
+  deploy-puller at it, install + arm the reconcile watchdog (strict mode).
+- **P2 — operator-gated, in waves.** Migrate the 20 already-deploy-intended organs first, verify,
+  then the 104 in waves with health-wait + per-label rollback.
+
+## P0 artifacts (all in `scripts/`, all inert, all kill-switchable)
+
+### `runtime-reconcile.sh` — anti-W81 watchdog (signaller, not actuator)
+Asserts: `-deploy` exists, is a clone (not a worktree), on the right branch, pulled recently.
+P0 default `RUNTIME_RECONCILE_STRICT=0` → records breaches to log + heartbeat, does NOT page.
+P1 flips `STRICT=1` → P0 Telegram on any breach. Kill: `NUZ_RUNTIME_RECONCILE_DISABLED=1`.
+Heartbeat: `~/.organism/last_seen/pro.runtime_reconcile.json` (A2-observable).
+```
+bash scripts/runtime-reconcile.sh          # warn-only
+RUNTIME_RECONCILE_STRICT=1 bash scripts/runtime-reconcile.sh   # pages on breach (P1)
+```
+
+### `runtime-health-gate.sh <CHECKOUT_DIR>` — pre-advance gate (council Q3)
+Run against a CANDIDATE checkout at the target SHA. Exit 0 = safe to become runtime; 1 = BLOCK
+(do not advance — keep last_good_head). Checks: registry valid+checksum, owner_module scripts
+exist (≤ tolerance, default 60 — today's baseline is 42 missing), sentinel compiles, A2 test
+green. Resolves python via the checkout's venv (Golden Rule #1). Kill: `NUZ_RUNTIME_HEALTH_GATE_DISABLED=1`.
+P1 wires this into `wr2-deploy-pull.sh` BEFORE the ff-only advance.
+```
+bash scripts/runtime-health-gate.sh ~/Desktop/nuzantara-deploy
+```
+
+### `runtime_checkout_report.py` — migration map (council Q2/E)
+Read-only. Cross-refs the registry against installed (or repo) plists and classifies each
+pro_launchd organ's runtime root: deploy | dirty-main | external | unknown. This is the list
+P2 migrates FROM (instead of eyeballing 104 plists). `--strict` exits 1 if any organ still runs
+from dirty-main (a P2 done-check). Run on the **Pro** for the real installed-plist truth.
+```
+python3 scripts/runtime_checkout_report.py --json | jq .summary
+```
+
+## Known gap (flagged, not solved in P0)
+`registry_launchd_gap` in the report = organs with no readable plist to classify. The registry
+lacks launchd schedule/env/args fields, so P0 does NOT generate full plists yet. Enriching
+`organs_registry.yaml` with `runtime_root` + launchd fields (then a real plist generator) is the
+first task of P1 — it also closes the ~42 owner_module "missing" audit (same source-of-truth).
+
+## P1/P2 are operator-gated because
+They touch 104 production h24 organs (bounded restarts = real disruption) and require the main
+checkout to be clonable — blocked today by a LIVE session's 213 dirty files (scar #5, leave-dirty).
+Run P1/P2 when no live session is active on Pro. That's Zero's call (DNA L6).

--- a/scripts/runtime-health-gate.sh
+++ b/scripts/runtime-health-gate.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# runtime-health-gate.sh — pre-advance health gate for the runtime checkout (SPEC split, P0).
+#
+# THE SCAR IT KILLS: ff-only auto-pull blindly advances the runtime onto origin/main even if
+# that commit is broken → all 104 h24 organs crash on next invocation (council red-team). This
+# gate runs against a CANDIDATE checkout at the target SHA; the puller advances the live runtime
+# ONLY if this exits 0. On non-zero the puller keeps last_good_head untouched (council Q3).
+#
+# INERT in P0: it's a standalone validator. No puller calls it yet. Run it by hand against any
+# checkout to see what it would verdict. Kill switch (for when wired into the puller in P1):
+# NUZ_RUNTIME_HEALTH_GATE_DISABLED=1 → gate auto-passes (operator escape).
+#
+# Usage:  runtime-health-gate.sh <CHECKOUT_DIR>
+# Exit:   0 = candidate is safe to become runtime. 1 = a check failed (do NOT advance). 2 = usage.
+set -uo pipefail
+
+CHECKOUT="${1:-}"
+if [[ -z "$CHECKOUT" ]]; then
+  echo "usage: runtime-health-gate.sh <CHECKOUT_DIR>" >&2
+  exit 2
+fi
+if [[ "${NUZ_RUNTIME_HEALTH_GATE_DISABLED:-0}" == "1" ]]; then
+  echo "[health-gate] disabled via NUZ_RUNTIME_HEALTH_GATE_DISABLED=1 — auto-pass"
+  exit 0
+fi
+if [[ ! -d "$CHECKOUT" ]]; then
+  echo "[health-gate] FAIL: checkout dir does not exist: $CHECKOUT" >&2
+  exit 1
+fi
+
+export PATH="/opt/homebrew/bin:/usr/bin:/bin:${PATH:-}"
+fails=0
+check() { local name="$1"; shift; if "$@"; then echo "[health-gate] PASS: $name"; else echo "[health-gate] FAIL: $name" >&2; fails=$((fails+1)); fi; }
+
+REG="$CHECKOUT/apps/organism/organism/organs_registry.yaml"
+
+# Resolve a python that has the repo deps (yaml). Golden Rule #1: prefer the checkout's venv,
+# never assume system python carries yaml (it doesn't on a bare M5). Fall back to whatever
+# python3 imports yaml; if none does, that's a real FAIL the gate must surface, not mask.
+PY="python3"
+for cand in "$CHECKOUT/apps/backend-rag/.venv/bin/python3" "$CHECKOUT/.venv/bin/python3" python3; do
+  if [[ -x "$cand" ]] && "$cand" -c "import yaml" >/dev/null 2>&1; then PY="$cand"; break; fi
+  if command -v "$cand" >/dev/null 2>&1 && "$cand" -c "import yaml" >/dev/null 2>&1; then PY="$cand"; break; fi
+done
+echo "[health-gate] python: $PY"
+
+# 1. registry parses + checksum valid (the source of truth must be intact)
+_reg_valid() {
+  [[ -f "$REG" ]] || return 1
+  ( cd "$CHECKOUT/apps/organism" && PYTHONPATH=. "$PY" -m organism.tools.validate_organs_registry \
+      organism/organs_registry.yaml >/dev/null 2>&1 )
+}
+check "organs_registry valid + checksum" _reg_valid
+
+# 2. every launchd-owned script the registry references actually EXISTS in this candidate
+#    (catches a commit that deletes/moves a script an organ runs — the owner_module-missing class)
+_owner_modules_exist() {
+  [[ -f "$REG" ]] || return 1
+  "$PY" - "$CHECKOUT" "$REG" <<'PY'
+import sys, os, yaml
+root, reg = sys.argv[1], sys.argv[2]
+d = yaml.safe_load(open(reg))
+missing = []
+for o in d.get("organs", []):
+    if not isinstance(o, dict) or o.get("enabled") is False: continue
+    om = o.get("owner_module")
+    if not om or "/" not in om: continue           # skip dotted module names / non-paths
+    if om.startswith("infra/fly") or om.startswith("backend."): continue
+    if not os.path.exists(os.path.join(root, om)):
+        missing.append((o["id"], om))
+# P0 reality: ~42 already-missing owner_modules exist on main TODAY. So this check reports the
+# COUNT and only fails if it GROWS past a baseline tolerance (a new commit deleting a live
+# script). Baseline overridable via env; default generous so P0 never false-fails.
+tol = int(os.environ.get("HEALTH_GATE_OWNER_MISSING_TOL", "60"))
+print(f"owner_module missing: {len(missing)} (tolerance {tol})", file=sys.stderr)
+sys.exit(0 if len(missing) <= tol else 1)
+PY
+}
+check "owner_module scripts exist (<= tolerance)" _owner_modules_exist
+
+# 3. sentinel + key self-loop python compiles (import-smoke, no execution)
+_compiles() {
+  "$PY" -m py_compile "$CHECKOUT/scripts/sentinel-aggregate.py" 2>/dev/null
+}
+check "sentinel-aggregate.py compiles" _compiles
+
+# 4. the A2 starved test passes on the candidate (the self-loop's own guard)
+_a2_test() {
+  [[ -f "$CHECKOUT/scripts/test_sentinel_starved.py" ]] || return 0   # absent on old commits = skip, not fail
+  ( cd "$CHECKOUT" && "$PY" scripts/test_sentinel_starved.py >/dev/null 2>&1 )
+}
+check "A2 starved test green" _a2_test
+
+if (( fails > 0 )); then
+  echo "[health-gate] VERDICT: BLOCK ($fails check(s) failed) — runtime must NOT advance to this commit" >&2
+  exit 1
+fi
+echo "[health-gate] VERDICT: SAFE — candidate may become runtime"
+exit 0

--- a/scripts/runtime-reconcile.sh
+++ b/scripts/runtime-reconcile.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# runtime-reconcile.sh — anti-W81 reconciliation watchdog (SPEC runtime/dev split, P0).
+#
+# THE SCAR IT KILLS: ~/Desktop/nuzantara-deploy (the stable runtime checkout the launchd
+# organs are meant to run from) VANISHED once and nobody noticed for weeks (W81). The
+# deploy-puller kept exiting 1 in silence; 20 organs ran at nothing. This watchdog makes
+# the absence LOUD — the reconciliation-report pattern of superscar #2 (built-but-vanished
+# is suspended, not alive).
+#
+# It is a SIGNALLER, not an actuator: it never restarts/moves/heals anything. It asserts
+# invariants and pages the operator. Lives OUTSIDE both checkouts by intent (so a vanished
+# repo cannot take its own watchdog down with it) — install the live copy under ~/scripts
+# via the P1 installer; this repo copy is the source of truth (cmp-checked, anti HOME-fork #1).
+#
+# INERT in P0: nothing is migrated yet, so by default it only checks what EXISTS and warns
+# (never P0-pages) unless RUNTIME_RECONCILE_STRICT=1. Kill switch: NUZ_RUNTIME_RECONCILE_DISABLED=1.
+#
+# Exit: 0 = all invariants hold (or disabled). 1 = a P0/invariant breach was found+alerted.
+set -uo pipefail
+
+DEPLOY_DIR="${WR2_DEPLOY_DIR:-${HOME}/Desktop/nuzantara-deploy}"
+SOURCE_REPO="${WR2_SOURCE_REPO:-${HOME}/Desktop/nuzantara}"
+DEPLOY_BRANCH="${WR2_DEPLOY_BRANCH:-deploy/main}"
+MAX_PULL_AGE_SEC="${RUNTIME_RECONCILE_MAX_PULL_AGE_SEC:-7200}"   # deploy must have pulled within 2h
+STRICT="${RUNTIME_RECONCILE_STRICT:-0}"                          # P0 default 0 = warn, don't page
+PULL_STATE="${HOME}/.agent/decisions/state/wr2_deploy_pull.state"
+LOG="${HOME}/logs/runtime-reconcile.log"
+STATE="${HOME}/.organism/last_seen/pro.runtime_reconcile.json"
+SECRETS="${HOME}/.nuzantara-secrets.env"
+ALERT_COOLDOWN_SEC="${RUNTIME_RECONCILE_ALERT_COOLDOWN_SEC:-21600}"
+ALERT_STAMP="${HOME}/.agent/decisions/state/runtime_reconcile.alert"
+
+mkdir -p "$(dirname "$LOG")" "$(dirname "$STATE")" "$(dirname "$ALERT_STAMP")"
+
+log() { printf '%s [runtime-reconcile] %s\n' "$(date '+%Y-%m-%d %H:%M:%S WITA')" "$*" >> "$LOG"; }
+
+if [[ "${NUZ_RUNTIME_RECONCILE_DISABLED:-0}" == "1" ]]; then
+  log "disabled via NUZ_RUNTIME_RECONCILE_DISABLED=1 — skipping"
+  exit 0
+fi
+
+# Best-effort Telegram, with cooldown so we never spam. Never fatal if it fails.
+alert() {
+  local msg="$1"
+  log "ALERT: $msg"
+  local now; now="$(date +%s)"
+  if [[ -f "$ALERT_STAMP" ]]; then
+    local last; last="$(cat "$ALERT_STAMP" 2>/dev/null || echo 0)"
+    if (( now - last < ALERT_COOLDOWN_SEC )); then
+      log "alert within cooldown — not paging again"
+      return 0
+    fi
+  fi
+  if [[ -f "$SECRETS" ]]; then
+    local tok cid
+    tok="$(grep '^TELEGRAM_BOT_TOKEN=' "$SECRETS" | head -1 | cut -d= -f2- | tr -d '"')" || true
+    cid="$(grep '^TELEGRAM_OWNER_CHAT_ID=' "$SECRETS" | head -1 | cut -d= -f2- | tr -d '"')" || true
+    if [[ -n "${tok:-}" && -n "${cid:-}" ]]; then
+      curl -s -m 10 "https://api.telegram.org/bot${tok}/sendMessage" \
+        --data-urlencode "chat_id=${cid}" \
+        --data-urlencode "text=🛟 runtime-reconcile P0 breach: ${msg}" >/dev/null 2>&1 || true
+    fi
+  fi
+  echo "$now" > "$ALERT_STAMP"
+}
+
+breaches=0
+note() { breaches=$((breaches+1)); log "INVARIANT BREACH: $*"; }
+
+# --- Invariant 1: the deploy runtime checkout must exist (the W81 check) ---
+deploy_exists=true
+if [[ ! -d "$DEPLOY_DIR/.git" ]]; then
+  deploy_exists=false
+  note "deploy runtime checkout missing: $DEPLOY_DIR (W81 vector)"
+fi
+
+# --- Invariant 2: deploy is a CLONE, not a worktree sharing the dirty main's .git ---
+# (council decision Q1: full clone, never worktree). A worktree has .git as a FILE.
+if $deploy_exists; then
+  if [[ -f "$DEPLOY_DIR/.git" ]]; then
+    note "deploy checkout is a git WORKTREE (.git is a file) — must be a full clone (scar W63/#5)"
+  fi
+fi
+
+# --- Invariant 3: deploy on the expected branch ---
+if $deploy_exists; then
+  cur_branch="$(git -C "$DEPLOY_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
+  if [[ "$cur_branch" != "$DEPLOY_BRANCH" && "$cur_branch" != "main" ]]; then
+    note "deploy on unexpected branch '$cur_branch' (want '$DEPLOY_BRANCH' or 'main')"
+  fi
+fi
+
+# --- Invariant 4: deploy pulled recently (puller not silently dead, the other half of W81) ---
+if $deploy_exists && [[ -f "$PULL_STATE" ]]; then
+  pull_mtime="$(stat -f %m "$PULL_STATE" 2>/dev/null || echo 0)"
+  age=$(( $(date +%s) - pull_mtime ))
+  if (( age > MAX_PULL_AGE_SEC )); then
+    note "deploy pull is stale: ${age}s since last pull-state (> ${MAX_PULL_AGE_SEC}s) — puller may be dead"
+  fi
+fi
+
+# --- write heartbeat (organism A2-observable) ---
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+status="ok"; [[ $breaches -gt 0 ]] && status="degraded"
+printf '{"ts":"%s","status":"%s","note":"breaches=%d deploy_exists=%s strict=%s"}\n' \
+  "$ts" "$status" "$breaches" "$deploy_exists" "$STRICT" > "$STATE" 2>/dev/null || true
+
+if (( breaches > 0 )); then
+  if [[ "$STRICT" == "1" ]]; then
+    alert "$breaches invariant breach(es) — see $LOG"
+    exit 1
+  else
+    log "P0 mode (STRICT=0): $breaches breach(es) recorded but not paging (split not armed yet)"
+    exit 0
+  fi
+fi
+
+log "all runtime invariants hold (deploy_exists=$deploy_exists)"
+exit 0

--- a/scripts/runtime_checkout_report.py
+++ b/scripts/runtime_checkout_report.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""runtime_checkout_report.py — which launchd organ runs from which checkout (SPEC split, P0).
+
+The migration (P2) needs to move ~104 launchd organs off the dirty main checkout onto the
+stable -deploy clone. Before moving anything you must KNOW, per organ, which checkout its
+installed plist currently points at. This script is that map — read-only, INERT, no migration.
+
+It cross-references:
+  - organs_registry.yaml  (the source of truth: organ id, runtime, label, owner_module)
+  - the installed *.plist files in ~/Library/LaunchAgents (what's ACTUALLY loaded)  [if present]
+  - the repo's infra/launchagents/*.plist                                            [fallback]
+
+and classifies each pro_launchd organ's runtime root as: deploy | dirty-main | external | unknown.
+
+This is the P0 deliverable that replaces "hand-edit 104 plists": it makes the drift VISIBLE and
+machine-readable so P2 can migrate from a list, not by eyeballing. It does NOT yet emit full
+generated plists — the registry lacks the launchd schedule/env/args fields for that; enriching
+the registry with those is its own step (flagged in the report as `registry_launchd_gap`).
+
+Usage:
+    python3 scripts/runtime_checkout_report.py [--repo DIR] [--launchagents DIR] [--json]
+Exit: 0 always (it's a report). Use --strict to exit 1 if any organ runs from dirty-main.
+"""
+from __future__ import annotations
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+DEPLOY_MARKER = "nuzantara-deploy"
+
+
+def _load_registry(repo: Path) -> list[dict]:
+    reg = repo / "apps" / "organism" / "organism" / "organs_registry.yaml"
+    d = yaml.safe_load(reg.read_text(encoding="utf-8"))
+    return [o for o in d.get("organs", []) if isinstance(o, dict) and o.get("id")]
+
+
+def _plist_paths(plist_text: str) -> list[str]:
+    """Extract every /Users/.../Desktop/nuzantara* path string from a plist."""
+    return re.findall(r"/Users/[^<\s]+/Desktop/nuzantara[A-Za-z0-9_./-]*", plist_text)
+
+
+def _classify_root(paths: list[str]) -> str:
+    if not paths:
+        return "unknown"
+    if any(DEPLOY_MARKER in p for p in paths):
+        return "deploy"
+    # any plain Desktop/nuzantara path that is NOT -deploy = the dirty main checkout
+    if any(re.search(r"/Desktop/nuzantara(?![A-Za-z0-9-])", p) for p in paths):
+        return "dirty-main"
+    return "external"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", default=str(Path.home() / "Desktop" / "nuzantara"))
+    ap.add_argument("--launchagents", default=str(Path.home() / "Library" / "LaunchAgents"))
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--strict", action="store_true", help="exit 1 if any organ runs from dirty-main")
+    args = ap.parse_args()
+
+    repo = Path(args.repo)
+    la_dir = Path(args.launchagents)
+    repo_la = repo / "infra" / "launchagents"
+
+    organs = _load_registry(repo)
+    rows = []
+    gap = 0
+    for o in organs:
+        if o.get("runtime") != "pro_launchd" or o.get("enabled") is False:
+            continue
+        label = (o.get("recovery_params") or {}).get("label")
+        # prefer the INSTALLED plist (truth), fall back to repo plist
+        text = None
+        src = None
+        if label:
+            for base in (la_dir, repo_la):
+                p = base / f"{label}.plist"
+                if p.exists():
+                    try:
+                        text = p.read_text(encoding="utf-8")
+                        src = str(p)
+                        break
+                    except OSError:
+                        continue
+        paths = _plist_paths(text) if text else []
+        root = _classify_root(paths) if text else "no-plist-found"
+        # registry_launchd_gap: organ has no installed/repo plist we can read → can't generate yet
+        if root in ("no-plist-found", "unknown"):
+            gap += 1
+        rows.append({
+            "id": o["id"],
+            "label": label,
+            "owner_module": o.get("owner_module"),
+            "runtime_root": root,
+            "plist_src": src,
+        })
+
+    by_root: dict[str, int] = {}
+    for r in rows:
+        by_root[r["runtime_root"]] = by_root.get(r["runtime_root"], 0) + 1
+
+    summary = {
+        "total_pro_launchd": len(rows),
+        "by_runtime_root": by_root,
+        "registry_launchd_gap": gap,
+        "note": "P2 must migrate every 'dirty-main' organ onto the -deploy clone.",
+    }
+
+    if args.json:
+        print(json.dumps({"summary": summary, "organs": rows}, indent=2))
+    else:
+        print("=== runtime checkout report (P0, read-only) ===")
+        print(f"total pro_launchd enabled organs: {summary['total_pro_launchd']}")
+        for root, n in sorted(by_root.items(), key=lambda kv: -kv[1]):
+            print(f"  {root:16s} {n}")
+        print(f"registry_launchd_gap (no readable plist): {gap}")
+        dm = [r for r in rows if r["runtime_root"] == "dirty-main"]
+        if dm:
+            print(f"\n-- {len(dm)} organs to migrate off dirty-main (sample 10) --")
+            for r in dm[:10]:
+                print(f"  {r['id']:38s} {r['label']}")
+
+    if args.strict and by_root.get("dirty-main", 0) > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Root cause (verified on Pro 2026-06-27)
`~/Desktop/nuzantara` is BOTH the h24 runtime (104 launchd organs run from it) AND a dirty dev scratch → it can't be pulled (169 commits / 6d behind origin/main), **every merge is sterile**, the live organs run stale code. 20 more organs point at `~/Desktop/nuzantara-deploy` which **vanished** (scar W81). This is the double scar #1 (HOME-fork) + #2 (merged≠armed) — and it's why #1755/#1760 (A2) are merged but not active on Pro.

## Fix (council-validated)
Designed via `sota-architecture-loop`: heterogeneous asymmetric council (Gemini red-team "destroy" + Codex constructive "salvage"). Decision: every runtime organ runs from a **read-only auto-pulled `-deploy` clone**; main becomes dev-only. Phased P0/P1/P2, each its own PR + operator gate.

## This PR = P0 only — INERT scaffolding
Nothing migrated, **no live organ touched**, everything kill-switchable. Three artifacts + runbook:

| file | role | kill-switch |
|---|---|---|
| `scripts/runtime-reconcile.sh` | anti-W81 watchdog (signaller). Asserts -deploy exists / is a clone not worktree / right branch / pulled recently. P0 warn-only, P1 flips to page. A2-observable heartbeat. | `NUZ_RUNTIME_RECONCILE_DISABLED=1` |
| `scripts/runtime-health-gate.sh` | pre-advance gate (council Q3): registry valid+checksum, owner_module scripts exist (≤tol), sentinel compiles, A2 test green → puller never ff's onto a broken commit. | `NUZ_RUNTIME_HEALTH_GATE_DISABLED=1` |
| `scripts/runtime_checkout_report.py` | read-only migration map: classifies each organ's runtime root (deploy/dirty-main/external). The list P2 migrates FROM. | (read-only) |
| `docs/runbooks/runtime-dev-checkout-split.md` | phases + operative steps | — |

## Verified on M5 (empirical, this session)
- `bash -n` / `py_compile` clean on all.
- health-gate → **SAFE/exit 0** against a real checkout (all 4 checks pass; owner_module-missing baseline 42 monitored, tol 60). Fixed a system-python `yaml` gap found in test → resolves via the checkout venv (Golden Rule #1).
- reconcile → correctly flags the **missing -deploy** in warn (exit 0) AND strict (exit 1) modes. It already proved its own value.
- all kill-switches work.

## Why P1/P2 are NOT in this PR (operator boundary, DNA L6)
They touch 104 production h24 organs (bounded restarts = real disruption) and need a clonable main — blocked today by a LIVE Pro session's 213 dirty files (scar #5, leave-dirty). Run when no live session is active on Pro. That's Zero's call.

## Scope
Pure inert tooling + docs. No PII, no backend-rag, no live organ, no migration. Worst case if merged and forgotten: three unused scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)