### PR TITLE
fix(mata-garuda): nlm_feeder dedup on item-identity not bare URL (W89 #2)

### DIFF
--- a/apps/mata-garuda/mata_garuda/workers/nlm_feeder.py
+++ b/apps/mata-garuda/mata_garuda/workers/nlm_feeder.py
@@ -24,6 +24,7 @@ Layer 3 Nexus.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -376,6 +377,31 @@ def _nlm_fed_marker(url_or_hash: str) -> str:
     return f"nlm_fed {url_or_hash}"
 
 
+def _dedup_key(title: str, url: str) -> str:
+    """Item-identity dedup key — NOT the bare URL (W89 #2).
+
+    Many distinct intel items share ONE landing-page URL: every LHKPN official's
+    declaration carries url='https://elhkpn.kpk.go.id/', and one peraturan
+    harmon URL covers many distinct regulations. Keying dedup on the bare URL
+    collapsed them — after the first was fed, persons #2..N matched 'already fed'
+    and were silently skip+ACKed, so distinct officials never reached NLM.
+
+    Fix: when a title exists, key on a stable hash of (title|url) so distinct
+    titles on a shared URL dedup independently. URL-only items (no title) keep
+    keying on the bare URL (true duplicates still collapse). Title-only items
+    (no URL) key on the title. Empty/empty → a constant so it's at least idempotent.
+    """
+    t = (title or "").strip()
+    u = (url or "").strip()
+    if t and u:
+        return "h:" + hashlib.sha1(f"{t}\x1f{u}".encode("utf-8")).hexdigest()[:24]
+    if u:
+        return u
+    if t:
+        return f"title:{t}"
+    return "empty"
+
+
 def _already_fed(kb: KnowledgeBase, dedup_key: str) -> bool:
     """Check if we've previously fed this dedup_key.
 
@@ -516,9 +542,11 @@ def _run_nlm_feeder_from(
             except (TypeError, ValueError):
                 pass  # unparseable score → fail-open, feed it
 
-        # Dedup: if we've already fed this URL, skip. Look up by (type, source)
-        # directly — FTS5 doesn't tokenize URLs reliably.
-        dedup_key = url or f"title:{title}"
+        # Dedup on ITEM identity (title+url), not the bare URL — distinct items
+        # sharing one landing-page URL (LHKPN officials, peraturan harmon docs)
+        # must dedup independently (W89 #2). Look up by (type, source) directly —
+        # FTS5 doesn't tokenize URLs/hashes reliably.
+        dedup_key = _dedup_key(title, url)
         already = _already_fed(kb, dedup_key)
         if already:
             stats["skipped"] += 1
@@ -526,9 +554,10 @@ def _run_nlm_feeder_from(
             continue
 
         # Feed as text (title + content) so NLM gets context even if URL
-        # is paywalled. Matches briefing spec.
+        # is paywalled. Matches briefing spec. Title falls back to url (NOT the
+        # dedup_key — that's a hash now and would make an unreadable NLM title).
         text_body = content[:4000] if content else title
-        effective_title = (title or dedup_key)[:200]
+        effective_title = (title or url or dedup_key)[:200]
         success = _nlm_add_text(notebook_id, effective_title, text_body)
 
         if success:

--- a/apps/mata-garuda/tests/test_nlm_feeder.py
+++ b/apps/mata-garuda/tests/test_nlm_feeder.py
@@ -231,10 +231,12 @@ class TestStreamConsumer:
 
     def test_dedup_skips_already_fed(self, tmp_path):
         kb = KnowledgeBase(db_path=tmp_path / "feeder.db")
-        # Pre-seed a fed marker
+        # Pre-seed a fed marker on the ITEM-IDENTITY dedup key (title+url), which
+        # is what the feeder now computes (W89 #2 — no longer the bare URL).
+        seed_key = nlm_feeder._dedup_key("dup", "https://ex.com/dup")
         kb.store("nlm_feeder", "nlm_fed",
-                 nlm_feeder._nlm_fed_marker("https://ex.com/dup"),
-                 "https://ex.com/dup", 1.0)
+                 nlm_feeder._nlm_fed_marker(seed_key),
+                 seed_key, 1.0)
 
         items = [
             _fake_enriched_item("1-0", domain="tax_fiscal",

--- a/apps/mata-garuda/tests/test_nlm_feeder_dedup_key.py
+++ b/apps/mata-garuda/tests/test_nlm_feeder_dedup_key.py
@@ -1,0 +1,55 @@
+"""Regression tests for the nlm_feeder dedup-key collapse (W89 #2).
+
+Bug: dedup_key was the bare URL, so distinct intel items sharing one landing-page
+URL (every LHKPN official carries url='https://elhkpn.kpk.go.id/'; one peraturan
+harmon URL covers many regulations) collapsed — after the first was fed, the rest
+matched 'already fed' and were silently skip+ACKed, never reaching NLM. The audit
+saw 130 distinct LHKPN entries on that one URL with 0 markers → 129 would drop.
+
+Fix: _dedup_key(title, url) keys on item identity (hash of title+url) so distinct
+titles on a shared URL dedup independently, while true duplicates still collapse.
+"""
+from __future__ import annotations
+
+from mata_garuda.workers.nlm_feeder import _dedup_key
+
+
+LHKPN_URL = "https://elhkpn.kpk.go.id/"
+
+
+class TestDedupKey:
+    # ── GUILT: the bug must be fixed ──────────────────────────────────────
+    def test_distinct_officials_same_url_get_distinct_keys(self):
+        """The W89 #2 core: two officials on the same portal URL must NOT collapse."""
+        k1 = _dedup_key("LHKPN GEDE DUDY DUWITA", LHKPN_URL)
+        k2 = _dedup_key("LHKPN RAJA ULUL AZMI", LHKPN_URL)
+        assert k1 != k2, "distinct titles on a shared URL must dedup independently"
+
+    def test_many_distinct_regs_one_harmon_url_all_distinct(self):
+        url = "https://peraturan.go.id/harmon/abc123"
+        keys = {_dedup_key(f"Peraturan {i} tahun 2026", url) for i in range(50)}
+        assert len(keys) == 50, "50 distinct regs on one harmon URL → 50 keys"
+
+    # ── INNOCENCE: true duplicates must STILL collapse ────────────────────
+    def test_identical_title_and_url_is_stable(self):
+        """Same item seen twice → same key (real dedup still works)."""
+        a = _dedup_key("Perpres baru kementerian", "https://x.go.id/p")
+        b = _dedup_key("Perpres baru kementerian", "https://x.go.id/p")
+        assert a == b
+
+    def test_url_only_item_keys_on_url(self):
+        """No title (e.g. arxiv feed) → bare-URL dedup preserved (back-compat)."""
+        u = "http://arxiv.org/abs/2604.07345v1"
+        assert _dedup_key("", u) == u
+        assert _dedup_key("  ", u) == u  # whitespace-only title is empty
+
+    def test_title_only_item_keys_on_title(self):
+        assert _dedup_key("Some headline", "") == "title:Some headline"
+
+    def test_empty_empty_is_constant(self):
+        assert _dedup_key("", "") == "empty"
+
+    def test_key_is_short_and_stable_string(self):
+        k = _dedup_key("a title", "http://u")
+        assert isinstance(k, str) and k.startswith("h:") and len(k) <= 30
+        assert k == _dedup_key("a title", "http://u")  # deterministic


### PR DESCRIPTION
## What

The alerts→NLM feeder keyed dedup on the **bare URL** (`dedup_key = url`). But many distinct intel items share **one landing-page URL**:
- every LHKPN official's wealth declaration carries `url=https://elhkpn.kpk.go.id/`
- one `peraturan.go.id/harmon/<hash>` URL covers many distinct regulations

After the first was fed, persons #2..N matched `_already_fed` → silently skip+ACKed → **distinct officials never reached the Immigration/Tax notebooks.** The audit (verified on disk, both verdicts `refuted=False`, high confidence) found **130 distinct LHKPN entries on that one URL with 0 KB markers** — i.e. 129 would silently drop the moment the feeder processed them.

## Fix
`_dedup_key(title, url)` keys on **item identity**:
- both title + url → `sha1(title|url)` → distinct titles on a shared URL dedup independently
- url only (arxiv feeds) → bare URL (true duplicates still collapse — back-compat)
- title only → `title:<t>`; empty/empty → constant

Also fixed the downstream `effective_title` fallback (`title or url`, not the dedup hash — which would make an unreadable NLM title). The `run_nlm_feeder` ai_research path (arxiv/github by URL) is unchanged — there one URL == one item, so URL-dedup is correct.

## Empirical proof
**52/52 pass on Pro** (real venv). New `test_nlm_feeder_dedup_key.py`: **guilt** (distinct officials/50 regs on a shared URL get distinct keys) + **innocence** (true dupes collapse; URL-only/title-only/empty back-compat). The gate caught `test_dedup_skips_already_fed` pinning the old bare-URL contract → updated to seed the item-identity key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)