### PR TITLE
feat(organism): status-aware detection — see the organs that cry, not just the mute

### DIFF
--- a/scripts/organism_stale_detector.py
+++ b/scripts/organism_stale_detector.py
@@ -47,11 +47,40 @@ DEFAULT_SIDECAR_DIR = os.path.expanduser("~/.organism/last_seen")
 DEFAULT_ALERTS_FILE = os.path.expanduser("~/.organism/alerts/open.jsonl")
 DEFAULT_STALE_DAYS = 7
 
+# Statuses that mean "the organ is breathing but reporting trouble".
+UNHEALTHY_STATUSES: frozenset[str] = frozenset({"failed", "fail", "degraded", "error"})
+
+# Organs whose status=failed/degraded is a KNOWN false-positive — do NOT surface
+# them (would cause alert-fatigue = the next blindness). Established by the
+# 2026-06-28 triage of all 14 fresh-but-failed organs. Each entry is here because
+# the failure is benign, with the documented reason:
+#   - codex.spark_*        : intentionally disabled by the W81 firebreak (runaway loop)
+#   - wr2.telegram_gate    : decommissioned 2026-06-11 (.removed-*), genome not pruned
+#   - wr2.carousel_dispatcher: decommissioned 2026-06-11 (.removed-*), genome not pruned
+#   - wr3.reflexion_weekly : launchctl-disabled on purpose (the dead twin of wr2's)
+#   - pro.agent_library_evolver_* : intentionally disabled (deploy-drift quarantine)
+#   - pro.audit_launchd_daily : exit 1 BY DESIGN = "N unhealthy jobs found" (a true report)
+# The bridge tags all of these "failed" because it has no `disabled`/`expected_exit`
+# concept (HEALTHY_EXIT_CODES={0}). Curing the bridge is a separate hot-zone PR;
+# this allow-list is the safe downstream filter. Audit this list when an organ is
+# re-enabled — a re-enabled organ that genuinely fails must NOT stay suppressed.
+KNOWN_BENIGN_FAILED: frozenset[str] = frozenset({
+    "codex.spark_loop",
+    "codex.spark_harvester",
+    "codex.spark_alarm",
+    "wr2.telegram_gate",
+    "wr2.carousel_dispatcher",
+    "wr3.reflexion_weekly",
+    "pro.agent_library_evolver_daily",
+    "pro.agent_library_evolver_weekly",
+    "pro.audit_launchd_daily",
+})
+
 
 @dataclass
 class StaleFinding:
     organ_id: str
-    kind: str  # "stale" | "dead_channel" | "corrupt"
+    kind: str  # "stale" | "dead_channel" | "corrupt" | "unhealthy"
     age_days: float = field(default=-1.0)
     status: str = field(default="?")
     detail: str = field(default="")
@@ -169,6 +198,64 @@ def scan_sidecars(
     return findings
 
 
+def scan_sidecars_status(
+    sidecar_dir: str = DEFAULT_SIDECAR_DIR,
+    stale_days: float = DEFAULT_STALE_DAYS,
+    now: float | None = None,
+    benign: frozenset[str] = KNOWN_BENIGN_FAILED,
+    expect_core: tuple[str, ...] | None = None,
+) -> list[StaleFinding]:
+    """Full receptor scan: stale/dead/corrupt (via scan_sidecars) PLUS unhealthy.
+
+    An "unhealthy" finding is a FRESH organ (it IS breathing) whose status is in
+    UNHEALTHY_STATUSES and which is NOT in the benign allow-list. Stale dominates:
+    a stale organ is reported once as stale, never also as unhealthy (the frozen
+    channel is the headline, not its last-reported status).
+
+    This is the status-aware extension (2026-06-28): the prior receptor saw the
+    mute organs but ignored the ones crying for help.
+    """
+    now = time.time() if now is None else now
+    findings = scan_sidecars(
+        sidecar_dir, stale_days=stale_days, now=now, expect_core=expect_core
+    )
+    already = {f.organ_id for f in findings}  # don't double-count stale/corrupt
+
+    if not os.path.isdir(sidecar_dir):
+        return findings
+
+    for fname in sorted(os.listdir(sidecar_dir)):
+        if not fname.endswith(".json"):
+            continue
+        organ_id = fname[: -len(".json")]
+        if organ_id in already or organ_id in benign:
+            continue
+        path = os.path.join(sidecar_dir, fname)
+        try:
+            with open(path, encoding="utf-8") as fh:
+                payload = json.load(fh)
+        except (json.JSONDecodeError, OSError):
+            continue  # corrupt already handled by scan_sidecars
+        status = str(payload.get("status", "")).lower()
+        if status in UNHEALTHY_STATUSES:
+            note = ""
+            md = payload.get("metadata") or {}
+            if isinstance(md, dict):
+                note = str(md.get("note") or md.get("last_error") or "")
+            findings.append(
+                StaleFinding(
+                    organ_id=organ_id,
+                    kind="unhealthy",
+                    age_days=0.0,
+                    status=status,
+                    detail=f"breathing but status={status}"
+                    + (f" — {note[:120]}" if note else ""),
+                )
+            )
+
+    return findings
+
+
 def emit_alerts(findings: list[StaleFinding], alerts_file: str = DEFAULT_ALERTS_FILE) -> str:
     """Overwrite the open-alerts file with current findings (idempotent snapshot).
 
@@ -190,17 +277,25 @@ def emit_alerts(findings: list[StaleFinding], alerts_file: str = DEFAULT_ALERTS_
 
 def _human_report(findings: list[StaleFinding]) -> str:
     if not findings:
-        return "✅ organism heartbeat: all organs breathing (no stale/dead channels)"
-    lines = [f"⚠️ ORGANISM: {len(findings)} organ(s) not breathing:"]
-    for f in sorted(findings, key=lambda x: x.age_days, reverse=True):
-        if f.kind == "dead_channel":
-            lines.append(f"  💀 {f.organ_id}: NO heartbeat sidecar (core guardian)")
-        elif f.kind == "corrupt":
-            lines.append(f"  ❓ {f.organ_id}: corrupt sidecar — {f.detail}")
-        else:
-            lines.append(
-                f"  🫥 {f.organ_id}: stale {f.age_days:.1f}d (status={f.status})"
-            )
+        return "✅ organism heartbeat: all organs breathing + healthy (no findings)"
+    not_breathing = [f for f in findings if f.kind != "unhealthy"]
+    unhealthy = [f for f in findings if f.kind == "unhealthy"]
+    lines = [f"⚠️ ORGANISM: {len(findings)} organ finding(s):"]
+    if not_breathing:
+        lines.append(f"  — not breathing ({len(not_breathing)}):")
+        for f in sorted(not_breathing, key=lambda x: x.age_days, reverse=True):
+            if f.kind == "dead_channel":
+                lines.append(f"    💀 {f.organ_id}: NO heartbeat sidecar (core guardian)")
+            elif f.kind == "corrupt":
+                lines.append(f"    ❓ {f.organ_id}: corrupt sidecar — {f.detail}")
+            else:
+                lines.append(
+                    f"    🫥 {f.organ_id}: stale {f.age_days:.1f}d (status={f.status})"
+                )
+    if unhealthy:
+        lines.append(f"  — breathing but unhealthy ({len(unhealthy)}):")
+        for f in sorted(unhealthy, key=lambda x: x.organ_id):
+            lines.append(f"    🤒 {f.organ_id}: {f.detail}")
     return "\n".join(lines)
 
 
@@ -212,7 +307,7 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--json", action="store_true", help="machine-readable output")
     args = ap.parse_args(argv)
 
-    findings = scan_sidecars(args.dir, stale_days=args.stale_days)
+    findings = scan_sidecars_status(args.dir, stale_days=args.stale_days)
 
     if args.emit:
         path = emit_alerts(findings)

--- a/scripts/tests/test_organism_stale_detector.py
+++ b/scripts/tests/test_organism_stale_detector.py
@@ -109,3 +109,78 @@ def test_finding_is_serializable(tmp_path):
     findings = scan_sidecars(d, stale_days=7)
     blob = json.dumps([f.to_dict() for f in findings])
     assert "pro.x" in blob
+
+
+# ---------------------------------------------------------------------------
+# Status-aware detection (2026-06-28 extension): a fresh organ that reports
+# status=failed/degraded is "breathing but crying". The receptor must surface
+# the genuine ones WITHOUT injecting the known false-positives (organs
+# intentionally disabled, decommissioned, or exit-1-by-design) the triage found
+# — else every session gets alert-fatigue (the next blindness).
+# ---------------------------------------------------------------------------
+
+from organism_stale_detector import (  # noqa: E402
+    KNOWN_BENIGN_FAILED,
+    scan_sidecars_status,
+)
+
+
+def test_fresh_failed_organ_flagged_unhealthy(tmp_path):
+    """GUILT: a fresh organ reporting failed (not in allow-list) is flagged."""
+    d = str(tmp_path)
+    _write(d, "mata_garuda.consumer_lag_check", {"ts": time.time(), "status": "failed"})
+    findings = scan_sidecars_status(d, now=time.time())
+    ids = {f.organ_id for f in findings if f.kind == "unhealthy"}
+    assert "mata_garuda.consumer_lag_check" in ids
+
+
+def test_fresh_ok_organ_not_flagged_unhealthy(tmp_path):
+    """INNOCENCE: a fresh organ reporting ok is not an unhealthy finding."""
+    d = str(tmp_path)
+    _write(d, "pro.something", {"ts": time.time(), "status": "ok"})
+    findings = scan_sidecars_status(d, now=time.time())
+    assert [f for f in findings if f.kind == "unhealthy"] == []
+
+
+def test_known_benign_failed_suppressed(tmp_path):
+    """INNOCENCE: an intentionally-disabled organ reporting failed is NOT flagged.
+
+    These are the false-positives from the triage (codex.spark_*, decommissioned
+    wr2 organs, by-design exit-1 auditors). Flagging them = alert-fatigue = the next
+    blindness. The allow-list must suppress them.
+    """
+    d = str(tmp_path)
+    for organ in ("codex.spark_loop", "wr2.telegram_gate", "pro.audit_launchd_daily"):
+        _write(d, organ, {"ts": time.time(), "status": "failed"})
+    findings = scan_sidecars_status(d, now=time.time())
+    flagged = {f.organ_id for f in findings if f.kind == "unhealthy"}
+    assert flagged == set(), f"benign organs wrongly flagged: {flagged}"
+
+
+def test_degraded_status_flagged(tmp_path):
+    """degraded (not just failed) is also surfaced if not benign."""
+    d = str(tmp_path)
+    _write(d, "pro.real_degraded", {"ts": time.time(), "status": "degraded"})
+    findings = scan_sidecars_status(d, now=time.time())
+    assert any(f.organ_id == "pro.real_degraded" and f.kind == "unhealthy" for f in findings)
+
+
+def test_stale_failed_not_double_counted(tmp_path):
+    """A STALE failed organ is a stale finding, not also an unhealthy one.
+
+    Stale dominates: if it hasn't breathed in days, the heartbeat-channel problem
+    is the headline, not the last-reported status."""
+    d = str(tmp_path)
+    old = time.time() - 30 * 86400
+    _write(d, "pro.old_and_failed", {"ts": old, "status": "failed"})
+    findings = scan_sidecars_status(d, now=time.time())
+    kinds = {f.kind for f in findings if f.organ_id == "pro.old_and_failed"}
+    assert kinds == {"stale"}, f"expected only stale, got {kinds}"
+
+
+def test_allow_list_is_documented_not_empty():
+    """The allow-list must be non-empty (the triage found several) and each entry
+    should be a real organ_id string, so drift is auditable."""
+    assert isinstance(KNOWN_BENIGN_FAILED, (set, frozenset, tuple))
+    assert len(KNOWN_BENIGN_FAILED) >= 6
+    assert "codex.spark_loop" in KNOWN_BENIGN_FAILED


### PR DESCRIPTION
## Why
The receptor (#1805) saw organs that **stopped breathing** (stale heartbeat) but ignored organs that **breathe while reporting failed/degraded**. A full census on the Pro found **14 fresh-but-failed organs** — but a triage (2 fan-out subagents, disk-grounded on Pro logs) proved **11 are FALSE positives**:
- `codex.spark_*` (3) — intentionally disabled by the W81 firebreak (was a runaway loop)
- `wr2.telegram_gate`, `wr2.carousel_dispatcher` — decommissioned 2026-06-11 (`.removed-*`), genome not pruned
- `wr3.reflexion_weekly`, `agent_library_evolver` (×2) — `launchctl disable`d on purpose
- `pro.audit_launchd_daily` — exit 1 **by design** = "N unhealthy jobs found" (a true report)

Root cause = the bridge: `HEALTHY_EXIT_CODES={0}`, no `disabled`/`expected_exit` concept → tags every non-zero as `failed` (superscar #2 **inverted** — the signal lies in the *failed* direction).

Flagging all 14 = inject 11 false alarms into every session = **alert-fatigue = the next blindness**. So this PR surfaces only the genuine ones.

## What
- `scan_sidecars_status()` adds `kind="unhealthy"` for **fresh** organs with status in `{failed,fail,degraded,error}` **and not** in `KNOWN_BENIGN_FAILED`. Stale dominates (a stale organ is reported once as stale, never also unhealthy).
- `KNOWN_BENIGN_FAILED` — documented allow-list of the 9 known false-positives, each with its reason inline + a note to **audit when an organ is re-enabled** (so a re-enabled organ that genuinely fails isn't silently suppressed). The bridge-side cure (a real `disabled` state) is a separate hot-zone PR; this is the safe downstream filter.

## Verification (LIVE on Pro, real 115 sidecars)
14 raw failures → **6 genuine signals, 0 noise**:
```
— not breathing (2): cell.observatory (stale 25d), pro.federation_alert_dispatcher (stale 18d)
— breathing but unhealthy (6): cell.organism (degraded), intel_lake.e2e_probe_6h,
  intel_lake.nb_pusher_15min, mata_garuda.consumer_lag_check,
  mata_garuda.redis_split_brain_check, pro.fly_restart_loop_detector (degraded)
```
Even caught `pro.fly_restart_loop_detector` + `intel_lake.e2e_probe` that a by-hand census missed.

**14 tests pass** (8 prior + 6 status-aware: guilt, innocence, benign-suppression, stale-dominates, allow-list-documented).

## Known REAL conditions surfaced (for operator follow-up, not in this PR)
- `intel_lake.nb_pusher` + `e2e_probe`: **NotebookLM auth invalid since 2026-06-27 23:46** → needs `nlm login --clear` (interactive, operator).
- `mata_garuda.consumer_lag_check` + `redis_split_brain_check`: **same incident** — normalizer/scorer consumers down on Pro, `garuda:enriched` stream ~51h stale (superscar #10 active-active).

Ref: `research/operations/2026-06-28-heartbeat-channel-dead-core-organs.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)