### PR TITLE
fix(intake): bridge local→Fly client identity on auto-attach delivery

### DIFF
--- a/apps/backend-rag/backend/services/intake/crm_delivery.py
+++ b/apps/backend-rag/backend/services/intake/crm_delivery.py
@@ -48,12 +48,14 @@ async def deliver_committed_to_crm(
 
     blob_path: str | None = None
     mime_type: str | None = None
+    sender_phone: str | None = None
+    client_full_name: str | None = None
     already: asyncpg.Record | None = None
     async with pool.acquire() as conn:
         if queue_id is not None:
             qrow = await conn.fetchrow(
                 """
-                SELECT q.blob_path, di.mime_type
+                SELECT q.blob_path, di.mime_type, q.sender_phone
                 FROM intake_queue q
                 LEFT JOIN document_instances di ON di.id = q.instance_id
                 WHERE q.id = $1
@@ -63,6 +65,18 @@ async def deliver_committed_to_crm(
             if qrow is not None:
                 blob_path = qrow["blob_path"]
                 mime_type = qrow["mime_type"]
+                sender_phone = qrow["sender_phone"]
+        # Local client name — used ONLY to name a fresh Fly lead if the cross-DB
+        # phone-upsert has to create one (placeholder "Lead +<phone>" names are
+        # skipped so they never overwrite a better Fly name). Derived field only.
+        if plan.client_id is not None:
+            crow = await conn.fetchrow(
+                "SELECT full_name FROM clients WHERE id = $1", int(plan.client_id)
+            )
+            if crow is not None:
+                _name = (crow["full_name"] or "").strip()
+                if _name and not _name.lower().startswith("lead "):
+                    client_full_name = _name
         if result.doc_id is not None:
             already = await conn.fetchrow(
                 "SELECT file_id, file_url FROM documents WHERE id = $1", result.doc_id
@@ -94,6 +108,8 @@ async def deliver_committed_to_crm(
             mime_type=mime_type,
             expiry_date=payload.get("expiry_date"),
             notes=payload.get("notes"),
+            sender_phone=sender_phone,
+            client_full_name=client_full_name,
         )
 
     crm_info: dict[str, Any] = {

--- a/apps/backend-rag/backend/services/intake/crm_push.py
+++ b/apps/backend-rag/backend/services/intake/crm_push.py
@@ -114,6 +114,69 @@ def _parse_drive_file_id(file_url: str | None) -> str | None:
     return m.group(1) if m else None
 
 
+async def _ensure_client_on_fly(
+    *,
+    crm_write_key: str,
+    sender_phone: str,
+    full_name: str | None,
+    base_url: str,
+) -> int | None:
+    """Resolve/create the Fly client for a WA sender phone, returning its FLY id.
+
+    The local Pro ``nuzantara_dev`` DB and the Fly ``nuzantara_rag`` DB do NOT
+    share a client_id namespace: leads minted locally by the wa-mirror sweeper
+    (id ≥ ~80k) have no row on Fly, so addressing the upload endpoint with the
+    LOCAL pk yields ``404 Client not found``. This calls the idempotent,
+    phone-keyed Fly upsert (``POST /api/crm/clients/upsert-by-phone``, scoped
+    ``X-CRM-Write-Key``) which returns the client's id ON FLY — the only id valid
+    against the upload endpoint. Only derived contact fields (normalized phone +
+    name) cross the boundary; no raw WhatsApp content (Law 2 — the upsert model's
+    own contract enforces this).
+
+    Returns the Fly client_id, or ``None`` if the upsert could not resolve/create
+    one (no phone, denied, unreachable). Never raises — delivery stays best-effort.
+    """
+    digits = re.sub(r"\D", "", sender_phone or "")
+    if not (6 <= len(digits) <= 20):
+        return None
+    body: dict[str, Any] = {
+        "phone_normalized": digits,
+        "create_if_missing": True,
+        "lead_source": "whatsapp_auto",
+    }
+    if full_name and full_name.strip():
+        body["full_name"] = full_name.strip()
+    url = f"{base_url}/api/crm/clients/upsert-by-phone"
+    headers = {"X-CRM-Write-Key": crm_write_key}
+    client = _get_client()
+    try:
+        resp = await client.post(url, json=body, headers=headers)
+    except (httpx.TimeoutException, httpx.TransportError) as exc:
+        logger.warning("intake.crm_push.upsert_unreachable phone=*** err=%s", type(exc).__name__)
+        return None
+    if resp.status_code >= 400:
+        logger.warning(
+            "intake.crm_push.upsert_failed status=%s detail=%s",
+            resp.status_code,
+            resp.text[:160],
+        )
+        return None
+    try:
+        data = resp.json()
+    except ValueError:
+        return None
+    fly_id = data.get("client_id") if isinstance(data, dict) else None
+    if fly_id is None:
+        return None
+    logger.info(
+        "intake.crm_push.upsert_ok fly_client=%s created=%s matched=%s",
+        fly_id,
+        (data.get("was_created") if isinstance(data, dict) else None),
+        (data.get("matched_count") if isinstance(data, dict) else None),
+    )
+    return int(fly_id)
+
+
 async def push_committed_document(
     *,
     bearer_token: str | None,
@@ -129,6 +192,8 @@ async def push_committed_document(
     notes: str | None = None,
     family_member_id: int | None = None,
     base_url: str | None = None,
+    sender_phone: str | None = None,
+    client_full_name: str | None = None,
 ) -> CrmPushResult:
     """Deliver one committed intake blob to the Fly CRM upload endpoint.
 
@@ -185,13 +250,21 @@ async def push_committed_document(
     payload.update({key: value for key, value in optional_fields.items() if value is not None})
 
     base = (base_url or _push_base_url()).rstrip("/")
-    if bearer_token:
-        url = f"{base}/api/crm/clients/{client_id}/documents/upload"
-        headers = {"Authorization": f"Bearer {bearer_token}"}
-    else:
-        url = f"{base}/api/crm/internal/clients/{client_id}/documents/upload"
-        headers = {"X-CRM-Write-Key": crm_write_key or ""}
+
+    def _build_request(cid: int) -> tuple[str, dict[str, str]]:
+        if bearer_token:
+            return (
+                f"{base}/api/crm/clients/{cid}/documents/upload",
+                {"Authorization": f"Bearer {bearer_token}"},
+            )
+        return (
+            f"{base}/api/crm/internal/clients/{cid}/documents/upload",
+            {"X-CRM-Write-Key": crm_write_key or ""},
+        )
+
+    url, headers = _build_request(client_id)
     client = _get_client()
+    upsert_tried = False
 
     try:
         last_detail: str | None = None
@@ -225,6 +298,34 @@ async def push_committed_document(
                     )
                     continue
                 return CrmPushResult(ok=False, status="server_error", detail=last_detail)
+            if resp.status_code == 404 and not upsert_tried and not bearer_token and crm_write_key and sender_phone:
+                # The LOCAL client_id has no row on Fly (wa-mirror lead minted only
+                # in nuzantara_dev). Phone-upsert it onto Fly, re-aim the upload at
+                # the RETURNED Fly id, and retry ONCE. This is the cross-DB identity
+                # bridge: never reuse the local pk against Fly.
+                upsert_tried = True
+                fly_cid = await _ensure_client_on_fly(
+                    crm_write_key=crm_write_key,
+                    sender_phone=sender_phone,
+                    full_name=client_full_name,
+                    base_url=base,
+                )
+                if fly_cid is not None and fly_cid != client_id:
+                    url, headers = _build_request(fly_cid)
+                    logger.info(
+                        "intake.crm_push.client_not_on_fly local=%s -> fly=%s — retrying upload",
+                        client_id,
+                        fly_cid,
+                    )
+                    if attempt == 0:
+                        continue
+                    # 404 on the SECOND attempt's slot — re-aimed but loop is done;
+                    # fall through to a clean rejected with the bridge note.
+                last_detail = (
+                    f"HTTP 404: {resp.text[:160]} "
+                    f"(phone-upsert {'mapped to fly=' + str(fly_cid) if fly_cid else 'failed'})"
+                )
+                return CrmPushResult(ok=False, status="rejected", detail=last_detail)
             if resp.status_code >= 400:
                 return CrmPushResult(
                     ok=False,

--- a/apps/backend-rag/backend/tests/services/intake/test_crm_push.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_crm_push.py
@@ -256,3 +256,109 @@ def test_parse_drive_file_id():
     assert crm_push._parse_drive_file_id(DRIVE_URL) == DRIVE_FILE_ID
     assert crm_push._parse_drive_file_id(None) is None
     assert crm_push._parse_drive_file_id("https://example.com/no-drive") is None
+
+
+# --------------------------------------------------------------------------- #
+# Cross-DB identity self-heal: local client_id absent on Fly -> phone-upsert.    #
+# GUILT (404 + service-key + phone -> upsert -> retry on Fly id) and INNOCENCE   #
+# (200 first try, or 404 with no phone) — the upsert must fire ONLY when needed. #
+# --------------------------------------------------------------------------- #
+FLY_CLIENT_ID = 4321
+
+
+async def test_404_phone_upsert_then_retry_succeeds(mock_client, blob):
+    """GUILT: a local pk (87262) that 404s on Fly is phone-upserted, and the
+    upload is re-aimed at the RETURNED Fly id and retried — and succeeds."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/upsert-by-phone"):
+            return httpx.Response(
+                200, json={"client_id": FLY_CLIENT_ID, "was_created": True, "matched_count": 0}
+            )
+        # upload endpoint: 404 for the local id, 200 for the Fly id
+        if f"/clients/{FLY_CLIENT_ID}/documents/upload" in path:
+            return httpx.Response(
+                200, json={"success": True, "document_id": 55, "file_url": DRIVE_URL}
+            )
+        return httpx.Response(404, json={"detail": "Client not found"})
+
+    requests = mock_client(handler)
+    result = await crm_push.push_committed_document(
+        **_push_kwargs(
+            blob,
+            bearer_token=None,
+            crm_write_key="service-key-abc",
+            client_id=87262,
+            sender_phone="+62 812-3456-7890",
+            client_full_name="Jane Doe",
+        )
+    )
+
+    assert result.ok is True
+    assert result.status == "pushed"
+    assert result.fly_doc_id == 55
+    paths = [r.url.path for r in requests]
+    # initial upload (local id, 404) -> upsert-by-phone -> retry upload (fly id)
+    assert paths[0] == "/api/crm/internal/clients/87262/documents/upload"
+    assert paths[1] == "/api/crm/clients/upsert-by-phone"
+    assert paths[2] == f"/api/crm/internal/clients/{FLY_CLIENT_ID}/documents/upload"
+    # the upsert body carries ONLY derived contact fields (Law 2), digits-only phone
+    upsert_body = json.loads(requests[1].content)
+    assert upsert_body["phone_normalized"] == "6281234567890"
+    assert upsert_body["full_name"] == "Jane Doe"
+    assert upsert_body["create_if_missing"] is True
+    assert "file" not in upsert_body  # never the document blob
+
+
+async def test_200_first_try_never_upserts(mock_client, blob):
+    """INNOCENCE: a clean 200 must NOT trigger any phone-upsert call."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert not request.url.path.endswith("/upsert-by-phone"), "must not upsert on success"
+        return httpx.Response(
+            200, json={"success": True, "document_id": 7, "file_url": DRIVE_URL}
+        )
+
+    requests = mock_client(handler)
+    result = await crm_push.push_committed_document(
+        **_push_kwargs(
+            blob,
+            bearer_token=None,
+            crm_write_key="service-key-abc",
+            sender_phone="+62 812-3456-7890",
+        )
+    )
+    assert result.ok is True
+    assert len(requests) == 1
+    assert requests[0].url.path.endswith("/documents/upload")
+
+
+async def test_404_without_phone_does_not_upsert(mock_client, blob):
+    """INNOCENCE: a 404 with NO sender_phone cannot self-heal — stays rejected,
+    and never calls upsert (no phone to key on)."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert not request.url.path.endswith("/upsert-by-phone")
+        return httpx.Response(404, json={"detail": "Client not found"})
+
+    requests = mock_client(handler)
+    result = await crm_push.push_committed_document(
+        **_push_kwargs(blob, bearer_token=None, crm_write_key="service-key-abc")
+    )
+    assert result.ok is False
+    assert result.status == "rejected"
+    assert len(requests) == 1  # just the failed upload, no upsert
+
+
+async def test_404_with_bearer_token_does_not_upsert(mock_client, blob):
+    """INNOCENCE: reviewer-JWT path is human-driven against Fly directly — the
+    cross-DB bridge is service-key-only, so a JWT 404 must NOT upsert."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert not request.url.path.endswith("/upsert-by-phone")
+        return httpx.Response(404, json={"detail": "Client not found"})
+
+    requests = mock_client(handler)
+    result = await crm_push.push_committed_document(
+        **_push_kwargs(blob, sender_phone="+62 812-3456-7890")  # keeps bearer_token
+    )
+    assert result.ok is False
+    assert result.status == "rejected"
+    assert len(requests) == 1


### PR DESCRIPTION
## Problem

The intake auto-attach (#1751) delivers documents to kita via `crm_push` → Fly upload endpoint, using the **local** `client_id` as the path id. But the sovereign-local worker DB (`nuzantara_dev` on the Pro) and Fly's `nuzantara_rag` do **not** share a client_id namespace:

- Fly's max client id is **~12k**; wa-mirror leads minted locally are **id ≥ ~80k** and have **zero** rows on Fly.
- Delivery for those leads 404s with `Client not found` — the document never reaches kita, while the local commit reports `auto_routed`. **Stale-state, cicatrix #2.**

Discovered live: a supervised re-route of 1 WhatsApp doc (client 87262) committed locally but `crm_delivery.failed status=rejected HTTP 404`. Rolled back. An audit of all ~220 LaunchAgents found this is the **only** automation with the cross-DB id-reuse bug (others stay single-DB or resolve by phone).

Split of the 584 true auto-attach candidates: **390** point to legacy ids <12k (deliver OK), **194** (45 distinct clients) point to local-only 87xxx leads (404 today).

## Fix

On a 404 from the **scoped service-key** upload, phone-upsert the client onto Fly via the existing idempotent `POST /api/crm/clients/upsert-by-phone`, re-aim the upload at the **returned Fly id**, retry once. The local pk is never reused against Fly.

- **Law 2**: only derived contact fields (normalized phone + non-placeholder name) cross — the upsert model's own contract forbids raw WhatsApp content. Worker stays local-sovereign; nothing about PII processing moves to Fly.
- **Human-review path untouched**: bridge is service-key-only (bearer-JWT 404s do not upsert).
- Covers both delivery callers (auto-attach + review approve) — phone/name sourced inside `crm_delivery` from the queue row.

## Tests

`test_crm_push.py`: 1 guilt (404→upsert→retry succeeds; upsert body is contact-only, never the blob) + 3 innocence (200 never upserts · 404 w/o phone stays rejected · JWT never upserts). **17/17 crm_push + 21/21 auto_attach pass.** Import chain OK.

## NOT in this PR / deferred

- The 2 auto-attach killswitches remain **OFF** (re-disabled during the live test). Arming them is a separate supervised step AFTER this delivery fix is on Fly.
- The 45 existing local-only leads will self-heal on their next delivery attempt once the killswitch is armed (no separate backfill needed — the upsert is idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)