### PR TITLE
fix(wr2): editorial-text dead-air — reserve logo band + space-evenly

### DIFF
--- a/skills/bali-zero-brand/layouts/editorial-text.md
+++ b/skills/bali-zero-brand/layouts/editorial-text.md
@@ -16,84 +16,100 @@
 ## Parameters
 
 ```yaml
-subheading: string  # 2-8 words UPPERCASE yellow accent (optional kicker)
-heading: string  # 4-10 words UPPERCASE
-body: string  # 25-110 words UPPERCASE, 2-5 sentences (more room — no photo)
+subheading: string # 2-8 words UPPERCASE yellow accent (optional kicker)
+heading: string # 4-10 words UPPERCASE
+body: string # 25-110 words UPPERCASE, 2-5 sentences (more room — no photo)
 ```
 
 ## HTML/CSS skeleton
 
 ```html
 <!doctype html>
-<html><head>
-<link rel="stylesheet" href="../_base.css">
-<style>
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@700;800&display=swap');
-.text-panel {
-  width: var(--canvas-width); height: var(--canvas-height);
-  background: var(--color-bg-antracite);
-  /* Vertically CENTRE the stack so the empty anthracite distributes
-     symmetrically above and below (balanced "breathing room") instead of
-     piling into one half — top-anchoring left a ~50% bottom void the vision
-     critic read as a layout bug, and bottom-anchoring left a top void
-     (2026-06-13 E2E, both rejected). A large heading (84px) + sentence-case
-     body fills more of the canvas so the residual void is small and centred.
-     A top yellow rule anchors the block editorially (NYT/FT). Per-element
-     margin-bottom drives vertical rhythm (no flex gap — Golden Visa fix). */
-  padding: 110px var(--spacing-edge-margin) 180px var(--spacing-edge-margin);
-  display: flex; flex-direction: column;
-  justify-content: center;
-}
-.top-rule {
-  width: 90px; height: 8px;
-  background: var(--color-accent-yellow);
-  margin-bottom: 44px;
-}
-.subheading {
-  font-weight: var(--font-weight-bold);
-  font-size: var(--font-size-subheadline);
-  line-height: var(--line-height-snug);
-  letter-spacing: var(--letter-spacing-title);
-  color: var(--color-accent-yellow);
-  text-transform: uppercase;
-  margin-bottom: 16px;
-}
-.heading {
-  font-weight: var(--font-weight-extrabold);
-  /* 84px (was 60px): on a text-only slide the headline is the only large
+<html>
+  <head>
+    <link rel="stylesheet" href="../_base.css" />
+    <style>
+      @import url("https://fonts.googleapis.com/css2?family=Montserrat:wght@700;800&display=swap");
+      .text-panel {
+        width: var(--canvas-width);
+        /* DEAD-AIR FIX 2026-06-30 (measured): the panel was full canvas height
+     (1350px) and centred its stack with justify-content:center, but the .logo
+     is position:absolute (bottom:70px) — INVISIBLE to the flex layout, so it
+     reserved no space. On a short (2-sentence) body the centred stack ended at
+     ~y889 while the logo sat fixed at y1200 → a measured 23% dead band between
+     them ("logo floats disconnected", "content anchored upper 40-45%"). The
+     asymmetric 110/180 padding biased the block a further 35px upward.
+     CURE: shrink the panel to canvas-minus-logo-band (250px = 80 logo + 70
+     bottom margin + 100 buffer) so the flow ends ABOVE the logo, drop the
+     asymmetric vertical padding, and distribute slack with space-evenly so a
+     short body fills the upper-three-quarters and the logo closes the frame
+     (gap lands in the healthy 12-18% range). A long body has little slack so
+     space-evenly degrades to near-centre automatically — both extremes balance.
+     Measured (2026-06-30): short body→logo gap 23%→15%, long 16.5%→~11% with
+     the 250px band (the 230px band measured 9.8% on a ~90-word long body — near
+     the 8% floor; 250px buys headroom for max-length ~110-word bodies). A top
+     yellow rule anchors the block editorially (NYT/FT). Per-element
+     margin-bottom still drives heading↔body rhythm. */
+        height: calc(var(--canvas-height) - 250px);
+        background: var(--color-bg-antracite);
+        padding: 0 var(--spacing-edge-margin);
+        display: flex;
+        flex-direction: column;
+        justify-content: space-evenly;
+      }
+      .top-rule {
+        width: 90px;
+        height: 8px;
+        background: var(--color-accent-yellow);
+        margin-bottom: 44px;
+      }
+      .subheading {
+        font-weight: var(--font-weight-bold);
+        font-size: var(--font-size-subheadline);
+        line-height: var(--line-height-snug);
+        letter-spacing: var(--letter-spacing-title);
+        color: var(--color-accent-yellow);
+        text-transform: uppercase;
+        margin-bottom: 16px;
+      }
+      .heading {
+        font-weight: var(--font-weight-extrabold);
+        /* 84px (was 60px): on a text-only slide the headline is the only large
      element — it must dominate and help fill the canvas (2026-06-13). */
-  font-size: var(--font-size-headline-cover);
-  line-height: var(--line-height-tight);
-  letter-spacing: var(--letter-spacing-title);
-  color: var(--color-text-white);
-  text-transform: uppercase;
-  text-wrap: balance;
-  margin-bottom: 32px;
-  /* gap to body absorbs a 2-3 line heading wrap without bleed. */
-}
-.body {
-  font-weight: var(--font-weight-bold);
-  font-size: var(--font-size-body-lg);
-  line-height: var(--line-height-normal);
-  letter-spacing: var(--letter-spacing-body);
-  color: var(--color-text-white);
-  /* Sentence case (NOT all-caps): an all-caps bold body shared the exact
+        font-size: var(--font-size-headline-cover);
+        line-height: var(--line-height-tight);
+        letter-spacing: var(--letter-spacing-title);
+        color: var(--color-text-white);
+        text-transform: uppercase;
+        text-wrap: balance;
+        margin-bottom: 32px;
+        /* gap to body absorbs a 2-3 line heading wrap without bleed. */
+      }
+      .body {
+        font-weight: var(--font-weight-bold);
+        font-size: var(--font-size-body-lg);
+        line-height: var(--line-height-normal);
+        letter-spacing: var(--letter-spacing-body);
+        color: var(--color-text-white);
+        /* Sentence case (NOT all-caps): an all-caps bold body shared the exact
      typographic register of the all-caps heading (flat hierarchy, vision
      critic 2026-06-13) AND read as a dense grey block. Sentence case gives a
      clear register break from the UPPERCASE heading and is far more legible
      for 2-5 sentences of prose. */
-  text-transform: none;
-}
-</style></head>
-<body>
-  <div class="text-panel" data-zone-type="text">
-    <div class="top-rule"></div>
-    <div class="subheading">{{subheading}}</div>
-    <div class="heading">{{heading}}</div>
-    <div class="body">{{body}}</div>
-  </div>
-  <div class="logo" data-zone-type="logo">3 ALI ZERO</div>
-</body></html>
+        text-transform: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="text-panel" data-zone-type="text">
+      <div class="top-rule"></div>
+      <div class="subheading">{{subheading}}</div>
+      <div class="heading">{{heading}}</div>
+      <div class="body">{{body}}</div>
+    </div>
+    <div class="logo" data-zone-type="logo">3 ALI ZERO</div>
+  </body>
+</html>
 ```
 
 ## Common failures


### PR DESCRIPTION
## Why

Text-only slides (`editorial-text` family) rendered with a **measured ~23% dead band** between the body bottom and the logo on short bodies. The vision critic repeatedly flagged "content anchored in the upper 40-45%", "logo floats disconnected at the bottom", "dead air". On draft `62b6b577` this made **6+ slides non-converge** (placed as N-1 composition debt) — the real reason the carousel still looked broken after the cover-drop fix (#1860).

## Root cause (measured on Pro, 1080×1350)

`.text-panel` was the **full canvas height (1350px)** and centred its stack with `justify-content: center`, but the `.logo` is `position:absolute` (bottom:70px) — **invisible to the flex layout**, reserving no space. A short body's centred stack ended at ~y889 while the logo sat fixed at y1200 → **311px (23.1%) of pure dead anthracite** between them. The asymmetric 110/180 padding biased the block a further 35px upward.

## Cure (3 declarations in `.text-panel` only — `.logo` + cover-photo untouched)

| | old | new |
|---|---|---|
| height | `var(--canvas-height)` | `calc(var(--canvas-height) - 250px)` |
| padding | `110px <edge> 180px <edge>` | `0 <edge>` |
| justify-content | `center` | `space-evenly` |

The 250px reserved band (80 logo + 70 margin + 100 buffer) makes the flow end **above** the logo; `space-evenly` distributes the slack so a short body fills the upper-three-quarters and the logo closes the frame.

## Measured before/after (% of 1350)

| Metric | OLD short | NEW short | OLD long | NEW long |
|---|---|---|---|---|
| Top void | 29% | **9.2%** | — | ~4% |
| **Body→logo gap** | **23.1%** | **15.2%** | **16.5%** | **~11%** |
| Body overflow? | — | no | — | no |

Short gap 23.1% → 15.2% (healthy 12-18% band); long stays ≥8% (no collision). No overflow on either extreme. **Independently verified by a render + getBoundingClientRect repro on Pro** (two subagent passes: measure-the-bug, then verify-the-fix).

> File reflowed by the repo's prettier pre-commit hook — the substantive change is the 3 `.text-panel` declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)