### PR TITLE
fix(mata-garuda): gap.consumer dead-worktree + durable gap wrapper (cicatrix #1)

### DIFF
--- a/apps/mata-garuda/infra/launchagents/migrate_crons_to_repo_wrapper.sh
+++ b/apps/mata-garuda/infra/launchagents/migrate_crons_to_repo_wrapper.sh
@@ -36,4 +36,20 @@ for c in "${CRONS[@]}"; do
   echo "  migrated $c → repo wrapper (label $L)"
 done
 
+
+# --- gap.consumer uses a SEPARATE wrapper (matagaruda-gap-consumer.sh) + had a
+# --- dead-worktree MATA_GARUDA_REPO. Repoint to repo wrapper + fix the repo env. ---
+GAP_P="/com.matagaruda.gap.consumer.plist"
+GAP_WRAPPER="/apps/mata-garuda/scripts/matagaruda-gap-consumer.sh"
+if [ -f "" ] && [ -x "" ]; then
+  cp -p "" ".bak-repowrapper-$(date +%Y%m%d-%H%M%S)"
+  /usr/libexec/PlistBuddy -c "Set :ProgramArguments:0 " "" 2>/dev/null || true
+  # kill the dead-worktree repo pointer → main checkout
+  /usr/libexec/PlistBuddy -c "Set :EnvironmentVariables:MATA_GARUDA_REPO /apps/mata-garuda" "" 2>/dev/null || true
+  plutil -lint "$GAP_P" >/dev/null
+  launchctl bootout "gui/$(id -u)/com.matagaruda.gap.consumer" 2>/dev/null || true
+  launchctl bootstrap "gui/$(id -u)" "$GAP_P" 2>/dev/null || echo "    (gap reload deferred)"
+  echo "  migrated gap.consumer → repo wrapper + MATA_GARUDA_REPO=main checkout"
+fi
+
 echo "done. HOME-fork wrapper $HOMEFORK is now unused (keep as fallback or rm after a clean cycle)."

--- a/apps/mata-garuda/scripts/matagaruda-gap-consumer.sh
+++ b/apps/mata-garuda/scripts/matagaruda-gap-consumer.sh
@@ -1,0 +1,40 @@
+#!/bin/zsh
+# Mata Garuda Gap Consumer — reads nexus:gaps, dispatches agents.
+# Runs every 10 minutes during 06:00-22:00 WITA.
+
+set -e
+# Mythos-P3 (2026-06-14): include ~/.local/bin so the gap_consumer's
+# CLIRuntime can find the `claude` binary (it lives at ~/.local/bin/claude,
+# not /opt/homebrew/bin). Under launchd's minimal PATH it was unresolved
+# → every agent dispatch failed "Command not found: claude" → gaps were
+# detected but never resolved.
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+if [ -f "$HOME/.nuzantara-secrets.env" ]; then
+    set -a
+    source "$HOME/.nuzantara-secrets.env"
+    set +a
+fi
+
+# Path-aware default: derive from THIS script's location
+# (<repo>/apps/mata-garuda/scripts/). MATA_GARUDA_REPO may still override,
+# but it must point at a LIVE checkout — a dead .worktrees/ path made the
+# gap.consumer cron exit 1 for 62 runs (cicatrix #1 dead-worktree, 2026-06-30).
+SCRIPT_DIR="${0:A:h}"
+REPO="${MATA_GARUDA_REPO:-${SCRIPT_DIR:h}}"
+VENV_PY="${MATA_GARUDA_VENV_PY:-$REPO/.venv/bin/python}"
+
+if [ ! -x "$VENV_PY" ]; then
+    echo "[gap_consumer] venv python not found at $VENV_PY" >&2
+    exit 1
+fi
+
+# Skip outside operating window (06:00-22:00 WITA — local time)
+HOUR=$(date +%H)
+if [ "$HOUR" -lt 6 ] || [ "$HOUR" -ge 22 ]; then
+    echo "[gap_consumer] Outside operating window ($HOUR:00) — skipping"
+    exit 0
+fi
+
+cd "$REPO"
+PYTHONPATH="$REPO" "$VENV_PY" -m mata_garuda.workers.gap_consumer

--- a/apps/mata-garuda/tests/test_cron_wrapper_no_homefork.py
+++ b/apps/mata-garuda/tests/test_cron_wrapper_no_homefork.py
@@ -51,7 +51,22 @@ def test_no_committed_file_references_homefork_wrapper():
         s = p.read_text()
         # the home-fork path; allow it only inside an explanatory comment line
         for i, line in enumerate(s.splitlines(), 1):
-            if "/scripts/matagaruda-cron-tcc-safe" in line and not line.lstrip().startswith("#"):
+            if "/scripts/matagaruda-" in line and ".sh" in line and not line.lstrip().startswith("#"):
                 if "$HOME/scripts" in line or "~/scripts" in line or "/Users/" in line:
                     offenders.append(f"{p.name}:{i}: {line.strip()}")
     assert not offenders, "committed files reference the HOME-fork wrapper:\n" + "\n".join(offenders)
+
+
+GAP_WRAPPER = ROOT / "scripts" / "matagaruda-gap-consumer.sh"
+
+
+def test_gap_wrapper_in_repo_and_path_aware():
+    assert GAP_WRAPPER.is_file(), f"gap-consumer wrapper missing from repo: {GAP_WRAPPER}"
+    s = GAP_WRAPPER.read_text()
+    # check EXECUTABLE lines only (comments may explain the old hardcode/bug)
+    code = [l for l in s.splitlines() if l.strip() and not l.lstrip().startswith("#")]
+    code_s = "\n".join(code)
+    assert "/Users/nuzantara/Desktop/nuzantara/apps/mata-garuda" not in code_s, \
+        "gap wrapper hardcodes a user path — derive REPO from script location"
+    # must NOT default REPO to a .worktrees path (the dead-worktree exit-1 bug)
+    assert ".worktrees" not in code_s, "gap wrapper defaults REPO to a .worktrees path (dead-worktree risk)"


### PR DESCRIPTION
`gap.consumer` cron exited 1 for **62 runs**: its plist set `MATA_GARUDA_REPO` to a `.worktrees/mata-garuda-agy-runtime/...` path that was reaped/removed → the wrapper's `cd "$REPO"` failed every cycle while a **3828-entry `nexus:gaps` backlog** (consumer lag 188) went unprocessed. (`MATA_GARUDA_VENV_PY` pointed at the live checkout — only the REPO pointer was dead.)

**A/B-confirmed:** REPO=dead-worktree → exit 1; REPO=main checkout → clean (read:5 skipped:5 errors:0, exit 0).

**Durable fix:**
- `scripts/matagaruda-gap-consumer.sh` — wrapper now in-repo, path-aware (no `/Users` hardcode, no `.worktrees` default).
- `migrate_crons_to_repo_wrapper.sh` — extended to repoint gap.consumer + reset its `MATA_GARUDA_REPO`.
- `test_cron_wrapper_no_homefork` — generalized to flag ANY `/scripts/matagaruda-*.sh` HOME-fork + asserts gap wrapper in-repo/path-aware/no-worktree-default.

Live plist already fixed (exit 0 verified) ahead of this; this makes it durable + lint-guarded. Sweep confirmed gap.consumer was the ONLY plist referencing a worktree.

TDD: 5/5 lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)