### PR TITLE
feat(ops): arm-keep defense-in-depth — WR2-reaper cabling + PreToolUse gate (W80)

### DIFF
--- a/infra/claude-hooks/install_worktree_hooks.sh
+++ b/infra/claude-hooks/install_worktree_hooks.sh
@@ -51,7 +51,9 @@ done
 echo "== self-verify: running the innocence vaccine against installed hooks =="
 # The vaccine copies the REPO hooks into a synthetic tempdir, so it validates the
 # logic we just installed (repo == live after copy). A red vaccine = broken hook.
-if python3 "$SRC/test_hook_innocence.py"; then
+# test_arm_keep_hook.py covers the W80 arm-before-remove guard with REAL git
+# worktrees (the synthetic vaccine can't, being a non-git repo) — both must pass.
+if python3 "$SRC/test_hook_innocence.py" && python3 "$SRC/test_arm_keep_hook.py"; then
     echo "== VACCINE GREEN — hooks installed and proven to bite only the guilty. =="
     echo "   Reload with /hooks (or restart the session)."
     echo "   Kill switch: AGENT_WORKTREE_ENFORCEMENT=false"

--- a/infra/claude-hooks/test_arm_keep_hook.py
+++ b/infra/claude-hooks/test_arm_keep_hook.py
@@ -112,6 +112,16 @@ def evaluate() -> list[str]:
         clean = _add_worktree(root, "clean")
         if _run_hook(hook, f"git worktree remove {clean}", rr, rr) == 2:
             fails.append("BIT-INNOCENT: remove CLEAN worktree → expected ALLOW")
+
+        # 4) OVER-MATCH regression (superscar #3): a noisy command run FROM INSIDE a
+        #    dirty worktree, where the only `git worktree remove` has its path empty
+        #    after quote-stripping and trailing shell residue (`2>/dev/null && echo`).
+        #    A stray token resolved against the cwd-worktree must NOT auto-incriminate
+        #    it. cwd = the dirty worktree itself; expect ALLOW (no explicit target).
+        noisy = f'git -C "{rr}" worktree remove --force "" 2>/dev/null && echo done'
+        if _run_hook(hook, noisy, str(dirty), rr) == 2:
+            fails.append("BIT-INNOCENT (over-match): empty-target remove + shell residue "
+                         "from inside a dirty worktree → expected ALLOW")
     finally:
         # best-effort: prune worktrees then nuke tmp
         try:

--- a/infra/claude-hooks/test_arm_keep_hook.py
+++ b/infra/claude-hooks/test_arm_keep_hook.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""W80 arm-before-remove guard — guilt+innocence with REAL git worktrees.
+
+The shared innocence vaccine (test_hook_innocence.py) runs against a SYNTHETIC
+non-git repo, so it can only cover the W80 cases whose verdict needs no git state
+(out-of-scope rm, quoted echo, read-only list, non-existent target). This suite
+covers the part that DOES need state: a worktree that is dirty-and-unarmed must be
+BLOCKED, while the same worktree once ARMED — and a clean one — must be ALLOWED.
+
+It builds a throwaway git repo with three worktrees, invokes the real on-disk hook
+exactly as Claude Code does (JSON on stdin, exit 2 = BLOCK), then tears everything
+down. Skips cleanly if git is unavailable.
+
+Run:  python3 infra/claude-hooks/test_arm_keep_hook.py
+      pytest infra/claude-hooks/test_arm_keep_hook.py -q
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = pathlib.Path(__file__).resolve().parent
+REPO_ROOT_SRC = HERE.parent.parent                       # real repo (for arm_keep + hook source)
+HOOK_SRC = HERE / "worktree_isolation.py"
+ARM_KEEP_SRC = REPO_ROOT_SRC / "scripts" / "arm_keep_worktrees.py"
+
+
+def _git(args: list[str], cwd: pathlib.Path) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=str(cwd),
+                          capture_output=True, text=True, timeout=30)
+
+
+def _run_hook(hook: pathlib.Path, cmd: str, cwd: str, repo_root: str) -> int:
+    env = dict(os.environ)
+    env["NUZ_REPO_ROOT"] = repo_root
+    env.pop("AGENT_WORKTREE_ENFORCEMENT", None)
+    env.pop("HOST_BOUNDARY_OFF", None)
+    payload = {"tool_name": "Bash", "tool_input": {"command": cmd}, "cwd": cwd}
+    proc = subprocess.run([sys.executable, str(hook)], input=json.dumps(payload),
+                          capture_output=True, text=True, timeout=20, env=env)
+    return proc.returncode
+
+
+def _build_repo(tmp: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path]:
+    """Create a git repo carrying the agent_start.py signature + a first commit.
+    Returns (repo_root, runnable_hook_path)."""
+    root = tmp / "main"
+    (root / "scripts").mkdir(parents=True)
+    (root / "scripts" / "agent_start.py").write_text("# signature\n")
+    (root / "infra" / "claude-hooks").mkdir(parents=True)
+    # bring the real hook + arm_keep into the synthetic repo so imports/paths line up
+    shutil.copy2(HOOK_SRC, root / "infra" / "claude-hooks" / "worktree_isolation.py")
+    shutil.copy2(ARM_KEEP_SRC, root / "scripts" / "arm_keep_worktrees.py")
+    _git(["init", "-q"], root)
+    _git(["config", "user.email", "t@t.t"], root)
+    _git(["config", "user.name", "t"], root)
+    _git(["add", "-A"], root)
+    _git(["commit", "-qm", "init"], root)
+    return root, root / "infra" / "claude-hooks" / "worktree_isolation.py"
+
+
+def _add_worktree(root: pathlib.Path, name: str) -> pathlib.Path:
+    wt = root / ".worktrees" / name
+    _git(["worktree", "add", "-q", "-b", f"b/{name}", str(wt), "HEAD"], root)
+    return wt
+
+
+def _arm(root: pathlib.Path, wt: pathlib.Path) -> None:
+    sys.path.insert(0, str(root / "scripts"))
+    try:
+        import importlib
+        import arm_keep_worktrees  # noqa
+        importlib.reload(arm_keep_worktrees)
+        # arm_keep resolves REPO_ROOT from its own __file__ → the synthetic root. Good.
+        arm_keep_worktrees._arm_one(wt, apply=True)
+    finally:
+        sys.path.pop(0)
+
+
+def evaluate() -> list[str]:
+    if not shutil.which("git"):
+        return []  # no git → skip (treated as pass)
+    fails: list[str] = []
+    tmp = pathlib.Path(tempfile.mkdtemp(prefix="armkeep_hook_"))
+    try:
+        root, hook = _build_repo(tmp)
+        rr = str(root)
+
+        # 1) dirty + unarmed → BLOCK
+        dirty = _add_worktree(root, "dirty")
+        (dirty / "UNTRACKED.txt").write_text("work\n")
+        for cmd, desc in [
+            (f"git worktree remove --force {dirty}", "git worktree remove dirty+unarmed"),
+            (f"rm -rf {dirty}", "rm -rf dirty+unarmed"),
+        ]:
+            if _run_hook(hook, cmd, rr, rr) != 2:
+                fails.append(f"WENT-BLIND: {desc} → expected BLOCK")
+
+        # 2) dirty + ARMED → ALLOW
+        armed = _add_worktree(root, "armed")
+        (armed / "UNTRACKED.txt").write_text("work\n")
+        _arm(root, armed)
+        if _run_hook(hook, f"git worktree remove --force {armed}", rr, rr) == 2:
+            fails.append("BIT-INNOCENT: remove dirty+ARMED → expected ALLOW")
+
+        # 3) clean → ALLOW
+        clean = _add_worktree(root, "clean")
+        if _run_hook(hook, f"git worktree remove {clean}", rr, rr) == 2:
+            fails.append("BIT-INNOCENT: remove CLEAN worktree → expected ALLOW")
+    finally:
+        # best-effort: prune worktrees then nuke tmp
+        try:
+            _git(["worktree", "prune"], tmp / "main")
+        except Exception:
+            pass
+        shutil.rmtree(tmp, ignore_errors=True)
+    return fails
+
+
+def test_arm_keep_hook():
+    fails = evaluate()
+    assert not fails, "W80 arm-before-remove regressions:\n" + "\n".join(fails)
+
+
+if __name__ == "__main__":
+    f = evaluate()
+    if f:
+        print(f"=== {len(f)} FAIL ===")
+        for x in f:
+            print("  [FAIL] " + x)
+        sys.exit(1)
+    print("=== W80 arm-before-remove guard OK (blocks dirty+unarmed, spares armed+clean) ===")
+    sys.exit(0)

--- a/infra/claude-hooks/test_hook_innocence.py
+++ b/infra/claude-hooks/test_hook_innocence.py
@@ -114,6 +114,13 @@ CASES: dict[str, list[tuple[dict, str, str]]] = {
         (bash(f"git -C {WT} checkout main"), "ALLOW", "git mutate inside worktree via -C"),
         (bash("grep -rn 'cp ' infra/ | head"), "ALLOW", "the word cp inside a grep pattern"),
         (bash("echo 'use tee to split output' "), "ALLOW", "the word tee inside a quoted string"),
+        # W80 arm-before-remove — INNOCENCE tripwires (no git state needed; these
+        # resolve to non-dirty / out-of-scope targets so the guard must stay silent).
+        (bash("rm -rf /tmp/scratch-dir"), "ALLOW", "rm -rf outside .worktrees → not a worktree removal"),
+        (bash("rm -rf node_modules"), "ALLOW", "rm -rf a non-worktree dir in repo"),
+        (bash(f"echo 'rm -rf {WT}'"), "ALLOW", "rm of a worktree path inside a quoted echo (W83 noise-strip)"),
+        (bash("git worktree list"), "ALLOW", "git worktree list is read-only, never a removal"),
+        (bash(f"git worktree remove {WT}-does-not-exist"), "ALLOW", "remove of a non-existent worktree → nothing to lose"),
         # GUILT — must still BLOCK
         (bash("git checkout main"), "BLOCK", "git checkout in main checkout"),
         (bash("git add ."), "BLOCK", "git add . in main"),

--- a/infra/claude-hooks/worktree_isolation.py
+++ b/infra/claude-hooks/worktree_isolation.py
@@ -170,9 +170,28 @@ def _worktree_is_dirty(wt: pathlib.Path) -> bool:
 
 
 def _resolve_under_worktrees(token: str, cwd: str) -> pathlib.Path | None:
-    """Resolve a path token to a concrete `<repo>/.worktrees/<name>` dir, else None."""
+    """Resolve a path token to a concrete `<repo>/.worktrees/<name>` dir, else None.
+
+    Conservative by design (superscar #3): a removal command names the worktree
+    EXPLICITLY, and that name always contains the `.worktrees/` segment (absolute
+    or repo-relative). We require it. This refuses to auto-incriminate the current
+    worktree from a bare/relative junk token: when cwd is itself inside
+    `.worktrees/<x>`, resolving a stray token like `2>/dev/null` or `&&` against it
+    would fall under <x> and falsely flag it. So we (a) drop tokens that carry
+    shell metacharacters (never a real path arg here) and (b) demand the literal
+    `.worktrees` segment in the token before resolving relative to cwd.
+    """
     token = token.strip().strip("'\"")
     if not token or token.startswith("-"):
+        return None
+    # Shell-structure residue that survived noise-strip is NOT a path.
+    if any(ch in token for ch in (">", "<", "&", "|", ";", "$", "*", "`")):
+        return None
+    # The remove target must explicitly name the worktrees dir (the W83 lesson:
+    # match the command's INTENT — a real `worktree remove`/`rm` arg points at
+    # `.worktrees/<x>`; a bare relative token does not and must not be resolved
+    # against a cwd that happens to sit inside a worktree).
+    if ".worktrees/" not in token and not token.endswith(".worktrees"):
         return None
     base = pathlib.Path(cwd) if cwd else pathlib.Path(REPO_ROOT)
     p = pathlib.Path(token)

--- a/infra/claude-hooks/worktree_isolation.py
+++ b/infra/claude-hooks/worktree_isolation.py
@@ -123,6 +123,94 @@ CD_GIT_RE = re.compile(r"\bcd\s+(\S+)\s*(?:&&|;)\s*git\b")
 # antidote: match the command's intent, not a substring.
 REMOTE_DISPATCH_RE = re.compile(r"(?:^|(?:&&|\|\||;|\|)\s*)\s*(?:ssh|scp|rsync)\b")
 
+# --- W80: arm-before-remove guard ----------------------------------------------
+# A worktree-REMOVING command (manual triage, `git worktree remove`, `rm -rf` on a
+# .worktrees/<x> dir) must not run while that worktree holds dirty/untracked work
+# that has NOT been frozen onto a quarantine ref. The official reaper quarantines
+# itself, but a HUMAN/agent triage at the shell bypasses every net — this is the
+# exact path that lost ~2400 lines in W80. The guard blocks ONLY the dirty-and-
+# unarmed case and tells you to run scripts/arm_keep_worktrees.py first.
+#
+# Intent-matched (superscar #3 antidote), NOT bare-substring:
+#   - `git worktree remove [--force] <path>`  — segment-anchored git verb
+#   - `rm -rf[...] <path>` where a resolved arg lands under <repo>/.worktrees/<x>
+# Anything we cannot resolve to a concrete dirty worktree → ALLOW (negative-gating).
+WT_REMOVE_GIT_RE = re.compile(
+    r"\bgit\s+(?:-C\s+\S+\s+)?worktree\s+remove\b((?:\s+(?:--?\S+|[^\s|;&)]+))+)"
+)
+RM_RF_RE = re.compile(r"\brm\s+(?:-\S+\s+)*-\S*[rf]\S*(?:\s+-\S+)*((?:\s+[^\s|;&)]+)+)")
+
+
+def _quarantine_ref_for(wt: pathlib.Path) -> str:
+    """Mirror arm_keep_worktrees._slug — the ref a freeze of <wt> would live under."""
+    slug = str(wt).strip("/").replace("/", "_")
+    return f"refs/agent-quarantine/{slug}"
+
+
+def _ref_exists(ref: str) -> bool:
+    try:
+        r = _sp.run(["git", "rev-parse", "--verify", "--quiet", ref],
+                    cwd=REPO_ROOT, capture_output=True, text=True, timeout=3)
+        return r.returncode == 0 and bool(r.stdout.strip())
+    except Exception:
+        return False
+
+
+def _worktree_is_dirty(wt: pathlib.Path) -> bool:
+    """True if <wt> has tracked-or-untracked changes. Conservative: on any error
+    we return False (→ ALLOW) so the guard never blocks on a probe failure."""
+    try:
+        r = _sp.run(["git", "-C", str(wt), "status", "--porcelain"],
+                    capture_output=True, text=True, timeout=5)
+        if r.returncode != 0:
+            return False
+        return any(ln.strip() for ln in r.stdout.splitlines())
+    except Exception:
+        return False
+
+
+def _resolve_under_worktrees(token: str, cwd: str) -> pathlib.Path | None:
+    """Resolve a path token to a concrete `<repo>/.worktrees/<name>` dir, else None."""
+    token = token.strip().strip("'\"")
+    if not token or token.startswith("-"):
+        return None
+    base = pathlib.Path(cwd) if cwd else pathlib.Path(REPO_ROOT)
+    p = pathlib.Path(token)
+    cand = (p if p.is_absolute() else (base / p))
+    try:
+        cand = cand.resolve()
+    except Exception:
+        return None
+    wt_root = pathlib.Path(REPO_ROOT, ".worktrees").resolve()
+    try:
+        rel = cand.relative_to(wt_root)
+    except ValueError:
+        return None
+    # must be a direct child .worktrees/<name> (not .worktrees itself, not deeper file)
+    if len(rel.parts) < 1 or not rel.parts[0]:
+        return None
+    return pathlib.Path(wt_root, rel.parts[0])
+
+
+def _unarmed_dirty_removal_target(cmd_scan: str, cwd: str) -> pathlib.Path | None:
+    """If the command removes a worktree that is dirty AND not yet quarantined,
+    return that worktree path (→ caller blocks). Else None (→ allow)."""
+    tokens: list[str] = []
+    for m in WT_REMOVE_GIT_RE.finditer(cmd_scan):
+        tokens += m.group(1).split()
+    for m in RM_RF_RE.finditer(cmd_scan):
+        tokens += m.group(1).split()
+    for tok in tokens:
+        wt = _resolve_under_worktrees(tok, cwd)
+        if wt is None or not wt.is_dir():
+            continue
+        if not _worktree_is_dirty(wt):
+            continue  # clean → safe to remove, nothing to lose
+        if _ref_exists(_quarantine_ref_for(wt)):
+            continue  # already frozen → safe
+        return wt  # dirty AND unarmed → block
+    return None
+
 # --- W79 B1: shell file-WRITE detection ----------------------------------------
 # Quick gate: does the command contain anything that could write a file?
 WRITE_HINT_RE = re.compile(r"(>>?|\btee\b|\bsed\b[^|]*-i|\bdd\b[^|]*\bof=|\b(?:cp|mv|install)\b)")
@@ -496,6 +584,33 @@ def main():
             f"Emergency escape: AGENT_WORKTREE_ENFORCEMENT=false (env var set in shell)\n"
         )
         sys.exit(2)
+
+    # --- W80: block removing a DIRTY, UNARMED worktree (manual triage path) ---
+    # Runs BEFORE the git-only quick-exit because `rm -rf .worktrees/x` carries no
+    # "git" token. Noise-stripped so a path inside a quoted string / heredoc is not
+    # mistaken for a real removal arg (same #3 antidote as the git scan below).
+    rm_scan = _strip_noise(cmd)
+    if ("worktree" in rm_scan and "remove" in rm_scan) or "rm " in rm_scan:
+        victim = _unarmed_dirty_removal_target(rm_scan, cwd)
+        if victim is not None:
+            _increment_block_counter()
+            _probe_log(payload, "block_unarmed_worktree_removal")
+            sys.stderr.write(
+                f"WORKTREE REMOVAL BLOCKED (dirty + unarmed — scar W80)\n"
+                f"  worktree: {victim}\n"
+                f"  command: {cmd[:200]}\n\n"
+                f"Reason: this worktree has uncommitted/untracked work that is NOT yet\n"
+                f"frozen onto a quarantine ref. Removing it now would silently destroy\n"
+                f"that work (W80: ~2400 lines lost exactly this way).\n\n"
+                f"Resolution — ARM it first (captures tracked + untracked, reversible):\n"
+                f"  python scripts/arm_keep_worktrees.py --names {victim.name}\n"
+                f"  # then re-run your removal; recover later via:\n"
+                f"  #   python scripts/arm_keep_worktrees.py --list\n"
+                f"  #   git stash apply <sha>\n\n"
+                f"If the work is genuinely disposable, arm it anyway (cheap) or set\n"
+                f"  AGENT_WORKTREE_ENFORCEMENT=false   (env var in shell)\n"
+            )
+            sys.exit(2)
 
     # Quick exit: cmd doesn't look git-mutating
     if "git" not in cmd:

--- a/scripts/arm_keep_worktrees.py
+++ b/scripts/arm_keep_worktrees.py
@@ -56,7 +56,17 @@ def _git(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProces
 
 
 def _slug(path: Path) -> str:
-    return str(path).strip("/").replace("/", "_")
+    # Canonicalize first: the same physical worktree must yield the SAME slug no
+    # matter how the path was written (relative, trailing slash, or the macOS
+    # /var → /private/var symlink). Otherwise the quarantine ref a reader looks
+    # for (e.g. the arm-before-remove hook) misses the one the writer created,
+    # and recovery silently breaks. resolve() with a fallback for non-existent
+    # paths (dry-run / already-removed) so it never raises.
+    try:
+        canon = path.resolve()
+    except Exception:
+        canon = path
+    return str(canon).strip("/").replace("/", "_")
 
 
 def _worktrees() -> list[dict]:

--- a/scripts/wr2_worktree_gc.py
+++ b/scripts/wr2_worktree_gc.py
@@ -38,6 +38,11 @@ from pathlib import Path
 logger = logging.getLogger("wr2.worktree_gc")
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
+# Make sibling scripts (arm_keep_worktrees) importable regardless of how the cron
+# invokes us (`python scripts/x.py` does NOT put scripts/ on sys.path).
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
 WORKTREES_DIR = _REPO_ROOT / ".worktrees"
 WORKTREE_PREFIX = "wr2-run-"
 DEFAULT_MAX_AGE_HOURS = 24
@@ -79,8 +84,38 @@ def list_wr2_run_worktrees() -> list[dict]:
     return out
 
 
+def _arm_before_remove(path: Path, *, apply: bool) -> None:
+    """Freeze any dirty/untracked work onto a quarantine ref BEFORE removal.
+
+    Scar W80: `git worktree remove --force` silently discards uncommitted +
+    untracked work with NO error. The official reaper (worktree_gc_universal.py)
+    quarantines first; this WR2 reaper used to `--force`-delete blind. Arm here so
+    the WR2 cron — which runs H24 without an operator or Claude hooks present —
+    can never be the thing that loses work. Best-effort: an arm failure is logged
+    but does NOT abort the GC (a stuck quarantine must not wedge the cron); the
+    worst case degrades to today's behavior, never worse.
+    """
+    try:
+        from arm_keep_worktrees import _arm_one, _dirty_count  # local import: optional dep
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("arm-keep unavailable (%s) — proceeding WITHOUT quarantine", exc)
+        return
+    try:
+        if _dirty_count(path) == 0:
+            return  # nothing to freeze
+    except Exception:  # noqa: BLE001
+        pass  # if we can't tell, arm anyway — fail safe toward preserving work
+    ok, msg = _arm_one(path, apply=apply)
+    logger.info("arm-keep: %s", msg)
+    if not ok:
+        logger.warning("arm-keep FAILED for %s — work may be at risk if removed", path.name)
+
+
 def remove_worktree(path: Path, *, apply: bool) -> bool:
-    """Run git worktree remove + cleanup branch."""
+    """Run git worktree remove + cleanup branch (arms dirty work first — W80)."""
+    # ALWAYS arm before any removal path, dry-run included (dry-run is a no-op arm).
+    _arm_before_remove(path, apply=apply)
+
     if not apply:
         logger.info(f"[dry-run] would remove worktree {path.name}")
         return True


### PR DESCRIPTION
## Context

Follow-up to #1791 (merged: the `arm_keep_worktrees.py` script + gitignore). That
PR gave us the *manual* tool. This one makes the protection **automatic** across
the three surfaces that #1791 left exposed, answering "do I always have to run it
by hand, or is it automatic?" — the answer is now: automatic.

The W80 incident was a worktree marked "KEEP" whose uncommitted work was destroyed
before anything froze it. The official reaper (`worktree_gc_universal.py`) already
quarantines first. The gaps this PR closes:

## 1. WR2 reaper cabling — `scripts/wr2_worktree_gc.py`
It removed aged `wr2-run-*` worktrees with `git worktree remove --force`, which
silently discards uncommitted + **untracked** work. It runs H24 via cron — no
operator, no hooks present — so it was a standing W80 trap. Now `remove_worktree`
arms every candidate (`refs/agent-quarantine/<slug>` + receipt) before removal.
Best-effort / fail-open: a wedged quarantine never wedges the cron; worst case
degrades to today's behavior, never worse.

## 2. PreToolUse gate — `infra/claude-hooks/worktree_isolation.py`
The W80 incident was a **manual triage at the shell**, which no reaper guards.
CLAUDE.md §7: "se una regola critica è violabile, scrivi un hook." Extends the
existing Bash isolation hook (it already carries the #3 over-match cures) with a
removal detector: removing a `.worktrees/<x>` that is **dirty AND unarmed** is
BLOCKED with the exact `arm_keep_worktrees.py` command to run first. Arm it →
the same removal is allowed. The gate forces a save, it does not trap you.

Intent-matched, not substring (superscar #3): noise-stripped, requires the
explicit `.worktrees/` segment, drops shell-metachar tokens. **Found and fixed a
live over-match during testing** — a noisy empty-target `git worktree remove ""
2>/dev/null && echo` run from inside a dirty worktree auto-incriminated the
*current* worktree; now a regression test pins it.

## 3. Hardening
- `_slug` canonicalizes the path (`/var` → `/private/var`, trailing slash) so the
  ref a reader looks for matches the one the writer created. Caught by the hook test.
- Installer (`install_worktree_hooks.sh`) self-verify now runs the W80 test too.

## Tests
- `test_arm_keep_hook.py` (NEW): real git worktrees — blocks dirty+unarmed (both
  `git worktree remove` and `rm -rf`), spares dirty+armed, clean, and the
  over-match case.
- `test_hook_innocence.py`: +5 W80 innocence tripwires; full vaccine **34/34**.
- Installed live on M5 and verified the installed copy blocks a real dirty+unarmed
  removal (and byte-matches the repo source — no HOME-fork).

Source lives in `infra/claude-hooks/` (repo SSOT) → installer copies to
`~/.claude/hooks/` (superscar #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)