### PR TITLE
fix(intake): self-heal worker venv before trusting it (scar W81b)

### DIFF
--- a/apps/backend-rag/backend/services/intake/intake-worker-run.sh
+++ b/apps/backend-rag/backend/services/intake/intake-worker-run.sh
@@ -24,6 +24,38 @@ if ! flock -n 9; then
 fi
 
 cd "${BACKEND}"
+
+# Self-heal the venv before trusting it (scar W81b "venv-SKELETON", 2026-06-27).
+# The deploy worktree's venv has been left unusable three distinct ways: a dead
+# python symlink (pyenv target moved), a corrupt vendored pip, and a skeleton
+# with zero deps after a venv recreate that never ran `pip install`. Each kills
+# the worker silently with ModuleNotFoundError while launchctl shows green — the
+# WhatsApp/Drive intake then stalls for hours with no alarm. One probe covers all
+# three: if the venv python can't import asyncpg (the worker's first import), the
+# venv is unusable → rebuild it from scratch + install from requirements.txt
+# (NOT requirements.lock.txt: its editable cell-core + hashes are mutually
+# exclusive in pip). Idempotent: a healthy venv skips straight past this.
+VENV_PY=".venv/bin/python"
+if ! "${VENV_PY}" -c "import asyncpg" >/dev/null 2>&1; then
+    echo "[intake-worker] venv unusable (asyncpg import failed) — rebuilding (scar W81b)" >&2
+    PYBASE="$(command -v python3.11 || echo /Users/nuzantara/.pyenv/versions/3.11.11/bin/python3.11)"
+    rm -rf .venv
+    if ! "${PYBASE}" -m venv .venv; then
+        echo "[intake-worker] FATAL: venv create failed with ${PYBASE}" >&2
+        exit 78
+    fi
+    .venv/bin/python -m pip install --quiet --upgrade pip >&2 || true
+    if ! .venv/bin/python -m pip install --quiet --disable-pip-version-check -r requirements.txt >&2; then
+        echo "[intake-worker] FATAL: dependency install failed" >&2
+        exit 78
+    fi
+    if ! "${VENV_PY}" -c "import asyncpg" >/dev/null 2>&1; then
+        echo "[intake-worker] FATAL: venv still broken after rebuild — not starting" >&2
+        exit 78
+    fi
+    echo "[intake-worker] venv rebuilt OK" >&2
+fi
+
 # shellcheck disable=SC1091
 source .venv/bin/activate
 


### PR DESCRIPTION
## Problem (found live, 2026-06-27)

Tracing \"who processes WhatsApp intake?\", found the **intake-worker LaunchAgent dead** (`ModuleNotFoundError: asyncpg`, `LastExitStatus=256`) while ~75 live WhatsApp client docs + 90k Drive docs sat pending with **nobody processing them**. WhatsApp keeps arriving (2/hour) → live client documents accumulating silently.

Root cause: the worker's venv (`~/Desktop/nuzantara-deploy/apps/backend-rag/.venv`) was a **7-package skeleton** vs 823 in the healthy main-checkout venv. Recreated today 18:37 (during a deploy pull) without ever running `pip install`. The wrapper did `source .venv/bin/activate; exec python` with **no check the venv was usable** → instant crash on first import, green exit code masking it (scar #2 esiste≠armato + #1 HOME-fork = **W81b venv-SKELETON**).

Observed THREE distinct ways the deploy venv has been left unusable:
1. dead python symlink (pyenv target moved)
2. corrupt vendored pip (`ImportError: RequirementInformation from resolvelib`)
3. skeleton with zero deps (venv recreated, install never ran)

## Fix

One probe covers all three: if the venv python can't `import asyncpg` (the worker's first import), rebuild from scratch + install from **`requirements.txt`** (NOT the lock — its editable `cell-core` + hashes are mutually exclusive in pip). Runs inside the existing `flock` so a concurrent tick can't race it. Fatal `exit 78` if the rebuild fails, so a genuinely broken env surfaces instead of flapping.

Sibling cron `wr2.html-apply` already had this auto-heal; `intake-worker` did not.

## Verification (done live on Pro)

- Healed the deploy venv manually → `asyncpg/httpx/fastapi/pydantic OK`, `worker module imports OK`.
- Kickstarted worker → `intake worker started`, `job 181198 stage=classify ok pending->ocr_done`, **4 active leases, queue advancing**. WhatsApp + Drive intake resumed.
- Auto-heal logic tested: healthy venv → probe passes → **skips** rebuild (innocence); broken/empty venv → probe **detects** (guilt).
- `bash -n` clean.

## Deploy note (HOME-fork)

Runtime copy is at `~/Desktop/nuzantara-deploy/.../intake-worker-run.sh` on the Pro. After merge the deploy worktree pulls it on next sync; the live worker already runs the healed venv. The auto-heal makes the NEXT deploy-induced venv breakage self-recover instead of silently stalling intake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)