### PR TITLE
fix(intake): name-concordance + anti-funnel guards in direct-phone gate (re-land orphaned by #1824 squash)

### DIFF
--- a/apps/backend-rag/backend/services/intake/auto_attach.py
+++ b/apps/backend-rag/backend/services/intake/auto_attach.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from typing import Any
 
 import asyncpg
@@ -169,6 +170,65 @@ def _has_subject_mismatch(reason: Any) -> bool:
     return isinstance(reason, dict) and bool(reason.get("sender_subject_mismatch"))
 
 
+# Volumetric anti-funnel thresholds: a single sender phone that has produced many
+# documents spanning many distinct doc types is a TRANSIT/AGENCY funnel (one phone
+# forwarding for many people), NOT a single client. Lived example: a phone with 51
+# documents across 8 doc types resolving to one client_id. Auto-attaching those
+# mis-attributes N people's PII to 1 client. Defaults overridable via env.
+_FUNNEL_MIN_DOCS = int(os.getenv("INTAKE_FUNNEL_MIN_DOCS", "8") or "8")
+_FUNNEL_MIN_DISTINCT_TYPES = int(os.getenv("INTAKE_FUNNEL_MIN_DISTINCT_TYPES", "5") or "5")
+
+# Names below this token-overlap ratio are treated as NOT the same person.
+_NAME_MATCH_MIN_RATIO = float(os.getenv("INTAKE_NAME_MATCH_MIN_RATIO", "0.5") or "0.5")
+
+_NAME_NOISE = re.compile(r"[^a-z0-9\s]+")
+
+
+def _name_tokens(value: object) -> frozenset[str]:
+    """Lowercased word-token set of a person name (diacritics/punct stripped).
+
+    Returns tokens of length >= 2 so single-letter initials don't create false
+    overlaps. Used for order-insensitive name comparison (Indonesian names and
+    passport MRZ frequently reorder given/family parts).
+    """
+    if not value:
+        return frozenset()
+    text = _NAME_NOISE.sub(" ", str(value).strip().lower())
+    return frozenset(t for t in text.split() if len(t) >= 2)
+
+
+def _extracted_subject_name(stage_output: Any) -> str | None:
+    """Pull the OCR-extracted subject name from a queue row's ``stage_output``.
+
+    Path: ``stage_output.extract.fields.name`` (present for passport / kitas /
+    birth_certificate; absent for ktp / bank_statement / payment_receipt). Returns
+    None when missing — the gate then abstains because the subject is unverifiable.
+    """
+    so = intake_writer._as_dict(stage_output)
+    if not so:
+        return None
+    fields = intake_writer._as_dict((intake_writer._as_dict(so.get("extract")) or {}).get("fields"))
+    name = fields.get("name") if fields else None
+    return str(name).strip() if name and str(name).strip() else None
+
+
+def _name_concordant(extracted_name: object, client_name: object) -> tuple[bool, float]:
+    """True when the document's subject name plausibly matches the client name.
+
+    Order-insensitive token overlap (Jaccard-ish, normalized by the SMALLER set so
+    a short CRM name still matches a longer full passport name). Returns
+    (is_match, ratio). Empty either side → (False, 0.0): we cannot verify the
+    subject, so we must NOT auto-attach.
+    """
+    a = _name_tokens(extracted_name)
+    b = _name_tokens(client_name)
+    if not a or not b:
+        return (False, 0.0)
+    overlap = len(a & b)
+    ratio = overlap / min(len(a), len(b))
+    return (ratio >= _NAME_MATCH_MIN_RATIO, ratio)
+
+
 async def evaluate_direct_phone_concordance(
     conn: asyncpg.Connection,
     *,
@@ -178,6 +238,7 @@ async def evaluate_direct_phone_concordance(
     sender_phone: str | None,
     source_context: dict[str, Any] | None,
     reason: Any,
+    extracted_name: str | None = None,
 ) -> dict[str, Any]:
     """Gate direct-chat phone-only proposals before autonomous cataloging.
 
@@ -270,9 +331,68 @@ async def evaluate_direct_phone_concordance(
             "phone_match_count": 1,
         }
 
+    # Anti-funnel volumetric guard. A sender phone that has produced many docs of
+    # many distinct types is a transit/agency funnel forwarding for many people,
+    # not a single client — even though it "resolves to one client_id". Keep these
+    # in human review so N people's PII is not collapsed onto 1 client.
+    funnel = await conn.fetchrow(
+        """
+        SELECT count(*) AS docs,
+               count(DISTINCT p.routing->>'doc_type') AS distinct_types
+        FROM document_routing_proposal p
+        JOIN intake_queue q ON q.id = p.queue_id
+        WHERE q.sender_phone IS NOT NULL
+          AND regexp_replace(q.sender_phone, '[^0-9]', '', 'g')
+              = regexp_replace($1, '[^0-9]', '', 'g')
+          AND p.entity_resolution->>'decision' = 'LINK_CANDIDATE'
+        """,
+        sender_phone or "",
+    )
+    if funnel is not None and (
+        funnel["docs"] >= _FUNNEL_MIN_DOCS
+        and funnel["distinct_types"] >= _FUNNEL_MIN_DISTINCT_TYPES
+    ):
+        return {
+            "concordant": False,
+            "reason": (
+                f"sender phone is a funnel/transit: {funnel['docs']} docs across "
+                f"{funnel['distinct_types']} doc types (not a single client)"
+            ),
+            "phone_client_id": phone_client_id,
+            "phone_match_count": 1,
+        }
+
+    # Name-concordance — "the phone proposes, the document content disposes".
+    # The phone tells you the LATTER; the name extracted from the document tells
+    # you the SUBJECT. Auto-attach only when both agree. If the document carries
+    # no extractable name (ktp/bank_statement/payment_receipt) we cannot verify
+    # the subject → abstain to review. This is the structural cure for the
+    # operator-/funnel-forwarding mis-attribution class.
+    client_name = await conn.fetchval(
+        "SELECT full_name FROM clients WHERE id = $1 AND deleted_at IS NULL",
+        phone_client_id,
+    )
+    name_ok, ratio = _name_concordant(extracted_name, client_name)
+    if not name_ok:
+        if not _name_tokens(extracted_name):
+            why = "document carries no extractable subject name"
+        elif not _name_tokens(client_name):
+            why = "resolved client has no name to verify against"
+        else:
+            why = f"document subject name does not match client (overlap {ratio:.2f})"
+        return {
+            "concordant": False,
+            "reason": f"name not concordant: {why}",
+            "phone_client_id": phone_client_id,
+            "phone_match_count": 1,
+        }
+
     return {
         "concordant": True,
-        "reason": "direct WA sender phone resolves to the same single routed client",
+        "reason": (
+            "direct WA sender phone resolves to the same single routed client "
+            f"and document subject name matches (overlap {ratio:.2f})"
+        ),
         "phone_client_id": phone_client_id,
         "phone_match_count": 1,
     }
@@ -426,7 +546,7 @@ async def try_direct_phone_auto_attach(
                 """
                 SELECT p.id, p.queue_id, p.doc_index, p.pipeline_version, p.status,
                        p.entity_resolution, p.routing, p.commit_gate,
-                       q.sender_phone, q.source_context
+                       q.sender_phone, q.source_context, q.stage_output
                 FROM document_routing_proposal p
                 JOIN intake_queue q ON q.id = p.queue_id
                 WHERE p.id = $1
@@ -457,6 +577,7 @@ async def try_direct_phone_auto_attach(
                 sender_phone=sender_phone or locked["sender_phone"],
                 source_context=locked_context,
                 reason=entity_resolution.get("reason"),
+                extracted_name=_extracted_subject_name(locked["stage_output"]),
             )
             if not verdict["concordant"]:
                 logger.info(

--- a/apps/backend-rag/backend/tests/services/intake/test_intake_auto_attach.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_intake_auto_attach.py
@@ -22,7 +22,24 @@ from backend.services.intake import auto_attach
 
 
 class _StubConn:
-    """Minimal stand-in; evaluate_concordance only passes it to the patched matcher."""
+    """Minimal stand-in for the direct-phone gate's own DB lookups.
+
+    ``evaluate_concordance`` (strict gate) never queries through it. The
+    direct-phone gate now runs two reads: an anti-funnel volume ``fetchrow`` and a
+    client-name ``fetchval``. Defaults are the benign case (low volume + a client
+    name); tests override per case.
+    """
+
+    def __init__(self, *, funnel=None, client_name="Maria Garcia"):
+        # benign default: 1 doc / 1 doctype (not a funnel)
+        self._funnel = funnel if funnel is not None else {"docs": 1, "distinct_types": 1}
+        self._client_name = client_name
+
+    async def fetchrow(self, _query, *_args):
+        return self._funnel
+
+    async def fetchval(self, _query, *_args):
+        return self._client_name
 
 
 def _patch_phone(monkeypatch, matches):
@@ -160,19 +177,76 @@ _DIRECT_SOURCE_CONTEXT = {
 
 @pytest.mark.asyncio
 async def test_guilt_direct_phone_link_candidate_is_concordant(monkeypatch):
-    _patch_phone(monkeypatch, [{"id": 42, "full_name": "X"}])
+    _patch_phone(monkeypatch, [{"id": 42, "full_name": "Maria Garcia"}])
     v = await auto_attach.evaluate_direct_phone_concordance(
-        _StubConn(),
+        _StubConn(client_name="Maria Garcia"),
         decision="LINK_CANDIDATE",
         client_id=42,
         doc_type="passport",
         sender_phone="0812...",
         source_context=_DIRECT_SOURCE_CONTEXT,
         reason={"reason": "sender phone match (no strong identifier, no fuzzy name >= 0.40)"},
+        extracted_name="MARIA GARCIA LOPEZ",  # OCR subject name agrees with client
     )
     assert v["concordant"] is True
     assert v["phone_client_id"] == 42
     assert v["phone_match_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_innocence_direct_phone_name_mismatch_abstains(monkeypatch):
+    """The lived incident: phone resolves a client but the document's OCR subject
+    name is a DIFFERENT person (operator forwarded a client's doc) → abstain."""
+    _patch_phone(monkeypatch, [{"id": 42, "full_name": "Ari Firda"}])
+    v = await auto_attach.evaluate_direct_phone_concordance(
+        _StubConn(client_name="Ari Firda"),
+        decision="LINK_CANDIDATE",
+        client_id=42,
+        doc_type="birth_certificate",
+        sender_phone="0812...",
+        source_context=_DIRECT_SOURCE_CONTEXT,
+        reason={"reason": "sender phone match"},
+        extracted_name="JUAN CARLOS FERNANDEZ",  # the Spanish client, not Ari
+    )
+    assert v["concordant"] is False
+    assert "name not concordant" in v["reason"]
+
+
+@pytest.mark.asyncio
+async def test_innocence_direct_phone_no_extractable_name_abstains(monkeypatch):
+    """doc with no subject name (ktp/bank_statement) cannot be verified → abstain."""
+    _patch_phone(monkeypatch, [{"id": 42, "full_name": "Maria Garcia"}])
+    v = await auto_attach.evaluate_direct_phone_concordance(
+        _StubConn(client_name="Maria Garcia"),
+        decision="LINK_CANDIDATE",
+        client_id=42,
+        doc_type="bank_statement",
+        sender_phone="0812...",
+        source_context=_DIRECT_SOURCE_CONTEXT,
+        reason={"reason": "sender phone match"},
+        extracted_name=None,  # nothing to verify the subject
+    )
+    assert v["concordant"] is False
+    assert "no extractable subject name" in v["reason"]
+
+
+@pytest.mark.asyncio
+async def test_innocence_direct_phone_funnel_abstains(monkeypatch):
+    """high-volume funnel phone (one number forwarding for many clients) → abstain
+    even though it resolves to one client_id and the name agrees."""
+    _patch_phone(monkeypatch, [{"id": 42, "full_name": "Maria Garcia"}])
+    v = await auto_attach.evaluate_direct_phone_concordance(
+        _StubConn(funnel={"docs": 51, "distinct_types": 8}, client_name="Maria Garcia"),
+        decision="LINK_CANDIDATE",
+        client_id=42,
+        doc_type="passport",
+        sender_phone="0812...",
+        source_context=_DIRECT_SOURCE_CONTEXT,
+        reason={"reason": "sender phone match"},
+        extracted_name="MARIA GARCIA",
+    )
+    assert v["concordant"] is False
+    assert "funnel/transit" in v["reason"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Re-land of an orphaned commit.** PR #1824 squash-merged only its first commit (`fc4ac55` — internal-sender suppression in the sweeper). The second commit (the downstream gate guards) was pushed to the branch *after* auto-merge fired, so it never reached main. This PR cherry-picks that lost commit onto fresh `main` — single commit, only the 2 intake files, **no regressions** (the stale branch had picked up unrelated reverts that this avoids).

## What it adds — downstream guards in `evaluate_direct_phone_concordance`

The wide direct-phone gate previously trusted only "phone → exactly 1 client == routed client". Two leaks remained after the upstream sweeper fix:
- **Operator/forwarder (general case)**: a phone resolves to client A but the document subject is B (lived incident: a Spanish client's birth cert auto-attached to operator "Ari Firda" who forwarded it).
- **Funnel/agency**: one phone forwards docs for many people, all collapsing onto one `client_id`.

Cure — **"the phone proposes, the document content disposes"**:
- **Name-concordance**: auto-attach only when the OCR subject name (`stage_output.extract.fields.name`) matches the resolved client's full name (order-insensitive token overlap ≥ ratio). No extractable subject name (ktp / bank_statement / payment_receipt) → abstain to human review.
- **Anti-funnel volumetric**: a sender phone with ≥8 docs across ≥5 distinct doc types is treated as transit/agency → abstain. All thresholds env-overridable.

## Tests
`backend/tests/services/intake/test_intake_auto_attach.py` — 24/24 pass (re-run fresh in worktree). Import OK, ruff clean.

## Net effect
The wide gate becomes much more conservative: only name-bearing docs whose subject matches the resolved client auto-attach; everything ambiguous stays in human review. Both `INTAKE_AUTO_ATTACH_ENABLED` and `INTAKE_DIRECT_PHONE_AUTO_ATTACH_ENABLED` stay **OFF** — this is the prerequisite guard set before arming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)