### PR TITLE
revert(wr2): editorial-text dead-air fix #1861 — did not work on real bodies

### DIFF
--- a/skills/bali-zero-brand/layouts/editorial-text.md
+++ b/skills/bali-zero-brand/layouts/editorial-text.md
@@ -16,100 +16,84 @@
 ## Parameters
 
 ```yaml
-subheading: string # 2-8 words UPPERCASE yellow accent (optional kicker)
-heading: string # 4-10 words UPPERCASE
-body: string # 25-110 words UPPERCASE, 2-5 sentences (more room — no photo)
+subheading: string  # 2-8 words UPPERCASE yellow accent (optional kicker)
+heading: string  # 4-10 words UPPERCASE
+body: string  # 25-110 words UPPERCASE, 2-5 sentences (more room — no photo)
 ```
 
 ## HTML/CSS skeleton
 
 ```html
 <!doctype html>
-<html>
-  <head>
-    <link rel="stylesheet" href="../_base.css" />
-    <style>
-      @import url("https://fonts.googleapis.com/css2?family=Montserrat:wght@700;800&display=swap");
-      .text-panel {
-        width: var(--canvas-width);
-        /* DEAD-AIR FIX 2026-06-30 (measured): the panel was full canvas height
-     (1350px) and centred its stack with justify-content:center, but the .logo
-     is position:absolute (bottom:70px) — INVISIBLE to the flex layout, so it
-     reserved no space. On a short (2-sentence) body the centred stack ended at
-     ~y889 while the logo sat fixed at y1200 → a measured 23% dead band between
-     them ("logo floats disconnected", "content anchored upper 40-45%"). The
-     asymmetric 110/180 padding biased the block a further 35px upward.
-     CURE: shrink the panel to canvas-minus-logo-band (250px = 80 logo + 70
-     bottom margin + 100 buffer) so the flow ends ABOVE the logo, drop the
-     asymmetric vertical padding, and distribute slack with space-evenly so a
-     short body fills the upper-three-quarters and the logo closes the frame
-     (gap lands in the healthy 12-18% range). A long body has little slack so
-     space-evenly degrades to near-centre automatically — both extremes balance.
-     Measured (2026-06-30): short body→logo gap 23%→15%, long 16.5%→~11% with
-     the 250px band (the 230px band measured 9.8% on a ~90-word long body — near
-     the 8% floor; 250px buys headroom for max-length ~110-word bodies). A top
-     yellow rule anchors the block editorially (NYT/FT). Per-element
-     margin-bottom still drives heading↔body rhythm. */
-        height: calc(var(--canvas-height) - 250px);
-        background: var(--color-bg-antracite);
-        padding: 0 var(--spacing-edge-margin);
-        display: flex;
-        flex-direction: column;
-        justify-content: space-evenly;
-      }
-      .top-rule {
-        width: 90px;
-        height: 8px;
-        background: var(--color-accent-yellow);
-        margin-bottom: 44px;
-      }
-      .subheading {
-        font-weight: var(--font-weight-bold);
-        font-size: var(--font-size-subheadline);
-        line-height: var(--line-height-snug);
-        letter-spacing: var(--letter-spacing-title);
-        color: var(--color-accent-yellow);
-        text-transform: uppercase;
-        margin-bottom: 16px;
-      }
-      .heading {
-        font-weight: var(--font-weight-extrabold);
-        /* 84px (was 60px): on a text-only slide the headline is the only large
+<html><head>
+<link rel="stylesheet" href="../_base.css">
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@700;800&display=swap');
+.text-panel {
+  width: var(--canvas-width); height: var(--canvas-height);
+  background: var(--color-bg-antracite);
+  /* Vertically CENTRE the stack so the empty anthracite distributes
+     symmetrically above and below (balanced "breathing room") instead of
+     piling into one half — top-anchoring left a ~50% bottom void the vision
+     critic read as a layout bug, and bottom-anchoring left a top void
+     (2026-06-13 E2E, both rejected). A large heading (84px) + sentence-case
+     body fills more of the canvas so the residual void is small and centred.
+     A top yellow rule anchors the block editorially (NYT/FT). Per-element
+     margin-bottom drives vertical rhythm (no flex gap — Golden Visa fix). */
+  padding: 110px var(--spacing-edge-margin) 180px var(--spacing-edge-margin);
+  display: flex; flex-direction: column;
+  justify-content: center;
+}
+.top-rule {
+  width: 90px; height: 8px;
+  background: var(--color-accent-yellow);
+  margin-bottom: 44px;
+}
+.subheading {
+  font-weight: var(--font-weight-bold);
+  font-size: var(--font-size-subheadline);
+  line-height: var(--line-height-snug);
+  letter-spacing: var(--letter-spacing-title);
+  color: var(--color-accent-yellow);
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+.heading {
+  font-weight: var(--font-weight-extrabold);
+  /* 84px (was 60px): on a text-only slide the headline is the only large
      element — it must dominate and help fill the canvas (2026-06-13). */
-        font-size: var(--font-size-headline-cover);
-        line-height: var(--line-height-tight);
-        letter-spacing: var(--letter-spacing-title);
-        color: var(--color-text-white);
-        text-transform: uppercase;
-        text-wrap: balance;
-        margin-bottom: 32px;
-        /* gap to body absorbs a 2-3 line heading wrap without bleed. */
-      }
-      .body {
-        font-weight: var(--font-weight-bold);
-        font-size: var(--font-size-body-lg);
-        line-height: var(--line-height-normal);
-        letter-spacing: var(--letter-spacing-body);
-        color: var(--color-text-white);
-        /* Sentence case (NOT all-caps): an all-caps bold body shared the exact
+  font-size: var(--font-size-headline-cover);
+  line-height: var(--line-height-tight);
+  letter-spacing: var(--letter-spacing-title);
+  color: var(--color-text-white);
+  text-transform: uppercase;
+  text-wrap: balance;
+  margin-bottom: 32px;
+  /* gap to body absorbs a 2-3 line heading wrap without bleed. */
+}
+.body {
+  font-weight: var(--font-weight-bold);
+  font-size: var(--font-size-body-lg);
+  line-height: var(--line-height-normal);
+  letter-spacing: var(--letter-spacing-body);
+  color: var(--color-text-white);
+  /* Sentence case (NOT all-caps): an all-caps bold body shared the exact
      typographic register of the all-caps heading (flat hierarchy, vision
      critic 2026-06-13) AND read as a dense grey block. Sentence case gives a
      clear register break from the UPPERCASE heading and is far more legible
      for 2-5 sentences of prose. */
-        text-transform: none;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="text-panel" data-zone-type="text">
-      <div class="top-rule"></div>
-      <div class="subheading">{{subheading}}</div>
-      <div class="heading">{{heading}}</div>
-      <div class="body">{{body}}</div>
-    </div>
-    <div class="logo" data-zone-type="logo">3 ALI ZERO</div>
-  </body>
-</html>
+  text-transform: none;
+}
+</style></head>
+<body>
+  <div class="text-panel" data-zone-type="text">
+    <div class="top-rule"></div>
+    <div class="subheading">{{subheading}}</div>
+    <div class="heading">{{heading}}</div>
+    <div class="body">{{body}}</div>
+  </div>
+  <div class="logo" data-zone-type="logo">3 ALI ZERO</div>
+</body></html>
 ```
 
 ## Common failures


### PR DESCRIPTION
## Why revert

PR #1861 (`editorial-text` dead-air: `.text-panel` shrink + `space-evenly`) **does not fix the dead-air on real slide bodies.** Verified by eye on the actual rendered PNG of draft 62b6b577 slide 2 (with the fix live): the void above the yellow rule and below the body is still large — visually indistinguishable from the pre-fix render.

The fix was built against a subagent measurement that reported a healthy 15% gap — but that measurement used a SHORTER test body than the real ~40-word slide bodies. On the real bodies `space-evenly` redistributes the slack but still leaves a large void. **The measurement was a proxy that lied** (cf. scar W88 — verify by content/eye, not by a proxy metric).

Leaving a non-working fix in production gives false confidence (it looks "fixed" in the commit log but the carousels still render with dead-air). Reverting to the known prior state.

## What this keeps

The two fixes that ARE proven stay on main, untouched:
- **#1856** N-1 carousel render (one weak slide is debt, not a killer)
- **#1860** cover-drop (per-slide render namespace race)

Only the dead-air CSS change (#1861) is reverted. The dead-air will be re-approached with a faithful method: render the REAL slide bodies and iterate against what the eye + the vision critic actually see, not against an invented test body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)