### PR TITLE
feat(kbli): single source-of-truth for KBLI dataset + drift lint (HOME-fork #1 cure)

### DIFF
--- a/.github/workflows/check-kbli-dataset-sync.yml
+++ b/.github/workflows/check-kbli-dataset-sync.yml
@@ -1,0 +1,74 @@
+name: check-kbli-dataset-sync
+
+# Superscar #1 (HOME-fork) antidote, made executable.
+#
+# The KBLI_2025_FINAL_CLEAN.json dataset has lived in 6 physical copies + 1 broken
+# symlink, drifting silently: the RAG chatbot read a stale/poor copy (86101 = TERBUKA/
+# 100, no OSS source, no l4_bali) while balizero.com/kbli + the native app served the
+# corrected rich OSS-base. The structural cure for the whole #1 family is a CI lint that
+# FAILS if a tracked consumer copy diverges (`cmp -s`) from the single canonical file.
+#
+# CANONICAL = source_documents/KBLI_2025_FINAL_CLEAN.json (repo ROOT, git-tracked) — the
+# path the RAG actually reads (kbli_eye.py default db_path + reindex parents[4]).
+#
+# This job runs `scripts/sync_kbli_dataset.sh --check`, which byte-compares canonical to
+# every consumer. Gitignored consumers (the RAG runtime copies) that are absent on a
+# fresh CI checkout are skipped — they're materialised at build time by the same script;
+# only git-TRACKED consumers must always be present & identical.
+#
+# Path-scoped: only runs when a dataset copy, the sync script, or this workflow changes —
+# a PR that touches none of them has nothing to check (no pending-forever, W69 BUCO #1).
+# NON-REQUIRED by design: a brand-new signal observes for a review cycle before it can
+# block; flip to required only after it proves zero false-positive.
+on:
+  pull_request:
+    paths:
+      - "source_documents/KBLI_2025_FINAL_CLEAN.json"
+      - "data/source_documents/KBLI_2025_FINAL_CLEAN.json"
+      - "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json"
+      - "scripts/sync_kbli_dataset.sh"
+      - ".github/workflows/check-kbli-dataset-sync.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "source_documents/KBLI_2025_FINAL_CLEAN.json"
+      - "data/source_documents/KBLI_2025_FINAL_CLEAN.json"
+      - "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json"
+      - "scripts/sync_kbli_dataset.sh"
+      - ".github/workflows/check-kbli-dataset-sync.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-kbli-dataset-sync-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-kbli-dataset-sync:
+    name: check-kbli-dataset-sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Canonical dataset is a real file (not a symlink, not missing)
+        run: |
+          set -uo pipefail
+          C=source_documents/KBLI_2025_FINAL_CLEAN.json
+          if [ -L "$C" ]; then
+            echo "::error::$C is a SYMLINK — the canonical KBLI dataset must be a physical file (HOME-fork #1)."
+            exit 1
+          fi
+          if [ ! -f "$C" ]; then
+            echo "::error::$C is missing — the canonical KBLI dataset must exist at repo root."
+            exit 1
+          fi
+          echo "OK: canonical $C present as a physical file."
+
+      - name: All tracked consumer copies are byte-identical to canonical
+        run: |
+          set -uo pipefail
+          chmod +x scripts/sync_kbli_dataset.sh
+          scripts/sync_kbli_dataset.sh --check

--- a/scripts/sync_kbli_dataset.sh
+++ b/scripts/sync_kbli_dataset.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# sync_kbli_dataset.sh — propagate the ONE canonical KBLI dataset to every consumer copy.
+#
+# WHY (superscar #1 HOME-fork + #9 schema-drift): the KBLI_2025_FINAL_CLEAN.json
+# dataset existed in 6 physical copies + 1 broken symlink, drifting silently. The
+# RAG chatbot read a stale/poor copy (86101=TERBUKA/100, no OSS source, no l4_bali)
+# while the web + native app served the corrected rich OSS-base. This script makes
+# the propagation a single deterministic command, and `check-kbli-dataset-sync.yml`
+# fails CI if any copy diverges from canonical.
+#
+# CANONICAL (source of truth):
+#   source_documents/KBLI_2025_FINAL_CLEAN.json   (repo ROOT, git-tracked)
+# This is the path the RAG reads at runtime (backend/services/kbli_eye.py default
+# db_path="source_documents/..." resolved from repo root, and reindex script's
+# parents[4]/source_documents/...). The 30MB rich OSS-base (1559 codes, l4_bali +
+# _l1_source/_l2_source OSS_RBA_2025 on every record).
+#
+# CONSUMERS kept in sync (physical files, NOT symlinks — Vercel/Fly build contexts
+# do not reliably follow a symlink that exits the project/app dir, so we copy):
+#   data/source_documents/KBLI_2025_FINAL_CLEAN.json    (tracked, secondary fallback)
+#   apps/mouth/data/KBLI_2025_FINAL_CLEAN.json          (tracked, balizero.com/kbli prod)
+#   apps/backend-rag/backend/data/KBLI_2025_FINAL_CLEAN.json  (gitignored, was MARCIA zombie)
+#
+# REPAIRED:
+#   apps/backend-rag/source_documents/KBLI_2025_FINAL_CLEAN.json
+#     — was a BROKEN symlink to /Users/nuzantara/... (a dead Pro-user HOME path on
+#       M5/balizero). Replaced with a physical copy of canonical.
+#
+# OUT OF SCOPE (handled by the native-app deploy script, not the repo):
+#   ~/Desktop/kbli-navigator-app/Resources/KBLI_2025_FINAL_CLEAN.json
+#     — lives outside the repo; deploy/install-3mac.sh copies it from the app's own
+#       Resources/. If you change canonical, re-run the app build+deploy to refresh it.
+#
+# Usage:
+#   scripts/sync_kbli_dataset.sh           # propagate canonical → all consumers
+#   scripts/sync_kbli_dataset.sh --check   # verify only, non-zero exit on drift (CI mode)
+set -euo pipefail
+
+# Resolve repo root from this script's location (works from any cwd / any worktree).
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+CANONICAL="source_documents/KBLI_2025_FINAL_CLEAN.json"
+
+# Consumer copies that MUST be byte-identical to canonical.
+CONSUMERS=(
+  "data/source_documents/KBLI_2025_FINAL_CLEAN.json"
+  "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json"
+  "apps/backend-rag/backend/data/KBLI_2025_FINAL_CLEAN.json"
+  "apps/backend-rag/source_documents/KBLI_2025_FINAL_CLEAN.json"
+)
+
+MODE="${1:-sync}"
+
+if [[ ! -f "$CANONICAL" ]]; then
+  echo "::error::canonical KBLI dataset missing at $CANONICAL — cannot sync." >&2
+  exit 2
+fi
+
+# A symlink in canonical's place would defeat the SoT (it must be a real file).
+if [[ -L "$CANONICAL" ]]; then
+  echo "::error::$CANONICAL is a SYMLINK — canonical must be a physical file (HOME-fork #1)." >&2
+  exit 2
+fi
+
+drift=0
+for dst in "${CONSUMERS[@]}"; do
+  if [[ "$MODE" == "--check" ]]; then
+    if [[ -L "$dst" ]]; then
+      echo "DRIFT: $dst is a SYMLINK (expected a physical copy of canonical)."
+      drift=1
+    elif [[ ! -f "$dst" ]]; then
+      # A gitignored consumer (RAG copies) may legitimately be absent on a fresh
+      # checkout/CI runner — it is materialised by this script at build time. Only
+      # the git-TRACKED consumers must always be present & identical.
+      if git ls-files --error-unmatch "$dst" >/dev/null 2>&1; then
+        echo "DRIFT: tracked consumer $dst is MISSING."
+        drift=1
+      else
+        echo "skip (gitignored, absent on this runner): $dst"
+      fi
+    elif ! cmp -s "$CANONICAL" "$dst"; then
+      echo "DRIFT: $dst differs from canonical $CANONICAL — run scripts/sync_kbli_dataset.sh."
+      drift=1
+    else
+      echo "ok: $dst == canonical"
+    fi
+  else
+    mkdir -p "$(dirname -- "$dst")"
+    # Replace a stale symlink with a real file.
+    [[ -L "$dst" ]] && rm -f "$dst"
+    if cmp -s "$CANONICAL" "$dst" 2>/dev/null; then
+      echo "unchanged: $dst"
+    else
+      cp -f "$CANONICAL" "$dst"
+      echo "synced: $dst"
+    fi
+  fi
+done
+
+if [[ "$MODE" == "--check" ]]; then
+  if [[ "$drift" -ne 0 ]]; then
+    echo "::error::KBLI dataset copies drifted from canonical ($CANONICAL). Run scripts/sync_kbli_dataset.sh and commit." >&2
+    exit 1
+  fi
+  echo "All KBLI dataset consumers are in sync with canonical."
+fi


### PR DESCRIPTION
## What

One canonical KBLI dataset + a sync script + a CI lint that fails on drift. Cures superscar **#1 HOME-fork** for the KBLI dataset family.

## Why

`KBLI_2025_FINAL_CLEAN.json` lived in **6 physical copies + 1 broken symlink**, drifting silently:

| copy | was | who reads it |
|---|---|---|
| `source_documents/` (ROOT) | rich OSS-base ✅ | **RAG runtime** (`kbli_eye.py` default `db_path`) |
| `data/source_documents/` | rich ✅ | kbli-navigator fallback |
| `apps/mouth/data/` | rich ✅ | **balizero.com/kbli** (prod) |
| `apps/backend-rag/source_documents/` | **BROKEN symlink** → `/Users/nuzantara/` (dead Pro HOME path on M5) | RAG primary path |
| `apps/backend-rag/backend/data/` | **MARCIA** (86101=TERBUKA/100, no OSS, no l4_bali) | zombie (read by nobody via code) |

The RAG's primary read path was a dead symlink → it fell back to the **stale/poor** copy. So the chatbot could serve `86101 = TERBUKA / 100% foreign` while the web + native app correctly served `TERTUTUP / route→86103`.

## How (the cure is executable, not documentation)

- **Canonical** = `source_documents/KBLI_2025_FINAL_CLEAN.json` (repo ROOT, tracked) — the path the RAG actually reads.
- `scripts/sync_kbli_dataset.sh` propagates canonical → every consumer as a **physical file** (not a symlink: Vercel/Fly build contexts don't reliably follow a symlink that exits the project/app dir). Repairs the broken symlink, overwrites the marcia zombie.
- `.github/workflows/check-kbli-dataset-sync.yml` runs `sync_kbli_dataset.sh --check` (`cmp -s`) and **fails CI** if any tracked consumer diverges. Path-scoped + **non-required** (W69: observe before blocking).

## Verified on disk this turn

- All 4 consumers now byte-identical to canonical (`b264a257`).
- `KBLIEye()` loads **1559 rich records** from the repaired path and decides on `86101` → now `TERTUTUP / route→86103 / l4_bali present`.
- Gitignored RAG copies are materialised at build time by the same script — never committed (only the 2 new artifacts land).

## Scope note

The native app (`~/Desktop/kbli-navigator-app/Resources/...`) is outside the repo; its own `deploy/install-3mac.sh` keeps it fresh. The sync script documents this. Not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)