### PR TITLE
fix(wr2): cure dead-air on editorial-text + hero layouts (eyeballed on real bodies)

### DIFF
--- a/skills/bali-zero-brand/layouts/editorial-text.md
+++ b/skills/bali-zero-brand/layouts/editorial-text.md
@@ -73,8 +73,14 @@ body: string  # 25-110 words UPPERCASE, 2-5 sentences (more room — no photo)
 }
 .body {
   font-weight: var(--font-weight-bold);
-  font-size: var(--font-size-body-lg);
-  line-height: var(--line-height-normal);
+  /* 40px (was --font-size-body-lg 32px): on a text-only slide a larger body
+     fills more of the tall canvas and is more legible for 2-5 sentences of
+     prose. With the .baseline-rule below, the residual lower space reads as
+     deliberate editorial margin, not a dead-air void (eyeballed on the real
+     29-34-word bodies, 2026-06-30 — pure flex center/space-evenly could NOT
+     cure a short block in a tall canvas; #1861 reverted). */
+  font-size: 40px;
+  line-height: 1.5;
   letter-spacing: var(--letter-spacing-body);
   color: var(--color-text-white);
   /* Sentence case (NOT all-caps): an all-caps bold body shared the exact
@@ -84,6 +90,19 @@ body: string  # 25-110 words UPPERCASE, 2-5 sentences (more room — no photo)
      for 2-5 sentences of prose. */
   text-transform: none;
 }
+.baseline-rule {
+  /* Footer hairline that BOOKENDS the top yellow .top-rule, framing the lower
+     negative space as intentional editorial margin (NYT/FT footer rule) instead
+     of a dead-air void. Absolutely positioned just above the logo; never
+     collides with the centered text block (verified on the densest real body,
+     6 lines @ 40px). 2026-06-30. */
+  position: absolute;
+  left: var(--spacing-edge-margin);
+  right: var(--spacing-edge-margin);
+  bottom: 200px;
+  height: 2px;
+  background: rgba(255, 255, 255, 0.14);
+}
 </style></head>
 <body>
   <div class="text-panel" data-zone-type="text">
@@ -92,6 +111,7 @@ body: string  # 25-110 words UPPERCASE, 2-5 sentences (more room — no photo)
     <div class="heading">{{heading}}</div>
     <div class="body">{{body}}</div>
   </div>
+  <div class="baseline-rule"></div>
   <div class="logo" data-zone-type="logo">3 ALI ZERO</div>
 </body></html>
 ```

--- a/skills/bali-zero-brand/layouts/photo-headline-yellow-sub.md
+++ b/skills/bali-zero-brand/layouts/photo-headline-yellow-sub.md
@@ -76,8 +76,13 @@ image_prompt: string  # if image not yet generated
 }
 .body {
   font-weight: var(--font-weight-bold);
-  font-size: var(--font-size-body-md);
-  line-height: var(--line-height-normal);
+  /* 34px (was --font-size-body-md 28px): the text panel is only 810px (bottom
+     half), so a larger body genuinely fills it and the body→logo gap shrinks to
+     normal padding instead of a dead-air void. Eyeballed on the real 29-33-word
+     hero bodies, 2026-06-30 (longest body, 5 lines, no overflow). No footer rule
+     here — the panel is short enough that a bigger body alone closes the void. */
+  font-size: 34px;
+  line-height: 1.45;
   letter-spacing: var(--letter-spacing-body);
   color: var(--color-text-white);
   text-transform: uppercase;


### PR DESCRIPTION
## What

Cures the **dead-air** void on two WR2 carousel layouts — the large empty
anthracite gap between the body text and the logo that the vision critic and
Antonello flagged on draft 62b6b577.

| Layout | Change |
|--------|--------|
| `editorial-text` (text-only slides) | body `32px→40px` / line-height `→1.5` **+ new `.baseline-rule`** hairline above the logo that bookends the top yellow rule |
| `photo-headline-yellow-sub` (hero slides) | body `28px→34px` / line-height `→1.45` (bigger body fills the 810px panel; no rule needed) |

## Why this, and why not #1861

The prior fix (#1861) was **reverted (#1865)** because it used pure flex geometry
(panel-height calc + `space-evenly`/`center`) and was backed only by a subagent's
%-gap measurement on an **invented short body**. On the real 29–34-word bodies the
void was unchanged. Root insight: **flex only relocates the slack of a short block
in a tall canvas — it can't remove it.** The cure is to *fill the content* (bigger
body) and *frame the residual* (editorial footer rule), not to move the block.

## Verification (eyeballed, not measured)

Rendered the **real** bodies of draft 62b6b577 through the production
composer+renderer (`materialize_slide_html` + `render_html_files`) end-to-end
through the patched templates, and looked at every PNG:

- editorial: s2 / s4 (densest, 6 lines) / s6 — void framed, no rule collision.
- hero: s3 (longest, 5 lines) / s7 / s8 — body fills panel, no overflow.

This is the acceptance test from the saved lesson: *for a visual fix, look at the
real rendered output with the real input — never a metric on a synthetic input.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
