### PR TITLE
fix(infra): dropbox-intake lock validates PID is our script (recycled-PID stale lock)

### DIFF
--- a/scripts/dropbox_intake_sync.sh
+++ b/scripts/dropbox_intake_sync.sh
@@ -48,12 +48,23 @@ if [ "$ENABLED" != "true" ]; then
 fi
 
 # Single-instance lock (a long backfill run keeps it; later cron ticks skip).
+# Validate the locked PID is OUR script, not just any live PID. The kernel
+# recycles PIDs: a stale lock pointing at a number later reassigned to an
+# unrelated process (e.g. syncthing) would make every tick exit 0 forever,
+# silently freezing the flow while the state-file goes stale and the sentinel
+# stays blind. Trust the lock only if the live process is dropbox-intake-sync.
+# (scar #2 "esiste ≠ armato" — recycled-PID stale-lock, 2026-06-27)
+LOCK_TAG="dropbox-intake-sync"
 if [ -f "$LOCK_FILE" ]; then
   PID=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
   if [ -n "$PID" ] && ps -p "$PID" >/dev/null 2>&1; then
-    log "another run alive (PID $PID) — exit 0"
-    exit 0
+    if ps -p "$PID" -o command= 2>/dev/null | grep -q "$LOCK_TAG"; then
+      log "another run alive (PID $PID) — exit 0"
+      exit 0
+    fi
+    log "stale lock: PID $PID alive but not $LOCK_TAG (recycled PID) — reclaiming"
   fi
+  rm -f "$LOCK_FILE"
 fi
 echo $$ > "$LOCK_FILE"
 trap 'rm -f "$LOCK_FILE"' EXIT


### PR DESCRIPTION
## Problem (found live, 2026-06-27)

User asked whether the Dropbox→Drive intake was still operating. It was **not** — frozen for ~36h, yet `launchctl` showed it green (scar #2, *esiste ≠ armato*).

Root cause: the single-instance lock in `dropbox_intake_sync.sh` trusted **any** live PID found in the lock file:

```bash
if [ -n "$PID" ] && ps -p "$PID" >/dev/null 2>&1; then exit 0; fi
```

The kernel recycles PIDs. The lock held PID `1392`, which the OS had reassigned to `syncthing`. So every 10-min tick saw "a live PID" → logged `another run alive (PID 1392) — exit 0` → did nothing. For ~36h. Meanwhile:
- last real `rclone copy` died 27/06 06:35 at 69% (~10k files pending),
- the sentinel state-file froze at 16/06 (`status:fail`) because the script exits on the lock *before* it writes state → the sentinel was blind too.

Immediate unblock (done): removed the orphan lock + kickstarted → `rclone copy` confirmed live (new PID, fresh run-log). This PR closes the **class**.

## Fix

Trust the lock only if the live process's command line actually matches `dropbox-intake-sync`. A recycled/unrelated PID → stale lock → reclaim and proceed.

## Tests (innocence + guilt)

| Scenario | Decision | |
|---|---|---|
| Lock PID alive but unrelated process (recycled) | `PROCEED` (reclaim) | ✓ |
| Lock PID alive and argv contains `dropbox-intake-sync` (genuine run) | `SKIP` | ✓ |
| No lock file | `PROCEED` | ✓ |

`bash -n` clean.

## Deploy note (HOME-fork discipline)

Runtime copy lives at `~/scripts/dropbox-intake-sync.sh` on the **Pro**. After merge, re-run `infra/launchagents/install_dropbox_intake.sh` on the Pro to propagate (scar family W50/W51/W52) — otherwise the live copy keeps the old lock logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)