### PR TITLE
feat(mata-garuda): automatic cap-rollover in nlm_feeder (B2)

### DIFF
--- a/apps/mata-garuda/mata_garuda/workers/nlm_feeder.py
+++ b/apps/mata-garuda/mata_garuda/workers/nlm_feeder.py
@@ -41,6 +41,7 @@ from mata_garuda.config import (
     STREAM_ALERTS,
     STREAM_ENRICHED,
 )
+from mata_garuda.notebook_registry import get_notebook
 from mata_garuda.runtime.knowledge import KnowledgeBase
 from mata_garuda.workers.base_worker import (
     stream_ack,
@@ -126,6 +127,37 @@ def _nlm_at_cap(notebook_id: str) -> bool:
     return count >= NLM_NOTEBOOK_SOURCE_CAP
 
 
+def _resolve_writable_nb(notebook_id: str) -> str:
+    """B2 (2026-06-30): automatic cap-rollover.
+
+    Given a domain notebook, return a notebook that still has room to write:
+      - not at cap → the notebook itself (fast path, the common case).
+      - at cap → the first registry `peer_uuids` overflow NB that has room
+        (this is what B1 wired by hand for ai_research; B2 makes it automatic
+        for every domain whose registry entry declares an overflow peer).
+      - at cap with no peer (or no free peer) → the original NB. The caller's
+        cap-check then skips the add, exactly as before — fail-safe, never
+        crashes, never silently drops the route.
+    """
+    if not notebook_id or not _nlm_at_cap(notebook_id):
+        return notebook_id
+    entry = get_notebook(notebook_id)
+    if entry is None:
+        return notebook_id
+    for peer in entry.peer_uuids:
+        if not _nlm_at_cap(peer):
+            logger.info(
+                "[nlm_feeder] cap-rollover: %s full → writing to overflow peer %s",
+                notebook_id, peer,
+            )
+            return peer
+    logger.warning(
+        "[nlm_feeder] %s at cap and no overflow peer has room — add will skip",
+        notebook_id,
+    )
+    return notebook_id
+
+
 def _nlm_add_url(notebook_id: str, url: str) -> bool:
     """Add a URL source to NLM notebook. Returns True on success.
 
@@ -135,9 +167,10 @@ def _nlm_add_url(notebook_id: str, url: str) -> bool:
     """
     if not notebook_id:
         return False
+    notebook_id = _resolve_writable_nb(notebook_id)
     if _nlm_at_cap(notebook_id):
         logger.warning(
-            "[nlm_feeder] skip add (NB at cap): nb=%s url=%s",
+            "[nlm_feeder] skip add (NB at cap, no overflow room): nb=%s url=%s",
             notebook_id, url,
         )
         return False
@@ -215,9 +248,10 @@ def _nlm_add_text(notebook_id: str, title: str, text: str) -> bool:
     """
     if not notebook_id:
         return False
+    notebook_id = _resolve_writable_nb(notebook_id)
     if _nlm_at_cap(notebook_id):
         logger.warning(
-            "[nlm_feeder] skip add_text (NB at cap): nb=%s title=%s",
+            "[nlm_feeder] skip add_text (NB at cap, no overflow room): nb=%s title=%s",
             notebook_id, title[:60],
         )
         return False

--- a/apps/mata-garuda/tests/test_nlm_feeder.py
+++ b/apps/mata-garuda/tests/test_nlm_feeder.py
@@ -317,3 +317,50 @@ class TestNlmCliPath:
             assert argv[0] == nlm_feeder.NLM_CLI
             # NLM_CLI is resolved at import; in CI it may be bare 'nlm' but must be the constant
             assert argv[0] != "nlm" or nlm_feeder.NLM_CLI == "nlm"
+
+
+class TestCapRollover:
+    """B2 (2026-06-30): when a domain NB hits the source cap, the feeder must roll
+    over to its registry peer_uuids overflow NB automatically — no manual registry
+    edit (B1 did that by hand). _resolve_writable_nb is the resolver every add goes
+    through. Fail-safe: if no peer has room, return the original NB (the add then
+    skips, as before — never crash, never lose-route silently)."""
+
+    FULL = "dc5d01cd-e99f-4c8f-aae4-75060b43d0de"
+    OVERFLOW = "069f009c-ce74-42e5-b75c-e584aa18feb1"
+
+    def test_not_at_cap_returns_self(self):
+        with patch.object(nlm_feeder, "_nlm_at_cap", return_value=False):
+            assert nlm_feeder._resolve_writable_nb(self.FULL) == self.FULL
+
+    def test_at_cap_rolls_over_to_peer_with_room(self):
+        # FULL is at cap; its registry peer OVERFLOW has room
+        def at_cap(nb):
+            return nb == self.FULL
+        with patch.object(nlm_feeder, "_nlm_at_cap", side_effect=at_cap):
+            assert nlm_feeder._resolve_writable_nb(self.FULL) == self.OVERFLOW
+
+    def test_at_cap_no_peer_room_returns_original(self):
+        # everything is full → fail-safe to the original (add will skip)
+        with patch.object(nlm_feeder, "_nlm_at_cap", return_value=True):
+            assert nlm_feeder._resolve_writable_nb(self.FULL) == self.FULL
+
+    def test_unknown_nb_returns_self(self):
+        # a NB not in the registry has no peers → returns itself
+        unknown = "00000000-0000-0000-0000-000000000000"
+        with patch.object(nlm_feeder, "_nlm_at_cap", return_value=True):
+            assert nlm_feeder._resolve_writable_nb(unknown) == unknown
+
+    def test_add_url_writes_to_rolled_over_nb(self):
+        """_nlm_add_url must target the resolved peer, not skip, when rolled over."""
+        from unittest.mock import MagicMock
+        def at_cap(nb):
+            return nb == self.FULL
+        with patch.object(nlm_feeder, "_nlm_at_cap", side_effect=at_cap), \
+             patch.object(nlm_feeder.subprocess, "run") as m_run:
+            m_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            ok = nlm_feeder._nlm_add_url(self.FULL, "https://example.test/x")
+        assert ok is True
+        # the add targeted the OVERFLOW, not the full FULL
+        argv = m_run.call_args.args[0]
+        assert self.OVERFLOW in argv and self.FULL not in argv


### PR DESCRIPTION
Clean re-cut of #1854 (which went DIRTY — W88 squash-divergence). Contains ONLY the B2 delta on top of main: `_resolve_writable_nb` (at-cap → registry peer overflow with room; fail-safe to skip+WARNING) + TestCapRollover. 34/34 nlm_feeder green. Supersedes #1854.

🤖 Generated with [Claude Code](https://claude.com/claude-code)