### PR TITLE
🎨 Palette: Accessible and Localized Recording Overlay

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -54,3 +54,7 @@
 ## 2026-06-16 - [Safe Exit Animations for Streaming UI]
 **Learning:** Exit animations in streaming interfaces (e.g., transitions from a 'thinking' state to a 'response' state) can feel abrupt if elements simply disappear. Wrapping conditional status indicators in `AnimatePresence` ensures a smooth visual handoff. However, avoid implementing live timers with `aria-live="polite"` as it creates excessive screen reader noise; prioritize silent visual progress for frequent updates.
 **Action:** Always use `AnimatePresence` for smooth transitions between streaming states. Avoid frequent `aria-live` updates for rapidly changing values like timers.
+
+## 2026-06-17 - [Accessible and Localized Status Overlays]
+**Learning:** Real-time status indicators that appear as overlays (e.g., voice recording) require `role="status"` and `aria-live="polite"` to be announced by screen readers without interrupting flow. They should also include a visually hidden (`sr-only`) label describing the active state to provide immediate context upon appearance.
+**Action:** Apply `role="status"` and `aria-live="polite"` to ephemeral status overlays. Ensure they contain localized `sr-only` labels for the state and localized instruction text for the user.

--- a/apps/mouth/src/components/chat/ChatRecordingOverlay.test.tsx
+++ b/apps/mouth/src/components/chat/ChatRecordingOverlay.test.tsx
@@ -1,9 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import {
   ChatRecordingOverlay,
   ChatRecordingOverlayProps,
 } from "./ChatRecordingOverlay";
+
+// Mock useChatLocale to return 'en' by default
+vi.mock("@/hooks/useChatLocale", () => ({
+  useChatLocale: vi.fn(() => "en"),
+}));
 
 describe("ChatRecordingOverlay", () => {
   const defaultProps: ChatRecordingOverlayProps = {
@@ -22,6 +27,29 @@ describe("ChatRecordingOverlay", () => {
     it("should render when recording", () => {
       render(<ChatRecordingOverlay {...defaultProps} isRecording={true} />);
       expect(screen.getByText("Release to send")).toBeInTheDocument();
+    });
+  });
+
+  describe("A11y and Localization", () => {
+    it("should have role='status' and aria-live='polite'", () => {
+      render(<ChatRecordingOverlay {...defaultProps} isRecording={true} />);
+      const status = screen.getByRole("status");
+      expect(status).toBeInTheDocument();
+      expect(status).toHaveAttribute("aria-live", "polite");
+    });
+
+    it("should have a screen reader only recording label", () => {
+      render(<ChatRecordingOverlay {...defaultProps} isRecording={true} />);
+      expect(screen.getByText("Recording")).toBeInTheDocument();
+      expect(screen.getByText("Recording")).toHaveClass("sr-only");
+    });
+
+    it("should have aria-hidden='true' on the pulsing dot", () => {
+      const { container } = render(
+        <ChatRecordingOverlay {...defaultProps} isRecording={true} />,
+      );
+      const dot = container.querySelector(".bg-red-500");
+      expect(dot).toHaveAttribute("aria-hidden", "true");
     });
   });
 

--- a/apps/mouth/src/components/chat/ChatRecordingOverlay.tsx
+++ b/apps/mouth/src/components/chat/ChatRecordingOverlay.tsx
@@ -1,7 +1,34 @@
+"use client";
+
+import { useChatLocale } from "@/hooks/useChatLocale";
+
 export interface ChatRecordingOverlayProps {
   isRecording: boolean;
   recordingTime: number;
 }
+
+const LABELS = {
+  en: {
+    recording: "Recording",
+    release: "Release to send",
+  },
+  it: {
+    recording: "Registrazione",
+    release: "Rilascia per inviare",
+  },
+  id: {
+    recording: "Merekam",
+    release: "Lepas untuk mengirim",
+  },
+  fr: {
+    recording: "Enregistrement",
+    release: "Relâcher pour envoyer",
+  },
+  ru: {
+    recording: "Запись",
+    release: "Отпустите, чтобы отправить",
+  },
+} as const;
 
 function formatTime(seconds: number): string {
   const mins = Math.floor(seconds / 60);
@@ -13,15 +40,26 @@ export function ChatRecordingOverlay({
   isRecording,
   recordingTime,
 }: ChatRecordingOverlayProps) {
+  const locale = useChatLocale();
+  const L = LABELS[locale as keyof typeof LABELS] || LABELS.en;
+
   if (!isRecording) {
     return null;
   }
 
   return (
-    <div className="absolute left-1/2 -translate-x-1/2 top-[-40px] bg-black/80 text-white px-3 py-1 rounded-full text-xs font-mono flex items-center gap-2 animate-in fade-in slide-in-from-bottom-2">
-      <span className="w-2 h-2 rounded-full bg-red-500 animate-pulse" />
+    <div
+      role="status"
+      aria-live="polite"
+      className="absolute left-1/2 -translate-x-1/2 top-[-40px] bg-black/80 text-white px-3 py-1 rounded-full text-xs font-mono flex items-center gap-2 animate-in fade-in slide-in-from-bottom-2"
+    >
+      <span className="sr-only">{L.recording}</span>
+      <span
+        className="w-2 h-2 rounded-full bg-red-500 animate-pulse"
+        aria-hidden="true"
+      />
       {formatTime(recordingTime)}
-      <span className="ml-2 opacity-50 text-[10px]">Release to send</span>
+      <span className="ml-2 opacity-50 text-[10px]">{L.release}</span>
     </div>
   );
 }


### PR DESCRIPTION
💡 **What:** Enhanced the `ChatRecordingOverlay` component with proper ARIA attributes and multi-language support.
🎯 **Why:** To ensure the voice recording state is programmatically announced to assistive technology and accessible to users across the five supported locales (EN, IT, ID, FR, RU).
♿ **Accessibility:** 
- Added `role="status"` and `aria-live="polite"` to the overlay container.
- Included a visually hidden `<span>` with a localized "Recording" label.
- Marked the pulsing red dot as `aria-hidden="true"` since it's purely decorative.
- Localized the "Release to send" instruction text.

---
*PR created automatically by Jules for task [12565694623683368583](https://jules.google.com/task/12565694623683368583) started by @Balizero1987*