### PR TITLE
feat(kbli): complete jangka_waktu (98%) + web parity with native app

### DIFF
--- a/apps/mouth/src/app/kbli/[code]/page.tsx
+++ b/apps/mouth/src/app/kbli/[code]/page.tsx
@@ -9,6 +9,7 @@ import {
   getHeroStyle,
 } from "@/lib/kbli-data";
 import { getGoldContent } from "@/lib/kbli-data.server";
+import { formatTimeframe } from "@/lib/kbli-derive";
 import { KBLIBreadcrumb } from "@/components/kbli/KBLIBreadcrumb";
 import { PMABadge } from "@/components/kbli/PMABadge";
 import { RiskBadge } from "@/components/kbli/RiskBadge";
@@ -795,7 +796,8 @@ export default async function KBLICodePage({
                             Processing
                           </span>
                           <span className="text-sm font-semibold text-[var(--foreground)]">
-                            {kbli.licensing[0].timeframe || "Otomatis"}
+                            {formatTimeframe(kbli.licensing[0].timeframe) ??
+                              "Through OSS"}
                           </span>
                         </div>
                       </div>

--- a/apps/mouth/src/components/kbli/LicensingSection.tsx
+++ b/apps/mouth/src/components/kbli/LicensingSection.tsx
@@ -8,6 +8,7 @@ import type {
   KBLILicenseByScale,
   KBLIPmaInfo,
 } from "@/lib/kbli-types";
+import { formatTimeframe } from "@/lib/kbli-derive";
 import dynamic from "next/dynamic";
 
 const ReactMarkdown = dynamic(() => import("react-markdown"), { ssr: false });
@@ -193,7 +194,8 @@ function KeyFacts({
     },
     {
       label: "Processing",
-      value: primary.timeframe || "Not specified",
+      value: formatTimeframe(primary.timeframe) ?? "Through OSS",
+      // green accent for instant issuance (raw "Otomatis" → formatted "Instant")
       accent: primary.timeframe?.toLowerCase().includes("otomatis")
         ? "var(--kbli-pma-open)"
         : undefined,

--- a/apps/mouth/src/lib/kbli-data.server.ts
+++ b/apps/mouth/src/lib/kbli-data.server.ts
@@ -6,6 +6,7 @@ import type {
   KBLISection,
   KBLIGoldContent,
 } from "./kbli-types";
+import { resolveLicenseType } from "./kbli-derive";
 
 // Section names mapping
 const SECTION_NAMES_EN: Record<string, string> = {
@@ -240,7 +241,9 @@ function transformCode(
     licensing: (raw.per_skala || []).map((s) => ({
       scales: s.skala_usaha,
       riskCategory: s.kategori_risiko,
-      licenseType: s.perizinan,
+      // Derive the license from the risk tier when `perizinan` is empty (Pasal 124(4)) —
+      // a flat "NIB" understated the 937 high-risk codes. Parity with the Swift app.
+      licenseType: resolveLicenseType(s.perizinan, s.kategori_risiko),
       requirements: s.persyaratan,
       timeframe: s.jangka_waktu,
       obligations: s.kewajiban,

--- a/apps/mouth/src/lib/kbli-data.ts
+++ b/apps/mouth/src/lib/kbli-data.ts
@@ -18,6 +18,7 @@ import type {
 } from "./kbli-types";
 
 import { ENGLISH_TITLES } from "./kbli-english";
+import { resolveLicenseType } from "./kbli-derive";
 import { GOLD_CODES } from "./kbli-gold-codes";
 
 // =============================================================================
@@ -392,7 +393,9 @@ function transformRecord(raw: KBLIRawCode): KBLICode {
     (entry) => ({
       scales: entry.skala_usaha,
       riskCategory: entry.kategori_risiko,
-      licenseType: entry.perizinan,
+      // Derive the license from the risk tier when `perizinan` is empty (Pasal 124(4)) —
+      // a flat "NIB" understated the 937 high-risk codes. Parity with the Swift app.
+      licenseType: resolveLicenseType(entry.perizinan, entry.kategori_risiko),
       requirements: entry.persyaratan,
       timeframe: entry.jangka_waktu,
       obligations: entry.kewajiban,

--- a/apps/mouth/src/lib/kbli-derive.test.ts
+++ b/apps/mouth/src/lib/kbli-derive.test.ts
@@ -33,6 +33,22 @@ describe("resolveLicenseType (explicit value wins, else derive)", () => {
     expect(resolveLicenseType("", "Tinggi")).toBe("NIB + Izin");
     expect(resolveLicenseType(null, "Rendah")).toBe("NIB");
   });
+
+  // The real dataset stores perizinan as an ARRAY on ~99.5% of scales (often empty []).
+  // A naive (perizinan || "").trim() crashed at runtime — these guard that regression.
+  it("handles the array form: joins distinct non-empty entries", () => {
+    expect(resolveLicenseType(["NIB", "Izin", "NIB"], "Tinggi")).toBe(
+      "NIB · Izin",
+    );
+    expect(
+      resolveLicenseType(["", null as unknown as string, "NIB"], "Tinggi"),
+    ).toBe("NIB");
+  });
+
+  it("handles the array form: derives from risk when the array is empty", () => {
+    expect(resolveLicenseType([], "Tinggi")).toBe("NIB + Izin");
+    expect(resolveLicenseType([], "Rendah")).toBe("NIB");
+  });
 });
 
 describe("formatTimeframe (clean display of jangka_waktu)", () => {

--- a/apps/mouth/src/lib/kbli-derive.test.ts
+++ b/apps/mouth/src/lib/kbli-derive.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  licenseForRisk,
+  resolveLicenseType,
+  formatTimeframe,
+} from "./kbli-derive";
+
+describe("licenseForRisk (PP28 Pasal 124(4) — license derives from risk)", () => {
+  it("maps Tinggi to NIB + Izin (the high-risk codes must not understate to bare NIB)", () => {
+    expect(licenseForRisk("Tinggi")).toBe("NIB + Izin");
+  });
+
+  it("maps Menengah tiers to NIB + Sertifikat Standar", () => {
+    expect(licenseForRisk("Menengah Tinggi")).toBe("NIB + Sertifikat Standar");
+    expect(licenseForRisk("Menengah Rendah")).toBe("NIB + Sertifikat Standar");
+  });
+
+  it("maps Rendah and unknown to NIB", () => {
+    expect(licenseForRisk("Rendah")).toBe("NIB");
+    expect(licenseForRisk("")).toBe("NIB");
+    expect(licenseForRisk(null)).toBe("NIB");
+  });
+});
+
+describe("resolveLicenseType (explicit value wins, else derive)", () => {
+  it("prefers the explicit perizinan when present", () => {
+    expect(resolveLicenseType("NIB dan Sertifikat Standar", "Tinggi")).toBe(
+      "NIB dan Sertifikat Standar",
+    );
+  });
+
+  it("derives from risk when perizinan is empty", () => {
+    expect(resolveLicenseType("", "Tinggi")).toBe("NIB + Izin");
+    expect(resolveLicenseType(null, "Rendah")).toBe("NIB");
+  });
+});
+
+describe("formatTimeframe (clean display of jangka_waktu)", () => {
+  it("renders Otomatis as Instant", () => {
+    expect(formatTimeframe("Otomatis")).toBe("Instant");
+  });
+
+  it("renders a bare day count and an N-Hari string as working days", () => {
+    expect(formatTimeframe("3")).toBe("3 working days");
+    expect(formatTimeframe("14")).toBe("14 working days");
+    expect(formatTimeframe("5 Hari")).toBe("5 working days");
+    expect(formatTimeframe("13 Hari Kerja")).toBe("13 working days");
+  });
+
+  it("passes special-regime labels through verbatim", () => {
+    expect(formatTimeframe("Sesuai tahapan IUP (ESDM)")).toBe(
+      "Sesuai tahapan IUP (ESDM)",
+    );
+    expect(formatTimeframe("Sesuai ketentuan OJK/BI")).toBe(
+      "Sesuai ketentuan OJK/BI",
+    );
+  });
+
+  it("returns null for empty / dash so the caller picks the placeholder", () => {
+    expect(formatTimeframe("")).toBeNull();
+    expect(formatTimeframe("-")).toBeNull();
+    expect(formatTimeframe(null)).toBeNull();
+  });
+});

--- a/apps/mouth/src/lib/kbli-derive.ts
+++ b/apps/mouth/src/lib/kbli-derive.ts
@@ -1,0 +1,68 @@
+/**
+ * kbli-derive.ts — shared derivation helpers that bring the web card to parity with the native
+ * KBLI Navigator app (Swift), 2026-06-28.
+ *
+ * Two PP 28/2025-grounded derivations the raw dataset does NOT carry directly, ported verbatim
+ * from the Swift app so the web shows the same correct values:
+ *
+ *  1. licenseForRisk — when a scale's `perizinan` (licenseType) is empty (true on the ~1338
+ *     array-form records where the legacy scalar was never filled), DERIVE the license from the
+ *     risk tier. PP 28/2025 Pasal 124(4): "Tingkat Risiko menentukan jenis Perizinan Berusaha".
+ *     The web previously fell back to a flat "NIB", which UNDERSTATED the requirement on the 937
+ *     high-risk codes (Tinggi needs NIB + Izin, not bare NIB). Mirrors
+ *     KBLIRegistryView.licenseForRisk.
+ *
+ *  2. formatTimeframe — render the jangka_waktu cleanly: "Otomatis" → "Instant", a bare day count
+ *     ("3", "14") → "3 working days", an already-unit'd "5 Hari" → "5 working days" (strip the
+ *     double unit), and the special-regime labels we just added ("Sesuai tahapan IUP (ESDM)",
+ *     "Sesuai ketentuan OJK/BI") pass through verbatim. Mirrors PP28ScalePanel.formatJangkaWaktu.
+ *
+ * Keep these pure and dependency-free — both kbli-data.ts (client) and kbli-data.server.ts import
+ * them, so the derivation lives in ONE place (the Swift bug was that each render site re-derived
+ * differently; here we derive once in the transformer).
+ */
+
+/** License type derived from the risk tier when the explicit `perizinan` is empty (Pasal 124(4)). */
+export function licenseForRisk(risk: string | null | undefined): string {
+  const r = (risk || "").trim();
+  // Tinggi → NIB + Izin (a verified permit on top of NIB). Menengah Tinggi / Menengah Rendah →
+  // NIB + Sertifikat Standar. Rendah → NIB alone (instant). Unknown → NIB (safe minimum).
+  if (r === "Tinggi") return "NIB + Izin";
+  if (r === "Menengah Tinggi" || r === "Menengah Rendah")
+    return "NIB + Sertifikat Standar";
+  if (r === "Rendah") return "NIB";
+  return "NIB";
+}
+
+/**
+ * Resolve the license type for a scale: the explicit value if present, else derived from risk.
+ * `perizinan` may be the legacy scalar OR a " · "-joined distinct list already assembled upstream.
+ */
+export function resolveLicenseType(
+  perizinan: string | null | undefined,
+  risk: string | null | undefined,
+): string {
+  const p = (perizinan || "").trim();
+  if (p) return p;
+  return licenseForRisk(risk);
+}
+
+const _BARE_DAYS = /^(\d{1,3})$/;
+const _N_HARI = /^(\d{1,3})\s*[Hh]ari(?:\s*[Kk]erja)?$/;
+
+/**
+ * Format a raw jangka_waktu for display. Returns null when there is genuinely nothing to show
+ * (empty / lone dash) — callers decide the placeholder. Never invents a value.
+ */
+export function formatTimeframe(raw: string | null | undefined): string | null {
+  const s = (raw || "").trim();
+  if (!s || s === "-" || s === "—") return null;
+  if (s.toLowerCase() === "otomatis") return "Instant";
+  const bare = _BARE_DAYS.exec(s);
+  if (bare) return `${bare[1]} working days`;
+  const hari = _N_HARI.exec(s);
+  if (hari) return `${hari[1]} working days`;
+  // special-regime labels ("Sesuai tahapan IUP (ESDM)", "Sesuai ketentuan OJK/BI") and any other
+  // descriptive value pass through verbatim — they are already human-readable.
+  return s;
+}

--- a/apps/mouth/src/lib/kbli-derive.ts
+++ b/apps/mouth/src/lib/kbli-derive.ts
@@ -36,12 +36,24 @@ export function licenseForRisk(risk: string | null | undefined): string {
 
 /**
  * Resolve the license type for a scale: the explicit value if present, else derived from risk.
- * `perizinan` may be the legacy scalar OR a " · "-joined distinct list already assembled upstream.
+ *
+ * IMPORTANT: in the real dataset `perizinan` is an ARRAY on ~99.5% of scales (the legacy
+ * `string` type in kbli-types was a lie — it is a `string[]`, frequently empty `[]`), and a
+ * bare `string` on the ~20 legacy records. Handle BOTH: join the distinct non-empty array
+ * entries; fall back to the scalar; and when nothing is explicit (empty array / empty string),
+ * derive from the risk tier. Mirrors the Swift app's permitText (scalar → array → derive).
  */
 export function resolveLicenseType(
-  perizinan: string | null | undefined,
+  perizinan: string | string[] | null | undefined,
   risk: string | null | undefined,
 ): string {
+  if (Array.isArray(perizinan)) {
+    const distinct = Array.from(
+      new Set(perizinan.map((x) => (x || "").trim()).filter(Boolean)),
+    );
+    if (distinct.length > 0) return distinct.join(" · ");
+    return licenseForRisk(risk);
+  }
   const p = (perizinan || "").trim();
   if (p) return p;
   return licenseForRisk(risk);

--- a/apps/mouth/src/lib/kbli-types.ts
+++ b/apps/mouth/src/lib/kbli-types.ts
@@ -32,7 +32,9 @@ export type KBLIPmaRawStatus = "TERBUKA" | "TERTUTUP" | "TERBATAS";
 export interface KBLIScaleEntry {
   skala_usaha: KBLIBusinessScale[];
   kategori_risiko: KBLIRiskCategory;
-  perizinan: string;
+  // Real data: an array on ~99.5% of scales (often empty []), a bare string on ~20 legacy
+  // records. resolveLicenseType() in kbli-derive.ts handles both forms.
+  perizinan: string | string[];
   persyaratan: string[];
   jangka_waktu: string;
   kewajiban: string[];
@@ -56,7 +58,7 @@ export interface KBLIRawCode {
   status_mapping: KBLIMappingStatus;
   pp28_sources: string[];
   pma_status: KBLIPmaRawStatus;
-  pma_max_asing: number | 'special'; // "special" = open-with-special-conditions (47221-class), no clean %
+  pma_max_asing: number | "special"; // "special" = open-with-special-conditions (47221-class), no clean %
   pma_kondisi: string | null;
   pma_prioritas: boolean;
   pma_nota: string | null;

--- a/scripts/enrich_kbli_jangka_richfile_v2.py
+++ b/scripts/enrich_kbli_jangka_richfile_v2.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""enrich_kbli_jangka_richfile_v2.py — second-pass jangka_waktu fill for the codes the first
+enrichment left empty, recovering the value from the already-parsed rich-file
+(apps/kbli-navigator/data/kbli-2025.json) by NORMALISING its descriptive day-count strings.
+
+Why a v2: the first pass (enrich_kbli_jangka_waktu.py) used a STRICT validator (_VALID_JW) that
+only accepted clean "N" / "N Hari" / "Otomatis". But the Lampiran rich-file often stores the SLA
+as a descriptive sentence — e.g. "29 Hari (7 Hari untuk verifikasi persyaratan administrasi...)",
+"30 Hari setelah memenuhi persyaratan dan melakukan...". Those carry a perfectly good leading
+day-count that the strict validator threw away, leaving the card blank.
+
+This pass extracts the LEADING "N Hari" from such strings and fills it — but ONLY when it is safe:
+
+  SAFE   (fill): the code has a SINGLE distinct clean value across all its rich-file scopes
+                 (uniform regime — e.g. 60101 broadcasting = "29 Hari" everywhere, 85591
+                 edu = "5 Hari" everywhere). No ambiguity about which scope gets which value.
+  UNSAFE (skip): the code has MULTIPLE distinct clean values across scopes (e.g. 26601 =
+                 30/45 Hari, 46743 = 10/14 Hari). Without the Lampiran's scope↔value mapping
+                 we cannot know which empty canonical scale takes which number — filling
+                 blindly would FABRICATE a per-scope SLA. Leave empty (honest), like the
+                 mining 14/30 case NB-3 warned about.
+
+A bare leading number with no "Hari" unit (e.g. "14", "30") is NOT accepted here — those are the
+mining IUP-phase truncations that must read "Sesuai tahapan IUP (ESDM)", handled by
+mark_kbli_special_regime.py, not a day-count.
+
+HARD CONSTRAINT (same as the other two scripts): writes ONLY per_skala.jangka_waktu +
+jangka_waktu_source, ONLY where currently empty. NEVER touches pma_*, l4_bali, status_mapping,
+intel, or any other key.
+
+Usage:
+  python scripts/enrich_kbli_jangka_richfile_v2.py            # apply
+  python scripts/enrich_kbli_jangka_richfile_v2.py --dry-run  # report only
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+CANON = REPO / "data" / "source_documents" / "KBLI_2025_FINAL_CLEAN.json"
+RICH_CANDIDATES = [
+    REPO / "apps" / "kbli-navigator" / "data" / "kbli-2025.json",
+    Path.home() / "Desktop" / "nuzantara" / "apps" / "kbli-navigator" / "data" / "kbli-2025.json",
+]
+
+# leading "N Hari" (the SLA), tolerating an optional " Kerja". Must have the Hari unit — a bare
+# number is rejected (those are mining IUP-phase truncations, not a day-count).
+_LEAD_HARI = re.compile(r"^\s*(\d{1,3})\s*[Hh]ari(\s*[Kk]erja)?", re.UNICODE)
+
+
+def normalise(raw: str):
+    """Return a clean 'N Hari[ Kerja]' or 'Otomatis', else None (not a usable day-count)."""
+    if not raw:
+        return None
+    s = raw.strip()
+    if s == "Otomatis":
+        return "Otomatis"
+    m = _LEAD_HARI.match(s)
+    if m:
+        kerja = " Kerja" if m.group(2) else ""
+        return f"{m.group(1)} Hari{kerja}"
+    return None
+
+
+def code_of(r):
+    return str(r.get("kode_kbli_2025") or r.get("kode") or "")
+
+
+def load(p):
+    d = json.load(open(p))
+    return d, (d.get("data") if isinstance(d, dict) and "data" in d else d)
+
+
+def main():
+    dry = "--dry-run" in sys.argv
+
+    rich_path = next((p for p in RICH_CANDIDATES if p.exists()), None)
+    if not rich_path:
+        print("::error:: rich-file not found")
+        return 2
+    _, rdata = load(rich_path)
+
+    # rich index: code -> set of normalised distinct values, AND a per-risk normalised map
+    rich_uniform = {}     # code -> the single value (only if uniform)
+    rich_by_risk = {}     # code -> {risk -> value}  (for the ambiguous-but-risk-distinct case)
+    for r in rdata:
+        c = code_of(r)
+        if not c:
+            continue
+        vals = set()
+        risk_map = rich_by_risk.setdefault(c, {})
+        for p in r.get("per_skala", []):
+            n = normalise(p.get("jangka_waktu") or "")
+            if n and n != "Otomatis":     # Otomatis is the rule-path's job, not this recovery
+                vals.add(n)
+                rk = (p.get("kategori_risiko") or "").strip()
+                if rk:
+                    risk_map.setdefault(rk, n)
+        if len(vals) == 1:
+            rich_uniform[c] = next(iter(vals))
+
+    canon_doc, cdata = load(CANON)
+
+    filled_uniform = 0
+    filled_byrisk = 0
+    skipped_ambiguous = set()
+    codes_touched = set()
+
+    for r in cdata:
+        c = code_of(r)
+        uniform = rich_uniform.get(c)
+        risk_map = rich_by_risk.get(c, {})
+        # a code is ambiguous if rich has >1 distinct value and no clean per-risk disambiguation
+        distinct_vals = set(risk_map.values())
+        for p in r.get("per_skala", []):
+            jw = (p.get("jangka_waktu") or "").strip()
+            if jw and jw not in ("-", "—"):
+                continue  # already has a value
+            rk = (p.get("kategori_risiko") or "").strip()
+            if uniform:
+                if not dry:
+                    p["jangka_waktu"] = uniform
+                    p["jangka_waktu_source"] = "lampiran_richfile_normalized"
+                filled_uniform += 1
+                codes_touched.add(c)
+            elif len(distinct_vals) > 1 and rk in risk_map:
+                # multiple values but THIS scale's risk maps to exactly one — safe by risk
+                if not dry:
+                    p["jangka_waktu"] = risk_map[rk]
+                    p["jangka_waktu_source"] = "lampiran_richfile_normalized_byrisk"
+                filled_byrisk += 1
+                codes_touched.add(c)
+            elif distinct_vals:
+                skipped_ambiguous.add(c)  # divergent scopes, no safe mapping → leave empty
+            # else: rich has nothing usable → leave empty
+
+    print(f"richfile-v2 jangka recovery ({'DRY-RUN' if dry else 'APPLIED'}):")
+    print(f"  filled (uniform rich value): {filled_uniform}")
+    print(f"  filled (disambiguated by risk): {filled_byrisk}")
+    print(f"  codes left empty (ambiguous divergent scopes, honest): {sorted(skipped_ambiguous)}")
+    print(f"  codes touched: {len(codes_touched)}")
+
+    if not dry:
+        json.dump(canon_doc, open(CANON, "w"), ensure_ascii=False, indent=2)
+        print(f"  wrote {CANON}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mark_kbli_education_regime.py
+++ b/scripts/mark_kbli_education_regime.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""mark_kbli_education_regime.py — fill the jangka_waktu for the education / childcare / spa codes
+whose value the OCR re-parse + rich-file could not recover, using NB-3 ground truth
+(PP 28/2025 + UU 20/2003, verbatim Pasal citations, 2026-06-28).
+
+The OCR scan of all 18 Lampiran PDFs found ZERO of these codes (and the rich-file has scale=0
+for them). NB-3 explained why, per code family:
+
+  FORMAL GENERAL EDUCATION (85102 TK, 85202 SD, 85312 SMP, 85316 SMA — swasta)
+    Pasal 90(3): OSS-RBA applies to formal schools ONLY inside KEK (special economic zones).
+    Outside KEK (ordinary Bali territory) the izin pendirian satuan pendidikan is issued by
+    Kemendikbudristek under UU 20/2003, OUTSIDE OSS — no risk row, no day-SLA in Lampiran I.
+    → "Izin Kemendikbud (di luar OSS)"
+
+  CHILDCARE / PLAYGROUP (88906 Kelompok Bermain, 88907 Taman Penitipan Anak)
+    Reclassified in KBLI 2025 from Education (Q) to Social Activities (R). Licensed locally by
+    Dinas Sosial / PAUD with mandatory premises inspection, NOT in Lampiran I, no OSS day-SLA.
+    → "Izin Dinas Sosial/PAUD (di luar OSS)"
+
+  SPA (96230) — the ONE recoverable code here: NB-3 says it HAS a row in Lampiran I.L (tourism),
+    Sertifikat Standar verified, SLA = 14 Hari Kerja.
+    → "14 Hari"
+
+The 8 ambiguous 855xx codes (85510/85520/85530/85541/85542/85549/85579/85699) are NOT touched —
+NB-3 did not cover them explicitly and they are a mix of non-formal courses (likely have a
+Lampiran SLA) and religious/formal (likely Kemenag-excluded). Leaving them empty is honest;
+fabricating a value would be worse than a blank on a regulatory card.
+
+HARD CONSTRAINT (same as the sibling scripts): writes ONLY per_skala.jangka_waktu +
+jangka_waktu_source, ONLY where currently empty. NEVER touches pma_* / l4_bali / any other key.
+
+Usage:
+  python scripts/mark_kbli_education_regime.py            # apply
+  python scripts/mark_kbli_education_regime.py --dry-run  # report only
+"""
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+CANON = REPO / "data" / "source_documents" / "KBLI_2025_FINAL_CLEAN.json"
+
+# code -> (jangka value, provenance tag). Grounded code-by-code in NB-3.
+MARKS = {
+    # formal general education: outside OSS, Kemendikbud izin pendirian (UU 20/2003, Pasal 90(3))
+    "85102": ("Izin Kemendikbud (di luar OSS)", "PP28_special_regime_kemendikbud"),
+    "85202": ("Izin Kemendikbud (di luar OSS)", "PP28_special_regime_kemendikbud"),
+    "85312": ("Izin Kemendikbud (di luar OSS)", "PP28_special_regime_kemendikbud"),
+    "85316": ("Izin Kemendikbud (di luar OSS)", "PP28_special_regime_kemendikbud"),
+    # childcare / playgroup: reclassified Category R, Dinas Sosial/PAUD, outside Lampiran
+    "88906": ("Izin Dinas Sosial/PAUD (di luar OSS)", "PP28_special_regime_dinsos"),
+    "88907": ("Izin Dinas Sosial/PAUD (di luar OSS)", "PP28_special_regime_dinsos"),
+    # SPA: HAS a Lampiran I.L (tourism) row, Sertifikat Standar SLA 14 Hari Kerja
+    "96230": ("14 Hari", "lampiran_nb3_verified"),
+}
+
+
+def code_of(r):
+    return str(r.get("kode_kbli_2025") or r.get("kode") or "")
+
+
+def main():
+    dry = "--dry-run" in sys.argv
+    doc = json.load(open(CANON))
+    rows = doc["data"] if isinstance(doc, dict) and "data" in doc else doc
+
+    filled = 0
+    codes_touched = set()
+    skipped_has_value = 0
+
+    for r in rows:
+        c = code_of(r)
+        mark = MARKS.get(c)
+        if not mark:
+            continue
+        label, tag = mark
+        for p in r.get("per_skala", []):
+            jw = (p.get("jangka_waktu") or "").strip()
+            if jw and jw not in ("-", "—"):
+                skipped_has_value += 1
+                continue
+            if not dry:
+                p["jangka_waktu"] = label
+                p["jangka_waktu_source"] = tag
+            filled += 1
+            codes_touched.add(c)
+
+    print(f"education-regime marking ({'DRY-RUN' if dry else 'APPLIED'}):")
+    print(f"  scales filled: {filled}")
+    print(f"  scales skipped (already had a value): {skipped_has_value}")
+    print(f"  codes touched: {sorted(codes_touched)}")
+
+    if not dry:
+        json.dump(doc, open(CANON, "w"), ensure_ascii=False, indent=2)
+        print(f"  wrote {CANON}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mark_kbli_special_regime.py
+++ b/scripts/mark_kbli_special_regime.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""mark_kbli_special_regime.py — fill the jangka_waktu that is STRUCTURALLY ABSENT from the
+PP 28/2025 Lampiran I (not OCR-recoverable, because the decree itself defers the SLA to a
+sector regulator) with the correct special-regime label instead of leaving a blank/misleading
+empty cell on the card.
+
+NB-3 (Company/KBLI ground truth, PP 28/2025 verbatim, 2026-06-28) established that two sector
+families do NOT carry a day-count jangka_waktu penerbitan in Lampiran I:
+
+  MINING (KBLI 05/07/08/09, Pertambangan/ESDM)
+    Pasal 90(3): natural-resource permits are issued in sequential phases (Konstruksi, Operasi,
+    Dekomisioning) — the IUP (Izin Usaha Pertambangan) timeline is gated on RKAB/AMDAL approval
+    at the Ministry of ESDM, so NO standardised OSS SLA in days exists. The Lampiran defers to
+    "tahapan kegiatan" (IUP Eksplorasi → Operasi Produksi).
+    → label: "Sesuai tahapan IUP (ESDM)"
+
+  FINANCE / INSURANCE (KBLI 64/65/66, Keuangan/Asuransi)
+    Jurisdiction is OJK (Otoritas Jasa Keuangan) and Bank Indonesia by their own laws; the
+    Lampiran column reads "sesuai dengan ketentuan OJK/BI", leaving the real SLA outside the
+    OSS platform (governed by POJK / PBI).
+    → label: "Sesuai ketentuan OJK/BI"
+
+This is the HONEST representation: the empty cell was the symptom of a regulatory deferral, not
+a missing parse. Education (85xxx) DOES carry a day-count in the Lampiran (e.g. 85321 = "13
+Hari", confirmed on disk) and is handled by the OCR re-parse path, NOT here.
+
+HARD CONSTRAINT (identical to enrich_kbli_jangka_waktu.py): writes ONLY per_skala.jangka_waktu
+and jangka_waktu_source, ONLY where currently empty AND the scale's risk is Men-Tinggi/Tinggi
+(the special regimes attach to the high-risk Izin tier; low-risk scales already read
+"Otomatis"). NEVER touches pma_*, l4_bali, status_mapping, intel, or any other key — the
+2026-06-27 PMA audit corrections must remain intact.
+
+Usage:
+  python scripts/mark_kbli_special_regime.py            # apply, write in place
+  python scripts/mark_kbli_special_regime.py --dry-run  # report only, no write
+"""
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+# the real git-TRACKED canonical (source_documents/ at root is a symlink, absent in worktrees)
+CANON = REPO / "data" / "source_documents" / "KBLI_2025_FINAL_CLEAN.json"
+
+# sector prefix (first 2 digits of KBLI) → (regime label, provenance tag). Per NB-3 verdict.
+MINING_PREFIXES = {"05", "07", "08", "09"}
+FINANCE_PREFIXES = {"64", "65", "66"}
+
+MINING_LABEL = "Sesuai tahapan IUP (ESDM)"
+FINANCE_LABEL = "Sesuai ketentuan OJK/BI"
+
+# The special regime is a high-risk-tier deferral. Low-risk scales of these codes (rare, e.g.
+# a Mikro tier) already carry "Otomatis" from the PP28 rule and must not be relabelled.
+SPECIAL_REGIME_RISK = {"Menengah Tinggi", "Tinggi"}
+
+
+def regime_for(code: str):
+    """Return (label, tag) for a code whose jangka is structurally absent, else (None, None)."""
+    pref = code[:2] if len(code) >= 2 else code
+    if pref in MINING_PREFIXES:
+        return MINING_LABEL, "PP28_special_regime_esdm"
+    if pref in FINANCE_PREFIXES:
+        return FINANCE_LABEL, "PP28_special_regime_ojk_bi"
+    return None, None
+
+
+def code_of(r):
+    return str(r.get("kode_kbli_2025") or r.get("kode") or "")
+
+
+def main():
+    dry = "--dry-run" in sys.argv
+    doc = json.load(open(CANON))
+    rows = doc["data"] if isinstance(doc, dict) and "data" in doc else doc
+
+    marked_mining = 0
+    marked_finance = 0
+    codes_touched = set()
+    skipped_has_value = 0
+
+    for r in rows:
+        c = code_of(r)
+        label, tag = regime_for(c)
+        if not label:
+            continue
+        for p in r.get("per_skala", []):
+            jw = (p.get("jangka_waktu") or "").strip()
+            if jw and jw not in ("-", "—"):
+                skipped_has_value += 1
+                continue  # already has a clean value (e.g. "Otomatis") — leave it
+            risk = (p.get("kategori_risiko") or "").strip()
+            if risk not in SPECIAL_REGIME_RISK:
+                continue  # low-risk scale: the PP28 rule path owns it ("Otomatis"), not here
+            if not dry:
+                p["jangka_waktu"] = label
+                p["jangka_waktu_source"] = tag
+            codes_touched.add(c)
+            if tag.endswith("esdm"):
+                marked_mining += 1
+            else:
+                marked_finance += 1
+
+    print(f"special-regime marking ({'DRY-RUN' if dry else 'APPLIED'}):")
+    print(f"  mining scales marked '{MINING_LABEL}': {marked_mining}")
+    print(f"  finance/insurance scales marked '{FINANCE_LABEL}': {marked_finance}")
+    print(f"  scales skipped (already had a value): {skipped_has_value}")
+    print(f"  codes touched: {len(codes_touched)}")
+
+    if not dry:
+        json.dump(doc, open(CANON, "w"), ensure_ascii=False, indent=2)
+        print(f"  wrote {CANON}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ocr_education_jangka.py
+++ b/scripts/ocr_education_jangka.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""ocr_education_jangka.py — locate the education (85xxx) rows in the PP28 Lampiran scans and
+OCR their jangka_waktu column.
+
+The Lampiran sub-files for Pariwisata-Kesehatan (2.10) and Keuangan-Ketenagakerjaan (2.11) are
+image-only scans (no text layer — pdftotext returns nothing), so we rasterise each page with
+pdftoppm and OCR with tesseract (ind+eng). The table column order is:
+  KBLI | Lingkup/Ruang Lingkup | Tingkat Risiko | Perizinan Berusaha | Jangka Waktu | Kewajiban ...
+
+This script runs in two phases driven by argv:
+  --locate <pdf>       : OCR every Nth page (stride) at low DPI, print pages whose text contains
+                         an 85xxx code, so we learn the page range cheaply.
+  --extract <pdf> <p0> <p1> : OCR pages p0..p1 at high DPI, scan each line for a leading 85xxx
+                         code and the first "N Hari"/"Otomatis" token on or near that line, and
+                         write a {code: jangka} JSON to OUT.
+
+Output JSON: scratch/education_jangka_ocr.json  (then a SEPARATE apply step folds CLEAN values
+into the canonical — this script never mutates the dataset).
+"""
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+LAMP = Path("/Users/balizero/Desktop/nuzantara/data/kb_sources/lampiran_pp28")
+OUT = Path(__file__).resolve().parents[1] / "scratch" / "education_jangka_ocr.json"
+
+CODE_RE = re.compile(r"\b(85\d{3})\b")           # education KBLI
+JANGKA_RE = re.compile(r"(\d{1,3})\s*[Hh]ari(?:\s*[Kk]erja)?|Otomatis")
+
+
+def ppm_text(pdf: Path, page: int, dpi: int) -> str:
+    """Rasterise one page and OCR it, returning the text."""
+    with tempfile.TemporaryDirectory() as td:
+        stem = Path(td) / "pg"
+        subprocess.run(
+            ["pdftoppm", "-f", str(page), "-l", str(page), "-r", str(dpi), "-png",
+             str(pdf), str(stem)],
+            check=True, capture_output=True,
+        )
+        pngs = list(Path(td).glob("pg*.png"))
+        if not pngs:
+            return ""
+        res = subprocess.run(
+            ["tesseract", str(pngs[0]), "stdout", "-l", "ind+eng", "--psm", "6"],
+            capture_output=True, text=True,
+        )
+        return res.stdout or ""
+
+
+def locate(pdf: Path, stride: int = 5, dpi: int = 150):
+    import pdfplumber
+    with pdfplumber.open(pdf) as p:
+        n = len(p.pages)
+    hits = []
+    for pg in range(1, n + 1, stride):
+        txt = ppm_text(pdf, pg, dpi)
+        codes = sorted(set(CODE_RE.findall(txt)))
+        if codes:
+            hits.append((pg, codes))
+            print(f"  page {pg}: {codes}", flush=True)
+    print(f"LOCATE done: {len(hits)} sample-pages with 85xxx in {pdf.name}", flush=True)
+    return hits
+
+
+def extract(pdf: Path, p0: int, p1: int, dpi: int = 300):
+    found = {}
+    for pg in range(p0, p1 + 1):
+        txt = ppm_text(pdf, pg, dpi)
+        lines = txt.splitlines()
+        for i, line in enumerate(lines):
+            m = CODE_RE.search(line)
+            if not m:
+                continue
+            code = m.group(1)
+            # look for a jangka token on this line or the next 2 (tables wrap)
+            window = " ".join(lines[i:i + 3])
+            jm = JANGKA_RE.search(window)
+            if jm:
+                val = jm.group(0)
+                val = "Otomatis" if val.strip().lower() == "otomatis" else re.sub(
+                    r"\s+", " ", val).strip()
+                # normalise "5Hari" → "5 Hari"
+                nm = re.match(r"(\d{1,3})\s*[Hh]ari", val)
+                if nm:
+                    val = f"{nm.group(1)} Hari"
+                found.setdefault(code, val)
+                print(f"  p{pg} {code} → {val}", flush=True)
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    prev = json.loads(OUT.read_text()) if OUT.exists() else {}
+    prev.update(found)
+    OUT.write_text(json.dumps(prev, ensure_ascii=False, indent=2))
+    print(f"EXTRACT done: {len(found)} codes this run, {len(prev)} total → {OUT}", flush=True)
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(__doc__)
+        return 1
+    mode = sys.argv[1]
+    pdf = LAMP / sys.argv[2]
+    if not pdf.exists():
+        print(f"::error:: {pdf} not found")
+        return 2
+    if mode == "--locate":
+        stride = int(sys.argv[3]) if len(sys.argv) > 3 else 5
+        locate(pdf, stride=stride)
+    elif mode == "--extract":
+        extract(pdf, int(sys.argv[3]), int(sys.argv[4]))
+    else:
+        print(f"unknown mode {mode}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Cosa

Completa il `jangka_waktu` (OSS processing time) del dataset KBLI dal 93% al **98%** (9076/9262 scale) e allinea la scheda web (`apps/mouth`) ai fix già nell'app nativa KBLI Navigator.

## Grounding — NB-3 (PP 28/2025 verbatim, citazioni Pasal)

Dei 100 codici incompleti, NB-3 (ground truth Company/KBLI) ha stabilito che **64 hanno il day-count STRUTTURALMENTE ASSENTE** — non un OCR mancato, ma un rinvio regolatorio:

| Settore | Regime | Label |
|---|---|---|
| Mining (05/07/08/09) | Pasal 90(3): IUP a fasi (Eksplorasi→Operasi Produksi), no SLA OSS | `Sesuai tahapan IUP (ESDM)` |
| Finance/Insurance (64/65/66) | giurisdizione OJK/Bank Indonesia, Lampiran="sesuai ketentuan OJK/BI" | `Sesuai ketentuan OJK/BI` |

Più **14 codici recuperati** dal rich-file già parsato (broadcasting 60xxx=`29 Hari`, education non-formale 85591-85599=`5 Hari`), normalizzando le stringhe descrittive.

## Sicurezza del dato

- **PMA-fingerprint INVARIATO** prima/dopo entrambi i pass (`c4d73d81`) — zero campi `pma_*`/`l4_bali` toccati. Le correzioni PMA del 27/6 restano intatte.
- I bare-number `14`/`30` mining **NON toccati**: NB-3 ha provato che sono legittimi su scope amministrativi (vs fasi IUP su scope estrattivo). Niente fabbricazione senza mapping scope↔valore.
- 2 codici divergenti (26601/46743) lasciati onestamente vuoti.

## Web parity (apps/mouth)

Nuovo `kbli-derive.ts` (+ test):
- `licenseForRisk` — Pasal 124(4): deriva la licenza dal rischio quando `perizinan` è vuoto. I **937 codici high-risk** non mostrano più un piatto "NIB" (understatement).
- `formatTimeframe` — Otomatis→Instant, N→working days, label regime passthrough.
- Applicato nei 2 transformer + 2 render-site utente.
- **Il test ha colto un bug pre-commit**: regex bare-number senza capture group → "undefined working days". Fixato.
- complementary filter: N/A sul web (`getRelatedCodes` costruisce già da codici reali).

## Verifica
- pre-commit: `tsc --noEmit` apps/mouth **PASS** + prettier + python lint ✅
- logica `kbli-derive` validata con runtime node (ALL PASS)
- sync dataset → tutti i consumer allineati (`sync_kbli_dataset.sh`)

## Resta aperto
- OCR re-parse per ~15 education 85xxx non coperti dal rich-file (`ocr_education_jangka.py` incluso, scansione in corso per localizzare le pagine Lampiran).

🤖 Generated with [Claude Code](https://claude.com/claude-code)