### PR TITLE
feat(pricing): migrate ServicePricing CTA to WhatsAppLeadButton

### DIFF
--- a/apps/mouth/src/components/services/ServicePricing.tsx
+++ b/apps/mouth/src/components/services/ServicePricing.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { Check, X, Info, Phone } from "lucide-react";
 import type { ServicePackage } from "@/data/services_data";
+import { WhatsAppLeadButton } from "@/components/lead/WhatsAppLeadButton";
 
 // ServiceData without icon (React component cannot be serialized)
 type ServiceDataWithoutIcon = Omit<
@@ -232,14 +233,22 @@ export default function ServicePricing({ service, slug }: ServicePricingProps) {
               </div>
 
               {/* WhatsApp CTA */}
-              <Link
-                href={`https://wa.me/6282210302328?text=${encodeURIComponent(`Hi, I'm interested in ${selectedPackage.name}. Can you help me?`)}`}
-                target="_blank"
+              <WhatsAppLeadButton
+                source="pricing_modal"
+                context={{
+                  service_slug: slug,
+                  package_name: selectedPackage.name,
+                }}
+                whatsappContext={[
+                  { label: "Service", value: slug },
+                  { label: "Package", value: selectedPackage.name },
+                ]}
+                utm={{ page: `/services/${slug}` }}
                 className="flex items-center justify-center gap-2 w-full px-6 py-4 rounded-xl bg-[#25D366] text-white font-medium hover:bg-[#20BD5A] transition-colors mb-3"
               >
                 <Phone className="w-5 h-5" />
                 Chat on WhatsApp
-              </Link>
+              </WhatsAppLeadButton>
 
               <Link
                 href="/chat"


### PR DESCRIPTION
## Insight
ServicePricing.tsx's WhatsApp CTA (the package-selection modal) was never migrated to the WhatsAppLeadButton pattern established by PR #1276/#1282 — it predates that work. Result: zero lead_intents attribution, zero analytics emission, and a hardcoded WA number, on what is likely a high-intent surface (user already selected a specific pricing package before clicking).

## Studio
Paired with backend PR (sancho/feat-pricing-modal-source-enum) registering the PRICING_MODAL LeadSource enum value. **This PR must stay in Draft until the backend PR is confirmed merged + deployed** — same blocking pattern as #1730/#1731. Flipping early would 422 on /api/lead/capture.

## Source
apps/mouth/src/components/services/ServicePricing.tsx — read verbatim (imports, modal block lines 220-263) via Antigravity investigation before writing the diff.

## Methodology
Antigravity 4-phase: Phase 1 read-only (confirmed WhatsAppLeadButton was not imported anywhere in this file; confirmed lead_whatsapp_cta already exists in FUNNEL_EVENTS — no new event needed, per 18 Jun clarification not to fragment into separate events), Phase 2 diagnosis, Phase 3 diff + npm build verification (webpack + TypeScript + 237/237 SSG pages, zero errors), Phase 4 commit (Subhi reviewed diff, ran prettier --write per pre-commit hook, then committed).

## Raw Observations
- Before: bare `<Link target="_blank" href="https://wa.me/6282210302328?text=...">` — hardcoded WA number, opens new tab, zero tracking.
- After: `<WhatsAppLeadButton source="pricing_modal" context={{service_slug, package_name}} whatsappContext={[...]} utm={{page}}>` — matches the live pattern in KBLIConsultationCTA.tsx and ArticleClient.tsx exactly.
- npm run build --workspace=apps/mouth: compiled successfully (4.8min), TypeScript clean (2.6min), 237/237 static pages generated including /services/[slug].

## Reasoning Path
Behavior change worth flagging: target="_blank" (new tab) → same-tab redirect via window.location.href. This is **standardization, not a regression** — every other live WhatsAppLeadButton usage (KBLI, Article) already redirects same-tab; this CTA was the outlier. Also incidentally removes the hardcoded WA number — WhatsAppLeadButton's built-in FALLBACK_WA_URL is the identical number, so no fallbackHref override was needed.

## Risk
Low-medium. UI behavior change (tab behavior) on a live conversion surface, but consistent with established pattern elsewhere. Scoped to exactly one CTA block — the second modal button ("Ask Zantara AI", /chat link) was intentionally left untouched.

## Implication
Closes one item from the known "remaining hardcoded WhatsApp links" backlog (ServicePricing.tsx L236). Gives pricing-modal clicks lead_intents attribution for the first time — relevant to the Big Fork funnel-data discussion, since this is a high-intent surface with currently zero signal.

## Recommendation
Merge only after backend PR is live (VERDE zone, apps/mouth — self-merge eligible once CI green AND backend dependency confirmed, per the #1730 precedent).

## Next Action
Verify via DevTools after backend lands: Network → collect → click CTA in modal → confirm event_name=lead_whatsapp_cta, source=pricing_modal fires, and POST /api/lead/capture returns 201 + lead_intent_id (not 422).