### PR TITLE
fix(intake): retention manages wa-mirror-media blobs (multi-root)

### DIFF
--- a/apps/backend-rag/backend/tests/scripts/test_intake_blob_retention_roots.py
+++ b/apps/backend-rag/backend/tests/scripts/test_intake_blob_retention_roots.py
@@ -1,0 +1,86 @@
+"""Defence-in-depth tests for the intake-blob retention managed-root set.
+
+Regression guard for the WhatsApp-blob leak (2026-06-27): wa-mirror-media
+blobs lived OUTSIDE the single managed root, so the retention job skipped them
+forever and the dir grew unbounded (2.0 GB / 5.6k files). The fix turns the
+single root into a managed SET that includes ~/wa-mirror-media while keeping
+the same "never unlink outside a managed root" guarantee.
+
+These tests load the script by path (it lives under scripts/, not a package)
+and exercise the pure helpers only — no DB, no filesystem mutation.
+"""
+
+import importlib.util
+import os
+from pathlib import Path
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[5] / "scripts" / "intake_blob_retention.py"
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("intake_blob_retention", _SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_default_roots_include_intake_blobs_and_wa_mirror(monkeypatch):
+    monkeypatch.delenv("INTAKE_BLOB_ROOTS", raising=False)
+    monkeypatch.delenv("INTAKE_BLOB_ROOT", raising=False)
+    m = _load()
+    roots = m._blob_roots()
+    names = {r.name for r in roots}
+    assert "intake-blobs" in names
+    assert "wa-mirror-media" in names
+
+
+def test_wa_mirror_blob_is_now_under_a_managed_root(monkeypatch):
+    monkeypatch.delenv("INTAKE_BLOB_ROOTS", raising=False)
+    monkeypatch.delenv("INTAKE_BLOB_ROOT", raising=False)
+    m = _load()
+    roots = m._blob_roots()
+    wa = Path(os.path.expanduser("~/wa-mirror-media/groups/x/abc.jpg"))
+    # the leak: this used to be skipped; it must now be eligible
+    assert m._is_under_any_root(wa, roots) is True
+
+
+def test_drive_intake_blob_still_under_a_managed_root(monkeypatch):
+    monkeypatch.delenv("INTAKE_BLOB_ROOTS", raising=False)
+    monkeypatch.delenv("INTAKE_BLOB_ROOT", raising=False)
+    m = _load()
+    roots = m._blob_roots()
+    ib = Path(os.path.expanduser("~/.nuzantara/intake-blobs/drive/1x/FILE__n.pdf"))
+    assert m._is_under_any_root(ib, roots) is True
+
+
+def test_arbitrary_path_is_never_under_a_managed_root(monkeypatch):
+    """Innocence: a path outside every managed root must never be unlinked."""
+    monkeypatch.delenv("INTAKE_BLOB_ROOTS", raising=False)
+    monkeypatch.delenv("INTAKE_BLOB_ROOT", raising=False)
+    m = _load()
+    roots = m._blob_roots()
+    for danger in ("/etc/passwd", "/", os.path.expanduser("~/.ssh/id_ed25519")):
+        assert m._is_under_any_root(Path(danger), roots) is False, danger
+
+
+def test_env_override_replaces_the_whole_set(monkeypatch):
+    monkeypatch.setenv("INTAKE_BLOB_ROOTS", os.pathsep.join(["/tmp/a", "/tmp/b"]))
+    m = _load()
+    roots = {r.name for r in m._blob_roots()}
+    assert roots == {"a", "b"}
+    # and a wa-mirror path is NOT matched once the set is overridden
+    wa = Path(os.path.expanduser("~/wa-mirror-media/x.jpg"))
+    assert m._is_under_any_root(wa, m._blob_roots()) is False
+
+
+def test_legacy_singular_env_still_overrides_first_root(monkeypatch):
+    monkeypatch.delenv("INTAKE_BLOB_ROOTS", raising=False)
+    monkeypatch.setenv("INTAKE_BLOB_ROOT", "/tmp/custom-intake")
+    m = _load()
+    names = {r.name for r in m._blob_roots()}
+    # custom intake root replaces the default intake-blobs; wa-mirror stays
+    assert "custom-intake" in names
+    assert "wa-mirror-media" in names

--- a/scripts/intake_blob_retention.py
+++ b/scripts/intake_blob_retention.py
@@ -62,19 +62,53 @@ _TERMINAL_STATUSES = (
 )
 
 
-def _blob_root() -> Path:
-    return Path(
-        os.environ.get("INTAKE_BLOB_ROOT", os.path.expanduser("~/.nuzantara/intake-blobs"))
-    ).resolve()
+def _blob_roots() -> list[Path]:
+    """The set of directories whose blobs this job is allowed to unlink.
+
+    Defence-in-depth: a blob is only ever unlinked if it resolves strictly
+    under ONE of these roots — never an arbitrary path from the DB row.
+
+    Two managed roots by default:
+    - the Drive/Dropbox intake cache (``~/.nuzantara/intake-blobs``)
+    - the WhatsApp mirror media dir (``~/wa-mirror-media``) — historically
+      *outside* the single root, so WA blobs were skipped forever and grew
+      unbounded (2.0 GB / 5.6k files, 2026-06-27). They are terminal-status
+      copies whose extracted value already lives in the DB, so they obey the
+      same TTL contract as every other intake blob.
+
+    Override the whole set with ``INTAKE_BLOB_ROOTS`` (os.pathsep-separated).
+    ``INTAKE_BLOB_ROOT`` (singular, legacy) still overrides the first root.
+    """
+    multi = os.environ.get("INTAKE_BLOB_ROOTS")
+    if multi:
+        raw = [p for p in multi.split(os.pathsep) if p.strip()]
+    else:
+        raw = [
+            os.environ.get("INTAKE_BLOB_ROOT", os.path.expanduser("~/.nuzantara/intake-blobs")),
+            os.path.expanduser("~/wa-mirror-media"),
+        ]
+    roots: list[Path] = []
+    for r in raw:
+        try:
+            roots.append(Path(r).expanduser().resolve())
+        except OSError:
+            continue
+    return roots
 
 
-def _is_under_root(path: Path, root: Path) -> bool:
-    """True iff `path` is strictly under `root` (defence-in-depth before unlink)."""
+def _is_under_any_root(path: Path, roots: list[Path]) -> bool:
+    """True iff `path` is strictly under ANY managed root (defence-in-depth)."""
     try:
-        path.resolve().relative_to(root)
-        return True
-    except (ValueError, OSError):
+        resolved = path.resolve()
+    except OSError:
         return False
+    for root in roots:
+        try:
+            resolved.relative_to(root)
+            return True
+        except ValueError:
+            continue
+    return False
 
 
 async def reclaim(pool: asyncpg.Pool, *, ttl_days: int, apply: bool) -> dict[str, int]:
@@ -86,11 +120,11 @@ async def reclaim(pool: asyncpg.Pool, *, ttl_days: int, apply: bool) -> dict[str
         "outside_root": 0,
         "errors": 0,
     }
-    root = _blob_root()
+    roots = _blob_roots()
 
     async with pool.acquire() as conn:
         rows = await conn.fetch(
-            f"""
+            """
             SELECT q.id, q.blob_path, q.status, di.byte_size
             FROM intake_queue q
             JOIN document_instances di ON di.id = q.instance_id
@@ -108,9 +142,9 @@ async def reclaim(pool: asyncpg.Pool, *, ttl_days: int, apply: bool) -> dict[str
         if not blob_path:
             continue
         p = Path(blob_path)
-        if not _is_under_root(p, root):
+        if not _is_under_any_root(p, roots):
             counters["outside_root"] += 1
-            logger.warning("retention: blob_path outside INTAKE_BLOB_ROOT, skipping: %s", blob_path)
+            logger.warning("retention: blob_path outside managed blob roots, skipping: %s", blob_path)
             continue
         if not p.exists():
             counters["already_gone"] += 1


### PR DESCRIPTION
## Problem
WhatsApp mirror media (`~/wa-mirror-media`) lived **outside** the single managed blob root, so the nightly `intake_blob_retention` job logged `outside INTAKE_BLOB_ROOT, skipping` for every WA blob and never reclaimed them. The dir grew unbounded: **2.0 GB / 5.6k files**, with ~2049 terminal-status rows >7d old eligible-but-skipped (verified live on Pro, 2026-06-27).

Drive/Dropbox `intake-blobs` was the *only* managed root.

## Fix
Single root → managed **set** (`_blob_roots` / `_is_under_any_root`) including `~/wa-mirror-media`, keeping the same defence-in-depth guarantee: a blob is unlinked **only** if it resolves strictly under a managed root, never an arbitrary DB path. Whole set overridable via `INTAKE_BLOB_ROOTS`; legacy `INTAKE_BLOB_ROOT` still overrides the first root.

## Verification (live dry-run on Pro, new code)
| | before | after |
|---|---|---|
| `outside_root` (skipped forever) | thousands | **8** |
| `would-unlink` | 9 | **2052** |
| GB reclaimable | 0.22 | **0.69** |

6 unit tests: innocence (`/etc`, `~/.ssh` never matched), guilt (wa + drive matched), env override. ruff clean, pre-commit green.

Cicatrix family **#1 HOME-fork** adjacent (path-scoped root) — the leak was a scope gap, not a path fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)