### PR TITLE
feat(mata-garuda): #5 summarize-then-store — daily NLM rollup (499:1 compaction)

### DIFF
--- a/apps/mata-garuda/infra/launchagents/install_rollup_cron.sh
+++ b/apps/mata-garuda/infra/launchagents/install_rollup_cron.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Install the mata_garuda NLM daily-rollup (#5 summarize-then-store) as a daily
+# LaunchAgent on the Pro.
+#
+# Council daily-rollup / log-compaction: NLM is a HARD-capped sink (~500 sources).
+# This rolls up the archived enriched corpus into ONE digest source per (day,
+# domain) — a day of intel = 1 source, so the cap holds ~500 DAYS not ~500 items.
+# Reads FROM the archive (the durable store), posts title-preserving digests.
+#
+# Cadence: DAILY (not hourly) at 23:30 WITA — runs after the day's harvest/score so
+# the digest is complete. Idempotent (rollup_ledger), so an extra run is harmless.
+# venv python direct (no HOME-fork), canonical Pro Redis is irrelevant here (reads
+# SQLite), but NLM auth needs the `nlm` CLI profile. plist chmod 600 (no Redis pw
+# needed, but keep restrictive).
+set -euo pipefail
+
+REPO="$HOME/Desktop/nuzantara"
+VENV="$REPO/apps/mata-garuda/.venv/bin/python"
+LABEL="com.matagaruda.nlm-rollup.daily"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+LOG="$HOME/logs/matagaruda-nlm-rollup.log"
+
+mkdir -p "$HOME/logs"
+
+cat > "$PLIST" <<PLIST_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>$LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$VENV</string>
+    <string>-u</string>
+    <string>-m</string>
+    <string>mata_garuda.workers.nlm_rollup</string>
+  </array>
+  <key>WorkingDirectory</key><string>$REPO/apps/mata-garuda</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PYTHONPATH</key><string>$REPO/apps/mata-garuda</string>
+    <key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:/usr/bin:/bin</string>
+    <key>GARUDA_ROLLUP_DAYS_BACK</key><string>3</string>
+  </dict>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key><integer>23</integer>
+    <key>Minute</key><integer>30</integer>
+  </dict>
+  <key>RunAtLoad</key><false/>
+  <key>StandardOutPath</key><string>$LOG</string>
+  <key>StandardErrorPath</key><string>$LOG</string>
+</dict>
+</plist>
+PLIST_EOF
+
+chmod 600 "$PLIST"
+
+launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST"
+
+echo "installed: $LABEL (daily 23:30 WITA)"
+echo "plist: $PLIST (perms $(stat -f %Lp "$PLIST"))"
+echo "log:   $LOG"
+echo "manual test: launchctl kickstart gui/\$(id -u)/$LABEL"

--- a/apps/mata-garuda/mata_garuda/workers/archiver.py
+++ b/apps/mata-garuda/mata_garuda/workers/archiver.py
@@ -70,6 +70,7 @@ class StreamArchive:
                 source_type TEXT,
                 content TEXT,
                 score TEXT,
+                domain TEXT,
                 agent TEXT,
                 harvested_ts TEXT,
                 archived_at TEXT DEFAULT (datetime('now'))
@@ -77,6 +78,13 @@ class StreamArchive:
             CREATE INDEX IF NOT EXISTS idx_archive_source ON archive(source);
             CREATE INDEX IF NOT EXISTS idx_archive_archived ON archive(archived_at);
         """)
+        # Guarded migration: add `domain` to DBs created before this column existed.
+        cols = [r[1] for r in self._conn.execute("PRAGMA table_info(archive)").fetchall()]
+        if "domain" not in cols:
+            self._conn.execute("ALTER TABLE archive ADD COLUMN domain TEXT")
+        # domain column now exists on every path → safe to index unconditionally.
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_archive_domain ON archive(domain)")
         self._conn.commit()
 
     def archive(self, stream_id: str, data: dict) -> bool:
@@ -90,8 +98,8 @@ class StreamArchive:
         cursor = self._conn.execute(
             "INSERT OR IGNORE INTO archive "
             "(content_hash, stream_id, title, url, source, source_type, "
-            " content, score, agent, harvested_ts) "
-            "VALUES (?,?,?,?,?,?,?,?,?,?)",
+            " content, score, domain, agent, harvested_ts) "
+            "VALUES (?,?,?,?,?,?,?,?,?,?,?)",
             (
                 chash,
                 stream_id,
@@ -100,7 +108,8 @@ class StreamArchive:
                 data.get("source", ""),
                 data.get("source_type", data.get("source", "")),
                 (data.get("content", "") or "")[:8000],
-                str(data.get("score", data.get("relevance", ""))),
+                str(data.get("relevance_score", data.get("score", data.get("relevance", "")))),
+                data.get("domain", ""),
                 data.get("agent", "unknown"),
                 data.get("timestamp", data.get("normalized_at", "")),
             ),

--- a/apps/mata-garuda/mata_garuda/workers/nlm_rollup.py
+++ b/apps/mata-garuda/mata_garuda/workers/nlm_rollup.py
@@ -1,0 +1,213 @@
+"""
+Mata Garuda — NLM Daily Rollup (summarize-then-store, council fix #5).
+
+THE PROBLEM (Zero's call 2026-06-30): NLM is a HARD-capped sink (~500 sources/NB).
+The per-item feeder, even with the relevance threshold (#3), burns one NLM source
+per intel item — a few thousand items would blow the cap. Feeding 5266 backlogged
+items one-by-one is exactly what this exists to prevent.
+
+THE CURE (council: Kafka log-compaction / daily-rollup): instead of N sources,
+write ONE digest source per (day, domain). The durable per-item record already
+lives in the archiver SQLite (#4) — NLM only needs the COMPACTED, queryable
+summary. This turns thousands of items into a handful of rollup sources → fits the
+cap with room for ~500 DAYS of intel instead of ~500 items.
+
+Reads FROM the archive (the "store" in summarize-then-store), groups by
+(date, domain), composes a deterministic digest (NO LLM — a digest of
+titles+urls+scores is mechanical, robust, quota-free, hallucination-free), and
+pushes one text source per group via the feeder's existing _nlm_add_text (which
+carries cap-rollover B2 + auth). Idempotent: a per-(date,domain) ledger row marks
+what's been rolled up, so re-runs never double-post.
+
+Stdlib-only (sqlite3). Layer 2.6 — compaction Sink off the archive, NOT the stream
+(council: don't re-consume the hot stream; the archive is the system of record).
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+from collections import defaultdict
+from pathlib import Path
+from typing import Optional
+
+from mata_garuda.workers.archiver import DEFAULT_ARCHIVE_PATH
+import subprocess
+from mata_garuda.workers.nlm_feeder import (
+    NLM_CLI,
+    _nlm_at_cap,
+    _resolve_writable_nb,
+    route_domain_to_notebook,
+)
+
+logger = logging.getLogger("mata_garuda.workers")
+
+# Only items scoring >= this make the digest body (keep rollups signal-dense).
+ROLLUP_MIN_SCORE = int(os.environ.get("GARUDA_ROLLUP_MIN_SCORE", "3"))
+# Domain fallback for un-classified / legacy-null items (the OSINT intel home).
+ROLLUP_DEFAULT_DOMAIN = os.environ.get("GARUDA_ROLLUP_DEFAULT_DOMAIN", "ai_research")
+MAX_ITEMS_PER_DIGEST = int(os.environ.get("GARUDA_ROLLUP_MAX_LINES", "80"))
+
+
+def _ensure_ledger(conn: sqlite3.Connection) -> None:
+    """Idempotency ledger: one row per (day, domain) already posted to NLM."""
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS rollup_ledger (
+            day TEXT NOT NULL,
+            domain TEXT NOT NULL,
+            notebook_id TEXT,
+            item_count INTEGER,
+            posted_at TEXT DEFAULT (datetime('now')),
+            PRIMARY KEY (day, domain)
+        )
+    """)
+    conn.commit()
+
+
+def _score_ok(raw) -> bool:
+    try:
+        return int(float(raw)) >= ROLLUP_MIN_SCORE
+    except (TypeError, ValueError):
+        return True  # un-scored → include (fail-open, same spirit as the feeder)
+
+
+def _compose_digest(day: str, domain: str, rows: list) -> tuple[str, str]:
+    """Build (title, body) for one (day, domain) digest. Deterministic, no LLM."""
+    title = f"Intel rollup {day} — {domain} ({len(rows)} items)"
+    lines = [
+        f"# Bali Zero OSINT intel digest — {day} — domain: {domain}",
+        f"# {len(rows)} items (signal score >= {ROLLUP_MIN_SCORE}); compacted by nlm_rollup #5.",
+        "",
+    ]
+    for r in rows[:MAX_ITEMS_PER_DIGEST]:
+        sc = (r["score"] or "").strip()
+        src = (r["source"] or "").strip()
+        tag = f"[{src}{('/'+sc) if sc else ''}]"
+        line = f"- {tag} {(r['title'] or '').strip()}"
+        url = (r["url"] or "").strip()
+        if url:
+            line += f"\n  {url}"
+        snippet = (r["content"] or "").strip().replace("\n", " ")
+        if snippet:
+            line += f"\n  {snippet[:240]}"
+        lines.append(line)
+    if len(rows) > MAX_ITEMS_PER_DIGEST:
+        lines.append(f"\n… +{len(rows) - MAX_ITEMS_PER_DIGEST} more items (in archive.db).")
+    return title, "\n".join(lines)
+
+
+def _post_digest(notebook_id: str, title: str, body: str) -> bool:
+    """Post one digest to NLM with its title PRESERVED.
+
+    Uses `nlm source add --text <body> --title <title>` (A/B-verified to keep the
+    title) instead of nlm_feeder._nlm_add_text, which writes a temp file and lets
+    the temp FILENAME become the source title (the rollup MUST be findable by its
+    'Intel rollup <day>' title). Honors cap-rollover via _resolve_writable_nb.
+    """
+    if not notebook_id:
+        return False
+    notebook_id = _resolve_writable_nb(notebook_id)
+    if _nlm_at_cap(notebook_id):
+        logger.warning("[rollup] NB at cap (no overflow room): nb=%s", notebook_id)
+        return False
+    try:
+        result = subprocess.run(
+            [NLM_CLI, "source", "add", "--profile", "default", notebook_id,
+             "--text", body, "--title", title],
+            capture_output=True, text=True, timeout=120,
+        )
+        if result.returncode == 0:
+            return True
+        snippet = ((result.stderr or "") + (result.stdout or "")).replace("\n", " ")[:200]
+        logger.warning("[rollup] add rejected nb=%s rc=%d reason=%s",
+                       notebook_id, result.returncode, snippet or "(empty)")
+        return False
+    except Exception as e:  # noqa: BLE001
+        logger.warning("[rollup] add failed: %s", e)
+        return False
+
+
+def run_rollup(db_path: Optional[Path] = None, days_back: int = 14) -> dict:
+    """Roll up un-posted (day, domain) groups from the archive into NLM digests.
+
+    Returns stats: {groups, posted, skipped_already, items, errors}.
+    """
+    stats = {"groups": 0, "posted": 0, "skipped_already": 0, "items": 0, "errors": 0}
+    path = db_path or DEFAULT_ARCHIVE_PATH
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    _ensure_ledger(conn)
+
+    # Candidate items: recent, scored window. Group by (day, domain).
+    rows = conn.execute(
+        "SELECT date(archived_at) AS day, "
+        "       COALESCE(NULLIF(domain,''), ?) AS dom, "
+        "       title, url, source, score, content "
+        "FROM archive "
+        "WHERE date(archived_at) >= date('now', ?) "
+        "ORDER BY day DESC, dom",
+        (ROLLUP_DEFAULT_DOMAIN, f"-{int(days_back)} days"),
+    ).fetchall()
+
+    groups: dict[tuple, list] = defaultdict(list)
+    for r in rows:
+        if _score_ok(r["score"]):
+            groups[(r["day"], r["dom"])].append(r)
+
+    # Already-posted set (idempotency).
+    posted = {(g["day"], g["domain"])
+              for g in conn.execute("SELECT day, domain FROM rollup_ledger").fetchall()}
+
+    for (day, domain), items in sorted(groups.items()):
+        stats["groups"] += 1
+        if (day, domain) in posted:
+            stats["skipped_already"] += 1
+            continue
+        nb_key, notebook_id = route_domain_to_notebook(domain)
+        if not notebook_id:
+            # unroutable domain → fall back to the OSINT intel home
+            nb_key, notebook_id = route_domain_to_notebook(ROLLUP_DEFAULT_DOMAIN)
+        if not notebook_id:
+            logger.warning("[rollup] no notebook for domain=%s — skipping %s", domain, day)
+            continue
+        title, body = _compose_digest(day, domain, items)
+        try:
+            ok = _post_digest(notebook_id, title, body)
+            if ok:
+                conn.execute(
+                    "INSERT OR REPLACE INTO rollup_ledger "
+                    "(day, domain, notebook_id, item_count) VALUES (?,?,?,?)",
+                    (day, domain, notebook_id, len(items)),
+                )
+                conn.commit()
+                stats["posted"] += 1
+                stats["items"] += len(items)
+                logger.info("[rollup] posted %s/%s (%d items) → %s",
+                            day, domain, len(items), nb_key)
+            else:
+                stats["errors"] += 1  # cap reached / nlm reject → retry next run
+        except Exception as e:  # noqa: BLE001
+            logger.error("[rollup] error posting %s/%s: %s", day, domain, e)
+            stats["errors"] += 1
+
+    conn.close()
+    return stats
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    days_back = int(os.environ.get("GARUDA_ROLLUP_DAYS_BACK", "14"))
+    try:
+        stats = run_rollup(days_back=days_back)
+        print(f"[rollup] {stats}")
+        return 0
+    except Exception as e:  # noqa: BLE001
+        logger.error(f"[rollup] FATAL: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/mata-garuda/tests/test_nlm_rollup.py
+++ b/apps/mata-garuda/tests/test_nlm_rollup.py
@@ -1,0 +1,102 @@
+"""Tests for #5 summarize-then-store (nlm_rollup) — compaction Sink off the archive."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+from mata_garuda.workers import nlm_rollup
+from mata_garuda.workers.archiver import StreamArchive
+
+
+def _seed(db: Path, items):
+    """Seed an archive.db with rows. items = list of dicts."""
+    a = StreamArchive(db_path=db)
+    for it in items:
+        a.archive(it.get("content_hash", it.get("url", it["title"])), it)
+    a.close()
+
+
+class TestRollup:
+    def _run(self, db, add_return=True):
+        with patch.object(nlm_rollup, "_post_digest", return_value=add_return) as m_add, \
+             patch.object(nlm_rollup, "route_domain_to_notebook",
+                          side_effect=lambda d: (d, f"nb-{d}") if d else ("", "")) as m_route:
+            stats = nlm_rollup.run_rollup(db_path=db, days_back=3650)
+        return stats, m_add, m_route
+
+    def test_groups_by_day_and_domain_one_source_each(self, tmp_path: Path):
+        db = tmp_path / "archive.db"
+        _seed(db, [
+            {"title": "a", "url": "u1", "domain": "ai_research", "score": "5",
+             "timestamp": "2026-06-30"},
+            {"title": "b", "url": "u2", "domain": "ai_research", "score": "4",
+             "timestamp": "2026-06-30"},
+            {"title": "c", "url": "u3", "domain": "press", "score": "5",
+             "timestamp": "2026-06-30"},
+        ])
+        stats, m_add, _ = self._run(db)
+        # 2 groups (ai_research, press) → 2 NLM sources, NOT 3 (one per item)
+        assert stats["posted"] == 2 and stats["groups"] == 2
+        assert m_add.call_count == 2
+        assert stats["items"] == 3
+
+    def test_idempotent_second_run_skips(self, tmp_path: Path):
+        db = tmp_path / "archive.db"
+        _seed(db, [{"title": "a", "url": "u1", "domain": "ai_research", "score": "5",
+                    "timestamp": "2026-06-30"}])
+        s1, m1, _ = self._run(db)
+        assert s1["posted"] == 1
+        s2, m2, _ = self._run(db)             # second run: ledger says already posted
+        assert s2["posted"] == 0 and s2["skipped_already"] == 1
+        m2.assert_not_called()                 # never re-posts
+
+    def test_low_score_excluded_from_digest(self, tmp_path: Path):
+        db = tmp_path / "archive.db"
+        _seed(db, [
+            {"title": "hi", "url": "u1", "domain": "ai_research", "score": "5",
+             "timestamp": "2026-06-30"},
+            {"title": "lo", "url": "u2", "domain": "ai_research", "score": "1",
+             "timestamp": "2026-06-30"},
+        ])
+        with patch.object(nlm_rollup, "_post_digest", return_value=True) as m_add, \
+             patch.object(nlm_rollup, "route_domain_to_notebook",
+                          return_value=("ai_research", "nb-x")):
+            stats = nlm_rollup.run_rollup(db_path=db, days_back=3650)
+        # only the high-score item counted (ROLLUP_MIN_SCORE default 3)
+        assert stats["items"] == 1
+        body = m_add.call_args.args[2]
+        assert "hi" in body and "lo" not in body
+
+    def test_null_domain_routes_to_default(self, tmp_path: Path):
+        db = tmp_path / "archive.db"
+        _seed(db, [{"title": "x", "url": "u1", "domain": "", "score": "5",
+                    "timestamp": "2026-06-30"}])
+        with patch.object(nlm_rollup, "_post_digest", return_value=True), \
+             patch.object(nlm_rollup, "route_domain_to_notebook",
+                          side_effect=lambda d: (d, f"nb-{d}")) as m_route:
+            stats = nlm_rollup.run_rollup(db_path=db, days_back=3650)
+        assert stats["posted"] == 1
+        # routed with the default domain, not empty string
+        assert any(c.args[0] == nlm_rollup.ROLLUP_DEFAULT_DOMAIN
+                   for c in m_route.call_args_list)
+
+    def test_failed_post_not_ledgered_retries_next_run(self, tmp_path: Path):
+        db = tmp_path / "archive.db"
+        _seed(db, [{"title": "a", "url": "u1", "domain": "ai_research", "score": "5",
+                    "timestamp": "2026-06-30"}])
+        s1, _, _ = self._run(db, add_return=False)   # NLM post fails
+        assert s1["posted"] == 0 and s1["errors"] == 1
+        # not ledgered → next run retries
+        s2, m2, _ = self._run(db, add_return=True)
+        assert s2["posted"] == 1
+        m2.assert_called_once()
+
+    def test_compaction_ratio_many_items_one_source(self, tmp_path: Path):
+        db = tmp_path / "archive.db"
+        _seed(db, [{"title": f"t{i}", "url": f"u{i}", "domain": "ai_research",
+                    "score": "5", "timestamp": "2026-06-30"} for i in range(200)])
+        stats, m_add, _ = self._run(db)
+        # 200 items → ONE NLM source (the whole point of #5)
+        assert stats["posted"] == 1 and m_add.call_count == 1
+        assert stats["items"] == 200


### PR DESCRIPTION
## #5 summarize-then-store — daily NLM rollup (Zero's call)

NLM is a HARD-capped sink (~500 sources/NB). The per-item feeder burns one source per item — thousands of items blow the cap. **The cure (council daily-rollup / log-compaction): write ONE digest source per (day, domain) instead of N.** A day of intel = 1 source → the cap now holds **~500 DAYS** of intel, not ~500 items.

### How
- `nlm_rollup` reads **FROM the archive** (#4 — the durable system of record, NOT the hot stream), groups by `(date, domain)`, composes a **deterministic** digest (no LLM — a list of titles+urls+scores is mechanical, quota-free, hallucination-free), posts one source per group.
- **Idempotent** via a per-`(day,domain)` `rollup_ledger`; a failed post is NOT ledgered → retried next run. Low-score items excluded (`ROLLUP_MIN_SCORE`). Null/legacy domain → OSINT intel home (`ai_research`).
- **archiver** also now captures `domain` (guarded ALTER for existing DBs, index after migration) + prefers the richer `relevance_score`.

### W65 caught a real bug
The rollup uses its own `_post_digest` → `nlm source add --text <body> --title <title>` (A/B-verified to keep the title) instead of `nlm_feeder._nlm_add_text`, which writes a temp file and lets the temp **FILENAME** become the NLM source title. The rollup MUST be findable by its `Intel rollup <day>` title. (8 mis-titled `nlm_feed_*.txt` sources already in prod prove the shared `_nlm_add_text` bug — tracked separately as a follow-up.)

### Proven live + independently verified
- `499 items → 1 NLM source` (compaction ratio 499:1).
- Independently confirmed present in AIResearch NB: `Intel rollup 2026-06-30 — ai_research (499 items)` (id `50d2380f`, type `generated_text`) — verified via `nlm source list`, NOT the worker's own success claim (W65).
- Second run posts 0 (idempotent).

### Cron
`install_rollup_cron.sh` → `com.matagaruda.nlm-rollup.daily` (StartCalendarInterval 23:30 WITA — after the day's harvest/score; daily not hourly; idempotent so safe).

### Tests
`test_nlm_rollup` 6/6 (groups-by-day-domain / idempotent / low-score-excluded / null-domain-routes-default / failed-post-retries / 200-items→1-source). archiver 8/8 + full related suite 32/32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
