### PR TITLE
fix(wr2): classify dead-air/float/weight-contrast critiques as composition debt (W82, 3rd)

### DIFF
--- a/scripts/wr2_html_renderer/designer_loop.py
+++ b/scripts/wr2_html_renderer/designer_loop.py
@@ -104,6 +104,37 @@ _COMPOSITION_CLAIM_MARKERS = (
     "bottom gap", "top gap", "large gap", "substantial gap",
     "large void", "void before", "void above", "void below",
     "negative space", "large empty", "empty band", "empty strip",
+    # "dead AIR" + float/anchor family (W82 under-match, 2nd occurrence
+    # 2026-06-30): the critic also names the SAME vertical-balance debt as
+    # "dead air", a block that "floats"/"is unanchored"/"sits marooned"/
+    # "sandwiched", a logo "stranded"/"isolated"/"floats at the bottom". These
+    # are composition/placement notes (NOT legibility/clip/brand), so they are
+    # editorial debt, not HARD. Innocence-tested: none overlaps a real
+    # legibility/clip/brand marker (has_hard still wins via _claim_is_hard when
+    # an actual defect co-occurs). NB: spatial "stranded/floats/isolated" on a
+    # text UNIT is already handled by _orphan_is_hard (positive typographic-orphan
+    # ID) — these terms here only carry the balance/dead-space meaning.
+    "dead air", "dead-air",
+    "floats", "floating", "unanchored", "anchorless",
+    "marooned", "stranded", "isolated at", "sandwiched",
+    "sits mid", "floats mid", "mid-dark", "mid-section",
+    "sunken into", "sinks into", "sunk into", "drifted",
+    "unfinished", "looks unfinished", "feels unfinished", "reads as unfinished",
+    "nowhere to go", "nothing to rest", "eye has nowhere",
+    # typographic-hierarchy / weight-contrast family (W82 under-match
+    # 2026-06-30): "body is full-bold throughout", "no weight contrast",
+    # "hierarchy gap too narrow", "size cliff", "feels lopsided" — emphasis/
+    # hierarchy refinements about the RELATION between heading and body (the text
+    # is legible; the critic wants a regular-vs-bold contrast), NOT legibility/
+    # clip/brand defects. These describe weight/contrast/relative-size, never
+    # absolute readability — that axis stays with the deterministic OCR +
+    # legibility tiers (codex refuter 2026-06-30: do NOT let soft size/comfort
+    # wording like "strains comfort"/"footnote"/"could be larger" mask a real
+    # readability failure — those are intentionally EXCLUDED here).
+    "full-bold", "full bold", "all-bold", "all bold", "bold throughout",
+    "weight contrast", "no weight", "weight differentiation", "uniform weight",
+    "hierarchy gap", "hierarchy", "size cliff", "size delta", "size gap",
+    "size jump", "lopsided", "featherweight", "heavy top", "lacks emphasis",
 )
 
 # HARD-defect markers, matched on WORD BOUNDARY (not bare substring) — the
@@ -154,6 +185,22 @@ _AFFIRMS_CORRECT_MARKERS = (
     "is correct", "are correct", "is the correct", "correct brand",
     "correct treatment", "is fine", "looks fine", "is good", "works well",
     "is solid", "reads well", "is legible",
+    # the critic EXPLICITLY affirming readability (W82 under-match 2026-06-30):
+    # "at full open size it reads", "technically legible", "it reads, but…",
+    # "readable but…". The element is CONCEDED legible by the critic, so the
+    # trailing critique is about something else (layout/hierarchy), not a HARD
+    # legibility defect.
+    #
+    # DELIBERATELY NOT ADDED (codex refuter REFUTED these 2026-06-30): soft
+    # comfort/size judgements — "strains comfort", "could be larger", "a few
+    # more points", "footnote". Those are NOT explicit readability affirmations;
+    # the critic can use them to describe a slide that is effectively unreadable
+    # on a phone. We must NOT trust soft wording for the readability axis — that
+    # axis is decided by the DETERMINISTIC cheap tiers (legibility critic +
+    # OCR score), which run before this classifier and gate on measured contrast
+    # / actual headline read-back, not on prose. So a genuinely too-small body
+    # is caught by OCR/legibility regardless of how gently the critic phrases it.
+    "it reads", "technically legible", "readable but", "legible but", "reads but",
 )
 
 # An issue that talks about an orphan / stub / wrap-rhythm / a line "sitting

--- a/scripts/wr2_html_renderer/tests/test_orphan_entity_gate.py
+++ b/scripts/wr2_html_renderer/tests/test_orphan_entity_gate.py
@@ -51,6 +51,85 @@ def test_logo_composition_slide_not_hard():
     assert has_hard is False
 
 
+def test_dead_air_float_slide_is_debt_not_hard():
+    """BUGFIX 2026-06-30 (W82 under-match, 2nd occurrence): the critic names the
+    SAME vertical-balance debt as 'dead air', a body that 'floats'/'sits
+    unanchored'/'sunken into the lower half', a layout that 'looks unfinished'.
+    These were NOT in the composition vocabulary → flipped all_composition False
+    → HARD reject → render_failed. They are placement/balance notes, not
+    legibility/clip/brand → must be acceptable composition debt.
+
+    Verbatim from draft 62b6b577 slide 3 (the reject that exposed this):
+    """
+    slide3 = [
+        "Dead air below body copy: the body text sits at ~73% of the slide with a "
+        "large void before the logo at ~90%. The composition feels unanchored — "
+        "body floats mid-dark-section with no visual weight to close the layout.",
+        "Body type is small and all-caps. At full open size it reads, but the "
+        "combination of small size + all-caps for a 2-line paragraph strains comfort.",
+        "Logo is isolated at the bottom of the frame.",
+        "vision: unbalanced/crammed",
+    ]
+    has_hard, all_comp = dl._classify_residual_issues(slide3, rebalance_applied=False)
+    assert has_hard is False, "dead-air/float/unanchored are composition, not HARD"
+    assert all_comp is True, "the whole slide-3 residual is editorial debt → acceptable"
+
+    # the slide-1 residual (also accepted live as debt) must stay acceptable too
+    slide1 = [
+        "Top ~35% of the canvas is a featureless dark void — the content block is "
+        "sunken into the lower half of the frame. As-is the slide looks unfinished.",
+        "Large dead zone also below the body text before the logo — the logo floats "
+        "in isolation at the very bottom of a ~20% gap.",
+        "Body copy is full-bold throughout — no weight contrast.",
+        "vision: unbalanced/crammed",
+    ]
+    has_hard, all_comp = dl._classify_residual_issues(slide1, rebalance_applied=False)
+    assert has_hard is False and all_comp is True
+
+
+def test_dead_air_does_not_swallow_real_hard_defect():
+    """Innocence guard: adding dead-air/float vocabulary must NOT let a genuine
+    HARD defect (illegible / clipped) slip through when it co-occurs."""
+    mixed = [
+        "Dead air below the body, logo floats unanchored at the bottom.",  # composition
+        "The headline is clipped — the last word is cut off the right edge.",  # HARD
+    ]
+    has_hard, all_comp = dl._classify_residual_issues(mixed, rebalance_applied=False)
+    assert has_hard is True, "a real clip defect must still win over composition debt"
+    assert all_comp is False
+
+
+def test_soft_comfort_size_wording_is_NOT_auto_accepted_by_text():
+    """Codex refuter guard (2026-06-30): soft comfort/size judgements
+    ('strains comfort', 'could be larger', 'a few more points', 'footnote')
+    must NOT be auto-classified as composition debt by WORDING — they can mask a
+    real readability failure on mobile. The readability axis is owned by the
+    DETERMINISTIC cheap tiers (legibility contrast + OCR read-back) that gate
+    BEFORE this classifier; text wording must not pre-empt them. So a bare
+    comfort/size complaint with no explicit readability affirmation and no
+    layout/hierarchy term stays unclassified → blocks (all_composition=False)."""
+    # Bare comfort/size complaints with no conditional/affirmation/layout term
+    # must NOT be auto-classified as debt by wording — they fall to the
+    # deterministic cheap tiers (legibility + OCR), i.e. block here.
+    for soft in [
+        "The body text strains comfort at phone size.",
+        "The body feels like a footnote.",
+    ]:
+        has_hard, all_comp = dl._classify_residual_issues([soft], rebalance_applied=False)
+        assert all_comp is False, f"soft size/comfort wording must not auto-accept: {soft!r}"
+        assert has_hard is False, "but it is not HARD either (not 'illegible')"
+    # NOTE: a phrasing like "could be larger" DOES match the pre-existing
+    # _CONDITIONAL_MARKERS ('could'/'would') and classifies as a suggestion —
+    # that predates this change and is acceptable because a body that is *really*
+    # too small is caught upstream by OCR/legibility regardless of wording. The
+    # point of THIS guard is only that we did not ADD bare comfort/size terms.
+
+    # but an EXPLICIT readability affirmation IS a legitimate concession → debt
+    affirmed = "At full open size it reads; the only note is the large top dead zone."
+    has_hard, all_comp = dl._classify_residual_issues([affirmed], rebalance_applied=False)
+    assert has_hard is False and all_comp is True
+
+
 def test_empty_residual_is_acceptable():
     """BUGFIX 2026-06-29: a clean slide (critic returns ZERO atomic defects)
     must classify as all_composition=True so the accept-gate converges it,


### PR DESCRIPTION
## Why
Follow-up to #1831 + #1840. With both live, a **live re-render of draft 62b6b577** proved the pipeline WORKS (vision runs, accepts slide 1 as composition debt) — but still `render_failed` on slide 3, for critiques the vision critic genuinely emits that the composition vocabulary didn't cover. One rejected slide sinks the whole carousel.

## Root cause — W82 under-match, 3rd occurrence
The critic names a balance/hierarchy debt with phrasings the taxonomy didn't have → defaulted to `all_composition=False` → HARD reject. Verbatim from the live residuals:
- **balance/placement**: "dead air", body "floats / unanchored", "sunken into the lower half", "looks unfinished"
- **typography hierarchy**: "full-bold throughout — no weight contrast"
- **readability affirmed**: "at full open size it reads, but …"

These are editorial composition/placement notes on a **legible** slide, not legibility/clip/brand defects.

## Fix
Extend `_COMPOSITION_CLAIM_MARKERS` (dead-air/float/unanchored/sunken/unfinished + full-bold/weight-contrast/hierarchy-gap/size-cliff) and `_AFFIRMS_CORRECT_MARKERS` (explicit readability affirmations only). HARD markers unchanged, keep precedence.

## Adversarial review (Codex refuter — REFUTED the first draft)
The refuter showed soft comfort/size wording ("strains comfort", "footnote", "could be larger", "title-class") could mask a **real** readability failure if trusted by wording. **Narrowed accordingly:**
- **REMOVED** those soft size/comfort terms. The readability axis is owned by the **deterministic cheap tiers** (legibility measured-contrast + OCR headline read-back) that gate BEFORE this classifier (`passes_cheap` at `designer_loop.py:689`). A genuinely too-small body fails OCR/legibility regardless of wording → never reaches here.
- **KEPT** weight-contrast/full-bold as debt (operator decision: Bali Zero brand-system constrains palette/font-family/logo, NOT body bold weight — "no weight contrast" is editorial taste).

## Tests
+3: slide-3/slide-1 verbatim residuals = debt; innocence guard (real clip still HARD); refuter guard (bare comfort/size wording does NOT auto-accept). Suite: **6/6** orphan-gate, **107/107** apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)