### PR TITLE
docs(kbli-navigator): native macOS app spec + design + plan

### DIFF
--- a/docs/superpowers/plans/2026-06-23-kbli-navigator-native-app.md
+++ b/docs/superpowers/plans/2026-06-23-kbli-navigator-native-app.md
@@ -1,0 +1,182 @@
+# KBLI Navigator Native App — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans (inline). Steps use checkbox (`- [ ]`).
+
+**Goal:** Native macOS SwiftUI app to browse KBLI 2025 codes (search → editorial detail with Bali-moratorium status), read the book/articles (media), and chat with a KBLI-grounded Zantara (GPT-5.5 via OpenClaw), running native on M5+Pro+Mini.
+
+**Architecture:** Standalone repo `~/Desktop/kbli-navigator-app` (like `wr2-control-app`), compiled with `build.sh` (swiftc + Xcode-beta macro plugin) → `.app`. 3 isolated units (KBLIStore / MediaLibrary / OpenClawRunner) wired by a thin KBLI-specific `AppState`. Data bundled in `Resources/` (offline). Chat = single OpenClaw brain on Mini, reached locally on Mini or via `ssh mini` from M5/Pro.
+
+**Tech Stack:** SwiftUI, AppKit, PDFKit, Foundation (AttributedString) — Apple-native only, NO Swift Package Manager. zsh `build.sh`. OpenClaw CLI (`agent --json`) as chat backend.
+
+## Global Constraints
+
+- **NO Swift Package Manager** — only Apple frameworks + single-file vendored Swift (build.sh swiftc constraint).
+- **Target:** `arm64-apple-macosx26.0`. Xcode-beta at `~/Downloads/Xcode-beta.app` (M5) or `/Applications/Xcode.app` (Pro).
+- **No Anthropic SDK / no paid API.** Chat = OpenClaw (GPT-5.5 via MAX-sanctioned codex auth on Mini). Strip `ANTHROPIC_API_KEY` from child env (defense-in-depth, like ClaudeRunner).
+- **Dataset:** `KBLI_2025_FINAL_CLEAN.json` v10.0-L2-oss-risk (1559 records) from `.worktrees/intel-kbli-rag-source-align/apps/mouth/data/`. Fields: `kode_kbli_2025`, `judul`, `uraian`, `ruang_lingkup`, `per_skala[]`, `pma_status`, `l4_bali{status,reason,blocked,moratorium{...}}`.
+- **Content source:** `~/Desktop/KBLI-2025-Content/` (20 articles, 13 book-chapters, 2 PDFs EN/ID).
+- **PII:** none (public codes). All grounding/retrieval local.
+- **After each Task:** severe 4-LLM/Codex review of the diff + run tests. Operator gate stays with parent (verify on disk in-turn).
+- **Markdown renderer (F3 decision):** vendored block renderer handling `#/##/###`, `- `/`* ` bullets (1 level nesting), `> ` blockquote, `**bold**`/`*italic*`/`[link](url)` inline via per-line `AttributedString(markdown:)`, paragraph spacing, fenced ``` code. Target the article corpus shape, not full GFM (no tables — articles use them sparsely; render raw `|` rows monospaced as fallback, logged).
+
+---
+
+### Task 0: Repo scaffold + build.sh + empty app launches
+
+**Files:**
+- Create: `~/Desktop/kbli-navigator-app/build.sh` (adapt from wr2-control-app)
+- Create: `~/Desktop/kbli-navigator-app/Info.plist`
+- Create: `~/Desktop/kbli-navigator-app/Sources/KBLINavigatorApp.swift`
+- Create: `~/Desktop/kbli-navigator-app/Sources/Theme.swift` (copy from WR2)
+- Create: `~/Desktop/kbli-navigator-app/.gitignore` (`build/`)
+
+**Interfaces:**
+- Produces: a buildable `.app` skeleton; `Theme` enum (colors/fonts) reused by all views.
+
+- [ ] **Step 1:** `git init` repo, copy `Theme.swift` verbatim from `~/Desktop/wr2-control-app/Sources/Theme.swift`, copy+adapt `build.sh` (rename APP_NAME="KBLI Navigator", EXEC="KBLINavigator"), copy `Info.plist` (bundle id `com.balizero.kbli-navigator`).
+- [ ] **Step 2:** Write minimal `KBLINavigatorApp.swift`: `@main struct App` with `WindowGroup` showing `Text("KBLI Navigator")`.
+- [ ] **Step 3:** Run `./build.sh` → expect exit 0, `build/KBLI Navigator.app` created.
+- [ ] **Step 4:** `open "build/KBLI Navigator.app"` → window appears with the text.
+- [ ] **Step 5:** Commit `chore: scaffold kbli-navigator app skeleton + build.sh`.
+
+---
+
+### Task 1: Models + KBLIStore (load 1559, search ranking)
+
+**Files:**
+- Create: `Sources/Models.swift` — `KBLI`, `PerSkala`, `L4Bali`, `Moratorium` (Codable, map JSON keys)
+- Create: `Sources/KBLIStore.swift` — `final class KBLIStore: ObservableObject`, loads bundled JSON, `func search(_ q: String) -> [KBLI]` (ranked), `func code(_ k: String) -> KBLI?`
+- Create: `Tests/storetest/main.swift` — standalone executable test
+- Resource: copy `KBLI_2025_FINAL_CLEAN.json` into `Resources/`
+
+**Interfaces:**
+- Produces: `KBLI { kode: String, judul: String, uraian: String, ruangLingkup: String?, perSkala: [PerSkala], pmaStatus: String?, l4Bali: L4Bali? }`; `L4Bali { status: String, reason: String?, blocked: Bool, moratorium: Moratorium? }`; `KBLIStore.search(q) -> [KBLI]` ranked exact-code>prefix-code>judul-prefix>substring; `KBLIStore.code(k) -> KBLI?`.
+
+- [ ] **Step 1:** Write `Tests/storetest/main.swift`: load JSON from `Resources/`, assert `store.all.count == 1559`, `store.code("55203")?.l4Bali?.status == "CHIUSO_PMA_NO_BESAR"`, `store.code("55203")?.l4Bali?.blocked == true`, `store.search("55203").first?.kode == "55203"`, `store.search("villa").contains{$0.kode=="55203"}`.
+- [ ] **Step 2:** Run test → FAIL (no Models/KBLIStore).
+- [ ] **Step 3:** Write `Models.swift` (CodingKeys mapping `kode_kbli_2025`→`kode` etc.) + `KBLIStore.swift` (decode `data` array, `rank()` per research snippet, search sorted by rank then code).
+- [ ] **Step 4:** Run test → PASS (all asserts).
+- [ ] **Step 5:** Commit `feat: KBLI models + store with ranked search (1559 codes)`.
+
+---
+
+### Task 2: NavigationSplitView shell + AppState (surgical fork) + search list
+
+**Files:**
+- Create: `Sources/AppState.swift` — slim KBLI `ObservableObject` (selectedKBLI, query, chat state) — NO WarRoom/QueueWriter
+- Create: `Sources/Localization.swift` — copy LanguageManager from WR2, replace keys with KBLI ones (IT/EN/ID)
+- Create: `Sources/Views/RootView.swift` — `NavigationSplitView` 3-col (sidebar Section enum / search list / detail)
+- Create: `Sources/Views/SearchListView.swift` — `.searchable` + `List` of results with status badge
+- Modify: `KBLINavigatorApp.swift` — wire AppState + RootView
+
+**Interfaces:**
+- Consumes: `KBLIStore.search`, `KBLI`.
+- Produces: `enum Section { search, media, chat }`; `AppState { @Published query, @Published selected: KBLI?, store: KBLIStore }`; `statusColor(_ status:String)->Color` + `statusSymbol(_:)->String` helpers.
+
+- [ ] **Step 1:** Write `Tests/uitest/main.swift` (logic-only): assert `statusColor("OK_or_HIGHER_RISK")==Theme.green`, `statusColor("BLOCCATO_CLASSE_RISCHIO")==Theme.red`, `statusSymbol("NEEDS_REVIEW_NO_OSS_SCOPE")=="questionmark.circle"`.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Implement `AppState`, `Section`, status helpers, `RootView` (NavigationSplitView), `SearchListView` (.searchable bound to AppState.query, List of `store.search(query)` rows: badge + kode mono + judul, selection → AppState.selected).
+- [ ] **Step 4:** Run helper test → PASS. Build → exit 0. `open` → sidebar + search bar; typing "55203" shows the row.
+- [ ] **Step 5:** Commit `feat: 3-col NavigationSplitView shell + searchable code list`.
+
+---
+
+### Task 3: KBLIDetailView (editorial card + moratorium callout)
+
+**Files:**
+- Create: `Sources/Views/KBLIDetailView.swift`
+
+**Interfaces:**
+- Consumes: `KBLI`, `L4Bali`, status helpers.
+- Produces: detail view rendering header(badge+kode+judul+pma) / moratorium callout (if `l4Bali.blocked`) / uraian+scope / per-skala GroupBoxes / "Ask Zantara" toolbar button → `AppState.openChat(forCode:)`.
+
+- [ ] **Step 1:** Write logic test in uitest: `KBLIDetailView.shouldShowMoratorium(l4)` true when `blocked==true`, false otherwise; `moratoriumText(l4)` contains "2026-05-13" for 55203.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Implement `KBLIDetailView`: `ScrollView` of `GroupBox` sections on material (no dividers), amber callout for moratorium, per-skala cards, `.toolbar` primaryAction "Ask Zantara".
+- [ ] **Step 4:** Test PASS; build+open, select 55203 → red badge + amber moratorium callout w/ 13/5/26.
+- [ ] **Step 5:** Commit `feat: KBLI detail card with Bali-moratorium callout`.
+
+---
+
+### Task 4: MediaLibrary + MarkdownView + PDFViewer
+
+**Files:**
+- Create: `Sources/MediaLibrary.swift` — enumerate articles/chapters/pdf from Resources
+- Create: `Sources/MarkdownView.swift` — vendored block renderer (per Global Constraints)
+- Create: `Sources/Views/MediaView.swift` — list + markdown detail + PDF tab (PDFKit NSViewRepresentable, bg-thread load)
+- Resource: copy 20 articles + 13 chapters + 2 PDFs into `Resources/`
+- Test: `Tests/mediatest/main.swift`
+
+**Interfaces:**
+- Consumes: bundled Resources.
+- Produces: `MediaLibrary { articles:[MediaItem], chapters:[MediaItem], books:[PDFItem] }`; `MarkdownView(text:)` rendering blocks; `PDFViewer(url:)`.
+
+- [ ] **Step 1:** mediatest: assert `library.articles.count==20`, `library.chapters.count==13`, both PDFs exist; `Markdown.blocks("## H2\n- a\n- b")` yields 1 heading + 2 bullets.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Implement MediaLibrary (FileManager enumerate), MarkdownView (line-based block parser + per-line AttributedString inline), MediaView (List + PDFViewer with `Task.detached` load + `document=nil` onDisappear).
+- [ ] **Step 4:** Test PASS; build+open Media → an article shows H2+bullets (not flat), book PDF opens + EN/ID switch.
+- [ ] **Step 5:** Commit `feat: media library — markdown articles + native PDF book viewer`.
+
+---
+
+### Task 5: FASE 0 — arm OpenClaw on Mini (gateway + zantara-kbli agent)
+
+**Files (on Mini, via ssh):**
+- Fix `~/.openclaw/openclaw.json` (remove 3 invalid keys / make env optional)
+- Create agent `zantara-kbli` (system-prompt: KBLI 2025 + Bali moratorium, grounded, GPT-5.5)
+- Create: `~/Desktop/kbli-navigator-app/deploy/arm-openclaw-mini.sh` (idempotent, documents the steps)
+- LaunchAgent for gateway H24 (or document `--local` fallback)
+
+**Interfaces:**
+- Produces: working `~/.openclaw/bin/openclaw agent --agent zantara-kbli --message <q> --json` → JSON with `result.finalAssistantVisibleText`.
+
+- [ ] **Step 1:** `ssh mini` validate current `openclaw config validate` errors; back up `openclaw.json` (chmod 0600).
+- [ ] **Step 2:** Fix config (drop `openai-codex.models.0.contextTokens`, fix `telegram.streaming`, make OPENROUTER/DEEPSEEK keys optional); create `zantara-kbli` agent.
+- [ ] **Step 3:** Start gateway (LaunchAgent) OR confirm `--local` works with codex auth.
+- [ ] **Step 4:** Test: `ssh mini '~/.openclaw/bin/openclaw agent --agent zantara-kbli --message "Cos'\''è il KBLI 55203?" --json'` → exit 0, JSON parses, `finalAssistantVisibleText` non-empty + mentions villa/55203. **Acceptance #6.**
+- [ ] **Step 5:** Commit `feat(deploy): arm OpenClaw zantara-kbli agent on Mini`.
+
+---
+
+### Task 6: OpenClawRunner (dual-mode) + grounding + ChatView fork
+
+**Files:**
+- Create: `Sources/OpenClawRunner.swift` — dual-mode (local on Mini / `ssh mini` from M5/Pro), parse JSON `finalAssistantVisibleText`
+- Create: `Sources/Grounding.swift` — local retrieval → "FONTI" block from KBLIStore + articles
+- Create: `Sources/Views/ChatView.swift` — fork of WR2 ChatView, wired to AppState (no WarRoom)
+- Test: `Tests/runnertest/main.swift`
+
+**Interfaces:**
+- Consumes: `KBLIStore` (grounding), `AppState`.
+- Produces: `OpenClawRunner.ask(prompt:, sources:, onReply:, onError:)`; `Grounding.sources(for query:, code:) -> String`; `OpenClawRunner.hostMode -> .local | .ssh`.
+
+- [ ] **Step 1:** runnertest: `OpenClawRunner.parseReply(mockJSON)` extracts `finalAssistantVisibleText`; `OpenClawRunner.commandArgs(host:"Air-M5")` starts with `ssh`; `commandArgs(host:"Mini-Pro2")` is local; `Grounding.sources(code:"55203")` contains "55203" + "CHIUSO_PMA_NO_BESAR".
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Implement OpenClawRunner (Process zsh -lc, dual-mode arg build, strip ANTHROPIC_API_KEY, JSON parse, gateway-down fallback), Grounding (retrieval), ChatView fork (AppState-bound, inject sources, "Ask Zantara from code" entry).
+- [ ] **Step 4:** Test PASS. Build+open on M5 → Chat "cos'è il 55203?" → reply via ssh mini citing real Bali status; stop gateway → clean "chat unavailable", no hang. **Acceptance #7, #10.**
+- [ ] **Step 5:** Commit `feat: OpenClaw dual-mode chat runner + KBLI grounding + chat UI`.
+
+---
+
+### Task 7: 3-Mac deploy + Gatekeeper fix (F2) + final QA
+
+**Files:**
+- Create: `deploy/install-3mac.sh` — build once, rsync to M5+Pro+Mini, `xattr -cr` + `codesign --force --sign -` on each
+- Create: `PROVENANCE.md` — WR2 reuse + dataset provenance + research + panel
+- Create: `README.md`
+
+**Interfaces:** none (deploy + docs).
+
+- [ ] **Step 1:** Write `install-3mac.sh`: build on current host, then for each target `rsync -a --delete "$APP" "$T":'~/Applications/'` + `ssh "$T" 'xattr -cr ~/Applications/"KBLI Navigator.app"; codesign --force --deep --sign - ~/Applications/"KBLI Navigator.app"'`.
+- [ ] **Step 2:** Run deploy to Mini first → `ssh mini 'open ~/Applications/"KBLI Navigator.app"'` → launches WITHOUT "damaged" (verifies F2). **Acceptance #9.**
+- [ ] **Step 3:** Deploy to Pro + M5; spot-check launch on each.
+- [ ] **Step 4:** Full acceptance run §8.1-§8.10; write PROVENANCE.md + README.
+- [ ] **Step 5:** Commit `feat(deploy): 3-Mac install + Gatekeeper re-sign + docs`.
+
+---
+
+## Self-Review
+
+**Spec coverage:** §2 arch→T0-T2; §3 search→T1-T3; §4 media→T4; §5 chat+grounding→T5-T6; §2 3-Mac→T7; §9 F1→T6, F2→T7, F3→T4, S2→T2. All covered.
+**Placeholder scan:** none — every task has concrete asserts + commands.
+**Type consistency:** `KBLI.kode`/`l4Bali`/`status` consistent T1→T3→T6; `OpenClawRunner.parseReply`/`commandArgs`/`hostMode` consistent T6.

--- a/docs/superpowers/specs/2026-06-23-kbli-navigator-native-app-design.md
+++ b/docs/superpowers/specs/2026-06-23-kbli-navigator-native-app-design.md
@@ -1,0 +1,130 @@
+# KBLI Navigator — app Mac nativa SwiftUI · DESIGN SPEC
+
+> Date: 2026-06-23 · Machine dev/build: M5 (`balizero@Air-M5`) · Runtime target: **Mini-Pro2** (H24)
+> Companion research: `research/operations/2026-06-23-sota-macos-native-reference-app-design.md`
+> Base d'oro riusata 1:1: `~/Desktop/wr2-control-app` (repo interno nostro, no LICENSE → copiabile)
+
+## 1. Scopo
+
+App **Mac nativa** SwiftUI, minimalista/pulita/immediata, per navigare i **codici KBLI 2025** con
+focus sul **moratorium Bali 2026**. Tre funzioni: (1) **Cerca** codice/testo → scheda editoriale;
+(2) **Media** — libro PDF (EN/ID) + 20 articoli + 13 capitoli; (3) **Chat** con Zantara (GPT-5.5 via
+`codex`) in focus sul codice. Offline-first. Il KBLI Navigator **web** è già live su balizero.com — questa
+è la sua controparte desktop nativa, standalone.
+
+## 2. Architettura
+
+App single-window, **`NavigationSplitView` 3-colonne** (sidebar sezioni / lista risultati / detail).
+SwiftUI + AppKit + PDFKit, compilata con `build.sh` (swiftc + plugin macro Xcode-beta) → bundle `.app`.
+
+- **Dev + build su M5** (ha Xcode-beta → macro SwiftUI). **Deploy del `.app` compilato via `rsync` sul Mini** (H24). Pattern identico a `wr2-control-app/deploy/`.
+- **NO Swift Package Manager**: solo framework Apple nativi + codice vendorato single-file (vincolo `build.sh` swiftc).
+- **3 unità isolate**, comunicano solo via modelli `Codable`:
+  - **(A) `KBLIStore`** — carica + indicizza il JSON, espone search ranked.
+  - **(B) `MediaLibrary`** — enumera articoli/capitoli `.md` + 2 PDF; rende markdown e PDF.
+  - **(C) `CodexRunner`** — chat: spawna `codex exec` locale sul Mini, streaming.
+
+### Dataset (DECISO — provenienza verificata 2026-06-23)
+
+`KBLI_2025_FINAL_CLEAN.json` **v10.0-L2-oss-risk** (1559 codici), copiato al build da
+`/.worktrees/intel-kbli-rag-source-align/apps/mouth/data/`. Questa versione (≠ v8.0 del 28-mar) ha
+**tutti i campi** che servono:
+- `kode_kbli_2025`, `judul`, `uraian`, `ruang_lingkup` (scope OSS, 1338/1559)
+- `per_skala[]` — per scala: `kategori_risiko`, `perizinan`, `kewajiban[]`, `sanksi_*`
+- `pma_status`, `pma_max_asing`, `pma_kondisi`, `intel_2026`
+- **`l4_bali`** (popolato su tutti i 1559) — `status`, `reason`, `confidence`, `blocked` (bool),
+  `moratorium{rule, effective:"2026-05-13", source:"Gubernur B.27.000/642/PM/DPMPTSP", ...}`.
+  Distribuzione status: 1014 `OK_or_HIGHER_RISK`, 373 `BLOCCATO_CLASSE_RISCHIO`, 70 `BLOCCATO_DIPENDE_SCOPE`,
+  63 `NEEDS_REVIEW_NO_OSS_SCOPE`, 20 `CHIUSO_PMA_NO_BESAR`, 8 `TERTUTUP`, 5 `TERBATAS`, 5 `CHIUSO_BALI_PROPOSTO`, 1 `CHIUSO_BALI`.
+
+Bundlati in `Resources/`: il JSON + 20 articoli `.md` + 13 `book-chapters/*.md` + **NON** i 2 PDF
+(troppo grandi da incorporare — vedi §6 trappola PDF; restano in `Resources/` come file copiati, caricati lazy).
+Fonte contenuti: `~/Desktop/KBLI-2025-Content/`.
+
+## 3. Sezione "Cerca" (cuore)
+
+`.searchable(text:)` sulla colonna-lista (Tahoe `.searchToolbarBehavior(.minimized)`). Filtro in-memory
+con **ranking manuale** (no lib): exact-code(0) > prefix-code(1) > judul-prefix(2) > substring judul/uraian(3).
+Debounce via `.task(id: query)`.
+
+**Lista risultati** = `List` nativo (selezione + frecce ↑↓ gratis). Ogni riga: status-badge SF Symbol
+colorato a sinistra + `kode` mono + `judul`.
+
+**Scheda dettaglio** (`ScrollView` + sezioni `GroupBox` su material, NO righe divisorie):
+- **Header**: `kode` grande + `judul` + **badge status-Bali grande** (verde `OK_or_HIGHER_RISK` `circle.fill` /
+  rosso `BLOCCATO_*`/`CHIUSO_*`/`TERTUTUP` `xmark.octagon.fill` / grigio `NEEDS_REVIEW` `questionmark.circle`) + badge PMA nazionale.
+- **Callout Moratorium** (solo se `l4_bali.blocked`): riquadro amber `exclamationmark.triangle` con
+  `reason` + regola + data 13/5/26 + fonte Gubernur. È la "notizia 2026".
+- **Uraian / ruang_lingkup**: descrizione + scope (markdown-renderer per il testo).
+- **Licensing** (`per_skala[]`): una card compatta per scala → rischio · perizinan · kewajiban · sanzioni.
+- **Toolbar primaryAction "Chiedi a Zantara"** → apre Chat con `kode` + estratto `l4_bali`/`uraian` come contesto.
+
+## 4. Sezione "Media"
+
+`MediaLibrary` enumera da `Resources/`: 20 articoli + 13 capitoli (lista → detail markdown renderizzato)
++ 2 PDF libro (`Bali-Threshold-2026.pdf` EN, `-ID.pdf`) con `PDFViewer` (NSViewRepresentable PDFKit),
+toggle EN/ID. **Markdown reso da mini block-renderer vendorato** (~120 righe): heading `#/##/###`,
+bullet `- `, blockquote `>`, paragrafi, inline bold/italic/link via `AttributedString(markdown:)` per-riga.
+
+## 5. Sezione "Chat" (Zantara KBLI · GPT-5.5)
+
+`CodexRunner` (clone di `ClaudeRunner.swift`, ma spawna `codex exec` invece di `claude`; strip env
+API-key billing come defense-in-depth, conforme a OpenClaw `LLM_ROUTING_POLICY`). System-prompt:
+"Zantara, esperta KBLI 2025 + moratorium Bali". Se arrivi dal bottone scheda: inietta `kode` + `l4_bali` +
+`uraian` di quel codice come contesto iniziale. Streaming → `ChatView` (riuso WR2). PII: nessuna (codici pubblici).
+Codex assente/offline → chat disabilitata con avviso; Cerca + Media intatte.
+
+## 6. Tema, errori, test, trappole
+
+- **Tema**: eredita `Theme.swift` WR2 (paper-ivory chiaro, ink, accenti amber/red, tipografia editoriale).
+  `@Environment(\.appearsActive)` per smorzare accenti su finestra inattiva (Mini kiosk H24). Tahoe: `.glassEffect` sulle card.
+- **Errori**: JSON mancante = banner "ricostruisci bundle"; PDF mancante = placeholder; codex assente = chat disabilitata con messaggio.
+- **Test** (stile `Tests/` WR2, eseguibili `swift` standalone): `KBLIStore` (carica 1559 / trova `55203` /
+  status `CHIUSO_PMA_NO_BESAR` / `blocked==true`); `Search.rank` (exact > prefix > substring ordering);
+  `MediaLibrary` (20+13 md presenti, 2 pdf path validi); `CodexRunner.resolveCodexPath` (trova binario / fallback pulito).
+- **Trappole** (da research):
+  1. `AttributedString(markdown:)` NON rende heading/liste → usa mini block-renderer per articoli.
+  2. PDF 49MB×2: NON istanziarli insieme, NON bundlare nel binario; lazy `PDFDocument` on-tab, `document=nil` all'uscita (Mini 24GB con Ollama).
+  3. SPM rompe `build.sh` → solo framework Apple + vendor single-file.
+
+## 7. Layout file (worktree → poi repo dedicato `~/Desktop/kbli-navigator-app/` su M5)
+
+```
+kbli-navigator-app/
+  build.sh                      # adattato da wr2-control-app
+  Info.plist
+  Sources/
+    KBLINavigatorApp.swift      # @main
+    Theme.swift                 # COPIA-DIRETTO da WR2
+    Localization.swift          # COPIA-DIRETTO da WR2 (IT/EN/ID)
+    Models.swift                # KBLI, PerSkala, L4Bali, MediaItem (Codable)
+    KBLIStore.swift             # load JSON + search ranking
+    MediaLibrary.swift          # enumera md/pdf
+    MarkdownView.swift          # mini block-renderer vendorato
+    CodexRunner.swift           # clone ClaudeRunner → codex exec
+    Views/
+      RootView.swift            # NavigationSplitView 3-col (adattato)
+      SearchListView.swift      # .searchable + List risultati
+      KBLIDetailView.swift      # scheda GroupBox + callout moratorium
+      MediaView.swift           # lista md + PDFViewer
+      ChatView.swift            # COPIA-DIRETTO da WR2
+  Resources/
+    KBLI_2025_FINAL_CLEAN.json  # v10.0
+    articles/*.md (20)
+    book-chapters/*.md (13)
+    Bali-Threshold-2026.pdf / -ID.pdf
+    bz-logo.png
+  Tests/                        # standalone swift test runners (stile WR2)
+  PROVENANCE.md                 # traccia riuso WR2 + dataset + research
+```
+
+## 8. Acceptance (falsificabili)
+
+1. `build.sh` su M5 → exit 0, produce `build/KBLI Navigator.app` (codesign ad-hoc OK).
+2. App lancia, sidebar 3 sezioni visibili.
+3. Cerca "55203" → 1 risultato in cima, scheda mostra badge ROSSO + callout moratorium con data 13/5/26.
+4. Cerca "villa" → 55203 tra i risultati (match judul).
+5. Media: libro PDF apre e fa switch EN/ID; un articolo .md mostra heading H2 renderizzati (non testo piatto).
+6. Chat: con codex presente, "ciao" → risposta streaming; con codex assente → avviso, no crash.
+7. `swift Tests/*` → tutti verdi.
+8. `rsync` del `.app` sul Mini → lancia e funziona (Cerca+Media offline; Chat se codex sul Mini).

--- a/docs/superpowers/specs/2026-06-23-kbli-navigator-native-app-design.md
+++ b/docs/superpowers/specs/2026-06-23-kbli-navigator-native-app-design.md
@@ -19,7 +19,19 @@ focus sul **moratorium Bali 2026**. Tre funzioni: (1) **Cerca** codice/testo →
 App single-window, **`NavigationSplitView` 3-colonne** (sidebar sezioni / lista risultati / detail).
 SwiftUI + AppKit + PDFKit, compilata con `build.sh` (swiftc + plugin macro Xcode-beta) → bundle `.app`.
 
-- **Dev + build su M5** (ha Xcode-beta → macro SwiftUI). **Deploy del `.app` compilato via `rsync` sul Mini** (H24). Pattern identico a `wr2-control-app/deploy/`.
+### Distribuzione 3-Mac (DECISO 2026-06-23) — icona nativa su M5 + Pro + Mini
+
+**Lo stesso `.app` gira nativo su tutte e 3 le macchine** (icona vera, doppio-click). NON è un'app remota:
+è un binario arm64 locale su ogni Mac. Due risorse, due politiche:
+- **Dati (Cerca + Media)** = **bundlati nel `.app`** → 100% locali, veloci, offline su OGNI Mac. Nessuna rete.
+- **Chat (Zantara-OpenClaw)** = **un solo cervello, sul Mini** (FASE 0). L'`OpenClawRunner` è **dual-mode**:
+  - **sul Mini** → invoca `~/.openclaw/bin/openclaw agent ... --json` diretto (locale).
+  - **su M5 / Pro** → invoca `ssh mini ~/.openclaw/bin/openclaw agent ... --json` (SSH verificato funzionante da
+    entrambe 2026-06-23; `openclaw` NON è in PATH sul Mini → path assoluto obbligatorio). Rileva l'host via `Host.current()`/`hostname`.
+  - Un solo Zantara condiviso → **niente split-brain** (cicatrice #10); ma se il Mini è giù, la chat si degrada
+    e Cerca+Media restano vivi ovunque.
+- **Build una volta** (M5 in `~/Downloads/Xcode-beta.app`, o Pro che ha Xcode.app pieno + macOS 27) →
+  `rsync` del `.app` sulle altre due macchine. Pattern `wr2-control-app/deploy/install-mini.sh` esteso a 3 target.
 - **NO Swift Package Manager**: solo framework Apple nativi + codice vendorato single-file (vincolo `build.sh` swiftc).
 - **3 unità isolate**, comunicano solo via modelli `Codable`:
   - **(A) `KBLIStore`** — carica + indicizza il JSON, espone search ranked.
@@ -85,10 +97,11 @@ bullet `- `, blockquote `>`, paragrafi, inline bold/italic/link via `AttributedS
 *grounded* sui contenuti reali Bali Zero (come NotebookLM: cita le fonti, non inventa codici/numeri/norme)
 MA conversazionale e fluido (come GPT, non un retriever rigido che sputa snippet).
 
-`OpenClawRunner` (NON clone di `codex exec` — vedi §9 F1): spawna
-`~/.openclaw/bin/openclaw agent --agent zantara-kbli --message <q> --json --session-id <s>` sul Mini,
-legge `result.finalAssistantVisibleText` (testo pulito, no banner/hook). GPT-5.5 dietro OpenClaw.
-Streaming/poll → `ChatView` (fork chirurgico da WR2). PII: nessuna (codici pubblici).
+`OpenClawRunner` (NON clone di `codex exec` — vedi §9 F1) è **dual-mode** (vedi §2 distribuzione 3-Mac):
+- **sul Mini**: spawna `~/.openclaw/bin/openclaw agent --agent zantara-kbli --message <q> --json --session-id <s>` (locale).
+- **su M5/Pro**: spawna `ssh mini ~/.openclaw/bin/openclaw agent --agent zantara-kbli --message <q> --json --session-id <s>`.
+Legge `result.finalAssistantVisibleText` (testo pulito, no banner/hook). GPT-5.5 dietro OpenClaw, **un solo cervello sul Mini**.
+Streaming/poll → `ChatView` (fork chirurgico da WR2). PII: nessuna (codici pubblici). L'host si rileva a runtime (`hostname`).
 
 **Grounding NLM-style (il cuore del "non inventa"):**
 - **Corpus di grounding = i contenuti già su disco**: 1559 record KBLI (`l4_bali`, `per_skala`, `uraian`),
@@ -162,7 +175,8 @@ kbli-navigator-app/
 6. **FASE 0**: `openclaw agent --agent zantara-kbli --message "test" --json` sul Mini → stdout JSON con `result.finalAssistantVisibleText` non vuoto.
 7. Chat: con gateway su, "cos'è il 55203?" → risposta che cita lo status Bali REALE dal grounding (no codice inventato); con gateway giù → avviso, no crash, no hang.
 8. `swift Tests/*` → tutti verdi.
-9. **Deploy**: `rsync` del `.app` sul Mini + `xattr -cr` + `codesign --force --sign -` sul Mini → **lancia senza "damaged/cannot open"** (verifica F2) e funziona (Cerca+Media offline; Chat via gateway locale).
+9. **Deploy 3-Mac**: `rsync` del `.app` su M5 + Pro + Mini, `xattr -cr` + `codesign --force --sign -` su OGNI macchina destinazione → **lancia senza "damaged/cannot open"** ovunque (verifica F2).
+10. **Chat dual-mode**: su M5/Pro "cos'è il 55203?" → risposta via `ssh mini openclaw` (cervello unico); sul Mini → stessa risposta via openclaw locale. Mini giù → chat degrada, Cerca+Media vivi su M5/Pro.
 
 ## 9. Findings review 4-LLM (REV 2) — incorporati sopra
 

--- a/docs/superpowers/specs/2026-06-23-kbli-navigator-native-app-design.md
+++ b/docs/superpowers/specs/2026-06-23-kbli-navigator-native-app-design.md
@@ -2,7 +2,9 @@
 
 > Date: 2026-06-23 · Machine dev/build: M5 (`balizero@Air-M5`) · Runtime target: **Mini-Pro2** (H24)
 > Companion research: `research/operations/2026-06-23-sota-macos-native-reference-app-design.md`
-> Base d'oro riusata 1:1: `~/Desktop/wr2-control-app` (repo interno nostro, no LICENSE → copiabile)
+> Base d'oro riusata (fork chirurgico, NON 1:1): `~/Desktop/wr2-control-app` (repo interno nostro, no LICENSE → copiabile)
+> **REV 2** (2026-06-23) post review 4-LLM severa (Gemini agy + DeepSeek V4 Pro + Codex; verdetto FIX-FIRST).
+> Findings incorporati sotto §9. Verifiche empiriche fatte in-turn (non assunte).
 
 ## 1. Scopo
 
@@ -22,7 +24,18 @@ SwiftUI + AppKit + PDFKit, compilata con `build.sh` (swiftc + plugin macro Xcode
 - **3 unità isolate**, comunicano solo via modelli `Codable`:
   - **(A) `KBLIStore`** — carica + indicizza il JSON, espone search ranked.
   - **(B) `MediaLibrary`** — enumera articoli/capitoli `.md` + 2 PDF; rende markdown e PDF.
-  - **(C) `CodexRunner`** — chat: spawna `codex exec` locale sul Mini, streaming.
+  - **(C) `OpenClawRunner`** — chat: spawna `openclaw agent --agent zantara-kbli --json` sul Mini (NON `codex exec` nudo — vedi §9 F1), legge `result.finalAssistantVisibleText`.
+
+### FASE 0 (prerequisito, sotto-progetto separato) — armare OpenClaw sul Mini
+
+L'app è un **client** del runtime OpenClaw, esattamente come il bridge WhatsApp
+(`~/.openclaw/bin/openclaw_whatsapp_bridge.py:1741` → `openclaw agent ... --json` → `finalAssistantVisibleText`).
+Prima che l'app possa parlare con Zantara, sul Mini serve (verificato 2026-06-23):
+- **Gateway daemon H24** (LaunchAgent) — oggi `pgrep openclaw` = vuoto, va armato.
+- **`openclaw.json` ripulito** — 3 errori live: `OPENROUTER_API_KEY`/`DEEPSEEK_API_KEY` env mancanti (rimuovere o rendere opzionali), `models.providers.openai-codex.models.0.contextTokens` key non riconosciuta, `channels.telegram.streaming` valore invalido. Tenere il provider codex/GPT-5.5 (auth già presente: `~/.codex/auth.json` ✅).
+- **Agent `zantara-kbli`** — nuovo agent con system-prompt "Zantara, esperta KBLI 2025 + moratorium Bali" (modello GPT-5.5 via OpenClaw). Agenti già presenti: `main`, `coder`, `telegram-codex`.
+- **PATH**: `openclaw` NON è in PATH sul Mini → l'app/runner usa path assoluto `~/.openclaw/bin/openclaw`.
+- Contratto d'interfaccia (ciò che l'app assume): `openclaw agent --agent zantara-kbli --message <q> --json [--session-id <s>]` → stdout JSON con `result.finalAssistantVisibleText`. L'app si sviluppa contro QUESTO contratto; la Fase 0 lo fornisce.
 
 ### Dataset (DECISO — provenienza verificata 2026-06-23)
 
@@ -66,26 +79,46 @@ colorato a sinistra + `kode` mono + `judul`.
 toggle EN/ID. **Markdown reso da mini block-renderer vendorato** (~120 righe): heading `#/##/###`,
 bullet `- `, blockquote `>`, paragrafi, inline bold/italic/link via `AttributedString(markdown:)` per-riga.
 
-## 5. Sezione "Chat" (Zantara KBLI · GPT-5.5)
+## 5. Sezione "Chat" (Zantara KBLI · GPT-5.5 via OpenClaw)
 
-`CodexRunner` (clone di `ClaudeRunner.swift`, ma spawna `codex exec` invece di `claude`; strip env
-API-key billing come defense-in-depth, conforme a OpenClaw `LLM_ROUTING_POLICY`). System-prompt:
-"Zantara, esperta KBLI 2025 + moratorium Bali". Se arrivi dal bottone scheda: inietta `kode` + `l4_bali` +
-`uraian` di quel codice come contesto iniziale. Streaming → `ChatView` (riuso WR2). PII: nessuna (codici pubblici).
-Codex assente/offline → chat disabilitata con avviso; Cerca + Media intatte.
+**Identità del bot: un "NLM focalizzato sui KBLI con la scioltezza di GPT"** — cioè un assistente
+*grounded* sui contenuti reali Bali Zero (come NotebookLM: cita le fonti, non inventa codici/numeri/norme)
+MA conversazionale e fluido (come GPT, non un retriever rigido che sputa snippet).
+
+`OpenClawRunner` (NON clone di `codex exec` — vedi §9 F1): spawna
+`~/.openclaw/bin/openclaw agent --agent zantara-kbli --message <q> --json --session-id <s>` sul Mini,
+legge `result.finalAssistantVisibleText` (testo pulito, no banner/hook). GPT-5.5 dietro OpenClaw.
+Streaming/poll → `ChatView` (fork chirurgico da WR2). PII: nessuna (codici pubblici).
+
+**Grounding NLM-style (il cuore del "non inventa"):**
+- **Corpus di grounding = i contenuti già su disco**: 1559 record KBLI (`l4_bali`, `per_skala`, `uraian`),
+  20 articoli + 13 capitoli, libro PDF. Stessi contenuti della sezione Media → l'app è coerente con sé stessa.
+- **Iniezione contesto**: quando l'utente chiede (o arriva dal bottone scheda), l'app fa una **retrieval locale**
+  (riusa il `KBLIStore.search` + match su articoli) e inietta i passaggi rilevanti nel `--message` come
+  blocco "FONTI" + la domanda. Il system-prompt dell'agent `zantara-kbli` impone: *rispondi SOLO su queste
+  fonti, cita il codice/articolo, se non è nelle fonti dillo, mai inventare un codice o uno status Bali*.
+- **Scioltezza GPT**: il system-prompt NON forza un formato rigido — Zantara spiega in linguaggio naturale,
+  bilingue, con tono Bali Zero ("Pragmatic Sherpa"), ma ancorata. È il pattern **bipolar verifier** invertito:
+  GPT per la forma, le fonti-on-disk per la verità.
+- **Confine**: il grounding è retrieval LOCALE (no rete, no PII — codici pubblici). NotebookLM vero NON è
+  coinvolto (sarebbe rete + account); "NLM-style" = il *comportamento* grounded, replicato sul corpus locale.
+
+Se OpenClaw/gateway assente/offline → chat disabilitata con avviso chiaro; Cerca + Media restano intatte.
 
 ## 6. Tema, errori, test, trappole
 
 - **Tema**: eredita `Theme.swift` WR2 (paper-ivory chiaro, ink, accenti amber/red, tipografia editoriale).
   `@Environment(\.appearsActive)` per smorzare accenti su finestra inattiva (Mini kiosk H24). Tahoe: `.glassEffect` sulle card.
-- **Errori**: JSON mancante = banner "ricostruisci bundle"; PDF mancante = placeholder; codex assente = chat disabilitata con messaggio.
+- **Errori**: JSON mancante = banner "ricostruisci bundle"; PDF mancante = placeholder; OpenClaw/gateway assente = chat disabilitata con messaggio (preflight: ping `openclaw agent` o gateway-health).
 - **Test** (stile `Tests/` WR2, eseguibili `swift` standalone): `KBLIStore` (carica 1559 / trova `55203` /
   status `CHIUSO_PMA_NO_BESAR` / `blocked==true`); `Search.rank` (exact > prefix > substring ordering);
-  `MediaLibrary` (20+13 md presenti, 2 pdf path validi); `CodexRunner.resolveCodexPath` (trova binario / fallback pulito).
-- **Trappole** (da research):
-  1. `AttributedString(markdown:)` NON rende heading/liste → usa mini block-renderer per articoli.
-  2. PDF 49MB×2: NON istanziarli insieme, NON bundlare nel binario; lazy `PDFDocument` on-tab, `document=nil` all'uscita (Mini 24GB con Ollama).
+  `MediaLibrary` (20+13 md presenti, 2 pdf path validi); `OpenClawRunner` (risolve path `~/.openclaw/bin/openclaw` /
+  parsa `result.finalAssistantVisibleText` da JSON mock / fallback pulito su gateway-down / rileva auth-fail su stderr).
+- **Trappole** (da research + panel — vedi §9):
+  1. `AttributedString(markdown:)` NON rende heading/liste → renderer markdown serio (vedi §9 F3), NON 120-righe naïf.
+  2. PDF 49MB×2: NON istanziarli insieme, NON bundlare nel binario; caricamento su **background thread** (`Task.detached` + `ProgressView`), `document=nil` all'uscita (Mini 24GB con Ollama).
   3. SPM rompe `build.sh` → solo framework Apple + vendor single-file.
+  4. **Riuso WR2 = fork chirurgico** (NON 1:1): gut `AppState`/`WarRoom`/`QueueWriter`/idle-kiosk; copia solo layout+styling+runner-shape (vedi §9 S2).
 
 ## 7. Layout file (worktree → poi repo dedicato `~/Desktop/kbli-navigator-app/` su M5)
 
@@ -100,14 +133,15 @@ kbli-navigator-app/
     Models.swift                # KBLI, PerSkala, L4Bali, MediaItem (Codable)
     KBLIStore.swift             # load JSON + search ranking
     MediaLibrary.swift          # enumera md/pdf
-    MarkdownView.swift          # mini block-renderer vendorato
-    CodexRunner.swift           # clone ClaudeRunner → codex exec
+    MarkdownView.swift          # renderer markdown serio (vedi §9 F3)
+    OpenClawRunner.swift        # spawna `openclaw agent --json` sul Mini (NON codex nudo)
+    Grounding.swift             # retrieval locale → blocco FONTI per il prompt (NLM-style)
     Views/
       RootView.swift            # NavigationSplitView 3-col (adattato)
       SearchListView.swift      # .searchable + List risultati
       KBLIDetailView.swift      # scheda GroupBox + callout moratorium
       MediaView.swift           # lista md + PDFViewer
-      ChatView.swift            # COPIA-DIRETTO da WR2
+      ChatView.swift            # fork chirurgico da WR2
   Resources/
     KBLI_2025_FINAL_CLEAN.json  # v10.0
     articles/*.md (20)
@@ -120,11 +154,25 @@ kbli-navigator-app/
 
 ## 8. Acceptance (falsificabili)
 
-1. `build.sh` su M5 → exit 0, produce `build/KBLI Navigator.app` (codesign ad-hoc OK).
+1. `build.sh` su M5 → exit 0, produce `build/KBLI Navigator.app`.
 2. App lancia, sidebar 3 sezioni visibili.
 3. Cerca "55203" → 1 risultato in cima, scheda mostra badge ROSSO + callout moratorium con data 13/5/26.
 4. Cerca "villa" → 55203 tra i risultati (match judul).
-5. Media: libro PDF apre e fa switch EN/ID; un articolo .md mostra heading H2 renderizzati (non testo piatto).
-6. Chat: con codex presente, "ciao" → risposta streaming; con codex assente → avviso, no crash.
-7. `swift Tests/*` → tutti verdi.
-8. `rsync` del `.app` sul Mini → lancia e funziona (Cerca+Media offline; Chat se codex sul Mini).
+5. Media: libro PDF apre e fa switch EN/ID (caricamento su background thread, no main-thread freeze); un articolo .md mostra heading H2 + liste renderizzati (non testo piatto).
+6. **FASE 0**: `openclaw agent --agent zantara-kbli --message "test" --json` sul Mini → stdout JSON con `result.finalAssistantVisibleText` non vuoto.
+7. Chat: con gateway su, "cos'è il 55203?" → risposta che cita lo status Bali REALE dal grounding (no codice inventato); con gateway giù → avviso, no crash, no hang.
+8. `swift Tests/*` → tutti verdi.
+9. **Deploy**: `rsync` del `.app` sul Mini + `xattr -cr` + `codesign --force --sign -` sul Mini → **lancia senza "damaged/cannot open"** (verifica F2) e funziona (Cerca+Media offline; Chat via gateway locale).
+
+## 9. Findings review 4-LLM (REV 2) — incorporati sopra
+
+Panel severo 2026-06-23: Gemini agy (REDESIGN) + DeepSeek V4 Pro (FIX-FIRST) + Codex GPT-5.5 (output solo-rumore → *prova* di F1). Verdetto sintesi: **FIX-FIRST**. Tutti i findings verificati empiricamente in-turn, non assunti.
+
+- **F1 [FATAL→risolto] codex nudo ≠ chat-backend.** Verificato: `codex exec` per 1 domanda → 718KB output, banner+hook, *esegue ssh/git* (agentic). **Fix**: backend = **OpenClaw `agent --json`** (GPT-5.5 dietro gateway → testo pulito, come bridge WhatsApp `openclaw_whatsapp_bridge.py:1741`). Prereq = FASE 0 (§2).
+- **F2 [FATAL] ad-hoc sig + rsync → Gatekeeper block sul Mini.** WR2 fa `codesign -s -` ma **mai deployato sul Mini** (verificato: `NO-WR2-APP-ON-MINI`) → mai provato. **Fix**: deploy-script con `xattr -cr` + re-`codesign --force --sign -` **eseguito sul Mini** post-rsync; acceptance #9.
+- **F3 [FATAL] markdown 120-righe insufficiente** per articoli con tabelle/liste-annidate. **Fix**: renderer serio single-file vendorato O pre-render `.md`→HTML a build + `WKWebView` (decisione in fase plan).
+- **S1 [SERIOUS→risolto] SwiftUI senza WindowServer crasha.** Verificato: Mini ha `nuzantara console` + `WindowServer up` → OK.
+- **S2 [SERIOUS] riuso WR2 1:1 trascina stato** (`AppState`/`WarRoom`/`QueueWriter`/idle-kiosk). **Fix**: fork chirurgico (§6 trappola 4).
+- **S3 [SERIOUS] macro-plugin forse inutile** — `NavigationSplitView`/`.searchable`/`.glassEffect` non richiedono il plugin (solo `#Preview`). **Fix**: in fase plan, testare build senza `-external-plugin-path` se niente `#Preview`.
+- **Minori** (DeepSeek): debounce vero (Combine), build.sh copy-phase per md/pdf, PDF set-nil-before-assign, auth-fail detection — tutti recepiti nei test/trappole.
+- **RESPINTO**: Gemini "`.glassEffect` è visionOS, non esiste su macOS" → **FALSO**, compila exit 0 su `arm64-apple-macosx26.0` (cicatrice #6: anche il refuter allucina, ri-verificato).

--- a/research/operations/2026-06-23-sota-macos-native-reference-app-design.md
+++ b/research/operations/2026-06-23-sota-macos-native-reference-app-design.md
@@ -1,0 +1,81 @@
+---
+date: 2026-06-23
+domain: operations
+client_case: none
+sources:
+  - https://kapeli.com/dash
+  - https://developer.apple.com/documentation/swiftui/building-a-great-mac-app-with-swiftui
+  - https://github.com/conorluddy/LiquidGlassReference
+  - https://github.com/gonzalezreal/swift-markdown-ui
+  - https://blog.eidinger.info/3-surprises-when-using-markdown-in-swiftui
+  - https://pfandrade.me/blog/mac-assed-swiftui-app/
+  - https://github.com/open-saas-directory/awesome-native-macosx-apps
+---
+
+# SOTA design — app Mac nativa reference/knowledge-browser (2026)
+
+Deep research (fork Opus, 8 tool-use, 167k tok) per il design dell'app **KBLI Navigator** nativa
+SwiftUI: reference browser search-driven (1559 codici → scheda editoriale) + media markdown/PDF + chat AI in focus.
+Bias spietato verso **framework Apple nativi** (zero-dependency, zero-licenza, compatibili con build `swiftc`/`build.sh`,
+NO Swift Package Manager).
+
+## TOP 5 app di riferimento — cosa rubare di preciso
+
+1. **Dash (Kapeli)** — modello 3 zone "sidebar tipi → lista risultati ranked → detail scrollabile",
+   ricerca istantanea offline, match-by-prefix che porta in cima gli esatti. È il flusso codice→scheda.
+2. **Bear** — tipografia editoriale + search per frammenti (substring tollerante), palette calma a tutta-area senza chrome.
+3. **Reflect** — "AI in focus sull'entità corrente": la card aperta diventa il contesto dell'AI → bottone "Chiedi a Zantara su questo codice".
+4. **Apple Dictionary.app** — reference-card densa fatta bene: lemma grande in testa, badge inline, blocchi gerarchici separati da spazio bianco NON da linee.
+5. **Proxyman** — Swift/SwiftUI nativo: `List` con selezione nativa + detail-pane reattivo + toolbar consolidata, "Mac-assed" senza Electron.
+
+## Decisione per mattone (reuse-first)
+
+| Mattone | Decisione | Etichetta | Licenza |
+|---|---|---|---|
+| M1 scheletro (Theme/Chat/Runner/RootView/build.sh) | da `wr2-control-app` | [COPIA-DIRETTO] | nostra (repo interno, no LICENSE) |
+| M2 search/filter 1559 record | `.searchable` nativo + ranking manuale ~30 righe (no Fuse/SwiftData) | [SCRIVI-NUOVO minimale] | nostra |
+| M3 markdown articoli/.md | mini block-renderer vendorato ~120 righe (NON AttributedString da solo) | [STUDIA-PATTERN-RISCRIVI] | nostra |
+| M4 PDF libro EN/ID | `PDFKit.PDFView` in `NSViewRepresentable`, lazy load | [INSTALLA-LIB Apple] | sistema |
+
+**Ranking search** (exact code > prefix code > judul prefix > substring judul/uraian):
+```swift
+func rank(_ r: KBLI, _ q: String) -> Int? {
+    let c = r.kode, j = r.judul.lowercased(), ql = q.lowercased()
+    if c == ql { return 0 }
+    if c.hasPrefix(ql) { return 1 }
+    if j.hasPrefix(ql) { return 2 }
+    if j.contains(ql) || r.uraian.lowercased().contains(ql) { return 3 }
+    return nil
+}
+```
+
+**PDF viewer nativo**:
+```swift
+struct PDFViewer: NSViewRepresentable {
+    let url: URL
+    func makeNSView(context: Context) -> PDFView {
+        let v = PDFView(); v.autoScales = true; v.displayMode = .singlePageContinuous
+        v.document = PDFDocument(url: url); return v
+    }
+    func updateNSView(_ v: PDFView, context: Context) {
+        if v.document?.documentURL != url { v.document = PDFDocument(url: url) } // switch EN/ID
+    }
+}
+```
+
+## Design moves concreti (traducibili in SwiftUI)
+
+1. **`NavigationSplitView` 3-col** (sidebar / lista risultati / scheda) invece dell'`HStack` manuale di WR2 → Liquid Glass + ambient reflection gratis su Tahoe; il pattern WR2 (HStack 2-col) li perde.
+2. **`.searchable(text:)` + `.searchToolbarBehavior(.minimized)`** sulla colonna lista → barra ricerca adattiva nativa, non TextField custom.
+3. **Status-badge Bali a sinistra del kode**, SF Symbol + colore semantico Theme: `circle.fill` verde (`OK_or_HIGHER_RISK`), `xmark.octagon.fill` rosso (`BLOCCATO_*`/`CHIUSO_*`), `questionmark.circle` grigio (`NEEDS_REVIEW`). Stesso badge piccolo in lista, grande in scheda.
+4. **Scheda in `ScrollView` con sezioni `GroupBox`** (header / Status-Bali / Licensing per-skala / Moratorium) su material — separa per spazio bianco e material, MAI righe divisorie (lezione Dictionary/Bear). Tahoe: `.glassEffect(.regular, in: .rect(cornerRadius:))`.
+5. **`List` nativo per i risultati** (non LazyVStack custom): selezione, emphasis finestra attiva, frecce ↑↓ gratis.
+6. **`@Environment(\.appearsActive)`** per smorzare accenti quando finestra inattiva (Mini = kiosk H24).
+7. **Moratorium come callout amber** (icona `exclamationmark.triangle` + regola + data 13/5/26 + fonte Gubernur), visibile solo se `l4_bali.blocked` → trasforma il dato nella "notizia 2026".
+8. **Bottone "Chiedi a Zantara" come `.toolbar` primaryAction** della scheda → apre Chat passando `kode` + estratto `l4_bali`/`uraian` come system-context (pattern Reflect AI-in-focus).
+
+## Trappole note
+
+1. **Markdown headings**: `AttributedString(markdown:)` nativo perde `##`/liste/immagini → long-form = muro di testo. Inline nativo (bold/italic/link) per-riga OK; per i blocchi serve il mini-renderer vendorato.
+2. **PDF 49MB ×2**: `PDFDocument(url:)` lazy per pagina OK, ma NON istanziare entrambi insieme né bundlare nel binario — tienili in `Resources/`, carica on-tab, `document=nil` all'uscita (Mini 24GB condiviso con Ollama).
+3. **SPM vs swiftc**: qualunque lib SPM (swift-markdown-ui, Fuse) rompe `build.sh`. Regola app: SOLO framework Apple + codice vendorato single-file.


### PR DESCRIPTION
Rescues an orphaned worktree (M5 orphan-report 2026-06-27, 🟢 PR-able).

Spec/design/plan docs for the KBLI Navigator native macOS app. Docs only, `docs/superpowers/` paths — the app itself already exists at ~/Desktop/kbli-navigator-app; this lands the design record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)