### PR TITLE
fix(mata-garuda): pipeline_health RED on Redis outage + nexus:gaps lag scan (RR-H4/RR-H1)

### DIFF
--- a/apps/mata-garuda/mata_garuda/workers/pipeline_health.py
+++ b/apps/mata-garuda/mata_garuda/workers/pipeline_health.py
@@ -7,8 +7,10 @@ alert when the pipeline is degraded.
 
 What it checks (each a falsifiable signal, not a PID):
   1. STREAM RAM       — sum of XLEN across streams vs STREAM_MAXLEN headroom.
-  2. CONSUMER LAG     — per-group lag on garuda:enriched; flags any group whose
-                        lag is GROWING run-over-run (the real "stuck" signal).
+  2. CONSUMER LAG     — per-group lag on garuda:enriched + nexus:gaps; flags any
+                        group whose lag is GROWING run-over-run (the real "stuck"
+                        signal). Stream 0 below probes Redis reachability first so
+                        a total outage is RED, never a silent GREEN (cicatrix #2).
   3. FRESHNESS        — age of the newest entry per stream (is harvest alive?).
   4. NLM THROUGHPUT   — did the feeder actually add sources in the last window?
                         (compares NLM source_count snapshots run-over-run).
@@ -37,6 +39,10 @@ REDIS_PORT = os.environ.get("GARUDA_REDIS_PORT", "6379")
 STREAM_MAXLEN = int(os.environ.get("GARUDA_STREAM_MAXLEN", "100000"))
 STREAMS = ["garuda:raw", "garuda:enriched", "garuda:alerts"]
 ENRICHED = "garuda:enriched"
+# Streams whose consumer-group lag is monitored. enriched fans out to the
+# classifier/ner/scorer/nlm_feeder workers; nexus:gaps drives gap_consumer.
+# (RR-H1: pre-fix only enriched was scanned, so a stuck gap_consumer was invisible.)
+LAG_STREAMS = [ENRICHED, "nexus:gaps"]
 STATE_FILE = Path(os.environ.get(
     "GARUDA_HEALTH_STATE",
     str(Path.home() / ".organism" / "pipeline_health.state.json"),
@@ -183,13 +189,33 @@ def _tg_alert(text: str) -> bool:
 
 def assess() -> dict:
     """Pure assessment → returns the report dict. No side effects (testable)."""
+    findings: list[str] = []
+    verdict = "GREEN"
+
+    # 0. REDIS REACHABILITY (RR-H4 / cicatrix #2 — green-but-dead).
+    # _r() returns "[ERR ...]" on any subprocess/connection failure. If Redis is
+    # unreachable, every numeric signal below silently reads as 0/None and the
+    # monitor would otherwise stay GREEN through a TOTAL OUTAGE — the exact
+    # failure this monitor exists to catch. A failed PING is hard RED, full stop.
+    ping = _r("PING")
+    if ping.startswith("[ERR") or "PONG" not in ping.upper():
+        return {
+            "verdict": "RED",
+            "ts": 0,
+            "xlens": {},
+            "total_entries": 0,
+            "maxlen": STREAM_MAXLEN,
+            "lags": {},
+            "ages_h": {},
+            "nlm_total": None,
+            "nlm_delta": None,
+            "findings": [f"redis probe FAILED (PING -> {ping!r}) — pipeline blind, total outage"],
+        }
+
     now_ms = _now_ms()
     prev = _load_state()
     prev_lags = prev.get("lags", {})
     prev_nlm = prev.get("nlm_total")
-
-    findings: list[str] = []
-    verdict = "GREEN"
 
     # 1. RAM / stream sizes
     xlens = {s: _xlen(s) for s in STREAMS}
@@ -199,8 +225,11 @@ def assess() -> dict:
         verdict = "RED"
         findings.append(f"stream over MAXLEN {STREAM_MAXLEN}: {over_cap}")
 
-    # 2. consumer lag (growing = real stuck)
-    lags = _group_lags(ENRICHED)
+    # 2. consumer lag (growing = real stuck) across ALL monitored streams
+    # (RR-H1: enriched + nexus:gaps, not enriched-only).
+    lags: dict[str, int] = {}
+    for s in LAG_STREAMS:
+        lags.update(_group_lags(s))
     for g, lag in lags.items():
         prev_lag = prev_lags.get(g)
         growing = prev_lag is not None and lag > prev_lag

--- a/apps/mata-garuda/scripts/pel_cleaner.py
+++ b/apps/mata-garuda/scripts/pel_cleaner.py
@@ -6,12 +6,12 @@ Scans all garuda:*, bridge:*, nexus:* Redis streams. For each consumer group:
     the youngest alive consumer in the group (lowest idle_ms). If no alive
     consumer exists, leave alone (manual decision needed).
   - GHOST_CONSUMER (consumer pending=0 AND idle>30d): XGROUP DELCONSUMER.
-  - DEEP_STALE_PEL (W13: any pending msg with msg_idle_ms > 7d): XACK directly.
+  - DEEP_STALE_PEL (W13: any pending msg with msg_idle_ms > 24h): XACK directly.
     Workers in this codebase use XREADGROUP STREAMS > semantic (only NEW
     messages, never re-process PEL), so XCLAIM alone is insufficient — the
-    new owner never re-reads. Messages >7d are dropped because:
+    new owner never re-reads. Messages >24h are dropped because:
       (a) already-fed pipelines (nlm_fed dedup table) would skip them anyway
-      (b) not-yet-fed >7d content is stale (cf 18d arxiv → NB noise > value)
+      (b) not-yet-fed >24h content is stale (cf 18d arxiv → NB noise > value)
       (c) re-injection would fan-out cascade through normalizer + ner + classifier
 
 Outputs JSON report to stdout. Exits 0 if no actions OR all actions succeeded,
@@ -158,8 +158,9 @@ def cleanup() -> dict[str, Any]:
         for group in list_groups(stream):
             # W13: deep-stale message ACK pass (per-message, not per-consumer).
             # XPENDING - + 1000 returns msg_id, owner, msg_idle_ms, deliveries.
-            # ACK any message whose msg_idle_ms > 7d regardless of which
-            # consumer owns it — workers use > semantic, never re-read PEL.
+            # ACK any message whose msg_idle_ms > 24h (DEEP_STALE_MSG_IDLE_MS)
+            # regardless of which consumer owns it — workers use > semantic,
+            # never re-read PEL.
             deep_acked = _xack_deep_stale(stream, group)
             if deep_acked:
                 report["deep_acks"].append({

--- a/apps/mata-garuda/tests/test_pipeline_hardening.py
+++ b/apps/mata-garuda/tests/test_pipeline_hardening.py
@@ -35,10 +35,20 @@ class TestStreamMaxlen:
 class TestPipelineHealthAssess:
     """The monitor must read OUTPUT (lag/freshness/RAM), not exit-0, and grade it."""
 
-    def _mock_redis(self, xlens, lags, newest_age_ms_back, now_ms=2_000_000_000_000):
-        """Build a fake _r() that answers XLEN/XINFO/XREVRANGE/TIME."""
+    def _mock_redis(self, xlens, lags, newest_age_ms_back, now_ms=2_000_000_000_000,
+                    lags_by_stream=None):
+        """Build a fake _r() that answers XLEN/XINFO/XREVRANGE/TIME.
+
+        ``lags`` are returned for ANY stream's XINFO GROUPS (back-compat).
+        ``lags_by_stream`` (optional) maps stream -> {group: lag} so a test can
+        place lag on a specific stream (e.g. nexus:gaps) — needed for RR-H1.
+        """
+        lags_by_stream = lags_by_stream or {}
+
         def fake_r(*args):
             cmd = args[0]
+            if cmd == "PING":
+                return "PONG"
             if cmd == "TIME":
                 return f"{now_ms // 1000}\n0"
             if cmd == "XLEN":
@@ -49,9 +59,11 @@ class TestPipelineHealthAssess:
                 eid = now_ms - age
                 return f"{eid}-0\ntitle\nx"
             if cmd == "XINFO" and args[1] == "GROUPS":
+                stream = args[2]
+                groups = lags_by_stream.get(stream, lags)
                 # flat: name <g> ... lag <n> per group
                 out = []
-                for g, lag in lags.items():
+                for g, lag in groups.items():
                     out += ["name", g, "lag", str(lag)]
                 return "\n".join(out)
             return ""
@@ -125,3 +137,55 @@ class TestPipelineHealthAssess:
             r = pipeline_health.assess()
         assert r["verdict"] == "YELLOW"
         assert any("draining" in f for f in r["findings"])
+
+    # ── RR-H4: total Redis outage must NOT stay GREEN (cicatrix #2) ──────────
+    def test_red_when_redis_down(self):
+        """GUILT: if _r() returns '[ERR ...]' (redis unreachable), every numeric
+        signal silently reads as 0/None and the monitor would stay GREEN — the
+        exact green-but-dead failure the monitor exists to catch. Must be RED."""
+        def err_r(*args):
+            return "[ERR Errno 61 connection refused]"
+
+        with patch.object(pipeline_health, "_r", side_effect=err_r), \
+             patch.object(pipeline_health, "_nlm_source_total", return_value=None), \
+             patch.object(pipeline_health, "_load_state", return_value={}):
+            r = pipeline_health.assess()
+        assert r["verdict"] == "RED"
+        assert any("redis" in f.lower() or "probe" in f.lower()
+                   for f in r["findings"])
+
+    def test_green_not_tripped_by_legit_zero_xlen(self):
+        """INNOCENCE: a real-but-empty stream (XLEN 0, no [ERR]) is nominal, not
+        an outage. The RR-H4 guard must key on the [ERR ...] sentinel, never on
+        a zero count — otherwise a quiet pipeline reads as down."""
+        fake = self._mock_redis(
+            xlens={"garuda:raw": 0, "garuda:enriched": 0, "garuda:alerts": 0},
+            lags={"classifier": 0},
+            newest_age_ms_back={"garuda:raw": 3_600_000},
+        )
+        with patch.object(pipeline_health, "_r", side_effect=fake), \
+             patch.object(pipeline_health, "_nlm_source_total", return_value=900), \
+             patch.object(pipeline_health, "_load_state", return_value={}):
+            r = pipeline_health.assess()
+        assert r["verdict"] == "GREEN"
+
+    # ── RR-H1: lag scan must cover nexus:gaps, not only enriched ─────────────
+    def test_red_when_nexus_gaps_lag_growing(self):
+        """GUILT: a stuck+growing consumer on nexus:gaps (gap_consumer) must
+        surface as RED. Pre-fix the monitor only scanned garuda:enriched and
+        was blind to this stream entirely."""
+        fake = self._mock_redis(
+            xlens={"garuda:raw": 100, "garuda:enriched": 100, "garuda:alerts": 1},
+            lags={},  # enriched has no lag
+            newest_age_ms_back={"garuda:raw": 3_600_000},
+            lags_by_stream={"nexus:gaps": {"gap_consumer": 9000}},
+        )
+        with patch.object(pipeline_health, "_r", side_effect=fake), \
+             patch.object(pipeline_health, "_nlm_source_total", return_value=900), \
+             patch.object(pipeline_health, "_load_state",
+                          return_value={"lags": {"gap_consumer": 5000},
+                                        "nlm_total": 900}):
+            r = pipeline_health.assess()
+        assert r["verdict"] == "RED"
+        assert any("gap_consumer" in f or "nexus:gaps" in f
+                   for f in r["findings"])


### PR DESCRIPTION
## What

Closes the **#4 health-blindness cluster** from the mata_garuda audit — the residual gaps that survived refutation (the `verify-template.js` workflow: 19 survivors / 4 refuted; #5 PEL-orphan turned out already-armed via `pel_cleaner.py` weekly, so this PR is the real residual).

The pipeline health monitor exists to catch green-but-dead (cicatrix #2) — but had that exact failure mode **inside itself**.

### RR-H4 (HIGH) — total Redis outage stayed GREEN
`assess()` initialised `verdict="GREEN"` and only escalated on positive numeric findings. On a total Redis outage `_r()` returns `"[ERR ...]"`, every signal silently reads as 0/None, and the monitor stayed GREEN through the outage it should flag.
**Fix:** `assess()` probes `PING` first. A failed PING (or NOAUTH — anything that isn't `PONG`) is hard **RED** with a blind-pipeline finding.
**Proven live:** `assess()` against a dead port → RED; `main()` → exit 2; sidecar `status=fail`; no crash.

### RR-H1 (MEDIUM) — lag scan was enriched-only
Consumer-lag scan covered only `garuda:enriched`, so a stuck+growing `gap_consumer` on `nexus:gaps` was invisible. Now scans `LAG_STREAMS` (enriched + nexus:gaps).

### RR-DOC — docstring drift
`pel_cleaner` docstring said DEEP_STALE `>7d` but the constant has been **24h** (`DEEP_STALE_MSG_IDLE_MS`). Aligned docstring + inline comments to the real value.

## Tests (TDD)
Reuses the existing `TestPipelineHealthAssess` `fake_r` harness:
- **guilt:** RED-on-outage + RED-on-`nexus:gaps`-growing
- **innocence:** a legit empty stream (XLEN 0, PONG alive) stays GREEN — the guard keys on the `[ERR]`/PING sentinel, never on a zero count

`11/11` in the class; `96` scope-relevant tests green (full suite needs the runtime env — httpx/tenacity/cell_core — only present in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)