### PR TITLE
fix(mouth/kbli): align PROD KBLI Navigator (balizero.com/kbli) PMA with native app — 34 wrong codes

### DIFF
--- a/apps/mouth/src/app/kbli/[code]/page.tsx
+++ b/apps/mouth/src/app/kbli/[code]/page.tsx
@@ -14,6 +14,7 @@ import { PMABadge } from "@/components/kbli/PMABadge";
 import { RiskBadge } from "@/components/kbli/RiskBadge";
 import { TransitionBadge } from "@/components/kbli/TransitionBadge";
 import { BaliStatusBadge } from "@/components/kbli/BaliStatusBadge";
+import { cn } from "@/lib/utils";
 import { KBLICard } from "@/components/kbli/KBLICard";
 import {
   KBLICodeJsonLd,
@@ -57,7 +58,9 @@ export async function generateMetadata({
     kbli.pma.status === "open"
       ? "100% Foreign Ownership"
       : kbli.pma.status === "restricted"
-        ? `Restricted (max ${kbli.pma.maxForeign}% foreign)`
+        ? kbli.pma.capSpecial
+          ? "Restricted (special distribution conditions)"
+          : `Restricted (max ${kbli.pma.maxForeign}% foreign)`
         : "Closed to Foreign Investment";
 
   const title = `KBLI ${kbli.code}: ${kbli.titleEn} — Indonesia Business Guide 2025`;
@@ -238,11 +241,62 @@ export default async function KBLICodePage({
                 </p>
               )}
 
+              {/* PMA verdict banner — the binding answer for a PT PMA, aligned with the native app */}
+              {(() => {
+                const baliBlocked = !!kbli.baliL4?.blocked;
+                const nationallyClosed =
+                  !kbli.pma.capSpecial &&
+                  (kbli.pma.status === "closed" || kbli.pma.maxForeign === 0);
+                const pmaBlocked = baliBlocked || nationallyClosed;
+                return (
+                  <>
+                    <div
+                      className={cn(
+                        "mt-5 rounded-xl border px-4 py-3",
+                        pmaBlocked
+                          ? "border-[var(--kbli-pma-closed)]/30 bg-[var(--kbli-pma-closed-bg)]"
+                          : "border-[var(--kbli-pma-open)]/30 bg-[var(--kbli-pma-open-bg)]",
+                      )}
+                    >
+                      <p
+                        className={cn(
+                          "text-base font-semibold",
+                          pmaBlocked
+                            ? "text-[var(--kbli-pma-closed)]"
+                            : "text-[var(--kbli-pma-open)]",
+                        )}
+                      >
+                        {nationallyClosed
+                          ? `Closed to PMA (national)${kbli.pma.routeTo ? ` — route to the private code ${kbli.pma.routeTo}` : ""}`
+                          : baliBlocked
+                            ? "In Bali: a PT PMA cannot register this code"
+                            : "In Bali: open to a PT PMA"}
+                      </p>
+                    </div>
+                    {baliBlocked && !nationallyClosed && (
+                      <div className="mt-3 rounded-xl border border-[var(--kbli-pma-restricted)]/30 bg-[var(--kbli-pma-restricted-bg)] px-4 py-3">
+                        <p className="text-sm font-semibold text-[var(--kbli-pma-restricted)]">
+                          National procedure — does not apply to a PT PMA in
+                          Bali
+                        </p>
+                        <p className="mt-1 text-sm text-[var(--kbli-text-muted)]">
+                          In Bali this activity is reserved for MSMEs; a PT PMA
+                          (large enterprise) cannot register it. The national
+                          procedure below applies only to non-PMA operators.
+                        </p>
+                      </div>
+                    )}
+                  </>
+                );
+              })()}
+
               {/* Badge strip */}
               <div className="mt-5 flex flex-wrap gap-2.5">
                 <PMABadge
                   status={kbli.pma.status}
                   maxForeign={kbli.pma.maxForeign}
+                  capSpecial={kbli.pma.capSpecial}
+                  capVerified={kbli.pma.capVerified}
                 />
                 {kbli.licensing[0] && (
                   <RiskBadge category={kbli.licensing[0].riskCategory} />
@@ -722,11 +776,15 @@ export default async function KBLICodePage({
                             Foreign Ownership
                           </span>
                           <span className="text-sm font-semibold text-[var(--foreground)]">
-                            {kbli.pma.status === "open"
-                              ? `${kbli.pma.maxForeign}% Open`
-                              : kbli.pma.status === "restricted"
-                                ? `Max ${kbli.pma.maxForeign}%`
-                                : "Closed"}
+                            {kbli.pma.capSpecial
+                              ? "Restricted · special conditions"
+                              : kbli.pma.status === "open"
+                                ? `${kbli.pma.maxForeign}% Open`
+                                : kbli.pma.status === "restricted"
+                                  ? kbli.pma.capVerified
+                                    ? `Max ${kbli.pma.maxForeign}%`
+                                    : `≈${kbli.pma.maxForeign}% (unverified)`
+                                  : "Closed"}
                           </span>
                         </div>
                         <div
@@ -821,7 +879,9 @@ export default async function KBLICodePage({
                       {kbli.pma.status === "open"
                         ? `Yes. KBLI ${kbli.code} (${kbli.titleId}) is classified as TERBUKA — open to 100% foreign ownership through a PT PMA company. You do not need a local Indonesian partner.`
                         : kbli.pma.status === "restricted"
-                          ? `Partially. KBLI ${kbli.code} (${kbli.titleId}) is classified as TERBATAS — foreign ownership is capped at ${kbli.pma.maxForeign}%. You will need an Indonesian partner for the remaining shares.${kbli.pma.condition ? ` Condition: ${kbli.pma.condition}` : ""}`
+                          ? kbli.pma.capSpecial
+                            ? `Conditionally. KBLI ${kbli.code} (${kbli.titleId}) is TERBATAS with special distribution conditions (open to foreign ownership but subject to a special distribution-network/location requirement — verify the exact terms in OSS).${kbli.pma.condition ? ` Condition: ${kbli.pma.condition}` : ""}`
+                            : `Partially. KBLI ${kbli.code} (${kbli.titleId}) is classified as TERBATAS — foreign ownership is ${kbli.pma.capVerified ? "capped" : "indicatively capped (unverified)"} at ${kbli.pma.maxForeign}%. You will need an Indonesian partner for the remaining shares.${kbli.pma.condition ? ` Condition: ${kbli.pma.condition}` : ""}`
                           : `No. KBLI ${kbli.code} (${kbli.titleId}) is classified as TERTUTUP — closed to foreign investment. This business activity is reserved for Indonesian nationals.`}
                     </div>
                   </details>

--- a/apps/mouth/src/components/kbli/PMABadge.tsx
+++ b/apps/mouth/src/components/kbli/PMABadge.tsx
@@ -2,7 +2,11 @@ import { cn } from "@/lib/utils";
 
 interface PMABadgeProps {
   status: "open" | "restricted" | "closed" | "unknown";
-  maxForeign: number;
+  maxForeign: number | "special";
+  /** true => special-distribution condition (47221-class): "· special conditions", not "Closed 0%" */
+  capSpecial?: boolean;
+  /** false => TERBATAS cap % not source-backed: render "· ≈N% unverified" */
+  capVerified?: boolean;
   size?: "sm" | "md";
 }
 
@@ -32,8 +36,30 @@ const config = {
   },
 };
 
-export function PMABadge({ status, maxForeign, size = "md" }: PMABadgeProps) {
+export function PMABadge({
+  status,
+  maxForeign,
+  capSpecial = false,
+  capVerified = true,
+  size = "md",
+}: PMABadgeProps) {
   const c = config[status] || config.open;
+  const numeric = typeof maxForeign === "number" ? maxForeign : null;
+
+  // Qualifying suffix, aligned with the native app:
+  //  - special-distribution → "· special conditions" (never a %)
+  //  - restricted & unverified % → "· ≈N% unverified"
+  //  - restricted & verified % → "· Max N%"
+  //  - open 100% → "· 100% Foreign"
+  let suffix: string | null = null;
+  if (capSpecial) {
+    suffix = "· special conditions";
+  } else if (status === "open" && numeric === 100) {
+    suffix = "· 100% Foreign";
+  } else if (status === "restricted" && numeric !== null && numeric < 100) {
+    suffix = capVerified ? `· Max ${numeric}%` : `· ≈${numeric}% unverified`;
+  }
+
   return (
     <span
       className={cn(
@@ -44,12 +70,7 @@ export function PMABadge({ status, maxForeign, size = "md" }: PMABadgeProps) {
     >
       <span>{c.icon}</span>
       <span>{c.label}</span>
-      {status === "open" && maxForeign === 100 && (
-        <span className="opacity-70">· 100% Foreign</span>
-      )}
-      {status === "restricted" && maxForeign < 100 && (
-        <span className="opacity-70">· Max {maxForeign}%</span>
-      )}
+      {suffix && <span className="opacity-70">{suffix}</span>}
     </span>
   );
 }

--- a/apps/mouth/src/lib/kbli-data.server.ts
+++ b/apps/mouth/src/lib/kbli-data.server.ts
@@ -233,6 +233,9 @@ function transformCode(
       isPriority: raw.pma_prioritas || false,
       note: raw.pma_nota,
       source: raw.pma_source,
+      capSpecial: raw.pma_cap_special === true,
+      capVerified: raw.pma_cap_verified !== false,
+      routeTo: raw.pma_route_to ?? null,
     },
     licensing: (raw.per_skala || []).map((s) => ({
       scales: s.skala_usaha,

--- a/apps/mouth/src/lib/kbli-data.ts
+++ b/apps/mouth/src/lib/kbli-data.ts
@@ -383,6 +383,9 @@ function transformRecord(raw: KBLIRawCode): KBLICode {
     isPriority: raw.pma_prioritas,
     note: raw.pma_nota,
     source: raw.pma_source,
+    capSpecial: raw.pma_cap_special === true,
+    capVerified: raw.pma_cap_verified !== false, // default true unless explicitly flagged unverified
+    routeTo: raw.pma_route_to ?? null,
   };
 
   const licensing: KBLILicenseByScale[] = (raw.per_skala ?? []).map(

--- a/apps/mouth/src/lib/kbli-search.test.ts
+++ b/apps/mouth/src/lib/kbli-search.test.ts
@@ -18,6 +18,9 @@ function makeCode(
       isPriority: false,
       note: null,
       source: null,
+      capSpecial: false,
+      capVerified: true,
+      routeTo: null,
     },
     licensing: [
       {
@@ -71,6 +74,9 @@ const closedHotel = makeCode({
     isPriority: false,
     note: null,
     source: null,
+    capSpecial: false,
+    capVerified: true,
+    routeTo: null,
   },
   licensing: [
     {

--- a/apps/mouth/src/lib/kbli-types.ts
+++ b/apps/mouth/src/lib/kbli-types.ts
@@ -56,11 +56,15 @@ export interface KBLIRawCode {
   status_mapping: KBLIMappingStatus;
   pp28_sources: string[];
   pma_status: KBLIPmaRawStatus;
-  pma_max_asing: number;
+  pma_max_asing: number | 'special'; // "special" = open-with-special-conditions (47221-class), no clean %
   pma_kondisi: string | null;
   pma_prioritas: boolean;
   pma_nota: string | null;
   pma_source: string | null;
+  // PMA cap provenance (synced from the native app dataset, 2026-06-27)
+  pma_cap_special?: boolean; // true => special-distribution condition, render "special conditions" not "Closed 0%"
+  pma_cap_verified?: boolean; // false => TERBATAS cap % not source-backed, render "≈N% unverified"
+  pma_route_to?: string; // sibling private code when a govt code is closed to PMA
   _source: string;
   // Optional fields (present on some records)
   aggregation_note?: string;
@@ -132,11 +136,15 @@ export type KBLIMatchType =
 /** PMA (foreign investment) details — processed */
 export interface KBLIPmaInfo {
   status: KBLIPmaStatus;
-  maxForeign: number;
+  maxForeign: number | "special";
   condition: string | null;
   isPriority: boolean;
   note: string | null;
   source: string | null;
+  // Synced from native app (2026-06-27): provenance flags that change the label.
+  capSpecial: boolean; // special-distribution (47221) → "special conditions", not "Closed 0%"
+  capVerified: boolean; // false → TERBATAS % not source-backed → "≈N% unverified"
+  routeTo: string | null; // sibling private code when a govt code is closed to PMA (86101→86103)
 }
 
 /** Processed licensing entry for a specific business scale */


### PR DESCRIPTION
## Problem — this is the REAL prod fix

`balizero.com/kbli` is served by **`apps/mouth`**, NOT `apps/kbli-navigator` (which is a 404 preview alias, 301-redirects `/kbli-navigator` → `/kbli`). PR #1767 aligned the preview app; **this PR aligns the production one.**

The prod KBLI Navigator showed **34 codes with WRONG foreign-ownership**, the most dangerous being **20 governmental codes** telling a foreigner they can own **100%** of a public hospital / public school / government clinic (`86101`, `85101`, `86104`, `87201`…). Plus 7 sea-transport (49% cap lost) and 7 official-lampiran codes (`47221`, `47222`, `73100`, `02102`, `03110`…).

## Fix

**Data** — `apps/mouth/data/KBLI_2025_FINAL_CLEAN.json` (tracked → ships to Vercel) replaced with the native-app dataset: verified superset (1559 codes, 34 corrected, `pma_cap_special`/`pma_cap_verified` carried, **zero fields lost**).

**Rendering** (mouth already mapped `l4_bali.blocked` and had a `BaliStatusBadge` fallback, so fewer changes than the kbli-navigator twin):
- types + **both** transformers (`kbli-data.ts` + `kbli-data.server.ts` — mouth has two): `pma_max_asing` now `number|'special'`, `capSpecial`/`capVerified`/`routeTo` propagated.
- `PMABadge`: special-distribution → "· special conditions" (not "Closed 0%"); unverified TERBATAS → "· ≈N% unverified".
- `[code]/page.tsx`: PMA verdict banner (open / closed-national+routeTo / cannot-register-Bali) + reserved-for-MSME callout, gated on `baliL4.blocked`; **4** maxForeign sites (pmaLabel, KeyFacts, the FAQ prose) made special/unverified-aware.

## Verification

- `tsc --noEmit` clean (caught & fixed 3 sites: a second transformer + 2 test mocks).
- `next build` green.
- **Runtime check** (`next start` + curl): `86101` → "Closed to PMA (national) — route to the private code 86103"; `47221` → "In Bali: open to a PT PMA" + "special conditions".

Makes the **production** Navigator at balizero.com/kbli coincide with the native app on the money question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)