### PR TITLE
feat(mata-garuda): #4 archiver — durable SQLite cold-store of enriched corpus

### DIFF
--- a/apps/mata-garuda/infra/launchagents/install_archiver_cron.sh
+++ b/apps/mata-garuda/infra/launchagents/install_archiver_cron.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Install the mata_garuda archiver as an hourly LaunchAgent on the Pro.
+#
+# Council pattern (cold-store / Lambda-arch slow path): the Redis streams are a
+# bounded HOT buffer (MAXLEN-capped). The archiver is the DURABLE record — it
+# consumes garuda:enriched and appends every item to data/archive.db (stdlib
+# SQLite, WAL). This gives full-corpus auditability WITHOUT growing Redis RAM:
+# the cap can trim freely because the archive holds the history.
+#
+# Design (same discipline as the pipeline-health cron):
+#  - Runs the venv python DIRECTLY (adhoc-signed, fast, no nlm-headless → no -9
+#    hang) — NO ~/scripts wrapper (avoids cicatrix #1 HOME-fork).
+#  - Targets the CANONICAL Pro Redis (127.0.0.1) — NOT Mini. (cicatrix #10
+#    split-brain: a stale GARUDA_REDIS_HOST=<mini> override made the feeder read
+#    the wrong empty Redis for days. The canonical is Pro; opt out of -h via the
+#    local sentinel.)
+#  - StartInterval 3600 (hourly) + RunAtLoad. plist chmod 600 (carries the Redis
+#    password — cicatrix #4).
+#  - Logs to ~/logs/matagaruda-archiver.log
+set -euo pipefail
+
+REPO="$HOME/Desktop/nuzantara"
+VENV="$REPO/apps/mata-garuda/.venv/bin/python"
+LABEL="com.matagaruda.archiver.hourly"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+LOG="$HOME/logs/matagaruda-archiver.log"
+SECRETS="$HOME/.nuzantara-secrets.env"
+
+mkdir -p "$HOME/logs" "$REPO/apps/mata-garuda/data"
+
+# pull the Redis password (no echo — never print values)
+[ -f "$SECRETS" ] && set -a && . "$SECRETS" && set +a || true
+RPW="${GARUDA_REDIS_PASSWORD:-}"
+
+cat > "$PLIST" <<PLIST_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>$LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$VENV</string>
+    <string>-u</string>
+    <string>-m</string>
+    <string>mata_garuda.workers.archiver</string>
+  </array>
+  <key>WorkingDirectory</key><string>$REPO/apps/mata-garuda</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PYTHONPATH</key><string>$REPO/apps/mata-garuda</string>
+    <key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:/usr/bin:/bin</string>
+    <key>GARUDA_CANONICAL_REDIS_HOST</key><string>127.0.0.1</string>
+    <key>GARUDA_REDIS_PASSWORD</key><string>$RPW</string>
+    <key>GARUDA_ARCHIVE_MAX_ITEMS</key><string>1000</string>
+  </dict>
+  <key>StartInterval</key><integer>3600</integer>
+  <key>RunAtLoad</key><true/>
+  <key>StandardOutPath</key><string>$LOG</string>
+  <key>StandardErrorPath</key><string>$LOG</string>
+</dict>
+</plist>
+PLIST_EOF
+
+chmod 600 "$PLIST"   # carries the Redis password — never world-readable (cicatrix #4)
+
+launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST"
+launchctl kickstart "gui/$(id -u)/$LABEL"
+
+echo "installed + kicked: $LABEL"
+echo "plist: $PLIST (perms $(stat -f %Lp "$PLIST"))"
+echo "log:   $LOG"
+sleep 8
+echo "--- first run output ---"
+tail -10 "$LOG" 2>/dev/null

--- a/apps/mata-garuda/mata_garuda/workers/archiver.py
+++ b/apps/mata-garuda/mata_garuda/workers/archiver.py
@@ -1,0 +1,180 @@
+"""
+Mata Garuda — Archiver Worker.
+
+Council pattern (Kafka log-compaction / Recorded Future cold-store / Dataminr
+Lambda-arch slow path): the Redis streams are a HOT, BOUNDED buffer (now MAXLEN-
+capped — bounded RAM). That cap means old entries are trimmed and lost. The
+archiver is the DURABLE record: it consumes garuda:enriched via its own consumer
+group and appends every item to an on-disk SQLite archive. This gives full-corpus
+auditability WITHOUT growing Redis RAM — the cap can trim freely because the
+archive holds the history.
+
+Stdlib-only (sqlite3) — mata_garuda vincolo is pydantic+pytest, NO new deps. The
+council suggested DuckDB/Parquet, but those would be new dependencies; SQLite is
+the stdlib equivalent and matches the existing KnowledgeBase store (data/*.db).
+Mirrors runtime/knowledge.py exactly: WAL + synchronous=NORMAL, Row factory,
+CREATE TABLE IF NOT EXISTS, data/ dir (gitignored).
+
+Idempotent by content_hash (UNIQUE) — re-archiving an already-stored item is a
+no-op INSERT OR IGNORE, so redelivery (PEL replay) never double-counts.
+
+Layer 2.5 — cold-store tap off the enriched stream. Does NOT publish anything
+back (terminal Sink — council: don't re-publish to a stream you consume).
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from mata_garuda.config import STREAM_ENRICHED
+from mata_garuda.workers.base_worker import stream_ack, stream_read_new
+
+logger = logging.getLogger("mata_garuda.workers")
+
+CONSUMER_GROUP = "archiver"
+CONSUMER_NAME = "archiver-1"
+
+DEFAULT_ARCHIVE_PATH = Path(__file__).parent.parent.parent / "data" / "archive.db"
+
+
+class StreamArchive:
+    """On-disk, append-only SQLite archive of every enriched intel item.
+
+    Mirrors runtime.knowledge.KnowledgeBase's connection discipline (WAL +
+    synchronous=NORMAL + Row factory) so two writers on the same machine never
+    hit the transient 'disk I/O error' (2026-05-06 scar).
+    """
+
+    def __init__(self, db_path: Optional[Path] = None):
+        self.db_path = db_path or DEFAULT_ARCHIVE_PATH
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA journal_mode = WAL")
+        self._conn.execute("PRAGMA synchronous = NORMAL")
+        self._init_tables()
+
+    def _init_tables(self) -> None:
+        self._conn.executescript("""
+            CREATE TABLE IF NOT EXISTS archive (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                content_hash TEXT UNIQUE,
+                stream_id TEXT,
+                title TEXT,
+                url TEXT,
+                source TEXT,
+                source_type TEXT,
+                content TEXT,
+                score TEXT,
+                agent TEXT,
+                harvested_ts TEXT,
+                archived_at TEXT DEFAULT (datetime('now'))
+            );
+            CREATE INDEX IF NOT EXISTS idx_archive_source ON archive(source);
+            CREATE INDEX IF NOT EXISTS idx_archive_archived ON archive(archived_at);
+        """)
+        self._conn.commit()
+
+    def archive(self, stream_id: str, data: dict) -> bool:
+        """Insert one enriched item. INSERT OR IGNORE on content_hash → idempotent.
+
+        Returns True if a NEW row was inserted, False if it was a duplicate.
+        """
+        chash = (data.get("content_hash")
+                 or data.get("url")
+                 or f"{data.get('title','')}{stream_id}")
+        cursor = self._conn.execute(
+            "INSERT OR IGNORE INTO archive "
+            "(content_hash, stream_id, title, url, source, source_type, "
+            " content, score, agent, harvested_ts) "
+            "VALUES (?,?,?,?,?,?,?,?,?,?)",
+            (
+                chash,
+                stream_id,
+                data.get("title", ""),
+                data.get("url", ""),
+                data.get("source", ""),
+                data.get("source_type", data.get("source", "")),
+                (data.get("content", "") or "")[:8000],
+                str(data.get("score", data.get("relevance", ""))),
+                data.get("agent", "unknown"),
+                data.get("timestamp", data.get("normalized_at", "")),
+            ),
+        )
+        self._conn.commit()
+        return cursor.rowcount > 0
+
+    def count(self) -> int:
+        return self._conn.execute("SELECT COUNT(*) FROM archive").fetchone()[0]
+
+    def close(self) -> None:
+        self._conn.close()
+
+
+def run_archiver(archive: StreamArchive, max_items: int = 200) -> dict:
+    """Run one pass of the archiver.
+
+    Reads garuda:enriched (own consumer group), appends each item to the on-disk
+    archive, ACKs. Terminal Sink — publishes nothing back.
+
+    Returns stats dict: {processed, archived, duplicates, errors}.
+    """
+    stats = {"processed": 0, "archived": 0, "duplicates": 0, "errors": 0}
+
+    items = stream_read_new(
+        STREAM_ENRICHED, CONSUMER_GROUP, CONSUMER_NAME, count=max_items)
+    if not items:
+        logger.info("[archiver] No new items in garuda:enriched")
+        return stats
+
+    for item in items:
+        msg_id = item["id"]
+        data = item["data"]
+        stats["processed"] += 1
+        try:
+            is_new = archive.archive(msg_id, data)
+            if is_new:
+                stats["archived"] += 1
+            else:
+                stats["duplicates"] += 1
+            # ACK in BOTH cases: a duplicate is fully handled (already on disk),
+            # so it must leave the PEL — else it redelivers forever and lag grows.
+            stream_ack(STREAM_ENRICHED, CONSUMER_GROUP, msg_id)
+        except Exception as e:
+            logger.error(f"[archiver] Error archiving {msg_id}: {e}")
+            stats["errors"] += 1
+            # do NOT ack on error → redelivered next pass (at-least-once)
+
+    logger.info(
+        f"[archiver] Done: {stats['processed']} processed, "
+        f"{stats['archived']} archived, {stats['duplicates']} dupes, "
+        f"total={archive.count()}"
+    )
+    return stats
+
+
+def main() -> int:
+    """Cron entrypoint: one archiver pass. Exit 0 on success, 1 on hard error."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    max_items = int(os.environ.get("GARUDA_ARCHIVE_MAX_ITEMS", "500"))
+    archive = StreamArchive()
+    try:
+        stats = run_archiver(archive, max_items=max_items)
+        print(f"[archiver] {stats} total_archived={archive.count()}")
+        return 0
+    except Exception as e:  # noqa: BLE001 — top-level cron guard
+        logger.error(f"[archiver] FATAL: {e}")
+        return 1
+    finally:
+        archive.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/mata-garuda/tests/test_archiver.py
+++ b/apps/mata-garuda/tests/test_archiver.py
@@ -1,0 +1,89 @@
+"""Tests for the archiver worker (#4 — durable cold-store, stdlib SQLite)."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from mata_garuda.workers import archiver
+from mata_garuda.workers.archiver import StreamArchive, run_archiver
+
+
+def _enriched(msg_id, **data):
+    return {"id": msg_id, "data": data}
+
+
+class TestStreamArchive:
+    def test_archive_inserts_new_row(self, tmp_path: Path):
+        a = StreamArchive(db_path=tmp_path / "a.db")
+        assert a.archive("1-0", {"content_hash": "h1", "title": "t", "url": "u"}) is True
+        assert a.count() == 1
+        a.close()
+
+    def test_archive_idempotent_on_content_hash(self, tmp_path: Path):
+        a = StreamArchive(db_path=tmp_path / "a.db")
+        assert a.archive("1-0", {"content_hash": "h1", "title": "t"}) is True
+        # same hash, different stream id → must NOT double-insert
+        assert a.archive("2-0", {"content_hash": "h1", "title": "t-again"}) is False
+        assert a.count() == 1
+        a.close()
+
+    def test_falls_back_to_url_then_title_for_hash(self, tmp_path: Path):
+        a = StreamArchive(db_path=tmp_path / "a.db")
+        # no content_hash → uses url as the dedup key
+        assert a.archive("1-0", {"url": "http://x/1", "title": "t"}) is True
+        assert a.archive("2-0", {"url": "http://x/1", "title": "t2"}) is False  # same url
+        assert a.count() == 1
+        a.close()
+
+    def test_persists_across_reopen(self, tmp_path: Path):
+        p = tmp_path / "a.db"
+        a = StreamArchive(db_path=p)
+        a.archive("1-0", {"content_hash": "h1"})
+        a.close()
+        b = StreamArchive(db_path=p)   # reopen — durable, survives process death
+        assert b.count() == 1
+        b.close()
+
+
+class TestRunArchiver:
+    def _run(self, items, archive):
+        with patch.object(archiver, "stream_read_new", return_value=items), \
+             patch.object(archiver, "stream_ack", return_value=True) as m_ack:
+            stats = run_archiver(archive, max_items=100)
+        return stats, m_ack
+
+    def test_archives_and_acks_new_items(self, tmp_path: Path):
+        a = StreamArchive(db_path=tmp_path / "a.db")
+        stats, m_ack = self._run([
+            _enriched("1-0", content_hash="h1", title="a"),
+            _enriched("2-0", content_hash="h2", title="b"),
+        ], a)
+        assert stats["archived"] == 2 and stats["processed"] == 2
+        assert m_ack.call_count == 2          # both acked
+        assert a.count() == 2
+        a.close()
+
+    def test_duplicate_is_acked_not_replayed(self, tmp_path: Path):
+        a = StreamArchive(db_path=tmp_path / "a.db")
+        a.archive("0-0", {"content_hash": "dup"})   # pre-existing
+        stats, m_ack = self._run([_enriched("1-0", content_hash="dup", title="x")], a)
+        assert stats["duplicates"] == 1 and stats["archived"] == 0
+        m_ack.assert_called_once()             # dupe MUST ack (else PEL grows forever)
+        a.close()
+
+    def test_empty_stream_no_error(self, tmp_path: Path):
+        a = StreamArchive(db_path=tmp_path / "a.db")
+        stats, _ = self._run([], a)
+        assert stats == {"processed": 0, "archived": 0, "duplicates": 0, "errors": 0}
+        a.close()
+
+    def test_error_does_not_ack(self, tmp_path: Path):
+        a = StreamArchive(db_path=tmp_path / "a.db")
+        with patch.object(archiver, "stream_read_new",
+                          return_value=[_enriched("1-0", content_hash="h")]), \
+             patch.object(a, "archive", side_effect=RuntimeError("boom")), \
+             patch.object(archiver, "stream_ack") as m_ack:
+            stats = run_archiver(a, max_items=10)
+        assert stats["errors"] == 1
+        m_ack.assert_not_called()              # at-least-once: no ack on error
+        a.close()


### PR DESCRIPTION
Council cold-store / Lambda-arch slow path: the Redis streams are MAXLEN-capped (bounded HOT buffer); the archiver is the DURABLE record. Terminal Sink on `garuda:enriched` → appends every item to `data/archive.db` (stdlib sqlite3, WAL, gitignored). Full-corpus auditability WITHOUT growing Redis RAM.

**Stdlib-only** (mata_garuda vincolo = pydantic+pytest, no new deps; SQLite is the stdlib equivalent of the council's DuckDB suggestion, matches existing `runtime/knowledge.py`). Idempotent by `content_hash` (INSERT OR IGNORE). ACKs dupes too (else PEL grows); no-ack on error (at-least-once).

**Proven live on Pro:** 300 processed → 274 archived + 26 dupes, 0 errors; `data/archive.db` 172KB, 274 rows across all sources (arxiv 90 / rss 75 / peraturan.go.id 31 / github / youtube / exa.ai). Survives reopen.

**Cron:** `install_archiver_cron.sh` → `com.matagaruda.archiver.hourly`, venv python direct (no HOME-fork), canonical Pro Redis (cicatrix #10), plist 600 (cicatrix #4).

TDD: `test_archiver` 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)