### PR TITLE
fix(wa-dashboard-m1): strip operator-tag suffix from CRM display names

### DIFF
--- a/apps/wa-dashboard-m1/server.cjs
+++ b/apps/wa-dashboard-m1/server.cjs
@@ -100,6 +100,32 @@ for (const m of TEAM) {
   if (m.e164) TEAM_BY_PHONE.set(m.e164, m);
 }
 
+// 2026-06-30: set of Bali Zero operator names (first tokens), used to strip the
+// operator-tag suffix some CRM full_names carry, e.g. "Aigerim Tugayeva (surya)".
+// The CRM value stays untouched in the DB — this is DISPLAY-ONLY. We strip ONLY when
+// the parenthetical is a known operator name, so real info like "(PT jam jam)",
+// "(Makar Burba)", "(satpam)" is preserved (verified against live data 2026-06-30).
+const OPERATOR_NAMES = new Set();
+for (const m of TEAM) {
+  for (const src of [m.name, m.full_name]) {
+    if (!src) continue;
+    for (const tok of String(src).toLowerCase().split(/\s+/)) {
+      if (tok.length >= 3) OPERATOR_NAMES.add(tok);
+    }
+  }
+}
+// strip a single trailing "(operator)" tag from a CRM display name, display-only.
+function stripOperatorSuffix(name) {
+  if (!name) return name;
+  const m = String(name).match(/^(.*?)\s*\(([^()]{1,30})\)\s*$/);
+  if (!m) return name;
+  const base = m[1].trim();
+  const inside = m[2].trim().toLowerCase();
+  // only strip if the WHOLE parenthetical is a single known operator name
+  if (base && /^[a-z]+$/.test(inside) && OPERATOR_NAMES.has(inside)) return base;
+  return name;
+}
+
 function readQwenGateSnapshot() {
   try {
     return JSON.parse(fs.readFileSync(QWEN_GATE_SNAPSHOT, "utf8"));
@@ -575,6 +601,9 @@ async function fetchOverview() {
       for (const r of directRows.rows) {
         // Display name with priority: CRM > TEAM > WA business > WA contact > raw-message pushName > lid_phone_map pushname > phone
         const crmName = cleanName(r.client_name);
+        // 2026-06-30: display-only — strip "(surya)"-style operator tags from the CRM
+        // name; crmName itself stays intact for the tag/crm_match logic below.
+        const crmNameDisplay = stripOperatorSuffix(crmName);
         const businessName = cleanName(r.wa_business_name);
         const waName = cleanName(r.wa_contact_name);
         const push = cleanName(r.pushname);
@@ -589,9 +618,9 @@ async function fetchOverview() {
           ? teamMatch.full_name || teamMatch.name
           : null;
 
-        let display = crmName || teamName;
+        let display = crmNameDisplay || teamName;
         if (display && crmName && r.company_name)
-          display = `${crmName} · ${r.company_name}`;
+          display = `${crmNameDisplay} · ${r.company_name}`;
         if (!display)
           display =
             businessName ||
@@ -664,7 +693,7 @@ async function fetchOverview() {
       }
       for (const r of groupRows.rows) {
         const senderName =
-          cleanName(r.sender_crm_name) ||
+          stripOperatorSuffix(cleanName(r.sender_crm_name)) ||
           cleanName(r.sender_wa_contact_name) ||
           cleanName(r.sender_pushname);
         const groupLabel =
@@ -1188,7 +1217,7 @@ async function fetchThread(memberPhone, convKey) {
     return {
       ...r,
       sender_display:
-        cleanName(r.sender_crm_name) ||
+        stripOperatorSuffix(cleanName(r.sender_crm_name)) ||
         cleanName(r.sender_wa_business_name) ||
         cleanName(r.sender_wa_contact_name) ||
         cleanName(r.pushname) ||


### PR DESCRIPTION
## Contesto
Domanda di Zero: *"i nomi dei clienti possono coincidere con il nome del CRM e non il nome con cui viene salvato sul cellulare?"* → Sì: la dashboard usa il **nome CRM** come fonte autoritativa (CRM > TEAM > rubrica WA > pushName > numero). Conseguenza: alcuni nomi CRM portano un tag-operatore tipo `Aigerim Tugayeva (surya)` (indica quale operatore Bali Zero segue il cliente) e veniva mostrato.

## Decisione (opzione C scelta da Zero)
CRM resta autoritativo, ma il tag-operatore si **strippa solo in visualizzazione**. **Il dato CRM nel DB non viene mai toccato.**

`stripOperatorSuffix()` rimuove un suffisso `(xxx)` finale **solo se** `xxx` è il nome di un operatore Bali Zero noto (costruito dal roster TEAM). Deliberatamente stretto — verificato su dati live che queste parentesi (informazione vera) restano **intatte**:
- `(PT jam jam)` `(PT Stone Real Estate)` `(Owner B Plus)` → azienda collegata
- `(Lorenzo Giuseppe Spagarino)` `(Makar Burba)` → persona reale collegata
- `(Staff Notaris Karlina)` `(satpam)` `(Tax Consultant)` → ruolo/contesto
- `(NEW)` `(Family Keet)` `(Eye-Gh-een)` `(✿ ♥️‿♥️)` → status/pronuncia/emoji

Solo i nomi single-token che matchano un operatore (es. `surya`) vengono strippati.

Applicato display-only a: nome conv diretta, nome sender gruppo, `sender_display` nel thread. `crmName` intatto → logica tag crm/crm_match invariata.

## Verifica
- Unit-test del matcher su **20 pattern reali** (strippa operatori, tiene tutto il resto).
- Test server `:7795` su `nuzantara_dev` live: **esattamente 3** nomi cambiano nella finestra attiva — `ANNA FISCHENKO (SURYA)`, `ULAN NAZARALIEV (SURYA)`, `Aigerim Tugayeva (surya)` → tag rimosso; **zero** altri nomi cambiati.
- `node --check` verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)