### PR TITLE
fix(organism): end the 28-day heartbeat-channel blindness (receptor + core-organ cures)

### DIFF
--- a/infra/scripts/pg-organism-bridge-watchdog.sh
+++ b/infra/scripts/pg-organism-bridge-watchdog.sh
@@ -3,23 +3,68 @@
 # Pattern secrets: source ~/.nuzantara-secrets.env (NON launchctl setenv)
 # Symbiosis L3 grandfathering: polling 5min (heartbeat-based = follow-up PR)
 # Test: apps/backend-rag/backend/tests/services/events/test_bridge_heartbeat_polling_grandfathered.py
+#
+# 2026-06-28: this watchdog was NOT LOADED for ~21 days (launchd never re-bootstrapped
+# after a Pro reboot) — the guardian-of-the-guardian was dead, which is WHY the bridge
+# could stop refreshing core organs for 28 days unseen. Two cures applied:
+#   1. emit its OWN heartbeat every tick (so it can never go stale-invisible again —
+#      the organism_stale_detector now covers it).
+#   2. route alerts to the ORGANISM channel (~/.organism/alerts/) FIRST, not only to
+#      the operator's Telegram. The alert must reach the organism (the brain-session
+#      via the SessionStart receptor), not a human who won't look. Telegram kept as
+#      a best-effort backup, not the primary path.
 
 set -uo pipefail  # NO -e: pgrep no-match exits 1
 LOG=~/logs/pg-organism-bridge-watchdog.log
 STATE=~/.agent/decisions/state/pg_organism_bridge_watchdog.state
-mkdir -p "$(dirname "$LOG")" "$(dirname "$STATE")"
+ORGANISM_DIR=~/.organism
+ALERTS_DIR="$ORGANISM_DIR/alerts"
+LAST_SEEN_DIR="$ORGANISM_DIR/last_seen"
+SELF_ORGAN="infra.pg_organism_bridge_watchdog"
+mkdir -p "$(dirname "$LOG")" "$(dirname "$STATE")" "$ALERTS_DIR" "$LAST_SEEN_DIR"
 
 set -a
 [ -f "$HOME/.nuzantara-secrets.env" ] && source "$HOME/.nuzantara-secrets.env"
 set +a
 
+# emit_self_heartbeat <status> <note> — atomic, never breaks the run.
+emit_self_heartbeat() {
+  local _status="${1:-ok}" _note="${2:-}"
+  local _path="$LAST_SEEN_DIR/$SELF_ORGAN.json"
+  local _tmp="$_path.tmp.$$"
+  local _ts; _ts="$(date +%s)"
+  printf '{"ts":%s,"status":"%s","organ_id":"%s","metadata":{"note":"%s"}}\n' \
+    "$_ts" "$_status" "$SELF_ORGAN" "$_note" > "$_tmp" 2>/dev/null \
+    && mv "$_tmp" "$_path" 2>/dev/null
+  return 0
+}
+
+# organism_alert <severity> <organ> <message> — write to the organism alert channel
+# the SessionStart receptor reads. Append-as-event; the detector snapshot dedups.
+organism_alert() {
+  local _sev="$1" _organ="$2" _msg="$3"
+  local _ts; _ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  local _esc="${_msg//\"/\\\"}"
+  printf '{"detected_at":"%s","severity":"%s","organ_id":"%s","source":"%s","message":"%s"}\n' \
+    "$_ts" "$_sev" "$_organ" "$SELF_ORGAN" "$_esc" >> "$ALERTS_DIR/bridge-watchdog.jsonl" 2>/dev/null
+  return 0
+}
+
+# telegram_backup <text> — best-effort operator backup, never the primary channel.
+telegram_backup() {
+  [ -n "${TELEGRAM_BOT_TOKEN:-}" ] || return 0
+  curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+    -d "chat_id=${TELEGRAM_OWNER_CHAT_ID:-1125336968}" \
+    -d "text=$1" >> "$LOG" 2>&1 || true
+}
+
 # Step A: bridge process alive
 PID=$(pgrep -f "pg-to-organism-bridge.py" | head -1 || true)
 if [ -z "$PID" ]; then
   echo "$(date) ALERT: pg-organism-bridge NOT RUNNING — Symbiosis SPOF" >> "$LOG"
-  curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-    -d "chat_id=${TELEGRAM_OWNER_CHAT_ID:-1125336968}" \
-    -d "text=⚠️ pg-organism-bridge DOWN ($(date +%H:%M)) — Symbiosis SPOF" >> "$LOG" 2>&1
+  organism_alert "critical" "pro.pg_organism_bridge" "bridge process NOT RUNNING — Symbiosis SPOF (the heartbeat writer for core organs is down)"
+  telegram_backup "⚠️ pg-organism-bridge DOWN ($(date +%H:%M)) — Symbiosis SPOF"
+  emit_self_heartbeat "degraded" "bridge down"
   exit 0
 fi
 
@@ -29,6 +74,7 @@ LAST_ID=$(redis-cli -h "$REDIS_HOST" XREVRANGE organism:events + - COUNT 1 2>/de
 
 if [ -z "$LAST_ID" ]; then
   echo "$(date) WARN: no events in organism:events stream (PID=$PID alive, stream empty)" >> "$LOG"
+  emit_self_heartbeat "ok" "PID=$PID stream empty"
   exit 0
 fi
 
@@ -39,11 +85,12 @@ LAG_MIN=$(( LAG_MS / 60000 ))
 
 if [ "$LAG_MIN" -gt 30 ]; then
   echo "$(date) ALERT: bridge alive (PID=$PID) but stream lag ${LAG_MIN}min > 30min threshold" >> "$LOG"
-  curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-    -d "chat_id=${TELEGRAM_OWNER_CHAT_ID:-1125336968}" \
-    -d "text=⚠️ pg-organism-bridge alive but stream STALE (${LAG_MIN}min, threshold 30min)" >> "$LOG" 2>&1
+  organism_alert "warning" "pro.pg_organism_bridge" "bridge alive (PID=$PID) but organism:events stream STALE ${LAG_MIN}min > 30min threshold"
+  telegram_backup "⚠️ pg-organism-bridge alive but stream STALE (${LAG_MIN}min, threshold 30min)"
+  emit_self_heartbeat "degraded" "stream lag ${LAG_MIN}min"
 else
   echo "$(date) OK: PID=$PID last_event_lag=${LAG_MIN}min" >> "$LOG"
+  emit_self_heartbeat "ok" "PID=$PID lag=${LAG_MIN}min"
 fi
 
 exit 0

--- a/scripts/dlq_autopilot.py
+++ b/scripts/dlq_autopilot.py
@@ -847,6 +847,30 @@ def run_autopilot() -> None:
             "_writer": "dlq_autopilot",  # D1.5: audit trail
         }))
 
+        # UNCONDITIONAL organism heartbeat sidecar (2026-06-28): this script READ
+        # ~/.organism/last_seen/ for recovery signals but never WROTE its own, so
+        # pro.dlq_autopilot.json froze for 28 days while the cron ran green. The
+        # bridge used to refresh it and stopped; now the organ breathes for itself.
+        try:
+            ORGANISM_DIR.mkdir(parents=True, exist_ok=True)
+            organ_path = ORGANISM_DIR / "pro.dlq_autopilot.json"
+            organ_tmp = organ_path.with_suffix(f".json.tmp.{os.getpid()}")
+            organ_tmp.write_text(json.dumps({
+                "ts": time.time(),
+                "status": "ok",
+                "organ_id": "pro.dlq_autopilot",
+                "metadata": {
+                    "queue_size": len(queue),
+                    "fixed": fixed,
+                    "escalated": escalated,
+                    "skipped": skipped,
+                    "duration_s": round(duration, 1),
+                },
+            }))
+            organ_tmp.replace(organ_path)
+        except Exception as exc:  # noqa: BLE001 — heartbeat must never break the run
+            logger.warning(f"organ heartbeat emit failed: {exc}")
+
     finally:
         release_lock(fd)
 

--- a/scripts/hooks/organism_alert_sessionstart.sh
+++ b/scripts/hooks/organism_alert_sessionstart.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# organism_alert_sessionstart.sh — the RECEPTOR (SessionStart hook).
+#
+# Ends the 28-day blindness (2026-06-28): core organs ran green while their
+# heartbeat froze, and NO session ever saw it because no hook read any alert
+# channel (CLAUDE.md §14 said "check escalations" but nothing enforced it —
+# documentation is not a receptor; a hook is. CLAUDE.md §7).
+#
+# Wired into ~/.claude/settings.json under hooks.SessionStart. On every session
+# start it runs the stale-organ detector and, if any organ has stopped breathing,
+# injects an alert into the session's context as hookSpecificOutput.additionalContext
+# so the brain-session (me) SEES it — the alert reaches the organism, not a human
+# on Telegram who won't look.
+#
+# Design constraints (so the receptor itself never becomes the blindness):
+#   - FAST: hard 4s budget; never blocks session start.
+#   - PATH-AWARE: works on M5 (balizero) and Pro/Mini (nuzantara).
+#   - FAIL-OPEN: any error => no alert, exit 0 (a broken receptor must not
+#     break sessions; it degrades to the pre-existing silence, never worse).
+#   - SNAPSHOT: shows only currently-open alerts (cured organs vanish) — no
+#     stale-alert graveyard (the failure mode that killed claude_tasks).
+
+set -o pipefail
+
+# Resolve repo root from this script's location (path-aware, no hardcoded user).
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+REPO_ROOT="$(cd "$HOOK_DIR/../.." && pwd)"
+DETECTOR="$REPO_ROOT/scripts/organism_stale_detector.py"
+
+# Only meaningful on machines that actually run organs (have the sidecar dir).
+SIDECAR_DIR="${ORGANISM_LAST_SEEN_DIR:-$HOME/.organism/last_seen}"
+[[ -d "$SIDECAR_DIR" ]] || exit 0
+[[ -f "$DETECTOR" ]] || exit 0
+
+# Pick a python that exists (prefer repo venv, fall back to system).
+PY=""
+for cand in \
+    "$REPO_ROOT/apps/backend-rag/.venv/bin/python" \
+    "$(command -v python3 2>/dev/null)"; do
+    [[ -x "$cand" ]] && { PY="$cand"; break; }
+done
+[[ -n "$PY" ]] || exit 0
+
+# Portable time budget: GNU `timeout`/`gtimeout` if present (Linux/brew), else
+# run directly (macOS ships neither). The detector is <0.1s so this is a belt,
+# not a requirement.
+_TIMEOUT=()
+if command -v timeout >/dev/null 2>&1; then _TIMEOUT=(timeout 4)
+elif command -v gtimeout >/dev/null 2>&1; then _TIMEOUT=(gtimeout 4); fi
+
+# Run the detector (human report). Fail-open on anything.
+REPORT="$(ORGANISM_LAST_SEEN_DIR="$SIDECAR_DIR" \
+    "${_TIMEOUT[@]}" "$PY" "$DETECTOR" --dir "$SIDECAR_DIR" 2>/dev/null)" || exit 0
+
+# No alert if all organs breathing.
+case "$REPORT" in
+    ""|*"all organs breathing"*) exit 0 ;;
+esac
+
+# Emit the snapshot file too (best-effort) so other readers can consume it.
+ORGANISM_LAST_SEEN_DIR="$SIDECAR_DIR" \
+    "${_TIMEOUT[@]}" "$PY" "$DETECTOR" --dir "$SIDECAR_DIR" --emit >/dev/null 2>&1 || true
+
+# Inject into session context. Build JSON safely with python (no manual escaping).
+"$PY" - "$REPORT" <<'PYEOF' 2>/dev/null || exit 0
+import json, sys
+report = sys.argv[1] if len(sys.argv) > 1 else ""
+ctx = (
+    "🫀 ORGANISM HEARTBEAT ALERT (injected by SessionStart receptor)\n"
+    + report
+    + "\n\nThese organs run green in launchd but their heartbeat sidecar is "
+      "frozen — green (exit 0) != working (heartbeat written). Restart is NOT "
+      "the cure (W2 disarmed): the heartbeat CHANNEL is dead. Investigate the "
+      "writer/bridge. See research/operations/2026-06-28-heartbeat-channel-dead-core-organs.md"
+)
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": ctx,
+    }
+}))
+PYEOF
+
+exit 0

--- a/scripts/nuzantara-sentinel.py
+++ b/scripts/nuzantara-sentinel.py
@@ -58,6 +58,35 @@ logger = logging.getLogger(__name__)
 STATE_DIR = os.path.expanduser("~/.agent/decisions/state")
 REGISTRY_FILE = os.path.expanduser("~/.agent/decisions/job_registry.json")
 HEARTBEAT_FILE = os.path.expanduser("~/.pro_heartbeat")
+# Organism heartbeat sidecar (the connectome reads ~/.organism/last_seen/<id>.json).
+# 2026-06-28: the sentinel ran green for 28 days while THIS sidecar stayed frozen
+# because no code wrote it unconditionally — green (exit 0) != working (heartbeat).
+ORGAN_LAST_SEEN_DIR = os.path.expanduser("~/.organism/last_seen")
+ORGAN_ID = "pro.sentinel"
+
+
+def _emit_organ_heartbeat(status: str = "ok", metadata: dict | None = None) -> None:
+    """Write the organism heartbeat sidecar UNCONDITIONALLY (must never raise).
+
+    Format matches the 108 healthy sidecars + organism_stale_detector reader:
+    {"ts": <float epoch>, "status": ..., "organ_id": ..., "metadata": {...}}.
+    Atomic via tmp+rename. A heartbeat that breaks its caller is worse than none.
+    """
+    try:
+        os.makedirs(ORGAN_LAST_SEEN_DIR, exist_ok=True)
+        path = os.path.join(ORGAN_LAST_SEEN_DIR, f"{ORGAN_ID}.json")
+        tmp = f"{path}.tmp.{os.getpid()}"
+        payload = {
+            "ts": time.time(),
+            "status": status,
+            "organ_id": ORGAN_ID,
+            "metadata": metadata or {},
+        }
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh)
+        os.replace(tmp, path)
+    except Exception as exc:  # noqa: BLE001 — heartbeat must never break the run
+        logger.warning(f"organ heartbeat emit failed: {exc}")
 SENTINEL_LOG = os.path.expanduser("~/logs/sentinel.jsonl")
 OPENCLAW_RESTART_RECORD = os.path.expanduser("~/.agent/decisions/openclaw_last_restart.json")
 PRO_HOST = "Nuzantara"
@@ -1092,6 +1121,17 @@ def run_sentinel() -> None:
     logger.info(f"=== Sentinel done: {log_entry['jobs_checked']} checked, "
                 f"{log_entry['healthy']} healthy, {log_entry['escalated']} escalated, "
                 f"{log_entry['suppressed']} suppressed in {duration:.1f}s ===")
+
+    # UNCONDITIONAL organism heartbeat — proves the sentinel breathed this tick,
+    # regardless of branches above. This is the fix for the 28-day frozen sidecar.
+    _emit_organ_heartbeat(
+        status="ok",
+        metadata={
+            "jobs_checked": log_entry.get("jobs_checked"),
+            "escalated": log_entry.get("escalated"),
+            "duration_s": round(duration, 1),
+        },
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/organism_stale_detector.py
+++ b/scripts/organism_stale_detector.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""organism_stale_detector — the heartbeat-channel watcher (the RECEPTOR).
+
+Born 2026-06-28 to end a 28-day blindness: five CORE organs (pro.sentinel,
+pro.dlq_autopilot, cell.observatory, infra.pg_organism_bridge_watchdog,
+pro.federation_alert_dispatcher) ran green (launchd exit 0) while their
+heartbeat sidecar (~/.organism/last_seen/<organ>.json) froze for 18-28 days.
+Nobody noticed because the bridge-watchdog that should have alarmed was itself
+NOT LOADED, and no SessionStart hook read any alert channel.
+
+This module answers ONE question honestly: which organs have stopped breathing?
+It does NOT act (restart is the wrong cure for a dead heartbeat channel — that
+lesson is why W2 was disarmed). It emits findings to ~/.organism/alerts/open.jsonl
+which the SessionStart hook injects into every session's context.
+
+green (launchd exit 0) != working (heartbeat written). This reads the breath,
+not the pulse. (cicatrix-superscar #2)
+
+CLI:
+    python3 scripts/organism_stale_detector.py            # human report
+    python3 scripts/organism_stale_detector.py --emit     # write alerts file
+    python3 scripts/organism_stale_detector.py --json     # machine-readable
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+# Organs whose absence is itself an alarm (the breath channel must exist).
+# Kept deliberately small: only the organism's own core guardians, because a
+# MISSING sidecar for a leaf organ is noise, but for a guardian it is the W2 bug.
+CORE_ORGANS_EXPECTED: tuple[str, ...] = (
+    "pro.sentinel",
+    "pro.dlq_autopilot",
+    "infra.pg_organism_bridge_watchdog",
+    "pro.federation_alert_dispatcher",
+    "cell.observatory",
+)
+
+DEFAULT_SIDECAR_DIR = os.path.expanduser("~/.organism/last_seen")
+DEFAULT_ALERTS_FILE = os.path.expanduser("~/.organism/alerts/open.jsonl")
+DEFAULT_STALE_DAYS = 7
+
+
+@dataclass
+class StaleFinding:
+    organ_id: str
+    kind: str  # "stale" | "dead_channel" | "corrupt"
+    age_days: float = field(default=-1.0)
+    status: str = field(default="?")
+    detail: str = field(default="")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "organ_id": self.organ_id,
+            "kind": self.kind,
+            "age_days": round(self.age_days, 1),
+            "status": self.status,
+            "detail": self.detail,
+        }
+
+
+def _parse_ts(raw: Any, fallback_mtime: float) -> float:
+    """Parse both sidecar schemas (superscar #9 tolerance).
+
+    A) float epoch  (~/scripts/_organism_lib.sh)
+    B) ISO8601 'Z'  (scripts/lib/heartbeat.sh)
+    Fall back to file mtime if the field is absent but the file parsed.
+    """
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    if isinstance(raw, str) and raw:
+        try:
+            from datetime import datetime, timezone
+
+            s = raw.replace("Z", "+00:00")
+            dt = datetime.fromisoformat(s)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.timestamp()
+        except ValueError:
+            pass
+    return fallback_mtime
+
+
+def scan_sidecars(
+    sidecar_dir: str = DEFAULT_SIDECAR_DIR,
+    stale_days: float = DEFAULT_STALE_DAYS,
+    now: float | None = None,
+    expect_core: tuple[str, ...] | None = None,
+) -> list[StaleFinding]:
+    """Return findings for organs whose heartbeat is stale, missing, or corrupt.
+
+    Pure: takes a directory, returns a list. No side effects (so it is testable
+    and the CLI decides whether to emit). now is injectable for determinism.
+
+    expect_core lists organs whose ABSENT sidecar is itself an alarm. It defaults
+    to CORE_ORGANS_EXPECTED only when scanning the real organism dir; tests pass
+    () so an isolated tmp dir does not spuriously flag the production core organs.
+    """
+    if expect_core is None:
+        expect_core = (
+            CORE_ORGANS_EXPECTED
+            if os.path.abspath(sidecar_dir) == os.path.abspath(DEFAULT_SIDECAR_DIR)
+            else ()
+        )
+    now = time.time() if now is None else now
+    findings: list[StaleFinding] = []
+
+    if not os.path.isdir(sidecar_dir):
+        return findings
+
+    seen: set[str] = set()
+    for fname in sorted(os.listdir(sidecar_dir)):
+        if not fname.endswith(".json"):
+            continue
+        organ_id = fname[: -len(".json")]
+        seen.add(organ_id)
+        path = os.path.join(sidecar_dir, fname)
+        try:
+            with open(path, encoding="utf-8") as fh:
+                payload = json.load(fh)
+        except (json.JSONDecodeError, OSError) as exc:
+            findings.append(
+                StaleFinding(
+                    organ_id=organ_id,
+                    kind="corrupt",
+                    detail=f"unparseable sidecar: {type(exc).__name__}",
+                )
+            )
+            continue
+
+        try:
+            mtime = os.path.getmtime(path)
+        except OSError:
+            mtime = now
+        ts = _parse_ts(
+            payload.get("ts") or payload.get("timestamp"), fallback_mtime=mtime
+        )
+        age_days = (now - ts) / 86400.0
+        if age_days > stale_days:
+            findings.append(
+                StaleFinding(
+                    organ_id=organ_id,
+                    kind="stale",
+                    age_days=age_days,
+                    status=str(payload.get("status", "?")),
+                    detail=f"heartbeat frozen {age_days:.1f}d (threshold {stale_days}d)",
+                )
+            )
+
+    # A core guardian with NO sidecar at all is the worst case (W2 root): flag it.
+    for organ_id in expect_core:
+        if organ_id not in seen:
+            findings.append(
+                StaleFinding(
+                    organ_id=organ_id,
+                    kind="dead_channel",
+                    detail="expected core organ has NO heartbeat sidecar",
+                )
+            )
+
+    return findings
+
+
+def emit_alerts(findings: list[StaleFinding], alerts_file: str = DEFAULT_ALERTS_FILE) -> str:
+    """Overwrite the open-alerts file with current findings (idempotent snapshot).
+
+    The file is a SNAPSHOT of currently-open alerts, not an append log — so a
+    cured organ disappears from it on the next run (no stale-alert graveyard,
+    the exact failure mode that killed claude_tasks).
+    """
+    os.makedirs(os.path.dirname(alerts_file), exist_ok=True)
+    tmp = f"{alerts_file}.tmp.{os.getpid()}"
+    stamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    with open(tmp, "w", encoding="utf-8") as fh:
+        for f in findings:
+            rec = f.to_dict()
+            rec["detected_at"] = stamp
+            fh.write(json.dumps(rec) + "\n")
+    os.replace(tmp, alerts_file)
+    return alerts_file
+
+
+def _human_report(findings: list[StaleFinding]) -> str:
+    if not findings:
+        return "✅ organism heartbeat: all organs breathing (no stale/dead channels)"
+    lines = [f"⚠️ ORGANISM: {len(findings)} organ(s) not breathing:"]
+    for f in sorted(findings, key=lambda x: x.age_days, reverse=True):
+        if f.kind == "dead_channel":
+            lines.append(f"  💀 {f.organ_id}: NO heartbeat sidecar (core guardian)")
+        elif f.kind == "corrupt":
+            lines.append(f"  ❓ {f.organ_id}: corrupt sidecar — {f.detail}")
+        else:
+            lines.append(
+                f"  🫥 {f.organ_id}: stale {f.age_days:.1f}d (status={f.status})"
+            )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dir", default=DEFAULT_SIDECAR_DIR)
+    ap.add_argument("--stale-days", type=float, default=DEFAULT_STALE_DAYS)
+    ap.add_argument("--emit", action="store_true", help="write alerts file")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    args = ap.parse_args(argv)
+
+    findings = scan_sidecars(args.dir, stale_days=args.stale_days)
+
+    if args.emit:
+        path = emit_alerts(findings)
+        if not args.json:
+            print(f"alerts written: {path} ({len(findings)} open)")
+
+    if args.json:
+        print(json.dumps([f.to_dict() for f in findings]))
+    elif not args.emit:
+        print(_human_report(findings))
+
+    # exit 1 if any core guardian has a dead channel — that is actionable now.
+    return 1 if any(f.kind == "dead_channel" for f in findings) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_organism_stale_detector.py
+++ b/scripts/tests/test_organism_stale_detector.py
@@ -1,0 +1,111 @@
+"""Tests for organism_stale_detector — the heartbeat-channel watcher.
+
+The detector is the RECEPTOR that ends the 28-day blindness (2026-06-28):
+core organs ran green (launchd exit 0) while their heartbeat sidecar froze for
+weeks, and nobody noticed because no guardian read the alert channel.
+
+Contract (guilt + innocence, per cicatrix-superscar #2 antidote):
+  - GUILT: an organ whose sidecar is older than its threshold is flagged STALE.
+  - GUILT: an organ whose expected sidecar is MISSING is flagged DEAD-CHANNEL.
+  - INNOCENCE: a fresh organ is NOT flagged.
+  - SCHEMA-TOLERANT (superscar #9): both sidecar formats parse —
+      A) {"ts": <float epoch>, "status": ...}            (~/scripts/_organism_lib.sh)
+      B) {"ts": "<ISO8601 Z>", "status": ...}            (scripts/lib/heartbeat.sh)
+  - ROBUST: a corrupt/unparseable sidecar is flagged (never silently skipped).
+"""
+
+import json
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from organism_stale_detector import (  # noqa: E402
+    StaleFinding,
+    scan_sidecars,
+)
+
+
+def _write(d, name, payload):
+    p = os.path.join(d, f"{name}.json")
+    with open(p, "w") as fh:
+        fh.write(payload if isinstance(payload, str) else json.dumps(payload))
+    return p
+
+
+def test_fresh_organ_not_flagged(tmp_path):
+    d = str(tmp_path)
+    _write(d, "pro.fresh_organ", {"ts": time.time(), "status": "ok"})
+    findings = scan_sidecars(d, stale_days=7)
+    assert findings == [], f"fresh organ wrongly flagged: {findings}"
+
+
+def test_stale_float_ts_flagged_guilt(tmp_path):
+    d = str(tmp_path)
+    old = time.time() - 28 * 86400
+    _write(d, "pro.dlq_autopilot", {"ts": old, "status": "ok"})
+    findings = scan_sidecars(d, stale_days=7)
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.organ_id == "pro.dlq_autopilot"
+    assert f.kind == "stale"
+    assert 27 <= f.age_days <= 29, f.age_days
+
+
+def test_stale_iso_ts_flagged_schema_tolerant(tmp_path):
+    """Format B (ISO8601) must parse identically — superscar #9 guard."""
+    d = str(tmp_path)
+    iso_old = time.strftime(
+        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - 20 * 86400)
+    )
+    _write(d, "pro.sentinel", {"ts": iso_old, "status": "degraded"})
+    findings = scan_sidecars(d, stale_days=7)
+    assert len(findings) == 1
+    assert findings[0].organ_id == "pro.sentinel"
+    assert 19 <= findings[0].age_days <= 21
+
+
+def test_corrupt_sidecar_flagged_not_skipped(tmp_path):
+    """A guard that silently skips a broken sidecar is blind (#2)."""
+    d = str(tmp_path)
+    _write(d, "pro.broken", "{not valid json")
+    findings = scan_sidecars(d, stale_days=7)
+    assert len(findings) == 1
+    assert findings[0].kind == "corrupt"
+
+
+def test_innocence_many_fresh_one_stale(tmp_path):
+    """The real shape: ~108 fresh, a handful stale — only the stale flagged."""
+    d = str(tmp_path)
+    now = time.time()
+    for i in range(20):
+        _write(d, f"pro.healthy_{i}", {"ts": now - 60, "status": "ok"})
+    _write(d, "infra.pg_bridge_watchdog", {"ts": now - 22 * 86400, "status": "ok"})
+    findings = scan_sidecars(d, stale_days=7)
+    assert len(findings) == 1
+    assert findings[0].organ_id == "infra.pg_bridge_watchdog"
+
+
+def test_threshold_boundary(tmp_path):
+    """Just under threshold = innocent; just over = guilty."""
+    d = str(tmp_path)
+    now = time.time()
+    _write(d, "pro.just_under", {"ts": now - 6 * 86400, "status": "ok"})
+    _write(d, "pro.just_over", {"ts": now - 8 * 86400, "status": "ok"})
+    findings = scan_sidecars(d, stale_days=7)
+    ids = {f.organ_id for f in findings}
+    assert ids == {"pro.just_over"}
+
+
+def test_missing_dir_returns_empty(tmp_path):
+    findings = scan_sidecars(str(tmp_path / "does_not_exist"), stale_days=7)
+    assert findings == []
+
+
+def test_finding_is_serializable(tmp_path):
+    d = str(tmp_path)
+    _write(d, "pro.x", {"ts": time.time() - 30 * 86400, "status": "ok"})
+    findings = scan_sidecars(d, stale_days=7)
+    blob = json.dumps([f.to_dict() for f in findings])
+    assert "pro.x" in blob


### PR DESCRIPTION
## The malady (verified on disk, 2026-06-28)

Five **core** organs ran green in launchd (exit 0) while their heartbeat sidecar
(`~/.organism/last_seen/<id>.json`) **froze for 18-28 days**. Nobody noticed for
a month because:
- the **bridge-watchdog** that should have alarmed was **NOT LOADED** (~21d), and
- **no SessionStart hook read any alert channel** (CLAUDE.md §14 said "check
  escalations" but nothing enforced it — `claude_tasks` had 571 files, 0 readers).

This is **superscar #2 nested**: `green (exit 0) != working (heartbeat written)`,
with the watcher-of-the-watcher itself dead. Surfaced only because arming W2
(auto-restart) forced the question — and restart was the **wrong** cure (a green
cron doesn't have a dead process to restart; its heartbeat *channel* is dead).
W2 was disarmed; this PR fixes the actual channel.

## What this PR does

**1. The receptor (ends the blindness) — `feat`**
- `scripts/organism_stale_detector.py` — pure scanner; flags stale / dead_channel
  (core organ with NO sidecar) / corrupt (never silently skipped). Schema-tolerant
  (float-epoch + ISO8601, superscar #9). Emits a **snapshot** alerts file (cured
  organs vanish — no graveyard). **8 tests** (guilt + innocence + boundary).
- `scripts/hooks/organism_alert_sessionstart.sh` — wired into SessionStart, injects
  the alert into the session's context via `hookSpecificOutput.additionalContext`,
  so the **brain-session sees it** — the alert reaches the organism, not a human on
  Telegram. Fail-open, path-aware (M5/Pro/Mini), portable (macOS has no `timeout`).

**2. Core-organ cures — `fix`**
- `nuzantara-sentinel.py` + `dlq_autopilot.py`: emit an **unconditional** heartbeat
  every tick (both ran green but wrote no sidecar of their own; the bridge used to
  and stopped). Canonical float-epoch schema, atomic, fail-open.
- `pg-organism-bridge-watchdog.sh`: re-loaded via launchctl bootstrap (was NOT
  LOADED 21d); now emits its own heartbeat **and routes alerts to the organism
  channel** (`~/.organism/alerts/`) first, Telegram demoted to backup — per the
  operator directive that organism alerts must reach the organism, not the operator.

## Operator-boundary (deliberately deferred, not forgotten)
- `cell.observatory`: runner lives in `~/agents/.observatory/observatory.py` — fully
  OUTSIDE the repo (HOME-fork). Curing it = promoting that file into the repo, a
  separate task (editing it in place would deepen #1).
- `pro.federation_alert_dispatcher`: a backend daemon (`backend.scripts.federation_alert_daemon`)
  — RAG perimeter (L3), needs the pre-deploy flow, not a commit-and-go.

## Verification
- 8/8 detector tests pass; receptor hook tested (guilt injects valid JSON, innocence
  silent, robustness). bridge-watchdog re-load verified live on Pro (bootstrap rc 0,
  kickstart rc 0, now active @300s). Heartbeat helpers tested in isolation → the
  detector sees the written sidecars as **fresh** (loop closed end-to-end).
- Post-merge: SessionStart hook to be wired into `~/.claude/settings.json` on Pro.

Ref: `research/operations/2026-06-28-heartbeat-channel-dead-core-organs.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)