### PR TITLE
fix(infra): bound drive poll worker runtime

### DIFF
--- a/apps/backend-rag/backend/app/routers/admin_drive_health.py
+++ b/apps/backend-rag/backend/app/routers/admin_drive_health.py
@@ -271,7 +271,8 @@ async def _read_drive_poll_worker_status(pool: Any | None) -> dict[str, Any]:
             last_result = {"raw": raw_result[:500], "parse_error": True}
 
     status = values.get("drive_poll_worker_last_status") or "never_seen"
-    healthy = heartbeat_at is not None and not stale and status not in {"error"}
+    unhealthy_statuses = {"error", "timeout"}
+    healthy = heartbeat_at is not None and not stale and status not in unhealthy_statuses
     return {
         "mode": "worker",
         "available": True,

--- a/apps/backend-rag/backend/tests/unit/routers/test_admin_drive_health.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_admin_drive_health.py
@@ -112,6 +112,43 @@ async def test_drive_poll_status_redacts_worker_error_details() -> None:
 
 
 @pytest.mark.asyncio
+async def test_drive_poll_status_treats_worker_timeout_as_unhealthy() -> None:
+    pool = FakePool(
+        [
+            {
+                "key": "drive_poll_worker_heartbeat_at",
+                "value": "2099-01-01T00:00:00+00:00",
+                "updated_at": None,
+            },
+            {
+                "key": "drive_poll_worker_last_status",
+                "value": "timeout",
+                "updated_at": None,
+            },
+            {
+                "key": "drive_poll_worker_last_finished_at",
+                "value": "2099-01-01T00:14:00+00:00",
+                "updated_at": None,
+            },
+            {
+                "key": "drive_poll_worker_last_error",
+                "value": "Drive poll worker exceeded 840s",
+                "updated_at": None,
+            },
+        ],
+    )
+
+    with patch.dict("os.environ", {"DRIVE_POLL_API_MODE": ""}, clear=False):
+        result = await drive_poll_status(_request_with_pool(pool))
+
+    assert result["status"] == "stale"
+    assert result["result"]["status"] == "timeout"
+    assert result["result"]["healthy"] is False
+    assert result["result"]["stale"] is False
+    assert result["result"]["last_error_present"] is True
+
+
+@pytest.mark.asyncio
 async def test_trigger_drive_poll_defaults_to_worker_status_without_polling() -> None:
     poll_drive_changes = AsyncMock(return_value={"status": "ok", "processed": 2})
     pool = FakePool(

--- a/apps/backend-rag/backend/tests/unit/workers/test_drive_poll_worker.py
+++ b/apps/backend-rag/backend/tests/unit/workers/test_drive_poll_worker.py
@@ -40,6 +40,7 @@ def test_load_config_from_env() -> None:
             "DATABASE_URL": "postgresql://test/db",
             "DRIVE_POLL_WORKER_INTERVAL_SECONDS": "120",
             "DRIVE_POLL_WORKER_JITTER_SECONDS": "0",
+            "DRIVE_POLL_WORKER_TIMEOUT_SECONDS": "240",
             "DRIVE_POLL_WORKER_INLINE_OCR": "true",
         },
         clear=False,
@@ -49,6 +50,7 @@ def test_load_config_from_env() -> None:
     assert config.database_url == "postgresql://test/db"
     assert config.interval_seconds == 120
     assert config.jitter_seconds == 0
+    assert config.timeout_seconds == 240
     assert config.inline_ocr is True
     assert config.once is True
 
@@ -60,6 +62,7 @@ async def test_run_once_records_heartbeat_and_result() -> None:
         database_url="postgresql://test/db",
         interval_seconds=300,
         jitter_seconds=0,
+        timeout_seconds=840,
         inline_ocr=False,
         once=True,
     )
@@ -82,3 +85,46 @@ async def test_run_once_records_heartbeat_and_result() -> None:
     assert "drive_poll_worker_heartbeat_at" in written_keys
     assert "drive_poll_worker_last_status" in written_keys
     assert "drive_poll_worker_last_result" in written_keys
+
+
+@pytest.mark.asyncio
+async def test_run_once_records_timeout_state() -> None:
+    fake_pool = FakePool()
+    config = DrivePollWorkerConfig(
+        database_url="postgresql://test/db",
+        interval_seconds=300,
+        jitter_seconds=0,
+        timeout_seconds=60,
+        inline_ocr=False,
+        once=True,
+    )
+    poll = AsyncMock(return_value={"status": "ok"})
+
+    async def fake_wait_for(awaitable: Any, timeout: int) -> Any:
+        if hasattr(awaitable, "close"):
+            awaitable.close()
+        raise TimeoutError
+
+    with (
+        patch(
+            "backend.workers.drive_poll_worker.asyncpg.create_pool",
+            new=AsyncMock(return_value=fake_pool),
+        ),
+        patch("backend.workers.drive_poll_worker.poll_drive_changes", new=poll),
+        patch("backend.workers.drive_poll_worker.asyncio.wait_for", new=fake_wait_for),
+    ):
+        result = await run_once(config)
+
+    assert result == {
+        "status": "timeout",
+        "error": "Drive poll worker exceeded 60s",
+        "timeout_seconds": 60,
+    }
+    assert fake_pool.closed is True
+
+    written = {
+        call.args[1]: call.args[2] for call in fake_pool.conn.execute.await_args_list
+    }
+    assert written["drive_poll_worker_last_status"] == "timeout"
+    assert written["drive_poll_worker_last_error"] == "Drive poll worker exceeded 60s"
+    assert "drive_poll_worker_last_finished_at" in written

--- a/apps/backend-rag/backend/workers/drive_poll_worker.py
+++ b/apps/backend-rag/backend/workers/drive_poll_worker.py
@@ -31,6 +31,7 @@ class DrivePollWorkerConfig:
     database_url: str
     interval_seconds: int
     jitter_seconds: int
+    timeout_seconds: int
     inline_ocr: bool
     once: bool
 
@@ -80,6 +81,12 @@ def load_config(argv: list[str] | None = None) -> DrivePollWorkerConfig:
             default=10,
             minimum=0,
             maximum=120,
+        ),
+        timeout_seconds=_env_int(
+            "DRIVE_POLL_WORKER_TIMEOUT_SECONDS",
+            default=840,
+            minimum=60,
+            maximum=86_400,
         ),
         inline_ocr=_env_bool("DRIVE_POLL_WORKER_INLINE_OCR", default=False),
         once=args.once or _env_bool("DRIVE_POLL_WORKER_ONCE", default=False),
@@ -136,9 +143,12 @@ async def run_once(config: DrivePollWorkerConfig) -> dict[str, Any]:
     pool = await asyncpg.create_pool(config.database_url, min_size=1, max_size=1)
     try:
         await _record_state(pool, status="running", started_at=started_at)
-        result = await poll_drive_changes(
-            inline_ocr=config.inline_ocr,
-            acquire_advisory_lock=True,
+        result = await asyncio.wait_for(
+            poll_drive_changes(
+                inline_ocr=config.inline_ocr,
+                acquire_advisory_lock=True,
+            ),
+            timeout=config.timeout_seconds,
         )
         status = str(result.get("status", "unknown"))
         await _record_state(
@@ -149,6 +159,20 @@ async def run_once(config: DrivePollWorkerConfig) -> dict[str, Any]:
         )
         logger.info("Drive poll worker cycle finished: %s", result)
         return result
+    except TimeoutError:
+        error = f"Drive poll worker exceeded {config.timeout_seconds}s"
+        logger.error(error)
+        await _record_state(
+            pool,
+            status="timeout",
+            error=error,
+            finished_at=_utc_now_iso(),
+        )
+        return {
+            "status": "timeout",
+            "error": error,
+            "timeout_seconds": config.timeout_seconds,
+        }
     except Exception as exc:
         logger.exception("Drive poll worker cycle failed")
         await _record_state(

--- a/apps/backend-rag/fly.toml
+++ b/apps/backend-rag/fly.toml
@@ -42,6 +42,7 @@ primary_region = 'sin'
   RAG_WORKER_URL = 'http://rag.process.nuzantara-rag.internal:8080'
   DRIVE_POLL_API_MODE = 'worker'
   DRIVE_POLL_WORKER_INTERVAL_SECONDS = '300'
+  DRIVE_POLL_WORKER_TIMEOUT_SECONDS = '840'
   DRIVE_POLL_WORKER_INLINE_OCR = 'false'
   ZANTARA_ALLOWED_ORIGINS = 'https://balizero.com,https://www.balizero.com,https://kita.balizero.com,https://www.kita.balizero.com,https://mail.balizero.com,https://calendar.balizero.com,https://drive.balizero.com,https://knowledge.balizero.com,https://nuzantara-mouth.vercel.app'
   # SQLite persistence paths (mounted volume /data on api process, PR #75)


### PR DESCRIPTION
## Summary
- add a configurable Drive poll worker timeout (`DRIVE_POLL_WORKER_TIMEOUT_SECONDS`, default 840s)
- persist `timeout` worker state with `finished_at` and sanitized error details
- treat timeout worker state as unhealthy in `/api/admin/drive/poll/status`

## Verification
- `apps/backend-rag/.venv/bin/python -m pytest apps/backend-rag/backend/tests/unit/workers/test_drive_poll_worker.py apps/backend-rag/backend/tests/unit/routers/test_admin_drive_health.py -q` -> 11 passed
- `apps/backend-rag/.venv/bin/python -m py_compile apps/backend-rag/backend/workers/drive_poll_worker.py apps/backend-rag/backend/app/routers/admin_drive_health.py` -> passed
- `git diff --check` -> passed
- `apps/backend-rag/.venv/bin/ruff check apps/backend-rag/backend/workers/drive_poll_worker.py apps/backend-rag/backend/app/routers/admin_drive_health.py apps/backend-rag/backend/tests/unit/workers/test_drive_poll_worker.py apps/backend-rag/backend/tests/unit/routers/test_admin_drive_health.py` -> passed
- `cd apps/backend-rag && source .venv/bin/activate && python -c "from backend.app.dependencies import get_current_user; print('OK')"` -> OK
- `cd apps/backend-rag && source .venv/bin/activate && PYTHONPATH=. pytest backend/tests/services/rag/test_kg_langgraph.py backend/tests/services/rag/test_kg_subgraphs.py backend/tests/services/rag/test_confidence.py -q` -> 91 passed

Live trigger: post-#1761 Drive worker heartbeat went stale after a first cycle stayed `running` beyond 900s.
