### PR TITLE
fix(organism): deploy-puller tracks main directly — cure the sterile pull

### DIFF
--- a/scripts/wr2-deploy-pull.sh
+++ b/scripts/wr2-deploy-pull.sh
@@ -8,7 +8,13 @@ set -uo pipefail
 
 DEPLOY_DIR="${WR2_DEPLOY_DIR:-${HOME}/Desktop/nuzantara-deploy}"
 SOURCE_REPO="${WR2_SOURCE_REPO:-${HOME}/Desktop/nuzantara}"
-EXPECTED_BRANCH="${WR2_DEPLOY_BRANCH:-deploy/main}"
+# 2026-06-27: track `main` directly. The old `deploy/main` intermediate branch made sense
+# only when -deploy was a WORKTREE (to isolate its HEAD from the main checkout's branch).
+# Now -deploy is an isolated CLONE, so a separate branch is pure overhead — and it caused a
+# STERILE pull: origin/deploy/main lagged origin/main by 3 commits and nobody advanced it, so
+# the puller saw "up-to-date" against a phantom ref while the real merges (incl. #1766) never
+# reached the live organs. Tracking main directly is the cure. (TAC self-loop anti-sterility.)
+EXPECTED_BRANCH="${WR2_DEPLOY_BRANCH:-main}"
 LOG="${HOME}/logs/wr2-deploy-pull.log"
 STATE="${HOME}/.agent/decisions/state/wr2_deploy_pull.state"
 LOCK="${HOME}/.agent/decisions/state/wr2_deploy_pull.lock"


### PR DESCRIPTION
## What
LIVE verification after #1766 merged exposed the real **sterile pull**: the `-deploy` clone stayed 3 commits behind `origin/main` while the puller reported "up-to-date".

**Root cause**: the puller tracked `deploy/main`, an intermediate branch origin had but **nobody advanced** (it lagged `origin/main`). The puller fetched `origin/deploy/main`, found it unchanged, declared success — so #1766's ring artifacts (`run_scar_gates.py`, `MANIFEST.json`, the A2 `_ESCALATE_STATUSES` cure) **never reached the live `-deploy` clone the organs run from**.

`deploy/main` only existed to isolate a WORKTREE's HEAD. Now `-deploy` is a CLONE → it's pure overhead. **Track `main` directly.**

## Verified live (Pro)
- Repointed clone to `origin/main`, puller fast-forwarded to `0e37089`
- All #1766 ring artifacts now present in the clone ✓
- A2 `_ESCALATE_STATUSES` cure now in the clone ✓
- reconcile STRICT=1: breaches=0 ✓

The merge→clone→organs chain is closed — **merges are no longer sterile.** This was the root problem that originated the whole runtime-split work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)