### PR TITLE
ci(pip-audit): ignore GHSA-537c-gmf6-5ccf (cryptography capped by presidio<47)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,8 @@ jobs:
             --ignore-vuln CVE-2026-41488 \
             --ignore-vuln PYSEC-2025-217 \
             --ignore-vuln GHSA-8jfx-5878-hv4v \
-            --ignore-vuln CVE-2025-3000
+            --ignore-vuln CVE-2025-3000 \
+            --ignore-vuln GHSA-537c-gmf6-5ccf
 
       - name: Mypy type check (core + models)
         run: |

--- a/apps/backend-rag/.pip-audit-ignore.md
+++ b/apps/backend-rag/.pip-audit-ignore.md
@@ -225,3 +225,54 @@ pip-audit --strict --requirement requirements.txt
 ```
 
 When pip-audit shows a Fix Version for CVE-2025-3000, bump torch and drop `--ignore-vuln CVE-2025-3000` from `.github/workflows/tests.yml`.
+
+---
+
+## GHSA-537c-gmf6-5ccf — cryptography 46.0.7 (vulnerable static OpenSSL in wheels)
+
+**Package:** `cryptography` (transitive — resolved to 46.0.7)
+**Fix version:** `48.0.1`
+**Ignored:** 2026-06-29
+
+**Summary:** pyca/cryptography wheels < 48.0.1 statically link an OpenSSL build affected by the
+OpenSSL security advisory of 2026-06-09 (https://openssl-library.org/news/secadv/20260609.txt).
+
+**Why we cannot bump to 48.0.1:**
+
+`presidio-anonymizer==2.2.363` (the latest published version, core to our PII-anonymization layer —
+SYMBIOSIS Law 2) hard-caps `cryptography>=46.0.4,<47.0.0`. Verified:
+
+```bash
+curl -s https://pypi.org/pypi/presidio-anonymizer/2.2.363/json \
+  | python3 -c "import sys,json; print([r for r in json.load(sys.stdin)['info']['requires_dist'] if 'cryptography' in r.lower()])"
+# ['cryptography<47.0.0,>=46.0.4']
+```
+
+No presidio-anonymizer release allows cryptography >= 47, so the dependency resolver pins 46.0.7.
+Bumping cryptography directly produces an unsatisfiable resolve; removing presidio is an
+architectural change far out of proportion to a non-applicable advisory.
+
+**Why not applicable to this codepath:**
+
+Every CVE in the 2026-06-09 OpenSSL advisory was reviewed (CVE-2026-45447, -34182, -34183, -35188,
+-42764, -45445, -7383, -9076, -34180, -34181, -42765..42771, -45446). **None is exploitable through
+standard TLS client/server use** — they live in PKCS#7/CMS/S-MIME, QUIC, CMP, AES-OCB/SIV, or behind
+flags disabled by default (OCSP stapling, partial-chain). `apps/backend-rag/` uses `cryptography`
+only for (a) standard TLS via httpx/urllib3 and (b) JWT signing/verification via `python-jose[cryptography]`.
+It never touches PKCS#7, CMS, S/MIME, QUIC, CMP, or OCSP stapling. The advisory's attack surface
+does not exist in this codebase.
+
+**Re-evaluate when:**
+
+- `presidio-anonymizer` publishes a release allowing `cryptography>=48.0.1` (then bump + drop this ignore)
+- `apps/backend-rag/` adds any PKCS#7 / CMS / S/MIME / QUIC / CMP / OCSP-stapling codepath
+
+**How to re-check:**
+
+```bash
+cd apps/backend-rag
+pip-audit --strict --requirement requirements.txt
+```
+
+When pip-audit shows cryptography resolved at >= 48.0.1, drop `--ignore-vuln GHSA-537c-gmf6-5ccf`
+from `.github/workflows/tests.yml`.


### PR DESCRIPTION
## Why

`pip-audit` (the **required** `Backend Tests (Python)` check) flags `cryptography 46.0.7` against the 2026-06-09 OpenSSL advisory **GHSA-537c-gmf6-5ccf** (fixed in 48.0.1). The advisory landed after the pin, so it blocks **every** PR repo-wide with no code change.

## Why not just bump cryptography

Not resolvable: **`presidio-anonymizer==2.2.363`** (latest published, core to PII-anonymization / SYMBIOSIS Law 2) hard-caps `cryptography>=46.0.4,<47.0.0`. No presidio release allows ≥47, so the resolver pins 46.0.7. Removing presidio is a disproportionate architectural change.

## Why ignoring is safe (security review)

Reviewed **every** CVE in the 2026-06-09 OpenSSL advisory (CVE-2026-45447, -34182, -34183, -35188, -42764, -45445, -7383, -9076, -34180/1, -42765..42771, -45446). **None is exploitable through standard TLS** — all live in PKCS#7 / CMS / S-MIME / QUIC / CMP / AES-OCB-SIV, or behind default-off flags (OCSP stapling, partial-chain).

`apps/backend-rag/` uses `cryptography` only for **standard TLS** (httpx/urllib3) and **JWT** (`python-jose[cryptography]`). It never touches PKCS#7/CMS/S-MIME/QUIC/CMP/OCSP-stapling. The attack surface does not exist here.

## What

- `--ignore-vuln GHSA-537c-gmf6-5ccf` in `tests.yml` (same mechanism already used for transformers/fastmcp).
- Full rationale + re-evaluate trigger documented in `apps/backend-rag/.pip-audit-ignore.md` (drop the ignore when presidio allows cryptography ≥48.0.1).

Unblocks the merge queue. No application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)