### PR TITLE
fix(wr2): designer-loop sank clean slides + cheap-lever no-ops (5-day WR2 outage)

### DIFF
--- a/apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py
@@ -560,6 +560,115 @@ async def test_designer_loop_converges_default_no_vision(monkeypatch):
     assert res.converged is True
 
 
+def _tiny_png_writer():
+    """A render_fn that writes a 1x1 PNG (the tests only need a file to exist)."""
+    import base64
+
+    async def render_fn(slide, png_path):
+        png_path.parent.mkdir(parents=True, exist_ok=True)
+        png_path.write_bytes(
+            base64.b64decode(
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+            )
+        )
+
+    return render_fn
+
+
+class _GeoFailInkAtEdge:
+    """Geometry NEVER passes and ALWAYS proposes the same ineffective lever —
+    exactly the slide-8 signature (ink at bottom edge, body shrink no-op)."""
+    passed = False
+    issues = ["ink at bottom edge (ratio=0.50) — possible text overflow"]
+    levers = [{"lever": "shrink_font", "target": "body", "reason": "bottom overflow"}]
+    score = 0.0
+    tier = "geometry"
+
+
+class _CheapPass:
+    passed = True
+    levers: list = []
+    score = 1.0
+    issues: list = []
+    tier = "mock"
+
+
+@pytest.mark.asyncio
+async def test_designer_loop_cheap_noop_escalates_to_vision_not_failed(monkeypatch):
+    """BUGFIX 2026-06-29 (Bug B): a cheap geometry lever that NEVER moves the
+    verdict (shrink_font body for `ink at bottom edge` when the bottom ink is the
+    LOGO, not the body) must NOT spin to max_iters → render_failed. It must defer
+    the verdict to the WHOLE-SLIDE vision critic (which can see body/footer
+    overflow), NOT blind-accept on legibility+headline-OCR (codex refuter
+    REFUTED that variant: OCR only checks the headline, body could be clipped).
+
+    Here the vision critic PASSES → the slide converges (vision saw the whole
+    slide and approved). Repro of the killer: drafts 8e582ce0 / d2d308bf /
+    9b923976 all died on slide 8 with ink-at-edge 0.50 constant, shrink_body
+    1→2→3, legibility PASS + OCR 1.0, then render_failed (critiques=[]). ~5 days
+    zero WR2 output — the cheap path never reached vision at all.
+    """
+    from wr2_html_renderer import designer_loop as dl
+
+    class _VisionPass:
+        passed = True
+        issues: list = []
+        levers: list = []
+        readable = True
+        tier = "vision"
+
+    vision_calls = {"n": 0}
+
+    def _vision(*a, **k):
+        vision_calls["n"] += 1
+        return _VisionPass()
+
+    monkeypatch.setattr(dl, "critic_geometry", lambda *a, **k: _GeoFailInkAtEdge())
+    monkeypatch.setattr(dl, "critic_legibility", lambda *a, **k: _CheapPass())
+    monkeypatch.setattr(dl, "critic_ocr", lambda *a, **k: _CheapPass())
+    monkeypatch.delenv("WR2_VISION_REQUIRED", raising=False)
+
+    out = Path(tempfile.mkdtemp())
+    res = await dl.run_designer_loop(
+        slide={"headline": "X"},
+        render_fn=_tiny_png_writer(),
+        out_dir=out,
+        vision_critic=_vision,
+        brand_verifier=None,
+        use_vision=True,
+        max_iters=3,
+    )
+    assert res.converged is True, "cheap no-op must escalate to vision, which here passes"
+    assert vision_calls["n"] >= 1, "the vision critic MUST be consulted on a cheap no-op"
+    # history must not double-append the escalated iter record
+    escalated = [h for h in res.history if h.get("cheap_noop_escalated_to_vision")]
+    assert len(escalated) == 1
+
+
+@pytest.mark.asyncio
+async def test_designer_loop_cheap_noop_no_vision_does_not_publish(monkeypatch):
+    """Counterpart: if the cheap lever is a no-op AND there is NO vision critic to
+    adjudicate the whole slide, the loop must NOT blind-accept — it escalates and
+    does NOT converge (a residual we cannot verify is never published)."""
+    from wr2_html_renderer import designer_loop as dl
+
+    monkeypatch.setattr(dl, "critic_geometry", lambda *a, **k: _GeoFailInkAtEdge())
+    monkeypatch.setattr(dl, "critic_legibility", lambda *a, **k: _CheapPass())
+    monkeypatch.setattr(dl, "critic_ocr", lambda *a, **k: _CheapPass())
+    monkeypatch.delenv("WR2_VISION_REQUIRED", raising=False)
+
+    out = Path(tempfile.mkdtemp())
+    res = await dl.run_designer_loop(
+        slide={"headline": "X"},
+        render_fn=_tiny_png_writer(),
+        out_dir=out,
+        vision_critic=None,
+        use_vision=True,
+        max_iters=3,
+    )
+    assert res.converged is False, "cheap no-op + no vision to adjudicate must NOT publish"
+
+
 @pytest.mark.asyncio
 async def test_designer_loop_fail_closed_when_vision_required(monkeypatch):
     import base64
@@ -1383,8 +1492,14 @@ def test_classify_residual_issues():
     # brand drift is hard
     has_hard, _ = _classify_residual_issues(["the palette uses an off-brand blue"])
     assert has_hard is True
-    # empty → not all_composition (nothing to accept)
-    assert _classify_residual_issues([]) == (False, False)
+    # empty → all_composition=True (BUGFIX 2026-06-29 / Bug A): a critic returning
+    # ZERO atomic defects is a CLEAN slide, the most acceptable case — not a
+    # reject-without-reason. The old `(False, False)` seed (bool(issues)) sank
+    # whole carousels whenever the residual list was empty. has_hard stays False.
+    assert _classify_residual_issues([]) == (False, True)
+    # a list of ONLY synthetic 'vision: …' summary markers (skipped, no atomic
+    # claim) is likewise clean → all_composition=True.
+    assert _classify_residual_issues(["vision: balanced/clean"]) == (False, True)
     # lever classifier
     assert _is_composition_only_lever({"rerender"}) is True
     assert _is_composition_only_lever({"rerender", "scrim_opacity"}) is False

--- a/scripts/wr2_html_renderer/designer_loop.py
+++ b/scripts/wr2_html_renderer/designer_loop.py
@@ -314,8 +314,11 @@ def _classify_residual_issues(
 
     Returns (has_hard, all_composition):
       has_hard         — at least one issue is a legibility/brand HARD defect.
-      all_composition  — every issue is a composition/editorial critique (and
-                         there is at least one issue).
+      all_composition  — no atomic issue blocks acceptance: every atomic claim is
+                         a composition/editorial critique, OR there are NO atomic
+                         claims at all (empty list, or only synthetic 'vision: …'
+                         summary markers). An empty residual is the MOST
+                         acceptable case, not the least.
     A HARD marker always wins (an issue that is both is treated as hard).
 
     `rebalance_applied` (True when the slide already committed _rebalance_wrap)
@@ -323,9 +326,21 @@ def _classify_residual_issues(
     is editorial rhythm (SOFT), while a 1-word orphan stays HARD (see
     _orphan_is_hard). When False (no re-wrap attempted) every orphan claim is
     treated as HARD.
+
+    BUGFIX (2026-06-29): the old `all_composition = bool(issues)` seed turned an
+    EMPTY residual — the critic returning ZERO atomic defects (`critiques=[]`),
+    i.e. a clean slide — into all_composition=False, which the accept-gate read
+    as "not safe to accept" → render_failed. Observed sinking whole carousels
+    on slide 8 (drafts 8e582ce0 / d2d308bf / 9b923976, ~5 days no WR2 output).
+    A slide with no atomic complaint must converge, never fail. Cure: track
+    whether any atomic claim was UNCLASSIFIABLE; all_composition is True unless
+    such a blocker is seen. (scar #3 under-match: fail-safe inverted — absence
+    of a defect was treated as presence of an unclassifiable one.)
     """
     has_hard = False
-    all_composition = bool(issues)
+    # True until an atomic claim we can't classify as composition is seen. An
+    # empty list, or one with only synthetic summary markers, stays True (clean).
+    all_composition = True
     for raw in issues:
         low = (raw or "").lower()
         # Synthetic 'vision: …' summary markers are the critic's own meta-labels,
@@ -581,6 +596,17 @@ async def run_designer_loop(
     best_png: Path | None = None
     best_score = -1.0
     escalated = False
+    # The cheap-tier (geometry/legibility/ocr) issue set from the PREVIOUS
+    # iteration, used for no-op detection on the cheap path (BUGFIX 2026-06-29 /
+    # Bug B). The vision path already detects idempotent levers; the cheap path
+    # did not — so a cheap lever that does not move the verdict (e.g. shrink_font
+    # body proposed for `ink at bottom edge` when the bottom ink is the LOGO, not
+    # the body) re-applied identically every iteration, spun to max_iters, and
+    # emitted render_failed with last_reject_issues=None (critiques=[]). Observed
+    # sinking whole carousels on slide 8 (drafts 8e582ce0 / d2d308bf / 9b923976,
+    # ~5 days zero WR2 output) with legibility PASS + OCR 1.0 — i.e. the text was
+    # perfectly legible, only a geometry ink-at-edge flag the lever could not fix.
+    prev_cheap_issues: tuple[str, ...] | None = None
     # last vision-reject residual that was committed-and-continued (incremental
     # lever applied). Used ONLY at the max_iters exit: if after exhausting the
     # iteration budget the remembered residual is all-SOFT, accept the best
@@ -631,6 +657,11 @@ async def run_designer_loop(
         }
 
         if not passes_cheap:
+            # The cheap-tier verdict fingerprint for no-op detection (Bug B):
+            # if applying the cheap levers does NOT change the combined issue set
+            # vs the previous iteration, the lever is ineffective for this defect
+            # and re-applying it just burns iterations to a render_failed.
+            cur_cheap_issues = tuple(geo.issues) + tuple(leg.issues) + tuple(ocr.issues)
             # apply the cheap remedy levers and re-render (no model cost)
             applied = _apply_levers(levers_acc, cheap_levers)
             iter_record["cheap_levers_pulled"] = applied
@@ -640,8 +671,49 @@ async def run_designer_loop(
                 iter_record["escalated"] = "near-empty, not CSS-fixable"
                 history.append(iter_record)
                 break
-            history.append(iter_record)
-            continue  # re-render with new levers
+            # NO-OP DETECTION ON CHEAP PATH (Bug B): a cheap lever was applied but
+            # the issue set is IDENTICAL to the previous iteration → the lever did
+            # not move the cheap verdict (idempotent for this defect; classic
+            # case: shrink_font body cannot reduce `ink at bottom edge` when the
+            # bottom ink is the logo/footer, not the body). Re-applying it just
+            # burns iterations to a render_failed (observed sinking carousels on
+            # slide 8 for ~5 days: ink-at-edge 0.50 constant, shrink_body 1→2→3,
+            # legibility PASS + OCR 1.0, then render_failed last_reject_issues=None).
+            #
+            # DO NOT accept blindly here on legibility+OCR pass: those cheap
+            # critics do NOT prove the residual is safe — geometry is the ONLY
+            # cheap critic that sees frame overflow, and OCR only checks the
+            # HEADLINE, so genuinely clipped BODY text could slip through (codex
+            # refuter 2026-06-29, REFUTED the blind-accept variant). Instead,
+            # ESCALATE the verdict to the vision critic, which sees the WHOLE
+            # slide (body/footer/overflow) and already has the correct
+            # HARD/SOFT/composition-debt logic below. If vision is unavailable,
+            # do NOT publish — fall through to the strict converged=False reject.
+            cheap_lever_noop = (
+                bool(applied)
+                and prev_cheap_issues is not None
+                and cur_cheap_issues == prev_cheap_issues
+            )
+            if cheap_lever_noop and use_vision and vision_critic is not None:
+                iter_record["cheap_noop_escalated_to_vision"] = (
+                    "cheap lever no-op (issues unchanged) — deferring verdict to "
+                    "vision critic (whole-slide) instead of spinning to max_iters"
+                )
+                # fall through to the vision tier below for an informed verdict
+                # (the vision tier appends iter_record to history — do NOT append
+                # here, or the record would be duplicated).
+            elif cheap_lever_noop:
+                # No vision critic to adjudicate the no-op residual → can't prove
+                # the slide is safe. Escalate (keeps the strict gate on a residual
+                # we cannot verify), never blind-accept.
+                escalated = True
+                iter_record["escalated"] = "cheap lever no-op, no vision to adjudicate"
+                history.append(iter_record)
+                break
+            else:
+                prev_cheap_issues = cur_cheap_issues
+                history.append(iter_record)
+                continue  # re-render with new levers
 
         # --- Tier 3: vision (paid) — only when cheap tiers pass and enabled ---
         if use_vision and vision_critic is not None:

--- a/scripts/wr2_html_renderer/tests/test_orphan_entity_gate.py
+++ b/scripts/wr2_html_renderer/tests/test_orphan_entity_gate.py
@@ -51,9 +51,42 @@ def test_logo_composition_slide_not_hard():
     assert has_hard is False
 
 
+def test_empty_residual_is_acceptable():
+    """BUGFIX 2026-06-29: a clean slide (critic returns ZERO atomic defects)
+    must classify as all_composition=True so the accept-gate converges it,
+    NOT render_failed.
+
+    Repro: drafts 8e582ce0 / d2d308bf / 9b923976 all died on slide 8 with
+    `critiques=[]` — the empty residual was seeded all_composition=False by the
+    old `bool(issues)` and sank the whole carousel (~5 days, zero WR2 output).
+    An empty list, or a list of ONLY synthetic 'vision: …' summary markers, has
+    no atomic blocker → must be acceptable.
+    """
+    # truly empty residual — the most acceptable case of all
+    has_hard, all_comp = dl._classify_residual_issues([], rebalance_applied=False)
+    assert has_hard is False
+    assert all_comp is True, "empty residual must be all_composition (clean slide)"
+
+    # only a synthetic summary marker, no atomic defect → still acceptable
+    has_hard, all_comp = dl._classify_residual_issues(
+        ["vision: balanced/clean"], rebalance_applied=False
+    )
+    assert has_hard is False
+    assert all_comp is True, "summary-marker-only residual must be all_composition"
+
+    # sanity: a genuine unclassifiable atomic claim still blocks (no regression)
+    has_hard, all_comp = dl._classify_residual_issues(
+        ["the headline color clashes with the brand palette in a way that"],
+        rebalance_applied=False,
+    )
+    assert all_comp is False, "an unclassifiable atomic claim must still block"
+
+
 if __name__ == "__main__":
     test_orphan_entity_intent_grading()
     print("PASS test_orphan_entity_intent_grading (11 cases)")
     test_logo_composition_slide_not_hard()
     print("PASS test_logo_composition_slide_not_hard")
+    test_empty_residual_is_acceptable()
+    print("PASS test_empty_residual_is_acceptable")
     print("ALL PASS")


### PR DESCRIPTION
## Why
WR2 produced **zero carousels for ~5 days**. The supervisor on Pro was crash-looping (`EX_IOERR 74`) and `output/carousel` was frozen at Jun 25. Diagnosis anchored to the real on-disk history dumps in `~/logs/wr2-html-debug/` (NOT theory), which showed every fresh draft dying on a single slide at `render_failed`.

Two distinct bugs in the per-slide designer loop, both causing **one bad slide to sink the whole carousel**:

### Bug A — clean slide marked unacceptable
`_classify_residual_issues([])` returned `(has_hard=False, all_composition=False)` because the seed was `all_composition = bool(issues)`. An **empty** residual (vision critic returned ZERO atomic defects = a clean slide) was read by the accept-gate as "not safe to accept" → `render_failed`.
**Fix:** seed `all_composition=True`. An empty list (or only synthetic `vision: …` summary markers) has no atomic blocker → most acceptable case. Any HARD or unclassifiable atomic claim still flips it `False`.
**Codex refuter: NOT-REFUTED.**

### Bug B — cheap-lever no-op spins to render_failed (the actual 5-day killer)
The cheap-tier loop (geometry/legibility/ocr) had **no no-op detection** (the vision path does). `geometry` proposes `shrink_font(body)` for `ink at bottom edge`, but when the bottom ink is the **logo/footer** (fixed), shrinking the body never moves the ratio → identical failure every iteration, `shrink_body 1→2→3`, max_iters → `render_failed` with `last_reject_issues=None` (`critiques=[]`).
Observed verbatim in slide-8 history dumps of drafts `8e582ce0` / `d2d308bf` / `9b923976` — legibility PASS + OCR 1.0 (text read perfectly).
**Fix:** detect the cheap no-op (issue set unchanged after a lever was applied) and **escalate the verdict to the whole-slide vision critic** instead of spinning. Do **NOT** blind-accept on legibility+headline-OCR (OCR only checks the headline → clipped BODY text could slip through — **codex refuter REFUTED the blind-accept variant**, fix reworked accordingly). If no vision critic is available, do not publish (strict reject).

## Tests
- `test_orphan_entity_gate.py`: +`test_empty_residual_is_acceptable` (empty / summary-marker = acceptable; unclassifiable still blocks)
- `test_wr2_html_render_apply.py`: +`test_designer_loop_cheap_noop_escalates_to_vision_not_failed`, +`test_designer_loop_cheap_noop_no_vision_does_not_publish`; updated `test_classify_residual_issues` empty case to `(False, True)`
- Green: **3/3** orphan-gate, **105/105** apply suite

## Scar family
cicatrix **#2** (Esiste≠Armato — green supervisor, dead output) + **#3** (under-match — absence-of-defect treated as unacceptable). Adversarially reviewed via Codex refuter panel (both fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)