### PR TITLE
fix(wr2): cover-drop — per-slide render namespace race clobbered slide 1

### DIFF
--- a/scripts/wr2_html_renderer/composer.py
+++ b/scripts/wr2_html_renderer/composer.py
@@ -31,6 +31,7 @@ import asyncio
 import json
 import logging
 import re
+import shutil
 from dataclasses import dataclass
 from html import escape as _html_escape
 from pathlib import Path
@@ -1276,22 +1277,40 @@ def make_slide_render_fn(
     from .renderer import render_html_files
 
     async def _render_fn(slide_with_levers: dict[str, Any], png_path: Path) -> None:
-        # Re-materialize THIS slide's HTML with the loop's accumulated levers.
-        # materialize writes into slides_dir; the renderer expects assets +
-        # the HTML under output_dir/"slides", so we render with
-        # output_dir = slides_dir.parent and let it use slides_dir.
-        render_root = slides_dir.parent
+        # SLIDE-PRIVATE RENDER NAMESPACE (cover-drop fix 2026-06-30, superscar #5/#9):
+        # render_html_files names its output by the 1-based position in the spec
+        # list, which is ALWAYS 1 here (single-element list) → it writes "01.png".
+        # If that landed in the shared slides_dir, EVERY slide would transiently
+        # write slides_dir/01.png — clobbering slide 1's already-placed cover
+        # before the upload glob runs (observed: Drive got 02..08, no cover).
+        # Cure: render each slide into its OWN private scratch dir, then move the
+        # PNG to its canonical slot. The transient "01.png" can never collide with
+        # another slide's canonical home because it lives under .render-NN/slides/.
+        render_root = slides_dir / f".render-{index:02d}"
+        scratch_slides = render_root / "slides"
+        scratch_slides.mkdir(parents=True, exist_ok=True)
+        # Stage assets (fonts/logo/_base.css) into the scratch slides dir so the
+        # co-located HTML resolves them under one file:// origin, and copy the
+        # downloaded hero (if any) alongside — materialize/render expect both.
+        _stage_assets(scratch_slides)
+        if hero_filename:
+            hero_src = slides_dir / hero_filename
+            if hero_src.is_file():
+                shutil.copy2(hero_src, scratch_slides / hero_filename)
+        # Re-materialize THIS slide's HTML with the loop's accumulated levers into
+        # the private scratch dir.
         await materialize_slide_html(
-            slide_with_levers, slides_dir, index=index, total=total, hero_filename=hero_filename
+            slide_with_levers, scratch_slides, index=index, total=total, hero_filename=hero_filename
         )
-        html_path = slides_dir / f"{index:02d}.html"
-        # render_html_files writes PNG to (render_root/"slides")/f"{enum_idx:02d}.png"
-        # where enum_idx is the 1-based position in the list → always "01" here.
+        html_path = scratch_slides / f"{index:02d}.html"
         # Thread the layout family (same derivation materialize_slide_html used)
         # so the hero-visibility gate samples the right band for this layout.
         family = map_slide_to_family(slide_with_levers, index, total)
         if family in UNDEFINED_FAMILIES:
             family = "photo-headline-yellow-sub"
+        # render_html_files writes PNG to (render_root/"slides")/f"{enum_idx:02d}.png"
+        # with enum_idx always 1 (single-element list) → render_root/slides/01.png,
+        # which is now PRIVATE to this slide.
         res = await render_html_files(
             [(html_path, expect_hero_for_index(slide_with_levers, index), family)],
             render_root,
@@ -1302,12 +1321,16 @@ def make_slide_render_fn(
         if res.png_paths:
             produced = Path(res.png_paths[0])
         else:
-            cand = render_root / "slides" / "01.png"
+            cand = scratch_slides / "01.png"
             if cand.is_file():
                 produced = cand
         if produced and produced.is_file() and produced.resolve() != png_path.resolve():
             png_path.parent.mkdir(parents=True, exist_ok=True)
             produced.replace(png_path)
+        # Best-effort cleanup of the scratch dir so it never pollutes the upload
+        # glob (which scans slides_dir/*.png — .render-NN/ is a subdir so its PNGs
+        # are NOT globbed, but we remove it to keep the workspace clean).
+        shutil.rmtree(render_root, ignore_errors=True)
 
     return _render_fn
 

--- a/scripts/wr2_html_renderer/tests/test_cover_namespace_race.py
+++ b/scripts/wr2_html_renderer/tests/test_cover_namespace_race.py
@@ -1,0 +1,98 @@
+"""Regression test for the cover-drop bug (superscar #5 shared-namespace race /
+#9 path mutation drift), 2026-06-30.
+
+SYMPTOM: WR2 draft 62b6b577 rendered to status='rendered' but uploaded only
+`02.png..08.png + logo.png` to Drive — `01.png` (the cover) was MISSING. The
+carousel opened with the "OUR READ" editorial slide because the cover was gone.
+
+ROOT CAUSE: `make_slide_render_fn` rendered every slide via `render_html_files`
+with a SINGLE-element spec list. `render_html_files` names its output by the
+1-based position in that list (`renderer.py: png_path = slides_out/f"{idx:02d}.png"`),
+which is ALWAYS "01.png" for a 1-element list. The output landed in the SHARED
+`slides_dir` (render_root = slides_dir.parent → render_root/"slides" == slides_dir).
+So slide 2's render transiently wrote `slides_dir/01.png`, CLOBBERING slide 1's
+already-placed cover before the upload glob ran.
+
+CURE: render each slide into a PRIVATE scratch dir (`slides_dir/.render-NN/`),
+then move the PNG to its canonical slot. The transient "01.png" can no longer
+collide with another slide's canonical home.
+
+This test drives `make_slide_render_fn` for slide index 2 with a faked
+`render_html_files` that reproduces the real "always writes 01.png in its
+output_dir/slides" behavior, and asserts the pre-existing cover `slides_dir/01.png`
+SURVIVES and the slide-2 PNG lands at the slide-2 png_path.
+"""
+import sys
+import os
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+@pytest.mark.asyncio
+async def test_per_slide_render_does_not_clobber_the_cover(tmp_path, monkeypatch):
+    from wr2_html_renderer import composer as comp
+
+    slides_dir = tmp_path / "carousel" / "slides"
+    slides_dir.mkdir(parents=True, exist_ok=True)
+
+    # slide 1 (cover) already placed at its canonical slot by an earlier loop iter
+    cover = slides_dir / "01.png"
+    cover.write_bytes(b"COVER-PNG-ORIGINAL")
+
+    # avoid real asset staging + HTML materialization + browser
+    monkeypatch.setattr(comp, "_stage_assets", lambda *a, **k: None)
+
+    async def fake_materialize(slide, sdir, *, index, total, hero_filename=None):
+        # the real one writes {index:02d}.html into sdir; mimic that
+        Path(sdir).mkdir(parents=True, exist_ok=True)
+        (Path(sdir) / f"{index:02d}.html").write_text("<html></html>", encoding="utf-8")
+        return (Path(sdir) / f"{index:02d}.html", True)
+
+    monkeypatch.setattr(comp, "materialize_slide_html", fake_materialize)
+
+    class _Res:
+        # reproduce the REAL render_html_files contract: it writes
+        # output_dir/slides/01.png (1-based position in a 1-element list) and
+        # returns that path in png_paths.
+        def __init__(self, png_paths):
+            self.png_paths = png_paths
+
+    async def fake_render_html_files(specs, output_dir, *, timeout_ms=30000, make_pdf=True):
+        out = Path(output_dir) / "slides"
+        out.mkdir(parents=True, exist_ok=True)
+        png = out / "01.png"  # <-- the bug-shaped behavior: ALWAYS 01.png
+        png.write_bytes(b"SLIDE-2-PNG")
+        return _Res([png])
+
+    # render_html_files is imported INSIDE make_slide_render_fn via
+    # `from .renderer import render_html_files`, so patch it on the renderer module.
+    from wr2_html_renderer import renderer as rnd
+    monkeypatch.setattr(rnd, "render_html_files", fake_render_html_files)
+
+    render_fn = comp.make_slide_render_fn(
+        slides_dir=slides_dir, index=2, total=8, hero_filename=None, timeout_ms=1000,
+    )
+    slide2_png = slides_dir / "02.png"
+    await render_fn({"headline": "B", "body": "x"}, slide2_png)
+
+    # THE COVER MUST SURVIVE — this is the whole bug.
+    assert cover.is_file(), "cover 01.png was clobbered by slide-2 render"
+    assert cover.read_bytes() == b"COVER-PNG-ORIGINAL", "cover content was overwritten"
+    # and slide 2 must land at its own slot
+    assert slide2_png.is_file(), "slide-2 PNG did not land at its canonical slot"
+    assert slide2_png.read_bytes() == b"SLIDE-2-PNG"
+    # the private scratch dir must be cleaned up (no .render-02 pollution)
+    assert not (slides_dir / ".render-02").exists(), "scratch dir not cleaned"
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    class _MP:
+        def setattr(self, o, n, v):
+            setattr(o, n, v)
+    # minimal manual run not supported (needs monkeypatch fixture); use pytest.
+    print("run via: pytest scripts/wr2_html_renderer/tests/test_cover_namespace_race.py -q")


### PR DESCRIPTION
## Why

WR2 draft `62b6b577` rendered to `status='rendered'` but Drive received only `02.png..08.png + logo.png` — **`01.png` (the cover) was MISSING**. The carousel opened with the "OUR READ" editorial slide because the cover was gone. (User caught it: "non c'è la cover slide, c'è B211, c'è OUR READ... ma cosa cazzo è?")

## Root cause (superscar #5 shared-namespace race / #9 path mutation drift)

`make_slide_render_fn` renders every slide via `render_html_files` with a **single-element spec list**. `render_html_files` names its output by the **1-based position in that list** (`renderer.py: png_path = slides_out/f"{idx:02d}.png"`) → **always `01.png`** for a 1-element list. With `render_root = slides_dir.parent`, that output landed in the **shared `slides_dir`**.

Sequence: slide 1 places the cover at `slides_dir/01.png` → **slide 2's render writes its transient screenshot to that same `slides_dir/01.png`, clobbering the cover**, then `.replace()`-moves it away to its loop dir. The cover is destroyed and never restored. The upload glob (`slides_dir.glob("*.png")`) sees only `02..08`.

Empirically reproduced (instrumented /tmp repro against the real draft's `slides_json`, no paid vision): bulk path produces `01..08.png` fine; per-slide path drops `01` → exact production symptom.

**This is the bug N-1 (PR #1856) could not catch**: `final_pngs` counted 8 (the cover WAS placed, then overwritten *after* the count), so the `len==total` guard passed. The defect is upstream of N-1, in the shared render namespace.

## Cure

Render each slide into a **private scratch dir** (`slides_dir/.render-NN/`) with its own staged assets + hero, then move the PNG to its canonical slot. The transient `01.png` now lives under `.render-NN/slides/` and can never collide with another slide's canonical home. Scratch is `rmtree`'d after each slide; the upload glob is flat so it never sees the subdir transients anyway (defense in depth).

## Tests

`test_cover_namespace_race.py` drives slide-2 render with a faked `render_html_files` reproducing the "always writes 01.png" behavior, asserts the pre-placed cover **survives** + slide-2 lands at its slot + scratch is cleaned. **138 tests green** across the touched WR2 files (109 render-apply incl. N-1, 7 composer/orphan, 22 pipeline).

Adversarial check: confirmed the upload glob is non-recursive (`glob`, not `rglob`) so subdir transients are never picked up even pre-cleanup; verified root cause independently against live Pro `renderer.py:292-293`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)