### PR TITLE
fix(infra): clear stale drive worker error after success

### DIFF
--- a/apps/backend-rag/backend/tests/unit/workers/test_drive_poll_worker.py
+++ b/apps/backend-rag/backend/tests/unit/workers/test_drive_poll_worker.py
@@ -85,6 +85,10 @@ async def test_run_once_records_heartbeat_and_result() -> None:
     assert "drive_poll_worker_heartbeat_at" in written_keys
     assert "drive_poll_worker_last_status" in written_keys
     assert "drive_poll_worker_last_result" in written_keys
+    written = {
+        call.args[1]: call.args[2] for call in fake_pool.conn.execute.await_args_list
+    }
+    assert written["drive_poll_worker_last_error"] == ""
 
 
 @pytest.mark.asyncio

--- a/apps/backend-rag/backend/workers/drive_poll_worker.py
+++ b/apps/backend-rag/backend/workers/drive_poll_worker.py
@@ -155,6 +155,7 @@ async def run_once(config: DrivePollWorkerConfig) -> dict[str, Any]:
             pool,
             status=status,
             result=result,
+            error="",
             finished_at=_utc_now_iso(),
         )
         logger.info("Drive poll worker cycle finished: %s", result)


### PR DESCRIPTION
## Summary
- clear the Drive poll worker last_error heartbeat key after successful or partial worker cycles
- add unit coverage proving successful run_once writes an empty last_error value

## Verification
- apps/backend-rag/.venv/bin/python -m pytest apps/backend-rag/backend/tests/unit/workers/test_drive_poll_worker.py apps/backend-rag/backend/tests/unit/routers/test_admin_drive_health.py -q

## Live ops note
- Production system_settings.drive_poll_worker_last_error was cleared separately after verifying the worker was healthy, status=partial, and heartbeat age was under 15 minutes.