### PR TITLE
fix(infra): gitignore .venv variants — keep -deploy clone pullable (anti-W81)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,17 @@ uv.lock
 # so it never counts as a local change.
 .venv-wr2-html/
 **/.venv-wr2-html/
+# Catch-all for venv SIBLINGS/BACKUPS that org self-heal creates (.venv.broken-<ts>,
+# .venv.bak, .venv-<name>) — same scar class as html-venv above. 2026-06-27 a
+# backend self-heal left apps/backend-rag/.venv.broken-210424/ in the -deploy CLONE,
+# which made `git status` dirty and the puller REFUSED to fast-forward → #1779 (and
+# every later merge) could not reach the live organs. The bare `.venv`/`.venv/`
+# patterns miss the `.venv.<suffix>` / `.venv-<suffix>` names. Cover the whole family
+# so a generated venv variant can never again wedge the runtime checkout (anti-W81).
+.venv.*
+**/.venv.*
+.venv-*
+**/.venv-*
 # apps/backend-rag/data/ holds large logs + raw assets we don't ship, BUT
 # apps/backend-rag/data/evaluation/ holds small static golden-query fixtures
 # that tests import at collection time — CI needs them in the repo.


### PR DESCRIPTION
## What
LIVE follow-up to #1777: after the puller correctly tracked `main`, the `-deploy` **clone still wouldn't fast-forward** — `git status` was dirty on `apps/backend-rag/.venv.broken-210424/`, a venv a backend self-heal left behind. The puller (rightly) refuses to ff a dirty checkout, so #1779 and every later merge was stuck *before* reaching the live organs.

## Root cause
`.gitignore` covers `.venv`/`.venv/` but not `.venv.<suffix>` / `.venv-<suffix>`. **Exact same scar class as `.venv-wr2-html` (W81/html-venv, 2026-06-17)** — it rebit under a new name.

## Fix
Cover the whole family (`.venv.*`, `.venv-*`) so a generated venv variant can never again wedge the runtime checkout.

Verified live: removed the stray `.venv.broken-210424/` → puller fast-forwarded the clone to origin/main (`98ed8e6b`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)