### PR TITLE
fix(lint): anti-reward-hacking — skip tests inherited from a merge parent

### DIFF
--- a/scripts/lint_test_reward_hacking.py
+++ b/scripts/lint_test_reward_hacking.py
@@ -161,6 +161,36 @@ def lint_source(path: Path, source: str) -> list[Finding]:
     return findings
 
 
+def _git_blob(ref: str, path: str) -> str | None:
+    """sha of <path> at <ref>, or None if absent. Used to decide whether a
+    staged file is genuinely changed by THIS commit vs inherited from a parent."""
+    try:
+        r = subprocess.run(
+            ["git", "rev-parse", f"{ref}:{path}"],
+            capture_output=True, text=True, timeout=10, check=False,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    return r.stdout.strip() if r.returncode == 0 else None
+
+
+def _merge_parents() -> list[str]:
+    """Return the parent refs of an in-progress merge (HEAD + MERGE_HEAD entries),
+    or [] when this is an ordinary (non-merge) commit."""
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--quiet", "--verify", "MERGE_HEAD"],
+            capture_output=True, text=True, timeout=10, check=False,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return []
+    if out.returncode != 0 or not out.stdout.strip():
+        return []
+    # MERGE_HEAD can hold multiple parents (octopus merge), one sha per line.
+    parents = ["HEAD"] + [ln.strip() for ln in out.stdout.splitlines() if ln.strip()]
+    return parents
+
+
 def _staged_test_files() -> list[Path]:
     try:
         out = subprocess.run(
@@ -169,7 +199,24 @@ def _staged_test_files() -> list[Path]:
         ).stdout
     except (subprocess.SubprocessError, OSError):
         return []
-    return [Path(p) for p in out.splitlines() if p.endswith(".py") and _is_test_file(Path(p))]
+    staged = [p for p in out.splitlines() if p.endswith(".py") and _is_test_file(Path(p))]
+
+    # MERGE-COMMIT GUARD (scar #3 over-match, W88-adjacent): on a merge commit, git
+    # stages EVERY file of the incoming side, so a test that is byte-identical to one
+    # of the merge parents — never touched by this branch — gets falsely flagged.
+    # Lint ONLY the tests this commit genuinely introduces: drop any staged file whose
+    # blob equals a parent's blob (i.e. inherited unchanged from HEAD or MERGE_HEAD).
+    parents = _merge_parents()
+    if parents:
+        kept = []
+        for p in staged:
+            staged_sha = _git_blob(":0", p)  # index (what will be committed)
+            if staged_sha is not None and any(_git_blob(par, p) == staged_sha for par in parents):
+                continue  # identical to a parent → inherited, not introduced here
+            kept.append(p)
+        staged = kept
+
+    return [Path(p) for p in staged]
 
 
 def main(argv: list[str]) -> int:

--- a/scripts/test_lint_test_reward_hacking.py
+++ b/scripts/test_lint_test_reward_hacking.py
@@ -138,3 +138,76 @@ def test_helper_function_not_flagged_for_no_assert():
     """A non-test_ helper that asserts nothing must NOT trigger RH005."""
     src = "def helper_compute():\n    return 42\n"
     assert "RH005" not in _codes(src)
+
+
+# ─── merge-commit guard (scar #3 over-match): a test inherited unchanged from a
+#     merge parent must NOT be linted — only tests THIS commit introduces ──────
+
+
+def test_merge_parents_empty_without_merge_head(monkeypatch):
+    """_merge_parents() returns [] on an ordinary commit (no MERGE_HEAD) — so the
+    merge-guard is a no-op and normal-commit behavior is unchanged."""
+    from scripts import lint_test_reward_hacking as L
+
+    class _R:
+        returncode = 1
+        stdout = ""
+
+    monkeypatch.setattr(L.subprocess, "run", lambda *a, **k: _R())
+    assert L._merge_parents() == []
+
+
+def test_merge_parents_lists_head_and_merge_head(monkeypatch):
+    """When MERGE_HEAD resolves, parents = HEAD + each MERGE_HEAD sha (octopus-safe)."""
+    from scripts import lint_test_reward_hacking as L
+
+    class _R:
+        returncode = 0
+        stdout = "abc123\ndef456\n"
+
+    monkeypatch.setattr(L.subprocess, "run", lambda *a, **k: _R())
+    assert L._merge_parents() == ["HEAD", "abc123", "def456"]
+
+
+def test_merge_guard_drops_inherited_test(monkeypatch):
+    """A staged test whose blob equals a parent's blob (inherited via merge, never
+    touched by this branch) is dropped from the lint set — the #1732 false-positive."""
+    from scripts import lint_test_reward_hacking as L
+
+    # one staged test file
+    class _Diff:
+        returncode = 0
+        stdout = "apps/backend-rag/backend/tests/x_test.py\n"
+
+    monkeypatch.setattr(L.subprocess, "run", lambda *a, **k: _Diff())
+    monkeypatch.setattr(L, "_is_test_file", lambda p: True)
+    # active merge with one parent
+    monkeypatch.setattr(L, "_merge_parents", lambda: ["HEAD"])
+    # staged blob == HEAD blob → inherited, must be dropped
+    monkeypatch.setattr(
+        L, "_git_blob",
+        lambda ref, path: "SAMESHA",  # both ":0" (index) and "HEAD" return same
+    )
+    assert L._staged_test_files() == []
+
+
+def test_merge_guard_keeps_introduced_test(monkeypatch):
+    """A staged test whose blob differs from every parent (genuinely changed by this
+    commit) is KEPT — the guard must not blind the linter to real cheats in a merge."""
+    from scripts import lint_test_reward_hacking as L
+
+    class _Diff:
+        returncode = 0
+        stdout = "apps/backend-rag/backend/tests/x_test.py\n"
+
+    monkeypatch.setattr(L.subprocess, "run", lambda *a, **k: _Diff())
+    monkeypatch.setattr(L, "_is_test_file", lambda p: True)
+    monkeypatch.setattr(L, "_merge_parents", lambda: ["HEAD"])
+
+    def _blob(ref, path):
+        return "INDEXSHA" if ref == ":0" else "PARENTSHA"
+
+    monkeypatch.setattr(L, "_git_blob", _blob)
+    assert [str(p) for p in L._staged_test_files()] == [
+        "apps/backend-rag/backend/tests/x_test.py"
+    ]


### PR DESCRIPTION
## Why
`_staged_test_files()` used `git diff --cached` = ALL staged files. On a **merge commit** git stages every file of the incoming side, so a test byte-identical to a merge parent — never touched by the branch — was falsely flagged as a reward-hack and **blocked the commit**.

Real case (PR #1732): merging origin/main into the intake-OCR branch hit RH001/RH005 on `test_service_account_drive_service.py` + `test_drive_poll_service.py`, both **proven byte-identical to main** and never authored by the branch.

Scar **#3 (guard over-match)**: the guard decided on "is it staged?" (surface) instead of "did THIS commit introduce it?" (intent).

## Fix
When `MERGE_HEAD` is present, drop any staged test whose index blob equals a parent's blob (HEAD or any MERGE_HEAD sha — octopus-safe). Non-merge commits are unaffected.

## Verification
- E2E against the **real #1732 merge**: linter now reports `no staged test files — nothing to check` instead of 5 false findings.
- **Innocence**: a genuine `assert True` cheat on a normal commit still fires RH001 (verified).
- **+4 tests** (guilt: inherited dropped / introduced kept; parents-list octopus-safe) per spec P1 §7.

Unblocks #1732 (intake-OCR, 5766 lines) once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)