### PR TITLE
feat(wa-mirror): capture & backfill group names (subjects)

### DIFF
--- a/apps/wa-mirror/bridge/group_subject.ts
+++ b/apps/wa-mirror/bridge/group_subject.ts
@@ -1,0 +1,179 @@
+// group_subject.ts — capture and backfill WhatsApp group names (subjects).
+//
+// PROBLEM (2026-06-30): every group in whatsapp_message_context had an empty
+// `group_subject_snapshot`, so every dashboard rendered groups as the raw JID
+// (`1203...@g.us`). Root cause: the bridge only subscribed to `messages.upsert`
+// and hardcoded `groupSubject: null` in extractMessageRecord — the group name
+// lives ONLY in Baileys `groupMetadata()` / `groupFetchAllParticipating()`,
+// never in the message envelope, and nothing ever fetched it.
+//
+// This module is the fix:
+//   - an in-memory Map<groupJid, subject> populated on connection open and on
+//     `groups.update` events,
+//   - read by extractMessageRecord so NEW rows persist a real subject,
+//   - a one-shot DB backfill (hydrateAllGroupSubjects) that updates historical
+//     rows for every group the connected account still participates in.
+//
+// Read-only toward WhatsApp (groupFetchAllParticipating / groupMetadata are
+// fetches, never sends) — consistent with the bridge's read-only contract
+// (session.ts:12). Defensive by design: nothing here throws into the event
+// loop; a fetch failure degrades to "subject stays null" (the prior behaviour),
+// never breaks message capture.
+
+import type { Pool } from "pg";
+import type { WASocket } from "@whiskeysockets/baileys";
+import type { Logger } from "pino";
+
+// Process-wide cache. extractMessageRecord (a pure sync fn with no socket
+// access) reads this; session.ts writes it. Shared across all account sessions
+// in the process — a group subject is the same regardless of which mirrored
+// member observed it.
+const groupSubjectCache = new Map<string, string>();
+
+/** Read a cached group subject, or null if unknown. Pure, never throws. */
+export function getGroupSubject(
+  groupJid: string | null | undefined,
+): string | null {
+  if (!groupJid) return null;
+  const s = groupSubjectCache.get(groupJid);
+  return s && s.length > 0 ? s : null;
+}
+
+/** Cache one (jid, subject) pair if the subject is non-empty. */
+export function setGroupSubject(
+  groupJid: string,
+  subject: string | null | undefined,
+): void {
+  if (!groupJid) return;
+  if (subject && subject.trim().length > 0) {
+    groupSubjectCache.set(groupJid, subject.trim());
+  }
+}
+
+/**
+ * Persist a single group's subject onto all historical rows for that JID that
+ * still lack one. Idempotent; only fills empty/NULL snapshots (never clobbers a
+ * subject already captured). Swallows DB errors to a warn — backfill must never
+ * crash the session.
+ */
+async function persistGroupSubject(
+  pool: Pool,
+  groupJid: string,
+  subject: string,
+  logger: Logger,
+): Promise<number> {
+  try {
+    const res = await pool.query(
+      `UPDATE whatsapp_message_context
+          SET group_subject_snapshot = $2
+        WHERE group_jid = $1
+          AND chat_type = 'group'
+          AND COALESCE(group_subject_snapshot, '') = ''`,
+      [groupJid, subject],
+    );
+    return res.rowCount ?? 0;
+  } catch (err) {
+    logger.warn(
+      { groupJid, err: (err as Error).message },
+      "wa-mirror group-subject DB backfill failed",
+    );
+    return 0;
+  }
+}
+
+/**
+ * One-shot hydration: fetch every group the connected account participates in,
+ * cache each subject, and backfill historical rows. Called once per session on
+ * connection open. A single `groupFetchAllParticipating()` returns all groups
+ * with metadata, avoiding per-JID rate-limit pressure.
+ *
+ * Fully defensive: any failure logs a warn and returns — message capture is
+ * unaffected, subjects simply stay as they were.
+ */
+export async function hydrateAllGroupSubjects(
+  sock: WASocket,
+  pool: Pool,
+  logger: Logger,
+): Promise<void> {
+  let groups: Record<string, { subject?: string }>;
+  try {
+    groups = await sock.groupFetchAllParticipating();
+  } catch (err) {
+    logger.warn(
+      { err: (err as Error).message },
+      "wa-mirror groupFetchAllParticipating failed — group subjects not hydrated this session",
+    );
+    return;
+  }
+
+  const jids = Object.keys(groups);
+  let cached = 0;
+  let backfilledRows = 0;
+  let backfilledGroups = 0;
+
+  for (const jid of jids) {
+    const subject = groups[jid]?.subject;
+    if (!subject || subject.trim().length === 0) continue;
+    setGroupSubject(jid, subject);
+    cached += 1;
+    const n = await persistGroupSubject(pool, jid, subject.trim(), logger);
+    if (n > 0) {
+      backfilledRows += n;
+      backfilledGroups += 1;
+    }
+  }
+
+  logger.info(
+    {
+      groupsFetched: jids.length,
+      subjectsCached: cached,
+      backfilledGroups,
+      backfilledRows,
+    },
+    "wa-mirror group subjects hydrated",
+  );
+}
+
+/**
+ * Subscribe to live group rename events so the cache (and DB) stay current
+ * after the initial hydration. `groups.update` carries partial group objects;
+ * `groups.upsert` carries full ones on (re)join. Both are best-effort.
+ *
+ * Returns a disposer to unregister the listeners on connection close.
+ */
+export function attachGroupSubjectListeners(
+  sock: WASocket,
+  pool: Pool,
+  logger: Logger,
+): () => void {
+  const onUpdate = (
+    updates: Array<{ id?: string; subject?: string }>,
+  ): void => {
+    for (const u of updates) {
+      if (u.id && u.subject && u.subject.trim().length > 0) {
+        setGroupSubject(u.id, u.subject);
+        void persistGroupSubject(pool, u.id, u.subject.trim(), logger);
+      }
+    }
+  };
+  const onUpsert = (groups: Array<{ id?: string; subject?: string }>): void => {
+    for (const g of groups) {
+      if (g.id && g.subject && g.subject.trim().length > 0) {
+        setGroupSubject(g.id, g.subject);
+        void persistGroupSubject(pool, g.id, g.subject.trim(), logger);
+      }
+    }
+  };
+
+  sock.ev.on("groups.update", onUpdate);
+  sock.ev.on("groups.upsert", onUpsert);
+
+  return () => {
+    try {
+      sock.ev.off("groups.update", onUpdate);
+      sock.ev.off("groups.upsert", onUpsert);
+    } catch {
+      // socket may already be torn down
+    }
+  };
+}

--- a/apps/wa-mirror/bridge/message_capture.ts
+++ b/apps/wa-mirror/bridge/message_capture.ts
@@ -1,6 +1,7 @@
 import { query } from "./pg.js";
 import { jidToPhone, parseJid } from "./filters.js";
 import { normalizePhone } from "./phone.js";
+import { getGroupSubject } from "./group_subject.js";
 
 export type Direction = "inbound" | "outbound";
 export type ChatType = "direct" | "group";
@@ -393,7 +394,12 @@ export function extractMessageRecord(
       rawBaileysEvent: raw,
       chatType: "group",
       groupJid,
-      groupSubject: null,
+      // FIX (2026-06-30): group name comes from Baileys group metadata, never
+      // from the message envelope. The group_subject cache is hydrated on
+      // connection open (session.ts) + kept fresh by groups.update listeners.
+      // Falls back to null (prior behaviour) when the subject isn't cached yet;
+      // the INSERT's COALESCE(EXCLUDED, existing) preserves any earlier value.
+      groupSubject: getGroupSubject(groupJid),
       senderPhone,
       senderLid,
       senderJid: participantRaw,

--- a/apps/wa-mirror/bridge/session.ts
+++ b/apps/wa-mirror/bridge/session.ts
@@ -53,7 +53,11 @@ import {
   openSession,
   touch,
 } from "./heartbeat.js";
-import { query } from "./pg.js";
+import { query, getPool } from "./pg.js";
+import {
+  hydrateAllGroupSubjects,
+  attachGroupSubjectListeners,
+} from "./group_subject.js";
 import {
   PgMessageContextStore,
   extractMessageRecord,
@@ -321,10 +325,21 @@ function connectWithRetry(ctx: ConnectContext): Promise<number> {
           bumpUpsertTs();
         }
       });
+      let groupSubjectsHydrated = false;
       onSock("connection.update", (u) => {
         if (u.connection === "open") {
           connectionOpen = true;
           lastUpsertAt = Date.now(); // reset timer on fresh open
+          // FIX (2026-06-30): hydrate group names once per session. Groups are
+          // dashboard-blind without this — group_subject_snapshot is only ever
+          // set from Baileys group metadata, never the message envelope.
+          // Fire-and-forget + fully defensive (never throws into the ev loop).
+          if (!groupSubjectsHydrated) {
+            groupSubjectsHydrated = true;
+            void hydrateAllGroupSubjects(sock, getPool(), logger);
+            const detach = attachGroupSubjectListeners(sock, getPool(), logger);
+            disposers.add(detach);
+          }
         } else if (u.connection === "close") {
           connectionOpen = false;
         }


### PR DESCRIPTION
## Problem
Every WhatsApp group rendered as the raw JID (`120363…@g.us`) in all three WA dashboards (M1 :7790, viewer :7777). Verified live on `nuzantara_dev`: **119 groups, 100% with empty `group_subject_snapshot`** across 6,565 group messages.

**Root cause** (mapped by 3 parallel explore agents, all file:line verified on disk):
- the bridge only subscribed to `messages.upsert` and **hardcoded `groupSubject: null`** (`message_capture.ts:396`);
- the group name lives **only** in Baileys group metadata (`groupFetchAllParticipating()` / `groupMetadata()`), **never** in the message envelope — confirmed by grepping a stored group `raw_baileys_event` (no `subject` field);
- no `groups.update`/`groups.upsert` listener existed anywhere in the bridge.

## Fix
- **`bridge/group_subject.ts`** (new): process-wide `Map<jid,subject>` cache + `hydrateAllGroupSubjects()` (one `groupFetchAllParticipating()` → cache + DB backfill of historical rows, idempotent, only fills empty snapshots) + `attachGroupSubjectListeners()` for live renames.
- **`message_capture.ts`**: `groupSubject` reads the cache instead of `null`; existing INSERT `COALESCE(EXCLUDED, existing)` preserves captured values.
- **`session.ts`**: hydrate once per session on `connection.update → open`, attach `groups.update`/`groups.upsert` listeners (disposed on close).

Backfillable now: **110/119 groups still active** in the last 30 days → the connected accounts can still fetch their names.

## Safety
- **Read-only toward WhatsApp** (group-metadata fetches, never sends) — consistent with the bridge's read-only contract (`session.ts:12`).
- **Fully defensive**: nothing throws into the event loop; any fetch/DB failure logs a warn and degrades to the prior `null` behaviour — message capture is never affected.
- The live mirror runs from compiled `dist/`, so this source change is inert until a deliberate `npm run build` + restart.

## Verification
- `npx prettier --write` clean.
- `npx tsc --noEmit` → **0 errors** against Baileys 7.0.0-rc13 (`groupFetchAllParticipating`, `groups.update`, `groups.upsert` all valid in the installed types).
- Live deploy + DB backfill verification to be done supervised on one test account before fleet rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)