### PR TITLE
fix(mata-garuda): rollup dedup — replace digest on day-grow, skip when unchanged

### DIFF
--- a/apps/mata-garuda/mata_garuda/workers/nlm_rollup.py
+++ b/apps/mata-garuda/mata_garuda/workers/nlm_rollup.py
@@ -56,11 +56,16 @@ def _ensure_ledger(conn: sqlite3.Connection) -> None:
             day TEXT NOT NULL,
             domain TEXT NOT NULL,
             notebook_id TEXT,
+            source_id TEXT,
             item_count INTEGER,
             posted_at TEXT DEFAULT (datetime('now')),
             PRIMARY KEY (day, domain)
         )
     """)
+    # guarded migration for pre-existing ledgers
+    cols = [r[1] for r in conn.execute("PRAGMA table_info(rollup_ledger)").fetchall()]
+    if "source_id" not in cols:
+        conn.execute("ALTER TABLE rollup_ledger ADD COLUMN source_id TEXT")
     conn.commit()
 
 
@@ -96,7 +101,7 @@ def _compose_digest(day: str, domain: str, rows: list) -> tuple[str, str]:
     return title, "\n".join(lines)
 
 
-def _post_digest(notebook_id: str, title: str, body: str) -> bool:
+def _post_digest(notebook_id: str, title: str, body: str) -> Optional[str]:
     """Post one digest to NLM with its title PRESERVED.
 
     Uses `nlm source add --text <body> --title <title>` (A/B-verified to keep the
@@ -105,11 +110,11 @@ def _post_digest(notebook_id: str, title: str, body: str) -> bool:
     'Intel rollup <day>' title). Honors cap-rollover via _resolve_writable_nb.
     """
     if not notebook_id:
-        return False
+        return None
     notebook_id = _resolve_writable_nb(notebook_id)
     if _nlm_at_cap(notebook_id):
         logger.warning("[rollup] NB at cap (no overflow room): nb=%s", notebook_id)
-        return False
+        return None
     try:
         result = subprocess.run(
             [NLM_CLI, "source", "add", "--profile", "default", notebook_id,
@@ -117,14 +122,37 @@ def _post_digest(notebook_id: str, title: str, body: str) -> bool:
             capture_output=True, text=True, timeout=120,
         )
         if result.returncode == 0:
-            return True
+            # parse "Source ID: <uuid>" so we can replace it on a later re-post
+            out = (result.stdout or "") + (result.stderr or "")
+            sid = ""
+            for line in out.splitlines():
+                if "Source ID:" in line:
+                    sid = line.split("Source ID:", 1)[1].strip()
+                    break
+            return sid or "posted"   # truthy even if id not parseable
         snippet = ((result.stderr or "") + (result.stdout or "")).replace("\n", " ")[:200]
         logger.warning("[rollup] add rejected nb=%s rc=%d reason=%s",
                        notebook_id, result.returncode, snippet or "(empty)")
-        return False
+        return None
     except Exception as e:  # noqa: BLE001
         logger.warning("[rollup] add failed: %s", e)
-        return False
+        return None
+
+
+def _delete_source(notebook_id: str, source_id: str) -> None:
+    """Best-effort delete a prior digest source before re-posting (replace, not
+    append) — prevents duplicate 'Intel rollup' sources when a day's archive grew
+    after its first digest (caught live 2026-06-30: 3 dupes 499/919/1370)."""
+    if not (notebook_id and source_id and source_id != "posted"):
+        return
+    try:
+        subprocess.run(
+            [NLM_CLI, "source", "delete", notebook_id, source_id,
+             "--confirm", "--profile", "default"],
+            capture_output=True, text=True, timeout=60,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning("[rollup] could not delete prior source %s: %s", source_id, e)
 
 
 def run_rollup(db_path: Optional[Path] = None, days_back: int = 14) -> dict:
@@ -158,15 +186,23 @@ def run_rollup(db_path: Optional[Path] = None, days_back: int = 14) -> dict:
         if _score_ok(r["score"]):
             groups[(r["day"], r["dom"])].append(r)
 
-    # Already-posted set (idempotency).
-    posted = {(g["day"], g["domain"])
-              for g in conn.execute("SELECT day, domain FROM rollup_ledger").fetchall()}
+    # Prior ledger: (day,domain) -> (item_count, source_id) for skip/replace logic.
+    prior = {(g["day"], g["domain"]): (g["item_count"], g["source_id"])
+             for g in conn.execute(
+                 "SELECT day, domain, item_count, source_id FROM rollup_ledger").fetchall()}
 
     for (day, domain), items in sorted(groups.items()):
         stats["groups"] += 1
-        if (day, domain) in posted:
-            stats["skipped_already"] += 1
-            continue
+        old = prior.get((day, domain))
+        old_sid = None
+        if old is not None:
+            old_count, old_sid = old
+            if old_count == len(items):
+                stats["skipped_already"] += 1   # unchanged → nothing to do
+                continue
+            # day grew since the last digest → REPLACE (delete old, post fresh)
+            logger.info("[rollup] %s/%s grew %s→%d — replacing digest",
+                        day, domain, old_count, len(items))
         nb_key, notebook_id = route_domain_to_notebook(domain)
         if not notebook_id:
             # unroutable domain → fall back to the OSINT intel home
@@ -176,12 +212,16 @@ def run_rollup(db_path: Optional[Path] = None, days_back: int = 14) -> dict:
             continue
         title, body = _compose_digest(day, domain, items)
         try:
-            ok = _post_digest(notebook_id, title, body)
-            if ok:
+            new_sid = _post_digest(notebook_id, title, body)
+            if new_sid:
+                # replace: remove the stale prior digest so NLM keeps ONE per day
+                if old_sid:
+                    _delete_source(notebook_id, old_sid)
                 conn.execute(
                     "INSERT OR REPLACE INTO rollup_ledger "
-                    "(day, domain, notebook_id, item_count) VALUES (?,?,?,?)",
-                    (day, domain, notebook_id, len(items)),
+                    "(day, domain, notebook_id, source_id, item_count) "
+                    "VALUES (?,?,?,?,?)",
+                    (day, domain, notebook_id, new_sid, len(items)),
                 )
                 conn.commit()
                 stats["posted"] += 1

--- a/apps/mata-garuda/tests/test_nlm_rollup.py
+++ b/apps/mata-garuda/tests/test_nlm_rollup.py
@@ -19,7 +19,7 @@ def _seed(db: Path, items):
 
 class TestRollup:
     def _run(self, db, add_return=True):
-        with patch.object(nlm_rollup, "_post_digest", return_value=add_return) as m_add, \
+        with patch.object(nlm_rollup, "_post_digest", return_value=("sid-x" if add_return else None)) as m_add, \
              patch.object(nlm_rollup, "route_domain_to_notebook",
                           side_effect=lambda d: (d, f"nb-{d}") if d else ("", "")) as m_route:
             stats = nlm_rollup.run_rollup(db_path=db, days_back=3650)
@@ -130,3 +130,36 @@ class TestRollup:
             stats = nlm_rollup.run_rollup(db_path=db, days_back=3650)
         assert stats["errors"] == 0
         assert stats["posted"] == 1   # the row rolled up under the default domain
+
+
+    def test_skip_when_count_unchanged_but_replace_when_grown(self, tmp_path):
+        """Idempotency by COUNT: same count → skip; grew → delete old + re-post
+        (prevents the duplicate 'Intel rollup' sources seen live 2026-06-30)."""
+        from unittest.mock import patch
+        db = tmp_path / "a.db"
+        _seed(db, [{"title": "a", "url": "u1", "domain": "ai_research", "score": "5",
+                    "timestamp": "2026-06-30"}])
+        with patch.object(nlm_rollup, "_post_digest", return_value="sid-1"), \
+             patch.object(nlm_rollup, "route_domain_to_notebook",
+                          return_value=("ai_research", "nb-x")):
+            s1 = nlm_rollup.run_rollup(db_path=db, days_back=3650)
+        assert s1["posted"] == 1
+        # run again, SAME data → unchanged → skip, no delete, no post
+        with patch.object(nlm_rollup, "_post_digest", return_value="sid-2") as m_post, \
+             patch.object(nlm_rollup, "_delete_source") as m_del, \
+             patch.object(nlm_rollup, "route_domain_to_notebook",
+                          return_value=("ai_research", "nb-x")):
+            s2 = nlm_rollup.run_rollup(db_path=db, days_back=3650)
+        assert s2["skipped_already"] == 1 and s2["posted"] == 0
+        m_post.assert_not_called(); m_del.assert_not_called()
+        # now the day GROWS → must delete sid-1 and post fresh
+        _seed(db, [{"title": "b", "url": "u2", "domain": "ai_research", "score": "5",
+                    "timestamp": "2026-06-30"}])
+        with patch.object(nlm_rollup, "_post_digest", return_value="sid-3") as m_post, \
+             patch.object(nlm_rollup, "_delete_source") as m_del, \
+             patch.object(nlm_rollup, "route_domain_to_notebook",
+                          return_value=("ai_research", "nb-x")):
+            s3 = nlm_rollup.run_rollup(db_path=db, days_back=3650)
+        assert s3["posted"] == 1
+        m_del.assert_called_once()                  # old digest deleted
+        assert m_del.call_args.args[1] == "sid-1"   # the prior source id


### PR DESCRIPTION
During the feeder-backlog catch-up, clearing the ledger + re-running left **3 duplicate 'Intel rollup' sources** in NLM (499/919/1370) — each re-post APPENDED instead of replacing, eating the ~500 cap. (Cleaned the 2 stale dupes by hand.)

**Fix:** idempotency by `(day, domain, item_count)`; ledger stores `source_id`. Count unchanged → skip; count grew → `_delete_source` the prior NLM source then post fresh → exactly ONE digest per (day, domain). `_post_digest` parses+returns the `Source ID:`. Guarded ALTER for existing ledgers.

**Proven live:** re-run with the 1370 digest ledgered → skips, NLM keeps exactly one rollup source.

TDD: `test_skip_when_count_unchanged_but_replace_when_grown`. 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)