### PR TITLE
fix(mata-garuda): rollup opens archive via StreamArchive (no such column: domain)

### DIFF
--- a/apps/mata-garuda/mata_garuda/workers/nlm_rollup.py
+++ b/apps/mata-garuda/mata_garuda/workers/nlm_rollup.py
@@ -31,7 +31,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Optional
 
-from mata_garuda.workers.archiver import DEFAULT_ARCHIVE_PATH
+from mata_garuda.workers.archiver import DEFAULT_ARCHIVE_PATH, StreamArchive
 import subprocess
 from mata_garuda.workers.nlm_feeder import (
     NLM_CLI,
@@ -134,7 +134,11 @@ def run_rollup(db_path: Optional[Path] = None, days_back: int = 14) -> dict:
     """
     stats = {"groups": 0, "posted": 0, "skipped_already": 0, "items": 0, "errors": 0}
     path = db_path or DEFAULT_ARCHIVE_PATH
-    conn = sqlite3.connect(str(path))
+    # Open via StreamArchive so its guarded ALTER (adds `domain` to pre-existing
+    # DBs) has definitely run before we SELECT domain — a raw sqlite3.connect
+    # skips that migration and dies 'no such column: domain'.
+    _archive = StreamArchive(db_path=path)
+    conn = _archive._conn
     conn.row_factory = sqlite3.Row
     _ensure_ledger(conn)
 
@@ -190,7 +194,7 @@ def run_rollup(db_path: Optional[Path] = None, days_back: int = 14) -> dict:
             logger.error("[rollup] error posting %s/%s: %s", day, domain, e)
             stats["errors"] += 1
 
-    conn.close()
+    _archive.close()
     return stats
 
 

--- a/apps/mata-garuda/tests/test_nlm_rollup.py
+++ b/apps/mata-garuda/tests/test_nlm_rollup.py
@@ -100,3 +100,33 @@ class TestRollup:
         # 200 items → ONE NLM source (the whole point of #5)
         assert stats["posted"] == 1 and m_add.call_count == 1
         assert stats["items"] == 200
+
+
+    def test_runs_on_legacy_db_without_domain_column(self, tmp_path):
+        """Regression: a DB created before the `domain` column must NOT crash the
+        rollup (the live cron died 'no such column: domain' — it opened a raw
+        sqlite3.connect, skipping StreamArchive's guarded ALTER). Opening via
+        StreamArchive must migrate it first."""
+        import sqlite3
+        db = tmp_path / "legacy.db"
+        # build a pre-domain archive table by hand (no domain column)
+        c = sqlite3.connect(str(db))
+        c.executescript("""
+            CREATE TABLE archive (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                content_hash TEXT UNIQUE, stream_id TEXT, title TEXT, url TEXT,
+                source TEXT, source_type TEXT, content TEXT, score TEXT,
+                agent TEXT, harvested_ts TEXT,
+                archived_at TEXT DEFAULT (datetime('now'))
+            );
+        """)
+        c.execute("INSERT INTO archive (content_hash,title,url,score,archived_at) "
+                  "VALUES ('h1','t','u','5',datetime('now'))")
+        c.commit(); c.close()
+        # must run without 'no such column: domain'
+        with patch.object(nlm_rollup, "_post_digest", return_value=True), \
+             patch.object(nlm_rollup, "route_domain_to_notebook",
+                          side_effect=lambda d: (d, f"nb-{d}")):
+            stats = nlm_rollup.run_rollup(db_path=db, days_back=3650)
+        assert stats["errors"] == 0
+        assert stats["posted"] == 1   # the row rolled up under the default domain


### PR DESCRIPTION
The #5 rollup cron crashed FATAL on first live run: `no such column: domain`. `run_rollup` opened the archive with a raw `sqlite3.connect`, skipping the guarded ALTER in `StreamArchive._init_tables` that adds `domain` to pre-existing DBs.

**Caught by reading the cron OUTPUT, not exit code** (cicatrix #2 — a stale earlier success tail masked the FATAL).

**Fix:** `run_rollup` opens via `StreamArchive(db_path=...)` and reuses its migrated connection → domain migration guaranteed before `SELECT domain`.

**Proven live** on the real legacy archive.db: rc=0, idempotent skip (`posted:0 skipped_already:1`), DB now has domain.

TDD: `test_runs_on_legacy_db_without_domain_column` (pre-domain table → must not crash; would have failed pre-fix). 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)