### PR TITLE
fix(organism): suppress infra.ollama_pro launchd-exit false-positive

### DIFF
--- a/scripts/organism_stale_detector.py
+++ b/scripts/organism_stale_detector.py
@@ -60,6 +60,12 @@ UNHEALTHY_STATUSES: frozenset[str] = frozenset({"failed", "fail", "degraded", "e
 #   - wr3.reflexion_weekly : launchctl-disabled on purpose (the dead twin of wr2's)
 #   - pro.agent_library_evolver_* : intentionally disabled (deploy-drift quarantine)
 #   - pro.audit_launchd_daily : exit 1 BY DESIGN = "N unhealthy jobs found" (a true report)
+#   - infra.ollama_pro : launchd job exits 1 because the real `ollama serve` already
+#       owns :11434 (port collision, two program paths) — the daemon is ALIVE and serving
+#       (6 models on :11434). The bridge reads the launchd exit code, not the live socket.
+#       (Live triage 2026-06-28. NOTE: pro.curiosity_weekly was triaged the same day as a
+#       REAL failure — W84 TCC-dead on ~/Desktop — and is deliberately NOT suppressed here:
+#       it must stay visible as an operator-boundary finding, not be hidden.)
 # The bridge tags all of these "failed" because it has no `disabled`/`expected_exit`
 # concept (HEALTHY_EXIT_CODES={0}). Curing the bridge is a separate hot-zone PR;
 # this allow-list is the safe downstream filter. Audit this list when an organ is
@@ -74,6 +80,7 @@ KNOWN_BENIGN_FAILED: frozenset[str] = frozenset({
     "pro.agent_library_evolver_daily",
     "pro.agent_library_evolver_weekly",
     "pro.audit_launchd_daily",
+    "infra.ollama_pro",
 })
 
 

--- a/scripts/tests/test_organism_stale_detector.py
+++ b/scripts/tests/test_organism_stale_detector.py
@@ -184,3 +184,22 @@ def test_allow_list_is_documented_not_empty():
     assert isinstance(KNOWN_BENIGN_FAILED, (set, frozenset, tuple))
     assert len(KNOWN_BENIGN_FAILED) >= 6
     assert "codex.spark_loop" in KNOWN_BENIGN_FAILED
+
+
+def test_ollama_pro_program_path_collision_suppressed(tmp_path):
+    """INNOCENCE: infra.ollama_pro reports failed (launchd exit 1) while the daemon
+    is actually alive — the launchd job binds the same :11434 the real `ollama serve`
+    already owns, so it exits 1 and keepalive re-spawns forever. The bridge tags it
+    'failed' from the launchd exit code, but the organ breathes (6 models served on
+    :11434). This is the same family as the other bridge false-positives: a non-zero
+    launchd exit that does NOT mean the organ is dead. (Live triage 2026-06-28.)
+    """
+    d = str(tmp_path)
+    _write(
+        d,
+        "infra.ollama_pro",
+        {"ts": time.time(), "status": "failed", "last_error": "daemon not running"},
+    )
+    findings = scan_sidecars_status(d, now=time.time())
+    flagged = {f.organ_id for f in findings if f.kind == "unhealthy"}
+    assert "infra.ollama_pro" not in flagged, f"ollama false-positive not suppressed: {flagged}"


### PR DESCRIPTION
## What

Live triage (2026-06-28) of the freshly-merged status-aware detector (#1808) found `infra.ollama_pro` flagged as **breathing but status=failed** — a false positive.

## Why it's a false positive (grounded on Pro, this turn)

- The Ollama daemon is **alive and serving 6 models** on `:11434` (`qwen3.5:9b`, `qwen2.5vl:7b`, `bge-m3`, `SEA-LION-32B`, `glm-ocr`, `qwen3-vl:8b`) — pid 1884, up >9h, `curl /api/tags` answers.
- The `homebrew.mxcl.ollama` launchd job exits 1 because it tries to bind the same `:11434` the real `ollama serve` (a **different program path**) already owns → keepalive re-spawns forever.
- `launchagent-state-bridge` reads the launchd exit code, not the live socket → tags `failed`.

Same family as the other `KNOWN_BENIGN_FAILED` entries: a non-zero launchd exit that does **not** mean the organ is dead. The real cure (give the bridge a `disabled`/`expected_exit` concept) is a separate hot-zone PR; this allow-list is the safe downstream filter.

## Deliberately NOT suppressed

`pro.curiosity_weekly` was triaged the same turn as a **REAL** failure — W84 TCC-dead on `~/Desktop` (`source .venv/bin/activate` → `operation not permitted` → exit 127). It stays **visible** as an operator-boundary finding, not hidden.

## Test

`test_ollama_pro_program_path_collision_suppressed` (RED→GREEN). Full suite **15/15**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)