### PR TITLE
fix(mata-garuda): migrate 7 remaining bare redis-cli callers to authed SSOT + lint (W89 #10,#12,#13)

### DIFF
--- a/apps/mata-garuda/mata_garuda/agents/kita_feed_generator.py
+++ b/apps/mata-garuda/mata_garuda/agents/kita_feed_generator.py
@@ -41,16 +41,14 @@ MIN_SCORE = 3
 
 
 def _redis_cmd(*args: str, timeout: int = 10) -> str:
-    try:
-        result = subprocess.run(
-            ["redis-cli", *args],
-            capture_output=True, text=True, timeout=timeout,
-        )
-        if result.returncode != 0:
-            return ""
-        return result.stdout.strip()
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    # Delegate to base_worker.redis_cmd (authed SSOT: REDISCLI_AUTH + canonical
+    # host + abs-path). Was bare redis-cli → NOAUTH-swallowed-to-'' under the
+    # requirepass cutover (W89, cicatrix #2). '[ERROR]' → '' to keep the contract.
+    from mata_garuda.workers.base_worker import redis_cmd as _bw_redis_cmd
+    out = _bw_redis_cmd(*args, timeout=timeout)
+    if out.startswith("[ERROR]"):
         return ""
+    return out
 
 
 def _parse(raw: str) -> list[dict[str, str]]:

--- a/apps/mata-garuda/mata_garuda/agents/public_channel_publisher.py
+++ b/apps/mata-garuda/mata_garuda/agents/public_channel_publisher.py
@@ -46,21 +46,21 @@ WITA = timezone(timedelta(hours=8))
 
 
 def _redis_cmd(*args: str, timeout: int = 10) -> str:
-    """Run redis-cli and return stdout (empty on error)."""
-    try:
-        result = subprocess.run(
-            ["redis-cli", *args],
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-        )
-        if result.returncode != 0:
-            logger.warning("redis-cli failed: %s", result.stderr.strip())
-            return ""
-        return result.stdout.strip()
-    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
-        logger.warning("redis-cli error: %s", e)
+    """Run redis-cli via base_worker (the authed SSOT), '' on error.
+
+    Previously ran BARE redis-cli with no REDISCLI_AUTH/-h: under the Stage 1
+    requirepass cutover (2026-06-29) every call got NOAUTH at exit 0, swallowed
+    into '' → this publisher (armed via LaunchAgent) silently published nothing
+    (W89, cicatrix #2 green-but-dead). Delegating to base_worker.redis_cmd gets
+    REDISCLI_AUTH (cicatrix #4), canonical-host resolution and the abs-path; its
+    '[ERROR]' sentinel is mapped back to '' to preserve this caller's contract.
+    """
+    from mata_garuda.workers.base_worker import redis_cmd as _bw_redis_cmd
+    out = _bw_redis_cmd(*args, timeout=timeout)
+    if out.startswith("[ERROR]"):
+        logger.warning("redis-cli failed: %s", out)
         return ""
+    return out
 
 
 def _parse_xrange_output(raw: str) -> list[dict[str, str]]:

--- a/apps/mata-garuda/mata_garuda/agents/wr2_bridge_publisher.py
+++ b/apps/mata-garuda/mata_garuda/agents/wr2_bridge_publisher.py
@@ -41,18 +41,15 @@ STATE_PATH = Path.home() / ".agent" / "decisions" / "wr2_bridge_cursor.json"
 
 
 def _redis_cmd(*args: str, timeout: int = 10) -> str:
-    try:
-        result = subprocess.run(
-            ["redis-cli", *args],
-            capture_output=True, text=True, timeout=timeout,
-        )
-        if result.returncode != 0:
-            logger.warning("redis-cli failed: %s", result.stderr.strip())
-            return ""
-        return result.stdout.strip()
-    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
-        logger.warning("redis-cli error: %s", e)
+    # Delegate to base_worker.redis_cmd (authed SSOT: REDISCLI_AUTH + canonical
+    # host + abs-path). Was bare redis-cli → NOAUTH-swallowed-to-'' under the
+    # requirepass cutover (W89, cicatrix #2). '[ERROR]' → '' to keep the contract.
+    from mata_garuda.workers.base_worker import redis_cmd as _bw_redis_cmd
+    out = _bw_redis_cmd(*args, timeout=timeout)
+    if out.startswith("[ERROR]"):
+        logger.warning("redis-cli failed: %s", out)
         return ""
+    return out
 
 
 def _parse_xrange_output(raw: str) -> list[dict[str, str]]:

--- a/apps/mata-garuda/mata_garuda/cell/sensors.py
+++ b/apps/mata-garuda/mata_garuda/cell/sensors.py
@@ -86,18 +86,20 @@ class GapStreamSensor:
         self.name = "gap_stream"
 
     async def read(self, **context) -> SensorReading:
+        # Route XLEN through base_worker.redis_cmd (authed SSOT) — bare redis-cli
+        # returned NOAUTH at exit 0 under the requirepass cutover, which then
+        # crashed int() and reported a misleading error (W89, cicatrix #2).
+        from mata_garuda.workers.base_worker import redis_cmd as _bw_redis_cmd
         try:
-            result = await asyncio.to_thread(
-                subprocess.run,
-                ["redis-cli", "XLEN", self.STREAM_KEY],
-                capture_output=True, text=True, timeout=5,
+            out = await asyncio.to_thread(
+                _bw_redis_cmd, "XLEN", self.STREAM_KEY, timeout=5
             )
-            if result.returncode != 0:
+            if out.startswith("[ERROR]"):
                 return SensorReading(
                     sensor_name=self.name, status="yellow",
-                    metadata={"error": "redis-cli failed"},
+                    metadata={"error": out},
                 )
-            count = int(result.stdout.strip())
+            count = int(out.strip())
             if count == 0:
                 status = "green"
             elif count < 10:

--- a/apps/mata-garuda/mata_garuda/tools/health_tools.py
+++ b/apps/mata-garuda/mata_garuda/tools/health_tools.py
@@ -44,17 +44,18 @@ EXPECTED_AGENTS = [
 
 
 def _redis_cmd(*args: str, timeout: int = 5) -> str | None:
-    """Run redis-cli, return stdout or None on error."""
-    try:
-        result = subprocess.run(
-            ["redis-cli", *args],
-            capture_output=True, text=True, timeout=timeout,
-        )
-        if result.returncode != 0:
-            return None
-        return result.stdout.strip()
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    """Run redis-cli via base_worker (authed SSOT), None on error.
+
+    Was bare redis-cli → NOAUTH under the requirepass cutover, which a health
+    tool MUST NOT read as 'fine' (W89, cicatrix #2). base_worker.redis_cmd
+    carries REDISCLI_AUTH + canonical host + abs-path; its '[ERROR]' sentinel is
+    mapped to None to preserve this module's None-on-error contract.
+    """
+    from mata_garuda.workers.base_worker import redis_cmd as _bw_redis_cmd
+    out = _bw_redis_cmd(*args, timeout=timeout)
+    if out.startswith("[ERROR]"):
         return None
+    return out
 
 
 def stream_length(stream: str) -> int | None:

--- a/apps/mata-garuda/mata_garuda/tools/intel_publisher.py
+++ b/apps/mata-garuda/mata_garuda/tools/intel_publisher.py
@@ -127,15 +127,24 @@ def build_envelope(
 
 
 def publish_to_redis(envelope: Envelope, stream: str = STREAM_BRIDGE_OUTBOUND) -> str:
-    """XADD the envelope to the Redis stream. Returns the stream entry ID."""
+    """XADD the envelope to the Redis stream (via the authed SSOT). Returns the entry ID.
+
+    Was bare redis-cli with no auth → under the requirepass cutover a Zero-invoked
+    publish aborted hard with NOAUTH (W89, cicatrix #2). Now delegates to
+    base_worker.redis_cmd (REDISCLI_AUTH + canonical host + abs-path) and adds the
+    MAXLEN ~ trim the other publishers carry (#11 — bounded stream growth).
+    """
+    from mata_garuda.config import STREAM_MAXLEN
+    from mata_garuda.workers.base_worker import redis_cmd as _bw_redis_cmd
+
     fields = envelope.to_redis_dict()
-    args = ["redis-cli", "XADD", stream, "*"]
+    args = ["XADD", stream, "MAXLEN", "~", str(STREAM_MAXLEN), "*"]
     for k, v in fields.items():
         args.extend([k, v])
-    result = subprocess.run(args, capture_output=True, text=True, timeout=10)
-    if result.returncode != 0:
-        raise RuntimeError(f"redis-cli XADD failed: {result.stderr.strip()}")
-    return result.stdout.strip()
+    out = _bw_redis_cmd(*args, timeout=10)
+    if out.startswith("[ERROR]"):
+        raise RuntimeError(f"redis-cli XADD failed: {out}")
+    return out
 
 
 def main(argv: Optional[list[str]] = None) -> int:

--- a/apps/mata-garuda/mata_garuda/tools/task_tools.py
+++ b/apps/mata-garuda/mata_garuda/tools/task_tools.py
@@ -26,17 +26,15 @@ REDIS_CLI = "redis-cli"
 
 
 def _redis_cmd(*args: str, timeout: int = 10) -> str:
-    """Execute a redis-cli command and return output."""
-    cmd = [REDIS_CLI] + list(args)
-    try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
-        if result.returncode != 0:
-            return f"[ERROR] redis-cli: {result.stderr.strip()}"
-        return result.stdout.strip()
-    except FileNotFoundError:
-        return "[ERROR] redis-cli not found"
-    except subprocess.TimeoutExpired:
-        return f"[ERROR] redis-cli timeout after {timeout}s"
+    """Execute a redis-cli command via base_worker (the authed SSOT).
+
+    Was bare redis-cli (no REDISCLI_AUTH/-h) → NOAUTH under the requirepass
+    cutover (W89, cicatrix #2). base_worker.redis_cmd carries auth + canonical
+    host + abs-path and returns the identical '[ERROR] ...' sentinel on failure,
+    so this is a drop-in for the existing callers.
+    """
+    from mata_garuda.workers.base_worker import redis_cmd as _bw_redis_cmd
+    return _bw_redis_cmd(*args, timeout=timeout)
 
 
 @dataclass

--- a/apps/mata-garuda/tests/test_cell_sensors.py
+++ b/apps/mata-garuda/tests/test_cell_sensors.py
@@ -101,11 +101,13 @@ class TestGapStreamSensor:
         assert isinstance(sensor, Sensor)
         assert sensor.name == "gap_stream"
 
+    # GapStreamSensor now routes XLEN through base_worker.redis_cmd (authed SSOT,
+    # W89) instead of bare subprocess — patch redis_cmd (returns the stdout string
+    # or an '[ERROR] ...' sentinel), not subprocess.
     @pytest.mark.asyncio
     async def test_reads_stream_length(self):
         from mata_garuda.cell.sensors import GapStreamSensor
-        with patch("mata_garuda.cell.sensors.subprocess") as mock_sub:
-            mock_sub.run.return_value = MagicMock(returncode=0, stdout="5\n")
+        with patch("mata_garuda.workers.base_worker.redis_cmd", return_value="5"):
             sensor = GapStreamSensor()
             reading = await sensor.read()
         assert reading.status == "yellow"  # 5 < 10 = yellow
@@ -114,8 +116,7 @@ class TestGapStreamSensor:
     @pytest.mark.asyncio
     async def test_zero_gaps_is_green(self):
         from mata_garuda.cell.sensors import GapStreamSensor
-        with patch("mata_garuda.cell.sensors.subprocess") as mock_sub:
-            mock_sub.run.return_value = MagicMock(returncode=0, stdout="0\n")
+        with patch("mata_garuda.workers.base_worker.redis_cmd", return_value="0"):
             sensor = GapStreamSensor()
             reading = await sensor.read()
         assert reading.status == "green"
@@ -123,8 +124,7 @@ class TestGapStreamSensor:
     @pytest.mark.asyncio
     async def test_many_gaps_is_red(self):
         from mata_garuda.cell.sensors import GapStreamSensor
-        with patch("mata_garuda.cell.sensors.subprocess") as mock_sub:
-            mock_sub.run.return_value = MagicMock(returncode=0, stdout="25\n")
+        with patch("mata_garuda.workers.base_worker.redis_cmd", return_value="25"):
             sensor = GapStreamSensor()
             reading = await sensor.read()
         assert reading.status == "red"
@@ -132,8 +132,9 @@ class TestGapStreamSensor:
     @pytest.mark.asyncio
     async def test_redis_unavailable_is_yellow(self):
         from mata_garuda.cell.sensors import GapStreamSensor
-        with patch("mata_garuda.cell.sensors.subprocess") as mock_sub:
-            mock_sub.run.return_value = MagicMock(returncode=1, stdout="")
+        # base_worker.redis_cmd returns '[ERROR] ...' on failure (incl. NOAUTH)
+        with patch("mata_garuda.workers.base_worker.redis_cmd",
+                   return_value="[ERROR] redis-cli: NOAUTH Authentication required."):
             sensor = GapStreamSensor()
             reading = await sensor.read()
         assert reading.status == "yellow"

--- a/apps/mata-garuda/tests/test_no_bare_redis_cli.py
+++ b/apps/mata-garuda/tests/test_no_bare_redis_cli.py
@@ -1,0 +1,46 @@
+"""Structural lint: no mata_garuda module may run bare `redis-cli` via subprocess.
+
+W89 meta-pattern (cicatrix #2 NOAUTH-swallow): PR #1825's Stage 1 cutover put the
+canonical Pro Redis behind requirepass and cured base_worker + stream_tools, but
+the migration was PARTIAL — 7 other modules kept their own bare `redis-cli`
+subprocess calls with no REDISCLI_AUTH, so they silently degraded to green-but-
+dead the moment the password went live.
+
+This test makes the cure structural: it greps every mata_garuda source file for a
+`subprocess.run([... "redis-cli" ...])` and FAILS if found, forcing all redis
+access through base_worker.redis_cmd (the single authed path: REDISCLI_AUTH +
+canonical host + abs-path). base_worker itself is the ONE allowed definition.
+
+If a new module needs redis, it must `from mata_garuda.workers.base_worker import
+redis_cmd` — not re-implement a bare helper. That keeps the auth fix from rotting.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+PKG = pathlib.Path(__file__).resolve().parent.parent / "mata_garuda"
+
+# The ONLY files allowed to hand a literal "redis-cli" to subprocess: base_worker
+# (the authed SSOT) and the split-brain guardian (probes BOTH hosts explicitly
+# with its own self-contained _redis_env — it cannot use the single-host SSOT).
+_ALLOWED = {"workers/base_worker.py"}
+
+# subprocess.run( ... "redis-cli" ... )  — bare invocation on the same statement
+_BARE = re.compile(r"subprocess\.run\([^)]*['\"]redis-cli['\"]", re.DOTALL)
+
+
+def test_no_module_runs_bare_redis_cli():
+    offenders = []
+    for py in PKG.rglob("*.py"):
+        rel = py.relative_to(PKG).as_posix()
+        if rel in _ALLOWED:
+            continue
+        text = py.read_text(encoding="utf-8")
+        if _BARE.search(text):
+            offenders.append(rel)
+    assert not offenders, (
+        "bare `subprocess.run([... 'redis-cli' ...])` found — these bypass "
+        "REDISCLI_AUTH and silently NOAUTH under requirepass (W89). Route through "
+        f"base_worker.redis_cmd instead: {offenders}"
+    )

--- a/apps/mata-garuda/tests/test_no_bare_redis_cli.py
+++ b/apps/mata-garuda/tests/test_no_bare_redis_cli.py
@@ -16,31 +16,53 @@ redis_cmd` — not re-implement a bare helper. That keeps the auth fix from rott
 """
 from __future__ import annotations
 
+import ast
 import pathlib
-import re
 
 PKG = pathlib.Path(__file__).resolve().parent.parent / "mata_garuda"
 
-# The ONLY files allowed to hand a literal "redis-cli" to subprocess: base_worker
-# (the authed SSOT) and the split-brain guardian (probes BOTH hosts explicitly
-# with its own self-contained _redis_env — it cannot use the single-host SSOT).
+# base_worker is the authed SSOT (its redis_cmd is the single allowed definition).
+# Other files MAY call subprocess.run with "redis-cli" ONLY if that same call
+# carries env= (nerve.py + check_redis_split_brain.py probe explicitly with their
+# own _redis_env and cannot use the single-host SSOT). A call WITHOUT env= is the
+# W89 offender (NOAUTH-swallow under requirepass). AST, not regex — paren-balanced.
 _ALLOWED = {"workers/base_worker.py"}
 
-# subprocess.run( ... "redis-cli" ... )  — bare invocation on the same statement
-_BARE = re.compile(r"subprocess\.run\([^)]*['\"]redis-cli['\"]", re.DOTALL)
+
+def _call_has_redis_cli_literal(node: ast.Call) -> bool:
+    """True if any arg (incl. inside a list literal) is the string 'redis-cli'."""
+    def _strings(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, str):
+            yield n.value
+        for child in ast.iter_child_nodes(n):
+            yield from _strings(child)
+    return any(s == "redis-cli" for arg in node.args for s in _strings(arg))
 
 
-def test_no_module_runs_bare_redis_cli():
+def _is_subprocess_run(node: ast.Call) -> bool:
+    f = node.func
+    return isinstance(f, ast.Attribute) and f.attr == "run" and (
+        (isinstance(f.value, ast.Name) and f.value.id == "subprocess")
+    )
+
+
+def test_no_unauthed_bare_redis_cli():
     offenders = []
     for py in PKG.rglob("*.py"):
         rel = py.relative_to(PKG).as_posix()
         if rel in _ALLOWED:
             continue
-        text = py.read_text(encoding="utf-8")
-        if _BARE.search(text):
-            offenders.append(rel)
+        tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Call) and _is_subprocess_run(node)):
+                continue
+            if not _call_has_redis_cli_literal(node):
+                continue
+            kwargs = {kw.arg for kw in node.keywords if kw.arg}
+            if "env" not in kwargs:
+                offenders.append(f"{rel}:{node.lineno}")
     assert not offenders, (
-        "bare `subprocess.run([... 'redis-cli' ...])` found — these bypass "
+        "subprocess.run([... 'redis-cli' ...]) WITHOUT env= found — these bypass "
         "REDISCLI_AUTH and silently NOAUTH under requirepass (W89). Route through "
-        f"base_worker.redis_cmd instead: {offenders}"
+        f"base_worker.redis_cmd (preferred) or pass env=_redis_env(): {offenders}"
     )


### PR DESCRIPTION
## What — closes the NOAUTH-swallow meta-pattern

The dominant finding of the mata_garuda adversarial audit (55 agents): PR #1825's `requirepass` cutover cured `base_worker` + `stream_tools`, but the migration was **partial**. 7 more modules kept their own bare `redis-cli` subprocess calls with no `REDISCLI_AUTH` → under requirepass each got `NOAUTH` at exit 0 → swallowed into `''`/`None`/crash → **green-but-dead (cicatrix #2)**. The 3 publishers + intel_publisher are armed via LaunchAgents, so they silently published nothing.

PR #1876 fixed `nerve.py` + the split-brain guardian. This PR finishes the family.

### Migrated to `base_worker.redis_cmd` (the single authed path: `REDISCLI_AUTH` per cicatrix #4, canonical-host resolution, abs redis-cli path), each preserving its caller's error convention:
| File | Convention preserved | Extra |
|---|---|---|
| `tools/task_tools.py` | `[ERROR]` sentinel (drop-in) | — |
| `tools/health_tools.py` | `[ERROR]` → `None` | (launchctl call left untouched) |
| `tools/intel_publisher.py` | `[ERROR]` → raise | **+ MAXLEN ~ trim (#11, was unbounded)** |
| `agents/public_channel_publisher.py` | `[ERROR]` → `''` | armed via LaunchAgent |
| `agents/wr2_bridge_publisher.py` | `[ERROR]` → `''` | armed |
| `agents/kita_feed_generator.py` | `[ERROR]` → `''` | armed |
| `cell/sensors.py` GapStreamSensor | `[ERROR]` → yellow | XLEN via `redis_cmd` in `to_thread` (was int()-crash on NOAUTH) |

### Structural antidote (kills the whole class)
`test_no_bare_redis_cli.py` — **AST** walk (not regex): any `subprocess.run([... "redis-cli" ...])` **without `env=`** fails the build. `base_worker` is the sole allowed definition; `nerve.py` + the guardian pass because they carry `env=_redis_env()`. Stops the family from regrowing.

## Empirical proof
The gate caught 3 of my own errors before merge (paren-naive regex falsely flagging nerve.py → rewrote with AST; stale GapStreamSensor mocks → re-pointed at `base_worker.redis_cmd`; weight off-by-design in the sibling scorer PR). Final: **50/50 pass on Pro** (real venv) — lint, sensors, wr2_bridge, nerve pull/push. All 7 modules import clean (no circular import).

Depends on #1876 (merged) for the nerve.py auth that the AST lint expects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)