### PR TITLE
fix(seo): link sitewide JSON-LD blocks via shared @id

### DIFF
--- a/apps/mouth/src/components/seo/JsonLd.tsx
+++ b/apps/mouth/src/components/seo/JsonLd.tsx
@@ -13,6 +13,7 @@ export function OrganizationJsonLd() {
   const schema = {
     "@context": "https://schema.org",
     "@type": "Organization",
+    "@id": `${baseUrl}/#organization`,
     name: "Bali Zero",
     alternateName: "Bali Zero Team",
     url: baseUrl,
@@ -55,6 +56,7 @@ export function LocalBusinessJsonLd() {
   const schema = {
     "@context": "https://schema.org",
     "@type": "ProfessionalService",
+    "@id": `${baseUrl}/#organization`,
     name: "Bali Zero",
     image: `${baseUrl}/static/balizero-logo-clean.png`,
     url: baseUrl,
@@ -330,6 +332,7 @@ export function AggregateRatingJsonLd() {
   const schema = {
     "@context": "https://schema.org",
     "@type": "ProfessionalService",
+    "@id": `${baseUrl}/#organization`,
     name: "Bali Zero",
     url: baseUrl,
     aggregateRating: {


### PR DESCRIPTION
**Insight**
Three sitewide JSON-LD blocks (`OrganizationJsonLd`, `LocalBusinessJsonLd`, `AggregateRatingJsonLd`) representing the same entity (Bali Zero) carried no `@id`, so search engines read them as three disconnected anonymous nodes instead of one consolidated entity.

**Studio**
`apps/mouth/src/components/seo/JsonLd.tsx` — sitewide structured-data layer, mounted via `DynamicJsonLd` in `layout.tsx`. VERDE scope.

**Source**
Carry-over audit task "[P3-I] Structured data — verify '2 valid Article items'" (15 Jun finding). DevTools `application/ld+json` inspection + Antonello's direct file review confirmed exact locations and ruled out the two original hypotheses (duplicate Article / mismatched @id) — real root cause was @id missing entirely.

**Methodology**
1. DevTools across KBLI + business pages: `Article` = 1x/page (no dup), `ProfessionalService` = 2x sitewide.
2. Antonello traced both `ProfessionalService` blocks + `Organization` block, confirmed none carry `@id`.
3. Antigravity 4-phase protocol: Phase 1 read-only audit, Phase 2 diagnosis + confidence rating, Phase 3 diff reviewed manually before commit, Phase 4 commit only after explicit approval.

**Raw Observations**
- `OrganizationJsonLd` (L12-51, `Organization`) — no `@id`
- `LocalBusinessJsonLd` (L54-100, `ProfessionalService`) — no `@id`
- `AggregateRatingJsonLd` (L329-358, `ProfessionalService`) — no `@id`
- Only existing `@id` in file: `ArticleJsonLd` (`mainEntityOfPage["@id"]`, L168) — unrelated scope
- `WebsiteJsonLd` (L302-326) also lacks `@id` — flagged, intentionally out of scope (separate backlog task)
- `baseUrl` is module-level (L9), already used in all 3 target functions — no import changes

**Reasoning Path**
No `@id` → schema.org treats each object as an anonymous blank node → even with identical `name: "Bali Zero"`, Google has no deterministic way to merge them → shared `@id` (`${baseUrl}/#organization`) on all three is the standard pattern for splitting one entity's attributes across multiple JSON-LD blocks while keeping them linked.

**Risk**
Low. Additive only (3 lines, no removals). Schema objects are untyped literals consumed only via `JSON.stringify()` — zero downstream TS consumers, zero type-check risk (confirmed, all pre-commit hooks green). `WebsiteJsonLd` deliberately untouched to keep this PR atomic.

**Implication**
Google should consolidate the three blocks into one Organization entity going forward — improves rich-result consistency for local business + review data. No user-facing or runtime behavior change.

**Recommendation**
Merge once reviewed — minimal, additive, single-file, zero TS/lint risk.

**Next Action**
Antonello review (explicitly requested, no self-merge this round even with green CI). `WebsiteJsonLd` @id fix already logged as separate backlog task.
