### PR TITLE
fix(mata-garuda): scorer political_risk weight + string-score coercion (W89 #5,#7)

### DIFF
--- a/apps/mata-garuda/mata_garuda/config.py
+++ b/apps/mata-garuda/mata_garuda/config.py
@@ -54,13 +54,19 @@ NLM_DOMAIN_ROUTING = {
 NLM_FEEDER_BATCH_SIZE = 10       # max items per run
 NLM_FEEDER_SLEEP_BETWEEN_S = 5   # seconds between MCP/CLI calls
 
-# Relevance scoring weights for business context
+# Relevance scoring weights for business context.
+# INVARIANT: every topic emitted by scorer._KEYWORD_FAST_PATH MUST be a key here,
+# else RELEVANCE_WEIGHTS.get(topic, 1) silently weights it DOWN to 1 and a
+# high-signal item never alerts (W89: 'political_risk' was missing → every new
+# Indonesian regulation got weighted_score = score - 1, below SCORE_SIGNAL).
+# test_scorer_topics_have_weights.py pins this contract.
 RELEVANCE_WEIGHTS = {
     "immigration_visa": 5,
     "tax_fiscal": 5,
     "investment_licensing": 4,
     "labor_manpower": 4,
     "provincial_bali": 4,
+    "political_risk": 4,   # new regs/perpres/permen/menteri — core signal for the agency
     "financial_banking": 3,
     "property": 3,
     "environmental": 2,

--- a/apps/mata-garuda/mata_garuda/config.py
+++ b/apps/mata-garuda/mata_garuda/config.py
@@ -66,7 +66,9 @@ RELEVANCE_WEIGHTS = {
     "investment_licensing": 4,
     "labor_manpower": 4,
     "provincial_bali": 4,
-    "political_risk": 4,   # new regs/perpres/permen/menteri — core signal for the agency
+    "political_risk": 5,   # new regs/perpres/permen/menteri — core signal; weight 5 so a
+                           # pure-regulation hit (default_score 3) clears SCORE_SIGNAL (4):
+                           # weighted = min(5, 3 + (5-3)*0.5) = 4.0. At 4 it'd be 3.5 (WATCH only).
     "financial_banking": 3,
     "property": 3,
     "environmental": 2,

--- a/apps/mata-garuda/mata_garuda/workers/scorer.py
+++ b/apps/mata-garuda/mata_garuda/workers/scorer.py
@@ -183,7 +183,13 @@ def run_scorer(kb: KnowledgeBase, max_items: int = 20) -> dict:
         source = data.get("source", "")
 
         scoring = score_with_ollama(title, content, source)
-        score = scoring.get("score", 2)
+        # Coerce the LLM 'score' to a number — a string score (e.g. "4") would
+        # crash the weighted arithmetic below and, with no per-item try/except,
+        # kill the whole batch and leave PEL orphans (W89 #7).
+        try:
+            score = float(scoring.get("score", 2))
+        except (TypeError, ValueError):
+            score = 2.0
         topic = scoring.get("topic", "other")
         reason = scoring.get("reason", "")
 

--- a/apps/mata-garuda/tests/test_scorer_topics_have_weights.py
+++ b/apps/mata-garuda/tests/test_scorer_topics_have_weights.py
@@ -57,4 +57,5 @@ class TestScoreCoercion:
                 score = 2.0
             weight = config.RELEVANCE_WEIGHTS.get("political_risk", 1)
             weighted = min(5, score + (weight - 3) * 0.5)  # must not raise
-            assert isinstance(weighted, float)
+            # numeric (int or float — min() returns the int on a tie like min(5, 5.0))
+            assert isinstance(weighted, (int, float)) and weighted == weighted  # not NaN

--- a/apps/mata-garuda/tests/test_scorer_topics_have_weights.py
+++ b/apps/mata-garuda/tests/test_scorer_topics_have_weights.py
@@ -1,0 +1,60 @@
+"""Regression tests for scorer topic/weight drift (W89 #5) + string-score crash (#7).
+
+#5: scorer._KEYWORD_FAST_PATH emitted topic 'political_risk', which was ABSENT
+from config.RELEVANCE_WEIGHTS → RELEVANCE_WEIGHTS.get(topic, 1) silently fell
+back to 1 → weighted_score = score + (1-3)*0.5 = score - 1 → every Indonesian
+regulation (peraturan/perpres/permen/menteri) landed BELOW SCORE_SIGNAL(4) and
+never alerted Zero. The structural antidote (kills the whole class, not just
+this instance): assert EVERY fast-path topic is a weights key.
+
+#7: a string 'score' from the LLM crashed the weighted arithmetic and — with no
+per-item try/except in run_scorer — killed the whole batch. The scorer now
+coerces score to float.
+"""
+from __future__ import annotations
+
+from mata_garuda import config
+from mata_garuda.workers import scorer
+
+
+class TestTopicWeightContract:
+    def test_every_fast_path_topic_has_a_weight(self):
+        """No keyword fast-path topic may be missing from RELEVANCE_WEIGHTS."""
+        topics = {topic for _pat, topic, _score in scorer._KEYWORD_FAST_PATH}
+        missing = topics - set(config.RELEVANCE_WEIGHTS)
+        assert not missing, (
+            f"fast-path topics absent from RELEVANCE_WEIGHTS (silently weighted to 1): {missing}"
+        )
+
+    def test_political_risk_is_present_and_high_signal(self):
+        """The specific W89 regression: political_risk must weight UP, not down."""
+        assert "political_risk" in config.RELEVANCE_WEIGHTS
+        # weight >= 3 means weighted_score >= score (no demotion)
+        assert config.RELEVANCE_WEIGHTS["political_risk"] >= 3
+
+    def test_regulation_item_now_clears_alert_threshold(self):
+        """'Prabowo teken Perpres' → political_risk(score 3) must reach SCORE_SIGNAL."""
+        result = scorer.classify_by_keyword(
+            "Prabowo teken Perpres baru soal kementerian", ""
+        )
+        assert result is not None and result["topic"] == "political_risk"
+        score = float(result["score"])
+        weight = config.RELEVANCE_WEIGHTS.get(result["topic"], 1)
+        weighted = min(5, score + (weight - 3) * 0.5)
+        assert weighted >= config.SCORE_SIGNAL, (
+            f"regulation weighted={weighted} must reach SCORE_SIGNAL={config.SCORE_SIGNAL}"
+        )
+
+
+class TestScoreCoercion:
+    def test_string_score_does_not_crash_weighted_math(self):
+        """A string score must coerce, not raise (W89 #7)."""
+        # mirror the scorer's coercion + arithmetic
+        for raw in ("4", 4, 4.0, "bogus", None):
+            try:
+                score = float(raw)
+            except (TypeError, ValueError):
+                score = 2.0
+            weight = config.RELEVANCE_WEIGHTS.get("political_risk", 1)
+            weighted = min(5, score + (weight - 3) * 0.5)  # must not raise
+            assert isinstance(weighted, float)


### PR DESCRIPTION
## What

Two scorer-correctness defects from the mata_garuda adversarial audit (both verified on Pro disk; both audit verdicts `refuted=False`, high confidence).

### #5 (HIGH, correctness) — regulations never alerted Zero
`scorer._KEYWORD_FAST_PATH` emits topic `political_risk` for every `(prabowo|jokowi|menteri|kementerian|peraturan|undang-undang|perpres|permen)` hit, but `RELEVANCE_WEIGHTS` had **no `political_risk` key** → `RELEVANCE_WEIGHTS.get(topic, 1)` → weight=1 → `weighted_score = score + (1-3)*0.5 = score - 1`. A regulation item (`default_score=3`) became `weighted=2.0`, **below `SCORE_SIGNAL=4`** → stored as WATCH, **never alerts**. New Indonesian regulations — the literal core signal for an immigration/tax/company-setup agency — reached Zero as no-alert noise.

**Fix:** `political_risk: 5` (a new reg is as high-signal as a visa/tax change; the empirical gate proved 4 gives only 3.5 = WATCH, 5 gives 4.0 = SIGNAL). **+ the structural antidote:** a test asserting **every `_KEYWORD_FAST_PATH` topic is a `RELEVANCE_WEIGHTS` key** — kills the whole drift class, not just this instance.

### #7 (MEDIUM, robustness) — string score crashes the batch
`score_with_ollama`'s `score` is used in arithmetic with no coercion. A string score (`"4"`) raises `TypeError` and, with no per-item try/except in `run_scorer` (#6, tracked separately), kills the whole batch → PEL orphans. **Fix:** coerce to float (fallback 2.0).

## Empirical proof
The gate caught two of my own off-by-design errors before merge (weight 4→5; `min()` returns int on a tie). Final: **18/18 pass on Pro** (real venv pydantic 2.12.5) — topic/weight contract, political_risk clears SCORE_SIGNAL, string/None coercion never raises, classifier suite no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)