### PR TITLE
fix(organism): restart_agent resolves organ_id → genome label (A2 last mile)

### DIFF
--- a/apps/organism/organism/actuators/restart_agent.py
+++ b/apps/organism/organism/actuators/restart_agent.py
@@ -1,9 +1,19 @@
 """Actuator: restart a launchd-managed agent via launchctl kickstart.
 
-Resolves `agent_ref`:
-- If it already contains a dot (e.g. `com.third.party.foo`) it's treated as a
-  full launchd label and passed through as-is.
-- Otherwise it's prefixed with `com.balizero.` (our namespace convention).
+Resolves `agent_ref` to a launchd label, in priority order:
+1. **Genome lookup (authoritative)** — if `agent_ref` matches an organ `id` in
+   organs_registry.yaml, use that organ's `recovery_params.label`. This is the
+   real launchd label (e.g. `pro.dlq_autopilot` → `com.nuzantara.dlq-autopilot`).
+2. Already a launchd label — if it has a dot AND looks like a launchd label
+   (starts with a reverse-DNS namespace `com.`/`homebrew.`/etc.), pass as-is.
+3. Otherwise prefix with `com.balizero.` (legacy namespace convention).
+
+Why the genome lookup exists (W: A2 dead-letter, 2026-06-27): the supervisor's
+heartbeat_silent events carry `agent_ref = "<node>.<organ>"` (e.g.
+`pro.dlq_autopilot`) — an ORGAN ID, NOT a launchd label. The old resolver saw a
+dot and used it as-is, so `launchctl kickstart gui/<uid>/pro.dlq_autopilot`
+fired at a label that does not exist → kickstart no-op → the organ stayed dead →
+re-flagged every tick. The genome carries the true label; read it.
 
 Then invokes:
     launchctl kickstart -k gui/<uid>/<label>
@@ -14,15 +24,70 @@ so the caller can treat "agent not loaded" as a soft failure.
 """
 import asyncio
 import os
+from functools import lru_cache
+from pathlib import Path
+
+import yaml
 
 from organism.actuators.base import ActuatorBase
+
+# Reverse-DNS namespaces that mark a string as an already-resolved launchd label.
+_LAUNCHD_NAMESPACES = ("com.", "homebrew.", "org.", "io.", "net.")
+
+_DEFAULT_GENOME = (
+    Path(__file__).resolve().parents[2] / "organism" / "organs_registry.yaml"
+)
+
+
+@lru_cache(maxsize=1)
+def _organ_label_map() -> dict[str, str]:
+    """Map organ `id` -> launchd label from the genome's recovery_params.
+
+    Cached for the process lifetime. Path overridable via ORGANISM_GENOME_PATH
+    (falls back to ORGANISM_RULES_PATH's sibling, then the package default) so a
+    test or an alternate runtime root resolves the right registry.
+    """
+    candidates = []
+    env_path = os.getenv("ORGANISM_GENOME_PATH")
+    if env_path:
+        candidates.append(Path(env_path).expanduser())
+    rules_path = os.getenv("ORGANISM_RULES_PATH")
+    if rules_path:
+        candidates.append(Path(rules_path).expanduser().parents[1] / "organs_registry.yaml")
+    candidates.append(_DEFAULT_GENOME)
+
+    for path in candidates:
+        try:
+            data = yaml.safe_load(path.read_text()) or {}
+        except (OSError, yaml.YAMLError):
+            continue
+        organs = data.get("organs", []) if isinstance(data, dict) else []
+        mapping: dict[str, str] = {}
+        for organ in organs:
+            if not isinstance(organ, dict):
+                continue
+            oid = organ.get("id")
+            label = (organ.get("recovery_params") or {}).get("label")
+            if oid and label:
+                mapping[oid] = label
+        if mapping:
+            return mapping
+    return {}
 
 
 class RestartAgent(ActuatorBase):
     name = "restart_agent"
 
     def _label(self, agent_ref: str) -> str:
-        return agent_ref if "." in agent_ref else f"com.balizero.{agent_ref}"
+        # 1. Authoritative: organ_id -> launchd label from the genome.
+        genome_label = _organ_label_map().get(agent_ref)
+        if genome_label:
+            return genome_label
+        # 2. Already a launchd label (reverse-DNS namespace prefix).
+        if agent_ref.startswith(_LAUNCHD_NAMESPACES):
+            return agent_ref
+        # 3. Legacy namespace convention.
+        return f"com.balizero.{agent_ref}"
 
     async def _execute(self, params: dict) -> dict:
         agent_ref = params["agent_ref"]

--- a/apps/organism/tests/actuators/test_restart_agent_label_resolver.py
+++ b/apps/organism/tests/actuators/test_restart_agent_label_resolver.py
@@ -1,0 +1,85 @@
+"""Regression test for the restart_agent label resolver (A2 dead-letter cure).
+
+THE BUG (2026-06-27): the supervisor's heartbeat_silent events carry
+`agent_ref = "<node>.<organ>"` (organ id, e.g. `pro.dlq_autopilot`) — NOT a
+launchd label. The old resolver saw the dot and used the ref as-is, so
+`launchctl kickstart gui/<uid>/pro.dlq_autopilot` fired at a non-existent label
+→ no-op → the organ stayed dead → re-flagged every tick (W2 restart loop with
+zero effect). The genome carries the true label in recovery_params.label; the
+fix reads it.
+
+These tests pin the cure: organ_id -> genome label, real labels pass through,
+unknown refs fall back to the legacy namespace. If someone reverts to the
+"dot == label" heuristic, the GUILT case (pro.dlq_autopilot) fails loudly.
+"""
+import textwrap
+
+import pytest
+
+from organism.actuators.restart_agent import RestartAgent, _organ_label_map
+
+
+_GENOME = textwrap.dedent(
+    """\
+    version: 1
+    organs:
+      - id: pro.dlq_autopilot
+        runtime: pro_launchd
+        recovery_action: launchctl_kickstart
+        recovery_params:
+          label: com.nuzantara.dlq-autopilot
+      - id: pro.login_healthcheck
+        runtime: pro_launchd
+        recovery_params:
+          label: com.nuzantara.login-healthcheck
+      - id: pro.no_recovery
+        runtime: pro_launchd
+    """
+)
+
+
+@pytest.fixture()
+def genome(tmp_path, monkeypatch):
+    p = tmp_path / "organs_registry.yaml"
+    p.write_text(_GENOME)
+    monkeypatch.setenv("ORGANISM_GENOME_PATH", str(p))
+    _organ_label_map.cache_clear()  # the map is lru_cached — clear per test
+    yield p
+    _organ_label_map.cache_clear()
+
+
+def test_genome_label_map_loads(genome):
+    m = _organ_label_map()
+    assert m["pro.dlq_autopilot"] == "com.nuzantara.dlq-autopilot"
+    assert m["pro.login_healthcheck"] == "com.nuzantara.login-healthcheck"
+    # an organ without recovery_params.label is not in the map
+    assert "pro.no_recovery" not in m
+
+
+def test_organ_id_resolves_to_genome_label(genome):
+    """GUILT: the exact bug — an organ id with a dot must NOT be used as-is."""
+    ra = RestartAgent()
+    assert ra._label("pro.dlq_autopilot") == "com.nuzantara.dlq-autopilot"
+    assert ra._label("pro.login_healthcheck") == "com.nuzantara.login-healthcheck"
+
+
+def test_real_launchd_label_passes_through(genome):
+    """INNOCENCE: a genuine launchd label (reverse-DNS) is left untouched."""
+    ra = RestartAgent()
+    assert ra._label("com.third.party.foo") == "com.third.party.foo"
+    assert ra._label("homebrew.mxcl.redis") == "homebrew.mxcl.redis"
+
+
+def test_unknown_dotless_ref_uses_legacy_namespace(genome):
+    """INNOCENCE: legacy convention preserved for bare names."""
+    ra = RestartAgent()
+    assert ra._label("standalone_agent") == "com.balizero.standalone_agent"
+
+
+def test_unknown_dotted_ref_not_in_genome_passes_through(genome):
+    """An organ-shaped ref absent from the genome and not reverse-DNS:
+    falls back to legacy prefixing (defensive — better a wrong label that
+    fails loudly than silently swallowing). It must NOT crash."""
+    ra = RestartAgent()
+    # 'pro.no_recovery' has no label in genome, not a reverse-DNS namespace
+    assert ra._label("pro.no_recovery") == "com.balizero.pro.no_recovery"


### PR DESCRIPTION
## What
The **last mile of ring A2**. The supervisor's `heartbeat_silent → restart_agent` decisions were firing `launchctl kickstart` at **non-existent labels** — so a dead organ was never actually restarted.

## Root cause (verified on Pro)
The supervisor emits `agent_ref = "<node>.<organ>"` (organ id, e.g. `pro.dlq_autopilot`) — **not** a launchd label. The old resolver: `return ref if "." in ref else f"com.balizero.{ref}"`. An organ id has a dot → used as-is → `kickstart gui/<uid>/pro.dlq_autopilot` → label doesn't exist → no-op → organ stays "dead" → re-flagged every tick. This is exactly what arming W2 exposed (restart_agent `dispatched` with zero effect).

## Fix
The genome `organs_registry.yaml` already maps each organ to its real label via `recovery_params.label`. The resolver now:
1. `organ_id` → genome `recovery_params.label` (authoritative)
2. already a launchd label (reverse-DNS `com.`/`homebrew.`/…) → as-is
3. else → `com.balizero.<ref>` (legacy, preserved)

## Proof (run, not claimed)
Against the **real 111-organ genome** on Pro + the runtime venv:
| Case | Result |
|---|---|
| `pro.dlq_autopilot` → `com.nuzantara.dlq-autopilot` | ✓ (the bug) |
| `pro.login_healthcheck` / `pro.federation_alert_dispatcher` | ✓ real labels |
| `com.third.party.foo`, `homebrew.mxcl.redis` | ✓ pass-through |
| `standalone_agent` → `com.balizero.standalone_agent` | ✓ legacy |
| pytest `test_restart_agent_label_resolver.py` | **5/5 pass** |

## Why it matters
This is the second of the two W2 re-arm preconditions. Pre-cond 1 (Redis MISCONF) already resolved by the disk cleanup. With this merged, re-arming W2 means a dead organ is **actually** kickstarted — A2 closes at the *result*, not at a phantom label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)