### PR TITLE
fix(ops): require explicit override for peer autostash

### DIFF
--- a/scripts/nuz_status.py
+++ b/scripts/nuz_status.py
@@ -26,6 +26,7 @@ DEFAULT_FLY_HEALTH_URL = "https://nuzantara-rag.fly.dev/health"
 DEFAULT_DRIVE_STATUS_URL = "https://nuzantara-rag.fly.dev/api/admin/drive/poll/status"
 DEFAULT_PEER_ALIAS = "pro"
 DEFAULT_PEER_REPO = "~/Desktop/nuzantara"
+PEER_AUTOSTASH_ENV = "NUZ_STATUS_ALLOW_PEER_AUTOSTASH"
 
 
 @dataclass(frozen=True)
@@ -86,6 +87,10 @@ def machine_role(hostname: str, username: str) -> str:
 
 def check_status(status: str, summary: str, **details: Any) -> dict[str, Any]:
     return {"status": status, "summary": summary, "details": details}
+
+
+def peer_autostash_allowed() -> bool:
+    return os.getenv(PEER_AUTOSTASH_ENV, "").strip() == "1"
 
 
 def git_status(path: Path, *, refresh: bool = False) -> dict[str, Any]:
@@ -319,17 +324,20 @@ def build_checks(
                     "target": "pro-main",
                 },
             )
+            autostash_allowed = peer_autostash_allowed()
             actions.append(
                 {
                     "id": "stash_and_sync_pro_main",
-                    "label": "Stash + sync Pro main",
+                    "label": "Stash + sync Pro main (manual override)",
                     "enabled": (
-                        peer_git.get("branch") == "main"
+                        autostash_allowed
+                        and peer_git.get("branch") == "main"
                         and bool(peer_git.get("dirty"))
                         and bool(peer_git.get("behind"))
                         and not peer_git.get("ahead")
                     ),
                     "target": "pro-main-autostash",
+                    "requires_env": f"{PEER_AUTOSTASH_ENV}=1",
                 },
             )
 
@@ -462,6 +470,14 @@ def safe_fix(target: str, *, peer: str) -> dict[str, Any]:
         }
 
     if target == "pro-main-autostash":
+        if not peer_autostash_allowed():
+            return {
+                "target": target,
+                "ok": False,
+                "returncode": 2,
+                "stdout": "",
+                "stderr": f"refusing peer autostash without {PEER_AUTOSTASH_ENV}=1",
+            }
         stash_name = f"nuz-status-auto-stash-{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}"
         remote = (
             f"cd {DEFAULT_PEER_REPO} && "

--- a/tests/scripts/test_nuz_status.py
+++ b/tests/scripts/test_nuz_status.py
@@ -135,7 +135,7 @@ def test_collect_status_offline_skips_network() -> None:
     http_json.assert_not_called()
 
 
-def test_collect_status_offers_reversible_pro_autostash_when_dirty_and_behind() -> None:
+def test_collect_status_disables_peer_autostash_without_explicit_override() -> None:
     args = Namespace(
         refresh=False,
         offline=False,
@@ -181,11 +181,26 @@ def test_collect_status_offers_reversible_pro_autostash_when_dirty_and_behind() 
         ),
         patch("nuz_status.gh_latest_run", return_value={"available": False}),
         patch("nuz_status.http_json", side_effect=fake_http_json),
+        patch.dict("os.environ", {"NUZ_STATUS_ALLOW_PEER_AUTOSTASH": ""}, clear=False),
     ):
         payload = nuz_status.collect_status(args)
 
     autostash = next(action for action in payload["actions"] if action["id"] == "stash_and_sync_pro_main")
     clean_sync = next(action for action in payload["actions"] if action["id"] == "sync_pro_main")
-    assert autostash["enabled"] is True
+    assert autostash["enabled"] is False
     assert autostash["target"] == "pro-main-autostash"
+    assert autostash["requires_env"] == "NUZ_STATUS_ALLOW_PEER_AUTOSTASH=1"
     assert clean_sync["enabled"] is False
+
+
+def test_safe_fix_refuses_peer_autostash_without_explicit_override() -> None:
+    with (
+        patch.dict("os.environ", {"NUZ_STATUS_ALLOW_PEER_AUTOSTASH": ""}, clear=False),
+        patch("nuz_status.run_command") as run_command,
+    ):
+        result = nuz_status.safe_fix("pro-main-autostash", peer="pro")
+
+    assert result["ok"] is False
+    assert result["returncode"] == 2
+    assert "NUZ_STATUS_ALLOW_PEER_AUTOSTASH=1" in result["stderr"]
+    run_command.assert_not_called()


### PR DESCRIPTION
## Summary
- disable the Pro peer autostash action in `nuz status` unless `NUZ_STATUS_ALLOW_PEER_AUTOSTASH=1` is set
- make `scripts/nuz fix --target pro-main-autostash` fail closed before SSH without the same override
- keep clean `pro-main` fast-forward sync behavior unchanged

## Verification
- `uv run --with pytest pytest tests/scripts/test_nuz_status.py -q`
- `python3 -m py_compile scripts/nuz_status.py tests/scripts/test_nuz_status.py`
- live `./scripts/nuz status --json --refresh` shows `stash_and_sync_pro_main.enabled=false` while Pro has dirty files
- live `./scripts/nuz fix --target pro-main-autostash --json` returns `refusing peer autostash without NUZ_STATUS_ALLOW_PEER_AUTOSTASH=1`
