### PR TITLE
refactor(mata-garuda): pipeline_health routes redis via canonical base_worker (RR-H3)

### DIFF
--- a/apps/mata-garuda/mata_garuda/workers/pipeline_health.py
+++ b/apps/mata-garuda/mata_garuda/workers/pipeline_health.py
@@ -33,9 +33,9 @@ import sys
 import time
 from pathlib import Path
 
+from mata_garuda.workers.base_worker import redis_cmd as _bw_redis_cmd
+
 # ── config (env-overridable, no hardcoded secrets) ────────────────────────
-REDIS_HOST = os.environ.get("GARUDA_REDIS_HOST", "localhost")
-REDIS_PORT = os.environ.get("GARUDA_REDIS_PORT", "6379")
 STREAM_MAXLEN = int(os.environ.get("GARUDA_STREAM_MAXLEN", "100000"))
 STREAMS = ["garuda:raw", "garuda:enriched", "garuda:alerts"]
 ENRICHED = "garuda:enriched"
@@ -55,34 +55,19 @@ LAG_YELLOW = int(os.environ.get("GARUDA_LAG_YELLOW", "3000"))
 FRESH_MAX_H = float(os.environ.get("GARUDA_FRESH_MAX_H", "26"))
 
 
-def _redis_cli() -> str:
-    for c in (shutil.which("redis-cli"), "/opt/homebrew/bin/redis-cli",
-              "/usr/local/bin/redis-cli", "/usr/bin/redis-cli"):
-        if c and os.path.exists(c):
-            return c
-    return "redis-cli"
-
-
-REDIS_CLI = _redis_cli()
-
-
-def _redis_env() -> dict:
-    env = dict(os.environ)
-    pw = (os.environ.get("GARUDA_REDIS_PASSWORD") or "").strip()
-    if pw:
-        env["REDISCLI_AUTH"] = pw
-    return env
-
-
 def _r(*args: str) -> str:
-    try:
-        p = subprocess.run(
-            [REDIS_CLI, "-h", REDIS_HOST, "-p", REDIS_PORT, *args],
-            capture_output=True, text=True, timeout=15, env=_redis_env(),
-        )
-        return (p.stdout or "").strip()
-    except Exception as e:
-        return f"[ERR {e}]"
+    """Run a redis-cli command via the canonical base_worker topology.
+
+    RR-H3 (Stage 1 single-writer, 2026-06-29): host/port/auth/cli-path
+    resolution lives in ONE place — base_worker._resolve_redis_host()
+    (GARUDA_REDIS_HOST → GARUDA_CANONICAL_REDIS_HOST → local sentinel) +
+    REDISCLI_AUTH (cicatrix #4, never -a) + abs-path redis-cli. This monitor
+    used to carry its own localhost default + duplicate cli/env logic, the
+    last organ outside the canonical cure. On any failure redis_cmd returns
+    "[ERROR] ..."; assess()'s reachability probe keys on the "[ER" prefix so
+    both that and a legacy "[ERR ...]" read as a failed probe (RR-H4).
+    """
+    return _bw_redis_cmd(*args, timeout=15)
 
 
 def _now_ms() -> int:
@@ -198,7 +183,9 @@ def assess() -> dict:
     # monitor would otherwise stay GREEN through a TOTAL OUTAGE — the exact
     # failure this monitor exists to catch. A failed PING is hard RED, full stop.
     ping = _r("PING")
-    if ping.startswith("[ERR") or "PONG" not in ping.upper():
+    # "[ER..." covers both base_worker's "[ERROR] ..." and the legacy "[ERR ...]"
+    # error sentinels; a live Redis answers exactly "PONG".
+    if ping.startswith("[ER") or "PONG" not in ping.upper():
         return {
             "verdict": "RED",
             "ts": 0,

--- a/apps/mata-garuda/tests/test_pipeline_hardening.py
+++ b/apps/mata-garuda/tests/test_pipeline_hardening.py
@@ -169,6 +169,29 @@ class TestPipelineHealthAssess:
             r = pipeline_health.assess()
         assert r["verdict"] == "GREEN"
 
+    # ── RR-H3: single Redis-topology source of truth (base_worker) ──────────
+    def test_r_delegates_to_base_worker(self):
+        """The monitor no longer carries its own localhost default / cli / env —
+        every redis-cli call routes through base_worker.redis_cmd, so host/auth
+        resolution is the canonical Stage 1 one (cicatrix #10)."""
+        # patch where it's looked up: pipeline_health binds the import at module
+        # load (`redis_cmd as _bw_redis_cmd`), so patch that bound name.
+        with patch.object(pipeline_health, "_bw_redis_cmd", return_value="PONG") as m:
+            out = pipeline_health._r("PING")
+        assert out == "PONG"
+        assert m.call_args.args == ("PING",)
+
+    def test_red_when_base_worker_error_format(self):
+        """base_worker.redis_cmd returns '[ERROR] ...' (not the legacy '[ERR ...]')
+        on failure. RR-H4's reachability probe must treat that as a failed probe
+        too, otherwise the migration would silently re-open the green-on-outage hole."""
+        with patch.object(pipeline_health, "_r",
+                          side_effect=lambda *a: "[ERROR] redis-cli: Connection refused"), \
+             patch.object(pipeline_health, "_nlm_source_total", return_value=None), \
+             patch.object(pipeline_health, "_load_state", return_value={}):
+            r = pipeline_health.assess()
+        assert r["verdict"] == "RED"
+
     # ── RR-H1: lag scan must cover nexus:gaps, not only enriched ─────────────
     def test_red_when_nexus_gaps_lag_growing(self):
         """GUILT: a stuck+growing consumer on nexus:gaps (gap_consumer) must


### PR DESCRIPTION
## What

Follow-up to #1882 (RR-H4/RR-H1/RR-DOC, merged). Closes the last item of the mata_garuda health audit — **RR-H3**.

`pipeline_health` was the **last mata_garuda organ** carrying its own Redis topology — a hardcoded `REDIS_HOST="localhost"` default plus duplicate `_redis_cli()`/`_redis_env()`/`subprocess` logic — **outside** the Stage 1 single-writer cure (2026-06-29, 3-LLM panel + Zero G1=Pro) that centralised host/auth/cli-path resolution in `base_worker._resolve_redis_host()` (`GARUDA_REDIS_HOST` → `GARUDA_CANONICAL_REDIS_HOST` → local sentinel).

## Grounded, not assumed

The original audit framed RR-H3 as "split-brain risk". Disk/Pro ground corrected it:
- the **live plist already sets `GARUDA_REDIS_HOST=localhost`** and the monitor runs **only on Pro** (= the canonical Redis) → never an *active* split-brain.
- it was **coherence-debt**: the one organ that wouldn't honor `GARUDA_CANONICAL_REDIS_HOST` if a future off-Pro run forgot the explicit override (cicatrix #10 antidote, structural everywhere else).

## Change

`_r()` is now a thin wrapper over `base_worker.redis_cmd`. Removes the duplicate host/port/cli/env block (-19 lines net in that region).

`base_worker.redis_cmd` returns `"[ERROR] ..."` on failure (vs the legacy `"[ERR ...]"`); the **RR-H4 reachability probe now keys on the `"[ER"` prefix** so both formats read as a failed probe — the migration **cannot silently re-open the green-on-outage hole**.

## Tests
- `_r` delegates to `base_worker` (patched at the bound import name)
- `assess()` goes RED on base_worker's `"[ERROR]"` format
- `13/13` in the class; `83` scope-relevant green
- Live: offline `assess()` still RED, finding now shows the `"[ERROR]"` sentinel = routing confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)