### PR TITLE
feat(crm): 'contacts to name' banner for unnamed WA leads

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_clients.py
+++ b/apps/backend-rag/backend/app/routers/crm_clients.py
@@ -693,6 +693,15 @@ async def list_clients(
     assigned_to: str | None = Query(None, description="Filter by assigned team member email"),
     search: str | None = Query(None, description="Search by name, email, or phone"),
     nationality: str | None = Query(None, description="Filter by nationality"),
+    unnamed: bool = Query(
+        False,
+        description=(
+            "When true, return ONLY phone-keyed leads whose full_name is still a "
+            "placeholder (`Lead +<digits>`, `wa:<digits>`, bare digits, or empty) — "
+            "the WA-mirror auto-created leads an operator must still name. "
+            "Combine with assigned_to (or rely on RBAC) to scope to one operator."
+        ),
+    ),
     passport_expiring_days: int | None = Query(
         None,
         ge=0,
@@ -808,6 +817,22 @@ async def list_clients(
                 query_parts.append(f" AND c.status = ${param_index}")
                 params.append(status)
                 param_index += 1
+
+            # Unnamed phone-keyed leads: full_name is still a placeholder the
+            # WA-mirror sweeper assigned (`Lead +628…`, `wa:+…`, bare digits) or
+            # empty. Mirrors JUNK_NAME_PATTERNS in apps/wa-dashboard-m1/server.cjs
+            # so both surfaces agree on "this contact still needs a human name".
+            # No bound params (constant predicate) → param_index unchanged.
+            if unnamed:
+                query_parts.append(
+                    " AND ("
+                    "c.full_name IS NULL"
+                    " OR btrim(c.full_name) = ''"
+                    " OR c.full_name ~* '^lead\\s*\\+?[0-9]+$'"
+                    " OR c.full_name ~* '^wa:\\s*\\+?[0-9]+$'"
+                    " OR c.full_name ~ '^\\+?[0-9]{8,}$'"
+                    ")",
+                )
 
             # Optional filter by assigned_to (admin users can filter by any team member)
             if assigned_to:

--- a/apps/backend-rag/backend/tests/routers/test_crm_clients.py
+++ b/apps/backend-rag/backend/tests/routers/test_crm_clients.py
@@ -260,6 +260,48 @@ class TestListClients:
         assert "%alice%" in fetch_args
 
     @pytest.mark.integration
+    def test_list_clients_unnamed_filter_adds_placeholder_predicate(
+        self,
+        client: TestClient,
+        mock_db_pool,
+    ) -> None:
+        """unnamed=true must restrict to placeholder-named phone leads."""
+        _pool, conn = mock_db_pool
+        conn.fetch = AsyncMock(return_value=[_client_row()])
+
+        with (
+            patch("backend.app.routers.crm_clients.get_crm_user_filter", return_value=None),
+            patch("backend.app.routers.crm_clients.is_crm_admin", return_value=True),
+        ):
+            response = client.get("/api/crm/clients/?unnamed=true")
+
+        assert response.status_code == 200
+        sql = conn.fetch.await_args.args[0]
+        # the placeholder predicate (mirrors wa-dashboard JUNK_NAME_PATTERNS)
+        assert "^lead" in sql.lower()
+        assert "btrim(c.full_name) = ''" in sql
+
+    @pytest.mark.integration
+    def test_list_clients_without_unnamed_has_no_placeholder_predicate(
+        self,
+        client: TestClient,
+        mock_db_pool,
+    ) -> None:
+        """Innocence: a normal list must NOT carry the placeholder predicate."""
+        _pool, conn = mock_db_pool
+        conn.fetch = AsyncMock(return_value=[_client_row()])
+
+        with (
+            patch("backend.app.routers.crm_clients.get_crm_user_filter", return_value=None),
+            patch("backend.app.routers.crm_clients.is_crm_admin", return_value=True),
+        ):
+            response = client.get("/api/crm/clients/")
+
+        assert response.status_code == 200
+        sql = conn.fetch.await_args.args[0]
+        assert "^lead" not in sql.lower()
+
+    @pytest.mark.integration
     def test_list_clients_requires_authenticated_email(self, mock_db_pool) -> None:
         pool, _conn = mock_db_pool
         application = FastAPI()

--- a/apps/mouth/src/app/(workspace)/clients/UnnamedLeadsBanner.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/UnnamedLeadsBanner.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import Link from "next/link";
+import { UserPlus } from "lucide-react";
+
+import { api } from "@/lib/api";
+
+/**
+ * Persistent "contacts to name" banner.
+ *
+ * WA-mirror auto-creates a phone-keyed lead (`Lead +628…`) the first time a new
+ * contact sends a document. Until an operator gives it a real name, every
+ * document from that contact lands as NO_MATCH/LINK_CANDIDATE in review instead
+ * of attaching to a named client. This banner is the persistent, non-blocking
+ * nudge: it shows the count of still-unnamed leads (scoped by RBAC to the
+ * operator's own clients) and links to the filtered list. It renders nothing
+ * when there is nothing to name, so it never adds noise on a clean book.
+ *
+ * The backend `unnamed=true` filter mirrors the placeholder-name patterns in
+ * apps/wa-dashboard-m1/server.cjs so both surfaces agree on "needs a name".
+ */
+export default function UnnamedLeadsBanner() {
+  const { data: unnamed } = useQuery({
+    queryKey: ["clients", "unnamed"],
+    queryFn: () => api.crm.getClients({ unnamed: true, limit: 200 }),
+    staleTime: 60_000,
+    refetchInterval: 120_000,
+  });
+
+  const count = unnamed?.length ?? 0;
+  if (count === 0) return null;
+
+  return (
+    <Link
+      href="/clients?unnamed=1"
+      className="flex items-center gap-3 rounded-lg px-4 py-3 transition-colors"
+      style={{
+        background: "rgba(212, 132, 90, 0.12)",
+        border: "1px solid rgba(212, 132, 90, 0.35)",
+      }}
+    >
+      <span
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full"
+        style={{ background: "rgba(212, 132, 90, 0.22)" }}
+      >
+        <UserPlus className="h-4 w-4" style={{ color: "#d4845a" }} />
+      </span>
+      <span className="text-sm">
+        <span className="font-semibold" style={{ color: "#d4845a" }}>
+          {count} {count === 1 ? "contatto" : "contatti"} da nominare
+        </span>
+        <span className="ml-2 text-[var(--foreground-muted)]">
+          — nuovi lead WhatsApp senza nome. Dai un nome così i loro documenti si
+          collegano automaticamente.
+        </span>
+      </span>
+    </Link>
+  );
+}

--- a/apps/mouth/src/app/(workspace)/clients/page.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/page.tsx
@@ -11,7 +11,7 @@
  */
 
 import React, { useState, useEffect, useRef, useCallback } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import {
   Users,
@@ -64,6 +64,7 @@ import {
   saveViewMode,
 } from "@/lib/utils/view-mode-storage";
 import { STRINGS } from "@/lib/strings";
+import UnnamedLeadsBanner from "./UnnamedLeadsBanner";
 
 // Status badge styling
 const STATUS_STYLES: Record<string, { bg: string; text: string }> = {
@@ -259,6 +260,10 @@ function VirtualizedClientGrid({
  */
 function ClientsListContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  // When arriving from the "contacts to name" banner (/clients?unnamed=1),
+  // show ONLY phone-keyed leads still on a placeholder name.
+  const unnamedOnly = searchParams.get("unnamed") === "1";
   const [listParent] = useAutoAnimate();
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
@@ -408,6 +413,17 @@ function ClientsListContent() {
         return false;
       // Hide inactive/test clients by default unless user explicitly filters by inactive status
       if (!filters.status && client.status === "inactive") return false;
+      // "Contacts to name" view (?unnamed=1): only placeholder-named phone leads.
+      // Mirrors the backend `unnamed=true` predicate + wa-dashboard JUNK_NAME_PATTERNS.
+      if (unnamedOnly) {
+        const n = (client.full_name || "").trim();
+        const isPlaceholder =
+          n === "" ||
+          /^lead\s*\+?[0-9]+$/i.test(n) ||
+          /^wa:\s*\+?[0-9]+$/i.test(n) ||
+          /^\+?[0-9]{8,}$/.test(n);
+        if (!isPlaceholder) return false;
+      }
       // Silent filter: only show clients not contacted in N days
       if (silentFilter !== null) {
         const lastContact = client.last_interaction_date
@@ -512,6 +528,7 @@ function ClientsListContent() {
 
   return (
     <div className="space-y-6 h-full flex flex-col">
+      <UnnamedLeadsBanner />
       <ListPageHeader
         title="Clients"
         subtitle={

--- a/apps/mouth/src/lib/api/crm/crm.api.ts
+++ b/apps/mouth/src/lib/api/crm/crm.api.ts
@@ -326,6 +326,7 @@ export class CrmApi {
       assigned_to?: string;
       nationality?: string;
       passport_expiring_days?: number;
+      unnamed?: boolean;
       limit?: number;
       offset?: number;
     } = {},
@@ -335,6 +336,7 @@ export class CrmApi {
     if (params.status) queryParams.append("status", params.status);
     if (params.assigned_to)
       queryParams.append("assigned_to", params.assigned_to);
+    if (params.unnamed) queryParams.append("unnamed", "true");
     if (params.nationality)
       queryParams.append("nationality", params.nationality);
     if (params.passport_expiring_days !== undefined)


### PR DESCRIPTION
## Why
WA-mirror auto-creates a phone-keyed lead (`Lead +628…`) the first time a new contact sends a document (sweeper #1751, **verified live: captures sender_phone on 21/21 recent WA rows**). Until an operator names it, that contact's documents land as **NO_MATCH/LINK_CANDIDATE** in review instead of attaching to a named client. The upstream identity is clean — what's missing is the **prompt to name it**.

This is the leg Zero asked for: push the operator toward *autodeterminazione del contatto* at the entry, so downstream matching stops being a guess.

## What
On the surface operators actually use (**`apps/mouth` /clients** — NOT wa-mirror dashboard or Telegram, neither is operator-facing):

- **backend**: `GET /api/crm/clients` gains `unnamed=true` → only placeholder-named phone leads (`Lead +digits`, `wa:+digits`, bare digits, empty). Predicate mirrors `JUNK_NAME_PATTERNS` in `apps/wa-dashboard-m1/server.cjs` so both surfaces agree on 'needs a name'. RBAC already scopes a non-admin to their own clients → each operator sees only the contacts **they** received. **Verified live: 7 matched, 11580 real names excluded.**
- **frontend**: `<UnnamedLeadsBanner>` — persistent (refetch 2m), non-blocking banner atop /clients with the count + link to the filtered view. Renders nothing on a clean book.

The **rename-from-passport** half already exists in #1751 (sweeper updates `full_name` only when current is junk). This closes the loop's missing prompt.

## Dependency
Full value lands **after #1751 is deployed** (it's now on the runtime — verified) so leads actually get created. Today only 7 placeholder leads exist; the banner scales as new WA contacts arrive.

## Tests
2 new (guilt: `unnamed=true` adds the predicate; innocence: default does not) + 13 existing = **15/15 green**. mouth typecheck clean, pre-commit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)