### PR TITLE
fix(db): catch asyncpg.InterfaceError alongside PostgresError (36 sites)

### DIFF
--- a/apps/backend-rag/backend/agents/agents/client_value_predictor.py
+++ b/apps/backend-rag/backend/agents/agents/client_value_predictor.py
@@ -308,7 +308,7 @@ All clients scored and segmented automatically!""",
                 "total_messages_sent": 0,
                 "errors": [f"Operation timed out after {timeout}s"],
             }
-        except asyncpg.PostgresError as e:
+        except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
             logger.error("Database error in run_daily_nurturing: %s", e, exc_info=True)
             return {
                 "vip_nurtured": 0,

--- a/apps/backend-rag/backend/agents/agents/conversation_trainer.py
+++ b/apps/backend-rag/backend/agents/agents/conversation_trainer.py
@@ -223,7 +223,7 @@ Return JSON:
                     "common_themes": [],
                 }
 
-        except asyncpg.PostgresError as e:
+        except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
             logger.error("Database error analyzing winning patterns: %s", e, exc_info=True)
             return None
         except Exception as e:

--- a/apps/backend-rag/backend/agents/agents/knowledge_graph_builder.py
+++ b/apps/backend-rag/backend/agents/agents/knowledge_graph_builder.py
@@ -284,7 +284,7 @@ class KnowledgeGraphBuilder:
                     f"✅ Processed conversation {conversation_id}: {len(entities)} entities, {relationships_count} relationships",
                 )
 
-        except asyncpg.PostgresError as e:
+        except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
             logger.error(
                 "Database error processing conversation %s: %s",
                 conversation_id,
@@ -329,7 +329,7 @@ class KnowledgeGraphBuilder:
 
             logger.info(f"✅ Knowledge graph built from {len(conversation_ids)} conversations")
 
-        except asyncpg.PostgresError as e:
+        except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
             logger.error("Database error building graph: %s", e, exc_info=True)
             raise
         except Exception as e:

--- a/apps/backend-rag/backend/agents/services/client_scoring.py
+++ b/apps/backend-rag/backend/agents/services/client_scoring.py
@@ -75,7 +75,7 @@ class ClientScoringService:
 
                 return self._calculate_scores_from_row(row, client_id)
 
-        except asyncpg.PostgresError as e:
+        except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
             logger.error(
                 "Database error calculating score for client %s: %s",
                 client_id,
@@ -141,7 +141,7 @@ class ClientScoringService:
 
                 return results
 
-        except asyncpg.PostgresError as e:
+        except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
             logger.error("Database error in batch score calculation: %s", e, exc_info=True)
             return {}
         except Exception as e:

--- a/apps/backend-rag/backend/agents/services/kg_repository.py
+++ b/apps/backend-rag/backend/agents/services/kg_repository.py
@@ -297,7 +297,7 @@ class KnowledgeGraphRepository:
                     "generated_at": datetime.now(tz=timezone.utc).isoformat(),
                 }
 
-        except asyncpg.PostgresError as e:
+        except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
             logger.error("Database error getting insights: %s", e, exc_info=True)
             return {
                 "top_entities": [],
@@ -492,7 +492,7 @@ class KnowledgeGraphRepository:
                     for row in rows
                 ]
 
-        except asyncpg.PostgresError as e:
+        except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
             logger.error("Database error in semantic search: %s", e, exc_info=True)
             return []
         except Exception as e:

--- a/apps/backend-rag/backend/agents/services/kg_schema.py
+++ b/apps/backend-rag/backend/agents/services/kg_schema.py
@@ -76,7 +76,7 @@ class KnowledgeGraphSchema:
                         f"Run migrations 028 and 029 to create them.",
                     )
 
-        except asyncpg.PostgresError as e:
+        except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
             logger.error("Database error verifying schema: %s", e, exc_info=True)
             raise
         except Exception as e:

--- a/apps/backend-rag/backend/app/routers/feedback.py
+++ b/apps/backend-rag/backend/app/routers/feedback.py
@@ -144,7 +144,7 @@ async def submit_feedback(
 
     except HTTPException:
         raise
-    except asyncpg.PostgresError as e:
+    except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
         logger.error("Database error saving feedback: %s", e, exc_info=True)
         raise HTTPException(status_code=500, detail=f"Database error: {e!s}") from e
     except Exception as e:

--- a/apps/backend-rag/backend/app/routers/funnel_email.py
+++ b/apps/backend-rag/backend/app/routers/funnel_email.py
@@ -46,7 +46,7 @@ async def unsubscribe(
     repo = EmailSubscriptionRepository(db_pool)
     try:
         count = await repo.unsubscribe_by_token(token)
-    except asyncpg.PostgresError:
+    except (asyncpg.PostgresError, asyncpg.InterfaceError):
         logger.exception("funnel_email.unsub: DB error token=%s", token[:8])
         count = 0
     app = "visa" if count > 0 else ""  # best-effort hint

--- a/apps/backend-rag/backend/app/routers/lead_capture.py
+++ b/apps/backend-rag/backend/app/routers/lead_capture.py
@@ -114,7 +114,7 @@ async def capture_lead(
             whatsapp_url=wa_url,
             intent_id=intent_id,
         )
-    except asyncpg.PostgresError:
+    except (asyncpg.PostgresError, asyncpg.InterfaceError):
         logger.exception("lead_capture: DB insert failed source=%s", payload.source)
         raise HTTPException(status_code=500, detail="Could not persist lead")
 

--- a/apps/backend-rag/backend/app/routers/portal_matters.py
+++ b/apps/backend-rag/backend/app/routers/portal_matters.py
@@ -397,7 +397,7 @@ async def get_matter_detail(
                     """,
                     client_id,
                 )
-            except asyncpg.PostgresError as e:
+            except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
                 logger.warning("approved intelligence fetch failed: %s", e)
                 rows = []
 

--- a/apps/backend-rag/backend/app/routers/visa_check.py
+++ b/apps/backend-rag/backend/app/routers/visa_check.py
@@ -201,7 +201,7 @@ async def submit_clock(
             extension_days=timeline.extension_days,
             client_fp=payload.client_fingerprint,
         )
-    except asyncpg.PostgresError:
+    except (asyncpg.PostgresError, asyncpg.InterfaceError):
         logger.exception("visa_clock: DB insert failed")
         raise HTTPException(status_code=500, detail="Could not save timeline")
 
@@ -256,7 +256,7 @@ async def submit_match(
             estimated_cost_idr=cost,
             client_fp=payload.client_fingerprint,
         )
-    except asyncpg.PostgresError:
+    except (asyncpg.PostgresError, asyncpg.InterfaceError):
         logger.exception("visa_match: DB insert failed")
         raise HTTPException(status_code=500, detail="Could not save match result")
 

--- a/apps/backend-rag/backend/app/utils/postgres_debugger.py
+++ b/apps/backend-rag/backend/app/utils/postgres_debugger.py
@@ -384,7 +384,7 @@ class PostgreSQLDebugger:
                 "columns": columns,
                 "query": normalized_query,
             }
-        except asyncpg.PostgresError as e:
+        except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
             logger.error("Query execution failed: %s", e, exc_info=True)
             raise
         except Exception as e:

--- a/apps/backend-rag/backend/db/base_repository.py
+++ b/apps/backend-rag/backend/db/base_repository.py
@@ -46,7 +46,7 @@ class BaseRepository:
         async with self.db_pool.acquire() as conn:
             try:
                 return await conn.fetchrow(query, *args)
-            except asyncpg.PostgresError as exc:
+            except (asyncpg.PostgresError, asyncpg.InterfaceError) as exc:
                 self.logger.error("fetchrow failed: %s | query=%s", exc, query[:120], exc_info=True)
                 raise
 
@@ -59,7 +59,7 @@ class BaseRepository:
         async with self.db_pool.acquire() as conn:
             try:
                 return await conn.fetch(query, *args)
-            except asyncpg.PostgresError as exc:
+            except (asyncpg.PostgresError, asyncpg.InterfaceError) as exc:
                 self.logger.error("fetch failed: %s | query=%s", exc, query[:120], exc_info=True)
                 raise
 
@@ -72,6 +72,6 @@ class BaseRepository:
         async with self.db_pool.acquire() as conn:
             try:
                 return await conn.execute(query, *args)
-            except asyncpg.PostgresError as exc:
+            except (asyncpg.PostgresError, asyncpg.InterfaceError) as exc:
                 self.logger.error("execute failed: %s | query=%s", exc, query[:120], exc_info=True)
                 raise

--- a/apps/backend-rag/backend/db/migration_base.py
+++ b/apps/backend-rag/backend/db/migration_base.py
@@ -512,7 +512,7 @@ class BaseMigration:
                 # MigrationManager.rollback_migration if ever invoked).
                 try:
                     await conn.execute(sql_forward)
-                except asyncpg.PostgresError as e:
+                except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
                     raise MigrationError(f"SQL execution failed: {e}") from e
 
                 # Verify migration

--- a/apps/backend-rag/backend/services/compliance/alert_feedback.py
+++ b/apps/backend-rag/backend/services/compliance/alert_feedback.py
@@ -223,7 +223,7 @@ class AlertFeedback:
                         str(new),
                         f'{{"precision":{precision},"sample_size":{sample_size}}}',
                     )
-            except asyncpg.PostgresError as exc:
+            except (asyncpg.PostgresError, asyncpg.InterfaceError) as exc:
                 logger.warning("guardian_decisions insert failed (non-fatal): %s", exc)
         else:
             # connection / tx mode (tests) — use a savepoint to protect the outer tx
@@ -242,7 +242,7 @@ class AlertFeedback:
                         str(new),
                         f'{{"precision":{precision},"sample_size":{sample_size}}}',
                     )
-            except asyncpg.PostgresError as exc:
+            except (asyncpg.PostgresError, asyncpg.InterfaceError) as exc:
                 logger.warning("guardian_decisions insert failed (non-fatal): %s", exc)
 
 

--- a/apps/backend-rag/backend/services/compliance/alerts_engine.py
+++ b/apps/backend-rag/backend/services/compliance/alerts_engine.py
@@ -117,7 +117,7 @@ class AlertsEngine:
         for fc in forecasts:
             try:
                 alert = await self._handle_one(fc, client_lang_resolver)
-            except asyncpg.PostgresError as exc:
+            except (asyncpg.PostgresError, asyncpg.InterfaceError) as exc:
                 logger.error(
                     "DB error generating alert for client %s: %s (skipping this forecast)",
                     fc.client_id,

--- a/apps/backend-rag/backend/services/compliance/revenue_estimator.py
+++ b/apps/backend-rag/backend/services/compliance/revenue_estimator.py
@@ -233,7 +233,7 @@ async def classify_client_risk(
             )
             or 0
         )
-    except asyncpg.PostgresError:
+    except (asyncpg.PostgresError, asyncpg.InterfaceError):
         overdue_days = 0
 
     if overdue_days >= 30:

--- a/apps/backend-rag/backend/services/integrations/messaging_identity_service.py
+++ b/apps/backend-rag/backend/services/integrations/messaging_identity_service.py
@@ -73,7 +73,7 @@ class MessagingIdentityService:
 
                 return None
 
-        except asyncpg.PostgresError as e:
+        except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
             logger.error("Database error getting user by phone %s: %s", normalized_phone, e)
             return None
 
@@ -104,7 +104,7 @@ class MessagingIdentityService:
 
                 return None
 
-        except asyncpg.PostgresError as e:
+        except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
             logger.error("Database error getting user by telegram %s: %s", chat_id, e)
             return None
 
@@ -179,7 +179,7 @@ class MessagingIdentityService:
         except asyncpg.UniqueViolationError:
             logger.warning(f"Mapping already exists for {channel} ({phone or telegram_chat_id})")
             return False
-        except asyncpg.PostgresError as e:
+        except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
             logger.error("Database error creating mapping: %s", e)
             return False
 
@@ -225,7 +225,7 @@ class MessagingIdentityService:
 
                 return True
 
-        except asyncpg.PostgresError as e:
+        except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
             logger.error("Error updating last_message timestamp: %s", e)
             return False
 
@@ -254,7 +254,7 @@ class MessagingIdentityService:
 
                 return [dict(row) for row in rows]
 
-        except asyncpg.PostgresError as e:
+        except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
             logger.error("Error getting mappings for user %s: %s", user_id, e)
             return []
 
@@ -301,7 +301,7 @@ class MessagingIdentityService:
                 logger.info(f"Deactivated mapping for {phone or telegram_chat_id}")
                 return True
 
-        except asyncpg.PostgresError as e:
+        except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
             logger.error("Error deactivating mapping: %s", e)
             return False
 

--- a/apps/backend-rag/backend/services/kg_monitoring/auto_ingestion.py
+++ b/apps/backend-rag/backend/services/kg_monitoring/auto_ingestion.py
@@ -229,7 +229,7 @@ Return ONLY the JSON object, no other text."""
 
             logger.info("✅ Ingestion tracking tables initialized")
 
-        except asyncpg.PostgresError as e:
+        except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
             logger.error("Failed to initialize DB tables: %s", e)
             raise
         except OSError as e:
@@ -610,7 +610,7 @@ Full Text:
                     result.error_message,
                     result.processing_time_ms,
                 )
-        except asyncpg.PostgresError as e:
+        except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
             logger.warning("DB error saving ingestion result: %s", e)
         except OSError as e:
             logger.warning("Connection error saving ingestion result: %s", e)
@@ -667,7 +667,7 @@ Full Text:
                     for row in rows
                 ]
 
-        except asyncpg.PostgresError as e:
+        except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
             logger.warning("DB error fetching recent results: %s", e)
             return []
         except (KeyError, ValueError, TypeError) as e:

--- a/apps/backend-rag/backend/services/rag/kg_subgraph_property.py
+++ b/apps/backend-rag/backend/services/rag/kg_subgraph_property.py
@@ -250,7 +250,7 @@ async def _execute_batch_insert(rows: list[tuple[Any, ...]], db_pool: asyncpg.Po
                 except (ValueError, IndexError):
                     count = len(rows)
             return count or len(rows)
-    except asyncpg.PostgresError as e:
+    except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
         logger.error("❌ [Zoning] Batch insert failed (DB): %s", e)
         return 0
     except Exception as e:
@@ -279,7 +279,7 @@ async def _check_existing_zoning(
             if row:
                 return dict(row)
         return None
-    except asyncpg.PostgresError as e:
+    except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
         logger.error("❌ [Zoning] DB check failed: %s", e)
         return None
     except Exception as e:
@@ -555,7 +555,7 @@ async def get_property_requirements_node(state: Any, db_pool: Any = None) -> dic
                         kg_sources,
                         prop_type,
                     )
-        except asyncpg.PostgresError as e:
+        except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
             logger.warning("[Property/legacy] KG query failed (DB), using fallback: %s", e)
         except Exception as e:
             logger.warning(


### PR DESCRIPTION
## What

`asyncpg.InterfaceError` is a **sibling** of `PostgresError`, not a subclass — empirically verified:

```
PostgresError MRO: PostgresError -> PostgresMessage -> Exception
InterfaceError MRO: InterfaceError -> InterfaceMessage -> Exception
issubclass(InterfaceError, PostgresError) = False
```

So every `except asyncpg.PostgresError` handler **silently misses** `InterfaceError`. On Fly Postgres proxy flaps or mid-operation connection drops ("connection was closed in the middle of operation"), asyncpg raises `InterfaceError` → it escapes those handlers → **zero diagnostics, no retry, no DLQ**. Scar family **#8** (network-flap / proxy fragility — W64/W34).

## Change

Mechanical, **purely additive** sweep across **36 single-class `except` sites in 20 files**:

```python
# before
except asyncpg.PostgresError as e:
# after
except (asyncpg.PostgresError, asyncpg.InterfaceError) as e:
```

Handler bodies are byte-identical. Existing tuple-form handlers (`except (PostgresError, OSError, …)`) and generic `except Exception` handlers already catch `InterfaceError` and were left untouched.

## Scope decision (Set A only)

The task's grep (`except asyncpg.PostgresError` literal) targets the **36 single-class sites**. A broader pattern also finds **~64 tuple-form sites** (`except (asyncpg.PostgresError, OSError/…)` — e.g. `services/crm/client_core.py` ×11, `services/prime/prime_nexus_service.py` ×14, `drive_poll_service.py`) that likewise miss `InterfaceError`. Those are **the same bug** but fall heavily in the **T1 (crm_clients) perimeter** and would make this PR non-atomic. They are flagged as a follow-up (T2b) and **not touched here** to respect the parallel-session merge perimeter.

## Verification

- ✅ Empirical proof `InterfaceError` is a sibling (not subclass) — `issubclass=False`
- ✅ Import smoke: `from backend.app.dependencies import get_current_user` → OK
- ✅ `py_compile` + AST parse clean on all 20 files
- ✅ `ruff check` — All checks passed (line-length=100, all new lines well under)
- ✅ Pre-commit hooks — all green (secrets, typecheck, FastAPI import chain, anti-reward-hacking)
- ✅ `backend/tests/db`: **270 passed, 12 skipped**. 6 failures (`test_migration_114_115_116_roundtrip.py`) are **pre-existing W87** — `role "nuzantara" does not exist` raised at asyncpg fixture **connect-time** on local M5 (no local PG configured), before any query or modified handler runs. Unrelated to this additive change.

## Diff stats

20 files changed, 36 insertions(+), 36 deletions(-) — exactly one line per site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)