### PR TITLE
docs(campaign): CONNECTOME CAMPAIGN shared-state + session-lifecycle SOTA (from Mini)

### DIFF
--- a/research/operations/campaign/00-CAMPAIGN-STATE.md
+++ b/research/operations/campaign/00-CAMPAIGN-STATE.md
@@ -1,0 +1,115 @@
+# CONNECTOME CAMPAIGN — stato condiviso (shared-context layer)
+
+> **Questo file è L'UNICA fonte di verità dello stato di campagna.** Ogni sessione (L0/L2/L3, su qualsiasi
+> macchina) lo rilegge al risveglio PRIMA di agire e lo aggiorna a ogni gate-round. È il rimedio al
+> context-inconsistency (causa #1 di fallimento multi-agente, ricerca 2026).
+> **Path identico su ogni macchina:** `~/Desktop/nuzantara/research/operations/campaign/00-CAMPAIGN-STATE.md`
+> (su M5 attualmente nel worktree `infra-tac-loop-megapattern`; verrà mergiato su main per la propagazione).
+
+---
+
+## 0. Genesi e mandato
+- **Data avvio:** 2026-06-15
+- **Mandato (Zero):** chiudere tutti i loop + trovare tutti i mega-pattern + audit completo + security/Law2 + knowledge-freshness + meta-loop. Autonomia: **trova + chiude tutto tranne firebreak FISICI**. Nessun limite di sessioni.
+- **Super-Osservatore (L0):** sessione M5 interattiva di Antonello+Claude (questa). NON esegue lavoro: vigila, raccoglie effect-receipt, decide firebreak fisici, fa gate finale.
+- **Fondamento ricerca:** orchestrator-worker (Anthropic, 70% prod, +90% vs single) · reliability compounding 95%^N · context-inconsistency = causa #1 · token ~15× giustificato · parallelismo solo su task indipendenti. Refuter cross-AI OBBLIGATORIO.
+
+## 1. Topologia (verificata su disco 2026-06-15, account aggiornati)
+| Host | RAM | Account Claude | Arsenale extra | Ruolo campagna | Max runner SICURO |
+|---|---|---|---|---|---|
+| **M5** balizero@Air-M5 | **24GB** | **antonellosiano@** (sianoantonello@ esaurita → torna ven) | agy(Gemini Ultra), codex(ChatGPT Pro ×20), ollama→mini, deepseek | **L0 Super-Osservatore + L2 lane META/ricerca-aperta** | **1 worker** (24GB, GUI interattiva) |
+| **Pro** nuzantara@Nuzantara | 48GB | **2 indipendenti** (default + kaiser…@acct2) | codex, ollama, deepseek; claude=alias .zshrc (`bash -lc`) | **L2 lane RUNTIME/SECURITY** (canali, CRM, Law2, deploy) | **4 worker** (2 account) |
+| **Mini** nuzantara@mini-pro2 | 24GB | **antonellosiano@** (condiviso con M5) | agy, codex, ollama(6), deepseek, 8 MCP validi | **L2 lane AUDIT-PESANTE/KNOWLEDGE** (RAG/KG/eventbus, KBLI/visa/tax) | **2 worker** (Ollama compete RAM) |
+
+### 1bis. Quota Claude — calibrazione (NON è "risparmia Claude", è "moltiplica con l'arsenale")
+- **Claude resta motore PRIMARIO di ogni lane.** Codex (ChatGPT Pro ×20, illimitato, OAuth VIVO) + Gemini (Google AI Ultra, VIVO) + DeepSeek + Ollama sono **potenza AGGIUNTIVA in parallelo**, non sostituti.
+- **Unica accortezza:** M5 e Mini condividono `antonellosiano@` → stessa finestra rolling-5h. Si danno il turno se la finestra si stringe.
+- **Cascade = RETE DI SICUREZZA, non default:** se la quota `antonellosiano@` si esaurisce a metà campagna, la lane NON si ferma → casca su Codex/Gemini per esplorazione+code+refuter (Ollama per PII). Il gate-finale-Opus aspetta che la finestra si riapra (qualità non degrada). Venerdì torna `sianoantonello@` → si ribilancia a 1 account per macchina.
+- **Pro è isolato** (2 suoi account) → non tocca la quota condivisa M5/Mini.
+
+- **Redis lease backbone:** Mini `localhost:6379` = PONG (verificato). Arbitro cross-machine unico.
+- **Broker worktree:** `scripts/agent_start.py` (39k). **Hook armati e verificati LIVE** (host_boundary + worktree_isolation hanno bloccato write reali in questa sessione).
+- **Dispatcher multi-AI:** `scripts/ai-dispatch.sh` (60k, machine-detection + cascade).
+- **Max runner concorrenti totali: ~7** (1 M5 + 4 Pro + 2 Mini). NON è il massimo possibile, è il massimo SICURO (banda di verifica del Super-Osservatore + reliability compounding).
+
+## 2. Assegnazione lane → macchina (con razionale)
+| Lane | Fronte | Macchina | Razionale |
+|---|---|---|---|
+| **L-META** | Salute loop apprendimento (#11): failure-injection su ogni loop verde-vuoto + antidoti (arm-gate CI, heartbeat-consumo, promote-gate). Ricerca aperta mega-pattern/scar nuove. | **M5** | tocca hook/cron/loop-logic = dominio dev; M5 ha gli hook da testare |
+| **L-RUNTIME** | Audit canali WA/TG/IG, intake, CRM (live) | **Pro** | i canali GIRANO sul Pro (deploy worktree presente) |
+| **L-SECURITY** | Security + sovranità Law2: secret in chiaro (#4), PII boundary, OSINT leak, deps/supply-chain | **Pro (ESCLUSIVO)** | firebreak fisico: OSINT/PII non lasciano il Pro (§13). DeepSeek key vive qui. |
+| **L-AUDIT** | Audit organismo per-anatomia: RAG/backend, KG, eventbus, WR2/WR3, deploy | **Mini** | read-heavy + Ollama bulk; H24; main 0-behind |
+| **L-KNOWLEDGE** | Knowledge freshness + correttezza dominio: KBLI/visa/tax/property, citazioni regolatorie, golden corpus | **Mini** | ground-truth NLM/Gemini + bulk re-embed Ollama |
+
+## 3. Costituzione di sicurezza (NON-NEGOZIABILE — vale per OGNI runner)
+1. **Worktree-per-lane + main read-only** (`agent_start.py`). → previene #5 sibling-race.
+2. **Account-per-host rigido.** Mai 2 host sullo stesso account. → quota + #10 split-brain.
+3. **Lease Redis FAIL-CLOSED per le CHIUSURE** (override del graceful-degrade): Redis down → leggere OK, committare/armare NO.
+4. **Gate a 5 cancelli prima di OGNI chiusura autonoma:** (0) grounding prova-in-questo-turn · (1) refuter indipendente su AI DIVERSO, mai self-review · (2) test di EFFETTO (non "i test passano") · (3) classificatore confine L2/L3 (hard) · (4) audit-write PRIMA dell'azione.
+5. **Confine L2-safe vs L3-firebreak (HARD):**
+   - **L2-safe (runner autonomo):** commit in lane-owned non-hot-zone · aprire PR (MAI merge) · docs/research/memory · fix reversibili con prova-di-effetto · implementare BUILDER items in PR.
+   - **L3-FIREBREAK (SOLO Zero):** armare/modificare cron o LaunchAgent · hot-zone (auth/billing/pricing/migrations/.github/workflows) · `~/.claude/` · propagate cross-machine via scp · merge su main · off-limits (`zantara_core.py`, `fly.toml`, `.env*`, `alembic/env.py`) · route flip WA · grant TCC GUI · account.
+6. **Heartbeat di EFFETTO, non di esistenza** (#11): exit 0 / "done" / PID NON contano. Conta la terna: (a) delta su disco/stato verificabile · (b) prova-di-causa (comando prima→dopo) · (c) refuter-ack ID. Zero-delta ripetuto = TEATRO → sospendi + scala.
+7. **Rollback:** solo azioni reversibili sono L2. Commit→revert (mai force-push/--amend su pushed). Audit-pre obbligatorio. Nuovo orphan-stash non attribuibile = sibling-race in atto.
+8. **PII assoluto:** KTP/passport/NPWP/akta/credentials/OSINT → SOLO Ollama-locale. MAI DeepSeek/Gemini/Codex/cloud.
+9. **Riserva quota 20%** per macchina intoccabile (per spegnersi in sicurezza). Chiusura NON degrada di modello: se MAX esaurito → chiusura in PAUSA, non con modello debole.
+
+## 4. Dispatch multi-AI (quando-chi)
+- **Width / sintesi 2°ordine:** Gemini 3.5 Flash High (default) / 3.1 Pro High (solo sintesi finale) via `agy`.
+- **Code / BUILDER / migration test:** Codex GPT-5.5 (illimitato), sandbox `read-only|workspace-write`.
+- **Refuter avversariale (non-PII):** DeepSeek V4 Pro `reasoning_effort=high` ($0.01/q).
+- **Refuter/processing PII:** Ollama locale Mini (6 modelli).
+- **Ground-truth dominio:** NotebookLM via MCP (bipolar verifier).
+- **Gate finale on-disk:** SEMPRE Opus (L0/L2). Il padre rifà il grep (W65).
+
+## 5. Effect-receipt (formato che ogni runner emette per ciclo, su path noto)
+```json
+{"host":"", "lane":"", "task_id":"", "account":"", "git_sha_before":"", "git_sha_after":"",
+ "files_touched":[], "artifact_proof":"", "cause_command":"", "cause_exitcode":0,
+ "refuter_id":"", "refuter_verdict":"", "lease_held":[], "ts":""}
+```
+Scritto in `research/operations/campaign/receipts/<host>-<lane>-<taskid>.json`. Il Super-Osservatore li RI-VERIFICA (non si fida del receipt: ri-legge sha, ri-esegue cause_command).
+
+## 6. Registro LIVE (aggiornato dai runner — append)
+> Formato: `[TS] HOST/LANE — stato — link finding/receipt`
+- [2026-06-15 init] M5/L0 — campagna creata, file-stato + 3 prompt scritti. In attesa di lancio runner.
+
+## 7. Backlog mega-pattern / scar / da-tracciare (cresce durante la campagna)
+- #11 Costruito≠Efficace — già identificato (TAC 2026-06-15). Bozza in `2026-06-15-tac-loop-closure-megapattern.md` §6.6. **Da promuovere** in cicatrix-superscar.md (L3, decisione Zero).
+- GOTCHA "verificatore-non-verificato" — da agganciare a #2/#6.
+- _[i runner aggiungono qui ogni candidato pattern/scar trovato]_
+
+## 8. §Residuo Operatore Puro (cresce — ciò che SOLO Zero può fare)
+- WR2 cutover (route flip + bootout Canva + finestra WA Meta) — Legge 5.
+- INTAKE FASE 5C (`INTAKE_WRITER_ENABLED`).
+- Grant TCC su M5 (Full-Disk-Access launchd/bash) — riarma 2 guardiani morti.
+- Promozione Lesson Harvester (shadow→enforcement).
+- deploy/main branch decision.
+- _[i runner promuovono qui ogni firebreak fisico incontrato]_
+
+## 9. PRE-FLIGHT 2026-06-15 (testato end-to-end, non assunto)
+| Macchina | Claude | Codex | Gemini(agy) | NLM | Redis | host_boundary | venv backend | Verdetto |
+|---|---|---|---|---|---|---|---|---|
+| **M5** | ✅ antonellosiano@ (live) | ✅ | ✅ loggato | ✅ loggato | ✅ (→Mini) | ✅ | ✅ | **PRONTA** |
+| **Mini** | ✅ loggato (haiku risponde) | ✅ | 🔴 NO auth | 🔴 auth scaduta | ✅ PONG (backbone) | ✅ | ✅ | **quasi** (agy+nlm login) |
+| **Pro** | 🔴 default=401, acct2=not-logged | ✅ | 🔴 missing | — | ✅(→Mini) | ✅ | ✅ | **BLOCCATA** (claude login) |
+
+### Blocchi reali (richiedono atto umano interattivo — firebreak fisico, login OAuth):
+1. **Pro Claude**: default account = `401 Invalid credentials` (scaduto), acct2 = `Not logged in`. Binario OK (`~/.local/bin/claude`, ma non in PATH → usare path assoluto). → serve `claude /login` su ENTRAMBI gli account Pro (dallo schermo Pro o tmux interattivo).
+2. **Mini agy (Gemini)**: NO auth → `agy login` interattivo (OAuth Google).
+3. **Mini nlm (NotebookLM)**: auth scaduta → `nlm login` interattivo (la lane KNOWLEDGE ne dipende).
+
+### Falsi-allarmi smontati (trap, NON blocchi):
+- "claude binary assente su Pro" → FALSO: esiste, solo non in PATH (`~/.local/bin` non incluso). Il problema vero è l'AUTH (401/not-logged), non il binario.
+- "repo Mini rotto" (sessione precedente) → FALSO: era trap cd-via-ssh; repo sano (main, 0 behind).
+
+### Mezzi CONFERMATI presenti ovunque (dall'inizio alla fine del lifecycle):
+broker agent_start.py · lease agent_lease.py · ai-dispatch.sh · redis backbone (Mini PONG) · host_boundary md5 uniforme · venv backend-rag · tmux · codex (illimitato, vivo) · ollama (Mini 6 modelli incl qwen2.5vl vision).
+
+## 10. PRE-LANCIO check 2026-06-16 — GIÀ FATTO da sessioni parallele (NON duplicare!)
+> Intuizione operatore: controllare cosa hanno fatto le altre sessioni PRIMA di lanciare. Ha evitato 3 duplicazioni.
+- ✅ **DLQ corpse-sweep auto-drain** (#1471 MERGED, Opus 4.8) = era il nostro BUILDER L-OP-3 (data-loss). Chiude heal-loop cieco non-registry (W70/W81b). 14 corpses drenati. → **lane AUDIT: NON ricostruire il DLQ replay; verifica solo che il sweep giri davvero (failure-injection).**
+- ✅ **lifecycle-guard "the vase empties itself"** (597f6fe25, antonellosiano@) = **antidoto #11 GIÀ in corso** (auto-GC che AGISCE non avvisa; nato da "chi svuota il vaso? non io"). BONUS sicurezza: rimossi 2 secret (JWT+QDRANT_KEY) nascosti nei permission entries. → **lane META: costruisci SOPRA questo (heartbeat-di-consumo + promote-gate), NON da zero. È la prova vivente di #11.**
+- ✅ **Law 2 PII output boundary** chiarito (#1476 + 5263eb50f) → **lane SECURITY: il PII-boundary base è fatto; concentrati su secret-in-chiaro residui (il GC ne ha già trovati 2 → cercane altri) + OSINT-leak + deps.**
+- ℹ️ Altro lavoro vivo (non sovrappone): intake NIB/akta filing (#1475), WR2 full-bleed carousel + ban-cliché (Pro), deps bump (82+6+4), team photos (#1469), npm-audit esbuild (worktree Pro).
+- ⚠️ **Sessioni VIVE ora:** Pro = Codex (app-server+chronicle+computer-use) + guardrails daemon + rsync→damar. M5 = 9 worktree attivi. → i runner DEVONO usare lease Redis (collisione reale possibile). Verifica `agent_lease list` prima di toccare un file.

--- a/research/operations/campaign/01-SESSION-LIFECYCLE-SOTA.md
+++ b/research/operations/campaign/01-SESSION-LIFECYCLE-SOTA.md
@@ -1,0 +1,204 @@
+# Il ciclo di vita di una sessione SOTA (giugno 2026) — mappa precisa + auto-critica
+
+> **Scopo:** descrivere ESATTAMENTE cosa fa ogni runner della Connectome Campaign, dal worktree-create al
+> cleanup, ogni step nel mezzo. Con dialogo di auto-critica inline (🔴 = io attacco il mio design, 🟢 = io rispondo).
+> **Ancoraggio:** disco (interfacce reali verificate) + best-practice web 2026 + reuse-first (cosa esiste già).
+>
+> **Reuse-first verdict:** 6 dei 7 mattoni del lifecycle ESISTONO GIÀ su disco (broker, lease, gate-hook,
+> dispatch, loop-skill, task-tracking). Solo l'**effect-receipt** (heartbeat-di-effetto, antidoto #11) è nuovo —
+> ed è un singolo JSON per ciclo. Il workflow è ORCHESTRAZIONE di pezzi esistenti, non costruzione.
+>
+> **Fondamento web 2026** (convergente col disco): worktree-isolation load-bearing da Q1 2026; i 6 pattern
+> anti-conflitto (spec-decomp · worktree-isolation · coordinator/specialist/verifier · per-task model routing ·
+> quality-gates · sequential-merges); self-verification abbassa i fallimenti dall'80% al 23%; "git worktree NON
+> avvisa se due worktree toccano lo stesso file" → serve il lease. context-rot su sessioni lunghe → task bounded.
+> Fonti in §Riferimenti.
+
+---
+
+## Vista d'insieme: le 9 fasi di una sessione
+
+```
+FASE 0  GROUND      stadio-zero: memoria + hot-files verificati su disco + criteri falsificabili
+FASE 1  SCOPE       il lane-lead riceve il mandato, decompone per-anatomia (task indipendenti)
+FASE 2  CREATE      agent_start.py → worktree isolato + branch dedicato + TTL
+FASE 3  LEASE       agent_lease acquire su ogni hot-zone che toccherà (FAIL-CLOSED per chiusure)
+FASE 4  FAN-OUT     spawn worker (1/organo) + dispatch multi-AI (Gemini width / Codex code / Ollama PII)
+FASE 5  ACT         il worker fa il lavoro nel worktree (read → edit → test)
+FASE 6  GATE        i 5 cancelli prima di QUALSIASI chiusura (grounding→refuter→effetto→confine→audit)
+FASE 7  RECEIPT     effect-receipt JSON (heartbeat-di-EFFETTO, non di esistenza) → path noto
+FASE 8  HARVEST     commit + PR (mai merge) · findings/ · aggiorna campaign-state · mem save
+FASE 9  CLEANUP     lease release · worktree --release (se merged) o TTL-reap · receipt finale
+```
+
+---
+
+## FASE 0 — GROUND (entry gate)
+**Cosa:** la sessione carica `stadio-zero` (o `opus-mythos` se deep/wide). Verifica: memory-hits pertinenti,
+hot-files VERIFICATI su disco (non citati a memoria), PII-scope, criteri di accettazione falsificabili.
+**Reuse:** skill `stadio-zero` esiste. Hook `stadio_zero_nudge.py` lo ricorda.
+**Perché:** previene la "file:line hallucination" — costruire un piano su un path che non esiste (superscar #6).
+
+> 🔴 *"FASE 0 è teatro se il runner la salta — è una skill, non un hook bloccante."*
+> 🟢 Vero, `stadio_zero_nudge.py` è nudge non block. MA il GATE di FASE 6 (cancello-0 grounding) RI-richiede
+>    prova-in-questo-turn prima di committare: se hai saltato FASE 0, FASE 6 ti ferma comunque. Doppia rete.
+> 🔴 *"E se il mandato è già nel file-prompt? FASE 0 non ridonda?"*
+> 🟢 No: il file-prompt dà lo SCOPO, FASE 0 verifica il TERRENO oggi (i file potrebbero essere cambiati da
+>    quando ho scritto il prompt, 1h fa). Lo scopo è statico, il terreno è vivo.
+
+## FASE 1 — SCOPE (decomposizione)
+**Cosa:** il lane-lead (L2) legge `00-CAMPAIGN-STATE.md` + il suo mandato, decompone la lane in task ATOMICI
+e INDIPENDENTI (best-practice: parallelismo solo su task indipendenti, altrimenti degenera in seriale costoso).
+**Reuse:** `TaskCreate`/`TaskList` (harness) per tracciare. La decomposizione per-anatomia è in opus-mythos.
+**Output:** una lista di task, ognuno → un worker in FASE 4.
+
+> 🔴 *"Decomporre per-anatomia garantisce davvero indipendenza? Un fix di security in un file backend che
+>     l'audit-lane sta leggendo NON è indipendente."*
+> 🟢 Corretto — ed è il limite noto del web 2026 ("git worktree non avvisa su file condivisi"). La rete è il
+>    LEASE (FASE 3): se due lane puntano lo stesso file, la seconda fallisce `agent_lease check`. L'indipendenza
+>    by-anatomy è il 90%; il lease copre il 10% di overlap residuo. Non mi fido della sola decomposizione.
+
+## FASE 2 — CREATE (worktree)
+**Cosa:** `python scripts/agent_start.py --lane <X> --task-id <Y> --ttl-min <N>` → crea
+`.worktrees/<lane>-<task>/` con branch dedicato forkato da main, TTL per il reap.
+**Reuse:** `agent_start.py` ESISTE (verificato: `--lane --task-id --ttl-min --base-branch --list --cleanup --release --force`).
+**Perché:** isolamento — "worktree load-bearing da Q1 2026"; il main checkout resta read-only (hook lo impone).
+
+> 🔴 *"Su Pro/Mini il main è 0-behind; su M5 è 37-behind. I worktree forkano da `main` LOCALE → un worker M5
+>     lavora su codice vecchio di 37 commit."*
+> 🟢 Catch reale. Mitigazione: `--base-branch origin/main` invece di `main` locale, OPPURE il lane-lead M5 fa
+>    `git fetch` (read-only, permesso) e forka da origin/main aggiornato. Lo metto come step esplicito di FASE 2
+>    per M5. Su Pro/Mini non serve (già allineati).
+> 🔴 *"TTL default 60min. Un audit profondo dura di più → il reap potrebbe uccidere un worktree vivo (W80!)."*
+> 🟢 Per questo `agent_start --cleanup` ha la `--skip-recent-min` guard (default 10min di FS-activity) + il
+>    reap-guard a 2-AND (no-live-process AND merged-in-origin). W80 è già fixato. Ma per sicurezza i runner
+>    della campagna usano `--ttl-min 240` (4h) per i task lunghi. Heartbeat di FS-activity tiene vivo il resto.
+
+## FASE 3 — LEASE (coordinamento cross-machine)
+**Cosa:** prima di toccare una hot-zone (LaunchAgent, migration, auth/billing, .github/workflows, ~/.claude),
+`python scripts/agent_lease.py acquire <resource> --task-id <Y>`. Heartbeat periodico. FAIL-CLOSED per chiusure.
+**Reuse:** `agent_lease.py` ESISTE (`acquire/release/heartbeat/list/check`), backbone Redis su Mini (PONG verificato).
+**Perché:** è la rete per l'overlap che la decomposizione non copre (limite noto web 2026).
+
+> 🔴 *"Redis è su Mini. Se Mini cade, il lease graceful-degrada a pass-through (WARN) → race silenziose
+>     proprio durante alta concorrenza. E Mini è ANCHE un runner → si auto-DOS?"*
+> 🟢 Due risposte. (1) Override di campagna (in costituzione §3.3): per le CHIUSURE, Redis-down = FAIL-CLOSED,
+>    non pass-through. Leggere sì, committare no. (2) Mini come backbone+runner: la costituzione cappa Mini a 2
+>    worker proprio perché regge Redis + Ollama + claude. Se va in pressione, scende a 1. Il Super-Osservatore
+>    (io) monitora `redis-cli ping` a ogni giro.
+> 🔴 *"Un lease su `~/.claude` cross-machine non ha senso — ogni macchina ha il SUO ~/.claude, non è condiviso."*
+> 🟢 Giusto, correzione: il lease cross-machine vale solo per risorse REALMENTE condivise (git origin, Fly DB,
+>    Redis stesso, organs_registry). `~/.claude` è per-host → lease LOCALE per-host, non cross. Lo annoto.
+
+## FASE 4 — FAN-OUT (worker + dispatch AI)
+**Cosa:** il lane-lead spawna worker (subagent Sonnet, 1 per organo/task) ognuno nel suo worktree. Dispatch
+multi-AI per ruolo: Gemini (width/corpus), Codex (code/migration-test), DeepSeek (refuter non-PII), Ollama
+(PII-local), NLM (ground-truth dominio).
+**Reuse:** `ai-dispatch.sh` ESISTE (explore/search/sandbox/redteam/oracolo). Agent tool per i subagent.
+**Perché:** coordinator/specialist/verifier split (best-practice 2026). +90% vs single-agent (Anthropic).
+
+> 🔴 *"Reliability compounding: 95% × N worker = degrado. Quanti worker prima che la catena collassi?"*
+> 🟢 Web+costituzione concordano: oltre ~4-5 worker in catena la qualità crolla SE non c'è verifica per-ramo.
+>    Per questo ogni finding ha un refuter (FASE 6 cancello-1). Cap: M5≤1, Pro≤4, Mini≤2 worker. Il refuter
+>    RECUPERA affidabilità — ma solo se il Super-Osservatore ha banda di ri-verificare ognuno (vedi FASE 7).
+> 🔴 *"Il refuter è un altro agente → alluc­ina anche lui (#6). Chi verifica il verificatore?"*
+> 🟢 Esatto, è il GOTCHA appena scoperto nella TAC. Risposta a 2 livelli: (a) il refuter è su AI DIVERSA dal
+>    producer (DeepSeek refuta Claude, non Claude-refuta-Claude) → errori non correlati. (b) il gate FINALE è
+>    sempre Opus che rifà il grep su disco (W65: "l'ultimo grep del padre non si delega"). Il Super-Osservatore
+>    è il verificatore-del-verificatore, e LUI ri-esegue i comandi-prova, non si fida dei receipt.
+
+## FASE 5 — ACT (il lavoro vero)
+**Cosa:** il worker, nel suo worktree, fa il ciclo: read (grep/glob) → ipotesi → edit → test. Per i fix
+applica `karpathy-discipline` (no silent assumptions, no hypertrophy, no collateral changes).
+**Reuse:** skill `karpathy-discipline`, `sota-architecture-loop` per le decisioni strutturali.
+**Confine:** SOLO L2-safe in autonomia (edit lane-owned, test). Le azioni di chiusura aspettano FASE 6.
+
+> 🔴 *"'no collateral changes' vs un audit che TROVA bug in 5 file diversi — il worker deve fixarli tutti o no?"*
+> 🟢 Un worker = un task atomico = un organo. Se trova bug fuori scope, NON li fixa: li registra in findings/ e
+>    il lane-lead crea un nuovo task (nuovo worktree). Mai espandere lo scope a runtime (context-rot, web 2026).
+
+## FASE 6 — GATE (i 5 cancelli, in sequenza, prima di OGNI chiusura)
+**Cosa:** nessun commit/PR/azione passa senza i 5 cancelli IN ORDINE (se uno fallisce, STOP):
+- **Cancello 0 — Grounding:** prova-in-questo-turn (file:line letti, comando+exit, test verde). No "ho visto prima".
+- **Cancello 1 — Refuter indipendente:** un AI DIVERSO prova a DEMOLIRE il finding (asimmetrico, non consenso). Mai self-review.
+- **Cancello 2 — Test di EFFETTO:** non "i test passano" ma "l'effetto è dimostrato" (il cron prima non produceva / ora sì; test rosso→verde attribuibile).
+- **Cancello 3 — Confine L2/L3 (hard, hook):** `host_boundary.py` + `orchestrate_gate.py` bloccano se l'azione è L3-firebreak.
+- **Cancello 4 — Audit-pre:** scrive l'intent nell'audit trail PRIMA di agire.
+**Reuse:** hooks ESISTONO (host_boundary, orchestrate_gate, seam_verify, stop_verify). Skill `verify`.
+**Perché:** self-verification 80%→23% fallimenti (web 2026). È il cuore della sicurezza.
+
+> 🔴 *"5 cancelli per OGNI commit = lentissimo. Un fix di un typo passa 5 cancelli?"*
+> 🟢 No, proporzionalità: un fix reversibile triviale in lane-owned passa solo cancello-0 (grounding) +
+>    cancello-3 (il confine, che è automatico via hook). I 5 pieni sono per azioni a impatto: armare-qualcosa,
+>    toccare hot-zone, chiudere un loop. Il GATE scala con il blast-radius dell'azione, non è fisso.
+> 🔴 *"Cancello-3 è hook → ma gli hook sono in ~/.claude di OGNI macchina. Sono identici su Pro/Mini/M5?"*
+> 🟢 DOMANDA APERTA load-bearing. Su M5 verificato (52 hook armati). Su Pro/Mini NON ri-verificato in questo
+>    turno. → è un task per la lane-AUDIT/META: confermare che host_boundary+worktree_isolation siano armati
+>    e IDENTICI (md5) sulle 3 macchine. Se un host ha hook diversi, il confine L2/L3 non è uniforme = pericolo.
+>    Lo aggiungo al backlog §7 del campaign-state.
+
+## FASE 7 — RECEIPT (heartbeat-di-EFFETTO) ← l'unico pezzo NUOVO
+**Cosa:** ad ogni ciclo, il worker emette un JSON in `research/operations/campaign/receipts/<host>-<lane>-<task>.json`:
+```json
+{"host","lane","task_id","account","git_sha_before","git_sha_after","files_touched":[],
+ "artifact_proof","cause_command","cause_exitcode","refuter_id","refuter_verdict","lease_held":[],"ts"}
+```
+**Reuse:** NON esiste → [SCRIVI-NUOVO], ma minimo (un dict + write). È l'antidoto #11 (heartbeat-di-consumo).
+**Perché:** distingue lavoro reale da teatro. exit-0 NON è prova; `git_sha_before != git_sha_after` + artifact lo è.
+
+> 🔴 *"Il receipt stesso può essere allucinato — un worker scrive sha falsi."*
+> 🟢 Per questo il Super-Osservatore NON si fida del receipt: ri-legge `git_sha_after` dal git reale, ri-esegue
+>    `cause_command` e controlla l'exit. Il receipt è un CLAIM, non una prova. La prova è la mia ri-verifica.
+>    (Esattamente il pattern "Verifier Agent monitora i tool-call output", web 2026.)
+> 🔴 *"Perché un file JSON e non un DB? Sembra fragile."*
+> 🟢 Reuse-first + sovranità: file su path-noto = zero infra nuova, git-tracciabile, leggibile via ssh,
+>    nessun servizio da armare (che sarebbe esso stesso #11: un servizio-receipt armato-a-vuoto). Il file È
+>    lo shared-context-layer (causa #1 di fallimento risolta col mezzo più semplice). KISS.
+
+## FASE 8 — HARVEST (raccolta del valore)
+**Cosa:** se i 5 cancelli passano: `git commit` (atomico, convenzionale, co-author) → `gh pr create` (MAI
+merge — il merge è L3) → scrive `findings/<host>-<lane>-<slug>.md` → aggiorna `00-CAMPAIGN-STATE.md` §6/§7/§8
+→ `mem save` delle discovery durevoli.
+**Reuse:** git/gh, skill `scar` per cicatrici nuove, CLI `mem`. Merge-train: `gh pr merge --auto` lo arma
+SOLO il Super-Osservatore/Zero, mai il runner.
+**Perché:** sequential-merges (best-practice 2026: mai merge paralleli che collidono).
+
+> 🔴 *"PR mai-merge → si accumulano PR aperte all'infinito. Chi le merga?"*
+> 🟢 Il merge è firebreak L3 = Zero (o io con conferma esplicita). È DELIBERATO: l'autonomia alta si ferma
+>    PRIMA del merge su main. Le PR sono il deliverable; Zero fa il merge-train a fine campagna o a comando.
+>    Questo è il confine "chiude tutto tranne firebreak fisico" che Zero ha confermato.
+
+## FASE 9 — CLEANUP (chiusura del ciclo)
+**Cosa:** `agent_lease release --task-id <Y>` (rilascia tutti i lease) → `agent_start.py --release <Y>` (se il
+branch è merged) OPPURE lascia che il TTL-reap lo recuperi (se WIP-safe) → scrive il receipt finale di lane.
+**Reuse:** `agent_start --release` (richiede branch merged) + `--cleanup` (TTL+WIP-safe) + `worktree_gc_universal.py`.
+**Perché:** "session lifecycle = create, navigate, delete, stage" (web 2026). Niente worktree zombie (superscar #5/W62).
+
+> 🔴 *"--release richiede branch MERGED, ma il merge è L3 (Zero). Quindi il runner non può MAI fare cleanup?"*
+> 🟢 Catch importante. Risoluzione: il runner a fine task fa SOLO `lease release` + lascia il worktree con la PR
+>    aperta (NON lo distrugge — contiene lavoro non ancora merged). Il cleanup del worktree avviene DOPO che
+>    Zero merga la PR: a quel punto `--release` funziona (branch merged) o il TTL-reap lo prende (W80-guard:
+>    no-live-process AND merged-in-origin). Il runner NON distrugge worktree con lavoro non-merged. Coerente
+>    con "leave-dirty intenzionale verso il lavoro sibling".
+> 🔴 *"E i worktree orfani se un runner crasha a metà?"*
+> 🟢 Il TTL (240min) + il cron `agent_worktree_cleanup_cron.sh` li reclamano, MA con la 2-AND guard (mai
+>    distruggere worktree con processo vivo O commit non-merged). NB: quel cron è uno dei 2 morti-da-TCC su M5
+>    (TAC §4.1) → su M5 il reap va fatto a mano dal Super-Osservatore finché Zero non concede il Full-Disk-Access.
+
+---
+
+## Sintesi del dialogo: cosa il self-critique ha aggiunto al design
+1. FASE 2 su M5: forka da `origin/main` (fetch read-only), non da main-locale-37-behind.
+2. FASE 2: TTL 240min per task lunghi, non 60 default.
+3. FASE 3: lease cross-machine SOLO per risorse condivise (git/Fly/Redis/registry); `~/.claude` = lease locale.
+4. FASE 3: Redis-down = FAIL-CLOSED per chiusure (override del graceful-degrade).
+5. FASE 6 cancello-3: VERIFICARE che gli hook siano armati e IDENTICI (md5) sulle 3 macchine → task aggiunto al backlog.
+6. FASE 6: il GATE scala col blast-radius (typo = 2 cancelli; armare-qualcosa = 5).
+7. FASE 9: il runner NON distrugge worktree con PR non-merged; cleanup post-merge-di-Zero; su M5 reap a mano (TCC).
+
+## Riferimenti (best-practice 2026)
+- Anthropic, multi-agent research system (orchestrator-worker, +90%, token 15×).
+- MindStudio / Augment / Google Cloud (Weinmeister): git worktrees per agenti paralleli, 6 pattern anti-conflitto, "git worktree non avvisa su file condivisi" → serve lease.
+- InfoWorld via dev.to: self-verification 80%→23% fallimenti; Verifier Agent indipendente sul Chain-of-Thought.
+- Penligent: "worktree need runtime isolation" (porte/DB/cache/secret/test-state oltre ai file).
+- decodethefuture / Lyzr: context-inconsistency = causa #1 di fallimento; reliability compounding.

--- a/research/operations/campaign/PROMPT-MINI-AUDIT-KNOWLEDGE.md
+++ b/research/operations/campaign/PROMPT-MINI-AUDIT-KNOWLEDGE.md
@@ -1,0 +1,53 @@
+# PROMPT — sessione Mini / Lane L-AUDIT + L-KNOWLEDGE (anatomia organismo + freschezza dominio)
+
+> **Come lanciare:** su Mini via `ssh mini` → `bash -lc "claude"` (claude 2.1.177, path-abs ok). Modello Opus, xhigh.
+> Mini ha **1 account** + Ollama (6 modelli) che compete per i 24GB → MAX **2 worker claude** concorrenti;
+> se lanci bulk-Ollama-eval, scendi a 1 worker claude per non OOM.
+> **PRIMA di tutto** leggi `~/Desktop/nuzantara/research/operations/campaign/00-CAMPAIGN-STATE.md`.
+
+---
+
+## MANDATO L-AUDIT (incolla questo)
+
+Sei Lane-Lead L2 della Connectome Campaign, lane **L-AUDIT**, su Mini (workhorse H24). Carica `opus-mythos`.
+Leggi PRIMA il file-stato §3 (costituzione) + §6 (registro) + **§10 (GIÀ FATTO — non duplicare!)**.
+
+⚠️ **§10 — il DLQ è GIÀ chiuso:** il "corpse-sweep auto-drain" (#1471 MERGED) chiude l'heal-loop cieco del DLQ.
+**NON ricostruire il DLQ replay.** Per l'EventBus/DLQ il tuo compito è SOLO: failure-injection per verificare che
+il sweep giri DAVVERO (inietta un corpse → viene drenato?). Se sì, marca verde e passa oltre.
+
+**Obiettivo:** TAC per-anatomia dell'organismo — un fan-out di worker, UNO per organo, ognuno caccia bug/debito/teatro/scar-nuove. Organi:
+- **RAG/backend** (`apps/backend-rag/backend/`): reasoning, orchestrator, abstain-policy (2 path live, domanda #31 SSOT aperta), evidence scoring. Caccia bug logici.
+- **KG** (`kg_subgraph_property.py` ecc.): knowledge graph, langgraph federation.
+- **EventBus** (`services/events/event_bus.py`): durabilità per-canale (Law3), replay, outbox. Channel-consumer parity. (DLQ replay = già fatto #1471, solo verifica failure-injection).
+- **WR2/WR3**: pipeline carousel/video — stato armamento (0 job launchd?), reflexion, critic gate. NOTA: Pro sta già lavorando su WR2 carousel — coordina via lease, non collidere.
+- **deploy/CI**: workflow .github, squawk lint, required checks (CODEOWNERS gate exit-0 LYING noto).
+
+Per ogni organo: spawna 1 worker (Sonnet) in worktree → trova → refuter (DeepSeek/Codex) verifica → tu (Opus) gate finale. Usa Ollama locale per scansioni bulk (grep semantico, classificazione) per risparmiare quota.
+
+**Output:** `research/operations/campaign/findings/mini-audit-SUMMARY.md` (per organo: bug confermati, debito, scar candidate) + effect-receipt.
+
+---
+
+## MANDATO L-KNOWLEDGE (incolla in una seconda sessione SE RAM lo consente, altrimenti dopo L-AUDIT)
+
+Sei Lane-Lead L2 della Connectome Campaign, lane **L-KNOWLEDGE**, su Mini. Carica `opus-mythos`. Leggi file-stato §3.
+
+**Obiettivo:** knowledge-decay + correttezza di dominio (continua l'audit Fable5 del 13/06 che trovò 8 P0).
+- **Sito/KB pubblici** (`apps/mouth/`): KBLI 2025, visa, tax-calendar, property. Citazioni regolatorie stale? (LKPM 10th→15, paid-up 2.5B, SABH/NIB, PP 20/2026). Campagne a scadenza: KBLI 18/06, RUPS 30/06.
+- **Golden corpus** (`apps/evaluator/zantara_persona_eval/golden_corpus.json`): valida con `validate_corpus.py`. Coverage dominio sufficiente?
+- **Ground truth**: usa NotebookLM (MCP, bipolar verifier) per verificare i fatti regolatori. NB-3 Company, NB-4 Tax, NB-5 Property. Gemini per width sul corpus.
+- **Bridge WA freshness**: il bridge WhatsAppRAG cita norme correnti? (era 100% CURRENT al 13/06 — riconferma).
+
+**REGOLE knowledge-specifiche:** i fatti regolatori vanno verificati contro NLM (ground-truth), MAI inventati. Domanda di dominio → bipolar verifier (1 LLM + 1 NB), non 4-LLM council. Correzioni sito = L2-safe (PR mai merge); NON toccare `apps/backend-rag/backend/kb/` (curato — Legge convention §15).
+
+**Output:** `research/operations/campaign/findings/mini-knowledge-SUMMARY.md` (P0/P1 freshness, con NB-citation) + effect-receipt.
+
+---
+
+## REGOLE COMUNI (da §3 costituzione)
+- Worktree: `python scripts/agent_start.py --lane audit|knowledge --task-id <slug>`.
+- Gate 5-cancelli. Refuter AI-diverso, mai self-review. Lease FAIL-CLOSED per chiusure (Redis è QUI su Mini localhost:6379 — sei il backbone, non farlo cadere).
+- L2-safe = commit + PR (mai merge) + docs. L3-firebreak (NO): cron, hot-zone, kb/ curato, off-limits, merge main, propagate.
+- Heartbeat-di-effetto. Ollama vs claude competono RAM: finestra-temporale, non simultaneo se OOM-risk.
+- Aggiorna §6/§7/§8 del file-stato. Non fermarti finché ogni organo + ogni fronte-knowledge non ha verdetto verificato.


### PR DESCRIPTION
Three Connectome Campaign process docs written on Mini, complementing the existing
`research/operations/campaign/{findings,receipts}/` on main:

- `00-CAMPAIGN-STATE.md` — shared single-source-of-truth state layer (L0/L2/L3 read/update)
- `01-SESSION-LIFECYCLE-SOTA.md` — precise map + self-critique of each SOTA runner
- `PROMPT-MINI-AUDIT-KNOWLEDGE.md` — launch prompt for Mini's L-AUDIT/L-KNOWLEDGE lane

Recovered from Mini's uncommitted work during the fleet sync. **No client PII** —
the security mentions are policy *descriptions* (PII boundary, Law 2), not data
(scan-verified).

Note: Mini also carried a divergent `config.py`/`.env.example` voice-concierge delta
that was **intentionally discarded** — its field removals would have broken 4 main
files (`voice.py`, `readiness.py` + tests) that use the fields main has since added.
That obsolete delta is preserved on a Mini quarantine ref if ever needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)