### PR TITLE
docs(review): replace Italian string in code comment with English

### DIFF
--- a/apps/mouth/src/app/(workspace)/review/page.tsx
+++ b/apps/mouth/src/app/(workspace)/review/page.tsx
@@ -731,8 +731,8 @@ export default function ReviewPage() {
   }, [selectedCategory, selectedClient, selectedGroup, selectedPractice]);
 
   // Authenticated blob preview: an <iframe>/<img> request cannot carry the
-  // Bearer header, so a direct src 401s ("Connessione negata"). Fetch the
-  // blob WITH the token, then preview via a local object URL.
+  // Bearer header, so a direct src 401s (the browser shows a connection-refused
+  // error). Fetch the blob WITH the token, then preview via a local object URL.
   const [blobUrl, setBlobUrl] = useState<string>("");
   useEffect(() => {
     if (!detail) {


### PR DESCRIPTION
The blob-preview comment in `apps/mouth/src/app/(workspace)/review/page.tsx:734` cited the browser's Italian 401 message verbatim (`"Connessione negata"`). Replaced with a language-neutral English description.

Comment-only change — no code touched, no behavior change. Enforces the "never Italian in artifacts" rule (CLAUDE.md §Language: English for code/comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)