### PR TITLE
fix(wa-dashboard-m1): also strip unclosed operator paren "(surya"

### DIFF
--- a/apps/wa-dashboard-m1/server.cjs
+++ b/apps/wa-dashboard-m1/server.cjs
@@ -117,7 +117,9 @@ for (const m of TEAM) {
 // strip a single trailing "(operator)" tag from a CRM display name, display-only.
 function stripOperatorSuffix(name) {
   if (!name) return name;
-  const m = String(name).match(/^(.*?)\s*\(([^()]{1,30})\)\s*$/);
+  // closing ")" is OPTIONAL: some CRM names are malformed, e.g. "Satya Dewi (surya"
+  // (paren opened, never closed) — still a stray operator tag, strip it too.
+  const m = String(name).match(/^(.*?)\s*\(([^()]{1,30})\)?\s*$/);
   if (!m) return name;
   const base = m[1].trim();
   const inside = m[2].trim().toLowerCase();

--- a/apps/wa-dashboard-m1/viewer.html
+++ b/apps/wa-dashboard-m1/viewer.html
@@ -1576,8 +1576,8 @@ function renderTeams() {
             ${pd.msgs_lid_only ? `<span class="pill lid" title="msg con counterpart_lid only (no phone resolved)">lid ${pd.msgs_lid_only}</span>` : ""}
             ${pd.crm_count ? `<span class="pill crm">CRM ${pd.crm_count}</span>` : ""}
             ${pd.archived_count ? `<span class="pill" title="clienti CRM soft-deleted ma ancora attivi su WA (cicatrix marzo-2026 purge)" style="background:#ff9500;color:white">👻 ${pd.archived_count}</span>` : ""}
-            ${pd.attention.high   ? `<span class="pill attention">${pd.attention.high} HIGH</span>` : ""}
-            ${pd.attention.medium ? `<span class="pill attention-med">${pd.attention.medium} MED</span>` : ""}
+            ${pd.attention.high   ? `<span class="pill attention" title="conversazioni urgenti">${pd.attention.high} urgenti</span>` : ""}
+            ${pd.attention.medium ? `<span class="pill attention-med" title="conversazioni da gestire">${pd.attention.medium} da gestire</span>` : ""}
           </div>
         </div>
       </div>`;
@@ -1604,7 +1604,7 @@ function renderConvs() {
   }
   const convs = sortedConvsForTeam(pd);
   const headerExtra = pd.attention.high || pd.attention.medium
-    ? ` <span style="color:var(--wa-error);font-weight:500">· ${pd.attention.high} HIGH</span>${pd.attention.medium ? ` <span style="color:var(--wa-warning)">· ${pd.attention.medium} MED</span>` : ""}`
+    ? ` <span style="color:var(--wa-error);font-weight:500">· ${pd.attention.high} urgenti</span>${pd.attention.medium ? ` <span style="color:var(--wa-warning)">· ${pd.attention.medium} da gestire</span>` : ""}`
     : "";
   let html = `<div class="col-header">2 · ${convs.length} conversazioni${headerExtra}</div>`;
   if (!convs.length) {


### PR DESCRIPTION
## Trovato verificando direttamente la dashboard renderizzata
Ho aperto la dashboard live in headless (Playwright) e letto il **DOM reale** (non il `/data.json`). Tutto a posto — tag IT, preview media IT, "Tu:", 0 token grezzi — **tranne un nome**: `Satya Dewi (surya` con la `)` mancante.

Causa: nel CRM il `full_name` è letteralmente `Satya Dewi (surya` (parentesi aperta **mai chiusa**, dato malformato). Il regex di `stripOperatorSuffix` (PR #1886) richiedeva la `)` di chiusura → non matchava.

## Fix
`)` opzionale nel matcher: `/\(([^()]{1,30})\)?\s*$/`. La guardia sul nome-operatore è invariata → si strippano solo i tag operatore, le parentesi reali (anche non chiuse) restano.

Verificato che restano intatti:
- `ayuratnadewi (Belinda jane Pillios` (persona reale, non chiusa)
- `Cassiana Bauermann Gonzales (Vitor` (persona reale, non chiusa)

## Verifica
- Unit-test 12 casi (chiusi+non chiusi, operatore+non): **12/12**.
- Test server `:7795` vs live: **esattamente 1** nome cambia (`Satya Dewi (surya` → `Satya Dewi`), zero altri.
- Dato CRM nel DB invariato (display-only). `node --check` verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)