### PR TITLE
fix(wa-mirror): observable media failures + retry, resolve group sender from participantAlt

### DIFF
--- a/apps/wa-mirror/bridge/media.ts
+++ b/apps/wa-mirror/bridge/media.ts
@@ -37,15 +37,60 @@ export function queueMediaDownload(opts: {
   }
 
   setImmediate(() => {
-    downloadAndStoreMedia(opts).catch(() => {
+    void downloadWithRetry(opts);
+  });
+}
+
+// FIX (2026-06-30): the previous `.catch(() => warn("failed"))` swallowed the
+// real error (no err.message, no mediaType, no retry) — a silent ~2% media
+// loss that read as healthy (cicatrix #2 "Esiste≠Armato"). Now: one retry with
+// backoff for transient failures (network flap, reupload-request races), and a
+// structured warn carrying the actual error + mediaType so failures are
+// observable and triageable. Permanent failures (expired WhatsApp CDN media,
+// ~14-day TTL) still fail — but now visibly, with the reason.
+const MEDIA_DOWNLOAD_RETRIES = 1;
+const MEDIA_RETRY_BACKOFF_MS = 2000;
+
+async function downloadWithRetry(opts: {
+  sock: WASocket;
+  rawMessage: unknown;
+  messageContextId: number;
+  record: CapturedMessageRecord;
+  store: MessageContextStore;
+  logger: pino.Logger;
+}): Promise<void> {
+  for (let attempt = 0; attempt <= MEDIA_DOWNLOAD_RETRIES; attempt++) {
+    try {
+      await downloadAndStoreMedia(opts);
+      if (attempt > 0) {
+        opts.logger.info(
+          {
+            messageContextId: opts.messageContextId,
+            mediaType: opts.record.mediaType,
+            attempt,
+          },
+          "wa-mirror media download recovered on retry",
+        );
+      }
+      return;
+    } catch (err) {
+      const isLast = attempt === MEDIA_DOWNLOAD_RETRIES;
       opts.logger.warn(
         {
           messageContextId: opts.messageContextId,
+          mediaType: opts.record.mediaType,
+          attempt,
+          willRetry: !isLast,
+          err: (err as Error).message,
         },
         "wa-mirror media download failed",
       );
-    });
-  });
+      if (isLast) return;
+      await new Promise((r) =>
+        setTimeout(r, MEDIA_RETRY_BACKOFF_MS * (attempt + 1)),
+      );
+    }
+  }
 }
 
 async function downloadAndStoreMedia(opts: {

--- a/apps/wa-mirror/bridge/message_capture.ts
+++ b/apps/wa-mirror/bridge/message_capture.ts
@@ -106,6 +106,7 @@ type BaileysMessageLike = {
     participant?: string | null;
     participantPn?: string | null;
     participantLid?: string | null;
+    participantAlt?: string | null;
   } | null;
   messageTimestamp?: number | string | { toNumber?: () => number } | null;
   message?: unknown;
@@ -361,9 +362,18 @@ export function extractMessageRecord(
     const senderPhoneFromPn = raw.key?.participantPn
       ? normalizePhone(jidToPhone(raw.key.participantPn))
       : "";
+    // FIX (2026-06-30): when a group sender arrives as @lid, the real phone is
+    // often only in key.participantAlt (`<number>@s.whatsapp.net`), not in
+    // participantPn/participant. Without this fallback senderPhone stays null
+    // and the dashboard shows `lid:<id>` instead of a name (251 such rows were
+    // backfilled from the raw event; this stops new ones from regressing).
+    const senderPhoneFromAlt = raw.key?.participantAlt
+      ? normalizePhone(jidToPhone(raw.key.participantAlt))
+      : "";
     const senderPhone =
       senderPhoneFromPn ||
       (participantParsed.kind === "phone" ? participantParsed.phone : "") ||
+      senderPhoneFromAlt ||
       null;
     const senderLid =
       (raw.key?.participantLid ? parseJid(raw.key.participantLid).lid : "") ||


### PR DESCRIPTION
Two cohesive bridge-resilience fixes for the WhatsApp mirror.

## 1. Observable media-download failures + retry (cicatrix #2)
`bridge/media.ts:40-48` swallowed the error: `.catch(() => warn("failed"))` logged only `messageContextId` — no `err.message`, no `mediaType`, **no retry**. A ~2% silent media loss (400 files: 151 img + 142 doc + 103 sticker + 4) read as healthy.
- one retry with linear backoff for transient failures (network flap, reupload-request races);
- structured warn carrying `err.message` + `mediaType` + `attempt` + `willRetry`;
- info log on retry-recovery.

Permanent failures (expired WhatsApp CDN media, ~14-day TTL) still fail — but now **visibly, with the reason**.

## 2. Resolve group sender phone from `key.participantAlt`
When a group sender arrives as `@lid`, the real phone is often only in `key.participantAlt` (`<number>@s.whatsapp.net`), not in `participantPn`/`participant`. The extraction never read it → `senderPhone` stayed null → dashboard showed `lid:<id>` instead of a name. **356 group messages affected, 251 with a recoverable participantAlt.**
- add `participantAlt` to the `BaileysMessageLike.key` type;
- use it as a fallback in the group sender-phone chain.

The 251 historical rows were **backfilled directly in `nuzantara_dev`** from the raw event (356 → 105 unresolved; group-sender readability now 99.9%). This code change stops new messages from regressing. The residual 105 are privacy-shielded LIDs with no participantAlt (need the `co_seen` identity resolver — out of scope here).

## Verification
- `prettier --write` clean (both files).
- `tsc --noEmit` → **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)