### PR TITLE
feat(voice-concierge): local LiveKit audio runtime (recovered from Mini, W80)

### DIFF
--- a/apps/backend-rag/deploy/launchd/com.nuzantara.local-livekit-server.plist
+++ b/apps/backend-rag/deploy/launchd/com.nuzantara.local-livekit-server.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.nuzantara.local-livekit-server</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/nuzantara/Library/Application Support/Nuzantara/local-livekit/scripts/run_local_livekit_server.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/local-livekit-server.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/local-livekit-server.err.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/apps/backend-rag/deploy/launchd/com.nuzantara.local-livekit-worker.plist
+++ b/apps/backend-rag/deploy/launchd/com.nuzantara.local-livekit-worker.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.nuzantara.local-livekit-worker</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/nuzantara/Library/Application Support/Nuzantara/local-livekit/scripts/run_local_livekit_worker.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/local-livekit-worker.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/local-livekit-worker.err.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/apps/backend-rag/deploy/launchd/install_local_livekit_audio.sh
+++ b/apps/backend-rag/deploy/launchd/install_local_livekit_audio.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Install/reload the local LiveKit voice stack LaunchAgents on Pro/Mini.
+set -euo pipefail
+
+HOST="$(scutil --get LocalHostName 2>/dev/null || hostname -s)"
+case "$HOST" in
+  Nuzantara|nuzantara|Mini-Pro2|mini-pro2)
+    HOME_DIR="/Users/nuzantara"
+    ;;
+  *)
+    echo "FATAL: local LiveKit audio LaunchAgents are Pro/Mini only (host=$HOST)" >&2
+    exit 1
+    ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SOURCE_APP_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LAUNCHAGENTS_DIR="$HOME_DIR/Library/LaunchAgents"
+ENV_FILE="$HOME_DIR/.config/nuzantara/local-livekit.env"
+RUNTIME_DIR="$HOME_DIR/Library/Application Support/Nuzantara/local-livekit"
+RUNTIME_SCRIPTS_DIR="$RUNTIME_DIR/scripts"
+
+SERVER_LABEL="com.nuzantara.local-livekit-server"
+WORKER_LABEL="com.nuzantara.local-livekit-worker"
+
+mkdir -p "$LAUNCHAGENTS_DIR" "$HOME_DIR/logs" "$HOME_DIR/.config/nuzantara" "$RUNTIME_SCRIPTS_DIR"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  cat > "$ENV_FILE.example" <<'EOF'
+LIVEKIT_URL=ws://127.0.0.1:7880
+LIVEKIT_API_KEY=devkey
+LIVEKIT_API_SECRET=secret
+VOICE_CONCIERGE_LIVEKIT_WORKER_HEALTH_URL=http://127.0.0.1:7889/healthz
+VOICE_CONCIERGE_LIVEKIT_WORKER_NATIVE_HEALTH_URL=http://127.0.0.1:7888/
+VOICE_CONCIERGE_LIVEKIT_AGENT_NAME=voice-concierge-local
+VOICE_CONCIERGE_LIVEKIT_BIND=127.0.0.1
+DO_NOT_TRACK=1
+HF_DATASETS_OFFLINE=1
+HF_HUB_DISABLE_TELEMETRY=1
+HF_HUB_OFFLINE=1
+TRANSFORMERS_OFFLINE=1
+EOF
+  echo "FATAL: create $ENV_FILE first; template written to $ENV_FILE.example" >&2
+  exit 1
+fi
+
+install -m 755 "$SOURCE_APP_DIR/scripts/run_local_livekit_server.sh" "$RUNTIME_SCRIPTS_DIR/run_local_livekit_server.sh"
+install -m 755 "$SOURCE_APP_DIR/scripts/run_local_livekit_worker.sh" "$RUNTIME_SCRIPTS_DIR/run_local_livekit_worker.sh"
+install -m 755 "$SOURCE_APP_DIR/scripts/run_local_livekit_server.py" "$RUNTIME_SCRIPTS_DIR/run_local_livekit_server.py"
+install -m 755 "$SOURCE_APP_DIR/scripts/local_livekit_voice_worker.py" "$RUNTIME_SCRIPTS_DIR/local_livekit_voice_worker.py"
+
+if [[ ! -x "$RUNTIME_DIR/.venv-livekit-worker/bin/python" ]]; then
+  /opt/homebrew/bin/python3.11 -m venv "$RUNTIME_DIR/.venv-livekit-worker"
+fi
+"$RUNTIME_DIR/.venv-livekit-worker/bin/python" -m pip install --upgrade pip >/dev/null
+"$RUNTIME_DIR/.venv-livekit-worker/bin/python" -m pip install -r "$SOURCE_APP_DIR/requirements-livekit-worker.txt" >/dev/null
+
+install -m 644 "$SCRIPT_DIR/$SERVER_LABEL.plist" "$LAUNCHAGENTS_DIR/$SERVER_LABEL.plist"
+install -m 644 "$SCRIPT_DIR/$WORKER_LABEL.plist" "$LAUNCHAGENTS_DIR/$WORKER_LABEL.plist"
+
+launchctl bootout "gui/$(id -u)" "$LAUNCHAGENTS_DIR/$WORKER_LABEL.plist" 2>/dev/null || true
+launchctl bootout "gui/$(id -u)" "$LAUNCHAGENTS_DIR/$SERVER_LABEL.plist" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$LAUNCHAGENTS_DIR/$SERVER_LABEL.plist"
+launchctl bootstrap "gui/$(id -u)" "$LAUNCHAGENTS_DIR/$WORKER_LABEL.plist"
+launchctl kickstart -k "gui/$(id -u)/$SERVER_LABEL"
+launchctl kickstart -k "gui/$(id -u)/$WORKER_LABEL"
+
+echo "Installed $SERVER_LABEL and $WORKER_LABEL"
+echo "Runtime: $RUNTIME_DIR"
+echo "Health: curl -fsS http://127.0.0.1:7889/healthz"

--- a/apps/backend-rag/requirements-livekit-worker.txt
+++ b/apps/backend-rag/requirements-livekit-worker.txt
@@ -1,0 +1,6 @@
+# Optional Pro/Mini LiveKit worker runtime.
+#
+# Install this in a dedicated local worker venv when possible. The backend doctor
+# only needs the worker's loopback HTTP health endpoint; the deployable backend
+# image must not depend on LiveKit Agents.
+livekit-agents==1.6.3

--- a/apps/backend-rag/scripts/bootstrap_local_audio_runtime.py
+++ b/apps/backend-rag/scripts/bootstrap_local_audio_runtime.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Bootstrap checks for the Pro/Mini local audio runtime.
+
+This script is intentionally local-only. It never downloads model assets; it
+only verifies/copies already-provisioned local files and, when requested,
+patches a legacy Chatterbox runtime so the v3 multilingual T3 checkpoint can be
+selected explicitly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import inspect
+import json
+import shutil
+import socket
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+APPROVED_RUNTIME_HOST_ALIASES = {
+    "nuzantara": "Nuzantara",
+    "mini-pro2": "Mini-Pro2",
+}
+APPROVED_RUNTIME_HOSTS = frozenset(APPROVED_RUNTIME_HOST_ALIASES.values())
+DEFAULT_PKUSEG_CACHE_DIR = Path.home() / ".pkuseg"
+PKUSEG_REQUIRED_FILES = (
+    "spacy_ontonotes.zip",
+    "spacy_ontonotes/features.msgpack",
+    "spacy_ontonotes/weights.npz",
+)
+CHATTERBOX_PATCH_MARKER = "MULTILINGUAL_T3_MODELS = {"
+
+
+@dataclass
+class BootstrapCheck:
+    name: str
+    status: str
+    detail: str
+    metadata: dict[str, str | int | bool | None] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "detail": self.detail,
+            "metadata": self.metadata,
+        }
+
+
+def normalize_hostname(hostname: str) -> str:
+    short_hostname = hostname.split(".", 1)[0]
+    return APPROVED_RUNTIME_HOST_ALIASES.get(short_hostname.lower(), short_hostname)
+
+
+def is_approved_runtime_host(hostname: str | None = None) -> bool:
+    return normalize_hostname(hostname or socket.gethostname()) in APPROVED_RUNTIME_HOSTS
+
+
+def chatterbox_mtl_tts_path(module_name: str) -> Path:
+    module = importlib.import_module(f"{module_name}.mtl_tts")
+    module_file = getattr(module, "__file__", None)
+    if not module_file:
+        raise RuntimeError(f"{module_name}.mtl_tts has no filesystem path")
+    return Path(module_file)
+
+
+def chatterbox_supports_t3_model(module_name: str) -> bool:
+    module = importlib.import_module(f"{module_name}.mtl_tts")
+    from_local = module.ChatterboxMultilingualTTS.from_local
+    try:
+        parameters = inspect.signature(from_local).parameters
+    except (TypeError, ValueError):
+        return False
+    return "t3_model" in parameters
+
+
+def pkuseg_missing_files(cache_dir: Path) -> list[str]:
+    return [relative for relative in PKUSEG_REQUIRED_FILES if not (cache_dir / relative).is_file()]
+
+
+def copy_pkuseg_assets(*, source_dir: Path, cache_dir: Path) -> None:
+    missing_from_source = pkuseg_missing_files(source_dir)
+    if missing_from_source:
+        raise RuntimeError(f"pkuseg source is incomplete: {missing_from_source[0]}")
+
+    for relative in PKUSEG_REQUIRED_FILES:
+        source = source_dir / relative
+        target = cache_dir / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+
+
+def apply_chatterbox_v3_patch(path: Path, *, dry_run: bool = False) -> bool:
+    text = path.read_text()
+    if _already_patched(text):
+        return False
+    if not _looks_like_legacy_chatterbox(text):
+        raise RuntimeError("Chatterbox runtime is neither v3-ready nor the known legacy layout")
+
+    patched = _patch_chatterbox_source(text)
+    if dry_run:
+        return True
+
+    backup_path = path.with_suffix(path.suffix + ".before-nuzantara-v3")
+    if not backup_path.exists():
+        backup_path.write_text(text)
+    path.write_text(patched)
+    return True
+
+
+def _already_patched(text: str) -> bool:
+    return CHATTERBOX_PATCH_MARKER in text and "t3_model: str | None = None" in text
+
+
+def _looks_like_legacy_chatterbox(text: str) -> bool:
+    return (
+        "def from_local(cls, ckpt_dir, device)" in text
+        and '"t3_mtl23ls_v2.safetensors"' in text
+        and "allow_patterns=[\"ve.pt\", \"t3_mtl23ls_v2.safetensors\"" in text
+    )
+
+
+def _patch_chatterbox_source(text: str) -> str:
+    constants = '''REPO_ID = "ResembleAI/chatterbox"
+DEFAULT_MULTILINGUAL_T3_MODEL = "t3_mtl23ls_v2.safetensors"
+MULTILINGUAL_T3_MODELS = {
+    "v2": "t3_mtl23ls_v2.safetensors",
+    "t3_mtl23ls_v2": "t3_mtl23ls_v2.safetensors",
+    "v3": "t3_mtl23ls_v3.safetensors",
+    "t3_mtl23ls_v3": "t3_mtl23ls_v3.safetensors",
+}
+
+
+def _resolve_multilingual_t3_model(t3_model: str | None) -> str:
+    if t3_model is None:
+        return DEFAULT_MULTILINGUAL_T3_MODEL
+    if t3_model in MULTILINGUAL_T3_MODELS:
+        return MULTILINGUAL_T3_MODELS[t3_model]
+    if t3_model.endswith(".safetensors"):
+        return t3_model
+    raise ValueError(
+        f"Unknown multilingual T3 model '{t3_model}'. "
+        f"Expected one of {sorted(MULTILINGUAL_T3_MODELS)} or a .safetensors filename."
+    )
+'''
+    text = text.replace('REPO_ID = "ResembleAI/chatterbox"', constants, 1)
+
+    old_from_local = '''    @classmethod
+    def from_local(cls, ckpt_dir, device) -> 'ChatterboxMultilingualTTS':
+        ckpt_dir = Path(ckpt_dir)
+
+        # Always load to CPU first for non-CUDA devices to handle CUDA-saved models
+        if device in ["cpu", "mps"]:
+            map_location = torch.device('cpu')
+        else:
+            map_location = None
+
+        ve = VoiceEncoder()
+        ve.load_state_dict(
+            torch.load(ckpt_dir / "ve.pt", map_location=map_location, weights_only=True)
+        )
+        ve.to(device).eval()
+
+        t3 = T3(T3Config.multilingual())
+        t3_state = load_safetensors(ckpt_dir / "t3_mtl23ls_v2.safetensors")
+        if "model" in t3_state.keys():
+            t3_state = t3_state["model"][0]
+        t3.load_state_dict(t3_state)
+        t3.to(device).eval()
+
+        s3gen = S3Gen()
+        s3gen.load_state_dict(
+            torch.load(ckpt_dir / "s3gen.pt", map_location=map_location, weights_only=True)
+        )
+        s3gen.to(device).eval()
+
+        tokenizer = MTLTokenizer(
+            str(ckpt_dir / "grapheme_mtl_merged_expanded_v1.json")
+        )
+
+        conds = None
+        if (builtin_voice := ckpt_dir / "conds.pt").exists():
+            conds = Conditionals.load(builtin_voice, map_location=map_location).to(device)
+
+        return cls(t3, s3gen, ve, tokenizer, device, conds=conds)
+'''
+    new_from_local = '''    @classmethod
+    def from_local(
+        cls,
+        ckpt_dir,
+        device,
+        t3_model: str | None = None,
+    ) -> 'ChatterboxMultilingualTTS':
+        ckpt_dir = Path(ckpt_dir)
+        t3_model = _resolve_multilingual_t3_model(t3_model)
+
+        # Always load to CPU first for non-CUDA devices to handle CUDA-saved models
+        if device in ["cpu", "mps"]:
+            map_location = torch.device('cpu')
+        else:
+            map_location = None
+
+        ve = VoiceEncoder()
+        ve.load_state_dict(
+            torch.load(ckpt_dir / "ve.pt", map_location=map_location, weights_only=True)
+        )
+        ve.to(device).eval()
+
+        t3 = T3(T3Config.multilingual())
+        t3_state = load_safetensors(ckpt_dir / t3_model)
+        if "model" in t3_state.keys():
+            t3_state = t3_state["model"][0]
+        t3.load_state_dict(t3_state)
+        t3.to(device).eval()
+
+        s3gen = S3Gen()
+        s3gen.load_state_dict(
+            torch.load(ckpt_dir / "s3gen.pt", map_location=map_location, weights_only=True)
+        )
+        s3gen.to(device).eval()
+
+        tokenizer = MTLTokenizer(
+            str(ckpt_dir / "grapheme_mtl_merged_expanded_v1.json")
+        )
+
+        conds = None
+        if (builtin_voice := ckpt_dir / "conds.pt").exists():
+            conds = Conditionals.load(builtin_voice, map_location=map_location).to(device)
+
+        return cls(t3, s3gen, ve, tokenizer, device, conds=conds)
+'''
+    text = _replace_required(text, old_from_local, new_from_local, "from_local")
+
+    old_from_pretrained = '''    @classmethod
+    def from_pretrained(cls, device: torch.device) -> 'ChatterboxMultilingualTTS':
+        # Check if MPS is available on macOS
+        if device == "mps" and not torch.backends.mps.is_available():
+            if not torch.backends.mps.is_built():
+                print("MPS not available because the current PyTorch install was not built with MPS enabled.")
+            else:
+                print("MPS not available because the current MacOS version is not 12.3+ and/or you do not have an MPS-enabled device on this machine.")
+            device = "cpu"
+
+        ckpt_dir = Path(
+            snapshot_download(
+                repo_id=REPO_ID,
+                repo_type="model",
+                revision="main",
+                allow_patterns=["ve.pt", "t3_mtl23ls_v2.safetensors", "s3gen.pt", "grapheme_mtl_merged_expanded_v1.json", "conds.pt", "Cangjie5_TC.json"],
+                token=os.getenv("HF_TOKEN"),
+            )
+        )
+        return cls.from_local(ckpt_dir, device)
+'''
+    new_from_pretrained = '''    @classmethod
+    def from_pretrained(
+        cls,
+        device: torch.device,
+        t3_model: str | None = None,
+    ) -> 'ChatterboxMultilingualTTS':
+        # Check if MPS is available on macOS
+        if device == "mps" and not torch.backends.mps.is_available():
+            if not torch.backends.mps.is_built():
+                print("MPS not available because the current PyTorch install was not built with MPS enabled.")
+            else:
+                print("MPS not available because the current MacOS version is not 12.3+ and/or you do not have an MPS-enabled device on this machine.")
+            device = "cpu"
+
+        t3_model = _resolve_multilingual_t3_model(t3_model)
+        ckpt_dir = Path(
+            snapshot_download(
+                repo_id=REPO_ID,
+                repo_type="model",
+                revision="main",
+                allow_patterns=["ve.pt", t3_model, "s3gen.pt", "grapheme_mtl_merged_expanded_v1.json", "conds.pt", "Cangjie5_TC.json"],
+                token=os.getenv("HF_TOKEN"),
+            )
+        )
+        return cls.from_local(ckpt_dir, device, t3_model=t3_model)
+'''
+    return _replace_required(text, old_from_pretrained, new_from_pretrained, "from_pretrained")
+
+
+def _replace_required(text: str, old: str, new: str, label: str) -> str:
+    patched = text.replace(old, new, 1)
+    if patched == text:
+        raise RuntimeError(f"unable to patch Chatterbox {label}; source layout changed")
+    return patched
+
+
+def build_report(args: argparse.Namespace) -> list[BootstrapCheck]:
+    checks: list[BootstrapCheck] = []
+    hostname = socket.gethostname()
+    approved = is_approved_runtime_host(hostname)
+    checks.append(
+        BootstrapCheck(
+            name="host_role",
+            status="pass" if approved else "fail",
+            detail=(
+                f"{normalize_hostname(hostname)} is approved for local audio bootstrap"
+                if approved
+                else "local audio bootstrap is allowed only on Nuzantara/Mini-Pro2"
+            ),
+            metadata={"hostname": hostname, "normalized_hostname": normalize_hostname(hostname)},
+        ),
+    )
+    if not approved:
+        return checks
+
+    cache_dir = Path(args.pkuseg_cache_dir).expanduser()
+    source_dir = Path(args.pkuseg_source_dir).expanduser() if args.pkuseg_source_dir else None
+    if source_dir is not None and pkuseg_missing_files(cache_dir):
+        copy_pkuseg_assets(source_dir=source_dir, cache_dir=cache_dir)
+
+    missing_pkuseg = pkuseg_missing_files(cache_dir)
+    checks.append(
+        BootstrapCheck(
+            name="pkuseg_asset",
+            status="fail" if missing_pkuseg else "pass",
+            detail=(
+                f"pkuseg asset cache incomplete: {missing_pkuseg[0]}"
+                if missing_pkuseg
+                else f"pkuseg asset cache ready: {cache_dir}"
+            ),
+            metadata={
+                "cache_dir": str(cache_dir),
+                "missing_count": len(missing_pkuseg),
+                "missing_first": missing_pkuseg[0] if missing_pkuseg else None,
+            },
+        ),
+    )
+
+    try:
+        mtl_path = chatterbox_mtl_tts_path(args.chatterbox_module)
+        supports_v3_selector = chatterbox_supports_t3_model(args.chatterbox_module)
+        patched = False
+        if not supports_v3_selector and args.apply:
+            patched = apply_chatterbox_v3_patch(mtl_path, dry_run=args.dry_run)
+            importlib.invalidate_caches()
+            supports_v3_selector = True
+        checks.append(
+            BootstrapCheck(
+                name="chatterbox_v3_patch",
+                status="pass" if supports_v3_selector else "fail",
+                detail=(
+                    "Chatterbox runtime supports t3_model selector"
+                    if supports_v3_selector and not patched
+                    else "Chatterbox v3 selector patch applied"
+                    if patched
+                    else "Chatterbox runtime is legacy; rerun with --apply"
+                ),
+                metadata={"module_path": str(mtl_path), "patched": patched},
+            ),
+        )
+    except Exception as exc:
+        checks.append(
+            BootstrapCheck(
+                name="chatterbox_v3_patch",
+                status="fail",
+                detail=f"Chatterbox runtime patch check failed: {type(exc).__name__}",
+            ),
+        )
+
+    return checks
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Bootstrap local audio runtime assets on Pro/Mini")
+    parser.add_argument("--chatterbox-module", default="chatterbox")
+    parser.add_argument("--pkuseg-cache-dir", default=str(DEFAULT_PKUSEG_CACHE_DIR))
+    parser.add_argument("--pkuseg-source-dir")
+    parser.add_argument("--apply", action="store_true", help="Patch legacy Chatterbox site-packages in-place")
+    parser.add_argument("--dry-run", action="store_true", help="Validate patchability without writing files")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    checks = build_report(args)
+    ok = all(check.status == "pass" for check in checks)
+    payload: dict[str, Any] = {
+        "ok": ok,
+        "checks": [check.to_dict() for check in checks],
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"local audio bootstrap: {'OK' if ok else 'FAILED'}")
+        for check in checks:
+            print(f"[{check.status.upper()}] {check.name}: {check.detail}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/backend-rag/scripts/local_livekit_audio_e2e.py
+++ b/apps/backend-rag/scripts/local_livekit_audio_e2e.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""End-to-end local audio smoke through a real LiveKit room.
+
+The script can record a short microphone sample or use an existing WAV file.
+It publishes the input audio into a local LiveKit room, runs the local STT/VAD
+and Chatterbox TTS providers, then publishes the generated TTS WAV back into
+the same room. Raw audio is written only to the requested local output dir.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import json
+import math
+import os
+import socket
+import sys
+import tempfile
+import time
+import wave
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from backend.app.core.config import settings
+from backend.app.services.local_audio.chatterbox import ChatterboxTTSProvider
+from backend.app.services.local_audio.runtime_checks import is_approved_voice_runtime_host
+from backend.app.services.local_audio.silero_vad import SileroVADProvider
+from backend.app.services.local_audio.whisper_cpp import WhisperCppSTTProvider
+
+LOCAL_LIVEKIT_HOSTS = {"localhost", "127.0.0.1", "::1", "0:0:0:0:0:0:0:1"}
+OFFLINE_ENV_GUARDS = {
+    "DO_NOT_TRACK": "1",
+    "HF_DATASETS_OFFLINE": "1",
+    "HF_HUB_DISABLE_TELEMETRY": "1",
+    "HF_HUB_OFFLINE": "1",
+    "TRANSFORMERS_OFFLINE": "1",
+}
+
+
+@dataclass(frozen=True)
+class WavInfo:
+    sample_rate: int
+    channels: int
+    sample_width: int
+    frames: int
+    duration_seconds: float
+
+
+class E2EPreflightError(RuntimeError):
+    """Raised when the local E2E smoke must fail closed."""
+
+
+def validate_runtime_host() -> None:
+    if not is_approved_voice_runtime_host(socket.gethostname()):
+        raise E2EPreflightError("local LiveKit audio E2E is allowed only on Pro/Mini")
+
+
+def validate_offline_env() -> None:
+    missing_or_wrong = [
+        key for key, expected in OFFLINE_ENV_GUARDS.items() if os.environ.get(key) != expected
+    ]
+    if missing_or_wrong:
+        raise E2EPreflightError("offline guard env missing or mismatched: " + ", ".join(missing_or_wrong))
+
+
+def validate_livekit_env() -> tuple[str, str, str]:
+    livekit_url = os.environ.get("LIVEKIT_URL", "").strip()
+    api_key = os.environ.get("LIVEKIT_API_KEY", "").strip()
+    api_secret = os.environ.get("LIVEKIT_API_SECRET", "").strip()
+    if not livekit_url or not api_key or not api_secret:
+        raise E2EPreflightError("LIVEKIT_URL, LIVEKIT_API_KEY, and LIVEKIT_API_SECRET are required")
+
+    parsed = urlparse(livekit_url)
+    if parsed.scheme not in {"ws", "wss"} or parsed.hostname is None:
+        raise E2EPreflightError("LIVEKIT_URL must be ws:// or wss://")
+    if parsed.hostname.lower() not in LOCAL_LIVEKIT_HOSTS:
+        raise E2EPreflightError("LIVEKIT_URL must point at loopback for this local E2E smoke")
+    return livekit_url, api_key, api_secret
+
+
+def ensure_livekit_sdk() -> tuple[Any, Any]:
+    try:
+        from livekit import api, rtc
+    except ImportError as exc:
+        raise E2EPreflightError(
+            "LiveKit Python SDK is missing; install requirements-livekit-worker.txt "
+            "into the local E2E virtualenv",
+        ) from exc
+    return api, rtc
+
+
+def wav_info(path: Path) -> WavInfo:
+    with wave.open(str(path), "rb") as wav_file:
+        sample_rate = wav_file.getframerate()
+        channels = wav_file.getnchannels()
+        sample_width = wav_file.getsampwidth()
+        frames = wav_file.getnframes()
+    if sample_width != 2:
+        raise E2EPreflightError("E2E WAV input/output must be 16-bit PCM")
+    if channels < 1:
+        raise E2EPreflightError("E2E WAV must have at least one channel")
+    return WavInfo(
+        sample_rate=sample_rate,
+        channels=channels,
+        sample_width=sample_width,
+        frames=frames,
+        duration_seconds=frames / sample_rate if sample_rate else 0.0,
+    )
+
+
+def record_microphone_wav(path: Path, *, seconds: float, sample_rate: int = 16_000) -> None:
+    try:
+        import sounddevice as sd  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise E2EPreflightError("sounddevice is required for --mic-seconds") from exc
+
+    frame_count = max(1, int(seconds * sample_rate))
+    recording = sd.rec(frame_count, samplerate=sample_rate, channels=1, dtype="int16")
+    sd.wait()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(recording.tobytes())
+
+
+def play_wav_output(path: Path) -> None:
+    try:
+        import sounddevice as sd  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise E2EPreflightError("sounddevice is required for --play-output") from exc
+
+    info = wav_info(path)
+    with wave.open(str(path), "rb") as wav_file:
+        with sd.RawOutputStream(
+            samplerate=info.sample_rate,
+            channels=info.channels,
+            dtype="int16",
+        ) as stream:
+            while True:
+                chunk = wav_file.readframes(max(1, int(info.sample_rate * 0.02)))
+                if not chunk:
+                    break
+                stream.write(chunk)
+
+
+def write_synthetic_wav(path: Path, *, seconds: float = 1.0, sample_rate: int = 16_000) -> None:
+    frame_count = max(1, int(seconds * sample_rate))
+    amplitude = 1200
+    frequency = 440.0
+    frames = bytearray()
+    for index in range(frame_count):
+        sample = int(amplitude * math.sin(2 * math.pi * frequency * index / sample_rate))
+        frames.extend(sample.to_bytes(2, byteorder="little", signed=True))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(bytes(frames))
+
+
+@contextlib.contextmanager
+def _redirect_stdout_to_stderr() -> Any:
+    """Redirect Python and child-process stdout while preserving final JSON stdout."""
+    sys.stdout.flush()
+    sys.stderr.flush()
+    saved_stdout_fd = os.dup(1)
+    try:
+        os.dup2(2, 1)
+        with contextlib.redirect_stdout(sys.stderr):
+            yield
+    finally:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os.dup2(saved_stdout_fd, 1)
+        os.close(saved_stdout_fd)
+
+
+def build_access_token(
+    *,
+    api_module: Any,
+    api_key: str,
+    api_secret: str,
+    room_name: str,
+    identity: str,
+) -> str:
+    return (
+        api_module.AccessToken(api_key, api_secret)
+        .with_identity(identity)
+        .with_name(identity)
+        .with_grants(
+            api_module.VideoGrants(
+                room_join=True,
+                room=room_name,
+                can_publish=True,
+                can_subscribe=True,
+            ),
+        )
+        .to_jwt()
+    )
+
+
+async def publish_wav_to_room(
+    *,
+    rtc_module: Any,
+    room: Any,
+    wav_path: Path,
+    track_name: str,
+    frame_ms: int = 20,
+) -> WavInfo:
+    info = wav_info(wav_path)
+    source = rtc_module.AudioSource(info.sample_rate, info.channels)
+    track = rtc_module.LocalAudioTrack.create_audio_track(track_name, source)
+    await room.local_participant.publish_track(track)
+
+    frames_per_chunk = max(1, int(info.sample_rate * frame_ms / 1000))
+    with wave.open(str(wav_path), "rb") as wav_file:
+        while True:
+            chunk = wav_file.readframes(frames_per_chunk)
+            if not chunk:
+                break
+            samples_per_channel = len(chunk) // (info.sample_width * info.channels)
+            frame = rtc_module.AudioFrame(
+                data=chunk,
+                sample_rate=info.sample_rate,
+                num_channels=info.channels,
+                samples_per_channel=samples_per_channel,
+            )
+            await source.capture_frame(frame)
+    await source.wait_for_playout()
+    await source.aclose()
+    return info
+
+
+async def run_local_audio_roundtrip(input_wav: Path, output_dir: Path, *, tts_text: str) -> dict[str, Any]:
+    whisper_binary = settings.voice_concierge_whisper_binary
+    whisper_model = settings.voice_concierge_whisper_model
+    if not whisper_binary or not whisper_model:
+        raise E2EPreflightError("Whisper binary/model not configured")
+
+    stt = WhisperCppSTTProvider(
+        binary_path=Path(whisper_binary),
+        model_path=Path(whisper_model),
+        timeout_seconds=settings.voice_concierge_whisper_timeout_seconds,
+    )
+    vad = SileroVADProvider(
+        module_name=settings.voice_concierge_silero_module,
+        sampling_rate=settings.voice_concierge_silero_sampling_rate,
+        threshold=settings.voice_concierge_silero_threshold,
+        timeout_seconds=settings.voice_concierge_silero_timeout_seconds,
+    )
+    tts = ChatterboxTTSProvider(
+        module_name=settings.voice_concierge_chatterbox_module,
+        model_path=Path(settings.voice_concierge_chatterbox_model_path)
+        if settings.voice_concierge_chatterbox_model_path
+        else None,
+        t3_model=settings.voice_concierge_chatterbox_t3_model,
+        language_id=settings.voice_concierge_chatterbox_language,
+        timeout_seconds=settings.voice_concierge_chatterbox_timeout_seconds,
+    )
+
+    segments = await vad.detect_segments(input_wav)
+    transcript = await stt.transcribe(input_wav, language="en")
+    tts_path = output_dir / "voice-concierge-e2e-tts.wav"
+    tts_result = await tts.synthesize(tts_text, output_path=tts_path)
+    return {
+        "vad_segments": [asdict(segment) for segment in segments],
+        "transcript": transcript.text,
+        "transcript_provider": transcript.provider,
+        "tts_path": str(tts_result.audio_path),
+        "tts_provider": tts_result.provider,
+    }
+
+
+async def run_e2e(args: argparse.Namespace) -> dict[str, Any]:
+    validate_runtime_host()
+    validate_offline_env()
+    livekit_url, api_key, api_secret = validate_livekit_env()
+    api_module, rtc_module = ensure_livekit_sdk()
+
+    output_dir = Path(args.output_dir).expanduser()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    input_mode_count = sum(
+        1
+        for enabled in (
+            bool(args.input_wav),
+            args.mic_seconds is not None,
+            bool(args.synthetic_input),
+        )
+        if enabled
+    )
+    if input_mode_count > 1:
+        raise E2EPreflightError("choose only one input source: --input-wav, --mic-seconds, or --synthetic-input")
+    if args.mic_seconds is not None and args.mic_seconds <= 0:
+        raise E2EPreflightError("--mic-seconds must be positive")
+
+    input_wav = Path(args.input_wav).expanduser() if args.input_wav else output_dir / "voice-concierge-e2e-input.wav"
+    if args.mic_seconds is not None:
+        await asyncio.to_thread(record_microphone_wav, input_wav, seconds=args.mic_seconds)
+    elif args.synthetic_input:
+        await asyncio.to_thread(write_synthetic_wav, input_wav)
+    elif not input_wav.exists():
+        raise E2EPreflightError("--input-wav must exist unless --mic-seconds or --synthetic-input is used")
+
+    room_name = args.room or f"voice-local-e2e-{int(time.time())}"
+    identity = args.identity or "voice-e2e-probe"
+    token = build_access_token(
+        api_module=api_module,
+        api_key=api_key,
+        api_secret=api_secret,
+        room_name=room_name,
+        identity=identity,
+    )
+
+    room = rtc_module.Room()
+    await room.connect(livekit_url, token)
+    try:
+        input_info = await publish_wav_to_room(
+            rtc_module=rtc_module,
+            room=room,
+            wav_path=input_wav,
+            track_name="voice-e2e-input",
+        )
+        audio_result = await run_local_audio_roundtrip(
+            input_wav,
+            output_dir,
+            tts_text=args.tts_text,
+        )
+        tts_info = await publish_wav_to_room(
+            rtc_module=rtc_module,
+            room=room,
+            wav_path=Path(audio_result["tts_path"]),
+            track_name="voice-e2e-tts",
+        )
+        played_output = False
+        if args.play_output:
+            await asyncio.to_thread(play_wav_output, Path(audio_result["tts_path"]))
+            played_output = True
+    finally:
+        await room.disconnect()
+
+    return {
+        "ok": True,
+        "room": room_name,
+        "identity": identity,
+        "input_wav": str(input_wav),
+        "input_audio": asdict(input_info),
+        "tts_audio": asdict(tts_info),
+        "played_output": played_output,
+        **audio_result,
+        "constraints": [
+            "local_only_audio",
+            "no_cloud_fallback",
+            "loopback_livekit_only",
+        ],
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run local LiveKit room audio E2E smoke")
+    parser.add_argument("--input-wav")
+    parser.add_argument("--mic-seconds", type=float)
+    parser.add_argument("--synthetic-input", action="store_true")
+    parser.add_argument("--output-dir", default=str(Path(tempfile.gettempdir()) / "nuz-local-audio-e2e"))
+    parser.add_argument("--room")
+    parser.add_argument("--identity")
+    parser.add_argument("--tts-text", default="Local voice concierge audio path is ready.")
+    parser.add_argument("--play-output", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        if args.json:
+            with _redirect_stdout_to_stderr():
+                payload = asyncio.run(run_e2e(args))
+        else:
+            payload = asyncio.run(run_e2e(args))
+    except Exception as exc:
+        payload = {
+            "ok": False,
+            "error": type(exc).__name__,
+            "detail": str(exc),
+        }
+    if args.json or not payload["ok"]:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("local LiveKit audio E2E: OK")
+        print(f"room: {payload['room']}")
+        print(f"input_wav: {payload['input_wav']}")
+        print(f"tts_path: {payload['tts_path']}")
+    return 0 if payload["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/backend-rag/scripts/local_livekit_voice_worker.py
+++ b/apps/backend-rag/scripts/local_livekit_voice_worker.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Local-only LiveKit worker for the voice concierge readiness gate."""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import json
+import logging
+import os
+import socket
+import sys
+import threading
+import urllib.error
+import urllib.request
+from collections.abc import Sequence
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
+
+APPROVED_RUNTIME_HOST_ALIASES = {
+    "nuzantara": "Nuzantara",
+    "mini-pro2": "Mini-Pro2",
+}
+APPROVED_RUNTIME_HOSTS = frozenset(APPROVED_RUNTIME_HOST_ALIASES.values())
+DEFAULT_HEALTH_URL = "http://127.0.0.1:7889/healthz"
+DEFAULT_NATIVE_HEALTH_URL = "http://127.0.0.1:7888/"
+LOCAL_HEALTH_HOSTS = {"localhost", "127.0.0.1", "::1", "0:0:0:0:0:0:0:1"}
+OFFLINE_ENV_GUARDS = {
+    "DO_NOT_TRACK": "1",
+    "HF_DATASETS_OFFLINE": "1",
+    "HF_HUB_DISABLE_TELEMETRY": "1",
+    "HF_HUB_OFFLINE": "1",
+    "TRANSFORMERS_OFFLINE": "1",
+}
+TAILSCALE_CGNAT = ipaddress.ip_network("100.64.0.0/10")
+
+logger = logging.getLogger("local_livekit_voice_worker")
+
+
+@dataclass(frozen=True)
+class HealthEndpoint:
+    host: str
+    port: int
+    path: str
+    url: str
+
+
+@dataclass(frozen=True)
+class SidecarConfig:
+    health_endpoint: HealthEndpoint
+    native_endpoint: HealthEndpoint
+    livekit_url: str
+    agent_name: str
+
+
+class PreflightError(RuntimeError):
+    """Raised when the local-only worker should not start."""
+
+
+def normalize_hostname(hostname: str) -> str:
+    short_hostname = hostname.split(".", 1)[0]
+    return APPROVED_RUNTIME_HOST_ALIASES.get(short_hostname.lower(), short_hostname)
+
+
+def is_approved_runtime_host(hostname: str | None = None) -> bool:
+    return normalize_hostname(hostname or socket.gethostname()) in APPROVED_RUNTIME_HOSTS
+
+
+def health_endpoint_from_env() -> HealthEndpoint:
+    configured_url = os.environ.get(
+        "VOICE_CONCIERGE_LIVEKIT_WORKER_HEALTH_URL",
+        DEFAULT_HEALTH_URL,
+    )
+    return _parse_loopback_http_url(configured_url, require_root_path=False)
+
+
+def native_health_endpoint_from_env() -> HealthEndpoint:
+    configured_url = os.environ.get(
+        "VOICE_CONCIERGE_LIVEKIT_WORKER_NATIVE_HEALTH_URL",
+        DEFAULT_NATIVE_HEALTH_URL,
+    )
+    endpoint = _parse_loopback_http_url(configured_url, require_root_path=True)
+    if endpoint.path != "/":
+        raise PreflightError(
+            "VOICE_CONCIERGE_LIVEKIT_WORKER_NATIVE_HEALTH_URL must point at the native LiveKit root /",
+        )
+    return endpoint
+
+
+def _parse_loopback_http_url(configured_url: str, *, require_root_path: bool) -> HealthEndpoint:
+    parsed = urlparse(configured_url)
+    if parsed.scheme not in {"http", "https"} or parsed.hostname is None:
+        raise PreflightError(
+            "LiveKit worker health URLs must be HTTP(S) loopback URLs",
+        )
+    if parsed.hostname.lower() not in LOCAL_HEALTH_HOSTS:
+        raise PreflightError(
+            "LiveKit worker health URLs must bind to localhost/loopback",
+        )
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise PreflightError(
+            "LiveKit worker health URLs must not include credentials, query, or fragment",
+        )
+    path = parsed.path or "/"
+    if require_root_path and path != "/":
+        raise PreflightError(
+            "LiveKit Agents native health is served at /",
+        )
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    return HealthEndpoint(host=parsed.hostname, port=port, path=path, url=configured_url)
+
+
+def livekit_server_url_from_env() -> str:
+    server_url = os.environ.get("LIVEKIT_URL", "").strip()
+    if not server_url:
+        raise PreflightError("LIVEKIT_URL is required and must point at the local LiveKit server")
+    parsed = urlparse(server_url)
+    if parsed.scheme not in {"ws", "wss"} or parsed.hostname is None:
+        raise PreflightError("LIVEKIT_URL must be ws:// or wss://")
+    if not _is_local_livekit_host(parsed.hostname):
+        raise PreflightError("LIVEKIT_URL must use localhost, .local, RFC1918, or Tailscale LAN")
+    return server_url
+
+
+def require_livekit_credentials() -> tuple[str, str]:
+    api_key = os.environ.get("LIVEKIT_API_KEY", "").strip()
+    api_secret = os.environ.get("LIVEKIT_API_SECRET", "").strip()
+    if not api_key or not api_secret:
+        raise PreflightError("LIVEKIT_API_KEY and LIVEKIT_API_SECRET are required")
+    return api_key, api_secret
+
+
+def validate_offline_env() -> None:
+    missing_or_wrong = [
+        key for key, expected in OFFLINE_ENV_GUARDS.items() if os.environ.get(key) != expected
+    ]
+    if missing_or_wrong:
+        raise PreflightError(
+            "offline guard env missing or mismatched: " + ", ".join(missing_or_wrong),
+        )
+
+
+def preflight() -> HealthEndpoint:
+    if not is_approved_runtime_host():
+        raise PreflightError("local LiveKit voice worker is allowed only on Nuzantara/Mini-Pro2")
+    validate_offline_env()
+    livekit_server_url_from_env()
+    require_livekit_credentials()
+    health_endpoint = health_endpoint_from_env()
+    native_endpoint = native_health_endpoint_from_env()
+    if (health_endpoint.host, health_endpoint.port) == (native_endpoint.host, native_endpoint.port):
+        raise PreflightError("sidecar health and native LiveKit health must use different ports")
+    return health_endpoint
+
+
+async def entrypoint(ctx: object) -> None:
+    from livekit.agents import AutoSubscribe
+
+    await ctx.connect(auto_subscribe=AutoSubscribe.AUDIO_ONLY)
+    await asyncio.Event().wait()
+
+
+def _is_local_livekit_host(hostname: str) -> bool:
+    host = hostname.lower()
+    if host in LOCAL_HEALTH_HOSTS or host.endswith(".local"):
+        return True
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        return normalize_hostname(host) in APPROVED_RUNTIME_HOSTS
+    return (
+        address.is_loopback
+        or address.is_private
+        or address.is_link_local
+        or address in TAILSCALE_CGNAT
+    )
+
+
+def start_health_sidecar(config: SidecarConfig) -> ThreadingHTTPServer:
+    class HealthHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            if self.path != config.health_endpoint.path:
+                self.send_error(404)
+                return
+            status_code, payload = build_sidecar_health_payload(config)
+            body = json.dumps(payload, sort_keys=True).encode("utf-8")
+            self.send_response(status_code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer((config.health_endpoint.host, config.health_endpoint.port), HealthHandler)
+    thread = threading.Thread(target=server.serve_forever, name="livekit-health-sidecar", daemon=True)
+    thread.start()
+    return server
+
+
+def build_sidecar_health_payload(config: SidecarConfig) -> tuple[int, dict[str, object]]:
+    livekit_reachable = _tcp_reachable(config.livekit_url)
+    native_ok = _native_worker_root_ok(config.native_endpoint.url)
+    worker_metadata = _native_worker_metadata(config.native_endpoint.url)
+    agent_matches = worker_metadata.get("agent_name") == config.agent_name
+    healthy = livekit_reachable and native_ok and agent_matches
+    payload: dict[str, object] = {
+        "healthy": healthy,
+        "status": "healthy" if healthy else "unhealthy",
+        "agent_name": config.agent_name,
+        "livekit_server_reachable": livekit_reachable,
+        "native_worker_ready": native_ok,
+        "worker_metadata": worker_metadata,
+    }
+    return (200 if healthy else 503), payload
+
+
+def _native_worker_root_ok(native_url: str) -> bool:
+    try:
+        body = _http_get(native_url).decode("utf-8").strip().lower()
+    except OSError:
+        return False
+    return body == "ok"
+
+
+def _native_worker_metadata(native_url: str) -> dict[str, object]:
+    worker_url = native_url.rstrip("/") + "/worker"
+    try:
+        body = _http_get(worker_url)
+    except OSError:
+        return {}
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _http_get(url: str) -> bytes:
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    with opener.open(url, timeout=1.0) as response:
+        status_code = getattr(response, "status", 0)
+        if status_code < 200 or status_code >= 300:
+            raise urllib.error.HTTPError(url, status_code, "not healthy", {}, None)
+        return response.read()
+
+
+def _tcp_reachable(url: str) -> bool:
+    parsed = urlparse(url)
+    if parsed.hostname is None:
+        return False
+    port = parsed.port or (443 if parsed.scheme == "wss" else 80)
+    try:
+        with socket.create_connection((parsed.hostname, port), timeout=1.0):
+            return True
+    except OSError:
+        return False
+
+
+def _help_requested(argv: Sequence[str]) -> bool:
+    return any(arg in {"-h", "--help"} for arg in argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    logging.basicConfig(level=os.environ.get("LIVEKIT_LOG_LEVEL", "INFO"))
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not _help_requested(args):
+        try:
+            health_endpoint = preflight()
+            native_endpoint = native_health_endpoint_from_env()
+            livekit_url = livekit_server_url_from_env()
+            agent_name = os.environ.get(
+                "VOICE_CONCIERGE_LIVEKIT_AGENT_NAME",
+                "voice-concierge-local",
+            )
+        except PreflightError as exc:
+            logger.error("%s", exc)
+            return 1
+        sidecar = start_health_sidecar(
+            SidecarConfig(
+                health_endpoint=health_endpoint,
+                native_endpoint=native_endpoint,
+                livekit_url=livekit_url,
+                agent_name=agent_name,
+            ),
+        )
+        logger.info("starting local LiveKit sidecar health at %s", health_endpoint.url)
+        logger.info("starting native LiveKit worker health at %s", native_endpoint.url)
+    else:
+        health_endpoint = health_endpoint_from_env()
+        native_endpoint = native_health_endpoint_from_env()
+        agent_name = os.environ.get("VOICE_CONCIERGE_LIVEKIT_AGENT_NAME", "voice-concierge-local")
+        sidecar = None
+
+    from livekit import agents
+
+    server_url = os.environ.get("LIVEKIT_URL")
+    api_key = os.environ.get("LIVEKIT_API_KEY")
+    api_secret = os.environ.get("LIVEKIT_API_SECRET")
+    agents.cli.run_app(
+        agents.WorkerOptions(
+            entrypoint_fnc=entrypoint,
+            agent_name=agent_name,
+            ws_url=server_url,
+            api_key=api_key,
+            api_secret=api_secret,
+            host=native_endpoint.host,
+            port=native_endpoint.port,
+            http_proxy=None,
+        ),
+    )
+    if sidecar is not None:
+        sidecar.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/backend-rag/scripts/run_local_livekit_server.py
+++ b/apps/backend-rag/scripts/run_local_livekit_server.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Run the local-only LiveKit server for voice concierge development."""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import os
+import shutil
+import socket
+from pathlib import Path
+from urllib.parse import urlparse
+
+APPROVED_RUNTIME_HOST_ALIASES = {
+    "nuzantara": "Nuzantara",
+    "mini-pro2": "Mini-Pro2",
+}
+APPROVED_RUNTIME_HOSTS = frozenset(APPROVED_RUNTIME_HOST_ALIASES.values())
+LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1", "0:0:0:0:0:0:0:1"}
+
+
+class PreflightError(RuntimeError):
+    """Raised when the local LiveKit server should not start."""
+
+
+def normalize_hostname(hostname: str) -> str:
+    short_hostname = hostname.split(".", 1)[0]
+    return APPROVED_RUNTIME_HOST_ALIASES.get(short_hostname.lower(), short_hostname)
+
+
+def is_approved_runtime_host(hostname: str | None = None) -> bool:
+    return normalize_hostname(hostname or socket.gethostname()) in APPROVED_RUNTIME_HOSTS
+
+
+def validate_loopback_bind(bind_host: str) -> None:
+    host = bind_host.strip().lower()
+    if host in LOOPBACK_HOSTS:
+        return
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError as exc:
+        raise PreflightError("LiveKit server bind host must be loopback") from exc
+    if not address.is_loopback:
+        raise PreflightError("LiveKit server bind host must be loopback")
+
+
+def validate_livekit_url(url: str, bind_host: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"ws", "wss"} or parsed.hostname is None:
+        raise PreflightError("LIVEKIT_URL must be ws:// or wss://")
+    if parsed.hostname.lower() not in LOOPBACK_HOSTS:
+        raise PreflightError("LIVEKIT_URL must point at loopback for local audio")
+    validate_loopback_bind(bind_host)
+
+
+def resolve_livekit_server_binary(configured_binary: str | None = None) -> Path:
+    configured = configured_binary or os.environ.get("LIVEKIT_SERVER_BINARY")
+    if configured:
+        path = Path(configured).expanduser()
+        if not path.exists():
+            raise PreflightError(f"LiveKit server binary not found: {path}")
+        return path
+
+    discovered = shutil.which("livekit-server")
+    if not discovered:
+        raise PreflightError("livekit-server binary not found in PATH")
+    return Path(discovered)
+
+
+def build_livekit_server_command(
+    *,
+    binary: Path,
+    bind_host: str,
+) -> list[str]:
+    validate_loopback_bind(bind_host)
+    return [str(binary), "--dev", "--bind", bind_host]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run local loopback LiveKit server")
+    parser.add_argument("--bind", default=os.environ.get("VOICE_CONCIERGE_LIVEKIT_BIND", "127.0.0.1"))
+    parser.add_argument("--binary", default=os.environ.get("LIVEKIT_SERVER_BINARY"))
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if not is_approved_runtime_host():
+        raise PreflightError("local LiveKit server is allowed only on Nuzantara/Mini-Pro2")
+
+    validate_livekit_url(os.environ.get("LIVEKIT_URL", "ws://127.0.0.1:7880"), args.bind)
+    binary = resolve_livekit_server_binary(args.binary)
+    command = build_livekit_server_command(binary=binary, bind_host=args.bind)
+    os.execv(command[0], command)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/backend-rag/scripts/run_local_livekit_server.sh
+++ b/apps/backend-rag/scripts/run_local_livekit_server.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# LaunchAgent-safe wrapper for the local LiveKit server.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEFAULT_APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+APP_DIR="${VOICE_CONCIERGE_BACKEND_DIR:-$DEFAULT_APP_DIR}"
+ENV_FILE="${VOICE_CONCIERGE_LIVEKIT_ENV_FILE:-/Users/nuzantara/.config/nuzantara/local-livekit.env}"
+
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
+export HOME="${HOME:-/Users/nuzantara}"
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${PATH:-}"
+export LIVEKIT_URL="${LIVEKIT_URL:-ws://127.0.0.1:7880}"
+export VOICE_CONCIERGE_LIVEKIT_BIND="${VOICE_CONCIERGE_LIVEKIT_BIND:-127.0.0.1}"
+
+mkdir -p "$HOME/logs"
+cd "$APP_DIR"
+PYTHON_BIN="${VOICE_CONCIERGE_LIVEKIT_SERVER_PYTHON:-}"
+if [[ -z "$PYTHON_BIN" ]]; then
+  if [[ -x "$APP_DIR/.venv/bin/python" ]]; then
+    PYTHON_BIN="$APP_DIR/.venv/bin/python"
+  else
+    PYTHON_BIN="$(command -v python3.11 || command -v python3)"
+  fi
+fi
+
+if [[ -z "$PYTHON_BIN" || ! -x "$PYTHON_BIN" ]]; then
+  echo "FATAL: Python runtime not found for local LiveKit server" >&2
+  exit 1
+fi
+
+exec "$PYTHON_BIN" scripts/run_local_livekit_server.py

--- a/apps/backend-rag/scripts/run_local_livekit_worker.sh
+++ b/apps/backend-rag/scripts/run_local_livekit_worker.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# LaunchAgent-safe wrapper for the local voice LiveKit worker.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEFAULT_APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+APP_DIR="${VOICE_CONCIERGE_BACKEND_DIR:-$DEFAULT_APP_DIR}"
+ENV_FILE="${VOICE_CONCIERGE_LIVEKIT_ENV_FILE:-/Users/nuzantara/.config/nuzantara/local-livekit.env}"
+
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
+export HOME="${HOME:-/Users/nuzantara}"
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${PATH:-}"
+export LIVEKIT_URL="${LIVEKIT_URL:-ws://127.0.0.1:7880}"
+export VOICE_CONCIERGE_LIVEKIT_WORKER_HEALTH_URL="${VOICE_CONCIERGE_LIVEKIT_WORKER_HEALTH_URL:-http://127.0.0.1:7889/healthz}"
+export VOICE_CONCIERGE_LIVEKIT_WORKER_NATIVE_HEALTH_URL="${VOICE_CONCIERGE_LIVEKIT_WORKER_NATIVE_HEALTH_URL:-http://127.0.0.1:7888/}"
+export VOICE_CONCIERGE_LIVEKIT_AGENT_NAME="${VOICE_CONCIERGE_LIVEKIT_AGENT_NAME:-voice-concierge-local}"
+export DO_NOT_TRACK="${DO_NOT_TRACK:-1}"
+export HF_DATASETS_OFFLINE="${HF_DATASETS_OFFLINE:-1}"
+export HF_HUB_DISABLE_TELEMETRY="${HF_HUB_DISABLE_TELEMETRY:-1}"
+export HF_HUB_OFFLINE="${HF_HUB_OFFLINE:-1}"
+export TRANSFORMERS_OFFLINE="${TRANSFORMERS_OFFLINE:-1}"
+
+if [[ -z "${LIVEKIT_API_KEY:-}" || -z "${LIVEKIT_API_SECRET:-}" ]]; then
+  echo "FATAL: LIVEKIT_API_KEY and LIVEKIT_API_SECRET must be set in $ENV_FILE" >&2
+  exit 1
+fi
+
+mkdir -p "$HOME/logs"
+cd "$APP_DIR"
+PYTHON_BIN="${VOICE_CONCIERGE_LIVEKIT_WORKER_PYTHON:-$APP_DIR/.venv-livekit-worker/bin/python}"
+if [[ ! -x "$PYTHON_BIN" ]]; then
+  echo "FATAL: worker Python runtime not found: $PYTHON_BIN" >&2
+  exit 1
+fi
+
+exec "$PYTHON_BIN" scripts/local_livekit_voice_worker.py start


### PR DESCRIPTION
## What

The local-sovereign voice-concierge LiveKit audio runtime, developed on Mini and
never committed (217 commits behind main). Part of the work the **W80 incident**
partially lost — recovered from Mini's working tree, frozen on a quarantine ref,
now promoted to the repo.

10 files (1448 insertions):
- `local_livekit_voice_worker.py` — the worker. Reads `LIVEKIT_API_KEY`/`SECRET`
  from env; preflight refuses to start if unset (no hardcoded creds).
- `run_local_livekit_server.{py,sh}`, `run_local_livekit_worker.sh` — launchers
- `local_livekit_audio_e2e.py` — end-to-end readiness probe
- `bootstrap_local_audio_runtime.py` — runtime bootstrap
- `com.nuzantara.local-livekit-{worker,server}.plist` + `install_local_livekit_audio.sh`
  — launchd install (generates a `.env.example` with LiveKit's standard
  `devkey`/`secret` **dev placeholders** — NOT production credentials, audited)
- `requirements-livekit-worker.txt` — pinned deps

## Audited
- Scanned all 10 files for hardcoded secrets / PII: only env-var *references*
  (`LIVEKIT_API_KEY ... required`), no real credentials, no WhatsApp numbers, no
  PII paths. The `devkey`/`secret` are LiveKit's documented local-dev defaults
  inside a generated `.env.example` template.
- Law 6 (sovereignty): runs entirely on Zero's machines, no cloud TTS.

## NOT included (operator decides)
The divergent `config.py` / `.env.example` deltas that **fork** main's
`voice_concierge_*` schema (Mini removes fields main has, adds fields main lacks)
need a human merge against main's version — left dirty + armed on Mini's quarantine
ref. The `.venv-livekit-worker/` is a regenerable virtualenv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)