### PR TITLE
fix(mata-garuda): durable cron wrapper in repo — kill the HOME-fork (cicatrix #1)

### DIFF
--- a/apps/mata-garuda/infra/launchagents/migrate_crons_to_repo_wrapper.sh
+++ b/apps/mata-garuda/infra/launchagents/migrate_crons_to_repo_wrapper.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Repoint the 10 mata_garuda wrapper-crons from the HOME-fork wrapper
+# (~/scripts/matagaruda-cron-tcc-safe.sh) to the REPO-tracked, path-aware copy.
+#
+# cicatrix #1 (HOME-fork drift): the live split-brain of 2026-06-30 happened
+# because the wrapper lived outside git and hardcoded the Mini Redis host. This
+# moves every cron onto the repo wrapper so `git pull` keeps them correct, and the
+# test_cron_wrapper_no_homefork lint stops re-drift.
+#
+# Idempotent. Run on Pro (where these 10 LaunchAgents live).
+set -euo pipefail
+
+REPO="$HOME/Desktop/nuzantara"
+REPO_WRAPPER="$REPO/apps/mata-garuda/scripts/matagaruda-cron-tcc-safe.sh"
+HOMEFORK="$HOME/scripts/matagaruda-cron-tcc-safe.sh"
+LA="$HOME/Library/LaunchAgents"
+
+[ -x "$REPO_WRAPPER" ] || { echo "[ERROR] repo wrapper missing/not-exec: $REPO_WRAPPER" >&2; exit 1; }
+
+CRONS=(daily-briefing kg-linker kita-feed.daily nlm-expander.weekly public-channel
+       reg-alert.30min sentinel.hourly weekly-digest wr-topic wr2-bridge.hourly)
+
+for c in "${CRONS[@]}"; do
+  P="$LA/com.matagaruda.$c.plist"
+  [ -f "$P" ] || { echo "  skip $c (no plist)"; continue; }
+  # the real label (some plists drop the schedule suffix)
+  L=$(/usr/libexec/PlistBuddy -c "Print :Label" "$P" 2>/dev/null)
+  cur=$(/usr/libexec/PlistBuddy -c "Print :ProgramArguments:0" "$P" 2>/dev/null || true)
+  if [ "$cur" = "$REPO_WRAPPER" ]; then echo "  ok   $c (already repo wrapper)"; continue; fi
+  cp -p "$P" "$P.bak-repowrapper-$(date +%Y%m%d-%H%M%S)"
+  /usr/libexec/PlistBuddy -c "Set :ProgramArguments:0 $REPO_WRAPPER" "$P"
+  plutil -lint "$P" >/dev/null
+  # reload under the REAL label
+  launchctl bootout "gui/$(id -u)/$L" 2>/dev/null || true
+  launchctl bootstrap "gui/$(id -u)" "$P" 2>/dev/null || echo "    (reload deferred — picks up next run)"
+  echo "  migrated $c → repo wrapper (label $L)"
+done
+
+echo "done. HOME-fork wrapper $HOMEFORK is now unused (keep as fallback or rm after a clean cycle)."

--- a/apps/mata-garuda/scripts/matagaruda-cron-tcc-safe.sh
+++ b/apps/mata-garuda/scripts/matagaruda-cron-tcc-safe.sh
@@ -1,0 +1,50 @@
+#!/bin/zsh
+# Mata Garuda generic cron wrapper — TCC-safe (W19+W20 pattern)
+# Usage: matagaruda-cron-tcc-safe.sh <entry_script_path> [log_label]
+#
+# Eliminates the /bin/bash -lc + source .venv/bin/activate failure that
+# launchd TCC sandbox produced as false-noise in .error.log for at
+# least kg-linker + wr-topic crons (W20 cicatrix 2026-05-22).
+#
+# Reusable: caller passes entry script. Wrapper does no business logic.
+
+set -e
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+if [ $# -lt 1 ]; then
+    echo "[ERROR] usage: $0 <entry_script_abs_path> [log_label]" >&2
+    exit 2
+fi
+
+ENTRY="$1"
+LABEL="${2:-$(basename "$ENTRY" .py)}"
+
+# Path-aware: derive repo root from THIS script's location
+# (<repo>/apps/mata-garuda/scripts/matagaruda-cron-tcc-safe.sh).
+SCRIPT_DIR="${0:A:h}"            # zsh: absolute dir of this script
+REPO_ROOT="${REPO_ROOT:-${SCRIPT_DIR:h:h:h}}"   # up 3: scripts→mata-garuda→apps→repo
+APP_ROOT="$REPO_ROOT/apps/mata-garuda"
+VENV_PY="$APP_ROOT/.venv/bin/python"
+
+if [ -f "$HOME/.nuzantara-secrets.env" ]; then
+    set -a
+    . "$HOME/.nuzantara-secrets.env"
+    set +a
+fi
+
+# Canonical Redis = Pro (127.0.0.1). Was 100.93.236.6 (Mini) → caused
+# the live split-brain: 10 crons read Mini while monitor/archiver/rollup
+# read Pro, and 982 alerts sat unsent. Fixed canonical to Pro 2026-06-30.
+export GARUDA_REDIS_HOST="${GARUDA_REDIS_HOST:-127.0.0.1}"  # canonical=Pro (Zero 2026-06-30, Stage1)
+export PYTHONPATH="${PYTHONPATH:-$APP_ROOT}"
+
+[ -x "$VENV_PY" ] || { echo "[ERROR] venv python missing: $VENV_PY" >&2; exit 2; }
+[ -f "$ENTRY" ] || { echo "[ERROR] entry script missing: $ENTRY" >&2; exit 2; }
+
+cd "$APP_ROOT"
+# W21 fix: do NOT redirect stdout/stderr — let launchd's StandardOutPath
+# and StandardErrorPath capture them separately. The W19+W20 version
+# redirected to ~/logs/matagaruda-${LABEL}.log which merged stdout+stderr
+# into one file, defeating the W8 signal/noise separation purpose.
+# Python -u flag forces unbuffered output for real-time log visibility.
+exec "$VENV_PY" -u "$ENTRY"

--- a/apps/mata-garuda/tests/test_cron_wrapper_no_homefork.py
+++ b/apps/mata-garuda/tests/test_cron_wrapper_no_homefork.py
@@ -1,0 +1,57 @@
+"""Lint: the mata_garuda cron wrapper must live in the REPO, never a HOME-fork.
+
+cicatrix #1 (HOME-fork drift): the split-brain of 2026-06-30 happened because the
+live cron wrapper was ~/scripts/matagaruda-cron-tcc-safe.sh — a copy outside git
+that hardcoded the Mini Redis host. The repo fix never reached it. This lint makes
+that class of drift fail CI:
+  1. the canonical wrapper EXISTS in the repo,
+  2. it points at the Pro-canonical Redis (not Mini),
+  3. it is path-aware (no /Users/<user> hardcode),
+  4. no committed installer/plist references the ~/scripts/ HOME-fork path.
+"""
+from __future__ import annotations
+
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent          # apps/mata-garuda
+WRAPPER = ROOT / "scripts" / "matagaruda-cron-tcc-safe.sh"
+INFRA = ROOT / "infra" / "launchagents"
+
+
+def test_wrapper_exists_in_repo():
+    assert WRAPPER.is_file(), f"canonical cron wrapper missing from repo: {WRAPPER}"
+
+
+def test_wrapper_targets_pro_canonical_not_mini():
+    # check the EXECUTABLE export line, not comments (which may mention the old Mini IP)
+    export_lines = [l for l in WRAPPER.read_text().splitlines()
+                    if "export GARUDA_REDIS_HOST" in l and not l.lstrip().startswith("#")]
+    assert export_lines, "no GARUDA_REDIS_HOST export found in wrapper"
+    line = export_lines[0]
+    assert "100.93.236.6" not in line, f"wrapper still defaults to Mini: {line.strip()}"
+    assert "127.0.0.1" in line, f"wrapper must default to Pro 127.0.0.1: {line.strip()}"
+
+
+def test_wrapper_is_path_aware_no_user_hardcode():
+    s = WRAPPER.read_text()
+    # REPO_ROOT must derive from the script location, not a hardcoded /Users/<user>
+    assert "/Users/nuzantara/Desktop/nuzantara" not in s, \
+        "wrapper hardcodes /Users/nuzantara — must derive REPO_ROOT from script location"
+
+
+def test_no_committed_file_references_homefork_wrapper():
+    """No installer/script in the repo may invoke the ~/scripts/ HOME-fork copy."""
+    # the migration script legitimately NAMES the home-fork path (its job is to
+    # migrate crons AWAY from it) — it is the one allowed exception.
+    ALLOWED = {"migrate_crons_to_repo_wrapper.sh"}
+    offenders = []
+    for p in list(INFRA.glob("*.sh")) + list((ROOT / "scripts").glob("*.sh")):
+        if p.name in ALLOWED:
+            continue
+        s = p.read_text()
+        # the home-fork path; allow it only inside an explanatory comment line
+        for i, line in enumerate(s.splitlines(), 1):
+            if "/scripts/matagaruda-cron-tcc-safe" in line and not line.lstrip().startswith("#"):
+                if "$HOME/scripts" in line or "~/scripts" in line or "/Users/" in line:
+                    offenders.append(f"{p.name}:{i}: {line.strip()}")
+    assert not offenders, "committed files reference the HOME-fork wrapper:\n" + "\n".join(offenders)


### PR DESCRIPTION
The 2026-06-30 split-brain root cause was a **HOME-fork**: the live cron wrapper lived at `~/scripts/matagaruda-cron-tcc-safe.sh` (outside git) and hardcoded the Mini Redis host, so the repo fix never reached the 10 wrapper-driven crons. They read Mini while monitor/archiver/rollup read Pro; 982 alerts sat unsent.

**Durable fix:**
- `scripts/matagaruda-cron-tcc-safe.sh` — wrapper now lives IN the repo (`git pull` keeps every machine correct). Path-aware: `REPO_ROOT` derives from the script's own location (no `/Users/nuzantara` hardcode → Pro/Mini/M5, any user). Canonical Redis = Pro (127.0.0.1).
- `infra/launchagents/migrate_crons_to_repo_wrapper.sh` — idempotent migration repointing the 10 LaunchAgents at the repo wrapper (backs up each plist, reloads under real Label).
- `tests/test_cron_wrapper_no_homefork.py` — **CI lint** failing if the wrapper goes missing / points at Mini / hardcodes a user path / any committed file invokes the `~/scripts/` HOME-fork. Makes the cicatrix-#1 family non-recurring.

The entry scripts (`run_*.py`) were already in the repo — only the wrapper was forked.

TDD: 4/4 lint. Full suite **1007 passed**; the lone failure (`test_kg_query::test_t11_concurrent_reads`, ConnectionReset) is pre-existing — this branch touches zero kg/api files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)