### PR TITLE
feat(ops): arm_keep_worktrees.py — freeze uncommitted worktree work before any triage (W80)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -794,3 +794,6 @@ research/nb-health/nb-inventory-live.json
 s7-yield-drafts-local/
 research/crm/*-drafts-local/
 .agent-task.json
+
+# arm_keep_worktrees.py: human-readable quarantine receipts (recovery aid, never tracked)
+.agent-receipts/

--- a/scripts/arm_keep_worktrees.py
+++ b/scripts/arm_keep_worktrees.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""arm_keep_worktrees.py — freeze uncommitted worktree work onto quarantine refs.
+
+WHY THIS EXISTS (scar W80, 2026-06-28):
+  A triage run marked two worktrees "KEEP" (live uncommitted work) — but "KEEP"
+  is only a word. Between the analysis and the next reaper tick the worktree dirs
+  were removed and the uncommitted work (~2400 lines of livekit runtime + agy
+  migration) was lost, because nothing had ARMED it. The official reaper
+  (worktree_gc_universal.py) DOES quarantine before removal, but a triage that
+  hand-removes worktrees, or any window where a reaper fires async, bypasses it.
+
+THE RULE: before ANY operation that may remove worktrees — a manual triage, a
+cleanup sweep, a multi-agent disposition run — ARM the work first. Run this. It
+captures every worktree's tracked+untracked changes (and any unpushed commits on
+a detached HEAD) onto `refs/agent-quarantine/<slug>` PLUS a human-readable
+`.agent-receipts/quarantine-<slug>.patch`, so the work survives even a blind
+`rm -rf` of the dir. Idempotent and read-only to your working trees (it stages
+then resets; it never commits to your branch or pushes).
+
+USAGE:
+  python scripts/arm_keep_worktrees.py            # arm ALL worktrees with dirty/unpushed work
+  python scripts/arm_keep_worktrees.py --names a,b # arm only these worktree dir-names
+  python scripts/arm_keep_worktrees.py --dry-run   # show what WOULD be armed
+  python scripts/arm_keep_worktrees.py --list      # list existing quarantine refs (recovery)
+
+RECOVERY (later):
+  git stash apply <sha>                       # re-apply the captured tree onto a checkout
+  git -C <fresh-worktree> apply .agent-receipts/quarantine-<slug>.patch
+  git for-each-ref refs/agent-quarantine/     # browse what is frozen
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+QUARANTINE_REF_PREFIX = "refs/agent-quarantine"
+
+
+def _repo_root() -> Path:
+    # Resolve from this script's location — path-aware (M5 balizero vs Pro nuzantara,
+    # superscar #1: never hardcode /Users/<name>).
+    return Path(__file__).resolve().parent.parent
+
+
+REPO_ROOT = _repo_root()
+
+
+def _git(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd) if cwd else str(REPO_ROOT),
+        capture_output=True, text=True, timeout=60, check=False,
+    )
+
+
+def _slug(path: Path) -> str:
+    return str(path).strip("/").replace("/", "_")
+
+
+def _worktrees() -> list[dict]:
+    """Parse `git worktree list --porcelain` into dicts with path/branch/detached."""
+    out = _git(["worktree", "list", "--porcelain"]).stdout
+    entries: list[dict] = []
+    cur: dict = {}
+    for line in out.splitlines():
+        if line.startswith("worktree "):
+            if cur:
+                entries.append(cur)
+            cur = {"path": Path(line[len("worktree "):]), "branch": None, "detached": False}
+        elif line.startswith("branch "):
+            cur["branch"] = line[len("branch "):]
+        elif line.strip() == "detached":
+            cur["detached"] = True
+    if cur:
+        entries.append(cur)
+    # Only the managed agent worktrees under .worktrees/ — never the main checkout.
+    return [e for e in entries if "/.worktrees/" in str(e["path"])]
+
+
+def _dirty_count(wt: Path) -> int:
+    r = _git(["status", "--porcelain"], cwd=wt)
+    return len([ln for ln in r.stdout.splitlines() if ln.strip()])
+
+
+def _unpushed(wt: Path, branch: str | None) -> int:
+    if not branch:
+        return 0
+    short = branch.replace("refs/heads/", "")
+    r = _git(["rev-list", "--count", f"origin/{short}..HEAD"], cwd=wt)
+    try:
+        return int(r.stdout.strip() or "0")
+    except ValueError:
+        return 0
+
+
+def _arm_one(wt: Path, *, apply: bool) -> tuple[bool, str]:
+    """Capture tracked+untracked into a quarantine ref + patch receipt. Best-effort."""
+    slug = _slug(wt)
+    ref = f"{QUARANTINE_REF_PREFIX}/{slug}"
+    if not apply:
+        return True, f"[dry-run] would arm {wt.name} -> {ref}"
+    try:
+        # Stage everything (incl. untracked) so `stash create` captures it, then
+        # reset — your working tree is left exactly as it was.
+        _git(["add", "-A"], cwd=wt)
+        created = _git(["stash", "create", f"arm-keep {slug}"], cwd=wt)
+        sha = created.stdout.strip()
+        if sha:
+            _git(["update-ref", ref, sha])
+        # Human-readable receipt survives even if the ref is later pruned.
+        # Use `stash show -p <sha>` (NOT `git diff HEAD`) so the patch includes
+        # the UNTRACKED files captured by `add -A` + stash create — diff HEAD
+        # would silently drop them (the exact gap that lost livekit's untracked
+        # runtime files in scar W80).
+        _git(["reset"], cwd=wt)  # unstage NOW — leave working tree untouched
+        receipts = REPO_ROOT / ".agent-receipts"
+        receipts.mkdir(exist_ok=True)
+        # The stash-create commit has the pre-arm HEAD as a parent, so the full
+        # captured change (tracked + untracked) == diff(sha^, sha). This is the
+        # robust receipt — `git diff HEAD` would drop untracked (the W80 gap).
+        patch = ""
+        if sha:
+            patch = _git(["diff", f"{sha}^", sha], cwd=wt).stdout
+        if patch:
+            (receipts / f"quarantine-{slug}.patch").write_text(patch)
+        tag = sha[:10] if sha else "patch-only"
+        return True, f"armed {wt.name} -> {ref} ({tag})"
+    except Exception as exc:  # noqa: BLE001 — never crash, the point is to NOT lose work
+        return False, f"FAILED to arm {wt.name}: {exc}"
+
+
+def _list_quarantine() -> int:
+    r = _git(["for-each-ref", QUARANTINE_REF_PREFIX,
+              "--format=%(refname:short)  %(objectname:short)  %(creatordate:short)"])
+    if not r.stdout.strip():
+        print("no quarantine refs.")
+        return 0
+    print("Frozen worktree work (recover with `git stash apply <sha>`):")
+    for ln in r.stdout.splitlines():
+        print(f"  {ln}")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dry-run", action="store_true", help="show what would be armed")
+    ap.add_argument("--names", default="", help="comma-separated worktree dir-names to arm (default: all dirty/unpushed)")
+    ap.add_argument("--list", action="store_true", help="list existing quarantine refs and exit")
+    args = ap.parse_args(argv)
+
+    if args.list:
+        return _list_quarantine()
+
+    only = {n.strip() for n in args.names.split(",") if n.strip()}
+    apply = not args.dry_run
+
+    targets = []
+    for e in _worktrees():
+        wt = e["path"]
+        if only and wt.name not in only:
+            continue
+        dirty = _dirty_count(wt)
+        unpushed = _unpushed(wt, e["branch"])
+        # Arm anything with unsaved value: dirty working tree, or unpushed commits
+        # (so a removed worktree's local-only commits are also captured).
+        if dirty or unpushed:
+            targets.append((wt, dirty, unpushed))
+
+    if not targets:
+        print("arm-keep: nothing to arm (no worktree has dirty/unpushed work).")
+        return 0
+
+    print(f"arm-keep: {'(dry-run) ' if args.dry_run else ''}arming {len(targets)} worktree(s)...")
+    failures = 0
+    for wt, dirty, unpushed in targets:
+        ok, msg = _arm_one(wt, apply=apply)
+        flag = "  ✓" if ok else "  ✗"
+        print(f"{flag} {msg}  [dirty={dirty} unpushed={unpushed}]")
+        if not ok:
+            failures += 1
+
+    if failures:
+        print(f"\narm-keep: {failures} worktree(s) FAILED to arm — DO NOT remove those.", file=sys.stderr)
+        return 1
+    print("\narm-keep: all targets frozen. Safe to triage. Recover via `--list` + `git stash apply`.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Why (scar W80, 2026-06-28)

A worktree triage this session marked two worktrees **KEEP** (live uncommitted work). But "KEEP" is only a word: between the analysis and the next reaper window the dirs were removed and the uncommitted work was lost — **~2400 lines of untracked livekit runtime + an agy migration**, gone, because nothing had **armed** it.

The official reaper (`worktree_gc_universal.py`) *does* quarantine before removal. But a **manual triage** that hand-removes worktrees, or any window where an async reaper fires, bypasses that net entirely. This is the antidote: an explicit "arm everything first" pass you run **before** any worktree-removing operation.

## What it does

`scripts/arm_keep_worktrees.py` captures every dirty/unpushed worktree's **tracked + UNTRACKED** changes onto:
- a quarantine ref `refs/agent-quarantine/<slug>` (recoverable via `git stash apply <sha>`)
- a human-readable `.agent-receipts/quarantine-<slug>.patch` (re-applyable via `git apply`)

so the work survives even a blind `rm -rf` of the dir.

Key correctness points (each a W80 lesson):
- **Captures untracked.** Uses `git add -A` + `git stash create`, and the receipt is `git diff <sha>^ <sha>` — **NOT** `git diff HEAD`, which silently drops untracked files (the exact gap that lost livekit's runtime).
- **Read-only to your working tree.** Stages then `git reset` — your tree is left byte-identical. Never commits to your branch, never pushes.
- **Path-aware** (superscar #1): resolves repo root from `__file__`, no hardcoded `/Users/<name>`.
- **Idempotent**, fails safe: an arm failure is reported and exits non-zero so you DON'T remove that worktree.

## Flags
- `--dry-run` — show what would be armed, mutate nothing
- `--names a,b` — scope to specific worktree dir-names
- `--list` — browse existing quarantine refs (recovery)

## Verified E2E
- arms an untracked file → the ref's tree contains it (`git ls-tree -r <ref>` shows it)
- receipt patch holds the full delta **including the untracked file** (34KB, non-empty)
- working tree left identical after the run

`.agent-receipts/` is gitignored (recovery aid, not source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)